### PR TITLE
refactor: extract withModelClient helper and remove empty-type flow-param aliases

### DIFF
--- a/docs/proposals/agent-sdk-readiness-checkpoint-2026-06-25.md
+++ b/docs/proposals/agent-sdk-readiness-checkpoint-2026-06-25.md
@@ -18,6 +18,33 @@ god-file mechanical split), this checkpoint confirms the existing findings are
 still accurate at HEAD and notes that the recommendations are **actively
 landing**.
 
+## Update (2026-06-25, applied) — the two open core cleanups landed
+
+A follow-up "check deeper and refactor" pass applied the two genuinely-safe,
+deliberately-deferred core cleanups from the 2026-06-24 delta. Both are
+behavior-neutral and verified (typecheck ×4 ✓, eslint ✓, 649 agent tests ✓):
+
+1. **Delta P3a — empty-type flow-param aliases removed.** Deleted the
+   `export type { FlowParams as ToolUseFlowParams }` / `… as ReflectionFlowParams`
+   re-export shims (`ToolUseServices.ts`, `ReflectionServices.ts`) and repointed
+   the 8 node generic slots directly at `FlowParams` from
+   `@agent/core/flows/BaseFlowServices`. Removes an anti-shim rename re-export the
+   repo convention flags; no distinct type information was lost (both aliased
+   `Record<string, unknown>`).
+2. **Delta P3b — `withModelClient` closure DRY, done the safe way.** The delta
+   deferred this because the obvious extraction (spread the helper's _result_ into
+   `setServices`) eagerly evaluates the `client` getter and **breaks the relay-401
+   live-rebinding**. The landed helper avoids that: `withModelClient(base,
+modelHandler)` defines the `client` getter + `refreshClient` on its **returned
+   literal**, and both call sites (`ResponseCycleNode`, `ToolUseCycleNode`) pass
+   the result straight to `flow.setServices(...)` — never spreading it — so the
+   getter stays live (the getter and `refreshClient` close over the same `client`
+   binding, exactly as the two former inline copies did). One home for the closure
+   instead of two; the `Node.exec → createFlow → flow.run` shape is untouched.
+
+The rest of this checkpoint is the original 2026-06-25 verification; the
+"genuinely open" list below now excludes the two items above.
+
 ## Verdict — unchanged
 
 **The codebase remains well-aligned and is converging on the plan.** The
@@ -30,14 +57,14 @@ relocation**, exactly as the canonical plan sequences it.
 
 ## Verified at HEAD (`b2dcd42`, 2026-06-25)
 
-| Audit claim                                              | Tree state                                                              | Result |
-| ------------------------------------------------------- | ---------------------------------------------------------------------- | ------ |
-| Step 5 — `@texra/core` populated (not the 1-line stub)  | `packages/core/src/index.ts` = 134 LOC curated surface                 | ✓      |
-| Step 1 — dead `getDefaultAgentRuntimeHost` singleton    | grep: zero hits in `src/`                                              | ✓      |
-| Delta P2b — dead `WorkspaceProvider.watch` port removed  | `src/platform/interfaces/workspace.ts`: no `watch`                     | ✓      |
-| Delta P1 — finalize-callback guard                       | `ResponseCycleFlow.ts:455-461` wraps `onRoundFinalized` in try/catch   | ✓      |
-| Delta P3a — empty-type flow-param aliases (deferred)     | still present in `ToolUseServices.ts:52` / `ReflectionServices.ts:38`  | open   |
-| Delta P3b — `withModelClient` closure duplication        | still duplicated in `ResponseCycleNode` / `ToolUseCycleNode`           | open   |
+| Audit claim                                             | Tree state                                                           | Result |
+| ------------------------------------------------------- | -------------------------------------------------------------------- | ------ |
+| Step 5 — `@texra/core` populated (not the 1-line stub)  | `packages/core/src/index.ts` = 134 LOC curated surface               | ✓      |
+| Step 1 — dead `getDefaultAgentRuntimeHost` singleton    | grep: zero hits in `src/`                                            | ✓      |
+| Delta P2b — dead `WorkspaceProvider.watch` port removed | `src/platform/interfaces/workspace.ts`: no `watch`                   | ✓      |
+| Delta P1 — finalize-callback guard                      | `ResponseCycleFlow.ts:455-461` wraps `onRoundFinalized` in try/catch | ✓      |
+| Delta P3a — empty-type flow-param aliases               | removed; 8 nodes use `FlowParams` directly (see Update above)        | landed |
+| Delta P3b — `withModelClient` closure duplication       | extracted to `CycleServices.withModelClient` (liveness-safe)         | landed |
 
 No drift: everything the audit marked LANDED is present; everything it marked
 deferred is still deferred. The audit is trustworthy as written.
@@ -47,33 +74,28 @@ deferred is still deferred. The audit is trustworthy as written.
 The plan is being executed, not just documented. Commits since the delta audit:
 
 - **`6cc6b20`** `refactor(agent,platform): harden round finalization; drop dead
-  workspace.watch port` — lands delta-audit **P1** + **P2b** verbatim.
+workspace.watch port` — lands delta-audit **P1** + **P2b** verbatim.
 - **`d32be3b`** + **`a15dd86`** `refactor/fix(executeAgent): extract per-category
-  flow runners from routing lambda` — lands the canonical proposal's
+flow runners from routing lambda` — lands the canonical proposal's
   **"cleanest internal seam"** subagent recommendation: stop threading the
   14-field launch context by spread; key each agent category to an explicit,
   typed per-flow runner. This is the structural pre-work for config-selected
   subagent delegates.
 - **`0e97b51`** `refactor: tighten two abstraction-layer boundaries`.
 - **`c17f4ce`** `refactor: dedupe model-handler prefill and guard core settings
-  paths`.
+paths`.
 - **`bd3b4b9`** `docs: reconcile stale Recommendation with second-pass Update`.
 
 ## What remains genuinely open (all deliberately deferred — do NOT apply unattended)
 
-These are the only open items, and the canonical/delta audits deferred each on
-purpose. None is a quick win; two carry verified regression risk.
+After the 2026-06-25 Update above (P3a + P3b landed), these are the only open
+items, and the canonical/delta audits deferred each on purpose. Neither is a
+quick win.
 
-1. **P3a — empty-type param aliases** (`ToolUseFlowParams` / `ReflectionFlowParams`):
-   cosmetic, low value. "Bundle only if touching these files anyway." (delta P3)
-2. **P3b — `withModelClient` closure DRY:** ⚠️ the duplicated closure exposes
-   `client` via a **getter with live rebinding** for the relay-401 token-refresh
-   path. Extracting + spreading evaluates the getter eagerly and **breaks
-   liveness** (silent auth-refresh regression). Not worth ~15 LOC. (delta Update)
-3. **Cross-provider user-message / media-block scaffold** (~150–250 LOC skeleton
+1. **Cross-provider user-message / media-block scaffold** (~150–250 LOC skeleton
    across the four handler families): real, but a tracked design item — the
    four-shape provider abstraction is justified and must survive. (delta "Track")
-4. **Surface / multi-tenant track:** the missing single SDK entry (streaming
+2. **Surface / multi-tenant track:** the missing single SDK entry (streaming
    `query()`-style handle) and per-session relocation of the remaining
    module-global registries — the canonical plan's Steps 6–7 / F-1 / F-2, already
    sequenced and partly landed (`SessionHandle`, `AgentRunHandle`). The
@@ -92,17 +114,32 @@ the per-run-handle state-isolation track.
 
 ## Recommendation
 
-**No new refactoring warranted at this time.** The audit is current, the
-recommendations are actively landing through a disciplined behavior-neutral PR
-train, and the only open items are deliberately deferred (two with verified
-regression risk). Continue executing the canonical plan's Steps 6–7 / surface
-track; do not re-open the adjudicated traps.
+**The two open core cleanups are now applied (see Update); no further core
+refactoring is warranted at this time.** The audit is current, its
+recommendations are landing through a disciplined behavior-neutral PR train, and
+the only remaining items are the two larger tracked design pieces (cross-provider
+message scaffold; surface / multi-tenant track). Continue executing the canonical
+plan's Steps 6–7 / surface track; do not re-open the adjudicated traps.
 
 ## Verified (this checkpoint)
 
 - `packages/core/src/index.ts` (line count), `src/platform/interfaces/workspace.ts`
   (no `watch`), `src/agent/core/flows/ResponseCycleFlow.ts:444-462` (finalize guard).
-- grep: `getDefaultAgentRuntimeHost` (empty), `ToolUseFlowParams`/`ReflectionFlowParams`
-  (present), `refreshClient` in both cycle wrapper nodes (present).
+- grep: `getDefaultAgentRuntimeHost` (empty); the `*FlowParams` aliases (now
+  removed) and the duplicated `refreshClient` closures (now centralized in
+  `CycleServices.withModelClient`).
 - `git log` since 2026-06-23 over `src/agent src/logger src/platform packages/core`
   (the landing commits cited above).
+
+## Verified (2026-06-25 applied pass)
+
+- `npm run typecheck` — exit 0 across all four projects (root, test-kernel,
+  `texra`, `@texra-ai/cli`).
+- `npx eslint` over the 11 touched files — 0 errors (import-order auto-fixed).
+- `npx vitest run src/test-kernel/agent` — 649 passed, 4 skipped (incl.
+  `ResponseCycleTools`, `ReflectionOutputLocation`, `ToolUseWaitNode`,
+  `ToolUseRoundFollowUpMedia`, `RetryState`).
+- Behavior-equivalence of `withModelClient`: the returned literal has the same
+  keys/values as the former inline `setServices` argument; the getter closes over
+  the same `client` variable `refreshClient` reassigns, and neither call site
+  spreads the result — liveness preserved.

--- a/docs/proposals/agent-sdk-readiness-checkpoint-2026-06-25.md
+++ b/docs/proposals/agent-sdk-readiness-checkpoint-2026-06-25.md
@@ -21,8 +21,12 @@ landing**.
 ## Update (2026-06-25, applied) — the two open core cleanups landed
 
 A follow-up "check deeper and refactor" pass applied the two genuinely-safe,
-deliberately-deferred core cleanups from the 2026-06-24 delta. Both are
-behavior-neutral and verified (typecheck ×4 ✓, eslint ✓, 649 agent tests ✓):
+deliberately-deferred core cleanups from the 2026-06-24 delta. **These two
+changes are introduced by this PR (#6620), not present at `b2dcd42`** — that SHA
+is the pre-refactor base the rest of this checkpoint verifies against, so a
+reader cross-referencing it will find the P3a/P3b diff in this PR's commit, not
+at `b2dcd42`. Both are behavior-neutral and verified (typecheck ×4 ✓, eslint ✓,
+649 agent tests ✓):
 
 1. **Delta P3a — empty-type flow-param aliases removed.** Deleted the
    `export type { FlowParams as ToolUseFlowParams }` / `… as ReflectionFlowParams`
@@ -57,17 +61,18 @@ relocation**, exactly as the canonical plan sequences it.
 
 ## Verified at HEAD (`b2dcd42`, 2026-06-25)
 
-| Audit claim                                             | Tree state                                                           | Result |
-| ------------------------------------------------------- | -------------------------------------------------------------------- | ------ |
-| Step 5 — `@texra/core` populated (not the 1-line stub)  | `packages/core/src/index.ts` = 134 LOC curated surface               | ✓      |
-| Step 1 — dead `getDefaultAgentRuntimeHost` singleton    | grep: zero hits in `src/`                                            | ✓      |
-| Delta P2b — dead `WorkspaceProvider.watch` port removed | `src/platform/interfaces/workspace.ts`: no `watch`                   | ✓      |
-| Delta P1 — finalize-callback guard                      | `ResponseCycleFlow.ts:455-461` wraps `onRoundFinalized` in try/catch | ✓      |
-| Delta P3a — empty-type flow-param aliases               | removed; 8 nodes use `FlowParams` directly (see Update above)        | landed |
-| Delta P3b — `withModelClient` closure duplication       | extracted to `CycleServices.withModelClient` (liveness-safe)         | landed |
+| Audit claim                                             | Tree state                                                           | Result  |
+| ------------------------------------------------------- | -------------------------------------------------------------------- | ------- |
+| Step 5 — `@texra/core` populated (not the 1-line stub)  | `packages/core/src/index.ts` = 134 LOC curated surface               | ✓       |
+| Step 1 — dead `getDefaultAgentRuntimeHost` singleton    | grep: zero hits in `src/`                                            | ✓       |
+| Delta P2b — dead `WorkspaceProvider.watch` port removed | `src/platform/interfaces/workspace.ts`: no `watch`                   | ✓       |
+| Delta P1 — finalize-callback guard                      | `ResponseCycleFlow.ts:455-461` wraps `onRoundFinalized` in try/catch | ✓       |
+| Delta P3a — empty-type flow-param aliases               | removed; 8 nodes use `FlowParams` directly (see Update above)        | this PR |
+| Delta P3b — `withModelClient` closure duplication       | extracted to `CycleServices.withModelClient` (liveness-safe)         | this PR |
 
-No drift: everything the audit marked LANDED is present; everything it marked
-deferred is still deferred. The audit is trustworthy as written.
+No drift in the `b2dcd42` rows: everything the audit marked LANDED is present;
+everything it marked deferred is still deferred. The last two rows (P3a/P3b) are
+not at `b2dcd42` — they are the changes this PR introduces (see Update above).
 
 ## Recommendations landing since 2026-06-24
 
@@ -136,9 +141,11 @@ plan's Steps 6–7 / surface track; do not re-open the adjudicated traps.
 - `npm run typecheck` — exit 0 across all four projects (root, test-kernel,
   `texra`, `@texra-ai/cli`).
 - `npx eslint` over the 11 touched files — 0 errors (import-order auto-fixed).
-- `npx vitest run src/test-kernel/agent` — 649 passed, 4 skipped (incl.
+- `npx vitest run src/test-kernel/agent` — 649 passed, 4 skipped (across 117
+  files). The 5 suites most directly covering this change all passed:
   `ResponseCycleTools`, `ReflectionOutputLocation`, `ToolUseWaitNode`,
-  `ToolUseRoundFollowUpMedia`, `RetryState`).
+  `ToolUseRoundFollowUpMedia`, `RetryState` (these are passing suites, not the
+  4 skipped tests).
 - Behavior-equivalence of `withModelClient`: the returned literal has the same
   keys/values as the former inline `setServices` argument; the getter closes over
   the same `client` variable `refreshClient` reassigns, and neither call site

--- a/docs/proposals/agent-sdk-readiness-checkpoint-2026-06-25.md
+++ b/docs/proposals/agent-sdk-readiness-checkpoint-2026-06-25.md
@@ -1,0 +1,108 @@
+# Agent SDK Readiness — Verification Checkpoint (2026-06-25)
+
+**Status:** Verification checkpoint, not a new audit. Read alongside the canonical
+[`agent-sdk-readiness.md`](./agent-sdk-readiness.md) and its most recent addendum
+[`agent-sdk-readiness-delta-2026-06-24.md`](./agent-sdk-readiness-delta-2026-06-24.md).
+This pass re-verified the standing audit against the working tree at HEAD
+(`b2dcd42`) and records **only** drift since the 2026-06-24 delta — it does not
+re-audit or re-litigate adjudicated findings.
+
+## Why this exists
+
+A fresh "review and refactor for Agent SDK readiness" request was scoped against
+the same four areas the canonical audit already covers (agent core + runtime,
+`modelHandlers/`, logger/trace, public surface). Rather than re-run an audit that
+the proposals explicitly warn will re-surface already-rejected traps
+(`IModelHandler` "duplicate", OpenRouter/OpenAI merge, cycle-wrapper inlining,
+god-file mechanical split), this checkpoint confirms the existing findings are
+still accurate at HEAD and notes that the recommendations are **actively
+landing**.
+
+## Verdict — unchanged
+
+**The codebase remains well-aligned and is converging on the plan.** The
+SDK-idiomatic spine is intact and confirmed in-tree: the PocketFlow
+`Node.exec → createFlow().run` shape, the `AgentTrace` emit/subscribe channel,
+the `platform()` composition root, the `createModelHandler` factory, and the
+lead-and-specialists delegation model. This is not a codebase drowning in
+needless abstraction; the live work is **surface curation and per-session state
+relocation**, exactly as the canonical plan sequences it.
+
+## Verified at HEAD (`b2dcd42`, 2026-06-25)
+
+| Audit claim                                              | Tree state                                                              | Result |
+| ------------------------------------------------------- | ---------------------------------------------------------------------- | ------ |
+| Step 5 — `@texra/core` populated (not the 1-line stub)  | `packages/core/src/index.ts` = 134 LOC curated surface                 | ✓      |
+| Step 1 — dead `getDefaultAgentRuntimeHost` singleton    | grep: zero hits in `src/`                                              | ✓      |
+| Delta P2b — dead `WorkspaceProvider.watch` port removed  | `src/platform/interfaces/workspace.ts`: no `watch`                     | ✓      |
+| Delta P1 — finalize-callback guard                       | `ResponseCycleFlow.ts:455-461` wraps `onRoundFinalized` in try/catch   | ✓      |
+| Delta P3a — empty-type flow-param aliases (deferred)     | still present in `ToolUseServices.ts:52` / `ReflectionServices.ts:38`  | open   |
+| Delta P3b — `withModelClient` closure duplication        | still duplicated in `ResponseCycleNode` / `ToolUseCycleNode`           | open   |
+
+No drift: everything the audit marked LANDED is present; everything it marked
+deferred is still deferred. The audit is trustworthy as written.
+
+## Recommendations landing since 2026-06-24
+
+The plan is being executed, not just documented. Commits since the delta audit:
+
+- **`6cc6b20`** `refactor(agent,platform): harden round finalization; drop dead
+  workspace.watch port` — lands delta-audit **P1** + **P2b** verbatim.
+- **`d32be3b`** + **`a15dd86`** `refactor/fix(executeAgent): extract per-category
+  flow runners from routing lambda` — lands the canonical proposal's
+  **"cleanest internal seam"** subagent recommendation: stop threading the
+  14-field launch context by spread; key each agent category to an explicit,
+  typed per-flow runner. This is the structural pre-work for config-selected
+  subagent delegates.
+- **`0e97b51`** `refactor: tighten two abstraction-layer boundaries`.
+- **`c17f4ce`** `refactor: dedupe model-handler prefill and guard core settings
+  paths`.
+- **`bd3b4b9`** `docs: reconcile stale Recommendation with second-pass Update`.
+
+## What remains genuinely open (all deliberately deferred — do NOT apply unattended)
+
+These are the only open items, and the canonical/delta audits deferred each on
+purpose. None is a quick win; two carry verified regression risk.
+
+1. **P3a — empty-type param aliases** (`ToolUseFlowParams` / `ReflectionFlowParams`):
+   cosmetic, low value. "Bundle only if touching these files anyway." (delta P3)
+2. **P3b — `withModelClient` closure DRY:** ⚠️ the duplicated closure exposes
+   `client` via a **getter with live rebinding** for the relay-401 token-refresh
+   path. Extracting + spreading evaluates the getter eagerly and **breaks
+   liveness** (silent auth-refresh regression). Not worth ~15 LOC. (delta Update)
+3. **Cross-provider user-message / media-block scaffold** (~150–250 LOC skeleton
+   across the four handler families): real, but a tracked design item — the
+   four-shape provider abstraction is justified and must survive. (delta "Track")
+4. **Surface / multi-tenant track:** the missing single SDK entry (streaming
+   `query()`-style handle) and per-session relocation of the remaining
+   module-global registries — the canonical plan's Steps 6–7 / F-1 / F-2, already
+   sequenced and partly landed (`SessionHandle`, `AgentRunHandle`). The
+   load-bearing `RunCoordinatorBridge` must be **relocated, never deleted**.
+
+## Subagent split points — re-confirmed
+
+No change to the canonical/delta subagent analysis: YAML agent profiles are
+near-isomorphic to the SDK `AgentDefinition`; teams (`AGENT_MODE_PRESETS`) are the
+subagent roster; `delegate_agent`/`delegate_workflow` + `executeSubagent` are the
+isolated-context delegation primitive; read-only-by-tool reviewers
+(`changeReviewer`, no bash) already model SDK tool-scoping. The lowest-risk
+concrete win remains wiring the existing `review` tool-use agent as a post-draft
+**Verifier** delegation; deeper in-agent round decomposition stays gated behind
+the per-run-handle state-isolation track.
+
+## Recommendation
+
+**No new refactoring warranted at this time.** The audit is current, the
+recommendations are actively landing through a disciplined behavior-neutral PR
+train, and the only open items are deliberately deferred (two with verified
+regression risk). Continue executing the canonical plan's Steps 6–7 / surface
+track; do not re-open the adjudicated traps.
+
+## Verified (this checkpoint)
+
+- `packages/core/src/index.ts` (line count), `src/platform/interfaces/workspace.ts`
+  (no `watch`), `src/agent/core/flows/ResponseCycleFlow.ts:444-462` (finalize guard).
+- grep: `getDefaultAgentRuntimeHost` (empty), `ToolUseFlowParams`/`ReflectionFlowParams`
+  (present), `refreshClient` in both cycle wrapper nodes (present).
+- `git log` since 2026-06-23 over `src/agent src/logger src/platform packages/core`
+  (the landing commits cited above).

--- a/src/agent/core/flows/CycleServices.ts
+++ b/src/agent/core/flows/CycleServices.ts
@@ -8,6 +8,11 @@ import type { AgentWorkspaceState } from '@agent/core/execution/AgentWorkspaceSt
 import type { IToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { IToolUseSession } from '@agent/core/flows/IToolUseSession';
 import type { BaseFlowContextInit } from '@agent/core/flows/BaseFlowServices';
+import type {
+  IModelHandler,
+  SdkToolCall,
+} from '@agent/modelHandlers/types/IModelHandler';
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import type { TaskRunFileService } from '@utils/files';
 
 /**
@@ -25,6 +30,40 @@ import type { TaskRunFileService } from '@utils/files';
 export interface ModelClientServices<C = unknown> {
   readonly client: C;
   readonly refreshClient?: () => Promise<void>;
+}
+
+/**
+ * Bridge the live model client into a cycle/round services object before the
+ * outer node runs the inner flow.
+ *
+ * The `client` getter and `refreshClient` are defined on the **returned
+ * literal** — never spread from a pre-evaluated object — so the relay-401
+ * token-refresh path keeps live rebinding: `refreshClient()` re-fetches the
+ * provider client after a mid-run model switch and the getter reflects it on
+ * the next read. Spreading the result of this call elsewhere would snapshot
+ * `client` and silently break that liveness, so callers pass the result
+ * straight to `flow.setServices(...)`.
+ */
+export async function withModelClient<C, T extends object>(
+  base: T,
+  modelHandler: IModelHandler<
+    ProviderMessage,
+    unknown,
+    unknown,
+    SdkToolCall,
+    C
+  >,
+): Promise<T & ModelClientServices<C>> {
+  let client = await modelHandler.getClient();
+  return {
+    ...base,
+    get client(): C {
+      return client;
+    },
+    async refreshClient(): Promise<void> {
+      client = await modelHandler.getClient();
+    },
+  };
 }
 
 export interface TextConnectionService {

--- a/src/agent/implementations/flows/reflection/ReflectionServices.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionServices.ts
@@ -3,10 +3,7 @@ import type { RoundFinalizedCallback } from '@agent/core/flows/BaseFlowServices'
 import type { OutputState } from '@agent/output/outputState';
 import type { LatexDiffManager } from '@agent/output/LatexDiffManager';
 import type { XmlOutputManager } from '@agent/output/XmlOutputManager';
-import type {
-  BaseFlowContextInit,
-  FlowParams,
-} from '@agent/core/flows/BaseFlowServices';
+import type { BaseFlowContextInit } from '@agent/core/flows/BaseFlowServices';
 import type { LatexMediaManager } from '@latex/LatexMediaManager';
 import type { AgentFileLocation, WorkspaceFileLocation } from '@shared/schemas';
 import type { PromptBuilder } from '@utils/prompt';
@@ -34,5 +31,3 @@ export interface ReflectionServices<
   readonly baseFiles: WorkspaceFileLocation[];
   readonly onRoundFinalized: RoundFinalizedCallback;
 }
-
-export type { FlowParams as ReflectionFlowParams };

--- a/src/agent/implementations/flows/reflection/nodes/MediaExtractionNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/MediaExtractionNode.ts
@@ -1,14 +1,12 @@
 import { Node } from '@agent/node';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { AgentWorkspaceState } from '@agent/core/execution/AgentWorkspaceState';
+import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
 import type { FileLocation } from '@shared/schemas';
 
 import { getFilesForRound } from '../helpers';
 import type { ReflectionFlowShared } from '../ReflectionFlowState';
-import type {
-  ReflectionFlowParams,
-  ReflectionServices,
-} from '../ReflectionServices';
+import type { ReflectionServices } from '../ReflectionServices';
 
 interface PrepInput {
   files: FileLocation[];
@@ -19,7 +17,7 @@ interface PrepInput {
 
 export class MediaExtractionNode<C = unknown> extends Node<
   ReflectionFlowShared,
-  ReflectionFlowParams,
+  FlowParams,
   ReflectionServices<C>
 > {
   async prep(shared: ReflectionFlowShared): Promise<PrepInput> {

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -24,6 +24,7 @@ import {
 } from '@agent/output/compileFailureRoundContext';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { tryOperation } from '@agent/output/outputOperations';
+import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
 import {
   MESSAGE_TYPES,
   type AgentFileLocation,
@@ -35,10 +36,7 @@ import {
 import { flexibleFS } from '@utils/files';
 
 import type { ReflectionFlowShared } from '../ReflectionFlowState';
-import type {
-  ReflectionFlowParams,
-  ReflectionServices,
-} from '../ReflectionServices';
+import type { ReflectionServices } from '../ReflectionServices';
 
 interface OutputPrepInput {
   outputLocation: AgentFileLocation;
@@ -57,7 +55,7 @@ interface OutputExecResult {
 
 export class OutputNode<C = unknown> extends Node<
   ReflectionFlowShared,
-  ReflectionFlowParams,
+  FlowParams,
   ReflectionServices<C>
 > {
   async prep(shared: ReflectionFlowShared): Promise<OutputPrepInput> {

--- a/src/agent/implementations/flows/reflection/nodes/PrepareContextNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/PrepareContextNode.ts
@@ -4,14 +4,12 @@ import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import { appendCompileFailureRoundContext } from '@agent/output/compileFailureRoundContext';
 
+import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
 import type {
   ReflectionFlowShared,
   RoundContext,
 } from '../ReflectionFlowState';
-import type {
-  ReflectionFlowParams,
-  ReflectionServices,
-} from '../ReflectionServices';
+import type { ReflectionServices } from '../ReflectionServices';
 
 interface PrepInput {
   currentRound: number;
@@ -21,7 +19,7 @@ interface PrepInput {
 
 export class PrepareContextNode<C = unknown> extends Node<
   ReflectionFlowShared,
-  ReflectionFlowParams,
+  FlowParams,
   ReflectionServices<C>
 > {
   async prep(shared: ReflectionFlowShared): Promise<PrepInput> {

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -6,20 +6,19 @@ import {
   createResponseCycleFlow,
   type ResponseCycleShared,
 } from '@agent/core/flows/ResponseCycleFlow';
+import { withModelClient } from '@agent/core/flows/CycleServices';
 import type {
   AgentRunStateSnapshot,
   ConversationRoundStateSnapshot,
 } from '@agent/core/execution/AgentState';
 import { bestConnectionMethod } from '@agent/runtime/textConnection';
+import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
 import { ensureError, normalizeProviderError } from '@common/errors';
 import type { AgentFileLocation, RetryErrorInfo } from '@shared/schemas';
 import { toRetryErrorInfo } from '@shared/schemas';
 
 import type { ReflectionFlowShared } from '../ReflectionFlowState';
-import type {
-  ReflectionFlowParams,
-  ReflectionServices,
-} from '../ReflectionServices';
+import type { ReflectionServices } from '../ReflectionServices';
 
 interface CyclePrepInput {
   shared: ReflectionFlowShared;
@@ -41,7 +40,7 @@ type CycleOutcome =
 
 export class ResponseCycleNode<C = unknown> extends Node<
   ReflectionFlowShared,
-  ReflectionFlowParams,
+  FlowParams,
   ReflectionServices<C>
 > {
   async prep(shared: ReflectionFlowShared): Promise<CyclePrepInput> {
@@ -99,20 +98,18 @@ export class ResponseCycleNode<C = unknown> extends Node<
 
       const flow = createResponseCycleFlow<C>();
       const { modelHandler } = this.services;
-      let client = await modelHandler.getClient();
-      flow.setServices({
-        ...this.services,
-        bestConnectionMethod,
-        get client() {
-          return client;
-        },
-        async refreshClient() {
-          client = await modelHandler.getClient();
-        },
-        round: prepRes.round,
-        run: prepRes.run,
-        workspace: prepRes.workspace,
-      });
+      flow.setServices(
+        await withModelClient(
+          {
+            ...this.services,
+            bestConnectionMethod,
+            round: prepRes.round,
+            run: prepRes.run,
+            workspace: prepRes.workspace,
+          },
+          modelHandler,
+        ),
+      );
       await flow.run(cycleShared);
 
       if (cycleShared.lastError) {

--- a/src/agent/implementations/flows/reflection/nodes/TeXCountNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/TeXCountNode.ts
@@ -1,18 +1,16 @@
 import { Node } from '@agent/node';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
+import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
 import { getTeXCountStats } from '@latex/texcount';
 import type { FileLocation } from '@shared/schemas';
 
 import { getFilesForRound } from '../helpers';
 import type { ReflectionFlowShared } from '../ReflectionFlowState';
-import type {
-  ReflectionFlowParams,
-  ReflectionServices,
-} from '../ReflectionServices';
+import type { ReflectionServices } from '../ReflectionServices';
 
 export class TeXCountNode<C = unknown> extends Node<
   ReflectionFlowShared,
-  ReflectionFlowParams,
+  FlowParams,
   ReflectionServices<C>
 > {
   async prep(shared: ReflectionFlowShared): Promise<FileLocation[]> {

--- a/src/agent/implementations/flows/tooluse/ToolUseServices.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseServices.ts
@@ -2,10 +2,7 @@ import type { AgentToolUseSetting } from '@agent/core/definition/AgentDataclass'
 import type { RoundFinalizedCallback } from '@agent/core/flows/BaseFlowServices';
 import type { IToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { AttachedMemoryMiss } from '@agent/types/AttachedMemory';
-import type {
-  BaseFlowContextInit,
-  FlowParams,
-} from '@agent/core/flows/BaseFlowServices';
+import type { BaseFlowContextInit } from '@agent/core/flows/BaseFlowServices';
 import type { IToolUseSession } from '@agent/core/flows/IToolUseSession';
 import type { ToolDefinition } from '@model';
 import type { SubagentProgressUpdate, TodoItem } from '@shared/schemas';
@@ -48,5 +45,3 @@ export interface ToolUseServices<C = unknown> extends BaseFlowContextInit<C> {
    */
   readonly delegationTrimmed?: boolean;
 }
-
-export type { FlowParams as ToolUseFlowParams };

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -5,7 +5,9 @@ import {
   createToolUseRoundFlow,
   type ToolUseRoundShared,
 } from '@agent/core/flows/ToolUseRoundFlow';
+import { withModelClient } from '@agent/core/flows/CycleServices';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
 import { normalizeProviderError, toErrorMessage } from '@common/errors';
 import { MESSAGE_TYPES, toRetryErrorInfo } from '@shared/schemas';
 import type { RetryErrorInfo } from '@shared/schemas';
@@ -15,7 +17,7 @@ import {
   type CyclePrepResult,
   assertPreparedShared,
 } from './types';
-import type { ToolUseServices, ToolUseFlowParams } from '../ToolUseServices';
+import type { ToolUseServices } from '../ToolUseServices';
 
 type ToolUseCycleOutcome =
   | { outcome: 'completed'; messages: ProviderMessage[] }
@@ -30,7 +32,7 @@ type ToolUseCycleOutcome =
 
 export class ToolUseCycleNode<C> extends Node<
   ToolUseRunShared,
-  ToolUseFlowParams,
+  FlowParams,
   ToolUseServices<C>
 > {
   async prep(shared: ToolUseRunShared): Promise<CyclePrepResult> {
@@ -77,19 +79,17 @@ export class ToolUseCycleNode<C> extends Node<
     };
 
     const flow = createToolUseRoundFlow<C>();
-    let client = await modelHandler.getClient();
-    flow.setServices({
-      ...this.services,
-      get client() {
-        return client;
-      },
-      async refreshClient() {
-        client = await modelHandler.getClient();
-      },
-      setting: { ...setting, tools: resolvedTools },
-      run: prepRes.runState,
-      workspace: prepRes.workspaceState,
-    });
+    flow.setServices(
+      await withModelClient(
+        {
+          ...this.services,
+          setting: { ...setting, tools: resolvedTools },
+          run: prepRes.runState,
+          workspace: prepRes.workspaceState,
+        },
+        modelHandler,
+      ),
+    );
 
     const { onProgress, persistTodos } = this.services;
     let todoPersistChain = Promise.resolve();

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -3,10 +3,11 @@ import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { AgentRunStateSnapshotSchema } from '@agent/core/execution/AgentState';
 import { AgentWorkspaceState } from '@agent/core/execution/AgentWorkspaceState';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
 import { hasDelegationTool } from '@shared/constants/delegationTools';
 import { buildInitialToolUsePrompts } from '@utils/prompt';
 
-import type { ToolUseServices, ToolUseFlowParams } from '../ToolUseServices';
+import type { ToolUseServices } from '../ToolUseServices';
 import type { ToolUseRunShared, PrepareResult } from './types';
 
 type PrepareExecResult =
@@ -23,7 +24,7 @@ type PrepareExecResult =
  */
 export class ToolUsePrepareNode<C> extends Node<
   ToolUseRunShared,
-  ToolUseFlowParams,
+  FlowParams,
   ToolUseServices<C>
 > {
   async exec(

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -6,11 +6,12 @@ import {
   appendFollowUpAsUserMessage,
   followUpDisplayText,
 } from '@agent/toolUse/followUpMessages';
+import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
 import { STREAM_STATUS } from '@shared/schemas';
 import { GoalStore, setGoalSessionBashAutoApproval } from '@tools/goal';
 
 import { findLastAssistantText, extractTouchedFiles } from './types';
-import type { ToolUseServices, ToolUseFlowParams } from '../ToolUseServices';
+import type { ToolUseServices } from '../ToolUseServices';
 import type { ToolUseRunShared, WaitExecResult } from './types';
 
 interface WaitPrepResult {
@@ -26,7 +27,7 @@ interface WaitPrepResult {
 
 export class ToolUseWaitNode<C> extends Node<
   ToolUseRunShared,
-  ToolUseFlowParams,
+  FlowParams,
   ToolUseServices<C>
 > {
   async prep(shared: ToolUseRunShared): Promise<WaitPrepResult> {


### PR DESCRIPTION
## Summary

Applies two behavior-neutral core cleanups from the Agent SDK readiness audit (delta P3a + P3b):

1. **Extract `withModelClient` helper** — Centralizes the duplicated `client` getter + `refreshClient` closure pattern from `ResponseCycleNode` and `ToolUseCycleNode` into a single reusable helper in `CycleServices.ts`. The helper returns a literal with live getters (never spreads the result) to preserve relay-401 token-refresh rebinding.

2. **Remove empty-type flow-param aliases** — Deletes the re-export shims `export type { FlowParams as ToolUseFlowParams }` and `export type { FlowParams as ReflectionFlowParams }` from `ToolUseServices.ts` and `ReflectionServices.ts`. Updates 8 node generic slots across reflection and tooluse flows to use `FlowParams` directly from `@agent/core/flows/BaseFlowServices`.

Both changes are verified behavior-equivalent: no distinct type information is lost (both aliases were `Record<string, unknown>`), and the getter liveness is preserved by passing the `withModelClient` result directly to `flow.setServices(...)` without spreading.

## Issue acceptance gates

Addresses Agent SDK readiness checkpoint (2026-06-25) recommendations P3a and P3b. Both are deliberately-deferred, genuinely-safe cleanups from the canonical audit.

## Single source of truth

- **`withModelClient` helper** now owns the `client` getter + `refreshClient` closure pattern; both call sites (`ResponseCycleNode.exec`, `ToolUseCycleNode.exec`) delegate to it.
- **`FlowParams`** from `@agent/core/flows/BaseFlowServices` is the canonical flow parameter type; no re-export aliases.

## Duplication and abstraction budget

- **Removed duplication:** The `client` getter + `refreshClient` closure was defined identically in two places; now centralized in `withModelClient`.
- **Removed anti-shim aliases:** `ToolUseFlowParams` and `ReflectionFlowParams` were empty re-exports that added no semantic value; direct use of `FlowParams` is clearer.
- **No new abstraction debt:** `withModelClient` is a thin bridge that returns a literal; it does not introduce a pass-through layer.

## Host impact

Extension: None (internal refactor)

Desktop: None (internal refactor)

CLI: None (internal refactor)

## Scheduled refactoring

None. The two larger tracked design pieces (cross-provider message scaffold; surface / multi-tenant track) remain gated behind their respective design work.

## Validation

- `npm run typecheck` — exit 0 across all four projects (root, test-kernel, `texra`, `@texra-ai/cli`).
- `npx eslint` over the 11 touched files — 0 errors (import-order auto-fixed).
- `npx vitest run src/test-kernel/agent` — 649 passed, 4 skipped.
- Behavior-equivalence of `withModelClient`: the returned literal has the same keys/values as the former inline `setServices` argument; the getter closes over the same `client` variable `refreshClient` reassigns, and neither call site spreads the result — liveness preserved.

https://claude.ai/code/session_01LCzf6HWNWEKPtyQA5mA5w2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal agent-flow refactor with explicit preservation of client getter liveness; no public API or auth/data-path changes, with broad agent test coverage noted in the PR.
> 
> **Overview**
> Behavior-neutral Agent SDK readiness cleanups (**P3a** / **P3b**): reflection and tool-use flows share one typing pattern, and cycle nodes no longer duplicate model-client wiring.
> 
> **`withModelClient`** in `CycleServices.ts` replaces identical inline `client` getter + `refreshClient` closures in `ResponseCycleNode` and `ToolUseCycleNode`. The helper returns a literal passed directly to `flow.setServices(...)` (not spread) so mid-run client refresh and relay-401 rebinding stay live.
> 
> **Flow param aliases** `ToolUseFlowParams` / `ReflectionFlowParams` are removed from the service modules; eight flow nodes now use **`FlowParams`** from `BaseFlowServices` in their `Node` generics.
> 
> A new **2026-06-25 readiness checkpoint** doc records that these items landed and that larger surface/multi-tenant work remains deferred.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9a087dfa8f0f7e3c714bfdef6e51a20ec69e8eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->