### PR TITLE
Redesign trust section with SVG icons and refined layout

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,18 +13,18 @@ import LandingCliStrip from './.vitepress/components/LandingCliStrip.vue';
 <section class="trust-row">
   <div class="trust-card">
     <span class="trust-icon">🔬</span>
-    <h3>Grounded, not generated</h3>
-    <p>Every citation comes from a real database. Every figure is compiled. Every edit lands as a diff you can read line by line.</p>
+    <h3>Output you can check</h3>
+    <p>Citations resolve to real database entries. Figures compile from source. Edits arrive as diffs you read line by line before they touch your files.</p>
   </div>
   <div class="trust-card">
     <span class="trust-icon">🧑‍🔬</span>
-    <h3>A team, not a chatbot</h3>
-    <p>One orchestrator decomposes the task and delegates to researchers, numericists, reviewers, and formalizers — each with its own tools and model.</p>
+    <h3>A team of specialist agents</h3>
+    <p>An orchestrator splits the task and hands the pieces to researchers, numericists, reviewers, and formalizers — each with its own tools and model.</p>
   </div>
   <div class="trust-card">
     <span class="trust-icon">🛡️</span>
-    <h3>Three levels of verification</h3>
-    <p>LLM prose, Wolfram algebra, and Lean 4 formal proof — connected in one environment for work where correctness is non-negotiable.</p>
+    <h3>Three independent checks</h3>
+    <p>Prose reviewed by an LLM, algebra checked in Wolfram, proofs verified in Lean 4 — three layers of verification in one environment.</p>
   </div>
 </section>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,21 +12,21 @@ import LandingCliStrip from './.vitepress/components/LandingCliStrip.vue';
 
 <section class="trust-row">
   <div class="trust-card">
-    <span class="trust-icon">
+    <span class="trust-icon" aria-hidden="true">
       <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><path d="m9 15 2 2 4-4"/></svg>
     </span>
     <h3>Output you can check</h3>
     <p>Citations resolve to real database entries. Figures compile from source. Edits arrive as diffs you read line by line before they touch your files.</p>
   </div>
   <div class="trust-card">
-    <span class="trust-icon">
+    <span class="trust-icon" aria-hidden="true">
       <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="5" r="2.5"/><circle cx="5" cy="18.5" r="2.5"/><circle cx="19" cy="18.5" r="2.5"/><path d="M12 7.5v3.5M12 11h-7v5M12 11h7v5"/></svg>
     </span>
     <h3>A team of specialist agents</h3>
     <p>An orchestrator splits the task and hands the pieces to researchers, numericists, reviewers, and formalizers — each with its own tools and model.</p>
   </div>
   <div class="trust-card">
-    <span class="trust-icon">
+    <span class="trust-icon" aria-hidden="true">
       <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>
     </span>
     <h3>Three independent checks</h3>
@@ -292,8 +292,8 @@ section p {
   height: 2.25rem;
   border-radius: 9px;
   margin-bottom: 0.8rem;
-  background: color-mix(in srgb, var(--vp-c-brand-1) 11%, transparent);
-  color: var(--vp-c-brand-1);
+  background: color-mix(in srgb, var(--vp-c-brand) 11%, transparent);
+  color: var(--vp-c-brand);
 }
 .trust-card h3 {
   margin: 0 0 0.4rem;

--- a/docs/index.md
+++ b/docs/index.md
@@ -269,45 +269,29 @@ section p {
 .trust-row {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 1.25rem;
-  margin-top: 1rem;
+  margin-top: 1.5rem;
+  padding-top: 1.75rem;
+  border-top: 1px solid var(--vp-c-divider);
 }
 .trust-card {
-  position: relative;
-  background: var(--vp-c-bg-soft);
-  border: 1px solid var(--vp-c-divider);
-  border-radius: 12px;
-  padding: 1.5rem;
-  transition: border-color 0.2s;
+  padding: 0 1.75rem;
+  border-left: 1px solid var(--vp-c-divider);
 }
-.trust-card::before {
-  content: '';
-  position: absolute;
-  inset: 0 0 auto 0;
-  height: 2px;
-  border-radius: 12px 12px 0 0;
-  background: linear-gradient(
-    90deg,
-    var(--vp-c-brand-1),
-    color-mix(in srgb, var(--vp-c-brand-1) 25%, transparent)
-  );
-  opacity: 0;
-  transition: opacity 0.2s;
+.trust-card:first-child {
+  padding-left: 0;
+  border-left: none;
 }
-.trust-card:hover {
-  border-color: color-mix(in srgb, var(--vp-c-brand-1) 45%, var(--vp-c-divider));
-}
-.trust-card:hover::before {
-  opacity: 1;
+.trust-card:last-child {
+  padding-right: 0;
 }
 .trust-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 10px;
-  margin-bottom: 0.9rem;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 9px;
+  margin-bottom: 0.8rem;
   background: color-mix(in srgb, var(--vp-c-brand-1) 11%, transparent);
   color: var(--vp-c-brand-1);
 }
@@ -678,7 +662,18 @@ section p {
   }
   .trust-row {
     grid-template-columns: 1fr;
-    gap: 1rem;
+  }
+  .trust-card {
+    padding: 1.25rem 0;
+    border-left: none;
+    border-top: 1px solid var(--vp-c-divider);
+  }
+  .trust-card:first-child {
+    padding-top: 0;
+    border-top: none;
+  }
+  .trust-card:last-child {
+    padding-bottom: 0;
   }
   .lifecycle {
     flex-wrap: wrap;

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,17 +12,23 @@ import LandingCliStrip from './.vitepress/components/LandingCliStrip.vue';
 
 <section class="trust-row">
   <div class="trust-card">
-    <span class="trust-icon">🔬</span>
+    <span class="trust-icon">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><path d="m9 15 2 2 4-4"/></svg>
+    </span>
     <h3>Output you can check</h3>
     <p>Citations resolve to real database entries. Figures compile from source. Edits arrive as diffs you read line by line before they touch your files.</p>
   </div>
   <div class="trust-card">
-    <span class="trust-icon">🧑‍🔬</span>
+    <span class="trust-icon">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="5" r="2.5"/><circle cx="5" cy="18.5" r="2.5"/><circle cx="19" cy="18.5" r="2.5"/><path d="M12 7.5v3.5M12 11h-7v5M12 11h7v5"/></svg>
+    </span>
     <h3>A team of specialist agents</h3>
     <p>An orchestrator splits the task and hands the pieces to researchers, numericists, reviewers, and formalizers — each with its own tools and model.</p>
   </div>
   <div class="trust-card">
-    <span class="trust-icon">🛡️</span>
+    <span class="trust-icon">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>
+    </span>
     <h3>Three independent checks</h3>
     <p>Prose reviewed by an LLM, algebra checked in Wolfram, proofs verified in Lean 4 — three layers of verification in one environment.</p>
   </div>
@@ -267,15 +273,43 @@ section p {
   margin-top: 1rem;
 }
 .trust-card {
+  position: relative;
   background: var(--vp-c-bg-soft);
   border: 1px solid var(--vp-c-divider);
   border-radius: 12px;
   padding: 1.5rem;
+  transition: border-color 0.2s;
+}
+.trust-card::before {
+  content: '';
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 2px;
+  border-radius: 12px 12px 0 0;
+  background: linear-gradient(
+    90deg,
+    var(--vp-c-brand-1),
+    color-mix(in srgb, var(--vp-c-brand-1) 25%, transparent)
+  );
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+.trust-card:hover {
+  border-color: color-mix(in srgb, var(--vp-c-brand-1) 45%, var(--vp-c-divider));
+}
+.trust-card:hover::before {
+  opacity: 1;
 }
 .trust-icon {
-  font-size: 1.6rem;
-  display: block;
-  margin-bottom: 0.6rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 10px;
+  margin-bottom: 0.9rem;
+  background: color-mix(in srgb, var(--vp-c-brand-1) 11%, transparent);
+  color: var(--vp-c-brand-1);
 }
 .trust-card h3 {
   margin: 0 0 0.4rem;


### PR DESCRIPTION
## Summary

Replaced emoji icons with custom SVG icons and restructured the trust section layout on the landing page. The cards now use a horizontal divider design with left borders instead of individual boxed cards, improving visual hierarchy and readability. Updated copy to be more concrete and action-oriented.

## Changes

### Content Updates
- **Icons**: Replaced emoji (🔬, 🧑‍🔬, 🛡️) with semantic SVG icons (document with checkmark, network diagram, shield with checkmark)
- **Headings**: Refined to be more specific:
  - "Grounded, not generated" → "Output you can check"
  - "A team, not a chatbot" → "A team of specialist agents"
  - "Three levels of verification" → "Three independent checks"
- **Descriptions**: Reworded for clarity and directness, emphasizing concrete verification mechanisms

### Layout & Styling
- Removed individual card backgrounds and borders; cards now use a cleaner horizontal layout
- Added top border to `.trust-row` as visual separator
- Changed card styling from boxed (padding, background, border-radius) to columnar (left borders, horizontal padding)
- First card removes left border; last card removes right padding for alignment
- Icon styling: Added background color with brand color at 11% opacity, centered flex layout, fixed dimensions (2.25rem), and rounded corners
- Responsive mobile layout: Converts to single-column with top borders between cards instead of left borders

## Issue acceptance gates

N/A — Documentation/landing page visual refresh.

## Single source of truth

Landing page documentation (`docs/index.md`) and its associated styles.

## Duplication and abstraction budget

No duplication introduced or removed. SVG icons are inlined in the template for direct control over styling and color inheritance.

## Host impact

Extension: None
Desktop: None
CLI: None

## Scheduled refactoring

None

## Validation

Visual inspection of rendered landing page. No automated tests required for documentation markup changes.

https://claude.ai/code/session_01Fc8cquSPe9kutHjibK4QwW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only markup and CSS on the VitePress home page; no product or runtime behavior changes.
> 
> **Overview**
> The landing page **trust row** is refreshed in `docs/index.md`: emoji icons become **inline SVGs** with `aria-hidden="true"`, and headings/body copy are tightened (e.g. “Output you can check”, “Three independent checks”).
> 
> **Layout/CSS** drops boxed cards (soft background, rounded borders, grid gap) for a **three-column divider** layout: top border on `.trust-row`, vertical separators between cards, and brand-tinted icon chips via `color-mix`. At **≤768px**, cards stack with **horizontal dividers** instead of left borders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c9109221332a924e17636548177f10d8ea46cf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->