### PR TITLE
refactor(settings): source option labels from catalogs

### DIFF
--- a/packages/extension/src/settingsView/frontend/components/profile/ApiAccessSection.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ApiAccessSection.ts
@@ -14,6 +14,7 @@ import '@awesome.me/webawesome/dist/components/radio-group/radio-group.js';
 
 // Local imports - shared copy
 import { PROMO_NOTICE_LONG } from '@shared/copy/promoNotice';
+import { API_ACCESS_MODE_OPTIONS } from '@shared/schemas/settingsViewMessages';
 
 // Local imports - profile view styles
 import { profileViewStyles } from './styles';
@@ -46,27 +47,18 @@ export class ApiAccessSection extends LitElement {
           .value=${this.mode}
           @change=${this.handleModeChange}
         >
-          <wa-radio class="api-access-option" value="included">
-            <span class="option-content">
-              <span class="option-title">Use Included Access</span>
-              <span class="option-description"
-                >Works automatically. No setup needed. Does not apply to
-                OpenRouter — those models always use your OpenRouter key. Bring
-                your own provider API keys to use more of your own quota and
-                avoid relay caps.</span
-              >
-            </span>
-          </wa-radio>
-          <wa-radio class="api-access-option" value="personal">
-            <span class="option-content">
-              <span class="option-title">Use My Own Keys</span>
-              <span class="option-description"
-                >Provide your own API keys from OpenAI, Anthropic, etc. This
-                uses your provider account directly for higher limits and models
-                outside Included Access.</span
-              >
-            </span>
-          </wa-radio>
+          ${API_ACCESS_MODE_OPTIONS.map(
+            (option) => html`
+              <wa-radio class="api-access-option" value=${option.value}>
+                <span class="option-content">
+                  <span class="option-title">${option.label}</span>
+                  <span class="option-description">
+                    ${option.description}
+                  </span>
+                </span>
+              </wa-radio>
+            `,
+          )}
         </wa-radio-group>
         ${this.mode === 'included'
           ? html`

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -31,7 +31,8 @@ import {
 
 // Local imports - profile view styles and events
 import {
-  ReasoningLevelSchema,
+  REASONING_LEVEL_LABELS,
+  REASONING_LEVEL_OPTIONS,
   type ModelSelectionItem,
   type ProviderKeyStatus,
   type ReasoningLevel,
@@ -42,18 +43,6 @@ import { resolveProviderKeyRows } from './providerKeyRows';
 import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
 import type WaSwitch from '@awesome.me/webawesome/dist/components/switch/switch.js';
-
-/** Display labels for reasoning level options. */
-const REASONING_LEVEL_LABELS: Record<ReasoningLevel, string> = {
-  none: 'None',
-  low: 'Low',
-  medium: 'Medium',
-  high: 'High',
-  xhigh: 'Extra High',
-  max: 'Max',
-};
-
-const REASONING_LEVELS = ReasoningLevelSchema.options;
 
 interface ProviderGroup {
   provider: string;
@@ -192,11 +181,9 @@ export class ModelSelectionList extends LitElement {
         @change=${(e: Event) => this.handleReasoningLevelChange(model.name, e)}
       >
         <wa-option value=""> ${defaultLabel} </wa-option>
-        ${REASONING_LEVELS.map(
-          (level) => html`
-            <wa-option value=${level}>
-              ${REASONING_LEVEL_LABELS[level]}
-            </wa-option>
+        ${REASONING_LEVEL_OPTIONS.map(
+          (option) => html`
+            <wa-option value=${option.value}> ${option.label} </wa-option>
           `,
         )}
       </wa-select>

--- a/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
@@ -26,6 +26,11 @@ import type {
   ClaudeAgentModel,
   ClaudeAgentPermissionMode,
 } from '@shared/schemas/settingsViewMessages';
+import {
+  settingEnumChoices,
+  stateSettingByKey,
+} from '@shared/schemas/stateSettings';
+import { WorkspaceStateKey } from '@shared/state/stateKeys';
 
 // Side-effect imports - register WA components
 import '@awesome.me/webawesome/dist/components/button/button.js';
@@ -37,65 +42,32 @@ import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.
 // Side-effect: register tool card component
 import '../components/tools/ToolCard';
 
-const SANDBOX_MODE_OPTIONS: readonly {
-  value: CodexSandboxMode;
-  label: string;
-}[] = [
-  { value: 'read-only', label: 'Read-only' },
-  { value: 'workspace-write', label: 'Workspace write' },
-  { value: 'danger-full-access', label: 'Full access' },
-] as const;
+function catalogSelectOptions<T extends string>(
+  key: WorkspaceStateKey,
+): readonly { value: T; label: string }[] {
+  const entry = stateSettingByKey(key);
+  return entry ? (settingEnumChoices<T>(entry) ?? []) : [];
+}
 
-const REASONING_EFFORT_OPTIONS: readonly {
-  value: CodexReasoningEffort;
-  label: string;
-}[] = [
-  { value: 'low', label: 'Low' },
-  { value: 'medium', label: 'Medium' },
-  { value: 'high', label: 'High' },
-  { value: 'xhigh', label: 'Extra high' },
-] as const;
-
-const APPROVAL_POLICY_OPTIONS: readonly {
-  value: CodexApprovalPolicy;
-  label: string;
-}[] = [
-  { value: 'never', label: 'Auto approve' },
-  { value: 'on-request', label: 'Ask when requested' },
-  { value: 'untrusted', label: 'Ask for untrusted' },
-  { value: 'on-failure', label: 'Ask on failure' },
-] as const;
-
-const CLAUDE_MODEL_OPTIONS: readonly {
-  value: ClaudeAgentModel;
-  label: string;
-}[] = [
-  { value: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
-  { value: 'claude-fable-5', label: 'Fable 5' },
-  { value: 'claude-opus-4-8', label: 'Opus 4.8' },
-  { value: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
-] as const;
-
-const CLAUDE_PERMISSION_MODE_OPTIONS: readonly {
-  value: ClaudeAgentPermissionMode;
-  label: string;
-}[] = [
-  { value: 'default', label: 'Prompt for risky actions' },
-  { value: 'acceptEdits', label: 'Auto-accept edits' },
-  { value: 'bypassPermissions', label: 'Bypass all (dangerous)' },
-  { value: 'plan', label: 'Plan only (read-only)' },
-] as const;
-
-const CLAUDE_EFFORT_OPTIONS: readonly {
-  value: ClaudeAgentEffort;
-  label: string;
-}[] = [
-  { value: 'low', label: 'Low' },
-  { value: 'medium', label: 'Medium' },
-  { value: 'high', label: 'High' },
-  { value: 'xhigh', label: 'Extra high' },
-  { value: 'max', label: 'Maximum' },
-] as const;
+const SANDBOX_MODE_OPTIONS = catalogSelectOptions<CodexSandboxMode>(
+  WorkspaceStateKey.CODEX_SANDBOX_MODE,
+);
+const REASONING_EFFORT_OPTIONS = catalogSelectOptions<CodexReasoningEffort>(
+  WorkspaceStateKey.CODEX_REASONING_EFFORT,
+);
+const APPROVAL_POLICY_OPTIONS = catalogSelectOptions<CodexApprovalPolicy>(
+  WorkspaceStateKey.CODEX_APPROVAL_POLICY,
+);
+const CLAUDE_MODEL_OPTIONS = catalogSelectOptions<ClaudeAgentModel>(
+  WorkspaceStateKey.CLAUDE_AGENT_MODEL,
+);
+const CLAUDE_PERMISSION_MODE_OPTIONS =
+  catalogSelectOptions<ClaudeAgentPermissionMode>(
+    WorkspaceStateKey.CLAUDE_AGENT_PERMISSION_MODE,
+  );
+const CLAUDE_EFFORT_OPTIONS = catalogSelectOptions<ClaudeAgentEffort>(
+  WorkspaceStateKey.CLAUDE_AGENT_EFFORT,
+);
 
 @customElement('ai-agents-tab')
 export class AIAgentsTab extends LitElement {

--- a/src/shared/schemas/agentCliSettings.ts
+++ b/src/shared/schemas/agentCliSettings.ts
@@ -52,8 +52,8 @@ export const parseCodexReasoningEffort = parseEnumSetting(
 export const CodexApprovalPolicySchema = z.enum([
   'never',
   'on-request',
-  'on-failure',
   'untrusted',
+  'on-failure',
 ]);
 export type CodexApprovalPolicy = z.infer<typeof CodexApprovalPolicySchema>;
 

--- a/src/shared/schemas/profileViewMessages.ts
+++ b/src/shared/schemas/profileViewMessages.ts
@@ -36,6 +36,24 @@ export type RemoteAgent = z.infer<typeof RemoteAgentSchema>;
 
 export const ApiAccessModeSchema = z.enum(['included', 'personal']);
 export type ApiAccessMode = z.infer<typeof ApiAccessModeSchema>;
+export const API_ACCESS_MODE_OPTIONS: readonly {
+  readonly value: ApiAccessMode;
+  readonly label: string;
+  readonly description: string;
+}[] = [
+  {
+    value: 'included',
+    label: 'Use Included Access',
+    description:
+      'Works automatically. No setup needed. Does not apply to OpenRouter — those models always use your OpenRouter key. Bring your own provider API keys to use more of your own quota and avoid relay caps.',
+  },
+  {
+    value: 'personal',
+    label: 'Use My Own Keys',
+    description:
+      'Provide your own API keys from OpenAI, Anthropic, etc. This uses your provider account directly for higher limits and models outside Included Access.',
+  },
+] as const;
 
 export const TierConstantsSchema = z.object({
   ultra: z.string(),

--- a/src/shared/schemas/settingsView/data.ts
+++ b/src/shared/schemas/settingsView/data.ts
@@ -144,6 +144,21 @@ export const ReasoningLevelSchema = z.enum([
   'max',
 ]);
 export type ReasoningLevel = z.infer<typeof ReasoningLevelSchema>;
+export const REASONING_LEVEL_LABELS: Record<ReasoningLevel, string> = {
+  none: 'None',
+  low: 'Low',
+  medium: 'Medium',
+  high: 'High',
+  xhigh: 'Extra High',
+  max: 'Max',
+};
+export const REASONING_LEVEL_OPTIONS: readonly {
+  readonly value: ReasoningLevel;
+  readonly label: string;
+}[] = ReasoningLevelSchema.options.map((value) => ({
+  value,
+  label: REASONING_LEVEL_LABELS[value],
+}));
 
 export const ModelSelectionItemSchema = z.object({
   name: z.string(),

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -57,6 +57,7 @@ export {
   ProfileUserSchema,
   RemoteAgentSchema,
   ApiAccessModeSchema,
+  API_ACCESS_MODE_OPTIONS,
   TierConstantsSchema,
   ProviderKeyStatusSchema,
   ProviderVscodeSettingSchema,

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -14,6 +14,20 @@ import {
   LATEX_FORMATTER_VALUES,
   LATEXDIFF_MATH_MARKUP_VALUES,
 } from '@shared/constants/latex';
+import {
+  CLAUDE_AGENT_DEFAULT_EFFORT,
+  CLAUDE_AGENT_DEFAULT_MODEL,
+  CLAUDE_AGENT_DEFAULT_PERMISSION_MODE,
+  ClaudeAgentEffortSchema,
+  ClaudeAgentModelSchema,
+  ClaudeAgentPermissionModeSchema,
+  CODEX_APPROVAL_POLICY_DEFAULT,
+  CODEX_REASONING_EFFORT_DEFAULT,
+  CODEX_SANDBOX_MODE_DEFAULT,
+  CodexApprovalPolicySchema,
+  CodexReasoningEffortSchema,
+  CodexSandboxModeSchema,
+} from '@shared/schemas/agentCliSettings';
 import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 
 /**
@@ -103,6 +117,8 @@ export interface StateSettingEntry {
    * derived from the schema, not restated here.
    */
   readonly enumDescriptions?: readonly string[];
+  /** Display labels for enum options, aligned 1:1 with the schema options. */
+  readonly enumLabels?: readonly string[];
   /**
    * Delegate editing to an existing list form (e.g. `ModelListForm`) instead of
    * the scalar read/write accessor.
@@ -197,6 +213,84 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     hosts: ['vscode', 'cli', 'desktop'],
     cliConsumer: GIT_AUTHOR_CONSUMER,
     cliRuntimeReachability: GIT_WORKTREE_RUNTIME_REACHABILITY,
+  },
+
+  // --- External coding agent controls ---------------------------------------
+  // These are workspace-shared settings read by the Codex and Claude Code tool
+  // integrations. They are cataloged for the extension/desktop settings view;
+  // CLI exposure remains deferred until each value has a verified CLI consumer
+  // and runtime reachability trace.
+  {
+    key: WorkspaceStateKey.CODEX_SANDBOX_MODE,
+    schema: CodexSandboxModeSchema.prefault(CODEX_SANDBOX_MODE_DEFAULT),
+    title: 'Codex sandbox mode',
+    description: 'Filesystem access mode used when TeXRA launches Codex.',
+    category: 'ai-agents',
+    store: 'workspaceState',
+    hosts: ['vscode', 'desktop'],
+    enumLabels: ['Read-only', 'Workspace write', 'Full access'],
+  },
+  {
+    key: WorkspaceStateKey.CODEX_REASONING_EFFORT,
+    schema: CodexReasoningEffortSchema.prefault(CODEX_REASONING_EFFORT_DEFAULT),
+    title: 'Codex reasoning effort',
+    description: 'Reasoning effort hint passed to Codex runs.',
+    category: 'ai-agents',
+    store: 'workspaceState',
+    hosts: ['vscode', 'desktop'],
+    enumLabels: ['Low', 'Medium', 'High', 'Extra high'],
+  },
+  {
+    key: WorkspaceStateKey.CODEX_APPROVAL_POLICY,
+    schema: CodexApprovalPolicySchema.prefault(CODEX_APPROVAL_POLICY_DEFAULT),
+    title: 'Codex approval policy',
+    description: 'When Codex should ask for approval before risky actions.',
+    category: 'ai-agents',
+    store: 'workspaceState',
+    hosts: ['vscode', 'desktop'],
+    enumLabels: [
+      'Auto approve',
+      'Ask when requested',
+      'Ask for untrusted',
+      'Ask on failure',
+    ],
+  },
+  {
+    key: WorkspaceStateKey.CLAUDE_AGENT_MODEL,
+    schema: ClaudeAgentModelSchema.prefault(CLAUDE_AGENT_DEFAULT_MODEL),
+    title: 'Claude Code model',
+    description: 'Claude model selected for Claude Code agent sessions.',
+    category: 'ai-agents',
+    store: 'workspaceState',
+    hosts: ['vscode', 'desktop'],
+    enumLabels: ['Sonnet 4.6', 'Fable 5', 'Opus 4.8', 'Haiku 4.5'],
+  },
+  {
+    key: WorkspaceStateKey.CLAUDE_AGENT_PERMISSION_MODE,
+    schema: ClaudeAgentPermissionModeSchema.prefault(
+      CLAUDE_AGENT_DEFAULT_PERMISSION_MODE,
+    ),
+    title: 'Claude Code permission mode',
+    description: 'Permission policy used by Claude Code agent sessions.',
+    category: 'ai-agents',
+    store: 'workspaceState',
+    hosts: ['vscode', 'desktop'],
+    enumLabels: [
+      'Prompt for risky actions',
+      'Auto-accept edits',
+      'Bypass all (dangerous)',
+      'Plan only (read-only)',
+    ],
+  },
+  {
+    key: WorkspaceStateKey.CLAUDE_AGENT_EFFORT,
+    schema: ClaudeAgentEffortSchema.prefault(CLAUDE_AGENT_DEFAULT_EFFORT),
+    title: 'Claude Code reasoning effort',
+    description: 'Reasoning effort hint passed to Claude Code agent sessions.',
+    category: 'ai-agents',
+    store: 'workspaceState',
+    hosts: ['vscode', 'desktop'],
+    enumLabels: ['Low', 'Medium', 'High', 'Extra high', 'Maximum'],
   },
 
   // --- Workflow auto-compile -------------------------------------------------
@@ -391,6 +485,27 @@ export function settingEnumOptions(
   return inner instanceof z.ZodEnum
     ? (inner.options as readonly string[])
     : undefined;
+}
+
+export interface SettingEnumChoice<T extends string = string> {
+  readonly value: T;
+  readonly label: string;
+  readonly description?: string;
+}
+
+/** Enum values paired with display metadata for settings UIs. */
+export function settingEnumChoices<T extends string = string>(
+  entry: StateSettingEntry,
+): readonly SettingEnumChoice<T>[] | undefined {
+  const values = settingEnumOptions(entry);
+  if (!values) return undefined;
+  return values.map((value, index) => ({
+    value: value as T,
+    label: entry.enumLabels?.[index] ?? value,
+    ...(entry.enumDescriptions?.[index] && {
+      description: entry.enumDescriptions[index],
+    }),
+  }));
 }
 
 /** Whether a setting's schema is a boolean (used to classify edit affordance). */

--- a/src/test-kernel/shared/stateSettings.vitest.ts
+++ b/src/test-kernel/shared/stateSettings.vitest.ts
@@ -15,11 +15,16 @@ import {
   CLI_STATE_SETTINGS,
   STATE_SETTINGS,
   STATE_SETTING_KEYS,
+  settingEnumChoices,
   settingEnumOptions,
   stateSettingByKey,
   type SettingStore,
   type StateSettingEntry,
 } from '@shared/schemas/stateSettings';
+import {
+  API_ACCESS_MODE_OPTIONS,
+  REASONING_LEVEL_OPTIONS,
+} from '@shared/schemas/settingsViewMessages';
 import {
   readSetting,
   resetSetting,
@@ -28,6 +33,14 @@ import {
 } from '@shared/config/settingsAccess';
 
 // Local imports - canonical defaults + keys the catalog must agree with
+import {
+  CLAUDE_AGENT_DEFAULT_EFFORT,
+  CLAUDE_AGENT_DEFAULT_MODEL,
+  CLAUDE_AGENT_DEFAULT_PERMISSION_MODE,
+  CODEX_APPROVAL_POLICY_DEFAULT,
+  CODEX_REASONING_EFFORT_DEFAULT,
+  CODEX_SANDBOX_MODE_DEFAULT,
+} from '@shared/schemas/agentCliSettings';
 import {
   DEFAULT_GIT_AUTHOR_EMAIL,
   DEFAULT_GIT_AUTHOR_NAME,
@@ -63,6 +76,13 @@ const EXPECTED_DEFAULTS: Record<string, unknown> = {
   [WorkspaceStateKey.GIT_AUTHOR_NAME]: DEFAULT_GIT_AUTHOR_NAME,
   [WorkspaceStateKey.GIT_AUTHOR_EMAIL]: DEFAULT_GIT_AUTHOR_EMAIL,
   [WorkspaceStateKey.GIT_WORKTREE_SUPPORT]: DEFAULT_GIT_WORKTREE_SUPPORT,
+  [WorkspaceStateKey.CODEX_SANDBOX_MODE]: CODEX_SANDBOX_MODE_DEFAULT,
+  [WorkspaceStateKey.CODEX_REASONING_EFFORT]: CODEX_REASONING_EFFORT_DEFAULT,
+  [WorkspaceStateKey.CODEX_APPROVAL_POLICY]: CODEX_APPROVAL_POLICY_DEFAULT,
+  [WorkspaceStateKey.CLAUDE_AGENT_MODEL]: CLAUDE_AGENT_DEFAULT_MODEL,
+  [WorkspaceStateKey.CLAUDE_AGENT_PERMISSION_MODE]:
+    CLAUDE_AGENT_DEFAULT_PERMISSION_MODE,
+  [WorkspaceStateKey.CLAUDE_AGENT_EFFORT]: CLAUDE_AGENT_DEFAULT_EFFORT,
   [WorkspaceStateKey.WORKFLOW_AUTO_COMPILE]:
     LATEX_CONFIG_DEFAULTS.workflowAutoCompile,
   [WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS]:
@@ -178,7 +198,7 @@ describe('state settings catalog', () => {
     }
   });
 
-  it('pairs enum entries with one description per schema option', () => {
+  it('pairs enum entries with aligned display metadata', () => {
     for (const entry of STATE_SETTINGS) {
       const options = settingEnumOptions(entry);
       if (!options) {
@@ -187,13 +207,23 @@ describe('state settings catalog', () => {
           undefined,
           `${entry.key} has enumDescriptions without an enum schema`,
         );
+        assert.equal(
+          entry.enumLabels,
+          undefined,
+          `${entry.key} has enumLabels without an enum schema`,
+        );
         continue;
       }
       assert.ok(
-        entry.enumDescriptions,
-        `${entry.key} enum entry is missing enumDescriptions`,
+        entry.enumDescriptions || entry.enumLabels,
+        `${entry.key} enum entry is missing display metadata`,
       );
-      assert.equal(entry.enumDescriptions?.length, options.length, entry.key);
+      if (entry.enumDescriptions) {
+        assert.equal(entry.enumDescriptions.length, options.length, entry.key);
+      }
+      if (entry.enumLabels) {
+        assert.equal(entry.enumLabels.length, options.length, entry.key);
+      }
     }
   });
 
@@ -233,6 +263,81 @@ describe('state settings catalog', () => {
       'tex-fmt',
       'none',
     ]);
+  });
+
+  it('drives the AI Agents tab enum option labels from catalog metadata', () => {
+    const labelsFor = (key: WorkspaceStateKey): string[] => {
+      const entry = stateSettingByKey(key);
+      assert.ok(entry, `missing catalog entry ${key}`);
+      return (settingEnumChoices(entry) ?? []).map(
+        (option) => `${option.value} — ${option.label}`,
+      );
+    };
+
+    assert.deepEqual(labelsFor(WorkspaceStateKey.CODEX_SANDBOX_MODE), [
+      'read-only — Read-only',
+      'workspace-write — Workspace write',
+      'danger-full-access — Full access',
+    ]);
+    assert.deepEqual(labelsFor(WorkspaceStateKey.CODEX_REASONING_EFFORT), [
+      'low — Low',
+      'medium — Medium',
+      'high — High',
+      'xhigh — Extra high',
+    ]);
+    assert.deepEqual(labelsFor(WorkspaceStateKey.CODEX_APPROVAL_POLICY), [
+      'never — Auto approve',
+      'on-request — Ask when requested',
+      'untrusted — Ask for untrusted',
+      'on-failure — Ask on failure',
+    ]);
+    assert.deepEqual(labelsFor(WorkspaceStateKey.CLAUDE_AGENT_MODEL), [
+      'claude-sonnet-4-6 — Sonnet 4.6',
+      'claude-fable-5 — Fable 5',
+      'claude-opus-4-8 — Opus 4.8',
+      'claude-haiku-4-5-20251001 — Haiku 4.5',
+    ]);
+    assert.deepEqual(
+      labelsFor(WorkspaceStateKey.CLAUDE_AGENT_PERMISSION_MODE),
+      [
+        'default — Prompt for risky actions',
+        'acceptEdits — Auto-accept edits',
+        'bypassPermissions — Bypass all (dangerous)',
+        'plan — Plan only (read-only)',
+      ],
+    );
+    assert.deepEqual(labelsFor(WorkspaceStateKey.CLAUDE_AGENT_EFFORT), [
+      'low — Low',
+      'medium — Medium',
+      'high — High',
+      'xhigh — Extra high',
+      'max — Maximum',
+    ]);
+  });
+
+  it('drives model-profile option labels from shared metadata', () => {
+    assert.deepEqual(
+      REASONING_LEVEL_OPTIONS.map(
+        (option) => `${option.value} — ${option.label}`,
+      ),
+      [
+        'none — None',
+        'low — Low',
+        'medium — Medium',
+        'high — High',
+        'xhigh — Extra High',
+        'max — Max',
+      ],
+    );
+    assert.deepEqual(
+      API_ACCESS_MODE_OPTIONS.map(
+        (option) => `${option.value} — ${option.label} — ${option.description}`,
+      ),
+      [
+        'included — Use Included Access — Works automatically. No setup needed. Does not apply to OpenRouter — those models always use your OpenRouter key. Bring your own provider API keys to use more of your own quota and avoid relay caps.',
+        'personal — Use My Own Keys — Provide your own API keys from OpenAI, Anthropic, etc. This uses your provider account directly for higher limits and models outside Included Access.',
+      ],
+    );
   });
 
   it('exposes exactly the verified CLI-consumed settings', () => {


### PR DESCRIPTION
## Summary

- Add state-setting catalog rows and enum display labels for the Codex and Claude Code workspace-backed agent settings.
- Export shared option metadata for model reasoning levels and API access mode choices.
- Repoint `AIAgentsTab`, `ModelSelectionList`, and `ApiAccessSection` to those catalogs so the components no longer own duplicated option tables.

## Rationale

#6608 tracks settings view surfaces that still hardcode option arrays after the catalog work from #6602. The stored Codex and Claude Code settings now derive their allowed values from the existing Zod schemas and their labels from `STATE_SETTINGS`. The model reasoning and API access choices are not direct state-setting rows, so their display metadata lives beside the corresponding settings-view message schemas.

This keeps the renderers responsible only for layout and events, while schemas/catalogs own the option value and label metadata.

Closes #6608.

## Validation

- `npm test -- src/test-kernel/shared/stateSettings.vitest.ts src/test-kernel/schemas/agentCliSettings.vitest.ts src/test-kernel/settings/ModelSelectionProviderKeys.vitest.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings outside this patch)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only label sourcing with regression tests pinning displayed text; stored values and Zod validation are unchanged aside from a harmless enum member order tweak in `CodexApprovalPolicySchema`.
> 
> **Overview**
> Moves **enum and choice display metadata** out of Lit settings components into shared schemas and the `STATE_SETTINGS` catalog, so option values stay on Zod enums and labels live in one place.
> 
> Adds **`settingEnumChoices`** (with optional `enumLabels` on catalog rows) and registers **six workspace-backed Codex / Claude Code agent settings** in `stateSettings` with aligned labels. **`AIAgentsTab`** now builds its `<wa-select>` options via `catalogSelectOptions` instead of local constant arrays.
> 
> Exports **`REASONING_LEVEL_OPTIONS`** / labels beside `ReasoningLevelSchema` and **`API_ACCESS_MODE_OPTIONS`** beside `ApiAccessModeSchema`; **`ModelSelectionList`** and **`ApiAccessSection`** map those arrays in render. Tests lock expected label wording and catalog default parity for the new agent keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e450db8cb1395afda584d97c7ef26218bee410f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->