### PR TITLE
refactor(storage): single-source the KV read-validate-or-null policy

### DIFF
--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -173,18 +173,27 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
 
   // -- Typed readers --------------------------------------------------------
 
-  async readMeta(): Promise<ExecutionMeta | null> {
-    const raw = await this.read(KEYS.META);
+  /**
+   * Read a key and validate it against a schema, returning the parsed value or
+   * `null` when the key is absent or fails validation. Single source of truth
+   * for the read-validate-or-null policy shared by the typed readers below.
+   */
+  private async readValidated<T>(
+    key: string,
+    schema: z.ZodType<T>,
+  ): Promise<T | null> {
+    const raw = await this.read(key);
     if (!raw) return null;
-    const result = ExecutionMetaSchema.safeParse(raw);
+    const result = schema.safeParse(raw);
     return result.success ? result.data : null;
   }
 
+  async readMeta(): Promise<ExecutionMeta | null> {
+    return this.readValidated(KEYS.META, ExecutionMetaSchema);
+  }
+
   async readConfig(): Promise<AgentConfig | null> {
-    const raw = await this.read(KEYS.CONFIG);
-    if (!raw) return null;
-    const result = AgentConfigSchema.safeParse(raw);
-    return result.success ? result.data : null;
+    return this.readValidated<AgentConfig>(KEYS.CONFIG, AgentConfigSchema);
   }
 
   async readReport(): Promise<string | null> {
@@ -225,10 +234,7 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
   }
 
   async readResultMeta(): Promise<ResultMeta | null> {
-    const raw = await this.read(KEYS.RESULT_META);
-    if (!raw) return null;
-    const result = ResultMetaSchema.safeParse(raw);
-    return result.success ? result.data : null;
+    return this.readValidated(KEYS.RESULT_META, ResultMetaSchema);
   }
 
   // -- Typed writers --------------------------------------------------------


### PR DESCRIPTION
## What

`readMeta`, `readConfig`, and `readResultMeta` on `StorageFSKVStore` (in `src/agent/storage/ExecutionKVStore.ts`) were **byte-identical** apart from their key constant and schema:

```ts
const raw = await this.read(KEY);
if (!raw) return null;
const result = SOME_SCHEMA.safeParse(raw);
return result.success ? result.data : null;
```

This extracts a single private `readValidated<T>(key, schema)` helper that all three delegate to, so the read-validate-or-null policy has one owner.

## Why

A single source of truth for the typed-reader policy (matches CLAUDE.md's Schema/SSOT guidance). The three readers become one-line delegations.

## Behavior-preserving

- Identical body, parameterized only by `(key, schema)`. Types line up: `ExecutionMeta`/`ResultMeta` are `z.infer` of their schemas, and `AgentConfig` is `z.output<typeof AgentConfigSchema>` (the call is explicitly typed `<AgentConfig>` since the schema is a `z.preprocess` pipe).
- **Entirely internal** — the public `ExecutionKVStore` interface is untouched, so **zero callers to update**.
- Deliberately **not** folded in: `readChildren` (spreads `{ id, ...data }`, no `if (!raw)` early return) and `readTodos` (array fallback to `[]`) genuinely differ — left as-is.
- `npm run typecheck` clean; `HistoryHandlers` + `ExecutionsToolWorkspaceFiles` tests pass (10).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor only; public store interface and caller behavior are unchanged.
> 
> **Overview**
> **`StorageFSKVStore`** in `ExecutionKVStore.ts` centralizes the repeated “read JSON → `safeParse` → `null` on missing/invalid” flow in a private **`readValidated<T>(key, schema)`** helper.
> 
> **`readMeta`**, **`readConfig`**, and **`readResultMeta`** now delegate to that helper instead of duplicating the same logic. **`readTodos`** and **`readChildren`** are unchanged because their semantics differ (empty array vs. `{ id, ...data }`).
> 
> The public **`ExecutionKVStore`** API is unchanged; this is an internal DRY refactor with the same runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1035c56f62a96636fa2f7bb817a42a09cd58fd88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->