### PR TITLE
refactor(tools): consolidate per-stream resource release into releaseStreamResources

### DIFF
--- a/docs/proposals/config-catalog-unification.md
+++ b/docs/proposals/config-catalog-unification.md
@@ -14,9 +14,9 @@ Decision (already made by the user): **full unification** — one catalog as SSO
 
 Exploration disproved two load-bearing assumptions in the draft. Both change the design:
 
-1. **State-backed keys must NOT become `CoreSettingsShape` nodes.** Every node in `CoreSettingsShape` flows into `CORE_SETTING_PATHS` → `TEXRA_SETTING_PATHS` → the package.json generator → a VS Code *configuration* contribution. But the extension reads the state-backed keys (e.g. `texra.git.markCommits`, `texra.workflow.*`, `texra.latexdiff.*`) from **worktree-shared WorkspaceState** (`WORKTREE_SHARED_KEYS` in `packages/extension/src/common/state/stateManager.ts`), not from config — they were deliberately migrated *out* of config (`LATEX_SETTINGS_MIGRATED` marker). Adding them to `CoreSettingsShape` would emit phantom VS Code settings the extension never reads. → They live in a **separate** catalog (`stateSettings.ts`), not coreSettings.
+1. **State-backed keys must NOT become `CoreSettingsShape` nodes.** Every node in `CoreSettingsShape` flows into `CORE_SETTING_PATHS` → `TEXRA_SETTING_PATHS` → the package.json generator → a VS Code _configuration_ contribution. But the extension reads the state-backed keys (e.g. `texra.git.markCommits`, `texra.workflow.*`, `texra.latexdiff.*`) from **worktree-shared WorkspaceState** (`WORKTREE_SHARED_KEYS` in `packages/extension/src/common/state/stateManager.ts`), not from config — they were deliberately migrated _out_ of config (`LATEX_SETTINGS_MIGRATED` marker). Adding them to `CoreSettingsShape` would emit phantom VS Code settings the extension never reads. → They live in a **separate** catalog (`stateSettings.ts`), not coreSettings.
 
-2. **The CLI has three distinct stores, not a single shared one.** `packages/cli/src/runtime/initPlatform.ts:193-200` wires `config` = `JsonConfigProvider` (`.texra/config.json` + `~/.texra/.../config.json`), but `workspaceState` / `globalState` = **separate** `state.json` files (`cliStateStores.ts`). The git-author bridge (`gitAuthor.ts`) works only because it *explicitly* passes `config` into `readGitAuthorSettingsFromState(stateStore)` — exploiting structural read-compat (`ConfigProvider` and `StateStore` both expose `.get(key, default)`), **not** because `workspaceState === config`. So the accessor must be **host-aware**, and the git-author keys need an explicit per-entry `cliStore` override, not an assumed slot identity.
+2. **The CLI has three distinct stores, not a single shared one.** `packages/cli/src/runtime/initPlatform.ts:193-200` wires `config` = `JsonConfigProvider` (`.texra/config.json` + `~/.texra/.../config.json`), but `workspaceState` / `globalState` = **separate** `state.json` files (`cliStateStores.ts`). The git-author bridge (`gitAuthor.ts`) works only because it _explicitly_ passes `config` into `readGitAuthorSettingsFromState(stateStore)` — exploiting structural read-compat (`ConfigProvider` and `StateStore` both expose `.get(key, default)`), **not** because `workspaceState === config`. So the accessor must be **host-aware**, and the git-author keys need an explicit per-entry `cliStore` override, not an assumed slot identity.
 
 ## Catalog & store model
 
@@ -70,6 +70,7 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 ## PR sequence
 
 ### PR 1 — Generator carries `description` + `enumDescriptions` (no behavior change)
+
 - `texraSettings.ts:97` — extend `GENERATED_PACKAGE_SCHEMA_FIELDS` with `'description'`, `'enumDescriptions'` only. (`z.toJSONSchema()` already passes `.describe()` → `description` and merges `.meta()` keys; `pickPackageSchemaFields` is allowlist-driven so other meta stays out of package.json.)
 - `coreSettings.ts` + `vscodeSettings.ts` — add `.describe('…')` to every config leaf and `.meta({ enumDescriptions: [...] })` to enum leaves, **back-filled verbatim from the current package.json strings** so the first generator run is zero-diff.
 - `settingsConfiguration.vitest.ts` — **rewrite the `removes stale generated package schema fields` test (lines 157-180)**: it currently injects `description: 'Preserved description'` and asserts it survives. Once `description` is generated, that assertion is wrong — pivot it to a still-hand-kept field (`order` or `editPresentation`). Add an invariant: every enum leaf's `enumDescriptions.length === enum.length`.
@@ -77,6 +78,7 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 - **Verify:** `sync:settings-configuration --check` is zero-diff; `npm test` (idempotency `assert.deepEqual(build(sections), sections)`) green; `npm run typecheck`.
 
 ### PR 2 — `stateSettings.ts` catalog + `settingsAccess.ts` accessor + knownKeys derivation
+
 - New `src/shared/schemas/stateSettings.ts` — metadata-only rows for the state-backed keys, starting with the four git-author keys (`store:'workspaceState'`, `cliStore:'config'`, `hosts:['vscode','cli','desktop']`, `cliConsumer:'packages/cli/src/runtime/gitAuthor.ts'`) and the `workflow.*` / `latexdiff.*` / `latex.formatter` scalars (`store:'workspaceState'`, `hosts:['vscode','desktop']` for now). Export the key list.
 - New `src/shared/config/settingsAccess.ts` — `readSetting(entry, stores)` / `writeSetting(entry, value, stores)` where `stores = { config, workspaceState, globalState }`. Dispatch on `entry.store` (or `entry.cliStore` when the caller is the CLI); validate writes via the entry's Zod schema where one exists; **reset writes `undefined`** (deletes the key per `jsonConfigProvider.ts:57` → `.prefault()` reappears), never the literal default. `openForm` entries bypass the accessor.
 - `packages/cli/src/schemas/knownKeys.ts` — add `...STATE_SETTING_KEYS` from the catalog; **delete** the four hand-listed `WorkspaceStateKey.GIT_*` lines (31-34). The `WorkspaceStateKey` enum entries stay (the extension still uses them).
@@ -84,6 +86,7 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 - **Verify:** `npm test` (guardrails) + `npm run typecheck`; `gitAuthor.ts` still applies marking (route it through the accessor or leave as-is — both read the same keys from `config`).
 
 ### PR 3 — CLI `/config` panel (USER-VISIBLE; lands in CHANGELOG under Features)
+
 - New `packages/cli/src/chat/tui/forms/ConfigForm.tsx`. **Not a single-Select clone of `ApprovalPolicyForm`** — it is a list + drill-in:
   - Outer `Select` lists catalog entries where `hosts.includes('cli')` (label = setting name, `description` = current resolved value + its store, so cross-host state is visible — risk #1 mitigation).
   - Selecting a **boolean** toggles inline; an **enum** opens an inner `Select` of values (per-option text from `enumDescriptions`); an **`openForm`** entry delegates to the existing `ModelListForm`/`AgentListForm`/`MemoryListForm`/etc.
@@ -94,23 +97,27 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 - **Verify:** roster test = exactly the consumer-verified entries; `SlashRegistry.vitest` covers the new command; manual PTY run via `packages/cli/scripts/tui-harness.tsx` — open `/config`, flip a boolean + an enum, confirm persistence to `.texra/config.json` (project) and that `Esc` closes; confirm the headless `texra run` / `--print` path is byte-unchanged.
 
 ### PR 4 — Extension settingsView re-point (zero message/port/dispatch change)
-- Delete the hardcoded enum/label arrays and read labels/descriptions from the catalog: `AIAgentsTab.ts` (SANDBOX/REASONING/APPROVAL/CLAUDE option arrays, ~lines 40-98), `LaTeXTab.ts` (mathMarkup + formatter options, ~lines 590-616), plus inline labels in `ModelSelectionList.ts` (reasoning-level labels) and `ApiAccessSection.ts`/`ModelsTab.ts`. Splittable per-tab. (Note: the codex/claude option arrays are state-backed complex domains — promoting them to catalog rows is fine for *labels*; their read/write stays in the existing controllers.)
+
+- Delete the hardcoded enum/label arrays and read labels/descriptions from the catalog: `AIAgentsTab.ts` (SANDBOX/REASONING/APPROVAL/CLAUDE option arrays, ~lines 40-98), `LaTeXTab.ts` (mathMarkup + formatter options, ~lines 590-616), plus inline labels in `ModelSelectionList.ts` (reasoning-level labels) and `ApiAccessSection.ts`/`ModelsTab.ts`. Splittable per-tab. (Note: the codex/claude option arrays are state-backed complex domains — promoting them to catalog rows is fine for _labels_; their read/write stays in the existing controllers.)
 - **Verify:** webview renders identical labels; no port/schema diff; `npm run typecheck` + `npm test`.
 
 ### PR 5+ — Promote complex/state-backed domains incrementally (one per PR)
+
 - Add the CLI consumer code path for a domain (e.g. workflow/latexdiff scalars read in CLI from `platform().workspaceState`), flip its catalog `hosts` to include `'cli'`; the entry auto-appears in `/config`, and the PR2 guardrail enforces the consumer exists. Complex domains (streaming/endpoints/models/agents/tools/presets) come in as `openForm` delegations, not scalars.
 
 ## Critical files
+
 - `src/shared/schemas/coreSettings.ts` — `.describe()`/`.meta({enumDescriptions})` back-fill (PR1).
 - `packages/extension/src/schemas/{texraSettings.ts,vscodeSettings.ts}` — allowlist +`description`/`enumDescriptions`; describe the 3 vscode leaves (PR1).
 - `src/test-kernel/shared/settingsConfiguration.vitest.ts` — rewrite preserve-field test + enum-length invariant (PR1).
 - New `src/shared/schemas/stateSettings.ts`, `src/shared/config/settingsAccess.ts` (PR2).
-- `packages/cli/src/schemas/knownKeys.ts` — derive from catalog, delete GIT_* lines 31-34 (PR2).
+- `packages/cli/src/schemas/knownKeys.ts` — derive from catalog, delete GIT\_\* lines 31-34 (PR2).
 - New `packages/cli/src/chat/tui/forms/ConfigForm.tsx`; `packages/cli/src/chat/tui/commands/{registerBuiltins.tsx,slashRegistry.ts}`; `packages/cli/src/chat/tui/runChatTui.tsx:516` (PR3).
 - Extension tabs: `packages/extension/src/settingsView/frontend/tabs/{AIAgentsTab.ts,LaTeXTab.ts,ModelsTab.ts}` + `components/profile/{ModelSelectionList.ts,ApiAccessSection.ts}` (PR4).
 - Reused untouched: `ui/Select.tsx`, `forms/_shared/{FormFrame,selectWindow}.ts`, `src/controllers/settingsView/*`, `scripts/sync-settings-configuration.mjs`, `src/utils/system/gitAuthorSettings.ts`.
 
 ## Verification (every PR)
+
 - `npm run typecheck` and `npm test`.
 - PR1: `npm run sync:settings-configuration --check` zero-diff (proves `.describe()`/`.meta()`+`.prefault()` compose through `z.toJSONSchema()`); enum-length invariant green.
 - PR2: guardrail suite (consumer-exists, knownKeys-derivation, store/scope coherence, Class-D exclusion, default round-trip).
@@ -118,6 +125,7 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 - PR4: identical webview labels; no port/schema diff.
 
 ## Risk register
+
 1. **Cross-host store divergence** (a key set in extension WorkspaceState reads as default in the CLI). Mitigate: store/cliStore coherence guardrail; `/config` shows the resolved value **and its store**; no silent auto-bridge beyond the declared `cliStore` override.
 2. **`description` promotion breaks the existing preserve-field test** (`settingsConfiguration.vitest.ts:157-180` asserts a hand-injected description survives). Mitigate: rewrite that test in PR1 to assert a still-hand-kept field (`order`/`editPresentation`).
 3. **Incomplete `.describe()` back-fill deletes package.json descriptions** (allowlisted + absent in `.meta`/`.describe` ⇒ generator deletes the field). Mitigate: back-fill every config leaf; the idempotency `--check` fails CI on any miss.
@@ -126,10 +134,12 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 6. **ConfigForm complexity** (it's a list + drill-in, not one Select). Mitigate: MVP = booleans + enums + `openForm` only; defer free-text editing; reuse `MemoryListForm` list shape + `Select`.
 
 ## Explicit exclusions (omit `'cli'` from `hosts`; never surfaced in `/config`)
+
 - `texra.memory.enabled`, `texra.goal.enabled` — gated by `registerAgentFeatures()`, confirmed **never called in the CLI** (`initPlatform.ts` has no call; only `extension.ts:219` / desktop `index.ts:154`). Toggling them in the CLI does nothing.
 - `SUPER_YOLO_ENABLED`, `ALLOW_ORCHESTRATOR_KILL`, `DETACH_SUBAGENTS_ON_STOP`, `NESTED_DELEGATION_MAX_DEPTH` — display-only / no CLI orchestrator consumer.
 - Complex global-state domains (streaming/endpoints/models/agents/tools/presets/codex/claude) — `openForm` delegation only, never `/config` scalars.
 - Class-D internal state (`AGENT_HISTORY`, caches, `*_MIGRATED`/`*_VERSION`, onboarding flags, `DESKTOP_CRASH_REPORTING_ENABLED`) — not user settings; excluded entirely, enforced by the PR2 guardrail.
 
 ## Process
+
 Grounded on fresh `origin/main`; re-sync before starting (`git rev-list --count main...origin/main`). Shared-repo concurrency: expect a format-bot commit — adopt via `reset --hard`, don't force-push. Each PR carries its own tests and is independently reviewable; CHANGELOG entry (Features) lands with PR3.

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -59,9 +59,9 @@ import { COMMON_COMMANDS } from '@shared/ipc/commonCommands';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import {
-  cleanupApprovalsForStream,
   cleanupUnscopedApprovals,
   handleProgressViewBashApprovalAction,
+  releaseStreamResources,
 } from '@tools/approval';
 import { GoalStore } from '@tools/goal';
 import { handleExternalInquiryAction } from '@tools/inquiry';
@@ -753,9 +753,9 @@ export class DesktopProgressBridge {
     this.deletedStreams.add(streamId);
     this.progressEvents.onStreamDeleted(streamId);
 
-    // Shared approval cleanup also owns retry/proposal/plan coordinator cleanup.
-    cleanupApprovalsForStream(streamId, this.session);
-    ToolUseFollowUpQueue.release(streamId);
+    // Releases approval state (pending approvals, bypass flags, coordinator
+    // requests) and the follow-up queue for this stream.
+    releaseStreamResources(streamId, this.session);
 
     this.deleteAgentProposalsForStream(streamId);
     this.releasePendingPermissionsForStream(streamId);
@@ -785,8 +785,7 @@ export class DesktopProgressBridge {
     // process-global and streamId-keyed; the coordinator half is session-owned).
     for (const streamId of streamIds) {
       this.deletedStreams.add(streamId);
-      cleanupApprovalsForStream(streamId, this.session);
-      ToolUseFollowUpQueue.release(streamId);
+      releaseStreamResources(streamId, this.session);
     }
     // Catch pending approvals with no concrete stream context (undefined or
     // empty streamId) — the per-stream loop skips them because they do not

--- a/packages/desktop/src/main/desktopToolEditApproval.ts
+++ b/packages/desktop/src/main/desktopToolEditApproval.ts
@@ -15,6 +15,7 @@ import {
   type LatexPreviewEntry,
 } from '@tools/approval/latexPreview';
 import { writeApprovalTempFiles } from '@tools/approval/tempFileManager';
+import type { ToolEditApprovalAction } from '@shared/schemas/prompts';
 import {
   computeLineChangeSummary,
   computeUserPatch,
@@ -22,7 +23,6 @@ import {
   registerPendingApproval,
   setToolEditApprovalHandler,
   unregisterPendingApproval,
-  type ToolEditApprovalAction,
   type ToolEditApprovalRequest,
   type ToolEditApprovalResult,
 } from '@tools/approval/toolEditApproval';

--- a/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
+++ b/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
@@ -28,6 +28,7 @@ import {
   runLatexdiff,
 } from '@tools/approval/latexPreview';
 import { writeApprovalTempFiles } from '@tools/approval/tempFileManager';
+import type { ToolEditApprovalAction } from '@shared/schemas/prompts';
 import {
   computeLineChangeSummary,
   computeUserPatch,
@@ -36,7 +37,6 @@ import {
   registerPendingApproval,
   setToolEditApprovalHandler,
   unregisterPendingApproval,
-  type ToolEditApprovalAction,
   type ToolEditApprovalRequest,
   type ToolEditApprovalResult,
 } from '@tools/approval/toolEditApproval';

--- a/packages/extension/src/progressView/managers/ProgressStreamLifecycleHost.ts
+++ b/packages/extension/src/progressView/managers/ProgressStreamLifecycleHost.ts
@@ -5,10 +5,7 @@ import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import { isInFlightStatus } from '@common/constants/streamStatus';
 import { buildStreamInfos } from '@shared/progressView/backend/streamInfoUtils';
-import {
-  cleanupAllApprovals,
-  cleanupApprovalsForStream,
-} from '@tools/approval';
+import { cleanupAllApprovals, releaseStreamResources } from '@tools/approval';
 
 import type { ProgressStreamLifecycleHost as ProgressStreamLifecycleHostPort } from '@controllers/progressView/ProgressStreamLifecycleController';
 import type { ProgressViewProvider } from '../ProgressViewProvider';
@@ -48,13 +45,15 @@ export class ProgressStreamLifecycleHost implements ProgressStreamLifecycleHostP
   }
 
   cleanupDeletedStream(stream: StreamTabId): void {
-    cleanupApprovalsForStream(stream);
-    ToolUseFollowUpQueue.release(stream);
+    releaseStreamResources(stream);
     this.backupCleaner.clearStreamBackups(stream);
     this.provider.webviewBridge.clearStream(stream);
   }
 
   cleanupDeletedStreams(streams: StreamTabId[]): void {
+    // Process-wide approval reset for the single-session extension host.
+    // ToolUseFollowUpQueue has no bulk-release method, so queues are released
+    // per stream after the approval sweep.
     cleanupAllApprovals();
     for (const stream of streams) {
       ToolUseFollowUpQueue.release(stream);

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -25,7 +25,6 @@ const BashApprovalResultSchema = z.object({
 });
 export type BashApprovalResult = z.infer<typeof BashApprovalResultSchema>;
 
-
 const DEFAULT_BASH_REJECTION_INSTRUCTION =
   'Do not retry this rejected command or another approval-gated shell command for the same check. ' +
   'Continue without running it, use a non-shell method, or explain what approval would be needed.';

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -4,10 +4,7 @@ import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { tryUseRunContext } from '@agent/runtime/RunContext';
 import { StreamTabIdSchema, type StreamTabId } from '@shared/schemas';
 import { BASH_APPROVAL_CONFIG_KEY } from '@shared/schemas/agentCliSettings';
-import {
-  BASH_APPROVAL_ACTIONS,
-  type BashApprovalAction,
-} from '@shared/schemas/prompts';
+import type { BashApprovalAction } from '@shared/schemas/prompts';
 import { requireRuntimeHost } from '@tools/contextHelpers';
 import { type ToolResult } from '@shared/schemas/toolResult';
 import { getConfig } from '@utils/config/configUtils';
@@ -28,9 +25,6 @@ const BashApprovalResultSchema = z.object({
 });
 export type BashApprovalResult = z.infer<typeof BashApprovalResultSchema>;
 
-// Defined in the schema layer (see @shared/schemas/prompts); re-exported here
-// so existing importers of `@tools/approval/bashApproval` keep working.
-export { BASH_APPROVAL_ACTIONS, type BashApprovalAction };
 
 const DEFAULT_BASH_REJECTION_INSTRUCTION =
   'Do not retry this rejected command or another approval-gated shell command for the same check. ' +

--- a/src/tools/approval/index.ts
+++ b/src/tools/approval/index.ts
@@ -116,7 +116,6 @@ export {
   setBashApprovalSessionBypass,
   toggleBashApprovalSessionBypass,
   isBashApprovalBypassedForStream,
-  type BashApprovalAction,
   type BashApprovalRequest,
   type BashApprovalResult,
 } from './bashApproval';
@@ -132,7 +131,6 @@ export {
   setToolEditApprovalSessionBypass,
   toggleToolEditApprovalSessionBypass,
   isApprovalBypassedForStream,
-  type ToolEditApprovalAction,
   type ToolEditApprovalRequest,
   type ToolEditApprovalResult,
   type WriteApprovedContentResult,

--- a/src/tools/approval/index.ts
+++ b/src/tools/approval/index.ts
@@ -12,6 +12,7 @@ import {
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import type { StreamTabId } from '@shared/schemas';
 import {
   _rejectAllPendingUserQuestions,
@@ -42,6 +43,25 @@ export function cleanupApprovalsForStream(
   bashApprovalController.bypass.clearForStream(streamId);
   proposalApprovalState.clearForStream(streamId);
   session.coordinators.cleanupRequestsForStream(streamId);
+}
+
+/**
+ * Release all agent resources held for a deleted stream: approval state
+ * (pending approvals, bypass flags, coordinator requests) AND the follow-up
+ * queue. These two always need to be cleared together when a stream is
+ * removed, so this is the single function hosts should call instead of
+ * combining {@link cleanupApprovalsForStream} + `ToolUseFollowUpQueue.release`
+ * manually.
+ *
+ * Host-specific teardown (webview state, backup files, goal store, etc.)
+ * remains the caller's responsibility after this returns.
+ */
+export function releaseStreamResources(
+  streamId: StreamTabId,
+  session: SessionHandle = defaultSession(),
+): void {
+  cleanupApprovalsForStream(streamId, session);
+  ToolUseFollowUpQueue.release(streamId);
 }
 
 /**

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -51,7 +51,6 @@ const TOOL_EDIT_APPROVAL_CONFIG_KEY = 'texra.toolUse.requireEditApproval';
 
 export const REVEAL_TIMEOUT_MS = 1500;
 
-
 export const toolEditApprovalController =
   createStreamApprovalController<ToolEditApprovalResult>({
     rejectionResult: () => ({ accepted: false }),

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -10,10 +10,7 @@ import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { tryUseRunContext } from '@agent/runtime/RunContext';
 import { isLatexFile } from '@common/files/fileTypeUtils';
 import { StreamTabIdSchema, type StreamTabId } from '@shared/schemas';
-import {
-  TOOL_EDIT_APPROVAL_ACTIONS,
-  type ToolEditApprovalAction,
-} from '@shared/schemas/prompts';
+import type { ToolEditApprovalAction } from '@shared/schemas/prompts';
 import {
   LineChangesSchema,
   type LineChanges,
@@ -54,9 +51,6 @@ const TOOL_EDIT_APPROVAL_CONFIG_KEY = 'texra.toolUse.requireEditApproval';
 
 export const REVEAL_TIMEOUT_MS = 1500;
 
-// Defined in the schema layer (see @shared/schemas/prompts); re-exported here
-// so existing importers of `@tools/approval/toolEditApproval` keep working.
-export { TOOL_EDIT_APPROVAL_ACTIONS, type ToolEditApprovalAction };
 
 export const toolEditApprovalController =
   createStreamApprovalController<ToolEditApprovalResult>({


### PR DESCRIPTION
Both host implementations (VS Code extension and desktop) independently
called `cleanupApprovalsForStream + ToolUseFollowUpQueue.release` whenever
a stream was deleted. This scattered ownership of "what to clean up on
stream deletion" across both hosts, and meant adding a third component to
clear on delete would require updating both files.

Add `releaseStreamResources(streamId, session?)` to `@tools/approval/index.ts`,
which already serves as the coordination point for stream cleanup. The new
function combines the two always-paired calls so hosts call one function
and know all core agent state is released.

`cleanupApprovalsForStream` is kept for tests and callers that only need
approval cleanup without touching the follow-up queue.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01P5Mo5a4VxQMoHoqE5S7n1B

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor consolidates existing cleanup calls without changing approval or queue semantics; `cleanupApprovalsForStream` remains for narrower callers.
> 
> **Overview**
> Adds **`releaseStreamResources(streamId, session?)`** in `@tools/approval/index.ts` so stream deletion clears **approval state** (via existing `cleanupApprovalsForStream`) and **`ToolUseFollowUpQueue`** in one call instead of pairing those steps in every host.
> 
> **Desktop** (`desktopAgentExecution.ts`) and the **extension** (`ProgressStreamLifecycleHost.ts`) now call `releaseStreamResources` on single-stream delete and in desktop’s per-stream `deleteAllStreams` loop; host-specific teardown (webview, backups, goals) is unchanged.
> 
> **Type imports:** `ToolEditApprovalAction` / `BashApprovalAction` are taken from `@shared/schemas/prompts` in desktop/native tool-edit approval and approval modules; re-exports of action constants from `bashApproval.ts` / `toolEditApproval.ts` are removed. The proposal doc `config-catalog-unification.md` only gets minor markdown formatting tweaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7d45ff7626dabb3fc24ddc68bf3c9251666f7ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->