### PR TITLE
Integrate new VS Code 1.109-1.110 APIs into the extension

### DIFF
--- a/docs/proposals/config-catalog-unification.md
+++ b/docs/proposals/config-catalog-unification.md
@@ -14,9 +14,9 @@ Decision (already made by the user): **full unification** — one catalog as SSO
 
 Exploration disproved two load-bearing assumptions in the draft. Both change the design:
 
-1. **State-backed keys must NOT become `CoreSettingsShape` nodes.** Every node in `CoreSettingsShape` flows into `CORE_SETTING_PATHS` → `TEXRA_SETTING_PATHS` → the package.json generator → a VS Code *configuration* contribution. But the extension reads the state-backed keys (e.g. `texra.git.markCommits`, `texra.workflow.*`, `texra.latexdiff.*`) from **worktree-shared WorkspaceState** (`WORKTREE_SHARED_KEYS` in `packages/extension/src/common/state/stateManager.ts`), not from config — they were deliberately migrated *out* of config (`LATEX_SETTINGS_MIGRATED` marker). Adding them to `CoreSettingsShape` would emit phantom VS Code settings the extension never reads. → They live in a **separate** catalog (`stateSettings.ts`), not coreSettings.
+1. **State-backed keys must NOT become `CoreSettingsShape` nodes.** Every node in `CoreSettingsShape` flows into `CORE_SETTING_PATHS` → `TEXRA_SETTING_PATHS` → the package.json generator → a VS Code _configuration_ contribution. But the extension reads the state-backed keys (e.g. `texra.git.markCommits`, `texra.workflow.*`, `texra.latexdiff.*`) from **worktree-shared WorkspaceState** (`WORKTREE_SHARED_KEYS` in `packages/extension/src/common/state/stateManager.ts`), not from config — they were deliberately migrated _out_ of config (`LATEX_SETTINGS_MIGRATED` marker). Adding them to `CoreSettingsShape` would emit phantom VS Code settings the extension never reads. → They live in a **separate** catalog (`stateSettings.ts`), not coreSettings.
 
-2. **The CLI has three distinct stores, not a single shared one.** `packages/cli/src/runtime/initPlatform.ts:193-200` wires `config` = `JsonConfigProvider` (`.texra/config.json` + `~/.texra/.../config.json`), but `workspaceState` / `globalState` = **separate** `state.json` files (`cliStateStores.ts`). The git-author bridge (`gitAuthor.ts`) works only because it *explicitly* passes `config` into `readGitAuthorSettingsFromState(stateStore)` — exploiting structural read-compat (`ConfigProvider` and `StateStore` both expose `.get(key, default)`), **not** because `workspaceState === config`. So the accessor must be **host-aware**, and the git-author keys need an explicit per-entry `cliStore` override, not an assumed slot identity.
+2. **The CLI has three distinct stores, not a single shared one.** `packages/cli/src/runtime/initPlatform.ts:193-200` wires `config` = `JsonConfigProvider` (`.texra/config.json` + `~/.texra/.../config.json`), but `workspaceState` / `globalState` = **separate** `state.json` files (`cliStateStores.ts`). The git-author bridge (`gitAuthor.ts`) works only because it _explicitly_ passes `config` into `readGitAuthorSettingsFromState(stateStore)` — exploiting structural read-compat (`ConfigProvider` and `StateStore` both expose `.get(key, default)`), **not** because `workspaceState === config`. So the accessor must be **host-aware**, and the git-author keys need an explicit per-entry `cliStore` override, not an assumed slot identity.
 
 ## Catalog & store model
 
@@ -70,6 +70,7 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 ## PR sequence
 
 ### PR 1 — Generator carries `description` + `enumDescriptions` (no behavior change)
+
 - `texraSettings.ts:97` — extend `GENERATED_PACKAGE_SCHEMA_FIELDS` with `'description'`, `'enumDescriptions'` only. (`z.toJSONSchema()` already passes `.describe()` → `description` and merges `.meta()` keys; `pickPackageSchemaFields` is allowlist-driven so other meta stays out of package.json.)
 - `coreSettings.ts` + `vscodeSettings.ts` — add `.describe('…')` to every config leaf and `.meta({ enumDescriptions: [...] })` to enum leaves, **back-filled verbatim from the current package.json strings** so the first generator run is zero-diff.
 - `settingsConfiguration.vitest.ts` — **rewrite the `removes stale generated package schema fields` test (lines 157-180)**: it currently injects `description: 'Preserved description'` and asserts it survives. Once `description` is generated, that assertion is wrong — pivot it to a still-hand-kept field (`order` or `editPresentation`). Add an invariant: every enum leaf's `enumDescriptions.length === enum.length`.
@@ -77,6 +78,7 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 - **Verify:** `sync:settings-configuration --check` is zero-diff; `npm test` (idempotency `assert.deepEqual(build(sections), sections)`) green; `npm run typecheck`.
 
 ### PR 2 — `stateSettings.ts` catalog + `settingsAccess.ts` accessor + knownKeys derivation
+
 - New `src/shared/schemas/stateSettings.ts` — metadata-only rows for the state-backed keys, starting with the four git-author keys (`store:'workspaceState'`, `cliStore:'config'`, `hosts:['vscode','cli','desktop']`, `cliConsumer:'packages/cli/src/runtime/gitAuthor.ts'`) and the `workflow.*` / `latexdiff.*` / `latex.formatter` scalars (`store:'workspaceState'`, `hosts:['vscode','desktop']` for now). Export the key list.
 - New `src/shared/config/settingsAccess.ts` — `readSetting(entry, stores)` / `writeSetting(entry, value, stores)` where `stores = { config, workspaceState, globalState }`. Dispatch on `entry.store` (or `entry.cliStore` when the caller is the CLI); validate writes via the entry's Zod schema where one exists; **reset writes `undefined`** (deletes the key per `jsonConfigProvider.ts:57` → `.prefault()` reappears), never the literal default. `openForm` entries bypass the accessor.
 - `packages/cli/src/schemas/knownKeys.ts` — add `...STATE_SETTING_KEYS` from the catalog; **delete** the four hand-listed `WorkspaceStateKey.GIT_*` lines (31-34). The `WorkspaceStateKey` enum entries stay (the extension still uses them).
@@ -84,6 +86,7 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 - **Verify:** `npm test` (guardrails) + `npm run typecheck`; `gitAuthor.ts` still applies marking (route it through the accessor or leave as-is — both read the same keys from `config`).
 
 ### PR 3 — CLI `/config` panel (USER-VISIBLE; lands in CHANGELOG under Features)
+
 - New `packages/cli/src/chat/tui/forms/ConfigForm.tsx`. **Not a single-Select clone of `ApprovalPolicyForm`** — it is a list + drill-in:
   - Outer `Select` lists catalog entries where `hosts.includes('cli')` (label = setting name, `description` = current resolved value + its store, so cross-host state is visible — risk #1 mitigation).
   - Selecting a **boolean** toggles inline; an **enum** opens an inner `Select` of values (per-option text from `enumDescriptions`); an **`openForm`** entry delegates to the existing `ModelListForm`/`AgentListForm`/`MemoryListForm`/etc.
@@ -94,23 +97,27 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 - **Verify:** roster test = exactly the consumer-verified entries; `SlashRegistry.vitest` covers the new command; manual PTY run via `packages/cli/scripts/tui-harness.tsx` — open `/config`, flip a boolean + an enum, confirm persistence to `.texra/config.json` (project) and that `Esc` closes; confirm the headless `texra run` / `--print` path is byte-unchanged.
 
 ### PR 4 — Extension settingsView re-point (zero message/port/dispatch change)
-- Delete the hardcoded enum/label arrays and read labels/descriptions from the catalog: `AIAgentsTab.ts` (SANDBOX/REASONING/APPROVAL/CLAUDE option arrays, ~lines 40-98), `LaTeXTab.ts` (mathMarkup + formatter options, ~lines 590-616), plus inline labels in `ModelSelectionList.ts` (reasoning-level labels) and `ApiAccessSection.ts`/`ModelsTab.ts`. Splittable per-tab. (Note: the codex/claude option arrays are state-backed complex domains — promoting them to catalog rows is fine for *labels*; their read/write stays in the existing controllers.)
+
+- Delete the hardcoded enum/label arrays and read labels/descriptions from the catalog: `AIAgentsTab.ts` (SANDBOX/REASONING/APPROVAL/CLAUDE option arrays, ~lines 40-98), `LaTeXTab.ts` (mathMarkup + formatter options, ~lines 590-616), plus inline labels in `ModelSelectionList.ts` (reasoning-level labels) and `ApiAccessSection.ts`/`ModelsTab.ts`. Splittable per-tab. (Note: the codex/claude option arrays are state-backed complex domains — promoting them to catalog rows is fine for _labels_; their read/write stays in the existing controllers.)
 - **Verify:** webview renders identical labels; no port/schema diff; `npm run typecheck` + `npm test`.
 
 ### PR 5+ — Promote complex/state-backed domains incrementally (one per PR)
+
 - Add the CLI consumer code path for a domain (e.g. workflow/latexdiff scalars read in CLI from `platform().workspaceState`), flip its catalog `hosts` to include `'cli'`; the entry auto-appears in `/config`, and the PR2 guardrail enforces the consumer exists. Complex domains (streaming/endpoints/models/agents/tools/presets) come in as `openForm` delegations, not scalars.
 
 ## Critical files
+
 - `src/shared/schemas/coreSettings.ts` — `.describe()`/`.meta({enumDescriptions})` back-fill (PR1).
 - `packages/extension/src/schemas/{texraSettings.ts,vscodeSettings.ts}` — allowlist +`description`/`enumDescriptions`; describe the 3 vscode leaves (PR1).
 - `src/test-kernel/shared/settingsConfiguration.vitest.ts` — rewrite preserve-field test + enum-length invariant (PR1).
 - New `src/shared/schemas/stateSettings.ts`, `src/shared/config/settingsAccess.ts` (PR2).
-- `packages/cli/src/schemas/knownKeys.ts` — derive from catalog, delete GIT_* lines 31-34 (PR2).
+- `packages/cli/src/schemas/knownKeys.ts` — derive from catalog, delete GIT\_\* lines 31-34 (PR2).
 - New `packages/cli/src/chat/tui/forms/ConfigForm.tsx`; `packages/cli/src/chat/tui/commands/{registerBuiltins.tsx,slashRegistry.ts}`; `packages/cli/src/chat/tui/runChatTui.tsx:516` (PR3).
 - Extension tabs: `packages/extension/src/settingsView/frontend/tabs/{AIAgentsTab.ts,LaTeXTab.ts,ModelsTab.ts}` + `components/profile/{ModelSelectionList.ts,ApiAccessSection.ts}` (PR4).
 - Reused untouched: `ui/Select.tsx`, `forms/_shared/{FormFrame,selectWindow}.ts`, `src/controllers/settingsView/*`, `scripts/sync-settings-configuration.mjs`, `src/utils/system/gitAuthorSettings.ts`.
 
 ## Verification (every PR)
+
 - `npm run typecheck` and `npm test`.
 - PR1: `npm run sync:settings-configuration --check` zero-diff (proves `.describe()`/`.meta()`+`.prefault()` compose through `z.toJSONSchema()`); enum-length invariant green.
 - PR2: guardrail suite (consumer-exists, knownKeys-derivation, store/scope coherence, Class-D exclusion, default round-trip).
@@ -118,6 +125,7 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 - PR4: identical webview labels; no port/schema diff.
 
 ## Risk register
+
 1. **Cross-host store divergence** (a key set in extension WorkspaceState reads as default in the CLI). Mitigate: store/cliStore coherence guardrail; `/config` shows the resolved value **and its store**; no silent auto-bridge beyond the declared `cliStore` override.
 2. **`description` promotion breaks the existing preserve-field test** (`settingsConfiguration.vitest.ts:157-180` asserts a hand-injected description survives). Mitigate: rewrite that test in PR1 to assert a still-hand-kept field (`order`/`editPresentation`).
 3. **Incomplete `.describe()` back-fill deletes package.json descriptions** (allowlisted + absent in `.meta`/`.describe` ⇒ generator deletes the field). Mitigate: back-fill every config leaf; the idempotency `--check` fails CI on any miss.
@@ -126,10 +134,12 @@ Promote only the fields with real cross-host SSOT value into `.describe()` / `.m
 6. **ConfigForm complexity** (it's a list + drill-in, not one Select). Mitigate: MVP = booleans + enums + `openForm` only; defer free-text editing; reuse `MemoryListForm` list shape + `Select`.
 
 ## Explicit exclusions (omit `'cli'` from `hosts`; never surfaced in `/config`)
+
 - `texra.memory.enabled`, `texra.goal.enabled` — gated by `registerAgentFeatures()`, confirmed **never called in the CLI** (`initPlatform.ts` has no call; only `extension.ts:219` / desktop `index.ts:154`). Toggling them in the CLI does nothing.
 - `SUPER_YOLO_ENABLED`, `ALLOW_ORCHESTRATOR_KILL`, `DETACH_SUBAGENTS_ON_STOP`, `NESTED_DELEGATION_MAX_DEPTH` — display-only / no CLI orchestrator consumer.
 - Complex global-state domains (streaming/endpoints/models/agents/tools/presets/codex/claude) — `openForm` delegation only, never `/config` scalars.
 - Class-D internal state (`AGENT_HISTORY`, caches, `*_MIGRATED`/`*_VERSION`, onboarding flags, `DESKTOP_CRASH_REPORTING_ENABLED`) — not user settings; excluded entirely, enforced by the PR2 guardrail.
 
 ## Process
+
 Grounded on fresh `origin/main`; re-sync before starting (`git rev-list --count main...origin/main`). Shared-repo concurrency: expect a format-bot commit — adopt via `reset --hard`, don't force-push. Each PR carries its own tests and is independently reviewable; CHANGELOG entry (Features) lands with PR3.

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1686,6 +1686,21 @@
         "mac": "cmd+option+e",
         "when": "texra.activated"
       }
+    ],
+    "chatSkills": [
+      { "name": "inline-paper-critic",   "path": "../../skills/inline-paper-critic" },
+      { "name": "lean-blueprint",        "path": "../../skills/lean-blueprint" },
+      { "name": "lean-proof-assistant",  "path": "../../skills/lean-proof-assistant" },
+      { "name": "lean-search",           "path": "../../skills/lean-search" },
+      { "name": "lean-simplifier",       "path": "../../skills/lean-simplifier" },
+      { "name": "literature-search",     "path": "../../skills/literature-search" },
+      { "name": "manuscript-review",     "path": "../../skills/manuscript-review" },
+      { "name": "math-ocr",              "path": "../../skills/math-ocr" },
+      { "name": "mathematical-enhancer", "path": "../../skills/mathematical-enhancer" },
+      { "name": "scientific-presenter",  "path": "../../skills/scientific-presenter" },
+      { "name": "scientific-simplifier", "path": "../../skills/scientific-simplifier" },
+      { "name": "tikz-figure-builder",   "path": "../../skills/tikz-figure-builder" },
+      { "name": "writing-commenter",     "path": "../../skills/writing-commenter" }
     ]
   },
   "repository": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1688,19 +1688,58 @@
       }
     ],
     "chatSkills": [
-      { "name": "inline-paper-critic",   "path": "../../skills/inline-paper-critic" },
-      { "name": "lean-blueprint",        "path": "../../skills/lean-blueprint" },
-      { "name": "lean-proof-assistant",  "path": "../../skills/lean-proof-assistant" },
-      { "name": "lean-search",           "path": "../../skills/lean-search" },
-      { "name": "lean-simplifier",       "path": "../../skills/lean-simplifier" },
-      { "name": "literature-search",     "path": "../../skills/literature-search" },
-      { "name": "manuscript-review",     "path": "../../skills/manuscript-review" },
-      { "name": "math-ocr",              "path": "../../skills/math-ocr" },
-      { "name": "mathematical-enhancer", "path": "../../skills/mathematical-enhancer" },
-      { "name": "scientific-presenter",  "path": "../../skills/scientific-presenter" },
-      { "name": "scientific-simplifier", "path": "../../skills/scientific-simplifier" },
-      { "name": "tikz-figure-builder",   "path": "../../skills/tikz-figure-builder" },
-      { "name": "writing-commenter",     "path": "../../skills/writing-commenter" }
+      {
+        "name": "inline-paper-critic",
+        "path": "../../skills/inline-paper-critic"
+      },
+      {
+        "name": "lean-blueprint",
+        "path": "../../skills/lean-blueprint"
+      },
+      {
+        "name": "lean-proof-assistant",
+        "path": "../../skills/lean-proof-assistant"
+      },
+      {
+        "name": "lean-search",
+        "path": "../../skills/lean-search"
+      },
+      {
+        "name": "lean-simplifier",
+        "path": "../../skills/lean-simplifier"
+      },
+      {
+        "name": "literature-search",
+        "path": "../../skills/literature-search"
+      },
+      {
+        "name": "manuscript-review",
+        "path": "../../skills/manuscript-review"
+      },
+      {
+        "name": "math-ocr",
+        "path": "../../skills/math-ocr"
+      },
+      {
+        "name": "mathematical-enhancer",
+        "path": "../../skills/mathematical-enhancer"
+      },
+      {
+        "name": "scientific-presenter",
+        "path": "../../skills/scientific-presenter"
+      },
+      {
+        "name": "scientific-simplifier",
+        "path": "../../skills/scientific-simplifier"
+      },
+      {
+        "name": "tikz-figure-builder",
+        "path": "../../skills/tikz-figure-builder"
+      },
+      {
+        "name": "writing-commenter",
+        "path": "../../skills/writing-commenter"
+      }
     ]
   },
   "repository": {

--- a/packages/extension/src/commands/agent/agentCreatorCommands.ts
+++ b/packages/extension/src/commands/agent/agentCreatorCommands.ts
@@ -95,6 +95,7 @@ function buildVSCodeUI(): AgentCreatorUI {
           title: `Tool Use Agent: ${agentName}`,
           placeHolder:
             'Select tool groups (pre-selected based on your description)',
+          prompt: 'Choose which tool groups this agent should have access to',
           canPickMany: true,
         },
       );

--- a/packages/extension/src/commands/api/apiKeyCommands.ts
+++ b/packages/extension/src/commands/api/apiKeyCommands.ts
@@ -94,6 +94,7 @@ export async function setApiKey(provider?: ApiProvider): Promise<void> {
   const providerItems = await SecretManager.getApiProviderQuickPickItems();
   const providerPick = await vscode.window.showQuickPick(providerItems, {
     placeHolder: 'Select API provider',
+    prompt: 'Choose the AI provider to configure an API key for',
   });
 
   if (providerPick?.provider) {
@@ -109,6 +110,7 @@ export async function removeApiKey(): Promise<void> {
   const providerItems = await SecretManager.getApiProviderQuickPickItems();
   const providerPick = await vscode.window.showQuickPick(providerItems, {
     placeHolder: 'Select API provider to remove key',
+    prompt: 'Choose the AI provider whose API key you want to remove',
   });
 
   const provider = providerPick?.provider;

--- a/packages/extension/src/commands/latex/figCommands.ts
+++ b/packages/extension/src/commands/latex/figCommands.ts
@@ -55,6 +55,7 @@ export async function handleExtractFigurePaths(): Promise<void> {
       if (figurePaths.length > 0) {
         const selected = await vscode.window.showQuickPick(figurePaths, {
           placeHolder: 'Found figures (select to copy path)',
+          prompt: 'Select a figure path to copy to the clipboard',
           canPickMany: false,
         });
 
@@ -100,6 +101,7 @@ export async function handleExtractTikzFigures(): Promise<void> {
 
         const selected = await vscode.window.showQuickPick(items, {
           placeHolder: 'Found TikZ figures (select to copy label)',
+          prompt: 'Select a TikZ figure label to copy to the clipboard',
           canPickMany: false,
         });
 
@@ -152,6 +154,7 @@ export async function handleCompileTikzFigures(): Promise<void> {
 
             const selected = await vscode.window.showQuickPick(items, {
               placeHolder: 'Compiled TikZ figures (select to open)',
+              prompt: 'Select a compiled TikZ figure to open in the editor',
               canPickMany: false,
             });
 

--- a/packages/extension/src/common/webview/BaseWebviewProvider.ts
+++ b/packages/extension/src/common/webview/BaseWebviewProvider.ts
@@ -10,6 +10,7 @@ export interface PanelOptions {
   viewPath: string;
   column?: vscode.ViewColumn;
   retainContextWhenHidden?: boolean;
+  iconPath?: vscode.ThemeIcon | vscode.Uri | { light: vscode.Uri; dark: vscode.Uri };
 }
 
 /**
@@ -108,6 +109,9 @@ export abstract class BaseWebviewProvider {
       },
     );
 
+    if (options.iconPath) {
+      this._view.iconPath = options.iconPath;
+    }
     this.resolveWebviewViewInternal(this._view);
     return true;
   }

--- a/packages/extension/src/common/webview/BaseWebviewProvider.ts
+++ b/packages/extension/src/common/webview/BaseWebviewProvider.ts
@@ -10,7 +10,10 @@ export interface PanelOptions {
   viewPath: string;
   column?: vscode.ViewColumn;
   retainContextWhenHidden?: boolean;
-  iconPath?: vscode.ThemeIcon | vscode.Uri | { light: vscode.Uri; dark: vscode.Uri };
+  iconPath?:
+    | vscode.ThemeIcon
+    | vscode.Uri
+    | { light: vscode.Uri; dark: vscode.Uri };
 }
 
 /**

--- a/packages/extension/src/frontend/review/promptReviewOptions.ts
+++ b/packages/extension/src/frontend/review/promptReviewOptions.ts
@@ -76,7 +76,8 @@ export async function promptReviewOptions(
   const approachPick = await vscode.window.showQuickPick(approachItems, {
     title: 'Agent Review — Approach',
     placeHolder: 'Choose review depth',
-    prompt: 'Quick checks key suspicions (fast); Thorough reads all changed files (deeper)',
+    prompt:
+      'Quick checks key suspicions (fast); Thorough reads all changed files (deeper)',
     ignoreFocusOut: true,
   });
   if (!approachPick) return undefined;
@@ -99,7 +100,8 @@ export async function promptReviewOptions(
   const branchPick = await vscode.window.showQuickPick(branchItems, {
     title: 'Agent Review — Diff Against',
     placeHolder: 'Choose the branch to compare against',
-    prompt: 'The review will diff the current branch against the selected branch',
+    prompt:
+      'The review will diff the current branch against the selected branch',
     ignoreFocusOut: true,
   });
   if (!branchPick) return undefined;

--- a/packages/extension/src/frontend/review/promptReviewOptions.ts
+++ b/packages/extension/src/frontend/review/promptReviewOptions.ts
@@ -76,6 +76,7 @@ export async function promptReviewOptions(
   const approachPick = await vscode.window.showQuickPick(approachItems, {
     title: 'Agent Review — Approach',
     placeHolder: 'Choose review depth',
+    prompt: 'Quick checks key suspicions (fast); Thorough reads all changed files (deeper)',
     ignoreFocusOut: true,
   });
   if (!approachPick) return undefined;
@@ -98,6 +99,7 @@ export async function promptReviewOptions(
   const branchPick = await vscode.window.showQuickPick(branchItems, {
     title: 'Agent Review — Diff Against',
     placeHolder: 'Choose the branch to compare against',
+    prompt: 'The review will diff the current branch against the selected branch',
     ignoreFocusOut: true,
   });
   if (!branchPick) return undefined;

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -699,6 +699,7 @@ export class ProgressViewProvider
         ),
       },
     );
+    this._panelView.iconPath = new vscode.ThemeIcon('pulse');
     this._panelReady = false;
 
     this._panelDisposables.push(

--- a/packages/extension/src/settingsView/SettingsViewProvider.ts
+++ b/packages/extension/src/settingsView/SettingsViewProvider.ts
@@ -60,6 +60,7 @@ export class SettingsViewProvider
       viewType: SettingsViewProvider.viewType,
       title: 'TeXRA Dashboard',
       viewPath: 'settingsView',
+      iconPath: new vscode.ThemeIcon('settings-gear'),
     });
 
     if (!isNew && this._view) {


### PR DESCRIPTION
- Add chatSkills contribution point (VS Code 1.109+) exposing all 13 bundled academic/LaTeX skills to Copilot Chat as native slash commands
- Add iconPath support to PanelOptions and set ThemeIcon on the TeXRA Dashboard (settings-gear) and TeXRA Progress (pulse) panels using the stable WebviewPanel.iconPath = ThemeIcon(...) API (1.110+)
- Add QuickPick.prompt text to API key, review, agent creator, and figure picker flows for better discoverability (stable in 1.108+)


Claude-Session: https://claude.ai/code/session_014e1h4Pay8CeDibKGSqf3ju

## Summary

<!-- Explain the change for a reader who has not seen the issue discussion. -->

## Issue acceptance gates

<!-- List the issue(s) this PR addresses and the exact acceptance gates satisfied. If a gate remains incomplete, say so. -->

## Single source of truth

<!-- Name the module, schema, context object, or coordinator that now owns the relevant fact or decision. -->

## Duplication and abstraction budget

<!-- State what duplication was removed or avoided. If a new abstraction was added, state the invariant or host-boundary decision it owns. Do not add pass-through layers. -->

## Host impact

Extension:

Desktop:

CLI:

## Scheduled refactoring

<!-- Link any follow-up issue, or state "None" if no follow-up is needed. -->

## Validation

<!-- List the checks run. If a check was intentionally not run, say why. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation and manifest contributions only; no auth, data, or agent-runtime behavior changes.
> 
> **Overview**
> Wires **VS Code 1.109+ `chatSkills`** in `package.json` so all **13** bundled academic/LaTeX skills under `skills/` appear as native Copilot Chat slash commands.
> 
> **Webview panel tabs** get optional **`iconPath`** on `PanelOptions` in `BaseWebviewProvider` (VS Code 1.110+ `WebviewPanel.iconPath`); the TeXRA Dashboard uses **`settings-gear`**, and the popped-out Progress editor panel uses **`pulse`** (set directly in `ProgressViewProvider`).
> 
> Several **`showQuickPick`** flows now include a **`prompt`** line for clearer guidance: API key set/remove, agent-review approach/branch, tool-group picker in agent creation, and LaTeX figure/TikZ pickers.
> 
> The config-catalog proposal doc only has **markdown emphasis/escaping** tweaks (no design change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1272f93823bf84a62b5a72792f687e7ddac3e057. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->