### PR TITLE
Move git subprocess env construction out of the agent domain layer

### DIFF
--- a/docs/prds/2026-01-17-agent-history-access.md
+++ b/docs/prds/2026-01-17-agent-history-access.md
@@ -207,13 +207,13 @@ src/tools/registry.ts  # Import + register ExecutionsTool
 
 ### Existing Utilities to Reuse
 
-| Utility                                | Location                                    | Usage                   |
-| -------------------------------------- | ------------------------------------------- | ----------------------- |
-| `getPathSegments`                      | `@utils/core/pathCore`                      | Parse virtual paths     |
+| Utility                                | Location                                     | Usage                   |
+| -------------------------------------- | -------------------------------------------- | ----------------------- |
+| `getPathSegments`                      | `@utils/core/pathCore`                       | Parse virtual paths     |
 | `getCurrentToolFileInteractionContext` | `@agent/followUp/ToolFileInteractionContext` | Get current executionId |
-| `getExecutionStore`                    | `@agent/storage/ExecutionKVStore`           | Read flow records       |
-| `AgentHistoryManager`                  | `@common/history`                           | List executions         |
-| `StorageFS`                            | `@utils/files`                              | Read task run files     |
+| `getExecutionStore`                    | `@agent/storage/ExecutionKVStore`            | Read flow records       |
+| `AgentHistoryManager`                  | `@common/history`                            | List executions         |
+| `StorageFS`                            | `@utils/files`                               | Read task run files     |
 
 ### No Changes Required
 

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -10,7 +10,7 @@ import { render } from 'ink';
 import React from 'react';
 
 import { getAgentsByCategory, loadAgents } from '@agent/index';
-import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { toErrorMessage } from '@common/errors';
 import { DEFAULT_STARTUP_TEAM_ID } from '@controllers/onboarding/defaultTeamSeeding';

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -22,7 +22,7 @@ import { platform, tryPlatform } from '@platform/platform';
 import { getFirstRunDone } from '@controllers/onboarding/onboardingFunnel';
 import { loadAgents } from '@agent/index';
 import { executionRegistry } from '@agent/runtime/executionRegistry';
-import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
+import { sendFollowUp } from '@agent/followUp/ToolUseFollowUp';
 import { type CliContext, readCliVersion } from '@cli/runtime/cliContext';
 import { type CliToolUseResumeResolution } from '@cli/runtime/sessionResume';
 import { effectiveCliApiMode } from '@cli/runtime/apiAccessMode';

--- a/src/agent/review/reviewDiff.ts
+++ b/src/agent/review/reviewDiff.ts
@@ -18,7 +18,7 @@ import simpleGit, { type SimpleGit } from 'simple-git';
 import { platform } from '@platform/platform';
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
-import { extendEnvPath } from '@utils/system/platformPaths';
+import { makeMachineGitEnv } from '@utils/system/platformPaths';
 import { splitContentLines, splitOutputLines } from '@utils/text/stringUtils';
 
 import { normalizeReviewFilePath } from './reviewIssues';
@@ -33,35 +33,6 @@ const MAX_UNTRACKED_FILE_LINES = 400;
 const MAX_UNTRACKED_FILE_BYTES = 200 * 1024;
 /** Overall cap on the diff text sent to the model (~40k tokens). */
 const MAX_REVIEW_DIFF_CHARS = 160_000;
-
-const SIMPLE_GIT_UNSAFE_ENV_KEYS = new Set([
-  'editor',
-  'git_askpass',
-  'git_config_global',
-  'git_config_system',
-  'git_config_count',
-  'git_config',
-  'git_editor',
-  'git_exec_path',
-  'git_external_diff',
-  'git_pager',
-  'git_proxy_command',
-  'git_sequence_editor',
-  'git_template_dir',
-  'pager',
-  'prefix',
-  'ssh_askpass',
-]);
-
-function makeMachineGitEnv(): NodeJS.ProcessEnv {
-  const env: NodeJS.ProcessEnv = {};
-  for (const [key, value] of Object.entries(process.env)) {
-    if (SIMPLE_GIT_UNSAFE_ENV_KEYS.has(key.toLowerCase())) continue;
-    env[key] = value;
-  }
-  env.PATH = extendEnvPath(env.PATH);
-  return env;
-}
 
 export interface CollectReviewDiffOptions {
   /** Any path inside the repository; the diff always covers the whole repo. */
@@ -103,10 +74,9 @@ export type CollectReviewDiffResult =
   | { ok: false; reason: string };
 
 function makeGit(cwd: string): SimpleGit {
-  // GUI-launched hosts (VS Code from the Dock, the Electron desktop app) start
-  // with a minimal PATH that omits Homebrew / /usr/local/bin, so `git` may be
-  // unresolvable. executeCommand previously ran git with extendEnvPath();
-  // preserve that here so simple-git can still locate the binary.
+  // makeMachineGitEnv() strips helper-invoking env keys and extends PATH so
+  // GUI-launched hosts (VS Code from the Dock, the Electron desktop app), whose
+  // minimal PATH omits Homebrew / /usr/local/bin, can still resolve `git`.
   return simpleGit(cwd, { timeout: { block: GIT_TIMEOUT_MS } }).env(
     makeMachineGitEnv(),
   );

--- a/src/test-kernel/cli/SessionStatus.vitest.mts
+++ b/src/test-kernel/cli/SessionStatus.vitest.mts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import {
   formatCliStatusLabel,
   formatCliSessionStatus,

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -11,7 +11,7 @@ import {
   StreamLogStore,
 } from '@transcript';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
-import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import {
   cliState,
   patchStream,

--- a/src/test-kernel/common/modules/pathUtils.vitest.ts
+++ b/src/test-kernel/common/modules/pathUtils.vitest.ts
@@ -1,5 +1,7 @@
+// Standard library imports
+import * as assert from 'node:assert';
+
 // Third-party imports
-import * as assert from 'assert';
 import { describe, it } from 'vitest';
 
 import { getBasename } from '@shared/utils/path';

--- a/src/test-kernel/controllers/SettingsAgentVisibilityController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsAgentVisibilityController.vitest.ts
@@ -1,5 +1,5 @@
 // Standard library imports
-import { strict as assert } from 'assert';
+import { strict as assert } from 'node:assert';
 
 // Third-party imports
 import { describe, expect, it } from 'vitest';

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -1606,7 +1606,7 @@ describe('DesktopProgressBridge', () => {
       resumeToolUseFromSnapshot,
     });
     const { ToolUseFollowUpQueue } =
-      await import('@agent/toolUse/ToolUseFollowUpQueueManager');
+      await import('@agent/followUp/ToolUseFollowUpQueueManager');
     const { StreamStatusService } =
       await import('@agent/runtime/StreamStatusService');
     const taskState = {
@@ -1692,7 +1692,7 @@ describe('DesktopProgressBridge', () => {
       resumeToolUseFromSnapshot,
     });
     const { ToolUseFollowUpQueue } =
-      await import('@agent/toolUse/ToolUseFollowUpQueueManager');
+      await import('@agent/followUp/ToolUseFollowUpQueueManager');
     const { StreamStatusService } =
       await import('@agent/runtime/StreamStatusService');
 

--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
-import { withToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
+import { withToolFileInteractionContext } from '@agent/followUp/ToolFileInteractionContext';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { AgentProposalCoordinator } from '@agent/runtime/AgentProposalCoordinator';
 import {
@@ -13,7 +13,7 @@ import { AgentFlowError } from '@agent/runtime/AgentFlowResult';
 import { PlanApprovalCoordinator } from '@agent/runtime/PlanApprovalCoordinator';
 import { RetryRequestCoordinatorImpl } from '@agent/runtime/RetryRequestCoordinator';
 import type { ToolUseBeforeWaitingCallback } from '@agent/implementations/flows/tooluse/ToolUseServices';
-import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import type { StreamTabId } from '@shared/schemas';
 import { DelegateAgentTool } from '@tools/DelegationTools';
 

--- a/src/utils/system/platformPaths.ts
+++ b/src/utils/system/platformPaths.ts
@@ -245,6 +245,48 @@ export function extendEnvPath(
 }
 
 /**
+ * Environment keys that let git invoke arbitrary helper programs (editors,
+ * pagers, askpass, external-diff, config overrides). Stripped before handing
+ * the environment to a non-interactive git subprocess so an inherited value
+ * can't run a helper or redirect config during automated operations.
+ */
+const GIT_UNSAFE_ENV_KEYS = new Set([
+  'editor',
+  'git_askpass',
+  'git_config_global',
+  'git_config_system',
+  'git_config_count',
+  'git_config',
+  'git_editor',
+  'git_exec_path',
+  'git_external_diff',
+  'git_pager',
+  'git_proxy_command',
+  'git_sequence_editor',
+  'git_template_dir',
+  'pager',
+  'prefix',
+  'ssh_askpass',
+]);
+
+/**
+ * Build an environment for a non-interactive git subprocess: the current
+ * environment with the helper-invoking keys in {@link GIT_UNSAFE_ENV_KEYS}
+ * removed and `PATH` extended via {@link extendEnvPath} so GUI-launched hosts
+ * (whose minimal PATH may omit Homebrew / /usr/local/bin) can still resolve
+ * the `git` binary.
+ */
+export function makeMachineGitEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (GIT_UNSAFE_ENV_KEYS.has(key.toLowerCase())) continue;
+    env[key] = value;
+  }
+  env.PATH = extendEnvPath(env.PATH);
+  return env;
+}
+
+/**
  * Check if a path is safe (doesn't contain dangerous sequences)
  */
 function isPathSafe(filepath: string): boolean {


### PR DESCRIPTION
## Summary

`src/agent/review/reviewDiff.ts` is a host-agnostic domain module (it carries a "Host-neutral … no vscode" header). It nonetheless read `process.env` directly to build the environment for its git subprocess — iterating `process.env`, stripping helper-invoking keys (`GIT_ASKPASS`, `GIT_EXTERNAL_DIFF`, `PAGER`, …), and extending `PATH`. That is an OS-infrastructure concern, and its sibling helper `extendEnvPath` already lives in the utils layer (`@utils/system/platformPaths`).

This PR relocates `makeMachineGitEnv` (and its unsafe-key set) into `@utils/system/platformPaths`, co-located with `extendEnvPath`, so the raw `process.env` read no longer lives in the agent domain. `reviewDiff.ts` now imports the helper. Behavior is byte-identical — the function body is unchanged, only its home moved.

It also prefixes the two bare `assert` imports in `test-kernel` with `node:` to match the repo-wide `node:` builtin convention.

### Second commit — unblock typecheck after rebase onto main

Between this PR opening and CI running, `main` was force-updated to include `ce10b68` (#6666, "rename `src/agent/toolUse/` → `src/agent/followUp/`"). That rename left **six importers still resolving the old `@agent/toolUse/*` alias**, which no longer exists — so `pnpm run typecheck` is red on `main` itself (and on any branch rebased onto it). The CI failure on this PR's first push came entirely from those dangling imports, not from the reviewDiff change.

The second commit rebases onto current `main` and repoints those six files to `@agent/followUp/*` (the modules — `ToolUseFollowUp`, `ToolUseFollowUpQueueManager`, `ToolFileInteractionContext` — all live there post-rename). Files touched: `packages/cli/scripts/tui-harness.tsx`, `packages/cli/src/chat/tui/runChatTui.tsx`, and four `src/test-kernel/**` specs. This is unrelated to the reviewDiff move but is required to make the branch typecheck; it incidentally fixes `main`'s breakage. Happy to split it into its own PR if preferred.

## Single source of truth

`@utils/system/platformPaths` now owns git-subprocess environment construction (`makeMachineGitEnv`) alongside the related `extendEnvPath` PATH helper. `reviewDiff.ts` is purely a consumer.

## Duplication and abstraction budget

No new abstraction or pass-through layer. `makeMachineGitEnv` is moved, not wrapped — the call site (`makeGit`) calls it directly as before. The second commit only rewrites import specifiers; no logic changes.

## Host impact

Extension: None — runtime behavior of the local agent review feature is unchanged.

Desktop: None.

CLI: Import-path fix only (no behavior change); the CLI now typechecks against the renamed `followUp/` modules.

## Scheduled refactoring

None for the reviewDiff move. The `@agent/followUp` import fix addresses a pre-existing incomplete rename from #6666 — if the maintainers would rather track that as its own change, it can be lifted out of this branch.

## Validation

- `npm run typecheck` — passes (root, test-kernel, extension, CLI projects), exit 0, zero TS errors, against current `main`.
- `npx vitest run` on `AgentReviewDiff`, `pathUtils`, `SettingsAgentVisibilityController`, plus the import-fixed `SessionStatus`, `TuiStateAndFocus`, and `DelegationHeadless` suites — all pass (158 tests in the latter batch).
- `npx eslint` on the touched files — no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSzL9jrhDcMSqS65cpVGn1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logic-preserving relocation and import-path fixes only; no new git or follow-up behavior.
> 
> **Overview**
> Moves **`makeMachineGitEnv`** (and the git helper-invoking env key denylist) from **`reviewDiff.ts`** into **`@utils/system/platformPaths`**, next to **`extendEnvPath`**, so host-neutral review code no longer owns **`process.env`** shaping for git subprocesses. **`makeGit`** in review diff collection now imports the shared helper; behavior is unchanged.
> 
> A follow-on fix repoints stale **`@agent/toolUse/*`** imports to **`@agent/followUp/*`** after the directory rename on main (CLI harness, **`runChatTui`**, and several test-kernel specs). Test files also switch bare **`assert`** imports to **`node:assert`**. The agent-history PRD table gets minor formatting and an updated **`ToolFileInteractionContext`** path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a9d86781f16c8c982a80033ad961a79ea5bd548. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->