### PR TITLE
refactor: consolidate onto existing shared utilities (safeParseJson, unique, ensureError, toErrorMessage)

### DIFF
--- a/packages/cli/src/chat/tui/state/focusCycle.ts
+++ b/packages/cli/src/chat/tui/state/focusCycle.ts
@@ -11,6 +11,7 @@
 // shift over a letter to the unshifted Ctrl combo (see 10-architecture.md).
 
 import { type StreamTabId } from '@shared/schemas';
+import { unique } from '@utils/core';
 
 import { visibleSubagentRows } from './childExecutions';
 import { cliState, type StreamSlice } from './cliState';
@@ -28,7 +29,7 @@ function orderedDescendantsFromSlice(
   ]) {
     if (child.childStreamId) out.push(child.childStreamId);
   }
-  return [...new Set(out)];
+  return unique(out);
 }
 
 export function orderedDescendantsFromTree(init: {

--- a/packages/cli/src/runtime/workflowInputs.ts
+++ b/packages/cli/src/runtime/workflowInputs.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
 import { glob, hasMagic } from 'glob';
+import { unique } from '@utils/core';
 
 import { SHUTDOWN_PHASE } from '@platform/interfaces/lifecycle';
 import { tryPlatform } from '@platform/platform';
@@ -326,11 +327,11 @@ async function finishWorkflowInputExpansion(
     }
     expanded.push(...entry);
   }
-  const unique = [...new Set(expanded)];
-  if (unique.length === 0 && options.allowEmpty !== true) {
+  const deduped = unique(expanded);
+  if (deduped.length === 0 && options.allowEmpty !== true) {
     throw new CliUsageError('At least one workflow input file is required.');
   }
-  return unique;
+  return deduped;
 }
 
 /**

--- a/packages/extension/src/webview/frontend/fileDropHandler.ts
+++ b/packages/extension/src/webview/frontend/fileDropHandler.ts
@@ -1,5 +1,6 @@
 // Local imports - common webview
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
+import { unique } from '@utils/core';
 
 // Local imports - shared utilities
 import { postMessage } from '@shared/hostBridge';
@@ -200,7 +201,7 @@ export function postDroppedFiles(
   paths: string[],
   target?: MultipleDocumentFileType,
 ): boolean {
-  const uniquePaths = [...new Set(paths.filter(Boolean))];
+  const uniquePaths = unique(paths.filter(Boolean));
   if (uniquePaths.length === 0) return false;
 
   postMessage(MAIN_VIEW_COMMANDS.ATTACH_DROPPED_FILES, {

--- a/src/agent/core/flows/toolUseRound/toolCallParsing.ts
+++ b/src/agent/core/flows/toolUseRound/toolCallParsing.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import type { AgentTrace } from '@agent/trace';
 import type { SdkToolCall } from '@agent/modelHandlers/types/IModelHandler';
 import { toErrorMessage } from '@common/errors';
+import { safeParseJson } from '@common/parsing/safeParseJson';
 import {
   DIAGNOSTIC_TYPE_VALIDATION_ERROR,
   formatZodIssuesForDiagnostics,
@@ -52,14 +53,12 @@ export function parseToolInput(
     return raw;
   }
 
-  try {
-    return JSON.parse(raw);
-  } catch {
-    logger.debug(
-      `Tool call ${callId}: Failed to parse input as JSON, using raw string`,
-    );
+  const parsed = safeParseJson(raw);
+  if (!parsed.ok) {
+    logger.debug(`Tool call ${callId}: Failed to parse input as JSON, using raw string`);
     return raw;
   }
+  return parsed.value;
 }
 
 /** Normalize a tool call error into a user-friendly message with optional diagnostics. */

--- a/src/agent/core/flows/toolUseRound/toolCallParsing.ts
+++ b/src/agent/core/flows/toolUseRound/toolCallParsing.ts
@@ -55,7 +55,9 @@ export function parseToolInput(
 
   const parsed = safeParseJson(raw);
   if (!parsed.ok) {
-    logger.debug(`Tool call ${callId}: Failed to parse input as JSON, using raw string`);
+    logger.debug(
+      `Tool call ${callId}: Failed to parse input as JSON, using raw string`,
+    );
     return raw;
   }
   return parsed.value;

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -39,7 +39,8 @@ import type { FileLocation } from '@shared/schemas';
 import type { ToolFileAttachment } from '@shared/schemas/toolResult';
 
 // Local imports - utils
-import { delay, isNonEmptyString } from '@utils/core';
+import { delay, isNonEmptyString, isObject } from '@utils/core';
+import { safeParseJson } from '@common/parsing/safeParseJson';
 import { flexibleFS, getShortDisplayPath } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
 import { joinNonEmpty, pluralize } from '@utils/text/stringUtils';
@@ -2145,17 +2146,14 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
 
   private parseArguments(buffer: string): Record<string, unknown> {
     if (!buffer) return {};
-    try {
-      const parsed = JSON.parse(buffer) as unknown;
-      return typeof parsed === 'object' && parsed !== null
-        ? (parsed as Record<string, unknown>)
-        : {};
-    } catch (error) {
+    const parsed = safeParseJson(buffer);
+    if (!parsed.ok) {
       this.logger.warn(
-        `Failed to parse streamed tool arguments: ${getSdkErrorMessage(error)}`,
+        `Failed to parse streamed tool arguments: ${getSdkErrorMessage(parsed.error)}`,
       );
       return {};
     }
+    return isObject(parsed.value) ? parsed.value : {};
   }
 
   // ===========================================================================

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -31,6 +31,7 @@ import {
   takeTail,
   PARTIAL_TEXT_TAIL_MAX,
 } from '@common/errors/sdkErrorUtils';
+import { safeParseJson } from '@common/parsing/safeParseJson';
 import type { ToolDefinition } from '@model';
 import replacementEngine from '@replacement/engine';
 
@@ -40,7 +41,6 @@ import type { ToolFileAttachment } from '@shared/schemas/toolResult';
 
 // Local imports - utils
 import { delay, isNonEmptyString, isObject } from '@utils/core';
-import { safeParseJson } from '@common/parsing/safeParseJson';
 import { flexibleFS, getShortDisplayPath } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
 import { joinNonEmpty, pluralize } from '@utils/text/stringUtils';

--- a/src/agent/modelHandlers/utils/parseArguments.ts
+++ b/src/agent/modelHandlers/utils/parseArguments.ts
@@ -1,4 +1,5 @@
 import type { AgentTrace } from '@agent/trace';
+import { safeParseJson } from '@common/parsing/safeParseJson';
 
 /**
  * Safely parse tool call arguments from raw string to object.
@@ -9,13 +10,13 @@ export function parseToolArguments(raw: unknown, logger: AgentTrace): unknown {
     return raw;
   }
 
-  try {
-    return JSON.parse(raw);
-  } catch (error) {
+  const parsed = safeParseJson(raw);
+  if (!parsed.ok) {
     logger.warn(
       'Tool call arguments could not be parsed as JSON; using raw string.',
-      { data: error },
+      { data: parsed.error },
     );
     return raw;
   }
+  return parsed.value;
 }

--- a/src/latex/latexdiff/outputDiscovery.ts
+++ b/src/latex/latexdiff/outputDiscovery.ts
@@ -16,7 +16,7 @@ import {
   parseWorkflowOutputRoundDir,
 } from '@agent/output/workflowOutputLayout';
 import { getStreamTabId } from '@agent/runtime/streamTab';
-import { isFileNotFoundError } from '@common/errors';
+import { isFileNotFoundError, toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import type {
   ExecutionId,
@@ -201,7 +201,7 @@ export async function scanRunDirForOutputs(
   } catch (error) {
     logger.debug(
       CHANNEL,
-      `RunDir scan for ${executionId} failed: ${String(error)}`,
+      `RunDir scan for ${executionId} failed: ${toErrorMessage(error)}`,
     );
     return null;
   }
@@ -254,7 +254,7 @@ export async function discoverLatestExecutionOutputs(query: {
   } catch (error) {
     logger.debug(
       CHANNEL,
-      `Metadata-driven latexdiff discovery failed: ${String(error)}`,
+      `Metadata-driven latexdiff discovery failed: ${toErrorMessage(error)}`,
     );
   }
   return null;

--- a/src/tools/lean/LoogleTool.ts
+++ b/src/tools/lean/LoogleTool.ts
@@ -151,9 +151,7 @@ Useful for finding the right lemma when you know roughly what type it should hav
             .json<unknown>();
         } catch (error: unknown) {
           if (isTransientHttpError(error)) throw error;
-          throw new AbortError(
-            ensureError(error),
-          );
+          throw new AbortError(ensureError(error));
         }
         // Validate the body at the boundary. A malformed shape is not transient,
         // so abort retries and let executeSingle surface it as a tool error.

--- a/src/tools/lean/LoogleTool.ts
+++ b/src/tools/lean/LoogleTool.ts
@@ -8,7 +8,7 @@ import ky from 'ky';
 import pRetry, { AbortError } from 'p-retry';
 import { z } from 'zod';
 
-import { toErrorMessage } from '@common/errors';
+import { ensureError, toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { ToolResult } from '@shared/schemas/toolResult';
 import { isTimeoutError, isTransientHttpError } from '@tools/timeouts';
@@ -152,7 +152,7 @@ Useful for finding the right lemma when you know roughly what type it should hav
         } catch (error: unknown) {
           if (isTransientHttpError(error)) throw error;
           throw new AbortError(
-            error instanceof Error ? error : new Error(String(error)),
+            ensureError(error),
           );
         }
         // Validate the body at the boundary. A malformed shape is not transient,

--- a/src/tools/web/WebFetchTool.ts
+++ b/src/tools/web/WebFetchTool.ts
@@ -8,7 +8,7 @@ import TurndownService from 'turndown';
 import { z } from 'zod';
 
 // Local imports - core
-import { toErrorMessage } from '@common/errors';
+import { ensureError, toErrorMessage } from '@common/errors';
 import { ToolError, ToolResult } from '@shared/schemas/toolResult';
 import { isTimeoutError, isTransientHttpError } from '@tools/timeouts';
 import { defineTool } from '@tools/core/define';
@@ -144,7 +144,7 @@ export class WebFetchTool extends defineTool({
           } catch (error: unknown) {
             if (isTransientHttpError(error)) throw error;
             throw new AbortError(
-              error instanceof Error ? error : new Error(String(error)),
+              ensureError(error),
             );
           }
 

--- a/src/tools/web/WebFetchTool.ts
+++ b/src/tools/web/WebFetchTool.ts
@@ -143,9 +143,7 @@ export class WebFetchTool extends defineTool({
             });
           } catch (error: unknown) {
             if (isTransientHttpError(error)) throw error;
-            throw new AbortError(
-              ensureError(error),
-            );
+            throw new AbortError(ensureError(error));
           }
 
           const lengthHeader = response.headers.get('content-length');

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -73,9 +73,7 @@ export class WebSearchTool extends defineTool({
             return (await response.json()) as DuckDuckGoResponse;
           } catch (error: unknown) {
             if (isTransientHttpError(error)) throw error;
-            throw new AbortError(
-              ensureError(error),
-            );
+            throw new AbortError(ensureError(error));
           }
         },
         { retries: DDG_RETRIES, minTimeout: 500, randomize: true },

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -4,7 +4,7 @@ import pRetry, { AbortError } from 'p-retry';
 import { z } from 'zod';
 
 // Internal imports
-import { toErrorMessage } from '@common/errors';
+import { ensureError, toErrorMessage } from '@common/errors';
 import { ToolError, ToolResult } from '@shared/schemas/toolResult';
 import { isTimeoutError, isTransientHttpError } from '@tools/timeouts';
 import { defineTool } from '@tools/core/define';
@@ -74,7 +74,7 @@ export class WebSearchTool extends defineTool({
           } catch (error: unknown) {
             if (isTransientHttpError(error)) throw error;
             throw new AbortError(
-              error instanceof Error ? error : new Error(String(error)),
+              ensureError(error),
             );
           }
         },


### PR DESCRIPTION
## Summary

Mechanical consolidation of repeated patterns onto utilities that **already existed** in the codebase but weren't being used consistently. No new abstractions are introduced. Four independent refactors across 10 files:

### 1. `JSON.parse` try/catch → `safeParseJson()` (`@common/parsing/safeParseJson`)

- `src/agent/modelHandlers/utils/parseArguments.ts` — `parseToolArguments`
- `src/agent/core/flows/toolUseRound/toolCallParsing.ts` — `parseToolInput`
- `src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts` — `parseArguments` (also adopts the existing `isObject` guard)

`safeParseJson` returns `Result<unknown, Error>`, so the error passed to logger warnings is now typed `Error` rather than `unknown`. Fallback return values (`raw` string / `{}`) and log message text are preserved.

### 2. `[...new Set(arr)]` → `unique()` (`@utils/core`)

- `packages/cli/src/chat/tui/state/focusCycle.ts`
- `packages/cli/src/runtime/workflowInputs.ts` (local var renamed `unique` → `deduped` to avoid shadowing the import)
- `packages/extension/src/webview/frontend/fileDropHandler.ts`

`unique()` is defined as `[...new Set(iterable)]` — an exact, order-preserving equivalent.

### 3. `String(error)` → `toErrorMessage()` (`@common/errors`)

- `src/latex/latexdiff/outputDiscovery.ts` (two debug-log sites)

### 4. `error instanceof Error ? error : new Error(String(error))` → `ensureError()` (`@common/errors`)

- `src/tools/web/WebFetchTool.ts`
- `src/tools/web/WebSearchTool.ts`
- `src/tools/lean/LoogleTool.ts`

`ensureError` is `err instanceof Error ? err : new Error(toErrorMessage(err))` — the checklist's preferred form, equivalent to the inlined ternaries it replaces.

## Behavioral notes (no observable change in practice)

- **`isObject` array narrowing** (`modelHandlerGoogleInteractions.ts`): the old guard `typeof parsed === 'object' && parsed !== null` admitted top-level JSON arrays; `isObject()` additionally rejects arrays (`!Array.isArray`). A top-level array would now fall back to `{}` instead of being mis-cast as `Record<string, unknown>`. This is unreachable for Google streaming function-call arguments (always objects) and is strictly more faithful to the declared return type — but it is a type-level behavior change, not a pure swap.
- **`toErrorMessage` log format** (`outputDiscovery.ts`): for `Error` instances, `String(err)` yields `"Error: msg"` while `toErrorMessage(err)` yields `"msg"`. Cosmetic change to debug-log output only; identical for non-Error thrown values.

## Test plan

- [x] `npm run compile:fast` — clean build
- [x] `npm test` — 3860/3868 tests pass (1 pre-existing environment flake in `execUtils.vitest.ts` process-abort timing, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNWpg2TKQw87AddDkS2o9v