### PR TITLE
refactor: drop field-extracting wrappers with no production callers

### DIFF
--- a/src/shared/constants/delegationPolicy.ts
+++ b/src/shared/constants/delegationPolicy.ts
@@ -78,15 +78,3 @@ export function evaluateDelegationGate(
     ...(allowed ? {} : { blockReason: 'max_depth_reached' as const }),
   };
 }
-
-/**
- * Delegation gate. An agent at depth `d` may delegate iff `d < maxDepth`.
- * Root (depth 0) with the default (maxDepth 1) can always delegate;
- * subagents (depth ≥ 1) can only delegate when the user raises the cap.
- */
-export function delegationAllowed(
-  depth: number,
-  config: NestedDelegationConfig,
-): boolean {
-  return evaluateDelegationGate(depth, config).allowed;
-}

--- a/src/test-kernel/shared/delegationPolicy.vitest.ts
+++ b/src/test-kernel/shared/delegationPolicy.vitest.ts
@@ -6,7 +6,6 @@ import { describe, it } from 'vitest';
 
 // Local imports - shared constants
 import {
-  delegationAllowed,
   evaluateDelegationGate,
   UNKNOWN_DELEGATION_DEPTH,
 } from '@shared/constants/delegationPolicy';
@@ -15,7 +14,6 @@ describe('delegationPolicy', () => {
   it('allows root delegation at the default max depth', () => {
     const config = { maxDepth: 1 };
 
-    assert.strictEqual(delegationAllowed(0, config), true);
     assert.deepStrictEqual(evaluateDelegationGate(0, config), {
       depth: 0,
       maxDepth: 1,

--- a/src/test-kernel/utils/GetXmlFormatFromReadableFiles.vitest.ts
+++ b/src/test-kernel/utils/GetXmlFormatFromReadableFiles.vitest.ts
@@ -21,24 +21,21 @@ vi.mock('@utils/files', async () => {
   };
 });
 
-import {
-  getXmlFormatFromFiles,
-  getXmlFormatFromReadableFiles,
-} from '@utils/prompt';
+import { getXmlFormatFromReadableFiles } from '@utils/prompt';
 
 beforeEach(() => {
   mocks.read.mockReset();
 });
 
-describe('getXmlFormatFromFiles', () => {
-  it('returns null when given no files', async () => {
-    expect(await getXmlFormatFromFiles([])).toBeNull();
+describe('getXmlFormatFromReadableFiles', () => {
+  it('returns null xml when given no files', async () => {
+    expect((await getXmlFormatFromReadableFiles([])).xml).toBeNull();
   });
 
   it('wraps every readable file in a <document> block', async () => {
     mocks.read.mockImplementation(async (file: string) => `body of ${file}`);
 
-    const xml = await getXmlFormatFromFiles(['a.tex', 'b.tex']);
+    const { xml } = await getXmlFormatFromReadableFiles(['a.tex', 'b.tex']);
 
     expect(xml).toBe(
       '<document name="a.tex">\nbody of a.tex\n</document>\n' +
@@ -56,7 +53,10 @@ describe('getXmlFormatFromFiles', () => {
       return `body of ${file}`;
     });
 
-    const xml = await getXmlFormatFromFiles(['missing.tex', 'present.tex']);
+    const { xml } = await getXmlFormatFromReadableFiles([
+      'missing.tex',
+      'present.tex',
+    ]);
 
     expect(xml).toBe(
       '<document name="present.tex">\nbody of present.tex\n</document>',
@@ -84,11 +84,11 @@ describe('getXmlFormatFromFiles', () => {
     });
   });
 
-  it('returns null when none of the files are readable', async () => {
+  it('returns null xml when none of the files are readable', async () => {
     mocks.read.mockRejectedValue(new Error('ENOENT'));
 
     expect(
-      await getXmlFormatFromFiles(['gone-1.tex', 'gone-2.tex']),
+      (await getXmlFormatFromReadableFiles(['gone-1.tex', 'gone-2.tex'])).xml,
     ).toBeNull();
   });
 });

--- a/src/test-kernel/utils/WorkflowPromptFileNames.vitest.mts
+++ b/src/test-kernel/utils/WorkflowPromptFileNames.vitest.mts
@@ -17,7 +17,7 @@ import {
 import {
   getListOfFiles,
   getPromptFileName,
-  getXmlFormatFromFiles,
+  getXmlFormatFromReadableFiles,
 } from '@utils/prompt';
 
 describe('workflow prompt file names', () => {
@@ -45,7 +45,7 @@ describe('workflow prompt file names', () => {
       getListOfFiles(['/workspace/chapter/main.tex', '/outside/absolute.tex']),
     ).toBe('chapter/main.tex, absolute.tex');
 
-    const xml = await getXmlFormatFromFiles([
+    const { xml } = await getXmlFormatFromReadableFiles([
       '/workspace/chapter/main.tex',
       '/outside/absolute.tex',
     ]);

--- a/src/utils/prompt/promptUtils.ts
+++ b/src/utils/prompt/promptUtils.ts
@@ -82,12 +82,6 @@ export async function getXmlFormatFromReadableFiles(
   };
 }
 
-export async function getXmlFormatFromFiles(
-  files: string[],
-): Promise<string | null> {
-  return (await getXmlFormatFromReadableFiles(files)).xml;
-}
-
 /**
  * Convert a list of files to a comma-separated string
  * @param files List of file paths


### PR DESCRIPTION
`delegationAllowed` and `getXmlFormatFromFiles` were thin convenience
wrappers that returned a single field of a richer function's result
(`evaluateDelegationGate(...).allowed` and
`getXmlFormatFromReadableFiles(...).xml`). Neither had any production
caller — they survived only because their tests exercised them. Per the
"flattening abstraction layers" guidance, remove the indirection and
retarget the tests onto the underlying functions so coverage is
preserved.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PtnCtSiHYZAwTVBc9TCcM7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only call-site updates plus removal of dead exports; no production code paths change.
> 
> **Overview**
> Removes two unused convenience wrappers that only forwarded a single field from richer APIs: **`delegationAllowed`** (replaced by **`evaluateDelegationGate(...).allowed`**) and **`getXmlFormatFromFiles`** (replaced by **`getXmlFormatFromReadableFiles`**).
> 
> Tests that only exercised those wrappers now call the underlying functions directly—asserting full gate results where appropriate and destructuring **`{ xml }`** for prompt XML—so behavior coverage stays the same without the extra layer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9ae548f76024a697572a661a99d0841985d4351. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->