### PR TITLE
fix(desktop): route ChatGPT sign-in dialog rejection through onError

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -747,8 +747,11 @@ export function createDesktopSettingsIpc(
           // OAuth callback, so awaiting a modal here would block sign-in
           // completion until the user dismisses a dialog that the completed
           // browser tab has already made redundant (matches the extension's
-          // non-blocking notification).
-          void options.presentChatGptSignInUrl?.(url);
+          // non-blocking notification). Route a rejection through `onError`
+          // instead of letting it surface as an unhandled rejection.
+          void Promise.resolve(options.presentChatGptSignInUrl?.(url)).catch(
+            onError,
+          );
         },
       });
       // The onboarding welcome card's "Sign in with ChatGPT" implies the user


### PR DESCRIPTION
## Summary

Follow-up tidy-up to #6759 (ChatGPT sign-in from a non-default browser). That PR made the desktop "Copy Sign-in Link" dialog fire-and-forget (`void options.presentChatGptSignInUrl?.(url)`) so it stays off the OAuth critical path. The remaining gap: if `dialog.showMessageBox` ever rejects, the floated promise surfaces as an unhandled rejection instead of going through the sign-in flow's error handling.

This wraps the call in `Promise.resolve(...).catch(onError)` so any rejection routes through the host's existing `onError` plumbing. Behavior is otherwise unchanged — the dialog still fires without blocking sign-in completion.

## Issue acceptance gates

No issue. Addresses a review suggestion left on #6759 after it merged (give the fire-and-forget its own error handling).

## Single source of truth

`signInChatGpt` in `packages/desktop/src/main/desktopSettingsIpc.ts` remains the owner of the desktop sign-in flow; `onError` (`options.onError ?? defaultOnError`) is the single error sink it already uses for the rest of the flow.

## Duplication and abstraction budget

No new abstraction. Reuses the existing `onError` handler rather than introducing a bespoke catch.

## Host impact

Extension: None.

Desktop: A rejection from the fire-and-forget sign-in-link dialog now routes through `onError` instead of becoming an unhandled rejection.

CLI: None.

## Scheduled refactoring

None.

## Validation

- `npx eslint packages/desktop/src/main/desktopSettingsIpc.ts` — clean
- `npx vitest run src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts` — 34 passed
- `npx tsc --noEmit -p packages/desktop/tsconfig.json` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KR8rGo54wKwRBNkMjaDnBh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line error-handling tweak on a non-blocking UI path; OAuth and sign-in completion behavior are unchanged.
> 
> **Overview**
> The fire-and-forget **Copy Sign-in Link** dialog in `signInChatGpt` is unchanged in timing—it still does not block OAuth—but rejections from `presentChatGptSignInUrl` (for example `dialog.showMessageBox`) are now handled.
> 
> Instead of `void presentChatGptSignInUrl?.(url)`, the call is wrapped as `void Promise.resolve(...).catch(onError)` so failures use the same `onError` sink as the rest of the ChatGPT sign-in flow instead of surfacing as unhandled promise rejections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38d4f3f57247e3ec70a6bbfeba190a6c05e9a72d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->