### PR TITLE
refactor: extract settleQuickInput utility and use getExtensionLowercase consistently

### DIFF
--- a/packages/extension/src/commands/_shared/quickInputUtils.ts
+++ b/packages/extension/src/commands/_shared/quickInputUtils.ts
@@ -3,17 +3,13 @@ import * as vscode from 'vscode';
 /**
  * Wraps a vscode QuickInput with an idempotent settle/accept callback.
  *
- * The `setup` function is called to attach `onDidAccept` and any other
- * event handlers; the caller does NOT need to register `onDidHide` or call
- * `show()` — this helper handles both. The returned promise resolves with
- * `undefined` when the input is dismissed without a selection.
+ * Use this as an escape hatch for inputs that need custom event handlers
+ * (e.g. canSelectMany + button toggles). For standard single-item pickers
+ * prefer the higher-level `showQuickPick`.
  *
- * Usage:
- *   const qp = vscode.window.createQuickPick<MyItem>();
- *   qp.title = '…'; qp.items = items;
- *   const pick = await settleQuickInput(qp, (accept) => {
- *     qp.onDidAccept(() => accept(qp.activeItems[0]));
- *   });
+ * The `setup` function is called to attach `onDidAccept` and any other event
+ * handlers; the caller does NOT need to register `onDidHide` or call `show()`
+ * — this helper handles both. Resolves with `undefined` when dismissed.
  */
 export async function settleQuickInput<T>(
   input: vscode.QuickInput,
@@ -30,5 +26,37 @@ export async function settleQuickInput<T>(
     setup(accept);
     input.onDidHide(() => accept(undefined));
     input.show();
+  });
+}
+
+/**
+ * Show a single-select QuickPick described by a plain config object.
+ *
+ * Handles picker creation, default active item, the VS Code 1.108+ `prompt`
+ * property (silently ignored on older hosts), and wiring up accept/dismiss.
+ * Resolves with the chosen item, or `undefined` when dismissed.
+ */
+export async function showQuickPick<T extends vscode.QuickPickItem>(opts: {
+  items: readonly T[];
+  title?: string;
+  placeholder?: string;
+  /** Persistent hint below the input box (VS Code 1.108+; ignored on older hosts). */
+  prompt?: string;
+  ignoreFocusOut?: boolean;
+}): Promise<T | undefined> {
+  const qp = vscode.window.createQuickPick<T>();
+  if (opts.title !== undefined) qp.title = opts.title;
+  if (opts.placeholder !== undefined) qp.placeholder = opts.placeholder;
+  if (opts.ignoreFocusOut !== undefined) qp.ignoreFocusOut = opts.ignoreFocusOut;
+  qp.items = opts.items;
+  const defaultItem = opts.items[0];
+  if (defaultItem) qp.activeItems = [defaultItem];
+  if (opts.prompt !== undefined && 'prompt' in qp) {
+    (qp as vscode.QuickPick<T> & { prompt: string }).prompt = opts.prompt;
+  }
+  return settleQuickInput(qp, (accept) => {
+    qp.onDidAccept(() => {
+      accept(qp.activeItems[0] ?? qp.selectedItems[0]);
+    });
   });
 }

--- a/packages/extension/src/commands/_shared/quickInputUtils.ts
+++ b/packages/extension/src/commands/_shared/quickInputUtils.ts
@@ -47,7 +47,8 @@ export async function showQuickPick<T extends vscode.QuickPickItem>(opts: {
   const qp = vscode.window.createQuickPick<T>();
   if (opts.title !== undefined) qp.title = opts.title;
   if (opts.placeholder !== undefined) qp.placeholder = opts.placeholder;
-  if (opts.ignoreFocusOut !== undefined) qp.ignoreFocusOut = opts.ignoreFocusOut;
+  if (opts.ignoreFocusOut !== undefined)
+    qp.ignoreFocusOut = opts.ignoreFocusOut;
   qp.items = opts.items;
   const defaultItem = opts.items[0];
   if (defaultItem) qp.activeItems = [defaultItem];

--- a/packages/extension/src/commands/_shared/quickInputUtils.ts
+++ b/packages/extension/src/commands/_shared/quickInputUtils.ts
@@ -1,0 +1,34 @@
+import * as vscode from 'vscode';
+
+/**
+ * Wraps a vscode QuickInput with an idempotent settle/accept callback.
+ *
+ * The `setup` function is called to attach `onDidAccept` and any other
+ * event handlers; the caller does NOT need to register `onDidHide` or call
+ * `show()` — this helper handles both. The returned promise resolves with
+ * `undefined` when the input is dismissed without a selection.
+ *
+ * Usage:
+ *   const qp = vscode.window.createQuickPick<MyItem>();
+ *   qp.title = '…'; qp.items = items;
+ *   const pick = await settleQuickInput(qp, (accept) => {
+ *     qp.onDidAccept(() => accept(qp.activeItems[0]));
+ *   });
+ */
+export async function settleQuickInput<T>(
+  input: vscode.QuickInput,
+  setup: (accept: (value: T | undefined) => void) => void,
+): Promise<T | undefined> {
+  return new Promise<T | undefined>((resolve) => {
+    let settled = false;
+    const accept = (value: T | undefined): void => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+      input.dispose();
+    };
+    setup(accept);
+    input.onDidHide(() => accept(undefined));
+    input.show();
+  });
+}

--- a/packages/extension/src/commands/agent/agentCreatorCommands.ts
+++ b/packages/extension/src/commands/agent/agentCreatorCommands.ts
@@ -83,15 +83,12 @@ async function pickToolGroups(
   const initiallySelected = items.filter((item) => item.picked);
   qp.selectedItems = initiallySelected;
   if ('prompt' in qp) {
-    (
-      qp as vscode.QuickPick<vscode.QuickPickItem> & { prompt: string }
-    ).prompt =
+    (qp as vscode.QuickPick<vscode.QuickPickItem> & { prompt: string }).prompt =
       'Space / click to toggle. Pre-selected groups match your description.';
   }
 
   let allSelected =
-    initiallySelected.length > 0 &&
-    initiallySelected.length === items.length;
+    initiallySelected.length > 0 && initiallySelected.length === items.length;
   const selectAllButton: vscode.QuickInputButton = {
     iconPath: new vscode.ThemeIcon('check-all'),
     tooltip: 'Select all / clear',
@@ -109,8 +106,7 @@ async function pickToolGroups(
   };
   refreshSelectAllButton();
   qp.onDidChangeSelection((selected) => {
-    allSelected =
-      selected.length > 0 && selected.length === qp.items.length;
+    allSelected = selected.length > 0 && selected.length === qp.items.length;
     refreshSelectAllButton();
   });
   qp.onDidTriggerButton((button) => {

--- a/packages/extension/src/commands/agent/agentCreatorCommands.ts
+++ b/packages/extension/src/commands/agent/agentCreatorCommands.ts
@@ -11,6 +11,7 @@ import {
   createAgentCreatorFlow,
 } from '@agent/implementations/flows/agentCreator/agentCreatorFlow';
 import { renderAgentTemplateString } from '@agent/templates/agentTemplateRenderer';
+import { settleQuickInput } from '@commands/_shared/quickInputUtils';
 import { agentDirectories, promptToAddAgentToConfig } from '@frontend/agents';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
@@ -74,73 +75,58 @@ async function pickToolGroups(
   agentName: string,
   items: vscode.QuickPickItem[],
 ): Promise<readonly vscode.QuickPickItem[] | undefined> {
-  return await new Promise<readonly vscode.QuickPickItem[] | undefined>(
-    (resolve) => {
-      const qp = vscode.window.createQuickPick();
-      let settled = false;
-      const finish = (
-        value: readonly vscode.QuickPickItem[] | undefined,
-      ): void => {
-        if (settled) return;
-        settled = true;
-        resolve(value);
-        qp.dispose();
-      };
-      qp.title = `Tool Use Agent: ${agentName}`;
-      qp.placeholder = 'Select tool groups';
-      qp.canSelectMany = true;
-      qp.items = items;
-      const initiallySelected = items.filter((item) => item.picked);
-      qp.selectedItems = initiallySelected;
-      if ('prompt' in qp) {
-        (
-          qp as vscode.QuickPick<vscode.QuickPickItem> & { prompt: string }
-        ).prompt =
-          'Space / click to toggle. Pre-selected groups match your description.';
-      }
+  const qp = vscode.window.createQuickPick();
+  qp.title = `Tool Use Agent: ${agentName}`;
+  qp.placeholder = 'Select tool groups';
+  qp.canSelectMany = true;
+  qp.items = items;
+  const initiallySelected = items.filter((item) => item.picked);
+  qp.selectedItems = initiallySelected;
+  if ('prompt' in qp) {
+    (
+      qp as vscode.QuickPick<vscode.QuickPickItem> & { prompt: string }
+    ).prompt =
+      'Space / click to toggle. Pre-selected groups match your description.';
+  }
 
-      let allSelected =
-        initiallySelected.length > 0 &&
-        initiallySelected.length === items.length;
-      const selectAllButton: vscode.QuickInputButton = {
-        iconPath: new vscode.ThemeIcon('check-all'),
-        tooltip: 'Select all / clear',
+  let allSelected =
+    initiallySelected.length > 0 &&
+    initiallySelected.length === items.length;
+  const selectAllButton: vscode.QuickInputButton = {
+    iconPath: new vscode.ThemeIcon('check-all'),
+    tooltip: 'Select all / clear',
+  };
+  let activeSelectAllButton: vscode.QuickInputButton | undefined;
+  const refreshSelectAllButton = () => {
+    if ('buttons' in qp) {
+      const toggleButton: QuickInputToggleButton = {
+        ...selectAllButton,
+        toggle: { checked: allSelected },
       };
-      let activeSelectAllButton: vscode.QuickInputButton | undefined;
-      const refreshSelectAllButton = () => {
-        if ('buttons' in qp) {
-          const toggleButton: QuickInputToggleButton = {
-            ...selectAllButton,
-            toggle: { checked: allSelected },
-          };
-          activeSelectAllButton = toggleButton;
-          qp.buttons = [toggleButton];
-        }
-      };
-      refreshSelectAllButton();
-      qp.onDidChangeSelection((selected) => {
-        allSelected =
-          selected.length > 0 && selected.length === qp.items.length;
-        refreshSelectAllButton();
-      });
-      qp.onDidTriggerButton((button) => {
-        if (button !== activeSelectAllButton) {
-          return;
-        }
-        allSelected = qp.items.length > 0 && !allSelected;
-        qp.selectedItems = allSelected ? [...qp.items] : [];
-        refreshSelectAllButton();
-      });
+      activeSelectAllButton = toggleButton;
+      qp.buttons = [toggleButton];
+    }
+  };
+  refreshSelectAllButton();
+  qp.onDidChangeSelection((selected) => {
+    allSelected =
+      selected.length > 0 && selected.length === qp.items.length;
+    refreshSelectAllButton();
+  });
+  qp.onDidTriggerButton((button) => {
+    if (button !== activeSelectAllButton) {
+      return;
+    }
+    allSelected = qp.items.length > 0 && !allSelected;
+    qp.selectedItems = allSelected ? [...qp.items] : [];
+    refreshSelectAllButton();
+  });
 
-      qp.onDidAccept(() => {
-        finish(qp.selectedItems);
-      });
-      qp.onDidHide(() => {
-        finish(undefined);
-      });
-      qp.show();
-    },
-  );
+  return settleQuickInput<readonly vscode.QuickPickItem[]>(qp, (accept) => {
+    qp.onDidAccept(() => {
+      accept(qp.selectedItems);
+    });
+  });
 }
 
 function buildVSCodeUI(): AgentCreatorUI {

--- a/packages/extension/src/commands/api/apiKeyCommands.ts
+++ b/packages/extension/src/commands/api/apiKeyCommands.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports
-import { settleQuickInput } from '@commands/_shared/quickInputUtils';
+import { settleQuickInput, showQuickPick } from '@commands/_shared/quickInputUtils';
 import { SecretManager, ApiProvider } from '@frontend/secretManager';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { getMainWebview } from '@frontend/system/commandUtils';
@@ -127,11 +127,11 @@ export async function setApiKey(provider?: ApiProvider): Promise<void> {
   }
 
   const providerItems = await SecretManager.getApiProviderQuickPickItems();
-  const providerPick = await pickProvider(
-    providerItems,
-    'Select API provider',
-    "Keys are stored in VS Code's encrypted secret store, never on disk.",
-  );
+  const providerPick = await showQuickPick<ProviderQuickPickItem>({
+    placeholder: 'Select API provider',
+    prompt: "Keys are stored in VS Code's encrypted secret store, never on disk.",
+    items: providerItems,
+  });
 
   if (providerPick?.provider) {
     await setApiKeyForProvider(providerPick.provider, true);
@@ -142,42 +142,17 @@ type ProviderQuickPickItem = Awaited<
   ReturnType<typeof SecretManager.getApiProviderQuickPickItems>
 >[number];
 
-/** Shared provider picker with a persistent prompt hint (VS Code 1.108+). */
-async function pickProvider(
-  items: ProviderQuickPickItem[],
-  placeholder: string,
-  promptHint: string,
-): Promise<ProviderQuickPickItem | undefined> {
-  const qp = vscode.window.createQuickPick<ProviderQuickPickItem>();
-  qp.placeholder = placeholder;
-  qp.items = items;
-  const defaultItem = items[0];
-  if (defaultItem) {
-    qp.activeItems = [defaultItem];
-  }
-  if ('prompt' in qp) {
-    (
-      qp as vscode.QuickPick<ProviderQuickPickItem> & { prompt: string }
-    ).prompt = promptHint;
-  }
-  return settleQuickInput(qp, (accept) => {
-    qp.onDidAccept(() => {
-      accept(qp.activeItems[0] ?? qp.selectedItems[0]);
-    });
-  });
-}
-
 /**
  * Remove an API key after a confirmation prompt. Migrated to the shared
  * command registry in #3781 batch 4.
  */
 export async function removeApiKey(): Promise<void> {
   const providerItems = await SecretManager.getApiProviderQuickPickItems();
-  const providerPick = await pickProvider(
-    providerItems,
-    'Select API provider to remove key',
-    'Only removes the key from TeXRA — does not delete it from the provider.',
-  );
+  const providerPick = await showQuickPick<ProviderQuickPickItem>({
+    placeholder: 'Select API provider to remove key',
+    prompt: 'Only removes the key from TeXRA — does not delete it from the provider.',
+    items: providerItems,
+  });
 
   const provider = providerPick?.provider;
   if (!provider) {

--- a/packages/extension/src/commands/api/apiKeyCommands.ts
+++ b/packages/extension/src/commands/api/apiKeyCommands.ts
@@ -2,7 +2,10 @@
 import * as vscode from 'vscode';
 
 // Local imports
-import { settleQuickInput, showQuickPick } from '@commands/_shared/quickInputUtils';
+import {
+  settleQuickInput,
+  showQuickPick,
+} from '@commands/_shared/quickInputUtils';
 import { SecretManager, ApiProvider } from '@frontend/secretManager';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { getMainWebview } from '@frontend/system/commandUtils';
@@ -129,7 +132,8 @@ export async function setApiKey(provider?: ApiProvider): Promise<void> {
   const providerItems = await SecretManager.getApiProviderQuickPickItems();
   const providerPick = await showQuickPick<ProviderQuickPickItem>({
     placeholder: 'Select API provider',
-    prompt: "Keys are stored in VS Code's encrypted secret store, never on disk.",
+    prompt:
+      "Keys are stored in VS Code's encrypted secret store, never on disk.",
     items: providerItems,
   });
 
@@ -150,7 +154,8 @@ export async function removeApiKey(): Promise<void> {
   const providerItems = await SecretManager.getApiProviderQuickPickItems();
   const providerPick = await showQuickPick<ProviderQuickPickItem>({
     placeholder: 'Select API provider to remove key',
-    prompt: 'Only removes the key from TeXRA — does not delete it from the provider.',
+    prompt:
+      'Only removes the key from TeXRA — does not delete it from the provider.',
     items: providerItems,
   });
 

--- a/packages/extension/src/commands/api/apiKeyCommands.ts
+++ b/packages/extension/src/commands/api/apiKeyCommands.ts
@@ -104,9 +104,7 @@ async function promptForApiKey(
     ib.buttons = [getKeyButton];
     ib.onDidTriggerButton((button) => {
       if (button === getKeyButton) {
-        void vscode.env.openExternal(
-          vscode.Uri.parse(PROVIDER_URLS[provider]),
-        );
+        void vscode.env.openExternal(vscode.Uri.parse(PROVIDER_URLS[provider]));
       }
     });
   }

--- a/packages/extension/src/commands/api/apiKeyCommands.ts
+++ b/packages/extension/src/commands/api/apiKeyCommands.ts
@@ -2,6 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports
+import { settleQuickInput } from '@commands/_shared/quickInputUtils';
 import { SecretManager, ApiProvider } from '@frontend/secretManager';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { getMainWebview } from '@frontend/system/commandUtils';
@@ -91,39 +92,28 @@ async function promptForApiKey(
     }
   }
 
-  return await new Promise<string | undefined>((resolve) => {
-    let settled = false;
-    const finish = (value: string | undefined): void => {
-      if (settled) return;
-      settled = true;
-      resolve(value);
-      ib.dispose();
-    };
-    ib.title = `Set ${provider} API key`;
-    ib.prompt = `Enter ${provider} API key`;
-    ib.password = true;
-    ib.placeholder = '************************************';
-    const getKeyButton: vscode.QuickInputButton = {
-      iconPath: new vscode.ThemeIcon('link-external'),
-      tooltip: `Get ${provider} API key`,
-    };
-    if (supportsTitleButtons) {
-      ib.buttons = [getKeyButton];
-      ib.onDidTriggerButton((button) => {
-        if (button === getKeyButton) {
-          void vscode.env.openExternal(
-            vscode.Uri.parse(PROVIDER_URLS[provider]),
-          );
-        }
-      });
-    }
+  ib.title = `Set ${provider} API key`;
+  ib.prompt = `Enter ${provider} API key`;
+  ib.password = true;
+  ib.placeholder = '************************************';
+  const getKeyButton: vscode.QuickInputButton = {
+    iconPath: new vscode.ThemeIcon('link-external'),
+    tooltip: `Get ${provider} API key`,
+  };
+  if (supportsTitleButtons) {
+    ib.buttons = [getKeyButton];
+    ib.onDidTriggerButton((button) => {
+      if (button === getKeyButton) {
+        void vscode.env.openExternal(
+          vscode.Uri.parse(PROVIDER_URLS[provider]),
+        );
+      }
+    });
+  }
+  return settleQuickInput(ib, (accept) => {
     ib.onDidAccept(() => {
-      finish(ib.value);
+      accept(ib.value);
     });
-    ib.onDidHide(() => {
-      finish(undefined);
-    });
-    ib.show();
   });
 }
 
@@ -160,33 +150,22 @@ async function pickProvider(
   placeholder: string,
   promptHint: string,
 ): Promise<ProviderQuickPickItem | undefined> {
-  return await new Promise<ProviderQuickPickItem | undefined>((resolve) => {
-    const qp = vscode.window.createQuickPick<ProviderQuickPickItem>();
-    let settled = false;
-    const finish = (value: ProviderQuickPickItem | undefined): void => {
-      if (settled) return;
-      settled = true;
-      resolve(value);
-      qp.dispose();
-    };
-    qp.placeholder = placeholder;
-    qp.items = items;
-    const defaultItem = items[0];
-    if (defaultItem) {
-      qp.activeItems = [defaultItem];
-    }
-    if ('prompt' in qp) {
-      (
-        qp as vscode.QuickPick<ProviderQuickPickItem> & { prompt: string }
-      ).prompt = promptHint;
-    }
+  const qp = vscode.window.createQuickPick<ProviderQuickPickItem>();
+  qp.placeholder = placeholder;
+  qp.items = items;
+  const defaultItem = items[0];
+  if (defaultItem) {
+    qp.activeItems = [defaultItem];
+  }
+  if ('prompt' in qp) {
+    (
+      qp as vscode.QuickPick<ProviderQuickPickItem> & { prompt: string }
+    ).prompt = promptHint;
+  }
+  return settleQuickInput(qp, (accept) => {
     qp.onDidAccept(() => {
-      finish(qp.activeItems[0] ?? qp.selectedItems[0]);
+      accept(qp.activeItems[0] ?? qp.selectedItems[0]);
     });
-    qp.onDidHide(() => {
-      finish(undefined);
-    });
-    qp.show();
   });
 }
 

--- a/packages/extension/src/commands/auth/authCommands.ts
+++ b/packages/extension/src/commands/auth/authCommands.ts
@@ -108,7 +108,8 @@ export async function signIn(): Promise<boolean> {
       title: 'TeXRA Sign In',
       placeholder: 'Choose a sign-in method',
       // VS Code 1.108+: explain what signing in grants. Ignored on older hosts.
-      prompt: 'Sign in to access AI models, remote agents, and TeXRA Researcher features',
+      prompt:
+        'Sign in to access AI models, remote agents, and TeXRA Researcher features',
       items: getSignInOptions(),
     });
     if (!selected) return false;

--- a/packages/extension/src/commands/auth/authCommands.ts
+++ b/packages/extension/src/commands/auth/authCommands.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { type OAuthProvider, getExternalAuthCallbackUri } from '@auth/config';
 import { AUTH_PROVIDER_ID, AUTH_COMMANDS } from '@auth/constants';
-import { settleQuickInput } from '@commands/_shared/quickInputUtils';
+import { showQuickPick } from '@commands/_shared/quickInputUtils';
 import { showSettingsView } from '@commands/settings';
 import { toErrorMessage } from '@common/errors';
 import { SupabaseAuthProvider } from '@frontend/auth/SupabaseAuthProvider';
@@ -104,24 +104,12 @@ export async function signIn(): Promise<boolean> {
       return true;
     }
 
-    const qp = vscode.window.createQuickPick<SignInOption>();
-    qp.title = 'TeXRA Sign In';
-    qp.placeholder = 'Choose a sign-in method';
-    const options = getSignInOptions();
-    qp.items = options;
-    const defaultOption = options[0];
-    if (defaultOption) {
-      qp.activeItems = [defaultOption];
-    }
-    // VS Code 1.108+: explain what signing in grants. Ignored on older hosts.
-    if ('prompt' in qp) {
-      (qp as vscode.QuickPick<SignInOption> & { prompt: string }).prompt =
-        'Sign in to access AI models, remote agents, and TeXRA Researcher features';
-    }
-    const selected = await settleQuickInput(qp, (accept) => {
-      qp.onDidAccept(() => {
-        accept(qp.activeItems[0] ?? qp.selectedItems[0]);
-      });
+    const selected = await showQuickPick<SignInOption>({
+      title: 'TeXRA Sign In',
+      placeholder: 'Choose a sign-in method',
+      // VS Code 1.108+: explain what signing in grants. Ignored on older hosts.
+      prompt: 'Sign in to access AI models, remote agents, and TeXRA Researcher features',
+      items: getSignInOptions(),
     });
     if (!selected) return false;
 

--- a/packages/extension/src/commands/auth/authCommands.ts
+++ b/packages/extension/src/commands/auth/authCommands.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { type OAuthProvider, getExternalAuthCallbackUri } from '@auth/config';
 import { AUTH_PROVIDER_ID, AUTH_COMMANDS } from '@auth/constants';
+import { settleQuickInput } from '@commands/_shared/quickInputUtils';
 import { showSettingsView } from '@commands/settings';
 import { toErrorMessage } from '@common/errors';
 import { SupabaseAuthProvider } from '@frontend/auth/SupabaseAuthProvider';
@@ -103,35 +104,24 @@ export async function signIn(): Promise<boolean> {
       return true;
     }
 
-    const selected = await new Promise<SignInOption | undefined>((resolve) => {
-      const qp = vscode.window.createQuickPick<SignInOption>();
-      let settled = false;
-      const finish = (value: SignInOption | undefined): void => {
-        if (settled) return;
-        settled = true;
-        resolve(value);
-        qp.dispose();
-      };
-      qp.title = 'TeXRA Sign In';
-      qp.placeholder = 'Choose a sign-in method';
-      const options = getSignInOptions();
-      qp.items = options;
-      const defaultOption = options[0];
-      if (defaultOption) {
-        qp.activeItems = [defaultOption];
-      }
-      // VS Code 1.108+: explain what signing in grants. Ignored on older hosts.
-      if ('prompt' in qp) {
-        (qp as vscode.QuickPick<SignInOption> & { prompt: string }).prompt =
-          'Sign in to access AI models, remote agents, and TeXRA Researcher features';
-      }
+    const qp = vscode.window.createQuickPick<SignInOption>();
+    qp.title = 'TeXRA Sign In';
+    qp.placeholder = 'Choose a sign-in method';
+    const options = getSignInOptions();
+    qp.items = options;
+    const defaultOption = options[0];
+    if (defaultOption) {
+      qp.activeItems = [defaultOption];
+    }
+    // VS Code 1.108+: explain what signing in grants. Ignored on older hosts.
+    if ('prompt' in qp) {
+      (qp as vscode.QuickPick<SignInOption> & { prompt: string }).prompt =
+        'Sign in to access AI models, remote agents, and TeXRA Researcher features';
+    }
+    const selected = await settleQuickInput(qp, (accept) => {
       qp.onDidAccept(() => {
-        finish(qp.activeItems[0] ?? qp.selectedItems[0]);
+        accept(qp.activeItems[0] ?? qp.selectedItems[0]);
       });
-      qp.onDidHide(() => {
-        finish(undefined);
-      });
-      qp.show();
     });
     if (!selected) return false;
 

--- a/packages/extension/src/commands/latex/compareCommands.ts
+++ b/packages/extension/src/commands/latex/compareCommands.ts
@@ -6,7 +6,7 @@ import * as vscode from 'vscode';
 
 // Local imports
 import { legacyWorkflowOutputStem } from '@agent/output/workflowOutputLayout';
-import { settleQuickInput } from '@commands/_shared/quickInputUtils';
+import { showQuickPick } from '@commands/_shared/quickInputUtils';
 import { registerCommands } from '@commands/_shared/registerCommands';
 import { bus } from '@eventBus/ProgressEventBus';
 import {
@@ -224,25 +224,14 @@ async function resolveAcceptTarget(
     },
   ];
 
-  const qp = vscode.window.createQuickPick<AcceptItem>();
-  qp.title = 'Accept edits';
-  qp.placeholder = `Accept '${path.basename(editedPath)}' into the workspace`;
-  qp.ignoreFocusOut = true;
-  qp.items = acceptItems;
-  const defaultItem = acceptItems[0];
-  if (defaultItem) {
-    qp.activeItems = [defaultItem];
-  }
-  // VS Code 1.108+: keep the edited filename visible after the placeholder
-  // is cleared by typing — this is a destructive replace-vs-copy choice.
-  if ('prompt' in qp) {
-    (qp as vscode.QuickPick<AcceptItem> & { prompt: string }).prompt =
-      `Edited file: ${path.basename(editedPath)}`;
-  }
-  const pick = await settleQuickInput(qp, (accept) => {
-    qp.onDidAccept(() => {
-      accept(qp.activeItems[0] ?? qp.selectedItems[0]);
-    });
+  const pick = await showQuickPick<AcceptItem>({
+    title: 'Accept edits',
+    placeholder: `Accept '${path.basename(editedPath)}' into the workspace`,
+    ignoreFocusOut: true,
+    // VS Code 1.108+: keep the edited filename visible after the placeholder
+    // is cleared by typing — this is a destructive replace-vs-copy choice.
+    prompt: `Edited file: ${path.basename(editedPath)}`,
+    items: acceptItems,
   });
   return pick?.target;
 }

--- a/packages/extension/src/commands/latex/compareCommands.ts
+++ b/packages/extension/src/commands/latex/compareCommands.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 
 // Local imports
 import { legacyWorkflowOutputStem } from '@agent/output/workflowOutputLayout';
+import { settleQuickInput } from '@commands/_shared/quickInputUtils';
 import { registerCommands } from '@commands/_shared/registerCommands';
 import { bus } from '@eventBus/ProgressEventBus';
 import {
@@ -223,36 +224,25 @@ async function resolveAcceptTarget(
     },
   ];
 
-  const pick = await new Promise<AcceptItem | undefined>((resolve) => {
-    const qp = vscode.window.createQuickPick<AcceptItem>();
-    let settled = false;
-    const finish = (value: AcceptItem | undefined): void => {
-      if (settled) return;
-      settled = true;
-      resolve(value);
-      qp.dispose();
-    };
-    qp.title = 'Accept edits';
-    qp.placeholder = `Accept '${path.basename(editedPath)}' into the workspace`;
-    qp.ignoreFocusOut = true;
-    qp.items = acceptItems;
-    const defaultItem = acceptItems[0];
-    if (defaultItem) {
-      qp.activeItems = [defaultItem];
-    }
-    // VS Code 1.108+: keep the edited filename visible after the placeholder
-    // is cleared by typing — this is a destructive replace-vs-copy choice.
-    if ('prompt' in qp) {
-      (qp as vscode.QuickPick<AcceptItem> & { prompt: string }).prompt =
-        `Edited file: ${path.basename(editedPath)}`;
-    }
+  const qp = vscode.window.createQuickPick<AcceptItem>();
+  qp.title = 'Accept edits';
+  qp.placeholder = `Accept '${path.basename(editedPath)}' into the workspace`;
+  qp.ignoreFocusOut = true;
+  qp.items = acceptItems;
+  const defaultItem = acceptItems[0];
+  if (defaultItem) {
+    qp.activeItems = [defaultItem];
+  }
+  // VS Code 1.108+: keep the edited filename visible after the placeholder
+  // is cleared by typing — this is a destructive replace-vs-copy choice.
+  if ('prompt' in qp) {
+    (qp as vscode.QuickPick<AcceptItem> & { prompt: string }).prompt =
+      `Edited file: ${path.basename(editedPath)}`;
+  }
+  const pick = await settleQuickInput(qp, (accept) => {
     qp.onDidAccept(() => {
-      finish(qp.activeItems[0] ?? qp.selectedItems[0]);
+      accept(qp.activeItems[0] ?? qp.selectedItems[0]);
     });
-    qp.onDidHide(() => {
-      finish(undefined);
-    });
-    qp.show();
   });
   return pick?.target;
 }

--- a/packages/extension/src/commands/latex/latexdiffCommands.ts
+++ b/packages/extension/src/commands/latex/latexdiffCommands.ts
@@ -5,7 +5,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 
 // Local imports
-import { settleQuickInput } from '@commands/_shared/quickInputUtils';
+import { showQuickPick } from '@commands/_shared/quickInputUtils';
 import { registerCommands } from '@commands/_shared/registerCommands';
 import { workspaceSM, WorkspaceStateKey } from '@common/state';
 import {
@@ -91,33 +91,18 @@ async function promptForLatexdiffMathMarkup(): Promise<
   ];
 
   type MarkupItem = vscode.QuickPickItem & { value: MathMarkupOption };
-  const qp = vscode.window.createQuickPick<MarkupItem>();
-  qp.title = 'Latexdiff math markup';
-  qp.placeholder = 'Select math markup granularity for this diff run';
-  qp.ignoreFocusOut = true;
-  qp.items = prioritizedItems;
-  const defaultItem = prioritizedItems.at(0);
-  if (defaultItem) {
-    qp.activeItems = [defaultItem];
-  }
-  // VS Code 1.108+: show the saved default as a persistent hint below the
-  // input box so users know why one item is listed first. Older hosts
-  // (incl. Cursor 1.105) silently ignore the property.
-  if ('prompt' in qp) {
-    (qp as MarkupQuickPick).prompt =
-      `Saved default: ${configuredMode} — press Enter to accept, or pick another`;
-  }
-  return settleQuickInput(qp, (accept) => {
-    qp.onDidAccept(() => {
-      const picked = qp.activeItems[0] ?? qp.selectedItems[0];
-      accept(picked?.value);
-    });
+  const pick = await showQuickPick<MarkupItem>({
+    title: 'Latexdiff math markup',
+    placeholder: 'Select math markup granularity for this diff run',
+    ignoreFocusOut: true,
+    // VS Code 1.108+: show the saved default as a persistent hint below the
+    // input box so users know why one item is listed first. Older hosts
+    // (incl. Cursor 1.105) silently ignore the property.
+    prompt: `Saved default: ${configuredMode} — press Enter to accept, or pick another`,
+    items: prioritizedItems,
   });
+  return pick?.value;
 }
-
-type MarkupQuickPick = vscode.QuickPick<
-  vscode.QuickPickItem & { value: MathMarkupOption }
-> & { prompt: string };
 
 async function openLatexdiffResult(
   base: FileLocation,

--- a/packages/extension/src/commands/latex/latexdiffCommands.ts
+++ b/packages/extension/src/commands/latex/latexdiffCommands.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 
 // Local imports
+import { settleQuickInput } from '@commands/_shared/quickInputUtils';
 import { registerCommands } from '@commands/_shared/registerCommands';
 import { workspaceSM, WorkspaceStateKey } from '@common/state';
 import {
@@ -90,38 +91,27 @@ async function promptForLatexdiffMathMarkup(): Promise<
   ];
 
   type MarkupItem = vscode.QuickPickItem & { value: MathMarkupOption };
-  return await new Promise<MathMarkupOption | undefined>((resolve) => {
-    const qp = vscode.window.createQuickPick<MarkupItem>();
-    let settled = false;
-    const finish = (value: MathMarkupOption | undefined): void => {
-      if (settled) return;
-      settled = true;
-      resolve(value);
-      qp.dispose();
-    };
-    qp.title = 'Latexdiff math markup';
-    qp.placeholder = 'Select math markup granularity for this diff run';
-    qp.ignoreFocusOut = true;
-    qp.items = prioritizedItems;
-    const defaultItem = prioritizedItems.at(0);
-    if (defaultItem) {
-      qp.activeItems = [defaultItem];
-    }
-    // VS Code 1.108+: show the saved default as a persistent hint below the
-    // input box so users know why one item is listed first. Older hosts
-    // (incl. Cursor 1.105) silently ignore the property.
-    if ('prompt' in qp) {
-      (qp as MarkupQuickPick).prompt =
-        `Saved default: ${configuredMode} — press Enter to accept, or pick another`;
-    }
+  const qp = vscode.window.createQuickPick<MarkupItem>();
+  qp.title = 'Latexdiff math markup';
+  qp.placeholder = 'Select math markup granularity for this diff run';
+  qp.ignoreFocusOut = true;
+  qp.items = prioritizedItems;
+  const defaultItem = prioritizedItems.at(0);
+  if (defaultItem) {
+    qp.activeItems = [defaultItem];
+  }
+  // VS Code 1.108+: show the saved default as a persistent hint below the
+  // input box so users know why one item is listed first. Older hosts
+  // (incl. Cursor 1.105) silently ignore the property.
+  if ('prompt' in qp) {
+    (qp as MarkupQuickPick).prompt =
+      `Saved default: ${configuredMode} — press Enter to accept, or pick another`;
+  }
+  return settleQuickInput(qp, (accept) => {
     qp.onDidAccept(() => {
       const picked = qp.activeItems[0] ?? qp.selectedItems[0];
-      finish(picked?.value);
+      accept(picked?.value);
     });
-    qp.onDidHide(() => {
-      finish(undefined);
-    });
-    qp.show();
   });
 }
 

--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -11,6 +11,7 @@ import { isCodexSubscriptionActive } from '@auth/codex';
 import { AUTH_COMMANDS } from '@auth/constants';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { apiKeyCommands } from '@commands/api/apiKeyCommands';
+import { settleQuickInput } from '@commands/_shared/quickInputUtils';
 import { toErrorMessage } from '@common/errors';
 import { GlobalStateKey, globalSM } from '@common/state';
 import { SecretManager } from '@frontend/secretManager';
@@ -228,36 +229,25 @@ async function ensureCredentialOrPrompt(): Promise<boolean> {
   ];
 
   type CredentialPick = (typeof picks)[number];
-  const picked = await new Promise<CredentialPick | undefined>((resolve) => {
-    const qp = vscode.window.createQuickPick<CredentialPick>();
-    let settled = false;
-    const finish = (value: CredentialPick | undefined): void => {
-      if (settled) return;
-      settled = true;
-      resolve(value);
-      qp.dispose();
-    };
-    qp.title = 'TeXRA Setup';
-    qp.placeholder =
-      'TeXRA needs a credential before the setup assistant can run models.';
-    qp.items = picks;
-    const defaultPick = picks[0];
-    if (defaultPick) {
-      qp.activeItems = [defaultPick];
-    }
-    // VS Code 1.108+: the four choices are not self-explanatory in isolation,
-    // and the placeholder vanishes on first keystroke. The prompt persists.
-    if ('prompt' in qp) {
-      (qp as vscode.QuickPick<CredentialPick> & { prompt: string }).prompt =
-        'ChatGPT uses your Plus/Pro subscription; Researcher Access uses your TeXRA account; API Key requires a provider key.';
-    }
+  const qp = vscode.window.createQuickPick<CredentialPick>();
+  qp.title = 'TeXRA Setup';
+  qp.placeholder =
+    'TeXRA needs a credential before the setup assistant can run models.';
+  qp.items = picks;
+  const defaultPick = picks[0];
+  if (defaultPick) {
+    qp.activeItems = [defaultPick];
+  }
+  // VS Code 1.108+: the four choices are not self-explanatory in isolation,
+  // and the placeholder vanishes on first keystroke. The prompt persists.
+  if ('prompt' in qp) {
+    (qp as vscode.QuickPick<CredentialPick> & { prompt: string }).prompt =
+      'ChatGPT uses your Plus/Pro subscription; Researcher Access uses your TeXRA account; API Key requires a provider key.';
+  }
+  const picked = await settleQuickInput(qp, (accept) => {
     qp.onDidAccept(() => {
-      finish(qp.activeItems[0] ?? qp.selectedItems[0]);
+      accept(qp.activeItems[0] ?? qp.selectedItems[0]);
     });
-    qp.onDidHide(() => {
-      finish(undefined);
-    });
-    qp.show();
   });
 
   if (!picked) return false;

--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -231,10 +231,12 @@ async function ensureCredentialOrPrompt(): Promise<boolean> {
   type CredentialPick = (typeof picks)[number];
   const picked = await showQuickPick<CredentialPick>({
     title: 'TeXRA Setup',
-    placeholder: 'TeXRA needs a credential before the setup assistant can run models.',
+    placeholder:
+      'TeXRA needs a credential before the setup assistant can run models.',
     // VS Code 1.108+: the four choices are not self-explanatory in isolation,
     // and the placeholder vanishes on first keystroke. The prompt persists.
-    prompt: 'ChatGPT uses your Plus/Pro subscription; Researcher Access uses your TeXRA account; API Key requires a provider key.',
+    prompt:
+      'ChatGPT uses your Plus/Pro subscription; Researcher Access uses your TeXRA account; API Key requires a provider key.',
     items: picks,
   });
 

--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -11,7 +11,7 @@ import { isCodexSubscriptionActive } from '@auth/codex';
 import { AUTH_COMMANDS } from '@auth/constants';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { apiKeyCommands } from '@commands/api/apiKeyCommands';
-import { settleQuickInput } from '@commands/_shared/quickInputUtils';
+import { showQuickPick } from '@commands/_shared/quickInputUtils';
 import { toErrorMessage } from '@common/errors';
 import { GlobalStateKey, globalSM } from '@common/state';
 import { SecretManager } from '@frontend/secretManager';
@@ -229,25 +229,13 @@ async function ensureCredentialOrPrompt(): Promise<boolean> {
   ];
 
   type CredentialPick = (typeof picks)[number];
-  const qp = vscode.window.createQuickPick<CredentialPick>();
-  qp.title = 'TeXRA Setup';
-  qp.placeholder =
-    'TeXRA needs a credential before the setup assistant can run models.';
-  qp.items = picks;
-  const defaultPick = picks[0];
-  if (defaultPick) {
-    qp.activeItems = [defaultPick];
-  }
-  // VS Code 1.108+: the four choices are not self-explanatory in isolation,
-  // and the placeholder vanishes on first keystroke. The prompt persists.
-  if ('prompt' in qp) {
-    (qp as vscode.QuickPick<CredentialPick> & { prompt: string }).prompt =
-      'ChatGPT uses your Plus/Pro subscription; Researcher Access uses your TeXRA account; API Key requires a provider key.';
-  }
-  const picked = await settleQuickInput(qp, (accept) => {
-    qp.onDidAccept(() => {
-      accept(qp.activeItems[0] ?? qp.selectedItems[0]);
-    });
+  const picked = await showQuickPick<CredentialPick>({
+    title: 'TeXRA Setup',
+    placeholder: 'TeXRA needs a credential before the setup assistant can run models.',
+    // VS Code 1.108+: the four choices are not self-explanatory in isolation,
+    // and the placeholder vanishes on first keystroke. The prompt persists.
+    prompt: 'ChatGPT uses your Plus/Pro subscription; Researcher Access uses your TeXRA account; API Key requires a provider key.',
+    items: picks,
   });
 
   if (!picked) return false;

--- a/src/latex/acceptedFileTarget.ts
+++ b/src/latex/acceptedFileTarget.ts
@@ -72,7 +72,7 @@ export function buildAcceptConfirmMessage(
 ): string {
   const action = getAcceptAction(target.isNewFile, targetExists);
   const extensionNote = target.isNewFile
-    ? `Extensions differ (${path.extname(basePath).toLowerCase()} vs ${path.extname(editedPath).toLowerCase()}). `
+    ? `Extensions differ (${getExtensionLowercase(basePath)} vs ${getExtensionLowercase(editedPath)}). `
     : '';
   return `${extensionNote}This will ${action} '${target.targetFileName}' with content from '${path.basename(editedPath)}'. Are you sure?`;
 }


### PR DESCRIPTION
## Summary

- **Extract `settleQuickInput()` utility** — seven VS Code command handlers each contained an identical 8-line settled-promise pattern (a `settled` flag, a `finish` closure, `onDidHide`, and `show()`). The new helper in `packages/extension/src/commands/_shared/quickInputUtils.ts` centralises this boilerplate: the caller creates the input, configures it, registers `onDidAccept` via a setup callback, and `settleQuickInput` handles the rest. Net removal of ~75 lines across `agentCreatorCommands`, `apiKeyCommands`, `authCommands`, `compareCommands`, `latexdiffCommands`, and `setupAssistantCommand`.

- **Use `getExtensionLowercase()` consistently** — `src/latex/acceptedFileTarget.ts` was calling `path.extname(p).toLowerCase()` inline at line 75 even though `getExtensionLowercase` from `@utils/core/pathCore` was already imported and used elsewhere in the same file. Replaced the two inline calls with the existing helper.

## Test plan

- [x] `npm run compile:fast` — build succeeds with no errors
- [x] `npm test` — full Vitest suite passes (exit code 0)
- Behaviour is unchanged: the settled-promise logic is identical to the extracted pattern; `getExtensionLowercase` is a direct alias for the replaced expression

---
_Generated by [Claude Code](https://claude.ai/code/session_01CjCRihDtpBMuQbfJ4EE9Zv)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical UI refactor with equivalent settle/dismiss semantics; the LaTeX helper change is a direct alias for the previous expression.
> 
> **Overview**
> Introduces **`quickInputUtils`** with **`settleQuickInput`** (idempotent accept/dismiss, `show()`, dispose) and **`showQuickPick`** (single-select config including optional VS Code 1.108+ **`prompt`**). Extension commands that duplicated the same settled-promise boilerplate now call these helpers instead.
> 
> **`settleQuickInput`** covers custom inputs: agent creator multi-select tool groups (with select-all button) and password API key **`InputBox`** (external “get key” button). **`showQuickPick`** replaces local **`pickProvider`** and inline pickers in API key, auth sign-in, compare accept-edits, latexdiff math markup, and setup credential flows.
> 
> In **`acceptedFileTarget`**, the accept-confirm extension mismatch line switches from inline **`path.extname(...).toLowerCase()`** to **`getExtensionLowercase`**, matching the rest of that module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44772ed35c52ac6d565f0bed4dd48b8374c325b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->