### PR TITLE
fix(cli): reject headless multi-agent ask

### DIFF
--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -3,7 +3,6 @@ import { defineCommand } from 'citty';
 import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 
-import { approvalPromptsUnavailable } from '../runtime/approvalPolicyAvailability';
 import { missingToolUseAgentMessage } from '../runtime/agents';
 import {
   CliUsageError,
@@ -69,6 +68,10 @@ interface MultiAgentRunInit {
 
 const MULTI_AGENT_TASK_REQUIRED_MESSAGE =
   'Provide --input, --instruction, or --instruction-file for the team task. Example: texra multi-agent run physicist --instruction "Check this derivation"';
+
+function headlessAskMultiAgentMessage(presetId: string): string {
+  return `Cannot run multi-agent preset "${presetId}" with headless approval policy "ask": delegation prompts cannot be answered. Use an interactive run to answer prompts, pass --approval-policy never to deny approval-gated tools, or pass --approval-policy yolo only when you intentionally want to auto-approve privileged tools.`;
+}
 
 function writeMultiAgentRunResult(
   context: CliContext,
@@ -138,11 +141,20 @@ export async function runMultiAgentPreset(
   if (init.inputFiles.length === 0 && !hasInstruction) {
     throw new CliUsageError(MULTI_AGENT_TASK_REQUIRED_MESSAGE);
   }
-
   await initCliPlatform({ ...context, quietLogs: true });
 
-  const { plan, remoteAgentLoadAttempted } =
-    await loadCliMultiAgentRunPlan(init);
+  const rejectsHeadlessAsk =
+    context.mode === 'headless' && context.approvalPolicy === 'ask';
+  const { plan, remoteAgentLoadAttempted } = await loadCliMultiAgentRunPlan(
+    init,
+    {
+      reloadRemoteAgents: !rejectsHeadlessAsk,
+    },
+  );
+  if (rejectsHeadlessAsk) {
+    writeTextStderr(headlessAskMultiAgentMessage(plan.preset.id));
+    return CliExitCode.Usage;
+  }
   if (remoteAgentLoadAttempted) {
     const inspectAdvice = `Run \`texra multi-agent show ${plan.preset.id}\` to view the resolved team.`;
     // Otherwise the silent second load makes runs behave differently from a
@@ -188,13 +200,9 @@ export async function runMultiAgentPreset(
       readStdinText: readCliStdinText,
     },
     async ({ inputFiles, contextFiles }) => {
-      if (approvalPromptsUnavailable(runContext)) {
-        const reason =
-          runContext.approvalPolicy === 'never'
-            ? 'approval policy "never" denies approval-gated delegation tools'
-            : 'headless approval policy "ask" cannot show delegation prompts';
+      if (runContext.approvalPolicy === 'never') {
         writeTextStderr(
-          `WARN preset ${plan.preset.id} may run without subagent delegation because ${reason}. Use an interactive run to answer prompts, or pass --approval-policy yolo only when you intentionally want to auto-approve privileged tools.`,
+          `WARN preset ${plan.preset.id} may run without subagent delegation because approval policy "never" denies approval-gated delegation tools. Use an interactive run to answer prompts, or pass --approval-policy yolo only when you intentionally want to auto-approve privileged tools.`,
         );
       }
 

--- a/packages/cli/src/runtime/multiAgentRunPlan.ts
+++ b/packages/cli/src/runtime/multiAgentRunPlan.ts
@@ -21,6 +21,10 @@ interface MultiAgentRunPlanInit {
   readonly agent?: string;
 }
 
+interface MultiAgentRunPlanLoadOptions {
+  readonly reloadRemoteAgents?: boolean;
+}
+
 interface RemoteAgentPlanReloadResult<T> {
   readonly value: T;
   readonly remoteAgentLoadAttempted: boolean;
@@ -71,10 +75,18 @@ function planLoadedCliMultiAgentPresets(
  */
 export async function loadCliMultiAgentRunPlan(
   init: MultiAgentRunPlanInit,
+  options: MultiAgentRunPlanLoadOptions = {},
 ): Promise<MultiAgentRunPlanLoadResult> {
   await loadAgents({ includeRemote: false });
+  const localPlan = planCurrentMultiAgentRun(init);
+  if (options.reloadRemoteAgents === false) {
+    return {
+      plan: localPlan,
+      remoteAgentLoadAttempted: false,
+    };
+  }
   const result = await reloadRemoteAgentsForGaps(
-    planCurrentMultiAgentRun(init),
+    localPlan,
     cliMultiAgentPlanHasGaps,
     () => planCurrentMultiAgentRun(init),
   );

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -146,8 +146,8 @@ function mockExpandedRunInputs(inputs: {
 describe('CLI multi-agent run command', () => {
   const approvalUnavailableWarning =
     'WARN preset mathematician may run without subagent delegation because approval policy "never" denies approval-gated delegation tools. Use an interactive run to answer prompts, or pass --approval-policy yolo only when you intentionally want to auto-approve privileged tools.';
-  const headlessAskWarning =
-    'WARN preset mathematician may run without subagent delegation because headless approval policy "ask" cannot show delegation prompts. Use an interactive run to answer prompts, or pass --approval-policy yolo only when you intentionally want to auto-approve privileged tools.';
+  const headlessAskError =
+    'Cannot run multi-agent preset "mathematician" with headless approval policy "ask": delegation prompts cannot be answered. Use an interactive run to answer prompts, pass --approval-policy never to deny approval-gated tools, or pass --approval-policy yolo only when you intentionally want to auto-approve privileged tools.';
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -358,7 +358,7 @@ describe('CLI multi-agent run command', () => {
     );
   });
 
-  it('warns when headless ask cannot show delegation prompts', async () => {
+  it('refuses headless ask before launching a team run', async () => {
     const { runMultiAgentPreset } = await import('@cli/commands/multiAgent');
 
     const exitCode = await runMultiAgentPreset(
@@ -372,8 +372,13 @@ describe('CLI multi-agent run command', () => {
       },
     );
 
-    expect(exitCode).toBe(0);
-    expect(mocks.writeTextStderr).toHaveBeenCalledWith(headlessAskWarning);
+    expect(exitCode).toBe(2);
+    expect(mocks.writeTextStderr).toHaveBeenCalledWith(headlessAskError);
+    expect(mocks.initCliPlatform).toHaveBeenCalledOnce();
+    expect(mocks.loadAgents).toHaveBeenCalledOnce();
+    expect(mocks.loadAgents).toHaveBeenCalledWith({ includeRemote: false });
+    expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
+    expect(mocks.executeCliConfig).not.toHaveBeenCalled();
   });
 
   it('does not warn when yolo can auto-approve delegation', async () => {


### PR DESCRIPTION
## What

Fixes #6789.

`texra multi-agent run ... --no-input --approval-policy ask` now fails with a usage error after local preset validation and before remote team reload, model resolution, input expansion, or execution.

This preserves ordinary recovery messages for invalid presets while keeping the three headless approval modes explicit:

- use an interactive run for `ask`, where delegation prompts can be answered;
- use `--approval-policy never` to deny approval-gated tools deterministically;
- use `--approval-policy yolo` only when privileged tool calls should be auto-approved.

## Why

CLI scouting found that headless `ask` warned that delegation prompts were impossible but still launched a real multi-agent run. That is surprising and can spend model or relay time before the user corrects the flags.

## Test plan

- `corepack pnpm exec vitest run src/test-kernel/cli/MultiAgentRunCommand.vitest.mts src/test-kernel/cli/MultiAgentInstruction.vitest.ts src/test-kernel/cli/CliRootArgs.vitest.mts`
- `corepack pnpm exec prettier --check packages/cli/src/commands/multiAgent.ts packages/cli/src/runtime/multiAgentRunPlan.ts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli build`
- `node packages/cli/dist/bin/texra.js multi-agent run physicist --instruction 'Check the algebra in a short proof.' --no-input --approval-policy ask --output-format ndjson --no-color`
- `node packages/cli/dist/bin/texra.js multi-agent run does-not-exist --instruction 'Check this derivation.' --no-color`
- `npm run lint` (existing warnings only)
- `npm run typecheck`