### PR TITLE
test: require CLI settings reachability evidence

### DIFF
--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -44,6 +44,19 @@ export type SettingHost = 'vscode' | 'cli' | 'desktop';
 /** Storage slot a setting is read from / written to. */
 export type SettingStore = 'config' | 'workspaceState' | 'globalState';
 
+export interface CliRuntimeReachability {
+  /**
+   * Representative CLI command that reaches this setting after it has been set.
+   * Placeholders are allowed when the command needs an installed agent/model.
+   */
+  readonly command: string;
+  /**
+   * Short manual trace from the CLI command surface to {@link cliConsumer}. This
+   * is a review checklist item, not executable wiring.
+   */
+  readonly through: string;
+}
+
 export interface StateSettingEntry {
   /**
    * Canonical `texra.*` key — identical to the WorkspaceState/GlobalState slot
@@ -77,6 +90,12 @@ export interface StateSettingEntry {
    */
   readonly cliConsumer?: string;
   /**
+   * Runtime-reachability evidence for CLI-hosted settings. **Required** whenever
+   * {@link hosts} includes `'cli'` (enforced by the guardrail suite), so marking
+   * a setting as CLI-consumed requires more than naming an existing file.
+   */
+  readonly cliRuntimeReachability?: CliRuntimeReachability;
+  /**
    * Per-value descriptions for an enum setting, aligned 1:1 with the schema's
    * enum options (see {@link settingEnumOptions}). The option *values* are
    * derived from the schema, not restated here.
@@ -90,6 +109,36 @@ export interface StateSettingEntry {
 }
 
 const GIT_AUTHOR_CONSUMER = 'packages/cli/src/runtime/gitAuthor.ts';
+const GIT_AUTHOR_RUNTIME_REACHABILITY = {
+  command:
+    'texra agents run <tool-use-agent> --instruction "create a git commit"',
+  through:
+    'packages/cli/src/runtime/initPlatform.ts -> packages/cli/src/runtime/gitAuthor.ts -> src/utils/system/execUtils.ts',
+} satisfies CliRuntimeReachability;
+const GIT_WORKTREE_RUNTIME_REACHABILITY = {
+  command:
+    'texra agents run <tool-use-agent> --instruction "delegate a task to a subagent"',
+  through:
+    'packages/cli/src/runtime/initPlatform.ts -> packages/cli/src/runtime/gitAuthor.ts -> src/tools/DelegationTools.ts',
+} satisfies CliRuntimeReachability;
+const WORKFLOW_COMPILE_RUNTIME_REACHABILITY = {
+  command:
+    'texra run <workflow-agent> --input paper.tex --instruction "revise the paper"',
+  through:
+    'packages/cli/src/commands/workflow.ts -> src/agent/output/compileCheck.ts',
+} satisfies CliRuntimeReachability;
+const WORKFLOW_REJECT_RUNTIME_REACHABILITY = {
+  command:
+    'texra run <workflow-agent> --input paper.tex --instruction "revise the paper"',
+  through:
+    'packages/cli/src/commands/workflow.ts -> src/agent/implementations/flows/reflection/runReflectionFlow.ts',
+} satisfies CliRuntimeReachability;
+const OPENAI_WEBSOCKET_RUNTIME_REACHABILITY = {
+  command:
+    'texra run <workflow-agent> --model <openai-model> --input paper.tex --instruction "summarize the paper"',
+  through:
+    'packages/cli/src/commands/workflow.ts -> src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts',
+} satisfies CliRuntimeReachability;
 
 export const STATE_SETTINGS: readonly StateSettingEntry[] = [
   // --- Git commit author marking ---------------------------------------------
@@ -105,6 +154,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     cliStore: 'config',
     hosts: ['vscode', 'cli', 'desktop'],
     cliConsumer: GIT_AUTHOR_CONSUMER,
+    cliRuntimeReachability: GIT_AUTHOR_RUNTIME_REACHABILITY,
   },
   {
     key: WorkspaceStateKey.GIT_AUTHOR_NAME,
@@ -116,6 +166,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     cliStore: 'config',
     hosts: ['vscode', 'cli', 'desktop'],
     cliConsumer: GIT_AUTHOR_CONSUMER,
+    cliRuntimeReachability: GIT_AUTHOR_RUNTIME_REACHABILITY,
   },
   {
     key: WorkspaceStateKey.GIT_AUTHOR_EMAIL,
@@ -127,6 +178,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     cliStore: 'config',
     hosts: ['vscode', 'cli', 'desktop'],
     cliConsumer: GIT_AUTHOR_CONSUMER,
+    cliRuntimeReachability: GIT_AUTHOR_RUNTIME_REACHABILITY,
   },
   {
     key: WorkspaceStateKey.GIT_WORKTREE_SUPPORT,
@@ -138,6 +190,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     cliStore: 'config',
     hosts: ['vscode', 'cli', 'desktop'],
     cliConsumer: GIT_AUTHOR_CONSUMER,
+    cliRuntimeReachability: GIT_WORKTREE_RUNTIME_REACHABILITY,
   },
 
   // --- Workflow auto-compile -------------------------------------------------
@@ -154,6 +207,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     store: 'workspaceState',
     hosts: ['vscode', 'desktop', 'cli'],
     cliConsumer: 'src/agent/output/compileCheck.ts',
+    cliRuntimeReachability: WORKFLOW_COMPILE_RUNTIME_REACHABILITY,
   },
   {
     key: WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS,
@@ -167,6 +221,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     store: 'workspaceState',
     hosts: ['vscode', 'desktop', 'cli'],
     cliConsumer: 'src/agent/output/compileCheck.ts',
+    cliRuntimeReachability: WORKFLOW_COMPILE_RUNTIME_REACHABILITY,
   },
   {
     key: WorkspaceStateKey.WORKFLOW_AUTO_OPEN_PDF,
@@ -191,6 +246,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     hosts: ['vscode', 'desktop', 'cli'],
     cliConsumer:
       'src/agent/implementations/flows/reflection/runReflectionFlow.ts',
+    cliRuntimeReachability: WORKFLOW_REJECT_RUNTIME_REACHABILITY,
   },
 
   // --- LaTeXdiff -------------------------------------------------------------
@@ -279,6 +335,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     store: 'globalState',
     hosts: ['cli'],
     cliConsumer: 'src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts',
+    cliRuntimeReachability: OPENAI_WEBSOCKET_RUNTIME_REACHABILITY,
   },
 ] as const;
 

--- a/src/test-kernel/shared/stateSettings.vitest.ts
+++ b/src/test-kernel/shared/stateSettings.vitest.ts
@@ -45,6 +45,9 @@ const VALID_STORES: ReadonlySet<SettingStore> = new Set<SettingStore>([
   'globalState',
 ]);
 
+const CLI_RUNTIME_COMMAND_PATTERN =
+  /^texra\s+(?:chat|run|agents run|multi-agent run|orchestrate)\b/;
+
 const CLASS_D_KEY_PATTERN = /migrated|version|onboarding|history|cache/i;
 
 /** Expected default-when-absent for each catalog key, from the real getters. */
@@ -90,6 +93,38 @@ describe('state settings catalog', () => {
       assert.ok(
         existsSync(resolve(process.cwd(), entry.cliConsumer as string)),
         `${entry.key} cliConsumer does not exist: ${entry.cliConsumer}`,
+      );
+    }
+  });
+
+  it('every CLI-host entry documents a runtime-reachability path', () => {
+    for (const entry of STATE_SETTINGS) {
+      if (!entry.hosts.includes('cli')) {
+        assert.equal(
+          entry.cliRuntimeReachability,
+          undefined,
+          `${entry.key} documents CLI reachability but is not CLI-hosted`,
+        );
+        continue;
+      }
+
+      const reachability = entry.cliRuntimeReachability;
+      assert.ok(
+        reachability,
+        `${entry.key} is surfaced to the CLI but declares no cliRuntimeReachability`,
+      );
+      assert.match(
+        reachability.command,
+        CLI_RUNTIME_COMMAND_PATTERN,
+        `${entry.key} reachability command is not a recognized runtime command: ${reachability.command}`,
+      );
+      assert.ok(
+        entry.cliConsumer,
+        `${entry.key} reachability path cannot be checked without cliConsumer`,
+      );
+      assert.ok(
+        reachability.through.includes(entry.cliConsumer),
+        `${entry.key} reachability path must mention its cliConsumer ${entry.cliConsumer}`,
       );
     }
   });

--- a/src/test-kernel/shared/stateSettings.vitest.ts
+++ b/src/test-kernel/shared/stateSettings.vitest.ts
@@ -48,6 +48,13 @@ const VALID_STORES: ReadonlySet<SettingStore> = new Set<SettingStore>([
 const CLI_RUNTIME_COMMAND_PATTERN =
   /^texra\s+(?:chat|run|agents run|multi-agent run|orchestrate)\b/;
 
+function reachabilitySegments(through: string): string[] {
+  return through
+    .split('->')
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+}
+
 const CLASS_D_KEY_PATTERN = /migrated|version|onboarding|history|cache/i;
 
 /** Expected default-when-absent for each catalog key, from the real getters. */
@@ -118,14 +125,22 @@ describe('state settings catalog', () => {
         CLI_RUNTIME_COMMAND_PATTERN,
         `${entry.key} reachability command is not a recognized runtime command: ${reachability.command}`,
       );
+      const cliConsumer = entry.cliConsumer;
       assert.ok(
-        entry.cliConsumer,
+        cliConsumer,
         `${entry.key} reachability path cannot be checked without cliConsumer`,
       );
+      const throughSegments = reachabilitySegments(reachability.through);
       assert.ok(
-        reachability.through.includes(entry.cliConsumer),
-        `${entry.key} reachability path must mention its cliConsumer ${entry.cliConsumer}`,
+        throughSegments.includes(cliConsumer),
+        `${entry.key} reachability path must include its cliConsumer as a path segment: ${cliConsumer}`,
       );
+      for (const segment of throughSegments) {
+        assert.ok(
+          existsSync(resolve(process.cwd(), segment)),
+          `${entry.key} reachability path segment does not exist: ${segment}`,
+        );
+      }
     }
   });
 


### PR DESCRIPTION
## Summary

Fixes #6611.

This PR strengthens the state-backed settings catalog guardrail for settings marked with `hosts: ['cli']`. The existing catalog check proved only that `cliConsumer` named an existing file. This adds explicit runtime-reachability evidence to each CLI-hosted setting: a representative CLI command and a short trace from that command surface to the consumer file.

The new test requires every CLI-hosted entry to provide this evidence, checks that the command is a recognized runtime command (`texra chat`, `texra run`, `texra agents run`, `texra multi-agent run`, or `texra orchestrate`), and checks that the trace mentions the declared `cliConsumer`. As a result, flipping a setting to `hosts: ['cli']` now requires documenting how the setting is actually reached in the CLI runtime, not merely naming a file that exists.

This is intentionally metadata plus a catalog invariant; it does not change runtime behavior.

## Validation

- `corepack pnpm exec prettier --write src/shared/schemas/stateSettings.ts src/test-kernel/shared/stateSettings.vitest.ts`
- `npm test -- src/test-kernel/shared/stateSettings.vitest.ts src/test-kernel/cli/ConfigForm.vitest.mts`
- `git diff --check`
- `npm run typecheck`
- `npm run lint` (0 errors; existing warnings only)
- `npm run compile:fast`

## Conflict check

The large `codex/decouple-ui-agent-core` branch does not touch the two files changed here, so this issue is not being postponed for that branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Catalog metadata and test guardrails only; no runtime or settings read/write behavior changes.
> 
> **Overview**
> CLI-hosted entries in the state settings catalog must now document **how** a setting is reached at runtime, not only which file consumes it.
> 
> Adds a `CliRuntimeReachability` shape (`command` + `through` trace) on `StateSettingEntry` and fills it for every setting with `hosts: ['cli']` (git author/worktree, workflow compile/reject, OpenAI WebSocket). The trace is review metadata only—it does not wire or execute anything.
> 
> A new catalog guardrail test requires CLI-hosted rows to declare reachability, use a recognized `texra …` command surface, include `cliConsumer` in the `through` path, and reference existing repo files for each path segment. Non-CLI entries must not declare reachability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e83f32267ed98a12a456cfdb262fb9610cf69ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->