### PR TITLE
refactor: consolidate repeated formatting patterns and use existing utilities

### DIFF
--- a/packages/cli/src/runtime/memory.ts
+++ b/packages/cli/src/runtime/memory.ts
@@ -9,7 +9,7 @@ import {
   toDisplayPath,
 } from '@tools/memory/memoryUtils';
 import { filterNotNullish } from '@utils/core';
-import { truncateSummary } from '@utils/text/stringUtils';
+import { formatLocaleTimestamp, truncateSummary } from '@utils/text/stringUtils';
 
 export const CLI_MEMORY_LIST_LIMIT = 50;
 const MEMORY_DESCRIPTION_MAX = 72;
@@ -22,7 +22,7 @@ function parseIsoTimestamp(value: string): number | undefined {
 function formatModifiedDate(value: string): string {
   const timestamp = parseIsoTimestamp(value);
   if (timestamp == null) return 'modified: unknown';
-  return `modified: ${new Date(timestamp).toLocaleString()}`;
+  return `modified: ${formatLocaleTimestamp(timestamp)}`;
 }
 
 export function cliMemoryItemDescription(item: MemoryViewItem): string {

--- a/packages/cli/src/runtime/memory.ts
+++ b/packages/cli/src/runtime/memory.ts
@@ -9,7 +9,10 @@ import {
   toDisplayPath,
 } from '@tools/memory/memoryUtils';
 import { filterNotNullish } from '@utils/core';
-import { formatLocaleTimestamp, truncateSummary } from '@utils/text/stringUtils';
+import {
+  formatLocaleTimestamp,
+  truncateSummary,
+} from '@utils/text/stringUtils';
 
 export const CLI_MEMORY_LIST_LIMIT = 50;
 const MEMORY_DESCRIPTION_MAX = 72;

--- a/packages/desktop/src/main/desktopCrashReporting.ts
+++ b/packages/desktop/src/main/desktopCrashReporting.ts
@@ -1,6 +1,6 @@
 import escapeRegExp from 'escape-string-regexp';
 import { GlobalStateKey } from '@shared/state/stateKeys';
-import { unique } from '@utils/core/typeGuards';
+import { unique } from '@utils/core';
 import type { PlatformSecrets } from '@platform/secrets';
 import type { StateStore } from '@platform/interfaces/state';
 

--- a/packages/desktop/src/main/desktopCrashReporting.ts
+++ b/packages/desktop/src/main/desktopCrashReporting.ts
@@ -1,5 +1,6 @@
 import escapeRegExp from 'escape-string-regexp';
 import { GlobalStateKey } from '@shared/state/stateKeys';
+import { unique } from '@utils/core/typeGuards';
 import type { PlatformSecrets } from '@platform/secrets';
 import type { StateStore } from '@platform/interfaces/state';
 
@@ -39,7 +40,7 @@ function pathVariants(path: string): string[] {
   if (!trimmed) return [];
   const forward = trimmed.replaceAll('\\', '/');
   const backward = forward.replaceAll('/', '\\');
-  return [...new Set([trimmed, forward, backward])];
+  return unique([trimmed, forward, backward]);
 }
 
 function buildPathScrubbers(paths: readonly (string | undefined)[]): RegExp[] {

--- a/packages/extension/src/commands/history/chatExport/formatSpec.ts
+++ b/packages/extension/src/commands/history/chatExport/formatSpec.ts
@@ -7,6 +7,7 @@
  */
 
 import { normalizeConversationForExport as normalizeMessages } from '@agent/export/normalizeConversation';
+import { formatLocaleTimestamp } from '@utils/text/stringUtils';
 import type {
   ChatExportInput,
   DocumentMeta,
@@ -51,7 +52,7 @@ function collectFiles(config: ExportConfig): Array<[string, string]> {
 
 export function extractMeta(input: ChatExportInput): DocumentMeta {
   return {
-    date: new Date(input.timestamp).toLocaleString(),
+    date: formatLocaleTimestamp(input.timestamp),
     agent: input.config.agent,
     model: input.config.model,
     description: input.description,

--- a/packages/extension/src/frontend/agents/remoteAgentUtils.ts
+++ b/packages/extension/src/frontend/agents/remoteAgentUtils.ts
@@ -10,10 +10,6 @@ import { delay } from '@utils/core';
 const CHANNEL = 'RemoteAgentUtils';
 logger.initialize(CHANNEL);
 
-function selectAgentErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : 'Unknown error';
-}
-
 interface SelectAgentResult {
   success: boolean;
   message: string;
@@ -83,7 +79,8 @@ export async function selectAgentInMainView(
       message: `Agent "${agentName}" selected successfully`,
     };
   } catch (error) {
-    const errorMessage = selectAgentErrorMessage(error);
+    const errorMessage =
+      error instanceof Error ? error.message : 'Unknown error';
     logger.error(CHANNEL, `Failed to select agent: ${errorMessage}`);
     return handleFallback(
       agentName,

--- a/packages/extension/src/frontend/agents/remoteAgentUtils.ts
+++ b/packages/extension/src/frontend/agents/remoteAgentUtils.ts
@@ -2,7 +2,6 @@ import * as vscode from 'vscode';
 
 import { createKey, getAgent, type AgentSource } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import { toErrorMessage } from '@common/errors';
 import { getMainWebview } from '@frontend/system/commandUtils';
 import * as logger from '@logger/logUtils';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
@@ -10,6 +9,10 @@ import { delay } from '@utils/core';
 
 const CHANNEL = 'RemoteAgentUtils';
 logger.initialize(CHANNEL);
+
+function selectAgentErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'Unknown error';
+}
 
 interface SelectAgentResult {
   success: boolean;
@@ -80,7 +83,7 @@ export async function selectAgentInMainView(
       message: `Agent "${agentName}" selected successfully`,
     };
   } catch (error) {
-    const errorMessage = toErrorMessage(error);
+    const errorMessage = selectAgentErrorMessage(error);
     logger.error(CHANNEL, `Failed to select agent: ${errorMessage}`);
     return handleFallback(
       agentName,

--- a/packages/extension/src/frontend/agents/remoteAgentUtils.ts
+++ b/packages/extension/src/frontend/agents/remoteAgentUtils.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 
 import { createKey, getAgent, type AgentSource } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { toErrorMessage } from '@common/errors';
 import { getMainWebview } from '@frontend/system/commandUtils';
 import * as logger from '@logger/logUtils';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
@@ -79,8 +80,7 @@ export async function selectAgentInMainView(
       message: `Agent "${agentName}" selected successfully`,
     };
   } catch (error) {
-    const errorMessage =
-      error instanceof Error ? error.message : 'Unknown error';
+    const errorMessage = toErrorMessage(error);
     logger.error(CHANNEL, `Failed to select agent: ${errorMessage}`);
     return handleFallback(
       agentName,

--- a/packages/extension/src/progressView/frontend/components/UsagePanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UsagePanel.ts
@@ -12,6 +12,7 @@ import { designTokens } from '@shared/styles';
 import type { TokenUsageStats } from '@shared/schemas';
 import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
 import { clamp, formatCompactTokenCount } from '@utils/core';
+import { formatCostUsd } from '@utils/text/stringUtils';
 
 // Local imports - progress view
 import { ELEMENT_IDS } from '../constants';
@@ -230,7 +231,7 @@ export class UsagePanel extends LitElement {
           title="Output tokens"
           aria-hidden="true"
         ></wa-icon
-        >${formatCompactTokenCount(outputTokens)} · $${cost.toFixed(3)}
+        >${formatCompactTokenCount(outputTokens)} · ${formatCostUsd(cost)}
       </span>
     `;
   }
@@ -273,6 +274,6 @@ export class UsagePanel extends LitElement {
   private buildUsageLabel(): string {
     if (!this.usage) return '';
     const { inputTokens, outputTokens, cost } = this.usage;
-    return `Total usage: ${formatCompactTokenCount(inputTokens)} input tokens, ${formatCompactTokenCount(outputTokens)} output tokens, $${cost.toFixed(3)}`;
+    return `Total usage: ${formatCompactTokenCount(inputTokens)} input tokens, ${formatCompactTokenCount(outputTokens)} output tokens, ${formatCostUsd(cost)}`;
   }
 }

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/dataFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/dataFormatters.ts
@@ -22,6 +22,7 @@ import {
 import { getBasename } from '@shared/utils/path';
 import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
 import { formatCompactTokenCount } from '@utils/core';
+import { formatCostUsd } from '@utils/text/stringUtils';
 
 // Local imports - shared schemas
 import { html, ifDefined, type FormatResult } from '../litTemplates';
@@ -150,7 +151,7 @@ const STAT_FIELDS: readonly StatFieldConfig[] = [
   ],
   ['toolUseTokens', 'tools', 'Tool tokens', formatCompactTokenCount],
   ['elapsedTime', 'clock', 'Elapsed time', (v) => `${v}s`],
-  ['cost', 'rocket', 'Cost', (v) => `$${v.toFixed(3)}`],
+  ['cost', 'rocket', 'Cost', formatCostUsd],
 ];
 
 /** Format statistics entry as TemplateResult. */

--- a/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
@@ -28,6 +28,9 @@ import '@awesome.me/webawesome/dist/components/details/details.js';
 // Local imports - history view styles
 import { historyStyles } from '@shared/styles/historyStyles';
 
+// Local imports - utils
+import { formatLocaleTimestamp } from '@utils/text/stringUtils';
+
 // Local imports - history view events
 import { HistoryViewEvents } from './events';
 
@@ -268,7 +271,7 @@ export class HistoryItemElement extends LitElement {
     }
 
     const config = this.item.agentConfig;
-    const timestamp = new Date(this.item.timestamp).toLocaleString();
+    const timestamp = formatLocaleTimestamp(this.item.timestamp);
     const isToolUse = config.agentCategory === AgentCategory.ToolUse;
     const categoryVariant: 'warning' | 'brand' = isToolUse
       ? 'warning'

--- a/packages/extension/src/settingsView/frontend/components/history/historySearch.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/historySearch.ts
@@ -1,5 +1,6 @@
 import type { HistoryItem } from '@shared/schemas';
 import { getAgentCategoryDecorator } from '@shared/utils/icons';
+import { formatLocaleTimestamp } from '@utils/text/stringUtils';
 
 type ToolConfigEntry = [string, unknown];
 
@@ -78,7 +79,7 @@ export function getHistorySearchText(item: HistoryItem): string {
   const parts: string[] = [
     item.id,
     item.timestamp,
-    new Date(item.timestamp).toLocaleString(),
+    formatLocaleTimestamp(item.timestamp),
   ];
   addSearchValue(parts, item.description);
 

--- a/src/utils/text/stringUtils.ts
+++ b/src/utils/text/stringUtils.ts
@@ -207,7 +207,7 @@ export function formatCostUsd(cost: number): string {
 }
 
 /**
- * Format a timestamp (number of ms since epoch, or ISO-8601 string) for
+ * Format a timestamp (number of ms since epoch, or a date-parsable string) for
  * locale-aware display using the system locale and timezone.
  */
 export function formatLocaleTimestamp(ts: number | string): string {

--- a/src/utils/text/stringUtils.ts
+++ b/src/utils/text/stringUtils.ts
@@ -197,3 +197,19 @@ export function splitOutputLines(text: string): string[] {
   if (!text) return [];
   return normalizeLineEndings(text).split('\n').filter(Boolean);
 }
+
+/**
+ * Format a USD cost value as a display string with three decimal places.
+ * e.g. `0.012` → `'$0.012'`
+ */
+export function formatCostUsd(cost: number): string {
+  return `$${cost.toFixed(3)}`;
+}
+
+/**
+ * Format a timestamp (number of ms since epoch, or ISO-8601 string) for
+ * locale-aware display using the system locale and timezone.
+ */
+export function formatLocaleTimestamp(ts: number | string): string {
+  return new Date(ts).toLocaleString();
+}


### PR DESCRIPTION
## Summary

- Add `formatCostUsd` and `formatLocaleTimestamp` to `src/utils/text/stringUtils.ts`, replacing three identical `` `$${cost.toFixed(3)}` `` inline expressions across the progressView and four `new Date(ts).toLocaleString()` calls spread across the CLI, settings view, and chat-export code
- Replace `[...new Set([...])]` with the existing `unique()` utility in `desktopCrashReporting.ts`
- Replace a manual `instanceof Error ? e.message : 'Unknown error'` guard with `toErrorMessage()` from `@common/errors` in `remoteAgentUtils.ts`

## Motivation

A codebase-wide scan (scanning `src/utils/`, `src/common/`, and all call sites) showed the utility layer itself is clean with no internal duplication. The gaps were in call sites:

| Pattern | Sites | Fix |
|---|---|---|
| `` `$${cost.toFixed(3)}` `` | `UsagePanel.ts` (×2), `dataFormatters.ts` | new `formatCostUsd()` |
| `new Date(ts).toLocaleString()` | `formatSpec.ts`, `historySearch.ts`, `HistoryItemElement.ts`, `memory.ts` | new `formatLocaleTimestamp()` |
| `[...new Set([...])]` | `desktopCrashReporting.ts` | existing `unique()` |
| `instanceof Error ? e.message : 'Unknown error'` | `remoteAgentUtils.ts` | existing `toErrorMessage()` |

## Out of scope (intentional non-changes)

- `browser.ts` — custom `'unknown browser launch error'` fallbacks are context-specific UX strings
- `modelOptionsBasic.ts` `formatContext` — uses different thresholds and `K` vs `k` capitalisation from `formatCompactTokenCount` by design
- `.toFixed(4)` cost sites in `extension.ts`, `claudeAgent.ts`, `subagentResults.ts` — different precision for XML attrs / markdown tables
- All 453 `path.join()` calls — inherently distributed, no consolidation needed

## Test plan

- [x] `npm test` (Vitest) passes with no failures
- [x] TypeScript type errors are pre-existing environment issues (`@types/node` not installed in CI container), not introduced by this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWNGTVSvUxGp3fimcUVveX)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-string refactors with no auth, data, or API changes; output should match prior formatting.
> 
> **Overview**
> Introduces **`formatCostUsd`** and **`formatLocaleTimestamp`** in `stringUtils.ts` and routes repeated display logic through them instead of ad hoc `` `$${cost.toFixed(3)}` `` and `new Date(...).toLocaleString()` at call sites.
> 
> **Usage/cost UI** in the progress view (`UsagePanel`, statistics log formatter) now uses `formatCostUsd` for run totals and cost fields. **Timestamps** in CLI memory listings, chat export metadata, history list rendering, and history search indexing all use `formatLocaleTimestamp` so displayed and searchable dates stay aligned.
> 
> **Desktop crash reporting** deduplicates path slash variants with the existing `unique()` helper instead of `[...new Set([...])]`. Behavior is unchanged; this is consolidation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6edfc408da4514192d260880bf560dc787c223d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->