### PR TITLE
fix(progressView): finish Web Awesome migration + layout polish

### DIFF
--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -28,7 +28,7 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/relative-time/relative-time.js';
 
 // Local imports
-import '@awesome.me/webawesome/dist/components/tag/tag.js';
+import '@awesome.me/webawesome/dist/components/badge/badge.js';
 import {
   STREAM_STATUS,
   type ActiveChildInfo,
@@ -154,16 +154,18 @@ export class BackgroundTasksPanel extends LitElement {
         color: var(--color-text-secondary);
       }
 
-      wa-tag.task-status {
+      /* Status uses a native wa-badge (filled), matching the app-wide badge
+         idiom (GoalTab / WorktreeChip / StreamHeader goal chip) rather than a
+         wa-tag — tags are for removable/category chips, badges for status. */
+      wa-badge.task-status {
         flex: 0 0 auto;
         margin-left: auto;
       }
 
-      wa-tag.task-status::part(base) {
-        min-height: 1.25rem;
-        padding: 0 var(--wa-space-xs);
+      wa-badge.task-status::part(base) {
+        padding: 2px var(--wa-space-2xs);
         font-size: var(--font-size-xs);
-        line-height: 1;
+        font-weight: var(--font-weight-medium);
       }
 
       /* Nested sections use Web Awesome <wa-details class="collapsible-quiet">
@@ -350,11 +352,11 @@ export class BackgroundTasksPanel extends LitElement {
             format="narrow"
             sync
           ></wa-relative-time>
-          <wa-tag
+          <wa-badge
             class="task-status"
             variant=${inquiryStatusVariant(thread.status)}
-            size="small"
-            >${thread.status}</wa-tag
+            appearance="filled"
+            >${thread.status}</wa-badge
           >
         </div>
       </div>
@@ -461,11 +463,11 @@ export class BackgroundTasksPanel extends LitElement {
           ${child.elapsed
             ? html`<span class="task-elapsed">(${child.elapsed})</span>`
             : nothing}
-          <wa-tag
+          <wa-badge
             class="task-status"
             variant=${waiting ? 'neutral' : 'warning'}
-            size="small"
-            >${waiting ? 'waiting' : 'running'}</wa-tag
+            appearance="filled"
+            >${waiting ? 'waiting' : 'running'}</wa-badge
           >
         </div>
         ${entry?.stdout

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -14,6 +14,7 @@ import type { GettingStartedAction } from '@shared/schemas';
 // Local imports - shared utilities
 // Side-effect imports - register WA icon and spinner components
 import '@awesome.me/webawesome/dist/components/button/button.js';
+import '@awesome.me/webawesome/dist/components/details/details.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
 
@@ -421,16 +422,31 @@ export class TaskGroupList extends LitElement {
     return remaining <= threshold;
   }
 
-  /** Handle details toggle — reads groupId from element ID to avoid closures */
-  private handleDetailsToggle(event: Event): void {
-    const details = event.currentTarget as HTMLDetailsElement;
+  /**
+   * Handle a group's open/close. wa-details emits wa-show / wa-hide which
+   * BUBBLE (unlike the native <details> `toggle`), so nested child groups
+   * would otherwise re-trigger their ancestors — guard on
+   * target === currentTarget. Reads groupId from the element ID to avoid
+   * per-row closures.
+   */
+  private handleGroupToggle(event: Event, open: boolean): void {
+    if (event.target !== event.currentTarget) return;
+    const details = event.currentTarget as HTMLElement;
     const groupId = details.id.slice(GROUP_DOM_IDS.DETAILS_PREFIX.length);
     if (this.toggleStates) {
-      this.toggleStates.set(groupId, !details.open);
+      this.toggleStates.set(groupId, !open);
     }
     // Re-render to add/remove children from the DOM (lazy collapsed groups)
     this.requestUpdate();
   }
+
+  private readonly handleGroupShow = (event: Event): void => {
+    this.handleGroupToggle(event, true);
+  };
+
+  private readonly handleGroupHide = (event: Event): void => {
+    this.handleGroupToggle(event, false);
+  };
 
   /** Render child group header inline (only called for non-root groups) */
   private renderGroupHeader(group: TaskGroup): TemplateResult {
@@ -506,13 +522,15 @@ export class TaskGroupList extends LitElement {
     const expanded = this.isExpanded(group.id);
 
     return html`
-      <details
+      <wa-details
         id=${detailsId}
         class="log-group"
         ?open=${expanded}
-        @toggle=${this.handleDetailsToggle}
+        @wa-show=${this.handleGroupShow}
+        @wa-hide=${this.handleGroupHide}
       >
-        <summary
+        <div
+          slot="summary"
           id="${GROUP_DOM_IDS.HEADER_PREFIX}${group.id}"
           class=${classMap({
             'log-group-header': true,
@@ -520,7 +538,7 @@ export class TaskGroupList extends LitElement {
           })}
         >
           ${this.renderGroupHeader(group)}
-        </summary>
+        </div>
         <div id=${contentId} class="log-group-content">
           ${expanded
             ? html`${this.renderMessageEntries(
@@ -533,7 +551,7 @@ export class TaskGroupList extends LitElement {
               )}`
             : nothing}
         </div>
-      </details>
+      </wa-details>
     `;
   }
 

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -423,30 +423,23 @@ export class TaskGroupList extends LitElement {
   }
 
   /**
-   * Handle a group's open/close. wa-details emits wa-show / wa-hide which
-   * BUBBLE (unlike the native <details> `toggle`), so nested child groups
-   * would otherwise re-trigger their ancestors — guard on
-   * target === currentTarget. Reads groupId from the element ID to avoid
-   * per-row closures.
+   * Handle a group's open/close — wired to both wa-show and wa-hide. Those
+   * events BUBBLE (unlike the native <details> `toggle`), so nested child
+   * groups would otherwise re-trigger their ancestors — guard on
+   * target === currentTarget. Open state comes from the event type; groupId
+   * from the element ID (no per-row closures). Lit binds the host as `this`.
    */
-  private handleGroupToggle(event: Event, open: boolean): void {
+  private handleGroupToggle(event: Event): void {
     if (event.target !== event.currentTarget) return;
     const details = event.currentTarget as HTMLElement;
     const groupId = details.id.slice(GROUP_DOM_IDS.DETAILS_PREFIX.length);
     if (this.toggleStates) {
-      this.toggleStates.set(groupId, !open);
+      // toggleStates stores `true` = collapsed; wa-show means now-open.
+      this.toggleStates.set(groupId, event.type !== 'wa-show');
     }
     // Re-render to add/remove children from the DOM (lazy collapsed groups)
     this.requestUpdate();
   }
-
-  private readonly handleGroupShow = (event: Event): void => {
-    this.handleGroupToggle(event, true);
-  };
-
-  private readonly handleGroupHide = (event: Event): void => {
-    this.handleGroupToggle(event, false);
-  };
 
   /** Render child group header inline (only called for non-root groups) */
   private renderGroupHeader(group: TaskGroup): TemplateResult {
@@ -526,8 +519,8 @@ export class TaskGroupList extends LitElement {
         id=${detailsId}
         class="log-group"
         ?open=${expanded}
-        @wa-show=${this.handleGroupShow}
-        @wa-hide=${this.handleGroupHide}
+        @wa-show=${this.handleGroupToggle}
+        @wa-hide=${this.handleGroupToggle}
       >
         <div
           slot="summary"

--- a/packages/extension/src/progressView/frontend/components/streamTabsStyles.ts
+++ b/packages/extension/src/progressView/frontend/components/streamTabsStyles.ts
@@ -146,9 +146,9 @@ export const streamTabStyles = css`
     display: flex;
     align-items: center;
     justify-content: center;
-    width: var(--height-control);
-    min-width: var(--height-control);
-    height: var(--height-control);
+    width: 20px;
+    min-width: 20px;
+    height: 20px;
     margin: 0 0 0 var(--wa-space-2xs);
     color: var(--wa-color-text-quiet, var(--wa-color-text-normal));
     opacity: 0;

--- a/packages/extension/src/progressView/frontend/progressAppStyles.ts
+++ b/packages/extension/src/progressView/frontend/progressAppStyles.ts
@@ -26,9 +26,18 @@ export const progressAppStyles = css`
     display: flex;
     align-items: center;
     gap: var(--wa-space-2xs);
-    padding: var(--wa-space-2xs) var(--wa-space-2xs) var(--wa-space-3xs);
+    padding: var(--wa-space-2xs) var(--wa-space-2xs) 0;
     border-bottom: var(--border-thin) solid var(--color-border);
     flex-shrink: 0;
+  }
+
+  /* The full-width view-header border is the single seam under the tab row.
+     Suppress the wa-tab-group's own track line and anchor the tabs flush on
+     that border (padding-bottom: 0 above) so the two no longer read as a
+     doubled rule with a gap between them. The active tab keeps its brand
+     indicator bar as the only accent. */
+  .view-header wa-tab-group.view-tabs {
+    --track-color: transparent;
   }
 
   .main-container.desktop .view-header {

--- a/packages/extension/src/progressView/frontend/styles/groupStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/groupStyles.ts
@@ -68,6 +68,26 @@ export const groupStyles = css`
     contain-intrinsic-size: auto 200px;
   }
 
+  /* Group banners are <wa-details> (matching Todos / Background Tasks etc.),
+     so the disclosure chevron is consistent with every other panel. Strip the
+     WA card chrome so the group reads as an inline disclosure rather than a
+     boxed panel — our .log-group-header (status rail + padding) and
+     .log-group-content (dashed connector) own the visuals. */
+  wa-details.log-group::part(base) {
+    background: transparent;
+    border: none;
+    border-radius: 0;
+  }
+
+  wa-details.log-group::part(header) {
+    padding: 0;
+    gap: var(--wa-space-2xs);
+  }
+
+  wa-details.log-group::part(content) {
+    padding: 0;
+  }
+
   /* Note: .spin class and @keyframes spin are in @shared/styles/litStyles.ts */
 
   :is(.log-line, .banner-details)[data-group-id] {

--- a/packages/extension/src/progressView/frontend/styles/groupStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/groupStyles.ts
@@ -72,7 +72,9 @@ export const groupStyles = css`
      so the disclosure chevron is consistent with every other panel. Strip the
      WA card chrome so the group reads as an inline disclosure rather than a
      boxed panel — our .log-group-header (status rail + padding) and
-     .log-group-content (dashed connector) own the visuals. */
+     .log-group-content (dashed connector) own the visuals. Unlike the shared
+     .collapsible-quiet panels, collapse here is by lazy DOM removal in
+     TaskGroupList (not the 1fr/0fr grid trick), so no content-grid rules. */
   wa-details.log-group::part(base) {
     background: transparent;
     border: none;


### PR DESCRIPTION
Cleans up the last bits of the progress view that weren't using native Web Awesome components, plus two layout seams flagged while reviewing the board.

## Component swaps
- **Subagent / inquiry status pills → `wa-badge`** (`BackgroundTasksPanel.ts`). The "running"/"waiting" chips were `wa-tag` (the chip/category component) with heavy `::part(base)` overrides. Now `wa-badge appearance="filled"`, matching the app-wide status idiom (GoalTab, WorktreeChip, StreamHeader goal chip).
- **Group banners → `wa-details`** (`TaskGroupList.ts` + `groupStyles.ts`). The "Files (n/n loaded)" / run banners were the one genuinely *native* `<details>` left. Migrated to `wa-details` so the disclosure chevron is consistent with every other panel. Preserved the toggle-state store, scroll-anchor DOM IDs, lazy child rendering, and `content-visibility`. The new `wa-show`/`wa-hide` handlers are guarded with `target === currentTarget` because — unlike native `toggle` — those events bubble, so nested child groups would otherwise re-toggle their parents.

## Layout polish
- **Doubled lines above the stream header** (`progressAppStyles.ts`). The `wa-tab-group` track line and the full-width `.view-header` border were stacking with a gap between them. Suppressed the track (`--track-color: transparent`) and anchored the tabs flush on the single full-width border. The active tab keeps its brand indicator bar.
- **Delete-stream button fill** (`streamTabsStyles.ts`). Shrank `.tab-delete` from `--height-control` (24px) to 20px so the grey box hugs the ✕.

## Investigated, intentionally unchanged
- **Subagent icons.** Already native `wa-icon` rendering Font Awesome glyphs (e.g. `faRobot`) via the `texra` library, which exists because webviews can't fetch Web Awesome's icon CDN under CSP. Switching to the WA default library would break under CSP and render the identical glyph.
- **Queued Messages (Followup).** Already `wa-details` + `wa-icon`; rows are plain `<div>`s only because Web Awesome has no list-item component.

## Verification
- `npm run typecheck` — exit 0
- `npm run compile:fast` — exit 0

Worth an eyeball in the running webview:
1. Group-banner open/close on a **large run** — `wa-details` animates height where native `<details>` was instant; lazy-render means content pops in on expand.
2. The group-banner chevron now sits on the **right** (consistent with other panels) instead of the left.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes in the progress webview (components and CSS); no auth, data, or backend logic. Nested `wa-details` toggle behavior is the main behavioral risk and is explicitly guarded.
> 
> **Overview**
> Finishes the progress view’s Web Awesome migration by swapping **status chips** from `wa-tag` to **`wa-badge` appearance="filled"** in Background Tasks (inquiry/subagent running/waiting), aligning with status badges elsewhere and simplifying `::part` styling.
> 
> **Log group banners** in `TaskGroupList` move from native `<details>` to **`wa-details`** with summary in a slot; toggle persistence still uses `ToggleStateStore` and lazy child rendering, but handlers listen to **`wa-show` / `wa-hide`** with **`target === currentTarget`** so bubbling doesn’t collapse parent groups when nested groups toggle. **`groupStyles`** strips default `wa-details` card chrome so groups keep the existing header rail and dashed connector look.
> 
> **Layout polish:** the view header drops extra bottom padding and hides the **`wa-tab-group` track** so one border sits under the tab row; stream tab **delete** controls shrink from `--height-control` to **20px** so the hit target hugs the ✕.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0be9c1fc7432e0c4c9e0bd7cd8645a944fa88ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->