### PR TITLE
refactor(google): share usage/pricing math across chat and Interactions handlers

### DIFF
--- a/src/agent/modelHandlers/google/googleInteractionsUsage.ts
+++ b/src/agent/modelHandlers/google/googleInteractionsUsage.ts
@@ -3,100 +3,64 @@
  *
  * The Interactions API reports usage with snake_case totals
  * ({@link Interactions.Usage}) that differ from the camelCase
- * `GenerateContentResponseUsageMetadata` the chat handler reads. These pure
- * functions mirror `googleUsage.ts` (the chat equivalent) against the snake_case
- * shape, then reuse the same shared price/normalize machinery
- * (`computeStandardPrice` / `normalizeUsage`) — no pricing logic is duplicated.
+ * `GenerateContentResponseUsageMetadata` the chat handler reads. This module
+ * supplies only the snake_case field accessor; the token math, pricing, and
+ * normalization are shared with the chat handler via `googleUsage.ts` — no
+ * formula is duplicated.
  *
  * The handler keeps thin `computePrice` / `normalizeUsage` overrides that
  * delegate here with the model's pricing config.
  */
 
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
-import { computeStandardPrice } from '@agent/utils/priceUtils';
 
-import { normalizeUsage } from '../support/UsageNormalizer';
+import {
+  computeGooglePriceFromFields,
+  normalizeGoogleUsageFromFields,
+  type GooglePricingConfig,
+  type GoogleUsageFields,
+} from './googleUsage';
 import type { Interactions } from '@google/genai';
-import type { GooglePricingConfig } from './googleUsage';
 
 type InteractionsUsage = Interactions.Usage;
 
-interface InteractionsTokenCounts {
-  inputTokens: number;
-  outputTokens: number;
-  reasoningTokens: number;
-}
-
 /**
- * Interactions token totals.
+ * Field accessors for the snake_case Interactions usage shape.
  *
- * Mirrors the chat formula `outputTokens = candidatesTokenCount +
- * thoughtsTokenCount`: the Interactions `total_output_tokens` is the visible
- * model output (excluding thoughts), and `total_thought_tokens` is reasoning, so
- * the unified output total is their sum. This keeps reasoning tokens billed once
- * (at the output rate via `outputTokens`) and never double-counts them — the
- * shared `computeStandardPrice` is called WITHOUT a separate `reasoningTokens`
- * surcharge, exactly as the chat handler does.
- *
- * Input mirrors chat's `promptTokenCount + toolUsePromptTokenCount`:
- * `total_input_tokens + total_tool_use_tokens`.
+ * Maps onto the same unified token model as the chat handler
+ * (`outputTokens = visible output + thoughts`, input = prompt + tool-use), so
+ * reasoning tokens are billed once at the output rate and never double-counted.
  *
  * NOTE: whether `total_output_tokens` already includes thoughts is documented
  * ambiguously upstream; a real-key smoke test should confirm before relying on
  * billing accuracy (spec §6.5). If the API ever folds thoughts into
- * `total_output_tokens`, drop the `+ reasoningTokens` term here.
+ * `total_output_tokens`, drop the reasoning term in `visibleOutputTokens`'s sum
+ * (see `computeGoogleTokenCounts`).
+ *
+ * Verified live (spec §6 S1, gemini-3.5-flash 2-round run): under
+ * previous_interaction_id chaining, total_input_tokens reports the CUMULATIVE
+ * server-side context, not just the new turn's delta (turn 2 reported 79 input
+ * tokens for a 1-step delta send). That is correct for billing — the server
+ * reprocesses the retained context — so we report it as-is; no double-count.
  */
-function computeInteractionsTokenCounts(
-  usage: InteractionsUsage | null,
-): InteractionsTokenCounts {
-  if (!usage) {
-    return { inputTokens: 0, outputTokens: 0, reasoningTokens: 0 };
-  }
-
-  // Verified live (spec §6 S1, gemini-3.5-flash 2-round run): under
-  // previous_interaction_id chaining, total_input_tokens reports the CUMULATIVE
-  // server-side context, not just the new turn's delta (turn 2 reported 79 input
-  // tokens for a 1-step delta send). That is correct for billing — the server
-  // reprocesses the retained context — so we report it as-is; no double-count.
-  const promptTokens = usage.total_input_tokens ?? 0;
-  const toolUseTokens = usage.total_tool_use_tokens ?? 0;
-  const visibleOutputTokens = usage.total_output_tokens ?? 0;
-  const reasoningTokens = usage.total_thought_tokens ?? 0;
-
-  const inputTokens = promptTokens + toolUseTokens;
-
-  // Per Google's formula: output = visible output + thoughts. When the totals
-  // are unpopulated (some models in streaming), derive output from total_tokens.
-  const directOutput = visibleOutputTokens + reasoningTokens;
-  const derivedOutput =
-    usage.total_tokens !== undefined
-      ? Math.max(0, usage.total_tokens - inputTokens)
-      : 0;
-
-  const outputTokens = directOutput > 0 ? directOutput : derivedOutput;
-
-  return { inputTokens, outputTokens, reasoningTokens };
-}
+const INTERACTIONS_USAGE_FIELDS: GoogleUsageFields<InteractionsUsage> = {
+  promptTokens: (usage) => usage.total_input_tokens ?? 0,
+  toolUseTokens: (usage) => usage.total_tool_use_tokens ?? 0,
+  visibleOutputTokens: (usage) => usage.total_output_tokens ?? 0,
+  reasoningTokens: (usage) => usage.total_thought_tokens ?? 0,
+  totalTokens: (usage) => usage.total_tokens,
+  cachedTokens: (usage) => usage.total_cached_tokens ?? 0,
+};
 
 /** Computes cost based on Interactions token usage and model pricing. */
 export function computeGoogleInteractionsPrice(
   responseUsage: InteractionsUsage | null,
   config: GooglePricingConfig,
 ): number {
-  if (!responseUsage) return 0.0;
-  const { inputTokens, outputTokens } =
-    computeInteractionsTokenCounts(responseUsage);
-
-  // No reasoning surcharge: thought tokens are already part of outputTokens.
-  // total_cached_tokens is a subset of total_input_tokens, so cached reads are
-  // billed at the full input rate and rebated by computeStandardPrice.
-  return computeStandardPrice(
-    {
-      inputTokens,
-      outputTokens,
-      cachedTokens: responseUsage.total_cached_tokens ?? 0,
-    },
+  return computeGooglePriceFromFields(
+    responseUsage,
     config,
+    INTERACTIONS_USAGE_FIELDS,
   );
 }
 
@@ -106,23 +70,10 @@ export function normalizeGoogleInteractionsUsage(
   responseTimeMs: number,
   config: GooglePricingConfig,
 ): NormalizedUsage {
-  return normalizeUsage(
-    {
-      provider: 'google',
-      computePrice: (usage) => computeGoogleInteractionsPrice(usage, config),
-      extract: (usage) => {
-        const { inputTokens, outputTokens, reasoningTokens } =
-          computeInteractionsTokenCounts(usage);
-        return {
-          inputTokens,
-          outputTokens,
-          cachedTokens: usage.total_cached_tokens ?? 0,
-          reasoningTokens,
-          toolUsePromptTokens: usage.total_tool_use_tokens ?? 0,
-        };
-      },
-    },
+  return normalizeGoogleUsageFromFields(
     rawUsage,
     responseTimeMs,
+    config,
+    INTERACTIONS_USAGE_FIELDS,
   );
 }

--- a/src/agent/modelHandlers/google/googleUsage.ts
+++ b/src/agent/modelHandlers/google/googleUsage.ts
@@ -5,6 +5,13 @@
  * and price computation can be reasoned about and unit-tested without a live
  * handler instance. The handler keeps thin `computePrice` / `normalizeUsage`
  * overrides that delegate here with the model's pricing config.
+ *
+ * The token model is shared with the Interactions API (`googleInteractionsUsage.ts`).
+ * Both surfaces report the same semantics with different field names (camelCase
+ * `GenerateContentResponseUsageMetadata` here vs. snake_case `Interactions.Usage`
+ * there), so the math lives once in {@link computeGooglePriceFromFields} /
+ * {@link normalizeGoogleUsageFromFields} and each surface supplies only a
+ * {@link GoogleUsageFields} accessor.
  */
 
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
@@ -19,6 +26,28 @@ import type { GenerateContentResponseUsageMetadata } from '@google/genai';
 /** Pricing inputs the handler supplies from its `config`/`capabilities`. */
 export type GooglePricingConfig = StandardPricingConfig;
 
+/**
+ * Maps a provider-specific usage payload onto the unified Google token model.
+ *
+ * Both Google surfaces (chat `generateContent` and the Interactions API) report
+ * the same quantities under different field names; an implementation of this
+ * interface is the only thing that varies between them.
+ */
+export interface GoogleUsageFields<U> {
+  /** Prompt/input tokens (chat `promptTokenCount` / interactions `total_input_tokens`). */
+  promptTokens(usage: U): number;
+  /** Tool-use prompt tokens (`toolUsePromptTokenCount` / `total_tool_use_tokens`). */
+  toolUseTokens(usage: U): number;
+  /** Visible model output, excluding thoughts (`candidatesTokenCount` / `total_output_tokens`). */
+  visibleOutputTokens(usage: U): number;
+  /** Reasoning/thought tokens (`thoughtsTokenCount` / `total_thought_tokens`). */
+  reasoningTokens(usage: U): number;
+  /** Grand total, used to derive output when the direct fields are unpopulated. */
+  totalTokens(usage: U): number | undefined;
+  /** Cached-read tokens, a subset of input (`cachedContentTokenCount` / `total_cached_tokens`). */
+  cachedTokens(usage: U): number;
+}
+
 interface GoogleTokenCounts {
   inputTokens: number;
   outputTokens: number;
@@ -26,7 +55,7 @@ interface GoogleTokenCounts {
 }
 
 /**
- * Google token totals. Output prefers candidatesTokenCount + thoughtsTokenCount
+ * Google token totals. Output prefers visible output + reasoning
  * (candidatesTokenCount excludes thinking tokens per llm-gemini#75); when those
  * fields are unpopulated (some models in streaming) it derives output from
  * totalTokenCount - inputTokens.
@@ -36,28 +65,24 @@ interface GoogleTokenCounts {
  * (ModalityTokenCount: TEXT/IMAGE/VIDEO/AUDIO/DOCUMENT; PDF pages report under
  * IMAGE, not DOCUMENT) for modality-specific cost tracking.
  */
-function computeGoogleTokenCounts(
-  usage: GenerateContentResponseUsageMetadata | null,
+function computeGoogleTokenCounts<U>(
+  usage: U | null,
+  fields: GoogleUsageFields<U>,
 ): GoogleTokenCounts {
   if (!usage) {
     return { inputTokens: 0, outputTokens: 0, reasoningTokens: 0 };
   }
 
-  const promptTokens = usage.promptTokenCount ?? 0;
-  const toolUseTokens = usage.toolUsePromptTokenCount ?? 0;
-  const candidatesTokens = usage.candidatesTokenCount ?? 0;
-  const reasoningTokens = usage.thoughtsTokenCount ?? 0;
+  const inputTokens = fields.promptTokens(usage) + fields.toolUseTokens(usage);
+  const reasoningTokens = fields.reasoningTokens(usage);
 
-  const inputTokens = promptTokens + toolUseTokens;
-
-  // Per Google's formula: outputTokens = candidatesTokenCount + thoughtsTokenCount
+  // Per Google's formula: outputTokens = visible output + thoughts.
   // When these fields are populated, use them directly.
-  // When unpopulated (some models in streaming), derive from totalTokenCount.
-  const directOutput = candidatesTokens + reasoningTokens;
+  // When unpopulated (some models in streaming), derive from the grand total.
+  const directOutput = fields.visibleOutputTokens(usage) + reasoningTokens;
+  const total = fields.totalTokens(usage);
   const derivedOutput =
-    usage.totalTokenCount !== undefined
-      ? Math.max(0, usage.totalTokenCount - inputTokens)
-      : 0;
+    total !== undefined ? Math.max(0, total - inputTokens) : 0;
 
   // Use direct values when available; otherwise use derived calculation
   const outputTokens = directOutput > 0 ? directOutput : derivedOutput;
@@ -65,25 +90,80 @@ function computeGoogleTokenCounts(
   return { inputTokens, outputTokens, reasoningTokens };
 }
 
+/**
+ * Shared price computation for any Google usage shape.
+ *
+ * No reasoning surcharge: thought tokens are already part of outputTokens.
+ * Cached reads are a subset of input, so they are billed at the full input rate
+ * and rebated by `computeStandardPrice`.
+ */
+export function computeGooglePriceFromFields<U>(
+  responseUsage: U | null,
+  config: GooglePricingConfig,
+  fields: GoogleUsageFields<U>,
+): number {
+  if (!responseUsage) return 0.0;
+  const { inputTokens, outputTokens } = computeGoogleTokenCounts(
+    responseUsage,
+    fields,
+  );
+
+  return computeStandardPrice(
+    {
+      inputTokens,
+      outputTokens,
+      cachedTokens: fields.cachedTokens(responseUsage),
+    },
+    config,
+  );
+}
+
+/** Shared usage normalization for any Google usage shape. */
+export function normalizeGoogleUsageFromFields<U>(
+  rawUsage: U | null,
+  responseTimeMs: number,
+  config: GooglePricingConfig,
+  fields: GoogleUsageFields<U>,
+): NormalizedUsage {
+  return normalizeUsage(
+    {
+      provider: 'google',
+      computePrice: (usage) =>
+        computeGooglePriceFromFields(usage, config, fields),
+      extract: (usage) => {
+        const { inputTokens, outputTokens, reasoningTokens } =
+          computeGoogleTokenCounts(usage, fields);
+        return {
+          inputTokens,
+          outputTokens,
+          cachedTokens: fields.cachedTokens(usage),
+          reasoningTokens,
+          toolUsePromptTokens: fields.toolUseTokens(usage),
+        };
+      },
+    },
+    rawUsage,
+    responseTimeMs,
+  );
+}
+
+/** Field accessors for the camelCase chat (`generateContent`) usage shape. */
+const CHAT_USAGE_FIELDS: GoogleUsageFields<GenerateContentResponseUsageMetadata> =
+  {
+    promptTokens: (usage) => usage.promptTokenCount ?? 0,
+    toolUseTokens: (usage) => usage.toolUsePromptTokenCount ?? 0,
+    visibleOutputTokens: (usage) => usage.candidatesTokenCount ?? 0,
+    reasoningTokens: (usage) => usage.thoughtsTokenCount ?? 0,
+    totalTokens: (usage) => usage.totalTokenCount,
+    cachedTokens: (usage) => usage.cachedContentTokenCount ?? 0,
+  };
+
 /** Computes cost based on token usage and model pricing. */
 export function computeGooglePrice(
   responseUsage: GenerateContentResponseUsageMetadata | null,
   config: GooglePricingConfig,
 ): number {
-  if (!responseUsage) return 0.0;
-  const { inputTokens, outputTokens } = computeGoogleTokenCounts(responseUsage);
-
-  // No reasoning surcharge: thoughtsTokenCount is already part of outputTokens.
-  // cachedContentTokenCount is a subset of promptTokenCount, so cached reads
-  // are billed at the full input rate and rebated by computeStandardPrice.
-  return computeStandardPrice(
-    {
-      inputTokens,
-      outputTokens,
-      cachedTokens: responseUsage.cachedContentTokenCount ?? 0,
-    },
-    config,
-  );
+  return computeGooglePriceFromFields(responseUsage, config, CHAT_USAGE_FIELDS);
 }
 
 /** Normalizes Google GenAI usage data into a unified format. */
@@ -92,23 +172,10 @@ export function normalizeGoogleUsage(
   responseTimeMs: number,
   config: GooglePricingConfig,
 ): NormalizedUsage {
-  return normalizeUsage(
-    {
-      provider: 'google',
-      computePrice: (usage) => computeGooglePrice(usage, config),
-      extract: (usage) => {
-        const { inputTokens, outputTokens, reasoningTokens } =
-          computeGoogleTokenCounts(usage);
-        return {
-          inputTokens,
-          outputTokens,
-          cachedTokens: usage.cachedContentTokenCount ?? 0,
-          reasoningTokens,
-          toolUsePromptTokens: usage.toolUsePromptTokenCount ?? 0,
-        };
-      },
-    },
+  return normalizeGoogleUsageFromFields(
     rawUsage,
     responseTimeMs,
+    config,
+    CHAT_USAGE_FIELDS,
   );
 }

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -69,7 +69,6 @@ import {
   type ToolResultPayload,
 } from '../utils/toolAttachmentUtils';
 import { convertToolSchema, toGoogleTools } from '../toolConversion';
-import type { GooglePricingConfig } from './googleUsage';
 
 // Type imports
 import type { MediaFileResult } from '../support/MediaAttachmentProcessor';
@@ -652,15 +651,10 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
   // ===========================================================================
 
   computePrice(responseUsage: Usage | null): number {
-    return computeGoogleInteractionsPrice(responseUsage, this.pricingConfig());
-  }
-
-  private pricingConfig(): GooglePricingConfig {
-    return {
-      inputPrice: this.config.inputPrice,
-      outputPrice: this.config.outputPrice,
-      cacheDiscountFactor: this.capabilities.cacheDiscountFactor,
-    };
+    return computeGoogleInteractionsPrice(
+      responseUsage,
+      this.standardPricingConfig(),
+    );
   }
 
   normalizeUsage(
@@ -670,7 +664,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
     return normalizeGoogleInteractionsUsage(
       rawUsage,
       responseTimeMs,
-      this.pricingConfig(),
+      this.standardPricingConfig(),
     );
   }
 


### PR DESCRIPTION
The chat (generateContent) and Interactions usage modules implemented the
same token-counting + price + normalize pipeline, differing only in field
names (camelCase GenerateContentResponseUsageMetadata vs snake_case
Interactions.Usage). Extract the math once into a generic field-mapper core
in googleUsage.ts (GoogleUsageFields<U> + computeGooglePriceFromFields /
normalizeGoogleUsageFromFields); both surfaces now supply only a small
accessor literal.

Also drop ModelHandlerGoogleInteractions.pricingConfig(), which was a
byte-for-byte duplicate of the base ModelHandler.standardPricingConfig().

Public exports and numeric behavior are unchanged; the cross-check test
(Interactions price == chat price for equivalent token counts) still passes.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XdCJ7ToyqRBAw2YiRFNcKx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with unchanged public APIs and delegated pricing; risk is limited to accidental behavioral drift in billing math, which the PR claims is covered by existing cross-check tests.
> 
> **Overview**
> Consolidates duplicate Google **token counting, pricing, and usage normalization** that previously lived separately in chat (`googleUsage.ts`) and Interactions (`googleInteractionsUsage.ts`).
> 
> **`googleUsage.ts`** now owns the shared pipeline via a generic `GoogleUsageFields<U>` mapper plus `computeGooglePriceFromFields` / `normalizeGoogleUsageFromFields`. Chat keeps thin wrappers around a `CHAT_USAGE_FIELDS` literal; Interactions supplies only `INTERACTIONS_USAGE_FIELDS` (snake_case) and delegates to the same core—local `computeInteractionsTokenCounts` and duplicated `computeStandardPrice` / `normalizeUsage` wiring are removed.
> 
> **`ModelHandlerGoogleInteractions`** drops its private `pricingConfig()` in favor of the base `standardPricingConfig()` for usage/price calls. Public exports and billing behavior are intended to stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f90b77347ef578a77c9f41bfeb9747f9ef0f7c2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->