### PR TITLE
refactor: centralize newest timestamp sorting

### DIFF
--- a/packages/cli/src/runtime/chatDefaults.ts
+++ b/packages/cli/src/runtime/chatDefaults.ts
@@ -1,6 +1,7 @@
 import { TEXRA_CONFIG_FILE_NAME } from '@platform/defaults/nodeStorage';
 import { listExecutions } from '@agent/storage';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { toNewestFirstByTimestamp } from '@utils/core';
 import { GlobalStorageFS } from '@utils/files/storageFS';
 import {
   CLI_BUILTIN_DEFAULT_MODEL,
@@ -73,19 +74,16 @@ async function loadUserDefaults(): Promise<PartialDefaults> {
 async function loadHistoryDefaults(): Promise<PartialDefaults> {
   // An unreadable history listing means no history defaults.
   const entries = await listExecutions().catch(() => []);
-  const candidates = entries
-    .filter(
+  const candidates = toNewestFirstByTimestamp(
+    entries.filter(
       (entry) =>
         entry.agentConfig?.agentCategory === AgentCategory.ToolUse &&
         // A multi-agent team run's root is an orchestrator agent, not a
         // sensible default for a plain single-agent chat session.
         !entry.agentConfig?.cliMultiAgentPresetId,
-    )
-    // Schwartzian transform: parse each timestamp once into a sort key rather
-    // than re-parsing both sides on every comparison.
-    .map((item) => ({ item, key: new Date(item.timestamp).getTime() }))
-    .sort((a, b) => b.key - a.key)
-    .map(({ item }) => item);
+    ),
+    (item) => item.timestamp,
+  );
   const mostRecent = candidates[0];
   if (!mostRecent?.agentConfig) return {};
   return {

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -25,6 +25,7 @@ import {
   type TaskGroup,
 } from '@shared/schemas';
 import { isProcessAgent } from '@shared/streams/agentKind';
+import { toNewestFirstByTimestamp } from '@utils/core';
 
 import { setsEqual } from './utils';
 import {
@@ -240,11 +241,12 @@ export const activeTaskGroups$ = new Signal.Computed(
 export const activeInquiries$ = new Signal.Computed(() => {
   const activeStreamId = activeStreamId$.get();
   if (!activeStreamId) return EMPTY_INQUIRIES;
-  const threads = [...inquiries$.get().values()]
-    .filter((thread) => thread.parentStreamId === activeStreamId)
-    .sort(
-      (a, b) => Date.parse(b.lastActivityIso) - Date.parse(a.lastActivityIso),
-    );
+  const threads = toNewestFirstByTimestamp(
+    [...inquiries$.get().values()].filter(
+      (thread) => thread.parentStreamId === activeStreamId,
+    ),
+    (thread) => thread.lastActivityIso,
+  );
   return threads.length > 0 ? threads : EMPTY_INQUIRIES;
 });
 

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -62,6 +62,9 @@ import type { AgentCategory } from '@shared/schemas/agent';
 import type { AgentModePreset } from '@shared/schemas/agentPresets';
 import '@shared/wa/tabs';
 import type { WaTabShowEvent } from '@shared/wa/tabs';
+
+// Local imports - shared utilities
+import { toNewestFirstByTimestamp } from '@utils/core';
 import { settingsViewStyles } from './styles';
 
 // Side-effect: register tab components
@@ -273,13 +276,8 @@ export class SettingsApp extends SettingsAppBase {
       );
     },
     [SETTINGS_VIEW_COMMANDS.UPDATE_HISTORY]: (data) => {
-      // Schwartzian transform: parse each timestamp once into a sort key
-      // rather than re-parsing both sides on every comparison.
       this.historyItems.set(
-        data.historyItems
-          .map((item) => ({ item, key: new Date(item.timestamp).getTime() }))
-          .sort((a, b) => b.key - a.key)
-          .map(({ item }) => item),
+        toNewestFirstByTimestamp(data.historyItems, (item) => item.timestamp),
       );
     },
     [SETTINGS_VIEW_COMMANDS.HISTORY_CLEARED]: () => {

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -62,8 +62,6 @@ import type { AgentCategory } from '@shared/schemas/agent';
 import type { AgentModePreset } from '@shared/schemas/agentPresets';
 import '@shared/wa/tabs';
 import type { WaTabShowEvent } from '@shared/wa/tabs';
-
-// Local imports - shared utilities
 import { toNewestFirstByTimestamp } from '@utils/core';
 import { settingsViewStyles } from './styles';
 

--- a/src/agent/storage/executionListing.ts
+++ b/src/agent/storage/executionListing.ts
@@ -21,7 +21,7 @@ import { toErrorMessage } from '@common/errors/errorMessage';
 import * as logger from '@logger/logUtils';
 import type { ExecutionId } from '@shared/schemas';
 import { StorageFS, WorkspaceFS, TASK_RUNS_DIR } from '@utils/files';
-import { filterNotNull } from '@utils/core';
+import { filterNotNull, toNewestFirstByTimestamp } from '@utils/core';
 import { isDirectory } from '@utils/files/fsEntryType';
 
 import { type ExecutionMeta, getExecutionStore } from './ExecutionKVStore';
@@ -150,13 +150,10 @@ export async function listExecutions(): Promise<ExecutionListingEntry[]> {
     { concurrency: EXECUTION_STORAGE_CONCURRENCY },
   );
 
-  // Schwartzian transform: parse each timestamp once into a sort key rather
-  // than re-parsing both sides on every comparison.
-  const listing = results
-    .filter(filterNotNull)
-    .map((item) => ({ item, key: new Date(item.timestamp).getTime() }))
-    .sort((a, b) => b.key - a.key)
-    .map(({ item }) => item);
+  const listing = toNewestFirstByTimestamp(
+    results.filter(filterNotNull),
+    (item) => item.timestamp,
+  );
 
   cache = listing;
   return listing;

--- a/src/test-kernel/utils/Comparators.vitest.ts
+++ b/src/test-kernel/utils/Comparators.vitest.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { toNewestFirstByTimestamp } from '@utils/core/comparators';
+
+describe('toNewestFirstByTimestamp', () => {
+  it('orders values by newest timestamp first', () => {
+    const rows = [
+      { id: 'middle', timestamp: '2026-06-20T12:00:00.000Z' },
+      { id: 'newest', timestamp: '2026-06-21T12:00:00.000Z' },
+      { id: 'oldest', timestamp: '2026-06-19T12:00:00.000Z' },
+    ];
+
+    expect(
+      toNewestFirstByTimestamp(rows, (row) => row.timestamp).map(
+        (row) => row.id,
+      ),
+    ).toEqual(['newest', 'middle', 'oldest']);
+  });
+
+  it('does not mutate the input array', () => {
+    const rows = [
+      { id: 'first', timestamp: '2026-06-20T12:00:00.000Z' },
+      { id: 'second', timestamp: '2026-06-21T12:00:00.000Z' },
+    ];
+
+    const sorted = toNewestFirstByTimestamp(rows, (row) => row.timestamp);
+
+    expect(sorted.map((row) => row.id)).toEqual(['second', 'first']);
+    expect(rows.map((row) => row.id)).toEqual(['first', 'second']);
+  });
+});

--- a/src/tools/inquiry/externalInquiryStorage.ts
+++ b/src/tools/inquiry/externalInquiryStorage.ts
@@ -17,6 +17,7 @@ import {
 } from '@shared/schemas';
 import { normalizeFilePath } from '@shared/utils/path';
 import { ToolError } from '@shared/schemas/toolResult';
+import { toNewestFirstByTimestamp } from '@utils/core';
 import { GlobalStorageFS, StorageFS } from '@utils/files';
 import { hexId12 } from '@utils/core/executionId';
 import { isDirectory, isFile } from '@utils/files/fsEntryType';
@@ -669,12 +670,10 @@ export async function listThreadsByStatus(params: {
     return true;
   });
 
-  // Schwartzian transform: parse each updatedAt once into a sort key rather
-  // than re-parsing both sides on every comparison.
-  const sorted = filtered
-    .map((manifest) => ({ manifest, key: Date.parse(manifest.updatedAt) }))
-    .sort((a, b) => b.key - a.key)
-    .map(({ manifest }) => manifest);
+  const sorted = toNewestFirstByTimestamp(
+    filtered,
+    (manifest) => manifest.updatedAt,
+  );
 
   const trimmed = params.limit != null ? sorted.slice(0, params.limit) : sorted;
   return trimmed.map(manifestToSummary);

--- a/src/utils/core/comparators.ts
+++ b/src/utils/core/comparators.ts
@@ -19,3 +19,17 @@ export function byString(a: string, b: string): number {
 export function byStringProp<T>(fn: (t: T) => string): (a: T, b: T) => number {
   return (a, b) => fn(a).localeCompare(fn(b));
 }
+
+/**
+ * Return a new array ordered by newest timestamp first.
+ * Each timestamp is parsed once before sorting.
+ */
+export function toNewestFirstByTimestamp<T>(
+  items: readonly T[],
+  timestampOf: (item: T) => string,
+): T[] {
+  return items
+    .map((item) => ({ item, key: Date.parse(timestampOf(item)) }))
+    .sort((a, b) => b.key - a.key)
+    .map(({ item }) => item);
+}

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -23,6 +23,11 @@ export {
   unique,
 } from './typeGuards';
 export { debounce, delay } from './async';
-export { byName, byString, byStringProp } from './comparators';
+export {
+  byName,
+  byString,
+  byStringProp,
+  toNewestFirstByTimestamp,
+} from './comparators';
 export { clamp, clampIndex, clampOptional, roundTo } from './math';
 export { tryParseUrl } from './urlCore';


### PR DESCRIPTION
Closes #6681.

## Problem

Several runtime and UI paths independently encoded the same newest-first timestamp ordering rule. Each call site decorated records with a parsed timestamp, sorted by that key, and unwrapped the original value. The repetitions were behavior-preserving, but they made future readers re-check the same ordering argument in execution listings, CLI chat defaults, settings history, external inquiry storage, and progress-view inquiry state.

## Design Change

This PR gives that ordering rule one direct owner: `toNewestFirstByTimestamp()` in `src/utils/core/comparators.ts`. The helper returns a new array, parses each timestamp once per item, and orders the original items from newest to oldest.

The repeated call sites now keep their existing filters and limits locally, then pass the already-selected records to the shared timestamp-ordering helper.

## Deleted or Consolidated Abstractions

No pass-through layer was added. The duplicated decorate-sort-undecorate blocks were consolidated into one core utility, and the local comments that explained the same Schwartzian transform at several call sites were removed because the helper name and implementation now carry that rule.

## Behavior Preserved

Public commands, schemas, stored data, event payloads, and user-visible text are unchanged. The refactor preserves the same newest-first ordering and keeps filtering, cache assignment, inquiry limits, and empty-array fallbacks at their former owners.

## Tests Run

- `corepack pnpm install`
- `npm run format`
- `corepack pnpm exec prettier --check packages/cli/src/runtime/chatDefaults.ts packages/extension/src/progressView/frontend/progressState.ts packages/extension/src/settingsView/frontend/SettingsApp.ts src/agent/storage/executionListing.ts src/tools/inquiry/externalInquiryStorage.ts src/utils/core/comparators.ts src/utils/core/index.ts src/test-kernel/utils/Comparators.vitest.ts`
- `git diff --check`
- `npm test -- src/test-kernel/utils/Comparators.vitest.ts`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (passes with existing warnings only)
- `npm run check:extension-package-invariants`
- `npm test -- --maxWorkers=4` (544 files passed, 1 skipped; 3968 tests passed, 4 skipped)

Default-concurrency `npm test` hit unrelated local timeout-sensitive suites in this worktree; the failed files passed when rerun directly, and the full suite passed with `--maxWorkers=4`.

## Remaining Risks

The remaining risk is limited to timestamp strings that are already consumed by these call sites. Invalid timestamps still produce JavaScript `NaN` sort keys, as before; this PR does not change validation or fallback semantics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor with unit tests; invalid timestamps still sort via `NaN` keys as before.
> 
> **Overview**
> Introduces **`toNewestFirstByTimestamp()`** in `src/utils/core/comparators.ts` (re-exported from `@utils/core`) as the single place for newest-first ordering with one `Date.parse` per item.
> 
> **Five call sites** swap inline decorate-sort-undecorate logic for the helper while keeping local filters and limits unchanged: CLI chat history defaults, execution listing cache, settings history updates, progress-view active inquiries, and external inquiry thread listing. Duplicate Schwartzian comments at those sites are removed.
> 
> Adds **`Comparators.vitest.ts`** covering sort order and non-mutation of the input array.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 780292bbffe24caa964076398064e01d675a1112. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->