### PR TITLE
Extract UI glyphs to centralized constants

### DIFF
--- a/packages/cli/src/chat/tui/panes/EntryErrorBoundary.tsx
+++ b/packages/cli/src/chat/tui/panes/EntryErrorBoundary.tsx
@@ -17,6 +17,8 @@ import { Component, type ReactNode } from 'react';
 import { toErrorMessage } from '@common/errors';
 import * as logUtils from '@logger/logUtils';
 
+import { WARNING } from '../ui/glyphs';
+
 interface EntryErrorBoundaryProps {
   // Names the failed entry in the inline marker and the log line (e.g. its
   // role or "session header"). Falls back to "entry" when omitted.
@@ -78,7 +80,7 @@ export class EntryErrorBoundary extends Component<
     return (
       <Box paddingX={1}>
         <Text color="red" dimColor>
-          {`⚠ failed to render ${this.props.label ?? 'entry'}${detail ? `: ${detail}` : ''}`}
+          {`${WARNING} failed to render ${this.props.label ?? 'entry'}${detail ? `: ${detail}` : ''}`}
         </Text>
       </Box>
     );

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -29,6 +29,7 @@ import {
 
 import { truncateSummaryToWidth } from '../render/terminalText';
 import { formatCliStatusLabel } from '../sessionStatus';
+import { STATUS_DIAMOND } from '../ui/glyphs';
 import {
   approvalQueueStatus,
   type ApprovalQueueStatusKind,
@@ -658,7 +659,7 @@ export function buildStatusBarDisplay(
   input: StatusBarDisplayInput,
 ): StatusBarDisplay {
   const left: StatusBarSegment[] = [
-    { text: '◆', color: 'cyan', decorative: true },
+    { text: STATUS_DIAMOND, color: 'cyan', decorative: true },
   ];
 
   if (input.pendingExitHint) {

--- a/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
@@ -13,18 +13,19 @@ import {
 
 import { cliState } from '../state/cliState';
 import { useSignal } from '../state/useSignal';
+import { TODO_ACTIVE, TODO_DONE, TODO_PENDING } from '../ui/glyphs';
 
 // Marker glyph + color per todo status; statuses absent here (e.g. PENDING)
 // fall back to the default empty box with no color.
 const TODO_STATUS_DISPLAY: Partial<
   Record<TodoStatus, { marker: string; color: string }>
 > = {
-  [TODO_STATUS.COMPLETED]: { marker: '☑', color: 'green' },
-  [TODO_STATUS.IN_PROGRESS]: { marker: '☐', color: 'cyan' },
+  [TODO_STATUS.COMPLETED]: { marker: TODO_DONE, color: 'green' },
+  [TODO_STATUS.IN_PROGRESS]: { marker: TODO_ACTIVE, color: 'cyan' },
 };
 
 function todoMarker(status: TodoStatus): string {
-  return TODO_STATUS_DISPLAY[status]?.marker ?? '□';
+  return TODO_STATUS_DISPLAY[status]?.marker ?? TODO_PENDING;
 }
 
 function todoColor(status: TodoStatus): string | undefined {

--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -11,6 +11,11 @@ import { renderAnsiMarkdown } from '../render/ansiMarkdown';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
 import { fillRows } from '../render/terminalText';
 import { completedProcessDisplayLines } from '../state/completedProcessTranscript';
+import {
+  ERROR_ENTRY_PREFIX,
+  STATUS_DOT,
+  USER_ENTRY_PREFIX,
+} from '../ui/glyphs';
 import { isInquiryContinuationText } from './transcriptEntries';
 import { ToolUseRow } from './ToolUseRow';
 import { toolUseDisplayLines } from './toolRenderers';
@@ -27,7 +32,7 @@ export const PROCESS_ENTRY_MARGIN_BOTTOM_ROWS = 1;
 function prefixedWrappedLines(
   text: string,
   cols: number,
-  prefix = '› ',
+  prefix = USER_ENTRY_PREFIX,
 ): readonly string[] {
   const continuationPrefix = ' '.repeat(prefix.length);
   return wrapAnsiToWidth(text, Math.max(1, cols - prefix.length))
@@ -53,7 +58,7 @@ function displayRows({
 export function compactPrefixedDisplayRows({
   fillWidth,
   maxRows,
-  prefix = '› ',
+  prefix = USER_ENTRY_PREFIX,
   text,
   width,
 }: {
@@ -190,7 +195,7 @@ function ProcessEntryRow({
       flexDirection="column"
     >
       <Box>
-        <Text color={color}>● </Text>
+        <Text color={color}>{STATUS_DOT} </Text>
         <Text>{process.title}</Text>
         {process.status ? <Text dimColor>{` · ${process.status}`}</Text> : null}
         {process.elapsed ? (
@@ -447,7 +452,8 @@ export const BoundedTranscriptEntry = memo(function BoundedTranscriptEntry({
     );
   }
 
-  const prefix = entry.role === 'error' ? '! ' : '› ';
+  const prefix =
+    entry.role === 'error' ? ERROR_ENTRY_PREFIX : USER_ENTRY_PREFIX;
   const color = entry.role === 'error' ? 'red' : undefined;
   const cols = Math.max(1, Math.floor(width ?? 80) - 2);
   return (

--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -264,7 +264,7 @@ export const TranscriptEntry = memo(function TranscriptEntry({
           <Text color="red">
             {compactPrefixedDisplayRows({
               fillWidth,
-              prefix: '! ',
+              prefix: ERROR_ENTRY_PREFIX,
               text: entry.text,
               width: cols,
             })}

--- a/packages/cli/src/chat/tui/ui/glyphs.ts
+++ b/packages/cli/src/chat/tui/ui/glyphs.ts
@@ -16,3 +16,20 @@ export const TICK = '✓';
 
 /** Steady status dot for tool rows and subagent rows (never animated). */
 export const STATUS_DOT = '●';
+
+/** Decorative brand marker at the head of the status bar (aria-hidden). */
+export const STATUS_DIAMOND = '◆';
+
+/** Warning marker for inline failure notices (e.g. render-error fallback). */
+export const WARNING = '⚠';
+
+// Todo checklist markers. Completed / in-progress / pending (default).
+export const TODO_DONE = '☑';
+export const TODO_ACTIVE = '☐';
+export const TODO_PENDING = '□';
+
+/** Transcript row prefixes (trailing space included for the gutter). User and
+ *  assistant rows reuse the same chevron as selects (POINTER) so the look stays
+ *  consistent; error rows use a bang. */
+export const USER_ENTRY_PREFIX = `${POINTER} `;
+export const ERROR_ENTRY_PREFIX = '! ';

--- a/packages/cli/src/chat/tui/ui/glyphs.ts
+++ b/packages/cli/src/chat/tui/ui/glyphs.ts
@@ -28,8 +28,9 @@ export const TODO_DONE = '☑';
 export const TODO_ACTIVE = '☐';
 export const TODO_PENDING = '□';
 
-/** Transcript row prefixes (trailing space included for the gutter). User and
- *  assistant rows reuse the same chevron as selects (POINTER) so the look stays
- *  consistent; error rows use a bang. */
+/** Transcript row prefixes (trailing space included for the gutter). User rows
+ *  (and the default fallback) reuse the same chevron as selects (POINTER) so the
+ *  look stays consistent; error rows use a bang. Assistant rows carry no prefix
+ *  — they render as plain Markdown. */
 export const USER_ENTRY_PREFIX = `${POINTER} `;
 export const ERROR_ENTRY_PREFIX = '! ';


### PR DESCRIPTION
## Summary

Consolidates hardcoded UI glyphs (checkmarks, diamonds, warnings, todo markers, and entry prefixes) into a centralized `glyphs.ts` module. This improves maintainability by establishing a single source of truth for all decorative and functional symbols used throughout the TUI, making it easier to update visual styling consistently across the codebase.

## Issue acceptance gates

N/A — This is a refactoring to improve code organization and maintainability.

## Single source of truth

`packages/cli/src/chat/tui/ui/glyphs.ts` now owns all UI glyph definitions used across the TUI, including:
- Status indicators (`STATUS_DOT`, `STATUS_DIAMOND`)
- Warning markers (`WARNING`)
- Todo checklist states (`TODO_DONE`, `TODO_ACTIVE`, `TODO_PENDING`)
- Transcript entry prefixes (`USER_ENTRY_PREFIX`, `ERROR_ENTRY_PREFIX`)

## Duplication and abstraction budget

Removed hardcoded glyph strings from:
- `TranscriptEntry.tsx` (hardcoded `'› '` and `'! '` prefixes, `'● '` status dot)
- `TodosPlanPanel.tsx` (hardcoded `'☑'`, `'☐'`, `'□'` todo markers)
- `EntryErrorBoundary.tsx` (hardcoded `'⚠'` warning marker)
- `StatusBar.tsx` (hardcoded `'◆'` diamond marker)

All components now import from the centralized `glyphs.ts` module, eliminating duplication and establishing a clear contract for UI symbols.

## Host impact

CLI: Improves maintainability of TUI glyph usage; no behavioral changes.

## Scheduled refactoring

None.

## Validation

- No new tests required; this is a pure refactoring with no behavioral changes.
- Existing TUI rendering tests continue to pass (glyphs are now imported constants rather than inline strings).
- Manual verification: TUI renders identically before and after the change.

https://claude.ai/code/session_01G9AX1wyMn7ctoXvg1SFr3j

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic constant extraction only; no behavior, API, or security-sensitive paths touched.
> 
> **Overview**
> **Extends** `glyphs.ts` with shared symbols for the status bar (`STATUS_DIAMOND`), warnings (`WARNING`), todo rows (`TODO_DONE` / `TODO_ACTIVE` / `TODO_PENDING`), transcript gutters (`USER_ENTRY_PREFIX`, `ERROR_ENTRY_PREFIX`), and process headers (`STATUS_DOT`).
> 
> **Replaces** inline Unicode in `StatusBar`, `EntryErrorBoundary`, `TodosPlanPanel`, and `TranscriptEntry` with imports from that module. User transcript prefixes now use `USER_ENTRY_PREFIX` built from the existing `POINTER` chevron so list focus markers and user rows stay aligned.
> 
> No rendering or layout logic changes—symbols are the same characters, just defined once.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c73162717a727ffd3dc061cf573f39ada8c772d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->