### PR TITLE
fix(cli): honor structured version output

### DIFF
--- a/packages/cli/src/commands/version.ts
+++ b/packages/cli/src/commands/version.ts
@@ -1,19 +1,45 @@
 import { defineCommand } from 'citty';
 
-import { readCliVersion } from '../runtime/cliContext';
+import { cliEnvValue, readCliVersion } from '../runtime/cliContext';
 import { CliExitCode } from '../runtime/exitCodes';
-import { writeTextStdout } from '../runtime/logSinks';
 
+import { emitCliResult } from './_helpers/output';
 import { setExitCode } from './_helpers/exitCode';
 import { GLOBAL_ARGS } from './_helpers/globalArgs';
+import {
+  CLI_OUTPUT_FORMATS,
+  type CliOutputFormat,
+} from '../schemas/cliSettings';
+
+function isCliOutputFormat(value: unknown): value is CliOutputFormat {
+  return (
+    typeof value === 'string' &&
+    CLI_OUTPUT_FORMATS.includes(value as CliOutputFormat)
+  );
+}
+
+function parseVersionOutputFormat(flagValue: unknown): CliOutputFormat {
+  if (isCliOutputFormat(flagValue)) return flagValue;
+  const envValue = cliEnvValue('TEXRA_OUTPUT_FORMAT')?.trim();
+  return isCliOutputFormat(envValue) ? envValue : 'text';
+}
 
 export const versionCommand = defineCommand({
   meta: { name: 'version', description: 'Print the CLI version' },
   args: {
     ...GLOBAL_ARGS,
   },
-  async run() {
-    writeTextStdout(await readCliVersion());
+  async run(ctx) {
+    const version = await readCliVersion();
+    const result = { version };
+    emitCliResult(
+      { outputFormat: parseVersionOutputFormat(ctx.args['output-format']) },
+      {
+        json: result,
+        ndjson: { kind: 'version', ...result },
+        text: version,
+      },
+    );
     setExitCode(CliExitCode.Success);
   },
 });

--- a/packages/cli/src/schemas/cliOutput.ts
+++ b/packages/cli/src/schemas/cliOutput.ts
@@ -34,6 +34,7 @@ export const CliNdjsonRecordSchema = z.discriminatedUnion('kind', [
   z.looseObject({ kind: z.literal('tool-status'), tool: payload }),
   z.looseObject({ kind: z.literal('tool-toggle'), tool: payload }),
   z.looseObject({ kind: z.literal('tool-guide'), guide: payload }),
+  z.looseObject({ kind: z.literal('version'), version: z.string() }),
   z.looseObject({ kind: z.literal('model'), model: payload }),
   z.looseObject({ kind: z.literal('memory'), memory: payload }),
   z.looseObject({ kind: z.literal('memory-detail') }),

--- a/src/test-kernel/cli/CliNdjsonRecordContract.vitest.mts
+++ b/src/test-kernel/cli/CliNdjsonRecordContract.vitest.mts
@@ -17,6 +17,7 @@ const REPRESENTATIVE_RECORDS: CliNdjsonRecord[] = [
   { kind: 'tool-status', tool: { name: 'bash', available: true } },
   { kind: 'tool-toggle', tool: { id: 'codex', enabled: false } },
   { kind: 'tool-guide', guide: { id: 'codex', operation: 'install' } },
+  { kind: 'version', version: '0.39.1' },
   { kind: 'model', model: { value: 'sonnet45', label: 'Sonnet 4.5' } },
   { kind: 'memory', memory: { id: 'm1', text: 'remember' } },
   { kind: 'memory-detail', id: 'm1', text: 'remember', scope: 'workspace' },

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -1479,6 +1479,73 @@ describe('runCli usage output stream routing', () => {
     }
   });
 
+  it('honors structured output for the version command', async () => {
+    const jsonResult = await runCli(['version', '--output-format', 'json']);
+    expect(jsonResult.exitCode).toBe(0);
+    expect(JSON.parse(stdout)).toMatchObject({
+      version: expect.stringMatching(/^\d+\.\d+\.\d+/),
+    });
+    expect(stderr).toBe('');
+
+    stdout = '';
+    stderr = '';
+
+    const ndjsonResult = await runCli([
+      '--version',
+      '--output-format',
+      'ndjson',
+    ]);
+    expect(ndjsonResult.exitCode).toBe(0);
+    expect(JSON.parse(stdout.trim())).toMatchObject({
+      kind: 'version',
+      version: expect.stringMatching(/^\d+\.\d+\.\d+/),
+      ts: expect.any(String),
+    });
+    expect(stderr).toBe('');
+  });
+
+  it('prints version output without resolving workspace context', async () => {
+    const result = await runCli([
+      '--cwd',
+      '/definitely/missing/texra-version-test',
+      '--version',
+      '--output-format',
+      'json',
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(stdout)).toMatchObject({
+      version: expect.stringMatching(/^\d+\.\d+\.\d+/),
+    });
+    expect(stderr).toBe('');
+  });
+
+  it('honors TEXRA_OUTPUT_FORMAT for version output without workspace context', async () => {
+    const previousOutputFormat = process.env.TEXRA_OUTPUT_FORMAT;
+    process.env.TEXRA_OUTPUT_FORMAT = 'ndjson';
+    try {
+      const result = await runCli([
+        '--cwd',
+        '/definitely/missing/texra-version-test',
+        '--version',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      expect(JSON.parse(stdout.trim())).toMatchObject({
+        kind: 'version',
+        version: expect.stringMatching(/^\d+\.\d+\.\d+/),
+        ts: expect.any(String),
+      });
+      expect(stderr).toBe('');
+    } finally {
+      if (previousOutputFormat === undefined) {
+        delete process.env.TEXRA_OUTPUT_FORMAT;
+      } else {
+        process.env.TEXRA_OUTPUT_FORMAT = previousOutputFormat;
+      }
+    }
+  });
+
   it('shows EXAMPLES and a docs link for bare `help`', async () => {
     const result = await runCli(['help']);
     expect(result.exitCode).toBe(0);


### PR DESCRIPTION
## Summary

`texra version` accepted the shared `--output-format` flag but always printed the bare version string. This made both `texra version --output-format json` and the top-level shortcut `texra --version --output-format ndjson` invalid for machine consumers.

This PR routes the version command through `emitCliResult`, producing:

- text: the bare version string, unchanged for humans.
- JSON: `{ "version": "..." }`.
- NDJSON: `{ "kind": "version", "version": "...", "ts": "..." }`.

The new `version` NDJSON kind is registered in the CLI output contract.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/CliNdjsonRecordContract.vitest.mts`
- `corepack pnpm exec prettier --check packages/cli/src/commands/version.ts packages/cli/src/schemas/cliOutput.ts src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/CliNdjsonRecordContract.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli build`
- `node packages/cli/dist/bin/texra.js version --output-format json`
- `node packages/cli/dist/bin/texra.js --version --output-format ndjson`
- JSON parse checks for both bundled outputs
- `corepack pnpm exec eslint packages/cli/src/commands/version.ts packages/cli/src/schemas/cliOutput.ts src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/CliNdjsonRecordContract.vitest.mts`
- `npm run typecheck`
- `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI output change with contract tests; no auth, data, or workflow execution paths touched.
> 
> **Overview**
> **`texra version` and `texra --version` now respect `--output-format` and `TEXRA_OUTPUT_FORMAT`** instead of always printing a bare semver string.
> 
> The version command uses **`emitCliResult`**: text stays the same for humans; JSON is `{ "version": "..." }`; NDJSON adds **`kind: "version"`** (registered in **`cliOutput.ts`**). Format resolution follows the flag, then the env var, then **`text`**.
> 
> Tests cover JSON/NDJSON (including the **`--version`** shortcut), success with a missing **`--cwd`**, and env-driven NDJSON without workspace setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 092a073884539c7f434fa48fc6f08b875d53091b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->