### PR TITLE
fix(latex): resolve \input and \bibliography for subfolder documents

### DIFF
--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -22,6 +22,7 @@ import {
   createWorkspaceLocation,
   flexibleFS,
   TaskRunFileService,
+  WorkspaceFS,
 } from '@utils/files';
 import { checkToolInstalled } from '@utils/system';
 import { getComparablePath } from '@utils/files/taskRunStorage';
@@ -59,6 +60,22 @@ export class LatexDiffManager {
       .fs.realPath(location.absolutePath)
       .catch(() => location.absolutePath);
     return path.dirname(resolved);
+  }
+
+  /**
+   * Directory of the document's live workspace source. `resolveBaseFilesForDiff`
+   * rewrites the base to its `executions/<id>/original/<rel>` snapshot, which
+   * holds only the snapshotted `.tex` files — not the `figures/` and `.bib`
+   * dependencies the diff still `\input`s. Map the workspace-relative path back
+   * onto the workspace root so the diff compile finds them; fall back to the
+   * file's own directory for external bases or when no workspace is open.
+   */
+  private resolveWorkspaceSourceDir(location: FileLocation): string {
+    const workspaceRoot = WorkspaceFS.getPath();
+    if (workspaceRoot && location.kind !== 'external') {
+      return path.join(workspaceRoot, path.dirname(location.relativePath));
+    }
+    return path.dirname(location.absolutePath);
   }
 
   private logLatexdiffResult(
@@ -376,10 +393,10 @@ export class LatexDiffManager {
       ),
     );
     // The diff `.tex` is written to `diff/r{round}/` rather than alongside the
-    // document's `\input`/`\bibliography` targets, so add the original source
-    // directory to the search path; otherwise `\input{figures/…}` and
+    // document's `\input`/`\bibliography` targets, so add the live workspace
+    // source directory to the search path; otherwise `\input{figures/…}` and
     // `\bibliography{…}` fail to resolve when the source lives in a subfolder.
-    const sourceDir = await this.getWorkingDirectory(referenceLocation);
+    const sourceDir = this.resolveWorkspaceSourceDir(referenceLocation);
     const ok = await compileLatex2Pdf(diffLocation, {
       channel: this.streamId,
       outputDirectory: buildDir,

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -63,17 +63,21 @@ export class LatexDiffManager {
   }
 
   /**
-   * Directory of the document's live workspace source. `resolveBaseFilesForDiff`
-   * rewrites the base to its `executions/<id>/original/<rel>` snapshot, which
-   * holds only the snapshotted `.tex` files — not the `figures/` and `.bib`
-   * dependencies the diff still `\input`s. Map the workspace-relative path back
-   * onto the workspace root so the diff compile finds them; fall back to the
-   * file's own directory for external bases or when no workspace is open.
+   * Directory of the document's live workspace source — the one place that
+   * carries the `figures/` and `.bib` dependencies the diff still `\input`s.
+   * The base location is never the live workspace file: `resolveBaseFilesForDiff`
+   * rewrites a round diff base to its `executions/<id>/original/<rel>` snapshot,
+   * and a between-round diff base is the prior round's output at `r<N>/<rel>`.
+   * Both keep the path workspace-relative apart from a leading run-storage
+   * `r<N>/` round segment, so strip that and map onto the workspace root; fall
+   * back to the file's own directory for external bases or when no workspace is
+   * open.
    */
   private resolveWorkspaceSourceDir(location: FileLocation): string {
     const workspaceRoot = WorkspaceFS.getPath();
     if (workspaceRoot && location.kind !== 'external') {
-      return path.join(workspaceRoot, path.dirname(location.relativePath));
+      const workspaceRelative = location.relativePath.replace(/^r\d+[/\\]/, '');
+      return path.join(workspaceRoot, path.dirname(workspaceRelative));
     }
     return path.dirname(location.absolutePath);
   }

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -66,12 +66,18 @@ export class LatexDiffManager {
    * Directory of the document's live workspace source — the one place that
    * carries the `figures/` and `.bib` dependencies the diff still `\input`s.
    * The base location is never the live workspace file: `resolveBaseFilesForDiff`
-   * rewrites a round diff base to its `executions/<id>/original/<rel>` snapshot,
-   * and a between-round diff base is the prior round's output at `r<N>/<rel>`.
-   * Both keep the path workspace-relative apart from a leading run-storage
-   * `r<N>/` round segment, so strip that and map onto the workspace root; fall
-   * back to the file's own directory for external bases or when no workspace is
-   * open.
+   * (`snapshotResolution.ts`) rewrites a round diff base to its
+   * `executions/<id>/original/<rel>` snapshot, and a between-round diff base is
+   * the prior round's output at `r<N>/<rel>`. Both keep the path
+   * workspace-relative apart from a leading run-storage `r<N>/` round segment,
+   * so strip that and map onto the workspace root; fall back to the file's own
+   * directory for external bases or when no workspace is open.
+   *
+   * Assumption: a leading `r<digits>/` segment is a run-storage round prefix,
+   * not a real workspace folder. A document whose live source genuinely sits
+   * under a top-level `r<digits>/` folder (e.g. a "revision 1" `r1/`) would be
+   * mis-stripped — unavoidable with a relativePath-only heuristic, and rare
+   * since it collides with the round-directory naming.
    */
   private resolveWorkspaceSourceDir(location: FileLocation): string {
     const workspaceRoot = WorkspaceFS.getPath();

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -375,10 +375,16 @@ export class LatexDiffManager {
         WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS,
       ),
     );
+    // The diff `.tex` is written to `diff/r{round}/` rather than alongside the
+    // document's `\input`/`\bibliography` targets, so add the original source
+    // directory to the search path; otherwise `\input{figures/…}` and
+    // `\bibliography{…}` fail to resolve when the source lives in a subfolder.
+    const sourceDir = await this.getWorkingDirectory(referenceLocation);
     const ok = await compileLatex2Pdf(diffLocation, {
       channel: this.streamId,
       outputDirectory: buildDir,
       timeout: timeoutMs,
+      extraInputDirs: [sourceDir],
     });
 
     if (!ok) {

--- a/src/agent/output/compileCheck.ts
+++ b/src/agent/output/compileCheck.ts
@@ -16,6 +16,7 @@ import {
   flexibleFS,
   getComparablePath,
   pathToLocation,
+  WorkspaceFS,
   type TaskRunFileService,
 } from '@utils/files';
 import { hasExtension } from '@utils/core/pathCore';
@@ -208,12 +209,23 @@ async function compileOne(
     return { failure: null, failureLogExcerpt: '', artifact: null };
   }
 
+  // The output compiles from `buildDir`, not its original workspace folder, so
+  // relative `\input{figures/…}` / `\bibliography{…}` only resolve if the
+  // original source directory is on the search path. Derive it from the
+  // workspace-relative path (r<N>/ already stripped above).
+  const workspaceRoot = WorkspaceFS.getPath();
+  const extraInputDirs =
+    workspaceRoot && !path.isAbsolute(pathForSafeName)
+      ? [path.join(workspaceRoot, path.dirname(pathForSafeName))]
+      : [];
+
   // execa's timeout option kills the child process on expiry, so we don't
   // orphan hanging latexmk/pdflatex runs.
   const ok = await compileLatex2Pdf(outputFile.location, {
     channel: ctx.streamId,
     outputDirectory: buildDir,
     timeout: opts.timeoutMs,
+    extraInputDirs,
   });
 
   if (ok) {

--- a/src/common/schemas.ts
+++ b/src/common/schemas.ts
@@ -20,6 +20,15 @@ export const LaTeXCompileOptionsSchema = z.object({
   compiler: z.enum(['pdflatex', 'latexmk']).prefault('latexmk'),
   /** Millisecond timeout per compiler invocation. Kills the child on expiry. */
   timeout: z.int().positive().optional(),
+  /**
+   * Extra directories to prepend onto the kpathsea search path (TEXINPUTS /
+   * BIBINPUTS / BSTINPUTS), after the main file's own directory and before the
+   * workspace root. Used when a run-storage document compiles outside its
+   * original location so relative `\input{…}` / `\bibliography{…}` targets
+   * (e.g. `figures/fig.tex`, `library.bib`) still resolve against the original
+   * source directory.
+   */
+  extraInputDirs: z.array(z.string()).prefault([]),
 });
 
 /** Input type - compiler optional with default applied by schema.parse() */

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -84,8 +84,9 @@ export function buildLatexSearchParts(input: {
   workspacePath?: string | null;
   tikzInputDirectory?: string | null;
 }): { texInputParts: string[]; bibSearchParts: string[] } {
-  const { documentDir, workspacePath, tikzInputDirectory } = input;
-  const sourceDirs = [documentDir, ...(input.extraInputDirs ?? [])];
+  const { documentDir, extraInputDirs, workspacePath, tikzInputDirectory } =
+    input;
+  const sourceDirs = [documentDir, ...(extraInputDirs ?? [])];
   const workspaceParts = workspacePath ? [workspacePath] : [];
   const tikzParts = tikzInputDirectory?.trim() ? [tikzInputDirectory] : [];
   return {

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -68,6 +68,29 @@ export function buildLatexInputEnv(
 }
 
 /**
+ * Compose the kpathsea search-path parts for a compile. The document's own
+ * directory and any caller-supplied source directories come first (so a revised
+ * sibling in run storage beats an original-source fallback), then the workspace
+ * root, then the TikZ input dir. Bibliography search omits `.` and TikZ — only
+ * directories that can hold `.bib`/`.bst` matter there.
+ */
+export function buildLatexSearchParts(input: {
+  documentDir: string;
+  extraInputDirs?: readonly string[];
+  workspacePath?: string | null;
+  tikzInputDirectory?: string | null;
+}): { texInputParts: string[]; bibSearchParts: string[] } {
+  const { documentDir, workspacePath, tikzInputDirectory } = input;
+  const sourceDirs = [documentDir, ...(input.extraInputDirs ?? [])];
+  const workspaceParts = workspacePath ? [workspacePath] : [];
+  const tikzParts = tikzInputDirectory?.trim() ? [tikzInputDirectory] : [];
+  return {
+    texInputParts: ['.', ...sourceDirs, ...workspaceParts, ...tikzParts],
+    bibSearchParts: [...sourceDirs, ...workspaceParts],
+  };
+}
+
+/**
  * Compile a LaTeX file to PDF
  * @param latexLocation FileLocation for the LaTeX file
  * @param options Compilation options (channel defaults to module CHANNEL)
@@ -80,11 +103,20 @@ export async function compileLatex2Pdf(
   // Schema provides compiler default; channel defaults to module constant
   const parsed = LaTeXCompileOptionsSchema.parse(options);
   const channel = parsed.channel ?? CHANNEL;
-  const { outputDirectory, compiler, timeout } = parsed;
+  const { outputDirectory, compiler, timeout, extraInputDirs } = parsed;
   try {
     const latexFile = latexLocation.absolutePath;
     const outDir = outputDirectory ?? path.dirname(latexFile);
     await flexibleFS.ensureDir(pathToLocation(outDir));
+
+    // TeX resolves relative `\input{…}` / `\bibliography{…}` against the
+    // compiler's cwd and TEXINPUTS, not the main file's location. When a
+    // run-storage document (round output or latexdiff) compiles from a build
+    // directory, its own folder and any caller-supplied source directories must
+    // be on the search path or `\input{preamble}`, `\input{figures/…}`, and the
+    // bibliography fail to resolve. The file's own directory comes first so a
+    // revised sibling wins over the original source fallback.
+    const documentDir = path.dirname(latexFile);
 
     // Get TikZ input directory from configuration
     const tikzInputDirectory = getConfig<string>(
@@ -100,12 +132,12 @@ export async function compileLatex2Pdf(
 
     // Build TEXINPUTS from configured paths
     const workspacePath = includeWorkspace ? WorkspaceFS.getPath() : null;
-    const texInputParts = [
-      '.',
-      ...(workspacePath ? [workspacePath] : []),
-      ...(tikzInputDirectory?.trim() ? [tikzInputDirectory] : []),
-    ];
-    const bibSearchParts = workspacePath ? [workspacePath] : [];
+    const { texInputParts, bibSearchParts } = buildLatexSearchParts({
+      documentDir,
+      extraInputDirs,
+      workspacePath,
+      tikzInputDirectory,
+    });
 
     // Build kpathsea search-path overrides, prepending workspace/TikZ dirs onto
     // any inherited values. `path.delimiter` keeps it cross-platform.

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -69,10 +69,14 @@ export function buildLatexInputEnv(
 
 /**
  * Compose the kpathsea search-path parts for a compile. The document's own
- * directory and any caller-supplied source directories come first (so a revised
- * sibling in run storage beats an original-source fallback), then the workspace
- * root, then the TikZ input dir. Bibliography search omits `.` and TikZ — only
- * directories that can hold `.bib`/`.bst` matter there.
+ * directory and any caller-supplied source directories come first — ahead of
+ * `.` (the compiler's cwd, which is the workspace root, not the document's
+ * folder) so a subfolder document's relative `\input{…}` resolves against its
+ * own tree rather than a same-named file at the workspace root; the document
+ * dir also precedes the extra source dirs so a revised sibling in run storage
+ * beats the original-source fallback. The workspace root and TikZ dir follow.
+ * Bibliography search omits `.` and TikZ — only directories that can hold
+ * `.bib`/`.bst` matter there.
  */
 export function buildLatexSearchParts(input: {
   documentDir: string;
@@ -85,7 +89,7 @@ export function buildLatexSearchParts(input: {
   const workspaceParts = workspacePath ? [workspacePath] : [];
   const tikzParts = tikzInputDirectory?.trim() ? [tikzInputDirectory] : [];
   return {
-    texInputParts: ['.', ...sourceDirs, ...workspaceParts, ...tikzParts],
+    texInputParts: [...sourceDirs, '.', ...workspaceParts, ...tikzParts],
     bibSearchParts: [...sourceDirs, ...workspaceParts],
   };
 }

--- a/src/test-kernel/latex/TexInputEnv.vitest.ts
+++ b/src/test-kernel/latex/TexInputEnv.vitest.ts
@@ -41,19 +41,20 @@ describe('buildLatexInputEnv', () => {
 });
 
 describe('buildLatexSearchParts', () => {
-  it('puts the document dir first, then extra source dirs, then workspace/tikz', () => {
+  it('ranks document + extra source dirs ahead of cwd, workspace, and tikz', () => {
     const { texInputParts, bibSearchParts } = buildLatexSearchParts({
       documentDir: '/run/diff/r1',
       extraInputDirs: ['/ws/Draft/LeanMPSPaper'],
       workspacePath: '/ws',
       tikzInputDirectory: '/tikz',
     });
-    // Source dirs (document + extra) rank above the workspace root so a revised
-    // sibling in run storage wins over the original-source fallback.
+    // Source dirs precede "." (cwd = workspace root) so a subfolder document's
+    // relative \input resolves against its own tree; the document dir precedes
+    // the extra source dir so a revised sibling beats the original fallback.
     expect(texInputParts).toEqual([
-      '.',
       '/run/diff/r1',
       '/ws/Draft/LeanMPSPaper',
+      '.',
       '/ws',
       '/tikz',
     ]);
@@ -70,7 +71,7 @@ describe('buildLatexSearchParts', () => {
       documentDir: '/run/r0/Draft/LeanMPSPaper',
       workspacePath: null,
     });
-    expect(texInputParts).toEqual(['.', '/run/r0/Draft/LeanMPSPaper']);
+    expect(texInputParts).toEqual(['/run/r0/Draft/LeanMPSPaper', '.']);
     expect(bibSearchParts).toEqual(['/run/r0/Draft/LeanMPSPaper']);
   });
 
@@ -80,6 +81,6 @@ describe('buildLatexSearchParts', () => {
       workspacePath: '/ws',
       tikzInputDirectory: '   ',
     });
-    expect(texInputParts).toEqual(['.', '/doc', '/ws']);
+    expect(texInputParts).toEqual(['/doc', '.', '/ws']);
   });
 });

--- a/src/test-kernel/latex/TexInputEnv.vitest.ts
+++ b/src/test-kernel/latex/TexInputEnv.vitest.ts
@@ -5,7 +5,7 @@ import * as path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 // Local imports - latex
-import { buildLatexInputEnv } from '@latex/texTools';
+import { buildLatexInputEnv, buildLatexSearchParts } from '@latex/texTools';
 
 const D = path.delimiter;
 
@@ -37,5 +37,49 @@ describe('buildLatexInputEnv', () => {
     const env = buildLatexInputEnv(['.', '/ws'], ['/ws'], {});
     expect(env.TEXINPUTS).toBe(`.${D}/ws${D}`);
     expect(env.BIBINPUTS).toBe(`/ws${D}`);
+  });
+});
+
+describe('buildLatexSearchParts', () => {
+  it('puts the document dir first, then extra source dirs, then workspace/tikz', () => {
+    const { texInputParts, bibSearchParts } = buildLatexSearchParts({
+      documentDir: '/run/diff/r1',
+      extraInputDirs: ['/ws/Draft/LeanMPSPaper'],
+      workspacePath: '/ws',
+      tikzInputDirectory: '/tikz',
+    });
+    // Source dirs (document + extra) rank above the workspace root so a revised
+    // sibling in run storage wins over the original-source fallback.
+    expect(texInputParts).toEqual([
+      '.',
+      '/run/diff/r1',
+      '/ws/Draft/LeanMPSPaper',
+      '/ws',
+      '/tikz',
+    ]);
+    // Bibliography search drops "." and the TikZ dir.
+    expect(bibSearchParts).toEqual([
+      '/run/diff/r1',
+      '/ws/Draft/LeanMPSPaper',
+      '/ws',
+    ]);
+  });
+
+  it('still emits the document dir when no workspace, tikz, or extras are given', () => {
+    const { texInputParts, bibSearchParts } = buildLatexSearchParts({
+      documentDir: '/run/r0/Draft/LeanMPSPaper',
+      workspacePath: null,
+    });
+    expect(texInputParts).toEqual(['.', '/run/r0/Draft/LeanMPSPaper']);
+    expect(bibSearchParts).toEqual(['/run/r0/Draft/LeanMPSPaper']);
+  });
+
+  it('ignores blank tikz dirs', () => {
+    const { texInputParts } = buildLatexSearchParts({
+      documentDir: '/doc',
+      workspacePath: '/ws',
+      tikzInputDirectory: '   ',
+    });
+    expect(texInputParts).toEqual(['.', '/doc', '/ws']);
   });
 });

--- a/supabase/functions/auth-device/deno.json
+++ b/supabase/functions/auth-device/deno.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "@hono/hono": "jsr:@hono/hono@4.12.24",
-    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.108.1"
+    "@hono/hono": "jsr:@hono/hono@4.12.27",
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.108.2"
   }
 }

--- a/supabase/functions/auth-device/deno.lock
+++ b/supabase/functions/auth-device/deno.lock
@@ -1,20 +1,20 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@hono/hono@4.12.24": "4.12.24",
-    "jsr:@supabase/supabase-js@2.108.1": "2.108.1",
-    "npm:@supabase/auth-js@2.108.1": "2.108.1",
-    "npm:@supabase/functions-js@2.108.1": "2.108.1",
-    "npm:@supabase/postgrest-js@2.108.1": "2.108.1",
-    "npm:@supabase/realtime-js@2.108.1": "2.108.1",
-    "npm:@supabase/storage-js@2.108.1": "2.108.1"
+    "jsr:@hono/hono@4.12.27": "4.12.27",
+    "jsr:@supabase/supabase-js@2.108.2": "2.108.2",
+    "npm:@supabase/auth-js@2.108.2": "2.108.2",
+    "npm:@supabase/functions-js@2.108.2": "2.108.2",
+    "npm:@supabase/postgrest-js@2.108.2": "2.108.2",
+    "npm:@supabase/realtime-js@2.108.2": "2.108.2",
+    "npm:@supabase/storage-js@2.108.2": "2.108.2"
   },
   "jsr": {
-    "@hono/hono@4.12.24": {
-      "integrity": "a74a40f06ae6704ddd0e8e576f6da9d34666c3e1e0f5412a2c1ff800ffd092f4"
+    "@hono/hono@4.12.27": {
+      "integrity": "3acc640592008e43f7048e8e53275203e0da84fbcd50201121195da7560583dc"
     },
-    "@supabase/supabase-js@2.108.1": {
-      "integrity": "c31883d00e36c759796683f2974e99201c3039fc2e539e0c3a1dd6dfb370332d",
+    "@supabase/supabase-js@2.108.2": {
+      "integrity": "db603b534b1939a216ef004fe9fdd0c72bb4ba097fb04be23ea76cb8c70272aa",
       "dependencies": [
         "npm:@supabase/auth-js",
         "npm:@supabase/functions-js",
@@ -25,36 +25,36 @@
     }
   },
   "npm": {
-    "@supabase/auth-js@2.108.1": {
-      "integrity": "sha512-Lle5rKU8f9LF3K5dDd8Or8mkkG+ptzRZZWKPVMm9B9UuovH65Ss2+iFnQqRsCqaGouvJEcTWyl0cj2riNrrDLQ==",
+    "@supabase/auth-js@2.108.2": {
+      "integrity": "sha512-tNaQmBgodDZwgB40mRwVbxFy8IDYwjdpcZ0BYrWiwlULCSQoJj4QoG4zgJT7QRPXcqipefNOzvO/qAu4dF98ag==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/functions-js@2.108.1": {
-      "integrity": "sha512-fxBRW/A4IG7ADQztVt0NaEy5ysiO1WJ2pbldsnBchrkHuyepX0Krek9qA9T4gUQBVVTCE9Ea4pdsM5hfn3nc4A==",
+    "@supabase/functions-js@2.108.2": {
+      "integrity": "sha512-RNUX8EiBy3iLwAX19jtRzLyePnl11/fHcgwDHLnpKcDSXt/5qBnh3LUwAtIjT21Q66QsmNUR2esrHziLCpNubw==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/phoenix@0.4.2": {
-      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A=="
+    "@supabase/phoenix@0.4.4": {
+      "integrity": "sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ=="
     },
-    "@supabase/postgrest-js@2.108.1": {
-      "integrity": "sha512-9lj2MCPPMgSTaJ5y+amnhb3TWPtMFVlbDn2hmX/VV91xQU4j0AauwfMaBErHBJ+zzsSwjc0jLU+zLIZFLQzfig==",
+    "@supabase/postgrest-js@2.108.2": {
+      "integrity": "sha512-GQ28/Y8hk3CFmkb3kXH1h/AQx6JIYSQfO0CJMRVBcEKZoNy6C45cXAZ4fcJvRC5Id0cs6xnkUV0+c0rIocigsw==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/realtime-js@2.108.1": {
-      "integrity": "sha512-mHGGqOjwd1XTydcoffUqEMsbFQHUi6A3uhQ0EXr3iqzpLqItxKA9nbN6gIQxrZ7JRRnuUe/iOFPUkYV9Tdc5lg==",
+    "@supabase/realtime-js@2.108.2": {
+      "integrity": "sha512-aAGxCSUemZvQIibnCdvNvgaKib28I4rfrNjKbQ9cG1uBLwUsI7hVpGXgEbypCCDhLjQlDTAiJlu7rgljYUT73g==",
       "dependencies": [
         "@supabase/phoenix",
         "tslib"
       ]
     },
-    "@supabase/storage-js@2.108.1": {
-      "integrity": "sha512-Er0SGGt85iT6ye+SSh98Az6L2CesoZJuyzEZYH2oBOAnIxa9Nn4CtwUC3veGxYggoT56X+3tVuuQeDBP8kR8sg==",
+    "@supabase/storage-js@2.108.2": {
+      "integrity": "sha512-TVZPQxXGxY2+A6yTtm77zUHsh70lBhYUEaJL8RQC+BghcX/ygiMG/rmXrNVBce30/WAeNPa8FiG8HbqlGeV05g==",
       "dependencies": [
         "iceberg-js",
         "tslib"
@@ -69,8 +69,8 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@hono/hono@4.12.24",
-      "jsr:@supabase/supabase-js@2.108.1"
+      "jsr:@hono/hono@4.12.27",
+      "jsr:@supabase/supabase-js@2.108.2"
     ]
   }
 }

--- a/supabase/functions/auth-github/deno.json
+++ b/supabase/functions/auth-github/deno.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "@hono/hono": "jsr:@hono/hono@4.12.24",
-    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.108.1"
+    "@hono/hono": "jsr:@hono/hono@4.12.27",
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.108.2"
   }
 }

--- a/supabase/functions/auth-github/deno.lock
+++ b/supabase/functions/auth-github/deno.lock
@@ -1,20 +1,20 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@hono/hono@4.12.24": "4.12.24",
-    "jsr:@supabase/supabase-js@2.108.1": "2.108.1",
-    "npm:@supabase/auth-js@2.108.1": "2.108.1",
-    "npm:@supabase/functions-js@2.108.1": "2.108.1",
-    "npm:@supabase/postgrest-js@2.108.1": "2.108.1",
-    "npm:@supabase/realtime-js@2.108.1": "2.108.1",
-    "npm:@supabase/storage-js@2.108.1": "2.108.1"
+    "jsr:@hono/hono@4.12.27": "4.12.27",
+    "jsr:@supabase/supabase-js@2.108.2": "2.108.2",
+    "npm:@supabase/auth-js@2.108.2": "2.108.2",
+    "npm:@supabase/functions-js@2.108.2": "2.108.2",
+    "npm:@supabase/postgrest-js@2.108.2": "2.108.2",
+    "npm:@supabase/realtime-js@2.108.2": "2.108.2",
+    "npm:@supabase/storage-js@2.108.2": "2.108.2"
   },
   "jsr": {
-    "@hono/hono@4.12.24": {
-      "integrity": "a74a40f06ae6704ddd0e8e576f6da9d34666c3e1e0f5412a2c1ff800ffd092f4"
+    "@hono/hono@4.12.27": {
+      "integrity": "3acc640592008e43f7048e8e53275203e0da84fbcd50201121195da7560583dc"
     },
-    "@supabase/supabase-js@2.108.1": {
-      "integrity": "c31883d00e36c759796683f2974e99201c3039fc2e539e0c3a1dd6dfb370332d",
+    "@supabase/supabase-js@2.108.2": {
+      "integrity": "db603b534b1939a216ef004fe9fdd0c72bb4ba097fb04be23ea76cb8c70272aa",
       "dependencies": [
         "npm:@supabase/auth-js",
         "npm:@supabase/functions-js",
@@ -25,36 +25,36 @@
     }
   },
   "npm": {
-    "@supabase/auth-js@2.108.1": {
-      "integrity": "sha512-Lle5rKU8f9LF3K5dDd8Or8mkkG+ptzRZZWKPVMm9B9UuovH65Ss2+iFnQqRsCqaGouvJEcTWyl0cj2riNrrDLQ==",
+    "@supabase/auth-js@2.108.2": {
+      "integrity": "sha512-tNaQmBgodDZwgB40mRwVbxFy8IDYwjdpcZ0BYrWiwlULCSQoJj4QoG4zgJT7QRPXcqipefNOzvO/qAu4dF98ag==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/functions-js@2.108.1": {
-      "integrity": "sha512-fxBRW/A4IG7ADQztVt0NaEy5ysiO1WJ2pbldsnBchrkHuyepX0Krek9qA9T4gUQBVVTCE9Ea4pdsM5hfn3nc4A==",
+    "@supabase/functions-js@2.108.2": {
+      "integrity": "sha512-RNUX8EiBy3iLwAX19jtRzLyePnl11/fHcgwDHLnpKcDSXt/5qBnh3LUwAtIjT21Q66QsmNUR2esrHziLCpNubw==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/phoenix@0.4.2": {
-      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A=="
+    "@supabase/phoenix@0.4.4": {
+      "integrity": "sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ=="
     },
-    "@supabase/postgrest-js@2.108.1": {
-      "integrity": "sha512-9lj2MCPPMgSTaJ5y+amnhb3TWPtMFVlbDn2hmX/VV91xQU4j0AauwfMaBErHBJ+zzsSwjc0jLU+zLIZFLQzfig==",
+    "@supabase/postgrest-js@2.108.2": {
+      "integrity": "sha512-GQ28/Y8hk3CFmkb3kXH1h/AQx6JIYSQfO0CJMRVBcEKZoNy6C45cXAZ4fcJvRC5Id0cs6xnkUV0+c0rIocigsw==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/realtime-js@2.108.1": {
-      "integrity": "sha512-mHGGqOjwd1XTydcoffUqEMsbFQHUi6A3uhQ0EXr3iqzpLqItxKA9nbN6gIQxrZ7JRRnuUe/iOFPUkYV9Tdc5lg==",
+    "@supabase/realtime-js@2.108.2": {
+      "integrity": "sha512-aAGxCSUemZvQIibnCdvNvgaKib28I4rfrNjKbQ9cG1uBLwUsI7hVpGXgEbypCCDhLjQlDTAiJlu7rgljYUT73g==",
       "dependencies": [
         "@supabase/phoenix",
         "tslib"
       ]
     },
-    "@supabase/storage-js@2.108.1": {
-      "integrity": "sha512-Er0SGGt85iT6ye+SSh98Az6L2CesoZJuyzEZYH2oBOAnIxa9Nn4CtwUC3veGxYggoT56X+3tVuuQeDBP8kR8sg==",
+    "@supabase/storage-js@2.108.2": {
+      "integrity": "sha512-TVZPQxXGxY2+A6yTtm77zUHsh70lBhYUEaJL8RQC+BghcX/ygiMG/rmXrNVBce30/WAeNPa8FiG8HbqlGeV05g==",
       "dependencies": [
         "iceberg-js",
         "tslib"
@@ -69,8 +69,8 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@hono/hono@4.12.24",
-      "jsr:@supabase/supabase-js@2.108.1"
+      "jsr:@hono/hono@4.12.27",
+      "jsr:@supabase/supabase-js@2.108.2"
     ]
   }
 }

--- a/supabase/functions/get-agent-config/deno.json
+++ b/supabase/functions/get-agent-config/deno.json
@@ -1,5 +1,5 @@
 {
   "imports": {
-    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.108.1"
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.108.2"
   }
 }

--- a/supabase/functions/get-agent-config/deno.lock
+++ b/supabase/functions/get-agent-config/deno.lock
@@ -1,16 +1,16 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@supabase/supabase-js@2.108.1": "2.108.1",
-    "npm:@supabase/auth-js@2.108.1": "2.108.1",
-    "npm:@supabase/functions-js@2.108.1": "2.108.1",
-    "npm:@supabase/postgrest-js@2.108.1": "2.108.1",
-    "npm:@supabase/realtime-js@2.108.1": "2.108.1",
-    "npm:@supabase/storage-js@2.108.1": "2.108.1"
+    "jsr:@supabase/supabase-js@2.108.2": "2.108.2",
+    "npm:@supabase/auth-js@2.108.2": "2.108.2",
+    "npm:@supabase/functions-js@2.108.2": "2.108.2",
+    "npm:@supabase/postgrest-js@2.108.2": "2.108.2",
+    "npm:@supabase/realtime-js@2.108.2": "2.108.2",
+    "npm:@supabase/storage-js@2.108.2": "2.108.2"
   },
   "jsr": {
-    "@supabase/supabase-js@2.108.1": {
-      "integrity": "c31883d00e36c759796683f2974e99201c3039fc2e539e0c3a1dd6dfb370332d",
+    "@supabase/supabase-js@2.108.2": {
+      "integrity": "db603b534b1939a216ef004fe9fdd0c72bb4ba097fb04be23ea76cb8c70272aa",
       "dependencies": [
         "npm:@supabase/auth-js",
         "npm:@supabase/functions-js",
@@ -21,36 +21,36 @@
     }
   },
   "npm": {
-    "@supabase/auth-js@2.108.1": {
-      "integrity": "sha512-Lle5rKU8f9LF3K5dDd8Or8mkkG+ptzRZZWKPVMm9B9UuovH65Ss2+iFnQqRsCqaGouvJEcTWyl0cj2riNrrDLQ==",
+    "@supabase/auth-js@2.108.2": {
+      "integrity": "sha512-tNaQmBgodDZwgB40mRwVbxFy8IDYwjdpcZ0BYrWiwlULCSQoJj4QoG4zgJT7QRPXcqipefNOzvO/qAu4dF98ag==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/functions-js@2.108.1": {
-      "integrity": "sha512-fxBRW/A4IG7ADQztVt0NaEy5ysiO1WJ2pbldsnBchrkHuyepX0Krek9qA9T4gUQBVVTCE9Ea4pdsM5hfn3nc4A==",
+    "@supabase/functions-js@2.108.2": {
+      "integrity": "sha512-RNUX8EiBy3iLwAX19jtRzLyePnl11/fHcgwDHLnpKcDSXt/5qBnh3LUwAtIjT21Q66QsmNUR2esrHziLCpNubw==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/phoenix@0.4.2": {
-      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A=="
+    "@supabase/phoenix@0.4.4": {
+      "integrity": "sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ=="
     },
-    "@supabase/postgrest-js@2.108.1": {
-      "integrity": "sha512-9lj2MCPPMgSTaJ5y+amnhb3TWPtMFVlbDn2hmX/VV91xQU4j0AauwfMaBErHBJ+zzsSwjc0jLU+zLIZFLQzfig==",
+    "@supabase/postgrest-js@2.108.2": {
+      "integrity": "sha512-GQ28/Y8hk3CFmkb3kXH1h/AQx6JIYSQfO0CJMRVBcEKZoNy6C45cXAZ4fcJvRC5Id0cs6xnkUV0+c0rIocigsw==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/realtime-js@2.108.1": {
-      "integrity": "sha512-mHGGqOjwd1XTydcoffUqEMsbFQHUi6A3uhQ0EXr3iqzpLqItxKA9nbN6gIQxrZ7JRRnuUe/iOFPUkYV9Tdc5lg==",
+    "@supabase/realtime-js@2.108.2": {
+      "integrity": "sha512-aAGxCSUemZvQIibnCdvNvgaKib28I4rfrNjKbQ9cG1uBLwUsI7hVpGXgEbypCCDhLjQlDTAiJlu7rgljYUT73g==",
       "dependencies": [
         "@supabase/phoenix",
         "tslib"
       ]
     },
-    "@supabase/storage-js@2.108.1": {
-      "integrity": "sha512-Er0SGGt85iT6ye+SSh98Az6L2CesoZJuyzEZYH2oBOAnIxa9Nn4CtwUC3veGxYggoT56X+3tVuuQeDBP8kR8sg==",
+    "@supabase/storage-js@2.108.2": {
+      "integrity": "sha512-TVZPQxXGxY2+A6yTtm77zUHsh70lBhYUEaJL8RQC+BghcX/ygiMG/rmXrNVBce30/WAeNPa8FiG8HbqlGeV05g==",
       "dependencies": [
         "iceberg-js",
         "tslib"
@@ -65,7 +65,7 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@supabase/supabase-js@2.108.1"
+      "jsr:@supabase/supabase-js@2.108.2"
     ]
   }
 }

--- a/supabase/functions/log-usage/deno.json
+++ b/supabase/functions/log-usage/deno.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.108.1",
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.108.2",
     "zod": "npm:zod@^4.4.3"
   }
 }

--- a/supabase/functions/log-usage/deno.lock
+++ b/supabase/functions/log-usage/deno.lock
@@ -1,17 +1,17 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@supabase/supabase-js@2.108.1": "2.108.1",
-    "npm:@supabase/auth-js@2.108.1": "2.108.1",
-    "npm:@supabase/functions-js@2.108.1": "2.108.1",
-    "npm:@supabase/postgrest-js@2.108.1": "2.108.1",
-    "npm:@supabase/realtime-js@2.108.1": "2.108.1",
-    "npm:@supabase/storage-js@2.108.1": "2.108.1",
+    "jsr:@supabase/supabase-js@2.108.2": "2.108.2",
+    "npm:@supabase/auth-js@2.108.2": "2.108.2",
+    "npm:@supabase/functions-js@2.108.2": "2.108.2",
+    "npm:@supabase/postgrest-js@2.108.2": "2.108.2",
+    "npm:@supabase/realtime-js@2.108.2": "2.108.2",
+    "npm:@supabase/storage-js@2.108.2": "2.108.2",
     "npm:zod@^4.4.3": "4.4.3"
   },
   "jsr": {
-    "@supabase/supabase-js@2.108.1": {
-      "integrity": "c31883d00e36c759796683f2974e99201c3039fc2e539e0c3a1dd6dfb370332d",
+    "@supabase/supabase-js@2.108.2": {
+      "integrity": "db603b534b1939a216ef004fe9fdd0c72bb4ba097fb04be23ea76cb8c70272aa",
       "dependencies": [
         "npm:@supabase/auth-js",
         "npm:@supabase/functions-js",
@@ -22,36 +22,36 @@
     }
   },
   "npm": {
-    "@supabase/auth-js@2.108.1": {
-      "integrity": "sha512-Lle5rKU8f9LF3K5dDd8Or8mkkG+ptzRZZWKPVMm9B9UuovH65Ss2+iFnQqRsCqaGouvJEcTWyl0cj2riNrrDLQ==",
+    "@supabase/auth-js@2.108.2": {
+      "integrity": "sha512-tNaQmBgodDZwgB40mRwVbxFy8IDYwjdpcZ0BYrWiwlULCSQoJj4QoG4zgJT7QRPXcqipefNOzvO/qAu4dF98ag==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/functions-js@2.108.1": {
-      "integrity": "sha512-fxBRW/A4IG7ADQztVt0NaEy5ysiO1WJ2pbldsnBchrkHuyepX0Krek9qA9T4gUQBVVTCE9Ea4pdsM5hfn3nc4A==",
+    "@supabase/functions-js@2.108.2": {
+      "integrity": "sha512-RNUX8EiBy3iLwAX19jtRzLyePnl11/fHcgwDHLnpKcDSXt/5qBnh3LUwAtIjT21Q66QsmNUR2esrHziLCpNubw==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/phoenix@0.4.2": {
-      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A=="
+    "@supabase/phoenix@0.4.4": {
+      "integrity": "sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ=="
     },
-    "@supabase/postgrest-js@2.108.1": {
-      "integrity": "sha512-9lj2MCPPMgSTaJ5y+amnhb3TWPtMFVlbDn2hmX/VV91xQU4j0AauwfMaBErHBJ+zzsSwjc0jLU+zLIZFLQzfig==",
+    "@supabase/postgrest-js@2.108.2": {
+      "integrity": "sha512-GQ28/Y8hk3CFmkb3kXH1h/AQx6JIYSQfO0CJMRVBcEKZoNy6C45cXAZ4fcJvRC5Id0cs6xnkUV0+c0rIocigsw==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/realtime-js@2.108.1": {
-      "integrity": "sha512-mHGGqOjwd1XTydcoffUqEMsbFQHUi6A3uhQ0EXr3iqzpLqItxKA9nbN6gIQxrZ7JRRnuUe/iOFPUkYV9Tdc5lg==",
+    "@supabase/realtime-js@2.108.2": {
+      "integrity": "sha512-aAGxCSUemZvQIibnCdvNvgaKib28I4rfrNjKbQ9cG1uBLwUsI7hVpGXgEbypCCDhLjQlDTAiJlu7rgljYUT73g==",
       "dependencies": [
         "@supabase/phoenix",
         "tslib"
       ]
     },
-    "@supabase/storage-js@2.108.1": {
-      "integrity": "sha512-Er0SGGt85iT6ye+SSh98Az6L2CesoZJuyzEZYH2oBOAnIxa9Nn4CtwUC3veGxYggoT56X+3tVuuQeDBP8kR8sg==",
+    "@supabase/storage-js@2.108.2": {
+      "integrity": "sha512-TVZPQxXGxY2+A6yTtm77zUHsh70lBhYUEaJL8RQC+BghcX/ygiMG/rmXrNVBce30/WAeNPa8FiG8HbqlGeV05g==",
       "dependencies": [
         "iceberg-js",
         "tslib"
@@ -69,7 +69,7 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@supabase/supabase-js@2.108.1",
+      "jsr:@supabase/supabase-js@2.108.2",
       "npm:zod@^4.4.3"
     ]
   }

--- a/supabase/functions/relay-tokens/deno.json
+++ b/supabase/functions/relay-tokens/deno.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "@hono/hono": "jsr:@hono/hono@4.12.24",
-    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.108.1"
+    "@hono/hono": "jsr:@hono/hono@4.12.27",
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.108.2"
   }
 }

--- a/supabase/functions/relay-tokens/deno.lock
+++ b/supabase/functions/relay-tokens/deno.lock
@@ -1,20 +1,20 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@hono/hono@4.12.24": "4.12.24",
-    "jsr:@supabase/supabase-js@2.108.1": "2.108.1",
-    "npm:@supabase/auth-js@2.108.1": "2.108.1",
-    "npm:@supabase/functions-js@2.108.1": "2.108.1",
-    "npm:@supabase/postgrest-js@2.108.1": "2.108.1",
-    "npm:@supabase/realtime-js@2.108.1": "2.108.1",
-    "npm:@supabase/storage-js@2.108.1": "2.108.1"
+    "jsr:@hono/hono@4.12.27": "4.12.27",
+    "jsr:@supabase/supabase-js@2.108.2": "2.108.2",
+    "npm:@supabase/auth-js@2.108.2": "2.108.2",
+    "npm:@supabase/functions-js@2.108.2": "2.108.2",
+    "npm:@supabase/postgrest-js@2.108.2": "2.108.2",
+    "npm:@supabase/realtime-js@2.108.2": "2.108.2",
+    "npm:@supabase/storage-js@2.108.2": "2.108.2"
   },
   "jsr": {
-    "@hono/hono@4.12.24": {
-      "integrity": "a74a40f06ae6704ddd0e8e576f6da9d34666c3e1e0f5412a2c1ff800ffd092f4"
+    "@hono/hono@4.12.27": {
+      "integrity": "3acc640592008e43f7048e8e53275203e0da84fbcd50201121195da7560583dc"
     },
-    "@supabase/supabase-js@2.108.1": {
-      "integrity": "c31883d00e36c759796683f2974e99201c3039fc2e539e0c3a1dd6dfb370332d",
+    "@supabase/supabase-js@2.108.2": {
+      "integrity": "db603b534b1939a216ef004fe9fdd0c72bb4ba097fb04be23ea76cb8c70272aa",
       "dependencies": [
         "npm:@supabase/auth-js",
         "npm:@supabase/functions-js",
@@ -25,36 +25,36 @@
     }
   },
   "npm": {
-    "@supabase/auth-js@2.108.1": {
-      "integrity": "sha512-Lle5rKU8f9LF3K5dDd8Or8mkkG+ptzRZZWKPVMm9B9UuovH65Ss2+iFnQqRsCqaGouvJEcTWyl0cj2riNrrDLQ==",
+    "@supabase/auth-js@2.108.2": {
+      "integrity": "sha512-tNaQmBgodDZwgB40mRwVbxFy8IDYwjdpcZ0BYrWiwlULCSQoJj4QoG4zgJT7QRPXcqipefNOzvO/qAu4dF98ag==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/functions-js@2.108.1": {
-      "integrity": "sha512-fxBRW/A4IG7ADQztVt0NaEy5ysiO1WJ2pbldsnBchrkHuyepX0Krek9qA9T4gUQBVVTCE9Ea4pdsM5hfn3nc4A==",
+    "@supabase/functions-js@2.108.2": {
+      "integrity": "sha512-RNUX8EiBy3iLwAX19jtRzLyePnl11/fHcgwDHLnpKcDSXt/5qBnh3LUwAtIjT21Q66QsmNUR2esrHziLCpNubw==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/phoenix@0.4.2": {
-      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A=="
+    "@supabase/phoenix@0.4.4": {
+      "integrity": "sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ=="
     },
-    "@supabase/postgrest-js@2.108.1": {
-      "integrity": "sha512-9lj2MCPPMgSTaJ5y+amnhb3TWPtMFVlbDn2hmX/VV91xQU4j0AauwfMaBErHBJ+zzsSwjc0jLU+zLIZFLQzfig==",
+    "@supabase/postgrest-js@2.108.2": {
+      "integrity": "sha512-GQ28/Y8hk3CFmkb3kXH1h/AQx6JIYSQfO0CJMRVBcEKZoNy6C45cXAZ4fcJvRC5Id0cs6xnkUV0+c0rIocigsw==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/realtime-js@2.108.1": {
-      "integrity": "sha512-mHGGqOjwd1XTydcoffUqEMsbFQHUi6A3uhQ0EXr3iqzpLqItxKA9nbN6gIQxrZ7JRRnuUe/iOFPUkYV9Tdc5lg==",
+    "@supabase/realtime-js@2.108.2": {
+      "integrity": "sha512-aAGxCSUemZvQIibnCdvNvgaKib28I4rfrNjKbQ9cG1uBLwUsI7hVpGXgEbypCCDhLjQlDTAiJlu7rgljYUT73g==",
       "dependencies": [
         "@supabase/phoenix",
         "tslib"
       ]
     },
-    "@supabase/storage-js@2.108.1": {
-      "integrity": "sha512-Er0SGGt85iT6ye+SSh98Az6L2CesoZJuyzEZYH2oBOAnIxa9Nn4CtwUC3veGxYggoT56X+3tVuuQeDBP8kR8sg==",
+    "@supabase/storage-js@2.108.2": {
+      "integrity": "sha512-TVZPQxXGxY2+A6yTtm77zUHsh70lBhYUEaJL8RQC+BghcX/ygiMG/rmXrNVBce30/WAeNPa8FiG8HbqlGeV05g==",
       "dependencies": [
         "iceberg-js",
         "tslib"
@@ -69,8 +69,8 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@hono/hono@4.12.24",
-      "jsr:@supabase/supabase-js@2.108.1"
+      "jsr:@hono/hono@4.12.27",
+      "jsr:@supabase/supabase-js@2.108.2"
     ]
   }
 }

--- a/supabase/functions/relay/deno.json
+++ b/supabase/functions/relay/deno.json
@@ -1,7 +1,7 @@
 {
   "imports": {
-    "@hono/hono": "jsr:@hono/hono@4.12.24",
-    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.108.1",
+    "@hono/hono": "jsr:@hono/hono@4.12.27",
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.108.2",
     "llm-zoo": "npm:llm-zoo@^1.11.0"
   }
 }

--- a/supabase/functions/relay/deno.lock
+++ b/supabase/functions/relay/deno.lock
@@ -1,21 +1,21 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@hono/hono@4.12.24": "4.12.24",
-    "jsr:@supabase/supabase-js@2.108.1": "2.108.1",
-    "npm:@supabase/auth-js@2.108.1": "2.108.1",
-    "npm:@supabase/functions-js@2.108.1": "2.108.1",
-    "npm:@supabase/postgrest-js@2.108.1": "2.108.1",
-    "npm:@supabase/realtime-js@2.108.1": "2.108.1",
-    "npm:@supabase/storage-js@2.108.1": "2.108.1",
+    "jsr:@hono/hono@4.12.27": "4.12.27",
+    "jsr:@supabase/supabase-js@2.108.2": "2.108.2",
+    "npm:@supabase/auth-js@2.108.2": "2.108.2",
+    "npm:@supabase/functions-js@2.108.2": "2.108.2",
+    "npm:@supabase/postgrest-js@2.108.2": "2.108.2",
+    "npm:@supabase/realtime-js@2.108.2": "2.108.2",
+    "npm:@supabase/storage-js@2.108.2": "2.108.2",
     "npm:llm-zoo@^1.11.0": "1.11.0"
   },
   "jsr": {
-    "@hono/hono@4.12.24": {
-      "integrity": "a74a40f06ae6704ddd0e8e576f6da9d34666c3e1e0f5412a2c1ff800ffd092f4"
+    "@hono/hono@4.12.27": {
+      "integrity": "3acc640592008e43f7048e8e53275203e0da84fbcd50201121195da7560583dc"
     },
-    "@supabase/supabase-js@2.108.1": {
-      "integrity": "c31883d00e36c759796683f2974e99201c3039fc2e539e0c3a1dd6dfb370332d",
+    "@supabase/supabase-js@2.108.2": {
+      "integrity": "db603b534b1939a216ef004fe9fdd0c72bb4ba097fb04be23ea76cb8c70272aa",
       "dependencies": [
         "npm:@supabase/auth-js",
         "npm:@supabase/functions-js",
@@ -26,36 +26,36 @@
     }
   },
   "npm": {
-    "@supabase/auth-js@2.108.1": {
-      "integrity": "sha512-Lle5rKU8f9LF3K5dDd8Or8mkkG+ptzRZZWKPVMm9B9UuovH65Ss2+iFnQqRsCqaGouvJEcTWyl0cj2riNrrDLQ==",
+    "@supabase/auth-js@2.108.2": {
+      "integrity": "sha512-tNaQmBgodDZwgB40mRwVbxFy8IDYwjdpcZ0BYrWiwlULCSQoJj4QoG4zgJT7QRPXcqipefNOzvO/qAu4dF98ag==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/functions-js@2.108.1": {
-      "integrity": "sha512-fxBRW/A4IG7ADQztVt0NaEy5ysiO1WJ2pbldsnBchrkHuyepX0Krek9qA9T4gUQBVVTCE9Ea4pdsM5hfn3nc4A==",
+    "@supabase/functions-js@2.108.2": {
+      "integrity": "sha512-RNUX8EiBy3iLwAX19jtRzLyePnl11/fHcgwDHLnpKcDSXt/5qBnh3LUwAtIjT21Q66QsmNUR2esrHziLCpNubw==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/phoenix@0.4.2": {
-      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A=="
+    "@supabase/phoenix@0.4.4": {
+      "integrity": "sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ=="
     },
-    "@supabase/postgrest-js@2.108.1": {
-      "integrity": "sha512-9lj2MCPPMgSTaJ5y+amnhb3TWPtMFVlbDn2hmX/VV91xQU4j0AauwfMaBErHBJ+zzsSwjc0jLU+zLIZFLQzfig==",
+    "@supabase/postgrest-js@2.108.2": {
+      "integrity": "sha512-GQ28/Y8hk3CFmkb3kXH1h/AQx6JIYSQfO0CJMRVBcEKZoNy6C45cXAZ4fcJvRC5Id0cs6xnkUV0+c0rIocigsw==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/realtime-js@2.108.1": {
-      "integrity": "sha512-mHGGqOjwd1XTydcoffUqEMsbFQHUi6A3uhQ0EXr3iqzpLqItxKA9nbN6gIQxrZ7JRRnuUe/iOFPUkYV9Tdc5lg==",
+    "@supabase/realtime-js@2.108.2": {
+      "integrity": "sha512-aAGxCSUemZvQIibnCdvNvgaKib28I4rfrNjKbQ9cG1uBLwUsI7hVpGXgEbypCCDhLjQlDTAiJlu7rgljYUT73g==",
       "dependencies": [
         "@supabase/phoenix",
         "tslib"
       ]
     },
-    "@supabase/storage-js@2.108.1": {
-      "integrity": "sha512-Er0SGGt85iT6ye+SSh98Az6L2CesoZJuyzEZYH2oBOAnIxa9Nn4CtwUC3veGxYggoT56X+3tVuuQeDBP8kR8sg==",
+    "@supabase/storage-js@2.108.2": {
+      "integrity": "sha512-TVZPQxXGxY2+A6yTtm77zUHsh70lBhYUEaJL8RQC+BghcX/ygiMG/rmXrNVBce30/WAeNPa8FiG8HbqlGeV05g==",
       "dependencies": [
         "iceberg-js",
         "tslib"
@@ -73,8 +73,8 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@hono/hono@4.12.24",
-      "jsr:@supabase/supabase-js@2.108.1",
+      "jsr:@hono/hono@4.12.27",
+      "jsr:@supabase/supabase-js@2.108.2",
       "npm:llm-zoo@^1.11.0"
     ]
   }


### PR DESCRIPTION
## Problem

When the main `.tex` file lives in a **workspace subfolder** (e.g. `Draft/LeanMPSPaper/Draft3.tex`), both the round-output compile check and the latexdiff compile fail:

```
! LaTeX Error: File `preamble.tex' not found.
l.2 \input{preamble}
```

and, for the diff, `\input{figures/...}` and `\bibliography{library,additional_references}` are unresolved too.

### Root cause

`compileLatex2Pdf` runs `latexmk`/`pdflatex` with the main file as an absolute path and `-output-directory=<flattened build dir>`, but never sets the subprocess cwd to the document's directory; `executeCommand` defaults cwd to the workspace **root**. TeX resolves relative `\input{...}` / `\bibliography{...}` against cwd + `TEXINPUTS`, **not** the main file's location. `TEXINPUTS` only contained `.` (= root), the workspace root, and the TikZ dir — none of which is `Draft/LeanMPSPaper/`. Flat projects work by accident (cwd happens to equal the file's dir).

Run-storage diff documents make this worse: the diff `.tex` is written to `diff/r{round}/` while its `\input`/`\bibliography` targets (and their mirrors) live elsewhere, so the relative paths never resolve.

The previous workaround was an `\input@path{{Draft/LeanMPSPaper/}...}` block in the user's **source** preamble — which a normal document does not have.

## Fix

Put the document's own directory and the original source directory on the kpathsea search path, so `\input`/`\bibliography` resolve exactly as if compiling from the document's folder ("from both locations"):

- **`compileLatex2Pdf`** prepends the main file's own directory, then caller-supplied `extraInputDirs`, then the workspace root, onto `TEXINPUTS`/`BIBINPUTS`/`BSTINPUTS`. File dir comes first so a **revised** sibling in run storage beats the original-source fallback.
- **`compileCheck`** passes the output's original workspace source directory (derived from the workspace-relative path).
- **`LatexDiffManager`** passes the base document's realpath-resolved source directory.

No source-file hack, works at any subfolder depth. Search-path composition is extracted into `buildLatexSearchParts`, a pure seam alongside the existing `buildLatexInputEnv`.

## Verification

- New unit tests for `buildLatexSearchParts` (ordering, document-dir-only, blank tikz).
- `npx vitest run src/test-kernel/latex` — 11 files / 52 tests pass.
- `npm run typecheck` — clean.
- eslint/prettier clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global LaTeX search-path ordering for all compiles (document dir before cwd), which fixes subfolder projects but could alter resolution if same-named files exist at workspace root vs document folder; latexdiff workspace mapping relies on stripping `r\d+/` prefixes.
> 
> **Overview**
> Fixes failed **workflow compile checks** and **latexdiff PDF builds** when the main `.tex` lives in a workspace subfolder or when run-storage copies compile from a separate build directory.
> 
> **`compileLatex2Pdf`** now builds kpathsea paths via new **`buildLatexSearchParts`**: the main file’s directory and optional **`extraInputDirs`** are prepended ahead of `.` (workspace-root cwd) and the workspace root on `TEXINPUTS` / `BIBINPUTS` / `BSTINPUTS`, so relative `\input{…}` and `\bibliography{…}` resolve like a compile from the document folder. **`LaTeXCompileOptionsSchema`** gains **`extraInputDirs`**.
> 
> **`compileCheck`** passes the original workspace source directory derived from the output’s relative path. **`LatexDiffManager`** adds **`resolveWorkspaceSourceDir`** (strips run-storage `r<N>/` prefix when mapping to the live workspace tree) and passes that directory when compiling diff `.tex` under `diff/r{round}/`.
> 
> Unit tests cover **`buildLatexSearchParts`** ordering and edge cases. Supabase edge functions bump **Hono** and **supabase-js** lockfiles only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6fe871e1eb8280c5bc268f6fa30b8b8f08ce383. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->