### PR TITLE
refactor(agent-runtime): single-source two duplicated reads in the run path

### DIFF
--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -246,6 +246,18 @@ export function shouldUseResponsesAPI(
   );
 }
 
+/**
+ * Single owner for the "prefer short model names" preference read. Read live
+ * (no caching) so a mid-session settings change is honored on the next handler
+ * creation, matching the other `globalState` reads in this module.
+ */
+function getPreferShortModelNames(): boolean {
+  return platform().globalState.get<boolean>(
+    GlobalStateKey.PREFER_SHORT_MODEL_NAMES,
+    false,
+  );
+}
+
 function applyShortModelNamePreference(
   config: ModelConfig,
   preferShortModelNames: boolean,
@@ -260,10 +272,7 @@ function applyShortModelNamePreference(
 export function modelHandlerCompatibilityKey(
   originalConfig: ModelConfig,
   useOpenRouter = getUseOpenRouter(),
-  preferShortModelNames = platform().globalState.get<boolean>(
-    GlobalStateKey.PREFER_SHORT_MODEL_NAMES,
-    false,
-  ),
+  preferShortModelNames = getPreferShortModelNames(),
 ): ModelHandlerCompatibilityKey | undefined {
   if (shouldUseInternalValidationModelHandler()) {
     return 'ModelHandlerValidation';
@@ -313,10 +322,7 @@ function withModelHandlerCompatibilityKey<T extends ModelHandler>(
 function withShortModelName(config: ModelConfig): ModelConfig {
   const resolved = applyShortModelNamePreference(
     config,
-    platform().globalState.get<boolean>(
-      GlobalStateKey.PREFER_SHORT_MODEL_NAMES,
-      false,
-    ),
+    getPreferShortModelNames(),
   );
   if (resolved === config) return config;
 

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -108,6 +108,21 @@ function toCompileFailureSummaries(
   );
 }
 
+/**
+ * Optional `AgentFlowResult` fields shared by both result categories. Included
+ * only when meaningful so an empty miss list or a zero cost never lands in the
+ * result — the single owner of that inclusion rule for both builders below.
+ */
+function buildOptionalFlowResultFields(
+  memoryMisses: AgentFlowResult['memoryMisses'],
+  totalCostUsd: number | undefined,
+): { memoryMisses?: AgentFlowResult['memoryMisses']; totalCostUsd?: number } {
+  return {
+    ...(memoryMisses && memoryMisses.length > 0 ? { memoryMisses } : {}),
+    ...(totalCostUsd != null && totalCostUsd > 0 ? { totalCostUsd } : {}),
+  };
+}
+
 /** Build a workflow AgentFlowResult from a reflection flow run. */
 function buildWorkflowFlowResult(
   result: RunReflectionFlowResult,
@@ -122,10 +137,7 @@ function buildWorkflowFlowResult(
     compileFailures: toCompileFailureSummaries(result.roundOutputs),
     executionId,
     streamId,
-    ...(memoryMisses && memoryMisses.length > 0 ? { memoryMisses } : {}),
-    ...(result.totalCostUsd != null && result.totalCostUsd > 0
-      ? { totalCostUsd: result.totalCostUsd }
-      : {}),
+    ...buildOptionalFlowResultFields(memoryMisses, result.totalCostUsd),
   };
 }
 
@@ -143,10 +155,7 @@ function buildToolUseFlowResult(
     touchedFiles: result.touchedFiles,
     executionId,
     streamId,
-    ...(memoryMisses && memoryMisses.length > 0 ? { memoryMisses } : {}),
-    ...(result.totalCostUsd != null && result.totalCostUsd > 0
-      ? { totalCostUsd: result.totalCostUsd }
-      : {}),
+    ...buildOptionalFlowResultFields(memoryMisses, result.totalCostUsd),
   };
 }
 


### PR DESCRIPTION
## Summary

Two small, behavior-preserving single-source-of-truth cleanups in the agent run path. Each replaces a duplicated read/rule with one owner; no logic changes.

### ModelFactory — one owner for the "prefer short model names" preference

The `PREFER_SHORT_MODEL_NAMES` preference (key + `false` default) was read inline in two places: the default parameter of `modelHandlerCompatibilityKey()` and inside `withShortModelName()`. If the key or default ever changed, both had to change in lockstep.

Both now route through a single `getPreferShortModelNames()` accessor. It is read **live (no caching)** so a mid-session settings change is still honored on the next handler creation — matching the other `globalState` reads in this module (e.g. `REASONING_LEVELS`).

### executeAgent — one owner for the optional flow-result fields

`buildWorkflowFlowResult` and `buildToolUseFlowResult` each spread the identical conditionals that include `memoryMisses` only when non-empty and `totalCostUsd` only when present and positive. Extracted to `buildOptionalFlowResultFields(memoryMisses, totalCostUsd)`, the single owner of that inclusion rule for both builders.

## Not included (deliberately)

A separate recon flagged the routing-precedence overlap between `modelHandlerCompatibilityKey()` (pure/sync) and `createModelHandler()` (async, with the extra Codex-subscription branch + config transforms + `assertGoogleInteractionsRoutable` side effect). That one is real but subtler and touches the live routing path, so it is tracked separately rather than bundled here.

## Verification

- `npm run typecheck` — clean (only the known-preexisting `@openrouter/sdk` module-resolution symptoms remain).
- `npx vitest run` on `ModelFactoryRouting`, `SettingsModelSelectionController`, `DelegationHeadless`, `DesktopAgentExecution` — **74 passed**.
- Prettier clean.

Internal refactor — no changelog entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure deduplication with no logic changes; only affects how existing preferences and flow-result fields are assembled.
> 
> **Overview**
> **Behavior-preserving refactor** in the agent run path: two duplicated reads/rules now have a single owner each.
> 
> In **`ModelFactory`**, the `PREFER_SHORT_MODEL_NAMES` `globalState` read (key + `false` default) lived in both `modelHandlerCompatibilityKey()` and `withShortModelName()`. Both call **`getPreferShortModelNames()`**, which still reads live (no cache) so mid-session setting changes apply on the next handler creation.
> 
> In **`executeAgent`**, **`buildWorkflowFlowResult`** and **`buildToolUseFlowResult`** shared identical spreads for optional `memoryMisses` (only when non-empty) and `totalCostUsd` (only when &gt; 0). That rule now lives in **`buildOptionalFlowResultFields()`**, used by both builders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddeebaee32a4bd9d6a6eb6af2713b19fafb1006b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->