### PR TITLE
refactor: microscopic LoC reduction in run-critical modules

### DIFF
--- a/src/agent/core/definition/AgentDataclass.ts
+++ b/src/agent/core/definition/AgentDataclass.ts
@@ -62,25 +62,29 @@ function stripLegacySettingFields(input: unknown): unknown {
   return rest;
 }
 
-/** Derive endTag from documentTag when endTag is not explicitly set. */
-function deriveEndTag(input: unknown): unknown {
+/**
+ * Derive endTag from documentTag when none is set. `fallbackTag` supplies the
+ * tag when documentTag is absent/blank; `null` leaves the input unchanged.
+ */
+function deriveEndTagFrom(input: unknown, fallbackTag: string | null): unknown {
   if (typeof input !== 'object' || input === null) return input;
   const obj = input as Record<string, unknown>;
   if (obj.endTag !== undefined) return obj;
   const docTag = isNonEmptyString(obj.documentTag)
     ? obj.documentTag.trim()
-    : 'documents';
+    : fallbackTag;
+  if (docTag === null) return input;
   return { ...obj, endTag: `</${docTag}>` };
+}
+
+/** Derive endTag from documentTag when endTag is not explicitly set. */
+function deriveEndTag(input: unknown): unknown {
+  return deriveEndTagFrom(input, 'documents');
 }
 
 /** Preserve partial child blocks: derive only from explicitly written documentTag. */
 function deriveExplicitEndTag(input: unknown): unknown {
-  if (typeof input !== 'object' || input === null) return input;
-  const obj = input as Record<string, unknown>;
-  if (obj.endTag !== undefined || !isNonEmptyString(obj.documentTag)) {
-    return input;
-  }
-  return { ...obj, endTag: `</${obj.documentTag.trim()}>` };
+  return deriveEndTagFrom(input, null);
 }
 
 export const AgentSettingSchema = z.preprocess(

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -351,30 +351,28 @@ export function handleInvocationResult<T extends { response: unknown }>(
     return null;
   }
 
-  if (result.kind === 'cancelled') {
-    state.lastError = undefined;
+  function stop(lastError: RetryErrorInfo | undefined): null {
+    state.lastError = lastError;
     state.shouldStop = true;
     state.endTurn = false;
     return null;
+  }
+
+  if (result.kind === 'cancelled') {
+    return stop(undefined);
   }
 
   if (result.kind === 'failed') {
     const { kind: _, ...errorInfo } = result;
-    state.lastError = errorInfo;
-    state.shouldStop = true;
-    state.endTurn = false;
-    return null;
+    return stop(errorInfo);
   }
 
   if (!result.response) {
     logger.warn(EMPTY_RESPONSE_ERROR_MESSAGE);
-    state.lastError = {
+    return stop({
       message: EMPTY_RESPONSE_ERROR_MESSAGE,
       userRetryable: false,
-    };
-    state.shouldStop = true;
-    state.endTurn = false;
-    return null;
+    });
   }
 
   state.lastError = undefined;

--- a/src/agent/core/flows/toolUseRound/roundShared.ts
+++ b/src/agent/core/flows/toolUseRound/roundShared.ts
@@ -4,10 +4,7 @@ import { z } from 'zod';
 // Local imports - core flow primitives
 import { BaseCycleFieldsSchema } from '@agent/core/flows/CommonCycleTypes';
 import type { SdkToolCall } from '@agent/modelHandlers/types/IModelHandler';
-import {
-  NormalizedUsageSchema,
-  type NormalizedUsage,
-} from '@agent/types/NormalizedUsage';
+import { NormalizedUsageSchema } from '@agent/types/NormalizedUsage';
 
 /**
  * Schema for serializable tool-use round fields.
@@ -71,8 +68,4 @@ export type ToolUseRoundFields = z.infer<typeof ToolUseRoundFieldsSchema>;
 export interface ToolUseRoundShared extends ToolUseRoundFields {
   /** Tool calls with proper typing (schema uses z.unknown()) */
   toolCalls?: SdkToolCall[];
-  /** Normalized usage with proper typing */
-  roundNormalizedUsage?: NormalizedUsage;
-  /** Last tool-result message index that received a blank-turn continuation. */
-  blankToolResultContinuationMessageIndex?: number;
 }

--- a/src/agent/index/platformAgentDirectories.ts
+++ b/src/agent/index/platformAgentDirectories.ts
@@ -1,4 +1,3 @@
-// Local imports - agent index
 import { platform } from '@platform/platform';
 import { isFileNotFoundError } from '@common/errors/errorPredicates';
 import * as logger from '@logger/logUtils';
@@ -10,10 +9,6 @@ import {
   type AgentDirectoryVersionStore,
 } from './AgentDirectorySync';
 import { setAgentDirectories } from './agentDirectoriesRegistry';
-
-// Local imports - common
-
-// Local imports - platform
 
 interface PlatformAgentDirectoryOptions {
   channel: string;

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -68,7 +68,6 @@ import {
   ANTHROPIC_STOP,
   GOOGLE_FINISH,
   OPENAI_CHAT_FINISH,
-  MCP_STOP,
 } from './types/StopReasonTypes';
 import {
   computeReducedMaxTokens,
@@ -104,6 +103,14 @@ const DEFAULT_CONTINUE_LIMIT = 10;
 // Default token limits
 const DEFAULT_INPUT_TOKEN_LIMIT = 1500000;
 const DEFAULT_OUTPUT_TOKEN_LIMIT_FACTOR = 2.5;
+
+// Stop markers that signal a completed turn across providers.
+const END_TURN_REASONS: ProviderStopReason[] = [
+  ANTHROPIC_STOP.END_TURN,
+  ANTHROPIC_STOP.STOP_SEQUENCE,
+  OPENAI_CHAT_FINISH.STOP,
+  GOOGLE_FINISH.STOP,
+];
 
 /**
  * Abstract base class for model-specific handlers that manage API interactions, message processing, and response handling.
@@ -621,13 +628,7 @@ export abstract class ModelHandler<
     const maxOutputTokensExceeded = totals.totalOutputTokens > maxOutputTokens;
 
     // Detect stop markers in model output
-    const endTurnReasons: ProviderStopReason[] = [
-      ANTHROPIC_STOP.END_TURN,
-      ANTHROPIC_STOP.STOP_SEQUENCE,
-      OPENAI_CHAT_FINISH.STOP,
-      GOOGLE_FINISH.STOP,
-    ];
-    const endTurn = endTurnReasons.includes(stopReason ?? '');
+    const endTurn = END_TURN_REASONS.includes(stopReason ?? '');
     const encounterDocumentTag = newResponse.includes(
       `</${agentSetting.documentTag}>`,
     );
@@ -1076,12 +1077,10 @@ export abstract class ModelHandler<
 
   /** Check if stop reason signals end-turn. */
   public isEndTurnStop(reason: ProviderStopReason): boolean {
-    return (
-      reason === ANTHROPIC_STOP.END_TURN ||
-      reason === MCP_STOP.END_TURN ||
-      String(reason).toLowerCase() === 'end_turn' ||
-      String(reason).toLowerCase() === 'endturn'
-    );
+    // Covers ANTHROPIC_STOP.END_TURN ('end_turn') and MCP_STOP.END_TURN
+    // ('endTurn') plus any provider casing of the same markers.
+    const lower = String(reason).toLowerCase();
+    return lower === 'end_turn' || lower === 'endturn';
   }
 
   /**

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -1369,6 +1369,22 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
    * validate reasoning across tool turns (resent each round in stateless mode;
    * retained server-side once sent in chained mode).
    */
+  /**
+   * Build a `thought` step from an optional signature and thinking summary, or
+   * `undefined` when both are empty (an empty thought step is noise on the wire).
+   */
+  private thoughtStep(
+    signature?: string,
+    thinking?: string,
+  ): ThoughtStep | undefined {
+    if (!signature && !thinking) return undefined;
+    return {
+      type: 'thought',
+      ...(signature ? { signature } : {}),
+      ...(thinking ? { summary: [{ type: 'text', text: thinking }] } : {}),
+    } satisfies ThoughtStep;
+  }
+
   private buildAssistantTurnSteps(
     calls: GoogleToolCall[],
     workspaceState: AgentWorkspaceState | undefined,
@@ -1377,14 +1393,8 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
     const steps: Step[] = [];
 
     for (const block of workspaceState?.reasoning.thinkingBlocks ?? []) {
-      if (!block.signature && !block.thinking) continue;
-      steps.push({
-        type: 'thought',
-        ...(block.signature ? { signature: block.signature } : {}),
-        ...(block.thinking
-          ? { summary: [{ type: 'text', text: block.thinking }] }
-          : {}),
-      } satisfies ThoughtStep);
+      const step = this.thoughtStep(block.signature, block.thinking);
+      if (step) steps.push(step);
     }
 
     if (text) {
@@ -2167,16 +2177,8 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
     const steps: Step[] = [];
     for (const [, slot] of ordered) {
       if (slot.type === 'thought') {
-        // Skip an empty thought (no signature and no summary) — matches
-        // buildAssistantTurnSteps; an empty thought step is noise on the wire.
-        if (!slot.signature && !slot.thought) continue;
-        steps.push({
-          type: 'thought',
-          ...(slot.signature ? { signature: slot.signature } : {}),
-          ...(slot.thought
-            ? { summary: [{ type: 'text', text: slot.thought }] }
-            : {}),
-        } satisfies ThoughtStep);
+        const step = this.thoughtStep(slot.signature, slot.thought);
+        if (step) steps.push(step);
       } else if (slot.type === 'function_call') {
         steps.push({
           type: 'function_call',

--- a/src/agent/modelHandlers/openai/openAIMessageUtils.ts
+++ b/src/agent/modelHandlers/openai/openAIMessageUtils.ts
@@ -29,6 +29,12 @@ function isTextContentItem(
   );
 }
 
+/** Join two strings with a newline; an empty operand passes the other through. */
+function joinStringsWithNewline(a: string, b: string): string {
+  if (a === '' || b === '') return a || b;
+  return `${a}\n${b}`;
+}
+
 function mergeReasoningContent(
   previous: MessageLike,
   current: MessageLike,
@@ -41,11 +47,10 @@ function mergeReasoningContent(
     return;
   }
   if (typeof prevReasoning === 'string' && typeof currReasoning === 'string') {
-    if (prevReasoning === '' || currReasoning === '') {
-      previous.reasoning_content = prevReasoning || currReasoning;
-    } else {
-      previous.reasoning_content = `${prevReasoning}\n${currReasoning}`;
-    }
+    previous.reasoning_content = joinStringsWithNewline(
+      prevReasoning,
+      currReasoning,
+    );
   }
 }
 
@@ -76,11 +81,7 @@ function mergeMessageContent(
 
   // Both strings: join with newline (empty strings pass through unchanged)
   if (typeof prevContent === 'string' && typeof currContent === 'string') {
-    if (prevContent === '' || currContent === '') {
-      previous.content = prevContent || currContent;
-    } else {
-      previous.content = `${prevContent}\n${currContent}`;
-    }
+    previous.content = joinStringsWithNewline(prevContent, currContent);
     return;
   }
 

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -343,17 +343,10 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
 
     if (systemPrompt) {
       const role = this.capabilities.supportsSystemPrompt ? 'system' : 'user';
-      if (role === 'system') {
-        messages.push({
-          role: 'system',
-          content: [{ type: 'text', text: systemPrompt }],
-        });
-      } else {
-        messages.push({
-          role: 'user',
-          content: [{ type: 'text', text: systemPrompt }],
-        });
-      }
+      messages.push({
+        role,
+        content: [{ type: 'text', text: systemPrompt }],
+      });
     }
 
     const userContent: ChatContentItems[] = [];
@@ -393,14 +386,9 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
         type: 'text',
         text: userRequest,
       });
-    } else if (requestRole === 'system') {
-      messages.push({
-        role: 'system',
-        content: [{ type: 'text', text: userRequest }],
-      });
     } else {
       messages.push({
-        role: 'user',
+        role: requestRole,
         content: [{ type: 'text', text: userRequest }],
       });
     }
@@ -730,17 +718,10 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     );
 
     const role = this.capabilities.supportsIntermDevMsgs ? 'system' : 'user';
-    if (role === 'system') {
-      messages.push({
-        role: 'system',
-        content: [{ type: 'text', text: userMessageContinuation }],
-      });
-    } else {
-      messages.push({
-        role: 'user',
-        content: [{ type: 'text', text: userMessageContinuation }],
-      });
-    }
+    messages.push({
+      role,
+      content: [{ type: 'text', text: userMessageContinuation }],
+    });
   }
 
   // ---------------------------------------------------------------------------

--- a/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
+++ b/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
@@ -5,10 +5,9 @@
 // Third-party imports
 import { logWebFetch, logWebSearch, type AgentTrace } from '@agent/trace';
 import {
-  extractDomain,
+  mapAnthropicWebSearchEntries,
   type WebFetchResult,
   type WebSearchResult,
-  type WebSearchResultEntry,
 } from '@agent/modelHandlers/types/ServerToolTypes';
 import { safeParseJson } from '@common/parsing/safeParseJson';
 import type { StreamDiagnostics } from '@shared/schemas';
@@ -21,7 +20,6 @@ import type { BetaMessageStream } from '@anthropic-ai/sdk/lib/BetaMessageStream'
 import type {
   ServerToolUseBlock,
   WebSearchToolResultBlock,
-  WebSearchResultBlock,
   WebFetchToolResultBlock,
 } from '@anthropic-ai/sdk/resources/messages';
 
@@ -361,10 +359,10 @@ export class AnthropicStreamHandler {
     const searchData = this.state.pendingSearches.get(block.tool_use_id);
 
     // Parse query from accumulated input JSON
-    const query = this.parseSearchQuery(searchData?.input);
+    const query = this.parseStreamField(searchData?.input, 'query');
 
     // Extract results from the block content
-    const entries = this.extractSearchResults(block);
+    const entries = mapAnthropicWebSearchEntries(block.content);
 
     // Emit to progress view
     if (entries.length > 0 || query) {
@@ -389,7 +387,7 @@ export class AnthropicStreamHandler {
     const fetchData = this.state.pendingFetches.get(block.tool_use_id);
 
     // Parse URL from accumulated input JSON
-    const fetchUrl = this.parseFetchUrl(fetchData?.input);
+    const fetchUrl = this.parseStreamField(fetchData?.input, 'url');
 
     // Native discriminated-union narrowing on block.content
     // (WebFetchBlock | WebFetchToolResultErrorBlock) replaces the prior
@@ -457,35 +455,6 @@ export class AnthropicStreamHandler {
       return (parsed.value as Record<string, string>)[field] ?? '';
     const match = input.match(new RegExp(`"${field}"\\s*:\\s*"([^"]+)"`));
     return match?.[1] ?? '';
-  }
-
-  /** Parses the fetch URL from accumulated input JSON. */
-  private parseFetchUrl(input: string | undefined): string {
-    return this.parseStreamField(input, 'url');
-  }
-
-  /** Parses the search query from accumulated input JSON. */
-  private parseSearchQuery(input: string | undefined): string {
-    return this.parseStreamField(input, 'query');
-  }
-
-  /**
-   * Extracts search results from a web_search_tool_result block.
-   */
-  private extractSearchResults(
-    block: WebSearchToolResultBlock,
-  ): WebSearchResultEntry[] {
-    if (!Array.isArray(block.content)) return [];
-
-    return (block.content as WebSearchResultBlock[])
-      .filter((r) => r.type === 'web_search_result' && r.url)
-      .map((r) => ({
-        url: r.url,
-        title: r.title,
-        snippet: r.encrypted_content,
-        pageAge: r.page_age ?? undefined,
-        domain: extractDomain(r.url),
-      }));
   }
 
   /**

--- a/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
+++ b/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
@@ -296,7 +296,7 @@ export class MediaAttachmentProcessor {
     ) {
       const entry = this.createEntry(
         path.basename(mediaFile),
-        this.getFirstItem(processed.data),
+        Array.isArray(processed.data) ? processed.data[0] : processed.data,
         processed.mediaType,
         processed.kind,
         absolutePath,
@@ -306,7 +306,7 @@ export class MediaAttachmentProcessor {
       return entry;
     }
 
-    const dataParts = this.normalizeToArray(processed.data);
+    const dataParts = ensureArray(processed.data);
     const isImage = processed.kind === 'image';
     const derivedFromConversion =
       isImage &&
@@ -367,15 +367,5 @@ export class MediaAttachmentProcessor {
 
   private isAudio(ext: string): boolean {
     return getMimeType(ext)?.startsWith('audio/') ?? false;
-  }
-
-  /** Normalize data to array for consistent processing */
-  private normalizeToArray(data: string | string[]): string[] {
-    return ensureArray(data);
-  }
-
-  /** Get the first data item (for single-item scenarios) */
-  private getFirstItem(data: string | string[]): string {
-    return Array.isArray(data) ? data[0] : data;
   }
 }

--- a/src/agent/modelHandlers/types/ServerToolTypes.ts
+++ b/src/agent/modelHandlers/types/ServerToolTypes.ts
@@ -228,6 +228,31 @@ function isWebSearchResultArray(
 }
 
 /**
+ * Map a web_search_tool_result block's content to normalized result entries.
+ * Shared by the streaming (AnthropicStreamHandler) and batch
+ * (extractAnthropicWebSearchResults) extraction paths.
+ */
+export function mapAnthropicWebSearchEntries(
+  content: WebSearchToolResultBlock['content'],
+): WebSearchResultEntry[] {
+  if (!isWebSearchResultArray(content)) {
+    return [];
+  }
+  return content
+    .filter(
+      (r): r is WebSearchResultBlock =>
+        r.type === 'web_search_result' && !!r.url,
+    )
+    .map((r) => ({
+      url: r.url,
+      title: r.title,
+      snippet: r.encrypted_content,
+      pageAge: r.page_age ?? undefined,
+      domain: extractDomain(r.url),
+    }));
+}
+
+/**
  * Extract web search results from Anthropic response content.
  * Uses SDK's WebSearchToolResultBlock and WebSearchResultBlock types.
  * Correlates server_tool_use blocks (which contain the query) with
@@ -255,25 +280,7 @@ export function extractAnthropicWebSearchResults(
       continue;
     }
 
-    // block is now properly typed as WebSearchToolResultBlock
-    if (!isWebSearchResultArray(block.content)) {
-      // Content is an error, not results
-      continue;
-    }
-
-    // block.content is now properly typed as WebSearchResultBlock[]
-    const entries: WebSearchResultEntry[] = block.content
-      .filter(
-        (r): r is WebSearchResultBlock =>
-          r.type === 'web_search_result' && !!r.url,
-      )
-      .map((r) => ({
-        url: r.url,
-        title: r.title,
-        snippet: r.encrypted_content,
-        pageAge: r.page_age ?? undefined,
-        domain: extractDomain(r.url),
-      }));
+    const entries = mapAnthropicWebSearchEntries(block.content);
 
     if (entries.length > 0) {
       // Look up the query from the corresponding server_tool_use block
@@ -380,15 +387,12 @@ export function buildOpenAIWebSearchResult(
 ): WebSearchResult {
   const searchItem = item as ResponseFunctionWebSearchWithAction;
 
-  // Determine status using SDK's status type
-  let status: WebSearchResult['status'];
-  if (searchItem.status === 'completed') {
-    status = 'completed';
-  } else if (searchItem.status === 'failed') {
-    status = 'failed';
-  } else {
-    status = 'in_progress';
-  }
+  // Determine status using SDK's status type. 'completed' and 'failed' map
+  // through directly; any other SDK status is reported as in-progress.
+  const status: WebSearchResult['status'] =
+    searchItem.status === 'completed' || searchItem.status === 'failed'
+      ? searchItem.status
+      : 'in_progress';
 
   const action = searchItem.action;
 

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -132,48 +132,45 @@ export async function registerExecution(
 }
 
 /**
- * Persist a terminal status on an existing execution's metadata.
+ * Persist supplementary metadata fields on an existing execution.
  * Serialized with other meta updates for the same execution to prevent
- * read-modify-write races (e.g. with writeSessionDescription).
- * Never throws — storage failures are swallowed so callers' lifecycle
- * logic (registry untrack, follow-up delivery) always runs.
+ * read-modify-write races (e.g. between terminal status and description).
+ * Never throws — these are non-critical bookkeeping writes, so storage
+ * failures are swallowed and callers' lifecycle logic (registry untrack,
+ * follow-up delivery) always runs.
  */
-export async function writeTerminalStatus(
+async function persistMetaField(
   executionId: ExecutionId,
-  status: string,
+  fields: Partial<ExecutionMeta>,
+  what: string,
 ): Promise<void> {
   try {
-    await enqueueMetaUpdate(executionId, () => ({ terminalStatus: status }));
+    await enqueueMetaUpdate(executionId, () => fields);
   } catch (err) {
     // Non-critical bookkeeping — don't let I/O errors disrupt execution lifecycle.
     logger.debug(
       'ExecutionLifecycle',
-      `Failed to persist terminal status for ${executionId}: ${toErrorMessage(
-        err,
-      )}`,
+      `Failed to persist ${what} for ${executionId}: ${toErrorMessage(err)}`,
     );
   }
 }
 
-/**
- * Persist an AI-generated session description on an existing execution's metadata.
- * Serialized with other meta updates for the same execution to prevent
- * read-modify-write races (e.g. with writeTerminalStatus).
- * Never throws — description is supplementary data.
- */
+/** Persist a terminal status on an existing execution's metadata. */
+export async function writeTerminalStatus(
+  executionId: ExecutionId,
+  status: string,
+): Promise<void> {
+  await persistMetaField(
+    executionId,
+    { terminalStatus: status },
+    'terminal status',
+  );
+}
+
+/** Persist an AI-generated session description on an existing execution's metadata. */
 export async function writeSessionDescription(
   executionId: ExecutionId,
   description: string,
 ): Promise<void> {
-  try {
-    await enqueueMetaUpdate(executionId, () => ({ description }));
-  } catch (err) {
-    // Non-critical bookkeeping — don't let I/O errors disrupt execution lifecycle.
-    logger.debug(
-      'ExecutionLifecycle',
-      `Failed to persist session description for ${executionId}: ${toErrorMessage(
-        err,
-      )}`,
-    );
-  }
+  await persistMetaField(executionId, { description }, 'session description');
 }

--- a/src/agent/storage/executionListing.ts
+++ b/src/agent/storage/executionListing.ts
@@ -75,6 +75,24 @@ async function readDirOrEmpty(path: string): Promise<[string, number][]> {
   }
 }
 
+/**
+ * Select execution-id directories (hex UUID-like) from a scanned listing,
+ * optionally excluding ids (e.g. active runs). A missing exclude set keeps all.
+ */
+function listExecutionDirs(
+  entries: [string, number][],
+  exclude?: ReadonlySet<string>,
+): ExecutionId[] {
+  return entries
+    .filter(
+      ([name, type]) =>
+        isDirectory(type) &&
+        EXECUTION_ID_PATTERN.test(name) &&
+        !exclude?.has(name),
+    )
+    .map(([name]) => name as ExecutionId);
+}
+
 // ============================================================================
 // Public API
 // ============================================================================
@@ -100,13 +118,7 @@ export async function listExecutions(): Promise<ExecutionListingEntry[]> {
   }
 
   const entries = await readDirOrEmpty(TASK_RUNS_DIR);
-
-  // Filter for directories matching execution ID pattern (hex UUID-like)
-  const executionDirs = entries
-    .filter(
-      ([name, type]) => isDirectory(type) && EXECUTION_ID_PATTERN.test(name),
-    )
-    .map(([name]) => name as ExecutionId);
+  const executionDirs = listExecutionDirs(entries);
 
   // Read meta + config with bounded concurrency. Large histories should not
   // enqueue one storage read pair per execution all at once.
@@ -185,15 +197,7 @@ export async function deleteAllExecutions(
   exclude?: ReadonlySet<string>,
 ): Promise<ExecutionId[]> {
   const entries = await readDirOrEmpty(TASK_RUNS_DIR);
-
-  const executionDirs = entries
-    .filter(
-      ([name, type]) =>
-        isDirectory(type) &&
-        EXECUTION_ID_PATTERN.test(name) &&
-        !exclude?.has(name),
-    )
-    .map(([name]) => name as ExecutionId);
+  const executionDirs = listExecutionDirs(entries, exclude);
 
   try {
     await pMap(executionDirs, (id) => getExecutionStore(id).clear(), {

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -119,7 +119,6 @@ export class UsageMonitor {
       const roundOutputTokens = latestUsage?.outputTokens ?? 0;
       const roundCacheReadTokens = latestUsage?.cachedInputTokens ?? 0;
       const roundCacheMissTokens = latestUsage?.cacheMissInputTokens;
-      const roundCacheMissTokensForDisplay = roundCacheMissTokens ?? 0;
       const roundCacheCreationTokens = latestUsage?.cacheCreationTokens ?? 0;
       const roundReasoningTokens = latestUsage?.reasoningTokens ?? 0;
       const roundCost = latestUsage?.cost ?? 0;
@@ -148,8 +147,8 @@ export class UsageMonitor {
         ...(roundCacheReadTokens > 0 && {
           cacheReadInputTokens: roundCacheReadTokens,
         }),
-        ...(roundCacheMissTokensForDisplay > 0 && {
-          cacheMissInputTokens: roundCacheMissTokensForDisplay,
+        ...((roundCacheMissTokens ?? 0) > 0 && {
+          cacheMissInputTokens: roundCacheMissTokens ?? 0,
         }),
         ...(roundCacheCreationTokens > 0 && {
           cacheCreationInputTokens: roundCacheCreationTokens,
@@ -175,10 +174,9 @@ export class UsageMonitor {
         usage: payload,
       });
       if (agentCategory === AgentCategory.Workflow) {
-        const transcriptPayload: Record<string, number> = {};
-        for (const [key, value] of Object.entries(payload)) {
-          if (typeof value === 'number') transcriptPayload[key] = value;
-        }
+        const transcriptPayload = Object.fromEntries(
+          Object.entries(payload).filter(([, v]) => typeof v === 'number'),
+        ) as Record<string, number>;
         // The round stage's AsyncLocalStorage scope already stamps the active
         // round id (r0/r1...) onto emitted events; fall back to storageKey for
         // any usage logged outside a round stage.

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -141,22 +141,15 @@ function getBasicVars(
   providerFlags: ModelProviderFlags,
   workspacePath?: string,
 ): UserVars {
-  // Build agent lists for template use
+  // Build agent lists for template use. Tool-use agents append their tools.
   function formatAgentList(
-    agents: { name: string; description?: string }[],
-  ): string {
-    return agents
-      .map((a) => `- ${a.name}: ${a.description || 'No description'}`)
-      .join('\n');
-  }
-
-  // Format tool-use agents with their available tools
-  function formatToolUseAgentList(
     agents: Pick<AgentEntry, 'name' | 'description' | 'tools'>[],
+    includeTools = false,
   ): string {
     return agents
       .map((a) => {
-        const toolsStr = a.tools?.length ? ` [${a.tools.join(', ')}]` : '';
+        const toolsStr =
+          includeTools && a.tools?.length ? ` [${a.tools.join(', ')}]` : '';
         return `- ${a.name}: ${a.description || 'No description'}${toolsStr}`;
       })
       .join('\n');
@@ -167,8 +160,9 @@ function getBasicVars(
   const workflowAgentsList = formatAgentList(
     getVisibleAgents('workflow').filter((a) => a.name !== selfName),
   );
-  const toolUseAgentsList = formatToolUseAgentList(
+  const toolUseAgentsList = formatAgentList(
     getVisibleAgents('toolUse').filter((a) => a.name !== selfName),
+    true,
   );
 
   // Get default bib path from settings (empty string if not configured)

--- a/src/housekeeping/pack.ts
+++ b/src/housekeeping/pack.ts
@@ -64,17 +64,13 @@ export async function runPackSingle(
     }
   }
 
-  const onlyInputFilePacked =
+  // Nothing to move, and the only copy (if any) is the input document itself.
+  const noFilesToPack =
     movedFiles.length === 0 &&
-    copiedFiles.length === 1 &&
-    copiedFiles[0] === inputFile;
+    (copiedFiles.length === 0 ||
+      (copiedFiles.length === 1 && copiedFiles[0] === inputFile));
 
-  if (onlyInputFilePacked) {
-    logger.warn(CHANNEL, `No files found to pack for ${inputFile}`);
-    return { status: 'noFiles' };
-  }
-
-  if (movedFiles.length === 0 && copiedFiles.length === 0) {
+  if (noFilesToPack) {
     logger.warn(CHANNEL, `No files found to pack for ${inputFile}`);
     return { status: 'noFiles' };
   }

--- a/src/latex/TikzPictureManager.ts
+++ b/src/latex/TikzPictureManager.ts
@@ -14,6 +14,14 @@ import { compileLatex2Pdf } from './texTools';
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);
 
+/**
+ * Pick the run-storage-relative path for a location, falling back to its
+ * absolute path for external (non-run-storage) locations.
+ */
+function runStoragePath(loc: FileLocation): string {
+  return loc.kind !== 'external' ? loc.relativePath : loc.absolutePath;
+}
+
 class TikzPictureManager {
   constructor(
     private readonly channel: string = CHANNEL,
@@ -108,11 +116,10 @@ class TikzPictureManager {
     });
 
     const filename = suffix ? `${label}_${suffix}.tex` : `${label}.tex`;
-    const buildDir =
-      buildDirLocation.kind !== 'external'
-        ? buildDirLocation.relativePath
-        : buildDirLocation.absolutePath;
-    const fileRelativePath = path.join(buildDir, filename);
+    const fileRelativePath = path.join(
+      runStoragePath(buildDirLocation),
+      filename,
+    );
 
     const texLocation = this.createLocation(
       fileRelativePath,
@@ -135,11 +142,7 @@ class TikzPictureManager {
    */
   async compile(latexFile: FileLocation): Promise<FileLocation[]> {
     const inputName = path.parse(path.basename(latexFile.absolutePath)).name;
-    const inputDir = path.dirname(
-      latexFile.kind !== 'external'
-        ? latexFile.relativePath
-        : latexFile.absolutePath,
-    );
+    const inputDir = path.dirname(runStoragePath(latexFile));
     const buildRelativePath = path.join(inputDir, 'build', inputName);
 
     const buildDirLocation = this.createLocation(
@@ -185,11 +188,7 @@ class TikzPictureManager {
         const pdfFilename = path
           .basename(texLocation.absolutePath)
           .replace(/\.tex$/, '.pdf');
-        const texDir = path.dirname(
-          texLocation.kind !== 'external'
-            ? texLocation.relativePath
-            : texLocation.absolutePath,
-        );
+        const texDir = path.dirname(runStoragePath(texLocation));
         const pdfRelativePath = path.join(texDir, pdfFilename);
 
         const pdfLocation = this.createLocation(

--- a/src/latex/extractFileDependencies.ts
+++ b/src/latex/extractFileDependencies.ts
@@ -73,12 +73,9 @@ export async function extractLatexFileDependencies(
   const content = await flexibleFS.read(latexFileLocation);
   const uncommented = stripLatexComments(content);
 
-  const texInputPaths: string[] = [];
-  for (const pattern of [INPUT_PATTERN, INCLUDE_PATTERN]) {
-    for (const match of uncommented.matchAll(pattern)) {
-      texInputPaths.push(match[1]);
-    }
-  }
+  const texInputPaths = [INPUT_PATTERN, INCLUDE_PATTERN].flatMap((pattern) =>
+    [...uncommented.matchAll(pattern)].map((match) => match[1]),
+  );
 
   const bibCandidates = collectBibliographyPaths(latexDir, uncommented);
 
@@ -93,10 +90,7 @@ export async function extractLatexFileDependencies(
     }),
   ]);
 
-  const results = new Set<string>();
-  for (const resolved of [...texResolved, ...bibResolved]) {
-    if (resolved) results.add(resolved);
-  }
-
-  return [...results];
+  return [
+    ...new Set([...texResolved, ...bibResolved].filter((r) => r !== null)),
+  ];
 }

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -231,28 +231,6 @@ export class LaTeXdiffService {
     }
   }
 
-  /** Run one VC diff, logging and reporting failure as `false` for the batch loop. */
-  private async runDiffVcEntry(
-    inputLocation: FileLocation,
-    commitHash: string,
-    mathMarkup?: MathMarkupOption,
-  ): Promise<boolean> {
-    try {
-      const result = await this.runDiffVc(
-        inputLocation,
-        commitHash,
-        mathMarkup,
-      );
-      return result.success;
-    } catch (err) {
-      logger.error(
-        this.channel,
-        `Error processing ${inputLocation.absolutePath}: ${toErrorMessage(err)}`,
-      );
-      return false;
-    }
-  }
-
   async runDiffVcMultiple(
     inputLocations: FileLocation[],
     commitHash: string,
@@ -273,9 +251,22 @@ export class LaTeXdiffService {
 
       for (const inputLocation of inputLocations) {
         const inputFile = inputLocation.absolutePath;
-        if (await this.runDiffVcEntry(inputLocation, commitHash, mathMarkup)) {
-          results.success.push(inputFile);
-        } else {
+        try {
+          const result = await this.runDiffVc(
+            inputLocation,
+            commitHash,
+            mathMarkup,
+          );
+          if (result.success) {
+            results.success.push(inputFile);
+          } else {
+            results.failed.push(inputFile);
+          }
+        } catch (err) {
+          logger.error(
+            this.channel,
+            `Error processing ${inputFile}: ${toErrorMessage(err)}`,
+          );
           results.failed.push(inputFile);
         }
       }
@@ -373,12 +364,9 @@ export class LaTeXdiffService {
   }
 
   private async validateDocumentStructure(
-    ...files: FileLocation[]
+    file: FileLocation,
   ): Promise<boolean> {
-    const contents = await Promise.all(
-      files.map((file) => flexibleFS.read(file)),
-    );
-    return contents.every(hasDocumentEnvironment);
+    return hasDocumentEnvironment(await flexibleFS.read(file));
   }
 
   private async bothFilesExist(

--- a/src/latex/latexdiff/diffCommandExecutor.ts
+++ b/src/latex/latexdiff/diffCommandExecutor.ts
@@ -134,6 +134,19 @@ export class DiffCommandExecutor {
     return command.toSpliced(position, 0, '--flatten');
   }
 
+  /** Markup-related flags shared by the latexdiff and latexdiff-vc commands. */
+  private markupFlags(
+    mathMarkup: MathMarkupOption,
+    subtype?: string,
+  ): string[] {
+    return [
+      '--graphics-markup=none',
+      buildLatexdiffTextCommandExclusionFlag(),
+      `--math-markup=${mathMarkup}`,
+      ...(subtype ? [`--subtype=${subtype}`] : []),
+    ];
+  }
+
   private buildLatexdiffCommand(
     inputFile: string,
     editedFile: string,
@@ -147,10 +160,7 @@ export class DiffCommandExecutor {
       '--encoding=utf8',
       '-c',
       `PICTUREENV=${pictureEnvs}`,
-      '--graphics-markup=none',
-      buildLatexdiffTextCommandExclusionFlag(),
-      `--math-markup=${mathMarkup}`,
-      ...(subtype ? [`--subtype=${subtype}`] : []),
+      ...this.markupFlags(mathMarkup, subtype),
       inputFile,
       editedFile,
     ];
@@ -172,10 +182,7 @@ export class DiffCommandExecutor {
       `PICTUREENV=${pictureEnvs}`,
       '--force',
       '--git',
-      '--graphics-markup=none',
-      buildLatexdiffTextCommandExclusionFlag(),
-      `--math-markup=${mathMarkup}`,
-      ...(subtype ? [`--subtype=${subtype}`] : []),
+      ...this.markupFlags(mathMarkup, subtype),
       '-r',
       commitHash,
       inputFile,

--- a/src/latex/latexdiff/mathMarkup.ts
+++ b/src/latex/latexdiff/mathMarkup.ts
@@ -4,15 +4,13 @@ export type MathMarkupOption = (typeof MATH_MARKUP_OPTIONS)[number];
 
 export const DEFAULT_MATH_MARKUP: MathMarkupOption = 'coarse';
 
+const MATH_MARKUP_DESCRIPTIONS: Record<MathMarkupOption, string> = {
+  off: 'No math markup',
+  whole: 'Mark entire math environments',
+  coarse: 'Default - recommended for most documents',
+  fine: 'Detailed math markup',
+};
+
 export function describeMathMarkupOption(option: MathMarkupOption): string {
-  switch (option) {
-    case 'coarse':
-      return 'Default - recommended for most documents';
-    case 'fine':
-      return 'Detailed math markup';
-    case 'whole':
-      return 'Mark entire math environments';
-    case 'off':
-      return 'No math markup';
-  }
+  return MATH_MARKUP_DESCRIPTIONS[option];
 }

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -143,11 +143,8 @@ export async function compileLatex2Pdf(
     // Build kpathsea search-path overrides, prepending workspace/TikZ dirs onto
     // any inherited values. `path.delimiter` keeps it cross-platform.
     const env = buildLatexInputEnv(texInputParts, bibSearchParts);
-    for (const key of ['TEXINPUTS', 'BIBINPUTS', 'BSTINPUTS'] as const) {
-      const value = env[key];
-      if (value) {
-        logger.debug(channel, `Setting ${key} to: ${value}`);
-      }
+    for (const [key, value] of Object.entries(env)) {
+      logger.debug(channel, `Setting ${key} to: ${value}`);
     }
 
     const latexmkArgs = [
@@ -164,6 +161,15 @@ export async function compileLatex2Pdf(
       latexFile,
     ];
 
+    function runPdflatex() {
+      return runToolWithCheck('pdflatex', pdflatexArgs, {
+        channel,
+        env,
+        timeout,
+        showError: true, // Show error if pdflatex fails
+      });
+    }
+
     let result: Awaited<ReturnType<typeof runToolWithCheck>>;
     if (compiler === 'latexmk') {
       result = await runToolWithCheck('latexmk', latexmkArgs, {
@@ -178,20 +184,10 @@ export async function compileLatex2Pdf(
           'latexmk not found, falling back to single-pass pdflatex — ' +
             'bibliography, cross-references, and index may be incomplete',
         );
-        result = await runToolWithCheck('pdflatex', pdflatexArgs, {
-          channel,
-          env,
-          timeout,
-          showError: true, // Show error if pdflatex also fails
-        });
+        result = await runPdflatex();
       }
     } else {
-      result = await runToolWithCheck('pdflatex', pdflatexArgs, {
-        channel,
-        env,
-        timeout,
-        showError: true, // Show error for missing pdflatex
-      });
+      result = await runPdflatex();
     }
 
     if (result && result.success) {

--- a/src/skills/loadSkills.ts
+++ b/src/skills/loadSkills.ts
@@ -52,6 +52,28 @@ export interface DiscoverSkillSourcesResult {
   errors: SkillLoadIssue[];
 }
 
+function dupNameIssue(name: string, path: string): SkillLoadIssue {
+  return issue(
+    'warning',
+    'duplicate_name',
+    `Skipping duplicate skill name "${name}"`,
+    { path, name },
+  );
+}
+
+function dupRealpathIssue(
+  realPath: string,
+  path: string,
+  name?: string,
+): SkillLoadIssue {
+  return issue(
+    'warning',
+    'duplicate_realpath',
+    `Skipping duplicate skill path ${realPath}`,
+    name === undefined ? { path } : { path, name },
+  );
+}
+
 /**
  * Discover one-level `SKILL.md` packages below `root`.
  *
@@ -102,14 +124,7 @@ export async function discoverSkills(
     }
 
     if (seenRealPaths.has(realSkillPath)) {
-      errors.push(
-        issue(
-          'warning',
-          'duplicate_realpath',
-          `Skipping duplicate skill path ${realSkillPath}`,
-          { path: skillPath },
-        ),
-      );
+      errors.push(dupRealpathIssue(realSkillPath, skillPath));
       continue;
     }
     seenRealPaths.add(realSkillPath);
@@ -119,14 +134,7 @@ export async function discoverSkills(
     if (!loaded.skill) continue;
 
     if (seenNames.has(loaded.skill.name)) {
-      errors.push(
-        issue(
-          'warning',
-          'duplicate_name',
-          `Skipping duplicate skill name "${loaded.skill.name}"`,
-          { path: loaded.skill.path, name: loaded.skill.name },
-        ),
-      );
+      errors.push(dupNameIssue(loaded.skill.name, loaded.skill.path));
       continue;
     }
 
@@ -225,26 +233,12 @@ export async function discoverSkillSources(
       }
 
       if (seenRealPaths.has(realSkillPath)) {
-        errors.push(
-          issue(
-            'warning',
-            'duplicate_realpath',
-            `Skipping duplicate skill path ${realSkillPath}`,
-            { path: skill.path, name: skill.name },
-          ),
-        );
+        errors.push(dupRealpathIssue(realSkillPath, skill.path, skill.name));
         continue;
       }
 
       if (seenNames.has(skill.name)) {
-        errors.push(
-          issue(
-            'warning',
-            'duplicate_name',
-            `Skipping duplicate skill name "${skill.name}"`,
-            { path: skill.path, name: skill.name },
-          ),
-        );
+        errors.push(dupNameIssue(skill.name, skill.path));
         continue;
       }
 

--- a/src/tools/approval/streamApprovalQueue.ts
+++ b/src/tools/approval/streamApprovalQueue.ts
@@ -120,10 +120,11 @@ export function createStreamApprovalController<R extends { accepted: boolean }>(
   // Serialize approvals so only one prompt is in flight at a time.
   const queue = new PQueue({ concurrency: 1 });
 
-  function rejectMatching(streamId?: StreamTabId): void {
+  function rejectWhere(
+    predicate: (entry: PendingApproval<R>) => boolean,
+  ): void {
     for (const entry of pending.values()) {
-      const matches = streamId === undefined || entry.streamId === streamId;
-      if (matches && !entry.isSettled()) {
+      if (!entry.isSettled() && predicate(entry)) {
         entry.settle(options.rejectionResult());
       }
     }
@@ -146,21 +147,17 @@ export function createStreamApprovalController<R extends { accepted: boolean }>(
       return queue.add(run) as Promise<T>;
     },
     rejectPendingForStream(streamId) {
-      rejectMatching(streamId);
+      rejectWhere((entry) => entry.streamId === streamId);
     },
     rejectUnscopedPending(runtimeHost) {
-      for (const entry of pending.values()) {
-        if (
+      rejectWhere(
+        (entry) =>
           !entry.streamId &&
-          !entry.isSettled() &&
-          (runtimeHost === undefined || entry.runtimeHost === runtimeHost)
-        ) {
-          entry.settle(options.rejectionResult());
-        }
-      }
+          (runtimeHost === undefined || entry.runtimeHost === runtimeHost),
+      );
     },
     rejectAllPending() {
-      rejectMatching();
+      rejectWhere(() => true);
     },
   };
 }

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -348,11 +348,7 @@ export async function writeApprovedContent(
   // so comparisons work directly without extra normalization.
   const currentContent = await WorkspaceFS.read(path);
 
-  if (currentContent === finalContent) {
-    return { appliedContent: currentContent, baseContent: currentContent };
-  }
-
-  if (originalContent === finalContent) {
+  if (currentContent === finalContent || originalContent === finalContent) {
     return { appliedContent: currentContent, baseContent: currentContent };
   }
 

--- a/src/tools/goal/goalStore.ts
+++ b/src/tools/goal/goalStore.ts
@@ -112,20 +112,34 @@ async function addToIndex(streamId: StreamTabId): Promise<void> {
   await platform().workspaceState.update(INDEX_KEY, [...index, streamId]);
 }
 
+/**
+ * Rewrite INDEX_KEY from the unioned index and drop LEGACY_INDEX_KEY when
+ * present, so a removed entry can't resurface from `odysseys:index` on the next
+ * `readIndex`. Returns an empty list when nothing needs to change.
+ */
+function buildIndexWriteOps(
+  state: NonNullable<ReturnType<typeof tryWorkspaceState>>,
+  index: StreamTabId[],
+  nextIndex: StreamTabId[],
+  hasLegacyIndex: boolean,
+): PromiseLike<void>[] {
+  const ops: PromiseLike<void>[] = [];
+  if (hasLegacyIndex || nextIndex.length !== index.length) {
+    ops.push(state.update(INDEX_KEY, nextIndex));
+  }
+  if (hasLegacyIndex) {
+    ops.push(state.update(LEGACY_INDEX_KEY, undefined));
+  }
+  return ops;
+}
+
 async function removeFromIndex(streamId: StreamTabId): Promise<void> {
   const state = tryWorkspaceState();
   if (!state) return;
-  // `readIndex` unions in the legacy index, so a removal must also migrate
-  // that union into the new key and drop the legacy one — otherwise the
-  // removed entry resurfaces from `odysseys:index` on the next read.
   const hasLegacyIndex = state.get<unknown>(LEGACY_INDEX_KEY) != null;
   const index = readIndex();
   const next = index.filter((id) => id !== streamId);
-  if (!hasLegacyIndex && next.length === index.length) return;
-  await Promise.all([
-    state.update(INDEX_KEY, next),
-    hasLegacyIndex ? state.update(LEGACY_INDEX_KEY, undefined) : null,
-  ]);
+  await Promise.all(buildIndexWriteOps(state, index, next, hasLegacyIndex));
 }
 
 /**
@@ -299,13 +313,7 @@ export const GoalStore = {
     await Promise.all([
       ...toRemove.map((id) => state.update(streamKey(id), undefined)),
       ...toRemove.map((id) => state.update(legacyStreamKey(id), undefined)),
-      hasLegacyIndex || nextIndex.length !== index.length
-        ? state.update(INDEX_KEY, nextIndex)
-        : Promise.resolve(),
-      // Migrated into the union write above; see removeFromIndex.
-      hasLegacyIndex
-        ? state.update(LEGACY_INDEX_KEY, undefined)
-        : Promise.resolve(),
+      ...buildIndexWriteOps(state, index, nextIndex, hasLegacyIndex),
     ]);
     for (const id of toRemove)
       emitRuntimeEvent('goalStateChanged', { streamId: id });

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -60,8 +60,7 @@ const MemoryToolInputSchema = z.strictObject({
   path: z.string().nullish(),
   file_text: z.string().nullish(),
   view_range: z
-    .array(z.int().min(1))
-    .length(2)
+    .tuple([z.int().min(1), z.int().min(1)])
     .refine(([start, end]) => end >= start, {
       error: 'view_range[1] must be greater than or equal to view_range[0]',
     })
@@ -138,8 +137,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
       case 'view':
         return this.view(
           locate(input.path, 'path'),
-          // Schema enforces length 2; cast since Zod infers number[]
-          input.view_range as [number, number] | undefined,
+          input.view_range ?? undefined,
           input.offset ?? 0,
           input.limit ?? 100,
         );
@@ -351,9 +349,9 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
 
     if (occurrences > 1) {
       const lines = content.split('\n');
-      const lineNumbers = lines
-        .map((line, index) => (line.includes(oldStr) ? index + 1 : -1))
-        .filter((n) => n !== -1);
+      const lineNumbers = lines.flatMap((line, index) =>
+        line.includes(oldStr) ? [index + 1] : [],
+      );
       throw new ToolError(
         `old_str is not unique within ${inputPath} (found in lines ${lineNumbers.join(', ')}). Include more surrounding context to make it unique.`,
       );

--- a/src/tools/memory/memoryFileSystem.ts
+++ b/src/tools/memory/memoryFileSystem.ts
@@ -65,18 +65,16 @@ async function readStoragePrefix(
  */
 function buildPreview(
   content: string,
-  options?: { truncated?: boolean; exactLineCount?: boolean },
+  options: { truncated: boolean; exactLineCount: boolean },
 ): {
   preview: string;
   lineCount?: number;
 } {
   const lines = splitContentLines(content);
-  const exactLineCount = options?.exactLineCount ?? true;
-  const lineCount = exactLineCount ? lines.length : undefined;
+  const lineCount = options.exactLineCount ? lines.length : undefined;
   const previewLines = lines.slice(0, MAX_PREVIEW_LINES);
   let preview = previewLines.join('\n');
-  let truncated =
-    lines.length > MAX_PREVIEW_LINES || (options?.truncated ?? false);
+  let truncated = lines.length > MAX_PREVIEW_LINES || options.truncated;
 
   if (preview.length > MAX_PREVIEW_CHARS) {
     preview = preview.slice(0, MAX_PREVIEW_CHARS);
@@ -201,10 +199,8 @@ export async function loadMemoryItems(): Promise<MemoryViewItem[]> {
   }
 
   const items = await walkMemoryDirectory(MEMORY_STORAGE_ROOT);
-  return items.sort((a, b) => {
-    const aPinned = a.pinned ? 1 : 0;
-    const bPinned = b.pinned ? 1 : 0;
-    if (aPinned !== bPinned) return bPinned - aPinned;
-    return b.mtime.localeCompare(a.mtime);
-  });
+  return items.toSorted(
+    (a, b) =>
+      (b.pinned ? 1 : 0) - (a.pinned ? 1 : 0) || b.mtime.localeCompare(a.mtime),
+  );
 }

--- a/src/tools/wolfram/wolframScriptUtils.ts
+++ b/src/tools/wolfram/wolframScriptUtils.ts
@@ -20,6 +20,16 @@ export interface WolframScriptResult {
   exitCode: number | null;
 }
 
+function wolframFailure(error: string): WolframScriptResult {
+  return {
+    success: false,
+    output: null,
+    error,
+    timedOut: false,
+    exitCode: null,
+  };
+}
+
 /**
  * Internal helper to run wolframscript commands with installation check.
  * @param commandArgs Array of command-line arguments to pass to wolframscript (e.g., ['-code', 'expr'] or ['-file', 'path'])
@@ -32,18 +42,11 @@ async function runWolfram(
 ): Promise<WolframScriptResult> {
   const isInstalled = await checkToolInstalled('wolframscript', false);
   if (!isInstalled) {
-    return {
-      success: false,
-      output: null,
-      error: WOLFRAM_NOT_INSTALLED_ERROR,
-      timedOut: false,
-      exitCode: null,
-    };
+    return wolframFailure(WOLFRAM_NOT_INSTALLED_ERROR);
   }
 
   try {
-    const command = ['wolframscript', ...commandArgs];
-    const result = await executeCommand(command, {
+    const result = await executeCommand(['wolframscript', ...commandArgs], {
       truncate: false,
       timeout,
       channel: WOLFRAM_CHANNEL,
@@ -57,15 +60,7 @@ async function runWolfram(
       exitCode: result.exitCode ?? null,
     };
   } catch (err) {
-    const errorMessage = toErrorMessage(err);
-
-    return {
-      success: false,
-      output: null,
-      error: errorMessage,
-      timedOut: false,
-      exitCode: null,
-    };
+    return wolframFailure(toErrorMessage(err));
   }
 }
 


### PR DESCRIPTION
## Summary

Microscopic, line-level LoC reduction — the **run-critical tier** (model handlers, agent runtime/flows, LaTeX, tool subsystems), kept separate from the low-risk micro PR (#6838) because provider/streaming and core-flow regressions are subtle. 29 files, net ~110 lines removed, behavior-preserving. File-disjoint from #6838 and the merged coupling work.

## Methods applied

- **Dedup into shared helpers**: `mapAnthropicWebSearchEntries` (stream handler + extractor now share one mapper), `thoughtStep` (Google handler), `joinStringsWithNewline` (OpenAI message utils), `persistMetaField` / `listExecutionDirs` (storage), `deriveEndTagFrom`, and skill duplicate-issue factories.
- **Pass-throughs inlined**: `normalizeToArray`/`getFirstItem`, `parseFetchUrl`/`parseSearchQuery`. Collapsed three redundant system/user `push` ladders in the OpenRouter handler — the discriminated-union role merge was verified against the structurally identical, already-shipping OpenAI handler.
- **Declarative over imperative**: `isEndTurnStop` lowercases once; `END_TURN_REASONS` hoisted to a module const; `UsageMonitor` number-filter via `Object.fromEntries`; a flat (non-nested) status assignment that honors the repo's no-nested-ternary rule.

## Verification

- Full workspace typecheck green.
- `pnpm run test` passes — **4215 tests, zero failures, no test fixes needed** (the careful tier landed clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches stop-reason handling, OpenRouter message roles, Anthropic streaming web-search mapping, and Google thought-step assembly in run-critical paths; changes are refactors but regressions would affect turns, tools, or streaming UX.
> 
> **Overview**
> Behavior-preserving cleanup across **~29 files** in the agent runtime, model handlers, LaTeX tooling, and tool subsystems—mostly shared helpers and collapsed branches, net ~110 lines removed.
> 
> **Agent / runtime:** `deriveEndTagFrom` unifies default vs explicit `endTag` derivation; `handleInvocationResult` routes cancel/fail/empty through a local `stop()` helper; execution meta writes share `persistMetaField`; execution directory scanning uses `listExecutionDirs`; goal index migration reuses `buildIndexWriteOps`.
> 
> **Model handlers:** Module-level `END_TURN_REASONS` and a simplified `isEndTurnStop` (case-normalized `end_turn` / `endturn`); **`mapAnthropicWebSearchEntries`** shared by stream and batch Anthropic web-search paths; Google Interactions **`thoughtStep`** for streaming and turn assembly; OpenAI message merge uses **`joinStringsWithNewline`**; OpenRouter message pushes use a single `role` variable instead of duplicated system/user ladders; `ToolUseRoundShared` drops redundant interface fields already on the schema type.
> 
> **Tools / LaTeX / misc:** Stream approval rejection uses **`rejectWhere`**; memory `view_range` is a Zod tuple; housekeeping **pack** treats “only input copied” as no-op; latexdiff markup flags and VC batch loop inlined; small helpers in TikZ, dependencies, skills, Wolfram, etc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11cb29a7216aecb8339316018697985c469dfb95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->