### PR TITLE
fix(progressView): "Use your own API key" should not re-prompt when a key is already set

### DIFF
--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -69,11 +69,13 @@ export class ProgressApiKeyRetryController {
       // Relay/subscription exhaustion does not break the stored direct key, so
       // if a usable one already exists, switch to it and retry without
       // re-prompting — the user has already provided a key. Only prompt when
-      // none exists yet.
-      if (!(await this.hasAnyUsableKey(providersToCheck))) {
-        await this.deps.promptForApiKey(request.provider);
-      }
+      // none exists yet, and only re-check the keys after that prompt (so the
+      // common already-set path reads the secret store once, not twice).
       shouldProceed = await this.hasAnyUsableKey(providersToCheck);
+      if (!shouldProceed) {
+        await this.deps.promptForApiKey(request.provider);
+        shouldProceed = await this.hasAnyUsableKey(providersToCheck);
+      }
     }
 
     if (!shouldProceed) {

--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -66,7 +66,13 @@ export class ProgressApiKeyRetryController {
       await this.deps.promptForApiKey(request.provider);
       shouldProceed = await this.hasChangedUsableKey(providersToCheck, before);
     } else {
-      await this.deps.promptForApiKey(request.provider);
+      // Relay/subscription exhaustion does not break the stored direct key, so
+      // if a usable one already exists, switch to it and retry without
+      // re-prompting — the user has already provided a key. Only prompt when
+      // none exists yet.
+      if (!(await this.hasAnyUsableKey(providersToCheck))) {
+        await this.deps.promptForApiKey(request.provider);
+      }
       shouldProceed = await this.hasAnyUsableKey(providersToCheck);
     }
 

--- a/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
@@ -159,7 +159,7 @@ describe('ProgressApiKeyRetryController', () => {
     assert.deepEqual(harness.retries, ['stream-b']);
   });
 
-  it('uses any existing usable key for relay-limit consent', async () => {
+  it('uses any existing usable key for relay-limit consent without re-prompting', async () => {
     const harness = createHarness({
       keys: { openai: 'stored-key' },
     });
@@ -175,7 +175,8 @@ describe('ProgressApiKeyRetryController', () => {
       disabledIncludedModelAccess: true,
       disabledChatGptSubscription: false,
     });
-    assert.deepEqual(harness.prompts, [undefined]);
+    // A usable key already exists, so the switch must not pop the key prompt.
+    assert.deepEqual(harness.prompts, []);
     assert.deepEqual(harness.includedAccessValues, [false]);
     assert.equal(harness.invalidations, 1);
     assert.deepEqual(harness.retries, ['stream-b']);
@@ -204,7 +205,7 @@ describe('ProgressApiKeyRetryController', () => {
     assert.deepEqual(harness.retries, ['stream-c']);
   });
 
-  it('disables the ChatGPT subscription and retries with a usable OpenAI key', async () => {
+  it('disables the ChatGPT subscription and retries with the existing OpenAI key, no prompt', async () => {
     const harness = createHarness({
       keys: { openai: 'stored-openai' },
     });
@@ -223,7 +224,9 @@ describe('ProgressApiKeyRetryController', () => {
       disabledIncludedModelAccess: true,
       disabledChatGptSubscription: true,
     });
-    assert.deepEqual(harness.prompts, ['openai']);
+    // The subscription quota failed, not the key — a stored key is already
+    // usable, so "Use your own API key" must not jump to the key-input prompt.
+    assert.deepEqual(harness.prompts, []);
     assert.deepEqual(harness.includedAccessValues, [false]);
     assert.equal(harness.codexDisableCount, 1);
     assert.equal(harness.invalidations, 2);
@@ -245,6 +248,8 @@ describe('ProgressApiKeyRetryController', () => {
       disabledIncludedModelAccess: false,
       disabledChatGptSubscription: false,
     });
+    // No usable key exists, so the prompt is still shown (then declined here).
+    assert.deepEqual(harness.prompts, ['openai']);
     assert.equal(harness.codexDisableCount, 0);
     assert.deepEqual(harness.retries, []);
   });


### PR DESCRIPTION
## Problem

When a relay or **ChatGPT-subscription** request hits its usage limit and you accept **"Use your own API key"**, TeXRA always pops the key-input prompt — even when a usable OpenAI key is already stored. But relay/subscription exhaustion doesn't break the stored key; it's perfectly usable, so the prompt is a needless extra step (you just want it to switch and retry).

## Cause

`ProgressApiKeyRetryController.useOwnApiKey` only skips the prompt for the upstream-credit-depletion path (`requireChange`, where the stored key itself is the broken credential). For relay/subscription exhaustion (`requireChange === false`) it called `promptForApiKey` **unconditionally** before checking for an existing key.

## Fix

In the non-`requireChange` branch, prompt **only when no usable key exists** for the relevant provider(s); if one is already set, switch (disable relay / subscription as before) and retry without prompting. The credit-depletion path is unchanged — it still requires a changed key.

Covers the **extension + desktop** (both wire this shared controller). The CLI has a separate retry path (`packages/cli/src/chat/tui/modals/RetryRequest.tsx`) — not touched here; can be a follow-up if it has the same behavior.

## Tests
- relay-limit + stored key → **no prompt** (was `[undefined]`)
- subscription switch + stored OpenAI key → **no prompt** (was `['openai']`)
- subscription + **no** key → still prompts (then declines)
- credit-depletion path unchanged

`npx vitest run src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts` → 7 pass; `tsc` clean (root + test-kernel).

## Verified
- `src/controllers/progressView/ProgressApiKeyRetryController.ts` — prompt gated on no-usable-key in the non-requireChange branch.
- `src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts` — updated expectations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral change in progress-view retry consent logic with targeted tests; no auth or data-model changes.
> 
> **Overview**
> Fixes **"Use your own API key"** so relay or ChatGPT subscription limit failures no longer open the key-input dialog when a usable direct key is already in the secret store.
> 
> In `ProgressApiKeyRetryController.useOwnApiKey`, the non–upstream-credit path now calls `hasAnyUsableKey` first and only invokes `promptForApiKey` when that check fails; if a key exists, it proceeds with the existing disable-relay/subscription and retry flow without prompting. The **upstream credit depletion** path is unchanged: it still always prompts and requires a **changed** key.
> 
> Vitest expectations were updated for relay-limit and subscription flows with a stored key (expect **no** prompts) and for subscription with no key (prompt still shown).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 513c96f1907970a7539d633f881709c40fdc6813. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->