### PR TITLE
feat(cli): expose OpenRouter routing in config

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -940,7 +940,7 @@ const SCENARIOS = [
       'Claude Code permission',
       'Claude Code reasoning',
       'Auto-compile outputs',
-      '... 3 more',
+      '... 4 more',
       '↑/↓ navigate',
       'Enter toggle / edit',
       'Esc close',

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -4,6 +4,7 @@ import type { CliApiMode } from '@cli/runtime/apiAccessMode';
 import { applyCliGitAuthorConfig } from '@cli/runtime/gitAuthor';
 import type { GetModelSwitchDisabledReason } from '@cli/runtime/modelAccess';
 import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
+import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { AgentCategory, type ExecutionId } from '@shared/schemas';
 import {
   readSetting,
@@ -11,7 +12,11 @@ import {
   writeSetting,
   type SettingsStores,
 } from '@shared/config/settingsAccess';
-import { CLI_STATE_SETTINGS } from '@shared/schemas/stateSettings';
+import {
+  CLI_STATE_SETTINGS,
+  type StateSettingEntry,
+} from '@shared/schemas/stateSettings';
+import { GlobalStateKey } from '@shared/state/stateKeys';
 
 import { ApiModeForm } from '../forms/ApiModeForm';
 import { AgentListForm } from '../forms/AgentListForm';
@@ -39,6 +44,25 @@ type ResumeSelectHandler = (id: ExecutionId) => void | Promise<void>;
 type SkillSelectHandler = (value: SkillActivation) => void | Promise<void>;
 type ErrorHandler = (error: unknown) => void | Promise<void>;
 type SelectionCompletion = 'afterAction' | 'beforeAction';
+
+async function applyCliConfigSettingSideEffects(
+  entry: StateSettingEntry,
+  stores: SettingsStores,
+  value?: unknown,
+  onApiModeSelect?: ApiModeSelectHandler,
+): Promise<void> {
+  if (entry.category === 'git') {
+    applyCliGitAuthorConfig(stores.config);
+  }
+  if (entry.key === GlobalStateKey.USE_OPENROUTER) {
+    if (value === true) {
+      invalidateModelOptionsCache();
+      await onApiModeSelect?.('personal');
+      return;
+    }
+    invalidateModelOptionsCache();
+  }
+}
 
 /** Run a form selection handler with consistent completion and error routing. */
 function runFormSelection<T>({
@@ -406,18 +430,21 @@ export function registerBuiltinSlashCommands(options?: {
           readValue={(entry) => readSetting(entry, stores, 'cli')}
           writeValue={async (entry, value) => {
             await writeSetting(entry, value, stores, 'cli');
-            // Git-author settings are applied to process env / worktree state
-            // at startup; re-apply so a /config change takes effect this session
-            // instead of only after a restart.
-            if (entry.category === 'git') {
-              applyCliGitAuthorConfig(stores.config);
-            }
+            await applyCliConfigSettingSideEffects(
+              entry,
+              stores,
+              value,
+              onApiModeSelect,
+            );
           }}
           resetValue={async (entry) => {
             await resetSetting(entry, stores, 'cli');
-            if (entry.category === 'git') {
-              applyCliGitAuthorConfig(stores.config);
-            }
+            await applyCliConfigSettingSideEffects(
+              entry,
+              stores,
+              undefined,
+              onApiModeSelect,
+            );
           }}
           onClose={() => props.onDone(undefined)}
           onError={options?.onError}

--- a/packages/cli/src/runtime/apiAccessMode.ts
+++ b/packages/cli/src/runtime/apiAccessMode.ts
@@ -1,6 +1,7 @@
-// Local imports - auth
+import { platform } from '@platform/platform';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
+import { GlobalStateKey } from '@shared/state/stateKeys';
 
 export type CliApiMode = 'included' | 'personal';
 
@@ -49,9 +50,17 @@ export function parseCliApiMode(input: string): CliApiMode | undefined {
     : undefined;
 }
 
+export async function enableCliIncludedModelAccess(): Promise<void> {
+  await platform().globalState.update(GlobalStateKey.USE_OPENROUTER, false);
+  await getServerSideKeyService().setUseIncludedModelAccess(true);
+  invalidateModelOptionsCache();
+}
+
 export async function setCliApiMode(mode: CliApiMode): Promise<void> {
-  await getServerSideKeyService().setUseIncludedModelAccess(
-    mode === 'included',
-  );
+  if (mode === 'included') {
+    await enableCliIncludedModelAccess();
+    return;
+  }
+  await getServerSideKeyService().setUseIncludedModelAccess(false);
   invalidateModelOptionsCache();
 }

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -36,11 +36,17 @@ import { toErrorMessage } from '@common/errors';
 // Local imports - logger
 import { setOutputChannelFactory } from '@logger/logUtils';
 
+// Local imports - model
+import { invalidateModelOptionsCache } from '@model/computeModelOptions';
+
 // Local imports - shared state
 import { GlobalStateKey } from '@shared/state/stateKeys';
 
 // Local imports - tool integrations
 import { registerDirectLeanLanguageServices } from '@tools/lean/direct/directLspAdapter';
+
+// Local imports - config
+import { getUseOpenRouter } from '@utils/config/providerConfig';
 
 // Local imports - CLI runtime
 import { applyCliGitAuthorConfig } from './gitAuthor';
@@ -241,8 +247,19 @@ export async function initCliPlatform(
     serverSideKeysInitialized = true;
   }
 
+  const useOpenRouter = getUseOpenRouter();
+  if (context.apiMode === 'included' && useOpenRouter) {
+    await tryPlatform()?.globalState.update(
+      GlobalStateKey.USE_OPENROUTER,
+      false,
+    );
+    invalidateModelOptionsCache();
+  }
+
   const forcePersonalApiKeys =
-    context.skipIncludedModelAccess === true || context.apiMode === 'personal';
+    context.skipIncludedModelAccess === true ||
+    context.apiMode === 'personal' ||
+    (context.apiMode !== 'included' && useOpenRouter);
   let authed = false;
   if (!forcePersonalApiKeys) {
     try {

--- a/packages/cli/src/runtime/supabaseAuth.ts
+++ b/packages/cli/src/runtime/supabaseAuth.ts
@@ -22,6 +22,7 @@ import {
 import { getServerSideKeyService } from '@auth/serverKeys';
 
 // Local imports - CLI runtime
+import { enableCliIncludedModelAccess } from './apiAccessMode';
 import { readCliEnv } from './cliContext';
 import { getCliSecrets } from './cliSecrets';
 import { openBrowser } from './browser';
@@ -160,7 +161,7 @@ export async function signInCliSupabase(
 
     const session = await callbackServer.waitForSession();
     getServerSideKeyService().clearAllCaches({ resetQuotaFlip: true });
-    await getServerSideKeyService().setUseIncludedModelAccess(true);
+    await enableCliIncludedModelAccess();
     return session;
   } finally {
     await callbackServer.close();
@@ -206,7 +207,7 @@ export async function signInCliSupabaseDeviceCode(
   });
   await authCoordinator.storeSession(session);
   getServerSideKeyService().clearAllCaches({ resetQuotaFlip: true });
-  await getServerSideKeyService().setUseIncludedModelAccess(true);
+  await enableCliIncludedModelAccess();
   return session;
 }
 

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -168,6 +168,14 @@ export type ProviderVscodeSettingDef = z.infer<
   typeof ProviderVscodeSettingDefSchema
 >;
 
+export const USE_OPENROUTER_PROVIDER_SETTING = {
+  key: GlobalStateKey.USE_OPENROUTER,
+  label: 'Use OpenRouter for All Models',
+  description:
+    'Route all API calls through OpenRouter instead of direct provider APIs. Requires an OpenRouter API key. Note: OpenRouter bypasses Included Access — your OpenRouter key is always used directly.',
+  globalStateKey: GlobalStateKey.USE_OPENROUTER,
+} satisfies ProviderVscodeSettingDef;
+
 /** VS Code config settings to surface per provider in the Models tab. */
 export const PROVIDER_VSCODE_SETTINGS: Record<
   string,
@@ -274,13 +282,5 @@ export const PROVIDER_VSCODE_SETTINGS: Record<
       globalStateKey: GlobalStateKey.GLM_CODING_PLAN,
     },
   ],
-  openrouter: [
-    {
-      key: GlobalStateKey.USE_OPENROUTER,
-      label: 'Use OpenRouter for All Models',
-      description:
-        'Route all API calls through OpenRouter instead of direct provider APIs. Requires an OpenRouter API key. Note: OpenRouter bypasses Included Access — your OpenRouter key is always used directly.',
-      globalStateKey: GlobalStateKey.USE_OPENROUTER,
-    },
-  ],
+  openrouter: [USE_OPENROUTER_PROVIDER_SETTING],
 };

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -14,6 +14,7 @@ import {
   LATEX_FORMATTER_VALUES,
   LATEXDIFF_MATH_MARKUP_VALUES,
 } from '@shared/constants/latex';
+import { USE_OPENROUTER_PROVIDER_SETTING } from '@shared/constants/providers';
 import {
   CLAUDE_AGENT_DEFAULT_EFFORT,
   CLAUDE_AGENT_DEFAULT_MODEL,
@@ -156,6 +157,12 @@ const OPENAI_WEBSOCKET_RUNTIME_REACHABILITY = {
     'texra run <workflow-agent> --model <openai-model> --input paper.tex --instruction "summarize the paper"',
   through:
     'packages/cli/src/commands/workflow.ts -> src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts',
+} satisfies CliRuntimeReachability;
+const OPENROUTER_ROUTING_RUNTIME_REACHABILITY = {
+  command:
+    'texra agents run <tool-use-agent> --model <openrouter-routable-model> --instruction "answer a short question"',
+  through:
+    'packages/cli/src/commands/agentsRun.ts -> packages/cli/src/runtime/runExecution.ts -> src/agent/runtime/ModelFactory.ts -> src/utils/config/providerConfig.ts',
 } satisfies CliRuntimeReachability;
 const CODEX_AGENT_RUNTIME_REACHABILITY = {
   command:
@@ -463,6 +470,23 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     hosts: ['cli'],
     cliConsumer: 'src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts',
     cliRuntimeReachability: OPENAI_WEBSOCKET_RUNTIME_REACHABILITY,
+  },
+
+  // --- OpenRouter routing ----------------------------------------------------
+  // Read by `getUseOpenRouter()` during model-handler routing. The extension
+  // and desktop already surface the same setting through provider settings; the
+  // catalog row is CLI-only so later settings-view catalog rendering does not
+  // duplicate that existing control.
+  {
+    key: GlobalStateKey.USE_OPENROUTER,
+    schema: z.boolean().prefault(false),
+    title: USE_OPENROUTER_PROVIDER_SETTING.label,
+    description: USE_OPENROUTER_PROVIDER_SETTING.description,
+    category: 'model',
+    store: 'globalState',
+    hosts: ['cli'],
+    cliConsumer: 'src/utils/config/providerConfig.ts',
+    cliRuntimeReachability: OPENROUTER_ROUTING_RUNTIME_REACHABILITY,
   },
 ] as const;
 

--- a/src/test-kernel/cli/ApiAccessModeSettings.vitest.mts
+++ b/src/test-kernel/cli/ApiAccessModeSettings.vitest.mts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  enableCliIncludedModelAccess,
+  setCliApiMode,
+} from '@cli/runtime/apiAccessMode';
+import { GlobalStateKey } from '@shared/state/stateKeys';
+
+const mocks = vi.hoisted(() => ({
+  invalidateModelOptionsCache: vi.fn(),
+  setUseIncludedModelAccess: vi.fn(),
+  updateGlobalState: vi.fn(),
+}));
+
+vi.mock('@auth/serverKeys', () => ({
+  getServerSideKeyService: () => ({
+    setUseIncludedModelAccess: mocks.setUseIncludedModelAccess,
+  }),
+}));
+
+vi.mock('@model/computeModelOptions', () => ({
+  invalidateModelOptionsCache: mocks.invalidateModelOptionsCache,
+}));
+
+vi.mock('@platform/platform', () => ({
+  platform: () => ({
+    globalState: {
+      update: mocks.updateGlobalState,
+    },
+  }),
+}));
+
+function expectOpenRouterClearedBeforeIncludedAccess(): void {
+  const [clearOrder] = mocks.updateGlobalState.mock.invocationCallOrder;
+  const [enableOrder] =
+    mocks.setUseIncludedModelAccess.mock.invocationCallOrder;
+  if (clearOrder == null || enableOrder == null) {
+    throw new Error('missing API-mode side-effect call order');
+  }
+  expect(clearOrder).toBeLessThan(enableOrder);
+}
+
+describe('CLI API access mode settings', () => {
+  beforeEach(() => {
+    mocks.invalidateModelOptionsCache.mockClear();
+    mocks.setUseIncludedModelAccess.mockReset();
+    mocks.updateGlobalState.mockReset();
+  });
+
+  it('enables included access while clearing OpenRouter routing', async () => {
+    await enableCliIncludedModelAccess();
+
+    expect(mocks.setUseIncludedModelAccess).toHaveBeenCalledWith(true);
+    expect(mocks.updateGlobalState).toHaveBeenCalledWith(
+      GlobalStateKey.USE_OPENROUTER,
+      false,
+    );
+    expectOpenRouterClearedBeforeIncludedAccess();
+    expect(mocks.invalidateModelOptionsCache).toHaveBeenCalledTimes(1);
+  });
+
+  it('turns off OpenRouter routing when switching to included access', async () => {
+    await setCliApiMode('included');
+
+    expect(mocks.setUseIncludedModelAccess).toHaveBeenCalledWith(true);
+    expect(mocks.updateGlobalState).toHaveBeenCalledWith(
+      GlobalStateKey.USE_OPENROUTER,
+      false,
+    );
+    expectOpenRouterClearedBeforeIncludedAccess();
+    expect(mocks.invalidateModelOptionsCache).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves OpenRouter routing unchanged when switching to personal keys', async () => {
+    await setCliApiMode('personal');
+
+    expect(mocks.setUseIncludedModelAccess).toHaveBeenCalledWith(false);
+    expect(mocks.updateGlobalState).not.toHaveBeenCalled();
+    expect(mocks.invalidateModelOptionsCache).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/test-kernel/cli/CliInitPlatform.vitest.mts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.mts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   defaultSkillSources: vi.fn<() => SkillSource[]>(() => []),
   setRuntimeSkillSources: vi.fn(),
   getCliSecrets: vi.fn(() => ({ kind: 'cli-secrets' })),
+  invalidateModelOptionsCache: vi.fn(),
   tryPlatform: vi.fn(),
   // Collects callbacks registered via the (mocked) lifecycle host's onShutdown
   // so a test can run them and assert the usage-log dispose was wired.
@@ -43,9 +44,14 @@ vi.mock('@logger/logUtils', () => ({
   setOutputChannelFactory: vi.fn(),
 }));
 
+vi.mock('@model/computeModelOptions', () => ({
+  invalidateModelOptionsCache: mocks.invalidateModelOptionsCache,
+}));
+
 vi.mock('@platform/platform', () => ({
   initPlatform: vi.fn(),
   tryPlatform: mocks.tryPlatform,
+  tryGlobalState: () => mocks.tryPlatform()?.globalState,
 }));
 
 vi.mock('@skills/index', () => ({
@@ -121,7 +127,7 @@ describe('CLI platform init', () => {
     mocks.tryPlatform.mockReset();
     mocks.tryPlatform.mockReturnValue({
       globalState: {
-        get: vi.fn(),
+        get: vi.fn((_key: string, defaultValue: unknown) => defaultValue),
         update: vi.fn(),
       },
     });
@@ -152,7 +158,7 @@ describe('CLI platform init', () => {
   it('wires usage logging on first platform init', async () => {
     // tryPlatform() === undefined drives the once-per-process first-init block.
     const globalState = {
-      get: vi.fn(),
+      get: vi.fn((_key: string, defaultValue: unknown) => defaultValue),
       update: vi.fn(),
     };
     mocks.tryPlatform.mockReturnValue({ globalState });
@@ -177,7 +183,11 @@ describe('CLI platform init', () => {
 
   it('bootstraps bundled agents with the CLI version store', async () => {
     const globalState = {
-      get: vi.fn().mockReturnValue('1.2.2'),
+      get: vi.fn((key: string, defaultValue: unknown) =>
+        key === GlobalStateKey.CLI_BUNDLED_AGENTS_LAST_KNOWN_VERSION
+          ? '1.2.2'
+          : defaultValue,
+      ),
       update: vi.fn().mockResolvedValue(undefined),
     };
     mocks.tryPlatform.mockReturnValue({ globalState });
@@ -246,6 +256,47 @@ describe('CLI platform init', () => {
     expect(
       mocks.serverSideKeyService.setUseIncludedModelAccess,
     ).toHaveBeenCalledWith(false);
+  });
+
+  it('keeps included access off when OpenRouter routing is enabled', async () => {
+    const globalState = {
+      get: vi.fn((key: string, defaultValue: unknown) =>
+        key === GlobalStateKey.USE_OPENROUTER ? true : defaultValue,
+      ),
+      update: vi.fn(),
+    };
+    mocks.tryPlatform.mockReturnValue({ globalState });
+    mocks.authProvider.isAuthenticated.mockResolvedValueOnce(true);
+
+    await initCliPlatform(cliContext());
+
+    expect(mocks.authProvider.isAuthenticated).not.toHaveBeenCalled();
+    expect(
+      mocks.serverSideKeyService.setUseIncludedModelAccess,
+    ).toHaveBeenCalledWith(false);
+  });
+
+  it('clears OpenRouter when startup explicitly selects included access', async () => {
+    const globalState = {
+      get: vi.fn((key: string, defaultValue: unknown) =>
+        key === GlobalStateKey.USE_OPENROUTER ? true : defaultValue,
+      ),
+      update: vi.fn().mockResolvedValue(undefined),
+    };
+    mocks.tryPlatform.mockReturnValue({ globalState });
+    mocks.authProvider.isAuthenticated.mockResolvedValueOnce(true);
+
+    await initCliPlatform(cliContext({ apiMode: 'included' }));
+
+    expect(globalState.update).toHaveBeenCalledWith(
+      GlobalStateKey.USE_OPENROUTER,
+      false,
+    );
+    expect(mocks.invalidateModelOptionsCache).toHaveBeenCalledOnce();
+    expect(mocks.authProvider.isAuthenticated).toHaveBeenCalledOnce();
+    expect(
+      mocks.serverSideKeyService.setUseIncludedModelAccess,
+    ).toHaveBeenCalledWith(true);
   });
 
   it('registers CLI runtime skill sources from context options', async () => {

--- a/src/test-kernel/cli/CliSupabaseAuth.vitest.mts
+++ b/src/test-kernel/cli/CliSupabaseAuth.vitest.mts
@@ -1,12 +1,30 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mocks = vi.hoisted(() => ({
-  createHostAuthCoordinator: vi.fn((init: { secrets: unknown }) => ({
-    secrets: init.secrets,
-  })),
-  getCliSecrets: vi.fn(),
-  tryPlatform: vi.fn(),
-}));
+import { GlobalStateKey } from '@shared/state/stateKeys';
+
+const mocks = vi.hoisted(() => {
+  const authCoordinator = {
+    clearSession: vi.fn(),
+    storeSession: vi.fn(),
+  };
+  return {
+    authCoordinator,
+    createHostAuthCoordinator: vi.fn((init: { secrets: unknown }) => ({
+      ...authCoordinator,
+      secrets: init.secrets,
+    })),
+    clearServerKeyCaches: vi.fn(),
+    getCliSecrets: vi.fn(),
+    pollForDeviceSession: vi.fn(),
+    requestDeviceAuthorization: vi.fn(),
+    setUseIncludedModelAccess: vi.fn(),
+    signInWithOAuth: vi.fn(),
+    startLoopbackCallbackServer: vi.fn(),
+    toStorableSupabaseSession: vi.fn((session) => session),
+    tryPlatform: vi.fn(),
+    updateGlobalState: vi.fn(),
+  };
+});
 
 vi.mock('@auth/config', () => ({
   DEFAULT_OAUTH_PROVIDER: 'github',
@@ -19,6 +37,11 @@ vi.mock('@auth/SupabaseAuthCoordinator', () => ({
 
 vi.mock('@auth/SupabaseClient', () => ({
   SupabaseClient: {
+    getClient: () => ({
+      auth: {
+        signInWithOAuth: mocks.signInWithOAuth,
+      },
+    }),
     getRelayAccessToken: vi.fn(),
     getUserTier: vi.fn(),
     isAuthenticated: vi.fn(),
@@ -26,7 +49,7 @@ vi.mock('@auth/SupabaseClient', () => ({
 }));
 
 vi.mock('@auth/SupabaseSession', () => ({
-  toStorableSupabaseSession: vi.fn((session) => session),
+  toStorableSupabaseSession: mocks.toStorableSupabaseSession,
 }));
 
 vi.mock('@auth/relayToken', () => ({
@@ -37,12 +60,17 @@ vi.mock('@auth/relayToken', () => ({
 
 vi.mock('@auth/serverKeys', () => ({
   getServerSideKeyService: () => ({
-    clearAllCaches: vi.fn(),
-    setUseIncludedModelAccess: vi.fn(),
+    clearAllCaches: mocks.clearServerKeyCaches,
+    setUseIncludedModelAccess: mocks.setUseIncludedModelAccess,
   }),
 }));
 
 vi.mock('@platform/platform', () => ({
+  platform: () => ({
+    globalState: {
+      update: mocks.updateGlobalState,
+    },
+  }),
   tryPlatform: mocks.tryPlatform,
 }));
 
@@ -59,12 +87,12 @@ vi.mock('@cli/runtime/browser', () => ({
 }));
 
 vi.mock('@cli/runtime/supabaseAuthCallbackServer', () => ({
-  startLoopbackCallbackServer: vi.fn(),
+  startLoopbackCallbackServer: mocks.startLoopbackCallbackServer,
 }));
 
 vi.mock('@cli/runtime/supabaseAuthDeviceCode', () => ({
-  pollForDeviceSession: vi.fn(),
-  requestDeviceAuthorization: vi.fn(),
+  pollForDeviceSession: mocks.pollForDeviceSession,
+  requestDeviceAuthorization: mocks.requestDeviceAuthorization,
 }));
 
 async function loadSupabaseAuth() {
@@ -77,6 +105,8 @@ describe('CLI Supabase auth', () => {
     vi.clearAllMocks();
     mocks.tryPlatform.mockReturnValue(null);
     mocks.getCliSecrets.mockReturnValue({ kind: 'cli-secrets' });
+    mocks.setUseIncludedModelAccess.mockResolvedValue(undefined);
+    mocks.updateGlobalState.mockResolvedValue(undefined);
   });
 
   it('uses platform-owned secrets after CLI platform init', async () => {
@@ -106,6 +136,50 @@ describe('CLI Supabase auth', () => {
     expect(mocks.getCliSecrets).toHaveBeenCalledWith('/tmp/sandbox-storage');
     expect(mocks.createHostAuthCoordinator).toHaveBeenCalledWith(
       expect.objectContaining({ secrets: cliSecrets }),
+    );
+  });
+
+  it('clears OpenRouter routing after browser sign-in enables included access', async () => {
+    const session = { access_token: 'token' };
+    const callbackServer = {
+      close: vi.fn().mockResolvedValue(undefined),
+      redirectTo: 'http://127.0.0.1:0/callback',
+      waitForSession: vi.fn().mockResolvedValue(session),
+    };
+    mocks.startLoopbackCallbackServer.mockResolvedValue(callbackServer);
+    mocks.signInWithOAuth.mockResolvedValue({
+      data: { url: 'https://auth.example/login' },
+      error: null,
+    });
+    const { signInCliSupabase } = await loadSupabaseAuth();
+
+    await expect(signInCliSupabase({ openBrowser: false })).resolves.toBe(
+      session,
+    );
+
+    expect(mocks.updateGlobalState).toHaveBeenCalledWith(
+      GlobalStateKey.USE_OPENROUTER,
+      false,
+    );
+  });
+
+  it('clears OpenRouter routing after device-code sign-in enables included access', async () => {
+    const session = { access_token: 'device-token' };
+    mocks.requestDeviceAuthorization.mockResolvedValue({
+      device_code: 'device-code',
+      expires_in: 600,
+      interval: 5,
+      user_code: 'ABCD-EFGH',
+      verification_uri: 'https://auth.example/device',
+    });
+    mocks.pollForDeviceSession.mockResolvedValue(session);
+    const { signInCliSupabaseDeviceCode } = await loadSupabaseAuth();
+
+    await expect(signInCliSupabaseDeviceCode()).resolves.toBe(session);
+
+    expect(mocks.updateGlobalState).toHaveBeenCalledWith(
+      GlobalStateKey.USE_OPENROUTER,
+      false,
     );
   });
 });

--- a/src/test-kernel/cli/ConfigForm.vitest.mts
+++ b/src/test-kernel/cli/ConfigForm.vitest.mts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 
 import {
@@ -30,8 +30,18 @@ import {
   type StateSettingEntry,
 } from '@shared/schemas/stateSettings';
 import { DEFAULT_GIT_AUTHOR_NAME } from '@shared/constants/git';
-import { WorkspaceStateKey } from '@shared/state/stateKeys';
+import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 import { getGitAuthorEnv } from '@utils/system/gitAuthorEnv';
+
+const invalidateModelOptionsCache = vi.hoisted(() => vi.fn());
+
+vi.mock('@model/computeModelOptions', () => ({
+  invalidateModelOptionsCache,
+}));
+
+beforeEach(() => {
+  invalidateModelOptionsCache.mockClear();
+});
 
 afterEach(() => {
   for (const cmd of [...listSlashCommands()]) unregisterSlashCommand(cmd.name);
@@ -305,5 +315,55 @@ describe('/config slash command wiring', () => {
     // The key is deleted, so reads fall back to the default identity.
     expect(isStored(config, WorkspaceStateKey.GIT_AUTHOR_NAME)).toBe(false);
     expect(props.readValue?.(authorName)).toBe(DEFAULT_GIT_AUTHOR_NAME);
+  });
+
+  it('switches to personal API mode when OpenRouter routing is enabled', async () => {
+    resetCliState({
+      agent: 'chat',
+      model: 'deepseekT',
+      modelSource: 'builtin',
+      cwd: '/tmp/workspace',
+      apiMode: 'included',
+      approvalPolicy: 'ask',
+      canDelegate: false,
+      version: 'test',
+    });
+    const { stores } = makeFakeSettingsStores();
+    const selectedApiModes: string[] = [];
+    registerBuiltinSlashCommands({
+      getConfigStores: () => stores,
+      onApiModeSelect: (apiMode) => {
+        selectedApiModes.push(apiMode);
+        cliState.sessionMeta.set({
+          ...cliState.sessionMeta.get(),
+          apiMode,
+        });
+      },
+    });
+    openCliSlashCommandForm('config', '');
+
+    const props = renderConfigFormProps();
+    const openRouter = entryByKey(GlobalStateKey.USE_OPENROUTER);
+
+    await props.writeValue?.(openRouter, true);
+
+    expect(selectedApiModes).toEqual(['personal']);
+    expect(cliState.sessionMeta.get().apiMode).toBe('personal');
+    expect(invalidateModelOptionsCache).toHaveBeenCalledOnce();
+  });
+
+  it('invalidates model options when OpenRouter routing is disabled or reset', async () => {
+    const { stores } = makeFakeSettingsStores();
+    registerBuiltinSlashCommands({ getConfigStores: () => stores });
+    openCliSlashCommandForm('config', '');
+
+    const props = renderConfigFormProps();
+    const openRouter = entryByKey(GlobalStateKey.USE_OPENROUTER);
+
+    await props.writeValue?.(openRouter, false);
+    expect(invalidateModelOptionsCache).toHaveBeenCalledTimes(1);
+
+    await props.resetValue?.(openRouter);
+    expect(invalidateModelOptionsCache).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/test-kernel/shared/stateSettings.vitest.ts
+++ b/src/test-kernel/shared/stateSettings.vitest.ts
@@ -101,6 +101,7 @@ const EXPECTED_DEFAULTS: Record<string, unknown> = {
     LATEX_CONFIG_DEFAULTS.latexdiffChangesOnly,
   [WorkspaceStateKey.LATEX_FORMATTER]: LATEX_CONFIG_DEFAULTS.latexFormatter,
   [GlobalStateKey.WEBSOCKET_OPENAI]: false,
+  [GlobalStateKey.USE_OPENROUTER]: false,
 };
 
 describe('state settings catalog', () => {
@@ -370,6 +371,7 @@ describe('state settings catalog', () => {
         WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS,
         WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE,
         GlobalStateKey.WEBSOCKET_OPENAI,
+        GlobalStateKey.USE_OPENROUTER,
       ].sort(),
     );
   });


### PR DESCRIPTION
## What

Refs #6606.

Adds `texra.useOpenRouter` to the shared state-backed settings catalog so CLI `/config` can toggle the same OpenRouter routing bit that CLI model creation already reads through `getUseOpenRouter()`.

The OpenRouter provider-setting metadata is now named once as `USE_OPENROUTER_PROVIDER_SETTING`, and the catalog reuses that label and description instead of restating them. The catalog row is CLI-only because the extension and desktop already surface this control through provider settings.

The CLI now also performs the state coordination required by exposing this toggle:

- `/config` writes and resets of `texra.useOpenRouter` invalidate cached model options immediately.
- Enabling `texra.useOpenRouter` from `/config` delegates to the same API-mode selection path as `/api personal`, so the persisted API mode, current session mode, and root model selection are reconciled together.
- Included-access selection clears `GlobalStateKey.USE_OPENROUTER` before enabling included relay and invalidating model options.
- TeXRA browser/device sign-in paths reuse the same included-access helper, so login cannot leave OpenRouter routing enabled while the UI reports included relay access.
- CLI startup treats an existing OpenRouter routing flag as a personal-key condition, so a signed-in user is not silently flipped back to included relay after restart.
- If startup is explicitly asked for included relay, it clears the persisted OpenRouter flag first and then uses the normal included-access auth probe.

## Why

#6606 asks for the remaining state-backed settings domains to be promoted incrementally, with each CLI-hosted setting backed by a verified runtime consumer. OpenRouter routing is a small model-routing increment: it is already consumed by the CLI runtime, but before this change it was not visible in the catalog-driven `/config` panel.

The review fixes are part of the same invariant: once the CLI can change this routing flag, model availability and included-relay mode must observe that change without waiting for the cache TTL, losing the compatible API mode, or leaving OpenRouter routing enabled under included relay.

## Test plan

- `corepack pnpm exec vitest run src/test-kernel/cli/ApiAccessMode.vitest.mts src/test-kernel/cli/ApiAccessModeSettings.vitest.mts src/test-kernel/cli/ConfigForm.vitest.mts src/test-kernel/cli/CliInitPlatform.vitest.mts src/test-kernel/cli/CliSupabaseAuth.vitest.mts src/test-kernel/shared/stateSettings.vitest.ts`
- `node --max-old-space-size=4096 ./node_modules/eslint/bin/eslint.js packages/cli/src/chat/tui/commands/registerBuiltins.tsx packages/cli/src/runtime/initPlatform.ts packages/cli/src/runtime/apiAccessMode.ts packages/cli/src/runtime/supabaseAuth.ts src/test-kernel/cli/ConfigForm.vitest.mts src/test-kernel/cli/CliInitPlatform.vitest.mts src/test-kernel/cli/ApiAccessModeSettings.vitest.mts src/test-kernel/cli/CliSupabaseAuth.vitest.mts`
- `git diff --check`
- `npm run typecheck`
- `corepack pnpm --filter @texra-ai/cli build`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --no-build --snapshot-dir /tmp/texra-config-catalog-openrouter config-form`
- `npm run lint` (passes with existing warnings only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes model routing and included-relay vs personal-key selection at startup, login, and `/config`; mistakes could mis-route API calls or show the wrong access mode.
> 
> **Overview**
> Adds **`texra.useOpenRouter`** to the CLI state settings catalog (reusing shared `USE_OPENROUTER_PROVIDER_SETTING` metadata) so **`/config`** can toggle the same routing flag the runtime already reads via `getUseOpenRouter()`.
> 
> **`/config` side effects:** toggling OpenRouter invalidates the model-options cache; turning it **on** also routes through the same path as **`/api personal`** so session API mode stays consistent. Git-author side effects are centralized in `applyCliConfigSettingSideEffects`.
> 
> **Included relay vs OpenRouter:** `enableCliIncludedModelAccess()` now clears `USE_OPENROUTER` before enabling included access and invalidates model options. Login (browser and device-code) uses that helper instead of only flipping server-side keys. **Startup** treats an existing OpenRouter flag as personal-key mode (skips flipping a signed-in user back to included relay); explicit **`apiMode: 'included'`** clears OpenRouter first, then runs the normal included-access probe.
> 
> Tests and the TUI **`config-form`** snapshot expect one additional catalog row (`... 4 more`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bce97f8af3ee1b65fcf3bdaf455806995c897c49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->