### PR TITLE
feat: switch from ChatGPT subscription to API key on usage limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ### Shared (all surfaces)
 
+#### Improvements
+
+- **Switch from your ChatGPT subscription to an API key when the quota runs out** — when a Codex model driven through your ChatGPT subscription hits its plan usage limit, the error now says so clearly (plan and how long until it resets) and offers a one-click switch to your own OpenAI API key. Accepting turns off "prefer ChatGPT subscription" and retries the same request on your key. In the VS Code progress view press **Use your own API key** (or `k`); in the CLI press `k` on the retry prompt or run `/subscription off`. Auto-retry no longer hammers an exhausted subscription.
+
 #### Bug Fixes
 
 - **Delegation launches the agent it validated** — when a custom or remote agent shares a name with a built-in agent of the other type (e.g. a custom workflow `assistant` next to the built-in tool-use `assistant`), delegating no longer resolves a different agent at launch than the one shown and validated, which previously failed with a spurious "is a workflow agent but was launched as tool-use" error. Validation and launch now resolve the name through one category-aware rule.

--- a/packages/cli/src/chat/tui/commands/handlers/loginCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/loginCommands.ts
@@ -1,5 +1,7 @@
-import { setPreferCodexSubscription } from '@auth/codex';
-import { bumpCodexPreferenceVersion } from '@cli/chat/tui/state/cliState';
+import {
+  refreshCodexPreferenceViews,
+  setCliCodexSubscription,
+} from '@cli/chat/tui/state/codexSubscription';
 import { appendLocalAssistantTranscript } from '@cli/chat/tui/state/transcript';
 import { loadCliApiStatusLines } from '@cli/runtime/apiStatus';
 import {
@@ -27,7 +29,6 @@ import {
 } from '@cli/runtime/supabaseAuth';
 import { formatCliDeviceAuthMessage } from '@cli/runtime/supabaseAuthDeviceCode';
 import { toErrorMessage } from '@common/errors/errorMessage';
-import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 
 import { setCliSessionApiMode } from './apiModeCommands';
 
@@ -53,9 +54,7 @@ async function loginToChatGptSubscription(
   const session = await signInCliChatGpt(args, {
     writeProgress: appendLocalAssistantTranscript,
   });
-  const update = await setPreferCodexSubscription(true);
-  invalidateModelOptionsCache();
-  bumpCodexPreferenceVersion();
+  const update = await setCliCodexSubscription(true);
 
   appendLocalAssistantTranscript(
     [
@@ -149,8 +148,7 @@ export async function logoutFromChat(): Promise<void> {
 
   try {
     const chatGptUpdate = await signOutCliChatGpt();
-    invalidateModelOptionsCache();
-    bumpCodexPreferenceVersion();
+    refreshCodexPreferenceViews();
     lines.push(chatGptSignOutPreferenceMessage(chatGptUpdate));
   } catch (error: unknown) {
     lines.push(`ChatGPT sign-out failed: ${toErrorMessage(error)}`);

--- a/packages/cli/src/chat/tui/commands/handlers/subscriptionCommand.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/subscriptionCommand.ts
@@ -1,11 +1,6 @@
-import {
-  getCodexStatus,
-  isPreferCodexSubscription,
-  setPreferCodexSubscription,
-} from '@auth/codex';
+import { getCodexStatus, isPreferCodexSubscription } from '@auth/codex';
 import { appendLocalAssistantTranscript } from '@cli/chat/tui/state/transcript';
-import { bumpCodexPreferenceVersion } from '@cli/chat/tui/state/cliState';
-import { invalidateModelOptionsCache } from '@model/computeModelOptions';
+import { setCliCodexSubscription } from '@cli/chat/tui/state/codexSubscription';
 
 const SUBSCRIPTION_ON = new Set(['on', 'enable', 'enabled', 'true', 'yes']);
 const SUBSCRIPTION_OFF = new Set(['off', 'disable', 'disabled', 'false', 'no']);
@@ -47,9 +42,7 @@ export async function applyCliSubscriptionToggle(input: string): Promise<void> {
     return;
   }
 
-  const update = await setPreferCodexSubscription(enabled);
-  invalidateModelOptionsCache();
-  bumpCodexPreferenceVersion();
+  const update = await setCliCodexSubscription(enabled);
 
   const lines = [
     update.effective === enabled

--- a/packages/cli/src/chat/tui/modals/RetryRequest.tsx
+++ b/packages/cli/src/chat/tui/modals/RetryRequest.tsx
@@ -18,10 +18,11 @@ export function RetryRequest(props: RetryRequestProps): React.JSX.Element {
   const subject = props.payload.errorMessage ?? props.payload.operation;
   const isChatGptSubscription = isCliChatGptSubscriptionRetry(props.payload);
   const canSwitchToPersonalKey = isCliApiSwitchableRetry(props.payload);
-  // The subscription switch turns off the "prefer ChatGPT subscription"
-  // preference; the relay switch flips the api-mode to personal keys.
+  // Both switches flip the api-mode to personal keys so the retry uses the
+  // user's own key (not the relay JWT); the subscription switch additionally
+  // turns off the "prefer ChatGPT subscription" preference.
   const switchDecision: ApprovalDecision = isChatGptSubscription
-    ? { accepted: true, disableChatGptSubscription: true }
+    ? { accepted: true, disableChatGptSubscription: true, apiMode: 'personal' }
     : { accepted: true, apiMode: 'personal' };
   const switchHint = isChatGptSubscription
     ? 'Press k to switch from your ChatGPT subscription to your OpenAI API key before retrying.'

--- a/packages/cli/src/chat/tui/modals/RetryRequest.tsx
+++ b/packages/cli/src/chat/tui/modals/RetryRequest.tsx
@@ -1,6 +1,9 @@
 import { Box, Text } from 'ink';
 
-import { isCliApiSwitchableRetry } from '@cli/runtime/approvalAdapter';
+import {
+  isCliApiSwitchableRetry,
+  isCliChatGptSubscriptionRetry,
+} from '@cli/runtime/approvalAdapter';
 import type { RetryPermission } from '@shared/schemas';
 
 import { ConfirmCard } from './ConfirmCard';
@@ -13,7 +16,16 @@ export interface RetryRequestProps {
 
 export function RetryRequest(props: RetryRequestProps): React.JSX.Element {
   const subject = props.payload.errorMessage ?? props.payload.operation;
+  const isChatGptSubscription = isCliChatGptSubscriptionRetry(props.payload);
   const canSwitchToPersonalKey = isCliApiSwitchableRetry(props.payload);
+  // The subscription switch turns off the "prefer ChatGPT subscription"
+  // preference; the relay switch flips the api-mode to personal keys.
+  const switchDecision: ApprovalDecision = isChatGptSubscription
+    ? { accepted: true, disableChatGptSubscription: true }
+    : { accepted: true, apiMode: 'personal' };
+  const switchHint = isChatGptSubscription
+    ? 'Press k to switch from your ChatGPT subscription to your OpenAI API key before retrying.'
+    : 'Press k to switch to personal API keys before retrying.';
   return (
     <ConfirmCard
       borderStyle="single"
@@ -27,7 +39,7 @@ export function RetryRequest(props: RetryRequestProps): React.JSX.Element {
               {
                 key: 'k',
                 label: 'use API key and retry',
-                decision: { accepted: true, apiMode: 'personal' },
+                decision: switchDecision,
               },
             ]
           : []
@@ -37,11 +49,7 @@ export function RetryRequest(props: RetryRequestProps): React.JSX.Element {
       <Box marginY={1}>
         <Text dimColor>{subject}</Text>
       </Box>
-      {canSwitchToPersonalKey ? (
-        <Text color="cyan">
-          Press k to switch to personal API keys before retrying.
-        </Text>
-      ) : null}
+      {canSwitchToPersonalKey ? <Text color="cyan">{switchHint}</Text> : null}
     </ConfirmCard>
   );
 }

--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -49,6 +49,9 @@ export interface ApprovalDecision extends Readonly<SharedApprovalDecision> {
   readonly bypass?: ApprovalBypassKind;
   /** Credential mode to apply before accepting this approval. */
   readonly apiMode?: CliApiMode;
+  /** Turn off the "prefer ChatGPT subscription" preference before accepting,
+   *  so a Codex usage-limit retry routes through the OpenAI API key. */
+  readonly disableChatGptSubscription?: boolean;
   /** Plan-only approval action when plain approve/reject is not specific enough. */
   readonly planAction?: Extract<PlanApprovalAction, 'approve_and_goal'>;
 }

--- a/packages/cli/src/chat/tui/state/codexSubscription.ts
+++ b/packages/cli/src/chat/tui/state/codexSubscription.ts
@@ -1,0 +1,31 @@
+import {
+  setPreferCodexSubscription,
+  type CodexSubscriptionPreferenceUpdate,
+} from '@auth/codex';
+import { invalidateModelOptionsCache } from '@model/computeModelOptions';
+
+import { bumpCodexPreferenceVersion } from './cliState';
+
+/**
+ * Single source of truth for reacting to a Codex / ChatGPT-subscription change
+ * inside the running TUI: drop the cached model options and bump the preference
+ * version so dependent views (model picker, status bar) re-render. Call after
+ * any sign-in/out or preference flip.
+ */
+export function refreshCodexPreferenceViews(): void {
+  invalidateModelOptionsCache();
+  bumpCodexPreferenceVersion();
+}
+
+/**
+ * Flip the "prefer ChatGPT subscription" preference and refresh the TUI views.
+ * Shared by `/subscription`, `/login chatgpt`, and the retry "switch to your
+ * own API key" path so the persist-then-refresh sequence lives in one place.
+ */
+export async function setCliCodexSubscription(
+  enabled: boolean,
+): Promise<CodexSubscriptionPreferenceUpdate> {
+  const update = await setPreferCodexSubscription(enabled);
+  refreshCodexPreferenceViews();
+  return update;
+}

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -14,6 +14,8 @@
 // event).
 
 import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
+import { setPreferCodexSubscription } from '@auth/codex';
+import { setCliApiMode } from '@cli/runtime/apiAccessMode';
 import {
   approvalPromptAllowed,
   humanInputDenialFeedback,
@@ -21,7 +23,6 @@ import {
   immediateDecisionForApproval,
   markApprovalDenied,
 } from '@cli/runtime/approvalAdapter';
-import { setCliApiMode } from '@cli/runtime/apiAccessMode';
 import {
   cliApprovalEventKind,
   isCliApprovalEvent,
@@ -30,6 +31,7 @@ import {
 import type { CliContext } from '@cli/runtime/cliContext';
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import {
   handleProgressViewBashApprovalAction,
   setBashApprovalSessionBypass,
@@ -41,7 +43,7 @@ import { handleExternalInquiryAction } from '@tools/inquiry/ExternalInquiryTool'
 
 import { assertNever } from '../assertNever';
 import { notify } from '../notifications/terminalNotifier';
-import { cliState } from './cliState';
+import { bumpCodexPreferenceVersion, cliState } from './cliState';
 import {
   approvalPayloadStreamId,
   enqueueApproval,
@@ -280,6 +282,11 @@ async function applyRetryDecision(
       ...cliState.sessionMeta.get(),
       apiMode: decision.apiMode,
     });
+  }
+  if (decision.disableChatGptSubscription) {
+    await setPreferCodexSubscription(false);
+    invalidateModelOptionsCache();
+    bumpCodexPreferenceVersion();
   }
   runCoordinatorBridge.triggerRetry(payload.streamId, decision.userMessage);
 }

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -14,7 +14,6 @@
 // event).
 
 import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
-import { setPreferCodexSubscription } from '@auth/codex';
 import { setCliApiMode } from '@cli/runtime/apiAccessMode';
 import {
   approvalPromptAllowed,
@@ -31,7 +30,6 @@ import {
 import type { CliContext } from '@cli/runtime/cliContext';
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
-import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import {
   handleProgressViewBashApprovalAction,
   setBashApprovalSessionBypass,
@@ -43,7 +41,8 @@ import { handleExternalInquiryAction } from '@tools/inquiry/ExternalInquiryTool'
 
 import { assertNever } from '../assertNever';
 import { notify } from '../notifications/terminalNotifier';
-import { bumpCodexPreferenceVersion, cliState } from './cliState';
+import { cliState } from './cliState';
+import { setCliCodexSubscription } from './codexSubscription';
 import {
   approvalPayloadStreamId,
   enqueueApproval,
@@ -284,9 +283,7 @@ async function applyRetryDecision(
     });
   }
   if (decision.disableChatGptSubscription) {
-    await setPreferCodexSubscription(false);
-    invalidateModelOptionsCache();
-    bumpCodexPreferenceVersion();
+    await setCliCodexSubscription(false);
   }
   runCoordinatorBridge.triggerRetry(payload.streamId, decision.userMessage);
 }

--- a/packages/cli/src/runtime/approval/approvalPolicy.ts
+++ b/packages/cli/src/runtime/approval/approvalPolicy.ts
@@ -15,6 +15,9 @@ export type ApprovalDecision = SharedApprovalDecision;
 export const CLI_PERSONAL_API_RETRY_HINT =
   'Use `/api personal` in the chat TUI, or press `k` on the retry prompt, to switch to personal API keys.';
 
+export const CLI_CHATGPT_SUBSCRIPTION_RETRY_HINT =
+  'Use `/subscription off`, or press `k` on the retry prompt, to switch from your ChatGPT subscription to your OpenAI API key.';
+
 export interface CliApprovalPromptHooks {
   readonly beforePrompt?: () => void;
 }
@@ -36,12 +39,22 @@ export function hasCliApprovalDenied(context: CliContext): boolean {
   return deniedApprovalContexts.has(context);
 }
 
+/** Whether the failed retry was a ChatGPT-subscription (Codex) usage limit, so
+ *  the switch turns off the subscription preference rather than relay access. */
+export function isCliChatGptSubscriptionRetry(
+  payload: ProgressEventPayloads['showRetryRequest'],
+): boolean {
+  return payload.errorDetails?.isChatGptSubscriptionLimited === true;
+}
+
 export function isCliApiSwitchableRetry(
   payload: ProgressEventPayloads['showRetryRequest'],
 ): boolean {
   const details = payload.errorDetails;
+  if (!details) return false;
+  if (details.isChatGptSubscriptionLimited === true) return true;
   return (
-    details?.isCredentialExhausted === true &&
+    details.isCredentialExhausted === true &&
     (details.isRelayError === true ||
       isRelayMonthlyLimitMessage(payload.errorMessage))
   );

--- a/packages/cli/src/runtime/approval/approvalPolicy.ts
+++ b/packages/cli/src/runtime/approval/approvalPolicy.ts
@@ -1,6 +1,9 @@
 import { isRelayMonthlyLimitMessage } from '@common/errors/sdkErrorUtils';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
-import type { ApprovalDecision as SharedApprovalDecision } from '@shared/schemas';
+import {
+  isChatGptSubscriptionLimitError,
+  type ApprovalDecision as SharedApprovalDecision,
+} from '@shared/schemas';
 
 import { type CliDecisionApprovalEvent } from '../approvalEvents';
 import { type CliContext, type CliPromptRequest } from '../cliContext';
@@ -44,7 +47,7 @@ export function hasCliApprovalDenied(context: CliContext): boolean {
 export function isCliChatGptSubscriptionRetry(
   payload: ProgressEventPayloads['showRetryRequest'],
 ): boolean {
-  return payload.errorDetails?.isChatGptSubscriptionLimited === true;
+  return isChatGptSubscriptionLimitError(payload.errorDetails);
 }
 
 export function isCliApiSwitchableRetry(
@@ -52,7 +55,7 @@ export function isCliApiSwitchableRetry(
 ): boolean {
   const details = payload.errorDetails;
   if (!details) return false;
-  if (details.isChatGptSubscriptionLimited === true) return true;
+  if (isChatGptSubscriptionLimitError(details)) return true;
   return (
     details.isCredentialExhausted === true &&
     (details.isRelayError === true ||

--- a/packages/cli/src/runtime/approval/approvalSummaries.ts
+++ b/packages/cli/src/runtime/approval/approvalSummaries.ts
@@ -9,8 +9,10 @@ import {
 import type { ToolEditApprovalRequest } from '@tools/approval/toolEditApproval';
 
 import {
+  CLI_CHATGPT_SUBSCRIPTION_RETRY_HINT,
   CLI_PERSONAL_API_RETRY_HINT,
   isCliApiSwitchableRetry,
+  isCliChatGptSubscriptionRetry,
 } from './approvalPolicy';
 
 const TRUNCATED_DIFF_LINE_MARKER = ' … [line truncated]';
@@ -140,6 +142,9 @@ export function formatRetryRequestMessage(
   payload: ProgressEventPayloads['showRetryRequest'],
 ): string {
   const message = `Retry requested (${payload.operation}): ${payload.errorMessage ?? 'unknown error'}`;
+  if (isCliChatGptSubscriptionRetry(payload)) {
+    return [message, CLI_CHATGPT_SUBSCRIPTION_RETRY_HINT].join('\n');
+  }
   if (isCliApiSwitchableRetry(payload)) {
     return [message, CLI_PERSONAL_API_RETRY_HINT].join('\n');
   }

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -37,12 +37,14 @@ export {
   type ApprovalDecision,
   appendCliApiSwitchHint,
   approvalPromptAllowed,
+  CLI_CHATGPT_SUBSCRIPTION_RETRY_HINT,
   denyMessage,
   hasCliApprovalDenied,
   humanInputDenialFeedback,
   immediateDecision,
   immediateDecisionForApproval,
   isCliApiSwitchableRetry,
+  isCliChatGptSubscriptionRetry,
   markApprovalDenied,
 } from './approval/approvalPolicy';
 export {

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -22,6 +22,7 @@ import {
   type ExecutionRequest,
 } from '@agent/core/execution/executionRequests';
 import { getServerSideKeyService } from '@auth/serverKeys';
+import { setPreferCodexSubscription } from '@auth/codex';
 import { apiKeyCommands } from '@commands/api/apiKeyCommands';
 import { toErrorMessage } from '@common/errors';
 import { BaseViewMessageHandler } from '@common/webview';
@@ -615,6 +616,9 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       },
       setUseIncludedModelAccess: (enabled) =>
         getServerSideKeyService().setUseIncludedModelAccess(enabled),
+      disablePreferCodexSubscription: async () => {
+        await setPreferCodexSubscription(false);
+      },
       invalidateModelOptionsCache,
       triggerRetry: (stream) => runCoordinatorBridge.triggerRetry(stream),
     });
@@ -693,6 +697,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       provider: providerArg,
       upstreamCreditDepleted: data.upstreamCreditDepleted,
       viaRelay: data.viaRelay,
+      chatgptSubscription: data.chatgptSubscription,
     });
     if (result.proceeded && !result.retried) {
       await this.host.info(

--- a/packages/extension/src/progressView/frontend/eventHandlers.ts
+++ b/packages/extension/src/progressView/frontend/eventHandlers.ts
@@ -288,9 +288,15 @@ export function handlePermissionAction(
         // Non-terminal: panel stays open. The extension handler will
         // trigger retry on success, or leave the panel for the user
         // to choose Retry/Dismiss if the user cancels the key picker.
+        const chatgptSubscription =
+          permission.data.errorDetails?.isChatGptSubscriptionLimited === true;
         postMessage(PROGRESS_VIEW_COMMANDS.USE_OWN_API_KEY, {
           stream: permission.data.streamId,
-          provider: permission.data.errorDetails?.provider,
+          // Subscription quota exhaustion always means the OpenAI key is the
+          // fallback credential, regardless of how the error tagged provider.
+          provider: chatgptSubscription
+            ? 'openai'
+            : permission.data.errorDetails?.provider,
           upstreamCreditDepleted:
             permission.data.errorDetails?.isUpstreamCreditDepleted === true
               ? true
@@ -299,6 +305,7 @@ export function handlePermissionAction(
             permission.data.errorDetails?.isRelayError === true
               ? true
               : undefined,
+          chatgptSubscription: chatgptSubscription ? true : undefined,
         });
         break;
       }

--- a/packages/extension/src/progressView/frontend/eventHandlers.ts
+++ b/packages/extension/src/progressView/frontend/eventHandlers.ts
@@ -3,7 +3,9 @@ import { create } from 'mutative';
 // Local imports - shared webview
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import { postMessage } from '@shared/hostBridge';
+import { isChatGptSubscriptionLimitError } from '@shared/schemas';
 import type { StreamTabId } from '@shared/schemas';
+import type { GettingStartedAction } from '@shared/schemas';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import type { ExtractedClipboardImage } from '@shared/utils/clipboardImages';
 
@@ -30,7 +32,6 @@ import type {
   StreamEventDetail,
   ToolbarCommandDetail,
 } from './events';
-import type { GettingStartedAction } from '@shared/schemas';
 import type {
   FrontendEventHandlerContext,
   MessageHandlerContext,
@@ -288,8 +289,9 @@ export function handlePermissionAction(
         // Non-terminal: panel stays open. The extension handler will
         // trigger retry on success, or leave the panel for the user
         // to choose Retry/Dismiss if the user cancels the key picker.
-        const chatgptSubscription =
-          permission.data.errorDetails?.isChatGptSubscriptionLimited === true;
+        const chatgptSubscription = isChatGptSubscriptionLimitError(
+          permission.data.errorDetails,
+        );
         postMessage(PROGRESS_VIEW_COMMANDS.USE_OWN_API_KEY, {
           stream: permission.data.streamId,
           // Subscription quota exhaustion always means the OpenAI key is the

--- a/src/agent/modelHandlers/openai/modelHandlerCodex.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerCodex.ts
@@ -66,7 +66,7 @@ function requestUrl(input: RequestInfo | URL): string {
 }
 
 /** True only for the generation endpoint (`…/responses`), not `…/responses/input_tokens`. */
-function isGenerationRequest(url: string): boolean {
+export function isGenerationRequest(url: string): boolean {
   try {
     return new URL(url).pathname.endsWith('/responses');
   } catch {
@@ -74,22 +74,88 @@ function isGenerationRequest(url: string): boolean {
   }
 }
 
+/** Default top-level `instructions` for the Codex backend when the request
+ *  carries none — it returns `400 {"detail":"Instructions are required"}`
+ *  otherwise. */
+export const CODEX_DEFAULT_INSTRUCTIONS = 'You are a helpful assistant.';
+
 /**
- * Rewrite the outgoing Responses request for the Codex backend:
- *  - drop `max_output_tokens` (rejected as unsupported) and `background`
- *    (the backend has no polling mode);
- *  - force `store: false`;
- *  - guarantee a non-empty top-level `instructions` (the backend returns
- *    `400 {"detail":"Instructions are required"}` otherwise), hoisting
- *    system/developer items out of `input` into `instructions` (matching
- *    Zed/Codex) with a minimal fallback;
- *  - force `stream: true` (the backend returns `400 Stream must be set to true`
- *    otherwise).
+ * Rewrite a parsed Responses request body for the (unofficial) Codex backend.
+ * Pure: returns a new top-level object and never mutates `body`, so the
+ * reverse-engineered wire contract is unit-testable without a live request (see
+ * CodexRequestRewrite tests). Each adjustment prevents a specific backend 400:
+ *  - drop `max_output_tokens` (rejected as unsupported);
+ *  - force `store: false` (the backend keeps no server-side state) and
+ *    `stream: true` (`400 Stream must be set to true` otherwise);
+ *  - guarantee a non-empty top-level `instructions`, hoisting system/developer
+ *    items out of `input` into `instructions` (matching Zed/Codex), deduping
+ *    text already present, with {@link CODEX_DEFAULT_INSTRUCTIONS} as fallback.
  *
- * The handler forces the streaming path (`getStreamingConfig` → true), so the
- * SDK's own `ResponseStream` accumulates the deltas natively — no SSE parsing
- * here. Token-counting / compaction endpoints are disabled at the capability
- * level, so only the generation endpoint reaches this rewrite.
+ * Background mode is the one exception: when the handler set `background: true`
+ * (with store:true via `storesResponsesServerSide`), the transport fields are
+ * left untouched so the real backend verdict is observed rather than masked.
+ * `instructions` is still normalized — that requirement holds either way.
+ */
+export function rewriteCodexRequestBody(
+  body: Record<string, unknown>,
+): Record<string, unknown> {
+  const rewritten: Record<string, unknown> = { ...body };
+  delete rewritten.max_output_tokens;
+
+  const testingBackground = rewritten.background === true;
+  if (!testingBackground) {
+    delete rewritten.background;
+    rewritten.store = false;
+  }
+
+  const instructions: string[] = [];
+  if (
+    typeof rewritten.instructions === 'string' &&
+    rewritten.instructions.trim()
+  ) {
+    instructions.push(rewritten.instructions.trim());
+  }
+  if (Array.isArray(rewritten.input)) {
+    const kept: unknown[] = [];
+    for (const item of rewritten.input) {
+      const role =
+        item && typeof item === 'object'
+          ? (item as { role?: unknown }).role
+          : undefined;
+      if (role === 'system' || role === 'developer') {
+        const text = partsToText(
+          (item as { content?: unknown }).content,
+        ).trim();
+        if (
+          text &&
+          !instructions.some((instruction) => instruction.includes(text))
+        ) {
+          instructions.push(text);
+        }
+      } else {
+        kept.push(item);
+      }
+    }
+    rewritten.input = kept;
+  }
+  rewritten.instructions =
+    instructions.join('\n\n') || CODEX_DEFAULT_INSTRUCTIONS;
+
+  if (!testingBackground) {
+    rewritten.stream = true;
+  }
+
+  return rewritten;
+}
+
+/**
+ * Custom `fetch` for the Codex client: a thin parse → {@link
+ * rewriteCodexRequestBody} → serialize adapter on the generation endpoint, so
+ * the large base request-builder is untouched. The handler forces the streaming
+ * path (`getStreamingConfig` → true), so the SDK's own `ResponseStream`
+ * accumulates the deltas natively — no SSE parsing here. Token-counting /
+ * compaction endpoints are disabled at the capability level, so only the
+ * generation endpoint reaches this rewrite.
  */
 const codexFetch = (async (input, init) => {
   const url = requestUrl(input);
@@ -104,51 +170,7 @@ const codexFetch = (async (input, init) => {
 
   try {
     const body = JSON.parse(init.body) as Record<string, unknown>;
-    delete body.max_output_tokens;
-    // When background mode is active the handler sets `background: true` (and
-    // store:true via storesResponsesServerSide). Leave the transport fields
-    // untouched then, so the real backend verdict is observed; otherwise enforce
-    // the streaming/stateless shape the backend requires.
-    const testingBackground = body.background === true;
-    if (!testingBackground) {
-      delete body.background;
-      body.store = false;
-    }
-
-    const instructions: string[] = [];
-    if (typeof body.instructions === 'string' && body.instructions.trim()) {
-      instructions.push(body.instructions.trim());
-    }
-    if (Array.isArray(body.input)) {
-      const kept: unknown[] = [];
-      for (const item of body.input) {
-        const role =
-          item && typeof item === 'object'
-            ? (item as { role?: unknown }).role
-            : undefined;
-        if (role === 'system' || role === 'developer') {
-          const text = partsToText(
-            (item as { content?: unknown }).content,
-          ).trim();
-          if (
-            text &&
-            !instructions.some((instruction) => instruction.includes(text))
-          ) {
-            instructions.push(text);
-          }
-        } else {
-          kept.push(item);
-        }
-      }
-      body.input = kept;
-    }
-    body.instructions =
-      instructions.join('\n\n') || 'You are a helpful assistant.';
-
-    if (!testingBackground) {
-      body.stream = true;
-    }
-    init = { ...init, body: JSON.stringify(body) };
+    init = { ...init, body: JSON.stringify(rewriteCodexRequestBody(body)) };
   } catch (error) {
     // Body isn't JSON we can edit — the backend will reject it (missing
     // stream/instructions). Log so the resulting 400 is diagnosable.

--- a/src/agent/modelHandlers/openai/modelHandlerCodex.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerCodex.ts
@@ -221,7 +221,9 @@ export class ModelHandlerCodex extends ModelHandlerOpenAIResponse {
   /** The Codex backend while the subscription is active (also disables the
    *  WebSocket transport path), else the default OpenAI base from the parent. */
   public override getBaseUrl(): string | null {
-    return this.usingSubscription() ? CODEX_BACKEND_BASE_URL : super.getBaseUrl();
+    return this.usingSubscription()
+      ? CODEX_BACKEND_BASE_URL
+      : super.getBaseUrl();
   }
 
   protected override async createOpenAIClient(): Promise<OpenAI> {

--- a/src/agent/modelHandlers/openai/modelHandlerCodex.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerCodex.ts
@@ -16,6 +16,12 @@
  *     requires `store: false`, applied via a custom `fetch` so the large base
  *     request-builder is untouched. (System prompts already go to top-level
  *     `instructions`, which the backend wants.)
+ *
+ * All three are gated on the "prefer ChatGPT subscription" preference, re-read
+ * per request: if the user turns it off mid-run (e.g. the "Use your own API
+ * key" switch after a `usage_limit_reached` error), this handler transparently
+ * falls back to the base Responses handler's OpenAI API-key path on the same
+ * instance — no handler swap needed.
  */
 import OpenAI from 'openai';
 
@@ -28,6 +34,7 @@ import {
   CODEX_ORIGINATOR_HEADER,
   CodexAuthError,
   codexCoordinator,
+  isPreferCodexSubscription,
 } from '@auth/codex';
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
@@ -179,22 +186,54 @@ export class ModelHandlerCodex extends ModelHandlerOpenAIResponse {
     return false;
   }
 
-  /** Subscription usage consumes ChatGPT quota, not TeXRA-tracked API spend. */
-  public override computePrice(_responseUsage: ResponseUsage): number {
-    return 0;
+  /**
+   * Whether this handler should still drive the ChatGPT subscription. Re-read
+   * per request (not cached at construction) so that turning the preference off
+   * mid-run — e.g. via the "Use your own API key" retry switch after a
+   * `usage_limit_reached` error — makes the next attempt fall back to the
+   * user's OpenAI API key on this same handler instance. The OpenAI client is
+   * rebuilt every request from `getApiKey()`/`getBaseUrl()`, so re-resolving
+   * here is enough to reroute the in-place retry, mirroring how the base
+   * handler re-resolves relay vs direct credentials per request.
+   *
+   * (Sign-in is intentionally not re-checked: the switch flips this preference,
+   * not the stored session, and an auth lapse still surfaces as an actionable
+   * error from {@link resolveAccessToken}.)
+   */
+  private usingSubscription(): boolean {
+    return isPreferCodexSubscription();
   }
 
-  /** OAuth access token in place of an API key (becomes the Bearer header). */
+  /** Subscription usage consumes ChatGPT quota, not TeXRA-tracked API spend;
+   *  once switched to the API key, fall back to real per-token pricing. */
+  public override computePrice(responseUsage: ResponseUsage): number {
+    return this.usingSubscription() ? 0 : super.computePrice(responseUsage);
+  }
+
+  /** OAuth access token in place of an API key (becomes the Bearer header),
+   *  or the user's OpenAI API key once the subscription preference is off. */
   public override async getApiKey(): Promise<string> {
-    return this.resolveAccessToken();
+    return this.usingSubscription()
+      ? this.resolveAccessToken()
+      : super.getApiKey();
   }
 
-  /** Always the Codex backend (also disables the WebSocket transport path). */
+  /** The Codex backend while the subscription is active (also disables the
+   *  WebSocket transport path), else the default OpenAI base from the parent. */
   public override getBaseUrl(): string | null {
-    return CODEX_BACKEND_BASE_URL;
+    return this.usingSubscription() ? CODEX_BACKEND_BASE_URL : super.getBaseUrl();
   }
 
   protected override async createOpenAIClient(): Promise<OpenAI> {
+    if (!this.usingSubscription()) {
+      // Preference switched off (e.g. after a usage limit) — route this request
+      // through the user's OpenAI API key via the standard Responses client.
+      this.logger.debug(
+        'ChatGPT subscription preference is off — using the OpenAI API key.',
+      );
+      return super.createOpenAIClient();
+    }
+
     const apiKey = await this.resolveAccessToken();
     const accountId = await codexCoordinator().getAccountId();
     const defaultHeaders: Record<string, string> = {

--- a/src/agent/modelHandlers/openai/modelHandlerCodex.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerCodex.ts
@@ -38,6 +38,7 @@ import {
 } from '@auth/codex';
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
+import { getWebSocketEnabled } from '@utils/config/providerConfig';
 
 import { ModelHandlerOpenAIResponse } from './modelHandlerOpenAIResponse';
 import type { ResponseUsage } from 'openai/resources/responses/responses';
@@ -104,8 +105,15 @@ const codexFetch = (async (input, init) => {
   try {
     const body = JSON.parse(init.body) as Record<string, unknown>;
     delete body.max_output_tokens;
-    delete body.background;
-    body.store = false;
+    // When background mode is active the handler sets `background: true` (and
+    // store:true via storesResponsesServerSide). Leave the transport fields
+    // untouched then, so the real backend verdict is observed; otherwise enforce
+    // the streaming/stateless shape the backend requires.
+    const testingBackground = body.background === true;
+    if (!testingBackground) {
+      delete body.background;
+      body.store = false;
+    }
 
     const instructions: string[] = [];
     if (typeof body.instructions === 'string' && body.instructions.trim()) {
@@ -137,7 +145,9 @@ const codexFetch = (async (input, init) => {
     body.instructions =
       instructions.join('\n\n') || 'You are a helpful assistant.';
 
-    body.stream = true;
+    if (!testingBackground) {
+      body.stream = true;
+    }
     init = { ...init, body: JSON.stringify(body) };
   } catch (error) {
     // Body isn't JSON we can edit — the backend will reject it (missing
@@ -152,16 +162,32 @@ const codexFetch = (async (input, init) => {
 }) satisfies typeof fetch;
 
 export class ModelHandlerCodex extends ModelHandlerOpenAIResponse {
-  protected override backgroundModeSupported = false;
+  // Background mode is honored through the SAME `model.useBackgroundResponses`
+  // toggle every OpenAI Responses model uses (plus the usual workflow + GPT
+  // eligibility) — no Codex-specific flag. EXPERIMENTAL on this backend: it
+  // forces store:false and has no polling endpoint, so a background request
+  // very likely fails; the toggle exists so it can be tested in practice.
+  protected override backgroundModeSupported = true;
 
   // The Codex backend is streaming-only (`400 Stream must be set to true`
-  // otherwise), so always take the streaming path regardless of the user's
-  // streaming toggle. The SDK's `ResponseStream` then accumulates the deltas
-  // natively, and the base path rebuilds `output` from the streamed
-  // `output_item.done` events (the backend leaves `response.completed.output`
-  // empty).
+  // otherwise), so take the streaming path unless background mode is active
+  // (then the base polling path needs non-streaming). The SDK's `ResponseStream`
+  // accumulates the deltas natively, and the base path rebuilds `output` from
+  // the streamed `output_item.done` events.
   public override getStreamingConfig(): boolean {
-    return true;
+    return !this.isBackgroundModeActive();
+  }
+
+  /**
+   * Allow WebSocket transport against the Codex backend whenever the SAME global
+   * `texra.websocket.openai` toggle is on (`getWebSocketEnabled()`) — no
+   * Codex-specific flag. The SDK derives the WebSocket URL + auth from the
+   * (Codex) client, so this targets the Codex endpoint; whether that endpoint
+   * speaks WebSocket is what's being tested. Off by default → the base gate
+   * (default endpoint only) keeps it disabled.
+   */
+  protected override isWebSocketModeEnabled(): boolean {
+    return getWebSocketEnabled() || super.isWebSocketModeEnabled();
   }
 
   // The Codex backend has no `/responses/input_tokens` or `/compact` endpoint
@@ -183,8 +209,13 @@ export class ModelHandlerCodex extends ModelHandlerOpenAIResponse {
   // encrypted-reasoning replay path: with no previous_response_id chaining,
   // reasoning continuity comes from replaying `reasoning.encrypted_content`
   // blobs in each turn's input instead.
+  //
+  // EXPERIMENTAL exception: background mode (polling) needs server-side storage,
+  // so when it's active store:true is requested — which also auto-disables the
+  // encrypted-reasoning replay (reasoning then lives server-side, like the base
+  // path), keeping the two mechanisms from conflicting.
   protected override get storesResponsesServerSide(): boolean {
-    return false;
+    return this.isBackgroundModeActive();
   }
 
   protected override get supportsInlineInputFileUpload(): boolean {

--- a/src/agent/modelHandlers/openai/modelHandlerCodex.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerCodex.ts
@@ -178,6 +178,15 @@ export class ModelHandlerCodex extends ModelHandlerOpenAIResponse {
     return false;
   }
 
+  // The Codex backend keeps no server-side state (store:false, also enforced at
+  // the fetch layer). This drives the base request `store` field and gates the
+  // encrypted-reasoning replay path: with no previous_response_id chaining,
+  // reasoning continuity comes from replaying `reasoning.encrypted_content`
+  // blobs in each turn's input instead.
+  protected override get storesResponsesServerSide(): boolean {
+    return false;
+  }
+
   protected override get supportsInlineInputFileUpload(): boolean {
     return false;
   }

--- a/src/agent/modelHandlers/openai/modelHandlerCodex.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerCodex.ts
@@ -169,63 +169,6 @@ export class ModelHandlerCodex extends ModelHandlerOpenAIResponse {
   // very likely fails; the toggle exists so it can be tested in practice.
   protected override backgroundModeSupported = true;
 
-  // The Codex backend is streaming-only (`400 Stream must be set to true`
-  // otherwise), so take the streaming path unless background mode is active
-  // (then the base polling path needs non-streaming). The SDK's `ResponseStream`
-  // accumulates the deltas natively, and the base path rebuilds `output` from
-  // the streamed `output_item.done` events.
-  public override getStreamingConfig(): boolean {
-    return !this.isBackgroundModeActive();
-  }
-
-  /**
-   * Allow WebSocket transport against the Codex backend whenever the SAME global
-   * `texra.websocket.openai` toggle is on (`getWebSocketEnabled()`) — no
-   * Codex-specific flag. The SDK derives the WebSocket URL + auth from the
-   * (Codex) client, so this targets the Codex endpoint; whether that endpoint
-   * speaks WebSocket is what's being tested. Off by default → the base gate
-   * (default endpoint only) keeps it disabled.
-   */
-  protected override isWebSocketModeEnabled(): boolean {
-    return getWebSocketEnabled() || super.isWebSocketModeEnabled();
-  }
-
-  // The Codex backend has no `/responses/input_tokens` or `/compact` endpoint
-  // (they return 403); rely on the handler's heuristic fallbacks instead.
-  public override get supportsTokenCounting(): boolean {
-    return false;
-  }
-
-  public override get supportsManualCompaction(): boolean {
-    return false;
-  }
-
-  protected override get supportsResponseChaining(): boolean {
-    return false;
-  }
-
-  // The Codex backend keeps no server-side state (store:false, also enforced at
-  // the fetch layer). This drives the base request `store` field and gates the
-  // encrypted-reasoning replay path: with no previous_response_id chaining,
-  // reasoning continuity comes from replaying `reasoning.encrypted_content`
-  // blobs in each turn's input instead.
-  //
-  // EXPERIMENTAL exception: background mode (polling) needs server-side storage,
-  // so when it's active store:true is requested — which also auto-disables the
-  // encrypted-reasoning replay (reasoning then lives server-side, like the base
-  // path), keeping the two mechanisms from conflicting.
-  protected override get storesResponsesServerSide(): boolean {
-    return this.isBackgroundModeActive();
-  }
-
-  protected override get supportsInlineInputFileUpload(): boolean {
-    return false;
-  }
-
-  protected override get supportsToolResultFileUpload(): boolean {
-    return false;
-  }
-
   /**
    * Whether this handler should still drive the ChatGPT subscription. Re-read
    * per request (not cached at construction) so that turning the preference off
@@ -236,12 +179,85 @@ export class ModelHandlerCodex extends ModelHandlerOpenAIResponse {
    * here is enough to reroute the in-place retry, mirroring how the base
    * handler re-resolves relay vs direct credentials per request.
    *
+   * EVERY Codex-specific override below is gated on this so the fallback is a
+   * genuine drop to the base handler — once the subscription is off the request
+   * runs against the normal OpenAI Responses endpoint with the base handler's
+   * full capabilities (token counting, compaction, response chaining, file
+   * upload, store:true, WebSocket eligibility), not Codex-restricted ones.
+   *
    * (Sign-in is intentionally not re-checked: the switch flips this preference,
    * not the stored session, and an auth lapse still surfaces as an actionable
    * error from {@link resolveAccessToken}.)
    */
   private usingSubscription(): boolean {
     return isPreferCodexSubscription();
+  }
+
+  // The Codex backend is streaming-only (`400 Stream must be set to true`
+  // otherwise), so take the streaming path unless background mode is active
+  // (then the base polling path needs non-streaming). After the fallback the
+  // base streaming logic applies.
+  public override getStreamingConfig(): boolean {
+    return this.usingSubscription()
+      ? !this.isBackgroundModeActive()
+      : super.getStreamingConfig();
+  }
+
+  /**
+   * Allow WebSocket transport against the Codex backend whenever the SAME global
+   * `texra.websocket.openai` toggle is on (`getWebSocketEnabled()`) — no
+   * Codex-specific flag. The SDK derives the WebSocket URL + auth from the
+   * (Codex) client, so this targets the Codex endpoint; whether that endpoint
+   * speaks WebSocket is what's being tested. Gated on the subscription: once it
+   * is off, the base rule (default OpenAI endpoint only) applies, so WebSocket
+   * is never attempted against a relay/proxy/custom base URL.
+   */
+  protected override isWebSocketModeEnabled(): boolean {
+    return this.usingSubscription()
+      ? getWebSocketEnabled()
+      : super.isWebSocketModeEnabled();
+  }
+
+  // The Codex backend has no `/responses/input_tokens` or `/compact` endpoint
+  // (they return 403); rely on the handler's heuristic fallbacks instead. After
+  // the fallback to the OpenAI API key the base capabilities are restored.
+  public override get supportsTokenCounting(): boolean {
+    return this.usingSubscription() ? false : super.supportsTokenCounting;
+  }
+
+  public override get supportsManualCompaction(): boolean {
+    return this.usingSubscription() ? false : super.supportsManualCompaction;
+  }
+
+  protected override get supportsResponseChaining(): boolean {
+    return this.usingSubscription() ? false : super.supportsResponseChaining;
+  }
+
+  // The Codex backend keeps no server-side state (store:false, also enforced at
+  // the fetch layer). This drives the base request `store` field and gates the
+  // encrypted-reasoning replay path: with no previous_response_id chaining,
+  // reasoning continuity comes from replaying `reasoning.encrypted_content`
+  // blobs in each turn's input instead.
+  //
+  // Background mode (polling) needs server-side storage, so when it's active
+  // store:true is requested — which also auto-disables the encrypted-reasoning
+  // replay (reasoning then lives server-side, like the base path). Once the
+  // subscription is off entirely, the base store:true + chaining is restored.
+  protected override get storesResponsesServerSide(): boolean {
+    if (!this.usingSubscription()) return super.storesResponsesServerSide;
+    return this.isBackgroundModeActive();
+  }
+
+  protected override get supportsInlineInputFileUpload(): boolean {
+    return this.usingSubscription()
+      ? false
+      : super.supportsInlineInputFileUpload;
+  }
+
+  protected override get supportsToolResultFileUpload(): boolean {
+    return this.usingSubscription()
+      ? false
+      : super.supportsToolResultFileUpload;
   }
 
   /** Subscription usage consumes ChatGPT quota, not TeXRA-tracked API spend;

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -2345,9 +2345,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     // store:true (default): only reasoning items immediately preceding a
     //   web_search_call are kept — that pairing is required by the API, and
     //   previous_response_id retains everything else server-side.
-    // store:false (Codex/stateless): keep EVERY reasoning item (each carries
-    //   `encrypted_content`) so the next turn can replay it for reasoning
-    //   continuity; web_search_call items are still preserved alongside.
+    // store:false (Codex/stateless): keep every reasoning item that actually
+    //   carries a non-empty `encrypted_content` blob so the next turn can replay
+    //   it for reasoning continuity; web_search_call items are preserved
+    //   alongside. A summary-only reasoning item (no encrypted_content) is
+    //   skipped — replaying it empty would be rejected by the stateless endpoint
+    //   rather than chained.
     // Preserving output order keeps the item-pairing invariant intact when the
     // blocks are replayed before the function_call.
     const preserveAllReasoning = !this.storesResponsesServerSide;
@@ -2355,7 +2358,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       [];
     for (const [i, item] of output.entries()) {
       if (preserveAllReasoning && isOpenAIReasoningItem(item)) {
-        contentBlocks.push(item);
+        const encrypted = item.encrypted_content;
+        if (typeof encrypted === 'string' && encrypted.length > 0) {
+          contentBlocks.push(item);
+        }
         continue;
       }
       if (isOpenAIWebSearchCall(item)) {

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -215,6 +215,21 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   }
 
   /**
+   * Whether the backend stores responses server-side (`store: true`). The base
+   * OpenAI Responses API does. A stateless backend (the Codex ChatGPT-subscription
+   * endpoint forces `store: false`) keeps no server-side reasoning, so it must
+   * (a) request `reasoning.encrypted_content` and (b) replay those blobs in the
+   * next turn's input for cross-turn reasoning continuity — the store:true path
+   * relies on `previous_response_id` instead and must NOT replay them (the items
+   * already live server-side, so resending throws "Duplicate item found").
+   *
+   * Single source for the `store` request field and the encrypted-reasoning gate.
+   */
+  protected get storesResponsesServerSide(): boolean {
+    return true;
+  }
+
+  /**
    * Override streaming config to disable streaming when background mode is enabled.
    * Background responses use polling for completed results, incompatible with streaming.
    */
@@ -1376,7 +1391,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     const params: ResponseCreateParamsBase = {
       ...baseParams,
       max_output_tokens: maxOutputTokens,
-      store: true,
+      store: this.storesResponsesServerSide,
       ...(convertedTools?.length && {
         tool_choice: 'auto' as const,
         ...(!parallelToolCalls && { parallel_tool_calls: false }),
@@ -1405,6 +1420,20 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     // native web search even when no explicit tools are passed.
     if (this.capabilities.supportsNativeWebSearch) {
       params.include = ['web_search_call.action.sources'];
+    }
+
+    // Stateless (store:false) backends keep no server-side reasoning, so request
+    // encrypted reasoning blobs to replay in the next turn's input for cross-turn
+    // reasoning continuity (matching the Codex CLI / OpenCode). The store:true
+    // path retains reasoning via previous_response_id and must not replay it.
+    if (
+      !this.storesResponsesServerSide &&
+      this.capabilities.supportsReasoning
+    ) {
+      params.include = [
+        ...(params.include ?? []),
+        'reasoning.encrypted_content',
+      ];
     }
 
     // Extend reasoning with summary option for API call (not needed for token counting)
@@ -2308,15 +2337,32 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       return { webSearchResults: [], webFetchResults: [], contentBlocks: [] };
     }
 
-    // Extract content blocks that need to be preserved
-    // Only include reasoning items that are immediately followed by web_search_call
-    // to satisfy both API requirements (reasoning needs following item, web_search needs preceding reasoning)
+    // Extract content blocks that need to be preserved, in output order.
+    //
+    // store:true (default): only reasoning items immediately preceding a
+    //   web_search_call are kept — that pairing is required by the API, and
+    //   previous_response_id retains everything else server-side.
+    // store:false (Codex/stateless): keep EVERY reasoning item (each carries
+    //   `encrypted_content`) so the next turn can replay it for reasoning
+    //   continuity; web_search_call items are still preserved alongside.
+    // Preserving output order keeps the item-pairing invariant intact when the
+    // blocks are replayed before the function_call.
+    const preserveAllReasoning = !this.storesResponsesServerSide;
     const contentBlocks: (ResponseFunctionWebSearch | ResponseReasoningItem)[] =
       [];
     for (const [i, item] of output.entries()) {
+      if (preserveAllReasoning && isOpenAIReasoningItem(item)) {
+        contentBlocks.push(item);
+        continue;
+      }
       if (isOpenAIWebSearchCall(item)) {
-        // Check if there's a reasoning item immediately before this web_search_call
-        if (i > 0 && isOpenAIReasoningItem(output[i - 1])) {
+        // store:true: pair the immediately-preceding reasoning with the
+        // web_search_call (store:false already captured it above).
+        if (
+          !preserveAllReasoning &&
+          i > 0 &&
+          isOpenAIReasoningItem(output[i - 1])
+        ) {
           contentBlocks.push(output[i - 1] as ResponseReasoningItem);
         }
         contentBlocks.push(item);

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -138,6 +138,52 @@ interface ResponseFinalizeContext {
   readonly compactedMessages: ResponseInputItem[] | undefined;
 }
 
+type ServerToolContentBlock = ResponseFunctionWebSearch | ResponseReasoningItem;
+
+/**
+ * store:false (stateless) content blocks: every reasoning item that carries a
+ * non-empty `encrypted_content` blob (replayed next turn for reasoning
+ * continuity) plus each web_search_call, in output order — so a reasoning item
+ * still immediately precedes its following item. A summary-only reasoning item
+ * is skipped; replayed empty the stateless endpoint rejects it rather than
+ * chaining.
+ */
+function collectStatelessContentBlocks(
+  output: readonly ResponseOutputItem[],
+): ServerToolContentBlock[] {
+  const blocks: ServerToolContentBlock[] = [];
+  for (const item of output) {
+    if (isOpenAIReasoningItem(item)) {
+      const encrypted = item.encrypted_content;
+      if (typeof encrypted === 'string' && encrypted.length > 0) {
+        blocks.push(item);
+      }
+    } else if (isOpenAIWebSearchCall(item)) {
+      blocks.push(item);
+    }
+  }
+  return blocks;
+}
+
+/**
+ * store:true content blocks: only the reasoning item immediately preceding each
+ * web_search_call (the API pairing requirement) plus the web_search_call.
+ * `previous_response_id` retains everything else server-side.
+ */
+function collectWebSearchPairedBlocks(
+  output: readonly ResponseOutputItem[],
+): ServerToolContentBlock[] {
+  const blocks: ServerToolContentBlock[] = [];
+  for (const [i, item] of output.entries()) {
+    if (!isOpenAIWebSearchCall(item)) continue;
+    if (i > 0 && isOpenAIReasoningItem(output[i - 1])) {
+      blocks.push(output[i - 1] as ResponseReasoningItem);
+    }
+    blocks.push(item);
+  }
+  return blocks;
+}
+
 function responseOutputItemKey(item: ResponseOutputItem): string | undefined {
   if (typeof item.id === 'string') return `id:${item.id}`;
   if (item.type === 'function_call' && typeof item.call_id === 'string') {
@@ -2340,43 +2386,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       return { webSearchResults: [], webFetchResults: [], contentBlocks: [] };
     }
 
-    // Extract content blocks that need to be preserved, in output order.
-    //
-    // store:true (default): only reasoning items immediately preceding a
-    //   web_search_call are kept — that pairing is required by the API, and
-    //   previous_response_id retains everything else server-side.
-    // store:false (Codex/stateless): keep every reasoning item that actually
-    //   carries a non-empty `encrypted_content` blob so the next turn can replay
-    //   it for reasoning continuity; web_search_call items are preserved
-    //   alongside. A summary-only reasoning item (no encrypted_content) is
-    //   skipped — replaying it empty would be rejected by the stateless endpoint
-    //   rather than chained.
-    // Preserving output order keeps the item-pairing invariant intact when the
-    // blocks are replayed before the function_call.
-    const preserveAllReasoning = !this.storesResponsesServerSide;
-    const contentBlocks: (ResponseFunctionWebSearch | ResponseReasoningItem)[] =
-      [];
-    for (const [i, item] of output.entries()) {
-      if (preserveAllReasoning && isOpenAIReasoningItem(item)) {
-        const encrypted = item.encrypted_content;
-        if (typeof encrypted === 'string' && encrypted.length > 0) {
-          contentBlocks.push(item);
-        }
-        continue;
-      }
-      if (isOpenAIWebSearchCall(item)) {
-        // store:true: pair the immediately-preceding reasoning with the
-        // web_search_call (store:false already captured it above).
-        if (
-          !preserveAllReasoning &&
-          i > 0 &&
-          isOpenAIReasoningItem(output[i - 1])
-        ) {
-          contentBlocks.push(output[i - 1] as ResponseReasoningItem);
-        }
-        contentBlocks.push(item);
-      }
-    }
+    // The two store modes preserve reasoning differently (see each helper);
+    // both keep output order so a reasoning item stays immediately before its
+    // following item when the blocks are replayed.
+    const contentBlocks = this.storesResponsesServerSide
+      ? collectWebSearchPairedBlocks(output)
+      : collectStatelessContentBlocks(output);
 
     // Extract normalized web search results for display
     const webSearchResults = extractOpenAIWebSearchResults(output);

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -361,8 +361,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    *
    * Also incompatible with background mode (polling-based, doesn't benefit
    * from persistent connection).
+   *
+   * `protected` so a subclass on a non-default endpoint (e.g. the Codex
+   * backend) can opt into trying WebSocket against its own base URL.
    */
-  private isWebSocketModeEnabled(): boolean {
+  protected isWebSocketModeEnabled(): boolean {
     return getWebSocketEnabled() && this.getBaseUrl() === null;
   }
 

--- a/src/common/errors/sdkError/chatgptSubscriptionDetection.ts
+++ b/src/common/errors/sdkError/chatgptSubscriptionDetection.ts
@@ -1,4 +1,5 @@
 import { isObject, isString } from '@utils/core';
+import { capitalize } from '@utils/text/stringUtils';
 
 /**
  * Detection + formatting for the ChatGPT-subscription (Codex backend) usage
@@ -19,7 +20,6 @@ import { isObject, isString } from '@utils/core';
 export interface ChatGptSubscriptionLimit {
   readonly planType?: string;
   readonly resetsInSeconds?: number;
-  readonly resetsAt?: number;
 }
 
 function pickStringField(value: unknown, key: string): string | undefined {
@@ -54,15 +54,9 @@ export function parseChatGptSubscriptionLimit(
     return {
       planType: pickStringField(candidate, 'plan_type'),
       resetsInSeconds: pickNumberField(candidate, 'resets_in_seconds'),
-      resetsAt: pickNumberField(candidate, 'resets_at'),
     };
   }
   return null;
-}
-
-/** Whether the raw error body is a ChatGPT-subscription usage-limit error. */
-export function isChatGptSubscriptionLimitBody(rawErrorBody: unknown): boolean {
-  return parseChatGptSubscriptionLimit(rawErrorBody) !== null;
 }
 
 /**
@@ -91,9 +85,7 @@ function formatResetDuration(totalSeconds: number): string {
 export function describeChatGptSubscriptionLimit(
   info: ChatGptSubscriptionLimit,
 ): string {
-  const plan = info.planType
-    ? ` (${info.planType.charAt(0).toUpperCase()}${info.planType.slice(1)} plan)`
-    : '';
+  const plan = info.planType ? ` (${capitalize(info.planType)} plan)` : '';
   const reset =
     info.resetsInSeconds !== undefined
       ? ` Resets in ${formatResetDuration(info.resetsInSeconds)}.`

--- a/src/common/errors/sdkError/chatgptSubscriptionDetection.ts
+++ b/src/common/errors/sdkError/chatgptSubscriptionDetection.ts
@@ -1,0 +1,105 @@
+import { isObject, isString } from '@utils/core';
+
+/**
+ * Detection + formatting for the ChatGPT-subscription (Codex backend) usage
+ * limit. When a user drives Codex-eligible models through their ChatGPT
+ * subscription (see `@auth/codex`), the backend rejects requests once the
+ * plan's quota is exhausted with a distinctive body:
+ *
+ *   { "type": "usage_limit_reached", "message": "...", "plan_type": "pro",
+ *     "resets_at": 1782634869, "resets_in_seconds": 159728 }
+ *
+ * This shape is ONLY ever returned by the Codex backend — a direct OpenAI API
+ * key reports rate limits as `rate_limit_exceeded` / `insufficient_quota`
+ * instead — so matching `type === 'usage_limit_reached'` reliably identifies a
+ * subscription request whose quota ran out, the signal that lets the retry UI
+ * offer "switch to your own API key" (parallel to the relay monthly-limit
+ * affordance). Pure body inspection, mirroring {@link relayDetection}.
+ */
+export interface ChatGptSubscriptionLimit {
+  readonly planType?: string;
+  readonly resetsInSeconds?: number;
+  readonly resetsAt?: number;
+}
+
+function pickStringField(value: unknown, key: string): string | undefined {
+  if (!isObject(value)) return undefined;
+  const field = (value as Record<string, unknown>)[key];
+  return isString(field) && field.trim().length > 0 ? field : undefined;
+}
+
+function pickNumberField(value: unknown, key: string): number | undefined {
+  if (!isObject(value)) return undefined;
+  const field = (value as Record<string, unknown>)[key];
+  return typeof field === 'number' && Number.isFinite(field)
+    ? field
+    : undefined;
+}
+
+/**
+ * Parse a Codex `usage_limit_reached` body, returning the plan/reset details
+ * or `null` when the body is not a subscription usage-limit error. Handles
+ * both the direct shape and the SDK-enveloped `{ error: { ... } }` form.
+ */
+export function parseChatGptSubscriptionLimit(
+  rawErrorBody: unknown,
+): ChatGptSubscriptionLimit | null {
+  if (!isObject(rawErrorBody)) return null;
+  const candidates = [
+    rawErrorBody,
+    (rawErrorBody as { error?: unknown }).error,
+  ];
+  for (const candidate of candidates) {
+    if (pickStringField(candidate, 'type') !== 'usage_limit_reached') continue;
+    return {
+      planType: pickStringField(candidate, 'plan_type'),
+      resetsInSeconds: pickNumberField(candidate, 'resets_in_seconds'),
+      resetsAt: pickNumberField(candidate, 'resets_at'),
+    };
+  }
+  return null;
+}
+
+/** Whether the raw error body is a ChatGPT-subscription usage-limit error. */
+export function isChatGptSubscriptionLimitBody(rawErrorBody: unknown): boolean {
+  return parseChatGptSubscriptionLimit(rawErrorBody) !== null;
+}
+
+/**
+ * Format a coarse "1d 20h" / "44h 22m" / "5m" duration from a second count.
+ * Day+hour, hour+minute, or minute granularity is plenty for a reset-window
+ * hint; sub-minute collapses to a friendly phrase. Pure (no clock read), so it
+ * stays usable from the synchronous error formatter.
+ */
+function formatResetDuration(totalSeconds: number): string {
+  const seconds = Math.max(0, Math.floor(totalSeconds));
+  const days = Math.floor(seconds / 86_400);
+  const hours = Math.floor((seconds % 86_400) / 3_600);
+  const minutes = Math.floor((seconds % 3_600) / 60);
+  const parts: string[] = [];
+  if (days > 0) parts.push(`${days}d`);
+  if (hours > 0) parts.push(`${hours}h`);
+  if (minutes > 0 && days === 0) parts.push(`${minutes}m`);
+  return parts.length > 0 ? parts.join(' ') : 'less than a minute';
+}
+
+/**
+ * Human-readable message for a subscription usage-limit error: plan name (when
+ * present), how long until the quota resets (from `resets_in_seconds`, no clock
+ * read needed), and the actionable next step.
+ */
+export function describeChatGptSubscriptionLimit(
+  info: ChatGptSubscriptionLimit,
+): string {
+  const plan = info.planType
+    ? ` (${info.planType.charAt(0).toUpperCase()}${info.planType.slice(1)} plan)`
+    : '';
+  const reset =
+    info.resetsInSeconds !== undefined
+      ? ` Resets in ${formatResetDuration(info.resetsInSeconds)}.`
+      : '';
+  return (
+    `ChatGPT subscription usage limit reached${plan}.${reset}` +
+    ' Switch to your own OpenAI API key to keep working, or wait until the limit resets.'
+  );
+}

--- a/src/common/errors/sdkError/providerErrorFormat.ts
+++ b/src/common/errors/sdkError/providerErrorFormat.ts
@@ -28,6 +28,10 @@ import {
   isUpstreamCreditDepletedBody,
 } from './relayDetection';
 import {
+  describeChatGptSubscriptionLimit,
+  parseChatGptSubscriptionLimit,
+} from './chatgptSubscriptionDetection';
+import {
   type SdkErrorEntry,
   SDK_ERRORS,
   SDK_ERRORS_BY_KIND,
@@ -150,10 +154,20 @@ export function formatProviderHttpError(err: unknown): ProviderError {
   // Anthropic 400 "credit balance is too low" still wants the "Use your
   // own API key" affordance so the user can switch credentials.
   const isUpstreamCreditDepleted = isUpstreamCreditDepletedBody(rawErrorBody);
+  // ChatGPT-subscription (Codex) quota exhaustion. Treated as a credential
+  // exhaustion so auto-retry is suppressed (the quota won't return mid-run) and
+  // the retry UI offers a switch to the user's own API key — but it disables
+  // the subscription preference, not relay, on accept.
+  const chatgptSubscriptionLimit = parseChatGptSubscriptionLimit(rawErrorBody);
+  const isChatGptSubscriptionLimited = chatgptSubscriptionLimit !== null;
+  const chatgptSubscriptionMessage = chatgptSubscriptionLimit
+    ? describeChatGptSubscriptionLimit(chatgptSubscriptionLimit)
+    : undefined;
   const isCredentialExhausted =
     isRelayMonthlyLimitBody(rawErrorBody) ||
     isRelayMonthlyLimitByMessage ||
-    isUpstreamCreditDepleted;
+    isUpstreamCreditDepleted ||
+    isChatGptSubscriptionLimited;
 
   // Handle DOMException AbortError (from AbortController.abort())
   if (err instanceof DOMException && err.name === 'AbortError') {
@@ -184,6 +198,9 @@ export function formatProviderHttpError(err: unknown): ProviderError {
   if (sdkMatch) {
     return {
       ...sdkMatch,
+      // Prefer the actionable subscription-limit message over the raw
+      // `HTTP 429 – The usage limit has been reached`.
+      message: chatgptSubscriptionMessage ?? sdkMatch.message,
       // Credential-exhausted errors keep userRetryable=true so the retry
       // panel surfaces with the "Use your own API key" affordance, but
       // shouldAutoRetry separately suppresses auto-retry for them — a
@@ -192,6 +209,7 @@ export function formatProviderHttpError(err: unknown): ProviderError {
       isRelayError: isRelay,
       isCredentialExhausted: isCredentialExhausted || undefined,
       isUpstreamCreditDepleted: isUpstreamCreditDepleted || undefined,
+      isChatGptSubscriptionLimited: isChatGptSubscriptionLimited || undefined,
       rawErrorBody,
       streamDiagnostics,
       partialText,
@@ -216,7 +234,7 @@ export function formatProviderHttpError(err: unknown): ProviderError {
     (statusCode ? isRetryableStatusCode(statusCode) : true);
 
   return {
-    message,
+    message: chatgptSubscriptionMessage ?? message,
     statusCode,
     statusText,
     provider,
@@ -224,6 +242,7 @@ export function formatProviderHttpError(err: unknown): ProviderError {
     isRelayError: isRelay,
     isCredentialExhausted: isCredentialExhausted || undefined,
     isUpstreamCreditDepleted: isUpstreamCreditDepleted || undefined,
+    isChatGptSubscriptionLimited: isChatGptSubscriptionLimited || undefined,
     requestId,
     rawErrorBody,
     streamDiagnostics,

--- a/src/common/errors/sdkError/providerErrorFormat.ts
+++ b/src/common/errors/sdkError/providerErrorFormat.ts
@@ -193,11 +193,26 @@ export function formatProviderHttpError(err: unknown): ProviderError {
     };
   }
 
+  // Classification flags + diagnostics carried by BOTH the SDK-matched and the
+  // unrecognized returns below. The abort / disk-full early returns above
+  // deliberately opt out (always non-relay, no credential flags). Single source
+  // for these fields so adding a future flag touches one place, not two.
+  const classification = {
+    isRelayError: isRelay,
+    isCredentialExhausted: isCredentialExhausted || undefined,
+    isUpstreamCreditDepleted: isUpstreamCreditDepleted || undefined,
+    isChatGptSubscriptionLimited: isChatGptSubscriptionLimited || undefined,
+    rawErrorBody,
+    streamDiagnostics,
+    partialText,
+  };
+
   // Try matching a known SDK error type (connection, abort, HTTP errors)
   const sdkMatch = matchSdkError(err, rawErrorBody);
   if (sdkMatch) {
     return {
       ...sdkMatch,
+      ...classification,
       // Prefer the actionable subscription-limit message over the raw
       // `HTTP 429 – The usage limit has been reached`.
       message: chatgptSubscriptionMessage ?? sdkMatch.message,
@@ -206,13 +221,6 @@ export function formatProviderHttpError(err: unknown): ProviderError {
       // shouldAutoRetry separately suppresses auto-retry for them — a
       // fresh attempt with the same depleted credential would just fail.
       userRetryable: isRelay || sdkMatch.userRetryable || isCredentialExhausted,
-      isRelayError: isRelay,
-      isCredentialExhausted: isCredentialExhausted || undefined,
-      isUpstreamCreditDepleted: isUpstreamCreditDepleted || undefined,
-      isChatGptSubscriptionLimited: isChatGptSubscriptionLimited || undefined,
-      rawErrorBody,
-      streamDiagnostics,
-      partialText,
     };
   }
 
@@ -234,19 +242,13 @@ export function formatProviderHttpError(err: unknown): ProviderError {
     (statusCode ? isRetryableStatusCode(statusCode) : true);
 
   return {
+    ...classification,
     message: chatgptSubscriptionMessage ?? message,
     statusCode,
     statusText,
     provider,
     userRetryable,
-    isRelayError: isRelay,
-    isCredentialExhausted: isCredentialExhausted || undefined,
-    isUpstreamCreditDepleted: isUpstreamCreditDepleted || undefined,
-    isChatGptSubscriptionLimited: isChatGptSubscriptionLimited || undefined,
     requestId,
-    rawErrorBody,
-    streamDiagnostics,
-    partialText,
   };
 }
 

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -38,3 +38,10 @@ export {
 } from './sdkError/providerErrorFormat';
 
 export { isRelayMonthlyLimitMessage } from './sdkError/relayDetection';
+
+export {
+  isChatGptSubscriptionLimitBody,
+  parseChatGptSubscriptionLimit,
+  describeChatGptSubscriptionLimit,
+  type ChatGptSubscriptionLimit,
+} from './sdkError/chatgptSubscriptionDetection';

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -40,7 +40,6 @@ export {
 export { isRelayMonthlyLimitMessage } from './sdkError/relayDetection';
 
 export {
-  isChatGptSubscriptionLimitBody,
   parseChatGptSubscriptionLimit,
   describeChatGptSubscriptionLimit,
   type ChatGptSubscriptionLimit,

--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -79,10 +79,15 @@ export class ProgressApiKeyRetryController {
       };
     }
 
+    // Disable relay (included access) so the retry uses the user's own key —
+    // not the relay JWT — whenever the switch promises "your own API key".
+    // Both relay exhaustion (viaRelay) and subscription exhaustion
+    // (chatgptSubscription) fall through to `super.getApiKey()`, which otherwise
+    // still prefers relay when included access is on, so the retry would never
+    // reach the stored OpenAI key the UI describes. A direct-key failure
+    // (neither flag) leaves relay untouched for other providers.
     let disabledIncludedModelAccess = false;
-    // Only disable relay access when the failing call actually went through
-    // relay. Direct-key failures should not revoke relay for other providers.
-    if (request.viaRelay === true) {
+    if (request.viaRelay === true || request.chatgptSubscription === true) {
       await this.deps.setUseIncludedModelAccess(false);
       this.deps.invalidateModelOptionsCache();
       disabledIncludedModelAccess = true;

--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -9,12 +9,18 @@ export interface ProgressApiKeyRetryRequest {
   provider?: ApiProvider;
   upstreamCreditDepleted?: boolean;
   viaRelay?: boolean;
+  /** True when the failing request ran through the ChatGPT subscription
+   *  (Codex backend) and hit its usage limit. Accepting the switch turns off
+   *  the "prefer ChatGPT subscription" preference so the retry routes through
+   *  the user's OpenAI API key instead. Orthogonal to `viaRelay`. */
+  chatgptSubscription?: boolean;
 }
 
 export interface ProgressApiKeyRetryResult {
   proceeded: boolean;
   retried: boolean;
   disabledIncludedModelAccess: boolean;
+  disabledChatGptSubscription: boolean;
 }
 
 export interface ProgressApiKeyRetryControllerDeps {
@@ -23,6 +29,9 @@ export interface ProgressApiKeyRetryControllerDeps {
   hasUsableKey(provider: ApiProvider): Promise<boolean>;
   promptForApiKey(provider?: ApiProvider): Promise<void>;
   setUseIncludedModelAccess(enabled: boolean): Promise<void>;
+  /** Turn off the "prefer ChatGPT subscription" (Codex) preference so
+   *  Codex-eligible models fall back to the OpenAI API-key path. */
+  disablePreferCodexSubscription(): Promise<void>;
   invalidateModelOptionsCache(): void;
   triggerRetry(stream: StreamTabId): boolean;
 }
@@ -66,6 +75,7 @@ export class ProgressApiKeyRetryController {
         proceeded: false,
         retried: false,
         disabledIncludedModelAccess: false,
+        disabledChatGptSubscription: false,
       };
     }
 
@@ -78,10 +88,20 @@ export class ProgressApiKeyRetryController {
       disabledIncludedModelAccess = true;
     }
 
+    // The subscription quota is exhausted, so turn off the preference and let
+    // Codex-eligible models route through the now-usable OpenAI key on retry.
+    let disabledChatGptSubscription = false;
+    if (request.chatgptSubscription === true) {
+      await this.deps.disablePreferCodexSubscription();
+      this.deps.invalidateModelOptionsCache();
+      disabledChatGptSubscription = true;
+    }
+
     return {
       proceeded: true,
       retried: this.deps.triggerRetry(request.stream),
       disabledIncludedModelAccess,
+      disabledChatGptSubscription,
     };
   }
 

--- a/src/shared/schemas/errors.ts
+++ b/src/shared/schemas/errors.ts
@@ -110,6 +110,21 @@ export const ProviderErrorPartialSchema = z.preprocess(
 );
 export type ProviderErrorPartial = z.infer<typeof ProviderErrorPartialSchema>;
 
+/** Single source of truth for "this error is a ChatGPT-subscription (Codex)
+ *  usage-limit rejection". Both hosts (VS Code progress view, CLI approval
+ *  policy) branch on this to switch the retry from the relay/personal-key path
+ *  to disabling the subscription preference. Accepts any error shape carrying
+ *  the flag (full `ProviderError`, `ProviderErrorPartial`, or `RetryErrorInfo`)
+ *  so the predicate stays the one place that owns the verdict. */
+export function isChatGptSubscriptionLimitError(
+  errorDetails:
+    | Pick<ProviderError, 'isChatGptSubscriptionLimited'>
+    | undefined
+    | null,
+): boolean {
+  return errorDetails?.isChatGptSubscriptionLimited === true;
+}
+
 /**
  * Minimal error info for retry state tracking.
  *

--- a/src/shared/schemas/errors.ts
+++ b/src/shared/schemas/errors.ts
@@ -64,6 +64,13 @@ const ProviderErrorObjectSchema = z.object({
    *  uses this to require a new key rather than reusing the depleted
    *  stored credential. */
   isUpstreamCreditDepleted: z.boolean().optional(),
+  /** True when a ChatGPT-subscription (Codex) request was rejected because the
+   *  plan's usage quota is exhausted. Like the relay monthly limit it is a
+   *  credential exhaustion (auto-retry suppressed, "Use your own API key"
+   *  offered), but accepting that switch disables the "prefer ChatGPT
+   *  subscription" preference and retries through the OpenAI API key rather
+   *  than disabling relay. */
+  isChatGptSubscriptionLimited: z.boolean().optional(),
   requestId: z.string().optional(),
   rawErrorBody: z.unknown().optional(),
   streamDiagnostics: StreamDiagnosticsSchema.optional(),

--- a/src/shared/schemas/progressView/inbound.ts
+++ b/src/shared/schemas/progressView/inbound.ts
@@ -158,6 +158,10 @@ const UseOwnApiKeyMessageSchema = StreamScopedBaseSchema.extend({
    *  must not globally disable relay access — other providers may still
    *  be served successfully by relay. */
   viaRelay: z.boolean().optional(),
+  /** True when the failing request went through the ChatGPT subscription
+   *  (Codex) and hit its usage limit. The handler turns off the "prefer
+   *  ChatGPT subscription" preference so the retry uses the OpenAI key. */
+  chatgptSubscription: z.boolean().optional(),
 });
 
 const ToggleToolEditApprovalBypassMessageSchema = StreamScopedBaseSchema.extend(

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -14,7 +14,7 @@ import {
   LATEX_FORMATTER_VALUES,
   LATEXDIFF_MATH_MARKUP_VALUES,
 } from '@shared/constants/latex';
-import { WorkspaceStateKey } from '@shared/state/stateKeys';
+import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 
 /**
  * Host-neutral catalog for **state-backed** TeXRA settings.
@@ -262,6 +262,23 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
       'Format with tex-fmt.',
       'Do not run any formatter.',
     ],
+  },
+
+  // --- OpenAI WebSocket transport (experimental) -----------------------------
+  // Read by `getWebSocketEnabled()` and consumed by the OpenAI Responses handler
+  // the CLI runs. Enables the persistent WebSocket transport for the direct
+  // OpenAI endpoint — and, experimentally, lets the ChatGPT-subscription Codex
+  // backend attempt WebSocket. Surfaced to the CLI so it can be toggled and
+  // tested there.
+  {
+    key: GlobalStateKey.WEBSOCKET_OPENAI,
+    schema: z.boolean().prefault(false),
+    description:
+      'EXPERIMENTAL: use the persistent WebSocket transport for OpenAI Responses requests (lower latency for tool-use loops), and let the ChatGPT-subscription Codex backend attempt WebSocket. Off by default.',
+    category: 'model',
+    store: 'globalState',
+    hosts: ['cli'],
+    cliConsumer: 'src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts',
   },
 ] as const;
 

--- a/src/test-kernel/agent/modelHandlers/CodexEncryptedReasoning.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/CodexEncryptedReasoning.vitest.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_MODEL_CAPABILITIES, ModelProvider } from 'llm-zoo';
+
+import type { AgentTrace } from '@agent/trace';
+import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/openai/modelHandlerOpenAIResponse';
+import { ModelHandlerCodex } from '@agent/modelHandlers/openai/modelHandlerCodex';
+import type { ModelConfig } from 'llm-zoo';
+import type { Response } from 'openai/resources/responses/responses';
+
+function loggerStub(): AgentTrace {
+  return {
+    streamId: 'test',
+    debug: () => undefined,
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    domain: () => undefined,
+  } as unknown as AgentTrace;
+}
+
+function config(): ModelConfig {
+  return {
+    name: 'gpt-5.5',
+    fullName: 'gpt-5.5',
+    shortName: 'gpt-5.5',
+    label: 'GPT-5.5',
+    provider: ModelProvider.OPENAI,
+    maxOutputTokens: 1024,
+    inputPrice: 0,
+    outputPrice: 0,
+    contextWindow: 200_000,
+    capabilities: { ...DEFAULT_MODEL_CAPABILITIES, supportsReasoning: true },
+    openRouterOnly: false,
+  };
+}
+
+function baseHandler(): ModelHandlerOpenAIResponse {
+  const h = new ModelHandlerOpenAIResponse(config());
+  h.setLogger(loggerStub());
+  return h;
+}
+
+function codexHandler(): ModelHandlerCodex {
+  const h = new ModelHandlerCodex(config());
+  h.setLogger(loggerStub());
+  return h;
+}
+
+const reasoning = (enc: string) =>
+  ({ type: 'reasoning', summary: [], encrypted_content: enc }) as never;
+const webSearch = () => ({ type: 'web_search_call', id: 'ws1' }) as never;
+const functionCall = () =>
+  ({
+    type: 'function_call',
+    call_id: 'c1',
+    name: 'foo',
+    arguments: '{}',
+  }) as never;
+
+function responseWith(output: unknown[]): Response {
+  return { output } as unknown as Response;
+}
+
+function encryptedBlobs(blocks: ReadonlyArray<{ type?: string }>): string[] {
+  return blocks
+    .filter((b) => b.type === 'reasoning')
+    .map((b) => (b as { encrypted_content?: string }).encrypted_content ?? '');
+}
+
+describe('extractServerToolData reasoning preservation by store mode', () => {
+  it('store:false (Codex) preserves every reasoning item carrying encrypted_content', () => {
+    const response = responseWith([reasoning('enc1'), functionCall()]);
+
+    // store:true base: no web_search_call, so no reasoning is preserved.
+    expect(baseHandler().extractServerToolData(response).contentBlocks).toEqual(
+      [],
+    );
+
+    // store:false Codex: the reasoning item is preserved for replay.
+    const codexBlocks =
+      codexHandler().extractServerToolData(response).contentBlocks;
+    expect(encryptedBlobs(codexBlocks)).toEqual(['enc1']);
+  });
+
+  it('preserves reasoning + web_search in output order, store:true keeps only the paired reasoning', () => {
+    const response = responseWith([
+      reasoning('enc1'),
+      webSearch(),
+      reasoning('enc2'),
+      functionCall(),
+    ]);
+
+    // store:true: reasoning-before-web_search + the web_search; the
+    // function_call-preceding reasoning (enc2) is NOT kept (it's server-side).
+    const baseBlocks =
+      baseHandler().extractServerToolData(response).contentBlocks;
+    expect(baseBlocks.map((b) => b.type)).toEqual([
+      'reasoning',
+      'web_search_call',
+    ]);
+    expect(encryptedBlobs(baseBlocks)).toEqual(['enc1']);
+
+    // store:false: every reasoning item + web_search, in output order, so the
+    // last reasoning still immediately precedes the replayed function_call.
+    const codexBlocks =
+      codexHandler().extractServerToolData(response).contentBlocks;
+    expect(codexBlocks.map((b) => b.type)).toEqual([
+      'reasoning',
+      'web_search_call',
+      'reasoning',
+    ]);
+    expect(encryptedBlobs(codexBlocks)).toEqual(['enc1', 'enc2']);
+  });
+});

--- a/src/test-kernel/agent/modelHandlers/CodexEncryptedReasoning.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/CodexEncryptedReasoning.vitest.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { DEFAULT_MODEL_CAPABILITIES, ModelProvider } from 'llm-zoo';
 
 import type { AgentTrace } from '@agent/trace';
@@ -68,6 +68,30 @@ function encryptedBlobs(blocks: ReadonlyArray<{ type?: string }>): string[] {
 }
 
 describe('extractServerToolData reasoning preservation by store mode', () => {
+  // The store:false (encrypted-reasoning) path is gated on the subscription
+  // being active; turning it off drops the Codex handler to base behavior.
+  beforeEach(async () => {
+    const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
+      import('@platform/platform'),
+      import('@test/support/FakePlatform'),
+    ]);
+    initPlatform(
+      createFakePlatform({
+        config: { 'texra.chatgptCodex.preferSubscription': true },
+      }),
+    );
+  });
+
+  it('skips reasoning items that carry no encrypted_content (would be rejected empty)', () => {
+    const summaryOnly = { type: 'reasoning', summary: [] } as never;
+    const response = responseWith([summaryOnly, reasoning('enc1')]);
+
+    const codexBlocks =
+      codexHandler().extractServerToolData(response).contentBlocks;
+    // Only the blob-carrying item survives.
+    expect(encryptedBlobs(codexBlocks)).toEqual(['enc1']);
+  });
+
   it('store:false (Codex) preserves every reasoning item carrying encrypted_content', () => {
     const response = responseWith([reasoning('enc1'), functionCall()]);
 

--- a/src/test-kernel/agent/modelHandlers/CodexExperimentalTransports.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/CodexExperimentalTransports.vitest.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  DEFAULT_MODEL_CAPABILITIES,
+  ModelProvider,
+  type ModelConfig,
+} from 'llm-zoo';
+
+import { ModelHandlerCodex } from '@agent/modelHandlers/openai/modelHandlerCodex';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { resetCodexCoordinator } from '@auth/codex';
+
+// Protected/private surface exercised by these tests via a narrow cast.
+interface CodexInternals {
+  storesResponsesServerSide: boolean;
+  isWebSocketModeEnabled(): boolean;
+}
+
+function config(): ModelConfig {
+  return {
+    name: 'gpt-5.5',
+    fullName: 'gpt-5.5',
+    shortName: 'gpt-5.5',
+    label: 'GPT-5.5',
+    provider: ModelProvider.OPENAI,
+    maxOutputTokens: 1024,
+    inputPrice: 0,
+    outputPrice: 0,
+    contextWindow: 200_000,
+    capabilities: { ...DEFAULT_MODEL_CAPABILITIES, supportsReasoning: true },
+    openRouterOnly: false,
+  };
+}
+
+async function initPlatformWith(opts: {
+  config?: Record<string, unknown>;
+  globalState?: Record<string, unknown>;
+}): Promise<void> {
+  const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
+    import('@platform/platform'),
+    import('@test/support/FakePlatform'),
+  ]);
+  initPlatform(
+    createFakePlatform({
+      config: {
+        'texra.chatgptCodex.preferSubscription': true,
+        ...opts.config,
+      },
+      globalState: opts.globalState,
+    }),
+  );
+}
+
+function workflowHandler(): ModelHandlerCodex {
+  const handler = new ModelHandlerCodex(config());
+  // Background mode is only eligible for workflow agents on GPT-family models.
+  handler.setAgentCategory(AgentCategory.Workflow);
+  return handler;
+}
+
+describe('Codex background/websocket transports follow the shared toggles', () => {
+  afterEach(() => {
+    resetCodexCoordinator();
+  });
+
+  it('stays streaming + store:false when the shared background toggle is off', async () => {
+    await initPlatformWith({
+      config: { 'texra.model.useBackgroundResponses': false },
+    });
+    const handler = workflowHandler();
+
+    expect(handler.isBackgroundModeActive()).toBe(false);
+    expect(handler.getStreamingConfig()).toBe(true);
+    expect(
+      (handler as unknown as CodexInternals).storesResponsesServerSide,
+    ).toBe(false);
+    expect(
+      (handler as unknown as CodexInternals).isWebSocketModeEnabled(),
+    ).toBe(false);
+  });
+
+  it('activates background mode (store:true, non-streaming) from the same useBackgroundResponses toggle', async () => {
+    await initPlatformWith({
+      config: { 'texra.model.useBackgroundResponses': true },
+    });
+    const handler = workflowHandler();
+
+    expect(handler.isBackgroundModeActive()).toBe(true);
+    // Background polls, so streaming is off and the response is stored server-side
+    // (which also disables encrypted-reasoning replay — store:true path).
+    expect(handler.getStreamingConfig()).toBe(false);
+    expect(
+      (handler as unknown as CodexInternals).storesResponsesServerSide,
+    ).toBe(true);
+  });
+
+  it('enables WebSocket against the Codex backend from the global websocket toggle', async () => {
+    await initPlatformWith({
+      config: { 'texra.model.useBackgroundResponses': false },
+      globalState: { 'texra.websocket.openai': true },
+    });
+    const handler = workflowHandler();
+
+    expect(
+      (handler as unknown as CodexInternals).isWebSocketModeEnabled(),
+    ).toBe(true);
+  });
+});

--- a/src/test-kernel/agent/modelHandlers/CodexRequestRewrite.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/CodexRequestRewrite.vitest.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CODEX_DEFAULT_INSTRUCTIONS,
+  isGenerationRequest,
+  rewriteCodexRequestBody,
+} from '@agent/modelHandlers/openai/modelHandlerCodex';
+
+/**
+ * Golden fixtures for the reverse-engineered Codex `/responses` wire contract.
+ * The backend is unofficial and unvalidatable from a schema, so the request
+ * shape this code emits IS the spec — each fixture pins one named invariant
+ * from {@link rewriteCodexRequestBody}'s contract. A change here is a
+ * deliberate change to what we send Codex.
+ */
+describe('rewriteCodexRequestBody', () => {
+  it('drops max_output_tokens and forces the stateless streaming shape', () => {
+    expect(
+      rewriteCodexRequestBody({
+        model: 'gpt-5.5',
+        max_output_tokens: 1024,
+        input: [{ role: 'user', content: 'Hello' }],
+      }),
+    ).toEqual({
+      model: 'gpt-5.5',
+      store: false,
+      stream: true,
+      input: [{ role: 'user', content: 'Hello' }],
+      instructions: CODEX_DEFAULT_INSTRUCTIONS,
+    });
+  });
+
+  it('drops a non-background-mode background flag and forces store/stream', () => {
+    const out = rewriteCodexRequestBody({
+      background: false,
+      store: true,
+      stream: false,
+      input: [{ role: 'user', content: 'hi' }],
+    });
+    expect(out).not.toHaveProperty('background');
+    expect(out.store).toBe(false);
+    expect(out.stream).toBe(true);
+  });
+
+  it('hoists system/developer items into instructions and keeps the rest of input', () => {
+    expect(
+      rewriteCodexRequestBody({
+        input: [
+          { role: 'system', content: 'You are Codex.' },
+          { role: 'developer', content: 'Be terse.' },
+          { role: 'user', content: 'Solve x+1=2.' },
+        ],
+      }),
+    ).toEqual({
+      store: false,
+      stream: true,
+      instructions: 'You are Codex.\n\nBe terse.',
+      input: [{ role: 'user', content: 'Solve x+1=2.' }],
+    });
+  });
+
+  it('flattens typed content parts when hoisting instructions', () => {
+    const out = rewriteCodexRequestBody({
+      input: [
+        {
+          role: 'developer',
+          content: [
+            { type: 'input_text', text: 'Be terse.' },
+            { type: 'input_text', text: 'Use SI units.' },
+          ],
+        },
+        { role: 'user', content: 'go' },
+      ],
+    });
+    expect(out.instructions).toBe('Be terse.\nUse SI units.');
+    expect(out.input).toEqual([{ role: 'user', content: 'go' }]);
+  });
+
+  it('prepends an existing top-level instructions string before hoisted text', () => {
+    const out = rewriteCodexRequestBody({
+      instructions: 'Top instr.',
+      input: [
+        { role: 'system', content: 'Sys instr.' },
+        { role: 'user', content: 'hi' },
+      ],
+    });
+    expect(out.instructions).toBe('Top instr.\n\nSys instr.');
+  });
+
+  it('does not duplicate hoisted text already covered by existing instructions', () => {
+    const out = rewriteCodexRequestBody({
+      instructions: 'Base policy applies here.',
+      input: [
+        { role: 'system', content: 'Base policy' },
+        { role: 'user', content: 'hi' },
+      ],
+    });
+    // "Base policy" is a substring of the existing instruction, so it is not
+    // re-appended.
+    expect(out.instructions).toBe('Base policy applies here.');
+  });
+
+  it('falls back to the default instructions when none can be derived', () => {
+    const out = rewriteCodexRequestBody({
+      input: [{ role: 'user', content: 'hi' }],
+    });
+    expect(out.instructions).toBe(CODEX_DEFAULT_INSTRUCTIONS);
+  });
+
+  it('leaves transport fields untouched in background mode but still normalizes', () => {
+    expect(
+      rewriteCodexRequestBody({
+        background: true,
+        store: true,
+        max_output_tokens: 50,
+        input: [
+          { role: 'system', content: 'S' },
+          { role: 'user', content: 'u' },
+        ],
+      }),
+    ).toEqual({
+      // background + store preserved, no stream forced, max_output_tokens gone,
+      // instructions still hoisted.
+      background: true,
+      store: true,
+      instructions: 'S',
+      input: [{ role: 'user', content: 'u' }],
+    });
+  });
+
+  it('is pure — it never mutates the caller body', () => {
+    const body = {
+      max_output_tokens: 10,
+      input: [
+        { role: 'system', content: 'S' },
+        { role: 'user', content: 'u' },
+      ],
+    };
+    const snapshot = structuredClone(body);
+    rewriteCodexRequestBody(body);
+    expect(body).toEqual(snapshot);
+  });
+});
+
+describe('isGenerationRequest', () => {
+  it('matches only the generation endpoint, not token counting', () => {
+    expect(
+      isGenerationRequest('https://chatgpt.com/backend-api/codex/responses'),
+    ).toBe(true);
+    expect(
+      isGenerationRequest(
+        'https://chatgpt.com/backend-api/codex/responses/input_tokens',
+      ),
+    ).toBe(false);
+    expect(isGenerationRequest('https://api.openai.com/v1/responses')).toBe(
+      true,
+    );
+  });
+});

--- a/src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  DEFAULT_MODEL_CAPABILITIES,
+  ModelProvider,
+  type ModelConfig,
+} from 'llm-zoo';
+
+import { ModelHandlerCodex } from '@agent/modelHandlers/openai/modelHandlerCodex';
+import {
+  CODEX_BACKEND_BASE_URL,
+  resetCodexCoordinator,
+  setPreferCodexSubscription,
+} from '@auth/codex';
+import { setServerSideKeyService } from '@auth/serverKeys';
+
+import type { ResponseUsage } from 'openai/resources/responses/responses';
+
+// Dynamic import keeps `initPlatform` out of the static import graph (it is
+// restricted to composition roots); the routing tests use the same pattern.
+async function initFakePlatformWithSubscription(): Promise<void> {
+  const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
+    import('@platform/platform'),
+    import('@test/support/FakePlatform'),
+  ]);
+  initPlatform(
+    createFakePlatform({
+      config: { 'texra.chatgptCodex.preferSubscription': true },
+    }),
+  );
+}
+
+const config: ModelConfig = {
+  name: 'gpt55-test',
+  label: 'GPT-5.5',
+  fullName: 'gpt-5.5',
+  shortName: 'gpt-5.5',
+  provider: ModelProvider.OPENAI,
+  maxOutputTokens: 1024,
+  inputPrice: 2,
+  outputPrice: 8,
+  contextWindow: 128_000,
+  capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
+  openRouterOnly: false,
+};
+
+const ONE_MILLION_INPUT_TOKENS = {
+  input_tokens: 1_000_000,
+  output_tokens: 0,
+} as ResponseUsage;
+
+describe('ModelHandlerCodex subscription fallback', () => {
+  beforeEach(() => {
+    // The fallback path resolves the OpenAI base via the relay service; stub it
+    // to "no relay" so getBaseUrl() yields the direct OpenAI base.
+    setServerSideKeyService({
+      shouldUseServerSideKeysSync: () => false,
+    } as never);
+  });
+
+  afterEach(() => {
+    resetCodexCoordinator();
+  });
+
+  it('targets the Codex backend and zero-rates usage while the preference is on', async () => {
+    await initFakePlatformWithSubscription();
+
+    const handler = new ModelHandlerCodex(config);
+    expect(handler.getBaseUrl()).toBe(CODEX_BACKEND_BASE_URL);
+    expect(handler.computePrice(ONE_MILLION_INPUT_TOKENS)).toBe(0);
+  });
+
+  it('falls back to the OpenAI API-key path when the preference is turned off mid-run', async () => {
+    await initFakePlatformWithSubscription();
+
+    const handler = new ModelHandlerCodex(config);
+    expect(handler.getBaseUrl()).toBe(CODEX_BACKEND_BASE_URL);
+
+    // The "Use your own API key" switch flips this preference; the same handler
+    // instance must reroute on the next request without being recreated.
+    await setPreferCodexSubscription(false);
+
+    expect(handler.getBaseUrl()).not.toBe(CODEX_BACKEND_BASE_URL);
+    expect(handler.computePrice(ONE_MILLION_INPUT_TOKENS)).toBeGreaterThan(0);
+  });
+});

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponseBackground.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponseBackground.vitest.ts
@@ -95,9 +95,20 @@ describe('ModelHandlerOpenAIResponse background mode', () => {
     assert.equal(handler.getStreamingConfig(), true);
   });
 
-  it('keeps Codex subscription handlers out of background mode', () => {
+  it('lets Codex subscription handlers follow the shared background toggle', () => {
+    // Codex no longer vetoes background mode; it uses the same
+    // useBackgroundResponses toggle (default on) + workflow/GPT eligibility, so
+    // the behavior can be tested against the backend in practice.
     const handler = new ModelHandlerCodex(createOpenAIConfig('gpt-5'));
     handler.setAgentCategory(AgentCategory.Workflow);
+
+    assert.equal(handler.isBackgroundModeActive(), true);
+    assert.equal(handler.getStreamingConfig(), false);
+  });
+
+  it('keeps Codex tool-use agents on streaming requests by default', () => {
+    const handler = new ModelHandlerCodex(createOpenAIConfig('gpt-5'));
+    handler.setAgentCategory(AgentCategory.ToolUse);
 
     assert.equal(handler.isBackgroundModeActive(), false);
     assert.equal(handler.getStreamingConfig(), true);

--- a/src/test-kernel/architecture/dependencyDirection.vitest.ts
+++ b/src/test-kernel/architecture/dependencyDirection.vitest.ts
@@ -1,0 +1,104 @@
+// Node imports
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Architecture ratchet: the platform-independent ("VS Code-free") source zones
+ * must never import the `vscode` module. They reach host services through
+ * `platform()` / host adapters instead (see CLAUDE.md "Separation of Concerns").
+ *
+ * This duplicates the guard already enforced by the `local/no-vscode-import-in-
+ * free-zones` ESLint rule, on purpose: a stray `// eslint-disable` line can
+ * silently neuter the lint rule, but it cannot bypass a test in the `npm test`
+ * gate. The two layers are independent on purpose — if you add a zone here, add
+ * it to `VSCODE_FREE_ZONE_DIRS` in `eslint.config.mjs` too (and vice versa).
+ */
+
+const REPO_ROOT = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../..',
+);
+
+// Keep in sync with `VSCODE_FREE_ZONE_DIRS` in eslint.config.mjs.
+const VSCODE_FREE_ZONES = [
+  'src/agent',
+  'src/model',
+  'src/latex',
+  'src/tools',
+  'src/controllers',
+  'src/shared',
+  'src/replacement',
+  'src/eventBus',
+  'src/hosts',
+  'packages/extension/src/webview/frontend',
+  'packages/extension/src/progressView/frontend',
+  'packages/extension/src/settingsView/frontend',
+] as const;
+
+const SOURCE_FILE = /\.(?:ts|tsx|mts)$/;
+
+// `import … from 'vscode'` / `export … from 'vscode'`, CommonJS `require('vscode')`
+// (incl. `import x = require('vscode')`), and dynamic `import('vscode')`.
+const VSCODE_IMPORT_PATTERNS = [
+  /\bfrom\s+['"]vscode['"]/,
+  /\brequire\s*\(\s*['"]vscode['"]\s*\)/,
+  /\bimport\s*\(\s*['"]vscode['"]\s*\)/,
+];
+
+/** Drop comments so a prose mention like "do not import from 'vscode'" can't
+ *  trip the import patterns. Naive `//` stripping is fine here: a real import
+ *  precedes any trailing comment, and cutting mid-string only matters on lines
+ *  that never contain a `vscode` import anyway. */
+function stripComments(source: string): string {
+  return source
+    .replaceAll(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .map((line) => {
+      const commentStart = line.indexOf('//');
+      return commentStart === -1 ? line : line.slice(0, commentStart);
+    })
+    .join('\n');
+}
+
+function sourceFilesUnder(zone: string): string[] {
+  const absoluteZone = resolve(REPO_ROOT, zone);
+  let entries: string[];
+  try {
+    entries = readdirSync(absoluteZone, { recursive: true }) as string[];
+  } catch {
+    // A renamed/removed zone surfaces as the file-count guard below failing,
+    // not as a silently green ratchet.
+    return [];
+  }
+  return entries
+    .filter((rel) => SOURCE_FILE.test(rel) && !rel.endsWith('.d.ts'))
+    .map((rel) => join(absoluteZone, rel));
+}
+
+function importsVscode(file: string): boolean {
+  const source = stripComments(readFileSync(file, 'utf8'));
+  return VSCODE_IMPORT_PATTERNS.some((pattern) => pattern.test(source));
+}
+
+describe('VS Code-free zones never import vscode', () => {
+  for (const zone of VSCODE_FREE_ZONES) {
+    it(`${zone} has no vscode imports`, () => {
+      const offenders = sourceFilesUnder(zone)
+        .filter(importsVscode)
+        .map((file) => relative(REPO_ROOT, file));
+      expect(offenders).toEqual([]);
+    });
+  }
+
+  it('actually scans the zones (guards against a broken file walk)', () => {
+    const scanned = VSCODE_FREE_ZONES.reduce(
+      (total, zone) => total + sourceFilesUnder(zone).length,
+      0,
+    );
+    expect(scanned).toBeGreaterThan(100);
+  });
+});

--- a/src/test-kernel/common/ChatGptSubscriptionDetection.vitest.ts
+++ b/src/test-kernel/common/ChatGptSubscriptionDetection.vitest.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 import {
   describeChatGptSubscriptionLimit,
   formatProviderHttpError,
-  isChatGptSubscriptionLimitBody,
   parseChatGptSubscriptionLimit,
 } from '@common/errors/sdkErrorUtils';
 
@@ -22,9 +21,7 @@ describe('parseChatGptSubscriptionLimit', () => {
     expect(limit).toEqual({
       planType: 'pro',
       resetsInSeconds: 159728,
-      resetsAt: 1782634869,
     });
-    expect(isChatGptSubscriptionLimitBody(USAGE_LIMIT_BODY)).toBe(true);
   });
 
   it('parses the SDK-enveloped { error } form', () => {
@@ -38,7 +35,7 @@ describe('parseChatGptSubscriptionLimit', () => {
       null,
     );
     expect(parseChatGptSubscriptionLimit(undefined)).toBe(null);
-    expect(isChatGptSubscriptionLimitBody({ message: 'nope' })).toBe(false);
+    expect(parseChatGptSubscriptionLimit({ message: 'nope' })).toBe(null);
   });
 
   it('formats a human-readable reset hint', () => {

--- a/src/test-kernel/common/ChatGptSubscriptionDetection.vitest.ts
+++ b/src/test-kernel/common/ChatGptSubscriptionDetection.vitest.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  describeChatGptSubscriptionLimit,
+  formatProviderHttpError,
+  isChatGptSubscriptionLimitBody,
+  parseChatGptSubscriptionLimit,
+} from '@common/errors/sdkErrorUtils';
+
+const USAGE_LIMIT_BODY = {
+  type: 'usage_limit_reached',
+  message: 'The usage limit has been reached',
+  plan_type: 'pro',
+  resets_at: 1782634869,
+  eligible_promo: null,
+  resets_in_seconds: 159728,
+} as const;
+
+describe('parseChatGptSubscriptionLimit', () => {
+  it('parses a direct Codex usage-limit body', () => {
+    const limit = parseChatGptSubscriptionLimit(USAGE_LIMIT_BODY);
+    expect(limit).toEqual({
+      planType: 'pro',
+      resetsInSeconds: 159728,
+      resetsAt: 1782634869,
+    });
+    expect(isChatGptSubscriptionLimitBody(USAGE_LIMIT_BODY)).toBe(true);
+  });
+
+  it('parses the SDK-enveloped { error } form', () => {
+    expect(
+      parseChatGptSubscriptionLimit({ error: USAGE_LIMIT_BODY })?.planType,
+    ).toBe('pro');
+  });
+
+  it('ignores unrelated bodies', () => {
+    expect(parseChatGptSubscriptionLimit({ type: 'rate_limit_exceeded' })).toBe(
+      null,
+    );
+    expect(parseChatGptSubscriptionLimit(undefined)).toBe(null);
+    expect(isChatGptSubscriptionLimitBody({ message: 'nope' })).toBe(false);
+  });
+
+  it('formats a human-readable reset hint', () => {
+    const text = describeChatGptSubscriptionLimit({
+      planType: 'pro',
+      resetsInSeconds: 159728,
+    });
+    expect(text).toContain('Pro plan');
+    expect(text).toContain('Resets in 1d 20h');
+    expect(text).toContain('OpenAI API key');
+  });
+});
+
+describe('formatProviderHttpError for ChatGPT subscription limits', () => {
+  it('classifies a usage-limit error as a switchable credential exhaustion', () => {
+    const error = new Error('codex backend rejected the request') as Error & {
+      error: unknown;
+      provider?: string;
+    };
+    error.error = USAGE_LIMIT_BODY;
+    error.provider = 'openai';
+
+    const providerError = formatProviderHttpError(error);
+
+    expect(providerError.isChatGptSubscriptionLimited).toBe(true);
+    expect(providerError.isCredentialExhausted).toBe(true);
+    // The stored OpenAI key is NOT the broken credential, so no key change is
+    // forced (that flag is reserved for upstream credit depletion).
+    expect(providerError.isUpstreamCreditDepleted).toBeUndefined();
+    expect(providerError.userRetryable).toBe(true);
+    expect(providerError.message).toContain('ChatGPT subscription usage limit');
+  });
+});

--- a/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
@@ -26,6 +26,7 @@ function createHarness(options: HarnessOptions = {}): {
   keys: Map<ApiProvider, string | undefined>;
   prompts: Array<ApiProvider | undefined>;
   includedAccessValues: boolean[];
+  codexDisableCount: number;
   invalidations: number;
   retries: string[];
 } {
@@ -36,6 +37,7 @@ function createHarness(options: HarnessOptions = {}): {
   );
   const prompts: Array<ApiProvider | undefined> = [];
   const includedAccessValues: boolean[] = [];
+  let codexDisableCount = 0;
   let invalidations = 0;
   const retries: string[] = [];
 
@@ -43,6 +45,9 @@ function createHarness(options: HarnessOptions = {}): {
     keys,
     prompts,
     includedAccessValues,
+    get codexDisableCount() {
+      return codexDisableCount;
+    },
     get invalidations() {
       return invalidations;
     },
@@ -58,6 +63,9 @@ function createHarness(options: HarnessOptions = {}): {
       },
       setUseIncludedModelAccess: async (enabled) => {
         includedAccessValues.push(enabled);
+      },
+      disablePreferCodexSubscription: async () => {
+        codexDisableCount += 1;
       },
       invalidateModelOptionsCache: () => {
         invalidations += 1;
@@ -90,6 +98,7 @@ describe('ProgressApiKeyRetryController', () => {
       proceeded: true,
       retried: true,
       disabledIncludedModelAccess: true,
+      disabledChatGptSubscription: false,
     });
     assert.deepEqual(harness.prompts, ['anthropic']);
     assert.deepEqual(harness.includedAccessValues, [false]);
@@ -116,6 +125,7 @@ describe('ProgressApiKeyRetryController', () => {
       proceeded: false,
       retried: false,
       disabledIncludedModelAccess: false,
+      disabledChatGptSubscription: false,
     });
     assert.deepEqual(harness.prompts, ['anthropic']);
     assert.deepEqual(harness.includedAccessValues, []);
@@ -141,6 +151,7 @@ describe('ProgressApiKeyRetryController', () => {
       proceeded: true,
       retried: true,
       disabledIncludedModelAccess: true,
+      disabledChatGptSubscription: false,
     });
     assert.deepEqual(harness.prompts, [undefined]);
     assert.deepEqual(harness.includedAccessValues, [false]);
@@ -162,6 +173,7 @@ describe('ProgressApiKeyRetryController', () => {
       proceeded: true,
       retried: true,
       disabledIncludedModelAccess: true,
+      disabledChatGptSubscription: false,
     });
     assert.deepEqual(harness.prompts, [undefined]);
     assert.deepEqual(harness.includedAccessValues, [false]);
@@ -185,9 +197,53 @@ describe('ProgressApiKeyRetryController', () => {
       proceeded: true,
       retried: false,
       disabledIncludedModelAccess: false,
+      disabledChatGptSubscription: false,
     });
     assert.deepEqual(harness.includedAccessValues, []);
     assert.equal(harness.invalidations, 0);
     assert.deepEqual(harness.retries, ['stream-c']);
+  });
+
+  it('disables the ChatGPT subscription and retries with a usable OpenAI key', async () => {
+    const harness = createHarness({
+      keys: { openai: 'stored-openai' },
+    });
+
+    const result = await harness.controller.useOwnApiKey({
+      stream: 'stream-d',
+      provider: 'openai',
+      chatgptSubscription: true,
+    });
+
+    assert.deepEqual(result, {
+      proceeded: true,
+      retried: true,
+      disabledIncludedModelAccess: false,
+      disabledChatGptSubscription: true,
+    });
+    assert.deepEqual(harness.prompts, ['openai']);
+    assert.deepEqual(harness.includedAccessValues, []);
+    assert.equal(harness.codexDisableCount, 1);
+    assert.equal(harness.invalidations, 1);
+    assert.deepEqual(harness.retries, ['stream-d']);
+  });
+
+  it('does not disable the subscription when no usable OpenAI key is available', async () => {
+    const harness = createHarness({ keys: {} });
+
+    const result = await harness.controller.useOwnApiKey({
+      stream: 'stream-e',
+      provider: 'openai',
+      chatgptSubscription: true,
+    });
+
+    assert.deepEqual(result, {
+      proceeded: false,
+      retried: false,
+      disabledIncludedModelAccess: false,
+      disabledChatGptSubscription: false,
+    });
+    assert.equal(harness.codexDisableCount, 0);
+    assert.deepEqual(harness.retries, []);
   });
 });

--- a/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
@@ -215,16 +215,18 @@ describe('ProgressApiKeyRetryController', () => {
       chatgptSubscription: true,
     });
 
+    // The subscription switch also drops relay so the retry reaches the stored
+    // OpenAI key rather than the relay JWT.
     assert.deepEqual(result, {
       proceeded: true,
       retried: true,
-      disabledIncludedModelAccess: false,
+      disabledIncludedModelAccess: true,
       disabledChatGptSubscription: true,
     });
     assert.deepEqual(harness.prompts, ['openai']);
-    assert.deepEqual(harness.includedAccessValues, []);
+    assert.deepEqual(harness.includedAccessValues, [false]);
     assert.equal(harness.codexDisableCount, 1);
-    assert.equal(harness.invalidations, 1);
+    assert.equal(harness.invalidations, 2);
     assert.deepEqual(harness.retries, ['stream-d']);
   });
 

--- a/src/test-kernel/shared/stateSettings.vitest.ts
+++ b/src/test-kernel/shared/stateSettings.vitest.ts
@@ -5,6 +5,10 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'vitest';
 
 // Local imports - catalog + accessor
+import {
+  isStored,
+  makeFakeSettingsStores,
+} from '@test/support/settingsStoresFake';
 import { KNOWN_TEXRA_KEYS } from '@cli/schemas/knownKeys';
 import { CORE_SETTING_PATHS } from '@shared/schemas/coreSettings';
 import {
@@ -31,13 +35,9 @@ import {
   DEFAULT_GIT_WORKTREE_SUPPORT,
 } from '@shared/constants/git';
 import { LATEX_CONFIG_DEFAULTS } from '@shared/constants/latex';
-import { WorkspaceStateKey } from '@shared/state/stateKeys';
+import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 
 // Local imports - shared store fakes
-import {
-  isStored,
-  makeFakeSettingsStores,
-} from '@test/support/settingsStoresFake';
 
 const VALID_STORES: ReadonlySet<SettingStore> = new Set<SettingStore>([
   'config',
@@ -70,6 +70,7 @@ const EXPECTED_DEFAULTS: Record<string, unknown> = {
   [WorkspaceStateKey.LATEXDIFF_CHANGES_ONLY]:
     LATEX_CONFIG_DEFAULTS.latexdiffChangesOnly,
   [WorkspaceStateKey.LATEX_FORMATTER]: LATEX_CONFIG_DEFAULTS.latexFormatter,
+  [GlobalStateKey.WEBSOCKET_OPENAI]: false,
 };
 
 describe('state settings catalog', () => {
@@ -190,6 +191,8 @@ describe('state settings catalog', () => {
     //    drives worktree delegation (DelegationTools);
     //  - the workflow compile settings run in `texra workflow` / `texra run`
     //    (the reflection flow, via OutputNode/runCompileCheck).
+    //  - the OpenAI WebSocket toggle is read by the Responses handler the CLI
+    //    runs (and lets the Codex backend attempt WebSocket).
     // auto-open-pdf (no CLI opener), latexdiff, and the formatter are
     // intentionally excluded. Changing the CLI roster must be a deliberate edit
     // here, not an accident of flipping `hosts`.
@@ -203,6 +206,7 @@ describe('state settings catalog', () => {
         WorkspaceStateKey.WORKFLOW_AUTO_COMPILE,
         WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS,
         WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE,
+        GlobalStateKey.WEBSOCKET_OPENAI,
       ].sort(),
     );
   });


### PR DESCRIPTION
When a Codex model driven through the ChatGPT subscription hits its plan
usage limit, the backend returns a `usage_limit_reached` body. Previously
this surfaced as a raw error with no way to fall back to the user's own
OpenAI API key.

Now that error is detected, classified as a credential exhaustion (so
auto-retry is suppressed and the message reports the plan plus how long
until the quota resets), and the existing "Use your own API key" retry
affordance is offered. Accepting it turns off the "prefer ChatGPT
subscription" preference and retries through the OpenAI API key.

The Codex handler re-reads the subscription preference per request, so
turning it off mid-run reroutes the in-place retry on the same handler
instance (mirroring how the base handler re-resolves relay vs direct
credentials per request) — no handler swap needed. Pricing falls back to
real per-token rates once on the API key.

Wired across surfaces:
- core: detection + classification (`chatgptSubscriptionDetection`,
  `providerErrorFormat`, `ProviderError.isChatGptSubscriptionLimited`)
- handler: per-request fallback in `ModelHandlerCodex`
- controller: `ProgressApiKeyRetryController.disablePreferCodexSubscription`
- VS Code: progress-view retry panel "Use your own API key" / `k`
- CLI: retry prompt `k` switch + `/subscription off` hint

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01J4Kwp2mG2Q1uWcmUgJxjmb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential routing, error classification, and the Codex/OpenAI Responses request path (store, reasoning replay, subscription fallback), where misclassification or a bad retry could send requests down the wrong auth path.
> 
> **Overview**
> Adds **ChatGPT subscription quota exhaustion** handling for Codex models: the backend’s `usage_limit_reached` body is parsed into a clear message (plan, reset window) and tagged on `ProviderError` as `isChatGptSubscriptionLimited`, treated like other credential exhaustion so **auto-retry does not loop** on an exhausted subscription.
> 
> The existing **“Use your own API key”** retry path is extended: accepting it **disables “prefer ChatGPT subscription”**, switches to personal keys (and relay off where needed), and retries. **CLI** centralizes preference updates in `setCliCodexSubscription`; the retry modal’s **`k`** action sets `disableChatGptSubscription` plus personal API mode. **VS Code** passes `chatgptSubscription` through the progress view and `ProgressApiKeyRetryController.disablePreferCodexSubscription`.
> 
> **`ModelHandlerCodex`** re-reads the subscription preference **each request**, so the same handler instance can move from the Codex OAuth endpoint to the normal OpenAI API-key Responses path without a swap; pricing and capabilities follow the base handler when off. Related work: pure **`rewriteCodexRequestBody`**, **store:false encrypted-reasoning replay**, optional experimental **background/WebSocket** on Codex tied to shared toggles, and a CLI catalog entry for **`texra.websocket.openai`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44e00ab5d4482c77bd9da7ab741be6d8df0b1234. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->