### PR TITLE
refactor(runtime): report stop stream outcomes

### DIFF
--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -50,6 +50,30 @@ export interface StopAgentStreamOptions {
   readonly runtimeHost?: AgentRuntimeHost;
 }
 
+export type StopAgentChildPolicy = 'cascade' | 'detach';
+
+export type StopAgentStreamResult =
+  | {
+      readonly kind: 'interrupted';
+      readonly streamId: StreamTabId;
+      readonly childPolicy: StopAgentChildPolicy;
+    }
+  | {
+      readonly kind: 'marked_stopped';
+      readonly streamId: StreamTabId;
+      readonly childPolicy: StopAgentChildPolicy;
+    }
+  | {
+      readonly kind: 'no_target';
+      readonly streamId: StreamTabId;
+      readonly childPolicy: StopAgentChildPolicy;
+    }
+  | {
+      readonly kind: 'missing_runtime_host';
+      readonly streamId: StreamTabId;
+      readonly childPolicy: 'detach';
+    };
+
 export interface KillExecutionOptions {
   readonly detachActiveChildren?: boolean;
 }
@@ -562,18 +586,22 @@ export class ExecutionRegistry {
   stopAgentStream(
     streamId: StreamTabId,
     options: StopAgentStreamOptions = {},
-  ): boolean {
+  ): StopAgentStreamResult {
     const rootHandle = this.getAgentHandleByStream(streamId);
     const runtimeHost = options.runtimeHost ?? rootHandle?.runtimeHost;
+    const childPolicy =
+      options.detachActiveChildren === true ? 'detach' : 'cascade';
     // Shared across the child sweep and the root cascade so each execution in
     // the chain is interrupted exactly once.
     const visited = new Set<string>();
 
     if (options.detachActiveChildren === true) {
       if (!runtimeHost) {
-        throw new Error(
-          'stopAgentStream requires a runtimeHost to detach active children',
-        );
+        return {
+          kind: 'missing_runtime_host',
+          streamId,
+          childPolicy: 'detach',
+        };
       }
       this.detachActiveChildren(streamId, runtimeHost, visited);
     } else {
@@ -590,7 +618,18 @@ export class ExecutionRegistry {
     if (!stopped && runtimeHost) {
       this.streamStatus.set(streamId, STREAM_STATUS.STOPPED, { runtimeHost });
     }
-    return stopped;
+    if (!stopped && !runtimeHost) {
+      return {
+        kind: 'no_target',
+        streamId,
+        childPolicy,
+      };
+    }
+    return {
+      kind: stopped ? 'interrupted' : 'marked_stopped',
+      streamId,
+      childPolicy,
+    };
   }
 
   /** Get active subagent and process children for a parent stream. */

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -107,7 +107,11 @@ describe('executionRegistry', () => {
         registry.stopAgentStream(rootStreamId, {
           runtimeHost: explicit.host,
         }),
-      ).toBe(true);
+      ).toEqual({
+        kind: 'interrupted',
+        streamId: rootStreamId,
+        childPolicy: 'cascade',
+      });
 
       expect(rootInterrupt).toHaveBeenCalledOnce();
       expect(childInterrupt).toHaveBeenCalledOnce();
@@ -287,7 +291,11 @@ describe('executionRegistry', () => {
           detachActiveChildren: true,
           runtimeHost: explicit.host,
         }),
-      ).toBe(true);
+      ).toEqual({
+        kind: 'interrupted',
+        streamId: rootStreamId,
+        childPolicy: 'detach',
+      });
 
       expect(rootInterrupt).toHaveBeenCalledOnce();
       expect(childInterrupt).not.toHaveBeenCalled();
@@ -334,10 +342,53 @@ describe('executionRegistry', () => {
         registry.stopAgentStream(streamId, {
           runtimeHost: explicit.host,
         }),
-      ).toBe(true);
+      ).toEqual({
+        kind: 'interrupted',
+        streamId,
+        childPolicy: 'cascade',
+      });
 
       expect(interrupt).toHaveBeenCalledOnce();
       expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.STOPPED);
+    } finally {
+      registry.dispose();
+    }
+  });
+
+  it('marks an ownerless stream stopped when a host can publish status', () => {
+    const explicit = createRecordingHost();
+    const streamStatus = new StreamStatusRegistry();
+    const registry = new ExecutionRegistry({ streamStatus });
+    const streamId = 'ownerless-stop-policy-test' as StreamTabId;
+
+    try {
+      expect(
+        registry.stopAgentStream(streamId, {
+          runtimeHost: explicit.host,
+        }),
+      ).toEqual({
+        kind: 'marked_stopped',
+        streamId,
+        childPolicy: 'cascade',
+      });
+      expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.STOPPED);
+    } finally {
+      registry.dispose();
+    }
+  });
+
+  it('reports no target when no execution, interrupt, or host owns the stream', () => {
+    const streamStatus = new StreamStatusRegistry();
+    const registry = new ExecutionRegistry({ streamStatus });
+    const streamId = 'missing-stop-target-test' as StreamTabId;
+
+    try {
+      expect(registry.stopAgentStream(streamId)).toEqual({
+        kind: 'no_target',
+        streamId,
+        childPolicy: 'cascade',
+      });
+      expect(streamStatus.get(streamId)).toBeUndefined();
     } finally {
       registry.dispose();
     }
@@ -519,16 +570,20 @@ describe('executionRegistry', () => {
     }
   });
 
-  it('requires a runtime host when detaching without a tracked root handle', () => {
+  it('reports a missing runtime host when detach cannot be applied', () => {
     const registry = new ExecutionRegistry();
     const streamId = 'missing-host-detach-stop-policy-test' as StreamTabId;
 
     try {
-      expect(() =>
+      expect(
         registry.stopAgentStream(streamId, {
           detachActiveChildren: true,
         }),
-      ).toThrow('requires a runtimeHost');
+      ).toEqual({
+        kind: 'missing_runtime_host',
+        streamId,
+        childPolicy: 'detach',
+      });
     } finally {
       registry.dispose();
     }


### PR DESCRIPTION
## Summary

This change makes `ExecutionRegistry.stopAgentStream` return an explicit runtime result instead of a boolean. The stop operation still owns the same side effects, but callers can now distinguish the possible outcomes:

- `interrupted` when a tracked execution or registered interruptible owner was actually interrupted;
- `marked_stopped` when no owner could be interrupted but the host could still publish a stopped status;
- `no_target` when there is no execution, interruptible owner, or host able to own the stop request;
- `missing_runtime_host` when detach mode was requested but no runtime host is available to reparent children.

The runtime remains the owner of stop policy. Hosts still decide their settings and user-facing behavior, while the registry now describes the result declaratively.

## Scope

Addresses the remaining stop-operation consolidation part of #6690. The manual-compaction half was handled by #6802.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts`
- `corepack pnpm exec eslint src/agent/runtime/executionRegistry.ts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts`
- `corepack pnpm run typecheck`
- `git diff --check`
- `corepack pnpm run lint` (passed with existing warnings outside this slice)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent stream termination in the execution registry; behavior is mostly declarative for callers, but incorrect handling of new result kinds could affect stop UX.
> 
> **Overview**
> **`ExecutionRegistry.stopAgentStream`** now returns a **`StopAgentStreamResult`** discriminated union instead of a boolean, so hosts can tell whether the stream was **interrupted**, only **marked_stopped** (status published with no interruptible owner), had **no_target**, or hit **missing_runtime_host** when detach was requested without a runtime host.
> 
> Stop side effects (cascade vs detach child policy, interrupts, status writes) are unchanged. Detach without a **`runtimeHost`** no longer throws; it returns **`missing_runtime_host`**. Each result includes **`streamId`** and **`childPolicy`** (`cascade` | `detach`). Vitest expectations and coverage were updated for the new outcomes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e25db7af30ae2858839dd18b665f1c0ec7fe512. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->