### PR TITLE
refactor(WebviewBridge): merge parallel changedStreams+cursors into single Map

### DIFF
--- a/src/shared/progressView/backend/WebviewBridge.ts
+++ b/src/shared/progressView/backend/WebviewBridge.ts
@@ -27,10 +27,16 @@ export interface ProgressLogStore {
   clearDirtyUpdates(streamId: StreamTabId): void;
 }
 
+/** Per-stream cursor and pending-flush state, created by `syncStream`. */
+interface StreamEntry {
+  cursor: number;
+  dirty: boolean;
+}
+
 export class WebviewBridge {
   private flushTimer: ReturnType<typeof setTimeout> | null = null;
-  private readonly changedStreams = new Set<StreamTabId>();
-  private readonly cursors = new Map<StreamTabId, number>();
+  /** Registered streams: presence means cursor is seeded; `dirty` means pending flush. */
+  private readonly streams = new Map<StreamTabId, StreamEntry>();
   private readonly unsubscribe: () => void;
   private flushInProgress = false;
   private flushRequested = false;
@@ -50,8 +56,9 @@ export class WebviewBridge {
       // streamState yet) while this bridge advances its cursor past them,
       // losing them until a manual reload. Until then the on-disk log is
       // authoritative and `syncStream` replays it in full.
-      if (!this.cursors.has(streamId)) return;
-      this.changedStreams.add(streamId);
+      const entry = this.streams.get(streamId);
+      if (!entry) return;
+      entry.dirty = true;
       this.scheduleFlush();
     });
   }
@@ -62,25 +69,21 @@ export class WebviewBridge {
       clearTimeout(this.flushTimer);
       this.flushTimer = null;
     }
-    this.changedStreams.clear();
-    this.cursors.clear();
+    this.streams.clear();
   }
 
   syncStream(streamId: StreamTabId): void {
-    this.cursors.set(streamId, 0);
+    this.streams.set(streamId, { cursor: 0, dirty: true });
     this.store.clearDirtyUpdates(streamId);
-    this.changedStreams.add(streamId);
     this.scheduleFlush();
   }
 
   clearStream(streamId: StreamTabId): void {
-    this.changedStreams.delete(streamId);
-    this.cursors.delete(streamId);
+    this.streams.delete(streamId);
   }
 
   clearAll(): void {
-    this.changedStreams.clear();
-    this.cursors.clear();
+    this.streams.clear();
   }
 
   private scheduleFlush(): void {
@@ -114,26 +117,22 @@ export class WebviewBridge {
   private async flush(): Promise<boolean> {
     const activeStream = this.getActiveStream();
     if (!activeStream) return true;
-    if (!this.changedStreams.has(activeStream)) return true;
+    const entry = this.streams.get(activeStream);
+    if (!entry?.dirty) return true;
 
     const log = this.store.get(activeStream);
     if (!log) {
-      this.changedStreams.delete(activeStream);
+      entry.dirty = false;
       return true;
     }
 
-    // `changedStreams` is a subset of `cursors`: onChange only enqueues a
-    // stream whose cursor is already seeded (the `syncStream` handshake), and
-    // syncStream seeds it before enqueuing. Thus a stream present here has a
-    // cursor here. The `?? 0` is therefore unreachable, kept only to satisfy
-    // the type.
-    const cursor = this.cursors.get(activeStream) ?? 0;
+    const { cursor } = entry;
     const nextCursor = log.head;
     const entries = log.getRange(cursor, nextCursor);
     const updates = log.getDirtyUpdates(cursor);
 
     if (entries.length === 0 && updates.length === 0) {
-      this.changedStreams.delete(activeStream);
+      entry.dirty = false;
       return true;
     }
 
@@ -147,12 +146,8 @@ export class WebviewBridge {
     if (!(await this.deliver(payload))) return false;
 
     log.ackDirtyUpdates(updates);
-    this.cursors.set(activeStream, nextCursor);
-    if (this.flushRequested) {
-      this.changedStreams.add(activeStream);
-    } else {
-      this.changedStreams.delete(activeStream);
-    }
+    entry.cursor = nextCursor;
+    entry.dirty = this.flushRequested;
     return true;
   }
 


### PR DESCRIPTION
## Summary

- `WebviewBridge` held two parallel data structures keyed by `StreamTabId`: a `Set<StreamTabId>` for dirty-tracking (`changedStreams`) and a `Map<StreamTabId, number>` for cursor positions (`cursors`). The code comment in `flush()` explicitly noted that `changedStreams` is always a subset of `cursors` and that the `?? 0` fallback was unreachable.
- Replaced both with a single `Map<StreamTabId, StreamEntry>` where `StreamEntry = { cursor: number; dirty: boolean }`. Presence in the map means "registered via `syncStream`"; `dirty: true` means a flush is pending.
- Removes the dead `?? 0` fallback, cuts two class fields to one, and simplifies every mutating method (`syncStream`, `clearStream`, `clearAll`, `dispose`, `flush`) to touch a single structure.

## Test plan

- All 5 existing `WebviewBridge.vitest.ts` tests pass (covering flush, tab-switch, cursor preservation on failed delivery, and async serialization).
- `npm run typecheck` exits 0 across all packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013381PPscNSgaSaonBTReFn

---
_Generated by [Claude Code](https://claude.ai/code/session_013381PPscNSgaSaonBTReFn)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor with unchanged flush semantics; existing WebviewBridge tests cover the behavior.
> 
> **Overview**
> **`WebviewBridge`** no longer keeps separate **`changedStreams`** and **`cursors`** maps. Per-stream state is a single **`Map<StreamTabId, StreamEntry>`** with **`{ cursor, dirty }`**: map membership means the stream was registered via **`syncStream`**; **`dirty`** means a LOG_DELTA flush is still needed.
> 
> **`onChange`**, **`syncStream`**, **`clearStream`**, **`dispose`**, and **`flush`** now update that one structure. **`flush`** drops the old invariant comment and unreachable **`?? 0`** cursor fallback; after a successful delivery it sets **`entry.cursor`** and **`entry.dirty`** from **`flushRequested`** instead of re-adding the stream to a separate set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba1adae887539d88b4111de36f2754466d364d1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->