### PR TITLE
refactor: consolidate duplicate parsing/filter logic

### DIFF
--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -38,7 +38,7 @@ import type { FileLocation } from '@shared/schemas';
 import type { ToolFileAttachment } from '@shared/schemas/toolResult';
 
 // Local imports - utils
-import { isNonEmptyString, isObject } from '@utils/core';
+import { filterNotNull, isNonEmptyString, isObject } from '@utils/core';
 import { getShortDisplayPath } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
 import { joinNonEmpty, pluralize } from '@utils/text/stringUtils';
@@ -675,7 +675,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
       if (step.type === 'user_input' || step.type === 'model_output') {
         const parts = (step.content ?? [])
           .map((content) => this.contentToCountablePart(content))
-          .filter((part): part is Part => part !== null);
+          .filter(filterNotNull);
         if (parts.length > 0) {
           contents.push({
             role: step.type === 'model_output' ? 'model' : 'user',
@@ -690,7 +690,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
         const parts = Array.isArray(step.result)
           ? step.result
               .map((content) => this.contentToCountablePart(content))
-              .filter((part): part is Part => part !== null)
+              .filter(filterNotNull)
           : [createPartFromText(this.functionResultToText(step.result))];
         if (parts.length > 0) {
           contents.push(createUserContent(parts));
@@ -1337,7 +1337,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
         await Promise.all(
           attachments.map((a) => this.buildFunctionResultImage(a)),
         )
-      ).filter((image): image is ImageContent => image !== null);
+      ).filter(filterNotNull);
       subcontent.push(...encoded);
       if (encoded.length === 0) {
         this.logger.warn(

--- a/src/latex/extractBibliography.ts
+++ b/src/latex/extractBibliography.ts
@@ -10,6 +10,7 @@ import { WorkspaceFS } from '@utils/files';
 // Local file imports
 import {
   collectBibliographyPaths,
+  collectCommaSeparatedMatches,
   stripLatexComments,
 } from './latexParsingUtils';
 
@@ -53,19 +54,7 @@ export interface BibliographyEntriesResult {
 }
 
 function collectCitationKeys(content: string): string[] {
-  const keys = new Set<string>();
-
-  for (const match of content.matchAll(CITATION_PATTERN)) {
-    const block = match[1];
-    for (const raw of block.split(',')) {
-      const key = raw.trim();
-      if (key) {
-        keys.add(key);
-      }
-    }
-  }
-
-  return [...keys];
+  return collectCommaSeparatedMatches(content, CITATION_PATTERN);
 }
 
 export async function extractBibliographyContext(

--- a/src/latex/latexParsingUtils.ts
+++ b/src/latex/latexParsingUtils.ts
@@ -88,6 +88,29 @@ export async function findExistingLatexPath(
 }
 
 /**
+ * Match `pattern` against `content` and split each match's first capture
+ * group on commas, trimming and de-duplicating the resulting tokens (empty
+ * entries are skipped). `transform` maps each trimmed token before adding it
+ * to the result set, so callers can resolve tokens to paths or leave them as
+ * plain keys.
+ */
+export function collectCommaSeparatedMatches(
+  content: string,
+  pattern: RegExp,
+  transform: (token: string) => string = (token) => token,
+): string[] {
+  const tokens = new Set<string>();
+  for (const match of content.matchAll(pattern)) {
+    for (const raw of match[1].split(',')) {
+      const trimmed = raw.trim();
+      if (!trimmed) continue;
+      tokens.add(transform(trimmed));
+    }
+  }
+  return [...tokens];
+}
+
+/**
  * Collect candidate `.bib` paths referenced by `\bibliography` and
  * `\addbibresource` directives in `content`, joined against `baseDir`.
  * Empty/whitespace entries are skipped and duplicates are de-duplicated.
@@ -97,13 +120,7 @@ export function collectBibliographyPaths(
   baseDir: string,
   content: string,
 ): string[] {
-  const paths = new Set<string>();
-  for (const match of content.matchAll(BIB_DIRECTIVE_PATTERN)) {
-    for (const raw of match[1].split(',')) {
-      const trimmed = raw.trim();
-      if (!trimmed) continue;
-      paths.add(joinLatexPath(baseDir, ensureExtension(trimmed, '.bib')));
-    }
-  }
-  return [...paths];
+  return collectCommaSeparatedMatches(content, BIB_DIRECTIVE_PATTERN, (token) =>
+    joinLatexPath(baseDir, ensureExtension(token, '.bib')),
+  );
 }

--- a/src/latex/latexParsingUtils.ts
+++ b/src/latex/latexParsingUtils.ts
@@ -99,9 +99,21 @@ export function collectCommaSeparatedMatches(
   pattern: RegExp,
   transform: (token: string) => string = (token) => token,
 ): string[] {
+  if (!pattern.global) {
+    throw new Error(
+      'collectCommaSeparatedMatches requires a global RegExp pattern; add the g flag.',
+    );
+  }
+
   const tokens = new Set<string>();
   for (const match of content.matchAll(pattern)) {
-    for (const raw of match[1].split(',')) {
+    const rawGroup = match[1];
+    if (rawGroup == null) {
+      throw new Error(
+        'collectCommaSeparatedMatches requires the pattern to provide a first capture group.',
+      );
+    }
+    for (const raw of rawGroup.split(',')) {
       const trimmed = raw.trim();
       if (!trimmed) continue;
       tokens.add(transform(trimmed));

--- a/src/test-kernel/latex/LatexParsingUtils.vitest.ts
+++ b/src/test-kernel/latex/LatexParsingUtils.vitest.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { collectCommaSeparatedMatches } from '@latex/latexParsingUtils';
+
+describe('collectCommaSeparatedMatches', () => {
+  it('splits, trims, transforms, and de-duplicates first capture groups', () => {
+    const tokens = collectCommaSeparatedMatches(
+      String.raw`\cite{ alpha, beta }\cite{beta,gamma}`,
+      /\\cite\{([^}]*)\}/g,
+      (token) => token.toUpperCase(),
+    );
+
+    expect(tokens).toEqual(['ALPHA', 'BETA', 'GAMMA']);
+  });
+
+  it('rejects non-global patterns with a clear error', () => {
+    expect(() =>
+      collectCommaSeparatedMatches(
+        String.raw`\cite{alpha}`,
+        /\\cite\{([^}]*)\}/,
+      ),
+    ).toThrow(/global RegExp pattern/);
+  });
+
+  it('rejects patterns without a first capture group with a clear error', () => {
+    expect(() =>
+      collectCommaSeparatedMatches(
+        String.raw`\cite{alpha}`,
+        /\\cite\{[^}]*\}/g,
+      ),
+    ).toThrow(/first capture group/);
+  });
+});


### PR DESCRIPTION
## Summary

A codebase-wide scan for duplicate logic and hand-rolled reimplementations of things a shared utility or native method already covers. Most of the codebase is already well-consolidated (e.g. `UsageNormalizer`, `MediaAttachmentProcessor`, `BackgroundPoller`, `RetryableInvocationNode` in `src/agent/`). This PR lands the two findings that were concrete, mechanical, and behavior-preserving:

- `src/latex/latexParsingUtils.ts` and `src/latex/extractBibliography.ts` each independently implemented the same "matchAll → split on comma → trim → skip empty → dedupe into a Set" loop, once for `\bibliography`/`\addbibresource` paths and once for citation keys. Extracted a shared `collectCommaSeparatedMatches()` helper and had both call it.
- `ModelHandlerGoogleInteractions` had three identical inline type guards (`.filter((x): x is T => x !== null)`) where the codebase already has `filterNotNull` in `@utils/core` for exactly this.

Other findings from the scan (a duplicated `requireNonEmpty`/`requireNonEmptyString` pair with intentionally different error types, a `path.join` vs `joinLatexPath` inconsistency that touches TeX path-resolution semantics, and a proposed `TimerController` abstraction for webview `setTimeout`/`setInterval` cleanup) were left out of scope — they either aren't true duplicates or carry enough behavioral/architectural risk that they deserve their own reviewed PR rather than bundling into a mechanical cleanup.

## Issue acceptance gates

Not tied to a specific issue — this is a proactive consolidation pass.

## Single source of truth

`collectCommaSeparatedMatches()` in `src/latex/latexParsingUtils.ts` now owns the comma-split/trim/dedupe pattern for LaTeX directive parsing. `filterNotNull()` in `@utils/core` is the sole null-filtering predicate used in `ModelHandlerGoogleInteractions`.

## Duplication and abstraction budget

Removed one duplicated parsing loop (bibliography paths vs. citation keys) and three duplicated inline type guards. No new abstractions beyond the single extracted helper function, which is a direct extraction of pre-existing, byte-identical logic (no new invariants).

## Host impact

Extension: none (host-agnostic `src/` change only).

Desktop: none.

CLI: none.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — passes
- `npm run lint` — 0 errors (pre-existing warnings elsewhere, none in touched files)
- `npm test` — 4176 passed / 1 unrelated pre-existing failure (`execUtils.vitest.ts` process-group-kill timing test, unrelated to these files, not touched by this change) / 7 skipped


---
_Generated by [Claude Code](https://claude.ai/code/session_01B2XuBhDiGEveSzvVo4hFpd)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical, behavior-preserving deduplication in LaTeX parsing and Google handler filtering with targeted unit tests; no auth, security, or API contract changes.
> 
> **Overview**
> **LaTeX parsing** now routes comma-separated brace captures through a shared `collectCommaSeparatedMatches()` helper (with optional per-token `transform`), replacing duplicate `matchAll` → split → trim → dedupe loops in bibliography path collection and citation key extraction.
> 
> **Google Interactions** token-counting and function-result attachment encoding use the existing `filterNotNull` utility instead of three repeated inline `(x): x is T => x !== null` filters.
> 
> Vitest coverage was added for the new helper’s happy path and for invalid regex usage (non-global pattern, missing capture group).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac8e0e9412f28744954e1ee35d87b261132393f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->