### PR TITLE
fix(onboarding): require an explicit click to launch first-run setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Extension (VS Code) and Desktop
+
+#### Improvements
+
+- **First-run setup no longer launches itself** — after a new user connects a credential, TeXRA now selects the setup assistant and shows a "Run setup assistant" card instead of silently starting it. The setup assistant inspects your environment and may install tools, so it now runs only when you explicitly click to start it.
+
 ## [0.39.0] - 2026-06-28
 
 ### Shared (all surfaces)

--- a/docs/prds/2026-06-11-agent-native-onboarding.md
+++ b/docs/prds/2026-06-11-agent-native-onboarding.md
@@ -246,7 +246,7 @@ credentials-only. A deprecation note covers the transition.
 | State | Extension / desktop     | CLI                        | Walkthrough beat                              | Docs page                                                             |
 | ----- | ----------------------- | -------------------------- | --------------------------------------------- | --------------------------------------------------------------------- |
 | 0     | welcome card            | first-run picker (shipped) | "Sign in — free for academics — or add a key" | `first-run.md` step 0; `quick-start.md` lead                          |
-| 1     | setup agent auto-starts | setup agent after picker   | "The setup assistant takes it from here"      | `first-run.md` body (polish demo, agent-run or manual)                |
+| 1     | setup card → click to run | setup agent after picker   | "The setup assistant takes it from here"      | `first-run.md` body (polish demo, agent-run or manual)                |
 | 2     | orchestrator default    | orchestrator/chat default  | "Meet the orchestrator"                       | `quick-start.md` (launcher reference), `built-in-agents.md` (catalog) |
 
 Doc changes:
@@ -324,7 +324,7 @@ mirrors it; this PRD's State 0 wording is the canonical text.
 | Funnel state derivation (host-neutral)                                | new `src/controllers/onboarding/` module; lift `packages/cli/src/onboarding/onboardingState.ts` + `packages/cli/src/runtime/credentialStatus.ts` logic behind `@platform`            |
 | Shared copy                                                           | new `src/shared/copy/onboarding.ts`; consume in `runOnboarding.tsx`, new welcome card, walkthrough source                                                                            |
 | Welcome card (extension/desktop)                                      | new component in `packages/extension/src/webview/frontend/components/`; visibility wiring in `BannerGroup.ts` / `MainApp.ts`                                                         |
-| State 0 → 1 handoff                                                   | extension credential-changed event → select `setup` + kickoff; CLI post-picker continuation in `chat.ts` / `orchestrate.ts`                                                          |
+| State 0 → 1 handoff                                                   | extension credential-changed event → select `setup` (launch is an explicit "Run setup assistant" click, never auto-started); CLI post-picker continuation in `chat.ts` / `orchestrate.ts`                                                          |
 | `apply_team` tool (writes workspace roster + user-level default team) | new tool in `src/tools/`; preset application path exists in `SettingsAgentCatalogController.ts`                                                                                      |
 | Default-team seeding of fresh workspaces                              | user-scoped `defaultTeamId` key (shared with launcher PRD), starter team in `agentRegistryConstants.ts`, seeding at activation in `packages/extension/src/extension.ts` and CLI init |
 | Project-bootstrap row (empty folder, State 2)                         | `GettingStartedBanner.ts` slimmed; trigger condition unchanged                                                                                                                       |
@@ -340,8 +340,10 @@ mirrors it; this PRD's State 0 wording is the canonical text.
    "Browse all agents…", slimmed bootstrap row.
 2. **State 0 on the extension**: shared copy module + welcome card
    replacing three banners; CLI unchanged.
-3. **State 1**: auto-start setup on credential arrival (both hosts),
-   `apply_team` tool + default-team seeding of fresh workspaces,
-   setup-prompt additions, `texra setup` vocabulary fix.
+3. **State 1**: on credential arrival, select `setup` and show the setup
+   card (both hosts); the user launches it with an explicit "Run setup
+   assistant" click — never auto-started. Plus `apply_team` tool +
+   default-team seeding of fresh workspaces, setup-prompt additions,
+   `texra setup` vocabulary fix.
 4. **Narrative**: walkthrough rewrite + docs-site edits (can trail by
    a release, but must land before marketing the flow).

--- a/docs/prds/2026-06-11-agent-native-onboarding.md
+++ b/docs/prds/2026-06-11-agent-native-onboarding.md
@@ -243,11 +243,11 @@ credentials-only. A deprecation note covers the transition.
 
 ## The narrative contract (docs + product, one story)
 
-| State | Extension / desktop     | CLI                        | Walkthrough beat                              | Docs page                                                             |
-| ----- | ----------------------- | -------------------------- | --------------------------------------------- | --------------------------------------------------------------------- |
-| 0     | welcome card            | first-run picker (shipped) | "Sign in — free for academics — or add a key" | `first-run.md` step 0; `quick-start.md` lead                          |
+| State | Extension / desktop       | CLI                        | Walkthrough beat                              | Docs page                                                             |
+| ----- | ------------------------- | -------------------------- | --------------------------------------------- | --------------------------------------------------------------------- |
+| 0     | welcome card              | first-run picker (shipped) | "Sign in — free for academics — or add a key" | `first-run.md` step 0; `quick-start.md` lead                          |
 | 1     | setup card → click to run | setup agent after picker   | "The setup assistant takes it from here"      | `first-run.md` body (polish demo, agent-run or manual)                |
-| 2     | orchestrator default    | orchestrator/chat default  | "Meet the orchestrator"                       | `quick-start.md` (launcher reference), `built-in-agents.md` (catalog) |
+| 2     | orchestrator default      | orchestrator/chat default  | "Meet the orchestrator"                       | `quick-start.md` (launcher reference), `built-in-agents.md` (catalog) |
 
 Doc changes:
 
@@ -319,20 +319,20 @@ mirrors it; this PRD's State 0 wording is the canonical text.
 
 ## Implementation surface
 
-| Concern                                                               | Files                                                                                                                                                                                |
-| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Funnel state derivation (host-neutral)                                | new `src/controllers/onboarding/` module; lift `packages/cli/src/onboarding/onboardingState.ts` + `packages/cli/src/runtime/credentialStatus.ts` logic behind `@platform`            |
-| Shared copy                                                           | new `src/shared/copy/onboarding.ts`; consume in `runOnboarding.tsx`, new welcome card, walkthrough source                                                                            |
-| Welcome card (extension/desktop)                                      | new component in `packages/extension/src/webview/frontend/components/`; visibility wiring in `BannerGroup.ts` / `MainApp.ts`                                                         |
-| State 0 → 1 handoff                                                   | extension credential-changed event → select `setup` (launch is an explicit "Run setup assistant" click, never auto-started); CLI post-picker continuation in `chat.ts` / `orchestrate.ts`                                                          |
-| `apply_team` tool (writes workspace roster + user-level default team) | new tool in `src/tools/`; preset application path exists in `SettingsAgentCatalogController.ts`                                                                                      |
-| Default-team seeding of fresh workspaces                              | user-scoped `defaultTeamId` key (shared with launcher PRD), starter team in `agentRegistryConstants.ts`, seeding at activation in `packages/extension/src/extension.ts` and CLI init |
-| Project-bootstrap row (empty folder, State 2)                         | `GettingStartedBanner.ts` slimmed; trigger condition unchanged                                                                                                                       |
-| "Browse all agents…" tail item                                        | `selectTemplates.ts`, `InstructionPanel.ts`                                                                                                                                          |
-| State 2 defaults                                                      | `agentRegistryConstants.ts` preferred lists (orchestrator/chat already first); default-selection logic in launcher controller                                                        |
-| Vocabulary (`texra setup`)                                            | `packages/cli/src/commands/setup.ts`                                                                                                                                                 |
-| Walkthrough rewrite                                                   | `packages/extension/resources/walkthroughs/getting-started.md`                                                                                                                       |
-| Docs site                                                             | `docs/guide/quick-start.md`, `docs/guide/first-run.md`, `docs/guide/configuration.md`                                                                                                |
+| Concern                                                               | Files                                                                                                                                                                                     |
+| --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Funnel state derivation (host-neutral)                                | new `src/controllers/onboarding/` module; lift `packages/cli/src/onboarding/onboardingState.ts` + `packages/cli/src/runtime/credentialStatus.ts` logic behind `@platform`                 |
+| Shared copy                                                           | new `src/shared/copy/onboarding.ts`; consume in `runOnboarding.tsx`, new welcome card, walkthrough source                                                                                 |
+| Welcome card (extension/desktop)                                      | new component in `packages/extension/src/webview/frontend/components/`; visibility wiring in `BannerGroup.ts` / `MainApp.ts`                                                              |
+| State 0 → 1 handoff                                                   | extension credential-changed event → select `setup` (launch is an explicit "Run setup assistant" click, never auto-started); CLI post-picker continuation in `chat.ts` / `orchestrate.ts` |
+| `apply_team` tool (writes workspace roster + user-level default team) | new tool in `src/tools/`; preset application path exists in `SettingsAgentCatalogController.ts`                                                                                           |
+| Default-team seeding of fresh workspaces                              | user-scoped `defaultTeamId` key (shared with launcher PRD), starter team in `agentRegistryConstants.ts`, seeding at activation in `packages/extension/src/extension.ts` and CLI init      |
+| Project-bootstrap row (empty folder, State 2)                         | `GettingStartedBanner.ts` slimmed; trigger condition unchanged                                                                                                                            |
+| "Browse all agents…" tail item                                        | `selectTemplates.ts`, `InstructionPanel.ts`                                                                                                                                               |
+| State 2 defaults                                                      | `agentRegistryConstants.ts` preferred lists (orchestrator/chat already first); default-selection logic in launcher controller                                                             |
+| Vocabulary (`texra setup`)                                            | `packages/cli/src/commands/setup.ts`                                                                                                                                                      |
+| Walkthrough rewrite                                                   | `packages/extension/resources/walkthroughs/getting-started.md`                                                                                                                            |
+| Docs site                                                             | `docs/guide/quick-start.md`, `docs/guide/first-run.md`, `docs/guide/configuration.md`                                                                                                     |
 
 ### Suggested shipping order
 

--- a/packages/desktop/src/main/desktopOnboardingIpc.ts
+++ b/packages/desktop/src/main/desktopOnboardingIpc.ts
@@ -130,9 +130,9 @@ export function createDesktopOnboardingIpc(
       .finally(() => {
         // Clear the guard once the run settles (success or failure), not only on
         // error: while it's in flight the guard blocks a concurrent second run,
-        // but afterwards a manual "Run Setup" click or a later credential cycle
-        // must be able to launch setup again (otherwise the guard would stay
-        // stuck for the window's lifetime after the first kickoff).
+        // but afterwards another manual "Run Setup" click must be able to launch
+        // setup again (otherwise the guard would stay stuck for the window's
+        // lifetime after the first kickoff).
         setupKickoffStarted = false;
       });
   }

--- a/packages/desktop/src/main/desktopOnboardingIpc.ts
+++ b/packages/desktop/src/main/desktopOnboardingIpc.ts
@@ -36,7 +36,7 @@ export interface DesktopOnboardingIpcOptions {
   readyGate?: Promise<void>;
   /** Post SET_SELECTED_AGENT to the renderer when entering State 1. */
   selectSetupAgent?: () => Promise<void>;
-  /** Auto-start the setup conversation on the State 0→1 transition. */
+  /** Launch the setup conversation when the user clicks "Run Setup". */
   kickoffSetup?: () => Promise<void>;
   /** Run ChatGPT sign-in flow from the welcome card. */
   signInWithChatGpt?: () => Promise<void>;
@@ -107,18 +107,15 @@ export function createDesktopOnboardingIpc(
     if (transition.selectSetupAgent) {
       await options.selectSetupAgent?.();
     }
-    // The funnel state was already pushed above so the renderer can paint the
-    // setup card immediately; the kickoff runs fire-and-forget (see
-    // startSetupKickoff) so a later refresh isn't blocked behind it.
-    if (transition.kickoffSetup) {
-      startSetupKickoff();
-    }
+    // Entering State 1 only selects the setup agent and paints the setup card;
+    // it never auto-starts the setup conversation. The user launches setup
+    // explicitly via the card's "Run Setup" button (ONBOARDING_RUN_SETUP).
   }
 
-  // Single guarded entry point for launching setup. Both the auto-kickoff on the
-  // needs-credential→setup transition and the explicit "Run Setup" card action
-  // route through here, so a setup run can't be started twice concurrently —
-  // the host's `handleExecute`/`runAgent` has no in-flight dedup of its own.
+  // Single guarded entry point for launching setup. The explicit "Run Setup"
+  // card action routes through here so a setup run can't be started twice
+  // concurrently — the host's `handleExecute`/`runAgent` has no in-flight
+  // dedup of its own.
   function startSetupKickoff(): void {
     if (setupKickoffStarted) return;
     setupKickoffStarted = true;
@@ -175,8 +172,8 @@ export function createDesktopOnboardingIpc(
 
   async function runSetup(): Promise<void> {
     await options.selectSetupAgent?.();
-    // Route through the shared guard so a manual "Run Setup" click after an
-    // auto-kickoff (or a double-click) can't launch a second concurrent run.
+    // Route through the shared guard so a double-click of "Run Setup" can't
+    // launch a second concurrent run.
     startSetupKickoff();
     await refreshOnboardingFunnel();
   }

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -679,13 +679,14 @@ function createWindow(options: {
           sessionType: 'toolUse' as const,
         });
       },
-      // Auto-start the setup conversation, mirroring the extension's
-      // `launchSetupAssistant` → `handleExecute` path: resolve a model the
-      // user's credentials can call, build the setup execute message, and run
-      // it through the same desktop execute path the renderer's Execute button
-      // uses. The per-session `setupKickoffStarted` dedup guard inside the
-      // onboarding IPC keeps this one-shot; on a resolution failure it throws so
-      // that guard resets and a later credential change can retry.
+      // Launch the setup conversation when the user clicks "Run Setup" on the
+      // setup card, mirroring the extension's `launchSetupAssistant` →
+      // `handleExecute` path: resolve a model the user's credentials can call,
+      // build the setup execute message, and run it through the same desktop
+      // execute path the renderer's Execute button uses. The per-session
+      // `setupKickoffStarted` dedup guard inside the onboarding IPC keeps this
+      // one-shot; on a resolution failure it throws so that guard resets and a
+      // later "Run Setup" click can retry.
       kickoffSetup: async () => {
         const { buildDesktopSetupExecuteMessage } =
           await import('@controllers/onboarding/setupLaunch');

--- a/packages/extension/src/MainViewProvider.ts
+++ b/packages/extension/src/MainViewProvider.ts
@@ -14,10 +14,7 @@ import { agentKeyOf } from '@shared/schemas/agent';
 import { getServerSideKeyService } from '@auth/serverKeys';
 
 // Local imports - common
-import {
-  hasAnyUsableSetupCredential,
-  launchSetupAssistant,
-} from '@commands/setup';
+import { hasAnyUsableSetupCredential } from '@commands/setup';
 import {
   BaseWebviewProvider,
   BundledViewContentProvider,
@@ -63,8 +60,6 @@ export class MainViewProvider
   /** Last computed funnel state, so credential hooks can detect the
    *  in-session State 0 → 1 transition. Session-scoped by design. */
   private onboardingFunnelState: OnboardingFunnelState | undefined;
-  /** The setup conversation auto-starts at most once per session. */
-  private setupKickoffStarted = false;
   /** A State 1 entry observed with no view keeps its setup-agent selection
    *  pending until a launcher exists to receive it. */
   private pendingSetupAgentSelection = false;
@@ -156,8 +151,9 @@ export class MainViewProvider
    * Single derivation point for the onboarding funnel on this host (PRD:
    * agent-native onboarding). Recomputes the user-scoped funnel state,
    * pushes it to the webview when the main tab is visible, and acts on the
-   * State 0 → 1 transition: clear a stale skip, select the setup agent, and
-   * start setup once.
+   * State 0 → 1 transition: clear a stale skip and select the setup agent.
+   * It never auto-starts setup — the user launches it explicitly from the
+   * setup card's "Run setup assistant" button (ONBOARDING_RUN_SETUP).
    * Invoked by the message handler on webview ready — which credential-changed
    * hooks replay via refreshOptionsAndView — and after welcome-card actions.
    */
@@ -205,17 +201,6 @@ export class MainViewProvider
         command: MAIN_VIEW_COMMANDS.SET_SELECTED_AGENT,
         agentId: entry ? agentKeyOf(entry) : 'setup',
         sessionType: 'toolUse',
-      });
-    }
-    if (transition.kickoffSetup && !this.setupKickoffStarted) {
-      this.setupKickoffStarted = true;
-      // Fire-and-forget: the setup agent run owns its own progress UI. If
-      // preflight declines to start, allow a later credential/config change
-      // to try again in this session.
-      void launchSetupAssistant().then((result) => {
-        if (result === 'not-started') {
-          this.setupKickoffStarted = false;
-        }
       });
     }
   }

--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -324,7 +324,7 @@ export type SetupAssistantLaunchResult =
 export async function launchSetupAssistant(): Promise<SetupAssistantLaunchResult> {
   try {
     // Every setup entry point funnels through here (command, status pill,
-    // walkthrough, onboarding auto-kickoff), so one guard covers them all:
+    // walkthrough, onboarding setup card), so one guard covers them all:
     // a second concurrent setup conversation would race the first one's
     // installs and config writes. The launcher's manual Execute path is
     // deliberately not gated — an explicit user action wins.

--- a/src/controllers/onboarding/onboardingFunnel.ts
+++ b/src/controllers/onboarding/onboardingFunnel.ts
@@ -50,13 +50,6 @@ export interface OnboardingFunnelTransition {
   state: OnboardingFunnelState;
   /** Select the setup agent in the launcher (entering State 1). */
   selectSetupAgent: boolean;
-  /**
-   * Auto-start the setup conversation — only on the in-session
-   * State 0 → 1 transition (a credential landed while the welcome card was
-   * up), never on plain activation in State 1. Hosts additionally guard
-   * with a per-session "already kicked off" flag.
-   */
-  kickoffSetup: boolean;
   /** Configuring a credential clears a previous skip (PRD edge case). */
   clearDeclined: boolean;
 }
@@ -65,6 +58,12 @@ export interface OnboardingFunnelTransition {
  * Pure transition planner for hosts that recompute the funnel in-session
  * (webview ready, credential-changed events, skip). `previous` is the state
  * from the host's last computation, or `undefined` on the first one.
+ *
+ * Entering State 1 only *selects* the setup agent and shows the setup card; it
+ * never auto-starts the setup conversation. The setup agent runs an
+ * environment probe that may install tools, so launching it is an explicit,
+ * consented action — the user clicks "Run setup assistant" on the setup card
+ * (or invokes the command) to start it. There is deliberately no auto-kickoff.
  */
 export function planOnboardingFunnelTransition(
   previous: OnboardingFunnelState | undefined,
@@ -77,9 +76,6 @@ export function planOnboardingFunnelTransition(
     // the setup agent; a refresh already in State 1 must not stomp a user
     // who deliberately switched agents mid-session.
     selectSetupAgent: state === 'setup' && previous !== 'setup',
-    // 'setup' already implies !firstRunDone (see deriveOnboardingFunnelState),
-    // so the transition alone gates the one-time auto-kickoff.
-    kickoffSetup: previous === 'needs-credential' && state === 'setup',
     clearDeclined: inputs.declined && inputs.hasCredential,
   };
 }

--- a/src/controllers/onboarding/setupLaunch.ts
+++ b/src/controllers/onboarding/setupLaunch.ts
@@ -23,7 +23,7 @@ import { SETUP_AGENT_NAME } from '@shared/constants/agents';
 import { isNonEmptyString } from '@utils/core';
 import { getUseOpenRouter } from '@utils/config/providerConfig';
 
-/** Instruction handed to the setup agent on auto-kickoff (mirrors the extension). */
+/** Instruction handed to the setup agent when launched (mirrors the extension). */
 export const SETUP_INSTRUCTION =
   'Please help me finish installing TeXRA. Probe my environment, install anything missing, and get me a working credential.';
 

--- a/src/controllers/onboarding/setupLaunch.ts
+++ b/src/controllers/onboarding/setupLaunch.ts
@@ -86,7 +86,7 @@ export async function resolveDesktopSetupModel(): Promise<string | null> {
 }
 
 /**
- * Build the execute message that auto-starts the setup conversation, or `null`
+ * Build the execute message that launches the setup conversation, or `null`
  * when no credential resolves to a runnable model. The message rides the same
  * `handleExecute` path the renderer's execute button uses.
  */

--- a/src/test-kernel/controllers/OnboardingFunnel.vitest.ts
+++ b/src/test-kernel/controllers/OnboardingFunnel.vitest.ts
@@ -84,7 +84,7 @@ describe('deriveOnboardingFunnelState', () => {
 });
 
 describe('planOnboardingFunnelTransition', () => {
-  it('in-session State 0 → 1: selects the setup agent, kicks off, clears the skip', () => {
+  it('in-session State 0 → 1: selects the setup agent but never auto-runs', () => {
     expect(
       planOnboardingFunnelTransition('needs-credential', {
         hasCredential: true,
@@ -94,7 +94,6 @@ describe('planOnboardingFunnelTransition', () => {
     ).toEqual({
       state: 'setup',
       selectSetupAgent: true,
-      kickoffSetup: true,
       clearDeclined: false,
     });
   });
@@ -109,7 +108,6 @@ describe('planOnboardingFunnelTransition', () => {
     ).toEqual({
       state: 'setup',
       selectSetupAgent: true,
-      kickoffSetup: false,
       clearDeclined: false,
     });
   });
@@ -124,7 +122,6 @@ describe('planOnboardingFunnelTransition', () => {
     ).toEqual({
       state: 'setup',
       selectSetupAgent: false,
-      kickoffSetup: false,
       clearDeclined: false,
     });
   });
@@ -139,7 +136,6 @@ describe('planOnboardingFunnelTransition', () => {
     ).toEqual({
       state: 'setup',
       selectSetupAgent: true,
-      kickoffSetup: false,
       clearDeclined: true,
     });
   });
@@ -154,7 +150,6 @@ describe('planOnboardingFunnelTransition', () => {
     ).toEqual({
       state: 'done',
       selectSetupAgent: false,
-      kickoffSetup: false,
       clearDeclined: false,
     });
   });
@@ -169,7 +164,6 @@ describe('planOnboardingFunnelTransition', () => {
     ).toEqual({
       state: 'done',
       selectSetupAgent: false,
-      kickoffSetup: false,
       clearDeclined: false,
     });
   });
@@ -184,7 +178,6 @@ describe('planOnboardingFunnelTransition', () => {
     ).toEqual({
       state: 'needs-credential',
       selectSetupAgent: false,
-      kickoffSetup: false,
       clearDeclined: false,
     });
   });
@@ -199,7 +192,6 @@ describe('planOnboardingFunnelTransition', () => {
     ).toEqual({
       state: 'done',
       selectSetupAgent: false,
-      kickoffSetup: false,
       clearDeclined: false,
     });
   });


### PR DESCRIPTION
The setup assistant inspects the environment and may install tools, so
it should not start itself. Previously, the moment a new user connected a
credential the funnel auto-started the setup conversation (the State 0→1
"kickoff").

Now entering State 1 only selects the setup agent and shows the setup
card; launching it is an explicit, consented action via the existing
"Run setup assistant" button (ONBOARDING_RUN_SETUP) or the command.

- Drop `kickoffSetup` from the host-neutral transition planner.
- Remove the auto-launch wiring in the extension (MainViewProvider) and
  desktop (desktopOnboardingIpc); keep the button-driven launch path.
- Update the agent-native-onboarding PRD and tests to match.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017zpuYEus88dHWvsAZNTNEd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes first-run onboarding behavior on extension and desktop; mistaken removal of the manual launch path could block new users from completing setup.
> 
> **Overview**
> **First-run setup no longer auto-starts** after a credential is connected. Entering onboarding State 1 still **selects the setup agent** and shows the setup card, but the setup conversation runs only when the user clicks **Run setup assistant** (or uses the command)—because setup can probe the environment and install tools.
> 
> The shared **`planOnboardingFunnelTransition`** drops **`kickoffSetup`**; extension **`MainViewProvider`** and desktop **`desktopOnboardingIpc`** no longer fire setup on the State 0→1 transition. **`startSetupKickoff`** / guarded launch remain for the explicit run path. **CHANGELOG**, the agent-native onboarding **PRD**, and **tests** are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 285e78e21c3951c94fb6ff376d4b4d1593c75e49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->