### PR TITLE
Cap request-panel action button widths instead of stretching to fill

### DIFF
--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -195,28 +195,14 @@ export const requestPanelStyles: CSSResult = css`
     max-width: 100%;
   }
 
-  /* The primary action buttons (which carry data-action) fill the row
-     equally; the diff dropdown's own buttons keep their bespoke sizing. */
+  /* The primary action buttons (which carry data-action) hug their content and
+     stay button-sized: they never grow to fill a wide panel, are width-capped,
+     and group at the start of the row. The diff dropdown's own buttons (tool
+     edit approvals) keep their bespoke sizing below. */
   :is(${ACTIONS}) wa-button[data-action] {
-    min-width: auto;
-    flex: 1 1 var(--action-button-basis, 8rem);
-  }
-
-  /* Per-panel basis tunes how many action buttons fit per row before wrapping.
-     Default 8rem (retry / inquiry / question); bash / plan want wider rows.
-     Tool edit approvals and workflow proposals stay compact below. */
-  .bash-approval-request__actions,
-  .plan-approval-request__actions {
-    --action-button-basis: 12rem;
-  }
-
-  /* The proposal's approve/reject/setup buttons keep a capped, button-sized
-     width and don't grow to fill a wide panel — they hug their content and
-     stay grouped at the start of the row. */
-  .workflow-proposal__actions wa-button[data-action] {
     flex: 0 1 auto;
     min-width: min(5.5rem, 100%);
-    max-width: min(9rem, 100%);
+    max-width: min(14rem, 100%);
   }
 
   .approval-request__actions wa-button[data-action] {
@@ -226,15 +212,11 @@ export const requestPanelStyles: CSSResult = css`
     max-width: min(7rem, 100%);
   }
 
+  /* Center the label within each content-sized button (they sit at or above
+     the 5.5rem min-width floor, so centering keeps short labels balanced). */
   :is(${ACTIONS}) wa-button[data-action]::part(base) {
-    justify-content: flex-start;
-    gap: ${sp.small};
-  }
-
-  /* Center the capped proposal labels. Must follow the shared flex-start rule
-     above — equal specificity, so source order decides the cascade. */
-  .workflow-proposal__actions wa-button[data-action]::part(base) {
     justify-content: center;
+    gap: ${sp.small};
   }
 
   .approval-request__actions wa-button[data-action]::part(base) {

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -203,15 +203,24 @@ export const requestPanelStyles: CSSResult = css`
   }
 
   /* Per-panel basis tunes how many action buttons fit per row before wrapping.
-     Default 8rem (retry / inquiry / question); bash / plan want wider rows,
-     the workflow proposal narrower. Tool edit approvals stay compact below. */
+     Default 8rem (retry / inquiry / question); bash / plan want wider rows.
+     Tool edit approvals and workflow proposals stay compact below. */
   .bash-approval-request__actions,
   .plan-approval-request__actions {
     --action-button-basis: 12rem;
   }
 
-  .workflow-proposal__actions {
-    --action-button-basis: 6rem;
+  /* The proposal's approve/reject/setup buttons keep a capped, button-sized
+     width and don't grow to fill a wide panel — they hug their content and
+     stay grouped at the start of the row. */
+  .workflow-proposal__actions wa-button[data-action] {
+    flex: 0 1 auto;
+    min-width: min(5.5rem, 100%);
+    max-width: min(9rem, 100%);
+  }
+
+  .workflow-proposal__actions wa-button[data-action]::part(base) {
+    justify-content: center;
   }
 
   .approval-request__actions wa-button[data-action] {

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -198,13 +198,17 @@ export const requestPanelStyles: CSSResult = css`
   /* The primary action buttons hug their content and stay button-sized: they
      never grow to fill a wide panel and are width-capped, so they group at the
      start of the row instead of stretching, and the label centers within the
-     button's own padding. Keyed off the semantic .action-button class the
-     button helper sets in its template (not the data-action behaviour hook)
-     and sized on the host element, so there is no shadow-part piercing and no
-     source-order tiebreak to keep in sync. Tool edit approvals override with
-     their bespoke sizing below, winning by specificity. */
+     button's own padding. min-width: auto restores the flex min-content floor
+     (overriding the bounded-children min-width: 0 above), so a button never
+     shrinks below its own label and wraps to the next row instead of
+     clipping. Keyed off the semantic .action-button class the button helper
+     sets in its template (not the data-action behaviour hook) and sized on the
+     host element, so there is no shadow-part piercing and no source-order
+     tiebreak to keep in sync. Tool edit approvals override with their bespoke
+     sizing below, winning by specificity. */
   :is(${ACTIONS}) .action-button {
     flex: 0 1 auto;
+    min-width: auto;
     max-width: min(14rem, 100%);
   }
 

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -195,13 +195,16 @@ export const requestPanelStyles: CSSResult = css`
     max-width: 100%;
   }
 
-  /* The primary action buttons (which carry data-action) hug their content and
-     stay button-sized: they never grow to fill a wide panel, are width-capped,
-     and group at the start of the row. The diff dropdown's own buttons (tool
-     edit approvals) keep their bespoke sizing below. */
-  :is(${ACTIONS}) wa-button[data-action] {
+  /* The primary action buttons hug their content and stay button-sized: they
+     never grow to fill a wide panel and are width-capped, so they group at the
+     start of the row instead of stretching, and the label centers within the
+     button's own padding. Keyed off the semantic .action-button class the
+     button helper sets in its template (not the data-action behaviour hook)
+     and sized on the host element, so there is no shadow-part piercing and no
+     source-order tiebreak to keep in sync. Tool edit approvals override with
+     their bespoke sizing below, winning by specificity. */
+  :is(${ACTIONS}) .action-button {
     flex: 0 1 auto;
-    min-width: min(5.5rem, 100%);
     max-width: min(14rem, 100%);
   }
 
@@ -210,13 +213,6 @@ export const requestPanelStyles: CSSResult = css`
     width: auto;
     min-width: min(5.5rem, 100%);
     max-width: min(7rem, 100%);
-  }
-
-  /* Center the label within each content-sized button (they sit at or above
-     the 5.5rem min-width floor, so centering keeps short labels balanced). */
-  :is(${ACTIONS}) wa-button[data-action]::part(base) {
-    justify-content: center;
-    gap: ${sp.small};
   }
 
   .approval-request__actions wa-button[data-action]::part(base) {

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -219,10 +219,6 @@ export const requestPanelStyles: CSSResult = css`
     max-width: min(9rem, 100%);
   }
 
-  .workflow-proposal__actions wa-button[data-action]::part(base) {
-    justify-content: center;
-  }
-
   .approval-request__actions wa-button[data-action] {
     flex: 0 1 7rem;
     width: auto;
@@ -233,6 +229,12 @@ export const requestPanelStyles: CSSResult = css`
   :is(${ACTIONS}) wa-button[data-action]::part(base) {
     justify-content: flex-start;
     gap: ${sp.small};
+  }
+
+  /* Center the capped proposal labels. Must follow the shared flex-start rule
+     above — equal specificity, so source order decides the cascade. */
+  .workflow-proposal__actions wa-button[data-action]::part(base) {
+    justify-content: center;
   }
 
   .approval-request__actions wa-button[data-action]::part(base) {


### PR DESCRIPTION
## Summary

Replace the `--action-button-basis` CSS variable approach with one shared, declarative rule for all request-panel action buttons (workflow proposal, bash approval, retry, plan approval, external inquiry, user question). These buttons previously used `flex: 1 1 <basis>` and grew to fill the row, so on a wide panel a primary control like **Approve** ballooned far past its label. They now hug their content, stay capped, and group at the start of the row instead of expanding to fill available space.

The change started as a workflow-proposal-only fix, was generalized to every panel, and then re-keyed off the semantic `.action-button` class (set by the button helper in its template) rather than the `data-action` behaviour attribute — sizing the host element only, with no WebAwesome shadow-part piercing and no source-order cascade tiebreaks.

## Issue acceptance gates

N/A — styling refinement with no associated issue.

## Single source of truth

`requestPanelStyles.ts` owns the action-button layout through one shared rule on `:is(${ACTIONS}) .action-button`, replacing the per-panel `--action-button-basis` variable (removed; it had no other consumers).

## Duplication and abstraction budget

Removed the `--action-button-basis` custom property and the proposal-specific override, folding everything into one shared rule:

- targeted via the semantic `.action-button` class the button helper sets (not the `data-action` behaviour hook)
- `flex: 0 1 auto` prevents growth beyond content
- `min-width: auto` restores the flex min-content floor (overriding the bounded-children `min-width: 0`), so a button never shrinks below its own label and wraps instead of clipping
- `max-width: min(14rem, 100%)` caps width (14rem keeps the longest real label, "Use your own API key", from clipping while still bounding width)
- label centering relies on WebAwesome's default `::part(base)` alignment — no shadow-part override and no source-order/specificity tiebreak needed

Tool-edit **approval** actions keep their tighter `7rem` cap and the diff dropdown's bespoke sizing (they need `width: 100%` on `::part(base)`), winning by specificity.

## Host impact

Extension: All request-panel action buttons (approve / reject / submit / retry / setup / etc.) now display with content-hugging, capped widths grouped at the start of the row, with centered labels. Single-button panels (user question "Submit", external inquiry "Submit Answer") change from full-width to a content-sized button at the row start.

Desktop: N/A

CLI: N/A

## Scheduled refactoring

None.

## Validation

Visual inspection of the request panels. `src/test-kernel/progressView/RequestPanelStyles.vitest.mts` passes (3/3) and Prettier is clean. No new automated tests required for this styling change.

https://claude.ai/code/session_01KGn7yC989hDMoePJ9JQZJ8