### PR TITLE
refactor(runtime): own manual compaction admission

### DIFF
--- a/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
+++ b/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
@@ -213,8 +213,8 @@ export async function handleTuiSlashCommand(
     case 'compact':
       requestCliCompaction({
         streamId: cliState.activeStreamId.get(),
-        getFlowContext: (streamId) =>
-          executionRegistry.getToolUseFlowContext(streamId),
+        requestManualCompaction: (streamId) =>
+          executionRegistry.requestManualCompaction(streamId),
         notifyFollowUpSent,
         appendTranscript: appendLocalAssistantTranscript,
       });

--- a/packages/cli/src/chat/tui/state/compactionRequest.ts
+++ b/packages/cli/src/chat/tui/state/compactionRequest.ts
@@ -1,19 +1,12 @@
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { ManualCompactionRequestResult } from '@agent/runtime/executionRegistry';
 import type { StreamTabId } from '@shared/schemas';
-
-interface CliCompactionFlowContext {
-  readonly modelHandler: {
-    readonly supportsManualCompaction: boolean;
-  };
-  readonly runtimeHost?: AgentRuntimeHost;
-  requestImmediateCompaction(): void;
-}
 
 export interface CliCompactionRequestOptions {
   readonly streamId: StreamTabId | undefined;
-  readonly getFlowContext: (
-    streamId: StreamTabId,
-  ) => CliCompactionFlowContext | undefined;
+  readonly requestManualCompaction: (
+    streamId: StreamTabId | undefined,
+  ) => ManualCompactionRequestResult;
   readonly notifyFollowUpSent: (
     streamId: StreamTabId,
     runtimeHost?: AgentRuntimeHost,
@@ -23,31 +16,30 @@ export interface CliCompactionRequestOptions {
 
 export function requestCliCompaction({
   streamId,
-  getFlowContext,
+  requestManualCompaction,
   notifyFollowUpSent,
   appendTranscript,
 }: CliCompactionRequestOptions): void {
-  const flowContext = streamId ? getFlowContext(streamId) : undefined;
-  if (!streamId || !flowContext) {
-    appendTranscript(
-      'No active tool-use session found for context compaction.',
-      streamId,
-    );
-    return;
+  const result = requestManualCompaction(streamId);
+  switch (result.kind) {
+    case 'no_active_tool_use':
+      appendTranscript(
+        'No active tool-use session found for context compaction.',
+        result.streamId,
+      );
+      return;
+    case 'unsupported':
+      appendTranscript(
+        'Manual context compaction is not available for the current model.',
+        result.streamId,
+      );
+      return;
+    case 'requested':
+      notifyFollowUpSent(result.streamId, result.runtimeHost);
+      appendTranscript(
+        'Context compaction requested. The agent will process it on the next model call.',
+        result.streamId,
+      );
+      return;
   }
-
-  if (!flowContext.modelHandler.supportsManualCompaction) {
-    appendTranscript(
-      'Manual context compaction is not available for the current model.',
-      streamId,
-    );
-    return;
-  }
-
-  flowContext.requestImmediateCompaction();
-  notifyFollowUpSent(streamId, flowContext.runtimeHost);
-  appendTranscript(
-    'Context compaction requested. The agent will process it on the next model call.',
-    streamId,
-  );
 }

--- a/packages/extension/src/commands/agent/agentCommands.ts
+++ b/packages/extension/src/commands/agent/agentCommands.ts
@@ -19,24 +19,23 @@ export function stopAgent(streamId: StreamTabId): void {
 }
 
 export async function compactResponse(streamId: StreamTabId): Promise<void> {
-  const flowContext = executionRegistry.getToolUseFlowContext(streamId);
-  if (!flowContext) {
-    await vscode.window.showInformationMessage(
-      'No active tool-use session found for this stream.',
-    );
-    return;
+  const result = executionRegistry.requestManualCompaction(streamId);
+  switch (result.kind) {
+    case 'no_active_tool_use':
+      await vscode.window.showInformationMessage(
+        'No active tool-use session found for this stream.',
+      );
+      return;
+    case 'unsupported':
+      await vscode.window.showInformationMessage(
+        'Manual context compaction is not yet available for this model. Stay tuned!',
+      );
+      return;
+    case 'requested':
+      notifyFollowUpSent(result.streamId, result.runtimeHost);
+      await vscode.window.showInformationMessage(
+        'Context compaction requested. The agent will process it on the next model call.',
+      );
+      return;
   }
-
-  if (!flowContext.modelHandler.supportsManualCompaction) {
-    await vscode.window.showInformationMessage(
-      'Manual context compaction is not yet available for this model. Stay tuned!',
-    );
-    return;
-  }
-
-  flowContext.requestImmediateCompaction();
-  notifyFollowUpSent(streamId, flowContext.runtimeHost);
-  await vscode.window.showInformationMessage(
-    'Context compaction requested. The agent will process it on the next model call.',
-  );
 }

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -85,6 +85,21 @@ export type ToolUseFollowUpTarget =
       readonly streamStatus: StreamStatus | undefined;
     };
 
+export type ManualCompactionRequestResult =
+  | {
+      readonly kind: 'requested';
+      readonly streamId: StreamTabId;
+      readonly runtimeHost?: AgentRuntimeHost;
+    }
+  | {
+      readonly kind: 'unsupported';
+      readonly streamId: StreamTabId;
+    }
+  | {
+      readonly kind: 'no_active_tool_use';
+      readonly streamId?: StreamTabId;
+    };
+
 /**
  * Process-wide owner for active executions and their change listeners.
  *
@@ -327,6 +342,35 @@ export class ExecutionRegistry {
     streamId: StreamTabId,
   ): LiveToolUseFlowContext | undefined {
     return this.getAgentHandleByStream(streamId)?.getToolUseFlow();
+  }
+
+  /**
+   * Request manual compaction from the active tool-use flow, if one exists.
+   *
+   * Hosts own the user-facing message, but the registry owns the live-flow
+   * lookup and model capability test so CLI and extension do not rederive the
+   * same runtime facts.
+   */
+  requestManualCompaction(
+    streamId: StreamTabId | undefined,
+  ): ManualCompactionRequestResult {
+    const context = streamId ? this.getToolUseFlowContext(streamId) : undefined;
+    if (!streamId || !context) {
+      return {
+        kind: 'no_active_tool_use',
+        ...(streamId && { streamId }),
+      };
+    }
+    if (!context.modelHandler.supportsManualCompaction) {
+      return { kind: 'unsupported', streamId };
+    }
+
+    context.requestImmediateCompaction();
+    return {
+      kind: 'requested',
+      streamId,
+      ...(context.runtimeHost && { runtimeHost: context.runtimeHost }),
+    };
   }
 
   /**

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -620,6 +620,83 @@ describe('executionRegistry', () => {
     }
   });
 
+  it('owns manual compaction admission for active tool-use flows', () => {
+    const explicit = createRecordingHost();
+    const registry = new ExecutionRegistry();
+    const streamId = 'stream-manual-compaction-test' as StreamTabId;
+    const unsupportedStreamId =
+      'stream-manual-compaction-unsupported-test' as StreamTabId;
+    const requestImmediateCompaction = vi.fn();
+    const context: LiveToolUseFlowContext = {
+      session: {
+        appendFollowUp: vi.fn(),
+      },
+      modelHandler: {
+        supportsManualCompaction: true,
+      },
+      runtimeHost: explicit.host,
+      requestImmediateCompaction,
+      modelSwitchDisabledReason: vi.fn(),
+      switchModel: vi.fn(),
+    };
+    const unsupportedContext: LiveToolUseFlowContext = {
+      ...context,
+      modelHandler: {
+        supportsManualCompaction: false,
+      },
+      requestImmediateCompaction: vi.fn(),
+    };
+
+    try {
+      expect(registry.requestManualCompaction(undefined)).toEqual({
+        kind: 'no_active_tool_use',
+      });
+      expect(registry.requestManualCompaction(streamId)).toEqual({
+        kind: 'no_active_tool_use',
+        streamId,
+      });
+
+      const handle = new AgentExecutionHandle(
+        'exec-manual-compaction-test',
+        streamId,
+        streamId,
+        'test-tool-use',
+        'toolUse',
+        explicit.host,
+      );
+      handle.attachToolUseFlow(context);
+      registry.track(handle);
+
+      const unsupportedHandle = new AgentExecutionHandle(
+        'exec-manual-compaction-unsupported-test',
+        unsupportedStreamId,
+        unsupportedStreamId,
+        'test-tool-use',
+        'toolUse',
+        explicit.host,
+      );
+      unsupportedHandle.attachToolUseFlow(unsupportedContext);
+      registry.track(unsupportedHandle);
+
+      expect(registry.requestManualCompaction(unsupportedStreamId)).toEqual({
+        kind: 'unsupported',
+        streamId: unsupportedStreamId,
+      });
+      expect(
+        unsupportedContext.requestImmediateCompaction,
+      ).not.toHaveBeenCalled();
+
+      expect(registry.requestManualCompaction(streamId)).toEqual({
+        kind: 'requested',
+        streamId,
+        runtimeHost: explicit.host,
+      });
+      expect(requestImmediateCompaction).toHaveBeenCalledOnce();
+    } finally {
+      registry.dispose();
+    }
+  });
+
   it('owns tool-use follow-up admission from status, context, and children', () => {
     const explicit = createRecordingHost();
     const streamStatus = new StreamStatusRegistry();

--- a/src/test-kernel/cli/CompactionRequest.vitest.mts
+++ b/src/test-kernel/cli/CompactionRequest.vitest.mts
@@ -1,29 +1,24 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import type { ManualCompactionRequestResult } from '@agent/runtime/executionRegistry';
 import { requestCliCompaction } from '@cli/chat/tui/state/compactionRequest';
-
-function compactableFlow() {
-  return {
-    modelHandler: { supportsManualCompaction: true },
-    runtimeHost: undefined,
-    requestImmediateCompaction: vi.fn(),
-  };
-}
 
 describe('requestCliCompaction', () => {
   it('reports a missing active stream without touching follow-up state', () => {
     const appendTranscript = vi.fn();
-    const getFlowContext = vi.fn();
+    const requestManualCompaction = vi.fn(
+      (): ManualCompactionRequestResult => ({ kind: 'no_active_tool_use' }),
+    );
     const notifyFollowUpSent = vi.fn();
 
     requestCliCompaction({
       streamId: undefined,
-      getFlowContext,
+      requestManualCompaction,
       notifyFollowUpSent,
       appendTranscript,
     });
 
-    expect(getFlowContext).not.toHaveBeenCalled();
+    expect(requestManualCompaction).toHaveBeenCalledExactlyOnceWith(undefined);
     expect(notifyFollowUpSent).not.toHaveBeenCalled();
     expect(appendTranscript).toHaveBeenCalledWith(
       'No active tool-use session found for context compaction.',
@@ -33,17 +28,22 @@ describe('requestCliCompaction', () => {
 
   it('reports a stale active stream when no flow context is registered', () => {
     const appendTranscript = vi.fn();
-    const getFlowContext = vi.fn().mockReturnValue(undefined);
+    const requestManualCompaction = vi.fn(
+      (): ManualCompactionRequestResult => ({
+        kind: 'no_active_tool_use',
+        streamId: 'stream-1',
+      }),
+    );
     const notifyFollowUpSent = vi.fn();
 
     requestCliCompaction({
       streamId: 'stream-1',
-      getFlowContext,
+      requestManualCompaction,
       notifyFollowUpSent,
       appendTranscript,
     });
 
-    expect(getFlowContext).toHaveBeenCalledExactlyOnceWith('stream-1');
+    expect(requestManualCompaction).toHaveBeenCalledExactlyOnceWith('stream-1');
     expect(notifyFollowUpSent).not.toHaveBeenCalled();
     expect(appendTranscript).toHaveBeenCalledWith(
       'No active tool-use session found for context compaction.',
@@ -53,21 +53,22 @@ describe('requestCliCompaction', () => {
 
   it('reports models that cannot compact manually', () => {
     const appendTranscript = vi.fn();
-    const flowContext = {
-      modelHandler: { supportsManualCompaction: false },
-      runtimeHost: undefined,
-      requestImmediateCompaction: vi.fn(),
-    };
+    const requestManualCompaction = vi.fn(
+      (): ManualCompactionRequestResult => ({
+        kind: 'unsupported',
+        streamId: 'stream-1',
+      }),
+    );
     const notifyFollowUpSent = vi.fn();
 
     requestCliCompaction({
       streamId: 'stream-1',
-      getFlowContext: vi.fn().mockReturnValue(flowContext),
+      requestManualCompaction,
       notifyFollowUpSent,
       appendTranscript,
     });
 
-    expect(flowContext.requestImmediateCompaction).not.toHaveBeenCalled();
+    expect(requestManualCompaction).toHaveBeenCalledExactlyOnceWith('stream-1');
     expect(notifyFollowUpSent).not.toHaveBeenCalled();
     expect(appendTranscript).toHaveBeenCalledWith(
       'Manual context compaction is not available for the current model.',
@@ -77,17 +78,22 @@ describe('requestCliCompaction', () => {
 
   it('requests compaction and wakes the active tool-use flow', () => {
     const appendTranscript = vi.fn();
-    const flowContext = compactableFlow();
+    const requestManualCompaction = vi.fn(
+      (): ManualCompactionRequestResult => ({
+        kind: 'requested',
+        streamId: 'stream-1',
+      }),
+    );
     const notifyFollowUpSent = vi.fn();
 
     requestCliCompaction({
       streamId: 'stream-1',
-      getFlowContext: vi.fn().mockReturnValue(flowContext),
+      requestManualCompaction,
       notifyFollowUpSent,
       appendTranscript,
     });
 
-    expect(flowContext.requestImmediateCompaction).toHaveBeenCalledOnce();
+    expect(requestManualCompaction).toHaveBeenCalledExactlyOnceWith('stream-1');
     expect(notifyFollowUpSent).toHaveBeenCalledExactlyOnceWith(
       'stream-1',
       undefined,


### PR DESCRIPTION
## Summary

This change moves manual-compaction admission into `ExecutionRegistry`. The runtime now returns an explicit result for the three possible states: a compaction request was accepted, the active model does not support manual compaction, or there is no active tool-use flow.

The CLI and VS Code extension now consume that declarative result and only render their host-specific messages. They no longer repeat live-flow lookup, model capability checks, or direct compaction requests.

## Scope

Addresses the manual-compaction part of #6690. Stop-operation consolidation remains intentionally out of scope so that the runtime/host ownership change stays small and reviewable.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/cli/CompactionRequest.vitest.mts`
- `corepack pnpm exec eslint src/agent/runtime/executionRegistry.ts packages/extension/src/commands/agent/agentCommands.ts packages/cli/src/chat/tui/state/compactionRequest.ts packages/cli/src/chat/tui/commands/handleSlashCommand.ts src/test-kernel/cli/CompactionRequest.vitest.mts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts`
- `corepack pnpm run typecheck`
- `git diff --check`
- `corepack pnpm run lint` (passed with existing warnings outside this slice)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor with focused unit tests; no new auth or data paths, only consolidation of existing compaction trigger logic.
> 
> **Overview**
> Manual context compaction admission moves into **`ExecutionRegistry.requestManualCompaction`**, which returns a **`ManualCompactionRequestResult`** (`requested`, `unsupported`, or `no_active_tool_use`) after resolving the live tool-use flow, checking **`supportsManualCompaction`**, and invoking **`requestImmediateCompaction`** when allowed.
> 
> The **CLI** (`/compact` via `requestCliCompaction`) and **VS Code** (`compactResponse`) no longer call **`getToolUseFlowContext`** or duplicate those checks; they only switch on the result and show host-specific copy, then call **`notifyFollowUpSent`** on success.
> 
> Tests cover registry admission paths and update CLI compaction tests to inject **`requestManualCompaction`** instead of mocking flow context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c2872eaada448578c550acb23c466ab9fac685d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->