### PR TITLE
chore: adopt finalized VS Code 1.105–1.109 APIs, drop workarounds

### DIFF
--- a/packages/extension/src/commands/agent/agentCreatorCommands.ts
+++ b/packages/extension/src/commands/agent/agentCreatorCommands.ts
@@ -24,10 +24,6 @@ interface ParsedCreatorYaml {
   prompts: { systemPrompt: string; userRequest: string; retryPrompt?: string };
 }
 
-type QuickInputToggleButton = vscode.QuickInputButton & {
-  readonly toggle: { checked: boolean };
-};
-
 /** Cached after first load. Templates are bundled resources — stable for the session. */
 let creatorConfig: CreatorConfig | null = null;
 
@@ -83,7 +79,7 @@ async function pickToolGroups(
   const initiallySelected = items.filter((item) => item.picked);
   qp.selectedItems = initiallySelected;
   if ('prompt' in qp) {
-    (qp as vscode.QuickPick<vscode.QuickPickItem> & { prompt: string }).prompt =
+    qp.prompt =
       'Space / click to toggle. Pre-selected groups match your description.';
   }
 
@@ -96,7 +92,7 @@ async function pickToolGroups(
   let activeSelectAllButton: vscode.QuickInputButton | undefined;
   const refreshSelectAllButton = () => {
     if ('buttons' in qp) {
-      const toggleButton: QuickInputToggleButton = {
+      const toggleButton: vscode.QuickInputButton = {
         ...selectAllButton,
         toggle: { checked: allSelected },
       };

--- a/packages/extension/src/commands/latex/figCommands.ts
+++ b/packages/extension/src/commands/latex/figCommands.ts
@@ -148,7 +148,9 @@ export async function handleCompileTikzFigures(): Promise<void> {
           if (compiledFiles.length > 0) {
             const items = compiledFiles.map((fileLocation) => ({
               label: path.basename(fileLocation.absolutePath),
-              description: fileLocation.absolutePath,
+              description: path.dirname(fileLocation.absolutePath),
+              resourceUri: vscode.Uri.file(fileLocation.absolutePath),
+              iconPath: vscode.ThemeIcon.File,
               file: fileLocation.absolutePath,
             }));
 

--- a/packages/extension/src/frontend/secretManager.ts
+++ b/packages/extension/src/frontend/secretManager.ts
@@ -48,7 +48,14 @@ export class SecretManager {
   }
 
   public static async listKeys(): Promise<readonly string[]> {
-    return this.storage.keys();
+    try {
+      return await this.storage.keys();
+    } catch (err) {
+      throw new Error(
+        'SecretStorage key enumeration is not supported by this host. Stored secrets may still exist, but TeXRA cannot audit their names here.',
+        { cause: err },
+      );
+    }
   }
 
   public static async gitHubTokenExists(): Promise<'secret' | 'env' | 'none'> {

--- a/src/test-kernel/tools/setup/ListApiKeysTool.vitest.ts
+++ b/src/test-kernel/tools/setup/ListApiKeysTool.vitest.ts
@@ -40,6 +40,26 @@ describe('list_api_keys tool', () => {
     assert.match(result.output ?? '', /SecretStorage is empty/);
   });
 
+  it('reports unsupported SecretStorage enumeration instead of an empty store', async () => {
+    const base = createFakeSetupPlatform();
+    setSetupPlatform({
+      ...base,
+      secrets: {
+        ...base.secrets,
+        providers: FAKE_PROVIDERS,
+        async listStoredKeys() {
+          throw new Error('SecretStorage key enumeration is not supported');
+        },
+      },
+    });
+
+    const result = await tool.call({});
+
+    assert.equal(result.isError, true);
+    assert.match(result.error ?? '', /enumeration is not supported/);
+    assert.doesNotMatch(result.output ?? '', /SecretStorage is empty/);
+  });
+
   it('shows known provider keys by provider name, not raw SecretStorage key', async () => {
     installPlatformWithKeys([apiKeySecretName('anthropic')]);
     const result = await tool.call({});


### PR DESCRIPTION
## Summary

Three focused cleanups based on the VS Code API audit for the supported 1.105+ range.

- `SecretManager.listKeys()` now reports unsupported `SecretStorage.keys()` enumeration as an explicit error instead of returning an empty list. This prevents `list_api_keys` from mistaking an unsupported host for an empty secret store.
- `agentCreatorCommands` uses the official `QuickPick.prompt` and `QuickInputButton.toggle` types, keeping the current shared quick-input settling helper.
- `handleCompileTikzFigures` sets `resourceUri` and `ThemeIcon.File` for compiled TikZ picker items, with the parent directory in the description.

## Review follow-up

- Addressed the review thread on secret enumeration by removing the normal `[]` fallback and adding a regression test for the tool error path.

## Test plan

- [x] `corepack pnpm exec prettier --check packages/extension/src/commands/agent/agentCreatorCommands.ts packages/extension/src/commands/latex/figCommands.ts packages/extension/src/frontend/secretManager.ts src/test-kernel/tools/setup/ListApiKeysTool.vitest.ts`
- [x] `node --max-old-space-size=4096 ./node_modules/eslint/bin/eslint.js packages/extension/src/commands/agent/agentCreatorCommands.ts packages/extension/src/commands/latex/figCommands.ts packages/extension/src/frontend/secretManager.ts src/test-kernel/tools/setup/ListApiKeysTool.vitest.ts`
- [x] `corepack pnpm exec vitest run src/test-kernel/tools/setup/ListApiKeysTool.vitest.ts`
- [x] `npm run typecheck`
- [ ] GitHub CI
