### PR TITLE
refactor: replace hand-rolled WSL detection with is-wsl; tidy citation rate limiter

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "identifiers-arxiv": "^0.1.1",
     "ignore": "^7.0.5",
     "is-network-error": "^1.3.2",
+    "is-wsl": "^3.1.1",
     "katex": "^0.17.0",
     "keyv": "^5.6.0",
     "ky": "^2.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       is-network-error:
         specifier: ^1.3.2
         version: 1.3.2
+      is-wsl:
+        specifier: ^3.1.1
+        version: 3.1.1
       katex:
         specifier: ^0.17.0
         version: 0.17.0

--- a/src/tools/citation/rateLimiter.ts
+++ b/src/tools/citation/rateLimiter.ts
@@ -10,14 +10,15 @@ export async function waitForRateLimit(
   apiName: string,
   minDelayMs: number,
 ): Promise<void> {
-  const existing = limiters.get(apiName);
-  if (!existing || existing.minDelayMs !== minDelayMs) {
-    limiters.set(apiName, {
+  let limiter = limiters.get(apiName);
+  if (!limiter || limiter.minDelayMs !== minDelayMs) {
+    limiter = {
       minDelayMs,
       wait: pThrottle({ limit: 1, interval: minDelayMs })(() =>
         Promise.resolve(),
       ),
-    });
+    };
+    limiters.set(apiName, limiter);
   }
-  await limiters.get(apiName)!.wait();
+  await limiter.wait();
 }

--- a/src/utils/system/wslDetect.ts
+++ b/src/utils/system/wslDetect.ts
@@ -1,31 +1,23 @@
 /**
  * WSL (Windows Subsystem for Linux) detection.
  *
+ * Delegates to the maintained `is-wsl` package rather than hand-parsing
+ * `/proc/version`: it also checks `os.release()`, the WSL-specific
+ * `/proc/sys/fs/binfmt_misc/WSLInterop` and `/run/WSL` markers, and excludes
+ * containers running on a WSL host (via `is-inside-container`) so a devcontainer
+ * isn't misreported as WSL. `is-wsl` computes its result once at import, so the
+ * previous module-level cache is no longer needed.
+ *
  * This module is intentionally free of VS Code dependencies so it can be
  * imported from VS Code-free zones like `src/tools/`.
  */
 
-import { readFileSync } from 'node:fs';
-
-/** Cached WSL detection result (null = not yet checked). */
-let wslDetected: boolean | null = null;
+import isWsl from 'is-wsl';
 
 /**
- * Detect whether we are running inside Windows Subsystem for Linux (WSL).
- * Checks /proc/version for the "microsoft" or "WSL" marker strings that
- * Microsoft's WSL kernel injects.  Result is cached after the first call.
+ * Whether we are running inside Windows Subsystem for Linux (WSL).
+ * Kept as a function so existing call sites (`isWSL()`) stay unchanged.
  */
 export function isWSL(): boolean {
-  if (wslDetected !== null) return wslDetected;
-  if (process.platform !== 'linux') {
-    wslDetected = false;
-    return false;
-  }
-  try {
-    const version = readFileSync('/proc/version', 'utf-8');
-    wslDetected = /microsoft|wsl/i.test(version);
-  } catch {
-    wslDetected = false;
-  }
-  return wslDetected;
+  return isWsl;
 }


### PR DESCRIPTION
## Summary

Two small "reinvented wheel" cleanups surfaced by a codebase scan for ad-hoc utilities that a well-maintained npm package can do better:

1. **WSL detection** — `src/utils/system/wslDetect.ts` hand-parsed `/proc/version` for the strings `microsoft`/`wsl` and cached the result in a module-level variable. This is now delegated to the maintained [`is-wsl`](https://www.npmjs.com/package/is-wsl) package (~2.4M downloads/week). Beyond the regex match, `is-wsl` also inspects `os.release()`, the WSL-specific `/proc/sys/fs/binfmt_misc/WSLInterop` and `/run/WSL` markers, and excludes containers running on a WSL host (via `is-inside-container`) — so a devcontainer on a WSL machine is no longer misreported as WSL, which matters for the "run this inside WSL" tool hints in `externalToolDefs.ts`. The `isWSL()` function wrapper is kept, so every call site is untouched; `is-wsl` computes once at import, retiring the manual cache.

2. **Citation rate limiter** — `src/tools/citation/rateLimiter.ts` did a redundant second `Map.get(apiName)!` lookup right after `set()`. Reuse the freshly created limiter object instead. Pure tidy-up; no behavior change.

### Candidates evaluated and intentionally *not* changed

- **`exponential-backoff` for `PollingSourceBase`** — rejected. The GitHub polling layer is timer-driven and stateful: it computes a per-subscription `skipPollUntilMs` timestamp, it does not own a retry loop. `exponential-backoff`'s `backOff(request, opts)` wants to own the retry loop, so adopting it would force a worse architecture. Left as-is.
- **`he` for `src/shared/utils/xmlEscape.ts`** — rejected. `he` is already a dependency, but `he.encode()` over-escapes for the minimal-XML contexts these helpers target (agent-core `<subagent-result>` emission). The bespoke 4–5-char escapers are correct and intentional.

## Issue acceptance gates

No linked issue — opportunistic refactor from a dependency-hygiene scan.

## Single source of truth

WSL detection now has a single source of truth in the `is-wsl` package, reached through the thin `isWSL()` wrapper in `wslDetect.ts`. The citation rate-limiter state remains owned by the module-level `limiters` map in `rateLimiter.ts`.

## Duplication and abstraction budget

Removes hand-rolled `/proc/version` parsing + manual caching (delegated to `is-wsl`) and an avoidable duplicate `Map` lookup. No new abstraction or pass-through layer added; the `isWSL()` wrapper that already existed is preserved to keep call sites stable.

## Host impact

Extension: WSL detection used by `workspaceInfo` (platform string) and `externalToolDefs` (tool hints); behavior preserved/improved. No API change.

Desktop: Shares the same VS Code-free `@utils/system` module; no host-specific change.

CLI: Shares the same module; no host-specific change.

## Scheduled refactoring

None.

## Validation

- `npm run compile:fast` — builds clean; ESM-only `is-wsl` bundles via esbuild.
- `npx eslint` on both changed files — passes.
- `npx vitest run src/test-kernel/tools/ArxivSearchTool.vitest.ts` — passes (covers the rate-limiter import).
- `npm run typecheck` — no new errors in the changed files. Pre-existing, unrelated errors remain in `packages/cli` and `packages/desktop` (missing `diff`/`citty`/`semver`/`picocolors`/`electron`/`react/jsx-runtime` in this environment's partial install); the lockfile change here is purely additive (`is-wsl` only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CM9an4vve6dhreaPv7Nm8h)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small dependency swap and a no-op refactor in the rate limiter; WSL reporting may change only at the edges (e.g. devcontainers), with no API changes.
> 
> **Overview**
> **WSL detection** now goes through the **`is-wsl`** dependency instead of reading `/proc/version` and keeping a local cache. The existing **`isWSL()`** API is unchanged; detection should be more reliable (extra WSL markers, **`os.release()`**) and devcontainers on a WSL host should no longer be treated as WSL, which affects platform labeling in **`workspaceInfo`** and WSL-specific install hints in **`externalToolDefs`**.
> 
> **Citation rate limiting** in **`rateLimiter.ts`** reuses the limiter object after create/update instead of a second **`Map.get`**, with no intended behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc61725854781ff530ad01f458d7b2e5d2b5508b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->