### PR TITLE
refactor(ui): replace render-time inline style strings with styleMap

### DIFF
--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -4,6 +4,7 @@ import '@awesome.me/webawesome/dist/components/tag/tag.js';
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
+import { styleMap } from 'lit/directives/style-map.js';
 
 // Local imports - shared styles
 import { commonViewStyles, designTokens } from '@shared/styles';
@@ -132,6 +133,7 @@ export class ToolsTab extends LitElement {
         stroke: var(--color-status-error);
         stroke-width: 4;
         stroke-linecap: round;
+        transform-origin: 50% 50%;
       }
 
       .tools-health-labels {
@@ -366,7 +368,7 @@ export class ToolsTab extends LitElement {
                   r="${r}"
                   stroke-dasharray="${circ}"
                   stroke-dashoffset="${missOffset}"
-                  style="transform: rotate(${missRotation}deg); transform-origin: 50% 50%"
+                  style=${styleMap({ transform: `rotate(${missRotation}deg)` })}
                 />`
               : nothing}
           </svg>

--- a/packages/extension/src/webview/frontend/mocks/ContextUtilizationMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/ContextUtilizationMock.ts
@@ -2,6 +2,7 @@
 import { LitElement, html, css, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { styleMap } from 'lit/directives/style-map.js';
 
 // Side-effect imports - Web Awesome components
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
@@ -111,7 +112,7 @@ export class ContextUtilizationMock extends LitElement {
         <span class="ctx-chip__bar" aria-hidden="true">
           <span
             class="ctx-chip__fill"
-            style="transform: scaleX(${scale})"
+            style=${styleMap({ transform: `scaleX(${scale})` })}
           ></span>
         </span>
         <span class="ctx-chip__numeric">${clamped}%</span>


### PR DESCRIPTION
## Summary

A UI consistency audit of the webview Lit components surfaced two places where a dynamic CSS `transform` was assembled as a raw `style="..."` string interpolated in the template. This PR converts both to Lit's `styleMap` directive — the established convention already used elsewhere in the webviews (e.g. `UsagePanel.ts`, `messageFormatters.ts`) — and moves the one static style declaration that was riding along in the inline string into the component's CSS where it belongs.

- **`ContextUtilizationMock.ts`** — the progress-bar fill's `scaleX(...)` now goes through `styleMap` instead of `style="transform: scaleX(${scale})"`.
- **`ToolsTab.ts`** (tool-health ring) — the missing-arc `rotate(...)` now goes through `styleMap`. The static `transform-origin: 50% 50%` that was bundled into the same inline string moves into the `.tools-health-ring__missing` CSS rule; only the rotation is dynamic.

Behavior-preserving: `styleMap` emits the same computed inline style as before, and the moved `transform-origin` is reinstated on the same element with the same value.

## Issue acceptance gates

No tracked issue — proactive cleanup from a UI-consistency audit.

## Single source of truth

Dynamic per-render transform values are expressed once via `styleMap` in each component's `render()`; the static `transform-origin` for the health ring now lives solely in the `.tools-health-ring__missing` CSS rule rather than being duplicated into the template's inline-style string.

## Duplication and abstraction budget

No new abstraction. Removes the ad-hoc string-built inline styles in favor of the `styleMap` directive already conventional in the webviews. No pass-through layers added.

## Host impact

Extension: Webview rendering only — `ContextUtilizationMock` (mocks gallery) and the Tools settings tab health ring render identically.

Desktop: No change (shares the same webview components; rendering identical).

CLI: None.

## Scheduled refactoring

None. The audit also noted larger opportunities (consolidating repeated flex blocks and `::part()` overrides, extracting the inline SVG ring into its own Lit component) but those overlap with in-flight CSS-standardization work (#6695, #6658) and are intentionally left out of this minimal, behavior-preserving change.

## Validation

- `npm run typecheck` — passes
- `npx eslint` on both changed files — clean
- `npx vitest run src/test-kernel/webview/MocksGalleryStyles.vitest.mts` — 3 passed

## Notes

An earlier revision of this description framed the change as an instance of CLAUDE.md's "Render-Time Workarounds (Anti-pattern)" rule. That rule specifically targets `Date.now()`/synthetic IDs/render-time dedup, not inline-style strings — so the attribution was imprecise. The change stands on its own as a `styleMap` consistency cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxSmZs8omn9fydFZdGv5pY