### PR TITLE
fix(cli): honor structured tools output

### DIFF
--- a/packages/cli/src/commands/tools.ts
+++ b/packages/cli/src/commands/tools.ts
@@ -4,11 +4,7 @@ import { defineCommand } from 'citty';
 
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform } from '../runtime/initPlatform';
-import {
-  writeErrorStderr,
-  writeTextStderr,
-  writeTextStdout,
-} from '../runtime/logSinks';
+import { writeErrorStderr, writeTextStderr } from '../runtime/logSinks';
 import {
   formatCliToolList,
   formatCliToolMissingInstallCommandMessage,
@@ -19,12 +15,28 @@ import {
   readCliToolStatus,
   readCliToolStatuses,
   setCliToolEnabled,
+  type CliToolGuide,
 } from '../runtime/tools';
 
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import { GLOBAL_ARGS } from './_helpers/globalArgs';
 import { emitCliResult } from './_helpers/output';
 import type { CliContext } from '../runtime/cliContext';
+
+type ToolGuideOperation = 'install' | 'auth';
+
+interface CliToolToggleResult {
+  readonly id: string;
+  readonly enabled: boolean;
+  readonly action: 'enabled' | 'disabled';
+}
+
+interface CliToolGuideResult {
+  readonly id: string;
+  readonly operation: ToolGuideOperation;
+  readonly text: string;
+  readonly command?: string;
+}
 
 async function listTools(context: CliContext): Promise<number> {
   await initCliPlatform({ ...context, quietLogs: true });
@@ -65,7 +77,16 @@ async function toggleTool(
     writeTextStderr(formatCliToolNotToggleableMessage(id));
     return CliExitCode.Usage;
   }
-  writeTextStdout(`${enabled ? 'Enabled' : 'Disabled'} ${id}.`);
+  const result: CliToolToggleResult = {
+    id,
+    enabled,
+    action: enabled ? 'enabled' : 'disabled',
+  };
+  emitCliResult(context, {
+    json: result,
+    ndjson: { kind: 'tool-toggle', tool: result },
+    text: `${enabled ? 'Enabled' : 'Disabled'} ${id}.`,
+  });
   return CliExitCode.Success;
 }
 
@@ -80,6 +101,19 @@ function shellRun(command: string): Promise<number> {
   });
 }
 
+function toolGuideResult(
+  id: string,
+  operation: ToolGuideOperation,
+  guide: CliToolGuide,
+): CliToolGuideResult {
+  return {
+    id,
+    operation,
+    text: guide.text,
+    command: guide.command,
+  };
+}
+
 async function installTool(
   context: CliContext,
   id: string,
@@ -92,7 +126,23 @@ async function installTool(
     return CliExitCode.Usage;
   }
 
-  writeTextStdout(guide.text);
+  if (run && !guide.command && context.outputFormat !== 'text') {
+    writeTextStderr(formatCliToolMissingInstallCommandMessage(id));
+    return CliExitCode.Usage;
+  }
+  if (run && context.outputFormat !== 'text') {
+    writeTextStderr(
+      'Cannot combine --output-format json|ndjson with tools install --run running an external command; use text output to run it, or omit the run request to inspect the guide.',
+    );
+    return CliExitCode.Usage;
+  }
+
+  const result = toolGuideResult(id, 'install', guide);
+  emitCliResult(context, {
+    json: result,
+    ndjson: { kind: 'tool-guide', guide: result },
+    text: result.text,
+  });
   if (!run) return CliExitCode.Success;
   if (!guide.command) {
     writeTextStderr(formatCliToolMissingInstallCommandMessage(id));
@@ -109,8 +159,14 @@ async function authTool(context: CliContext, id: string): Promise<number> {
     return CliExitCode.Usage;
   }
 
-  writeTextStdout(guide.text);
-  if (!guide.command) return CliExitCode.Success;
+  const result = toolGuideResult(id, 'auth', guide);
+  emitCliResult(context, {
+    json: result,
+    ndjson: { kind: 'tool-guide', guide: result },
+    text: result.text,
+  });
+  if (!guide.command || context.outputFormat !== 'text')
+    return CliExitCode.Success;
   try {
     return await shellRun(guide.command);
   } catch (error) {

--- a/packages/cli/src/schemas/cliOutput.ts
+++ b/packages/cli/src/schemas/cliOutput.ts
@@ -32,6 +32,8 @@ const payload = z.unknown();
 export const CliNdjsonRecordSchema = z.discriminatedUnion('kind', [
   z.looseObject({ kind: z.literal('agent'), agent: payload }),
   z.looseObject({ kind: z.literal('tool-status'), tool: payload }),
+  z.looseObject({ kind: z.literal('tool-toggle'), tool: payload }),
+  z.looseObject({ kind: z.literal('tool-guide'), guide: payload }),
   z.looseObject({ kind: z.literal('model'), model: payload }),
   z.looseObject({ kind: z.literal('memory'), memory: payload }),
   z.looseObject({ kind: z.literal('memory-detail') }),

--- a/src/test-kernel/cli/CliNdjsonRecordContract.vitest.mts
+++ b/src/test-kernel/cli/CliNdjsonRecordContract.vitest.mts
@@ -15,6 +15,8 @@ import {
 const REPRESENTATIVE_RECORDS: CliNdjsonRecord[] = [
   { kind: 'agent', agent: { name: 'coder' } },
   { kind: 'tool-status', tool: { name: 'bash', available: true } },
+  { kind: 'tool-toggle', tool: { id: 'codex', enabled: false } },
+  { kind: 'tool-guide', guide: { id: 'codex', operation: 'install' } },
   { kind: 'model', model: { value: 'sonnet45', label: 'Sonnet 4.5' } },
   { kind: 'memory', memory: { id: 'm1', text: 'remember' } },
   { kind: 'memory-detail', id: 'm1', text: 'remember', scope: 'workspace' },

--- a/src/test-kernel/cli/ToolsCommand.vitest.mts
+++ b/src/test-kernel/cli/ToolsCommand.vitest.mts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  initCliPlatform: vi.fn(),
+  readCliToolGuide: vi.fn(),
+  setCliToolEnabled: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+vi.mock('node:child_process', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:child_process')>()),
+  spawn: mocks.spawn,
+}));
+
+vi.mock('@cli/runtime/initPlatform', () => ({
+  initCliPlatform: mocks.initCliPlatform,
+}));
+
+vi.mock('@cli/runtime/tools', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@cli/runtime/tools')>();
+  return {
+    ...actual,
+    readCliToolGuide: mocks.readCliToolGuide,
+    setCliToolEnabled: mocks.setCliToolEnabled,
+  };
+});
+
+const { runCli } = await import('@cli/commands/root');
+
+describe('CLI tools command', () => {
+  let stdout = '';
+  let stderr = '';
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stdout = '';
+    stderr = '';
+    mocks.initCliPlatform.mockReset().mockResolvedValue(undefined);
+    mocks.readCliToolGuide.mockReset().mockReturnValue({
+      text: 'Install help',
+      command: 'echo install',
+    });
+    mocks.setCliToolEnabled.mockReset().mockResolvedValue(true);
+    mocks.spawn.mockReset();
+    stdoutSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation((chunk: unknown, ...rest: unknown[]) => {
+        stdout += String(chunk);
+        const cb = rest.find((arg) => typeof arg === 'function') as
+          | ((err?: Error | null) => void)
+          | undefined;
+        cb?.(null);
+        return true;
+      }) as unknown as ReturnType<typeof vi.spyOn>;
+    stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation((chunk: unknown, ...rest: unknown[]) => {
+        stderr += String(chunk);
+        const cb = rest.find((arg) => typeof arg === 'function') as
+          | ((err?: Error | null) => void)
+          | undefined;
+        cb?.(null);
+        return true;
+      }) as unknown as ReturnType<typeof vi.spyOn>;
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  it('emits JSON for tool toggles', async () => {
+    const result = await runCli([
+      'tools',
+      'disable',
+      'codex',
+      '--print',
+      '--api-mode',
+      'personal',
+      '--output-format',
+      'json',
+      '--no-color',
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(stderr).toBe('');
+    expect(mocks.setCliToolEnabled).toHaveBeenCalledWith('codex', false);
+    expect(JSON.parse(stdout)).toEqual({
+      id: 'codex',
+      enabled: false,
+      action: 'disabled',
+    });
+  });
+
+  it('emits NDJSON for tool toggles', async () => {
+    const result = await runCli([
+      'tools',
+      'enable',
+      'codex',
+      '--print',
+      '--api-mode',
+      'personal',
+      '--output-format',
+      'ndjson',
+      '--no-color',
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(stderr).toBe('');
+    const lines = stdout.trimEnd().split('\n');
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0] ?? '{}')).toMatchObject({
+      kind: 'tool-toggle',
+      tool: { id: 'codex', enabled: true, action: 'enabled' },
+      ts: expect.any(String),
+    });
+  });
+
+  it('emits JSON for install guides without running the command', async () => {
+    const result = await runCli([
+      'tools',
+      'install',
+      'codex',
+      '--print',
+      '--api-mode',
+      'personal',
+      '--output-format',
+      'json',
+      '--no-color',
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(stderr).toBe('');
+    expect(mocks.spawn).not.toHaveBeenCalled();
+    expect(JSON.parse(stdout)).toEqual({
+      id: 'codex',
+      operation: 'install',
+      text: 'Install help',
+      command: 'echo install',
+    });
+  });
+
+  it('rejects structured install output when --run would contaminate stdout', async () => {
+    const result = await runCli([
+      'tools',
+      'install',
+      'codex',
+      '--run',
+      '--print',
+      '--api-mode',
+      'personal',
+      '--output-format',
+      'json',
+      '--no-color',
+    ]);
+
+    expect(result.exitCode).toBe(2);
+    expect(stdout).toBe('');
+    expect(stderr).toContain('Cannot combine --output-format json|ndjson');
+    expect(mocks.spawn).not.toHaveBeenCalled();
+  });
+
+  it('reports missing install commands before structured --run conflicts', async () => {
+    mocks.readCliToolGuide.mockReturnValueOnce({
+      text: 'Install help',
+    });
+
+    const result = await runCli([
+      'tools',
+      'install',
+      'github-pr-subscription',
+      '--run',
+      '--print',
+      '--api-mode',
+      'personal',
+      '--output-format',
+      'json',
+      '--no-color',
+    ]);
+
+    expect(result.exitCode).toBe(2);
+    expect(stdout).toBe('');
+    expect(stderr).toContain(
+      'No install command is registered for github-pr-subscription.',
+    );
+    expect(mocks.spawn).not.toHaveBeenCalled();
+  });
+
+  it('emits structured auth guides without launching the external login', async () => {
+    mocks.readCliToolGuide.mockReturnValueOnce({
+      text: 'Auth help',
+      command: 'codex login',
+    });
+
+    const result = await runCli([
+      'tools',
+      'auth',
+      'codex',
+      '--print',
+      '--api-mode',
+      'personal',
+      '--output-format',
+      'ndjson',
+      '--no-color',
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(stderr).toBe('');
+    expect(mocks.spawn).not.toHaveBeenCalled();
+    expect(JSON.parse(stdout)).toMatchObject({
+      kind: 'tool-guide',
+      guide: {
+        id: 'codex',
+        operation: 'auth',
+        text: 'Auth help',
+        command: 'codex login',
+      },
+      ts: expect.any(String),
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Route `tools enable` / `tools disable` through the shared CLI output formatter so `json` and `ndjson` output is parseable.
- Return structured install/auth guide records for machine-readable `tools install` and `tools auth` output.
- Keep external process launches out of structured stdout: `tools auth --output-format json|ndjson` emits the guide without launching login, and `tools install --run --output-format json|ndjson` exits with a usage error before writing stdout.
- Register `tool-toggle` and `tool-guide` NDJSON records and add command-level regression tests.

## Validation
- `corepack pnpm exec vitest run src/test-kernel/cli/ToolsCommand.vitest.mts src/test-kernel/cli/CliNdjsonRecordContract.vitest.mts`
- `corepack pnpm exec eslint packages/cli/src/commands/tools.ts packages/cli/src/schemas/cliOutput.ts src/test-kernel/cli/ToolsCommand.vitest.mts src/test-kernel/cli/CliNdjsonRecordContract.vitest.mts`
- `corepack pnpm exec prettier --check packages/cli/src/commands/tools.ts packages/cli/src/schemas/cliOutput.ts src/test-kernel/cli/ToolsCommand.vitest.mts src/test-kernel/cli/CliNdjsonRecordContract.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli build`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- Direct bundled-binary parse checks for `tools disable --output-format json`, `tools enable --output-format ndjson`, `tools install --output-format json`, `tools auth --output-format ndjson`, and structured `install --run` error paths.
- `npm run lint` (passes with existing warnings)
- `npm run typecheck`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI output-format and guard-rail changes only; no auth, data, or core runtime logic beyond keeping stdout clean for structured consumers.
> 
> **Overview**
> **`tools enable` / `tools disable`** now go through `emitCliResult` instead of printing plain text, so `--output-format json|ndjson` returns parseable toggle payloads (`tool-toggle` NDJSON).
> 
> **`tools install` and `tools auth`** emit structured **tool-guide** records (id, operation, text, optional command) for machine-readable output. With **json/ndjson**, **`tools auth` no longer spawns** the external login command; **`tools install --run`** is rejected with a usage error so subprocess output cannot corrupt stdout. Text mode behavior for running install/auth commands is unchanged.
> 
> The NDJSON schema and contract tests register **`tool-toggle`** and **`tool-guide`**, and new **`ToolsCommand`** tests lock the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec9f64aae5678da8384712c5f19d0f17626e6ffa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->