### PR TITLE
feat(progress): show usage route badges

### DIFF
--- a/packages/extension/src/progressView/frontend/components/UsagePanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UsagePanel.ts
@@ -7,9 +7,15 @@ import { when } from 'lit/directives/when.js';
 // Side-effect imports - register WA icon component
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
+// Local imports - shared schemas
+import {
+  resolveUsageRoute,
+  type TokenUsageStats,
+  type UsageRoute,
+} from '@shared/schemas';
+
 // Local imports - shared styles
 import { designTokens } from '@shared/styles';
-import type { TokenUsageStats, UsageRoute } from '@shared/schemas';
 import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
 import { clamp, formatCompactTokenCount } from '@utils/core';
 import { formatCostUsd } from '@utils/text/stringUtils';
@@ -34,17 +40,6 @@ function fillColor(percent: number): string {
   if (percent <= 65) return 'var(--color-success)';
   if (percent <= 80) return 'var(--color-warning)';
   return 'var(--color-status-error)';
-}
-
-function resolveUsageRoute(
-  usage: TokenUsageStats | null,
-): UsageRoute | undefined {
-  return (
-    usage?.usageRoute ??
-    (usage?.viaChatGptSubscription === true
-      ? 'chatgpt-subscription'
-      : undefined)
-  );
 }
 
 function usageRouteBadge(

--- a/packages/extension/src/progressView/frontend/components/UsagePanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UsagePanel.ts
@@ -9,7 +9,7 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
 // Local imports - shared styles
 import { designTokens } from '@shared/styles';
-import type { TokenUsageStats } from '@shared/schemas';
+import type { TokenUsageStats, UsageRoute } from '@shared/schemas';
 import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
 import { clamp, formatCompactTokenCount } from '@utils/core';
 import { formatCostUsd } from '@utils/text/stringUtils';
@@ -24,11 +24,60 @@ import type { ContextStateData } from '../store';
  */
 const COMPACTION_THRESHOLD = 75;
 
+type UsageRouteBadge = {
+  label: string;
+  title: string;
+};
+
 /** Solid fill color based on context utilization. */
 function fillColor(percent: number): string {
   if (percent <= 65) return 'var(--color-success)';
   if (percent <= 80) return 'var(--color-warning)';
   return 'var(--color-status-error)';
+}
+
+function resolveUsageRoute(
+  usage: TokenUsageStats | null,
+): UsageRoute | undefined {
+  return (
+    usage?.usageRoute ??
+    (usage?.viaChatGptSubscription === true
+      ? 'chatgpt-subscription'
+      : undefined)
+  );
+}
+
+function usageRouteBadge(
+  route: UsageRoute | undefined,
+): UsageRouteBadge | undefined {
+  switch (route) {
+    case 'chatgpt-subscription':
+      return {
+        label: 'ChatGPT',
+        title: 'No charge; covered by your ChatGPT subscription',
+      };
+    case 'relay':
+      return {
+        label: 'relay',
+        title: 'Routed through the TeXRA relay',
+      };
+    case 'api-key':
+      return {
+        label: 'your key',
+        title: 'Billed through your configured API key',
+      };
+    default:
+      return undefined;
+  }
+}
+
+function usageCostLabel(cost: number, route: UsageRoute | undefined): string {
+  const badge = usageRouteBadge(route);
+  if (!badge) return formatCostUsd(cost);
+  if (route === 'chatgpt-subscription' && cost === 0) {
+    return `Free via ${badge.label}`;
+  }
+  return `${formatCostUsd(cost)} via ${badge.label}`;
 }
 
 @customElement('usage-panel')
@@ -69,9 +118,12 @@ export class UsagePanel extends LitElement {
         opacity: var(--opacity-subtle);
       }
 
-      .run-summary__free {
-        color: var(--color-success);
+      .run-summary__route {
         font-weight: var(--wa-font-weight-semibold);
+      }
+
+      .run-summary__route--free {
+        color: var(--color-success);
       }
 
       /* Context gauge bar */
@@ -237,15 +289,28 @@ export class UsagePanel extends LitElement {
           aria-hidden="true"
         ></wa-icon
         >${formatCompactTokenCount(outputTokens)} ·
-        ${this.usage.viaChatGptSubscription === true && cost === 0
-          ? html`<span
-              class="run-summary__free"
-              title="No charge — covered by your ChatGPT subscription"
-              >Free</span
-            >`
-          : html`${formatCostUsd(cost)}`}
+        ${this.renderCostRoute(cost)}
       </span>
     `;
+  }
+
+  private renderCostRoute(cost: number): TemplateResult {
+    const route = resolveUsageRoute(this.usage);
+    const badge = usageRouteBadge(route);
+    if (!badge) return html`${formatCostUsd(cost)}`;
+
+    if (route === 'chatgpt-subscription' && cost === 0) {
+      return html`<span
+        class="run-summary__route run-summary__route--free"
+        title=${badge.title}
+        >Free · ${badge.label}</span
+      >`;
+    }
+
+    return html`${formatCostUsd(cost)} ·
+      <span class="run-summary__route" title=${badge.title}>
+        ${badge.label}
+      </span>`;
   }
 
   private renderContext(): TemplateResult | typeof nothing {
@@ -285,12 +350,8 @@ export class UsagePanel extends LitElement {
 
   private buildUsageLabel(): string {
     if (!this.usage) return '';
-    const { inputTokens, outputTokens, cost, viaChatGptSubscription } =
-      this.usage;
-    const costLabel =
-      viaChatGptSubscription === true && cost === 0
-        ? 'Free'
-        : formatCostUsd(cost);
+    const { inputTokens, outputTokens, cost } = this.usage;
+    const costLabel = usageCostLabel(cost, resolveUsageRoute(this.usage));
     return `Total usage: ${formatCompactTokenCount(inputTokens)} input tokens, ${formatCompactTokenCount(outputTokens)} output tokens, ${costLabel}`;
   }
 }

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -127,7 +127,6 @@ export class UsageMonitor {
       const viaChatGptSubscription =
         latestUsage?.viaChatGptSubscription ?? false;
       const usageRoute = this.resolveUsageRoute(viaChatGptSubscription);
-      const usedRelay = usageRoute === 'relay';
 
       const { capabilities } = this.modelInfo;
       const supportsCaching =
@@ -163,7 +162,7 @@ export class UsageMonitor {
         }),
         ...(toolUseTokens > 0 && { toolUseTokens }),
         ...(viaChatGptSubscription && { viaChatGptSubscription: true }),
-        usageRoute,
+        ...(usageRoute != null && { usageRoute }),
       };
 
       // Two surfaces for usage: the progress-view sidebar (via runtimeHost
@@ -203,7 +202,7 @@ export class UsageMonitor {
         // Free ChatGPT-subscription round: still logged (cost is 0), but marked
         // so analytics can tell it apart from any other zero-cost row.
         viaChatGptSubscription,
-        usedRelay,
+        usageRoute,
       });
     } catch (error) {
       logger.error(
@@ -230,27 +229,29 @@ export class UsageMonitor {
     return (totals.totalCacheReadInputTokens / totalCacheableTokens) * 100;
   }
 
-  private resolveUsageRoute(viaChatGptSubscription: boolean): UsageRoute {
+  private resolveUsageRoute(
+    viaChatGptSubscription: boolean,
+  ): UsageRoute | undefined {
     if (viaChatGptSubscription) return 'chatgpt-subscription';
-    return this.usesRelayRoute() ? 'relay' : 'api-key';
-  }
-
-  private usesRelayRoute(): boolean {
     try {
-      const { config } = this.modelInfo;
-      return (
-        !shouldUseOpenRouter(config) &&
-        getServerSideKeyService().shouldUseServerSideKeysSync(
-          config.provider,
-          config.name,
-        )
-      );
+      return this.usesRelayRoute() ? 'relay' : 'api-key';
     } catch (error) {
       this.context.logger.debug(
         `Usage route relay check failed: ${toErrorMessage(error)}`,
       );
-      return false;
+      return undefined;
     }
+  }
+
+  private usesRelayRoute(): boolean {
+    const { config } = this.modelInfo;
+    return (
+      !shouldUseOpenRouter(config) &&
+      getServerSideKeyService().shouldUseServerSideKeysSync(
+        config.provider,
+        config.name,
+      )
+    );
   }
 
   /**
@@ -268,7 +269,7 @@ export class UsageMonitor {
       reasoningTokens?: number;
       cost: number;
       viaChatGptSubscription?: boolean;
-      usedRelay: boolean;
+      usageRoute?: UsageRoute;
     },
   ): Promise<void> {
     try {
@@ -281,7 +282,15 @@ export class UsageMonitor {
         usage.cacheMissInputTokens ??
         Math.max(0, usage.inputTokens - cachedInputTokens);
 
-      const { usedRelay } = usage;
+      const usedRelay =
+        usage.usageRoute != null
+          ? usage.usageRoute === 'relay'
+          : !usage.viaChatGptSubscription &&
+            !shouldUseOpenRouter(config) &&
+            getServerSideKeyService().shouldUseServerSideKeysSync(
+              config.provider,
+              config.name,
+            );
 
       UsageLogService.log({
         model: config.fullName,

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -13,6 +13,7 @@ import type {
   StorageKey,
   StreamTabId,
   TokenUsageStats,
+  UsageRoute,
 } from '@shared/schemas';
 import { roundTo } from '@utils/core';
 import type { ModelCapabilities, ModelConfig } from 'llm-zoo';
@@ -125,6 +126,8 @@ export class UsageMonitor {
       const toolUseTokens = latestUsage?.toolUsePromptTokens ?? 0;
       const viaChatGptSubscription =
         latestUsage?.viaChatGptSubscription ?? false;
+      const usageRoute = this.resolveUsageRoute(viaChatGptSubscription);
+      const usedRelay = usageRoute === 'relay';
 
       const { capabilities } = this.modelInfo;
       const supportsCaching =
@@ -160,6 +163,7 @@ export class UsageMonitor {
         }),
         ...(toolUseTokens > 0 && { toolUseTokens }),
         ...(viaChatGptSubscription && { viaChatGptSubscription: true }),
+        usageRoute,
       };
 
       // Two surfaces for usage: the progress-view sidebar (via runtimeHost
@@ -199,6 +203,7 @@ export class UsageMonitor {
         // Free ChatGPT-subscription round: still logged (cost is 0), but marked
         // so analytics can tell it apart from any other zero-cost row.
         viaChatGptSubscription,
+        usedRelay,
       });
     } catch (error) {
       logger.error(
@@ -225,6 +230,29 @@ export class UsageMonitor {
     return (totals.totalCacheReadInputTokens / totalCacheableTokens) * 100;
   }
 
+  private resolveUsageRoute(viaChatGptSubscription: boolean): UsageRoute {
+    if (viaChatGptSubscription) return 'chatgpt-subscription';
+    return this.usesRelayRoute() ? 'relay' : 'api-key';
+  }
+
+  private usesRelayRoute(): boolean {
+    try {
+      const { config } = this.modelInfo;
+      return (
+        !shouldUseOpenRouter(config) &&
+        getServerSideKeyService().shouldUseServerSideKeysSync(
+          config.provider,
+          config.name,
+        )
+      );
+    } catch (error) {
+      this.context.logger.debug(
+        `Usage route relay check failed: ${toErrorMessage(error)}`,
+      );
+      return false;
+    }
+  }
+
   /**
    * Log per-round usage to backend for analytics/billing.
    * Errors are caught and logged, never thrown.
@@ -240,6 +268,7 @@ export class UsageMonitor {
       reasoningTokens?: number;
       cost: number;
       viaChatGptSubscription?: boolean;
+      usedRelay: boolean;
     },
   ): Promise<void> {
     try {
@@ -252,13 +281,7 @@ export class UsageMonitor {
         usage.cacheMissInputTokens ??
         Math.max(0, usage.inputTokens - cachedInputTokens);
 
-      const usedRelay =
-        !usage.viaChatGptSubscription &&
-        !shouldUseOpenRouter(config) &&
-        getServerSideKeyService().shouldUseServerSideKeysSync(
-          config.provider,
-          config.name,
-        );
+      const { usedRelay } = usage;
 
       UsageLogService.log({
         model: config.fullName,

--- a/src/shared/schemas/streamData.ts
+++ b/src/shared/schemas/streamData.ts
@@ -21,6 +21,7 @@ import { z } from 'zod';
 import { CompileFailureSchema, OutputFileInfoSchema } from './output';
 import {
   TokenUsageStatsSchema,
+  UsageRouteSchema,
   emptyUsageStats,
   type TokenUsageStats,
 } from './usage';
@@ -273,6 +274,7 @@ const numericUsageParsingShape = Object.fromEntries(
 const TokenUsageStatsParsingBaseSchema = z.object({
   ...numericUsageParsingShape,
   viaChatGptSubscription: z.boolean().catch(false).prefault(false),
+  usageRoute: UsageRouteSchema.optional().catch(undefined),
   // The numeric fields are derived from `TokenUsageStatsSchema.shape` above;
   // TypeScript cannot recover the required keys through `Object.fromEntries`.
 }) as unknown as z.ZodType<TokenUsageStats>;

--- a/src/shared/schemas/usage.ts
+++ b/src/shared/schemas/usage.ts
@@ -2,6 +2,14 @@ import { z } from 'zod';
 
 export const TokenCountSchema = z.int().nonnegative();
 
+export const UsageRouteSchema = z.enum([
+  'chatgpt-subscription',
+  'relay',
+  'api-key',
+]);
+
+export type UsageRoute = z.infer<typeof UsageRouteSchema>;
+
 export const TokenUsageStatsSchema = z.strictObject({
   inputTokens: TokenCountSchema,
   outputTokens: TokenCountSchema,
@@ -10,12 +18,16 @@ export const TokenUsageStatsSchema = z.strictObject({
   cacheMissInputTokens: TokenCountSchema.optional(),
   cacheCreationInputTokens: TokenCountSchema.optional(),
   viaChatGptSubscription: z.boolean().optional(),
+  usageRoute: UsageRouteSchema.optional(),
 });
 
 export type TokenUsageStats = z.infer<typeof TokenUsageStatsSchema>;
 
+type EmptyUsageStats = Required<Omit<TokenUsageStats, 'usageRoute'>> &
+  Pick<TokenUsageStats, 'usageRoute'>;
+
 /** Returns zero-initialized usage stats. */
-export function emptyUsageStats(): Required<TokenUsageStats> {
+export function emptyUsageStats(): EmptyUsageStats {
   return {
     inputTokens: 0,
     outputTokens: 0,
@@ -38,6 +50,15 @@ function hasUsageActivity(usage: TokenUsageStats): boolean {
   );
 }
 
+function usageRouteForAggregation(
+  usage: TokenUsageStats,
+): UsageRoute | undefined {
+  return (
+    usage.usageRoute ??
+    (usage.viaChatGptSubscription === true ? 'chatgpt-subscription' : undefined)
+  );
+}
+
 /** Accumulates usage stats from an iterable into a single total. */
 export function sumUsageStats(
   items: Iterable<TokenUsageStats>,
@@ -45,6 +66,9 @@ export function sumUsageStats(
   const total = emptyUsageStats();
   let sawUsageActivity = false;
   let allRoundsViaChatGptSubscription = true;
+  let commonUsageRoute: UsageRoute | undefined;
+  let sawUsageRoute = false;
+  let hasMixedOrMissingUsageRoute = false;
   for (const usage of items) {
     total.inputTokens += usage.inputTokens;
     total.outputTokens += usage.outputTokens;
@@ -61,12 +85,31 @@ export function sumUsageStats(
       allRoundsViaChatGptSubscription =
         allRoundsViaChatGptSubscription &&
         usage.viaChatGptSubscription === true;
+
+      const usageRoute = usageRouteForAggregation(usage);
+      if (usageRoute == null) {
+        hasMixedOrMissingUsageRoute = true;
+      } else if (!sawUsageRoute) {
+        commonUsageRoute = usageRoute;
+        sawUsageRoute = true;
+      } else if (commonUsageRoute !== usageRoute) {
+        hasMixedOrMissingUsageRoute = true;
+        commonUsageRoute = undefined;
+      }
     }
   }
   // Only true when every non-empty accumulated round used the subscription;
   // zero baselines are neutral, while API-key or relay rounds make the total mixed.
   total.viaChatGptSubscription =
     sawUsageActivity && allRoundsViaChatGptSubscription;
+  if (
+    sawUsageActivity &&
+    sawUsageRoute &&
+    !hasMixedOrMissingUsageRoute &&
+    commonUsageRoute
+  ) {
+    total.usageRoute = commonUsageRoute;
+  }
   return total;
 }
 

--- a/src/shared/schemas/usage.ts
+++ b/src/shared/schemas/usage.ts
@@ -23,6 +23,11 @@ export const TokenUsageStatsSchema = z.strictObject({
 
 export type TokenUsageStats = z.infer<typeof TokenUsageStatsSchema>;
 
+type UsageRouteInput = Pick<
+  TokenUsageStats,
+  'usageRoute' | 'viaChatGptSubscription'
+>;
+
 type EmptyUsageStats = Required<Omit<TokenUsageStats, 'usageRoute'>> &
   Pick<TokenUsageStats, 'usageRoute'>;
 
@@ -50,12 +55,14 @@ function hasUsageActivity(usage: TokenUsageStats): boolean {
   );
 }
 
-function usageRouteForAggregation(
-  usage: TokenUsageStats,
+export function resolveUsageRoute(
+  usage: UsageRouteInput | null | undefined,
 ): UsageRoute | undefined {
   return (
-    usage.usageRoute ??
-    (usage.viaChatGptSubscription === true ? 'chatgpt-subscription' : undefined)
+    usage?.usageRoute ??
+    (usage?.viaChatGptSubscription === true
+      ? 'chatgpt-subscription'
+      : undefined)
   );
 }
 
@@ -86,7 +93,7 @@ export function sumUsageStats(
         allRoundsViaChatGptSubscription &&
         usage.viaChatGptSubscription === true;
 
-      const usageRoute = usageRouteForAggregation(usage);
+      const usageRoute = resolveUsageRoute(usage);
       if (usageRoute == null) {
         hasMixedOrMissingUsageRoute = true;
       } else if (!sawUsageRoute) {

--- a/src/test-kernel/agent/runtime/UsageMonitorLastTotals.vitest.ts
+++ b/src/test-kernel/agent/runtime/UsageMonitorLastTotals.vitest.ts
@@ -94,7 +94,10 @@ describe('UsageMonitor.lastTotals (SDK Step 7d PR 5)', () => {
       (event) => event.event === 'updateStreamUsage',
     );
     expect(usageEvent?.payload).toMatchObject({
-      usage: { viaChatGptSubscription: true },
+      usage: {
+        viaChatGptSubscription: true,
+        usageRoute: 'chatgpt-subscription',
+      },
     });
   });
 });

--- a/src/test-kernel/progressView/UsagePanel.vitest.mts
+++ b/src/test-kernel/progressView/UsagePanel.vitest.mts
@@ -1,0 +1,85 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - progress view component types
+import type { UsagePanel } from '@progressView/frontend/components/UsagePanel';
+
+// Local imports - shared schemas
+import type { TokenUsageStats, UsageRoute } from '@shared/schemas';
+
+// Local imports - test utilities
+import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
+
+useLitComponentTestDom(
+  () => import('@progressView/frontend/components/UsagePanel'),
+);
+
+function usage(overrides: Partial<TokenUsageStats>): TokenUsageStats {
+  return {
+    inputTokens: 1200,
+    outputTokens: 80,
+    cost: 0.123,
+    ...overrides,
+  };
+}
+
+async function mountUsagePanel(stats: TokenUsageStats): Promise<UsagePanel> {
+  const element = document.createElement('usage-panel') as UsagePanel;
+  element.usage = stats;
+  document.body.append(element);
+  await element.updateComplete;
+  return element;
+}
+
+function panelText(element: UsagePanel): string {
+  return element.shadowRoot?.textContent?.replaceAll(/\s+/g, ' ').trim() ?? '';
+}
+
+function usageAriaLabel(element: UsagePanel): string {
+  return (
+    element.shadowRoot
+      ?.querySelector('.run-summary')
+      ?.getAttribute('aria-label') ?? ''
+  );
+}
+
+describe('usage-panel route badges', () => {
+  it('shows subscription-backed usage as Free · ChatGPT', async () => {
+    const element = await mountUsagePanel(
+      usage({
+        cost: 0,
+        viaChatGptSubscription: true,
+      }),
+    );
+
+    expect(panelText(element)).toContain('Free · ChatGPT');
+    expect(usageAriaLabel(element)).toContain('Free via ChatGPT');
+  });
+
+  it.each([
+    {
+      route: 'relay' as UsageRoute,
+      visibleLabel: 'relay',
+      ariaCost: '$0.123 via relay',
+    },
+    {
+      route: 'api-key' as UsageRoute,
+      visibleLabel: 'your key',
+      ariaCost: '$0.123 via your key',
+    },
+  ])(
+    'shows $visibleLabel beside the cost',
+    async ({ route, visibleLabel, ariaCost }) => {
+      const element = await mountUsagePanel(
+        usage({
+          usageRoute: route,
+        }),
+      );
+
+      const text = panelText(element);
+      expect(text).toContain('$0.123');
+      expect(text).toContain(visibleLabel);
+      expect(usageAriaLabel(element)).toContain(ariaCost);
+    },
+  );
+});

--- a/src/test-kernel/schemas/StreamDataUsage.vitest.ts
+++ b/src/test-kernel/schemas/StreamDataUsage.vitest.ts
@@ -47,6 +47,7 @@ describe('stream data usage parsing', () => {
         cost: '0',
         cacheReadInputTokens: '3',
         viaChatGptSubscription: true,
+        usageRoute: 'chatgpt-subscription',
       },
     });
 
@@ -55,6 +56,7 @@ describe('stream data usage parsing', () => {
       cacheMissInputTokens: 0,
       cacheCreationInputTokens: 0,
       viaChatGptSubscription: true,
+      usageRoute: 'chatgpt-subscription',
     });
   });
 
@@ -87,5 +89,53 @@ describe('stream data usage parsing', () => {
         },
       ]).viaChatGptSubscription,
     ).toBe(true);
+  });
+
+  it('keeps route badges only for unambiguous accumulated usage', () => {
+    expect(
+      sumUsageStats([
+        emptyUsageStats(),
+        {
+          inputTokens: 10,
+          outputTokens: 2,
+          cost: 0,
+          usageRoute: 'relay',
+        },
+        {
+          inputTokens: 1,
+          outputTokens: 1,
+          cost: 0.001,
+          usageRoute: 'relay',
+        },
+      ]).usageRoute,
+    ).toBe('relay');
+
+    expect(
+      sumUsageStats([
+        {
+          inputTokens: 10,
+          outputTokens: 2,
+          cost: 0,
+          usageRoute: 'relay',
+        },
+        {
+          inputTokens: 1,
+          outputTokens: 1,
+          cost: 0.001,
+          usageRoute: 'api-key',
+        },
+      ]),
+    ).not.toHaveProperty('usageRoute');
+
+    expect(
+      sumUsageStats([
+        {
+          inputTokens: 10,
+          outputTokens: 2,
+          cost: 0,
+          viaChatGptSubscription: true,
+        },
+      ]).usageRoute,
+    ).toBe('chatgpt-subscription');
   });
 });


### PR DESCRIPTION
## Summary

- Add a `usageRoute` field to the shared usage schema so progress usage can distinguish ChatGPT subscription, TeXRA relay, and direct API-key routes.
- Preserve the route only when accumulated usage has one unambiguous route; legacy ChatGPT subscription entries still infer the ChatGPT route from `viaChatGptSubscription`.
- Update the progress usage panel to show `Free · ChatGPT`, `relay`, and `your key` route badges, including matching accessible labels.

Closes #6769.

## Validation

- `corepack pnpm vitest run src/test-kernel/schemas/StreamDataUsage.vitest.ts src/test-kernel/agent/runtime/UsageMonitorLastTotals.vitest.ts src/test-kernel/progressView/UsagePanel.vitest.mts`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- `corepack pnpm exec eslint src/shared/schemas/usage.ts src/shared/schemas/streamData.ts src/agent/utils/UsageMonitor.ts packages/extension/src/progressView/frontend/components/UsagePanel.ts src/test-kernel/schemas/StreamDataUsage.vitest.ts src/test-kernel/progressView/UsagePanel.vitest.mts src/test-kernel/agent/runtime/UsageMonitorLastTotals.vitest.ts`
- `npm run lint` (passes with the repository's existing 33 warnings)
- `npm run typecheck`
- `npm run compile:fast`
- `npm test` (558 passed, 1 skipped; emitted the existing metadata-persistence warning)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and display metadata changes with backward-compatible inference from `viaChatGptSubscription`; relay billing logic is refactored to use the same route field, not new behavior.
> 
> **Overview**
> Introduces optional **`usageRoute`** on shared token usage (`chatgpt-subscription`, `relay`, `api-key`) plus **`resolveUsageRoute`** so legacy **`viaChatGptSubscription`** still maps to ChatGPT. **`sumUsageStats`** only keeps a route when every active round agrees; mixed or missing routes drop the badge.
> 
> **`UsageMonitor`** classifies each round (subscription vs relay vs API key), attaches **`usageRoute`** to progress events and backend logging, and derives **`usedRelay`** from that field when present.
> 
> The progress **`UsagePanel`** replaces a lone “Free” label with route-specific copy and tooltips—e.g. **Free · ChatGPT**, cost beside **relay** / **your key**—with matching **`aria-label`** text. Parsing schemas and tests cover persistence, accumulation, monitor events, and panel rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84ef6bdc224b55da1a1f9feb27752d580abb3fc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->