### PR TITLE
refactor(agent): collapse RetryState, narrow IModelHandler port, dedup createResponse template

### DIFF
--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts
@@ -7,8 +7,6 @@ import {
   CODEX_THREAD_TOOL,
   CODEX_TODO_TOOL,
   CODEX_TURN_TOOL,
-} from '@tools/codexShared';
-import {
   CodexFileChangeToolInputSchema,
   CodexThreadToolInputSchema,
   CodexTodoToolInputSchema,

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts
@@ -7,11 +7,13 @@ import {
   CODEX_THREAD_TOOL,
   CODEX_TODO_TOOL,
   CODEX_TURN_TOOL,
+} from '@tools/codexShared';
+import {
   CodexFileChangeToolInputSchema,
   CodexThreadToolInputSchema,
   CodexTodoToolInputSchema,
   CodexTurnToolInputSchema,
-} from '@tools/codexShared';
+} from '@shared/schemas/codex';
 import { formatDuration } from '@utils/core';
 
 // Local imports - Lit template utilities

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
@@ -51,7 +51,7 @@ import type { AcceptRunFilesInput } from '@tools/AcceptRunFilesTool';
 import {
   CodexMcpToolOutputSchema,
   type CodexMcpToolOutput,
-} from '@tools/codexShared';
+} from '@shared/schemas/codex';
 import type { MemoryToolInput } from '@tools/memory/MemoryTool';
 import { isObject } from '@utils/core';
 

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
@@ -36,6 +36,10 @@ import {
   getLanguageFromPath,
 } from '@progressView/frontend/formatters/constants';
 import { getProposalFileGroups } from '@shared/schemas/proposalFields';
+import {
+  CodexMcpToolOutputSchema,
+  type CodexMcpToolOutput,
+} from '@shared/schemas/codex';
 import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
 import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
 import type { ExecutionsToolInput } from '@tools/ExecutionsTool';
@@ -48,10 +52,6 @@ import type {
   WorkflowAgentInput,
 } from '@tools/DelegationTools';
 import type { AcceptRunFilesInput } from '@tools/AcceptRunFilesTool';
-import {
-  CodexMcpToolOutputSchema,
-  type CodexMcpToolOutput,
-} from '@shared/schemas/codex';
 import type { MemoryToolInput } from '@tools/memory/MemoryTool';
 import { isObject } from '@utils/core';
 

--- a/src/agent/core/flows/ModelInvocationNode.ts
+++ b/src/agent/core/flows/ModelInvocationNode.ts
@@ -120,7 +120,7 @@ export class ModelInvocationNode<
     _prepRes: BaseInvocationPrepResult,
     execRes: InvocationResult<BaseInvocationSuccessData>,
   ): Promise<string | undefined> {
-    const successRes = handleInvocationResult(execRes, shared, shared, {
+    const successRes = handleInvocationResult(execRes, shared, {
       logger: this.services.logger,
       operationName: this._config.operationName,
     });

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -26,10 +26,6 @@ import { getConfig } from '@utils/config/configUtils';
 
 const BACKGROUND_MODE_MIN_RETRIES = 3;
 
-export interface RetryState {
-  lastError?: RetryErrorInfo;
-}
-
 /** Returns maxRetries (1 initial + N auto-retries) and wait (seconds between retries). */
 function getNodeRetryConfig(): { maxRetries: number; wait: number } {
   const maxAutoAttempts = getConfig<number>('texra.model.retry.maxAttempts', 1);
@@ -345,8 +341,7 @@ interface InvocationResultHandlerOptions {
 /** Returns narrowed success result or null (flow stopped). Records error for failures. */
 export function handleInvocationResult<T extends { response: unknown }>(
   result: InvocationResult<T>,
-  state: { shouldStop: boolean; endTurn: boolean },
-  retryState: RetryState,
+  state: { shouldStop: boolean; endTurn: boolean; lastError?: RetryErrorInfo },
   options: InvocationResultHandlerOptions,
 ): (T & { kind: 'success' }) | null {
   const { logger, operationName } = options;
@@ -357,7 +352,7 @@ export function handleInvocationResult<T extends { response: unknown }>(
   }
 
   if (result.kind === 'cancelled') {
-    retryState.lastError = undefined;
+    state.lastError = undefined;
     state.shouldStop = true;
     state.endTurn = false;
     return null;
@@ -365,7 +360,7 @@ export function handleInvocationResult<T extends { response: unknown }>(
 
   if (result.kind === 'failed') {
     const { kind: _, ...errorInfo } = result;
-    retryState.lastError = errorInfo;
+    state.lastError = errorInfo;
     state.shouldStop = true;
     state.endTurn = false;
     return null;
@@ -373,7 +368,7 @@ export function handleInvocationResult<T extends { response: unknown }>(
 
   if (!result.response) {
     logger.warn(EMPTY_RESPONSE_ERROR_MESSAGE);
-    retryState.lastError = {
+    state.lastError = {
       message: EMPTY_RESPONSE_ERROR_MESSAGE,
       userRetryable: false,
     };
@@ -382,6 +377,6 @@ export function handleInvocationResult<T extends { response: unknown }>(
     return null;
   }
 
-  retryState.lastError = undefined;
+  state.lastError = undefined;
   return result;
 }

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -137,7 +137,7 @@ export abstract class ModelHandler<
    * Whether the handler supports processing attachments in tool results.
    * Override in handlers that don't support attachments (e.g., DeepSeek).
    */
-  get canProcessToolResultAttachments(): boolean {
+  protected get canProcessToolResultAttachments(): boolean {
     return true;
   }
 
@@ -173,7 +173,7 @@ export abstract class ModelHandler<
     this.agentCategory = agentCategory ?? undefined;
   }
 
-  public getAgentCategory(): AgentCategory | undefined {
+  protected getAgentCategory(): AgentCategory | undefined {
     return this.agentCategory;
   }
 
@@ -354,7 +354,7 @@ export abstract class ModelHandler<
    *
    * @throws Error if required API key is missing from environment
    */
-  public async getApiKey(): Promise<string> {
+  protected async getApiKey(): Promise<string> {
     const serverSideKeyService = getServerSideKeyService();
     const useIncludedAccess = serverSideKeyService.getUseIncludedModelAccess();
 
@@ -588,7 +588,7 @@ export abstract class ModelHandler<
    * Individual providers can override if needed.
    * @returns Array of media content objects in provider-specific format
    */
-  public async createMediaMessage(
+  protected async createMediaMessage(
     mediaFiles: FileLocation[],
   ): Promise<ReturnType<typeof this.createMediaContent>> {
     const { entries, results } =
@@ -652,7 +652,7 @@ export abstract class ModelHandler<
     return { endTurn, shouldStop };
   }
 
-  public containCutOffMessage(
+  protected containCutOffMessage(
     content: Array<{ type: string; text?: string }> | string,
   ): boolean {
     const marker = 'Your response got cut off';
@@ -691,11 +691,12 @@ export abstract class ModelHandler<
   /**
    * Generates a model response using the provider's API.
    *
-   * Template method: installs SDK-boundary error tagging via
-   * {@link sdkErrorTagger}, then delegates to {@link createResponseImpl}.
-   * Subclasses normally override {@link createResponseImpl} (and
-   * {@link sdkErrorTagger}); only override this method when a guard must wrap
-   * the call (e.g. OpenAIResponse's single-turn `inFlight` assertion).
+   * Template method: runs under {@link withCreateResponseGuard}, installs
+   * SDK-boundary error tagging via {@link sdkErrorTagger}, then delegates to
+   * {@link createResponseImpl}. Subclasses normally override
+   * {@link createResponseImpl} (and {@link sdkErrorTagger}); a subclass that
+   * needs to bracket the whole call (e.g. a single-turn `inFlight` assertion)
+   * overrides only {@link withCreateResponseGuard}.
    *
    * @param options Options for creating the response
    * @returns Promise resolving to result containing response and optionally updated messages
@@ -703,9 +704,22 @@ export abstract class ModelHandler<
   createResponse(
     options: CreateResponseOptions<M, C>,
   ): Promise<CreateResponseResult<Resp, M>> {
-    return withSdkErrorTag(this.sdkErrorTagger, this.config.provider, () =>
-      this.createResponseImpl(options),
+    return this.withCreateResponseGuard(() =>
+      withSdkErrorTag(this.sdkErrorTagger, this.config.provider, () =>
+        this.createResponseImpl(options),
+      ),
     );
+  }
+
+  /**
+   * Hook to bracket a whole {@link createResponse} call (error tagging +
+   * {@link createResponseImpl}). Default: run directly. Override to add a guard
+   * such as the single-turn `inFlight` assertion that handlers chaining on a
+   * `previous_response_id` / conversation state need. Keeping the error-tag wrap
+   * in the base means subclasses supply only the guard, never re-copy the wrap.
+   */
+  protected withCreateResponseGuard<T>(run: () => Promise<T>): Promise<T> {
+    return run();
   }
 
   /**

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -688,7 +688,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     return joinNonEmpty(message.parts.filter(isTextPart).map((p) => p.text));
   }
 
-  override async createMediaMessage(
+  protected override async createMediaMessage(
     mediaFiles: FileLocation[],
   ): Promise<Part[]> {
     if (!mediaFiles?.length || !this.supportsFileUploads()) {

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -58,7 +58,6 @@ import {
   CLIENT_COMPACTION_SUMMARY_MAX_TOKENS,
   COMPACTION_SYSTEM_PROMPT,
 } from '../contextManagementConstants';
-import { withSdkErrorTag } from '../support/sdkErrorTagging';
 import { prepareExistingOutputContent } from '../utils/fileContentUtils';
 import { tagGoogleSdkError } from './googleSdkError';
 import {
@@ -766,7 +765,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
     );
   }
 
-  override async createMediaMessage(
+  protected override async createMediaMessage(
     mediaFiles: FileLocation[],
   ): Promise<Content[]> {
     if (!mediaFiles?.length || !this.supportsFileUploads()) {
@@ -1423,15 +1422,15 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
   // ===========================================================================
 
   /**
-   * Single-turn override. The base {@link ModelHandler.createResponse} already
-   * wraps {@link createResponseImpl} in {@link withSdkErrorTag}; we override only
-   * to add the in-flight guard (mirrors {@link ModelHandlerOpenAIResponse}).
-   * Concurrent callers would race chainedInteractionId / sentStepCount and
-   * corrupt the chain, so fail loudly instead of silently corrupting state.
+   * Single-turn guard (mirrors {@link ModelHandlerOpenAIResponse}). The base
+   * {@link ModelHandler.createResponse} owns the SDK error-tag wrap;
+   * we supply only the in-flight guard. Concurrent callers would race
+   * chainedInteractionId / sentStepCount and corrupt the chain, so fail loudly
+   * instead of silently corrupting state.
    */
-  override async createResponse(
-    options: CreateResponseOptions<Step, GoogleGenAI>,
-  ): Promise<CreateResponseResult<GoogleGenAIInteraction, Step>> {
+  protected override async withCreateResponseGuard<T>(
+    run: () => Promise<T>,
+  ): Promise<T> {
     if (this.inFlight) {
       throw new Error(
         'modelHandlerGoogleInteractions.createResponse invoked while a prior ' +
@@ -1440,11 +1439,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
     }
     this.inFlight = true;
     try {
-      return await withSdkErrorTag(
-        this.sdkErrorTagger,
-        this.config.provider,
-        () => this.createResponseImpl(options),
-      );
+      return await run();
     } finally {
       this.inFlight = false;
     }

--- a/src/agent/modelHandlers/openai/modelHandlerCodex.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerCodex.ts
@@ -184,12 +184,20 @@ const codexFetch = (async (input, init) => {
 }) satisfies typeof fetch;
 
 export class ModelHandlerCodex extends ModelHandlerOpenAIResponse {
-  // Background mode is honored through the SAME `model.useBackgroundResponses`
-  // toggle every OpenAI Responses model uses (plus the usual workflow + GPT
-  // eligibility) — no Codex-specific flag. EXPERIMENTAL on this backend: it
-  // forces store:false and has no polling endpoint, so a background request
-  // very likely fails; the toggle exists so it can be tested in practice.
-  protected override backgroundModeSupported = true;
+  /**
+   * Background mode (polling) needs a stored response and a polling endpoint;
+   * the Codex backend has neither — it forces `store:false` and has no
+   * `/responses/{id}` GET route — so a background request very likely fails.
+   * While the subscription drives the request, never enter background mode and
+   * keep the working default streaming path (the shared
+   * `model.useBackgroundResponses` toggle stays default-on for the real OpenAI
+   * Responses models, just not for this backend). Once the subscription is off,
+   * the request runs on the user's OpenAI API key, where the base handler
+   * decides background mode normally.
+   */
+  public override isBackgroundModeActive(): boolean {
+    return this.usingSubscription() ? false : super.isBackgroundModeActive();
+  }
 
   /**
    * Whether this handler should still drive the ChatGPT subscription. Re-read

--- a/src/agent/modelHandlers/openai/modelHandlerCodex.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerCodex.ts
@@ -290,7 +290,7 @@ export class ModelHandlerCodex extends ModelHandlerOpenAIResponse {
 
   /** OAuth access token in place of an API key (becomes the Bearer header),
    *  or the user's OpenAI API key once the subscription preference is off. */
-  public override async getApiKey(): Promise<string> {
+  protected override async getApiKey(): Promise<string> {
     return this.usingSubscription()
       ? this.resolveAccessToken()
       : super.getApiKey();

--- a/src/agent/modelHandlers/openai/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerDeepSeek.ts
@@ -35,7 +35,7 @@ export class ModelHandlerDeepSeek extends ReasoningModelHandlerOpenAI<DeepSeekTo
   /**
    * DeepSeek models don't support vision/attachments in tool results.
    */
-  override get canProcessToolResultAttachments(): boolean {
+  protected override get canProcessToolResultAttachments(): boolean {
     return false;
   }
 

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -48,7 +48,6 @@ import { toOpenAIReasoningEffort } from '../support/reasoningEffort';
 import { normalizeUsage } from '../support/UsageNormalizer';
 import { initializeOpenAiCompatibleOutputAndPrefill } from '../support/openAiCompatiblePrefill';
 import { tagOpenAISdkError } from './openAISdkError';
-import { withSdkErrorTag } from '../support/sdkErrorTagging';
 import {
   classifyOpenAIBackgroundResumeError,
   createOpenAIBackgroundPollingError,
@@ -1207,12 +1206,15 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     return tagOpenAISdkError;
   }
 
-  override async createResponse(
-    options: CreateResponseOptions<ResponseInputItem, OpenAI>,
-  ): Promise<CreateResponseResult<Response, ResponseInputItem>> {
-    // Single-turn contract: concurrent callers would race on previousResponseId
-    // and conversationState. Fail loudly so the caller bug surfaces instead of
-    // corrupting the conversation silently.
+  /**
+   * Single-turn guard. The base {@link ModelHandler.createResponse} owns the
+   * SDK error-tag wrap; we supply only the in-flight guard. Concurrent
+   * callers would race on previousResponseId and conversationState, so fail
+   * loudly instead of corrupting the conversation silently.
+   */
+  protected override async withCreateResponseGuard<T>(
+    run: () => Promise<T>,
+  ): Promise<T> {
     if (this.inFlight) {
       throw new Error(
         'modelHandlerOpenAIResponse.createResponse invoked while a prior ' +
@@ -1221,11 +1223,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     }
     this.inFlight = true;
     try {
-      return await withSdkErrorTag(
-        this.sdkErrorTagger,
-        this.config.provider,
-        () => this.createResponseImpl(options),
-      );
+      return await run();
     } finally {
       this.inFlight = false;
     }

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -12,7 +12,6 @@ import type {
 import type { AgentWorkspaceState } from '@agent/core/execution/AgentWorkspaceState';
 import type { ProviderUsage } from '@agent/core/usage/ResponseUsage';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
-import type { MediaEntry } from '@agent/utils/mediaTypes';
 import type { ToolResultPayload } from '@agent/modelHandlers/utils/toolAttachmentUtils';
 import type { ToolDefinition } from '@model';
 import type { FileLocation } from '@shared/schemas';
@@ -226,9 +225,6 @@ export interface IModelHandler<
 
   readonly isGoogle: boolean;
 
-  /** Whether the handler supports processing attachments in tool results. */
-  readonly canProcessToolResultAttachments: boolean;
-
   /**
    * Whether parallel tool calls in a single turn must be batched into one
    * follow-up message to preserve provider-side reasoning / thought signatures
@@ -245,7 +241,6 @@ export interface IModelHandler<
 
   setLogger(logger: AgentTrace): void;
   setAgentCategory(agentCategory?: AgentCategory | null): void;
-  getAgentCategory(): AgentCategory | undefined;
   getClient(): Promise<C>;
 
   /**
@@ -270,7 +265,6 @@ export interface IModelHandler<
     mediaFiles?: FileLocation[],
   ): Promise<M[]>;
 
-  createMediaContent(mediaMessage: MediaEntry[]): unknown[];
   extractResponse(responseObject: Resp, endTag: string): ExtractResponseResult;
 
   addContinueMessageWithPrefill(
@@ -401,11 +395,6 @@ export interface IModelHandler<
    * Appends the user's message to the existing conversation array.
    */
   createUserFollowUpMessages(messages: M[], userMessage: string): Promise<M[]>;
-
-  /**
-   * Build a simple assistant message from plain text.
-   */
-  createAssistantMessage(text: string): M;
 
   /**
    * Build an assistant message from a provider response.

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -336,34 +336,36 @@ function withShortModelName(config: ModelConfig): ModelConfig {
 /**
  * Creates a model handler instance based on provider and routing configuration.
  * Applies short model name preference and reasoning level overrides.
+ *
+ * The ordered routing precedence is owned solely by
+ * {@link modelHandlerCompatibilityKey}; this live path computes that key and
+ * `switch`es on it for instantiation, so the two can never drift on the key
+ * they produce. The only routing decision made here is the async
+ * Codex-subscription override, which the pure key predicate deliberately omits
+ * because it is key-neutral (same `ModelHandlerOpenAIResponse` key, different
+ * handler + backend model id).
  */
 export async function createModelHandler(
   originalConfig: ModelConfig,
 ): Promise<ModelHandler> {
   const config = withShortModelName(originalConfig);
-
-  if (shouldUseInternalValidationModelHandler()) {
-    // Package validation still enters the real CLI and executeAgent path.
-    // Only the provider boundary is deterministic, so this must not become
-    // a user-facing model selector or an injected command-layer substitute.
-    logger.warn(
-      CHANNEL,
-      `${internalValidationModelHandlerEnvName()}=1 is replacing provider handlers with the internal validation handler.`,
-    );
-    const { ModelHandlerValidation } =
-      await import('@agent/modelHandlers/modelHandlerValidation');
-    return withModelHandlerCompatibilityKey(
-      new ModelHandlerValidation(config),
-      'ModelHandlerValidation',
-    );
-  }
-
   const useOpenRouter = getUseOpenRouter();
+  const compatibilityKey = modelHandlerCompatibilityKey(
+    config,
+    useOpenRouter,
+    // Short-name preference was already applied by withShortModelName above;
+    // pass false so the key predicate routes on the same resolved config
+    // instead of re-resolving it.
+    false,
+  );
 
-  // ChatGPT subscription (Codex backend via the user's OAuth session). Must come
-  // before the normal Responses branch: these are OpenAI Responses-shaped models
-  // the user has opted to drive through their subscription instead of an API key.
+  // ChatGPT subscription (Codex backend via the user's OAuth session) — an
+  // async, key-neutral override of the Responses path: these are OpenAI
+  // Responses-shaped models the user has opted to drive through their
+  // subscription instead of an API key. Gated on the key not being the
+  // validation override so the package-validation gate still wins.
   if (
+    compatibilityKey !== 'ModelHandlerValidation' &&
     shouldUseCodexSubscription(config, useOpenRouter) &&
     (await isCodexSignedIn())
   ) {
@@ -384,55 +386,73 @@ export async function createModelHandler(
     );
   }
 
-  // OpenAI Responses API (required or optional)
-  if (shouldUseResponsesAPI(config, useOpenRouter)) {
-    logger.debug(CHANNEL, 'Using OpenAI Responses API Handler');
-    const { ModelHandlerOpenAIResponse } =
-      await import('@agent/modelHandlers/openai/modelHandlerOpenAIResponse');
-    return withModelHandlerCompatibilityKey(
-      withReasoningOverride(new ModelHandlerOpenAIResponse(config)),
-      'ModelHandlerOpenAIResponse',
-    );
-  }
+  switch (compatibilityKey) {
+    case 'ModelHandlerValidation': {
+      // Package validation still enters the real CLI and executeAgent path.
+      // Only the provider boundary is deterministic, so this must not become
+      // a user-facing model selector or an injected command-layer substitute.
+      logger.warn(
+        CHANNEL,
+        `${internalValidationModelHandlerEnvName()}=1 is replacing provider handlers with the internal validation handler.`,
+      );
+      const { ModelHandlerValidation } =
+        await import('@agent/modelHandlers/modelHandlerValidation');
+      return withModelHandlerCompatibilityKey(
+        new ModelHandlerValidation(config),
+        'ModelHandlerValidation',
+      );
+    }
 
-  // Google Interactions API (additive, flag-gated; never via OpenRouter)
-  if (shouldUseGoogleInteractionsAPI(config, useOpenRouter)) {
-    logger.debug(CHANNEL, 'Using Google Interactions API Handler');
-    const { ModelHandlerGoogleInteractions } =
-      await import('@agent/modelHandlers/google/modelHandlerGoogleInteractions');
-    return withModelHandlerCompatibilityKey(
-      withReasoningOverride(new ModelHandlerGoogleInteractions(config)),
-      'ModelHandlerGoogleInteractions',
-    );
-  }
+    case 'ModelHandlerOpenAIResponse': {
+      logger.debug(CHANNEL, 'Using OpenAI Responses API Handler');
+      const { ModelHandlerOpenAIResponse } =
+        await import('@agent/modelHandlers/openai/modelHandlerOpenAIResponse');
+      return withModelHandlerCompatibilityKey(
+        withReasoningOverride(new ModelHandlerOpenAIResponse(config)),
+        'ModelHandlerOpenAIResponse',
+      );
+    }
 
-  // An Interactions-only model cannot be served through OpenRouter — fail loudly
-  // here rather than silently routing it to the OpenRouter handler below.
-  assertGoogleInteractionsRoutable(config, useOpenRouter);
+    case 'ModelHandlerGoogleInteractions': {
+      logger.debug(CHANNEL, 'Using Google Interactions API Handler');
+      const { ModelHandlerGoogleInteractions } =
+        await import('@agent/modelHandlers/google/modelHandlerGoogleInteractions');
+      return withModelHandlerCompatibilityKey(
+        withReasoningOverride(new ModelHandlerGoogleInteractions(config)),
+        'ModelHandlerGoogleInteractions',
+      );
+    }
 
-  // Route through OpenRouter if configured
-  if (config.openRouterOnly || useOpenRouter) {
-    const openrouterFullName =
-      config.openrouterFullName ?? `${config.provider}/${config.fullName}`;
-    const { ModelHandlerOpenRouterNative } =
-      await import('@agent/modelHandlers/openrouter/modelHandlerOpenRouterNative');
-    return withModelHandlerCompatibilityKey(
-      withReasoningOverride(
-        new ModelHandlerOpenRouterNative({ ...config, openrouterFullName }),
-      ),
-      'ModelHandlerOpenRouterNative',
-    );
-  }
+    case 'ModelHandlerOpenRouterNative': {
+      // An Interactions-only model cannot be served through OpenRouter — fail
+      // loudly rather than silently routing it to the OpenRouter handler.
+      assertGoogleInteractionsRoutable(config, useOpenRouter);
+      const openrouterFullName =
+        config.openrouterFullName ?? `${config.provider}/${config.fullName}`;
+      const { ModelHandlerOpenRouterNative } =
+        await import('@agent/modelHandlers/openrouter/modelHandlerOpenRouterNative');
+      return withModelHandlerCompatibilityKey(
+        withReasoningOverride(
+          new ModelHandlerOpenRouterNative({ ...config, openrouterFullName }),
+        ),
+        'ModelHandlerOpenRouterNative',
+      );
+    }
 
-  // Direct provider handler
-  const route = PROVIDER_HANDLER_ROUTES[config.provider];
-  if (!route.load || !route.compatibilityKey) {
-    throw new Error(`Unsupported model provider: ${config.provider}`);
+    default: {
+      // Direct provider handler. The key is the provider's route key (or
+      // undefined for providers with no direct handler, e.g. Copilot).
+      assertGoogleInteractionsRoutable(config, useOpenRouter);
+      const route = PROVIDER_HANDLER_ROUTES[config.provider];
+      if (!route.load || !route.compatibilityKey) {
+        throw new Error(`Unsupported model provider: ${config.provider}`);
+      }
+      const HandlerClass = await route.load();
+      logger.debug(CHANNEL, `Using Handler: ${HandlerClass.name}`);
+      return withModelHandlerCompatibilityKey(
+        withReasoningOverride(new HandlerClass(config)),
+        route.compatibilityKey,
+      );
+    }
   }
-  const HandlerClass = await route.load();
-  logger.debug(CHANNEL, `Using Handler: ${HandlerClass.name}`);
-  return withModelHandlerCompatibilityKey(
-    withReasoningOverride(new HandlerClass(config)),
-    route.compatibilityKey,
-  );
 }

--- a/src/shared/schemas/codex.ts
+++ b/src/shared/schemas/codex.ts
@@ -1,0 +1,64 @@
+// Third-party imports
+import { z } from 'zod';
+
+/**
+ * Zod schemas for Codex tool-log inputs/outputs.
+ *
+ * These are pure data validators (no platform, `vscode`, or `node:*`
+ * dependencies) used both by the backend Codex tool-log builders
+ * (`@tools/codexShared`) and by the progress-view webview formatters, which
+ * `.safeParse()` them while rendering. They live in `@shared/schemas` so the
+ * webview frontend never imports runtime values from the backend `src/tools/`
+ * zone.
+ */
+
+const CodexFileChangeItemSchema = z.object({
+  path: z.string(),
+  kind: z.string(),
+});
+
+export const CodexFileChangeToolInputSchema = z.object({
+  changes: z.array(CodexFileChangeItemSchema),
+  patchStatus: z.string().nullish(),
+});
+
+export type CodexFileChangeToolInput = z.infer<
+  typeof CodexFileChangeToolInputSchema
+>;
+
+export const CodexMcpToolOutputSchema = z.object({
+  status: z.string().optional(),
+  structuredContent: z.unknown().optional(),
+  contentBlocks: z.array(z.record(z.string(), z.unknown())).optional(),
+});
+
+export type CodexMcpToolOutput = z.infer<typeof CodexMcpToolOutputSchema>;
+
+export const CodexThreadToolInputSchema = z.object({
+  threadId: z.string(),
+});
+
+export type CodexThreadToolInput = z.infer<typeof CodexThreadToolInputSchema>;
+
+const CodexTodoItemSchema = z.object({
+  text: z.string(),
+  completed: z.boolean(),
+});
+
+export const CodexTodoToolInputSchema = z.object({
+  items: z.array(CodexTodoItemSchema),
+  completedCount: z.number(),
+  totalCount: z.number(),
+});
+
+export type CodexTodoToolInput = z.infer<typeof CodexTodoToolInputSchema>;
+
+const CodexTurnStateSchema = z.enum(['running', 'completed', 'failed']);
+export type CodexTurnState = z.infer<typeof CodexTurnStateSchema>;
+
+export const CodexTurnToolInputSchema = z.object({
+  state: CodexTurnStateSchema,
+  wallTimeMs: z.number().nullish(),
+});
+
+export type CodexTurnToolInput = z.infer<typeof CodexTurnToolInputSchema>;

--- a/src/shared/schemas/codex.ts
+++ b/src/shared/schemas/codex.ts
@@ -2,15 +2,21 @@
 import { z } from 'zod';
 
 /**
- * Zod schemas for Codex tool-log inputs/outputs.
+ * Codex tool-log identifiers and Zod schemas (pure data: no platform,
+ * `vscode`, or `node:*` dependencies).
  *
- * These are pure data validators (no platform, `vscode`, or `node:*`
- * dependencies) used both by the backend Codex tool-log builders
- * (`@tools/codexShared`) and by the progress-view webview formatters, which
- * `.safeParse()` them while rendering. They live in `@shared/schemas` so the
- * webview frontend never imports runtime values from the backend `src/tools/`
- * zone.
+ * Used both by the backend Codex tool-log builders (`@tools/codexShared`) and
+ * by the progress-view webview formatters, which key on the tool-name constants
+ * and `.safeParse()` the schemas while rendering. They live in
+ * `@shared/schemas` so the webview frontend never imports runtime values from
+ * the backend `src/tools/` zone.
  */
+
+/** Synthetic tool names for the native Codex tool-use cards. */
+export const CODEX_FILE_CHANGE_TOOL = 'codex_patch';
+export const CODEX_THREAD_TOOL = 'codex_thread';
+export const CODEX_TODO_TOOL = 'codex_todo';
+export const CODEX_TURN_TOOL = 'codex_turn';
 
 const CodexFileChangeItemSchema = z.object({
   path: z.string(),

--- a/src/test-kernel/agent/modelHandlers/CodexExperimentalTransports.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/CodexExperimentalTransports.vitest.ts
@@ -78,15 +78,35 @@ describe('Codex background/websocket transports follow the shared toggles', () =
     ).toBe(false);
   });
 
-  it('activates background mode (store:true, non-streaming) from the same useBackgroundResponses toggle', async () => {
+  it('stays on the streaming path while the subscription is active, even with the background toggle on', async () => {
+    // The Codex backend can't run background mode (store:false forced, no
+    // polling endpoint), so the subscription path never enters it — the default
+    // workflow request stays streaming regardless of the shared toggle.
     await initPlatformWith({
       config: { 'texra.model.useBackgroundResponses': true },
     });
     const handler = workflowHandler();
 
+    expect(handler.isBackgroundModeActive()).toBe(false);
+    expect(handler.getStreamingConfig()).toBe(true);
+    expect(
+      (handler as unknown as CodexInternals).storesResponsesServerSide,
+    ).toBe(false);
+  });
+
+  it('honors background mode on the fallback OpenAI-API-key path when the subscription is off', async () => {
+    // Once the subscription preference is off the request runs on the user's
+    // OpenAI API key with full base capabilities, so the shared toggle decides
+    // background mode normally.
+    await initPlatformWith({
+      config: {
+        'texra.chatgptCodex.preferSubscription': false,
+        'texra.model.useBackgroundResponses': true,
+      },
+    });
+    const handler = workflowHandler();
+
     expect(handler.isBackgroundModeActive()).toBe(true);
-    // Background polls, so streaming is off and the response is stored server-side
-    // (which also disables encrypted-reasoning replay — store:true path).
     expect(handler.getStreamingConfig()).toBe(false);
     expect(
       (handler as unknown as CodexInternals).storesResponsesServerSide,

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -161,7 +161,7 @@ class PdfStubAnthropicHandler extends ModelHandlerAnthropic {
     this.mediaContent = content;
   }
 
-  override async createMediaMessage(): Promise<any[]> {
+  protected override async createMediaMessage(): Promise<any[]> {
     return this.mediaContent;
   }
 }

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerGoogleGenAI.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerGoogleGenAI.vitest.ts
@@ -309,7 +309,11 @@ describe('ModelHandlerGoogleGenAI media uploads', () => {
     };
 
     const docLocation = pathToLocation('/tmp/doc.pdf');
-    const parts = await handler.createMediaMessage([docLocation]);
+    const parts = await (
+      handler as unknown as {
+        createMediaMessage: (files: FileLocation[]) => Promise<Part[]>;
+      }
+    ).createMediaMessage([docLocation]);
 
     assert.equal(loadCalls.length, 1, 'loadEntries should be called once');
     assert.equal(loadCalls[0].length, 1, 'should pass one media file');

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponseBackground.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponseBackground.vitest.ts
@@ -95,10 +95,12 @@ describe('ModelHandlerOpenAIResponse background mode', () => {
     assert.equal(handler.getStreamingConfig(), true);
   });
 
-  it('lets Codex subscription handlers follow the shared background toggle', () => {
-    // Codex no longer vetoes background mode; it uses the same
-    // useBackgroundResponses toggle (default on) + workflow/GPT eligibility, so
-    // the behavior can be tested against the backend in practice.
+  it('runs the Codex fallback (subscription off) path through the shared background toggle', () => {
+    // With the subscription preference off (the default here — no platform
+    // override sets it), ModelHandlerCodex drops to the base OpenAI-API-key
+    // path, where background mode follows the shared useBackgroundResponses
+    // toggle (default on) + workflow/GPT eligibility. The subscription-ON veto
+    // (Codex backend can't poll) is covered in CodexExperimentalTransports.
     const handler = new ModelHandlerCodex(createOpenAIConfig('gpt-5'));
     handler.setAgentCategory(AgentCategory.Workflow);
 

--- a/src/tools/codexShared.ts
+++ b/src/tools/codexShared.ts
@@ -1,8 +1,13 @@
-// Third-party imports
-import { z } from 'zod';
-
 // Local imports - shared schemas
 import type { TokenUsageStats, ToolUseLog } from '@shared/schemas';
+import type {
+  CodexFileChangeToolInput,
+  CodexMcpToolOutput,
+  CodexThreadToolInput,
+  CodexTodoToolInput,
+  CodexTurnState,
+  CodexTurnToolInput,
+} from '@shared/schemas/codex';
 import { getBasename } from '@shared/utils/path';
 import { truncateSummary } from '@utils/text/stringUtils';
 import type {
@@ -32,61 +37,6 @@ export type CodexTodoItem = TodoListItem['items'][number];
 export type CodexMcpContentBlock = NonNullable<
   NonNullable<McpToolCallItem['result']>['content']
 >[number];
-
-// ---------------------------------------------------------------------------
-// Zod schemas for codex tool-log inputs (used for safe parsing in renderers)
-// ---------------------------------------------------------------------------
-
-const CodexFileChangeItemSchema = z.object({
-  path: z.string(),
-  kind: z.string(),
-});
-
-export const CodexFileChangeToolInputSchema = z.object({
-  changes: z.array(CodexFileChangeItemSchema),
-  patchStatus: z.string().nullish(),
-});
-
-export type CodexFileChangeToolInput = z.infer<
-  typeof CodexFileChangeToolInputSchema
->;
-
-export const CodexMcpToolOutputSchema = z.object({
-  status: z.string().optional(),
-  structuredContent: z.unknown().optional(),
-  contentBlocks: z.array(z.record(z.string(), z.unknown())).optional(),
-});
-
-export type CodexMcpToolOutput = z.infer<typeof CodexMcpToolOutputSchema>;
-
-export const CodexThreadToolInputSchema = z.object({
-  threadId: z.string(),
-});
-
-export type CodexThreadToolInput = z.infer<typeof CodexThreadToolInputSchema>;
-
-const CodexTodoItemSchema = z.object({
-  text: z.string(),
-  completed: z.boolean(),
-});
-
-export const CodexTodoToolInputSchema = z.object({
-  items: z.array(CodexTodoItemSchema),
-  completedCount: z.number(),
-  totalCount: z.number(),
-});
-
-export type CodexTodoToolInput = z.infer<typeof CodexTodoToolInputSchema>;
-
-const CodexTurnStateSchema = z.enum(['running', 'completed', 'failed']);
-type CodexTurnState = z.infer<typeof CodexTurnStateSchema>;
-
-export const CodexTurnToolInputSchema = z.object({
-  state: CodexTurnStateSchema,
-  wallTimeMs: z.number().nullish(),
-});
-
-export type CodexTurnToolInput = z.infer<typeof CodexTurnToolInputSchema>;
 
 /** Normalize Codex command execution events for the native bash tool card. */
 export function buildCodexCommandToolLog(

--- a/src/tools/codexShared.ts
+++ b/src/tools/codexShared.ts
@@ -1,5 +1,11 @@
 // Local imports - shared schemas
 import type { TokenUsageStats, ToolUseLog } from '@shared/schemas';
+import {
+  CODEX_FILE_CHANGE_TOOL,
+  CODEX_THREAD_TOOL,
+  CODEX_TODO_TOOL,
+  CODEX_TURN_TOOL,
+} from '@shared/schemas/codex';
 import type {
   CodexFileChangeToolInput,
   CodexMcpToolOutput,
@@ -21,10 +27,14 @@ import type {
 
 export const CODEX_AGENT_NAME = 'codex';
 export const CODEX_DISPLAY_MODEL = 'gpt55';
-export const CODEX_FILE_CHANGE_TOOL = 'codex_patch';
-export const CODEX_THREAD_TOOL = 'codex_thread';
-export const CODEX_TODO_TOOL = 'codex_todo';
-export const CODEX_TURN_TOOL = 'codex_turn';
+// Re-exported from the shared schema module (where the webview formatters also
+// read them) so backend callers can keep importing tool names from here.
+export {
+  CODEX_FILE_CHANGE_TOOL,
+  CODEX_THREAD_TOOL,
+  CODEX_TODO_TOOL,
+  CODEX_TURN_TOOL,
+};
 const CODEX_COMMAND_SUMMARY_MAX_LENGTH = 60;
 type ToolUseStatus = NonNullable<ToolUseLog['status']>;
 

--- a/src/tools/lean/LoogleTool.ts
+++ b/src/tools/lean/LoogleTool.ts
@@ -11,7 +11,11 @@ import { z } from 'zod';
 import { ensureError, toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { ToolResult } from '@shared/schemas/toolResult';
-import { isTimeoutError, isTransientHttpError } from '@tools/timeouts';
+import {
+  isTimeoutError,
+  isTransientHttpError,
+  unwrapAbortError,
+} from '@tools/timeouts';
 import { defineTool } from '@tools/core/define';
 import { ensureArray } from '@utils/core';
 
@@ -231,7 +235,10 @@ Useful for finding the right lemma when you know roughly what type it should hav
         },
       };
     } catch (error) {
-      if (isTimeoutError(error)) {
+      // p-retry wraps non-transient errors in AbortError to stop retries;
+      // unwrap so the checks below (and the surfaced message) see the real error.
+      const err = unwrapAbortError(error);
+      if (isTimeoutError(err)) {
         return {
           query,
           result: {
@@ -248,7 +255,7 @@ Useful for finding the right lemma when you know roughly what type it should hav
         query,
         result: {
           summary: 'Loogle search failed',
-          output: `Error: ${toErrorMessage(error)}`,
+          output: `Error: ${toErrorMessage(err)}`,
           isError: true,
         },
       };

--- a/src/tools/lean/LoogleTool.ts
+++ b/src/tools/lean/LoogleTool.ts
@@ -235,8 +235,9 @@ Useful for finding the right lemma when you know roughly what type it should hav
         },
       };
     } catch (error) {
-      // p-retry wraps non-transient errors in AbortError to stop retries;
-      // unwrap so the checks below (and the surfaced message) see the real error.
+      // Defensive: ensure the checks below (and the surfaced message) see the
+      // real error even if a p-retry AbortError wrapper reaches here (p-retry v8
+      // already unwraps it to .originalError, so this is normally a no-op).
       const err = unwrapAbortError(error);
       if (isTimeoutError(err)) {
         return {

--- a/src/tools/timeouts.ts
+++ b/src/tools/timeouts.ts
@@ -7,6 +7,20 @@
  */
 
 import { HTTPError, TimeoutError } from 'ky';
+import { AbortError } from 'p-retry';
+
+/**
+ * Unwrap a p-retry {@link AbortError} to the original error it carried.
+ *
+ * Non-transient HTTP errors are wrapped in `new AbortError(error)` inside a
+ * retry callback to stop retries; p-retry stores the wrapped error on
+ * `.originalError`. Outer `catch` blocks must unwrap before any `instanceof`
+ * check, or every specific type test silently fails against the wrapper and
+ * falls through to the generic handler.
+ */
+export function unwrapAbortError(error: unknown): unknown {
+  return (error instanceof AbortError && error.originalError) || error;
+}
 
 /**
  * Whether an error is a request timeout.

--- a/src/tools/timeouts.ts
+++ b/src/tools/timeouts.ts
@@ -13,10 +13,12 @@ import { AbortError } from 'p-retry';
  * Unwrap a p-retry {@link AbortError} to the original error it carried.
  *
  * Non-transient HTTP errors are wrapped in `new AbortError(error)` inside a
- * retry callback to stop retries; p-retry stores the wrapped error on
- * `.originalError`. Outer `catch` blocks must unwrap before any `instanceof`
- * check, or every specific type test silently fails against the wrapper and
- * falls through to the generic handler.
+ * retry callback to stop retries. p-retry v8 already unwraps these — its
+ * `onAttemptFailure` rethrows `error.originalError` — so the outer `catch`
+ * normally receives the original error directly. This is a defensive safeguard
+ * at the error-classification boundary so the specific `instanceof` checks stay
+ * correct even if an `AbortError` wrapper ever does reach the catch (a future
+ * p-retry change, or an `AbortError` thrown outside the retry callback).
  */
 export function unwrapAbortError(error: unknown): unknown {
   return (error instanceof AbortError && error.originalError) || error;

--- a/src/tools/web/WebFetchTool.ts
+++ b/src/tools/web/WebFetchTool.ts
@@ -164,8 +164,9 @@ export class WebFetchTool extends defineTool({
         { retries: WEB_FETCH_RETRIES, minTimeout: 500, randomize: true },
       ));
     } catch (error) {
-      // p-retry wraps non-transient errors in AbortError to stop retries;
-      // unwrap so the specific type checks below see the real error.
+      // Defensive: ensure the specific type checks below see the real error
+      // even if a p-retry AbortError wrapper reaches here (p-retry v8 already
+      // unwraps it to .originalError, so this is normally a no-op).
       const err = unwrapAbortError(error);
       if (isTimeoutError(err)) {
         throw new ToolError(

--- a/src/tools/web/WebFetchTool.ts
+++ b/src/tools/web/WebFetchTool.ts
@@ -10,7 +10,11 @@ import { z } from 'zod';
 // Local imports - core
 import { ensureError, toErrorMessage } from '@common/errors';
 import { ToolError, ToolResult } from '@shared/schemas/toolResult';
-import { isTimeoutError, isTransientHttpError } from '@tools/timeouts';
+import {
+  isTimeoutError,
+  isTransientHttpError,
+  unwrapAbortError,
+} from '@tools/timeouts';
 import { defineTool } from '@tools/core/define';
 
 const WEB_FETCH_TIMEOUT_MS = 30_000; // 30 s
@@ -160,21 +164,24 @@ export class WebFetchTool extends defineTool({
         { retries: WEB_FETCH_RETRIES, minTimeout: 500, randomize: true },
       ));
     } catch (error) {
-      if (isTimeoutError(error)) {
+      // p-retry wraps non-transient errors in AbortError to stop retries;
+      // unwrap so the specific type checks below see the real error.
+      const err = unwrapAbortError(error);
+      if (isTimeoutError(err)) {
         throw new ToolError(
           `Request to ${url} timed out after ${WEB_FETCH_TIMEOUT_MS / 1000}s. ` +
             `The remote server did not respond in time. Retry the request, or try a different URL.`,
         );
       }
-      if (error instanceof HTTPError) {
+      if (err instanceof HTTPError) {
         throw new ToolError(
-          `HTTP ${error.response.status}: Failed to fetch ${url}`,
+          `HTTP ${err.response.status}: Failed to fetch ${url}`,
         );
       }
-      if (error instanceof TypeError) {
-        throw new ToolError(`Network error fetching ${url}: ${error.message}`);
+      if (err instanceof TypeError) {
+        throw new ToolError(`Network error fetching ${url}: ${err.message}`);
       }
-      throw new ToolError(`Failed to fetch ${url}: ${toErrorMessage(error)}`);
+      throw new ToolError(`Failed to fetch ${url}: ${toErrorMessage(err)}`);
     }
 
     const ctLower = contentType.toLowerCase();

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -83,8 +83,9 @@ export class WebSearchTool extends defineTool({
         { retries: DDG_RETRIES, minTimeout: 500, randomize: true },
       );
     } catch (error) {
-      // p-retry wraps non-transient errors in AbortError to stop retries;
-      // unwrap so the specific type checks below see the real error.
+      // Defensive: ensure the specific type checks below see the real error
+      // even if a p-retry AbortError wrapper reaches here (p-retry v8 already
+      // unwraps it to .originalError, so this is normally a no-op).
       const err = unwrapAbortError(error);
       if (isTimeoutError(err)) {
         throw new ToolError(

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -6,7 +6,11 @@ import { z } from 'zod';
 // Internal imports
 import { ensureError, toErrorMessage } from '@common/errors';
 import { ToolError, ToolResult } from '@shared/schemas/toolResult';
-import { isTimeoutError, isTransientHttpError } from '@tools/timeouts';
+import {
+  isTimeoutError,
+  isTransientHttpError,
+  unwrapAbortError,
+} from '@tools/timeouts';
 import { defineTool } from '@tools/core/define';
 
 const DDG_TIMEOUT_MS = 15_000; // 15 s
@@ -79,22 +83,25 @@ export class WebSearchTool extends defineTool({
         { retries: DDG_RETRIES, minTimeout: 500, randomize: true },
       );
     } catch (error) {
-      if (isTimeoutError(error)) {
+      // p-retry wraps non-transient errors in AbortError to stop retries;
+      // unwrap so the specific type checks below see the real error.
+      const err = unwrapAbortError(error);
+      if (isTimeoutError(err)) {
         throw new ToolError(
           `Web search timed out after ${DDG_TIMEOUT_MS / 1000}s. Retry the request.`,
         );
       }
-      if (error instanceof HTTPError) {
+      if (err instanceof HTTPError) {
         throw new ToolError(
-          `Web search failed: HTTP ${error.response.status} from DuckDuckGo.`,
+          `Web search failed: HTTP ${err.response.status} from DuckDuckGo.`,
         );
       }
-      if (error instanceof TypeError) {
+      if (err instanceof TypeError) {
         throw new ToolError(
-          `Web search failed: network error — ${error.message}`,
+          `Web search failed: network error — ${err.message}`,
         );
       }
-      throw new ToolError(`Web search failed: ${toErrorMessage(error)}`);
+      throw new ToolError(`Web search failed: ${toErrorMessage(err)}`);
     }
 
     const results: string[] = [];


### PR DESCRIPTION
Closes #6639, #6640, #6641 — SDK-readiness follow-ups from #6629.

- #6639: delete the one-field RetryState interface (lastError already lives
  on BaseCycleFields) and collapse handleInvocationResult's duplicate
  state/retryState params into a single state param.
- #6640: drop four internal-surface members from the IModelHandler port
  (getAgentCategory, canProcessToolResultAttachments, createMediaContent,
  createAssistantMessage); keep them on the base, tightening getAgentCategory
  and canProcessToolResultAttachments to protected.
- #6641: tighten createMediaMessage, containCutOffMessage, getApiKey to
  protected; add a protected withCreateResponseGuard hook so the base owns the
  SDK error-tag wrap and OpenAIResponse/GoogleInteractions supply only the
  single-turn in-flight guard (removes the hand-copied template body).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013G7zeC1Bs37WuB8xvKXAi6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core model invocation, handler selection, and Codex subscription behavior; changes are mostly structural but incorrect routing or background-mode logic could affect live agent runs.
> 
> **Overview**
> SDK-readiness refactor across the agent stack: **retry/invocation state**, **`IModelHandler` surface**, **`createResponse` template**, plus a few **Codex** and **tool** fixes bundled in the same PR.
> 
> **Retry flow:** Removes the standalone `RetryState` type and passes a single shared state object (including `lastError`) into `handleInvocationResult`, so `ModelInvocationNode` no longer threads duplicate state/retry params.
> 
> **Model handler API:** Trims `IModelHandler` (drops `getAgentCategory`, `canProcessToolResultAttachments`, `createMediaContent`, `createAssistantMessage` from the port) and moves several former public base methods (`getApiKey`, `createMediaMessage`, etc.) to **protected**. Adds **`withCreateResponseGuard`** on `ModelHandler` so the base owns SDK error tagging and OpenAI Responses / Google Interactions only override the in-flight single-turn guard instead of duplicating the full `createResponse` wrapper.
> 
> **Handler factory:** `createModelHandler` now **`switch`es on `modelHandlerCompatibilityKey`** so live routing stays aligned with the key predicate; async Codex subscription selection remains a key-neutral override before instantiation.
> 
> **Codex:** Tool-log Zod schemas and constants move to **`@shared/schemas/codex`** (webview imports shared zone, not `src/tools`). **`ModelHandlerCodex`** overrides **`isBackgroundModeActive()`** to force streaming while ChatGPT subscription is active (Codex backend can’t poll); API-key fallback still honors the shared background toggle. Tests updated accordingly.
> 
> **Web tools:** Adds **`unwrapAbortError`** in `@tools/timeouts` and uses it in Loogle / WebFetch / WebSearch catch paths so `p-retry` `AbortError` wrappers don’t break timeout/HTTP classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8c33bcbabd88adf6cf9e5e191e6607e751e3e48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->