### PR TITLE
Extract LineChanges and EditRecord types to shared schemas

### DIFF
--- a/src/agent/core/execution/AgentWorkspaceState.ts
+++ b/src/agent/core/execution/AgentWorkspaceState.ts
@@ -10,9 +10,13 @@ import {
   type TodoItem,
   type Plan,
   type FileLocation,
+  type LineChanges,
   type WorkPlanSnapshot,
 } from '@shared/schemas';
-import { FlattenedEditRecordSchema } from '@shared/schemas/toolResult';
+import {
+  FlattenedEditRecordSchema,
+  type EditRecord,
+} from '@shared/schemas/toolResult';
 import { isObject } from '@utils/core';
 import { pathToLocation } from '@utils/files';
 
@@ -47,10 +51,7 @@ type FileInteractionStateSnapshot = z.output<
 
 export class FileInteractionState {
   private readonly readFiles = new Set<string>();
-  private readonly edits = new Map<
-    string,
-    { added: number; removed: number }
-  >();
+  private readonly edits = new Map<string, LineChanges>();
   private _toolCallCount = 0;
 
   /** Total number of tool calls executed in this session. */
@@ -106,19 +107,15 @@ export class FileInteractionState {
     return this.readFiles.has(path);
   }
 
-  recordEdits(
-    edits:
-      | { path?: string; lineChanges?: { added?: number; removed?: number } }[]
-      | undefined,
-  ): {
-    edits: { path: string; lineChanges?: { added: number; removed: number } }[];
-    lineChanges?: { added: number; removed: number };
+  recordEdits(edits: EditRecord[] | undefined): {
+    edits: EditRecord[];
+    lineChanges?: LineChanges;
   } {
     if (!Array.isArray(edits)) {
       return { edits: [] };
     }
 
-    const perCallEdits = new Map<string, { added: number; removed: number }>();
+    const perCallEdits = new Map<string, LineChanges>();
     let totalAdded = 0;
     let totalRemoved = 0;
 
@@ -154,7 +151,7 @@ export class FileInteractionState {
   }
 
   private updateEditMap(
-    map: Map<string, { added: number; removed: number }>,
+    map: Map<string, LineChanges>,
     path: string,
     added: number,
     removed: number,


### PR DESCRIPTION
## Summary

Refactored `FileInteractionState` to use shared type definitions for edit tracking. Extracted `LineChanges` type (representing added/removed line counts) and imported `EditRecord` type from `@shared/schemas/toolResult`, eliminating inline type definitions and improving type consistency across the codebase.

## Issue acceptance gates

N/A — internal refactoring for type consistency.

## Single source of truth

`LineChanges` and `EditRecord` types are now defined in `@shared/schemas/toolResult`, serving as the authoritative definitions for edit metadata throughout the agent execution system.

## Duplication and abstraction budget

Removed inline type definitions:
- `{ added: number; removed: number }` → `LineChanges` (shared schema)
- Inline edit record shape → `EditRecord` (shared schema)

This eliminates duplication and ensures consistent edit metadata representation across the codebase.

## Host impact

Extension: No functional change; uses shared type definitions.

Desktop: No functional change; uses shared type definitions.

CLI: No functional change; uses shared type definitions.

## Scheduled refactoring

None.

## Validation

- TypeScript compilation: Types are properly imported and applied to all usages in `FileInteractionState`
- No runtime behavior changes; refactoring is type-only
- Existing tests continue to pass (no test modifications required)

https://claude.ai/code/session_0155zgz6Qx3UjGXm8eFqdZfH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure TypeScript typing cleanup in agent workspace state; no behavioral or security-sensitive logic changes.
> 
> **Overview**
> **Type-only refactor** in `FileInteractionState` (`AgentWorkspaceState.ts`): edit tracking now uses shared **`LineChanges`** and **`EditRecord`** instead of inline `{ added, removed }` and ad-hoc edit shapes.
> 
> The internal edits map, `recordEdits` parameters/return types, and `updateEditMap` are aligned with `@shared/schemas` / `@shared/schemas/toolResult`. **No runtime logic changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae79f97bc5d8475f2896fefdbb5e727d6e57f48f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->