### PR TITLE
refactor(agent): unify the two AgentCreator blueprint nodes

### DIFF
--- a/src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts
+++ b/src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts
@@ -293,13 +293,21 @@ class GatherInputNode extends Node<AgentCreatorShared> {
   }
 }
 
-class WorkflowBlueprintNode extends Node<AgentCreatorShared> {
+/**
+ * Builds the {@link AgentBlueprint} for the category chosen upstream. Both
+ * categories share the same prep/post and the same `AGENT_NAME`/`DESCRIPTION`
+ * render vars; only `toolUse` runs the tool-pick step and contributes the
+ * tool-derived vars. The tool pick happens before the target directory is
+ * resolved so cancelling it short-circuits without side effects.
+ */
+class BlueprintNode extends Node<AgentCreatorShared> {
   constructor(private ui: AgentCreatorUI) {
     super();
   }
 
   async prep(shared: AgentCreatorShared) {
     return {
+      category: shared.category,
       agentName: shared.agentName!,
       description: shared.description!,
       config: shared.config,
@@ -307,71 +315,43 @@ class WorkflowBlueprintNode extends Node<AgentCreatorShared> {
   }
 
   async exec(prepRes: {
+    category: AgentCategory;
     agentName: string;
     description: string;
     config: CreatorConfig;
   }): Promise<AgentBlueprint | undefined> {
-    const { agentName, description, config } = prepRes;
+    const { category, agentName, description, config } = prepRes;
+    const base = { AGENT_NAME: agentName, DESCRIPTION: description };
+
+    if (category === 'toolUse') {
+      const picked = await this.ui.pickTools(agentName, description);
+      if (!picked) return undefined;
+      const targetDir = await this.ui.getCustomAgentDir();
+      return {
+        category: 'toolUse',
+        agentName,
+        filePath: path.join(targetDir, `${agentName}.yaml`),
+        aiVars: {
+          ...base,
+          SELECTED_TOOLS: picked.tools.join(', '),
+          SELECTED_GROUPS: picked.groups.join(', '),
+        },
+        fallbackTemplate: config.templates.toolUse,
+        fallbackVars: {
+          ...base,
+          TOOLS_YAML: picked.tools.map((t) => `    - ${t}`).join('\n'),
+        },
+      };
+    }
+
     const targetDir = await this.ui.getCustomAgentDir();
     return {
       category: 'workflow',
       agentName,
       filePath: path.join(targetDir, `${agentName}.yaml`),
-      aiVars: { AGENT_NAME: agentName, DESCRIPTION: description },
+      aiVars: { ...base },
       fallbackTemplate: config.templates.workflowSingle,
-      fallbackVars: { AGENT_NAME: agentName, DESCRIPTION: description },
-    };
-  }
-
-  async post(
-    shared: AgentCreatorShared,
-    _prepRes: unknown,
-    execRes: AgentBlueprint | undefined,
-  ): Promise<string | undefined> {
-    if (!execRes) return 'cancel';
-    shared.blueprint = execRes;
-    return FlowTransition.DEFAULT;
-  }
-}
-
-class ToolUseBlueprintNode extends Node<AgentCreatorShared> {
-  constructor(private ui: AgentCreatorUI) {
-    super();
-  }
-
-  async prep(shared: AgentCreatorShared) {
-    return {
-      agentName: shared.agentName!,
-      description: shared.description!,
-      config: shared.config,
-    };
-  }
-
-  async exec(prepRes: {
-    agentName: string;
-    description: string;
-    config: CreatorConfig;
-  }): Promise<AgentBlueprint | undefined> {
-    const { agentName, description, config } = prepRes;
-    const picked = await this.ui.pickTools(agentName, description);
-    if (!picked) return undefined;
-    const targetDir = await this.ui.getCustomAgentDir();
-    return {
-      category: 'toolUse',
-      agentName,
-      filePath: path.join(targetDir, `${agentName}.yaml`),
-      aiVars: {
-        AGENT_NAME: agentName,
-        DESCRIPTION: description,
-        SELECTED_TOOLS: picked.tools.join(', '),
-        SELECTED_GROUPS: picked.groups.join(', '),
-      },
-      fallbackTemplate: config.templates.toolUse,
-      fallbackVars: {
-        AGENT_NAME: agentName,
-        DESCRIPTION: description,
-        TOOLS_YAML: picked.tools.map((t) => `    - ${t}`).join('\n'),
-      },
+      fallbackVars: { ...base },
     };
   }
 
@@ -526,16 +506,14 @@ export function createAgentCreatorFlow(
   ui: AgentCreatorUI,
 ): Flow<AgentCreatorShared> {
   const gatherInput = new GatherInputNode(ui);
-  const workflowBlueprint = new WorkflowBlueprintNode(ui);
-  const toolUseBlueprint = new ToolUseBlueprintNode(ui);
+  const blueprint = new BlueprintNode(ui);
   const generate = new GenerateNode(ui);
   const register = new RegisterNode(ui);
 
-  gatherInput.on('workflow', workflowBlueprint);
-  gatherInput.on('toolUse', toolUseBlueprint);
+  gatherInput.on('workflow', blueprint);
+  gatherInput.on('toolUse', blueprint);
 
-  workflowBlueprint.next(generate);
-  toolUseBlueprint.next(generate);
+  blueprint.next(generate);
   generate.next(register);
 
   return new Flow<AgentCreatorShared>(gatherInput);


### PR DESCRIPTION
## What

`WorkflowBlueprintNode` and `ToolUseBlueprintNode` (in `agentCreatorFlow.ts`) had **identical** constructor, `prep`, and `post`, and an `exec` that differed only by the optional tool-pick step. This collapses them into a single `BlueprintNode` that reads the chosen category from `shared.category` (the existing source of truth) and branches in `exec` only for the `toolUse` tool pick and its tool-derived render vars. Both `gatherInput` transitions route to the one instance.

## Why

Per the lean-codebase mandate (#6623): two node classes that are 90% the same are a duplicated source of truth for "how a blueprint is built." One parameterized node is leaner and keeps the workflow/toolUse blueprint logic side by side where the only real difference is visible.

## Behavior-preserving

- Identical blueprint output for both categories (same `aiVars`/`fallbackVars`/`filePath`/`fallbackTemplate`).
- Same ordering: `pickTools` runs **before** `getCustomAgentDir`, so cancelling the tool pick still short-circuits without resolving the target dir.
- Same cancel semantics (`post` returns `'cancel'` on `undefined`).
- Public API `createAgentCreatorFlow(ui)` unchanged.

Net **−22 LOC**, one fewer node class. `npm run typecheck` clean for the touched file (remaining repo-baseline `ky`/openrouter module-resolution errors are pre-existing and unrelated).

Part of #6623.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving structural refactor in the agent creator flow only; no API or blueprint output contract changes.
> 
> **Overview**
> **Refactors** the agent creator flow by replacing `WorkflowBlueprintNode` and `ToolUseBlueprintNode` with a single **`BlueprintNode`** that shares one `prep`/`post` and branches in `exec` on `category`.
> 
> For **`toolUse`**, behavior is unchanged: `pickTools` still runs before `getCustomAgentDir`, cancel still returns `undefined` → `'cancel'`, and the same tool-related `aiVars` / `TOOLS_YAML` fallback vars are produced. **`workflow`** still builds the same blueprint with shared `AGENT_NAME` / `DESCRIPTION` vars.
> 
> `createAgentCreatorFlow` now wires both `gatherInput` transitions (`workflow` and `toolUse`) to the same blueprint instance, then `blueprint` → `generate` → `register` as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00d3d5788b4700375e57f7d451cefb9ab858aa5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->