### PR TITLE
refactor(agent): trim three dead-code surfaces; add SDK-readiness checkpoint

### DIFF
--- a/docs/proposals/agent-sdk-readiness-checkpoint-2026-06-26.md
+++ b/docs/proposals/agent-sdk-readiness-checkpoint-2026-06-26.md
@@ -1,0 +1,219 @@
+# Agent SDK Readiness — Verification Checkpoint (2026-06-26)
+
+**Status:** Verification checkpoint, not a new audit. Read alongside the canonical
+[`agent-sdk-readiness.md`](./agent-sdk-readiness.md), the
+[`agent-sdk-readiness-delta-2026-06-24.md`](./agent-sdk-readiness-delta-2026-06-24.md)
+addendum, and the [`agent-sdk-readiness-checkpoint-2026-06-25.md`](./agent-sdk-readiness-checkpoint-2026-06-25.md)
+checkpoint. This pass re-verified the standing audit against the working tree at
+HEAD (`93af483`) and records **only** what is genuinely new since the 2026-06-25
+checkpoint. It does not re-audit or re-litigate adjudicated findings.
+
+## Why this exists
+
+Another "review and refactor for Agent SDK readiness" request landed, scoped (as
+before) against the same four areas: agent core + runtime, `modelHandlers/`,
+logger/trace, and the public surface. Exactly as the 2026-06-25 checkpoint
+predicted for a recurring request, four independent uninformed fan-out audits
+re-surfaced several already-adjudicated traps. Those are filtered out here and
+listed under "Already adjudicated — do NOT re-litigate." What remains is a small
+set of genuinely-new, additive micro-findings; the three safest were applied this
+pass under the established behavior-neutral discipline.
+
+## Verdict — unchanged
+
+**The codebase remains well-aligned and continues to converge on the plan.** The
+SDK-idiomatic spine is intact and re-confirmed in-tree: the PocketFlow
+`Node.exec → createFlow().run` shape, the `AgentTrace` emit/subscribe channel,
+the `platform()` composition root, the `createModelHandler` factory, and the
+lead-and-specialists delegation model. The four audits independently reached the
+same conclusion the canonical plan already holds — there are no barrels, no
+re-export shims, and no trivial/two-layer identity factories in `modelHandlers/`;
+the logger is already a single hop (host-injected sink, no `platform().log`
+port); and the cycle-wrapper nodes are the *mandated* shape, not the anti-pattern.
+The live work remains **surface curation and per-session state relocation**.
+
+## Drift since 2026-06-25
+
+The plan keeps landing through the PR train. Since the `b2dcd42` checkpoint base:
+
+- **PR #6620 merged** (`b62eb1f`) — lands the deferred delta cleanups P3a
+  (empty-type flow-param aliases removed) and P3b (`withModelClient` closure DRY,
+  liveness-safe). Both now present at HEAD, confirming the prior checkpoint's
+  "this PR" rows.
+- **`cee3eb6`** `refactor(agent): collapse the two AgentCreator blueprint nodes
+  into one` — another abstraction-collapse landing in the same direction.
+- **`93af483`**, **`b9bd9b5`**, **`7043749`** — CLI module split + config-catalog
+  unification plan; unrelated to the four audit areas, no regressions to the spine.
+
+## Applied this pass (#this-PR) — three new behavior-neutral micro-cleanups
+
+Each was traced to ground truth and confirmed a **pure dead-code deletion** (zero
+production and test callers) before editing. Verified: `npm run typecheck` exit 0
+across all four projects (root, test-kernel, `texra`, `@texra-ai/cli`); `npx
+vitest run src/test-kernel/agent` → **649 passed, 4 skipped** (116 files);
+`npx eslint` over the four touched files → 0 errors.
+
+1. **Dead `PersistedFlow.step()` wrapper removed.**
+   (`src/agent/node/persistedFlow.ts`). The one-line `step()` —
+   `const result = await this.stepWithResult(); return result.hasMore;` — had a
+   single caller: the base-class `run()` loop in the same file (`RoundPersistedFlow`
+   overrides `run()` and calls `stepWithResult()` directly, never `step()`).
+   Inlined into `run()` as `while ((await this.stepWithResult()).hasMore) {}`.
+   Removes one method from the class surface; no behavior change.
+
+2. **Dead registry re-exports dropped.**
+   (`src/agent/index/agentRegistry.ts`). The block re-exported
+   `BUNDLED_ORCHESTRATOR_AGENT_NAMES` and `REMOTE_ORCHESTRATOR_AGENT_NAMES` from
+   `agentRegistryConstants` — a re-export of a re-export. Grep confirms **no
+   consumer imports either via the registry path**: the one real consumer
+   (`src/tools/setup/ApplyTeamTool.ts`) imports `REMOTE_ORCHESTRATOR_AGENT_NAMES`
+   directly from `@shared/constants/agents`, `BUNDLED_…` has zero importers
+   anywhere outside the constants chain, and the `@agent/index` barrel does not
+   re-export either. `BUILTIN_TEAM_ROOT_AGENT_NAMES` (consumed via the barrel by
+   `packages/cli/.../multiAgentPresets.ts`) was kept. Narrows the registry's
+   public surface.
+
+3. **Dead `isOutputStreamingEnabled()` getter removed from the port + base.**
+   (`src/agent/modelHandlers/types/IModelHandler.ts`,
+   `src/agent/modelHandlers/ModelHandler.ts`). Declared on `IModelHandler` and
+   defined on `ModelHandler`, but **never read anywhere** (the setter
+   `setOutputStreaming` is used; the getter is not, and the `outputStreaming`
+   field is read internally without it). Removed both declaration and
+   implementation. One fewer member every provider must satisfy — a small step on
+   the "trim the over-wide `IModelHandler` port" track.
+
+## Genuinely-new findings — NOT applied (additive backlog)
+
+None of these are in the existing ledger/delta/checkpoint docs. They are ranked;
+all are deferred to the reviewed PR train rather than applied unattended.
+
+### Core / runtime
+
+- **`RetryState` interface + redundant third parameter** *(HIGH)*. `RetryState`
+  (`src/agent/core/flows/RetryState.ts:29-31`) is a one-field interface
+  (`lastError?`) whose only field is already on `BaseCycleFields`
+  (`CommonCycleTypes.ts`). `handleInvocationResult(execRes, state, retryState, …)`
+  takes `state` and `retryState` as separate params, but the sole non-test call
+  site passes the **same object for both**: `handleInvocationResult(execRes,
+  shared, shared, …)` (`ModelInvocationNode.ts:123`). Collapse to a single
+  `state` param widened to carry `lastError`, and delete the `RetryState`
+  interface. Behavior-neutral; a function-signature change, so left for review.
+
+### Model handlers (port-narrowing / surface curation track)
+
+- **Four port members that leak internal surface** *(MEDIUM — design)*.
+  `getAgentCategory()` (getter), `canProcessToolResultAttachments`,
+  `createMediaContent`, and `createAssistantMessage` are on `IModelHandler` but
+  are only ever invoked as `this.x` inside handler implementations — no external
+  consumer calls them. They widen the contract every provider must expose.
+  Candidates to drop from the port (keep as `protected`/abstract on the base).
+  This is the same "trim the ~45-member flattened-union port" item the canonical
+  plan tracks; advance it deliberately, not mechanically.
+- **Three `public` base methods that should be `protected`** *(LOW)*.
+  `createMediaMessage`, `containCutOffMessage`, `getApiKey` (`ModelHandler.ts`)
+  have only `this.` callers in subclasses (plus one test). Tighten visibility.
+- **`createResponse` template body duplicated in two handlers** *(LOW)*.
+  `modelHandlerOpenAIResponse.ts` and `modelHandlerGoogleInteractions.ts` override
+  `createResponse` itself and hand-copy the base's `withSdkErrorTag(this.
+  sdkErrorTagger, …)` wrap just to add a single-turn `inFlight` guard. Add a
+  `protected` guard hook so the base keeps owning the error-tag wrap and the two
+  only supply the guard (~12 lines of copied template body removed, drift risk
+  eliminated).
+
+### Public surface (barrel curation)
+
+- **Over-wide `@agent/index` barrel** *(LOW)*. `src/agent/index/index.ts`
+  re-exports ~10 type symbols with zero cross-module consumers
+  (`AgentDirectoryServiceOptions`, `CustomAgentDirectoryStore`,
+  `AgentDirectoryDocsId`, `AgentDirectoryBundleSource`, `AgentDirectoryStorage`,
+  `AgentDirectorySyncLogger`, `AgentDirectoryVersionStore`,
+  `BundledAgentDirectorySyncOptions`, `BundledAgentDirectoryName`,
+  `AgentDirectories`). Trimming them to the symbols with real consumers curates
+  the SDK-facing surface. Deferred because barrel curation is a deliberate surface
+  decision, not a mechanical delete.
+- **`PlatformAgentDirectoryBootstrapOptions` exported, zero external consumers**
+  *(LOW)* (`platformAgentDirectories.ts:23`). Inline as the parameter type or drop
+  the `export`.
+- **NOTE — `sortAgentEntries` export is NOT removable.** The
+  2026-06-26 audit flagged dropping its `export` (`agentOptionsBuilder.ts:34`) as
+  internal-only; that is **wrong** — it is imported cross-file by
+  `agentRegistry.ts:27` within the same module, so the `export` is load-bearing.
+  Recorded here so the next uninformed pass does not re-propose it.
+
+### Documentation drift
+
+- **Stale `agent-trace-sdk-surface.md`** *(doc fix)*. That proposal
+  (`docs/proposals/agent-trace-sdk-surface.md:26`) references a `@agent/core/logger`
+  facade, an `AgentLogger` class, and `platform().log` — **none of which exist**
+  (the logger was already flattened to a single host-injected sink). The proposal
+  has been executed; the prose should be reconciled or marked landed.
+
+## Already adjudicated — do NOT re-litigate
+
+The uninformed passes re-surfaced these; the standing rulings hold at HEAD
+(`93af483`). See the delta-2026-06-24 table for citations.
+
+| Re-surfaced candidate | Ruling |
+| --- | --- |
+| Remove `IModelHandler` as a "duplicate" of `ModelHandler` | **Trap** — optional `createBatchedToolUseFollowUpMessages` makes it load-bearing; removal breaks `tsc`. |
+| Inline the cycle-wrapper nodes / `createXCycleFlow` factories | **Keep** — this *is* the mandated `Node.exec → createFlow → flow.run` shape. |
+| Merge `ModelHandlerOpenRouterNative` into the OpenAI base | **Trap** — two real SDK type families; the merge was deliberately deleted in PR #2962. |
+| Dedup MiniMax `extractTextFromReasoningDetails` into the shared util | **Trap** — different input shapes; the shared util would return empty reasoning for MiniMax's `type: 'thinking'` items. |
+| Split `modelHandlerOpenAIResponse.ts` (god-file) into collaborators | **Real smell, not a quick win** — shared mutable state + background polling + test subclassing. Tracked design migration. |
+| `@logger` not routed through `platform()` | **Intentional, documented** — logging is its own host-injected subsystem (`platform.ts:23-28`). |
+| UsageMonitor `updateStreamUsage` + `logger.usage` "double emit" | **Documented dual-sink** (sidebar vs. transcript), agentCategory-gated, intentional. |
+
+## Subagent split points — re-confirmed
+
+No change to the canonical/delta analysis. TeXRA already has a **mature subagent
+mechanism**; the only gap is that it is a *tool call*, not a typed primitive:
+
+- YAML agent profiles (`{ name, description, settings.tools, prompts.systemPrompt }`)
+  are near-isomorphic to the SDK `AgentDefinition`; the two flow implementations
+  (reflection, tool-use) run *all* 6 workflow + ~18 tool-use agents — a new
+  subagent is a YAML + tool-list, never new flow code.
+- Teams (`AGENT_MODE_PRESETS`) are the SDK "available subagents" roster;
+  `delegate_agent`/`delegate_workflow` + `executeSubagent`
+  (`src/tools/DelegationTools.ts`) are the isolated-context delegation primitive
+  (own `RunContext`, KV store, usage accumulator, depth-gating, cost roll-up,
+  async result delivery via `FollowUpQueue`); read-only-by-tool reviewers
+  (`changeReviewer`, no bash) already model SDK tool-scoping.
+
+Split points ranked by value/effort (unchanged):
+
+1. **Wire the existing `review` tool-use agent as a post-draft Verifier
+   delegation** — lowest risk, reuses `executeSubagent`, no new flow code.
+2. **Introduce a typed `delegateTo(subagent, input, { maxDepth, tools })`
+   primitive** over the existing plumbing — decouples delegation from "did the
+   model emit a tool call." Structural pre-work landed (`d32be3b`/`a15dd86`
+   extracted per-category flow runners).
+3. **Formalize workflow agents (`polish`/`correct`/`merge`) as SDK actors with
+   typed I/O contracts** — already isolated single-turn deterministic actors.
+4. **Relocate the three module-global registries onto the per-session handle**
+   (`executionRegistry` Maps, `runCoordinators.bridgeState` — *relocate, never
+   delete*, it is load-bearing — and the interrupt registry). Gates concurrent
+   in-process sessions.
+5. **Decompose in-agent multi-phase workflow agents** (`devise`, `verifyFix`)
+   into draft → Verifier → apply hand-offs — gated by #4.
+
+## Recommendation
+
+**The codebase is SDK-ready in shape; no structural refactoring is warranted.**
+This pass applied three behavior-neutral dead-code deletions and recorded the
+remaining additive micro-findings as backlog for the reviewed PR train. Continue
+executing the canonical plan's surface/multi-tenant track (port narrowing,
+per-session state relocation, the typed `delegateTo` primitive, and wiring
+`review` as the first Verifier delegation). Do not re-open the adjudicated traps.
+
+## Verified (this checkpoint)
+
+- `npm run typecheck` — exit 0 across all four projects.
+- `npx vitest run src/test-kernel/agent` — 649 passed, 4 skipped (116 files).
+- `npx eslint` over the four touched files — 0 errors.
+- Grep-confirmed zero callers for each applied deletion: `.step(` (only the
+  base `run()` loop), `BUNDLED_/REMOTE_ORCHESTRATOR_AGENT_NAMES` via the registry
+  path (none), `isOutputStreamingEnabled` (only its own declaration + definition).
+- `git log` since 2026-06-25 over `src/agent` (the PR #6620 / `cee3eb6` landings
+  cited above).
+</content>
+</invoke>

--- a/docs/proposals/agent-sdk-readiness-checkpoint-2026-06-26.md
+++ b/docs/proposals/agent-sdk-readiness-checkpoint-2026-06-26.md
@@ -215,5 +215,3 @@ per-session state relocation, the typed `delegateTo` primitive, and wiring
   path (none), `isOutputStreamingEnabled` (only its own declaration + definition).
 - `git log` since 2026-06-25 over `src/agent` (the PR #6620 / `cee3eb6` landings
   cited above).
-  </content>
-  </invoke>

--- a/docs/proposals/agent-sdk-readiness-checkpoint-2026-06-26.md
+++ b/docs/proposals/agent-sdk-readiness-checkpoint-2026-06-26.md
@@ -29,7 +29,7 @@ lead-and-specialists delegation model. The four audits independently reached the
 same conclusion the canonical plan already holds — there are no barrels, no
 re-export shims, and no trivial/two-layer identity factories in `modelHandlers/`;
 the logger is already a single hop (host-injected sink, no `platform().log`
-port); and the cycle-wrapper nodes are the *mandated* shape, not the anti-pattern.
+port); and the cycle-wrapper nodes are the _mandated_ shape, not the anti-pattern.
 The live work remains **surface curation and per-session state relocation**.
 
 ## Drift since 2026-06-25
@@ -41,7 +41,7 @@ The plan keeps landing through the PR train. Since the `b2dcd42` checkpoint base
   liveness-safe). Both now present at HEAD, confirming the prior checkpoint's
   "this PR" rows.
 - **`cee3eb6`** `refactor(agent): collapse the two AgentCreator blueprint nodes
-  into one` — another abstraction-collapse landing in the same direction.
+into one` — another abstraction-collapse landing in the same direction.
 - **`93af483`**, **`b9bd9b5`**, **`7043749`** — CLI module split + config-catalog
   unification plan; unrelated to the four audit areas, no regressions to the spine.
 
@@ -89,19 +89,19 @@ all are deferred to the reviewed PR train rather than applied unattended.
 
 ### Core / runtime
 
-- **`RetryState` interface + redundant third parameter** *(HIGH)*. `RetryState`
+- **`RetryState` interface + redundant third parameter** _(HIGH)_. `RetryState`
   (`src/agent/core/flows/RetryState.ts:29-31`) is a one-field interface
   (`lastError?`) whose only field is already on `BaseCycleFields`
   (`CommonCycleTypes.ts`). `handleInvocationResult(execRes, state, retryState, …)`
   takes `state` and `retryState` as separate params, but the sole non-test call
   site passes the **same object for both**: `handleInvocationResult(execRes,
-  shared, shared, …)` (`ModelInvocationNode.ts:123`). Collapse to a single
+shared, shared, …)` (`ModelInvocationNode.ts:123`). Collapse to a single
   `state` param widened to carry `lastError`, and delete the `RetryState`
   interface. Behavior-neutral; a function-signature change, so left for review.
 
 ### Model handlers (port-narrowing / surface curation track)
 
-- **Four port members that leak internal surface** *(MEDIUM — design)*.
+- **Four port members that leak internal surface** _(MEDIUM — design)_.
   `getAgentCategory()` (getter), `canProcessToolResultAttachments`,
   `createMediaContent`, and `createAssistantMessage` are on `IModelHandler` but
   are only ever invoked as `this.x` inside handler implementations — no external
@@ -109,20 +109,20 @@ all are deferred to the reviewed PR train rather than applied unattended.
   Candidates to drop from the port (keep as `protected`/abstract on the base).
   This is the same "trim the ~45-member flattened-union port" item the canonical
   plan tracks; advance it deliberately, not mechanically.
-- **Three `public` base methods that should be `protected`** *(LOW)*.
+- **Three `public` base methods that should be `protected`** _(LOW)_.
   `createMediaMessage`, `containCutOffMessage`, `getApiKey` (`ModelHandler.ts`)
   have only `this.` callers in subclasses (plus one test). Tighten visibility.
-- **`createResponse` template body duplicated in two handlers** *(LOW)*.
+- **`createResponse` template body duplicated in two handlers** _(LOW)_.
   `modelHandlerOpenAIResponse.ts` and `modelHandlerGoogleInteractions.ts` override
   `createResponse` itself and hand-copy the base's `withSdkErrorTag(this.
-  sdkErrorTagger, …)` wrap just to add a single-turn `inFlight` guard. Add a
+sdkErrorTagger, …)` wrap just to add a single-turn `inFlight` guard. Add a
   `protected` guard hook so the base keeps owning the error-tag wrap and the two
   only supply the guard (~12 lines of copied template body removed, drift risk
   eliminated).
 
 ### Public surface (barrel curation)
 
-- **Over-wide `@agent/index` barrel** *(LOW)*. `src/agent/index/index.ts`
+- **Over-wide `@agent/index` barrel** _(LOW)_. `src/agent/index/index.ts`
   re-exports ~10 type symbols with zero cross-module consumers
   (`AgentDirectoryServiceOptions`, `CustomAgentDirectoryStore`,
   `AgentDirectoryDocsId`, `AgentDirectoryBundleSource`, `AgentDirectoryStorage`,
@@ -132,7 +132,7 @@ all are deferred to the reviewed PR train rather than applied unattended.
   the SDK-facing surface. Deferred because barrel curation is a deliberate surface
   decision, not a mechanical delete.
 - **`PlatformAgentDirectoryBootstrapOptions` exported, zero external consumers**
-  *(LOW)* (`platformAgentDirectories.ts:23`). Inline as the parameter type or drop
+  _(LOW)_ (`platformAgentDirectories.ts:23`). Inline as the parameter type or drop
   the `export`.
 - **NOTE — `sortAgentEntries` export is NOT removable.** The
   2026-06-26 audit flagged dropping its `export` (`agentOptionsBuilder.ts:34`) as
@@ -142,7 +142,7 @@ all are deferred to the reviewed PR train rather than applied unattended.
 
 ### Documentation drift
 
-- **Stale `agent-trace-sdk-surface.md`** *(doc fix)*. That proposal
+- **Stale `agent-trace-sdk-surface.md`** _(doc fix)_. That proposal
   (`docs/proposals/agent-trace-sdk-surface.md:26`) references a `@agent/core/logger`
   facade, an `AgentLogger` class, and `platform().log` — **none of which exist**
   (the logger was already flattened to a single host-injected sink). The proposal
@@ -153,24 +153,24 @@ all are deferred to the reviewed PR train rather than applied unattended.
 The uninformed passes re-surfaced these; the standing rulings hold at HEAD
 (`93af483`). See the delta-2026-06-24 table for citations.
 
-| Re-surfaced candidate | Ruling |
-| --- | --- |
-| Remove `IModelHandler` as a "duplicate" of `ModelHandler` | **Trap** — optional `createBatchedToolUseFollowUpMessages` makes it load-bearing; removal breaks `tsc`. |
-| Inline the cycle-wrapper nodes / `createXCycleFlow` factories | **Keep** — this *is* the mandated `Node.exec → createFlow → flow.run` shape. |
-| Merge `ModelHandlerOpenRouterNative` into the OpenAI base | **Trap** — two real SDK type families; the merge was deliberately deleted in PR #2962. |
-| Dedup MiniMax `extractTextFromReasoningDetails` into the shared util | **Trap** — different input shapes; the shared util would return empty reasoning for MiniMax's `type: 'thinking'` items. |
-| Split `modelHandlerOpenAIResponse.ts` (god-file) into collaborators | **Real smell, not a quick win** — shared mutable state + background polling + test subclassing. Tracked design migration. |
-| `@logger` not routed through `platform()` | **Intentional, documented** — logging is its own host-injected subsystem (`platform.ts:23-28`). |
-| UsageMonitor `updateStreamUsage` + `logger.usage` "double emit" | **Documented dual-sink** (sidebar vs. transcript), agentCategory-gated, intentional. |
+| Re-surfaced candidate                                                | Ruling                                                                                                                    |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Remove `IModelHandler` as a "duplicate" of `ModelHandler`            | **Trap** — optional `createBatchedToolUseFollowUpMessages` makes it load-bearing; removal breaks `tsc`.                   |
+| Inline the cycle-wrapper nodes / `createXCycleFlow` factories        | **Keep** — this _is_ the mandated `Node.exec → createFlow → flow.run` shape.                                              |
+| Merge `ModelHandlerOpenRouterNative` into the OpenAI base            | **Trap** — two real SDK type families; the merge was deliberately deleted in PR #2962.                                    |
+| Dedup MiniMax `extractTextFromReasoningDetails` into the shared util | **Trap** — different input shapes; the shared util would return empty reasoning for MiniMax's `type: 'thinking'` items.   |
+| Split `modelHandlerOpenAIResponse.ts` (god-file) into collaborators  | **Real smell, not a quick win** — shared mutable state + background polling + test subclassing. Tracked design migration. |
+| `@logger` not routed through `platform()`                            | **Intentional, documented** — logging is its own host-injected subsystem (`platform.ts:23-28`).                           |
+| UsageMonitor `updateStreamUsage` + `logger.usage` "double emit"      | **Documented dual-sink** (sidebar vs. transcript), agentCategory-gated, intentional.                                      |
 
 ## Subagent split points — re-confirmed
 
 No change to the canonical/delta analysis. TeXRA already has a **mature subagent
-mechanism**; the only gap is that it is a *tool call*, not a typed primitive:
+mechanism**; the only gap is that it is a _tool call_, not a typed primitive:
 
 - YAML agent profiles (`{ name, description, settings.tools, prompts.systemPrompt }`)
   are near-isomorphic to the SDK `AgentDefinition`; the two flow implementations
-  (reflection, tool-use) run *all* 6 workflow + ~18 tool-use agents — a new
+  (reflection, tool-use) run _all_ 6 workflow + ~18 tool-use agents — a new
   subagent is a YAML + tool-list, never new flow code.
 - Teams (`AGENT_MODE_PRESETS`) are the SDK "available subagents" roster;
   `delegate_agent`/`delegate_workflow` + `executeSubagent`
@@ -190,8 +190,8 @@ Split points ranked by value/effort (unchanged):
 3. **Formalize workflow agents (`polish`/`correct`/`merge`) as SDK actors with
    typed I/O contracts** — already isolated single-turn deterministic actors.
 4. **Relocate the three module-global registries onto the per-session handle**
-   (`executionRegistry` Maps, `runCoordinators.bridgeState` — *relocate, never
-   delete*, it is load-bearing — and the interrupt registry). Gates concurrent
+   (`executionRegistry` Maps, `runCoordinators.bridgeState` — _relocate, never
+   delete_, it is load-bearing — and the interrupt registry). Gates concurrent
    in-process sessions.
 5. **Decompose in-agent multi-phase workflow agents** (`devise`, `verifyFix`)
    into draft → Verifier → apply hand-offs — gated by #4.
@@ -215,5 +215,5 @@ per-session state relocation, the typed `delegateTo` primitive, and wiring
   path (none), `isOutputStreamingEnabled` (only its own declaration + definition).
 - `git log` since 2026-06-25 over `src/agent` (the PR #6620 / `cee3eb6` landings
   cited above).
-</content>
-</invoke>
+  </content>
+  </invoke>

--- a/docs/proposals/config-catalog-unification.md
+++ b/docs/proposals/config-catalog-unification.md
@@ -14,9 +14,9 @@ Decision (already made by the user): **full unification** — one catalog as SSO
 
 Exploration disproved two load-bearing assumptions in the draft. Both change the design:
 
-1. **State-backed keys must NOT become `CoreSettingsShape` nodes.** Every node in `CoreSettingsShape` flows into `CORE_SETTING_PATHS` → `TEXRA_SETTING_PATHS` → the package.json generator → a VS Code *configuration* contribution. But the extension reads the state-backed keys (e.g. `texra.git.markCommits`, `texra.workflow.*`, `texra.latexdiff.*`) from **worktree-shared WorkspaceState** (`WORKTREE_SHARED_KEYS` in `packages/extension/src/common/state/stateManager.ts`), not from config — they were deliberately migrated *out* of config (`LATEX_SETTINGS_MIGRATED` marker). Adding them to `CoreSettingsShape` would emit phantom VS Code settings the extension never reads. → They live in a **separate** catalog (`stateSettings.ts`), not coreSettings.
+1. **State-backed keys must NOT become `CoreSettingsShape` nodes.** Every node in `CoreSettingsShape` flows into `CORE_SETTING_PATHS` → `TEXRA_SETTING_PATHS` → the package.json generator → a VS Code _configuration_ contribution. But the extension reads the state-backed keys (e.g. `texra.git.markCommits`, `texra.workflow.*`, `texra.latexdiff.*`) from **worktree-shared WorkspaceState** (`WORKTREE_SHARED_KEYS` in `packages/extension/src/common/state/stateManager.ts`), not from config — they were deliberately migrated _out_ of config (`LATEX_SETTINGS_MIGRATED` marker). Adding them to `CoreSettingsShape` would emit phantom VS Code settings the extension never reads. → They live in a **separate** catalog (`stateSettings.ts`), not coreSettings.
 
-2. **The CLI has three distinct stores, not a single shared one.** `packages/cli/src/runtime/initPlatform.ts:193-200` wires `config` = `JsonConfigProvider` (`.texra/config.json` + `~/.texra/.../config.json`), but `workspaceState` / `globalState` = **separate** `state.json` files (`cliStateStores.ts`). The git-author bridge (`gitAuthor.ts`) works only because it *explicitly* passes `config` into `readGitAuthorSettingsFromState(stateStore)` — exploiting structural read-compat (`ConfigProvider` and `StateStore` both expose `.get(key, default)`), **not** because `workspaceState === config`. So the accessor must be **host-aware**, and the git-author keys need an explicit per-entry `cliStore` override, not an assumed slot identity.
+2. **The CLI has three distinct stores, not a single shared one.** `packages/cli/src/runtime/initPlatform.ts:193-200` wires `config` = `JsonConfigProvider` (`.texra/config.json` + `~/.texra/.../config.json`), but `workspaceState` / `globalState` = **separate** `state.json` files (`cliStateStores.ts`). The git-author bridge (`gitAuthor.ts`) works only because it _explicitly_ passes `config` into `readGitAuthorSettingsFromState(stateStore)` — exploiting structural read-compat (`ConfigProvider` and `StateStore` both expose `.get(key, default)`), **not** because `workspaceState === config`. So the accessor must be **host-aware**, and the git-author keys need an explicit per-entry `cliStore` override, not an assumed slot identity.
 
 ## Catalog & store model
 
@@ -70,6 +70,7 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 ## PR sequence
 
 ### PR 1 — Generator carries `description` + `enumDescriptions` (no behavior change)
+
 - `texraSettings.ts:97` — extend `GENERATED_PACKAGE_SCHEMA_FIELDS` with `'description'`, `'enumDescriptions'` only. (`z.toJSONSchema()` already passes `.describe()` → `description` and merges `.meta()` keys; `pickPackageSchemaFields` is allowlist-driven so other meta stays out of package.json.)
 - `coreSettings.ts` + `vscodeSettings.ts` — add `.describe('…')` to every config leaf and `.meta({ enumDescriptions: [...] })` to enum leaves, **back-filled verbatim from the current package.json strings** so the first generator run is zero-diff.
 - `settingsConfiguration.vitest.ts` — **rewrite the `removes stale generated package schema fields` test (lines 157-180)**: it currently injects `description: 'Preserved description'` and asserts it survives. Once `description` is generated, that assertion is wrong — pivot it to a still-hand-kept field (`order` or `editPresentation`). Add an invariant: every enum leaf's `enumDescriptions.length === enum.length`.
@@ -77,6 +78,7 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 - **Verify:** `sync:settings-configuration --check` is zero-diff; `npm test` (idempotency `assert.deepEqual(build(sections), sections)`) green; `npm run typecheck`.
 
 ### PR 2 — `stateSettings.ts` catalog + `settingsAccess.ts` accessor + knownKeys derivation
+
 - New `src/shared/schemas/stateSettings.ts` — metadata-only rows for the state-backed keys, starting with the four git-author keys (`store:'workspaceState'`, `cliStore:'config'`, `hosts:['vscode','cli','desktop']`, `cliConsumer:'packages/cli/src/runtime/gitAuthor.ts'`) and the `workflow.*` / `latexdiff.*` / `latex.formatter` scalars (`store:'workspaceState'`, `hosts:['vscode','desktop']` for now). Export the key list.
 - New `src/shared/config/settingsAccess.ts` — `readSetting(entry, stores)` / `writeSetting(entry, value, stores)` where `stores = { config, workspaceState, globalState }`. Dispatch on `entry.store` (or `entry.cliStore` when the caller is the CLI); validate writes via the entry's Zod schema where one exists; **reset writes `undefined`** (deletes the key per `jsonConfigProvider.ts:57` → `.prefault()` reappears), never the literal default. `openForm` entries bypass the accessor.
 - `packages/cli/src/schemas/knownKeys.ts` — add `...STATE_SETTING_KEYS` from the catalog; **delete** the four hand-listed `WorkspaceStateKey.GIT_*` lines (31-34). The `WorkspaceStateKey` enum entries stay (the extension still uses them).
@@ -84,6 +86,7 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 - **Verify:** `npm test` (guardrails) + `npm run typecheck`; `gitAuthor.ts` still applies marking (route it through the accessor or leave as-is — both read the same keys from `config`).
 
 ### PR 3 — CLI `/config` panel (USER-VISIBLE; lands in CHANGELOG under Features)
+
 - New `packages/cli/src/chat/tui/forms/ConfigForm.tsx`. **Not a single-Select clone of `ApprovalPolicyForm`** — it is a list + drill-in:
   - Outer `Select` lists catalog entries where `hosts.includes('cli')` (label = setting name, `description` = current resolved value + its store, so cross-host state is visible — risk #1 mitigation).
   - Selecting a **boolean** toggles inline; an **enum** opens an inner `Select` of values (per-option text from `enumDescriptions`); an **`openForm`** entry delegates to the existing `ModelListForm`/`AgentListForm`/`MemoryListForm`/etc.
@@ -94,23 +97,27 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 - **Verify:** roster test = exactly the consumer-verified entries; `SlashRegistry.vitest` covers the new command; manual PTY run via `packages/cli/scripts/tui-harness.tsx` — open `/config`, flip a boolean + an enum, confirm persistence to `.texra/config.json` (project) and that `Esc` closes; confirm the headless `texra run` / `--print` path is byte-unchanged.
 
 ### PR 4 — Extension settingsView re-point (zero message/port/dispatch change)
-- Delete the hardcoded enum/label arrays and read labels/descriptions from the catalog: `AIAgentsTab.ts` (SANDBOX/REASONING/APPROVAL/CLAUDE option arrays, ~lines 40-98), `LaTeXTab.ts` (mathMarkup + formatter options, ~lines 590-616), plus inline labels in `ModelSelectionList.ts` (reasoning-level labels) and `ApiAccessSection.ts`/`ModelsTab.ts`. Splittable per-tab. (Note: the codex/claude option arrays are state-backed complex domains — promoting them to catalog rows is fine for *labels*; their read/write stays in the existing controllers.)
+
+- Delete the hardcoded enum/label arrays and read labels/descriptions from the catalog: `AIAgentsTab.ts` (SANDBOX/REASONING/APPROVAL/CLAUDE option arrays, ~lines 40-98), `LaTeXTab.ts` (mathMarkup + formatter options, ~lines 590-616), plus inline labels in `ModelSelectionList.ts` (reasoning-level labels) and `ApiAccessSection.ts`/`ModelsTab.ts`. Splittable per-tab. (Note: the codex/claude option arrays are state-backed complex domains — promoting them to catalog rows is fine for _labels_; their read/write stays in the existing controllers.)
 - **Verify:** webview renders identical labels; no port/schema diff; `npm run typecheck` + `npm test`.
 
 ### PR 5+ — Promote complex/state-backed domains incrementally (one per PR)
+
 - Add the CLI consumer code path for a domain (e.g. workflow/latexdiff scalars read in CLI from `platform().workspaceState`), flip its catalog `hosts` to include `'cli'`; the entry auto-appears in `/config`, and the PR2 guardrail enforces the consumer exists. Complex domains (streaming/endpoints/models/agents/tools/presets) come in as `openForm` delegations, not scalars.
 
 ## Critical files
+
 - `src/shared/schemas/coreSettings.ts` — `.describe()`/`.meta({enumDescriptions})` back-fill (PR1).
 - `packages/extension/src/schemas/{texraSettings.ts,vscodeSettings.ts}` — allowlist +`description`/`enumDescriptions`; describe the 3 vscode leaves (PR1).
 - `src/test-kernel/shared/settingsConfiguration.vitest.ts` — rewrite preserve-field test + enum-length invariant (PR1).
 - New `src/shared/schemas/stateSettings.ts`, `src/shared/config/settingsAccess.ts` (PR2).
-- `packages/cli/src/schemas/knownKeys.ts` — derive from catalog, delete GIT_* lines 31-34 (PR2).
+- `packages/cli/src/schemas/knownKeys.ts` — derive from catalog, delete GIT\_\* lines 31-34 (PR2).
 - New `packages/cli/src/chat/tui/forms/ConfigForm.tsx`; `packages/cli/src/chat/tui/commands/{registerBuiltins.tsx,slashRegistry.ts}`; `packages/cli/src/chat/tui/runChatTui.tsx:516` (PR3).
 - Extension tabs: `packages/extension/src/settingsView/frontend/tabs/{AIAgentsTab.ts,LaTeXTab.ts,ModelsTab.ts}` + `components/profile/{ModelSelectionList.ts,ApiAccessSection.ts}` (PR4).
 - Reused untouched: `ui/Select.tsx`, `forms/_shared/{FormFrame,selectWindow}.ts`, `src/controllers/settingsView/*`, `scripts/sync-settings-configuration.mjs`, `src/utils/system/gitAuthorSettings.ts`.
 
 ## Verification (every PR)
+
 - `npm run typecheck` and `npm test`.
 - PR1: `npm run sync:settings-configuration --check` zero-diff (proves `.describe()`/`.meta()`+`.prefault()` compose through `z.toJSONSchema()`); enum-length invariant green.
 - PR2: guardrail suite (consumer-exists, knownKeys-derivation, store/scope coherence, Class-D exclusion, default round-trip).
@@ -118,6 +125,7 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 - PR4: identical webview labels; no port/schema diff.
 
 ## Risk register
+
 1. **Cross-host store divergence** (a key set in extension WorkspaceState reads as default in the CLI). Mitigate: store/cliStore coherence guardrail; `/config` shows the resolved value **and its store**; no silent auto-bridge beyond the declared `cliStore` override.
 2. **`description` promotion breaks the existing preserve-field test** (`settingsConfiguration.vitest.ts:157-180` asserts a hand-injected description survives). Mitigate: rewrite that test in PR1 to assert a still-hand-kept field (`order`/`editPresentation`).
 3. **Incomplete `.describe()` back-fill deletes package.json descriptions** (allowlisted + absent in `.meta`/`.describe` ⇒ generator deletes the field). Mitigate: back-fill every config leaf; the idempotency `--check` fails CI on any miss.
@@ -126,10 +134,12 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 6. **ConfigForm complexity** (it's a list + drill-in, not one Select). Mitigate: MVP = booleans + enums + `openForm` only; defer free-text editing; reuse `MemoryListForm` list shape + `Select`.
 
 ## Explicit exclusions (omit `'cli'` from `hosts`; never surfaced in `/config`)
+
 - `texra.memory.enabled`, `texra.goal.enabled` — gated by `registerAgentFeatures()`, confirmed **never called in the CLI** (`initPlatform.ts` has no call; only `extension.ts:219` / desktop `index.ts:154`). Toggling them in the CLI does nothing.
 - `SUPER_YOLO_ENABLED`, `ALLOW_ORCHESTRATOR_KILL`, `DETACH_SUBAGENTS_ON_STOP`, `NESTED_DELEGATION_MAX_DEPTH` — display-only / no CLI orchestrator consumer.
 - Complex global-state domains (streaming/endpoints/models/agents/tools/presets/codex/claude) — `openForm` delegation only, never `/config` scalars.
 - Class-D internal state (`AGENT_HISTORY`, caches, `*_MIGRATED`/`*_VERSION`, onboarding flags, `DESKTOP_CRASH_REPORTING_ENABLED`) — not user settings; excluded entirely, enforced by the PR2 guardrail.
 
 ## Process
+
 Grounded on fresh `origin/main`; re-sync before starting (`git rev-list --count main...origin/main`). Shared-repo concurrency: expect a format-bot commit — adopt via `reset --hard`, don't force-push. Each PR carries its own tests and is independently reviewable; CHANGELOG entry (Features) lands with PR3.

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -35,11 +35,7 @@ logger.initialize(CHANNEL);
 // Re-exports kept stable for external consumers.
 export type { AgentEntry, ResolvedAgent } from './agentEntry';
 export { extractToolNames } from './agentYamlScanner';
-export {
-  BUILTIN_TEAM_ROOT_AGENT_NAMES,
-  BUNDLED_ORCHESTRATOR_AGENT_NAMES,
-  REMOTE_ORCHESTRATOR_AGENT_NAMES,
-} from './agentRegistryConstants';
+export { BUILTIN_TEAM_ROOT_AGENT_NAMES } from './agentRegistryConstants';
 export { createKey };
 
 /** Legacy prefix from pre-rename era (builtIn → builtInWorkflow). */

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -224,10 +224,6 @@ export abstract class ModelHandler<
     this.outputStreaming = enabled;
   }
 
-  public isOutputStreamingEnabled(): boolean {
-    return this.outputStreaming;
-  }
-
   /**
    * Indicates whether background mode is active for this handler.
    * Background mode runs requests asynchronously and polls for completion.

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -209,7 +209,6 @@ export interface IModelHandler<
 
   getStreamingConfig(): boolean;
   setOutputStreaming(enabled: boolean): void;
-  isOutputStreamingEnabled(): boolean;
   isBackgroundModeActive(): boolean;
 
   /** Whether this handler supports manual context compaction. */

--- a/src/agent/node/persistedFlow.ts
+++ b/src/agent/node/persistedFlow.ts
@@ -127,19 +127,10 @@ export class PersistedFlow<
 
   async run(shared: S): Promise<Action | undefined> {
     await this.ensureRecord(shared);
-    while (await this.step()) {
+    while ((await this.stepWithResult()).hasMore) {
       // step loop
     }
     return this.cachedRecord?.nodes.at(-1)?.action as Action | undefined;
-  }
-
-  /**
-   * Execute a single step (one node).
-   * Returns true if there are more nodes to execute.
-   */
-  async step(): Promise<boolean> {
-    const result = await this.stepWithResult();
-    return result.hasMore;
   }
 
   /**


### PR DESCRIPTION
Behavior-neutral dead-code removals found by a fresh four-area SDK-readiness
audit (typecheck x4, 649 agent tests, eslint all green):

- Remove the dead `PersistedFlow.step()` wrapper; its only caller is the
  base-class `run()` loop, now inlined to call `stepWithResult()` directly.
- Drop the dead registry re-exports of `BUNDLED_/REMOTE_ORCHESTRATOR_AGENT_NAMES`
  (no consumer imports them via the registry path; the one real consumer imports
  from `@shared/constants/agents` directly).
- Remove the never-read `isOutputStreamingEnabled()` getter from the
  `IModelHandler` port and `ModelHandler` base.

Document the verification and the remaining additive micro-findings (RetryState
param dedup, IModelHandler port narrowing, barrel curation, a stale proposal) in
docs/proposals/agent-sdk-readiness-checkpoint-2026-06-26.md.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Luuo4bLBaXPYt5E2mwGzq5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure deletions with no callers and inlined equivalent logic; no runtime or API behavior change.
> 
> **Overview**
> This PR applies **three behavior-neutral dead-code removals** in the agent layer and adds a **2026-06-26 SDK-readiness verification checkpoint** document.
> 
> **Code changes:** `PersistedFlow.run()` now loops on `stepWithResult().hasMore` directly and drops the unused `step()` wrapper. `agentRegistry` stops re-exporting `BUNDLED_ORCHESTRATOR_AGENT_NAMES` and `REMOTE_ORCHESTRATOR_AGENT_NAMES` (callers use `@shared/constants/agents`); `BUILTIN_TEAM_ROOT_AGENT_NAMES` stays. `isOutputStreamingEnabled()` is removed from `IModelHandler` and `ModelHandler` while `setOutputStreaming` remains.
> 
> **Documentation:** `agent-sdk-readiness-checkpoint-2026-06-26.md` records what was applied, deferred backlog (e.g. `RetryState` param collapse, port narrowing), and adjudicated traps not to re-litigate. `config-catalog-unification.md` gets minor markdown/formatting tweaks only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82a2b660ea77cd5d86854c0af7a3e5687d5600bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->