### PR TITLE
fix(commands): drop duplicate settings-dashboard command

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1214,12 +1214,6 @@
         "icon": "$(gear)"
       },
       {
-        "command": "texra.showSettingsView",
-        "title": "Show Settings",
-        "category": "TeXRA",
-        "icon": "$(gear)"
-      },
-      {
         "command": "texra.agentReview.run",
         "title": "Find Issues (Agent Review)",
         "shortTitle": "Find Issues",
@@ -1791,10 +1785,6 @@
         },
         {
           "command": "texra.showDashboard",
-          "when": "texra.activated"
-        },
-        {
-          "command": "texra.showSettingsView",
           "when": "texra.activated"
         }
       ]

--- a/packages/extension/resources/tool_use_agents/setup.yaml
+++ b/packages/extension/resources/tool_use_agents/setup.yaml
@@ -244,7 +244,7 @@ prompts:
       - Tools dashboard: `texra.showTools`
       - Git author & GitHub token: `texra.showGitSettings`
       - Native VS Code settings (search-filterable): `texra.openSettings`
-      - Full TeXRA dashboard: `texra.showSettingsView`
+      - Full TeXRA dashboard: `texra.showDashboard`
 
     Then tell the user which control to click. The TeXRA dashboard tabs
     embed the same UI surfaces a power user would use, so this is also

--- a/packages/extension/src/commands/extensionCommandSurface.ts
+++ b/packages/extension/src/commands/extensionCommandSurface.ts
@@ -111,80 +111,86 @@ const CHATGPT_SIGN_IN_CHANNEL = 'ChatGptSubscription';
 /**
  * Subset of `CommandId` whose registration is now driven by the shared
  * `dispatchCommandFromRegistry` helper. Any new entry must also exist in
- * `commandCatalog` so the shared catalog stays the source of truth.
+ * `commandCatalog` so the shared catalog stays the source of truth. Hidden
+ * compatibility aliases are the exception: they stay callable by command id
+ * but are intentionally absent from the public command catalog and manifest.
  *
  * The desktop registry (`packages/desktop/src/desktopCommandSurface.ts`)
  * dispatches the same IDs through the same helper — this is deliberate
  * so adding a new view-routing command is a single registry entry per
  * host, not a parallel `vscode.commands.registerCommand` call site.
  */
-export type ExtensionRegistryCommandId = Extract<
-  CommandId,
-  | 'texra.showDashboard'
-  | 'texra.showMemory'
-  | 'texra.showAgentHistory'
-  | 'texra.showModels'
-  | 'texra.showAgents'
-  | 'texra.showTools'
-  | 'texra.showMultiAgent'
-  | 'texra.showGitSettings'
-  | 'texra.openSettings'
-  | 'texra.mainView.reset'
-  | 'texra.cleanOutput'
-  | 'texra.cleanBuild'
-  | 'texra.indentTeX'
-  | 'texra.auth.signIn'
-  | 'texra.auth.chatgpt.signIn'
-  | 'texra.auth.signOut'
-  | 'texra.auth.viewProfile'
-  | 'texra.runSetupAssistant'
-  | 'texra.openGettingStarted'
-  | 'texra.createSampleProject'
-  | 'texra.downloadArXivSource'
-  | 'texra.testConnection'
-  | 'texra.testAgentLoading'
-  | 'texra.loadSpecificAgent'
-  | 'texra.openProgressViewInTab'
-  | 'texra.openDoc'
-  | 'texra.stopAgent'
-  | 'texra.compactResponse'
-  // Batch 2 (#3775) — no-arg host-context commands. These read from
-  // the active editor or fixed UI surfaces; their args are not
-  // serializable, so they ride the legacy no-arg handler shape.
-  | 'texra.parseXml'
-  | 'texra.parseYaml'
-  | 'texra.testTextEditor'
-  | 'texra.indentCurrentTeX'
-  | 'texra.applyReplacements'
-  | 'texra.fixCompilation'
-  | 'texra.getTeXCount'
-  | 'texra.countPdfPages'
-  | 'texra.showLinterMessages'
-  | 'texra.countLinterMessages'
-  | 'texra.extractFigurePaths'
-  // Batch 3 (#3781) — additional no-arg commands. Each handler runs
-  // its own user prompt internally (file picker, input box) so the
-  // VS Code call site doesn't pass arguments. The `cloneOverleafProject`
-  // entry needs `vscode.ExtensionContext` for `secrets` access; that's
-  // captured as a closure inside the action factory below.
-  | 'texra.encodeImageToBase64'
-  | 'texra.convertPdfToImages'
-  | 'texra.extractTikzFigures'
-  | 'texra.compileTikzFigures'
-  | 'texra.cloneOverleafProject'
-  // Batch 4 (#3781) — settings/api/agent surface follow-ups. The
-  // typed handlers carry a Zod schema for their argument so the dispatcher
-  // can parse the optional provider / category / inPlace / config flag
-  // before the handler runs. The remaining no-arg entries (toggleView,
-  // showImportOptions, removeApiKey) drive interactive UI flows internally.
-  | 'texra.removeApiKey'
-  | 'texra.showImportOptions'
-  | 'texra.toggleView'
-  | 'texra.showProgressView'
-  | 'texra.setApiKey'
-  | 'texra.createAgentWithAI'
-  | 'texra.execute'
->;
+type HiddenExtensionRegistryCommandId = 'texra.showSettingsView';
+
+export type ExtensionRegistryCommandId =
+  | Extract<
+      CommandId,
+      | 'texra.showDashboard'
+      | 'texra.showMemory'
+      | 'texra.showAgentHistory'
+      | 'texra.showModels'
+      | 'texra.showAgents'
+      | 'texra.showTools'
+      | 'texra.showMultiAgent'
+      | 'texra.showGitSettings'
+      | 'texra.openSettings'
+      | 'texra.mainView.reset'
+      | 'texra.cleanOutput'
+      | 'texra.cleanBuild'
+      | 'texra.indentTeX'
+      | 'texra.auth.signIn'
+      | 'texra.auth.chatgpt.signIn'
+      | 'texra.auth.signOut'
+      | 'texra.auth.viewProfile'
+      | 'texra.runSetupAssistant'
+      | 'texra.openGettingStarted'
+      | 'texra.createSampleProject'
+      | 'texra.downloadArXivSource'
+      | 'texra.testConnection'
+      | 'texra.testAgentLoading'
+      | 'texra.loadSpecificAgent'
+      | 'texra.openProgressViewInTab'
+      | 'texra.openDoc'
+      | 'texra.stopAgent'
+      | 'texra.compactResponse'
+      // Batch 2 (#3775) — no-arg host-context commands. These read from
+      // the active editor or fixed UI surfaces; their args are not
+      // serializable, so they ride the legacy no-arg handler shape.
+      | 'texra.parseXml'
+      | 'texra.parseYaml'
+      | 'texra.testTextEditor'
+      | 'texra.indentCurrentTeX'
+      | 'texra.applyReplacements'
+      | 'texra.fixCompilation'
+      | 'texra.getTeXCount'
+      | 'texra.countPdfPages'
+      | 'texra.showLinterMessages'
+      | 'texra.countLinterMessages'
+      | 'texra.extractFigurePaths'
+      // Batch 3 (#3781) — additional no-arg commands. Each handler runs
+      // its own user prompt internally (file picker, input box) so the
+      // VS Code call site doesn't pass arguments. The `cloneOverleafProject`
+      // entry needs `vscode.ExtensionContext` for `secrets` access; that's
+      // captured as a closure inside the action factory below.
+      | 'texra.encodeImageToBase64'
+      | 'texra.convertPdfToImages'
+      | 'texra.extractTikzFigures'
+      | 'texra.compileTikzFigures'
+      | 'texra.cloneOverleafProject'
+      // Batch 4 (#3781) — settings/api/agent surface follow-ups. The
+      // typed handlers carry a Zod schema for their argument so the dispatcher
+      // can parse the optional provider / category / inPlace / config flag
+      // before the handler runs. The remaining no-arg entries (toggleView,
+      // showImportOptions, removeApiKey) drive interactive UI flows internally.
+      | 'texra.removeApiKey'
+      | 'texra.showImportOptions'
+      | 'texra.toggleView'
+      | 'texra.showProgressView'
+      | 'texra.setApiKey'
+      | 'texra.createAgentWithAI'
+      | 'texra.execute'
+    >
+  | HiddenExtensionRegistryCommandId;
 
 /*
  * Duplicate-registration audit (#3787 follow-up):
@@ -352,6 +358,7 @@ export function createExtensionCommandActions(
 
 const EXTENSION_COMMAND_HANDLERS = {
   'texra.showDashboard': (actions) => awaitTrue(actions.showSettings()),
+  'texra.showSettingsView': (actions) => awaitTrue(actions.showSettings()),
   'texra.showMemory': (actions) =>
     awaitTrue(actions.showSettings(SETTINGS_TAB.MEMORY)),
   'texra.showAgentHistory': (actions) =>

--- a/packages/extension/src/commands/extensionCommandSurface.ts
+++ b/packages/extension/src/commands/extensionCommandSurface.ts
@@ -120,7 +120,6 @@ const CHATGPT_SIGN_IN_CHANNEL = 'ChatGptSubscription';
  */
 export type ExtensionRegistryCommandId = Extract<
   CommandId,
-  | 'texra.showSettingsView'
   | 'texra.showDashboard'
   | 'texra.showMemory'
   | 'texra.showAgentHistory'
@@ -352,7 +351,6 @@ export function createExtensionCommandActions(
 }
 
 const EXTENSION_COMMAND_HANDLERS = {
-  'texra.showSettingsView': (actions) => awaitTrue(actions.showSettings()),
   'texra.showDashboard': (actions) => awaitTrue(actions.showSettings()),
   'texra.showMemory': (actions) =>
     awaitTrue(actions.showSettings(SETTINGS_TAB.MEMORY)),

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -418,12 +418,6 @@
         },
         {
           "category": "TeXRA",
-          "command": "texra.showSettingsView",
-          "icon": "$(gear)",
-          "title": "Show Settings"
-        },
-        {
-          "category": "TeXRA",
           "command": "texra.agentReview.run",
           "icon": "$(search)",
           "shortTitle": "Find Issues",
@@ -1560,10 +1554,6 @@
           },
           {
             "command": "texra.showDashboard",
-            "when": "texra.activated"
-          },
-          {
-            "command": "texra.showSettingsView",
             "when": "texra.activated"
           }
         ],

--- a/src/shared/commands/catalog.ts
+++ b/src/shared/commands/catalog.ts
@@ -375,12 +375,6 @@ export const commandCatalog = [
     icon: '$(gear)',
   },
   {
-    id: 'texra.showSettingsView',
-    title: 'Show Settings',
-    category: 'TeXRA',
-    icon: '$(gear)',
-  },
-  {
     id: 'texra.agentReview.run',
     title: 'Find Issues (Agent Review)',
     shortTitle: 'Find Issues',

--- a/src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts
+++ b/src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts
@@ -23,6 +23,10 @@ import { StreamTabIdSchema } from '@shared/schemas/identifiers';
 import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
 
 const HANDLERS = {
+  'texra.showDashboard': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.showSettings()),
+  'texra.showSettingsView': (actions: ExtensionCommandActions) =>
+    awaitTrue(actions.showSettings()),
   'texra.cleanOutput': (actions: ExtensionCommandActions) =>
     awaitTrue(actions.cleanOutput()),
   'texra.cleanBuild': (actions: ExtensionCommandActions) =>
@@ -208,6 +212,8 @@ function makeActions(): ExtensionCommandActions {
 
 describe('extension command surface — newly migrated commands (#3771, #3775, #3781)', () => {
   it.each([
+    ['texra.showDashboard', 'showSettings'],
+    ['texra.showSettingsView', 'showSettings'],
     ['texra.cleanOutput', 'cleanOutput'],
     ['texra.cleanBuild', 'cleanBuild'],
     ['texra.indentTeX', 'indentTeX'],

--- a/src/tools/setup/ConfigTools.ts
+++ b/src/tools/setup/ConfigTools.ts
@@ -102,7 +102,7 @@ export class ReadConfigTool extends defineTool({
   name: 'read_config',
   description: `Read the effective value of a TeXRA configuration key.
 
-Accepts any key starting with \`texra.\`. Returns the current resolved value (workspace value if set, else user, else default). Use this when teaching the user what a setting controls — read first, explain, then propose a change with \`update_config\`. For settings outside this tool's reach (which is most of them), open the settings UI via \`invoke_command\` with \`texra.openSettings\` or \`texra.showSettingsView\`.`,
+Accepts any key starting with \`texra.\`. Returns the current resolved value (workspace value if set, else user, else default). Use this when teaching the user what a setting controls — read first, explain, then propose a change with \`update_config\`. For settings outside this tool's reach (which is most of them), open the settings UI via \`invoke_command\` with \`texra.openSettings\` or \`texra.showDashboard\`.`,
   schema: ReadConfigInputSchema,
 }) {
   protected async execute(input: ReadConfigInput): Promise<ToolResult> {
@@ -145,7 +145,7 @@ Use this AFTER calling \`read_config\` and explaining to the user what the setti
 Allowlisted keys:
 ${describeAllowlist()}
 
-Anything outside this list must be changed through the settings UI — invoke \`texra.openSettings\` (native VS Code Settings, filtered to texra.*) or \`texra.showSettingsView\` (TeXRA dashboard).`,
+Anything outside this list must be changed through the settings UI — invoke \`texra.openSettings\` (native VS Code Settings, filtered to texra.*) or \`texra.showDashboard\` (TeXRA dashboard).`,
   schema: UpdateConfigInputSchema,
 }) {
   protected async execute(input: UpdateConfigInput): Promise<ToolResult> {

--- a/src/tools/setup/InvokeCommandTool.ts
+++ b/src/tools/setup/InvokeCommandTool.ts
@@ -27,7 +27,6 @@ const ALLOWED_COMMAND_IDS = [
   AUTH_COMMANDS.SIGN_IN,
   AUTH_COMMANDS.VIEW_PROFILE,
   // Settings dashboard tabs
-  'texra.showSettingsView',
   'texra.showDashboard',
   'texra.showMemory',
   'texra.showAgentHistory',


### PR DESCRIPTION
## Why

From the deep UI-overlap audit (follow-up to #6751 / #6752): the command palette listed **two** TeXRA commands that open the exact same settings dashboard.

- `texra.showDashboard` ("Show Settings Dashboard")
- `texra.showSettingsView` ("Show Settings")

Both dispatch the byte-identical handler `actions.showSettings()` (`extensionCommandSurface.ts:355-356`). Two differently-labeled palette entries for one effect is precisely the "one home per action" rule added in #6752.

## What

Consolidate onto **`texra.showDashboard`** (already the id wired into the toolbar / view-title menus, and already present in the agent command catalog and invoke allowlist). Remove `texra.showSettingsView`:

- `package.json` — the duplicate command definition and its `commandPalette` entry
- `extensionCommandSurface.ts` — its handler and `ExtensionRegistryCommandId` union member
- `src/shared/commands/catalog.ts` — its catalog entry
- Setup-agent references repointed to `texra.showDashboard`: invoke allowlist (`InvokeCommandTool.ts`), `read_config` / `update_config` prompt text (`ConfigTools.ts`), and `setup.yaml`

The shared implementation `settingsViewProvider.showSettingsView()` (the method) is untouched; only the redundant command id is removed.

## Verified

- `tsc --noEmit` (root `src/`) — exit 0
- `tsc --noEmit` (packages/extension) — exit 0
- `grep` confirms no remaining `texra.showSettingsView` references; `package.json` re-parsed as valid JSON
- No keybinding bound to the removed id

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Command-id and documentation cleanup only; behavior unchanged and the old id remains callable via the registry alias.
> 
> **Overview**
> Removes the duplicate **Show Settings** palette entry (`texra.showSettingsView`) so opening the TeXRA settings dashboard has a single public home: **`texra.showDashboard`** ("Show Settings Dashboard"), which already drives the toolbar and agent flows.
> 
> The redundant id is stripped from **`package.json`** (command + command palette), **`commandCatalog`**, and the extension manifest snapshot. Setup-agent docs and tools (`setup.yaml`, `read_config` / `update_config` prompts, `invoke_command` allowlist) now point agents at `texra.showDashboard` instead.
> 
> **`texra.showSettingsView` stays registered** as a hidden compatibility alias (same `actions.showSettings()` handler) so existing `executeCommand` callers still work, but it is intentionally omitted from the public catalog and VS Code manifest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e43baa8c6b6e13c86ec46c0197adfd68e450663d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->