### PR TITLE
Refactor retry logic and session coordination with p-retry and async-mutex

### DIFF
--- a/src/agent/node/index.ts
+++ b/src/agent/node/index.ts
@@ -189,13 +189,18 @@ class Node<
     const effectiveMaxRetries = Math.max(1, this.maxRetries);
     const MAX_MANUAL_RETRIES = 100;
 
-    for (let manualRetryCount = 0; manualRetryCount < MAX_MANUAL_RETRIES; manualRetryCount++) {
+    for (
+      let manualRetryCount = 0;
+      manualRetryCount < MAX_MANUAL_RETRIES;
+      manualRetryCount++
+    ) {
       try {
         return await pRetry(
           () => {
             // Throw AbortError at each attempt start so p-retry surfaces it
             // immediately (before any delay) and skips onFailedAttempt.
-            if (this.signal?.aborted) throw new AbortError('Operation cancelled by user');
+            if (this.signal?.aborted)
+              throw new AbortError('Operation cancelled by user');
             return this.exec(prepRes);
           },
           {
@@ -217,7 +222,10 @@ class Node<
         // signal aborted during delay (p-retry rethrows signal.reason)
         // or shouldAutoRetry returned false: both skip manual retry.
         if (this.signal?.aborted) {
-          return await this.execFallback(prepRes, new Error('Operation cancelled by user'));
+          return await this.execFallback(
+            prepRes,
+            new Error('Operation cancelled by user'),
+          );
         }
         const shouldRetry = await this.retryPrompt(prepRes, e as Error);
         if (shouldRetry) continue;

--- a/src/agent/node/index.ts
+++ b/src/agent/node/index.ts
@@ -223,7 +223,7 @@ class Node<
       } catch (e) {
         if (e instanceof AbortError) {
           // AbortError is thrown by our pre-attempt check above.
-          return await this.execFallback(prepRes, e.originalError);
+          return await this.execFallback(prepRes, lastExecError ?? (e.originalError ?? e));
         }
         // signal aborted during delay (p-retry rethrows signal.reason) or
         // shouldAutoRetry returned false: forward the original exec error.

--- a/src/agent/node/index.ts
+++ b/src/agent/node/index.ts
@@ -228,7 +228,10 @@ class Node<
         // signal aborted during delay (p-retry rethrows signal.reason) or
         // shouldAutoRetry returned false: forward the original exec error.
         if (this.signal?.aborted) {
-          return await this.execFallback(prepRes, lastExecError ?? (e as Error));
+          return await this.execFallback(
+            prepRes,
+            lastExecError ?? (e as Error),
+          );
         }
         const shouldRetry = await this.retryPrompt(prepRes, e as Error);
         if (shouldRetry) continue;

--- a/src/agent/node/index.ts
+++ b/src/agent/node/index.ts
@@ -194,6 +194,10 @@ class Node<
       manualRetryCount < MAX_MANUAL_RETRIES;
       manualRetryCount++
     ) {
+      // Track the last exec error so we can forward it to execFallback when
+      // the abort signal fires during the inter-retry delay (p-retry would
+      // otherwise rethrow signal.reason, discarding the original failure).
+      let lastExecError: Error | undefined;
       try {
         return await pRetry(
           () => {
@@ -207,8 +211,10 @@ class Node<
             retries: effectiveMaxRetries - 1,
             minTimeout: this.wait * 1000,
             factor: 1, // linear (fixed) delay to preserve existing behaviour
+            randomize: false, // explicit: default is false; no jitter on fixed delays
             signal: this.signal, // aborts the inter-retry delay early
             shouldRetry: ({ error }) => {
+              lastExecError = error;
               if (this.signal?.aborted) return false;
               return this.shouldAutoRetry(error);
             },
@@ -219,13 +225,10 @@ class Node<
           // AbortError is thrown by our pre-attempt check above.
           return await this.execFallback(prepRes, e.originalError);
         }
-        // signal aborted during delay (p-retry rethrows signal.reason)
-        // or shouldAutoRetry returned false: both skip manual retry.
+        // signal aborted during delay (p-retry rethrows signal.reason) or
+        // shouldAutoRetry returned false: forward the original exec error.
         if (this.signal?.aborted) {
-          return await this.execFallback(
-            prepRes,
-            new Error('Operation cancelled by user'),
-          );
+          return await this.execFallback(prepRes, lastExecError ?? (e as Error));
         }
         const shouldRetry = await this.retryPrompt(prepRes, e as Error);
         if (shouldRetry) continue;

--- a/src/agent/node/index.ts
+++ b/src/agent/node/index.ts
@@ -1,5 +1,6 @@
+import pRetry, { AbortError } from 'p-retry';
+
 import * as logger from '@logger/logUtils';
-import { delay } from '@utils/core';
 
 export type NonIterableObject = Partial<Record<string, unknown>> & {
   [Symbol.iterator]?: never;
@@ -179,7 +180,6 @@ class Node<
     return cloned;
   }
   async _exec(prepRes: unknown): Promise<unknown> {
-    // Guard against infinite loop: ensure at least 1 retry attempt
     if (this.maxRetries < 1) {
       logger.warn(
         CHANNEL,
@@ -187,57 +187,44 @@ class Node<
       );
     }
     const effectiveMaxRetries = Math.max(1, this.maxRetries);
-
-    // Safety limit for manual retries to prevent infinite loops from buggy retryPrompt
     const MAX_MANUAL_RETRIES = 100;
-    let manualRetryCount = 0;
 
-    // Outer loop for manual retry (restarts auto-retry cycle)
-    while (manualRetryCount < MAX_MANUAL_RETRIES) {
-      for (
-        let currentRetry = 0;
-        currentRetry < effectiveMaxRetries;
-        currentRetry++
-      ) {
-        // Check abort at start of each retry for responsive cancellation
-        // This ensures we don't attempt exec when the user has already cancelled
+    for (let manualRetryCount = 0; manualRetryCount < MAX_MANUAL_RETRIES; manualRetryCount++) {
+      try {
+        return await pRetry(
+          () => {
+            // Throw AbortError at each attempt start so p-retry surfaces it
+            // immediately (before any delay) and skips onFailedAttempt.
+            if (this.signal?.aborted) throw new AbortError('Operation cancelled by user');
+            return this.exec(prepRes);
+          },
+          {
+            retries: effectiveMaxRetries - 1,
+            minTimeout: this.wait * 1000,
+            factor: 1, // linear (fixed) delay to preserve existing behaviour
+            signal: this.signal, // aborts the inter-retry delay early
+            shouldRetry: ({ error }) => {
+              if (this.signal?.aborted) return false;
+              return this.shouldAutoRetry(error);
+            },
+          },
+        );
+      } catch (e) {
+        if (e instanceof AbortError) {
+          // AbortError is thrown by our pre-attempt check above.
+          return await this.execFallback(prepRes, e.originalError);
+        }
+        // signal aborted during delay (p-retry rethrows signal.reason)
+        // or shouldAutoRetry returned false: both skip manual retry.
         if (this.signal?.aborted) {
-          const cancelError = new Error('Operation cancelled by user');
-          return await this.execFallback(prepRes, cancelError);
+          return await this.execFallback(prepRes, new Error('Operation cancelled by user'));
         }
-        try {
-          return await this.exec(prepRes);
-        } catch (e) {
-          // If abort signal is set and aborted, skip retries and go to fallback
-          // This prevents unnecessary retries when the user intentionally cancelled
-          const isAborted = this.signal?.aborted;
-          const isLastAutoRetry = currentRetry === effectiveMaxRetries - 1;
-          const skipAutoRetry = !this.shouldAutoRetry(e as Error);
-
-          if (isLastAutoRetry || isAborted || skipAutoRetry) {
-            // Auto-retries exhausted - try manual retry (unless aborted)
-            if (!isAborted) {
-              const shouldRetry = await this.retryPrompt(prepRes, e as Error);
-              if (shouldRetry) {
-                manualRetryCount++;
-                break; // Break inner loop to restart auto-retries
-              }
-            }
-            return await this.execFallback(prepRes, e as Error);
-          }
-          if (this.wait > 0) {
-            await delay(this.wait * 1000);
-            // Check abort after delay to exit quickly if cancelled during wait
-            if (this.signal?.aborted) {
-              return await this.execFallback(prepRes, e as Error);
-            }
-          }
-        }
+        const shouldRetry = await this.retryPrompt(prepRes, e as Error);
+        if (shouldRetry) continue;
+        return await this.execFallback(prepRes, e as Error);
       }
-      // If we broke from inner loop, continue outer loop to restart auto-retries
     }
 
-    // Safeguard: if we somehow exit the loop without returning, throw
     throw new Error(
       `Node exceeded maximum manual retry limit (${MAX_MANUAL_RETRIES})`,
     );

--- a/src/agent/node/index.ts
+++ b/src/agent/node/index.ts
@@ -223,7 +223,10 @@ class Node<
       } catch (e) {
         if (e instanceof AbortError) {
           // AbortError is thrown by our pre-attempt check above.
-          return await this.execFallback(prepRes, lastExecError ?? (e.originalError ?? e));
+          return await this.execFallback(
+            prepRes,
+            lastExecError ?? e.originalError ?? e,
+          );
         }
         // signal aborted during delay (p-retry rethrows signal.reason) or
         // shouldAutoRetry returned false: forward the original exec error.

--- a/src/auth/SupabaseSession.ts
+++ b/src/auth/SupabaseSession.ts
@@ -1,3 +1,5 @@
+import { Mutex } from 'async-mutex';
+
 import { toErrorMessage } from '@common/errors/errorMessage';
 import {
   parseAuthCallbackCode,
@@ -67,8 +69,7 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
   private sessionMutationVersion = 0;
   private lastStoredSession: SupabaseSession | null = null;
   private lastStoredSessionVersion = 0;
-  private pendingSessionMutations = 0;
-  private sessionMutationTail: Promise<void> = Promise.resolve();
+  private readonly sessionMutex = new Mutex();
 
   constructor(private readonly options: SupabaseSessionCoordinatorOptions) {}
 
@@ -290,19 +291,16 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
   }
 
   private async loadStableSessionSnapshot(): Promise<StableSessionSnapshot> {
-    let versionBeforeLoad = this.sessionMutationVersion;
     for (;;) {
-      const pendingBeforeLoad = this.pendingSessionMutations;
+      const versionBeforeLoad = this.sessionMutationVersion;
+      await this.sessionMutex.waitForUnlock();
       const session = await this.loadSession();
       if (
         versionBeforeLoad === this.sessionMutationVersion &&
-        pendingBeforeLoad === 0 &&
-        this.pendingSessionMutations === 0
+        !this.sessionMutex.isLocked()
       ) {
         return { session, version: versionBeforeLoad };
       }
-      await this.sessionMutationTail;
-      versionBeforeLoad = this.sessionMutationVersion;
     }
   }
 
@@ -310,21 +308,13 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
     session: SupabaseSession | null,
     operation: () => Promise<void>,
   ): Promise<void> {
-    this.sessionMutationVersion += 1;
-    this.pendingSessionMutations += 1;
-    const mutationVersion = this.sessionMutationVersion;
-    const previousMutation = this.sessionMutationTail;
-    const run = previousMutation
-      .then(operation)
-      .then(() => {
-        this.lastStoredSession = session;
-        this.lastStoredSessionVersion = mutationVersion;
-      })
-      .finally(() => {
-        this.pendingSessionMutations -= 1;
-      });
-    this.sessionMutationTail = run.catch(() => {});
-    await run;
+    await this.sessionMutex.runExclusive(async () => {
+      this.sessionMutationVersion += 1;
+      const mutationVersion = this.sessionMutationVersion;
+      await operation();
+      this.lastStoredSession = session;
+      this.lastStoredSessionVersion = mutationVersion;
+    });
   }
 
   private async storeRefreshIfCurrent(
@@ -333,7 +323,7 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
   ): Promise<SupabaseSession | null> {
     if (
       this.sessionMutationVersion !== expectedVersion ||
-      this.pendingSessionMutations > 0
+      this.sessionMutex.isLocked()
     ) {
       return this.loadStableSession();
     }

--- a/src/tools/citation/rateLimiter.ts
+++ b/src/tools/citation/rateLimiter.ts
@@ -1,17 +1,18 @@
 import pThrottle from 'p-throttle';
 
-const limiters = new Map<string, () => Promise<void>>();
+const limiters = new Map<string, { minDelayMs: number; wait: () => Promise<void> }>();
 
 /** Enforces a minimum delay between consecutive requests to the same API. */
 export async function waitForRateLimit(
   apiName: string,
   minDelayMs: number,
 ): Promise<void> {
-  if (!limiters.has(apiName)) {
-    limiters.set(
-      apiName,
-      pThrottle({ limit: 1, interval: minDelayMs })(() => Promise.resolve()),
-    );
+  const existing = limiters.get(apiName);
+  if (!existing || existing.minDelayMs !== minDelayMs) {
+    limiters.set(apiName, {
+      minDelayMs,
+      wait: pThrottle({ limit: 1, interval: minDelayMs })(() => Promise.resolve()),
+    });
   }
-  await limiters.get(apiName)!();
+  await limiters.get(apiName)!.wait();
 }

--- a/src/tools/citation/rateLimiter.ts
+++ b/src/tools/citation/rateLimiter.ts
@@ -1,6 +1,9 @@
 import pThrottle from 'p-throttle';
 
-const limiters = new Map<string, { minDelayMs: number; wait: () => Promise<void> }>();
+const limiters = new Map<
+  string,
+  { minDelayMs: number; wait: () => Promise<void> }
+>();
 
 /** Enforces a minimum delay between consecutive requests to the same API. */
 export async function waitForRateLimit(
@@ -11,7 +14,9 @@ export async function waitForRateLimit(
   if (!existing || existing.minDelayMs !== minDelayMs) {
     limiters.set(apiName, {
       minDelayMs,
-      wait: pThrottle({ limit: 1, interval: minDelayMs })(() => Promise.resolve()),
+      wait: pThrottle({ limit: 1, interval: minDelayMs })(() =>
+        Promise.resolve(),
+      ),
     });
   }
   await limiters.get(apiName)!.wait();

--- a/src/tools/citation/rateLimiter.ts
+++ b/src/tools/citation/rateLimiter.ts
@@ -1,32 +1,17 @@
 import pThrottle from 'p-throttle';
 
-interface ApiLimiter {
-  minDelayMs: number;
-  wait: () => Promise<void>;
-}
-
-const limiters = new Map<string, ApiLimiter>();
-
-function getLimiter(apiName: string, minDelayMs: number): ApiLimiter {
-  const existing = limiters.get(apiName);
-  if (existing && existing.minDelayMs === minDelayMs) {
-    return existing;
-  }
-  // p-throttle's interval is fixed at creation, so a changed delay (callers
-  // pass a constant per API in practice) rebuilds the limiter.
-  const throttle = pThrottle({ limit: 1, interval: minDelayMs });
-  const limiter: ApiLimiter = {
-    minDelayMs,
-    wait: throttle(() => Promise.resolve()),
-  };
-  limiters.set(apiName, limiter);
-  return limiter;
-}
+const limiters = new Map<string, () => Promise<void>>();
 
 /** Enforces a minimum delay between consecutive requests to the same API. */
 export async function waitForRateLimit(
   apiName: string,
   minDelayMs: number,
 ): Promise<void> {
-  await getLimiter(apiName, minDelayMs).wait();
+  if (!limiters.has(apiName)) {
+    limiters.set(
+      apiName,
+      pThrottle({ limit: 1, interval: minDelayMs })(() => Promise.resolve()),
+    );
+  }
+  await limiters.get(apiName)!();
 }

--- a/src/tools/github/PollingSourceBase.ts
+++ b/src/tools/github/PollingSourceBase.ts
@@ -11,6 +11,8 @@
  * 24 h detach gate) lives here once.
  */
 
+import pMap from 'p-map';
+
 import type { AgentTrace } from '@agent/trace';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
@@ -251,8 +253,10 @@ export abstract class PollingSourceBase<
     try {
       const now = Date.now();
       const entries = [...this.subscriptions.entries()];
-      await Promise.allSettled(
-        entries.map(([key, state]) => this.pollEntry(key, state, now)),
+      await pMap(
+        entries,
+        ([key, state]) => this.pollEntry(key, state, now),
+        { concurrency: this.config.maxConcurrent, stopOnError: false },
       );
       await this.runAfterTick(entries, now);
       if (this.subscriptions.size === 0) this.stopTimer();

--- a/src/tools/github/PollingSourceBase.ts
+++ b/src/tools/github/PollingSourceBase.ts
@@ -253,11 +253,10 @@ export abstract class PollingSourceBase<
     try {
       const now = Date.now();
       const entries = [...this.subscriptions.entries()];
-      await pMap(
-        entries,
-        ([key, state]) => this.pollEntry(key, state, now),
-        { concurrency: this.config.maxConcurrent, stopOnError: false },
-      );
+      await pMap(entries, ([key, state]) => this.pollEntry(key, state, now), {
+        concurrency: this.config.maxConcurrent,
+        stopOnError: false,
+      });
       await this.runAfterTick(entries, now);
       if (this.subscriptions.size === 0) this.stopTimer();
     } finally {


### PR DESCRIPTION
## Summary

This PR refactors three critical coordination systems to use battle-tested libraries instead of custom implementations:

1. **Node retry logic** (`src/agent/node/index.ts`): Replaced manual retry loops with `p-retry`, simplifying the nested loop structure and improving abort signal handling.
2. **Session mutation coordination** (`src/auth/SupabaseSession.ts`): Replaced custom promise-chaining with `async-mutex`, making concurrent access patterns explicit and easier to reason about.
3. **Rate limiting** (`src/tools/citation/rateLimiter.ts`): Simplified the limiter cache by removing the `ApiLimiter` wrapper interface.
4. **Polling concurrency** (`src/tools/github/PollingSourceBase.ts`): Replaced `Promise.allSettled` with `pMap` to enforce configurable concurrency limits.

## Issue acceptance gates

No specific issue referenced. This is a refactoring to improve code maintainability and correctness.

## Single source of truth

- **Node retry coordination**: `p-retry` library now owns the auto-retry loop and delay logic; manual retry is still coordinated by the outer loop in `_exec`.
- **Session mutations**: `async-mutex` now owns the exclusive access guarantee; `sessionMutationVersion` tracks logical ordering.
- **Rate limiting**: `pThrottle` owns the per-API delay enforcement; the `limiters` map caches throttled functions.
- **Polling concurrency**: `pMap` with `concurrency` option owns the concurrent request limit.

## Duplication and abstraction budget

- **Removed**: Custom retry loop with manual delay handling, promise-chaining for sequential mutations, and `ApiLimiter` wrapper.
- **Avoided**: Re-implementing abort signal handling, mutex semantics, and throttling—all now delegated to proven libraries.
- **Added**: No new abstractions; existing public APIs (`_exec`, `loadStableSession`, `waitForRateLimit`, `tick`) remain unchanged.

## Host impact

Extension: No user-facing changes; internal coordination improvements.

Desktop: No user-facing changes; internal coordination improvements.

CLI: No user-facing changes; internal coordination improvements.

## Scheduled refactoring

None.

## Validation

- Existing unit and integration tests should pass without modification (public APIs unchanged).
- Manual testing of agent retry flows (including abort via cancellation token) recommended.
- Manual testing of concurrent session mutations (e.g., rapid token refresh + store operations) recommended.
- Polling concurrency limits should be verified in GitHub source integration tests.

https://claude.ai/code/session_01Bicj8t7TnEQaaCLuGwMYhU

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent retry/cancellation, auth session storage ordering, and GitHub poll concurrency (now capped per tick); behavior is intended to match prior semantics but deserves targeted tests around abort and concurrent session updates.
> 
> **Overview**
> Swaps hand-rolled coordination in four areas for **`p-retry`**, **`async-mutex`**, **`p-throttle`**, and **`p-map`**, while keeping the same public entry points (`Node._exec`, session store/load, `waitForRateLimit`, GitHub polling `tick`).
> 
> **Agent `Node` retries** now use **`p-retry`** for auto-retries (fixed `wait` delay, `shouldAutoRetry`, abort `signal`), with an outer loop still driving **`retryPrompt`** manual retries. Abort/cancel paths are tightened so **`execFallback`** gets the original exec failure when cancellation happens during inter-retry waits, not only `signal.reason`.
> 
> **Supabase session mutations** replace promise-chaining and pending counters with an **`async-mutex`**: exclusive **`runSessionMutation`**, stable reads via **`waitForUnlock`**, and **`isLocked()`** checks when deciding whether a refresh store is still current.
> 
> **Citation rate limiting** inlines the per-API throttle cache (same **`pThrottle`** behavior when `minDelayMs` changes).
> 
> **GitHub polling** runs subscription polls through **`pMap`** with **`config.maxConcurrent`** and **`stopOnError: false`**, instead of unbounded **`Promise.allSettled`** over every subscription each tick.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0346761279768a88144fdfec680ebc48f3e6c4ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->