### PR TITLE
refactor: remove dead exported surface

### DIFF
--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -29,7 +29,7 @@ import { POINTER } from '../ui/glyphs';
 import { SELECT_LABEL_MAX_COLS } from '../ui/Select';
 import type { StreamSlice } from '../state/cliState';
 
-export interface ChildControlPickerProps {
+interface ChildControlPickerProps {
   readonly availableColumns?: number;
   readonly streamLabel: string | undefined;
   readonly activeStreamId: StreamTabId | undefined;
@@ -410,7 +410,7 @@ function metaLine(
   );
 }
 
-export interface TaskDetailLayout {
+interface TaskDetailLayout {
   readonly compact: boolean;
   readonly showCommand: boolean;
   readonly showExpandedMeta: boolean;
@@ -420,7 +420,7 @@ export interface TaskDetailLayout {
   readonly visibleLineCount: number;
 }
 
-export interface PickerListLayout {
+interface PickerListLayout {
   readonly end: number;
   readonly hiddenAfter: number;
   readonly hiddenBefore: number;
@@ -444,19 +444,19 @@ export function compactPickerOverflowText({
   return `+${more} more`;
 }
 
-export interface TaskDetailScrollState {
+interface TaskDetailScrollState {
   readonly anchor?: TaskDetailScrollAnchor;
   readonly executionId: string;
   readonly followsTail: boolean;
   readonly offset: number;
 }
 
-export interface TaskDetailScrollAnchor {
+interface TaskDetailScrollAnchor {
   readonly lineIndex: number;
   readonly wrappedRowOffset: number;
 }
 
-export interface TaskDetailScrollContext {
+interface TaskDetailScrollContext {
   readonly availableColumns?: number;
   readonly compact: boolean;
   readonly tailLines: readonly string[];

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -55,9 +55,9 @@ import { useLiveNowMs } from '../state/useLiveNowMs';
 import { useSignal } from '../state/useSignal';
 
 type StatusBarColor = 'cyan' | 'yellow' | 'red' | 'dim';
-export type CtrlCAction = 'exit' | 'stop' | 'stop root';
+type CtrlCAction = 'exit' | 'stop' | 'stop root';
 
-export interface StatusBarSegment {
+interface StatusBarSegment {
   readonly text: string;
   readonly color?: StatusBarColor;
   readonly badge?: boolean;
@@ -121,7 +121,7 @@ export interface StatusBarDisplayInput {
   readonly foregroundEscapeAction?: string;
 }
 
-export interface StatusBarDisplay {
+interface StatusBarDisplay {
   readonly left: readonly StatusBarSegment[];
   readonly right?: string;
   readonly bindings: string;
@@ -606,7 +606,7 @@ interface StatusBarVisibleStream {
   readonly status: StreamStatus | undefined;
 }
 
-export interface StatusBarStreamTarget {
+interface StatusBarStreamTarget {
   readonly ctrlCAction: CtrlCAction;
   readonly displaySlice: StreamSlice | undefined;
 }
@@ -797,7 +797,7 @@ export function buildStatusBarDisplay(
   };
 }
 
-export interface StatusBarProps {
+interface StatusBarProps {
   readonly agentSelectionAvailable?: boolean;
   readonly canStopActiveRun?: () => boolean;
   readonly canStopPendingRunWithoutStream?: () => boolean;

--- a/packages/cli/src/chat/tui/render/DiffView.tsx
+++ b/packages/cli/src/chat/tui/render/DiffView.tsx
@@ -13,19 +13,19 @@ import { wrapAnsiToWidth } from './ansiWrap';
 import { maxScrollableRowOffset, scrollBoundedRows } from './scrollBounds';
 import { clipToWidth, fillRows, textDisplayWidth } from './terminalText';
 
-export type Hunk = StructuredPatchHunk;
+type Hunk = StructuredPatchHunk;
 
 export interface InlinePatchGroup {
   readonly fileLabel: string;
   readonly hunks: readonly Hunk[];
 }
 
-export interface DiffDisplayLine {
+interface DiffDisplayLine {
   readonly kind: 'added' | 'context' | 'header' | 'removed' | 'overflow';
   readonly text: string;
 }
 
-export interface DiffStats {
+interface DiffStats {
   readonly added: number;
   readonly removed: number;
   readonly hunks: number;
@@ -295,7 +295,7 @@ export function scrollBoundedDiffDisplayLines(
   ];
 }
 
-export interface DiffViewProps {
+interface DiffViewProps {
   readonly hunks: readonly Hunk[];
   /** Maximum total rendered diff rows before truncating; 0 = no truncation. */
   readonly maxDisplayLines?: number;

--- a/packages/cli/src/chat/tui/render/ansiMarkdown.ts
+++ b/packages/cli/src/chat/tui/render/ansiMarkdown.ts
@@ -443,7 +443,7 @@ function processorFor(
   return processor;
 }
 
-export interface RenderAnsiMarkdownOptions {
+interface RenderAnsiMarkdownOptions {
   readonly width?: number;
   readonly colorEnabled?: boolean;
 }

--- a/packages/cli/src/runtime/tools.ts
+++ b/packages/cli/src/runtime/tools.ts
@@ -27,7 +27,7 @@ export interface CliToolStatusRecord {
   readonly note?: string;
 }
 
-export type CliToolGuideKind = 'install' | 'auth';
+type CliToolGuideKind = 'install' | 'auth';
 
 export interface CliToolGuide {
   readonly text: string;

--- a/packages/cli/src/runtime/workflowOutput.ts
+++ b/packages/cli/src/runtime/workflowOutput.ts
@@ -88,7 +88,7 @@ type WorkflowAgentResult = Extract<
   { category: 'workflow' }
 >;
 
-export interface WorkflowOutputResolutionOptions {
+interface WorkflowOutputResolutionOptions {
   readonly expectedOutputFiles?: readonly string[];
   readonly runDirectory?: string;
   readonly terminalStatus: ExecutionStatus;

--- a/packages/desktop/src/main/desktopCrashReporting.ts
+++ b/packages/desktop/src/main/desktopCrashReporting.ts
@@ -4,8 +4,7 @@ import { unique } from '@utils/core';
 import type { PlatformSecrets } from '@platform/secrets';
 import type { StateStore } from '@platform/interfaces/state';
 
-export const DESKTOP_CRASH_REPORTING_DSN_SECRET =
-  'texra.desktop.crashReporting.dsn';
+const DESKTOP_CRASH_REPORTING_DSN_SECRET = 'texra.desktop.crashReporting.dsn';
 
 const REDACTED_PATH = '<redacted-path>';
 
@@ -14,7 +13,7 @@ export interface DesktopCrashReportingStatus {
   configured: boolean;
 }
 
-export interface DesktopCrashReportingInitOptions {
+interface DesktopCrashReportingInitOptions {
   globalState: StateStore;
   secrets: PlatformSecrets;
   sensitivePaths: readonly (string | undefined)[];
@@ -76,14 +75,7 @@ function scrubValue(value: unknown, scrubbers: readonly RegExp[]): unknown {
   return value;
 }
 
-export function scrubDesktopCrashEvent(
-  event: CrashEvent,
-  sensitivePaths: readonly (string | undefined)[],
-): CrashEvent | null {
-  return createDesktopCrashEventScrubber(sensitivePaths)(event);
-}
-
-export function createDesktopCrashEventScrubber(
+function createDesktopCrashEventScrubber(
   sensitivePaths: readonly (string | undefined)[],
 ): (event: CrashEvent) => CrashEvent | null {
   const scrubbers = buildPathScrubbers(sensitivePaths);

--- a/packages/desktop/src/main/desktopCrashReporting.ts
+++ b/packages/desktop/src/main/desktopCrashReporting.ts
@@ -4,7 +4,8 @@ import { unique } from '@utils/core';
 import type { PlatformSecrets } from '@platform/secrets';
 import type { StateStore } from '@platform/interfaces/state';
 
-const DESKTOP_CRASH_REPORTING_DSN_SECRET = 'texra.desktop.crashReporting.dsn';
+export const DESKTOP_CRASH_REPORTING_DSN_SECRET =
+  'texra.desktop.crashReporting.dsn';
 
 const REDACTED_PATH = '<redacted-path>';
 
@@ -13,7 +14,7 @@ export interface DesktopCrashReportingStatus {
   configured: boolean;
 }
 
-interface DesktopCrashReportingInitOptions {
+export interface DesktopCrashReportingInitOptions {
   globalState: StateStore;
   secrets: PlatformSecrets;
   sensitivePaths: readonly (string | undefined)[];
@@ -75,7 +76,14 @@ function scrubValue(value: unknown, scrubbers: readonly RegExp[]): unknown {
   return value;
 }
 
-function createDesktopCrashEventScrubber(
+export function scrubDesktopCrashEvent(
+  event: CrashEvent,
+  sensitivePaths: readonly (string | undefined)[],
+): CrashEvent | null {
+  return createDesktopCrashEventScrubber(sensitivePaths)(event);
+}
+
+export function createDesktopCrashEventScrubber(
   sensitivePaths: readonly (string | undefined)[],
 ): (event: CrashEvent) => CrashEvent | null {
   const scrubbers = buildPathScrubbers(sensitivePaths);

--- a/packages/desktop/src/main/platform/electronSecrets.ts
+++ b/packages/desktop/src/main/platform/electronSecrets.ts
@@ -12,10 +12,10 @@ interface ElectronSecretsOptions {
   showWarningMessage?: (message: string) => Promise<void> | void;
 }
 
-const LINUX_BASIC_TEXT_SECRET_STORAGE_MESSAGE =
+export const LINUX_BASIC_TEXT_SECRET_STORAGE_MESSAGE =
   'TeXRA cannot store secrets securely because Electron is using Linux basic_text storage. Set up a system keyring such as GNOME Keyring/libsecret or KWallet, then restart TeXRA. Environment variables still work for API keys.';
 
-const KEYCHAIN_DENIED_WARNING_MESSAGE =
+export const KEYCHAIN_DENIED_WARNING_MESSAGE =
   'TeXRA could not decrypt its saved secrets. This usually happens when the system keychain prompt was denied, but it can also occur with corrupted entries or rotated encryption keys. Saved API keys and sign-in sessions will not be available until decryption succeeds. Restart TeXRA after granting keychain access (or re-saving secrets) to retry.';
 
 const SAFE_STORAGE_UNAVAILABLE_MESSAGE =
@@ -162,7 +162,12 @@ export class ElectronSecrets implements PlatformSecrets {
   }
 }
 
-function getSecretStorageMode(): SecretStorageMode {
+/** Test-only: reset latched module-level state so unit tests can re-exercise the path. */
+export function __resetKeychainStateForTests(): void {
+  warnedAboutKeychainDisabled = false;
+}
+
+export function getSecretStorageMode(): SecretStorageMode {
   // Test-harness shim: report unavailable without ever calling safeStorage,
   // which is the path that would otherwise prompt the macOS keychain.
   if (isKeychainDisabled()) return 'unavailable';

--- a/packages/desktop/src/main/platform/electronSecrets.ts
+++ b/packages/desktop/src/main/platform/electronSecrets.ts
@@ -12,10 +12,10 @@ interface ElectronSecretsOptions {
   showWarningMessage?: (message: string) => Promise<void> | void;
 }
 
-export const LINUX_BASIC_TEXT_SECRET_STORAGE_MESSAGE =
+const LINUX_BASIC_TEXT_SECRET_STORAGE_MESSAGE =
   'TeXRA cannot store secrets securely because Electron is using Linux basic_text storage. Set up a system keyring such as GNOME Keyring/libsecret or KWallet, then restart TeXRA. Environment variables still work for API keys.';
 
-export const KEYCHAIN_DENIED_WARNING_MESSAGE =
+const KEYCHAIN_DENIED_WARNING_MESSAGE =
   'TeXRA could not decrypt its saved secrets. This usually happens when the system keychain prompt was denied, but it can also occur with corrupted entries or rotated encryption keys. Saved API keys and sign-in sessions will not be available until decryption succeeds. Restart TeXRA after granting keychain access (or re-saving secrets) to retry.';
 
 const SAFE_STORAGE_UNAVAILABLE_MESSAGE =
@@ -162,12 +162,7 @@ export class ElectronSecrets implements PlatformSecrets {
   }
 }
 
-/** Test-only: reset latched module-level state so unit tests can re-exercise the path. */
-export function __resetKeychainStateForTests(): void {
-  warnedAboutKeychainDisabled = false;
-}
-
-export function getSecretStorageMode(): SecretStorageMode {
+function getSecretStorageMode(): SecretStorageMode {
   // Test-harness shim: report unavailable without ever calling safeStorage,
   // which is the path that would otherwise prompt the macOS keychain.
   if (isKeychainDisabled()) return 'unavailable';

--- a/src/agent/core/constants.ts
+++ b/src/agent/core/constants.ts
@@ -1,5 +1,2 @@
 /** Length for preview slices of tool output and responses. */
 export const K_SLICE = 200;
-
-/** Generic preview length for logging message content. */
-export const MESSAGE_PREVIEW_LENGTH = 50;

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -9,13 +9,11 @@ export {
   type ExecutionMeta,
   type TodoEntry,
   type ChildRecord,
-  type ChildRecordData,
   type ResultMeta,
   getExecutionStore,
   clearStoreCache,
 } from './ExecutionKVStore';
 export {
-  type ExecutionWorkspaceFile,
   listExecutionWorkspaceFiles,
   resolveExecutionWorkspaceFilePath,
 } from './executionWorkspaceFiles';

--- a/src/agent/types/index.ts
+++ b/src/agent/types/index.ts
@@ -5,12 +5,4 @@
  * For schemas and less common types, import directly from the specific file.
  */
 
-// Identifier types - most commonly used
-export type { StreamTabId, ExecutionId, StorageKey } from '@shared/schemas';
-
-// Usage types
-export type { TokenUsageStats, ExtendedTokenUsageStats } from '@shared/schemas';
-export type { NormalizedUsage } from './NormalizedUsage';
-
-// Result types
-export type { ExecResult, FileOpResult } from '@shared/schemas/opResults';
+export type { FileOpResult } from '@shared/schemas/opResults';

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -14,20 +14,15 @@ import {
 } from './sharedConfig';
 export {
   AUTH_BRIDGE_URL,
-  DEVICE_AUTH_BASE_URL,
   FREE_TIER,
   GITHUB_TOKEN_EXCHANGE_URL,
   GITHUB_TOKEN_REFRESH_URL,
   MAX_TIER,
-  OAUTH_PROVIDERS,
-  SERVER_SIDE_CACHE_TTL_MS,
   SUPABASE_CONFIG,
   SUPABASE_CUSTOM_DOMAIN,
   ULTRA_TIER,
-  UserTierSchema,
   isOAuthProvider,
   type OAuthProvider,
-  type SupabaseConfig,
   type UserTier,
 } from './sharedConfig';
 

--- a/src/shared/schemas/agent.ts
+++ b/src/shared/schemas/agent.ts
@@ -54,8 +54,6 @@ export const AgentMetadataBaseSchema = z.object({
   description: z.string().optional(),
 });
 
-export type AgentMetadataBase = z.infer<typeof AgentMetadataBaseSchema>;
-
 /** Canonical key format: disambiguates agents with same name across sources. */
 export function agentKey(source: string, name: string): string {
   return `${source}:${name}`;

--- a/src/shared/schemas/commonViewMessages.ts
+++ b/src/shared/schemas/commonViewMessages.ts
@@ -56,10 +56,5 @@ export const CommonViewMessageSchema = z.discriminatedUnion('command', [
   ErrorMessageSchema,
 ]);
 
-export type SetThemeMessage = z.infer<typeof SetThemeMessageSchema>;
-export type SetDebugModeMessage = z.infer<typeof SetDebugModeMessageSchema>;
 export type StateRestoreMessage = z.infer<typeof StateRestoreMessageSchema>;
-export type WebviewReadyMessage = z.infer<typeof WebviewReadyMessageSchema>;
 export type SwitchViewMessage = z.infer<typeof SwitchViewMessageSchema>;
-export type ErrorMessage = z.infer<typeof ErrorMessageSchema>;
-export type CommonViewMessage = z.infer<typeof CommonViewMessageSchema>;

--- a/src/shared/schemas/log.ts
+++ b/src/shared/schemas/log.ts
@@ -57,8 +57,6 @@ export const STREAM_LOG_ENTRY_TYPES = {
 
 export const StreamLogEntryTypeSchema = z.enum(STREAM_LOG_ENTRY_TYPES);
 
-export type StreamLogEntryType = z.infer<typeof StreamLogEntryTypeSchema>;
-
 export const FileListEntrySchema = z.object({
   path: z.string(),
   ok: z.boolean(),
@@ -100,7 +98,6 @@ export type LogMessageData = z.infer<typeof LogMessageDataSchema>;
 export const LogMessageUpdateSchema = LogMessageDataSchema.partial().required({
   id: true,
 });
-export type LogMessageUpdate = z.infer<typeof LogMessageUpdateSchema>;
 
 /**
  * Legacy log message format (from STREAM_TABS era).

--- a/src/shared/schemas/mainView/state.ts
+++ b/src/shared/schemas/mainView/state.ts
@@ -38,7 +38,6 @@ export const PickerOptionBaseSchema = z.object({
   value: z.string(),
   label: z.string(),
 });
-export type PickerOptionBase = z.infer<typeof PickerOptionBaseSchema>;
 
 export const ModelAvailabilityKindSchema = z.enum([
   'included-access',
@@ -67,10 +66,6 @@ export const ModelAvailabilityFieldsSchema = z.object({
   requiresKey: z.boolean().optional(),
   disabled: z.boolean().optional(),
 });
-export type ModelAvailabilityFields = z.infer<
-  typeof ModelAvailabilityFieldsSchema
->;
-
 export const ModelOptionDataSchema = PickerOptionBaseSchema.extend({
   provider: z.string().optional(),
   context: z.string().optional(),

--- a/src/shared/schemas/memoryViewMessages.ts
+++ b/src/shared/schemas/memoryViewMessages.ts
@@ -44,23 +44,16 @@ export const UpdateMemoryMessageSchema = z.object({
   command: z.literal(MEMORY_VIEW_COMMANDS.UPDATE_MEMORY),
   items: z.array(MemoryViewItemSchema),
 });
-export type UpdateMemoryMessage = z.infer<typeof UpdateMemoryMessageSchema>;
 
 export const UpdateMemoryPreviewMessageSchema = z.object({
   command: z.literal(MEMORY_VIEW_COMMANDS.UPDATE_MEMORY_PREVIEW),
   preview: MemoryPreviewSchema,
 });
-export type UpdateMemoryPreviewMessage = z.infer<
-  typeof UpdateMemoryPreviewMessageSchema
->;
 
 export const UpdateMemoryEnabledMessageSchema = z.object({
   command: z.literal(MEMORY_VIEW_COMMANDS.UPDATE_MEMORY_ENABLED),
   enabled: z.boolean(),
 });
-export type UpdateMemoryEnabledMessage = z.infer<
-  typeof UpdateMemoryEnabledMessageSchema
->;
 
 // ============================================================
 // Inbound message schemas (frontend → backend)

--- a/src/shared/schemas/output.ts
+++ b/src/shared/schemas/output.ts
@@ -84,8 +84,6 @@ export const CompileFailureSchema = z.strictObject({
   logRelativePath: z.string(),
 });
 
-export type OutputFile = z.infer<typeof OutputFileSchema>;
-export type FileLineage = z.infer<typeof FileLineageSchema>;
 export type OutputFileInfo = z.infer<typeof OutputFileInfoSchema>;
 export type OutputFileSummary = z.infer<typeof OutputFileSummarySchema>;
 export type CompileFailure = z.infer<typeof CompileFailureSchema>;

--- a/src/shared/schemas/progressView/data.ts
+++ b/src/shared/schemas/progressView/data.ts
@@ -86,7 +86,6 @@ export const WebSearchResultItemSchema = z.object({
   title: z.string().optional(),
   domain: z.string().optional(),
 });
-export type WebSearchResultItem = z.infer<typeof WebSearchResultItemSchema>;
 
 export const WebSearchPayloadSchema = z.object({
   query: z.string().optional(),

--- a/src/shared/schemas/progressView/outbound.ts
+++ b/src/shared/schemas/progressView/outbound.ts
@@ -215,10 +215,6 @@ export const UpdatePermissionMessageSchema = z.discriminatedUnion('action', [
     id: z.string(),
   }),
 ]);
-export type UpdatePermissionMessage = z.infer<
-  typeof UpdatePermissionMessageSchema
->;
-
 const BypassTypeSchema = z.enum(['toolEdit', 'superYolo']);
 
 export const UpdateBypassMessageSchema = StreamScopedBaseSchema.extend({

--- a/src/shared/schemas/prompts.ts
+++ b/src/shared/schemas/prompts.ts
@@ -20,7 +20,6 @@ export const OptionalStreamIdSchema = z.union([
   StreamTabIdSchema,
   z.literal(''),
 ]);
-export type OptionalStreamId = z.infer<typeof OptionalStreamIdSchema>;
 
 /** Common permission request fields */
 const PermissionBaseSchema = z.strictObject({
@@ -89,9 +88,6 @@ export type WorkflowAgentProposalPermission = z.infer<
 
 export const ToolUseAgentProposalPermissionSchema =
   ProposalPermissionBaseSchema.extend(ToolUseAgentProposalSchema.shape);
-export type ToolUseAgentProposalPermission = z.infer<
-  typeof ToolUseAgentProposalPermissionSchema
->;
 
 export const AgentProposalPermissionSchema = z.discriminatedUnion(
   'agentCategory',
@@ -133,16 +129,10 @@ const ExternalInquiryPermissionBaseSchema = PermissionBaseSchema.extend(
  */
 export const NewExternalInquiryPermissionSchema =
   ExternalInquiryPermissionBaseSchema.extend({ mode: z.literal('new') });
-export type NewExternalInquiryPermission = z.infer<
-  typeof NewExternalInquiryPermissionSchema
->;
 
 /** Follow-up inquiry — carries thread context from prior turns. */
 export const FollowUpExternalInquiryPermissionSchema =
   ExternalInquiryPermissionBaseSchema.extend({ mode: z.literal('followUp') });
-export type FollowUpExternalInquiryPermission = z.infer<
-  typeof FollowUpExternalInquiryPermissionSchema
->;
 
 export const ExternalInquiryPermissionSchema = z.discriminatedUnion('mode', [
   NewExternalInquiryPermissionSchema,
@@ -157,7 +147,6 @@ export type ExternalInquiryPermission = z.infer<
 // ============================================================================
 
 export const USER_QUESTION_ACTIONS = ['submit', 'reject'] as const;
-export type UserQuestionAction = (typeof USER_QUESTION_ACTIONS)[number];
 
 export const UserQuestionOptionSchema = z.strictObject({
   label: z.string().min(1),

--- a/src/shared/schemas/settingsView/data.ts
+++ b/src/shared/schemas/settingsView/data.ts
@@ -100,8 +100,6 @@ export const SetTabMessageSchema = z.object({
   agentSubTab: AgentCategorySchema.optional(),
 });
 
-export type SetTabMessage = z.infer<typeof SetTabMessageSchema>;
-
 // ============================================================
 // Agent selection data schema
 // ============================================================
@@ -126,9 +124,6 @@ export const UpdateAgentSelectionMessageSchema = z.object({
   workflow: z.array(AgentSelectionItemSchema),
   toolUse: z.array(AgentSelectionItemSchema),
 });
-export type UpdateAgentSelectionMessage = z.infer<
-  typeof UpdateAgentSelectionMessageSchema
->;
 
 // ============================================================
 // Model selection data schema
@@ -206,9 +201,6 @@ export const UpdateCustomAgentDirMessageSchema = z.object({
   path: z.string(),
   isDefault: z.boolean(),
 });
-export type UpdateCustomAgentDirMessage = z.infer<
-  typeof UpdateCustomAgentDirMessageSchema
->;
 
 // ============================================================
 // Super YOLO enabled data schema
@@ -246,9 +238,6 @@ export const UpdateAgentModePresetsMessageSchema = z.object({
    */
   orchestratorAgents: z.array(z.string()).prefault([]),
 });
-export type UpdateAgentModePresetsMessage = z.infer<
-  typeof UpdateAgentModePresetsMessageSchema
->;
 
 // ============================================================
 // Tool dashboard data schemas
@@ -312,9 +301,6 @@ export const UpdateToolDashboardMessageSchema = z.object({
   command: z.literal(SETTINGS_VIEW_COMMANDS.UPDATE_TOOL_DASHBOARD),
   items: z.array(ToolDashboardItemSchema),
 });
-export type UpdateToolDashboardMessage = z.infer<
-  typeof UpdateToolDashboardMessageSchema
->;
 
 // ============================================================
 // Approval settings data schema
@@ -347,9 +333,6 @@ export const UpdateGitAuthorSettingsMessageSchema = z.object({
   authorEmail: z.string(),
   worktreeSupport: z.boolean(),
 });
-export type UpdateGitAuthorSettingsMessage = z.infer<
-  typeof UpdateGitAuthorSettingsMessageSchema
->;
 
 /** Outbound: backend → frontend GitHub token status. */
 export const UpdateGitHubTokenStatusMessageSchema = z.object({
@@ -357,9 +340,6 @@ export const UpdateGitHubTokenStatusMessageSchema = z.object({
   /** 'secret' = stored in SecretStorage; 'env' = GITHUB_TOKEN env var; 'none' = missing. */
   status: z.enum(['secret', 'env', 'none']),
 });
-export type UpdateGitHubTokenStatusMessage = z.infer<
-  typeof UpdateGitHubTokenStatusMessageSchema
->;
 
 /** Outbound: backend → frontend ChatGPT-subscription sign-in status. */
 export const ChatGptAuthStatusSchema = z.object({
@@ -375,9 +355,6 @@ export const UpdateChatGptAuthStatusMessageSchema = z.object({
   command: z.literal(SETTINGS_VIEW_COMMANDS.UPDATE_CHATGPT_AUTH_STATUS),
   status: ChatGptAuthStatusSchema,
 });
-export type UpdateChatGptAuthStatusMessage = z.infer<
-  typeof UpdateChatGptAuthStatusMessageSchema
->;
 
 /** Outbound: backend → frontend desktop crash reporting status. */
 export const UpdateDesktopCrashReportingMessageSchema = z.object({
@@ -385,15 +362,11 @@ export const UpdateDesktopCrashReportingMessageSchema = z.object({
   enabled: z.boolean(),
   configured: z.boolean(),
 });
-export type UpdateDesktopCrashReportingMessage = z.infer<
-  typeof UpdateDesktopCrashReportingMessageSchema
->;
 
 export const PRSubscriptionOwnerSchema = z.object({
   streamId: StreamTabIdSchema,
   label: z.string(),
 });
-export type PRSubscriptionOwner = z.infer<typeof PRSubscriptionOwnerSchema>;
 
 export const PRSubscriptionEntrySchema = z.object({
   key: z.string().min(1),
@@ -406,9 +379,6 @@ export const UpdatePRSubscriptionsMessageSchema = z.object({
   command: z.literal(SETTINGS_VIEW_COMMANDS.UPDATE_PR_SUBSCRIPTIONS),
   subscriptions: z.array(PRSubscriptionEntrySchema),
 });
-export type UpdatePRSubscriptionsMessage = z.infer<
-  typeof UpdatePRSubscriptionsMessageSchema
->;
 
 // ============================================================
 // LaTeX settings data schemas
@@ -463,9 +433,6 @@ export const UpdateLatexSettingsStatusMessageSchema = z.object({
   command: z.literal(SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_SETTINGS_STATUS),
   settings: LatexSettingsStatusSchema,
 });
-export type UpdateLatexSettingsStatusMessage = z.infer<
-  typeof UpdateLatexSettingsStatusMessageSchema
->;
 
 /**
  * LaTeX/compile/diff configuration values, persisted in workspace storage.
@@ -478,10 +445,8 @@ export type UpdateLatexSettingsStatusMessage = z.infer<
  * and the runtime readers all stay in lockstep.
  */
 export const LatexFormatterSchema = z.enum(LATEX_FORMATTER_VALUES);
-export type LatexFormatter = z.infer<typeof LatexFormatterSchema>;
 
 export const LatexdiffMathMarkupSchema = z.enum(LATEXDIFF_MATH_MARKUP_VALUES);
-export type LatexdiffMathMarkup = z.infer<typeof LatexdiffMathMarkupSchema>;
 
 export const LatexConfigValuesSchema = z.object({
   workflowAutoCompile: z.boolean().optional(),
@@ -508,18 +473,12 @@ export const UpdateLatexConfigValuesMessageSchema = z.object({
   command: z.literal(SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_CONFIG_VALUES),
   values: LatexConfigValuesSchema,
 });
-export type UpdateLatexConfigValuesMessage = z.infer<
-  typeof UpdateLatexConfigValuesMessageSchema
->;
 
 /** Outbound: backend → frontend inline criticism toggle state */
 export const UpdateInlineCriticismEnabledMessageSchema = z.object({
   command: z.literal(SETTINGS_VIEW_COMMANDS.UPDATE_INLINE_CRITICISM_ENABLED),
   enabled: z.boolean(),
 });
-export type UpdateInlineCriticismEnabledMessage = z.infer<
-  typeof UpdateInlineCriticismEnabledMessageSchema
->;
 
 /** Outbound: pushed when the list changes or in response to GET_GOAL_LIST. */
 export const UpdateGoalListMessageSchema = z.object({

--- a/src/shared/schemas/taskGroup.ts
+++ b/src/shared/schemas/taskGroup.ts
@@ -18,14 +18,9 @@ export const AddTaskGroupPayloadSchema = z.strictObject({
   streamId: StreamTabIdSchema,
   ...TaskGroupSchema.shape,
 });
-export type AddTaskGroupPayload = z.infer<typeof AddTaskGroupPayloadSchema>;
-
 export const UpdateTaskGroupPayloadSchema = AddTaskGroupPayloadSchema.pick({
   streamId: true,
   id: true,
   status: true,
   endTime: true,
 });
-export type UpdateTaskGroupPayload = z.infer<
-  typeof UpdateTaskGroupPayloadSchema
->;

--- a/src/transcript/index.ts
+++ b/src/transcript/index.ts
@@ -16,12 +16,7 @@ export {
   STREAM_LOGS_DIR,
   STREAM_LOG_SUMMARIES_DIR,
 } from './StreamLogStore';
-export {
-  StreamLog,
-  type StreamLogAppendInput,
-  type StreamLogUpdatePatch,
-} from './StreamLog';
-export { type TranscriptRecorderHandle } from './TexraTranscriptRecorder';
+export { StreamLog, type StreamLogAppendInput } from './StreamLog';
 export {
   createRunTrace,
   flushPendingRunTraces,
@@ -29,5 +24,5 @@ export {
   unregisterFlushers,
   type RunTrace,
 } from './runTrace';
-export { streamDataDir, type StreamDataKey } from './streamDataPaths';
+export { streamDataDir } from './streamDataPaths';
 export { StreamSnapshotStore } from './StreamSnapshotStore';

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -12,7 +12,6 @@ export {
   formatCompactTokenCount,
   formatDuration,
   serializeError,
-  type SerializedError,
 } from './stringCore';
 export {
   isObject,

--- a/src/utils/files/index.ts
+++ b/src/utils/files/index.ts
@@ -1,5 +1,4 @@
 // Core filesystem abstractions
-export { type ResolvedPath } from './workspaceRoot';
 export { WorkspaceFS } from './workspaceFS';
 export { AbsoluteFS } from './absoluteFS';
 export { StorageFS, GlobalStorageFS } from './storageFS';


### PR DESCRIPTION
## Summary

Remove provably-unused exported surface — a down payment on the knip dead-code sweep. 24 files, behavior-preserving (all removals are compile-time-only).

## What changed

- **~40 dead `z.infer` type aliases** across the view-message schemas whose only occurrence was their own declaration line. Every underlying Zod `*Schema` const was **kept** — each is still composed into a discriminated union, `.extend()`-ed, or backs an externally-used inferred type.
- **Dropped the `export` keyword** on module-private types in the CLI TUI (`DiffView`, `StatusBar`, `ChildControlPicker`, `ansiMarkdown`, etc.) — symbols stay, just no longer surfaced.
- **Trimmed dead barrel re-export lines.**

## What was deliberately kept

Conservative throughout: union-member schemas that are externally-unused but actively build an exported union; composition-base schemas; and the curated public re-export facades (`settingsViewMessages`, `schemas/index`). When unsure, kept.

## Verification

- Full workspace typecheck green.
- `pnpm run test` passes (**4215 tests**).
- Two over-eager removals (test-used runtime helpers reached via dynamic import, which typecheck couldn't see) were caught by the full vitest gate and restored — that's why the diff is conservative.

This is the safe subset; a broader knip-driven sweep can follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time export and type-alias removals only; Zod schemas and runtime logic are preserved, with typecheck and full test suite reported green.
> 
> **Overview**
> This PR trims **unused public API** across ~24 files as a conservative knip/dead-code pass. **Runtime behavior is unchanged**—only exports, type aliases, and barrel lines disappear.
> 
> **CLI TUI** — Several props/layout types in `ChildControlPicker`, `StatusBar`, `DiffView`, and `ansiMarkdown` are no longer exported; they stay as module-local `interface`s. `CliToolGuideKind` and `WorkflowOutputResolutionOptions` are likewise internal.
> 
> **Shared Zod schemas** — Dozens of `export type X = z.infer<typeof XSchema>` aliases are removed where nothing imported them. The underlying `*Schema` constants remain for unions, `.extend()`, and inference on types that are still exported.
> 
> **Barrels and constants** — `MESSAGE_PREVIEW_LENGTH`, slimmed `@agent/types`, `@agent/storage`, `@auth/config`, `@transcript`, `@utils/core`, and `@utils/files` re-exports drop symbols that had no external consumers.
> 
> Callers that need types should use `z.infer<typeof …Schema>` or import from the schema modules that still export the shapes they need.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3df8035ae5804e7e222442bed808ff1453d0bcae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->