### PR TITLE
[codex] Fix LaTeX workflow compile input dirs

### DIFF
--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -88,6 +88,11 @@ export class LatexDiffManager {
     return path.dirname(location.absolutePath);
   }
 
+  private resolveRunStorageSourceDir(location: FileLocation): string | null {
+    if (location.kind !== 'runStorage') return null;
+    return path.dirname(location.absolutePath);
+  }
+
   private logLatexdiffResult(
     result: LaTeXdiffResult,
     operation: string = 'latexdiff',
@@ -402,16 +407,19 @@ export class LatexDiffManager {
         WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS,
       ),
     );
-    // The diff `.tex` is written to `diff/r{round}/` rather than alongside the
-    // document's `\input`/`\bibliography` targets, so add the live workspace
-    // source directory to the search path; otherwise `\input{figures/…}` and
-    // `\bibliography{…}` fail to resolve when the source lives in a subfolder.
-    const sourceDir = this.resolveWorkspaceSourceDir(referenceLocation);
+    // The diff `.tex` is written to `diff/r{round}/`, away from both the
+    // revised round output and the live workspace source. Search the revised
+    // round directory first so same-round sibling edits win, then fall back to
+    // the original source tree for unchanged inputs and bibliographies.
+    const extraInputDirs = [
+      this.resolveRunStorageSourceDir(sourceLocation),
+      this.resolveWorkspaceSourceDir(referenceLocation),
+    ].filter((dir): dir is string => dir !== null);
     const ok = await compileLatex2Pdf(diffLocation, {
       channel: this.streamId,
       outputDirectory: buildDir,
       timeout: timeoutMs,
-      extraInputDirs: [sourceDir],
+      extraInputDirs,
     });
 
     if (!ok) {

--- a/src/agent/output/compileCheck.ts
+++ b/src/agent/output/compileCheck.ts
@@ -63,6 +63,24 @@ function getCompileDisplayName(file: OutputFileInfo): string {
   return srcBase && !GENERIC_STEMS.has(srcBase) ? srcBase : rawBase;
 }
 
+function resolveWorkspaceSourceDir(
+  outputFile: OutputFileInfo,
+  fallbackRelativePath: string,
+): string[] {
+  const workspaceRoot = WorkspaceFS.getPath();
+  if (!workspaceRoot) return [];
+
+  const source = outputFile.source.trim();
+  const located =
+    source.length > 0 ? WorkspaceFS.locatePath(source) : undefined;
+  const sourceRelativePath =
+    located?.kind === 'workspace' ? located.relativePath : fallbackRelativePath;
+
+  return path.isAbsolute(sourceRelativePath)
+    ? []
+    : [path.join(workspaceRoot, path.dirname(sourceRelativePath))];
+}
+
 /**
  * Compile each .tex output of a round to verify the workflow produced a
  * buildable document. Success is silent; failures write the log tail to
@@ -209,15 +227,10 @@ async function compileOne(
     return { failure: null, failureLogExcerpt: '', artifact: null };
   }
 
-  // The output compiles from `buildDir`, not its original workspace folder, so
-  // relative `\input{figures/…}` / `\bibliography{…}` only resolve if the
-  // original source directory is on the search path. Derive it from the
-  // workspace-relative path (r<N>/ already stripped above).
-  const workspaceRoot = WorkspaceFS.getPath();
-  const extraInputDirs =
-    workspaceRoot && !path.isAbsolute(pathForSafeName)
-      ? [path.join(workspaceRoot, path.dirname(pathForSafeName))]
-      : [];
+  // The output compiles from `buildDir`, not its original workspace folder.
+  // For extracted outputs, the run-storage basename can be generic while
+  // outputFile.source carries the real workspace path.
+  const extraInputDirs = resolveWorkspaceSourceDir(outputFile, pathForSafeName);
 
   // execa's timeout option kills the child process on expiry, so we don't
   // orphan hanging latexmk/pdflatex runs.

--- a/src/test-kernel/agent/output/LatexCompileInputDirs.vitest.ts
+++ b/src/test-kernel/agent/output/LatexCompileInputDirs.vitest.ts
@@ -1,0 +1,209 @@
+// Standard library imports
+import * as path from 'node:path';
+
+// Third-party imports
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports - agent
+import type { AgentTrace } from '@agent/trace';
+import {
+  AgentCategory,
+  AgentWorkflowSettingSchema,
+} from '@agent/core/definition/AgentDataclass';
+import { LatexDiffManager } from '@agent/output/LatexDiffManager';
+import { runCompileCheck } from '@agent/output/compileCheck';
+import { createOutputState, ensureRoundData } from '@agent/output/outputState';
+
+// Local imports - shared
+import type {
+  ExecutionId,
+  FileLocation,
+  OutputFileInfo,
+} from '@shared/schemas';
+import { WorkspaceStateKey } from '@shared/state/stateKeys';
+
+// Local imports - file utilities
+import {
+  TaskRunFileService,
+  createRunStorageLocation,
+  createWorkspaceLocation,
+} from '@utils/files';
+
+const mocks = vi.hoisted(() => ({
+  compileLatex2Pdf: vi.fn(async () => true),
+  hasLatexCompiler: vi.fn(async () => true),
+}));
+
+vi.mock('@latex/texTools', () => ({
+  compileLatex2Pdf: mocks.compileLatex2Pdf,
+}));
+
+vi.mock('@latex/latexToolchain', () => ({
+  hasLatexCompiler: mocks.hasLatexCompiler,
+}));
+
+const storagePath = '/storage';
+const workspacePath = '/workspace';
+
+function runDir(executionId: ExecutionId): string {
+  return path.join(storagePath, 'executions', executionId);
+}
+
+function runStorageFile(
+  executionId: ExecutionId,
+  relativePath: string,
+): FileLocation {
+  return createRunStorageLocation(
+    path.join(runDir(executionId), relativePath),
+    relativePath,
+    executionId,
+  );
+}
+
+function outputFile(
+  executionId: ExecutionId,
+  relativePath: string,
+  source: string,
+  round: number,
+): OutputFileInfo {
+  return {
+    source,
+    round,
+    location: runStorageFile(executionId, relativePath),
+    lineage: null,
+    diff: null,
+  };
+}
+
+function logger(): AgentTrace {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  } as unknown as AgentTrace;
+}
+
+async function initLatexPlatform(files: Record<string, string>): Promise<void> {
+  const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
+    import('@platform/platform'),
+    import('@test/support/FakePlatform'),
+  ]);
+  initPlatform(
+    createFakePlatform({
+      files,
+      storagePath,
+      workspacePath,
+      workspaceState: {
+        [WorkspaceStateKey.WORKFLOW_AUTO_COMPILE]: true,
+        [WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS]: 30_000,
+      },
+    }),
+  );
+}
+
+describe('workflow LaTeX compile input directories', () => {
+  beforeEach(() => {
+    mocks.compileLatex2Pdf.mockClear();
+    mocks.hasLatexCompiler.mockClear();
+  });
+
+  it('derives compile-check input dirs from outputFile.source', async () => {
+    const executionId = 'compile-source-dir';
+    const texPath = path.join(runDir(executionId), 'r1', 'main.tex');
+    await initLatexPlatform({
+      [texPath]: '\\documentclass{article}\\begin{document}Hi\\end{document}',
+    });
+
+    const outputState = createOutputState();
+    ensureRoundData(outputState, 1).outputs = [
+      outputFile(executionId, path.join('r1', 'main.tex'), 'Draft/main.tex', 1),
+    ];
+
+    await runCompileCheck(
+      {
+        fileService: new TaskRunFileService(executionId),
+        outputState,
+        logger: logger(),
+        streamId: 'compile-stream',
+      },
+      1,
+    );
+
+    expect(mocks.compileLatex2Pdf).toHaveBeenCalledWith(
+      expect.objectContaining({ absolutePath: texPath }),
+      expect.objectContaining({
+        extraInputDirs: [path.join(workspacePath, 'Draft')],
+      }),
+    );
+  });
+
+  it('compiles diffs with revised round inputs before workspace fallbacks', async () => {
+    const executionId = 'latexdiff-input-dir';
+    await initLatexPlatform({});
+
+    const manager = new LatexDiffManager(
+      AgentWorkflowSettingSchema.parse({
+        agentCategory: AgentCategory.Workflow,
+      }),
+      () => ({}),
+      [],
+      logger(),
+      'diff-stream',
+      new TaskRunFileService(executionId),
+    );
+
+    const referenceLocation = createWorkspaceLocation(
+      path.join(workspacePath, 'Draft', 'main.tex'),
+      'Draft/main.tex',
+    );
+    const sourceLocation = runStorageFile(
+      executionId,
+      path.join('r2', 'Draft', 'main.tex'),
+    );
+    const compileDiff = manager as unknown as {
+      compileDiffIfSuccessful(
+        result: { success: boolean; diffFileName?: string },
+        referenceLocation: FileLocation,
+        diffDirectory: {
+          absolutePath: string;
+          relativePath: string;
+          executionId: ExecutionId;
+        },
+        round: number,
+        sourceLocation: FileLocation,
+        pdfStemSuffix: string,
+      ): Promise<unknown>;
+    };
+
+    await compileDiff.compileDiffIfSuccessful(
+      { success: true, diffFileName: 'main-diff.tex' },
+      referenceLocation,
+      {
+        absolutePath: path.join(runDir(executionId), 'diff', 'r2'),
+        relativePath: path.join('diff', 'r2'),
+        executionId,
+      },
+      2,
+      sourceLocation,
+      '-diff',
+    );
+
+    expect(mocks.compileLatex2Pdf).toHaveBeenCalledWith(
+      expect.objectContaining({
+        absolutePath: path.join(
+          runDir(executionId),
+          'diff',
+          'r2',
+          'main-diff.tex',
+        ),
+      }),
+      expect.objectContaining({
+        extraInputDirs: [
+          path.join(runDir(executionId), 'r2', 'Draft'),
+          path.join(workspacePath, 'Draft'),
+        ],
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

This fixes two follow-ups from #6758 in the workflow LaTeX compile path.

- Derive automatic compile-check `extraInputDirs` from `outputFile.source` when it resolves inside the workspace, instead of only from the run-storage output path.
- Add the current revised run-storage source directory before the workspace fallback when compiling generated latexdiff files.
- Add focused test-kernel coverage for both caller paths without requiring a local TeX toolchain.

## Root Cause

Run-storage outputs can have a generic or relocated path such as `r1/main.tex`, while their recorded `source` still names the original workspace document such as `Draft/main.tex`. The compile check was deriving its search directory from the run-storage path, so subfolder inputs and bibliographies could be missed.

For compiled latexdiff PDFs, the generated diff file lives under `diff/r<N>/`, away from both the revised round outputs and the workspace source tree. Only the workspace source directory was passed to TeX, so included sibling files could resolve to the older workspace copy instead of the current round output.

## Validation

- `corepack pnpm vitest run src/test-kernel/agent/output/LatexCompileInputDirs.vitest.ts`
- `corepack pnpm vitest run src/test-kernel/agent/output/LatexCompileInputDirs.vitest.ts src/test-kernel/agent/output/CompiledPdfArtifacts.vitest.ts src/test-kernel/agent/output/LineageMapping.vitest.ts src/test-kernel/agent/output/XmlOutputManager.vitest.ts src/test-kernel/latex/TexInputEnv.vitest.ts`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- `corepack pnpm exec eslint src/agent/output/compileCheck.ts src/agent/output/LatexDiffManager.ts src/test-kernel/agent/output/LatexCompileInputDirs.vitest.ts`
- `npm run lint` (passes with existing warnings only)

Closes #6765.
Closes #6766.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted path-resolution fixes in the workflow LaTeX compile path with new unit tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **LaTeX `extraInputDirs`** for workflow auto-compile and latexdiff PDF builds so `\input` / `\bibliography` resolve against the right trees when outputs live in run storage.
> 
> **Compile check** (`compileCheck.ts`) now derives the workspace search directory from **`outputFile.source`** (via `WorkspaceFS.locatePath`) when it points at a workspace file, instead of only the run-storage path (e.g. `r1/main.tex` vs `Draft/main.tex`).
> 
> **Latexdiff PDF compile** (`LatexDiffManager.ts`) passes **two** extra dirs in order: the **current revised round** run-storage parent (`resolveRunStorageSourceDir` on the revised output), then the **workspace source** fallback from the reference/base location—so same-round sibling files win over stale workspace copies.
> 
> Adds **`LatexCompileInputDirs.vitest.ts`** with mocked `compileLatex2Pdf` covering both caller paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eeb15587c4024764b5b49415038e2d8f1707b35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->