### PR TITLE
docs(review): ban duplicate UI controls (one home per action)

### DIFF
--- a/.claude/skills/code-review/references/review-checklist.md
+++ b/.claude/skills/code-review/references/review-checklist.md
@@ -51,7 +51,7 @@ Design rules in `CLAUDE.md` → "Schema and Type Guidelines" / "Backward Compati
 - **Webview providers/handlers not extending `BaseViewContentProvider` / `BaseViewMessageHandler`** (`src/common/webview/`).
 - **String literals for webview commands** → constants in `src/common/webview/commands.ts`.
 - **New shared module path referenced without updating `localResourceRoots`** → 401 at runtime.
-- **The same action exposed from two UI surfaces** → one home per action. Flag an `*Events.<name>(` creator dispatched from 2+ components (e.g. `ProviderKeyEvents.setKey`), the same config/state/message key edited in 2+ tabs or views, or a command and a webview button wired to one effect. Secondary surfaces show **read-only status**, not a second control. Legit: global default vs per-item override; a command plus a single UI button for one stable action. See `CLAUDE.md` → "Duplicate UI Controls".
+- **The same action exposed from two UI surfaces** → one home per action. Flag an `*Events.<name>(` creator dispatched from 2+ components, the same config/state/message key edited in 2+ tabs or views, or multiple UI controls wired to the same command/effect. Secondary surfaces show **read-only status**, not a second control. Legit: global default vs per-item override; a command plus a single UI button for one stable action. See `CLAUDE.md` → "Duplicate UI Controls".
 
 ## 6. Error handling and logging
 

--- a/.claude/skills/code-review/references/review-checklist.md
+++ b/.claude/skills/code-review/references/review-checklist.md
@@ -51,6 +51,7 @@ Design rules in `CLAUDE.md` → "Schema and Type Guidelines" / "Backward Compati
 - **Webview providers/handlers not extending `BaseViewContentProvider` / `BaseViewMessageHandler`** (`src/common/webview/`).
 - **String literals for webview commands** → constants in `src/common/webview/commands.ts`.
 - **New shared module path referenced without updating `localResourceRoots`** → 401 at runtime.
+- **The same action exposed from two UI surfaces** → one home per action. Flag an `*Events.<name>(` creator dispatched from 2+ components (e.g. `ProviderKeyEvents.setKey`), the same config/state/message key edited in 2+ tabs or views, or a command and a webview button wired to one effect. Secondary surfaces show **read-only status**, not a second control. Legit: global default vs per-item override; a command plus a single UI button for one stable action. See `CLAUDE.md` → "Duplicate UI Controls".
 
 ## 6. Error handling and logging
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,6 +276,14 @@ Never compensate for data model problems at render time. Renderers should only t
 
 **Fix:** Store data once at the source with all metadata (timestamps, IDs). If renderers need to generate or deduplicate, the upstream code path is missing data.
 
+### Duplicate UI Controls (Anti-pattern)
+
+One home per user action. Don't surface the same action (a dispatched event, a
+config/state write, or a command) from two controls; competing controls confuse
+users and drift out of sync. Secondary surfaces show read-only status, never a
+second control. Legit: a global default vs a per-item override, or one action as
+a command plus a single UI button. Grep and details: code-review checklist § 5.
+
 ### Terminal UI (CLI / Ink) discipline
 
 The `texra` CLI ships an Ink (React) TUI under `packages/cli/src/chat/tui/`.


### PR DESCRIPTION
## Why

Follow-up to #6751, which removed the duplicated provider **Set key / Get key** buttons (the same `ProviderKeyEvents` dispatched from both the API Configuration table and the Model Selection groups). This adds a guardrail so the "two competing controls for one action" pattern gets caught next time, at write time and review time.

## What

- **Code-review checklist § 5** (Webview / render-time): a new rule to flag
  - an `*Events.<name>(` creator dispatched from 2+ components,
  - the same config / state / message key edited in 2+ tabs or views, or
  - a VS Code command and a webview button wired to one effect.

  Secondary surfaces show **read-only status**, not a second control. Legit exceptions noted (global default vs per-item override; a command plus one UI button for one stable action).
- **CLAUDE.md**: a compact "Duplicate UI Controls (Anti-pattern)" note for write-time guidance. Kept terse on purpose (CLAUDE.md is always in context); the grep and detail live in the checklist.

Docs only. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to review checklist and CLAUDE.md; no runtime or product behavior.
> 
> **Overview**
> Documents the **one home per user action** rule so duplicate controls get caught at write time and in `/review`, following #6751’s removal of duplicated provider key buttons.
> 
> **Code-review checklist § 5** gains a webview/render-time check: flag the same action from two surfaces (e.g. `*Events.<name>(` from multiple components, the same config/state/message key in multiple tabs, or several controls wired to one effect). Secondary UI should be **read-only status**; allowed exceptions are called out (global vs per-item override; one command plus a single button).
> 
> **CLAUDE.md** adds a short **Duplicate UI Controls** anti-pattern under render-time guidance and points reviewers to checklist § 5 for grep detail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64188c45b4ac3408c736eb90d0e37286d06be449. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->