### PR TITLE
Host-neutral settings catalog → unified /config (CLI) + extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 #### Features
 
-- **`/config` settings panel** — view and change settings from the chat TUI without leaving the terminal. `/config` (alias `/settings`) lists each setting with its current value and where it is stored; press Enter to toggle a switch, pick from a choice list, or edit a value inline. Covers the git commit-author identity settings the CLI applies to agent commits and worktrees. Settings come from the same shared catalog the VS Code extension uses, so the two surfaces stay in sync instead of drifting apart.
+- **`/config` settings panel** — view and change settings from the chat TUI without leaving the terminal. `/config` (alias `/settings`) lists each setting with its current value and where it is stored; press Enter to toggle a switch, pick from a choice list, or edit a value inline. Covers the git commit-author identity (applied to agent commits and worktrees) and the workflow auto-compile options the CLI uses for `texra workflow` / `texra run`. Settings come from the same shared catalog the VS Code extension uses, so the two surfaces stay in sync instead of drifting apart.
 - **`texra latexdiff` command** — generate round-aware LaTeX diffs for an agent run's outputs straight from the terminal, the same capability the VS Code extension offers. Point it at a run with `texra latexdiff <agent> -m <model> -i <file>`; add `--between-rounds` to also diff consecutive rounds, `--run-id` to target a specific execution, and `--output-format json|ndjson` for scripting.
 
 #### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 #### Features
 
-- **`/config` settings panel** — view and change settings from the chat TUI without leaving the terminal. `/config` (alias `/settings`) lists each setting with its current value and where it is stored; press Enter to toggle a switch, pick from a choice list, or edit a value inline. Covers git commit-author marking, the LaTeX formatter, and workflow auto-compile options today. Settings come from the same shared catalog the VS Code extension uses, so the two surfaces stay in sync instead of drifting apart.
+- **`/config` settings panel** — view and change settings from the chat TUI without leaving the terminal. `/config` (alias `/settings`) lists each setting with its current value and where it is stored; press Enter to toggle a switch, pick from a choice list, or edit a value inline. Covers the git commit-author identity settings the CLI applies to agent commits and worktrees. Settings come from the same shared catalog the VS Code extension uses, so the two surfaces stay in sync instead of drifting apart.
 - **`texra latexdiff` command** — generate round-aware LaTeX diffs for an agent run's outputs straight from the terminal, the same capability the VS Code extension offers. Point it at a run with `texra latexdiff <agent> -m <model> -i <file>`; add `--between-rounds` to also diff consecutive rounds, `--run-id` to target a specific execution, and `--output-format json|ndjson` for scripting.
 
 #### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 #### Features
 
-- **`/config` settings panel** — view and change settings from the chat TUI without leaving the terminal. `/config` (alias `/settings`) lists each setting with its current value and where it is stored; press Enter to toggle a switch or drill into a choice list. Settings come from the same shared catalog the VS Code extension uses, so the two surfaces stay in sync instead of drifting apart.
+- **`/config` settings panel** — view and change settings from the chat TUI without leaving the terminal. `/config` (alias `/settings`) lists each setting with its current value and where it is stored; press Enter to toggle a switch, pick from a choice list, or edit a value inline. Covers git commit-author marking, the LaTeX formatter, and workflow auto-compile options today. Settings come from the same shared catalog the VS Code extension uses, so the two surfaces stay in sync instead of drifting apart.
 - **`texra latexdiff` command** — generate round-aware LaTeX diffs for an agent run's outputs straight from the terminal, the same capability the VS Code extension offers. Point it at a run with `texra latexdiff <agent> -m <model> -i <file>`; add `--between-rounds` to also diff consecutive rounds, `--run-id` to target a specific execution, and `--output-format json|ndjson` for scripting.
 
 #### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 #### Features
 
+- **`/config` settings panel** — view and change settings from the chat TUI without leaving the terminal. `/config` (alias `/settings`) lists each setting with its current value and where it is stored; press Enter to toggle a switch or drill into a choice list. Settings come from the same shared catalog the VS Code extension uses, so the two surfaces stay in sync instead of drifting apart.
 - **`texra latexdiff` command** — generate round-aware LaTeX diffs for an agent run's outputs straight from the terminal, the same capability the VS Code extension offers. Point it at a run with `texra latexdiff <agent> -m <model> -i <file>`; add `--between-rounds` to also diff consecutive rounds, `--run-id` to target a specific execution, and `--output-format json|ndjson` for scripting.
 
 #### Improvements

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -40,6 +40,7 @@ import { getDefaultStreamLogStore } from '@transcript';
 
 import { App } from '../src/chat/tui/App';
 import { registerBuiltinSlashCommands } from '../src/chat/tui/commands/registerBuiltins';
+import { cliSettingsStores } from '../src/runtime/settingsStores';
 import {
   formatSlashCommandHelp,
   GOAL_MODE_HELP,
@@ -1592,6 +1593,7 @@ registerBuiltinSlashCommands({
   onResumeSelect: (id) => {
     appendHarnessAssistantTranscript(`Harness resume selected: ${id}.`);
   },
+  getConfigStores: cliSettingsStores,
   onError: (error) => {
     appendHarnessAssistantTranscript(
       `Slash command failed: ${toErrorMessage(error)}`,

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -7,6 +7,7 @@ import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
 import type { ExecutionId } from '@shared/schemas';
 import {
   readSetting,
+  resetSetting,
   writeSetting,
   type SettingsStores,
 } from '@shared/config/settingsAccess';
@@ -405,8 +406,14 @@ export function registerBuiltinSlashCommands(options?: {
           writeValue={async (entry, value) => {
             await writeSetting(entry, value, stores, 'cli');
             // Git-author settings are applied to process env / worktree state
-            // at startup; re-apply so a /config toggle takes effect this session
+            // at startup; re-apply so a /config change takes effect this session
             // instead of only after a restart.
+            if (entry.category === 'git') {
+              applyCliGitAuthorConfig(stores.config);
+            }
+          }}
+          resetValue={async (entry) => {
+            await resetSetting(entry, stores, 'cli');
             if (entry.category === 'git') {
               applyCliGitAuthorConfig(stores.config);
             }

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -1,6 +1,7 @@
 // Registers the slash commands the input palette surfaces.
 
 import type { CliApiMode } from '@cli/runtime/apiAccessMode';
+import { applyCliGitAuthorConfig } from '@cli/runtime/gitAuthor';
 import type { GetModelSwitchDisabledReason } from '@cli/runtime/modelAccess';
 import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
 import type { ExecutionId } from '@shared/schemas';
@@ -401,9 +402,15 @@ export function registerBuiltinSlashCommands(options?: {
           availableRows={props.availableRows}
           entries={CLI_STATE_SETTINGS}
           readValue={(entry) => readSetting(entry, stores, 'cli')}
-          writeValue={(entry, value) =>
-            writeSetting(entry, value, stores, 'cli')
-          }
+          writeValue={async (entry, value) => {
+            await writeSetting(entry, value, stores, 'cli');
+            // Git-author settings are applied to process env / worktree state
+            // at startup; re-apply so a /config toggle takes effect this session
+            // instead of only after a restart.
+            if (entry.category === 'git') {
+              applyCliGitAuthorConfig(stores.config);
+            }
+          }}
           onClose={() => props.onDone(undefined)}
           onError={options?.onError}
         />

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -4,10 +4,16 @@ import type { CliApiMode } from '@cli/runtime/apiAccessMode';
 import type { GetModelSwitchDisabledReason } from '@cli/runtime/modelAccess';
 import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
 import type { ExecutionId } from '@shared/schemas';
+import {
+  readSetting,
+  writeSetting,
+  type SettingsStores,
+} from '@shared/config/settingsAccess';
 
 import { ApiModeForm } from '../forms/ApiModeForm';
 import { AgentListForm } from '../forms/AgentListForm';
 import { ApprovalPolicyForm } from '../forms/ApprovalPolicyForm';
+import { CLI_CONFIG_ROSTER, ConfigForm } from '../forms/ConfigForm';
 import { LoginForm, type LoginFormValue } from '../forms/LoginForm';
 import { MemoryListForm } from '../forms/MemoryListForm';
 import { ModelListForm } from '../forms/ModelListForm';
@@ -79,6 +85,7 @@ export function registerBuiltinSlashCommands(options?: {
   onMemorySelect?: MemorySelectHandler;
   onResumeSelect?: ResumeSelectHandler;
   onSkillSelect?: SkillSelectHandler;
+  getConfigStores?: () => SettingsStores;
   onError?: ErrorHandler;
 }): void {
   const onAgentSelect: AgentSelectHandler =
@@ -281,6 +288,24 @@ export function registerBuiltinSlashCommands(options?: {
     );
   }
 
+  function ConfigFormAdapter(props: SlashFormProps): React.JSX.Element {
+    const stores = options?.getConfigStores?.();
+    return (
+      <ConfigForm
+        availableRows={props.availableRows}
+        entries={CLI_CONFIG_ROSTER}
+        readValue={(entry) =>
+          stores ? readSetting(entry, stores, 'cli') : undefined
+        }
+        writeValue={(entry, value) =>
+          stores ? writeSetting(entry, value, stores, 'cli') : undefined
+        }
+        onClose={() => props.onDone(undefined)}
+        onError={options?.onError}
+      />
+    );
+  }
+
   registerSlashCommand({
     name: 'help',
     description: 'Show available slash commands',
@@ -381,6 +406,14 @@ export function registerBuiltinSlashCommands(options?: {
     description: 'List or toggle external integrations',
     category: 'configuration',
     formComponent: ToolsListFormAdapter,
+  });
+  registerSlashCommand({
+    name: 'config',
+    description: 'View and toggle settings',
+    aliases: ['settings'],
+    category: 'configuration',
+    formComponent: ConfigFormAdapter,
+    formEscapeAction: 'close',
   });
   registerSlashCommand({
     name: 'compact',

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -9,11 +9,12 @@ import {
   writeSetting,
   type SettingsStores,
 } from '@shared/config/settingsAccess';
+import { CLI_STATE_SETTINGS } from '@shared/schemas/stateSettings';
 
 import { ApiModeForm } from '../forms/ApiModeForm';
 import { AgentListForm } from '../forms/AgentListForm';
 import { ApprovalPolicyForm } from '../forms/ApprovalPolicyForm';
-import { CLI_CONFIG_ROSTER, ConfigForm } from '../forms/ConfigForm';
+import { ConfigForm } from '../forms/ConfigForm';
 import { LoginForm, type LoginFormValue } from '../forms/LoginForm';
 import { MemoryListForm } from '../forms/MemoryListForm';
 import { ModelListForm } from '../forms/ModelListForm';
@@ -288,24 +289,6 @@ export function registerBuiltinSlashCommands(options?: {
     );
   }
 
-  function ConfigFormAdapter(props: SlashFormProps): React.JSX.Element {
-    const stores = options?.getConfigStores?.();
-    return (
-      <ConfigForm
-        availableRows={props.availableRows}
-        entries={CLI_CONFIG_ROSTER}
-        readValue={(entry) =>
-          stores ? readSetting(entry, stores, 'cli') : undefined
-        }
-        writeValue={(entry, value) =>
-          stores ? writeSetting(entry, value, stores, 'cli') : undefined
-        }
-        onClose={() => props.onDone(undefined)}
-        onError={options?.onError}
-      />
-    );
-  }
-
   registerSlashCommand({
     name: 'help',
     description: 'Show available slash commands',
@@ -407,14 +390,34 @@ export function registerBuiltinSlashCommands(options?: {
     category: 'configuration',
     formComponent: ToolsListFormAdapter,
   });
-  registerSlashCommand({
-    name: 'config',
-    description: 'View and toggle settings',
-    aliases: ['settings'],
-    category: 'configuration',
-    formComponent: ConfigFormAdapter,
-    formEscapeAction: 'close',
-  });
+  // Only offer /config when the host wired the stores it reads/writes — a
+  // command that can't reach a store would render an inert panel.
+  const getConfigStores = options?.getConfigStores;
+  if (getConfigStores) {
+    const ConfigFormAdapter = (props: SlashFormProps): React.JSX.Element => {
+      const stores = getConfigStores();
+      return (
+        <ConfigForm
+          availableRows={props.availableRows}
+          entries={CLI_STATE_SETTINGS}
+          readValue={(entry) => readSetting(entry, stores, 'cli')}
+          writeValue={(entry, value) =>
+            writeSetting(entry, value, stores, 'cli')
+          }
+          onClose={() => props.onDone(undefined)}
+          onError={options?.onError}
+        />
+      );
+    };
+    registerSlashCommand({
+      name: 'config',
+      description: 'View and toggle settings',
+      aliases: ['settings'],
+      category: 'configuration',
+      formComponent: ConfigFormAdapter,
+      formEscapeAction: 'close',
+    });
+  }
   registerSlashCommand({
     name: 'compact',
     description: 'Request context compaction',

--- a/packages/cli/src/chat/tui/forms/ConfigForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ConfigForm.tsx
@@ -12,8 +12,10 @@ import { Box, Text } from 'ink';
 import { useState } from 'react';
 
 import { stripPrefix } from '@shared/config/configKeys';
+import { settingSlot } from '@shared/config/settingsAccess';
 import {
-  STATE_SETTINGS,
+  settingEnumOptions,
+  settingIsBoolean,
   type StateSettingEntry,
 } from '@shared/schemas/stateSettings';
 
@@ -22,23 +24,16 @@ import { Select, type SelectItem } from '../ui/Select';
 import { FormFrame } from './_shared/FormFrame';
 import { computeSelectWindowSize } from './_shared/selectWindow';
 
-/** Catalog entries the CLI actually consumes — the `/config` roster. */
-export const CLI_CONFIG_ROSTER: readonly StateSettingEntry[] =
-  STATE_SETTINGS.filter((entry) => entry.hosts.includes('cli'));
-
 export type SettingEditKind = 'boolean' | 'enum' | 'readonly';
 
 /**
- * How a setting is edited in `/config`. Enum settings drill into a value
- * picker; booleans toggle inline; everything else (string/number) is read-only
- * for now (free-text editing is deferred).
+ * How a setting is edited in `/config`, derived from its schema: enum settings
+ * drill into a value picker; booleans toggle inline; everything else
+ * (string/number) is read-only for now (free-text editing is deferred).
  */
-export function settingEditKind(
-  entry: StateSettingEntry,
-  value: unknown,
-): SettingEditKind {
-  if (entry.enumValues && entry.enumValues.length > 0) return 'enum';
-  if (typeof value === 'boolean') return 'boolean';
+export function settingEditKind(entry: StateSettingEntry): SettingEditKind {
+  if (settingEnumOptions(entry)) return 'enum';
+  if (settingIsBoolean(entry)) return 'boolean';
   return 'readonly';
 }
 
@@ -50,7 +45,7 @@ export function formatSettingValue(value: unknown): string {
 
 /** The store the CLI reads/writes this setting from (cliStore override wins). */
 export function settingStoreLabel(entry: StateSettingEntry): string {
-  return entry.cliStore ?? entry.store;
+  return settingSlot(entry, 'cli');
 }
 
 export function settingDisplayName(entry: StateSettingEntry): string {
@@ -62,9 +57,8 @@ export function buildConfigListItems(
   readValue: (entry: StateSettingEntry) => unknown,
 ): Array<SelectItem<string>> {
   return entries.map((entry) => {
-    const value = readValue(entry);
-    const kind = settingEditKind(entry, value);
-    const valueText = formatSettingValue(value);
+    const kind = settingEditKind(entry);
+    const valueText = formatSettingValue(readValue(entry));
     const store = settingStoreLabel(entry);
     const suffix = kind === 'readonly' ? ' · read-only' : '';
     return {
@@ -79,7 +73,7 @@ export function buildConfigListItems(
 export function buildEnumItems(
   entry: StateSettingEntry,
 ): Array<SelectItem<string>> {
-  const values = entry.enumValues ?? [];
+  const values = settingEnumOptions(entry) ?? [];
   const descriptions = entry.enumDescriptions ?? [];
   return values.map((value, index) => ({
     value,
@@ -114,13 +108,12 @@ export function ConfigForm(props: ConfigFormProps): React.JSX.Element {
   const [, setRevision] = useState(0);
 
   const commit = (entry: StateSettingEntry, value: unknown): void => {
-    try {
-      Promise.resolve(props.writeValue(entry, value))
-        .then(() => setRevision((revision) => revision + 1))
-        .catch((error: unknown) => props.onError?.(error));
-    } catch (error: unknown) {
-      props.onError?.(error);
-    }
+    // Starting from a resolved promise routes both a synchronous throw (e.g. a
+    // schema-rejected value) and an async rejection through the single `.catch`.
+    void Promise.resolve()
+      .then(() => props.writeValue(entry, value))
+      .then(() => setRevision((revision) => revision + 1))
+      .catch((error: unknown) => props.onError?.(error));
   };
 
   if (mode.kind === 'enum') {
@@ -182,10 +175,9 @@ export function ConfigForm(props: ConfigFormProps): React.JSX.Element {
   const handleSelect = (key: string): void => {
     const entry = props.entries.find((candidate) => candidate.key === key);
     if (!entry) return;
-    const value = props.readValue(entry);
-    const kind = settingEditKind(entry, value);
+    const kind = settingEditKind(entry);
     if (kind === 'boolean') {
-      commit(entry, !(value as boolean));
+      commit(entry, !(props.readValue(entry) as boolean));
     } else if (kind === 'enum') {
       setMode({ kind: 'enum', entry });
     }

--- a/packages/cli/src/chat/tui/forms/ConfigForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ConfigForm.tsx
@@ -1,14 +1,13 @@
-// `/config` — view and toggle host-neutral settings from the chat TUI.
+// `/config` — view and edit host-neutral settings from the chat TUI.
 //
 // Unlike the single-Select pickers (`/approval`, `/api`), this is a list +
 // drill-in: the outer list shows every catalog entry the CLI consumes with its
 // current value and store; selecting a boolean toggles it inline, an enum opens
-// an inner value picker, and free-text (string/number) entries render read-only
-// for now (deferred editing). Reads/writes go through the host-aware
-// `settingsAccess` accessor so the same catalog drives the extension settings
-// view and this panel without drift.
+// an inner value picker, and a string/number opens an inline text editor.
+// Reads/writes go through the host-aware `settingsAccess` accessor so the same
+// catalog drives the extension settings view and this panel without drift.
 
-import { Box, Text } from 'ink';
+import { Box, Text, useInput } from 'ink';
 import { useState } from 'react';
 
 import { stripPrefix } from '@shared/config/configKeys';
@@ -16,25 +15,53 @@ import { settingSlot } from '@shared/config/settingsAccess';
 import {
   settingEnumOptions,
   settingIsBoolean,
+  settingIsNumber,
+  settingIsString,
   type StateSettingEntry,
 } from '@shared/schemas/stateSettings';
 
+import { BaseTextInput } from '../input/BaseTextInput';
 import { KeyHints } from '../ui/KeyHints';
+import { POINTER } from '../ui/glyphs';
 import { Select, type SelectItem } from '../ui/Select';
 import { FormFrame } from './_shared/FormFrame';
 import { computeSelectWindowSize } from './_shared/selectWindow';
 
-export type SettingEditKind = 'boolean' | 'enum' | 'readonly';
+export type SettingEditKind =
+  | 'boolean'
+  | 'enum'
+  | 'string'
+  | 'number'
+  | 'readonly';
 
 /**
- * How a setting is edited in `/config`, derived from its schema: enum settings
- * drill into a value picker; booleans toggle inline; everything else
- * (string/number) is read-only for now (free-text editing is deferred).
+ * How a setting is edited in `/config`, derived from its schema: enums drill
+ * into a value picker, booleans toggle inline, strings/numbers open a text
+ * editor; anything else (e.g. a record) is read-only.
  */
 export function settingEditKind(entry: StateSettingEntry): SettingEditKind {
   if (settingEnumOptions(entry)) return 'enum';
   if (settingIsBoolean(entry)) return 'boolean';
+  if (settingIsNumber(entry)) return 'number';
+  if (settingIsString(entry)) return 'string';
   return 'readonly';
+}
+
+/**
+ * Coerce raw text-editor input to the value a `string`/`number` setting
+ * expects, or `null` when a number field's input is blank or non-numeric (so
+ * the caller can ignore the submit rather than write `NaN`). Range/format
+ * violations are left to the schema, which rejects them on write.
+ */
+export function coerceSettingInput(
+  raw: string,
+  isNumber: boolean,
+): { value: unknown } | null {
+  if (!isNumber) return { value: raw };
+  const trimmed = raw.trim();
+  if (trimmed === '') return null;
+  const parsed = Number(trimmed);
+  return Number.isNaN(parsed) ? null : { value: parsed };
 }
 
 export function formatSettingValue(value: unknown): string {
@@ -96,10 +123,57 @@ export interface ConfigFormProps {
 
 type ConfigFormMode =
   | { readonly kind: 'list' }
-  | { readonly kind: 'enum'; readonly entry: StateSettingEntry };
+  | { readonly kind: 'enum'; readonly entry: StateSettingEntry }
+  | {
+      readonly kind: 'text';
+      readonly entry: StateSettingEntry;
+      readonly isNumber: boolean;
+    };
 
 const LIST_CHROME_ROWS = 5;
 const ENUM_CHROME_ROWS = 4;
+
+/** Inline text editor for a string/number setting (its own input buffer). */
+function ConfigTextEditor(props: {
+  readonly entry: StateSettingEntry;
+  readonly initialValue: string;
+  readonly isNumber: boolean;
+  readonly onSubmit: (raw: string) => void;
+  readonly onCancel: () => void;
+}): React.JSX.Element {
+  const [buffer, setBuffer] = useState(props.initialValue);
+  // BaseTextInput owns Enter (onSubmit) and ignores Escape, so handle Escape
+  // here to back out to the list.
+  useInput((_input, key) => {
+    if (key.escape) props.onCancel();
+  });
+  return (
+    <FormFrame
+      color="cyan"
+      title={`/config · ${settingDisplayName(props.entry)}`}
+      showCloseHint={false}
+    >
+      <Box>
+        <Text>{`${POINTER} `}</Text>
+        <BaseTextInput
+          value={buffer}
+          placeholder={props.isNumber ? 'enter a number' : 'enter a value'}
+          onChange={setBuffer}
+          onSubmit={props.onSubmit}
+        />
+      </Box>
+      <Box marginTop={1}>
+        <KeyHints
+          hints={[
+            { key: 'Enter', action: 'save' },
+            { key: 'Esc', action: 'back' },
+          ]}
+          confirmCancel={false}
+        />
+      </Box>
+    </FormFrame>
+  );
+}
 
 export function ConfigForm(props: ConfigFormProps): React.JSX.Element {
   const [mode, setMode] = useState<ConfigFormMode>({ kind: 'list' });
@@ -156,6 +230,25 @@ export function ConfigForm(props: ConfigFormProps): React.JSX.Element {
     );
   }
 
+  if (mode.kind === 'text') {
+    const { entry, isNumber } = mode;
+    const current = props.readValue(entry);
+    return (
+      <ConfigTextEditor
+        key={entry.key}
+        entry={entry}
+        initialValue={current == null ? '' : String(current)}
+        isNumber={isNumber}
+        onSubmit={(raw) => {
+          const coerced = coerceSettingInput(raw, isNumber);
+          if (coerced) commit(entry, coerced.value);
+          setMode({ kind: 'list' });
+        }}
+        onCancel={() => setMode({ kind: 'list' })}
+      />
+    );
+  }
+
   const items = buildConfigListItems(props.entries, props.readValue);
 
   if (items.length === 0) {
@@ -180,6 +273,10 @@ export function ConfigForm(props: ConfigFormProps): React.JSX.Element {
       commit(entry, !(props.readValue(entry) as boolean));
     } else if (kind === 'enum') {
       setMode({ kind: 'enum', entry });
+    } else if (kind === 'string') {
+      setMode({ kind: 'text', entry, isNumber: false });
+    } else if (kind === 'number') {
+      setMode({ kind: 'text', entry, isNumber: true });
     }
     // 'readonly' rows are disabled in the list and never reach here.
   };

--- a/packages/cli/src/chat/tui/forms/ConfigForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ConfigForm.tsx
@@ -1,0 +1,216 @@
+// `/config` — view and toggle host-neutral settings from the chat TUI.
+//
+// Unlike the single-Select pickers (`/approval`, `/api`), this is a list +
+// drill-in: the outer list shows every catalog entry the CLI consumes with its
+// current value and store; selecting a boolean toggles it inline, an enum opens
+// an inner value picker, and free-text (string/number) entries render read-only
+// for now (deferred editing). Reads/writes go through the host-aware
+// `settingsAccess` accessor so the same catalog drives the extension settings
+// view and this panel without drift.
+
+import { Box, Text } from 'ink';
+import { useState } from 'react';
+
+import { stripPrefix } from '@shared/config/configKeys';
+import {
+  STATE_SETTINGS,
+  type StateSettingEntry,
+} from '@shared/schemas/stateSettings';
+
+import { KeyHints } from '../ui/KeyHints';
+import { Select, type SelectItem } from '../ui/Select';
+import { FormFrame } from './_shared/FormFrame';
+import { computeSelectWindowSize } from './_shared/selectWindow';
+
+/** Catalog entries the CLI actually consumes — the `/config` roster. */
+export const CLI_CONFIG_ROSTER: readonly StateSettingEntry[] =
+  STATE_SETTINGS.filter((entry) => entry.hosts.includes('cli'));
+
+export type SettingEditKind = 'boolean' | 'enum' | 'readonly';
+
+/**
+ * How a setting is edited in `/config`. Enum settings drill into a value
+ * picker; booleans toggle inline; everything else (string/number) is read-only
+ * for now (free-text editing is deferred).
+ */
+export function settingEditKind(
+  entry: StateSettingEntry,
+  value: unknown,
+): SettingEditKind {
+  if (entry.enumValues && entry.enumValues.length > 0) return 'enum';
+  if (typeof value === 'boolean') return 'boolean';
+  return 'readonly';
+}
+
+export function formatSettingValue(value: unknown): string {
+  if (typeof value === 'boolean') return value ? 'on' : 'off';
+  if (value === '' || value == null) return '(empty)';
+  return String(value);
+}
+
+/** The store the CLI reads/writes this setting from (cliStore override wins). */
+export function settingStoreLabel(entry: StateSettingEntry): string {
+  return entry.cliStore ?? entry.store;
+}
+
+export function settingDisplayName(entry: StateSettingEntry): string {
+  return stripPrefix(entry.key);
+}
+
+export function buildConfigListItems(
+  entries: readonly StateSettingEntry[],
+  readValue: (entry: StateSettingEntry) => unknown,
+): Array<SelectItem<string>> {
+  return entries.map((entry) => {
+    const value = readValue(entry);
+    const kind = settingEditKind(entry, value);
+    const valueText = formatSettingValue(value);
+    const store = settingStoreLabel(entry);
+    const suffix = kind === 'readonly' ? ' · read-only' : '';
+    return {
+      value: entry.key,
+      label: settingDisplayName(entry),
+      description: `${valueText} · ${store}${suffix}`,
+      disabled: kind === 'readonly',
+    };
+  });
+}
+
+export function buildEnumItems(
+  entry: StateSettingEntry,
+): Array<SelectItem<string>> {
+  const values = entry.enumValues ?? [];
+  const descriptions = entry.enumDescriptions ?? [];
+  return values.map((value, index) => ({
+    value,
+    label: value,
+    description: descriptions[index],
+  }));
+}
+
+export interface ConfigFormProps {
+  readonly entries: readonly StateSettingEntry[];
+  readonly readValue: (entry: StateSettingEntry) => unknown;
+  readonly writeValue: (
+    entry: StateSettingEntry,
+    value: unknown,
+  ) => void | Promise<void>;
+  readonly availableRows?: number;
+  readonly onClose: () => void;
+  readonly onError?: (error: unknown) => void;
+}
+
+type ConfigFormMode =
+  | { readonly kind: 'list' }
+  | { readonly kind: 'enum'; readonly entry: StateSettingEntry };
+
+const LIST_CHROME_ROWS = 5;
+const ENUM_CHROME_ROWS = 4;
+
+export function ConfigForm(props: ConfigFormProps): React.JSX.Element {
+  const [mode, setMode] = useState<ConfigFormMode>({ kind: 'list' });
+  // Values are read live from `props.readValue`; bumping this after a write
+  // forces a re-render so the new value paints (the store itself is the SSOT).
+  const [, setRevision] = useState(0);
+
+  const commit = (entry: StateSettingEntry, value: unknown): void => {
+    try {
+      Promise.resolve(props.writeValue(entry, value))
+        .then(() => setRevision((revision) => revision + 1))
+        .catch((error: unknown) => props.onError?.(error));
+    } catch (error: unknown) {
+      props.onError?.(error);
+    }
+  };
+
+  if (mode.kind === 'enum') {
+    const { entry } = mode;
+    const current = props.readValue(entry);
+    const items = buildEnumItems(entry);
+    const window = computeSelectWindowSize({
+      availableRows: props.availableRows,
+      itemCount: items.length,
+      chromeRows: ENUM_CHROME_ROWS,
+    });
+    return (
+      <FormFrame
+        color="cyan"
+        title={`/config · ${settingDisplayName(entry)}`}
+        showCloseHint={false}
+      >
+        <Select
+          items={items}
+          activeValue={typeof current === 'string' ? current : undefined}
+          maxVisibleItems={window.maxVisibleItems}
+          showOverflow={window.showOverflow}
+          onSelect={(value) => {
+            commit(entry, value);
+            setMode({ kind: 'list' });
+          }}
+          onCancel={() => setMode({ kind: 'list' })}
+        />
+        <Box marginTop={1}>
+          <KeyHints
+            hints={[
+              { key: '↑/↓', action: 'navigate' },
+              { key: 'Enter', action: 'select' },
+              { key: 'Esc', action: 'back' },
+            ]}
+            confirmCancel={false}
+          />
+        </Box>
+      </FormFrame>
+    );
+  }
+
+  const items = buildConfigListItems(props.entries, props.readValue);
+
+  if (items.length === 0) {
+    return (
+      <FormFrame color="cyan" title="/config">
+        <Text dimColor>No configurable settings are available here yet.</Text>
+      </FormFrame>
+    );
+  }
+
+  const window = computeSelectWindowSize({
+    availableRows: props.availableRows,
+    itemCount: items.length,
+    chromeRows: LIST_CHROME_ROWS,
+  });
+
+  const handleSelect = (key: string): void => {
+    const entry = props.entries.find((candidate) => candidate.key === key);
+    if (!entry) return;
+    const value = props.readValue(entry);
+    const kind = settingEditKind(entry, value);
+    if (kind === 'boolean') {
+      commit(entry, !(value as boolean));
+    } else if (kind === 'enum') {
+      setMode({ kind: 'enum', entry });
+    }
+    // 'readonly' rows are disabled in the list and never reach here.
+  };
+
+  return (
+    <FormFrame color="cyan" title="/config" showCloseHint={false}>
+      <Select
+        items={items}
+        maxVisibleItems={window.maxVisibleItems}
+        showOverflow={window.showOverflow}
+        onSelect={handleSelect}
+        onCancel={props.onClose}
+      />
+      <Box marginTop={1}>
+        <KeyHints
+          hints={[
+            { key: '↑/↓', action: 'navigate' },
+            { key: 'Enter', action: 'toggle / edit' },
+            { key: 'Esc', action: 'close' },
+          ]}
+          confirmCancel={false}
+        />
+      </Box>
+    </FormFrame>
+  );
+}

--- a/packages/cli/src/chat/tui/forms/ConfigForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ConfigForm.tsx
@@ -11,7 +11,7 @@ import { Box, Text, useInput } from 'ink';
 import { useState } from 'react';
 
 import { stripPrefix } from '@shared/config/configKeys';
-import { settingSlot } from '@shared/config/settingsAccess';
+import { settingDefault, settingSlot } from '@shared/config/settingsAccess';
 import {
   settingEnumOptions,
   settingIsBoolean,
@@ -116,6 +116,8 @@ export interface ConfigFormProps {
     entry: StateSettingEntry,
     value: unknown,
   ) => void | Promise<void>;
+  /** Reset a setting to its default (delete the key). */
+  readonly resetValue?: (entry: StateSettingEntry) => void | Promise<void>;
   readonly availableRows?: number;
   readonly onClose: () => void;
   readonly onError?: (error: unknown) => void;
@@ -177,22 +179,54 @@ function ConfigTextEditor(props: {
 
 export function ConfigForm(props: ConfigFormProps): React.JSX.Element {
   const [mode, setMode] = useState<ConfigFormMode>({ kind: 'list' });
-  // Values are read live from `props.readValue`; bumping this after a write
-  // forces a re-render so the new value paints (the store itself is the SSOT).
-  const [, setRevision] = useState(0);
+  // Optimistic overrides: a write is async, so without these a rapid second
+  // toggle would recompute from a stale `readValue`. The override is set
+  // synchronously (so the next keypress sees it), reconciles with the store
+  // once the write lands, and rolls back if the write is rejected.
+  const [overrides, setOverrides] = useState<Record<string, unknown>>({});
 
-  const commit = (entry: StateSettingEntry, value: unknown): void => {
-    // Starting from a resolved promise routes both a synchronous throw (e.g. a
-    // schema-rejected value) and an async rejection through the single `.catch`.
+  const effective = (entry: StateSettingEntry): unknown =>
+    Object.hasOwn(overrides, entry.key)
+      ? overrides[entry.key]
+      : props.readValue(entry);
+
+  // Optimistically show `optimisticValue`, run the async `action`, and roll the
+  // override back to the prior value if it rejects. Starting from a resolved
+  // promise routes both a synchronous throw (e.g. a schema-rejected value) and
+  // an async rejection through the single `.catch`.
+  const runWrite = (
+    entry: StateSettingEntry,
+    optimisticValue: unknown,
+    action: () => void | Promise<void>,
+  ): void => {
+    const previous = effective(entry);
+    setOverrides((current) => ({ ...current, [entry.key]: optimisticValue }));
     void Promise.resolve()
-      .then(() => props.writeValue(entry, value))
-      .then(() => setRevision((revision) => revision + 1))
-      .catch((error: unknown) => props.onError?.(error));
+      .then(action)
+      .catch((error: unknown) => {
+        setOverrides((current) => ({ ...current, [entry.key]: previous }));
+        props.onError?.(error);
+      });
+  };
+
+  const commit = (entry: StateSettingEntry, value: unknown): void =>
+    runWrite(entry, value, () => props.writeValue(entry, value));
+
+  // Clearing a text field resets the setting (deletes the key) so its default
+  // reappears — otherwise a stored empty string can read back as "(empty)" while
+  // a consumer that coalesces empty→default (e.g. the git-author reader) quietly
+  // uses the default, leaving the panel and the effect out of sync.
+  const resetEntry = (entry: StateSettingEntry): void => {
+    if (!props.resetValue) {
+      commit(entry, '');
+      return;
+    }
+    runWrite(entry, settingDefault(entry), () => props.resetValue?.(entry));
   };
 
   if (mode.kind === 'enum') {
     const { entry } = mode;
-    const current = props.readValue(entry);
+    const current = effective(entry);
     const items = buildEnumItems(entry);
     const window = computeSelectWindowSize({
       availableRows: props.availableRows,
@@ -232,7 +266,7 @@ export function ConfigForm(props: ConfigFormProps): React.JSX.Element {
 
   if (mode.kind === 'text') {
     const { entry, isNumber } = mode;
-    const current = props.readValue(entry);
+    const current = effective(entry);
     return (
       <ConfigTextEditor
         key={entry.key}
@@ -240,8 +274,12 @@ export function ConfigForm(props: ConfigFormProps): React.JSX.Element {
         initialValue={current == null ? '' : String(current)}
         isNumber={isNumber}
         onSubmit={(raw) => {
-          const coerced = coerceSettingInput(raw, isNumber);
-          if (coerced) commit(entry, coerced.value);
+          if (!isNumber && raw.trim() === '') {
+            resetEntry(entry);
+          } else {
+            const coerced = coerceSettingInput(raw, isNumber);
+            if (coerced) commit(entry, coerced.value);
+          }
           setMode({ kind: 'list' });
         }}
         onCancel={() => setMode({ kind: 'list' })}
@@ -249,7 +287,7 @@ export function ConfigForm(props: ConfigFormProps): React.JSX.Element {
     );
   }
 
-  const items = buildConfigListItems(props.entries, props.readValue);
+  const items = buildConfigListItems(props.entries, effective);
 
   if (items.length === 0) {
     return (
@@ -270,7 +308,7 @@ export function ConfigForm(props: ConfigFormProps): React.JSX.Element {
     if (!entry) return;
     const kind = settingEditKind(entry);
     if (kind === 'boolean') {
-      commit(entry, !(props.readValue(entry) as boolean));
+      commit(entry, !(effective(entry) as boolean));
     } else if (kind === 'enum') {
       setMode({ kind: 'enum', entry });
     } else if (kind === 'string') {

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -38,6 +38,7 @@ import {
 } from '@cli/runtime/modelAccess';
 import { selectCliRootModel } from '@cli/runtime/rootModelSelection';
 import { writeTextStderr, writeTextStdout } from '@cli/runtime/logSinks';
+import { cliSettingsStores } from '@cli/runtime/settingsStores';
 import {
   formatInteractiveTerminalFailure,
   interactiveTerminalFailure,
@@ -534,6 +535,7 @@ export async function runChat(
     onMemorySelect: showCliMemoryPreview,
     onSkillSelect: activateSkillForNextMessage,
     onResumeSelect: (id: ExecutionId) => chatController.resume(id),
+    getConfigStores: cliSettingsStores,
     onError: (error) => {
       appendLocalAssistantTranscript(toErrorMessage(error));
     },

--- a/packages/cli/src/runtime/settingsStores.ts
+++ b/packages/cli/src/runtime/settingsStores.ts
@@ -1,0 +1,19 @@
+import { platform } from '@platform';
+
+import type { SettingsStores } from '@shared/config/settingsAccess';
+
+/**
+ * The three platform stores the host-aware {@link SettingsStores} accessor
+ * dispatches over, resolved from the active CLI platform. Used by the `/config`
+ * panel; `settingsAccess` picks `cliStore ?? store` per entry, so the
+ * git-author keys read/write `.texra/config.json` (config) while other
+ * state-backed keys use the CLI `state.json` stores.
+ */
+export function cliSettingsStores(): SettingsStores {
+  const active = platform();
+  return {
+    config: active.config,
+    workspaceState: active.workspaceState,
+    globalState: active.globalState,
+  };
+}

--- a/packages/cli/src/schemas/knownKeys.ts
+++ b/packages/cli/src/schemas/knownKeys.ts
@@ -1,8 +1,8 @@
-// Local imports - shared state keys (canonical git-author key names)
-import { WorkspaceStateKey } from '@shared/state/stateKeys';
-
 // Local imports - shared core schema
 import { CORE_SETTING_PATHS } from '@shared/schemas/coreSettings';
+
+// Local imports - state-backed settings catalog (canonical key list)
+import { STATE_SETTING_KEYS } from '@shared/schemas/stateSettings';
 
 // Local imports - compatibility keys
 import { LEGACY_GOAL_FEATURE_FLAG_KEYS } from '@shared/schemas/goal';
@@ -14,10 +14,15 @@ import { CLI_SETTING_PATHS } from './cliSettings';
  * Authoritative set of canonical `texra.*` keys recognized by the CLI for
  * unknown-key detection in `.texra/config.json`.
  *
- * Derived from Core paths (universal settings) and CLI-only paths
- * (`agent`, `model`, etc.). VS Code-only keys are intentionally excluded:
- * the CLI doesn't validate against another host's surface — anything not in
- * this set warns as unknown.
+ * Derived from Core paths (universal config settings), CLI-only paths
+ * (`agent`, `model`, etc.), and the state-backed settings catalog. VS Code-only
+ * keys are intentionally excluded: the CLI doesn't validate against another
+ * host's surface — anything not in this set warns as unknown.
+ *
+ * The state-backed keys (git commit-author marking, workflow/latexdiff
+ * settings, …) are stored as workspace state in the VS Code extension, but the
+ * catalog is the single source of truth for their canonical key names, so they
+ * are recognized here without a hand-maintained list.
  */
 export const KNOWN_TEXRA_KEYS: ReadonlySet<string> = new Set<string>([
   ...CORE_SETTING_PATHS.map((path) => `texra.${path}`),
@@ -25,11 +30,7 @@ export const KNOWN_TEXRA_KEYS: ReadonlySet<string> = new Set<string>([
   // Keep warning behavior aligned with runtime compatibility for pre-rename
   // `texra.odyssey.*` keys that `isGoalEnabled()` still honors when set.
   ...LEGACY_GOAL_FEATURE_FLAG_KEYS,
-  // Git commit-author marking is stored as workspace state in the VS Code
-  // extension, but the CLI reads it from `.texra/config.json`. Recognize the
-  // keys here so they don't warn as unknown.
-  WorkspaceStateKey.GIT_MARK_COMMITS,
-  WorkspaceStateKey.GIT_AUTHOR_NAME,
-  WorkspaceStateKey.GIT_AUTHOR_EMAIL,
-  WorkspaceStateKey.GIT_WORKTREE_SUPPORT,
+  // State-backed settings (git author marking, workflow/latexdiff, …) derived
+  // from the catalog rather than hand-listed.
+  ...STATE_SETTING_KEYS,
 ]);

--- a/packages/cli/src/schemas/knownKeys.ts
+++ b/packages/cli/src/schemas/knownKeys.ts
@@ -2,7 +2,7 @@
 import { CORE_SETTING_PATHS } from '@shared/schemas/coreSettings';
 
 // Local imports - state-backed settings catalog (canonical key list)
-import { STATE_SETTING_KEYS } from '@shared/schemas/stateSettings';
+import { CLI_STATE_SETTINGS } from '@shared/schemas/stateSettings';
 
 // Local imports - compatibility keys
 import { LEGACY_GOAL_FEATURE_FLAG_KEYS } from '@shared/schemas/goal';
@@ -15,14 +15,11 @@ import { CLI_SETTING_PATHS } from './cliSettings';
  * unknown-key detection in `.texra/config.json`.
  *
  * Derived from Core paths (universal config settings), CLI-only paths
- * (`agent`, `model`, etc.), and the state-backed settings catalog. VS Code-only
- * keys are intentionally excluded: the CLI doesn't validate against another
- * host's surface — anything not in this set warns as unknown.
- *
- * The state-backed keys (git commit-author marking, workflow/latexdiff
- * settings, …) are stored as workspace state in the VS Code extension, but the
- * catalog is the single source of truth for their canonical key names, so they
- * are recognized here without a hand-maintained list.
+ * (`agent`, `model`, etc.), and the state-backed settings the CLI reads *from
+ * config*. Keys the CLI doesn't read from `.texra/config.json` are intentionally
+ * excluded so they still warn as unknown — including state-backed settings the
+ * CLI reads from its `state.json` store (workflow/latexdiff): putting those in
+ * `config.json` is a no-op the warning should catch.
  */
 export const KNOWN_TEXRA_KEYS: ReadonlySet<string> = new Set<string>([
   ...CORE_SETTING_PATHS.map((path) => `texra.${path}`),
@@ -30,7 +27,9 @@ export const KNOWN_TEXRA_KEYS: ReadonlySet<string> = new Set<string>([
   // Keep warning behavior aligned with runtime compatibility for pre-rename
   // `texra.odyssey.*` keys that `isGoalEnabled()` still honors when set.
   ...LEGACY_GOAL_FEATURE_FLAG_KEYS,
-  // State-backed settings (git author marking, workflow/latexdiff, …) derived
-  // from the catalog rather than hand-listed.
-  ...STATE_SETTING_KEYS,
+  // State-backed settings the CLI reads from config (git author marking, via
+  // `cliStore: 'config'`) — derived from the catalog rather than hand-listed.
+  ...CLI_STATE_SETTINGS.filter(
+    (entry) => (entry.cliStore ?? entry.store) === 'config',
+  ).map((entry) => entry.key),
 ]);

--- a/packages/extension/src/schemas/texraSettings.ts
+++ b/packages/extension/src/schemas/texraSettings.ts
@@ -92,6 +92,8 @@ type JsonSchemaObject = {
   default?: unknown;
   minimum?: number;
   maximum?: number;
+  description?: string;
+  enumDescriptions?: unknown[];
 };
 
 const GENERATED_PACKAGE_SCHEMA_FIELDS = [
@@ -102,6 +104,8 @@ const GENERATED_PACKAGE_SCHEMA_FIELDS = [
   'enum',
   'minimum',
   'maximum',
+  'description',
+  'enumDescriptions',
 ] as const;
 
 let texraSettingsJsonSchema: JsonSchemaObject | undefined;

--- a/packages/extension/src/schemas/vscodeSettings.ts
+++ b/packages/extension/src/schemas/vscodeSettings.ts
@@ -32,6 +32,7 @@ export const VscodeSettingsExtensionShape = {
     .strictObject({
       enableVSCodeGitHub: z
         .boolean()
+        .describe('Enable VS Code native GitHub authentication (experimental)')
         .prefault(DEFAULT_VSCODE_SETTINGS_EXTENSION.auth.enableVSCodeGitHub),
     })
     .prefault(DEFAULT_VSCODE_SETTINGS_EXTENSION.auth),

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -31,7 +31,16 @@ import {
 import {
   LATEX_CONFIG_DEFAULTS,
   LATEX_CONFIG_RANGES,
+  type LatexdiffMathMarkupValue,
+  type LatexFormatterValue,
 } from '@shared/constants/latex';
+
+// Local imports - state-backed settings catalog (single source for enum options)
+import { WorkspaceStateKey } from '@shared/state/stateKeys';
+import {
+  settingEnumOptions,
+  stateSettingByKey,
+} from '@shared/schemas/stateSettings';
 
 // Local imports - shared constants
 import {
@@ -54,6 +63,44 @@ import { latexTabStyles } from './LaTeXTab.styles';
 import type WaSwitch from '@awesome.me/webawesome/dist/components/switch/switch.js';
 import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
+
+/**
+ * Build the `<wa-select>` option list for an enum setting from the shared
+ * catalog so the allowed values + per-option text live in one place
+ * (`stateSettings.ts`) rather than being hand-listed here. The label format
+ * stays this tab's own: `value — description` for math markup, bare `value`
+ * for the formatter, with ` (default)` appended to the default option.
+ */
+function catalogEnumOptions<T extends string>(
+  key: string,
+  defaultValue: T,
+  withDescription: boolean,
+): Array<{ value: T; label: string }> {
+  const entry = stateSettingByKey(key);
+  const values = entry ? (settingEnumOptions(entry) ?? []) : [];
+  const descriptions = entry?.enumDescriptions ?? [];
+  return values.map((value, index) => {
+    const base =
+      withDescription && descriptions[index]
+        ? `${value} — ${descriptions[index]}`
+        : value;
+    const label = value === defaultValue ? `${base} (default)` : base;
+    return { value: value as T, label };
+  });
+}
+
+const LATEXDIFF_MATH_MARKUP_OPTIONS =
+  catalogEnumOptions<LatexdiffMathMarkupValue>(
+    WorkspaceStateKey.LATEXDIFF_MATH_MARKUP,
+    LATEX_CONFIG_DEFAULTS.latexdiffMathMarkup,
+    true,
+  );
+
+const LATEX_FORMATTER_OPTIONS = catalogEnumOptions<LatexFormatterValue>(
+  WorkspaceStateKey.LATEX_FORMATTER,
+  LATEX_CONFIG_DEFAULTS.latexFormatter,
+  false,
+);
 
 /** Path keys in LatexSettingsStatus for tool paths. */
 type ToolPathKey =
@@ -588,12 +635,7 @@ export class LaTeXTab extends LitElement {
         description: 'Granularity of markup in displayed math environments.',
         defaultValue: LATEX_CONFIG_DEFAULTS.latexdiffMathMarkup,
         currentValue: cv.latexdiffMathMarkup,
-        options: [
-          { value: 'off', label: 'off — suppress markup' },
-          { value: 'whole', label: 'whole — equation-level' },
-          { value: 'coarse', label: 'coarse — within equations (default)' },
-          { value: 'fine', label: 'fine — small changes inside equations' },
-        ],
+        options: LATEXDIFF_MATH_MARKUP_OPTIONS,
       })}
       ${this.renderBooleanSetting({
         field: 'latexdiffChangesOnly',
@@ -610,11 +652,7 @@ export class LaTeXTab extends LitElement {
           '"none" disables formatting; "latexindent" requires Perl; "tex-fmt" is a Rust-based alternative.',
         defaultValue: LATEX_CONFIG_DEFAULTS.latexFormatter,
         currentValue: cv.latexFormatter,
-        options: [
-          { value: 'latexindent', label: 'latexindent (default)' },
-          { value: 'tex-fmt', label: 'tex-fmt' },
-          { value: 'none', label: 'none' },
-        ],
+        options: LATEX_FORMATTER_OPTIONS,
       })}
     `;
   }

--- a/src/shared/config/settingsAccess.ts
+++ b/src/shared/config/settingsAccess.ts
@@ -26,7 +26,12 @@ export interface SettingsStores {
 
 export type SettingsHostKind = 'extension' | 'cli';
 
-function slotFor(
+/**
+ * The storage slot a setting resolves to for a host: the CLI's `cliStore`
+ * override when set, otherwise the canonical `store`. Single source of the
+ * resolution rule — display labels and read/write all go through it.
+ */
+export function settingSlot(
   entry: StateSettingEntry,
   host: SettingsHostKind,
 ): SettingStore {
@@ -50,12 +55,32 @@ export function readSetting(
   stores: SettingsStores,
   host: SettingsHostKind = 'extension',
 ): unknown {
-  const raw = stores[slotFor(entry, host)].get<unknown>(entry.key);
+  const raw = stores[settingSlot(entry, host)].get<unknown>(entry.key);
   if (raw === undefined) {
     return settingDefault(entry);
   }
   const parsed = entry.schema.safeParse(raw);
   return parsed.success ? parsed.data : settingDefault(entry);
+}
+
+/**
+ * Persist a value to an entry's resolved slot. The only slot-specific detail is
+ * that `config` writes carry a target while state stores do not, so the
+ * dispatch lives here once for both write and reset.
+ */
+function writeSlot(
+  entry: StateSettingEntry,
+  value: unknown,
+  stores: SettingsStores,
+  host: SettingsHostKind,
+  target: ConfigTarget,
+): Promise<void> {
+  const slot = settingSlot(entry, host);
+  return Promise.resolve(
+    slot === 'config'
+      ? stores.config.update(entry.key, value, target)
+      : stores[slot].update(entry.key, value),
+  );
 }
 
 /**
@@ -70,13 +95,9 @@ export async function writeSetting(
   host: SettingsHostKind = 'extension',
   target: ConfigTarget = 'workspace',
 ): Promise<void> {
-  const parsed = entry.schema.parse(value);
-  const slot = slotFor(entry, host);
-  if (slot === 'config') {
-    await stores.config.update(entry.key, parsed, target);
-  } else {
-    await stores[slot].update(entry.key, parsed);
-  }
+  // `async` so a schema-rejected value surfaces as a rejected promise rather
+  // than a synchronous throw — callers rely on the uniform promise contract.
+  await writeSlot(entry, entry.schema.parse(value), stores, host, target);
 }
 
 /**
@@ -84,16 +105,11 @@ export async function writeSetting(
  * (`update(key, undefined)`), so the schema's `.prefault()` reappears on the
  * next read. Never writes the literal default value.
  */
-export async function resetSetting(
+export function resetSetting(
   entry: StateSettingEntry,
   stores: SettingsStores,
   host: SettingsHostKind = 'extension',
   target: ConfigTarget = 'workspace',
 ): Promise<void> {
-  const slot = slotFor(entry, host);
-  if (slot === 'config') {
-    await stores.config.update(entry.key, undefined, target);
-  } else {
-    await stores[slot].update(entry.key, undefined);
-  }
+  return writeSlot(entry, undefined, stores, host, target);
 }

--- a/src/shared/config/settingsAccess.ts
+++ b/src/shared/config/settingsAccess.ts
@@ -26,20 +26,11 @@ export interface SettingsStores {
 
 export type SettingsHostKind = 'extension' | 'cli';
 
-interface KeyValueReader {
-  get<T>(key: string, defaultValue?: T): T;
-}
-
 function slotFor(
   entry: StateSettingEntry,
   host: SettingsHostKind,
 ): SettingStore {
   return host === 'cli' && entry.cliStore ? entry.cliStore : entry.store;
-}
-
-function readerFor(slot: SettingStore, stores: SettingsStores): KeyValueReader {
-  // ConfigProvider and StateStore both satisfy KeyValueReader.
-  return stores[slot] as unknown as KeyValueReader;
 }
 
 /** The default-when-absent value for an entry, from its `.prefault()`. */
@@ -50,20 +41,21 @@ export function settingDefault(entry: StateSettingEntry): unknown {
 /**
  * Read a state-backed setting, falling back to (and validating against) the
  * entry's schema. A stored value that no longer validates resolves to the
- * default rather than propagating a stale/invalid value.
+ * default rather than propagating a stale/invalid value. Both `ConfigProvider`
+ * and `StateStore` expose the same `get(key, default)`, so the read dispatches
+ * uniformly on the resolved slot.
  */
 export function readSetting(
   entry: StateSettingEntry,
   stores: SettingsStores,
   host: SettingsHostKind = 'extension',
 ): unknown {
-  const fallback = settingDefault(entry);
-  const raw = readerFor(slotFor(entry, host), stores).get<unknown>(entry.key);
+  const raw = stores[slotFor(entry, host)].get<unknown>(entry.key);
   if (raw === undefined) {
-    return fallback;
+    return settingDefault(entry);
   }
   const parsed = entry.schema.safeParse(raw);
-  return parsed.success ? parsed.data : fallback;
+  return parsed.success ? parsed.data : settingDefault(entry);
 }
 
 /**

--- a/src/shared/config/settingsAccess.ts
+++ b/src/shared/config/settingsAccess.ts
@@ -1,0 +1,107 @@
+// Local imports - catalog + platform interfaces (type-only; vscode-free)
+import type {
+  SettingStore,
+  StateSettingEntry,
+} from '@shared/schemas/stateSettings';
+import type { ConfigProvider, ConfigTarget } from '@platform/interfaces/config';
+import type { StateStore } from '@platform/interfaces/state';
+
+/**
+ * Host-aware read/write for {@link StateSettingEntry} rows.
+ *
+ * Both `ConfigProvider` and `StateStore` expose the same `get(key, default)`
+ * read surface, so reads dispatch uniformly. Writes differ (`ConfigProvider`
+ * takes a target; `StateStore` does not), so they branch on the resolved slot.
+ *
+ * The resolved slot is `entry.cliStore ?? entry.store` for the CLI and
+ * `entry.store` for the extension/desktop — the git-author keys are the only
+ * rows that diverge (extension WorkspaceState vs CLI `.texra/config.json`).
+ */
+
+export interface SettingsStores {
+  readonly config: ConfigProvider;
+  readonly workspaceState: StateStore;
+  readonly globalState: StateStore;
+}
+
+export type SettingsHostKind = 'extension' | 'cli';
+
+interface KeyValueReader {
+  get<T>(key: string, defaultValue?: T): T;
+}
+
+function slotFor(
+  entry: StateSettingEntry,
+  host: SettingsHostKind,
+): SettingStore {
+  return host === 'cli' && entry.cliStore ? entry.cliStore : entry.store;
+}
+
+function readerFor(slot: SettingStore, stores: SettingsStores): KeyValueReader {
+  // ConfigProvider and StateStore both satisfy KeyValueReader.
+  return stores[slot] as unknown as KeyValueReader;
+}
+
+/** The default-when-absent value for an entry, from its `.prefault()`. */
+export function settingDefault(entry: StateSettingEntry): unknown {
+  return entry.schema.parse(undefined);
+}
+
+/**
+ * Read a state-backed setting, falling back to (and validating against) the
+ * entry's schema. A stored value that no longer validates resolves to the
+ * default rather than propagating a stale/invalid value.
+ */
+export function readSetting(
+  entry: StateSettingEntry,
+  stores: SettingsStores,
+  host: SettingsHostKind = 'extension',
+): unknown {
+  const fallback = settingDefault(entry);
+  const raw = readerFor(slotFor(entry, host), stores).get<unknown>(entry.key);
+  if (raw === undefined) {
+    return fallback;
+  }
+  const parsed = entry.schema.safeParse(raw);
+  return parsed.success ? parsed.data : fallback;
+}
+
+/**
+ * Validate and persist a state-backed setting. Throws if `value` fails the
+ * entry's schema. For `config`-slot writes the target defaults to `'workspace'`
+ * (matching today's CLI git-author behavior); state-store slots ignore target.
+ */
+export async function writeSetting(
+  entry: StateSettingEntry,
+  value: unknown,
+  stores: SettingsStores,
+  host: SettingsHostKind = 'extension',
+  target: ConfigTarget = 'workspace',
+): Promise<void> {
+  const parsed = entry.schema.parse(value);
+  const slot = slotFor(entry, host);
+  if (slot === 'config') {
+    await stores.config.update(entry.key, parsed, target);
+  } else {
+    await stores[slot].update(entry.key, parsed);
+  }
+}
+
+/**
+ * Reset a state-backed setting to its default by **deleting** the stored key
+ * (`update(key, undefined)`), so the schema's `.prefault()` reappears on the
+ * next read. Never writes the literal default value.
+ */
+export async function resetSetting(
+  entry: StateSettingEntry,
+  stores: SettingsStores,
+  host: SettingsHostKind = 'extension',
+  target: ConfigTarget = 'workspace',
+): Promise<void> {
+  const slot = slotFor(entry, host);
+  if (slot === 'config') {
+    await stores.config.update(entry.key, undefined, target);
+  } else {
+    await stores[slot].update(entry.key, undefined);
+  }
+}

--- a/src/shared/constants/git.ts
+++ b/src/shared/constants/git.ts
@@ -9,3 +9,10 @@ export const DEFAULT_GIT_AUTHOR_EMAIL = 'texra-ai@users.noreply.github.com';
  * wrong state on first paint before settings arrive.
  */
 export const DEFAULT_GIT_MARK_COMMITS = true;
+
+/**
+ * Default for `texra.git.worktreeSupport` when the workspace has never toggled
+ * it. Shared by the backend reader (`readGitAuthorSettingsFromState`) and the
+ * state-settings catalog so the default lives in one place.
+ */
+export const DEFAULT_GIT_WORKTREE_SUPPORT = false;

--- a/src/shared/schemas/coreSettings.ts
+++ b/src/shared/schemas/coreSettings.ts
@@ -266,11 +266,14 @@ export const DEFAULT_CORE_SETTINGS = {
   },
 };
 
-const stringArray = (defaultValue: string[]) =>
-  z.array(z.string()).prefault(defaultValue);
+const stringArray = (defaultValue: string[], description: string) =>
+  z.array(z.string()).describe(description).prefault(defaultValue);
 
-const stringRecord = (defaultValue: Record<string, string>) =>
-  z.record(z.string(), z.string()).prefault(defaultValue);
+const stringRecord = (
+  defaultValue: Record<string, string>,
+  description: string,
+) =>
+  z.record(z.string(), z.string()).describe(description).prefault(defaultValue);
 
 /**
  * Field shape for {@link CoreSettingsSchema}.
@@ -285,6 +288,9 @@ export const CoreSettingsShape = {
     .strictObject({
       autoOpenFinal: z
         .boolean()
+        .describe(
+          "When a workflow run completes, automatically preview the final revised file in a new editor tab. Disable for batch runs when you don't want a tab to steal focus.",
+        )
         .prefault(DEFAULT_CORE_SETTINGS.agentOutputs.autoOpenFinal),
     })
     .prefault(DEFAULT_CORE_SETTINGS.agentOutputs),
@@ -292,27 +298,47 @@ export const CoreSettingsShape = {
     .strictObject({
       enabled: z
         .boolean()
+        .describe(
+          'Experimental: parse \\criticize{message}{severity}{confidence} annotations from agent-revised LaTeX files and surface them as VS Code diagnostics (squiggles + Problems panel). Severity 5→Error, 4→Warning, 3→Info, 1–2→Hint. Tool-use agents may also push diagnostics directly via the add_criticism tool.',
+        )
         .prefault(DEFAULT_CORE_SETTINGS.inlineCriticism.enabled),
     })
     .prefault(DEFAULT_CORE_SETTINGS.inlineCriticism),
   goal: z
     .strictObject({
-      enabled: z.boolean().prefault(DEFAULT_CORE_SETTINGS.goal.enabled),
+      enabled: z
+        .boolean()
+        .describe(
+          'Enable Goal, a per-stream autonomous-continuation mode for tool-use agents. When on, an active Goal lets the agent keep working across turns toward a stated objective until it calls plan(command="complete"). On by default; set to false to require manual continuation.',
+        )
+        .prefault(DEFAULT_CORE_SETTINGS.goal.enabled),
     })
     .prefault(DEFAULT_CORE_SETTINGS.goal),
   ui: z
     .strictObject({
       showApiKeyReminders: z
         .boolean()
+        .describe(
+          'Show API key reminders in the status bar and main view when no API keys are configured',
+        )
         .prefault(DEFAULT_CORE_SETTINGS.ui.showApiKeyReminders),
       showLoginBanner: z
         .boolean()
+        .describe(
+          'Show login banner prompting users to sign in for access to remote agents',
+        )
         .prefault(DEFAULT_CORE_SETTINGS.ui.showLoginBanner),
       showGettingStartedBanner: z
         .boolean()
+        .describe(
+          'Show getting started banner with import options when no LaTeX files are found',
+        )
         .prefault(DEFAULT_CORE_SETTINGS.ui.showGettingStartedBanner),
       showOrchestratorBanner: z
         .boolean()
+        .describe(
+          'Show orchestrator and session reminder text in the main view',
+        )
         .prefault(DEFAULT_CORE_SETTINGS.ui.showOrchestratorBanner),
     })
     .prefault(DEFAULT_CORE_SETTINGS.ui),
@@ -320,42 +346,71 @@ export const CoreSettingsShape = {
     .strictObject({
       useImprovedConnection: z
         .boolean()
+        .describe('Use improved connection for API requests')
         .prefault(DEFAULT_CORE_SETTINGS.model.useImprovedConnection),
       improvedConnectionDomain: z
         .string()
+        .describe('Domain to use when using improved connection')
         .prefault(DEFAULT_CORE_SETTINGS.model.improvedConnectionDomain),
       useOpenAIResponsesAPI: z
         .boolean()
+        .describe(
+          "Use OpenAI's newer Responses API for additional features like built-in tool use. Disable to fall back to the classic Chat Completions API.",
+        )
         .prefault(DEFAULT_CORE_SETTINGS.model.useOpenAIResponsesAPI),
       useGoogleInteractionsAPI: z
         .boolean()
+        .describe(
+          "Use Google's Interactions API instead of Generate Content when available. Experimental; disabled by default. OpenRouter-proxied Google models always use Generate Content.",
+        )
         .prefault(DEFAULT_CORE_SETTINGS.model.useGoogleInteractionsAPI),
       useGoogleInteractionsServerState: z
         .boolean()
+        .describe(
+          "Store Google Interactions conversation state on Google's servers via previous_interaction_id chaining, sending only the new turn each round. Google then retains the conversation for a limited period to enable chaining. Enabled by default. Disable to keep conversations off Google's servers — stateless mode resends the full transcript each round (store:false).",
+        )
         .prefault(DEFAULT_CORE_SETTINGS.model.useGoogleInteractionsServerState),
       useBackgroundResponses: z
         .boolean()
+        .describe(
+          'Keep long-running OpenAI requests alive in the background (polling) instead of timing out after 10 minutes. Applies automatically to GPT models running workflow agents; ignored otherwise. Disable to fall back to synchronous streaming requests.',
+        )
         .prefault(DEFAULT_CORE_SETTINGS.model.useBackgroundResponses),
       openaiParallelToolCalls: z
         .boolean()
+        .describe(
+          'Let OpenAI models use multiple tools at the same time for faster results. Disabled by default for more predictable behavior.',
+        )
         .prefault(DEFAULT_CORE_SETTINGS.model.openaiParallelToolCalls),
       compactionThresholdPercent: z
         .number()
         .min(0)
         .max(100)
+        .describe(
+          "When the conversation reaches this percentage of the model's context limit, TeXRA automatically summarizes earlier messages to free up space. Lower values trigger summarization sooner. Set to 0 to disable.",
+        )
         .prefault(DEFAULT_CORE_SETTINGS.model.compactionThresholdPercent),
       gpt5ReasoningSummary: z
         .boolean()
+        .describe(
+          "Show the model's reasoning steps alongside its output when using GPT-5 models. Requires an OpenAI account with access to reasoning features.",
+        )
         .prefault(DEFAULT_CORE_SETTINGS.model.gpt5ReasoningSummary),
       retry: z
         .strictObject({
           maxAttempts: z
             .number()
             .min(0)
+            .describe(
+              'Number of automatic retry attempts before surfacing a manual retry option for model calls. Set to 0 for no automatic retries (manual retry button only).',
+            )
             .prefault(DEFAULT_CORE_SETTINGS.model.retry.maxAttempts),
           backoffMs: z
             .number()
             .min(0)
+            .describe(
+              'Base backoff delay in milliseconds between retry attempts for model calls',
+            )
             .prefault(DEFAULT_CORE_SETTINGS.model.retry.backoffMs),
         })
         .prefault(DEFAULT_CORE_SETTINGS.model.retry),
@@ -365,6 +420,9 @@ export const CoreSettingsShape = {
     .strictObject({
       preferSubscription: z
         .boolean()
+        .describe(
+          'Prefer your signed-in ChatGPT subscription for Codex-eligible OpenAI models instead of API-key routing. Experimental.',
+        )
         .prefault(DEFAULT_CORE_SETTINGS.chatgptCodex.preferSubscription),
     })
     .prefault(DEFAULT_CORE_SETTINGS.chatgptCodex),
@@ -374,15 +432,19 @@ export const CoreSettingsShape = {
         .strictObject({
           mediaExtensions: stringArray(
             DEFAULT_CORE_SETTINGS.files.included.mediaExtensions,
+            'File extensions to include when searching for media files',
           ),
           inputExtensions: stringArray(
             DEFAULT_CORE_SETTINGS.files.included.inputExtensions,
+            'File extensions to include when searching for input files',
           ),
           contextExtensions: stringArray(
             DEFAULT_CORE_SETTINGS.files.included.contextExtensions,
+            'File extensions to include when searching for context files',
           ),
           editedExtensions: stringArray(
             DEFAULT_CORE_SETTINGS.files.included.editedExtensions,
+            'File extensions to include when searching for edited files',
           ),
         })
         .prefault(DEFAULT_CORE_SETTINGS.files.included),
@@ -390,20 +452,28 @@ export const CoreSettingsShape = {
         .strictObject({
           fileExtensions: stringArray(
             DEFAULT_CORE_SETTINGS.files.ignored.fileExtensions,
+            'File extensions to ignore when listing text files',
           ),
           inputFiles: stringArray(
             DEFAULT_CORE_SETTINGS.files.ignored.inputFiles,
+            'Files to ignore when listing input, sample, and edited files',
           ),
           inputDirectories: stringArray(
             DEFAULT_CORE_SETTINGS.files.ignored.inputDirectories,
+            'Additional directories to ignore when listing input and edited files',
           ),
           mediaDirectories: stringArray(
             DEFAULT_CORE_SETTINGS.files.ignored.mediaDirectories,
+            'Directories to ignore in the figure path',
           ),
           directories: stringArray(
             DEFAULT_CORE_SETTINGS.files.ignored.directories,
+            'Directories to ignore when listing files',
           ),
-          keywords: stringArray(DEFAULT_CORE_SETTINGS.files.ignored.keywords),
+          keywords: stringArray(
+            DEFAULT_CORE_SETTINGS.files.ignored.keywords,
+            'Keywords to ignore when selecting files',
+          ),
         })
         .prefault(DEFAULT_CORE_SETTINGS.files.ignored),
     })
@@ -412,14 +482,25 @@ export const CoreSettingsShape = {
     .number()
     .min(100)
     .max(10000)
+    .describe(
+      'Maximum dimension (width or height) in pixels for images before resizing. Images larger than this will be resized to fit within this dimension while maintaining aspect ratio.',
+    )
     .prefault(DEFAULT_CORE_SETTINGS.maxImageDimension),
   bib: z
     .strictObject({
-      defaultPath: z.string().prefault(DEFAULT_CORE_SETTINGS.bib.defaultPath),
+      defaultPath: z
+        .string()
+        .describe(
+          'Default path to bibliography file (.bib). This is used by bibliography tools when no explicit path is provided. Supports Zotero auto-exported .bib files.',
+        )
+        .prefault(DEFAULT_CORE_SETTINGS.bib.defaultPath),
       zoteroPort: z
         .number()
         .min(1)
         .max(65535)
+        .describe(
+          'Port number for Zotero integration (default: 23119). Used by both the Connector API and Better BibTeX JSON-RPC.',
+        )
         .prefault(DEFAULT_CORE_SETTINGS.bib.zoteroPort),
     })
     .prefault(DEFAULT_CORE_SETTINGS.bib),
@@ -427,36 +508,55 @@ export const CoreSettingsShape = {
     .strictObject({
       showLatexindentWarning: z
         .boolean()
+        .describe('Show warning when latexindent is not installed')
         .prefault(DEFAULT_CORE_SETTINGS.latex.showLatexindentWarning),
       latexindentConfig: z
         .string()
+        .describe('Path to latexindent configuration file')
         .prefault(DEFAULT_CORE_SETTINGS.latex.latexindentConfig),
       texfmtConfig: z
         .string()
+        .describe('Path to tex-fmt configuration file')
         .prefault(DEFAULT_CORE_SETTINGS.latex.texfmtConfig),
       tikzInputDirectory: z
         .string()
+        .describe(
+          'Directory where to look for extra input files when compiling extracted TikZ figures. Absolute path is required. Sets TEXINPUTS environment variable for TikZ compilation.',
+        )
         .prefault(DEFAULT_CORE_SETTINGS.latex.tikzInputDirectory),
       tikzTemplate: z
         .string()
+        .describe(
+          'Template used for generating standalone documents when extracting and compiling TikZ figures',
+        )
         .prefault(DEFAULT_CORE_SETTINGS.latex.tikzTemplate),
       includeWorkspaceInTexinputs: z
         .boolean()
+        .describe(
+          'Include the workspace root directory in TEXINPUTS when compiling TikZ figures',
+        )
         .prefault(DEFAULT_CORE_SETTINGS.latex.includeWorkspaceInTexinputs),
       wrapCritiqueInAlign: z
         .boolean()
+        .describe(
+          'When enabled, bare \\critique and \\comment commands inside align blocks are wrapped with \\intertext.',
+        )
         .prefault(DEFAULT_CORE_SETTINGS.latex.wrapCritiqueInAlign),
       enabledReplacements: z
         .array(z.enum(NON_REGEX_REPLACEMENT_CATEGORIES))
+        .describe('List of enabled non-regex LaTeX replacement categories')
         .prefault(DEFAULT_CORE_SETTINGS.latex.enabledReplacements),
       enabledReplacementsRegex: z
         .array(z.enum(REGEX_REPLACEMENT_CATEGORIES))
+        .describe('List of enabled regex LaTeX replacement categories')
         .prefault(DEFAULT_CORE_SETTINGS.latex.enabledReplacementsRegex),
       customReplacementsRegex: stringRecord(
         DEFAULT_CORE_SETTINGS.latex.customReplacementsRegex,
+        "Custom regex replacements in the format: { 'pattern': 'replacement' }. Use capture groups with $1, $2, etc. Example: { '\\\\section\\{([^}]+)\\}': '\\section{$1}' }",
       ),
       customReplacements: stringRecord(
         DEFAULT_CORE_SETTINGS.latex.customReplacements,
+        "Custom LaTeX replacements in the format: { 'from': 'to' }. Example: { '\\alpha': '\\al' }",
       ),
     })
     .prefault(DEFAULT_CORE_SETTINGS.latex),
@@ -464,9 +564,20 @@ export const CoreSettingsShape = {
     .strictObject({
       pictureEnvironments: z
         .string()
+        .describe(
+          'Regular expression pattern for environments to be treated as pictures. These environments will be processed as a unit without internal differencing.',
+        )
         .prefault(DEFAULT_CORE_SETTINGS.latexdiff.pictureEnvironments),
       tempFileLocation: z
         .enum(LATEXDIFF_TEMP_FILE_LOCATIONS)
+        .meta({
+          description:
+            'Where to create temporary files for LaTeX preview and diff operations during tool edit approval.',
+          enumDescriptions: [
+            'Create temp files in the same directory as the original file. Best for resolving \\input{} and relative paths.',
+            'Create temp files in .texra-temp directory at workspace root. Keeps source directories clean but may break relative paths.',
+          ],
+        })
         .prefault(DEFAULT_CORE_SETTINGS.latexdiff.tempFileLocation),
     })
     .prefault(DEFAULT_CORE_SETTINGS.latexdiff),
@@ -476,9 +587,15 @@ export const CoreSettingsShape = {
         .number()
         .min(1)
         .max(100)
+        .describe(
+          'Number of recent commits to show in the commit selection dropdown',
+        )
         .prefault(DEFAULT_CORE_SETTINGS.git.numberOfCommitsToShow),
       emitPrCiStartedEvents: z
         .boolean()
+        .describe(
+          'Emit a PR subscription event when GitHub check runs first appear for a new head commit.',
+        )
         .prefault(DEFAULT_CORE_SETTINGS.git.emitPrCiStartedEvents),
     })
     .prefault(DEFAULT_CORE_SETTINGS.git),
@@ -486,60 +603,107 @@ export const CoreSettingsShape = {
     .strictObject({
       runOnCommit: z
         .boolean()
+        .describe(
+          'Automatically review your changes for issues after each commit.',
+        )
         .prefault(DEFAULT_CORE_SETTINGS.agentReview.runOnCommit),
       includeSubmodules: z
         .boolean()
+        .describe('Include changes from Git submodules in the review.')
         .prefault(DEFAULT_CORE_SETTINGS.agentReview.includeSubmodules),
       includeUntrackedFiles: z
         .boolean()
+        .describe(
+          'Include untracked files (new files not yet added to Git) in the review.',
+        )
         .prefault(DEFAULT_CORE_SETTINGS.agentReview.includeUntrackedFiles),
       approach: z
         .enum(AGENT_REVIEW_APPROACHES)
+        .meta({
+          description:
+            'Choose between quick or more thorough, higher-cost analysis.',
+          enumDescriptions: [
+            'The reviewer verifies only its strongest suspicions with tools — fast and cheap.',
+            'The reviewer reads every changed file in full, checks callers, and pulls diagnostics before reporting — deeper, higher-cost analysis.',
+          ],
+        })
         .prefault(DEFAULT_CORE_SETTINGS.agentReview.approach),
-      model: z.string().prefault(DEFAULT_CORE_SETTINGS.agentReview.model),
+      model: z
+        .string()
+        .describe(
+          'Model id for the review session (e.g. a stronger model for thorough reviews). Leave empty to use the default agent model.',
+        )
+        .prefault(DEFAULT_CORE_SETTINGS.agentReview.model),
     })
     .prefault(DEFAULT_CORE_SETTINGS.agentReview),
   audio: z
     .strictObject({
-      soxPath: z.string().prefault(DEFAULT_CORE_SETTINGS.audio.soxPath),
+      soxPath: z
+        .string()
+        .describe('Path to the SoX executable. Overrides automatic detection.')
+        .prefault(DEFAULT_CORE_SETTINGS.audio.soxPath),
     })
     .prefault(DEFAULT_CORE_SETTINGS.audio),
   logger: z
     .strictObject({
-      debugMode: z.boolean().prefault(DEFAULT_CORE_SETTINGS.logger.debugMode),
+      debugMode: z
+        .boolean()
+        .describe('Whether to show verbose debug messages in the logger view')
+        .prefault(DEFAULT_CORE_SETTINGS.logger.debugMode),
     })
     .prefault(DEFAULT_CORE_SETTINGS.logger),
   debug: z
     .strictObject({
       saveDebugObjects: z
         .boolean()
+        .describe(
+          'Save message and response objects to JSON files for debugging purposes',
+        )
         .prefault(DEFAULT_CORE_SETTINGS.debug.saveDebugObjects),
       saveInputPrompt: z
         .boolean()
+        .describe(
+          'Save the final input prompt sent to the model as an XML file for debugging purposes',
+        )
         .prefault(DEFAULT_CORE_SETTINGS.debug.saveInputPrompt),
     })
     .prefault(DEFAULT_CORE_SETTINGS.debug),
   skills: z
     .strictObject({
-      enabled: z.boolean().prefault(DEFAULT_CORE_SETTINGS.skills.enabled),
+      enabled: z
+        .boolean()
+        .describe(
+          'Discover imported skills and expose them to tool-use agent prompts',
+        )
+        .prefault(DEFAULT_CORE_SETTINGS.skills.enabled),
     })
     .prefault(DEFAULT_CORE_SETTINGS.skills),
   toolUse: z
     .strictObject({
       requireEditApproval: z
         .boolean()
+        .describe(
+          'Require user approval in a diff view before tool-driven edits modify workspace files',
+        )
         .prefault(DEFAULT_CORE_SETTINGS.toolUse.requireEditApproval),
       requireBashApproval: z
         .boolean()
+        .describe(
+          'Require user approval before tool-use agents execute bash commands',
+        )
         .prefault(DEFAULT_CORE_SETTINGS.toolUse.requireBashApproval),
       persistence: z
         .strictObject({
           enabled: z
             .boolean()
+            .describe('Persist tool-use conversations across VS Code restarts')
             .prefault(DEFAULT_CORE_SETTINGS.toolUse.persistence.enabled),
           ttlHours: z
             .number()
             .min(1)
+            .describe(
+              'Maximum age (in hours) to keep saved tool-use sessions before automatic cleanup',
+            )
             .prefault(DEFAULT_CORE_SETTINGS.toolUse.persistence.ttlHours),
         })
         .prefault(DEFAULT_CORE_SETTINGS.toolUse.persistence),

--- a/src/shared/schemas/coreSettings.ts
+++ b/src/shared/schemas/coreSettings.ts
@@ -570,9 +570,10 @@ export const CoreSettingsShape = {
         .prefault(DEFAULT_CORE_SETTINGS.latexdiff.pictureEnvironments),
       tempFileLocation: z
         .enum(LATEXDIFF_TEMP_FILE_LOCATIONS)
+        .describe(
+          'Where to create temporary files for LaTeX preview and diff operations during tool edit approval.',
+        )
         .meta({
-          description:
-            'Where to create temporary files for LaTeX preview and diff operations during tool edit approval.',
           enumDescriptions: [
             'Create temp files in the same directory as the original file. Best for resolving \\input{} and relative paths.',
             'Create temp files in .texra-temp directory at workspace root. Keeps source directories clean but may break relative paths.',
@@ -619,9 +620,10 @@ export const CoreSettingsShape = {
         .prefault(DEFAULT_CORE_SETTINGS.agentReview.includeUntrackedFiles),
       approach: z
         .enum(AGENT_REVIEW_APPROACHES)
+        .describe(
+          'Choose between quick or more thorough, higher-cost analysis.',
+        )
         .meta({
-          description:
-            'Choose between quick or more thorough, higher-cost analysis.',
           enumDescriptions: [
             'The reviewer verifies only its strongest suspicions with tools — fast and cheap.',
             'The reviewer reads every changed file in full, checks callers, and pulls diagnostics before reporting — deeper, higher-cost analysis.',

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -141,8 +141,9 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
   },
 
   // --- Workflow auto-compile -------------------------------------------------
-  // Consumed today by the VS Code extension + desktop only (no CLI consumer
-  // yet); a later PR adds the CLI read path and flips `hosts` to include 'cli'.
+  // Read by the shared reflection/compile flow, which runs in every host
+  // including the CLI; the CLI reads/writes them from its own `state.json`
+  // (`platform().workspaceState`), the same slot the consumer reads.
   {
     key: WorkspaceStateKey.WORKFLOW_AUTO_COMPILE,
     schema: z.boolean().prefault(LATEX_CONFIG_DEFAULTS.workflowAutoCompile),
@@ -150,7 +151,8 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
       'Compile the LaTeX project automatically after an agent writes its output.',
     category: 'workflow',
     store: 'workspaceState',
-    hosts: ['vscode', 'desktop'],
+    hosts: ['vscode', 'desktop', 'cli'],
+    cliConsumer: 'src/agent/output/compileCheck.ts',
   },
   {
     key: WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS,
@@ -162,7 +164,8 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
       'Maximum time (in milliseconds) to wait for an automatic post-output compile before giving up.',
     category: 'workflow',
     store: 'workspaceState',
-    hosts: ['vscode', 'desktop'],
+    hosts: ['vscode', 'desktop', 'cli'],
+    cliConsumer: 'src/agent/output/compileCheck.ts',
   },
   {
     key: WorkspaceStateKey.WORKFLOW_AUTO_OPEN_PDF,
@@ -171,7 +174,9 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
       'Open the compiled PDF automatically after a successful auto-compile.',
     category: 'workflow',
     store: 'workspaceState',
-    hosts: ['vscode', 'desktop'],
+    hosts: ['vscode', 'desktop', 'cli'],
+    cliConsumer:
+      'src/agent/implementations/flows/reflection/runReflectionFlow.ts',
   },
   {
     key: WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE,
@@ -182,10 +187,13 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
       'Reject an agent edit when the automatic post-output compile fails, so broken LaTeX is not accepted.',
     category: 'workflow',
     store: 'workspaceState',
-    hosts: ['vscode', 'desktop'],
+    hosts: ['vscode', 'desktop', 'cli'],
+    cliConsumer:
+      'src/agent/implementations/flows/reflection/runReflectionFlow.ts',
   },
 
   // --- LaTeXdiff -------------------------------------------------------------
+  // VS Code + desktop only for now (the CLI doesn't surface latexdiff config).
   {
     key: WorkspaceStateKey.LATEXDIFF_BETWEEN_ROUNDS,
     schema: z.boolean().prefault(LATEX_CONFIG_DEFAULTS.latexdiffBetweenRounds),
@@ -243,7 +251,8 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     description: 'Which formatter to run when formatting LaTeX source.',
     category: 'latex',
     store: 'workspaceState',
-    hosts: ['vscode', 'desktop'],
+    hosts: ['vscode', 'desktop', 'cli'],
+    cliConsumer: 'src/latex/texFormatter.ts',
     enumDescriptions: [
       'Format with latexindent.',
       'Format with tex-fmt.',
@@ -299,4 +308,14 @@ export function settingEnumOptions(
 /** Whether a setting's schema is a boolean (used to classify edit affordance). */
 export function settingIsBoolean(entry: StateSettingEntry): boolean {
   return innerSchema(entry) instanceof z.ZodBoolean;
+}
+
+/** Whether a setting's schema is a string (free-text edit affordance). */
+export function settingIsString(entry: StateSettingEntry): boolean {
+  return innerSchema(entry) instanceof z.ZodString;
+}
+
+/** Whether a setting's schema is a number (numeric free-text edit affordance). */
+export function settingIsNumber(entry: StateSettingEntry): boolean {
+  return innerSchema(entry) instanceof z.ZodNumber;
 }

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -251,10 +251,6 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
   },
 ] as const;
 
-/** Catalog keyed by canonical `texra.*` key for direct lookup. */
-export const STATE_SETTINGS_BY_KEY: ReadonlyMap<string, StateSettingEntry> =
-  new Map(STATE_SETTINGS.map((entry) => [entry.key, entry]));
-
 /** Every canonical `texra.*` key in the catalog. */
 export const STATE_SETTING_KEYS: readonly string[] = STATE_SETTINGS.map(
   (entry) => entry.key,

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -1,0 +1,266 @@
+// Third-party imports
+import { z } from 'zod';
+
+// Local imports - shared constants & state keys
+import {
+  DEFAULT_GIT_AUTHOR_EMAIL,
+  DEFAULT_GIT_AUTHOR_NAME,
+  DEFAULT_GIT_MARK_COMMITS,
+} from '@shared/constants/git';
+import {
+  LATEX_CONFIG_DEFAULTS,
+  LATEX_CONFIG_RANGES,
+  LATEX_FORMATTER_VALUES,
+  LATEXDIFF_MATH_MARKUP_VALUES,
+} from '@shared/constants/latex';
+import { WorkspaceStateKey } from '@shared/state/stateKeys';
+
+/**
+ * Host-neutral catalog for **state-backed** TeXRA settings.
+ *
+ * Unlike {@link CoreSettingsShape} (config-tree settings that flow into the VS
+ * Code `contributes.configuration` block), these keys are read from
+ * WorkspaceState / GlobalState — they were deliberately migrated *out* of VS
+ * Code config (see `LATEX_SETTINGS_MIGRATED`). Putting them in
+ * `CoreSettingsShape` would emit phantom VS Code configuration the extension
+ * never reads, so they live here as metadata-only rows instead.
+ *
+ * Each row is the single source of truth for a state-backed setting's default,
+ * validation schema, description, storage slot, and the hosts that consume it.
+ * Consumers:
+ *
+ * - `settingsAccess.ts` — host-aware read/write that dispatches on `store`
+ *   (or `cliStore` when the caller is the CLI).
+ * - `packages/cli/src/schemas/knownKeys.ts` — derives the CLI unknown-key
+ *   whitelist from {@link STATE_SETTING_KEYS}.
+ * - The CLI `/config` panel + extension settingsView (later PRs) read labels,
+ *   descriptions, and enum metadata from these rows.
+ */
+
+/** Hosts that may consume a setting. */
+export type SettingHost = 'vscode' | 'cli' | 'desktop';
+
+/** Storage slot a setting is read from / written to. */
+export type SettingStore = 'config' | 'workspaceState' | 'globalState';
+
+export interface StateSettingEntry {
+  /**
+   * Canonical `texra.*` key — identical to the WorkspaceState/GlobalState slot
+   * the extension already uses.
+   */
+  readonly key: string;
+  /**
+   * Zod schema carrying both validation and the `.prefault()` default applied
+   * when the key is absent. `schema.parse(undefined)` yields that default.
+   */
+  readonly schema: z.ZodType;
+  /** Human-readable description, shared across every host that renders it. */
+  readonly description: string;
+  /** Grouping label for settings UIs. */
+  readonly category: string;
+  /** Canonical (extension) storage slot. */
+  readonly store: SettingStore;
+  /**
+   * Storage slot the CLI reads/writes when it differs from {@link store}. Only
+   * the git-author keys use this today: the extension keeps them in
+   * worktree-shared WorkspaceState, but the CLI reads them from
+   * `.texra/config.json`.
+   */
+  readonly cliStore?: SettingStore;
+  /** Hosts that actually consume this setting today. */
+  readonly hosts: readonly SettingHost[];
+  /**
+   * Source file that consumes the setting in the CLI. **Required** whenever
+   * {@link hosts} includes `'cli'` (enforced by the guardrail suite) so a
+   * surfaced setting is never a silent no-op.
+   */
+  readonly cliConsumer?: string;
+  /** Allowed values for enum settings — drives the inner value picker. */
+  readonly enumValues?: readonly string[];
+  /** Per-value descriptions, aligned 1:1 with {@link enumValues}. */
+  readonly enumDescriptions?: readonly string[];
+  /**
+   * Delegate editing to an existing list form (e.g. `ModelListForm`) instead of
+   * the scalar read/write accessor.
+   */
+  readonly openForm?: string;
+}
+
+const GIT_AUTHOR_CONSUMER = 'packages/cli/src/runtime/gitAuthor.ts';
+
+export const STATE_SETTINGS: readonly StateSettingEntry[] = [
+  // --- Git commit author marking ---------------------------------------------
+  // Stored in worktree-shared WorkspaceState by the extension; read from
+  // `.texra/config.json` by the CLI (hence `cliStore: 'config'`).
+  {
+    key: WorkspaceStateKey.GIT_MARK_COMMITS,
+    schema: z.boolean().prefault(DEFAULT_GIT_MARK_COMMITS),
+    description:
+      'Attribute agent-authored git commits to the TeXRA identity so they are distinguishable from your own commits.',
+    category: 'git',
+    store: 'workspaceState',
+    cliStore: 'config',
+    hosts: ['vscode', 'cli', 'desktop'],
+    cliConsumer: GIT_AUTHOR_CONSUMER,
+  },
+  {
+    key: WorkspaceStateKey.GIT_AUTHOR_NAME,
+    schema: z.string().prefault(DEFAULT_GIT_AUTHOR_NAME),
+    description:
+      'Author and committer name used for agent-authored commits when commit marking is enabled.',
+    category: 'git',
+    store: 'workspaceState',
+    cliStore: 'config',
+    hosts: ['vscode', 'cli', 'desktop'],
+    cliConsumer: GIT_AUTHOR_CONSUMER,
+  },
+  {
+    key: WorkspaceStateKey.GIT_AUTHOR_EMAIL,
+    schema: z.string().prefault(DEFAULT_GIT_AUTHOR_EMAIL),
+    description:
+      'Author and committer email used for agent-authored commits when commit marking is enabled.',
+    category: 'git',
+    store: 'workspaceState',
+    cliStore: 'config',
+    hosts: ['vscode', 'cli', 'desktop'],
+    cliConsumer: GIT_AUTHOR_CONSUMER,
+  },
+  {
+    key: WorkspaceStateKey.GIT_WORKTREE_SUPPORT,
+    schema: z.boolean().prefault(false),
+    description:
+      'Allow spawned subagents to run in isolated git worktrees so parallel edits do not conflict.',
+    category: 'git',
+    store: 'workspaceState',
+    cliStore: 'config',
+    hosts: ['vscode', 'cli', 'desktop'],
+    cliConsumer: GIT_AUTHOR_CONSUMER,
+  },
+
+  // --- Workflow auto-compile -------------------------------------------------
+  // Consumed today by the VS Code extension + desktop only (no CLI consumer
+  // yet); a later PR adds the CLI read path and flips `hosts` to include 'cli'.
+  {
+    key: WorkspaceStateKey.WORKFLOW_AUTO_COMPILE,
+    schema: z.boolean().prefault(LATEX_CONFIG_DEFAULTS.workflowAutoCompile),
+    description:
+      'Compile the LaTeX project automatically after an agent writes its output.',
+    category: 'workflow',
+    store: 'workspaceState',
+    hosts: ['vscode', 'desktop'],
+  },
+  {
+    key: WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS,
+    schema: z
+      .number()
+      .min(LATEX_CONFIG_RANGES.workflowAutoCompileTimeoutMs.min)
+      .prefault(LATEX_CONFIG_DEFAULTS.workflowAutoCompileTimeoutMs),
+    description:
+      'Maximum time (in milliseconds) to wait for an automatic post-output compile before giving up.',
+    category: 'workflow',
+    store: 'workspaceState',
+    hosts: ['vscode', 'desktop'],
+  },
+  {
+    key: WorkspaceStateKey.WORKFLOW_AUTO_OPEN_PDF,
+    schema: z.boolean().prefault(LATEX_CONFIG_DEFAULTS.workflowAutoOpenPdf),
+    description:
+      'Open the compiled PDF automatically after a successful auto-compile.',
+    category: 'workflow',
+    store: 'workspaceState',
+    hosts: ['vscode', 'desktop'],
+  },
+  {
+    key: WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE,
+    schema: z
+      .boolean()
+      .prefault(LATEX_CONFIG_DEFAULTS.workflowRejectOnCompileFailure),
+    description:
+      'Reject an agent edit when the automatic post-output compile fails, so broken LaTeX is not accepted.',
+    category: 'workflow',
+    store: 'workspaceState',
+    hosts: ['vscode', 'desktop'],
+  },
+
+  // --- LaTeXdiff -------------------------------------------------------------
+  {
+    key: WorkspaceStateKey.LATEXDIFF_BETWEEN_ROUNDS,
+    schema: z.boolean().prefault(LATEX_CONFIG_DEFAULTS.latexdiffBetweenRounds),
+    description:
+      'Generate a latexdiff between successive reflection rounds, not just against the original input.',
+    category: 'latexdiff',
+    store: 'workspaceState',
+    hosts: ['vscode', 'desktop'],
+  },
+  {
+    key: WorkspaceStateKey.LATEXDIFF_TIMEOUT_MS,
+    schema: z
+      .number()
+      .min(LATEX_CONFIG_RANGES.latexdiffTimeoutMs.min)
+      .max(LATEX_CONFIG_RANGES.latexdiffTimeoutMs.max)
+      .prefault(LATEX_CONFIG_DEFAULTS.latexdiffTimeoutMs),
+    description:
+      'Maximum time (in milliseconds) to allow a single latexdiff invocation to run.',
+    category: 'latexdiff',
+    store: 'workspaceState',
+    hosts: ['vscode', 'desktop'],
+  },
+  {
+    key: WorkspaceStateKey.LATEXDIFF_MATH_MARKUP,
+    schema: z
+      .enum(LATEXDIFF_MATH_MARKUP_VALUES)
+      .prefault(LATEX_CONFIG_DEFAULTS.latexdiffMathMarkup),
+    description: 'How latexdiff marks up changes inside math environments.',
+    category: 'latexdiff',
+    store: 'workspaceState',
+    hosts: ['vscode', 'desktop'],
+    enumValues: LATEXDIFF_MATH_MARKUP_VALUES,
+    enumDescriptions: [
+      'Do not mark up changes inside math at all.',
+      'Mark a whole math environment as changed if anything inside it changed.',
+      'Mark up changes at a coarse granularity inside math (recommended).',
+      'Mark up changes at the finest granularity inside math.',
+    ],
+  },
+  {
+    key: WorkspaceStateKey.LATEXDIFF_CHANGES_ONLY,
+    schema: z.boolean().prefault(LATEX_CONFIG_DEFAULTS.latexdiffChangesOnly),
+    description:
+      'Produce a changes-only diff (show only the parts that changed) rather than the full marked-up document.',
+    category: 'latexdiff',
+    store: 'workspaceState',
+    hosts: ['vscode', 'desktop'],
+  },
+
+  // --- LaTeX formatter -------------------------------------------------------
+  {
+    key: WorkspaceStateKey.LATEX_FORMATTER,
+    schema: z
+      .enum(LATEX_FORMATTER_VALUES)
+      .prefault(LATEX_CONFIG_DEFAULTS.latexFormatter),
+    description: 'Which formatter to run when formatting LaTeX source.',
+    category: 'latex',
+    store: 'workspaceState',
+    hosts: ['vscode', 'desktop'],
+    enumValues: LATEX_FORMATTER_VALUES,
+    enumDescriptions: [
+      'Format with latexindent.',
+      'Format with tex-fmt.',
+      'Do not run any formatter.',
+    ],
+  },
+] as const;
+
+/** Catalog keyed by canonical `texra.*` key for direct lookup. */
+export const STATE_SETTINGS_BY_KEY: ReadonlyMap<string, StateSettingEntry> =
+  new Map(STATE_SETTINGS.map((entry) => [entry.key, entry]));
+
+/** Every canonical `texra.*` key in the catalog. */
+export const STATE_SETTING_KEYS: readonly string[] = STATE_SETTINGS.map(
+  (entry) => entry.key,
+);
+
+/** Catalog keys whose consuming hosts include the CLI. */
+export const CLI_STATE_SETTING_KEYS: readonly string[] = STATE_SETTINGS.filter(
+  (entry) => entry.hosts.includes('cli'),
+).map((entry) => entry.key);

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -218,10 +218,10 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     store: 'workspaceState',
     hosts: ['vscode', 'desktop'],
     enumDescriptions: [
-      'Do not mark up changes inside math at all.',
-      'Mark a whole math environment as changed if anything inside it changed.',
-      'Mark up changes at a coarse granularity inside math (recommended).',
-      'Mark up changes at the finest granularity inside math.',
+      'suppress markup',
+      'equation-level',
+      'within equations',
+      'small changes inside equations',
     ],
   },
   {
@@ -256,6 +256,15 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
 export const STATE_SETTING_KEYS: readonly string[] = STATE_SETTINGS.map(
   (entry) => entry.key,
 );
+
+const STATE_SETTINGS_BY_KEY: ReadonlyMap<string, StateSettingEntry> = new Map(
+  STATE_SETTINGS.map((entry) => [entry.key, entry]),
+);
+
+/** Look up a catalog entry by its canonical `texra.*` key. */
+export function stateSettingByKey(key: string): StateSettingEntry | undefined {
+  return STATE_SETTINGS_BY_KEY.get(key);
+}
 
 /**
  * The single canonical "CLI roster" — catalog entries the CLI consumes. Both

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -141,9 +141,9 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
   },
 
   // --- Workflow auto-compile -------------------------------------------------
-  // Read by the shared reflection/compile flow, which runs in every host
-  // including the CLI; the CLI reads/writes them from its own `state.json`
-  // (`platform().workspaceState`), the same slot the consumer reads.
+  // Consumed only by the reflection/compile flow (OutputNode), which runs in
+  // the VS Code extension + desktop. The CLI runs tool-use agents only, never
+  // the reflection flow, so it does not read these — keep it off `hosts`.
   {
     key: WorkspaceStateKey.WORKFLOW_AUTO_COMPILE,
     schema: z.boolean().prefault(LATEX_CONFIG_DEFAULTS.workflowAutoCompile),
@@ -151,8 +151,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
       'Compile the LaTeX project automatically after an agent writes its output.',
     category: 'workflow',
     store: 'workspaceState',
-    hosts: ['vscode', 'desktop', 'cli'],
-    cliConsumer: 'src/agent/output/compileCheck.ts',
+    hosts: ['vscode', 'desktop'],
   },
   {
     key: WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS,
@@ -164,8 +163,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
       'Maximum time (in milliseconds) to wait for an automatic post-output compile before giving up.',
     category: 'workflow',
     store: 'workspaceState',
-    hosts: ['vscode', 'desktop', 'cli'],
-    cliConsumer: 'src/agent/output/compileCheck.ts',
+    hosts: ['vscode', 'desktop'],
   },
   {
     key: WorkspaceStateKey.WORKFLOW_AUTO_OPEN_PDF,
@@ -174,9 +172,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
       'Open the compiled PDF automatically after a successful auto-compile.',
     category: 'workflow',
     store: 'workspaceState',
-    hosts: ['vscode', 'desktop', 'cli'],
-    cliConsumer:
-      'src/agent/implementations/flows/reflection/runReflectionFlow.ts',
+    hosts: ['vscode', 'desktop'],
   },
   {
     key: WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE,
@@ -187,13 +183,11 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
       'Reject an agent edit when the automatic post-output compile fails, so broken LaTeX is not accepted.',
     category: 'workflow',
     store: 'workspaceState',
-    hosts: ['vscode', 'desktop', 'cli'],
-    cliConsumer:
-      'src/agent/implementations/flows/reflection/runReflectionFlow.ts',
+    hosts: ['vscode', 'desktop'],
   },
 
   // --- LaTeXdiff -------------------------------------------------------------
-  // VS Code + desktop only for now (the CLI doesn't surface latexdiff config).
+  // Reflection-flow only (LatexDiffManager); not consumed by the CLI.
   {
     key: WorkspaceStateKey.LATEXDIFF_BETWEEN_ROUNDS,
     schema: z.boolean().prefault(LATEX_CONFIG_DEFAULTS.latexdiffBetweenRounds),
@@ -243,6 +237,8 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
   },
 
   // --- LaTeX formatter -------------------------------------------------------
+  // Read by the formatter via LatexDiffManager (reflection flow); the CLI's
+  // tool-use flow never formats output, so this stays vscode/desktop only.
   {
     key: WorkspaceStateKey.LATEX_FORMATTER,
     schema: z
@@ -251,8 +247,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     description: 'Which formatter to run when formatting LaTeX source.',
     category: 'latex',
     store: 'workspaceState',
-    hosts: ['vscode', 'desktop', 'cli'],
-    cliConsumer: 'src/latex/texFormatter.ts',
+    hosts: ['vscode', 'desktop'],
     enumDescriptions: [
       'Format with latexindent.',
       'Format with tex-fmt.',

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_GIT_AUTHOR_EMAIL,
   DEFAULT_GIT_AUTHOR_NAME,
   DEFAULT_GIT_MARK_COMMITS,
+  DEFAULT_GIT_WORKTREE_SUPPORT,
 } from '@shared/constants/git';
 import {
   LATEX_CONFIG_DEFAULTS,
@@ -75,9 +76,11 @@ export interface StateSettingEntry {
    * surfaced setting is never a silent no-op.
    */
   readonly cliConsumer?: string;
-  /** Allowed values for enum settings — drives the inner value picker. */
-  readonly enumValues?: readonly string[];
-  /** Per-value descriptions, aligned 1:1 with {@link enumValues}. */
+  /**
+   * Per-value descriptions for an enum setting, aligned 1:1 with the schema's
+   * enum options (see {@link settingEnumOptions}). The option *values* are
+   * derived from the schema, not restated here.
+   */
   readonly enumDescriptions?: readonly string[];
   /**
    * Delegate editing to an existing list form (e.g. `ModelListForm`) instead of
@@ -127,7 +130,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
   },
   {
     key: WorkspaceStateKey.GIT_WORKTREE_SUPPORT,
-    schema: z.boolean().prefault(false),
+    schema: z.boolean().prefault(DEFAULT_GIT_WORKTREE_SUPPORT),
     description:
       'Allow spawned subagents to run in isolated git worktrees so parallel edits do not conflict.',
     category: 'git',
@@ -214,7 +217,6 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     category: 'latexdiff',
     store: 'workspaceState',
     hosts: ['vscode', 'desktop'],
-    enumValues: LATEXDIFF_MATH_MARKUP_VALUES,
     enumDescriptions: [
       'Do not mark up changes inside math at all.',
       'Mark a whole math environment as changed if anything inside it changed.',
@@ -242,7 +244,6 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     category: 'latex',
     store: 'workspaceState',
     hosts: ['vscode', 'desktop'],
-    enumValues: LATEX_FORMATTER_VALUES,
     enumDescriptions: [
       'Format with latexindent.',
       'Format with tex-fmt.',
@@ -256,7 +257,37 @@ export const STATE_SETTING_KEYS: readonly string[] = STATE_SETTINGS.map(
   (entry) => entry.key,
 );
 
-/** Catalog keys whose consuming hosts include the CLI. */
-export const CLI_STATE_SETTING_KEYS: readonly string[] = STATE_SETTINGS.filter(
-  (entry) => entry.hosts.includes('cli'),
-).map((entry) => entry.key);
+/**
+ * The single canonical "CLI roster" — catalog entries the CLI consumes. Both
+ * the `/config` panel and any key-list derivation come from this one filter so
+ * the `hosts.includes('cli')` predicate lives in exactly one place.
+ */
+export const CLI_STATE_SETTINGS: readonly StateSettingEntry[] =
+  STATE_SETTINGS.filter((entry) => entry.hosts.includes('cli'));
+
+/** The entry's schema with the outer `.prefault()` wrapper peeled off. */
+function innerSchema(entry: StateSettingEntry): unknown {
+  return entry.schema instanceof z.ZodPrefault
+    ? entry.schema.unwrap()
+    : entry.schema;
+}
+
+/**
+ * Enum option values for a setting, derived from its `z.enum(...)` schema (via
+ * the public `.unwrap().options`) rather than restated on the row, or
+ * `undefined` for non-enum settings. The schema stays the single source of the
+ * allowed values; only the per-value prose (`enumDescriptions`) is editorial.
+ */
+export function settingEnumOptions(
+  entry: StateSettingEntry,
+): readonly string[] | undefined {
+  const inner = innerSchema(entry);
+  return inner instanceof z.ZodEnum
+    ? (inner.options as readonly string[])
+    : undefined;
+}
+
+/** Whether a setting's schema is a boolean (used to classify edit affordance). */
+export function settingIsBoolean(entry: StateSettingEntry): boolean {
+  return innerSchema(entry) instanceof z.ZodBoolean;
+}

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -141,9 +141,10 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
   },
 
   // --- Workflow auto-compile -------------------------------------------------
-  // Consumed only by the reflection/compile flow (OutputNode), which runs in
-  // the VS Code extension + desktop. The CLI runs tool-use agents only, never
-  // the reflection flow, so it does not read these — keep it off `hosts`.
+  // The CLI runs workflow (reflection) agents via `texra workflow` / `texra
+  // run`, so these take effect there as well as in the extension/desktop. The
+  // exception is auto-open-pdf: it emits `requestOpenFile`, which the headless
+  // CLI has no handler for, so it stays off the CLI roster.
   {
     key: WorkspaceStateKey.WORKFLOW_AUTO_COMPILE,
     schema: z.boolean().prefault(LATEX_CONFIG_DEFAULTS.workflowAutoCompile),
@@ -151,7 +152,8 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
       'Compile the LaTeX project automatically after an agent writes its output.',
     category: 'workflow',
     store: 'workspaceState',
-    hosts: ['vscode', 'desktop'],
+    hosts: ['vscode', 'desktop', 'cli'],
+    cliConsumer: 'src/agent/output/compileCheck.ts',
   },
   {
     key: WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS,
@@ -163,7 +165,8 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
       'Maximum time (in milliseconds) to wait for an automatic post-output compile before giving up.',
     category: 'workflow',
     store: 'workspaceState',
-    hosts: ['vscode', 'desktop'],
+    hosts: ['vscode', 'desktop', 'cli'],
+    cliConsumer: 'src/agent/output/compileCheck.ts',
   },
   {
     key: WorkspaceStateKey.WORKFLOW_AUTO_OPEN_PDF,
@@ -172,6 +175,8 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
       'Open the compiled PDF automatically after a successful auto-compile.',
     category: 'workflow',
     store: 'workspaceState',
+    // Read by OutputNode but the emitted `requestOpenFile` has no CLI handler
+    // (headless), so toggling it would be a no-op there — vscode/desktop only.
     hosts: ['vscode', 'desktop'],
   },
   {
@@ -183,11 +188,14 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
       'Reject an agent edit when the automatic post-output compile fails, so broken LaTeX is not accepted.',
     category: 'workflow',
     store: 'workspaceState',
-    hosts: ['vscode', 'desktop'],
+    hosts: ['vscode', 'desktop', 'cli'],
+    cliConsumer:
+      'src/agent/implementations/flows/reflection/runReflectionFlow.ts',
   },
 
   // --- LaTeXdiff -------------------------------------------------------------
-  // Reflection-flow only (LatexDiffManager); not consumed by the CLI.
+  // Run by the reflection flow (so the CLI executes them), but deferred from the
+  // CLI roster for now per product decision — not surfaced in `/config`.
   {
     key: WorkspaceStateKey.LATEXDIFF_BETWEEN_ROUNDS,
     schema: z.boolean().prefault(LATEX_CONFIG_DEFAULTS.latexdiffBetweenRounds),
@@ -237,8 +245,9 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
   },
 
   // --- LaTeX formatter -------------------------------------------------------
-  // Read by the formatter via LatexDiffManager (reflection flow); the CLI's
-  // tool-use flow never formats output, so this stays vscode/desktop only.
+  // Invoked via LatexDiffManager during the reflection flow (which the CLI runs),
+  // i.e. coupled to the latexdiff path that's deferred from the CLI roster, so
+  // it stays vscode/desktop only for now.
   {
     key: WorkspaceStateKey.LATEX_FORMATTER,
     schema: z

--- a/src/test-kernel/cli/ConfigForm.vitest.mts
+++ b/src/test-kernel/cli/ConfigForm.vitest.mts
@@ -3,7 +3,6 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   buildConfigListItems,
   buildEnumItems,
-  CLI_CONFIG_ROSTER,
   ConfigForm,
   formatSettingValue,
   settingDisplayName,
@@ -18,6 +17,7 @@ import { registerBuiltinSlashCommands } from '@cli/chat/tui/commands/registerBui
 import { openCliSlashCommandForm } from '@cli/chat/tui/commands/slashForms';
 import { cliState, resetCliState } from '@cli/chat/tui/state/cliState';
 import {
+  CLI_STATE_SETTINGS,
   STATE_SETTINGS,
   type StateSettingEntry,
 } from '@shared/schemas/stateSettings';
@@ -61,26 +61,26 @@ function renderConfigFormProps(): {
 
 describe('ConfigForm helpers', () => {
   it('rosters exactly the CLI-consumed catalog entries', () => {
-    expect([...CLI_CONFIG_ROSTER].map((entry) => entry.key)).toEqual(
+    expect([...CLI_STATE_SETTINGS].map((entry) => entry.key)).toEqual(
       STATE_SETTINGS.filter((entry) => entry.hosts.includes('cli')).map(
         (entry) => entry.key,
       ),
     );
-    expect(CLI_CONFIG_ROSTER.length).toBeGreaterThan(0);
+    expect(CLI_STATE_SETTINGS.length).toBeGreaterThan(0);
     // Every rostered entry must be reachable from the CLI's store set.
-    for (const entry of CLI_CONFIG_ROSTER) {
+    for (const entry of CLI_STATE_SETTINGS) {
       expect(entry.hosts).toContain('cli');
     }
   });
 
-  it('classifies edit kinds by value type and enum metadata', () => {
+  it('classifies edit kinds from the entry schema', () => {
     const markCommits = entryByKey(WorkspaceStateKey.GIT_MARK_COMMITS);
     const authorName = entryByKey(WorkspaceStateKey.GIT_AUTHOR_NAME);
     const formatter = entryByKey(WorkspaceStateKey.LATEX_FORMATTER);
 
-    expect(settingEditKind(markCommits, true)).toBe('boolean');
-    expect(settingEditKind(authorName, 'texra-ai')).toBe('readonly');
-    expect(settingEditKind(formatter, 'latexindent')).toBe('enum');
+    expect(settingEditKind(markCommits)).toBe('boolean');
+    expect(settingEditKind(authorName)).toBe('readonly');
+    expect(settingEditKind(formatter)).toBe('enum');
   });
 
   it('formats values for display', () => {
@@ -107,7 +107,7 @@ describe('ConfigForm helpers', () => {
   });
 
   it('builds list items with read-only rows disabled', () => {
-    const items = buildConfigListItems(CLI_CONFIG_ROSTER, (entry) =>
+    const items = buildConfigListItems(CLI_STATE_SETTINGS, (entry) =>
       entry.key === WorkspaceStateKey.GIT_MARK_COMMITS ? true : 'texra-ai',
     );
     const markCommits = items.find(
@@ -169,7 +169,7 @@ describe('/config slash command wiring', () => {
 
     const props = renderConfigFormProps();
     expect(props.entries?.map((entry) => entry.key)).toEqual(
-      CLI_CONFIG_ROSTER.map((entry) => entry.key),
+      CLI_STATE_SETTINGS.map((entry) => entry.key),
     );
 
     const markCommits = entryByKey(WorkspaceStateKey.GIT_MARK_COMMITS);

--- a/src/test-kernel/cli/ConfigForm.vitest.mts
+++ b/src/test-kernel/cli/ConfigForm.vitest.mts
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, it } from 'vitest';
+import { z } from 'zod';
 
 import {
   buildConfigListItems,
   buildEnumItems,
+  coerceSettingInput,
   ConfigForm,
   formatSettingValue,
   settingDisplayName,
@@ -79,10 +81,26 @@ describe('ConfigForm helpers', () => {
     const markCommits = entryByKey(WorkspaceStateKey.GIT_MARK_COMMITS);
     const authorName = entryByKey(WorkspaceStateKey.GIT_AUTHOR_NAME);
     const formatter = entryByKey(WorkspaceStateKey.LATEX_FORMATTER);
+    const timeout = entryByKey(
+      WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS,
+    );
 
     expect(settingEditKind(markCommits)).toBe('boolean');
-    expect(settingEditKind(authorName)).toBe('readonly');
+    expect(settingEditKind(authorName)).toBe('string');
     expect(settingEditKind(formatter)).toBe('enum');
+    expect(settingEditKind(timeout)).toBe('number');
+  });
+
+  it('coerces text-editor input by kind', () => {
+    expect(coerceSettingInput('texra-ai', false)).toEqual({
+      value: 'texra-ai',
+    });
+    expect(coerceSettingInput('', false)).toEqual({ value: '' });
+    expect(coerceSettingInput('120000', true)).toEqual({ value: 120000 });
+    expect(coerceSettingInput('  90000 ', true)).toEqual({ value: 90000 });
+    // Blank / non-numeric input for a number field is ignored, not written.
+    expect(coerceSettingInput('', true)).toBeNull();
+    expect(coerceSettingInput('abc', true)).toBeNull();
   });
 
   it('formats values for display', () => {
@@ -108,7 +126,7 @@ describe('ConfigForm helpers', () => {
     ).toBe('git.markCommits');
   });
 
-  it('builds list items with read-only rows disabled', () => {
+  it('builds list items showing value + store, with editable rows enabled', () => {
     const items = buildConfigListItems(CLI_STATE_SETTINGS, (entry) =>
       entry.key === WorkspaceStateKey.GIT_MARK_COMMITS ? true : 'texra-ai',
     );
@@ -125,8 +143,24 @@ describe('ConfigForm helpers', () => {
     });
     expect(markCommits?.description).toContain('on');
     expect(markCommits?.description).toContain('config');
-    expect(authorName).toMatchObject({ disabled: true });
-    expect(authorName?.description).toContain('read-only');
+    // Strings/numbers are now editable, so no row is read-only in the roster.
+    expect(authorName).toMatchObject({ disabled: false });
+    expect(authorName?.description).not.toContain('read-only');
+  });
+
+  it('marks an unsupported schema kind read-only', () => {
+    const recordEntry: StateSettingEntry = {
+      key: 'texra.example.record',
+      schema: z.record(z.string(), z.string()).prefault({}),
+      description: 'A record setting with no inline editor.',
+      category: 'example',
+      store: 'workspaceState',
+      hosts: ['vscode'],
+    };
+    expect(settingEditKind(recordEntry)).toBe('readonly');
+    const [item] = buildConfigListItems([recordEntry], () => ({}));
+    expect(item).toMatchObject({ disabled: true });
+    expect(item?.description).toContain('read-only');
   });
 
   it('builds enum items from catalog enum metadata', () => {

--- a/src/test-kernel/cli/ConfigForm.vitest.mts
+++ b/src/test-kernel/cli/ConfigForm.vitest.mts
@@ -21,8 +21,11 @@ import {
   STATE_SETTINGS,
   type StateSettingEntry,
 } from '@shared/schemas/stateSettings';
-import type { SettingsStores } from '@shared/config/settingsAccess';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
+import {
+  isStored,
+  makeFakeSettingsStores,
+} from '@test/support/settingsStoresFake';
 
 afterEach(() => {
   for (const cmd of [...listSlashCommands()]) unregisterSlashCommand(cmd.name);
@@ -33,43 +36,6 @@ function entryByKey(key: string): StateSettingEntry {
   const entry = STATE_SETTINGS.find((candidate) => candidate.key === key);
   if (!entry) throw new Error(`missing catalog entry ${key}`);
   return entry;
-}
-
-class FakeStore {
-  private readonly data = new Map<string, unknown>();
-  get<T>(key: string, defaultValue?: T): T {
-    return this.data.has(key) ? (this.data.get(key) as T) : (defaultValue as T);
-  }
-  update(key: string, value: unknown): Promise<void> {
-    if (value === undefined) this.data.delete(key);
-    else this.data.set(key, value);
-    return Promise.resolve();
-  }
-  has(key: string): boolean {
-    return this.data.has(key);
-  }
-}
-
-class FakeConfig extends FakeStore {
-  update(key: string, value: unknown, _target?: string): Promise<void> {
-    return super.update(key, value);
-  }
-}
-
-function makeStores(): {
-  stores: SettingsStores;
-  config: FakeConfig;
-} {
-  const config = new FakeConfig();
-  return {
-    stores: {
-      config: config as unknown as SettingsStores['config'],
-      workspaceState:
-        new FakeStore() as unknown as SettingsStores['workspaceState'],
-      globalState: new FakeStore() as unknown as SettingsStores['globalState'],
-    },
-    config,
-  };
 }
 
 function renderConfigFormProps(): {
@@ -180,7 +146,7 @@ describe('ConfigForm helpers', () => {
 describe('/config slash command wiring', () => {
   it('registers /config with a form and settings alias', () => {
     registerBuiltinSlashCommands({
-      getConfigStores: () => makeStores().stores,
+      getConfigStores: () => makeFakeSettingsStores().stores,
     });
     const config = listSlashCommands().find((cmd) => cmd.name === 'config');
     expect(config).toEqual(
@@ -193,7 +159,7 @@ describe('/config slash command wiring', () => {
   });
 
   it('wires the roster and reads through the injected CLI stores', () => {
-    const { stores, config } = makeStores();
+    const { stores, config } = makeFakeSettingsStores();
     // Seed the git-author config slot the CLI reads from.
     void config.update(WorkspaceStateKey.GIT_MARK_COMMITS, false);
 
@@ -211,7 +177,7 @@ describe('/config slash command wiring', () => {
   });
 
   it('persists writes through the accessor to the CLI store', async () => {
-    const { stores, config } = makeStores();
+    const { stores, config } = makeFakeSettingsStores();
     registerBuiltinSlashCommands({ getConfigStores: () => stores });
     openCliSlashCommandForm('config', '');
 
@@ -219,7 +185,7 @@ describe('/config slash command wiring', () => {
     const markCommits = entryByKey(WorkspaceStateKey.GIT_MARK_COMMITS);
     await props.writeValue?.(markCommits, false);
 
-    expect(config.has(WorkspaceStateKey.GIT_MARK_COMMITS)).toBe(true);
+    expect(isStored(config, WorkspaceStateKey.GIT_MARK_COMMITS)).toBe(true);
     expect(props.readValue?.(markCommits)).toBe(false);
   });
 });

--- a/src/test-kernel/cli/ConfigForm.vitest.mts
+++ b/src/test-kernel/cli/ConfigForm.vitest.mts
@@ -21,7 +21,9 @@ import {
   STATE_SETTINGS,
   type StateSettingEntry,
 } from '@shared/schemas/stateSettings';
+import { DEFAULT_GIT_AUTHOR_NAME } from '@shared/constants/git';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
+import { getGitAuthorEnv } from '@utils/system/gitAuthorEnv';
 import {
   isStored,
   makeFakeSettingsStores,
@@ -187,5 +189,20 @@ describe('/config slash command wiring', () => {
 
     expect(isStored(config, WorkspaceStateKey.GIT_MARK_COMMITS)).toBe(true);
     expect(props.readValue?.(markCommits)).toBe(false);
+  });
+
+  it('re-applies git author config so a toggle takes effect this session', async () => {
+    const { stores } = makeFakeSettingsStores();
+    registerBuiltinSlashCommands({ getConfigStores: () => stores });
+    openCliSlashCommandForm('config', '');
+
+    const props = renderConfigFormProps();
+    const markCommits = entryByKey(WorkspaceStateKey.GIT_MARK_COMMITS);
+
+    await props.writeValue?.(markCommits, true);
+    expect(getGitAuthorEnv().GIT_AUTHOR_NAME).toBe(DEFAULT_GIT_AUTHOR_NAME);
+
+    await props.writeValue?.(markCommits, false);
+    expect(getGitAuthorEnv()).toEqual({});
   });
 });

--- a/src/test-kernel/cli/ConfigForm.vitest.mts
+++ b/src/test-kernel/cli/ConfigForm.vitest.mts
@@ -49,6 +49,7 @@ function renderConfigFormProps(): {
     entry: StateSettingEntry,
     value: unknown,
   ) => void | Promise<void>;
+  resetValue?: (entry: StateSettingEntry) => void | Promise<void>;
 } {
   const node = cliState.activeForm.get()?.render(() => {}, 20) as {
     type?: (props: unknown) => unknown;
@@ -238,5 +239,22 @@ describe('/config slash command wiring', () => {
 
     await props.writeValue?.(markCommits, false);
     expect(getGitAuthorEnv()).toEqual({});
+  });
+
+  it('resets a git setting (delete) and re-applies the identity', async () => {
+    const { stores, config } = makeFakeSettingsStores();
+    registerBuiltinSlashCommands({ getConfigStores: () => stores });
+    openCliSlashCommandForm('config', '');
+
+    const props = renderConfigFormProps();
+    const authorName = entryByKey(WorkspaceStateKey.GIT_AUTHOR_NAME);
+
+    await props.writeValue?.(authorName, 'someone-else');
+    expect(isStored(config, WorkspaceStateKey.GIT_AUTHOR_NAME)).toBe(true);
+
+    await props.resetValue?.(authorName);
+    // The key is deleted, so reads fall back to the default identity.
+    expect(isStored(config, WorkspaceStateKey.GIT_AUTHOR_NAME)).toBe(false);
+    expect(props.readValue?.(authorName)).toBe(DEFAULT_GIT_AUTHOR_NAME);
   });
 });

--- a/src/test-kernel/cli/ConfigForm.vitest.mts
+++ b/src/test-kernel/cli/ConfigForm.vitest.mts
@@ -1,0 +1,225 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  buildConfigListItems,
+  buildEnumItems,
+  CLI_CONFIG_ROSTER,
+  ConfigForm,
+  formatSettingValue,
+  settingDisplayName,
+  settingEditKind,
+  settingStoreLabel,
+} from '@cli/chat/tui/forms/ConfigForm';
+import {
+  listSlashCommands,
+  unregisterSlashCommand,
+} from '@cli/chat/tui/commands/slashRegistry';
+import { registerBuiltinSlashCommands } from '@cli/chat/tui/commands/registerBuiltins';
+import { openCliSlashCommandForm } from '@cli/chat/tui/commands/slashForms';
+import { cliState, resetCliState } from '@cli/chat/tui/state/cliState';
+import {
+  STATE_SETTINGS,
+  type StateSettingEntry,
+} from '@shared/schemas/stateSettings';
+import type { SettingsStores } from '@shared/config/settingsAccess';
+import { WorkspaceStateKey } from '@shared/state/stateKeys';
+
+afterEach(() => {
+  for (const cmd of [...listSlashCommands()]) unregisterSlashCommand(cmd.name);
+  resetCliState();
+});
+
+function entryByKey(key: string): StateSettingEntry {
+  const entry = STATE_SETTINGS.find((candidate) => candidate.key === key);
+  if (!entry) throw new Error(`missing catalog entry ${key}`);
+  return entry;
+}
+
+class FakeStore {
+  private readonly data = new Map<string, unknown>();
+  get<T>(key: string, defaultValue?: T): T {
+    return this.data.has(key) ? (this.data.get(key) as T) : (defaultValue as T);
+  }
+  update(key: string, value: unknown): Promise<void> {
+    if (value === undefined) this.data.delete(key);
+    else this.data.set(key, value);
+    return Promise.resolve();
+  }
+  has(key: string): boolean {
+    return this.data.has(key);
+  }
+}
+
+class FakeConfig extends FakeStore {
+  update(key: string, value: unknown, _target?: string): Promise<void> {
+    return super.update(key, value);
+  }
+}
+
+function makeStores(): {
+  stores: SettingsStores;
+  config: FakeConfig;
+} {
+  const config = new FakeConfig();
+  return {
+    stores: {
+      config: config as unknown as SettingsStores['config'],
+      workspaceState:
+        new FakeStore() as unknown as SettingsStores['workspaceState'],
+      globalState: new FakeStore() as unknown as SettingsStores['globalState'],
+    },
+    config,
+  };
+}
+
+function renderConfigFormProps(): {
+  entries?: readonly StateSettingEntry[];
+  readValue?: (entry: StateSettingEntry) => unknown;
+  writeValue?: (
+    entry: StateSettingEntry,
+    value: unknown,
+  ) => void | Promise<void>;
+} {
+  const node = cliState.activeForm.get()?.render(() => {}, 20) as {
+    type?: (props: unknown) => unknown;
+    props?: unknown;
+  };
+  if (typeof node?.type !== 'function') {
+    throw new TypeError('Expected /config form adapter element');
+  }
+  const rendered = node.type(node.props) as {
+    props?: ReturnType<typeof Object>;
+  };
+  return (rendered.props ?? {}) as ReturnType<typeof renderConfigFormProps>;
+}
+
+describe('ConfigForm helpers', () => {
+  it('rosters exactly the CLI-consumed catalog entries', () => {
+    expect([...CLI_CONFIG_ROSTER].map((entry) => entry.key)).toEqual(
+      STATE_SETTINGS.filter((entry) => entry.hosts.includes('cli')).map(
+        (entry) => entry.key,
+      ),
+    );
+    expect(CLI_CONFIG_ROSTER.length).toBeGreaterThan(0);
+    // Every rostered entry must be reachable from the CLI's store set.
+    for (const entry of CLI_CONFIG_ROSTER) {
+      expect(entry.hosts).toContain('cli');
+    }
+  });
+
+  it('classifies edit kinds by value type and enum metadata', () => {
+    const markCommits = entryByKey(WorkspaceStateKey.GIT_MARK_COMMITS);
+    const authorName = entryByKey(WorkspaceStateKey.GIT_AUTHOR_NAME);
+    const formatter = entryByKey(WorkspaceStateKey.LATEX_FORMATTER);
+
+    expect(settingEditKind(markCommits, true)).toBe('boolean');
+    expect(settingEditKind(authorName, 'texra-ai')).toBe('readonly');
+    expect(settingEditKind(formatter, 'latexindent')).toBe('enum');
+  });
+
+  it('formats values for display', () => {
+    expect(formatSettingValue(true)).toBe('on');
+    expect(formatSettingValue(false)).toBe('off');
+    expect(formatSettingValue('')).toBe('(empty)');
+    expect(formatSettingValue('latexindent')).toBe('latexindent');
+    expect(formatSettingValue(120000)).toBe('120000');
+  });
+
+  it('labels the store the CLI reads from (cliStore wins)', () => {
+    expect(
+      settingStoreLabel(entryByKey(WorkspaceStateKey.GIT_MARK_COMMITS)),
+    ).toBe('config');
+    expect(
+      settingStoreLabel(entryByKey(WorkspaceStateKey.LATEX_FORMATTER)),
+    ).toBe('workspaceState');
+  });
+
+  it('strips the texra prefix for display names', () => {
+    expect(
+      settingDisplayName(entryByKey(WorkspaceStateKey.GIT_MARK_COMMITS)),
+    ).toBe('git.markCommits');
+  });
+
+  it('builds list items with read-only rows disabled', () => {
+    const items = buildConfigListItems(CLI_CONFIG_ROSTER, (entry) =>
+      entry.key === WorkspaceStateKey.GIT_MARK_COMMITS ? true : 'texra-ai',
+    );
+    const markCommits = items.find(
+      (item) => item.value === WorkspaceStateKey.GIT_MARK_COMMITS,
+    );
+    const authorName = items.find(
+      (item) => item.value === WorkspaceStateKey.GIT_AUTHOR_NAME,
+    );
+
+    expect(markCommits).toMatchObject({
+      label: 'git.markCommits',
+      disabled: false,
+    });
+    expect(markCommits?.description).toContain('on');
+    expect(markCommits?.description).toContain('config');
+    expect(authorName).toMatchObject({ disabled: true });
+    expect(authorName?.description).toContain('read-only');
+  });
+
+  it('builds enum items from catalog enum metadata', () => {
+    const formatter = entryByKey(WorkspaceStateKey.LATEX_FORMATTER);
+    const items = buildEnumItems(formatter);
+    expect(items.map((item) => item.value)).toEqual([
+      'latexindent',
+      'tex-fmt',
+      'none',
+    ]);
+    expect(items[0]?.description).toBeTruthy();
+  });
+
+  it('exports a renderable component', () => {
+    expect(typeof ConfigForm).toBe('function');
+  });
+});
+
+describe('/config slash command wiring', () => {
+  it('registers /config with a form and settings alias', () => {
+    registerBuiltinSlashCommands({
+      getConfigStores: () => makeStores().stores,
+    });
+    const config = listSlashCommands().find((cmd) => cmd.name === 'config');
+    expect(config).toEqual(
+      expect.objectContaining({
+        description: 'View and toggle settings',
+        aliases: ['settings'],
+        formComponent: expect.any(Function),
+      }),
+    );
+  });
+
+  it('wires the roster and reads through the injected CLI stores', () => {
+    const { stores, config } = makeStores();
+    // Seed the git-author config slot the CLI reads from.
+    void config.update(WorkspaceStateKey.GIT_MARK_COMMITS, false);
+
+    registerBuiltinSlashCommands({ getConfigStores: () => stores });
+    expect(openCliSlashCommandForm('config', '')).toBe(true);
+    expect(cliState.activeForm.get()?.commandName).toBe('config');
+
+    const props = renderConfigFormProps();
+    expect(props.entries?.map((entry) => entry.key)).toEqual(
+      CLI_CONFIG_ROSTER.map((entry) => entry.key),
+    );
+
+    const markCommits = entryByKey(WorkspaceStateKey.GIT_MARK_COMMITS);
+    expect(props.readValue?.(markCommits)).toBe(false);
+  });
+
+  it('persists writes through the accessor to the CLI store', async () => {
+    const { stores, config } = makeStores();
+    registerBuiltinSlashCommands({ getConfigStores: () => stores });
+    openCliSlashCommandForm('config', '');
+
+    const props = renderConfigFormProps();
+    const markCommits = entryByKey(WorkspaceStateKey.GIT_MARK_COMMITS);
+    await props.writeValue?.(markCommits, false);
+
+    expect(config.has(WorkspaceStateKey.GIT_MARK_COMMITS)).toBe(true);
+    expect(props.readValue?.(markCommits)).toBe(false);
+  });
+});

--- a/src/test-kernel/shared/settingsConfiguration.vitest.ts
+++ b/src/test-kernel/shared/settingsConfiguration.vitest.ts
@@ -156,13 +156,18 @@ describe('TexraSettingsSchema', () => {
 
   it('removes stale generated package schema fields during regeneration', () => {
     const sections = getPackageConfigurationSections();
+    // `order` and `editPresentation` are VS Code-presentation-only fields that
+    // stay hand-maintained in package.json (not in the generator allowlist), so
+    // they must survive regeneration. `enum` is generated, so a stale value not
+    // present in the schema must be removed (compactionThresholdPercent is a
+    // plain number with no enum).
     const sectionWithStaleField = {
       ...sections[0],
       properties: {
         ...sections[0].properties,
         'texra.model.compactionThresholdPercent': {
           ...sections[0].properties?.['texra.model.compactionThresholdPercent'],
-          description: 'Preserved description',
+          order: 999,
           enum: [75],
         },
       },
@@ -175,8 +180,29 @@ describe('TexraSettingsSchema', () => {
     const regeneratedProperty =
       regenerated.properties?.['texra.model.compactionThresholdPercent'];
 
-    assert.equal(regeneratedProperty?.description, 'Preserved description');
+    assert.equal(regeneratedProperty?.order, 999);
     assert.equal(Object.hasOwn(regeneratedProperty ?? {}, 'enum'), false);
+  });
+
+  it('pairs every enum setting with one description per enum value', () => {
+    const packageProperties = getPackageConfigurationProperties();
+
+    for (const [key, property] of Object.entries(packageProperties)) {
+      const enumValues = property.enum;
+      if (!Array.isArray(enumValues)) {
+        continue;
+      }
+      const enumDescriptions = property.enumDescriptions;
+      assert.ok(
+        Array.isArray(enumDescriptions),
+        `${key} declares enum but no enumDescriptions`,
+      );
+      assert.equal(
+        (enumDescriptions as unknown[]).length,
+        enumValues.length,
+        key,
+      );
+    }
   });
 
   it('rejects unknown texra package configuration keys', () => {

--- a/src/test-kernel/shared/stateSettings.vitest.ts
+++ b/src/test-kernel/shared/stateSettings.vitest.ts
@@ -11,6 +11,7 @@ import {
   STATE_SETTINGS,
   STATE_SETTING_KEYS,
   settingEnumOptions,
+  stateSettingByKey,
   type SettingStore,
   type StateSettingEntry,
 } from '@shared/schemas/stateSettings';
@@ -142,6 +143,44 @@ describe('state settings catalog', () => {
       );
       assert.equal(entry.enumDescriptions?.length, options.length, entry.key);
     }
+  });
+
+  it('drives the LaTeX tab enum option labels from catalog metadata', () => {
+    // Locks the catalog wording the extension's LaTeXTab now composes its
+    // <wa-select> labels from, so the displayed options stay byte-identical to
+    // the previously hand-listed arrays.
+    const mathMarkup = stateSettingByKey(
+      WorkspaceStateKey.LATEXDIFF_MATH_MARKUP,
+    );
+    assert.ok(mathMarkup);
+    const mathMarkupLabels = (settingEnumOptions(mathMarkup) ?? []).map(
+      (value, index) => {
+        const base = `${value} — ${mathMarkup.enumDescriptions?.[index]}`;
+        return value === LATEX_CONFIG_DEFAULTS.latexdiffMathMarkup
+          ? `${base} (default)`
+          : base;
+      },
+    );
+    assert.deepEqual(mathMarkupLabels, [
+      'off — suppress markup',
+      'whole — equation-level',
+      'coarse — within equations (default)',
+      'fine — small changes inside equations',
+    ]);
+
+    const formatter = stateSettingByKey(WorkspaceStateKey.LATEX_FORMATTER);
+    assert.ok(formatter);
+    const formatterLabels = (settingEnumOptions(formatter) ?? []).map(
+      (value) =>
+        value === LATEX_CONFIG_DEFAULTS.latexFormatter
+          ? `${value} (default)`
+          : value,
+    );
+    assert.deepEqual(formatterLabels, [
+      'latexindent (default)',
+      'tex-fmt',
+      'none',
+    ]);
   });
 
   it('shares no keys with the config-tree catalog', () => {

--- a/src/test-kernel/shared/stateSettings.vitest.ts
+++ b/src/test-kernel/shared/stateSettings.vitest.ts
@@ -18,7 +18,6 @@ import {
   resetSetting,
   settingDefault,
   writeSetting,
-  type SettingsStores,
 } from '@shared/config/settingsAccess';
 
 // Local imports - canonical defaults + keys the catalog must agree with
@@ -30,7 +29,11 @@ import {
 import { LATEX_CONFIG_DEFAULTS } from '@shared/constants/latex';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 
-// Local imports - CLI whitelist derived from the catalog
+// Local imports - shared store fakes
+import {
+  isStored,
+  makeFakeSettingsStores,
+} from '@test/support/settingsStoresFake';
 
 const VALID_STORES: ReadonlySet<SettingStore> = new Set<SettingStore>([
   'config',
@@ -176,52 +179,6 @@ describe('knownKeys derivation', () => {
 
 // --- accessor round-trip ----------------------------------------------------
 
-class FakeStore {
-  private readonly data = new Map<string, unknown>();
-  get<T>(key: string, defaultValue?: T): T {
-    return this.data.has(key) ? (this.data.get(key) as T) : (defaultValue as T);
-  }
-  update(key: string, value: unknown): Promise<void> {
-    if (value === undefined) {
-      this.data.delete(key);
-    } else {
-      this.data.set(key, value);
-    }
-    return Promise.resolve();
-  }
-  has(key: string): boolean {
-    return this.data.has(key);
-  }
-}
-
-class FakeConfig extends FakeStore {
-  lastTarget: string | undefined;
-  update(key: string, value: unknown, target?: string): Promise<void> {
-    this.lastTarget = target;
-    return super.update(key, value);
-  }
-}
-
-function makeStores(): {
-  stores: SettingsStores;
-  config: FakeConfig;
-  workspaceState: FakeStore;
-} {
-  const config = new FakeConfig();
-  const workspaceState = new FakeStore();
-  const globalState = new FakeStore();
-  return {
-    stores: {
-      config: config as unknown as SettingsStores['config'],
-      workspaceState:
-        workspaceState as unknown as SettingsStores['workspaceState'],
-      globalState: globalState as unknown as SettingsStores['globalState'],
-    },
-    config,
-    workspaceState,
-  };
-}
-
 function entryByKey(key: string): StateSettingEntry {
   const entry = STATE_SETTINGS.find((e) => e.key === key);
   assert.ok(entry, `missing catalog entry ${key}`);
@@ -230,7 +187,7 @@ function entryByKey(key: string): StateSettingEntry {
 
 describe('settingsAccess', () => {
   it('reads the default when the key is absent', () => {
-    const { stores } = makeStores();
+    const { stores } = makeFakeSettingsStores();
     const entry = entryByKey(WorkspaceStateKey.GIT_MARK_COMMITS);
     assert.equal(
       readSetting(entry, stores, 'extension'),
@@ -239,26 +196,31 @@ describe('settingsAccess', () => {
   });
 
   it('routes extension writes to the canonical store', async () => {
-    const { stores, config, workspaceState } = makeStores();
+    const { stores, config, workspaceState } = makeFakeSettingsStores();
     const entry = entryByKey(WorkspaceStateKey.GIT_MARK_COMMITS);
     await writeSetting(entry, false, stores, 'extension');
-    assert.equal(workspaceState.has(entry.key), true);
-    assert.equal(config.has(entry.key), false);
+    assert.equal(isStored(workspaceState, entry.key), true);
+    assert.equal(isStored(config, entry.key), false);
     assert.equal(readSetting(entry, stores, 'extension'), false);
   });
 
   it('routes CLI writes to the cliStore override (config)', async () => {
-    const { stores, config, workspaceState } = makeStores();
+    const { stores, config, workspaceState } = makeFakeSettingsStores();
     const entry = entryByKey(WorkspaceStateKey.GIT_MARK_COMMITS);
     await writeSetting(entry, false, stores, 'cli');
-    assert.equal(config.has(entry.key), true);
-    assert.equal(workspaceState.has(entry.key), false);
-    assert.equal(config.lastTarget, 'workspace');
+    assert.equal(isStored(config, entry.key), true);
+    assert.equal(isStored(workspaceState, entry.key), false);
+    // The config write used the default 'workspace' target.
+    assert.deepEqual(config.inspect(entry.key), {
+      globalValue: undefined,
+      workspaceValue: false,
+      effectiveValue: false,
+    });
     assert.equal(readSetting(entry, stores, 'cli'), false);
   });
 
   it('rejects values that fail the entry schema', async () => {
-    const { stores } = makeStores();
+    const { stores } = makeFakeSettingsStores();
     const entry = entryByKey(WorkspaceStateKey.LATEX_FORMATTER);
     await assert.rejects(() =>
       writeSetting(entry, 'not-a-formatter', stores, 'extension'),
@@ -266,12 +228,12 @@ describe('settingsAccess', () => {
   });
 
   it('reset deletes the key so the default reappears', async () => {
-    const { stores, workspaceState } = makeStores();
+    const { stores, workspaceState } = makeFakeSettingsStores();
     const entry = entryByKey(WorkspaceStateKey.LATEXDIFF_CHANGES_ONLY);
     await writeSetting(entry, false, stores, 'extension');
-    assert.equal(workspaceState.has(entry.key), true);
+    assert.equal(isStored(workspaceState, entry.key), true);
     await resetSetting(entry, stores, 'extension');
-    assert.equal(workspaceState.has(entry.key), false);
+    assert.equal(isStored(workspaceState, entry.key), false);
     assert.equal(
       readSetting(entry, stores, 'extension'),
       LATEX_CONFIG_DEFAULTS.latexdiffChangesOnly,
@@ -279,7 +241,7 @@ describe('settingsAccess', () => {
   });
 
   it('falls back to the default for a stored value that no longer validates', () => {
-    const { stores, workspaceState } = makeStores();
+    const { stores, workspaceState } = makeFakeSettingsStores();
     const entry = entryByKey(WorkspaceStateKey.LATEX_FORMATTER);
     void workspaceState.update(entry.key, 'stale-bogus-value');
     assert.equal(

--- a/src/test-kernel/shared/stateSettings.vitest.ts
+++ b/src/test-kernel/shared/stateSettings.vitest.ts
@@ -8,6 +8,7 @@ import { describe, it } from 'vitest';
 import { KNOWN_TEXRA_KEYS } from '@cli/schemas/knownKeys';
 import { CORE_SETTING_PATHS } from '@shared/schemas/coreSettings';
 import {
+  CLI_STATE_SETTINGS,
   STATE_SETTINGS,
   STATE_SETTING_KEYS,
   settingEnumOptions,
@@ -181,6 +182,29 @@ describe('state settings catalog', () => {
       'tex-fmt',
       'none',
     ]);
+  });
+
+  it('exposes exactly the verified CLI-consumed settings', () => {
+    // Each entry below is confirmed to actually take effect in the CLI:
+    //  - git author identity is merged into spawned commands (execUtils) and
+    //    drives worktree delegation (DelegationTools);
+    //  - the workflow compile settings run in `texra workflow` / `texra run`
+    //    (the reflection flow, via OutputNode/runCompileCheck).
+    // auto-open-pdf (no CLI opener), latexdiff, and the formatter are
+    // intentionally excluded. Changing the CLI roster must be a deliberate edit
+    // here, not an accident of flipping `hosts`.
+    assert.deepEqual(
+      [...CLI_STATE_SETTINGS].map((entry) => entry.key).sort(),
+      [
+        WorkspaceStateKey.GIT_AUTHOR_EMAIL,
+        WorkspaceStateKey.GIT_AUTHOR_NAME,
+        WorkspaceStateKey.GIT_MARK_COMMITS,
+        WorkspaceStateKey.GIT_WORKTREE_SUPPORT,
+        WorkspaceStateKey.WORKFLOW_AUTO_COMPILE,
+        WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS,
+        WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE,
+      ].sort(),
+    );
   });
 
   it('shares no keys with the config-tree catalog', () => {

--- a/src/test-kernel/shared/stateSettings.vitest.ts
+++ b/src/test-kernel/shared/stateSettings.vitest.ts
@@ -1,0 +1,290 @@
+// Standard library imports
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'vitest';
+
+// Local imports - catalog + accessor
+import { KNOWN_TEXRA_KEYS } from '@cli/schemas/knownKeys';
+import {
+  CLI_STATE_SETTING_KEYS,
+  STATE_SETTINGS,
+  STATE_SETTING_KEYS,
+  type SettingStore,
+  type StateSettingEntry,
+} from '@shared/schemas/stateSettings';
+import {
+  readSetting,
+  resetSetting,
+  settingDefault,
+  writeSetting,
+  type SettingsStores,
+} from '@shared/config/settingsAccess';
+
+// Local imports - canonical defaults + keys the catalog must agree with
+import {
+  DEFAULT_GIT_AUTHOR_EMAIL,
+  DEFAULT_GIT_AUTHOR_NAME,
+  DEFAULT_GIT_MARK_COMMITS,
+} from '@shared/constants/git';
+import { LATEX_CONFIG_DEFAULTS } from '@shared/constants/latex';
+import { WorkspaceStateKey } from '@shared/state/stateKeys';
+
+// Local imports - CLI whitelist derived from the catalog
+
+const VALID_STORES: ReadonlySet<SettingStore> = new Set<SettingStore>([
+  'config',
+  'workspaceState',
+  'globalState',
+]);
+
+const CLASS_D_KEY_PATTERN = /migrated|version|onboarding|history|cache/i;
+
+/** Expected default-when-absent for each catalog key, from the real getters. */
+const EXPECTED_DEFAULTS: Record<string, unknown> = {
+  [WorkspaceStateKey.GIT_MARK_COMMITS]: DEFAULT_GIT_MARK_COMMITS,
+  [WorkspaceStateKey.GIT_AUTHOR_NAME]: DEFAULT_GIT_AUTHOR_NAME,
+  [WorkspaceStateKey.GIT_AUTHOR_EMAIL]: DEFAULT_GIT_AUTHOR_EMAIL,
+  [WorkspaceStateKey.GIT_WORKTREE_SUPPORT]: false,
+  [WorkspaceStateKey.WORKFLOW_AUTO_COMPILE]:
+    LATEX_CONFIG_DEFAULTS.workflowAutoCompile,
+  [WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS]:
+    LATEX_CONFIG_DEFAULTS.workflowAutoCompileTimeoutMs,
+  [WorkspaceStateKey.WORKFLOW_AUTO_OPEN_PDF]:
+    LATEX_CONFIG_DEFAULTS.workflowAutoOpenPdf,
+  [WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE]:
+    LATEX_CONFIG_DEFAULTS.workflowRejectOnCompileFailure,
+  [WorkspaceStateKey.LATEXDIFF_BETWEEN_ROUNDS]:
+    LATEX_CONFIG_DEFAULTS.latexdiffBetweenRounds,
+  [WorkspaceStateKey.LATEXDIFF_TIMEOUT_MS]:
+    LATEX_CONFIG_DEFAULTS.latexdiffTimeoutMs,
+  [WorkspaceStateKey.LATEXDIFF_MATH_MARKUP]:
+    LATEX_CONFIG_DEFAULTS.latexdiffMathMarkup,
+  [WorkspaceStateKey.LATEXDIFF_CHANGES_ONLY]:
+    LATEX_CONFIG_DEFAULTS.latexdiffChangesOnly,
+  [WorkspaceStateKey.LATEX_FORMATTER]: LATEX_CONFIG_DEFAULTS.latexFormatter,
+};
+
+describe('state settings catalog', () => {
+  it('uses unique canonical keys', () => {
+    assert.equal(new Set(STATE_SETTING_KEYS).size, STATE_SETTING_KEYS.length);
+  });
+
+  it('every CLI-host entry names an existing consumer file', () => {
+    for (const entry of STATE_SETTINGS) {
+      if (!entry.hosts.includes('cli')) {
+        continue;
+      }
+      assert.ok(
+        entry.cliConsumer,
+        `${entry.key} is surfaced to the CLI but declares no cliConsumer`,
+      );
+      assert.ok(
+        existsSync(resolve(process.cwd(), entry.cliConsumer as string)),
+        `${entry.key} cliConsumer does not exist: ${entry.cliConsumer}`,
+      );
+    }
+  });
+
+  it('uses valid, coherent storage slots', () => {
+    for (const entry of STATE_SETTINGS) {
+      assert.ok(VALID_STORES.has(entry.store), `${entry.key} invalid store`);
+      if (entry.cliStore !== undefined) {
+        assert.ok(
+          VALID_STORES.has(entry.cliStore),
+          `${entry.key} invalid cliStore`,
+        );
+        // A cliStore override only makes sense when the CLI consumes the entry.
+        assert.ok(
+          entry.hosts.includes('cli'),
+          `${entry.key} declares cliStore but no 'cli' host`,
+        );
+        // Global and project scope must not be mixed between the two slots.
+        const storeIsGlobal = entry.store === 'globalState';
+        const cliStoreIsGlobal = entry.cliStore === 'globalState';
+        assert.equal(
+          storeIsGlobal,
+          cliStoreIsGlobal,
+          `${entry.key} mixes global and project scope across store/cliStore`,
+        );
+      }
+    }
+  });
+
+  it('excludes Class-D internal state keys', () => {
+    for (const key of STATE_SETTING_KEYS) {
+      assert.ok(
+        !CLASS_D_KEY_PATTERN.test(key),
+        `${key} looks like internal (Class-D) state and must not be a setting`,
+      );
+    }
+  });
+
+  it('pairs enum entries with one description per value', () => {
+    for (const entry of STATE_SETTINGS) {
+      if (!entry.enumValues) {
+        assert.equal(
+          entry.enumDescriptions,
+          undefined,
+          `${entry.key} has enumDescriptions without enumValues`,
+        );
+        continue;
+      }
+      assert.ok(
+        entry.enumDescriptions,
+        `${entry.key} enum entry is missing enumDescriptions`,
+      );
+      assert.equal(
+        entry.enumDescriptions?.length,
+        entry.enumValues.length,
+        entry.key,
+      );
+    }
+  });
+
+  it('round-trips each `.prefault()` default to the real getter default', () => {
+    for (const entry of STATE_SETTINGS) {
+      assert.ok(
+        Object.hasOwn(EXPECTED_DEFAULTS, entry.key),
+        `${entry.key} has no expected default declared in the test`,
+      );
+      assert.deepEqual(
+        settingDefault(entry),
+        EXPECTED_DEFAULTS[entry.key],
+        entry.key,
+      );
+    }
+  });
+});
+
+describe('knownKeys derivation', () => {
+  it('recognizes every catalog key (no unknown-key warnings)', () => {
+    for (const key of STATE_SETTING_KEYS) {
+      assert.ok(
+        KNOWN_TEXRA_KEYS.has(key),
+        `${key} missing from KNOWN_TEXRA_KEYS`,
+      );
+    }
+  });
+
+  it('recognizes every CLI-consumed catalog key', () => {
+    for (const key of CLI_STATE_SETTING_KEYS) {
+      assert.ok(KNOWN_TEXRA_KEYS.has(key), key);
+    }
+  });
+});
+
+// --- accessor round-trip ----------------------------------------------------
+
+class FakeStore {
+  private readonly data = new Map<string, unknown>();
+  get<T>(key: string, defaultValue?: T): T {
+    return this.data.has(key) ? (this.data.get(key) as T) : (defaultValue as T);
+  }
+  update(key: string, value: unknown): Promise<void> {
+    if (value === undefined) {
+      this.data.delete(key);
+    } else {
+      this.data.set(key, value);
+    }
+    return Promise.resolve();
+  }
+  has(key: string): boolean {
+    return this.data.has(key);
+  }
+}
+
+class FakeConfig extends FakeStore {
+  lastTarget: string | undefined;
+  update(key: string, value: unknown, target?: string): Promise<void> {
+    this.lastTarget = target;
+    return super.update(key, value);
+  }
+}
+
+function makeStores(): {
+  stores: SettingsStores;
+  config: FakeConfig;
+  workspaceState: FakeStore;
+} {
+  const config = new FakeConfig();
+  const workspaceState = new FakeStore();
+  const globalState = new FakeStore();
+  return {
+    stores: {
+      config: config as unknown as SettingsStores['config'],
+      workspaceState:
+        workspaceState as unknown as SettingsStores['workspaceState'],
+      globalState: globalState as unknown as SettingsStores['globalState'],
+    },
+    config,
+    workspaceState,
+  };
+}
+
+function entryByKey(key: string): StateSettingEntry {
+  const entry = STATE_SETTINGS.find((e) => e.key === key);
+  assert.ok(entry, `missing catalog entry ${key}`);
+  return entry as StateSettingEntry;
+}
+
+describe('settingsAccess', () => {
+  it('reads the default when the key is absent', () => {
+    const { stores } = makeStores();
+    const entry = entryByKey(WorkspaceStateKey.GIT_MARK_COMMITS);
+    assert.equal(
+      readSetting(entry, stores, 'extension'),
+      DEFAULT_GIT_MARK_COMMITS,
+    );
+  });
+
+  it('routes extension writes to the canonical store', async () => {
+    const { stores, config, workspaceState } = makeStores();
+    const entry = entryByKey(WorkspaceStateKey.GIT_MARK_COMMITS);
+    await writeSetting(entry, false, stores, 'extension');
+    assert.equal(workspaceState.has(entry.key), true);
+    assert.equal(config.has(entry.key), false);
+    assert.equal(readSetting(entry, stores, 'extension'), false);
+  });
+
+  it('routes CLI writes to the cliStore override (config)', async () => {
+    const { stores, config, workspaceState } = makeStores();
+    const entry = entryByKey(WorkspaceStateKey.GIT_MARK_COMMITS);
+    await writeSetting(entry, false, stores, 'cli');
+    assert.equal(config.has(entry.key), true);
+    assert.equal(workspaceState.has(entry.key), false);
+    assert.equal(config.lastTarget, 'workspace');
+    assert.equal(readSetting(entry, stores, 'cli'), false);
+  });
+
+  it('rejects values that fail the entry schema', async () => {
+    const { stores } = makeStores();
+    const entry = entryByKey(WorkspaceStateKey.LATEX_FORMATTER);
+    await assert.rejects(() =>
+      writeSetting(entry, 'not-a-formatter', stores, 'extension'),
+    );
+  });
+
+  it('reset deletes the key so the default reappears', async () => {
+    const { stores, workspaceState } = makeStores();
+    const entry = entryByKey(WorkspaceStateKey.LATEXDIFF_CHANGES_ONLY);
+    await writeSetting(entry, false, stores, 'extension');
+    assert.equal(workspaceState.has(entry.key), true);
+    await resetSetting(entry, stores, 'extension');
+    assert.equal(workspaceState.has(entry.key), false);
+    assert.equal(
+      readSetting(entry, stores, 'extension'),
+      LATEX_CONFIG_DEFAULTS.latexdiffChangesOnly,
+    );
+  });
+
+  it('falls back to the default for a stored value that no longer validates', () => {
+    const { stores, workspaceState } = makeStores();
+    const entry = entryByKey(WorkspaceStateKey.LATEX_FORMATTER);
+    void workspaceState.update(entry.key, 'stale-bogus-value');
+    assert.equal(
+      readSetting(entry, stores, 'extension'),
+      LATEX_CONFIG_DEFAULTS.latexFormatter,
+    );
+  });
+});

--- a/src/test-kernel/shared/stateSettings.vitest.ts
+++ b/src/test-kernel/shared/stateSettings.vitest.ts
@@ -236,13 +236,22 @@ describe('state settings catalog', () => {
 });
 
 describe('knownKeys derivation', () => {
-  it('recognizes every catalog key (no unknown-key warnings)', () => {
-    for (const key of STATE_SETTING_KEYS) {
-      assert.ok(
-        KNOWN_TEXRA_KEYS.has(key),
-        `${key} missing from KNOWN_TEXRA_KEYS`,
+  it('recognizes config-slot CLI keys, but warns on state.json keys in config.json', () => {
+    for (const entry of CLI_STATE_SETTINGS) {
+      const readFromConfig = (entry.cliStore ?? entry.store) === 'config';
+      assert.equal(
+        KNOWN_TEXRA_KEYS.has(entry.key),
+        readFromConfig,
+        `${entry.key}: config-recognition should match read-from-config=${readFromConfig}`,
       );
     }
+    // A workspaceState-backed setting is read from state.json, not config.json,
+    // so it must NOT be whitelisted there (a config.json entry is a no-op the
+    // unknown-key warning should catch).
+    assert.equal(
+      KNOWN_TEXRA_KEYS.has(WorkspaceStateKey.WORKFLOW_AUTO_COMPILE),
+      false,
+    );
   });
 });
 
@@ -307,6 +316,16 @@ describe('settingsAccess', () => {
       readSetting(entry, stores, 'extension'),
       LATEX_CONFIG_DEFAULTS.latexdiffChangesOnly,
     );
+  });
+
+  it('reset deletes a config-slot (ConfigProvider) key too', async () => {
+    const { stores, config } = makeFakeSettingsStores();
+    const entry = entryByKey(WorkspaceStateKey.GIT_MARK_COMMITS);
+    await writeSetting(entry, false, stores, 'cli');
+    assert.equal(isStored(config, entry.key), true);
+    await resetSetting(entry, stores, 'cli');
+    assert.equal(isStored(config, entry.key), false);
+    assert.equal(readSetting(entry, stores, 'cli'), DEFAULT_GIT_MARK_COMMITS);
   });
 
   it('falls back to the default for a stored value that no longer validates', () => {

--- a/src/test-kernel/shared/stateSettings.vitest.ts
+++ b/src/test-kernel/shared/stateSettings.vitest.ts
@@ -6,10 +6,11 @@ import { describe, it } from 'vitest';
 
 // Local imports - catalog + accessor
 import { KNOWN_TEXRA_KEYS } from '@cli/schemas/knownKeys';
+import { CORE_SETTING_PATHS } from '@shared/schemas/coreSettings';
 import {
-  CLI_STATE_SETTING_KEYS,
   STATE_SETTINGS,
   STATE_SETTING_KEYS,
+  settingEnumOptions,
   type SettingStore,
   type StateSettingEntry,
 } from '@shared/schemas/stateSettings';
@@ -25,6 +26,7 @@ import {
   DEFAULT_GIT_AUTHOR_EMAIL,
   DEFAULT_GIT_AUTHOR_NAME,
   DEFAULT_GIT_MARK_COMMITS,
+  DEFAULT_GIT_WORKTREE_SUPPORT,
 } from '@shared/constants/git';
 import { LATEX_CONFIG_DEFAULTS } from '@shared/constants/latex';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
@@ -48,7 +50,7 @@ const EXPECTED_DEFAULTS: Record<string, unknown> = {
   [WorkspaceStateKey.GIT_MARK_COMMITS]: DEFAULT_GIT_MARK_COMMITS,
   [WorkspaceStateKey.GIT_AUTHOR_NAME]: DEFAULT_GIT_AUTHOR_NAME,
   [WorkspaceStateKey.GIT_AUTHOR_EMAIL]: DEFAULT_GIT_AUTHOR_EMAIL,
-  [WorkspaceStateKey.GIT_WORKTREE_SUPPORT]: false,
+  [WorkspaceStateKey.GIT_WORKTREE_SUPPORT]: DEFAULT_GIT_WORKTREE_SUPPORT,
   [WorkspaceStateKey.WORKFLOW_AUTO_COMPILE]:
     LATEX_CONFIG_DEFAULTS.workflowAutoCompile,
   [WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS]:
@@ -123,13 +125,14 @@ describe('state settings catalog', () => {
     }
   });
 
-  it('pairs enum entries with one description per value', () => {
+  it('pairs enum entries with one description per schema option', () => {
     for (const entry of STATE_SETTINGS) {
-      if (!entry.enumValues) {
+      const options = settingEnumOptions(entry);
+      if (!options) {
         assert.equal(
           entry.enumDescriptions,
           undefined,
-          `${entry.key} has enumDescriptions without enumValues`,
+          `${entry.key} has enumDescriptions without an enum schema`,
         );
         continue;
       }
@@ -137,10 +140,19 @@ describe('state settings catalog', () => {
         entry.enumDescriptions,
         `${entry.key} enum entry is missing enumDescriptions`,
       );
-      assert.equal(
-        entry.enumDescriptions?.length,
-        entry.enumValues.length,
-        entry.key,
+      assert.equal(entry.enumDescriptions?.length, options.length, entry.key);
+    }
+  });
+
+  it('shares no keys with the config-tree catalog', () => {
+    // The two catalogs must stay disjoint: a state-backed key must never reach
+    // the package.json generator via CoreSettingsShape, and a config key must
+    // never be double-registered through the catalog.
+    const coreKeys = new Set(CORE_SETTING_PATHS.map((path) => `texra.${path}`));
+    for (const key of STATE_SETTING_KEYS) {
+      assert.ok(
+        !coreKeys.has(key),
+        `${key} is in both CoreSettingsShape and STATE_SETTINGS`,
       );
     }
   });
@@ -167,12 +179,6 @@ describe('knownKeys derivation', () => {
         KNOWN_TEXRA_KEYS.has(key),
         `${key} missing from KNOWN_TEXRA_KEYS`,
       );
-    }
-  });
-
-  it('recognizes every CLI-consumed catalog key', () => {
-    for (const key of CLI_STATE_SETTING_KEYS) {
-      assert.ok(KNOWN_TEXRA_KEYS.has(key), key);
     }
   });
 });

--- a/src/test-kernel/support/settingsStoresFake.ts
+++ b/src/test-kernel/support/settingsStoresFake.ts
@@ -1,0 +1,41 @@
+// Shared fakes for exercising the host-aware `settingsAccess` accessor. Builds
+// the `SettingsStores` shape from the canonical platform fakes so the store
+// contract lives in one place (`FakePlatform.ts`) rather than being re-rolled
+// per suite.
+
+import type { SettingsStores } from '@shared/config/settingsAccess';
+
+import { FakeConfigProvider, FakeStateStore } from './FakePlatform';
+
+export interface FakeSettingsStores {
+  readonly stores: SettingsStores;
+  readonly config: FakeConfigProvider;
+  readonly workspaceState: FakeStateStore;
+  readonly globalState: FakeStateStore;
+}
+
+export function makeFakeSettingsStores(): FakeSettingsStores {
+  const config = new FakeConfigProvider();
+  const workspaceState = new FakeStateStore();
+  const globalState = new FakeStateStore();
+  return {
+    stores: { config, workspaceState, globalState },
+    config,
+    workspaceState,
+    globalState,
+  };
+}
+
+const ABSENT = Symbol('absent');
+
+/**
+ * Whether a key is present in a store. Works for both `ConfigProvider` and
+ * `StateStore` (neither exposes `has`) via a sentinel default, so reset/delete
+ * assertions can distinguish "deleted" from "wrote the literal default".
+ */
+export function isStored(
+  store: { get<T>(key: string, defaultValue?: T): T },
+  key: string,
+): boolean {
+  return store.get<unknown>(key, ABSENT) !== ABSENT;
+}

--- a/src/utils/system/gitAuthorSettings.ts
+++ b/src/utils/system/gitAuthorSettings.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_GIT_AUTHOR_EMAIL,
   DEFAULT_GIT_AUTHOR_NAME,
   DEFAULT_GIT_MARK_COMMITS,
+  DEFAULT_GIT_WORKTREE_SUPPORT,
 } from '@shared/constants/git';
 import { setWorktreeSupportEnabled } from '@tools/worktreeConfig';
 import { setGitAuthorEnv } from './gitAuthorEnv';
@@ -31,7 +32,7 @@ export function readGitAuthorSettingsFromState(
       DEFAULT_GIT_AUTHOR_EMAIL,
     worktreeSupport: workspaceState.get<boolean>(
       WorkspaceStateKey.GIT_WORKTREE_SUPPORT,
-      false,
+      DEFAULT_GIT_WORKTREE_SUPPORT,
     ),
   };
 }


### PR DESCRIPTION
## Why

A CLI `/config` panel risked overlapping with — and drifting from — the VS Code extension's settings. This makes the schema/catalog the single source of truth feeding the package.json generator, the new CLI `/config` panel, and the extension settings view, so the surfaces stay in sync instead of being hand-maintained in parallel.

Everything is in this one PR (6 commits), each independently reviewable.

## What

**Schema as SSOT for descriptions** — `description`/`enumDescriptions` move from hand-written package.json strings into Zod `.describe()`/`.meta()`, back-filled verbatim so the generator run is zero-diff. The generator allowlist now emits them; VS-Code-presentation fields (`scope`/`order`/`markdownDescription`/`editPresentation`) stay hand-maintained.

**State-backed settings catalog + host-aware accessor** — new `src/shared/schemas/stateSettings.ts` (metadata-only rows for WorkspaceState/GlobalState keys: git-author, workflow, latexdiff, formatter), kept separate from `CoreSettingsShape` so state keys never emit phantom VS Code config. New `src/shared/config/settingsAccess.ts` reads/writes/resets host-aware (`cliStore ?? store`); reset deletes the key so `.prefault()` reappears. The CLI unknown-key whitelist now derives from the catalog (deleted the hand-listed git keys).

**CLI `/config` panel** (user-visible → CHANGELOG) — a list + drill-in: booleans toggle inline, enums drill into a value picker, free-text is read-only for now. Each row shows its current value **and its store**. TUI-only — the headless `run`/`--print` path is unchanged.

**Extension re-point** — the LaTeXdiff math-markup and formatter dropdowns now source their options from the catalog instead of hand-listed arrays; displayed labels are byte-identical (locked by a test).

**Two `/simplify` passes** folded in — converged duplicated slot resolution, the CLI-roster predicate, and the `enum` value list (now derived from the schema via `.unwrap().options`); extracted shared write dispatch; gated `/config` registration so there's no inert path; single `DEFAULT_GIT_WORKTREE_SUPPORT`; reused the canonical platform test fakes; and added a guardrail that the config-tree and state-backed catalogs stay disjoint.

## Commits

1. Generate setting descriptions from schema metadata (SSOT)
2. Add state-backed settings catalog + host-aware accessor
3. Add `/config` settings panel to the CLI TUI
4. Simplify settings catalog/accessor and dedupe test fakes
5. Converge settings SSOT: derive enum/roster/slot, single defaults
6. Source LaTeX tab enum options from the shared catalog

## Test plan

- `npm run typecheck` clean across all four projects.
- `npm test` — 3852 pass (the one failing `execUtils` process-group-abort test is a pre-existing sandbox flake, fails identically on `main`).
- `npm run sync:settings-configuration --check` is zero-diff (proves `.describe()`/`.meta()` + `.prefault()` compose through `z.toJSONSchema()`).
- New guardrails: catalog consumer-exists, knownKeys derivation, store/scope coherence, Class-D exclusion, default round-trip vs the real getter constants, catalog disjointness, and a byte-for-byte lock on the extension's LaTeX dropdown labels.

## Not included (deliberate)

- Promoting the codex/claude/reasoning option arrays (AIAgentsTab/ModelsTab) into the catalog — those complex domains are excluded from the catalog by design (openForm delegation, no second consumer today), so moving them would be relocation without an SSOT win.
- Unifying the *access layer* across both catalogs (rerouting the extension/desktop getters through the accessor) and wiring CLI consumers for the workflow/latexdiff/formatter domains — additive follow-ups; the catalog + guardrails are ready for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CvUaexVbVkYzFUXpfgnSN

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how CLI and extension read/write git identity and workflow compile settings, with immediate git env re-application; scope is bounded by catalog guardrails and tests but still touches runtime config behavior.
> 
> **Overview**
> Adds a **`/config`** (alias **`/settings`**) panel in the CLI chat TUI so git-author and workflow auto-compile options can be viewed and edited without leaving the session. The panel is a list with drill-in: booleans toggle inline, enums use a picker, strings/numbers use an inline editor; each row shows the current value and which store backs it. Writes go through new host-aware **`settingsAccess`** helpers and **`cliSettingsStores`**; git-related changes call **`applyCliGitAuthorConfig`** so identity takes effect immediately.
> 
> Introduces **`stateSettings.ts`** as the catalog for state-backed keys (separate from VS Code config-tree **`CoreSettingsShape`**) plus **`CLI_STATE_SETTINGS`** for what the CLI actually surfaces. **`knownKeys`** for `.texra/config.json` now derives config-slot entries from that catalog instead of hand-listed git keys.
> 
> Moves setting **descriptions** and **enumDescriptions** into Zod **`.describe()`** / **`.meta()`** on **`coreSettings`** (and related schema plumbing) so package.json generation stays in sync. The extension LaTeX tab’s latexdiff math-markup and formatter dropdowns read enum options from the catalog instead of hard-coded arrays.
> 
> Adds focused tests for **`ConfigForm`**, catalog guardrails, and **`settingsAccess`** round-trips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 097d3e312a1f9ac17b37c1b9ec42a1d35aaeb3c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->