### PR TITLE
fix(reflection): derive round cancellation from the interrupt signal, not a flag proxy

### DIFF
--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -120,7 +120,19 @@ export class ResponseCycleNode<C = unknown> extends Node<
           lastError: cycleShared.lastError,
         };
       }
-      if (cycleShared.shouldStop && !cycleShared.endTurn) {
+      // A round is `cancelled` only when the run was genuinely interrupted —
+      // sourced from the authoritative interrupt signal, the same one
+      // `RoundPersistedFlow` already uses for its run-outcome, round-loop, and
+      // step-loop decisions (resolveOutcome / shouldContinueNextRound /
+      // executeRoundSteps). The previous `shouldStop && !endTurn` proxy
+      // conflated three distinct cases — genuine interrupt, empty response, and
+      // a completed response whose stop reason wasn't recognized as end-of-turn
+      // — so any non-interrupt stop without `endTurn` discarded an
+      // already-written round (e.g. a token/continuation-limit stop carrying
+      // real output, or any provider whose terminal reason isn't yet mapped to
+      // the canonical end-turn vocabulary). The `!endTurn` guard preserves a
+      // cleanly-finished round even if an interrupt races in at completion.
+      if (this.services.checkInterruption() && !cycleShared.endTurn) {
         return { outcome: 'cancelled' };
       }
       return { outcome: 'completed', endTurn: cycleShared.endTurn };

--- a/src/test-kernel/agent/ResponseCycleCancellation.vitest.ts
+++ b/src/test-kernel/agent/ResponseCycleCancellation.vitest.ts
@@ -1,0 +1,120 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Scripted state the mocked ResponseCycleFlow writes back onto the cycle shared
+// object, so each test controls the post-run `shouldStop` / `endTurn` flags.
+const flowState = vi.hoisted(() => ({ shouldStop: false, endTurn: false }));
+
+// Replace the inner cycle flow with a stub that just applies the scripted flags.
+// This isolates ResponseCycleNode's outcome *classification* from the full
+// model-invocation pipeline.
+vi.mock('@agent/core/flows/ResponseCycleFlow', () => ({
+  createResponseCycleFlow: () => ({
+    setServices() {},
+    async run(shared: { shouldStop: boolean; endTurn: boolean }) {
+      shared.shouldStop = flowState.shouldStop;
+      shared.endTurn = flowState.endTurn;
+    },
+  }),
+}));
+
+vi.mock('@agent/core/flows/CycleServices', () => ({
+  withModelClient: async (services: unknown) => services,
+}));
+
+// Local imports - reflection flow
+import { ResponseCycleNode } from '@agent/implementations/flows/reflection/nodes/ResponseCycleNode';
+import type { ReflectionFlowShared } from '@agent/implementations/flows/reflection/ReflectionFlowState';
+import type { ReflectionServices } from '@agent/implementations/flows/reflection/ReflectionServices';
+
+// Local imports - agent state
+import {
+  AgentRunStateSnapshotSchema,
+  ConversationRoundStateSnapshotSchema,
+} from '@agent/core/execution/AgentState';
+import { AgentWorkspaceState } from '@agent/core/execution/AgentWorkspaceState';
+
+// Local imports - shared schemas
+import type { AgentFileLocation } from '@shared/schemas';
+
+const outputLocation: AgentFileLocation = {
+  kind: 'workspace',
+  absolutePath: '/tmp/output.xml',
+  relativePath: 'output.xml',
+};
+
+function reflectionShared(): ReflectionFlowShared {
+  return {
+    currentRound: 0,
+    totalRounds: 2,
+    workspaceSnapshot: AgentWorkspaceState.emptySnapshot(),
+    context: {
+      messages: [],
+      prefill: '',
+      stateRoundSnapshot: ConversationRoundStateSnapshotSchema.parse({
+        roundIndex: 0,
+      }),
+    },
+    outputLocation: null,
+    conversation: [],
+    runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
+    roundStateSnapshots: [],
+    roundOutputs: [],
+    continueRounds: true,
+    endTurn: false,
+  };
+}
+
+function makeNode(checkInterruption: () => boolean): ResponseCycleNode {
+  return new ResponseCycleNode().setServices({
+    getOutputFileLocation: async () => outputLocation,
+    checkInterruption,
+    modelHandler: {
+      initializeOutputAndPrefill: async () => [false, []],
+    },
+    config: {},
+    setting: {},
+  } as unknown as ReflectionServices);
+}
+
+async function runCycle(checkInterruption: () => boolean) {
+  const node = makeNode(checkInterruption);
+  const prep = await node.prep(reflectionShared());
+  return node.exec(prep);
+}
+
+describe('ResponseCycleNode outcome classification', () => {
+  it('does NOT cancel a stop-without-end-of-turn when the run is not interrupted', async () => {
+    // The regression: a round that stopped (e.g. a completed response whose
+    // terminal reason was not recognized as end-of-turn, or a token/continuation
+    // limit carrying real output) used to be discarded as `cancelled` via the
+    // `shouldStop && !endTurn` proxy. It must now complete so its output is kept.
+    flowState.shouldStop = true;
+    flowState.endTurn = false;
+
+    const result = await runCycle(() => false);
+
+    expect(result.outcome).toBe('completed');
+  });
+
+  it('cancels only when the run is genuinely interrupted', async () => {
+    flowState.shouldStop = true;
+    flowState.endTurn = false;
+
+    const result = await runCycle(() => true);
+
+    expect(result.outcome).toBe('cancelled');
+  });
+
+  it('keeps a cleanly completed round even if an interrupt races in at completion', async () => {
+    flowState.shouldStop = true;
+    flowState.endTurn = true;
+
+    const result = await runCycle(() => true);
+
+    expect(result.outcome).toBe('completed');
+    if (result.outcome === 'completed') {
+      expect(result.endTurn).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

`ResponseCycleNode.exec` classified a reflection round as `cancelled` from the **lossy proxy** `shouldStop && !endTurn`:

```ts
if (cycleShared.shouldStop && !cycleShared.endTurn) {
  return { outcome: 'cancelled' };
}
```

But `shouldStop` is set true by three structurally different situations:

1. a **genuine user interrupt** (`ResponsePrepNode.post`, `ResponseContinuationNode`’s interrupt branch),
2. an **empty model response** (`ResponseProcessNode.post`, `!processedResponse`),
3. a **completed response** whose terminal stop reason wasn’t in the canonical `endTurnReasons` list (so `endTurn=false`) while the `</document>` end tag forced `shouldStop=true`.

Only case 1 is a cancellation. Cases 2–3 are not — yet they took the `cancelled` branch, which sets `continueRounds=false` and **skips committing the round’s snapshot**, so an already-written `output.xml` was discarded and the whole run finalized as `cancelled` (`RoundPersistedFlow.resolveOutcome`: `cancelled: checkInterruption() || !continueRounds`).

This is the underlying landmine behind the Google Interactions `completed`-status discard (fixed separately in the sibling PR): any non-interrupt stop without a recognized end-of-turn — a **token/continuation-limit stop carrying real output**, or **any provider whose terminal reason isn’t yet mapped** to the canonical vocabulary — silently loses output.

## Fix

Source the `cancelled` outcome from the **authoritative interrupt signal**, `checkInterruption()` — the *same single source of truth* `RoundPersistedFlow` already uses everywhere else:

- `resolveOutcome` → `cancelled: checkInterruption() || !continueRounds`
- `shouldContinueNextRound` → `!checkInterruption()`
- `executeRoundSteps` → `if (checkInterruption()) { continueRounds = false; break }`

```ts
if (this.services.checkInterruption() && !cycleShared.endTurn) {
  return { outcome: 'cancelled' };
}
return { outcome: 'completed', endTurn: cycleShared.endTurn };
```

The `!endTurn` guard is kept so a cleanly-finished round survives an interrupt that races in exactly at completion. Non-interrupt stops now `complete` and commit their output; the run still finalizes as `cancelled` via `resolveOutcome` whenever an interrupt is actually present. Net effect: a round that produced committable output can no longer be thrown away unless the user genuinely interrupted.

### Behavior delta
- **Limit/unrecognized-stop stops with output** → previously the whole round was discarded and the run reported `cancelled`; now the run finalizes `completed` and the workspace snapshot / `accumulatedOutput` are preserved. Note: per-round output-file *extraction* in `OutputNode` remains gated on `endTurn` (`OutputNode.ts:94`) and is **unchanged** here — surfacing a round's `output.xml` as finalized round outputs still requires a real end-of-turn (which is what the sibling stop-reason mapping, #6709, restores for Google). This PR's improvement is the run-outcome + snapshot, not new file extraction for `endTurn=false` rounds.
- **Empty response** → previously surfaced as `cancelled` (a misnomer — nothing was cancelled); now `completed`. With rounds remaining it may run one more bounded reflection round instead of halting; the workspace snapshot is unchanged when there’s no output.
- **Genuine interrupt** → unchanged (`cancelled`).

## Tests
- `ResponseCycleCancellation.vitest.ts` (new) — stubs the inner cycle flow to script `shouldStop`/`endTurn` and asserts: stop-without-end-of-turn + not interrupted → `completed`; interrupted → `cancelled`; clean completion + racing interrupt → `completed`.
- `npm run typecheck` clean; full agent test-kernel suite green (690 passed / 4 skipped).

## Relationship to the sibling PR
This is the deeper, provider-agnostic hardening promised in the “Noted follow-up” of #6709 (Google Interactions status mapping). #6709 makes the Google handler speak the canonical stop-reason vocabulary; this PR makes the cancellation classifier structurally immune to any future contract gap. They are independent and can merge in either order.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core reflection run outcome and round-commit behavior; wrong classification could still affect multi-round flows, though the change aligns with existing interrupt handling elsewhere.
> 
> **Overview**
> **Fixes reflection rounds being wrongly marked `cancelled` and dropped** when the model stopped without a recognized end-of-turn reason (token limits, unrecognized provider stop reasons, empty responses) even though output was already written.
> 
> `ResponseCycleNode.exec` no longer uses `shouldStop && !endTurn` to infer cancellation. It now treats a round as **`cancelled` only when `checkInterruption()` is true and the round did not cleanly end** (`!cycleShared.endTurn`), matching how `RoundPersistedFlow` already decides run outcomes. Non-interrupt stops return **`completed`** so round snapshots and `output.xml` are committed instead of skipped.
> 
> Adds **`ResponseCycleCancellation.vitest.ts`** with a stubbed inner cycle flow to cover: stop without end-of-turn + no interrupt → `completed`; genuine interrupt → `cancelled`; end-of-turn complete despite a racing interrupt → `completed`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e092cf108a8eeb66da9099cc6fcf2c5da5e557c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
