### PR TITLE
feat(webview): Web Awesome tooltips on icon button groups

### DIFF
--- a/packages/extension/src/progressView/frontend/components/ApproveSplitButton.ts
+++ b/packages/extension/src/progressView/frontend/components/ApproveSplitButton.ts
@@ -10,6 +10,7 @@ import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/dropdown/dropdown.js';
 import '@awesome.me/webawesome/dist/components/dropdown-item/dropdown-item.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 
 // Local imports - shared styles + helpers
 import { commonViewStyles, designTokens } from '@shared/styles';
@@ -140,6 +141,7 @@ export class ApproveSplitButton extends LitElement {
           @wa-select=${this.handleSelect}
         >
           <wa-button
+            id="approve-split-trigger-button"
             slot="trigger"
             class="action-icon-button approve-split-trigger"
             appearance="plain"
@@ -147,7 +149,6 @@ export class ApproveSplitButton extends LitElement {
             size="small"
             type="button"
             aria-label="More approve options"
-            title="Approve and stop asking this session (a)"
           >
             ${waIcon('chevron-down')}
           </wa-button>
@@ -166,6 +167,9 @@ export class ApproveSplitButton extends LitElement {
               </wa-dropdown-item>`,
           )}
         </wa-dropdown>
+        <wa-tooltip for="approve-split-trigger-button">
+          Approve and stop asking this session (a)
+        </wa-tooltip>
       </div>
     `;
   }

--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -14,6 +14,7 @@ import { repeat } from 'lit/directives/repeat.js';
 // Side-effect imports - register WA icon component
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 
 // Local imports
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
@@ -46,15 +47,22 @@ interface FileActionOptions {
 }
 
 function renderFileActionButton(opts: FileActionOptions): TemplateResult {
+  // command+file is unique per row; sanitize to a valid id the <wa-tooltip>
+  // can anchor to via `for`. These buttons live in a flex `.file-actions`
+  // row (not a wa-button-group), so the sibling tooltip is safe.
+  const buttonId = `file-action-${opts.command}-${opts.file}`.replace(
+    /[^a-zA-Z0-9_-]/g,
+    '-',
+  );
   return html`
     <wa-button
+      id=${buttonId}
       class="action-icon-button ${opts.className}"
       appearance="plain"
       variant="neutral"
       size="small"
       type="button"
       aria-label=${opts.label}
-      title=${opts.title}
       data-command=${opts.command}
       data-file=${opts.file}
       data-base=${ifDefined(opts.base)}
@@ -62,6 +70,7 @@ function renderFileActionButton(opts: FileActionOptions): TemplateResult {
     >
       ${waIcon(opts.icon)}
     </wa-button>
+    <wa-tooltip for=${buttonId}>${opts.title}</wa-tooltip>
   `;
 }
 
@@ -352,9 +361,10 @@ export class FileList extends LitElement {
           button to open the full run.
         </span>
         ${renderIconActionButton({
+          id: 'storage-hint-dismiss-button',
           icon: 'close',
           label: 'Dismiss storage explanation',
-          title: 'Dismiss storage explanation',
+          tooltip: 'Dismiss storage explanation',
           className: 'storage-hint__dismiss',
           onClick: this.handleDismissStorageHint,
         })}

--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -42,15 +42,20 @@ interface FileActionOptions {
   readonly className: string;
   readonly command: string;
   readonly file: string;
+  // Unique per (round, file-index) so the button id can't collide when the
+  // same workspace path appears across rounds in one shadow root.
+  readonly idPrefix: string;
   readonly base?: string;
   readonly prev?: string;
 }
 
 function renderFileActionButton(opts: FileActionOptions): TemplateResult {
-  // command+file is unique per row; sanitize to a valid id the <wa-tooltip>
-  // can anchor to via `for`. These buttons live in a flex `.file-actions`
-  // row (not a wa-button-group), so the sibling tooltip is safe.
-  const buttonId = `file-action-${opts.command}-${opts.file}`.replace(
+  // idPrefix is unique per (round, file-index); command is unique per button
+  // within a file, so the pair never collides — even when the same path shows
+  // up across rounds in one shadow root. Sanitize to a valid id the
+  // <wa-tooltip> anchors to via `for`. These buttons live in a flex
+  // `.file-actions` row (not a wa-button-group), so the sibling tooltip is safe.
+  const buttonId = `${opts.idPrefix}-${opts.command}`.replace(
     /[^a-zA-Z0-9_-]/g,
     '-',
   );
@@ -382,7 +387,7 @@ export class FileList extends LitElement {
       return html`${repeat(
         files,
         (file, index) => `${round}-${file.location?.absolutePath ?? index}`,
-        (file) => this.renderFileItem(file, round),
+        (file, index) => this.renderFileItem(file, round, index),
       )}`;
     }
 
@@ -396,7 +401,7 @@ export class FileList extends LitElement {
           ${repeat(
             files,
             (file, index) => `${round}-${file.location?.absolutePath ?? index}`,
-            (file) => this.renderFileItem(file, round),
+            (file, index) => this.renderFileItem(file, round, index),
           )}
         </div>
       </wa-details>
@@ -406,8 +411,12 @@ export class FileList extends LitElement {
   private renderFileItem(
     file: OutputFileInfo,
     round: number,
+    fileIndex: number,
   ): TemplateResult | typeof nothing {
     if (!file?.location) return nothing;
+
+    // Unique within this shadow root: round + the file's index in that round.
+    const idPrefix = `file-action-r${round}-f${fileIndex}`;
 
     const location = file.location;
     // Prefer: workspace original → source doc name → run-storage relative path.
@@ -443,11 +452,13 @@ export class FileList extends LitElement {
       filePath,
       effectiveBase,
       compareBase,
+      idPrefix,
     );
     const previousAction = this.renderPreviousAction(
       filePath,
       effectiveBase,
       diffBase,
+      idPrefix,
     );
 
     return html`
@@ -484,6 +495,7 @@ export class FileList extends LitElement {
                 className: '',
                 command: PROGRESS_VIEW_COMMANDS.OPEN_FILE,
                 file: failure.log.absolutePath,
+                idPrefix,
               })
             : nothing}
           ${baseActions} ${previousAction}
@@ -606,6 +618,7 @@ export class FileList extends LitElement {
     filePath: string,
     basePath: string,
     compareBase: string,
+    idPrefix: string,
   ): TemplateResult | typeof nothing {
     if (!basePath) return nothing;
 
@@ -618,6 +631,7 @@ export class FileList extends LitElement {
         command: PROGRESS_VIEW_COMMANDS.COMPARE_ORIGINAL,
         file: filePath,
         base: compareBase,
+        idPrefix,
       })}
       ${renderFileActionButton({
         icon: 'diff-multiple',
@@ -627,6 +641,7 @@ export class FileList extends LitElement {
         command: PROGRESS_VIEW_COMMANDS.LATEXDIFF_FILE,
         file: filePath,
         base: basePath,
+        idPrefix,
       })}
       ${renderFileActionButton({
         icon: 'check',
@@ -636,6 +651,7 @@ export class FileList extends LitElement {
         command: PROGRESS_VIEW_COMMANDS.ACCEPT_FILE,
         file: filePath,
         base: compareBase,
+        idPrefix,
       })}
       ${renderFileActionButton({
         icon: 'git-merge',
@@ -645,6 +661,7 @@ export class FileList extends LitElement {
         command: PROGRESS_VIEW_COMMANDS.MERGE_FILE,
         file: filePath,
         base: basePath,
+        idPrefix,
       })}
     `;
   }
@@ -653,6 +670,7 @@ export class FileList extends LitElement {
     filePath: string,
     basePath: string,
     previousPath: string | undefined,
+    idPrefix: string,
   ): TemplateResult | typeof nothing {
     if (!previousPath || previousPath === basePath) return nothing;
 
@@ -665,6 +683,7 @@ export class FileList extends LitElement {
       file: filePath,
       base: basePath,
       prev: previousPath,
+      idPrefix,
     });
   }
 }

--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -273,7 +273,7 @@ export class FollowUpInput extends LitElement {
                 id: ELEMENT_IDS.POLISH_FOLLOW_UP_BTN,
                 icon: 'sparkle',
                 label: 'Polish follow-up',
-                title: 'Polish follow-up with AI',
+                tooltip: 'Polish follow-up with AI',
                 busy: this.polishing,
                 onClick: this.emitPolish,
               })}
@@ -281,7 +281,7 @@ export class FollowUpInput extends LitElement {
                 id: ELEMENT_IDS.RECORD_FOLLOW_UP_BTN,
                 icon: this.recordingController.state.icon,
                 label: this.recordingController.state.title,
-                title: this.recordingController.state.title,
+                tooltip: this.recordingController.state.title,
                 className: this.recordingController.state.recording
                   ? this.recordingController.state.recordingClass
                   : '',
@@ -291,14 +291,14 @@ export class FollowUpInput extends LitElement {
                 id: ELEMENT_IDS.CLEAR_FOLLOW_UP_BTN,
                 icon: 'clear-all',
                 label: 'Clear input',
-                title: 'Clear input',
+                tooltip: 'Clear input',
                 onClick: this.emitClear,
               })}
               ${renderIconActionButton({
                 id: ELEMENT_IDS.SEND_FOLLOW_UP_BTN,
                 icon: 'send',
                 label: 'Send',
-                title: 'Send follow-up message',
+                tooltip: 'Send follow-up message',
                 onClick: this.emitSend,
               })}
             </div>

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -323,6 +323,36 @@ export class StreamHeader extends LitElement {
     const toolbarButtons =
       TOOLBAR_BUTTONS[agentCategory] ?? TOOLBAR_BUTTONS.workflow;
 
+    // Precompute per-button view metadata once so the button-group and the
+    // sibling <wa-tooltip> elements share the same active-state-aware title.
+    // The tooltips live OUTSIDE <wa-button-group>: the group's rounded-corner
+    // styling keys off ::slotted(:first-child)/(:last-child), so interleaving
+    // tooltip nodes between the buttons would break those selectors. They
+    // anchor by `for=${btn.id}` within this shadow root instead.
+    const toolbarButtonViews = (toolbarButtons as ToolbarButton[]).map(
+      (btn) => {
+        const { disabled, hidden } = this.getButtonState(
+          btn.id,
+          status,
+          hasExecutionId,
+        );
+        const isActive = Boolean(
+          btn.isToggle &&
+          (btn.id === ELEMENT_IDS.SUPER_YOLO_TOGGLE_BTN
+            ? this.superYoloActive
+            : this.yoloActive),
+        );
+        const title = isActive && btn.titleActive ? btn.titleActive : btn.title;
+        const classes = classMap({
+          'action-icon-button': true,
+          ...(btn.className ? { [btn.className]: true } : {}),
+          'toolbar-button--hidden': hidden,
+          'is-active': isActive,
+        });
+        return { btn, disabled, hidden, title, classes };
+      },
+    );
+
     return html`
       <div class="log-header">
         <div class="log-header__primary">
@@ -357,48 +387,32 @@ export class StreamHeader extends LitElement {
               @click=${this.handleToolbarClick}
             >
               ${repeat(
-                toolbarButtons as ToolbarButton[],
-                (btn) => btn.id,
-                (btn) => {
-                  const { disabled, hidden } = this.getButtonState(
-                    btn.id,
-                    status,
-                    hasExecutionId,
-                  );
-                  const isActive = Boolean(
-                    btn.isToggle &&
-                    (btn.id === ELEMENT_IDS.SUPER_YOLO_TOGGLE_BTN
-                      ? this.superYoloActive
-                      : this.yoloActive),
-                  );
-                  const title =
-                    isActive && btn.titleActive ? btn.titleActive : btn.title;
-                  const classes = classMap({
-                    'action-icon-button': true,
-                    ...(btn.className ? { [btn.className]: true } : {}),
-                    'toolbar-button--hidden': hidden,
-                    'is-active': isActive,
-                  });
-                  return html`
-                    <wa-button
-                      id=${btn.id}
-                      class=${classes}
-                      appearance="plain"
-                      variant="neutral"
-                      size="small"
-                      type="button"
-                      aria-label=${title}
-                      title=${title}
-                      data-command=${btn.command}
-                      aria-hidden=${hidden ? 'true' : 'false'}
-                      ?disabled=${disabled}
-                    >
-                      ${waIcon(btn.icon as TeXRAIconName)}
-                    </wa-button>
-                  `;
-                },
+                toolbarButtonViews,
+                (view) => view.btn.id,
+                ({ btn, disabled, hidden, title, classes }) => html`
+                  <wa-button
+                    id=${btn.id}
+                    class=${classes}
+                    appearance="plain"
+                    variant="neutral"
+                    size="small"
+                    type="button"
+                    aria-label=${title}
+                    data-command=${btn.command}
+                    aria-hidden=${hidden ? 'true' : 'false'}
+                    ?disabled=${disabled}
+                  >
+                    ${waIcon(btn.icon as TeXRAIconName)}
+                  </wa-button>
+                `,
               )}
             </wa-button-group>
+            ${repeat(
+              toolbarButtonViews.filter((view) => !view.hidden),
+              (view) => view.btn.id,
+              (view) =>
+                html`<wa-tooltip for=${view.btn.id}>${view.title}</wa-tooltip>`,
+            )}
           </div>
         </div>
       </div>

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -51,6 +51,7 @@ import type { StreamFilter } from '../store';
 // Web Awesome native components
 import '@awesome.me/webawesome/dist/components/radio/radio.js';
 import '@awesome.me/webawesome/dist/components/radio-group/radio-group.js';
+import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 
 function buildTooltip(
   info: StreamTabInfo,
@@ -224,18 +225,19 @@ export class StreamTab extends LitElement {
               `}
         </button>
         <wa-button
+          id="stream-tab-delete-button"
           class="action-icon-button tab-delete"
           appearance="plain"
           variant="neutral"
           size="small"
           type="button"
           aria-label="Delete stream"
-          title="Delete stream"
           data-stream=${stream.name}
           data-action="delete"
         >
           ${waIcon('close')}
         </wa-button>
+        <wa-tooltip for="stream-tab-delete-button">Delete stream</wa-tooltip>
       </div>
     `;
   }
@@ -432,7 +434,7 @@ export class StreamTabs extends LitElement {
                     id: ELEMENT_IDS.DELETE_ALL_BTN,
                     icon: 'trash',
                     label: 'Clear all streams',
-                    title: 'Clear all streams',
+                    tooltip: 'Clear all streams',
                     className: 'delete-all-streams',
                     onClick: this.handleDeleteAll,
                   })}

--- a/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
@@ -9,6 +9,7 @@ import { when } from 'lit/directives/when.js';
 import '@awesome.me/webawesome/dist/components/dropdown/dropdown.js';
 import '@awesome.me/webawesome/dist/components/dropdown-item/dropdown-item.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 
 // Local imports - shared styles
 import {
@@ -99,6 +100,7 @@ export class ToolEditRequestPanel extends BaseFeedbackPanel {
                 @wa-select=${this.handleMenuSelect}
               >
                 <wa-button
+                  id="tool-edit-diff-dropdown-trigger"
                   slot="trigger"
                   class="action-icon-button diff-dropdown-trigger"
                   appearance="plain"
@@ -106,7 +108,6 @@ export class ToolEditRequestPanel extends BaseFeedbackPanel {
                   size="small"
                   type="button"
                   aria-label="More diff actions"
-                  title="More diff actions"
                 >
                   ${waIcon('chevron-down')}
                 </wa-button>
@@ -117,6 +118,9 @@ export class ToolEditRequestPanel extends BaseFeedbackPanel {
                   LaTeXdiff
                 </wa-dropdown-item>
               </wa-dropdown>
+              <wa-tooltip for="tool-edit-diff-dropdown-trigger">
+                More diff actions
+              </wa-tooltip>
             `
           : nothing}
       </div>

--- a/packages/extension/src/progressView/frontend/components/UserMessage.ts
+++ b/packages/extension/src/progressView/frontend/components/UserMessage.ts
@@ -251,17 +251,19 @@ export class UserMessage extends LitElement {
               >
             </span>
             ${renderIconActionButton({
+              id: 'user-message-copy-button',
               icon: 'copy',
               label: copyState.ariaLabel,
-              title: copyState.title,
+              tooltip: copyState.title,
               className: `user-message-copy ${copyState.copied ? copyState.successClass : ''}`,
               onClick: () => this.copyController.copy(displayText),
             })}
             ${hasRawMessage
               ? renderIconActionButton({
+                  id: 'user-message-raw-copy-button',
                   icon: 'code',
                   label: rawMessageCopyState.ariaLabel,
-                  title: rawMessageCopyState.title,
+                  tooltip: rawMessageCopyState.title,
                   className: `user-message-copy ${rawMessageCopyState.copied ? rawMessageCopyState.successClass : ''}`,
                   onClick: () => this.rawMessageCopyController.copy(this.text),
                 })

--- a/packages/extension/src/progressView/frontend/components/WorkflowHintBanner.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowHintBanner.ts
@@ -76,9 +76,10 @@ export class WorkflowHintBanner extends LitElement {
             edits.
           </div>
           ${renderIconActionButton({
+            id: 'workflow-hint-dismiss-button',
             icon: 'close',
             label: 'Dismiss workflow mode reminder',
-            title: 'Dismiss this reminder',
+            tooltip: 'Dismiss this reminder',
             onClick: this.handleDismiss,
           })}
         </div>

--- a/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
@@ -343,38 +343,47 @@ export class HistoryItemElement extends LitElement {
             @click=${this.handleActionClick}
           >
             ${renderIconActionButton({
+              id: 'history-delete-button',
               icon: 'trash',
               label: 'Delete',
+              tooltip: 'Delete this history item',
               action: 'delete',
             })}
             ${renderIconActionButton({
+              id: 'history-setup-button',
               icon: 'reply',
               label: 'Setup',
+              tooltip: "Restore this run's setup",
               action: 'restore',
             })}
             ${renderIconActionButton({
+              id: 'history-rerun-button',
               icon: 'rotate-right',
               label: 'Rerun',
+              tooltip: 'Rerun this task',
               action: 'rerun',
             })}
             ${isToolUse
               ? html`
                   ${renderIconActionButton({
+                    id: 'history-export-md-button',
                     icon: 'file-lines',
                     label: 'Export Markdown',
-                    title: 'Export as Markdown',
+                    tooltip: 'Export as Markdown',
                     action: 'export-md',
                   })}
                   ${renderIconActionButton({
+                    id: 'history-export-pdf-button',
                     icon: 'file-pdf',
                     label: 'Export PDF',
-                    title: 'Export as LaTeX/PDF',
+                    tooltip: 'Export as LaTeX/PDF',
                     action: 'export-tex',
                   })}
                   ${renderIconActionButton({
+                    id: 'history-export-html-button',
                     icon: 'globe',
                     label: 'Export HTML',
-                    title: 'Export as shareable HTML webpage',
+                    tooltip: 'Export as shareable HTML webpage',
                     action: 'export-html',
                   })}
                 `

--- a/packages/extension/src/settingsView/frontend/components/history/SearchBar.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/SearchBar.ts
@@ -77,21 +77,26 @@ export class SearchBar extends LitElement {
         ></wa-input>
         <div class="search-controls action-button-group">
           ${renderIconActionButton({
+            id: 'history-search-prev-button',
             icon: 'chevron-up',
             label: 'Previous match',
+            tooltip: 'Previous match',
             onClick: this.handlePrev,
           })}
           ${renderIconActionButton({
+            id: 'history-search-next-button',
             icon: 'chevron-down',
             label: 'Next match',
+            tooltip: 'Next match',
             onClick: this.handleNext,
           })}
           <span class="match-count">${this.matchCount}</span>
           ${this.canClearHistory
             ? renderIconActionButton({
+                id: 'history-search-clear-button',
                 icon: 'trash',
                 label: 'Clear history',
-                title: 'Clear all history',
+                tooltip: 'Clear all history',
                 action: 'clear-history',
                 onClick: this.handleClearHistory,
               })

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
@@ -10,9 +10,12 @@ import {
 } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { repeat } from 'lit/directives/repeat.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import '@awesome.me/webawesome/dist/components/details/details.js';
+import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/button-group/button-group.js';
+import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 
 // Local imports - shared styles
 import { designTokens, commonViewStyles } from '@shared/styles';
@@ -24,7 +27,7 @@ import {
   formatUpdatedDate,
 } from '@shared/utils/string';
 import { getLightweightMd } from '@shared/highlighting/lightweightMd';
-import { renderIconActionButton } from '@shared/wa/actionButtons';
+import { type TeXRAIconName, waIcon } from '@shared/wa/webAwesomeIcons';
 import { metaStripStyles, renderDotMeta } from '@shared/wa/metaStrip';
 
 // Local imports - memory view events
@@ -187,6 +190,68 @@ export class MemoryItem extends LitElement {
     }
   }
 
+  /**
+   * Pin / Open / Delete cluster. Tooltips render after the group: a
+   * wa-button-group fuses corners via CSS ::slotted(:first/:last-child), so a
+   * slotted <wa-tooltip> would break the segmenting. Each <wa-tooltip> anchors
+   * by `for` within this element's shadow root, so the static ids stay unique
+   * per instance even when many memory-item rows are on screen.
+   */
+  private renderActionGroup(): TemplateResult {
+    const pinned = this.item?.pinned === true;
+    const actions = [
+      {
+        id: 'memory-pin-button',
+        icon: (pinned ? 'thumbtack-slash' : 'thumbtack') as TeXRAIconName,
+        label: pinned ? 'Unpin' : 'Pin',
+        tooltip: pinned ? 'Unpin this memory' : 'Pin as core long-term memory',
+        onClick: this.handleTogglePin,
+      },
+      {
+        id: 'memory-open-button',
+        icon: 'file-export' as TeXRAIconName,
+        label: 'Open',
+        tooltip: 'Open in editor',
+        onClick: this.handleOpen,
+      },
+      {
+        id: 'memory-delete-button',
+        icon: 'trash' as TeXRAIconName,
+        label: 'Delete',
+        tooltip: 'Delete this memory',
+        onClick: this.handleDelete,
+      },
+    ];
+    return html`
+      <wa-button-group label="Memory actions">
+        ${repeat(
+          actions,
+          (action) => action.id,
+          (action) => html`
+            <wa-button
+              id=${action.id}
+              class="action-icon-button"
+              appearance="plain"
+              variant="neutral"
+              size="small"
+              type="button"
+              aria-label=${action.label}
+              @click=${action.onClick}
+            >
+              ${waIcon(action.icon)}
+            </wa-button>
+          `,
+        )}
+      </wa-button-group>
+      ${repeat(
+        actions,
+        (action) => action.id,
+        (action) =>
+          html`<wa-tooltip for=${action.id}>${action.tooltip}</wa-tooltip>`,
+      )}
+    `;
+  }
+
   override render(): TemplateResult | typeof nothing {
     if (!this.item) {
       return nothing;
@@ -206,28 +271,7 @@ export class MemoryItem extends LitElement {
       >
         <div class="list-item-header">
           <div class="memory-path">${this.item.displayPath}</div>
-          <wa-button-group label="Memory actions">
-            ${renderIconActionButton({
-              icon: this.item.pinned ? 'thumbtack-slash' : 'thumbtack',
-              label: this.item.pinned ? 'Unpin' : 'Pin',
-              title: this.item.pinned
-                ? 'Unpin this memory'
-                : 'Pin as core long-term memory',
-              onClick: this.handleTogglePin,
-            })}
-            ${renderIconActionButton({
-              icon: 'file-export',
-              label: 'Open',
-              title: 'Open in editor',
-              onClick: this.handleOpen,
-            })}
-            ${renderIconActionButton({
-              icon: 'trash',
-              label: 'Delete',
-              title: 'Delete this memory',
-              onClick: this.handleDelete,
-            })}
-          </wa-button-group>
+          ${this.renderActionGroup()}
         </div>
         <div class="text-secondary meta-strip">
           ${this.renderMeta(this.item)}

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
@@ -75,9 +75,10 @@ export class ProviderKeyList extends LitElement {
     const removeButton =
       entry.status === 'set'
         ? renderIconActionButton({
+            id: `provider-key-remove-${provider}`,
             icon: 'trash',
             label: 'Remove',
-            title: 'Remove key',
+            tooltip: 'Remove key',
             onClick: () =>
               this.dispatchEvent(ProviderKeyEvents.removeKey({ provider })),
           })
@@ -86,16 +87,18 @@ export class ProviderKeyList extends LitElement {
     return html`
       <div class="provider-actions action-button-group">
         ${renderIconActionButton({
+          id: `provider-key-set-${provider}`,
           icon: 'key',
           label: 'Set',
-          title: 'Set API key',
+          tooltip: 'Set API key',
           onClick: () =>
             this.dispatchEvent(ProviderKeyEvents.setKey({ provider })),
         })}
         ${renderIconActionButton({
+          id: `provider-key-get-${provider}`,
           icon: 'arrow-up-right-from-square',
           label: 'Get',
-          title: 'Get API key from provider',
+          tooltip: 'Get API key from provider',
           onClick: () =>
             this.dispatchEvent(ProviderKeyEvents.openKeyUrl({ provider })),
         })}

--- a/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
+++ b/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
@@ -244,6 +244,12 @@ export class FileSelectGroup extends LitElement {
         (file) => file,
         (file) => {
           const display = this.formatFilePath(file);
+          // Per-file id so the sibling <wa-tooltip> anchors to the right row
+          // (this list renders in a single shadow root).
+          const removeButtonId = `file-select-remove-${file}`.replace(
+            /[^a-zA-Z0-9_-]/g,
+            '-',
+          );
           return html`
             <div class="file-item" data-path=${file} title=${file}>
               <span class="file-name">
@@ -255,6 +261,7 @@ export class FileSelectGroup extends LitElement {
                   : nothing}
               </span>
               <wa-button
+                id=${removeButtonId}
                 class="action-icon-button remove-button"
                 appearance="plain"
                 variant="neutral"
@@ -265,6 +272,7 @@ export class FileSelectGroup extends LitElement {
               >
                 ${waIcon('trash')}
               </wa-button>
+              <wa-tooltip for=${removeButtonId}>Remove file</wa-tooltip>
             </div>
           `;
         },

--- a/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
+++ b/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
@@ -242,14 +242,12 @@ export class FileSelectGroup extends LitElement {
       ${repeat(
         this.currentFiles,
         (file) => file,
-        (file) => {
+        (file, index) => {
           const display = this.formatFilePath(file);
-          // Per-file id so the sibling <wa-tooltip> anchors to the right row
-          // (this list renders in a single shadow root).
-          const removeButtonId = `file-select-remove-${file}`.replace(
-            /[^a-zA-Z0-9_-]/g,
-            '-',
-          );
+          // Per-row id so the sibling <wa-tooltip> anchors to the right row
+          // (this list renders in a single shadow root). The repeat index is
+          // unique and collision-proof, unlike a sanitized path.
+          const removeButtonId = `file-select-remove-${index}`;
           return html`
             <div class="file-item" data-path=${file} title=${file}>
               <span class="file-name">

--- a/src/test-kernel/progressView/FileList.vitest.mts
+++ b/src/test-kernel/progressView/FileList.vitest.mts
@@ -29,6 +29,14 @@ const originalGlobals = {
   ResizeObserver: globalThis.ResizeObserver,
   localStorage: globalThis.localStorage,
   Node: (globalThis as { Node?: unknown }).Node,
+  HTMLSlotElement: globalThis.HTMLSlotElement,
+  MouseEvent: globalThis.MouseEvent,
+  AbortController: globalThis.AbortController,
+  AbortSignal: globalThis.AbortSignal,
+  requestAnimationFrame: (globalThis as { requestAnimationFrame?: unknown })
+    .requestAnimationFrame,
+  cancelAnimationFrame: (globalThis as { cancelAnimationFrame?: unknown })
+    .cancelAnimationFrame,
 };
 
 class NoopResizeObserver implements ResizeObserver {
@@ -56,6 +64,21 @@ function installDom(): void {
   globalThis.ResizeObserver = NoopResizeObserver;
   globalThis.localStorage = dom.window.localStorage;
   (globalThis as { Node: unknown }).Node = dom.window.Node;
+  // <wa-tooltip> attaches anchor listeners with an AbortSignal and positions
+  // via requestAnimationFrame. Bind the jsdom-backed implementations so the
+  // signal identity matches the EventTarget (jsdom rejects a foreign signal).
+  globalThis.HTMLSlotElement = dom.window.HTMLSlotElement;
+  globalThis.MouseEvent = dom.window.MouseEvent;
+  globalThis.AbortController = dom.window.AbortController;
+  globalThis.AbortSignal = dom.window.AbortSignal;
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) =>
+    setTimeout(() => cb(performance.now()), 0) as unknown as number) as (
+    cb: FrameRequestCallback,
+  ) => number;
+  globalThis.cancelAnimationFrame = ((handle: number) =>
+    clearTimeout(handle as unknown as ReturnType<typeof setTimeout>)) as (
+    handle: number,
+  ) => void;
   installAttachInternalsFallback(
     dom.window as unknown as Parameters<
       typeof installAttachInternalsFallback
@@ -78,10 +101,30 @@ function restoreDom(): void {
   globalThis.KeyboardEvent = originalGlobals.KeyboardEvent;
   globalThis.ResizeObserver = originalGlobals.ResizeObserver;
   globalThis.localStorage = originalGlobals.localStorage;
+  globalThis.HTMLSlotElement = originalGlobals.HTMLSlotElement;
+  globalThis.MouseEvent = originalGlobals.MouseEvent;
+  globalThis.AbortController = originalGlobals.AbortController;
+  globalThis.AbortSignal = originalGlobals.AbortSignal;
+  restoreOptionalGlobal(
+    'requestAnimationFrame',
+    originalGlobals.requestAnimationFrame,
+  );
+  restoreOptionalGlobal(
+    'cancelAnimationFrame',
+    originalGlobals.cancelAnimationFrame,
+  );
   if (originalGlobals.Node === undefined) {
     delete (globalThis as { Node?: unknown }).Node;
   } else {
     (globalThis as { Node: unknown }).Node = originalGlobals.Node;
+  }
+}
+
+function restoreOptionalGlobal(key: string, value: unknown): void {
+  if (value === undefined) {
+    delete (globalThis as Record<string, unknown>)[key];
+  } else {
+    (globalThis as Record<string, unknown>)[key] = value;
   }
 }
 

--- a/src/test-kernel/progressView/FileList.vitest.mts
+++ b/src/test-kernel/progressView/FileList.vitest.mts
@@ -101,10 +101,12 @@ function restoreDom(): void {
   globalThis.KeyboardEvent = originalGlobals.KeyboardEvent;
   globalThis.ResizeObserver = originalGlobals.ResizeObserver;
   globalThis.localStorage = originalGlobals.localStorage;
-  globalThis.HTMLSlotElement = originalGlobals.HTMLSlotElement;
-  globalThis.MouseEvent = originalGlobals.MouseEvent;
   globalThis.AbortController = originalGlobals.AbortController;
   globalThis.AbortSignal = originalGlobals.AbortSignal;
+  // HTMLSlotElement/MouseEvent aren't Node globals, so they captured undefined;
+  // route them through restoreOptionalGlobal to delete rather than set undefined.
+  restoreOptionalGlobal('HTMLSlotElement', originalGlobals.HTMLSlotElement);
+  restoreOptionalGlobal('MouseEvent', originalGlobals.MouseEvent);
   restoreOptionalGlobal(
     'requestAnimationFrame',
     originalGlobals.requestAnimationFrame,


### PR DESCRIPTION
## What

Icon-only buttons in several button groups were stuck on the plain native browser `title` tooltip, while neighbors like the **Agent settings** button already showed the nicer Web Awesome `<wa-tooltip>` popup. This brings every icon-button group in line.

Started with the progress-board stream-action toolbar (the stop / shield / rocket / collapse / undo / folder cluster) flagged in the original report, then swept the rest of the webview / progress / settings frontends.

## How

The key gotcha: `<wa-button-group>` fuses its buttons' corners via CSS `::slotted(:first-child)`/`:last-child`, so a `<wa-tooltip>` interleaved between the buttons breaks the rounded-corner segmenting. Tooltips for grouped buttons are therefore rendered **outside** the group and anchored by `for=${id}` (resolves by id within the same shadow root) — matching the existing `LatexDiffsSection` pattern.

- **Grouped buttons** (StreamHeader toolbar, MemoryItem Pin/Open/Delete): hand-rolled buttons inside the group, `<wa-tooltip>`s rendered after `</wa-button-group>`.
- **Helper-based standalone buttons** (FollowUpInput, StreamTabs clear-all, UserMessage copy, WorkflowHintBanner, FileList dismiss, ProviderKeyList, SearchBar, HistoryItemElement): switched `title:` → `tooltip:` and added an `id` so `renderIconActionButton` emits the `<wa-tooltip>` and suppresses the duplicate native title.
- **Hand-rolled buttons** (StreamTab delete, FileList file-actions, FileSelect remove, ApproveSplitButton / ToolEditRequestPanel dropdown triggers): added an `id` + sibling/after-group `<wa-tooltip>`, dropped the native `title`.
- **List-rendered rows** (ProviderKeyList, FileList, FileSelectGroup) derive ids from their item key (provider name / file path, sanitized) so ids stay unique within the single shadow root. Explicit `tooltip.js` imports added wherever a `<wa-tooltip>` is hand-rolled.

## Verified

- `npm run typecheck` — clean across all 5 workspace projects.
- `npm run compile:fast` — webview bundles successfully.
- `npx prettier --write` on all touched files.

Files: StreamHeader, MemoryItem, FollowUpInput, StreamTabs, UserMessage, WorkflowHintBanner, FileList, ProviderKeyList, SearchBar, HistoryItemElement, ApproveSplitButton, ToolEditRequestPanel, FileSelectGroup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only tooltip presentation and test harness tweaks; no auth, IPC, or business-logic changes.
> 
> **Overview**
> Replaces native `title` tooltips on icon-only controls across progress, settings, and main webview UIs with **Web Awesome `<wa-tooltip>`**, so hover help matches the rest of the extension.
> 
> **`wa-button-group` constraint:** grouped toolbars (`StreamHeader`, `MemoryItem`) precompute button state, render buttons inside the group, then attach tooltips **after** the group via `for=${id}` so `::slotted(:first/:last-child)` corner styling is not broken. Toggle buttons keep **active-state** tooltip text shared between button and tooltip.
> 
> **Call sites:** `renderIconActionButton` callers switch `title` → `tooltip` and pass stable `id`s; hand-rolled rows (`FileList` actions, `FileSelectGroup` remove, split/dropdown triggers) add sanitized or index-based ids plus sibling tooltips. `FileList` tests gain jsdom globals (`AbortController`, `requestAnimationFrame`, etc.) so `<wa-tooltip>` mounts under Vitest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cecb80727a4fab76f5b08b2eac3557accf80de4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->