### PR TITLE
fix(cli): honor structured init output

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -13,7 +13,7 @@ import {
   seedCliRosterFromDefaultTeam,
 } from '../runtime/defaultTeamRoster';
 import { initCliPlatform } from '../runtime/initPlatform';
-import { writeTextStderr, writeTextStdout } from '../runtime/logSinks';
+import { writeTextStderr } from '../runtime/logSinks';
 import { effectiveCliApiMode, type CliApiMode } from '../runtime/apiAccessMode';
 import {
   getCliModelAccessList,
@@ -24,10 +24,13 @@ import {
   configFileExists,
   ensureTexraGitignored,
   writeInitConfig,
+  type GitignoreOutcome,
   type InitAnswers,
+  type InitConfigShape,
 } from '../runtime/initConfig';
 
 import { defineCliCommand } from './_helpers/defineCliCommand';
+import { emitCliResult } from './_helpers/output';
 import { GLOBAL_ARGS } from './_helpers/globalArgs';
 import type { CliContext } from '../runtime/cliContext';
 
@@ -76,31 +79,87 @@ export function defaultInitAnswers(
   };
 }
 
-function printSummary(
-  filePath: string,
+interface InitSummary {
+  readonly path: string;
+  readonly agent: string;
+  readonly model: string;
+  readonly approvalPolicy: InitAnswers['approvalPolicy'];
+  readonly outputFormat: InitAnswers['outputFormat'];
+  readonly config: InitConfigShape;
+  readonly gitignore?: GitignoreOutcome;
+  readonly warning?: {
+    readonly model: string;
+    readonly message: string;
+    readonly recovery: string;
+  };
+  readonly next: readonly string[];
+}
+
+function initWarning(
   answers: InitAnswers,
   models: readonly CliModelAccess[],
-): void {
-  const lines = [
-    `Wrote ${filePath}`,
-    `  agent: ${answers.agent}`,
-    `  model: ${answers.model}`,
-    `  approval: ${answers.approvalPolicy}`,
-    `  output: ${answers.outputFormat}`,
-  ];
+): InitSummary['warning'] {
   const chosen = models.find((model) => model.model.value === answers.model);
-  if (chosen && !chosen.available) {
+  if (!chosen || chosen.available) return undefined;
+  return {
+    model: answers.model,
+    message: `"${answers.model}" is not usable in the current access mode.`,
+    recovery:
+      'Run `texra login` for included relay access, set the provider API key, or run `texra models list` to pick another.',
+  };
+}
+
+function initGitignoreText(outcome: GitignoreOutcome | undefined): string[] {
+  if (outcome == null || outcome === 'present') return [];
+  return [
+    `${outcome === 'created' ? 'Created' : 'Updated'} .gitignore (.texra/ ignored).`,
+  ];
+}
+
+function initTextSummary(summary: InitSummary): string {
+  const lines = [
+    ...initGitignoreText(summary.gitignore),
+    `Wrote ${summary.path}`,
+    `  agent: ${summary.agent}`,
+    `  model: ${summary.model}`,
+    `  approval: ${summary.approvalPolicy}`,
+    `  output: ${summary.outputFormat}`,
+  ];
+  if (summary.warning) {
     lines.push(
       '',
-      `Note: "${answers.model}" is not usable in the current access mode.`,
-      'Run `texra login` for included relay access, set the provider API key, or run `texra models list` to pick another.',
+      `Note: ${summary.warning.message}`,
+      summary.warning.recovery,
     );
   }
-  lines.push(
-    '',
-    'Next: run `texra` for the launcher, or `texra chat` to start.',
-  );
-  writeTextStdout(lines.join('\n'));
+  lines.push('', ...summary.next);
+  return lines.join('\n');
+}
+
+function emitInitSummary(
+  context: CliContext,
+  filePath: string,
+  answers: InitAnswers,
+  config: InitConfigShape,
+  models: readonly CliModelAccess[],
+  gitignore: GitignoreOutcome | undefined,
+): void {
+  const summary: InitSummary = {
+    path: filePath,
+    agent: answers.agent,
+    model: answers.model,
+    approvalPolicy: answers.approvalPolicy,
+    outputFormat: answers.outputFormat,
+    config,
+    gitignore,
+    warning: initWarning(answers, models),
+    next: ['Next: run `texra` for the launcher, or `texra chat` to start.'],
+  };
+  emitCliResult(context, {
+    json: summary,
+    ndjson: { kind: 'init-config', init: summary },
+    text: initTextSummary(summary),
+  });
 }
 
 async function runInit(
@@ -156,23 +215,20 @@ async function runInit(
     gitignore = opts.gitignore ?? false;
   }
 
+  const config = buildInitConfig(answers);
   try {
-    await writeInitConfig(filePath, buildInitConfig(answers));
+    await writeInitConfig(filePath, config);
   } catch (error: unknown) {
     if (seededRoster) await clearCliSeededRoster();
     throw error;
   }
 
+  let gitignoreOutcome: GitignoreOutcome | undefined;
   if (gitignore) {
-    const outcome = await ensureTexraGitignored(context.cwd);
-    if (outcome !== 'present') {
-      writeTextStdout(
-        `${outcome === 'created' ? 'Created' : 'Updated'} .gitignore (.texra/ ignored).`,
-      );
-    }
+    gitignoreOutcome = await ensureTexraGitignored(context.cwd);
   }
 
-  printSummary(filePath, answers, models);
+  emitInitSummary(context, filePath, answers, config, models, gitignoreOutcome);
   return CliExitCode.Success;
 }
 

--- a/packages/cli/src/schemas/cliOutput.ts
+++ b/packages/cli/src/schemas/cliOutput.ts
@@ -37,6 +37,7 @@ export const CliNdjsonRecordSchema = z.discriminatedUnion('kind', [
   z.looseObject({ kind: z.literal('memory-detail') }),
   z.looseObject({ kind: z.literal('auth') }),
   z.looseObject({ kind: z.literal('auth-status') }),
+  z.looseObject({ kind: z.literal('init-config'), init: payload }),
   z.looseObject({ kind: z.literal('chatgpt-auth') }),
   z.looseObject({ kind: z.literal('chatgpt-auth-status') }),
   z.looseObject({ kind: z.literal('relay-usage') }),

--- a/src/test-kernel/cli/CliNdjsonRecordContract.vitest.mts
+++ b/src/test-kernel/cli/CliNdjsonRecordContract.vitest.mts
@@ -21,6 +21,7 @@ const REPRESENTATIVE_RECORDS: CliNdjsonRecord[] = [
   { kind: 'auth', authenticated: true, account: 'a@b.c', expiresAt: 1 },
   { kind: 'auth', authenticated: false, relayTokenConfigured: true },
   { kind: 'auth-status', authenticated: true, tier: 'pro' },
+  { kind: 'init-config', init: { path: '.texra/config.json' } },
   { kind: 'relay-usage', tier: 'pro', costUsd: 1, limitUsd: 10 },
   { kind: 'relay-token', name: 'ci', token: 'secret' },
   { kind: 'relay-token-info', name: 'ci', createdAt: 1 },

--- a/src/test-kernel/cli/InitCommand.vitest.mts
+++ b/src/test-kernel/cli/InitCommand.vitest.mts
@@ -1,5 +1,47 @@
-import { describe, expect, it } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  clearCliSeededRoster: vi.fn(),
+  getCliModelAccessList: vi.fn(),
+  getVisibleAgents: vi.fn(),
+  initCliPlatform: vi.fn(),
+  loadAgents: vi.fn(),
+  seedCliRosterFromDefaultTeam: vi.fn(),
+}));
+
+vi.mock('@agent/index', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@agent/index')>();
+  return {
+    ...actual,
+    getVisibleAgents: mocks.getVisibleAgents,
+    loadAgents: mocks.loadAgents,
+  };
+});
+
+vi.mock('@cli/runtime/defaultTeamRoster', () => ({
+  clearCliSeededRoster: mocks.clearCliSeededRoster,
+  seedCliRosterFromDefaultTeam: mocks.seedCliRosterFromDefaultTeam,
+}));
+
+vi.mock('@cli/runtime/initPlatform', () => ({
+  initCliPlatform: mocks.initCliPlatform,
+}));
+
+vi.mock('@cli/runtime/modelAccess', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@cli/runtime/modelAccess')>();
+  return {
+    ...actual,
+    getCliModelAccessList: mocks.getCliModelAccessList,
+  };
+});
+
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { runCli } from '@cli/commands/root';
 import {
   defaultInitAgentOptions,
   defaultInitAnswers,
@@ -23,7 +65,58 @@ function modelAccess(
   };
 }
 
+async function makeTempProject(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'texra-init-test-'));
+}
+
 describe('CLI init command', () => {
+  let stdout = '';
+  let stderr = '';
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stdout = '';
+    stderr = '';
+    mocks.clearCliSeededRoster.mockReset().mockResolvedValue(undefined);
+    mocks.getCliModelAccessList
+      .mockReset()
+      .mockResolvedValue([modelAccess('deepseekproT')]);
+    mocks.getVisibleAgents
+      .mockReset()
+      .mockReturnValue([
+        { name: 'assistant', category: AgentCategory.ToolUse },
+      ]);
+    mocks.initCliPlatform.mockReset().mockResolvedValue(undefined);
+    mocks.loadAgents.mockReset().mockResolvedValue(undefined);
+    mocks.seedCliRosterFromDefaultTeam.mockReset().mockResolvedValue(false);
+    stdoutSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation((chunk: unknown, ...rest: unknown[]) => {
+        stdout += String(chunk);
+        const cb = rest.find((arg) => typeof arg === 'function') as
+          | ((err?: Error | null) => void)
+          | undefined;
+        cb?.(null);
+        return true;
+      }) as unknown as ReturnType<typeof vi.spyOn>;
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation((chunk: unknown, ...rest: unknown[]) => {
+        stderr += String(chunk);
+        const cb = rest.find((arg) => typeof arg === 'function') as
+          | ((err?: Error | null) => void)
+          | undefined;
+        cb?.(null);
+        return true;
+      }) as unknown as ReturnType<typeof vi.spyOn>;
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
   it('accepts global CLI flags while keeping init-specific cwd help', () => {
     const args = initCommand.args as Record<
       string,
@@ -138,5 +231,95 @@ describe('CLI init command', () => {
         disabled: false,
       },
     ]);
+  });
+
+  it('emits valid NDJSON for non-interactive init', async () => {
+    const root = await makeTempProject();
+    try {
+      const workspaceRoot = await fs.realpath(root);
+      const result = await runCli([
+        '--cwd',
+        root,
+        'init',
+        '--print',
+        '--api-mode',
+        'personal',
+        '--output-format',
+        'ndjson',
+        '--gitignore',
+        '--no-color',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      expect(stderr).toBe('');
+      expect(stdout).not.toContain('Wrote ');
+      expect(stdout).not.toContain('Created .gitignore');
+      const lines = stdout.trimEnd().split('\n');
+      expect(lines).toHaveLength(1);
+      const record = JSON.parse(lines[0] ?? '{}') as {
+        readonly kind?: string;
+        readonly ts?: string;
+        readonly init?: {
+          readonly path?: string;
+          readonly agent?: string;
+          readonly model?: string;
+          readonly approvalPolicy?: string;
+          readonly outputFormat?: string;
+          readonly gitignore?: string;
+          readonly config?: unknown;
+        };
+      };
+      expect(record).toMatchObject({
+        kind: 'init-config',
+        init: {
+          path: path.join(workspaceRoot, '.texra', 'config.json'),
+          agent: 'assistant',
+          model: 'deepseekproT',
+          approvalPolicy: 'ask',
+          outputFormat: 'text',
+          gitignore: 'created',
+          config: {
+            model: 'deepseekproT',
+            outputFormat: 'text',
+            approvalPolicy: 'ask',
+            chat: { agent: 'assistant', model: 'deepseekproT' },
+          },
+        },
+      });
+      expect(record.ts).toEqual(expect.any(String));
+      await expect(
+        fs.readFile(path.join(root, '.gitignore'), 'utf8'),
+      ).resolves.toBe('.texra/\n');
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps the legacy text init summary for human output', async () => {
+    const root = await makeTempProject();
+    try {
+      const workspaceRoot = await fs.realpath(root);
+      const result = await runCli([
+        '--cwd',
+        root,
+        'init',
+        '--print',
+        '--api-mode',
+        'personal',
+        '--gitignore',
+        '--no-color',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      expect(stderr).toBe('');
+      expect(stdout).toContain('Created .gitignore (.texra/ ignored).');
+      expect(stdout).toContain(
+        `Wrote ${path.join(workspaceRoot, '.texra', 'config.json')}`,
+      );
+      expect(stdout).toContain('  agent: assistant');
+      expect(stdout).toContain('Next: run `texra` for the launcher');
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Route `texra init` through the shared CLI output formatter so `--output-format json` and `--output-format ndjson` produce machine-readable stdout.
- Include the optional `.gitignore` outcome and model-availability warning in the structured initialization payload instead of printing stray human text.
- Register the new `init-config` NDJSON record kind and cover it with focused init command tests.

## Validation
- `corepack pnpm exec vitest run src/test-kernel/cli/InitCommand.vitest.mts src/test-kernel/cli/CliNdjsonRecordContract.vitest.mts`
- `corepack pnpm exec eslint packages/cli/src/commands/init.ts packages/cli/src/schemas/cliOutput.ts src/test-kernel/cli/InitCommand.vitest.mts src/test-kernel/cli/CliNdjsonRecordContract.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli build`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `npm run lint` (passes with existing warnings)
- `npm run typecheck`
- `npm test`

Direct checks also parsed fresh bundled `texra init --print --api-mode personal --output-format ndjson --gitignore --no-color` and `--output-format json` output successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to init command stdout formatting and NDJSON contract registration; behavior for writing config and `.gitignore` is preserved with added test coverage.
> 
> **Overview**
> **`texra init` now uses the shared CLI output path** so `--output-format json` and `ndjson` return machine-readable results instead of printing human summary lines on stdout.
> 
> The structured payload includes the written config path, chosen agent/model/approval/output settings, the full `config` object, optional `.gitignore` outcome (`created` / `updated` / omitted when already present), and the model-availability warning when the default model is unusable in the current access mode. Text output keeps the same summary wording, with gitignore and warning folded into that formatter.
> 
> A new NDJSON record kind **`init-config`** is registered in the CLI output schema and contract tests; init command tests assert NDJSON shape and that default text output is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba0b79ced5d82356931b1a01e18e0583c43eb9f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->