### PR TITLE
fix(ui): name anonymous diff hex colors; drop non-standard tag appearance

### DIFF
--- a/packages/cli/src/chat/tui/render/DiffView.tsx
+++ b/packages/cli/src/chat/tui/render/DiffView.tsx
@@ -323,6 +323,13 @@ interface DiffLineStyle {
   readonly color: string;
 }
 
+// Light-background diff band colors: green for additions, rose for removals.
+// Both pairs pass WCAG AA contrast at typical terminal font weights.
+const DIFF_ADDED_BG = '#dff4e8';
+const DIFF_ADDED_FG = '#16351f';
+const DIFF_REMOVED_BG = '#f7d9dc';
+const DIFF_REMOVED_FG = '#4a171b';
+
 /**
  * Full-width bands for changed lines. Use light backgrounds plus explicit
  * foreground colors so text stays readable on both light and dark terminals.
@@ -332,12 +339,12 @@ export const DIFF_LINE_STYLE: Partial<
   Record<DiffDisplayLine['kind'], DiffLineStyle>
 > = {
   added: {
-    backgroundColor: '#dff4e8',
-    color: '#16351f',
+    backgroundColor: DIFF_ADDED_BG,
+    color: DIFF_ADDED_FG,
   },
   removed: {
-    backgroundColor: '#f7d9dc',
-    color: '#4a171b',
+    backgroundColor: DIFF_REMOVED_BG,
+    color: DIFF_REMOVED_FG,
   },
 };
 

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -278,11 +278,7 @@ export class ToolCard extends LitElement {
     const label = toolStatusLabel(status, this.item.statusLabel);
 
     return html`
-      <wa-tag
-        class="tool-badge"
-        variant=${config.variant}
-        size="small"
-      >
+      <wa-tag class="tool-badge" variant=${config.variant} size="small">
         ${waIcon(config.icon)} ${label}
       </wa-tag>
     `;

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -281,7 +281,6 @@ export class ToolCard extends LitElement {
       <wa-tag
         class="tool-badge"
         variant=${config.variant}
-        appearance="accent"
         size="small"
       >
         ${waIcon(config.icon)} ${label}


### PR DESCRIPTION
## Summary

Two targeted UI consistency fixes surfaced by a codebase-wide audit of webview frontends, the Ink TUI, and recent commits against the project's Web Awesome / Font Awesome standards.

**DiffView.tsx** — the four hex literals `#dff4e8 / #16351f` (added band) and `#f7d9dc / #4a171b` (removed band) were anonymous strings embedded inside the exported `DIFF_LINE_STYLE` constant. Extracting them into `DIFF_ADDED_BG/FG` and `DIFF_REMOVED_BG/FG` module constants makes their semantic intent visible and gives a single place to update if the palette changes.

**ToolCard.ts** — the tool-status `<wa-tag>` carried `appearance="accent"`, an attribute that does not appear on any other `<wa-tag>` in the repository. The `variant` prop already drives the visual treatment; the stray `appearance` was dropped.

## Issue acceptance gates

No tracked issue. Changes are cleanup findings from a UI-consistency audit.

## Single source of truth

- Diff band colors: the four named constants in `DiffView.tsx` are now the single definition.
- Tool-status badge appearance: governed by `STATUS_CONFIG[status].variant` alone, matching every other `<wa-tag>` in the codebase.

## Duplication and abstraction budget

No new abstractions added. No duplication removed (the constants are referenced once each). Change reduces the number of anonymous magic strings and brings `<wa-tag>` usage into conformance with the established pattern.

## Host impact

Extension: `ToolCard.ts` visual change — tool-status badge loses the non-standard `appearance="accent"` attribute; rendered output should be identical or closer to design intent since `accent` is not a documented `<wa-tag>` appearance value.

Desktop: None.

CLI: `DiffView.tsx` — no behavior change, rename only.

## Scheduled refactoring

The audit also flagged native `<details>` vs `<wa-details>` inconsistency in four progressView components (`LatexdiffResults`, `StatisticsPanel`, `ExternalInquiryPanel`, `ContextManagement`) and a loading-state helper gap in progressView. Those require updating `buildDetailsSummary()` and CSS selectors and are tracked for a follow-up PR.

## Validation

- `npx eslint packages/cli/src/chat/tui/render/DiffView.tsx packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts` — no errors
- `git diff --check` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01PJ1cLHUaK4CXHyeQ8xkQwb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic/refactor-only changes to diff colors and tag markup with no auth, data, or logic paths touched.
> 
> **Overview**
> Small UI consistency cleanup from a webview/TUI audit—no functional behavior changes.
> 
> **CLI `DiffView.tsx`** — The added/removed diff band hex values are lifted into named module constants (`DIFF_ADDED_BG/FG`, `REMOVED_BG/FG`) with a short WCAG note; `DIFF_LINE_STYLE` references those names instead of inline literals.
> 
> **Extension `ToolCard.ts`** — The tool-status `<wa-tag>` no longer sets `appearance="accent"`, aligning with other tags in the repo where `variant` alone drives styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18c17e4633372ed5733532cb90b4e7f6cbdaa86e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->