### PR TITLE
chore(deps-dev): bump Electron to 42.5.1

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@playwright/test": "^1.61.1",
     "@texra/core": "workspace:*",
-    "electron": "^42.5.0",
+    "electron": "^42.5.1",
     "electron-builder": "^26.15.3",
     "esbuild": "^0.28.1",
     "playwright": "^1.61.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -494,8 +494,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       electron:
-        specifier: ^42.5.0
-        version: 42.5.0
+        specifier: ^42.5.1
+        version: 42.5.1
       electron-builder:
         specifier: ^26.15.3
         version: 26.15.3(electron-builder-squirrel-windows@26.15.3)
@@ -1154,8 +1154,8 @@ packages:
     resolution: {integrity: sha512-WyOx8cJQ+FQus4Mm4uPIZA64gbk3Wxh0so5Lcii0aJifqwoVOlfFtorjLE0Hen4OYyHZMXDWqMmaQemBhgxFRQ==}
     engines: {node: '>=14'}
 
-  '@electron-internal/extract-zip@1.0.3':
-    resolution: {integrity: sha512-OjKpjB7gohtEjZiq6nDx1egqjZJhGPN1iFOIED+NFhB/MMkXw/XRcHjh1DGXKT5z2W9eW7Jy2UKU3gpjvusFTQ==}
+  '@electron-internal/extract-zip@1.0.4':
+    resolution: {integrity: sha512-Zr1Vs7E9tpCNhZHDAbFVXc2gEVCG9RqPDjrno5+bdgB6LRAuvgyMHJut4NCVyYwtAieapMzc3fiQ3CSTi75ARg==}
     engines: {node: '>=22.12.0'}
 
   '@electron/asar@3.4.1':
@@ -3419,8 +3419,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@42.5.0:
-    resolution: {integrity: sha512-cYEKS9XFz+c9fAB4jI0x49yz1FFzB55r3q96wu9YkwwJMv7t9202IE/ltlgy6yitl/J4M7C8JQcmUqdzDvPl/w==}
+  electron@42.5.1:
+    resolution: {integrity: sha512-2VFNJcHHbrhIpGsJHdkLoi/nWPZPxN3GHVPe+9At3Oz3/TJRwpr+7JL97ddBDbKyLmHGx3GfI2jvzcEQL28uFw==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
@@ -6553,7 +6553,7 @@ snapshots:
 
   '@ctrl/tinycolor@4.1.0': {}
 
-  '@electron-internal/extract-zip@1.0.3': {}
+  '@electron-internal/extract-zip@1.0.4': {}
 
   '@electron/asar@3.4.1':
     dependencies:
@@ -8862,9 +8862,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@42.5.0:
+  electron@42.5.1:
     dependencies:
-      '@electron-internal/extract-zip': 1.0.3
+      '@electron-internal/extract-zip': 1.0.4
       '@electron/get': 5.0.0
       '@types/node': 24.13.2
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

Bump the desktop app's Electron development dependency from `42.5.0` to `42.5.1`, including the corresponding `@electron-internal/extract-zip` lockfile update.

This is the shippable subset of Dependabot #6822. The rest of that grouped dev-dependency update is currently blocked by the pnpm minimum-release-age policy for the TypeScript-ESLint family, `prettier`, `typescript-eslint`, and `vite`.

## Verification

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec prettier --check packages/desktop/package.json pnpm-lock.yaml`
- `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level dev dependency bump with no source changes; runtime behavior should match 42.5.0 aside from Electron’s patch fixes.
> 
> **Overview**
> Bumps the `@texra/desktop` **devDependency** `electron` from **42.5.0** to **42.5.1** and refreshes `pnpm-lock.yaml` so the resolved `electron@42.5.1` tree is pinned.
> 
> The lockfile also moves Electron’s transitive **`@electron-internal/extract-zip`** from **1.0.3** to **1.0.4**; there are no application or build-script edits beyond the version pins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12fca4562c5a0ac1d872b4806b4718b7960f04ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->