### PR TITLE
fix(progressView): cap proposal Approve width + add Super Yolo caret

### DIFF
--- a/packages/extension/src/progressView/frontend/components/ApproveSplitButton.ts
+++ b/packages/extension/src/progressView/frontend/components/ApproveSplitButton.ts
@@ -1,8 +1,9 @@
-/** Approve control with an optional "Yolo (this session)" split-menu. */
+/** Approve control with an optional "Yolo" / "Super Yolo" split-menu. */
 
 // Third-party imports
 import { css, html, LitElement, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { when } from 'lit/directives/when.js';
 
 // Side-effect imports - register WA components
 import '@awesome.me/webawesome/dist/components/button/button.js';
@@ -12,11 +13,14 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
 // Local imports - shared styles + helpers
 import { commonViewStyles, designTokens } from '@shared/styles';
+import { createEvent } from '@shared/utils/events';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 
-/** Internal dropdown-item value for the session-bypass entry. */
+/** Internal dropdown-item value for the edit/bash session-bypass entry. */
 const YOLO_VALUE = 'approve-session';
+/** Internal dropdown-item value for the proposal super-yolo entry. */
+const SUPER_YOLO_VALUE = 'approve-super-yolo';
 
 /**
  * Approve control for approval prompts, used declaratively:
@@ -28,13 +32,15 @@ const YOLO_VALUE = 'approve-session';
  *     @approve-session=${onYolo}
  *   ></approve-split-button>
  *
- * When `canBypass` is false it renders a plain Approve button. When true it
- * becomes a split button: the main click emits `approve`; the ▾ caret opens a
- * menu whose "Yolo (this session)" item emits `approve-session`. Selection is
- * handled via Web Awesome's `wa-select` (Enter/Space dispatch `wa-select`, not a
- * DOM click on the item), so the menu stays keyboard-accessible. Layout/colors
- * are scoped here; outer width is governed by the host via the inherited
- * `--action-button-basis` so it matches the surrounding action row.
+ * With no bypass flags it renders a plain Approve button. When `canBypass`
+ * (edit/bash prompts) or `canSuperYolo` (agent proposals) is set it becomes a
+ * split button: the main click emits `approve`; the ▾ caret opens a menu whose
+ * "Yolo (this session)" item emits `approve-session` and whose "Super Yolo (this
+ * session)" item emits `approve-super-yolo`. Selection is handled via Web
+ * Awesome's `wa-select` (Enter/Space dispatch `wa-select`, not a DOM click on
+ * the item), so the menu stays keyboard-accessible. Layout/colors are scoped
+ * here; the host is width-capped to match the `.action-button` rule in
+ * `requestPanelStyles` (#6658) so Approve stays button-sized like its siblings.
  */
 @customElement('approve-split-button')
 export class ApproveSplitButton extends LitElement {
@@ -42,11 +48,15 @@ export class ApproveSplitButton extends LitElement {
     designTokens,
     commonViewStyles,
     css`
+      /* Mirror the .action-button cap (requestPanelStyles, #6658): hug content
+         and width-cap so Approve stays button-sized instead of growing to fill
+         the action row like its Reject/Setup siblings. min-width: auto keeps the
+         label (plus caret) from clipping. */
       :host {
         display: inline-flex;
-        flex: 1 1 var(--action-button-basis, 8rem);
-        min-width: 0;
-        max-width: 100%;
+        flex: 0 1 auto;
+        min-width: auto;
+        max-width: min(14rem, 100%);
       }
 
       .approve-split-main {
@@ -103,8 +113,11 @@ export class ApproveSplitButton extends LitElement {
   /** Tooltip / aria-label for the main Approve button. */
   @property({ attribute: false }) approveTitle = '';
 
-  /** When true, surface the "Yolo (this session)" split menu. */
+  /** When true, surface the edit/bash "Yolo (this session)" menu item. */
   @property({ type: Boolean }) canBypass = false;
+
+  /** When true, surface the proposal "Super Yolo (this session)" menu item. */
+  @property({ type: Boolean }) canSuperYolo = false;
 
   override render(): TemplateResult {
     const approveButton = renderLabeledActionButton({
@@ -115,7 +128,7 @@ export class ApproveSplitButton extends LitElement {
       className: 'approve-split-main',
       onClick: () => this.emit('approve'),
     });
-    if (!this.canBypass) {
+    if (!this.canBypass && !this.canSuperYolo) {
       return approveButton;
     }
     return html`
@@ -134,13 +147,22 @@ export class ApproveSplitButton extends LitElement {
             size="small"
             type="button"
             aria-label="More approve options"
-            title="Approve and stop asking for edits & bash this session (a)"
+            title="Approve and stop asking this session (a)"
           >
             ${waIcon('chevron-down')}
           </wa-button>
-          <wa-dropdown-item value=${YOLO_VALUE}>
-            ${waIcon('shield')} Yolo (this session)
-          </wa-dropdown-item>
+          ${when(
+            this.canBypass,
+            () => html`<wa-dropdown-item value=${YOLO_VALUE}>
+              ${waIcon('shield')} Yolo (this session)
+            </wa-dropdown-item>`,
+          )}
+          ${when(
+            this.canSuperYolo,
+            () => html`<wa-dropdown-item value=${SUPER_YOLO_VALUE}>
+              ${waIcon('rocket')} Super Yolo (this session)
+            </wa-dropdown-item>`,
+          )}
         </wa-dropdown>
       </div>
     `;
@@ -149,16 +171,19 @@ export class ApproveSplitButton extends LitElement {
   private handleSelect = (event: CustomEvent<{ item: HTMLElement }>): void => {
     const value =
       (event.detail?.item as HTMLElement & { value?: string })?.value ?? '';
-    // The menu has a single actionable item; ignore anything else defensively.
     if (value === YOLO_VALUE) {
       this.emit('approve-session');
+    } else if (value === SUPER_YOLO_VALUE) {
+      this.emit('approve-super-yolo');
     }
   };
 
-  private emit(type: 'approve' | 'approve-session'): void {
-    this.dispatchEvent(
-      new CustomEvent(type, { bubbles: true, composed: true }),
-    );
+  private emit(
+    type: 'approve' | 'approve-session' | 'approve-super-yolo',
+  ): void {
+    // Dispatch via the shared typed factory (bubbles + composed) like every
+    // other ProgressView component, not a hand-rolled CustomEvent.
+    this.dispatchEvent(createEvent(type));
   }
 }
 

--- a/packages/extension/src/progressView/frontend/components/ApproveSplitButton.ts
+++ b/packages/extension/src/progressView/frontend/components/ApproveSplitButton.ts
@@ -153,15 +153,17 @@ export class ApproveSplitButton extends LitElement {
           </wa-button>
           ${when(
             this.canBypass,
-            () => html`<wa-dropdown-item value=${YOLO_VALUE}>
-              ${waIcon('shield')} Yolo (this session)
-            </wa-dropdown-item>`,
+            () =>
+              html`<wa-dropdown-item value=${YOLO_VALUE}>
+                ${waIcon('shield')} Yolo (this session)
+              </wa-dropdown-item>`,
           )}
           ${when(
             this.canSuperYolo,
-            () => html`<wa-dropdown-item value=${SUPER_YOLO_VALUE}>
-              ${waIcon('rocket')} Super Yolo (this session)
-            </wa-dropdown-item>`,
+            () =>
+              html`<wa-dropdown-item value=${SUPER_YOLO_VALUE}>
+                ${waIcon('rocket')} Super Yolo (this session)
+              </wa-dropdown-item>`,
           )}
         </wa-dropdown>
       </div>

--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -47,6 +47,7 @@ import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
 
 // Local imports - base class
 import { BaseFeedbackPanel } from './BaseFeedbackPanel';
+import { APPROVE_SUPER_YOLO_ACTION } from '../events';
 import { processMarkdownContent } from '../formatters/markdownRenderer';
 import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 import type { PermissionState } from '../permissionState';
@@ -92,6 +93,29 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
       return true;
     }
     return false;
+  }
+
+  // Proposals carry their own bypass affordance ("Super Yolo"), not the
+  // edit/bash session bypass. Override the base Approve button to surface the
+  // super-yolo caret (canBypass stays false) and override the shared `a`
+  // accelerator to trigger it. A proposal always has a streamId, so the menu
+  // always applies.
+  protected override renderApproveButton(approveTitle: string): TemplateResult {
+    return html`
+      <approve-split-button
+        .approveTitle=${approveTitle}
+        .canBypass=${false}
+        .canSuperYolo=${true}
+        @approve=${() => this.emitAction('approve')}
+        @approve-super-yolo=${() => this.emitAction(APPROVE_SUPER_YOLO_ACTION)}
+      ></approve-split-button>
+    `;
+  }
+
+  protected override handleApproveSessionKey(): boolean {
+    if (this.showFeedback) return false;
+    this.emitAction(APPROVE_SUPER_YOLO_ACTION);
+    return true;
   }
 
   override render(): TemplateResult {
@@ -292,7 +316,9 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
   // ===========================================================================
 
   protected override emitAction(action: string, feedback?: string): void {
-    if (action !== 'approve') {
+    // Super Yolo approves this proposal too, so it carries the same model/agent
+    // dropdown overrides as a plain approve.
+    if (action !== 'approve' && action !== APPROVE_SUPER_YOLO_ACTION) {
       super.emitAction(action, feedback);
       return;
     }

--- a/packages/extension/src/progressView/frontend/eventHandlers.ts
+++ b/packages/extension/src/progressView/frontend/eventHandlers.ts
@@ -338,14 +338,16 @@ export function handlePermissionAction(
       // stream — mirroring the edit/bash "Yolo (this session)" decomposition. It
       // never reaches the backend proposal protocol (action enum stays
       // approve|reject|setup). Enable bypass BEFORE settling the approval:
-      // webview messages are FIFO and TOGGLE_SUPER_YOLO_BYPASS sets the
+      // webview messages are FIFO and ENABLE_SUPER_YOLO_BYPASS sets the
       // per-stream bypass synchronously, so it lands before approve unblocks the
-      // agent and the next proposal can't race ahead and re-prompt. A visible
-      // proposal prompt means super-yolo is currently OFF (a bypassed stream
-      // auto-approves and never prompts), so TOGGLE reliably turns it ON.
+      // agent and the next proposal can't race ahead and re-prompt. Use the
+      // idempotent ENABLE (force-on), not the TOGGLE: super-yolo can be turned on
+      // from the stream header while this prompt is still visible (that doesn't
+      // auto-resolve the open proposal), and a toggle would then flip bypass back
+      // OFF here — the opposite of "enable". Mirrors edit/bash ENABLE_APPROVAL_BYPASS.
       const isSuperYolo = action === APPROVE_SUPER_YOLO_ACTION;
       if (isSuperYolo) {
-        postMessage(PROGRESS_VIEW_COMMANDS.TOGGLE_SUPER_YOLO_BYPASS, {
+        postMessage(PROGRESS_VIEW_COMMANDS.ENABLE_SUPER_YOLO_BYPASS, {
           stream: permission.data.streamId,
         });
       }

--- a/packages/extension/src/progressView/frontend/eventHandlers.ts
+++ b/packages/extension/src/progressView/frontend/eventHandlers.ts
@@ -21,7 +21,7 @@ import {
 import { removePrompt, resolvedProposalIds } from './slices/permissionSlice';
 import { updateToolUseState } from './stateUtils';
 import { clearInquiryDraft } from './components/ExternalInquiryPanel';
-import { APPROVE_SESSION_ACTION } from './events';
+import { APPROVE_SESSION_ACTION, APPROVE_SUPER_YOLO_ACTION } from './events';
 import type {
   FilterEventDetail,
   FollowupCommandDetail,
@@ -332,10 +332,26 @@ export function handlePermissionAction(
         permission.data.streamId,
       );
       break;
-    case PERMISSION_KIND.PROPOSAL:
+    case PERMISSION_KIND.PROPOSAL: {
+      // "Super Yolo (this session)" approves this proposal like a normal approve
+      // and enables per-stream delegated-task auto-approval for the rest of the
+      // stream — mirroring the edit/bash "Yolo (this session)" decomposition. It
+      // never reaches the backend proposal protocol (action enum stays
+      // approve|reject|setup). Enable bypass BEFORE settling the approval:
+      // webview messages are FIFO and TOGGLE_SUPER_YOLO_BYPASS sets the
+      // per-stream bypass synchronously, so it lands before approve unblocks the
+      // agent and the next proposal can't race ahead and re-prompt. A visible
+      // proposal prompt means super-yolo is currently OFF (a bypassed stream
+      // auto-approves and never prompts), so TOGGLE reliably turns it ON.
+      const isSuperYolo = action === APPROVE_SUPER_YOLO_ACTION;
+      if (isSuperYolo) {
+        postMessage(PROGRESS_VIEW_COMMANDS.TOGGLE_SUPER_YOLO_BYPASS, {
+          stream: permission.data.streamId,
+        });
+      }
       postMessage(PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION, {
         proposalId: permission.data.proposalId,
-        action,
+        action: isSuperYolo ? 'approve' : action,
         feedback,
         model: modelOverride,
         agent: agentOverride,
@@ -351,6 +367,7 @@ export function handlePermissionAction(
         resolvedProposalIds.add(permission.data.proposalId);
       }
       break;
+    }
     case PERMISSION_KIND.PLAN_APPROVAL:
       postMessage(PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION, {
         approvalId: permission.data.approvalId,

--- a/packages/extension/src/progressView/frontend/events.ts
+++ b/packages/extension/src/progressView/frontend/events.ts
@@ -57,6 +57,17 @@ export type FollowupCommandDetail = WorkflowFollowupFormData;
  */
 export const APPROVE_SESSION_ACTION = 'approveSession';
 
+/**
+ * Frontend-only panel action emitted by the "Super Yolo (this session)" item on
+ * the agent-proposal Approve caret. Like {@link APPROVE_SESSION_ACTION},
+ * `handlePermissionAction` decomposes it — into a normal proposal approve plus a
+ * per-stream super-yolo bypass enable (`TOGGLE_SUPER_YOLO_BYPASS`) — so it never
+ * reaches the backend proposal protocol (whose action enum stays
+ * `approve | reject | setup`). Single source of truth shared by the panel that
+ * emits it and the handler that consumes it.
+ */
+export const APPROVE_SUPER_YOLO_ACTION = 'approveSuperYolo';
+
 export interface PermissionActionDetail {
   permission: PermissionState;
   action: string;

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -229,6 +229,26 @@ export function createProgressViewCommandHandlers(
           : 'Delegated task auto-approval disabled for this stream.',
       );
     },
+    // Inline "Super Yolo (this session)" proposal button: force the
+    // delegated-task auto-approval bypass ON. Idempotent like
+    // ENABLE_APPROVAL_BYPASS, so selecting it (or the `a` shortcut) on a
+    // still-visible proposal can never invert an already-on bypass back off the
+    // way TOGGLE_SUPER_YOLO_BYPASS would (e.g. when super-yolo was turned on
+    // from the stream header while this prompt was open). Mirrors the toggle's
+    // enabled branch: edit bypass rides along only if not already on, bash
+    // silently.
+    [PROGRESS_VIEW_COMMANDS.ENABLE_SUPER_YOLO_BYPASS]: async (data) => {
+      proposalApprovalState.setBypass(data.stream, true, runtimeHost);
+      if (!isApprovalBypassedForStream(data.stream)) {
+        setToolEditApprovalSessionBypass(data.stream, true, runtimeHost);
+      }
+      setBashApprovalSessionBypass(data.stream, true, runtimeHost, {
+        silent: true,
+      });
+      await showInfo?.(
+        'Delegated task auto-approval enabled for this stream.',
+      );
+    },
 
     [PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION]: (data) => {
       const handled = approval.handleToolEditApprovalAction(data);

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -245,9 +245,7 @@ export function createProgressViewCommandHandlers(
       setBashApprovalSessionBypass(data.stream, true, runtimeHost, {
         silent: true,
       });
-      await showInfo?.(
-        'Delegated task auto-approval enabled for this stream.',
-      );
+      await showInfo?.('Delegated task auto-approval enabled for this stream.');
     },
 
     [PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION]: (data) => {

--- a/src/shared/ipc/progressViewCommands.ts
+++ b/src/shared/ipc/progressViewCommands.ts
@@ -67,6 +67,7 @@ export const PROGRESS_VIEW_COMMANDS = {
   USER_QUESTION_ACTION: 'userQuestionAction',
   RESTORE_PROPOSAL_CONFIG: 'restoreProposalConfig',
   TOGGLE_SUPER_YOLO_BYPASS: 'toggleSuperYoloBypass',
+  ENABLE_SUPER_YOLO_BYPASS: 'enableSuperYoloBypass',
   GOAL_ACTIVE_UPDATED: 'goalActiveUpdated',
 
   OPEN_MEMORY_VIEW: 'openMemoryView',

--- a/src/shared/schemas/progressView/inbound.ts
+++ b/src/shared/schemas/progressView/inbound.ts
@@ -174,6 +174,14 @@ const ToggleSuperYoloBypassMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.TOGGLE_SUPER_YOLO_BYPASS),
 });
 
+// Set-on (idempotent) super-yolo enable, the proposal counterpart to
+// ENABLE_APPROVAL_BYPASS: the inline "Super Yolo (this session)" prompt button
+// means "enable", never "flip", so it can't invert an already-on bypass that
+// was turned on from the stream header while the prompt was still visible.
+const EnableSuperYoloBypassMessageSchema = StreamScopedBaseSchema.extend({
+  command: z.literal(PROGRESS_VIEW_COMMANDS.ENABLE_SUPER_YOLO_BYPASS),
+});
+
 // Set-on (idempotent) bypass enable, distinct from the shield's toggle: the
 // inline "Yolo (this session)" prompt button means "enable", never "flip".
 const EnableApprovalBypassMessageSchema = StreamScopedBaseSchema.extend({
@@ -373,6 +381,7 @@ export const ProgressViewInboundMessageSchema = z.discriminatedUnion(
     ToolEditApprovalActionMessageSchema,
     ToggleToolEditApprovalBypassMessageSchema,
     ToggleSuperYoloBypassMessageSchema,
+    EnableSuperYoloBypassMessageSchema,
     EnableApprovalBypassMessageSchema,
     BashApprovalActionMessageSchema,
     AgentProposalActionMessageSchema,


### PR DESCRIPTION
## What & why

Two fixes to the **Agent proposal** card in the ProgressView.

### 1. Approve button no longer stretches full-width
The proposal's Approve button is the `<approve-split-button>` custom element. PR #6658 capped request-panel action buttons via `.action-button { max-width: min(14rem, 100%) }`, but that rule targets the inner button inside the component's **shadow DOM** — it can't govern the host element. The host still used `flex: 1 1 var(--action-button-basis, 8rem)`, so it grew to fill the action row while Reject/Setup stayed capped.

Fix: cap the `:host` to mirror #6658 (`flex: 0 1 auto; min-width: auto; max-width: min(14rem, 100%)`). The `--action-button-basis` variable was already undefined (subsumed by #6658); this removed its last fallback reference.

| Before | After |
|---|---|
| Approve stretches across the whole card | Approve is button-sized, grouped with Reject/Setup |

### 2. Super Yolo caret on the proposal Approve
Super Yolo (per-stream auto-approval of delegated proposals) already exists, toggled from the stream header. The edit/bash Approve already has a split-menu caret ("Yolo (this session)") that approves **and** enables bypass. This adds the same affordance to proposals: a 🚀 **"Super Yolo (this session)"** item (and the `a` accelerator) that **approves this proposal AND enables super-yolo bypass** for the stream.

Decomposed entirely in the frontend handler — `TOGGLE_SUPER_YOLO_BYPASS` is posted **before** the approve (webview messages are FIFO, so bypass lands before the agent unblocks and no later proposal can race a re-prompt). The backend proposal action enum stays `approve | reject | setup` — **no schema change**.

## Changes
- `ApproveSplitButton.ts` — host width cap; new `canSuperYolo` prop; caret shows when `canBypass || canSuperYolo`; "Super Yolo" item emits a new `approve-super-yolo` event. Rendered with the `when` directive and dispatched via the shared `createEvent` factory to match house Lit conventions.
- `events.ts` — `APPROVE_SUPER_YOLO_ACTION` frontend-only constant (decomposed by the handler, like `APPROVE_SESSION_ACTION`).
- `ProposalRequestPanel.ts` — overrides `renderApproveButton` to surface the caret, routes `a` to it, and carries model/agent dropdown overrides through the super-yolo approve.
- `eventHandlers.ts` — PROPOSAL case posts `TOGGLE_SUPER_YOLO_BYPASS` then a normal `approve`.

## Verification
- `tsc --noEmit` clean (root × 2 + `packages/extension`).
- Manual: on an Agent proposal, Approve is button-sized with a ▾ caret → "Super Yolo (this session)"; selecting it approves and flips the stream into delegated-task auto-approval (toast confirms; header shield reflects ON). Edit/bash "Yolo" prompts unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches per-stream approval bypass ordering and proposal settlement, but follows the established Yolo decomposition and keeps backend proposal actions as approve|reject|setup only.
> 
> **Overview**
> Fixes the **agent proposal** card so Approve no longer stretches across the action row, and adds a **Super Yolo (this session)** path on the Approve split menu (plus the `a` shortcut on proposals).
> 
> **Approve sizing:** `approve-split-button` `:host` flex is changed to hug content with `max-width: min(14rem, 100%)`, matching the request-panel `.action-button` cap that could not apply inside the custom element’s shadow DOM.
> 
> **Super Yolo on proposals:** `ApproveSplitButton` gains `canSuperYolo` and a rocket menu item that emits `approve-super-yolo`; events go through `createEvent`. `ProposalRequestPanel` overrides the approve control (`canSuperYolo` only), maps `a` to `APPROVE_SUPER_YOLO_ACTION`, and passes model/agent overrides for super-yolo the same as a normal approve.
> 
> **Handler plumbing:** Frontend-only `APPROVE_SUPER_YOLO_ACTION` is decomposed like edit/bash Yolo: post **`ENABLE_SUPER_YOLO_BYPASS`** (idempotent force-on, not toggle) **before** `AGENT_PROPOSAL_ACTION` with `approve`, so bypass is set before the agent unblocks. New IPC command + Zod schema and a shared `ProgressViewCommandHandlers` entry mirror the existing `ENABLE_APPROVAL_BYPASS` / super-yolo toggle side effects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbd7cc678e7cc91a340f238af03d3d09dec7d4aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->