### PR TITLE
Adopt modern VS Code APIs across pickers, status bar, and chat tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,22 @@ All notable changes to this project will be documented in this file.
 - **Clearer validation error messages** — when a configuration value, stored session, or API response fails schema validation, the error now reads as a concise human-readable summary of what was wrong instead of a raw JSON dump of the validation internals.
 - **Diagnostic logs survive circular references** — object-to-log formatting no longer collapses to an opaque `[object Object]` when a value contains a circular reference; the structure is preserved with `[Circular]` markers so log lines stay useful.
 
+### VS Code Extension
+
+#### Features
+
+- **TeXRA research tools in Copilot Chat** — when running on a VS Code build that supports the Language Model Tool API, TeXRA's arXiv search, web fetch, and Crossref search are available in Copilot Chat as `#texra_arxiv_search`, `#texra_web_fetch`, and `#texra_crossref_search`, so agents can pull papers, web pages, and citations without leaving chat. Hosts without the API simply don't show them.
+- **Live usage in the status bar** — hovering the TeXRA status bar item now shows a running cost and input/output token total for active streams, so you can keep an eye on spend without opening the task board.
+
+#### Improvements
+
+- **Clearer pickers** — file, credential, review, and tool-selection menus now keep an explanatory hint visible as you type (on VS Code 1.108+): the latexdiff math-markup and review pickers show your saved default, the API-key picker reminds you keys are stored encrypted, the "Accept edits" picker keeps the edited filename in view, and the review flow echoes your focus text. Entering an API key offers a one-click "Get API key" button inline (VS Code 1.109+).
+
+#### Bug Fixes
+
+- **Tool-edit approval no longer hangs when you close the diff** — closing the proposed-edit diff tab now rejects the edit instead of leaving the agent waiting indefinitely.
+- **More precise diff cleanup** — finishing a tool-edit approval now only closes that exact diff, never an unrelated diff that happens to share a file.
+
 ### CLI
 
 #### Features

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -35,6 +35,156 @@
         "label": "TeXRA"
       }
     ],
+    "languageModelTools": [
+      {
+        "name": "texra_arxiv_search",
+        "displayName": "arXiv Search",
+        "modelDescription": "Search arXiv for papers and return basic metadata for each hit. Use field=\"author\" for author name searches.",
+        "toolReferenceName": "texra_arxiv_search",
+        "canBeReferencedInPrompt": true,
+        "icon": "$(search)",
+        "tags": [
+          "texra",
+          "research",
+          "arxiv"
+        ],
+        "inputSchema": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "Search query terms, title text, or author names."
+            },
+            "field": {
+              "type": "string",
+              "enum": [
+                "all",
+                "author",
+                "title",
+                "abstract"
+              ],
+              "description": "Search field: \"author\" for author names, \"title\" for paper titles, \"abstract\" for abstracts, \"all\" (default) for all fields."
+            },
+            "categories": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Optional arXiv category filters such as \"math.NT\" or \"cs.AI\"."
+            },
+            "maxResults": {
+              "type": "integer",
+              "description": "Maximum number of papers to return."
+            },
+            "start": {
+              "type": "integer",
+              "description": "Zero-based result offset for pagination."
+            },
+            "sortBy": {
+              "type": "string",
+              "enum": [
+                "relevance",
+                "lastUpdatedDate",
+                "submittedDate"
+              ],
+              "description": "arXiv sort field to use."
+            },
+            "sortOrder": {
+              "type": "string",
+              "enum": [
+                "ascending",
+                "descending"
+              ],
+              "description": "Sort direction for results."
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      },
+      {
+        "name": "texra_web_fetch",
+        "displayName": "Web Fetch",
+        "modelDescription": "Fetch content from a URL and return it as clean text. Include an optional prompt to explain what context you need so the fetched content can be interpreted correctly.",
+        "toolReferenceName": "texra_web_fetch",
+        "canBeReferencedInPrompt": true,
+        "icon": "$(globe)",
+        "tags": [
+          "texra",
+          "research",
+          "web"
+        ],
+        "inputSchema": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "Public HTTP or HTTPS URL to fetch."
+            },
+            "prompt": {
+              "type": "string",
+              "description": "Optional instruction describing what to extract from the page."
+            }
+          },
+          "required": [
+            "url"
+          ]
+        }
+      },
+      {
+        "name": "texra_crossref_search",
+        "displayName": "Crossref Search",
+        "modelDescription": "Search Crossref works (journal articles, books, conference papers) and return top matches with bibliographic metadata.",
+        "toolReferenceName": "texra_crossref_search",
+        "canBeReferencedInPrompt": true,
+        "icon": "$(book)",
+        "tags": [
+          "texra",
+          "research",
+          "citation"
+        ],
+        "inputSchema": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "Bibliographic search query for Crossref works."
+            },
+            "rows": {
+              "type": "integer",
+              "description": "Maximum number of works to return."
+            },
+            "offset": {
+              "type": "integer",
+              "description": "Zero-based result offset for pagination."
+            },
+            "sort": {
+              "type": "string",
+              "description": "Crossref sort field to apply."
+            },
+            "order": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "description": "Crossref sort order."
+            },
+            "filter": {
+              "type": "string",
+              "description": "Crossref filter string, e.g. \"from-pub-date:2023\"."
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      }
+    ],
     "configuration": [
       {
         "title": "TeXRA",

--- a/packages/extension/src/commands/agent/agentCreatorCommands.ts
+++ b/packages/extension/src/commands/agent/agentCreatorCommands.ts
@@ -106,12 +106,14 @@ async function pickToolGroups(
         iconPath: new vscode.ThemeIcon('check-all'),
         tooltip: 'Select all / clear',
       };
+      let activeSelectAllButton: vscode.QuickInputButton | undefined;
       const refreshSelectAllButton = () => {
         if ('buttons' in qp) {
           const toggleButton: QuickInputToggleButton = {
             ...selectAllButton,
             toggle: { checked: allSelected },
           };
+          activeSelectAllButton = toggleButton;
           qp.buttons = [toggleButton];
         }
       };
@@ -121,7 +123,10 @@ async function pickToolGroups(
           selected.length > 0 && selected.length === qp.items.length;
         refreshSelectAllButton();
       });
-      qp.onDidTriggerButton(() => {
+      qp.onDidTriggerButton((button) => {
+        if (button !== activeSelectAllButton) {
+          return;
+        }
         allSelected = qp.items.length > 0 && !allSelected;
         qp.selectedItems = allSelected ? [...qp.items] : [];
         refreshSelectAllButton();

--- a/packages/extension/src/commands/agent/agentCreatorCommands.ts
+++ b/packages/extension/src/commands/agent/agentCreatorCommands.ts
@@ -23,6 +23,10 @@ interface ParsedCreatorYaml {
   prompts: { systemPrompt: string; userRequest: string; retryPrompt?: string };
 }
 
+type QuickInputToggleButton = vscode.QuickInputButton & {
+  readonly toggle: { checked: boolean };
+};
+
 /** Cached after first load. Templates are bundled resources — stable for the session. */
 let creatorConfig: CreatorConfig | null = null;
 
@@ -104,9 +108,11 @@ async function pickToolGroups(
       };
       const refreshSelectAllButton = () => {
         if ('buttons' in qp) {
-          qp.buttons = [
-            { ...selectAllButton, toggle: { checked: allSelected } },
-          ];
+          const toggleButton: QuickInputToggleButton = {
+            ...selectAllButton,
+            toggle: { checked: allSelected },
+          };
+          qp.buttons = [toggleButton];
         }
       };
       refreshSelectAllButton();

--- a/packages/extension/src/commands/agent/agentCreatorCommands.ts
+++ b/packages/extension/src/commands/agent/agentCreatorCommands.ts
@@ -60,6 +60,78 @@ async function loadCreatorConfig(
   return creatorConfig;
 }
 
+/**
+ * Multi-select tool-group picker. Adds a persistent prompt hint (VS Code
+ * 1.108+) and a "Select all / Clear" toggle button (VS Code 1.109+) on top
+ * of the stateful multi-select. Older hosts (incl. Cursor 1.105) silently
+ * ignore the unsupported properties and render a plain `canSelectMany` picker.
+ */
+async function pickToolGroups(
+  agentName: string,
+  items: vscode.QuickPickItem[],
+): Promise<readonly vscode.QuickPickItem[] | undefined> {
+  return await new Promise<readonly vscode.QuickPickItem[] | undefined>(
+    (resolve) => {
+      const qp = vscode.window.createQuickPick();
+      let settled = false;
+      const finish = (
+        value: readonly vscode.QuickPickItem[] | undefined,
+      ): void => {
+        if (settled) return;
+        settled = true;
+        resolve(value);
+        qp.dispose();
+      };
+      qp.title = `Tool Use Agent: ${agentName}`;
+      qp.placeholder = 'Select tool groups';
+      qp.canSelectMany = true;
+      qp.items = items;
+      const initiallySelected = items.filter((item) => item.picked);
+      qp.selectedItems = initiallySelected;
+      if ('prompt' in qp) {
+        (
+          qp as vscode.QuickPick<vscode.QuickPickItem> & { prompt: string }
+        ).prompt =
+          'Space / click to toggle. Pre-selected groups match your description.';
+      }
+
+      let allSelected =
+        initiallySelected.length > 0 &&
+        initiallySelected.length === items.length;
+      const selectAllButton: vscode.QuickInputButton = {
+        iconPath: new vscode.ThemeIcon('check-all'),
+        tooltip: 'Select all / clear',
+      };
+      const refreshSelectAllButton = () => {
+        if ('buttons' in qp) {
+          qp.buttons = [
+            { ...selectAllButton, toggle: { checked: allSelected } },
+          ];
+        }
+      };
+      refreshSelectAllButton();
+      qp.onDidChangeSelection((selected) => {
+        allSelected =
+          selected.length > 0 && selected.length === qp.items.length;
+        refreshSelectAllButton();
+      });
+      qp.onDidTriggerButton(() => {
+        allSelected = qp.items.length > 0 && !allSelected;
+        qp.selectedItems = allSelected ? [...qp.items] : [];
+        refreshSelectAllButton();
+      });
+
+      qp.onDidAccept(() => {
+        finish(qp.selectedItems);
+      });
+      qp.onDidHide(() => {
+        finish(undefined);
+      });
+      qp.show();
+    },
+  );
+}
+
 function buildVSCodeUI(): AgentCreatorUI {
   return {
     async promptAgentName(categoryLabel) {
@@ -84,21 +156,16 @@ function buildVSCodeUI(): AgentCreatorUI {
         if (group.keywords.some((kw) => lower.includes(kw)))
           suggested.add(name);
       }
-      const selected = await vscode.window.showQuickPick(
-        Object.entries(TOOL_GROUPS).map(([label, group]) => ({
+      const items: vscode.QuickPickItem[] = Object.entries(TOOL_GROUPS).map(
+        ([label, group]) => ({
           label,
           description: group.description,
           detail: group.tools.join(', '),
           picked: suggested.has(label),
-        })),
-        {
-          title: `Tool Use Agent: ${agentName}`,
-          placeHolder:
-            'Select tool groups (pre-selected based on your description)',
-          prompt: 'Choose which tool groups this agent should have access to',
-          canPickMany: true,
-        },
+        }),
       );
+
+      const selected = await pickToolGroups(agentName, items);
       if (!selected || selected.length === 0) return undefined;
       const tools: string[] = [];
       const groups: string[] = [];

--- a/packages/extension/src/commands/api/apiKeyCommands.ts
+++ b/packages/extension/src/commands/api/apiKeyCommands.ts
@@ -26,45 +26,8 @@ async function refreshApiKeyUI(): Promise<void> {
   await vscode.commands.executeCommand('texra.refreshAllOptions');
 }
 
-function supportsInputBoxTitleButtons(): boolean {
-  const inputBox = vscode.window.createInputBox();
-  try {
-    return 'buttons' in inputBox;
-  } finally {
-    inputBox.dispose();
-  }
-}
-
-async function setApiKeyForProvider(
-  provider: ApiProvider,
-  skipDialog = false,
-): Promise<void> {
-  // Newer VS Code hosts support placing a QuickInputButton in the input box's
-  // title area. Feature detection keeps this correct for older Cursor builds
-  // and any future major VS Code version.
-  const supportsTitleButton = supportsInputBoxTitleButtons();
-
-  if (!skipDialog && !supportsTitleButton) {
-    const actions: Array<vscode.MessageItem & { id: 'enter' | 'getApiKey' }> = [
-      { title: 'Enter Key', id: 'enter' },
-      { title: 'Get API Key', id: 'getApiKey' },
-    ];
-    const action = await vscode.window.showInformationMessage(
-      `Set your ${provider} API key`,
-      ...actions,
-    );
-
-    if (!action) {
-      return;
-    }
-
-    if (action.id === 'getApiKey') {
-      await vscode.env.openExternal(vscode.Uri.parse(PROVIDER_URLS[provider]));
-      return;
-    }
-  }
-
-  const apiKey = await promptForApiKey(provider, supportsTitleButton);
+async function setApiKeyForProvider(provider: ApiProvider): Promise<void> {
+  const apiKey = await promptForApiKey(provider);
 
   if (!apiKey) {
     return;
@@ -91,23 +54,14 @@ async function setApiKeyForProvider(
 }
 
 /**
- * Prompt for an API key. When the host supports title-area input buttons
- * (VS Code 1.109+), attach a "Get API Key" button that opens the provider's
- * key portal without closing the input box, so the user can paste straight
- * away. Otherwise fall back to a plain input box.
+ * Prompt for an API key with an inline "Get API Key" button that opens the
+ * provider's key portal without closing the input box, so the user can paste
+ * straight away. InputBox title buttons are within the supported VS Code engine
+ * range for this extension.
  */
 async function promptForApiKey(
   provider: ApiProvider,
-  withGetKeyButton: boolean,
 ): Promise<string | undefined> {
-  if (!withGetKeyButton) {
-    return vscode.window.showInputBox({
-      prompt: `Enter ${provider} API key`,
-      password: true,
-      placeHolder: '************************************',
-    });
-  }
-
   return await new Promise<string | undefined>((resolve) => {
     const ib = vscode.window.createInputBox();
     let settled = false;
@@ -148,7 +102,7 @@ async function promptForApiKey(
  */
 export async function setApiKey(provider?: ApiProvider): Promise<void> {
   if (provider) {
-    await setApiKeyForProvider(provider, true);
+    await setApiKeyForProvider(provider);
     return;
   }
 

--- a/packages/extension/src/commands/api/apiKeyCommands.ts
+++ b/packages/extension/src/commands/api/apiKeyCommands.ts
@@ -171,6 +171,10 @@ async function pickProvider(
     };
     qp.placeholder = placeholder;
     qp.items = items;
+    const defaultItem = items[0];
+    if (defaultItem) {
+      qp.activeItems = [defaultItem];
+    }
     if ('prompt' in qp) {
       (
         qp as vscode.QuickPick<ProviderQuickPickItem> & { prompt: string }

--- a/packages/extension/src/commands/api/apiKeyCommands.ts
+++ b/packages/extension/src/commands/api/apiKeyCommands.ts
@@ -54,10 +54,9 @@ async function setApiKeyForProvider(provider: ApiProvider): Promise<void> {
 }
 
 /**
- * Prompt for an API key with an inline "Get API Key" button that opens the
- * provider's key portal without closing the input box, so the user can paste
- * straight away. InputBox title buttons are within the supported VS Code engine
- * range for this extension.
+ * Prompt for an API key. When the host exposes InputBox title buttons, add a
+ * "Get API Key" action that opens the provider's key portal without closing the
+ * input box, so the user can paste straight away.
  */
 async function promptForApiKey(
   provider: ApiProvider,
@@ -79,12 +78,16 @@ async function promptForApiKey(
       iconPath: new vscode.ThemeIcon('link-external'),
       tooltip: `Get ${provider} API key`,
     };
-    ib.buttons = [getKeyButton];
-    ib.onDidTriggerButton((button) => {
-      if (button === getKeyButton) {
-        void vscode.env.openExternal(vscode.Uri.parse(PROVIDER_URLS[provider]));
-      }
-    });
+    if ('buttons' in ib) {
+      ib.buttons = [getKeyButton];
+      ib.onDidTriggerButton((button) => {
+        if (button === getKeyButton) {
+          void vscode.env.openExternal(
+            vscode.Uri.parse(PROVIDER_URLS[provider]),
+          );
+        }
+      });
+    }
     ib.onDidAccept(() => {
       finish(ib.value);
     });

--- a/packages/extension/src/commands/api/apiKeyCommands.ts
+++ b/packages/extension/src/commands/api/apiKeyCommands.ts
@@ -30,7 +30,14 @@ async function setApiKeyForProvider(
   provider: ApiProvider,
   skipDialog = false,
 ): Promise<void> {
-  if (!skipDialog) {
+  // VS Code 1.109+ supports placing a QuickInputButton in the input box's
+  // title area, so we can offer "Get API Key" inline and skip the extra
+  // info-message step. On older hosts (incl. Cursor 1.105) we keep the
+  // legacy two-step dialog.
+  const vsMinor = Number.parseInt(vscode.version.split('.')[1] ?? '0', 10);
+  const supportsTitleButton = vsMinor >= 109;
+
+  if (!skipDialog && !supportsTitleButton) {
     const actions: Array<vscode.MessageItem & { id: 'enter' | 'getApiKey' }> = [
       { title: 'Enter Key', id: 'enter' },
       { title: 'Get API Key', id: 'getApiKey' },
@@ -50,11 +57,7 @@ async function setApiKeyForProvider(
     }
   }
 
-  const apiKey = await vscode.window.showInputBox({
-    prompt: `Enter ${provider} API key`,
-    password: true,
-    placeHolder: '************************************',
-  });
+  const apiKey = await promptForApiKey(provider, supportsTitleButton);
 
   if (!apiKey) {
     return;
@@ -81,6 +84,57 @@ async function setApiKeyForProvider(
 }
 
 /**
+ * Prompt for an API key. When the host supports title-area input buttons
+ * (VS Code 1.109+), attach a "Get API Key" button that opens the provider's
+ * key portal without closing the input box, so the user can paste straight
+ * away. Otherwise fall back to a plain input box.
+ */
+async function promptForApiKey(
+  provider: ApiProvider,
+  withGetKeyButton: boolean,
+): Promise<string | undefined> {
+  if (!withGetKeyButton) {
+    return vscode.window.showInputBox({
+      prompt: `Enter ${provider} API key`,
+      password: true,
+      placeHolder: '************************************',
+    });
+  }
+
+  return await new Promise<string | undefined>((resolve) => {
+    const ib = vscode.window.createInputBox();
+    let settled = false;
+    const finish = (value: string | undefined): void => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+      ib.dispose();
+    };
+    ib.title = `Set ${provider} API key`;
+    ib.prompt = `Enter ${provider} API key`;
+    ib.password = true;
+    ib.placeholder = '************************************';
+    const getKeyButton: vscode.QuickInputButton = {
+      iconPath: new vscode.ThemeIcon('link-external'),
+      tooltip: `Get ${provider} API key`,
+    };
+    ib.buttons = [getKeyButton];
+    ib.onDidTriggerButton((button) => {
+      if (button === getKeyButton) {
+        void vscode.env.openExternal(vscode.Uri.parse(PROVIDER_URLS[provider]));
+      }
+    });
+    ib.onDidAccept(() => {
+      finish(ib.value);
+    });
+    ib.onDidHide(() => {
+      finish(undefined);
+    });
+    ib.show();
+  });
+}
+
+/**
  * Set an API key. Migrated to the shared command registry in
  * #3781 batch 4. The registry forwards a single typed argument so the
  * optional `provider` is parsed at the dispatch boundary.
@@ -92,14 +146,51 @@ export async function setApiKey(provider?: ApiProvider): Promise<void> {
   }
 
   const providerItems = await SecretManager.getApiProviderQuickPickItems();
-  const providerPick = await vscode.window.showQuickPick(providerItems, {
-    placeHolder: 'Select API provider',
-    prompt: 'Choose the AI provider to configure an API key for',
-  });
+  const providerPick = await pickProvider(
+    providerItems,
+    'Select API provider',
+    "Keys are stored in VS Code's encrypted secret store, never on disk.",
+  );
 
   if (providerPick?.provider) {
     await setApiKeyForProvider(providerPick.provider);
   }
+}
+
+type ProviderQuickPickItem = Awaited<
+  ReturnType<typeof SecretManager.getApiProviderQuickPickItems>
+>[number];
+
+/** Shared provider picker with a persistent prompt hint (VS Code 1.108+). */
+async function pickProvider(
+  items: ProviderQuickPickItem[],
+  placeholder: string,
+  promptHint: string,
+): Promise<ProviderQuickPickItem | undefined> {
+  return await new Promise<ProviderQuickPickItem | undefined>((resolve) => {
+    const qp = vscode.window.createQuickPick<ProviderQuickPickItem>();
+    let settled = false;
+    const finish = (value: ProviderQuickPickItem | undefined): void => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+      qp.dispose();
+    };
+    qp.placeholder = placeholder;
+    qp.items = items;
+    if ('prompt' in qp) {
+      (
+        qp as vscode.QuickPick<ProviderQuickPickItem> & { prompt: string }
+      ).prompt = promptHint;
+    }
+    qp.onDidAccept(() => {
+      finish(qp.activeItems[0] ?? qp.selectedItems[0]);
+    });
+    qp.onDidHide(() => {
+      finish(undefined);
+    });
+    qp.show();
+  });
 }
 
 /**
@@ -108,10 +199,11 @@ export async function setApiKey(provider?: ApiProvider): Promise<void> {
  */
 export async function removeApiKey(): Promise<void> {
   const providerItems = await SecretManager.getApiProviderQuickPickItems();
-  const providerPick = await vscode.window.showQuickPick(providerItems, {
-    placeHolder: 'Select API provider to remove key',
-    prompt: 'Choose the AI provider whose API key you want to remove',
-  });
+  const providerPick = await pickProvider(
+    providerItems,
+    'Select API provider to remove key',
+    'Only removes the key from TeXRA — does not delete it from the provider.',
+  );
 
   const provider = providerPick?.provider;
   if (!provider) {

--- a/packages/extension/src/commands/api/apiKeyCommands.ts
+++ b/packages/extension/src/commands/api/apiKeyCommands.ts
@@ -26,16 +26,23 @@ async function refreshApiKeyUI(): Promise<void> {
   await vscode.commands.executeCommand('texra.refreshAllOptions');
 }
 
+function supportsInputBoxTitleButtons(): boolean {
+  const inputBox = vscode.window.createInputBox();
+  try {
+    return 'buttons' in inputBox;
+  } finally {
+    inputBox.dispose();
+  }
+}
+
 async function setApiKeyForProvider(
   provider: ApiProvider,
   skipDialog = false,
 ): Promise<void> {
-  // VS Code 1.109+ supports placing a QuickInputButton in the input box's
-  // title area, so we can offer "Get API Key" inline and skip the extra
-  // info-message step. On older hosts (incl. Cursor 1.105) we keep the
-  // legacy two-step dialog.
-  const vsMinor = Number.parseInt(vscode.version.split('.')[1] ?? '0', 10);
-  const supportsTitleButton = vsMinor >= 109;
+  // Newer VS Code hosts support placing a QuickInputButton in the input box's
+  // title area. Feature detection keeps this correct for older Cursor builds
+  // and any future major VS Code version.
+  const supportsTitleButton = supportsInputBoxTitleButtons();
 
   if (!skipDialog && !supportsTitleButton) {
     const actions: Array<vscode.MessageItem & { id: 'enter' | 'getApiKey' }> = [

--- a/packages/extension/src/commands/api/apiKeyCommands.ts
+++ b/packages/extension/src/commands/api/apiKeyCommands.ts
@@ -26,8 +26,11 @@ async function refreshApiKeyUI(): Promise<void> {
   await vscode.commands.executeCommand('texra.refreshAllOptions');
 }
 
-async function setApiKeyForProvider(provider: ApiProvider): Promise<void> {
-  const apiKey = await promptForApiKey(provider);
+async function setApiKeyForProvider(
+  provider: ApiProvider,
+  showNavigationFallback = false,
+): Promise<void> {
+  const apiKey = await promptForApiKey(provider, showNavigationFallback);
 
   if (!apiKey) {
     return;
@@ -56,13 +59,39 @@ async function setApiKeyForProvider(provider: ApiProvider): Promise<void> {
 /**
  * Prompt for an API key. When the host exposes InputBox title buttons, add a
  * "Get API Key" action that opens the provider's key portal without closing the
- * input box, so the user can paste straight away.
+ * input box, so the user can paste straight away. Older hosts use the previous
+ * message-button fallback when the provider-picker path asks for it.
  */
 async function promptForApiKey(
   provider: ApiProvider,
+  showNavigationFallback: boolean,
 ): Promise<string | undefined> {
+  const ib = vscode.window.createInputBox();
+  const supportsTitleButtons = Reflect.has(ib, 'buttons');
+
+  if (!supportsTitleButtons && showNavigationFallback) {
+    const actions: Array<vscode.MessageItem & { id: 'enter' | 'getApiKey' }> = [
+      { title: 'Enter Key', id: 'enter' },
+      { title: 'Get API Key', id: 'getApiKey' },
+    ];
+    const action = await vscode.window.showInformationMessage(
+      `Set your ${provider} API key`,
+      ...actions,
+    );
+
+    if (action == null) {
+      ib.dispose();
+      return undefined;
+    }
+
+    if (action.id === 'getApiKey') {
+      ib.dispose();
+      await vscode.env.openExternal(vscode.Uri.parse(PROVIDER_URLS[provider]));
+      return undefined;
+    }
+  }
+
   return await new Promise<string | undefined>((resolve) => {
-    const ib = vscode.window.createInputBox();
     let settled = false;
     const finish = (value: string | undefined): void => {
       if (settled) return;
@@ -78,7 +107,7 @@ async function promptForApiKey(
       iconPath: new vscode.ThemeIcon('link-external'),
       tooltip: `Get ${provider} API key`,
     };
-    if ('buttons' in ib) {
+    if (supportsTitleButtons) {
       ib.buttons = [getKeyButton];
       ib.onDidTriggerButton((button) => {
         if (button === getKeyButton) {
@@ -117,7 +146,7 @@ export async function setApiKey(provider?: ApiProvider): Promise<void> {
   );
 
   if (providerPick?.provider) {
-    await setApiKeyForProvider(providerPick.provider);
+    await setApiKeyForProvider(providerPick.provider, true);
   }
 }
 

--- a/packages/extension/src/commands/auth/authCommands.ts
+++ b/packages/extension/src/commands/auth/authCommands.ts
@@ -114,7 +114,12 @@ export async function signIn(): Promise<boolean> {
       };
       qp.title = 'TeXRA Sign In';
       qp.placeholder = 'Choose a sign-in method';
-      qp.items = getSignInOptions();
+      const options = getSignInOptions();
+      qp.items = options;
+      const defaultOption = options[0];
+      if (defaultOption) {
+        qp.activeItems = [defaultOption];
+      }
       // VS Code 1.108+: explain what signing in grants. Ignored on older hosts.
       if ('prompt' in qp) {
         (qp as vscode.QuickPick<SignInOption> & { prompt: string }).prompt =

--- a/packages/extension/src/commands/auth/authCommands.ts
+++ b/packages/extension/src/commands/auth/authCommands.ts
@@ -103,9 +103,30 @@ export async function signIn(): Promise<boolean> {
       return true;
     }
 
-    const selected = await vscode.window.showQuickPick(getSignInOptions(), {
-      placeHolder: 'Choose a sign-in method',
-      title: 'TeXRA Sign In',
+    const selected = await new Promise<SignInOption | undefined>((resolve) => {
+      const qp = vscode.window.createQuickPick<SignInOption>();
+      let settled = false;
+      const finish = (value: SignInOption | undefined): void => {
+        if (settled) return;
+        settled = true;
+        resolve(value);
+        qp.dispose();
+      };
+      qp.title = 'TeXRA Sign In';
+      qp.placeholder = 'Choose a sign-in method';
+      qp.items = getSignInOptions();
+      // VS Code 1.108+: explain what signing in grants. Ignored on older hosts.
+      if ('prompt' in qp) {
+        (qp as vscode.QuickPick<SignInOption> & { prompt: string }).prompt =
+          'Sign in to access AI models, remote agents, and TeXRA Researcher features';
+      }
+      qp.onDidAccept(() => {
+        finish(qp.activeItems[0] ?? qp.selectedItems[0]);
+      });
+      qp.onDidHide(() => {
+        finish(undefined);
+      });
+      qp.show();
     });
     if (!selected) return false;
 

--- a/packages/extension/src/commands/latex/compareCommands.ts
+++ b/packages/extension/src/commands/latex/compareCommands.ts
@@ -207,25 +207,49 @@ async function resolveAcceptTarget(
   }
 
   const copyTarget = buildCopyTarget(baseLocation, copyMeta);
-  const pick = await vscode.window.showQuickPick(
-    [
-      {
-        label: '$(replace) Replace original',
-        description: replaceTarget.targetFileName,
-        target: replaceTarget,
-      },
-      {
-        label: '$(files) Save as copy',
-        description: copyTarget.targetFileName,
-        target: copyTarget,
-      },
-    ],
+  type AcceptItem = vscode.QuickPickItem & {
+    target: { targetLocation: FileLocation; targetFileName: string };
+  };
+  const acceptItems: AcceptItem[] = [
     {
-      title: 'Accept edits',
-      placeHolder: `Accept '${path.basename(editedPath)}' into the workspace`,
-      ignoreFocusOut: true,
+      label: '$(replace) Replace original',
+      description: replaceTarget.targetFileName,
+      target: replaceTarget,
     },
-  );
+    {
+      label: '$(files) Save as copy',
+      description: copyTarget.targetFileName,
+      target: copyTarget,
+    },
+  ];
+
+  const pick = await new Promise<AcceptItem | undefined>((resolve) => {
+    const qp = vscode.window.createQuickPick<AcceptItem>();
+    let settled = false;
+    const finish = (value: AcceptItem | undefined): void => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+      qp.dispose();
+    };
+    qp.title = 'Accept edits';
+    qp.placeholder = `Accept '${path.basename(editedPath)}' into the workspace`;
+    qp.ignoreFocusOut = true;
+    qp.items = acceptItems;
+    // VS Code 1.108+: keep the edited filename visible after the placeholder
+    // is cleared by typing — this is a destructive replace-vs-copy choice.
+    if ('prompt' in qp) {
+      (qp as vscode.QuickPick<AcceptItem> & { prompt: string }).prompt =
+        `Edited file: ${path.basename(editedPath)}`;
+    }
+    qp.onDidAccept(() => {
+      finish(qp.activeItems[0] ?? qp.selectedItems[0]);
+    });
+    qp.onDidHide(() => {
+      finish(undefined);
+    });
+    qp.show();
+  });
   return pick?.target;
 }
 

--- a/packages/extension/src/commands/latex/compareCommands.ts
+++ b/packages/extension/src/commands/latex/compareCommands.ts
@@ -236,6 +236,10 @@ async function resolveAcceptTarget(
     qp.placeholder = `Accept '${path.basename(editedPath)}' into the workspace`;
     qp.ignoreFocusOut = true;
     qp.items = acceptItems;
+    const defaultItem = acceptItems[0];
+    if (defaultItem) {
+      qp.activeItems = [defaultItem];
+    }
     // VS Code 1.108+: keep the edited filename visible after the placeholder
     // is cleared by typing — this is a destructive replace-vs-copy choice.
     if ('prompt' in qp) {

--- a/packages/extension/src/commands/latex/latexdiffCommands.ts
+++ b/packages/extension/src/commands/latex/latexdiffCommands.ts
@@ -103,6 +103,10 @@ async function promptForLatexdiffMathMarkup(): Promise<
     qp.placeholder = 'Select math markup granularity for this diff run';
     qp.ignoreFocusOut = true;
     qp.items = prioritizedItems;
+    const defaultItem = prioritizedItems.at(0);
+    if (defaultItem) {
+      qp.activeItems = [defaultItem];
+    }
     // VS Code 1.108+: show the saved default as a persistent hint below the
     // input box so users know why one item is listed first. Older hosts
     // (incl. Cursor 1.105) silently ignore the property.

--- a/packages/extension/src/commands/latex/latexdiffCommands.ts
+++ b/packages/extension/src/commands/latex/latexdiffCommands.ts
@@ -83,19 +83,47 @@ async function promptForLatexdiffMathMarkup(): Promise<
       picked: mode === configuredMode,
       value: mode,
     }));
+  // Keep the configured mode first so Enter accepts it immediately.
   const prioritizedItems = [
     ...items.filter((item) => item.value === configuredMode),
     ...items.filter((item) => item.value !== configuredMode),
   ];
 
-  const selection = await vscode.window.showQuickPick(prioritizedItems, {
-    title: 'Latexdiff math markup',
-    placeHolder: 'Select math markup granularity for this diff run',
-    ignoreFocusOut: true,
+  type MarkupItem = vscode.QuickPickItem & { value: MathMarkupOption };
+  return await new Promise<MathMarkupOption | undefined>((resolve) => {
+    const qp = vscode.window.createQuickPick<MarkupItem>();
+    let settled = false;
+    const finish = (value: MathMarkupOption | undefined): void => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+      qp.dispose();
+    };
+    qp.title = 'Latexdiff math markup';
+    qp.placeholder = 'Select math markup granularity for this diff run';
+    qp.ignoreFocusOut = true;
+    qp.items = prioritizedItems;
+    // VS Code 1.108+: show the saved default as a persistent hint below the
+    // input box so users know why one item is listed first. Older hosts
+    // (incl. Cursor 1.105) silently ignore the property.
+    if ('prompt' in qp) {
+      (qp as MarkupQuickPick).prompt =
+        `Saved default: ${configuredMode} — press Enter to accept, or pick another`;
+    }
+    qp.onDidAccept(() => {
+      const picked = qp.activeItems[0] ?? qp.selectedItems[0];
+      finish(picked?.value);
+    });
+    qp.onDidHide(() => {
+      finish(undefined);
+    });
+    qp.show();
   });
-
-  return selection?.value;
 }
+
+type MarkupQuickPick = vscode.QuickPick<
+  vscode.QuickPickItem & { value: MathMarkupOption }
+> & { prompt: string };
 
 async function openLatexdiffResult(
   base: FileLocation,

--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -227,10 +227,33 @@ async function ensureCredentialOrPrompt(): Promise<boolean> {
     },
   ];
 
-  const picked = await vscode.window.showQuickPick(picks, {
-    placeHolder:
-      'TeXRA needs a credential before the setup assistant can run models.',
-    title: 'TeXRA Setup',
+  type CredentialPick = (typeof picks)[number];
+  const picked = await new Promise<CredentialPick | undefined>((resolve) => {
+    const qp = vscode.window.createQuickPick<CredentialPick>();
+    let settled = false;
+    const finish = (value: CredentialPick | undefined): void => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+      qp.dispose();
+    };
+    qp.title = 'TeXRA Setup';
+    qp.placeholder =
+      'TeXRA needs a credential before the setup assistant can run models.';
+    qp.items = picks;
+    // VS Code 1.108+: the four choices are not self-explanatory in isolation,
+    // and the placeholder vanishes on first keystroke. The prompt persists.
+    if ('prompt' in qp) {
+      (qp as vscode.QuickPick<CredentialPick> & { prompt: string }).prompt =
+        'ChatGPT uses your Plus/Pro subscription; Researcher Access uses your TeXRA account; API Key requires a provider key.';
+    }
+    qp.onDidAccept(() => {
+      finish(qp.activeItems[0] ?? qp.selectedItems[0]);
+    });
+    qp.onDidHide(() => {
+      finish(undefined);
+    });
+    qp.show();
   });
 
   if (!picked) return false;

--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -241,6 +241,10 @@ async function ensureCredentialOrPrompt(): Promise<boolean> {
     qp.placeholder =
       'TeXRA needs a credential before the setup assistant can run models.';
     qp.items = picks;
+    const defaultPick = picks[0];
+    if (defaultPick) {
+      qp.activeItems = [defaultPick];
+    }
     // VS Code 1.108+: the four choices are not self-explanatory in isolation,
     // and the placeholder vanishes on first keystroke. The prompt persists.
     if ('prompt' in qp) {

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -42,7 +42,6 @@ import { openGettingStarted } from '@commands/system/walkthroughCommands';
 import { toErrorMessage } from '@common/errors';
 import { SIDEBAR_VIEWS, setActiveSidebarView } from '@common/webview';
 import { globalSM, initializeStateManagers, workspaceSM } from '@common/state';
-import { isTerminalStatus } from '@common/constants/streamStatus';
 import { bus } from '@eventBus/ProgressEventBus';
 import { SecretManager } from '@frontend/secretManager';
 import {
@@ -55,6 +54,7 @@ import {
 import { runTerminalCommand } from '@frontend/setupTerminalRunner';
 import { agentDirectories } from '@frontend/agents';
 import { FileLister } from '@frontend/files';
+import { StatusBarUsageTracker } from '@frontend/statusBar/StatusBarUsageTracker';
 import { killActiveRecording } from '@frontend/media/audio';
 import { disposeDiffRefresh } from '@frontend/ui/diffView';
 import { registerFileDecorations } from '@frontend/ui/fileDecorations';
@@ -63,6 +63,7 @@ import { initializeNativeToolEditApproval } from '@frontend/approval/nativeToolE
 import { SupabaseAuthProvider } from '@frontend/auth/SupabaseAuthProvider';
 import { SupabaseUriHandler } from '@frontend/auth/UriHandler';
 import { registerAgentEventListeners } from '@frontend/events/agentEventListeners';
+import { registerLanguageModelTools } from '@frontend/lm/registerLanguageModelTools';
 import { onTexraAuthSessionsChanged } from '@frontend/events/onTexraAuthSessionsChanged';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import * as leanVscodeIntegration from '@frontend/lean/VscodeIntegration';
@@ -81,7 +82,7 @@ import { VscodeSecrets } from '@frontend/vscode/vscodeSecrets';
 import { VscodeConfigProvider } from '@frontend/vscode/vscodeConfig';
 import * as logger from '@logger/logUtils';
 import { refreshModelListStateIfNeeded } from '@model/modelListRefresh';
-import { STREAM_STATUS, type StreamStatus } from '@shared/schemas';
+import { type StreamStatus, type TokenUsageStats } from '@shared/schemas';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { setOpenPdfOpener } from '@tools/OpenPdfTool';
 import { refreshToolAvailability } from '@tools/toolAvailability';
@@ -217,7 +218,9 @@ export async function activate(context: vscode.ExtensionContext) {
     },
   });
   registerAgentFeatures();
-  lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () => disposeStatusListener?.());
+  // `disposeStatusListener` and `statusBarItem` are owned solely by
+  // `context.subscriptions` (see the push near the end of `activate`), matching
+  // `apiKeyStatusBarItem`. Registering them here too would double-dispose.
   registerAgentShutdownHandlers(lifecycle);
   lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () => killActiveRecording());
   lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () => UsageLogService.dispose());
@@ -234,7 +237,6 @@ export async function activate(context: vscode.ExtensionContext) {
     bus.emit('extensionDeactivating', undefined),
   );
   lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => disposeDiffRefresh());
-  lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => statusBarItem?.dispose());
   await StorageFS.ensureDir(TASK_RUNS_DIR);
   FileLister.initialize(context);
   initializeServerSideKeyAccess(
@@ -661,9 +663,30 @@ export async function activate(context: vscode.ExtensionContext) {
     }),
   );
 
-  const runningStreams = new Set<string>();
+  const statusBarUsageTracker = new StatusBarUsageTracker();
+  const updateStatusBarTooltip = () => {
+    const { cost, inputTokens, outputTokens } =
+      statusBarUsageTracker.totalUsage;
+    if (cost === 0 && inputTokens === 0 && outputTokens === 0) {
+      statusBarItem!.tooltip = 'Show TeXRA Tasks';
+      return;
+    }
+    const tip = new vscode.MarkdownString(
+      [
+        '| TeXRA usage | |',
+        '| --- | ---: |',
+        `| Cost | $${cost.toFixed(4)} |`,
+        `| Input tokens | ${inputTokens.toLocaleString()} |`,
+        `| Output tokens | ${outputTokens.toLocaleString()} |`,
+        '',
+        '*Click to open the TeXRA task board*',
+      ].join('\n'),
+    );
+    tip.isTrusted = false;
+    statusBarItem!.tooltip = tip;
+  };
   const updateStatusBarText = () => {
-    const count = runningStreams.size;
+    const count = statusBarUsageTracker.activeStreamCount;
     if (count > 1) {
       statusBarItem!.text = `$(loading) TeXRA: ${count} active`;
     } else if (count === 1) {
@@ -673,17 +696,27 @@ export async function activate(context: vscode.ExtensionContext) {
     }
   };
 
-  disposeStatusListener = bus.on(
+  const disposeStreamStatusListener = bus.on(
     'updateStreamStatus',
     ({ streamId, status }: { streamId: string; status: StreamStatus }) => {
-      if (status === STREAM_STATUS.RUNNING) {
-        runningStreams.add(streamId);
-      } else if (isTerminalStatus(status)) {
-        runningStreams.delete(streamId);
-      }
+      statusBarUsageTracker.updateStreamStatus(streamId, status);
+      updateStatusBarTooltip();
       updateStatusBarText();
     },
   );
+  const disposeUsageListener = bus.on(
+    'updateStreamUsage',
+    ({ streamId, usage }: { streamId: string; usage: TokenUsageStats }) => {
+      // UsageMonitor emits per-round deltas; the tracker accumulates them.
+      if (statusBarUsageTracker.recordUsage(streamId, usage)) {
+        updateStatusBarTooltip();
+      }
+    },
+  );
+  disposeStatusListener = () => {
+    disposeStreamStatusListener();
+    disposeUsageListener();
+  };
 
   const showMainView = async () => {
     const mvp = getMainViewProvider();
@@ -697,6 +730,10 @@ export async function activate(context: vscode.ExtensionContext) {
   };
 
   const agentEventDisposable = registerAgentEventListeners();
+
+  // Surface curated research tools to VS Code's Language Model Tool API
+  // (Copilot Chat `#texra_*` references). No-op on hosts without the API.
+  registerLanguageModelTools(context);
 
   context.subscriptions.push(
     agentEventDisposable,

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -665,10 +665,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
   const statusBarUsageTracker = new StatusBarUsageTracker();
   const updateStatusBarTooltip = () => {
+    if (!statusBarItem) return;
     const { cost, inputTokens, outputTokens } =
       statusBarUsageTracker.totalUsage;
     if (cost === 0 && inputTokens === 0 && outputTokens === 0) {
-      statusBarItem!.tooltip = 'Show TeXRA Tasks';
+      statusBarItem.tooltip = 'Show TeXRA Tasks';
       return;
     }
     const tip = new vscode.MarkdownString(
@@ -683,16 +684,17 @@ export async function activate(context: vscode.ExtensionContext) {
       ].join('\n'),
     );
     tip.isTrusted = false;
-    statusBarItem!.tooltip = tip;
+    statusBarItem.tooltip = tip;
   };
   const updateStatusBarText = () => {
+    if (!statusBarItem) return;
     const count = statusBarUsageTracker.activeStreamCount;
     if (count > 1) {
-      statusBarItem!.text = `$(loading) TeXRA: ${count} active`;
+      statusBarItem.text = `$(loading) TeXRA: ${count} active`;
     } else if (count === 1) {
-      statusBarItem!.text = '$(loading) TeXRA: Running';
+      statusBarItem.text = '$(loading) TeXRA: Running';
     } else {
-      statusBarItem!.text = '$(bracket-dot) TeXRA: Idle';
+      statusBarItem.text = '$(bracket-dot) TeXRA: Idle';
     }
   };
 

--- a/packages/extension/src/frontend/approval/VscodeDiffViewHost.ts
+++ b/packages/extension/src/frontend/approval/VscodeDiffViewHost.ts
@@ -31,10 +31,8 @@ export class VscodeDiffViewHost implements DiffViewHost {
   }
 
   async closeDiff(session: DiffSession): Promise<void> {
-    const targetUris = new Set([
-      this.toUri(session.original).toString(),
-      this.toUri(session.proposed).toString(),
-    ]);
+    const originalUri = this.toUri(session.original).toString();
+    const proposedUri = this.toUri(session.proposed).toString();
 
     const tabsToClose: vscode.Tab[] = [];
     for (const group of vscode.window.tabGroups.all) {
@@ -44,9 +42,12 @@ export class VscodeDiffViewHost implements DiffViewHost {
           typeof vscode.TabInputTextDiff !== 'undefined' &&
           input instanceof vscode.TabInputTextDiff
         ) {
-          const original = input.original.toString();
-          const modified = input.modified.toString();
-          if (targetUris.has(original) && targetUris.has(modified)) {
+          // Require an exact pair match so we never close an unrelated diff
+          // that merely shares one side, nor a tab whose sides are swapped.
+          if (
+            input.original.toString() === originalUri &&
+            input.modified.toString() === proposedUri
+          ) {
             tabsToClose.push(tab);
           }
           continue;
@@ -56,7 +57,8 @@ export class VscodeDiffViewHost implements DiffViewHost {
           typeof vscode.TabInputText !== 'undefined' &&
           input instanceof vscode.TabInputText
         ) {
-          if (targetUris.has(input.uri.toString())) {
+          const uri = input.uri.toString();
+          if (uri === originalUri || uri === proposedUri) {
             tabsToClose.push(tab);
           }
         }

--- a/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
+++ b/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
@@ -183,20 +183,13 @@ async function nativeRequestApproval(
     );
     diffSession = openedSession;
 
-    await revealFirstChangedLine(
-      openedSession,
-      originalContent,
-      proposedContent,
-    );
-
-    result = await new Promise<ToolEditApprovalResult>((resolve) => {
-      let settled = false;
-
+    let approvalSettled = false;
+    const approvalPromise = new Promise<ToolEditApprovalResult>((resolve) => {
       const settle = (value: ToolEditApprovalResult) => {
-        if (settled) {
+        if (approvalSettled) {
           return;
         }
-        settled = true;
+        approvalSettled = true;
         // Note: Don't delete from pendingApprovals here - finally block handles cleanup
         resolve(value);
       };
@@ -211,7 +204,7 @@ async function nativeRequestApproval(
         title,
         streamId: streamId ?? undefined,
         lineChanges,
-        isSettled: () => settled,
+        isSettled: () => approvalSettled,
         settle,
         workspaceTempCleanup: [],
         latexOperationInProgress: false,
@@ -223,7 +216,7 @@ async function nativeRequestApproval(
       registerPendingApproval(requestId, {
         streamId: streamId ?? undefined,
         runtimeHost: getRuntimeHost(),
-        isSettled: () => settled,
+        isSettled: () => approvalSettled,
         settle,
       });
 
@@ -236,7 +229,7 @@ async function nativeRequestApproval(
         proposedSource.filePath,
       ).toString();
       tabCloseDisposable = vscode.window.tabGroups.onDidChangeTabs((event) => {
-        if (settled) {
+        if (approvalSettled) {
           tabCloseDisposable?.dispose();
           return;
         }
@@ -261,14 +254,30 @@ async function nativeRequestApproval(
           settle({ accepted: false });
         }
       });
+    });
 
+    try {
+      await revealFirstChangedLine(
+        openedSession,
+        originalContent,
+        proposedContent,
+      );
+    } catch (err) {
+      if (!approvalSettled) {
+        throw err;
+      }
+    }
+
+    if (!approvalSettled) {
       void showProgressViewApprovalPrompt(
         requestId,
         request,
         description,
         lineChanges,
       );
-    });
+    }
+
+    result = await approvalPromise;
 
     if (result.accepted) {
       // Normalize here: these reads bypass BaseFS so may contain CRLF.

--- a/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
+++ b/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
@@ -173,6 +173,7 @@ async function nativeRequestApproval(
   const title = `Tool edit (${sourceTool}): ${description}${changeSuffix}`;
   let result: ToolEditApprovalResult = { accepted: false };
   let diffSession: DiffSession | undefined;
+  let tabCloseDisposable: vscode.Disposable | undefined;
   try {
     const openedSession = await diffViewHost.openDiff(
       originalSource,
@@ -225,6 +226,42 @@ async function nativeRequestApproval(
         isSettled: () => settled,
         settle,
       });
+
+      // Closing the proposed diff tab (e.g. Ctrl+W) must resolve the approval
+      // as a rejection. Without this the approval Promise would never settle
+      // and the agent would hang indefinitely. The listener is self-cleaning:
+      // it disposes once the approval settles (including the programmatic
+      // close in the `finally` block below).
+      const proposedUriStr = vscode.Uri.file(
+        proposedSource.filePath,
+      ).toString();
+      tabCloseDisposable = vscode.window.tabGroups.onDidChangeTabs((event) => {
+        if (settled) {
+          tabCloseDisposable?.dispose();
+          return;
+        }
+        const wasClosed = event.closed.some((tab) => {
+          const input = tab.input;
+          if (
+            typeof vscode.TabInputTextDiff !== 'undefined' &&
+            input instanceof vscode.TabInputTextDiff
+          ) {
+            return input.modified.toString() === proposedUriStr;
+          }
+          if (
+            typeof vscode.TabInputText !== 'undefined' &&
+            input instanceof vscode.TabInputText
+          ) {
+            return input.uri.toString() === proposedUriStr;
+          }
+          return false;
+        });
+        if (wasClosed) {
+          tabCloseDisposable?.dispose();
+          settle({ accepted: false });
+        }
+      });
+
       void showProgressViewApprovalPrompt(
         requestId,
         request,
@@ -251,6 +288,8 @@ async function nativeRequestApproval(
       lineChanges: result.lineChanges ?? lineChanges,
     };
   } finally {
+    // Stop listening for tab closes before we programmatically close the diff.
+    tabCloseDisposable?.dispose();
     // Get entry before deleting to access workspace temp cleanup functions
     const entry = pendingApprovals.get(requestId);
     pendingApprovals.delete(requestId);

--- a/packages/extension/src/frontend/lm/registerLanguageModelTools.ts
+++ b/packages/extension/src/frontend/lm/registerLanguageModelTools.ts
@@ -1,0 +1,74 @@
+/**
+ * Exposes a curated subset of TeXRA's research tools to VS Code's Language
+ * Model Tool API (`vscode.lm.registerTool`), so they can be referenced in
+ * Copilot Chat (e.g. `#texra_arxiv_search`) and invoked by agent mode.
+ *
+ * Only context-free, read-only research tools are surfaced — they need no
+ * agent runtime state and are safe to call from an arbitrary chat session.
+ * The API is feature-detected: on hosts without it (incl. Cursor 1.105) this
+ * is a no-op, so the manifest `languageModelTools` contribution is simply
+ * ignored there.
+ */
+
+import * as vscode from 'vscode';
+
+import * as logger from '@logger/logUtils';
+import type { ToolResult } from '@shared/schemas/toolResult';
+import { getDefaultToolRegistry } from '@tools/registry';
+
+const CHANNEL = 'LanguageModelTools';
+
+/** VS Code tool name (manifest) → canonical TeXRA registry tool name. */
+const LM_TOOL_NAMES: Record<string, string> = {
+  texra_arxiv_search: 'arxiv_search',
+  texra_web_fetch: 'web_fetch',
+  texra_crossref_search: 'crossref_search',
+};
+
+/** Flatten a TeXRA ToolResult into the plain text VS Code chat expects. */
+function toResultText(result: ToolResult): string {
+  if (result.isError || result.error) {
+    return result.error ?? result.output ?? 'Tool reported an error.';
+  }
+  return result.output ?? result.summary ?? '(no output)';
+}
+
+/**
+ * Register the curated TeXRA tools with the VS Code Language Model Tool API.
+ * Safe to call unconditionally — it detects API availability and exits early
+ * on unsupported hosts.
+ */
+export function registerLanguageModelTools(
+  context: vscode.ExtensionContext,
+): void {
+  const lm = vscode.lm as Partial<Pick<typeof vscode.lm, 'registerTool'>>;
+  if (typeof lm.registerTool !== 'function') {
+    // Language Model Tool API not available (e.g. Cursor 1.105).
+    return;
+  }
+
+  const registry = getDefaultToolRegistry();
+  for (const [lmName, toolName] of Object.entries(LM_TOOL_NAMES)) {
+    const tool = registry.get(toolName);
+    if (!tool) {
+      logger.warn(
+        CHANNEL,
+        `Tool "${toolName}" missing from registry; skipping LM registration for "${lmName}".`,
+      );
+      continue;
+    }
+    const disposable = lm.registerTool(lmName, {
+      async invoke(
+        options: vscode.LanguageModelToolInvocationOptions<unknown>,
+      ) {
+        // The tool runs its own Zod validation and returns a structured error
+        // result for bad input, so we forward the raw, manifest-validated input.
+        const result = await tool.call(options.input);
+        return new vscode.LanguageModelToolResult([
+          new vscode.LanguageModelTextPart(toResultText(result)),
+        ]);
+      },
+    });
+    context.subscriptions.push(disposable);
+  }
+}

--- a/packages/extension/src/frontend/lm/registerLanguageModelTools.ts
+++ b/packages/extension/src/frontend/lm/registerLanguageModelTools.ts
@@ -41,8 +41,16 @@ function toResultText(result: ToolResult): string {
 export function registerLanguageModelTools(
   context: vscode.ExtensionContext,
 ): void {
-  const lm = vscode.lm as Partial<Pick<typeof vscode.lm, 'registerTool'>>;
-  if (typeof lm.registerTool !== 'function') {
+  const lm = (vscode as { lm?: typeof vscode.lm }).lm;
+  if (!lm) {
+    // Language Model namespace not available (e.g. older Cursor builds).
+    return;
+  }
+
+  const languageModelTools = lm as Partial<
+    Pick<typeof vscode.lm, 'registerTool'>
+  >;
+  if (typeof languageModelTools.registerTool !== 'function') {
     // Language Model Tool API not available (e.g. Cursor 1.105).
     return;
   }
@@ -57,7 +65,7 @@ export function registerLanguageModelTools(
       );
       continue;
     }
-    const disposable = lm.registerTool(lmName, {
+    const disposable = languageModelTools.registerTool(lmName, {
       async invoke(
         options: vscode.LanguageModelToolInvocationOptions<unknown>,
       ) {

--- a/packages/extension/src/frontend/review/promptReviewOptions.ts
+++ b/packages/extension/src/frontend/review/promptReviewOptions.ts
@@ -73,13 +73,37 @@ export async function promptReviewOptions(
     currentApproach === 'thorough'
       ? [thoroughItem, quickItem]
       : [quickItem, thoroughItem];
-  const approachPick = await vscode.window.showQuickPick(approachItems, {
-    title: 'Agent Review — Approach',
-    placeHolder: 'Choose review depth',
-    prompt:
-      'Quick checks key suspicions (fast); Thorough reads all changed files (deeper)',
-    ignoreFocusOut: true,
-  });
+  const trimmedInstructions = userInstructions.trim();
+  const approachPick = await new Promise<ApproachItem | undefined>(
+    (resolve) => {
+      const qp = vscode.window.createQuickPick<ApproachItem>();
+      let settled = false;
+      const finish = (value: ApproachItem | undefined): void => {
+        if (settled) return;
+        settled = true;
+        resolve(value);
+        qp.dispose();
+      };
+      qp.title = 'Agent Review — Approach';
+      qp.placeholder = 'Choose review depth';
+      qp.ignoreFocusOut = true;
+      qp.items = approachItems;
+      qp.activeItems = [approachItems[0]];
+      // VS Code 1.108+: echo the step-1 focus text so the user doesn't have
+      // to remember what they typed across the multi-step flow.
+      if (trimmedInstructions && 'prompt' in qp) {
+        (qp as vscode.QuickPick<ApproachItem> & { prompt: string }).prompt =
+          `Focus: ${trimmedInstructions}`;
+      }
+      qp.onDidAccept(() => {
+        finish(qp.activeItems[0] ?? qp.selectedItems[0]);
+      });
+      qp.onDidHide(() => {
+        finish(undefined);
+      });
+      qp.show();
+    },
+  );
   if (!approachPick) return undefined;
 
   const candidates = await listBaseBranchCandidates(cwd);
@@ -97,12 +121,41 @@ export async function promptReviewOptions(
       }),
     ),
   ];
-  const branchPick = await vscode.window.showQuickPick(branchItems, {
-    title: 'Agent Review — Diff Against',
-    placeHolder: 'Choose the branch to compare against',
-    prompt:
-      'The review will diff the current branch against the selected branch',
-    ignoreFocusOut: true,
+  // VS Code 1.109+ can place a button in the QuickPick title area; offer a
+  // one-click "use auto-detect" since most runs take the default.
+  const useDefaultButton: vscode.QuickInputButton = {
+    iconPath: new vscode.ThemeIcon('check'),
+    tooltip: 'Use auto-detect (skip)',
+  };
+  const branchPick = await new Promise<BranchItem | undefined>((resolve) => {
+    const qp = vscode.window.createQuickPick<BranchItem>();
+    let settled = false;
+    const finish = (value: BranchItem | undefined): void => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+      qp.dispose();
+    };
+    qp.title = 'Agent Review — Diff Against';
+    qp.placeholder = 'Choose the branch to compare against';
+    qp.ignoreFocusOut = true;
+    qp.items = branchItems;
+    qp.activeItems = [branchItems[0]];
+    if ('buttons' in qp) {
+      qp.buttons = [useDefaultButton];
+    }
+    qp.onDidTriggerButton((button) => {
+      if (button === useDefaultButton) {
+        finish(branchItems[0]);
+      }
+    });
+    qp.onDidAccept(() => {
+      finish(qp.activeItems[0] ?? qp.selectedItems[0]);
+    });
+    qp.onDidHide(() => {
+      finish(undefined);
+    });
+    qp.show();
   });
   if (!branchPick) return undefined;
 

--- a/packages/extension/src/frontend/review/promptReviewOptions.ts
+++ b/packages/extension/src/frontend/review/promptReviewOptions.ts
@@ -35,6 +35,9 @@ interface BranchItem extends vscode.QuickPickItem {
   ref: string | undefined;
 }
 
+const APPROACH_PROMPT_HINT =
+  'Quick checks key suspicions (fast); Thorough reads all changed files (deeper)';
+
 /**
  * Drive the three-step QuickPick flow. Each step honors Escape: returning
  * `undefined` from any prompt cancels the whole run, so a half-configured
@@ -89,11 +92,13 @@ export async function promptReviewOptions(
       qp.ignoreFocusOut = true;
       qp.items = approachItems;
       qp.activeItems = [approachItems[0]];
-      // VS Code 1.108+: echo the step-1 focus text so the user doesn't have
-      // to remember what they typed across the multi-step flow.
-      if (trimmedInstructions && 'prompt' in qp) {
+      // VS Code 1.108+: echo the step-1 focus text when present; otherwise
+      // keep the original approach explanation visible.
+      if ('prompt' in qp) {
         (qp as vscode.QuickPick<ApproachItem> & { prompt: string }).prompt =
-          `Focus: ${trimmedInstructions}`;
+          trimmedInstructions
+            ? `Focus: ${trimmedInstructions}`
+            : APPROACH_PROMPT_HINT;
       }
       qp.onDidAccept(() => {
         finish(qp.activeItems[0] ?? qp.selectedItems[0]);

--- a/packages/extension/src/frontend/review/promptReviewOptions.ts
+++ b/packages/extension/src/frontend/review/promptReviewOptions.ts
@@ -37,6 +37,8 @@ interface BranchItem extends vscode.QuickPickItem {
 
 const APPROACH_PROMPT_HINT =
   'Quick checks key suspicions (fast); Thorough reads all changed files (deeper)';
+const BRANCH_PROMPT_HINT =
+  'The review will diff the current branch against the selected branch';
 
 /**
  * Drive the three-step QuickPick flow. Each step honors Escape: returning
@@ -146,6 +148,10 @@ export async function promptReviewOptions(
     qp.ignoreFocusOut = true;
     qp.items = branchItems;
     qp.activeItems = [branchItems[0]];
+    if ('prompt' in qp) {
+      (qp as vscode.QuickPick<BranchItem> & { prompt: string }).prompt =
+        BRANCH_PROMPT_HINT;
+    }
     if ('buttons' in qp) {
       qp.buttons = [useDefaultButton];
     }

--- a/packages/extension/src/frontend/statusBar/StatusBarUsageTracker.ts
+++ b/packages/extension/src/frontend/statusBar/StatusBarUsageTracker.ts
@@ -19,13 +19,10 @@ const ZERO_USAGE: StatusBarUsageTotals = {
   outputTokens: 0,
 };
 
-const MAX_TERMINATED_STREAM_GUARDS = 200;
-
 /** Tracks active streams and usage totals for the extension status bar. */
 export class StatusBarUsageTracker {
   private readonly activeStreams = new Set<string>();
   private readonly streamStatuses = new Map<string, StreamStatus>();
-  private readonly terminatedStreams = new Set<string>();
   private readonly usageByStream = new Map<string, StatusBarUsageTotals>();
 
   public updateStreamStatus(streamId: string, status: StreamStatus): void {
@@ -37,23 +34,17 @@ export class StatusBarUsageTracker {
 
     if (isTerminalStatus(status) && !isInFlightStatus(status)) {
       this.streamStatuses.delete(streamId);
-      this.rememberTerminatedStream(streamId);
       this.usageByStream.delete(streamId);
       return;
     }
 
-    this.terminatedStreams.delete(streamId);
     this.streamStatuses.set(streamId, status);
   }
 
-  /** Records a per-round usage delta; returns false for already-finished streams. */
+  /** Records a per-round usage delta only for streams known to be in flight. */
   public recordUsage(streamId: string, usage: TokenUsageStats): boolean {
-    if (this.terminatedStreams.has(streamId)) {
-      return false;
-    }
-
     const status = this.streamStatuses.get(streamId);
-    if (status !== undefined && !isInFlightStatus(status)) {
+    if (status === undefined || !isInFlightStatus(status)) {
       return false;
     }
 
@@ -78,16 +69,5 @@ export class StatusBarUsageTracker {
       total.outputTokens += usage.outputTokens;
     }
     return total;
-  }
-
-  private rememberTerminatedStream(streamId: string): void {
-    this.terminatedStreams.delete(streamId);
-    this.terminatedStreams.add(streamId);
-
-    if (this.terminatedStreams.size <= MAX_TERMINATED_STREAM_GUARDS) return;
-    const oldest = this.terminatedStreams.values().next().value;
-    if (oldest !== undefined) {
-      this.terminatedStreams.delete(oldest);
-    }
   }
 }

--- a/packages/extension/src/frontend/statusBar/StatusBarUsageTracker.ts
+++ b/packages/extension/src/frontend/statusBar/StatusBarUsageTracker.ts
@@ -41,7 +41,12 @@ export class StatusBarUsageTracker {
     this.streamStatuses.set(streamId, status);
   }
 
-  /** Records a per-round usage delta only for streams known to be in flight. */
+  /**
+   * Records a per-round usage delta only for streams known to be in flight.
+   * The runtime emits the in-flight status before usage for a round; unknown or
+   * terminated stream ids are ignored so stale async events cannot recreate
+   * completed streams.
+   */
   public recordUsage(streamId: string, usage: TokenUsageStats): boolean {
     const status = this.streamStatuses.get(streamId);
     if (status === undefined || !isInFlightStatus(status)) {

--- a/packages/extension/src/frontend/statusBar/StatusBarUsageTracker.ts
+++ b/packages/extension/src/frontend/statusBar/StatusBarUsageTracker.ts
@@ -1,0 +1,93 @@
+// Local imports - stream state
+import {
+  isActiveStatus,
+  isInFlightStatus,
+  isTerminalStatus,
+} from '@common/constants/streamStatus';
+import type { StreamStatus } from '@shared/schemas/stream';
+import type { TokenUsageStats } from '@shared/schemas/usage';
+
+export interface StatusBarUsageTotals {
+  cost: number;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+const ZERO_USAGE: StatusBarUsageTotals = {
+  cost: 0,
+  inputTokens: 0,
+  outputTokens: 0,
+};
+
+const MAX_TERMINATED_STREAM_GUARDS = 200;
+
+/** Tracks active streams and usage totals for the extension status bar. */
+export class StatusBarUsageTracker {
+  private readonly activeStreams = new Set<string>();
+  private readonly streamStatuses = new Map<string, StreamStatus>();
+  private readonly terminatedStreams = new Set<string>();
+  private readonly usageByStream = new Map<string, StatusBarUsageTotals>();
+
+  public updateStreamStatus(streamId: string, status: StreamStatus): void {
+    if (isActiveStatus(status)) {
+      this.activeStreams.add(streamId);
+    } else {
+      this.activeStreams.delete(streamId);
+    }
+
+    if (isTerminalStatus(status) && !isInFlightStatus(status)) {
+      this.streamStatuses.delete(streamId);
+      this.rememberTerminatedStream(streamId);
+      this.usageByStream.delete(streamId);
+      return;
+    }
+
+    this.terminatedStreams.delete(streamId);
+    this.streamStatuses.set(streamId, status);
+  }
+
+  /** Records a per-round usage delta; returns false for already-finished streams. */
+  public recordUsage(streamId: string, usage: TokenUsageStats): boolean {
+    if (this.terminatedStreams.has(streamId)) {
+      return false;
+    }
+
+    const status = this.streamStatuses.get(streamId);
+    if (status !== undefined && !isInFlightStatus(status)) {
+      return false;
+    }
+
+    const previous = this.usageByStream.get(streamId) ?? ZERO_USAGE;
+    this.usageByStream.set(streamId, {
+      cost: previous.cost + usage.cost,
+      inputTokens: previous.inputTokens + usage.inputTokens,
+      outputTokens: previous.outputTokens + usage.outputTokens,
+    });
+    return true;
+  }
+
+  public get activeStreamCount(): number {
+    return this.activeStreams.size;
+  }
+
+  public get totalUsage(): StatusBarUsageTotals {
+    const total = { ...ZERO_USAGE };
+    for (const usage of this.usageByStream.values()) {
+      total.cost += usage.cost;
+      total.inputTokens += usage.inputTokens;
+      total.outputTokens += usage.outputTokens;
+    }
+    return total;
+  }
+
+  private rememberTerminatedStream(streamId: string): void {
+    this.terminatedStreams.delete(streamId);
+    this.terminatedStreams.add(streamId);
+
+    if (this.terminatedStreams.size <= MAX_TERMINATED_STREAM_GUARDS) return;
+    const oldest = this.terminatedStreams.values().next().value;
+    if (oldest !== undefined) {
+      this.terminatedStreams.delete(oldest);
+    }
+  }
+}

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -32,6 +32,60 @@
           "label": "TeXRA"
         }
       ],
+      "chatSkills": [
+        {
+          "name": "inline-paper-critic",
+          "path": "../../skills/inline-paper-critic"
+        },
+        {
+          "name": "lean-blueprint",
+          "path": "../../skills/lean-blueprint"
+        },
+        {
+          "name": "lean-proof-assistant",
+          "path": "../../skills/lean-proof-assistant"
+        },
+        {
+          "name": "lean-search",
+          "path": "../../skills/lean-search"
+        },
+        {
+          "name": "lean-simplifier",
+          "path": "../../skills/lean-simplifier"
+        },
+        {
+          "name": "literature-search",
+          "path": "../../skills/literature-search"
+        },
+        {
+          "name": "manuscript-review",
+          "path": "../../skills/manuscript-review"
+        },
+        {
+          "name": "math-ocr",
+          "path": "../../skills/math-ocr"
+        },
+        {
+          "name": "mathematical-enhancer",
+          "path": "../../skills/mathematical-enhancer"
+        },
+        {
+          "name": "scientific-presenter",
+          "path": "../../skills/scientific-presenter"
+        },
+        {
+          "name": "scientific-simplifier",
+          "path": "../../skills/scientific-simplifier"
+        },
+        {
+          "name": "tikz-figure-builder",
+          "path": "../../skills/tikz-figure-builder"
+        },
+        {
+          "name": "writing-commenter",
+          "path": "../../skills/writing-commenter"
+        }
+      ],
       "commands": [
         {
           "category": "TeXRA",
@@ -1135,6 +1189,123 @@
           "key": "ctrl+alt+e",
           "mac": "cmd+option+e",
           "when": "texra.activated"
+        }
+      ],
+      "languageModelTools": [
+        {
+          "canBeReferencedInPrompt": true,
+          "displayName": "arXiv Search",
+          "icon": "$(search)",
+          "inputSchema": {
+            "additionalProperties": false,
+            "properties": {
+              "categories": {
+                "description": "Optional arXiv category filters such as \"math.NT\" or \"cs.AI\".",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "field": {
+                "description": "Search field: \"author\" for author names, \"title\" for paper titles, \"abstract\" for abstracts, \"all\" (default) for all fields.",
+                "enum": ["all", "author", "title", "abstract"],
+                "type": "string"
+              },
+              "maxResults": {
+                "description": "Maximum number of papers to return.",
+                "type": "integer"
+              },
+              "query": {
+                "description": "Search query terms, title text, or author names.",
+                "type": "string"
+              },
+              "sortBy": {
+                "description": "arXiv sort field to use.",
+                "enum": ["relevance", "lastUpdatedDate", "submittedDate"],
+                "type": "string"
+              },
+              "sortOrder": {
+                "description": "Sort direction for results.",
+                "enum": ["ascending", "descending"],
+                "type": "string"
+              },
+              "start": {
+                "description": "Zero-based result offset for pagination.",
+                "type": "integer"
+              }
+            },
+            "required": ["query"],
+            "type": "object"
+          },
+          "modelDescription": "Search arXiv for papers and return basic metadata for each hit. Use field=\"author\" for author name searches.",
+          "name": "texra_arxiv_search",
+          "tags": ["texra", "research", "arxiv"],
+          "toolReferenceName": "texra_arxiv_search"
+        },
+        {
+          "canBeReferencedInPrompt": true,
+          "displayName": "Web Fetch",
+          "icon": "$(globe)",
+          "inputSchema": {
+            "additionalProperties": false,
+            "properties": {
+              "prompt": {
+                "description": "Optional instruction describing what to extract from the page.",
+                "type": "string"
+              },
+              "url": {
+                "description": "Public HTTP or HTTPS URL to fetch.",
+                "type": "string"
+              }
+            },
+            "required": ["url"],
+            "type": "object"
+          },
+          "modelDescription": "Fetch content from a URL and return it as clean text. Include an optional prompt to explain what context you need so the fetched content can be interpreted correctly.",
+          "name": "texra_web_fetch",
+          "tags": ["texra", "research", "web"],
+          "toolReferenceName": "texra_web_fetch"
+        },
+        {
+          "canBeReferencedInPrompt": true,
+          "displayName": "Crossref Search",
+          "icon": "$(book)",
+          "inputSchema": {
+            "additionalProperties": false,
+            "properties": {
+              "filter": {
+                "description": "Crossref filter string, e.g. \"from-pub-date:2023\".",
+                "type": "string"
+              },
+              "offset": {
+                "description": "Zero-based result offset for pagination.",
+                "type": "integer"
+              },
+              "order": {
+                "description": "Crossref sort order.",
+                "enum": ["asc", "desc"],
+                "type": "string"
+              },
+              "query": {
+                "description": "Bibliographic search query for Crossref works.",
+                "type": "string"
+              },
+              "rows": {
+                "description": "Maximum number of works to return.",
+                "type": "integer"
+              },
+              "sort": {
+                "description": "Crossref sort field to apply.",
+                "type": "string"
+              }
+            },
+            "required": ["query"],
+            "type": "object"
+          },
+          "modelDescription": "Search Crossref works (journal articles, books, conference papers) and return top matches with bibliographic metadata.",
+          "name": "texra_crossref_search",
+          "tags": ["texra", "research", "citation"],
+          "toolReferenceName": "texra_crossref_search"
         }
       ],
       "menus": {

--- a/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
+++ b/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
@@ -222,6 +222,7 @@ describe('setup assistant routing check ordering', () => {
     expect(mocks.showWarningMessage).not.toHaveBeenCalled();
     expect(mocks.createQuickPick).toHaveBeenCalledWith(
       expect.objectContaining({
+        activeItems: [expect.objectContaining({ id: 'chatgpt' })],
         placeholder: expect.stringContaining('credential'),
       }),
     );

--- a/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
+++ b/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   hasUsableApiKey: vi.fn<(provider: string) => Promise<boolean>>(),
   showWarningMessage: vi.fn<() => Promise<string | undefined>>(),
   showQuickPick: vi.fn<() => Promise<unknown>>(),
+  createQuickPick: vi.fn<(qp: unknown) => void>(),
   showInformationMessage: vi.fn<() => Promise<unknown>>(),
   showErrorMessage: vi.fn<() => Promise<unknown>>(),
   executeCommand: vi.fn<() => Promise<unknown>>(),
@@ -77,6 +78,34 @@ vi.mock('vscode', () => ({
   window: {
     showWarningMessage: mocks.showWarningMessage,
     showQuickPick: mocks.showQuickPick,
+    // The credential picker now uses the createQuickPick instance API so it
+    // can attach a persistent prompt hint (VS Code 1.108+). The fake records
+    // the created instance and auto-hides on show() so the awaiting promise
+    // resolves to `undefined` (user dismissed), preserving prior behavior.
+    createQuickPick: () => {
+      let onHide: (() => void) | undefined;
+      const qp = {
+        title: '',
+        placeholder: '',
+        items: [] as unknown[],
+        selectedItems: [] as unknown[],
+        activeItems: [] as unknown[],
+        buttons: [] as unknown[],
+        onDidAccept: () => ({ dispose: () => {} }),
+        onDidHide: (cb: () => void) => {
+          onHide = cb;
+          return { dispose: () => {} };
+        },
+        onDidTriggerButton: () => ({ dispose: () => {} }),
+        show: () => {
+          mocks.createQuickPick(qp);
+          queueMicrotask(() => onHide?.());
+        },
+        hide: () => {},
+        dispose: () => {},
+      };
+      return qp;
+    },
     showInformationMessage: mocks.showInformationMessage,
     showErrorMessage: mocks.showErrorMessage,
     createOutputChannel: () => ({
@@ -147,6 +176,7 @@ describe('setup assistant routing check ordering', () => {
     mocks.hasUsableApiKey.mockReset();
     mocks.showWarningMessage.mockReset();
     mocks.showQuickPick.mockReset();
+    mocks.createQuickPick.mockReset();
     mocks.showInformationMessage.mockReset();
     mocks.showErrorMessage.mockReset();
     mocks.executeCommand.mockReset();
@@ -179,7 +209,7 @@ describe('setup assistant routing check ordering', () => {
       expect.any(String),
       expect.any(String),
     );
-    expect(mocks.showQuickPick).not.toHaveBeenCalled();
+    expect(mocks.createQuickPick).not.toHaveBeenCalled();
   });
 
   it('proceeds to credential check when routing is correctly configured', async () => {
@@ -190,10 +220,9 @@ describe('setup assistant routing check ordering', () => {
     // Credential prompt shown (routing check passed first silently).
     expect(result).toBe('not-started');
     expect(mocks.showWarningMessage).not.toHaveBeenCalled();
-    expect(mocks.showQuickPick).toHaveBeenCalledWith(
-      expect.any(Array),
+    expect(mocks.createQuickPick).toHaveBeenCalledWith(
       expect.objectContaining({
-        placeHolder: expect.stringContaining('credential'),
+        placeholder: expect.stringContaining('credential'),
       }),
     );
   });
@@ -210,6 +239,7 @@ describe('setup assistant routing check ordering', () => {
 
     expect(mocks.showWarningMessage).not.toHaveBeenCalled();
     expect(mocks.showQuickPick).not.toHaveBeenCalled();
+    expect(mocks.createQuickPick).not.toHaveBeenCalled();
     expect(mocks.showErrorMessage).not.toHaveBeenCalled();
     expect(result).toBe('launched');
   });

--- a/src/test-kernel/frontend/StatusBarUsageTracker.vitest.ts
+++ b/src/test-kernel/frontend/StatusBarUsageTracker.vitest.ts
@@ -1,0 +1,100 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - stream state
+import { StatusBarUsageTracker } from '@frontend/statusBar/StatusBarUsageTracker';
+import { STREAM_STATUS } from '@shared/schemas/stream';
+
+describe('StatusBarUsageTracker', () => {
+  it('accumulates per-round usage deltas for an active stream', () => {
+    const tracker = new StatusBarUsageTracker();
+    tracker.updateStreamStatus('stream-a', STREAM_STATUS.RUNNING);
+
+    expect(
+      tracker.recordUsage('stream-a', {
+        cost: 0.01,
+        inputTokens: 10,
+        outputTokens: 20,
+      }),
+    ).toBe(true);
+    expect(
+      tracker.recordUsage('stream-a', {
+        cost: 0.02,
+        inputTokens: 30,
+        outputTokens: 40,
+      }),
+    ).toBe(true);
+
+    expect(tracker.totalUsage.cost).toBeCloseTo(0.03);
+    expect(tracker.totalUsage.inputTokens).toBe(40);
+    expect(tracker.totalUsage.outputTokens).toBe(60);
+  });
+
+  it('retains accumulated usage while a stream waits for follow-up input', () => {
+    const tracker = new StatusBarUsageTracker();
+    tracker.updateStreamStatus('stream-a', STREAM_STATUS.RUNNING);
+    tracker.recordUsage('stream-a', {
+      cost: 0.01,
+      inputTokens: 10,
+      outputTokens: 20,
+    });
+
+    tracker.updateStreamStatus('stream-a', STREAM_STATUS.WAITING);
+
+    expect(tracker.activeStreamCount).toBe(0);
+    expect(
+      tracker.recordUsage('stream-a', {
+        cost: 0.02,
+        inputTokens: 30,
+        outputTokens: 40,
+      }),
+    ).toBe(true);
+    expect(tracker.totalUsage.cost).toBeCloseTo(0.03);
+    expect(tracker.totalUsage.inputTokens).toBe(40);
+    expect(tracker.totalUsage.outputTokens).toBe(60);
+  });
+
+  it('ignores delayed usage after a stream reaches a final status', () => {
+    const tracker = new StatusBarUsageTracker();
+    tracker.updateStreamStatus('stream-a', STREAM_STATUS.RUNNING);
+    tracker.recordUsage('stream-a', {
+      cost: 0.01,
+      inputTokens: 10,
+      outputTokens: 20,
+    });
+
+    tracker.updateStreamStatus('stream-a', STREAM_STATUS.READY);
+
+    expect(tracker.totalUsage).toEqual({
+      cost: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+    });
+    expect(
+      tracker.recordUsage('stream-a', {
+        cost: 0.02,
+        inputTokens: 30,
+        outputTokens: 40,
+      }),
+    ).toBe(false);
+    expect(tracker.totalUsage).toEqual({
+      cost: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+    });
+
+    tracker.updateStreamStatus('stream-a', STREAM_STATUS.RUNNING);
+    expect(
+      tracker.recordUsage('stream-a', {
+        cost: 0.03,
+        inputTokens: 50,
+        outputTokens: 60,
+      }),
+    ).toBe(true);
+    expect(tracker.totalUsage).toEqual({
+      cost: 0.03,
+      inputTokens: 50,
+      outputTokens: 60,
+    });
+  });
+});

--- a/src/test-kernel/frontend/StatusBarUsageTracker.vitest.ts
+++ b/src/test-kernel/frontend/StatusBarUsageTracker.vitest.ts
@@ -6,6 +6,23 @@ import { StatusBarUsageTracker } from '@frontend/statusBar/StatusBarUsageTracker
 import { STREAM_STATUS } from '@shared/schemas/stream';
 
 describe('StatusBarUsageTracker', () => {
+  it('ignores usage for streams without a known in-flight status', () => {
+    const tracker = new StatusBarUsageTracker();
+
+    expect(
+      tracker.recordUsage('stream-a', {
+        cost: 0.01,
+        inputTokens: 10,
+        outputTokens: 20,
+      }),
+    ).toBe(false);
+    expect(tracker.totalUsage).toEqual({
+      cost: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+    });
+  });
+
   it('accumulates per-round usage deltas for an active stream', () => {
     const tracker = new StatusBarUsageTracker();
     tracker.updateStreamStatus('stream-a', STREAM_STATUS.RUNNING);


### PR DESCRIPTION
Implements the practical VS Code API upgrade opportunities surfaced by the codebase audit. All changes are Cursor-safe: new APIs are feature-detected (`'prompt' in qp`, version guards, `'registerTool' in vscode.lm`) and degrade to prior behavior on VS Code <1.108 / Cursor 1.105.

Bug fixes (exposed by the new-API review):
- Tool-edit approval: close the proposed diff tab now rejects the edit via tabGroups.onDidChangeTabs instead of hanging the agent forever.
- VscodeDiffViewHost.closeDiff: require an exact original/proposed pair match so an unrelated or side-swapped diff is never closed.

QuickPick.prompt hints (VS Code 1.108+):
- latexdiff math markup, Accept edits, sign-in method, API-key provider, agent-creator tool groups, setup credential, and review approach pickers.

QuickInputButton (VS Code 1.109+):
- "Get API key" inline button on the key input box (replaces the extra info-message step on supported hosts).
- "Use auto-detect" title button on the review branch picker.
- Select-all/clear toggle button on the tool-group multi-select.

Status bar (no new API):
- Status bar tooltip now shows running session cost / token totals from updateStreamUsage events.
- Removed double-dispose of statusBarItem and the status listener; they are now owned solely by context.subscriptions.

Language Model Tool API (VS Code ~1.110+):
- Expose arxiv_search, web_fetch, and crossref_search to Copilot Chat via contributes.languageModelTools + vscode.lm.registerTool. No-op on hosts without the API.

Updated SetupAssistantRouting test for the createQuickPick migration.


Claude-Session: https://claude.ai/code/session_01WEdgBAcDfJJ92asui689hH

## Summary

<!-- Explain the change for a reader who has not seen the issue discussion. -->

## Issue acceptance gates

<!-- List the issue(s) this PR addresses and the exact acceptance gates satisfied. If a gate remains incomplete, say so. -->

## Single source of truth

<!-- Name the module, schema, context object, or coordinator that now owns the relevant fact or decision. -->

## Duplication and abstraction budget

<!-- State what duplication was removed or avoided. If a new abstraction was added, state the invariant or host-boundary decision it owns. Do not add pass-through layers. -->

## Host impact

Extension:

Desktop:

CLI:

## Scheduled refactoring

<!-- Link any follow-up issue, or state "None" if no follow-up is needed. -->

## Validation

<!-- List the checks run. If a check was intentionally not run, say why. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent tool-edit approval and diff-tab lifecycle (user-visible but fixes a hang); Copilot-facing network tools add a new invocation surface, though limited to read-only research tools with API gating.
> 
> **Overview**
> Adds **Copilot Chat research tools** (`#texra_arxiv_search`, `#texra_web_fetch`, `#texra_crossref_search`) via `contributes.languageModelTools` and runtime `registerLanguageModelTools`, wiring three read-only registry tools with feature detection so unsupported hosts skip registration.
> 
> The **status bar** now aggregates per-stream token cost from `updateStreamUsage` through a new `StatusBarUsageTracker` and shows totals in the hover tooltip, while fixing **double-dispose** of the status bar item and its bus listeners.
> 
> **Quick Input UX** moves several flows off `showQuickPick`/`showInputBox` one-shots onto `createQuickPick` / `createInputBox` so VS Code 1.108+ can keep persistent **prompt** hints (latexdiff, accept edits, sign-in, API provider, setup credentials, review) and 1.109+ can add title buttons (inline **Get API key**, review branch auto-detect, tool-group select-all toggle).
> 
> **Tool-edit approval** no longer hangs when the user closes the proposed diff tab—`onDidChangeTabs` settles as rejected—and **diff cleanup** closes only tabs that match the exact original/modified URI pair.
> 
> Tests cover the usage tracker and the setup assistant’s `createQuickPick` credential picker; extension package invariants snapshot is updated for the new contributions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce6cdd4645478ae7a061d58754f5b81456ce1f15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->