### PR TITLE
refactor(runtime): single-source the optional-flow-result inclusion rule

### DIFF
--- a/src/agent/runtime/AgentFlowResult.ts
+++ b/src/agent/runtime/AgentFlowResult.ts
@@ -72,6 +72,21 @@ export function getAgentFlowErrorResult(
 /** The discriminant of {@link AgentFlowResult}: which flow produced the result. */
 export type AgentFlowCategory = AgentFlowResult['category'];
 
+/**
+ * Optional `AgentFlowResult` fields shared by both result categories. Included
+ * only when meaningful so an empty miss list or a zero cost never lands in the
+ * result — the single owner of that inclusion rule for every builder.
+ */
+export function buildOptionalFlowResultFields(
+  memoryMisses: AgentFlowResult['memoryMisses'],
+  totalCostUsd: number | undefined,
+): { memoryMisses?: AgentFlowResult['memoryMisses']; totalCostUsd?: number } {
+  return {
+    ...(memoryMisses && memoryMisses.length > 0 ? { memoryMisses } : {}),
+    ...(totalCostUsd != null && totalCostUsd > 0 ? { totalCostUsd } : {}),
+  };
+}
+
 export function buildTerminalFlowResult(
   category: AgentFlowCategory,
   outcome: RunOutcome,
@@ -82,7 +97,7 @@ export function buildTerminalFlowResult(
   const meta = {
     executionId,
     streamId,
-    ...(memoryMisses && memoryMisses.length > 0 ? { memoryMisses } : {}),
+    ...buildOptionalFlowResultFields(memoryMisses, undefined),
   };
   if (category === 'toolUse') {
     return { category, outcome, ...meta };

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -50,7 +50,11 @@ import { currentSession, type SessionHandle } from './SessionHandle';
 import { createInterruptCallbacks } from './InterruptManager';
 import { generateSessionDescription } from './sessionDescription';
 import { getProgressViewBridge } from './ProgressViewBridge';
-import { AgentFlowError, type AgentFlowResult } from './AgentFlowResult';
+import {
+  AgentFlowError,
+  buildOptionalFlowResultFields,
+  type AgentFlowResult,
+} from './AgentFlowResult';
 import type { AgentExecutionHandle, AgentRunHandle } from './executionRegistry';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 
@@ -106,21 +110,6 @@ function toCompileFailureSummaries(
       logAbsolutePath: failure.log.absolutePath,
     })),
   );
-}
-
-/**
- * Optional `AgentFlowResult` fields shared by both result categories. Included
- * only when meaningful so an empty miss list or a zero cost never lands in the
- * result — the single owner of that inclusion rule for both builders below.
- */
-function buildOptionalFlowResultFields(
-  memoryMisses: AgentFlowResult['memoryMisses'],
-  totalCostUsd: number | undefined,
-): { memoryMisses?: AgentFlowResult['memoryMisses']; totalCostUsd?: number } {
-  return {
-    ...(memoryMisses && memoryMisses.length > 0 ? { memoryMisses } : {}),
-    ...(totalCostUsd != null && totalCostUsd > 0 ? { totalCostUsd } : {}),
-  };
 }
 
 /** Build a workflow AgentFlowResult from a reflection flow run. */


### PR DESCRIPTION
## What

A direct follow-on to #6643. That PR extracted `buildOptionalFlowResultFields` — the "include `memoryMisses`/`totalCostUsd` only when meaningful" rule — into a helper, but (a) placed it as a private function in `executeAgent.ts` rather than next to the schema it serves, and (b) left the **third** builder of `AgentFlowResult`, `buildTerminalFlowResult` (in `AgentFlowResult.ts`), still inlining the same rule.

This moves the helper into `AgentFlowResult.ts` beside `AgentFlowResultSchema` / `AgentFlowMetaSchema` (the `memoryMisses`/`totalCostUsd` field definitions), exports it, and routes `buildTerminalFlowResult` through it. `executeAgent.ts` imports it instead of defining it locally.

## Why

The inclusion rule for the schema's optional fields now has a single home next to that schema, and **all three** `AgentFlowResult` builders route through it.

## Behavior-preserving

- `buildTerminalFlowResult` never carries a cost, so `buildOptionalFlowResultFields(memoryMisses, undefined)` keeps the `totalCostUsd` spread as `{}` — the result is byte-identical to the previous inline `...(memoryMisses && memoryMisses.length > 0 ? { memoryMisses } : {})`.
- Both functions are pure object builders; no lifecycle / error-recovery / interrupt / persistence semantics change. `buildTerminalFlowResult`'s signature and `AgentRunLifecycle` callers are untouched.
- `executeAgent.ts`'s two call sites are unchanged (same import name).
- `npm run typecheck` clean; `SubagentResults.vitest.ts` (7) + `DelegationHeadless.vitest.mts` (12) pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of object-shaping helpers with no lifecycle, persistence, or API surface changes beyond export location.
> 
> **Overview**
> **Moves** `buildOptionalFlowResultFields` from a private helper in `executeAgent.ts` into **`AgentFlowResult.ts`**, next to the schema fields it governs (`memoryMisses`, `totalCostUsd`), and **exports** it.
> 
> **`buildTerminalFlowResult`** now spreads that helper instead of duplicating the “only include `memoryMisses` when non-empty” rule; **`executeAgent.ts`** imports the shared helper for `buildWorkflowFlowResult` / `buildToolUseFlowResult` and drops its local copy.
> 
> Inclusion behavior is unchanged: empty miss lists and zero/undefined cost still omit those keys from results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67a9b30cbf78bcd0b9e052e1a42d199871f42de0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->