### PR TITLE
refactor(runtime): declare follow-up wake outcomes

### DIFF
--- a/packages/extension/src/commands/agent/followUpCommand.ts
+++ b/packages/extension/src/commands/agent/followUpCommand.ts
@@ -6,9 +6,9 @@ import { shouldProbePersistedFlowForFollowUp } from '@agent/runtime/followUpResu
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
   sendFollowUp,
+  wakeQueuedFollowUpStream,
   type SendFollowUpResult,
 } from '@agent/followUp/ToolUseFollowUp';
-import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import { hasPersistedFlowRecord } from '@agent/storage/detectWaitingStreams';
 import { registerCommands } from '@commands/_shared/registerCommands';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
@@ -16,8 +16,6 @@ import { createChannelTrace } from '@logger';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import { STREAM_STATUS } from '@shared/schemas';
 import type { StreamTabId } from '@shared/schemas';
-
-import { tryResumeFromSnapshot } from './resumeFromSnapshot';
 
 const logger = createChannelTrace('followUpCommand');
 
@@ -70,30 +68,22 @@ async function handleFollowUpResult(
       break;
     case 'queued':
       extensionAgentRuntimeHost.emit('updateQueuedFollowUps', { streamId });
-      if (result.reason === 'waiting' || result.reason === 'children_running') {
-        const resumed = await tryResumeFromSnapshot(streamId);
-        // tryResumeFromSnapshot also returns false when the stream is
-        // already active/resuming — another consumer is on the way, so
-        // neither branch below should drop the queue or warn the user.
-        if (!resumed && !StreamStatusService.isActiveOrResuming(streamId)) {
-          if (result.reason === 'children_running') {
-            // sendFollowUp force-reopened a released queue on behalf of the
-            // auto-resume attempt. Re-release drops the just-enqueued message
-            // too, but that's the lesser evil — leaving the queue open would
-            // leak late child deliveries into the next run on this stream.
-            ToolUseFollowUpQueue.release(streamId);
-            extensionAgentRuntimeHost.emit('updateQueuedFollowUps', {
-              streamId,
-            });
-            await vscode.window.showWarningMessage(
-              'Message dropped — no session available to receive it. Start a new agent task to continue.',
-            );
-          } else {
-            await vscode.window.showInformationMessage(
-              'Message queued. Auto-resume failed — start a new agent task to continue.',
-            );
-          }
-        }
+      switch ((await wakeQueuedFollowUpStream(streamId, result)).kind) {
+        case 'dropped':
+          extensionAgentRuntimeHost.emit('updateQueuedFollowUps', {
+            streamId,
+          });
+          await vscode.window.showWarningMessage(
+            'Message dropped — no session available to receive it. Start a new agent task to continue.',
+          );
+          break;
+        case 'queued_resume_failed':
+          await vscode.window.showInformationMessage(
+            'Message queued. Auto-resume failed — start a new agent task to continue.',
+          );
+          break;
+        default:
+          break;
       }
       break;
     case 'no_session':

--- a/src/agent/followUp/ToolUseFollowUp.ts
+++ b/src/agent/followUp/ToolUseFollowUp.ts
@@ -34,7 +34,16 @@ export type SendFollowUpResult =
     }
   | { status: 'no_session'; streamStatus: string | undefined };
 
-/** In-flight resume attempts per stream — see {@link wakeOrReleaseQueuedStream}. */
+export type FollowUpWakeResult =
+  | { kind: 'not_required' }
+  | { kind: 'queued_without_wake' }
+  | { kind: 'resumed' }
+  | { kind: 'resume_in_flight' }
+  | { kind: 'active_or_resuming' }
+  | { kind: 'queued_resume_failed' }
+  | { kind: 'dropped' };
+
+/** In-flight resume attempts per stream — see {@link wakeQueuedFollowUpStream}. */
 const wakeAttempts = new Map<StreamTabId, Promise<boolean>>();
 
 /**
@@ -45,18 +54,20 @@ const wakeAttempts = new Map<StreamTabId, Promise<boolean>>();
  * non-in-flight stream), re-release the force-reopened queue so late
  * deliveries don't leak into the next run on that stream.
  *
- * Returns false when the queued item was dropped by the re-release; callers
- * should treat the delivery as failed and rely on their durable copy.
+ * Returns a declarative outcome so hosts can map queue/wake policy to their
+ * own user-facing messages without reconstructing the release rules.
  */
-export async function wakeOrReleaseQueuedStream(
+export async function wakeQueuedFollowUpStream(
   streamId: StreamTabId,
   result: SendFollowUpResult,
-): Promise<boolean> {
+): Promise<FollowUpWakeResult> {
   if (
     result.status !== 'queued' ||
     (result.reason !== 'waiting' && result.reason !== 'children_running')
   ) {
-    return true;
+    return result.status === 'queued'
+      ? { kind: 'queued_without_wake' }
+      : { kind: 'not_required' };
   }
   // Serialize wakes per stream: hosts report an already-in-flight resume as
   // `false`, indistinguishable from "unresumable", and may not have set
@@ -72,16 +83,31 @@ export async function wakeOrReleaseQueuedStream(
     wakeAttempts.set(streamId, attempt);
   }
   const resumed = await attempt;
-  if (
-    resumed ||
-    result.reason !== 'children_running' ||
-    resumePort.isResumeInFlight?.(streamId) === true ||
-    StreamStatusService.isActiveOrResuming(streamId)
-  ) {
-    return true;
+  if (resumed) {
+    return { kind: 'resumed' };
+  }
+  if (resumePort.isResumeInFlight?.(streamId) === true) {
+    return { kind: 'resume_in_flight' };
+  }
+  if (StreamStatusService.isActiveOrResuming(streamId)) {
+    return { kind: 'active_or_resuming' };
+  }
+  if (result.reason !== 'children_running') {
+    return { kind: 'queued_resume_failed' };
   }
   ToolUseFollowUpQueue.release(streamId);
-  return false;
+  return { kind: 'dropped' };
+}
+
+/**
+ * Compatibility view for tool paths that only need to know whether the queued
+ * item survived. UI callers should prefer {@link wakeQueuedFollowUpStream}.
+ */
+export async function wakeOrReleaseQueuedStream(
+  streamId: StreamTabId,
+  result: SendFollowUpResult,
+): Promise<boolean> {
+  return (await wakeQueuedFollowUpStream(streamId, result)).kind !== 'dropped';
 }
 
 const logger = createChannelTrace('ToolUseFollowUp');

--- a/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
@@ -10,6 +10,7 @@ import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
   AgentExecutionHandle,
   executionRegistry,
@@ -17,12 +18,13 @@ import {
 } from '@agent/runtime/executionRegistry';
 import {
   sendFollowUp,
+  wakeQueuedFollowUpStream,
   wakeOrReleaseQueuedStream,
 } from '@agent/followUp/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import type { FollowUpQueueInput } from '@agent/followUp/FollowUpQueue';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
-import type { StreamTabId } from '@shared/schemas';
+import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 
 describe('ToolUseFollowUp', () => {
   const streamId = 'stream-follow-up' as StreamTabId;
@@ -110,6 +112,20 @@ describe('ToolUseFollowUp', () => {
     assert.deepEqual(calls, [
       { text: 'subagent result', origin: 'subagent_result' },
     ]);
+  });
+
+  it('reports unknown streams as no session', async () => {
+    const missingStreamId = 'missing-follow-up-session' as StreamTabId;
+
+    const result = await sendFollowUp(missingStreamId, 'hello');
+
+    assert.deepEqual(result, {
+      status: 'no_session',
+      streamStatus: undefined,
+    });
+    assert.deepEqual(await wakeQueuedFollowUpStream(missingStreamId, result), {
+      kind: 'not_required',
+    });
   });
 
   it('queues follow-ups when children are still running', async () => {
@@ -312,14 +328,50 @@ describe('ToolUseFollowUp', () => {
         reason: 'children_running',
       });
 
-      assert.equal(
-        await wakeOrReleaseQueuedStream(parentStreamId, result),
-        false,
-      );
+      assert.deepEqual(await wakeQueuedFollowUpStream(parentStreamId, result), {
+        kind: 'dropped',
+      });
       assert.deepEqual(ToolUseFollowUpQueue.getAll(parentStreamId), []);
     } finally {
       executionRegistry.untrack(executionId);
       ToolUseFollowUpQueue.release(parentStreamId);
+    }
+  });
+
+  it('reports failed waiting-stream wakes without dropping the queue', async () => {
+    const waitingStreamId = 'parent-stream-wake-waiting' as StreamTabId;
+
+    const { initPlatform } = await import('@platform/platform');
+    initPlatform(
+      createFakePlatform(
+        {},
+        { agentResume: { tryResumeStream: async () => false } },
+      ),
+    );
+    StreamStatusService.set(waitingStreamId, STREAM_STATUS.WAITING, {
+      emit: false,
+    });
+
+    try {
+      const result = await sendFollowUp(
+        waitingStreamId,
+        'queued while waiting',
+      );
+      assert.deepEqual(result, {
+        status: 'queued',
+        reason: 'waiting',
+      });
+
+      assert.deepEqual(
+        await wakeQueuedFollowUpStream(waitingStreamId, result),
+        { kind: 'queued_resume_failed' },
+      );
+      assert.deepEqual(ToolUseFollowUpQueue.getAll(waitingStreamId), [
+        'queued while waiting',
+      ]);
+    } finally {
+      StreamStatusService.clear(waitingStreamId, { emit: false });
+      ToolUseFollowUpQueue.release(waitingStreamId);
     }
   });
 


### PR DESCRIPTION
## Summary

This moves extension follow-up wake and queue-release policy behind the shared runtime follow-up helper.

`wakeQueuedFollowUpStream(...)` now returns an explicit `FollowUpWakeResult` for resumed, in-flight, active/resuming, queued-resume-failed, dropped, and no-op outcomes. The previous boolean `wakeOrReleaseQueuedStream(...)` remains as a compatibility view for non-UI callers.

The VS Code follow-up command now consumes the shared wake result and keeps only host-specific effects: queued-follow-up refreshes and user messages. It no longer imports `ToolUseFollowUpQueue` or calls the extension resume helper directly to reconstruct queue lifetime policy.

## Design Effect

This is a narrow step toward #6691. Runtime owns whether a queued follow-up should wake a stream, remain queued, or be dropped. The extension maps those declared states to UI notifications without knowing the release rules.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts`
- `corepack pnpm exec eslint src/agent/followUp/ToolUseFollowUp.ts packages/extension/src/commands/agent/followUpCommand.ts src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts`
- `corepack pnpm run typecheck`
- `corepack pnpm run lint` (passes with the existing 33 warnings)
- `git diff --check`

Closes #6691.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes follow-up delivery and queue lifecycle on agent streams; behavior is covered by tests but incorrect mapping could drop or mis-notify queued messages.
> 
> **Overview**
> Moves follow-up **wake and queue-release policy** into shared runtime via **`wakeQueuedFollowUpStream`**, which returns explicit **`FollowUpWakeResult`** kinds (`resumed`, `dropped`, `queued_resume_failed`, etc.) instead of a single boolean. **`wakeOrReleaseQueuedStream`** remains as a thin compatibility wrapper for callers that only need “not dropped.”
> 
> The VS Code **`followUpCommand`** now calls the shared helper and maps **`dropped`** / **`queued_resume_failed`** to the existing user messages. It no longer imports **`ToolUseFollowUpQueue`**, calls **`tryResumeFromSnapshot`**, or re-implements release rules when auto-resume fails.
> 
> Tests assert the new wake outcomes, including **waiting** streams that stay queued on failed wake and **children_running** paths that drop the queue when resume is impossible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3feb7fbf2cfefb5b15dbc264db5f8b477c1819d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->