### PR TITLE
refactor: extract three repeated code patterns into shared helpers

### DIFF
--- a/packages/cli/src/commands/_helpers/globalArgs.ts
+++ b/packages/cli/src/commands/_helpers/globalArgs.ts
@@ -204,7 +204,7 @@ export interface CommonAgentRunFlags {
 
 /**
  * The `--input/-i`, `--context/-c`, `--instruction`, and `--instruction-file`
- * flags shared by every agent-run command (`run`, `agents run`, `multi-agent`).
+ * flags shared by the `agents run`, `multi-agent`, and `workflow run` commands.
  * Spread the result into the command's run options.
  */
 export function collectCommonAgentRunFlags(

--- a/packages/cli/src/commands/_helpers/globalArgs.ts
+++ b/packages/cli/src/commands/_helpers/globalArgs.ts
@@ -195,6 +195,30 @@ export function optString(value: unknown): string | undefined {
   return typeof value === 'string' ? value : undefined;
 }
 
+export interface CommonAgentRunFlags {
+  inputFiles: string[];
+  contextFiles: string[];
+  instruction: string;
+  instructionFile: string | undefined;
+}
+
+/**
+ * The `--input/-i`, `--context/-c`, `--instruction`, and `--instruction-file`
+ * flags shared by every agent-run command (`run`, `agents run`, `multi-agent`).
+ * Spread the result into the command's run options.
+ */
+export function collectCommonAgentRunFlags(
+  rawArgs: readonly string[],
+  instruction: unknown,
+): CommonAgentRunFlags {
+  return {
+    inputFiles: collectStringFlagValues(rawArgs, 'input', 'i'),
+    contextFiles: collectStringFlagValues(rawArgs, 'context', 'c'),
+    instruction: optString(instruction) ?? '',
+    instructionFile: optionalStringFlagValue(rawArgs, 'instruction-file'),
+  };
+}
+
 function headlessOnlyFlagLabel(arg: string): string | undefined {
   for (const name of HEADLESS_ONLY_GLOBAL_ARG_NAMES) {
     for (const spelling of flagSpellings(name, GLOBAL_ARGS[name])) {

--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -20,8 +20,7 @@ import { initLocalCliPlatform } from '../runtime/initPlatform';
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import {
   AGENT_RUN_GLOBAL_ARGS,
-  collectStringFlagValues,
-  optionalStringFlagValue,
+  collectCommonAgentRunFlags,
   optString,
 } from './_helpers/globalArgs';
 import { resolveFileBackedInstruction } from './_helpers/instructionFile';
@@ -157,10 +156,7 @@ export const agentsRunCommand = defineCliCommand({
   run: (context, ctx) =>
     runToolUseAgent(context, {
       agent: ctx.args.name,
-      inputFiles: collectStringFlagValues(ctx.rawArgs, 'input', 'i'),
-      contextFiles: collectStringFlagValues(ctx.rawArgs, 'context', 'c'),
+      ...collectCommonAgentRunFlags(ctx.rawArgs, ctx.args.instruction),
       model: optString(ctx.args.model),
-      instruction: optString(ctx.args.instruction) ?? '',
-      instructionFile: optionalStringFlagValue(ctx.rawArgs, 'instruction-file'),
     }),
 });

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -49,8 +49,7 @@ import { emitCliResult } from './_helpers/output';
 import {
   AGENT_RUN_GLOBAL_ARGS,
   GLOBAL_ARGS,
-  collectStringFlagValues,
-  optionalStringFlagValue,
+  collectCommonAgentRunFlags,
   optString,
 } from './_helpers/globalArgs';
 import { resolveFileBackedInstruction } from './_helpers/instructionFile';
@@ -343,15 +342,9 @@ const multiAgentRunCommand = withUsageSections(
     run: (context, ctx) =>
       runMultiAgentPreset(context, {
         preset: ctx.args.preset,
-        inputFiles: collectStringFlagValues(ctx.rawArgs, 'input', 'i'),
-        contextFiles: collectStringFlagValues(ctx.rawArgs, 'context', 'c'),
+        ...collectCommonAgentRunFlags(ctx.rawArgs, ctx.args.instruction),
         agent: optString(ctx.args.agent),
         model: optString(ctx.args.model),
-        instruction: optString(ctx.args.instruction) ?? '',
-        instructionFile: optionalStringFlagValue(
-          ctx.rawArgs,
-          'instruction-file',
-        ),
       }),
   }),
   [

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -29,7 +29,7 @@ import { defineCliCommand } from './_helpers/defineCliCommand';
 import { emitCliResult } from './_helpers/output';
 import {
   AGENT_RUN_GLOBAL_ARGS,
-  collectStringFlagValues,
+  collectCommonAgentRunFlags,
   optionalStringFlagValue,
   optString,
 } from './_helpers/globalArgs';
@@ -236,12 +236,9 @@ export const runWorkflowCommand = defineCliCommand({
   run: (context, ctx) =>
     runWorkflowAgent(context, {
       agent: ctx.args.agent,
-      inputFiles: collectStringFlagValues(ctx.rawArgs, 'input', 'i'),
-      contextFiles: collectStringFlagValues(ctx.rawArgs, 'context', 'c'),
+      ...collectCommonAgentRunFlags(ctx.rawArgs, ctx.args.instruction),
       output: optionalStringFlagValue(ctx.rawArgs, 'output'),
       outputDir: optionalStringFlagValue(ctx.rawArgs, 'output-dir'),
       model: optString(ctx.args.model),
-      instruction: optString(ctx.args.instruction) ?? '',
-      instructionFile: optionalStringFlagValue(ctx.rawArgs, 'instruction-file'),
     }),
 });

--- a/packages/extension/src/commands/latex/latexCommands.ts
+++ b/packages/extension/src/commands/latex/latexCommands.ts
@@ -237,9 +237,7 @@ export async function handleGetTeXCount(): Promise<void> {
           const stats = patterns
             .map(([pattern, template]) => {
               const match = output.match(pattern);
-              return match
-                ? { label: template.replace('$1', match[1]) }
-                : null;
+              return match ? { label: template.replace('$1', match[1]) } : null;
             })
             .filter(filterNotNull);
 

--- a/packages/extension/src/commands/latex/latexCommands.ts
+++ b/packages/extension/src/commands/latex/latexCommands.ts
@@ -7,7 +7,11 @@ import {
   showLoggedInfoMessage,
   showLoggedMessage,
 } from '@frontend/ui/errorHandlingUtils';
-import { withLaTeXGuard } from '@frontend/editor/activeFileGuards';
+import {
+  withLaTeXGuard,
+  type ActiveFileGuardSuccess,
+  type LaTeXGuardOptions,
+} from '@frontend/editor/activeFileGuards';
 import { runLatexFormatter } from '@latex/texFormatter';
 import { getTeXCount, type TexcountMode } from '@latex/texcount';
 import { indentLatexFilesInDirectory } from '@latex/formatter/indentDirectory';
@@ -21,6 +25,23 @@ import { getIndentTeXNotification } from './latexHousekeepingNotifications';
 
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);
+
+/**
+ * Run a LaTeX entry-point command under the active-file guard, surfacing any
+ * thrown error through the shared channel logger. Centralizes the
+ * `try/withLaTeXGuard/catch` boilerplate every guarded command repeats.
+ */
+async function runGuardedLatexCommand(
+  guard: Omit<LaTeXGuardOptions, 'channel'>,
+  errorMessage: string,
+  operation: (guardResult: ActiveFileGuardSuccess) => Promise<void>,
+): Promise<void> {
+  try {
+    await withLaTeXGuard({ channel: CHANNEL, ...guard }, operation);
+  } catch (err) {
+    await showLoggedErrorMessage(CHANNEL, errorMessage, err);
+  }
+}
 
 /**
  * All LaTeX entry-point commands (`indentTeX`, `indentCurrentTeX`,
@@ -55,31 +76,24 @@ export async function handleIndentTeX(): Promise<void> {
 }
 
 export async function handleFixCompilation(): Promise<void> {
-  try {
-    await withLaTeXGuard(
-      { channel: CHANNEL, action: 'fix compilation', saveDocument: true },
-      async ({ editor, relativePath }) => {
-        logger.info(
-          CHANNEL,
-          `Launching tool-use agent to fix compilation for: ${relativePath}`,
-        );
+  await runGuardedLatexCommand(
+    { action: 'fix compilation', saveDocument: true },
+    'Error launching LaTeX compilation fixer',
+    async ({ editor, relativePath }) => {
+      logger.info(
+        CHANNEL,
+        `Launching tool-use agent to fix compilation for: ${relativePath}`,
+      );
 
-        await vscode.commands.executeCommand('texra.execute', {
-          agent: 'latexFixer',
-          instruction: await buildFixCompilationInstruction(
-            editor.document.fileName,
-            relativePath,
-          ),
-        });
-      },
-    );
-  } catch (err) {
-    await showLoggedErrorMessage(
-      CHANNEL,
-      'Error launching LaTeX compilation fixer',
-      err,
-    );
-  }
+      await vscode.commands.executeCommand('texra.execute', {
+        agent: 'latexFixer',
+        instruction: await buildFixCompilationInstruction(
+          editor.document.fileName,
+          relativePath,
+        ),
+      });
+    },
+  );
 }
 
 /**
@@ -116,142 +130,125 @@ async function buildFixCompilationInstruction(
 }
 
 export async function handleApplyReplacements(): Promise<void> {
-  try {
-    await withLaTeXGuard(
-      { channel: CHANNEL, action: 'apply replacements', saveDocument: true },
-      async ({ editor }) => {
-        const document = editor.document;
-        const text = document.getText();
+  await runGuardedLatexCommand(
+    { action: 'apply replacements', saveDocument: true },
+    'Error applying LaTeX replacements',
+    async ({ editor }) => {
+      const document = editor.document;
+      const text = document.getText();
 
-        const processedText = replacementEngine.applyAll(text);
-        const fullRange = new vscode.Range(
-          document.positionAt(0),
-          document.positionAt(text.length),
-        );
+      const processedText = replacementEngine.applyAll(text);
+      const fullRange = new vscode.Range(
+        document.positionAt(0),
+        document.positionAt(text.length),
+      );
 
-        await editor.edit((editBuilder) => {
-          editBuilder.replace(fullRange, processedText);
-        });
+      await editor.edit((editBuilder) => {
+        editBuilder.replace(fullRange, processedText);
+      });
 
-        await showLoggedInfoMessage(
-          CHANNEL,
-          'LaTeX replacements applied successfully',
-        );
-      },
-    );
-  } catch (err) {
-    await showLoggedErrorMessage(
-      CHANNEL,
-      'Error applying LaTeX replacements',
-      err,
-    );
-  }
+      await showLoggedInfoMessage(
+        CHANNEL,
+        'LaTeX replacements applied successfully',
+      );
+    },
+  );
 }
 
 export async function handleIndentCurrentTeX(): Promise<void> {
-  try {
-    await withLaTeXGuard(
-      {
-        channel: CHANNEL,
-        action: 'indent LaTeX document',
-        saveDocument: true,
-      },
-      async ({ relativePath }) => {
-        logger.debug(CHANNEL, `Indenting LaTeX file: ${relativePath}`);
+  await runGuardedLatexCommand(
+    { action: 'indent LaTeX document', saveDocument: true },
+    'Error in indentTeX command',
+    async ({ relativePath }) => {
+      logger.debug(CHANNEL, `Indenting LaTeX file: ${relativePath}`);
 
-        const success = await runLatexFormatter(relativePath);
+      const success = await runLatexFormatter(relativePath);
 
-        if (success) {
-          await delay(100);
-          await showLoggedInfoMessage(
-            CHANNEL,
-            'LaTeX file indented successfully',
-          );
-        } else {
-          await showLoggedMessage(CHANNEL, 'Failed to indent LaTeX file');
-        }
-      },
-    );
-  } catch (err) {
-    await showLoggedErrorMessage(CHANNEL, 'Error in indentTeX command', err);
-  }
+      if (success) {
+        await delay(100);
+        await showLoggedInfoMessage(
+          CHANNEL,
+          'LaTeX file indented successfully',
+        );
+      } else {
+        await showLoggedMessage(CHANNEL, 'Failed to indent LaTeX file');
+      }
+    },
+  );
 }
 
 export async function handleGetTeXCount(): Promise<void> {
-  try {
-    await withLaTeXGuard(
-      { channel: CHANNEL, action: 'get TeX count' },
-      async ({ relativePath }) => {
-        logger.debug(CHANNEL, `Getting tex count for: ${relativePath}`);
+  await runGuardedLatexCommand(
+    { action: 'get TeX count' },
+    'Error getting tex count',
+    async ({ relativePath }) => {
+      logger.debug(CHANNEL, `Getting tex count for: ${relativePath}`);
 
-        const countingMode = await vscode.window.showQuickPick<
-          vscode.QuickPickItem & { value: TexcountMode }
-        >(
-          [
-            { label: 'Count main file only', value: 'separate' as const },
-            {
-              label: 'Follow \\input/\\include and combine',
-              value: 'include' as const,
-            },
-          ],
+      const countingMode = await vscode.window.showQuickPick<
+        vscode.QuickPickItem & { value: TexcountMode }
+      >(
+        [
+          { label: 'Count main file only', value: 'separate' as const },
           {
-            placeHolder: 'Count options',
+            label: 'Follow \\input/\\include and combine',
+            value: 'include' as const,
+          },
+        ],
+        {
+          placeHolder: 'Count options',
+          canPickMany: false,
+        },
+      );
+
+      if (!countingMode) {
+        return;
+      }
+
+      await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: 'Counting LaTeX Document',
+          cancellable: false,
+        },
+        async (progress) => {
+          progress.report({ message: 'Running texcount...' });
+
+          const { output, errors } = await getTeXCount(relativePath, {
+            mode: countingMode.value,
+            channel: CHANNEL,
+          });
+
+          if (!output) {
+            const message =
+              errors[0] ??
+              'Failed to get tex count. Please verify the file path.';
+            await showLoggedMessage(CHANNEL, message);
+            return;
+          }
+
+          const patterns: [RegExp, string][] = [
+            [/Words in text:\s*(\d+)/, 'Text: $1 words'],
+            [/Words in headers:\s*(\d+)/, 'Headers: $1'],
+            [/Words in float captions:\s*(\d+)/, 'Captions: $1'],
+            [/Number of inline math:\s*(\d+)/, 'Inline math: $1'],
+            [/Number of displayed math:\s*(\d+)/, 'Display math: $1'],
+          ];
+
+          const stats = patterns
+            .map(([pattern, template]) => {
+              const match = output.match(pattern);
+              return match
+                ? { label: template.replace('$1', match[1]) }
+                : null;
+            })
+            .filter(filterNotNull);
+
+          await vscode.window.showQuickPick(stats, {
+            placeHolder: 'TeXCount Results (press Esc to dismiss)',
             canPickMany: false,
-          },
-        );
-
-        if (!countingMode) {
-          return;
-        }
-
-        await vscode.window.withProgress(
-          {
-            location: vscode.ProgressLocation.Notification,
-            title: 'Counting LaTeX Document',
-            cancellable: false,
-          },
-          async (progress) => {
-            progress.report({ message: 'Running texcount...' });
-
-            const { output, errors } = await getTeXCount(relativePath, {
-              mode: countingMode.value,
-              channel: CHANNEL,
-            });
-
-            if (!output) {
-              const message =
-                errors[0] ??
-                'Failed to get tex count. Please verify the file path.';
-              await showLoggedMessage(CHANNEL, message);
-              return;
-            }
-
-            const patterns: [RegExp, string][] = [
-              [/Words in text:\s*(\d+)/, 'Text: $1 words'],
-              [/Words in headers:\s*(\d+)/, 'Headers: $1'],
-              [/Words in float captions:\s*(\d+)/, 'Captions: $1'],
-              [/Number of inline math:\s*(\d+)/, 'Inline math: $1'],
-              [/Number of displayed math:\s*(\d+)/, 'Display math: $1'],
-            ];
-
-            const stats = patterns
-              .map(([pattern, template]) => {
-                const match = output.match(pattern);
-                return match
-                  ? { label: template.replace('$1', match[1]) }
-                  : null;
-              })
-              .filter(filterNotNull);
-
-            await vscode.window.showQuickPick(stats, {
-              placeHolder: 'TeXCount Results (press Esc to dismiss)',
-              canPickMany: false,
-            });
-          },
-        );
-      },
-    );
-  } catch (err) {
-    await showLoggedErrorMessage(CHANNEL, 'Error getting tex count', err);
-  }
+          });
+        },
+      );
+    },
+  );
 }

--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -290,13 +290,14 @@ export class BackgroundTasksPanel extends LitElement {
   private renderInquirySection(): TemplateResult | typeof nothing {
     if (this.inquiries.length === 0) return nothing;
 
-    const openCount = this.inquiries.filter((t) => t.status === 'open').length;
-    const answeredCount = this.inquiries.filter(
-      (t) => t.status === 'answered',
-    ).length;
-    const droppedCount = this.inquiries.filter(
-      (t) => t.status === 'dropped',
-    ).length;
+    let openCount = 0;
+    let answeredCount = 0;
+    let droppedCount = 0;
+    for (const t of this.inquiries) {
+      if (t.status === 'open') openCount += 1;
+      else if (t.status === 'answered') answeredCount += 1;
+      else if (t.status === 'dropped') droppedCount += 1;
+    }
 
     return html`
       <wa-details class="collapsible-quiet" open>

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -32,6 +32,60 @@
           "label": "TeXRA"
         }
       ],
+      "chatSkills": [
+        {
+          "name": "inline-paper-critic",
+          "path": "../../skills/inline-paper-critic"
+        },
+        {
+          "name": "lean-blueprint",
+          "path": "../../skills/lean-blueprint"
+        },
+        {
+          "name": "lean-proof-assistant",
+          "path": "../../skills/lean-proof-assistant"
+        },
+        {
+          "name": "lean-search",
+          "path": "../../skills/lean-search"
+        },
+        {
+          "name": "lean-simplifier",
+          "path": "../../skills/lean-simplifier"
+        },
+        {
+          "name": "literature-search",
+          "path": "../../skills/literature-search"
+        },
+        {
+          "name": "manuscript-review",
+          "path": "../../skills/manuscript-review"
+        },
+        {
+          "name": "math-ocr",
+          "path": "../../skills/math-ocr"
+        },
+        {
+          "name": "mathematical-enhancer",
+          "path": "../../skills/mathematical-enhancer"
+        },
+        {
+          "name": "scientific-presenter",
+          "path": "../../skills/scientific-presenter"
+        },
+        {
+          "name": "scientific-simplifier",
+          "path": "../../skills/scientific-simplifier"
+        },
+        {
+          "name": "tikz-figure-builder",
+          "path": "../../skills/tikz-figure-builder"
+        },
+        {
+          "name": "writing-commenter",
+          "path": "../../skills/writing-commenter"
+        }
+      ],
       "commands": [
         {
           "category": "TeXRA",

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -255,8 +255,12 @@ function migrateLegacyAgentNameKeys(): void {
  * persisted visibility selections alive after switching identity to `name:`.
  */
 function migrateFilenameAgentNameKeys(entries: readonly AgentEntry[]): void {
-  const currentKeys = new Set(entries.map((entry) => agentKeyOf(entry)));
-  const currentNames = new Set(entries.map((entry) => entry.name));
+  const currentKeys = new Set<string>();
+  const currentNames = new Set<string>();
+  for (const entry of entries) {
+    currentKeys.add(agentKeyOf(entry));
+    currentNames.add(entry.name);
+  }
   const qualifiedCandidates = new Map<string, Set<string>>();
   const bareCandidates = new Map<string, Set<string>>();
 
@@ -329,7 +333,8 @@ export function getAgent(
   lookupCategory?: AgentCategoryType,
 ): AgentEntry | undefined {
   // Direct lookup for source:name format (already resolved)
-  if (cache.has(identifier)) return cache.get(identifier);
+  const direct = cache.get(identifier);
+  if (direct) return direct;
 
   // Find first match using session-appropriate priority
   const priority =

--- a/src/agent/modelHandlers/anthropic/anthropicDocumentHandling.ts
+++ b/src/agent/modelHandlers/anthropic/anthropicDocumentHandling.ts
@@ -8,6 +8,7 @@ import { toFile } from '@anthropic-ai/sdk';
 
 // Local imports
 import { FILES_API_BETA } from './anthropicContextManagement';
+import { wipeBuffer } from '../utils/toolAttachmentUtils';
 
 // Type imports - Anthropic SDK
 import type { Anthropic } from '@anthropic-ai/sdk';
@@ -189,10 +190,7 @@ export async function replaceDocumentDataWithUploads(
           uploadedPdfPageCounts.set(uploadedFile.id, pageCount);
         }
       } finally {
-        if (buffer) {
-          buffer.fill(0);
-          buffer = undefined;
-        }
+        buffer = wipeBuffer(buffer);
       }
 
       if (uploadedSource) {

--- a/src/agent/modelHandlers/anthropic/anthropicTools.ts
+++ b/src/agent/modelHandlers/anthropic/anthropicTools.ts
@@ -17,7 +17,10 @@ import {
   countPdfPagesFromBuffer,
   sanitizeAnthropicFilename,
 } from './anthropicDocumentHandling';
-import { loadAttachmentBuffer } from '../utils/toolAttachmentUtils';
+import {
+  loadAttachmentBuffer,
+  wipeBuffer,
+} from '../utils/toolAttachmentUtils';
 
 // Type imports - Anthropic SDK
 import type { Base64ImageSource } from '@anthropic-ai/sdk/resources/messages';
@@ -98,8 +101,7 @@ export async function uploadToolAttachments(
       pdfPageCount = await countPdfPagesFromBuffer(buffer);
       if (trackedPdfPageCount() + pdfPageCount > maxPdfPages) {
         pageLimitExceeded.push(attachment);
-        buffer.fill(0);
-        buffer = undefined;
+        buffer = wipeBuffer(buffer);
         continue;
       }
     }
@@ -137,10 +139,7 @@ export async function uploadToolAttachments(
       );
       unsupported.push(attachment);
     } finally {
-      if (buffer) {
-        buffer.fill(0);
-        buffer = undefined;
-      }
+      buffer = wipeBuffer(buffer);
     }
   }
 

--- a/src/agent/modelHandlers/anthropic/anthropicTools.ts
+++ b/src/agent/modelHandlers/anthropic/anthropicTools.ts
@@ -17,10 +17,7 @@ import {
   countPdfPagesFromBuffer,
   sanitizeAnthropicFilename,
 } from './anthropicDocumentHandling';
-import {
-  loadAttachmentBuffer,
-  wipeBuffer,
-} from '../utils/toolAttachmentUtils';
+import { loadAttachmentBuffer, wipeBuffer } from '../utils/toolAttachmentUtils';
 
 // Type imports - Anthropic SDK
 import type { Base64ImageSource } from '@anthropic-ai/sdk/resources/messages';

--- a/src/agent/modelHandlers/openai/openAIResponseFileUploads.ts
+++ b/src/agent/modelHandlers/openai/openAIResponseFileUploads.ts
@@ -23,7 +23,10 @@ import type { ToolFileAttachment } from '@shared/schemas/toolResult';
 import { isNonEmptyString } from '@utils/core';
 import { OFFICE_MIME_TYPES } from '@utils/files/mimeUtils';
 
-import { loadAttachmentBuffer } from '../utils/toolAttachmentUtils';
+import {
+  loadAttachmentBuffer,
+  wipeBuffer,
+} from '../utils/toolAttachmentUtils';
 import { isInputFileContent, isMessageItem } from './openAIResponseContent';
 import type {
   ResponseFunctionCallOutputItemList,
@@ -147,10 +150,7 @@ async function replaceFileDataWithUpload(
     );
     throw err;
   } finally {
-    if (buffer) {
-      buffer.fill(0);
-      buffer = undefined;
-    }
+    buffer = wipeBuffer(buffer);
   }
 }
 
@@ -201,10 +201,7 @@ export async function uploadToolAttachments(
         `Failed to upload attachment to OpenAI: ${getSdkErrorMessage(err)}`,
       );
     } finally {
-      if (buffer) {
-        buffer.fill(0);
-        buffer = undefined;
-      }
+      buffer = wipeBuffer(buffer);
     }
   }
 
@@ -277,10 +274,7 @@ export async function buildInlineAttachmentParts(
       );
       skipped.push(attachment);
     } finally {
-      if (buffer) {
-        buffer.fill(0);
-        buffer = undefined;
-      }
+      buffer = wipeBuffer(buffer);
     }
   }
 

--- a/src/agent/modelHandlers/openai/openAIResponseFileUploads.ts
+++ b/src/agent/modelHandlers/openai/openAIResponseFileUploads.ts
@@ -23,10 +23,7 @@ import type { ToolFileAttachment } from '@shared/schemas/toolResult';
 import { isNonEmptyString } from '@utils/core';
 import { OFFICE_MIME_TYPES } from '@utils/files/mimeUtils';
 
-import {
-  loadAttachmentBuffer,
-  wipeBuffer,
-} from '../utils/toolAttachmentUtils';
+import { loadAttachmentBuffer, wipeBuffer } from '../utils/toolAttachmentUtils';
 import { isInputFileContent, isMessageItem } from './openAIResponseContent';
 import type {
   ResponseFunctionCallOutputItemList,

--- a/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
+++ b/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
@@ -221,6 +221,16 @@ export function formatAttachmentSummaryFromNotes(
   return `${header}\n${notes}${hint}`;
 }
 
+/**
+ * Securely zero a sensitive attachment buffer and drop the reference. Returns
+ * `undefined` so callers can wipe and release in a single expression:
+ * `buffer = wipeBuffer(buffer);`
+ */
+export function wipeBuffer(buffer: Buffer | undefined): undefined {
+  buffer?.fill(0);
+  return undefined;
+}
+
 export async function loadAttachmentBuffer(
   attachment: ToolFileAttachment,
 ): Promise<Buffer> {

--- a/src/tools/lean/direct/leanSession.ts
+++ b/src/tools/lean/direct/leanSession.ts
@@ -121,15 +121,13 @@ export class LeanSession {
   async restartFile(filePath: string): Promise<void> {
     const absolute = path.resolve(filePath);
     if (!this.rpc) return;
-    if (this.openFiles.has(absolute)) {
+    const state = this.openFiles.get(absolute);
+    if (state) {
       this.rpc.notify('textDocument/didClose', {
         textDocument: { uri: pathToUri(absolute) },
       });
-      const state = this.openFiles.get(absolute);
-      if (state) {
-        this.releaseDiagnosticsWaiters(state);
-        this.openFiles.delete(absolute);
-      }
+      this.releaseDiagnosticsWaiters(state);
+      this.openFiles.delete(absolute);
     }
     await this.ensureFileOpen(absolute, { forceReload: true });
   }

--- a/src/tools/zotero/ZoteroCollectionsTool.ts
+++ b/src/tools/zotero/ZoteroCollectionsTool.ts
@@ -180,9 +180,7 @@ export class ZoteroCollectionsTool extends defineTool({
     // Filter by library name if specified
     const normalizedLibrary = library?.toLowerCase();
     const targetLibraries = normalizedLibrary
-      ? libraries.filter(
-          (lib) => lib.name.toLowerCase() === normalizedLibrary,
-        )
+      ? libraries.filter((lib) => lib.name.toLowerCase() === normalizedLibrary)
       : libraries;
 
     if (targetLibraries.length === 0) {

--- a/src/tools/zotero/ZoteroCollectionsTool.ts
+++ b/src/tools/zotero/ZoteroCollectionsTool.ts
@@ -178,9 +178,10 @@ export class ZoteroCollectionsTool extends defineTool({
     }
 
     // Filter by library name if specified
-    const targetLibraries = library
+    const normalizedLibrary = library?.toLowerCase();
+    const targetLibraries = normalizedLibrary
       ? libraries.filter(
-          (lib) => lib.name.toLowerCase() === library.toLowerCase(),
+          (lib) => lib.name.toLowerCase() === normalizedLibrary,
         )
       : libraries;
 


### PR DESCRIPTION
Closes #6678.

## Problem

The affected paths repeated small but important local decisions: CLI agent-run flag parsing, LaTeX guarded-command error handling, model attachment buffer wiping, and several count or lookup passes over the same data. None of these repetitions changed behavior, but each made the reader compare parallel implementations to verify that they remained equivalent.

The rebase onto current `main` also exposed a stale extension package invariant snapshot: the extension manifest already declared packaged chat skills, but the generated invariant snapshot did not include them.

## Design Change

The PR gives each repeated decision one direct owner:

- `collectCommonAgentRunFlags()` parses the common agent-run CLI flags for `agents run`, `multi-agent run`, and `workflow run`.
- `runGuardedLatexCommand()` owns the common `withLaTeXGuard` plus logged-error command wrapper for the active-file LaTeX commands.
- `wipeBuffer()` owns the repeated zero-fill-and-release buffer cleanup used by Anthropic and OpenAI attachment paths.
- Several local loops now count, look up, or normalize once instead of making repeated passes over the same value.
- `scripts/extension-package-invariants.snapshot.json` is resynced to the current extension manifest.

## Deleted or Consolidated Abstractions

This change removes duplicated inline scaffolding rather than adding pass-through layers. The consolidated pieces are the repeated flag-parser blocks, the repeated LaTeX guard wrappers, the repeated buffer cleanup blocks, and small repeated list/count/look-up patterns in progress, agent registry, Lean session, and Zotero collection code.

## Behavior Preserved

Public commands, schemas, options, and user-visible text are unchanged. The CLI still accepts the same flags with the same precedence; LaTeX commands still pass through the same guard and error-reporting path; attachment buffers are still wiped before references are released; and the list/count rewrites preserve ordering and filtering. The invariant snapshot change only records existing extension manifest content.

## Tests Run

- `corepack pnpm install`
- `npm run format`
- `npm run check:extension-package-invariants`
- `npm run compile:fast`
- `npm run lint` (passes with warnings only)
- `npm test` (543 files passed, 1 skipped; 3966 tests passed, 4 skipped)
- `npm run typecheck`

## Remaining Risks

The remaining risk is confined to shared-helper call sites: a future change to one helper will affect all of its users. The helpers are small, typed, and reviewed against their former inline forms. Existing lint warnings remain outside the changed code; there are no lint errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactoring only; helpers mirror prior inline logic and tests reportedly pass. Shared helpers mean future edits affect multiple call sites.
> 
> **Overview**
> This PR **deduplicates repeated patterns** into small shared helpers and tightens a few hot loops, without changing user-facing behavior.
> 
> **CLI:** `collectCommonAgentRunFlags()` in `globalArgs.ts` now parses `--input`, `--context`, `--instruction`, and `--instruction-file` once; `agents run`, `multi-agent run`, and `workflow run` spread that object instead of duplicating flag parsing.
> 
> **Extension:** `runGuardedLatexCommand()` centralizes the `withLaTeXGuard` + logged-error wrapper for active-file LaTeX commands (`fixCompilation`, `applyReplacements`, `indentCurrentTeX`, `getTeXCount`).
> 
> **Model handlers:** `wipeBuffer()` in `toolAttachmentUtils.ts` replaces repeated zero-fill-and-release blocks in Anthropic and OpenAI attachment upload paths.
> 
> **Misc:** Single-pass inquiry status counts in `BackgroundTasksPanel`; one-pass key/name sets in agent registry migration; lean `restartFile` lookup cleanup; Zotero library name normalized once before filtering. **`extension-package-invariants.snapshot.json`** is updated to include packaged `chatSkills` already declared in the extension manifest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11e96f676612f1db9e654f7059ee90ca7bcae7d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->