### PR TITLE
refactor(cli): route skills list through the shared emitCliResult helper

### DIFF
--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -1,11 +1,7 @@
 import { defineCommand } from 'citty';
 
 import { CliExitCode } from '../runtime/exitCodes';
-import {
-  writeNdjsonStdout,
-  writeTextStderr,
-  writeTextStdout,
-} from '../runtime/logSinks';
+import { writeTextStderr } from '../runtime/logSinks';
 import {
   formatCliSkillIssue,
   formatCliSkillList,
@@ -19,6 +15,7 @@ import {
   SKILL_SOURCE_ARGS,
   collectStringFlagValues,
 } from './_helpers/globalArgs';
+import { emitCliResult } from './_helpers/output';
 import type { CliContext } from '../runtime/cliContext';
 
 async function listSkills(
@@ -38,42 +35,36 @@ async function listSkills(
     ? CliExitCode.Usage
     : CliExitCode.Success;
 
-  if (context.outputFormat === 'json') {
-    // Match the bare-array JSON shape every other `<resource> list` command
-    // emits (agents, models, multi-agent, history, tools). Parse errors are
-    // surfaced on stderr below (same as the text branch) so the stdout
-    // contract stays scriptable with `jq '.[]'`. NDJSON consumers still get
-    // structured `kind: skill-issue` records for the same errors.
+  // Parse errors surface on stderr for json + text (NDJSON consumers get them
+  // as `kind: skill-issue` records instead), so the stdout contract stays
+  // scriptable with `jq '.[]'`.
+  if (context.outputFormat !== 'ndjson') {
     for (const issue of result.errors) {
       writeTextStderr(formatCliSkillIssue(issue));
     }
-    writeTextStdout(
-      JSON.stringify(result.skills.map(skillListRecord), null, 2),
-    );
-    return exitCode;
   }
 
-  if (context.outputFormat === 'ndjson') {
-    const ts = new Date().toISOString();
-    for (const entry of result.skills) {
-      writeNdjsonStdout({
-        kind: 'skill',
-        ts,
+  // Emit the bare-array JSON / per-line NDJSON shape every other
+  // `<resource> list` command produces, via the shared emitCliResult helper.
+  // The text list is suppressed on a usage error with no skills (nothing
+  // useful to show); the helper skips the write for the resulting empty string.
+  emitCliResult(context, {
+    json: result.skills.map(skillListRecord),
+    ndjson: [
+      ...result.skills.map((entry) => ({
+        kind: 'skill' as const,
         skill: skillListRecord(entry),
-      });
-    }
-    for (const issue of result.errors) {
-      writeNdjsonStdout({ kind: 'skill-issue', ts, issue });
-    }
-    return exitCode;
-  }
-
-  for (const issue of result.errors) {
-    writeTextStderr(formatCliSkillIssue(issue));
-  }
-  if (exitCode === CliExitCode.Success || result.skills.length > 0) {
-    writeTextStdout(formatCliSkillList(result.skills));
-  }
+      })),
+      ...result.errors.map((issue) => ({
+        kind: 'skill-issue' as const,
+        issue,
+      })),
+    ],
+    text:
+      exitCode === CliExitCode.Success || result.skills.length > 0
+        ? formatCliSkillList(result.skills)
+        : '',
+  });
   return exitCode;
 }
 


### PR DESCRIPTION
## Summary

`skills list` was the only `<resource> list` command that hand-rolled all three output branches (`json` / `ndjson` / `text`) inline. Every sibling — `agents`, `models`, `tools`, `history` — emits through the shared `emitCliResult` helper. This routes `skills list` through the same helper so the output contract has a single owner, and new list commands have exactly one correct pattern to copy (instead of cargo-culting the inline branching).

Net: −35/+26 LOC, removes ~3 duplicated format-selection blocks.

## Behavior-preserving

- **stderr errors**: parse errors still print to stderr for `json` + `text` (kept out of the stdout contract so `jq '.[]'` stays clean); `ndjson` still surfaces them as `kind: skill-issue` records.
- **text suppression**: the human list is still suppressed on a usage error with no skills — passed as an empty `text`, which `emitCliResult` skips.
- **non-paged**: kept non-paged (unlike the siblings' `{ paged: true }`) to preserve current behavior; paging-consistency would be a separate decision.
- **NDJSON**: `ts` is now appended by the helper (so `kind` stays the first key — the convention line-oriented consumers anchor on), matching the sibling commands. The `skill` / `skill-issue` record shapes are unchanged and remain validated by `CliNdjsonRecordSchema`.

## Verification

- `npm run typecheck` — clean (only the known-preexisting `@openrouter/sdk` symptoms).
- `CliSkills.vitest.mts` (7) + `CliNdjsonRecordContract.vitest.mts` (28) pass. Prettier clean.

Internal refactor — no changelog entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal CLI output refactor with behavior documented as unchanged; covered by existing vitest contracts.
> 
> **Overview**
> **`skills list`** no longer hand-rolls `json` / `ndjson` / `text` output; it now goes through the shared **`emitCliResult`** helper like the other `<resource> list` commands.
> 
> Parse errors still go to **stderr** for `json` and `text` (stdout stays a bare array for `jq`); **NDJSON** still emits `skill` and `skill-issue` records, with **`ts`** added by the helper so **`kind`** stays first. Human **text** is still omitted on usage failure with no skills via an empty `text` string. **`skills list`** remains **non-paged** (no `{ paged: true }`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e505073f467fafa7ace0bc69b577ff54c3ff1048. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->