### PR TITLE
test(model-handlers): lock the compat-key ↔ createModelHandler routing invariant (#6644)

### DIFF
--- a/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
@@ -515,30 +515,53 @@ describe('routing precedence: compat-key ↔ createModelHandler invariant', () =
   // The handler-routing precedence is encoded twice: once in the pure
   // `modelHandlerCompatibilityKey` predicate (used exception-free by
   // history-restore and model-switch gating) and once in the live
-  // `createModelHandler` dispatch. The two must never drift — otherwise the
-  // key a restored session keys on could disagree with the handler actually
-  // built. For every registered model the key tagged onto the created handler
-  // must equal the predicted key, and a model with no handler route (predicted
-  // `undefined`, e.g. Copilot) must make `createModelHandler` reject rather
-  // than silently build a mismatched handler. Default routing (no OpenRouter
-  // proxy, signed out) is the shared baseline both paths observe, so they are
-  // compared under identical inputs.
+  // `createModelHandler` dispatch. The two must never drift on the *key* they
+  // produce — otherwise the key a restored session keys on could disagree with
+  // the handler actually built. For every registered model the key tagged onto
+  // the created handler must equal the predicted key, and a model with no
+  // handler route (predicted `undefined`, e.g. Copilot) must make
+  // `createModelHandler` reject rather than silently build a mismatched
+  // handler. Default routing (no OpenRouter proxy) is the shared baseline both
+  // paths observe. The Codex-subscription override in `createModelHandler` is
+  // intentionally absent from the predicate, but it is key-neutral: a signed-in
+  // run still tags `ModelHandlerCodex` with `ModelHandlerOpenAIResponse` (only
+  // the class differs, not the key), so this signed-out sweep guards the key
+  // invariant for both states.
   it('tags every registered model with its predicted compatibility key', async () => {
+    // Re-import the factory alongside a freshly-initialized platform. An
+    // earlier test in this file calls vi.resetModules(), which would otherwise
+    // desync the statically-imported factory from the platform it reads; this
+    // also makes the block robust to isolated `--grep` runs rather than
+    // free-riding on a prior test's initPlatform.
+    const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
+      import('@platform/platform'),
+      import('@test/support/FakePlatform'),
+    ]);
+    initPlatform(createFakePlatform());
+    const {
+      modelHandlerCompatibilityKey: compatKey,
+      createModelHandler: create,
+      activeModelHandlerCompatibilityKey: activeKey,
+    } = await import('@agent/runtime/ModelFactory');
+
     const mismatches: string[] = [];
     for (const [name, config] of Object.entries(MODEL_CONFIGS)) {
-      const predicted = modelHandlerCompatibilityKey(config);
+      const predicted = compatKey(config);
       if (predicted === undefined) {
         await expect(
-          createModelHandler(config),
+          create(config),
           `${name}: no handler route, createModelHandler should reject`,
         ).rejects.toThrow();
         continue;
       }
-      const actual = activeModelHandlerCompatibilityKey(
-        await createModelHandler(config),
-      );
-      if (actual !== predicted) {
-        mismatches.push(`${name}: predicted ${predicted}, got ${actual}`);
+      const handler = await create(config);
+      try {
+        const actual = activeKey(handler);
+        if (actual !== predicted) {
+          mismatches.push(`${name}: predicted ${predicted}, got ${actual}`);
+        }
+      } finally {
+        handler.dispose();
       }
     }
     expect(mismatches).toEqual([]);

--- a/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
@@ -505,3 +505,42 @@ describe('direct handler capability overrides', () => {
     ).toBe(false);
   });
 });
+
+describe('routing precedence: compat-key ↔ createModelHandler invariant', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    resetCodexCoordinator();
+  });
+
+  // The handler-routing precedence is encoded twice: once in the pure
+  // `modelHandlerCompatibilityKey` predicate (used exception-free by
+  // history-restore and model-switch gating) and once in the live
+  // `createModelHandler` dispatch. The two must never drift — otherwise the
+  // key a restored session keys on could disagree with the handler actually
+  // built. For every registered model the key tagged onto the created handler
+  // must equal the predicted key, and a model with no handler route (predicted
+  // `undefined`, e.g. Copilot) must make `createModelHandler` reject rather
+  // than silently build a mismatched handler. Default routing (no OpenRouter
+  // proxy, signed out) is the shared baseline both paths observe, so they are
+  // compared under identical inputs.
+  it('tags every registered model with its predicted compatibility key', async () => {
+    const mismatches: string[] = [];
+    for (const [name, config] of Object.entries(MODEL_CONFIGS)) {
+      const predicted = modelHandlerCompatibilityKey(config);
+      if (predicted === undefined) {
+        await expect(
+          createModelHandler(config),
+          `${name}: no handler route, createModelHandler should reject`,
+        ).rejects.toThrow();
+        continue;
+      }
+      const actual = activeModelHandlerCompatibilityKey(
+        await createModelHandler(config),
+      );
+      if (actual !== predicted) {
+        mismatches.push(`${name}: predicted ${predicted}, got ${actual}`);
+      }
+    }
+    expect(mismatches).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Resolves the drift risk in #6644 — the safe way.

The handler-routing precedence is encoded twice in `ModelFactory.ts`:

- `modelHandlerCompatibilityKey()` — a **pure, synchronous** predicate that returns only the compatibility *key*. Used by exception-free callers (history restore, `modelSwitchDisabledReason`).
- `createModelHandler()` — the **async** live path that instantiates the handler and tags it with a key.

They walk the same precedence (Validation → Responses → Google Interactions → OpenRouter → provider default) but deliberately diverge in shape (the live path adds an async Codex-subscription override, config transforms, and a throwing `assertGoogleInteractionsRoutable` side-channel the pure predicate omits). If the two orderings drift, a restored session could key on a handler different from the one actually built.

## Why a guard test, not a live-path restructure

#6644 proposed consolidating the precedence into one owner. Having looked closely, restructuring `createModelHandler` to dispatch off `modelHandlerCompatibilityKey`'s key is **high blast radius**: a subtle mistake would route a model to the wrong provider API for end users, and the consolidation has to re-introduce the Interactions-under-OpenRouter throw and the Codex override by hand. The drift risk #6644 actually worries about is fully addressable without touching the live path.

This PR adds a **parametric invariant test**: for every one of the 128 registered models, the key tagged onto the created handler must equal `modelHandlerCompatibilityKey`'s prediction; a model with no route (predicted `undefined`, e.g. Copilot) must make `createModelHandler` reject. It **passes on current `main`** (the two encodings agree today) and **fails fast** on any future reorder/addition that desyncs them — turning a silent latent bug into a CI failure.

## Verification

- `npx vitest run …/ModelFactoryRouting.vitest.ts` — **27 passed** (the new guard sweeps all 128 models in ~2s).
- `npm run typecheck` clean; prettier clean.

The full structural consolidation can still be done later with maintainer awareness; this removes the urgency by making drift impossible to merge unnoticed. Test-only — no changelog entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds regression tests only; no runtime or routing logic is modified.
> 
> **Overview**
> Adds a **parametric CI guard** so `modelHandlerCompatibilityKey` and `createModelHandler` cannot drift on the compatibility key used for history restore and model-switch gating.
> 
> The new test in `ModelFactoryRouting.vitest.ts` initializes a fake platform, re-imports `ModelFactory` (to survive `vi.resetModules()` elsewhere in the file), and sweeps **all** entries in `MODEL_CONFIGS`. For each model it asserts the key on the created handler matches the pure predicate’s prediction, and that models with no route (`undefined` key, e.g. Copilot) cause `createModelHandler` to **reject** instead of building a mismatched handler.
> 
> **Test-only** — no production routing changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e06a194fda55cc4029c862924453adb399f6596. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->