### PR TITLE
[codex] clarify init recovery for unavailable model

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -16,6 +16,7 @@ import { initCliPlatform } from '../runtime/initPlatform';
 import { writeTextStderr } from '../runtime/logSinks';
 import { effectiveCliApiMode, type CliApiMode } from '../runtime/apiAccessMode';
 import {
+  formatCliNoAvailableModelsRecovery,
   getCliModelAccessList,
   type CliModelAccess,
 } from '../runtime/modelAccess';
@@ -98,15 +99,25 @@ interface InitSummary {
 function initWarning(
   answers: InitAnswers,
   models: readonly CliModelAccess[],
+  apiMode: CliApiMode,
 ): InitSummary['warning'] {
   const chosen = models.find((model) => model.model.value === answers.model);
   if (!chosen || chosen.available) return undefined;
   return {
     model: answers.model,
     message: `"${answers.model}" is not usable in the current access mode.`,
-    recovery:
-      'Run `texra login` for included relay access, set the provider API key, or run `texra models list` to pick another.',
+    recovery: `${formatCliNoAvailableModelsRecovery(apiMode)} Run \`texra models list --all\` to inspect access.`,
   };
+}
+
+function initNextSteps(warning: InitSummary['warning']): readonly string[] {
+  if (!warning) {
+    return ['Next: run `texra` for the launcher, or `texra chat` to start.'];
+  }
+  return [
+    `Next: ${warning.recovery}`,
+    'After a model is available, run `texra` for the launcher or `texra chat` to start.',
+  ];
 }
 
 function initGitignoreText(outcome: GitignoreOutcome | undefined): string[] {
@@ -126,11 +137,7 @@ function initTextSummary(summary: InitSummary): string {
     `  output: ${summary.outputFormat}`,
   ];
   if (summary.warning) {
-    lines.push(
-      '',
-      `Note: ${summary.warning.message}`,
-      summary.warning.recovery,
-    );
+    lines.push('', `Note: ${summary.warning.message}`);
   }
   lines.push('', ...summary.next);
   return lines.join('\n');
@@ -143,7 +150,9 @@ function emitInitSummary(
   config: InitConfigShape,
   models: readonly CliModelAccess[],
   gitignore: GitignoreOutcome | undefined,
+  apiMode: CliApiMode,
 ): void {
+  const warning = initWarning(answers, models, apiMode);
   const summary: InitSummary = {
     path: filePath,
     agent: answers.agent,
@@ -152,8 +161,8 @@ function emitInitSummary(
     outputFormat: answers.outputFormat,
     config,
     gitignore,
-    warning: initWarning(answers, models),
-    next: ['Next: run `texra` for the launcher, or `texra chat` to start.'],
+    warning,
+    next: initNextSteps(warning),
   };
   emitCliResult(context, {
     json: summary,
@@ -183,9 +192,8 @@ async function runInit(
     return CliExitCode.Usage;
   }
 
-  const { agents, models, seededRoster } = await gatherOptions(
-    effectiveCliApiMode(context),
-  );
+  const apiMode = effectiveCliApiMode(context);
+  const { agents, models, seededRoster } = await gatherOptions(apiMode);
 
   const interactive =
     !opts.yes &&
@@ -228,7 +236,15 @@ async function runInit(
     gitignoreOutcome = await ensureTexraGitignored(context.cwd);
   }
 
-  emitInitSummary(context, filePath, answers, config, models, gitignoreOutcome);
+  emitInitSummary(
+    context,
+    filePath,
+    answers,
+    config,
+    models,
+    gitignoreOutcome,
+    apiMode,
+  );
   return CliExitCode.Success;
 }
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -102,7 +102,7 @@ function initWarning(
   apiMode: CliApiMode,
 ): InitSummary['warning'] {
   const chosen = models.find((model) => model.model.value === answers.model);
-  if (!chosen || chosen.available) return undefined;
+  if (chosen?.available === true) return undefined;
   return {
     model: answers.model,
     message: `"${answers.model}" is not usable in the current access mode.`,

--- a/src/test-kernel/cli/InitCommand.vitest.mts
+++ b/src/test-kernel/cli/InitCommand.vitest.mts
@@ -322,4 +322,52 @@ describe('CLI init command', () => {
       await fs.rm(root, { recursive: true, force: true });
     }
   });
+
+  it('points non-interactive init at model recovery when the default model is unavailable', async () => {
+    mocks.getCliModelAccessList.mockResolvedValue([
+      modelAccess('deepseekproT', {
+        available: false,
+        status: 'missing key',
+        model: {
+          value: 'deepseekproT',
+          label: 'DeepSeek Pro',
+          availability: 'missing-key',
+          requiresKey: true,
+        },
+      }),
+    ]);
+    const root = await makeTempProject();
+    try {
+      const result = await runCli([
+        '--cwd',
+        root,
+        'init',
+        '--print',
+        '--api-mode',
+        'personal',
+        '--gitignore',
+        '--no-color',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      expect(stderr).toBe('');
+      expect(stdout).toContain(
+        'Note: "deepseekproT" is not usable in the current access mode.',
+      );
+      expect(stdout).toContain(
+        'Next: Add a provider API key with `texra setup` for personal mode',
+      );
+      expect(stdout).toContain(
+        'Run `texra models list --all` to inspect access.',
+      );
+      expect(stdout).toContain(
+        'After a model is available, run `texra` for the launcher or `texra chat` to start.',
+      );
+      expect(stdout).not.toContain(
+        'Next: run `texra` for the launcher, or `texra chat` to start.',
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/test-kernel/cli/InitCommand.vitest.mts
+++ b/src/test-kernel/cli/InitCommand.vitest.mts
@@ -69,6 +69,22 @@ async function makeTempProject(): Promise<string> {
   return fs.mkdtemp(path.join(os.tmpdir(), 'texra-init-test-'));
 }
 
+function expectUnavailableDefaultRecovery(output: string): void {
+  expect(output).toContain(
+    'Note: "deepseekproT" is not usable in the current access mode.',
+  );
+  expect(output).toContain(
+    'Next: Add a provider API key with `texra setup` for personal mode',
+  );
+  expect(output).toContain('Run `texra models list --all` to inspect access.');
+  expect(output).toContain(
+    'After a model is available, run `texra` for the launcher or `texra chat` to start.',
+  );
+  expect(output).not.toContain(
+    'Next: run `texra` for the launcher, or `texra chat` to start.',
+  );
+}
+
 describe('CLI init command', () => {
   let stdout = '';
   let stderr = '';
@@ -351,21 +367,41 @@ describe('CLI init command', () => {
 
       expect(result.exitCode).toBe(0);
       expect(stderr).toBe('');
-      expect(stdout).toContain(
-        'Note: "deepseekproT" is not usable in the current access mode.',
-      );
-      expect(stdout).toContain(
-        'Next: Add a provider API key with `texra setup` for personal mode',
-      );
-      expect(stdout).toContain(
-        'Run `texra models list --all` to inspect access.',
-      );
-      expect(stdout).toContain(
-        'After a model is available, run `texra` for the launcher or `texra chat` to start.',
-      );
-      expect(stdout).not.toContain(
-        'Next: run `texra` for the launcher, or `texra chat` to start.',
-      );
+      expectUnavailableDefaultRecovery(stdout);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('points init at model recovery when the fallback default has no access entry', async () => {
+    mocks.getCliModelAccessList.mockResolvedValue([
+      modelAccess('sonnet46T', {
+        available: false,
+        status: 'login required',
+        model: {
+          value: 'sonnet46T',
+          label: 'Sonnet',
+          availability: 'included-login-required',
+          disabled: true,
+        },
+      }),
+    ]);
+    const root = await makeTempProject();
+    try {
+      const result = await runCli([
+        '--cwd',
+        root,
+        'init',
+        '--print',
+        '--api-mode',
+        'personal',
+        '--gitignore',
+        '--no-color',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      expect(stderr).toBe('');
+      expectUnavailableDefaultRecovery(stdout);
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- derive `texra init` next steps from whether the selected model is runnable
- reuse the existing CLI model-access recovery copy for unavailable defaults
- keep the normal launcher/chat next step only for configurations with a runnable selected model

Closes #6817.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/InitCommand.vitest.mts`
- `corepack pnpm exec prettier --check packages/cli/src/commands/init.ts src/test-kernel/cli/InitCommand.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm --filter @texra-ai/cli check:architecture`
- `corepack pnpm --filter @texra-ai/cli bundle`
- `git diff --check`
- Fresh-home bundle smoke:

  ```sh
  tmp="$(mktemp -d)"
  env -i PATH="$PATH" HOME="$tmp" node packages/cli/dist/bin/texra.js --cwd "$tmp" init --yes --gitignore --api-mode personal --no-color --print
  rm -rf "$tmp"
  ```

## Notes

This PR touches only `packages/cli/src/commands/init.ts` and `src/test-kernel/cli/InitCommand.vitest.mts`; neither file is in #6812.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI messaging and init summary output only; no auth, config schema, or runtime behavior changes beyond clearer guidance.
> 
> **Overview**
> **`texra init`** now tailors post-init guidance to whether the chosen default model is actually runnable in the current API mode.
> 
> When the selected model is unavailable or missing from the access list, recovery copy comes from **`formatCliNoAvailableModelsRecovery`** (same as elsewhere in the CLI), plus a pointer to **`texra models list --all`**. **Next steps** lead with that recovery and defer launcher/chat until a model works; runnable defaults still get the usual **`texra` / `texra chat`** line. Human text no longer repeats recovery as a separate line under the note—it lives in the **Next:** block. Tests cover unavailable defaults and fallback defaults with no access entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 360accd4b9257cf48be38d1276a371773c6c235d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->