### PR TITLE
fix(cli): skip retry modal when personal key exists

### DIFF
--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -230,3 +230,26 @@ export function clearApprovals(): void {
     if (item === activeItem) advance?.();
   }
 }
+
+export function clearRetryApprovalsForStream(streamId: string): void {
+  let changed = false;
+  for (const item of [...pendingItems]) {
+    if (
+      item.payload.kind !== 'retry' ||
+      item.payload.payload.streamId !== streamId
+    ) {
+      continue;
+    }
+    if (!pendingItems.delete(item)) continue;
+    changed = true;
+    const advance = item.advance;
+    item.advance = undefined;
+    item.resolve(INTERRUPT);
+    if (currentItem === item) {
+      currentItem = undefined;
+      CURRENT.set(undefined);
+      advance?.();
+    }
+  }
+  if (changed) syncApprovalStatus();
+}

--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -79,6 +79,7 @@ export const currentApproval = CURRENT as Signal.State<
 export const approvalQueueStatus = STATUS as Signal.State<ApprovalQueueStatus>;
 
 const queue = new PQueue({ concurrency: 1 });
+const clearListeners = new Set<() => void>();
 
 interface ApprovalQueueItem {
   readonly payload: ApprovalPayload;
@@ -93,6 +94,13 @@ const INTERRUPT: ApprovalDecision = {
   accepted: false,
   userMessage: 'Session interrupted.',
 };
+
+export function onApprovalsCleared(listener: () => void): () => void {
+  clearListeners.add(listener);
+  return () => {
+    clearListeners.delete(listener);
+  };
+}
 
 function statusKindForPayload(
   payload: ApprovalPayload,
@@ -218,6 +226,14 @@ export function enqueueApproval(
 export function clearApprovals(): void {
   queue.clear();
   CURRENT.set(undefined);
+  for (const listener of clearListeners) {
+    try {
+      listener();
+    } catch {
+      // Clear hooks invalidate surrounding async state only; approval
+      // interruption must continue even if a hook fails.
+    }
+  }
   const items = [...pendingItems];
   pendingItems.clear();
   syncApprovalStatus();

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -42,7 +42,12 @@ import { handleUserQuestionAction } from '@tools/userQuestion';
 import { handleExternalInquiryAction } from '@tools/inquiry/ExternalInquiryTool';
 
 import { assertNever } from '@utils/core';
-import { lookupApiKey, isApiProvider } from '@model/apiProviders';
+import {
+  API_PROVIDERS,
+  lookupApiKey,
+  isApiProvider,
+  type ApiProvider,
+} from '@model/apiProviders';
 import { platform } from '@platform/platform';
 import { notify } from '../notifications/terminalNotifier';
 import { cliState } from './cliState';
@@ -59,8 +64,7 @@ import {
 // =========================================================================
 
 /** Check whether a usable personal API key is stored for a provider. */
-async function hasUsablePersonalKey(provider: string): Promise<boolean> {
-  if (!isApiProvider(provider)) return false;
+async function hasUsablePersonalKey(provider: ApiProvider): Promise<boolean> {
   const key = await lookupApiKey(platform().secrets, provider);
   return typeof key === 'string' && key.trim().length > 0;
 }
@@ -85,15 +89,22 @@ async function maybeAutoSwitchRetry(
   // auto-switch to the stored value.
   if (details?.isUpstreamCreditDepleted) return undefined;
 
-  // ChatGPT-subscription exhaustion → the user needs an OpenAI key.
-  // Relay exhaustion → use the provider from the error details if known.
-  const provider = isCliChatGptSubscriptionRetry(payload)
-    ? 'openai'
-    : details?.provider;
+  // ChatGPT-subscription exhaustion -> the user needs an OpenAI key.
+  // Relay exhaustion -> use the provider from error details when known;
+  // provider-less relay failures can use any configured personal key.
+  const providers: readonly ApiProvider[] = isCliChatGptSubscriptionRetry(
+    payload,
+  )
+    ? ['openai']
+    : details?.provider && isApiProvider(details.provider)
+      ? [details.provider]
+      : API_PROVIDERS;
 
-  if (!provider || !isApiProvider(provider)) return undefined;
-
-  const hasKey = await hasUsablePersonalKey(provider);
+  const hasKey = (
+    await Promise.all(
+      providers.map((provider) => hasUsablePersonalKey(provider)),
+    )
+  ).some(Boolean);
   if (!hasKey) return undefined;
 
   const isChatGptSubscription = isCliChatGptSubscriptionRetry(payload);
@@ -199,37 +210,13 @@ function routeApproval(
         dispatchProposal,
       );
       return;
-    case 'showRetryRequest': {
-      const retryPayload = payload as ProgressEventPayloads['showRetryRequest'];
-      // Policy check (yolo/never). For 'ask' mode this returns undefined
-      // so the user can decide; for auto modes it returns yolo(accept) or
-      // never(reject) directly. When the failing request carries a
-      // credential-exhausted / 401-403 error the policy also returns
-      // undefined in interactive mode so the switch-to-personal affordance
-      // remains available.
-      const policy = immediateDecisionForApproval(
-        'showRetryRequest',
-        retryPayload,
+    case 'showRetryRequest':
+      routeRetry(
         context,
+        host,
+        payload as ProgressEventPayloads['showRetryRequest'],
       );
-      if (policy) {
-        dispatchRetry(retryPayload, policy);
-        return;
-      }
-      // Relay / subscription exhaustion with a stored personal key →
-      // switch and retry without showing the modal (matches progress-view
-      // gate: ProgressApiKeyRetryController §hasAnyUsableKey).
-      void (async () => {
-        const autoDecision = await maybeAutoSwitchRetry(retryPayload);
-        if (autoDecision) {
-          await applyRetryDecision(retryPayload, autoDecision);
-          return;
-        }
-        // No usable key available — show the modal so the user can enter one.
-        routeWithPolicyForRetry(context, host, retryPayload);
-      })();
       return;
-    }
     case 'showExternalInquiry':
       // Human-input requests cannot be auto-answered in yolo mode, so they
       // share a policy helper with the non-TUI approval path.
@@ -252,20 +239,43 @@ function routeApproval(
 }
 
 /**
- * Enqueue a retry approval for the TUI modal — only called after the
- * auto-switch check found no usable personal key, so the user needs to
- * see the retry prompt.
+ * Retry auto-switches need an async key lookup before the modal appears.
+ * Track the latest route per stream so a stale lookup cannot switch API mode
+ * or trigger an older retry after a newer retry request replaced it.
  */
-function routeWithPolicyForRetry(
+const activeRetryRoutes = new Map<string, symbol>();
+
+function routeRetry(
   context: CliContext,
   host: CliRuntimeHost,
   payload: ProgressEventPayloads['showRetryRequest'],
 ): void {
-  const queuePayload: ApprovalPayload = { kind: 'retry', payload };
-  void enqueueTuiApproval(queuePayload, host).then((decision) => {
-    markIfRejected(context, decision);
-    dispatchRetry(payload, decision);
-  });
+  const routeId = Symbol(payload.streamId);
+  activeRetryRoutes.set(payload.streamId, routeId);
+  const isCurrent = () => activeRetryRoutes.get(payload.streamId) === routeId;
+  const finish = () => {
+    if (isCurrent()) activeRetryRoutes.delete(payload.streamId);
+  };
+
+  routeWithPolicy(
+    context,
+    host,
+    'retry',
+    payload,
+    (retryPayload, decision) => {
+      if (!isCurrent()) return;
+      dispatchRetry(retryPayload, decision, { isCurrent, onComplete: finish });
+    },
+    {
+      beforeQueue: maybeAutoSwitchRetry,
+      isCurrent,
+    },
+  );
+}
+
+interface RouteWithPolicyOptions<P> {
+  beforeQueue?: (payload: P) => Promise<ApprovalDecision | undefined>;
+  isCurrent?: () => boolean;
 }
 
 function routeWithPolicy<K extends 'bash' | 'plan' | 'proposal' | 'retry', P>(
@@ -274,6 +284,7 @@ function routeWithPolicy<K extends 'bash' | 'plan' | 'proposal' | 'retry', P>(
   kind: K,
   payload: P,
   dispatch: (payload: P, decision: ApprovalDecision) => void,
+  options: RouteWithPolicyOptions<P> = {},
 ): void {
   const policy =
     kind === 'retry'
@@ -293,10 +304,36 @@ function routeWithPolicy<K extends 'bash' | 'plan' | 'proposal' | 'retry', P>(
     ApprovalPayload,
     { kind: K }
   >;
-  void enqueueTuiApproval(queuePayload, host).then((decision) => {
-    markIfRejected(context, decision);
-    dispatch(payload, decision);
-  });
+  void (async () => {
+    try {
+      let autoDecision: ApprovalDecision | undefined;
+      if (options.beforeQueue) {
+        try {
+          autoDecision = await options.beforeQueue(payload);
+        } catch {
+          autoDecision = undefined;
+        }
+        if (options.isCurrent && !options.isCurrent()) return;
+        if (autoDecision) {
+          dispatch(payload, autoDecision);
+          return;
+        }
+      }
+
+      const decision = await enqueueTuiApproval(queuePayload, host);
+      if (options.isCurrent && !options.isCurrent()) return;
+      markIfRejected(context, decision);
+      dispatch(payload, decision);
+    } catch {
+      if (options.isCurrent && !options.isCurrent()) return;
+      const decision: ApprovalDecision = {
+        accepted: false,
+        userMessage: 'CLI approval prompt failed.',
+      };
+      markIfRejected(context, decision);
+      dispatch(payload, decision);
+    }
+  })();
 }
 
 export function enqueueTuiApproval(
@@ -356,10 +393,18 @@ function dispatchProposal(
 function dispatchRetry(
   payload: ProgressEventPayloads['showRetryRequest'],
   decision: ApprovalDecision,
+  options: { isCurrent?: () => boolean; onComplete?: () => void } = {},
 ): void {
   if (decision.accepted) {
-    void applyRetryDecision(payload, decision);
+    void applyRetryDecision(payload, decision, options)
+      .catch(() => {
+        runCoordinatorBridge.cancelRetry(payload.streamId);
+      })
+      .finally(() => {
+        options.onComplete?.();
+      });
   } else {
+    options.onComplete?.();
     runCoordinatorBridge.cancelRetry(payload.streamId);
   }
 }
@@ -367,9 +412,13 @@ function dispatchRetry(
 async function applyRetryDecision(
   payload: ProgressEventPayloads['showRetryRequest'],
   decision: ApprovalDecision,
+  options: { isCurrent?: () => boolean } = {},
 ): Promise<void> {
+  const isCurrent = () => options.isCurrent?.() ?? true;
+  if (!isCurrent()) return;
   if (decision.apiMode) {
     await setCliApiMode(decision.apiMode);
+    if (!isCurrent()) return;
     cliState.sessionMeta.set({
       ...cliState.sessionMeta.get(),
       apiMode: decision.apiMode,
@@ -377,7 +426,9 @@ async function applyRetryDecision(
   }
   if (decision.disableChatGptSubscription) {
     await setCliCodexSubscription(false);
+    if (!isCurrent()) return;
   }
+  if (!isCurrent()) return;
   runCoordinatorBridge.triggerRetry(payload.streamId, decision.userMessage);
 }
 

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -54,6 +54,7 @@ import { cliState } from './cliState';
 import { setCliCodexSubscription } from './codexSubscription';
 import {
   approvalPayloadStreamId,
+  clearRetryApprovalsForStream,
   enqueueApproval,
   type ApprovalDecision,
   type ApprovalPayload,
@@ -264,6 +265,12 @@ function routeRetry(
     payload,
     (retryPayload, decision) => {
       if (!isCurrent()) return;
+      if (
+        decision.accepted &&
+        (decision.apiMode || decision.disableChatGptSubscription)
+      ) {
+        clearRetryApprovalsForStream(retryPayload.streamId);
+      }
       dispatchRetry(retryPayload, decision, { isCurrent, onComplete: finish });
     },
     {
@@ -398,7 +405,9 @@ function dispatchRetry(
   if (decision.accepted) {
     void applyRetryDecision(payload, decision, options)
       .catch(() => {
-        runCoordinatorBridge.cancelRetry(payload.streamId);
+        if (options.isCurrent?.() ?? true) {
+          runCoordinatorBridge.cancelRetry(payload.streamId);
+        }
       })
       .finally(() => {
         options.onComplete?.();

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -74,7 +74,7 @@ async function hasUsablePersonalKey(provider: ApiProvider): Promise<boolean> {
  * When a retry is triggered by relay exhaustion or ChatGPT-subscription
  * limits, and the stored personal key is not the broken credential, switch
  * to personal keys and retry without showing the modal — matching the
- * progress-view behaviour in {@link ProgressApiKeyRetryController}.
+ * progress-view API-key retry behaviour.
  *
  * Returns the auto-switch decision, or `undefined` when the modal is needed
  * (no usable key stored, direct-key failure, or unknown provider).

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -20,6 +20,8 @@ import {
   humanInputDenialFeedback,
   immediateDecision,
   immediateDecisionForApproval,
+  isCliApiSwitchableRetry,
+  isCliChatGptSubscriptionRetry,
   markApprovalDenied,
 } from '@cli/runtime/approvalAdapter';
 import {
@@ -40,6 +42,8 @@ import { handleUserQuestionAction } from '@tools/userQuestion';
 import { handleExternalInquiryAction } from '@tools/inquiry/ExternalInquiryTool';
 
 import { assertNever } from '@utils/core';
+import { lookupApiKey, isApiProvider } from '@model/apiProviders';
+import { platform } from '@platform/platform';
 import { notify } from '../notifications/terminalNotifier';
 import { cliState } from './cliState';
 import { setCliCodexSubscription } from './codexSubscription';
@@ -49,6 +53,56 @@ import {
   type ApprovalDecision,
   type ApprovalPayload,
 } from './approvalQueue';
+
+// =========================================================================
+// Retry auto-switch: skip the modal when a usable personal key exists
+// =========================================================================
+
+/** Check whether a usable personal API key is stored for a provider. */
+async function hasUsablePersonalKey(provider: string): Promise<boolean> {
+  if (!isApiProvider(provider)) return false;
+  const key = await lookupApiKey(platform().secrets, provider);
+  return typeof key === 'string' && key.trim().length > 0;
+}
+
+/**
+ * When a retry is triggered by relay exhaustion or ChatGPT-subscription
+ * limits, and the stored personal key is not the broken credential, switch
+ * to personal keys and retry without showing the modal — matching the
+ * progress-view behaviour in {@link ProgressApiKeyRetryController}.
+ *
+ * Returns the auto-switch decision, or `undefined` when the modal is needed
+ * (no usable key stored, direct-key failure, or unknown provider).
+ */
+async function maybeAutoSwitchRetry(
+  payload: ProgressEventPayloads['showRetryRequest'],
+): Promise<ApprovalDecision | undefined> {
+  if (!isCliApiSwitchableRetry(payload)) return undefined;
+
+  const details = payload.errorDetails;
+  // Upstream credit depletion means the stored direct key IS the broken
+  // credential — the user must provide a changed key, so we cannot
+  // auto-switch to the stored value.
+  if (details?.isUpstreamCreditDepleted) return undefined;
+
+  // ChatGPT-subscription exhaustion → the user needs an OpenAI key.
+  // Relay exhaustion → use the provider from the error details if known.
+  const provider = isCliChatGptSubscriptionRetry(payload)
+    ? 'openai'
+    : details?.provider;
+
+  if (!provider || !isApiProvider(provider)) return undefined;
+
+  const hasKey = await hasUsablePersonalKey(provider);
+  if (!hasKey) return undefined;
+
+  const isChatGptSubscription = isCliChatGptSubscriptionRetry(payload);
+  return {
+    accepted: true,
+    apiMode: 'personal',
+    ...(isChatGptSubscription ? { disableChatGptSubscription: true } : {}),
+  };
+}
 
 /**
  * Install the typed approval pipeline. Returns an `unbind` callback that
@@ -145,15 +199,38 @@ function routeApproval(
         dispatchProposal,
       );
       return;
-    case 'showRetryRequest':
-      routeWithPolicy(
+    case 'showRetryRequest': {
+      const retryPayload =
+        payload as ProgressEventPayloads['showRetryRequest'];
+      // Policy check (yolo/never). For 'ask' mode this returns undefined
+      // so the user can decide; for auto modes it returns yolo(accept) or
+      // never(reject) directly. When the failing request carries a
+      // credential-exhausted / 401-403 error the policy also returns
+      // undefined in interactive mode so the switch-to-personal affordance
+      // remains available.
+      const policy = immediateDecisionForApproval(
+        'showRetryRequest',
+        retryPayload,
         context,
-        host,
-        cliApprovalEventKind(event),
-        payload as ProgressEventPayloads['showRetryRequest'],
-        dispatchRetry,
       );
+      if (policy) {
+        dispatchRetry(retryPayload, policy);
+        return;
+      }
+      // Relay / subscription exhaustion with a stored personal key →
+      // switch and retry without showing the modal (matches progress-view
+      // gate: ProgressApiKeyRetryController §hasAnyUsableKey).
+      void (async () => {
+        const autoDecision = await maybeAutoSwitchRetry(retryPayload);
+        if (autoDecision) {
+          await applyRetryDecision(retryPayload, autoDecision);
+          return;
+        }
+        // No usable key available — show the modal so the user can enter one.
+        routeWithPolicyForRetry(context, host, retryPayload);
+      })();
       return;
+    }
     case 'showExternalInquiry':
       // Human-input requests cannot be auto-answered in yolo mode, so they
       // share a policy helper with the non-TUI approval path.
@@ -173,6 +250,23 @@ function routeApproval(
     default:
       assertNever(event, 'Unhandled TUI approval event');
   }
+}
+
+/**
+ * Enqueue a retry approval for the TUI modal — only called after the
+ * auto-switch check found no usable personal key, so the user needs to
+ * see the retry prompt.
+ */
+function routeWithPolicyForRetry(
+  context: CliContext,
+  host: CliRuntimeHost,
+  payload: ProgressEventPayloads['showRetryRequest'],
+): void {
+  const queuePayload: ApprovalPayload = { kind: 'retry', payload };
+  void enqueueTuiApproval(queuePayload, host).then((decision) => {
+    markIfRejected(context, decision);
+    dispatchRetry(payload, decision);
+  });
 }
 
 function routeWithPolicy<K extends 'bash' | 'plan' | 'proposal' | 'retry', P>(

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -13,6 +13,7 @@
 // it returns a typed Promise<ToolEditApprovalResult>, not a fire-and-forget
 // event).
 
+import { platform } from '@platform/platform';
 import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
 import { setCliApiMode } from '@cli/runtime/apiAccessMode';
 import {
@@ -33,6 +34,12 @@ import type { CliContext } from '@cli/runtime/cliContext';
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import {
+  API_PROVIDERS,
+  lookupApiKey,
+  isApiProvider,
+  type ApiProvider,
+} from '@model/apiProviders';
+import {
   handleProgressViewBashApprovalAction,
   setBashApprovalSessionBypass,
   setToolEditApprovalSessionBypass,
@@ -42,13 +49,6 @@ import { handleUserQuestionAction } from '@tools/userQuestion';
 import { handleExternalInquiryAction } from '@tools/inquiry/ExternalInquiryTool';
 
 import { assertNever } from '@utils/core';
-import {
-  API_PROVIDERS,
-  lookupApiKey,
-  isApiProvider,
-  type ApiProvider,
-} from '@model/apiProviders';
-import { platform } from '@platform/platform';
 import { notify } from '../notifications/terminalNotifier';
 import { cliState } from './cliState';
 import { setCliCodexSubscription } from './codexSubscription';
@@ -56,6 +56,7 @@ import {
   approvalPayloadStreamId,
   clearRetryApprovalsForStream,
   enqueueApproval,
+  onApprovalsCleared,
   type ApprovalDecision,
   type ApprovalPayload,
 } from './approvalQueue';
@@ -97,9 +98,12 @@ async function maybeAutoSwitchRetry(
     payload,
   )
     ? ['openai']
-    : details?.provider && isApiProvider(details.provider)
-      ? [details.provider]
+    : details?.provider
+      ? isApiProvider(details.provider)
+        ? [details.provider]
+        : []
       : API_PROVIDERS;
+  if (providers.length === 0) return undefined;
 
   const hasKey = (
     await Promise.all(
@@ -125,6 +129,9 @@ export function installTuiApprovals(
   context: CliContext,
 ): () => void {
   const originalEmit = host.emit;
+  const disposeApprovalClearListener = onApprovalsCleared(() => {
+    invalidateRetryRoutes({ cancel: true });
+  });
   host.emit = ((event, payload) => {
     // Approval events are intentionally NOT forwarded to originalEmit.
     // The underlying `createCliRuntimeHost.emit` chains through
@@ -163,6 +170,8 @@ export function installTuiApprovals(
   });
 
   return () => {
+    invalidateRetryRoutes({ cancel: false });
+    disposeApprovalClearListener();
     host.emit = originalEmit;
     setToolEditApprovalHandler();
   };
@@ -246,6 +255,15 @@ function routeApproval(
  */
 const activeRetryRoutes = new Map<string, symbol>();
 
+function invalidateRetryRoutes(options: { cancel: boolean }): void {
+  const streamIds = [...activeRetryRoutes.keys()];
+  activeRetryRoutes.clear();
+  if (!options.cancel) return;
+  for (const streamId of streamIds) {
+    runCoordinatorBridge.cancelRetry(streamId);
+  }
+}
+
 function routeRetry(
   context: CliContext,
   host: CliRuntimeHost,
@@ -253,6 +271,7 @@ function routeRetry(
 ): void {
   const routeId = Symbol(payload.streamId);
   activeRetryRoutes.set(payload.streamId, routeId);
+  clearRetryApprovalsForStream(payload.streamId);
   const isCurrent = () => activeRetryRoutes.get(payload.streamId) === routeId;
   const finish = () => {
     if (isCurrent()) activeRetryRoutes.delete(payload.streamId);
@@ -318,6 +337,7 @@ function routeWithPolicy<K extends 'bash' | 'plan' | 'proposal' | 'retry', P>(
         try {
           autoDecision = await options.beforeQueue(payload);
         } catch {
+          // The lookup is speculative; falling back to the retry modal is safe.
           autoDecision = undefined;
         }
         if (options.isCurrent && !options.isCurrent()) return;

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -200,8 +200,7 @@ function routeApproval(
       );
       return;
     case 'showRetryRequest': {
-      const retryPayload =
-        payload as ProgressEventPayloads['showRetryRequest'];
+      const retryPayload = payload as ProgressEventPayloads['showRetryRequest'];
       // Policy check (yolo/never). For 'ask' mode this returns undefined
       // so the user can decide; for auto modes it returns yolo(accept) or
       // never(reject) directly. When the failing request carries a

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -1,0 +1,232 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  lookupApiKey: vi.fn(),
+  notify: vi.fn(),
+  secrets: {},
+  setCliApiMode: vi.fn(async () => undefined),
+  setCliCodexSubscription: vi.fn(async () => undefined),
+  triggerRetry: vi.fn(),
+  cancelRetry: vi.fn(),
+}));
+
+vi.mock('@cli/chat/tui/notifications/terminalNotifier', () => ({
+  notify: mocks.notify,
+}));
+
+vi.mock('@cli/runtime/apiAccessMode', async (importActual) => {
+  const actual =
+    await importActual<typeof import('@cli/runtime/apiAccessMode')>();
+  return {
+    ...actual,
+    setCliApiMode: mocks.setCliApiMode,
+  };
+});
+
+vi.mock('@cli/chat/tui/state/codexSubscription', () => ({
+  setCliCodexSubscription: mocks.setCliCodexSubscription,
+}));
+
+vi.mock('@agent/runtime/runCoordinators', () => ({
+  runCoordinatorBridge: {
+    triggerRetry: mocks.triggerRetry,
+    cancelRetry: mocks.cancelRetry,
+  },
+}));
+
+vi.mock('@cli/runtime/approvalAdapter', () => ({
+  approvalPromptAllowed: (context: { approvalPolicy: string; mode: string }) =>
+    context.approvalPolicy === 'ask' && context.mode === 'interactive',
+  humanInputDenialFeedback: () => 'Denied by CLI approval policy.',
+  immediateDecision: (context: { approvalPolicy: string }) => {
+    if (context.approvalPolicy === 'yolo') return { accepted: true };
+    if (context.approvalPolicy === 'ask') return undefined;
+    return { accepted: false, userMessage: 'Denied by CLI approval policy.' };
+  },
+  immediateDecisionForApproval: (
+    _event: string,
+    _payload: unknown,
+    context: { approvalPolicy: string; mode: string },
+  ) => {
+    if (context.approvalPolicy === 'ask' && context.mode === 'interactive') {
+      return undefined;
+    }
+    if (context.approvalPolicy === 'yolo') return { accepted: true };
+    return { accepted: false, userMessage: 'Denied by CLI approval policy.' };
+  },
+  isCliApiSwitchableRetry: (payload: {
+    errorDetails?: { isCredentialExhausted?: boolean; isRelayError?: boolean };
+  }) =>
+    payload.errorDetails?.isCredentialExhausted === true &&
+    payload.errorDetails?.isRelayError === true,
+  isCliChatGptSubscriptionRetry: () => false,
+  markApprovalDenied: vi.fn(),
+}));
+
+vi.mock('@model/apiProviders', async (importActual) => {
+  const actual = await importActual<typeof import('@model/apiProviders')>();
+  return {
+    ...actual,
+    lookupApiKey: mocks.lookupApiKey,
+  };
+});
+
+vi.mock('@platform/platform', () => ({
+  platform: () => ({ secrets: mocks.secrets }),
+}));
+
+import { API_PROVIDERS, type ApiProvider } from '@model/apiProviders';
+import {
+  clearApprovals,
+  currentApproval,
+} from '@cli/chat/tui/state/approvalQueue';
+import { installTuiApprovals } from '@cli/chat/tui/state/subscribeApprovals';
+import type { CliContext } from '@cli/runtime/cliContext';
+import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+
+function context(): CliContext {
+  return {
+    cwd: '/work',
+    mode: 'interactive',
+    outputFormat: 'text',
+    approvalPolicy: 'ask',
+    colorEnabled: false,
+    version: 'test',
+    resourcesPath: '/resources',
+  };
+}
+
+function host(): CliRuntimeHost {
+  return {
+    emit: vi.fn(),
+    close: vi.fn(async () => undefined),
+  } as unknown as CliRuntimeHost;
+}
+
+function relayRetry(params: {
+  streamId: string;
+  provider?: string;
+  message?: string;
+}): ProgressEventPayloads['showRetryRequest'] {
+  return {
+    streamId: params.streamId,
+    operation: 'model request',
+    errorMessage: params.message ?? 'Relay monthly limit reached.',
+    errorDetails: {
+      message: params.message ?? 'Relay monthly limit reached.',
+      isCredentialExhausted: true,
+      isRelayError: true,
+      ...(params.provider ? { provider: params.provider } : {}),
+    },
+  } as ProgressEventPayloads['showRetryRequest'];
+}
+
+afterEach(() => {
+  clearApprovals();
+  mocks.lookupApiKey.mockReset();
+  mocks.notify.mockReset();
+  mocks.setCliApiMode.mockClear();
+  mocks.setCliCodexSubscription.mockClear();
+  mocks.triggerRetry.mockClear();
+  mocks.cancelRetry.mockClear();
+});
+
+describe('TUI retry approvals', () => {
+  it('auto-switches provider-less relay retries when any personal key exists', async () => {
+    const fallbackProvider =
+      API_PROVIDERS.find((provider) => provider !== 'openai') ??
+      API_PROVIDERS[0];
+    mocks.lookupApiKey.mockImplementation(
+      async (_secrets, provider: ApiProvider) =>
+        provider === fallbackProvider ? 'sk-test' : undefined,
+    );
+
+    const runtimeHost = host();
+    const unbind = installTuiApprovals(runtimeHost, context());
+    try {
+      runtimeHost.emit('showRetryRequest', relayRetry({ streamId: 's1' }));
+
+      await vi.waitFor(() => {
+        expect(mocks.setCliApiMode).toHaveBeenCalledWith('personal');
+        expect(mocks.triggerRetry).toHaveBeenCalledWith('s1', undefined);
+      });
+      expect(currentApproval.get()).toBeUndefined();
+      expect(mocks.lookupApiKey.mock.calls.map((call) => call[1])).toContain(
+        fallbackProvider,
+      );
+    } finally {
+      unbind();
+    }
+  });
+
+  it('falls back to the retry modal when API key lookup fails', async () => {
+    mocks.lookupApiKey.mockRejectedValue(new Error('keychain unavailable'));
+
+    const runtimeHost = host();
+    const unbind = installTuiApprovals(runtimeHost, context());
+    try {
+      const retry = relayRetry({ streamId: 's2', provider: 'openai' });
+      runtimeHost.emit('showRetryRequest', retry);
+
+      await vi.waitFor(() => {
+        expect(currentApproval.get()?.payload).toMatchObject({
+          kind: 'retry',
+          payload: { streamId: 's2' },
+        });
+      });
+      expect(mocks.triggerRetry).not.toHaveBeenCalled();
+    } finally {
+      unbind();
+    }
+  });
+
+  it('ignores stale auto-switch lookups after a newer retry replaces them', async () => {
+    let resolveFirstLookup: ((value: string | undefined) => void) | undefined;
+    mocks.lookupApiKey
+      .mockImplementationOnce(
+        () =>
+          new Promise<string | undefined>((resolve) => {
+            resolveFirstLookup = resolve;
+          }),
+      )
+      .mockResolvedValueOnce(undefined);
+
+    const runtimeHost = host();
+    const unbind = installTuiApprovals(runtimeHost, context());
+    try {
+      runtimeHost.emit(
+        'showRetryRequest',
+        relayRetry({
+          streamId: 'same-stream',
+          provider: 'openai',
+          message: 'first retry',
+        }),
+      );
+      runtimeHost.emit(
+        'showRetryRequest',
+        relayRetry({
+          streamId: 'same-stream',
+          provider: 'openai',
+          message: 'second retry',
+        }),
+      );
+
+      await vi.waitFor(() => {
+        expect(currentApproval.get()?.payload).toMatchObject({
+          kind: 'retry',
+          payload: { errorMessage: 'second retry' },
+        });
+      });
+
+      resolveFirstLookup?.('sk-stale');
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mocks.setCliApiMode).not.toHaveBeenCalled();
+      expect(mocks.triggerRetry).not.toHaveBeenCalled();
+    } finally {
+      unbind();
+    }
+  });
+});

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -34,34 +34,48 @@ vi.mock('@agent/runtime/runCoordinators', () => ({
   },
 }));
 
-vi.mock('@cli/runtime/approvalAdapter', () => ({
-  approvalPromptAllowed: (context: { approvalPolicy: string; mode: string }) =>
-    context.approvalPolicy === 'ask' && context.mode === 'interactive',
-  humanInputDenialFeedback: () => 'Denied by CLI approval policy.',
-  immediateDecision: (context: { approvalPolicy: string }) => {
-    if (context.approvalPolicy === 'yolo') return { accepted: true };
-    if (context.approvalPolicy === 'ask') return undefined;
-    return { accepted: false, userMessage: 'Denied by CLI approval policy.' };
-  },
-  immediateDecisionForApproval: (
-    _event: string,
-    _payload: unknown,
-    context: { approvalPolicy: string; mode: string },
-  ) => {
-    if (context.approvalPolicy === 'ask' && context.mode === 'interactive') {
-      return undefined;
-    }
-    if (context.approvalPolicy === 'yolo') return { accepted: true };
-    return { accepted: false, userMessage: 'Denied by CLI approval policy.' };
-  },
-  isCliApiSwitchableRetry: (payload: {
-    errorDetails?: { isCredentialExhausted?: boolean; isRelayError?: boolean };
-  }) =>
-    payload.errorDetails?.isCredentialExhausted === true &&
-    payload.errorDetails?.isRelayError === true,
-  isCliChatGptSubscriptionRetry: () => false,
-  markApprovalDenied: vi.fn(),
-}));
+vi.mock('@cli/runtime/approvalAdapter', () => {
+  interface RetryPayloadForMock {
+    errorDetails?: {
+      isCredentialExhausted?: boolean;
+      isRelayError?: boolean;
+      isChatGptSubscriptionLimited?: boolean;
+    };
+  }
+
+  const isChatGptSubscriptionRetry = (payload: RetryPayloadForMock) =>
+    payload.errorDetails?.isChatGptSubscriptionLimited === true;
+
+  return {
+    approvalPromptAllowed: (context: {
+      approvalPolicy: string;
+      mode: string;
+    }) => context.approvalPolicy === 'ask' && context.mode === 'interactive',
+    humanInputDenialFeedback: () => 'Denied by CLI approval policy.',
+    immediateDecision: (context: { approvalPolicy: string }) => {
+      if (context.approvalPolicy === 'yolo') return { accepted: true };
+      if (context.approvalPolicy === 'ask') return undefined;
+      return { accepted: false, userMessage: 'Denied by CLI approval policy.' };
+    },
+    immediateDecisionForApproval: (
+      _event: string,
+      _payload: unknown,
+      context: { approvalPolicy: string; mode: string },
+    ) => {
+      if (context.approvalPolicy === 'ask' && context.mode === 'interactive') {
+        return undefined;
+      }
+      if (context.approvalPolicy === 'yolo') return { accepted: true };
+      return { accepted: false, userMessage: 'Denied by CLI approval policy.' };
+    },
+    isCliApiSwitchableRetry: (payload: RetryPayloadForMock) =>
+      isChatGptSubscriptionRetry(payload) ||
+      (payload.errorDetails?.isCredentialExhausted === true &&
+        payload.errorDetails?.isRelayError === true),
+    isCliChatGptSubscriptionRetry: isChatGptSubscriptionRetry,
+    markApprovalDenied: vi.fn(),
+  };
+});
 
 vi.mock('@model/apiProviders', async (importActual) => {
   const actual = await importActual<typeof import('@model/apiProviders')>();
@@ -122,6 +136,22 @@ function relayRetry(params: {
   } as ProgressEventPayloads['showRetryRequest'];
 }
 
+function chatGptSubscriptionRetry(
+  streamId: string,
+): ProgressEventPayloads['showRetryRequest'] {
+  return {
+    streamId,
+    operation: 'model request',
+    errorMessage: 'ChatGPT subscription usage limit reached.',
+    errorDetails: {
+      message: 'ChatGPT subscription usage limit reached.',
+      isCredentialExhausted: true,
+      isChatGptSubscriptionLimited: true,
+      provider: 'openai',
+    },
+  } as ProgressEventPayloads['showRetryRequest'];
+}
+
 afterEach(() => {
   clearApprovals();
   mocks.lookupApiKey.mockReset();
@@ -176,6 +206,31 @@ describe('TUI retry approvals', () => {
         });
       });
       expect(mocks.triggerRetry).not.toHaveBeenCalled();
+    } finally {
+      unbind();
+    }
+  });
+
+  it('auto-switches ChatGPT subscription retries to an OpenAI API key', async () => {
+    mocks.lookupApiKey.mockImplementation(
+      async (_secrets, provider: ApiProvider) =>
+        provider === 'openai' ? 'sk-openai' : undefined,
+    );
+
+    const runtimeHost = host();
+    const unbind = installTuiApprovals(runtimeHost, context());
+    try {
+      runtimeHost.emit('showRetryRequest', chatGptSubscriptionRetry('s3'));
+
+      await vi.waitFor(() => {
+        expect(mocks.setCliApiMode).toHaveBeenCalledWith('personal');
+        expect(mocks.setCliCodexSubscription).toHaveBeenCalledWith(false);
+        expect(mocks.triggerRetry).toHaveBeenCalledWith('s3', undefined);
+      });
+      expect(currentApproval.get()).toBeUndefined();
+      expect(mocks.lookupApiKey.mock.calls.map((call) => call[1])).toEqual([
+        'openai',
+      ]);
     } finally {
       unbind();
     }

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -36,6 +36,7 @@ vi.mock('@agent/runtime/runCoordinators', () => ({
 
 vi.mock('@cli/runtime/approvalAdapter', () => {
   interface RetryPayloadForMock {
+    errorMessage?: string;
     errorDetails?: {
       isCredentialExhausted?: boolean;
       isRelayError?: boolean;
@@ -45,6 +46,8 @@ vi.mock('@cli/runtime/approvalAdapter', () => {
 
   const isChatGptSubscriptionRetry = (payload: RetryPayloadForMock) =>
     payload.errorDetails?.isChatGptSubscriptionLimited === true;
+  const isRelayMonthlyLimitMessage = (message?: string) =>
+    message?.toLowerCase().includes('monthly spending limit') === true;
 
   return {
     approvalPromptAllowed: (context: {
@@ -71,7 +74,8 @@ vi.mock('@cli/runtime/approvalAdapter', () => {
     isCliApiSwitchableRetry: (payload: RetryPayloadForMock) =>
       isChatGptSubscriptionRetry(payload) ||
       (payload.errorDetails?.isCredentialExhausted === true &&
-        payload.errorDetails?.isRelayError === true),
+        (payload.errorDetails?.isRelayError === true ||
+          isRelayMonthlyLimitMessage(payload.errorMessage))),
     isCliChatGptSubscriptionRetry: isChatGptSubscriptionRetry,
     markApprovalDenied: vi.fn(),
   };
@@ -89,7 +93,6 @@ vi.mock('@platform/platform', () => ({
   platform: () => ({ secrets: mocks.secrets }),
 }));
 
-import { API_PROVIDERS, type ApiProvider } from '@model/apiProviders';
 import {
   clearApprovals,
   currentApproval,
@@ -98,6 +101,7 @@ import { installTuiApprovals } from '@cli/chat/tui/state/subscribeApprovals';
 import type { CliContext } from '@cli/runtime/cliContext';
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import { API_PROVIDERS, type ApiProvider } from '@model/apiProviders';
 
 function context(): CliContext {
   return {
@@ -211,6 +215,65 @@ describe('TUI retry approvals', () => {
     }
   });
 
+  it('does not auto-switch when a retry provider is not an API provider', async () => {
+    mocks.lookupApiKey.mockResolvedValue('sk-test');
+
+    const runtimeHost = host();
+    const unbind = installTuiApprovals(runtimeHost, context());
+    try {
+      const retry = relayRetry({
+        streamId: 'unknown-provider',
+        provider: 'custom-provider',
+      });
+      runtimeHost.emit('showRetryRequest', retry);
+
+      await vi.waitFor(() => {
+        expect(currentApproval.get()?.payload).toMatchObject({
+          kind: 'retry',
+          payload: { streamId: 'unknown-provider' },
+        });
+      });
+      expect(mocks.lookupApiKey).not.toHaveBeenCalled();
+      expect(mocks.triggerRetry).not.toHaveBeenCalled();
+    } finally {
+      unbind();
+    }
+  });
+
+  it('auto-switches relay retries detected by monthly-limit message fallback', async () => {
+    mocks.lookupApiKey.mockImplementation(
+      async (_secrets, provider: ApiProvider) =>
+        provider === 'openai' ? 'sk-openai' : undefined,
+    );
+
+    const runtimeHost = host();
+    const unbind = installTuiApprovals(runtimeHost, context());
+    try {
+      runtimeHost.emit('showRetryRequest', {
+        streamId: 'message-fallback',
+        operation: 'model request',
+        errorMessage: 'Monthly spending limit reached.',
+        errorDetails: {
+          message: 'Monthly spending limit reached.',
+          isCredentialExhausted: true,
+          isRelayError: false,
+          provider: 'openai',
+        },
+      } as ProgressEventPayloads['showRetryRequest']);
+
+      await vi.waitFor(() => {
+        expect(mocks.setCliApiMode).toHaveBeenCalledWith('personal');
+        expect(mocks.triggerRetry).toHaveBeenCalledWith(
+          'message-fallback',
+          undefined,
+        );
+      });
+      expect(currentApproval.get()).toBeUndefined();
+    } finally {
+      unbind();
+    }
+  });
+
   it('auto-switches ChatGPT subscription retries to an OpenAI API key', async () => {
     mocks.lookupApiKey.mockImplementation(
       async (_secrets, provider: ApiProvider) =>
@@ -231,6 +294,91 @@ describe('TUI retry approvals', () => {
       expect(mocks.lookupApiKey.mock.calls.map((call) => call[1])).toEqual([
         'openai',
       ]);
+    } finally {
+      unbind();
+    }
+  });
+
+  it('invalidates pre-queue retry lookups when approvals are cleared', async () => {
+    let resolveLookup: ((value: string | undefined) => void) | undefined;
+    mocks.lookupApiKey.mockImplementation(
+      () =>
+        new Promise<string | undefined>((resolve) => {
+          resolveLookup = resolve;
+        }),
+    );
+
+    const runtimeHost = host();
+    const unbind = installTuiApprovals(runtimeHost, context());
+    try {
+      runtimeHost.emit(
+        'showRetryRequest',
+        relayRetry({ streamId: 'interrupted', provider: 'openai' }),
+      );
+      clearApprovals();
+      expect(mocks.cancelRetry).toHaveBeenCalledWith('interrupted');
+
+      resolveLookup?.('sk-after-interrupt');
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mocks.setCliApiMode).not.toHaveBeenCalled();
+      expect(mocks.triggerRetry).not.toHaveBeenCalled();
+      expect(mocks.cancelRetry).toHaveBeenCalledTimes(1);
+      expect(currentApproval.get()).toBeUndefined();
+    } finally {
+      unbind();
+    }
+  });
+
+  it('invalidates pre-queue retry lookups when approvals are unbound', async () => {
+    let resolveLookup: ((value: string | undefined) => void) | undefined;
+    mocks.lookupApiKey.mockImplementation(
+      () =>
+        new Promise<string | undefined>((resolve) => {
+          resolveLookup = resolve;
+        }),
+    );
+
+    const runtimeHost = host();
+    const unbind = installTuiApprovals(runtimeHost, context());
+    runtimeHost.emit(
+      'showRetryRequest',
+      relayRetry({ streamId: 'unbound', provider: 'openai' }),
+    );
+    unbind();
+
+    resolveLookup?.('sk-after-unbind');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mocks.setCliApiMode).not.toHaveBeenCalled();
+    expect(mocks.triggerRetry).not.toHaveBeenCalled();
+    expect(mocks.cancelRetry).not.toHaveBeenCalled();
+    expect(currentApproval.get()).toBeUndefined();
+  });
+
+  it('cancels an active retry modal when approvals are cleared', async () => {
+    mocks.lookupApiKey.mockResolvedValue(undefined);
+
+    const runtimeHost = host();
+    const unbind = installTuiApprovals(runtimeHost, context());
+    try {
+      runtimeHost.emit(
+        'showRetryRequest',
+        relayRetry({ streamId: 'modal-interrupt', provider: 'openai' }),
+      );
+
+      await vi.waitFor(() => {
+        expect(currentApproval.get()?.payload).toMatchObject({
+          kind: 'retry',
+          payload: { streamId: 'modal-interrupt' },
+        });
+      });
+
+      clearApprovals();
+      expect(mocks.cancelRetry).toHaveBeenCalledWith('modal-interrupt');
+      expect(currentApproval.get()).toBeUndefined();
     } finally {
       unbind();
     }
@@ -329,13 +477,56 @@ describe('TUI retry approvals', () => {
     }
   });
 
+  it('replaces an older retry modal when a newer retry also needs input', async () => {
+    mocks.lookupApiKey.mockResolvedValue(undefined);
+
+    const runtimeHost = host();
+    const unbind = installTuiApprovals(runtimeHost, context());
+    try {
+      runtimeHost.emit(
+        'showRetryRequest',
+        relayRetry({
+          streamId: 'same-stream',
+          provider: 'openai',
+          message: 'first retry',
+        }),
+      );
+      await vi.waitFor(() => {
+        expect(currentApproval.get()?.payload).toMatchObject({
+          kind: 'retry',
+          payload: { errorMessage: 'first retry' },
+        });
+      });
+
+      runtimeHost.emit(
+        'showRetryRequest',
+        relayRetry({
+          streamId: 'same-stream',
+          provider: 'openai',
+          message: 'second retry',
+        }),
+      );
+
+      await vi.waitFor(() => {
+        expect(currentApproval.get()?.payload).toMatchObject({
+          kind: 'retry',
+          payload: { errorMessage: 'second retry' },
+        });
+      });
+      expect(mocks.cancelRetry).not.toHaveBeenCalled();
+      expect(mocks.triggerRetry).not.toHaveBeenCalled();
+    } finally {
+      unbind();
+    }
+  });
+
   it('does not let a stale auto-switch failure cancel a newer retry', async () => {
     let rejectFirstModeSwitch: ((error: Error) => void) | undefined;
     mocks.lookupApiKey.mockResolvedValue('sk-test');
     mocks.setCliApiMode
       .mockImplementationOnce(
         () =>
-          new Promise<void>((_resolve, reject) => {
+          new Promise<undefined>((_resolve, reject) => {
             rejectFirstModeSwitch = reject;
           }),
       )

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -229,4 +229,100 @@ describe('TUI retry approvals', () => {
       unbind();
     }
   });
+
+  it('clears an older retry modal when a newer retry auto-switches', async () => {
+    mocks.lookupApiKey
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce('sk-new');
+
+    const runtimeHost = host();
+    const unbind = installTuiApprovals(runtimeHost, context());
+    try {
+      runtimeHost.emit(
+        'showRetryRequest',
+        relayRetry({
+          streamId: 'same-stream',
+          provider: 'openai',
+          message: 'first retry',
+        }),
+      );
+      await vi.waitFor(() => {
+        expect(currentApproval.get()?.payload).toMatchObject({
+          kind: 'retry',
+          payload: { errorMessage: 'first retry' },
+        });
+      });
+
+      runtimeHost.emit(
+        'showRetryRequest',
+        relayRetry({
+          streamId: 'same-stream',
+          provider: 'openai',
+          message: 'second retry',
+        }),
+      );
+
+      await vi.waitFor(() => {
+        expect(mocks.triggerRetry).toHaveBeenCalledWith(
+          'same-stream',
+          undefined,
+        );
+        expect(currentApproval.get()).toBeUndefined();
+      });
+    } finally {
+      unbind();
+    }
+  });
+
+  it('does not let a stale auto-switch failure cancel a newer retry', async () => {
+    let rejectFirstModeSwitch: ((error: Error) => void) | undefined;
+    mocks.lookupApiKey.mockResolvedValue('sk-test');
+    mocks.setCliApiMode
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((_resolve, reject) => {
+            rejectFirstModeSwitch = reject;
+          }),
+      )
+      .mockResolvedValueOnce(undefined);
+
+    const runtimeHost = host();
+    const unbind = installTuiApprovals(runtimeHost, context());
+    try {
+      runtimeHost.emit(
+        'showRetryRequest',
+        relayRetry({
+          streamId: 'same-stream',
+          provider: 'openai',
+          message: 'first retry',
+        }),
+      );
+      await vi.waitFor(() => {
+        expect(mocks.setCliApiMode).toHaveBeenCalledTimes(1);
+      });
+
+      runtimeHost.emit(
+        'showRetryRequest',
+        relayRetry({
+          streamId: 'same-stream',
+          provider: 'openai',
+          message: 'second retry',
+        }),
+      );
+      await vi.waitFor(() => {
+        expect(mocks.triggerRetry).toHaveBeenCalledWith(
+          'same-stream',
+          undefined,
+        );
+      });
+
+      rejectFirstModeSwitch?.(new Error('stale mode switch failed'));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mocks.cancelRetry).not.toHaveBeenCalled();
+    } finally {
+      unbind();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- Auto-switch CLI TUI retry requests to stored personal API keys when relay or ChatGPT subscription exhaustion can be recovered without user input.
- Keep unsafe cases in the retry modal: direct-key exhaustion, unknown providers, missing keys, and failed key lookup.
- Guard stale retry routes across replaced prompts, interrupts, approval teardown, and asynchronous mode-switch failures.
- Add focused TUI retry coverage for provider-less relay retries, monthly-limit message fallback, ChatGPT subscription limits, unknown providers, stale lookups, interrupt cancellation, unbind invalidation, stale modal replacement, and stale failure handling.

## Verification

- `corepack pnpm exec vitest run src/test-kernel/cli/TuiApprovalRetry.vitest.mts`
- `corepack pnpm run typecheck`
- `corepack pnpm run lint`
- `corepack pnpm run test`
- `corepack pnpm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes credential mode and retry coordination in the interactive CLI approval path; guards limit stale side effects but API access behavior is user-visible.
> 
> **Overview**
> The CLI TUI **retry approval flow** now **auto-switches to personal API keys** (and retries without a modal) when relay or ChatGPT subscription limits are hit and a usable stored key is available—aligned with progress-view behavior. The modal still appears for upstream credit depletion on a direct key, unknown providers, missing keys, or failed keychain lookup.
> 
> **Approval queue** changes add `onApprovalsCleared` hooks and `clearRetryApprovalsForStream` so duplicate or superseded retry prompts for the same stream are dropped cleanly.
> 
> **Retry routing** tracks the latest route per `streamId` so stale async key lookups, interrupts, teardown, or failed mode switches cannot apply API mode or trigger/cancel the wrong retry. Clearing approvals cancels in-flight retry routes via `runCoordinatorBridge.cancelRetry`.
> 
> Focused **Vitest** coverage exercises auto-switch paths, modal fallback, and race/interrupt scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 061c122cb1ad7652a98f24336c7ae8ab63da99a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->