### PR TITLE
refactor(tools): make the delegation/ split self-contained (post-#6648)

### DIFF
--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -47,6 +47,8 @@ import {
   workingDirectoryField,
   withToolUseSubagentHandoffInstruction,
   rejectOversizedBibAttachments,
+  WorkflowAgentInputSchema,
+  type WorkflowAgentInput,
 } from './delegation/inputFields';
 
 // Local imports - utils
@@ -54,6 +56,7 @@ import { WorkspaceFS } from '@utils/files';
 import { isNonEmptyString } from '@utils/core/stringCore';
 
 export { rejectOversizedBibAttachments } from './delegation/inputFields';
+export type { WorkflowAgentInput };
 
 /** Get required context fields, throwing if unavailable. */
 function getRequiredContext(): RunContext & {
@@ -71,59 +74,6 @@ function getRequiredContext(): RunContext & {
 // ============================================================================
 // delegate_workflow tool - for document processing agents
 // ============================================================================
-
-/** Schema for delegate_workflow tool (document processing). */
-const WorkflowAgentInputSchema = z.strictObject({
-  agent: z.string().describe('Name of the workflow agent to execute'),
-  model: z
-    .string()
-    .nullish()
-    .describe(
-      'Model short name from the Available models line. Omit unless the user explicitly requested a model; defaults to the current model when available.',
-    ),
-  instruction: z
-    .string()
-    .describe(
-      'What the agent should do, in plain prose. If you attach context or media files, name each one and say what role it plays — e.g., "preamble.tex defines the math macros; refs.bib is the bibliography to cite from; figure.png shows the panel layout to match". The sub-agent has no other signal for why each file was attached.',
-    ),
-  inputFiles: z
-    .array(z.string())
-    .min(1)
-    .describe(
-      'Files the agent rewrites. List every file you want it to touch. The agent emits one revised <document> per entry.',
-    ),
-  contextFiles: z
-    .array(z.string())
-    .prefault([])
-    .describe(
-      'Read-only context the agent should see but not modify: guidance, examples, related papers, bibliographies (.bib), style/macro definitions (.sty/.cls). Explain each one in the instruction.',
-    ),
-  mediaFiles: z
-    .array(z.string())
-    .prefault([])
-    .describe('Images, figures, PDFs, or audio files the agent should view.'),
-  extractFigures: z
-    .boolean()
-    .nullish()
-    .describe(
-      'When true, automatically extracts figures referenced by the input LaTeX file(s) (via \\includegraphics, \\begin{overpic}) and attaches them as media files. Merges with any explicitly provided mediaFile/mediaFiles.',
-    ),
-  extractTikz: z
-    .boolean()
-    .nullish()
-    .describe(
-      'When true, extracts TikZ figures from the input LaTeX file(s), compiles them into standalone PDFs, and attaches them as media files.',
-    ),
-  outputFiles: z
-    .array(z.string())
-    .prefault([])
-    .describe(
-      'Output file paths. Must be a subset of input files—never create new files or change format. Leave empty for default suffix-based outputs.',
-    ),
-  memories: memoriesField,
-});
-
-export type WorkflowAgentInput = z.infer<typeof WorkflowAgentInputSchema>;
 
 /** Tool for delegating tasks to workflow agents (document processing). */
 export class WorkflowAgentTool extends defineTool({

--- a/src/tools/delegation/inputFields.ts
+++ b/src/tools/delegation/inputFields.ts
@@ -22,9 +22,6 @@ import { AbsoluteFS, WorkspaceFS } from '@utils/files';
 import { hasExtension } from '@utils/core/pathCore';
 import { isNonEmptyString } from '@utils/core/stringCore';
 
-// Local imports - delegation
-import type { WorkflowAgentInput } from '../DelegationTools';
-
 const LARGE_BIB_LIMIT_BYTES = 100 * 1024;
 
 /**
@@ -53,6 +50,59 @@ export const memoriesField = z
       }
     }
   });
+
+/** Schema for the delegate_workflow tool (document processing). */
+export const WorkflowAgentInputSchema = z.strictObject({
+  agent: z.string().describe('Name of the workflow agent to execute'),
+  model: z
+    .string()
+    .nullish()
+    .describe(
+      'Model short name from the Available models line. Omit unless the user explicitly requested a model; defaults to the current model when available.',
+    ),
+  instruction: z
+    .string()
+    .describe(
+      'What the agent should do, in plain prose. If you attach context or media files, name each one and say what role it plays — e.g., "preamble.tex defines the math macros; refs.bib is the bibliography to cite from; figure.png shows the panel layout to match". The sub-agent has no other signal for why each file was attached.',
+    ),
+  inputFiles: z
+    .array(z.string())
+    .min(1)
+    .describe(
+      'Files the agent rewrites. List every file you want it to touch. The agent emits one revised <document> per entry.',
+    ),
+  contextFiles: z
+    .array(z.string())
+    .prefault([])
+    .describe(
+      'Read-only context the agent should see but not modify: guidance, examples, related papers, bibliographies (.bib), style/macro definitions (.sty/.cls). Explain each one in the instruction.',
+    ),
+  mediaFiles: z
+    .array(z.string())
+    .prefault([])
+    .describe('Images, figures, PDFs, or audio files the agent should view.'),
+  extractFigures: z
+    .boolean()
+    .nullish()
+    .describe(
+      'When true, automatically extracts figures referenced by the input LaTeX file(s) (via \\includegraphics, \\begin{overpic}) and attaches them as media files. Merges with any explicitly provided mediaFile/mediaFiles.',
+    ),
+  extractTikz: z
+    .boolean()
+    .nullish()
+    .describe(
+      'When true, extracts TikZ figures from the input LaTeX file(s), compiles them into standalone PDFs, and attaches them as media files.',
+    ),
+  outputFiles: z
+    .array(z.string())
+    .prefault([])
+    .describe(
+      'Output file paths. Must be a subset of input files—never create new files or change format. Leave empty for default suffix-based outputs.',
+    ),
+  memories: memoriesField,
+});
+
+export type WorkflowAgentInput = z.infer<typeof WorkflowAgentInputSchema>;
 
 const WORKTREE_DISABLED_MESSAGE =
   "git worktree support is disabled in this workspace. Omit working_directory, or enable 'Allow agents to work in git worktrees' on the Multi-Agent settings tab.";

--- a/src/tools/delegation/subagentExecution.ts
+++ b/src/tools/delegation/subagentExecution.ts
@@ -63,7 +63,7 @@ import { generateExecutionId } from '@utils/core/executionId';
 // Shared utilities
 // ============================================================================
 
-const LOG_CHANNEL = 'DelegationTools';
+const LOG_CHANNEL = 'delegation';
 logger.initialize(LOG_CHANNEL);
 
 /** Metadata about how the delegation was approved, included in the tool result. */


### PR DESCRIPTION
Addresses the delegation findings of #6650 (a quality follow-up to the #6648 `DelegationTools` split).

## 1. Remove the child→parent type back-ref

The #6648 split left `delegation/inputFields.ts` importing `WorkflowAgentInput` *type* back from the parent `DelegationTools.ts` (used by `rejectOversizedBibAttachments`'s signature). This moves `WorkflowAgentInputSchema` and its derived `WorkflowAgentInput` type into `inputFields.ts` — beside `memoriesField`, which the schema already uses — so the extracted module is **self-contained** (no back-reference). `DelegationTools.ts` imports the schema for its tool class and re-exports the type, so the **public surface is unchanged**.

## 2. Fix the stale log channel name

`delegation/subagentExecution.ts` still set `LOG_CHANNEL = 'DelegationTools'` (the old parent module). Renamed to the module-scoped `'delegation'`.

## Behavior-preserving

- Pure move of the schema/type + a constant rename — no logic change.
- Public export set of `DelegationTools.ts` is identical (`WorkflowAgentInput` preserved via re-export, as `rejectOversizedBibAttachments` already was); all importers unaffected.
- `npm run typecheck` clean for the delegation files; `DelegationTools.vitest.ts` 4/4 pass.

Finding 3 of #6650 (five Codex Zod schemas imported as runtime values into the progress-view webview frontend → move to `@shared/schemas/`) is a separate `codexShared` boundary concern and is intentionally **not** in this PR — it touches the Codex subsystem (active in #6651) and warrants its own change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure structural move and a logging constant rename with no runtime behavior or public export changes beyond the same re-exported type.
> 
> **Overview**
> **Moves** `WorkflowAgentInputSchema` and `WorkflowAgentInput` from `DelegationTools.ts` into `delegation/inputFields.ts`, next to `memoriesField` and `rejectOversizedBibAttachments`, so the extracted module no longer imports types back from the parent.
> 
> `DelegationTools.ts` **imports** the schema for `delegate_workflow` and **re-exports** `WorkflowAgentInput`, keeping the public API the same for tests and other importers.
> 
> In `delegation/subagentExecution.ts`, the logger channel is **renamed** from `'DelegationTools'` to `'delegation'` so logs match the module layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3522e062bc30c8712d56db3ad9b175f3eb726e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->