### PR TITLE
Hide external inquiry tool from CLI, keep for VS Code/desktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file.
 #### Improvements
 
 - **Leaner, non-overlapping CLI options** — trimmed redundant choices so the same thing has one spelling: `--api-mode` now accepts just `included`/`personal` (plus the `relay`/`byok` shorthands) instead of seven near-synonyms, the duplicate `texra agents inspect` is gone in favor of `texra agents show`, and `texra login` now rejects `--device` together with `--no-browser` (they are different sign-in transports) instead of silently ignoring one.
+- **External Inquiry is now VS Code / desktop only** — the human-in-the-loop "ask an external chat subscription" tool relies on the long-lived progress-view panel for pasting answers back, which the terminal does not provide, so it is hidden from every CLI run (interactive chat and headless commands alike) and no longer listed under `texra tools`. Agents running in the CLI will not attempt to dispatch external inquiries.
 
 ### Extension (VS Code)
 

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -37,6 +37,7 @@ import {
   cliTerminalStatus,
   terminalStatusExitCode,
 } from '@cli/runtime/terminalStatus';
+import { CLI_UNAVAILABLE_TOOLS } from '@cli/runtime/unavailableTools';
 import { toErrorMessage } from '@common/errors/errorMessage';
 import {
   EXECUTION_STATUS,
@@ -235,6 +236,7 @@ export function createChatSessionController(
           runtimeHost: wrapped,
           enforceCategory: true,
           approvalPromptsUnavailable: approvalsUnavailable,
+          runtimeUnavailableTools: CLI_UNAVAILABLE_TOOLS,
           onStreamResolved: (resolvedStreamId) => {
             session.streamId = resolvedStreamId;
             cliState.rootStreamId.set(resolvedStreamId);
@@ -369,6 +371,7 @@ export function createChatSessionController(
       .then(() =>
         resumeToolUseFromSnapshot(resolution.snapshot, wrapped, {
           approvalPromptsUnavailable: approvalsUnavailable,
+          runtimeUnavailableTools: CLI_UNAVAILABLE_TOOLS,
         }),
       )
       .then(() => {

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -22,9 +22,8 @@ import {
   readCliTerminalStatus,
   type ExecuteAgentResult,
 } from './terminalStatus';
+import { CLI_UNAVAILABLE_TOOLS } from './unavailableTools';
 import type { CliContext } from './cliContext';
-
-const NON_TUI_CLI_UNAVAILABLE_TOOLS = ['inquiry'] as const;
 
 export interface CliExecuteOptions {
   /** Forwarded to `runAgent`. */
@@ -161,7 +160,7 @@ export async function executeCliRequest(
       stopAfterCycle: options.stopAfterCycle,
       approvalPromptsUnavailable: approvalPromptsUnavailable(runContext),
       runtimeUnavailableTools: [
-        ...NON_TUI_CLI_UNAVAILABLE_TOOLS,
+        ...CLI_UNAVAILABLE_TOOLS,
         ...(options.runtimeUnavailableTools ?? []),
       ],
     });

--- a/packages/cli/src/runtime/unavailableTools.ts
+++ b/packages/cli/src/runtime/unavailableTools.ts
@@ -1,0 +1,14 @@
+import type { RegisteredToolName } from '@tools/registry';
+
+/**
+ * Tools hidden from every `texra` CLI run — both the headless command paths
+ * (`run`, `agents run`, `multi-agent run`) and the interactive TUI chat.
+ *
+ * The async external-inquiry flow is a VS Code / desktop feature: the user
+ * pastes an external model's answer back through the long-lived progress-view
+ * panel, possibly hours later and across host reloads. The CLI does not offer
+ * that flow, so the `inquiry` tool is excluded from the agent's effective tool
+ * list for all CLI runs. Subagents inherit this exclusion through
+ * `runtimeUnavailableTools` on the run context.
+ */
+export const CLI_UNAVAILABLE_TOOLS: readonly RegisteredToolName[] = ['inquiry'];

--- a/src/test-kernel/cli/CliTools.vitest.mts
+++ b/src/test-kernel/cli/CliTools.vitest.mts
@@ -39,8 +39,11 @@ function record(
 describe('CLI tools runtime', () => {
   it('exposes external tool definition ids', () => {
     expect(cliToolIds()).toEqual(
-      expect.arrayContaining(['codex', 'claude-agent', 'external-inquiry']),
+      expect.arrayContaining(['codex', 'claude-agent']),
     );
+    // External inquiry is a VS Code / desktop feature; the CLI hides it.
+    expect(cliToolIds()).not.toContain('external-inquiry');
+    expect(findCliToolDef('external-inquiry')).toBeUndefined();
     expect(cliToolIds()).not.toContain('texra-cli');
     expect(findCliToolDef('texra-cli')).toBeUndefined();
   });

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -422,6 +422,10 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       'No local install required. Uses your own external chat subscription through a human-in-the-loop copy/paste flow.',
     authNote: 'Uses your premium chat subscription',
     toggleable: true,
+    // VS Code / desktop only — the async paste-the-answer-back flow depends on
+    // the long-lived progress-view panel. CLI runs hide the `inquiry` tool
+    // (see CLI_UNAVAILABLE_TOOLS), so it must not appear on CLI tools surfaces.
+    hideFromCli: true,
     check: async () => true,
   },
 


### PR DESCRIPTION
## Summary

The external inquiry tool (human-in-the-loop "ask an external chat subscription") relies on VS Code's long-lived progress-view panel to receive pasted answers back from users. The CLI terminal cannot provide this flow, so the tool is now hidden from all CLI runs—both interactive chat and headless commands—and agents running in the CLI will not attempt to dispatch external inquiries.

## Issue acceptance gates

N/A (improvement identified during development)

## Single source of truth

`CLI_UNAVAILABLE_TOOLS` in `packages/cli/src/runtime/unavailableTools.ts` now owns the list of tools hidden from CLI execution. The `hideFromCli` flag on `ExternalToolDef` marks tools that should not appear on CLI tool surfaces.

## Duplication and abstraction budget

Removed the hardcoded `NON_TUI_CLI_UNAVAILABLE_TOOLS` constant from `runExecution.ts` and replaced it with the centralized `CLI_UNAVAILABLE_TOOLS` export. This eliminates duplication and makes the unavailable tools list reusable across the CLI codebase (now used in both `runExecution.ts` and `chatSessionController.ts`).

## Host impact

**Extension:** No change—external inquiry remains available in VS Code.

**Desktop:** No change—external inquiry remains available in Electron.

**CLI:** External inquiry tool is now hidden from `texra tools` output and will not be dispatched during agent execution in any CLI mode (interactive chat, `texra run`, `texra agents run`, `texra multi-agent run`).

## Scheduled refactoring

None

## Validation

- Updated test in `src/test-kernel/cli/CliTools.vitest.mts` to verify external inquiry is not exposed in CLI tool IDs and cannot be found via `findCliToolDef()`.
- Existing test suite passes with the changes.
- CHANGELOG updated to document the user-facing change.

https://claude.ai/code/session_01KjyhHmJ4LVP9j9JSdnA2U6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only capability gating with no auth or data-path changes; VS Code and desktop behavior for external inquiry is unchanged.
> 
> **Overview**
> **External Inquiry is CLI-only no longer** — the human-in-the-loop `inquiry` tool (paste answers from ChatGPT/Claude/etc.) needs the VS Code progress-view panel, so it is now unavailable on every CLI execution path and hidden from CLI tool listings.
> 
> A shared **`CLI_UNAVAILABLE_TOOLS`** list in `packages/cli/src/runtime/unavailableTools.ts` replaces the headless-only `NON_TUI_CLI_UNAVAILABLE_TOOLS` constant. Headless runs (`runExecution`) and interactive chat (`chatSessionController` for new runs and resume) both pass `runtimeUnavailableTools: CLI_UNAVAILABLE_TOOLS`, so agents and subagents never see or dispatch `inquiry` in the terminal.
> 
> **`texra tools` alignment** — the `external-inquiry` integration is marked **`hideFromCli: true`** on its external tool definition so it no longer appears alongside Codex/Claude Code in CLI tools UI, matching runtime exclusion.
> 
> CHANGELOG and **`CliTools.vitest`** assert `external-inquiry` is absent from `cliToolIds()` / `findCliToolDef`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b46e466c9185ef97abc4023b06d5ddb7905e7b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->