### PR TITLE
[codex] fix retired model availability

### DIFF
--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -115,6 +115,7 @@ const RELAY_STATUS_BY_AVAILABILITY = {
   'openrouter-key': 'relay: unavailable; openrouter key set',
   'missing-key': 'relay: unavailable; missing api key',
   'subscription-access': 'chatgpt subscription',
+  retired: 'retired',
 } satisfies Record<ModelAvailabilityKind, string>;
 
 const NO_RUNNABLE_MODEL_ACCESS_COPY = {
@@ -348,7 +349,12 @@ function toCliModelAccess(
 }
 
 function toIncludedLoginRequiredAccess(entry: CliModelAccess): CliModelAccess {
-  if (entry.model.availability === 'subscription-access') return entry;
+  if (
+    entry.model.availability === 'subscription-access' ||
+    entry.model.availability === 'retired'
+  ) {
+    return entry;
+  }
   return {
     model: {
       ...entry.model,
@@ -483,6 +489,8 @@ function formatCliModelRecovery(
       return apiMode === 'personal'
         ? `${startSentence(configureKeyAction)} for personal mode.`
         : `${startSentence(configureKeyAction)}, then ${personalModeAction}.`;
+    case 'retired':
+      return 'Choose an active model.';
     default:
       return undefined;
   }

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -100,6 +100,11 @@ const AVAILABILITY_STATUS_FIELDS: Record<
     available: false,
     requiresKey: false,
   },
+  retired: {
+    label: 'Retired',
+    available: false,
+    requiresKey: false,
+  },
 };
 
 /** Resolve a full availability status from its kind. */
@@ -165,6 +170,10 @@ async function resolveModelAvailability(
   config: ModelConfig,
   ctx: ModelAvailabilityContext,
 ): Promise<ModelAvailabilityStatus> {
+  if (config.retired) {
+    return availabilityStatus('retired');
+  }
+
   // ChatGPT subscription (Codex) is a preference, not a hard requirement. When
   // the host is not signed in, continue through the normal API-key/relay paths
   // so the switch cannot disable models that are otherwise runnable.
@@ -283,6 +292,10 @@ export async function getModelUnavailableReason(
   const ctx = await buildAvailabilityContext(effectiveAccess, access == null);
   const availability = await resolveModelAvailability(model, config, ctx);
   if (availability.available) return null;
+
+  if (availability.kind === 'retired') {
+    return `Model "${model}" is retired and no longer available from its provider. Choose an active model.`;
+  }
 
   if (shouldRouteModelThroughOpenRouter(config, ctx.useOpenRouter)) {
     return `Model "${model}" requires an OpenRouter API key.`;

--- a/src/model/modelListRefresh.ts
+++ b/src/model/modelListRefresh.ts
@@ -3,6 +3,7 @@ import { GlobalStateKey } from '@shared/state/stateKeys';
 import {
   DEFAULT_MODELS,
   isDeprecatedModel,
+  isRetiredModel,
   MODEL_LIST_VERSION,
 } from './modelOptionsBasic';
 
@@ -58,9 +59,20 @@ function reconcileEnabledModels(
     }
   }
 
+  // Retired models are hard unavailable even for users with included relay
+  // access. Strip them whenever this refresh version is crossed.
+  if ((previousVersion ?? 0) < 21) {
+    for (const model of currentModels) {
+      if (isRetiredModel(model)) strippedSet.add(model);
+    }
+  }
+
   const kept = currentModels.filter((model) => !strippedSet.has(model));
   const added = DEFAULT_MODELS.filter(
-    (model) => !kept.includes(model) && !isDeprecatedModel(model),
+    (model) =>
+      !kept.includes(model) &&
+      !isDeprecatedModel(model) &&
+      !isRetiredModel(model),
   );
 
   return {

--- a/src/model/modelOptionsBasic.ts
+++ b/src/model/modelOptionsBasic.ts
@@ -24,7 +24,7 @@ export const DEFAULT_MODELS = [
 ];
 
 /** Increment when the persisted model list needs reconciliation. */
-export const MODEL_LIST_VERSION = 20;
+export const MODEL_LIST_VERSION = 21;
 
 const MILLION = 1_000_000;
 const THOUSAND = 1_000;
@@ -32,6 +32,11 @@ const THOUSAND = 1_000;
 /** Return whether the registry marks a model as deprecated. */
 export function isDeprecatedModel(model: string): boolean {
   return MODEL_CONFIGS[model]?.deprecated ?? false;
+}
+
+/** Return whether the registry marks a model as no longer served. */
+export function isRetiredModel(model: string): boolean {
+  return MODEL_CONFIGS[model]?.retired ?? false;
 }
 
 /** Format context window number for display. */

--- a/src/shared/schemas/mainView/state.ts
+++ b/src/shared/schemas/mainView/state.ts
@@ -48,6 +48,7 @@ export const ModelAvailabilityKindSchema = z.enum([
   'not-included',
   'included-login-required',
   'relay-quota-exhausted',
+  'retired',
   // ChatGPT-subscription (Codex) access via the user's own OAuth session. Kept
   // distinct from relay `included-access` because it is the user's own
   // credential and runs regardless of relay-vs-personal API mode.

--- a/src/test-kernel/cli/ModelAccess.vitest.mts
+++ b/src/test-kernel/cli/ModelAccess.vitest.mts
@@ -837,6 +837,72 @@ describe('CLI model access resolution', () => {
     expect(text).not.toContain('`--api-mode included`');
   });
 
+  it('shows terminal recovery text for retired models in model details', () => {
+    const text = formatCliModelDetails(
+      model('haiku3', {
+        available: false,
+        status: 'retired',
+        model: modelOption('haiku3', {
+          label: 'Haiku 3',
+          availability: 'retired',
+          availabilityLabel: 'Retired',
+          disabled: true,
+        }),
+      }),
+      'included',
+    );
+
+    expect(text).toContain('status: retired');
+    expect(text).toContain('availability: Retired');
+    expect(text).toContain('recovery: Choose an active model.');
+    expect(text).not.toContain('texra setup');
+  });
+
+  it('rejects explicit retired hidden models before fallback', async () => {
+    computeModelOptionsDataMock.mockResolvedValueOnce([
+      modelOption('haiku3', {
+        label: 'Haiku 3',
+        availability: 'retired',
+        availabilityLabel: 'Retired',
+        disabled: true,
+        requiresKey: false,
+      }),
+    ]);
+
+    await expect(
+      resolveCliRunnableModel('haiku3', {
+        fallbackSource: 'override',
+        apiMode: 'included',
+        accessList: [],
+      }),
+    ).rejects.toThrow(
+      'Model "haiku3" is not available in the active API mode (retired).',
+    );
+  });
+
+  it('does not mask explicit retired models behind included login', async () => {
+    mocks.authProvider.isAuthenticated.mockResolvedValue(false);
+    computeModelOptionsDataMock.mockResolvedValueOnce([
+      modelOption('haiku3', {
+        label: 'Haiku 3',
+        availability: 'retired',
+        availabilityLabel: 'Retired',
+        disabled: true,
+        requiresKey: false,
+      }),
+    ]);
+
+    await expect(
+      resolveCliRunnableModel('haiku3', {
+        fallbackSource: 'override',
+        apiMode: 'included',
+        accessList: [],
+      }),
+    ).rejects.toThrow(
+      'Model "haiku3" is not available in the active API mode (retired).',
+    );
+  });
+
   it('shows a recovery hint for missing provider-key models in model details', () => {
     const text = formatCliModelDetails(
       model('glm52', {

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -1701,6 +1701,7 @@ describe('desktop settings IPC', () => {
       'custom-model',
       'gpt54pro',
       'opus46T',
+      'haiku3',
     ]);
     const errors: unknown[] = [];
 
@@ -1718,6 +1719,39 @@ describe('desktop settings IPC', () => {
     );
     const expectedDefaults = DEFAULT_MODELS.filter(
       (model) => !(MODEL_CONFIGS[model]?.deprecated ?? false),
+    );
+    expect(globalState.values.get(GlobalStateKey.ENABLED_MODELS)).toEqual([
+      'custom-model',
+      ...expectedDefaults,
+    ]);
+  });
+
+  it('strips retired models from recent persisted model lists', async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    const globalState = new MemoryStateStore();
+    globalState.values.set(GlobalStateKey.MODEL_LIST_VERSION, 20);
+    globalState.values.set(GlobalStateKey.ENABLED_MODELS, [
+      'custom-model',
+      'haiku3',
+    ]);
+    const errors: unknown[] = [];
+
+    createDesktopSettingsIpc({
+      workspaceState: new MemoryStateStore(),
+      globalState,
+      postToRenderer: () => {},
+      onError: (error) => errors.push(error),
+    });
+    await flushAsyncWork();
+
+    expect(errors).toEqual([]);
+    expect(globalState.values.get(GlobalStateKey.MODEL_LIST_VERSION)).toBe(
+      MODEL_LIST_VERSION,
+    );
+    const expectedDefaults = DEFAULT_MODELS.filter(
+      (model) =>
+        !(MODEL_CONFIGS[model]?.deprecated ?? false) &&
+        !(MODEL_CONFIGS[model]?.retired ?? false),
     );
     expect(globalState.values.get(GlobalStateKey.ENABLED_MODELS)).toEqual([
       'custom-model',

--- a/src/test-kernel/model/ComputeModelOptions.vitest.ts
+++ b/src/test-kernel/model/ComputeModelOptions.vitest.ts
@@ -23,6 +23,8 @@ import { AgentCategory } from '@shared/schemas/agent';
 
 function createServerSideKeyService(options: {
   useIncludedAccess: boolean;
+  readonly canUseServerSideKeys?: boolean;
+  readonly canUseModelSync?: boolean;
   readonly relayQuotaExceeded: boolean;
   readonly quotaAutoSwitched: boolean;
   readonly autoSwitchDuringAccessCheck?: boolean;
@@ -34,13 +36,13 @@ function createServerSideKeyService(options: {
       if (options.autoSwitchDuringAccessCheck) {
         options.useIncludedAccess = false;
       }
-      return false;
+      return options.canUseServerSideKeys ?? false;
     },
     getUseIncludedModelAccess: () => options.useIncludedAccess,
     isRelayQuotaExceeded: () => options.relayQuotaExceeded,
     wasQuotaAutoSwitched: () => options.quotaAutoSwitched,
     isProviderOnServer: () => true,
-    canUseModelSync: () => false,
+    canUseModelSync: () => options.canUseModelSync ?? false,
   };
 }
 
@@ -150,6 +152,29 @@ describe('computeModelOptionsData relay quota state', () => {
 
     expect(model.availability).toBe('missing-key');
     expect(model.disabled).toBe(true);
+  });
+
+  it('marks retired models unavailable before included-access checks', async () => {
+    const access = createModelOptionsAccess({
+      useIncludedAccess: true,
+      canUseServerSideKeys: true,
+      canUseModelSync: true,
+      relayQuotaExceeded: false,
+      quotaAutoSwitched: false,
+    });
+
+    const [model] = await computeModelOptionsData(['haiku3'], access);
+    const reason = await getModelUnavailableReason('haiku3', access);
+
+    expect(model).toMatchObject({
+      availability: 'retired',
+      availabilityLabel: 'Retired',
+      disabled: true,
+      requiresKey: false,
+    });
+    expect(reason).toBe(
+      'Model "haiku3" is retired and no longer available from its provider. Choose an active model.',
+    );
   });
 
   it('does not tell users to configure API keys for keyless providers', async () => {

--- a/src/test-kernel/model/ModelOptionsBasic.vitest.ts
+++ b/src/test-kernel/model/ModelOptionsBasic.vitest.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { MODEL_CONFIGS } from 'llm-zoo';
 
 // Local imports - model
-import { DEFAULT_MODELS } from '@model/modelOptionsBasic';
+import { DEFAULT_MODELS, isRetiredModel } from '@model/modelOptionsBasic';
 import { DEFAULT_HELPER_MODEL } from '@shared/constants/providers';
 
 describe('default helper model', () => {
@@ -50,5 +50,9 @@ describe('default model list', () => {
 
   it('only contains model ids known by llm-zoo', () => {
     expect(DEFAULT_MODELS.filter((model) => !MODEL_CONFIGS[model])).toEqual([]);
+  });
+
+  it('does not include retired models', () => {
+    expect(DEFAULT_MODELS.filter(isRetiredModel)).toEqual([]);
   });
 });

--- a/src/test-kernel/supabase/RelayModelAccess.vitest.ts
+++ b/src/test-kernel/supabase/RelayModelAccess.vitest.ts
@@ -11,6 +11,7 @@ import {
   TIER_CONFIG,
   ULTRA_TIER,
   isModelAllowedForTier,
+  isRetiredModelRequest,
 } from '../../../supabase/functions/relay/models';
 
 describe('relay tier model access', () => {
@@ -33,5 +34,24 @@ describe('relay tier model access', () => {
     assert.equal(isModelAllowedForTier(FREE_TIER, 'gpt-5-2025-08-07'), false);
     assert.equal(isModelAllowedForTier(FREE_TIER, 'unknown-model'), false);
     assert.equal(isModelAllowedForTier(FREE_TIER, null), false);
+  });
+
+  it('denies retired registry models for relay passthrough tiers', () => {
+    assert.equal(isRetiredModelRequest('haiku3'), true);
+    assert.equal(
+      isRetiredModelRequest('anthropic/claude-3.5-haiku-20240307:beta'),
+      true,
+    );
+    assert.equal(isRetiredModelRequest('unknown-model'), false);
+
+    assert.equal(
+      isModelAllowedForTier(MAX_TIER, 'claude-3-haiku-20240307'),
+      false,
+    );
+    assert.equal(
+      isModelAllowedForTier(ULTRA_TIER, 'anthropic/claude-3-haiku-20240307'),
+      false,
+    );
+    assert.equal(isModelAllowedForTier(ULTRA_TIER, 'unknown-model'), true);
   });
 });

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -75,6 +75,7 @@ import {
   TIER_CONFIG,
   TIER_SPENDING_LIMITS,
   getRequestLimits,
+  isRetiredModelRequest,
   isModelAllowedForTier,
   getSpendingLimit,
   FREE_TIER_SUGGESTED_MODEL,
@@ -622,7 +623,7 @@ app.all('/:provider{[^/]+}/*', async (c) => {
     }
   }
 
-  // 6. Apply tier constraints for non-Ultra tiers.
+  // 6. Apply retired-model and tier constraints for model endpoints.
   // Skip model validation for endpoints that don't require a model (e.g., file uploads)
   // - OpenAI: /v1/files
   // - Anthropic: /v1/files (same as OpenAI)
@@ -656,7 +657,9 @@ app.all('/:provider{[^/]+}/*', async (c) => {
     requestBody = requestSize.body;
   }
 
-  if (userTier !== ULTRA_TIER && c.req.method !== 'GET' && !isModelFreePath) {
+  const isModelRequest = c.req.method !== 'GET' && !isModelFreePath;
+
+  if (isModelRequest) {
     if (requestBody === null) {
       requestBody = await c.req.text();
     } else if (requestBody instanceof Uint8Array) {
@@ -677,7 +680,16 @@ app.all('/:provider{[^/]+}/*', async (c) => {
     if (!modelName) {
       modelName = extractModelFromPath(apiPath);
     }
+  }
 
+  if (modelName && isRetiredModelRequest(modelName)) {
+    return jsonError(
+      `Model '${modelName}' is retired and no longer available from its provider. Choose an active model.`,
+      403,
+    );
+  }
+
+  if (userTier !== ULTRA_TIER && isModelRequest) {
     if (!isModelAllowedForTier(userTier, modelName)) {
       const tierName = userTier === FREE_TIER ? 'free' : userTier;
       // Point users at a model their tier can actually use, not just an upsell.

--- a/supabase/functions/relay/models.ts
+++ b/supabase/functions/relay/models.ts
@@ -115,8 +115,16 @@ function toRelayModel(config: ModelConfig): RelayModel {
 
 /** All relay-compatible models from llm-zoo, converted to relay format. */
 const RELAY_MODELS: RelayModel[] = Object.values(MODEL_CONFIGS)
-  .filter((m) => !m.openRouterOnly)
+  .filter((m) => !m.openRouterOnly && !m.retired)
   .map(toRelayModel);
+
+const RETIRED_MODEL_PATTERNS = Object.values(MODEL_CONFIGS)
+  .filter((m) => !m.openRouterOnly && m.retired)
+  .flatMap((m) =>
+    [m.name, m.fullName, m.openrouterFullName]
+      .filter((name): name is string => name != null)
+      .map((name) => name.toLowerCase()),
+  );
 
 // =============================================================================
 // Derived Arrays
@@ -258,6 +266,14 @@ function resolveAllModelsByApiName(modelName: string): RelayModel[] {
   return exactMatches.length > 0 ? exactMatches : boundaryMatches;
 }
 
+export function isRetiredModelRequest(modelName: string): boolean {
+  const name = normalizeModelName(modelName);
+  const modelPart = stripProviderPrefix(name);
+  return RETIRED_MODEL_PATTERNS.some(
+    (pattern) => modelPart === pattern || name === pattern,
+  );
+}
+
 /**
  * Check if a model is allowed for a given tier.
  * Free tier: models within the free price ceiling (input <= $1.5/M AND
@@ -275,8 +291,11 @@ export function isModelAllowedForTier(
   tier: string,
   modelName: string | null,
 ): boolean {
-  if (tier === ULTRA_TIER) return true;
+  if (tier === ULTRA_TIER) {
+    return modelName == null || !isRetiredModelRequest(modelName);
+  }
   if (!modelName) return false;
+  if (isRetiredModelRequest(modelName)) return false;
   if (tier === MAX_TIER) return true;
 
   const models = resolveAllModelsByApiName(modelName);


### PR DESCRIPTION
## Summary

- add an explicit `retired` model availability state derived from `llm-zoo`
- make retired models unavailable before subscription, included-relay, or personal-key checks
- remove retired models during persisted model-list refresh and block retired relay requests

Closes #6808.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/model/ComputeModelOptions.vitest.ts src/test-kernel/model/ModelOptionsBasic.vitest.ts src/test-kernel/cli/ModelAccess.vitest.mts src/test-kernel/supabase/RelayModelAccess.vitest.ts src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts`
- `corepack pnpm run typecheck`
- `corepack pnpm run lint` (passes with existing warnings)
- `corepack pnpm --filter @texra-ai/cli build`
- `printf ... | node packages/cli/dist/bin/texra.js run generic --print --no-input --model haiku3 --input - --instruction ...` now fails locally with `Model "haiku3" is not available in the active API mode (retired).`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core model-selection and relay routing for users who still have retired models enabled; behavior is covered by tests but affects production model access paths.
> 
> **Overview**
> Introduces a **`retired`** model availability state from `llm-zoo`’s `retired` flag so those models are blocked **before** subscription, included relay, or personal API-key logic.
> 
> **Client:** `computeModelOptions` marks retired models disabled with a dedicated unavailable message; persisted enabled-model lists reconcile at **`MODEL_LIST_VERSION` 21** to strip retired ids and stop adding them from defaults. The CLI shows **retired** status, recovery **“Choose an active model.”**, and does not rewrite retired models as login-required when signed out.
> 
> **Relay:** Retired models are omitted from the active relay catalog; requests matching retired API names are rejected with **403** even on Max/Ultra passthrough tiers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f35becd61abaabba054242760a8cfef8a26de82e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->