### PR TITLE
[codex] avoid redundant provider-key status hint

### DIFF
--- a/packages/cli/src/runtime/apiStatus.ts
+++ b/packages/cli/src/runtime/apiStatus.ts
@@ -50,28 +50,35 @@ export function formatApiKeyShadowWarning(
 
 const CLI_API_STATUS_ACTION_HINTS: Record<
   CliApiMode,
-  Record<'signedIn' | 'signedOut', string>
+  Record<'signedIn' | 'signedOut' | 'signedOutWithPersonalKey', string>
 > = {
   included: {
     signedIn:
       'actions: `texra login --select-account` changes account; `--api-mode personal` uses provider keys',
     signedOut:
       'actions: `texra auth chatgpt login` uses ChatGPT; `texra login` uses Researcher Access',
+    signedOutWithPersonalKey:
+      'actions: `--api-mode personal` uses provider keys; `texra auth chatgpt login` uses ChatGPT; `texra login` uses Researcher Access',
   },
   personal: {
     signedIn:
       'actions: `--api-mode included` uses relay; `texra logout` signs out',
     signedOut:
       'actions: use ChatGPT, add a provider key, or sign in with Researcher Access',
+    signedOutWithPersonalKey:
+      'actions: provider keys are configured; use ChatGPT or sign in with Researcher Access',
   },
 };
 
 export function formatCliApiStatusActionHint(
   mode: CliApiMode,
   profile: Pick<CliAuthProfile, 'authenticated'>,
+  options: { readonly hasPersonalKey?: boolean } = {},
 ): string {
+  const signedOutState =
+    options.hasPersonalKey === true ? 'signedOutWithPersonalKey' : 'signedOut';
   return CLI_API_STATUS_ACTION_HINTS[mode][
-    profile.authenticated ? 'signedIn' : 'signedOut'
+    profile.authenticated ? 'signedIn' : signedOutState
   ];
 }
 
@@ -95,15 +102,16 @@ export async function loadCliApiStatusLines(
     `api: ${formatCliApiMode(mode)}`,
     formatCliAuthStatusLine(profile),
   ];
+  const hasPersonalKey =
+    options.includeActionHint === true || profile.authenticated
+      ? await anyPersonalKeyPresent()
+      : false;
   const actionHint = options.includeActionHint
-    ? formatCliApiStatusActionHint(mode, profile)
+    ? formatCliApiStatusActionHint(mode, profile, { hasPersonalKey })
     : undefined;
 
   if (profile.authenticated) {
-    const shadowWarning = formatApiKeyShadowWarning(
-      true,
-      await anyPersonalKeyPresent(),
-    );
+    const shadowWarning = formatApiKeyShadowWarning(true, hasPersonalKey);
     if (shadowWarning) lines.push(shadowWarning);
   }
 

--- a/src/test-kernel/cli/ApiStatus.vitest.mts
+++ b/src/test-kernel/cli/ApiStatus.vitest.mts
@@ -75,6 +75,15 @@ describe('CLI API status text', () => {
       'actions: `texra auth chatgpt login` uses ChatGPT; `texra login` uses Researcher Access',
     );
     expect(
+      formatCliApiStatusActionHint(
+        'included',
+        { authenticated: false },
+        { hasPersonalKey: true },
+      ),
+    ).toBe(
+      'actions: `--api-mode personal` uses provider keys; `texra auth chatgpt login` uses ChatGPT; `texra login` uses Researcher Access',
+    );
+    expect(
       formatCliApiStatusActionHint('included', { authenticated: true }),
     ).toBe(
       'actions: `texra login --select-account` changes account; `--api-mode personal` uses provider keys',
@@ -88,6 +97,15 @@ describe('CLI API status text', () => {
       formatCliApiStatusActionHint('personal', { authenticated: false }),
     ).toBe(
       'actions: use ChatGPT, add a provider key, or sign in with Researcher Access',
+    );
+    expect(
+      formatCliApiStatusActionHint(
+        'personal',
+        { authenticated: false },
+        { hasPersonalKey: true },
+      ),
+    ).toBe(
+      'actions: provider keys are configured; use ChatGPT or sign in with Researcher Access',
     );
   });
 });

--- a/src/test-kernel/cli/ApiStatusLoad.vitest.mts
+++ b/src/test-kernel/cli/ApiStatusLoad.vitest.mts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   getCliApiMode: vi.fn(),
   getCliAuthProfile: vi.fn(),
+  lookupApiKeyOrigin: vi.fn(),
+  secrets: {},
 }));
 
 vi.mock('@cli/runtime/apiAccessMode', async (importOriginal) => {
@@ -18,14 +20,25 @@ vi.mock('@cli/runtime/supabaseAuth', () => ({
   getCliAuthProfile: mocks.getCliAuthProfile,
 }));
 
+vi.mock('@model/apiProviders', () => ({
+  API_PROVIDERS: ['deepseek'],
+  lookupApiKeyOrigin: mocks.lookupApiKeyOrigin,
+}));
+
+vi.mock('@platform/platform', () => ({
+  platform: () => ({ secrets: mocks.secrets }),
+}));
+
 const { loadCliApiStatusLines } = await import('@cli/runtime/apiStatus');
 
 describe('loadCliApiStatusLines', () => {
   beforeEach(() => {
     mocks.getCliApiMode.mockReset();
     mocks.getCliAuthProfile.mockReset();
+    mocks.lookupApiKeyOrigin.mockReset();
     mocks.getCliApiMode.mockReturnValue('personal');
     mocks.getCliAuthProfile.mockResolvedValue({ authenticated: false });
+    mocks.lookupApiKeyOrigin.mockResolvedValue('none');
   });
 
   it('uses an invocation API mode override for launcher status text', async () => {
@@ -40,5 +53,17 @@ describe('loadCliApiStatusLines', () => {
       'actions: `texra auth chatgpt login` uses ChatGPT; `texra login` uses Researcher Access',
     ]);
     expect(mocks.getCliApiMode).not.toHaveBeenCalled();
+  });
+
+  it('does not ask signed-out personal-key users to add another key', async () => {
+    mocks.lookupApiKeyOrigin.mockResolvedValue('env');
+
+    await expect(
+      loadCliApiStatusLines({ includeActionHint: true }),
+    ).resolves.toEqual([
+      'api: personal API keys',
+      'auth: signed out',
+      'actions: provider keys are configured; use ChatGPT or sign in with Researcher Access',
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- add an explicit signed-out-with-provider-key state for CLI API status action hints
- avoid telling personal-key users to add a provider key when one is already configured
- reuse the personal-key probe for both shadow warnings and launcher action hints

Closes #6819.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ApiStatus.vitest.mts src/test-kernel/cli/ApiStatusLoad.vitest.mts`
- `corepack pnpm exec prettier --check packages/cli/src/runtime/apiStatus.ts src/test-kernel/cli/ApiStatus.vitest.mts src/test-kernel/cli/ApiStatusLoad.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm --filter @texra-ai/cli check:architecture`
- `corepack pnpm --filter @texra-ai/cli bundle`
- `git diff --check`

## Notes

This PR touches only `packages/cli/src/runtime/apiStatus.ts`, `src/test-kernel/cli/ApiStatus.vitest.mts`, and `src/test-kernel/cli/ApiStatusLoad.vitest.mts`; none of these files are in #6812.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing CLI status text only; no changes to auth, API routing, or secret storage behavior beyond when keys are probed for messaging.
> 
> **Overview**
> CLI startup/status **action hints** now distinguish signed-out users who already have a provider API key configured from those who do not.
> 
> `formatCliApiStatusActionHint` accepts an optional `hasPersonalKey` flag and selects new `signedOutWithPersonalKey` copy for both `included` and `personal` modes—e.g. personal mode no longer says “add a provider key” when keys are already present. `loadCliApiStatusLines` runs the personal-key probe when action hints are requested or the user is signed in, and reuses that result for the existing signed-in shadow warning so the secrets lookup is not duplicated.
> 
> Tests cover the new hint strings and an integration case for signed-out users with an env key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92e22ed5c764e32287730f8ba93965e8dfd8ed5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->