### PR TITLE
fix(schemas): deduplicate TokenCountSchema, use .nullish() in tool input schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ packages/desktop/playwright-report/
 references/openrouter-skills/
 
 .pnpm-store/
+# CI checks out a private trusted-actions repo here at runtime; never commit it.
+.trusted-actions/

--- a/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
+++ b/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
@@ -208,7 +208,7 @@ async function nativeRequestApproval(
         originalContent,
         proposedContent,
         title,
-        streamId,
+        streamId: streamId ?? undefined,
         lineChanges,
         isSettled: () => settled,
         settle,
@@ -220,7 +220,7 @@ async function nativeRequestApproval(
       pendingApprovals.set(requestId, entry);
       // Register with the pure module for rejection tracking
       registerPendingApproval(requestId, {
-        streamId,
+        streamId: streamId ?? undefined,
         runtimeHost: getRuntimeHost(),
         isSettled: () => settled,
         settle,

--- a/src/agent/core/usage/RunUsageAccumulator.ts
+++ b/src/agent/core/usage/RunUsageAccumulator.ts
@@ -6,8 +6,7 @@ import {
   NormalizedUsageSchema,
   type NormalizedUsage,
 } from '@agent/types/NormalizedUsage';
-
-const TokenCountSchema = z.int().nonnegative();
+import { TokenCountSchema } from '@shared/schemas';
 
 /**
  * Schema for run usage totals. Internal only.

--- a/src/agent/types/NormalizedUsage.ts
+++ b/src/agent/types/NormalizedUsage.ts
@@ -4,9 +4,7 @@
  */
 import { z } from 'zod';
 
-import { TokenUsageStatsSchema } from '@shared/schemas';
-
-const TokenCountSchema = z.int().nonnegative();
+import { TokenCountSchema, TokenUsageStatsSchema } from '@shared/schemas';
 
 /** Provider identifiers for usage tracking. */
 export const UsageProviderSchema = z.enum([

--- a/src/shared/schemas/contextManagement.ts
+++ b/src/shared/schemas/contextManagement.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { TokenCountSchema } from './usage';
+
 export const ContextManagementAction = z.enum([
   'compaction',
   'clear_tool_uses',
@@ -9,7 +11,6 @@ export const ContextManagementAction = z.enum([
 ]);
 export type ContextManagementAction = z.infer<typeof ContextManagementAction>;
 
-const TokenCountSchema = z.int().nonnegative();
 const PositiveTokenCountSchema = z.int().positive();
 
 export const ContextManagementDataSchema = z.object({

--- a/src/shared/schemas/usage.ts
+++ b/src/shared/schemas/usage.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-const TokenCountSchema = z.int().nonnegative();
+export const TokenCountSchema = z.int().nonnegative();
 
 export const TokenUsageStatsSchema = z.strictObject({
   inputTokens: TokenCountSchema,

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -17,8 +17,8 @@ import { createStreamApprovalController } from './streamApprovalQueue';
 
 const BashApprovalRequestSchema = z.object({
   command: z.string(),
-  cwd: z.string().optional(),
-  streamId: StreamTabIdSchema.optional(),
+  cwd: z.string().nullish(),
+  streamId: StreamTabIdSchema.nullish(),
 });
 export type BashApprovalRequest = z.infer<typeof BashApprovalRequestSchema>;
 

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -31,7 +31,7 @@ const ToolEditApprovalRequestSchema = z.object({
   originalContent: z.string(),
   proposedContent: z.string(),
   sourceTool: z.string(),
-  streamId: StreamTabIdSchema.optional(),
+  streamId: StreamTabIdSchema.nullish(),
 });
 export type ToolEditApprovalRequest = z.infer<
   typeof ToolEditApprovalRequestSchema

--- a/src/tools/codexShared.ts
+++ b/src/tools/codexShared.ts
@@ -44,7 +44,7 @@ const CodexFileChangeItemSchema = z.object({
 
 export const CodexFileChangeToolInputSchema = z.object({
   changes: z.array(CodexFileChangeItemSchema),
-  patchStatus: z.string().optional(),
+  patchStatus: z.string().nullish(),
 });
 
 export type CodexFileChangeToolInput = z.infer<
@@ -83,7 +83,7 @@ type CodexTurnState = z.infer<typeof CodexTurnStateSchema>;
 
 export const CodexTurnToolInputSchema = z.object({
   state: CodexTurnStateSchema,
-  wallTimeMs: z.number().optional(),
+  wallTimeMs: z.number().nullish(),
 });
 
 export type CodexTurnToolInput = z.infer<typeof CodexTurnToolInputSchema>;


### PR DESCRIPTION
- Export TokenCountSchema from src/shared/schemas/usage.ts and import it in the three other modules instead of redefining it
- Replace .optional() with .nullish() on tool input schema fields in bashApproval.ts, codexShared.ts, and toolEditApproval.ts
- Fix type fallout from .nullish() in nativeToolEditApproval.ts

Closes #6603

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema deduplication and looser null handling on non-critical tool metadata fields; localized type fix in the extension approval UI.
> 
> **Overview**
> Centralizes **token count validation** by exporting `TokenCountSchema` from `src/shared/schemas/usage.ts` and reusing it in usage accumulation, normalized usage, and context-management schemas instead of four separate definitions.
> 
> Tool and approval **input parsing** now uses `.nullish()` (optional or `null`) on fields like `streamId`, `cwd`, `patchStatus`, and `wallTimeMs` so serialized tool payloads that send `null` validate consistently. The VS Code native tool-edit approval path normalizes `streamId` with `?? undefined` where downstream types expect `undefined` only.
> 
> Also adds **`.trusted-actions/`** to `.gitignore` for CI’s runtime checkout of a private actions repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51858e02c74cb963e34376a2150020c026df9e42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->