### PR TITLE
Extract shared Google handler logic into googleHandlerShared

### DIFF
--- a/docs/proposals/config-catalog-unification.md
+++ b/docs/proposals/config-catalog-unification.md
@@ -14,9 +14,9 @@ Decision (already made by the user): **full unification** — one catalog as SSO
 
 Exploration disproved two load-bearing assumptions in the draft. Both change the design:
 
-1. **State-backed keys must NOT become `CoreSettingsShape` nodes.** Every node in `CoreSettingsShape` flows into `CORE_SETTING_PATHS` → `TEXRA_SETTING_PATHS` → the package.json generator → a VS Code *configuration* contribution. But the extension reads the state-backed keys (e.g. `texra.git.markCommits`, `texra.workflow.*`, `texra.latexdiff.*`) from **worktree-shared WorkspaceState** (`WORKTREE_SHARED_KEYS` in `packages/extension/src/common/state/stateManager.ts`), not from config — they were deliberately migrated *out* of config (`LATEX_SETTINGS_MIGRATED` marker). Adding them to `CoreSettingsShape` would emit phantom VS Code settings the extension never reads. → They live in a **separate** catalog (`stateSettings.ts`), not coreSettings.
+1. **State-backed keys must NOT become `CoreSettingsShape` nodes.** Every node in `CoreSettingsShape` flows into `CORE_SETTING_PATHS` → `TEXRA_SETTING_PATHS` → the package.json generator → a VS Code _configuration_ contribution. But the extension reads the state-backed keys (e.g. `texra.git.markCommits`, `texra.workflow.*`, `texra.latexdiff.*`) from **worktree-shared WorkspaceState** (`WORKTREE_SHARED_KEYS` in `packages/extension/src/common/state/stateManager.ts`), not from config — they were deliberately migrated _out_ of config (`LATEX_SETTINGS_MIGRATED` marker). Adding them to `CoreSettingsShape` would emit phantom VS Code settings the extension never reads. → They live in a **separate** catalog (`stateSettings.ts`), not coreSettings.
 
-2. **The CLI has three distinct stores, not a single shared one.** `packages/cli/src/runtime/initPlatform.ts:193-200` wires `config` = `JsonConfigProvider` (`.texra/config.json` + `~/.texra/.../config.json`), but `workspaceState` / `globalState` = **separate** `state.json` files (`cliStateStores.ts`). The git-author bridge (`gitAuthor.ts`) works only because it *explicitly* passes `config` into `readGitAuthorSettingsFromState(stateStore)` — exploiting structural read-compat (`ConfigProvider` and `StateStore` both expose `.get(key, default)`), **not** because `workspaceState === config`. So the accessor must be **host-aware**, and the git-author keys need an explicit per-entry `cliStore` override, not an assumed slot identity.
+2. **The CLI has three distinct stores, not a single shared one.** `packages/cli/src/runtime/initPlatform.ts:193-200` wires `config` = `JsonConfigProvider` (`.texra/config.json` + `~/.texra/.../config.json`), but `workspaceState` / `globalState` = **separate** `state.json` files (`cliStateStores.ts`). The git-author bridge (`gitAuthor.ts`) works only because it _explicitly_ passes `config` into `readGitAuthorSettingsFromState(stateStore)` — exploiting structural read-compat (`ConfigProvider` and `StateStore` both expose `.get(key, default)`), **not** because `workspaceState === config`. So the accessor must be **host-aware**, and the git-author keys need an explicit per-entry `cliStore` override, not an assumed slot identity.
 
 ## Catalog & store model
 
@@ -70,6 +70,7 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 ## PR sequence
 
 ### PR 1 — Generator carries `description` + `enumDescriptions` (no behavior change)
+
 - `texraSettings.ts:97` — extend `GENERATED_PACKAGE_SCHEMA_FIELDS` with `'description'`, `'enumDescriptions'` only. (`z.toJSONSchema()` already passes `.describe()` → `description` and merges `.meta()` keys; `pickPackageSchemaFields` is allowlist-driven so other meta stays out of package.json.)
 - `coreSettings.ts` + `vscodeSettings.ts` — add `.describe('…')` to every config leaf and `.meta({ enumDescriptions: [...] })` to enum leaves, **back-filled verbatim from the current package.json strings** so the first generator run is zero-diff.
 - `settingsConfiguration.vitest.ts` — **rewrite the `removes stale generated package schema fields` test (lines 157-180)**: it currently injects `description: 'Preserved description'` and asserts it survives. Once `description` is generated, that assertion is wrong — pivot it to a still-hand-kept field (`order` or `editPresentation`). Add an invariant: every enum leaf's `enumDescriptions.length === enum.length`.
@@ -77,6 +78,7 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 - **Verify:** `sync:settings-configuration --check` is zero-diff; `npm test` (idempotency `assert.deepEqual(build(sections), sections)`) green; `npm run typecheck`.
 
 ### PR 2 — `stateSettings.ts` catalog + `settingsAccess.ts` accessor + knownKeys derivation
+
 - New `src/shared/schemas/stateSettings.ts` — metadata-only rows for the state-backed keys, starting with the four git-author keys (`store:'workspaceState'`, `cliStore:'config'`, `hosts:['vscode','cli','desktop']`, `cliConsumer:'packages/cli/src/runtime/gitAuthor.ts'`) and the `workflow.*` / `latexdiff.*` / `latex.formatter` scalars (`store:'workspaceState'`, `hosts:['vscode','desktop']` for now). Export the key list.
 - New `src/shared/config/settingsAccess.ts` — `readSetting(entry, stores)` / `writeSetting(entry, value, stores)` where `stores = { config, workspaceState, globalState }`. Dispatch on `entry.store` (or `entry.cliStore` when the caller is the CLI); validate writes via the entry's Zod schema where one exists; **reset writes `undefined`** (deletes the key per `jsonConfigProvider.ts:57` → `.prefault()` reappears), never the literal default. `openForm` entries bypass the accessor.
 - `packages/cli/src/schemas/knownKeys.ts` — add `...STATE_SETTING_KEYS` from the catalog; **delete** the four hand-listed `WorkspaceStateKey.GIT_*` lines (31-34). The `WorkspaceStateKey` enum entries stay (the extension still uses them).
@@ -84,6 +86,7 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 - **Verify:** `npm test` (guardrails) + `npm run typecheck`; `gitAuthor.ts` still applies marking (route it through the accessor or leave as-is — both read the same keys from `config`).
 
 ### PR 3 — CLI `/config` panel (USER-VISIBLE; lands in CHANGELOG under Features)
+
 - New `packages/cli/src/chat/tui/forms/ConfigForm.tsx`. **Not a single-Select clone of `ApprovalPolicyForm`** — it is a list + drill-in:
   - Outer `Select` lists catalog entries where `hosts.includes('cli')` (label = setting name, `description` = current resolved value + its store, so cross-host state is visible — risk #1 mitigation).
   - Selecting a **boolean** toggles inline; an **enum** opens an inner `Select` of values (per-option text from `enumDescriptions`); an **`openForm`** entry delegates to the existing `ModelListForm`/`AgentListForm`/`MemoryListForm`/etc.
@@ -94,23 +97,27 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 - **Verify:** roster test = exactly the consumer-verified entries; `SlashRegistry.vitest` covers the new command; manual PTY run via `packages/cli/scripts/tui-harness.tsx` — open `/config`, flip a boolean + an enum, confirm persistence to `.texra/config.json` (project) and that `Esc` closes; confirm the headless `texra run` / `--print` path is byte-unchanged.
 
 ### PR 4 — Extension settingsView re-point (zero message/port/dispatch change)
-- Delete the hardcoded enum/label arrays and read labels/descriptions from the catalog: `AIAgentsTab.ts` (SANDBOX/REASONING/APPROVAL/CLAUDE option arrays, ~lines 40-98), `LaTeXTab.ts` (mathMarkup + formatter options, ~lines 590-616), plus inline labels in `ModelSelectionList.ts` (reasoning-level labels) and `ApiAccessSection.ts`/`ModelsTab.ts`. Splittable per-tab. (Note: the codex/claude option arrays are state-backed complex domains — promoting them to catalog rows is fine for *labels*; their read/write stays in the existing controllers.)
+
+- Delete the hardcoded enum/label arrays and read labels/descriptions from the catalog: `AIAgentsTab.ts` (SANDBOX/REASONING/APPROVAL/CLAUDE option arrays, ~lines 40-98), `LaTeXTab.ts` (mathMarkup + formatter options, ~lines 590-616), plus inline labels in `ModelSelectionList.ts` (reasoning-level labels) and `ApiAccessSection.ts`/`ModelsTab.ts`. Splittable per-tab. (Note: the codex/claude option arrays are state-backed complex domains — promoting them to catalog rows is fine for _labels_; their read/write stays in the existing controllers.)
 - **Verify:** webview renders identical labels; no port/schema diff; `npm run typecheck` + `npm test`.
 
 ### PR 5+ — Promote complex/state-backed domains incrementally (one per PR)
+
 - Add the CLI consumer code path for a domain (e.g. workflow/latexdiff scalars read in CLI from `platform().workspaceState`), flip its catalog `hosts` to include `'cli'`; the entry auto-appears in `/config`, and the PR2 guardrail enforces the consumer exists. Complex domains (streaming/endpoints/models/agents/tools/presets) come in as `openForm` delegations, not scalars.
 
 ## Critical files
+
 - `src/shared/schemas/coreSettings.ts` — `.describe()`/`.meta({enumDescriptions})` back-fill (PR1).
 - `packages/extension/src/schemas/{texraSettings.ts,vscodeSettings.ts}` — allowlist +`description`/`enumDescriptions`; describe the 3 vscode leaves (PR1).
 - `src/test-kernel/shared/settingsConfiguration.vitest.ts` — rewrite preserve-field test + enum-length invariant (PR1).
 - New `src/shared/schemas/stateSettings.ts`, `src/shared/config/settingsAccess.ts` (PR2).
-- `packages/cli/src/schemas/knownKeys.ts` — derive from catalog, delete GIT_* lines 31-34 (PR2).
+- `packages/cli/src/schemas/knownKeys.ts` — derive from catalog, delete GIT\_\* lines 31-34 (PR2).
 - New `packages/cli/src/chat/tui/forms/ConfigForm.tsx`; `packages/cli/src/chat/tui/commands/{registerBuiltins.tsx,slashRegistry.ts}`; `packages/cli/src/chat/tui/runChatTui.tsx:516` (PR3).
 - Extension tabs: `packages/extension/src/settingsView/frontend/tabs/{AIAgentsTab.ts,LaTeXTab.ts,ModelsTab.ts}` + `components/profile/{ModelSelectionList.ts,ApiAccessSection.ts}` (PR4).
 - Reused untouched: `ui/Select.tsx`, `forms/_shared/{FormFrame,selectWindow}.ts`, `src/controllers/settingsView/*`, `scripts/sync-settings-configuration.mjs`, `src/utils/system/gitAuthorSettings.ts`.
 
 ## Verification (every PR)
+
 - `npm run typecheck` and `npm test`.
 - PR1: `npm run sync:settings-configuration --check` zero-diff (proves `.describe()`/`.meta()`+`.prefault()` compose through `z.toJSONSchema()`); enum-length invariant green.
 - PR2: guardrail suite (consumer-exists, knownKeys-derivation, store/scope coherence, Class-D exclusion, default round-trip).
@@ -118,6 +125,7 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 - PR4: identical webview labels; no port/schema diff.
 
 ## Risk register
+
 1. **Cross-host store divergence** (a key set in extension WorkspaceState reads as default in the CLI). Mitigate: store/cliStore coherence guardrail; `/config` shows the resolved value **and its store**; no silent auto-bridge beyond the declared `cliStore` override.
 2. **`description` promotion breaks the existing preserve-field test** (`settingsConfiguration.vitest.ts:157-180` asserts a hand-injected description survives). Mitigate: rewrite that test in PR1 to assert a still-hand-kept field (`order`/`editPresentation`).
 3. **Incomplete `.describe()` back-fill deletes package.json descriptions** (allowlisted + absent in `.meta`/`.describe` ⇒ generator deletes the field). Mitigate: back-fill every config leaf; the idempotency `--check` fails CI on any miss.
@@ -126,10 +134,12 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 6. **ConfigForm complexity** (it's a list + drill-in, not one Select). Mitigate: MVP = booleans + enums + `openForm` only; defer free-text editing; reuse `MemoryListForm` list shape + `Select`.
 
 ## Explicit exclusions (omit `'cli'` from `hosts`; never surfaced in `/config`)
+
 - `texra.memory.enabled`, `texra.goal.enabled` — gated by `registerAgentFeatures()`, confirmed **never called in the CLI** (`initPlatform.ts` has no call; only `extension.ts:219` / desktop `index.ts:154`). Toggling them in the CLI does nothing.
 - `SUPER_YOLO_ENABLED`, `ALLOW_ORCHESTRATOR_KILL`, `DETACH_SUBAGENTS_ON_STOP`, `NESTED_DELEGATION_MAX_DEPTH` — display-only / no CLI orchestrator consumer.
 - Complex global-state domains (streaming/endpoints/models/agents/tools/presets/codex/claude) — `openForm` delegation only, never `/config` scalars.
 - Class-D internal state (`AGENT_HISTORY`, caches, `*_MIGRATED`/`*_VERSION`, onboarding flags, `DESKTOP_CRASH_REPORTING_ENABLED`) — not user settings; excluded entirely, enforced by the PR2 guardrail.
 
 ## Process
+
 Grounded on fresh `origin/main`; re-sync before starting (`git rev-list --count main...origin/main`). Shared-repo concurrency: expect a format-bot commit — adopt via `reset --hard`, don't force-push. Each PR carries its own tests and is independently reviewable; CHANGELOG entry (Features) lands with PR3.

--- a/src/agent/modelHandlers/google/googleHandlerShared.ts
+++ b/src/agent/modelHandlers/google/googleHandlerShared.ts
@@ -1,0 +1,144 @@
+import { GoogleGenAI } from '@google/genai';
+import { ReasoningEffort } from 'llm-zoo';
+
+import type { AgentTrace } from '@agent/trace';
+
+/**
+ * Shared helpers for the two Google handlers (generateContent chat handler and
+ * the Interactions handler). Both use the SAME `GoogleGenAI` SDK, so client
+ * setup, Gemini-3 detection, and reasoning->thinking-level mapping are identical
+ * in shape and were previously copy-pasted across the two files.
+ *
+ * The mapping helpers are generic over the per-handler value space: the chat
+ * handler emits SDK `ThinkingLevel` enums while the Interactions handler emits
+ * lowercase string literals, so callers supply their own level values and the
+ * matching message labels to keep log output byte-identical.
+ */
+
+/** Whether the model is a Gemini 3 variant (different thinking/media rules). */
+export function isGemini3Model(fullName: string): boolean {
+  return /^gemini-3[\.\-]/.test(fullName);
+}
+
+interface ResolveGoogleClientParams {
+  /** SDK surface label used in debug logs, e.g. `'Native'` or `'Interactions'`. */
+  sdkLabel: string;
+  shouldUseServerSideKeys: boolean;
+  getApiKey: () => Promise<string>;
+  getBaseUrl: () => string | null;
+  logger: AgentTrace;
+  /** Current cached client (server-side keys bypass the cache). */
+  cached: GoogleGenAI | null;
+  /** Stores a freshly-created client for reuse with personal API keys. */
+  setCached: (client: GoogleGenAI) => void;
+}
+
+/**
+ * Resolve a `GoogleGenAI` client, refreshing on every call for server-side relay
+ * keys (auth tokens expire ~30 mins) and caching for non-expiring personal keys.
+ *
+ * SDK-level retries are disabled (`retryOptions: { attempts: 1 }`) so that only
+ * the flow-level retry loop (`RetryState.getNodeRetryConfig`) governs the user's
+ * retry budget — otherwise transient errors would be retried by both the SDK and
+ * the flow, multiplying the configured attempt count.
+ */
+export async function resolveGoogleClient(
+  params: ResolveGoogleClientParams,
+): Promise<GoogleGenAI> {
+  const {
+    sdkLabel,
+    shouldUseServerSideKeys,
+    getApiKey,
+    getBaseUrl,
+    logger,
+    cached,
+    setCached,
+  } = params;
+
+  if (shouldUseServerSideKeys) {
+    const credential = await getApiKey();
+    const baseUrl = getBaseUrl();
+    logger.debug(
+      `Using Google GenAI ${sdkLabel} SDK with relay auth. Base URL: ${baseUrl}`,
+    );
+    return new GoogleGenAI({
+      apiKey: credential,
+      httpOptions: {
+        baseUrl: baseUrl ?? undefined,
+        retryOptions: { attempts: 1 },
+      },
+    });
+  }
+
+  if (!cached) {
+    const credential = await getApiKey();
+    const baseUrl = getBaseUrl();
+    logger.debug(`Using Google GenAI ${sdkLabel} SDK. Base URL: ${baseUrl}`);
+    const client = new GoogleGenAI({
+      apiKey: credential,
+      httpOptions: {
+        baseUrl: baseUrl ?? undefined,
+        retryOptions: { attempts: 1 },
+      },
+    });
+    setCached(client);
+    return client;
+  }
+  return cached;
+}
+
+interface ResolveGeminiThinkingLevelParams<T> {
+  reasoningEffort: ReasoningEffort | undefined;
+  isGemini3: boolean;
+  /** Whether the model is a `-pro` variant (only supports low/high). */
+  isPro: boolean;
+  logger: AgentTrace;
+  /** Per-handler level values (SDK enum vs lowercase string literals). */
+  levels: { low: T; medium: T; high: T };
+  /** Human-readable level names used in log messages (casing differs per SDK). */
+  labels: { low: string; medium: string; high: string };
+}
+
+/**
+ * Map the model's reasoning effort to a Gemini `thinking_level`.
+ *
+ * Returns `levels.low` (not `undefined`) for `NONE` so the API does not fall back
+ * to its default medium/high — that would defeat the user's intent. Gemini tops
+ * out at HIGH thinking, so xhigh/max both map to it; Gemini 3 Pro only supports
+ * low/high, so MEDIUM falls back to HIGH for Pro.
+ */
+export function resolveGeminiThinkingLevel<T>(
+  params: ResolveGeminiThinkingLevelParams<T>,
+): T | undefined {
+  const { reasoningEffort, isGemini3, isPro, logger, levels, labels } = params;
+
+  switch (reasoningEffort) {
+    case ReasoningEffort.NONE:
+      if (isGemini3) {
+        logger.warn(
+          `Gemini 3 models can't fully disable thinking. Using thinking_level '${labels.low}'.`,
+        );
+      }
+      return levels.low;
+
+    case ReasoningEffort.LOW:
+      return levels.low;
+
+    case ReasoningEffort.MEDIUM:
+      if (isGemini3 && isPro) {
+        logger.debug(
+          `Gemini 3 Pro does not support ${labels.medium} thinking level. Using ${labels.high}.`,
+        );
+        return levels.high;
+      }
+      return levels.medium;
+
+    case ReasoningEffort.HIGH:
+    case ReasoningEffort.XHIGH:
+    case ReasoningEffort.MAX:
+      return levels.high;
+
+    default:
+      return undefined;
+  }
+}

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -20,7 +20,6 @@ import {
 } from '@google/genai';
 
 // Local imports - agent
-import { ReasoningEffort } from 'llm-zoo';
 import { logSdkError } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { hasEndTag } from '@agent/core/definition/AgentDataclass';
@@ -49,6 +48,11 @@ import type { ToolFileAttachment } from '@shared/schemas/toolResult';
 import { isNonEmptyString } from '@utils/core';
 import { flexibleFS, getShortDisplayPath } from '@utils/files';
 import { joinNonEmpty, pluralize } from '@utils/text/stringUtils';
+import {
+  isGemini3Model,
+  resolveGeminiThinkingLevel,
+  resolveGoogleClient,
+} from './googleHandlerShared';
 import { computeGooglePrice, normalizeGoogleUsage } from './googleUsage';
 import { prepareExistingOutputContent } from '../utils/fileContentUtils';
 import { tagGoogleSdkError } from './googleSdkError';
@@ -113,7 +117,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
   }
 
   private isGemini3Model(): boolean {
-    return /^gemini-3[\.\-]/.test(this.config.fullName);
+    return isGemini3Model(this.config.fullName);
   }
 
   /**
@@ -141,43 +145,18 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
   }
 
   private getThinkingLevel(): ThinkingLevel | undefined {
-    const requestedLevel = this.capabilities.reasoningEffort;
-    const isGemini3 = this.isGemini3Model();
-
-    switch (requestedLevel) {
-      case ReasoningEffort.NONE:
-        if (isGemini3) {
-          this.logger.warn(
-            "Gemini 3 models can't fully disable thinking. Using thinking_level 'LOW'.",
-          );
-        }
-        // Use LOW as the minimum supported level across all thinking models.
-        // Returning undefined would omit thinkingLevel entirely, making the
-        // API fall back to its default (medium/high) — defeating the user's intent.
-        return ThinkingLevel.LOW;
-
-      case ReasoningEffort.LOW:
-        return ThinkingLevel.LOW;
-
-      case ReasoningEffort.MEDIUM:
-        // Gemini 3 Pro only supports LOW/HIGH; MEDIUM falls back to HIGH for Pro
-        if (isGemini3 && this.config.fullName.includes('-pro')) {
-          this.logger.debug(
-            'Gemini 3 Pro does not support MEDIUM thinking level. Using HIGH.',
-          );
-          return ThinkingLevel.HIGH;
-        }
-        return ThinkingLevel.MEDIUM;
-
-      case ReasoningEffort.HIGH:
-      case ReasoningEffort.XHIGH:
-      case ReasoningEffort.MAX:
-        // Gemini tops out at HIGH thinking; xhigh/max both map to it.
-        return ThinkingLevel.HIGH;
-
-      default:
-        return undefined;
-    }
+    return resolveGeminiThinkingLevel({
+      reasoningEffort: this.capabilities.reasoningEffort,
+      isGemini3: this.isGemini3Model(),
+      isPro: this.config.fullName.includes('-pro'),
+      logger: this.logger,
+      levels: {
+        low: ThinkingLevel.LOW,
+        medium: ThinkingLevel.MEDIUM,
+        high: ThinkingLevel.HIGH,
+      },
+      labels: { low: 'LOW', medium: 'MEDIUM', high: 'HIGH' },
+    });
   }
 
   protected getInlineUploadLimitBytes(): number {
@@ -288,43 +267,17 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
   }
 
   async getClient(): Promise<GoogleGenAI> {
-    // When using server-side relay keys, always create a fresh client to ensure
-    // auth tokens are refreshed (tokens expire and need refresh every 30 mins).
-    // Personal API keys don't expire, so caching is safe for those.
-    if (this.shouldUseServerSideKeys()) {
-      const credential = await this.getApiKey();
-      const baseUrl = this.getBaseUrl();
-      this.logger.debug(
-        `Using Google GenAI Native SDK with relay auth. Base URL: ${baseUrl}`,
-      );
-      return new GoogleGenAI({
-        apiKey: credential,
-        httpOptions: {
-          baseUrl: baseUrl ?? undefined,
-          // Disable SDK-level retries so that only the flow-level retry loop
-          // (RetryState.getNodeRetryConfig) manages the user's retry budget.
-          // Without this, transient errors would be retried by BOTH the SDK and
-          // the flow, multiplying the configured attempt count.
-          retryOptions: { attempts: 1 },
-        },
-      });
-    }
-
-    // For personal API keys, cache the client
-    if (!this.googleClient) {
-      const credential = await this.getApiKey();
-      const baseUrl = this.getBaseUrl();
-      this.logger.debug(`Using Google GenAI Native SDK. Base URL: ${baseUrl}`);
-
-      this.googleClient = new GoogleGenAI({
-        apiKey: credential,
-        httpOptions: {
-          baseUrl: baseUrl ?? undefined,
-          retryOptions: { attempts: 1 },
-        },
-      });
-    }
-    return this.googleClient;
+    return resolveGoogleClient({
+      sdkLabel: 'Native',
+      shouldUseServerSideKeys: this.shouldUseServerSideKeys(),
+      getApiKey: () => this.getApiKey(),
+      getBaseUrl: () => this.getBaseUrl(),
+      logger: this.logger,
+      cached: this.googleClient,
+      setCached: (client) => {
+        this.googleClient = client;
+      },
+    });
   }
 
   /**

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -13,7 +13,6 @@ import {
 } from '@google/genai';
 
 // Local imports - agent
-import { ReasoningEffort } from 'llm-zoo';
 import { logProgressStatus, logSdkError } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { hasEndTag } from '@agent/core/definition/AgentDataclass';
@@ -44,6 +43,11 @@ import { delay, isNonEmptyString, isObject } from '@utils/core';
 import { flexibleFS, getShortDisplayPath } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
 import { joinNonEmpty, pluralize } from '@utils/text/stringUtils';
+import {
+  isGemini3Model,
+  resolveGeminiThinkingLevel,
+  resolveGoogleClient,
+} from './googleHandlerShared';
 
 // Local file imports
 import {
@@ -482,7 +486,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
   }
 
   private isGemini3Model(): boolean {
-    return /^gemini-3[\.\-]/.test(this.config.fullName);
+    return isGemini3Model(this.config.fullName);
   }
 
   private getMediaResolution(mimeType: string): MediaResolution | undefined {
@@ -506,39 +510,14 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
    * `GenerationConfig.thinking_level` lowercase literals.
    */
   private getThinkingLevel(): ThinkingLevel | undefined {
-    const requestedLevel = this.capabilities.reasoningEffort;
-    const isGemini3 = this.isGemini3Model();
-
-    switch (requestedLevel) {
-      case ReasoningEffort.NONE:
-        if (isGemini3) {
-          this.logger.warn(
-            "Gemini 3 models can't fully disable thinking. Using thinking_level 'low'.",
-          );
-        }
-        return 'low';
-
-      case ReasoningEffort.LOW:
-        return 'low';
-
-      case ReasoningEffort.MEDIUM:
-        // Gemini 3 Pro only supports low/high; medium falls back to high for Pro.
-        if (isGemini3 && this.config.fullName.includes('-pro')) {
-          this.logger.debug(
-            'Gemini 3 Pro does not support medium thinking level. Using high.',
-          );
-          return 'high';
-        }
-        return 'medium';
-
-      case ReasoningEffort.HIGH:
-      case ReasoningEffort.XHIGH:
-      case ReasoningEffort.MAX:
-        return 'high';
-
-      default:
-        return undefined;
-    }
+    return resolveGeminiThinkingLevel<ThinkingLevel>({
+      reasoningEffort: this.capabilities.reasoningEffort,
+      isGemini3: this.isGemini3Model(),
+      isPro: this.config.fullName.includes('-pro'),
+      logger: this.logger,
+      levels: { low: 'low', medium: 'medium', high: 'high' },
+      labels: { low: 'low', medium: 'medium', high: 'high' },
+    });
   }
 
   protected getInlineUploadLimitBytes(): number {
@@ -546,40 +525,18 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
   }
 
   async getClient(): Promise<GoogleGenAI> {
-    // When using server-side relay keys, always create a fresh client to ensure
-    // auth tokens are refreshed (tokens expire every ~30 mins). Personal API
-    // keys don't expire, so caching is safe for those. (REUSE: identical to the
-    // chat handler; `apiVersion` left unset for v0 — see spec §6.4.)
-    if (this.shouldUseServerSideKeys()) {
-      const credential = await this.getApiKey();
-      const baseUrl = this.getBaseUrl();
-      this.logger.debug(
-        `Using Google GenAI Interactions SDK with relay auth. Base URL: ${baseUrl}`,
-      );
-      return new GoogleGenAI({
-        apiKey: credential,
-        httpOptions: {
-          baseUrl: baseUrl ?? undefined,
-          retryOptions: { attempts: 1 },
-        },
-      });
-    }
-
-    if (!this.googleClient) {
-      const credential = await this.getApiKey();
-      const baseUrl = this.getBaseUrl();
-      this.logger.debug(
-        `Using Google GenAI Interactions SDK. Base URL: ${baseUrl}`,
-      );
-      this.googleClient = new GoogleGenAI({
-        apiKey: credential,
-        httpOptions: {
-          baseUrl: baseUrl ?? undefined,
-          retryOptions: { attempts: 1 },
-        },
-      });
-    }
-    return this.googleClient;
+    // `apiVersion` left unset for v0 — see spec §6.4.
+    return resolveGoogleClient({
+      sdkLabel: 'Interactions',
+      shouldUseServerSideKeys: this.shouldUseServerSideKeys(),
+      getApiKey: () => this.getApiKey(),
+      getBaseUrl: () => this.getBaseUrl(),
+      logger: this.logger,
+      cached: this.googleClient,
+      setCached: (client) => {
+        this.googleClient = client;
+      },
+    });
   }
 
   override get supportsTokenCounting(): boolean {


### PR DESCRIPTION
## Summary

Consolidate duplicated client initialization and thinking-level mapping logic between the two Google model handlers (`ModelHandlerGoogleGenAI` and `ModelHandlerGoogleInteractions`) into a new shared module. Both handlers use the same `GoogleGenAI` SDK and implement identical logic for client setup, Gemini-3 detection, and reasoning-effort-to-thinking-level mapping, with only minor differences in enum/string literal values.

## Issue acceptance gates

N/A — internal refactoring to reduce duplication.

## Single source of truth

`src/agent/modelHandlers/google/googleHandlerShared.ts` now owns:
- `isGemini3Model()` — Gemini 3 variant detection
- `resolveGoogleClient()` — Client initialization with caching and retry configuration
- `resolveGeminiThinkingLevel()` — Reasoning effort to thinking level mapping

## Duplication and abstraction budget

**Removed duplication:**
- Eliminated ~40 lines of identical client initialization code (auth token refresh logic, retry configuration, caching strategy)
- Consolidated ~35 lines of identical thinking-level mapping logic with identical branching and fallback rules

**Abstraction design:**
- `resolveGeminiThinkingLevel<T>()` is generic over the per-handler level value space (SDK `ThinkingLevel` enum vs lowercase string literals), with callers supplying both level values and human-readable labels to keep log output byte-identical
- `resolveGoogleClient()` accepts callbacks (`getApiKey`, `getBaseUrl`, `setCached`) to remain handler-agnostic while preserving each handler's caching strategy
- Both functions accept a `logger` parameter to maintain existing debug/warn output

## Host impact

Extension: No user-facing changes; internal refactoring only.

Desktop: No user-facing changes; internal refactoring only.

CLI: No impact.

## Scheduled refactoring

None.

## Validation

- Existing tests pass (no test changes required; logic is identical)
- Code review confirms byte-identical log output and behavior preservation

https://claude.ai/code/session_01RGcffRKtov8L5WZzXLuHR4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor in Google model handlers with no API or config surface changes; logic is intended to be behavior- and log-preserving.
> 
> **Overview**
> Introduces **`googleHandlerShared.ts`** and wires **`ModelHandlerGoogleGenAI`** and **`ModelHandlerGoogleInteractions`** through it so duplicated logic lives in one place.
> 
> **Shared behavior:** Gemini 3 name detection, **`GoogleGenAI`** client resolution (relay keys always refresh; personal keys cached; SDK retries set to 1), and reasoning-effort → thinking-level mapping (including Gemini 3 Pro fallbacks and **`NONE`** → minimum level so the API does not default to higher thinking).
> 
> **Handler-specific output** stays local: callers pass SDK enum vs lowercase string levels and matching log labels so behavior and log text stay the same as before.
> 
> Also includes trivial formatting-only edits in **`docs/proposals/config-catalog-unification.md`** (emphasis/whitespace).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81df41996bf100336846d3abdf04242f04f26b6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->