### PR TITLE
refactor: consolidate cross-host runtime coupling (macro round 2)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -62,7 +62,6 @@ const COMPOSITION_ROOT_FILES = new Set([
   path.join(__dirname, 'packages/extension/src/extension.ts'),
   path.join(__dirname, 'packages/desktop/src/main/platform/index.ts'),
   path.join(__dirname, 'packages/cli/src/runtime/initPlatform.ts'),
-  path.join(__dirname, 'src/platform/defaults/nodeHost.ts'),
 ]);
 
 const extensionPackageDir = path.join(__dirname, 'packages', 'extension');

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -62,6 +62,7 @@ const COMPOSITION_ROOT_FILES = new Set([
   path.join(__dirname, 'packages/extension/src/extension.ts'),
   path.join(__dirname, 'packages/desktop/src/main/platform/index.ts'),
   path.join(__dirname, 'packages/cli/src/runtime/initPlatform.ts'),
+  path.join(__dirname, 'src/platform/defaults/nodeHost.ts'),
 ]);
 
 const extensionPackageDir = path.join(__dirname, 'packages', 'extension');

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -7,7 +7,6 @@
 
 import PQueue from 'p-queue';
 
-import { tryPlatform } from '@platform/platform';
 import { getDefaultStreamLogStore, StreamSnapshotStore } from '@transcript';
 import { registerExecution, writeTerminalStatus } from '@agent/storage';
 import {
@@ -16,6 +15,7 @@ import {
   type AgentConfigPayload,
 } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { detachSubagentsOnStop } from '@agent/runtime/detachSubagentsOnStop';
 import { executionRegistry } from '@agent/runtime/executionRegistry';
 import {
   executeAgent,
@@ -47,7 +47,6 @@ import {
   type ExecutionId,
   sumUsageStats,
 } from '@shared/schemas';
-import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { generateExecutionId } from '@utils/core/executionId';
 
 import { chatAgentSupportsDelegation } from './tui/commands/handlers/agentModelCommands';
@@ -195,11 +194,7 @@ export function createChatSessionController(
     clearApprovals();
     if (!session.streamId) return;
     executionRegistry.stopAgentStream(session.streamId, {
-      detachActiveChildren:
-        tryPlatform()?.workspaceState.get<boolean>(
-          WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP,
-          false,
-        ) === true,
+      detachActiveChildren: detachSubagentsOnStop(),
       runtimeHost: session.runtimeHost,
     });
   };

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -22,6 +22,7 @@ import { platform, tryPlatform } from '@platform/platform';
 import { getFirstRunDone } from '@controllers/onboarding/onboardingFunnel';
 import { getVisibleAgents, loadAgents } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { detachSubagentsOnStop } from '@agent/runtime/detachSubagentsOnStop';
 import { executionRegistry } from '@agent/runtime/executionRegistry';
 import { sendFollowUp } from '@agent/followUp/ToolUseFollowUp';
 import { type CliContext, readCliVersion } from '@cli/runtime/cliContext';
@@ -55,7 +56,6 @@ import {
   type ExecutionId,
   type StreamTabId,
 } from '@shared/schemas';
-import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { escapeText } from '@shared/utils/xmlEscape';
 import { assertNever } from '@utils/core';
 
@@ -719,11 +719,7 @@ export async function runChat(
       onKillExecution={(executionId) => {
         clearApprovals();
         executionRegistry.kill(executionId, {
-          detachActiveChildren:
-            tryPlatform()?.workspaceState.get<boolean>(
-              WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP,
-              false,
-            ) === true,
+          detachActiveChildren: detachSubagentsOnStop(),
         });
       }}
       history={inputHistory}

--- a/packages/cli/src/chat/tui/state/completedProcessTranscript.ts
+++ b/packages/cli/src/chat/tui/state/completedProcessTranscript.ts
@@ -16,7 +16,7 @@ import type {
 
 export const COMPLETED_PROCESS_TAIL_LINES = 20;
 
-export function completedProcessTailLines(
+function completedProcessTailLines(
   tail: ProcessOutputTail | undefined,
 ): string[] {
   if (!tail) return [];

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -2,14 +2,14 @@
 import * as nodePath from 'node:path';
 
 // Local imports - platform
-import { JsonConfigProvider } from '@platform/defaults/jsonConfigProvider';
 import { JsonStore } from '@platform/defaults/jsonStore';
 import { createLifecycleHost } from '@platform/defaults/lifecycleHost';
-import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
-import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
+import {
+  initNodeAgentRuntime,
+  initNodePlatform,
+} from '@platform/defaults/nodeHost';
 import { SHUTDOWN_PHASE } from '@platform/interfaces/lifecycle';
-import { NO_TOOL_AVAILABILITY_HOST } from '@platform/interfaces/toolAvailability';
-import { initPlatform, tryPlatform } from '@platform/platform';
+import { platform, tryPlatform } from '@platform/platform';
 
 // Local imports - telemetry
 import { UsageLogService } from '@telemetry/UsageLogService';
@@ -20,7 +20,6 @@ import {
   TEXRA_CONFIG_FILE_NAME,
   workspaceTexraConfigPath,
 } from '@platform/defaults/nodeStorage';
-import { initializeGoalPrompts } from '@agent/goal';
 import { bootstrapPlatformAgentDirectories } from '@agent/index/platformAgentDirectories';
 import { PathAgentDirectoryBundleSource } from '@agent/index/AgentDirectorySync';
 
@@ -41,9 +40,6 @@ import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 
 // Local imports - shared state
 import { GlobalStateKey } from '@shared/state/stateKeys';
-
-// Local imports - tool integrations
-import { registerDirectLeanLanguageServices } from '@tools/lean/direct/directLspAdapter';
 
 // Local imports - config
 import { getUseOpenRouter } from '@utils/config/providerConfig';
@@ -193,22 +189,16 @@ export async function initCliPlatform(
         );
       },
     });
-    const config = new JsonConfigProvider({
-      workspace: configStore,
-      global: globalConfigStore,
-    });
-    initPlatform({
-      config,
+    initNodePlatform({
+      configStores: { workspace: configStore, global: globalConfigStore },
       globalState: stateStores.globalState,
       workspaceState: stateStores.workspaceState,
-      fs: nodeFilesystem,
-      workspace: createNodeWorkspace(() => cliWorkspaceCwd),
       storage: stateStores.storage,
       secrets: getCliSecrets(context.storageRoot),
       lifecycle,
       agentResume: { tryResumeStream: async () => false },
+      getWorkspacePath: () => cliWorkspaceCwd,
       toolAvailability: {
-        ...NO_TOOL_AVAILABILITY_HOST,
         isTexraCliEntrypoint: () =>
           isTexraCliEntrypointPath(readCliEntrypointPath()),
       },
@@ -216,13 +206,15 @@ export async function initCliPlatform(
     if (context.installSignalHandlers !== false) {
       installCliShutdownSignalHandlers(lifecycle);
     }
-    // Direct LSP adapter for Lean tools. Errors are surfaced via the Tools
-    // dashboard if `lake` isn't on PATH.
-    registerDirectLeanLanguageServices(lifecycle);
+    // Register the shared Node-host agent runtime: memory + goal tool
+    // injections, the direct Lean language services (errors surface via the
+    // Tools dashboard if `lake` isn't on PATH), and the packaged Goal prompt
+    // path.
+    initNodeAgentRuntime(lifecycle, context.resourcesPath);
 
     // Attribute agent-authored commits to the TeXRA identity by default;
     // configurable via `.texra/config.json` `texra.git.markCommits`.
-    applyCliGitAuthorConfig(config);
+    applyCliGitAuthorConfig(platform().config);
 
     // Route CLI model traffic to the same Supabase usage log the extension
     // writes to, tagged with editorType 'cli' and the CLI version so relay
@@ -272,9 +264,6 @@ export async function initCliPlatform(
   }
   await getServerSideKeyService().setUseIncludedModelAccess(authed);
   await setCliHelperModel(context.helperModel);
-  initializeGoalPrompts(
-    nodePath.join(context.resourcesPath, 'goal', 'goal.yaml'),
-  );
 
   if (bootstrappedResourcesPath !== context.resourcesPath) {
     const globalState = tryPlatform()?.globalState;

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -5,11 +5,12 @@ import * as nodePath from 'node:path';
 import { JsonStore } from '@platform/defaults/jsonStore';
 import { createLifecycleHost } from '@platform/defaults/lifecycleHost';
 import {
+  createNodePlatform,
   initNodeAgentRuntime,
-  initNodePlatform,
+  initializeNodeGoalPrompts,
 } from '@platform/defaults/nodeHost';
 import { SHUTDOWN_PHASE } from '@platform/interfaces/lifecycle';
-import { platform, tryPlatform } from '@platform/platform';
+import { initPlatform, platform, tryPlatform } from '@platform/platform';
 
 // Local imports - telemetry
 import { UsageLogService } from '@telemetry/UsageLogService';
@@ -189,28 +190,29 @@ export async function initCliPlatform(
         );
       },
     });
-    initNodePlatform({
-      configStores: { workspace: configStore, global: globalConfigStore },
-      globalState: stateStores.globalState,
-      workspaceState: stateStores.workspaceState,
-      storage: stateStores.storage,
-      secrets: getCliSecrets(context.storageRoot),
-      lifecycle,
-      agentResume: { tryResumeStream: async () => false },
-      getWorkspacePath: () => cliWorkspaceCwd,
-      toolAvailability: {
-        isTexraCliEntrypoint: () =>
-          isTexraCliEntrypointPath(readCliEntrypointPath()),
-      },
-    });
+    initPlatform(
+      createNodePlatform({
+        configStores: { workspace: configStore, global: globalConfigStore },
+        globalState: stateStores.globalState,
+        workspaceState: stateStores.workspaceState,
+        storage: stateStores.storage,
+        secrets: getCliSecrets(context.storageRoot),
+        lifecycle,
+        agentResume: { tryResumeStream: async () => false },
+        getWorkspacePath: () => cliWorkspaceCwd,
+        toolAvailability: {
+          isTexraCliEntrypoint: () =>
+            isTexraCliEntrypointPath(readCliEntrypointPath()),
+        },
+      }),
+    );
     if (context.installSignalHandlers !== false) {
       installCliShutdownSignalHandlers(lifecycle);
     }
     // Register the shared Node-host agent runtime: memory + goal tool
-    // injections, the direct Lean language services (errors surface via the
-    // Tools dashboard if `lake` isn't on PATH), and the packaged Goal prompt
-    // path.
-    initNodeAgentRuntime(lifecycle, context.resourcesPath);
+    // injections and the direct Lean language services (errors surface via the
+    // Tools dashboard if `lake` isn't on PATH).
+    initNodeAgentRuntime(lifecycle);
 
     // Attribute agent-authored commits to the TeXRA identity by default;
     // configurable via `.texra/config.json` `texra.git.markCommits`.
@@ -264,6 +266,7 @@ export async function initCliPlatform(
   }
   await getServerSideKeyService().setUseIncludedModelAccess(authed);
   await setCliHelperModel(context.helperModel);
+  initializeNodeGoalPrompts(context.resourcesPath);
 
   if (bootstrappedResourcesPath !== context.resourcesPath) {
     const globalState = tryPlatform()?.globalState;

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -635,7 +635,7 @@ function cliMultiAgentPresetListHint(
   return hints.length > 0 ? hints.join('\n') : undefined;
 }
 
-export function cliMultiAgentPresetShouldIncludeLoginHint(
+function cliMultiAgentPresetShouldIncludeLoginHint(
   plan: CliMultiAgentPresetRunPlan,
   options: CliMultiAgentPresetFormatOptions,
 ): boolean {

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -16,14 +16,15 @@ import { readMeta } from '@transcript/streamSnapshotRead';
 import type { AgentTrace } from '@agent/trace';
 import type { ValidatedExecutionRequest } from '@agent/core/state/executionRequests';
 import { TaskStateSchema, type TaskState } from '@agent/core/state/TaskState';
+import { detachSubagentsOnStop } from '@agent/runtime/detachSubagentsOnStop';
 import { retrieveSessionResumeData } from '@agent/runtime/SessionResumeRetrieval';
 import type { ModelHandlerCompatibilityKey } from '@agent/runtime/modelHandlerCompatibilityKey';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
-import { resumeToolUseFromSnapshot } from '@agent/runtime/executeAgent';
+import { resumeQueuedToolUseSnapshot } from '@agent/runtime/resumeQueuedToolUse';
+import { selectAutoOpenFinalOutput } from '@agent/runtime/selectAutoOpenFinalOutput';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
 import { setProgressViewBridge } from '@agent/runtime/ProgressViewBridge';
-import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import { sendFollowUp } from '@agent/followUp/ToolUseFollowUp';
 import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
 import { toErrorMessage } from '@common/errors';
@@ -39,21 +40,30 @@ import type { DiffViewHost, ExternalOpener } from '@hosts/uiHosts';
 import { createChannelTrace } from '@logger';
 import type { MainViewExecuteMessage } from '@shared/mainView';
 import {
-  RUN_OUTCOME,
   STREAM_STATUS,
   type AgentProposalPermission,
   type AgentCategoryFilter,
+  type BashPermission,
+  type ExternalInquiryPermission,
   type MainViewPersistedState,
+  type PlanApprovalPermission,
   type ProgressViewOutboundMessage,
+  type RetryPermission,
+  type ToolEditPermission,
+  type UserQuestionPermission,
   type ExecutionId,
   type StreamTabId,
 } from '@shared/schemas';
 import type { ProgressViewInboundHandlerRegistry } from '@shared/schemas/progressView';
+import { ApprovalRequestHandler } from '@shared/progressView/backend/ApprovalRequestHandler';
 import { ProgressBackend } from '@shared/progressView/backend/ProgressBackend';
+import {
+  createProgressBackendUiConfig,
+  type ApprovalRequestHandlerSet,
+} from '@shared/progressView/backend/progressBackendUiConfig';
 import type { MementoStorage } from '@shared/progressView/backend/persistence/PersistentMapManager';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc/progressViewCommands';
 import { COMMON_COMMANDS } from '@shared/ipc/commonCommands';
-import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import {
   cleanupUnscopedApprovals,
@@ -63,9 +73,7 @@ import {
 import type { RegisteredToolName } from '@tools/registry';
 import { DIAGNOSTICS_ADD_RUNTIME_CAPABILITY } from '@tools/diagnosticsRuntimeCapabilities';
 import { GoalStore } from '@tools/goal';
-import { handleExternalInquiryAction } from '@tools/inquiry';
 import { handleUserQuestionAction } from '@tools/userQuestion';
-import { persistOpenTurnDraft } from '@tools/inquiry/externalInquiryStorage';
 import type { BuildDisplayFn } from '@tools/approval/latexPreview';
 import { getConfig } from '@utils/config/configUtils';
 
@@ -185,13 +193,13 @@ export class DesktopProgressBridge {
   readonly streamLogs: ProgressBackend['state']['streamLogs'];
   private readonly agentProposalController: ProgressAgentProposalController;
   private readonly workflowFileActions: ProgressWorkflowFileActionsController;
-  private readonly agentProposals = new Map<string, AgentProposalPermission>();
   /**
-   * Shown-but-unresolved approval prompts, keyed by `kind:id` and holding the
-   * prompt's stream id (may be `''` when the prompt has no stream context).
-   * Backs the shared pending-permissions guard against view switches.
+   * Shown-but-unresolved approval prompts, one {@link ApprovalRequestHandler}
+   * per kind. These back the shared pending-permissions guard against view
+   * switches and the pending-proposal lookup — the same host-agnostic
+   * bookkeeping the extension uses, rather than a hand-rolled registry.
    */
-  private readonly pendingPermissionStreams = new Map<string, string>();
+  private approvalHandlers!: ApprovalRequestHandlerSet;
   private readonly resumeAttempts = new Set<StreamTabId>();
   private readonly deletedStreams = new Set<StreamTabId>();
   private readonly unsubscribe: () => void;
@@ -232,151 +240,118 @@ export class DesktopProgressBridge {
       hasTarget: () => true,
       getStreamControls: getProgressStreamControls,
       configureUi: ({ webviewUpdater }) => {
-        // Track shown-but-unresolved prompts so hasPendingPermissions can
-        // keep the active view on a stream awaiting input (the shared
-        // ProgressEventHandler guard), mirroring the extension's
-        // ApprovalRequestHandler bookkeeping.
-        const track = (kind: string, id: string, streamId: string) => {
-          this.pendingPermissionStreams.set(`${kind}:${id}`, streamId);
-        };
-        const release = (kind: string, id: string) => {
-          this.pendingPermissionStreams.delete(`${kind}:${id}`);
-        };
-        return {
-          callbacks: {
-            // Desktop has no retry panel yet: decline the affordance so the
-            // run takes the normal cancel path instead of hanging in WAITING
-            // for an answer that can never arrive.
-            showRetryRequest: (payload) => {
-              this.session.coordinators.cancelRetry(payload.streamId);
-            },
-            resolveRetryRequest: () => undefined,
-            showToolEditPermission: (payload) => {
-              track(
-                PERMISSION_KIND.TOOL_EDIT,
-                payload.requestId,
-                payload.streamId,
-              );
+        // The desktop renderer is always attached (no sidebar/editor re-target),
+        // so every show/resolve reaches the webview.
+        const canSend = () => true;
+        this.approvalHandlers = {
+          toolEdit: new ApprovalRequestHandler<ToolEditPermission, 'requestId'>(
+            'requestId',
+            (p) =>
               webviewUpdater.showPermission({
                 kind: PERMISSION_KIND.TOOL_EDIT,
-                data: payload,
-              });
-            },
-            resolveToolEditPermission: (requestId) => {
-              release(PERMISSION_KIND.TOOL_EDIT, requestId);
-              webviewUpdater.resolvePermission(
-                PERMISSION_KIND.TOOL_EDIT,
-                requestId,
-              );
-            },
-            updateToolEditApprovalBypassState: (streamId, bypassActive) =>
-              webviewUpdater.updateBypassState(
-                streamId,
-                'toolEdit',
-                bypassActive,
-              ),
-            updateSuperYoloBypassState: (streamId, bypassActive) =>
-              webviewUpdater.updateBypassState(
-                streamId,
-                'superYolo',
-                bypassActive,
-              ),
-            showBashPermission: (payload) => {
-              track(PERMISSION_KIND.BASH, payload.requestId, payload.streamId);
+                data: p,
+              }),
+            (id) =>
+              webviewUpdater.resolvePermission(PERMISSION_KIND.TOOL_EDIT, id),
+            canSend,
+          ),
+          bash: new ApprovalRequestHandler<BashPermission, 'requestId'>(
+            'requestId',
+            (p) =>
               webviewUpdater.showPermission({
                 kind: PERMISSION_KIND.BASH,
-                data: payload,
-              });
-            },
-            resolveBashPermission: (requestId) => {
-              release(PERMISSION_KIND.BASH, requestId);
-              webviewUpdater.resolvePermission(PERMISSION_KIND.BASH, requestId);
-            },
-            showAgentProposal: (payload) => {
-              this.agentProposals.set(payload.proposalId, payload);
-              track(
-                PERMISSION_KIND.PROPOSAL,
-                payload.proposalId,
-                payload.streamId,
-              );
+                data: p,
+              }),
+            (id) => webviewUpdater.resolvePermission(PERMISSION_KIND.BASH, id),
+            canSend,
+          ),
+          // Desktop has no retry panel: showRetryRequest below cancels instead
+          // of showing, so this handler is never populated and contributes
+          // nothing to the pending guard. Its transport is therefore unused.
+          retry: new ApprovalRequestHandler<RetryPermission, 'streamId'>(
+            'streamId',
+            () => undefined,
+            () => undefined,
+            canSend,
+          ),
+          agentProposal: new ApprovalRequestHandler<
+            AgentProposalPermission,
+            'proposalId'
+          >(
+            'proposalId',
+            (p) =>
               webviewUpdater.showPermission({
                 kind: PERMISSION_KIND.PROPOSAL,
-                data: payload,
-              });
-            },
-            resolveAgentProposal: (proposalId) => {
-              this.agentProposals.delete(proposalId);
-              release(PERMISSION_KIND.PROPOSAL, proposalId);
-              webviewUpdater.resolvePermission(
-                PERMISSION_KIND.PROPOSAL,
-                proposalId,
-              );
-            },
-            showPlanApproval: (payload) => {
-              track(
-                PERMISSION_KIND.PLAN_APPROVAL,
-                payload.approvalId,
-                payload.streamId,
-              );
+                data: p,
+              }),
+            (id) =>
+              webviewUpdater.resolvePermission(PERMISSION_KIND.PROPOSAL, id),
+            canSend,
+          ),
+          planApproval: new ApprovalRequestHandler<
+            PlanApprovalPermission,
+            'approvalId'
+          >(
+            'approvalId',
+            (p) =>
               webviewUpdater.showPermission({
                 kind: PERMISSION_KIND.PLAN_APPROVAL,
-                data: payload,
-              });
-            },
-            resolvePlanApproval: (approvalId) => {
-              release(PERMISSION_KIND.PLAN_APPROVAL, approvalId);
+                data: p,
+              }),
+            (id) =>
               webviewUpdater.resolvePermission(
                 PERMISSION_KIND.PLAN_APPROVAL,
-                approvalId,
-              );
-            },
-            showExternalInquiry: (payload) => {
-              track(
-                PERMISSION_KIND.EXTERNAL_INQUIRY,
-                payload.requestId,
-                payload.streamId,
-              );
+                id,
+              ),
+            canSend,
+          ),
+          externalInquiry: new ApprovalRequestHandler<
+            ExternalInquiryPermission,
+            'requestId'
+          >(
+            'requestId',
+            (p) =>
               webviewUpdater.showPermission({
                 kind: PERMISSION_KIND.EXTERNAL_INQUIRY,
-                data: payload,
-              });
-            },
-            resolveExternalInquiry: (requestId) => {
-              release(PERMISSION_KIND.EXTERNAL_INQUIRY, requestId);
+                data: p,
+              }),
+            (id) =>
               webviewUpdater.resolvePermission(
                 PERMISSION_KIND.EXTERNAL_INQUIRY,
-                requestId,
-              );
-            },
-            showUserQuestion: (payload) => {
-              track(
-                PERMISSION_KIND.USER_QUESTION,
-                payload.requestId,
-                payload.streamId,
-              );
+                id,
+              ),
+            canSend,
+          ),
+          userQuestion: new ApprovalRequestHandler<
+            UserQuestionPermission,
+            'requestId'
+          >(
+            'requestId',
+            (p) =>
               webviewUpdater.showPermission({
                 kind: PERMISSION_KIND.USER_QUESTION,
-                data: payload,
-              });
-            },
-            resolveUserQuestion: (requestId) => {
-              release(PERMISSION_KIND.USER_QUESTION, requestId);
+                data: p,
+              }),
+            (id) =>
               webviewUpdater.resolvePermission(
                 PERMISSION_KIND.USER_QUESTION,
-                requestId,
-              );
-            },
-          },
-          hasPendingPermissions: (streamId) => {
-            for (const pending of this.pendingPermissionStreams.values()) {
-              // An empty id means the prompt has no stream context; treat it
-              // as blocking any switch, matching the extension's
-              // ApprovalRequestHandler.hasPendingForStream.
-              if (!pending || pending === streamId) return true;
-            }
-            return false;
-          },
+                id,
+              ),
+            canSend,
+          ),
         };
+        return createProgressBackendUiConfig({
+          handlers: this.approvalHandlers,
+          webviewUpdater,
+          canSend,
+          // Desktop has no retry panel: decline the affordance so the run takes
+          // the normal cancel path instead of hanging in WAITING for an answer
+          // that can never arrive.
+          showRetryRequest: (payload) => {
+            this.session.coordinators.cancelRetry(payload.streamId);
+          },
+          resolveRetryRequest: () => undefined,
+        });
       },
     });
     this.state = this.backend.state;
@@ -493,7 +468,8 @@ export class DesktopProgressBridge {
       },
     });
     this.agentProposalController = new ProgressAgentProposalController({
-      getPendingProposal: (proposalId) => this.agentProposals.get(proposalId),
+      getPendingProposal: (proposalId) =>
+        this.approvalHandlers.agentProposal.get(proposalId),
       restoreTaskState: async (taskState) => {
         let state: MainViewPersistedState;
         try {
@@ -609,6 +585,11 @@ export class DesktopProgressBridge {
         handleAgentProposalAction: (message) =>
           this.agentProposalController.handleAction(message),
       },
+      externalInquiry: {
+        logWarn: (message, context) =>
+          this.logger.warn(message, { data: context }),
+        sessionContext: { session: this.session },
+      },
     });
     return {
       ...sharedHandlers,
@@ -627,45 +608,6 @@ export class DesktopProgressBridge {
         };
         await this.options.showInfoMessage?.(
           `"${labels[data.action]}" requires the VS Code extension.`,
-        );
-      },
-      // External inquiry rides outside the shared registry (as in the
-      // extension's ProgressViewMessageHandler): draft persists the open
-      // turn, submit/drop settle the durable thread.
-      [PROGRESS_VIEW_COMMANDS.EXTERNAL_INQUIRY_ACTION]: async (data) => {
-        if (data.action === 'draft') {
-          await persistOpenTurnDraft({
-            threadId: data.threadId,
-            draft: data.draft ?? null,
-          });
-          return;
-        }
-        if (data.action === 'submit') {
-          if (data.answer == null || data.answer.length === 0) {
-            this.logger.warn(
-              'Ignoring external inquiry submit without an answer',
-              { data: { threadId: data.threadId } },
-            );
-            return;
-          }
-          await handleExternalInquiryAction(
-            {
-              action: 'submit',
-              threadId: data.threadId,
-              answer: data.answer,
-              sessionLinks: data.sessionLinks,
-            },
-            { session: this.session },
-          );
-          return;
-        }
-        await handleExternalInquiryAction(
-          {
-            action: 'drop',
-            threadId: data.threadId,
-            feedback: data.feedback,
-          },
-          { session: this.session },
         );
       },
     };
@@ -690,8 +632,12 @@ export class DesktopProgressBridge {
   }
 
   private clearDesktopSessionMaps(): void {
-    this.agentProposals.clear();
-    this.pendingPermissionStreams.clear();
+    // Drop every pending approval (and proposal payload) without notifying the
+    // webview — the "delete all"/teardown sweep already settles the underlying
+    // approvals through releaseStreamResources/cleanup helpers.
+    for (const handler of Object.values(this.approvalHandlers)) {
+      handler.clear();
+    }
     // Ghost-stream state is owned by the extracted progressEvents bridge;
     // onAllStreamsDeleted handles clearing it.
   }
@@ -770,8 +716,7 @@ export class DesktopProgressBridge {
     // requests) and the follow-up queue for this stream.
     releaseStreamResources(streamId, this.session);
 
-    this.deleteAgentProposalsForStream(streamId);
-    this.releasePendingPermissionsForStream(streamId);
+    this.releaseApprovalsForStream(streamId);
     this.workflowFileActions.clearStreamBackups(streamId);
     await GoalStore.forget(streamId);
     await this.state.clearStream(streamId);
@@ -844,13 +789,7 @@ export class DesktopProgressBridge {
   private stopStream(streamId: StreamTabId): void {
     this.session.coordinators.clearRetryRequest(streamId);
     this.session.executions.stopAgentStream(streamId, {
-      // Read the live workspace-state value (written by the desktop settings
-      // view) at stop time, matching the extension and CLI hosts.
-      detachActiveChildren:
-        tryPlatform()?.workspaceState.get<boolean>(
-          WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP,
-          false,
-        ) === true,
+      detachActiveChildren: detachSubagentsOnStop(),
       runtimeHost: this.runtimeHost,
     });
   }
@@ -899,33 +838,27 @@ export class DesktopProgressBridge {
       }
 
       if (resume.type === 'toolUse') {
-        ToolUseFollowUpQueue.acquire(streamId);
-        ownsResumingStatus = true;
-        StreamStatusService.set(streamId, STREAM_STATUS.RESUMING, {
-          runtimeHost: this.runtimeHost,
-        });
-        const queuedFollowUps = ToolUseFollowUpQueue.drainItems(streamId);
-        this.runtimeHost.emit('updateQueuedFollowUps', { streamId });
-        try {
-          await resumeToolUseFromSnapshot(resume.snapshot, this.runtimeHost, {
+        // The shared helper owns the RESUMING flip, follow-up drain/replay,
+        // failure re-enqueue, and the RESUMING->WAITING reset, surfacing
+        // failures through this host's own log + error dialog (the same
+        // messaging the outer catch applies to the workflow path).
+        return await resumeQueuedToolUseSnapshot(
+          streamId,
+          resume.snapshot,
+          this.runtimeHost,
+          {
             session: this.session,
             runtimeUnavailableTools: DESKTOP_UNAVAILABLE_TOOLS,
-            setupSession: (session) => {
-              for (const item of queuedFollowUps) {
-                session.appendFollowUp(item);
-              }
+            onError: async (error) => {
+              this.logger.error(`Failed to resume desktop stream ${streamId}`, {
+                data: error instanceof Error ? error : { error },
+              });
+              await this.options.showErrorMessage?.(
+                `Resume failed: ${toErrorMessage(error)}`,
+              );
             },
-          });
-        } catch (error) {
-          for (const item of queuedFollowUps) {
-            ToolUseFollowUpQueue.enqueue(streamId, item, { force: true });
-          }
-          if (queuedFollowUps.length > 0) {
-            this.runtimeHost.emit('updateQueuedFollowUps', { streamId });
-          }
-          throw error;
-        }
-        return true;
+          },
+        );
       }
 
       ownsResumingStatus = true;
@@ -1136,14 +1069,9 @@ export class DesktopProgressBridge {
       runtimeUnavailableTools: DESKTOP_UNAVAILABLE_TOOLS,
       modelHandlerCompatibilityKey: options.modelHandlerCompatibilityKey,
       openWorkflowOutput: async (result) => {
-        // Match the extension's auto-open contract: only a completed workflow
-        // opens its final output — cancelled runs may carry partial outputs
-        // the user did not ask to review — and the config gate applies.
-        if (!getConfig<boolean>('texra.agentOutputs.autoOpenFinal', true)) {
-          return;
-        }
-        if (result.outcome !== RUN_OUTCOME.COMPLETED) return;
-        const output = result.outputs.at(-1);
+        // Gate, outcome check, and final-output selection are shared policy
+        // (selectAutoOpenFinalOutput); the desktop host only supplies openPath.
+        const output = selectAutoOpenFinalOutput(result);
         if (!output) return;
         await this.options.openPath?.(output.absolutePath);
       },
@@ -1167,19 +1095,16 @@ export class DesktopProgressBridge {
     );
   }
 
-  private deleteAgentProposalsForStream(streamId: StreamTabId): void {
-    for (const [proposalId, proposal] of this.agentProposals.entries()) {
-      if (proposal.streamId === streamId) {
-        this.agentProposals.delete(proposalId);
-      }
-    }
-  }
-
-  private releasePendingPermissionsForStream(streamId: StreamTabId): void {
-    for (const [key, pending] of this.pendingPermissionStreams) {
-      if (pending === streamId) {
-        this.pendingPermissionStreams.delete(key);
-      }
+  /**
+   * Drop every pending approval (incl. proposal payloads) tied to a deleted
+   * stream from the pending guard. The underlying approvals are settled by
+   * releaseStreamResources; this only clears prompts that never receive a
+   * resolve event (e.g. durable external inquiries), keeping the guard from
+   * blocking switches on a stream that no longer exists.
+   */
+  private releaseApprovalsForStream(streamId: StreamTabId): void {
+    for (const handler of Object.values(this.approvalHandlers)) {
+      handler.releaseForStream(streamId);
     }
   }
 

--- a/packages/desktop/src/main/desktopProgressFileActions.ts
+++ b/packages/desktop/src/main/desktopProgressFileActions.ts
@@ -4,11 +4,7 @@ import path from 'node:path';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { ValidatedExecutionRequest } from '@agent/core/state/executionRequests';
 import type { DiffViewHost } from '@hosts/uiHosts';
-import {
-  buildAcceptConfirmMessage,
-  buildAcceptSuccessMessage,
-  getAcceptedFileTarget,
-} from '@latex/acceptedFileTarget';
+import { acceptEditedFileReplace } from '@latex/acceptedFileTarget';
 import { openFirstLabelMatch } from '@latex/labelSearch';
 import { LaTeXdiffService } from '@latex/latexdiff';
 import { DEFAULT_MATH_MARKUP } from '@latex/latexdiff/mathMarkup';
@@ -123,43 +119,25 @@ export class DesktopProgressFileActions {
     baseFile: string,
     editedFile: string,
   ): Promise<boolean> {
-    const baseLocation = pathToLocation(baseFile);
-    const editedLocation = pathToLocation(editedFile);
-    const target = getAcceptedFileTarget(
-      baseLocation,
-      editedLocation.absolutePath,
+    return acceptEditedFileReplace(
+      pathToLocation(baseFile),
+      pathToLocation(editedFile),
+      {
+        exists: (location) => AbsoluteFS.exists(location.absolutePath),
+        readFile: (location) => readFile(location.absolutePath, 'utf8'),
+        writeFile: (location, content) =>
+          writeFile(location.absolutePath, content, 'utf8'),
+        confirm: (message) =>
+          this.options.confirmAcceptFile
+            ? this.options.confirmAcceptFile(message)
+            : Promise.resolve(true),
+        emitWritten: (absolutePath) =>
+          this.host.runtimeHost.emit('workspaceFilesWritten', {
+            absolutePaths: [absolutePath],
+          }),
+        showInfo: (message) => this.options.showInfoMessage?.(message),
+      },
     );
-    const { targetLocation, targetFileName, isNewFile } = target;
-    const targetExists =
-      isNewFile && (await AbsoluteFS.exists(targetLocation.absolutePath));
-    const confirmMessage = buildAcceptConfirmMessage(
-      target,
-      baseFile,
-      editedFile,
-      targetExists,
-    );
-
-    if (this.options.confirmAcceptFile) {
-      const confirmed = await this.options.confirmAcceptFile(confirmMessage);
-      if (!confirmed) return false;
-    }
-
-    const editedContent = await readFile(editedLocation.absolutePath, 'utf8');
-    await writeFile(targetLocation.absolutePath, editedContent, 'utf8');
-    if (targetLocation.kind === 'workspace') {
-      this.host.runtimeHost.emit('workspaceFilesWritten', {
-        absolutePaths: [targetLocation.absolutePath],
-      });
-    }
-
-    await this.options.showInfoMessage?.(
-      buildAcceptSuccessMessage(
-        targetFileName,
-        editedFile,
-        !isNewFile || targetExists,
-      ),
-    );
-    return true;
   }
 
   async runLatexdiffForRun(

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -8,6 +8,7 @@ import {
 import { createSettingsViewCommandHandlers } from '@controllers/settingsView/SettingsViewCommandHandlers';
 import { createSettingsMemoryController } from '@controllers/settingsView/SettingsMemoryControllerFactory';
 import { buildProfileMessage } from '@controllers/settingsView/ProfileMessageBuilder';
+import { buildProviderKeyStatuses } from '@controllers/settingsView/SettingsProfileController';
 import { buildHistoryMessage } from '@controllers/settingsView/HistoryMessageBuilder';
 import {
   buildModelSelectionMessage,
@@ -350,21 +351,26 @@ export function createDesktopSettingsIpc(
     });
   }
 
-  async function getProviderKeyStatuses(): Promise<ProviderKeyStatus[]> {
-    const statuses = await loadApiKeyStatusMap(secrets, API_PROVIDERS);
-    return API_PROVIDERS.map((provider) => ({
-      provider,
-      displayName: getProviderDisplayName(
-        provider,
-        PROVIDER_DISPLAY_NAMES[provider] ?? provider,
-      ),
-      status: statuses[provider],
-      keyUrl: getProviderKeyUrl(provider, PROVIDER_URLS[provider] ?? ''),
-      streaming: getProviderStreaming(provider),
-      customEndpoint: getProviderEndpoint(provider),
-      supportsCustomEndpoint: supportsCustomEndpoint(provider),
-      vscodeSettings: [],
-    }));
+  // Desktop has no VS Code settings, so `getProviderVscodeSettings` returns [];
+  // the rest of the mapping is shared with the extension via
+  // `buildProviderKeyStatuses` so the wire shape stays in one place.
+  function getProviderKeyStatuses(): Promise<ProviderKeyStatus[]> {
+    return buildProviderKeyStatuses({
+      providerIds: API_PROVIDERS,
+      loadProviderKeyStatuses: () =>
+        loadApiKeyStatusMap(secrets, API_PROVIDERS),
+      getProviderDisplayName: (provider) =>
+        getProviderDisplayName(
+          provider,
+          PROVIDER_DISPLAY_NAMES[provider] ?? provider,
+        ),
+      getProviderKeyUrl: (provider) =>
+        getProviderKeyUrl(provider, PROVIDER_URLS[provider] ?? ''),
+      getProviderStreaming,
+      getProviderEndpoint,
+      supportsCustomEndpoint,
+      getProviderVscodeSettings: () => [],
+    });
   }
 
   async function postProfileData(): Promise<void> {

--- a/packages/desktop/src/main/desktopTerminalRunner.ts
+++ b/packages/desktop/src/main/desktopTerminalRunner.ts
@@ -1,9 +1,7 @@
-// Third-party imports
-import stripAnsi from 'strip-ansi';
-
 // Local imports - hosts
 import {
   TERMINAL_OUTPUT_MAX_CHARS,
+  truncateTerminalOutput,
   type TerminalRunner,
   type TerminalRunRequest,
 } from '@hosts/uiHosts';
@@ -46,7 +44,7 @@ export function createDesktopTerminalRunner(
 
       return {
         exitCode: result.exitCode,
-        output: tail(output || bufferedOutput),
+        output: truncateTerminalOutput(output || bufferedOutput),
         timedOut: result.timedOut ?? false,
       };
     },
@@ -62,11 +60,4 @@ function normalizeEnv(
       (entry): entry is [string, string] => entry[1] !== undefined,
     ),
   );
-}
-
-function tail(output: string): string {
-  const stripped = stripAnsi(output);
-  return stripped.length > TERMINAL_OUTPUT_MAX_CHARS
-    ? stripped.slice(-TERMINAL_OUTPUT_MAX_CHARS)
-    : stripped;
 }

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -2,24 +2,20 @@ import { join } from 'node:path';
 
 import { app } from 'electron';
 
-import { JsonConfigProvider } from '@platform/defaults/jsonConfigProvider';
 import { JsonStore } from '@platform/defaults/jsonStore';
-import { workspaceTexraConfigPath } from '@platform/defaults/nodeStorage';
 import { createLifecycleHost } from '@platform/defaults/lifecycleHost';
-import { NO_TOOL_AVAILABILITY_HOST } from '@platform/interfaces/toolAvailability';
-import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
-import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
+import {
+  initNodeAgentRuntime,
+  initNodePlatform,
+} from '@platform/defaults/nodeHost';
+import { workspaceTexraConfigPath } from '@platform/defaults/nodeStorage';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
-import { initPlatform } from '@platform/platform';
 import { SHUTDOWN_PHASE } from '@platform/interfaces/lifecycle';
 import { StreamSnapshotStore } from '@transcript';
-import { registerAgentFeatures } from '@agent/features';
-import { initializeGoalPrompts } from '@agent/goal';
 import { toErrorMessage } from '@common/errors';
 import { DESKTOP_WORKSPACE_PATH_STATE_KEY } from '@desktop/workspacePath.js';
 import { configKeyVariants } from '@shared/config/configKeys';
 import { GlobalStateKey } from '@shared/state/stateKeys';
-import { registerDirectLeanLanguageServices } from '@tools/lean/direct/directLspAdapter';
 
 import { bootstrapElectronAgentDirectories } from './agentDirectories.js';
 import { ElectronSecrets } from './electronSecrets.js';
@@ -131,15 +127,13 @@ export async function initializeElectronPlatform(
   const secretsStore = await JsonStore.open(join(userDataPath, 'secrets.json'));
 
   repairLaunchPath();
-  initPlatform({
-    config: new JsonConfigProvider({
+  initNodePlatform({
+    configStores: {
       workspace: workspaceConfigStore,
       global: globalConfigStore,
-    }),
+    },
     globalState: globalStateStore,
     workspaceState: workspaceStateStore,
-    fs: nodeFilesystem,
-    workspace: createNodeWorkspace(() => workspacePath),
     storage,
     secrets: new ElectronSecrets(secretsStore, {
       showWarningMessage: showSecretStorageWarningDialog,
@@ -149,9 +143,8 @@ export async function initializeElectronPlatform(
       tryResumeStream: tryResumeDesktopStream,
       isResumeInFlight: isDesktopResumeInFlight,
     },
-    toolAvailability: NO_TOOL_AVAILABILITY_HOST,
+    getWorkspacePath: () => workspacePath,
   });
-  registerAgentFeatures();
 
   // Capture the prior-install signal BEFORE bootstrapElectronAgentDirectories
   // (below) writes LAST_KNOWN_VERSION via the bundled-agent directory sync.
@@ -163,7 +156,6 @@ export async function initializeElectronPlatform(
     ) !== undefined;
 
   const resourcesPath = resolveResourcesPath(mainDirname);
-  initializeGoalPrompts(join(resourcesPath, 'goal', 'goal.yaml'));
 
   // Persist per-stream sidecar data (todos, plan, usage, output files) via the
   // shared, host-agnostic snapshot store. The desktop progress backend owns the
@@ -172,8 +164,11 @@ export async function initializeElectronPlatform(
   const snapshotStore = new StreamSnapshotStore();
   lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => snapshotStore.flush());
 
-  // Lean tools talk to `lake env lean --server` directly in the desktop build.
-  registerDirectLeanLanguageServices(lifecycle);
+  // Register the shared Node-host agent runtime: memory + goal tool injections,
+  // the direct Lean language services (lake env lean --server), and the
+  // packaged Goal prompt path. Registered after the snapshot-store shutdown
+  // handler so the snapshot flush still runs before the Lean adapter dispose.
+  initNodeAgentRuntime(lifecycle, resourcesPath);
 
   await bootstrapElectronAgentDirectories(resourcesPath, app.getVersion());
 

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -5,11 +5,13 @@ import { app } from 'electron';
 import { JsonStore } from '@platform/defaults/jsonStore';
 import { createLifecycleHost } from '@platform/defaults/lifecycleHost';
 import {
+  createNodePlatform,
   initNodeAgentRuntime,
-  initNodePlatform,
+  initializeNodeGoalPrompts,
 } from '@platform/defaults/nodeHost';
 import { workspaceTexraConfigPath } from '@platform/defaults/nodeStorage';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
+import { initPlatform } from '@platform/platform';
 import { SHUTDOWN_PHASE } from '@platform/interfaces/lifecycle';
 import { StreamSnapshotStore } from '@transcript';
 import { toErrorMessage } from '@common/errors';
@@ -127,24 +129,26 @@ export async function initializeElectronPlatform(
   const secretsStore = await JsonStore.open(join(userDataPath, 'secrets.json'));
 
   repairLaunchPath();
-  initNodePlatform({
-    configStores: {
-      workspace: workspaceConfigStore,
-      global: globalConfigStore,
-    },
-    globalState: globalStateStore,
-    workspaceState: workspaceStateStore,
-    storage,
-    secrets: new ElectronSecrets(secretsStore, {
-      showWarningMessage: showSecretStorageWarningDialog,
+  initPlatform(
+    createNodePlatform({
+      configStores: {
+        workspace: workspaceConfigStore,
+        global: globalConfigStore,
+      },
+      globalState: globalStateStore,
+      workspaceState: workspaceStateStore,
+      storage,
+      secrets: new ElectronSecrets(secretsStore, {
+        showWarningMessage: showSecretStorageWarningDialog,
+      }),
+      lifecycle,
+      agentResume: {
+        tryResumeStream: tryResumeDesktopStream,
+        isResumeInFlight: isDesktopResumeInFlight,
+      },
+      getWorkspacePath: () => workspacePath,
     }),
-    lifecycle,
-    agentResume: {
-      tryResumeStream: tryResumeDesktopStream,
-      isResumeInFlight: isDesktopResumeInFlight,
-    },
-    getWorkspacePath: () => workspacePath,
-  });
+  );
 
   // Capture the prior-install signal BEFORE bootstrapElectronAgentDirectories
   // (below) writes LAST_KNOWN_VERSION via the bundled-agent directory sync.
@@ -164,11 +168,12 @@ export async function initializeElectronPlatform(
   const snapshotStore = new StreamSnapshotStore();
   lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => snapshotStore.flush());
 
-  // Register the shared Node-host agent runtime: memory + goal tool injections,
-  // the direct Lean language services (lake env lean --server), and the
-  // packaged Goal prompt path. Registered after the snapshot-store shutdown
-  // handler so the snapshot flush still runs before the Lean adapter dispose.
-  initNodeAgentRuntime(lifecycle, resourcesPath);
+  // Register the shared Node-host agent runtime: memory + goal tool injections
+  // and the direct Lean language services (lake env lean --server). Registered
+  // after the snapshot-store shutdown handler so the snapshot flush still runs
+  // before the Lean adapter dispose.
+  initNodeAgentRuntime(lifecycle);
+  initializeNodeGoalPrompts(resourcesPath);
 
   await bootstrapElectronAgentDirectories(resourcesPath, app.getVersion());
 

--- a/packages/extension/src/commands.ts
+++ b/packages/extension/src/commands.ts
@@ -8,7 +8,6 @@ import {
 } from '@commands/files';
 import {
   registerLatexdiffCommands,
-  registerLatexCommands,
   registerImageCommands,
   registerFigureCommands,
   registerLinterCommands,
@@ -40,7 +39,6 @@ import {
   createExtensionCommandActions,
   registerExtensionCommandRegistry,
 } from '@commands/extensionCommandSurface';
-import { registerApiKeyCommands } from '@commands/api/apiKeyCommands';
 import { registerGitCommands } from '@commands/git/gitCommands';
 import { registerAgentReviewCommands } from '@commands/review/agentReviewCommands';
 // Local file imports
@@ -61,12 +59,10 @@ export function registerCommands(context: vscode.ExtensionContext): void {
   registerCleanCommands(context);
   registerMergeCommands(context);
   registerExecuteCommand(context);
-  registerLatexCommands(context);
   registerImageCommands(context);
   registerFigureCommands(context);
   registerXmlCommands(context);
   registerYamlCommands(context);
-  registerApiKeyCommands(context);
   registerAuthCommands(context);
   registerStateRestoreCommand(context);
   registerTextEditorCommands(context);

--- a/packages/extension/src/commands/agent/agentCommands.ts
+++ b/packages/extension/src/commands/agent/agentCommands.ts
@@ -2,18 +2,15 @@
 import * as vscode from 'vscode';
 
 // Local imports - agent
+import { detachSubagentsOnStop } from '@agent/runtime/detachSubagentsOnStop';
 import { executionRegistry } from '@agent/runtime/executionRegistry';
 import { notifyFollowUpSent } from '@agent/followUp/ToolUseFollowUp';
-import { workspaceSM, WorkspaceStateKey } from '@common/state';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import type { StreamTabId } from '@shared/schemas';
 
 export function stopAgent(streamId: StreamTabId): void {
   executionRegistry.stopAgentStream(streamId, {
-    detachActiveChildren: workspaceSM.get<boolean>(
-      WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP,
-      false,
-    ),
+    detachActiveChildren: detachSubagentsOnStop(),
     runtimeHost: extensionAgentRuntimeHost,
   });
 }

--- a/packages/extension/src/commands/agent/resumeCommand.ts
+++ b/packages/extension/src/commands/agent/resumeCommand.ts
@@ -3,14 +3,11 @@ import * as vscode from 'vscode';
 import { z } from 'zod';
 
 // Local imports - agent
-import { resumeToolUseFromSnapshot } from '@agent/runtime/executeAgent';
+import { resumeQueuedToolUseSnapshot } from '@agent/runtime/resumeQueuedToolUse';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
-import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
-import type { FollowUpQueueInput } from '@agent/followUp/FollowUpQueue';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { logErrorMessage } from '@frontend/ui/errorHandlingUtils';
-import { STREAM_STATUS } from '@shared/schemas';
 import { getToolUsePersistenceEnabled } from '@utils/config';
 
 export const ResumeAgentResultSchema = z.object({
@@ -40,62 +37,26 @@ async function resumeFromSnapshot(
     return { success: false };
   }
 
-  ToolUseFollowUpQueue.acquire(streamId);
-  const runtimeHost = extensionAgentRuntimeHost;
-  StreamStatusService.set(streamId, STREAM_STATUS.RESUMING, {
-    runtimeHost,
-  });
-
-  // Seed with the explicit follow-up so the catch path still re-enqueues it
-  // even if the drain below throws before the full list is assigned.
-  const explicitFollowUp: readonly FollowUpQueueInput[] =
-    followUp !== undefined ? [{ text: followUp, origin: 'user' as const }] : [];
-  let followUps: readonly FollowUpQueueInput[] = explicitFollowUp;
-  try {
-    followUps = [
-      ...explicitFollowUp,
-      ...ToolUseFollowUpQueue.drainItems(streamId),
-    ];
-    runtimeHost.emit('updateQueuedFollowUps', {
-      streamId,
-    });
-
-    await resumeToolUseFromSnapshot(snapshot, runtimeHost, {
-      setupSession: (session) => {
-        for (const item of followUps) {
-          session.appendFollowUp(item);
-        }
+  const success = await resumeQueuedToolUseSnapshot(
+    streamId,
+    snapshot,
+    extensionAgentRuntimeHost,
+    {
+      extraFollowUps:
+        followUp !== undefined
+          ? [{ text: followUp, origin: 'user' as const }]
+          : [],
+      onError: async (error) => {
+        const baseMessage = logErrorMessage(
+          CHANNEL,
+          'Failed to resume tool-use session',
+          error,
+        );
+        await vscode.window.showWarningMessage(baseMessage);
       },
-    });
-
-    return { success: true };
-  } catch (error) {
-    // Re-enqueue the drained follow-ups (and the explicit one, ahead of
-    // them) so a later resume picks them up instead of dropping them —
-    // matching the desktop bridge's failure path.
-    for (const item of followUps) {
-      ToolUseFollowUpQueue.enqueue(streamId, item, { force: true });
-    }
-    if (followUps.length > 0) {
-      runtimeHost.emit('updateQueuedFollowUps', { streamId });
-    }
-
-    const baseMessage = logErrorMessage(
-      CHANNEL,
-      'Failed to resume tool-use session',
-      error,
-    );
-    await vscode.window.showWarningMessage(baseMessage);
-
-    return { success: false };
-  } finally {
-    const status = StreamStatusService.get(streamId);
-    if (status === STREAM_STATUS.RESUMING) {
-      StreamStatusService.set(streamId, STREAM_STATUS.WAITING, {
-        runtimeHost,
-      });
-    }
-  }
+    },
+  );
+  return { success };
 }
 
 export function registerResumeAgentCommand(

--- a/packages/extension/src/commands/api/apiKeyCommands.ts
+++ b/packages/extension/src/commands/api/apiKeyCommands.ts
@@ -193,17 +193,3 @@ export async function removeApiKey(): Promise<void> {
     );
   }
 }
-
-/**
- * Both `texra.setApiKey` and `texra.removeApiKey` are now registered through
- * the shared command registry in `extensionCommandSurface.ts`. The
- * registration function is kept as a no-op so existing call sites in
- * `commands.ts` don't have to be reshuffled — removing the dependency would
- * require dropping it from the `registerCommands` call list, which is
- * outside the scope of this batch.
- */
-export function registerApiKeyCommands(
-  _context: vscode.ExtensionContext,
-): void {
-  // Intentionally empty: handlers moved to the shared registry (#3781 batch 4).
-}

--- a/packages/extension/src/commands/latex/compareCommands.ts
+++ b/packages/extension/src/commands/latex/compareCommands.ts
@@ -15,11 +15,10 @@ import {
 } from '@frontend/ui/errorHandlingUtils';
 import { registerDiffRefresh } from '@frontend/ui/diffView';
 import {
-  buildAcceptConfirmMessage,
+  acceptEditedFileReplace,
   buildAcceptSuccessMessage,
   getAcceptedFileTarget,
   siblingLocation,
-  type AcceptedFileTarget,
 } from '@latex/acceptedFileTarget';
 import * as logger from '@logger/logUtils';
 import type { FileLocation } from '@shared/schemas';
@@ -162,51 +161,17 @@ function buildCopyTarget(
   };
 }
 
-/** Original single-confirm flow used when no run metadata is available. */
-async function confirmReplace(
-  target: AcceptedFileTarget,
-  basePath: string,
-  editedPath: string,
-): Promise<boolean> {
-  const { targetLocation, isNewFile } = target;
-  const targetExists = isNewFile && (await flexibleFS.exists(targetLocation));
-  const confirmMessage = buildAcceptConfirmMessage(
-    target,
-    basePath,
-    editedPath,
-    targetExists,
-  );
-
-  const answer = await vscode.window.showWarningMessage(
-    confirmMessage,
-    { modal: true },
-    'Yes',
-    'Cancel',
-  );
-  return answer === 'Yes';
-}
-
-/** Resolve which target to write: a quick-pick (replace vs postfixed copy)
- *  when run metadata is available, otherwise the legacy confirm dialog.
- *  Returns undefined when the user cancels. */
-async function resolveAcceptTarget(
+/** Offer a quick-pick between replacing the original and saving a postfixed
+ *  copy, used when run metadata is available. Returns undefined when the user
+ *  cancels. */
+async function pickReplaceOrCopyTarget(
   baseLocation: FileLocation,
   editedPath: string,
-  copyMeta: AcceptCopyMeta | undefined,
+  copyMeta: AcceptCopyMeta,
 ): Promise<
   { targetLocation: FileLocation; targetFileName: string } | undefined
 > {
   const replaceTarget = getAcceptedFileTarget(baseLocation, editedPath);
-
-  if (!copyMeta) {
-    const confirmed = await confirmReplace(
-      replaceTarget,
-      baseLocation.absolutePath,
-      editedPath,
-    );
-    return confirmed ? replaceTarget : undefined;
-  }
-
   const copyTarget = buildCopyTarget(baseLocation, copyMeta);
   type AcceptItem = vscode.QuickPickItem & {
     target: { targetLocation: FileLocation; targetFileName: string };
@@ -255,11 +220,35 @@ async function handleAcceptEdited(
       return false;
     }
 
-    const editedPath = editedLocation.absolutePath;
+    // No run metadata: single-confirm replace flow shared with the desktop host.
+    if (!copyMeta) {
+      return await acceptEditedFileReplace(fileToUseLocation, editedLocation, {
+        exists: (location) => flexibleFS.exists(location),
+        readFile: (location) => flexibleFS.read(location),
+        writeFile: (location, content) => flexibleFS.write(location, content),
+        confirm: async (message) => {
+          const answer = await vscode.window.showWarningMessage(
+            message,
+            { modal: true },
+            'Yes',
+            'Cancel',
+          );
+          return answer === 'Yes';
+        },
+        emitWritten: (absolutePath) =>
+          bus.emit('workspaceFilesWritten', { absolutePaths: [absolutePath] }),
+        showInfo: (message) => {
+          vscode.window.showInformationMessage(message);
+          logger.info(CHANNEL, message);
+        },
+      });
+    }
 
-    const resolved = await resolveAcceptTarget(
+    // Run metadata present: let the user replace the original or save a
+    // postfixed copy, then commit the chosen target.
+    const resolved = await pickReplaceOrCopyTarget(
       fileToUseLocation,
-      editedPath,
+      editedLocation.absolutePath,
       copyMeta,
     );
     if (!resolved) return false;
@@ -278,7 +267,7 @@ async function handleAcceptEdited(
 
     const successMessage = buildAcceptSuccessMessage(
       targetFileName,
-      editedPath,
+      editedLocation.absolutePath,
       targetExisted,
     );
     vscode.window.showInformationMessage(successMessage);

--- a/packages/extension/src/commands/latex/index.ts
+++ b/packages/extension/src/commands/latex/index.ts
@@ -3,6 +3,5 @@ export { arXivCommands, downloadArXivSource } from './arXivCommands';
 export { registerCompareCommands } from './compareCommands';
 export { registerFigureCommands } from './figCommands';
 export { registerImageCommands } from './imageCommands';
-export { registerLatexCommands } from './latexCommands';
 export { registerLatexdiffCommands } from './latexdiffCommands';
 export { registerLinterCommands } from './linterCommands';

--- a/packages/extension/src/commands/latex/latexCommands.ts
+++ b/packages/extension/src/commands/latex/latexCommands.ts
@@ -44,17 +44,6 @@ async function runGuardedLatexCommand(
   }
 }
 
-/**
- * All LaTeX entry-point commands (`indentTeX`, `indentCurrentTeX`,
- * `getTeXCount`, `applyReplacements`, `fixCompilation`) are now
- * registered through the shared command registry in
- * `extensionCommandSurface.ts` (#3771, #3775). This stub is kept for
- * the existing `registerLatexCommands(context)` call site.
- */
-export function registerLatexCommands(_context: vscode.ExtensionContext): void {
-  /* registration handled by extensionCommandSurface */
-}
-
 export async function handleIndentTeX(): Promise<void> {
   try {
     const notification = getIndentTeXNotification(

--- a/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
+++ b/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
@@ -12,7 +12,7 @@ import {
   AgentDirectoryService,
   GlobalStorageAgentDirectoryStorage,
 } from '@agent/index';
-import type { AgentSource } from '@agent/index';
+import type { AgentDirectoryEntry, AgentSource } from '@agent/index';
 import { toErrorMessage } from '@common/errors';
 import { GlobalStateKey, globalSM } from '@common/state';
 import { showLoggedMessageWithDocs } from '@frontend/ui/errorHandlingUtils';
@@ -24,12 +24,6 @@ const CHANNEL = 'AgentLoad';
 logger.initialize(CHANNEL);
 
 type AgentDirectoryEventType = 'create' | 'change' | 'delete';
-
-/** A local agent directory paired with the source it represents. */
-interface AgentDirectoryEntry {
-  directory: string;
-  source: AgentSource;
-}
 
 export interface AgentDirectoryWatcherEvent extends AgentDirectoryEntry {
   type: AgentDirectoryEventType;

--- a/packages/extension/src/frontend/agents/finalOutputOpener.ts
+++ b/packages/extension/src/frontend/agents/finalOutputOpener.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode';
 
 import type { WorkflowFlowResult } from '@agent/runtime/AgentFlowResult';
+import { selectAutoOpenFinalOutput } from '@agent/runtime/selectAutoOpenFinalOutput';
 import * as logger from '@logger/logUtils';
-import { getConfig } from '@utils/config';
 
 const CHANNEL = 'FinalOutputOpener';
 logger.initialize(CHANNEL);
@@ -12,22 +12,14 @@ logger.initialize(CHANNEL);
  * users don't feel the file "vanished" into run storage. A dismissible
  * status-bar hint reminds users that workflow mode is slow by design.
  *
- * Gated by `texra.agentOutputs.autoOpenFinal` (default: true).
+ * The gate, outcome check, and which output counts as final live in
+ * {@link selectAutoOpenFinalOutput} (shared with the desktop host); this only
+ * supplies the VS Code open verb and status-bar hint.
  */
 export async function openFinalOutputIfAvailable(
   result: WorkflowFlowResult,
 ): Promise<void> {
-  if (!getConfig<boolean>('texra.agentOutputs.autoOpenFinal', true)) {
-    return;
-  }
-  // Only a completed workflow auto-opens its final output — cancelled runs
-  // may carry partial outputs the user did not ask to review.
-  if (result.outcome !== 'completed' || result.outputs.length === 0) {
-    return;
-  }
-
-  const lastRound = Math.max(...result.outputs.map((o) => o.round));
-  const primary = result.outputs.find((o) => o.round === lastRound);
+  const primary = selectAutoOpenFinalOutput(result);
   if (!primary) return;
 
   try {

--- a/packages/extension/src/frontend/setupTerminalRunner.ts
+++ b/packages/extension/src/frontend/setupTerminalRunner.ts
@@ -12,11 +12,11 @@
 
 // Third-party imports
 import * as vscode from 'vscode';
-import stripAnsi from 'strip-ansi';
 
 // Local imports - hosts
 import {
   TERMINAL_OUTPUT_MAX_CHARS,
+  truncateTerminalOutput,
   type TerminalRunRequest,
   type TerminalRunResult,
 } from '@hosts/uiHosts';
@@ -94,9 +94,10 @@ async function captureExecution(
   // Drain the stream into a sliding-window tail. `.catch` swallows
   // late stream errors (terminal closed after we stopped awaiting)
   // so they cannot bubble up as unhandled rejections.
-  const reader = tail(execution.read(), TERMINAL_OUTPUT_MAX_CHARS).catch(
-    () => '',
-  );
+  const reader = drainStreamTail(
+    execution.read(),
+    TERMINAL_OUTPUT_MAX_CHARS,
+  ).catch(() => '');
 
   const result = await raced;
 
@@ -111,7 +112,7 @@ async function captureExecution(
 
   return {
     exitCode: result.timedOut ? undefined : result.value,
-    output: stripAnsi(output),
+    output: truncateTerminalOutput(output),
     timedOut: result.timedOut,
   };
 }
@@ -154,11 +155,13 @@ function raceWithTimeout<T>(
 }
 
 /**
- * Drain an async iterable into a length-capped sliding-window tail.
- * Caller may abandon the returned promise; chunk errors are surfaced
- * to the caller for them to decide whether to swallow.
+ * Drain an async iterable into a length-capped sliding-window tail,
+ * bounding in-flight memory while streaming. The final ANSI strip and cap
+ * happen via {@link truncateTerminalOutput}. Caller may abandon the
+ * returned promise; chunk errors are surfaced to the caller for them to
+ * decide whether to swallow.
  */
-async function tail(
+async function drainStreamTail(
   stream: AsyncIterable<string>,
   maxChars: number,
 ): Promise<string> {

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -44,11 +44,9 @@ import {
   type ProgressViewInboundHandlerRegistry,
   type ProgressViewInboundMessage,
 } from '@shared/schemas/progressView';
-import { handleExternalInquiryAction } from '@tools/inquiry';
 import { handleUserQuestionAction } from '@tools/userQuestion';
 import { handleProgressViewBashApprovalAction } from '@tools/approval';
 import { GoalStore } from '@tools/goal';
-import { persistOpenTurnDraft } from '@tools/inquiry/externalInquiryStorage';
 import {
   createExternalLocation,
   flexibleFS,
@@ -272,6 +270,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           handleAgentProposalAction: (message) =>
             this.agentProposalController.handleAction(message),
         },
+        externalInquiry: {
+          logWarn: (message, context) =>
+            this.logger.warn(this.channel, message, { data: context }),
+        },
       }),
       [PROGRESS_VIEW_COMMANDS.COMPACT_RESPONSE]: async (data) => {
         await safeExecuteCommand(
@@ -338,38 +340,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           );
         }
       },
-      [PROGRESS_VIEW_COMMANDS.EXTERNAL_INQUIRY_ACTION]: async (data) => {
-        if (data.action === 'draft') {
-          await persistOpenTurnDraft({
-            threadId: data.threadId,
-            draft: data.draft ?? null,
-          });
-          return;
-        }
-        if (data.action === 'submit') {
-          if (data.answer == null || data.answer.length === 0) {
-            this.logger.warn(
-              this.channel,
-              'Ignoring external inquiry submit without an answer',
-              { data: { threadId: data.threadId } },
-            );
-            return;
-          }
-          await handleExternalInquiryAction({
-            action: 'submit',
-            threadId: data.threadId,
-            answer: data.answer,
-            sessionLinks: data.sessionLinks,
-          });
-          return;
-        }
-        await handleExternalInquiryAction({
-          action: 'drop',
-          threadId: data.threadId,
-          feedback: data.feedback,
-        });
-      },
-
       // Profile & Memory - direct command execution
       [PROGRESS_VIEW_COMMANDS.OPEN_PROFILE]: runCommand(
         'texra.auth.viewProfile',

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -24,7 +24,6 @@ import {
   buildVisibleBasicModelOptionsData,
   computeModelOptionsData,
 } from '@model/computeModelOptions';
-import { ApprovalRequestHandler } from '@progressView/managers/ApprovalRequestHandler';
 import {
   AgentCategory,
   type AgentProposalPermission,
@@ -39,7 +38,9 @@ import {
   type UserQuestionPermission,
 } from '@shared/schemas';
 import { agentName } from '@shared/schemas/agent';
+import { ApprovalRequestHandler } from '@shared/progressView/backend/ApprovalRequestHandler';
 import { ProgressBackend } from '@shared/progressView/backend/ProgressBackend';
+import { createProgressBackendUiConfig } from '@shared/progressView/backend/progressBackendUiConfig';
 import { buildStreamInfo } from '@shared/progressView/backend/streamInfoUtils';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import { collectKnownSessionLinks } from '@tools/inquiry/externalInquiryResultFormatter';
@@ -198,35 +199,23 @@ export class ProgressViewProvider
           canSend,
         );
 
-        return {
-          callbacks: {
-            showRetryRequest: (p) => this.retryRequestHandler.show(p),
-            resolveRetryRequest: (id) => this.retryRequestHandler.resolve(id),
-            showToolEditPermission: (p) => this.toolEditHandler.show(p),
-            resolveToolEditPermission: (id) => this.toolEditHandler.resolve(id),
-            updateToolEditApprovalBypassState: (streamId, bypassActive) => {
-              if (canSend())
-                u.updateBypassState(streamId, 'toolEdit', bypassActive);
-            },
-            updateSuperYoloBypassState: (streamId, bypassActive) => {
-              if (canSend())
-                u.updateBypassState(streamId, 'superYolo', bypassActive);
-            },
-            showBashPermission: (p) => this.bashApprovalHandler.show(p),
-            resolveBashPermission: (id) => this.bashApprovalHandler.resolve(id),
-            showAgentProposal: (p) => this.agentProposalHandler.show(p),
-            resolveAgentProposal: (id) => this.agentProposalHandler.resolve(id),
-            showPlanApproval: (p) => this.planApprovalHandler.show(p),
-            resolvePlanApproval: (id) => this.planApprovalHandler.resolve(id),
-            showExternalInquiry: (p) => this.externalInquiryHandler.show(p),
-            resolveExternalInquiry: (id) =>
-              this.externalInquiryHandler.resolve(id),
-            showUserQuestion: (p) => this.userQuestionHandler.show(p),
-            resolveUserQuestion: (id) => this.userQuestionHandler.resolve(id),
+        // Retry is the one host-specific kind: the extension shows a retry
+        // panel via its handler (so the handler also feeds the pending guard).
+        return createProgressBackendUiConfig({
+          handlers: {
+            toolEdit: this.toolEditHandler,
+            bash: this.bashApprovalHandler,
+            retry: this.retryRequestHandler,
+            agentProposal: this.agentProposalHandler,
+            planApproval: this.planApprovalHandler,
+            externalInquiry: this.externalInquiryHandler,
+            userQuestion: this.userQuestionHandler,
           },
-          hasPendingPermissions: (streamId) =>
-            this.hasPendingPermissionsForStream(streamId),
-        };
+          webviewUpdater: u,
+          canSend,
+          showRetryRequest: (p) => this.retryRequestHandler.show(p),
+          resolveRetryRequest: (id) => this.retryRequestHandler.resolve(id),
+        });
       },
     });
     this.state = this.backend.state;
@@ -532,22 +521,6 @@ export class ProgressViewProvider
     proposalId: string,
   ): AgentProposalPermission | undefined {
     return this.agentProposalHandler.get(proposalId);
-  }
-
-  /**
-   * Check if a stream has any pending approval requests (tool-edit, bash,
-   * retry, proposal, or plan approval) that require user interaction.
-   */
-  public hasPendingPermissionsForStream(streamId: string): boolean {
-    return (
-      this.retryRequestHandler.hasPendingForStream(streamId) ||
-      this.toolEditHandler.hasPendingForStream(streamId) ||
-      this.bashApprovalHandler.hasPendingForStream(streamId) ||
-      this.agentProposalHandler.hasPendingForStream(streamId) ||
-      this.planApprovalHandler.hasPendingForStream(streamId) ||
-      this.externalInquiryHandler.hasPendingForStream(streamId) ||
-      this.userQuestionHandler.hasPendingForStream(streamId)
-    );
   }
 
   private canSendToWebview(): boolean {

--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -166,7 +166,7 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
                     .value=${currentAgent}
                     @change=${this.handleAgentSelectChange}
                   >
-                    ${renderAgentOptions(agentOptions, currentAgent)}
+                    ${renderAgentOptions(agentOptions)}
                   </wa-select>
                 </div>
               `
@@ -184,7 +184,7 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
                     .value=${currentModel}
                     @change=${this.handleSelectChange}
                   >
-                    ${renderModelOptions(modelOptions, currentModel)}
+                    ${renderModelOptions(modelOptions)}
                   </wa-select>
                 </div>
               `

--- a/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
@@ -145,7 +145,7 @@ export class WorkflowToolUseFollowupSection extends LitElement {
                 ?disabled=${agents.length === 0}
                 @change=${this.handleAgentChange}
               >
-                ${renderAgentOptions(agents, this.selectedAgent)}
+                ${renderAgentOptions(agents)}
               </wa-select>
             </label>
             <label class="followup__field">
@@ -157,7 +157,7 @@ export class WorkflowToolUseFollowupSection extends LitElement {
                 ?disabled=${models.length === 0}
                 @change=${this.handleModelChange}
               >
-                ${renderModelOptions(models, this.selectedModel)}
+                ${renderModelOptions(models)}
               </wa-select>
             </label>
           </div>

--- a/packages/extension/src/settingsView/frontend/components/memory/events.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/events.ts
@@ -1,4 +1,4 @@
-import type { MemoryItemActionDetail } from '@shared/schemas';
+import type { MemoryItemActionDetail } from '@shared/schemas/settingsViewMessages';
 import { createEvent } from '@shared/utils/events';
 
 export const MemoryViewEvents = {

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -297,7 +297,7 @@ export class InstructionPanel extends LitElement {
         @focus=${this.handleAgentFocus}
         @change=${this.handleAgentChange}
       >
-        ${renderAgentOptions(agent.options, agent.value, {
+        ${renderAgentOptions(agent.options, {
           includeBrowseAll: true,
         })}
       </wa-select>
@@ -458,7 +458,7 @@ export class InstructionPanel extends LitElement {
                 @focus=${this.handleModelFocus}
                 @change=${this.handleModelChange}
               >
-                ${renderModelOptions(session.modelOptions, session.model)}
+                ${renderModelOptions(session.modelOptions)}
               </wa-select>
             </div>
           </div>

--- a/src/agent/core/flows/CycleServices.ts
+++ b/src/agent/core/flows/CycleServices.ts
@@ -103,5 +103,3 @@ export interface ToolUseRoundServices<C = unknown> extends CycleRunServices<C> {
   /** Callback when a queued follow-up is consumed (clears UI display). */
   readonly onFollowUpConsumed?: () => void;
 }
-
-export type CycleParams = Record<string, unknown>;

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -13,6 +13,7 @@ import {
   saveCycleDebug,
   SkippableNodeResult,
 } from '@agent/core/flows/CommonCycleTypes';
+import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import type { ProviderStopReason } from '@agent/modelHandlers/types/StopReasonTypes';
 import type { ProviderUsage } from '@agent/core/usage/ResponseUsage';
@@ -29,7 +30,7 @@ import { extractScratchpad } from '@utils/text/xmlUtils';
 
 import { FlowTransition } from './FlowTransitions';
 import { ModelInvocationNode } from './ModelInvocationNode';
-import type { CycleParams, ResponseCycleServices } from './CycleServices';
+import type { ResponseCycleServices } from './CycleServices';
 
 // ============================================================================
 // Cycle Fields Schema (Extends Base)
@@ -104,7 +105,7 @@ interface ResponsePrepResult {
  */
 class ResponsePrepNode<C> extends BaseNode<
   ResponseCycleShared,
-  CycleParams,
+  FlowParams,
   ResponseCycleServices<C>
 > {
   async prep(shared: ResponseCycleShared): Promise<ResponsePrepResult> {
@@ -224,7 +225,7 @@ export function responseCycleToolsForModel<C>(
  */
 class ResponseProcessNode<C> extends BaseNode<
   ResponseCycleShared,
-  CycleParams,
+  FlowParams,
   ResponseCycleServices<C>
 > {
   async prep(shared: ResponseCycleShared): Promise<ProcessPrepResult> {
@@ -441,7 +442,7 @@ class ResponseProcessNode<C> extends BaseNode<
  */
 class ResponseCycleFinalizeNode<C> extends BaseNode<
   ResponseCycleShared,
-  CycleParams,
+  FlowParams,
   ResponseCycleServices<C>
 > {
   /** Finalize the round by recording stats and invoking callback. */
@@ -475,7 +476,7 @@ class ResponseCycleFinalizeNode<C> extends BaseNode<
  */
 class ResponseContinuationNode<C> extends BaseNode<
   ResponseCycleShared,
-  CycleParams,
+  FlowParams,
   ResponseCycleServices<C>
 > {
   async prep(shared: ResponseCycleShared): Promise<ContinuationPrepResult> {
@@ -604,13 +605,13 @@ class ResponseContinuationNode<C> extends BaseNode<
  */
 export function createResponseCycleFlow<C>(): Flow<
   ResponseCycleShared,
-  CycleParams,
+  FlowParams,
   ResponseCycleServices<C>
 > {
   const prepNode = new ResponsePrepNode<C>();
   const invokeNode = new ModelInvocationNode<
     ResponseCycleShared,
-    CycleParams,
+    FlowParams,
     ResponseCycleServices<C>
   >({
     operationName: 'Model invocation',
@@ -644,7 +645,7 @@ export function createResponseCycleFlow<C>(): Flow<
 
   continuationNode.on(FlowTransition.CONTINUE, prepNode);
 
-  return new Flow<ResponseCycleShared, CycleParams, ResponseCycleServices<C>>(
+  return new Flow<ResponseCycleShared, FlowParams, ResponseCycleServices<C>>(
     prepNode,
   );
 }

--- a/src/agent/core/flows/ToolUseRoundFlow.ts
+++ b/src/agent/core/flows/ToolUseRoundFlow.ts
@@ -18,6 +18,7 @@
 // Local imports - core flow primitives
 import { Flow } from '@agent/node';
 import { defaultPostCompactionContext } from '@agent/core/flows/CommonCycleTypes';
+import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
 
 // Local file imports
 import { FlowTransition } from './FlowTransitions';
@@ -25,7 +26,7 @@ import { ModelInvocationNode } from './ModelInvocationNode';
 import { ToolUseRoundPrepNode } from './toolUseRound/ToolUseRoundPrepNode';
 import { ToolUseProcessNode } from './toolUseRound/ToolUseProcessNode';
 import { ToolUseDispatchNode } from './toolUseRound/ToolUseDispatchNode';
-import type { CycleParams, ToolUseRoundServices } from './CycleServices';
+import type { ToolUseRoundServices } from './CycleServices';
 import type { ToolUseRoundShared } from './toolUseRound/roundShared';
 
 export {
@@ -48,13 +49,13 @@ export {
  */
 export function createToolUseRoundFlow<C>(): Flow<
   ToolUseRoundShared,
-  CycleParams,
+  FlowParams,
   ToolUseRoundServices<C>
 > {
   const prepNode = new ToolUseRoundPrepNode<C>();
   const callNode = new ModelInvocationNode<
     ToolUseRoundShared,
-    CycleParams,
+    FlowParams,
     ToolUseRoundServices<C>
   >({
     operationName: 'Tool-use call',
@@ -77,7 +78,7 @@ export function createToolUseRoundFlow<C>(): Flow<
   processNode.on(FlowTransition.CONTINUE, prepNode);
   dispatchNode.on(FlowTransition.CONTINUE, prepNode);
 
-  return new Flow<ToolUseRoundShared, CycleParams, ToolUseRoundServices<C>>(
+  return new Flow<ToolUseRoundShared, FlowParams, ToolUseRoundServices<C>>(
     prepNode,
   );
 }

--- a/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
@@ -15,6 +15,7 @@ import type {
   FileInteractionState,
   WorkPlanState,
 } from '@agent/core/state/AgentWorkspaceState';
+import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
 import { toErrorMessage } from '@common/errors';
 
 // Local imports - logging
@@ -31,7 +32,7 @@ import {
   normalizeToolCallError,
   parseToolInput,
 } from './toolCallParsing';
-import type { CycleParams, ToolUseRoundServices } from '../CycleServices';
+import type { ToolUseRoundServices } from '../CycleServices';
 import type { ToolUseRoundShared } from './roundShared';
 
 /** Tools that may take a while and benefit from showing in-progress state. */
@@ -85,7 +86,7 @@ interface ToolExecutionResult {
  */
 export class ToolUseDispatchNode<C> extends BatchNode<
   ToolUseRoundShared,
-  CycleParams,
+  FlowParams,
   ToolUseRoundServices<C>
 > {
   /**

--- a/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
@@ -3,6 +3,7 @@ import { BaseNode } from '@agent/node';
 import { logWebFetch, logWebSearch } from '@agent/trace';
 import { recordCycleMetrics } from '@agent/core/state/AgentState';
 import { extractModelResponse } from '@agent/core/flows/CommonCycleTypes';
+import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
 import { appendFollowUpAsUserMessage } from '@agent/followUp/followUpMessages';
 import type { SdkToolCall } from '@agent/modelHandlers/types/IModelHandler';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
@@ -17,7 +18,7 @@ import { formatContent } from '@utils/text/xmlUtils';
 
 // Local file imports
 import { FlowTransition } from '../FlowTransitions';
-import type { CycleParams, ToolUseRoundServices } from '../CycleServices';
+import type { ToolUseRoundServices } from '../CycleServices';
 import type { ToolUseRoundShared } from './roundShared';
 
 const BLANK_TOOL_RESULT_CONTINUATION =
@@ -85,7 +86,7 @@ interface ToolUseProcessPrepResult {
 /** Processes the model response to extract tool calls and usage data. */
 export class ToolUseProcessNode<C> extends BaseNode<
   ToolUseRoundShared,
-  CycleParams,
+  FlowParams,
   ToolUseRoundServices<C>
 > {
   async prep(shared: ToolUseRoundShared): Promise<ToolUseProcessPrepResult> {

--- a/src/agent/core/flows/toolUseRound/ToolUseRoundPrepNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseRoundPrepNode.ts
@@ -5,6 +5,7 @@ import {
   resetCycleState,
   saveCycleDebug,
 } from '@agent/core/flows/CommonCycleTypes';
+import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
 import {
   appendFollowUpAsUserMessage,
   followUpDisplayText,
@@ -13,7 +14,7 @@ import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
 
 // Local file imports
 import { FlowTransition } from '../FlowTransitions';
-import type { CycleParams, ToolUseRoundServices } from '../CycleServices';
+import type { ToolUseRoundServices } from '../CycleServices';
 import type { ToolUseRoundShared } from './roundShared';
 
 /** Prep result for ToolUseRoundPrepNode - drained queued follow-up plus interrupt flag. */
@@ -38,7 +39,7 @@ interface ToolUseRoundPrepResult {
  */
 export class ToolUseRoundPrepNode<C> extends BaseNode<
   ToolUseRoundShared,
-  CycleParams,
+  FlowParams,
   ToolUseRoundServices<C>
 > {
   async prep(_shared: ToolUseRoundShared): Promise<ToolUseRoundPrepResult> {

--- a/src/agent/core/usage/ResponseUsage.ts
+++ b/src/agent/core/usage/ResponseUsage.ts
@@ -55,9 +55,6 @@ export type NativeUsagePayload =
  */
 export type ProviderUsage = NativeUsagePayload | null | undefined;
 
-// Re-export the Google usage type consumed by modelHandlerGoogleGenAI.
-export type { GenerateContentResponseUsageMetadata };
-
 /** Base interface for common response usage metrics. Internal only. */
 interface ResponseUsageBase {
   totalInputTokens: number;

--- a/src/agent/index/AgentDirectoryService.ts
+++ b/src/agent/index/AgentDirectoryService.ts
@@ -28,6 +28,12 @@ export interface AbsoluteDirectoryAccess {
 
 export type AgentDirectoryDocsId = 'custom-agents';
 
+/** A local agent directory paired with the source it represents. */
+export interface AgentDirectoryEntry {
+  directory: string;
+  source: AgentSource;
+}
+
 export interface AgentDirectoryIssueReporter {
   report(message: string, docsId: AgentDirectoryDocsId): Promise<void>;
 }
@@ -88,9 +94,7 @@ export class AgentDirectoryService {
     }
   }
 
-  async getAllLocal(): Promise<
-    Array<{ directory: string; source: AgentSource }>
-  > {
+  async getAllLocal(): Promise<AgentDirectoryEntry[]> {
     const [customDir, builtInDir, builtInToolUseDir] = await Promise.all([
       this.custom(),
       this.builtIn(),

--- a/src/agent/index/agentRegistryConstants.ts
+++ b/src/agent/index/agentRegistryConstants.ts
@@ -2,10 +2,8 @@
 
 import type { AgentSource } from '@shared/schemas/agent';
 export {
-  BUNDLED_ORCHESTRATOR_AGENT_NAMES,
   BUILTIN_TEAM_ROOT_AGENT_NAMES,
   PREFERRED_TOOL_USE_AGENTS,
-  REMOTE_ORCHESTRATOR_AGENT_NAMES,
 } from '@shared/constants/agents';
 
 /** Source priority for lookups (higher priority first). */

--- a/src/agent/index/index.ts
+++ b/src/agent/index/index.ts
@@ -7,29 +7,15 @@ export { AgentSource } from '@shared/schemas/agent';
 export {
   AgentDirectoryService,
   type AbsoluteDirectoryAccess,
-  type AgentDirectoryDocsId,
+  type AgentDirectoryEntry,
   type AgentDirectoryIssueReporter,
   type AgentDirectoryPathStorage,
   type AgentDirectoryServiceLogger,
-  type AgentDirectoryServiceOptions,
-  type CustomAgentDirectoryStore,
 } from './AgentDirectoryService';
 
-export { type BundledAgentDirectoryName } from './BundledAgentDirectories';
+export { GlobalStorageAgentDirectoryStorage } from './AgentDirectorySync';
 
-export {
-  GlobalStorageAgentDirectoryStorage,
-  type AgentDirectoryBundleSource,
-  type AgentDirectoryStorage,
-  type AgentDirectorySyncLogger,
-  type AgentDirectoryVersionStore,
-  type BundledAgentDirectorySyncOptions,
-} from './AgentDirectorySync';
-
-export {
-  type AgentDirectories,
-  setAgentDirectories,
-} from './agentDirectoriesRegistry';
+export { setAgentDirectories } from './agentDirectoriesRegistry';
 
 export { toRemoteAgentProfileData } from './remoteAgentProfileData';
 

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -25,7 +25,6 @@ import type { StreamHandle } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { hasEndTag } from '@agent/core/definition/AgentDataclass';
 import type { AgentSetting } from '@agent/core/definition/AgentDataclass';
-import type { GenerateContentResponseUsageMetadata } from '@agent/core/usage/ResponseUsage';
 import type { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
@@ -74,6 +73,7 @@ import type {
   Content,
   Candidate,
   GenerateContentResponse,
+  GenerateContentResponseUsageMetadata,
   FunctionResponsePart,
   Tool as GeminiTool,
   GenerateContentConfig,

--- a/src/agent/runtime/detachSubagentsOnStop.ts
+++ b/src/agent/runtime/detachSubagentsOnStop.ts
@@ -1,0 +1,24 @@
+import { tryPlatform } from '@platform/platform';
+import { WorkspaceStateKey } from '@shared/state/stateKeys';
+
+/**
+ * Whether stopping or killing an agent stream should detach its active child
+ * executions instead of letting them die with the parent.
+ *
+ * Read live at stop/kill time so the desktop and extension settings toggle
+ * takes effect immediately, and shared by every host (extension stop command,
+ * desktop execution, CLI session controller and TUI kill, and the orchestrator
+ * kill tool) so the `detachActiveChildren` policy has one source of truth.
+ *
+ * Uses `tryPlatform()` and the `=== true` coercion so the policy defaults to
+ * false when the toggle is unset or the platform has not been initialized,
+ * matching the previous inline reads at every call site.
+ */
+export function detachSubagentsOnStop(): boolean {
+  return (
+    tryPlatform()?.workspaceState.get<boolean>(
+      WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP,
+      false,
+    ) === true
+  );
+}

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -89,6 +89,11 @@ export async function resumeQueuedToolUseSnapshot(
   if (!resumeError) {
     return true;
   }
-  await options.onError(resumeError.error);
+  try {
+    await options.onError(resumeError.error);
+  } catch {
+    // A broken host error surface should not turn a handled resume failure into
+    // an unhandled rejection.
+  }
   return false;
 }

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -1,0 +1,94 @@
+import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
+import type { FollowUpQueueInput } from '@agent/followUp/FollowUpQueue';
+import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
+import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+
+import type { AgentRuntimeHost } from './AgentRuntimeHost';
+import { resumeToolUseFromSnapshot } from './executeAgent';
+import type { SessionHandle } from './SessionHandle';
+import { StreamStatusService } from './StreamStatusService';
+
+export interface ResumeQueuedToolUseOptions {
+  /** Session owning this run's coordination state. Defaults to the process session. */
+  readonly session?: SessionHandle;
+  /** Tools hidden because the current host/runtime cannot support them. */
+  readonly runtimeUnavailableTools?: readonly string[];
+  /**
+   * Follow-ups to replay ahead of any items already queued for the stream
+   * (e.g. an explicit follow-up typed alongside a manual resume). Seeded before
+   * the drain so the failure path re-enqueues them even if the drain throws
+   * before the full list is assigned.
+   */
+  readonly extraFollowUps?: readonly FollowUpQueueInput[];
+  /**
+   * Host-specific failure surface (log + toast). Invoked after the stream has
+   * been returned to WAITING, so a blocking host dialog cannot strand the
+   * stream in RESUMING while it awaits dismissal.
+   */
+  readonly onError: (error: unknown) => void | Promise<void>;
+}
+
+/**
+ * Drive the shared tool-use resume "queue dance" that both the VS Code
+ * extension and the desktop bridge wrap around `resumeToolUseFromSnapshot`:
+ *
+ *   acquire the follow-up queue → flip the stream to RESUMING → drain the
+ *   queued follow-ups and notify the UI → resume, re-appending the drained
+ *   items into the rebuilt session → on failure, re-enqueue the follow-ups
+ *   (force) and re-notify → always return the stream to WAITING if the resume
+ *   never reached the run lifecycle.
+ *
+ * Hosts stay thin adapters: they supply only what differs (`session`,
+ * `runtimeUnavailableTools`, an optional seed follow-up, and the `onError`
+ * toast). Returns `true` when the resume completed and `false` when it failed.
+ */
+export async function resumeQueuedToolUseSnapshot(
+  streamId: StreamTabId,
+  snapshot: ToolUseSessionSnapshot,
+  runtimeHost: AgentRuntimeHost,
+  options: ResumeQueuedToolUseOptions,
+): Promise<boolean> {
+  ToolUseFollowUpQueue.acquire(streamId);
+  StreamStatusService.set(streamId, STREAM_STATUS.RESUMING, { runtimeHost });
+
+  const seed = options.extraFollowUps ?? [];
+  let followUps: readonly FollowUpQueueInput[] = seed;
+  let resumeError: { error: unknown } | undefined;
+  try {
+    followUps = [...seed, ...ToolUseFollowUpQueue.drainItems(streamId)];
+    runtimeHost.emit('updateQueuedFollowUps', { streamId });
+
+    await resumeToolUseFromSnapshot(snapshot, runtimeHost, {
+      session: options.session,
+      runtimeUnavailableTools: options.runtimeUnavailableTools,
+      setupSession: (session) => {
+        for (const item of followUps) {
+          session.appendFollowUp(item);
+        }
+      },
+    });
+  } catch (error) {
+    resumeError = { error };
+    // Re-enqueue the drained follow-ups (explicit seed first) so a later
+    // resume replays them instead of dropping them.
+    for (const item of followUps) {
+      ToolUseFollowUpQueue.enqueue(streamId, item, { force: true });
+    }
+    if (followUps.length > 0) {
+      runtimeHost.emit('updateQueuedFollowUps', { streamId });
+    }
+  } finally {
+    // Only the early-failure path leaves the stream RESUMING (a started run
+    // owns its own status); settle it back to WAITING before surfacing the
+    // error so a blocking host dialog cannot hold the stream in RESUMING.
+    if (StreamStatusService.get(streamId) === STREAM_STATUS.RESUMING) {
+      StreamStatusService.set(streamId, STREAM_STATUS.WAITING, { runtimeHost });
+    }
+  }
+
+  if (!resumeError) {
+    return true;
+  }
+  await options.onError(resumeError.error);
+  return false;
+}

--- a/src/agent/runtime/selectAutoOpenFinalOutput.ts
+++ b/src/agent/runtime/selectAutoOpenFinalOutput.ts
@@ -1,0 +1,31 @@
+import type { WorkflowFlowResult } from '@agent/runtime/AgentFlowResult';
+import { RUN_OUTCOME } from '@shared/schemas';
+import type { OutputFileSummary } from '@shared/schemas/output';
+import { getConfig } from '@utils/config';
+
+/**
+ * Decide whether a finished workflow should auto-open a final output, and which
+ * one. Shared policy across hosts (VS Code extension, desktop) so a multi-round
+ * run resolves the same file everywhere instead of each host picking its own:
+ *
+ * - Gated by `texra.agentOutputs.autoOpenFinal` (default true).
+ * - Only a `completed` run qualifies — cancelled or failed runs may carry
+ *   partial outputs the user did not ask to review.
+ * - The highest round wins, which is the canonical "final" revision.
+ *
+ * Returns `undefined` when nothing should open; the host supplies only its own
+ * open verb (the extension's text-document preview, the desktop's `openPath`).
+ */
+export function selectAutoOpenFinalOutput(
+  result: WorkflowFlowResult,
+): OutputFileSummary | undefined {
+  if (!getConfig<boolean>('texra.agentOutputs.autoOpenFinal', true)) {
+    return undefined;
+  }
+  if (result.outcome !== RUN_OUTCOME.COMPLETED || result.outputs.length === 0) {
+    return undefined;
+  }
+
+  const lastRound = Math.max(...result.outputs.map((output) => output.round));
+  return result.outputs.find((output) => output.round === lastRound);
+}

--- a/src/agent/trace/index.ts
+++ b/src/agent/trace/index.ts
@@ -10,37 +10,13 @@
  *
  * See `docs/proposals/agent-trace-sdk-surface.md` for the design.
  */
-export type {
-  AgentEvent,
-  ContextStateData,
-  ContextStateEvent,
-  DomainEvent,
-  LogEvent,
-  ResultEvent,
-  StageEndEvent,
-  StageStartEvent,
-  StageStamp,
-  StreamChunkEvent,
-  StreamEndEvent,
-  StreamKind,
-  StreamStartEvent,
-  TokenUsageStats,
-  ToolEndEvent,
-  ToolStartEvent,
-  ToolStatus,
-  UsageEvent,
-} from './events';
+export type { AgentEvent, LogEvent, ResultEvent } from './events';
 
 export type {
   AgentTrace,
   AgentTraceSubscriber,
-  DomainEventInput,
-  LogOptions,
-  StagedEmitOptions,
   StageHandle,
-  StageOptions,
   StreamHandle,
-  StreamOptions,
 } from './AgentTrace';
 
 export { TraceEmitter } from './TraceEmitter';

--- a/src/auth/SupabaseSession.ts
+++ b/src/auth/SupabaseSession.ts
@@ -20,24 +20,21 @@ import {
 import type { AuthTokenProvider, SessionTokens } from './TokenProvider';
 import type { SupabaseClient as Client } from '@supabase/supabase-js';
 
-// Public entry point: external consumers import session schemas, value-object
+// Public entry point: external consumers import the session value-object
 // helpers, the fetch-with-timeout utility, and this coordinator through
-// `@auth/SupabaseSession`. Implementation is split into the modules above.
+// `@auth/SupabaseSession`. Implementation is split into the modules above. Only
+// the symbols consumers actually use are forwarded; the Zod schemas and the
+// callback/parse-option types stay internal to `supabaseSessionTypes`.
 export { fetchWithTimeout } from './fetchWithTimeout';
 export {
   DEFAULT_SUPABASE_SESSION_EXPIRY_MS,
-  GitHubTokenExchangeSchema,
-  SupabaseSessionSchema,
   parseStoredSupabaseSession,
   parseTokenExchangeResponse,
   toStorableSupabaseSession,
   type GitHubTokenExchangeResponse,
-  type SupabaseCallbackParseError,
-  type SupabaseCallbackParseResult,
   type SupabaseCallbackResult,
   type SupabaseSession,
   type SupabaseSessionLog,
-  type SupabaseSessionParseOptions,
   type SupabaseSessionStorage,
 } from './supabaseSessionTypes';
 

--- a/src/auth/tier/types.ts
+++ b/src/auth/tier/types.ts
@@ -18,10 +18,7 @@
  */
 
 import { z } from 'zod';
-import { UserTierSchema, type UserTier } from '../sharedConfig';
-
-// Re-export for convenience
-export { UserTierSchema, type UserTier };
+import { UserTierSchema } from '../sharedConfig';
 
 /**
  * Schema for user access status including expiration.

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -1,7 +1,12 @@
 // Local imports - shared
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
-import type { AgentCategoryFilter, StreamTabId } from '@shared/schemas';
+import type {
+  AgentCategoryFilter,
+  ExternalInquiryThreadId,
+  StreamTabId,
+} from '@shared/schemas';
 import type {
   ProgressViewInboundHandlerRegistry,
   ProgressViewInboundMessage,
@@ -12,6 +17,8 @@ import {
   setBashApprovalSessionBypass,
   setToolEditApprovalSessionBypass,
 } from '@tools/approval';
+import { handleExternalInquiryAction } from '@tools/inquiry';
+import { persistOpenTurnDraft } from '@tools/inquiry/externalInquiryStorage';
 
 // Local imports - utilities
 import { savePastedImageBase64 } from '@utils/files/pastedImageUtils';
@@ -107,6 +114,23 @@ export interface ProgressViewApprovalCommandActions {
   ): unknown;
 }
 
+export interface ProgressViewExternalInquiryCommandActions {
+  /**
+   * Host log sink for the empty-answer guard. The guard policy and message
+   * live in the shared handler; hosts differ only in whether their logger
+   * carries a channel, so they pass just the transport here.
+   */
+  logWarn(
+    message: string,
+    context: { threadId: ExternalInquiryThreadId },
+  ): void;
+  /**
+   * Forwarded to the inquiry submit/drop settle path. Desktop scopes it to its
+   * window session; the extension omits it so the module default applies.
+   */
+  sessionContext?: { session?: SessionHandle };
+}
+
 export interface ProgressViewCommandActions {
   lifecycle: ProgressViewLifecycleCommandActions;
   run: ProgressViewRunCommandActions;
@@ -114,6 +138,7 @@ export interface ProgressViewCommandActions {
   bypass: ProgressViewBypassCommandOptions;
   file: ProgressViewFileCommandActions;
   approval: ProgressViewApprovalCommandActions;
+  externalInquiry: ProgressViewExternalInquiryCommandActions;
 }
 
 /**
@@ -128,7 +153,7 @@ export interface ProgressViewCommandActions {
 export function createProgressViewCommandHandlers(
   actions: ProgressViewCommandActions,
 ): ProgressViewInboundHandlerRegistry {
-  const { lifecycle, run, file, followUp, approval } = actions;
+  const { lifecycle, run, file, followUp, approval, externalInquiry } = actions;
   const { runtimeHost, showInfo } = actions.bypass;
 
   // Single source of truth for the coupled edit + bash session bypass behind
@@ -272,6 +297,46 @@ export function createProgressViewCommandHandlers(
     },
     [PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION]: async (data) => {
       await approval.handleAgentProposalAction(data);
+    },
+
+    // External inquiry settle path: draft persists the open turn, submit/drop
+    // settle the durable thread. The empty-answer guard and warning message are
+    // shared; hosts supply only the log transport and (desktop) the session.
+    [PROGRESS_VIEW_COMMANDS.EXTERNAL_INQUIRY_ACTION]: async (data) => {
+      if (data.action === 'draft') {
+        await persistOpenTurnDraft({
+          threadId: data.threadId,
+          draft: data.draft ?? null,
+        });
+        return;
+      }
+      if (data.action === 'submit') {
+        if (data.answer == null || data.answer.length === 0) {
+          externalInquiry.logWarn(
+            'Ignoring external inquiry submit without an answer',
+            { threadId: data.threadId },
+          );
+          return;
+        }
+        await handleExternalInquiryAction(
+          {
+            action: 'submit',
+            threadId: data.threadId,
+            answer: data.answer,
+            sessionLinks: data.sessionLinks,
+          },
+          externalInquiry.sessionContext,
+        );
+        return;
+      }
+      await handleExternalInquiryAction(
+        {
+          action: 'drop',
+          threadId: data.threadId,
+          feedback: data.feedback,
+        },
+        externalInquiry.sessionContext,
+      );
     },
   };
 }

--- a/src/controllers/settingsView/SettingsProfileController.ts
+++ b/src/controllers/settingsView/SettingsProfileController.ts
@@ -78,6 +78,45 @@ export interface SettingsProfileControllerDeps {
   invalidateModelOptionsCache(): void;
 }
 
+/**
+ * Per-provider data needed to assemble a `ProviderKeyStatus`. Each host resolves
+ * these the same way, except `getProviderVscodeSettings`: the VS Code extension
+ * fills it from config while the desktop app returns [].
+ */
+export interface ProviderKeyStatusSources {
+  readonly providerIds: readonly string[];
+  loadProviderKeyStatuses(): Promise<
+    Record<string, ProviderKeyStatus['status']>
+  >;
+  getProviderDisplayName(provider: string): string;
+  getProviderKeyUrl(provider: string): string | undefined;
+  getProviderStreaming(provider: string): boolean;
+  getProviderEndpoint(provider: string): string;
+  supportsCustomEndpoint(provider: string): boolean;
+  getProviderVscodeSettings(provider: string): ProviderVscodeSetting[];
+}
+
+/**
+ * Map every provider id to its `ProviderKeyStatus`. Shared by the VS Code
+ * extension controller and the desktop settings IPC so the wire shape lives in
+ * exactly one place and the two hosts cannot drift.
+ */
+export async function buildProviderKeyStatuses(
+  sources: ProviderKeyStatusSources,
+): Promise<ProviderKeyStatus[]> {
+  const secretStatuses = await sources.loadProviderKeyStatuses();
+  return sources.providerIds.map((provider) => ({
+    provider,
+    displayName: sources.getProviderDisplayName(provider),
+    status: secretStatuses[provider] ?? 'not-set',
+    keyUrl: sources.getProviderKeyUrl(provider) ?? '',
+    streaming: sources.getProviderStreaming(provider),
+    customEndpoint: sources.getProviderEndpoint(provider),
+    supportsCustomEndpoint: sources.supportsCustomEndpoint(provider),
+    vscodeSettings: sources.getProviderVscodeSettings(provider),
+  }));
+}
+
 export class SettingsProfileController {
   private readonly providerSettingsByKey: Map<string, ProviderVscodeSettingDef>;
   private readonly reliabilitySettingKeys = new Set(
@@ -169,18 +208,22 @@ export class SettingsProfileController {
     return { kind: 'updated', affectsModelAvailability };
   }
 
-  private async getProviderKeyStatuses(): Promise<ProviderKeyStatus[]> {
-    const secretStatuses = await this.deps.loadProviderKeyStatuses();
-    return this.deps.providerIds.map((provider) => ({
-      provider,
-      displayName: this.getProviderDisplayName(provider),
-      status: secretStatuses[provider] ?? 'not-set',
-      keyUrl: this.getProviderKeyUrl(provider) ?? '',
-      streaming: this.deps.getProviderStreaming(provider),
-      customEndpoint: this.deps.getProviderEndpoint(provider),
-      supportsCustomEndpoint: this.deps.supportsCustomEndpoint(provider),
-      vscodeSettings: this.getProviderVscodeSettings(provider),
-    }));
+  private getProviderKeyStatuses(): Promise<ProviderKeyStatus[]> {
+    return buildProviderKeyStatuses({
+      providerIds: this.deps.providerIds,
+      loadProviderKeyStatuses: () => this.deps.loadProviderKeyStatuses(),
+      getProviderDisplayName: (provider) =>
+        this.getProviderDisplayName(provider),
+      getProviderKeyUrl: (provider) => this.getProviderKeyUrl(provider),
+      getProviderStreaming: (provider) =>
+        this.deps.getProviderStreaming(provider),
+      getProviderEndpoint: (provider) =>
+        this.deps.getProviderEndpoint(provider),
+      supportsCustomEndpoint: (provider) =>
+        this.deps.supportsCustomEndpoint(provider),
+      getProviderVscodeSettings: (provider) =>
+        this.getProviderVscodeSettings(provider),
+    });
   }
 
   private getProviderVscodeSettings(provider: string): ProviderVscodeSetting[] {

--- a/src/hosts/uiHosts.ts
+++ b/src/hosts/uiHosts.ts
@@ -1,3 +1,6 @@
+// Third-party imports
+import stripAnsi from 'strip-ansi';
+
 export interface ClipboardHost {
   readText(): Promise<string>;
   writeText(text: string): Promise<void>;
@@ -99,11 +102,23 @@ export interface TerminalRunRequest extends TerminalOptions {
 }
 
 /**
- * Length cap (chars) for {@link TerminalRunResult.output}. Every host's
- * `TerminalRunner` keeps the same sliding-window tail so agents see identical
- * truncation regardless of where a setup command ran.
+ * Length cap (chars) for {@link TerminalRunResult.output}. Apply it through
+ * {@link truncateTerminalOutput} so agents see identical truncation regardless
+ * of where a setup command ran.
  */
 export const TERMINAL_OUTPUT_MAX_CHARS = 12_000;
+
+/**
+ * The shared ANSI-stripped, length-capped tail every host's `TerminalRunner`
+ * returns in {@link TerminalRunResult.output}. Strips control sequences, then
+ * keeps the trailing {@link TERMINAL_OUTPUT_MAX_CHARS} characters.
+ */
+export function truncateTerminalOutput(output: string): string {
+  const stripped = stripAnsi(output);
+  return stripped.length > TERMINAL_OUTPUT_MAX_CHARS
+    ? stripped.slice(-TERMINAL_OUTPUT_MAX_CHARS)
+    : stripped;
+}
 
 export interface TerminalRunResult {
   /** Undefined when the host cannot observe the command exit code. */
@@ -128,12 +143,4 @@ export interface TerminalHost {
 
 export interface TerminalRunner {
   runCommand(request: TerminalRunRequest): Promise<TerminalRunResult>;
-}
-
-export interface UIHosts {
-  readonly prompt: PromptHost;
-  readonly externalOpener: ExternalOpener;
-  readonly diff: DiffViewHost;
-  readonly terminal: TerminalHost;
-  readonly clipboard: ClipboardHost;
 }

--- a/src/latex/acceptedFileTarget.ts
+++ b/src/latex/acceptedFileTarget.ts
@@ -90,6 +90,68 @@ export function buildAcceptSuccessMessage(
   return `Successfully ${operation} '${targetFileName}' with content from '${path.basename(editedPath)}'`;
 }
 
+/**
+ * Host capabilities the accept-edited replace flow reaches through, so the
+ * host-neutral orchestration can run on both the VS Code command (flexibleFS,
+ * warning dialog, ProgressEventBus) and the desktop bridge (node fs, runtime
+ * host emit) without each side re-implementing the confirm / write / emit /
+ * success sequence.
+ */
+export interface AcceptEditedFileReplacePorts {
+  exists: (location: FileLocation) => Promise<boolean>;
+  readFile: (location: FileLocation) => Promise<string>;
+  writeFile: (location: FileLocation, content: string) => Promise<void>;
+  /** Confirm the (possibly overwriting) write; return false to abort. */
+  confirm: (message: string) => Promise<boolean>;
+  /** Notify the host that a workspace file was written at this absolute path. */
+  emitWritten: (absolutePath: string) => void;
+  showInfo: (message: string) => void | Promise<void>;
+}
+
+/**
+ * Resolve the accept target beside the base file, confirm the write, then copy
+ * the edited content into it, emitting a workspace-write notification and a
+ * success message. Returns whether the write happened (false when the user
+ * declined the confirmation). Shared by the desktop file actions and the VS
+ * Code compare command's replace branch; the latter wraps this with its own
+ * replace-vs-copy quick pick when run metadata is available.
+ */
+export async function acceptEditedFileReplace(
+  baseLocation: FileLocation,
+  editedLocation: FileLocation,
+  ports: AcceptEditedFileReplacePorts,
+): Promise<boolean> {
+  const editedPath = editedLocation.absolutePath;
+  const target = getAcceptedFileTarget(baseLocation, editedPath);
+  const { targetLocation, targetFileName, isNewFile } = target;
+  const targetExists = isNewFile && (await ports.exists(targetLocation));
+
+  const confirmed = await ports.confirm(
+    buildAcceptConfirmMessage(
+      target,
+      baseLocation.absolutePath,
+      editedPath,
+      targetExists,
+    ),
+  );
+  if (!confirmed) return false;
+
+  const editedContent = await ports.readFile(editedLocation);
+  await ports.writeFile(targetLocation, editedContent);
+  if (targetLocation.kind === 'workspace') {
+    ports.emitWritten(targetLocation.absolutePath);
+  }
+
+  await ports.showInfo(
+    buildAcceptSuccessMessage(
+      targetFileName,
+      editedPath,
+      !isNewFile || targetExists,
+    ),
+  );
+  return true;
+}
+
 export function getAcceptedFileTarget(
   baseLocation: FileLocation,
   editedPath: string,

--- a/src/platform/defaults/nodeHost.ts
+++ b/src/platform/defaults/nodeHost.ts
@@ -1,0 +1,106 @@
+/**
+ * Node host composition helpers.
+ *
+ * The two Node composition roots (the `texra` CLI runtime and the Electron
+ * desktop main process) wire the same platform skeleton and the same
+ * post-`initPlatform` agent-runtime registration. This module owns that shared
+ * sequence so the hosts cannot drift; each host keeps only its genuinely
+ * host-specific concerns (secrets, state stores, auth, signal handlers,
+ * snapshot store, config migration, ...).
+ *
+ * This file is a composition helper, not a core platform abstraction: it
+ * deliberately reaches "up" into `@agent` and `@tools` to register the agent
+ * runtime, mirroring what each host's composition root would otherwise inline.
+ * Nothing in `@agent` / `@tools` imports it back, so there is no cycle.
+ */
+
+// Node imports
+import { join } from 'node:path';
+
+// Local imports - agent + tools (composition wiring)
+import { registerAgentFeatures } from '@agent/features';
+import { initializeGoalPrompts } from '@agent/goal';
+import { registerDirectLeanLanguageServices } from '@tools/lean/direct/directLspAdapter';
+
+// Local imports - platform
+import { JsonConfigProvider } from './jsonConfigProvider';
+import { nodeFilesystem } from './nodeFilesystem';
+import { createNodeWorkspace } from './nodeWorkspace';
+import { NO_TOOL_AVAILABILITY_HOST } from '../interfaces/toolAvailability';
+import { initPlatform } from '../platform';
+
+// Type imports
+import type { JsonConfigProviderOptions } from './jsonConfigProvider';
+import type { AgentResumePort } from '../interfaces/agentResume';
+import type { LifecycleHost } from '../interfaces/lifecycle';
+import type { StateStore } from '../interfaces/state';
+import type { StorageProvider } from '../interfaces/storage';
+import type { ToolAvailabilityHost } from '../interfaces/toolAvailability';
+import type { PlatformSecrets } from '../secrets';
+
+/**
+ * Host-specific services a Node host supplies to {@link initNodePlatform}. The
+ * shared Node defaults (filesystem, workspace provider, config provider, and
+ * the no-op tool-availability host) are filled in by the helper.
+ */
+export interface NodePlatformServices {
+  /** Workspace + optional global config stores backing the config provider. */
+  readonly configStores: JsonConfigProviderOptions;
+  readonly globalState: StateStore;
+  readonly workspaceState: StateStore;
+  readonly storage: StorageProvider;
+  readonly secrets: PlatformSecrets;
+  readonly lifecycle: LifecycleHost;
+  readonly agentResume: AgentResumePort;
+  /** Current workspace root, read lazily so the host can update it later. */
+  readonly getWorkspacePath: () => string | undefined;
+  /** Host-specific availability overrides merged over the no-op defaults. */
+  readonly toolAvailability?: Partial<ToolAvailabilityHost>;
+}
+
+/**
+ * Assemble and install the platform for a Node host (CLI, desktop).
+ *
+ * Centralizes the default building blocks both hosts pass to `initPlatform`
+ * (`nodeFilesystem`, `createNodeWorkspace`, `JsonConfigProvider`, the no-op
+ * tool-availability host) so they cannot diverge between hosts.
+ */
+export function initNodePlatform(services: NodePlatformServices): void {
+  initPlatform({
+    config: new JsonConfigProvider(services.configStores),
+    globalState: services.globalState,
+    workspaceState: services.workspaceState,
+    fs: nodeFilesystem,
+    workspace: createNodeWorkspace(services.getWorkspacePath),
+    storage: services.storage,
+    secrets: services.secrets,
+    lifecycle: services.lifecycle,
+    agentResume: services.agentResume,
+    toolAvailability: {
+      ...NO_TOOL_AVAILABILITY_HOST,
+      ...services.toolAvailability,
+    },
+  });
+}
+
+/**
+ * Register the agent runtime for a Node host after {@link initNodePlatform}.
+ *
+ * Both Node hosts share this exact post-init sequence: the conditional
+ * tool-injection features (memory + goal), the direct Lean language services,
+ * and the packaged Goal prompt path. Centralized so the hosts cannot drift;
+ * the CLI previously skipped `registerAgentFeatures`, silently losing the
+ * memory and goal tool injections.
+ *
+ * Call exactly once per process: `registerAgentFeatures` and
+ * `registerDirectLeanLanguageServices` register a singleton / shutdown handler
+ * that throws or double-registers on a second call.
+ */
+export function initNodeAgentRuntime(
+  lifecycle: LifecycleHost,
+  resourcesPath: string,
+): void {
+  registerAgentFeatures();
+  registerDirectLeanLanguageServices(lifecycle);
+  initializeGoalPrompts(join(resourcesPath, 'goal', 'goal.yaml'));
+}

--- a/src/platform/defaults/nodeHost.ts
+++ b/src/platform/defaults/nodeHost.ts
@@ -3,14 +3,13 @@
  *
  * The two Node composition roots (the `texra` CLI runtime and the Electron
  * desktop main process) wire the same platform skeleton and the same
- * post-`initPlatform` agent-runtime registration. This module owns that shared
- * sequence so the hosts cannot drift; each host keeps only its genuinely
- * host-specific concerns (secrets, state stores, auth, signal handlers,
- * snapshot store, config migration, ...).
+ * post-`initPlatform` agent-runtime registration. This module owns the shared
+ * ingredients so the hosts cannot drift; each host still performs the actual
+ * `initPlatform(...)` call in its own composition root.
  *
  * This file is a composition helper, not a core platform abstraction: it
- * deliberately reaches "up" into `@agent` and `@tools` to register the agent
- * runtime, mirroring what each host's composition root would otherwise inline.
+ * deliberately reaches "up" into `@agent` and `@tools` for the registration
+ * helpers, mirroring what each host's composition root would otherwise inline.
  * Nothing in `@agent` / `@tools` imports it back, so there is no cycle.
  */
 
@@ -27,7 +26,6 @@ import { JsonConfigProvider } from './jsonConfigProvider';
 import { nodeFilesystem } from './nodeFilesystem';
 import { createNodeWorkspace } from './nodeWorkspace';
 import { NO_TOOL_AVAILABILITY_HOST } from '../interfaces/toolAvailability';
-import { initPlatform } from '../platform';
 
 // Type imports
 import type { JsonConfigProviderOptions } from './jsonConfigProvider';
@@ -36,10 +34,11 @@ import type { LifecycleHost } from '../interfaces/lifecycle';
 import type { StateStore } from '../interfaces/state';
 import type { StorageProvider } from '../interfaces/storage';
 import type { ToolAvailabilityHost } from '../interfaces/toolAvailability';
+import type { Platform } from '../platform';
 import type { PlatformSecrets } from '../secrets';
 
 /**
- * Host-specific services a Node host supplies to {@link initNodePlatform}. The
+ * Host-specific services a Node host supplies to {@link createNodePlatform}. The
  * shared Node defaults (filesystem, workspace provider, config provider, and
  * the no-op tool-availability host) are filled in by the helper.
  */
@@ -59,14 +58,15 @@ export interface NodePlatformServices {
 }
 
 /**
- * Assemble and install the platform for a Node host (CLI, desktop).
+ * Assemble the platform services for a Node host (CLI, desktop).
  *
  * Centralizes the default building blocks both hosts pass to `initPlatform`
  * (`nodeFilesystem`, `createNodeWorkspace`, `JsonConfigProvider`, the no-op
- * tool-availability host) so they cannot diverge between hosts.
+ * tool-availability host) while preserving the rule that only composition
+ * roots call `initPlatform(...)`.
  */
-export function initNodePlatform(services: NodePlatformServices): void {
-  initPlatform({
+export function createNodePlatform(services: NodePlatformServices): Platform {
+  return {
     config: new JsonConfigProvider(services.configStores),
     globalState: services.globalState,
     workspaceState: services.workspaceState,
@@ -80,27 +80,34 @@ export function initNodePlatform(services: NodePlatformServices): void {
       ...NO_TOOL_AVAILABILITY_HOST,
       ...services.toolAvailability,
     },
-  });
+  };
 }
 
 /**
- * Register the agent runtime for a Node host after {@link initNodePlatform}.
+ * Register the singleton agent runtime for a Node host after `initPlatform`.
  *
  * Both Node hosts share this exact post-init sequence: the conditional
- * tool-injection features (memory + goal), the direct Lean language services,
- * and the packaged Goal prompt path. Centralized so the hosts cannot drift;
- * the CLI previously skipped `registerAgentFeatures`, silently losing the
- * memory and goal tool injections.
+ * tool-injection features (memory + goal) and the direct Lean language
+ * services. Centralized so the hosts cannot drift; the CLI previously skipped
+ * `registerAgentFeatures`, silently losing the memory and goal tool
+ * injections.
  *
  * Call exactly once per process: `registerAgentFeatures` and
  * `registerDirectLeanLanguageServices` register a singleton / shutdown handler
  * that throws or double-registers on a second call.
  */
-export function initNodeAgentRuntime(
-  lifecycle: LifecycleHost,
-  resourcesPath: string,
-): void {
+export function initNodeAgentRuntime(lifecycle: LifecycleHost): void {
   registerAgentFeatures();
   registerDirectLeanLanguageServices(lifecycle);
+}
+
+/**
+ * Point host-neutral Goal prompts at the active packaged resource bundle.
+ *
+ * Safe to call repeatedly: the loader replaces the path and clears its cache.
+ * CLI validation can re-enter platform init with a different resources path in
+ * the same process, so this stays separate from one-shot runtime registration.
+ */
+export function initializeNodeGoalPrompts(resourcesPath: string): void {
   initializeGoalPrompts(join(resourcesPath, 'goal', 'goal.yaml'));
 }

--- a/src/replacement/helpers.ts
+++ b/src/replacement/helpers.ts
@@ -10,10 +10,6 @@ export {
   SECTION_TYPES,
   MATH_OPERATORS,
   LATEX_ENVIRONMENTS,
-  FENCED_LATEX_ENVIRONMENTS,
-  FENCED_LATEX_ENVIRONMENT_PATTERN,
-  FENCED_LATEX_BLOCK_PATTERN_MULTILINE,
-  FENCED_LATEX_BLOCK_PATTERN_INLINE,
 } from './constants';
 
 // ============================================================================

--- a/src/shared/progressView/backend/ApprovalRequestHandler.ts
+++ b/src/shared/progressView/backend/ApprovalRequestHandler.ts
@@ -1,6 +1,8 @@
 /**
  * Generic handler for approval/prompt requests with pending state management.
- * Eliminates duplication across tool edit, bash approval, retry, and proposal handlers.
+ * Eliminates duplication across tool edit, bash approval, retry, and proposal
+ * handlers, and is shared by both the VS Code extension and the desktop host so
+ * neither re-implements the pending-approval bookkeeping.
  *
  * The `delivered` set tracks IDs sent to the current webview target so that
  * show() won't duplicate an item that replay() already sent.  replay() always
@@ -63,5 +65,28 @@ export class ApprovalRequestHandler<
       if (!item.streamId || item.streamId === streamId) return true;
     }
     return false;
+  }
+
+  /**
+   * Silently drop every pending item tied to `streamId` (exact match, so
+   * streamless prompts survive). Unlike resolve(), this does NOT notify the
+   * webview — it only keeps the pending-permissions guard consistent when a
+   * stream is deleted and its prompts were already settled (or are durable,
+   * like external inquiries, and never receive a resolve event).
+   */
+  releaseForStream(streamId: string): void {
+    for (const [id, item] of this.pending) {
+      if (item.streamId === streamId) {
+        this.pending.delete(id);
+        this.delivered.delete(id);
+      }
+    }
+  }
+
+  /** Silently drop all pending items (and delivery tracking) without notifying
+   *  the webview. Used on a "delete all"/teardown sweep. */
+  clear(): void {
+    this.pending.clear();
+    this.delivered.clear();
   }
 }

--- a/src/shared/progressView/backend/progressBackendUiConfig.ts
+++ b/src/shared/progressView/backend/progressBackendUiConfig.ts
@@ -1,0 +1,101 @@
+import type {
+  AgentProposalPermission,
+  BashPermission,
+  ExternalInquiryPermission,
+  PlanApprovalPermission,
+  RetryPermission,
+  ToolEditPermission,
+  UserQuestionPermission,
+} from '@shared/schemas';
+
+import type { ApprovalRequestHandler } from './ApprovalRequestHandler';
+import type { ProgressBackendUiConfig } from './ProgressBackend';
+import type { WebviewUpdater } from './WebviewUpdater';
+
+/**
+ * The seven pending-approval handlers a progress backend wires. Hosts build
+ * each handler with their own show/resolve transport (and `canSend` gate), then
+ * hand the set to {@link createProgressBackendUiConfig}, which derives the
+ * uniform UI callbacks and the pending-permissions guard from them.
+ */
+export interface ApprovalRequestHandlerSet {
+  toolEdit: ApprovalRequestHandler<ToolEditPermission, 'requestId'>;
+  bash: ApprovalRequestHandler<BashPermission, 'requestId'>;
+  retry: ApprovalRequestHandler<RetryPermission, 'streamId'>;
+  agentProposal: ApprovalRequestHandler<AgentProposalPermission, 'proposalId'>;
+  planApproval: ApprovalRequestHandler<PlanApprovalPermission, 'approvalId'>;
+  externalInquiry: ApprovalRequestHandler<
+    ExternalInquiryPermission,
+    'requestId'
+  >;
+  userQuestion: ApprovalRequestHandler<UserQuestionPermission, 'requestId'>;
+}
+
+export interface ProgressBackendUiConfigParams {
+  handlers: ApprovalRequestHandlerSet;
+  /** Transport for the bypass-state pushes (handlers own their own transport). */
+  webviewUpdater: WebviewUpdater;
+  /** Gate shared with the handlers; also guards the bypass-state pushes. */
+  canSend: () => boolean;
+  /**
+   * Retry is host-specific and so is supplied directly rather than derived from
+   * `handlers.retry`: the extension shows a retry panel (via that handler),
+   * while the desktop has no panel and instead cancels the retry. The retry
+   * handler still participates in the pending guard — it stays empty on hosts
+   * that never call `show` on it.
+   */
+  showRetryRequest: (payload: RetryPermission) => void;
+  resolveRetryRequest: (streamId: string) => void;
+}
+
+/**
+ * Build the host-neutral {@link ProgressBackendUiConfig} (UI callbacks plus the
+ * pending-permissions guard) from a set of {@link ApprovalRequestHandler}s.
+ *
+ * Every show/resolve callback (other than retry) delegates to its handler, so
+ * host differences live entirely in how each handler is constructed (its
+ * show/resolve transport and `canSend` gate) — not in this wiring. The guard
+ * ORs `hasPendingForStream` across all handlers, reusing the handler's
+ * empty-streamId-blocks-all rule instead of re-deriving it per host.
+ */
+export function createProgressBackendUiConfig(
+  params: ProgressBackendUiConfigParams,
+): ProgressBackendUiConfig {
+  const { handlers, webviewUpdater, canSend } = params;
+  return {
+    callbacks: {
+      showRetryRequest: params.showRetryRequest,
+      resolveRetryRequest: params.resolveRetryRequest,
+      showToolEditPermission: (p) => handlers.toolEdit.show(p),
+      resolveToolEditPermission: (id) => handlers.toolEdit.resolve(id),
+      updateToolEditApprovalBypassState: (streamId, bypassActive) => {
+        if (canSend()) {
+          webviewUpdater.updateBypassState(streamId, 'toolEdit', bypassActive);
+        }
+      },
+      updateSuperYoloBypassState: (streamId, bypassActive) => {
+        if (canSend()) {
+          webviewUpdater.updateBypassState(streamId, 'superYolo', bypassActive);
+        }
+      },
+      showBashPermission: (p) => handlers.bash.show(p),
+      resolveBashPermission: (id) => handlers.bash.resolve(id),
+      showAgentProposal: (p) => handlers.agentProposal.show(p),
+      resolveAgentProposal: (id) => handlers.agentProposal.resolve(id),
+      showPlanApproval: (p) => handlers.planApproval.show(p),
+      resolvePlanApproval: (id) => handlers.planApproval.resolve(id),
+      showExternalInquiry: (p) => handlers.externalInquiry.show(p),
+      resolveExternalInquiry: (id) => handlers.externalInquiry.resolve(id),
+      showUserQuestion: (p) => handlers.userQuestion.show(p),
+      resolveUserQuestion: (id) => handlers.userQuestion.resolve(id),
+    },
+    hasPendingPermissions: (streamId) =>
+      handlers.retry.hasPendingForStream(streamId) ||
+      handlers.toolEdit.hasPendingForStream(streamId) ||
+      handlers.bash.hasPendingForStream(streamId) ||
+      handlers.agentProposal.hasPendingForStream(streamId) ||
+      handlers.planApproval.hasPendingForStream(streamId) ||
+      handlers.externalInquiry.hasPendingForStream(streamId) ||
+      handlers.userQuestion.hasPendingForStream(streamId),
+  };
+}

--- a/src/shared/schemas/index.ts
+++ b/src/shared/schemas/index.ts
@@ -54,9 +54,10 @@ export * from './progressView';
 // Layer 6: Other view message schemas
 export * as commonViewMessages from './commonViewMessages';
 export { ThemeSchema, type Theme } from './commonViewMessages';
-export * from './memoryViewMessages';
-export * from './historyViewMessages';
-export * from './profileViewMessages';
+// Memory/History/Profile view-message schemas have a single public home in
+// settingsViewMessages (the canonical settings entry point), which re-exports
+// the symbols consumers need. They are not re-exported directly here, so each
+// family is published through exactly one barrel path.
 export * from './settingsViewMessages';
 
 // Layer 7: Composite schemas (depend on multiple layers)

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -35,6 +35,7 @@ export {
   MemoryPreviewSchema,
   type MemoryViewItem,
   type MemoryPreview,
+  type MemoryItemActionDetail,
   type MemoryPathMessage,
   type MemoryDeleteMessage,
   type MemoryEnabledMessage,

--- a/src/shared/utils/selectTemplates.ts
+++ b/src/shared/utils/selectTemplates.ts
@@ -59,7 +59,6 @@ function renderAgentOption(opt: AgentOptionData): TemplateResult {
 
 export function renderAgentOptions(
   options: AgentOptionData[],
-  _selectedValue: string,
   { includeBrowseAll = false }: { includeBrowseAll?: boolean } = {},
 ): TemplateResult {
   return html`
@@ -128,10 +127,7 @@ function renderModelOption(opt: ModelOptionData): TemplateResult {
   `;
 }
 
-export function renderModelOptions(
-  options: ModelOptionData[],
-  _selectedValue: string,
-): TemplateResult {
+export function renderModelOptions(options: ModelOptionData[]): TemplateResult {
   return html`
     ${repeat(
       options,

--- a/src/test-kernel/cli/CliInitPlatform.vitest.mts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.mts
@@ -52,6 +52,16 @@ vi.mock('@platform/platform', () => ({
   initPlatform: vi.fn(),
   tryPlatform: mocks.tryPlatform,
   tryGlobalState: () => mocks.tryPlatform()?.globalState,
+  platform: () => ({ config: { get: (_key: string, def: unknown) => def } }),
+}));
+
+// initCliPlatform delegates platform composition + the shared node-host agent
+// runtime (memory/goal injections, Lean, goal prompts) to nodeHost; stub it so
+// the test exercises only the CLI-specific wiring and feature registration does
+// not run twice across cases.
+vi.mock('@platform/defaults/nodeHost', () => ({
+  initNodePlatform: vi.fn(),
+  initNodeAgentRuntime: vi.fn(),
 }));
 
 vi.mock('@skills/index', () => ({

--- a/src/test-kernel/cli/CliInitPlatform.vitest.mts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.mts
@@ -11,7 +11,10 @@ const mocks = vi.hoisted(() => ({
     isAuthenticated: vi.fn(),
   },
   bootstrapPlatformAgentDirectories: vi.fn(),
+  createNodePlatform: vi.fn(() => ({})),
   initializeCliSupabaseAuth: vi.fn(),
+  initializeNodeGoalPrompts: vi.fn(),
+  initNodeAgentRuntime: vi.fn(),
   initializeServerSideKeyAccess: vi.fn(),
   serverSideKeyService: {
     setUseIncludedModelAccess: vi.fn(),
@@ -55,13 +58,13 @@ vi.mock('@platform/platform', () => ({
   platform: () => ({ config: { get: (_key: string, def: unknown) => def } }),
 }));
 
-// initCliPlatform delegates platform composition + the shared node-host agent
-// runtime (memory/goal injections, Lean, goal prompts) to nodeHost; stub it so
-// the test exercises only the CLI-specific wiring and feature registration does
-// not run twice across cases.
+// initCliPlatform delegates shared Node-host construction and runtime wiring to
+// nodeHost; stub it so the test exercises only the CLI-specific wiring and
+// feature registration does not run twice across cases.
 vi.mock('@platform/defaults/nodeHost', () => ({
-  initNodePlatform: vi.fn(),
-  initNodeAgentRuntime: vi.fn(),
+  createNodePlatform: mocks.createNodePlatform,
+  initNodeAgentRuntime: mocks.initNodeAgentRuntime,
+  initializeNodeGoalPrompts: mocks.initializeNodeGoalPrompts,
 }));
 
 vi.mock('@skills/index', () => ({
@@ -159,6 +162,8 @@ describe('CLI platform init', () => {
     );
 
     expect(mocks.getCliSecrets).toHaveBeenCalledWith('/tmp/texra-storage-root');
+    expect(mocks.createNodePlatform).toHaveBeenCalledOnce();
+    expect(mocks.initNodeAgentRuntime).toHaveBeenCalledOnce();
     expect(mocks.initializeCliSupabaseAuth).toHaveBeenCalledWith(
       expect.anything(),
       '/tmp/texra-storage-root',
@@ -210,6 +215,9 @@ describe('CLI platform init', () => {
       }),
     );
 
+    expect(mocks.initializeNodeGoalPrompts).toHaveBeenCalledWith(
+      '/tmp/resources-versioned',
+    );
     expect(mocks.bootstrapPlatformAgentDirectories).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: 'cli',

--- a/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
@@ -69,6 +69,9 @@ function createActions(
       handleUserQuestionAction: vi.fn(),
       handleAgentProposalAction: vi.fn(),
     },
+    externalInquiry: {
+      logWarn: vi.fn(),
+    },
     ...overrides,
   };
 }

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -1270,7 +1270,7 @@ describe('DesktopProgressBridge', () => {
     const runAgent = vi.fn(async (_request, options) => {
       await options.openWorkflowOutput({
         outcome: RUN_OUTCOME.COMPLETED,
-        outputs: [{ absolutePath: '/tmp/result.pdf' }],
+        outputs: [{ absolutePath: '/tmp/result.pdf', round: 0 }],
       });
     });
     const execution = await createExecution({

--- a/src/test-kernel/desktop/ElectronCompositionRoot.vitest.mts
+++ b/src/test-kernel/desktop/ElectronCompositionRoot.vitest.mts
@@ -75,12 +75,15 @@ describe('desktop composition root and launch environment', () => {
   }
 
   it('keeps platform initialization in the Electron composition root', async () => {
+    // The raw initPlatform() call lives in the shared node host composition
+    // (src/platform/defaults/nodeHost.ts); the desktop drives it from exactly
+    // one place via initNodePlatform().
     const files = await walkTypeScriptFiles(DESKTOP_SRC_DIR);
     const initPlatformFiles: string[] = [];
 
     for (const filePath of files) {
       const source = await readFile(filePath, 'utf8');
-      if (source.includes('initPlatform(')) {
+      if (source.includes('initNodePlatform(')) {
         initPlatformFiles.push(relative(REPO_ROOT, filePath));
       }
     }
@@ -98,9 +101,9 @@ describe('desktop composition root and launch environment', () => {
 
     expect(source.indexOf('repairLaunchPath();')).toBeGreaterThanOrEqual(0);
     expect(source.indexOf('repairLaunchPath();')).toBeLessThan(
-      source.indexOf('initPlatform({'),
+      source.indexOf('initNodePlatform({'),
     );
-    expect(source.indexOf('initPlatform({')).toBeLessThan(
+    expect(source.indexOf('initNodePlatform({')).toBeLessThan(
       source.indexOf('bootstrapElectronAgentDirectories('),
     );
   });

--- a/src/test-kernel/desktop/ElectronCompositionRoot.vitest.mts
+++ b/src/test-kernel/desktop/ElectronCompositionRoot.vitest.mts
@@ -75,15 +75,12 @@ describe('desktop composition root and launch environment', () => {
   }
 
   it('keeps platform initialization in the Electron composition root', async () => {
-    // The raw initPlatform() call lives in the shared node host composition
-    // (src/platform/defaults/nodeHost.ts); the desktop drives it from exactly
-    // one place via initNodePlatform().
     const files = await walkTypeScriptFiles(DESKTOP_SRC_DIR);
     const initPlatformFiles: string[] = [];
 
     for (const filePath of files) {
       const source = await readFile(filePath, 'utf8');
-      if (source.includes('initNodePlatform(')) {
+      if (source.includes('initPlatform(')) {
         initPlatformFiles.push(relative(REPO_ROOT, filePath));
       }
     }
@@ -101,9 +98,9 @@ describe('desktop composition root and launch environment', () => {
 
     expect(source.indexOf('repairLaunchPath();')).toBeGreaterThanOrEqual(0);
     expect(source.indexOf('repairLaunchPath();')).toBeLessThan(
-      source.indexOf('initNodePlatform({'),
+      source.indexOf('initPlatform('),
     );
-    expect(source.indexOf('initNodePlatform({')).toBeLessThan(
+    expect(source.indexOf('initPlatform(')).toBeLessThan(
       source.indexOf('bootstrapElectronAgentDirectories('),
     );
   });

--- a/src/test-kernel/progressView/ProgressViewProviderPending.vitest.mts
+++ b/src/test-kernel/progressView/ProgressViewProviderPending.vitest.mts
@@ -23,15 +23,20 @@ function readProgressViewProvider(): string {
 
 describe('ProgressViewProvider pending permissions', () => {
   it('keeps streams with pending user questions active', () => {
-    const source = readProgressViewProvider();
-    const methodStart = source.indexOf('hasPendingPermissionsForStream');
-    const methodEnd = source.indexOf('private canSendToWebview', methodStart);
+    // The pending-permission gate now lives in the shared backend UI config so
+    // every host computes it the same way.
+    const source = readFileSync(
+      resolve(
+        REPO_ROOT,
+        'src/shared/progressView/backend/progressBackendUiConfig.ts',
+      ),
+      'utf8',
+    );
+    const methodStart = source.indexOf('hasPendingPermissions');
     expect(methodStart).toBeGreaterThanOrEqual(0);
-    expect(methodEnd).toBeGreaterThan(methodStart);
-    const method = source.slice(methodStart, methodEnd);
 
-    expect(method).toContain(
-      'this.userQuestionHandler.hasPendingForStream(streamId)',
+    expect(source).toContain(
+      'handlers.userQuestion.hasPendingForStream(streamId)',
     );
   });
 

--- a/src/test-kernel/support/FakeHosts.ts
+++ b/src/test-kernel/support/FakeHosts.ts
@@ -13,7 +13,6 @@ import type {
   TerminalHandle,
   TerminalHost,
   TerminalOptions,
-  UIHosts,
 } from '@hosts/uiHosts';
 
 export type PromptEventKind = 'info' | 'warning' | 'error';
@@ -282,6 +281,19 @@ export class FakeTerminalHandle implements TerminalHandle {
   createLookupHandle(): FakeTerminalHandle {
     return new FakeTerminalHandle(this.options, this.state);
   }
+}
+
+/**
+ * The five UI ports a host wires together. Production hosts (VS Code,
+ * desktop) inject each port individually; this aggregate exists only so
+ * test support can assemble and pass them as a single bundle.
+ */
+export interface UIHosts {
+  readonly prompt: PromptHost;
+  readonly externalOpener: ExternalOpener;
+  readonly diff: DiffViewHost;
+  readonly terminal: TerminalHost;
+  readonly clipboard: ClipboardHost;
 }
 
 export interface FakeUIHosts extends UIHosts {

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -22,6 +22,7 @@ import {
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { flowKey } from '@agent/node/persistedFlow';
 import { tryUseRunContext } from '@agent/runtime/RunContext';
+import { detachSubagentsOnStop } from '@agent/runtime/detachSubagentsOnStop';
 import {
   AgentExecutionHandle,
   ProcessExecutionHandle,
@@ -665,10 +666,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
     }
 
     const success = currentSession().executions.kill(executionId, {
-      detachActiveChildren: platform().workspaceState.get<boolean>(
-        WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP,
-        false,
-      ),
+      detachActiveChildren: detachSubagentsOnStop(),
     });
     if (success) {
       return { output: `Execution ${executionId} terminated.` };

--- a/src/tools/setup/index.ts
+++ b/src/tools/setup/index.ts
@@ -30,14 +30,4 @@ export { InstallVscodeExtensionTool } from './InstallVscodeExtensionTool';
 export { ReadConfigTool, UpdateConfigTool } from './ConfigTools';
 export { SendToTerminalTool } from './SendToTerminalTool';
 export { ApplyTeamTool } from './ApplyTeamTool';
-export {
-  setSetupPlatform,
-  type SetupPlatform,
-  type SetupSecretsAdapter,
-  type SetupCommandAdapter,
-  type SetupExtensionAdapter,
-  type SetupAuthAdapter,
-  type SetupConfigAdapter,
-  type SetupTerminalAdapter,
-  type TerminalRunResult,
-} from './platform';
+export { setSetupPlatform } from './platform';

--- a/src/tools/support/externalBinaryUtils.ts
+++ b/src/tools/support/externalBinaryUtils.ts
@@ -25,7 +25,7 @@ type ElectronProcess = NodeJS.Process & {
  * (`defaultApp === true`) and in non-Electron runtimes (VS Code extension
  * host, plain Node.js).
  */
-export function getPackagedElectronResourcesPath(): string | undefined {
+function getPackagedElectronResourcesPath(): string | undefined {
   const electronProcess = process as ElectronProcess;
   if (electronProcess.versions.electron == null) return undefined;
   if (electronProcess.defaultApp === true) return undefined;

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -24,11 +24,6 @@ export {
   assertNever,
 } from './typeGuards';
 export { debounce, delay } from './async';
-export {
-  byName,
-  byString,
-  byStringProp,
-  toNewestFirstByTimestamp,
-} from './comparators';
+export { byName, byString, toNewestFirstByTimestamp } from './comparators';
 export { clamp, clampIndex, clampOptional, roundTo } from './math';
 export { tryParseUrl } from './urlCore';

--- a/src/utils/text/sanitizeTag.ts
+++ b/src/utils/text/sanitizeTag.ts
@@ -16,7 +16,7 @@ import escapeRegExp from 'escape-string-regexp';
 
 const VALID_TAG_NAME = /^[a-z][a-z0-9-]*$/i;
 
-export function sanitizeTag(tagName: string, body: string): string {
+function sanitizeTag(tagName: string, body: string): string {
   if (!VALID_TAG_NAME.test(tagName)) {
     throw new Error(`Invalid tag name for sanitizer: ${tagName}`);
   }


### PR DESCRIPTION
## Summary

Macroscopic round 2 of the post-0.38.9 refactor: consolidate **cross-host duplication** and prune dead surface, from a deep architecture audit. The VS Code extension, Electron desktop, and CLI were each reimplementing the same runtime/UI flows; this lifts shared logic into host-neutral helpers so the hosts become thinner adapters. Net ~250 lines removed.

## Cross-host coupling consolidated

- **Tool-use resume queue dance** -> new `src/agent/runtime/resumeQueuedToolUse.ts` owns acquire -> RESUMING -> drain+emit -> resume-with-append -> catch re-enqueue(force) -> finally WAITING. Extension and desktop keep only their own log/toast surfaces. The error callback is guarded so a broken host notification cannot turn a handled resume failure into an unhandled rejection.
- **ApprovalRequestHandler** relocated to `src/shared/progressView/backend` + new `createProgressBackendUiConfig` so both hosts build the permission UI callbacks one way; desktop drops its hand-rolled pending-permission Maps.
- **`detachSubagentsOnStop()`** was copy-pasted across five host sites; now one helper.
- **`selectAutoOpenFinalOutput()`** makes desktop match the extension's completed-output selection policy: highest `round`, not array tail.
- **EXTERNAL_INQUIRY** handling moved into the shared progress-view command factory.
- **Node-host platform composition** is split cleanly: `src/platform/defaults/nodeHost.ts` builds the shared Node platform shape and one-shot runtime registrations, while the CLI and desktop composition roots still own the actual `initPlatform(...)` call. This also fixes real drift: the CLI now calls `registerAgentFeatures`, so memory/goal tools are injected there too. Goal prompt paths remain refreshable per active resources bundle.

## Logic consolidations & dead code

`buildProviderKeyStatuses` lifted (desktop IPC + extension controller deduped); ~40 dead barrel re-exports pruned; pass-throughs/stubs removed (`registerLatex/ApiKeyCommands` no-op chain, `_selectedValue`, Google SDK usage type, `SupabaseSession` shim, `FlowParams`/`CycleParams` alias).

## Deferred / out of scope

The full `AgentResumePort` orchestrator unification, the CLI↔webview progress-reducer dedup, and the two parallel run state machines are tracked in #6826 / #6827 / #6828. The `SetupPlatform` composition-root dedup and larger folder moves are deferred to separate PRs.

## Verification

- `npm run lint -- --quiet`
- `npm run typecheck`
- `npm run format`
- `corepack pnpm exec vitest run src/test-kernel/cli/CliInitPlatform.vitest.mts src/test-kernel/desktop/ElectronCompositionRoot.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- Earlier branch verification: full workspace typecheck and `pnpm run test` passed before the final CI/review fix.
