### PR TITLE
refactor: simplify two data structures flagged in design review

### DIFF
--- a/src/agent/core/usage/RunUsageAccumulator.ts
+++ b/src/agent/core/usage/RunUsageAccumulator.ts
@@ -51,13 +51,19 @@ export type RunUsageAccumulatorJSON = z.output<
 /**
  * Legacy persisted format: an unbounded `normalizedSnapshots` array instead of
  * `latestUsage`. Only the most-recent snapshot's usage is needed, so the array
- * is collapsed to its last element and the rest discarded. This arm is required
- * to carry `normalizedSnapshots`, so it only matches genuinely-legacy data and
- * canonical/empty inputs fall through to the canonical schema below.
+ * is collapsed to its last element and the rest discarded. This arm requires
+ * `normalizedSnapshots`, so it only matches genuinely-legacy data; canonical
+ * and empty inputs fall through to the canonical schema below.
+ *
+ * A hybrid payload carrying BOTH a canonical `latestUsage` and snapshots keeps
+ * its canonical value — the transform prefers it over the snapshot-derived
+ * value, preserving the prior preprocess behavior (which skipped migration when
+ * `latestUsage` was already present) and avoiding overwrites with stale data.
  */
 const LegacyRunUsageAccumulatorSchema = z
   .object({
     totals: RunUsageTotalsSchema.prefault({}),
+    latestUsage: NormalizedUsageSchema.nullish(),
     normalizedSnapshots: z.array(
       z.object({ usage: NormalizedUsageSchema.optional() }),
     ),
@@ -65,7 +71,8 @@ const LegacyRunUsageAccumulatorSchema = z
   .transform(
     (legacy): RunUsageAccumulatorJSON => ({
       totals: legacy.totals,
-      latestUsage: legacy.normalizedSnapshots.at(-1)?.usage ?? null,
+      latestUsage:
+        legacy.latestUsage ?? legacy.normalizedSnapshots.at(-1)?.usage ?? null,
     }),
   );
 

--- a/src/agent/core/usage/RunUsageAccumulator.ts
+++ b/src/agent/core/usage/RunUsageAccumulator.ts
@@ -59,13 +59,20 @@ export type RunUsageAccumulatorJSON = z.output<
  * its canonical value — the transform prefers it over the snapshot-derived
  * value, preserving the prior preprocess behavior (which skipped migration when
  * `latestUsage` was already present) and avoiding overwrites with stale data.
+ *
+ * Each snapshot is parsed tolerantly (`.catch`): the old preprocess only ever
+ * read the last element's `usage`, so a malformed *earlier* snapshot must not
+ * fail the whole arm (which would drop the latest valid usage on resume). A
+ * malformed `usage` degrades to `null` rather than rejecting the payload.
  */
 const LegacyRunUsageAccumulatorSchema = z
   .object({
     totals: RunUsageTotalsSchema.prefault({}),
     latestUsage: NormalizedUsageSchema.nullish(),
     normalizedSnapshots: z.array(
-      z.object({ usage: NormalizedUsageSchema.optional() }),
+      z
+        .object({ usage: NormalizedUsageSchema.nullish() })
+        .catch({ usage: null }),
     ),
   })
   .transform(

--- a/src/agent/core/usage/RunUsageAccumulator.ts
+++ b/src/agent/core/usage/RunUsageAccumulator.ts
@@ -56,9 +56,11 @@ export type RunUsageAccumulatorJSON = z.output<
  * and empty inputs fall through to the canonical schema below.
  *
  * A hybrid payload carrying BOTH a canonical `latestUsage` and snapshots keeps
- * its canonical value — the transform prefers it over the snapshot-derived
- * value, preserving the prior preprocess behavior (which skipped migration when
- * `latestUsage` was already present) and avoiding overwrites with stale data.
+ * its canonical value. The transform uses key-presence semantics (NOT value
+ * nullish): an explicit `latestUsage` — even `null` — means the state already
+ * migrated, so it wins; only an absent key falls back to the snapshot-derived
+ * value. This exactly matches the prior preprocess guard (`'latestUsage' in
+ * raw`) and avoids reviving stale snapshot data over a canonical value.
  *
  * Each snapshot is parsed tolerantly (`.catch`): the old preprocess only ever
  * read the last element's `usage`, so a malformed *earlier* snapshot must not
@@ -78,8 +80,14 @@ const LegacyRunUsageAccumulatorSchema = z
   .transform(
     (legacy): RunUsageAccumulatorJSON => ({
       totals: legacy.totals,
+      // Key-presence, not value-nullish: `.nullish()` parses an absent key as
+      // `undefined` and an explicit `null` as `null`, so `!== undefined` keeps
+      // an explicit null (already-migrated state) and only an absent key falls
+      // back to the latest snapshot.
       latestUsage:
-        legacy.latestUsage ?? legacy.normalizedSnapshots.at(-1)?.usage ?? null,
+        legacy.latestUsage !== undefined
+          ? legacy.latestUsage
+          : (legacy.normalizedSnapshots.at(-1)?.usage ?? null),
     }),
   );
 

--- a/src/agent/core/usage/RunUsageAccumulator.ts
+++ b/src/agent/core/usage/RunUsageAccumulator.ts
@@ -30,54 +30,55 @@ const RunUsageTotalsSchema = z.object({
 export type RunUsageTotals = z.infer<typeof RunUsageTotalsSchema>;
 
 /**
- * Schema for RunUsageAccumulator JSON serialization.
- * Uses .prefault() for input normalization before validation.
+ * Canonical schema for RunUsageAccumulator JSON serialization.
  *
  * `latestUsage` replaces the old unbounded `normalizedSnapshots` array —
- * only the most-recent round's usage is needed at runtime. The preprocess
- * migrates legacy persisted data (with `normalizedSnapshots`) by extracting
- * the last element, so existing sessions resume without data loss.
+ * only the most-recent round's usage is needed at runtime.
  */
-export const RunUsageAccumulatorJSONSchema = z.preprocess(
-  (raw) => {
-    if (
-      raw &&
-      typeof raw === 'object' &&
-      !Array.isArray(raw) &&
-      !('latestUsage' in raw) &&
-      'normalizedSnapshots' in raw &&
-      Array.isArray((raw as Record<string, unknown>).normalizedSnapshots)
-    ) {
-      const snapshots = (raw as Record<string, unknown>)
-        .normalizedSnapshots as unknown[];
-      const last = snapshots.at(-1);
-      const usage =
-        last &&
-        typeof last === 'object' &&
-        !Array.isArray(last) &&
-        'usage' in (last as Record<string, unknown>)
-          ? (last as Record<string, unknown>).usage
-          : null;
-      return {
-        ...(raw as Record<string, unknown>),
-        latestUsage: usage ?? null,
-      };
-    }
-    return raw;
-  },
-  z.object({
-    totals: RunUsageTotalsSchema.prefault({}),
-    latestUsage: NormalizedUsageSchema.nullable().prefault(null),
-  }),
-);
+const RunUsageAccumulatorCanonicalSchema = z.object({
+  totals: RunUsageTotalsSchema.prefault({}),
+  latestUsage: NormalizedUsageSchema.nullable().prefault(null),
+});
 
 /**
  * Output type for RunUsageAccumulator serialization.
  * Uses z.output<> to get the type after parsing (totals fully resolved).
  */
 export type RunUsageAccumulatorJSON = z.output<
-  typeof RunUsageAccumulatorJSONSchema
+  typeof RunUsageAccumulatorCanonicalSchema
 >;
+
+/**
+ * Legacy persisted format: an unbounded `normalizedSnapshots` array instead of
+ * `latestUsage`. Only the most-recent snapshot's usage is needed, so the array
+ * is collapsed to its last element and the rest discarded. This arm is required
+ * to carry `normalizedSnapshots`, so it only matches genuinely-legacy data and
+ * canonical/empty inputs fall through to the canonical schema below.
+ */
+const LegacyRunUsageAccumulatorSchema = z
+  .object({
+    totals: RunUsageTotalsSchema.prefault({}),
+    normalizedSnapshots: z.array(
+      z.object({ usage: NormalizedUsageSchema.optional() }),
+    ),
+  })
+  .transform(
+    (legacy): RunUsageAccumulatorJSON => ({
+      totals: legacy.totals,
+      latestUsage: legacy.normalizedSnapshots.at(-1)?.usage ?? null,
+    }),
+  );
+
+/**
+ * Entry schema handling both formats in one place (per the backward-compat
+ * convention in CLAUDE.md). The legacy arm is tried first because it requires
+ * `normalizedSnapshots`; canonical and empty payloads only match the second
+ * arm, so all downstream code sees one canonical shape.
+ */
+export const RunUsageAccumulatorJSONSchema = z.union([
+  LegacyRunUsageAccumulatorSchema,
+  RunUsageAccumulatorCanonicalSchema,
+]);
 
 // ============================================================================
 // Standalone functions operating on RunUsageAccumulatorJSON

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -50,59 +50,58 @@ interface ModelAvailabilityStatus {
   requiresKey: boolean;
 }
 
-const AVAILABILITY_STATUS: Record<
+/**
+ * Per-kind status fields. `kind` is intentionally omitted here — the record key
+ * is the single source of truth and `availabilityStatus()` reattaches it.
+ */
+const AVAILABILITY_STATUS_FIELDS: Record<
   ModelAvailabilityKind,
-  ModelAvailabilityStatus
+  Omit<ModelAvailabilityStatus, 'kind'>
 > = {
   'openrouter-key': {
-    kind: 'openrouter-key',
     label: 'OpenRouter key',
     available: true,
     requiresKey: false,
   },
-  'provider-key': {
-    kind: 'provider-key',
-    label: 'API key set',
-    available: true,
-    requiresKey: false,
-  },
+  'provider-key': { label: 'API key set', available: true, requiresKey: false },
   'included-access': {
-    kind: 'included-access',
     label: 'Included access',
     available: true,
     requiresKey: false,
   },
   'missing-key': {
-    kind: 'missing-key',
     label: 'Missing API key',
     available: false,
     requiresKey: true,
   },
   'not-included': {
-    kind: 'not-included',
     label: 'Not included',
     available: false,
     requiresKey: false,
   },
   'included-login-required': {
-    kind: 'included-login-required',
     label: 'Login required',
     available: false,
     requiresKey: false,
   },
   'subscription-access': {
-    kind: 'subscription-access',
     label: 'ChatGPT subscription',
     available: true,
     requiresKey: false,
   },
   'relay-quota-exhausted': {
-    kind: 'relay-quota-exhausted',
     label: 'Relay quota exhausted',
     available: false,
     requiresKey: false,
   },
 };
+
+/** Resolve a full availability status from its kind. */
+function availabilityStatus(
+  kind: ModelAvailabilityKind,
+): ModelAvailabilityStatus {
+  return { kind, ...AVAILABILITY_STATUS_FIELDS[kind] };
+}
 
 /** Check whether a model is available through a personal provider or OpenRouter key. */
 async function getPersonalAccessKindForModel(
@@ -166,36 +165,36 @@ async function resolveModelAvailability(
     ctx.codexSignedIn &&
     shouldUseCodexSubscription(config, ctx.useOpenRouter)
   ) {
-    return AVAILABILITY_STATUS['subscription-access'];
+    return availabilityStatus('subscription-access');
   }
 
   // OpenRouter routing is intentionally outside included access; a configured
   // OpenRouter key is the only ready state for these calls.
   if (shouldRouteModelThroughOpenRouter(config, ctx.useOpenRouter)) {
     return ctx.hasOpenRouter
-      ? AVAILABILITY_STATUS['openrouter-key']
-      : AVAILABILITY_STATUS['missing-key'];
+      ? availabilityStatus('openrouter-key')
+      : availabilityStatus('missing-key');
   }
 
   if (ctx.relayQuotaExhausted) {
-    return AVAILABILITY_STATUS['relay-quota-exhausted'];
+    return availabilityStatus('relay-quota-exhausted');
   }
 
   if (canUseIncludedAccessForModel(model, config, ctx)) {
-    return AVAILABILITY_STATUS['included-access'];
+    return availabilityStatus('included-access');
   }
 
   // Fall back to personal API keys when the user opted out of included access
   // OR they aren't authenticated for it (avoids showing every model as
   // disabled for unauthenticated users with the default setting).
   if (ctx.useIncludedAccess && ctx.hasServerAccess) {
-    return AVAILABILITY_STATUS['not-included'];
+    return availabilityStatus('not-included');
   }
 
   const personalAccess = await getPersonalAccessKindForModel(config, ctx);
   return personalAccess
-    ? AVAILABILITY_STATUS[personalAccess]
-    : AVAILABILITY_STATUS['missing-key'];
+    ? availabilityStatus(personalAccess)
+    : availabilityStatus('missing-key');
 }
 
 async function buildAvailabilityContext(

--- a/src/test-kernel/schemas/SchemaMigrations.vitest.ts
+++ b/src/test-kernel/schemas/SchemaMigrations.vitest.ts
@@ -61,6 +61,17 @@ describe('RunUsageAccumulatorJSONSchema — legacy normalizedSnapshots migration
     expect(result.latestUsage).toMatchObject(usageFixture);
   });
 
+  it('keeps an explicit null latestUsage over snapshots in a hybrid payload', () => {
+    const result = RunUsageAccumulatorJSONSchema.parse({
+      latestUsage: null,
+      normalizedSnapshots: [{ round: 0, usage: usageFixture }],
+    });
+
+    // Key-presence semantics: an explicit null means already-migrated, so the
+    // snapshot must NOT revive a value. Matches the old `'latestUsage' in raw`.
+    expect(result.latestUsage).toBeNull();
+  });
+
   it('preserves the last valid usage when an earlier snapshot is malformed', () => {
     const result = RunUsageAccumulatorJSONSchema.parse({
       normalizedSnapshots: [

--- a/src/test-kernel/schemas/SchemaMigrations.vitest.ts
+++ b/src/test-kernel/schemas/SchemaMigrations.vitest.ts
@@ -61,6 +61,18 @@ describe('RunUsageAccumulatorJSONSchema — legacy normalizedSnapshots migration
     expect(result.latestUsage).toMatchObject(usageFixture);
   });
 
+  it('preserves the last valid usage when an earlier snapshot is malformed', () => {
+    const result = RunUsageAccumulatorJSONSchema.parse({
+      normalizedSnapshots: [
+        { round: 0, usage: { bogus: 'not a usage' } },
+        { round: 1, usage: usageFixture },
+      ],
+    });
+
+    // A malformed earlier snapshot must not drop the latest valid usage.
+    expect(result.latestUsage).toMatchObject(usageFixture);
+  });
+
   it('parses empty object to zero totals and null latestUsage', () => {
     const result = RunUsageAccumulatorJSONSchema.parse({});
 

--- a/src/test-kernel/schemas/SchemaMigrations.vitest.ts
+++ b/src/test-kernel/schemas/SchemaMigrations.vitest.ts
@@ -50,6 +50,17 @@ describe('RunUsageAccumulatorJSONSchema — legacy normalizedSnapshots migration
     expect(result.latestUsage).toMatchObject(usageFixture);
   });
 
+  it('keeps canonical latestUsage when a hybrid payload also has snapshots', () => {
+    const stale = { ...usageFixture, inputTokens: 1 };
+    const result = RunUsageAccumulatorJSONSchema.parse({
+      latestUsage: usageFixture,
+      normalizedSnapshots: [{ round: 0, usage: stale }],
+    });
+
+    // The canonical latestUsage must win over the snapshot-derived value.
+    expect(result.latestUsage).toMatchObject(usageFixture);
+  });
+
   it('parses empty object to zero totals and null latestUsage', () => {
     const result = RunUsageAccumulatorJSONSchema.parse({});
 


### PR DESCRIPTION
## Summary

A data-structure design review of the codebase surfaced several over-complex patterns. This PR lands the two smallest, highest-confidence, behavior-preserving simplifications from that review:

1. **`RunUsageAccumulator`** — replaces the hand-rolled `z.preprocess()` legacy migration with the `z.union()` + `.transform()` backward-compatibility pattern that CLAUDE.md mandates. The old code inspected the raw object with a chain of manual type guards (`typeof === 'object'`, `!Array.isArray`, `'x' in raw`, casts to `Record<string, unknown>`) to migrate the legacy `normalizedSnapshots` array into the canonical `latestUsage` field. The new version expresses the legacy shape as its own schema whose `.transform()` collapses the array to its last element, and composes both formats with `z.union()`.

2. **`computeModelOptions`** — removes the redundant `kind` field that was repeated in all 8 `AVAILABILITY_STATUS` entries. The record key already carries the kind, so it was duplicated as both key and value. A small `availabilityStatus(kind)` helper reattaches it on read.

The broader high/medium findings from the review (e.g. discriminated unions for `ExternalInquiryPermissionSchema`, `ToolResultPayloadSchema`, and `RunContext`; typing `AgentDataclass.settings`/`prompts`) touch many call sites and change behavior, so they are intentionally left for separate focused PRs.

## Issue acceptance gates

No tracked issue — this PR originates from an ad-hoc design review. Acceptance: both refactors preserve behavior (existing migration tests pass), typecheck and lint are clean.

## Single source of truth

- Usage-accumulator serialization now has one canonical schema (`RunUsageAccumulatorCanonicalSchema`); the legacy arm transforms into that shape, so all downstream code sees a single canonical structure rather than a preprocessed intermediate.
- The `ModelAvailabilityKind` record key is now the sole source of truth for a status's kind; `availabilityStatus()` derives the full object from it.

## Duplication and abstraction budget

- Removed the per-entry `kind:` duplication (8 occurrences) in `AVAILABILITY_STATUS`.
- Removed the bespoke type-guard/cast block in the usage preprocess in favor of schema-expressed validation.
- New abstractions are minimal: `availabilityStatus()` owns the key→status reattachment invariant; `LegacyRunUsageAccumulatorSchema` owns the legacy→canonical migration. Neither is a pass-through layer.

## Host impact

Extension: No behavior change (internal schema + lookup-table refactor).

Desktop: No behavior change.

CLI: No behavior change.

## Scheduled refactoring

Follow-up: the larger review findings (discriminated unions for permission/tool-result/run-context schemas, typing untyped `Record<string, unknown>` agent config buckets) remain as candidates for separate PRs. None blocking.

## Validation

- `npm run typecheck` — clean
- `npx vitest run src/test-kernel/schemas/SchemaMigrations.vitest.ts` — 8/8 pass (covers the usage-accumulator legacy migration and idempotency)
- `npx eslint` on both changed files — clean
- Model availability / options Vitest suites — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZQmDy8dYnc1qVSw3HrLjd

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZQmDy8dYnc1qVSw3HrLjd)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal schema and lookup-table refactors with expanded migration tests; session usage resume semantics are intentionally preserved.
> 
> **Overview**
> **Run usage persistence** moves legacy `normalizedSnapshots` handling from a hand-rolled `z.preprocess()` block to the project’s **`z.union()` + legacy `.transform()`** pattern. Canonical shape is `RunUsageAccumulatorCanonicalSchema`; `LegacyRunUsageAccumulatorSchema` collapses snapshots to the last `usage`, keeps **key-presence** semantics so hybrid payloads prefer explicit `latestUsage` (including `null`) over stale snapshots, and tolerantly parses bad snapshot entries so resume does not drop valid latest usage.
> 
> **Model options** drops duplicated `kind` on each `AVAILABILITY_STATUS` entry: status metadata lives in `AVAILABILITY_STATUS_FIELDS` keyed by `ModelAvailabilityKind`, and **`availabilityStatus(kind)`** reattaches `kind` at read sites—no change to availability logic.
> 
> Tests add coverage for hybrid/null-latest and malformed snapshot rows in `SchemaMigrations.vitest.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b29f551f6a9b0e0fe1ff7197d098ef146aa0a4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->