### PR TITLE
fix(progress): make Approve/diff split-button carets read as one control

### DIFF
--- a/packages/extension/src/progressView/frontend/components/ApproveSplitButton.ts
+++ b/packages/extension/src/progressView/frontend/components/ApproveSplitButton.ts
@@ -79,30 +79,64 @@ export class ApproveSplitButton extends LitElement {
         min-width: 0;
       }
 
+      /* Square the inner corners so the label and caret fuse into one pill. */
       .approve-split .approve-split-main::part(base) {
         border-top-right-radius: 0;
         border-bottom-right-radius: 0;
       }
 
+      /* Pull the caret onto the label so their 1px borders overlap into a
+         single divider (instead of a doubled line) once they appear on hover. */
       .approve-split-menu {
         flex: 0 0 auto;
         display: inline-flex;
+        margin-left: calc(-1 * var(--border-thin));
       }
 
       .approve-split-trigger {
         flex: 0 0 auto;
-        width: 20px;
-        min-width: 20px;
-        padding: 0;
+        width: 1.5rem;
+        min-width: 1.5rem;
       }
 
+      /* Match the .action-button chrome: borderless at rest with the border
+         reserved (transparent) so nothing shifts, the caret at full presence
+         (success color, not the faint icon-button default), and only the right
+         corners rounded so it tucks against the label. */
       .approve-split-trigger::part(base) {
+        min-height: var(--height-control-compact);
+        height: auto;
+        width: 100%;
         padding: 0;
+        opacity: var(--opacity-full);
         color: var(--wa-color-success-fill-loud);
+        background: transparent;
+        border: var(--border-thin) solid transparent;
         border-top-left-radius: 0;
         border-bottom-left-radius: 0;
-        border-left: var(--border-thin) solid
-          var(--wa-color-button-separator, var(--wa-form-control-border-color));
+      }
+
+      .approve-split-trigger::part(base):hover {
+        background: transparent;
+      }
+
+      .approve-split-trigger wa-icon {
+        font-size: var(--font-size-sm);
+      }
+
+      /* Hovering or opening either half outlines the whole pair as one box with
+         a single internal divider, so the caret reads as Approve's menu rather
+         than a stray glyph floating beside the button. */
+      .approve-split:hover .approve-split-main::part(base),
+      .approve-split:hover .approve-split-trigger::part(base),
+      .approve-split:focus-within .approve-split-trigger::part(base),
+      .approve-split wa-dropdown[open] .approve-split-trigger::part(base) {
+        border-color: var(--wa-color-surface-border, var(--color-border));
+      }
+
+      .approve-split-trigger:focus-visible::part(base) {
+        outline: var(--border-thin) solid var(--wa-color-focus);
+        outline-offset: var(--border-thin);
       }
 
       .approve-split wa-dropdown[open] .approve-split-trigger wa-icon {
@@ -143,7 +177,7 @@ export class ApproveSplitButton extends LitElement {
           <wa-button
             id="approve-split-trigger-button"
             slot="trigger"
-            class="action-icon-button approve-split-trigger"
+            class="approve-split-trigger"
             appearance="plain"
             variant="neutral"
             size="small"

--- a/packages/extension/src/progressView/frontend/components/ApproveSplitButton.ts
+++ b/packages/extension/src/progressView/frontend/components/ApproveSplitButton.ts
@@ -129,7 +129,9 @@ export class ApproveSplitButton extends LitElement {
          than a stray glyph floating beside the button. */
       .approve-split:hover .approve-split-main::part(base),
       .approve-split:hover .approve-split-trigger::part(base),
+      .approve-split:focus-within .approve-split-main::part(base),
       .approve-split:focus-within .approve-split-trigger::part(base),
+      .approve-split wa-dropdown[open] .approve-split-main::part(base),
       .approve-split wa-dropdown[open] .approve-split-trigger::part(base) {
         border-color: var(--wa-color-surface-border, var(--color-border));
       }

--- a/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
@@ -102,7 +102,7 @@ export class ToolEditRequestPanel extends BaseFeedbackPanel {
                 <wa-button
                   id="tool-edit-diff-dropdown-trigger"
                   slot="trigger"
-                  class="action-icon-button diff-dropdown-trigger"
+                  class="diff-dropdown-trigger"
                   appearance="plain"
                   variant="neutral"
                   size="small"

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -304,7 +304,7 @@ export const requestPanelStyles: CSSResult = css`
   .approval-request__actions .diff-dropdown {
     position: relative;
     display: inline-flex;
-    align-items: center;
+    align-items: stretch;
     flex: 1 1 7rem;
     min-width: 0;
     max-width: min(8.25rem, 100%);
@@ -314,32 +314,78 @@ export const requestPanelStyles: CSSResult = css`
     flex: 1 1 auto;
     width: auto;
     min-width: 0;
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
   }
 
+  /* Square the inner corners so the label and caret fuse into one pill. */
   .approval-request__actions .diff-dropdown .diff-main-button::part(base) {
     width: 100%;
     min-width: 0;
     justify-content: center;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  /* wa-dropdown handles its own popup positioning; pull the caret onto the
+     label so their 1px borders overlap into a single divider on hover. */
+  .approval-request__actions .diff-dropdown .diff-dropdown-menu {
+    flex: 0 0 auto;
+    display: inline-flex;
+    margin-left: calc(-1 * var(--border-thin));
   }
 
   .approval-request__actions .diff-dropdown .diff-dropdown-trigger {
     flex: 0 0 auto;
-    width: 20px;
-    min-width: 20px;
-    padding: 0;
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-    border-left: var(--border-thin) solid
-      var(--wa-color-button-separator, var(--wa-form-control-border-color));
+    width: 1.5rem;
+    min-width: 1.5rem;
   }
 
-  /* wa-dropdown handles its own popup positioning, but we still want
-     the trigger button to lay out alongside the main diff button. */
-  .approval-request__actions .diff-dropdown .diff-dropdown-menu {
-    flex: 0 0 auto;
-    display: inline-flex;
+  /* Match the .action-button chrome: borderless at rest with the border
+     reserved (transparent) so nothing shifts, caret at full presence, and only
+     the right corners rounded so it tucks against the label. */
+  .approval-request__actions .diff-dropdown .diff-dropdown-trigger::part(base) {
+    min-height: var(--height-control-compact);
+    height: auto;
+    width: 100%;
+    padding: 0;
+    opacity: var(--opacity-full);
+    background: transparent;
+    border: var(--border-thin) solid transparent;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+
+  .approval-request__actions
+    .diff-dropdown
+    .diff-dropdown-trigger::part(base):hover {
+    background: transparent;
+  }
+
+  .approval-request__actions .diff-dropdown .diff-dropdown-trigger wa-icon {
+    font-size: var(--font-size-sm);
+  }
+
+  /* Hovering or opening either half outlines the whole pair as one box with a
+     single internal divider, so the caret reads as the diff button's menu
+     rather than a stray glyph floating beside it. */
+  .approval-request__actions .diff-dropdown:hover .diff-main-button::part(base),
+  .approval-request__actions
+    .diff-dropdown:hover
+    .diff-dropdown-trigger::part(base),
+  .approval-request__actions
+    .diff-dropdown:focus-within
+    .diff-dropdown-trigger::part(base),
+  .approval-request__actions
+    .diff-dropdown
+    wa-dropdown[open]
+    .diff-dropdown-trigger::part(base) {
+    border-color: var(--wa-color-surface-border, var(--color-border));
+  }
+
+  .approval-request__actions
+    .diff-dropdown
+    .diff-dropdown-trigger:focus-visible::part(base) {
+    outline: var(--border-thin) solid var(--wa-color-focus);
+    outline-offset: var(--border-thin);
   }
 
   .approval-request__actions

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -373,7 +373,14 @@ export const requestPanelStyles: CSSResult = css`
     .diff-dropdown-trigger::part(base),
   .approval-request__actions
     .diff-dropdown:focus-within
+    .diff-main-button::part(base),
+  .approval-request__actions
+    .diff-dropdown:focus-within
     .diff-dropdown-trigger::part(base),
+  .approval-request__actions
+    .diff-dropdown
+    wa-dropdown[open]
+    .diff-main-button::part(base),
   .approval-request__actions
     .diff-dropdown
     wa-dropdown[open]


### PR DESCRIPTION
## Summary

This PR makes the approval and diff split buttons read as one segmented control. The main action half and caret half now share the same hover, focus-within, and open-menu border treatment, with the caret styled as part of the button rather than as a detached icon.

The review follow-up adds the missing border state on the main half for keyboard focus and open dropdown states in both the Approve split button and the shared diff-action styles.

## Verification

- `corepack pnpm exec prettier --write packages/extension/src/progressView/frontend/components/ApproveSplitButton.ts src/shared/styles/requestPanelStyles.ts`
- `git diff --check`
- `corepack pnpm run typecheck`
- `corepack pnpm run lint` (passes with existing warnings)
- `corepack pnpm run compile:fast`