### PR TITLE
refactor: reduce low-risk schema, UI, and test boilerplate

### DIFF
--- a/packages/cli/src/orchestration/runOrchestrationTui.tsx
+++ b/packages/cli/src/orchestration/runOrchestrationTui.tsx
@@ -105,6 +105,10 @@ const ORCHESTRATION_SELECT_MARGIN_ROWS = 1;
 const ORCHESTRATION_KEY_HINT_ROWS = 2;
 const ORCHESTRATION_TARGET_VISIBLE_ITEMS = 4;
 
+// Shared between the wrapped-row layout measurement (`headerLines`) and the
+// rendered launcher header so the measured and displayed subtitle can't drift.
+const ORCHESTRATION_LAUNCHER_SUBTITLE = 'Choose how to start this CLI session.';
+
 function orchestrationLinesRowCost(
   lines: readonly string[],
   columns: number,
@@ -220,7 +224,7 @@ export function OrchestrationApp(
         `${modelStepTitle} · ${formatCliApiMode(props.apiMode)}`,
         modelStepSubtitle,
       ]
-    : [`TeXRA v${props.version}`, 'Choose how to start this CLI session.'];
+    : [`TeXRA v${props.version}`, ORCHESTRATION_LAUNCHER_SUBTITLE];
   const layout = orchestrationLauncherLayout({
     rows,
     columns,
@@ -286,7 +290,7 @@ export function OrchestrationApp(
         </Text>
         <Text dimColor>v{props.version}</Text>
       </Box>
-      <Text dimColor>Choose how to start this CLI session.</Text>
+      <Text dimColor>{ORCHESTRATION_LAUNCHER_SUBTITLE}</Text>
       {layout.statusLines.length > 0 ? (
         <Box marginTop={1} flexDirection="column">
           {layout.statusLines.map((line, index) => (

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -154,19 +154,12 @@ function startSentence(text: string): string {
 function cliModelRecoveryActions(
   options: CliNoAvailableModelsRecoveryOptions = {},
 ): Required<CliNoAvailableModelsRecoveryOptions> {
-  return {
-    includedModeAction:
-      options.includedModeAction ??
-      DEFAULT_CLI_MODEL_RECOVERY_ACTIONS.includedModeAction,
-    loginAction:
-      options.loginAction ?? DEFAULT_CLI_MODEL_RECOVERY_ACTIONS.loginAction,
-    personalModeAction:
-      options.personalModeAction ??
-      DEFAULT_CLI_MODEL_RECOVERY_ACTIONS.personalModeAction,
-    configureKeyAction:
-      options.configureKeyAction ??
-      DEFAULT_CLI_MODEL_RECOVERY_ACTIONS.configureKeyAction,
-  };
+  // Drop null/undefined overrides so each missing field keeps its default,
+  // matching the per-field `?? DEFAULT` fallback this replaced.
+  const overrides = Object.fromEntries(
+    Object.entries(options).filter(([, value]) => value != null),
+  ) as Partial<CliNoAvailableModelsRecoveryOptions>;
+  return { ...DEFAULT_CLI_MODEL_RECOVERY_ACTIONS, ...overrides };
 }
 
 function isCliModelOptionBasicallyAvailable(model: ModelOptionData): boolean {
@@ -459,7 +452,7 @@ function formatCliModelRecovery(
     loginAction,
     personalModeAction,
     configureKeyAction,
-  } = cliModelRecoveryActions();
+  } = DEFAULT_CLI_MODEL_RECOVERY_ACTIONS;
 
   const availability = entry.model.availability;
 
@@ -533,16 +526,23 @@ function withModelAccess(
   return [...models, entry];
 }
 
+async function loadCliModelAccessList(
+  options: CliModelAccessEntryOptions,
+): Promise<readonly CliModelAccess[]> {
+  return (
+    options.accessList ??
+    getCliModelAccessList({
+      apiMode: options.apiMode,
+      agentCategory: options.agentCategory,
+    })
+  );
+}
+
 export async function resolveCliModelAccessEntry(
   model: string,
   options: CliModelAccessEntryOptions = {},
 ): Promise<CliModelAccess | undefined> {
-  const models =
-    options.accessList ??
-    (await getCliModelAccessList({
-      apiMode: options.apiMode,
-      agentCategory: options.agentCategory,
-    }));
+  const models = await loadCliModelAccessList(options);
   const trimmed = model.trim();
   const listedEntry = findCliModelAccessEntry(models, trimmed);
   if (listedEntry || trimmed.length === 0) return listedEntry;
@@ -566,12 +566,14 @@ export async function resolveCliModelAccessEntry(
   return hiddenModel;
 }
 
+type CliAvailableModelsMessageOptions = Pick<
+  CliRunnableModelOptions,
+  'apiMode' | 'noAvailableModelsMessage'
+>;
+
 function formatAvailableModels(
   ids: readonly string[],
-  options: Pick<
-    CliRunnableModelOptions,
-    'apiMode' | 'noAvailableModelsMessage'
-  >,
+  options: CliAvailableModelsMessageOptions,
 ): string {
   if (ids.length > 0) return `Available models: ${ids.join(', ')}.`;
   const recoveryMessage =
@@ -584,10 +586,7 @@ function formatUnavailableModelMessage(
   model: string,
   entry: CliModelAccess | undefined,
   availableIds: readonly string[],
-  options: Pick<
-    CliRunnableModelOptions,
-    'apiMode' | 'noAvailableModelsMessage'
-  >,
+  options: CliAvailableModelsMessageOptions,
 ): string {
   const status = entry ? ` (${entry.status})` : '';
   return `Model "${model}" is not available in the active API mode${status}. ${formatAvailableModels(availableIds, options)}`;
@@ -632,12 +631,7 @@ export async function resolveCliRunnableModel(
   model: string,
   options: CliRunnableModelOptions,
 ): Promise<CliRunnableModelResolution> {
-  const models =
-    options.accessList ??
-    (await getCliModelAccessList({
-      apiMode: options.apiMode,
-      agentCategory: options.agentCategory,
-    }));
+  const models = await loadCliModelAccessList(options);
   const trimmed = model.trim();
   const modelEntry = await resolveCliModelAccessEntry(trimmed, {
     apiMode: options.apiMode,

--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -116,18 +116,17 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
         }
         return true;
       case 'updateActiveProcesses':
-        if (this.rootStreamTerminal) return true;
-        this.applyActiveProcesses(
-          payload as ProgressEventPayloads['updateActiveProcesses'],
-        );
-        this.updateHeartbeat();
-        this.render(true);
-        return true;
       case 'updateActiveSubagents':
         if (this.rootStreamTerminal) return true;
-        this.applyActiveSubagents(
-          payload as ProgressEventPayloads['updateActiveSubagents'],
-        );
+        if (event === 'updateActiveProcesses') {
+          this.applyActiveProcesses(
+            payload as ProgressEventPayloads['updateActiveProcesses'],
+          );
+        } else {
+          this.applyActiveSubagents(
+            payload as ProgressEventPayloads['updateActiveSubagents'],
+          );
+        }
         this.updateHeartbeat();
         this.render(true);
         return true;
@@ -292,7 +291,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     parts.push(subject || phase || 'running');
     if (subject && phase && phase !== 'running') parts.push(phase);
     if (this.state.round == null && isMultiRound(this.state.plannedRounds)) {
-      parts.push(formatPlannedRounds(this.state.plannedRounds));
+      parts.push(`${this.state.plannedRounds} rounds`);
     }
 
     if (this.state.activeSubagents) parts.push(this.state.activeSubagents);
@@ -354,10 +353,6 @@ function formatRoundProgress(
     return `[r${round}/${plannedRounds}]`;
   }
   return `[r${round}]`;
-}
-
-function formatPlannedRounds(rounds: number): string {
-  return `${rounds} rounds`;
 }
 
 function isMultiRound(rounds: number | undefined): rounds is number {

--- a/packages/cli/src/runtime/workflowOutput.ts
+++ b/packages/cli/src/runtime/workflowOutput.ts
@@ -94,10 +94,14 @@ export interface WorkflowOutputResolutionOptions {
   readonly terminalStatus: ExecutionStatus;
 }
 
+function toPosix(p: string): string {
+  return p.replaceAll('\\', '/');
+}
+
 function outputCopyRelativePath(output: OutputFileSummary): string {
   const relativePath =
     output.relativePath || path.basename(output.absolutePath);
-  const parts = relativePath.replaceAll('\\', '/').split('/');
+  const parts = toPosix(relativePath).split('/');
   const withoutRoundDir = /^r\d+$/.test(parts[0] ?? '')
     ? parts.slice(1)
     : parts;
@@ -114,14 +118,15 @@ function outputCopyRelativePathForExpectedOutput(
     getSafeDocumentRelativePath(file),
   );
 
-  const normalizedGeneratedPath = generatedRelativePath.replaceAll('\\', '/');
+  const normalizedGeneratedPath = toPosix(generatedRelativePath);
   const generatedName = path.posix.basename(normalizedGeneratedPath);
-  const normalizedOriginalPath = output.originalPath?.replaceAll('\\', '/');
+  const normalizedOriginalPath =
+    output.originalPath == null ? undefined : toPosix(output.originalPath);
   const matchingExpectedPaths =
     normalizedOriginalPath == null
       ? []
       : expectedRelativePaths.filter((expected) => {
-          const normalizedExpected = expected.replaceAll('\\', '/');
+          const normalizedExpected = toPosix(expected);
           if (path.posix.basename(normalizedExpected) !== generatedName) {
             return false;
           }
@@ -182,23 +187,15 @@ export function expectedOutputFilesForOutputDir(
     : expectedInputOutputFiles(inputFiles);
 }
 
-function shouldUseOutputForCopy(
-  existing: OutputFileSummary | undefined,
-  candidate: OutputFileSummary,
-): boolean {
-  return existing == null || candidate.round > existing.round;
-}
-
 function latestWorkflowOutput(
   outputs: readonly OutputFileSummary[],
 ): OutputFileSummary | undefined {
-  let latest: OutputFileSummary | undefined;
-  for (const output of outputs) {
-    if (latest == null || output.round >= latest.round) {
-      latest = output;
-    }
-  }
-  return latest;
+  // `>=` keeps the later element on a round tie, matching the prior loop.
+  return outputs.reduce<OutputFileSummary | undefined>(
+    (latest, output) =>
+      latest == null || output.round >= latest.round ? output : latest,
+    undefined,
+  );
 }
 
 export async function resolveWorkflowOutput(
@@ -237,9 +234,8 @@ export async function resolveWorkflowOutput(
         output,
         expectedOutputFiles,
       );
-      if (
-        shouldUseOutputForCopy(outputsByRelativePath.get(relativePath), output)
-      ) {
+      const existing = outputsByRelativePath.get(relativePath);
+      if (existing == null || output.round > existing.round) {
         outputsByRelativePath.set(relativePath, output);
       }
     }

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -51,10 +51,7 @@ import { postMessage } from '@shared/hostBridge';
 import type { StreamTabId } from '@shared/schemas';
 import { Signal } from '@shared/signals';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc/progressViewCommands';
-import {
-  SetThemeMessageSchema,
-  type SetThemeMessage,
-} from '@shared/schemas/commonViewMessages';
+import { SetThemeMessageSchema } from '@shared/schemas/commonViewMessages';
 import {
   ProgressViewOutboundMessageSchema,
   type ProgressViewOutboundMessage,
@@ -64,17 +61,13 @@ import {
   applyHostBodyTheme,
   getWindowTargetOrigin,
 } from '@shared/wa/hostTheme';
-import { waIcon, type TeXRAIconName } from '@shared/wa/webAwesomeIcons';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 import {
   DesktopSetRouteMessageSchema,
   type DesktopRoute,
-  type DesktopSetRouteMessage,
 } from '../desktopShellMessages';
-import {
-  DesktopSetLogMessageSchema,
-  type DesktopSetLogMessage,
-} from '../desktopLogMessages';
+import { DesktopSetLogMessageSchema } from '../desktopLogMessages';
 import {
   buildDesktopMainViewResetMessage,
   buildDesktopSettingsTabMessage,
@@ -88,17 +81,14 @@ import {
 import {
   DESKTOP_ONBOARDING_COMMANDS,
   DesktopOnboardingSetStateMessageSchema,
-  type DesktopOnboardingSetStateMessage,
 } from '../desktopOnboardingMessages';
 import {
   DesktopShowDiffMessageSchema,
   DesktopCloseDiffMessageSchema,
-  type DesktopCloseDiffMessage,
 } from '../desktopDiffMessages';
 import {
   DesktopShowPdfMessageSchema,
   DesktopClosePdfMessageSchema,
-  type DesktopClosePdfMessage,
 } from '../desktopPdfMessages';
 import { createDesktopCommandPalette } from './desktopCommandPalette';
 import { createFirstRunWalkthrough } from './desktopOnboarding';
@@ -280,17 +270,6 @@ function isProgressOutboundMessage(
 // Shell template
 // =============================================================================
 
-interface ChromeIconButtonSpec {
-  readonly key: 'logs';
-  readonly icon: TeXRAIconName;
-  readonly label: string;
-  readonly onClick: () => void;
-}
-
-const CHROME_ICON_BUTTONS: ReadonlyArray<ChromeIconButtonSpec> = [
-  { key: 'logs', icon: 'file-lines', label: 'Logs', onClick: openLogsDrawer },
-] as const;
-
 function getWorkspaceDirectoryLabel(workspacePath: string | undefined): string {
   if (!workspacePath) return 'No folder';
 
@@ -333,24 +312,17 @@ function shellTemplate(): TemplateResult {
         >
           Commands
         </wa-button>
-        ${CHROME_ICON_BUTTONS.map(
-          (spec) => html`
-            <wa-button
-              class="desktop-icon-button"
-              appearance="plain"
-              size="small"
-              data-route-button=${spec.key}
-              aria-label=${spec.label}
-              title=${commandTitle(
-                DESKTOP_LOCAL_COMMANDS.SHOW_LOGS,
-                spec.label,
-              )}
-              @click=${spec.onClick}
-            >
-              ${waIcon(spec.icon, { label: spec.label })}
-            </wa-button>
-          `,
-        )}
+        <wa-button
+          class="desktop-icon-button"
+          appearance="plain"
+          size="small"
+          data-route-button="logs"
+          aria-label="Logs"
+          title=${commandTitle(DESKTOP_LOCAL_COMMANDS.SHOW_LOGS, 'Logs')}
+          @click=${openLogsDrawer}
+        >
+          ${waIcon('file-lines', { label: 'Logs' })}
+        </wa-button>
       </nav>
       <div class="desktop-three-pane">
         <aside class="desktop-rail" aria-label="Sessions">
@@ -679,40 +651,6 @@ function returnToLauncher(): void {
   setRouteState('main');
 }
 
-function isDesktopSetRouteMessage(
-  message: unknown,
-): message is DesktopSetRouteMessage {
-  return DesktopSetRouteMessageSchema.safeParse(message).success;
-}
-
-function isDesktopOnboardingSetStateMessage(
-  message: unknown,
-): message is DesktopOnboardingSetStateMessage {
-  return DesktopOnboardingSetStateMessageSchema.safeParse(message).success;
-}
-
-function isDesktopSetLogMessage(
-  message: unknown,
-): message is DesktopSetLogMessage {
-  return DesktopSetLogMessageSchema.safeParse(message).success;
-}
-
-function isThemeMessage(message: unknown): message is SetThemeMessage {
-  return SetThemeMessageSchema.safeParse(message).success;
-}
-
-function isDesktopCloseDiffMessage(
-  message: unknown,
-): message is DesktopCloseDiffMessage {
-  return DesktopCloseDiffMessageSchema.safeParse(message).success;
-}
-
-function isDesktopClosePdfMessage(
-  message: unknown,
-): message is DesktopClosePdfMessage {
-  return DesktopClosePdfMessageSchema.safeParse(message).success;
-}
-
 // Bridge for legacy `desktop:setRoute` IPC. The shell no longer has four
 // routes, so map the old route names onto the new surfaces:
 //   - 'main' / 'progress' → center pane (clear active stream for 'main')
@@ -740,24 +678,30 @@ function setRoute(route: DesktopRoute): void {
 }
 
 window.addEventListener('message', (event) => {
-  if (isDesktopSetRouteMessage(event.data)) {
-    setRoute(event.data.route);
+  const routeParsed = DesktopSetRouteMessageSchema.safeParse(event.data);
+  if (routeParsed.success) {
+    setRoute(routeParsed.data.route);
     return;
   }
-  if (isDesktopOnboardingSetStateMessage(event.data)) {
-    if (event.data.shouldShow) {
+  const onboardingParsed = DesktopOnboardingSetStateMessageSchema.safeParse(
+    event.data,
+  );
+  if (onboardingParsed.success) {
+    if (onboardingParsed.data.shouldShow) {
       firstRunWalkthrough?.show();
     } else {
       firstRunWalkthrough?.hide();
     }
     return;
   }
-  if (isThemeMessage(event.data)) {
-    applyDesktopTheme(event.data.theme);
+  const themeParsed = SetThemeMessageSchema.safeParse(event.data);
+  if (themeParsed.success) {
+    applyDesktopTheme(themeParsed.data.theme);
     return;
   }
-  if (isDesktopSetLogMessage(event.data)) {
-    logsDrawer.applySnapshot(event.data);
+  const logParsed = DesktopSetLogMessageSchema.safeParse(event.data);
+  if (logParsed.success) {
+    logsDrawer.applySnapshot(logParsed.data);
     return;
   }
   const diffParsed = DesktopShowDiffMessageSchema.safeParse(event.data);
@@ -765,7 +709,7 @@ window.addEventListener('message', (event) => {
     diffOverlay.open(diffParsed.data);
     return;
   }
-  if (isDesktopCloseDiffMessage(event.data)) {
+  if (DesktopCloseDiffMessageSchema.safeParse(event.data).success) {
     diffOverlay.close();
     return;
   }
@@ -774,7 +718,7 @@ window.addEventListener('message', (event) => {
     pdfOverlay.open(pdfParsed.data);
     return;
   }
-  if (isDesktopClosePdfMessage(event.data)) {
+  if (DesktopClosePdfMessageSchema.safeParse(event.data).success) {
     pdfOverlay.close();
     return;
   }

--- a/packages/desktop/tests/e2e/screenshots.spec.ts
+++ b/packages/desktop/tests/e2e/screenshots.spec.ts
@@ -4,6 +4,7 @@ import { test, expect } from '@playwright/test';
 
 import {
   closeTexraApp,
+  dismissOnboarding,
   launchTexraApp,
   type LaunchedApp,
 } from './electronApp.js';
@@ -15,31 +16,7 @@ let launched: LaunchedApp;
 
 test.beforeAll(async () => {
   launched = await launchTexraApp();
-  await launched.page.waitForFunction(
-    () => {
-      const btn = Array.from(document.querySelectorAll('wa-button')).find(
-        (b) => b.textContent?.trim() === 'Got it',
-      );
-      return btn instanceof HTMLElement;
-    },
-    undefined,
-    { timeout: 10000 },
-  );
-  const dismissed = await launched.page.evaluate(() => {
-    const btn = Array.from(document.querySelectorAll('wa-button')).find(
-      (b) => b.textContent?.trim() === 'Got it',
-    );
-    if (btn instanceof HTMLElement) {
-      btn.click();
-      return true;
-    }
-    return false;
-  });
-  if (dismissed) {
-    await launched.page
-      .locator('wa-dialog.desktop-onboarding')
-      .waitFor({ state: 'hidden', timeout: 5000 });
-  }
+  await dismissOnboarding(launched.page);
 });
 
 test.afterAll(async () => {

--- a/packages/desktop/tests/e2e/trajectories.spec.ts
+++ b/packages/desktop/tests/e2e/trajectories.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 
 import {
   closeTexraApp,
+  dismissOnboarding,
   launchTexraApp,
   type LaunchedApp,
 } from './electronApp.js';
@@ -37,25 +38,7 @@ let launched: LaunchedApp;
 test.beforeAll(async () => {
   launched = await launchTexraApp();
   // Dismiss the first-run walkthrough so it doesn't intercept clicks.
-  await launched.page.waitForFunction(
-    () => {
-      const btn = Array.from(document.querySelectorAll('wa-button')).find(
-        (b) => b.textContent?.trim() === 'Got it',
-      );
-      return btn instanceof HTMLElement;
-    },
-    undefined,
-    { timeout: 10_000 },
-  );
-  await launched.page.evaluate(() => {
-    const btn = Array.from(document.querySelectorAll('wa-button')).find(
-      (b) => b.textContent?.trim() === 'Got it',
-    );
-    if (btn instanceof HTMLElement) btn.click();
-  });
-  await launched.page
-    .locator('wa-dialog.desktop-onboarding')
-    .waitFor({ state: 'hidden', timeout: 5000 });
+  await dismissOnboarding(launched.page);
 });
 
 test.afterAll(async () => {
@@ -101,6 +84,27 @@ async function setSettingsTab(tabIndex: number): Promise<void> {
 }
 
 /**
+ * Wait until the named settings panel (or its tab) reports `active`. Without
+ * this confirmation a test can catch the previous tab's render and report a
+ * false positive.
+ */
+async function waitForActiveSettingsPanel(panel: string): Promise<void> {
+  await launched.page.waitForFunction(
+    (name) => {
+      const settingsApp = document.querySelector('settings-app');
+      const root = settingsApp?.shadowRoot;
+      const activePanel = root?.querySelector(
+        `wa-tab-panel[name="${name}"][active]`,
+      );
+      const activeTab = root?.querySelector(`wa-tab[panel="${name}"][active]`);
+      return activeTab != null || activePanel != null;
+    },
+    panel,
+    { timeout: 10_000 },
+  );
+}
+
+/**
  * Trajectory 1 — first launch on an empty workspace.
  * The launcher (main route) must mount without crashing the renderer.
  */
@@ -136,19 +140,7 @@ test('settings → models tab mounts and the auth surface is reachable', async (
   await setSettingsTab(SETTINGS_TAB_INDEX.MODELS);
   // Confirm the Models panel actually activated; without this we may catch
   // the previous tab's render and report a false positive.
-  await launched.page.waitForFunction(
-    () => {
-      const settingsApp = document.querySelector('settings-app');
-      const root = settingsApp?.shadowRoot;
-      const activePanel = root?.querySelector(
-        'wa-tab-panel[name="models"][active]',
-      );
-      const activeTab = root?.querySelector('wa-tab[panel="models"][active]');
-      return activeTab != null || activePanel != null;
-    },
-    undefined,
-    { timeout: 10_000 },
-  );
+  await waitForActiveSettingsPanel('models');
   // Sanity: the panel mounted a child custom element (the profile/models
   // surface). The actual auth banner text and provider list live one or
   // two shadow roots deep, so we only assert structural presence here.
@@ -169,19 +161,7 @@ test('settings → models tab mounts and the auth surface is reachable', async (
  */
 test('settings → memory tab mounts', async () => {
   await setSettingsTab(SETTINGS_TAB_INDEX.MEMORY);
-  await launched.page.waitForFunction(
-    () => {
-      const settingsApp = document.querySelector('settings-app');
-      const root = settingsApp?.shadowRoot;
-      const activePanel = root?.querySelector(
-        'wa-tab-panel[name="memory"][active]',
-      );
-      const activeTab = root?.querySelector('wa-tab[panel="memory"][active]');
-      return activeTab != null || activePanel != null;
-    },
-    undefined,
-    { timeout: 10_000 },
-  );
+  await waitForActiveSettingsPanel('memory');
 });
 
 /**
@@ -208,19 +188,7 @@ test('logs route renders the desktop log viewer', async () => {
  */
 test('settings → tools tab mounts', async () => {
   await setSettingsTab(SETTINGS_TAB_INDEX.TOOLS);
-  await launched.page.waitForFunction(
-    () => {
-      const settingsApp = document.querySelector('settings-app');
-      const root = settingsApp?.shadowRoot;
-      const activePanel = root?.querySelector(
-        'wa-tab-panel[name="tools"][active]',
-      );
-      const activeTab = root?.querySelector('wa-tab[panel="tools"][active]');
-      return activeTab != null || activePanel != null;
-    },
-    undefined,
-    { timeout: 10_000 },
-  );
+  await waitForActiveSettingsPanel('tools');
 });
 
 /**

--- a/packages/desktop/tests/e2e/verify-fixes.spec.ts
+++ b/packages/desktop/tests/e2e/verify-fixes.spec.ts
@@ -4,6 +4,7 @@ import { SETTINGS_VIEW_CMD } from '../../../../src/common/webview/settingsViewCo
 import { SETTINGS_TAB } from '../../../../src/shared/schemas/settingsViewMessages.js';
 import {
   closeTexraApp,
+  dismissOnboarding,
   launchTexraApp,
   type LaunchedApp,
 } from './electronApp.js';
@@ -12,25 +13,7 @@ let launched: LaunchedApp;
 
 test.beforeAll(async () => {
   launched = await launchTexraApp();
-  await launched.page.waitForFunction(
-    () => {
-      const btn = Array.from(document.querySelectorAll('wa-button')).find(
-        (b) => b.textContent?.trim() === 'Got it',
-      );
-      return btn instanceof HTMLElement;
-    },
-    undefined,
-    { timeout: 10000 },
-  );
-  await launched.page.evaluate(() => {
-    const btn = Array.from(document.querySelectorAll('wa-button')).find(
-      (b) => b.textContent?.trim() === 'Got it',
-    );
-    if (btn instanceof HTMLElement) btn.click();
-  });
-  await launched.page
-    .locator('wa-dialog.desktop-onboarding')
-    .waitFor({ state: 'hidden', timeout: 5000 });
+  await dismissOnboarding(launched.page);
 });
 
 test.afterAll(async () => {
@@ -57,6 +40,31 @@ async function setRoute(route: 'main' | 'settings'): Promise<void> {
     route,
     { timeout: 5000 },
   );
+}
+
+/**
+ * Read the scroll metrics of the Tools settings panel (the scrollable element
+ * under the flex-body fix). Returns null when the panel has not mounted.
+ */
+async function readToolsPanelMetrics(): Promise<{
+  scrollHeight: number;
+  clientHeight: number;
+  scrollTop: number;
+} | null> {
+  return launched.page.evaluate(() => {
+    const dialog = document.querySelector('wa-dialog.desktop-settings-overlay');
+    const settingsApp = dialog?.querySelector('settings-app');
+    const root = settingsApp?.shadowRoot;
+    const panel = root?.querySelector<HTMLElement>(
+      'wa-tab-panel[name="tools"]',
+    );
+    if (!panel) return null;
+    return {
+      scrollHeight: panel.scrollHeight,
+      clientHeight: panel.clientHeight,
+      scrollTop: panel.scrollTop,
+    };
+  });
 }
 
 test('main view no longer renders inner Launcher/Progress toolbar', async ({}, testInfo) => {
@@ -112,20 +120,7 @@ test('settings overlay scrolls (Tools tab top + bottom)', async ({}, testInfo) =
 
   // Find the wa-tab-panel for tools — that's the scrollable element under
   // the new flex-body fix.
-  const probeBefore = await launched.page.evaluate(() => {
-    const dialog = document.querySelector('wa-dialog.desktop-settings-overlay');
-    const settingsApp = dialog?.querySelector('settings-app');
-    const root = settingsApp?.shadowRoot;
-    const panel = root?.querySelector<HTMLElement>(
-      'wa-tab-panel[name="tools"]',
-    );
-    if (!panel) return null;
-    return {
-      scrollHeight: panel.scrollHeight,
-      clientHeight: panel.clientHeight,
-      scrollTop: panel.scrollTop,
-    };
-  });
+  const probeBefore = await readToolsPanelMetrics();
   console.log('tools panel before scroll:', probeBefore);
 
   await launched.page.screenshot({
@@ -145,20 +140,7 @@ test('settings overlay scrolls (Tools tab top + bottom)', async ({}, testInfo) =
   });
   await launched.page.waitForTimeout(150);
 
-  const probeAfter = await launched.page.evaluate(() => {
-    const dialog = document.querySelector('wa-dialog.desktop-settings-overlay');
-    const settingsApp = dialog?.querySelector('settings-app');
-    const root = settingsApp?.shadowRoot;
-    const panel = root?.querySelector<HTMLElement>(
-      'wa-tab-panel[name="tools"]',
-    );
-    if (!panel) return null;
-    return {
-      scrollHeight: panel.scrollHeight,
-      clientHeight: panel.clientHeight,
-      scrollTop: panel.scrollTop,
-    };
-  });
+  const probeAfter = await readToolsPanelMetrics();
   console.log('tools panel after scroll:', probeAfter);
 
   await launched.page.screenshot({

--- a/packages/extension/src/commands/auth/authCommands.ts
+++ b/packages/extension/src/commands/auth/authCommands.ts
@@ -66,6 +66,20 @@ function getSignInOptions(): SignInOption[] {
   });
 }
 
+// "<prefix> <email>" info toast; the tier suffix is only fetched and
+// appended when `includeTier` is set.
+async function showSignedInMessage(
+  prefix: string,
+  includeTier: boolean,
+): Promise<void> {
+  const user = await SupabaseClient.getUser();
+  const email = user?.email || 'unknown user';
+  const tierSuffix = includeTier
+    ? ` (${await SupabaseClient.getUserTier()} tier)`
+    : '';
+  void vscode.window.showInformationMessage(`${prefix} ${email}${tierSuffix}`);
+}
+
 /**
  * Run the interactive sign-in flow.
  *
@@ -91,10 +105,7 @@ export async function signIn(): Promise<boolean> {
 
     const existing = await getExistingSession(authReady);
     if (existing) {
-      const user = await SupabaseClient.getUser();
-      void vscode.window.showInformationMessage(
-        `Already signed in as ${user?.email || 'unknown user'}`,
-      );
+      await showSignedInMessage('Already signed in as', false);
       return true;
     }
 
@@ -120,11 +131,7 @@ export async function signIn(): Promise<boolean> {
     );
 
     if (session) {
-      const user = await SupabaseClient.getUser();
-      const tier = await SupabaseClient.getUserTier();
-      void vscode.window.showInformationMessage(
-        `Signed in as ${user?.email || 'unknown user'} (${tier} tier)`,
-      );
+      await showSignedInMessage('Signed in as', true);
       return true;
     }
     return false;

--- a/packages/extension/src/commands/housekeeping/cleanCommands.ts
+++ b/packages/extension/src/commands/housekeeping/cleanCommands.ts
@@ -68,6 +68,10 @@ async function runCleanCommand(
   );
   if (!data) return;
 
+  if (outputFiles.length > 0) {
+    logger.debug(CHANNEL, `Additional files: ${outputFiles.join(', ')}`);
+  }
+
   const result =
     outputFiles.length > 0
       ? await runCleanMultiple(

--- a/packages/extension/src/commands/housekeeping/cleanCommands.ts
+++ b/packages/extension/src/commands/housekeeping/cleanCommands.ts
@@ -50,29 +50,50 @@ export function registerCleanCommands(context: vscode.ExtensionContext): void {
   ]);
 }
 
-async function handleCleanSingle(
+// Shared backing for the single- and multiple-file clean commands. Mirrors
+// `runWorkspaceClean` in `handleClean`: an empty `outputFiles` list cleans the
+// input alone, a non-empty list also sweeps the extra files.
+async function runCleanCommand(
   inputFile: string,
   agent: string,
   model: string,
+  label: string,
+  outputFiles: string[],
 ): Promise<void> {
   const data = await parseWithErrorDisplay(
     CHANNEL,
     FileOpParamsSchema,
     { inputFile, agent, model },
-    'cleanSingle params',
+    label,
   );
   if (!data) return;
 
-  const result = await runCleanSingle(data.model, data.inputFile, data.agent);
+  const result =
+    outputFiles.length > 0
+      ? await runCleanMultiple(
+          data.model,
+          data.inputFile,
+          data.agent,
+          outputFiles,
+        )
+      : await runCleanSingle(data.model, data.inputFile, data.agent);
   showCleanResult(result, data.inputFile);
   emitClearMissingOutputs({
     streamConfig: {
       agent: data.agent,
       model: data.model,
       inputFile: data.inputFile,
-      outputFiles: [],
+      outputFiles,
     },
   });
+}
+
+async function handleCleanSingle(
+  inputFile: string,
+  agent: string,
+  model: string,
+): Promise<void> {
+  await runCleanCommand(inputFile, agent, model, 'cleanSingle params', []);
 }
 
 async function handleCleanMultiple(
@@ -81,31 +102,13 @@ async function handleCleanMultiple(
   model: string,
   inputFiles: string[] = [],
 ): Promise<void> {
-  const data = await parseWithErrorDisplay(
-    CHANNEL,
-    FileOpParamsSchema,
-    { inputFile, agent, model },
+  await runCleanCommand(
+    inputFile,
+    agent,
+    model,
     'cleanMultiple params',
-  );
-  if (!data) return;
-
-  logger.debug(CHANNEL, `Additional files: ${inputFiles.join(', ')}`);
-
-  const result = await runCleanMultiple(
-    data.model,
-    data.inputFile,
-    data.agent,
     inputFiles,
   );
-  showCleanResult(result, data.inputFile);
-  emitClearMissingOutputs({
-    streamConfig: {
-      agent: data.agent,
-      model: data.model,
-      inputFile: data.inputFile,
-      outputFiles: inputFiles,
-    },
-  });
 }
 
 async function handleClean(config: unknown): Promise<void> {

--- a/packages/extension/src/commands/latex/latexdiffCommands.ts
+++ b/packages/extension/src/commands/latex/latexdiffCommands.ts
@@ -20,6 +20,7 @@ import {
   runPackLatexdiffvcMultiple,
   runCleanLatexdiffvc,
   runCleanLatexdiffvcMultiple,
+  type LatexdiffPackResult,
 } from '@housekeeping';
 import type { LaTeXdiffResult } from '@latex/latexdiff';
 import {
@@ -38,10 +39,7 @@ import { LATEX_CONFIG_DEFAULTS } from '@shared/constants/latex';
 import { flexibleFS, pathToLocation } from '@utils/files';
 import { checkToolInstalled } from '@utils/system';
 
-import {
-  getLatexdiffPackNotifications,
-  type LatexHousekeepingNotification,
-} from './latexHousekeepingNotifications';
+import { getLatexdiffPackNotifications } from './latexHousekeepingNotifications';
 
 type LatexdiffTool = 'latexdiff' | 'latexdiff-vc';
 
@@ -155,20 +153,26 @@ async function runDiffAndOpen(
   await openLatexdiffResult(fileToUseLocation, result.diffFileName);
 }
 
-function showLatexdiffPackNotifications(
-  notifications: LatexHousekeepingNotification[],
+// Turn pack/clean run results into user notifications. Folds the notification
+// derivation and display that every latexdiff-vc handler invoked together.
+function reportLatexdiff(
+  results: LatexdiffPackResult | LatexdiffPackResult[],
 ): void {
-  for (const notification of notifications) {
-    if (notification.severity === 'info') {
-      void showLoggedInfoMessage(CHANNEL, notification.message);
-    } else if (notification.severity === 'error') {
-      void showLoggedErrorMessage(
-        CHANNEL,
-        notification.message,
-        notification.error,
-      );
-    } else {
-      void showLoggedMessage(CHANNEL, notification.message);
+  for (const notification of getLatexdiffPackNotifications(results)) {
+    switch (notification.severity) {
+      case 'info':
+        void showLoggedInfoMessage(CHANNEL, notification.message);
+        break;
+      case 'error':
+        void showLoggedErrorMessage(
+          CHANNEL,
+          notification.message,
+          notification.error,
+        );
+        break;
+      default:
+        void showLoggedMessage(CHANNEL, notification.message);
+        break;
     }
   }
 }
@@ -261,11 +265,7 @@ async function handlePackLatexdiffvc(
         `Command called with: inputFile=${inputFile}, baseFile=${baseFile}, commitHash=${commitHash}, clean=${clean}`,
       );
       const fileToUse = baseFile ?? inputFile;
-      showLatexdiffPackNotifications(
-        getLatexdiffPackNotifications(
-          await runPackLatexdiffvc(fileToUse, commitHash, clean),
-        ),
-      );
+      reportLatexdiff(await runPackLatexdiffvc(fileToUse, commitHash, clean));
     },
   );
 }
@@ -284,10 +284,8 @@ async function handlePackLatexdiffvcMultiple(
         `Command called with: commitHash=${commitHash}, clean=${clean}`,
       );
       logger.debug(CHANNEL, `Input files: ${inputFiles.join(', ')}`);
-      showLatexdiffPackNotifications(
-        getLatexdiffPackNotifications(
-          await runPackLatexdiffvcMultiple(inputFiles, commitHash, clean),
-        ),
+      reportLatexdiff(
+        await runPackLatexdiffvcMultiple(inputFiles, commitHash, clean),
       );
     },
   );
@@ -307,11 +305,7 @@ async function handleCleanLatexdiffvc(
         `Command called with: inputFile=${inputFile}, baseFile=${baseFile}, commitHash=${commitHash}`,
       );
       const fileToUse = baseFile ?? inputFile;
-      showLatexdiffPackNotifications(
-        getLatexdiffPackNotifications(
-          await runCleanLatexdiffvc(fileToUse, commitHash),
-        ),
-      );
+      reportLatexdiff(await runCleanLatexdiffvc(fileToUse, commitHash));
     },
   );
 }
@@ -326,10 +320,8 @@ async function handleCleanLatexdiffvcMultiple(
     async () => {
       logger.debug(CHANNEL, `Command called with: commitHash=${commitHash}`);
       logger.debug(CHANNEL, `Input files: ${inputFiles.join(', ')}`);
-      showLatexdiffPackNotifications(
-        getLatexdiffPackNotifications(
-          await runCleanLatexdiffvcMultiple(inputFiles, commitHash),
-        ),
+      reportLatexdiff(
+        await runCleanLatexdiffvcMultiple(inputFiles, commitHash),
       );
     },
   );

--- a/packages/extension/src/commands/progress/progressViewCommands.ts
+++ b/packages/extension/src/commands/progress/progressViewCommands.ts
@@ -2,28 +2,28 @@ import * as vscode from 'vscode';
 
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 
+function getProgressProviderOrWarn(): ProgressViewProvider | undefined {
+  const provider = ProgressViewProvider.getInstance();
+  if (!provider) {
+    void vscode.window.showErrorMessage(
+      'Progress View is not available. Please try again.',
+    );
+  }
+  return provider;
+}
+
 /**
  * Show the progress view. The `inPlace` flag controls whether to keep the
  * sidebar in its current location vs. focusing it.
  */
 export async function showProgressView(inPlace: boolean): Promise<void> {
-  const provider = ProgressViewProvider.getInstance();
-  if (!provider) {
-    vscode.window.showErrorMessage(
-      'Progress View is not available. Please try again.',
-    );
-    return;
-  }
+  const provider = getProgressProviderOrWarn();
+  if (!provider) return;
   await provider.showProgressView({ inPlace });
 }
 
 export async function openProgressViewInTab(): Promise<void> {
-  const provider = ProgressViewProvider.getInstance();
-  if (!provider) {
-    await vscode.window.showErrorMessage(
-      'Progress View is not available. Please try again.',
-    );
-    return;
-  }
+  const provider = getProgressProviderOrWarn();
+  if (!provider) return;
   await provider.popOutToEditor();
 }

--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -242,24 +242,31 @@ async function ensureCredentialOrPrompt(): Promise<boolean> {
 
   if (!picked) return false;
 
-  if (picked.id === 'signIn') {
-    await vscode.commands.executeCommand(AUTH_COMMANDS.SIGN_IN);
-    return hasAnyUsableSetupCredential();
-  }
+  // Each credential path runs its action then re-checks for a usable
+  // credential; only the walkthrough leaves setup un-launched.
+  const credentialActions: Partial<
+    Record<typeof picked.id, () => PromiseLike<unknown>>
+  > = {
+    chatgpt: () => signInWithChatGptSubscription(CHANNEL),
+    signIn: () => vscode.commands.executeCommand(AUTH_COMMANDS.SIGN_IN),
+    apiKey: () => vscode.commands.executeCommand(apiKeyCommands.setApiKey),
+  };
 
-  if (picked.id === 'apiKey') {
-    await vscode.commands.executeCommand(apiKeyCommands.setApiKey);
-    return hasAnyUsableSetupCredential();
-  }
-
-  if (picked.id === 'chatgpt') {
-    await signInWithChatGptSubscription(CHANNEL);
+  const action = credentialActions[picked.id];
+  if (action) {
+    await action();
     return hasAnyUsableSetupCredential();
   }
 
   // walkthrough
   await vscode.commands.executeCommand('texra.openGettingStarted');
   return false;
+}
+
+// Routing is fine unless "Use OpenRouter" is on without an OpenRouter key.
+async function isRoutingConfigured(): Promise<boolean> {
+  if (!getUseOpenRouter()) return true;
+  return SecretManager.hasUsableApiKey('openRouter');
 }
 
 /**
@@ -272,8 +279,7 @@ async function ensureCredentialOrPrompt(): Promise<boolean> {
  * purpose and may have concurrent OR-routed agents running.
  */
 async function ensureRoutingConfigured(): Promise<boolean> {
-  if (!getUseOpenRouter()) return true;
-  if (await SecretManager.hasUsableApiKey('openRouter')) return true;
+  if (await isRoutingConfigured()) return true;
 
   const choice = await vscode.window.showWarningMessage(
     '"Use OpenRouter" is enabled in settings, but no OpenRouter key is set. Every model call routes through OpenRouter and will fail. Add an OpenRouter key, or disable "Use OpenRouter" in the Models tab, then retry.',
@@ -291,9 +297,7 @@ async function ensureRoutingConfigured(): Promise<boolean> {
   // Re-check: the user may have resolved the misconfiguration (added an
   // OR key, or disabled Use OpenRouter in the Models tab), in which case
   // we can proceed without forcing them to re-invoke the command.
-  if (!getUseOpenRouter()) return true;
-  if (await SecretManager.hasUsableApiKey('openRouter')) return true;
-  return false;
+  return isRoutingConfigured();
 }
 
 export type SetupAssistantLaunchResult =

--- a/packages/extension/src/commands/system/textEditorCommands.ts
+++ b/packages/extension/src/commands/system/textEditorCommands.ts
@@ -25,6 +25,25 @@ export function registerTextEditorCommands(
   /* registration handled by extensionCommandSurface */
 }
 
+// Prompt for a line number, rejecting non-numeric input and (when `min` is
+// given) values below the floor. Shared by the start/end/insert prompts.
+async function promptLineNumber(
+  prompt: string,
+  errorMessage: string,
+  min?: number,
+): Promise<string | undefined> {
+  return vscode.window.showInputBox({
+    prompt,
+    validateInput: (value) => {
+      const num = Number.parseInt(value, 10);
+      if (Number.isNaN(num) || (min !== undefined && num < min)) {
+        return errorMessage;
+      }
+      return '';
+    },
+  });
+}
+
 /**
  * Handle the test text editor command
  * This command allows testing the TextEditorTool with different commands
@@ -78,23 +97,16 @@ export async function handleTestTextEditor(): Promise<void> {
         });
 
         if (useRange === 'Yes') {
-          const startLine = await vscode.window.showInputBox({
-            prompt: 'Enter start line number',
-            validateInput: (value) => {
-              const num = Number.parseInt(value, 10);
-              return isNaN(num) || num < 1
-                ? 'Please enter a valid line number'
-                : '';
-            },
-          });
+          const startLine = await promptLineNumber(
+            'Enter start line number',
+            'Please enter a valid line number',
+            1,
+          );
 
-          const endLine = await vscode.window.showInputBox({
-            prompt: 'Enter end line number (or -1 for end of file)',
-            validateInput: (value) => {
-              const num = Number.parseInt(value, 10);
-              return isNaN(num) ? 'Please enter a valid line number' : '';
-            },
-          });
+          const endLine = await promptLineNumber(
+            'Enter end line number (or -1 for end of file)',
+            'Please enter a valid line number',
+          );
 
           if (startLine && endLine) {
             input.view_range = [
@@ -126,15 +138,11 @@ export async function handleTestTextEditor(): Promise<void> {
 
       case 'insert':
         // Get line number and text to insert
-        const insertLine = await vscode.window.showInputBox({
-          prompt: 'Enter line number to insert at',
-          validateInput: (value) => {
-            const num = Number.parseInt(value, 10);
-            return isNaN(num) || num < 0
-              ? 'Please enter a valid line number (0 or greater)'
-              : '';
-          },
-        });
+        const insertLine = await promptLineNumber(
+          'Enter line number to insert at',
+          'Please enter a valid line number (0 or greater)',
+          0,
+        );
 
         if (!insertLine) {
           return;

--- a/packages/extension/src/common/webview/BaseViewMessageHandler.ts
+++ b/packages/extension/src/common/webview/BaseViewMessageHandler.ts
@@ -92,15 +92,23 @@ export abstract class BaseViewMessageHandler<
   }
 
   /**
+   * Record the active webview reference when tracking is enabled. No-op
+   * otherwise, mirroring {@link clearActiveView}.
+   */
+  private setActiveView(webviewView: T): void {
+    if (this._options.trackActiveView) {
+      this._activeView = webviewView;
+    }
+  }
+
+  /**
    * Track the active webview reference for custom handlers.
    */
   protected async withActiveView(
     webviewView: T,
     handler: () => Promise<void> | void,
   ): Promise<void> {
-    if (this._options.trackActiveView) {
-      this._activeView = webviewView;
-    }
+    this.setActiveView(webviewView);
     await handler();
   }
 
@@ -135,16 +143,8 @@ export abstract class BaseViewMessageHandler<
         });
       });
 
-      if (
-        !handled &&
-        message &&
-        typeof message === 'object' &&
-        'command' in message
-      ) {
-        this.logger.warn(
-          this.channel,
-          `Unhandled command: ${(message as { command: string }).command}`,
-        );
+      if (!handled && isCommandMessage(message)) {
+        this.logger.warn(this.channel, `Unhandled command: ${message.command}`);
       }
     });
   }
@@ -157,9 +157,7 @@ export abstract class BaseViewMessageHandler<
    */
   public async handleMessage(message: unknown, webviewView: T): Promise<void> {
     // Track active view when option is enabled
-    if (this._options.trackActiveView) {
-      this._activeView = webviewView;
-    }
+    this.setActiveView(webviewView);
 
     if (!isCommandMessage(message)) {
       this.logger.warn(

--- a/packages/extension/src/schemas/vscodeSettings.ts
+++ b/packages/extension/src/schemas/vscodeSettings.ts
@@ -46,14 +46,6 @@ export const VscodeSettingsExtensionShape = {
     .prefault(DEFAULT_VSCODE_SETTINGS_EXTENSION.apiKeys),
 };
 
-export const VscodeSettingsExtensionSchema = z
-  .strictObject(VscodeSettingsExtensionShape)
-  .prefault(DEFAULT_VSCODE_SETTINGS_EXTENSION);
-
-export type VscodeSettingsExtension = z.infer<
-  typeof VscodeSettingsExtensionSchema
->;
-
 /**
  * Dotted leaf paths for every VS Code-only setting.
  */

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -31,6 +31,7 @@ import type { SpendingStatus } from '@shared/schemas/spendingStatus';
 import {
   registerTeXRAWebAwesomeIcons,
   waIcon,
+  type TeXRAIconName,
 } from '@shared/wa/webAwesomeIcons';
 import {
   type AgentSelectionItem,
@@ -97,6 +98,20 @@ function toSettingsTabPanelName(name: string): string {
 }
 
 const SETTINGS_TAB_PANEL_NAMES = SETTINGS_TAB_ORDER.map(toSettingsTabPanelName);
+
+/** Header tab strip: panel name, icon, and label in display order. */
+const SETTINGS_TABS = [
+  { panel: 'memory', icon: 'database', label: 'Memory' },
+  { panel: 'history', icon: 'clock-rotate-left', label: 'History' },
+  { panel: 'models', icon: 'server', label: 'Models' },
+  { panel: 'agents', icon: 'robot', label: 'Agents' },
+  { panel: 'multi-agent', icon: 'users', label: 'Multi-Agent' },
+  { panel: 'tools', icon: 'screwdriver-wrench', label: 'Tools' },
+  { panel: 'ai-agents', icon: 'robot', label: 'Integrations' },
+  { panel: 'git', icon: 'code-branch', label: 'Git' },
+  { panel: 'latex', icon: 'file-code', label: 'LaTeX' },
+  { panel: 'goal', icon: 'compass', label: 'Goal' },
+] satisfies readonly { panel: string; icon: TeXRAIconName; label: string }[];
 
 /** Create an event handler that forwards event.detail to a postMessage command. */
 function forwardDetail<T extends Record<string, unknown>>(
@@ -889,46 +904,13 @@ export class SettingsApp extends SettingsAppBase {
           'memory'}
           @wa-tab-show=${this.handleTabShow}
         >
-          <wa-tab panel="memory"
-            >${waIcon('database', { className: 'settings-tab-icon' })}
-            Memory</wa-tab
-          >
-          <wa-tab panel="history"
-            >${waIcon('clock-rotate-left', { className: 'settings-tab-icon' })}
-            History</wa-tab
-          >
-          <wa-tab panel="models"
-            >${waIcon('server', { className: 'settings-tab-icon' })}
-            Models</wa-tab
-          >
-          <wa-tab panel="agents"
-            >${waIcon('robot', { className: 'settings-tab-icon' })}
-            Agents</wa-tab
-          >
-          <wa-tab panel="multi-agent"
-            >${waIcon('users', { className: 'settings-tab-icon' })}
-            Multi-Agent</wa-tab
-          >
-          <wa-tab panel="tools"
-            >${waIcon('screwdriver-wrench', { className: 'settings-tab-icon' })}
-            Tools</wa-tab
-          >
-          <wa-tab panel="ai-agents"
-            >${waIcon('robot', { className: 'settings-tab-icon' })}
-            Integrations</wa-tab
-          >
-          <wa-tab panel="git"
-            >${waIcon('code-branch', { className: 'settings-tab-icon' })}
-            Git</wa-tab
-          >
-          <wa-tab panel="latex"
-            >${waIcon('file-code', { className: 'settings-tab-icon' })}
-            LaTeX</wa-tab
-          >
-          <wa-tab panel="goal"
-            >${waIcon('compass', { className: 'settings-tab-icon' })}
-            Goal</wa-tab
-          >
+          ${SETTINGS_TABS.map(
+            (tab) =>
+              html`<wa-tab panel=${tab.panel}
+                >${waIcon(tab.icon, { className: 'settings-tab-icon' })}
+                ${tab.label}</wa-tab
+              >`,
+          )}
 
           <wa-tab-panel name="memory">
             <memory-tab

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -53,11 +53,9 @@ interface ProviderGroup {
 
 /** Stable sort: fast-first-response models bubble to the top of their provider. */
 function sortFastFirst(items: ModelSelectionItem[]): ModelSelectionItem[] {
-  return items.toSorted((a, b) => {
-    const aFast = a.isFast ? 0 : 1;
-    const bFast = b.isFast ? 0 : 1;
-    return aFast - bFast;
-  });
+  return items.toSorted(
+    (a, b) => Number(Boolean(b.isFast)) - Number(Boolean(a.isFast)),
+  );
 }
 
 @customElement('model-selection-list')

--- a/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
@@ -155,30 +155,6 @@ export class AIAgentsTab extends LitElement {
     }
   }
 
-  private handleCodexSandboxModeChange = (e: Event): void => {
-    this.emitSelect('codex-sandbox-mode-change', 'mode', e);
-  };
-
-  private handleCodexReasoningEffortChange = (e: Event): void => {
-    this.emitSelect('codex-reasoning-effort-change', 'effort', e);
-  };
-
-  private handleCodexApprovalPolicyChange = (e: Event): void => {
-    this.emitSelect('codex-approval-policy-change', 'policy', e);
-  };
-
-  private handleClaudeAgentModelChange = (e: Event): void => {
-    this.emitSelect('claude-agent-model-change', 'model', e);
-  };
-
-  private handleClaudeAgentPermissionModeChange = (e: Event): void => {
-    this.emitSelect('claude-agent-permission-mode-change', 'mode', e);
-  };
-
-  private handleClaudeAgentEffortChange = (e: Event): void => {
-    this.emitSelect('claude-agent-effort-change', 'effort', e);
-  };
-
   private renderSelectRow(
     label: string,
     value: string,
@@ -206,19 +182,19 @@ export class AIAgentsTab extends LitElement {
           'Sandbox mode',
           this.codexSandboxMode,
           SANDBOX_MODE_OPTIONS,
-          this.handleCodexSandboxModeChange,
+          (e) => this.emitSelect('codex-sandbox-mode-change', 'mode', e),
         )}
         ${this.renderSelectRow(
           'Reasoning effort',
           this.codexReasoningEffort,
           REASONING_EFFORT_OPTIONS,
-          this.handleCodexReasoningEffortChange,
+          (e) => this.emitSelect('codex-reasoning-effort-change', 'effort', e),
         )}
         ${this.renderSelectRow(
           'Approval policy',
           this.codexApprovalPolicy,
           APPROVAL_POLICY_OPTIONS,
-          this.handleCodexApprovalPolicyChange,
+          (e) => this.emitSelect('codex-approval-policy-change', 'policy', e),
         )}
       </div>
     `;
@@ -231,19 +207,20 @@ export class AIAgentsTab extends LitElement {
           'Model',
           this.claudeAgentModel,
           CLAUDE_MODEL_OPTIONS,
-          this.handleClaudeAgentModelChange,
+          (e) => this.emitSelect('claude-agent-model-change', 'model', e),
         )}
         ${this.renderSelectRow(
           'Reasoning effort',
           this.claudeAgentEffort,
           CLAUDE_EFFORT_OPTIONS,
-          this.handleClaudeAgentEffortChange,
+          (e) => this.emitSelect('claude-agent-effort-change', 'effort', e),
         )}
         ${this.renderSelectRow(
           'Permission mode',
           this.claudeAgentPermissionMode,
           CLAUDE_PERMISSION_MODE_OPTIONS,
-          this.handleClaudeAgentPermissionModeChange,
+          (e) =>
+            this.emitSelect('claude-agent-permission-mode-change', 'mode', e),
         )}
       </div>
     `;

--- a/packages/extension/src/webview/MainViewMessageHandler.ts
+++ b/packages/extension/src/webview/MainViewMessageHandler.ts
@@ -24,6 +24,7 @@ import { COMMON_COMMANDS, MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import {
   dispatchMainViewInbound,
   MainViewInboundHandlerRegistry,
+  type GettingStartedAction,
 } from '@shared/schemas';
 import type { MainViewExecuteMessage } from '@shared/mainView';
 import { PROVIDER_URLS } from '@shared/constants/providers';
@@ -44,6 +45,14 @@ export interface MainViewOnboardingHooks {
    */
   refreshOnboardingFunnel(): Promise<void>;
 }
+
+const GETTING_STARTED_COMMANDS = {
+  runSetup: 'texra.runSetupAssistant',
+  createSampleProject: 'texra.createSampleProject',
+  cloneOverleaf: 'texra.cloneOverleafProject',
+  downloadArxiv: 'texra.downloadArXivSource',
+  openWalkthrough: 'texra.openGettingStarted',
+} satisfies Record<GettingStartedAction, string>;
 
 export class MainViewMessageHandler extends BaseViewMessageHandler {
   private readonly recordingManager: RecordingManager;
@@ -310,47 +319,15 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
           this.interactionController.getDismissConfigUpdate(m),
         ),
       [MAIN_VIEW_COMMANDS.GETTING_STARTED_ACTION]: async (m) => {
-        switch (m.action) {
-          case 'runSetup':
-            await safeExecuteCommand(
-              'texra.runSetupAssistant',
-              [],
-              this.viewName,
-            );
-            await this.onboarding?.refreshOnboardingFunnel();
-            break;
-          case 'createSampleProject':
-            await safeExecuteCommand(
-              'texra.createSampleProject',
-              [],
-              this.viewName,
-            );
-            break;
-          case 'cloneOverleaf':
-            await safeExecuteCommand(
-              'texra.cloneOverleafProject',
-              [],
-              this.viewName,
-            );
-            break;
-          case 'downloadArxiv':
-            await safeExecuteCommand(
-              'texra.downloadArXivSource',
-              [],
-              this.viewName,
-            );
-            break;
-          case 'openWalkthrough':
-            await safeExecuteCommand(
-              'texra.openGettingStarted',
-              [],
-              this.viewName,
-            );
-            break;
-          default: {
-            const exhaustive: never = m.action;
-            throw new Error(`Unhandled getting started action: ${exhaustive}`);
-          }
+        await safeExecuteCommand(
+          GETTING_STARTED_COMMANDS[m.action],
+          [],
+          this.viewName,
+        );
+        // runSetup changes the onboarding funnel inputs, so re-derive the
+        // card state once the setup assistant returns.
+        if (m.action === 'runSetup') {
+          await this.onboarding?.refreshOnboardingFunnel();
         }
       },
       [MAIN_VIEW_COMMANDS.ONBOARDING_SKIP]: async () => {

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -71,6 +71,7 @@ import type { StateRestoreMessage } from '@shared/schemas/commonViewMessages';
 import { agentName } from '@shared/schemas/agent';
 import type { MutableWaTabGroup, WaTabShowEvent } from '@shared/wa/tabs';
 import '@shared/wa/tabs';
+import { unique } from '@utils/core';
 
 import './components/FileSelectGroup';
 import './components/BannerGroup';
@@ -79,7 +80,6 @@ import './components/InstructionPanel';
 import './components/OnboardingWelcomeCard';
 import './components/OnboardingSetupCard';
 import {
-  ELEMENT_IDS,
   DOCUMENT_FILE_TYPES,
   MULTIPLE_DOCUMENT_FILE_TYPES,
   SESSION_TYPES,
@@ -949,7 +949,7 @@ export class MainApp extends MainAppBase {
     if (!listId) return;
 
     this.multiFiles.set({ ...this.multiFiles.get(), [listId]: files });
-    if (listId === ELEMENT_IDS.OUTPUT_FILES) {
+    if (listId === 'outputFiles') {
       this.outputFilesActive.set(false);
     }
     this.saveState();
@@ -1054,7 +1054,7 @@ export class MainApp extends MainAppBase {
 
     const filesToAdd = message.files ?? [];
     const existing = mf[listId] ?? [];
-    const merged = this.mergeUnique(existing, filesToAdd);
+    const merged = unique([...existing, ...filesToAdd]);
     this.multiFiles.set({ ...mf, [listId]: merged });
     this.saveState();
   }
@@ -1204,7 +1204,7 @@ export class MainApp extends MainAppBase {
       (f: string) => f !== file,
     );
     if (files.length === 0) {
-      if (listId === ELEMENT_IDS.OUTPUT_FILES) {
+      if (listId === 'outputFiles') {
         this.outputFilesActive.set(false);
       }
     }
@@ -1651,17 +1651,6 @@ export class MainApp extends MainAppBase {
       const [hash] = commit.split(': ');
       return hash === value;
     });
-  }
-
-  /** Merge arrays, appending only items not already present */
-  private mergeUnique(existing: string[], additions: string[]): string[] {
-    const merged = [...existing];
-    for (const item of additions) {
-      if (!merged.includes(item)) {
-        merged.push(item);
-      }
-    }
-    return merged;
   }
 
   /** Launcher/Progress tabs plus header actions (hidden on the desktop host). */

--- a/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
+++ b/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
@@ -221,22 +221,27 @@ export class LatexDiffsSection extends LitElement {
     this.dispatchEvent(MainViewEvents.latexDiffsToggle({ visible }));
   }
 
-  private handleBaseSelectChange(event: Event): void {
+  private selectValue(event: Event): string {
     const select = event.currentTarget as WaSelect | null;
-    const value = typeof select?.value === 'string' ? select.value : '';
-    this.dispatchEvent(MainViewEvents.baseFileChange({ value }));
+    return typeof select?.value === 'string' ? select.value : '';
+  }
+
+  private handleBaseSelectChange(event: Event): void {
+    this.dispatchEvent(
+      MainViewEvents.baseFileChange({ value: this.selectValue(event) }),
+    );
   }
 
   private handleEditedSelectChange(event: Event): void {
-    const select = event.currentTarget as WaSelect | null;
-    const value = typeof select?.value === 'string' ? select.value : '';
-    this.dispatchEvent(MainViewEvents.editedFileChange({ value }));
+    this.dispatchEvent(
+      MainViewEvents.editedFileChange({ value: this.selectValue(event) }),
+    );
   }
 
   private handleCommitSelectChange(event: Event): void {
-    const select = event.currentTarget as WaSelect | null;
-    const value = typeof select?.value === 'string' ? select.value : '';
-    this.dispatchEvent(MainViewEvents.commitChange({ value }));
+    this.dispatchEvent(
+      MainViewEvents.commitChange({ value: this.selectValue(event) }),
+    );
   }
 
   private handleRefreshEditedFiles(): void {

--- a/packages/extension/src/webview/frontend/constants.ts
+++ b/packages/extension/src/webview/frontend/constants.ts
@@ -21,31 +21,6 @@ export type { SessionType, DocumentFileType, MultipleDocumentFileType };
 export const DOCUMENT_FILE_TYPES = DocumentFileTypeSchema.options;
 export { MULTIPLE_DOCUMENT_FILE_TYPES };
 
-export const ELEMENT_IDS = {
-  INSTRUCTION: 'instruction',
-  SESSION_TYPE_TOGGLE: 'sessionTypeToggle',
-  WORKFLOW_AGENT_SELECT: 'workflowAgent',
-  TOOL_USE_AGENT_SELECT: 'toolUseAgent',
-  MODEL_SELECT: 'model',
-  COMMIT_SELECT: 'commit',
-  OUTPUT_FILES: 'outputFiles',
-  OUTPUT_FILES_CONTAINER: 'outputFilesContainer',
-  TOGGLE_OUTPUT_FILES: 'toggleOutputFiles',
-  TOGGLE_AUTO_EXTRACT: 'toggleAutoExtract',
-  AUTO_EXTRACT_OPTIONS: 'autoExtractOptions',
-  TOGGLE_TOOL_CONFIG: 'toggleToolConfig',
-  TOOL_CONFIG_OPTIONS: 'toolConfigOptions',
-  BASE_FILE: 'baseFile',
-  EDITED_FILE: 'editedFile',
-  LATEXDIFFS_CONTENT: 'latexdiffsContent',
-  TOGGLE_LATEXDIFFS: 'toggleLatexdiffs',
-  API_KEY_BANNER: 'apiKeyBanner',
-  AGENT_CONFIG_BANNER: 'agentConfigBanner',
-  DEPENDENCY_BANNER: 'dependencyBanner',
-  GETTING_STARTED_BANNER: 'gettingStartedBanner',
-  LOGIN_BANNER: 'loginBanner',
-} as const;
-
 export function parseSessionType(
   sessionType: string | null | undefined,
 ): SessionType | undefined {

--- a/packages/extension/src/webview/frontend/fileDropHandler.ts
+++ b/packages/extension/src/webview/frontend/fileDropHandler.ts
@@ -39,17 +39,15 @@ function decodeFileUri(value: string): string | null {
   }
 }
 
-function normalizeLocalPath(value: string | null | undefined): string | null {
+function normalizeDroppedPath(
+  value: string | null | undefined,
+  fallbackToRaw: boolean,
+): string | null {
   if (!value) return null;
   const trimmed = value.trim();
   if (!trimmed || trimmed.startsWith('#')) return null;
-  return decodeFileUri(trimmed) ?? trimmed;
-}
-
-function normalizeFileUri(value: string): string | null {
-  const trimmed = value.trim();
-  if (!trimmed || trimmed.startsWith('#')) return null;
-  return decodeFileUri(trimmed);
+  const decoded = decodeFileUri(trimmed);
+  return fallbackToRaw ? (decoded ?? trimmed) : decoded;
 }
 
 function hasFileUri(dataTransfer: DataTransfer, type: string): boolean {
@@ -62,7 +60,9 @@ function hasFileUri(dataTransfer: DataTransfer, type: string): boolean {
   // files, so an empty read here is safe to accept.
   const data = dataTransfer.getData(type);
   if (!data) return true;
-  return data.split(/\r?\n/).some((line) => normalizeFileUri(line) != null);
+  return data
+    .split(/\r?\n/)
+    .some((line) => normalizeDroppedPath(line, false) != null);
 }
 
 /** Return true when the drag payload appears to contain files or file URIs. */
@@ -86,7 +86,7 @@ export function extractDroppedFilePaths(
 
   const paths = new Set<string>();
   for (const file of dataTransfer.files ?? []) {
-    const path = normalizeLocalPath((file as FileWithPath).path);
+    const path = normalizeDroppedPath((file as FileWithPath).path, true);
     if (path) paths.add(path);
   }
 
@@ -94,7 +94,7 @@ export function extractDroppedFilePaths(
     const data = dataTransfer.getData(type);
     if (!data) continue;
     for (const line of data.split(/\r?\n/)) {
-      const path = normalizeFileUri(line);
+      const path = normalizeDroppedPath(line, false);
       if (path) paths.add(path);
     }
   }

--- a/src/controllers/mainView/MainViewDroppedFilesController.ts
+++ b/src/controllers/mainView/MainViewDroppedFilesController.ts
@@ -34,11 +34,12 @@ export interface MainViewDroppedFileAttachmentInput {
 export function planMainViewDroppedFileAttachments(
   input: MainViewDroppedFileAttachmentInput,
 ): MainViewDroppedFileAttachmentPlan {
-  const grouped: Record<MainViewAttachableDropCategory, Set<string>> = {
-    input: new Set(),
-    context: new Set(),
-    media: new Set(),
-  };
+  const grouped = Object.fromEntries(
+    MAIN_VIEW_ATTACHABLE_DROP_CATEGORIES.map((category) => [
+      category,
+      new Set<string>(),
+    ]),
+  ) as Record<MainViewAttachableDropCategory, Set<string>>;
   let rejectedCount = 0;
 
   for (const filePath of input.paths) {
@@ -56,11 +57,12 @@ export function planMainViewDroppedFileAttachments(
     grouped[category].add(filePath);
   }
 
-  const filesByCategory = {
-    input: [...grouped.input],
-    context: [...grouped.context],
-    media: [...grouped.media],
-  };
+  const filesByCategory = Object.fromEntries(
+    MAIN_VIEW_ATTACHABLE_DROP_CATEGORIES.map((category) => [
+      category,
+      [...grouped[category]],
+    ]),
+  ) as Record<MainViewAttachableDropCategory, string[]>;
 
   return {
     filesByCategory,

--- a/src/controllers/settingsView/LatexConfigPersistenceController.ts
+++ b/src/controllers/settingsView/LatexConfigPersistenceController.ts
@@ -13,11 +13,6 @@ import {
   type LatexConfigValues,
 } from '@shared/schemas/settingsViewMessages';
 
-export type LatexConfigPersistenceEntry = {
-  field: LatexConfigField;
-  key: WorkspaceStateKey;
-};
-
 export type LatexConfigPersistenceUpdatePlan =
   | {
       ok: true;
@@ -33,24 +28,15 @@ export type LatexConfigPersistenceUpdatePlan =
 
 /** Plans storage-backed LaTeX config reads and writes without host side effects. */
 export class LatexConfigPersistenceController {
-  getEntries(): LatexConfigPersistenceEntry[] {
-    return (
-      Object.entries(LATEX_FIELD_TO_KEY) as [
-        LatexConfigField,
-        WorkspaceStateKey,
-      ][]
-    ).map(([field, key]) => ({
-      field,
-      key,
-    }));
-  }
-
   buildConfigValues(
     readStoredValue: (key: WorkspaceStateKey) => unknown,
   ): LatexConfigValues {
     const values: Partial<Record<LatexConfigField, unknown>> = {};
 
-    for (const { field, key } of this.getEntries()) {
+    for (const [field, key] of Object.entries(LATEX_FIELD_TO_KEY) as [
+      LatexConfigField,
+      WorkspaceStateKey,
+    ][]) {
       const stored = readStoredValue(key);
       if (stored === undefined) continue;
 

--- a/src/controllers/settingsView/ProfileMessageBuilder.ts
+++ b/src/controllers/settingsView/ProfileMessageBuilder.ts
@@ -47,22 +47,25 @@ export async function buildProfileMessage(
   const providerKeyStatuses = await deps.getProviderKeyStatuses();
   const globalStreamingDefault = getGlobalStreaming();
   const tierConstants = { ultra: ULTRA_TIER, max: MAX_TIER };
+  const base = {
+    command: PROFILE_VIEW_COMMANDS.UPDATE_PROFILE,
+    tierConstants,
+    providerKeyStatuses,
+    globalStreamingDefault,
+  };
 
   if (!authenticated) {
     return {
-      command: PROFILE_VIEW_COMMANDS.UPDATE_PROFILE,
+      ...base,
       authenticated: false,
       user: null,
       tier: FREE_TIER,
       permissions: [],
       remoteAgents: [],
       apiAccessMode: 'personal',
-      tierConstants,
       accessExpiresAt: null,
       spendingStatus: null,
       quotaAutoSwitched: false,
-      providerKeyStatuses,
-      globalStreamingDefault,
     };
   }
 
@@ -114,18 +117,15 @@ export async function buildProfileMessage(
   }
 
   return {
-    command: PROFILE_VIEW_COMMANDS.UPDATE_PROFILE,
+    ...base,
     authenticated: true,
     user: { email: user?.email ?? 'N/A', id: user?.id ?? '' },
     tier,
     permissions,
     remoteAgents,
     apiAccessMode,
-    tierConstants,
     accessExpiresAt,
     spendingStatus,
     quotaAutoSwitched,
-    providerKeyStatuses,
-    globalStreamingDefault,
   };
 }

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -167,37 +167,22 @@ export function setOutputChannelFactory(
   mainOutputChannel = null;
 }
 
-export function debug(
+type LogFn = (
   channel: string,
   message: string,
-  options: LogUtilsOptions = {},
-): void {
-  logAt('debug', channel, message, options);
+  options?: LogUtilsOptions,
+) => void;
+
+/** Build a level-bound forwarder onto {@link logAt}. */
+function makeLogFn(level: LogLevel): LogFn {
+  return (channel, message, options = {}) =>
+    logAt(level, channel, message, options);
 }
 
-export function info(
-  channel: string,
-  message: string,
-  options: LogUtilsOptions = {},
-): void {
-  logAt('info', channel, message, options);
-}
-
-export function warn(
-  channel: string,
-  message: string,
-  options: LogUtilsOptions = {},
-): void {
-  logAt('warn', channel, message, options);
-}
-
-export function error(
-  channel: string,
-  message: string,
-  options: LogUtilsOptions = {},
-): void {
-  logAt('error', channel, message, options);
-}
+export const debug = makeLogFn(LOG_LEVELS.DEBUG);
+export const info = makeLogFn(LOG_LEVELS.INFO);
+export const warn = makeLogFn(LOG_LEVELS.WARN);
+export const error = makeLogFn(LOG_LEVELS.ERROR);
 
 // ─── Trace subscriber ────────────────────────────────────────────────────
 

--- a/src/shared/commands/accelerators.ts
+++ b/src/shared/commands/accelerators.ts
@@ -40,54 +40,46 @@ export function formatDesktopAccelerator(
   return parts.join(isMac ? '' : '+');
 }
 
+const ELECTRON_ACCELERATOR_PARTS: Record<string, string> = {
+  cmd: 'Command',
+  ctrl: 'Control',
+  option: 'Option',
+  alt: 'Alt',
+  shift: 'Shift',
+  enter: 'Enter',
+  escape: 'Escape',
+  space: 'Space',
+  tab: 'Tab',
+};
+
 function toElectronAcceleratorPart(part: string): string {
   const normalized = part.trim().toLowerCase();
-  switch (normalized) {
-    case 'cmd':
-      return 'Command';
-    case 'ctrl':
-      return 'Control';
-    case 'option':
-      return 'Option';
-    case 'alt':
-      return 'Alt';
-    case 'shift':
-      return 'Shift';
-    case 'enter':
-      return 'Enter';
-    case 'escape':
-      return 'Escape';
-    case 'space':
-      return 'Space';
-    case 'tab':
-      return 'Tab';
-    default:
-      if (/^f\d{1,2}$/.test(normalized)) return normalized.toUpperCase();
-      return normalized.length === 1 ? normalized.toUpperCase() : normalized;
-  }
+  const mapped = ELECTRON_ACCELERATOR_PARTS[normalized];
+  if (mapped) return mapped;
+  if (/^f\d{1,2}$/.test(normalized)) return normalized.toUpperCase();
+  return normalized.length === 1 ? normalized.toUpperCase() : normalized;
 }
+
+// Each entry maps a token to its [mac symbol, non-mac label] display forms.
+const DISPLAY_ACCELERATOR_PARTS: Record<
+  string,
+  readonly [mac: string, nonMac: string]
+> = {
+  cmd: ['⌘', 'Cmd'],
+  command: ['⌘', 'Cmd'],
+  ctrl: ['⌃', 'Ctrl'],
+  control: ['⌃', 'Ctrl'],
+  alt: ['⌥', 'Alt'],
+  option: ['⌥', 'Alt'],
+  shift: ['⇧', 'Shift'],
+};
 
 function toDisplayAcceleratorPart(
   part: string,
   platform: NodeJS.Platform,
 ): string {
-  const normalized = part.trim().toLowerCase();
-  const isMac = platform === 'darwin';
-  switch (normalized) {
-    case 'cmd':
-    case 'command':
-      return isMac ? '⌘' : 'Cmd';
-    case 'ctrl':
-    case 'control':
-      return isMac ? '⌃' : 'Ctrl';
-    case 'alt':
-    case 'option':
-      return isMac ? '⌥' : 'Alt';
-    case 'shift':
-      return isMac ? '⇧' : 'Shift';
-    default: {
-      const trimmed = part.trim();
-      return trimmed.length === 1 ? trimmed.toUpperCase() : trimmed;
-    }
-  }
+  const mapped = DISPLAY_ACCELERATOR_PARTS[part.trim().toLowerCase()];
+  if (mapped) return platform === 'darwin' ? mapped[0] : mapped[1];
+  const trimmed = part.trim();
+  return trimmed.length === 1 ? trimmed.toUpperCase() : trimmed;
 }

--- a/src/shared/mainView/actionPlanner.ts
+++ b/src/shared/mainView/actionPlanner.ts
@@ -231,12 +231,7 @@ export function planLatexdiffVC(
 // LatexdiffVC Pack/Clean
 // ============================================================
 
-export interface LatexdiffVCPackState {
-  readonly inputFile: string;
-  readonly baseFile: string;
-  readonly commitHash: string;
-}
-
+// Shares LatexdiffVCState's fields (inputFile, baseFile, commitHash).
 export type LatexdiffVCPackPayload = {
   inputFile: string;
   baseFile: string;
@@ -245,7 +240,7 @@ export type LatexdiffVCPackPayload = {
 };
 
 export function planLatexdiffVCPack(
-  state: LatexdiffVCPackState,
+  state: LatexdiffVCState,
   action: 'pack' | 'clean',
 ): ActionSuccess<LatexdiffVCPackPayload> {
   const command =

--- a/src/shared/markdown/createMarkdownProcessor.ts
+++ b/src/shared/markdown/createMarkdownProcessor.ts
@@ -124,25 +124,32 @@ const MATH_SPAN_PATTERNS: readonly RegExp[] = [
   /(?<!\\)\$(?!\$)[^\n$]+?(?<!\\)\$/g, // $ … $  (inline, single line, both $ unescaped)
 ];
 
-function protectLatexMath(content: string): {
-  content: string;
-  spans: string[];
-} {
-  const spans: string[] = [];
+// Replace every match of `patterns` with an indexed `@@<tag>-N@@` placeholder,
+// returning the captured matches so restorePlaceholders can reinstate them.
+function protectByPatterns(
+  content: string,
+  patterns: readonly RegExp[],
+  tag: string,
+): { content: string; items: string[] } {
+  const items: string[] = [];
   let out = content;
-  for (const pattern of MATH_SPAN_PATTERNS) {
+  for (const pattern of patterns) {
     out = out.replaceAll(pattern, (match) => {
-      const index = spans.push(match) - 1;
-      return `@@LATEX-MATH-${index}@@`;
+      const index = items.push(match) - 1;
+      return `@@${tag}-${index}@@`;
     });
   }
-  return { content: out, spans };
+  return { content: out, items };
 }
 
-function restoreLatexMath(content: string, spans: string[]): string {
-  return content.replaceAll(MATH_PLACEHOLDER, (match, rawIndex) => {
-    const span = spans[Number(rawIndex)];
-    return span ?? match;
+function restorePlaceholders(
+  content: string,
+  placeholder: RegExp,
+  items: string[],
+): string {
+  return content.replaceAll(placeholder, (match, rawIndex) => {
+    const item = items[Number(rawIndex)];
+    return item ?? match;
   });
 }
 
@@ -156,25 +163,6 @@ const MACRO_PLACEHOLDER = /@@LATEX-MACRO-(\d+)@@/g;
 // markdown escape in math output. We deliberately exclude `\$` `\#` `\&` `\%`
 // `\_` `\*` etc., which carry real markdown-escape semantics.
 const LATEX_MACRO = /\\([,;:!(){}[\]])/g;
-
-function protectLatexMacros(content: string): {
-  content: string;
-  macros: string[];
-} {
-  const macros: string[] = [];
-  const protectedContent = content.replaceAll(LATEX_MACRO, (match) => {
-    const index = macros.push(match) - 1;
-    return `@@LATEX-MACRO-${index}@@`;
-  });
-  return { content: protectedContent, macros };
-}
-
-function restoreLatexMacros(content: string, macros: string[]): string {
-  return content.replaceAll(MACRO_PLACEHOLDER, (match, rawIndex) => {
-    const macro = macros[Number(rawIndex)];
-    return macro ?? match;
-  });
-}
 
 /** FNV-1a hash → base-36 string. Cheap, no crypto needs here. */
 function hashContent(str: string): string {
@@ -211,12 +199,12 @@ export function createMarkdownProcessor(
     // reverse so a ref placeholder revealed inside a restored span is still
     // formatted. After span protection, only out-of-span macros remain to net.
     const { content: refProtected, refs } = protectLatexReferences(content);
-    const { content: mathProtected, spans } = config.protectLatexMath
-      ? protectLatexMath(refProtected)
-      : { content: refProtected, spans: [] };
-    const { content: protectedContent, macros } = config.protectLatexMath
-      ? protectLatexMacros(mathProtected)
-      : { content: mathProtected, macros: [] };
+    const { content: mathProtected, items: spans } = config.protectLatexMath
+      ? protectByPatterns(refProtected, MATH_SPAN_PATTERNS, 'LATEX-MATH')
+      : { content: refProtected, items: [] };
+    const { content: protectedContent, items: macros } = config.protectLatexMath
+      ? protectByPatterns(mathProtected, [LATEX_MACRO], 'LATEX-MACRO')
+      : { content: mathProtected, items: [] };
     // OpenAI reasoning summaries sometimes omit the line break before a bold
     // heading mid-sentence (".**Heading**" → no break). Force one.
     const formatted = protectedContent.replaceAll(/\.(\*\*[A-Z])/g, '.\n$1');
@@ -224,8 +212,8 @@ export function createMarkdownProcessor(
     const restoreProtectedLatex = (value: string): string => {
       let restored = value;
       if (config.protectLatexMath) {
-        restored = restoreLatexMacros(restored, macros);
-        restored = restoreLatexMath(restored, spans);
+        restored = restorePlaceholders(restored, MACRO_PLACEHOLDER, macros);
+        restored = restorePlaceholders(restored, MATH_PLACEHOLDER, spans);
       }
       return restoreLatexReferences(restored, refs, format);
     };

--- a/src/shared/progressView/backend/streamInfoUtils.ts
+++ b/src/shared/progressView/backend/streamInfoUtils.ts
@@ -57,7 +57,7 @@ export function buildStreamInfo(
     hints.creationTimestamp ??
     Date.now();
 
-  const workingDirectory = config?.workingDirectory ?? undefined;
+  const workingDirectory = config?.workingDirectory;
   let worktreeInfo;
   if (workingDirectory) {
     worktreeInfo = peekWorktreeInfo(workingDirectory);
@@ -67,12 +67,7 @@ export function buildStreamInfo(
   return buildStreamTabInfo({
     streamId: id,
     config,
-    hints: {
-      agent: hints.agent,
-      agentCategory: hints.agentCategory,
-      inputFile: hints.inputFile,
-      isRemote: hints.isRemote,
-    },
+    hints,
     creationTimestamp,
     executionId: state.snapshots.getExecutionId(id) ?? hints.executionId,
     parentStreamId:

--- a/src/shared/schemas/agent.ts
+++ b/src/shared/schemas/agent.ts
@@ -13,10 +13,7 @@ export const AgentCategory = {
 } as const;
 export type AgentCategory = (typeof AgentCategory)[keyof typeof AgentCategory];
 
-export const AgentCategorySchema = z.enum([
-  AgentCategory.Workflow,
-  AgentCategory.ToolUse,
-]);
+export const AgentCategorySchema = z.enum(AgentCategory);
 
 export const AGENT_SOURCE = {
   CUSTOM: 'custom',
@@ -26,12 +23,7 @@ export const AGENT_SOURCE = {
 } as const;
 
 /** Single source of truth for agent source identifiers. */
-export const AgentSourceSchema = z.enum([
-  AGENT_SOURCE.CUSTOM,
-  AGENT_SOURCE.BUILT_IN_WORKFLOW,
-  AGENT_SOURCE.BUILT_IN_TOOL_USE,
-  AGENT_SOURCE.REMOTE,
-]);
+export const AgentSourceSchema = z.enum(AGENT_SOURCE);
 
 export type AgentSourceType = z.infer<typeof AgentSourceSchema>;
 

--- a/src/shared/schemas/diffResult.ts
+++ b/src/shared/schemas/diffResult.ts
@@ -1,6 +1,11 @@
 import { z } from 'zod';
 
-import { FileLocationSchema, OutputFileInfoSchema } from './output';
+import {
+  type FileLocation,
+  FileLocationSchema,
+  type OutputFileInfo,
+  OutputFileInfoSchema,
+} from './output';
 import { getBasename } from '../utils/path';
 
 export const DiffStatusSchema = z.enum(['success', 'error']);
@@ -35,15 +40,13 @@ export const DiffResultDisplaySchema = DiffMetadataSchema.extend({
 
 export type DiffResultDisplay = z.infer<typeof DiffResultDisplaySchema>;
 
-function getAbsolutePath(
-  location: z.infer<typeof FileLocationSchema> | null,
-): string {
+function getAbsolutePath(location: FileLocation | null): string {
   return location?.absolutePath ?? '';
 }
 
 function getDisplayName(
-  revised: z.infer<typeof OutputFileInfoSchema>,
-  baseLocation: z.infer<typeof FileLocationSchema> | null,
+  revised: OutputFileInfo,
+  baseLocation: FileLocation | null,
 ): string {
   // Prefer original path from lineage
   const original = revised.lineage?.original;
@@ -159,39 +162,25 @@ export const LegacyDiffResultSchema = z
     };
   });
 
-/** Parse a diff result entry from either new or legacy format */
-function parseDiffResultEntry(
-  data: unknown,
-):
-  | { success: true; data: DiffResultDisplay }
-  | { success: false; error: string } {
+/** Parse a diff result entry from either new or legacy format, or null if neither matches. */
+function parseDiffResultEntry(data: unknown): DiffResultDisplay | null {
   // Try new format first (canonical)
   const newResult = DiffResultSchema.safeParse(data);
   if (newResult.success) {
-    return {
-      success: true,
-      data: transformDiffResultToDisplay(newResult.data),
-    };
+    return transformDiffResultToDisplay(newResult.data);
   }
 
   // Try legacy format (transforms to display)
   const legacyResult = LegacyDiffResultSchema.safeParse(data);
-  if (legacyResult.success) {
-    return { success: true, data: legacyResult.data };
-  }
-
-  return { success: false, error: 'Invalid diff result format' };
+  return legacyResult.success ? legacyResult.data : null;
 }
 
 /** Parse an array of diff result entries, skipping invalid ones */
 export function parseDiffResultEntries(data: unknown): DiffResultDisplay[] {
   if (!Array.isArray(data)) return [];
 
-  return data
-    .map((entry) => parseDiffResultEntry(entry))
-    .filter(
-      (result): result is { success: true; data: DiffResultDisplay } =>
-        result.success,
-    )
-    .map((result) => result.data);
+  return data.flatMap((entry) => {
+    const parsed = parseDiffResultEntry(entry);
+    return parsed ? [parsed] : [];
+  });
 }

--- a/src/shared/schemas/fileFields.ts
+++ b/src/shared/schemas/fileFields.ts
@@ -83,16 +83,21 @@ export function migrateLegacyContextFileFields(input: unknown): unknown {
   return obj;
 }
 
+/** The four canonical `*Files` list fields shared by every file-fields schema. */
+const fileListFields = {
+  inputFiles: z.array(z.string()).prefault([]),
+  contextFiles: z.array(z.string()).prefault([]),
+  mediaFiles: z.array(z.string()).prefault([]),
+  outputFiles: z.array(z.string()).prefault([]),
+};
+
 /**
  * Used by AgentConfig where `editedFile` may be null. The migration
  * shim is applied at the outer schema (not here) because ZodEffects
  * doesn't compose with `.merge()`/`.extend()`.
  */
 export const NullableFileFieldsSchema = z.object({
-  inputFiles: z.array(z.string()).prefault([]),
-  contextFiles: z.array(z.string()).prefault([]),
-  mediaFiles: z.array(z.string()).prefault([]),
-  outputFiles: z.array(z.string()).prefault([]),
+  ...fileListFields,
   editedFile: z.string().nullable().prefault(null),
 });
 
@@ -109,10 +114,7 @@ const nullishString = z
  * Uses transform to coerce null/undefined → ''.
  */
 export const UIFileFieldsSchema = z.object({
-  inputFiles: z.array(z.string()).prefault([]),
-  contextFiles: z.array(z.string()).prefault([]),
-  mediaFiles: z.array(z.string()).prefault([]),
-  outputFiles: z.array(z.string()).prefault([]),
+  ...fileListFields,
   editedFile: nullishString,
 });
 

--- a/src/shared/schemas/goal.ts
+++ b/src/shared/schemas/goal.ts
@@ -56,11 +56,10 @@ export function goalElapsedMs(goal: { createdAt: string }): number {
 
 /**
  * Duration of a goal. With only the live `active`/`paused` states, any
- * persisted record is in flight, so this is wall-clock time since start.
+ * persisted record is in flight, so this is wall-clock time since start
+ * (identical to `goalElapsedMs`).
  */
-export function goalDurationMs(goal: { createdAt: string }): number {
-  return goalElapsedMs(goal);
-}
+export const goalDurationMs = goalElapsedMs;
 
 /** Hour-aware duration formatter for Goal timings. */
 export const formatGoalTime = formatCompactDuration;

--- a/src/shared/schemas/log.ts
+++ b/src/shared/schemas/log.ts
@@ -9,12 +9,7 @@ export const LOG_LEVELS = {
   DEBUG: 'debug',
 } as const;
 
-export const LogLevelSchema = z.enum([
-  LOG_LEVELS.ERROR,
-  LOG_LEVELS.WARN,
-  LOG_LEVELS.INFO,
-  LOG_LEVELS.DEBUG,
-]);
+export const LogLevelSchema = z.enum(LOG_LEVELS);
 export type LogLevel = z.infer<typeof LogLevelSchema>;
 
 /** Terminal states for finalizing log groups (subset of TaskGroupStatus) */
@@ -23,10 +18,7 @@ export const END_GROUP_STATUS = {
   STOPPED: 'stopped',
 } as const;
 
-export const EndGroupStatusSchema = z.enum([
-  END_GROUP_STATUS.ERROR,
-  END_GROUP_STATUS.STOPPED,
-]);
+export const EndGroupStatusSchema = z.enum(END_GROUP_STATUS);
 export type EndGroupStatus = z.infer<typeof EndGroupStatusSchema>;
 
 type _AssertEndGroupStatusSubset = EndGroupStatus extends TaskGroupStatus
@@ -53,25 +45,7 @@ export const MESSAGE_TYPES = {
   DEFAULT: 'default',
 } as const;
 
-export const MessageTypeSchema = z.enum([
-  MESSAGE_TYPES.THINKING,
-  MESSAGE_TYPES.SCRATCHPAD,
-  MESSAGE_TYPES.FILE_LIST,
-  MESSAGE_TYPES.MISSING_OUTPUTS,
-  MESSAGE_TYPES.LATEXDIFF,
-  MESSAGE_TYPES.STATISTICS,
-  MESSAGE_TYPES.TOOL_USE,
-  MESSAGE_TYPES.WEB_SEARCH,
-  MESSAGE_TYPES.WEB_FETCH,
-  MESSAGE_TYPES.MODEL_RESPONSE,
-  MESSAGE_TYPES.USER_MESSAGE,
-  MESSAGE_TYPES.PROGRESS_STATUS,
-  MESSAGE_TYPES.ERROR,
-  MESSAGE_TYPES.INTERNAL,
-  MESSAGE_TYPES.CONTEXT_MANAGEMENT,
-  MESSAGE_TYPES.CONTEXT_STATE,
-  MESSAGE_TYPES.DEFAULT,
-]);
+export const MessageTypeSchema = z.enum(MESSAGE_TYPES);
 
 export type MessageType = z.infer<typeof MessageTypeSchema>;
 
@@ -81,11 +55,7 @@ export const STREAM_LOG_ENTRY_TYPES = {
   GROUP_END: 'group-end',
 } as const;
 
-export const StreamLogEntryTypeSchema = z.enum([
-  STREAM_LOG_ENTRY_TYPES.LOG,
-  STREAM_LOG_ENTRY_TYPES.GROUP_START,
-  STREAM_LOG_ENTRY_TYPES.GROUP_END,
-]);
+export const StreamLogEntryTypeSchema = z.enum(STREAM_LOG_ENTRY_TYPES);
 
 export type StreamLogEntryType = z.infer<typeof StreamLogEntryTypeSchema>;
 

--- a/src/shared/schemas/progressView/inbound.ts
+++ b/src/shared/schemas/progressView/inbound.ts
@@ -12,6 +12,7 @@ import {
 } from '@shared/utils/dispatcher';
 
 import { SwitchViewMessageSchema } from '../commonViewMessages';
+import { commandOnly } from '../messageFactories';
 import {
   ExternalInquirySessionLinksSchema,
   ExternalInquiryThreadIdSchema,
@@ -33,37 +34,10 @@ const TrimmedStringSchema = z
   .transform((s) => s.trim())
   .pipe(z.string().min(1));
 
-const WebviewReadyMessageSchema = z.object({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.WEBVIEW_READY),
-});
-
-const InboundDeleteAllMessageSchema = z.object({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.DELETE_ALL),
-});
-
-const OpenProfileMessageSchema = z.object({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.OPEN_PROFILE),
-});
-
-const OpenMemoryViewMessageSchema = z.object({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.OPEN_MEMORY_VIEW),
-});
-
-const StartRecordingMessageSchema = z.object({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.START_RECORDING),
-});
-
-const StopRecordingMessageSchema = z.object({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.STOP_RECORDING),
-});
-
-const PopOutMessageSchema = z.object({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.POP_OUT),
-});
-
-const PopBackMessageSchema = z.object({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.POP_BACK),
-});
+/** StreamScopedBaseSchema plus a `command` literal, with no extra fields. */
+function streamScopedCommand<T extends string>(command: T) {
+  return StreamScopedBaseSchema.extend({ command: z.literal(command) });
+}
 
 const ThemeSetMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.THEME_SET),
@@ -73,58 +47,6 @@ const ThemeSetMessageSchema = z.object({
 const DebugModeSetMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.DEBUG_MODE_SET),
   debugMode: z.boolean(),
-});
-
-const SwitchStreamMessageSchema = StreamScopedBaseSchema.extend({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.SWITCH_STREAM),
-});
-
-const InboundDeleteStreamMessageSchema = StreamScopedBaseSchema.extend({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.DELETE_STREAM),
-});
-
-const StopStreamMessageSchema = StreamScopedBaseSchema.extend({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.STOP_STREAM),
-});
-
-const CompactResponseMessageSchema = StreamScopedBaseSchema.extend({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.COMPACT_RESPONSE),
-});
-
-const ResumeMessageSchema = StreamScopedBaseSchema.extend({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.RESUME),
-});
-
-const RunNewMessageSchema = StreamScopedBaseSchema.extend({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.RUN_NEW),
-});
-
-const DiffStreamMessageSchema = StreamScopedBaseSchema.extend({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.DIFF_STREAM),
-});
-
-const PackStreamMessageSchema = StreamScopedBaseSchema.extend({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.PACK_STREAM),
-});
-
-const CleanStreamMessageSchema = StreamScopedBaseSchema.extend({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.CLEAN_STREAM),
-});
-
-const RestoreStateMessageSchema = StreamScopedBaseSchema.extend({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.RESTORE_STATE),
-});
-
-const OpenTaskStorageMessageSchema = StreamScopedBaseSchema.extend({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.OPEN_TASK_STORAGE),
-});
-
-const RunCompileFixerMessageSchema = StreamScopedBaseSchema.extend({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.RUN_COMPILE_FIXER),
-});
-
-const GetFollowupOptionsMessageSchema = StreamScopedBaseSchema.extend({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.GET_FOLLOWUP_OPTIONS),
 });
 
 const FollowupConfigSchema = StreamScopedBaseSchema.extend({
@@ -139,10 +61,6 @@ const SetupFollowupMessageSchema = FollowupConfigSchema.extend({
 
 const RunFollowupMessageSchema = FollowupConfigSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.RUN_FOLLOWUP),
-});
-
-const CancelRetryRequestMessageSchema = StreamScopedBaseSchema.extend({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.CANCEL_RETRY_REQUEST),
 });
 
 const UseOwnApiKeyMessageSchema = StreamScopedBaseSchema.extend({
@@ -162,30 +80,6 @@ const UseOwnApiKeyMessageSchema = StreamScopedBaseSchema.extend({
    *  (Codex) and hit its usage limit. The handler turns off the "prefer
    *  ChatGPT subscription" preference so the retry uses the OpenAI key. */
   chatgptSubscription: z.boolean().optional(),
-});
-
-const ToggleToolEditApprovalBypassMessageSchema = StreamScopedBaseSchema.extend(
-  {
-    command: z.literal(PROGRESS_VIEW_COMMANDS.TOGGLE_TOOL_EDIT_APPROVAL_BYPASS),
-  },
-);
-
-const ToggleSuperYoloBypassMessageSchema = StreamScopedBaseSchema.extend({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.TOGGLE_SUPER_YOLO_BYPASS),
-});
-
-// Set-on (idempotent) super-yolo enable, the proposal counterpart to
-// ENABLE_APPROVAL_BYPASS: the inline "Super Yolo (this session)" prompt button
-// means "enable", never "flip", so it can't invert an already-on bypass that
-// was turned on from the stream header while the prompt was still visible.
-const EnableSuperYoloBypassMessageSchema = StreamScopedBaseSchema.extend({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.ENABLE_SUPER_YOLO_BYPASS),
-});
-
-// Set-on (idempotent) bypass enable, distinct from the shield's toggle: the
-// inline "Yolo (this session)" prompt button means "enable", never "flip".
-const EnableApprovalBypassMessageSchema = StreamScopedBaseSchema.extend({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.ENABLE_APPROVAL_BYPASS),
 });
 
 const SendFollowUpMessageSchema = StreamScopedBaseSchema.extend({
@@ -351,38 +245,47 @@ const GettingStartedActionMessageSchema = z.object({
 export const ProgressViewInboundMessageSchema = z.discriminatedUnion(
   'command',
   [
-    WebviewReadyMessageSchema,
+    commandOnly(PROGRESS_VIEW_COMMANDS.WEBVIEW_READY),
     SwitchViewMessageSchema,
     ThemeSetMessageSchema,
     DebugModeSetMessageSchema,
-    SwitchStreamMessageSchema,
-    InboundDeleteStreamMessageSchema,
-    InboundDeleteAllMessageSchema,
-    StopStreamMessageSchema,
-    CompactResponseMessageSchema,
-    ResumeMessageSchema,
-    RunNewMessageSchema,
-    DiffStreamMessageSchema,
-    PackStreamMessageSchema,
-    CleanStreamMessageSchema,
-    RestoreStateMessageSchema,
-    OpenTaskStorageMessageSchema,
-    RunCompileFixerMessageSchema,
+    streamScopedCommand(PROGRESS_VIEW_COMMANDS.SWITCH_STREAM),
+    streamScopedCommand(PROGRESS_VIEW_COMMANDS.DELETE_STREAM),
+    commandOnly(PROGRESS_VIEW_COMMANDS.DELETE_ALL),
+    streamScopedCommand(PROGRESS_VIEW_COMMANDS.STOP_STREAM),
+    streamScopedCommand(PROGRESS_VIEW_COMMANDS.COMPACT_RESPONSE),
+    streamScopedCommand(PROGRESS_VIEW_COMMANDS.RESUME),
+    streamScopedCommand(PROGRESS_VIEW_COMMANDS.RUN_NEW),
+    streamScopedCommand(PROGRESS_VIEW_COMMANDS.DIFF_STREAM),
+    streamScopedCommand(PROGRESS_VIEW_COMMANDS.PACK_STREAM),
+    streamScopedCommand(PROGRESS_VIEW_COMMANDS.CLEAN_STREAM),
+    streamScopedCommand(PROGRESS_VIEW_COMMANDS.RESTORE_STATE),
+    streamScopedCommand(PROGRESS_VIEW_COMMANDS.OPEN_TASK_STORAGE),
+    streamScopedCommand(PROGRESS_VIEW_COMMANDS.RUN_COMPILE_FIXER),
     FilterStreamsMessageSchema,
     SendFollowUpMessageSchema,
     PolishFollowUpMessageSchema,
     RetryStreamRequestMessageSchema,
-    CancelRetryRequestMessageSchema,
+    streamScopedCommand(PROGRESS_VIEW_COMMANDS.CANCEL_RETRY_REQUEST),
     UseOwnApiKeyMessageSchema,
-    StartRecordingMessageSchema,
-    StopRecordingMessageSchema,
-    PopOutMessageSchema,
-    PopBackMessageSchema,
+    commandOnly(PROGRESS_VIEW_COMMANDS.START_RECORDING),
+    commandOnly(PROGRESS_VIEW_COMMANDS.STOP_RECORDING),
+    commandOnly(PROGRESS_VIEW_COMMANDS.POP_OUT),
+    commandOnly(PROGRESS_VIEW_COMMANDS.POP_BACK),
     ToolEditApprovalActionMessageSchema,
-    ToggleToolEditApprovalBypassMessageSchema,
-    ToggleSuperYoloBypassMessageSchema,
-    EnableSuperYoloBypassMessageSchema,
-    EnableApprovalBypassMessageSchema,
+    streamScopedCommand(
+      PROGRESS_VIEW_COMMANDS.TOGGLE_TOOL_EDIT_APPROVAL_BYPASS,
+    ),
+    streamScopedCommand(PROGRESS_VIEW_COMMANDS.TOGGLE_SUPER_YOLO_BYPASS),
+    // Set-on (idempotent) super-yolo enable, the proposal counterpart to
+    // ENABLE_APPROVAL_BYPASS: the inline "Super Yolo (this session)" prompt
+    // button means "enable", never "flip", so it can't invert an already-on
+    // bypass that was turned on from the stream header while the prompt was
+    // still visible.
+    streamScopedCommand(PROGRESS_VIEW_COMMANDS.ENABLE_SUPER_YOLO_BYPASS),
+    // Set-on (idempotent) bypass enable, distinct from the shield's toggle: the
+    // inline "Yolo (this session)" prompt button means "enable", never "flip".
+    streamScopedCommand(PROGRESS_VIEW_COMMANDS.ENABLE_APPROVAL_BYPASS),
     BashApprovalActionMessageSchema,
     AgentProposalActionMessageSchema,
     PlanApprovalActionMessageSchema,
@@ -390,8 +293,8 @@ export const ProgressViewInboundMessageSchema = z.discriminatedUnion(
     UserQuestionActionMessageSchema,
     RestoreProposalConfigMessageSchema,
     ShowInformationMessageSchema,
-    OpenProfileMessageSchema,
-    OpenMemoryViewMessageSchema,
+    commandOnly(PROGRESS_VIEW_COMMANDS.OPEN_PROFILE),
+    commandOnly(PROGRESS_VIEW_COMMANDS.OPEN_MEMORY_VIEW),
     OpenFileMessageSchema,
     OpenFileCompileMessageSchema,
     CompareOriginalMessageSchema,
@@ -400,7 +303,7 @@ export const ProgressViewInboundMessageSchema = z.discriminatedUnion(
     MergeFileMessageSchema,
     LatexdiffFileMessageSchema,
     OpenLabelMessageSchema,
-    GetFollowupOptionsMessageSchema,
+    streamScopedCommand(PROGRESS_VIEW_COMMANDS.GET_FOLLOWUP_OPTIONS),
     SetupFollowupMessageSchema,
     RunFollowupMessageSchema,
     GettingStartedActionMessageSchema,

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -13,15 +13,7 @@ export const STREAM_STATUS = {
   INITIALIZING: 'initializing',
 } as const;
 
-export const StreamStatusSchema = z.enum([
-  STREAM_STATUS.RUNNING,
-  STREAM_STATUS.ERROR,
-  STREAM_STATUS.STOPPED,
-  STREAM_STATUS.READY,
-  STREAM_STATUS.WAITING,
-  STREAM_STATUS.RESUMING,
-  STREAM_STATUS.INITIALIZING,
-]);
+export const StreamStatusSchema = z.enum(STREAM_STATUS);
 export type StreamStatus = z.infer<typeof StreamStatusSchema>;
 
 /**
@@ -131,11 +123,7 @@ export const EXECUTION_STATUS = {
   ERROR: 'error',
 } as const;
 
-export const ExecutionStatusSchema = z.enum([
-  EXECUTION_STATUS.COMPLETED,
-  EXECUTION_STATUS.INTERRUPTED,
-  EXECUTION_STATUS.ERROR,
-]);
+export const ExecutionStatusSchema = z.enum(EXECUTION_STATUS);
 export type ExecutionStatus = z.infer<typeof ExecutionStatusSchema>;
 
 /**
@@ -154,11 +142,7 @@ export const RUN_OUTCOME = {
   FAILED: 'failed',
 } as const;
 
-export const RunOutcomeSchema = z.enum([
-  RUN_OUTCOME.COMPLETED,
-  RUN_OUTCOME.CANCELLED,
-  RUN_OUTCOME.FAILED,
-]);
+export const RunOutcomeSchema = z.enum(RUN_OUTCOME);
 export type RunOutcome = z.infer<typeof RunOutcomeSchema>;
 
 export const WORKTREE_PR_STATE = {
@@ -168,12 +152,7 @@ export const WORKTREE_PR_STATE = {
   DRAFT: 'draft',
 } as const;
 
-export const WorktreePRStateSchema = z.enum([
-  WORKTREE_PR_STATE.OPEN,
-  WORKTREE_PR_STATE.MERGED,
-  WORKTREE_PR_STATE.CLOSED,
-  WORKTREE_PR_STATE.DRAFT,
-]);
+export const WorktreePRStateSchema = z.enum(WORKTREE_PR_STATE);
 export type WorktreePRState = z.infer<typeof WorktreePRStateSchema>;
 
 export const WORKTREE_CI_STATE = {
@@ -184,13 +163,7 @@ export const WORKTREE_CI_STATE = {
   UNKNOWN: 'unknown',
 } as const;
 
-export const WorktreeCIStateSchema = z.enum([
-  WORKTREE_CI_STATE.PENDING,
-  WORKTREE_CI_STATE.RUNNING,
-  WORKTREE_CI_STATE.SUCCESS,
-  WORKTREE_CI_STATE.FAILURE,
-  WORKTREE_CI_STATE.UNKNOWN,
-]);
+export const WorktreeCIStateSchema = z.enum(WORKTREE_CI_STATE);
 export type WorktreeCIState = z.infer<typeof WorktreeCIStateSchema>;
 
 export const WorktreePRInfoSchema = z.object({

--- a/src/shared/schemas/streamData.ts
+++ b/src/shared/schemas/streamData.ts
@@ -147,13 +147,11 @@ export function flattenLegacyRuns(
       return picked as Record<string, unknown>;
     }
   }
-  let latest: Record<string, unknown> | null = null;
-  for (const value of Object.values(raw)) {
-    if (value && typeof value === 'object' && !Array.isArray(value)) {
-      latest = value as Record<string, unknown>;
-    }
-  }
-  return latest ?? {};
+  const latest = Object.values(raw).findLast(
+    (value) =>
+      value != null && typeof value === 'object' && !Array.isArray(value),
+  );
+  return (latest as Record<string, unknown> | undefined) ?? {};
 }
 
 // ============================================================================

--- a/src/shared/schemas/todo.ts
+++ b/src/shared/schemas/todo.ts
@@ -2,16 +2,14 @@ import { z } from 'zod';
 
 import { StreamTabIdSchema } from './identifiers';
 
-const todoStatusValues = ['pending', 'in_progress', 'completed'] as const;
-
 export const TODO_STATUS = {
   PENDING: 'pending',
   IN_PROGRESS: 'in_progress',
   COMPLETED: 'completed',
-} as const satisfies Record<string, (typeof todoStatusValues)[number]>;
+} as const;
 
 export const TodoStatusSchema = z
-  .enum(todoStatusValues)
+  .enum(TODO_STATUS)
   .describe('Current status of the task');
 export type TodoStatus = z.infer<typeof TodoStatusSchema>;
 

--- a/src/shared/state/PersistedState.ts
+++ b/src/shared/state/PersistedState.ts
@@ -101,34 +101,38 @@ export class PersistedState<T extends Record<string, unknown>> {
     if (result.success) {
       return result.data;
     }
-    // Fall back to schema defaults via safeParse so a schema whose defaults
-    // don't cover every field can't throw out of a caller's constructor — a
-    // stale or malformed PersistedState key must never block webview
-    // activation or extension startup. Also persist the reset so the bad
-    // value is replaced and the next load doesn't keep hitting this path.
+    // Fall back to schema defaults so a schema whose defaults don't cover every
+    // field can't throw out of a caller's constructor — a stale or malformed
+    // PersistedState key must never block webview activation or extension
+    // startup. Also persist the reset so the bad value is replaced and the next
+    // load doesn't keep hitting this path.
+    console.warn(
+      `[PersistedState] Invalid stored data for ${this.key}, resetting.`,
+      {
+        storedType: describeStored(stored),
+        issues: summarizeIssues(result.error),
+      },
+    );
+    const defaults = this.resolveDefaults();
+    this.storage.set(this.key, defaults);
+    return defaults;
+  }
+
+  /**
+   * Resolve the schema's default state by parsing an empty object. Returns the
+   * parsed defaults, or an empty object (with a warning) when the schema's
+   * defaults don't cover every field.
+   */
+  private resolveDefaults(): T {
     const defaultResult = this.schema.safeParse({});
     if (defaultResult.success) {
-      console.warn(
-        `[PersistedState] Invalid stored data for ${this.key}, resetting.`,
-        {
-          storedType: describeStored(stored),
-          issues: summarizeIssues(result.error),
-        },
-      );
-      this.storage.set(this.key, defaultResult.data);
       return defaultResult.data;
     }
     console.warn(
-      `[PersistedState] Invalid stored data and no default for ${this.key}; using empty object.`,
-      {
-        storedType: describeStored(stored),
-        storedIssues: summarizeIssues(result.error),
-        defaultIssues: summarizeIssues(defaultResult.error),
-      },
+      `[PersistedState] No schema defaults for ${this.key}; using empty object.`,
+      { issues: summarizeIssues(defaultResult.error) },
     );
-    const empty = {} as T;
-    this.storage.set(this.key, empty);
-    return empty;
+    return {} as T;
   }
 
   /** Get current state (shallow copy) */
@@ -154,16 +158,7 @@ export class PersistedState<T extends Record<string, unknown>> {
 
   /** Reset to schema defaults */
   reset(): void {
-    const defaultResult = this.schema.safeParse({});
-    if (defaultResult.success) {
-      this.state = defaultResult.data;
-    } else {
-      console.warn(
-        `[PersistedState] Reset has no schema defaults for ${this.key}; using empty object.`,
-        { issues: summarizeIssues(defaultResult.error) },
-      );
-      this.state = {} as T;
-    }
+    this.state = this.resolveDefaults();
     this.storage.set(this.key, this.state);
   }
 }

--- a/src/shared/state/ToggleStateStore.ts
+++ b/src/shared/state/ToggleStateStore.ts
@@ -2,12 +2,9 @@
  * Manages toggle/collapse states with optional persistence callback.
  */
 export class ToggleStateStore {
-  private states: Map<string, boolean> = new Map();
-  private saveCallback?: () => void;
+  private states = new Map<string, boolean>();
 
-  constructor(saveCallback?: () => void) {
-    this.saveCallback = saveCallback;
-  }
+  constructor(private readonly saveCallback?: () => void) {}
 
   set(id: string, value: boolean): void {
     if (!id) return;

--- a/src/shared/utils/icons.ts
+++ b/src/shared/utils/icons.ts
@@ -93,9 +93,8 @@ export function getAgentCategoryDecorator(
   agentCategory: string | undefined,
 ): (typeof AGENT_DECORATORS.agentCategories)[AgentCategory] {
   const categories = AGENT_DECORATORS.agentCategories;
-  const isValidCategory =
-    agentCategory !== undefined && agentCategory in categories;
-  return isValidCategory
-    ? categories[agentCategory as AgentCategory]
-    : categories.workflow;
+  return (
+    (agentCategory && categories[agentCategory as AgentCategory]) ||
+    categories.workflow
+  );
 }

--- a/src/shared/wa/commandPalette.ts
+++ b/src/shared/wa/commandPalette.ts
@@ -138,12 +138,6 @@ export function isCommandPaletteShortcut(event: KeyboardEvent): boolean {
   );
 }
 
-function resolveCommandPaletteEntries(
-  entries: CommandPaletteEntrySource,
-): CommandPaletteEntry[] {
-  return [...(typeof entries === 'function' ? entries() : entries)];
-}
-
 export function createCommandPalette({
   document,
   entries,
@@ -185,25 +179,18 @@ export function createCommandPalette({
   const handleFilterKeydown = (event: KeyboardEvent): void => {
     switch (event.key) {
       case 'ArrowDown':
+      case 'ArrowUp': {
         event.preventDefault();
+        const delta = event.key === 'ArrowDown' ? 1 : -1;
         activeIndex = getNextCommandPaletteIndex(
           activeIndex,
           visibleEntries.length,
-          1,
+          delta,
         );
         renderTemplate();
         scrollActiveItemIntoView();
         break;
-      case 'ArrowUp':
-        event.preventDefault();
-        activeIndex = getNextCommandPaletteIndex(
-          activeIndex,
-          visibleEntries.length,
-          -1,
-        );
-        renderTemplate();
-        scrollActiveItemIntoView();
-        break;
+      }
       case 'Enter':
         event.preventDefault();
         executeActiveCommand();
@@ -223,11 +210,7 @@ export function createCommandPalette({
   };
 
   const inputClass = classes?.input;
-  const listClass = classes?.list;
   const itemClass = classes?.item;
-  const labelClass = classes?.label;
-  const metaClass = classes?.meta;
-  const emptyClass = classes?.empty;
 
   const renderTemplate = (): void => {
     render(
@@ -243,9 +226,9 @@ export function createCommandPalette({
           @input=${handleFilterInput}
           @keydown=${handleFilterKeydown}
         ></wa-input>
-        <div class=${listClass ?? ''} role="listbox">
+        <div class=${classes?.list ?? ''} role="listbox">
           ${visibleEntries.length === 0
-            ? html`<div class=${emptyClass ?? ''} role="status">
+            ? html`<div class=${classes?.empty ?? ''} role="status">
                 No matching commands
               </div>`
             : nothing}
@@ -263,8 +246,8 @@ export function createCommandPalette({
                 @mouseenter=${handleItemMouseEnter(index)}
                 @click=${handleItemClick(entry)}
               >
-                <span class=${labelClass ?? ''}>${entry.label}</span>
-                <span class=${metaClass ?? ''}>${entry.meta ?? ''}</span>
+                <span class=${classes?.label ?? ''}>${entry.label}</span>
+                <span class=${classes?.meta ?? ''}>${entry.meta ?? ''}</span>
               </button>
             `,
           )}
@@ -286,7 +269,7 @@ export function createCommandPalette({
   const open = (): void => {
     if (canOpen?.() === false) return;
     if (dialog.open) return;
-    allEntries = resolveCommandPaletteEntries(entries);
+    allEntries = [...(typeof entries === 'function' ? entries() : entries)];
     query = '';
     visibleEntries = [...allEntries];
     activeIndex = visibleEntries.length > 0 ? 0 : -1;
@@ -312,7 +295,7 @@ export function createCommandPalette({
   // no palette descendant is focused. canOpen guards against modal dialogs
   // (e.g. the onboarding walkthrough) stealing the shortcut while visible.
   if (isShortcut) {
-    document.defaultView?.addEventListener('keydown', (event) => {
+    view?.addEventListener('keydown', (event) => {
       if (!isShortcut(event)) return;
       if (isTextEntryShortcutTarget(view, document, event)) return;
       event.preventDefault();

--- a/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
+++ b/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
@@ -144,7 +144,7 @@ describe('desktop renderer shell — three-pane layout (PRD § 6 + § 7.D)', () 
     expect(rendererMain).toMatch(
       /waIcon\('arrow-left',\s*\{\s*label:\s*'Back to launcher'\s*\}\)/,
     );
-    expect(rendererMain).toContain('waIcon(spec.icon, { label: spec.label })');
+    expect(rendererMain).toContain("waIcon('file-lines', { label: 'Logs' })");
     expect(rendererMain).not.toContain('TEXRA_ICON_LIBRARY');
     expect(rendererMain).not.toContain('desktop-back-button');
     expect(rendererMain).not.toContain(

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -69,7 +69,6 @@ const ReadInputSchema = z.strictObject({
 export type ReadInput = z.infer<typeof ReadInputSchema>;
 
 type AttachmentKind = 'pdf' | 'image' | 'document';
-type AttachmentConfig = { kind: AttachmentKind; label: string };
 
 export class ReadFileTool extends defineTool({
   name: 'read_file',
@@ -85,11 +84,11 @@ export class ReadFileTool extends defineTool({
     );
     const filePath = resolved.fsPath;
 
-    const attachmentConfig = this.getAttachmentConfig(resolved.absolute);
-    if (attachmentConfig) {
+    const attachmentKind = this.getAttachmentConfig(resolved.absolute);
+    if (attachmentKind) {
       const result = await this.returnBinaryAttachment(
         input,
-        attachmentConfig,
+        attachmentKind,
         resolved,
       );
       recordToolFileRead(filePath);
@@ -180,14 +179,14 @@ export class ReadFileTool extends defineTool({
     return totalLines;
   }
 
-  private getAttachmentConfig(filePath: string): AttachmentConfig | null {
+  private getAttachmentConfig(filePath: string): AttachmentKind | null {
     const mimeType = getMimeType(filePath)?.toLowerCase();
     // Keep extension detection case-insensitive so users can reference files regardless of casing.
     const extension = getExtensionLowercase(filePath);
 
     const isPdf = mimeType === 'application/pdf' || extension === '.pdf';
     if (isPdf) {
-      return { kind: 'pdf', label: 'PDF' };
+      return 'pdf';
     }
 
     // Treat SVG as an image attachment so vision-capable models can inspect its rendered appearance
@@ -195,7 +194,7 @@ export class ReadFileTool extends defineTool({
     const isImage =
       mimeType?.startsWith('image/') || IMAGE_EXTENSIONS.has(extension);
     if (isImage) {
-      return { kind: 'image', label: 'Image' };
+      return 'image';
     }
 
     // Office documents are binary formats that cannot be read as text.
@@ -203,7 +202,7 @@ export class ReadFileTool extends defineTool({
     const isDocument =
       OFFICE_EXTENSIONS.has(extension) || OFFICE_MIME_TYPES.has(mimeType ?? '');
     if (isDocument) {
-      return { kind: 'document', label: 'Document' };
+      return 'document';
     }
 
     return null;
@@ -211,17 +210,17 @@ export class ReadFileTool extends defineTool({
 
   private async returnBinaryAttachment(
     input: ReadInput,
-    config: AttachmentConfig,
+    kind: AttachmentKind,
     resolved: WorkspacePathResolution,
   ): Promise<ToolResult> {
-    const copy = ATTACHMENT_COPY[config.kind];
+    const copy = ATTACHMENT_COPY[kind];
     const attachment = await buildFileAttachment({
       filePath: resolved.fsPath,
-      description: `${config.label} returned by read_file tool.`,
+      description: `${copy.label} returned by read_file tool.`,
       resolved,
     });
 
-    const baseSummary = `Attached ${config.label} ${attachment.path}.`;
+    const baseSummary = `Attached ${copy.label} ${attachment.path}.`;
     const summary = input.range
       ? `${baseSummary} ${copy.rangeSummary}`
       : baseSummary;
@@ -251,24 +250,28 @@ const IMAGE_EXTENSIONS = new Set([
 const ATTACHMENT_COPY: Record<
   AttachmentKind,
   {
+    label: string;
     rangeSummary: string;
     rangeOutput: string;
     coreOutput: string;
   }
 > = {
   pdf: {
+    label: 'PDF',
     rangeSummary: 'Ignored requested line range because PDFs are binary.',
     rangeOutput: 'Line ranges are not supported when reading PDFs.',
     coreOutput:
       'Returned the PDF as a file attachment. Vision-capable models can analyze each page with text and visual context.',
   },
   image: {
+    label: 'Image',
     rangeSummary: 'Ignored requested line range because images are binary.',
     rangeOutput: 'Line ranges are not supported when reading images.',
     coreOutput:
       'Returned the image as a file attachment. Vision-capable models can analyze the visual content directly.',
   },
   document: {
+    label: 'Document',
     rangeSummary:
       'Ignored requested line range because office documents are binary.',
     rangeOutput: 'Line ranges are not supported when reading office documents.',

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -21,6 +21,7 @@ import {
   writeApprovedContent,
   type ToolEditApprovalResult,
 } from '@tools/approval/toolEditApproval';
+import { assertNever } from '@utils/core';
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
 import { isDirectory } from '@utils/files/fsEntryType';
 import { splitContentLines } from '@utils/text/stringUtils';
@@ -152,6 +153,8 @@ export class TextEditorTool extends defineTool({
         }
         logger.info(CHANNEL, `undo_edit: ${displayPath}`);
         return this.undoEdit(filePath, displayPath);
+      default:
+        return assertNever(command, 'Unrecognized TextEditor command');
     }
   }
 

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -56,7 +56,6 @@ const API_TYPE_TO_NAME = {
 } as const;
 
 type TextEditorApiType = keyof typeof API_TYPE_TO_NAME;
-type TextEditorName = (typeof API_TYPE_TO_NAME)[TextEditorApiType];
 
 export const TextEditorInputSchema = z.strictObject({
   command: z.enum(['view', 'create', 'str_replace', 'insert', 'undo_edit']),
@@ -86,9 +85,8 @@ export class TextEditorTool extends defineTool({
   description: 'Edit files using search and replace or insertion operations',
   schema: TextEditorInputSchema,
 }) {
-  // Tool type and name
+  // Tool API type
   private apiType: TextEditorApiType;
-  private name: TextEditorName;
 
   // File history for undo operations
   private fileHistory: Map<string, string[]> = new Map();
@@ -97,13 +95,6 @@ export class TextEditorTool extends defineTool({
     const name = API_TYPE_TO_NAME[apiType];
     super({ name });
     this.apiType = apiType;
-    this.name = name;
-  }
-
-  private getAllowedCommands(): string {
-    return this.apiType === 'text_editor_20250429'
-      ? 'view, create, str_replace, insert'
-      : 'view, create, str_replace, insert, undo_edit';
   }
 
   protected async execute(input: TextEditorInput): Promise<ToolResult> {
@@ -161,10 +152,6 @@ export class TextEditorTool extends defineTool({
         }
         logger.info(CHANNEL, `undo_edit: ${displayPath}`);
         return this.undoEdit(filePath, displayPath);
-      default:
-        throw new ToolError(
-          `Unrecognized command ${command}. The allowed commands for the ${this.name} tool are: ${this.getAllowedCommands()}`,
-        );
     }
   }
 

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -14,6 +14,9 @@ import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 // Local imports - errors
 import { classifyAgentError, toErrorMessage } from '@common/errors';
 
+// Local imports - constants
+import { deriveRunOutcome } from '@common/constants/streamStatus';
+
 // Local imports - shared
 import type { ExecutionId, StreamTabId, StorageKey } from '@shared/schemas';
 import { STREAM_STATUS } from '@shared/schemas';
@@ -187,12 +190,10 @@ function finalizeChildStream(args: FinalizeChildStreamArgs): void {
       : hasError
         ? STREAM_STATUS.ERROR
         : requestedStatus;
-  const outcome =
-    finalStatus === STREAM_STATUS.ERROR
-      ? 'failed'
-      : finalStatus === STREAM_STATUS.STOPPED
-        ? 'cancelled'
-        : 'completed';
+  const outcome = deriveRunOutcome({
+    failed: finalStatus === STREAM_STATUS.ERROR,
+    cancelled: finalStatus === STREAM_STATUS.STOPPED,
+  });
   const error =
     outcome === 'failed'
       ? {

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -364,13 +364,9 @@ function extractToolErrorMessage(content: unknown): string | undefined {
   if (typeof content === 'string') return content;
   if (!Array.isArray(content)) return undefined;
   for (const block of content) {
-    if (
-      block != null &&
-      typeof block === 'object' &&
-      'text' in block &&
-      typeof (block as { text?: unknown }).text === 'string'
-    ) {
-      return (block as { text: string }).text;
+    if (block != null && typeof block === 'object' && 'text' in block) {
+      const text = (block as { text: unknown }).text;
+      if (typeof text === 'string') return text;
     }
   }
   return undefined;

--- a/src/tools/github/PollingSourceBase.ts
+++ b/src/tools/github/PollingSourceBase.ts
@@ -181,6 +181,12 @@ export abstract class PollingSourceBase<
     this.notifyKeysChanged(runtimeHosts);
   }
 
+  /** Emit a formatted halted-subscription error, then detach the key. */
+  private emitErrorAndDetach(key: K, state: S, detail: string): void {
+    this.emit(state, this.formatErrorEvent(key, state, detail));
+    this.detach(key);
+  }
+
   private removeListener(key: K, onEvent: (text: string) => void): void {
     const state = this.subscriptions.get(key);
     if (!state) return;
@@ -305,8 +311,7 @@ export abstract class PollingSourceBase<
       this.logger.warn(
         `Permanent error for ${key} (HTTP ${err.status}); stopping subscription. ${err.message}`,
       );
-      this.emit(state, this.formatErrorEvent(key, state, err.message));
-      this.detach(key);
+      this.emitErrorAndDetach(key, state, err.message);
       return;
     }
     if (err instanceof GitHubRateLimitError) {
@@ -320,15 +325,11 @@ export abstract class PollingSourceBase<
         this.logger.warn(
           `Rate limited polling ${key} and unreachable for over 24 h; detaching.`,
         );
-        this.emit(
+        this.emitErrorAndDetach(
+          key,
           state,
-          this.formatErrorEvent(
-            key,
-            state,
-            `unreachable for over 24 h; detaching`,
-          ),
+          'unreachable for over 24 h; detaching',
         );
-        this.detach(key);
         return;
       }
       this.logger.warn(
@@ -351,15 +352,11 @@ export abstract class PollingSourceBase<
         `Poll failed for ${key} (failure #${state.consecutiveFailures}); ` +
           `unreachable for over 24 h, detaching: ${String(err)}`,
       );
-      this.emit(
+      this.emitErrorAndDetach(
+        key,
         state,
-        this.formatErrorEvent(
-          key,
-          state,
-          `unreachable for over 24 h; detaching`,
-        ),
+        'unreachable for over 24 h; detaching',
       );
-      this.detach(key);
       return;
     }
     this.logger.warn(

--- a/src/tools/github/formatPREvent.ts
+++ b/src/tools/github/formatPREvent.ts
@@ -209,9 +209,6 @@ export function formatCIStarted(
   const uniqueNames = unique(runs.map((r) => r.name)).sort();
   const shownNames = uniqueNames.slice(0, MAX_CI_STARTED_CHECK_NAMES);
   const remainingNames = uniqueNames.length - shownNames.length;
-  const totalCheckLabel = totalCount === 1 ? 'check' : 'checks';
-  const observedCheckLabel = runs.length === 1 ? 'check' : 'checks';
-  const nameLabel = uniqueNames.length === 1 ? 'check name' : 'check names';
   const body = [
     ...shownNames.map((name) => `- ${name}`),
     ...(remainingNames > 0
@@ -221,7 +218,7 @@ export function formatCIStarted(
 
   return wrap(
     sections(
-      `CI triggered on ${prRef(slug, prNumber)} (head ${sha.slice(0, 7)}): GitHub reports ${totalCount} ${totalCheckLabel} registered; this poll observed ${runs.length} ${observedCheckLabel} across ${uniqueNames.length} distinct ${nameLabel}.`,
+      `CI triggered on ${prRef(slug, prNumber)} (head ${sha.slice(0, 7)}): GitHub reports ${formatResultCount(totalCount, 'check')} registered; this poll observed ${formatResultCount(runs.length, 'check')} across ${formatResultCount(uniqueNames.length, 'distinct check name')}.`,
       body,
     ),
   );

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -19,10 +19,8 @@
 
 import { z } from 'zod';
 
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { tryUseRunContext } from '@agent/runtime/RunContext';
 import { toErrorMessage } from '@common/errors';
-import type { StreamTabId } from '@shared/schemas';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { requireRunStream } from '@tools/contextHelpers';
 import { parseWorkingDirectory } from '@tools/pathResolution';
@@ -130,14 +128,6 @@ async function requireToken(): Promise<void> {
   }
 }
 
-function requireSubscriptionContext(): {
-  streamId: StreamTabId;
-  runtimeHost: AgentRuntimeHost;
-} {
-  const { streamId, runtimeHost } = requireRunStream('github_subscription');
-  return { streamId, runtimeHost };
-}
-
 function requirePath(input: GitHubSubscriptionInput): ParsedPath {
   if (!input.path) {
     throw new ToolError(
@@ -156,10 +146,6 @@ const ANNOTATION_LEVEL_DESCRIPTIONS: Record<
   notice: 'notices, warnings, and failures',
 };
 
-function describeAnnotationLevel(level: GitHubCheckAnnotationLevel): string {
-  return ANNOTATION_LEVEL_DESCRIPTIONS[level];
-}
-
 /** Shared body sentence describing what a PR subscription delivers. */
 function prSubscriptionActivitySentence(
   annotationLevelDescription: string,
@@ -171,7 +157,7 @@ async function execSubscribe(
   input: GitHubSubscriptionInput,
 ): Promise<ToolResult> {
   await requireToken();
-  const { streamId, runtimeHost } = requireSubscriptionContext();
+  const { streamId, runtimeHost } = requireRunStream('github_subscription');
   const target = requirePath(input);
   const minAnnotationLevel =
     input.min_annotation_level ?? DEFAULT_CHECK_ANNOTATION_LEVEL;
@@ -198,7 +184,7 @@ async function execSubscribe(
     );
     const slug = `${target.owner}/${target.repo}/pulls/${target.pullNumber}`;
     const annotationLevelDescription =
-      describeAnnotationLevel(minAnnotationLevel);
+      ANNOTATION_LEVEL_DESCRIPTIONS[minAnnotationLevel];
     return {
       summary: created
         ? `Subscribed to ${slug}`
@@ -240,7 +226,7 @@ async function execSubscribe(
     );
     const wasIssuePath = !knownPR;
     const annotationLevelDescription =
-      describeAnnotationLevel(minAnnotationLevel);
+      ANNOTATION_LEVEL_DESCRIPTIONS[minAnnotationLevel];
     return {
       summary: created
         ? wasIssuePath
@@ -284,7 +270,7 @@ async function resolveIssueIsPR(
 }
 
 function execUnsubscribe(input: GitHubSubscriptionInput): ToolResult {
-  const { streamId, runtimeHost } = requireSubscriptionContext();
+  const { streamId, runtimeHost } = requireRunStream('github_subscription');
   const target = requirePath(input);
   if (target.kind === 'repo') {
     const removed = unbindRepoSubscription(streamId, target, runtimeHost);
@@ -326,7 +312,7 @@ function execUnsubscribe(input: GitHubSubscriptionInput): ToolResult {
 }
 
 function execList(): ToolResult {
-  const { streamId } = requireSubscriptionContext();
+  const { streamId } = requireRunStream('github_subscription');
   const prKeys = listPRSubscriptionBindings(prPollingSource.activeKeys())
     .filter((b) => b.streamIds.includes(streamId))
     .map((b) => b.key);

--- a/src/tools/github/subscriptionBindings.ts
+++ b/src/tools/github/subscriptionBindings.ts
@@ -16,7 +16,10 @@ import {
   repoPollingSource,
   type RepoKey,
 } from './RepoPollingSource';
-import { StreamSubscriptionRegistry } from './StreamSubscriptionRegistry';
+import {
+  StreamSubscriptionRegistry,
+  type SubscriptionBinding,
+} from './StreamSubscriptionRegistry';
 
 const prSubscriptions = new StreamSubscriptionRegistry<
   string,
@@ -28,10 +31,7 @@ const prSubscriptions = new StreamSubscriptionRegistry<
   bindingsChangedEvent: 'prSubscriptionBindingsChanged',
 });
 
-export interface PRSubscriptionBinding {
-  key: string;
-  streamIds: readonly StreamTabId[];
-}
+export type PRSubscriptionBinding = SubscriptionBinding<string>;
 
 export function listPRSubscriptionBindings(
   keys: readonly string[] = prPollingSource.activeKeys(),
@@ -94,10 +94,7 @@ const repoSubscriptions = new StreamSubscriptionRegistry<
   bindingsChangedEvent: 'repoSubscriptionBindingsChanged',
 });
 
-export interface RepoSubscriptionBinding {
-  key: RepoKey;
-  streamIds: readonly StreamTabId[];
-}
+export type RepoSubscriptionBinding = SubscriptionBinding<RepoKey>;
 
 export function listRepoSubscriptionBindings(
   keys: readonly RepoKey[] = repoPollingSource.activeKeys(),
@@ -147,10 +144,7 @@ const issueSubscriptions = new StreamSubscriptionRegistry<string, IssueKey>({
   bindingsChangedEvent: 'issueSubscriptionBindingsChanged',
 });
 
-export interface IssueSubscriptionBinding {
-  key: string;
-  streamIds: readonly StreamTabId[];
-}
+export type IssueSubscriptionBinding = SubscriptionBinding<string>;
 
 export function listIssueSubscriptionBindings(
   keys: readonly string[] = issuePollingSource.activeKeys(),

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -13,6 +13,7 @@ import {
   type WorkspacePathResolution,
 } from '@tools/pathResolution';
 import { getGitignoreMatcher } from '@tools/gitignore';
+import { filterNotNull } from '@utils/core';
 import { WorkspaceFS } from '@utils/files';
 import { pluralize } from '@utils/text/stringUtils';
 import { toPosixPath } from '@utils/core/pathCore';
@@ -88,18 +89,15 @@ export class GlobTool extends defineTool({
     );
 
     const results = await Promise.all(statPromises);
-    const decorated = results.filter(
-      (item): item is GlobMatchInfo => item !== null,
-    );
-
-    const sorted = decorated.sort((a, b) => {
-      if (b.mtime !== a.mtime) {
-        return b.mtime - a.mtime;
-      }
-      return a.relativePath.localeCompare(b.relativePath);
-    });
-
-    const lines = sorted.map((item) => toPosixPath(item.relativePath));
+    const lines = results
+      .filter(filterNotNull)
+      .toSorted((a, b) => {
+        if (b.mtime !== a.mtime) {
+          return b.mtime - a.mtime;
+        }
+        return a.relativePath.localeCompare(b.relativePath);
+      })
+      .map((item) => toPosixPath(item.relativePath));
     const count = lines.length;
     const header = `Found ${count} ${pluralize(count, 'file')} matching "${input.pattern}" under ${display}`;
     return {

--- a/src/tools/imageUtils.ts
+++ b/src/tools/imageUtils.ts
@@ -61,7 +61,7 @@ function getImageDimensionsFromBuffer(
     return undefined;
   }
 
-  // WebP: "RIFF" + 4 bytes + "WEBP", then VP8/VP8L/VP8X subtype
+  // WebP: "RIFF" + 4 bytes + "WEBP", then a "VP8" + subtype-byte chunk tag.
   if (
     buffer.length >= 30 &&
     buffer[0] === 0x52 &&
@@ -71,42 +71,31 @@ function getImageDimensionsFromBuffer(
     buffer[8] === 0x57 &&
     buffer[9] === 0x45 &&
     buffer[10] === 0x42 &&
-    buffer[11] === 0x50
+    buffer[11] === 0x50 &&
+    buffer[12] === 0x56 &&
+    buffer[13] === 0x50 &&
+    buffer[14] === 0x38
   ) {
-    if (
-      buffer[12] === 0x56 &&
-      buffer[13] === 0x50 &&
-      buffer[14] === 0x38 &&
-      buffer[15] === 0x20
-    ) {
-      return {
-        width: buffer.readUInt16LE(26) & 0x3fff,
-        height: buffer.readUInt16LE(28) & 0x3fff,
-      };
-    }
-    if (
-      buffer[12] === 0x56 &&
-      buffer[13] === 0x50 &&
-      buffer[14] === 0x38 &&
-      buffer[15] === 0x4c
-    ) {
-      if (buffer.length < 25) return undefined;
-      const bits = buffer.readUInt32LE(21);
-      return {
-        width: (bits & 0x3fff) + 1,
-        height: ((bits >> 14) & 0x3fff) + 1,
-      };
-    }
-    if (
-      buffer[12] === 0x56 &&
-      buffer[13] === 0x50 &&
-      buffer[14] === 0x38 &&
-      buffer[15] === 0x58
-    ) {
-      return {
-        width: (buffer[24] | (buffer[25] << 8) | (buffer[26] << 16)) + 1,
-        height: (buffer[27] | (buffer[28] << 8) | (buffer[29] << 16)) + 1,
-      };
+    switch (buffer[15]) {
+      case 0x20: // VP8 (lossy)
+        return {
+          width: buffer.readUInt16LE(26) & 0x3fff,
+          height: buffer.readUInt16LE(28) & 0x3fff,
+        };
+      case 0x4c: {
+        // VP8L (lossless)
+        if (buffer.length < 25) return undefined;
+        const bits = buffer.readUInt32LE(21);
+        return {
+          width: (bits & 0x3fff) + 1,
+          height: ((bits >> 14) & 0x3fff) + 1,
+        };
+      }
+      case 0x58: // VP8X (extended)
+        return {
+          width: (buffer[24] | (buffer[25] << 8) | (buffer[26] << 16)) + 1,
+          height: (buffer[27] | (buffer[28] << 8) | (buffer[29] << 16)) + 1,
+        };
     }
   }
 

--- a/src/utils/diagnostics/diagnosticFormatting.ts
+++ b/src/utils/diagnostics/diagnosticFormatting.ts
@@ -81,13 +81,12 @@ export function countBySeverity(
  * Example: "3 errors, 2 warnings, 1 hint"
  */
 export function formatCounts(counts: SeverityCounts): string {
-  const parts: string[] = [];
-  for (const { key, label, plural } of COUNT_FORMAT_ORDER) {
-    const count = counts[key];
-    if (count > 0) {
-      parts.push(`${count} ${count === 1 ? label : plural}`);
-    }
-  }
+  const parts = COUNT_FORMAT_ORDER.filter(({ key }) => counts[key] > 0).map(
+    ({ key, label, plural }) => {
+      const count = counts[key];
+      return `${count} ${count === 1 ? label : plural}`;
+    },
+  );
   return parts.length > 0 ? parts.join(', ') : 'No issues';
 }
 
@@ -118,12 +117,6 @@ export function formatMessageList(diagnostics: GenericDiagnostic[]): string {
 export function formatGroupedSections(
   diagnostics: GenericDiagnostic[],
 ): string {
-  const errors = diagnostics.filter((d) => d.severity === SEVERITY_ERROR);
-  const warnings = diagnostics.filter((d) => d.severity === SEVERITY_WARNING);
-  const hints = diagnostics.filter(
-    (d) => d.severity === SEVERITY_INFO || d.severity === SEVERITY_HINT,
-  );
-
   const formatSection = (title: string, items: GenericDiagnostic[]): string => {
     if (items.length === 0) return '';
     const lines = items
@@ -132,11 +125,25 @@ export function formatGroupedSections(
     return `## ${title} (${items.length})\n\n${lines}`;
   };
 
-  return [
-    formatSection('Errors', errors),
-    formatSection('Warnings', warnings),
-    formatSection('Info/Hints', hints),
-  ]
+  const sections: Array<{
+    title: string;
+    match: (severity: number) => boolean;
+  }> = [
+    { title: 'Errors', match: (s) => s === SEVERITY_ERROR },
+    { title: 'Warnings', match: (s) => s === SEVERITY_WARNING },
+    {
+      title: 'Info/Hints',
+      match: (s) => s === SEVERITY_INFO || s === SEVERITY_HINT,
+    },
+  ];
+
+  return sections
+    .map(({ title, match }) =>
+      formatSection(
+        title,
+        diagnostics.filter((d) => match(d.severity)),
+      ),
+    )
     .filter(Boolean)
     .join('\n\n');
 }

--- a/src/utils/media/img.ts
+++ b/src/utils/media/img.ts
@@ -18,14 +18,6 @@ import { executeCommand } from '@utils/system/execUtils';
 const CHANNEL = 'ImgUtils';
 logger.initialize(CHANNEL);
 
-/**
- * Get the maximum image dimension from VS Code configuration
- * @returns Maximum image dimension (defaults to 2000)
- */
-function getMaxImageDimension(): number {
-  return getConfig<number>('texra.maxImageDimension', 2000);
-}
-
 // Define the temporary directory path
 const TEMP_DIR = path.join(os.tmpdir(), 'texra-pdf-conversion');
 
@@ -130,7 +122,7 @@ const API_MAX_IMAGE_DIMENSION = 8000;
 async function resizeImageIfNeeded(imagePath: string): Promise<string> {
   const tool = await selectImageTool();
   const maxDimension = Math.min(
-    getMaxImageDimension(),
+    getConfig<number>('texra.maxImageDimension', 2000),
     API_MAX_IMAGE_DIMENSION,
   );
   const { width, height } = await getImageDimensions(imagePath, tool);

--- a/src/utils/prompt/PromptBuilder.ts
+++ b/src/utils/prompt/PromptBuilder.ts
@@ -4,6 +4,7 @@ import type {
   AgentPrompt,
   AgentWorkflowSetting,
 } from '@agent/core/definition/AgentDataclass';
+import { ensureArray } from '@utils/core';
 import { loadTexraRules } from '@utils/files/rulesUtils';
 import { buildWorkspaceInfoBlock } from '@utils/system/workspaceInfo';
 
@@ -194,14 +195,7 @@ export class PromptBuilder {
 
   private getRoundTemplate(currRound: number): string | undefined {
     const { userRequest } = this.agentPrompt;
-    let templates: string[];
-    if (Array.isArray(userRequest)) {
-      templates = userRequest;
-    } else if (userRequest) {
-      templates = [userRequest];
-    } else {
-      templates = [];
-    }
+    const templates = userRequest ? ensureArray(userRequest) : [];
 
     const round = Math.max(0, currRound);
     if (round < templates.length) return templates[round];

--- a/src/utils/system/workspaceInfo.ts
+++ b/src/utils/system/workspaceInfo.ts
@@ -46,16 +46,21 @@ function detectShell(): string | undefined {
 
 /** Get a human-readable platform name. */
 function getPlatformLabel(): string {
+  let base: string;
   switch (process.platform) {
     case 'darwin':
-      return `macOS (${os.arch()})`;
+      base = 'macOS';
+      break;
     case 'win32':
-      return `Windows (${os.arch()})`;
+      base = 'Windows';
+      break;
     case 'linux':
-      return isWSL() ? `Linux/WSL (${os.arch()})` : `Linux (${os.arch()})`;
+      base = isWSL() ? 'Linux/WSL' : 'Linux';
+      break;
     default:
-      return `${process.platform} (${os.arch()})`;
+      base = process.platform;
   }
+  return `${base} (${os.arch()})`;
 }
 
 /**

--- a/src/utils/text/xmlCdata.ts
+++ b/src/utils/text/xmlCdata.ts
@@ -33,11 +33,20 @@ export function removeCDATA(content: string): string {
 }
 
 /**
- * Wrap content of specified tags with CDATA sections
+ * Wrap the content of each tag with a CDATA section. `attrPattern` is an extra
+ * regex fragment inserted before the open-tag's `>` to optionally match
+ * attributes (empty string for a bare `<tag>`).
  */
-export function addCdataToTags(xmlData: string, tags: string[]): string {
+function wrapTagsWithCdata(
+  xmlData: string,
+  tags: string[],
+  attrPattern: string,
+): string {
   return tags.reduce((result, tag) => {
-    const pattern = new RegExp(`(<${tag}>)(.*?)(</${tag}>)`, 'gs');
+    const pattern = new RegExp(
+      `(<${tag}${attrPattern}>)(.*?)(</${tag}>)`,
+      'gs',
+    );
     return result.replace(pattern, (_, openTag, body, closeTag) =>
       isCdataWrapped(body)
         ? `${openTag}${body}${closeTag}`
@@ -47,21 +56,18 @@ export function addCdataToTags(xmlData: string, tags: string[]): string {
 }
 
 /**
+ * Wrap content of specified tags with CDATA sections
+ */
+export function addCdataToTags(xmlData: string, tags: string[]): string {
+  return wrapTagsWithCdata(xmlData, tags, '');
+}
+
+/**
  * Wrap content of specified tags with CDATA sections, handling attributes
  */
 export function addCdataToTagsMultiple(
   xmlData: string,
   tags: string[],
 ): string {
-  return tags.reduce((result, tag) => {
-    const pattern = new RegExp(
-      `(<${tag}(?:\\s+[^>]*)?>)(.*?)(</${tag}>)`,
-      'gs',
-    );
-    return result.replace(pattern, (_, openTag, body, closeTag) =>
-      isCdataWrapped(body)
-        ? `${openTag}${body}${closeTag}`
-        : `${openTag}<![CDATA[${body}]]>${closeTag}`,
-    );
-  }, xmlData);
+  return wrapTagsWithCdata(xmlData, tags, '(?:\\s+[^>]*)?');
 }

--- a/src/utils/text/xmlExtraction.ts
+++ b/src/utils/text/xmlExtraction.ts
@@ -152,11 +152,13 @@ export function extractContentFromXMLbyTagMultiple(
     if (isObject(container) && 'document' in container) {
       const documents = container.document;
       if (Array.isArray(documents)) {
-        return documents.map((doc) => ({
-          content:
-            (doc as Record<string, unknown>).content?.toString().trim() ?? '',
-          name: (doc as Record<string, unknown>).name as string,
-        }));
+        return documents.map((doc) => {
+          const entry = doc as Record<string, unknown>;
+          return {
+            content: entry.content?.toString().trim() ?? '',
+            name: entry.name as string,
+          };
+        });
       }
       logger.error(
         CHANNEL,
@@ -192,7 +194,7 @@ export async function extractScratchpad(
 
 export interface ExtractionResult {
   content: string | null;
-  method: 'named' | 'simple' | 'markdown' | 'latex' | 'none';
+  method: 'simple' | 'markdown' | 'latex' | 'none';
 }
 
 export interface MultipleExtractionResult {
@@ -202,30 +204,16 @@ export interface MultipleExtractionResult {
 
 /**
  * Extract document content using a consolidated cascade of fallback methods.
- * Tries in order: named document -> simple tag -> markdown block -> latex document
+ * Tries in order: simple tag -> markdown block -> latex document
  *
  * @param outputContent The raw output content to extract from
  * @param documentTag The XML tag to look for
- * @param preferredName Optional filename to match against named documents. When provided,
- * the extractor prioritizes named document matches before other fallbacks.
  * @returns Extraction result with content and method used
  */
 function extractDocument(
   outputContent: string,
   documentTag: string,
-  preferredName?: string,
 ): ExtractionResult {
-  // Try named document extraction first (if preferredName provided)
-  if (preferredName) {
-    const documents = extractMultipleTextFromTag(outputContent);
-    if (documents && documents.length > 0) {
-      const match = documents.find((doc) => doc.name === preferredName);
-      if (match && match.content) {
-        return { content: match.content, method: 'named' };
-      }
-    }
-  }
-
   // Try simple tag extraction
   const fallbackContent = extractTextFromTag(outputContent, documentTag);
   if (fallbackContent) {
@@ -275,16 +263,10 @@ export function extractDocuments(
   }
 
   if (preferredName) {
-    // No preferredName is passed into extractDocument, so the 'named' branch
-    // is never taken — narrow the type accordingly for the result mapping.
     const single = extractDocument(outputContent, 'latex_document');
     if (single.content && single.method !== 'none') {
       const method: MultipleExtractionResult['method'] =
-        single.method === 'simple'
-          ? 'latex_document'
-          : single.method === 'markdown' || single.method === 'latex'
-            ? single.method
-            : 'simple';
+        single.method === 'simple' ? 'latex_document' : single.method;
       return {
         documents: [{ content: single.content, name: preferredName }],
         method,


### PR DESCRIPTION
## Summary

This PR applies a low-risk refactoring pass across schema, UI, runtime helper, tool, and test modules. It removes about 550 net lines by replacing repeated hand-written structures with existing single sources of truth and small local helpers, while preserving behavior.

The main changes are:

- Replace hand-relisted Zod enum arrays with `z.enum(CONST_OBJECT)` for the existing constant objects.
- Inline single-use wrappers and dead types whose behavior was already expressed by the caller or schema.
- Reuse existing utilities such as `commandOnly`, `unique`, `filterNotNull`, `ensureArray`, `deriveRunOutcome`, and shared e2e helpers.
- Consolidate repeated desktop, settings, markdown, file-drop, and latexdiff notification logic into smaller declarative forms.
- Keep the `TextEditorTool` command switch exhaustive with `assertNever` after review feedback.

## Scope Notes

The change is intentionally line-local and behavior-preserving. A mechanical comparison against `codex/decouple-ui-agent-core` showed that current `main` already accounts for the broad merge pressure against that draft branch; this PR adds one additional conflict path beyond `main`: `src/tools/github/githubSubscriptionTool.ts`.

## Verification

- `corepack pnpm run typecheck`
- `corepack pnpm run lint` (warnings only; no errors)
- `corepack pnpm test` (4214 passed, 4 skipped)
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/tools/ToolEditApprovalGate.vitest.ts` after the review follow-up

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactors with stated full test/typecheck/lint verification; no intentional behavior changes beyond small consolidations (e.g. model recovery merge semantics preserved per comments).
> 
> **Overview**
> This PR is a broad, behavior-preserving cleanup that removes repeated hand-written patterns in favor of shared constants and small helpers (~550 net lines).
> 
> **Schemas and shared utilities** — Zod enums now derive from existing const objects (`z.enum(STREAM_STATUS)` etc.) instead of duplicated string lists. Progress view inbound messages use `commandOnly` / `streamScopedCommand`; file list fields are shared via `fileListFields`. Markdown LaTeX protection, XML CDATA wrapping, `PersistedState` default resolution, and log level exports are consolidated similarly.
> 
> **CLI, desktop, and extension surfaces** — The orchestration TUI shares one launcher subtitle constant for layout measurement and rendering. Desktop renderer IPC drops thin type-guard wrappers in favor of inline `safeParse`, inlines the Logs chrome button, and e2e specs call shared `dismissOnboarding` / `waitForActiveSettingsPanel`. Extension commands dedupe sign-in toasts, clean/latexdiff handlers, setup credential routing, settings tab markup, and main-view getting-started dispatch.
> 
> **Runtime and tools** — Model access recovery merges overrides generically and centralizes access-list loading; run progress merges active-process/subagent handling; workflow output uses `toPosix` and simpler “latest round” selection. Tools and utils pick up `deriveRunOutcome`, `assertNever` on text editor commands, shared GitHub subscription/error helpers, and assorted small refactors (`unique`, `filterNotNull`, WebP dimension parsing, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 288684eb0aede4cde0710d7de7dc00a16631fe70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->