### PR TITLE
fix(cli): clarify session approval scopes

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1268,7 +1268,7 @@ const SCENARIOS = [
       'n reject',
       'Esc cancel',
     ],
-    unexpect: [' · …', 'a session'],
+    unexpect: [' · …', 'a bash session'],
   },
   {
     name: 'bash-approval-feedback',

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1234,7 +1234,7 @@ const SCENARIOS = [
       '$ npm run compile:safe',
       'Directory:',
       'y approve',
-      'a approve session',
+      'a approve bash for session',
       'Use foreground panel shortcuts',
     ],
     unexpect: ['[Alt-p]tasks', '[Option-p]tasks', '[/model]models'],

--- a/packages/cli/src/chat/tui/modals/BashApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/BashApproval.tsx
@@ -171,7 +171,7 @@ export function BashApproval(props: BashApprovalProps): React.JSX.Element {
       borderStyle="double"
       color="yellow"
       title={BASH_APPROVAL_TITLE}
-      alwaysAllow={{ kind: 'bash', label: 'approve session' }}
+      alwaysAllow={{ kind: 'bash', label: 'approve bash for session' }}
       onDecide={props.onDecide}
     >
       {cwdLine ? <Text dimColor>{cwdLine}</Text> : null}

--- a/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
+++ b/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
@@ -108,6 +108,10 @@ function hintsFit(
 
 function compactHintAction(action: string): string {
   switch (action) {
+    case 'approve bash for session':
+      return 'bash session';
+    case 'approve edits for session':
+      return 'edit session';
     case 'approve session':
       return 'session';
     case 'feedback':

--- a/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
+++ b/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
@@ -112,8 +112,6 @@ function compactHintAction(action: string): string {
       return 'bash session';
     case 'approve edits for session':
       return 'edit session';
-    case 'approve session':
-      return 'session';
     case 'feedback':
       return 'note';
     default:
@@ -144,13 +142,13 @@ export function confirmCardKeyHintsForWidth(
     return withoutExtraActions;
   }
 
+  const withoutFeedback = compactHints.filter((hint) => hint.key !== 'e');
+  if (hintsFit(withoutFeedback, options.maxColumns)) return withoutFeedback;
+
   const withFeedback = compactHints.filter(
     (hint) => isCoreApprovalHint(hint) || hint.key === 'e',
   );
   if (hintsFit(withFeedback, options.maxColumns)) return withFeedback;
-
-  const withoutFeedback = compactHints.filter((hint) => hint.key !== 'e');
-  if (hintsFit(withoutFeedback, options.maxColumns)) return withoutFeedback;
 
   const coreHints = compactHints.filter(isCoreApprovalHint);
   if (hintsFit(coreHints, options.maxColumns)) return coreHints;

--- a/packages/cli/src/chat/tui/modals/EditApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/EditApproval.tsx
@@ -147,7 +147,7 @@ export function EditApproval(props: EditApprovalProps): React.JSX.Element {
       borderStyle="double"
       color="cyan"
       title={title}
-      alwaysAllow={{ kind: 'toolEdit', label: 'approve session' }}
+      alwaysAllow={{ kind: 'toolEdit', label: 'approve edits for session' }}
       feedbackPlaceholder={EDIT_APPROVAL_FEEDBACK_PLACEHOLDER}
       compact={compactCard}
       onFeedbackModeChange={setFeedbackMode}

--- a/src/test-kernel/cli/ConfirmCardState.vitest.mts
+++ b/src/test-kernel/cli/ConfirmCardState.vitest.mts
@@ -97,6 +97,23 @@ describe('CLI confirm-card key handling', () => {
     ).toContainEqual({ key: 'a', action: 'edit session' });
   });
 
+  it('keeps session-scope hints before feedback on mid-width terminals', () => {
+    const compact = confirmCardKeyHintsForWidth({
+      alwaysAllowLabel: 'approve bash for session',
+      maxColumns: 50,
+    });
+
+    expect(compact).toEqual([
+      { key: 'y', action: 'approve' },
+      { key: 'n', action: 'reject' },
+      { key: 'a', action: 'bash session' },
+      { key: 'Esc', action: 'cancel' },
+    ]);
+    expect(
+      compact.map((hint) => `${hint.key} ${hint.action}`).join(' · ').length,
+    ).toBeLessThanOrEqual(50);
+  });
+
   it('drops optional approval hints before hiding cancel on narrow terminals', () => {
     expect(
       confirmCardKeyHintsForWidth({

--- a/src/test-kernel/cli/ConfirmCardState.vitest.mts
+++ b/src/test-kernel/cli/ConfirmCardState.vitest.mts
@@ -27,25 +27,33 @@ describe('CLI confirm-card key handling', () => {
     expect(confirmCardKeyAction('a', {}, false)).toBe('ignore');
   });
 
-  it('keeps session-wide approval hints compact enough for approval modals', () => {
+  it('shows scoped session-wide approval hints for approval modals', () => {
     expect(
       confirmCardKeyHints({
-        alwaysAllowLabel: 'approve session',
+        alwaysAllowLabel: 'approve bash for session',
       }),
     ).toEqual([
       { key: 'y', action: 'approve' },
       { key: 'n', action: 'reject' },
-      { key: 'a', action: 'approve session' },
+      { key: 'a', action: 'approve bash for session' },
       { key: 'e', action: 'feedback' },
       { key: 'Esc', action: 'cancel' },
     ]);
 
-    const rendered = confirmCardKeyHints({
-      alwaysAllowLabel: 'approve session',
+    expect(
+      confirmCardKeyHints({
+        alwaysAllowLabel: 'approve edits for session',
+      }),
+    ).toContainEqual({ key: 'a', action: 'approve edits for session' });
+
+    const compactRendered = confirmCardKeyHintsForWidth({
+      alwaysAllowLabel: 'approve bash for session',
+      maxColumns: 72,
     })
       .map((hint) => `${hint.key} ${hint.action}`)
       .join(' · ');
-    expect(rendered.length).toBeLessThanOrEqual(72);
+    expect(compactRendered).toContain('a bash session');
+    expect(compactRendered.length).toBeLessThanOrEqual(72);
   });
 
   it('shows submit/back hints while collecting rejection feedback', () => {
@@ -58,32 +66,41 @@ describe('CLI confirm-card key handling', () => {
   it('compacts long optional approval hints before hiding cancel', () => {
     expect(
       confirmCardKeyHintsForWidth({
-        alwaysAllowLabel: 'approve session',
+        alwaysAllowLabel: 'approve bash for session',
         maxColumns: 80,
       }),
-    ).toEqual(confirmCardKeyHints({ alwaysAllowLabel: 'approve session' }));
+    ).toEqual(
+      confirmCardKeyHints({ alwaysAllowLabel: 'approve bash for session' }),
+    );
 
     const compact = confirmCardKeyHintsForWidth({
-      alwaysAllowLabel: 'approve session',
-      maxColumns: 56,
+      alwaysAllowLabel: 'approve bash for session',
+      maxColumns: 60,
     });
 
     expect(compact).toEqual([
       { key: 'y', action: 'approve' },
       { key: 'n', action: 'reject' },
-      { key: 'a', action: 'session' },
+      { key: 'a', action: 'bash session' },
       { key: 'e', action: 'note' },
       { key: 'Esc', action: 'cancel' },
     ]);
     expect(
       compact.map((hint) => `${hint.key} ${hint.action}`).join(' · ').length,
-    ).toBeLessThanOrEqual(56);
+    ).toBeLessThanOrEqual(60);
+
+    expect(
+      confirmCardKeyHintsForWidth({
+        alwaysAllowLabel: 'approve edits for session',
+        maxColumns: 60,
+      }),
+    ).toContainEqual({ key: 'a', action: 'edit session' });
   });
 
   it('drops optional approval hints before hiding cancel on narrow terminals', () => {
     expect(
       confirmCardKeyHintsForWidth({
-        alwaysAllowLabel: 'approve session',
+        alwaysAllowLabel: 'approve bash for session',
         maxColumns: 42,
       }),
     ).toEqual([
@@ -95,7 +112,7 @@ describe('CLI confirm-card key handling', () => {
 
     expect(
       confirmCardKeyHintsForWidth({
-        alwaysAllowLabel: 'approve session',
+        alwaysAllowLabel: 'approve bash for session',
         maxColumns: 36,
       }),
     ).toEqual([
@@ -106,7 +123,7 @@ describe('CLI confirm-card key handling', () => {
 
     expect(
       confirmCardKeyHintsForWidth({
-        alwaysAllowLabel: 'approve session',
+        alwaysAllowLabel: 'approve bash for session',
         maxColumns: 10,
       }),
     ).toEqual([{ key: 'Esc', action: 'cancel' }]);


### PR DESCRIPTION
## Summary

This PR clarifies the session-wide approval labels shown in the CLI TUI approval modals.

- Bash approvals now show `approve bash for session` instead of the generic `approve session`.
- Tool-edit approvals now show `approve edits for session` instead of the same generic text.
- Compact terminal layouts preserve the scope as `bash session` / `edit session`.
- Mid-width layouts now keep the session-scope `a` hint before the feedback hint, so the visible hints match the live key behavior.

The approval semantics are unchanged. The change only makes the user-visible scope explicit before enabling a session bypass.

## Review Follow-Up

Resolved the review threads by removing the dead bare `approve session` compact-label branch and by adding coverage for the 50-column layout where `a bash session` fits if feedback is dropped first.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ConfirmCardState.vitest.mts src/test-kernel/cli/BashApproval.vitest.mts src/test-kernel/cli/EditApproval.vitest.mts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ConfirmCardState.vitest.mts`
- `corepack pnpm exec eslint packages/cli/src/chat/tui/modals/BashApproval.tsx packages/cli/src/chat/tui/modals/EditApproval.tsx packages/cli/src/chat/tui/modals/ConfirmCardState.ts src/test-kernel/cli/ConfirmCardState.vitest.mts`
- `corepack pnpm exec eslint packages/cli/src/chat/tui/modals/ConfirmCardState.ts src/test-kernel/cli/ConfirmCardState.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- bash-approval edit-approval narrow-edit-approval compact-long-bash-approval`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- bash-approval narrow-bash-approval edit-approval compact-long-bash-approval`
- `git diff --check`
