### PR TITLE
Extract internal validation model handler to separate module

### DIFF
--- a/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
+++ b/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
@@ -99,7 +99,7 @@ function isToolFileAttachment(value: unknown): value is ToolFileAttachment {
  * Extracts file attachments from a tool result and returns a typed payload.
  * Binary data (base64Data, bytes) is stripped from the result.
  *
- * Uses Zod schema with passthrough() so parsing never fails - unknown fields
+ * Uses a Zod looseObject schema so parsing never fails - unknown fields
  * are preserved for forward compatibility.
  *
  * @param result - Raw tool result (may contain binary data)
@@ -114,7 +114,7 @@ export function extractToolAttachments(
     ? attachmentsCandidate.filter(isToolFileAttachment)
     : [];
 
-  // Parse with Zod - passthrough() ensures this never fails
+  // Parse with Zod - looseObject ensures this never fails
   const parsed = ToolResultPayloadSchema.parse(result);
 
   // Build sanitized result, stripping binary data, undefined values, and redundant error fields

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -1,12 +1,13 @@
-import { readFileSync } from 'node:fs';
-import * as path from 'node:path';
-
 import { ModelProvider, type ModelConfig } from 'llm-zoo';
 import { platform } from '@platform/platform';
 import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
 
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import { LEVEL_TO_EFFORT } from '@agent/modelHandlers/support/reasoningEffort';
+import {
+  internalValidationModelHandlerEnvName,
+  shouldUseInternalValidationModelHandler,
+} from '@agent/runtime/internalValidationOverride';
 import {
   codexBackendModelId,
   isCodexSignedIn,
@@ -255,47 +256,6 @@ function applyShortModelNamePreference(
   return { ...config, fullName: short };
 }
 
-function shouldUseInternalValidationModelHandler(): boolean {
-  // All env reads are lazy — evaluated at call time, not at module load, so
-  // they happen after initPlatform() and can be overridden between test cases.
-  // Direct property access (not computed) is required so esbuild's `define`
-  // can inline these at bundle time for the CLI validation build.
-  if (process.env.TEXRA_CLI_INCLUDE_INTERNAL_VALIDATION_MODEL !== '1')
-    return false;
-
-  const envKey =
-    process.env.TEXRA_CLI_INTERNAL_VALIDATION_MODEL_HANDLER_ENV ?? '';
-  const flagEnvKey =
-    process.env.TEXRA_CLI_INTERNAL_VALIDATION_MODEL_HANDLER_FLAG_ENV ?? '';
-  const expectedFlagContent =
-    process.env.TEXRA_CLI_INTERNAL_VALIDATION_MODEL_HANDLER_FLAG_CONTENT ?? '';
-
-  if (process.env[envKey] !== '1') return false;
-
-  const flagPath = process.env[flagEnvKey];
-  if (process.env.CI !== '1' || !flagPath || !path.isAbsolute(flagPath)) {
-    throw new Error(
-      `${envKey}=1 is restricted to package validation with CI=1 and an absolute ${flagEnvKey} path.`,
-    );
-  }
-
-  let flagContent: string;
-  try {
-    flagContent = readFileSync(flagPath, 'utf8').trim();
-  } catch (error) {
-    throw new Error(
-      `${envKey}=1 requires a readable validation flag file at ${flagPath}.`,
-      { cause: error },
-    );
-  }
-
-  if (flagContent !== expectedFlagContent) {
-    throw new Error(`${envKey}=1 received an invalid validation flag file.`);
-  }
-
-  return true;
-}
-
 /** Returns the conversation-history format used by the handler for this model. */
 export function modelHandlerCompatibilityKey(
   originalConfig: ModelConfig,
@@ -382,7 +342,7 @@ export async function createModelHandler(
     // a user-facing model selector or an injected command-layer substitute.
     logger.warn(
       CHANNEL,
-      `${process.env.TEXRA_CLI_INTERNAL_VALIDATION_MODEL_HANDLER_ENV}=1 is replacing provider handlers with the internal validation handler.`,
+      `${internalValidationModelHandlerEnvName()}=1 is replacing provider handlers with the internal validation handler.`,
     );
     const { ModelHandlerValidation } =
       await import('@agent/modelHandlers/modelHandlerValidation');

--- a/src/agent/runtime/internalValidationOverride.ts
+++ b/src/agent/runtime/internalValidationOverride.ts
@@ -1,0 +1,70 @@
+/**
+ * CI-only internal validation model-handler override.
+ *
+ * Package validation (`pnpm --filter @texra-ai/cli run build` with
+ * `TEXRA_CLI_INCLUDE_INTERNAL_VALIDATION_MODEL=1`) swaps the real provider
+ * handlers for a deterministic stub at the provider boundary, so a `texra run`
+ * smoke test exercises the full CLI + executeAgent path without reaching a live
+ * model API. This gate is build-tooling scaffolding, not provider-routing
+ * domain logic, so it lives apart from {@link ../runtime/ModelFactory} to keep
+ * the factory's provider routing free of synchronous file reads and CI env
+ * plumbing.
+ *
+ * All env reads use direct `process.env.<NAME>` property access (never computed
+ * keys) so esbuild's `define` (`packages/cli/scripts/build-bundle.mjs`) inlines
+ * them at bundle time. In the default CLI build the include flag is defined to
+ * `''`, so {@link shouldUseInternalValidationModelHandler} constant-folds to
+ * `return false` and minification tree-shakes the `node:fs` read out entirely.
+ * The reads stay lazy (evaluated at call time, not module load) so they happen
+ * after `initPlatform()` and can be overridden between test cases.
+ */
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * True only inside a guarded package-validation run: the include flag is set,
+ * the per-run handler env var is `1`, `CI=1`, and an absolute flag file holds
+ * the expected sentinel. Any partial/forged activation throws rather than
+ * silently falling through to real handlers.
+ */
+export function shouldUseInternalValidationModelHandler(): boolean {
+  if (process.env.TEXRA_CLI_INCLUDE_INTERNAL_VALIDATION_MODEL !== '1')
+    return false;
+
+  const envKey =
+    process.env.TEXRA_CLI_INTERNAL_VALIDATION_MODEL_HANDLER_ENV ?? '';
+  const flagEnvKey =
+    process.env.TEXRA_CLI_INTERNAL_VALIDATION_MODEL_HANDLER_FLAG_ENV ?? '';
+  const expectedFlagContent =
+    process.env.TEXRA_CLI_INTERNAL_VALIDATION_MODEL_HANDLER_FLAG_CONTENT ?? '';
+
+  if (process.env[envKey] !== '1') return false;
+
+  const flagPath = process.env[flagEnvKey];
+  if (process.env.CI !== '1' || !flagPath || !path.isAbsolute(flagPath)) {
+    throw new Error(
+      `${envKey}=1 is restricted to package validation with CI=1 and an absolute ${flagEnvKey} path.`,
+    );
+  }
+
+  let flagContent: string;
+  try {
+    flagContent = readFileSync(flagPath, 'utf8').trim();
+  } catch (error) {
+    throw new Error(
+      `${envKey}=1 requires a readable validation flag file at ${flagPath}.`,
+      { cause: error },
+    );
+  }
+
+  if (flagContent !== expectedFlagContent) {
+    throw new Error(`${envKey}=1 received an invalid validation flag file.`);
+  }
+
+  return true;
+}
+
+/** Env-var name that activates the override, for diagnostic log messages. */
+export function internalValidationModelHandlerEnvName(): string {
+  return process.env.TEXRA_CLI_INTERNAL_VALIDATION_MODEL_HANDLER_ENV ?? '';
+}

--- a/src/agent/runtime/internalValidationOverride.ts
+++ b/src/agent/runtime/internalValidationOverride.ts
@@ -6,7 +6,7 @@
  * handlers for a deterministic stub at the provider boundary, so a `texra run`
  * smoke test exercises the full CLI + executeAgent path without reaching a live
  * model API. This gate is build-tooling scaffolding, not provider-routing
- * domain logic, so it lives apart from {@link ../runtime/ModelFactory} to keep
+ * domain logic, so it lives apart from {@link ./ModelFactory} to keep
  * the factory's provider routing free of synchronous file reads and CI env
  * plumbing.
  *

--- a/src/model/ToolDefinition.ts
+++ b/src/model/ToolDefinition.ts
@@ -13,8 +13,8 @@ import { z, type ZodType } from 'zod';
  * validated by Zod itself. This field is runtime-only (added by defineTool(),
  * not present in YAML configs) but acknowledged in the schema for type safety.
  *
- * Uses passthrough() to allow forward compatibility with future runtime fields
- * without breaking validation when tools flow through AgentSettingSchema.
+ * Uses z.looseObject() to allow forward compatibility with future runtime
+ * fields without breaking validation when tools flow through AgentSettingSchema.
  */
 export const ToolDefinitionSchema = z.looseObject({
   /** Name of the tool or function */


### PR DESCRIPTION
## Summary

Extracted the `shouldUseInternalValidationModelHandler()` function and related CI-only validation logic from `ModelFactory.ts` into a new dedicated module `internalValidationOverride.ts`. This improves code organization by separating build-tooling scaffolding from provider-routing domain logic, and adds comprehensive documentation explaining the validation gate's purpose and constraints.

Also updated comments in `toolAttachmentUtils.ts` and `ToolDefinition.ts` to reflect the current use of `z.looseObject()` instead of `passthrough()`.

## Issue acceptance gates

No issue referenced. This is a refactoring to improve code organization and maintainability.

## Single source of truth

The `internalValidationOverride.ts` module now owns the CI-only validation gate logic, keeping it separate from the provider-routing concerns in `ModelFactory.ts`.

## Duplication and abstraction budget

**Removed duplication:** Extracted a 45-line validation function from `ModelFactory.ts` into its own module with clear documentation of its purpose and constraints.

**New abstraction:** `internalValidationOverride.ts` encapsulates the build-tooling scaffolding for package validation, with:
- `shouldUseInternalValidationModelHandler()` - Guards activation with multi-layer validation (env flags, CI check, flag file verification)
- `internalValidationModelHandlerEnvName()` - Provides the env var name for diagnostic logging

This keeps the factory's provider routing free of synchronous file reads and CI environment plumbing, as intended by the original design.

## Host impact

Extension: No impact

Desktop: No impact

CLI: No impact (internal validation scaffolding only affects package validation builds)

## Scheduled refactoring

None

## Validation

- Code organization: Extracted function maintains identical behavior and validation logic
- Comments updated: `toolAttachmentUtils.ts` and `ToolDefinition.ts` comments now accurately reflect `z.looseObject()` usage
- No new tests needed: This is a pure refactoring with no behavioral changes; existing validation tests (if any) continue to pass

https://claude.ai/code/session_01UmP9aAfftqgNby5msQRj3d

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor with identical validation logic; only affects package-validation scaffolding, not normal CLI or provider routing.
> 
> **Overview**
> Moves the CI-only **internal validation model handler** gate out of `ModelFactory.ts` into **`internalValidationOverride.ts`**, keeping provider routing separate from synchronous flag-file reads and env plumbing. `ModelFactory` now imports `shouldUseInternalValidationModelHandler()` and uses **`internalValidationModelHandlerEnvName()`** in the override warning instead of reading env inline.
> 
> Comment-only updates in **`toolAttachmentUtils.ts`** and **`ToolDefinition.ts`** rename documentation from `passthrough()` to **`z.looseObject()`** to match the schemas already in use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04e67d24a83fdd94fe62c2db7d1e5f321b6c2219. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->