### PR TITLE
fix(cli): polish config form validation

### DIFF
--- a/packages/cli/src/chat/tui/forms/ConfigForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ConfigForm.tsx
@@ -21,6 +21,7 @@ import {
 } from '@shared/schemas/stateSettings';
 
 import { BaseTextInput } from '../input/BaseTextInput';
+import { isCtrlInput, type ReturnKeyInput } from '../input/inputKeys';
 import { KeyHints } from '../ui/KeyHints';
 import { POINTER } from '../ui/glyphs';
 import { Select, type SelectItem } from '../ui/Select';
@@ -87,6 +88,13 @@ export function validateSettingInput(
     ok: false,
     message: parsed.error.issues.at(0)?.message ?? 'Invalid setting value.',
   };
+}
+
+export function isConfigResetInput(
+  input: string,
+  key: Pick<ReturnKeyInput, 'ctrl' | 'meta'>,
+): boolean {
+  return isCtrlInput(input, key, 'r');
 }
 
 export function formatSettingValue(value: unknown): string {
@@ -174,7 +182,7 @@ function ConfigTextEditor(props: {
   // BaseTextInput owns Enter (onSubmit) and ignores Escape, so handle Escape
   // here to back out to the list.
   useInput((input, key) => {
-    if (key.ctrl && input.toLowerCase() === 'r') props.onReset();
+    if (isConfigResetInput(input, key)) props.onReset();
     if (key.escape) props.onCancel();
   });
   return (
@@ -266,7 +274,7 @@ export function ConfigForm(props: ConfigFormProps): React.JSX.Element {
 
   useInput((input, key) => {
     if (mode.kind !== 'enum') return;
-    if (key.ctrl && input.toLowerCase() === 'r') {
+    if (isConfigResetInput(input, key)) {
       resetEntry(mode.entry);
       setMode({ kind: 'list' });
     }

--- a/packages/cli/src/chat/tui/forms/ConfigForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ConfigForm.tsx
@@ -34,6 +34,10 @@ export type SettingEditKind =
   | 'number'
   | 'readonly';
 
+export type SettingInputResult =
+  | { readonly ok: true; readonly value: unknown }
+  | { readonly ok: false; readonly message: string };
+
 /**
  * How a setting is edited in `/config`, derived from its schema: enums drill
  * into a value picker, booleans toggle inline, strings/numbers open a text
@@ -49,19 +53,40 @@ export function settingEditKind(entry: StateSettingEntry): SettingEditKind {
 
 /**
  * Coerce raw text-editor input to the value a `string`/`number` setting
- * expects, or `null` when a number field's input is blank or non-numeric (so
- * the caller can ignore the submit rather than write `NaN`). Range/format
- * violations are left to the schema, which rejects them on write.
+ * expects. Invalid numeric input carries the user-facing error that keeps the
+ * editor open instead of silently ignoring the submit.
  */
 export function coerceSettingInput(
   raw: string,
   isNumber: boolean,
-): { value: unknown } | null {
-  if (!isNumber) return { value: raw };
+): SettingInputResult {
+  if (!isNumber) return { ok: true, value: raw };
   const trimmed = raw.trim();
-  if (trimmed === '') return null;
+  if (trimmed === '') {
+    return { ok: false, message: 'Enter a number, or press Ctrl+R to reset.' };
+  }
   const parsed = Number(trimmed);
-  return Number.isNaN(parsed) ? null : { value: parsed };
+  return Number.isFinite(parsed)
+    ? { ok: true, value: parsed }
+    : { ok: false, message: 'Enter a finite number.' };
+}
+
+/** Coerce text input, then run the setting's own schema before writing. */
+export function validateSettingInput(
+  entry: StateSettingEntry,
+  raw: string,
+  isNumber: boolean,
+): SettingInputResult {
+  const coerced = coerceSettingInput(raw, isNumber);
+  if (!coerced.ok) return coerced;
+
+  const parsed = entry.schema.safeParse(coerced.value);
+  if (parsed.success) return { ok: true, value: parsed.data };
+
+  return {
+    ok: false,
+    message: parsed.error.issues.at(0)?.message ?? 'Invalid setting value.',
+  };
 }
 
 export function formatSettingValue(value: unknown): string {
@@ -76,7 +101,7 @@ export function settingStoreLabel(entry: StateSettingEntry): string {
 }
 
 export function settingDisplayName(entry: StateSettingEntry): string {
-  return stripPrefix(entry.key);
+  return entry.title ?? stripPrefix(entry.key);
 }
 
 export function buildConfigListItems(
@@ -140,13 +165,16 @@ function ConfigTextEditor(props: {
   readonly entry: StateSettingEntry;
   readonly initialValue: string;
   readonly isNumber: boolean;
-  readonly onSubmit: (raw: string) => void;
+  readonly onSubmit: (raw: string) => string | undefined;
+  readonly onReset: () => void;
   readonly onCancel: () => void;
 }): React.JSX.Element {
   const [buffer, setBuffer] = useState(props.initialValue);
+  const [error, setError] = useState<string>();
   // BaseTextInput owns Enter (onSubmit) and ignores Escape, so handle Escape
   // here to back out to the list.
-  useInput((_input, key) => {
+  useInput((input, key) => {
+    if (key.ctrl && input.toLowerCase() === 'r') props.onReset();
     if (key.escape) props.onCancel();
   });
   return (
@@ -160,14 +188,26 @@ function ConfigTextEditor(props: {
         <BaseTextInput
           value={buffer}
           placeholder={props.isNumber ? 'enter a number' : 'enter a value'}
-          onChange={setBuffer}
-          onSubmit={props.onSubmit}
+          onChange={(value) => {
+            setBuffer(value);
+            if (error) setError(undefined);
+          }}
+          onSubmit={(raw) => {
+            const submitError = props.onSubmit(raw);
+            if (submitError) setError(submitError);
+          }}
         />
       </Box>
+      {error ? (
+        <Box marginTop={1}>
+          <Text color="red">{error}</Text>
+        </Box>
+      ) : null}
       <Box marginTop={1}>
         <KeyHints
           hints={[
             { key: 'Enter', action: 'save' },
+            { key: 'Ctrl+R', action: 'reset' },
             { key: 'Esc', action: 'back' },
           ]}
           confirmCancel={false}
@@ -224,6 +264,14 @@ export function ConfigForm(props: ConfigFormProps): React.JSX.Element {
     runWrite(entry, settingDefault(entry), () => props.resetValue?.(entry));
   };
 
+  useInput((input, key) => {
+    if (mode.kind !== 'enum') return;
+    if (key.ctrl && input.toLowerCase() === 'r') {
+      resetEntry(mode.entry);
+      setMode({ kind: 'list' });
+    }
+  });
+
   if (mode.kind === 'enum') {
     const { entry } = mode;
     const current = effective(entry);
@@ -255,6 +303,7 @@ export function ConfigForm(props: ConfigFormProps): React.JSX.Element {
             hints={[
               { key: '↑/↓', action: 'navigate' },
               { key: 'Enter', action: 'select' },
+              { key: 'Ctrl+R', action: 'reset' },
               { key: 'Esc', action: 'back' },
             ]}
             confirmCancel={false}
@@ -276,10 +325,18 @@ export function ConfigForm(props: ConfigFormProps): React.JSX.Element {
         onSubmit={(raw) => {
           if (!isNumber && raw.trim() === '') {
             resetEntry(entry);
-          } else {
-            const coerced = coerceSettingInput(raw, isNumber);
-            if (coerced) commit(entry, coerced.value);
+            setMode({ kind: 'list' });
+            return undefined;
           }
+
+          const parsed = validateSettingInput(entry, raw, isNumber);
+          if (!parsed.ok) return parsed.message;
+          commit(entry, parsed.value);
+          setMode({ kind: 'list' });
+          return undefined;
+        }}
+        onReset={() => {
+          resetEntry(entry);
           setMode({ kind: 'list' });
         }}
         onCancel={() => setMode({ kind: 'list' })}

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -68,6 +68,8 @@ export interface StateSettingEntry {
    * when the key is absent. `schema.parse(undefined)` yields that default.
    */
   readonly schema: z.ZodType;
+  /** Short label for compact settings UIs; falls back to the stripped key. */
+  readonly title?: string;
   /** Human-readable description, shared across every host that renders it. */
   readonly description: string;
   /** Grouping label for settings UIs. */
@@ -147,6 +149,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
   {
     key: WorkspaceStateKey.GIT_MARK_COMMITS,
     schema: z.boolean().prefault(DEFAULT_GIT_MARK_COMMITS),
+    title: 'Mark agent commits',
     description:
       'Attribute agent-authored git commits to the TeXRA identity so they are distinguishable from your own commits.',
     category: 'git',
@@ -159,6 +162,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
   {
     key: WorkspaceStateKey.GIT_AUTHOR_NAME,
     schema: z.string().prefault(DEFAULT_GIT_AUTHOR_NAME),
+    title: 'Agent commit author',
     description:
       'Author and committer name used for agent-authored commits when commit marking is enabled.',
     category: 'git',
@@ -171,6 +175,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
   {
     key: WorkspaceStateKey.GIT_AUTHOR_EMAIL,
     schema: z.string().prefault(DEFAULT_GIT_AUTHOR_EMAIL),
+    title: 'Agent commit email',
     description:
       'Author and committer email used for agent-authored commits when commit marking is enabled.',
     category: 'git',
@@ -183,6 +188,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
   {
     key: WorkspaceStateKey.GIT_WORKTREE_SUPPORT,
     schema: z.boolean().prefault(DEFAULT_GIT_WORKTREE_SUPPORT),
+    title: 'Subagent worktrees',
     description:
       'Allow spawned subagents to run in isolated git worktrees so parallel edits do not conflict.',
     category: 'git',
@@ -201,6 +207,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
   {
     key: WorkspaceStateKey.WORKFLOW_AUTO_COMPILE,
     schema: z.boolean().prefault(LATEX_CONFIG_DEFAULTS.workflowAutoCompile),
+    title: 'Auto-compile outputs',
     description:
       'Compile the LaTeX project automatically after an agent writes its output.',
     category: 'workflow',
@@ -215,6 +222,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
       .number()
       .min(LATEX_CONFIG_RANGES.workflowAutoCompileTimeoutMs.min)
       .prefault(LATEX_CONFIG_DEFAULTS.workflowAutoCompileTimeoutMs),
+    title: 'Auto-compile timeout',
     description:
       'Maximum time (in milliseconds) to wait for an automatic post-output compile before giving up.',
     category: 'workflow',
@@ -239,6 +247,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     schema: z
       .boolean()
       .prefault(LATEX_CONFIG_DEFAULTS.workflowRejectOnCompileFailure),
+    title: 'Reject compile failures',
     description:
       'Reject an agent edit when the automatic post-output compile fails, so broken LaTeX is not accepted.',
     category: 'workflow',
@@ -329,6 +338,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
   {
     key: GlobalStateKey.WEBSOCKET_OPENAI,
     schema: z.boolean().prefault(false),
+    title: 'OpenAI WebSocket',
     description:
       'EXPERIMENTAL: use the persistent WebSocket transport for OpenAI Responses requests (lower latency for tool-use loops), and let the ChatGPT-subscription Codex backend attempt WebSocket. Off by default.',
     category: 'model',

--- a/src/test-kernel/cli/ConfigForm.vitest.mts
+++ b/src/test-kernel/cli/ConfigForm.vitest.mts
@@ -2,6 +2,10 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
 import {
+  isStored,
+  makeFakeSettingsStores,
+} from '@test/support/settingsStoresFake';
+import {
   buildConfigListItems,
   buildEnumItems,
   coerceSettingInput,
@@ -10,6 +14,7 @@ import {
   settingDisplayName,
   settingEditKind,
   settingStoreLabel,
+  validateSettingInput,
 } from '@cli/chat/tui/forms/ConfigForm';
 import {
   listSlashCommands,
@@ -26,10 +31,6 @@ import {
 import { DEFAULT_GIT_AUTHOR_NAME } from '@shared/constants/git';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { getGitAuthorEnv } from '@utils/system/gitAuthorEnv';
-import {
-  isStored,
-  makeFakeSettingsStores,
-} from '@test/support/settingsStoresFake';
 
 afterEach(() => {
   for (const cmd of [...listSlashCommands()]) unregisterSlashCommand(cmd.name);
@@ -94,14 +95,44 @@ describe('ConfigForm helpers', () => {
 
   it('coerces text-editor input by kind', () => {
     expect(coerceSettingInput('texra-ai', false)).toEqual({
+      ok: true,
       value: 'texra-ai',
     });
-    expect(coerceSettingInput('', false)).toEqual({ value: '' });
-    expect(coerceSettingInput('120000', true)).toEqual({ value: 120000 });
-    expect(coerceSettingInput('  90000 ', true)).toEqual({ value: 90000 });
-    // Blank / non-numeric input for a number field is ignored, not written.
-    expect(coerceSettingInput('', true)).toBeNull();
-    expect(coerceSettingInput('abc', true)).toBeNull();
+    expect(coerceSettingInput('', false)).toEqual({ ok: true, value: '' });
+    expect(coerceSettingInput('120000', true)).toEqual({
+      ok: true,
+      value: 120000,
+    });
+    expect(coerceSettingInput('  90000 ', true)).toEqual({
+      ok: true,
+      value: 90000,
+    });
+    expect(coerceSettingInput('', true)).toEqual({
+      ok: false,
+      message: 'Enter a number, or press Ctrl+R to reset.',
+    });
+    expect(coerceSettingInput('abc', true)).toEqual({
+      ok: false,
+      message: 'Enter a finite number.',
+    });
+    expect(coerceSettingInput('Infinity', true)).toEqual({
+      ok: false,
+      message: 'Enter a finite number.',
+    });
+  });
+
+  it('validates coerced text input against the setting schema', () => {
+    const timeout = entryByKey(
+      WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS,
+    );
+    expect(validateSettingInput(timeout, '120000', true)).toEqual({
+      ok: true,
+      value: 120000,
+    });
+
+    const invalid = validateSettingInput(timeout, '0', true);
+    expect(invalid.ok).toBe(false);
+    if (!invalid.ok) expect(invalid.message).not.toBe('');
   });
 
   it('formats values for display', () => {
@@ -121,10 +152,21 @@ describe('ConfigForm helpers', () => {
     ).toBe('workspaceState');
   });
 
-  it('strips the texra prefix for display names', () => {
+  it('prefers compact titles and falls back to stripped keys for display names', () => {
     expect(
       settingDisplayName(entryByKey(WorkspaceStateKey.GIT_MARK_COMMITS)),
-    ).toBe('git.markCommits');
+    ).toBe('Mark agent commits');
+
+    expect(
+      settingDisplayName({
+        key: 'texra.example.record',
+        schema: z.record(z.string(), z.string()).prefault({}),
+        description: 'A record setting with no inline editor.',
+        category: 'example',
+        store: 'workspaceState',
+        hosts: ['vscode'],
+      }),
+    ).toBe('example.record');
   });
 
   it('builds list items showing value + store, with editable rows enabled', () => {
@@ -139,7 +181,7 @@ describe('ConfigForm helpers', () => {
     );
 
     expect(markCommits).toMatchObject({
-      label: 'git.markCommits',
+      label: 'Mark agent commits',
       disabled: false,
     });
     expect(markCommits?.description).toContain('on');

--- a/src/test-kernel/cli/ConfigForm.vitest.mts
+++ b/src/test-kernel/cli/ConfigForm.vitest.mts
@@ -11,6 +11,7 @@ import {
   coerceSettingInput,
   ConfigForm,
   formatSettingValue,
+  isConfigResetInput,
   settingDisplayName,
   settingEditKind,
   settingStoreLabel,
@@ -133,6 +134,12 @@ describe('ConfigForm helpers', () => {
     const invalid = validateSettingInput(timeout, '0', true);
     expect(invalid.ok).toBe(false);
     if (!invalid.ok) expect(invalid.message).not.toBe('');
+  });
+
+  it('recognizes parsed and raw Ctrl+R reset input', () => {
+    expect(isConfigResetInput('r', { ctrl: true })).toBe(true);
+    expect(isConfigResetInput('\u0012', {})).toBe(true);
+    expect(isConfigResetInput('r', { meta: true })).toBe(false);
   });
 
   it('formats values for display', () => {


### PR DESCRIPTION
## Summary
- Add compact shared catalog titles for CLI-visible settings and render them in `/config`.
- Keep the text editor open on invalid numeric input or Zod schema rejection, with an inline error.
- Add a visible `Ctrl+R` reset affordance for text/number and enum edit panels.

Closes #6610

## Tests
- `npm test -- --run src/test-kernel/cli/ConfigForm.vitest.mts`
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes with the existing 32 warnings)
- `npm run compile:fast`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only settings UI and catalog metadata; writes still go through existing accessors and schema validation, with no auth or data-model changes.
> 
> **Overview**
> Improves the chat TUI **`/config`** panel so edits are clearer and invalid values are not silently dropped.
> 
> **Labels:** Shared settings catalog rows gain an optional **`title`**, and CLI-visible entries get short titles (e.g. “Mark agent commits”). **`settingDisplayName`** prefers **`title`** over the stripped key.
> 
> **Validation:** Numeric and schema checks return explicit **`SettingInputResult`** errors instead of ignoring submit. **`validateSettingInput`** runs each setting’s Zod schema before write; the text editor **stays open** and shows a **red inline message** on failure (blank/non-finite numbers, min/max violations, etc.).
> 
> **Reset:** **`Ctrl+R`** resets the current setting to its default from **text/number** and **enum** drill-in views, with matching **KeyHints**; blank string submit still clears/resets as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cf9fcfe0548f8d60eea851859335178b513263a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->