### PR TITLE
refactor(model-handlers): extract BackgroundPoller collaborator for duplicated poll loops

### DIFF
--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -25,7 +25,6 @@ import { K_SLICE } from '@agent/core/constants';
 import {
   detectStatusCode,
   getSdkErrorMessage,
-  isUserAbort,
   attachPartialText,
   takeTail,
   PARTIAL_TEXT_TAIL_MAX,
@@ -39,7 +38,7 @@ import type { FileLocation } from '@shared/schemas';
 import type { ToolFileAttachment } from '@shared/schemas/toolResult';
 
 // Local imports - utils
-import { delay, isNonEmptyString, isObject } from '@utils/core';
+import { isNonEmptyString, isObject } from '@utils/core';
 import { flexibleFS, getShortDisplayPath } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
 import { joinNonEmpty, pluralize } from '@utils/text/stringUtils';
@@ -54,6 +53,7 @@ import {
   computeGoogleInteractionsPrice,
   normalizeGoogleInteractionsUsage,
 } from './googleInteractionsUsage';
+import { BackgroundPoller } from '../support/BackgroundPoller';
 import {
   CLIENT_COMPACTION_SUMMARY_MAX_TOKENS,
   COMPACTION_SYSTEM_PROMPT,
@@ -296,10 +296,6 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
 
   protected override backgroundModeSupported = true;
 
-  private static readonly BACKGROUND_POLL_INTERVAL_MS = 5000;
-  private static readonly BACKGROUND_MAX_DURATION_MS = 3 * 60 * 60 * 1000; // 3 hours
-
-  /** Immutable params for every background poll get() — id is the positional arg. */
   private static readonly BACKGROUND_GET_PARAMS: InteractionGetParamsNonStreaming =
     { stream: false };
 
@@ -317,6 +313,20 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
    */
   private static readonly BACKGROUND_PENDING_STATUSES: readonly InteractionStatus[] =
     ['in_progress'];
+
+  /** Shared polling collaborator, created lazily on first use. */
+  private _backgroundPoller?: BackgroundPoller<GoogleGenAIInteraction>;
+  private get backgroundPoller(): BackgroundPoller<GoogleGenAIInteraction> {
+    if (!this._backgroundPoller) {
+      this._backgroundPoller = new BackgroundPoller({
+        pollIntervalMs: 5000,
+        maxDurationMs: 3 * 60 * 60 * 1000, // 3 hours
+        isPending: (r) => this.isBackgroundPending(r),
+        logger: this.logger,
+      });
+    }
+    return this._backgroundPoller;
+  }
 
   /**
    * Id of the background interaction currently being polled, so an abort handler
@@ -1754,98 +1764,68 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
     }
 
     this.pendingBackgroundInteractionId = interactionId;
-    const onAbort = () => {
-      // Fire-and-forget cancel; do NOT await inside the listener. The in-flight
-      // delay()/get() reject with AbortError, which the loop translates into the
-      // user-abort throw.
-      void this.cancelBackgroundInteraction(client, interactionId);
-    };
-    signal?.addEventListener('abort', onAbort, { once: true });
-    if (signal?.aborted) onAbort();
-
-    const pollInterval =
-      ModelHandlerGoogleInteractions.BACKGROUND_POLL_INTERVAL_MS;
-    const maxDuration =
-      ModelHandlerGoogleInteractions.BACKGROUND_MAX_DURATION_MS;
-    const startTime = Date.now();
-    let current = initial;
-    let pollCount = 0;
-
     try {
-      while (this.isBackgroundPending(current)) {
-        pollCount += 1;
-        try {
-          await delay(pollInterval, { signal });
-        } catch (err) {
-          if (isUserAbort(err)) {
-            this.logger.debug(
-              `Background polling aborted for interaction ${interactionId} ` +
-                `while waiting (poll ${pollCount}).`,
-            );
+      const onAbort = () => {
+        // Fire-and-forget cancel; do NOT await inside the listener.
+        void this.cancelBackgroundInteraction(client, interactionId);
+      };
+
+      const polled = await this.backgroundPoller.poll({
+        initialResponse: initial,
+        retrieve: async (id, sig) => {
+          const opts = sig
+            ? { fetchOptions: { signal: sig } }
+            : requestOptions;
+          try {
+            return (await client.interactions.get(
+              id,
+              ModelHandlerGoogleInteractions.BACKGROUND_GET_PARAMS,
+              opts,
+            )) as unknown as GoogleGenAIInteraction;
+          } catch (err) {
+            // Tag and rethrow — a user-abort surfaces as-is; a transient poll
+            // error (5xx/429/network) re-enters createResponse via PocketFlow's
+            // retry layer with a fresh submit (orphaned job ages out; no resume
+            // path in v0).
+            this.sdkErrorTagger(err, this.config.provider);
+            throw err;
           }
-          throw err; // cancel already requested via onAbort
-        }
+        },
+        extractId: (r) => r.id,
+        extractStatus: (r) => r.status ?? 'unknown',
+        signal,
+        providerLabel: 'Google Interactions',
+        onAbort,
+      });
 
-        if (Date.now() - startTime > maxDuration) {
-          throw new Error(
-            `Background interaction ${interactionId} exceeded maximum polling ` +
-              `duration of ${maxDuration} ms. Cancel it with ` +
-              `client.interactions.cancel("${interactionId}").`,
-          );
-        }
-
-        // get(id, params, options): params is Omit<GetInteractionByIdRequest,
-        // 'id'> & { stream?: false } — the id is the positional arg, NOT repeated
-        // in params. Returns Promise<GoogleGenAIInteraction>.
-        try {
-          current = (await client.interactions.get(
-            interactionId,
-            ModelHandlerGoogleInteractions.BACKGROUND_GET_PARAMS,
-            requestOptions,
-          )) as unknown as GoogleGenAIInteraction;
-        } catch (err) {
-          // Tag and rethrow — a user-abort surfaces as-is; a transient poll
-          // error (5xx/429/network) re-enters createResponse via PocketFlow's
-          // retry layer with a fresh submit (orphaned job ages out; no resume
-          // path in v0).
-          this.sdkErrorTagger(err, this.config.provider);
-          throw err;
-        }
-        this.logger.debug(
-          `Background poll ${pollCount} for ${interactionId}: ` +
-            `status=${current.status ?? 'unknown'}`,
-        );
+      // `completed` and `requires_action` are both serviceable terminals: the
+      // latter carries function_call steps, so return it (don't throw) and let the
+      // cycle service the tools, mirroring the streaming/non-streaming paths and
+      // finalizeChain's chain-safe handling. Workflow agents normally carry no
+      // tools, but the gate (isWorkflowMode) is not a hard guarantee, so handle it
+      // rather than crash a run that does emit a call.
+      if (
+        polled.status === 'completed' ||
+        polled.status === 'requires_action'
+      ) {
+        return polled;
       }
+
+      // Terminal failure: failed / cancelled / incomplete / budget_exceeded —
+      // treated uniformly as a thrown, tagged error.
+      const status = polled.status ?? 'unknown';
+      this.logger.error(
+        `Background interaction ${interactionId} ended with status "${status}".`,
+      );
+      const err = new Error(
+        `Google Interactions background interaction ${interactionId} ended with ` +
+          `status "${status}".`,
+      );
+      this.sdkErrorTagger(err, this.config.provider);
+      throw err;
     } finally {
-      signal?.removeEventListener('abort', onAbort);
       this.clearPendingBackgroundInteraction();
     }
-
-    // `completed` and `requires_action` are both serviceable terminals: the
-    // latter carries function_call steps, so return it (don't throw) and let the
-    // cycle service the tools, mirroring the streaming/non-streaming paths and
-    // finalizeChain's chain-safe handling. Workflow agents normally carry no
-    // tools, but the gate (isWorkflowMode) is not a hard guarantee, so handle it
-    // rather than crash a run that does emit a call.
-    if (
-      current.status === 'completed' ||
-      current.status === 'requires_action'
-    ) {
-      return current;
-    }
-
-    // Terminal failure: failed / cancelled / incomplete / budget_exceeded —
-    // treated uniformly as a thrown, tagged error.
-    const status = current.status ?? 'unknown';
-    this.logger.error(
-      `Background interaction ${interactionId} ended with status "${status}".`,
-    );
-    const err = new Error(
-      `Google Interactions background interaction ${interactionId} ended with ` +
-        `status "${status}".`,
-    );
-    this.sdkErrorTagger(err, this.config.provider);
-    throw err;
   }
 
   /** Cancel the in-flight background interaction (best-effort; swallow errors). */

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -1773,9 +1773,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
       const polled = await this.backgroundPoller.poll({
         initialResponse: initial,
         retrieve: async (id, sig) => {
-          const opts = sig
-            ? { fetchOptions: { signal: sig } }
-            : requestOptions;
+          const opts = sig ? { fetchOptions: { signal: sig } } : requestOptions;
           try {
             return (await client.interactions.get(
               id,

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -317,19 +317,13 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
   private static readonly BACKGROUND_PENDING_STATUSES: readonly InteractionStatus[] =
     ['in_progress'];
 
-  /** Shared polling collaborator, created lazily on first use. */
-  private _backgroundPoller?: BackgroundPoller<GoogleGenAIInteraction>;
-  private get backgroundPoller(): BackgroundPoller<GoogleGenAIInteraction> {
-    if (!this._backgroundPoller) {
-      this._backgroundPoller = new BackgroundPoller({
-        pollIntervalMs: 5000,
-        maxDurationMs: 3 * 60 * 60 * 1000, // 3 hours
-        isPending: (r) => this.isBackgroundPending(r),
-        logger: () => this.logger,
-      });
-    }
-    return this._backgroundPoller;
-  }
+  private readonly backgroundPoller =
+    new BackgroundPoller<GoogleGenAIInteraction>({
+      pollIntervalMs: 5000,
+      maxDurationMs: 3 * 60 * 60 * 1000, // 3 hours
+      isPending: (r) => this.isBackgroundPending(r),
+      logger: () => this.logger,
+    });
 
   /**
    * Id of the background interaction currently being polled, so an abort handler

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -53,7 +53,10 @@ import {
   computeGoogleInteractionsPrice,
   normalizeGoogleInteractionsUsage,
 } from './googleInteractionsUsage';
-import { BackgroundPoller } from '../support/BackgroundPoller';
+import {
+  BackgroundPoller,
+  type BackgroundPollStats,
+} from '../support/BackgroundPoller';
 import {
   CLIENT_COMPACTION_SUMMARY_MAX_TOKENS,
   COMPACTION_SYSTEM_PROMPT,
@@ -322,7 +325,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
         pollIntervalMs: 5000,
         maxDurationMs: 3 * 60 * 60 * 1000, // 3 hours
         isPending: (r) => this.isBackgroundPending(r),
-        logger: this.logger,
+        logger: () => this.logger,
       });
     }
     return this._backgroundPoller;
@@ -1770,6 +1773,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
         void this.cancelBackgroundInteraction(client, interactionId);
       };
 
+      let pollStats: BackgroundPollStats | undefined;
       const polled = await this.backgroundPoller.poll({
         initialResponse: initial,
         retrieve: async (id, sig) => {
@@ -1792,8 +1796,19 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
         extractId: (r) => r.id,
         extractStatus: (r) => r.status ?? 'unknown',
         signal,
+        resourceLabel: 'interaction',
         providerLabel: 'Google Interactions',
         onAbort,
+        formatTimeoutError: ({ responseId, maxDurationMs }) =>
+          `Google Interactions background interaction ${responseId} exceeded ` +
+          `maximum polling duration of ${maxDurationMs} ms. Cancel it with ` +
+          `client.interactions.cancel("${responseId}").`,
+        extraFinishData: (interaction) => ({
+          usage: interaction.usage ?? undefined,
+        }),
+        onFinished: (_interaction, stats) => {
+          pollStats = stats;
+        },
       });
 
       // `completed` and `requires_action` are both serviceable terminals: the
@@ -1814,6 +1829,14 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
       const status = polled.status ?? 'unknown';
       this.logger.error(
         `Background interaction ${interactionId} ended with status "${status}".`,
+        {
+          data: {
+            interactionId,
+            status,
+            pollCount: pollStats?.pollCount,
+            elapsedMs: pollStats?.elapsedMs,
+          },
+        },
       );
       const err = new Error(
         `Google Interactions background interaction ${interactionId} ended with ` +

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -1762,11 +1762,6 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
 
     this.pendingBackgroundInteractionId = interactionId;
     try {
-      const onAbort = () => {
-        // Fire-and-forget cancel; do NOT await inside the listener.
-        void this.cancelBackgroundInteraction(client, interactionId);
-      };
-
       let pollStats: BackgroundPollStats | undefined;
       const polled = await this.backgroundPoller.poll({
         initialResponse: initial,
@@ -1792,7 +1787,10 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
         signal,
         resourceLabel: 'interaction',
         providerLabel: 'Google Interactions',
-        onAbort,
+        onAbort: () => {
+          // Fire-and-forget cancel; do NOT await inside the listener.
+          void this.cancelBackgroundInteraction(client, interactionId);
+        },
         formatTimeoutError: ({ responseId, maxDurationMs }) =>
           `Google Interactions background interaction ${responseId} exceeded ` +
           `maximum polling duration of ${maxDurationMs} ms. Cancel it with ` +

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -2033,7 +2033,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     // tryResumeBackgroundResponse instead of creating a new request.
     this.pendingBackgroundResponseId = initialResponse.id;
 
-    const polled = await this.backgroundPoller.poll({
+    const polled = (await this.backgroundPoller.poll({
       initialResponse,
       retrieve: async (responseId, sig) => {
         try {
@@ -2077,7 +2077,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       signal,
       providerLabel: 'OpenAI',
       onAbort: () => this.clearPendingBackgroundResponse(),
-    }) as T;
+    })) as T;
 
     if (polled.status === 'completed') {
       return polled;

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -330,19 +330,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   private static readonly BACKGROUND_PENDING_STATUSES: readonly ResponseStatus[] =
     ['queued', 'in_progress'];
 
-  /** Shared polling collaborator, created lazily on first use. */
-  private _backgroundPoller?: BackgroundPoller<Response>;
-  private get backgroundPoller(): BackgroundPoller<Response> {
-    if (!this._backgroundPoller) {
-      this._backgroundPoller = new BackgroundPoller({
-        pollIntervalMs: 15000,
-        maxDurationMs: 3 * 60 * 60 * 1000, // 3 hours
-        isPending: (r) => this.isBackgroundPending(r),
-        logger: () => this.logger,
-      });
-    }
-    return this._backgroundPoller;
-  }
+  private readonly backgroundPoller = new BackgroundPoller<Response>({
+    pollIntervalMs: 15000,
+    maxDurationMs: 3 * 60 * 60 * 1000, // 3 hours
+    isPending: (r) => this.isBackgroundPending(r),
+    logger: () => this.logger,
+  });
 
   private previousResponseId: string | null = null;
 

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -39,7 +39,7 @@ import type { FileLocation } from '@shared/schemas';
 import type { ToolFileAttachment } from '@shared/schemas/toolResult';
 
 // Local imports - utils
-import { clamp, delay, filterNotNullish, roundTo } from '@utils/core';
+import { clamp, filterNotNullish, roundTo } from '@utils/core';
 import { getConfig } from '@utils/config/configUtils';
 import {
   getWebSocketEnabled,
@@ -81,6 +81,7 @@ import {
 } from '../types/ServerToolTypes';
 import { ResponseStreamProcessor } from './ResponseStreamProcessor';
 import { OpenAIResponseWebSocketTransport } from './OpenAIResponseWebSocketTransport';
+import { BackgroundPoller } from '../support/BackgroundPoller';
 import { isResponseFunctionToolCallItem } from './responseStreamEvents';
 import {
   createInputText,
@@ -322,11 +323,24 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     return isGptFamilyModelName(this.config.name) && this.isWorkflowMode();
   }
 
-  private static readonly BACKGROUND_POLL_INTERVAL_MS = 15000;
-  private static readonly BACKGROUND_MAX_DURATION_MS = 3 * 60 * 60 * 1000; // 3 hours
   /** Statuses indicating the background response is still processing. */
   private static readonly BACKGROUND_PENDING_STATUSES: readonly ResponseStatus[] =
     ['queued', 'in_progress'];
+
+  /** Shared polling collaborator, created lazily on first use. */
+  private _backgroundPoller?: BackgroundPoller<Response>;
+  private get backgroundPoller(): BackgroundPoller<Response> {
+    if (!this._backgroundPoller) {
+      this._backgroundPoller = new BackgroundPoller({
+        pollIntervalMs: 15000,
+        maxDurationMs: 3 * 60 * 60 * 1000, // 3 hours
+        isPending: (r) => this.isBackgroundPending(r),
+        logger: this.logger,
+      });
+    }
+    return this._backgroundPoller;
+  }
+
   private previousResponseId: string | null = null;
 
   /**
@@ -2015,168 +2029,75 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       return initialResponse;
     }
 
-    let current = initialResponse;
-    const responseId = initialResponse.id;
-
     // Track which response is being polled so retry logic can resume via
     // tryResumeBackgroundResponse instead of creating a new request.
-    this.pendingBackgroundResponseId = responseId;
-    const pollInterval = ModelHandlerOpenAIResponse.BACKGROUND_POLL_INTERVAL_MS;
-    const startTime = Date.now();
-    let pollCount = 0;
-    const initialStatus = current.status ?? 'unknown';
+    this.pendingBackgroundResponseId = initialResponse.id;
 
-    this.logger.debug(
-      `Background polling started for response ${responseId} (status: ${initialStatus})`,
-      {
-        data: {
-          responseId,
-          status: current.status,
-        },
-      },
-    );
-
-    while (this.isBackgroundPending(current)) {
-      pollCount += 1;
-      this.logger.debug(
-        `Waiting ${pollInterval}ms before poll ${pollCount} for response ${responseId}`,
-        {
-          data: {
+    const polled = await this.backgroundPoller.poll({
+      initialResponse,
+      retrieve: async (responseId, sig) => {
+        try {
+          return (await client.responses.retrieve(
             responseId,
-            pollCount,
-            waitMs: pollInterval,
-          },
-        },
-      );
-      try {
-        await delay(pollInterval, { signal });
-      } catch (err) {
-        if (isUserAbort(err)) {
-          this.logger.debug(
-            `Background polling aborted for response ${responseId} while waiting to poll.`,
-            {
-              data: {
-                responseId,
-                pollCount,
-                elapsedMs: Date.now() - startTime,
-              },
-            },
-          );
-          // User cancelled - clear pending ID to prevent ghost-resume on next call.
-          // The background job keeps running on OpenAI's side but we won't try to
-          // resume it since the user explicitly cancelled.
-          this.clearPendingBackgroundResponse();
-        }
-        throw err;
-      }
-
-      const elapsedMs = Date.now() - startTime;
-      if (elapsedMs > ModelHandlerOpenAIResponse.BACKGROUND_MAX_DURATION_MS) {
-        this.logger.error(
-          `Background response ${responseId} exceeded maximum polling duration while pending`,
-          {
-            data: {
+            undefined,
+            sig ? { signal: sig } : undefined,
+          )) as T;
+        } catch (err) {
+          // Tag before checking: retrieve() throws the SDK's APIUserAbortError,
+          // not a DOMException, when the signal fires.
+          tagOpenAISdkError(err, this.config.provider);
+          if (isUserAbort(err)) {
+            // User cancelled during retrieve — clear pending ID to prevent
+            // ghost-resume on next call.
+            this.clearPendingBackgroundResponse();
+            throw err;
+          }
+          // 404 "response not found" during polling means the response is truly
+          // gone server-side. Clear the pending ID so the next retry creates a
+          // fresh background request instead of routing through
+          // tryResumeBackgroundResponse to rediscover the 404.
+          const statusCode = detectStatusCode(err);
+          if (statusCode === 404) {
+            this.clearPendingBackgroundResponse();
+            throw createOpenAIBackgroundPollingError(
               responseId,
-              status: current.status,
-              pollCount,
-              elapsedMs,
-            },
-          },
-        );
-        throw new Error(
-          `Background response ${responseId} exceeded maximum polling duration of ${ModelHandlerOpenAIResponse.BACKGROUND_MAX_DURATION_MS} ms. Retry later or cancel the job with client.responses.cancel("${responseId}").`,
-        );
-      }
-
-      const requestOptions = signal ? { signal } : undefined;
-      try {
-        // Cast is safe: retrieve returns the same response structure, just without parsed output typing
-        current = (await client.responses.retrieve(
-          responseId,
-          undefined,
-          requestOptions,
-        )) as T;
-      } catch (err) {
-        // Tag before checking: retrieve() throws the SDK's APIUserAbortError,
-        // not a DOMException, when the signal fires.
-        tagOpenAISdkError(err, this.config.provider);
-        if (isUserAbort(err)) {
-          // User cancelled during retrieve - clear pending ID
-          this.clearPendingBackgroundResponse();
+              err,
+              this.config.provider,
+            );
+          }
+          // All other errors (401, 403, 5xx, network, etc.) propagate unchanged
+          // so downstream handlers (relay 401 token refresh, retryability checks,
+          // non-retryable classification) work correctly with full HTTP metadata.
+          // The ID is intentionally NOT cleared — retry may resume the same response.
           throw err;
         }
-        // 404 "response not found" during polling means the response is truly
-        // gone server-side. Clear the pending ID so the next retry creates a
-        // fresh background request instead of routing through
-        // tryResumeBackgroundResponse to rediscover the 404. The wrapping
-        // below strips the 404 status so the provider-error normalizer
-        // classifies the error as retryable (network-like), keeping the retry
-        // loop engaged rather than bailing out on a non-retryable 4xx.
-        //
-        // All other errors (401, 403, 5xx, network, etc.) propagate unchanged
-        // so downstream handlers (relay 401 token refresh, retryability checks,
-        // non-retryable classification) work correctly with full HTTP metadata.
-        const statusCode = detectStatusCode(err);
-        if (statusCode === 404) {
-          this.clearPendingBackgroundResponse();
-          throw createOpenAIBackgroundPollingError(
-            responseId,
-            err,
-            this.config.provider,
-          );
-        }
-        throw err;
-      }
-
-      this.logger.debug(
-        `Background poll ${pollCount} for response ${responseId}: status=${
-          current.status ?? 'unknown'
-        }`,
-        {
-          data: {
-            responseId,
-            status: current.status,
-            pollCount,
-          },
-        },
-      );
-    }
-
-    const elapsedMs = Date.now() - startTime;
-    this.logger.debug(
-      `Background polling finished for response ${responseId} with status=${
-        current.status ?? 'unknown'
-      } after ${pollCount} polls (${elapsedMs} ms)`,
-      {
-        data: {
-          responseId,
-          status: current.status,
-          pollCount,
-          elapsedMs,
-          usage: current.usage ?? undefined,
-        },
       },
-    );
+      extractId: (r) => r.id,
+      extractStatus: (r) => r.status ?? 'unknown',
+      signal,
+      providerLabel: 'OpenAI',
+      onAbort: () => this.clearPendingBackgroundResponse(),
+    }) as T;
 
-    if (current.status === 'completed') {
-      return current;
+    if (polled.status === 'completed') {
+      return polled;
     }
 
-    const fallbackStatus = current.status ?? 'unknown';
+    // Terminal failure — the background response ended with a non-completed,
+    // non-pending status (failed / cancelled / incomplete).
+    const fallbackStatus = polled.status ?? 'unknown';
     this.logger.error(
-      `Background response ${responseId} ended with status ${fallbackStatus}`,
+      `Background response ${polled.id} ended with status ${fallbackStatus}`,
       {
         data: {
-          responseId,
-          status: current.status,
-          pollCount,
-          elapsedMs,
-          error: current.error ?? undefined,
-          incomplete: current.incomplete_details ?? undefined,
+          responseId: polled.id,
+          status: polled.status,
+          error: polled.error ?? undefined,
+          incomplete: polled.incomplete_details ?? undefined,
         },
       },
     );
-    throw createOpenAIBackgroundTerminalError(current, this.config.provider);
+    throw createOpenAIBackgroundTerminalError(polled, this.config.provider);
   }
 
   /** Adds continuation instructions for models without prefill support. */

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -81,7 +81,10 @@ import {
 } from '../types/ServerToolTypes';
 import { ResponseStreamProcessor } from './ResponseStreamProcessor';
 import { OpenAIResponseWebSocketTransport } from './OpenAIResponseWebSocketTransport';
-import { BackgroundPoller } from '../support/BackgroundPoller';
+import {
+  BackgroundPoller,
+  type BackgroundPollStats,
+} from '../support/BackgroundPoller';
 import { isResponseFunctionToolCallItem } from './responseStreamEvents';
 import {
   createInputText,
@@ -335,7 +338,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         pollIntervalMs: 15000,
         maxDurationMs: 3 * 60 * 60 * 1000, // 3 hours
         isPending: (r) => this.isBackgroundPending(r),
-        logger: this.logger,
+        logger: () => this.logger,
       });
     }
     return this._backgroundPoller;
@@ -2033,6 +2036,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     // tryResumeBackgroundResponse instead of creating a new request.
     this.pendingBackgroundResponseId = initialResponse.id;
 
+    let pollStats: BackgroundPollStats | undefined;
     const polled = (await this.backgroundPoller.poll({
       initialResponse,
       retrieve: async (responseId, sig) => {
@@ -2075,8 +2079,18 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       extractId: (r) => r.id,
       extractStatus: (r) => r.status ?? 'unknown',
       signal,
+      resourceLabel: 'response',
       providerLabel: 'OpenAI',
       onAbort: () => this.clearPendingBackgroundResponse(),
+      formatTimeoutError: ({ responseId, maxDurationMs }) =>
+        `OpenAI response ${responseId} exceeded maximum polling duration of ${maxDurationMs} ms. ` +
+        `Retry later or cancel the job with client.responses.cancel("${responseId}").`,
+      extraFinishData: (response) => ({
+        usage: response.usage ?? undefined,
+      }),
+      onFinished: (_response, stats) => {
+        pollStats = stats;
+      },
     })) as T;
 
     if (polled.status === 'completed') {
@@ -2092,6 +2106,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         data: {
           responseId: polled.id,
           status: polled.status,
+          pollCount: pollStats?.pollCount,
+          elapsedMs: pollStats?.elapsedMs,
           error: polled.error ?? undefined,
           incomplete: polled.incomplete_details ?? undefined,
         },

--- a/src/agent/modelHandlers/support/BackgroundPoller.ts
+++ b/src/agent/modelHandlers/support/BackgroundPoller.ts
@@ -211,7 +211,13 @@ export class BackgroundPoller<TResponse> {
           if (isUserAbort(err)) {
             logger().debug(
               `${providerLabel} background polling aborted for ${resourceLabel} ${responseId} while waiting (poll ${pollCount}).`,
-              { data: { responseId, pollCount } },
+              {
+                data: {
+                  responseId,
+                  pollCount,
+                  elapsedMs: Date.now() - startTime,
+                },
+              },
             );
           }
           throw err;

--- a/src/agent/modelHandlers/support/BackgroundPoller.ts
+++ b/src/agent/modelHandlers/support/BackgroundPoller.ts
@@ -1,8 +1,25 @@
 // Local imports - utils
 import { delay } from '@utils/core';
+import { isUserAbort } from '@common/errors/sdkErrorUtils';
 
 // Type imports
 import type { AgentTrace } from '@agent/trace';
+
+export interface BackgroundPollStats {
+  readonly responseId: string;
+  readonly status: string;
+  readonly pollCount: number;
+  readonly elapsedMs: number;
+}
+
+export interface BackgroundPollTimeoutContext<
+  TResponse,
+> extends BackgroundPollStats {
+  readonly maxDurationMs: number;
+  readonly response: TResponse;
+}
+
+type BackgroundPollLogger = AgentTrace | (() => AgentTrace);
 
 /**
  * Configuration for a {@link BackgroundPoller} instance.
@@ -16,8 +33,8 @@ export interface BackgroundPollerConfig<TResponse> {
   readonly maxDurationMs: number;
   /** Predicate: is the given response still being processed? */
   readonly isPending: (response: TResponse) => boolean;
-  /** Logger for debug/progress output. */
-  readonly logger: AgentTrace;
+  /** Logger for debug/progress output, or a supplier for handlers with mutable loggers. */
+  readonly logger: BackgroundPollLogger;
 }
 
 /**
@@ -47,11 +64,43 @@ export interface BackgroundPollOptions<TResponse> {
    * cancel the in-flight job server-side or clear local tracking state.
    */
   readonly onAbort?: (responseId: string) => void;
+  /** Resource noun for logs and timeout messages. Defaults to `response`. */
+  readonly resourceLabel?: string;
   /**
    * Human-readable label for log messages (e.g. `'OpenAI'`,
    * `'Google Interactions'`). Defaults to `'Background'`.
    */
   readonly providerLabel?: string;
+  /** Provider-specific timeout error text with cancellation guidance. */
+  readonly formatTimeoutError?: (
+    context: BackgroundPollTimeoutContext<TResponse>,
+  ) => string;
+  /** Provider-specific fields to append to the final polling-finished log. */
+  readonly extraFinishData?: (
+    response: TResponse,
+    stats: BackgroundPollStats,
+  ) => Record<string, unknown>;
+  /** Observe final poll stats without changing the returned response. */
+  readonly onFinished?: (
+    response: TResponse,
+    stats: BackgroundPollStats,
+  ) => void;
+}
+
+function resolveLogger(logger: BackgroundPollLogger): AgentTrace {
+  return typeof logger === 'function' ? logger() : logger;
+}
+
+function safeExtraData<TResponse>(
+  options: BackgroundPollOptions<TResponse>,
+  response: TResponse,
+  stats: BackgroundPollStats,
+): Record<string, unknown> {
+  try {
+    return options.extraFinishData?.(response, stats) ?? {};
+  } catch {
+    return {};
+  }
 }
 
 /**
@@ -111,6 +160,7 @@ export class BackgroundPoller<TResponse> {
       extractStatus,
       signal,
       onAbort,
+      resourceLabel = 'response',
       providerLabel = 'Background',
     } = options;
 
@@ -119,14 +169,15 @@ export class BackgroundPoller<TResponse> {
       return initialResponse;
     }
 
-    const { pollIntervalMs, maxDurationMs, isPending, logger } = this.config;
+    const { pollIntervalMs, maxDurationMs, isPending } = this.config;
+    const logger = () => resolveLogger(this.config.logger);
     const startTime = Date.now();
     let current = initialResponse;
     let pollCount = 0;
 
     const initialStatus = extractStatus(current);
-    logger.debug(
-      `${providerLabel} polling started for response ${responseId} (status: ${initialStatus})`,
+    logger().debug(
+      `${providerLabel} polling started for ${resourceLabel} ${responseId} (status: ${initialStatus})`,
       { data: { responseId, status: initialStatus } },
     );
 
@@ -147,37 +198,52 @@ export class BackgroundPoller<TResponse> {
     try {
       while (isPending(current)) {
         pollCount += 1;
-        logger.debug(
-          `Waiting ${pollIntervalMs}ms before poll ${pollCount} for ${providerLabel} response ${responseId}`,
+        logger().debug(
+          `Waiting ${pollIntervalMs}ms before poll ${pollCount} for ${providerLabel} ${resourceLabel} ${responseId}`,
           {
             data: { responseId, pollCount, waitMs: pollIntervalMs },
           },
         );
 
-        await delay(pollIntervalMs, { signal });
+        try {
+          await delay(pollIntervalMs, { signal });
+        } catch (err) {
+          if (isUserAbort(err)) {
+            logger().debug(
+              `${providerLabel} background polling aborted for ${resourceLabel} ${responseId} while waiting (poll ${pollCount}).`,
+              { data: { responseId, pollCount } },
+            );
+          }
+          throw err;
+        }
 
         const elapsedMs = Date.now() - startTime;
+        const status = extractStatus(current);
         if (elapsedMs > maxDurationMs) {
-          logger.error(
-            `${providerLabel} response ${responseId} exceeded maximum polling duration while pending`,
+          const stats = { responseId, status, pollCount, elapsedMs };
+          logger().error(
+            `${providerLabel} ${resourceLabel} ${responseId} exceeded maximum polling duration while pending`,
             {
               data: {
-                responseId,
-                status: extractStatus(current),
-                pollCount,
-                elapsedMs,
+                ...stats,
+                maxDurationMs,
               },
             },
           );
           throw new Error(
-            `${providerLabel} response ${responseId} exceeded maximum polling duration of ${maxDurationMs} ms.`,
+            options.formatTimeoutError?.({
+              ...stats,
+              maxDurationMs,
+              response: current,
+            }) ??
+              `${providerLabel} ${resourceLabel} ${responseId} exceeded maximum polling duration of ${maxDurationMs} ms.`,
           );
         }
 
         current = await retrieve(responseId, signal);
 
-        logger.debug(
-          `${providerLabel} poll ${pollCount} for response ${responseId}: status=${extractStatus(current)}`,
+        logger().debug(
+          `${providerLabel} poll ${pollCount} for ${resourceLabel} ${responseId}: status=${extractStatus(current)}`,
           {
             data: {
               responseId,
@@ -189,17 +255,22 @@ export class BackgroundPoller<TResponse> {
       }
 
       const elapsedMs = Date.now() - startTime;
-      logger.debug(
-        `${providerLabel} polling finished for response ${responseId} with status=${extractStatus(current)} after ${pollCount} polls (${elapsedMs} ms)`,
+      const stats = {
+        responseId,
+        status: extractStatus(current),
+        pollCount,
+        elapsedMs,
+      };
+      logger().debug(
+        `${providerLabel} polling finished for ${resourceLabel} ${responseId} with status=${stats.status} after ${pollCount} polls (${elapsedMs} ms)`,
         {
           data: {
-            responseId,
-            status: extractStatus(current),
-            pollCount,
-            elapsedMs,
+            ...stats,
+            ...safeExtraData(options, current, stats),
           },
         },
       );
+      options.onFinished?.(current, stats);
 
       return current;
     } finally {

--- a/src/agent/modelHandlers/support/BackgroundPoller.ts
+++ b/src/agent/modelHandlers/support/BackgroundPoller.ts
@@ -1,0 +1,209 @@
+// Local imports - utils
+import { delay } from '@utils/core';
+
+// Type imports
+import type { AgentTrace } from '@agent/trace';
+
+/**
+ * Configuration for a {@link BackgroundPoller} instance.
+ *
+ * @typeParam TResponse - The provider-specific response type
+ */
+export interface BackgroundPollerConfig<TResponse> {
+  /** Interval in milliseconds between consecutive poll retrievals. */
+  readonly pollIntervalMs: number;
+  /** Maximum total wall-clock duration for polling before giving up. */
+  readonly maxDurationMs: number;
+  /** Predicate: is the given response still being processed? */
+  readonly isPending: (response: TResponse) => boolean;
+  /** Logger for debug/progress output. */
+  readonly logger: AgentTrace;
+}
+
+/**
+ * Options for a single invocation of {@link BackgroundPoller.poll}.
+ *
+ * @typeParam TResponse - The provider-specific response type
+ */
+export interface BackgroundPollOptions<TResponse> {
+  /**
+   * The response returned by the initial create/submit call. Its id is
+   * extracted to key subsequent poll retrievals.
+   */
+  readonly initialResponse: TResponse;
+  /** Retrieve the current state of the response by its id. */
+  readonly retrieve: (
+    responseId: string,
+    signal?: AbortSignal,
+  ) => Promise<TResponse>;
+  /** Extract the id string from a response, or undefined if there is none. */
+  readonly extractId: (response: TResponse) => string | undefined;
+  /** Extract a human-readable status string for log messages. */
+  readonly extractStatus: (response: TResponse) => string;
+  /** Optional abort signal propagated to `delay` and `retrieve`. */
+  readonly signal?: AbortSignal;
+  /**
+   * Optional callback invoked on abort (best-effort). Handlers use this to
+   * cancel the in-flight job server-side or clear local tracking state.
+   */
+  readonly onAbort?: (responseId: string) => void;
+  /**
+   * Human-readable label for log messages (e.g. `'OpenAI'`,
+   * `'Google Interactions'`). Defaults to `'Background'`.
+   */
+  readonly providerLabel?: string;
+}
+
+/**
+ * Shared polling collaborator for background / asynchronous API responses.
+ *
+ * Providers whose non-streaming endpoints return a pending response and expect
+ * the client to periodically check for completion (OpenAI Responses API,
+ * Google Interactions API) share the same mechanical polling loop:
+ *
+ * 1. While the response status is pending:
+ *    a. Sleep for the configured poll interval (respecting the abort signal).
+ *    b. Check if the max duration has been exceeded.
+ *    c. Retrieve the current response state from the provider.
+ *    d. Log the status.
+ * 2. Return the final (terminal) response.
+ *
+ * Each handler composes this collaborator with its own create, retrieve,
+ * error-classification, resume, and state-management logic.
+ *
+ * ## Usage
+ *
+ * ```typescript
+ * const poller = new BackgroundPoller({
+ *   pollIntervalMs: 15_000,
+ *   maxDurationMs: 3 * 60 * 60 * 1000,
+ *   isPending: (r) => ['queued', 'in_progress'].includes(r.status),
+ *   logger: this.logger,
+ * });
+ *
+ * const completed = await poller.poll({
+ *   initialResponse: created,
+ *   retrieve: (id, signal) => client.responses.retrieve(id, undefined, { signal }),
+ *   extractId: (r) => r.id,
+ *   extractStatus: (r) => r.status ?? 'unknown',
+ *   signal,
+ *   providerLabel: 'OpenAI',
+ * });
+ * ```
+ */
+export class BackgroundPoller<TResponse> {
+  constructor(private readonly config: BackgroundPollerConfig<TResponse>) {}
+
+  /**
+   * Poll a pending response until it reaches a terminal status.
+   *
+   * Errors thrown by `retrieve` propagate unmodified — the caller is
+   * responsible for classifying them (retryable vs. terminal) and for any
+   * resume logic that chains a prior poll across retries.
+   *
+   * @returns The terminal response (no longer pending).
+   */
+  async poll(options: BackgroundPollOptions<TResponse>): Promise<TResponse> {
+    const {
+      initialResponse,
+      retrieve,
+      extractId,
+      extractStatus,
+      signal,
+      onAbort,
+      providerLabel = 'Background',
+    } = options;
+
+    const responseId = extractId(initialResponse);
+    if (!responseId) {
+      return initialResponse;
+    }
+
+    const { pollIntervalMs, maxDurationMs, isPending, logger } = this.config;
+    const startTime = Date.now();
+    let current = initialResponse;
+    let pollCount = 0;
+
+    const initialStatus = extractStatus(current);
+    logger.debug(
+      `${providerLabel} polling started for response ${responseId} (status: ${initialStatus})`,
+      { data: { responseId, status: initialStatus } },
+    );
+
+    // Register a one-shot abort listener to fire the onAbort callback, then
+    // let the signal propagate naturally through delay() and retrieve().
+    const abortHandler = () => {
+      if (onAbort) {
+        try {
+          onAbort(responseId);
+        } catch {
+          // Best-effort — swallow failures so the original abort propagates.
+        }
+      }
+    };
+    signal?.addEventListener('abort', abortHandler, { once: true });
+    if (signal?.aborted) abortHandler();
+
+    try {
+      while (isPending(current)) {
+        pollCount += 1;
+        logger.debug(
+          `Waiting ${pollIntervalMs}ms before poll ${pollCount} for ${providerLabel} response ${responseId}`,
+          {
+            data: { responseId, pollCount, waitMs: pollIntervalMs },
+          },
+        );
+
+        await delay(pollIntervalMs, { signal });
+
+        const elapsedMs = Date.now() - startTime;
+        if (elapsedMs > maxDurationMs) {
+          logger.error(
+            `${providerLabel} response ${responseId} exceeded maximum polling duration while pending`,
+            {
+              data: {
+                responseId,
+                status: extractStatus(current),
+                pollCount,
+                elapsedMs,
+              },
+            },
+          );
+          throw new Error(
+            `${providerLabel} response ${responseId} exceeded maximum polling duration of ${maxDurationMs} ms.`,
+          );
+        }
+
+        current = await retrieve(responseId, signal);
+
+        logger.debug(
+          `${providerLabel} poll ${pollCount} for response ${responseId}: status=${extractStatus(current)}`,
+          {
+            data: {
+              responseId,
+              status: extractStatus(current),
+              pollCount,
+            },
+          },
+        );
+      }
+
+      const elapsedMs = Date.now() - startTime;
+      logger.debug(
+        `${providerLabel} polling finished for response ${responseId} with status=${extractStatus(current)} after ${pollCount} polls (${elapsedMs} ms)`,
+        {
+          data: {
+            responseId,
+            status: extractStatus(current),
+            pollCount,
+            elapsedMs,
+          },
+        },
+      );
+
+      return current;
+    } finally {
+      signal?.removeEventListener('abort', abortHandler);
+    }
+  }
+}

--- a/src/test-kernel/agent/modelHandlers/BackgroundPoller.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/BackgroundPoller.vitest.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AgentTrace } from '@agent/trace';
+import {
+  BackgroundPoller,
+  type BackgroundPollStats,
+} from '@agent/modelHandlers/support/BackgroundPoller';
+
+interface TestResponse {
+  id?: string;
+  status: string;
+  usage?: unknown;
+}
+
+function trace() {
+  return {
+    debug: vi.fn(),
+    error: vi.fn(),
+  } as unknown as AgentTrace & {
+    debug: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+  };
+}
+
+const extractId = (response: TestResponse) => response.id;
+const extractStatus = (response: TestResponse) => response.status;
+
+describe('BackgroundPoller', () => {
+  it('resolves the logger supplier at poll time', async () => {
+    const staleLogger = trace();
+    const activeLogger = trace();
+    let logger = staleLogger;
+    const poller = new BackgroundPoller<TestResponse>({
+      pollIntervalMs: 0,
+      maxDurationMs: 1000,
+      isPending: () => false,
+      logger: () => logger,
+    });
+
+    logger = activeLogger;
+    await poller.poll({
+      initialResponse: { id: 'resp-1', status: 'completed' },
+      retrieve: vi.fn(),
+      extractId,
+      extractStatus,
+      providerLabel: 'OpenAI',
+    });
+
+    expect(staleLogger.debug).not.toHaveBeenCalled();
+    expect(activeLogger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('OpenAI polling started'),
+      expect.anything(),
+    );
+  });
+
+  it('uses provider-specific timeout guidance', async () => {
+    const logger = trace();
+    const poller = new BackgroundPoller<TestResponse>({
+      pollIntervalMs: 0,
+      maxDurationMs: -1,
+      isPending: (response) => response.status === 'in_progress',
+      logger,
+    });
+
+    await expect(
+      poller.poll({
+        initialResponse: { id: 'resp-2', status: 'in_progress' },
+        retrieve: vi.fn(),
+        extractId,
+        extractStatus,
+        providerLabel: 'OpenAI',
+        formatTimeoutError: ({ responseId, maxDurationMs }) =>
+          `Cancel ${responseId} after ${maxDurationMs} ms with provider API.`,
+      }),
+    ).rejects.toThrow('Cancel resp-2 after -1 ms with provider API.');
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('exceeded maximum polling duration'),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          responseId: 'resp-2',
+          pollCount: 1,
+          maxDurationMs: -1,
+        }),
+      }),
+    );
+  });
+
+  it('logs aborts that happen while waiting for the next poll', async () => {
+    const logger = trace();
+    const controller = new AbortController();
+    const poller = new BackgroundPoller<TestResponse>({
+      pollIntervalMs: 1000,
+      maxDurationMs: 10_000,
+      isPending: (response) => response.status === 'in_progress',
+      logger,
+    });
+
+    const promise = poller.poll({
+      initialResponse: { id: 'int-1', status: 'in_progress' },
+      retrieve: vi.fn(),
+      extractId,
+      extractStatus,
+      signal: controller.signal,
+      providerLabel: 'Google Interactions',
+      resourceLabel: 'interaction',
+    });
+    controller.abort();
+
+    await expect(promise).rejects.toThrow();
+    expect(
+      logger.debug.mock.calls.some(
+        ([message]) =>
+          typeof message === 'string' &&
+          message.includes('aborted') &&
+          message.includes('interaction int-1') &&
+          message.includes('poll 1'),
+      ),
+    ).toBe(true);
+  });
+
+  it('logs final stats with provider usage data', async () => {
+    const logger = trace();
+    let finishedStats: BackgroundPollStats | undefined;
+    const usage = { input_tokens: 3, output_tokens: 5 };
+    const poller = new BackgroundPoller<TestResponse>({
+      pollIntervalMs: 0,
+      maxDurationMs: 1000,
+      isPending: (response) => response.status === 'in_progress',
+      logger,
+    });
+
+    await poller.poll({
+      initialResponse: { id: 'resp-3', status: 'in_progress' },
+      retrieve: vi.fn(async () => ({
+        id: 'resp-3',
+        status: 'completed',
+        usage,
+      })),
+      extractId,
+      extractStatus,
+      providerLabel: 'OpenAI',
+      extraFinishData: (response) => ({ usage: response.usage }),
+      onFinished: (_response, stats) => {
+        finishedStats = stats;
+      },
+    });
+
+    expect(finishedStats).toMatchObject({
+      responseId: 'resp-3',
+      status: 'completed',
+      pollCount: 1,
+    });
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('polling finished'),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          responseId: 'resp-3',
+          pollCount: 1,
+          usage,
+        }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

OpenAI Responses and Google Interactions handlers each implemented their own background-mode polling loop with duplicated logic. Extract the common pattern into a shared `BackgroundPoller<TResponse>` collaborator.

## Changes

- **New: `support/BackgroundPoller.ts`** — Generic polling loop (while pending: delay → check timeout → retrieve → log) with abort lifecycle management
- **Modified: `modelHandlerOpenAIResponse.ts`** — `waitForBackgroundCompletion` delegates to `BackgroundPoller<Response>`; retains provider-specific error classification in the wrapped `retrieve`
- **Modified: `modelHandlerGoogleInteractions.ts`** — `pollBackgroundInteraction` delegates to `BackgroundPoller<GoogleGenAIInteraction>`; cancel-on-abort stays via `onAbort` callback

## References

- Closes #6733

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors agent background completion paths where abort, timeout, and retry/resume semantics must stay correct; behavior is intended to be preserved via handler-specific `retrieve`/`onAbort` hooks but warrants careful review.
> 
> **Overview**
> Introduces a generic **`BackgroundPoller<TResponse>`** in `support/BackgroundPoller.ts` that centralizes the wait → timeout check → retrieve → log loop used for long-running provider jobs.
> 
> **OpenAI Responses** (`waitForBackgroundCompletion`) and **Google Interactions** (`pollBackgroundInteraction`) now delegate to instance-level pollers (15s vs 5s intervals) instead of inlined `while` loops. Provider-specific behavior stays in the `poll()` options: wrapped `retrieve` (SDK error tagging, user abort, OpenAI 404 / pending-ID clearing), `onAbort` (OpenAI clears pending ID; Google fire-and-forget `interactions.cancel`), custom timeout messages, and post-poll terminal status handling (`completed` / `requires_action` vs failures).
> 
> Adds **`BackgroundPoller.vitest.ts`** covering logger suppliers, timeout formatting, abort logging, and finish stats/`onFinished`. Removes now-unused `delay` imports from the two handlers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80410d827616689afa9f3517a282b83db0bec22a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->