### PR TITLE
Allow ChatGPT sign-in from non-default browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 #### Improvements
 
+- **Sign in with ChatGPT from a non-default browser** — the ChatGPT subscription sign-in opens your system default browser, but if your ChatGPT subscription is signed in on a different browser you can now copy the sign-in link and open it there. The VS Code extension shows a "Copy Sign-in Link" notification action and the desktop app offers a "Copy Sign-in Link" dialog button; the loopback callback accepts the redirect from whichever browser you complete it in.
 - **First-run setup no longer launches itself** — after a new user connects a credential, TeXRA now selects the setup assistant and shows a "Run setup assistant" card instead of silently starting it. The setup assistant inspects your environment and may install tools, so it now runs only when you explicitly click to start it.
 
 ## [0.39.0] - 2026-06-28

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -140,6 +140,13 @@ export interface DesktopSettingsIpcOptions {
   openPath?: (filePath: string) => Promise<void>;
   revealPath?: (filePath: string) => Promise<void>;
   openExternalUrl?: (url: string) => Promise<void>;
+  /**
+   * Offer the ChatGPT sign-in URL as a copyable link. `openExternalUrl` only
+   * targets the system default browser; this lets a user whose ChatGPT
+   * subscription lives in a different browser open the same link there (the
+   * loopback callback accepts the redirect from any browser).
+   */
+  presentChatGptSignInUrl?: (url: string) => void | Promise<void>;
   installToolExtension?: (extensionId: string) => Promise<void>;
   promptSecret?: (input: {
     title: string;
@@ -730,9 +737,13 @@ export function createDesktopSettingsIpc(
         );
         return;
       }
+      const openExternalUrl = options.openExternalUrl;
       const session = await loginWithLoopback({
         coordinator: codexCoordinator(),
-        openBrowser: options.openExternalUrl,
+        openBrowser: async (url) => {
+          await openExternalUrl(url);
+          await options.presentChatGptSignInUrl?.(url);
+        },
       });
       // The onboarding welcome card's "Sign in with ChatGPT" implies the user
       // wants subscription routing, so enable the preference after a successful

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -742,7 +742,13 @@ export function createDesktopSettingsIpc(
         coordinator: codexCoordinator(),
         openBrowser: async (url) => {
           await openExternalUrl(url);
-          await options.presentChatGptSignInUrl?.(url);
+          // Fire-and-forget: the dialog is informational, so don't await it.
+          // `loginWithLoopback` awaits `openBrowser` before it waits for the
+          // OAuth callback, so awaiting a modal here would block sign-in
+          // completion until the user dismisses a dialog that the completed
+          // browser tab has already made redundant (matches the extension's
+          // non-blocking notification).
+          void options.presentChatGptSignInUrl?.(url);
         },
       });
       // The onboarding welcome card's "Sign in with ChatGPT" implies the user

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -609,6 +609,24 @@ function createWindow(options: {
       shell.showItemInFolder(filePath);
     },
     openExternalUrl: (url) => previewHost.openExternal(url),
+    presentChatGptSignInUrl: async (url) => {
+      // `openExternal` opens the system default browser. Offer the raw link so
+      // a user whose ChatGPT subscription is signed in elsewhere can open it in
+      // that browser — the loopback callback accepts the redirect from any one.
+      const result = await dialog.showMessageBox(window, {
+        type: 'info',
+        message: 'Signing in with ChatGPT',
+        detail:
+          'Opened your default browser. Using a different browser for ChatGPT? ' +
+          'Copy the link and open it there.',
+        buttons: ['Copy Sign-in Link', 'Close'],
+        defaultId: 0,
+        cancelId: 1,
+      });
+      if (result.response === 0) {
+        clipboard.writeText(url);
+      }
+    },
     installToolExtension: async (extensionId) => {
       // The desktop shell can't host VS Code extensions, so opening the
       // marketplace URL was misleading. Surface an info dialog that names

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -618,7 +618,8 @@ function createWindow(options: {
         message: 'Signing in with ChatGPT',
         detail:
           'Opened your default browser. Using a different browser for ChatGPT? ' +
-          'Copy the link and open it there.',
+          'Open this link there instead:\n\n' +
+          `${url}`,
         buttons: ['Copy Sign-in Link', 'Close'],
         defaultId: 0,
         cancelId: 1,

--- a/packages/extension/src/frontend/auth/codexSubscriptionSignIn.ts
+++ b/packages/extension/src/frontend/auth/codexSubscriptionSignIn.ts
@@ -11,6 +11,8 @@ import {
 } from '@auth/codex';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 
+const COPY_SIGN_IN_LINK = 'Copy Sign-in Link';
+
 async function runChatGptSignIn(): Promise<CodexSession> {
   const coordinator = codexCoordinator();
   if (vscode.env.remoteName) {
@@ -45,10 +47,10 @@ async function runChatGptSignIn(): Promise<CodexSession> {
       void vscode.window
         .showInformationMessage(
           'Signing in with ChatGPT in your default browser. Using a different browser for ChatGPT? Copy the link and open it there.',
-          'Copy Sign-in Link',
+          COPY_SIGN_IN_LINK,
         )
         .then((choice) => {
-          if (choice === 'Copy Sign-in Link') {
+          if (choice === COPY_SIGN_IN_LINK) {
             void vscode.env.clipboard.writeText(url);
           }
         });

--- a/packages/extension/src/frontend/auth/codexSubscriptionSignIn.ts
+++ b/packages/extension/src/frontend/auth/codexSubscriptionSignIn.ts
@@ -38,6 +38,20 @@ async function runChatGptSignIn(): Promise<CodexSession> {
     coordinator,
     openBrowser: async (url) => {
       await vscode.env.openExternal(vscode.Uri.parse(url));
+      // `openExternal` always targets the system default browser. The loopback
+      // callback accepts the redirect from *any* browser, so offer the raw link
+      // for users whose ChatGPT subscription is signed in elsewhere (e.g. their
+      // default browser is Chrome but the subscription lives in Firefox).
+      void vscode.window
+        .showInformationMessage(
+          'Signing in with ChatGPT in your default browser. Using a different browser for ChatGPT? Copy the link and open it there.',
+          'Copy Sign-in Link',
+        )
+        .then((choice) => {
+          if (choice === 'Copy Sign-in Link') {
+            void vscode.env.clipboard.writeText(url);
+          }
+        });
     },
   });
 }

--- a/src/test-kernel/frontend/CodexSubscriptionSignIn.vitest.ts
+++ b/src/test-kernel/frontend/CodexSubscriptionSignIn.vitest.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   showInformationMessage: vi.fn(),
   showWarningMessage: vi.fn(),
   openExternal: vi.fn(),
+  writeText: vi.fn(),
   withProgress: vi.fn(),
 }));
 
@@ -14,7 +15,7 @@ vi.mock('vscode', () => ({
   env: {
     remoteName: undefined,
     openExternal: mocks.openExternal,
-    clipboard: { writeText: vi.fn() },
+    clipboard: { writeText: mocks.writeText },
   },
   ProgressLocation: { Notification: 15 },
   Uri: {
@@ -106,6 +107,39 @@ describe('signInWithChatGptSubscription', () => {
     expect(signedIn).toBe(false);
     expect(mocks.showWarningMessage).toHaveBeenCalledWith(
       'Signed in with ChatGPT as person@example.com, but a more specific setting kept the subscription preference disabled.',
+    );
+  });
+
+  it('opens the default browser and offers the link for a non-default browser', async () => {
+    mocks.withProgress.mockImplementation((_options, task) => task());
+    mocks.openExternal.mockResolvedValue(true);
+    mocks.showInformationMessage.mockResolvedValue('Copy Sign-in Link');
+    mocks.setPreferCodexSubscription.mockResolvedValue({
+      effective: true,
+      target: 'global',
+    });
+    mocks.loginWithLoopback.mockImplementation(async ({ openBrowser }) => {
+      await openBrowser('https://auth.openai.com/authorize?x=1');
+      return {
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        expiresAtMs: Date.now() + 60_000,
+        email: 'person@example.com',
+      };
+    });
+
+    await signInWithChatGptSubscription('TestChannel');
+    // The deferred clipboard write is queued on a resolved-promise microtask.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mocks.openExternal).toHaveBeenCalledTimes(1);
+    expect(mocks.showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining('different browser'),
+      'Copy Sign-in Link',
+    );
+    expect(mocks.writeText).toHaveBeenCalledWith(
+      'https://auth.openai.com/authorize?x=1',
     );
   });
 


### PR DESCRIPTION
## Summary

When signing in with ChatGPT, the system default browser is opened automatically. However, users whose ChatGPT subscription is signed in on a different browser cannot complete the sign-in flow. This change offers the raw sign-in link as a copyable option in both the VS Code extension and desktop app, allowing users to open it in their subscription's browser while still accepting the OAuth redirect from any browser.

## Issue acceptance gates

Addresses the user experience gap where ChatGPT sign-in only targets the system default browser, preventing users with subscriptions in alternate browsers from completing authentication.

## Single source of truth

The `loginWithLoopback` coordinator in `src/agent/` now accepts an `openBrowser` callback that can perform additional actions after opening the default browser. The desktop and extension hosts implement the "offer copyable link" behavior by wrapping this callback.

## Duplication and abstraction budget

- **Desktop** (`packages/desktop/src/main/index.ts`): Added `presentChatGptSignInUrl` IPC option to handle the dialog and clipboard write.
- **Extension** (`packages/extension/src/frontend/auth/codexSubscriptionSignIn.ts`): Inline implementation of the information message and clipboard write after `openExternal`.
- **IPC interface** (`packages/desktop/src/main/desktopSettingsIpc.ts`): New optional `presentChatGptSignInUrl` method on `DesktopSettingsIpcOptions` to separate the "open browser" concern from the "offer link" concern.

No pass-through layers added; the abstraction boundary is the IPC interface between extension and desktop.

## Host impact

**Extension:** After opening the default browser via `vscode.env.openExternal()`, shows an information message with a "Copy Sign-in Link" action that copies the URL to the clipboard.

**Desktop:** After opening the default browser via `shell.openExternal()`, shows a message dialog with a "Copy Sign-in Link" button that copies the URL to the clipboard.

**CLI:** No changes.

## Scheduled refactoring

None.

## Validation

- Added test case `'opens the default browser and offers the link for a non-default browser'` in `src/test-kernel/frontend/CodexSubscriptionSignIn.vitest.ts` that verifies:
  - `openExternal` is called once
  - Information message is shown with the expected text
  - Clipboard write is called with the sign-in URL
- Updated mock setup to use a shared `mocks.writeText` instead of an inline `vi.fn()` for consistency
- Existing sign-in tests continue to pass

https://claude.ai/code/session_01KR8rGo54wKwRBNkMjaDnBh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX-only change around existing loopback OAuth; no new auth endpoints or callback rules, with careful non-blocking desktop dialog wiring to avoid sign-in regressions.
> 
> **Overview**
> ChatGPT loopback sign-in still opens the **system default browser**, but users whose subscription is active in another browser can now **copy the OAuth URL** and complete sign-in there—the loopback callback already accepts redirects from any browser.
> 
> **VS Code extension:** After `openExternal`, an information notification explains the default-browser behavior and adds a **Copy Sign-in Link** action that writes the authorize URL to the clipboard.
> 
> **Desktop:** A new optional `presentChatGptSignInUrl` hook shows an info dialog with the full link and a **Copy Sign-in Link** button. `signInChatGpt` invokes it **fire-and-forget** after opening the browser so a modal cannot block `loginWithLoopback` from waiting on the OAuth callback (aligned with the extension’s non-blocking notification).
> 
> Changelog documents the improvement; a vitest covers default-browser open, notification copy, and clipboard write.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07e418b6266f0357a3e8fee344c513f3e5ab03a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->