### PR TITLE
refactor: remove unsafe schema casts around active-file and stream-metadata state

### DIFF
--- a/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
@@ -42,14 +42,11 @@ function mergeBackendOwnedState(
       taskGroups: existing.taskGroups,
     });
   }
+  // Overlay every backend-owned field from metadata (its own keys are exactly
+  // the BackendOwnedFieldsSchema shape) so a new field added there is picked
+  // up here without also updating this call site.
   return create(existing, (draft) => {
-    draft.status = metadata.status;
-    draft.lastTimestamp = metadata.lastTimestamp;
-    draft.conversationProgress = metadata.conversationProgress;
-    draft.activeSubagents = metadata.activeSubagents;
-    draft.finishedSubagentCount = metadata.finishedSubagentCount;
-    draft.activeProcesses = metadata.activeProcesses;
-    draft.finishedProcessCount = metadata.finishedProcessCount;
+    Object.assign(draft, metadata);
   });
 }
 

--- a/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
@@ -42,9 +42,10 @@ function mergeBackendOwnedState(
       taskGroups: existing.taskGroups,
     });
   }
-  // Overlay every backend-owned field from metadata (its own keys are exactly
-  // the BackendOwnedFieldsSchema shape) so a new field added there is picked
-  // up here without also updating this call site.
+  // Overlay every backend-owned field from metadata (its own keys include
+  // every BackendOwnedFieldsSchema field plus `kind`, which the guard above
+  // already ensures matches `existing.kind`) so a new field added to that
+  // schema is picked up here without also updating this call site.
   return create(existing, (draft) => {
     Object.assign(draft, metadata);
   });

--- a/src/agent/core/state/TaskState.ts
+++ b/src/agent/core/state/TaskState.ts
@@ -10,10 +10,15 @@ import { AgentConfigSchema, type AgentConfig } from '../definition/AgentConfig';
 
 const ToolSessionStateSchema = z.object({});
 
-const ActiveFilesSchema = z.partialRecord(
-  z.enum(MULTIPLE_DOCUMENT_FILE_TYPES),
-  z.boolean(),
-) as z.ZodType<Record<MultipleDocumentFileType, boolean>>;
+const ActiveFilesSchema = z
+  .partialRecord(z.enum(MULTIPLE_DOCUMENT_FILE_TYPES), z.boolean())
+  .transform((partial) => {
+    const complete = {} as Record<MultipleDocumentFileType, boolean>;
+    for (const key of MULTIPLE_DOCUMENT_FILE_TYPES) {
+      complete[key] = partial[key] ?? false;
+    }
+    return complete;
+  });
 
 type WorkflowAgentConfig = AgentConfig & {
   agentCategory: typeof AgentCategory.Workflow;

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -1500,12 +1500,12 @@ describe('DesktopProgressBridge', () => {
         'stream-1',
         executionId,
         expect.objectContaining({
-          activeFiles: {
+          activeFiles: expect.objectContaining({
             input: false,
             context: false,
             media: false,
             output: false,
-          },
+          }),
           agentConfig: expect.objectContaining(taskState.agentConfig),
         }),
       );
@@ -1555,12 +1555,12 @@ describe('DesktopProgressBridge', () => {
         'stream-1',
         executionId,
         expect.objectContaining({
-          activeFiles: {
+          activeFiles: expect.objectContaining({
             input: false,
             context: false,
             media: false,
             output: false,
-          },
+          }),
           agentConfig: expect.objectContaining(taskState.agentConfig),
         }),
       );

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -1500,7 +1500,12 @@ describe('DesktopProgressBridge', () => {
         'stream-1',
         executionId,
         expect.objectContaining({
-          activeFiles: {},
+          activeFiles: {
+            input: false,
+            context: false,
+            media: false,
+            output: false,
+          },
           agentConfig: expect.objectContaining(taskState.agentConfig),
         }),
       );
@@ -1550,7 +1555,12 @@ describe('DesktopProgressBridge', () => {
         'stream-1',
         executionId,
         expect.objectContaining({
-          activeFiles: {},
+          activeFiles: {
+            input: false,
+            context: false,
+            media: false,
+            output: false,
+          },
           agentConfig: expect.objectContaining(taskState.agentConfig),
         }),
       );


### PR DESCRIPTION
## Summary

Follow-up from a data-structure complexity review of the codebase. Two of the concrete, low-risk findings are fixed here; several other findings from the review turned out, on closer inspection, to be appropriate given their problem domain (polymorphic multi-provider SDK parsing, genuinely dynamic user data) and were left alone rather than over-engineered.

- `src/agent/core/state/TaskState.ts`: `ActiveFilesSchema` force-cast a `z.partialRecord` (which legitimately allows missing keys) to a fully-populated `Record<MultipleDocumentFileType, boolean>` type. A persisted `TaskState` missing a key would parse successfully but produce `undefined` at a field the type declared as `boolean` — a real type/runtime mismatch. Fixed by filling missing keys via `.transform()` so the schema's output always matches its declared type.
- `packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts`: `mergeBackendOwnedState()` hand-enumerated the same 6 fields already declared once in `BackendOwnedFieldsSchema`, so adding a new backend-owned field required updating both places. Replaced the manual field list with `Object.assign(draft, metadata)`, driven by the metadata payload's own keys.

## Issue acceptance gates

Addresses two "High"/"Medium" findings from an internal data-structure-complexity audit: (1) a schema cast that could mask missing persisted state, (2) a duplicated field enumeration between a schema and its consumer.

## Single source of truth

`BackendOwnedFieldsSchema` (in `src/shared/schemas/streamState.ts`) is now the sole place enumerating backend-owned stream fields; `ActiveFilesSchema`'s `.transform()` is the sole place defining "missing file-type key defaults to `false`."

## Duplication and abstraction budget

Removed the duplicated backend-owned-field list in `mergeBackendOwnedState()`. No new abstractions added.

## Host impact

Extension: `streamLifecycleSlice.ts` merge behavior is unchanged for well-formed metadata; it now also survives future schema additions without a second edit.

Desktop: `tryResumeStream()` now receives a fully-populated `activeFiles` object on resume instead of a partial one that could omit keys.

CLI: No change (does not use either touched module directly).

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — passes
- `npm run lint` — passes (0 errors; only pre-existing warnings in unrelated files)
- `npm test` — 544 files / 4174 tests pass (updated 2 assertions in `DesktopAgentExecution.vitest.mts` to match the corrected, fully-populated `activeFiles` shape). One failing test (`execUtils.vitest.ts` process-group abort) is a pre-existing sandbox/environment issue, reproduced identically on `main` before this change.


---
_Generated by [Claude Code](https://claude.ai/code/session_016g5NG4qjbhQvkCodbqy1JB)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted schema and merge refactors with clearer defaults on resume; behavior is unchanged for well-formed metadata and only normalizes missing active-file keys.
> 
> **Overview**
> Removes two places where types and runtime behavior could drift apart.
> 
> **`ActiveFilesSchema`** no longer relies on a cast from a partial record to a full `Record<MultipleDocumentFileType, boolean>`. Parsing now **fills every document file type** (`input`, `context`, `media`, `output`) with `false` when a key is missing, so persisted workflow task state and resume paths always get booleans instead of `undefined`.
> 
> **`mergeBackendOwnedState`** in the progress view stops hand-copying six backend-owned stream fields and uses **`Object.assign(draft, metadata)`** so new fields on `BackendOwnedFieldsSchema` / `StreamMetadata` are merged automatically. Frontend-owned fields such as `taskGroups` stay on the draft because they are not on the metadata payload.
> 
> Desktop workflow resume tests now expect the **fully populated `activeFiles`** object passed into session resume retrieval.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55de7715e43aa5376196881494fdc380992a8e3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->