### PR TITLE
refactor(settings): route state-backed reads through the catalog schema (#6609)

### DIFF
--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -2,7 +2,6 @@
 import * as path from 'node:path';
 
 // Local imports
-import { platform } from '@platform/platform';
 import { getExecutionStore } from '@agent/storage';
 import type { StageHandle } from '@agent/trace';
 import {
@@ -37,7 +36,6 @@ import {
   type StorageKey,
   type WorkspaceFileLocation,
 } from '@shared/schemas';
-import { LATEX_CONFIG_DEFAULTS } from '@shared/constants/latex';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import {
   AbsoluteFS,
@@ -46,6 +44,7 @@ import {
   createWorkspaceLocation,
 } from '@utils/files';
 import { PromptBuilder } from '@utils/prompt';
+import { readPlatformSetting } from '@utils/config/platformSettings';
 
 // Local imports - flow nodes and state
 import { TeXCountNode } from './nodes/TeXCountNode';
@@ -352,14 +351,10 @@ export async function runReflectionFlow<C = unknown>(
 function createWorkspaceStateWorkflowOutputPolicy(): WorkflowOutputPolicy {
   return {
     shouldAutoOpenPdfOrLog: () =>
-      platform().workspaceState.get<boolean>(
-        WorkspaceStateKey.WORKFLOW_AUTO_OPEN_PDF,
-        LATEX_CONFIG_DEFAULTS.workflowAutoOpenPdf,
-      ),
+      readPlatformSetting<boolean>(WorkspaceStateKey.WORKFLOW_AUTO_OPEN_PDF),
     shouldRejectOnCompileFailure: () =>
-      platform().workspaceState.get<boolean>(
+      readPlatformSetting<boolean>(
         WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE,
-        LATEX_CONFIG_DEFAULTS.workflowRejectOnCompileFailure,
       ),
   };
 }

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -15,10 +15,7 @@ import {
   type OutputFileInfo,
 } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
-import {
-  LATEX_CONFIG_DEFAULTS,
-  LATEX_CONFIG_RANGES,
-} from '@shared/constants/latex';
+import { LATEX_CONFIG_RANGES } from '@shared/constants/latex';
 import {
   createExternalLocation,
   createRunStorageLocation,
@@ -28,6 +25,7 @@ import {
 } from '@utils/files';
 import { checkToolInstalled } from '@utils/system';
 import { getComparablePath } from '@utils/files/taskRunStorage';
+import { readPlatformSetting } from '@utils/config/platformSettings';
 
 import {
   publishCompiledPdfArtifact,
@@ -193,9 +191,8 @@ export class LatexDiffManager {
       }
     }
 
-    const generateBetweenRoundDiffs = platform().workspaceState.get<boolean>(
+    const generateBetweenRoundDiffs = readPlatformSetting<boolean>(
       WorkspaceStateKey.LATEXDIFF_BETWEEN_ROUNDS,
-      LATEX_CONFIG_DEFAULTS.latexdiffBetweenRounds,
     );
 
     if (generateBetweenRoundDiffs && currRound > 0) {
@@ -374,9 +371,8 @@ export class LatexDiffManager {
     // gets killed by execa instead of orphaning latexmk/pdflatex.
     const timeoutMs = Math.max(
       LATEX_CONFIG_RANGES.workflowAutoCompileTimeoutMs.min,
-      platform().workspaceState.get<number>(
+      readPlatformSetting<number>(
         WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS,
-        LATEX_CONFIG_DEFAULTS.workflowAutoCompileTimeoutMs,
       ),
     );
     const ok = await compileLatex2Pdf(diffLocation, {

--- a/src/agent/output/compileCheck.ts
+++ b/src/agent/output/compileCheck.ts
@@ -1,6 +1,5 @@
 import * as path from 'node:path';
 
-import { platform } from '@platform/platform';
 import type { AgentTrace } from '@agent/trace';
 import { toErrorMessage } from '@common/errors';
 import { hasLatexCompiler } from '@latex/latexToolchain';
@@ -11,10 +10,7 @@ import type {
   OutputFileInfo,
 } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
-import {
-  LATEX_CONFIG_DEFAULTS,
-  LATEX_CONFIG_RANGES,
-} from '@shared/constants/latex';
+import { LATEX_CONFIG_RANGES } from '@shared/constants/latex';
 import {
   createRunStorageLocation,
   flexibleFS,
@@ -24,6 +20,7 @@ import {
 } from '@utils/files';
 import { hasExtension } from '@utils/core/pathCore';
 import { splitContentLines } from '@utils/text/stringUtils';
+import { readPlatformSetting } from '@utils/config/platformSettings';
 
 import {
   publishCompiledPdfArtifact,
@@ -75,12 +72,7 @@ export async function runCompileCheck(
   ctx: CompileCheckContext,
   currentRound: number,
 ): Promise<CompileCheckResult> {
-  if (
-    !platform().workspaceState.get<boolean>(
-      WorkspaceStateKey.WORKFLOW_AUTO_COMPILE,
-      LATEX_CONFIG_DEFAULTS.workflowAutoCompile,
-    )
-  ) {
+  if (!readPlatformSetting<boolean>(WorkspaceStateKey.WORKFLOW_AUTO_COMPILE)) {
     return { failures: [], artifacts: [] };
   }
 
@@ -107,9 +99,8 @@ export async function runCompileCheck(
 
   const timeoutMs = Math.max(
     MIN_TIMEOUT_MS,
-    platform().workspaceState.get<number>(
+    readPlatformSetting<number>(
       WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS,
-      LATEX_CONFIG_DEFAULTS.workflowAutoCompileTimeoutMs,
     ),
   );
   // compileRoot is created lazily on first failure so successful rounds leave

--- a/src/latex/formatter/indentDirectory.ts
+++ b/src/latex/formatter/indentDirectory.ts
@@ -1,13 +1,12 @@
 import * as path from 'node:path';
 
-import { platform } from '@platform/platform';
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
-import { LATEX_CONFIG_DEFAULTS } from '@shared/constants/latex';
 import { EXCLUDED_DIRS } from '@shared/constants/workspaceDirs';
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
 import { getConfig } from '@utils/config';
+import { readPlatformSetting } from '@utils/config/platformSettings';
 import { isDirectory, isFile, isSymlink } from '@utils/files/fsEntryType';
 import { hasExtension } from '@utils/core/pathCore';
 
@@ -55,9 +54,8 @@ export async function indentLatexFilesInDirectory(
     `Starting LaTeX indentation process for directory: ${directory}`,
   );
 
-  const formatter = platform().workspaceState.get<string>(
+  const formatter = readPlatformSetting<string>(
     WorkspaceStateKey.LATEX_FORMATTER,
-    LATEX_CONFIG_DEFAULTS.latexFormatter,
   );
   if (formatter === 'none') {
     logger.debug(CHANNEL, 'LaTeX formatter disabled; skipping indentation');

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -68,10 +68,11 @@ export class LaTeXdiffService {
    * Resolve the latexdiff timeout from workspace state. Tolerant of
    * pre-initialization: `LaTeXdiffService` is instantiated at module scope in
    * `commands/latex/latexdiffCommands.ts` and `tools/approval/latexPreview.ts`,
-   * which evaluate before `initPlatform()` runs in `activate()`. A throwing
-   * `platform().workspaceState` would prevent the extension from activating; falling
-   * back to the documented default keeps construction safe. Called per-diff
-   * so user updates take effect on the next invocation without any rebuild.
+   * which evaluate before `initPlatform()` runs in `activate()`. `readPlatformSetting`
+   * uses `tryPlatform()` internally, so it returns the catalog schema default
+   * instead of throwing when the platform isn't initialized yet — keeping
+   * construction safe. Called per-diff so user updates take effect on the next
+   * invocation without any rebuild.
    */
   private getLatexdiffTimeout(): number {
     return readPlatformSetting<number>(WorkspaceStateKey.LATEXDIFF_TIMEOUT_MS);

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -2,15 +2,14 @@ import * as path from 'node:path';
 
 import { z } from 'zod';
 
-import { tryWorkspaceState } from '@platform/platform';
 import { extractLastRoundMatch } from '@agent/utils/mergeFileUtils';
 import { formatError, toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import type { FileLocation } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
-import { LATEX_CONFIG_DEFAULTS } from '@shared/constants/latex';
 import { flexibleFS, pathToLocation } from '@utils/files';
 import { executeCommand } from '@utils/system';
+import { readPlatformSetting } from '@utils/config/platformSettings';
 import { runLatexFormatter } from './texFormatter';
 import { generateDiffFileName } from './latexdiff/diffFileNameManager';
 import { DiffFileProcessor } from './latexdiff/diffFileProcessor';
@@ -42,8 +41,6 @@ export type LaTeXdiffMultipleResult = z.infer<
 
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);
-
-const DEFAULT_LATEXDIFF_TIMEOUT_MS = LATEX_CONFIG_DEFAULTS.latexdiffTimeoutMs;
 
 function hasDocumentEnvironment(content: string): boolean {
   return (
@@ -77,12 +74,7 @@ export class LaTeXdiffService {
    * so user updates take effect on the next invocation without any rebuild.
    */
   private getLatexdiffTimeout(): number {
-    return (
-      tryWorkspaceState()?.get<number>(
-        WorkspaceStateKey.LATEXDIFF_TIMEOUT_MS,
-        DEFAULT_LATEXDIFF_TIMEOUT_MS,
-      ) ?? DEFAULT_LATEXDIFF_TIMEOUT_MS
-    );
+    return readPlatformSetting<number>(WorkspaceStateKey.LATEXDIFF_TIMEOUT_MS);
   }
 
   private logDiffError(context: string, err: unknown): LaTeXdiffResult {

--- a/src/latex/latexdiff/diffCommandExecutor.ts
+++ b/src/latex/latexdiff/diffCommandExecutor.ts
@@ -1,11 +1,10 @@
 // Internal imports
-import { platform } from '@platform/platform';
 import * as logger from '@logger/logUtils';
 import type { ExecResult } from '@shared/schemas/opResults';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
-import { LATEX_CONFIG_DEFAULTS } from '@shared/constants/latex';
 import { executeCommand } from '@utils/system';
 import { getConfig } from '@utils/config/configUtils';
+import { readPlatformSetting } from '@utils/config/platformSettings';
 
 // Local file imports
 import { DEFAULT_MATH_MARKUP, type MathMarkupOption } from './mathMarkup';
@@ -265,18 +264,15 @@ export class DiffCommandExecutor {
     pictureEnvs: string;
     subtype?: string;
   } {
-    const state = platform().workspaceState;
-    const changesOnly = state.get<boolean>(
+    const changesOnly = readPlatformSetting<boolean>(
       WorkspaceStateKey.LATEXDIFF_CHANGES_ONLY,
-      LATEX_CONFIG_DEFAULTS.latexdiffChangesOnly,
     );
 
     return {
       mathMarkup:
         options?.mathMarkup ??
-        state.get<MathMarkupOption>(
+        readPlatformSetting<MathMarkupOption>(
           WorkspaceStateKey.LATEXDIFF_MATH_MARKUP,
-          LATEX_CONFIG_DEFAULTS.latexdiffMathMarkup as MathMarkupOption,
         ),
       pictureEnvs: getConfig<string>(
         'texra.latexdiff.pictureEnvironments',

--- a/src/latex/texFormatter.ts
+++ b/src/latex/texFormatter.ts
@@ -1,16 +1,14 @@
 // Local imports - formatter implementations
-import { platform } from '@platform/platform';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
-import { LATEX_CONFIG_DEFAULTS } from '@shared/constants/latex';
+import { readPlatformSetting } from '@utils/config/platformSettings';
 
 // Local file imports
 import { runLatexIndent } from './formatter/latexindentpt';
 import { runTexFmt } from './formatter/texfmt';
 
 export async function runLatexFormatter(filePath: string): Promise<boolean> {
-  const formatter = platform().workspaceState.get<string>(
+  const formatter = readPlatformSetting<string>(
     WorkspaceStateKey.LATEX_FORMATTER,
-    LATEX_CONFIG_DEFAULTS.latexFormatter,
   );
 
   switch (formatter) {

--- a/src/test-kernel/utils/config/PlatformSettings.vitest.ts
+++ b/src/test-kernel/utils/config/PlatformSettings.vitest.ts
@@ -1,0 +1,54 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports
+import { createFakePlatform } from '@test/support/FakePlatform';
+import { LATEX_CONFIG_DEFAULTS } from '@shared/constants/latex';
+import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
+import { readPlatformSetting } from '@utils/config/platformSettings';
+
+async function initWith(options: {
+  workspaceState?: Record<string, unknown>;
+  globalState?: Record<string, unknown>;
+}): Promise<void> {
+  const { initPlatform } = await import('@platform/platform');
+  initPlatform(createFakePlatform(options));
+}
+
+describe('readPlatformSetting', () => {
+  it('resolves the default from the catalog schema when the key is unset', async () => {
+    await initWith({});
+    expect(readPlatformSetting(WorkspaceStateKey.LATEX_FORMATTER)).toBe(
+      LATEX_CONFIG_DEFAULTS.latexFormatter,
+    );
+    // A globalState-slot key resolves the same way.
+    expect(readPlatformSetting(GlobalStateKey.WEBSOCKET_OPENAI)).toBe(false);
+  });
+
+  it('returns the stored value when present and valid', async () => {
+    await initWith({
+      workspaceState: { [WorkspaceStateKey.LATEX_FORMATTER]: 'tex-fmt' },
+    });
+    expect(readPlatformSetting(WorkspaceStateKey.LATEX_FORMATTER)).toBe(
+      'tex-fmt',
+    );
+  });
+
+  it('snaps a stored value that fails the schema back to the catalog default', async () => {
+    await initWith({
+      workspaceState: {
+        [WorkspaceStateKey.LATEX_FORMATTER]: 'not-a-formatter',
+      },
+    });
+    expect(readPlatformSetting(WorkspaceStateKey.LATEX_FORMATTER)).toBe(
+      LATEX_CONFIG_DEFAULTS.latexFormatter,
+    );
+  });
+
+  it('throws for a key with no catalog entry', async () => {
+    await initWith({});
+    expect(() => readPlatformSetting('texra.not.a.catalog.key')).toThrow(
+      /no state-setting catalog entry/i,
+    );
+  });
+});

--- a/src/utils/config/platformSettings.ts
+++ b/src/utils/config/platformSettings.ts
@@ -1,0 +1,48 @@
+import { tryPlatform } from '@platform/platform';
+
+import {
+  readSetting,
+  settingDefault,
+  type SettingsHostKind,
+} from '@shared/config/settingsAccess';
+import { stateSettingByKey } from '@shared/schemas/stateSettings';
+
+/**
+ * Read a catalog-modeled state setting from the live platform, resolving its
+ * default from the entry's schema `.prefault()` — the single default source.
+ *
+ * Replaces the scattered `platform().<store>.get(key, handPassedDefault)` reads
+ * whose second argument duplicated the catalog default: the value now comes from
+ * the schema, and a stale/invalid stored value snaps back to that default (via
+ * `readSetting`'s `safeParse`) rather than propagating. The store slot
+ * (`workspaceState` / `globalState` / `config`) is the one the catalog entry
+ * declares, so the right backing store is picked without the caller naming it.
+ *
+ * Graceful when the platform isn't initialized yet — returns the schema default
+ * instead of throwing — matching the previous `tryWorkspaceState()?.get(...) ??
+ * default` sites. `host` only changes the slot for the CLI-divergent git-author
+ * keys (`cliStore: 'config'`); every key read through here today is
+ * host-uniform, so the default suffices.
+ */
+export function readPlatformSetting<T>(
+  key: string,
+  host: SettingsHostKind = 'extension',
+): T {
+  const entry = stateSettingByKey(key);
+  if (!entry) {
+    throw new Error(`No state-setting catalog entry for key: ${key}`);
+  }
+  const active = tryPlatform();
+  if (!active) {
+    return settingDefault(entry) as T;
+  }
+  return readSetting(
+    entry,
+    {
+      config: active.config,
+      workspaceState: active.workspaceState,
+      globalState: active.globalState,
+    },
+    host,
+  ) as T;
+}

--- a/src/utils/config/providerConfig.ts
+++ b/src/utils/config/providerConfig.ts
@@ -10,6 +10,7 @@
 import { tryGlobalState } from '@platform/platform';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { getConfig } from '@utils/config';
+import { readPlatformSetting } from './platformSettings';
 
 /**
  * When `key` is set in globalSM (treated as boolean), the provider is in its
@@ -215,8 +216,12 @@ export function setWebSocketEnabledOverride(value: boolean | undefined): void {
 }
 
 export function getWebSocketEnabled(): boolean {
+  // WEBSOCKET_OPENAI is catalog-modeled, so its default comes from the schema
+  // via the shared accessor. The other provider toggles below are not in the
+  // catalog and stay on the local `read`.
   return (
-    webSocketEnabledOverride ?? read(GlobalStateKey.WEBSOCKET_OPENAI, false)
+    webSocketEnabledOverride ??
+    readPlatformSetting<boolean>(GlobalStateKey.WEBSOCKET_OPENAI)
   );
 }
 


### PR DESCRIPTION
## What

The settings catalog (`stateSettings.ts`) is the SSOT for keys/defaults, but **reads were still split**: the extension/desktop/agent read state-backed keys directly via `platform().<store>.get(key, handPassedDefault)`, duplicating the catalog default as a second argument. This routes those reads through a single accessor so the default comes only from the entry's schema `.prefault()`.

Resolves #6609. Subsumes #6605 (same read/write-layer unification — closing that one as a duplicate).

## How

- **New `readPlatformSetting(key)`** (`src/utils/config/platformSettings.ts`): looks up the catalog entry, assembles the platform stores, and delegates to the existing `settingsAccess.readSetting` pipe. Graceful (returns the schema default) when the platform isn't initialized — matching the prior `tryWorkspaceState()?.get(...) ?? default` sites.
- **Rerouted 8 read sites**, dropping their hand-passed default constants:
  - `latex/texFormatter.ts`, `latex/formatter/indentDirectory.ts`, `latex/latexdiff.ts`, `latex/latexdiff/diffCommandExecutor.ts`
  - `agent/output/compileCheck.ts`, `agent/output/LatexDiffManager.ts`, `agent/implementations/flows/reflection/runReflectionFlow.ts`
  - `utils/config/providerConfig.ts` (the `WEBSOCKET_OPENAI` read — the one catalog-modeled key there; the other provider toggles aren't in the catalog and stay on the local `read`)

## Behavior

Defaults are **unchanged**: every rerouted key's `.prefault()` already equals the constant it replaced (verified against `LATEX_CONFIG_DEFAULTS` / `false`). The only behavior delta is the documented improvement from `readSetting`'s `safeParse`: a stale/invalid stored value now snaps back to the catalog default instead of propagating. The existing `Math.max(...)` range guards on the timeout reads are kept as-is.

## Verify

- `tsc --noEmit` (root + test-kernel + extension + cli): clean
- `eslint` on all changed files: clean
- New `PlatformSettings.vitest.ts` (default-from-catalog, stored-value, invalid-snaps-to-default, no-entry-throws) + `stateSettings` / `settingsConfiguration` / `LatexConfigPersistenceController` / `XmlOutputManager` suites: 40 passed
- Disjoint from the in-flight `codex/decouple-ui-agent-core` branch (no shared files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical read-path refactor with unchanged intended defaults; only behavioral delta is stricter validation of corrupt stored values.
> 
> **Overview**
> Introduces **`readPlatformSetting(key)`** so catalog-modeled workspace/global settings are read through `settingsAccess.readSetting` instead of `platform().<store>.get(key, handPassedDefault)`. Defaults now come only from each entry’s schema `.prefault()`; invalid stored values snap back via `safeParse`.
> 
> **Eight call sites** in LaTeX formatting/diff, workflow compile checks, reflection flow output policy, and `getWebSocketEnabled()` are switched over and no longer pass duplicated `LATEX_CONFIG_DEFAULTS` (or hardcoded `false`). Pre-`initPlatform()` behavior is preserved by returning the schema default when `tryPlatform()` is unset—replacing prior `tryWorkspaceState()?.get(...) ?? default` patterns.
> 
> Adds **`PlatformSettings.vitest.ts`** covering unset defaults, valid stored values, invalid snap-back, and missing catalog keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8eca0714518cae7545558171b9cd4b1ba064ec93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->