### PR TITLE
refactor: simplify source changed since v0.38.9 not in #6812/#6832 (round 2)

### DIFF
--- a/packages/cli/src/chat/tui/commands/handlers/apiModeCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/apiModeCommands.ts
@@ -95,11 +95,8 @@ export async function applyCliApiModeSelection(
 }
 
 export async function showCliAuthStatus(): Promise<void> {
-  appendLocalAssistantTranscript(
-    (
-      await loadCliApiStatusLines({
-        apiMode: cliState.sessionMeta.get().apiMode,
-      })
-    ).join('\n'),
-  );
+  const lines = await loadCliApiStatusLines({
+    apiMode: cliState.sessionMeta.get().apiMode,
+  });
+  appendLocalAssistantTranscript(lines.join('\n'));
 }

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -55,12 +55,10 @@ async function applyCliConfigSettingSideEffects(
     applyCliGitAuthorConfig(stores.config);
   }
   if (entry.key === GlobalStateKey.USE_OPENROUTER) {
-    if (value === true) {
-      invalidateModelOptionsCache();
-      await onApiModeSelect?.('personal');
-      return;
-    }
     invalidateModelOptionsCache();
+    if (value === true) {
+      await onApiModeSelect?.('personal');
+    }
   }
 }
 

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -233,6 +233,11 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
   // unmounts after this flips. Future persistent Select users should reset it.
   const cancelledRef = useRef(false);
 
+  function cancelAndDrop(): void {
+    cancelledRef.current = true;
+    props.onCancel();
+  }
+
   useEffect(() => {
     setHighlight((h) => clampIndex(h, props.items.length));
   }, [props.items.length]);
@@ -284,8 +289,7 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
       (key.meta && !rawNavigationInput) ||
       isRawSelectEscChordInput(input)
     ) {
-      cancelledRef.current = true;
-      props.onCancel();
+      cancelAndDrop();
       return;
     }
     if (isPlainReturnInput(input, key)) {
@@ -295,8 +299,7 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
     }
     if (!key.ctrl && input.length > 2) {
       if (rawNavigationInput) return;
-      cancelledRef.current = true;
-      props.onCancel();
+      cancelAndDrop();
       return;
     }
     // Single-key jumps (1-9, then a-z) for direct selection. Ignore Ctrl

--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -122,9 +122,9 @@ const agentsShowCommand = defineCliCommand({
 
 export const agentsCommand = defineCommand({
   meta: { name: 'agents', description: 'Inspect TeXRA agents' },
-  // Unlike `multi-agent show` (which resolves a team run plan), an agent has
-  // no separate "inspected" view — `show` already prints everything — so there
-  // is just one inspection verb here.
+  // `show` already prints everything about an agent, so there is no separate
+  // `inspect` verb here (unlike `multi-agent show`, which resolves a team run
+  // plan).
   subCommands: {
     list: agentsListCommand,
     show: agentsShowCommand,

--- a/packages/cli/src/orchestration/runOrchestrationTui.tsx
+++ b/packages/cli/src/orchestration/runOrchestrationTui.tsx
@@ -209,12 +209,16 @@ export function OrchestrationApp(
     CliOrchestrationModelPickAction | undefined
   >(undefined);
   const isPendingTeam = pending?.kind === 'preset';
+  // Model-step header text, shared between the wrapped-row measurement in
+  // `headerLines` and the styled render in the `pending` branch below.
+  const modelStepTitle = isPendingTeam ? 'Lead model' : 'Model';
+  const modelStepSubtitle = isPendingTeam
+    ? 'Runs the orchestrator agent and is the model it can choose for delegation.'
+    : 'Model for the first message.';
   const headerLines = pending
     ? [
-        `${isPendingTeam ? 'Lead model' : 'Model'} · ${formatCliApiMode(props.apiMode)}`,
-        isPendingTeam
-          ? 'Runs the orchestrator agent and is the model it can choose for delegation.'
-          : 'Model for the first message.',
+        `${modelStepTitle} · ${formatCliApiMode(props.apiMode)}`,
+        modelStepSubtitle,
       ]
     : [`TeXRA v${props.version}`, 'Choose how to start this CLI session.'];
   const layout = orchestrationLauncherLayout({
@@ -252,15 +256,11 @@ export function OrchestrationApp(
     return (
       <Box flexDirection="column" paddingX={1}>
         <Text bold color="cyan">
-          {isPendingTeam ? 'Lead model' : 'Model'}
+          {modelStepTitle}
           {' · '}
           <Text dimColor>{formatCliApiMode(props.apiMode)}</Text>
         </Text>
-        <Text dimColor>
-          {isPendingTeam
-            ? 'Runs the orchestrator agent and is the model it can choose for delegation.'
-            : 'Model for the first message.'}
-        </Text>
+        <Text dimColor>{modelStepSubtitle}</Text>
         <Box marginTop={1}>
           <Select
             key="orchestration-model-picker"

--- a/packages/cli/src/runtime/defaultAgents.ts
+++ b/packages/cli/src/runtime/defaultAgents.ts
@@ -55,10 +55,10 @@ export function pickDefaultToolUseAgent<T extends { readonly name: string }>(
   agents: readonly T[] | undefined,
 ): string {
   const candidates = agents ? implicitDefaultToolUseAgents(agents) : [];
-  const findByName = (name: string): T | undefined =>
-    candidates.find((candidate) => agentName(candidate.name) === name);
   for (const name of DEFAULT_AGENT_PRIORITY) {
-    const found = findByName(name);
+    const found = candidates.find(
+      (candidate) => agentName(candidate.name) === name,
+    );
     if (found) return found.name;
   }
   return candidates[0]?.name ?? BUILTIN_DEFAULT_CHAT_AGENT;

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -173,8 +173,8 @@ function recentAgentItems(
   return items;
 }
 
-// Lists every available team (built-in and custom) so the user can pick — and
-// switch — among them in the launcher, rather than being pinned to one. The
+// Lists every available team (built-in and custom) so the user can pick and
+// switch among them in the launcher, rather than being pinned to one. The
 // Select component windows and scrolls the visible rows, so the full team list
 // is offered without an artificial data cap that would hide extra custom teams.
 function presetItems(

--- a/packages/cli/src/runtime/supabaseAuthCallbackServer.ts
+++ b/packages/cli/src/runtime/supabaseAuthCallbackServer.ts
@@ -191,24 +191,25 @@ function parseCallbackBody(rawBody: string): {
   fragment?: string;
   nonce?: string;
 } {
+  let json: unknown;
   try {
-    const parsed = CallbackBodySchema.safeParse(JSON.parse(rawBody));
-    if (!parsed.success) {
-      throw new RecoverableCallbackRequestError(
-        'Authentication callback request was malformed.',
-      );
-    }
-    return {
-      query: parsed.data.query ?? undefined,
-      fragment: parsed.data.fragment ?? undefined,
-      nonce: parsed.data.nonce ?? undefined,
-    };
-  } catch (error) {
-    if (isRecoverableCallbackRequestError(error)) throw error;
+    json = JSON.parse(rawBody);
+  } catch {
     throw new RecoverableCallbackRequestError(
       'Authentication callback request was malformed.',
     );
   }
+  const parsed = CallbackBodySchema.safeParse(json);
+  if (!parsed.success) {
+    throw new RecoverableCallbackRequestError(
+      'Authentication callback request was malformed.',
+    );
+  }
+  return {
+    query: parsed.data.query ?? undefined,
+    fragment: parsed.data.fragment ?? undefined,
+    nonce: parsed.data.nonce ?? undefined,
+  };
 }
 
 function trimUrlMarker(value: string | undefined, marker: '?' | '#'): string {

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -63,7 +63,6 @@ import {
   type LatexSettingsStatus,
   type ProviderKeyStatus,
   type ReasoningLevel,
-  type SettingsViewInboundHandlerRegistry,
   type ToolDashboardItem,
 } from '@shared/schemas/settingsViewMessages';
 import {

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -42,7 +42,7 @@ export interface ElectronPlatformInitResult {
    * Whether TeXRA had run on this machine before this session, captured from
    * `LAST_KNOWN_VERSION` BEFORE the bundled-agent directory sync writes that
    * key during this same init. Threaded out so the onboarding backfill can
-   * tell a returning user (veteran) from a fresh install — reading the key
+   * tell a returning user (veteran) from a fresh install; reading the key
    * after init would always see the just-written version and misclassify a
    * brand-new credentialed user as a veteran (→ State 2 'done', so the setup
    * card never shows). Mirrors the extension's read-before-write ordering

--- a/packages/extension/src/commands/housekeeping/cleanCommands.ts
+++ b/packages/extension/src/commands/housekeeping/cleanCommands.ts
@@ -17,9 +17,7 @@ import { emitClearMissingOutputs } from './streamEventUtils';
 const CHANNEL = 'cleanCommands';
 logger.initialize(CHANNEL);
 
-const CleanConfigSchema = FileOpParamsSchema.extend({
-  ...fileOpConfigFields,
-});
+const CleanConfigSchema = FileOpParamsSchema.extend(fileOpConfigFields);
 
 function showCleanResult(result: FileOpResult, inputFile: string): void {
   switch (result.status) {

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -27,7 +27,7 @@ import { apiKeyCommands } from '@commands/api/apiKeyCommands';
 import { toErrorMessage } from '@common/errors';
 import { BaseViewMessageHandler } from '@common/webview';
 import { bus } from '@eventBus/ProgressEventBus';
-import { SecretManager, type ApiProvider } from '@frontend/secretManager';
+import { SecretManager } from '@frontend/secretManager';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { loadOptions } from '@frontend/agents/optionsLoader';
 import { handleProgressViewToolEditApprovalAction } from '@frontend/approval/nativeToolEditApproval';

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/dataFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/dataFormatters.ts
@@ -122,7 +122,6 @@ export function formatLatexdiffTemplate(
 // Statistics Formatter
 // =============================================================================
 
-/** Configuration for a statistics field: [key, icon, label, formatter]. */
 type NumericExtendedTokenUsageStatsKey = {
   [K in keyof ExtendedTokenUsageStats]-?: NonNullable<
     ExtendedTokenUsageStats[K]
@@ -131,6 +130,7 @@ type NumericExtendedTokenUsageStatsKey = {
     : never;
 }[keyof ExtendedTokenUsageStats];
 
+/** Configuration for a statistics field: [key, icon, label, formatter]. */
 type StatFieldConfig = readonly [
   key: NumericExtendedTokenUsageStatsKey,
   icon: string,

--- a/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
@@ -135,6 +135,20 @@ export class ModelsTab extends LitElement {
   private readonly handleScrollToChatGpt = (): void =>
     this.scrollToSection('#chatgpt-subscription');
 
+  private readonly handlePreferSubscriptionChange = (event: Event): void => {
+    const enabled = (event.target as WaSwitch).checked;
+    this.dispatchEvent(ChatGptAuthEvents.setPreferSubscription({ enabled }));
+  };
+
+  private readonly handleSubscriptionToolUseOnlyChange = (
+    event: Event,
+  ): void => {
+    const enabled = (event.target as WaSwitch).checked;
+    this.dispatchEvent(
+      ChatGptAuthEvents.setSubscriptionToolUseOnly({ enabled }),
+    );
+  };
+
   private renderTabHint(): TemplateResult {
     const description =
       this.apiAccessMode === 'included'
@@ -252,12 +266,7 @@ export class ModelsTab extends LitElement {
         <div class="chatgpt-subscription__setting">
           <wa-switch
             ?checked=${preferSubscription}
-            @change=${(event: Event) => {
-              const enabled = (event.target as WaSwitch).checked;
-              this.dispatchEvent(
-                ChatGptAuthEvents.setPreferSubscription({ enabled }),
-              );
-            }}
+            @change=${this.handlePreferSubscriptionChange}
           >
             Prefer ChatGPT subscription
           </wa-switch>
@@ -267,12 +276,7 @@ export class ModelsTab extends LitElement {
             ?checked=${subscriptionToolUseOnly}
             ?disabled=${!preferSubscription}
             hint="Workflow agents use your API key or relay instead — the Codex backend has no background mode and is less stable for long runs."
-            @change=${(event: Event) => {
-              const enabled = (event.target as WaSwitch).checked;
-              this.dispatchEvent(
-                ChatGptAuthEvents.setSubscriptionToolUseOnly({ enabled }),
-              );
-            }}
+            @change=${this.handleSubscriptionToolUseOnlyChange}
           >
             Use subscription for tool-use agents only
           </wa-switch>

--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -5,12 +5,9 @@
  * Handles agent enable/disable, create/customize/delete, YAML editing,
  * custom agent directories, and agent teams.
  */
-
-// Standard library and third-party imports
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 
-// Local imports
 import { SettingsAgentFileController } from '@controllers/settingsView/SettingsAgentFileController';
 import { SettingsRemoteAgentPromptController } from '@controllers/settingsView/SettingsRemoteAgentPromptController';
 import { createSettingsAgentControllers } from '@controllers/settingsView/SettingsAgentControllerFactory';
@@ -34,7 +31,6 @@ import type { SettingsAgentVisibilityController } from '@controllers/settingsVie
 import type { SettingsAgentDirectoryController } from '@controllers/settingsView/SettingsAgentDirectoryController';
 import type { SettingsAgentCatalogController } from '@controllers/settingsView/SettingsAgentCatalogController';
 
-// Local imports - handler context
 import type { SettingsHandlerContext } from './SettingsHandlerContext';
 
 /**

--- a/packages/extension/src/settingsView/handlers/historyHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/historyHandlers.ts
@@ -153,15 +153,16 @@ export class HistoryHandlers {
 
       const { exportInput } = result;
 
-      if (format === 'html') {
-        await this.exportAndOpenHtml(data.historyId, exportInput);
-        return;
-      }
-
-      if (format === 'md') {
-        await this.exportAndOpenMarkdown(data.historyId, exportInput);
-      } else {
-        await this.exportAndOpenLatex(data.historyId, exportInput);
+      switch (format) {
+        case 'html':
+          await this.exportAndOpenHtml(data.historyId, exportInput);
+          return;
+        case 'md':
+          await this.exportAndOpenMarkdown(data.historyId, exportInput);
+          return;
+        case 'tex':
+          await this.exportAndOpenLatex(data.historyId, exportInput);
+          return;
       }
     } catch (error) {
       await showLoggedErrorMessage(
@@ -203,7 +204,7 @@ export class HistoryHandlers {
       await this.chatExportController.exportAsMarkdown(historyId, exportInput);
     const doc = await vscode.workspace.openTextDocument(absolutePath);
     await vscode.window.showTextDocument(doc, { preview: false });
-    const filename = storagePath.split('/').pop() ?? storagePath;
+    const filename = path.basename(storagePath);
     void vscode.window.showInformationMessage(`Chat exported: ${filename}`);
   }
 
@@ -218,7 +219,7 @@ export class HistoryHandlers {
       // Open the generated PDF
       const pdfUri = vscode.Uri.file(pdfPath);
       await vscode.commands.executeCommand('vscode.open', pdfUri);
-      const filename = storagePath.split('/').pop() ?? storagePath;
+      const filename = path.basename(storagePath);
       void vscode.window.showInformationMessage(
         `Chat exported and compiled: ${filename.replace('.tex', '.pdf')}`,
       );

--- a/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
+++ b/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
@@ -14,6 +14,7 @@ import type { CheckboxValues, FileSelectConfig } from '@shared/schemas';
 import { getBasename, normalizeFilePath } from '@shared/utils/path';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
 import { type TeXRAIconName, waIcon } from '@shared/wa/webAwesomeIcons';
+import { capitalize } from '@utils/text/stringUtils';
 import { MainViewEvents } from '../events';
 import { FileDropController, postDroppedFiles } from '../fileDropHandler';
 import { SESSION_TYPES } from '../constants';
@@ -295,8 +296,7 @@ export class FileSelectGroup extends LitElement {
 
   override render(): TemplateResult {
     const { config } = this;
-    const typeLabel =
-      config.type.charAt(0).toUpperCase() + config.type.slice(1);
+    const typeLabel = capitalize(config.type);
 
     return html`
       <div

--- a/packages/extension/src/webview/frontend/components/StateVisibleBanner.ts
+++ b/packages/extension/src/webview/frontend/components/StateVisibleBanner.ts
@@ -8,7 +8,7 @@ import type { BannerState } from '@shared/schemas';
  * `visible` flag. It mirrors `state.visible` onto a reflected `visible`
  * attribute so the `:host(:not([visible]))` rule in `bannerStyles` can hide the
  * host via CSS. Keeping the mirror here means each banner declares only its own
- * `state` shape — the visibility plumbing lives in exactly one place instead of
+ * `state` shape. The visibility plumbing lives in exactly one place instead of
  * being copy-pasted per banner.
  */
 export abstract class StateVisibleBanner<

--- a/packages/extension/src/webview/frontend/components/bannerFrame.ts
+++ b/packages/extension/src/webview/frontend/components/bannerFrame.ts
@@ -1,4 +1,4 @@
-// Side-effect imports — register the WA elements the frame renders.
+// Side-effect imports: register the WA elements the frame renders.
 import '@awesome.me/webawesome/dist/components/callout/callout.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import { html, type TemplateResult } from 'lit';
@@ -12,7 +12,7 @@ import { waIcon } from '@shared/wa/webAwesomeIcons';
  * spacing live in `bannerStyles`.
  *
  * Keeping the frame in one place makes it the single source of truth for what a
- * warning banner looks like — a change to the chrome (icon, variant, row
+ * warning banner looks like. A change to the chrome (icon, variant, row
  * structure) lands here instead of in three near-identical component templates.
  */
 export function renderWarningBanner(options: {

--- a/src/agent/core/usage/RunUsageAccumulator.ts
+++ b/src/agent/core/usage/RunUsageAccumulator.ts
@@ -32,7 +32,7 @@ export type RunUsageTotals = z.infer<typeof RunUsageTotalsSchema>;
 /**
  * Canonical schema for RunUsageAccumulator JSON serialization.
  *
- * `latestUsage` replaces the old unbounded `normalizedSnapshots` array —
+ * `latestUsage` replaces the old unbounded `normalizedSnapshots` array;
  * only the most-recent round's usage is needed at runtime.
  */
 const RunUsageAccumulatorCanonicalSchema = z.object({
@@ -53,17 +53,11 @@ export type RunUsageAccumulatorJSON = z.output<
  * `latestUsage`. Only the most-recent snapshot's usage is needed, so the array
  * is collapsed to its last element and the rest discarded. This arm requires
  * `normalizedSnapshots`, so it only matches genuinely-legacy data; canonical
- * and empty inputs fall through to the canonical schema below.
- *
- * A hybrid payload carrying BOTH a canonical `latestUsage` and snapshots keeps
- * its canonical value. The transform uses key-presence semantics (NOT value
- * nullish): an explicit `latestUsage` — even `null` — means the state already
- * migrated, so it wins; only an absent key falls back to the snapshot-derived
- * value. This exactly matches the prior preprocess guard (`'latestUsage' in
- * raw`) and avoids reviving stale snapshot data over a canonical value.
+ * and empty inputs fall through to the canonical schema below. Hybrid payloads
+ * that carry both keys keep their canonical `latestUsage` (see the transform).
  *
  * Each snapshot is parsed tolerantly (`.catch`): the old preprocess only ever
- * read the last element's `usage`, so a malformed *earlier* snapshot must not
+ * read the last element's `usage`, so a malformed earlier snapshot must not
  * fail the whole arm (which would drop the latest valid usage on resume). A
  * malformed `usage` degrades to `null` rather than rejecting the payload.
  */
@@ -80,10 +74,12 @@ const LegacyRunUsageAccumulatorSchema = z
   .transform(
     (legacy): RunUsageAccumulatorJSON => ({
       totals: legacy.totals,
-      // Key-presence, not value-nullish: `.nullish()` parses an absent key as
-      // `undefined` and an explicit `null` as `null`, so `!== undefined` keeps
-      // an explicit null (already-migrated state) and only an absent key falls
-      // back to the latest snapshot.
+      // Key-presence, not value-nullish: a hybrid payload carrying both an
+      // explicit `latestUsage` (even `null`, an already-migrated state) and
+      // snapshots must keep the canonical value. `.nullish()` parses an absent
+      // key as `undefined` and an explicit `null` as `null`, so `!== undefined`
+      // keeps an explicit null and only an absent key falls back to the latest
+      // snapshot. Matches the prior `'latestUsage' in raw` preprocess guard.
       latestUsage:
         legacy.latestUsage !== undefined
           ? legacy.latestUsage

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -1,7 +1,5 @@
-// Standard library imports
 import * as path from 'node:path';
 
-// Local imports
 import { getExecutionStore } from '@agent/storage';
 import type { StageHandle } from '@agent/trace';
 import {
@@ -48,7 +46,6 @@ import {
 import { PromptBuilder } from '@utils/prompt';
 import { readPlatformSetting } from '@utils/config/platformSettings';
 
-// Local imports - flow nodes and state
 import { TeXCountNode } from './nodes/TeXCountNode';
 import { MediaExtractionNode } from './nodes/MediaExtractionNode';
 import { PrepareContextNode } from './nodes/PrepareContextNode';

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -232,7 +232,7 @@ function migrateLegacyAgentNameKeys(): void {
         // keys literally, so a cross-category key would orphan the toggle).
         // Keep the original key when no agent of this category matches, rather
         // than inventing one.
-        const rewritten = key.slice(0, key.length - name.length) + alias;
+        const rewritten = withAgentName(key, alias);
         if (getAgent(rewritten)?.category === category) return rewritten;
         const canonical = getCategoryAgent(category, alias);
         return canonical ? agentKeyOf(canonical) : key;
@@ -305,8 +305,9 @@ function migrateFilenameAgentNameKeys(entries: readonly AgentEntry[]): void {
       'Migrated filename-based agent names',
       (key) => {
         const name = agentName(key);
-        const prefix = key.slice(0, key.length - name.length);
-        if (prefix) return qualified.get(key) ?? key;
+        // A source-qualified key differs from its bare name; match it in full,
+        // otherwise map the bare name.
+        if (key !== name) return qualified.get(key) ?? key;
         return bare.get(name) ?? key;
       },
     );
@@ -324,6 +325,15 @@ function singleTargetMappings(
     }
   }
   return mappings;
+}
+
+/**
+ * Replace the name part of a possibly source-qualified key while preserving its
+ * source prefix ("src:old" → "src:new", bare "old" → "new").
+ */
+function withAgentName(key: string, newName: string): string {
+  const name = agentName(key);
+  return key.slice(0, key.length - name.length) + newName;
 }
 
 /**
@@ -358,11 +368,9 @@ export function getAgent(
   // Legacy-name fallback, for both bare names ("chat") and source-qualified
   // keys ("builtInToolUse:chat"): map the name part through the alias table
   // and retry once.
-  const name = agentName(identifier);
-  const alias = LEGACY_AGENT_ALIASES[name];
+  const alias = LEGACY_AGENT_ALIASES[agentName(identifier)];
   if (alias) {
-    const prefix = identifier.slice(0, identifier.length - name.length);
-    return getAgent(`${prefix}${alias}`, lookupCategory);
+    return getAgent(withAgentName(identifier, alias), lookupCategory);
   }
   return undefined;
 }

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -496,19 +496,19 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
     return isGemini3Model(this.config.fullName);
   }
 
-  private getMediaResolution(mimeType: string): MediaResolution | undefined {
-    if (!this.isGemini3Model()) return undefined;
-    if (mimeType.startsWith('image/')) return 'high';
-    // Interactions DocumentContent currently has no resolution field, so PDF
-    // resolution cannot mirror generateContent until the SDK exposes it.
-    return undefined;
-  }
-
+  /**
+   * Optional `resolution` field for an Interactions media `Content`: Gemini 3
+   * images use high resolution; everything else omits the field.
+   */
   private mediaResolutionFields(mimeType: string): {
     resolution?: MediaResolution;
   } {
-    const resolution = this.getMediaResolution(mimeType);
-    return resolution ? { resolution } : {};
+    // Interactions DocumentContent currently has no resolution field, so PDF
+    // resolution cannot mirror generateContent until the SDK exposes it.
+    if (this.isGemini3Model() && mimeType.startsWith('image/')) {
+      return { resolution: 'high' };
+    }
+    return {};
   }
 
   /**

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -2649,6 +2649,16 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   // Message modification methods (for post-build enrichment)
   // =========================================================================
 
+  /** Find the last user message in the conversation, if any. */
+  private findLastUserMessage(
+    messages: ResponseInputItem[],
+  ): EasyInputMessage | ResponseInputItem.Message | undefined {
+    return messages.findLast(
+      (m): m is EasyInputMessage | ResponseInputItem.Message =>
+        isMessageItem(m) && m.role === 'user',
+    );
+  }
+
   /**
    * Prepend text to the last user message in the conversation.
    * Finds the last user message and prepends text to its content.
@@ -2656,10 +2666,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   prependTextToUserMessage(messages: ResponseInputItem[], text: string): void {
     if (!text.trim()) return;
 
-    const lastUserMsg = messages.findLast(
-      (m): m is EasyInputMessage | ResponseInputItem.Message =>
-        isMessageItem(m) && m.role === 'user',
-    );
+    const lastUserMsg = this.findLastUserMessage(messages);
     if (!lastUserMsg || !Array.isArray(lastUserMsg.content)) return;
 
     const content = lastUserMsg.content;
@@ -2681,10 +2688,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   ): Promise<void> {
     if (!mediaFiles.length || !this.capabilities.supportsVision) return;
 
-    const lastUserMsg = messages.findLast(
-      (m): m is EasyInputMessage | ResponseInputItem.Message =>
-        isMessageItem(m) && m.role === 'user',
-    );
+    const lastUserMsg = this.findLastUserMessage(messages);
     if (!lastUserMsg || !Array.isArray(lastUserMsg.content)) return;
 
     try {

--- a/src/agent/modelHandlers/support/openAiCompatiblePrefill.ts
+++ b/src/agent/modelHandlers/support/openAiCompatiblePrefill.ts
@@ -1,6 +1,8 @@
 import type { AgentTrace } from '@agent/trace';
-import type { AgentSetting } from '@agent/core/definition/AgentDataclass';
-import { hasEndTag } from '@agent/core/definition/AgentDataclass';
+import {
+  hasEndTag,
+  type AgentSetting,
+} from '@agent/core/definition/AgentDataclass';
 import type { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import type { FileLocation } from '@shared/schemas';
 import { flexibleFS } from '@utils/files';

--- a/src/agent/modelHandlers/types/ServerToolTypes.ts
+++ b/src/agent/modelHandlers/types/ServerToolTypes.ts
@@ -298,11 +298,7 @@ export function extractAnthropicWebSearchResults(
 function isWebFetchBlock(
   content: WebFetchToolResultBlock['content'],
 ): content is WebFetchBlock {
-  return (
-    typeof content === 'object' &&
-    content !== null &&
-    content.type === 'web_fetch_result'
-  );
+  return hasBlockType(content, 'web_fetch_result');
 }
 
 /**

--- a/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
+++ b/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
@@ -72,7 +72,7 @@ const ERROR_PAYLOAD_STRIPPED_KEYS = new Set([
  * Each variant is a looseObject to preserve unknown keys for forward
  * compatibility.
  *
- * This is what gets passed to handlers — no binary data, properly typed fields.
+ * This is what gets passed to handlers: no binary data, properly typed fields.
  */
 export const ToolResultPayloadSchema = z.discriminatedUnion('status', [
   z.looseObject({
@@ -353,38 +353,32 @@ export function formatToolResultAsText(
 ): string {
   const textPieces: string[] = [];
 
-  if (result.status === 'executed') {
-    // Primary output text (the tool's result)
-    if (isNonEmptyString(result.output)) {
-      textPieces.push(result.output);
-    }
-    // userPatch captures user modifications to tool proposals (distinct from
-    // userDiffNote which only shows merge conflicts). Include when user modified
-    // the proposed edit.
-    if (result.userPatch) {
-      textPieces.push(
-        `User modifications:\n\`\`\`diff\n${result.userPatch}\n\`\`\``,
-      );
-    }
-    if (result.userInstruction) {
-      textPieces.push(`User feedback: ${result.userInstruction}`);
-    }
-    // Fallback to summary when no output text was produced
-    if (textPieces.length === 0 && result.summary) {
-      textPieces.push(result.summary);
-    }
-  } else {
-    // Error variant — error is required (non-empty string), no output/summary
-    if (result.userPatch) {
-      textPieces.push(
-        `User modifications:\n\`\`\`diff\n${result.userPatch}\n\`\`\``,
-      );
-    }
-    if (result.userInstruction) {
-      textPieces.push(`User feedback: ${result.userInstruction}`);
-    }
-    textPieces.push(result.error);
+  // Primary output text, present on the executed variant only.
+  if (result.status === 'executed' && isNonEmptyString(result.output)) {
+    textPieces.push(result.output);
   }
+
+  // userPatch / userInstruction are shared fields on both variants. userPatch
+  // captures user modifications to tool proposals (distinct from userDiffNote,
+  // which only shows merge conflicts); include it when the user modified the
+  // proposed edit.
+  if (result.userPatch) {
+    textPieces.push(
+      `User modifications:\n\`\`\`diff\n${result.userPatch}\n\`\`\``,
+    );
+  }
+  if (result.userInstruction) {
+    textPieces.push(`User feedback: ${result.userInstruction}`);
+  }
+
+  if (result.status === 'error') {
+    // Error variant: error is a required non-empty string, no output/summary.
+    textPieces.push(result.error);
+  } else if (textPieces.length === 0 && result.summary) {
+    // Fallback to summary when no output text was produced.
+    textPieces.push(result.summary);
+  }
+
   if (attachmentSummary) {
     textPieces.push(attachmentSummary);
   }

--- a/src/agent/node/index.ts
+++ b/src/agent/node/index.ts
@@ -221,21 +221,18 @@ class Node<
           },
         );
       } catch (e) {
-        if (e instanceof AbortError) {
-          // AbortError is thrown by our pre-attempt check above.
-          return await this.execFallback(
-            prepRes,
-            lastExecError ?? e.originalError ?? e,
-          );
-        }
-        // signal aborted during delay (p-retry rethrows signal.reason) or
-        // shouldAutoRetry returned false: forward the original exec error.
+        // User cancellation surfaces here as p-retry's aborted-delay rejection
+        // (signal.reason) or as the unwrapped error from our pre-attempt check
+        // (p-retry rethrows an AbortError's originalError, not the AbortError).
+        // Forward the recorded exec failure when one exists.
         if (this.signal?.aborted) {
           return await this.execFallback(
             prepRes,
             lastExecError ?? (e as Error),
           );
         }
+        // No abort: auto-retries are exhausted or shouldAutoRetry declined.
+        // Offer the manual retry prompt before falling back.
         const shouldRetry = await this.retryPrompt(prepRes, e as Error);
         if (shouldRetry) continue;
         return await this.execFallback(prepRes, e as Error);

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -68,7 +68,7 @@ export class LatexDiffManager {
   }
 
   /**
-   * Directory of the document's live workspace source — the one place that
+   * Directory of the document's live workspace source, the one place that
    * carries the `figures/` and `.bib` dependencies the diff still `\input`s.
    * The base location is never the live workspace file: `resolveBaseFilesForDiff`
    * (`snapshotResolution.ts`) rewrites a round diff base to its
@@ -81,7 +81,7 @@ export class LatexDiffManager {
    * Assumption: a leading `r<digits>/` segment is a run-storage round prefix,
    * not a real workspace folder. A document whose live source genuinely sits
    * under a top-level `r<digits>/` folder (e.g. a "revision 1" `r1/`) would be
-   * mis-stripped — unavoidable with a relativePath-only heuristic, and rare
+   * mis-stripped: unavoidable with a relativePath-only heuristic, and rare
    * since it collides with the round-directory naming.
    */
   private resolveWorkspaceSourceDir(location: FileLocation): string {

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 
+import escapeRegExp from 'escape-string-regexp';
 import { XMLParser } from 'fast-xml-parser';
 
 import {
@@ -195,10 +196,6 @@ function shouldKeepPercentHeaderAsLatexComment(
 
 function hasLikelyLatexContent(lines: readonly string[]): boolean {
   return lines.some((line) => LIKELY_LATEX_CONTENT_REGEX.test(line.trim()));
-}
-
-function escapeRegExp(value: string): string {
-  return value.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function stripXmlTagBlocks(content: string, tagName: string): string {

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -615,21 +615,14 @@ export class ExecutionRegistry {
           cascadeChildren: options.detachActiveChildren !== true,
         })
       : this.interruptRegisteredStream(streamId, runtimeHost);
-    if (!stopped && runtimeHost) {
-      this.streamStatus.set(streamId, STREAM_STATUS.STOPPED, { runtimeHost });
+    if (stopped) {
+      return { kind: 'interrupted', streamId, childPolicy };
     }
-    if (!stopped && !runtimeHost) {
-      return {
-        kind: 'no_target',
-        streamId,
-        childPolicy,
-      };
+    if (!runtimeHost) {
+      return { kind: 'no_target', streamId, childPolicy };
     }
-    return {
-      kind: stopped ? 'interrupted' : 'marked_stopped',
-      streamId,
-      childPolicy,
-    };
+    this.streamStatus.set(streamId, STREAM_STATUS.STOPPED, { runtimeHost });
+    return { kind: 'marked_stopped', streamId, childPolicy };
   }
 
   /** Get active subagent and process children for a parent stream. */

--- a/src/auth/codex/codexOAuthClient.ts
+++ b/src/auth/codex/codexOAuthClient.ts
@@ -59,6 +59,28 @@ async function postForm(url: string, body: URLSearchParams): Promise<Response> {
   }
 }
 
+/** POST a JSON body, mapping a network failure to a CodexAuthError. */
+async function postJson(
+  url: string,
+  body: unknown,
+  networkErrorMessage: string,
+  networkErrorKind: CodexAuthError['kind'],
+): Promise<Response> {
+  try {
+    return await fetch(url, {
+      method: 'POST',
+      headers: JSON_HEADERS,
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+  } catch (cause) {
+    throw new CodexAuthError(
+      `${networkErrorMessage}: ${toErrorMessage(cause)}`,
+      networkErrorKind,
+    );
+  }
+}
+
 /** Throw a CodexAuthError for a non-ok HTTP response, appending any body text. */
 async function throwHttpError(
   response: Response,
@@ -134,20 +156,12 @@ export async function refreshTokens(
 
 /** Begin the device-code flow: request a user code to display. */
 export async function requestDeviceUserCode(): Promise<CodexDeviceUserCode> {
-  let response: Response;
-  try {
-    response = await fetch(CODEX_DEVICE_USERCODE_URL, {
-      method: 'POST',
-      headers: JSON_HEADERS,
-      body: JSON.stringify({ client_id: CODEX_CLIENT_ID }),
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-    });
-  } catch (cause) {
-    throw new CodexAuthError(
-      `Network error requesting device code: ${toErrorMessage(cause)}`,
-      'transient',
-    );
-  }
+  const response = await postJson(
+    CODEX_DEVICE_USERCODE_URL,
+    { client_id: CODEX_CLIENT_ID },
+    'Network error requesting device code',
+    'transient',
+  );
   if (response.status === 404) {
     throw new CodexAuthError(
       'Device-code login is not enabled for this account. Enable it under ChatGPT settings → Security (chatgpt.com/settings/security), then try again.',
@@ -177,24 +191,13 @@ export async function pollDeviceToken(params: {
   deviceAuthId: string;
   userCode: string;
 }): Promise<CodexDeviceToken> {
-  let response: Response;
-  try {
-    response = await fetch(CODEX_DEVICE_TOKEN_URL, {
-      method: 'POST',
-      headers: JSON_HEADERS,
-      body: JSON.stringify({
-        device_auth_id: params.deviceAuthId,
-        user_code: params.userCode,
-      }),
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-    });
-  } catch (cause) {
-    // Network blip mid-poll: treat as pending so the loop keeps trying.
-    throw new CodexAuthError(
-      `Network error polling device authorization: ${toErrorMessage(cause)}`,
-      'pending',
-    );
-  }
+  // A network blip mid-poll is reported as 'pending' so the loop keeps trying.
+  const response = await postJson(
+    CODEX_DEVICE_TOKEN_URL,
+    { device_auth_id: params.deviceAuthId, user_code: params.userCode },
+    'Network error polling device authorization',
+    'pending',
+  );
   if (response.status === 403 || response.status === 404) {
     throw new CodexAuthError(
       'Authorization pending',

--- a/src/common/errors/sdkError/chatgptSubscriptionDetection.ts
+++ b/src/common/errors/sdkError/chatgptSubscriptionDetection.ts
@@ -24,13 +24,13 @@ export interface ChatGptSubscriptionLimit {
 
 function pickStringField(value: unknown, key: string): string | undefined {
   if (!isObject(value)) return undefined;
-  const field = (value as Record<string, unknown>)[key];
+  const field = value[key];
   return isString(field) && field.trim().length > 0 ? field : undefined;
 }
 
 function pickNumberField(value: unknown, key: string): number | undefined {
   if (!isObject(value)) return undefined;
-  const field = (value as Record<string, unknown>)[key];
+  const field = value[key];
   return typeof field === 'number' && Number.isFinite(field)
     ? field
     : undefined;
@@ -45,10 +45,7 @@ export function parseChatGptSubscriptionLimit(
   rawErrorBody: unknown,
 ): ChatGptSubscriptionLimit | null {
   if (!isObject(rawErrorBody)) return null;
-  const candidates = [
-    rawErrorBody,
-    (rawErrorBody as { error?: unknown }).error,
-  ];
+  const candidates = [rawErrorBody, rawErrorBody.error];
   for (const candidate of candidates) {
     if (pickStringField(candidate, 'type') !== 'usage_limit_reached') continue;
     return {

--- a/src/controllers/mainView/MainViewBaseFileController.ts
+++ b/src/controllers/mainView/MainViewBaseFileController.ts
@@ -34,7 +34,7 @@ export interface MainViewBaseFileSelectionPlan {
  *
  * The caller is responsible for deriving the base file path (via
  * `deriveBaseFileFromLatexDiff`) and checking disk existence (via
- * `WorkspaceFS.exists`) — this function only decides what to do with
+ * `WorkspaceFS.exists`). This function only decides what to do with
  * those results.
  *
  * @param currentOpenFile - The path of the currently open editor file.
@@ -48,7 +48,7 @@ export function planCurrentFileAsBase(
   derivedBaseFileExists: boolean,
 ): MainViewBaseFileSelectionPlan {
   if (!derivedBaseFile) {
-    // Not a latexdiff file — select the current file as-is.
+    // Not a latexdiff file, so select the current file as-is.
     return {
       filePathToSelect: currentOpenFile,
       shouldPostSetCurrentFile: true,

--- a/src/controllers/onboarding/defaultTeamSeeding.ts
+++ b/src/controllers/onboarding/defaultTeamSeeding.ts
@@ -82,11 +82,12 @@ export async function seedRosterFromDefaultTeam(
   ) {
     return false;
   }
+  // Prefer the user's recorded default team; fall back to the host's startup
+  // team when no default is recorded or the recorded id no longer resolves.
   const { fallbackTeamId = DEFAULT_STARTUP_TEAM_ID } = options;
-  const teamId = getDefaultTeamId(globalState) ?? fallbackTeamId;
-  if (!teamId) return false;
+  const defaultTeamId = getDefaultTeamId(globalState);
   const preset =
-    resolveTeamPreset(teamId) ??
+    (defaultTeamId ? resolveTeamPreset(defaultTeamId) : undefined) ??
     (fallbackTeamId ? resolveTeamPreset(fallbackTeamId) : undefined);
   if (!preset) return false;
   await applyPresetRoster(registryPresetRosterState(workspaceState), preset);

--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -68,7 +68,7 @@ export class ProgressApiKeyRetryController {
     } else {
       // Relay/subscription exhaustion does not break the stored direct key, so
       // if a usable one already exists, switch to it and retry without
-      // re-prompting — the user has already provided a key. Only prompt when
+      // re-prompting, since the user has already provided a key. Only prompt when
       // none exists yet, and only re-check the keys after that prompt (so the
       // common already-set path reads the secret store once, not twice).
       shouldProceed = await this.hasAnyUsableKey(providersToCheck);
@@ -87,8 +87,8 @@ export class ProgressApiKeyRetryController {
       };
     }
 
-    // Disable relay (included access) so the retry uses the user's own key —
-    // not the relay JWT — whenever the switch promises "your own API key".
+    // Disable relay (included access) so the retry uses the user's own key,
+    // not the relay JWT, whenever the switch promises "your own API key".
     // Both relay exhaustion (viaRelay) and subscription exhaustion
     // (chatgptSubscription) fall through to `super.getApiKey()`, which otherwise
     // still prefers relay when included access is on, so the retry would never

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -133,8 +133,8 @@ export function createProgressViewCommandHandlers(
 
   // Single source of truth for the coupled edit + bash session bypass behind
   // the one Yolo concept. The shield toolbar button flips it; the inline "Yolo
-  // (this session)" prompt button forces it on. Bash rides along silently — the
-  // shield reflects tool-edit state — so both surfaces stay in lockstep.
+  // (this session)" prompt button forces it on. Bash rides along silently (the
+  // shield reflects tool-edit state), so both surfaces stay in lockstep.
   const applyCoupledBypass = async (
     stream: StreamTabId,
     enabled: boolean,

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -178,7 +178,6 @@ class ArxivSourceProcessor {
     timeout: number,
   ): Promise<string> {
     let destPath = destBasePath;
-    let usedDispositionFilename = false;
     let shouldCleanup = true;
     try {
       // AbortSignal.timeout covers both connection establishment and body streaming.
@@ -203,12 +202,12 @@ class ArxivSourceProcessor {
       // which handles both `filename=` and `filename*=UTF-8''...` (percent-encoded
       // Unicode names that the old regex silently dropped).
       const disposition = response.headers.get('content-disposition');
+      let filename: string | undefined;
       if (disposition) {
-        let filename: string | undefined;
         try {
           filename = parseContentDisposition(disposition).parameters.filename;
         } catch (error) {
-          // Malformed header — fall through to content-type fallback below.
+          // Malformed header; the content-type fallback below handles it.
           logger.debug(
             this.channel,
             'Ignoring malformed Content-Disposition header from arXiv source download',
@@ -220,16 +219,14 @@ class ArxivSourceProcessor {
             },
           );
         }
-        if (filename) {
-          // basename prevents path traversal from a crafted header value.
-          destPath = path.join(
-            path.dirname(destBasePath),
-            path.basename(filename),
-          );
-          usedDispositionFilename = true;
-        }
       }
-      if (!usedDispositionFilename) {
+      if (filename) {
+        // basename prevents path traversal from a crafted header value.
+        destPath = path.join(
+          path.dirname(destBasePath),
+          path.basename(filename),
+        );
+      } else {
         const contentType = response.headers.get('content-type') ?? '';
         const extension = this.getExtensionFromContentType(contentType);
         destPath = destBasePath + extension;

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -57,7 +57,7 @@ interface ModelAvailabilityStatus {
 }
 
 /**
- * Per-kind status fields. `kind` is intentionally omitted here — the record key
+ * Per-kind status fields. `kind` is intentionally omitted here: the record key
  * is the single source of truth and `availabilityStatus()` reattaches it.
  */
 const AVAILABILITY_STATUS_FIELDS: Record<

--- a/src/platform/defaults/nodeFsOps.ts
+++ b/src/platform/defaults/nodeFsOps.ts
@@ -5,8 +5,8 @@ import * as fs from 'node:fs';
  * in the VS Code host: `vscode.workspace.fs` offers no chunked read and does
  * not reliably report the symbolic-link bit across platforms. Both
  * `FileSystemProvider` implementations (Node and VS Code) delegate here, so the
- * Node-fs fallback surface — and the reason it bypasses the host FS — lives in
- * one place. The extension host is always Node, so this is safe there too.
+ * Node-fs fallback surface and the reason it bypasses the host FS live in one
+ * place. The extension host is always Node, so this is safe there too.
  */
 
 export async function isSymlink(target: string): Promise<boolean> {

--- a/src/shared/constants/agents.ts
+++ b/src/shared/constants/agents.ts
@@ -29,8 +29,7 @@ export const BUILTIN_TEAM_ROOT_AGENT_NAMES = [
  * and task-flavored fallbacks for users without sign-in.
  */
 export const PREFERRED_TOOL_USE_AGENTS = [
-  ...REMOTE_ORCHESTRATOR_AGENT_NAMES,
-  ...BUNDLED_ORCHESTRATOR_AGENT_NAMES,
+  ...BUILTIN_TEAM_ROOT_AGENT_NAMES,
   'assistant',
   'research',
   'review',

--- a/src/shared/mainView/executeMessage.ts
+++ b/src/shared/mainView/executeMessage.ts
@@ -83,7 +83,7 @@ function buildMainViewMultipleFileSelections(
     const listId = `${type}Files` as keyof MultiFiles;
     const files = type === 'output' ? [] : (multiFiles[listId] ?? []);
     selections[listId] = files;
-    selections[`${listId}Active`] = type !== 'output' && files.length > 0;
+    selections[`${listId}Active`] = files.length > 0;
   }
   return selections;
 }

--- a/src/shared/schemas/agent.ts
+++ b/src/shared/schemas/agent.ts
@@ -46,7 +46,7 @@ export const AgentNameSchema = z
   .string()
   .trim()
   .min(1)
-  .refine((name) => AGENT_NAME_IDENTIFIER.test(name), {
+  .regex(AGENT_NAME_IDENTIFIER, {
     message:
       'Agent names must be identifiers: letters, numbers, underscores, or hyphens.',
   });

--- a/src/shared/schemas/prompts.ts
+++ b/src/shared/schemas/prompts.ts
@@ -120,28 +120,26 @@ const ExternalInquiryHydrationFieldsSchema = z.object({
   transcript: z.array(InquiryTranscriptTurnSchema).nullish(),
 });
 
+// Both inquiry modes share the same fields and differ only in the `mode`
+// discriminator. Hydration fields live on both so the discriminated union
+// exposes a common surface for renderers that read them regardless of mode.
+const ExternalInquiryPermissionBaseSchema = PermissionBaseSchema.extend(
+  CommonExternalInquiryFieldsSchema.shape,
+).extend(ExternalInquiryHydrationFieldsSchema.shape);
+
 /**
  * First inquiry in a thread. Fresh dispatches have no prior transcript, draft,
  * or session links, but durable hydration may carry a saved open-turn draft.
  */
-export const NewExternalInquiryPermissionSchema = PermissionBaseSchema.extend(
-  CommonExternalInquiryFieldsSchema.shape,
-).extend({
-  mode: z.literal('new'),
-  // Included so the discriminated union produces a common surface for renderers
-  // that access these fields.
-  ...ExternalInquiryHydrationFieldsSchema.shape,
-});
+export const NewExternalInquiryPermissionSchema =
+  ExternalInquiryPermissionBaseSchema.extend({ mode: z.literal('new') });
 export type NewExternalInquiryPermission = z.infer<
   typeof NewExternalInquiryPermissionSchema
 >;
 
 /** Follow-up inquiry — carries thread context from prior turns. */
 export const FollowUpExternalInquiryPermissionSchema =
-  PermissionBaseSchema.extend(CommonExternalInquiryFieldsSchema.shape).extend({
-    mode: z.literal('followUp'),
-    ...ExternalInquiryHydrationFieldsSchema.shape,
-  });
+  ExternalInquiryPermissionBaseSchema.extend({ mode: z.literal('followUp') });
 export type FollowUpExternalInquiryPermission = z.infer<
   typeof FollowUpExternalInquiryPermissionSchema
 >;

--- a/src/shared/settingsView/handlers/approvalHandlers.ts
+++ b/src/shared/settingsView/handlers/approvalHandlers.ts
@@ -26,61 +26,54 @@ import {
 } from '@shared/schemas/agentCliSettings';
 import type { SettingsStatePorts } from '@shared/settingsView/types';
 import type { ConfigProvider, ConfigTarget } from '@platform/interfaces/config';
-import type { StateStore } from '@platform/interfaces/state';
 
 export interface ApprovalHandlerPorts extends SettingsStatePorts {
   readonly config: ConfigProvider;
-}
-
-/** Read a workspace-state string (with default) and parse it to its enum. */
-function readParsedSetting<T>(
-  workspaceState: StateStore,
-  key: WorkspaceStateKey,
-  fallback: string,
-  parse: (raw: string) => T,
-): T {
-  return parse(workspaceState.get<string>(key, fallback));
 }
 
 export function buildApprovalSettingsMessage(
   ports: ApprovalHandlerPorts,
 ): UpdateApprovalSettingsMessage {
   const { workspaceState, config } = ports;
+
+  // Read a workspace-state string (with default) and parse it to its enum.
+  function read<T>(
+    key: WorkspaceStateKey,
+    fallback: string,
+    parse: (raw: string) => T,
+  ): T {
+    return parse(workspaceState.get<string>(key, fallback));
+  }
+
   return {
     command: SETTINGS_VIEW_COMMANDS.UPDATE_APPROVAL_SETTINGS,
     bashApprovalEnabled: config.get<boolean>(BASH_APPROVAL_CONFIG_KEY, true),
-    codexSandboxMode: readParsedSetting(
-      workspaceState,
+    codexSandboxMode: read(
       WorkspaceStateKey.CODEX_SANDBOX_MODE,
       CODEX_SANDBOX_MODE_DEFAULT,
       parseCodexSandboxMode,
     ),
-    codexReasoningEffort: readParsedSetting(
-      workspaceState,
+    codexReasoningEffort: read(
       WorkspaceStateKey.CODEX_REASONING_EFFORT,
       CODEX_REASONING_EFFORT_DEFAULT,
       parseCodexReasoningEffort,
     ),
-    codexApprovalPolicy: readParsedSetting(
-      workspaceState,
+    codexApprovalPolicy: read(
       WorkspaceStateKey.CODEX_APPROVAL_POLICY,
       CODEX_APPROVAL_POLICY_DEFAULT,
       parseCodexApprovalPolicy,
     ),
-    claudeAgentModel: readParsedSetting(
-      workspaceState,
+    claudeAgentModel: read(
       WorkspaceStateKey.CLAUDE_AGENT_MODEL,
       CLAUDE_AGENT_DEFAULT_MODEL,
       parseClaudeAgentModel,
     ),
-    claudeAgentPermissionMode: readParsedSetting(
-      workspaceState,
+    claudeAgentPermissionMode: read(
       WorkspaceStateKey.CLAUDE_AGENT_PERMISSION_MODE,
       CLAUDE_AGENT_DEFAULT_PERMISSION_MODE,
       parseClaudeAgentPermissionMode,
     ),
-    claudeAgentEffort: readParsedSetting(
-      workspaceState,
+    claudeAgentEffort: read(
       WorkspaceStateKey.CLAUDE_AGENT_EFFORT,
       CLAUDE_AGENT_DEFAULT_EFFORT,
       parseClaudeAgentEffort,

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -1,7 +1,5 @@
 import { css, unsafeCSS, type CSSResult } from 'lit';
 
-/** Shared selector groups that drive the :is() consolidation below. */
-
 /**
  * Single source of truth for request panel types. Each entry pairs the outer
  * container class (plural), the item class (singular, used for cards and BEM

--- a/src/telemetry/UsageLogService.ts
+++ b/src/telemetry/UsageLogService.ts
@@ -172,7 +172,7 @@ class UsageLogServiceImpl {
   ): Promise<UsageLogResponse> {
     // ky's `timeout` only guards until response headers arrive (it clears the
     // timer once fetch settles), so a server that stalls mid-body would hang the
-    // subsequent `.json()` read indefinitely — wedging activeFlush and dispose().
+    // subsequent `.json()` read indefinitely, wedging activeFlush and dispose().
     // AbortSignal.timeout stays armed through the body read, like the previous
     // manual AbortController did.
     const data = await ky

--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -145,11 +145,15 @@ export class DiagnosticsTool extends defineTool({
     return this.readDiagnostics(input);
   }
 
+  /** Resolve an input path to an absolute path against the active working directory. */
+  private resolveAbsolutePath(filePath: string): string {
+    const workingDirectory = tryUseRunContext()?.workingDirectory;
+    return resolveWorkspaceRelativePath(filePath, workingDirectory).absolute;
+  }
+
   private async readDiagnostics(input: DiagnosticsInput): Promise<ToolResult> {
     const { command, path } = input;
-    const workingDirectory = tryUseRunContext()?.workingDirectory;
-    const resolved = resolveWorkspaceRelativePath(path, workingDirectory);
-    const diagnosticsPath = resolved.absolute;
+    const diagnosticsPath = this.resolveAbsolutePath(path);
 
     try {
       const messages = await linterProvider(diagnosticsPath);
@@ -198,10 +202,9 @@ export class DiagnosticsTool extends defineTool({
     }
 
     try {
-      const workingDirectory = tryUseRunContext()?.workingDirectory;
-      const resolved = resolveWorkspaceRelativePath(path, workingDirectory);
+      const absolutePath = this.resolveAbsolutePath(path);
       const result = criticismSink({
-        absolutePath: resolved.absolute,
+        absolutePath,
         line,
         message,
         severity,
@@ -214,7 +217,7 @@ export class DiagnosticsTool extends defineTool({
             'Inline criticism diagnostics are disabled. Enable "texra.inlineCriticism.enabled" in settings to surface critiques as diagnostics.',
         };
       }
-      const where = result.resolvedPath || resolved.absolute;
+      const where = result.resolvedPath || absolutePath;
       const summary = `Added criticism for ${where}:${line} (S${severity}/C${confidence})`;
       return { summary, output: summary };
     } catch (error) {

--- a/src/tools/arxiv/ArxivDownloadTool.ts
+++ b/src/tools/arxiv/ArxivDownloadTool.ts
@@ -16,10 +16,11 @@ const NO_ENTRIES_MESSAGE = '(no entries)';
 const DEFAULT_HIDDEN_NAMES = new Set(['.git', '.gitignore']);
 
 function formatDirEntry(name: string, type: number): string {
+  const isDir = isDirectory(type);
   let label = 'other';
-  if (isDirectory(type)) label = 'dir';
+  if (isDir) label = 'dir';
   else if (isFile(type)) label = 'file';
-  const suffix = isDirectory(type) ? '/' : '';
+  const suffix = isDir ? '/' : '';
   return `${label.padEnd(4)} ${name}${suffix}`;
 }
 

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -20,8 +20,10 @@ import { z } from 'zod';
 import type { WorkPlanState } from '@agent/core/state/AgentWorkspaceState';
 import type { PlanApprovalResult } from '@agent/runtime/PlanApprovalCoordinator';
 import { currentSession } from '@agent/runtime/SessionHandle';
-import { getCurrentToolContexts } from '@agent/followUp/ToolFileInteractionContext';
-import type { CurrentToolContexts } from '@agent/followUp/ToolFileInteractionContext';
+import {
+  getCurrentToolContexts,
+  type CurrentToolContexts,
+} from '@agent/followUp/ToolFileInteractionContext';
 import { toErrorMessage } from '@common/errors';
 import { createChannelTrace } from '@logger';
 import type { Plan } from '@shared/schemas';
@@ -31,13 +33,13 @@ import {
   isGoalInFlight,
   type Goal,
 } from '@shared/schemas/goal';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { proposalApprovalState } from '@tools/approval';
 import {
   GoalStore,
   isGoalEnabled,
   setGoalSessionBashAutoApproval,
 } from '@tools/goal';
-import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { requireNonEmptyString } from '@tools/utils';
 import { defineTool } from '@tools/core/define';
 

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -154,15 +154,12 @@ export function formatSubagentDelivery(
 ): string {
   const lines = [
     `<subagent-result id="${escapeAttr(result.executionId)}" agent="${escapeAttr(agentName)}" category="${escapeAttr(result.category)}" status="${escapeAttr(result.outcome)}">`,
-  ];
-
-  lines.push(
     ...formatDeliveryPreamble({
       wallTimeMs: options?.wallTimeMs,
       workingDirectory: options?.workingDirectory,
       memoryMisses: result.memoryMisses,
     }),
-  );
+  ];
 
   if (result.category === 'workflow') {
     if (options?.diffsUnavailable) {
@@ -215,14 +212,12 @@ export function formatSubagentError(
   const formatted = normalizeProviderError(err);
   const lines = [
     `<subagent-error id="${escapeAttr(executionId)}" agent="${escapeAttr(agentName)}" retryable="${formatted.userRetryable ? 'true' : 'false'}">`,
-  ];
-  lines.push(
     ...formatDeliveryPreamble({
       wallTimeMs: options?.wallTimeMs,
       workingDirectory: options?.workingDirectory,
       memoryMisses: options?.memoryMisses,
     }),
-  );
+  ];
   lines.push(
     `<message>${escapeText(formatted.message)}</message>`,
     '</subagent-error>',

--- a/src/tools/zotero/ZoteroCollectionsTool.ts
+++ b/src/tools/zotero/ZoteroCollectionsTool.ts
@@ -165,7 +165,7 @@ export class ZoteroCollectionsTool extends defineTool({
       z.array(BbtLibrarySchema),
     );
 
-    if (!Array.isArray(libraries) || libraries.length === 0) {
+    if (libraries.length === 0) {
       return {
         summary: 'No libraries found in Zotero.',
         output:

--- a/src/tools/zotero/ZoteroSearchTool.ts
+++ b/src/tools/zotero/ZoteroSearchTool.ts
@@ -166,7 +166,7 @@ export class ZoteroSearchTool extends defineTool({
 
     const label = describeSearch({ query, title, author, year });
 
-    if (!Array.isArray(result) || result.length === 0) {
+    if (result.length === 0) {
       return {
         summary: `No results found for ${label}`,
         output: 'No matching items in Zotero library.',

--- a/src/utils/config/platformSettings.ts
+++ b/src/utils/config/platformSettings.ts
@@ -36,13 +36,7 @@ export function readPlatformSetting<T>(
   if (!active) {
     return settingDefault(entry) as T;
   }
-  return readSetting(
-    entry,
-    {
-      config: active.config,
-      workspaceState: active.workspaceState,
-      globalState: active.globalState,
-    },
-    host,
-  ) as T;
+  // `Platform` structurally supplies the `config`/`workspaceState`/`globalState`
+  // slots `readSetting` reads from, so it passes as `SettingsStores` directly.
+  return readSetting(entry, active, host) as T;
 }

--- a/supabase/functions/auth-bridge/index.ts
+++ b/supabase/functions/auth-bridge/index.ts
@@ -292,13 +292,8 @@ function bridgePageHtml(ext: string, id: string): string {
       // so the editor sees the same error it would have on the raw redirect.
       heading.textContent = 'Sign-in did not complete';
       lede.className = 'error';
-      var message;
-      if (errorDescription) {
-        message = errorDescription;
-      } else {
-        message = 'Authorization failed (' + oauthError + ').';
-      }
-      lede.textContent = message;
+      lede.textContent =
+        errorDescription || 'Authorization failed (' + oauthError + ').';
     }
 
     var tail = '';


### PR DESCRIPTION
## What

Round-2 comprehensive simplification of **source code changed since v0.38.9** that was **not** covered by the two existing cleanup PRs:

- #6812 (merged) — round-1 source simplification
- #6832 (open) — test-suite simplification

This PR is the complement: the source files changed since v0.38.9 that neither touched.

## Scope & method

- Enumerated all source (non-test) files changed since `v0.38.9`, subtracted the file sets of #6812 and #6832, and focused on the **461 files with meaningful churn (≥10 changed lines)**. The ~225 files with trivial 1–9 line changes were intentionally skipped to respect the anti-churn bar.
- Grouped into coherent, disjoint per-module batches and ran a code-simplifier over each, then an **adversarial verify pass** per batch that re-read the actual diff and checked behavior-preservation, scope, and convention compliance (self-repairing on any high-severity finding).
- **Test files changed since v0.38.9 were deliberately excluded** to avoid colliding with the still-open test PR #6832.

## Result

**55 files, +291 / −334 (net −43 LoC).** Representative changes:

- Collapse redundant `if/else` chains into early returns or short-circuit expressions
- Inline trivial single-use closures/helpers; flatten a throw/recatch and a few wrapper layers
- Dedupe local helpers against existing shared utilities (`escape-string-regexp`, `path.basename`, shared formatters)
- Pass Zod shape objects directly to `.extend()` (drop redundant spreads); minor Zod v4 idiom tidy
- Tighten import grouping and normalize new-comment prose

No public APIs, exports, or observable behavior changed.

## Verification

- `tsc --noEmit` green for repo-root `src`, `tsconfig.test-kernel.json`, `packages/extension`, and `packages/cli`
- `eslint` clean on all changed files
- Prettier clean (pre-commit hook)
- Rebased onto current `main`; the 3 files that also changed upstream were re-verified individually (typecheck + lint + manual diff review)

## Notes

- The sensitive `auth-bridge` and `codexOAuthClient` edits are limited to behavior-preserving local refactors and were reviewed by hand.
- A pre-existing observation (not introduced here): the `skills` CLI command's NDJSON output dropped its per-record `ts` field when it moved to `emitCliResult` on `main` — flagging for a maintainer to confirm it was intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactors with typecheck/lint called out in the PR; the only subtle areas (auth callback parsing, agent key migration, mainView active flags) appear equivalent to prior logic. No new features or security surface.
> 
> **Overview**
> Round-2 **behavior-preserving** cleanup across ~55 files (net −43 LoC): local refactors, deduplication, and comment/prose tidy—no intentional API or product behavior changes.
> 
> **CLI / TUI:** `Select` centralizes cancel handling in `cancelAndDrop`; orchestration model-step titles/subtitles are shared variables; OpenRouter toggles invalidate the model cache once; auth callback JSON parsing separates `JSON.parse` from Zod validation.
> 
> **Extension / desktop:** Chat export uses a `switch` on format and `path.basename`; Models tab ChatGPT switches use named handlers; unused imports/types dropped; Zod `.extend(fileOpConfigFields)` without redundant spread.
> 
> **Core agent / models:** `withAgentName` dedupes source-qualified key rewrites; filename migration matches qualified keys via `key !== name`; OpenAI Responses adds `findLastUserMessage`; Google Interactions folds media resolution into `mediaResolutionFields`; `formatToolResultAsText` merges shared user-patch/instruction handling; `RunUsageAccumulator` comments tightened; `executionRegistry` stop flow uses early returns.
> 
> **Shared / misc:** `PREFERRED_TOOL_USE_AGENTS` reuses `BUILTIN_TEAM_ROOT_AGENT_NAMES`; external-inquiry permission schemas share a base; `AgentNameSchema` uses `.regex()`; Codex OAuth adds shared `postJson`; `XmlOutputManager` uses `escape-string-regexp`; default team seeding prefers recorded default before host fallback; auth-bridge OAuth error copy simplified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a9056e0fc597ab0e14656f70c4862d62c46bde9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->