### PR TITLE
refactor(progress): inject run coordinators

### DIFF
--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -16,7 +16,7 @@ import { ProgressWorkflowActionsController } from '@controllers/progressView/Pro
 import { ProgressWorkflowFileActionsController } from '@controllers/progressView/ProgressWorkflowFileActionsController';
 import { getAgent } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
+import type { RunCoordinatorBridge } from '@agent/runtime/runCoordinators';
 import {
   validateExecutionRequest,
   type ExecutionRequest,
@@ -65,6 +65,15 @@ type MessageFor<C extends ProgressViewInboundMessage['command']> = Extract<
   { command: C }
 >;
 
+type ProgressViewCoordinatorBridge = Pick<
+  RunCoordinatorBridge,
+  | 'cancelRetry'
+  | 'clearRetryRequest'
+  | 'resolvePlanApproval'
+  | 'resolveProposal'
+  | 'triggerRetry'
+>;
+
 /**
  * Schema-driven message handler for ProgressView.
  *
@@ -92,6 +101,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     private readonly provider: ProgressViewProvider,
     context: vscode.ExtensionContext,
     private readonly host: PromptHost,
+    private readonly coordinators: ProgressViewCoordinatorBridge,
   ) {
     super('ProgressView', { trackActiveView: true });
 
@@ -281,7 +291,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       [PROGRESS_VIEW_COMMANDS.RETRY_STREAM_REQUEST]: (data) =>
         this.handleRetryStreamRequest(data),
       [PROGRESS_VIEW_COMMANDS.CANCEL_RETRY_REQUEST]: (data) => {
-        runCoordinatorBridge.cancelRetry(data.stream);
+        this.coordinators.cancelRetry(data.stream);
       },
       [PROGRESS_VIEW_COMMANDS.USE_OWN_API_KEY]: (data) =>
         this.handleUseOwnApiKey(data),
@@ -451,6 +461,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       host: new ProgressStreamLifecycleHost(
         this.provider,
         this.workflowFileActionsController,
+        this.coordinators,
       ),
     });
   }
@@ -598,7 +609,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         );
       },
       resolveProposal: (proposalId, result) => {
-        runCoordinatorBridge.resolveProposal(proposalId, result);
+        this.coordinators.resolveProposal(proposalId, result);
       },
       onMissingProposal: (proposalId) => {
         this.logger.warn(
@@ -642,7 +653,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         await setPreferCodexSubscription(false);
       },
       invalidateModelOptionsCache,
-      triggerRetry: (stream) => runCoordinatorBridge.triggerRetry(stream),
+      triggerRetry: (stream) => this.coordinators.triggerRetry(stream),
     });
   }
 
@@ -695,10 +706,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   private async handleRetryStreamRequest(
     data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.RETRY_STREAM_REQUEST>,
   ): Promise<void> {
-    const success = runCoordinatorBridge.triggerRetry(
-      data.stream,
-      data.feedback,
-    );
+    const success = this.coordinators.triggerRetry(data.stream, data.feedback);
     if (!success) {
       await this.host.info(
         'No retryable request is available for this stream yet.',
@@ -807,17 +815,17 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     const { approvalId, action } = data;
     switch (action) {
       case 'approve':
-        runCoordinatorBridge.resolvePlanApproval(approvalId, {
+        this.coordinators.resolvePlanApproval(approvalId, {
           action: 'approve',
         });
         break;
       case 'approve_and_goal':
-        runCoordinatorBridge.resolvePlanApproval(approvalId, {
+        this.coordinators.resolvePlanApproval(approvalId, {
           action: 'approve_and_goal',
         });
         break;
       case 'reject':
-        runCoordinatorBridge.resolvePlanApproval(approvalId, {
+        this.coordinators.resolvePlanApproval(approvalId, {
           action: 'reject',
           feedback: data.feedback,
         });

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -5,6 +5,7 @@ import { computeAgentOptionsData } from '@agent/index';
 import type { AgentTrace } from '@agent/trace';
 import type { IProgressViewBridge } from '@agent/runtime/ProgressViewBridge';
 import { setProgressViewBridge } from '@agent/runtime/ProgressViewBridge';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import { detectWaitingStreams } from '@agent/storage/detectWaitingStreams';
 import {
   BaseWebviewProvider,
@@ -244,6 +245,7 @@ export class ProgressViewProvider
       this,
       context,
       new VscodePromptHost(),
+      defaultSession().coordinators,
     );
 
     ProgressViewProvider._instance = this;

--- a/packages/extension/src/progressView/managers/ProgressStreamLifecycleHost.ts
+++ b/packages/extension/src/progressView/managers/ProgressStreamLifecycleHost.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
+import type { RunCoordinatorBridge } from '@agent/runtime/runCoordinators';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import { isInFlightStatus } from '@common/constants/streamStatus';
@@ -11,6 +11,7 @@ import type { ProgressStreamLifecycleHost as ProgressStreamLifecycleHostPort } f
 import type { ProgressViewProvider } from '../ProgressViewProvider';
 
 type StreamTabId = import('@shared/schemas').StreamTabId;
+type ProgressRetryCoordinator = Pick<RunCoordinatorBridge, 'clearRetryRequest'>;
 
 interface ModelOutputBackupCleaner {
   clearStreamBackups(stream: StreamTabId): void;
@@ -21,6 +22,7 @@ export class ProgressStreamLifecycleHost implements ProgressStreamLifecycleHostP
   constructor(
     private readonly provider: ProgressViewProvider,
     private readonly backupCleaner: ModelOutputBackupCleaner,
+    private readonly coordinators: ProgressRetryCoordinator,
   ) {}
 
   getVisibleStreamIds(): StreamTabId[] {
@@ -39,7 +41,7 @@ export class ProgressStreamLifecycleHost implements ProgressStreamLifecycleHostP
     options: { clearRetryRequest?: boolean } = {},
   ): Promise<void> {
     if (options.clearRetryRequest === true) {
-      runCoordinatorBridge.clearRetryRequest(stream);
+      this.coordinators.clearRetryRequest(stream);
     }
     await vscode.commands.executeCommand('texra.stopAgent', stream);
   }

--- a/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
+++ b/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
@@ -1,6 +1,9 @@
 // Third-party imports
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+// Local imports - agent runtime
+import type { RunCoordinatorBridge } from '@agent/runtime/runCoordinators';
+
 // Local imports - progress view
 import { ProgressViewMessageHandler } from '@progressView/ProgressViewMessageHandler';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
@@ -37,6 +40,37 @@ function createWebviewView(): vscode.WebviewView {
 type ProgressViewProviderFake = ProgressViewProvider & {
   refreshOnboardingFunnel: ReturnType<typeof vi.fn>;
 };
+
+type CoordinatorBridgeFake = Pick<
+  RunCoordinatorBridge,
+  | 'cancelRetry'
+  | 'clearRetryRequest'
+  | 'resolvePlanApproval'
+  | 'resolveProposal'
+  | 'triggerRetry'
+>;
+
+function createCoordinatorBridge(
+  overrides: Partial<CoordinatorBridgeFake> = {},
+): CoordinatorBridgeFake {
+  return {
+    cancelRetry: vi.fn(() => false),
+    clearRetryRequest: vi.fn(),
+    resolvePlanApproval: vi.fn(() => false),
+    resolveProposal: vi.fn(() => false),
+    triggerRetry: vi.fn(() => true),
+    ...overrides,
+  };
+}
+
+function createMessageHandler(
+  provider: ProgressViewProvider,
+  context: vscode.ExtensionContext,
+  host = new FakePromptHost(),
+  coordinators = createCoordinatorBridge(),
+): ProgressViewMessageHandler {
+  return new ProgressViewMessageHandler(provider, context, host, coordinators);
+}
 
 function createProgressViewProvider(): ProgressViewProviderFake {
   const snapshots = {
@@ -97,11 +131,7 @@ describe('progress-view onboarding refresh wiring', () => {
     const context = createExtensionContext();
     const provider = createProgressViewProvider();
     provider.refreshOnboardingFunnel.mockResolvedValue(undefined);
-    const handler = new ProgressViewMessageHandler(
-      provider,
-      context,
-      new FakePromptHost(),
-    );
+    const handler = createMessageHandler(provider, context);
 
     await handler.handleMessage(
       {
@@ -138,11 +168,7 @@ describe('progress-view onboarding refresh wiring', () => {
     async (action) => {
       const context = createExtensionContext();
       const provider = createProgressViewProvider();
-      const handler = new ProgressViewMessageHandler(
-        provider,
-        context,
-        new FakePromptHost(),
-      );
+      const handler = createMessageHandler(provider, context);
 
       await handler.handleMessage(
         {
@@ -171,7 +197,7 @@ describe('progress-view onboarding refresh wiring', () => {
       }
     ).keys = vi.fn(() => []);
 
-    const handler = new ProgressViewMessageHandler(provider, context, prompt);
+    const handler = createMessageHandler(provider, context, prompt);
 
     await handler.handleMessage(
       { command: PROGRESS_VIEW_COMMANDS.DELETE_ALL },
@@ -198,6 +224,124 @@ describe('progress-view onboarding refresh wiring', () => {
     expect(provider.webviewBridge.clearAll).toHaveBeenCalledOnce();
     expect(provider.syncFullView).toHaveBeenCalledWith({
       forceRebuild: true,
+    });
+  });
+
+  it('routes retry request actions through the injected coordinators', async () => {
+    const context = createExtensionContext();
+    const provider = createProgressViewProvider();
+    const coordinators = createCoordinatorBridge();
+    const handler = createMessageHandler(
+      provider,
+      context,
+      new FakePromptHost(),
+      coordinators,
+    );
+
+    await handler.handleMessage(
+      {
+        command: PROGRESS_VIEW_COMMANDS.RETRY_STREAM_REQUEST,
+        stream: 'stream-a',
+        feedback: 'try the other branch',
+      },
+      createWebviewView(),
+    );
+    await handler.handleMessage(
+      {
+        command: PROGRESS_VIEW_COMMANDS.CANCEL_RETRY_REQUEST,
+        stream: 'stream-a',
+      },
+      createWebviewView(),
+    );
+
+    expect(coordinators.triggerRetry).toHaveBeenCalledWith(
+      'stream-a',
+      'try the other branch',
+    );
+    expect(coordinators.cancelRetry).toHaveBeenCalledWith('stream-a');
+  });
+
+  it('reports missing retry requests from the injected coordinators', async () => {
+    const context = createExtensionContext();
+    const provider = createProgressViewProvider();
+    const prompt = new FakePromptHost();
+    const coordinators = createCoordinatorBridge({
+      triggerRetry: vi.fn(() => false),
+    });
+    const handler = createMessageHandler(
+      provider,
+      context,
+      prompt,
+      coordinators,
+    );
+
+    await handler.handleMessage(
+      {
+        command: PROGRESS_VIEW_COMMANDS.RETRY_STREAM_REQUEST,
+        stream: 'stream-a',
+      },
+      createWebviewView(),
+    );
+
+    expect(prompt.messages).toContainEqual({
+      kind: 'info',
+      message: 'No retryable request is available for this stream yet.',
+    });
+  });
+
+  it('routes agent proposal actions through the injected coordinators', async () => {
+    const context = createExtensionContext();
+    const provider = createProgressViewProvider();
+    const coordinators = createCoordinatorBridge();
+    const handler = createMessageHandler(
+      provider,
+      context,
+      new FakePromptHost(),
+      coordinators,
+    );
+
+    await handler.handleMessage(
+      {
+        command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
+        proposalId: 'proposal-a',
+        action: 'approve',
+        model: 'gemini31p',
+        agent: 'critic',
+      },
+      createWebviewView(),
+    );
+
+    expect(coordinators.resolveProposal).toHaveBeenCalledWith('proposal-a', {
+      action: 'approve',
+      model: 'gemini31p',
+      agent: 'critic',
+    });
+  });
+
+  it('routes plan approval actions through the injected coordinators', async () => {
+    const context = createExtensionContext();
+    const provider = createProgressViewProvider();
+    const coordinators = createCoordinatorBridge();
+    const handler = createMessageHandler(
+      provider,
+      context,
+      new FakePromptHost(),
+      coordinators,
+    );
+
+    await handler.handleMessage(
+      {
+        command: PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION,
+        approvalId: 'plan-a',
+        action: 'reject',
+        feedback: 'state the invariant first',
+      },
+      createWebviewView(),
+    );
+
+    expect(coordinators.resolvePlanApproval).toHaveBeenCalledWith('plan-a', {
+      action: 'reject',
+      feedback: 'state the invariant first',
     });
   });
 


### PR DESCRIPTION
## Summary

This moves progress-view approval and retry resolution off the process-global `runCoordinatorBridge` import and onto an explicit coordinator dependency supplied by `ProgressViewProvider`.

`ProgressViewProvider` is the extension-side owner of the progress surface, so it now passes `defaultSession().coordinators` into `ProgressViewMessageHandler`. The message handler and stream lifecycle host use that injected bridge for retry cancellation, retry triggering, proposal resolution, plan approval resolution, and retry cleanup.

## Design Effect

This is a behavior-preserving ownership step toward #6692. The progress view no longer reconstructs the runtime owner by importing the global bridge directly. Instead, the owner is explicit at construction time, and tests can substitute a fake coordinator bridge to check that UI actions are routed through the boundary.

This does not introduce a new pass-through controller. The existing `SessionHandle` / `RunCoordinatorBridge` owner remains the single runtime coordination object; the progress view simply receives it rather than reaching for the global instance.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts`
- `corepack pnpm exec eslint packages/extension/src/progressView/ProgressViewMessageHandler.ts packages/extension/src/progressView/ProgressViewProvider.ts packages/extension/src/progressView/managers/ProgressStreamLifecycleHost.ts src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts`
- `corepack pnpm run typecheck`
- `git diff --check`
- `corepack pnpm run lint` (passes with the existing 33 warnings outside this change)

Refs #6692.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only wiring with no new runtime logic; production still uses `defaultSession().coordinators` as before.
> 
> **Overview**
> Progress view **retry, proposal, and plan-approval** handling no longer imports the process-global `runCoordinatorBridge`. Those UI paths now call an injected **`RunCoordinatorBridge` slice** (`cancelRetry`, `clearRetryRequest`, `triggerRetry`, `resolveProposal`, `resolvePlanApproval`).
> 
> **`ProgressViewProvider`** wires the bridge at construction via `defaultSession().coordinators` into **`ProgressViewMessageHandler`** and **`ProgressStreamLifecycleHost`** (retry cleanup on stop). Behavior is unchanged; ownership is explicit for #6692.
> 
> Tests add a **`createCoordinatorBridge`** fake and assert message-handler routing for retries (including the “no retryable request” info prompt), agent proposals, and plan approvals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98e674ba12e5db7ed8907f02566840db3d9c37eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->