### PR TITLE
fix(model): avoid key prompt for keyless providers

### DIFF
--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -297,7 +297,7 @@ export async function getModelUnavailableReason(
     return `Model "${model}" is unavailable because your monthly TeXRA relay quota is exhausted. Switch to personal API keys or wait for the next quota period.`;
   }
 
-  // Personal key mode or unauthenticated — missing provider key
+  // Personal key mode or unauthenticated — missing key or keyless provider.
   const providerName =
     PROVIDER_DISPLAY_NAMES[config.provider] ?? config.provider;
   if (!isApiProvider(config.provider)) {

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -300,6 +300,9 @@ export async function getModelUnavailableReason(
   // Personal key mode or unauthenticated — missing provider key
   const providerName =
     PROVIDER_DISPLAY_NAMES[config.provider] ?? config.provider;
+  if (!isApiProvider(config.provider)) {
+    return `Model "${model}" is provided by ${providerName}, which does not use provider API keys. Use a host that supports ${providerName} models or choose another model.`;
+  }
   return `Model "${model}" requires your ${providerName} API key. Provide it, or enable included access.`;
 }
 

--- a/src/test-kernel/model/ComputeModelOptions.vitest.ts
+++ b/src/test-kernel/model/ComputeModelOptions.vitest.ts
@@ -13,6 +13,7 @@ import {
 import { apiKeySecretName, invalidateApiKeyCache } from '@model/apiProviders';
 import {
   computeModelOptionsData,
+  getModelUnavailableReason,
   invalidateModelOptionsCache,
   type ModelOptionsAccess,
   type ModelOptionsServerAccess,
@@ -149,6 +150,20 @@ describe('computeModelOptionsData relay quota state', () => {
 
     expect(model.availability).toBe('missing-key');
     expect(model.disabled).toBe(true);
+  });
+
+  it('does not tell users to configure API keys for keyless providers', async () => {
+    const access = createModelOptionsAccess({
+      useIncludedAccess: false,
+      relayQuotaExceeded: false,
+      quotaAutoSwitched: false,
+    });
+
+    const reason = await getModelUnavailableReason('copilot4o', access);
+
+    expect(reason).toBe(
+      'Model "copilot4o" is provided by Copilot, which does not use provider API keys. Use a host that supports Copilot models or choose another model.',
+    );
   });
 
   it('does not disable API-key access when ChatGPT subscription is preferred but signed out', async () => {


### PR DESCRIPTION
## Summary

After #6783, keyless providers such as Copilot are no longer treated as if a personal provider API key exists. One unavailable-model explanation still used the generic provider-key fallback, so a Copilot model reaching that path could tell users to configure a Copilot API key. Copilot is keyless and must be host-gated instead.

This PR makes `getModelUnavailableReason` provider-aware for non-API providers, so it tells users that the provider does not use provider API keys and that they should use a supporting host or choose another model.

## Validation

- `npm test -- src/test-kernel/model/ComputeModelOptions.vitest.ts`
- `node --max-old-space-size=4096 ./node_modules/eslint/bin/eslint.js src/model/computeModelOptions.ts src/test-kernel/model/ComputeModelOptions.vitest.ts`
- `npm run typecheck`

Refs #6729

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing string change only in unavailable-model messaging; availability logic is unchanged.
> 
> **Overview**
> **Unavailable-model copy** for keyless providers (e.g. Copilot) no longer falls through to the generic “configure a provider API key” message when availability is `missing-key`.
> 
> `getModelUnavailableReason` now branches on `isApiProvider`: non-API providers get text that the provider does not use provider API keys and that users should use a host that supports those models or pick another model. API providers still get the existing key / included-access message.
> 
> A test asserts `copilot4o` returns the new Copilot-specific explanation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9559908029eeaecb4f9ec1fc6a571e03925b234a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->