### PR TITLE
Extract OpenAI Responses API pricing logic to shared utility

### DIFF
--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -19,7 +19,6 @@ import { type OpenAIAPIResponseUsage } from '@agent/core/usage/ResponseUsage';
 import type { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import type { MediaEntry } from '@agent/utils/mediaTypes';
-import { calculateTokenPrice } from '@agent/utils/priceUtils';
 import { K_SLICE } from '@agent/core/constants';
 import {
   detectStatusCode,
@@ -47,6 +46,7 @@ import {
 } from '@utils/config/providerConfig';
 import { toOpenAIReasoningEffort } from '../support/reasoningEffort';
 import { normalizeUsage } from '../support/UsageNormalizer';
+import { computeOpenAIResponsePrice } from './openAIUsage';
 import { initializeOpenAiCompatibleOutputAndPrefill } from '../support/openAiCompatiblePrefill';
 import { tagOpenAISdkError } from './openAISdkError';
 import {
@@ -2014,32 +2014,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
   /** Price computation adapted for Responses API token fields. */
   computePrice(responseUsage: ResponseUsage): number {
-    const promptTokens = responseUsage.input_tokens ?? 0;
-    const completionTokens = responseUsage.output_tokens ?? 0;
-
-    let basePrice = calculateTokenPrice(
-      promptTokens,
-      completionTokens,
-      this.config.inputPrice,
-      this.config.outputPrice,
+    return computeOpenAIResponsePrice(
+      responseUsage,
+      this.standardPricingConfig(),
     );
-
-    const reasoningTokens =
-      responseUsage.output_tokens_details?.reasoning_tokens ?? 0;
-    const cachedTokens = responseUsage.input_tokens_details?.cached_tokens ?? 0;
-
-    if (reasoningTokens) {
-      basePrice += (reasoningTokens * this.config.outputPrice) / 1e6;
-    }
-    if (cachedTokens) {
-      basePrice -=
-        (cachedTokens *
-          this.config.inputPrice *
-          (1 - this.capabilities.cacheDiscountFactor)) /
-        1e6;
-    }
-
-    return basePrice;
   }
 
   /** Normalizes OpenAI Responses API usage data into a unified format. */

--- a/src/agent/modelHandlers/openai/openAIUsage.ts
+++ b/src/agent/modelHandlers/openai/openAIUsage.ts
@@ -6,6 +6,7 @@
  * live handler instance. The handler keeps thin `computePrice` / `normalizeUsage`
  * overrides that delegate here with the model's pricing config and provider id.
  */
+
 import type { ExtendedCompletionUsage } from '@agent/core/usage/ResponseUsage';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import {
@@ -14,6 +15,7 @@ import {
 } from '@agent/utils/priceUtils';
 
 import { normalizeUsage } from '../support/UsageNormalizer';
+import type { ResponseUsage } from 'openai/resources/responses/responses';
 
 /** Pricing inputs the handler supplies from its `config`/`capabilities`. */
 export type OpenAIPricingConfig = StandardPricingConfig;
@@ -41,6 +43,27 @@ export function computeOpenAIPrice(
       cachedTokens,
       reasoningTokens:
         responseUsage.completion_tokens_details?.reasoning_tokens ?? 0,
+    },
+    config,
+  );
+}
+
+/**
+ * Cost for the Responses API. Same inclusive-cache formula as
+ * {@link computeOpenAIPrice}; only the token field names differ
+ * (`input_tokens`/`output_tokens` vs `prompt_tokens`/`completion_tokens`).
+ */
+export function computeOpenAIResponsePrice(
+  responseUsage: ResponseUsage,
+  config: OpenAIPricingConfig,
+): number {
+  return computeStandardPrice(
+    {
+      inputTokens: responseUsage.input_tokens ?? 0,
+      outputTokens: responseUsage.output_tokens ?? 0,
+      cachedTokens: responseUsage.input_tokens_details?.cached_tokens ?? 0,
+      reasoningTokens:
+        responseUsage.output_tokens_details?.reasoning_tokens ?? 0,
     },
     config,
   );


### PR DESCRIPTION
## Summary

Refactors the `computePrice` method in `ModelHandlerOpenAIResponse` to delegate to a new shared utility function `computeOpenAIResponsePrice` in `openAIUsage.ts`. This eliminates duplicated pricing logic and establishes a single source of truth for OpenAI Responses API cost calculations.

The new function handles the same inclusive-cache pricing formula as the existing `computeOpenAIPrice`, but adapts it for Responses API token field names (`input_tokens`/`output_tokens` vs `prompt_tokens`/`completion_tokens`).

## Issue acceptance gates

N/A

## Single source of truth

`src/agent/modelHandlers/openai/openAIUsage.ts` now owns all OpenAI pricing computations via:
- `computeOpenAIPrice()` - for standard completion APIs
- `computeOpenAIResponsePrice()` - for Responses API (new)

Both delegate to the shared `computeStandardPrice()` utility with appropriately mapped token fields.

## Duplication and abstraction budget

**Removed duplication:** The 22-line pricing calculation in `ModelHandlerOpenAIResponse.computePrice()` is now a 3-line delegation to `computeOpenAIResponsePrice()`.

**Abstraction added:** `computeOpenAIResponsePrice()` encapsulates the Responses API token field mapping and pricing formula, allowing handlers to remain thin and focused on delegation.

## Host impact

Extension: No user-facing changes; internal refactor only.

Desktop: No user-facing changes; internal refactor only.

CLI: No user-facing changes; internal refactor only.

## Scheduled refactoring

None

## Validation

- No new tests added; this is a pure refactor of existing logic with identical behavior
- Existing pricing calculations remain unchanged
- Import statement updated to use the new utility function

https://claude.ai/code/session_01BFS1ATBF4bNmTY7jGgGSvZ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor with no intended billing behavior change; pricing still flows through the shared `computeStandardPrice` path.
> 
> **Overview**
> **Responses API cost calculation** now lives in `computeOpenAIResponsePrice` in `openAIUsage.ts`, alongside the existing Chat Completions helper `computeOpenAIPrice`.
> 
> `ModelHandlerOpenAIResponse.computePrice` no longer inlines token math with `calculateTokenPrice`; it delegates to that utility with `standardPricingConfig()`. The new function maps Responses usage fields (`input_tokens`, `output_tokens`, cached/reasoning details) into `computeStandardPrice`, matching the inclusive-cache formula already used for completions—only the field names differ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44766f31144c529a12c80c824716ccf374b2c61a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->