### PR TITLE
fix(model-handlers): unify output cleanup, dedupe end-tag, finalize streams on error

### DIFF
--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -21,7 +21,6 @@ import { isTokenLimitStopReason } from '@agent/modelHandlers/utils/stopReasonUti
 import { K_SLICE } from '@agent/core/constants';
 import { toErrorMessage } from '@common/errors';
 import type { ToolDefinition } from '@model';
-import replacementEngine from '@replacement/engine';
 import { MESSAGE_TYPES, AgentFileLocationSchema } from '@shared/schemas';
 import { isApprovalGatedToolName } from '@tools/approvalGatedTools';
 import { AbsoluteFS, flexibleFS } from '@utils/files';
@@ -297,7 +296,10 @@ class ResponseProcessNode<C> extends BaseNode<
       let updatedAccumulatedOutput: string | undefined;
 
       if (newResponse) {
-        processedResponse = replacementEngine.applyAll(newResponse);
+        // Text cleanup (replacementEngine.applyAll) is applied once inside each
+        // handler's extractResponse, so newResponse is already cleaned here.
+        // Re-applying would run non-idempotent custom replacements twice.
+        processedResponse = newResponse;
 
         const connector = await this.services.bestConnectionMethod(
           prepRes.lastResponse.slice(-K_SLICE),

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -652,6 +652,23 @@ export abstract class ModelHandler<
     return { endTurn, shouldStop };
   }
 
+  /**
+   * Append the agent's end tag to a natural-stop response when the model did
+   * not already emit it. Shared by the provider handlers that use an
+   * `includes` presence check; each caller supplies its own "natural stop"
+   * predicate because provider stop-reason vocabularies differ.
+   */
+  protected appendEndTagIfNeeded(
+    text: string,
+    endTag: string,
+    isNaturalStop: boolean,
+  ): string {
+    if (isNaturalStop && endTag && !text.includes(endTag)) {
+      return `${text}\n${endTag}`;
+    }
+    return text;
+  }
+
   protected containCutOffMessage(
     content: Array<{ type: string; text?: string }> | string,
   ): boolean {

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -966,12 +966,11 @@ export class ModelHandlerAnthropic extends ModelHandler<
       .join('');
 
     // Add end tag if needed
-    if (
-      stopReason === ANTHROPIC_STOP.STOP_SEQUENCE &&
-      !newResponse.includes(endTag)
-    ) {
-      newResponse += `\n${endTag}`;
-    }
+    newResponse = this.appendEndTagIfNeeded(
+      newResponse,
+      endTag,
+      stopReason === ANTHROPIC_STOP.STOP_SEQUENCE,
+    );
 
     newResponse = replacementEngine.applyAll(newResponse);
 

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -574,9 +574,11 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     } catch (error) {
       // Finalize the progress streams on error so the view does not hang in a
       // loading state. Undefined on the non-streaming path; `finalize` is
-      // idempotent so a re-finalize after the success path is a no-op.
+      // idempotent so a re-finalize after the success path is a no-op. No
+      // explicit final text so any chunks already streamed are preserved
+      // (passing `''` would overwrite the visible partial output).
       thinking?.finalize(undefined);
-      output?.finalize('');
+      output?.finalize();
       // Error logging follows "log at the boundary" principle - Node's retryPrompt
       // or execFallback will log the error once. We only add debug diagnostics here
       // for specific error types that need additional context.

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -21,6 +21,7 @@ import {
 
 // Local imports - agent
 import { logSdkError } from '@agent/trace';
+import type { StreamHandle } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { hasEndTag } from '@agent/core/definition/AgentDataclass';
 import type { AgentSetting } from '@agent/core/definition/AgentDataclass';
@@ -437,6 +438,11 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     // mid-stream failure (Google's SDK has no currentMessage accessor, so
     // we accumulate manually as we iterate).
     let aggregatedText = '';
+    // Hoisted so the outer catch can finalize the progress streams on a
+    // mid-stream failure (otherwise the progress view hangs in a loading
+    // state). `StreamHandle.finalize` is idempotent.
+    let thinking: StreamHandle | undefined;
+    let output: StreamHandle | undefined;
 
     try {
       this.logger.debug(
@@ -457,8 +463,8 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
         // Opened before the request; the deferred starts fire (if ever) at
         // the first thought/text part — the phase signal for this API.
-        const thinking = this.createThinkingStream();
-        const output = this.createOutputStream();
+        thinking = this.createThinkingStream();
+        output = this.createOutputStream();
 
         let baseResponse: GenerateContentResponse | undefined;
         let latestCandidate: Candidate | undefined;
@@ -566,6 +572,11 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       const response = await chat.sendMessage(sendParams);
       return { response };
     } catch (error) {
+      // Finalize the progress streams on error so the view does not hang in a
+      // loading state. Undefined on the non-streaming path; `finalize` is
+      // idempotent so a re-finalize after the success path is a no-op.
+      thinking?.finalize(undefined);
+      output?.finalize('');
       // Error logging follows "log at the boundary" principle - Node's retryPrompt
       // or execFallback will log the error once. We only add debug diagnostics here
       // for specific error types that need additional context.

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -1906,98 +1906,110 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
   ): Promise<CreateResponseResult<GoogleGenAIInteraction, Step>> {
     const output = this.createOutputStream();
     const thinking = this.createThinkingStream();
+    let streamsFinalized = false;
 
-    const pending = new Map<number, PendingStep>();
-    let completedInteraction: GoogleGenAIInteraction | undefined;
-    let runningUsage: Usage | undefined;
-    let interactionId: string | undefined;
+    try {
+      const pending = new Map<number, PendingStep>();
+      let completedInteraction: GoogleGenAIInteraction | undefined;
+      let runningUsage: Usage | undefined;
+      let interactionId: string | undefined;
 
-    for await (const event of stream) {
-      switch (event.event_type) {
-        case 'interaction.created':
-          interactionId = event.interaction.id;
-          this.logger.debug(`Interaction created: ${interactionId}`);
-          break;
+      for await (const event of stream) {
+        switch (event.event_type) {
+          case 'interaction.created':
+            interactionId = event.interaction.id;
+            this.logger.debug(`Interaction created: ${interactionId}`);
+            break;
 
-        case 'step.start':
-          pending.set(event.index, this.seedPendingStep(event.step));
-          break;
+          case 'step.start':
+            pending.set(event.index, this.seedPendingStep(event.step));
+            break;
 
-        case 'step.delta': {
-          const slot = pending.get(event.index) ?? this.seedPendingStep();
-          pending.set(event.index, slot);
-          this.applyDelta(slot, event.delta, output, thinking, onOutputText);
-          if (event.metadata?.total_usage) {
-            runningUsage = event.metadata.total_usage;
+          case 'step.delta': {
+            const slot = pending.get(event.index) ?? this.seedPendingStep();
+            pending.set(event.index, slot);
+            this.applyDelta(slot, event.delta, output, thinking, onOutputText);
+            if (event.metadata?.total_usage) {
+              runningUsage = event.metadata.total_usage;
+            }
+            break;
           }
-          break;
-        }
 
-        case 'step.stop': {
-          const slot = pending.get(event.index);
-          if (slot && slot.type === 'function_call' && slot.argsBuffer) {
-            slot.args = this.parseArguments(slot.argsBuffer);
+          case 'step.stop': {
+            const slot = pending.get(event.index);
+            if (slot && slot.type === 'function_call' && slot.argsBuffer) {
+              slot.args = this.parseArguments(slot.argsBuffer);
+            }
+            break;
           }
-          break;
-        }
 
-        case 'interaction.status_update':
-          this.logger.debug(`Interaction status: ${event.status}`);
-          break;
+          case 'interaction.status_update':
+            this.logger.debug(`Interaction status: ${event.status}`);
+            break;
 
-        case 'interaction.completed':
-          // The completed event carries the final status/usage/steps. Cast to
-          // the handler's Resp shape (steps non-optional downstream is tolerated
-          // via the `?? []` reads in extractors).
-          completedInteraction =
-            event.interaction as unknown as GoogleGenAIInteraction;
-          break;
+          case 'interaction.completed':
+            // The completed event carries the final status/usage/steps. Cast to
+            // the handler's Resp shape (steps non-optional downstream is tolerated
+            // via the `?? []` reads in extractors).
+            completedInteraction =
+              event.interaction as unknown as GoogleGenAIInteraction;
+            break;
 
-        case 'error': {
-          const message = event.error?.message ?? 'Interactions stream error';
-          const err = new Error(message);
-          this.sdkErrorTagger(err, this.config.provider);
-          throw err;
+          case 'error': {
+            const message = event.error?.message ?? 'Interactions stream error';
+            const err = new Error(message);
+            this.sdkErrorTagger(err, this.config.provider);
+            throw err;
+          }
         }
       }
+
+      // Assemble the finalized step list from the per-index accumulators so that
+      // thought signatures + function calls round-trip verbatim next round.
+      const finalizedSteps = this.finalizeSteps(pending);
+
+      const usage = completedInteraction?.usage ?? runningUsage ?? undefined;
+      // If the stream ended without an interaction.completed (or error) event the
+      // turn was truncated/abnormally cut — report `incomplete` (not `completed`)
+      // so the cycle can continue rather than silently treating partial output as
+      // done. `finalizeSteps` preferred over the server steps so streamed thought
+      // signatures survive the round-trip.
+      let status = completedInteraction?.status;
+      if (!status) {
+        this.logger.warn(
+          'Google Interactions stream ended without an interaction.completed event; treating as incomplete.',
+        );
+        status = 'incomplete';
+      }
+
+      const response: GoogleGenAIInteraction = {
+        ...(completedInteraction ?? {}),
+        id: completedInteraction?.id ?? interactionId ?? nanoid(),
+        status,
+        usage,
+        steps:
+          finalizedSteps.length > 0
+            ? finalizedSteps
+            : (completedInteraction?.steps ?? []),
+      } as unknown as GoogleGenAIInteraction;
+
+      const finalReasoning = this.processThinkingBlock(response);
+      thinking.finalize(finalReasoning ?? undefined);
+
+      const finalText = this.extractResponse(response, endTag ?? '').text;
+      output.finalize(finalText);
+      streamsFinalized = true;
+
+      return { response };
+    } finally {
+      // Finalize the progress streams on a mid-stream failure so the progress
+      // view does not hang in a loading state. Guarded so the success-path
+      // finalize above (with the real content) is not overwritten.
+      if (!streamsFinalized) {
+        thinking.finalize(undefined);
+        output.finalize('');
+      }
     }
-
-    // Assemble the finalized step list from the per-index accumulators so that
-    // thought signatures + function calls round-trip verbatim next round.
-    const finalizedSteps = this.finalizeSteps(pending);
-
-    const usage = completedInteraction?.usage ?? runningUsage ?? undefined;
-    // If the stream ended without an interaction.completed (or error) event the
-    // turn was truncated/abnormally cut — report `incomplete` (not `completed`)
-    // so the cycle can continue rather than silently treating partial output as
-    // done. `finalizeSteps` preferred over the server steps so streamed thought
-    // signatures survive the round-trip.
-    let status = completedInteraction?.status;
-    if (!status) {
-      this.logger.warn(
-        'Google Interactions stream ended without an interaction.completed event; treating as incomplete.',
-      );
-      status = 'incomplete';
-    }
-
-    const response: GoogleGenAIInteraction = {
-      ...(completedInteraction ?? {}),
-      id: completedInteraction?.id ?? interactionId ?? nanoid(),
-      status,
-      usage,
-      steps:
-        finalizedSteps.length > 0
-          ? finalizedSteps
-          : (completedInteraction?.steps ?? []),
-    } as unknown as GoogleGenAIInteraction;
-
-    const finalReasoning = this.processThinkingBlock(response);
-    thinking.finalize(finalReasoning ?? undefined);
-
-    const finalText = this.extractResponse(response, endTag ?? '').text;
-    output.finalize(finalText);
-
-    return { response };
   }
 
   private seedPendingStep(step?: Step): PendingStep {

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -2004,10 +2004,12 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
     } finally {
       // Finalize the progress streams on a mid-stream failure so the progress
       // view does not hang in a loading state. Guarded so the success-path
-      // finalize above (with the real content) is not overwritten.
+      // finalize above (with the real content) is not overwritten. No explicit
+      // final text so any chunks already streamed are preserved (passing `''`
+      // would overwrite the visible partial output).
       if (!streamsFinalized) {
         thinking.finalize(undefined);
-        output.finalize('');
+        output.finalize();
       }
     }
   }

--- a/src/agent/modelHandlers/modelHandlerValidation.ts
+++ b/src/agent/modelHandlers/modelHandlerValidation.ts
@@ -8,6 +8,7 @@ import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import type { MediaEntry } from '@agent/utils/mediaTypes';
 
 // Local imports - tools and utils
+import replacementEngine from '@replacement/engine';
 import type { FileLocation } from '@shared/schemas';
 import type { ToolFileAttachment } from '@shared/schemas/toolResult';
 
@@ -100,8 +101,12 @@ export class ModelHandlerValidation extends ModelHandler<
   }
 
   extractResponse(responseObject: ValidationResponse): ExtractResponseResult {
+    // Apply text cleanup here like every other handler's extractResponse. The
+    // response cycle relies on this single per-handler pass (it no longer
+    // re-applies cleanup itself), so a handler that returned raw text would
+    // silently skip cleanup on the reflection path.
     return {
-      text: responseObject.text,
+      text: replacementEngine.applyAll(responseObject.text),
       usage: responseObject.usage,
       stopReason: responseObject.stopReason,
     };

--- a/src/agent/modelHandlers/openai/OpenAIResponseWebSocketTransport.ts
+++ b/src/agent/modelHandlers/openai/OpenAIResponseWebSocketTransport.ts
@@ -251,8 +251,15 @@ export class OpenAIResponseWebSocketTransport {
         }
       };
 
-      /** Attach partial-text tail to an error before rejecting with it. */
+      /** Finalize the processor's streams, attach any partial-text tail, then reject. */
       const rejectWithPartial = (err: unknown): void => {
+        // Finalize the processor's progress streams so a mid-stream WebSocket
+        // failure does not leave the progress view hanging in a loading state.
+        // Unlike the HTTP path (which finalizes via the caller's catch), the
+        // processor is owned here and is never returned to the caller on a
+        // reject, so it must be finalized on this side. `abort()` preserves any
+        // chunks already streamed; `finalize` is idempotent.
+        processor.abort();
         if (streamedText) {
           attachPartialText(err, takeTail(streamedText, PARTIAL_TEXT_TAIL_MAX));
         }
@@ -348,10 +355,11 @@ export class OpenAIResponseWebSocketTransport {
         } as ResponsesClientEvent);
       } catch (sendError) {
         // If send() throws synchronously, clean up listeners to prevent leaks
-        // on the reused WebSocket connection.
+        // on the reused WebSocket connection, and finalize the processor's
+        // streams (via rejectWithPartial) so they do not hang.
         settled = true;
         cleanup();
-        reject(sendError);
+        rejectWithPartial(sendError);
       }
     });
   }

--- a/src/agent/modelHandlers/openai/ResponseStreamProcessor.ts
+++ b/src/agent/modelHandlers/openai/ResponseStreamProcessor.ts
@@ -103,6 +103,17 @@ export class ResponseStreamProcessor {
     this.emitWebSearchesFromResponse(response);
   }
 
+  /**
+   * Finalize the thinking/output streams without a completed response. Used on
+   * the error path so a mid-stream failure does not leave the progress view's
+   * streams hanging in a loading state. `StreamHandle.finalize` is idempotent,
+   * so calling this after a partial `finalize` is safe.
+   */
+  abort(): void {
+    this.closeThinkingStream();
+    this.outputStream.finalize('');
+  }
+
   private openThinkingStream(): StreamHandle {
     return (this.thinkingStream ??= this.deps.createThinkingStream());
   }

--- a/src/agent/modelHandlers/openai/ResponseStreamProcessor.ts
+++ b/src/agent/modelHandlers/openai/ResponseStreamProcessor.ts
@@ -106,12 +106,14 @@ export class ResponseStreamProcessor {
   /**
    * Finalize the thinking/output streams without a completed response. Used on
    * the error path so a mid-stream failure does not leave the progress view's
-   * streams hanging in a loading state. `StreamHandle.finalize` is idempotent,
-   * so calling this after a partial `finalize` is safe.
+   * streams hanging in a loading state. Finalizes with no explicit text so any
+   * chunks already streamed are preserved (passing `''` would overwrite the
+   * visible partial output). `StreamHandle.finalize` is idempotent, so calling
+   * this after a partial `finalize` is safe.
    */
   abort(): void {
     this.closeThinkingStream();
-    this.outputStream.finalize('');
+    this.outputStream.finalize();
   }
 
   private openThinkingStream(): StreamHandle {

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -27,6 +27,7 @@ import {
 import type { ToolDefinition } from '@model';
 
 // Local imports - tools and utils
+import replacementEngine from '@replacement/engine';
 import type { FileLocation } from '@shared/schemas';
 import type { ToolFileAttachment } from '@shared/schemas/toolResult';
 import { isNonEmptyString } from '@utils/core';
@@ -406,6 +407,12 @@ export class ModelHandlerOpenAI<
       this.finalizeStreams(thinking, output, finalResponse);
       return finalResponse;
     } catch (streamError) {
+      // Finalize the progress streams on error so the progress view does not
+      // hang in a loading state (parity with the OpenRouter streaming path).
+      // `finalize` is idempotent, so this is safe even if a partial finalize
+      // already ran.
+      thinking.finalize(undefined);
+      output.finalize('');
       // Tag at the boundary so abort identity survives wrapping and
       // minification (mirrors the Anthropic stream catch).
       tagOpenAISdkError(streamError, this.config.provider);
@@ -899,14 +906,12 @@ export class ModelHandlerOpenAI<
         };
 
         // Add end tag if response was stopped and tag isn't present
-        if (
-          stopReason === OPENAI_CHAT_FINISH.STOP &&
-          endTag &&
-          !newResponse.includes(endTag)
-        ) {
-          this.logger.debug(`Adding end tag to response: ${endTag}`);
-          newResponse = `${newResponse}\n${endTag}`;
-        }
+        newResponse = this.appendEndTagIfNeeded(
+          newResponse,
+          endTag,
+          stopReason === OPENAI_CHAT_FINISH.STOP,
+        );
+        newResponse = replacementEngine.applyAll(newResponse);
 
         return { text: newResponse, usage, stopReason };
       }
@@ -951,14 +956,12 @@ export class ModelHandlerOpenAI<
     }
 
     // Add end tag if response was stopped and tag isn't present
-    if (
-      stopReason === OPENAI_CHAT_FINISH.STOP &&
-      endTag &&
-      !newResponse.includes(endTag)
-    ) {
-      this.logger.debug(`Adding end tag to response: ${endTag}`);
-      newResponse = `${newResponse}\n${endTag}`;
-    }
+    newResponse = this.appendEndTagIfNeeded(
+      newResponse,
+      endTag,
+      stopReason === OPENAI_CHAT_FINISH.STOP,
+    );
+    newResponse = replacementEngine.applyAll(newResponse);
 
     return { text: newResponse, usage: responseObject.usage, stopReason };
   }

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -409,10 +409,11 @@ export class ModelHandlerOpenAI<
     } catch (streamError) {
       // Finalize the progress streams on error so the progress view does not
       // hang in a loading state (parity with the OpenRouter streaming path).
-      // `finalize` is idempotent, so this is safe even if a partial finalize
-      // already ran.
+      // No explicit final text so any chunks already streamed are preserved
+      // (passing `''` would overwrite the visible partial output). `finalize`
+      // is idempotent, so this is safe even if a partial finalize already ran.
       thinking.finalize(undefined);
-      output.finalize('');
+      output.finalize();
       // Tag at the boundary so abort identity survives wrapping and
       // minification (mirrors the Anthropic stream catch).
       tagOpenAISdkError(streamError, this.config.provider);

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -32,6 +32,7 @@ import {
   PARTIAL_TEXT_TAIL_MAX,
 } from '@common/errors/sdkErrorUtils';
 import { isGpt5ModelName, isGptFamilyModelName } from '@model/modelNames';
+import replacementEngine from '@replacement/engine';
 
 // Type imports
 import type { FileLocation } from '@shared/schemas';
@@ -1643,6 +1644,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     // the completed response's `output` empty, so we keep the items to rebuild
     // it below — otherwise the whole turn, tool calls included, is dropped.
     const streamedItems: Response['output'] = [];
+    // Hoisted so the catch can finalize the progress streams on a mid-stream
+    // failure (otherwise the progress view hangs in a loading state).
+    let processor: ResponseStreamProcessor | undefined;
     try {
       const { stream: _stream, ...rest } = params;
       const streamParams: ResponseStreamParams = { ...rest, stream: true };
@@ -1650,7 +1654,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
       // Processor handles interleaved thinking and web search
       // GPT can: think → web_search → think more → web_search → text
-      const processor = this.createStreamProcessor();
+      processor = this.createStreamProcessor();
 
       for await (const event of stream) {
         processor.process(event);
@@ -1704,6 +1708,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       );
       return { response, updatedMessages: ctx.compactedMessages };
     } catch (error) {
+      // Finalize the progress streams on error so the view does not hang in a
+      // loading state (no-op if the stream never opened or already finalized).
+      processor?.abort();
       // Attach a capped tail of any streamed text before it propagates so the
       // retry UI receives the same structured error shape downstream.
       if (streamedText) {
@@ -1901,13 +1908,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         ? OPENAI_CHAT_FINISH.STOP
         : OPENAI_CHAT_FINISH.LENGTH;
 
-    if (
-      stopReason === OPENAI_CHAT_FINISH.STOP &&
-      endTag &&
-      !newResponse.includes(endTag)
-    ) {
-      return { text: `${newResponse}\n${endTag}`, usage, stopReason };
-    }
+    newResponse = this.appendEndTagIfNeeded(
+      newResponse,
+      endTag,
+      stopReason === OPENAI_CHAT_FINISH.STOP,
+    );
+    newResponse = replacementEngine.applyAll(newResponse);
 
     return { text: newResponse, usage, stopReason };
   }

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -16,6 +16,7 @@ import {
   takeTail,
   PARTIAL_TEXT_TAIL_MAX,
 } from '@common/errors/sdkErrorUtils';
+import replacementEngine from '@replacement/engine';
 
 // Local imports - tools and utils
 import type { FileLocation } from '@shared/schemas';
@@ -546,14 +547,12 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
       this.logger.error('content is empty');
     }
 
-    if (
-      stopReason === OPENAI_CHAT_FINISH.STOP &&
-      endTag &&
-      !newResponse.includes(endTag)
-    ) {
-      this.logger.debug(`Adding end tag to response: ${endTag}`);
-      newResponse = `${newResponse}\n${endTag}`;
-    }
+    newResponse = this.appendEndTagIfNeeded(
+      newResponse,
+      endTag,
+      stopReason === OPENAI_CHAT_FINISH.STOP,
+    );
+    newResponse = replacementEngine.applyAll(newResponse);
 
     return {
       text: newResponse,

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -244,9 +244,11 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
         return { response, updatedMessages };
       } catch (err) {
         // Ensure progress streams are finalized on error to prevent
-        // the progress view from being stuck in a loading state
+        // the progress view from being stuck in a loading state. No explicit
+        // final text so any chunks already streamed are preserved (passing `''`
+        // would overwrite the visible partial output).
         thinking.finalize(undefined);
-        output.finalize('');
+        output.finalize();
         // Lift the accumulated partial text onto the error so the retry UI
         // can show the tail (parity with the other streaming providers).
         const partialTail = takeTail(


### PR DESCRIPTION
## Summary

A model-handler tech-debt audit surfaced two real bugs and one duplication cleanup, all in `src/agent/modelHandlers/`. This PR fixes them together because they touch the same `extractResponse` / streaming code paths.

1. **Cross-provider output cleanup (bug).** `extractResponse` ran `replacementEngine.applyAll` (the LaTeX/text cleanup pass) for the Anthropic and Google handlers but **not** for OpenAI, OpenAI-Responses, or OpenRouter. The reflection flow hid this because it re-applies cleanup at `ResponseCycleFlow`, but the **tool-use flow** (`ToolUseProcessNode`) consumes the handler text directly — so the final assistant response from OpenAI/OpenRouter/xAI bypassed cleanup that Anthropic/Google output received. Now applied symmetrically in all handlers (xAI inherits via OpenAI).

2. **Un-finalized progress streams on mid-stream error (bug).** Only the OpenRouter handler finalized its thinking/output streams when a stream failed mid-flight. OpenAI, OpenAI-Responses, GoogleGenAI, and Google Interactions left them open, which can leave the progress view stuck in a loading state after a mid-stream failure. Each now finalizes on the error path.

3. **End-tag dedupe (refactor).** The duplicated "append the agent end tag on a natural stop" block (7 copies) is extracted into a shared `ModelHandler.appendEndTagIfNeeded` helper.

## Issue acceptance gates

No tracked issue — findings came from an internal audit. Acceptance: tool-use final responses from every provider receive the same text cleanup; a mid-stream error finalizes the progress streams for every provider; the end-tag logic has a single source.

## Single source of truth

- **End-tag appending** now lives in `ModelHandler.appendEndTagIfNeeded` (base class), replacing 5 inline copies.
- **Error-path stream finalization** for the OpenAI-Responses handler is owned by the new `ResponseStreamProcessor.abort()`, alongside the existing `finalize()`.

## Duplication and abstraction budget

- Removed 5 copies of the end-tag append block in favor of one base-class helper.
- `appendEndTagIfNeeded` owns the invariant "append `endTag` only on a natural stop when not already present (`includes` check)"; callers still supply their own provider-specific natural-stop predicate, so no provider's stop vocabulary leaks into the base.
- `ResponseStreamProcessor.abort()` owns "finalize streams without a completed response"; it reuses the existing idempotent `StreamHandle.finalize`, adding no pass-through layer.
- Bug #1 is fixed by applying the existing `replacementEngine` symmetrically rather than adding indirection. Hoisting `applyAll` into the shared dispatcher was considered but rejected: two handlers route their streamed **display** text through `extractResponse`, so hoisting would have regressed the progress-view display to raw text. Left as a documented follow-up.

## Host impact

Extension: Indirect only — affects agent model output (cleaner OpenAI/OpenRouter tool-use responses; progress view no longer hangs on mid-stream errors). No API/UI changes.

Desktop: Same indirect behavior via the shared core. No host-specific changes.

CLI: Same indirect behavior via the shared core. No host-specific changes.

## Scheduled refactoring

Follow-ups identified by the audit, intentionally **not** included here to keep this PR focused and low-risk:
- Hoist `replacementEngine.applyAll` into the shared `extractModelResponse` dispatcher and fold display-text cleanup, removing the per-handler `applyAll` copies.
- Extract a `BackgroundPoller` collaborator for the duplicated OpenAI/Google background-mode poll loops.
- Extract a base-class `runStreamingResponse` template unifying the open/accumulate/finalize/tail-attach scaffold across handlers.
- Share a `createSettingsViewCommandHandlers` factory across the extension + desktop settings dispatch (80 duplicated command keys), mirroring the existing progress-view factory.

## Validation

- `npm run typecheck` — passes.
- `npm test` — all model-handler and flow suites pass (3970 passing). One unrelated failure, `src/test-kernel/utils/system/execUtils.vitest.ts` (POSIX process-group kill), reproduces on the clean base in this sandbox and is environmental, not caused by this change.
- `npm run lint` — changed files are clean (0 errors); pre-existing warnings elsewhere untouched.
- Added behavior is covered by the existing streaming/extract suites, including the Google Interactions streaming test that asserts the success-path finalize content is preserved (guarded so the error-path finalize does not overwrite it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsAhWnjErzCEbASXYv9pV8

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsAhWnjErzCEbASXYv9pV8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes span all major model handlers and shared response-cycle output paths; behavior fixes are targeted but affect final assistant text and progress UI on errors across providers.
> 
> **Overview**
> **Model output cleanup is applied once per provider** via each handler’s `extractResponse` (`replacementEngine.applyAll`), including OpenAI, OpenAI-Responses, OpenRouter, and the validation handler. **ResponseCycleFlow no longer re-applies cleanup**, avoiding double runs of non-idempotent replacements.
> 
> **End-tag appending on natural stop** is centralized in `ModelHandler.appendEndTagIfNeeded`, replacing duplicated inline logic in Anthropic/OpenAI handlers.
> 
> **Mid-stream failures** now finalize thinking/output progress streams (and OpenAI-Responses adds `ResponseStreamProcessor.abort()`) across Google GenAI, Google Interactions, OpenAI chat streaming, OpenAI-Responses HTTP/WebSocket, and OpenRouter—preserving partial streamed text instead of leaving the UI loading or overwriting with empty final text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e839525e15bbbf274dec8a4a372275167b4fe0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->