### PR TITLE
fix(latexdiff): discover headless run outputs via on-disk run-dir scan

### DIFF
--- a/src/latex/latexdiff/outputDiscovery.ts
+++ b/src/latex/latexdiff/outputDiscovery.ts
@@ -250,6 +250,16 @@ export async function discoverLatestExecutionOutputs(query: {
       if (rounds && rounds.size > 0) {
         return { executionId: candidate.id, rounds };
       }
+      // Stream-tab snapshots are a progress-view artifact that headless
+      // `texra run` executions never persist. Fall back to scanning the matched
+      // execution's run directory on disk — the same source the `--run-id` path
+      // uses — so a headless run's outputs are still discovered instead of
+      // dropping through to the cwd-based workspace scan (which only sees files
+      // copied back into the workspace, not the per-round execution outputs).
+      const scanned = await scanRunDirForOutputs(candidate.id, query.inputFile);
+      if (scanned && scanned.size > 0) {
+        return { executionId: candidate.id, rounds: scanned };
+      }
     }
   } catch (error) {
     logger.debug(

--- a/src/latex/latexdiff/outputDiscovery.ts
+++ b/src/latex/latexdiff/outputDiscovery.ts
@@ -256,7 +256,15 @@ export async function discoverLatestExecutionOutputs(query: {
       // uses — so a headless run's outputs are still discovered instead of
       // dropping through to the cwd-based workspace scan (which only sees files
       // copied back into the workspace, not the per-round execution outputs).
-      const scanned = await scanRunDirForOutputs(candidate.id, query.inputFile);
+      // Mirror the `--run-id` path's base set: the matched execution's other
+      // configured input files become extra diff bases, so a multi-file run's
+      // secondary outputs diff against their own originals rather than all
+      // collapsing onto the single `-i` file.
+      const scanned = await scanRunDirForOutputs(
+        candidate.id,
+        query.inputFile,
+        candidate.agentConfig?.inputFiles?.slice(1),
+      );
       if (scanned && scanned.size > 0) {
         return { executionId: candidate.id, rounds: scanned };
       }

--- a/src/test-kernel/latex/OutputDiscovery.vitest.mts
+++ b/src/test-kernel/latex/OutputDiscovery.vitest.mts
@@ -1,0 +1,123 @@
+// Standard library imports
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+// Third-party imports
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `discoverLatestExecutionOutputs` matches a run by agent/model/input and then
+// reads its per-round outputs. Headless `texra run` executions persist those
+// outputs on disk but never write the progress-view stream-tab snapshot, so the
+// snapshot read comes back empty. These mocks reproduce that case: a matching
+// execution whose stream-tab snapshot is empty while its run directory holds
+// r0/r1 outputs on disk (the same source the `--run-id` path scans).
+const mocks = vi.hoisted(() => ({
+  listExecutions: vi.fn(),
+  resolveRunDir: vi.fn(),
+  readOutputFiles: vi.fn(),
+}));
+
+vi.mock('@agent/storage', async (importActual) => ({
+  ...(await importActual<typeof import('@agent/storage')>()),
+  listExecutions: mocks.listExecutions,
+}));
+
+vi.mock('@utils/files', async (importActual) => ({
+  ...(await importActual<typeof import('@utils/files')>()),
+  resolveRunDir: mocks.resolveRunDir,
+}));
+
+vi.mock('@transcript', async (importActual) => {
+  // A class (not an arrow) so `new StreamSnapshotStore()` is constructable.
+  class FakeStreamSnapshotStore {
+    readOutputFiles = mocks.readOutputFiles;
+  }
+  return {
+    ...(await importActual<typeof import('@transcript')>()),
+    StreamSnapshotStore: FakeStreamSnapshotStore,
+  };
+});
+
+const { discoverLatestExecutionOutputs } =
+  await import('@latex/latexdiff/outputDiscovery');
+
+function matchingExecution(id: string) {
+  return {
+    id,
+    agent: 'polish',
+    model: 'deepseek',
+    timestamp: '2026-01-01T00:00:00.000Z',
+    agentConfig: { inputFiles: ['paper.tex'] },
+  };
+}
+
+describe('discoverLatestExecutionOutputs', () => {
+  const tempDirs: string[] = [];
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const [{ initPlatform }, { nodeFilesystem }, { createFakePlatform }] =
+      await Promise.all([
+        import('@platform/platform'),
+        import('@platform/defaults/nodeFilesystem'),
+        import('@test/support/FakePlatform'),
+      ]);
+    initPlatform(createFakePlatform({}, { fs: nodeFilesystem }));
+    // No stream-tab snapshot exists for headless runs.
+    mocks.readOutputFiles.mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs
+        .splice(0)
+        .map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it('falls back to an on-disk run-dir scan when the stream-tab snapshot is empty', async () => {
+    const runDir = await mkdtemp(path.join(os.tmpdir(), 'texra-latexdiff-'));
+    tempDirs.push(runDir);
+    for (const round of ['r0', 'r1']) {
+      await mkdir(path.join(runDir, round), { recursive: true });
+      await writeFile(
+        path.join(runDir, round, 'paper.tex'),
+        `\\documentclass{article}\\begin{document}${round}\\end{document}`,
+      );
+    }
+
+    mocks.listExecutions.mockResolvedValue([
+      matchingExecution('exec-headless'),
+    ]);
+    mocks.resolveRunDir.mockResolvedValue(runDir);
+
+    const result = await discoverLatestExecutionOutputs({
+      agent: 'polish',
+      model: 'deepseek',
+      inputFile: 'paper.tex',
+    });
+
+    expect(result?.executionId).toBe('exec-headless');
+    expect([...(result?.rounds.keys() ?? [])].sort((a, b) => a - b)).toEqual([
+      0, 1,
+    ]);
+    expect(mocks.resolveRunDir).toHaveBeenCalledWith('exec-headless');
+  });
+
+  it('returns null when neither the snapshot nor the run directory has outputs', async () => {
+    const emptyDir = await mkdtemp(path.join(os.tmpdir(), 'texra-latexdiff-'));
+    tempDirs.push(emptyDir);
+
+    mocks.listExecutions.mockResolvedValue([matchingExecution('exec-empty')]);
+    mocks.resolveRunDir.mockResolvedValue(emptyDir);
+
+    const result = await discoverLatestExecutionOutputs({
+      agent: 'polish',
+      model: 'deepseek',
+      inputFile: 'paper.tex',
+    });
+
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

`texra latexdiff <agent> -m <model> -i <file>` — the documented primary invocation — returns `No LaTeX diff operations available for this run.` for any run created by a headless `texra run`, even though the run's per-round outputs are on disk and `--run-id` diffs them fine.

## Root cause

`discoverLatestExecutionOutputs` matches the execution by agent/model/input but reads its outputs **only** from the `StreamSnapshotStore` (a progress-view artifact). Headless runs never persist those stream-tab snapshots, so discovery returns `null` and the orchestration falls through to the cwd-based workspace scan — which only sees files copied back into the workspace, not the per-round execution outputs. `--run-id` works because it uses `scanRunDirForOutputs` (a direct on-disk run-dir scan).

## Fix

When the stream-tab snapshot is empty, fall back to `scanRunDirForOutputs` (the same on-disk scan the `--run-id` path uses), so a headless run's outputs are discovered from its run directory. Both discovery paths now share the same on-disk source of truth. The change is additive and reuses already-proven code.

## Validation

- New regression test `src/test-kernel/latex/OutputDiscovery.vitest.mts` reproduces the headless case (matching execution, empty snapshot, on-disk `r0`/`r1` outputs) and asserts the fallback returns the outputs; plus a null case when neither source has outputs.
- Verified end-to-end against a real headless `polish` run: before, `latexdiff` reported 0 operations (`executionId: null`); the matched execution's outputs scan to 2 operations via `--run-id`, which this fix now reaches automatically.
- Existing `RunLatexdiff.vitest.mts` suite still green.

Fixes #6687

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive fallback in latexdiff output discovery reusing existing scanRunDirForOutputs; covered by new unit tests with no auth or data-model changes.
> 
> **Overview**
> Fixes **`texra latexdiff`** without `--run-id` reporting no diff operations for headless **`texra run`** executions, even when per-round outputs exist on disk.
> 
> **`discoverLatestExecutionOutputs`** still prefers stream-tab snapshots, but when that store is empty it now falls back to **`scanRunDirForOutputs`** on the matched execution’s run directory—the same on-disk path **`--run-id`** uses. Extra configured input files from the execution are passed as diff bases so multi-file runs don’t all compare against the single **`-i`** file.
> 
> Adds **`OutputDiscovery.vitest.mts`** covering the empty-snapshot + on-disk **r0/r1** case and the null case when neither source has outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a61433510fa76de4ef8e22121a37dbf15f44ab7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->