### PR TITLE
Use toErrorMessage() in codexOAuthClient catch blocks

### DIFF
--- a/src/auth/codex/codexOAuthClient.ts
+++ b/src/auth/codex/codexOAuthClient.ts
@@ -5,6 +5,7 @@
  * these and persists the result. Kept separate so the state machine
  * (refresh thresholds, single-flight) is unit-testable without the network.
  */
+import { toErrorMessage } from '@common/errors';
 import {
   CODEX_CLIENT_ID,
   CODEX_DEVICE_REDIRECT_URI,
@@ -51,7 +52,7 @@ async function postForm(url: string, body: URLSearchParams): Promise<Response> {
     });
   } catch (cause) {
     throw new CodexAuthError(
-      `Network error contacting ${url}: ${(cause as Error).message}`,
+      `Network error contacting ${url}: ${toErrorMessage(cause)}`,
       'transient',
     );
   }
@@ -126,7 +127,7 @@ export async function requestDeviceUserCode(): Promise<CodexDeviceUserCode> {
     });
   } catch (cause) {
     throw new CodexAuthError(
-      `Network error requesting device code: ${(cause as Error).message}`,
+      `Network error requesting device code: ${toErrorMessage(cause)}`,
       'transient',
     );
   }
@@ -184,7 +185,7 @@ export async function pollDeviceToken(params: {
   } catch (cause) {
     // Network blip mid-poll: treat as pending so the loop keeps trying.
     throw new CodexAuthError(
-      `Network error polling device authorization: ${(cause as Error).message}`,
+      `Network error polling device authorization: ${toErrorMessage(cause)}`,
       'pending',
     );
   }


### PR DESCRIPTION
## Summary

- Replace `(cause as Error).message` with `toErrorMessage(cause)` in the three `catch` blocks in `src/auth/codex/codexOAuthClient.ts`
- Add the `@common/errors` import

## Why

`(cause as Error).message` is a type-unsafe cast that silently produces `"undefined"` when `fetch` throws a non-`Error` value (e.g. a `DOMException`, a string, or `undefined` in some runtimes). `toErrorMessage()` already exists in `@common/errors` for exactly this purpose and is used by 310+ call sites across the codebase. This is the only file in `src/` that bypassed it.

## Codebase-wide consolidation scan

A broader 4-agent scan of the codebase was run before this change. Key findings (most showed the codebase is already well-maintained):

| Area | Finding |
|---|---|
| Native methods | Excellent — `Intl`, `Object.hasOwn`, `Number.isFinite`, `Set` spread, `Map.entries`, `p-retry` all used correctly |
| Error handling | One real violation (this file); Supabase Deno function intentionally standalone |
| Async retry | Uses `p-retry` correctly; no manual `setTimeout` + while-loop reimplementations |
| Type guards | Well-centralised in `src/utils/core/typeGuards.ts` |
| Utility duplication | Minor: `formatLineCount` (frontend) vs `formatResultCount` (backend) serve different sides of the boundary and are correctly split |
| Path utilities | `src/utils/core/pathCore.ts` (Node) vs `src/shared/utils/path.ts` (frontend) — intentional split |
| Model handler boilerplate | Significant shared shape (BUILD→COUNT→EXECUTE lifecycle, `prependTextToUserMessage`, stop-reason evaluation) but refactoring the handler hierarchy is architectural scope beyond this PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3SQXEBMBmEXFR6oJ19kxG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3SQXEBMBmEXFR6oJ19kxG)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Message-only change in OAuth client error paths; no changes to token exchange, polling logic, or auth decisions.
> 
> **Overview**
> **Codex OAuth network errors** now use the shared `toErrorMessage()` helper from `@common/errors` instead of `(cause as Error).message` in three `fetch` `catch` blocks (`postForm`, `requestDeviceUserCode`, and `pollDeviceToken`).
> 
> Behavior of `CodexAuthError` kinds (`transient` / `pending`) is unchanged; only how non-`Error` throw values are turned into message text is safer and consistent with the rest of the codebase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da231c0e77208e953fcc3242a19c4a94d630e770. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->