### PR TITLE
refactor(progressView): extract shared bounded-id-set for out-of-order guards

### DIFF
--- a/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -42,6 +42,7 @@ import { tryParseUrl } from '@utils/core';
 
 import { BaseFeedbackPanel } from './BaseFeedbackPanel';
 import { ProgressEvents } from '../events';
+import { createBoundedIdSet } from '../utils/boundedIdSet';
 import type { PermissionState } from '../permissionState';
 
 // ── Draft persistence ──
@@ -49,7 +50,7 @@ import type { PermissionState } from '../permissionState';
 const DRAFT_CACHE_CAP = 50;
 const DRAFT_SAVE_DELAY_MS = 400;
 const draftCache = new Map<string, InquiryDraft>();
-const resolvedIds = new Set<string>();
+const resolvedIds = createBoundedIdSet(DRAFT_CACHE_CAP);
 const INQUIRY_SUBMIT_ACTION = 'submit';
 
 interface InquiryPermissionIds {
@@ -86,11 +87,6 @@ function idsEqual(a: InquiryPermissionIds, b: InquiryPermissionIds): boolean {
 export function clearInquiryDraft(requestId: string): void {
   draftCache.delete(requestId);
   resolvedIds.add(requestId);
-  // Bound resolvedIds like draftCache
-  if (resolvedIds.size > DRAFT_CACHE_CAP) {
-    const oldest = resolvedIds.values().next().value;
-    if (oldest !== undefined) resolvedIds.delete(oldest);
-  }
 }
 
 // ── Component ──

--- a/packages/extension/src/progressView/frontend/eventHandlers.ts
+++ b/packages/extension/src/progressView/frontend/eventHandlers.ts
@@ -21,7 +21,7 @@ import {
   type StreamLogs,
   type StreamState,
 } from './store';
-import { removePrompt, resolvedProposalIds } from './slices/permissionSlice';
+import { addResolvedProposalId, removePrompt } from './slices/permissionSlice';
 import { updateToolUseState } from './stateUtils';
 import { clearInquiryDraft } from './components/ExternalInquiryPanel';
 import {
@@ -370,7 +370,7 @@ export function handlePermissionAction(
         permission.data.proposalId,
       );
       if (!removed) {
-        resolvedProposalIds.add(permission.data.proposalId);
+        addResolvedProposalId(permission.data.proposalId);
       }
       break;
     }

--- a/packages/extension/src/progressView/frontend/slices/permissionSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/permissionSlice.ts
@@ -12,6 +12,7 @@ import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 
 import { clearInquiryDraft } from '../components/ExternalInquiryPanel';
 import { updateToolUseState } from '../stateUtils';
+import { createBoundedIdSet } from '../utils/boundedIdSet';
 import type { PermissionState } from '../permissionState';
 import type {
   HandlerRegistry,
@@ -22,11 +23,11 @@ import type {
 // Module state
 // ============================================================
 
-/** Proposal IDs resolved before a show message arrives (out-of-order guard). */
-export const resolvedProposalIds = new Set<string>();
-
 /** Maximum entries before evicting oldest resolved IDs. */
 const RESOLVED_PROPOSAL_IDS_CAP = 200;
+
+/** Proposal IDs resolved before a show message arrives (out-of-order guard). */
+const resolvedProposalIds = createBoundedIdSet(RESOLVED_PROPOSAL_IDS_CAP);
 
 /** Clear all resolved proposal IDs (called on stream delete / delete-all). */
 export function clearResolvedProposalIds(): void {
@@ -36,11 +37,11 @@ export function clearResolvedProposalIds(): void {
 /** Add a resolved proposal ID, evicting the oldest entry if over cap. */
 export function addResolvedProposalId(id: string): void {
   resolvedProposalIds.add(id);
-  if (resolvedProposalIds.size > RESOLVED_PROPOSAL_IDS_CAP) {
-    // Set iteration order is insertion order — first value is oldest
-    const oldest = resolvedProposalIds.values().next().value;
-    if (oldest !== undefined) resolvedProposalIds.delete(oldest);
-  }
+}
+
+/** Consume (delete) a resolved proposal ID; returns true if it was present. */
+function consumeResolvedProposalId(id: string): boolean {
+  return resolvedProposalIds.delete(id);
 }
 
 // ============================================================
@@ -121,7 +122,7 @@ export const permissionHandlers: HandlerRegistry = {
       const { permission } = data;
       if (permission.kind === PERMISSION_KIND.PROPOSAL) {
         // Drop if this proposal was already resolved (out-of-order messages)
-        if (resolvedProposalIds.delete(permission.data.proposalId)) return;
+        if (consumeResolvedProposalId(permission.data.proposalId)) return;
         upsertProposalPermission(ctx, {
           kind: PERMISSION_KIND.PROPOSAL,
           data: permission.data,

--- a/packages/extension/src/progressView/frontend/slices/permissionSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/permissionSlice.ts
@@ -39,11 +39,6 @@ export function addResolvedProposalId(id: string): void {
   resolvedProposalIds.add(id);
 }
 
-/** Consume (delete) a resolved proposal ID; returns true if it was present. */
-function consumeResolvedProposalId(id: string): boolean {
-  return resolvedProposalIds.delete(id);
-}
-
 // ============================================================
 // Helpers (exported for use by eventHandlers.ts)
 // ============================================================
@@ -122,7 +117,7 @@ export const permissionHandlers: HandlerRegistry = {
       const { permission } = data;
       if (permission.kind === PERMISSION_KIND.PROPOSAL) {
         // Drop if this proposal was already resolved (out-of-order messages)
-        if (consumeResolvedProposalId(permission.data.proposalId)) return;
+        if (resolvedProposalIds.delete(permission.data.proposalId)) return;
         upsertProposalPermission(ctx, {
           kind: PERMISSION_KIND.PROPOSAL,
           data: permission.data,

--- a/packages/extension/src/progressView/frontend/utils/boundedIdSet.ts
+++ b/packages/extension/src/progressView/frontend/utils/boundedIdSet.ts
@@ -1,0 +1,29 @@
+/**
+ * A Set<string> capped at a maximum size, evicting the oldest entry (in
+ * insertion order) once the cap is exceeded. Used to bound "seen id" guards
+ * (out-of-order message guards, resolved-id tracking) that would otherwise
+ * grow unbounded over a long-running webview session.
+ */
+export interface BoundedIdSet {
+  has(id: string): boolean;
+  add(id: string): void;
+  delete(id: string): boolean;
+  clear(): void;
+}
+
+export function createBoundedIdSet(cap: number): BoundedIdSet {
+  const ids = new Set<string>();
+  return {
+    has: (id) => ids.has(id),
+    delete: (id) => ids.delete(id),
+    clear: () => ids.clear(),
+    add(id) {
+      ids.add(id);
+      if (ids.size > cap) {
+        // Set iteration order is insertion order — first value is oldest
+        const oldest = ids.values().next().value;
+        if (oldest !== undefined) ids.delete(oldest);
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Follow-up from an abstraction-layer audit of the codebase. `permissionSlice.ts` and `ExternalInquiryPanel.ts` each independently reimplemented the same "bounded Set with evict-oldest-on-cap" logic for tracking resolved/out-of-order request IDs. Extracted the shared logic into `progressView/frontend/utils/boundedIdSet.ts` and encapsulated the Set behind an interface instead of exporting the raw mutable `Set`.

While extracting this, found that `eventHandlers.ts` was mutating `resolvedProposalIds` directly via `.add()` (imported as the raw exported `Set`), bypassing the 200-entry cap that `addResolvedProposalId()` enforced on the other write path — so that call site could grow the Set unbounded over a long-running webview session. Fixed by routing it through the exported function instead.

## Issue acceptance gates

No linked issue — this is a repo-wide abstraction-layer review requested directly, not tracked against a GitHub issue. Gate: eliminate the duplicated cache-eviction logic and close the encapsulation gap that let one call site bypass the cap.

## Single source of truth

`createBoundedIdSet()` in `progressView/frontend/utils/boundedIdSet.ts` now owns the cap-and-evict invariant for "seen id" guards. `permissionSlice.ts` and `ExternalInquiryPanel.ts` each hold a private instance and expose only the operations callers need. `permissionSlice.ts` exports `addResolvedProposalId` (used by `eventHandlers.ts`) and `clearResolvedProposalIds`; the consume path (`resolvedProposalIds.delete(...)`) is called directly from the sole same-module call site rather than through a single-use wrapper. The raw `Set` itself is never exported.

## Duplication and abstraction budget

Removed: two near-identical inline "evict oldest entry past cap" blocks. Added: one small utility module (`BoundedIdSet` interface + `createBoundedIdSet()` factory), used by exactly the two call sites that had the duplicated logic — no speculative generality beyond that.

## Host impact

Extension: `packages/extension/src/progressView/frontend` (webview UI for the progress board) — behavior-preserving refactor plus the cap-enforcement fix described above.

Desktop: none (shares the same webview code, no separate desktop-only path here).

CLI: none.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — passes clean.
- `npx eslint` on all touched/added files — no errors.
- `npm test` — 4176 passed, 1 pre-existing unrelated failure (`execUtils.vitest.ts` process-group abort test, a sandboxed-process-signaling flake reproduced identically on `main` before this change), 7 skipped.
