### PR TITLE
refactor(config): derive provider endpoints from registry

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -948,7 +948,7 @@ const SCENARIOS = [
       'Claude Code permission',
       'Claude Code reasoning',
       'Auto-compile outputs',
-      '... 4 more',
+      '... 13 more',
       '↑/↓ navigate',
       'Enter toggle / edit',
       'Esc close',

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -16,7 +16,33 @@ interface ProviderDef {
   readonly hasServerKey: boolean;
   /** URL for obtaining API keys. undefined = no standalone key page. */
   readonly keyUrl?: string;
+  /** Global-state key for this provider's streaming toggle. */
+  readonly streamingKey?: GlobalStateKey;
+  /** Global-state key for this provider's custom endpoint. */
+  readonly endpointKey?: GlobalStateKey;
+  /** Optional alternate-region metadata for endpoint/key-url derivation. */
+  readonly region?: ProviderRegionSetting;
 }
+
+export interface ProviderRegionSetting {
+  readonly key: GlobalStateKey;
+  readonly default: boolean;
+  readonly displayName?: string;
+  readonly keyUrlWhenSet?: string;
+  readonly keyUrlWhenUnset?: string;
+}
+
+export interface ProviderStateEntry {
+  readonly id: string;
+  readonly displayName: string;
+  readonly streamingKey?: GlobalStateKey;
+  readonly endpointKey?: GlobalStateKey;
+  readonly region?: ProviderRegionSetting;
+}
+
+export type ProviderEndpointStateEntry = ProviderStateEntry & {
+  readonly endpointKey: GlobalStateKey;
+};
 
 /**
  * Canonical provider registry. All provider lists are derived from this.
@@ -31,54 +57,90 @@ const PROVIDER_REGISTRY = [
     displayName: 'OpenAI',
     hasServerKey: true,
     keyUrl: 'https://platform.openai.com/api-keys',
+    streamingKey: GlobalStateKey.STREAMING_OPENAI,
+    endpointKey: GlobalStateKey.ENDPOINT_OPENAI,
   },
   {
     id: ModelProvider.ANTHROPIC,
     displayName: 'Anthropic',
     hasServerKey: true,
     keyUrl: 'https://console.anthropic.com/',
+    streamingKey: GlobalStateKey.STREAMING_ANTHROPIC,
+    endpointKey: GlobalStateKey.ENDPOINT_ANTHROPIC,
   },
   {
     id: ModelProvider.GOOGLE,
     displayName: 'Google',
     hasServerKey: true,
     keyUrl: 'https://aistudio.google.com/app/apikey',
+    streamingKey: GlobalStateKey.STREAMING_GOOGLE,
+    endpointKey: GlobalStateKey.ENDPOINT_GOOGLE,
   },
   {
     id: ModelProvider.XAI,
     displayName: 'xAI',
     hasServerKey: true,
     keyUrl: 'https://console.x.ai/',
+    streamingKey: GlobalStateKey.STREAMING_XAI,
+    endpointKey: GlobalStateKey.ENDPOINT_XAI,
   },
   {
     id: ModelProvider.DEEPSEEK,
     displayName: 'DeepSeek',
     hasServerKey: true,
     keyUrl: 'https://platform.deepseek.com/api_keys',
+    streamingKey: GlobalStateKey.STREAMING_DEEPSEEK,
+    endpointKey: GlobalStateKey.ENDPOINT_DEEPSEEK,
   },
   {
     id: ModelProvider.MOONSHOT,
     displayName: 'Moonshot',
     hasServerKey: true,
     keyUrl: 'https://platform.moonshot.cn/console',
+    streamingKey: GlobalStateKey.STREAMING_MOONSHOT,
+    endpointKey: GlobalStateKey.ENDPOINT_MOONSHOT,
   },
   {
     id: ModelProvider.DASHSCOPE,
     displayName: 'Qwen',
     hasServerKey: true,
     keyUrl: 'https://dashscope.aliyun.com/api-console/',
+    streamingKey: GlobalStateKey.STREAMING_DASHSCOPE,
+    endpointKey: GlobalStateKey.ENDPOINT_DASHSCOPE,
+    region: {
+      key: GlobalStateKey.DASHSCOPE_USE_CHINA,
+      default: false,
+      displayName: 'Bailian',
+      keyUrlWhenSet: 'https://bailian.console.aliyun.com/',
+    },
   },
   {
     id: ModelProvider.MINIMAX,
     displayName: 'MiniMax',
     hasServerKey: true,
     keyUrl: 'https://platform.minimax.io/',
+    streamingKey: GlobalStateKey.STREAMING_MINIMAX,
+    endpointKey: GlobalStateKey.ENDPOINT_MINIMAX,
+    region: {
+      key: GlobalStateKey.MINIMAX_USE_CHINA,
+      default: false,
+      keyUrlWhenSet: 'https://platform.minimaxi.com/',
+    },
   },
   {
     id: ModelProvider.GLM,
     displayName: 'GLM',
     hasServerKey: true,
     keyUrl: 'https://open.bigmodel.cn/',
+    streamingKey: GlobalStateKey.STREAMING_GLM,
+    endpointKey: GlobalStateKey.ENDPOINT_GLM,
+    // China=true is the default since bigmodel.cn is the primary platform;
+    // when toggled off (international), the key URL is z.ai.
+    region: {
+      key: GlobalStateKey.GLM_USE_CHINA,
+      default: true,
+      keyUrlWhenUnset: 'https://z.ai/',
+    },
   },
 ] as const satisfies readonly ProviderDef[];
 
@@ -128,6 +190,30 @@ export const PROVIDER_URLS: Record<string, string> = {
   ),
   openRouter: 'https://openrouter.ai/keys',
 };
+
+export const PROVIDER_STATE_ENTRIES: readonly ProviderStateEntry[] = [
+  ...PROVIDER_REGISTRY.map((provider) => ({
+    id: provider.id,
+    displayName: provider.displayName,
+    streamingKey: provider.streamingKey,
+    endpointKey: provider.endpointKey,
+    region: 'region' in provider ? provider.region : undefined,
+  })),
+  {
+    id: 'openrouter',
+    displayName: 'OpenRouter',
+    streamingKey: GlobalStateKey.STREAMING_OPENROUTER,
+  },
+];
+
+function hasEndpoint(
+  entry: ProviderStateEntry,
+): entry is ProviderEndpointStateEntry {
+  return entry.endpointKey !== undefined;
+}
+
+export const PROVIDER_ENDPOINT_STATE_ENTRIES: readonly ProviderEndpointStateEntry[] =
+  PROVIDER_STATE_ENTRIES.filter(hasEndpoint);
 
 /**
  * Default model used for auxiliary/helper tasks (polishing, agent creation,

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -14,7 +14,10 @@ import {
   LATEX_FORMATTER_VALUES,
   LATEXDIFF_MATH_MARKUP_VALUES,
 } from '@shared/constants/latex';
-import { USE_OPENROUTER_PROVIDER_SETTING } from '@shared/constants/providers';
+import {
+  PROVIDER_ENDPOINT_STATE_ENTRIES,
+  USE_OPENROUTER_PROVIDER_SETTING,
+} from '@shared/constants/providers';
 import {
   CLAUDE_AGENT_DEFAULT_EFFORT,
   CLAUDE_AGENT_DEFAULT_MODEL,
@@ -166,6 +169,12 @@ const OPENROUTER_ROUTING_RUNTIME_REACHABILITY = {
   through:
     'packages/cli/src/commands/agentsRun.ts -> packages/cli/src/runtime/runExecution.ts -> src/agent/runtime/ModelFactory.ts -> src/utils/config/providerConfig.ts',
 } satisfies CliRuntimeReachability;
+const PROVIDER_ENDPOINT_RUNTIME_REACHABILITY = {
+  command:
+    'texra agents run <tool-use-agent> --model <provider-model> --instruction "answer a short question"',
+  through:
+    'packages/cli/src/commands/agentsRun.ts -> packages/cli/src/runtime/runExecution.ts -> src/agent/runtime/ModelFactory.ts -> src/agent/modelHandlers/support/ProxyConfigResolver.ts',
+} satisfies CliRuntimeReachability;
 const CODEX_AGENT_RUNTIME_REACHABILITY = {
   command:
     'texra agents run <tool-use-agent> --instruction "launch a Codex subagent"',
@@ -178,6 +187,24 @@ const CLAUDE_AGENT_RUNTIME_REACHABILITY = {
   through:
     'packages/cli/src/commands/agentsRun.ts -> packages/cli/src/runtime/runExecution.ts -> src/tools/claudeAgent.ts -> src/tools/claudeAgentConfig.ts',
 } satisfies CliRuntimeReachability;
+
+const PROVIDER_ENDPOINT_CONSUMER =
+  'src/agent/modelHandlers/support/ProxyConfigResolver.ts';
+
+const PROVIDER_ENDPOINT_SETTINGS = PROVIDER_ENDPOINT_STATE_ENTRIES.map(
+  ({ endpointKey, displayName }) =>
+    ({
+      key: endpointKey,
+      schema: z.string().prefault(''),
+      title: `${displayName} endpoint`,
+      description: `Custom base URL for ${displayName} API requests. Leave empty to use the default endpoint.`,
+      category: 'model',
+      store: 'globalState',
+      hosts: ['cli'],
+      cliConsumer: PROVIDER_ENDPOINT_CONSUMER,
+      cliRuntimeReachability: PROVIDER_ENDPOINT_RUNTIME_REACHABILITY,
+    }) satisfies StateSettingEntry,
+);
 
 export const STATE_SETTINGS: readonly StateSettingEntry[] = [
   // --- Git commit author marking ---------------------------------------------
@@ -473,6 +500,13 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     cliConsumer: 'src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts',
     cliRuntimeReachability: OPENAI_WEBSOCKET_RUNTIME_REACHABILITY,
   },
+
+  // --- Provider endpoints ---------------------------------------------------
+  // The extension/desktop Models tab already has per-provider endpoint inputs.
+  // The CLI consumes the same global-state keys in `ProxyConfigResolver`, so
+  // these rows expose that existing runtime behavior through `/config` without
+  // adding another imperative settings list.
+  ...PROVIDER_ENDPOINT_SETTINGS,
 
   // --- OpenRouter routing ----------------------------------------------------
   // Read by `getUseOpenRouter()` during model-handler routing. The extension

--- a/src/test-kernel/shared/stateSettings.vitest.ts
+++ b/src/test-kernel/shared/stateSettings.vitest.ts
@@ -25,6 +25,7 @@ import {
   API_ACCESS_MODE_OPTIONS,
   REASONING_LEVEL_OPTIONS,
 } from '@shared/schemas/settingsViewMessages';
+import { PROVIDER_ENDPOINT_STATE_ENTRIES } from '@shared/constants/providers';
 import {
   readSetting,
   resetSetting,
@@ -67,6 +68,9 @@ function reachabilitySegments(through: string): string[] {
 }
 
 const CLASS_D_KEY_PATTERN = /migrated|version|onboarding|history|cache/i;
+const PROVIDER_ENDPOINT_DEFAULTS = Object.fromEntries(
+  PROVIDER_ENDPOINT_STATE_ENTRIES.map(({ endpointKey }) => [endpointKey, '']),
+);
 
 /** Expected default-when-absent for each catalog key, from the real getters. */
 const EXPECTED_DEFAULTS: Record<string, unknown> = {
@@ -99,6 +103,7 @@ const EXPECTED_DEFAULTS: Record<string, unknown> = {
     LATEX_CONFIG_DEFAULTS.latexdiffChangesOnly,
   [WorkspaceStateKey.LATEX_FORMATTER]: LATEX_CONFIG_DEFAULTS.latexFormatter,
   [GlobalStateKey.WEBSOCKET_OPENAI]: false,
+  ...PROVIDER_ENDPOINT_DEFAULTS,
   [GlobalStateKey.USE_OPENROUTER]: false,
 };
 
@@ -349,6 +354,8 @@ describe('state settings catalog', () => {
     //    (the reflection flow, via OutputNode/runCompileCheck).
     //  - the OpenAI WebSocket toggle is read by the Responses handler the CLI
     //    runs (and lets the Codex backend attempt WebSocket).
+    //  - provider endpoints are read by the proxy resolver used by CLI model
+    //    handlers before falling back to provider defaults.
     // auto-open-pdf (no CLI opener), latexdiff, and the formatter are
     // intentionally excluded. Changing the CLI roster must be a deliberate edit
     // here, not an accident of flipping `hosts`.
@@ -368,6 +375,9 @@ describe('state settings catalog', () => {
         WorkspaceStateKey.WORKFLOW_AUTO_COMPILE,
         WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS,
         WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE,
+        ...PROVIDER_ENDPOINT_STATE_ENTRIES.map(
+          ({ endpointKey }) => endpointKey,
+        ),
         GlobalStateKey.WEBSOCKET_OPENAI,
         GlobalStateKey.USE_OPENROUTER,
       ].sort(),
@@ -462,6 +472,18 @@ describe('settingsAccess', () => {
       effectiveValue: false,
     });
     assert.equal(readSetting(entry, stores, 'cli'), false);
+  });
+
+  it('routes CLI endpoint writes to global state', async () => {
+    const { stores, config, globalState } = makeFakeSettingsStores();
+    const entry = entryByKey(GlobalStateKey.ENDPOINT_GOOGLE);
+    await writeSetting(entry, 'https://example.invalid/v1', stores, 'cli');
+    assert.equal(isStored(globalState, entry.key), true);
+    assert.equal(isStored(config, entry.key), false);
+    assert.equal(
+      readSetting(entry, stores, 'cli'),
+      'https://example.invalid/v1',
+    );
   });
 
   it('rejects values that fail the entry schema', async () => {

--- a/src/utils/config/providerConfig.ts
+++ b/src/utils/config/providerConfig.ts
@@ -1,98 +1,28 @@
 /**
  * Provider-specific streaming, endpoint, and region configuration.
  *
- * Each entry in PROVIDERS bundles a provider's globalSM keys and any
- * region-toggle metadata that drives display name / key URL overrides.
- * Static provider constants (default URLs, descriptions, etc.) live in
- * @shared/constants/providers.
+ * The shared provider registry owns provider state keys and region metadata.
+ * This module only reads/writes those keys through the active platform state.
  */
 
 import { tryGlobalState } from '@platform/platform';
+import {
+  PROVIDER_STATE_ENTRIES,
+  type ProviderStateEntry,
+} from '@shared/constants/providers';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { getConfig } from '@utils/config';
 import { readPlatformSetting } from './platformSettings';
 
-/**
- * When `key` is set in globalSM (treated as boolean), the provider is in its
- * alternate region. `displayName` overrides the default name; `keyUrlWhenSet`
- * and `keyUrlWhenUnset` override the default key URL passed to
- * `getProviderKeyUrl`. Each is optional — only the dimensions that actually
- * differ across regions are populated.
- */
-type RegionOverride = {
-  key: GlobalStateKey;
-  default: boolean;
-  displayName?: string;
-  keyUrlWhenSet?: string;
-  keyUrlWhenUnset?: string;
-};
+const PROVIDERS: ReadonlyMap<string, ProviderStateEntry> = new Map(
+  PROVIDER_STATE_ENTRIES.map((provider) => [
+    provider.id.toLowerCase(),
+    provider,
+  ]),
+);
 
-type ProviderEntry = {
-  streaming?: GlobalStateKey;
-  endpoint?: GlobalStateKey;
-  region?: RegionOverride;
-};
-
-const PROVIDERS: Record<string, ProviderEntry> = {
-  openai: {
-    streaming: GlobalStateKey.STREAMING_OPENAI,
-    endpoint: GlobalStateKey.ENDPOINT_OPENAI,
-  },
-  anthropic: {
-    streaming: GlobalStateKey.STREAMING_ANTHROPIC,
-    endpoint: GlobalStateKey.ENDPOINT_ANTHROPIC,
-  },
-  openrouter: { streaming: GlobalStateKey.STREAMING_OPENROUTER },
-  google: {
-    streaming: GlobalStateKey.STREAMING_GOOGLE,
-    endpoint: GlobalStateKey.ENDPOINT_GOOGLE,
-  },
-  xai: {
-    streaming: GlobalStateKey.STREAMING_XAI,
-    endpoint: GlobalStateKey.ENDPOINT_XAI,
-  },
-  deepseek: {
-    streaming: GlobalStateKey.STREAMING_DEEPSEEK,
-    endpoint: GlobalStateKey.ENDPOINT_DEEPSEEK,
-  },
-  moonshot: {
-    streaming: GlobalStateKey.STREAMING_MOONSHOT,
-    endpoint: GlobalStateKey.ENDPOINT_MOONSHOT,
-  },
-  dashscope: {
-    streaming: GlobalStateKey.STREAMING_DASHSCOPE,
-    endpoint: GlobalStateKey.ENDPOINT_DASHSCOPE,
-    region: {
-      key: GlobalStateKey.DASHSCOPE_USE_CHINA,
-      default: false,
-      displayName: 'Bailian',
-      keyUrlWhenSet: 'https://bailian.console.aliyun.com/',
-    },
-  },
-  minimax: {
-    streaming: GlobalStateKey.STREAMING_MINIMAX,
-    endpoint: GlobalStateKey.ENDPOINT_MINIMAX,
-    region: {
-      key: GlobalStateKey.MINIMAX_USE_CHINA,
-      default: false,
-      keyUrlWhenSet: 'https://platform.minimaxi.com/',
-    },
-  },
-  glm: {
-    streaming: GlobalStateKey.STREAMING_GLM,
-    endpoint: GlobalStateKey.ENDPOINT_GLM,
-    // China=true is the default since bigmodel.cn is the primary platform;
-    // when toggled off (international), the key URL is z.ai.
-    region: {
-      key: GlobalStateKey.GLM_USE_CHINA,
-      default: true,
-      keyUrlWhenUnset: 'https://z.ai/',
-    },
-  },
-};
-
-function entry(provider: string): ProviderEntry | undefined {
-  return PROVIDERS[provider.toLowerCase()];
+function entry(provider: string): ProviderStateEntry | undefined {
+  return PROVIDERS.get(provider.toLowerCase());
 }
 
 function read<T>(key: GlobalStateKey, defaultValue: T): T {
@@ -118,7 +48,7 @@ export async function setGlobalStreaming(enabled: boolean): Promise<void> {
 
 export function getProviderStreaming(provider: string): boolean {
   const fallback = getGlobalStreaming();
-  const key = entry(provider)?.streaming;
+  const key = entry(provider)?.streamingKey;
   return key ? read(key, fallback) : fallback;
 }
 
@@ -126,7 +56,7 @@ export async function setProviderStreaming(
   provider: string,
   enabled: boolean,
 ): Promise<void> {
-  const key = entry(provider)?.streaming;
+  const key = entry(provider)?.streamingKey;
   if (key) await tryGlobalState()?.update(key, enabled);
 }
 
@@ -135,7 +65,7 @@ export async function setProviderStreaming(
 // ---------------------------------------------------------------------------
 
 export function getProviderEndpoint(provider: string): string {
-  const key = entry(provider)?.endpoint;
+  const key = entry(provider)?.endpointKey;
   return key ? read(key, '') : '';
 }
 
@@ -143,12 +73,12 @@ export async function setProviderEndpoint(
   provider: string,
   endpoint: string,
 ): Promise<void> {
-  const key = entry(provider)?.endpoint;
+  const key = entry(provider)?.endpointKey;
   if (key) await tryGlobalState()?.update(key, endpoint);
 }
 
 export function supportsCustomEndpoint(provider: string): boolean {
-  return entry(provider)?.endpoint !== undefined;
+  return entry(provider)?.endpointKey !== undefined;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Part of #6606.

This PR promotes provider endpoint settings into the state-backed settings catalog used by the CLI `/config` panel, while keeping provider ownership declarative:

- moves provider streaming keys, endpoint keys, and region metadata into the shared provider registry
- derives `providerConfig` runtime lookup from that registry instead of maintaining a parallel provider map
- derives CLI endpoint catalog rows from the same registry, so `/config` exposes the endpoint settings already consumed by model handlers
- updates the deterministic TUI frame expectation for the larger `/config` list

The runtime behavior is intended to be unchanged except that provider endpoint rows are now editable from the CLI `/config` surface. Endpoint values still live in global state and are read by `ProxyConfigResolver` before falling back to provider defaults.

## Verification

- `corepack pnpm vitest run src/test-kernel/shared/stateSettings.vitest.ts src/test-kernel/cli/ConfigForm.vitest.mts src/test-kernel/controllers/SettingsProfileController.vitest.ts src/test-kernel/settings/ProviderKeyRows.vitest.mts src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts` — 85 tests passed
- `corepack pnpm run typecheck`
- `corepack pnpm run lint` — passed with existing warnings only
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-frames-endpoint-config-fixed` — 141 scenarios passed, including `/config`
- `git diff --check`
