### PR TITLE
refactor(agent): centralize helper-model one-shot calls

### DIFF
--- a/src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts
+++ b/src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts
@@ -10,7 +10,10 @@ import {
   AgentToolUseSettingSchema,
   AgentPromptSchema,
 } from '@agent/core/definition/AgentDataclass';
-import { createHelperModelKit } from '@agent/runtime/helperModel';
+import {
+  createHelperModelKit,
+  runHelperModelCompletion,
+} from '@agent/runtime/helperModel';
 import { validateAgentYamlContent } from '@agent/runtime/agentLoad';
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
@@ -388,7 +391,6 @@ class GenerateNode extends Node<AgentCreatorShared> {
     if (!helperResult.kit) {
       throw new Error(helperResult.reason);
     }
-    const { handler, client } = helperResult.kit;
 
     const prompts = config[blueprint.category];
     const schemaRef = getSchemaReference(blueprint.category);
@@ -410,19 +412,10 @@ class GenerateNode extends Node<AgentCreatorShared> {
         });
     }
 
-    const messages = await handler.initializeMessages(
-      '',
-      userMessage,
-      undefined,
-      systemPrompt,
-    );
-    const result = await handler.createResponse({
-      client,
-      messages,
-      temperature: 0,
+    const text = await runHelperModelCompletion(helperResult.kit, {
+      userPrompt: userMessage,
       systemPrompt,
     });
-    const { text } = handler.extractResponse(result.response, '');
 
     if (!isNonEmptyString(text)) {
       throw new Error('Model returned no text');

--- a/src/agent/runtime/helperModel.ts
+++ b/src/agent/runtime/helperModel.ts
@@ -43,3 +43,41 @@ export async function createHelperModelKit(): Promise<HelperModelResult> {
   const client = await handler.getClient();
   return { kit: { handler, client, modelName } };
 }
+
+/** A single non-streaming helper-model text completion. */
+export interface HelperModelCompletion {
+  /** User message content. */
+  userPrompt: string;
+  /** Optional system prompt. */
+  systemPrompt?: string;
+  /** Sampling temperature (defaults to 0 for deterministic helper calls). */
+  temperature?: number;
+}
+
+/**
+ * Run one non-streaming completion against a helper-model kit and return the
+ * extracted response text.
+ *
+ * Encapsulates the `initializeMessages → createResponse → extractResponse`
+ * handler protocol so callers (session descriptions, instruction polishing,
+ * agent creation, LaTeX text connection) share one call path instead of each
+ * reaching into the {@link ModelHandler} internals.
+ */
+export async function runHelperModelCompletion(
+  kit: HelperModelKit,
+  { userPrompt, systemPrompt, temperature = 0 }: HelperModelCompletion,
+): Promise<string> {
+  const messages = await kit.handler.initializeMessages(
+    '',
+    userPrompt,
+    undefined,
+    systemPrompt,
+  );
+  const result = await kit.handler.createResponse({
+    client: kit.client,
+    messages,
+    temperature,
+    systemPrompt,
+  });
+  return kit.handler.extractResponse(result.response, '').text;
+}

--- a/src/agent/runtime/sessionDescription.ts
+++ b/src/agent/runtime/sessionDescription.ts
@@ -12,7 +12,10 @@ import { writeSessionDescription } from '@agent/storage';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { createHelperModelKit } from '@agent/runtime/helperModel';
+import {
+  createHelperModelKit,
+  runHelperModelCompletion,
+} from '@agent/runtime/helperModel';
 import { getSdkErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
@@ -96,25 +99,15 @@ export async function generateSessionDescription(
       return;
     }
 
-    const { handler, client } = helperResult.kit;
     const userPrompt = buildUserPrompt(
       config.agent,
       agentDescription,
       instruction,
     );
-    const messages = await handler.initializeMessages(
-      '',
+    const text = await runHelperModelCompletion(helperResult.kit, {
       userPrompt,
-      undefined,
-      SYSTEM_PROMPT,
-    );
-    const result = await handler.createResponse({
-      client,
-      messages,
-      temperature: 0,
       systemPrompt: SYSTEM_PROMPT,
     });
-    const { text } = handler.extractResponse(result.response, '');
 
     if (isNonEmptyString(text)) {
       const description = cleanSessionDescription(text);

--- a/src/agent/runtime/textConnection.ts
+++ b/src/agent/runtime/textConnection.ts
@@ -5,7 +5,10 @@ import { MODEL_CONFIGS } from 'llm-zoo';
 
 import { ModelHandlerOpenAI } from '@agent/modelHandlers/openai/modelHandlerOpenAI';
 import { ModelHandlerAnthropic } from '@agent/modelHandlers/anthropic/modelHandlerAnthropic';
-import { createHelperModelKit } from '@agent/runtime/helperModel';
+import {
+  createHelperModelKit,
+  runHelperModelCompletion,
+} from '@agent/runtime/helperModel';
 import { classifyAgentError, getSdkErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 
@@ -73,24 +76,14 @@ async function bestConnectionMethodWithHelperModel(
     return DEFAULT_RESULT;
   }
 
-  const { handler, client } = helperResult.kit;
   const prompt = buildPrompt(str1, str2);
   const choices: string[] = [];
 
   for (let i = 0; i < Math.max(1, n); i += 1) {
-    const messages = await handler.initializeMessages(
-      '',
-      prompt,
-      undefined,
-      SYSTEM_PROMPT,
-    );
-    const result = await handler.createResponse({
-      client,
-      messages,
-      temperature: 0,
+    const text = await runHelperModelCompletion(helperResult.kit, {
+      userPrompt: prompt,
       systemPrompt: SYSTEM_PROMPT,
     });
-    const { text } = handler.extractResponse(result.response, '');
     choices.push(text.trim());
   }
 

--- a/src/agent/runtime/textEnhancement.ts
+++ b/src/agent/runtime/textEnhancement.ts
@@ -5,7 +5,7 @@ import { isNonEmptyString } from '@utils/core';
 
 import { extractTextFromTag } from '@utils/text/xmlUtils';
 import { renderPolishPrompt } from './polishModel';
-import { createHelperModelKit } from './helperModel';
+import { createHelperModelKit, runHelperModelCompletion } from './helperModel';
 
 const CHANNEL = 'TextEnhancement';
 
@@ -83,14 +83,9 @@ export async function polishTextWithAI(
     if (!helperResult.kit) {
       throw new Error(helperResult.reason);
     }
-    const { handler, client } = helperResult.kit;
-    const messages = await handler.initializeMessages('', prompt);
-    const result = await handler.createResponse({
-      client,
-      messages,
-      temperature: 0,
+    const responseText = await runHelperModelCompletion(helperResult.kit, {
+      userPrompt: prompt,
     });
-    const { text: responseText } = handler.extractResponse(result.response, '');
     if (!isNonEmptyString(responseText)) {
       throw new Error('Model returned no text.');
     }

--- a/src/test-kernel/agent/TextConnectionHelperModel.vitest.ts
+++ b/src/test-kernel/agent/TextConnectionHelperModel.vitest.ts
@@ -3,7 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const createHelperModelKit = vi.hoisted(() => vi.fn());
 
-vi.mock('@agent/runtime/helperModel', () => ({
+vi.mock('@agent/runtime/helperModel', async (importActual) => ({
+  ...(await importActual<typeof import('@agent/runtime/helperModel')>()),
   createHelperModelKit,
 }));
 

--- a/src/test-kernel/agent/runtime/SessionDescription.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionDescription.vitest.ts
@@ -21,7 +21,8 @@ vi.mock('@agent/index', () => ({
   getAgent: mocks.getAgent,
 }));
 
-vi.mock('@agent/runtime/helperModel', () => ({
+vi.mock('@agent/runtime/helperModel', async (importActual) => ({
+  ...(await importActual<typeof import('@agent/runtime/helperModel')>()),
   createHelperModelKit: mocks.createHelperModelKit,
 }));
 


### PR DESCRIPTION
## Summary

The `helperModel` runtime abstraction handed each caller a raw `{ handler, client }` kit and stopped there. As a result, four separate consumers re-implemented the exact same low-level call sequence against the `ModelHandler` protocol:

```ts
const { handler, client } = helperResult.kit;
const messages = await handler.initializeMessages('', prompt, undefined, systemPrompt);
const result = await handler.createResponse({ client, messages, temperature: 0, systemPrompt });
const { text } = handler.extractResponse(result.response, '');
```

duplicated across:
- `src/agent/runtime/sessionDescription.ts`
- `src/agent/runtime/textConnection.ts`
- `src/agent/runtime/textEnhancement.ts`
- `src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts`

That is an abstraction-layer leak: the "helper model" concept is meant to be a lightweight one-shot LLM call, but every consumer had to know the handler's internal `initialize → create → extract` protocol. Any change to that protocol meant editing four call sites.

This PR lifts the sequence into `runHelperModelCompletion(kit, { userPrompt, systemPrompt?, temperature? })`, which returns the extracted text. Each call site now expresses intent (prompt in, text out) without touching handler internals. Behavior is preserved at every site (`textEnhancement` keeps its no-system-prompt call; `textConnection` keeps its N-sample loop, now reusing one kit).

## Issue acceptance gates

N/A — this is a self-contained abstraction-layer cleanup surfaced during a code-review pass, not tied to a tracked issue.

## Single source of truth

`src/agent/runtime/helperModel.ts` now owns the helper-model one-shot call protocol (`runHelperModelCompletion`), in addition to kit construction (`createHelperModelKit`). Consumers depend only on this module, not on `ModelHandler` method shapes.

## Duplication and abstraction budget

Removes four copies of the `initializeMessages → createResponse → extractResponse` orchestration. The one new function, `runHelperModelCompletion`, is not a pass-through layer: it owns the helper-call protocol (default temperature, message construction, response extraction) that was previously copy-pasted. No speculative parameters were added — the `signal` plumbing was deliberately left out since no caller wires cancellation today.

## Host impact

Extension: No behavior change. Agent creation, session descriptions, and instruction polishing produce identical output.

Desktop: No behavior change (shares the same core runtime).

CLI: No behavior change (shares the same core runtime).

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — pass
- `npx eslint` on all changed source and test files — pass
- `npx vitest run src/test-kernel/agent/` — 687 passed, 4 skipped (includes the updated `SessionDescription` and `TextConnectionHelperModel` suites, which now spread the real `helperModel` module via `importActual` so `runHelperModelCompletion` stays live while `createHelperModelKit` is mocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017XceVBW8NjHVirnMRhnuAC)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with no intended behavior change; risk is limited to subtle differences if the shared completion path diverges from the old inline calls.
> 
> **Overview**
> Adds **`runHelperModelCompletion`** in `helperModel.ts` so one-shot helper LLM calls go through a single **initialize → create → extract** path instead of each caller touching `ModelHandler` directly.
> 
> **Agent creator**, **session descriptions**, **LaTeX text connection**, and **text enhancement** now call that helper with `userPrompt` / optional `systemPrompt` and get back plain text; behavior stays the same (default temperature 0, same prompts, multi-sample loop in text connection).
> 
> Vitest mocks for **`helperModel`** use **`importActual`** so **`runHelperModelCompletion`** stays real while **`createHelperModelKit`** stays mocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b83c6deacb717da67dbe7ff48c681ace35ba399. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->