### PR TITLE
fix(output): recover percent-header workflow outputs

### DIFF
--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -67,10 +67,25 @@ const EXTRACTION_METHOD_MESSAGES: Record<string, string> = {
 };
 
 const PERCENT_FILENAME_HEADER_REGEX =
-  /^%\s+([A-Za-z0-9][A-Za-z0-9._/-]*\.[A-Za-z0-9]+)\s*$/;
+  /^%\s+((?:\.\/)*[A-Za-z0-9][A-Za-z0-9._/-]*\.[A-Za-z0-9]+)\s*$/;
+const LATEX_DOCUMENT_BEGIN_REGEX = /\\begin\s*\{\s*document\s*\}/;
+const LATEX_DOCUMENT_END_REGEX = /\\end\s*\{\s*document\s*\}/;
 
 function isMarkdownFenceDelimiter(line: string): boolean {
-  return /^(?:`{3,}|~{3,})(?:\s+\S.*)?\s*$/.test(line.trim());
+  return /^(?:`{3,}|~{3,})(?:\S.*)?\s*$/.test(line.trim());
+}
+
+function isInsideLatexDocument(lines: readonly string[]): boolean {
+  let depth = 0;
+  for (const line of lines) {
+    if (LATEX_DOCUMENT_BEGIN_REGEX.test(line)) {
+      depth += 1;
+    }
+    if (LATEX_DOCUMENT_END_REGEX.test(line) && depth > 0) {
+      depth -= 1;
+    }
+  }
+  return depth > 0;
 }
 
 export class XmlOutputManager {
@@ -200,7 +215,7 @@ export class XmlOutputManager {
       .split('\n');
     for (const line of lines) {
       const match = PERCENT_FILENAME_HEADER_REGEX.exec(line.trim());
-      if (match) {
+      if (match && !isInsideLatexDocument(currentLines)) {
         flushCurrent();
         currentName = match[1];
         continue;
@@ -253,6 +268,13 @@ export class XmlOutputManager {
       debugInternal(
         this.logger,
         `Failed to parse XML content: ${toErrorMessage(err)}, attempting fallback extraction...`,
+      );
+    }
+
+    if (!documents) {
+      documents = this.extractMultipleDocumentsbyRegex(
+        outputContent,
+        documentTag,
       );
     }
 

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -69,6 +69,10 @@ const EXTRACTION_METHOD_MESSAGES: Record<string, string> = {
 const PERCENT_FILENAME_HEADER_REGEX =
   /^%\s+([A-Za-z0-9][A-Za-z0-9._/-]*\.[A-Za-z0-9]+)\s*$/;
 
+function isMarkdownFenceDelimiter(line: string): boolean {
+  return /^(?:`{3,}|~{3,})(?:\s+\S.*)?\s*$/.test(line.trim());
+}
+
 export class XmlOutputManager {
   constructor(
     private readonly agentSetting: AgentSetting,
@@ -203,6 +207,9 @@ export class XmlOutputManager {
       }
 
       if (currentName) {
+        if (isMarkdownFenceDelimiter(line)) {
+          continue;
+        }
         currentLines.push(line);
       }
     }
@@ -250,6 +257,13 @@ export class XmlOutputManager {
     }
 
     if (!documents) {
+      documents = this.extractPercentHeaderDocuments(
+        rawOutputContent,
+        getFileDirectory(outputLocation),
+      );
+    }
+
+    if (!documents) {
       // Single-input agents whose model regressed to a legacy single-doc shape
       // (<latex_document>, ```latex fence, or bare \documentclass) can still
       // be recovered: pass the primary input filename so the fallback can
@@ -266,11 +280,6 @@ export class XmlOutputManager {
         preferredName,
       );
     }
-
-    documents ??= this.extractPercentHeaderDocuments(
-      rawOutputContent,
-      getFileDirectory(outputLocation),
-    );
 
     if (!documents) {
       this.warnPartialExtraction(outputLocation, expectedDocumentCount, 0);

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -63,6 +63,9 @@ const EXTRACTION_METHOD_MESSAGES: Record<string, string> = {
   latex: 'from \\documentclass block',
 };
 
+const PERCENT_FILENAME_HEADER_REGEX =
+  /^%\s+([A-Za-z0-9][A-Za-z0-9._/-]*\.[A-Za-z0-9]+)\s*$/;
+
 export class XmlOutputManager {
   constructor(
     private readonly agentSetting: AgentSetting,
@@ -130,13 +133,72 @@ export class XmlOutputManager {
     });
   }
 
+  private makeUniquePercentHeaderName(
+    source: string,
+    seen: Map<string, number>,
+  ): string {
+    const normalized = source.replaceAll('\\', '/');
+    const count = (seen.get(normalized) ?? 0) + 1;
+    seen.set(normalized, count);
+    if (count === 1) return normalized;
+
+    const parsed = path.posix.parse(normalized);
+    const fileName = `${parsed.name}-${count}${parsed.ext}`;
+    return parsed.dir ? path.posix.join(parsed.dir, fileName) : fileName;
+  }
+
+  private extractPercentHeaderDocuments(
+    outputContent: string,
+  ): Array<{ content: string; name: string }> | null {
+    const documents: Array<{ content: string; name: string }> = [];
+    const seenNames = new Map<string, number>();
+    let currentName: string | null = null;
+    let currentLines: string[] = [];
+
+    const flushCurrent = () => {
+      if (!currentName) return;
+      const content = currentLines.join('\n').trim();
+      if (content) {
+        documents.push({ name: currentName, content });
+      }
+      currentLines = [];
+    };
+
+    const lines = outputContent
+      .replaceAll('\r\n', '\n')
+      .replaceAll('\r', '\n')
+      .split('\n');
+    for (const line of lines) {
+      const match = PERCENT_FILENAME_HEADER_REGEX.exec(line.trim());
+      if (match) {
+        flushCurrent();
+        currentName = this.makeUniquePercentHeaderName(match[1], seenNames);
+        continue;
+      }
+
+      if (currentName) {
+        currentLines.push(line);
+      }
+    }
+    flushCurrent();
+
+    if (documents.length === 0) return null;
+
+    logInternal(
+      this.logger,
+      `Recovered ${this.agentSetting.documentTag} from % filename headers (${formatResultCount(documents.length, 'document')})`,
+    );
+    return documents;
+  }
+
   async splitScratchpadMultipleOutputXml(
     outputLocation: FileLocation,
     documentTag: string,
     round: number,
     thinkingTag: string = 'scratchpad',
   ): Promise<OutputFileInfo[]> {
-    let outputContent = await AbsoluteFS.read(outputLocation.absolutePath);
+    const rawOutputContent = await AbsoluteFS.read(outputLocation.absolutePath);
+    let outputContent = rawOutputContent;
     const expectedDocumentCount = this.countDocumentTags(outputContent);
 
     const tagsToWrap = [thinkingTag, 'document'];
@@ -178,6 +240,8 @@ export class XmlOutputManager {
         preferredName,
       );
     }
+
+    documents ??= this.extractPercentHeaderDocuments(rawOutputContent);
 
     if (!documents) {
       this.warnPartialExtraction(outputLocation, expectedDocumentCount, 0);

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -10,7 +10,10 @@ import {
 } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentSetting } from '@agent/core/definition/AgentDataclass';
-import { getExtractedDocOutputFileName } from '@agent/utils/outputFileUtils';
+import {
+  getExtractedDocOutputFileName,
+  getSafeDocumentRelativePath,
+} from '@agent/utils/outputFileUtils';
 import { toErrorMessage } from '@common/errors';
 import replacementEngine, { applyReplacements } from '@replacement/engine';
 import { FENCED_LATEX_BLOCK_REPLACEMENTS } from '@replacement/rulesRegex';
@@ -135,23 +138,34 @@ export class XmlOutputManager {
 
   private makeUniquePercentHeaderName(
     source: string,
-    seen: Map<string, number>,
+    reservedNames: Set<string>,
   ): string {
     const normalized = source.replaceAll('\\', '/');
-    const count = (seen.get(normalized) ?? 0) + 1;
-    seen.set(normalized, count);
-    if (count === 1) return normalized;
+    const safeName = getSafeDocumentRelativePath(normalized).replaceAll(
+      '\\',
+      '/',
+    );
+    let candidate = safeName;
+    let suffix = 2;
 
-    const parsed = path.posix.parse(normalized);
-    const fileName = `${parsed.name}-${count}${parsed.ext}`;
-    return parsed.dir ? path.posix.join(parsed.dir, fileName) : fileName;
+    while (reservedNames.has(candidate)) {
+      const parsed = path.posix.parse(safeName);
+      candidate = path.posix.join(
+        parsed.dir,
+        `${parsed.name}-${suffix}${parsed.ext}`,
+      );
+      suffix += 1;
+    }
+
+    reservedNames.add(candidate);
+    return candidate;
   }
 
   private extractPercentHeaderDocuments(
     outputContent: string,
   ): Array<{ content: string; name: string }> | null {
     const documents: Array<{ content: string; name: string }> = [];
-    const seenNames = new Map<string, number>();
+    const reservedNames = new Set<string>();
     let currentName: string | null = null;
     let currentLines: string[] = [];
 
@@ -172,7 +186,7 @@ export class XmlOutputManager {
       const match = PERCENT_FILENAME_HEADER_REGEX.exec(line.trim());
       if (match) {
         flushCurrent();
-        currentName = this.makeUniquePercentHeaderName(match[1], seenNames);
+        currentName = this.makeUniquePercentHeaderName(match[1], reservedNames);
         continue;
       }
 

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -138,7 +138,8 @@ export class XmlOutputManager {
 
   private makeUniquePercentHeaderName(
     source: string,
-    reservedNames: Set<string>,
+    reservedFinalPaths: Set<string>,
+    roundDir: string,
   ): string {
     const normalized = source.replaceAll('\\', '/');
     const safeName = getSafeDocumentRelativePath(normalized).replaceAll(
@@ -148,7 +149,10 @@ export class XmlOutputManager {
     let candidate = safeName;
     let suffix = 2;
 
-    while (reservedNames.has(candidate)) {
+    const finalPathKey = (name: string) =>
+      getExtractedDocOutputFileName(name, roundDir).replaceAll('\\', '/');
+
+    while (reservedFinalPaths.has(finalPathKey(candidate))) {
       const parsed = path.posix.parse(safeName);
       candidate = path.posix.join(
         parsed.dir,
@@ -157,15 +161,16 @@ export class XmlOutputManager {
       suffix += 1;
     }
 
-    reservedNames.add(candidate);
+    reservedFinalPaths.add(finalPathKey(candidate));
     return candidate;
   }
 
   private extractPercentHeaderDocuments(
     outputContent: string,
+    roundDir: string,
   ): Array<{ content: string; name: string }> | null {
     const documents: Array<{ content: string; name: string }> = [];
-    const reservedNames = new Set<string>();
+    const reservedFinalPaths = new Set<string>();
     let currentName: string | null = null;
     let currentLines: string[] = [];
 
@@ -173,7 +178,14 @@ export class XmlOutputManager {
       if (!currentName) return;
       const content = currentLines.join('\n').trim();
       if (content) {
-        documents.push({ name: currentName, content });
+        documents.push({
+          name: this.makeUniquePercentHeaderName(
+            currentName,
+            reservedFinalPaths,
+            roundDir,
+          ),
+          content,
+        });
       }
       currentLines = [];
     };
@@ -186,7 +198,7 @@ export class XmlOutputManager {
       const match = PERCENT_FILENAME_HEADER_REGEX.exec(line.trim());
       if (match) {
         flushCurrent();
-        currentName = this.makeUniquePercentHeaderName(match[1], reservedNames);
+        currentName = match[1];
         continue;
       }
 
@@ -255,7 +267,10 @@ export class XmlOutputManager {
       );
     }
 
-    documents ??= this.extractPercentHeaderDocuments(rawOutputContent);
+    documents ??= this.extractPercentHeaderDocuments(
+      rawOutputContent,
+      getFileDirectory(outputLocation),
+    );
 
     if (!documents) {
       this.warnPartialExtraction(outputLocation, expectedDocumentCount, 0);

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -67,25 +67,152 @@ const EXTRACTION_METHOD_MESSAGES: Record<string, string> = {
 };
 
 const PERCENT_FILENAME_HEADER_REGEX =
-  /^%\s+((?:\.\/)*[A-Za-z0-9][A-Za-z0-9._/-]*\.[A-Za-z0-9]+)\s*$/;
+  /^%\s+((?:\.[/\\])*[A-Za-z0-9_][A-Za-z0-9._/\\-]*\.[A-Za-z0-9]+)\s*$/;
+const LATEX_DOCUMENTCLASS_REGEX = /\\documentclass\b/;
 const LATEX_DOCUMENT_BEGIN_REGEX = /\\begin\s*\{\s*document\s*\}/;
 const LATEX_DOCUMENT_END_REGEX = /\\end\s*\{\s*document\s*\}/;
+const LIKELY_LATEX_CONTENT_REGEX =
+  /^\\(?:chapter|section|subsection|subsubsection|paragraph|begin|end|input|include|documentclass|usepackage|newcommand|renewcommand|[([])/;
 
-function isMarkdownFenceDelimiter(line: string): boolean {
-  return /^(?:`{3,}|~{3,})(?:\S.*)?\s*$/.test(line.trim());
+type MarkdownFence = {
+  marker: '`' | '~';
+  length: number;
+};
+
+function parseMarkdownFenceDelimiter(line: string): MarkdownFence | null {
+  const match = /^(`{3,}|~{3,})(?:\s*\S.*)?\s*$/.exec(line.trim());
+  if (!match) {
+    return null;
+  }
+  const delimiter = match[1];
+  return {
+    marker: delimiter[0] as '`' | '~',
+    length: delimiter.length,
+  };
 }
 
-function isInsideLatexDocument(lines: readonly string[]): boolean {
+function isMarkdownFenceDelimiter(line: string): boolean {
+  return parseMarkdownFenceDelimiter(line) !== null;
+}
+
+function isClosingMarkdownFence(
+  line: string,
+  openingFence: MarkdownFence,
+): boolean {
+  const closingFence = parseMarkdownFenceDelimiter(line);
+  return (
+    closingFence !== null &&
+    closingFence.marker === openingFence.marker &&
+    closingFence.length >= openingFence.length
+  );
+}
+
+function stripSurroundingMarkdownFence(lines: readonly string[]): string[] {
+  const firstContentIndex = lines.findIndex((line) => line.trim() !== '');
+  if (firstContentIndex === -1) {
+    return [];
+  }
+
+  const lastContentIndex = lines.findLastIndex((line) => line.trim() !== '');
+  if (
+    firstContentIndex < lastContentIndex &&
+    isMarkdownFenceDelimiter(lines[firstContentIndex]) &&
+    isMarkdownFenceDelimiter(lines[lastContentIndex])
+  ) {
+    return [
+      ...lines.slice(0, firstContentIndex),
+      ...lines.slice(firstContentIndex + 1, lastContentIndex),
+      ...lines.slice(lastContentIndex + 1),
+    ];
+  }
+
+  return [...lines];
+}
+
+function getLatexDocumentContext(lines: readonly string[]): {
+  insideDocumentBody: boolean;
+  inDocumentPreamble: boolean;
+} {
   let depth = 0;
+  let sawDocumentclassWithoutBody = false;
   for (const line of lines) {
+    if (line.trim().startsWith('%')) {
+      continue;
+    }
+    if (LATEX_DOCUMENTCLASS_REGEX.test(line)) {
+      sawDocumentclassWithoutBody = true;
+    }
     if (LATEX_DOCUMENT_BEGIN_REGEX.test(line)) {
       depth += 1;
+      sawDocumentclassWithoutBody = false;
     }
     if (LATEX_DOCUMENT_END_REGEX.test(line) && depth > 0) {
       depth -= 1;
+      if (depth === 0) {
+        sawDocumentclassWithoutBody = false;
+      }
     }
   }
-  return depth > 0;
+  return {
+    insideDocumentBody: depth > 0,
+    inDocumentPreamble: sawDocumentclassWithoutBody,
+  };
+}
+
+function hasDocumentBeginInCurrentPreamble(
+  lines: readonly string[],
+  startIndex: number,
+): boolean {
+  for (const line of lines.slice(startIndex + 1)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('%')) {
+      continue;
+    }
+    if (LATEX_DOCUMENTCLASS_REGEX.test(line)) {
+      return false;
+    }
+    if (LATEX_DOCUMENT_BEGIN_REGEX.test(line)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function shouldKeepPercentHeaderAsLatexComment(
+  linesBeforeHeader: readonly string[],
+  allLines: readonly string[],
+  headerIndex: number,
+): boolean {
+  const context = getLatexDocumentContext(linesBeforeHeader);
+  if (context.insideDocumentBody) {
+    return true;
+  }
+  return (
+    context.inDocumentPreamble &&
+    hasDocumentBeginInCurrentPreamble(allLines, headerIndex)
+  );
+}
+
+function hasLikelyLatexContent(lines: readonly string[]): boolean {
+  return lines.some((line) => LIKELY_LATEX_CONTENT_REGEX.test(line.trim()));
+}
+
+function escapeRegExp(value: string): string {
+  return value.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function stripXmlTagBlocks(content: string, tagName: string): string {
+  const trimmedTag = tagName.trim();
+  if (!trimmedTag) {
+    return content;
+  }
+  return content.replaceAll(
+    new RegExp(
+      `<${escapeRegExp(trimmedTag)}\\b[^>]*>[\\s\\S]*?<\\/${escapeRegExp(trimmedTag)}>`,
+      'gi',
+    ),
+    '',
+  );
 }
 
 export class XmlOutputManager {
@@ -187,15 +314,24 @@ export class XmlOutputManager {
   private extractPercentHeaderDocuments(
     outputContent: string,
     roundDir: string,
+    thinkingTag: string,
   ): Array<{ content: string; name: string }> | null {
     const documents: Array<{ content: string; name: string }> = [];
     const reservedFinalPaths = new Set<string>();
     let currentName: string | null = null;
     let currentLines: string[] = [];
+    let preHeaderLines: string[] = [];
+    let pendingPrefacedMarkdownFence: MarkdownFence | null = null;
+    let currentMarkdownFence: MarkdownFence | null = null;
+    let ignoreProseUntilNextHeader = false;
+    let synthesizedSingleInputFromPrefix = false;
 
-    const flushCurrent = () => {
-      if (!currentName) return;
-      const content = currentLines.join('\n').trim();
+    const flushCurrent = (): MarkdownFence | null => {
+      if (!currentName) return null;
+      const content = stripSurroundingMarkdownFence(currentLines)
+        .join('\n')
+        .trim();
+      const carriedFence = content ? null : currentMarkdownFence;
       if (content) {
         documents.push({
           name: this.makeUniquePercentHeaderName(
@@ -207,25 +343,93 @@ export class XmlOutputManager {
         });
       }
       currentLines = [];
+      currentMarkdownFence = null;
+      return carriedFence;
     };
 
-    const lines = outputContent
-      .replaceAll('\r\n', '\n')
-      .replaceAll('\r', '\n')
-      .split('\n');
-    for (const line of lines) {
-      const match = PERCENT_FILENAME_HEADER_REGEX.exec(line.trim());
-      if (match && !isInsideLatexDocument(currentLines)) {
+    const lines = stripSurroundingMarkdownFence(
+      stripXmlTagBlocks(outputContent, thinkingTag)
+        .replaceAll('\r\n', '\n')
+        .replaceAll('\r', '\n')
+        .split('\n'),
+    );
+    for (const [index, line] of lines.entries()) {
+      const fence = parseMarkdownFenceDelimiter(line);
+
+      if (!currentName && fence) {
+        if (
+          pendingPrefacedMarkdownFence &&
+          isClosingMarkdownFence(line, pendingPrefacedMarkdownFence)
+        ) {
+          pendingPrefacedMarkdownFence = null;
+        } else {
+          pendingPrefacedMarkdownFence = fence;
+        }
+        ignoreProseUntilNextHeader = false;
+        continue;
+      }
+
+      if (
+        currentName &&
+        currentMarkdownFence &&
+        isClosingMarkdownFence(line, currentMarkdownFence) &&
+        !getLatexDocumentContext(currentLines).insideDocumentBody
+      ) {
         flushCurrent();
+        currentName = null;
+        preHeaderLines = [];
+        pendingPrefacedMarkdownFence = null;
+        ignoreProseUntilNextHeader = true;
+        synthesizedSingleInputFromPrefix = false;
+        continue;
+      }
+
+      const match = PERCENT_FILENAME_HEADER_REGEX.exec(line.trim());
+      if (match && synthesizedSingleInputFromPrefix) {
+        currentLines.push(line);
+        continue;
+      }
+
+      const linesBeforeHeader = currentName ? currentLines : preHeaderLines;
+      if (
+        match &&
+        !shouldKeepPercentHeaderAsLatexComment(linesBeforeHeader, lines, index)
+      ) {
+        if (!currentName && hasLikelyLatexContent(preHeaderLines)) {
+          if (this.agentConfig.inputFiles.length === 1) {
+            currentName = this.agentConfig.inputFiles[0];
+            currentLines = [...preHeaderLines, line];
+            currentMarkdownFence = pendingPrefacedMarkdownFence;
+            pendingPrefacedMarkdownFence = null;
+            preHeaderLines = [];
+            ignoreProseUntilNextHeader = false;
+            synthesizedSingleInputFromPrefix = true;
+            continue;
+          }
+          preHeaderLines = [];
+        }
+        const carriedFence = flushCurrent();
         currentName = match[1];
+        currentMarkdownFence = pendingPrefacedMarkdownFence ?? carriedFence;
+        pendingPrefacedMarkdownFence = null;
+        preHeaderLines = [];
+        ignoreProseUntilNextHeader = false;
+        synthesizedSingleInputFromPrefix = false;
         continue;
       }
 
       if (currentName) {
-        if (isMarkdownFenceDelimiter(line)) {
+        if (
+          fence &&
+          !currentMarkdownFence &&
+          !currentLines.some((currentLine) => currentLine.trim() !== '')
+        ) {
+          currentMarkdownFence = fence;
           continue;
         }
         currentLines.push(line);
+      } else if (!ignoreProseUntilNextHeader) {
+        preHeaderLines.push(line);
       }
     }
     flushCurrent();
@@ -282,6 +486,7 @@ export class XmlOutputManager {
       documents = this.extractPercentHeaderDocuments(
         rawOutputContent,
         getFileDirectory(outputLocation),
+        thinkingTag,
       );
     }
 

--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -48,7 +48,7 @@ function createXmlManager(documentTag = 'document'): XmlOutputManager {
     {
       inputFiles: ['paper.tex'],
     } as AgentConfig,
-    { debug: vi.fn() } as unknown as AgentTrace,
+    { debug: vi.fn(), info: vi.fn() } as unknown as AgentTrace,
     new TaskRunFileService(),
   );
 }
@@ -109,6 +109,62 @@ describe('XmlOutputManager', () => {
 
     await expect(AbsoluteFS.read('/tmp/run/sections/main.tex')).resolves.toBe(
       'Nested section.\n',
+    );
+  });
+
+  it('recovers documents from percent filename headers as a last-resort fallback', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        'Here is the output:',
+        '% main.tex',
+        '\\section{Recovered}',
+        '% sections/appendix.tex',
+        'Appendix text.',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents');
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual([
+      'main.tex',
+      'sections/appendix.tex',
+    ]);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      '\\section{Recovered}\n',
+    );
+    await expect(
+      AbsoluteFS.read('/tmp/run/sections/appendix.tex'),
+    ).resolves.toBe('Appendix text.\n');
+  });
+
+  it('makes duplicate percent filename headers unique before writing', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      ['% chunk.tex', 'First.', '% chunk.tex', 'Second.'].join('\n'),
+    );
+    const manager = createXmlManager('documents');
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual([
+      'chunk.tex',
+      'chunk-2.tex',
+    ]);
+    await expect(AbsoluteFS.read('/tmp/run/chunk.tex')).resolves.toBe(
+      'First.\n',
+    );
+    await expect(AbsoluteFS.read('/tmp/run/chunk-2.tex')).resolves.toBe(
+      'Second.\n',
     );
   });
 

--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -168,6 +168,72 @@ describe('XmlOutputManager', () => {
     );
   });
 
+  it('avoids percent filename suffix collisions with explicit headers', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '% chunk.tex',
+        'First.',
+        '% chunk-2.tex',
+        'Explicit suffix.',
+        '% chunk.tex',
+        'Second duplicate.',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents');
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual([
+      'chunk.tex',
+      'chunk-2.tex',
+      'chunk-3.tex',
+    ]);
+    await expect(AbsoluteFS.read('/tmp/run/chunk.tex')).resolves.toBe(
+      'First.\n',
+    );
+    await expect(AbsoluteFS.read('/tmp/run/chunk-2.tex')).resolves.toBe(
+      'Explicit suffix.\n',
+    );
+    await expect(AbsoluteFS.read('/tmp/run/chunk-3.tex')).resolves.toBe(
+      'Second duplicate.\n',
+    );
+  });
+
+  it('deduplicates percent filename headers after safe-path normalization', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '% sections/main.tex',
+        'Plain path.',
+        '% sections/./main.tex',
+        'Equivalent safe path.',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents');
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual([
+      'sections/main.tex',
+      'sections/main-2.tex',
+    ]);
+    await expect(AbsoluteFS.read('/tmp/run/sections/main.tex')).resolves.toBe(
+      'Plain path.\n',
+    );
+    await expect(AbsoluteFS.read('/tmp/run/sections/main-2.tex')).resolves.toBe(
+      'Equivalent safe path.\n',
+    );
+  });
+
   it('does not auto-format extracted workflow outputs', async () => {
     await AbsoluteFS.write(
       '/tmp/run/output.xml',

--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -112,7 +112,7 @@ describe('XmlOutputManager', () => {
     );
   });
 
-  it('recovers documents from percent filename headers as a last-resort fallback', async () => {
+  it('recovers documents from percent filename headers', async () => {
     await AbsoluteFS.write(
       '/tmp/run/output.xml',
       [
@@ -141,6 +141,71 @@ describe('XmlOutputManager', () => {
     await expect(
       AbsoluteFS.read('/tmp/run/sections/appendix.tex'),
     ).resolves.toBe('Appendix text.\n');
+  });
+
+  it('removes surrounding markdown fences from percent filename output', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '```latex',
+        '% main.tex',
+        '\\documentclass{article}',
+        '\\begin{document}',
+        'Recovered.',
+        '\\end{document}',
+        '```',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents');
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual(['main.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      [
+        '\\documentclass{article}',
+        '\\begin{document}',
+        'Recovered.',
+        '\\end{document}',
+        '',
+      ].join('\n'),
+    );
+  });
+
+  it('prefers percent filename headers over single-document input recovery', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '% declared.tex',
+        '\\documentclass{article}',
+        '\\begin{document}',
+        'Recovered.',
+        '\\end{document}',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents');
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual(['declared.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/declared.tex')).resolves.toBe(
+      [
+        '\\documentclass{article}',
+        '\\begin{document}',
+        'Recovered.',
+        '\\end{document}',
+        '',
+      ].join('\n'),
+    );
+    await expect(AbsoluteFS.exists('/tmp/run/paper.tex')).resolves.toBe(false);
   });
 
   it('recovers hyphenated percent filename headers', async () => {

--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -143,6 +143,36 @@ describe('XmlOutputManager', () => {
     ).resolves.toBe('Appendix text.\n');
   });
 
+  it('recovers hyphenated percent filename headers', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '% main-file.tex',
+        'Main text.',
+        '% sections/part-1.tex',
+        'Part text.',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents');
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual([
+      'main-file.tex',
+      'sections/part-1.tex',
+    ]);
+    await expect(AbsoluteFS.read('/tmp/run/main-file.tex')).resolves.toBe(
+      'Main text.\n',
+    );
+    await expect(AbsoluteFS.read('/tmp/run/sections/part-1.tex')).resolves.toBe(
+      'Part text.\n',
+    );
+  });
+
   it('makes duplicate percent filename headers unique before writing', async () => {
     await AbsoluteFS.write(
       '/tmp/run/output.xml',
@@ -204,6 +234,25 @@ describe('XmlOutputManager', () => {
     );
   });
 
+  it('does not reserve empty percent filename header blocks', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      ['% chunk.tex', '% chunk.tex', 'Actual content.'].join('\n'),
+    );
+    const manager = createXmlManager('documents');
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual(['chunk.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/chunk.tex')).resolves.toBe(
+      'Actual content.\n',
+    );
+  });
+
   it('deduplicates percent filename headers after safe-path normalization', async () => {
     await AbsoluteFS.write(
       '/tmp/run/output.xml',
@@ -232,6 +281,36 @@ describe('XmlOutputManager', () => {
     await expect(AbsoluteFS.read('/tmp/run/sections/main-2.tex')).resolves.toBe(
       'Equivalent safe path.\n',
     );
+  });
+
+  it('deduplicates percent filename headers after final output path mapping', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '% output.tex',
+        'Primary fallback.',
+        '% output_extracted.tex',
+        'Explicit extracted fallback.',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents');
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual([
+      'output.tex',
+      'output_extracted-2.tex',
+    ]);
+    await expect(
+      AbsoluteFS.read('/tmp/run/output_extracted.tex'),
+    ).resolves.toBe('Primary fallback.\n');
+    await expect(
+      AbsoluteFS.read('/tmp/run/output_extracted-2.tex'),
+    ).resolves.toBe('Explicit extracted fallback.\n');
   });
 
   it('does not auto-format extracted workflow outputs', async () => {

--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -29,7 +29,10 @@ async function initFakePlatform(files: Record<string, string> = {}) {
   initPlatform(createFakePlatform({ files, workspacePath: '/workspace' }));
 }
 
-function createXmlManager(documentTag = 'document'): XmlOutputManager {
+function createXmlManager(
+  documentTag = 'document',
+  inputFiles: string[] = ['paper.tex'],
+): XmlOutputManager {
   return new XmlOutputManager(
     {
       agentCategory: AgentCategory.Workflow,
@@ -46,7 +49,7 @@ function createXmlManager(documentTag = 'document'): XmlOutputManager {
       prefills: [],
     },
     {
-      inputFiles: ['paper.tex'],
+      inputFiles,
     } as AgentConfig,
     { debug: vi.fn(), info: vi.fn() } as unknown as AgentTrace,
     new TaskRunFileService(),
@@ -209,6 +212,74 @@ describe('XmlOutputManager', () => {
     );
   });
 
+  it('removes spaced markdown fence info strings after percent headers', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '% main.tex',
+        '``` latex',
+        '\\documentclass{article}',
+        '\\begin{document}',
+        'Recovered.',
+        '\\end{document}',
+        '```',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents');
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual(['main.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      [
+        '\\documentclass{article}',
+        '\\begin{document}',
+        'Recovered.',
+        '\\end{document}',
+        '',
+      ].join('\n'),
+    );
+  });
+
+  it('preserves fence-looking lines inside percent-header content', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '% main.tex',
+        '\\documentclass{article}',
+        '\\begin{document}',
+        '\\begin{verbatim}',
+        '```',
+        '\\end{verbatim}',
+        '\\end{document}',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents');
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual(['main.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      [
+        '\\documentclass{article}',
+        '\\begin{document}',
+        '\\begin{verbatim}',
+        '```',
+        '\\end{verbatim}',
+        '\\end{document}',
+        '',
+      ].join('\n'),
+    );
+  });
+
   it('prefers named document fallback over percent filename comments', async () => {
     await AbsoluteFS.write(
       '/tmp/run/output.xml',
@@ -336,6 +407,57 @@ describe('XmlOutputManager', () => {
     );
   });
 
+  it('recovers underscore-prefixed percent filename headers', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '% _macros.tex',
+        '\\newcommand{\\R}{\\mathbb{R}}',
+        '% _generated/main.tex',
+        'Generated text.',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents');
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual([
+      '_macros.tex',
+      '_generated/main.tex',
+    ]);
+    await expect(AbsoluteFS.read('/tmp/run/_macros.tex')).resolves.toBe(
+      '\\newcommand{\\R}{\\mathbb{R}}\n',
+    );
+    await expect(AbsoluteFS.read('/tmp/run/_generated/main.tex')).resolves.toBe(
+      'Generated text.\n',
+    );
+  });
+
+  it('recovers backslash-separated percent filename headers', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      ['% sections\\intro.tex', 'Intro text.'].join('\n'),
+    );
+    const manager = createXmlManager('documents');
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual([
+      'sections/intro.tex',
+    ]);
+    await expect(AbsoluteFS.read('/tmp/run/sections/intro.tex')).resolves.toBe(
+      'Intro text.\n',
+    );
+  });
+
   it('keeps percent filename comments inside a LaTeX document body', async () => {
     await AbsoluteFS.write(
       '/tmp/run/output.xml',
@@ -375,6 +497,472 @@ describe('XmlOutputManager', () => {
     await expect(AbsoluteFS.read('/tmp/run/appendix.tex')).resolves.toBe(
       'Appendix text.\n',
     );
+  });
+
+  it('keeps percent filename comments in a LaTeX document preamble', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '% main.tex',
+        '\\documentclass{article}',
+        '% macros.tex',
+        '\\begin{document}',
+        'Body.',
+        '\\end{document}',
+        '% appendix.tex',
+        'Appendix text.',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents');
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual([
+      'main.tex',
+      'appendix.tex',
+    ]);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      [
+        '\\documentclass{article}',
+        '% macros.tex',
+        '\\begin{document}',
+        'Body.',
+        '\\end{document}',
+        '',
+      ].join('\n'),
+    );
+    await expect(AbsoluteFS.read('/tmp/run/appendix.tex')).resolves.toBe(
+      'Appendix text.\n',
+    );
+  });
+
+  it('keeps multiple percent filename comments in a LaTeX document preamble', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '% main.tex',
+        '\\documentclass{article}',
+        '% macros.tex',
+        '% notation.tex',
+        '\\begin{document}',
+        'Body.',
+        '\\end{document}',
+        '% appendix.tex',
+        'Appendix text.',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents');
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual([
+      'main.tex',
+      'appendix.tex',
+    ]);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      [
+        '\\documentclass{article}',
+        '% macros.tex',
+        '% notation.tex',
+        '\\begin{document}',
+        'Body.',
+        '\\end{document}',
+        '',
+      ].join('\n'),
+    );
+    await expect(AbsoluteFS.read('/tmp/run/appendix.tex')).resolves.toBe(
+      'Appendix text.\n',
+    );
+  });
+
+  it('does not treat pre-header LaTeX preamble comments as percent outputs', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '\\documentclass{article}',
+        '% macros.tex',
+        '\\begin{document}',
+        'Body.',
+        '\\end{document}',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents');
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual(['paper.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/paper.tex')).resolves.toBe(
+      [
+        '\\documentclass{article}',
+        '% macros.tex',
+        '\\begin{document}',
+        'Body.',
+        '\\end{document}',
+        '',
+      ].join('\n'),
+    );
+    await expect(AbsoluteFS.exists('/tmp/run/macros.tex')).resolves.toBe(false);
+  });
+
+  it('falls back to single-document recovery for LaTeX content before the first percent header', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '\\section{Intro}',
+        '% appendix.tex',
+        'More text.',
+        '% notes.tex',
+        'Still the same fragment.',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents');
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual(['paper.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/paper.tex')).resolves.toBe(
+      [
+        '\\section{Intro}',
+        '% appendix.tex',
+        'More text.',
+        '% notes.tex',
+        'Still the same fragment.',
+        '',
+      ].join('\n'),
+    );
+    await expect(AbsoluteFS.exists('/tmp/run/appendix.tex')).resolves.toBe(
+      false,
+    );
+    await expect(AbsoluteFS.exists('/tmp/run/notes.tex')).resolves.toBe(false);
+  });
+
+  it('continues percent recovery for multi-input outputs after leading LaTeX content', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      ['\\section{Unroutable preface}', '% appendix.tex', 'Appendix.'].join(
+        '\n',
+      ),
+    );
+    const manager = createXmlManager('documents', ['main.tex', 'appendix.tex']);
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual(['appendix.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/appendix.tex')).resolves.toBe(
+      'Appendix.\n',
+    );
+  });
+
+  it('allows percent headers after documentclass-only blocks', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '% main.tex',
+        '\\documentclass{article}',
+        '% sections/intro.tex',
+        '\\section{Intro}',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents');
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual([
+      'main.tex',
+      'sections/intro.tex',
+    ]);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      '\\documentclass{article}\n',
+    );
+    await expect(AbsoluteFS.read('/tmp/run/sections/intro.tex')).resolves.toBe(
+      '\\section{Intro}\n',
+    );
+  });
+
+  it('allows percent headers before later files with their own documentclass', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '% main.tex',
+        '\\documentclass{article}',
+        '% appendix.tex',
+        '\\documentclass{article}',
+        '\\begin{document}',
+        'Appendix.',
+        '\\end{document}',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents');
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual([
+      'main.tex',
+      'appendix.tex',
+    ]);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      '\\documentclass{article}\n',
+    );
+    await expect(AbsoluteFS.read('/tmp/run/appendix.tex')).resolves.toBe(
+      [
+        '\\documentclass{article}',
+        '\\begin{document}',
+        'Appendix.',
+        '\\end{document}',
+        '',
+      ].join('\n'),
+    );
+  });
+
+  it('ignores commented end-document lines when detecting percent headers', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '% main.tex',
+        '\\documentclass{article}',
+        '\\begin{document}',
+        '% \\end{document}',
+        '% notes.tex',
+        'Still the main document.',
+        '\\end{document}',
+        '% appendix.tex',
+        'Appendix text.',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents');
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual([
+      'main.tex',
+      'appendix.tex',
+    ]);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      [
+        '\\documentclass{article}',
+        '\\begin{document}',
+        '% \\end{document}',
+        '% notes.tex',
+        'Still the main document.',
+        '\\end{document}',
+        '',
+      ].join('\n'),
+    );
+    await expect(AbsoluteFS.read('/tmp/run/appendix.tex')).resolves.toBe(
+      'Appendix text.\n',
+    );
+  });
+
+  it('removes prefaced markdown fence delimiters from percent output', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        'Here are the files:',
+        '```latex',
+        '% main.tex',
+        'Main text.',
+        '```',
+        'Done.',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents');
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual(['main.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      'Main text.\n',
+    );
+  });
+
+  it('preserves prefaced fence state across empty repeated headers', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        'Here are the files:',
+        '```latex',
+        '% main.tex',
+        '% main.tex',
+        'Main text.',
+        '```',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents');
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual(['main.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      'Main text.\n',
+    );
+  });
+
+  it('clears complete pre-header fences before the real percent output', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        'Example:',
+        '```tex',
+        'not output',
+        '```',
+        'Actual files:',
+        '```latex',
+        '% main.tex',
+        'Main text.',
+        '```',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents');
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual(['main.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      'Main text.\n',
+    );
+  });
+
+  it('keeps inner fence delimiters inside prefaced fenced percent output', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        'Here are the files:',
+        '```latex',
+        '% main.tex',
+        '\\documentclass{article}',
+        '\\begin{document}',
+        '\\begin{verbatim}',
+        '```',
+        '\\end{verbatim}',
+        '\\end{document}',
+        '```',
+        'Done.',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents');
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual(['main.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      [
+        '\\documentclass{article}',
+        '\\begin{document}',
+        '\\begin{verbatim}',
+        '```',
+        '\\end{verbatim}',
+        '\\end{document}',
+        '',
+      ].join('\n'),
+    );
+  });
+
+  it('ignores prose after a fenced percent-header block until the next header', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '% main.tex',
+        '```latex',
+        'Main text.',
+        '```',
+        'Done.',
+        '% appendix.tex',
+        'Appendix text.',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents');
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual([
+      'main.tex',
+      'appendix.tex',
+    ]);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      'Main text.\n',
+    );
+    await expect(AbsoluteFS.read('/tmp/run/appendix.tex')).resolves.toBe(
+      'Appendix text.\n',
+    );
+  });
+
+  it('ignores scratchpad percent filename mentions during recovery', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '<scratchpad>',
+        '% main.tex',
+        'Draft routing notes.',
+        '</scratchpad>',
+        '% main.tex',
+        'Actual output.',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents');
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual(['main.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      'Actual output.\n',
+    );
+    await expect(AbsoluteFS.exists('/tmp/run/main-2.tex')).resolves.toBe(false);
   });
 
   it('makes duplicate percent filename headers unique before writing', async () => {

--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -176,6 +176,74 @@ describe('XmlOutputManager', () => {
     );
   });
 
+  it('removes compact markdown fence info strings after percent headers', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '% main.tex',
+        '```latex',
+        '\\documentclass{article}',
+        '\\begin{document}',
+        'Recovered.',
+        '\\end{document}',
+        '```',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents');
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual(['main.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      [
+        '\\documentclass{article}',
+        '\\begin{document}',
+        'Recovered.',
+        '\\end{document}',
+        '',
+      ].join('\n'),
+    );
+  });
+
+  it('prefers named document fallback over percent filename comments', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '<document name="main.tex">',
+        'Main body.',
+        '% notes.tex',
+        'Still main body.',
+        '</document>',
+        '<document name="appendix.tex">',
+        'Appendix body.',
+        '</document>',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents');
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual([
+      'main.tex',
+      'appendix.tex',
+    ]);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      'Main body.\n% notes.tex\nStill main body.\n',
+    );
+    await expect(AbsoluteFS.read('/tmp/run/appendix.tex')).resolves.toBe(
+      'Appendix body.\n',
+    );
+    await expect(AbsoluteFS.exists('/tmp/run/notes.tex')).resolves.toBe(false);
+  });
+
   it('prefers percent filename headers over single-document input recovery', async () => {
     await AbsoluteFS.write(
       '/tmp/run/output.xml',
@@ -208,6 +276,36 @@ describe('XmlOutputManager', () => {
     await expect(AbsoluteFS.exists('/tmp/run/paper.tex')).resolves.toBe(false);
   });
 
+  it('recovers dot-prefixed relative percent filename headers', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '% ./main.tex',
+        'Main text.',
+        '% ./sections/appendix.tex',
+        'Appendix text.',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents');
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual([
+      'main.tex',
+      'sections/appendix.tex',
+    ]);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      'Main text.\n',
+    );
+    await expect(
+      AbsoluteFS.read('/tmp/run/sections/appendix.tex'),
+    ).resolves.toBe('Appendix text.\n');
+  });
+
   it('recovers hyphenated percent filename headers', async () => {
     await AbsoluteFS.write(
       '/tmp/run/output.xml',
@@ -235,6 +333,47 @@ describe('XmlOutputManager', () => {
     );
     await expect(AbsoluteFS.read('/tmp/run/sections/part-1.tex')).resolves.toBe(
       'Part text.\n',
+    );
+  });
+
+  it('keeps percent filename comments inside a LaTeX document body', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '% main.tex',
+        '\\documentclass{article}',
+        '\\begin{document}',
+        '% notes.tex',
+        'Still the main document.',
+        '\\end{document}',
+        '% appendix.tex',
+        'Appendix text.',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents');
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual([
+      'main.tex',
+      'appendix.tex',
+    ]);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      [
+        '\\documentclass{article}',
+        '\\begin{document}',
+        '% notes.tex',
+        'Still the main document.',
+        '\\end{document}',
+        '',
+      ].join('\n'),
+    );
+    await expect(AbsoluteFS.read('/tmp/run/appendix.tex')).resolves.toBe(
+      'Appendix text.\n',
     );
   });
 


### PR DESCRIPTION
## Summary

This PR adds a last-resort workflow-output extraction fallback for raw model responses that use `% filename.ext` headers instead of XML document blocks.

The fallback now:

- preserves named `<document name="...">` regex recovery before percent-header scanning, so ordinary percent comments cannot preempt named document extraction;
- strips Markdown fence delimiters such as ```latex, ``` latex, and ~~~tex when they wrap the whole response, a recovered percent-header block, or a prose-prefaced fenced response;
- stops fenced percent blocks at their closing fence and ignores trailing explanatory prose until the next header;
- carries fence state across repeated empty headers and clears complete pre-header example fences before the real output;
- preserves fence-looking lines that are part of the recovered LaTeX document body;
- accepts `./file.tex`, `./dir/file.tex`, `_macros.tex`, `_generated/main.tex`, and backslash-separated relative paths, relying on the existing safe-path normalization;
- avoids treating `% file.tex` comments inside a LaTeX document preamble or open `document` environment as new file boundaries, including multiple filename-shaped preamble comments and comments before the first percent header;
- preserves likely LaTeX content that appears before the first percent header by routing it to the single input file when there is exactly one input;
- continues named percent-header recovery for multi-input runs when unroutable leading LaTeX content appears before the first header;
- allows subsequent real percent headers after documentclass-only or truncated blocks that never enter `\begin{document}`;
- ignores commented LaTeX begin/end markers when deciding whether a `% file.tex` line is a real boundary;
- ignores filename-looking lines inside `<scratchpad>...</scratchpad>` before percent-header recovery;
- keeps duplicate/colliding output names deterministic by reserving final output paths before writing.

Closes #6716.

## Verification

- `corepack pnpm exec vitest run src/test-kernel/agent/output/XmlOutputManager.vitest.ts`
- `corepack pnpm run typecheck`
- `corepack pnpm run lint` (passes with existing warnings)
- `corepack pnpm run test`
- `corepack pnpm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent output routing and on-disk file naming when fallbacks trigger; wrong boundary heuristics could mis-split or overwrite workflow artifacts, though existing XML/regex paths run first and tests are broad.
> 
> **Overview**
> **`XmlOutputManager`** gains a **last-resort fallback** that splits workflow outputs when models emit **`% path/to/file.ext` headers** instead of XML `<document>` blocks. It runs **after** XML parse and **named-document regex** recovery (on **raw** scratchpad output, with the thinking tag stripped).
> 
> The scanner treats filename-shaped `%` lines as file boundaries only when they are **not** LaTeX preamble/body comments, handles **markdown fences** (wrap, prefaced, and per-block closers), **ignores prose** after fenced blocks until the next header, and can **synthesize** leading LaTeX into the **single input file** when routing is unambiguous. Output names go through **safe-path normalization** and **collision avoidance** on final extracted paths.
> 
> Extensive **`XmlOutputManager.vitest.ts`** coverage documents precedence and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c30070c423437f8d2b5d3d8fcdb74f6f52d0dd51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->