### PR TITLE
[codex] document OAuth signup outage diagnostics

### DIFF
--- a/docs/supabase/AUTH_OPERATIONS.md
+++ b/docs/supabase/AUTH_OPERATIONS.md
@@ -18,7 +18,33 @@ control case: `POST /auth/v1/recover` for an existing user sends email and does
 not involve the Before User Created hook. If both sign-up and recovery hang, the
 mailer should be checked before changing hook code.
 
-## First response checklist
+## OAuth provider sign-up outage
+
+OAuth providers can fail before Supabase sees the user. The June 2026 outage had
+this shape for Google: existing users who had already granted consent could
+continue logging in, but new users were blocked on Google's side because the
+OAuth app was in Testing mode. Supabase had little useful evidence because the
+failure happened before the normal user-creation path.
+
+Diagnose OAuth outages by splitting sign-ups by provider, not only by the total
+number of new users. A provider-specific zero with other providers still working
+usually points to that identity provider's configuration.
+
+For Google, check:
+
+1. **Google Cloud Console** -> **Google Auth Platform** -> **Audience**:
+   publishing status should be **In production**, not **Testing**.
+2. **Google Cloud Console** -> **APIs & Services** -> **Credentials**: verify the
+   OAuth client ID and client secret used by Supabase.
+3. **Supabase Dashboard** -> **Authentication** -> **Providers** -> **Google**:
+   verify the stored client ID and secret.
+4. **Supabase Dashboard** -> **Authentication** -> **URL Configuration**: verify
+   the redirect URL allow-list still covers the extension and CLI flows.
+5. Auth logs around the failure window: if `/auth/v1/authorize` redirects to
+   Google but no user appears, inspect the provider console and consent-screen
+   status before assuming a Supabase hook or database problem.
+
+## Email first response checklist
 
 1. In Supabase Dashboard, open **Project Settings** -> **Authentication** ->
    **SMTP**.
@@ -44,10 +70,12 @@ After changing SMTP or hook settings, verify all of the following:
    recovery email.
 2. Email/password sign-up for a fresh canary address returns promptly, creates
    an `auth.users` row, and delivers the confirmation email.
-3. The Before User Created hook is enabled and its logs show a normal allow or
+3. Google sign-up for a fresh canary account that has not already granted consent
+   completes end to end.
+4. The Before User Created hook is enabled and its logs show a normal allow or
    deny response.
-4. Existing OAuth sign-in still works.
-5. GitHub sign-up through `supabase/functions/auth-github/index.ts` still works.
+5. Existing OAuth sign-in still works.
+6. GitHub sign-up through `supabase/functions/auth-github/index.ts` still works.
    That path uses `admin.createUser({ email_confirm: true })`, so it is not a
    substitute for testing the email mailer path.
 
@@ -56,18 +84,21 @@ in the project.
 
 ## Distinguishing likely causes
 
-| Observation                                                                                               | Most likely cause                                  |
-| --------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| `/auth/v1/signup` hangs, no `auth.users` row appears, and `/auth/v1/recover` also hangs                   | SMTP or email delivery misconfiguration            |
-| `/auth/v1/signup` fails quickly, `/auth/v1/recover` succeeds, and the Edge Function logs show a rejection | Before User Created policy rejected the user       |
-| `/auth/v1/signup` returns `401` or signature errors appear in Edge Function logs                          | Hook secret or webhook signature configuration     |
-| OAuth sign-in works while email sign-up and recovery fail                                                 | OAuth path bypasses confirmation email; check SMTP |
+| Observation                                                                                                      | Most likely cause                                                     |
+| ---------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `/auth/v1/signup` hangs, no `auth.users` row appears, and `/auth/v1/recover` also hangs                          | SMTP or email delivery misconfiguration                               |
+| `/auth/v1/signup` fails quickly, `/auth/v1/recover` succeeds, and the Edge Function logs show a rejection        | Before User Created policy rejected the user                          |
+| `/auth/v1/signup` returns `401` or signature errors appear in Edge Function logs                                 | Hook secret or webhook signature configuration                        |
+| OAuth sign-in works while email sign-up and recovery fail                                                        | OAuth path bypasses confirmation email; check SMTP                    |
+| New Google users fail before any Supabase user row or hook log appears, while existing Google users still log in | Google OAuth publishing status, consent screen, or client credentials |
+| One OAuth provider has zero new users while other providers still create users                                   | Provider-specific OAuth configuration or provider outage              |
 
 ## Sign-up funnel alert
 
-The outage class above can be silent because failed email sign-ups roll back and
-leave no user row. A low-volume project should still alert when the sign-up
-funnel goes to zero while it previously had traffic.
+The outage classes above can be silent: failed email sign-ups can roll back and
+leave no user row, and provider-side OAuth failures can happen before Supabase
+records a flow. A low-volume project should still alert when the sign-up funnel
+goes to zero while it previously had traffic.
 
 If an auth audit export is available, alert on zero `user_signedup` events over
 24 hours. Otherwise, use `auth.users.created_at` as a durable proxy:
@@ -94,6 +125,38 @@ FROM windows;
 For very low-volume periods, tune the baseline threshold rather than disabling
 the alert. The important invariant is that a completely inactive sign-up funnel
 is noticed within one day.
+
+Also keep a provider-split view, because an aggregate alert can miss the case
+where only one provider is broken:
+
+```sql
+WITH users_by_provider AS (
+  SELECT
+    COALESCE(raw_app_meta_data ->> 'provider', 'email') AS provider,
+    created_at
+  FROM auth.users
+),
+provider_windows AS (
+  SELECT
+    provider,
+    COUNT(*) FILTER (
+      WHERE created_at >= NOW() - INTERVAL '24 hours'
+    ) AS users_24h,
+    COUNT(*) FILTER (
+      WHERE created_at >= NOW() - INTERVAL '8 days'
+        AND created_at < NOW() - INTERVAL '24 hours'
+    ) / 7.0 AS prior_daily_avg
+  FROM users_by_provider
+  GROUP BY provider
+)
+SELECT
+  provider,
+  users_24h,
+  prior_daily_avg,
+  users_24h = 0 AND prior_daily_avg >= 1 AS alert
+FROM provider_windows
+ORDER BY provider;
+```
 
 ## Hook behavior
 


### PR DESCRIPTION
## Summary

- extend the Supabase auth runbook with the final Google OAuth outage diagnosis from #5868
- add provider-specific checks for Google OAuth Testing mode, credentials, redirect URLs, and provider-side evidence
- add a provider-split sign-up alert query so a single broken provider is visible even when aggregate sign-ups continue

## Notes

Refs #5868. This follows up #6813 by recording the later issue comments: SMTP remained a separate defect, while the primary June sign-up outage was Google OAuth provider configuration.

This PR intentionally avoids #6812's changed-file set.

## Validation

- `corepack pnpm exec prettier --check docs/supabase/AUTH_OPERATIONS.md`
- `git diff --check`
- commit hook: `npm run format`
- commit hook: docs root public/internal boundary

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to an internal Supabase auth runbook; no runtime, auth, or application code is modified.
> 
> **Overview**
> Extends **`docs/supabase/AUTH_OPERATIONS.md`** with runbook guidance for **OAuth provider-side** sign-up failures (notably Google OAuth in **Testing** mode), separate from the existing SMTP/email path.
> 
> Adds a new **OAuth provider sign-up outage** section: diagnose by **provider**, Google Cloud / Supabase provider and redirect checks, and when to suspect the IdP before hooks or the database. Renames the SMTP triage list to **Email first response checklist**, adds a **Google new-user canary** to verification, and expands the **likely causes** table with Google- and provider-specific rows.
> 
> Updates **Sign-up funnel alert** copy for silent OAuth failures and adds a **provider-split SQL alert** so one broken provider is visible when aggregate sign-ups still look healthy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cc2a14403a0d701806b7118aff77cfc565eb65b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->