### PR TITLE
fix(cli): hide unsupported Copilot model

### DIFF
--- a/packages/cli/src/runtime/cliConfig.ts
+++ b/packages/cli/src/runtime/cliConfig.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises';
 
-import { MODEL_CONFIGS } from 'llm-zoo';
+import { MODEL_CONFIGS, ModelProvider } from 'llm-zoo';
 import { z } from 'zod';
 
 import { workspaceTexraConfigPath } from '@platform/defaults/nodeStorage';
@@ -39,11 +39,16 @@ export interface LoadedCliConfig {
 }
 
 export function isKnownCliModel(model: string): boolean {
-  return MODEL_CONFIGS[model] != null;
+  return isCliSupportedModelId(model);
 }
 
 export function knownCliModelIds(): string[] {
-  return Object.keys(MODEL_CONFIGS);
+  return Object.keys(MODEL_CONFIGS).filter(isCliSupportedModelId);
+}
+
+function isCliSupportedModelId(model: string): boolean {
+  const config = MODEL_CONFIGS[model];
+  return config != null && config.provider !== ModelProvider.COPILOT;
 }
 
 function normalizeCliModelLookupKey(value: string): string {
@@ -63,10 +68,10 @@ function modelLookupKeys(id: string): string[] {
 export function resolveKnownCliModelId(model: string): string | undefined {
   const trimmed = model.trim();
   if (!trimmed) return undefined;
-  if (Object.hasOwn(MODEL_CONFIGS, trimmed)) return trimmed;
+  if (isCliSupportedModelId(trimmed)) return trimmed;
 
   const lower = trimmed.toLowerCase();
-  const ids = Object.keys(MODEL_CONFIGS);
+  const ids = knownCliModelIds();
   const exactIdMatch = ids.find((id) => id.toLowerCase() === lower);
   if (exactIdMatch) return exactIdMatch;
 

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -116,7 +116,7 @@ async function getPersonalAccessKindForModel(
 ): Promise<PersonalModelAccessKind | null> {
   const { provider } = config;
   if (!isApiProvider(provider)) {
-    return 'provider-key';
+    return null;
   }
 
   try {

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -47,7 +47,11 @@ import {
   resolveWorkflowOutput,
   resumeWorkflowOutputFile,
 } from '@cli/runtime/workflowOutput';
-import { isKnownCliModel } from '@cli/runtime/cliConfig';
+import {
+  isKnownCliModel,
+  knownCliModelIds,
+  resolveKnownCliModelId,
+} from '@cli/runtime/cliConfig';
 import type { CliContext } from '@cli/runtime/cliContext';
 import { pickGlobalArgs } from '@cli/runtime/globalArgs';
 import { EXECUTION_STATUS, RUN_OUTCOME } from '@shared/schemas';
@@ -1110,6 +1114,13 @@ describe('CLI model flag validation contract', () => {
     expect(isKnownCliModel('deepseekT')).toBe(true);
     expect(isKnownCliModel('nonexistent-model-xyz')).toBe(false);
     expect(isKnownCliModel('')).toBe(false);
+  });
+
+  it('does not advertise host-only Copilot models as CLI models', () => {
+    expect(isKnownCliModel('copilot4o')).toBe(false);
+    expect(knownCliModelIds()).not.toContain('copilot4o');
+    expect(resolveKnownCliModelId('copilot4o')).toBeUndefined();
+    expect(resolveKnownCliModelId('Copilot GPT-4o')).toBeUndefined();
   });
 });
 

--- a/src/test-kernel/model/ComputeModelOptions.vitest.ts
+++ b/src/test-kernel/model/ComputeModelOptions.vitest.ts
@@ -138,6 +138,19 @@ describe('computeModelOptionsData relay quota state', () => {
     expect(model.disabled).toBe(false);
   });
 
+  it('does not treat non-API providers as personal API-key access', async () => {
+    const access = createModelOptionsAccess({
+      useIncludedAccess: false,
+      relayQuotaExceeded: false,
+      quotaAutoSwitched: false,
+    });
+
+    const [model] = await computeModelOptionsData(['copilot4o'], access);
+
+    expect(model.availability).toBe('missing-key');
+    expect(model.disabled).toBe(true);
+  });
+
   it('does not disable API-key access when ChatGPT subscription is preferred but signed out', async () => {
     const { initPlatform } = await import('@platform/platform');
     initPlatform(


### PR DESCRIPTION
## Summary

The CLI could advertise `copilot4o` as available even though Copilot is a keyless VS Code `vscode.lm` provider and the CLI has no host capability for it. In an isolated CLI environment, `texra models list --all` showed `copilot4o` with `api key set`, which made the model look runnable.

This PR narrows the CLI model roster to models that the CLI can actually resolve, and fixes model availability so non-API providers are not treated as personal API-key providers. It is intentionally a small slice of the broader Copilot host-gating work in #6729 rather than a Copilot provider integration.

## Changes

- Excludes Copilot-backed models from `knownCliModelIds`, `isKnownCliModel`, and name/id resolution in the CLI.
- Returns missing-key availability for non-API providers instead of reporting a fictitious provider key.
- Adds regression tests for the CLI resolver and model availability path.

## Validation

- `npm test -- src/test-kernel/model/ComputeModelOptions.vitest.ts src/test-kernel/cli/CliRootArgs.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli build`
- isolated `texra models list --all --no-color` no longer lists `copilot4o`
- isolated `texra run polish --input paper.tex --model copilot4o --no-input --no-color` returns `Model not found: copilot4o`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `npm run lint` (0 errors; existing warnings remain)
- `npm run typecheck`

Refs #6729

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow roster and availability labeling changes with targeted tests; no auth or runtime execution path changes beyond how models are advertised.
> 
> **Overview**
> Stops the CLI from treating **Copilot** (`vscode.lm`) models as runnable by filtering `ModelProvider.COPILOT` out of `knownCliModelIds`, `isKnownCliModel`, and `resolveKnownCliModelId` in `cliConfig.ts`.
> 
> Fixes model listing so providers that are not API-key backends no longer show **API key set**: `getPersonalAccessKindForModel` in `computeModelOptions.ts` returns `null` for non-API providers instead of assuming `provider-key`, so models like `copilot4o` surface as **missing-key** and disabled when they still appear in a visible list.
> 
> Adds regression tests for CLI model resolution and `computeModelOptionsData` for `copilot4o`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c273f7c49177a9d43880f3cd7402f1fcf966adb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->