### PR TITLE
[codex] show chat descriptions in history list

### DIFF
--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -256,10 +256,18 @@ export function formatCliHistoryText(
         entry.timestamp,
         formatCliHistoryAgentLabel(entry),
         entry.status,
-        entry.inputBasename,
+        historyListSubject(entry),
       ].join('\t'),
     )
     .join('\n');
+}
+
+function historyListSubject(
+  entry: Pick<CliHistoryEntry, 'description' | 'inputBasename'>,
+): string {
+  if (entry.inputBasename !== '-') return entry.inputBasename;
+  const description = entry.description?.replaceAll(/\s+/g, ' ').trim();
+  return description || '-';
 }
 
 export function formatCliHistoryNotFoundText(

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -162,6 +162,32 @@ describe('CLI history runtime', () => {
     );
   });
 
+  it('uses the history description for no-input chat rows', async () => {
+    const chatConfig = {
+      ...config,
+      agent: 'assistant',
+      agentCategory: 'toolUse',
+      inputFiles: [],
+    } as AgentConfig;
+    mocks.listExecutions.mockResolvedValue([
+      {
+        id: 'chat1' as ExecutionId,
+        timestamp: '2026-05-18T11:00:00.000Z',
+        agent: 'assistant',
+        model: 'deepseekT',
+        agentConfig: chatConfig,
+        terminalStatus: 'resumable',
+        description: 'Sketch a proof outline',
+      },
+    ]);
+
+    const entries = await listCliHistoryEntries();
+
+    expect(formatCliHistoryText(entries)).toBe(
+      'chat1\t2026-05-18T11:00:00.000Z\tassistant\tresumable\tSketch a proof outline',
+    );
+  });
+
   it('parses positive history list limits', () => {
     expect(parseHistoryListLimit('1')).toBe(1);
     expect(parseHistoryListLimit('25')).toBe(25);


### PR DESCRIPTION
## Summary

- use the stored history description as the `history list` subject for no-input chat sessions
- keep file-backed history rows showing their input basename
- add a regression test for no-input chat rows

Closes #6810.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/History.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm exec prettier --check packages/cli/src/runtime/history.ts src/test-kernel/cli/History.vitest.mts`
- `corepack pnpm exec eslint packages/cli/src/runtime/history.ts src/test-kernel/cli/History.vitest.mts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI display-only change to history list formatting with a focused unit test; no storage or execution behavior changes.
> 
> **Overview**
> **`texra history list`** now shows a more useful last column for sessions without input files.
> 
> The tab-separated text formatter no longer always prints `inputBasename`. It uses a new **`historyListSubject`** helper: file-backed runs still show the first input file’s basename; when that placeholder is `-`, the row shows the stored execution **description** (whitespace collapsed), falling back to `-` if missing.
> 
> A regression test covers no-input chat runs so the list shows something like `Sketch a proof outline` instead of `-`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b65ed868518efc0ab4b752405a2110f073acb50d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->