### PR TITLE
refactor(commands): single-source the pack/clean file-op schemas

### DIFF
--- a/docs/proposals/config-catalog-unification.md
+++ b/docs/proposals/config-catalog-unification.md
@@ -14,9 +14,9 @@ Decision (already made by the user): **full unification** — one catalog as SSO
 
 Exploration disproved two load-bearing assumptions in the draft. Both change the design:
 
-1. **State-backed keys must NOT become `CoreSettingsShape` nodes.** Every node in `CoreSettingsShape` flows into `CORE_SETTING_PATHS` → `TEXRA_SETTING_PATHS` → the package.json generator → a VS Code *configuration* contribution. But the extension reads the state-backed keys (e.g. `texra.git.markCommits`, `texra.workflow.*`, `texra.latexdiff.*`) from **worktree-shared WorkspaceState** (`WORKTREE_SHARED_KEYS` in `packages/extension/src/common/state/stateManager.ts`), not from config — they were deliberately migrated *out* of config (`LATEX_SETTINGS_MIGRATED` marker). Adding them to `CoreSettingsShape` would emit phantom VS Code settings the extension never reads. → They live in a **separate** catalog (`stateSettings.ts`), not coreSettings.
+1. **State-backed keys must NOT become `CoreSettingsShape` nodes.** Every node in `CoreSettingsShape` flows into `CORE_SETTING_PATHS` → `TEXRA_SETTING_PATHS` → the package.json generator → a VS Code _configuration_ contribution. But the extension reads the state-backed keys (e.g. `texra.git.markCommits`, `texra.workflow.*`, `texra.latexdiff.*`) from **worktree-shared WorkspaceState** (`WORKTREE_SHARED_KEYS` in `packages/extension/src/common/state/stateManager.ts`), not from config — they were deliberately migrated _out_ of config (`LATEX_SETTINGS_MIGRATED` marker). Adding them to `CoreSettingsShape` would emit phantom VS Code settings the extension never reads. → They live in a **separate** catalog (`stateSettings.ts`), not coreSettings.
 
-2. **The CLI has three distinct stores, not a single shared one.** `packages/cli/src/runtime/initPlatform.ts:193-200` wires `config` = `JsonConfigProvider` (`.texra/config.json` + `~/.texra/.../config.json`), but `workspaceState` / `globalState` = **separate** `state.json` files (`cliStateStores.ts`). The git-author bridge (`gitAuthor.ts`) works only because it *explicitly* passes `config` into `readGitAuthorSettingsFromState(stateStore)` — exploiting structural read-compat (`ConfigProvider` and `StateStore` both expose `.get(key, default)`), **not** because `workspaceState === config`. So the accessor must be **host-aware**, and the git-author keys need an explicit per-entry `cliStore` override, not an assumed slot identity.
+2. **The CLI has three distinct stores, not a single shared one.** `packages/cli/src/runtime/initPlatform.ts:193-200` wires `config` = `JsonConfigProvider` (`.texra/config.json` + `~/.texra/.../config.json`), but `workspaceState` / `globalState` = **separate** `state.json` files (`cliStateStores.ts`). The git-author bridge (`gitAuthor.ts`) works only because it _explicitly_ passes `config` into `readGitAuthorSettingsFromState(stateStore)` — exploiting structural read-compat (`ConfigProvider` and `StateStore` both expose `.get(key, default)`), **not** because `workspaceState === config`. So the accessor must be **host-aware**, and the git-author keys need an explicit per-entry `cliStore` override, not an assumed slot identity.
 
 ## Catalog & store model
 
@@ -70,6 +70,7 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 ## PR sequence
 
 ### PR 1 — Generator carries `description` + `enumDescriptions` (no behavior change)
+
 - `texraSettings.ts:97` — extend `GENERATED_PACKAGE_SCHEMA_FIELDS` with `'description'`, `'enumDescriptions'` only. (`z.toJSONSchema()` already passes `.describe()` → `description` and merges `.meta()` keys; `pickPackageSchemaFields` is allowlist-driven so other meta stays out of package.json.)
 - `coreSettings.ts` + `vscodeSettings.ts` — add `.describe('…')` to every config leaf and `.meta({ enumDescriptions: [...] })` to enum leaves, **back-filled verbatim from the current package.json strings** so the first generator run is zero-diff.
 - `settingsConfiguration.vitest.ts` — **rewrite the `removes stale generated package schema fields` test (lines 157-180)**: it currently injects `description: 'Preserved description'` and asserts it survives. Once `description` is generated, that assertion is wrong — pivot it to a still-hand-kept field (`order` or `editPresentation`). Add an invariant: every enum leaf's `enumDescriptions.length === enum.length`.
@@ -77,6 +78,7 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 - **Verify:** `sync:settings-configuration --check` is zero-diff; `npm test` (idempotency `assert.deepEqual(build(sections), sections)`) green; `npm run typecheck`.
 
 ### PR 2 — `stateSettings.ts` catalog + `settingsAccess.ts` accessor + knownKeys derivation
+
 - New `src/shared/schemas/stateSettings.ts` — metadata-only rows for the state-backed keys, starting with the four git-author keys (`store:'workspaceState'`, `cliStore:'config'`, `hosts:['vscode','cli','desktop']`, `cliConsumer:'packages/cli/src/runtime/gitAuthor.ts'`) and the `workflow.*` / `latexdiff.*` / `latex.formatter` scalars (`store:'workspaceState'`, `hosts:['vscode','desktop']` for now). Export the key list.
 - New `src/shared/config/settingsAccess.ts` — `readSetting(entry, stores)` / `writeSetting(entry, value, stores)` where `stores = { config, workspaceState, globalState }`. Dispatch on `entry.store` (or `entry.cliStore` when the caller is the CLI); validate writes via the entry's Zod schema where one exists; **reset writes `undefined`** (deletes the key per `jsonConfigProvider.ts:57` → `.prefault()` reappears), never the literal default. `openForm` entries bypass the accessor.
 - `packages/cli/src/schemas/knownKeys.ts` — add `...STATE_SETTING_KEYS` from the catalog; **delete** the four hand-listed `WorkspaceStateKey.GIT_*` lines (31-34). The `WorkspaceStateKey` enum entries stay (the extension still uses them).
@@ -84,6 +86,7 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 - **Verify:** `npm test` (guardrails) + `npm run typecheck`; `gitAuthor.ts` still applies marking (route it through the accessor or leave as-is — both read the same keys from `config`).
 
 ### PR 3 — CLI `/config` panel (USER-VISIBLE; lands in CHANGELOG under Features)
+
 - New `packages/cli/src/chat/tui/forms/ConfigForm.tsx`. **Not a single-Select clone of `ApprovalPolicyForm`** — it is a list + drill-in:
   - Outer `Select` lists catalog entries where `hosts.includes('cli')` (label = setting name, `description` = current resolved value + its store, so cross-host state is visible — risk #1 mitigation).
   - Selecting a **boolean** toggles inline; an **enum** opens an inner `Select` of values (per-option text from `enumDescriptions`); an **`openForm`** entry delegates to the existing `ModelListForm`/`AgentListForm`/`MemoryListForm`/etc.
@@ -94,23 +97,27 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 - **Verify:** roster test = exactly the consumer-verified entries; `SlashRegistry.vitest` covers the new command; manual PTY run via `packages/cli/scripts/tui-harness.tsx` — open `/config`, flip a boolean + an enum, confirm persistence to `.texra/config.json` (project) and that `Esc` closes; confirm the headless `texra run` / `--print` path is byte-unchanged.
 
 ### PR 4 — Extension settingsView re-point (zero message/port/dispatch change)
-- Delete the hardcoded enum/label arrays and read labels/descriptions from the catalog: `AIAgentsTab.ts` (SANDBOX/REASONING/APPROVAL/CLAUDE option arrays, ~lines 40-98), `LaTeXTab.ts` (mathMarkup + formatter options, ~lines 590-616), plus inline labels in `ModelSelectionList.ts` (reasoning-level labels) and `ApiAccessSection.ts`/`ModelsTab.ts`. Splittable per-tab. (Note: the codex/claude option arrays are state-backed complex domains — promoting them to catalog rows is fine for *labels*; their read/write stays in the existing controllers.)
+
+- Delete the hardcoded enum/label arrays and read labels/descriptions from the catalog: `AIAgentsTab.ts` (SANDBOX/REASONING/APPROVAL/CLAUDE option arrays, ~lines 40-98), `LaTeXTab.ts` (mathMarkup + formatter options, ~lines 590-616), plus inline labels in `ModelSelectionList.ts` (reasoning-level labels) and `ApiAccessSection.ts`/`ModelsTab.ts`. Splittable per-tab. (Note: the codex/claude option arrays are state-backed complex domains — promoting them to catalog rows is fine for _labels_; their read/write stays in the existing controllers.)
 - **Verify:** webview renders identical labels; no port/schema diff; `npm run typecheck` + `npm test`.
 
 ### PR 5+ — Promote complex/state-backed domains incrementally (one per PR)
+
 - Add the CLI consumer code path for a domain (e.g. workflow/latexdiff scalars read in CLI from `platform().workspaceState`), flip its catalog `hosts` to include `'cli'`; the entry auto-appears in `/config`, and the PR2 guardrail enforces the consumer exists. Complex domains (streaming/endpoints/models/agents/tools/presets) come in as `openForm` delegations, not scalars.
 
 ## Critical files
+
 - `src/shared/schemas/coreSettings.ts` — `.describe()`/`.meta({enumDescriptions})` back-fill (PR1).
 - `packages/extension/src/schemas/{texraSettings.ts,vscodeSettings.ts}` — allowlist +`description`/`enumDescriptions`; describe the 3 vscode leaves (PR1).
 - `src/test-kernel/shared/settingsConfiguration.vitest.ts` — rewrite preserve-field test + enum-length invariant (PR1).
 - New `src/shared/schemas/stateSettings.ts`, `src/shared/config/settingsAccess.ts` (PR2).
-- `packages/cli/src/schemas/knownKeys.ts` — derive from catalog, delete GIT_* lines 31-34 (PR2).
+- `packages/cli/src/schemas/knownKeys.ts` — derive from catalog, delete GIT\_\* lines 31-34 (PR2).
 - New `packages/cli/src/chat/tui/forms/ConfigForm.tsx`; `packages/cli/src/chat/tui/commands/{registerBuiltins.tsx,slashRegistry.ts}`; `packages/cli/src/chat/tui/runChatTui.tsx:516` (PR3).
 - Extension tabs: `packages/extension/src/settingsView/frontend/tabs/{AIAgentsTab.ts,LaTeXTab.ts,ModelsTab.ts}` + `components/profile/{ModelSelectionList.ts,ApiAccessSection.ts}` (PR4).
 - Reused untouched: `ui/Select.tsx`, `forms/_shared/{FormFrame,selectWindow}.ts`, `src/controllers/settingsView/*`, `scripts/sync-settings-configuration.mjs`, `src/utils/system/gitAuthorSettings.ts`.
 
 ## Verification (every PR)
+
 - `npm run typecheck` and `npm test`.
 - PR1: `npm run sync:settings-configuration --check` zero-diff (proves `.describe()`/`.meta()`+`.prefault()` compose through `z.toJSONSchema()`); enum-length invariant green.
 - PR2: guardrail suite (consumer-exists, knownKeys-derivation, store/scope coherence, Class-D exclusion, default round-trip).
@@ -118,6 +125,7 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 - PR4: identical webview labels; no port/schema diff.
 
 ## Risk register
+
 1. **Cross-host store divergence** (a key set in extension WorkspaceState reads as default in the CLI). Mitigate: store/cliStore coherence guardrail; `/config` shows the resolved value **and its store**; no silent auto-bridge beyond the declared `cliStore` override.
 2. **`description` promotion breaks the existing preserve-field test** (`settingsConfiguration.vitest.ts:157-180` asserts a hand-injected description survives). Mitigate: rewrite that test in PR1 to assert a still-hand-kept field (`order`/`editPresentation`).
 3. **Incomplete `.describe()` back-fill deletes package.json descriptions** (allowlisted + absent in `.meta`/`.describe` ⇒ generator deletes the field). Mitigate: back-fill every config leaf; the idempotency `--check` fails CI on any miss.
@@ -126,10 +134,12 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 6. **ConfigForm complexity** (it's a list + drill-in, not one Select). Mitigate: MVP = booleans + enums + `openForm` only; defer free-text editing; reuse `MemoryListForm` list shape + `Select`.
 
 ## Explicit exclusions (omit `'cli'` from `hosts`; never surfaced in `/config`)
+
 - `texra.memory.enabled`, `texra.goal.enabled` — gated by `registerAgentFeatures()`, confirmed **never called in the CLI** (`initPlatform.ts` has no call; only `extension.ts:219` / desktop `index.ts:154`). Toggling them in the CLI does nothing.
 - `SUPER_YOLO_ENABLED`, `ALLOW_ORCHESTRATOR_KILL`, `DETACH_SUBAGENTS_ON_STOP`, `NESTED_DELEGATION_MAX_DEPTH` — display-only / no CLI orchestrator consumer.
 - Complex global-state domains (streaming/endpoints/models/agents/tools/presets/codex/claude) — `openForm` delegation only, never `/config` scalars.
 - Class-D internal state (`AGENT_HISTORY`, caches, `*_MIGRATED`/`*_VERSION`, onboarding flags, `DESKTOP_CRASH_REPORTING_ENABLED`) — not user settings; excluded entirely, enforced by the PR2 guardrail.
 
 ## Process
+
 Grounded on fresh `origin/main`; re-sync before starting (`git rev-list --count main...origin/main`). Shared-repo concurrency: expect a format-bot commit — adopt via `reset --hard`, don't force-push. Each PR carries its own tests and is independently reviewable; CHANGELOG entry (Features) lands with PR3.

--- a/packages/extension/src/commands/housekeeping/cleanCommands.ts
+++ b/packages/extension/src/commands/housekeeping/cleanCommands.ts
@@ -1,6 +1,5 @@
 // Third-party imports
 import * as vscode from 'vscode';
-import { z } from 'zod';
 
 // Local imports
 import type { FileOpResult } from '@agent/types';
@@ -12,25 +11,14 @@ import {
   runCleanRunDir,
 } from '@housekeeping';
 import * as logger from '@logger/logUtils';
-import { ExecutionIdSchema } from '@shared/schemas';
+import { FileOpParamsSchema, fileOpConfigFields } from './fileOpSchemas';
 import { emitClearMissingOutputs } from './streamEventUtils';
 
 const CHANNEL = 'cleanCommands';
 logger.initialize(CHANNEL);
 
-const RequiredString = z.string().min(1);
-
-const CleanParamsSchema = z.object({
-  inputFile: RequiredString,
-  agent: RequiredString,
-  model: RequiredString,
-});
-
-const CleanConfigSchema = CleanParamsSchema.extend({
-  outputFiles: z.array(z.string()).prefault([]),
-  streamId: z.string().optional(),
-  executionId: ExecutionIdSchema.optional(),
-  skipProgressViewClear: z.boolean().optional(),
+const CleanConfigSchema = FileOpParamsSchema.extend({
+  ...fileOpConfigFields,
 });
 
 function showCleanResult(result: FileOpResult, inputFile: string): void {
@@ -71,7 +59,7 @@ async function handleCleanSingle(
 ): Promise<void> {
   const data = await parseWithErrorDisplay(
     CHANNEL,
-    CleanParamsSchema,
+    FileOpParamsSchema,
     { inputFile, agent, model },
     'cleanSingle params',
   );
@@ -97,7 +85,7 @@ async function handleCleanMultiple(
 ): Promise<void> {
   const data = await parseWithErrorDisplay(
     CHANNEL,
-    CleanParamsSchema,
+    FileOpParamsSchema,
     { inputFile, agent, model },
     'cleanMultiple params',
   );

--- a/packages/extension/src/commands/housekeeping/fileOpSchemas.ts
+++ b/packages/extension/src/commands/housekeeping/fileOpSchemas.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { ExecutionIdSchema } from '@shared/schemas';
 
 /** Non-empty string for the required file-operation identity fields. */
-export const RequiredString = z.string().min(1);
+const RequiredString = z.string().min(1);
 
 /**
  * Identity shared by every pack/clean file operation: the input file plus the

--- a/packages/extension/src/commands/housekeeping/fileOpSchemas.ts
+++ b/packages/extension/src/commands/housekeeping/fileOpSchemas.ts
@@ -1,0 +1,33 @@
+// Third-party imports
+import { z } from 'zod';
+
+// Local imports
+import { ExecutionIdSchema } from '@shared/schemas';
+
+/** Non-empty string for the required file-operation identity fields. */
+export const RequiredString = z.string().min(1);
+
+/**
+ * Identity shared by every pack/clean file operation: the input file plus the
+ * agent and model that produced it. The single source of truth for both the
+ * pack and clean command schemas and their parameter type.
+ */
+export const FileOpParamsSchema = z.object({
+  inputFile: RequiredString,
+  agent: RequiredString,
+  model: RequiredString,
+});
+
+export type FileOpParams = z.infer<typeof FileOpParamsSchema>;
+
+/**
+ * Config-level fields shared by the pack and clean config schemas. Spread into
+ * a base schema's `.extend(...)` so each command can still override an
+ * individual field (pack permits an empty `model` in config, for example).
+ */
+export const fileOpConfigFields = {
+  outputFiles: z.array(z.string()).prefault([]),
+  streamId: z.string().optional(),
+  executionId: ExecutionIdSchema.optional(),
+  skipProgressViewClear: z.boolean().optional(),
+};

--- a/packages/extension/src/commands/housekeeping/packCommands.ts
+++ b/packages/extension/src/commands/housekeeping/packCommands.ts
@@ -13,8 +13,12 @@ import {
   runPackRunDir,
 } from '@housekeeping';
 import * as logger from '@logger/logUtils';
-import { ExecutionIdSchema } from '@shared/schemas';
 import { WorkspaceFS } from '@utils/files';
+import {
+  FileOpParamsSchema,
+  fileOpConfigFields,
+  type FileOpParams,
+} from './fileOpSchemas';
 import {
   emitClearMissingOutputs,
   type ClearMissingOutputsOptions,
@@ -23,23 +27,13 @@ import {
 const CHANNEL = 'packCommands';
 logger.initialize(CHANNEL);
 
-const RequiredString = z.string().min(1);
-
-const BasePackSchema = z.object({
-  inputFile: RequiredString,
-  agent: RequiredString,
-  model: RequiredString,
-});
-
-const PackConfigSchema = BasePackSchema.extend({
+const PackConfigSchema = FileOpParamsSchema.extend({
+  // Pack permits an empty model in config; clean keeps it required.
   model: z.string().prefault(''),
-  outputFiles: z.array(z.string()).prefault([]),
-  streamId: z.string().optional(),
-  executionId: ExecutionIdSchema.optional(),
-  skipProgressViewClear: z.boolean().optional(),
+  ...fileOpConfigFields,
 });
 
-const PackMultipleSchema = BasePackSchema.extend({
+const PackMultipleSchema = FileOpParamsSchema.extend({
   inputFile: z.string().prefault(''),
   inputFiles: z.array(z.string()).prefault([]),
 }).refine((d) => d.inputFile || d.inputFiles.length > 0, {
@@ -77,13 +71,7 @@ function showPackResult(result: FileOpResult, inputFile: string): void {
   }
 }
 
-interface PackParams {
-  agent: string;
-  model: string;
-  inputFile: string;
-}
-
-async function executePackOperation<T extends PackParams>(
+async function executePackOperation<T extends FileOpParams>(
   schema: z.ZodType<T>,
   input: unknown,
   label: string,
@@ -159,7 +147,7 @@ async function handlePackSingle(
   model: string,
 ): Promise<void> {
   return executePackOperation(
-    BasePackSchema,
+    FileOpParamsSchema,
     { inputFile, agent, model },
     'params',
     (data) => runPackSingle(data.model, data.inputFile, data.agent),


### PR DESCRIPTION
## What

`packCommands.ts` and `cleanCommands.ts` each declared their own copies of the same schema pieces:
- an identical `const RequiredString = z.string().min(1)`,
- a **byte-identical base params schema** (`inputFile`/`agent`/`model`, all `RequiredString`) — `BasePackSchema` vs `CleanParamsSchema`,
- the same config-field block (`outputFiles`/`streamId`/`executionId`/`skipProgressViewClear`),
- and `packCommands.ts` additionally hand-wrote an `interface PackParams { agent; model; inputFile }` that exactly duplicates `z.infer` of that base schema.

This moves the shared pieces into one `housekeeping/fileOpSchemas.ts` — `RequiredString`, `FileOpParamsSchema`, `fileOpConfigFields`, and `type FileOpParams = z.infer<typeof FileOpParamsSchema>` — and has both command files compose from it.

## Why

The "single source of truth data structure" the refactoring sweep is targeting, and a direct application of CLAUDE.md's Schema guidelines (define the schema once, derive the type via `z.infer`, share via composition rather than duplicating field definitions).

## Behavior-preserving

- `FileOpParamsSchema` is structurally identical to the old `BasePackSchema`/`CleanParamsSchema`.
- The **one asymmetry is preserved**: pack's config still overrides `model: z.string().prefault('')` (pack permits an empty model in config) while clean keeps `model` required.
- `PackMultipleSchema`'s `inputFile`/`inputFiles` override + `.refine` are unchanged; `executePackOperation<T extends FileOpParams>` is the same constraint as the old `<T extends PackParams>`.
- No external importers of any moved symbol (verified); types are erased at runtime.
- `npm run typecheck` clean for the touched files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal schema deduplication with structurally identical validation; no command behavior or external API changes.
> 
> **Overview**
> Introduces **`housekeeping/fileOpSchemas.ts`** as the shared Zod layer for pack/clean commands: `FileOpParamsSchema` (`inputFile` / `agent` / `model`), `fileOpParams` via `z.infer`, and **`fileOpConfigFields`** (`outputFiles`, `streamId`, `executionId`, `skipProgressViewClear`).
> 
> **`cleanCommands.ts`** and **`packCommands.ts`** drop their duplicate `RequiredString`, base param objects, and config field blocks; they compose from the shared module instead. **`executePackOperation`** now bounds on **`FileOpParams`** rather than a hand-written `PackParams` interface.
> 
> **Behavior is unchanged:** clean keeps a required `model`; pack’s config schema still **overrides** `model` with `z.string().prefault('')`. `PackMultipleSchema`’s refine and overrides stay as before.
> 
> The **`config-catalog-unification`** proposal doc only gets minor markdown formatting (emphasis/escaping), not design changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9b5acfac96d6fcf63a6d2090865690e0772be1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->