### PR TITLE
fix(google): translate Interactions terminal status to canonical stop reason

### DIFF
--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -68,9 +68,9 @@ import {
   type ToolResultPayload,
 } from '../utils/toolAttachmentUtils';
 import { convertToolSchema, toGoogleTools } from '../toolConversion';
+import { GOOGLE_FINISH } from '../types/StopReasonTypes';
 
 // Type imports
-import { GOOGLE_FINISH } from '../types/StopReasonTypes';
 import type { MediaFileResult } from '../support/MediaAttachmentProcessor';
 import type { ProviderStopReason } from '../types/StopReasonTypes';
 import type {

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -70,6 +70,7 @@ import {
 import { convertToolSchema, toGoogleTools } from '../toolConversion';
 
 // Type imports
+import { GOOGLE_FINISH } from '../types/StopReasonTypes';
 import type { MediaFileResult } from '../support/MediaAttachmentProcessor';
 import type { ProviderStopReason } from '../types/StopReasonTypes';
 import type {
@@ -923,12 +924,28 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
 
     let responseText = replacementEngine.applyAll(rawText);
     const usage = responseObject.usage;
-    const stopReason: ProviderStopReason = responseObject.status ?? 'completed';
+    // Map the Interactions terminal *status* to the canonical Google chat
+    // FinishReason the shared stop/continue logic understands (mirrors the
+    // OpenAI Responses handler at extractResponse). `checkStopConditions` keys
+    // `endTurn` on GOOGLE_FINISH.STOP and `shouldContinue` /
+    // `isTokenLimitStopReason` key truncation on GOOGLE_FINISH.MAX_TOKENS; the
+    // raw 'completed' / 'incomplete' status strings match neither, so a clean
+    // completion ending on the document tag would be misread as
+    // `shouldStop && !endTurn` — i.e. a user cancellation — and its
+    // already-generated output discarded. Non-terminal statuses (e.g.
+    // 'requires_action' for tool-call rounds) pass through unchanged.
+    const status = responseObject.status ?? 'completed';
+    const stopReason: ProviderStopReason =
+      status === 'completed'
+        ? GOOGLE_FINISH.STOP
+        : status === 'incomplete'
+          ? GOOGLE_FINISH.MAX_TOKENS
+          : status;
 
     // If the model completed naturally without the end tag, append it (mirrors
-    // the chat handler's STOP behavior, keyed on the terminal `completed` status).
+    // the chat handler's STOP behavior, keyed on the terminal completion).
     if (
-      stopReason === 'completed' &&
+      stopReason === GOOGLE_FINISH.STOP &&
       endTag &&
       responseText.length > 0 &&
       !responseText.endsWith(endTag)
@@ -1003,14 +1020,15 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
     newResponse: string,
     agentSetting: AgentSetting,
   ): boolean {
-    // "incomplete" is the Interactions truncation status (analogous to chat's
+    // The Interactions truncation status ('incomplete') is normalized to
+    // GOOGLE_FINISH.MAX_TOKENS in extractResponse (analogous to chat's
     // MAX_TOKENS): the response was cut short by the output budget.
-    const truncated = stopReason === 'incomplete';
+    const truncated = stopReason === GOOGLE_FINISH.MAX_TOKENS;
     const containsEndTag = hasEndTag(agentSetting, newResponse);
 
     if (truncated && !containsEndTag) {
       this.logger.debug(
-        `Should continue: incomplete status and end tag '${agentSetting.endTag}' is missing.`,
+        `Should continue: truncated (MAX_TOKENS) and end tag '${agentSetting.endTag}' is missing.`,
       );
       return true;
     }

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsMessages.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsMessages.vitest.ts
@@ -7,6 +7,7 @@ import {
 
 import type { AgentTrace } from '@agent/trace';
 import { ModelHandlerGoogleInteractions } from '@agent/modelHandlers/google/modelHandlerGoogleInteractions';
+import { GOOGLE_FINISH } from '@agent/modelHandlers/types/StopReasonTypes';
 import type { Interactions } from '@google/genai';
 
 type Step = Interactions.Step;
@@ -278,6 +279,52 @@ describe('ModelHandlerGoogleInteractions message construction', () => {
     expect(extracted.text).toContain('answer body');
     expect(extracted.text).not.toContain('ignore me');
     expect(extracted.text.endsWith('</doc>')).toBe(true);
-    expect(extracted.stopReason).toBe('completed');
+    // The Interactions 'completed' status is normalized to the canonical Google
+    // STOP finish reason so shared stop logic reads it as a natural end-of-turn.
+    expect(extracted.stopReason).toBe(GOOGLE_FINISH.STOP);
+  });
+
+  it('maps a completed interaction to endTurn (not a spurious cancellation)', () => {
+    // Regression: a background/non-streaming Interactions response that finished
+    // cleanly on the document end tag was returning the raw 'completed' status,
+    // which is not in `endTurnReasons` — so checkStopConditions yielded
+    // endTurn=false while encounterDocumentTag forced shouldStop=true. The
+    // ResponseCycle then read `shouldStop && !endTurn` as a user cancellation
+    // and discarded the already-generated output. The status must normalize to
+    // GOOGLE_FINISH.STOP so endTurn=true.
+    const handler = createHandler();
+    const response = {
+      id: 'int',
+      status: 'completed',
+      steps: [
+        {
+          type: 'model_output',
+          content: [{ type: 'text', text: 'body</doc>' }],
+        },
+      ],
+    } as never;
+
+    const { stopReason, text } = handler.extractResponse(response, '</doc>');
+    const setting = { documentTag: 'doc', endTag: '</doc>' } as never;
+    const round = { continuationCount: 0 } as never;
+    const global = {
+      usageAccumulator: {
+        totals: {
+          firstInputTokens: 100,
+          totalInputTokens: 100,
+          totalOutputTokens: 50,
+        },
+      },
+    } as never;
+
+    const { endTurn, shouldStop } = handler.checkStopConditions(
+      stopReason,
+      text,
+      round,
+      global,
+      setting,
+    );
+    expect(shouldStop).toBe(true);
+    expect(endTurn).toBe(true);
   });
 });

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsStreaming.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsStreaming.vitest.ts
@@ -8,6 +8,7 @@ import {
 import type { AgentTrace } from '@agent/trace';
 import type { AgentWorkspaceState } from '@agent/core/execution/AgentWorkspaceState';
 import { ModelHandlerGoogleInteractions } from '@agent/modelHandlers/google/modelHandlerGoogleInteractions';
+import { GOOGLE_FINISH } from '@agent/modelHandlers/types/StopReasonTypes';
 import type { Interactions } from '@google/genai';
 
 type StreamRecord = {
@@ -211,8 +212,10 @@ describe('ModelHandlerGoogleInteractions streaming', () => {
 
     // Truncation is surfaced as `incomplete`, not silently `completed`.
     expect(result.response.status).toBe('incomplete');
+    // extractResponse normalizes the 'incomplete' status to the canonical
+    // MAX_TOKENS finish reason the shared continuation logic keys on.
     expect(handler.extractResponse(result.response, '').stopReason).toBe(
-      'incomplete',
+      GOOGLE_FINISH.MAX_TOKENS,
     );
   });
 


### PR DESCRIPTION
## Problem

A Google **Interactions**-mode run (flag `texra.model.useGoogleInteractionsAPI`) that **completed successfully** had its output silently discarded and was reported as `cancelled`.

Observed live: a `criticize@gemini31p` run on a paper appendix polled in background mode, returned `status=completed` with the full annotated document **written to `executions/<id>/r0/output.xml`** (clean `</document>` end tag, ~38KB), then immediately logged `Response cycle cancelled by user`. The run reported `✓ criticize cancelled`, `outputFiles=[]`, `edits=[]`. It reproduced identically across two runs (146s and 233s). Background mode only made it *visible* (long silent poll); the defect hits any Interactions completion ending on the document tag.

## Root cause — an incomplete handler port

A model handler's contract is to translate its provider's native terminal signal into the shared **canonical** stop-reason vocabulary (`ANTHROPIC_STOP` / `OPENAI_CHAT_FINISH` / `GOOGLE_FINISH`). Every sibling handler does this — notably `ModelHandlerOpenAIResponse.extractResponse`, which maps its Responses `status` (`completed`/else) to `OPENAI_CHAT_FINISH.STOP`/`LENGTH`.

`ModelHandlerGoogleInteractions` did **not** translate — it leaked the raw Interaction `status` (`'completed'` / `'incomplete'`) into the shared layer. The shared logic only understands the canonical vocabulary:

- `ModelHandler.checkStopConditions` keys `endTurn` on `GOOGLE_FINISH.STOP` (`'STOP'`) — `'completed'` ∉ the list → `endTurn=false`.
- The `</document>` end tag forces `shouldStop=true`.
- `ResponseCycleNode` reads `shouldStop && !endTurn` as the "stop without committing" sentinel → the finished round is dropped (no snapshot commit) and the run finalizes as `cancelled`.

So a completed turn was indistinguishable from a user cancellation purely because its stop reason was never translated.

## Fix

Complete the port. In `extractResponse`, map the Interaction status to the canonical Google finish reason (mirrors the OpenAI Responses handler):

- `completed → GOOGLE_FINISH.STOP` → `endTurn=true` (natural end of turn)
- `incomplete → GOOGLE_FINISH.MAX_TOKENS` → recognized as truncation by `shouldContinue` / `isTokenLimitStopReason`, so continuation works
- everything else (e.g. `requires_action` tool rounds) passes through unchanged

`shouldContinue` now keys on `GOOGLE_FINISH.MAX_TOKENS` instead of the raw `'incomplete'`.

### Why not import an SDK enum
Checked `@google/genai` 2.9.0: `InteractionStatus` is an **internal, non-exported** string-literal union with a `(string & {})` escape hatch and **no runtime enum** (genai.d.ts:7620) — nothing to import. The handler already derives the *type* via `Interactions.Interaction['status']`. `GOOGLE_FINISH` is deliberately SDK-free string constants (`StopReasonTypes.ts`) so the shared stop-reason utilities don't pull in the Google SDK; importing the chat `FinishReason` enum there would break that boundary.

## Tests
- Updated `GoogleInteractionsMessages` / `GoogleInteractionsStreaming` assertions for the mapped reasons.
- Added a `checkStopConditions` regression test: a completed interaction ending on the document tag yields `endTurn=true` (not a spurious cancellation).
- `npm run typecheck` clean; Google Interactions suite **44 passed / 4 skipped** (skipped = live real-key tests).

## Noted follow-up (out of scope)
`ResponseCycleNode.exec` infers `cancelled` from the lossy proxy `shouldStop && !endTurn` rather than the authoritative interrupt signal (`checkInterruption()`, already computed in `ResponseCycleFlow`). That proxy is also true for empty responses and token/continuation-limit stops, so it remains a latent fragility for any future contract gap. Hardening it (sourcing `cancelled` from the real interrupt signal without disturbing the empty-response/limit halt semantics) is a separate shared-flow change worth doing on its own.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches response-cycle stop/continue behavior for the Interactions handler; wrong mapping could still mis-handle truncation or tool rounds, but scope is localized and covered by regression tests.
> 
> **Overview**
> Fixes **successful Google Interactions runs being dropped as “cancelled”** by mapping Interaction `status` to the shared `GOOGLE_FINISH` vocabulary in `extractResponse` (same pattern as OpenAI Responses).
> 
> **`completed` → `GOOGLE_FINISH.STOP`** so `checkStopConditions` sets `endTurn=true` when the document end tag stops the round. **`incomplete` → `GOOGLE_FINISH.MAX_TOKENS`** so truncation continuation logic applies; other statuses (e.g. `requires_action`) are unchanged. **`shouldContinue`** now keys on `MAX_TOKENS` instead of the raw `'incomplete'` string.
> 
> Tests assert the mapped stop reasons and add a regression that a completed interaction ending on the end tag yields `endTurn=true` and `shouldStop=true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd517e828990869e6588a4a532d1212b5b9657b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->