### PR TITLE
refactor(streams): share host-neutral per-stream-meta reducer (#6827)

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -69,9 +69,16 @@ function refreshQueuedFollowUps(
 const PROCESS_TAIL_CHARS_MAX = 8 * 1024;
 const CLI_OUTPUT_CAP = { maxChars: PROCESS_TAIL_CHARS_MAX } as const;
 
-/** Project a CLI stream slice onto the host-neutral stream-meta shape. */
-function toStreamMeta(s: StreamSlice): StreamMeta {
-  return {
+/**
+ * Run one stream-meta command against a CLI slice with the CLI cap policy.
+ * The slice is projected onto the host-neutral `StreamMeta` shape so host-only
+ * fields (usage, bypass, entries, …) never reach the shared reducer.
+ */
+function applyStreamMeta(
+  s: StreamSlice,
+  command: StreamMetaCommand,
+): StreamMeta {
+  const meta: StreamMeta = {
     conversation: s.conversation,
     activeSubagents: s.activeSubagents,
     activeProcesses: s.activeProcesses,
@@ -80,16 +87,7 @@ function toStreamMeta(s: StreamSlice): StreamMeta {
     plan: s.plan,
     description: s.description,
   };
-}
-
-/** Run one stream-meta command against a CLI slice with the CLI cap policy. */
-function applyStreamMeta(
-  s: StreamSlice,
-  command: StreamMetaCommand,
-): StreamMeta {
-  return reduceStreamMeta(toStreamMeta(s), command, {
-    outputCap: CLI_OUTPUT_CAP,
-  });
+  return reduceStreamMeta(meta, command, { outputCap: CLI_OUTPUT_CAP });
 }
 
 export function wrapRuntimeHost(host: CliRuntimeHost): CliRuntimeHost {

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -11,7 +11,6 @@ import type {
 import { bus } from '@eventBus/ProgressEventBus';
 import {
   reduceStreamMeta,
-  type StreamMeta,
   type StreamMetaCommand,
 } from '@shared/streams/streamMetaReducer';
 
@@ -71,23 +70,20 @@ const CLI_OUTPUT_CAP = { maxChars: PROCESS_TAIL_CHARS_MAX } as const;
 
 /**
  * Run one stream-meta command against a CLI slice with the CLI cap policy.
- * The slice is projected onto the host-neutral `StreamMeta` shape so host-only
- * fields (usage, bypass, entries, …) never reach the shared reducer.
+ * The shared reducer owns only process-tail capping and pruning.
  */
 function applyStreamMeta(
   s: StreamSlice,
   command: StreamMetaCommand,
-): StreamMeta {
-  const meta: StreamMeta = {
-    conversation: s.conversation,
-    activeSubagents: s.activeSubagents,
-    activeProcesses: s.activeProcesses,
-    processOutput: s.processOutput,
-    todos: s.todos,
-    plan: s.plan,
-    description: s.description,
-  };
-  return reduceStreamMeta(meta, command, { outputCap: CLI_OUTPUT_CAP });
+): Pick<StreamSlice, 'activeProcesses' | 'processOutput'> {
+  return reduceStreamMeta(
+    {
+      activeProcesses: s.activeProcesses,
+      processOutput: s.processOutput,
+    },
+    command,
+    { outputCap: CLI_OUTPUT_CAP },
+  );
 }
 
 export function wrapRuntimeHost(host: CliRuntimeHost): CliRuntimeHost {
@@ -166,10 +162,7 @@ function applyToState<K extends ProgressEvent>(
       const p = payload as ProgressEventPayloads['updateConversationProgress'];
       patchStream(p.streamId, (s) => ({
         ...s,
-        conversation: applyStreamMeta(s, {
-          kind: 'conversation',
-          conversation: p.progress,
-        }).conversation,
+        conversation: p.progress,
       }));
       return;
     }
@@ -177,10 +170,7 @@ function applyToState<K extends ProgressEvent>(
       const p = payload as ProgressEventPayloads['updateStreamDescription'];
       patchStream(p.streamId, (s) => ({
         ...s,
-        description: applyStreamMeta(s, {
-          kind: 'description',
-          description: p.description,
-        }).description,
+        description: p.description,
       }));
       return;
     }
@@ -189,10 +179,7 @@ function applyToState<K extends ProgressEvent>(
       registerChildStreams(p.parentStreamId, p.children);
       patchStream(p.parentStreamId, (s) => ({
         ...s,
-        activeSubagents: applyStreamMeta(s, {
-          kind: 'activeSubagents',
-          subagents: p.children,
-        }).activeSubagents,
+        activeSubagents: p.children,
         childStreams: mergeChildStreams(s.childStreams, p.children),
       }));
       return;
@@ -239,7 +226,7 @@ function applyToState<K extends ProgressEvent>(
       const p = payload as ProgressEventPayloads['updateTodos'];
       patchStream(p.streamId, (s) => ({
         ...s,
-        todos: applyStreamMeta(s, { kind: 'todos', todos: p.todos }).todos,
+        todos: p.todos,
       }));
       return;
     }
@@ -247,7 +234,7 @@ function applyToState<K extends ProgressEvent>(
       const p = payload as ProgressEventPayloads['updatePlan'];
       patchStream(p.streamId, (s) => ({
         ...s,
-        plan: applyStreamMeta(s, { kind: 'plan', plan: p.plan }).plan,
+        plan: p.plan,
       }));
       return;
     }

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -9,7 +9,11 @@ import type {
   ProgressEventPayloads,
 } from '@eventBus/ProgressEventBus';
 import { bus } from '@eventBus/ProgressEventBus';
-import { appendTail } from '@utils/strings/appendTail';
+import {
+  reduceStreamMeta,
+  type StreamMeta,
+  type StreamMetaCommand,
+} from '@shared/streams/streamMetaReducer';
 
 import {
   cliState,
@@ -17,7 +21,7 @@ import {
   registerChildStreams,
   removeStream,
   setParentStream,
-  type ProcessOutputTail,
+  type StreamSlice,
 } from './cliState';
 import { mergeChildStreams } from './childExecutions';
 import { appendCompletedProcessEntries } from './completedProcessTranscript';
@@ -60,9 +64,33 @@ function refreshQueuedFollowUps(
 
 /** Cap on per-process tail length held in the signal map (UTF-16 code
  *  units, not bytes — markdown-it / ink work in JS strings). Beyond this
- *  we truncate at the head via the shared `appendTail` helper so the live
- *  pane never grows unbounded. */
+ *  the shared stream-meta reducer truncates at the head (exact cut, no
+ *  `retainChars`) so the live pane never grows unbounded. */
 const PROCESS_TAIL_CHARS_MAX = 8 * 1024;
+const CLI_OUTPUT_CAP = { maxChars: PROCESS_TAIL_CHARS_MAX } as const;
+
+/** Project a CLI stream slice onto the host-neutral stream-meta shape. */
+function toStreamMeta(s: StreamSlice): StreamMeta {
+  return {
+    conversation: s.conversation,
+    activeSubagents: s.activeSubagents,
+    activeProcesses: s.activeProcesses,
+    processOutput: s.processOutput,
+    todos: s.todos,
+    plan: s.plan,
+    description: s.description,
+  };
+}
+
+/** Run one stream-meta command against a CLI slice with the CLI cap policy. */
+function applyStreamMeta(
+  s: StreamSlice,
+  command: StreamMetaCommand,
+): StreamMeta {
+  return reduceStreamMeta(toStreamMeta(s), command, {
+    outputCap: CLI_OUTPUT_CAP,
+  });
+}
 
 export function wrapRuntimeHost(host: CliRuntimeHost): CliRuntimeHost {
   const original = host.emit;
@@ -138,14 +166,23 @@ function applyToState<K extends ProgressEvent>(
     }
     case 'updateConversationProgress': {
       const p = payload as ProgressEventPayloads['updateConversationProgress'];
-      patchStream(p.streamId, (s) => ({ ...s, conversation: p.progress }));
+      patchStream(p.streamId, (s) => ({
+        ...s,
+        conversation: applyStreamMeta(s, {
+          kind: 'conversation',
+          conversation: p.progress,
+        }).conversation,
+      }));
       return;
     }
     case 'updateStreamDescription': {
       const p = payload as ProgressEventPayloads['updateStreamDescription'];
       patchStream(p.streamId, (s) => ({
         ...s,
-        description: p.description,
+        description: applyStreamMeta(s, {
+          kind: 'description',
+          description: p.description,
+        }).description,
       }));
       return;
     }
@@ -154,63 +191,66 @@ function applyToState<K extends ProgressEvent>(
       registerChildStreams(p.parentStreamId, p.children);
       patchStream(p.parentStreamId, (s) => ({
         ...s,
-        activeSubagents: p.children,
+        activeSubagents: applyStreamMeta(s, {
+          kind: 'activeSubagents',
+          subagents: p.children,
+        }).activeSubagents,
         childStreams: mergeChildStreams(s.childStreams, p.children),
       }));
       return;
     }
     case 'updateActiveProcesses': {
       const p = payload as ProgressEventPayloads['updateActiveProcesses'];
-      // Drop tails for executions that just left the active list — mirrors
-      // `pruneStaleOutputs` in the webview's streamMetaSlice so the map
-      // doesn't grow unboundedly for the lifetime of the parent stream.
+      // The shared reducer drops tails for executions that left the active
+      // list; the CLI also persists a bounded transcript for each finished
+      // process before its tail is pruned (a CLI-only side effect).
       const live = new Set(p.processes.map((c) => c.executionId));
       patchStream(p.parentStreamId, (s) => {
-        let pruned: Map<string, ProcessOutputTail> | undefined;
-        for (const id of s.processOutput.keys()) {
-          if (live.has(id)) continue;
-          pruned ??= new Map(s.processOutput);
-          pruned.delete(id);
-        }
         const entries = appendCompletedProcessEntries(
           p.parentStreamId,
           s,
           live,
         );
+        const meta = applyStreamMeta(s, {
+          kind: 'activeProcesses',
+          processes: p.processes,
+        });
         return {
           ...s,
-          activeProcesses: p.processes,
+          activeProcesses: meta.activeProcesses,
           entries,
-          processOutput: pruned ?? s.processOutput,
+          processOutput: meta.processOutput,
         };
       });
       return;
     }
     case 'updateProcessOutput': {
       const p = payload as ProgressEventPayloads['updateProcessOutput'];
-      patchStream(p.parentStreamId, (s) => {
-        const prev = s.processOutput.get(p.executionId) ?? {
-          stdout: '',
-          stderr: '',
-        };
-        const next = {
-          stdout: appendTail(prev.stdout, p.stdout, PROCESS_TAIL_CHARS_MAX),
-          stderr: appendTail(prev.stderr, p.stderr, PROCESS_TAIL_CHARS_MAX),
-        };
-        const map = new Map(s.processOutput);
-        map.set(p.executionId, next);
-        return { ...s, processOutput: map };
-      });
+      patchStream(p.parentStreamId, (s) => ({
+        ...s,
+        processOutput: applyStreamMeta(s, {
+          kind: 'processOutput',
+          executionId: p.executionId,
+          stdout: p.stdout,
+          stderr: p.stderr,
+        }).processOutput,
+      }));
       return;
     }
     case 'updateTodos': {
       const p = payload as ProgressEventPayloads['updateTodos'];
-      patchStream(p.streamId, (s) => ({ ...s, todos: p.todos }));
+      patchStream(p.streamId, (s) => ({
+        ...s,
+        todos: applyStreamMeta(s, { kind: 'todos', todos: p.todos }).todos,
+      }));
       return;
     }
     case 'updatePlan': {
       const p = payload as ProgressEventPayloads['updatePlan'];
-      patchStream(p.streamId, (s) => ({ ...s, plan: p.plan }));
+      patchStream(p.streamId, (s) => ({
+        ...s,
+        plan: applyStreamMeta(s, { kind: 'plan', plan: p.plan }).plan,
+      }));
       return;
     }
     case 'updateToolEditApprovalBypassState': {

--- a/packages/extension/src/progressView/frontend/slices/streamMetaSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamMetaSlice.ts
@@ -7,12 +7,18 @@ import { create } from 'mutative';
 
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+import {
+  EMPTY_STREAM_META,
+  reduceStreamMeta,
+} from '@shared/streams/streamMetaReducer';
 
-import { getStreamState, isToolUseState } from '../store';
-import type {
-  HandlerRegistry,
-  MessageHandlerContext,
-} from '../messageHandlerTypes';
+import {
+  EMPTY_PROCESS_OUTPUTS,
+  getStreamState,
+  isToolUseState,
+  type ProcessOutputMap,
+} from '../store';
+import type { HandlerRegistry } from '../messageHandlerTypes';
 
 /**
  * Buffer for subagent descriptions that race their own UPDATE_STREAMS
@@ -29,46 +35,12 @@ export function takePendingDescription(
   return desc;
 }
 
-/** Max characters retained per output stream (stdout/stderr) per process. */
-const MAX_OUTPUT = 100_000;
-/** Trim below the cap so new output can append for a while before the next reset. */
-const TRIMMED_OUTPUT_LENGTH = 80_000;
-
-/** Append delta to prev, trimming below MAX_OUTPUT when the cap is crossed. */
-function capOutput(prev: string, delta: string): string {
-  if (!delta) return prev;
-  const combined = prev + delta;
-  return combined.length > MAX_OUTPUT
-    ? combined.slice(combined.length - TRIMMED_OUTPUT_LENGTH)
-    : combined;
-}
-
-/** Remove output entries for processes no longer in the active list. */
-function pruneStaleOutputs(
-  ctx: MessageHandlerContext,
-  stream: string,
-  activeIds: Set<string>,
-): void {
-  ctx.setState((prev) => {
-    const streamOutputs = prev.processOutputs.get(stream);
-    if (!streamOutputs) return prev;
-    let hasStale = false;
-    for (const id of streamOutputs.keys()) {
-      if (!activeIds.has(id)) {
-        hasStale = true;
-        break;
-      }
-    }
-    if (!hasStale) return prev;
-    return create(prev, (draft) => {
-      const outputs = draft.processOutputs.get(stream);
-      if (!outputs) return;
-      for (const id of [...outputs.keys()]) {
-        if (!activeIds.has(id)) outputs.delete(id);
-      }
-    });
-  });
-}
+/**
+ * Per-output cap policy for the webview: keep at most 100k UTF-16 code units
+ * per stdout/stderr, trimming to 80k when the cap is crossed so output can keep
+ * appending for a while before the next reset. The shared reducer applies it.
+ */
+const WEBVIEW_OUTPUT_CAP = { maxChars: 100_000, retainChars: 80_000 } as const;
 
 export const streamMetaHandlers: HandlerRegistry = {
   [PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_STATUS]: (data, ctx) => {
@@ -139,33 +111,39 @@ export const streamMetaHandlers: HandlerRegistry = {
         draft.finishedProcessCount = data.finishedProcessCount;
       }),
     );
-    pruneStaleOutputs(
-      ctx,
-      data.stream,
-      new Set(
-        data.activeProcesses.map((p: { executionId: string }) => p.executionId),
-      ),
-    );
+    // Prune output buffers for processes that just left the active list. Output
+    // lives in a separate store, so only `processOutput` is projected into the
+    // shared reducer and spliced back; an unchanged map skips the re-render.
+    ctx.setState((prev) => {
+      const current = prev.processOutputs.get(data.stream);
+      if (!current) return prev;
+      const { processOutput } = reduceStreamMeta(
+        { ...EMPTY_STREAM_META, processOutput: current },
+        { kind: 'activeProcesses', processes: data.activeProcesses },
+        { outputCap: WEBVIEW_OUTPUT_CAP },
+      );
+      if (processOutput === current) return prev;
+      return create(prev, (draft) => {
+        draft.processOutputs.set(
+          data.stream,
+          processOutput as ProcessOutputMap,
+        );
+      });
+    });
   },
 
   [PROGRESS_VIEW_COMMANDS.UPDATE_PROCESS_OUTPUT]: (data, ctx) => {
     const { stream, executionId, stdout, stderr } = data;
-    ctx.setState((prev) =>
-      create(prev, (draft) => {
-        let streamOutputs = draft.processOutputs.get(stream);
-        if (!streamOutputs) {
-          streamOutputs = new Map();
-          draft.processOutputs.set(stream, streamOutputs);
-        }
-        const existing = streamOutputs.get(executionId) ?? {
-          stdout: '',
-          stderr: '',
-        };
-        streamOutputs.set(executionId, {
-          stdout: capOutput(existing.stdout, stdout),
-          stderr: capOutput(existing.stderr, stderr),
-        });
-      }),
-    );
+    ctx.setState((prev) => {
+      const current = prev.processOutputs.get(stream) ?? EMPTY_PROCESS_OUTPUTS;
+      const { processOutput } = reduceStreamMeta(
+        { ...EMPTY_STREAM_META, processOutput: current },
+        { kind: 'processOutput', executionId, stdout, stderr },
+        { outputCap: WEBVIEW_OUTPUT_CAP },
+      );
+      return create(prev, (draft) => {
+        draft.processOutputs.set(stream, processOutput as ProcessOutputMap);
+      });
+    });
   },
 };

--- a/src/shared/streams/streamMetaReducer.ts
+++ b/src/shared/streams/streamMetaReducer.ts
@@ -1,0 +1,142 @@
+// Host-neutral per-stream-meta reducer shared by the CLI TUI and the webview
+// progress view. Both hosts used to maintain their own near-identical copy of
+// this logic (the CLI's `applyToState` mirrored the webview's `streamMetaSlice`
+// prune/cap rules). This is the single source of truth: each host projects its
+// own store into a `StreamMeta`, runs a `StreamMetaCommand`, and splices the
+// returned fields back. Host-only concerns (finished counts, usage, focus,
+// task groups, child-stream routing, transcript entries) stay in the adapters.
+//
+// NO host imports here (no vscode / electron / ink / immer): the reducer is a
+// pure function over plain values.
+
+import type {
+  ActiveChildInfo,
+  ConversationProgress,
+  Plan,
+  TodoItem,
+} from '@shared/schemas';
+import { appendTail } from '@utils/strings/appendTail';
+
+/** Per-execution captured stdout/stderr tail held in stream meta. */
+export interface StreamProcessOutput {
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+/**
+ * The slice of per-stream state this reducer owns. `ActiveChildInfo` is the
+ * shared badge value object used for both subagent and process rows.
+ */
+export interface StreamMeta {
+  readonly conversation: ConversationProgress | undefined;
+  readonly activeSubagents: readonly ActiveChildInfo[];
+  readonly activeProcesses: readonly ActiveChildInfo[];
+  readonly processOutput: ReadonlyMap<string, StreamProcessOutput>;
+  readonly todos: readonly TodoItem[];
+  readonly plan: Plan | null;
+  readonly description: string | undefined;
+}
+
+export type StreamMetaCommand =
+  | {
+      readonly kind: 'processOutput';
+      readonly executionId: string;
+      readonly stdout: string;
+      readonly stderr: string;
+    }
+  // Sets the active-process list AND prunes output for processes that vanished.
+  | {
+      readonly kind: 'activeProcesses';
+      readonly processes: readonly ActiveChildInfo[];
+    }
+  | {
+      readonly kind: 'activeSubagents';
+      readonly subagents: readonly ActiveChildInfo[];
+    }
+  | {
+      readonly kind: 'conversation';
+      readonly conversation: ConversationProgress | undefined;
+    }
+  | { readonly kind: 'todos'; readonly todos: readonly TodoItem[] }
+  | { readonly kind: 'plan'; readonly plan: Plan | null }
+  | { readonly kind: 'description'; readonly description: string | undefined };
+
+/**
+ * Output-cap policy. Once a stream's stdout/stderr crosses `maxChars`, it is
+ * trimmed to the last `retainChars` (default `maxChars`, i.e. an exact head-cut
+ * at the cap). The CLI uses an exact cut; the webview trims to a lower
+ * `retainChars` so output can keep appending before the next reset.
+ */
+export interface OutputCap {
+  readonly maxChars: number;
+  readonly retainChars?: number;
+}
+
+export interface ReduceStreamMetaOptions {
+  readonly outputCap: OutputCap;
+}
+
+const EMPTY_OUTPUT: StreamProcessOutput = { stdout: '', stderr: '' };
+
+/**
+ * An empty stream-meta slice. Hosts whose state is split across stores (the
+ * webview keeps process output separate from the rest of stream meta) project
+ * just the field a command touches over this default.
+ */
+export const EMPTY_STREAM_META: StreamMeta = {
+  conversation: undefined,
+  activeSubagents: [],
+  activeProcesses: [],
+  processOutput: new Map(),
+  todos: [],
+  plan: null,
+  description: undefined,
+};
+
+/**
+ * Apply one command to a stream-meta slice. Pure: never mutates `meta`, always
+ * returns a fresh `StreamMeta` (with a fresh `processOutput` Map when output
+ * changes), so callers can compare identities or copy fields into their store.
+ */
+export function reduceStreamMeta(
+  meta: StreamMeta,
+  command: StreamMetaCommand,
+  options: ReduceStreamMetaOptions,
+): StreamMeta {
+  switch (command.kind) {
+    case 'processOutput': {
+      const { maxChars, retainChars } = options.outputCap;
+      const prev = meta.processOutput.get(command.executionId) ?? EMPTY_OUTPUT;
+      const processOutput = new Map(meta.processOutput);
+      processOutput.set(command.executionId, {
+        stdout: appendTail(prev.stdout, command.stdout, maxChars, retainChars),
+        stderr: appendTail(prev.stderr, command.stderr, maxChars, retainChars),
+      });
+      return { ...meta, processOutput };
+    }
+    case 'activeProcesses': {
+      const live = new Set(command.processes.map((p) => p.executionId));
+      let pruned: Map<string, StreamProcessOutput> | undefined;
+      for (const id of meta.processOutput.keys()) {
+        if (live.has(id)) continue;
+        pruned ??= new Map(meta.processOutput);
+        pruned.delete(id);
+      }
+      return {
+        ...meta,
+        activeProcesses: command.processes,
+        processOutput: pruned ?? meta.processOutput,
+      };
+    }
+    case 'activeSubagents':
+      return { ...meta, activeSubagents: command.subagents };
+    case 'conversation':
+      return { ...meta, conversation: command.conversation };
+    case 'todos':
+      return { ...meta, todos: command.todos };
+    case 'plan':
+      return { ...meta, plan: command.plan };
+    case 'description':
+      return { ...meta, description: command.description };
+  }
+}

--- a/src/shared/streams/streamMetaReducer.ts
+++ b/src/shared/streams/streamMetaReducer.ts
@@ -1,20 +1,12 @@
 // Host-neutral per-stream-meta reducer shared by the CLI TUI and the webview
-// progress view. Both hosts used to maintain their own near-identical copy of
-// this logic (the CLI's `applyToState` mirrored the webview's `streamMetaSlice`
-// prune/cap rules). This is the single source of truth: each host projects its
-// own store into a `StreamMeta`, runs a `StreamMetaCommand`, and splices the
-// returned fields back. Host-only concerns (finished counts, usage, focus,
-// task groups, child-stream routing, transcript entries) stay in the adapters.
+// progress view. It owns only the cross-host logic that was duplicated:
+// bounded per-process output tails and pruning vanished process tails. Verbatim
+// assignments stay in the host adapters.
 //
 // NO host imports here (no vscode / electron / ink / immer): the reducer is a
 // pure function over plain values.
 
-import type {
-  ActiveChildInfo,
-  ConversationProgress,
-  Plan,
-  TodoItem,
-} from '@shared/schemas';
+import type { ActiveChildInfo } from '@shared/schemas';
 import { appendTail } from '@utils/strings/appendTail';
 
 /** Per-execution captured stdout/stderr tail held in stream meta. */
@@ -23,18 +15,10 @@ export interface StreamProcessOutput {
   readonly stderr: string;
 }
 
-/**
- * The slice of per-stream state this reducer owns. `ActiveChildInfo` is the
- * shared badge value object used for both subagent and process rows.
- */
+/** The slice of per-stream state this reducer owns. */
 export interface StreamMeta {
-  readonly conversation: ConversationProgress | undefined;
-  readonly activeSubagents: readonly ActiveChildInfo[];
   readonly activeProcesses: readonly ActiveChildInfo[];
   readonly processOutput: ReadonlyMap<string, StreamProcessOutput>;
-  readonly todos: readonly TodoItem[];
-  readonly plan: Plan | null;
-  readonly description: string | undefined;
 }
 
 export type StreamMetaCommand =
@@ -48,18 +32,7 @@ export type StreamMetaCommand =
   | {
       readonly kind: 'activeProcesses';
       readonly processes: readonly ActiveChildInfo[];
-    }
-  | {
-      readonly kind: 'activeSubagents';
-      readonly subagents: readonly ActiveChildInfo[];
-    }
-  | {
-      readonly kind: 'conversation';
-      readonly conversation: ConversationProgress | undefined;
-    }
-  | { readonly kind: 'todos'; readonly todos: readonly TodoItem[] }
-  | { readonly kind: 'plan'; readonly plan: Plan | null }
-  | { readonly kind: 'description'; readonly description: string | undefined };
+    };
 
 /**
  * Output-cap policy. Once a stream's stdout/stderr crosses `maxChars`, it is
@@ -84,13 +57,8 @@ const EMPTY_OUTPUT: StreamProcessOutput = { stdout: '', stderr: '' };
  * just the field a command touches over this default.
  */
 export const EMPTY_STREAM_META: StreamMeta = {
-  conversation: undefined,
-  activeSubagents: [],
   activeProcesses: [],
   processOutput: new Map(),
-  todos: [],
-  plan: null,
-  description: undefined,
 };
 
 /**
@@ -105,7 +73,8 @@ export function reduceStreamMeta(
 ): StreamMeta {
   switch (command.kind) {
     case 'processOutput': {
-      const { maxChars, retainChars } = options.outputCap;
+      const { maxChars } = options.outputCap;
+      const retainChars = options.outputCap.retainChars ?? maxChars;
       const prev = meta.processOutput.get(command.executionId) ?? EMPTY_OUTPUT;
       const processOutput = new Map(meta.processOutput);
       processOutput.set(command.executionId, {
@@ -128,15 +97,5 @@ export function reduceStreamMeta(
         processOutput: pruned ?? meta.processOutput,
       };
     }
-    case 'activeSubagents':
-      return { ...meta, activeSubagents: command.subagents };
-    case 'conversation':
-      return { ...meta, conversation: command.conversation };
-    case 'todos':
-      return { ...meta, todos: command.todos };
-    case 'plan':
-      return { ...meta, plan: command.plan };
-    case 'description':
-      return { ...meta, description: command.description };
   }
 }

--- a/src/test-kernel/shared/StreamMetaReducer.vitest.ts
+++ b/src/test-kernel/shared/StreamMetaReducer.vitest.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type {
-  ActiveChildInfo,
-  ConversationProgress,
-  Plan,
-  TodoItem,
-} from '@shared/schemas';
+import type { ActiveChildInfo } from '@shared/schemas';
 import {
   EMPTY_STREAM_META,
   reduceStreamMeta,
@@ -45,6 +40,18 @@ describe('reduceStreamMeta', () => {
         base,
         { kind: 'processOutput', executionId: 'e', stdout: 'abc', stderr: '' },
         { outputCap: { maxChars: 10, retainChars: 5 } },
+      );
+      expect(next.processOutput.get('e')?.stdout).toBe('89abc');
+    });
+
+    it('clamps retainChars to maxChars', () => {
+      const base = meta({
+        processOutput: new Map([['e', { stdout: '0123456789', stderr: '' }]]),
+      });
+      const next = reduceStreamMeta(
+        base,
+        { kind: 'processOutput', executionId: 'e', stdout: 'abc', stderr: '' },
+        { outputCap: { maxChars: 5, retainChars: 100 } },
       );
       expect(next.processOutput.get('e')?.stdout).toBe('89abc');
     });
@@ -115,47 +122,6 @@ describe('reduceStreamMeta', () => {
         OPTS,
       );
       expect(next.processOutput).toBe(output);
-    });
-  });
-
-  describe('verbatim copies', () => {
-    it('sets activeSubagents', () => {
-      const subagents: ActiveChildInfo[] = [
-        { executionId: 's1', agentName: 'review', childStreamId: 'c1' },
-      ];
-      expect(
-        reduceStreamMeta(meta(), { kind: 'activeSubagents', subagents }, OPTS)
-          .activeSubagents,
-      ).toBe(subagents);
-    });
-
-    it('sets conversation, todos, plan, and description', () => {
-      const conversation: ConversationProgress = {
-        conversationTurns: 2,
-        toolCallCount: 5,
-      };
-      const todos: TodoItem[] = [
-        { content: 'do x', status: 'pending', activeForm: 'doing x' },
-      ];
-      const plan: Plan = { objective: 'finish the proof' };
-
-      expect(
-        reduceStreamMeta(meta(), { kind: 'conversation', conversation }, OPTS)
-          .conversation,
-      ).toBe(conversation);
-      expect(
-        reduceStreamMeta(meta(), { kind: 'todos', todos }, OPTS).todos,
-      ).toBe(todos);
-      expect(reduceStreamMeta(meta(), { kind: 'plan', plan }, OPTS).plan).toBe(
-        plan,
-      );
-      expect(
-        reduceStreamMeta(
-          meta(),
-          { kind: 'description', description: 'desc' },
-          OPTS,
-        ).description,
-      ).toBe('desc');
     });
   });
 

--- a/src/test-kernel/shared/StreamMetaReducer.vitest.ts
+++ b/src/test-kernel/shared/StreamMetaReducer.vitest.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest';
+
+import type {
+  ActiveChildInfo,
+  ConversationProgress,
+  Plan,
+  TodoItem,
+} from '@shared/schemas';
+import {
+  EMPTY_STREAM_META,
+  reduceStreamMeta,
+  type StreamMeta,
+} from '@shared/streams/streamMetaReducer';
+
+const OPTS = { outputCap: { maxChars: 100 } } as const;
+
+function meta(overrides: Partial<StreamMeta> = {}): StreamMeta {
+  return { ...EMPTY_STREAM_META, ...overrides };
+}
+
+describe('reduceStreamMeta', () => {
+  describe('processOutput cap policies', () => {
+    it('exact head-cut at the cap when retainChars is omitted (CLI policy)', () => {
+      const base = meta({
+        processOutput: new Map([['e', { stdout: '0123456789', stderr: '' }]]),
+      });
+      // combined = "0123456789abc" (13) > 5 → keep last 5 → "89abc".
+      const next = reduceStreamMeta(
+        base,
+        { kind: 'processOutput', executionId: 'e', stdout: 'abc', stderr: '' },
+        { outputCap: { maxChars: 5 } },
+      );
+      expect(next.processOutput.get('e')).toEqual({
+        stdout: '89abc',
+        stderr: '',
+      });
+    });
+
+    it('trims to retainChars once maxChars is crossed (webview 100k→80k policy)', () => {
+      const base = meta({
+        processOutput: new Map([['e', { stdout: '0123456789', stderr: '' }]]),
+      });
+      // combined length 13 > 10 → keep last 5 → "89abc".
+      const next = reduceStreamMeta(
+        base,
+        { kind: 'processOutput', executionId: 'e', stdout: 'abc', stderr: '' },
+        { outputCap: { maxChars: 10, retainChars: 5 } },
+      );
+      expect(next.processOutput.get('e')?.stdout).toBe('89abc');
+    });
+
+    it('keeps appending up to maxChars before the next reset', () => {
+      const base = meta({
+        processOutput: new Map([['e', { stdout: '012345', stderr: '' }]]),
+      });
+      // combined "012345ab" (8) <= 10 → plain append, no reset yet.
+      const next = reduceStreamMeta(
+        base,
+        { kind: 'processOutput', executionId: 'e', stdout: 'ab', stderr: '' },
+        { outputCap: { maxChars: 10, retainChars: 5 } },
+      );
+      expect(next.processOutput.get('e')?.stdout).toBe('012345ab');
+    });
+
+    it('seeds a missing execution entry from empty', () => {
+      const next = reduceStreamMeta(
+        meta(),
+        {
+          kind: 'processOutput',
+          executionId: 'new',
+          stdout: 'hi',
+          stderr: 'e',
+        },
+        OPTS,
+      );
+      expect(next.processOutput.get('new')).toEqual({
+        stdout: 'hi',
+        stderr: 'e',
+      });
+    });
+  });
+
+  describe('activeProcesses', () => {
+    const active: ActiveChildInfo = {
+      executionId: 'active',
+      agentName: 'bash',
+    };
+
+    it('sets the active list and prunes output for vanished processes', () => {
+      const base = meta({
+        activeProcesses: [],
+        processOutput: new Map([
+          ['active', { stdout: 'a', stderr: '' }],
+          ['stale', { stdout: 's', stderr: '' }],
+        ]),
+      });
+      const next = reduceStreamMeta(
+        base,
+        { kind: 'activeProcesses', processes: [active] },
+        OPTS,
+      );
+      expect(next.activeProcesses).toEqual([active]);
+      expect(next.processOutput.has('active')).toBe(true);
+      expect(next.processOutput.has('stale')).toBe(false);
+      // Input is untouched.
+      expect(base.processOutput.has('stale')).toBe(true);
+    });
+
+    it('keeps the same output-map identity when nothing is pruned', () => {
+      const output = new Map([['active', { stdout: 'a', stderr: '' }]]);
+      const base = meta({ processOutput: output });
+      const next = reduceStreamMeta(
+        base,
+        { kind: 'activeProcesses', processes: [active] },
+        OPTS,
+      );
+      expect(next.processOutput).toBe(output);
+    });
+  });
+
+  describe('verbatim copies', () => {
+    it('sets activeSubagents', () => {
+      const subagents: ActiveChildInfo[] = [
+        { executionId: 's1', agentName: 'review', childStreamId: 'c1' },
+      ];
+      expect(
+        reduceStreamMeta(meta(), { kind: 'activeSubagents', subagents }, OPTS)
+          .activeSubagents,
+      ).toBe(subagents);
+    });
+
+    it('sets conversation, todos, plan, and description', () => {
+      const conversation: ConversationProgress = {
+        conversationTurns: 2,
+        toolCallCount: 5,
+      };
+      const todos: TodoItem[] = [
+        { content: 'do x', status: 'pending', activeForm: 'doing x' },
+      ];
+      const plan: Plan = { objective: 'finish the proof' };
+
+      expect(
+        reduceStreamMeta(meta(), { kind: 'conversation', conversation }, OPTS)
+          .conversation,
+      ).toBe(conversation);
+      expect(
+        reduceStreamMeta(meta(), { kind: 'todos', todos }, OPTS).todos,
+      ).toBe(todos);
+      expect(reduceStreamMeta(meta(), { kind: 'plan', plan }, OPTS).plan).toBe(
+        plan,
+      );
+      expect(
+        reduceStreamMeta(
+          meta(),
+          { kind: 'description', description: 'desc' },
+          OPTS,
+        ).description,
+      ).toBe('desc');
+    });
+  });
+
+  describe('purity', () => {
+    it('returns a fresh meta and map without mutating the input', () => {
+      const output = new Map([['e', { stdout: 'x', stderr: '' }]]);
+      const base = meta({ processOutput: output });
+      const next = reduceStreamMeta(
+        base,
+        { kind: 'processOutput', executionId: 'e', stdout: 'y', stderr: '' },
+        OPTS,
+      );
+      expect(next).not.toBe(base);
+      expect(next.processOutput).not.toBe(output);
+      expect(output.get('e')).toEqual({ stdout: 'x', stderr: '' });
+    });
+  });
+});

--- a/src/test-kernel/utils/AppendTail.vitest.ts
+++ b/src/test-kernel/utils/AppendTail.vitest.ts
@@ -16,6 +16,26 @@ describe('appendTail', () => {
     expect(appendTail('0123456789', 'abc', 5)).toBe('89abc');
   });
 
+  it('trims to retainChars (below the cap) when retainChars < maxChars', () => {
+    // joined = "0123456789abc" (13). 13 > maxChars 10 ⇒ reset, keeping the
+    // last retainChars (5) → "89abc". Models the 100k→80k webview policy.
+    expect(appendTail('0123456789', 'abc', 10, 5)).toBe('89abc');
+  });
+
+  it('does not reset while within maxChars even when retainChars is lower', () => {
+    // joined = "012345ab" (8) ≤ maxChars 10 ⇒ plain append, no reset.
+    expect(appendTail('012345', 'ab', 10, 5)).toBe('012345ab');
+  });
+
+  it('keeps a surrogate pair intact when trimming to retainChars', () => {
+    // "𐍈" = D800 DF48. joined = "ab𐍈YZ" (length 6); maxChars 4 crossed ⇒
+    // cut at index 6-3=3, the low surrogate; the fix advances past it so the
+    // whole codepoint is dropped → "YZ".
+    const out = appendTail('ab', '𐍈YZ', 4, 3);
+    expect(out).toBe('YZ');
+    expect(out.charCodeAt(0)).toBeLessThan(0xd800);
+  });
+
   it('does not split surrogate pairs at the truncation boundary', () => {
     // "𐍈" (U+10348) is encoded as two UTF-16 code units: high D800, low DF48.
     // joined = "𐍈Y" (length 3); maxChars = 2 ⇒ cut at index 1, which is the

--- a/src/test-kernel/utils/AppendTail.vitest.ts
+++ b/src/test-kernel/utils/AppendTail.vitest.ts
@@ -22,6 +22,15 @@ describe('appendTail', () => {
     expect(appendTail('0123456789', 'abc', 10, 5)).toBe('89abc');
   });
 
+  it('clamps retainChars to maxChars', () => {
+    // Misconfigured callers still get the documented "at most maxChars" tail.
+    expect(appendTail('0123456789', 'abc', 5, 100)).toBe('89abc');
+  });
+
+  it('clamps negative caps to an empty tail', () => {
+    expect(appendTail('0123456789', 'abc', -1, 100)).toBe('');
+  });
+
   it('does not reset while within maxChars even when retainChars is lower', () => {
     // joined = "012345ab" (8) ≤ maxChars 10 ⇒ plain append, no reset.
     expect(appendTail('012345', 'ab', 10, 5)).toBe('012345ab');

--- a/src/utils/strings/appendTail.ts
+++ b/src/utils/strings/appendTail.ts
@@ -1,16 +1,23 @@
 // Append `chunk` to `current` and keep at most `maxChars` UTF-16 code units,
-// truncating at the head. Used by the bash background tail and the CLI TUI
-// process-output buffer; consolidated here to avoid drift.
+// truncating at the head. Used by the bash background tail, the CLI TUI
+// process-output buffer, and the shared stream-meta reducer; consolidated here
+// to avoid drift.
+//
+// `retainChars` is the length to keep once the cap is crossed; it defaults to
+// `maxChars` (an exact head-cut at the cap). Passing a smaller `retainChars`
+// trims further below the cap so output can keep appending for a while before
+// the next reset (the webview's 100k→80k policy).
 
 export function appendTail(
   current: string,
   chunk: string,
   maxChars: number,
+  retainChars: number = maxChars,
 ): string {
   if (!chunk) return current;
   const combined = current + chunk;
   if (combined.length <= maxChars) return combined;
-  let cut = combined.length - maxChars;
+  let cut = Math.max(0, combined.length - retainChars);
   // Don't slice in the middle of a surrogate pair — the low half (DC00..DFFF)
   // alone is a ?-rendering invalid code point.
   const code = combined.charCodeAt(cut);

--- a/src/utils/strings/appendTail.ts
+++ b/src/utils/strings/appendTail.ts
@@ -6,7 +6,8 @@
 // `retainChars` is the length to keep once the cap is crossed; it defaults to
 // `maxChars` (an exact head-cut at the cap). Passing a smaller `retainChars`
 // trims further below the cap so output can keep appending for a while before
-// the next reset (the webview's 100k→80k policy).
+// the next reset (the webview's 100k→80k policy). It is clamped to the cap so
+// callers cannot accidentally retain more than `maxChars`.
 
 export function appendTail(
   current: string,
@@ -14,10 +15,12 @@ export function appendTail(
   maxChars: number,
   retainChars: number = maxChars,
 ): string {
+  const safeMaxChars = Math.max(0, maxChars);
+  const safeRetainChars = Math.min(Math.max(0, retainChars), safeMaxChars);
   if (!chunk) return current;
   const combined = current + chunk;
-  if (combined.length <= maxChars) return combined;
-  let cut = Math.max(0, combined.length - retainChars);
+  if (combined.length <= safeMaxChars) return combined;
+  let cut = combined.length - safeRetainChars;
   // Don't slice in the middle of a surrogate pair — the low half (DC00..DFFF)
   // alone is a ?-rendering invalid code point.
   const code = combined.charCodeAt(cut);


### PR DESCRIPTION
Closes #6827.

## What

Replaces the two hand-maintained per-stream-meta reducers (the webview's `streamMetaSlice` and the CLI's `applyToState`, whose own comments say it "mirrors" the webview) with one host-neutral reducer both consume.

- **New `src/shared/streams/streamMetaReducer.ts`** — pure `reduceStreamMeta(meta, cmd, { outputCap })` keyed off an internal `StreamMetaCommand` union (`processOutput`, `activeProcesses` [sets list + prunes vanished output], `activeSubagents`, `conversation`, `todos`, `plan`, `description`). Cap-configurable via `OutputCap { maxChars, retainChars? }`. No host imports; returns a fresh `StreamMeta` + fresh `Map`, never mutates input.
- **`appendTail`** gains an optional 4th `retainChars` param (default `= maxChars`, so every existing call site is byte-identical).
- **Webview** deletes its local `capOutput` + `pruneStaleOutputs` and delegates `UPDATE_PROCESS_OUTPUT` and the active-processes path of `UPDATE_STREAM_BADGES` to the reducer with `{ maxChars: 100_000, retainChars: 80_000 }`, keeping finished-counts / runUsage / focus / taskGroups outside it.
- **CLI** routes the same facts through the reducer with `{ maxChars: PROCESS_TAIL_CHARS_MAX }` (exact-cut), keeping its CLI-only side effects (completed-process entries, child-stream merge/register, usage, entries) outside.

**Bonus fix:** the webview previously capped output with a raw slice that could split a surrogate pair; it now inherits the CLI's surrogate-safe capping.

## Honest LoC note (please read)

This is a **convergence / correctness PR, not a LoC reduction** — production net is **+165**. The shared reducer must be cap-configurable and host-neutral, so it is necessarily larger than either copy it replaces; the win is a single source of truth for the `capOutput` / `pruneStaleOutputs` / output-append logic (which had drifted between hosts) plus the surrogate-safety fix. A comprehensive `code-simplifier` pass found only **−2 LoC** safe to cut, confirming the size is inherent to the seam, not verbosity.

## Behavior preservation (verified)

- Both cap policies reproduced exactly: CLI exact-cut at `PROCESS_TAIL_CHARS_MAX` (`retainChars` omitted); webview `100k → 80k` reset.
- Reducer is pure (input map never mutated; identity preserved when nothing prunes); no Immer draft leaks into CLI signal state.
- Host-only fields stay in the adapters, not the shared reducer.
- Reducer imports only `@shared/schemas` types + `@utils/strings/appendTail` (no vscode/electron/ink/immer).

## Verification

- Typecheck: root + `tsconfig.test-kernel.json` + extension + cli — all green.
- Tests: `212/212` across `shared` (incl. new `StreamMetaReducer` suite: both cap policies, prune, active-list set, trivial copies, purity), `ProcessOutputState` (webview adapter), `AppendTail` (new `retainChars` + surrogate cases), `TuiStateAndFocus` (CLI adapter).
- Lint clean.

Part of the cross-host convergence effort (#6826 / #6827 / #6828). File-disjoint from #6826; #6828 stays deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of bounded in-memory process output with preserved cap policies and new unit tests; no auth, persistence, or network behavior changes.
> 
> **Overview**
> Introduces **`reduceStreamMeta`** in `src/shared/streams/streamMetaReducer.ts` so the CLI TUI and extension progress webview no longer maintain separate logic for **bounded process stdout/stderr tails** and **pruning output when processes leave the active list**.
> 
> The **CLI** routes `updateActiveProcesses` / `updateProcessOutput` through `applyStreamMeta` with an **8 KiB exact head-cut** cap; **completed-process transcript** side effects stay in the adapter. The **webview** drops local `capOutput` / `pruneStaleOutputs` and calls the same reducer with **100k max / 80k retain** on `UPDATE_STREAM_BADGES` and `UPDATE_PROCESS_OUTPUT`, skipping store updates when the output map identity is unchanged.
> 
> **`appendTail`** gains an optional **`retainChars`** argument (default `maxChars`), with clamping and extra tests; the webview path now uses surrogate-safe trimming instead of a raw slice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 930398ec8129efbe30a41c913f83c163fb90a47e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->