### PR TITLE
fix(supabase): revert accidental edge-function deno dep bump from #6758

### DIFF
--- a/supabase/functions/auth-device/deno.json
+++ b/supabase/functions/auth-device/deno.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "@hono/hono": "jsr:@hono/hono@4.12.27",
-    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.108.2"
+    "@hono/hono": "jsr:@hono/hono@4.12.24",
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.108.1"
   }
 }

--- a/supabase/functions/auth-device/deno.lock
+++ b/supabase/functions/auth-device/deno.lock
@@ -1,20 +1,20 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@hono/hono@4.12.27": "4.12.27",
-    "jsr:@supabase/supabase-js@2.108.2": "2.108.2",
-    "npm:@supabase/auth-js@2.108.2": "2.108.2",
-    "npm:@supabase/functions-js@2.108.2": "2.108.2",
-    "npm:@supabase/postgrest-js@2.108.2": "2.108.2",
-    "npm:@supabase/realtime-js@2.108.2": "2.108.2",
-    "npm:@supabase/storage-js@2.108.2": "2.108.2"
+    "jsr:@hono/hono@4.12.24": "4.12.24",
+    "jsr:@supabase/supabase-js@2.108.1": "2.108.1",
+    "npm:@supabase/auth-js@2.108.1": "2.108.1",
+    "npm:@supabase/functions-js@2.108.1": "2.108.1",
+    "npm:@supabase/postgrest-js@2.108.1": "2.108.1",
+    "npm:@supabase/realtime-js@2.108.1": "2.108.1",
+    "npm:@supabase/storage-js@2.108.1": "2.108.1"
   },
   "jsr": {
-    "@hono/hono@4.12.27": {
-      "integrity": "3acc640592008e43f7048e8e53275203e0da84fbcd50201121195da7560583dc"
+    "@hono/hono@4.12.24": {
+      "integrity": "a74a40f06ae6704ddd0e8e576f6da9d34666c3e1e0f5412a2c1ff800ffd092f4"
     },
-    "@supabase/supabase-js@2.108.2": {
-      "integrity": "db603b534b1939a216ef004fe9fdd0c72bb4ba097fb04be23ea76cb8c70272aa",
+    "@supabase/supabase-js@2.108.1": {
+      "integrity": "c31883d00e36c759796683f2974e99201c3039fc2e539e0c3a1dd6dfb370332d",
       "dependencies": [
         "npm:@supabase/auth-js",
         "npm:@supabase/functions-js",
@@ -25,36 +25,36 @@
     }
   },
   "npm": {
-    "@supabase/auth-js@2.108.2": {
-      "integrity": "sha512-tNaQmBgodDZwgB40mRwVbxFy8IDYwjdpcZ0BYrWiwlULCSQoJj4QoG4zgJT7QRPXcqipefNOzvO/qAu4dF98ag==",
+    "@supabase/auth-js@2.108.1": {
+      "integrity": "sha512-Lle5rKU8f9LF3K5dDd8Or8mkkG+ptzRZZWKPVMm9B9UuovH65Ss2+iFnQqRsCqaGouvJEcTWyl0cj2riNrrDLQ==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/functions-js@2.108.2": {
-      "integrity": "sha512-RNUX8EiBy3iLwAX19jtRzLyePnl11/fHcgwDHLnpKcDSXt/5qBnh3LUwAtIjT21Q66QsmNUR2esrHziLCpNubw==",
+    "@supabase/functions-js@2.108.1": {
+      "integrity": "sha512-fxBRW/A4IG7ADQztVt0NaEy5ysiO1WJ2pbldsnBchrkHuyepX0Krek9qA9T4gUQBVVTCE9Ea4pdsM5hfn3nc4A==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/phoenix@0.4.4": {
-      "integrity": "sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ=="
+    "@supabase/phoenix@0.4.2": {
+      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A=="
     },
-    "@supabase/postgrest-js@2.108.2": {
-      "integrity": "sha512-GQ28/Y8hk3CFmkb3kXH1h/AQx6JIYSQfO0CJMRVBcEKZoNy6C45cXAZ4fcJvRC5Id0cs6xnkUV0+c0rIocigsw==",
+    "@supabase/postgrest-js@2.108.1": {
+      "integrity": "sha512-9lj2MCPPMgSTaJ5y+amnhb3TWPtMFVlbDn2hmX/VV91xQU4j0AauwfMaBErHBJ+zzsSwjc0jLU+zLIZFLQzfig==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/realtime-js@2.108.2": {
-      "integrity": "sha512-aAGxCSUemZvQIibnCdvNvgaKib28I4rfrNjKbQ9cG1uBLwUsI7hVpGXgEbypCCDhLjQlDTAiJlu7rgljYUT73g==",
+    "@supabase/realtime-js@2.108.1": {
+      "integrity": "sha512-mHGGqOjwd1XTydcoffUqEMsbFQHUi6A3uhQ0EXr3iqzpLqItxKA9nbN6gIQxrZ7JRRnuUe/iOFPUkYV9Tdc5lg==",
       "dependencies": [
         "@supabase/phoenix",
         "tslib"
       ]
     },
-    "@supabase/storage-js@2.108.2": {
-      "integrity": "sha512-TVZPQxXGxY2+A6yTtm77zUHsh70lBhYUEaJL8RQC+BghcX/ygiMG/rmXrNVBce30/WAeNPa8FiG8HbqlGeV05g==",
+    "@supabase/storage-js@2.108.1": {
+      "integrity": "sha512-Er0SGGt85iT6ye+SSh98Az6L2CesoZJuyzEZYH2oBOAnIxa9Nn4CtwUC3veGxYggoT56X+3tVuuQeDBP8kR8sg==",
       "dependencies": [
         "iceberg-js",
         "tslib"
@@ -69,8 +69,8 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@hono/hono@4.12.27",
-      "jsr:@supabase/supabase-js@2.108.2"
+      "jsr:@hono/hono@4.12.24",
+      "jsr:@supabase/supabase-js@2.108.1"
     ]
   }
 }

--- a/supabase/functions/auth-github/deno.json
+++ b/supabase/functions/auth-github/deno.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "@hono/hono": "jsr:@hono/hono@4.12.27",
-    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.108.2"
+    "@hono/hono": "jsr:@hono/hono@4.12.24",
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.108.1"
   }
 }

--- a/supabase/functions/auth-github/deno.lock
+++ b/supabase/functions/auth-github/deno.lock
@@ -1,20 +1,20 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@hono/hono@4.12.27": "4.12.27",
-    "jsr:@supabase/supabase-js@2.108.2": "2.108.2",
-    "npm:@supabase/auth-js@2.108.2": "2.108.2",
-    "npm:@supabase/functions-js@2.108.2": "2.108.2",
-    "npm:@supabase/postgrest-js@2.108.2": "2.108.2",
-    "npm:@supabase/realtime-js@2.108.2": "2.108.2",
-    "npm:@supabase/storage-js@2.108.2": "2.108.2"
+    "jsr:@hono/hono@4.12.24": "4.12.24",
+    "jsr:@supabase/supabase-js@2.108.1": "2.108.1",
+    "npm:@supabase/auth-js@2.108.1": "2.108.1",
+    "npm:@supabase/functions-js@2.108.1": "2.108.1",
+    "npm:@supabase/postgrest-js@2.108.1": "2.108.1",
+    "npm:@supabase/realtime-js@2.108.1": "2.108.1",
+    "npm:@supabase/storage-js@2.108.1": "2.108.1"
   },
   "jsr": {
-    "@hono/hono@4.12.27": {
-      "integrity": "3acc640592008e43f7048e8e53275203e0da84fbcd50201121195da7560583dc"
+    "@hono/hono@4.12.24": {
+      "integrity": "a74a40f06ae6704ddd0e8e576f6da9d34666c3e1e0f5412a2c1ff800ffd092f4"
     },
-    "@supabase/supabase-js@2.108.2": {
-      "integrity": "db603b534b1939a216ef004fe9fdd0c72bb4ba097fb04be23ea76cb8c70272aa",
+    "@supabase/supabase-js@2.108.1": {
+      "integrity": "c31883d00e36c759796683f2974e99201c3039fc2e539e0c3a1dd6dfb370332d",
       "dependencies": [
         "npm:@supabase/auth-js",
         "npm:@supabase/functions-js",
@@ -25,36 +25,36 @@
     }
   },
   "npm": {
-    "@supabase/auth-js@2.108.2": {
-      "integrity": "sha512-tNaQmBgodDZwgB40mRwVbxFy8IDYwjdpcZ0BYrWiwlULCSQoJj4QoG4zgJT7QRPXcqipefNOzvO/qAu4dF98ag==",
+    "@supabase/auth-js@2.108.1": {
+      "integrity": "sha512-Lle5rKU8f9LF3K5dDd8Or8mkkG+ptzRZZWKPVMm9B9UuovH65Ss2+iFnQqRsCqaGouvJEcTWyl0cj2riNrrDLQ==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/functions-js@2.108.2": {
-      "integrity": "sha512-RNUX8EiBy3iLwAX19jtRzLyePnl11/fHcgwDHLnpKcDSXt/5qBnh3LUwAtIjT21Q66QsmNUR2esrHziLCpNubw==",
+    "@supabase/functions-js@2.108.1": {
+      "integrity": "sha512-fxBRW/A4IG7ADQztVt0NaEy5ysiO1WJ2pbldsnBchrkHuyepX0Krek9qA9T4gUQBVVTCE9Ea4pdsM5hfn3nc4A==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/phoenix@0.4.4": {
-      "integrity": "sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ=="
+    "@supabase/phoenix@0.4.2": {
+      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A=="
     },
-    "@supabase/postgrest-js@2.108.2": {
-      "integrity": "sha512-GQ28/Y8hk3CFmkb3kXH1h/AQx6JIYSQfO0CJMRVBcEKZoNy6C45cXAZ4fcJvRC5Id0cs6xnkUV0+c0rIocigsw==",
+    "@supabase/postgrest-js@2.108.1": {
+      "integrity": "sha512-9lj2MCPPMgSTaJ5y+amnhb3TWPtMFVlbDn2hmX/VV91xQU4j0AauwfMaBErHBJ+zzsSwjc0jLU+zLIZFLQzfig==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/realtime-js@2.108.2": {
-      "integrity": "sha512-aAGxCSUemZvQIibnCdvNvgaKib28I4rfrNjKbQ9cG1uBLwUsI7hVpGXgEbypCCDhLjQlDTAiJlu7rgljYUT73g==",
+    "@supabase/realtime-js@2.108.1": {
+      "integrity": "sha512-mHGGqOjwd1XTydcoffUqEMsbFQHUi6A3uhQ0EXr3iqzpLqItxKA9nbN6gIQxrZ7JRRnuUe/iOFPUkYV9Tdc5lg==",
       "dependencies": [
         "@supabase/phoenix",
         "tslib"
       ]
     },
-    "@supabase/storage-js@2.108.2": {
-      "integrity": "sha512-TVZPQxXGxY2+A6yTtm77zUHsh70lBhYUEaJL8RQC+BghcX/ygiMG/rmXrNVBce30/WAeNPa8FiG8HbqlGeV05g==",
+    "@supabase/storage-js@2.108.1": {
+      "integrity": "sha512-Er0SGGt85iT6ye+SSh98Az6L2CesoZJuyzEZYH2oBOAnIxa9Nn4CtwUC3veGxYggoT56X+3tVuuQeDBP8kR8sg==",
       "dependencies": [
         "iceberg-js",
         "tslib"
@@ -69,8 +69,8 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@hono/hono@4.12.27",
-      "jsr:@supabase/supabase-js@2.108.2"
+      "jsr:@hono/hono@4.12.24",
+      "jsr:@supabase/supabase-js@2.108.1"
     ]
   }
 }

--- a/supabase/functions/get-agent-config/deno.json
+++ b/supabase/functions/get-agent-config/deno.json
@@ -1,5 +1,5 @@
 {
   "imports": {
-    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.108.2"
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.108.1"
   }
 }

--- a/supabase/functions/get-agent-config/deno.lock
+++ b/supabase/functions/get-agent-config/deno.lock
@@ -1,16 +1,16 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@supabase/supabase-js@2.108.2": "2.108.2",
-    "npm:@supabase/auth-js@2.108.2": "2.108.2",
-    "npm:@supabase/functions-js@2.108.2": "2.108.2",
-    "npm:@supabase/postgrest-js@2.108.2": "2.108.2",
-    "npm:@supabase/realtime-js@2.108.2": "2.108.2",
-    "npm:@supabase/storage-js@2.108.2": "2.108.2"
+    "jsr:@supabase/supabase-js@2.108.1": "2.108.1",
+    "npm:@supabase/auth-js@2.108.1": "2.108.1",
+    "npm:@supabase/functions-js@2.108.1": "2.108.1",
+    "npm:@supabase/postgrest-js@2.108.1": "2.108.1",
+    "npm:@supabase/realtime-js@2.108.1": "2.108.1",
+    "npm:@supabase/storage-js@2.108.1": "2.108.1"
   },
   "jsr": {
-    "@supabase/supabase-js@2.108.2": {
-      "integrity": "db603b534b1939a216ef004fe9fdd0c72bb4ba097fb04be23ea76cb8c70272aa",
+    "@supabase/supabase-js@2.108.1": {
+      "integrity": "c31883d00e36c759796683f2974e99201c3039fc2e539e0c3a1dd6dfb370332d",
       "dependencies": [
         "npm:@supabase/auth-js",
         "npm:@supabase/functions-js",
@@ -21,36 +21,36 @@
     }
   },
   "npm": {
-    "@supabase/auth-js@2.108.2": {
-      "integrity": "sha512-tNaQmBgodDZwgB40mRwVbxFy8IDYwjdpcZ0BYrWiwlULCSQoJj4QoG4zgJT7QRPXcqipefNOzvO/qAu4dF98ag==",
+    "@supabase/auth-js@2.108.1": {
+      "integrity": "sha512-Lle5rKU8f9LF3K5dDd8Or8mkkG+ptzRZZWKPVMm9B9UuovH65Ss2+iFnQqRsCqaGouvJEcTWyl0cj2riNrrDLQ==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/functions-js@2.108.2": {
-      "integrity": "sha512-RNUX8EiBy3iLwAX19jtRzLyePnl11/fHcgwDHLnpKcDSXt/5qBnh3LUwAtIjT21Q66QsmNUR2esrHziLCpNubw==",
+    "@supabase/functions-js@2.108.1": {
+      "integrity": "sha512-fxBRW/A4IG7ADQztVt0NaEy5ysiO1WJ2pbldsnBchrkHuyepX0Krek9qA9T4gUQBVVTCE9Ea4pdsM5hfn3nc4A==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/phoenix@0.4.4": {
-      "integrity": "sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ=="
+    "@supabase/phoenix@0.4.2": {
+      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A=="
     },
-    "@supabase/postgrest-js@2.108.2": {
-      "integrity": "sha512-GQ28/Y8hk3CFmkb3kXH1h/AQx6JIYSQfO0CJMRVBcEKZoNy6C45cXAZ4fcJvRC5Id0cs6xnkUV0+c0rIocigsw==",
+    "@supabase/postgrest-js@2.108.1": {
+      "integrity": "sha512-9lj2MCPPMgSTaJ5y+amnhb3TWPtMFVlbDn2hmX/VV91xQU4j0AauwfMaBErHBJ+zzsSwjc0jLU+zLIZFLQzfig==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/realtime-js@2.108.2": {
-      "integrity": "sha512-aAGxCSUemZvQIibnCdvNvgaKib28I4rfrNjKbQ9cG1uBLwUsI7hVpGXgEbypCCDhLjQlDTAiJlu7rgljYUT73g==",
+    "@supabase/realtime-js@2.108.1": {
+      "integrity": "sha512-mHGGqOjwd1XTydcoffUqEMsbFQHUi6A3uhQ0EXr3iqzpLqItxKA9nbN6gIQxrZ7JRRnuUe/iOFPUkYV9Tdc5lg==",
       "dependencies": [
         "@supabase/phoenix",
         "tslib"
       ]
     },
-    "@supabase/storage-js@2.108.2": {
-      "integrity": "sha512-TVZPQxXGxY2+A6yTtm77zUHsh70lBhYUEaJL8RQC+BghcX/ygiMG/rmXrNVBce30/WAeNPa8FiG8HbqlGeV05g==",
+    "@supabase/storage-js@2.108.1": {
+      "integrity": "sha512-Er0SGGt85iT6ye+SSh98Az6L2CesoZJuyzEZYH2oBOAnIxa9Nn4CtwUC3veGxYggoT56X+3tVuuQeDBP8kR8sg==",
       "dependencies": [
         "iceberg-js",
         "tslib"
@@ -65,7 +65,7 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@supabase/supabase-js@2.108.2"
+      "jsr:@supabase/supabase-js@2.108.1"
     ]
   }
 }

--- a/supabase/functions/log-usage/deno.json
+++ b/supabase/functions/log-usage/deno.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.108.2",
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.108.1",
     "zod": "npm:zod@^4.4.3"
   }
 }

--- a/supabase/functions/log-usage/deno.lock
+++ b/supabase/functions/log-usage/deno.lock
@@ -1,17 +1,17 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@supabase/supabase-js@2.108.2": "2.108.2",
-    "npm:@supabase/auth-js@2.108.2": "2.108.2",
-    "npm:@supabase/functions-js@2.108.2": "2.108.2",
-    "npm:@supabase/postgrest-js@2.108.2": "2.108.2",
-    "npm:@supabase/realtime-js@2.108.2": "2.108.2",
-    "npm:@supabase/storage-js@2.108.2": "2.108.2",
+    "jsr:@supabase/supabase-js@2.108.1": "2.108.1",
+    "npm:@supabase/auth-js@2.108.1": "2.108.1",
+    "npm:@supabase/functions-js@2.108.1": "2.108.1",
+    "npm:@supabase/postgrest-js@2.108.1": "2.108.1",
+    "npm:@supabase/realtime-js@2.108.1": "2.108.1",
+    "npm:@supabase/storage-js@2.108.1": "2.108.1",
     "npm:zod@^4.4.3": "4.4.3"
   },
   "jsr": {
-    "@supabase/supabase-js@2.108.2": {
-      "integrity": "db603b534b1939a216ef004fe9fdd0c72bb4ba097fb04be23ea76cb8c70272aa",
+    "@supabase/supabase-js@2.108.1": {
+      "integrity": "c31883d00e36c759796683f2974e99201c3039fc2e539e0c3a1dd6dfb370332d",
       "dependencies": [
         "npm:@supabase/auth-js",
         "npm:@supabase/functions-js",
@@ -22,36 +22,36 @@
     }
   },
   "npm": {
-    "@supabase/auth-js@2.108.2": {
-      "integrity": "sha512-tNaQmBgodDZwgB40mRwVbxFy8IDYwjdpcZ0BYrWiwlULCSQoJj4QoG4zgJT7QRPXcqipefNOzvO/qAu4dF98ag==",
+    "@supabase/auth-js@2.108.1": {
+      "integrity": "sha512-Lle5rKU8f9LF3K5dDd8Or8mkkG+ptzRZZWKPVMm9B9UuovH65Ss2+iFnQqRsCqaGouvJEcTWyl0cj2riNrrDLQ==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/functions-js@2.108.2": {
-      "integrity": "sha512-RNUX8EiBy3iLwAX19jtRzLyePnl11/fHcgwDHLnpKcDSXt/5qBnh3LUwAtIjT21Q66QsmNUR2esrHziLCpNubw==",
+    "@supabase/functions-js@2.108.1": {
+      "integrity": "sha512-fxBRW/A4IG7ADQztVt0NaEy5ysiO1WJ2pbldsnBchrkHuyepX0Krek9qA9T4gUQBVVTCE9Ea4pdsM5hfn3nc4A==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/phoenix@0.4.4": {
-      "integrity": "sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ=="
+    "@supabase/phoenix@0.4.2": {
+      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A=="
     },
-    "@supabase/postgrest-js@2.108.2": {
-      "integrity": "sha512-GQ28/Y8hk3CFmkb3kXH1h/AQx6JIYSQfO0CJMRVBcEKZoNy6C45cXAZ4fcJvRC5Id0cs6xnkUV0+c0rIocigsw==",
+    "@supabase/postgrest-js@2.108.1": {
+      "integrity": "sha512-9lj2MCPPMgSTaJ5y+amnhb3TWPtMFVlbDn2hmX/VV91xQU4j0AauwfMaBErHBJ+zzsSwjc0jLU+zLIZFLQzfig==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/realtime-js@2.108.2": {
-      "integrity": "sha512-aAGxCSUemZvQIibnCdvNvgaKib28I4rfrNjKbQ9cG1uBLwUsI7hVpGXgEbypCCDhLjQlDTAiJlu7rgljYUT73g==",
+    "@supabase/realtime-js@2.108.1": {
+      "integrity": "sha512-mHGGqOjwd1XTydcoffUqEMsbFQHUi6A3uhQ0EXr3iqzpLqItxKA9nbN6gIQxrZ7JRRnuUe/iOFPUkYV9Tdc5lg==",
       "dependencies": [
         "@supabase/phoenix",
         "tslib"
       ]
     },
-    "@supabase/storage-js@2.108.2": {
-      "integrity": "sha512-TVZPQxXGxY2+A6yTtm77zUHsh70lBhYUEaJL8RQC+BghcX/ygiMG/rmXrNVBce30/WAeNPa8FiG8HbqlGeV05g==",
+    "@supabase/storage-js@2.108.1": {
+      "integrity": "sha512-Er0SGGt85iT6ye+SSh98Az6L2CesoZJuyzEZYH2oBOAnIxa9Nn4CtwUC3veGxYggoT56X+3tVuuQeDBP8kR8sg==",
       "dependencies": [
         "iceberg-js",
         "tslib"
@@ -69,7 +69,7 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@supabase/supabase-js@2.108.2",
+      "jsr:@supabase/supabase-js@2.108.1",
       "npm:zod@^4.4.3"
     ]
   }

--- a/supabase/functions/relay-tokens/deno.json
+++ b/supabase/functions/relay-tokens/deno.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "@hono/hono": "jsr:@hono/hono@4.12.27",
-    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.108.2"
+    "@hono/hono": "jsr:@hono/hono@4.12.24",
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.108.1"
   }
 }

--- a/supabase/functions/relay-tokens/deno.lock
+++ b/supabase/functions/relay-tokens/deno.lock
@@ -1,20 +1,20 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@hono/hono@4.12.27": "4.12.27",
-    "jsr:@supabase/supabase-js@2.108.2": "2.108.2",
-    "npm:@supabase/auth-js@2.108.2": "2.108.2",
-    "npm:@supabase/functions-js@2.108.2": "2.108.2",
-    "npm:@supabase/postgrest-js@2.108.2": "2.108.2",
-    "npm:@supabase/realtime-js@2.108.2": "2.108.2",
-    "npm:@supabase/storage-js@2.108.2": "2.108.2"
+    "jsr:@hono/hono@4.12.24": "4.12.24",
+    "jsr:@supabase/supabase-js@2.108.1": "2.108.1",
+    "npm:@supabase/auth-js@2.108.1": "2.108.1",
+    "npm:@supabase/functions-js@2.108.1": "2.108.1",
+    "npm:@supabase/postgrest-js@2.108.1": "2.108.1",
+    "npm:@supabase/realtime-js@2.108.1": "2.108.1",
+    "npm:@supabase/storage-js@2.108.1": "2.108.1"
   },
   "jsr": {
-    "@hono/hono@4.12.27": {
-      "integrity": "3acc640592008e43f7048e8e53275203e0da84fbcd50201121195da7560583dc"
+    "@hono/hono@4.12.24": {
+      "integrity": "a74a40f06ae6704ddd0e8e576f6da9d34666c3e1e0f5412a2c1ff800ffd092f4"
     },
-    "@supabase/supabase-js@2.108.2": {
-      "integrity": "db603b534b1939a216ef004fe9fdd0c72bb4ba097fb04be23ea76cb8c70272aa",
+    "@supabase/supabase-js@2.108.1": {
+      "integrity": "c31883d00e36c759796683f2974e99201c3039fc2e539e0c3a1dd6dfb370332d",
       "dependencies": [
         "npm:@supabase/auth-js",
         "npm:@supabase/functions-js",
@@ -25,36 +25,36 @@
     }
   },
   "npm": {
-    "@supabase/auth-js@2.108.2": {
-      "integrity": "sha512-tNaQmBgodDZwgB40mRwVbxFy8IDYwjdpcZ0BYrWiwlULCSQoJj4QoG4zgJT7QRPXcqipefNOzvO/qAu4dF98ag==",
+    "@supabase/auth-js@2.108.1": {
+      "integrity": "sha512-Lle5rKU8f9LF3K5dDd8Or8mkkG+ptzRZZWKPVMm9B9UuovH65Ss2+iFnQqRsCqaGouvJEcTWyl0cj2riNrrDLQ==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/functions-js@2.108.2": {
-      "integrity": "sha512-RNUX8EiBy3iLwAX19jtRzLyePnl11/fHcgwDHLnpKcDSXt/5qBnh3LUwAtIjT21Q66QsmNUR2esrHziLCpNubw==",
+    "@supabase/functions-js@2.108.1": {
+      "integrity": "sha512-fxBRW/A4IG7ADQztVt0NaEy5ysiO1WJ2pbldsnBchrkHuyepX0Krek9qA9T4gUQBVVTCE9Ea4pdsM5hfn3nc4A==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/phoenix@0.4.4": {
-      "integrity": "sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ=="
+    "@supabase/phoenix@0.4.2": {
+      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A=="
     },
-    "@supabase/postgrest-js@2.108.2": {
-      "integrity": "sha512-GQ28/Y8hk3CFmkb3kXH1h/AQx6JIYSQfO0CJMRVBcEKZoNy6C45cXAZ4fcJvRC5Id0cs6xnkUV0+c0rIocigsw==",
+    "@supabase/postgrest-js@2.108.1": {
+      "integrity": "sha512-9lj2MCPPMgSTaJ5y+amnhb3TWPtMFVlbDn2hmX/VV91xQU4j0AauwfMaBErHBJ+zzsSwjc0jLU+zLIZFLQzfig==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/realtime-js@2.108.2": {
-      "integrity": "sha512-aAGxCSUemZvQIibnCdvNvgaKib28I4rfrNjKbQ9cG1uBLwUsI7hVpGXgEbypCCDhLjQlDTAiJlu7rgljYUT73g==",
+    "@supabase/realtime-js@2.108.1": {
+      "integrity": "sha512-mHGGqOjwd1XTydcoffUqEMsbFQHUi6A3uhQ0EXr3iqzpLqItxKA9nbN6gIQxrZ7JRRnuUe/iOFPUkYV9Tdc5lg==",
       "dependencies": [
         "@supabase/phoenix",
         "tslib"
       ]
     },
-    "@supabase/storage-js@2.108.2": {
-      "integrity": "sha512-TVZPQxXGxY2+A6yTtm77zUHsh70lBhYUEaJL8RQC+BghcX/ygiMG/rmXrNVBce30/WAeNPa8FiG8HbqlGeV05g==",
+    "@supabase/storage-js@2.108.1": {
+      "integrity": "sha512-Er0SGGt85iT6ye+SSh98Az6L2CesoZJuyzEZYH2oBOAnIxa9Nn4CtwUC3veGxYggoT56X+3tVuuQeDBP8kR8sg==",
       "dependencies": [
         "iceberg-js",
         "tslib"
@@ -69,8 +69,8 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@hono/hono@4.12.27",
-      "jsr:@supabase/supabase-js@2.108.2"
+      "jsr:@hono/hono@4.12.24",
+      "jsr:@supabase/supabase-js@2.108.1"
     ]
   }
 }

--- a/supabase/functions/relay/deno.json
+++ b/supabase/functions/relay/deno.json
@@ -1,7 +1,7 @@
 {
   "imports": {
-    "@hono/hono": "jsr:@hono/hono@4.12.27",
-    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.108.2",
+    "@hono/hono": "jsr:@hono/hono@4.12.24",
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.108.1",
     "llm-zoo": "npm:llm-zoo@^1.11.0"
   }
 }

--- a/supabase/functions/relay/deno.lock
+++ b/supabase/functions/relay/deno.lock
@@ -1,21 +1,21 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@hono/hono@4.12.27": "4.12.27",
-    "jsr:@supabase/supabase-js@2.108.2": "2.108.2",
-    "npm:@supabase/auth-js@2.108.2": "2.108.2",
-    "npm:@supabase/functions-js@2.108.2": "2.108.2",
-    "npm:@supabase/postgrest-js@2.108.2": "2.108.2",
-    "npm:@supabase/realtime-js@2.108.2": "2.108.2",
-    "npm:@supabase/storage-js@2.108.2": "2.108.2",
+    "jsr:@hono/hono@4.12.24": "4.12.24",
+    "jsr:@supabase/supabase-js@2.108.1": "2.108.1",
+    "npm:@supabase/auth-js@2.108.1": "2.108.1",
+    "npm:@supabase/functions-js@2.108.1": "2.108.1",
+    "npm:@supabase/postgrest-js@2.108.1": "2.108.1",
+    "npm:@supabase/realtime-js@2.108.1": "2.108.1",
+    "npm:@supabase/storage-js@2.108.1": "2.108.1",
     "npm:llm-zoo@^1.11.0": "1.11.0"
   },
   "jsr": {
-    "@hono/hono@4.12.27": {
-      "integrity": "3acc640592008e43f7048e8e53275203e0da84fbcd50201121195da7560583dc"
+    "@hono/hono@4.12.24": {
+      "integrity": "a74a40f06ae6704ddd0e8e576f6da9d34666c3e1e0f5412a2c1ff800ffd092f4"
     },
-    "@supabase/supabase-js@2.108.2": {
-      "integrity": "db603b534b1939a216ef004fe9fdd0c72bb4ba097fb04be23ea76cb8c70272aa",
+    "@supabase/supabase-js@2.108.1": {
+      "integrity": "c31883d00e36c759796683f2974e99201c3039fc2e539e0c3a1dd6dfb370332d",
       "dependencies": [
         "npm:@supabase/auth-js",
         "npm:@supabase/functions-js",
@@ -26,36 +26,36 @@
     }
   },
   "npm": {
-    "@supabase/auth-js@2.108.2": {
-      "integrity": "sha512-tNaQmBgodDZwgB40mRwVbxFy8IDYwjdpcZ0BYrWiwlULCSQoJj4QoG4zgJT7QRPXcqipefNOzvO/qAu4dF98ag==",
+    "@supabase/auth-js@2.108.1": {
+      "integrity": "sha512-Lle5rKU8f9LF3K5dDd8Or8mkkG+ptzRZZWKPVMm9B9UuovH65Ss2+iFnQqRsCqaGouvJEcTWyl0cj2riNrrDLQ==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/functions-js@2.108.2": {
-      "integrity": "sha512-RNUX8EiBy3iLwAX19jtRzLyePnl11/fHcgwDHLnpKcDSXt/5qBnh3LUwAtIjT21Q66QsmNUR2esrHziLCpNubw==",
+    "@supabase/functions-js@2.108.1": {
+      "integrity": "sha512-fxBRW/A4IG7ADQztVt0NaEy5ysiO1WJ2pbldsnBchrkHuyepX0Krek9qA9T4gUQBVVTCE9Ea4pdsM5hfn3nc4A==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/phoenix@0.4.4": {
-      "integrity": "sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ=="
+    "@supabase/phoenix@0.4.2": {
+      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A=="
     },
-    "@supabase/postgrest-js@2.108.2": {
-      "integrity": "sha512-GQ28/Y8hk3CFmkb3kXH1h/AQx6JIYSQfO0CJMRVBcEKZoNy6C45cXAZ4fcJvRC5Id0cs6xnkUV0+c0rIocigsw==",
+    "@supabase/postgrest-js@2.108.1": {
+      "integrity": "sha512-9lj2MCPPMgSTaJ5y+amnhb3TWPtMFVlbDn2hmX/VV91xQU4j0AauwfMaBErHBJ+zzsSwjc0jLU+zLIZFLQzfig==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/realtime-js@2.108.2": {
-      "integrity": "sha512-aAGxCSUemZvQIibnCdvNvgaKib28I4rfrNjKbQ9cG1uBLwUsI7hVpGXgEbypCCDhLjQlDTAiJlu7rgljYUT73g==",
+    "@supabase/realtime-js@2.108.1": {
+      "integrity": "sha512-mHGGqOjwd1XTydcoffUqEMsbFQHUi6A3uhQ0EXr3iqzpLqItxKA9nbN6gIQxrZ7JRRnuUe/iOFPUkYV9Tdc5lg==",
       "dependencies": [
         "@supabase/phoenix",
         "tslib"
       ]
     },
-    "@supabase/storage-js@2.108.2": {
-      "integrity": "sha512-TVZPQxXGxY2+A6yTtm77zUHsh70lBhYUEaJL8RQC+BghcX/ygiMG/rmXrNVBce30/WAeNPa8FiG8HbqlGeV05g==",
+    "@supabase/storage-js@2.108.1": {
+      "integrity": "sha512-Er0SGGt85iT6ye+SSh98Az6L2CesoZJuyzEZYH2oBOAnIxa9Nn4CtwUC3veGxYggoT56X+3tVuuQeDBP8kR8sg==",
       "dependencies": [
         "iceberg-js",
         "tslib"
@@ -73,8 +73,8 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@hono/hono@4.12.27",
-      "jsr:@supabase/supabase-js@2.108.2",
+      "jsr:@hono/hono@4.12.24",
+      "jsr:@supabase/supabase-js@2.108.1",
       "npm:llm-zoo@^1.11.0"
     ]
   }


### PR DESCRIPTION
## What happened

PR #6758 (the LaTeX subfolder-`\input` fix) unintentionally carried a dependency bump across all six Supabase edge functions:

- `@hono/hono` `4.12.24` → `4.12.27`
- `@supabase/supabase-js` `2.108.1` → `2.108.2`

(12 files: each function's `deno.json` + `deno.lock`.)

## Why

These were **not** a reviewed change. While iterating on #6758 I ran `CI=true npm run typecheck`, which triggered a local `pnpm install` that regenerated the `deno.*` files; a subsequent `git add -A` swept them into commit `e48401936`. My branch base (`384d40d27`) and pre-merge `main` both had `4.12.24`/`2.108.1`, so this was a pure accident, not an intentional bump.

No live impact: edge functions deploy separately (`supabase functions deploy`), so nothing shipped — but `main` shouldn't carry an unreviewed infra bump.

## This PR

Restores the twelve `deno.json`/`deno.lock` files to their pre-#6758 state (`4.12.24`/`2.108.1`). Pure revert — symmetric 152/152 diff, no other files touched. The LaTeX fix from #6758 stays intact.

If `4.12.27`/`2.108.2` is actually wanted, it should land as its own deliberate dependency PR rather than ride in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only downgrade to previously used versions; no application code changes, though auth/relay functions depend on these libs at deploy time.
> 
> **Overview**
> Reverts **unreviewed** Deno import/lockfile bumps that landed on `main` via PR #6758, restoring the prior pinned versions across six Supabase edge functions (`auth-device`, `auth-github`, `get-agent-config`, `log-usage`, `relay`, `relay-tokens`).
> 
> **`@hono/hono`** goes from `4.12.27` back to **`4.12.24`** where that function uses Hono. **`@supabase/supabase-js`** goes from `2.108.2` back to **`2.108.1`**, with matching updates in each function’s `deno.lock` (including transitive `@supabase/*` packages and `@supabase/phoenix` `0.4.4` → `0.4.2`). No edge function source or runtime logic is changed—only `deno.json` / `deno.lock` (12 files total).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38b3eca9b3e8a62668fb3fa8c402b16e616b4002. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->