### PR TITLE
refactor: consolidate duplicate logic and use shared utilities

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -977,6 +977,20 @@ export abstract class ModelHandler<
     workspaceState?: AgentWorkspaceState,
   ): string | null;
 
+  /** Applies a single-string reasoning value to workspace thinking state.
+   *  No-op when workspaceState is absent or thinking was already recorded. */
+  protected applyStringReasoningToWorkspaceState(
+    reasoning: string,
+    workspaceState?: AgentWorkspaceState,
+  ): void {
+    if (workspaceState && !workspaceState.reasoning.thinkingAdded) {
+      workspaceState.reasoning.thinkingBlocks = [
+        { type: 'thinking', thinking: reasoning },
+      ];
+      workspaceState.reasoning.thinkingAdded = true;
+    }
+  }
+
   /**
    * Extracts tool-use information from provider responses.
    * @param responseObject The raw response object from the model

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -8,7 +8,6 @@ import { assertToolCallsAreChatCompletionFunctionToolCalls } from 'openai/lib/pa
 // Local imports - agent components
 import { logSdkError } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
-import { hasEndTag } from '@agent/core/definition/AgentDataclass';
 import type { AgentSetting } from '@agent/core/definition/AgentDataclass';
 import type {
   OpenAIAPIResponseUsage,
@@ -56,6 +55,7 @@ import {
   type ToolResultPayload,
 } from '../utils/toolAttachmentUtils';
 import { parseToolArguments } from '../utils/parseArguments';
+import { shouldContinueOnLengthStop } from '../utils/stopReasonUtils';
 import { ModelHandler } from '../ModelHandler';
 import {
   BaseReasoningStreamAggregator,
@@ -1164,10 +1164,7 @@ export class ModelHandlerOpenAI<
     newResponse: string,
     agentSetting: AgentSetting,
   ): boolean {
-    return (
-      stopReason === OPENAI_CHAT_FINISH.LENGTH &&
-      !hasEndTag(agentSetting, newResponse)
-    );
+    return shouldContinueOnLengthStop(stopReason, newResponse, agentSetting);
   }
 
   /**
@@ -1202,12 +1199,7 @@ export class ModelHandlerOpenAI<
       return null;
     }
 
-    if (workspaceState && !workspaceState.reasoning.thinkingAdded) {
-      workspaceState.reasoning.thinkingBlocks = [
-        { type: 'thinking', thinking: reasoning },
-      ];
-      workspaceState.reasoning.thinkingAdded = true;
-    }
+    this.applyStringReasoningToWorkspaceState(reasoning, workspaceState);
 
     this.logger.debug(
       `Reasoning content preview: ${reasoning.slice(0, K_SLICE)}...`,

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -5,7 +5,6 @@ import { ModelProvider } from 'llm-zoo';
 // Local imports - agent
 import { logSdkError } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
-import { hasEndTag } from '@agent/core/definition/AgentDataclass';
 import type { AgentSetting } from '@agent/core/definition/AgentDataclass';
 import type { AgentWorkspaceState } from '@agent/core/execution/AgentWorkspaceState';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
@@ -44,6 +43,7 @@ import {
   OpenRouterStreamAggregator,
   toOpenRouterReasoningEffort,
 } from './openRouterStreaming';
+import { shouldContinueOnLengthStop } from '../utils/stopReasonUtils';
 import { ModelHandler } from '../ModelHandler';
 import {
   CLIENT_COMPACTION_SUMMARY_MAX_TOKENS,
@@ -617,12 +617,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     reasoning: string,
     workspaceState?: AgentWorkspaceState,
   ): void {
-    if (workspaceState && !workspaceState.reasoning.thinkingAdded) {
-      workspaceState.reasoning.thinkingBlocks = [
-        { type: 'thinking', thinking: reasoning },
-      ];
-      workspaceState.reasoning.thinkingAdded = true;
-    }
+    this.applyStringReasoningToWorkspaceState(reasoning, workspaceState);
     this.logger.debug(
       `Reasoning content preview: ${reasoning.slice(0, K_SLICE)}...`,
     );
@@ -718,10 +713,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     newResponse: string,
     agentSetting: AgentSetting,
   ): boolean {
-    return (
-      stopReason === OPENAI_CHAT_FINISH.LENGTH &&
-      !hasEndTag(agentSetting, newResponse)
-    );
+    return shouldContinueOnLengthStop(stopReason, newResponse, agentSetting);
   }
 
   addContinueMessageWithoutPrefill(

--- a/src/agent/modelHandlers/utils/stopReasonUtils.ts
+++ b/src/agent/modelHandlers/utils/stopReasonUtils.ts
@@ -8,6 +8,10 @@ import {
   OPENAI_CHAT_FINISH,
   OPENAI_COMPLETION_FINISH,
 } from '@agent/modelHandlers/types/StopReasonTypes';
+import {
+  type AgentSetting,
+  hasEndTag,
+} from '@agent/core/definition/AgentDataclass';
 
 /** Known stop reasons that indicate token limit was hit */
 const TOKEN_LIMIT_STOP_REASONS: readonly ProviderStopReason[] = [
@@ -26,6 +30,24 @@ const TOKEN_LIMIT_KEYWORDS = [
   'token_limit',
   'length',
 ];
+
+/**
+ * Shared continuation predicate for OpenAI-family handlers (OpenAI, OpenRouter).
+ *
+ * Returns true when the stop reason is a token-length cutoff and the response
+ * does not already contain the agent's end tag, meaning generation should
+ * resume with a continuation prompt.
+ */
+export function shouldContinueOnLengthStop(
+  stopReason: ProviderStopReason,
+  newResponse: string,
+  agentSetting: AgentSetting,
+): boolean {
+  return (
+    stopReason === OPENAI_CHAT_FINISH.LENGTH &&
+    !hasEndTag(agentSetting, newResponse)
+  );
+}
 
 /**
  * Determines whether a provider stop reason represents a token limit hit.

--- a/src/shared/schemas/historyViewMessages.ts
+++ b/src/shared/schemas/historyViewMessages.ts
@@ -81,36 +81,30 @@ export const GetHistoryDataMessageSchema = commandOnly(
   HISTORY_VIEW_COMMANDS.GET_HISTORY_DATA,
 );
 
-export const RerunAgentMessageSchema = z.object({
+export const RerunAgentMessageSchema = HistoryIdMessageSchema.extend({
   command: z.literal(HISTORY_VIEW_COMMANDS.RERUN_AGENT),
-  historyId: z.string().min(1),
 });
 
-export const RestoreAgentMessageSchema = z.object({
+export const RestoreAgentMessageSchema = HistoryIdMessageSchema.extend({
   command: z.literal(HISTORY_VIEW_COMMANDS.RESTORE_AGENT),
-  historyId: z.string().min(1),
 });
 
-export const DeleteAgentMessageSchema = z.object({
+export const DeleteAgentMessageSchema = HistoryIdMessageSchema.extend({
   command: z.literal(HISTORY_VIEW_COMMANDS.DELETE_AGENT),
-  historyId: z.string().min(1),
 });
 
 export const ClearHistoryMessageSchema = commandOnly(
   HISTORY_VIEW_COMMANDS.CLEAR_HISTORY,
 );
 
-export const ExportChatMdMessageSchema = z.object({
+export const ExportChatMdMessageSchema = HistoryIdMessageSchema.extend({
   command: z.literal(HISTORY_VIEW_COMMANDS.EXPORT_CHAT_MD),
-  historyId: z.string().min(1),
 });
 
-export const ExportChatTexMessageSchema = z.object({
+export const ExportChatTexMessageSchema = HistoryIdMessageSchema.extend({
   command: z.literal(HISTORY_VIEW_COMMANDS.EXPORT_CHAT_TEX),
-  historyId: z.string().min(1),
 });
 
-export const ExportChatHtmlMessageSchema = z.object({
+export const ExportChatHtmlMessageSchema = HistoryIdMessageSchema.extend({
   command: z.literal(HISTORY_VIEW_COMMANDS.EXPORT_CHAT_HTML),
-  historyId: z.string().min(1),
 });

--- a/src/shared/schemas/progressView/data.ts
+++ b/src/shared/schemas/progressView/data.ts
@@ -6,6 +6,7 @@
 import { z } from 'zod';
 
 import { AgentCategorySchema } from '../agent';
+import { StreamTabIdSchema } from '../identifiers';
 
 // ============================================================
 // Shared Field Schemas
@@ -19,6 +20,13 @@ export type AgentCategoryFilter = z.infer<typeof AgentCategoryFilterSchema>;
 
 export const ProgressViewPlacementSchema = z.enum(['sidebar', 'editor']);
 export type ProgressViewPlacement = z.infer<typeof ProgressViewPlacementSchema>;
+
+/**
+ * Base schema for stream-scoped messages: those carrying a single `stream` tab
+ * id. Compose with `.extend(...)` so the `stream` field is declared once and
+ * inbound/outbound message schemas stay consistent.
+ */
+export const StreamScopedBaseSchema = z.object({ stream: StreamTabIdSchema });
 
 // ============================================================
 // Progress View Data Schemas

--- a/src/shared/schemas/progressView/inbound.ts
+++ b/src/shared/schemas/progressView/inbound.ts
@@ -160,9 +160,11 @@ const UseOwnApiKeyMessageSchema = StreamScopedBaseSchema.extend({
   viaRelay: z.boolean().optional(),
 });
 
-const ToggleToolEditApprovalBypassMessageSchema = StreamScopedBaseSchema.extend({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.TOGGLE_TOOL_EDIT_APPROVAL_BYPASS),
-});
+const ToggleToolEditApprovalBypassMessageSchema = StreamScopedBaseSchema.extend(
+  {
+    command: z.literal(PROGRESS_VIEW_COMMANDS.TOGGLE_TOOL_EDIT_APPROVAL_BYPASS),
+  },
+);
 
 const ToggleSuperYoloBypassMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.TOGGLE_SUPER_YOLO_BYPASS),

--- a/src/shared/schemas/progressView/inbound.ts
+++ b/src/shared/schemas/progressView/inbound.ts
@@ -12,7 +12,6 @@ import {
 } from '@shared/utils/dispatcher';
 
 import { SwitchViewMessageSchema } from '../commonViewMessages';
-import { StreamTabIdSchema } from '../identifiers';
 import {
   ExternalInquirySessionLinksSchema,
   ExternalInquiryThreadIdSchema,
@@ -26,7 +25,7 @@ import {
   USER_QUESTION_ACTIONS,
   UserQuestionAnswersSchema,
 } from '../prompts';
-import { AgentCategoryFilterSchema } from './data';
+import { AgentCategoryFilterSchema, StreamScopedBaseSchema } from './data';
 import { GettingStartedActionSchema } from '../mainView/state';
 
 const TrimmedStringSchema = z
@@ -76,73 +75,59 @@ const DebugModeSetMessageSchema = z.object({
   debugMode: z.boolean(),
 });
 
-const SwitchStreamMessageSchema = z.object({
+const SwitchStreamMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.SWITCH_STREAM),
-  stream: StreamTabIdSchema,
 });
 
-const InboundDeleteStreamMessageSchema = z.object({
+const InboundDeleteStreamMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.DELETE_STREAM),
-  stream: StreamTabIdSchema,
 });
 
-const StopStreamMessageSchema = z.object({
+const StopStreamMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.STOP_STREAM),
-  stream: StreamTabIdSchema,
 });
 
-const CompactResponseMessageSchema = z.object({
+const CompactResponseMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.COMPACT_RESPONSE),
-  stream: StreamTabIdSchema,
 });
 
-const ResumeMessageSchema = z.object({
+const ResumeMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.RESUME),
-  stream: StreamTabIdSchema,
 });
 
-const RunNewMessageSchema = z.object({
+const RunNewMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.RUN_NEW),
-  stream: StreamTabIdSchema,
 });
 
-const DiffStreamMessageSchema = z.object({
+const DiffStreamMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.DIFF_STREAM),
-  stream: StreamTabIdSchema,
 });
 
-const PackStreamMessageSchema = z.object({
+const PackStreamMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.PACK_STREAM),
-  stream: StreamTabIdSchema,
 });
 
-const CleanStreamMessageSchema = z.object({
+const CleanStreamMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.CLEAN_STREAM),
-  stream: StreamTabIdSchema,
 });
 
-const RestoreStateMessageSchema = z.object({
+const RestoreStateMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.RESTORE_STATE),
-  stream: StreamTabIdSchema,
 });
 
-const OpenTaskStorageMessageSchema = z.object({
+const OpenTaskStorageMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.OPEN_TASK_STORAGE),
-  stream: StreamTabIdSchema,
 });
 
-const RunCompileFixerMessageSchema = z.object({
+const RunCompileFixerMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.RUN_COMPILE_FIXER),
-  stream: StreamTabIdSchema,
 });
 
-const GetFollowupOptionsMessageSchema = z.object({
+const GetFollowupOptionsMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.GET_FOLLOWUP_OPTIONS),
-  stream: StreamTabIdSchema,
 });
 
-const FollowupConfigSchema = z.object({
-  stream: StreamTabIdSchema,
+const FollowupConfigSchema = StreamScopedBaseSchema.extend({
   agent: TrimmedStringSchema,
   model: TrimmedStringSchema,
   initialQuestion: z.string().optional(),
@@ -156,14 +141,12 @@ const RunFollowupMessageSchema = FollowupConfigSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.RUN_FOLLOWUP),
 });
 
-const CancelRetryRequestMessageSchema = z.object({
+const CancelRetryRequestMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.CANCEL_RETRY_REQUEST),
-  stream: StreamTabIdSchema,
 });
 
-const UseOwnApiKeyMessageSchema = z.object({
+const UseOwnApiKeyMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.USE_OWN_API_KEY),
-  stream: StreamTabIdSchema,
   provider: z.string().optional(),
   /** True when the underlying cause is an upstream provider credit
    *  depletion (Anthropic 400 "credit balance is too low"), meaning the
@@ -177,19 +160,16 @@ const UseOwnApiKeyMessageSchema = z.object({
   viaRelay: z.boolean().optional(),
 });
 
-const ToggleToolEditApprovalBypassMessageSchema = z.object({
+const ToggleToolEditApprovalBypassMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.TOGGLE_TOOL_EDIT_APPROVAL_BYPASS),
-  stream: StreamTabIdSchema,
 });
 
-const ToggleSuperYoloBypassMessageSchema = z.object({
+const ToggleSuperYoloBypassMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.TOGGLE_SUPER_YOLO_BYPASS),
-  stream: StreamTabIdSchema,
 });
 
-const SendFollowUpMessageSchema = z.object({
+const SendFollowUpMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP),
-  stream: StreamTabIdSchema,
   text: TrimmedStringSchema,
   /** Pasted images (base64) to attach to this follow-up turn. */
   images: z
@@ -203,15 +183,13 @@ const SendFollowUpMessageSchema = z.object({
     .optional(),
 });
 
-const PolishFollowUpMessageSchema = z.object({
+const PolishFollowUpMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.POLISH_FOLLOW_UP),
-  stream: StreamTabIdSchema,
   text: TrimmedStringSchema,
 });
 
-const RetryStreamRequestMessageSchema = z.object({
+const RetryStreamRequestMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.RETRY_STREAM_REQUEST),
-  stream: StreamTabIdSchema,
   feedback: z.string().optional(),
 });
 

--- a/src/shared/schemas/progressView/outbound.ts
+++ b/src/shared/schemas/progressView/outbound.ts
@@ -31,7 +31,11 @@ import { PlanSchema } from '../plan';
 import { TodoItemSchema } from '../todo';
 import { ContextStateDataSchema } from '../contextManagement';
 import { RunUsageMapSchema, TokenUsageStatsSchema } from '../usage';
-import { AgentCategoryFilterSchema, ProgressViewPlacementSchema } from './data';
+import {
+  AgentCategoryFilterSchema,
+  ProgressViewPlacementSchema,
+  StreamScopedBaseSchema,
+} from './data';
 
 export const UpdateStreamsMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS),
@@ -46,44 +50,40 @@ export const SetActiveStreamMessageSchema = z.object({
   activeStream: z.union([StreamTabIdSchema, z.literal('')]),
 });
 
-export const UpdateConversationProgressMessageSchema = z.object({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_CONVERSATION_PROGRESS),
-  stream: StreamTabIdSchema,
-  progress: ConversationProgressSchema,
-});
+export const UpdateConversationProgressMessageSchema =
+  StreamScopedBaseSchema.extend({
+    command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_CONVERSATION_PROGRESS),
+    progress: ConversationProgressSchema,
+  });
 
-export const UpdateStreamBadgesMessageSchema = z.object({
+export const UpdateStreamBadgesMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_BADGES),
-  stream: StreamTabIdSchema,
   activeSubagents: z.array(ActiveChildInfoSchema),
   finishedSubagentCount: z.number(),
   activeProcesses: z.array(ActiveChildInfoSchema),
   finishedProcessCount: z.number(),
 });
 
-export const UpdateProcessOutputMessageSchema = z.object({
+export const UpdateProcessOutputMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_PROCESS_OUTPUT),
-  stream: StreamTabIdSchema,
   executionId: z.string(),
   stdout: z.string(),
   stderr: z.string(),
 });
 
-export const UpdateParentStreamMessageSchema = z.object({
+export const UpdateParentStreamMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_PARENT_STREAM),
-  stream: StreamTabIdSchema,
   parentStreamId: StreamTabIdSchema.nullish(),
 });
 
-export const UpdateStreamDescriptionMessageSchema = z.object({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_DESCRIPTION),
-  stream: StreamTabIdSchema,
-  description: z.string(),
-});
+export const UpdateStreamDescriptionMessageSchema =
+  StreamScopedBaseSchema.extend({
+    command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_DESCRIPTION),
+    description: z.string(),
+  });
 
-export const UpdateStreamStatusMessageSchema = z.object({
+export const UpdateStreamStatusMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_STATUS),
-  stream: StreamTabIdSchema,
   status: StreamStatusSchema,
   lastTimestamp: z.number().optional(),
 });
@@ -103,9 +103,8 @@ function RoundUpdateMessageSchema<C extends string, T extends z.ZodType>(
   command: C,
   elementSchema: T,
 ) {
-  return z.object({
+  return StreamScopedBaseSchema.extend({
     command: z.literal(command),
-    stream: StreamTabIdSchema,
     rounds: z.record(z.string(), z.array(elementSchema)).optional(),
     reset: z.boolean().optional(),
   });
@@ -126,34 +125,29 @@ export const UpdateCompileFailuresMessageSchema = RoundUpdateMessageSchema(
   CompileFailureSchema,
 );
 
-export const UpdateTodosMessageSchema = z.object({
+export const UpdateTodosMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_TODOS),
-  stream: StreamTabIdSchema,
   todos: z.array(TodoItemSchema),
 });
 
-export const UpdatePlanMessageSchema = z.object({
+export const UpdatePlanMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_PLAN),
-  stream: StreamTabIdSchema,
   plan: PlanSchema.nullable(),
 });
 
-export const UpdateRunUsageMessageSchema = z.object({
+export const UpdateRunUsageMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_RUN_USAGE),
-  stream: StreamTabIdSchema,
   runId: z.string(),
   usage: TokenUsageStatsSchema,
 });
 
-export const UpdateQueuedFollowUpsMessageSchema = z.object({
+export const UpdateQueuedFollowUpsMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_QUEUED_FOLLOW_UPS),
-  stream: StreamTabIdSchema,
   messages: z.array(z.string()),
 });
 
-export const SetFollowupOptionsMessageSchema = z.object({
+export const SetFollowupOptionsMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.SET_FOLLOWUP_OPTIONS),
-  stream: StreamTabIdSchema,
   toolUseAgentsData: z.array(AgentOptionDataSchema).optional(),
   modelOptionsData: z.array(ModelOptionDataSchema).optional(),
 });
@@ -225,9 +219,8 @@ export type UpdatePermissionMessage = z.infer<
 
 const BypassTypeSchema = z.enum(['toolEdit', 'superYolo']);
 
-export const UpdateBypassMessageSchema = z.object({
+export const UpdateBypassMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_BYPASS),
-  stream: StreamTabIdSchema,
   type: BypassTypeSchema,
   bypassActive: z.boolean(),
 });
@@ -301,9 +294,8 @@ export const SyncStreamContentMessageSchema = z.object({
   goalObjective: z.string().optional(),
 });
 
-const GoalActiveUpdatedMessageSchema = z.object({
+const GoalActiveUpdatedMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.GOAL_ACTIVE_UPDATED),
-  stream: StreamTabIdSchema,
   active: z.boolean(),
   status: GoalStatusSchema.optional(),
   objective: z.string().optional(),
@@ -314,9 +306,8 @@ export const ProgressSetThemeMessageSchema = z.object({
   theme: z.enum(['dark', 'light']),
 });
 
-export const ProgressDeleteStreamMessageSchema = z.object({
+export const ProgressDeleteStreamMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.DELETE_STREAM),
-  stream: StreamTabIdSchema,
 });
 
 export const ProgressDeleteAllMessageSchema = z.object({

--- a/src/shared/schemas/progressView/outbound.ts
+++ b/src/shared/schemas/progressView/outbound.ts
@@ -141,10 +141,12 @@ export const UpdateRunUsageMessageSchema = StreamScopedBaseSchema.extend({
   usage: TokenUsageStatsSchema,
 });
 
-export const UpdateQueuedFollowUpsMessageSchema = StreamScopedBaseSchema.extend({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_QUEUED_FOLLOW_UPS),
-  messages: z.array(z.string()),
-});
+export const UpdateQueuedFollowUpsMessageSchema = StreamScopedBaseSchema.extend(
+  {
+    command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_QUEUED_FOLLOW_UPS),
+    messages: z.array(z.string()),
+  },
+);
 
 export const SetFollowupOptionsMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.SET_FOLLOWUP_OPTIONS),


### PR DESCRIPTION
## Summary

Four behavior-preserving consolidations identified by an automated scan, re-based onto current `main`. No logic changes — only structural cleanup that removes duplicate field/block declarations.

### F9 — `historyViewMessages.ts`: make `HistoryIdMessageSchema` load-bearing

`HistoryIdMessageSchema` was exported as a base schema but none of its six siblings composed from it — they re-declared `historyId: z.string().min(1)` inline. All six now use `.extend()`, so the `historyId` contract has a single source of truth.

### F7 — `progressView/`: `StreamScopedBaseSchema` eliminates ~30 inline `stream` repeats

Defines `StreamScopedBaseSchema = z.object({ stream: StreamTabIdSchema })` once in `progressView/data.ts` and composes the qualifying inbound (21) and outbound (15) message schemas from it via `.extend()`, instead of copying the `stream` field verbatim. Schemas with special variants (`stream` as `.nullish()`, a `z.union([…])`, or a differently-named field such as `streamId`/`activeStream`) are deliberately left untouched. Re-targeted to the per-domain modules introduced by the schema-monolith split (`6ce0f4de8`).

### F6 — `applyStringReasoningToWorkspaceState`: remove a duplicated guard block

The identical guard-and-assign that sets thinking state was duplicated across the OpenAI and OpenRouter handlers. Extracted to a protected method on `ModelHandler`; both handlers call it.

### F2 — `shouldContinueOnLengthStop`: share OpenAI-family continuation logic

The identical continuation body was copied verbatim into both `ModelHandlerOpenAI` and `ModelHandlerOpenRouterNative`. Extracted to `shouldContinueOnLengthStop()` in `stopReasonUtils.ts` (which already owns related stop-reason predicates); both handlers delegate to it.

### Dropped during rebase — F10 (`WorkflowBaseSchema`)

The original scan also proposed an F10 `WorkflowBaseSchema` to share the housekeeping command base. `main` already implements that consolidation — and better — via `packages/extension/src/commands/housekeeping/fileOpSchemas.ts` (`FileOpParamsSchema` / `fileOpConfigFields`), which `cleanCommands.ts` and `packCommands.ts` already import. Adding `WorkflowBaseSchema` would have created a duplicate identical schema, so F10 was dropped; its intent is fully covered by the existing code.

---

Typecheck clean (only the known-preexisting `@openrouter/sdk` / `vscode-jsonrpc` module-resolution errors remain); 272 schema/handler tests pass.
