### PR TITLE
fix(output): warn when a non-empty response extracts zero files

### DIFF
--- a/src/agent/output/OutputFileProcessor.ts
+++ b/src/agent/output/OutputFileProcessor.ts
@@ -67,7 +67,7 @@ export class OutputFileProcessor {
         logger.debug(
           `No processed files were generated from ${outputLocation.absolutePath}`,
         );
-        this.emitMissingOutputs(currRound, outputLocation);
+        await this.emitMissingOutputs(currRound, outputLocation);
         await this.handleEmptyOutput(currRound, rawLocation);
       },
       {
@@ -75,7 +75,7 @@ export class OutputFileProcessor {
         level: 'debug',
         label: 'Error processing output file',
         recover: async () => {
-          this.emitMissingOutputs(currRound, outputLocation);
+          await this.emitMissingOutputs(currRound, outputLocation);
           await this.handleEmptyOutput(currRound, rawLocation);
         },
       },
@@ -83,10 +83,24 @@ export class OutputFileProcessor {
   }
 
   /** Logs and signals the UI that a round produced no extractable output files. */
-  private emitMissingOutputs(
+  private async emitMissingOutputs(
     currRound: number,
     outputLocation: FileLocation,
-  ): void {
+  ): Promise<void> {
+    // Distinguish a genuinely empty turn from a non-empty response that simply
+    // could not be parsed: if the model returned content but nothing extracted,
+    // it almost always means it did not wrap each file in
+    // `<documentTag name="…">`. Surface that as a warning so the round is not a
+    // silent "success" that writes no files; the raw response is kept for recovery.
+    const rawText = await flexibleFS.read(outputLocation).catch(() => '');
+    if (rawText.trim().length > 0) {
+      this.ctx.logger.warn(
+        `Round ${currRound}: the model returned output but no files could be ` +
+          `extracted from it — it likely did not wrap each document in ` +
+          `<${this.ctx.agentSetting.documentTag} name="…">. The raw response ` +
+          `was kept at ${outputLocation.absolutePath}.`,
+      );
+    }
     logMissingOutputs(this.ctx.logger, {
       missing: [] as string[],
       xmlFile: outputLocation.absolutePath,

--- a/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import type { AgentTrace } from '@agent/trace';
@@ -13,6 +13,7 @@ import {
   type ProcessingContext,
 } from '@agent/output/OutputFileProcessor';
 import type { XmlOutputManager } from '@agent/output/XmlOutputManager';
+import { flexibleFS } from '@utils/files';
 import { normalizeRunId } from '@common/constants/runIds';
 import type {
   AgentFileLocation,
@@ -401,5 +402,75 @@ describe('output progress events', () => {
       },
     ]);
     expect(roundData.get(4)?.outputs).toEqual([]);
+  });
+
+  it('warns when a non-empty response yields zero extracted files', async () => {
+    // Regression: a run where the model returned content but nothing could be
+    // extracted (e.g. it did not wrap files in <documents>) used to "complete"
+    // silently with only the raw output. It must now surface a warning. Stub
+    // the read so the model output is treated as non-empty.
+    const readSpy = vi
+      .spyOn(flexibleFS, 'read')
+      .mockResolvedValue('% chunk.tex\n\\section{Untagged content}\n');
+    try {
+      const { events, host } = createRecordingHost();
+      const warnings: string[] = [];
+      const roundData = new Map<number, RoundOutput>();
+      const logger = {
+        debug: () => {},
+        domain: () => {},
+        warn: (message: string) => warnings.push(message),
+      } as unknown as AgentTrace;
+      const xmlManager = {
+        splitScratchpadMultipleOutputXml: async () => [],
+      } as unknown as XmlOutputManager;
+      const ensureRound = (round: number): RoundOutput => {
+        let data = roundData.get(round);
+        if (!data) {
+          data = {
+            round,
+            outputs: [],
+            compileFailures: [],
+            rawOutput: null,
+            xmlSummary: emptyXmlSummary,
+          };
+          roundData.set(round, data);
+        }
+        return data;
+      };
+      const context: ProcessingContext = {
+        agentSetting: {
+          agentCategory: AgentCategory.Workflow,
+          documentTag: 'documents',
+        } as ProcessingContext['agentSetting'],
+        baseFiles: [],
+        streamId: 'stream:processor',
+        runtimeHost: host,
+        logger,
+        xmlManager,
+        setRoundOutputs: (round, outputs) => {
+          ensureRound(round).outputs = outputs;
+        },
+        ensureRoundData: ensureRound,
+      };
+
+      await new OutputFileProcessor(context).processMultipleOutputs(
+        createLocation('/tmp/output.xml'),
+        5,
+        createLocation('/tmp/output.xml'),
+      );
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('no files could be extracted');
+      // The missing-output signal is still emitted alongside the warning.
+      expect(events).toEqual([
+        {
+          event: 'updateMissingOutputs',
+          payload: { streamId: 'stream:processor', filesByRound: { 5: [] } },
+        },
+      ]);
+    } finally {
+      readSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Problem

A workflow run where the model returned content but **nothing could be extracted** into output files — e.g. it didn't wrap each file in `<documentTag name="…">` (a reasoning model on a long multi-file task echoing the `% <filename>` input format instead) — used to **"complete" silently**. The only trace was a `debug` line plus `updateMissingOutputs` with an empty list, which `logMissingOutputs` renders as **"0 output files missing"** (i.e. looks fine). The user is left with just the raw `output.xml` and no indication anything went wrong.

Observed on a real `criticize`/gpt-5.5 run (`060f9c43d400`): 30 min, status `completed`, two rounds of `output.xml` (~60 KB each, annotations correct), **zero extracted `.tex` files**.

## Fix

`emitMissingOutputs` now reads the model output and, when it is **non-empty**, emits a clear `logger.warn` that points at the kept raw response and the likely cause (missing `<documentTag name="…">` wrapper). Genuinely empty turns stay quiet (no spurious warning). Made the method async and awaited at both call sites.

This is the safety-net half of the extraction-robustness work. A `% <filename>` extraction *fallback* (to actually recover files in this format) can be a follow-up.

## Tests

Added `OutputProgressEvents.vitest.ts` case: a non-empty response with zero extracted documents emits exactly one warning containing "no files could be extracted" and still emits `updateMissingOutputs`. The two existing zero-extraction tests (empty/error paths) stay quiet. `tsc` clean (root + test-kernel); `npx vitest run src/test-kernel/agent/output` → all pass.

## Verified
- `src/agent/output/OutputFileProcessor.ts` — `emitMissingOutputs` reads output, warns on non-empty 0-extraction; both call sites awaited.
- `src/test-kernel/agent/output/OutputProgressEvents.vitest.ts` — new regression test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change in output processing with no changes to auth, persistence, or extraction logic beyond an extra file read on the already-missing-output path.
> 
> **Overview**
> When a workflow round finishes with **no extracted files**, `OutputFileProcessor.emitMissingOutputs` now **reads the raw model output** and, if it is non-empty, logs a **`logger.warn`** that extraction likely failed because documents were not wrapped in the configured `<documentTag name="…">`, while still emitting `updateMissingOutputs` and keeping the raw response path in the message. **Genuinely empty** outputs stay quiet.
> 
> The method is **async** and both zero-extraction call sites (normal path and error recovery) **await** it. A regression test stubs `flexibleFS.read` to assert one warning containing "no files could be extracted" alongside the existing missing-output event.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0bee1de99f12b133ec658e1cf5e837fa5d4f0f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->