### PR TITLE
fix(github): accept GH_TOKEN for activity subscriptions

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -256,7 +256,7 @@ The **Git tab** in the TeXRA Dashboard (`TeXRA: Show Settings Dashboard` → **G
 
 <GitTabCard />
 
-<p class="hero-caption">The Git tab: the GitHub token row (here picked up from <code>GITHUB_TOKEN</code>, shown as <strong>Env</strong>) with Create on GitHub and Set token, and the commit-author toggle.</p>
+<p class="hero-caption">The Git tab: the GitHub token row (here picked up from <code>GITHUB_TOKEN</code> or <code>GH_TOKEN</code>, shown as <strong>Env</strong>) with Create on GitHub and Set token, and the commit-author toggle.</p>
 
 ### GitHub personal access token
 
@@ -272,7 +272,7 @@ Setup:
 3. Pick an expiration (90 days is a common choice) and generate the token. GitHub shows it only once.
 4. Back in TeXRA's Git tab, click **Set token** and paste it in.
 
-The token is stored in VS Code's encrypted **Secret Storage** — never written to `settings.json`. Alternatively, export `GITHUB_TOKEN` in the shell VS Code is launched from and the tool will pick it up automatically (the Git tab will show **Env** as the status).
+The token is stored in VS Code's encrypted **Secret Storage** — never written to `settings.json`. Alternatively, export `GITHUB_TOKEN` or `GH_TOKEN` in the host environment and the tool will pick it up automatically (the Git tab will show **Env** as the status).
 
 Once a token is configured, an agent can run `github_subscription command=subscribe path=owner/repo/pulls/N` (or `path=owner/repo` for the whole repo, `path=owner/repo/issues/N` for a single issue) and every new event arrives wrapped in a `<github-webhook-activity>` tag in the follow-up queue. Use `command=unsubscribe` with the same path to stop, `command=list` to see active subscriptions, and `command=find_current` to resolve the current branch's PR. Subscriptions auto-terminate when the PR closes or merges, and up to 25 PRs can be watched concurrently.
 

--- a/docs/prds/2026-05-04-prd-cli-app.md
+++ b/docs/prds/2026-05-04-prd-cli-app.md
@@ -1193,7 +1193,7 @@ The rest of round 2 is the spec for these deltas, in dependency order: §22 → 
 
 The CLI's relationship to the RunContext PRD is one of _consumer_, not _driver_:
 
-- The CLI's `cli/src/runtime/initPlatform.ts` constructs a `RunContext` per `texra run` invocation, populates `RunCapabilities` (no extension; GitHub token from `process.env.GITHUB_TOKEN`; no callback resolver), and threads it via `withRunContext(ctx, () => executeAgent(...))`.
+- The CLI's `cli/src/runtime/initPlatform.ts` constructs a `RunContext` per `texra run` invocation, populates `RunCapabilities` (no extension; GitHub token from `process.env.GITHUB_TOKEN` or `process.env.GH_TOKEN`; no callback resolver), and threads it via `withRunContext(ctx, () => executeAgent(...))`.
 - The CLI's `texra mcp serve` host (§24) constructs _one `RunContext` per MCP `tools/call`_ — that's the workload that gates the RunContext PRD's Phase 2 (singleton retirement) for v1.1 concurrency safety.
 - Until the RunContext PRD's Phase 1 lands, the CLI's `runAgent()` SDK is documented as **single-consumer-per-process** (round-1 §7.6 caveat). The shim path makes this safe-by-default, not safe-by-design.
 

--- a/packages/extension/src/frontend/secretManager.ts
+++ b/packages/extension/src/frontend/secretManager.ts
@@ -4,7 +4,11 @@ import * as vscode from 'vscode';
 // Local imports
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { API_PROVIDERS, type ApiProvider } from '@model/apiProviders';
-import { GITHUB_TOKEN_STORAGE_KEY } from '@tools/github/githubAuth';
+import {
+  GITHUB_TOKEN_STORAGE_KEY,
+  getGitHubEnvToken,
+  normalizeGitHubToken,
+} from '@tools/github/githubAuth';
 import { isNonEmptyString } from '@utils/core';
 
 export type { ApiProvider };
@@ -59,9 +63,9 @@ export class SecretManager {
   }
 
   public static async gitHubTokenExists(): Promise<'secret' | 'env' | 'none'> {
-    const stored = await this.get(this.GITHUB_TOKEN_KEY);
+    const stored = normalizeGitHubToken(await this.get(this.GITHUB_TOKEN_KEY));
     if (stored) return 'secret';
-    if (process.env.GITHUB_TOKEN) return 'env';
+    if (getGitHubEnvToken()) return 'env';
     return 'none';
   }
 

--- a/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
@@ -313,8 +313,9 @@ export class GitTab extends LitElement {
                   ${this.githubTokenStatus === 'env'
                     ? html`<p>
                         A token is currently being read from the
-                        <code>GITHUB_TOKEN</code> environment variable. Setting
-                        one above will override it.
+                        <code>GITHUB_TOKEN</code> or <code>GH_TOKEN</code>
+                        environment variable. Setting one above will override
+                        it.
                       </p>`
                     : nothing}
                 </div>

--- a/src/shared/schemas/settingsView/data.ts
+++ b/src/shared/schemas/settingsView/data.ts
@@ -337,7 +337,7 @@ export const UpdateGitAuthorSettingsMessageSchema = z.object({
 /** Outbound: backend → frontend GitHub token status. */
 export const UpdateGitHubTokenStatusMessageSchema = z.object({
   command: z.literal(SETTINGS_VIEW_COMMANDS.UPDATE_GITHUB_TOKEN_STATUS),
-  /** 'secret' = stored in SecretStorage; 'env' = GITHUB_TOKEN env var; 'none' = missing. */
+  /** 'secret' = stored in SecretStorage; 'env' = GITHUB_TOKEN/GH_TOKEN env var; 'none' = missing. */
   status: z.enum(['secret', 'env', 'none']),
 });
 

--- a/src/test-kernel/tools/GitHubAuth.vitest.ts
+++ b/src/test-kernel/tools/GitHubAuth.vitest.ts
@@ -2,10 +2,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const originalGitHubToken = process.env.GITHUB_TOKEN;
+const originalGhToken = process.env.GH_TOKEN;
 
 beforeEach(() => {
   vi.resetModules();
-  process.env.GITHUB_TOKEN = 'gh-env-token';
+  delete process.env.GITHUB_TOKEN;
+  delete process.env.GH_TOKEN;
 });
 
 afterEach(() => {
@@ -14,17 +16,53 @@ afterEach(() => {
   } else {
     process.env.GITHUB_TOKEN = originalGitHubToken;
   }
+  if (originalGhToken === undefined) {
+    delete process.env.GH_TOKEN;
+  } else {
+    process.env.GH_TOKEN = originalGhToken;
+  }
   vi.resetModules();
 });
 
 describe('getGitHubToken', () => {
   it('uses the GITHUB_TOKEN fallback before platform initialization', async () => {
+    process.env.GITHUB_TOKEN = 'github-env-token';
+
+    const { getGitHubToken } = await import('@tools/github/githubAuth');
+
+    await expect(getGitHubToken()).resolves.toBe('github-env-token');
+  });
+
+  it('uses the GH_TOKEN fallback before platform initialization', async () => {
+    process.env.GH_TOKEN = 'gh-env-token';
+
+    const { getGitHubToken } = await import('@tools/github/githubAuth');
+
+    await expect(getGitHubToken()).resolves.toBe('gh-env-token');
+  });
+
+  it('prefers GH_TOKEN over GITHUB_TOKEN', async () => {
+    process.env.GITHUB_TOKEN = 'github-env-token';
+    process.env.GH_TOKEN = 'gh-env-token';
+
+    const { getGitHubToken } = await import('@tools/github/githubAuth');
+
+    await expect(getGitHubToken()).resolves.toBe('gh-env-token');
+  });
+
+  it('ignores blank environment token values', async () => {
+    process.env.GITHUB_TOKEN = '   ';
+    process.env.GH_TOKEN = 'gh-env-token';
+
     const { getGitHubToken } = await import('@tools/github/githubAuth');
 
     await expect(getGitHubToken()).resolves.toBe('gh-env-token');
   });
 
   it('prefers the platform secret when the platform is initialized', async () => {
+    process.env.GITHUB_TOKEN = 'github-env-token';
+    process.env.GH_TOKEN = 'gh-env-token';
+
     const [{ initPlatform }, { createFakePlatform }, githubAuth] =
       await Promise.all([
         import('@platform/platform'),
@@ -41,5 +79,26 @@ describe('getGitHubToken', () => {
     );
 
     await expect(githubAuth.getGitHubToken()).resolves.toBe('gh-secret-token');
+  });
+
+  it('ignores blank platform secrets before using environment fallbacks', async () => {
+    process.env.GH_TOKEN = 'gh-env-token';
+
+    const [{ initPlatform }, { createFakePlatform }, githubAuth] =
+      await Promise.all([
+        import('@platform/platform'),
+        import('@test/support/FakePlatform'),
+        import('@tools/github/githubAuth'),
+      ]);
+
+    initPlatform(
+      createFakePlatform({
+        secrets: {
+          [githubAuth.GITHUB_TOKEN_STORAGE_KEY]: '   ',
+        },
+      }),
+    );
+
+    await expect(githubAuth.getGitHubToken()).resolves.toBe('gh-env-token');
   });
 });

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -387,13 +387,11 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     installGuide:
       'Requires a git-tracked workspace and a GitHub personal access token:\n\n' +
       '  1. Open the folder as a git repo (or `git init` + set a github.com remote).\n' +
-      '  2. In TeXRA settings → Git tab, click "Create on GitHub…"\n' +
-      '     (opens the token page with the right scopes pre-filled).\n' +
+      '  2. In VS Code, TeXRA settings → Git tab can open the token page with the right scopes pre-filled.\n' +
       '  3. Scopes: "repo" for private repositories, "public_repo" for public only.\n' +
-      '  4. Copy the token back into TeXRA via "Set token".\n\n' +
-      'Alternatively, export GITHUB_TOKEN in the environment VS Code is launched from.',
+      '  4. Store the token in host secret storage, or export GITHUB_TOKEN/GH_TOKEN for CLI and automation.',
     installUrl: 'https://github.com/settings/tokens',
-    configNotes: `Token stored in VS Code SecretStorage (managed from Git tab). Requires a git repository in the workspace. Polls every ${PR_POLL_INTERVAL_MS / 1000}s; cap: ${MAX_CONCURRENT_PR_SUBSCRIPTIONS} concurrent PRs and 3 concurrent repos. Bot-authored events are dropped end-to-end by policy.`,
+    configNotes: `Token stored in host secret storage or read from GITHUB_TOKEN/GH_TOKEN. In VS Code, the Git tab manages the stored token. Requires a git repository in the workspace. Polls every ${PR_POLL_INTERVAL_MS / 1000}s; cap: ${MAX_CONCURRENT_PR_SUBSCRIPTIONS} concurrent PRs and 3 concurrent repos. Bot-authored events are dropped end-to-end by policy.`,
     authNote: 'Uses personal access token',
     toggleable: true,
     installActionCommand: 'texra.showGitSettings',

--- a/src/tools/github/githubAuth.ts
+++ b/src/tools/github/githubAuth.ts
@@ -2,19 +2,36 @@
  * GitHub personal access token lookup.
  *
  * Host-neutral: reads from the platform secrets port (each host wires its own
- * secret store) with a `GITHUB_TOKEN` environment-variable fallback. The token
- * is persisted under `github.token` (set via the Git settings tab), while the
- * conventional env var is `GITHUB_TOKEN` — a different name — hence the explicit
- * second fallback. Because every host wires `platform().secrets`, GitHub tools
- * now work in the CLI and desktop too, not just the extension.
+ * secret store) with GitHub environment-variable fallbacks. The token is
+ * persisted under `github.token` (set via the Git settings tab or CLI secrets),
+ * while the conventional env vars are `GH_TOKEN` and `GITHUB_TOKEN`; hence the
+ * explicit fallback. Because every host wires `platform().secrets`, GitHub
+ * tools work in the CLI and desktop too, not just the extension.
  */
 import { tryPlatform } from '@platform/platform';
 
 /** SecretStorage key under which the GitHub PAT is persisted. */
 export const GITHUB_TOKEN_STORAGE_KEY = 'github.token';
 
+/** Environment variables accepted by GitHub tools, in precedence order. */
+export const GITHUB_TOKEN_ENV_VARS = ['GH_TOKEN', 'GITHUB_TOKEN'] as const;
+
+export function normalizeGitHubToken(
+  token: string | undefined,
+): string | undefined {
+  const trimmed = token?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function getGitHubEnvToken(): string | undefined {
+  for (const envVar of GITHUB_TOKEN_ENV_VARS) {
+    const token = normalizeGitHubToken(process.env[envVar]);
+    if (token) return token;
+  }
+  return undefined;
+}
+
 export async function getGitHubToken(): Promise<string | undefined> {
   const stored = await tryPlatform()?.secrets.get(GITHUB_TOKEN_STORAGE_KEY);
-  const token = stored ?? process.env.GITHUB_TOKEN;
-  return token && token.length > 0 ? token : undefined;
+  return normalizeGitHubToken(stored) ?? getGitHubEnvToken();
 }

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -33,6 +33,7 @@ import {
 } from './checkAnnotationLevels';
 import { getGitHubToken } from './githubAuth';
 import { ghGet } from './githubClient';
+import { MAX_CONCURRENT_PR_SUBSCRIPTIONS } from './prSubscriptionConstants';
 import {
   bindIssueSubscription,
   bindPRSubscription,
@@ -123,7 +124,7 @@ function parsePath(raw: string): ParsedPath {
 async function requireToken(): Promise<void> {
   if (!(await getGitHubToken())) {
     throw new ToolError(
-      'No GitHub token configured. Open TeXRA settings → Git tab → "Set token" (or export GITHUB_TOKEN). Needs `repo` scope for private repos, `public_repo` for public.',
+      'No GitHub token configured. Set one in host settings (VS Code: TeXRA settings → Git tab → "Set token"), or export GITHUB_TOKEN or GH_TOKEN. Needs `repo` scope for private repos, `public_repo` for public.',
     );
   }
 }
@@ -514,7 +515,7 @@ export class GitHubSubscriptionTool extends defineTool({
     '- list: list active subscriptions on this stream.',
     '- find_current: resolve the current git branch to its PR path (returns "owner/repo/pulls/N").',
     'Bot-authored events are dropped end-to-end by policy.',
-    'Caps: 10 concurrent PR subscriptions, 10 concurrent issue subscriptions, 3 concurrent repo subscriptions per process. Poll interval ≈ 30s. Requires a GitHub token — set it in TeXRA settings → Git tab, or via GITHUB_TOKEN.',
+    `Caps: ${MAX_CONCURRENT_PR_SUBSCRIPTIONS} concurrent PR subscriptions, 10 concurrent issue subscriptions, 3 concurrent repo subscriptions per process. Poll interval ≈ 30s. Requires a GitHub token — set it in host settings, or via GITHUB_TOKEN or GH_TOKEN.`,
   ].join(' '),
   schema: GitHubSubscriptionInputSchema,
 }) {


### PR DESCRIPTION
## Summary
- Accept `GH_TOKEN` and `GITHUB_TOKEN` as GitHub subscription token fallbacks after stored `github.token`, matching GitHub CLI precedence by checking `GH_TOKEN` first.
- Reuse the same token normalization for settings status and GitHub subscription diagnostics, including whitespace-only stored values.
- Update the user guide, CLI PRD note, and auth tests to document the supported CLI token aliases.

## Root Cause
The CLI design and GitHub conventions allowed `GH_TOKEN`, but the shared GitHub token resolver only checked `GITHUB_TOKEN` after the host secret store. CLI sessions using `GH_TOKEN` therefore reported that no token was configured.

## Validation
- `CI=true npm test -- GitHubAuth.vitest.ts`
- `CI=true npm run typecheck`
- `CI=true npm run lint -- --quiet`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow auth/env fallback change with expanded tests; no new scopes or storage format changes.
> 
> **Overview**
> **GitHub token resolution** now treats **`GH_TOKEN`** the same as **`GITHUB_TOKEN`** after stored `github.token`, with **`GH_TOKEN` winning** when both are set. Tokens are **trimmed** and **blank** secret/env values are ignored before falling through.
> 
> The VS Code **Git tab**, **SecretManager** env detection, **settings schema** comments, **user guide**, **CLI PRD**, **`github_subscription` errors**, and **external tool install copy** all mention **`GH_TOKEN`** and use **host-neutral** wording (secret storage vs VS Code-only).
> 
> **Tests** in `GitHubAuth.vitest.ts` cover precedence, both env vars, and blank stored secrets. The subscription tool description now pulls the **PR subscription cap** from `MAX_CONCURRENT_PR_SUBSCRIPTIONS` instead of a hardcoded number.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a952a9c23bf4c2d56c10ef33715f36d4fb4c7dc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->