### PR TITLE
chore(deps-dev): align desktop Playwright packages

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -28,7 +28,7 @@
     "electron": "^42.5.0",
     "electron-builder": "^26.15.3",
     "esbuild": "^0.28.1",
-    "playwright": "^1.61.0",
+    "playwright": "^1.61.1",
     "typescript": "^6.0.3",
     "vite": "^8.0.16"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -506,8 +506,8 @@ importers:
         specifier: ^0.28.1
         version: 0.28.1
       playwright:
-        specifier: ^1.61.0
-        version: 1.61.0
+        specifier: ^1.61.1
+        version: 1.61.1
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -4970,18 +4970,8 @@ packages:
     resolution: {integrity: sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==}
     engines: {node: '>=16.0.0'}
 
-  playwright-core@1.61.0:
-    resolution: {integrity: sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   playwright-core@1.61.1:
     resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  playwright@1.61.0:
-    resolution: {integrity: sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -10502,15 +10492,7 @@ snapshots:
       pvutils: 1.1.5
       tslib: 2.8.1
 
-  playwright-core@1.61.0: {}
-
   playwright-core@1.61.1: {}
-
-  playwright@1.61.0:
-    dependencies:
-      playwright-core: 1.61.0
-    optionalDependencies:
-      fsevents: 2.3.2
 
   playwright@1.61.1:
     dependencies:


### PR DESCRIPTION
## What

Align the desktop package's direct `playwright` dev dependency with `@playwright/test` after #6762.

#6762 bumped `@playwright/test` to `^1.61.1`, but left the direct `playwright` dependency at `^1.61.0`. The desktop e2e harness imports `_electron`, `ElectronApplication`, and `Page` from the direct `playwright` package, so the runner and Electron launcher should stay on the same patch release.

This PR changes only:

- `packages/desktop/package.json`: `playwright` `^1.61.0` -> `^1.61.1`
- `pnpm-lock.yaml`: removes the duplicate `playwright@1.61.0` / `playwright-core@1.61.0` entries

## Test plan

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm run typecheck`
- `corepack pnpm run lint` (0 errors; existing warnings remain)
- `corepack pnpm run test`
- `corepack pnpm run compile`
- `corepack pnpm run check:extension-package-invariants`

I also tried `corepack pnpm --filter @texra/desktop run --if-present test:e2e`; it fails before launching Playwright because the local e2e suite imports `src/common/webview/settingsViewCommands.js`, which is not present in this worktree build layout. That failure is independent of the Playwright version alignment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level dev dependency alignment only; no application or runtime code changes.
> 
> **Overview**
> Bumps the desktop package’s direct **`playwright`** dev dependency from **`^1.61.0`** to **`^1.61.1`** so it matches **`@playwright/test`** after a prior bump. The e2e harness imports Electron APIs from **`playwright`** directly, so both packages should stay on the same patch release.
> 
> The lockfile drops the duplicate **`playwright@1.61.0`** / **`playwright-core@1.61.0`** entries in favor of **1.61.1** only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cbb0978ea07638e92652a38832b334ac839f613. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->