### PR TITLE
fix(ui): use wa-details for progress panels

### DIFF
--- a/packages/extension/src/progressView/frontend/components/ContextManagement.ts
+++ b/packages/extension/src/progressView/frontend/components/ContextManagement.ts
@@ -5,12 +5,16 @@ import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 
-// Side-effect imports - register WA icon component
+// Side-effect imports - register WA components
+import '@awesome.me/webawesome/dist/components/details/details.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
 // Local imports - shared styles
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+
+// Local imports - progress view helpers
+import { buildDetailsSummary } from '../formatters/htmlBuilders';
 
 // Local imports - local components (re-use StatItem type)
 import type { StatItem } from './StatisticsPanel';
@@ -33,19 +37,15 @@ export class ContextManagement extends LitElement {
         margin: var(--wa-space-2xs) 0;
       }
 
-      details {
+      wa-details {
         margin: 0;
       }
 
       /* Extend .details-summary from commonViewStyles with accent color */
-      summary,
-      .context-icon,
+      .details-summary,
+      .details-summary .icon,
       .context-title {
         color: var(--accent-color, var(--wa-color-text-normal));
-      }
-
-      .context-icon {
-        margin-right: var(--wa-space-2xs);
       }
 
       .context-title {
@@ -118,25 +118,17 @@ export class ContextManagement extends LitElement {
     }
 
     return html`
-      <details
+      <wa-details
         class="banner-details"
+        appearance="plain"
         style="--accent-color: ${this.config.color}"
       >
-        <summary class="details-summary">
-          <wa-icon
-            library=${TEXRA_ICON_LIBRARY}
-            name="chevron-right"
-            class="toggle-icon"
-            aria-hidden="true"
-          ></wa-icon>
-          <wa-icon
-            library=${TEXRA_ICON_LIBRARY}
-            name=${this.config.icon}
-            class="context-icon"
-            aria-hidden="true"
-          ></wa-icon>
-          <span class="context-title">${this.config.label}</span>
-        </summary>
+        ${buildDetailsSummary({
+          iconName: this.config.icon,
+          label: this.config.label,
+          labelClass: 'context-title',
+          summarySlot: true,
+        })}
         <div class="context-content" data-log-id=${this.logId}>
           ${repeat(
             this.items,
@@ -168,7 +160,7 @@ export class ContextManagement extends LitElement {
               `
             : nothing}
         </div>
-      </details>
+      </wa-details>
     `;
   }
 }

--- a/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -20,6 +20,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { live } from 'lit/directives/live.js';
 import { repeat } from 'lit/directives/repeat.js';
 
+import '@awesome.me/webawesome/dist/components/details/details.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
@@ -290,15 +291,21 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
     if (answeredTurns.length === 0) return nothing;
 
     return html`
-      <details class="external-inquiry-request__transcript">
-        <summary class="external-inquiry-request__transcript-summary">
+      <wa-details
+        class="external-inquiry-request__transcript"
+        appearance="plain"
+      >
+        <span
+          slot="summary"
+          class="external-inquiry-request__transcript-summary"
+        >
           <wa-icon
             library=${TEXRA_ICON_LIBRARY}
             name="history"
             aria-hidden="true"
           ></wa-icon>
           Conversation transcript (${answeredTurns.length})
-        </summary>
+        </span>
         <div class="external-inquiry-request__transcript-turns">
           ${repeat(
             answeredTurns,
@@ -306,7 +313,7 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
             (turn) => this.renderTranscriptTurn(turn),
           )}
         </div>
-      </details>
+      </wa-details>
     `;
   }
 

--- a/packages/extension/src/progressView/frontend/components/LatexdiffResults.ts
+++ b/packages/extension/src/progressView/frontend/components/LatexdiffResults.ts
@@ -7,6 +7,7 @@ import { repeat } from 'lit/directives/repeat.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
 // Side-effect imports - register WA components
+import '@awesome.me/webawesome/dist/components/details/details.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
 // Local imports - shared styles
@@ -36,7 +37,7 @@ export class LatexdiffResults extends LitElement {
         display: block;
       }
 
-      details {
+      wa-details {
         margin: var(--wa-space-2xs) 0;
         content-visibility: auto;
         contain-intrinsic-size: auto 40px;
@@ -153,13 +154,18 @@ export class LatexdiffResults extends LitElement {
         : `Latexdiff results (${this.entries.length})`;
 
     return html`
-      <details
+      <wa-details
         class="banner-details"
+        appearance="plain"
         open
         data-log-id=${ifDefined(this.logId || undefined)}
         data-run-id=${ifDefined(this.runId || undefined)}
       >
-        ${buildDetailsSummary({ iconName: 'diff', label: summaryText })}
+        ${buildDetailsSummary({
+          iconName: 'diff',
+          label: summaryText,
+          summarySlot: true,
+        })}
         <ul class="latexdiff-content">
           ${repeat(
             this.entries,
@@ -168,7 +174,7 @@ export class LatexdiffResults extends LitElement {
             (entry) => this.renderEntry(entry),
           )}
         </ul>
-      </details>
+      </wa-details>
     `;
   }
 }

--- a/packages/extension/src/progressView/frontend/components/StatisticsPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/StatisticsPanel.ts
@@ -7,6 +7,7 @@ import { repeat } from 'lit/directives/repeat.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
 // Side-effect imports - register WA components
+import '@awesome.me/webawesome/dist/components/details/details.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
 // Local imports - shared styles
@@ -33,7 +34,7 @@ export class StatisticsPanel extends LitElement {
         display: block;
       }
 
-      details {
+      wa-details {
         margin: var(--wa-space-2xs) 0;
         content-visibility: auto;
         contain-intrinsic-size: auto 40px;
@@ -73,11 +74,16 @@ export class StatisticsPanel extends LitElement {
     }
 
     return html`
-      <details
+      <wa-details
         class="banner-details"
+        appearance="plain"
         data-log-id=${ifDefined(this.logId || undefined)}
       >
-        ${buildDetailsSummary({ iconName: 'graph', label: 'Statistics' })}
+        ${buildDetailsSummary({
+          iconName: 'graph',
+          label: 'Statistics',
+          summarySlot: true,
+        })}
         <div class="statistics-content">
           ${repeat(
             this.items,
@@ -94,7 +100,7 @@ export class StatisticsPanel extends LitElement {
             `,
           )}
         </div>
-      </details>
+      </wa-details>
     `;
   }
 }

--- a/packages/extension/src/progressView/frontend/components/TexraDiffView.ts
+++ b/packages/extension/src/progressView/frontend/components/TexraDiffView.ts
@@ -3,12 +3,13 @@ import { LitElement, css, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { consume } from '@lit/context';
 
-// Local imports - shared styles
-import { commonViewStyles, designTokens } from '@shared/styles';
-
-// Local imports - shared webview
+// Local imports - shared modules
 import { themeContext } from '@shared/BaseWebviewApp';
+import { commonViewStyles, designTokens } from '@shared/styles';
 import { DESKTOP_THEME_KIND } from '@shared/constants/desktopTheme';
+
+// Local imports - shared Web Awesome helpers
+import { renderLoadingState } from '@shared/wa/loadingState';
 
 type MonacoModule = typeof import('monaco-editor/esm/vs/editor/editor.api.js');
 type MonacoWorkerModule = { default: new () => Worker };
@@ -119,7 +120,6 @@ export class TexraDiffView extends LitElement {
         min-height: 0;
       }
 
-      .placeholder,
       .error {
         display: flex;
         align-items: center;
@@ -192,9 +192,7 @@ export class TexraDiffView extends LitElement {
       return html`<div class="error">${this.errorMessage}</div>`;
     }
     return html`
-      ${this.loading
-        ? html`<div class="placeholder">Loading diff...</div>`
-        : nothing}
+      ${this.loading ? renderLoadingState('Loading diff...') : nothing}
       <div class="diff-view" ?hidden=${this.loading}>
         <div class="editor"></div>
       </div>

--- a/packages/extension/src/progressView/frontend/components/TexraDiffView.ts
+++ b/packages/extension/src/progressView/frontend/components/TexraDiffView.ts
@@ -134,6 +134,12 @@ export class TexraDiffView extends LitElement {
       .error {
         color: var(--color-error);
       }
+
+      .loading-state {
+        min-height: 240px;
+        border: var(--border-thin) solid var(--color-border);
+        background: var(--color-bg-secondary);
+      }
     `,
   ];
 

--- a/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
+++ b/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
@@ -126,6 +126,8 @@ export interface DetailsSummaryOptions {
   iconName: string;
   label: string;
   labelClass?: string;
+  /** Render as Web Awesome summary-slot content instead of a native summary. */
+  summarySlot?: boolean;
   timestamp?: { display: string; tooltip: string };
   copyButton?: {
     title: string;
@@ -145,6 +147,7 @@ export function buildDetailsSummary(
     iconName,
     label,
     labelClass = 'label',
+    summarySlot = false,
     timestamp,
     copyButton,
     extraContent,
@@ -161,7 +164,11 @@ export function buildDetailsSummary(
     ? buildCopyButton(copyButton.title, copyButton)
     : nothing;
   const extraTemplate = extraContent ?? nothing;
-  // Toggle icon uses CSS rotation via details[open] selector - always start with chevron-right
+  if (summarySlot) {
+    // prettier-ignore
+    return html`<div slot="summary" class="details-summary">${iconTemplate} <span class=${labelClass}>${label}</span>${extraTemplate}${timestampTemplate}${copyTemplate}</div>`;
+  }
+  // Native details toggle icon uses CSS rotation via details[open].
   // prettier-ignore
   return html`<summary class="details-summary"><wa-icon library=${TEXRA_ICON_LIBRARY} name="chevron-right" class="toggle-icon" aria-hidden="true"></wa-icon> ${iconTemplate} <span class=${labelClass}>${label}</span>${extraTemplate}${timestampTemplate}${copyTemplate}</summary>`;
 }

--- a/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
+++ b/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
@@ -126,7 +126,10 @@ export interface DetailsSummaryOptions {
   iconName: string;
   label: string;
   labelClass?: string;
-  /** Render as Web Awesome summary-slot content instead of a native summary. */
+  /**
+   * Render as `<wa-details>` summary-slot content instead of a native summary.
+   * The caller must register `<wa-details>` and rely on its built-in toggle icon.
+   */
   summarySlot?: boolean;
   timestamp?: { display: string; tooltip: string };
   copyButton?: {

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -314,8 +314,8 @@ export const commonViewStyles: CSSResult = css`
     border-radius: var(--border-radius-small);
   }
 
-  /* Toggle icon for collapsible details - applies to any summary */
-  summary .toggle-icon {
+  /* Toggle icon for collapsible native details summaries. */
+  .details-summary .toggle-icon {
     opacity: var(--opacity-subtle);
     font-size: var(--font-size-sm);
     display: inline-block;
@@ -324,6 +324,18 @@ export const commonViewStyles: CSSResult = css`
 
   details[open] > summary .toggle-icon {
     transform: rotate(90deg);
+  }
+
+  /* Compact banner variant used by progress-view custom-element panels. */
+  wa-details.banner-details::part(base) {
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+  }
+
+  wa-details.banner-details::part(header),
+  wa-details.banner-details::part(content) {
+    padding: 0;
   }
 
   .text-secondary {

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -730,6 +730,7 @@ export const requestPanelStyles: CSSResult = css`
     padding: 0;
   }
 
+  /* Web Awesome's details template exposes the disclosure indicator as part="icon". */
   .external-inquiry-request__transcript::part(icon) {
     padding-inline-end: ${sp.medium};
   }

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -719,6 +719,21 @@ export const requestPanelStyles: CSSResult = css`
     background: var(--wa-color-surface-lowered, rgba(0, 0, 0, 0.05));
   }
 
+  .external-inquiry-request__transcript::part(base) {
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+  }
+
+  .external-inquiry-request__transcript::part(header),
+  .external-inquiry-request__transcript::part(content) {
+    padding: 0;
+  }
+
+  .external-inquiry-request__transcript::part(icon) {
+    padding-inline-end: ${sp.medium};
+  }
+
   .external-inquiry-request__transcript-summary {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary

This PR addresses #6799 by replacing the remaining native disclosure controls in the named progress-view components with Web Awesome `<wa-details>`.

- Converts `StatisticsPanel`, `LatexdiffResults`, `ContextManagement`, and `ExternalInquiryPanel` from native `<details>/<summary>` to `<wa-details>`.
- Extends `buildDetailsSummary()` with a `summarySlot` mode so component panels can reuse the existing icon-and-label summary markup without carrying bespoke summary code.
- Adds compact `wa-details.banner-details` styling so the converted panels keep the progress-log banner spacing rather than inheriting boxed Web Awesome panel chrome.
- Reuses the shared `renderLoadingState()` helper in `TexraDiffView`, replacing the local loading placeholder called out by the same audit.

Closes #6799.

## Validation

- `corepack pnpm exec eslint packages/extension/src/progressView/frontend/components/StatisticsPanel.ts packages/extension/src/progressView/frontend/components/LatexdiffResults.ts packages/extension/src/progressView/frontend/components/ContextManagement.ts packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts packages/extension/src/progressView/frontend/components/TexraDiffView.ts packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts src/shared/styles/commonViewStyles.ts src/shared/styles/requestPanelStyles.ts`
- `corepack pnpm run typecheck`
- `corepack pnpm run compile:fast`
- `git diff --check`
- `rg -n "<details|</details|<summary|</summary"` on the four target component files returned no matches.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes in progress webview components; no auth, data, or backend logic touched.
> 
> **Overview**
> Progress-view collapsible panels now use Web Awesome **`<wa-details>`** instead of native **`<details>`**, with **`appearance="plain"`** and **`banner-details`** styling so log banners stay flat and tight instead of picking up boxed WA chrome.
> 
> **`buildDetailsSummary()`** gains **`summarySlot`** so panels can reuse the same icon/label header via **`slot="summary"`** and WA’s built-in disclosure control (no custom chevron). **`ContextManagement`**, **`StatisticsPanel`**, and **`LatexdiffResults`** adopt that path; **`ExternalInquiryPanel`**’s transcript block uses **`wa-details`** with a slotted summary and **`::part`** tweaks in **`requestPanelStyles`**.
> 
> **`TexraDiffView`** swaps its local “Loading diff…” placeholder for shared **`renderLoadingState()`**. Native-summary chevron CSS in **`commonViewStyles`** is scoped to **`.details-summary .toggle-icon`** for any remaining native **`details`** callers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 697f62aa9eb341e2ddcec4820bff76964169f454. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->