### PR TITLE
docs(supabase): require --no-verify-jwt in edge-function deploy commands

### DIFF
--- a/docs/supabase/RELAY_SETUP.md
+++ b/docs/supabase/RELAY_SETUP.md
@@ -132,8 +132,12 @@ curl -X POST \
 To update the relay function after changes:
 
 ```bash
-supabase functions deploy relay
+supabase functions deploy relay --no-verify-jwt
 ```
+
+Always pass `--no-verify-jwt` — the relay validates the JWT (and CI tokens)
+itself, so omitting the flag flips the gateway to `verify_jwt=true` and breaks
+every relay call. This applies to all TeXRA edge functions.
 
 Changes take effect immediately. Client caches expire after 5 minutes.
 

--- a/docs/supabase/SUPABASE_SETUP.md
+++ b/docs/supabase/SUPABASE_SETUP.md
@@ -520,8 +520,12 @@ serve(async (req) => {
 ### 5. Deploy Edge Function
 
 ```bash
-supabase functions deploy get-agent-config
+supabase functions deploy get-agent-config --no-verify-jwt
 ```
+
+Deploy with `--no-verify-jwt`: the function verifies the user's JWT internally,
+so the gateway check must stay off (it would otherwise reject the request before
+the function runs). All TeXRA edge functions are deployed this way.
 
 ### 6. Get Edge Function URL
 


### PR DESCRIPTION
## What

Two deploy snippets in the Supabase setup docs omitted `--no-verify-jwt`:

- `docs/supabase/RELAY_SETUP.md` (the "update the relay function" section)
- `docs/supabase/SUPABASE_SETUP.md` (deploy `get-agent-config`)

Both now pass `--no-verify-jwt` and carry a one-line rationale.

## Why

Every TeXRA edge function validates auth itself (relay parses the provider Authorization header + accepts CI tokens; `auth-*` establish sessions; `before-user-created` checks a Standard Webhooks signature; the rest call `_shared/auth.ts`). Deploying without `--no-verify-jwt` flips the gateway to `verify_jwt=true` and rejects the request before the function runs — i.e. following these docs verbatim breaks relay / get-agent-config. Verified against the live project: all 8 deployed functions are `verify_jwt=false`.

## Scope

Docs only. The edge-function dependency bumps (`supabase-js` 2.108.2, `hono` 4.12.27) already landed on `main` separately, so they are not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to deploy commands; no application or infrastructure code is modified.
> 
> **Overview**
> Updates two Supabase setup doc snippets that still showed bare `supabase functions deploy` commands so they **always include `--no-verify-jwt`**, matching how TeXRA actually ships edge functions.
> 
> In **`RELAY_SETUP.md`**, the “update the relay function” redeploy example now uses `deploy relay --no-verify-jwt`, with a short note that the relay (and other TeXRA functions) validate JWTs/CI tokens in-function—skipping the flag turns gateway `verify_jwt` on and breaks relay traffic. In **`SUPABASE_SETUP.md`**, the `get-agent-config` deploy step gets the same flag plus rationale that internal JWT verification requires the gateway check to stay off.
> 
> **Docs only**; no runtime or deploy script changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15d3e89a4142b6ea63e150a453ffbdfc85344e52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->