### PR TITLE
ci: stop re-running OS-independent checks on the macOS runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,17 +51,16 @@ jobs:
           fi
 
   validate:
-    name: validate (${{ matrix.os }})
+    name: validate
     needs: changes
     if: needs.changes.outputs.code == 'true'
-    runs-on: ${{ matrix.os }}
+    # OS-independent checks (typecheck/lint/tests/compile) and the
+    # Linux-only artifacts (CLI TUI frames, extension VSIX) live here and run
+    # once, on Linux. The macOS-specific Electron webview smoke is a separate
+    # `webview-smoke` job so the expensive macOS runner (~10x Linux billing)
+    # never re-runs platform-independent work it would only duplicate.
+    runs-on: ubuntu-latest
     timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
 
     steps:
       - name: Checkout repository
@@ -98,7 +97,6 @@ jobs:
         run: pnpm run test
 
       - name: Validate CLI TUI smoke frames
-        if: runner.os == 'Linux'
         run: |
           mkdir -p "$GITHUB_WORKSPACE/artifacts"
           pnpm --filter @texra-ai/cli validate:tui -- \
@@ -106,7 +104,7 @@ jobs:
             edit-approval subagent-picker hidden-root-approval-tab-return
 
       - name: Upload CLI TUI smoke frames
-        if: runner.os == 'Linux' && always()
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: texra-cli-tui-smoke-frames
@@ -120,37 +118,64 @@ jobs:
       # Desktop app packaging is intentionally not part of PR CI. Keep this
       # check scoped to the VS Code extension package.
       - name: Build extension VSIX package
-        if: runner.os == 'Linux'
         run: pnpm --filter texra build:fast
 
       - name: Check extension VSIX contents
-        if: runner.os == 'Linux'
         run: pnpm run check:vsix-contents
 
-      - name: Build webview smoke assets
-        if: runner.os == 'macOS'
-        run: pnpm run vite:webviews
-
-      - name: Smoke extension webviews in Electron
-        if: runner.os == 'macOS'
-        run: pnpm run smoke:webviews:run
-
-      - name: Upload webview smoke screenshots
-        if: runner.os == 'macOS' && always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: texra-webview-smoke-screenshots
-          path: artifacts/webview-smoke/*.png
-          if-no-files-found: ignore
-          retention-days: 14
-
       - name: Upload extension VSIX artifact
-        if: runner.os == 'Linux'
         uses: actions/upload-artifact@v7
         with:
           name: texra-extension-vsix
           path: releases/*.vsix
           if-no-files-found: error
+          retention-days: 14
+
+  webview-smoke:
+    name: webview smoke (macOS)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    # macOS-only because the smoke renders the packaged webviews in Electron on
+    # the macOS runner. It needs just the Vite webview bundles
+    # (packages/extension/dist/*/bundle.js) — not the esbuild extension-host
+    # compile, typecheck, lint, or kernel tests, which the `validate` job
+    # already covers on Linux. Keeping this job lean avoids paying macOS rates
+    # to re-run platform-independent checks.
+    runs-on: macos-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build webview smoke assets
+        run: pnpm run vite:webviews
+
+      - name: Smoke extension webviews in Electron
+        run: pnpm run smoke:webviews:run
+
+      - name: Upload webview smoke screenshots
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: texra-webview-smoke-screenshots
+          path: artifacts/webview-smoke/*.png
+          if-no-files-found: ignore
           retention-days: 14
 
   docs-check:
@@ -187,16 +212,22 @@ jobs:
     needs:
       - changes
       - validate
+      - webview-smoke
       - docs-check
     if: always()
 
     steps:
       - name: Require validation jobs success
         run: |
-          # On code PRs the validate matrix gates; on docs-only PRs it is skipped
-          # and the lightweight docs build gates instead — require whichever ran.
+          # On code PRs the validate + webview-smoke jobs gate; on docs-only PRs
+          # they are skipped and the lightweight docs build gates instead —
+          # require whichever ran.
           if [ '${{ needs.validate.result }}' != 'success' ] && [ '${{ needs.validate.result }}' != 'skipped' ]; then
-            echo 'Validation matrix result: ${{ needs.validate.result }}'
+            echo 'Validation result: ${{ needs.validate.result }}'
+            exit 1
+          fi
+          if [ '${{ needs.webview-smoke.result }}' != 'success' ] && [ '${{ needs.webview-smoke.result }}' != 'skipped' ]; then
+            echo 'Webview smoke result: ${{ needs.webview-smoke.result }}'
             exit 1
           fi
           if [ '${{ needs.docs-check.result }}' != 'success' ] && [ '${{ needs.docs-check.result }}' != 'skipped' ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           fi
 
   validate:
-    name: validate
+    name: validate (linux)
     needs: changes
     if: needs.changes.outputs.code == 'true'
     # OS-independent checks (typecheck/lint/tests/compile) and the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           # Heavy validation (typecheck/lint/tests/build) only runs when a PR touches
           # something other than docs. Docs-only PRs fall through to the
           # lightweight docs-build job below, keeping CI spend down. Pushes to
-          # main and manual dispatches always run the full matrix.
+          # main and manual dispatches always run full validation.
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "Event '${{ github.event_name }}' -> full validation."
             echo "code=true" >> "$GITHUB_OUTPUT"
@@ -181,7 +181,7 @@ jobs:
   docs-check:
     name: docs build
     needs: changes
-    # Runs only for docs-only PRs (where the heavy validate matrix is skipped).
+    # Runs only for docs-only PRs (where the heavy validate job is skipped).
     # The VitePress docs are a self-contained npm sub-project, so this mirrors
     # docs-deploy.yml's install/build rather than the pnpm workspace.
     if: needs.changes.outputs.code != 'true'


### PR DESCRIPTION
## Problem

The `validate` job in `.github/workflows/ci.yml` ran as a matrix over **both** `ubuntu-latest` and `macos-latest`. The un-gated steps — `typecheck`, core `typecheck`, `lint`, `check:extension-package-invariants`, kernel `test`, and `compile` — are all platform-independent, yet executed on **both** runners.

GitHub bills macOS minutes at ~**10× Linux rates**, so every code PR paid macOS prices to re-run checks that already passed on Linux. That's overlapping coverage that wastes money.

## Change

Split the matrix into two focused jobs:

- **`validate`** (`ubuntu-latest`) — owns every OS-independent check plus the Linux-only artifacts (CLI TUI frames, extension VSIX).
- **`webview-smoke`** (`macos-latest`) — runs *only* the macOS-specific Electron webview smoke (`vite:webviews` → `smoke:webviews:run`) + screenshot upload.

The macOS smoke was confirmed to need only the Vite webview bundles (`packages/extension/dist/*/bundle.js`) — not the esbuild compile, typecheck, lint, or kernel tests. The `validate-status` gate now requires both jobs (or their docs-only skips).

## Impact

- **No coverage lost** — the macOS runner just stops repeating Linux-covered work.
- Each code PR drops roughly 5–7 min of 10×-billed macOS compute.

## Out of scope (intentionally)

Two other per-PR cost items were left untouched pending a policy decision on review coverage:

- Two LLM review bots (`claude-code-review.yml` + `texra-code-review.yml`) both fire on every PR push.
- The `synchronize` trigger re-runs those reviews on every push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtTmBPbXJvtZhyoPmCid9R

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtTmBPbXJvtZhyoPmCid9R)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only refactor with the same checks split across runners; main risk is mis-gating if a job is skipped incorrectly, but logic mirrors the prior matrix behavior.
> 
> **Overview**
> **CI cost and layout:** The `validate` job no longer uses an `ubuntu` + `macOS` matrix. It runs only on **Linux** and owns typecheck, lint, tests, compile, CLI TUI frames, and extension VSIX build/check/upload (Linux-only `if` guards removed).
> 
> **New `webview-smoke` job** on **macOS** runs only `vite:webviews`, Electron webview smoke, and screenshot upload—so macOS minutes are not spent repeating checks already done on Linux.
> 
> The **`validate-status`** aggregate job now requires **`webview-smoke`** to succeed or be skipped (along with `validate` and docs-only `docs-check`), preserving gating for code vs docs-only PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a7536e7b359585e762472b49e18d6e0136a8c55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->