### PR TITLE
[codex] Fix TUI display-math live row handoff

### DIFF
--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -315,27 +315,27 @@ function boundedLines(
 }
 
 // Slice raw text to a tail window before wrapping: ~2 screen widths per
-// visible row covers worst-case wrapping without making the wrap O(text)
-// on every streaming delta. Shared by the live renderers and the viewport
-// row estimator so the cap stays consistent.
-export function tailWindow(
-  text: string,
-  cols: number,
-  tailRows: number,
-): string {
+// visible row covers worst-case wrapping without making the wrap O(text) on
+// every streaming delta. liveAssistantDisplayLines applies this window and is
+// shared by the live renderers and viewport row estimator.
+function tailWindow(text: string, cols: number, tailRows: number): string {
   const budget = Math.max(1, cols) * tailRows * 2;
   return text.length > budget ? text.slice(-budget) : text;
 }
 
-function plainWrapTailLines(
-  text: string,
-  cols: number,
-  tailRows: number,
-): readonly string[] {
-  const c = Math.max(1, cols);
-  return wrapAnsiToWidth(tailWindow(text, c, tailRows), c)
+export function liveAssistantDisplayLines({
+  rows,
+  text,
+  width,
+}: {
+  readonly rows: number;
+  readonly text: string;
+  readonly width?: number;
+}): readonly string[] {
+  const cols = Math.max(1, Math.floor(width ?? 80));
+  return wrapAnsiToWidth(tailWindow(text, cols, rows), cols)
     .split('\n')
-    .slice(-Math.max(1, tailRows));
+    .slice(-Math.max(1, rows));
 }
 
 export function boundedAssistantDisplayLines({
@@ -353,7 +353,7 @@ export function boundedAssistantDisplayLines({
 }): readonly string[] {
   const cols = Math.max(1, Math.floor(width ?? 80));
   if (!finalized) {
-    return plainWrapTailLines(text, cols, rows);
+    return liveAssistantDisplayLines({ rows, text, width: cols });
   }
   return boundedLines(
     renderAnsiMarkdown(text, { width: cols, colorEnabled }).split('\n'),
@@ -484,7 +484,11 @@ export const LiveTranscriptEntry = memo(function LiveTranscriptEntry({
   readonly width?: number;
 }): React.JSX.Element {
   const cols = Math.max(1, Math.floor(width ?? 80));
-  const rows = plainWrapTailLines(entry.text, cols, LIVE_TAIL_ROWS);
+  const rows = liveAssistantDisplayLines({
+    rows: LIVE_TAIL_ROWS,
+    text: entry.text,
+    width: cols,
+  });
   return (
     <Box flexDirection="column">
       <Text>{fillRows(rows.join('\n'), cols)}</Text>

--- a/packages/cli/src/chat/tui/panes/transcriptViewport.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptViewport.ts
@@ -8,7 +8,7 @@ import {
   PROCESS_ENTRY_MARGIN_BOTTOM_ROWS,
   USER_ENTRY_MARGIN_BOTTOM_ROWS,
   USER_ENTRY_MARGIN_TOP_ROWS,
-  tailWindow,
+  liveAssistantDisplayLines,
 } from './TranscriptEntry';
 import {
   isInquiryContinuationText,
@@ -91,10 +91,11 @@ function estimateLiveTranscriptEntryRows(
   if (entry.role === 'assistant') {
     return estimateEntryRows(() => {
       const cols = Math.max(1, width);
-      return Math.min(
-        LIVE_TAIL_ROWS,
-        estimateWrappedRows(tailWindow(entry.text, cols, LIVE_TAIL_ROWS), cols),
-      );
+      return liveAssistantDisplayLines({
+        rows: LIVE_TAIL_ROWS,
+        text: entry.text,
+        width: cols,
+      }).length;
     });
   }
   return estimateTranscriptEntryRows(entry, width);

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest';
 
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
+  LIVE_TAIL_ROWS,
   boundedAssistantDisplayLines,
   compactPrefixedDisplayRows,
+  liveAssistantDisplayLines,
 } from '@cli/chat/tui/panes/TranscriptEntry';
 import { formatRenderError } from '@cli/chat/tui/panes/EntryErrorBoundary';
 import {
@@ -349,6 +351,33 @@ describe('CLI conversation transcript splitting', () => {
     expect(finalizedTail).toContain('bold tail marker');
     expect(finalizedTail).not.toContain('**bold tail marker**');
     expect(streamingTail).toContain('**bold tail marker**');
+  });
+
+  it('budgets live assistant display-math rows with the live renderer', () => {
+    const text = [
+      'The sum evaluates to 1.6449290668357264.',
+      'For reference, the exact value is',
+      '\\[',
+      '  \\frac{\\pi^2}{6} \\approx 1.6449340668482264',
+      '\\]',
+      'So the partial sum up to $n = 199,\\!999$ is only off by about $5 \\times 10^{-6}$.',
+    ].join('\n');
+    const assistant = entry('a1', 'assistant', text, false);
+    const width = 52;
+    const liveRows = liveAssistantDisplayLines({
+      rows: LIVE_TAIL_ROWS,
+      text,
+      width,
+    }).length;
+
+    const selected = selectTranscriptEntriesForViewport(
+      [assistant],
+      100,
+      width,
+    );
+
+    expect(selected.usedRows).toBe(liveRows);
+    expect(selected.rowLimits.has('a1')).toBe(false);
   });
 
   it('pads compact prefixed rows to the viewport width', () => {


### PR DESCRIPTION
## Summary

Fixes #6740.

This PR makes the chat TUI use a single helper for the rows painted by live assistant text. The live renderer and the pending-viewport row estimator previously had separate implementations: the renderer used the ANSI-aware wrapping path, while the estimator used a raw character-count approximation. For responses containing multi-line display math, those two computations can disagree, so the live raw copy may not be fully cleared before the finalized Markdown-rendered copy is committed to static scrollback.

The change exports the live assistant row helper from the transcript entry renderer and uses it in the viewport estimator. The old tail-window helper is now private to that renderer module, so there is one owner for the live assistant row geometry.

## Validation

- corepack pnpm vitest run src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/AnsiMarkdown.vitest.mts
- corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-cli-6740 transcript slash-palette slash-help bash-approval subagents task-picker retry-approval external-inquiry-long
- corepack pnpm exec eslint packages/cli/src/chat/tui/panes/TranscriptEntry.tsx packages/cli/src/chat/tui/panes/transcriptViewport.ts src/test-kernel/cli/ConversationPane.vitest.mts
- corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json
- corepack pnpm --filter @texra-ai/cli typecheck
- npm run lint (passes with existing warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized TUI transcript layout refactor with a focused test; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes a **handoff glitch** when streaming assistant replies with multi-line display math: the live tail renderer and the pending-viewport row estimator no longer disagree about how many terminal rows the text occupies.
> 
> The change introduces **`liveAssistantDisplayLines`** as the single path for tail-window slicing, ANSI-aware wrapping, and row capping. **`LiveTranscriptEntry`**, streaming **`boundedAssistantDisplayLines`**, and **`estimateLiveTranscriptEntryRows`** in `transcriptViewport.ts` all call it instead of duplicating logic (the estimator previously used a raw character-wrap approximation on `tailWindow` alone). **`tailWindow`** stays module-private behind that helper.
> 
> A regression test asserts that **`selectTranscriptEntriesForViewport`** budgets the same row count as the live renderer for LaTeX-style assistant text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e797584d19ff3dcf4d71c83f8e73e0e21a2cc524. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->