### PR TITLE
refactor: remove dead helper exports

### DIFF
--- a/packages/cli/src/commands/chatgptAuth.ts
+++ b/packages/cli/src/commands/chatgptAuth.ts
@@ -172,8 +172,6 @@ const CHATGPT_SUBCOMMANDS = {
   status: chatgptStatusCommand,
 } as const;
 
-export const CHATGPT_SUBCOMMAND_NAMES = Object.keys(CHATGPT_SUBCOMMANDS);
-
 export const chatgptAuthCommand = defineCommand({
   meta: {
     name: 'chatgpt',

--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -56,7 +56,7 @@ export function createDesktopCommandPalette({
   });
 }
 
-export function getDesktopCommandPaletteEntries({
+function getDesktopCommandPaletteEntries({
   streams = [],
   platform = getDefaultPlatform(),
 }: {

--- a/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
@@ -8,7 +8,11 @@ import Mark from 'mark.js';
 
 // Local imports - shared
 import type { HistoryItem as HistoryItemData } from '@shared/schemas';
-import { badgeStyles, commonViewStyles, designTokens } from '@shared/styles';
+import {
+  commonViewStyles,
+  designTokens,
+  searchHighlightStyles,
+} from '@shared/styles';
 import { AgentCategory } from '@shared/schemas/agent';
 import { markdownStyles } from '@shared/styles/markdownStyles';
 import { getAgentCategoryDecorator } from '@shared/utils/icons';
@@ -36,7 +40,7 @@ export class HistoryItemElement extends LitElement {
   static override styles = [
     designTokens,
     commonViewStyles,
-    ...badgeStyles,
+    searchHighlightStyles,
     historyStyles,
     metaStripStyles,
     markdownStyles,

--- a/packages/extension/src/settingsView/frontend/tabs/HistoryTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/HistoryTab.ts
@@ -4,12 +4,7 @@ import { LitElement, html, type TemplateResult, css } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 // Local imports - shared styles
-import {
-  badgeStyles,
-  commonViewStyles,
-  designTokens,
-  historyStyles,
-} from '@shared/styles';
+import { commonViewStyles, designTokens, historyStyles } from '@shared/styles';
 
 // Local imports - shared schemas
 import type { HistoryItem } from '@shared/schemas';
@@ -25,7 +20,6 @@ export class HistoryTab extends LitElement {
   static override styles = [
     designTokens,
     commonViewStyles,
-    ...badgeStyles,
     ...historyStyles,
     css`
       :host {

--- a/src/auth/tier/index.ts
+++ b/src/auth/tier/index.ts
@@ -39,10 +39,3 @@ export function getTierService(logger?: AuthServiceLogger): TierService {
   }
   return _instance;
 }
-
-/**
- * Set a custom TierService instance (for testing).
- */
-export function setTierService(service: TierService): void {
-  _instance = service;
-}

--- a/src/shared/styles/badgeStyles.ts
+++ b/src/shared/styles/badgeStyles.ts
@@ -1,13 +1,7 @@
-import { css, type CSSResult } from 'lit';
+import { css } from 'lit';
 
-// NOTE: the hand-rolled badge/pill rules formerly here (.badge, .category-badge,
-// .agent-category-badge, .tinted-badge) were retired in favor of native <wa-badge>,
-// and the dead .no-data/.loading empty-state rules in favor of renderEmptyState.
-// What remains is the search-match highlight (mark.js) used by list views.
-// TODO: rename this export to searchHighlightStyles and drop it from importers
-// that no longer render <mark> (only HistoryItemElement still needs it).
-
-const searchHighlightStyles: CSSResult = css`
+/** Search-match highlight rules for mark.js output in history item rows. */
+export const searchHighlightStyles = css`
   mark {
     background-color: var(--wa-color-editor-find-match-highlight, #ffef0b80);
     color: var(--wa-color-editor-find-match-highlight-fg, inherit);
@@ -20,5 +14,3 @@ const searchHighlightStyles: CSSResult = css`
     outline: var(--border-thin) solid var(--wa-color-focus);
   }
 `;
-
-export const badgeStyles: CSSResult[] = [searchHighlightStyles];

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -75,11 +75,10 @@ export const compactIconActionButtonStyles: CSSResult = css`
  * hidden under the spinner. Emitted by `renderIconActionButton({ busy })` —
  * the helper owns the markup, this sheet styles the class hooks.
  *
- * Exported as a focused subset and interpolated into `commonViewStyles` below
- * so the selectors have a single source of truth (mirrors
- * `compactIconActionButtonStyles`).
+ * Interpolated into `commonViewStyles` below so the selectors have a single
+ * source of truth.
  */
-export const busyIconButtonStyles: CSSResult = css`
+const busyIconButtonStyles: CSSResult = css`
   .action-icon-busy {
     position: relative;
     display: inline-flex;

--- a/src/shared/styles/index.ts
+++ b/src/shared/styles/index.ts
@@ -11,8 +11,8 @@ export { selectStyles, compactFormControlStyles } from './selectStyles';
 export { requestPanelStyles } from './requestPanelStyles';
 export { viewTabStyles, waTabThemeTokenStyles } from './viewTabStyles';
 
-// Shared list-view styles: search highlighting + empty states
-export { badgeStyles } from './badgeStyles';
+// Shared list-view styles: search highlighting
+export { searchHighlightStyles } from './badgeStyles';
 
 // History/search styles
 export {

--- a/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
@@ -28,10 +28,6 @@ interface DesktopCommandPaletteModule {
     platform?: NodeJS.Platform;
     canOpen?: () => boolean;
   }): DesktopCommandPaletteController;
-  getDesktopCommandPaletteEntries(options?: {
-    streams?: DesktopPaletteStream[];
-    platform?: NodeJS.Platform;
-  }): DesktopPaletteEntry[];
 }
 
 interface DesktopPaletteEntry {

--- a/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
@@ -30,15 +30,6 @@ interface DesktopCommandPaletteModule {
   }): DesktopCommandPaletteController;
 }
 
-interface DesktopPaletteEntry {
-  id: string;
-  label: string;
-  category: string;
-  accelerator?: string;
-  enabled: boolean;
-  unavailableReason?: string;
-}
-
 interface DesktopPaletteStream {
   name: string;
   label: string;

--- a/src/utils/system/platformPaths.ts
+++ b/src/utils/system/platformPaths.ts
@@ -17,9 +17,6 @@ import { unique } from '@utils/core';
 /** Whether the current platform is Windows (cached at module load). */
 export const IS_WINDOWS = process.platform === 'win32';
 
-/** Whether the current platform is macOS (cached at module load). */
-export const IS_MACOS = process.platform === 'darwin';
-
 // Common LaTeX tool names used across the system
 const TEX_TOOLS = ['latexdiff', 'latexindent', 'latexmk'] as const;
 


### PR DESCRIPTION
## Summary

Closes #6689.

This PR removes a small set of declaration-only exports and one stale shared style wrapper reported by the dead-code scan. The change is intentionally limited to symbols that had no remaining external importers in the repository.

## Changes

- Remove unused public exports for `CHATGPT_SUBCOMMAND_NAMES`, `IS_MACOS`, and `setTierService`.
- Make `getDesktopCommandPaletteEntries` and `busyIconButtonStyles` module-private because they are only used inside their defining modules.
- Replace the obsolete `badgeStyles` wrapper with `searchHighlightStyles`, and import that stylesheet only in `HistoryItemElement`, where the `mark.js` output is rendered.
- Update the desktop command-palette test module shape after the helper becomes private.

## Verification

- `npm test -- src/test-kernel/desktop/DesktopCommandPalette.vitest.mts src/test-kernel/settings/HistorySearchPrefilter.vitest.ts src/test-kernel/settings/HistoryHandlers.vitest.ts src/test-kernel/auth/TierService.vitest.ts src/test-kernel/cli/AuthCommand.vitest.mts src/test-kernel/cli/ChatDefaults.vitest.mts --maxWorkers=4`
- `npm run compile:fast`
- `npm run lint` (passes with existing warnings)
- `npm test -- --maxWorkers=4`
- `npm run check:dead-code -- --reporter compact --max-show-issues 180` (still reports other known candidates; the removed symbols are absent)

## Risk

Low. The removed names had no repository importers, and the only retained style rule is now applied at the component that owns the highlighted text shadow tree.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Symbols removed had no callers; styling change is a rename and import relocation with the same CSS rules still applied where highlights render.
> 
> **Overview**
> Dead-code cleanup that drops unused public symbols and tightens a few module boundaries without changing runtime behavior.
> 
> **Removed exports:** `CHATGPT_SUBCOMMAND_NAMES`, `IS_MACOS`, and `setTierService` — none had remaining importers in the repo.
> 
> **Narrowed visibility:** `getDesktopCommandPaletteEntries` is no longer exported from the desktop command palette module (only `createDesktopCommandPalette` uses it). `busyIconButtonStyles` stays inlined into `commonViewStyles` but is no longer re-exported.
> 
> **Style API rename:** The obsolete `badgeStyles` array wrapper is replaced by a direct export of `searchHighlightStyles` (mark.js `mark` / current-match rules). `HistoryTab` stops pulling those rules; only `HistoryItemElement` imports them, matching where search highlights actually render.
> 
> Desktop command-palette tests drop the now-private helper from their module typing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88460b0d4f8d3ed57711a69c2afa186c24422aa3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->