### PR TITLE
refactor(logger): single-source the debugMode setting via isDebugModeEnabled

### DIFF
--- a/packages/extension/src/webview/MainViewMessageHandler.ts
+++ b/packages/extension/src/webview/MainViewMessageHandler.ts
@@ -19,6 +19,7 @@ import { RecordingManager } from '@frontend/media/RecordingManager';
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
+import { isDebugModeEnabled } from '@logger/logUtils';
 import { COMMON_COMMANDS, MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import {
   dispatchMainViewInbound,
@@ -428,7 +429,7 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
   }
 
   private handleDebugModeRequest(): void {
-    const debugMode = getConfig<boolean>('texra.logger.debugMode', false);
+    const debugMode = isDebugModeEnabled();
     this.postToActiveView({
       command: MAIN_VIEW_COMMANDS.DEBUG_MODE_SET,
       debugMode,

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -97,6 +97,15 @@ function ensureChannel(channel: string, isAgent: boolean): OutputSink {
  * Write one line to the per-channel sink. Single emission point — both the
  * functional logger API and the trace subscriber funnel through this.
  */
+/**
+ * Single owner of the `texra.logger.debugMode` setting (config key + default).
+ * Gates the verbose data line below and the transcript recorder's `verbose`
+ * flag, so the key and its default live in exactly one place.
+ */
+export function isDebugModeEnabled(): boolean {
+  return getConfig<boolean>('texra.logger.debugMode', false);
+}
+
 function writeLine(
   level: LogLevel,
   channel: string,
@@ -111,7 +120,7 @@ function writeLine(
   );
 
   if (data === null || data === undefined) return;
-  if (!getConfig<boolean>('texra.logger.debugMode', false)) return;
+  if (!isDebugModeEnabled()) return;
 
   sink.appendLine(
     typeof data === 'string' ? data : JSON.stringify(data, null, 2),

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -94,18 +94,19 @@ function ensureChannel(channel: string, isAgent: boolean): OutputSink {
 }
 
 /**
- * Write one line to the per-channel sink. Single emission point — both the
- * functional logger API and the trace subscriber funnel through this.
- */
-/**
  * Single owner of the `texra.logger.debugMode` setting (config key + default).
- * Gates the verbose data line below and the transcript recorder's `verbose`
- * flag, so the key and its default live in exactly one place.
+ * Gates the verbose data line below, the transcript recorder's `verbose` flag,
+ * and the webview debug-mode delivery, so the key and its default live in one
+ * place.
  */
 export function isDebugModeEnabled(): boolean {
   return getConfig<boolean>('texra.logger.debugMode', false);
 }
 
+/**
+ * Write one line to the per-channel sink. Single emission point — both the
+ * functional logger API and the trace subscriber funnel through this.
+ */
 function writeLine(
   level: LogLevel,
   channel: string,

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -22,6 +22,7 @@ import type {
   AgentTraceSubscriber,
   LogEvent,
 } from '@agent/trace';
+import { isDebugModeEnabled } from '@logger/logUtils';
 import {
   END_GROUP_STATUS,
   MESSAGE_TYPES,
@@ -32,7 +33,6 @@ import {
   type StreamTabId,
   type ToolUseLog,
 } from '@shared/schemas';
-import { getConfig } from '@utils/config';
 
 import { type StreamLogStore } from './StreamLogStore';
 
@@ -55,11 +55,7 @@ function asMessageType(candidate: string | undefined): MessageType {
 function shouldEmit(level: LogLevel, messageType: MessageType): boolean {
   if (messageType === MESSAGE_TYPES.INTERNAL) return false;
   if (level !== 'debug') return true;
-  return getConfig<boolean>('texra.logger.debugMode', false);
-}
-
-function debugModeEnabled(): boolean {
-  return getConfig<boolean>('texra.logger.debugMode', false);
+  return isDebugModeEnabled();
 }
 
 /**
@@ -132,7 +128,7 @@ export function attachTranscriptRecorder(
         messageType: state.messageType,
         text: state.buffer,
         data: { status: state.ended ? 'completed' : 'running' },
-        verbose: debugModeEnabled(),
+        verbose: isDebugModeEnabled(),
       });
       state.created = !!appended;
       if (!state.created) state.enabled = false;
@@ -170,7 +166,7 @@ export function attachTranscriptRecorder(
       messageType,
       text: event.message,
       data: event.data,
-      verbose: event.verbose ?? debugModeEnabled(),
+      verbose: event.verbose ?? isDebugModeEnabled(),
     });
   };
 
@@ -190,7 +186,7 @@ export function attachTranscriptRecorder(
           messageType: MESSAGE_TYPES.DEFAULT,
           text: event.label,
           data: { status: 'running' },
-          verbose: debugModeEnabled(),
+          verbose: isDebugModeEnabled(),
         });
         return;
 
@@ -220,7 +216,7 @@ export function attachTranscriptRecorder(
             input: redactToolInputForLog(event.toolName, event.input),
             status: 'in_progress',
           } satisfies ToolUseLog,
-          verbose: debugModeEnabled(),
+          verbose: isDebugModeEnabled(),
         });
         return;
 
@@ -256,7 +252,7 @@ export function attachTranscriptRecorder(
           messageType: MESSAGE_TYPES.STATISTICS,
           text: `Usage - input: ${event.stats.inputTokens ?? 0}, output: ${event.stats.outputTokens ?? 0}`,
           data: event.stats,
-          verbose: debugModeEnabled(),
+          verbose: isDebugModeEnabled(),
         });
         return;
 
@@ -276,7 +272,7 @@ export function attachTranscriptRecorder(
             contextWindow: event.contextWindow,
             utilizationPercent,
           },
-          verbose: debugModeEnabled(),
+          verbose: isDebugModeEnabled(),
         });
         return;
       }
@@ -351,7 +347,7 @@ export function attachTranscriptRecorder(
             messageType: MESSAGE_TYPES.FILE_LIST,
             text: `Loading ${payload?.category ?? ''} (${okCount}/${entries.length})`,
             data: entries,
-            verbose: debugModeEnabled(),
+            verbose: isDebugModeEnabled(),
           });
           return;
         }
@@ -364,7 +360,7 @@ export function attachTranscriptRecorder(
           messageType: domainMessageType(event.key),
           text: event.text ?? event.key,
           data: event.data,
-          verbose: debugModeEnabled(),
+          verbose: isDebugModeEnabled(),
         });
         return;
       }


### PR DESCRIPTION
## Summary

The `texra.logger.debugMode` setting (config key + `false` default) was read inline in **four** places:

- `logUtils.writeLine` (gates the verbose data line)
- `TexraTranscriptRecorder.shouldEmit` (gates debug-level emits)
- `TexraTranscriptRecorder.debugModeEnabled` — a local helper called 8× to set each entry's `verbose` flag
- `MainViewMessageHandler.handleDebugModeRequest` (delivers the value to the webview)

This gives the setting **one owner** — `isDebugModeEnabled()` in `logUtils` (the logger module that owns the `texra.logger.*` namespace) — and routes every reader through it. `TexraTranscriptRecorder` drops its local `debugModeEnabled` helper and its now-unused `getConfig` import; the webview handler and `writeLine` call the shared owner.

The magic config string and its default now live in exactly one place.

## Behavior-preserving

`isDebugModeEnabled()` returns exactly the prior `getConfig<boolean>('texra.logger.debugMode', false)` at each site — no semantic change, just centralized. Read live each call, so a mid-session settings change is honored as before.

## Verification

- `npm run typecheck` — clean (only the known-preexisting `@openrouter/sdk` symptoms).
- `npx vitest run src/test-kernel/transcript` — **30 passed**.
- Prettier clean.

Internal refactor — no changelog entry.

---
_Updated per the claude bot review: fixed the `writeLine` JSDoc binding (the helper had landed between the doc and `writeLine`), and folded in the 4th reader (`MainViewMessageHandler`) so the SSOT claim is genuinely true._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor with no semantic change; only consolidates an existing config read behind one exported helper.
> 
> **Overview**
> Introduces **`isDebugModeEnabled()`** in `logUtils` as the single place that reads `texra.logger.debugMode` (key + default `false`), with a short doc comment tying it to verbose log data, transcript `verbose` flags, and webview debug delivery.
> 
> **Call sites** that previously inlined `getConfig<boolean>('texra.logger.debugMode', false)` or used a local `debugModeEnabled` helper now import this function: `writeLine` (verbose data lines), `TexraTranscriptRecorder` (`shouldEmit` and all `verbose` fields), and `MainViewMessageHandler.handleDebugModeRequest` (webview `DEBUG_MODE_SET`). `TexraTranscriptRecorder` drops its redundant helper and `getConfig` import.
> 
> Behavior is unchanged: each call still reads config live, so mid-session toggles behave as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 244e0c6fa04d82204acd970c186984f5326b4d03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->