### PR TITLE
refactor(progress): share approval handler construction

### DIFF
--- a/packages/cli/src/runtime/apiStatus.ts
+++ b/packages/cli/src/runtime/apiStatus.ts
@@ -1,6 +1,7 @@
 import { platform } from '@platform/platform';
 import { toErrorMessage } from '@common/errors/errorMessage';
 import { API_PROVIDERS, lookupApiKeyOrigin } from '@model/apiProviders';
+import { formatPercent } from '@utils/core/stringCore';
 
 import {
   formatCliApiMode,
@@ -15,15 +16,9 @@ import {
   type CliAuthProfile,
 } from './supabaseAuth';
 
-function formatPercent(value: number): string {
-  if (!Number.isFinite(value) || value <= 0) return '0%';
-  if (value < 1) return '<1%';
-  return `${value.toFixed(1)}%`;
-}
-
 export function formatRelayUsageStatus(summary: RelayUsageSummary): string {
-  const used = formatPercent(summary.usagePercent);
-  const remaining = formatPercent(Math.max(0, 100 - summary.usagePercent));
+  const used = formatPercent(summary.usagePercent, 1);
+  const remaining = formatPercent(Math.max(0, 100 - summary.usagePercent), 1);
   return `relay usage this month: ${used} used, ${remaining} remaining`;
 }
 

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -41,23 +41,16 @@ import { createChannelTrace } from '@logger';
 import type { MainViewExecuteMessage } from '@shared/mainView';
 import {
   STREAM_STATUS,
-  type AgentProposalPermission,
   type AgentCategoryFilter,
-  type BashPermission,
-  type ExternalInquiryPermission,
   type MainViewPersistedState,
-  type PlanApprovalPermission,
   type ProgressViewOutboundMessage,
-  type RetryPermission,
-  type ToolEditPermission,
-  type UserQuestionPermission,
   type ExecutionId,
   type StreamTabId,
 } from '@shared/schemas';
 import type { ProgressViewInboundHandlerRegistry } from '@shared/schemas/progressView';
-import { ApprovalRequestHandler } from '@shared/progressView/backend/ApprovalRequestHandler';
 import { ProgressBackend } from '@shared/progressView/backend/ProgressBackend';
 import {
+  buildApprovalRequestHandlerSet,
   createProgressBackendUiConfig,
   type ApprovalRequestHandlerSet,
 } from '@shared/progressView/backend/progressBackendUiConfig';
@@ -243,103 +236,25 @@ export class DesktopProgressBridge {
         // The desktop renderer is always attached (no sidebar/editor re-target),
         // so every show/resolve reaches the webview.
         const canSend = () => true;
-        this.approvalHandlers = {
-          toolEdit: new ApprovalRequestHandler<ToolEditPermission, 'requestId'>(
-            'requestId',
-            (p) =>
-              webviewUpdater.showPermission({
-                kind: PERMISSION_KIND.TOOL_EDIT,
-                data: p,
-              }),
-            (id) =>
-              webviewUpdater.resolvePermission(PERMISSION_KIND.TOOL_EDIT, id),
-            canSend,
-          ),
-          bash: new ApprovalRequestHandler<BashPermission, 'requestId'>(
-            'requestId',
-            (p) =>
-              webviewUpdater.showPermission({
-                kind: PERMISSION_KIND.BASH,
-                data: p,
-              }),
-            (id) => webviewUpdater.resolvePermission(PERMISSION_KIND.BASH, id),
-            canSend,
-          ),
-          // Desktop has no retry panel: showRetryRequest below cancels instead
-          // of showing, so this handler is never populated and contributes
-          // nothing to the pending guard. Its transport is therefore unused.
-          retry: new ApprovalRequestHandler<RetryPermission, 'streamId'>(
-            'streamId',
-            () => undefined,
-            () => undefined,
-            canSend,
-          ),
-          agentProposal: new ApprovalRequestHandler<
-            AgentProposalPermission,
-            'proposalId'
-          >(
-            'proposalId',
-            (p) =>
-              webviewUpdater.showPermission({
-                kind: PERMISSION_KIND.PROPOSAL,
-                data: p,
-              }),
-            (id) =>
-              webviewUpdater.resolvePermission(PERMISSION_KIND.PROPOSAL, id),
-            canSend,
-          ),
-          planApproval: new ApprovalRequestHandler<
-            PlanApprovalPermission,
-            'approvalId'
-          >(
-            'approvalId',
-            (p) =>
-              webviewUpdater.showPermission({
-                kind: PERMISSION_KIND.PLAN_APPROVAL,
-                data: p,
-              }),
-            (id) =>
-              webviewUpdater.resolvePermission(
-                PERMISSION_KIND.PLAN_APPROVAL,
-                id,
-              ),
-            canSend,
-          ),
-          externalInquiry: new ApprovalRequestHandler<
-            ExternalInquiryPermission,
-            'requestId'
-          >(
-            'requestId',
-            (p) =>
-              webviewUpdater.showPermission({
-                kind: PERMISSION_KIND.EXTERNAL_INQUIRY,
-                data: p,
-              }),
-            (id) =>
-              webviewUpdater.resolvePermission(
-                PERMISSION_KIND.EXTERNAL_INQUIRY,
-                id,
-              ),
-            canSend,
-          ),
-          userQuestion: new ApprovalRequestHandler<
-            UserQuestionPermission,
-            'requestId'
-          >(
-            'requestId',
-            (p) =>
-              webviewUpdater.showPermission({
-                kind: PERMISSION_KIND.USER_QUESTION,
-                data: p,
-              }),
-            (id) =>
-              webviewUpdater.resolvePermission(
-                PERMISSION_KIND.USER_QUESTION,
-                id,
-              ),
-            canSend,
-          ),
-        };
+        this.approvalHandlers = buildApprovalRequestHandlerSet({
+          webviewUpdater,
+          canSend,
+          overrides: {
+            retry: {
+              show: () => undefined,
+              resolve: () => undefined,
+            },
+            agentProposal: {
+              show: (p) =>
+                webviewUpdater.showPermission({
+                  kind: PERMISSION_KIND.PROPOSAL,
+                  data: p,
+                }),
+              resolve: (id) =>
+                webviewUpdater.resolvePermission(PERMISSION_KIND.PROPOSAL, id),
+            },
+          },
+        });
         return createProgressBackendUiConfig({
           handlers: this.approvalHandlers,
           webviewUpdater,

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -27,20 +27,18 @@ import {
 import {
   AgentCategory,
   type AgentProposalPermission,
-  type BashPermission,
   type ExternalInquiryPermission,
-  type PlanApprovalPermission,
   type ProgressViewOutboundMessage,
   type ProgressViewPlacement,
-  type RetryPermission,
   type StreamTabId,
-  type ToolEditPermission,
-  type UserQuestionPermission,
 } from '@shared/schemas';
 import { agentName } from '@shared/schemas/agent';
-import { ApprovalRequestHandler } from '@shared/progressView/backend/ApprovalRequestHandler';
 import { ProgressBackend } from '@shared/progressView/backend/ProgressBackend';
-import { createProgressBackendUiConfig } from '@shared/progressView/backend/progressBackendUiConfig';
+import {
+  buildApprovalRequestHandlerSet,
+  createProgressBackendUiConfig,
+  type ApprovalRequestHandlerSet,
+} from '@shared/progressView/backend/progressBackendUiConfig';
 import { buildStreamInfo } from '@shared/progressView/backend/streamInfoUtils';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import { collectKnownSessionLinks } from '@tools/inquiry/externalInquiryResultFormatter';
@@ -98,34 +96,7 @@ export class ProgressViewProvider
   private _sidebarWebviewGetter?: () => vscode.Webview | undefined;
   private _mainViewProvider?: MainViewProvider;
 
-  private toolEditHandler!: ApprovalRequestHandler<
-    ToolEditPermission,
-    'requestId'
-  >;
-  private bashApprovalHandler!: ApprovalRequestHandler<
-    BashPermission,
-    'requestId'
-  >;
-  private retryRequestHandler!: ApprovalRequestHandler<
-    RetryPermission,
-    'streamId'
-  >;
-  private agentProposalHandler!: ApprovalRequestHandler<
-    AgentProposalPermission,
-    'proposalId'
-  >;
-  private planApprovalHandler!: ApprovalRequestHandler<
-    PlanApprovalPermission,
-    'approvalId'
-  >;
-  private externalInquiryHandler!: ApprovalRequestHandler<
-    ExternalInquiryPermission,
-    'requestId'
-  >;
-  private userQuestionHandler!: ApprovalRequestHandler<
-    UserQuestionPermission,
-    'requestId'
-  >;
+  private approvalHandlers!: ApprovalRequestHandlerSet;
 
   constructor(protected readonly context: vscode.ExtensionContext) {
     super(context);
@@ -138,83 +109,38 @@ export class ProgressViewProvider
       getStreamControls: getProgressStreamControls,
       configureUi: ({ webviewUpdater: u }) => {
         const canSend = () => this.canSendToWebview();
-        this.toolEditHandler = new ApprovalRequestHandler(
-          'requestId',
-          (p) => u.showPermission({ kind: PERMISSION_KIND.TOOL_EDIT, data: p }),
-          (id) => u.resolvePermission(PERMISSION_KIND.TOOL_EDIT, id),
+        this.approvalHandlers = buildApprovalRequestHandlerSet({
+          webviewUpdater: u,
           canSend,
-        );
-        this.bashApprovalHandler = new ApprovalRequestHandler(
-          'requestId',
-          (p) => u.showPermission({ kind: PERMISSION_KIND.BASH, data: p }),
-          (id) => u.resolvePermission(PERMISSION_KIND.BASH, id),
-          canSend,
-        );
-        this.retryRequestHandler = new ApprovalRequestHandler(
-          'streamId',
-          (p) => u.showPermission({ kind: PERMISSION_KIND.RETRY, data: p }),
-          (id) => u.resolvePermission(PERMISSION_KIND.RETRY, id),
-          canSend,
-        );
-        this.agentProposalHandler = new ApprovalRequestHandler(
-          'proposalId',
-          (p) => {
-            // Show proposal immediately with basic model dropdown (synchronous)
-            u.showPermission({
-              kind: PERMISSION_KIND.PROPOSAL,
-              data: p,
-              modelOptionsData: buildVisibleBasicModelOptionsData(),
-            });
-            // Then upgrade with availability metadata if possible
-            void this.sendProposalModelOptions(p);
+          overrides: {
+            retry: {
+              show: (p) =>
+                u.showPermission({ kind: PERMISSION_KIND.RETRY, data: p }),
+              resolve: (id) => u.resolvePermission(PERMISSION_KIND.RETRY, id),
+            },
+            agentProposal: {
+              show: (p) => {
+                u.showPermission({
+                  kind: PERMISSION_KIND.PROPOSAL,
+                  data: p,
+                  modelOptionsData: buildVisibleBasicModelOptionsData(),
+                });
+                void this.sendProposalModelOptions(p);
+              },
+              resolve: (id) =>
+                u.resolvePermission(PERMISSION_KIND.PROPOSAL, id),
+            },
           },
-          (id) => u.resolvePermission(PERMISSION_KIND.PROPOSAL, id),
-          canSend,
-        );
-        this.planApprovalHandler = new ApprovalRequestHandler(
-          'approvalId',
-          (p) =>
-            u.showPermission({ kind: PERMISSION_KIND.PLAN_APPROVAL, data: p }),
-          (id) => u.resolvePermission(PERMISSION_KIND.PLAN_APPROVAL, id),
-          canSend,
-        );
-        this.externalInquiryHandler = new ApprovalRequestHandler(
-          'requestId',
-          (p) =>
-            u.showPermission({
-              kind: PERMISSION_KIND.EXTERNAL_INQUIRY,
-              data: p,
-            }),
-          (id) => u.resolvePermission(PERMISSION_KIND.EXTERNAL_INQUIRY, id),
-          canSend,
-        );
-        this.userQuestionHandler = new ApprovalRequestHandler(
-          'requestId',
-          (p) =>
-            u.showPermission({
-              kind: PERMISSION_KIND.USER_QUESTION,
-              data: p,
-            }),
-          (id) => u.resolvePermission(PERMISSION_KIND.USER_QUESTION, id),
-          canSend,
-        );
+        });
 
         // Retry is the one host-specific kind: the extension shows a retry
         // panel via its handler (so the handler also feeds the pending guard).
         return createProgressBackendUiConfig({
-          handlers: {
-            toolEdit: this.toolEditHandler,
-            bash: this.bashApprovalHandler,
-            retry: this.retryRequestHandler,
-            agentProposal: this.agentProposalHandler,
-            planApproval: this.planApprovalHandler,
-            externalInquiry: this.externalInquiryHandler,
-            userQuestion: this.userQuestionHandler,
-          },
+          handlers: this.approvalHandlers,
           webviewUpdater: u,
           canSend,
-          showRetryRequest: (p) => this.retryRequestHandler.show(p),
-          resolveRetryRequest: (id) => this.retryRequestHandler.resolve(id),
+          showRetryRequest: (p) => this.approvalHandlers.retry.show(p),
+          resolveRetryRequest: (id) => this.approvalHandlers.retry.resolve(id),
         });
       },
     });
@@ -301,7 +227,7 @@ export class ProgressViewProvider
    *
    * Guards against the RESOLVE-between-two-SHOWs race: if the user
    * approves/rejects while model options are loading, the proposal is
-   * removed from agentProposalHandler. We check before sending so the
+   * removed from the agent-proposal handler. We check before sending so the
    * late SHOW doesn't re-create an undismissable ghost proposal.
    *
    * Uses a 30-second TTL cache to avoid redundant async work when
@@ -327,7 +253,7 @@ export class ProgressViewProvider
       }).catch(() => buildVisibleBasicModelOptionsData()),
       loadAgentOptions().catch(() => undefined),
     ]);
-    if (!this.agentProposalHandler.get(proposal.proposalId)) return;
+    if (!this.approvalHandlers.agentProposal.get(proposal.proposalId)) return;
     this.webviewUpdater.showPermission({
       kind: PERMISSION_KIND.PROPOSAL,
       data: proposal,
@@ -445,7 +371,7 @@ export class ProgressViewProvider
    */
   private async hydrateOpenInquiries(): Promise<void> {
     if (!this.webviewUpdater.isAvailable()) return;
-    if (this.externalInquiryHandler.pendingSize > 0) return;
+    if (this.approvalHandlers.externalInquiry.pendingSize > 0) return;
 
     const open = await listOpenThreads().catch((error) => {
       // A storage read failure here silently skips inquiry hydration; log
@@ -494,7 +420,7 @@ export class ProgressViewProvider
               ...hydrationFields,
               mode: 'new',
             };
-        this.externalInquiryHandler.show(permission);
+        this.approvalHandlers.externalInquiry.show(permission);
       } catch {
         // Skip threads whose manifest can't be read; surface logs elsewhere.
       }
@@ -506,21 +432,21 @@ export class ProgressViewProvider
       return;
     }
 
-    this.toolEditHandler.replay();
-    this.bashApprovalHandler.replay();
-    this.externalInquiryHandler.replay();
+    this.approvalHandlers.toolEdit.replay();
+    this.approvalHandlers.bash.replay();
+    this.approvalHandlers.externalInquiry.replay();
     // YOLO / Super YOLO state is already sent by syncFullView() which is
     // always called before replayPendingPrompts() in markWebviewReady().
 
-    this.retryRequestHandler.replay();
-    this.agentProposalHandler.replay();
-    this.planApprovalHandler.replay();
+    this.approvalHandlers.retry.replay();
+    this.approvalHandlers.agentProposal.replay();
+    this.approvalHandlers.planApproval.replay();
   }
 
   public getPendingAgentProposal(
     proposalId: string,
   ): AgentProposalPermission | undefined {
-    return this.agentProposalHandler.get(proposalId);
+    return this.approvalHandlers.agentProposal.get(proposalId);
   }
 
   private canSendToWebview(): boolean {

--- a/packages/extension/src/settingsView/frontend/components/profile/RelayQuotaMeter.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/RelayQuotaMeter.ts
@@ -7,16 +7,11 @@ import '@awesome.me/webawesome/dist/components/progress-bar/progress-bar.js';
 import { designTokens } from '@shared/styles';
 import type { SpendingStatus } from '@shared/schemas/spendingStatus';
 import { clamp } from '@utils/core';
+import { formatPercent } from '@utils/core/stringCore';
 
 import { profileViewStyles } from './styles';
 
 const WARNING_THRESHOLD_PCT = 80;
-
-function formatPercent(value: number): string {
-  if (!Number.isFinite(value) || value <= 0) return '0%';
-  if (value < 1) return '<1%';
-  return `${Math.round(value)}%`;
-}
 
 type QuotaState = 'ok' | 'warning' | 'exhausted';
 

--- a/src/shared/progressView/backend/progressBackendUiConfig.ts
+++ b/src/shared/progressView/backend/progressBackendUiConfig.ts
@@ -3,12 +3,14 @@ import type {
   BashPermission,
   ExternalInquiryPermission,
   PlanApprovalPermission,
+  PermissionPayload,
   RetryPermission,
   ToolEditPermission,
   UserQuestionPermission,
 } from '@shared/schemas';
+import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 
-import type { ApprovalRequestHandler } from './ApprovalRequestHandler';
+import { ApprovalRequestHandler } from './ApprovalRequestHandler';
 import type { ProgressBackendUiConfig } from './ProgressBackend';
 import type { WebviewUpdater } from './WebviewUpdater';
 
@@ -29,6 +31,119 @@ export interface ApprovalRequestHandlerSet {
     'requestId'
   >;
   userQuestion: ApprovalRequestHandler<UserQuestionPermission, 'requestId'>;
+}
+
+/**
+ * Host-specific show/resolve transport for one approval kind. retry and
+ * agentProposal differ across hosts (the extension shows a retry panel and
+ * upgrades proposals with model/agent dropdowns; the desktop cancels retries
+ * and shows a plain proposal), so each host supplies these two directly.
+ */
+interface ApprovalHandlerTransport<T> {
+  show: (item: T) => void;
+  resolve: (id: string) => void;
+}
+
+export interface ApprovalRequestHandlerOverrides {
+  retry: ApprovalHandlerTransport<RetryPermission>;
+  agentProposal: ApprovalHandlerTransport<AgentProposalPermission>;
+}
+
+export interface BuildApprovalRequestHandlerSetParams {
+  webviewUpdater: WebviewUpdater;
+  /** Gate passed to every handler; an empty/false gate keeps it pending-only. */
+  canSend: () => boolean;
+  overrides: ApprovalRequestHandlerOverrides;
+}
+
+type PermissionData<K extends PermissionPayload['kind']> = Extract<
+  PermissionPayload,
+  { kind: K }
+>['data'] & { streamId: string };
+
+function webviewPermissionTransport<K extends PermissionPayload['kind']>(
+  webviewUpdater: WebviewUpdater,
+  kind: K,
+): ApprovalHandlerTransport<PermissionData<K>> {
+  return {
+    show: (data) =>
+      webviewUpdater.showPermission({
+        kind,
+        data,
+      } as Extract<PermissionPayload, { kind: K }>),
+    resolve: (id) => webviewUpdater.resolvePermission(kind, id),
+  };
+}
+
+function webviewPermissionHandler<
+  K extends PermissionPayload['kind'],
+  IdField extends keyof PermissionData<K>,
+>(
+  webviewUpdater: WebviewUpdater,
+  canSend: () => boolean,
+  kind: K,
+  idField: IdField,
+): ApprovalRequestHandler<PermissionData<K>, IdField> {
+  const transport = webviewPermissionTransport(webviewUpdater, kind);
+  return new ApprovalRequestHandler(
+    idField,
+    transport.show,
+    transport.resolve,
+    canSend,
+  );
+}
+
+export function buildApprovalRequestHandlerSet(
+  params: BuildApprovalRequestHandlerSetParams,
+): ApprovalRequestHandlerSet {
+  const { webviewUpdater, canSend, overrides } = params;
+  return {
+    toolEdit: webviewPermissionHandler(
+      webviewUpdater,
+      canSend,
+      PERMISSION_KIND.TOOL_EDIT,
+      'requestId',
+    ),
+    bash: webviewPermissionHandler(
+      webviewUpdater,
+      canSend,
+      PERMISSION_KIND.BASH,
+      'requestId',
+    ),
+    planApproval: webviewPermissionHandler(
+      webviewUpdater,
+      canSend,
+      PERMISSION_KIND.PLAN_APPROVAL,
+      'approvalId',
+    ),
+    externalInquiry: webviewPermissionHandler(
+      webviewUpdater,
+      canSend,
+      PERMISSION_KIND.EXTERNAL_INQUIRY,
+      'requestId',
+    ),
+    userQuestion: webviewPermissionHandler(
+      webviewUpdater,
+      canSend,
+      PERMISSION_KIND.USER_QUESTION,
+      'requestId',
+    ),
+    retry: new ApprovalRequestHandler<RetryPermission, 'streamId'>(
+      'streamId',
+      overrides.retry.show,
+      overrides.retry.resolve,
+      canSend,
+    ),
+    agentProposal: new ApprovalRequestHandler<
+      AgentProposalPermission,
+      'proposalId'
+    >(
+      'proposalId',
+      overrides.agentProposal.show,
+      overrides.agentProposal.resolve,
+      canSend,
+    ),
+  };
 }
 
 export interface ProgressBackendUiConfigParams {

--- a/src/shared/progressView/backend/progressBackendUiConfig.ts
+++ b/src/shared/progressView/backend/progressBackendUiConfig.ts
@@ -61,20 +61,6 @@ type PermissionData<K extends PermissionPayload['kind']> = Extract<
   { kind: K }
 >['data'] & { streamId: string };
 
-function webviewPermissionTransport<K extends PermissionPayload['kind']>(
-  webviewUpdater: WebviewUpdater,
-  kind: K,
-): ApprovalHandlerTransport<PermissionData<K>> {
-  return {
-    show: (data) =>
-      webviewUpdater.showPermission({
-        kind,
-        data,
-      } as Extract<PermissionPayload, { kind: K }>),
-    resolve: (id) => webviewUpdater.resolvePermission(kind, id),
-  };
-}
-
 function webviewPermissionHandler<
   K extends PermissionPayload['kind'],
   IdField extends keyof PermissionData<K>,
@@ -84,11 +70,14 @@ function webviewPermissionHandler<
   kind: K,
   idField: IdField,
 ): ApprovalRequestHandler<PermissionData<K>, IdField> {
-  const transport = webviewPermissionTransport(webviewUpdater, kind);
   return new ApprovalRequestHandler(
     idField,
-    transport.show,
-    transport.resolve,
+    (data) =>
+      webviewUpdater.showPermission({
+        kind,
+        data,
+      } as Extract<PermissionPayload, { kind: K }>),
+    (id) => webviewUpdater.resolvePermission(kind, id),
     canSend,
   );
 }

--- a/src/utils/core/stringCore.ts
+++ b/src/utils/core/stringCore.ts
@@ -68,6 +68,20 @@ export function formatCompactDuration(durationMs: number): string {
 }
 
 /**
+ * Format a percentage value for compact status displays (e.g. `12%`, `12.5%`).
+ *
+ * Non-finite or non-positive input renders as `0%`, and a positive value below
+ * one renders as `<1%` so a tiny-but-present share never reads as `0%`. The
+ * `decimals` argument controls the fractional digits of the rendered number
+ * (default `0` for whole-percent displays).
+ */
+export function formatPercent(value: number, decimals = 0): string {
+  if (!Number.isFinite(value) || value <= 0) return '0%';
+  if (value < 1) return '<1%';
+  return `${value.toFixed(decimals)}%`;
+}
+
+/**
  * Format token counts for compact usage displays.
  *
  * Token displays intentionally stay raw until they exceed 4096, the common


### PR DESCRIPTION
## Summary

- Centralize construction of the shared progress approval handlers in `buildApprovalRequestHandlerSet`.
- Keep the host-specific retry and agent-proposal transports in the VS Code and desktop hosts, while removing repeated construction of the ordinary permission handlers.
- Share the compact percent formatter used by CLI relay status and the settings quota meter without changing either caller's formatting.

## Verification

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `corepack pnpm run typecheck`
- `corepack pnpm exec eslint src/shared/progressView/backend/progressBackendUiConfig.ts`
- `git diff --check`