### PR TITLE
[codex] feat(cli): surface tool integrations in config catalog

### DIFF
--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -31,6 +31,7 @@ import { ToolsListForm } from '../forms/ToolsListForm';
 import { cliState, setCliSessionModelOverride } from '../state/cliState';
 import { loginFromChat } from './handlers/loginCommands';
 import { registerSlashCommand, type SlashFormProps } from './slashRegistry';
+import { openCliSlashCommandForm } from './slashForms';
 
 type AgentSelectHandler = (value: string) => void | Promise<void>;
 type ApprovalPolicySelectHandler = (
@@ -444,6 +445,7 @@ export function registerBuiltinSlashCommands(options?: {
               onApiModeSelect,
             );
           }}
+          openForm={(formName) => openCliSlashCommandForm(formName, '')}
           onClose={() => props.onDone(undefined)}
           onError={options?.onError}
         />

--- a/packages/cli/src/chat/tui/forms/ConfigForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ConfigForm.tsx
@@ -29,6 +29,7 @@ import { FormFrame } from './_shared/FormFrame';
 import { computeSelectWindowSize } from './_shared/selectWindow';
 
 export type SettingEditKind =
+  | 'form'
   | 'boolean'
   | 'enum'
   | 'string'
@@ -42,9 +43,11 @@ export type SettingInputResult =
 /**
  * How a setting is edited in `/config`, derived from its schema: enums drill
  * into a value picker, booleans toggle inline, strings/numbers open a text
- * editor; anything else (e.g. a record) is read-only.
+ * editor, form-backed settings delegate to an existing list form; anything
+ * else (e.g. a record) is read-only.
  */
 export function settingEditKind(entry: StateSettingEntry): SettingEditKind {
+  if (entry.openForm) return 'form';
   if (settingEnumOptions(entry)) return 'enum';
   if (settingIsBoolean(entry)) return 'boolean';
   if (settingIsNumber(entry)) return 'number';
@@ -118,8 +121,11 @@ export function buildConfigListItems(
 ): Array<SelectItem<string>> {
   return entries.map((entry) => {
     const kind = settingEditKind(entry);
-    const valueText = formatSettingValue(readValue(entry));
     const store = settingStoreLabel(entry);
+    const valueText =
+      kind === 'form'
+        ? `open /${entry.openForm}`
+        : formatSettingValue(readValue(entry));
     const suffix = kind === 'readonly' ? ' · read-only' : '';
     return {
       value: entry.key,
@@ -151,6 +157,7 @@ export interface ConfigFormProps {
   ) => void | Promise<void>;
   /** Reset a setting to its default (delete the key). */
   readonly resetValue?: (entry: StateSettingEntry) => void | Promise<void>;
+  readonly openForm?: (formName: string) => void;
   readonly availableRows?: number;
   readonly onClose: () => void;
   readonly onError?: (error: unknown) => void;
@@ -374,6 +381,9 @@ export function ConfigForm(props: ConfigFormProps): React.JSX.Element {
     const kind = settingEditKind(entry);
     if (kind === 'boolean') {
       commit(entry, !(effective(entry) as boolean));
+    } else if (kind === 'form') {
+      const formName = entry.openForm;
+      if (formName) props.openForm?.(formName);
     } else if (kind === 'enum') {
       setMode({ kind: 'enum', entry });
     } else if (kind === 'string') {
@@ -397,7 +407,7 @@ export function ConfigForm(props: ConfigFormProps): React.JSX.Element {
         <KeyHints
           hints={[
             { key: '↑/↓', action: 'navigate' },
-            { key: 'Enter', action: 'toggle / edit' },
+            { key: 'Enter', action: 'toggle / edit / open' },
             { key: 'Esc', action: 'close' },
           ]}
           confirmCancel={false}

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -187,6 +187,12 @@ const CLAUDE_AGENT_RUNTIME_REACHABILITY = {
   through:
     'packages/cli/src/commands/agentsRun.ts -> packages/cli/src/runtime/runExecution.ts -> src/tools/claudeAgent.ts -> src/tools/claudeAgentConfig.ts',
 } satisfies CliRuntimeReachability;
+const TOOL_AVAILABILITY_RUNTIME_REACHABILITY = {
+  command:
+    'texra agents run <tool-use-agent> --instruction "use an external tool"',
+  through:
+    'packages/cli/src/commands/agentsRun.ts -> packages/cli/src/runtime/runExecution.ts -> src/agent/runtime/agentToolResolution.ts -> src/tools/toolAvailability.ts',
+} satisfies CliRuntimeReachability;
 
 const PROVIDER_ENDPOINT_CONSUMER =
   'src/agent/modelHandlers/support/ProxyConfigResolver.ts';
@@ -523,6 +529,24 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     hosts: ['cli'],
     cliConsumer: 'src/utils/config/providerConfig.ts',
     cliRuntimeReachability: OPENROUTER_ROUTING_RUNTIME_REACHABILITY,
+  },
+
+  // --- External tool integrations ------------------------------------------
+  // This is a list-backed global-state domain. `/config` delegates editing to
+  // the existing `/tools` form so the catalog owns discoverability while the
+  // tool dashboard remains the single editor for per-integration toggles.
+  {
+    key: GlobalStateKey.DISABLED_TOOLS,
+    schema: z.array(z.string()).prefault([]),
+    title: 'Tool integrations',
+    description:
+      'Enable or disable external tool integration groups used by agent tool resolution.',
+    category: 'tools',
+    store: 'globalState',
+    hosts: ['vscode', 'desktop', 'cli'],
+    cliConsumer: 'src/tools/toolAvailability.ts',
+    cliRuntimeReachability: TOOL_AVAILABILITY_RUNTIME_REACHABILITY,
+    openForm: 'tools',
   },
 ] as const;
 

--- a/src/test-kernel/cli/ConfigForm.vitest.mts
+++ b/src/test-kernel/cli/ConfigForm.vitest.mts
@@ -62,6 +62,7 @@ function renderConfigFormProps(): {
     value: unknown,
   ) => void | Promise<void>;
   resetValue?: (entry: StateSettingEntry) => void | Promise<void>;
+  openForm?: (formName: string) => void;
 } {
   const node = cliState.activeForm.get()?.render(() => {}, 20) as {
     type?: (props: unknown) => unknown;
@@ -94,6 +95,7 @@ describe('ConfigForm helpers', () => {
     const markCommits = entryByKey(WorkspaceStateKey.GIT_MARK_COMMITS);
     const authorName = entryByKey(WorkspaceStateKey.GIT_AUTHOR_NAME);
     const formatter = entryByKey(WorkspaceStateKey.LATEX_FORMATTER);
+    const tools = entryByKey(GlobalStateKey.DISABLED_TOOLS);
     const timeout = entryByKey(
       WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS,
     );
@@ -101,6 +103,7 @@ describe('ConfigForm helpers', () => {
     expect(settingEditKind(markCommits)).toBe('boolean');
     expect(settingEditKind(authorName)).toBe('string');
     expect(settingEditKind(formatter)).toBe('enum');
+    expect(settingEditKind(tools)).toBe('form');
     expect(settingEditKind(timeout)).toBe('number');
   });
 
@@ -196,6 +199,9 @@ describe('ConfigForm helpers', () => {
     const authorName = items.find(
       (item) => item.value === WorkspaceStateKey.GIT_AUTHOR_NAME,
     );
+    const tools = items.find(
+      (item) => item.value === GlobalStateKey.DISABLED_TOOLS,
+    );
 
     expect(markCommits).toMatchObject({
       label: 'Mark agent commits',
@@ -206,6 +212,11 @@ describe('ConfigForm helpers', () => {
     // Strings/numbers are now editable, so no row is read-only in the roster.
     expect(authorName).toMatchObject({ disabled: false });
     expect(authorName?.description).not.toContain('read-only');
+    expect(tools).toMatchObject({
+      label: 'Tool integrations',
+      description: 'open /tools · globalState',
+      disabled: false,
+    });
   });
 
   it('marks an unsupported schema kind read-only', () => {
@@ -365,5 +376,17 @@ describe('/config slash command wiring', () => {
 
     await props.resetValue?.(openRouter);
     expect(invalidateModelOptionsCache).toHaveBeenCalledTimes(2);
+  });
+
+  it('delegates catalog form rows through the slash form registry', () => {
+    registerBuiltinSlashCommands({
+      getConfigStores: () => makeFakeSettingsStores().stores,
+    });
+    openCliSlashCommandForm('config', '');
+
+    const props = renderConfigFormProps();
+    props.openForm?.('tools');
+
+    expect(cliState.activeForm.get()?.commandName).toBe('tools');
   });
 });

--- a/src/test-kernel/shared/stateSettings.vitest.ts
+++ b/src/test-kernel/shared/stateSettings.vitest.ts
@@ -105,6 +105,7 @@ const EXPECTED_DEFAULTS: Record<string, unknown> = {
   [GlobalStateKey.WEBSOCKET_OPENAI]: false,
   ...PROVIDER_ENDPOINT_DEFAULTS,
   [GlobalStateKey.USE_OPENROUTER]: false,
+  [GlobalStateKey.DISABLED_TOOLS]: [],
 };
 
 describe('state settings catalog', () => {
@@ -380,6 +381,7 @@ describe('state settings catalog', () => {
         ),
         GlobalStateKey.WEBSOCKET_OPENAI,
         GlobalStateKey.USE_OPENROUTER,
+        GlobalStateKey.DISABLED_TOOLS,
       ].sort(),
     );
   });


### PR DESCRIPTION
## Summary

This PR promotes the tools-domain state into the shared settings catalog and lets `/config` delegate editing to the existing `/tools` form. The catalog now owns discovery for `texra.tools.disabled`, while the tools dashboard remains the single editor for per-integration toggles.

## Issue Scope

Addresses the tools slice of #6606. This intentionally does not close #6606, since streaming, models, and presets still remain as separate catalog-promotion work.

## Changes

- Add `GlobalStateKey.DISABLED_TOOLS` to `STATE_SETTINGS` with a Zod v4 `prefault([])` schema, CLI host coverage, and runtime reachability through agent tool resolution.
- Teach `/config` to treat catalog entries with `openForm` as form-backed rows.
- Wire the tools catalog row to the existing `/tools` slash form instead of creating a second editor.
- Add focused tests for catalog defaults, CLI roster coverage, list rendering, and slash-form delegation.

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/shared/stateSettings.vitest.ts src/test-kernel/cli/ConfigForm.vitest.mts src/test-kernel/cli/CliTools.vitest.mts`
- `corepack pnpm run typecheck`
- `corepack pnpm run lint`
- `corepack pnpm run compile:fast`
- `git diff --check`

`corepack pnpm run lint` passes with the repository's existing warning set and no errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/catalog wiring and metadata only; behavior still flows through existing `toolAvailability` and the `/tools` form, with no new auth or data paths.
> 
> **Overview**
> Adds **`GlobalStateKey.DISABLED_TOOLS`** to the shared state settings catalog so tool-integration toggles are discoverable from `/config`, while **`/tools`** stays the only editor for per-integration switches.
> 
> **`/config`** now supports catalog rows with **`openForm`**: they show as `open /tools` (or another slash form) and Enter opens that form via **`openCliSlashCommandForm`**, wired from **`registerBuiltins`**.
> 
> Tests cover the new catalog entry, **`form`** edit kind, list rendering, CLI roster inclusion, and delegation from `/config` to the tools slash form.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 684abb1dc06e3bf4226eb312a4b44df40edc9727. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->