### PR TITLE
fix(settings): drop duplicate provider key buttons from Model Selection

### DIFF
--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -6,7 +6,6 @@ import { customElement, property, state } from 'lit/decorators.js';
 
 // Local imports - shared styles
 import { commonViewStyles, designTokens } from '@shared/styles';
-import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import {
   renderSetStatusIcon,
@@ -38,7 +37,7 @@ import {
   type ReasoningLevel,
 } from '@shared/schemas/settingsViewMessages';
 import { profileViewStyles } from './styles';
-import { ModelSelectionEvents, ProviderKeyEvents } from './events';
+import { ModelSelectionEvents } from './events';
 import { resolveProviderKeyRows } from './providerKeyRows';
 import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
@@ -271,38 +270,21 @@ export class ModelSelectionList extends LitElement {
     const enabledCount = group.current.filter((m) => m.enabled).length;
     const totalCount = group.current.length;
     const keyStatus = this.getProviderKeyStatus(group.provider);
-    const providerKeyActions = keyStatus
+    // Key status is read-only here. Setting, fetching, and removing keys all
+    // live in the API Configuration section above; mirroring those actions in
+    // this list produced two competing key UIs. Labels match that section.
+    const providerKeyStatus = keyStatus
       ? html`
           <span class="provider-group-key-status">
             ${renderSetStatusIcon({
               status: keyStatus.status,
               title: 'Key set',
               fallbacks: {
-                env: { label: 'Env key' },
-                'not-set': { label: 'No key' },
+                env: { label: 'Env' },
+                'not-set': { label: 'Not set' },
               },
             })}
           </span>
-          ${renderLabeledActionButton({
-            icon: 'key',
-            text: 'Set key',
-            label: `Set ${group.displayName} API key`,
-            className: 'provider-group-key-button',
-            onClick: () =>
-              this.dispatchEvent(
-                ProviderKeyEvents.setKey({ provider: group.provider }),
-              ),
-          })}
-          ${renderLabeledActionButton({
-            icon: 'arrow-up-right-from-square',
-            text: 'Get key',
-            label: `Get ${group.displayName} API key`,
-            className: 'provider-group-key-button',
-            onClick: () =>
-              this.dispatchEvent(
-                ProviderKeyEvents.openKeyUrl({ provider: group.provider }),
-              ),
-          })}
         `
       : nothing;
 
@@ -323,7 +305,7 @@ export class ModelSelectionList extends LitElement {
               ${enabledCount}/${totalCount} enabled
             </span>
           </button>
-          <div class="provider-group-actions">${providerKeyActions}</div>
+          <div class="provider-group-actions">${providerKeyStatus}</div>
         </div>
         ${isExpanded
           ? html`

--- a/packages/extension/src/settingsView/frontend/components/profile/styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/styles.ts
@@ -310,8 +310,8 @@ export const profileViewStyles: CSSResult = css`
   /*
    * No hover on .provider-group-header itself — only the inner
    * .provider-group-toggle button is the click target. Hovering the
-   * surrounding header (which also contains key-action buttons) would
-   * misleadingly suggest the whole row is clickable.
+   * surrounding header (which also holds the read-only key-status badge)
+   * would misleadingly suggest the whole row is clickable.
    */
 
   .provider-group-toggle {
@@ -374,10 +374,6 @@ export const profileViewStyles: CSSResult = css`
   }
 
   .provider-group-key-status {
-    flex-shrink: 0;
-  }
-
-  .provider-group-key-button {
     flex-shrink: 0;
   }
 

--- a/src/test-kernel/settings/ModelSelectionProviderKeys.vitest.ts
+++ b/src/test-kernel/settings/ModelSelectionProviderKeys.vitest.ts
@@ -25,13 +25,13 @@ const deepseekModel: ModelSelectionItem = {
   isFast: true,
 };
 
-describe('ModelSelectionList provider key actions', () => {
+describe('ModelSelectionList provider key status', () => {
   useLitComponentTestDom(
     () =>
       import('@settingsView/frontend/components/profile/ModelSelectionList'),
   );
 
-  it('shows direct API-key actions in model provider groups before profile load', async () => {
+  it('shows a read-only API-key status in model provider groups before profile load', async () => {
     const list = document.createElement(
       'model-selection-list',
     ) as ModelSelectionListElement;
@@ -41,21 +41,18 @@ describe('ModelSelectionList provider key actions', () => {
     await list.updateComplete;
 
     const shadow = list.shadowRoot!;
-    expect(shadow.textContent).toContain('No key');
+    expect(shadow.textContent).toContain('Not set');
+    expect(shadow.textContent).not.toContain('No key');
 
     const setKeyButton = shadow.querySelector<HTMLElement>(
       '[title="Set DeepSeek API key"]',
     );
-    expect(setKeyButton).toBeTruthy();
+    const getKeyButton = shadow.querySelector<HTMLElement>(
+      '[title="Get DeepSeek API key"]',
+    );
 
-    const events: unknown[] = [];
-    list.addEventListener('provider-key-set', (event) => {
-      events.push((event as CustomEvent).detail);
-    });
-
-    setKeyButton!.click();
-
-    expect(events).toEqual([{ provider: 'deepseek' }]);
+    expect(setKeyButton).toBeNull();
+    expect(getKeyButton).toBeNull();
   });
 
   it('shows helper model labels together with short ids', async () => {


### PR DESCRIPTION
## Why

The Models tab showed **Set key / Get key** controls in two places:

- **API Configuration** — the provider table that also owns **Remove key** and per-provider settings (streaming, custom endpoint). The real key manager.
- **Model Selection** — every provider group mirrored *Set key / Get key* as an inline shortcut.

Both dispatched the same `ProviderKeyEvents` and read the same `providerKeyStatuses`, so they read as two competing key UIs. Mismatched badge wording made it worse: API Configuration said **Not set** while Model Selection said **No key** for the same provider, suggesting a missed setup step.

## What

- Remove the duplicate **Set key / Get key** buttons from each provider group in `ModelSelectionList`. Model Selection now shows only a **read-only key-status badge** per provider (check / `Env` / `Not set`).
- Align the badge wording with API Configuration (`Env`, `Not set`).
- API Configuration is now the single home for setting, fetching, and removing keys. Disabled model rows already point users there ("configure it in API Configuration").
- Drop the now-unused imports (`renderLabeledActionButton`, `ProviderKeyEvents`), the dead `.provider-group-key-button` CSS rule, and refresh the stale header-hover comment.

No behavior change to key storage or the API Configuration panel.

## Verified

- `npm run typecheck` passes (exit 0)
- `eslint` on both changed files is clean (catches the removed imports)
- `prettier` unchanged; pre-commit format hook passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Settings UI-only change; key storage and API Configuration behavior are unchanged.
> 
> **Overview**
> Removes **Set key** and **Get key** from each provider group in **Model Selection**, leaving a **read-only** key-status badge so **API Configuration** is the only place to set, fetch, or remove keys.
> 
> Badge copy now matches that section (**Env**, **Not set** instead of **No key**). Cleans up unused imports, the `.provider-group-key-button` style, and related comments; tests assert the buttons are gone and the new labels show.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74efe20ca3d6a7f0b1c0ae390a900a237ce1a4bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->