### PR TITLE
fix(agents): restore the full Physicist team roster

### DIFF
--- a/src/shared/schemas/agentPresets.ts
+++ b/src/shared/schemas/agentPresets.ts
@@ -121,14 +121,24 @@ export const AGENT_MODE_PRESETS: AgentModePreset[] = [
     description:
       'For physics papers -- analytical derivations, numerical experiments, literature search, slides, and critical review.',
     icon: 'symbol-operator',
-    workflowAgents: ['correct', 'polish'],
+    workflowAgents: [
+      'correct',
+      'polish',
+      'generic',
+      'devise',
+      'apply',
+      'criticize',
+    ],
     toolUseAgents: [
       'orchestrator',
       'research',
       'numerics',
       'review',
       'presenter',
+      'simplifier',
       'latexFixer',
+      'progressCheck',
+      'search',
     ],
   },
   {

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -63,7 +63,7 @@ describe('CLI multi-agent presets', () => {
     const output = formatCliMultiAgentPresetList(plans);
 
     expect(output).toContain(
-      'built-in\tphysicist\tPhysicist\tworkflow:2\ttool-use:6',
+      'built-in\tphysicist\tPhysicist\tworkflow:6\ttool-use:9',
     );
     expect(output).not.toContain('Hint:');
   });
@@ -166,7 +166,7 @@ describe('CLI multi-agent presets', () => {
     });
 
     expect(formatCliMultiAgentPresetLauncherSummary(plan)).toBe(
-      'degraded; 1/2 workflows; 2/6 tools',
+      'degraded; 1/6 workflows; 2/9 tools',
     );
     expect(formatCliMultiAgentPresetLauncherHints(plan)).toEqual([
       'Team setup: run `texra multi-agent inspect <team-id>` for unavailable or degraded teams.',
@@ -188,7 +188,7 @@ describe('CLI multi-agent presets', () => {
     });
 
     expect(formatCliMultiAgentPresetRunWarnings(plan)).toEqual([
-      'WARN preset physicist references unavailable agents: workflow:correct, workflow:polish, tool-use:research, tool-use:numerics, tool-use:presenter, tool-use:latexFixer',
+      'WARN preset physicist references unavailable agents: workflow:correct, workflow:polish, workflow:generic, workflow:devise, workflow:apply, workflow:criticize, tool-use:research, tool-use:numerics, tool-use:presenter, tool-use:simplifier, tool-use:latexFixer, tool-use:progressCheck, tool-use:search',
       'WARN preset physicist is degraded; running root agent orchestrator with 1 available team agent.',
     ]);
   });
@@ -206,7 +206,7 @@ describe('CLI multi-agent presets', () => {
     });
 
     expect(formatCliMultiAgentPresetRunWarnings(plan)).toEqual([
-      'WARN preset physicist references unavailable agents: workflow:correct, workflow:polish, tool-use:research, tool-use:numerics, tool-use:review, tool-use:presenter, tool-use:latexFixer',
+      'WARN preset physicist references unavailable agents: workflow:correct, workflow:polish, workflow:generic, workflow:devise, workflow:apply, workflow:criticize, tool-use:research, tool-use:numerics, tool-use:review, tool-use:presenter, tool-use:simplifier, tool-use:latexFixer, tool-use:progressCheck, tool-use:search',
     ]);
   });
 
@@ -230,8 +230,8 @@ describe('CLI multi-agent presets', () => {
 
     expect(cliMultiAgentPresetAvailability(plan)).toMatchObject({
       status: 'available',
-      toolUse: { available: 6, total: 6 },
-      workflow: { available: 2, total: 2 },
+      toolUse: { available: 9, total: 9 },
+      workflow: { available: 6, total: 6 },
     });
   });
 
@@ -273,8 +273,8 @@ describe('CLI multi-agent presets', () => {
 
     expect(cliMultiAgentPresetAvailability(plan)).toMatchObject({
       status: 'unavailable',
-      toolUse: { available: 0, total: 6 },
-      workflow: { available: 0, total: 2 },
+      toolUse: { available: 0, total: 9 },
+      workflow: { available: 0, total: 6 },
     });
     expect(cliMultiAgentPresetTeamLaunchBlockReason(plan)).toBe(
       'no runnable team root',
@@ -554,14 +554,19 @@ describe('CLI multi-agent presets', () => {
     expect(details).toContain(
       'Available tool-use agents:\n  orchestrator\n  review',
     );
-    expect(details).toContain('Missing workflow agents:\n  (none)');
+    expect(details).toContain(
+      'Missing workflow agents:\n  generic\n  devise\n  apply\n  criticize',
+    );
     expect(details).toContain(
       [
         'Missing tool-use agents:',
         '  research',
         '  numerics',
         '  presenter',
+        '  simplifier',
         '  latexFixer',
+        '  progressCheck',
+        '  search',
         '',
         'Hint: Researcher Access sign-in may load additional remote team agents.',
       ].join('\n'),

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -1308,7 +1308,14 @@ describe('desktop settings IPC', () => {
     // Catalog-resolved names become source-qualified keys, preserving the
     // winning source when a custom agent overrides a built-in name.
     expect(workspaceState.values.get(WorkspaceStateKey.ENABLED_AGENTS)).toEqual(
-      ['builtInWorkflow:correct', 'builtInWorkflow:polish'],
+      [
+        'builtInWorkflow:correct',
+        'builtInWorkflow:polish',
+        'generic',
+        'devise',
+        'apply',
+        'criticize',
+      ],
     );
     expect(
       workspaceState.values.get(WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS),
@@ -1318,7 +1325,10 @@ describe('desktop settings IPC', () => {
       'builtInToolUse:numerics',
       'builtInToolUse:review',
       'builtInToolUse:presenter',
+      'simplifier',
       'builtInToolUse:latexFixer',
+      'progressCheck',
+      'search',
     ]);
     expect(errorMessages).toEqual([]);
     expect(infoMessages).toEqual(['Applied "Physicist" team']);

--- a/src/test-kernel/tools/setup/ApplyTeamTool.vitest.mts
+++ b/src/test-kernel/tools/setup/ApplyTeamTool.vitest.mts
@@ -151,8 +151,12 @@ describe('seedRosterFromDefaultTeam', () => {
     expect(seeded).toBe(true);
     const roster = workspaceRoster();
     expect(roster.workflow?.toSorted()).toEqual([
+      'apply',
       'builtInWorkflow:correct',
       'builtInWorkflow:polish',
+      'criticize',
+      'devise',
+      'generic',
     ]);
     expect(roster.toolUse).toContain('builtInToolUse:review');
     expect(roster.toolUse).toContain('builtInToolUse:research');
@@ -170,8 +174,12 @@ describe('seedRosterFromDefaultTeam', () => {
     expect(seeded).toBe(true);
     const roster = workspaceRoster();
     expect(roster.workflow?.toSorted()).toEqual([
+      'apply',
       'builtInWorkflow:correct',
       'builtInWorkflow:polish',
+      'criticize',
+      'devise',
+      'generic',
     ]);
     expect(roster.toolUse).toContain('builtInToolUse:review');
     expect(roster.toolUse).toContain('builtInToolUse:research');


### PR DESCRIPTION
PR #6563 narrowed the Physicist team when it became the default startup
roster, dropping the research workflow agents (generic, devise, apply,
criticize) and the simplifier, progressCheck, and search tool-use agents.
Physics work needs those agents, so restore the full roster while keeping
Physicist as the default startup team.

Update the multi-agent preset, desktop settings, and seeding tests to the
expanded roster counts and member lists.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PuJfXS6T2WWQzef5K7PwR6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Preset definition and test expectation updates only; no auth, security, or runtime logic changes beyond which agent names the Physicist preset enables.
> 
> **Overview**
> **Restores the Physicist built-in team** to its full agent lineup after a prior change left only `correct` and `polish` on the workflow side and a shorter tool-use list.
> 
> **Workflow agents added back:** `generic`, `devise`, `apply`, `criticize`. **Tool-use agents added back:** `simplifier`, `progressCheck`, `search`. Physicist stays the default startup roster (`DEFAULT_STARTUP_TEAM_ID`); this only widens what gets enabled when users pick Physicist or when empty workspaces seed from that default.
> 
> Tests are aligned to the new counts (**6** workflow / **9** tool-use), including CLI preset listing, inspection, degraded-run warnings, desktop **Apply Physicist** workspace keys, and `seedRosterFromDefaultTeam` fallback expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4500ed4ac3f24c065a52ab0fc237b6909e4d2e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->