### PR TITLE
Refactor schema composition and improve type documentation

### DIFF
--- a/docs/proposals/config-catalog-unification.md
+++ b/docs/proposals/config-catalog-unification.md
@@ -14,9 +14,9 @@ Decision (already made by the user): **full unification** — one catalog as SSO
 
 Exploration disproved two load-bearing assumptions in the draft. Both change the design:
 
-1. **State-backed keys must NOT become `CoreSettingsShape` nodes.** Every node in `CoreSettingsShape` flows into `CORE_SETTING_PATHS` → `TEXRA_SETTING_PATHS` → the package.json generator → a VS Code *configuration* contribution. But the extension reads the state-backed keys (e.g. `texra.git.markCommits`, `texra.workflow.*`, `texra.latexdiff.*`) from **worktree-shared WorkspaceState** (`WORKTREE_SHARED_KEYS` in `packages/extension/src/common/state/stateManager.ts`), not from config — they were deliberately migrated *out* of config (`LATEX_SETTINGS_MIGRATED` marker). Adding them to `CoreSettingsShape` would emit phantom VS Code settings the extension never reads. → They live in a **separate** catalog (`stateSettings.ts`), not coreSettings.
+1. **State-backed keys must NOT become `CoreSettingsShape` nodes.** Every node in `CoreSettingsShape` flows into `CORE_SETTING_PATHS` → `TEXRA_SETTING_PATHS` → the package.json generator → a VS Code _configuration_ contribution. But the extension reads the state-backed keys (e.g. `texra.git.markCommits`, `texra.workflow.*`, `texra.latexdiff.*`) from **worktree-shared WorkspaceState** (`WORKTREE_SHARED_KEYS` in `packages/extension/src/common/state/stateManager.ts`), not from config — they were deliberately migrated _out_ of config (`LATEX_SETTINGS_MIGRATED` marker). Adding them to `CoreSettingsShape` would emit phantom VS Code settings the extension never reads. → They live in a **separate** catalog (`stateSettings.ts`), not coreSettings.
 
-2. **The CLI has three distinct stores, not a single shared one.** `packages/cli/src/runtime/initPlatform.ts:193-200` wires `config` = `JsonConfigProvider` (`.texra/config.json` + `~/.texra/.../config.json`), but `workspaceState` / `globalState` = **separate** `state.json` files (`cliStateStores.ts`). The git-author bridge (`gitAuthor.ts`) works only because it *explicitly* passes `config` into `readGitAuthorSettingsFromState(stateStore)` — exploiting structural read-compat (`ConfigProvider` and `StateStore` both expose `.get(key, default)`), **not** because `workspaceState === config`. So the accessor must be **host-aware**, and the git-author keys need an explicit per-entry `cliStore` override, not an assumed slot identity.
+2. **The CLI has three distinct stores, not a single shared one.** `packages/cli/src/runtime/initPlatform.ts:193-200` wires `config` = `JsonConfigProvider` (`.texra/config.json` + `~/.texra/.../config.json`), but `workspaceState` / `globalState` = **separate** `state.json` files (`cliStateStores.ts`). The git-author bridge (`gitAuthor.ts`) works only because it _explicitly_ passes `config` into `readGitAuthorSettingsFromState(stateStore)` — exploiting structural read-compat (`ConfigProvider` and `StateStore` both expose `.get(key, default)`), **not** because `workspaceState === config`. So the accessor must be **host-aware**, and the git-author keys need an explicit per-entry `cliStore` override, not an assumed slot identity.
 
 ## Catalog & store model
 
@@ -70,6 +70,7 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 ## PR sequence
 
 ### PR 1 — Generator carries `description` + `enumDescriptions` (no behavior change)
+
 - `texraSettings.ts:97` — extend `GENERATED_PACKAGE_SCHEMA_FIELDS` with `'description'`, `'enumDescriptions'` only. (`z.toJSONSchema()` already passes `.describe()` → `description` and merges `.meta()` keys; `pickPackageSchemaFields` is allowlist-driven so other meta stays out of package.json.)
 - `coreSettings.ts` + `vscodeSettings.ts` — add `.describe('…')` to every config leaf and `.meta({ enumDescriptions: [...] })` to enum leaves, **back-filled verbatim from the current package.json strings** so the first generator run is zero-diff.
 - `settingsConfiguration.vitest.ts` — **rewrite the `removes stale generated package schema fields` test (lines 157-180)**: it currently injects `description: 'Preserved description'` and asserts it survives. Once `description` is generated, that assertion is wrong — pivot it to a still-hand-kept field (`order` or `editPresentation`). Add an invariant: every enum leaf's `enumDescriptions.length === enum.length`.
@@ -77,6 +78,7 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 - **Verify:** `sync:settings-configuration --check` is zero-diff; `npm test` (idempotency `assert.deepEqual(build(sections), sections)`) green; `npm run typecheck`.
 
 ### PR 2 — `stateSettings.ts` catalog + `settingsAccess.ts` accessor + knownKeys derivation
+
 - New `src/shared/schemas/stateSettings.ts` — metadata-only rows for the state-backed keys, starting with the four git-author keys (`store:'workspaceState'`, `cliStore:'config'`, `hosts:['vscode','cli','desktop']`, `cliConsumer:'packages/cli/src/runtime/gitAuthor.ts'`) and the `workflow.*` / `latexdiff.*` / `latex.formatter` scalars (`store:'workspaceState'`, `hosts:['vscode','desktop']` for now). Export the key list.
 - New `src/shared/config/settingsAccess.ts` — `readSetting(entry, stores)` / `writeSetting(entry, value, stores)` where `stores = { config, workspaceState, globalState }`. Dispatch on `entry.store` (or `entry.cliStore` when the caller is the CLI); validate writes via the entry's Zod schema where one exists; **reset writes `undefined`** (deletes the key per `jsonConfigProvider.ts:57` → `.prefault()` reappears), never the literal default. `openForm` entries bypass the accessor.
 - `packages/cli/src/schemas/knownKeys.ts` — add `...STATE_SETTING_KEYS` from the catalog; **delete** the four hand-listed `WorkspaceStateKey.GIT_*` lines (31-34). The `WorkspaceStateKey` enum entries stay (the extension still uses them).
@@ -84,6 +86,7 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 - **Verify:** `npm test` (guardrails) + `npm run typecheck`; `gitAuthor.ts` still applies marking (route it through the accessor or leave as-is — both read the same keys from `config`).
 
 ### PR 3 — CLI `/config` panel (USER-VISIBLE; lands in CHANGELOG under Features)
+
 - New `packages/cli/src/chat/tui/forms/ConfigForm.tsx`. **Not a single-Select clone of `ApprovalPolicyForm`** — it is a list + drill-in:
   - Outer `Select` lists catalog entries where `hosts.includes('cli')` (label = setting name, `description` = current resolved value + its store, so cross-host state is visible — risk #1 mitigation).
   - Selecting a **boolean** toggles inline; an **enum** opens an inner `Select` of values (per-option text from `enumDescriptions`); an **`openForm`** entry delegates to the existing `ModelListForm`/`AgentListForm`/`MemoryListForm`/etc.
@@ -94,23 +97,27 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 - **Verify:** roster test = exactly the consumer-verified entries; `SlashRegistry.vitest` covers the new command; manual PTY run via `packages/cli/scripts/tui-harness.tsx` — open `/config`, flip a boolean + an enum, confirm persistence to `.texra/config.json` (project) and that `Esc` closes; confirm the headless `texra run` / `--print` path is byte-unchanged.
 
 ### PR 4 — Extension settingsView re-point (zero message/port/dispatch change)
-- Delete the hardcoded enum/label arrays and read labels/descriptions from the catalog: `AIAgentsTab.ts` (SANDBOX/REASONING/APPROVAL/CLAUDE option arrays, ~lines 40-98), `LaTeXTab.ts` (mathMarkup + formatter options, ~lines 590-616), plus inline labels in `ModelSelectionList.ts` (reasoning-level labels) and `ApiAccessSection.ts`/`ModelsTab.ts`. Splittable per-tab. (Note: the codex/claude option arrays are state-backed complex domains — promoting them to catalog rows is fine for *labels*; their read/write stays in the existing controllers.)
+
+- Delete the hardcoded enum/label arrays and read labels/descriptions from the catalog: `AIAgentsTab.ts` (SANDBOX/REASONING/APPROVAL/CLAUDE option arrays, ~lines 40-98), `LaTeXTab.ts` (mathMarkup + formatter options, ~lines 590-616), plus inline labels in `ModelSelectionList.ts` (reasoning-level labels) and `ApiAccessSection.ts`/`ModelsTab.ts`. Splittable per-tab. (Note: the codex/claude option arrays are state-backed complex domains — promoting them to catalog rows is fine for _labels_; their read/write stays in the existing controllers.)
 - **Verify:** webview renders identical labels; no port/schema diff; `npm run typecheck` + `npm test`.
 
 ### PR 5+ — Promote complex/state-backed domains incrementally (one per PR)
+
 - Add the CLI consumer code path for a domain (e.g. workflow/latexdiff scalars read in CLI from `platform().workspaceState`), flip its catalog `hosts` to include `'cli'`; the entry auto-appears in `/config`, and the PR2 guardrail enforces the consumer exists. Complex domains (streaming/endpoints/models/agents/tools/presets) come in as `openForm` delegations, not scalars.
 
 ## Critical files
+
 - `src/shared/schemas/coreSettings.ts` — `.describe()`/`.meta({enumDescriptions})` back-fill (PR1).
 - `packages/extension/src/schemas/{texraSettings.ts,vscodeSettings.ts}` — allowlist +`description`/`enumDescriptions`; describe the 3 vscode leaves (PR1).
 - `src/test-kernel/shared/settingsConfiguration.vitest.ts` — rewrite preserve-field test + enum-length invariant (PR1).
 - New `src/shared/schemas/stateSettings.ts`, `src/shared/config/settingsAccess.ts` (PR2).
-- `packages/cli/src/schemas/knownKeys.ts` — derive from catalog, delete GIT_* lines 31-34 (PR2).
+- `packages/cli/src/schemas/knownKeys.ts` — derive from catalog, delete GIT\_\* lines 31-34 (PR2).
 - New `packages/cli/src/chat/tui/forms/ConfigForm.tsx`; `packages/cli/src/chat/tui/commands/{registerBuiltins.tsx,slashRegistry.ts}`; `packages/cli/src/chat/tui/runChatTui.tsx:516` (PR3).
 - Extension tabs: `packages/extension/src/settingsView/frontend/tabs/{AIAgentsTab.ts,LaTeXTab.ts,ModelsTab.ts}` + `components/profile/{ModelSelectionList.ts,ApiAccessSection.ts}` (PR4).
 - Reused untouched: `ui/Select.tsx`, `forms/_shared/{FormFrame,selectWindow}.ts`, `src/controllers/settingsView/*`, `scripts/sync-settings-configuration.mjs`, `src/utils/system/gitAuthorSettings.ts`.
 
 ## Verification (every PR)
+
 - `npm run typecheck` and `npm test`.
 - PR1: `npm run sync:settings-configuration --check` zero-diff (proves `.describe()`/`.meta()`+`.prefault()` compose through `z.toJSONSchema()`); enum-length invariant green.
 - PR2: guardrail suite (consumer-exists, knownKeys-derivation, store/scope coherence, Class-D exclusion, default round-trip).
@@ -118,6 +125,7 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 - PR4: identical webview labels; no port/schema diff.
 
 ## Risk register
+
 1. **Cross-host store divergence** (a key set in extension WorkspaceState reads as default in the CLI). Mitigate: store/cliStore coherence guardrail; `/config` shows the resolved value **and its store**; no silent auto-bridge beyond the declared `cliStore` override.
 2. **`description` promotion breaks the existing preserve-field test** (`settingsConfiguration.vitest.ts:157-180` asserts a hand-injected description survives). Mitigate: rewrite that test in PR1 to assert a still-hand-kept field (`order`/`editPresentation`).
 3. **Incomplete `.describe()` back-fill deletes package.json descriptions** (allowlisted + absent in `.meta`/`.describe` ⇒ generator deletes the field). Mitigate: back-fill every config leaf; the idempotency `--check` fails CI on any miss.
@@ -126,10 +134,12 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 6. **ConfigForm complexity** (it's a list + drill-in, not one Select). Mitigate: MVP = booleans + enums + `openForm` only; defer free-text editing; reuse `MemoryListForm` list shape + `Select`.
 
 ## Explicit exclusions (omit `'cli'` from `hosts`; never surfaced in `/config`)
+
 - `texra.memory.enabled`, `texra.goal.enabled` — gated by `registerAgentFeatures()`, confirmed **never called in the CLI** (`initPlatform.ts` has no call; only `extension.ts:219` / desktop `index.ts:154`). Toggling them in the CLI does nothing.
 - `SUPER_YOLO_ENABLED`, `ALLOW_ORCHESTRATOR_KILL`, `DETACH_SUBAGENTS_ON_STOP`, `NESTED_DELEGATION_MAX_DEPTH` — display-only / no CLI orchestrator consumer.
 - Complex global-state domains (streaming/endpoints/models/agents/tools/presets/codex/claude) — `openForm` delegation only, never `/config` scalars.
 - Class-D internal state (`AGENT_HISTORY`, caches, `*_MIGRATED`/`*_VERSION`, onboarding flags, `DESKTOP_CRASH_REPORTING_ENABLED`) — not user settings; excluded entirely, enforced by the PR2 guardrail.
 
 ## Process
+
 Grounded on fresh `origin/main`; re-sync before starting (`git rev-list --count main...origin/main`). Shared-repo concurrency: expect a format-bot commit — adopt via `reset --hard`, don't force-push. Each PR carries its own tests and is independently reviewable; CHANGELOG entry (Features) lands with PR3.

--- a/src/replacement/types.ts
+++ b/src/replacement/types.ts
@@ -1,7 +1,10 @@
 export type ReplacementFunction = (
   match: string,
-
-  ...args: any[]
+  // Regex capture groups, in order. A non-participating group is `undefined`,
+  // which is why every callback treats these as `string | undefined`. (The
+  // trailing offset/full-string args that `String.prototype.replace` also
+  // passes are unused by every replacement here, so they are not modeled.)
+  ...groups: (string | undefined)[]
 ) => string;
 
 export type ReplacementValue = string | ReplacementFunction;

--- a/src/shared/schemas/mainView/outbound.ts
+++ b/src/shared/schemas/mainView/outbound.ts
@@ -10,12 +10,11 @@ import {
   type HandlerRegistry,
 } from '@shared/utils/dispatcher';
 
-import { commandOnly } from '../messageFactories';
+import { commandOnly, withFilesArray } from '../messageFactories';
 import { OnboardingFunnelStateSchema } from '../onboarding';
 import { AgentOptionDataSchema, ModelOptionDataSchema } from './state';
 
 const FileListSchema = z.array(z.string());
-const FilesPayloadSchema = z.object({ files: FileListSchema });
 const SingleFileSelectedSchema = z.object({ filePath: z.string() });
 
 export const SetModelOptionsMessageSchema = z.object({
@@ -33,12 +32,13 @@ export const SetAgentOptionsMessageSchema = z.object({
     .optional(),
 });
 
-export const SetEditedFileMessageSchema = FilesPayloadSchema.extend({
-  command: z.literal(MAIN_VIEW_COMMANDS.SET_EDITED_FILE),
-});
+export const SetEditedFileMessageSchema = withFilesArray(
+  MAIN_VIEW_COMMANDS.SET_EDITED_FILE,
+);
 
-export const SetBaseFileMessageSchema = FilesPayloadSchema.extend({
-  command: z.literal(MAIN_VIEW_COMMANDS.SET_BASE_FILE),
+export const SetBaseFileMessageSchema = withFilesArray(
+  MAIN_VIEW_COMMANDS.SET_BASE_FILE,
+).extend({
   preserveBaseFile: z.boolean().nullish(),
 });
 
@@ -46,21 +46,21 @@ export const EditedFileSelectedMessageSchema = SingleFileSelectedSchema.extend({
   command: z.literal(MAIN_VIEW_COMMANDS.EDITED_FILE_SELECTED),
 });
 
-export const SetInputFilesMessageSchema = FilesPayloadSchema.extend({
-  command: z.literal(MAIN_VIEW_COMMANDS.SET_INPUT_FILES),
-});
+export const SetInputFilesMessageSchema = withFilesArray(
+  MAIN_VIEW_COMMANDS.SET_INPUT_FILES,
+);
 
-export const SetContextFilesMessageSchema = FilesPayloadSchema.extend({
-  command: z.literal(MAIN_VIEW_COMMANDS.SET_CONTEXT_FILES),
-});
+export const SetContextFilesMessageSchema = withFilesArray(
+  MAIN_VIEW_COMMANDS.SET_CONTEXT_FILES,
+);
 
-export const SetMediaFilesMessageSchema = FilesPayloadSchema.extend({
-  command: z.literal(MAIN_VIEW_COMMANDS.SET_MEDIA_FILES),
-});
+export const SetMediaFilesMessageSchema = withFilesArray(
+  MAIN_VIEW_COMMANDS.SET_MEDIA_FILES,
+);
 
-export const SetOutputFilesMessageSchema = FilesPayloadSchema.extend({
-  command: z.literal(MAIN_VIEW_COMMANDS.SET_OUTPUT_FILES),
-});
+export const SetOutputFilesMessageSchema = withFilesArray(
+  MAIN_VIEW_COMMANDS.SET_OUTPUT_FILES,
+);
 
 export const AddMediaFileMessageSchema = z.object({
   command: z.literal(MAIN_VIEW_COMMANDS.ADD_MEDIA_FILE),

--- a/src/shared/schemas/toolResult.ts
+++ b/src/shared/schemas/toolResult.ts
@@ -113,27 +113,6 @@ export function formatZodIssuesForDiagnostics(
   });
 }
 
-export interface DiagnosticsPayload {
-  path: string;
-  command: 'list' | 'count';
-  severity: Record<string, number>;
-  /** Diagnostic messages from the linter (platform-specific type at runtime). */
-  messages?: unknown[];
-}
-
-/**
- * Union type for diagnostic information attached to tool results.
- * - ZodIssue[]: Validation errors from schema parsing
- * - Error-like: Regular errors with name and optional stack
- * - DiagnosticsPayload: Structured diagnostics from tools
- * - unknown: Other diagnostic formats for forward compatibility
- */
-export type ErrorDiagnostics =
-  | ZodIssue[]
-  | { name: string; stack?: string }
-  | DiagnosticsPayload
-  | unknown;
-
 // ============================================================================
 // ToolResult Schema
 // ============================================================================


### PR DESCRIPTION
## Summary

This PR improves code maintainability through three focused changes:

1. **Schema composition refactoring** in `mainView/outbound.ts`: Replaces repeated `FilesPayloadSchema.extend()` patterns with a new `withFilesArray()` helper function, eliminating duplication across six message schemas.

2. **Unused code removal** in `toolResult.ts`: Removes the `DiagnosticsPayload` interface and `ErrorDiagnostics` type union that were no longer referenced in the codebase.

3. **Type documentation improvement** in `replacement/types.ts`: Clarifies the `ReplacementFunction` signature with detailed comments explaining regex capture groups and their `string | undefined` type, making the contract explicit for maintainers.

## Issue acceptance gates

N/A — This is a refactoring and cleanup PR with no associated issue.

## Single source of truth

The `withFilesArray()` helper function in `messageFactories` now owns the schema pattern for file array messages with command literals, eliminating the need for repeated schema composition across multiple message types.

## Duplication and abstraction budget

**Duplication removed:**
- Six message schemas (`SetEditedFile`, `SetBaseFile`, `SetInputFiles`, `SetContextFiles`, `SetMediaFiles`, `SetOutputFiles`) previously duplicated the `FilesPayloadSchema.extend()` pattern. Now they use the `withFilesArray()` helper, reducing boilerplate and improving consistency.

**Dead code removed:**
- `DiagnosticsPayload` interface and `ErrorDiagnostics` type union in `toolResult.ts` were unused and have been removed.

**Documentation added:**
- Inline comments in `ReplacementFunction` clarify the semantics of capture group arguments and their types, reducing cognitive load for future maintainers.

## Host impact

Extension: No functional change; schema composition is internal.

Desktop: No impact.

CLI: No impact.

## Scheduled refactoring

None.

## Validation

- No new tests required; this is a refactoring of existing schema definitions with no behavioral changes.
- TypeScript compilation will verify that the `withFilesArray()` helper produces equivalent schemas to the previous inline patterns.
- Existing message validation tests (if any) will continue to pass unchanged.

https://claude.ai/code/session_01Eay452EJT3o2LvNL7GzrMh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal schema composition and type cleanup with no runtime or IPC behavior changes; removed types had no remaining references.
> 
> **Overview**
> Refactors **MainView outbound** file-list message schemas to use the shared `withFilesArray()` helper instead of repeating `FilesPayloadSchema.extend()`, including `SetBaseFile` via `.extend({ preserveBaseFile })`.
> 
> Removes unused **`DiagnosticsPayload`** and **`ErrorDiagnostics`** from `toolResult.ts` (validation diagnostics stay on `ValidationErrorDiagnostics` and `diagnostics: z.unknown()` on `ToolResultSchema`).
> 
> Tightens **`ReplacementFunction`** in `replacement/types.ts` to typed regex capture groups `(string | undefined)[]` with comments explaining why offset/full-string args are omitted.
> 
> The config-catalog proposal doc only gets markdown formatting tweaks (italics, spacing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3759ae1cf059b6e7de62052034c067b312d9c137. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->