### PR TITLE
Apply Schwartzian transform to date-sorted listings

### DIFF
--- a/packages/cli/src/runtime/chatDefaults.ts
+++ b/packages/cli/src/runtime/chatDefaults.ts
@@ -81,10 +81,11 @@ async function loadHistoryDefaults(): Promise<PartialDefaults> {
         // sensible default for a plain single-agent chat session.
         !entry.agentConfig?.cliMultiAgentPresetId,
     )
-    .sort(
-      (a, b) =>
-        new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
-    );
+    // Schwartzian transform: parse each timestamp once into a sort key rather
+    // than re-parsing both sides on every comparison.
+    .map((item) => ({ item, key: new Date(item.timestamp).getTime() }))
+    .sort((a, b) => b.key - a.key)
+    .map(({ item }) => item);
   const mostRecent = candidates[0];
   if (!mostRecent?.agentConfig) return {};
   return {

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -273,11 +273,13 @@ export class SettingsApp extends SettingsAppBase {
       );
     },
     [SETTINGS_VIEW_COMMANDS.UPDATE_HISTORY]: (data) => {
+      // Schwartzian transform: parse each timestamp once into a sort key
+      // rather than re-parsing both sides on every comparison.
       this.historyItems.set(
-        [...data.historyItems].sort(
-          (a, b) =>
-            new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
-        ),
+        data.historyItems
+          .map((item) => ({ item, key: new Date(item.timestamp).getTime() }))
+          .sort((a, b) => b.key - a.key)
+          .map(({ item }) => item),
       );
     },
     [SETTINGS_VIEW_COMMANDS.HISTORY_CLEARED]: () => {

--- a/src/agent/storage/executionListing.ts
+++ b/src/agent/storage/executionListing.ts
@@ -150,12 +150,13 @@ export async function listExecutions(): Promise<ExecutionListingEntry[]> {
     { concurrency: EXECUTION_STORAGE_CONCURRENCY },
   );
 
+  // Schwartzian transform: parse each timestamp once into a sort key rather
+  // than re-parsing both sides on every comparison.
   const listing = results
     .filter(filterNotNull)
-    .sort(
-      (a, b) =>
-        new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
-    );
+    .map((item) => ({ item, key: new Date(item.timestamp).getTime() }))
+    .sort((a, b) => b.key - a.key)
+    .map(({ item }) => item);
 
   cache = listing;
   return listing;

--- a/src/tools/inquiry/externalInquiryStorage.ts
+++ b/src/tools/inquiry/externalInquiryStorage.ts
@@ -669,10 +669,15 @@ export async function listThreadsByStatus(params: {
     return true;
   });
 
-  filtered.sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt));
+  // Schwartzian transform: parse each updatedAt once into a sort key rather
+  // than re-parsing both sides on every comparison.
+  const sorted = filtered
+    .map((manifest) => ({ manifest, key: Date.parse(manifest.updatedAt) }))
+    .sort((a, b) => b.key - a.key)
+    .map(({ manifest }) => manifest);
 
   const trimmed =
-    params.limit != null ? filtered.slice(0, params.limit) : filtered;
+    params.limit != null ? sorted.slice(0, params.limit) : sorted;
   return trimmed.map(manifestToSummary);
 }
 

--- a/src/tools/inquiry/externalInquiryStorage.ts
+++ b/src/tools/inquiry/externalInquiryStorage.ts
@@ -676,8 +676,7 @@ export async function listThreadsByStatus(params: {
     .sort((a, b) => b.key - a.key)
     .map(({ manifest }) => manifest);
 
-  const trimmed =
-    params.limit != null ? sorted.slice(0, params.limit) : sorted;
+  const trimmed = params.limit != null ? sorted.slice(0, params.limit) : sorted;
   return trimmed.map(manifestToSummary);
 }
 


### PR DESCRIPTION
Sort comparators that parsed dates inline re-parsed both operands on
every comparison (O(n log n) parses). Decorate each item with its parsed
sort key once, sort on the numeric key, then undecorate.

Affects execution listings, settings history, CLI chat defaults, and
external inquiry thread listing.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XhfZyub5YAFSw1yHKUNtou

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure performance refactor with identical sort semantics; no API or persistence changes.
> 
> **Overview**
> **Replaces inline date parsing in sort comparators** with a Schwartzian transform (decorate → sort on numeric keys → undecorate) so each timestamp/`updatedAt` is parsed once per item instead of on every comparison during sort.
> 
> Applied in four places that still used `new Date(...).getTime()` or `Date.parse(...)` inside `.sort()`: **`listExecutions`** (execution history cache), **settings `UPDATE_HISTORY`** (newest-first history tab), **CLI `loadHistoryDefaults`** (most recent tool-use run for chat model default), and **`listThreadsByStatus`** in external inquiry storage (newest `updatedAt` before limit/trim).
> 
> Sort order stays **descending by time**; behavior is unchanged aside from less redundant parsing on larger lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31585a50782f8ea2eca8ae243359c8cdebb6063f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->