### PR TITLE
fix(agent): recover multi-doc output when the model skips XML/% headers

### DIFF
--- a/src/agent/output/OutputFileProcessor.ts
+++ b/src/agent/output/OutputFileProcessor.ts
@@ -94,20 +94,29 @@ export class OutputFileProcessor {
 
     // An output's source is the workspace-relative document name; a base
     // file is workspace-relative too, except external locations, which only
-    // carry an absolute path — hence the suffix comparison.
-    const matchesSource = (location: FileLocation, source: string): boolean => {
-      const path = normalizeFilePath(
+    // carry an absolute path — hence the suffix comparison. A suffix match
+    // only counts when it is unambiguous: a basename-only source (e.g. from
+    // a `% main.tex` header) must not map onto several same-named base
+    // files in different directories.
+    const pathOf = (location: FileLocation): string =>
+      normalizeFilePath(
         location.kind === 'external'
           ? location.absolutePath
           : location.relativePath,
       );
-      const normalizedSource = normalizeFilePath(source);
-      return path === normalizedSource || path.endsWith(`/${normalizedSource}`);
-    };
+    const basesMatching = (source: string): number =>
+      baseFiles.filter((base) => {
+        const path = pathOf(base);
+        return path === source || path.endsWith(`/${source}`);
+      }).length;
+
     return baseFiles.map((location) => {
-      const previous = previousOutputs.find((output) =>
-        matchesSource(location, output.source),
-      );
+      const path = pathOf(location);
+      const previous = previousOutputs.find((output) => {
+        const source = normalizeFilePath(output.source);
+        if (source === path) return true;
+        return path.endsWith(`/${source}`) && basesMatching(source) === 1;
+      });
       return previous?.location ?? location;
     });
   }

--- a/src/agent/output/OutputFileProcessor.ts
+++ b/src/agent/output/OutputFileProcessor.ts
@@ -48,6 +48,8 @@ export class OutputFileProcessor {
             outputLocation,
             this.ctx.agentSetting.documentTag,
             currRound,
+            'scratchpad',
+            this.ctx.baseFiles,
           );
 
         if (processedPairs.length === 0) {

--- a/src/agent/output/OutputFileProcessor.ts
+++ b/src/agent/output/OutputFileProcessor.ts
@@ -6,6 +6,7 @@ import {
   type OutputFileInfo,
   type RoundOutput,
 } from '@shared/schemas';
+import { normalizeFilePath } from '@shared/utils/path';
 import { flexibleFS, replaceInputCommands } from '@utils/files';
 import {
   extractMultipleTextFromTag,
@@ -49,7 +50,7 @@ export class OutputFileProcessor {
             this.ctx.agentSetting.documentTag,
             currRound,
             'scratchpad',
-            this.ctx.baseFiles,
+            this.similarityBaseFiles(currRound),
           );
 
         if (processedPairs.length === 0) {
@@ -75,6 +76,40 @@ export class OutputFileProcessor {
           this.handleNoOutputs(currRound, outputLocation, rawLocation),
       },
     );
+  }
+
+  /**
+   * Base files for the unlabeled-fence similarity fallback. Rounds after the
+   * first revise the previous round's outputs, so compare against those, not
+   * the originals the content may have diverged from. Positional order is
+   * preserved (the fallback zips base files with the agent's inputFiles by
+   * index); a file the previous round did not produce keeps its original
+   * location.
+   */
+  private similarityBaseFiles(currRound: number): FileLocation[] {
+    const { baseFiles } = this.ctx;
+    if (currRound === 0) return baseFiles;
+    const previousOutputs = this.ctx.ensureRoundData(currRound - 1).outputs;
+    if (previousOutputs.length === 0) return baseFiles;
+
+    // An output's source is the workspace-relative document name; a base
+    // file is workspace-relative too, except external locations, which only
+    // carry an absolute path — hence the suffix comparison.
+    const matchesSource = (location: FileLocation, source: string): boolean => {
+      const path = normalizeFilePath(
+        location.kind === 'external'
+          ? location.absolutePath
+          : location.relativePath,
+      );
+      const normalizedSource = normalizeFilePath(source);
+      return path === normalizedSource || path.endsWith(`/${normalizedSource}`);
+    };
+    return baseFiles.map((location) => {
+      const previous = previousOutputs.find((output) =>
+        matchesSource(location, output.source),
+      );
+      return previous?.location ?? location;
+    });
   }
 
   /** Signal a missing/empty round, then persist the empty round summary. */

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -20,6 +20,7 @@ import { toErrorMessage } from '@common/errors';
 import replacementEngine, { applyReplacements } from '@replacement/engine';
 import { FENCED_LATEX_BLOCK_REPLACEMENTS } from '@replacement/rulesRegex';
 import type { FileLocation, OutputFileInfo } from '@shared/schemas';
+import { getBasename, normalizeFilePath } from '@shared/utils/path';
 import {
   AbsoluteFS,
   createExternalLocation,
@@ -87,14 +88,15 @@ function matchKnownInputFileLabel(
 ): string | null {
   const candidate = line.trim().replaceAll(BARE_LABEL_DECORATION_REGEX, '');
   if (!candidate) return null;
-  const normalize = (p: string) => p.replaceAll('\\', '/');
-  const exact = inputFiles.find((f) => normalize(f) === normalize(candidate));
+  const exact = inputFiles.find(
+    (f) => normalizeFilePath(f) === normalizeFilePath(candidate),
+  );
   if (exact) return exact;
 
   // Fall back to a basename match when the model dropped the leading
   // directories, but only when it resolves unambiguously.
   const basenameMatches = inputFiles.filter(
-    (f) => path.posix.basename(normalize(f)) === candidate,
+    (f) => getBasename(f) === candidate,
   );
   return basenameMatches.length === 1 ? basenameMatches[0] : null;
 }
@@ -585,6 +587,9 @@ export class XmlOutputManager {
     const files = await Promise.all(
       baseFiles.slice(0, inputFiles.length).map(async (loc, idx) => ({
         name: inputFiles[idx],
+        // An unreadable base file becomes '': it will score near-zero
+        // similarity against any real fenced block rather than aborting the
+        // whole recovery pass.
         content: await AbsoluteFS.read(loc.absolutePath).catch(() => ''),
       })),
     );
@@ -669,10 +674,19 @@ export class XmlOutputManager {
       );
     }
 
-    if (!documents && this.agentConfig.inputFiles.length > 1) {
+    if (
+      !documents &&
+      this.agentConfig.inputFiles.length > 1 &&
+      this.agentConfig.outputFiles.length === 0
+    ) {
       // Multi-input agents have no name to synthesize a single-document
       // recovery from, but an unlabeled fenced block can still be routed by
-      // comparing it against each original input file's content.
+      // comparing it against each original input file's content. Only valid
+      // when baseFiles really is the input files: runReflectionFlow.ts
+      // substitutes config.outputFiles for baseFiles whenever the agent
+      // declares any (single-artifact-from-many-inputs agents like ocr/
+      // paper2slide), so zipping baseFiles[i] with inputFiles[i] there would
+      // label a matched block with the wrong input filename.
       documents = await this.extractDocumentsByContentSimilarity(
         rawOutputContent,
         thinkingTag,

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -298,6 +298,8 @@ export class XmlOutputManager {
         roundDir: getFileDirectory(outputLocation),
         labelFiles: expectedFiles,
         synthesisName: soleExpectedFile,
+        coalesceRepeatedName:
+          this.agentConfig.outputFiles.length === 1 ? soleExpectedFile : null,
       });
       if (documents) {
         logInternal(
@@ -314,7 +316,11 @@ export class XmlOutputManager {
       }
     }
 
-    if (!documents && soleExpectedFile) {
+    if (
+      !documents &&
+      this.agentConfig.outputFiles.length === 1 &&
+      soleExpectedFile
+    ) {
       const fencedBlocks = this.collectLatexFencedBlocks(
         rawOutputContent,
         thinkingTag,

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -240,23 +240,26 @@ export class XmlOutputManager {
       );
     }
 
+    // The files this agent is expected to write: the declared outputFiles
+    // when present (single-artifact agents like ocr / paper2slide, whose
+    // inputs can be media files a response might mention in prose),
+    // otherwise the inputs (workflow edit agents reuse the input names as
+    // output names). Bare labels may only name these, and single-document
+    // synthesis may only use one of these — never an input name when the
+    // agent declares a different output.
+    const expectedFiles =
+      this.agentConfig.outputFiles.length > 0
+        ? this.agentConfig.outputFiles
+        : this.agentConfig.inputFiles;
+    const soleExpectedFile =
+      expectedFiles.length === 1 ? expectedFiles[0] : null;
+
     if (!documents) {
       documents = extractFilenameHeaderDocuments(rawOutputContent, {
         thinkingTag,
         roundDir: getFileDirectory(outputLocation),
-        // Bare labels may only name files this agent is expected to write:
-        // the declared outputFiles when present (single-artifact agents like
-        // ocr / paper2slide, whose inputs can be media files a response might
-        // mention in prose), otherwise the inputs (workflow edit agents reuse
-        // the input names as output names).
-        labelFiles:
-          this.agentConfig.outputFiles.length > 0
-            ? this.agentConfig.outputFiles
-            : this.agentConfig.inputFiles,
-        singleInputName:
-          this.agentConfig.inputFiles.length === 1
-            ? this.agentConfig.inputFiles[0]
-            : null,
+        labelFiles: expectedFiles,
+        synthesisName: soleExpectedFile,
       });
       if (documents) {
         logInternal(
@@ -267,20 +270,19 @@ export class XmlOutputManager {
     }
 
     if (!documents) {
-      // Single-input agents whose model regressed to a legacy single-doc shape
-      // (<latex_document>, ```latex fence, or bare \documentclass) can still
-      // be recovered: pass the primary input filename so the fallback can
-      // synthesize a named document. Multi-input agents cannot safely recover
-      // — without per-document names there's no way to route content.
-      const inputFiles = this.agentConfig.inputFiles;
+      // Agents expected to write exactly one file whose model regressed to a
+      // legacy single-doc shape (<latex_document>, ```latex fence, or bare
+      // \documentclass) can still be recovered: pass that filename so the
+      // fallback can synthesize a named document. Agents with several
+      // expected files cannot safely recover — without per-document names
+      // there's no way to route content.
       // Keep the relative path verbatim — getExtractedDocOutputFileName
       // preserves subdirectories so `Draft/Draft1.tex` lands at the right
       // workspace location instead of collapsing to the round root.
-      const preferredName = inputFiles.length === 1 ? inputFiles[0] : undefined;
       documents = this.extractMultipleDocumentsByRegex(
         cdataWrapped,
         documentTag,
-        preferredName,
+        soleExpectedFile ?? undefined,
       );
     }
 

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -31,7 +31,7 @@ import {
 
 import {
   assignByContentSimilarity,
-  collectLatexFencedBlocks,
+  collectLatexFencedBlocks as collectLatexFencedBlocksFromResponse,
 } from './extraction/contentSimilarity';
 import { extractFilenameHeaderDocuments } from './extraction/filenameHeaders';
 
@@ -134,6 +134,44 @@ export class XmlOutputManager {
     });
   }
 
+  private warnMissingExpectedFiles(
+    outputLocation: FileLocation,
+    expectedFiles: readonly string[],
+    documents: ReadonlyArray<{ name: string }>,
+  ): void {
+    const recoveredNames = new Set(
+      documents.map((doc) => this.normalizeExpectedFileName(doc.name)),
+    );
+    const missing = expectedFiles.filter(
+      (name) => !recoveredNames.has(this.normalizeExpectedFileName(name)),
+    );
+    if (missing.length === 0) return;
+
+    logMissingOutputs(this.logger, {
+      missing,
+      xmlFile: outputLocation.absolutePath,
+      documentTag: this.agentSetting.documentTag,
+    });
+  }
+
+  private normalizeExpectedFileName(name: string): string {
+    return name.replaceAll('\\', '/').replace(/^(?:\.\/)+/, '');
+  }
+
+  private collectLatexFencedBlocks(
+    outputContent: string,
+    thinkingTag: string,
+  ): string[] {
+    return collectLatexFencedBlocksFromResponse(outputContent, thinkingTag, {
+      onUnclosedFence: (lineCount) => {
+        debugInternal(
+          this.logger,
+          `Dropped unclosed LaTeX fence with ${formatResultCount(lineCount, 'line')} during fallback extraction`,
+        );
+      },
+    });
+  }
+
   /**
    * Last-resort recovery for multi-input agents that returned fenced
    * ```latex/```tex blocks with no filename header at all (neither the
@@ -148,7 +186,7 @@ export class XmlOutputManager {
     thinkingTag: string,
     baseFiles: readonly FileLocation[],
   ): Promise<Array<{ content: string; name: string }> | null> {
-    const blocks = collectLatexFencedBlocks(outputContent, thinkingTag);
+    const blocks = this.collectLatexFencedBlocks(outputContent, thinkingTag);
     if (blocks.length === 0) return null;
 
     const inputFiles = this.agentConfig.inputFiles;
@@ -265,6 +303,33 @@ export class XmlOutputManager {
         logInternal(
           this.logger,
           `Recovered ${this.agentSetting.documentTag} from filename headers (${formatResultCount(documents.length, 'document')})`,
+        );
+        if (expectedFiles.length > 1) {
+          this.warnMissingExpectedFiles(
+            outputLocation,
+            expectedFiles,
+            documents,
+          );
+        }
+      }
+    }
+
+    if (!documents && soleExpectedFile) {
+      const fencedBlocks = this.collectLatexFencedBlocks(
+        rawOutputContent,
+        thinkingTag,
+      );
+      if (fencedBlocks.length > 1) {
+        documents = [
+          {
+            name: soleExpectedFile,
+            content: fencedBlocks.join('\n\n'),
+          },
+        ];
+        logInternal(
+          this.logger,
+          `Recovered ${this.agentSetting.documentTag} by concatenating ` +
+            `unlabeled fenced blocks under ${soleExpectedFile} (${formatResultCount(fencedBlocks.length, 'block')})`,
         );
       }
     }

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -1,7 +1,5 @@
 import * as path from 'node:path';
 
-import { diff_match_patch } from 'diff-match-patch';
-import escapeRegExp from 'escape-string-regexp';
 import { XMLParser } from 'fast-xml-parser';
 
 import {
@@ -12,15 +10,11 @@ import {
 } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentSetting } from '@agent/core/definition/AgentDataclass';
-import {
-  getExtractedDocOutputFileName,
-  getSafeDocumentRelativePath,
-} from '@agent/utils/outputFileUtils';
+import { getExtractedDocOutputFileName } from '@agent/utils/outputFileUtils';
 import { toErrorMessage } from '@common/errors';
 import replacementEngine, { applyReplacements } from '@replacement/engine';
 import { FENCED_LATEX_BLOCK_REPLACEMENTS } from '@replacement/rulesRegex';
 import type { FileLocation, OutputFileInfo } from '@shared/schemas';
-import { getBasename, normalizeFilePath } from '@shared/utils/path';
 import {
   AbsoluteFS,
   createExternalLocation,
@@ -34,6 +28,12 @@ import {
   extractContentFromXMLbyTagMultiple,
   extractDocuments,
 } from '@utils/text/xmlUtils';
+
+import {
+  assignByContentSimilarity,
+  collectLatexFencedBlocks,
+} from './extraction/contentSimilarity';
+import { extractFilenameHeaderDocuments } from './extraction/filenameHeaders';
 
 /** Delete any pre-staged symlink before writing so the write never follows the link into the immutable snapshot. */
 async function writeRoundOutput(
@@ -68,306 +68,6 @@ const EXTRACTION_METHOD_MESSAGES: Record<string, string> = {
   markdown: 'from markdown code block',
   latex: 'from \\documentclass block',
 };
-
-const PERCENT_FILENAME_HEADER_REGEX =
-  /^%\s+((?:\.[/\\])*[A-Za-z0-9_][A-Za-z0-9._/\\-]*\.[A-Za-z0-9]+)\s*$/;
-/** Strip markdown emphasis/label punctuation a model might wrap a bare filename in. */
-const BARE_LABEL_DECORATION_REGEX = /^[*_`]+|[*_`:]+$/g;
-
-/**
- * Recognize a header line that names one of the agent's known files directly,
- * without the `%` comment prefix (e.g. `Draft/Draft3.tex:` or
- * `**Draft3.tex**`). Unlike the percent-header form, a bare line like this is
- * never valid LaTeX on its own, so the only ambiguity risk is a coincidental
- * match — guarded against by only ever matching against the agent's own
- * known files rather than any path-shaped string.
- */
-function matchKnownFileLabel(
-  line: string,
-  knownFiles: readonly string[],
-): string | null {
-  const stripped = line.trim().replaceAll(BARE_LABEL_DECORATION_REGEX, '');
-  if (!stripped) return null;
-  const candidate = normalizeFilePath(stripped).replace(/^(?:\.\/)+/, '');
-  const exact = knownFiles.find((f) => normalizeFilePath(f) === candidate);
-  if (exact) return exact;
-
-  // Fall back to a basename match when the model dropped the leading
-  // directories, but only when it resolves unambiguously.
-  const basenameMatches = knownFiles.filter(
-    (f) => getBasename(f) === candidate,
-  );
-  return basenameMatches.length === 1 ? basenameMatches[0] : null;
-}
-const LATEX_DOCUMENTCLASS_REGEX = /\\documentclass\b/;
-const LATEX_DOCUMENT_BEGIN_REGEX = /\\begin\s*\{\s*document\s*\}/;
-const LATEX_DOCUMENT_END_REGEX = /\\end\s*\{\s*document\s*\}/;
-const LIKELY_LATEX_CONTENT_REGEX =
-  /^\\(?:chapter|section|subsection|subsubsection|paragraph|begin|end|input|include|documentclass|usepackage|newcommand|renewcommand|[([])/;
-
-type MarkdownFence = {
-  marker: '`' | '~';
-  length: number;
-};
-
-function parseMarkdownFenceDelimiter(line: string): MarkdownFence | null {
-  const match = /^(`{3,}|~{3,})(?:\s*\S.*)?\s*$/.exec(line.trim());
-  if (!match) {
-    return null;
-  }
-  const delimiter = match[1];
-  return {
-    marker: delimiter[0] as '`' | '~',
-    length: delimiter.length,
-  };
-}
-
-function isMarkdownFenceDelimiter(line: string): boolean {
-  return parseMarkdownFenceDelimiter(line) !== null;
-}
-
-function isClosingMarkdownFence(
-  line: string,
-  openingFence: MarkdownFence,
-): boolean {
-  const closingFence = parseMarkdownFenceDelimiter(line);
-  return (
-    closingFence !== null &&
-    closingFence.marker === openingFence.marker &&
-    closingFence.length >= openingFence.length
-  );
-}
-
-function stripSurroundingMarkdownFence(lines: readonly string[]): string[] {
-  const firstContentIndex = lines.findIndex((line) => line.trim() !== '');
-  if (firstContentIndex === -1) {
-    return [];
-  }
-
-  const lastContentIndex = lines.findLastIndex((line) => line.trim() !== '');
-  if (
-    firstContentIndex < lastContentIndex &&
-    isMarkdownFenceDelimiter(lines[firstContentIndex]) &&
-    isMarkdownFenceDelimiter(lines[lastContentIndex])
-  ) {
-    return [
-      ...lines.slice(0, firstContentIndex),
-      ...lines.slice(firstContentIndex + 1, lastContentIndex),
-      ...lines.slice(lastContentIndex + 1),
-    ];
-  }
-
-  return [...lines];
-}
-
-function getLatexDocumentContext(lines: readonly string[]): {
-  insideDocumentBody: boolean;
-  inDocumentPreamble: boolean;
-} {
-  let depth = 0;
-  let sawDocumentclassWithoutBody = false;
-  for (const line of lines) {
-    if (line.trim().startsWith('%')) {
-      continue;
-    }
-    if (LATEX_DOCUMENTCLASS_REGEX.test(line)) {
-      sawDocumentclassWithoutBody = true;
-    }
-    if (LATEX_DOCUMENT_BEGIN_REGEX.test(line)) {
-      depth += 1;
-      sawDocumentclassWithoutBody = false;
-    }
-    if (LATEX_DOCUMENT_END_REGEX.test(line) && depth > 0) {
-      depth -= 1;
-      if (depth === 0) {
-        sawDocumentclassWithoutBody = false;
-      }
-    }
-  }
-  return {
-    insideDocumentBody: depth > 0,
-    inDocumentPreamble: sawDocumentclassWithoutBody,
-  };
-}
-
-function hasDocumentBeginInCurrentPreamble(
-  lines: readonly string[],
-  startIndex: number,
-): boolean {
-  for (const line of lines.slice(startIndex + 1)) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith('%')) {
-      continue;
-    }
-    if (LATEX_DOCUMENTCLASS_REGEX.test(line)) {
-      return false;
-    }
-    if (LATEX_DOCUMENT_BEGIN_REGEX.test(line)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-function shouldKeepPercentHeaderAsLatexComment(
-  linesBeforeHeader: readonly string[],
-  allLines: readonly string[],
-  headerIndex: number,
-): boolean {
-  const context = getLatexDocumentContext(linesBeforeHeader);
-  if (context.insideDocumentBody) {
-    return true;
-  }
-  return (
-    context.inDocumentPreamble &&
-    hasDocumentBeginInCurrentPreamble(allLines, headerIndex)
-  );
-}
-
-function hasLikelyLatexContent(lines: readonly string[]): boolean {
-  return lines.some((line) => LIKELY_LATEX_CONTENT_REGEX.test(line.trim()));
-}
-
-/** Opening delimiter for a fenced block explicitly tagged as latex/tex. */
-const LATEX_FENCE_OPEN_REGEX = /^(`{3,}|~{3,})\s*(?:latex|tex)\s*$/i;
-
-/** Collect the content of every ```latex/```tex fenced block, in document order. */
-function collectLatexFencedBlocks(
-  content: string,
-  thinkingTag: string,
-): string[] {
-  const lines = stripXmlTagBlocks(content, thinkingTag)
-    .replaceAll('\r\n', '\n')
-    .replaceAll('\r', '\n')
-    .split('\n');
-
-  const blocks: string[] = [];
-  let openFence: MarkdownFence | null = null;
-  let current: string[] = [];
-
-  for (const line of lines) {
-    if (!openFence) {
-      if (LATEX_FENCE_OPEN_REGEX.test(line.trim())) {
-        openFence = parseMarkdownFenceDelimiter(line);
-        current = [];
-      }
-      continue;
-    }
-    if (isClosingMarkdownFence(line, openFence)) {
-      const block = current.join('\n').trim();
-      if (block) blocks.push(block);
-      openFence = null;
-      current = [];
-      continue;
-    }
-    current.push(line);
-  }
-  return blocks;
-}
-
-/**
- * Similarity in [0, 1] between two documents via a `diff-match-patch` Myers
- * diff (with the line-mode speedup enabled, which keeps this cheap for
- * large, mostly-unchanged documents): 1 minus the diff's edit distance,
- * normalized by the longer document's length. Clamped at 0 because
- * `diff_levenshtein` counts a substitution as delete-plus-insert, which can
- * exceed the longer length for very different documents.
- */
-function documentSimilarity(
-  dmp: InstanceType<typeof diff_match_patch>,
-  a: string,
-  b: string,
-): number {
-  if (a === b) return 1;
-  const maxLength = Math.max(a.length, b.length, 1);
-  const diffs = dmp.diff_main(a, b, true);
-  return Math.max(0, 1 - dmp.diff_levenshtein(diffs) / maxLength);
-}
-
-/**
- * Greedily pair each candidate document with the base file it most closely
- * resembles, highest-confidence pairs first, so an unambiguous match never
- * gets displaced by a later tie. Never guesses: candidates below
- * `minSimilarity`, candidates whose best remaining files tie exactly (e.g.
- * identical template stubs), and leftovers once the other side is exhausted
- * all come back unmatched.
- */
-function assignByContentSimilarity(
-  candidates: readonly string[],
-  files: ReadonlyArray<{ name: string; content: string }>,
-  minSimilarity = 0.15,
-): Array<{ content: string; name: string } | null> {
-  const dmp = new diff_match_patch();
-  const scores = candidates.map((candidate) =>
-    files.map((file) => documentSimilarity(dmp, candidate, file.content)),
-  );
-  const bestFileOf = scores.map((row) => row.indexOf(Math.max(...row)));
-
-  // A block that echoes a base file verbatim (modulo surrounding whitespace —
-  // fenced blocks arrive trimmed) is a quote of the original, not a revision.
-  // When some other block's best match is that same file (the model quoted
-  // the original before its revision), drop the verbatim pair so the
-  // revision can claim the file.
-  const trimmedFileContents = files.map((file) => file.content.trim());
-  const isDisplacedEcho = (c: number, f: number): boolean =>
-    candidates[c].trim() === trimmedFileContents[f] &&
-    candidates.some(
-      (_, other) =>
-        other !== c &&
-        bestFileOf[other] === f &&
-        scores[other][f] >= minSimilarity,
-    );
-
-  const scored: Array<{ c: number; f: number; score: number }> = [];
-  for (const c of candidates.keys()) {
-    for (const f of files.keys()) {
-      if (isDisplacedEcho(c, f)) continue;
-      scored.push({ c, f, score: scores[c][f] });
-    }
-  }
-  scored.sort((a, b) => b.score - a.score);
-
-  const takenCandidates = new Set<number>();
-  const takenFiles = new Set<number>();
-  const nameByCandidate = new Map<number, string>();
-  for (const { c, f, score } of scored) {
-    if (score < minSimilarity) break;
-    if (takenCandidates.has(c) || takenFiles.has(f)) continue;
-    takenCandidates.add(c);
-    // An exact score tie against another still-free file means there is no
-    // evidence which file this block belongs to — leave it unmatched rather
-    // than routing by declaration order.
-    const ambiguous = scored.some(
-      (other) =>
-        other.c === c &&
-        other.f !== f &&
-        !takenFiles.has(other.f) &&
-        other.score === score,
-    );
-    if (ambiguous) continue;
-    takenFiles.add(f);
-    nameByCandidate.set(c, files[f].name);
-  }
-
-  return candidates.map((content, idx) => {
-    const name = nameByCandidate.get(idx);
-    return name ? { content, name } : null;
-  });
-}
-
-function stripXmlTagBlocks(content: string, tagName: string): string {
-  const trimmedTag = tagName.trim();
-  if (!trimmedTag) {
-    return content;
-  }
-  return content.replaceAll(
-    new RegExp(
-      `<${escapeRegExp(trimmedTag)}\\b[^>]*>[\\s\\S]*?<\\/${escapeRegExp(trimmedTag)}>`,
-      'gi',
-    ),
-    '',
-  );
-}
 
 export class XmlOutputManager {
   constructor(
@@ -434,188 +134,10 @@ export class XmlOutputManager {
     });
   }
 
-  private makeUniquePercentHeaderName(
-    source: string,
-    reservedFinalPaths: Set<string>,
-    roundDir: string,
-  ): string {
-    const normalized = source.replaceAll('\\', '/');
-    const safeName = getSafeDocumentRelativePath(normalized).replaceAll(
-      '\\',
-      '/',
-    );
-    let candidate = safeName;
-    let suffix = 2;
-
-    const finalPathKey = (name: string) =>
-      getExtractedDocOutputFileName(name, roundDir).replaceAll('\\', '/');
-
-    while (reservedFinalPaths.has(finalPathKey(candidate))) {
-      const parsed = path.posix.parse(safeName);
-      candidate = path.posix.join(
-        parsed.dir,
-        `${parsed.name}-${suffix}${parsed.ext}`,
-      );
-      suffix += 1;
-    }
-
-    reservedFinalPaths.add(finalPathKey(candidate));
-    return candidate;
-  }
-
-  private extractPercentHeaderDocuments(
-    outputContent: string,
-    roundDir: string,
-    thinkingTag: string,
-  ): Array<{ content: string; name: string }> | null {
-    const documents: Array<{ content: string; name: string }> = [];
-    const reservedFinalPaths = new Set<string>();
-    let currentName: string | null = null;
-    let currentLines: string[] = [];
-    let preHeaderLines: string[] = [];
-    let pendingPrefacedMarkdownFence: MarkdownFence | null = null;
-    let currentMarkdownFence: MarkdownFence | null = null;
-    let ignoreProseUntilNextHeader = false;
-    let synthesizedSingleInputFromPrefix = false;
-
-    // Bare labels may only name files this agent is expected to write: the
-    // declared outputFiles when present (single-artifact agents like ocr /
-    // paper2slide, whose inputs can be media files a response might mention
-    // in prose), otherwise the inputs (workflow edit agents reuse the input
-    // names as output names).
-    const labelFiles =
-      this.agentConfig.outputFiles.length > 0
-        ? this.agentConfig.outputFiles
-        : this.agentConfig.inputFiles;
-
-    const flushCurrent = (): MarkdownFence | null => {
-      if (!currentName) return null;
-      const content = stripSurroundingMarkdownFence(currentLines)
-        .join('\n')
-        .trim();
-      const carriedFence = content ? null : currentMarkdownFence;
-      if (content) {
-        documents.push({
-          name: this.makeUniquePercentHeaderName(
-            currentName,
-            reservedFinalPaths,
-            roundDir,
-          ),
-          content,
-        });
-      }
-      currentLines = [];
-      currentMarkdownFence = null;
-      return carriedFence;
-    };
-
-    const lines = stripSurroundingMarkdownFence(
-      stripXmlTagBlocks(outputContent, thinkingTag)
-        .replaceAll('\r\n', '\n')
-        .replaceAll('\r', '\n')
-        .split('\n'),
-    );
-    for (const [index, line] of lines.entries()) {
-      const fence = parseMarkdownFenceDelimiter(line);
-
-      if (!currentName && fence) {
-        if (
-          pendingPrefacedMarkdownFence &&
-          isClosingMarkdownFence(line, pendingPrefacedMarkdownFence)
-        ) {
-          pendingPrefacedMarkdownFence = null;
-        } else {
-          pendingPrefacedMarkdownFence = fence;
-        }
-        ignoreProseUntilNextHeader = false;
-        continue;
-      }
-
-      if (
-        currentName &&
-        currentMarkdownFence &&
-        isClosingMarkdownFence(line, currentMarkdownFence) &&
-        !getLatexDocumentContext(currentLines).insideDocumentBody
-      ) {
-        flushCurrent();
-        currentName = null;
-        preHeaderLines = [];
-        pendingPrefacedMarkdownFence = null;
-        ignoreProseUntilNextHeader = true;
-        synthesizedSingleInputFromPrefix = false;
-        continue;
-      }
-
-      const percentHeaderName =
-        PERCENT_FILENAME_HEADER_REGEX.exec(line.trim())?.[1] ?? null;
-      const headerName =
-        percentHeaderName ?? matchKnownFileLabel(line, labelFiles);
-      if (headerName && synthesizedSingleInputFromPrefix) {
-        // A `%` header is a valid LaTeX comment and can stay in the
-        // synthesized document's body; a bare label is not LaTeX, so drop it.
-        if (percentHeaderName) {
-          currentLines.push(line);
-        }
-        continue;
-      }
-
-      const linesBeforeHeader = currentName ? currentLines : preHeaderLines;
-      if (
-        headerName &&
-        !shouldKeepPercentHeaderAsLatexComment(linesBeforeHeader, lines, index)
-      ) {
-        if (!currentName && hasLikelyLatexContent(preHeaderLines)) {
-          if (this.agentConfig.inputFiles.length === 1) {
-            currentName = this.agentConfig.inputFiles[0];
-            currentLines = [...preHeaderLines, line];
-            currentMarkdownFence = pendingPrefacedMarkdownFence;
-            pendingPrefacedMarkdownFence = null;
-            preHeaderLines = [];
-            ignoreProseUntilNextHeader = false;
-            synthesizedSingleInputFromPrefix = true;
-            continue;
-          }
-          preHeaderLines = [];
-        }
-        const carriedFence = flushCurrent();
-        currentName = headerName;
-        currentMarkdownFence = pendingPrefacedMarkdownFence ?? carriedFence;
-        pendingPrefacedMarkdownFence = null;
-        preHeaderLines = [];
-        ignoreProseUntilNextHeader = false;
-        synthesizedSingleInputFromPrefix = false;
-        continue;
-      }
-
-      if (currentName) {
-        if (
-          fence &&
-          !currentMarkdownFence &&
-          !currentLines.some((currentLine) => currentLine.trim() !== '')
-        ) {
-          currentMarkdownFence = fence;
-          continue;
-        }
-        currentLines.push(line);
-      } else if (!ignoreProseUntilNextHeader) {
-        preHeaderLines.push(line);
-      }
-    }
-    flushCurrent();
-
-    if (documents.length === 0) return null;
-
-    logInternal(
-      this.logger,
-      `Recovered ${this.agentSetting.documentTag} from filename headers (${formatResultCount(documents.length, 'document')})`,
-    );
-    return documents;
-  }
-
   /**
    * Last-resort recovery for multi-input agents that returned fenced
    * ```latex/```tex blocks with no filename header at all (neither the
-   * `%`-comment nor bare-label forms `extractPercentHeaderDocuments`
+   * `%`-comment nor bare-label forms `extractFilenameHeaderDocuments`
    * recognizes). Matches each fenced block against the agent's original
    * input files by content similarity rather than guessing from response
    * order, since a model can reorder or drop files in its response.
@@ -715,11 +237,29 @@ export class XmlOutputManager {
     }
 
     if (!documents) {
-      documents = this.extractPercentHeaderDocuments(
-        rawOutputContent,
-        getFileDirectory(outputLocation),
+      documents = extractFilenameHeaderDocuments(rawOutputContent, {
         thinkingTag,
-      );
+        roundDir: getFileDirectory(outputLocation),
+        // Bare labels may only name files this agent is expected to write:
+        // the declared outputFiles when present (single-artifact agents like
+        // ocr / paper2slide, whose inputs can be media files a response might
+        // mention in prose), otherwise the inputs (workflow edit agents reuse
+        // the input names as output names).
+        labelFiles:
+          this.agentConfig.outputFiles.length > 0
+            ? this.agentConfig.outputFiles
+            : this.agentConfig.inputFiles,
+        singleInputName:
+          this.agentConfig.inputFiles.length === 1
+            ? this.agentConfig.inputFiles[0]
+            : null,
+      });
+      if (documents) {
+        logInternal(
+          this.logger,
+          `Recovered ${this.agentSetting.documentTag} from filename headers (${formatResultCount(documents.length, 'document')})`,
+        );
+      }
     }
 
     if (!documents) {

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -172,33 +172,6 @@ export class XmlOutputManager {
     });
   }
 
-  private coalesceSoleOutputFencedBlocks(
-    documents: Array<{ content: string; name: string }>,
-    outputContent: string,
-    thinkingTag: string,
-    soleExpectedFile: string,
-  ): void {
-    const target = documents.find(
-      (document) =>
-        this.normalizeExpectedFileName(document.name) ===
-        this.normalizeExpectedFileName(soleExpectedFile),
-    );
-    if (!target) return;
-
-    const existingContent = target.content.trim();
-    const additionalBlocks = this.collectLatexFencedBlocks(
-      outputContent,
-      thinkingTag,
-    ).filter((block) => !existingContent.includes(block.trim()));
-    if (additionalBlocks.length === 0) return;
-
-    target.content = [target.content.trim(), ...additionalBlocks].join('\n\n');
-    logInternal(
-      this.logger,
-      `Coalesced ${formatResultCount(additionalBlocks.length, 'additional fenced block')} into ${soleExpectedFile}`,
-    );
-  }
-
   /**
    * Last-resort recovery for multi-input agents that returned fenced
    * ```latex/```tex blocks with no filename header at all (neither the
@@ -329,14 +302,6 @@ export class XmlOutputManager {
           this.agentConfig.outputFiles.length === 1 ? soleExpectedFile : null,
       });
       if (documents) {
-        if (this.agentConfig.outputFiles.length === 1 && soleExpectedFile) {
-          this.coalesceSoleOutputFencedBlocks(
-            documents,
-            rawOutputContent,
-            thinkingTag,
-            soleExpectedFile,
-          );
-        }
         logInternal(
           this.logger,
           `Recovered ${this.agentSetting.documentTag} from filename headers (${formatResultCount(documents.length, 'document')})`,

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -84,7 +84,7 @@ export class XmlOutputManager {
     return applyReplacements(normalized, FENCED_LATEX_BLOCK_REPLACEMENTS);
   }
 
-  private extractMultipleDocumentsbyRegex(
+  private extractMultipleDocumentsByRegex(
     outputContent: string,
     documentTag: string,
     preferredName?: string,
@@ -204,17 +204,21 @@ export class XmlOutputManager {
     baseFiles: readonly FileLocation[] = [],
   ): Promise<OutputFileInfo[]> {
     const rawOutputContent = await AbsoluteFS.read(outputLocation.absolutePath);
-    let outputContent = rawOutputContent;
-    const expectedDocumentCount = this.countDocumentTags(outputContent);
+    const expectedDocumentCount = this.countDocumentTags(rawOutputContent);
 
-    const tagsToWrap = [thinkingTag, 'document'];
-    outputContent = addCdataToTagsMultiple(outputContent, tagsToWrap);
+    // The XML-parse and regex tiers read the CDATA-wrapped variant (so the
+    // parser treats thinking/document bodies as opaque text); the header and
+    // similarity tiers below read the raw response instead.
+    const cdataWrapped = addCdataToTagsMultiple(rawOutputContent, [
+      thinkingTag,
+      'document',
+    ]);
 
     let documents: Array<{ content: string; name: string }> | null = null;
 
     try {
       const parser = new XMLParser(XML_PARSER_OPTIONS);
-      const root = parser.parse(outputContent);
+      const root = parser.parse(cdataWrapped);
       documents = extractContentFromXMLbyTagMultiple(root, documentTag);
       if (!documents) {
         debugInternal(
@@ -230,8 +234,8 @@ export class XmlOutputManager {
     }
 
     if (!documents) {
-      documents = this.extractMultipleDocumentsbyRegex(
-        outputContent,
+      documents = this.extractMultipleDocumentsByRegex(
+        cdataWrapped,
         documentTag,
       );
     }
@@ -273,8 +277,8 @@ export class XmlOutputManager {
       // preserves subdirectories so `Draft/Draft1.tex` lands at the right
       // workspace location instead of collapsing to the round root.
       const preferredName = inputFiles.length === 1 ? inputFiles[0] : undefined;
-      documents = this.extractMultipleDocumentsbyRegex(
-        outputContent,
+      documents = this.extractMultipleDocumentsByRegex(
+        cdataWrapped,
         documentTag,
         preferredName,
       );

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -75,27 +75,26 @@ const PERCENT_FILENAME_HEADER_REGEX =
 const BARE_LABEL_DECORATION_REGEX = /^[*_`]+|[*_`:]+$/g;
 
 /**
- * Recognize a header line that names one of the agent's known input files
- * directly, without the `%` comment prefix (e.g. `Draft/Draft3.tex:` or
+ * Recognize a header line that names one of the agent's known files directly,
+ * without the `%` comment prefix (e.g. `Draft/Draft3.tex:` or
  * `**Draft3.tex**`). Unlike the percent-header form, a bare line like this is
  * never valid LaTeX on its own, so the only ambiguity risk is a coincidental
  * match — guarded against by only ever matching against the agent's own
- * declared input files rather than any path-shaped string.
+ * known files rather than any path-shaped string.
  */
-function matchKnownInputFileLabel(
+function matchKnownFileLabel(
   line: string,
-  inputFiles: readonly string[],
+  knownFiles: readonly string[],
 ): string | null {
-  const candidate = line.trim().replaceAll(BARE_LABEL_DECORATION_REGEX, '');
-  if (!candidate) return null;
-  const exact = inputFiles.find(
-    (f) => normalizeFilePath(f) === normalizeFilePath(candidate),
-  );
+  const stripped = line.trim().replaceAll(BARE_LABEL_DECORATION_REGEX, '');
+  if (!stripped) return null;
+  const candidate = normalizeFilePath(stripped).replace(/^(?:\.\/)+/, '');
+  const exact = knownFiles.find((f) => normalizeFilePath(f) === candidate);
   if (exact) return exact;
 
   // Fall back to a basename match when the model dropped the leading
   // directories, but only when it resolves unambiguously.
-  const basenameMatches = inputFiles.filter(
+  const basenameMatches = knownFiles.filter(
     (f) => getBasename(f) === candidate,
   );
   return basenameMatches.length === 1 ? basenameMatches[0] : null;
@@ -267,10 +266,12 @@ function collectLatexFencedBlocks(
 }
 
 /**
- * Similarity in [0, 1] between two documents via a line-mode Myers diff
- * (`diff-match-patch`, already a project dependency): 1 minus the edit
- * distance implied by the diff, normalized by the longer document's length.
- * Line mode keeps this cheap even for large, mostly-unchanged documents.
+ * Similarity in [0, 1] between two documents via a `diff-match-patch` Myers
+ * diff (with the line-mode speedup enabled, which keeps this cheap for
+ * large, mostly-unchanged documents): 1 minus the diff's edit distance,
+ * normalized by the longer document's length. Clamped at 0 because
+ * `diff_levenshtein` counts a substitution as delete-plus-insert, which can
+ * exceed the longer length for very different documents.
  */
 function documentSimilarity(
   dmp: InstanceType<typeof diff_match_patch>,
@@ -280,15 +281,16 @@ function documentSimilarity(
   if (a === b) return 1;
   const maxLength = Math.max(a.length, b.length, 1);
   const diffs = dmp.diff_main(a, b, true);
-  return 1 - dmp.diff_levenshtein(diffs) / maxLength;
+  return Math.max(0, 1 - dmp.diff_levenshtein(diffs) / maxLength);
 }
 
 /**
  * Greedily pair each candidate document with the base file it most closely
  * resembles, highest-confidence pairs first, so an unambiguous match never
- * gets displaced by a later tie. Candidates/files below `minSimilarity`, or
- * left over once the other side is exhausted, come back unmatched rather
- * than being guessed.
+ * gets displaced by a later tie. Never guesses: candidates below
+ * `minSimilarity`, candidates whose best remaining files tie exactly (e.g.
+ * identical template stubs), and leftovers once the other side is exhausted
+ * all come back unmatched.
  */
 function assignByContentSimilarity(
   candidates: readonly string[],
@@ -296,14 +298,31 @@ function assignByContentSimilarity(
   minSimilarity = 0.15,
 ): Array<{ content: string; name: string } | null> {
   const dmp = new diff_match_patch();
+  const scores = candidates.map((candidate) =>
+    files.map((file) => documentSimilarity(dmp, candidate, file.content)),
+  );
+  const bestFileOf = scores.map((row) => row.indexOf(Math.max(...row)));
+
+  // A block that echoes a base file verbatim (modulo surrounding whitespace —
+  // fenced blocks arrive trimmed) is a quote of the original, not a revision.
+  // When some other block's best match is that same file (the model quoted
+  // the original before its revision), drop the verbatim pair so the
+  // revision can claim the file.
+  const trimmedFileContents = files.map((file) => file.content.trim());
+  const isDisplacedEcho = (c: number, f: number): boolean =>
+    candidates[c].trim() === trimmedFileContents[f] &&
+    candidates.some(
+      (_, other) =>
+        other !== c &&
+        bestFileOf[other] === f &&
+        scores[other][f] >= minSimilarity,
+    );
+
   const scored: Array<{ c: number; f: number; score: number }> = [];
-  for (const [c, candidate] of candidates.entries()) {
-    for (const [f, file] of files.entries()) {
-      scored.push({
-        c,
-        f,
-        score: documentSimilarity(dmp, candidate, file.content),
-      });
+  for (const c of candidates.keys()) {
+    for (const f of files.keys()) {
+      if (isDisplacedEcho(c, f)) continue;
+      scored.push({ c, f, score: scores[c][f] });
     }
   }
   scored.sort((a, b) => b.score - a.score);
@@ -315,6 +334,17 @@ function assignByContentSimilarity(
     if (score < minSimilarity) break;
     if (takenCandidates.has(c) || takenFiles.has(f)) continue;
     takenCandidates.add(c);
+    // An exact score tie against another still-free file means there is no
+    // evidence which file this block belongs to — leave it unmatched rather
+    // than routing by declaration order.
+    const ambiguous = scored.some(
+      (other) =>
+        other.c === c &&
+        other.f !== f &&
+        !takenFiles.has(other.f) &&
+        other.score === score,
+    );
+    if (ambiguous) continue;
     takenFiles.add(f);
     nameByCandidate.set(c, files[f].name);
   }
@@ -448,6 +478,16 @@ export class XmlOutputManager {
     let ignoreProseUntilNextHeader = false;
     let synthesizedSingleInputFromPrefix = false;
 
+    // Bare labels may only name files this agent is expected to write: the
+    // declared outputFiles when present (single-artifact agents like ocr /
+    // paper2slide, whose inputs can be media files a response might mention
+    // in prose), otherwise the inputs (workflow edit agents reuse the input
+    // names as output names).
+    const labelFiles =
+      this.agentConfig.outputFiles.length > 0
+        ? this.agentConfig.outputFiles
+        : this.agentConfig.inputFiles;
+
     const flushCurrent = (): MarkdownFence | null => {
       if (!currentName) return null;
       const content = stripSurroundingMarkdownFence(currentLines)
@@ -506,11 +546,16 @@ export class XmlOutputManager {
         continue;
       }
 
+      const percentHeaderName =
+        PERCENT_FILENAME_HEADER_REGEX.exec(line.trim())?.[1] ?? null;
       const headerName =
-        PERCENT_FILENAME_HEADER_REGEX.exec(line.trim())?.[1] ??
-        matchKnownInputFileLabel(line, this.agentConfig.inputFiles);
+        percentHeaderName ?? matchKnownFileLabel(line, labelFiles);
       if (headerName && synthesizedSingleInputFromPrefix) {
-        currentLines.push(line);
+        // A `%` header is a valid LaTeX comment and can stay in the
+        // synthesized document's body; a bare label is not LaTeX, so drop it.
+        if (percentHeaderName) {
+          currentLines.push(line);
+        }
         continue;
       }
 
@@ -577,6 +622,7 @@ export class XmlOutputManager {
    */
   private async extractDocumentsByContentSimilarity(
     outputContent: string,
+    outputLocation: FileLocation,
     thinkingTag: string,
     baseFiles: readonly FileLocation[],
   ): Promise<Array<{ content: string; name: string }> | null> {
@@ -605,6 +651,26 @@ export class XmlOutputManager {
       `Recovered ${this.agentSetting.documentTag} by matching unlabeled fenced ` +
         `blocks against the original input files (${formatResultCount(documents.length, 'document')})`,
     );
+
+    // Recovery is best-effort per block: surface what stayed unmatched so a
+    // partially recovered round never silently reads as a complete one.
+    const matchedNames = new Set(documents.map((doc) => doc.name));
+    const unmatchedFiles = files
+      .map((file) => file.name)
+      .filter((name) => !matchedNames.has(name));
+    if (unmatchedFiles.length > 0) {
+      logMissingOutputs(this.logger, {
+        missing: unmatchedFiles,
+        xmlFile: outputLocation.absolutePath,
+        documentTag: this.agentSetting.documentTag,
+      });
+    }
+    if (documents.length < blocks.length) {
+      debugInternal(
+        this.logger,
+        `${blocks.length - documents.length} of ${formatResultCount(blocks.length, 'fenced block')} matched no input file and were dropped`,
+      );
+    }
     return documents;
   }
 
@@ -689,6 +755,7 @@ export class XmlOutputManager {
       // label a matched block with the wrong input filename.
       documents = await this.extractDocumentsByContentSimilarity(
         rawOutputContent,
+        outputLocation,
         thinkingTag,
         baseFiles,
       );

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -300,6 +300,7 @@ export class XmlOutputManager {
         synthesisName: soleExpectedFile,
         coalesceRepeatedName:
           this.agentConfig.outputFiles.length === 1 ? soleExpectedFile : null,
+        wrapperTag: documentTag,
       });
       if (documents) {
         logInternal(
@@ -321,6 +322,9 @@ export class XmlOutputManager {
       this.agentConfig.outputFiles.length === 1 &&
       soleExpectedFile
     ) {
+      // This fully unlabeled tier is intentionally stricter than
+      // filename-header recovery: without a trusted file label, only fences
+      // explicitly marked latex/tex are treated as output.
       const fencedBlocks = this.collectLatexFencedBlocks(
         rawOutputContent,
         thinkingTag,

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -269,20 +269,21 @@ export class XmlOutputManager {
       }
     }
 
-    if (!documents) {
+    if (!documents && soleExpectedFile) {
       // Agents expected to write exactly one file whose model regressed to a
       // legacy single-doc shape (<latex_document>, ```latex fence, or bare
       // \documentclass) can still be recovered: pass that filename so the
       // fallback can synthesize a named document. Agents with several
       // expected files cannot safely recover — without per-document names
-      // there's no way to route content.
+      // there's no way to route content (and without a preferredName this
+      // call would just repeat the earlier one).
       // Keep the relative path verbatim — getExtractedDocOutputFileName
       // preserves subdirectories so `Draft/Draft1.tex` lands at the right
       // workspace location instead of collapsing to the round root.
       documents = this.extractMultipleDocumentsByRegex(
         cdataWrapped,
         documentTag,
-        soleExpectedFile ?? undefined,
+        soleExpectedFile,
       );
     }
 

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 
+import { diff_match_patch } from 'diff-match-patch';
 import escapeRegExp from 'escape-string-regexp';
 import { XMLParser } from 'fast-xml-parser';
 
@@ -69,6 +70,34 @@ const EXTRACTION_METHOD_MESSAGES: Record<string, string> = {
 
 const PERCENT_FILENAME_HEADER_REGEX =
   /^%\s+((?:\.[/\\])*[A-Za-z0-9_][A-Za-z0-9._/\\-]*\.[A-Za-z0-9]+)\s*$/;
+/** Strip markdown emphasis/label punctuation a model might wrap a bare filename in. */
+const BARE_LABEL_DECORATION_REGEX = /^[*_`]+|[*_`:]+$/g;
+
+/**
+ * Recognize a header line that names one of the agent's known input files
+ * directly, without the `%` comment prefix (e.g. `Draft/Draft3.tex:` or
+ * `**Draft3.tex**`). Unlike the percent-header form, a bare line like this is
+ * never valid LaTeX on its own, so the only ambiguity risk is a coincidental
+ * match — guarded against by only ever matching against the agent's own
+ * declared input files rather than any path-shaped string.
+ */
+function matchKnownInputFileLabel(
+  line: string,
+  inputFiles: readonly string[],
+): string | null {
+  const candidate = line.trim().replaceAll(BARE_LABEL_DECORATION_REGEX, '');
+  if (!candidate) return null;
+  const normalize = (p: string) => p.replaceAll('\\', '/');
+  const exact = inputFiles.find((f) => normalize(f) === normalize(candidate));
+  if (exact) return exact;
+
+  // Fall back to a basename match when the model dropped the leading
+  // directories, but only when it resolves unambiguously.
+  const basenameMatches = inputFiles.filter(
+    (f) => path.posix.basename(normalize(f)) === candidate,
+  );
+  return basenameMatches.length === 1 ? basenameMatches[0] : null;
+}
 const LATEX_DOCUMENTCLASS_REGEX = /\\documentclass\b/;
 const LATEX_DOCUMENT_BEGIN_REGEX = /\\begin\s*\{\s*document\s*\}/;
 const LATEX_DOCUMENT_END_REGEX = /\\end\s*\{\s*document\s*\}/;
@@ -196,6 +225,102 @@ function shouldKeepPercentHeaderAsLatexComment(
 
 function hasLikelyLatexContent(lines: readonly string[]): boolean {
   return lines.some((line) => LIKELY_LATEX_CONTENT_REGEX.test(line.trim()));
+}
+
+/** Opening delimiter for a fenced block explicitly tagged as latex/tex. */
+const LATEX_FENCE_OPEN_REGEX = /^(`{3,}|~{3,})\s*(?:latex|tex)\s*$/i;
+
+/** Collect the content of every ```latex/```tex fenced block, in document order. */
+function collectLatexFencedBlocks(
+  content: string,
+  thinkingTag: string,
+): string[] {
+  const lines = stripXmlTagBlocks(content, thinkingTag)
+    .replaceAll('\r\n', '\n')
+    .replaceAll('\r', '\n')
+    .split('\n');
+
+  const blocks: string[] = [];
+  let openFence: MarkdownFence | null = null;
+  let current: string[] = [];
+
+  for (const line of lines) {
+    if (!openFence) {
+      if (LATEX_FENCE_OPEN_REGEX.test(line.trim())) {
+        openFence = parseMarkdownFenceDelimiter(line);
+        current = [];
+      }
+      continue;
+    }
+    if (isClosingMarkdownFence(line, openFence)) {
+      const block = current.join('\n').trim();
+      if (block) blocks.push(block);
+      openFence = null;
+      current = [];
+      continue;
+    }
+    current.push(line);
+  }
+  return blocks;
+}
+
+/**
+ * Similarity in [0, 1] between two documents via a line-mode Myers diff
+ * (`diff-match-patch`, already a project dependency): 1 minus the edit
+ * distance implied by the diff, normalized by the longer document's length.
+ * Line mode keeps this cheap even for large, mostly-unchanged documents.
+ */
+function documentSimilarity(
+  dmp: InstanceType<typeof diff_match_patch>,
+  a: string,
+  b: string,
+): number {
+  if (a === b) return 1;
+  const maxLength = Math.max(a.length, b.length, 1);
+  const diffs = dmp.diff_main(a, b, true);
+  return 1 - dmp.diff_levenshtein(diffs) / maxLength;
+}
+
+/**
+ * Greedily pair each candidate document with the base file it most closely
+ * resembles, highest-confidence pairs first, so an unambiguous match never
+ * gets displaced by a later tie. Candidates/files below `minSimilarity`, or
+ * left over once the other side is exhausted, come back unmatched rather
+ * than being guessed.
+ */
+function assignByContentSimilarity(
+  candidates: readonly string[],
+  files: ReadonlyArray<{ name: string; content: string }>,
+  minSimilarity = 0.15,
+): Array<{ content: string; name: string } | null> {
+  const dmp = new diff_match_patch();
+  const scored: Array<{ c: number; f: number; score: number }> = [];
+  for (const [c, candidate] of candidates.entries()) {
+    for (const [f, file] of files.entries()) {
+      scored.push({
+        c,
+        f,
+        score: documentSimilarity(dmp, candidate, file.content),
+      });
+    }
+  }
+  scored.sort((a, b) => b.score - a.score);
+
+  const takenCandidates = new Set<number>();
+  const takenFiles = new Set<number>();
+  const nameByCandidate = new Map<number, string>();
+  for (const { c, f, score } of scored) {
+    if (score < minSimilarity) break;
+    if (takenCandidates.has(c) || takenFiles.has(f)) continue;
+    takenCandidates.add(c);
+    takenFiles.add(f);
+    nameByCandidate.set(c, files[f].name);
+  }
+
+  return candidates.map((content, idx) => {
+    const name = nameByCandidate.get(idx);
+    return name ? { content, name } : null;
+  });
 }
 
 function stripXmlTagBlocks(content: string, tagName: string): string {
@@ -379,15 +504,17 @@ export class XmlOutputManager {
         continue;
       }
 
-      const match = PERCENT_FILENAME_HEADER_REGEX.exec(line.trim());
-      if (match && synthesizedSingleInputFromPrefix) {
+      const headerName =
+        PERCENT_FILENAME_HEADER_REGEX.exec(line.trim())?.[1] ??
+        matchKnownInputFileLabel(line, this.agentConfig.inputFiles);
+      if (headerName && synthesizedSingleInputFromPrefix) {
         currentLines.push(line);
         continue;
       }
 
       const linesBeforeHeader = currentName ? currentLines : preHeaderLines;
       if (
-        match &&
+        headerName &&
         !shouldKeepPercentHeaderAsLatexComment(linesBeforeHeader, lines, index)
       ) {
         if (!currentName && hasLikelyLatexContent(preHeaderLines)) {
@@ -404,7 +531,7 @@ export class XmlOutputManager {
           preHeaderLines = [];
         }
         const carriedFence = flushCurrent();
-        currentName = match[1];
+        currentName = headerName;
         currentMarkdownFence = pendingPrefacedMarkdownFence ?? carriedFence;
         pendingPrefacedMarkdownFence = null;
         preHeaderLines = [];
@@ -433,7 +560,45 @@ export class XmlOutputManager {
 
     logInternal(
       this.logger,
-      `Recovered ${this.agentSetting.documentTag} from % filename headers (${formatResultCount(documents.length, 'document')})`,
+      `Recovered ${this.agentSetting.documentTag} from filename headers (${formatResultCount(documents.length, 'document')})`,
+    );
+    return documents;
+  }
+
+  /**
+   * Last-resort recovery for multi-input agents that returned fenced
+   * ```latex/```tex blocks with no filename header at all (neither the
+   * `%`-comment nor bare-label forms `extractPercentHeaderDocuments`
+   * recognizes). Matches each fenced block against the agent's original
+   * input files by content similarity rather than guessing from response
+   * order, since a model can reorder or drop files in its response.
+   */
+  private async extractDocumentsByContentSimilarity(
+    outputContent: string,
+    thinkingTag: string,
+    baseFiles: readonly FileLocation[],
+  ): Promise<Array<{ content: string; name: string }> | null> {
+    const blocks = collectLatexFencedBlocks(outputContent, thinkingTag);
+    if (blocks.length === 0) return null;
+
+    const inputFiles = this.agentConfig.inputFiles;
+    const files = await Promise.all(
+      baseFiles.slice(0, inputFiles.length).map(async (loc, idx) => ({
+        name: inputFiles[idx],
+        content: await AbsoluteFS.read(loc.absolutePath).catch(() => ''),
+      })),
+    );
+    if (files.length === 0) return null;
+
+    const documents = assignByContentSimilarity(blocks, files).filter(
+      (d): d is { content: string; name: string } => d !== null,
+    );
+    if (documents.length === 0) return null;
+
+    logInternal(
+      this.logger,
+      `Recovered ${this.agentSetting.documentTag} by matching unlabeled fenced ` +
+        `blocks against the original input files (${formatResultCount(documents.length, 'document')})`,
     );
     return documents;
   }
@@ -443,6 +608,7 @@ export class XmlOutputManager {
     documentTag: string,
     round: number,
     thinkingTag: string = 'scratchpad',
+    baseFiles: readonly FileLocation[] = [],
   ): Promise<OutputFileInfo[]> {
     const rawOutputContent = await AbsoluteFS.read(outputLocation.absolutePath);
     let outputContent = rawOutputContent;
@@ -500,6 +666,17 @@ export class XmlOutputManager {
         outputContent,
         documentTag,
         preferredName,
+      );
+    }
+
+    if (!documents && this.agentConfig.inputFiles.length > 1) {
+      // Multi-input agents have no name to synthesize a single-document
+      // recovery from, but an unlabeled fenced block can still be routed by
+      // comparing it against each original input file's content.
+      documents = await this.extractDocumentsByContentSimilarity(
+        rawOutputContent,
+        thinkingTag,
+        baseFiles,
       );
     }
 

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -172,6 +172,33 @@ export class XmlOutputManager {
     });
   }
 
+  private coalesceSoleOutputFencedBlocks(
+    documents: Array<{ content: string; name: string }>,
+    outputContent: string,
+    thinkingTag: string,
+    soleExpectedFile: string,
+  ): void {
+    const target = documents.find(
+      (document) =>
+        this.normalizeExpectedFileName(document.name) ===
+        this.normalizeExpectedFileName(soleExpectedFile),
+    );
+    if (!target) return;
+
+    const existingContent = target.content.trim();
+    const additionalBlocks = this.collectLatexFencedBlocks(
+      outputContent,
+      thinkingTag,
+    ).filter((block) => !existingContent.includes(block.trim()));
+    if (additionalBlocks.length === 0) return;
+
+    target.content = [target.content.trim(), ...additionalBlocks].join('\n\n');
+    logInternal(
+      this.logger,
+      `Coalesced ${formatResultCount(additionalBlocks.length, 'additional fenced block')} into ${soleExpectedFile}`,
+    );
+  }
+
   /**
    * Last-resort recovery for multi-input agents that returned fenced
    * ```latex/```tex blocks with no filename header at all (neither the
@@ -302,6 +329,14 @@ export class XmlOutputManager {
           this.agentConfig.outputFiles.length === 1 ? soleExpectedFile : null,
       });
       if (documents) {
+        if (this.agentConfig.outputFiles.length === 1 && soleExpectedFile) {
+          this.coalesceSoleOutputFencedBlocks(
+            documents,
+            rawOutputContent,
+            thinkingTag,
+            soleExpectedFile,
+          );
+        }
         logInternal(
           this.logger,
           `Recovered ${this.agentSetting.documentTag} from filename headers (${formatResultCount(documents.length, 'document')})`,

--- a/src/agent/output/extraction/contentSimilarity.ts
+++ b/src/agent/output/extraction/contentSimilarity.ts
@@ -22,6 +22,9 @@ const LATEX_FENCE_OPEN_REGEX = /^(`{3,}|~{3,})\s*(?:latex|tex)\s*$/i;
 export function collectLatexFencedBlocks(
   content: string,
   thinkingTag: string,
+  options: {
+    onUnclosedFence?: (lineCount: number) => void;
+  } = {},
 ): string[] {
   const lines = responseLines(content, thinkingTag);
 
@@ -45,6 +48,9 @@ export function collectLatexFencedBlocks(
       continue;
     }
     current.push(line);
+  }
+  if (openFence && current.some((line) => line.trim() !== '')) {
+    options.onUnclosedFence?.(current.length);
   }
   return blocks;
 }

--- a/src/agent/output/extraction/contentSimilarity.ts
+++ b/src/agent/output/extraction/contentSimilarity.ts
@@ -88,10 +88,11 @@ export function assignByContentSimilarity(
   const bestFileOf = scores.map((row) => row.indexOf(Math.max(...row)));
 
   // A block that echoes a base file verbatim (modulo surrounding whitespace —
-  // fenced blocks arrive trimmed) is a quote of the original, not a revision.
-  // When some other block's best match is that same file (the model quoted
-  // the original before its revision), drop the verbatim pair so the
-  // revision can claim the file.
+  // fenced blocks arrive trimmed) while some other block's best match is that
+  // same file is a quote of the original, not a revision (the model quoted
+  // the original before its revision). Such a block is excluded from
+  // assignment entirely: letting it fall back to a different, merely-similar
+  // file would write one file's stale content over another.
   const trimmedFileContents = files.map((file) => file.content.trim());
   const isDisplacedEcho = (c: number, f: number): boolean =>
     candidates[c].trim() === trimmedFileContents[f] &&
@@ -101,11 +102,16 @@ export function assignByContentSimilarity(
         bestFileOf[other] === f &&
         scores[other][f] >= minSimilarity,
     );
+  const quotedOriginals = new Set(
+    [...candidates.keys()].filter((c) =>
+      [...files.keys()].some((f) => isDisplacedEcho(c, f)),
+    ),
+  );
 
   const scored: Array<{ c: number; f: number; score: number }> = [];
   for (const c of candidates.keys()) {
+    if (quotedOriginals.has(c)) continue;
     for (const f of files.keys()) {
-      if (isDisplacedEcho(c, f)) continue;
       scored.push({ c, f, score: scores[c][f] });
     }
   }

--- a/src/agent/output/extraction/contentSimilarity.ts
+++ b/src/agent/output/extraction/contentSimilarity.ts
@@ -139,6 +139,7 @@ export function assignByContentSimilarity(
     madeProgress = false;
     for (const { c, f, score } of scored) {
       if (score < minSimilarity) break;
+      if (score < bestScoreOf[c]) continue;
       if (takenCandidates.has(c) || takenFiles.has(f)) continue;
       // An exact score tie against another still-free file means there is no
       // evidence which file this block belongs to yet. Leave it for a later

--- a/src/agent/output/extraction/contentSimilarity.ts
+++ b/src/agent/output/extraction/contentSimilarity.ts
@@ -1,0 +1,140 @@
+/**
+ * Content-similarity document recovery for fallback output extraction.
+ *
+ * Collects unlabeled ```latex/```tex fenced blocks from a response and pairs
+ * each with the base file it most closely resembles via a diff-match-patch
+ * diff, so blocks can be routed to filenames without trusting response order.
+ */
+
+import { diff_match_patch } from 'diff-match-patch';
+
+import {
+  isClosingMarkdownFence,
+  type MarkdownFence,
+  parseMarkdownFenceDelimiter,
+} from './markdownFences';
+import { responseLines } from './responseText';
+
+/** Opening delimiter for a fenced block explicitly tagged as latex/tex. */
+const LATEX_FENCE_OPEN_REGEX = /^(`{3,}|~{3,})\s*(?:latex|tex)\s*$/i;
+
+/** Collect the content of every ```latex/```tex fenced block, in document order. */
+export function collectLatexFencedBlocks(
+  content: string,
+  thinkingTag: string,
+): string[] {
+  const lines = responseLines(content, thinkingTag);
+
+  const blocks: string[] = [];
+  let openFence: MarkdownFence | null = null;
+  let current: string[] = [];
+
+  for (const line of lines) {
+    if (!openFence) {
+      if (LATEX_FENCE_OPEN_REGEX.test(line.trim())) {
+        openFence = parseMarkdownFenceDelimiter(line);
+        current = [];
+      }
+      continue;
+    }
+    if (isClosingMarkdownFence(line, openFence)) {
+      const block = current.join('\n').trim();
+      if (block) blocks.push(block);
+      openFence = null;
+      current = [];
+      continue;
+    }
+    current.push(line);
+  }
+  return blocks;
+}
+
+/**
+ * Similarity in [0, 1] between two documents via a `diff-match-patch` Myers
+ * diff (with the line-mode speedup enabled, which keeps this cheap for
+ * large, mostly-unchanged documents): 1 minus the diff's edit distance,
+ * normalized by the longer document's length. Clamped at 0 because
+ * `diff_levenshtein` counts a substitution as delete-plus-insert, which can
+ * exceed the longer length for very different documents.
+ */
+function documentSimilarity(
+  dmp: InstanceType<typeof diff_match_patch>,
+  a: string,
+  b: string,
+): number {
+  if (a === b) return 1;
+  const maxLength = Math.max(a.length, b.length, 1);
+  const diffs = dmp.diff_main(a, b, true);
+  return Math.max(0, 1 - dmp.diff_levenshtein(diffs) / maxLength);
+}
+
+/**
+ * Greedily pair each candidate document with the base file it most closely
+ * resembles, highest-confidence pairs first, so an unambiguous match never
+ * gets displaced by a later tie. Never guesses: candidates below
+ * `minSimilarity`, candidates whose best remaining files tie exactly (e.g.
+ * identical template stubs), and leftovers once the other side is exhausted
+ * all come back unmatched.
+ */
+export function assignByContentSimilarity(
+  candidates: readonly string[],
+  files: ReadonlyArray<{ name: string; content: string }>,
+  minSimilarity = 0.15,
+): Array<{ content: string; name: string } | null> {
+  const dmp = new diff_match_patch();
+  const scores = candidates.map((candidate) =>
+    files.map((file) => documentSimilarity(dmp, candidate, file.content)),
+  );
+  const bestFileOf = scores.map((row) => row.indexOf(Math.max(...row)));
+
+  // A block that echoes a base file verbatim (modulo surrounding whitespace —
+  // fenced blocks arrive trimmed) is a quote of the original, not a revision.
+  // When some other block's best match is that same file (the model quoted
+  // the original before its revision), drop the verbatim pair so the
+  // revision can claim the file.
+  const trimmedFileContents = files.map((file) => file.content.trim());
+  const isDisplacedEcho = (c: number, f: number): boolean =>
+    candidates[c].trim() === trimmedFileContents[f] &&
+    candidates.some(
+      (_, other) =>
+        other !== c &&
+        bestFileOf[other] === f &&
+        scores[other][f] >= minSimilarity,
+    );
+
+  const scored: Array<{ c: number; f: number; score: number }> = [];
+  for (const c of candidates.keys()) {
+    for (const f of files.keys()) {
+      if (isDisplacedEcho(c, f)) continue;
+      scored.push({ c, f, score: scores[c][f] });
+    }
+  }
+  scored.sort((a, b) => b.score - a.score);
+
+  const takenCandidates = new Set<number>();
+  const takenFiles = new Set<number>();
+  const nameByCandidate = new Map<number, string>();
+  for (const { c, f, score } of scored) {
+    if (score < minSimilarity) break;
+    if (takenCandidates.has(c) || takenFiles.has(f)) continue;
+    takenCandidates.add(c);
+    // An exact score tie against another still-free file means there is no
+    // evidence which file this block belongs to — leave it unmatched rather
+    // than routing by declaration order.
+    const ambiguous = scored.some(
+      (other) =>
+        other.c === c &&
+        other.f !== f &&
+        !takenFiles.has(other.f) &&
+        other.score === score,
+    );
+    if (ambiguous) continue;
+    takenFiles.add(f);
+    nameByCandidate.set(c, files[f].name);
+  }
+
+  return candidates.map((content, idx) => {
+    const name = nameByCandidate.get(idx);
+    return name ? { content, name } : null;
+  });
+}

--- a/src/agent/output/extraction/contentSimilarity.ts
+++ b/src/agent/output/extraction/contentSimilarity.ts
@@ -111,6 +111,7 @@ export function assignByContentSimilarity(
     candidates.some(
       (_, other) =>
         other !== c &&
+        candidates[other].trim() !== trimmedFileContents[f] &&
         // Best-match check by score, not argmax index, so a revision tied
         // across several files displaces the echo of each of them.
         scores[other][f] === bestScoreOf[other] &&

--- a/src/agent/output/extraction/contentSimilarity.ts
+++ b/src/agent/output/extraction/contentSimilarity.ts
@@ -134,23 +134,29 @@ export function assignByContentSimilarity(
   const takenCandidates = new Set<number>();
   const takenFiles = new Set<number>();
   const nameByCandidate = new Map<number, string>();
-  for (const { c, f, score } of scored) {
-    if (score < minSimilarity) break;
-    if (takenCandidates.has(c) || takenFiles.has(f)) continue;
-    takenCandidates.add(c);
-    // An exact score tie against another still-free file means there is no
-    // evidence which file this block belongs to — leave it unmatched rather
-    // than routing by declaration order.
-    const ambiguous = scored.some(
-      (other) =>
-        other.c === c &&
-        other.f !== f &&
-        !takenFiles.has(other.f) &&
-        other.score === score,
-    );
-    if (ambiguous) continue;
-    takenFiles.add(f);
-    nameByCandidate.set(c, files[f].name);
+  let madeProgress = true;
+  while (madeProgress) {
+    madeProgress = false;
+    for (const { c, f, score } of scored) {
+      if (score < minSimilarity) break;
+      if (takenCandidates.has(c) || takenFiles.has(f)) continue;
+      // An exact score tie against another still-free file means there is no
+      // evidence which file this block belongs to yet. Leave it for a later
+      // pass: another candidate may claim one of the tied files, making this
+      // candidate's remaining match unambiguous.
+      const ambiguous = scored.some(
+        (other) =>
+          other.c === c &&
+          other.f !== f &&
+          !takenFiles.has(other.f) &&
+          other.score === score,
+      );
+      if (ambiguous) continue;
+      takenCandidates.add(c);
+      takenFiles.add(f);
+      nameByCandidate.set(c, files[f].name);
+      madeProgress = true;
+    }
   }
 
   return candidates.map((content, idx) => {

--- a/src/agent/output/extraction/contentSimilarity.ts
+++ b/src/agent/output/extraction/contentSimilarity.ts
@@ -85,7 +85,7 @@ export function assignByContentSimilarity(
   const scores = candidates.map((candidate) =>
     files.map((file) => documentSimilarity(dmp, candidate, file.content)),
   );
-  const bestFileOf = scores.map((row) => row.indexOf(Math.max(...row)));
+  const bestScoreOf = scores.map((row) => Math.max(...row));
 
   // A block that echoes a base file verbatim (modulo surrounding whitespace —
   // fenced blocks arrive trimmed) while some other block's best match is that
@@ -93,14 +93,22 @@ export function assignByContentSimilarity(
   // the original before its revision). Such a block is excluded from
   // assignment entirely: letting it fall back to a different, merely-similar
   // file would write one file's stale content over another.
+  //
+  // The competing block must clear a higher bar than the routing threshold:
+  // a genuine rewrite stays broadly similar to the file it revises, and
+  // dropping an exact copy (a legitimately unchanged output) for a weak
+  // stray snippet would lose real content.
+  const ECHO_DISPLACEMENT_MIN_SIMILARITY = 0.5;
   const trimmedFileContents = files.map((file) => file.content.trim());
   const isDisplacedEcho = (c: number, f: number): boolean =>
     candidates[c].trim() === trimmedFileContents[f] &&
     candidates.some(
       (_, other) =>
         other !== c &&
-        bestFileOf[other] === f &&
-        scores[other][f] >= minSimilarity,
+        // Best-match check by score, not argmax index, so a revision tied
+        // across several files displaces the echo of each of them.
+        scores[other][f] === bestScoreOf[other] &&
+        scores[other][f] >= ECHO_DISPLACEMENT_MIN_SIMILARITY,
     );
   const quotedOriginals = new Set(
     [...candidates.keys()].filter((c) =>

--- a/src/agent/output/extraction/filenameHeaders.ts
+++ b/src/agent/output/extraction/filenameHeaders.ts
@@ -99,11 +99,15 @@ export function extractFilenameHeaderDocuments(
     roundDir: string;
     /** Names a bare label may resolve to (declared outputs, else inputs). */
     labelFiles: readonly string[];
-    /** The single input name used to synthesize a document from an unlabeled LaTeX prefix, or null for multi-input agents. */
-    singleInputName: string | null;
+    /**
+     * The name for a document synthesized from an unlabeled LaTeX prefix.
+     * Null when the agent may write more than one file, which disables
+     * prefix synthesis (there is no way to pick the right name).
+     */
+    synthesisName: string | null;
   },
 ): Array<{ content: string; name: string }> | null {
-  const { thinkingTag, roundDir, labelFiles, singleInputName } = options;
+  const { thinkingTag, roundDir, labelFiles, synthesisName } = options;
   const documents: Array<{ content: string; name: string }> = [];
   const reservedFinalPaths = new Set<string>();
   let currentName: string | null = null;
@@ -194,8 +198,8 @@ export function extractFilenameHeaderDocuments(
       : getLatexDocumentContext(linesBeforeHeader).insideDocumentBody;
     if (headerName && !keepHeaderAsContent) {
       if (!currentName && hasLikelyLatexContent(preHeaderLines)) {
-        if (singleInputName !== null) {
-          currentName = singleInputName;
+        if (synthesisName !== null) {
+          currentName = synthesisName;
           // Keep the triggering `%` header as an in-document comment, but a
           // bare label is not LaTeX and must not enter the synthesized body.
           currentLines = percentHeaderName

--- a/src/agent/output/extraction/filenameHeaders.ts
+++ b/src/agent/output/extraction/filenameHeaders.ts
@@ -183,14 +183,24 @@ export function extractFilenameHeaderDocuments(
     }
 
     const linesBeforeHeader = currentName ? currentLines : preHeaderLines;
-    if (
-      headerName &&
-      !shouldKeepPercentHeaderAsLatexComment(linesBeforeHeader, lines, index)
-    ) {
+    // The keep-as-comment heuristic exists because a `%` header is
+    // indistinguishable from a genuine LaTeX comment. A bare label is never
+    // valid LaTeX, so for it only the inside-document-body check applies
+    // (a filename-looking line in a verbatim example stays content); the
+    // preamble lookahead must not swallow a label that separates a
+    // preamble-only file from the next document.
+    const keepHeaderAsContent = percentHeaderName
+      ? shouldKeepPercentHeaderAsLatexComment(linesBeforeHeader, lines, index)
+      : getLatexDocumentContext(linesBeforeHeader).insideDocumentBody;
+    if (headerName && !keepHeaderAsContent) {
       if (!currentName && hasLikelyLatexContent(preHeaderLines)) {
         if (singleInputName !== null) {
           currentName = singleInputName;
-          currentLines = [...preHeaderLines, line];
+          // Keep the triggering `%` header as an in-document comment, but a
+          // bare label is not LaTeX and must not enter the synthesized body.
+          currentLines = percentHeaderName
+            ? [...preHeaderLines, line]
+            : [...preHeaderLines];
           currentMarkdownFence = pendingPrefacedMarkdownFence;
           pendingPrefacedMarkdownFence = null;
           preHeaderLines = [];

--- a/src/agent/output/extraction/filenameHeaders.ts
+++ b/src/agent/output/extraction/filenameHeaders.ts
@@ -38,6 +38,8 @@ const TRAILING_COLON_REGEX = /:+$/;
 const SAFE_DECORATION_REGEX = /^[*`]+|[*`:]+$/g;
 /** Full decoration strip, including emphasis underscores (`_x_`). */
 const FULL_DECORATION_REGEX = /^[*_`]+|[*_`:]+$/g;
+const DOCUMENTS_OPEN_REGEX = /^<documents\b[^>]*>\s*$/i;
+const DOCUMENTS_CLOSE_REGEX = /^<\/documents>\s*$/i;
 
 function matchNormalizedCandidate(
   stripped: string,
@@ -113,6 +115,39 @@ function makeUniquePercentHeaderName(
   return candidate;
 }
 
+function safeDocumentName(source: string): string {
+  return getSafeDocumentRelativePath(source.replaceAll('\\', '/')).replaceAll(
+    '\\',
+    '/',
+  );
+}
+
+function sameNormalizedPath(a: string, b: string): boolean {
+  return (
+    normalizeFilePath(a).replace(/^(?:\.\/)+/, '') ===
+    normalizeFilePath(b).replace(/^(?:\.\/)+/, '')
+  );
+}
+
+function stripDocumentsEnvelope(lines: readonly string[]): string[] {
+  const firstContentIndex = lines.findIndex((line) => line.trim() !== '');
+  const lastContentIndex = lines.findLastIndex((line) => line.trim() !== '');
+  if (
+    firstContentIndex !== -1 &&
+    lastContentIndex !== -1 &&
+    firstContentIndex < lastContentIndex &&
+    DOCUMENTS_OPEN_REGEX.test(lines[firstContentIndex].trim()) &&
+    DOCUMENTS_CLOSE_REGEX.test(lines[lastContentIndex].trim())
+  ) {
+    return [
+      ...lines.slice(0, firstContentIndex),
+      ...lines.slice(firstContentIndex + 1, lastContentIndex),
+      ...lines.slice(lastContentIndex + 1),
+    ];
+  }
+  return [...lines];
+}
+
 /**
  * Recover named documents from filename headers in a raw response. Returns
  * the recovered documents in response order, or null when none were found.
@@ -130,9 +165,21 @@ export function extractFilenameHeaderDocuments(
      * prefix synthesis (there is no way to pick the right name).
      */
     synthesisName: string | null;
+    /**
+     * When an agent declares one generated output, models often repeat that
+     * same output label for chunks of one artifact. Coalesce only that exact
+     * target; multi-file and in-place edits still keep duplicate names unique.
+     */
+    coalesceRepeatedName?: string | null;
   },
 ): Array<{ content: string; name: string }> | null {
-  const { thinkingTag, roundDir, labelFiles, synthesisName } = options;
+  const {
+    thinkingTag,
+    roundDir,
+    labelFiles,
+    synthesisName,
+    coalesceRepeatedName = null,
+  } = options;
   const documents: Array<{ content: string; name: string }> = [];
   const reservedFinalPaths = new Set<string>();
   let currentName: string | null = null;
@@ -148,16 +195,32 @@ export function extractFilenameHeaderDocuments(
     const content = stripSurroundingMarkdownFence(currentLines)
       .join('\n')
       .trim();
-    const carriedFence = content ? null : currentMarkdownFence;
+    const carriedFence = currentMarkdownFence;
     if (content) {
-      documents.push({
-        name: makeUniquePercentHeaderName(
-          currentName,
-          reservedFinalPaths,
-          roundDir,
-        ),
-        content,
-      });
+      if (
+        coalesceRepeatedName &&
+        sameNormalizedPath(currentName, coalesceRepeatedName)
+      ) {
+        const name = safeDocumentName(currentName);
+        const existing = documents.find((document) => document.name === name);
+        if (existing) {
+          existing.content = `${existing.content}\n\n${content}`;
+        } else {
+          reservedFinalPaths.add(
+            getExtractedDocOutputFileName(name, roundDir).replaceAll('\\', '/'),
+          );
+          documents.push({ name, content });
+        }
+      } else {
+        documents.push({
+          name: makeUniquePercentHeaderName(
+            currentName,
+            reservedFinalPaths,
+            roundDir,
+          ),
+          content,
+        });
+      }
     }
     currentLines = [];
     currentMarkdownFence = null;
@@ -165,10 +228,14 @@ export function extractFilenameHeaderDocuments(
   };
 
   const lines = stripSurroundingMarkdownFence(
-    responseLines(outputContent, thinkingTag),
+    stripDocumentsEnvelope(responseLines(outputContent, thinkingTag)),
   );
   for (const [index, line] of lines.entries()) {
     const fence = parseMarkdownFenceDelimiter(line);
+    const percentHeaderName =
+      PERCENT_FILENAME_HEADER_REGEX.exec(line.trim())?.[1] ?? null;
+    const headerName =
+      percentHeaderName ?? matchKnownFileLabel(line, labelFiles);
 
     if (!currentName && fence) {
       if (
@@ -188,14 +255,24 @@ export function extractFilenameHeaderDocuments(
       pendingPrefacedMarkdownFence &&
       !isLatexMarkdownFence(pendingPrefacedMarkdownFence)
     ) {
-      continue;
+      const openExampleFence = pendingPrefacedMarkdownFence;
+      const fenceClosesLater = lines
+        .slice(index)
+        .some((candidate) =>
+          isClosingMarkdownFence(candidate, openExampleFence),
+        );
+      if (!headerName || fenceClosesLater) {
+        continue;
+      }
+      pendingPrefacedMarkdownFence = null;
     }
 
     if (
       currentName &&
       currentMarkdownFence &&
       isClosingMarkdownFence(line, currentMarkdownFence) &&
-      !getLatexDocumentContext(currentLines).insideDocumentBody
+      !getLatexDocumentContext(currentLines).insideDocumentBody &&
+      !isInsideLiteralEnvironment(currentLines)
     ) {
       flushCurrent();
       currentName = null;
@@ -206,10 +283,6 @@ export function extractFilenameHeaderDocuments(
       continue;
     }
 
-    const percentHeaderName =
-      PERCENT_FILENAME_HEADER_REGEX.exec(line.trim())?.[1] ?? null;
-    const headerName =
-      percentHeaderName ?? matchKnownFileLabel(line, labelFiles);
     if (headerName && synthesizedSingleInputFromPrefix) {
       // A `%` header is a valid LaTeX comment and can stay in the
       // synthesized document's body, as can a filename-looking line inside

--- a/src/agent/output/extraction/filenameHeaders.ts
+++ b/src/agent/output/extraction/filenameHeaders.ts
@@ -148,6 +148,43 @@ function stripDocumentsEnvelope(lines: readonly string[]): string[] {
   return [...lines];
 }
 
+function matchHeaderName(
+  line: string,
+  labelFiles: readonly string[],
+): string | null {
+  return (
+    PERCENT_FILENAME_HEADER_REGEX.exec(line.trim())?.[1] ??
+    matchKnownFileLabel(line, labelFiles)
+  );
+}
+
+function findClosingFenceIndex(
+  lines: readonly string[],
+  startIndex: number,
+  openingFence: MarkdownFence,
+): number {
+  return lines.findIndex(
+    (line, index) =>
+      index >= startIndex && isClosingMarkdownFence(line, openingFence),
+  );
+}
+
+function shouldParseHeaderInsideNonLatexFence(
+  lines: readonly string[],
+  headerIndex: number,
+  openingFence: MarkdownFence,
+  labelFiles: readonly string[],
+): boolean {
+  const closingIndex = findClosingFenceIndex(lines, headerIndex, openingFence);
+  if (closingIndex === -1) return true;
+
+  const bodyLines = lines.slice(headerIndex + 1, closingIndex);
+  return (
+    hasLikelyLatexContent(bodyLines) ||
+    bodyLines.some((line) => matchHeaderName(line, labelFiles) !== null)
+  );
+}
+
 /**
  * Recover named documents from filename headers in a raw response. Returns
  * the recovered documents in response order, or null when none were found.
@@ -256,15 +293,17 @@ export function extractFilenameHeaderDocuments(
       !isLatexMarkdownFence(pendingPrefacedMarkdownFence)
     ) {
       const openExampleFence = pendingPrefacedMarkdownFence;
-      const fenceClosesLater = lines
-        .slice(index)
-        .some((candidate) =>
-          isClosingMarkdownFence(candidate, openExampleFence),
-        );
-      if (!headerName || fenceClosesLater) {
+      if (
+        !headerName ||
+        !shouldParseHeaderInsideNonLatexFence(
+          lines,
+          index,
+          openExampleFence,
+          labelFiles,
+        )
+      ) {
         continue;
       }
-      pendingPrefacedMarkdownFence = null;
     }
 
     if (

--- a/src/agent/output/extraction/filenameHeaders.ts
+++ b/src/agent/output/extraction/filenameHeaders.ts
@@ -9,6 +9,8 @@
 
 import * as path from 'node:path';
 
+import escapeRegExp from 'escape-string-regexp';
+
 import {
   getExtractedDocOutputFileName,
   getSafeDocumentRelativePath,
@@ -40,8 +42,6 @@ const SAFE_DECORATION_REGEX = /^[*`]+|[*`:]+$/g;
 const TRAILING_EMPHASIS_DECORATION_REGEX = /^[*`]+|[*_`:]+$/g;
 /** Full decoration strip, including emphasis underscores (`_x_`). */
 const FULL_DECORATION_REGEX = /^[*_`]+|[*_`:]+$/g;
-const DOCUMENTS_OPEN_REGEX = /^<documents\b[^>]*>\s*$/i;
-const DOCUMENTS_CLOSE_REGEX = /^<\/documents>\s*$/i;
 const FILE_LIKE_LABEL_REGEX =
   /^\s*(?:\.[/\\])*[A-Za-z0-9_][A-Za-z0-9._/\\-]*\.[A-Za-z0-9]+:+\s*$/;
 
@@ -134,15 +134,25 @@ function sameNormalizedPath(a: string, b: string): boolean {
   );
 }
 
-function stripDocumentsEnvelope(lines: readonly string[]): string[] {
+function stripDocumentsEnvelope(
+  lines: readonly string[],
+  wrapperTag: string,
+): string[] {
+  const trimmedTag = wrapperTag.trim();
+  if (!trimmedTag) return [...lines];
+  const openRegex = new RegExp(
+    `^<${escapeRegExp(trimmedTag)}\\b[^>]*>\\s*$`,
+    'i',
+  );
+  const closeRegex = new RegExp(`^<\\/${escapeRegExp(trimmedTag)}>\\s*$`, 'i');
   const firstContentIndex = lines.findIndex((line) => line.trim() !== '');
   const lastContentIndex = lines.findLastIndex((line) => line.trim() !== '');
   if (
     firstContentIndex !== -1 &&
     lastContentIndex !== -1 &&
     firstContentIndex < lastContentIndex &&
-    DOCUMENTS_OPEN_REGEX.test(lines[firstContentIndex].trim()) &&
-    DOCUMENTS_CLOSE_REGEX.test(lines[lastContentIndex].trim())
+    openRegex.test(lines[firstContentIndex].trim()) &&
+    closeRegex.test(lines[lastContentIndex].trim())
   ) {
     return [
       ...lines.slice(0, firstContentIndex),
@@ -184,14 +194,12 @@ function shouldParseHeaderInsideNonLatexFence(
   if (closingIndex === -1) return true;
 
   const bodyLines = lines.slice(headerIndex + 1, closingIndex);
+  const linesAfterFence = lines.slice(closingIndex + 1);
   return (
     hasLikelyLatexContent(bodyLines) ||
-    bodyLines.some((line) => matchHeaderName(line, labelFiles) !== null)
+    bodyLines.some((line) => matchHeaderName(line, labelFiles) !== null) ||
+    !linesAfterFence.some((line) => matchHeaderName(line, labelFiles) !== null)
   );
-}
-
-function canIntroduceSoleOutputChunk(line: string): boolean {
-  return FILE_LIKE_LABEL_REGEX.test(line);
 }
 
 /**
@@ -217,6 +225,7 @@ export function extractFilenameHeaderDocuments(
      * target; multi-file and in-place edits still keep duplicate names unique.
      */
     coalesceRepeatedName?: string | null;
+    wrapperTag: string;
   },
 ): Array<{ content: string; name: string }> | null {
   const {
@@ -225,6 +234,7 @@ export function extractFilenameHeaderDocuments(
     labelFiles,
     synthesisName,
     coalesceRepeatedName = null,
+    wrapperTag,
   } = options;
   const documents: Array<{ content: string; name: string }> = [];
   const reservedFinalPaths = new Set<string>();
@@ -293,8 +303,12 @@ export function extractFilenameHeaderDocuments(
   const lines = stripSurroundingMarkdownFence(
     stripDocumentsEnvelope(
       stripSurroundingMarkdownFence(
-        stripDocumentsEnvelope(responseLines(outputContent, thinkingTag)),
+        stripDocumentsEnvelope(
+          responseLines(outputContent, thinkingTag),
+          wrapperTag,
+        ),
       ),
+      wrapperTag,
     ),
   );
   for (const [index, line] of lines.entries()) {
@@ -450,7 +464,7 @@ export function extractFilenameHeaderDocuments(
     } else if (
       coalesceRepeatedName &&
       coalescedOutput() &&
-      canIntroduceSoleOutputChunk(line)
+      FILE_LIKE_LABEL_REGEX.test(line)
     ) {
       sawSoleOutputChunkLabel = true;
     } else {

--- a/src/agent/output/extraction/filenameHeaders.ts
+++ b/src/agent/output/extraction/filenameHeaders.ts
@@ -23,6 +23,7 @@ import {
 } from './latexHeuristics';
 import {
   isClosingMarkdownFence,
+  isLatexMarkdownFence,
   type MarkdownFence,
   parseMarkdownFenceDelimiter,
   stripSurroundingMarkdownFence,
@@ -179,6 +180,14 @@ export function extractFilenameHeaderDocuments(
         pendingPrefacedMarkdownFence = fence;
       }
       ignoreProseUntilNextHeader = false;
+      continue;
+    }
+
+    if (
+      !currentName &&
+      pendingPrefacedMarkdownFence &&
+      !isLatexMarkdownFence(pendingPrefacedMarkdownFence)
+    ) {
       continue;
     }
 

--- a/src/agent/output/extraction/filenameHeaders.ts
+++ b/src/agent/output/extraction/filenameHeaders.ts
@@ -18,6 +18,7 @@ import { getBasename, normalizeFilePath } from '@shared/utils/path';
 import {
   getLatexDocumentContext,
   hasLikelyLatexContent,
+  isInsideLiteralEnvironment,
   shouldKeepPercentHeaderAsLatexComment,
 } from './latexHeuristics';
 import {
@@ -30,22 +31,17 @@ import { responseLines } from './responseText';
 
 const PERCENT_FILENAME_HEADER_REGEX =
   /^%\s+((?:\.[/\\])*[A-Za-z0-9_][A-Za-z0-9._/\\-]*\.[A-Za-z0-9]+)\s*$/;
-/** Strip markdown emphasis/label punctuation a model might wrap a bare filename in. */
-const BARE_LABEL_DECORATION_REGEX = /^[*_`]+|[*_`:]+$/g;
+/** Trailing label punctuation after a bare filename (`Draft3.tex:`). */
+const TRAILING_COLON_REGEX = /:+$/;
+/** Markdown decoration that is never part of a filename (`**x**`, `` `x` ``). */
+const SAFE_DECORATION_REGEX = /^[*`]+|[*`:]+$/g;
+/** Full decoration strip, including emphasis underscores (`_x_`). */
+const FULL_DECORATION_REGEX = /^[*_`]+|[*_`:]+$/g;
 
-/**
- * Recognize a header line that names one of the agent's known files directly,
- * without the `%` comment prefix (e.g. `Draft/Draft3.tex:` or
- * `**Draft3.tex**`). Unlike the percent-header form, a bare line like this is
- * never valid LaTeX on its own, so the only ambiguity risk is a coincidental
- * match — guarded against by only ever matching against the agent's own
- * known files rather than any path-shaped string.
- */
-function matchKnownFileLabel(
-  line: string,
+function matchNormalizedCandidate(
+  stripped: string,
   knownFiles: readonly string[],
 ): string | null {
-  const stripped = line.trim().replaceAll(BARE_LABEL_DECORATION_REGEX, '');
   if (!stripped) return null;
   const candidate = normalizeFilePath(stripped).replace(/^(?:\.\/)+/, '');
   const exact = knownFiles.find((f) => normalizeFilePath(f) === candidate);
@@ -57,6 +53,34 @@ function matchKnownFileLabel(
     (f) => getBasename(f) === candidate,
   );
   return basenameMatches.length === 1 ? basenameMatches[0] : null;
+}
+
+/**
+ * Recognize a header line that names one of the agent's known files directly,
+ * without the `%` comment prefix (e.g. `Draft/Draft3.tex:` or
+ * `**Draft3.tex**`). Unlike the percent-header form, a bare line like this is
+ * never valid LaTeX on its own, so the only ambiguity risk is a coincidental
+ * match — guarded against by only ever matching against the agent's own
+ * known files rather than any path-shaped string.
+ *
+ * Decoration is stripped progressively because an underscore is both markdown
+ * emphasis and a legal filename character: `_macros.tex:` must keep its
+ * underscore, while `_paper.tex_` must lose both.
+ */
+function matchKnownFileLabel(
+  line: string,
+  knownFiles: readonly string[],
+): string | null {
+  const trimmed = line.trim();
+  for (const stripped of [
+    trimmed.replace(TRAILING_COLON_REGEX, ''),
+    trimmed.replaceAll(SAFE_DECORATION_REGEX, ''),
+    trimmed.replaceAll(FULL_DECORATION_REGEX, ''),
+  ]) {
+    const match = matchNormalizedCandidate(stripped, knownFiles);
+    if (match) return match;
+  }
+  return null;
 }
 
 function makeUniquePercentHeaderName(
@@ -179,8 +203,10 @@ export function extractFilenameHeaderDocuments(
       percentHeaderName ?? matchKnownFileLabel(line, labelFiles);
     if (headerName && synthesizedSingleInputFromPrefix) {
       // A `%` header is a valid LaTeX comment and can stay in the
-      // synthesized document's body; a bare label is not LaTeX, so drop it.
-      if (percentHeaderName) {
+      // synthesized document's body, as can a filename-looking line inside
+      // a verbatim-style environment; a bare label elsewhere is not LaTeX,
+      // so drop it.
+      if (percentHeaderName || isInsideLiteralEnvironment(currentLines)) {
         currentLines.push(line);
       }
       continue;
@@ -189,13 +215,15 @@ export function extractFilenameHeaderDocuments(
     const linesBeforeHeader = currentName ? currentLines : preHeaderLines;
     // The keep-as-comment heuristic exists because a `%` header is
     // indistinguishable from a genuine LaTeX comment. A bare label is never
-    // valid LaTeX, so for it only the inside-document-body check applies
-    // (a filename-looking line in a verbatim example stays content); the
-    // preamble lookahead must not swallow a label that separates a
-    // preamble-only file from the next document.
+    // valid LaTeX, so for it only literal contexts apply — inside a
+    // \begin{document} body or an unclosed verbatim-style environment, a
+    // filename-looking line stays content. The preamble lookahead must not
+    // swallow a label that separates a preamble-only file from the next
+    // document.
     const keepHeaderAsContent = percentHeaderName
       ? shouldKeepPercentHeaderAsLatexComment(linesBeforeHeader, lines, index)
-      : getLatexDocumentContext(linesBeforeHeader).insideDocumentBody;
+      : getLatexDocumentContext(linesBeforeHeader).insideDocumentBody ||
+        isInsideLiteralEnvironment(linesBeforeHeader);
     if (headerName && !keepHeaderAsContent) {
       if (!currentName && hasLikelyLatexContent(preHeaderLines)) {
         if (synthesisName !== null) {

--- a/src/agent/output/extraction/filenameHeaders.ts
+++ b/src/agent/output/extraction/filenameHeaders.ts
@@ -36,10 +36,14 @@ const PERCENT_FILENAME_HEADER_REGEX =
 const TRAILING_COLON_REGEX = /:+$/;
 /** Markdown decoration that is never part of a filename (`**x**`, `` `x` ``). */
 const SAFE_DECORATION_REGEX = /^[*`]+|[*`:]+$/g;
+/** Strip trailing emphasis without stripping a filename's leading underscore. */
+const TRAILING_EMPHASIS_DECORATION_REGEX = /^[*`]+|[*_`:]+$/g;
 /** Full decoration strip, including emphasis underscores (`_x_`). */
 const FULL_DECORATION_REGEX = /^[*_`]+|[*_`:]+$/g;
 const DOCUMENTS_OPEN_REGEX = /^<documents\b[^>]*>\s*$/i;
 const DOCUMENTS_CLOSE_REGEX = /^<\/documents>\s*$/i;
+const FILE_LIKE_LABEL_REGEX =
+  /^\s*(?:\.[/\\])*[A-Za-z0-9_][A-Za-z0-9._/\\-]*\.[A-Za-z0-9]+:+\s*$/;
 
 function matchNormalizedCandidate(
   stripped: string,
@@ -78,6 +82,7 @@ function matchKnownFileLabel(
   for (const stripped of [
     trimmed.replace(TRAILING_COLON_REGEX, ''),
     trimmed.replaceAll(SAFE_DECORATION_REGEX, ''),
+    trimmed.replaceAll(TRAILING_EMPHASIS_DECORATION_REGEX, ''),
     trimmed.replaceAll(FULL_DECORATION_REGEX, ''),
   ]) {
     const match = matchNormalizedCandidate(stripped, knownFiles);
@@ -185,6 +190,10 @@ function shouldParseHeaderInsideNonLatexFence(
   );
 }
 
+function canIntroduceSoleOutputChunk(line: string): boolean {
+  return FILE_LIKE_LABEL_REGEX.test(line);
+}
+
 /**
  * Recover named documents from filename headers in a raw response. Returns
  * the recovered documents in response order, or null when none were found.
@@ -226,6 +235,31 @@ export function extractFilenameHeaderDocuments(
   let currentMarkdownFence: MarkdownFence | null = null;
   let ignoreProseUntilNextHeader = false;
   let synthesizedSingleInputFromPrefix = false;
+  let pendingSoleOutputChunk: { fence: MarkdownFence; lines: string[] } | null =
+    null;
+  let mayStartAdjacentSoleOutputChunk = false;
+  let sawSoleOutputChunkLabel = false;
+
+  const coalescedOutputName = coalesceRepeatedName
+    ? safeDocumentName(coalesceRepeatedName)
+    : null;
+  const coalescedOutput = () =>
+    coalescedOutputName
+      ? documents.find((document) => document.name === coalescedOutputName)
+      : undefined;
+
+  const appendCoalescedContent = (source: string, content: string): void => {
+    const name = safeDocumentName(source);
+    const existing = documents.find((document) => document.name === name);
+    if (existing) {
+      existing.content = `${existing.content.trim()}\n\n${content}`;
+    } else {
+      reservedFinalPaths.add(
+        getExtractedDocOutputFileName(name, roundDir).replaceAll('\\', '/'),
+      );
+      documents.push({ name, content });
+    }
+  };
 
   const flushCurrent = (): MarkdownFence | null => {
     if (!currentName) return null;
@@ -238,16 +272,8 @@ export function extractFilenameHeaderDocuments(
         coalesceRepeatedName &&
         sameNormalizedPath(currentName, coalesceRepeatedName)
       ) {
-        const name = safeDocumentName(currentName);
-        const existing = documents.find((document) => document.name === name);
-        if (existing) {
-          existing.content = `${existing.content}\n\n${content}`;
-        } else {
-          reservedFinalPaths.add(
-            getExtractedDocOutputFileName(name, roundDir).replaceAll('\\', '/'),
-          );
-          documents.push({ name, content });
-        }
+        appendCoalescedContent(currentName, content);
+        mayStartAdjacentSoleOutputChunk = true;
       } else {
         documents.push({
           name: makeUniquePercentHeaderName(
@@ -265,7 +291,11 @@ export function extractFilenameHeaderDocuments(
   };
 
   const lines = stripSurroundingMarkdownFence(
-    stripDocumentsEnvelope(responseLines(outputContent, thinkingTag)),
+    stripDocumentsEnvelope(
+      stripSurroundingMarkdownFence(
+        stripDocumentsEnvelope(responseLines(outputContent, thinkingTag)),
+      ),
+    ),
   );
   for (const [index, line] of lines.entries()) {
     const fence = parseMarkdownFenceDelimiter(line);
@@ -274,7 +304,32 @@ export function extractFilenameHeaderDocuments(
     const headerName =
       percentHeaderName ?? matchKnownFileLabel(line, labelFiles);
 
+    if (pendingSoleOutputChunk) {
+      if (isClosingMarkdownFence(line, pendingSoleOutputChunk.fence)) {
+        const content = pendingSoleOutputChunk.lines.join('\n').trim();
+        if (content && coalesceRepeatedName) {
+          appendCoalescedContent(coalesceRepeatedName, content);
+          mayStartAdjacentSoleOutputChunk = true;
+        }
+        pendingSoleOutputChunk = null;
+        ignoreProseUntilNextHeader = true;
+        continue;
+      }
+      pendingSoleOutputChunk.lines.push(line);
+      continue;
+    }
+
     if (!currentName && fence) {
+      if (
+        coalesceRepeatedName &&
+        coalescedOutput() &&
+        isLatexMarkdownFence(fence) &&
+        (mayStartAdjacentSoleOutputChunk || sawSoleOutputChunkLabel)
+      ) {
+        pendingSoleOutputChunk = { fence, lines: [] };
+        sawSoleOutputChunkLabel = false;
+        continue;
+      }
       if (
         pendingPrefacedMarkdownFence &&
         isClosingMarkdownFence(line, pendingPrefacedMarkdownFence)
@@ -370,6 +425,8 @@ export function extractFilenameHeaderDocuments(
       preHeaderLines = [];
       ignoreProseUntilNextHeader = false;
       synthesizedSingleInputFromPrefix = false;
+      mayStartAdjacentSoleOutputChunk = false;
+      sawSoleOutputChunkLabel = false;
       continue;
     }
 
@@ -385,6 +442,20 @@ export function extractFilenameHeaderDocuments(
       currentLines.push(line);
     } else if (!ignoreProseUntilNextHeader) {
       preHeaderLines.push(line);
+      mayStartAdjacentSoleOutputChunk = line.trim() === '';
+      sawSoleOutputChunkLabel = false;
+    } else if (line.trim() === '') {
+      // Keep mayStartAdjacentSoleOutputChunk as-is: a chunk may follow the
+      // previous one after blank separation.
+    } else if (
+      coalesceRepeatedName &&
+      coalescedOutput() &&
+      canIntroduceSoleOutputChunk(line)
+    ) {
+      sawSoleOutputChunkLabel = true;
+    } else {
+      mayStartAdjacentSoleOutputChunk = false;
+      sawSoleOutputChunkLabel = false;
     }
   }
   flushCurrent();

--- a/src/agent/output/extraction/filenameHeaders.ts
+++ b/src/agent/output/extraction/filenameHeaders.ts
@@ -1,0 +1,230 @@
+/**
+ * Filename-header document recovery for fallback output extraction.
+ *
+ * Splits a raw model response into named documents by recognizing
+ * `% path/file.ext` comment headers and bare known-file labels, handling
+ * markdown fences around each document and the ambiguity of `%` headers
+ * that are really LaTeX comments.
+ */
+
+import * as path from 'node:path';
+
+import {
+  getExtractedDocOutputFileName,
+  getSafeDocumentRelativePath,
+} from '@agent/utils/outputFileUtils';
+import { getBasename, normalizeFilePath } from '@shared/utils/path';
+
+import {
+  getLatexDocumentContext,
+  hasLikelyLatexContent,
+  shouldKeepPercentHeaderAsLatexComment,
+} from './latexHeuristics';
+import {
+  isClosingMarkdownFence,
+  type MarkdownFence,
+  parseMarkdownFenceDelimiter,
+  stripSurroundingMarkdownFence,
+} from './markdownFences';
+import { responseLines } from './responseText';
+
+const PERCENT_FILENAME_HEADER_REGEX =
+  /^%\s+((?:\.[/\\])*[A-Za-z0-9_][A-Za-z0-9._/\\-]*\.[A-Za-z0-9]+)\s*$/;
+/** Strip markdown emphasis/label punctuation a model might wrap a bare filename in. */
+const BARE_LABEL_DECORATION_REGEX = /^[*_`]+|[*_`:]+$/g;
+
+/**
+ * Recognize a header line that names one of the agent's known files directly,
+ * without the `%` comment prefix (e.g. `Draft/Draft3.tex:` or
+ * `**Draft3.tex**`). Unlike the percent-header form, a bare line like this is
+ * never valid LaTeX on its own, so the only ambiguity risk is a coincidental
+ * match — guarded against by only ever matching against the agent's own
+ * known files rather than any path-shaped string.
+ */
+function matchKnownFileLabel(
+  line: string,
+  knownFiles: readonly string[],
+): string | null {
+  const stripped = line.trim().replaceAll(BARE_LABEL_DECORATION_REGEX, '');
+  if (!stripped) return null;
+  const candidate = normalizeFilePath(stripped).replace(/^(?:\.\/)+/, '');
+  const exact = knownFiles.find((f) => normalizeFilePath(f) === candidate);
+  if (exact) return exact;
+
+  // Fall back to a basename match when the model dropped the leading
+  // directories, but only when it resolves unambiguously.
+  const basenameMatches = knownFiles.filter(
+    (f) => getBasename(f) === candidate,
+  );
+  return basenameMatches.length === 1 ? basenameMatches[0] : null;
+}
+
+function makeUniquePercentHeaderName(
+  source: string,
+  reservedFinalPaths: Set<string>,
+  roundDir: string,
+): string {
+  const normalized = source.replaceAll('\\', '/');
+  const safeName = getSafeDocumentRelativePath(normalized).replaceAll(
+    '\\',
+    '/',
+  );
+  let candidate = safeName;
+  let suffix = 2;
+
+  const finalPathKey = (name: string) =>
+    getExtractedDocOutputFileName(name, roundDir).replaceAll('\\', '/');
+
+  while (reservedFinalPaths.has(finalPathKey(candidate))) {
+    const parsed = path.posix.parse(safeName);
+    candidate = path.posix.join(
+      parsed.dir,
+      `${parsed.name}-${suffix}${parsed.ext}`,
+    );
+    suffix += 1;
+  }
+
+  reservedFinalPaths.add(finalPathKey(candidate));
+  return candidate;
+}
+
+/**
+ * Recover named documents from filename headers in a raw response. Returns
+ * the recovered documents in response order, or null when none were found.
+ */
+export function extractFilenameHeaderDocuments(
+  outputContent: string,
+  options: {
+    thinkingTag: string;
+    roundDir: string;
+    /** Names a bare label may resolve to (declared outputs, else inputs). */
+    labelFiles: readonly string[];
+    /** The single input name used to synthesize a document from an unlabeled LaTeX prefix, or null for multi-input agents. */
+    singleInputName: string | null;
+  },
+): Array<{ content: string; name: string }> | null {
+  const { thinkingTag, roundDir, labelFiles, singleInputName } = options;
+  const documents: Array<{ content: string; name: string }> = [];
+  const reservedFinalPaths = new Set<string>();
+  let currentName: string | null = null;
+  let currentLines: string[] = [];
+  let preHeaderLines: string[] = [];
+  let pendingPrefacedMarkdownFence: MarkdownFence | null = null;
+  let currentMarkdownFence: MarkdownFence | null = null;
+  let ignoreProseUntilNextHeader = false;
+  let synthesizedSingleInputFromPrefix = false;
+
+  const flushCurrent = (): MarkdownFence | null => {
+    if (!currentName) return null;
+    const content = stripSurroundingMarkdownFence(currentLines)
+      .join('\n')
+      .trim();
+    const carriedFence = content ? null : currentMarkdownFence;
+    if (content) {
+      documents.push({
+        name: makeUniquePercentHeaderName(
+          currentName,
+          reservedFinalPaths,
+          roundDir,
+        ),
+        content,
+      });
+    }
+    currentLines = [];
+    currentMarkdownFence = null;
+    return carriedFence;
+  };
+
+  const lines = stripSurroundingMarkdownFence(
+    responseLines(outputContent, thinkingTag),
+  );
+  for (const [index, line] of lines.entries()) {
+    const fence = parseMarkdownFenceDelimiter(line);
+
+    if (!currentName && fence) {
+      if (
+        pendingPrefacedMarkdownFence &&
+        isClosingMarkdownFence(line, pendingPrefacedMarkdownFence)
+      ) {
+        pendingPrefacedMarkdownFence = null;
+      } else {
+        pendingPrefacedMarkdownFence = fence;
+      }
+      ignoreProseUntilNextHeader = false;
+      continue;
+    }
+
+    if (
+      currentName &&
+      currentMarkdownFence &&
+      isClosingMarkdownFence(line, currentMarkdownFence) &&
+      !getLatexDocumentContext(currentLines).insideDocumentBody
+    ) {
+      flushCurrent();
+      currentName = null;
+      preHeaderLines = [];
+      pendingPrefacedMarkdownFence = null;
+      ignoreProseUntilNextHeader = true;
+      synthesizedSingleInputFromPrefix = false;
+      continue;
+    }
+
+    const percentHeaderName =
+      PERCENT_FILENAME_HEADER_REGEX.exec(line.trim())?.[1] ?? null;
+    const headerName =
+      percentHeaderName ?? matchKnownFileLabel(line, labelFiles);
+    if (headerName && synthesizedSingleInputFromPrefix) {
+      // A `%` header is a valid LaTeX comment and can stay in the
+      // synthesized document's body; a bare label is not LaTeX, so drop it.
+      if (percentHeaderName) {
+        currentLines.push(line);
+      }
+      continue;
+    }
+
+    const linesBeforeHeader = currentName ? currentLines : preHeaderLines;
+    if (
+      headerName &&
+      !shouldKeepPercentHeaderAsLatexComment(linesBeforeHeader, lines, index)
+    ) {
+      if (!currentName && hasLikelyLatexContent(preHeaderLines)) {
+        if (singleInputName !== null) {
+          currentName = singleInputName;
+          currentLines = [...preHeaderLines, line];
+          currentMarkdownFence = pendingPrefacedMarkdownFence;
+          pendingPrefacedMarkdownFence = null;
+          preHeaderLines = [];
+          ignoreProseUntilNextHeader = false;
+          synthesizedSingleInputFromPrefix = true;
+          continue;
+        }
+        preHeaderLines = [];
+      }
+      const carriedFence = flushCurrent();
+      currentName = headerName;
+      currentMarkdownFence = pendingPrefacedMarkdownFence ?? carriedFence;
+      pendingPrefacedMarkdownFence = null;
+      preHeaderLines = [];
+      ignoreProseUntilNextHeader = false;
+      synthesizedSingleInputFromPrefix = false;
+      continue;
+    }
+
+    if (currentName) {
+      if (
+        fence &&
+        !currentMarkdownFence &&
+        !currentLines.some((currentLine) => currentLine.trim() !== '')
+      ) {
+        currentMarkdownFence = fence;
+        continue;
+      }
+      currentLines.push(line);
+    } else if (!ignoreProseUntilNextHeader) {
+      preHeaderLines.push(line);
+    }
+  }
+  flushCurrent();
+
+  return documents.length === 0 ? null : documents;
+}

--- a/src/agent/output/extraction/latexHeuristics.ts
+++ b/src/agent/output/extraction/latexHeuristics.ts
@@ -80,3 +80,25 @@ export function shouldKeepPercentHeaderAsLatexComment(
 export function hasLikelyLatexContent(lines: readonly string[]): boolean {
   return lines.some((line) => LIKELY_LATEX_CONTENT_REGEX.test(line.trim()));
 }
+
+const LITERAL_ENV_BOUNDARY_REGEX =
+  /\\(begin|end)\s*\{\s*(?:verbatim\*?|lstlisting|minted|Verbatim)\s*\}/g;
+
+/**
+ * Whether the last of these lines sits inside an unclosed verbatim-style
+ * environment, whose content is literal text — a filename-looking line
+ * there is part of the listing, not a document header.
+ */
+export function isInsideLiteralEnvironment(lines: readonly string[]): boolean {
+  let depth = 0;
+  for (const line of lines) {
+    for (const match of line.matchAll(LITERAL_ENV_BOUNDARY_REGEX)) {
+      if (match[1] === 'begin') {
+        depth += 1;
+      } else if (depth > 0) {
+        depth -= 1;
+      }
+    }
+  }
+  return depth > 0;
+}

--- a/src/agent/output/extraction/latexHeuristics.ts
+++ b/src/agent/output/extraction/latexHeuristics.ts
@@ -1,0 +1,82 @@
+/**
+ * LaTeX-shape heuristics for fallback output extraction.
+ *
+ * Answers structural questions about candidate lines without parsing LaTeX:
+ * whether text sits inside a \begin{document} body or a preamble, whether a
+ * filename header line doubles as a real LaTeX comment, and whether a block
+ * of lines looks like LaTeX content at all.
+ */
+
+const LATEX_DOCUMENTCLASS_REGEX = /\\documentclass\b/;
+const LATEX_DOCUMENT_BEGIN_REGEX = /\\begin\s*\{\s*document\s*\}/;
+const LATEX_DOCUMENT_END_REGEX = /\\end\s*\{\s*document\s*\}/;
+const LIKELY_LATEX_CONTENT_REGEX =
+  /^\\(?:chapter|section|subsection|subsubsection|paragraph|begin|end|input|include|documentclass|usepackage|newcommand|renewcommand|[([])/;
+
+export function getLatexDocumentContext(lines: readonly string[]): {
+  insideDocumentBody: boolean;
+  inDocumentPreamble: boolean;
+} {
+  let depth = 0;
+  let sawDocumentclassWithoutBody = false;
+  for (const line of lines) {
+    if (line.trim().startsWith('%')) {
+      continue;
+    }
+    if (LATEX_DOCUMENTCLASS_REGEX.test(line)) {
+      sawDocumentclassWithoutBody = true;
+    }
+    if (LATEX_DOCUMENT_BEGIN_REGEX.test(line)) {
+      depth += 1;
+      sawDocumentclassWithoutBody = false;
+    }
+    if (LATEX_DOCUMENT_END_REGEX.test(line) && depth > 0) {
+      depth -= 1;
+      if (depth === 0) {
+        sawDocumentclassWithoutBody = false;
+      }
+    }
+  }
+  return {
+    insideDocumentBody: depth > 0,
+    inDocumentPreamble: sawDocumentclassWithoutBody,
+  };
+}
+
+function hasDocumentBeginInCurrentPreamble(
+  lines: readonly string[],
+  startIndex: number,
+): boolean {
+  for (const line of lines.slice(startIndex + 1)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('%')) {
+      continue;
+    }
+    if (LATEX_DOCUMENTCLASS_REGEX.test(line)) {
+      return false;
+    }
+    if (LATEX_DOCUMENT_BEGIN_REGEX.test(line)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function shouldKeepPercentHeaderAsLatexComment(
+  linesBeforeHeader: readonly string[],
+  allLines: readonly string[],
+  headerIndex: number,
+): boolean {
+  const context = getLatexDocumentContext(linesBeforeHeader);
+  if (context.insideDocumentBody) {
+    return true;
+  }
+  return (
+    context.inDocumentPreamble &&
+    hasDocumentBeginInCurrentPreamble(allLines, headerIndex)
+  );
+}
+
+export function hasLikelyLatexContent(lines: readonly string[]): boolean {
+  return lines.some((line) => LIKELY_LATEX_CONTENT_REGEX.test(line.trim()));
+}

--- a/src/agent/output/extraction/markdownFences.ts
+++ b/src/agent/output/extraction/markdownFences.ts
@@ -1,0 +1,66 @@
+/**
+ * Markdown code-fence recognition for fallback output extraction.
+ *
+ * Parses backtick/tilde fence delimiter lines and strips a fence that wraps
+ * an entire block of lines, following CommonMark's closing-fence rule (same
+ * marker, at least the opening delimiter's length).
+ */
+
+export type MarkdownFence = {
+  marker: '`' | '~';
+  length: number;
+};
+
+export function parseMarkdownFenceDelimiter(
+  line: string,
+): MarkdownFence | null {
+  const match = /^(`{3,}|~{3,})(?:\s*\S.*)?\s*$/.exec(line.trim());
+  if (!match) {
+    return null;
+  }
+  const delimiter = match[1];
+  return {
+    marker: delimiter[0] as '`' | '~',
+    length: delimiter.length,
+  };
+}
+
+function isMarkdownFenceDelimiter(line: string): boolean {
+  return parseMarkdownFenceDelimiter(line) !== null;
+}
+
+export function isClosingMarkdownFence(
+  line: string,
+  openingFence: MarkdownFence,
+): boolean {
+  const closingFence = parseMarkdownFenceDelimiter(line);
+  return (
+    closingFence !== null &&
+    closingFence.marker === openingFence.marker &&
+    closingFence.length >= openingFence.length
+  );
+}
+
+export function stripSurroundingMarkdownFence(
+  lines: readonly string[],
+): string[] {
+  const firstContentIndex = lines.findIndex((line) => line.trim() !== '');
+  if (firstContentIndex === -1) {
+    return [];
+  }
+
+  const lastContentIndex = lines.findLastIndex((line) => line.trim() !== '');
+  if (
+    firstContentIndex < lastContentIndex &&
+    isMarkdownFenceDelimiter(lines[firstContentIndex]) &&
+    isMarkdownFenceDelimiter(lines[lastContentIndex])
+  ) {
+    return [
+      ...lines.slice(0, firstContentIndex),
+      ...lines.slice(firstContentIndex + 1, lastContentIndex),
+      ...lines.slice(lastContentIndex + 1),
+    ];
+  }
+
+  return [...lines];
+}

--- a/src/agent/output/extraction/markdownFences.ts
+++ b/src/agent/output/extraction/markdownFences.ts
@@ -56,10 +56,15 @@ export function stripSurroundingMarkdownFence(
   }
 
   const lastContentIndex = lines.findLastIndex((line) => line.trim() !== '');
+  const openingFence = parseMarkdownFenceDelimiter(lines[firstContentIndex]);
   if (
     firstContentIndex < lastContentIndex &&
-    isMarkdownFenceDelimiter(lines[firstContentIndex]) &&
-    isMarkdownFenceDelimiter(lines[lastContentIndex])
+    openingFence &&
+    isMarkdownFenceDelimiter(lines[lastContentIndex]) &&
+    isClosingMarkdownFence(lines[lastContentIndex], openingFence) &&
+    !lines
+      .slice(firstContentIndex + 1, lastContentIndex)
+      .some((line) => isClosingMarkdownFence(line, openingFence))
   ) {
     return [
       ...lines.slice(0, firstContentIndex),

--- a/src/agent/output/extraction/markdownFences.ts
+++ b/src/agent/output/extraction/markdownFences.ts
@@ -9,12 +9,13 @@
 export type MarkdownFence = {
   marker: '`' | '~';
   length: number;
+  info: string;
 };
 
 export function parseMarkdownFenceDelimiter(
   line: string,
 ): MarkdownFence | null {
-  const match = /^(`{3,}|~{3,})(?:\s*\S.*)?\s*$/.exec(line.trim());
+  const match = /^(`{3,}|~{3,})(?:\s*(.*?))?\s*$/.exec(line.trim());
   if (!match) {
     return null;
   }
@@ -22,7 +23,12 @@ export function parseMarkdownFenceDelimiter(
   return {
     marker: delimiter[0] as '`' | '~',
     length: delimiter.length,
+    info: (match[2] ?? '').trim(),
   };
+}
+
+export function isLatexMarkdownFence(fence: MarkdownFence): boolean {
+  return fence.info === '' || /^(?:latex|tex)$/i.test(fence.info);
 }
 
 function isMarkdownFenceDelimiter(line: string): boolean {

--- a/src/agent/output/extraction/responseText.ts
+++ b/src/agent/output/extraction/responseText.ts
@@ -1,0 +1,31 @@
+/**
+ * Response-text preprocessing for fallback output extraction.
+ *
+ * Strips the model's thinking-tag XML blocks from a raw response and
+ * normalizes the remainder into lines, so the header/fence recovery
+ * heuristics only ever see candidate document text.
+ */
+
+import escapeRegExp from 'escape-string-regexp';
+
+function stripXmlTagBlocks(content: string, tagName: string): string {
+  const trimmedTag = tagName.trim();
+  if (!trimmedTag) {
+    return content;
+  }
+  return content.replaceAll(
+    new RegExp(
+      `<${escapeRegExp(trimmedTag)}\\b[^>]*>[\\s\\S]*?<\\/${escapeRegExp(trimmedTag)}>`,
+      'gi',
+    ),
+    '',
+  );
+}
+
+/** Strip `thinkingTag` blocks, normalize CRLF/CR to LF, and split into lines. */
+export function responseLines(content: string, thinkingTag: string): string[] {
+  return stripXmlTagBlocks(content, thinkingTag)
+    .replaceAll('\r\n', '\n')
+    .replaceAll('\r', '\n')
+    .split('\n');
+}

--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -1338,6 +1338,35 @@ Appendix.
     );
   });
 
+  it('recovers real filename-labelled outputs inside a prefaced text fence', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        'Here are the files:',
+        '```text',
+        'main.tex:',
+        'Main body.',
+        'appendix.tex:',
+        'Appendix body.',
+        '```',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents', ['main.tex', 'appendix.tex']);
+
+    const outputs = await splitDocuments(manager);
+
+    expect(outputs.map((output) => output.source)).toEqual([
+      'main.tex',
+      'appendix.tex',
+    ]);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      'Main body.\n',
+    );
+    await expect(AbsoluteFS.read('/tmp/run/appendix.tex')).resolves.toBe(
+      'Appendix body.\n',
+    );
+  });
+
   it('keeps inner fence delimiters inside fenced LaTeX fragments', async () => {
     await AbsoluteFS.write(
       '/tmp/run/output.xml',
@@ -1646,6 +1675,37 @@ Appendix.
     );
     await expect(AbsoluteFS.exists('/tmp/run/ocr_result-2.tex')).resolves.toBe(
       false,
+    );
+  });
+
+  it('coalesces unlabeled chunks after a sole-output header chunk', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        'ocr_result.tex:',
+        '```latex',
+        'Page one transcription.',
+        '```',
+        '',
+        'page2.png:',
+        '```latex',
+        'Page two transcription.',
+        '```',
+      ].join('\n'),
+    );
+
+    const outputs =
+      await createSingleArtifactManager().splitScratchpadMultipleOutputXml(
+        createExternalLocation('/tmp/run/output.xml'),
+        'documents',
+        0,
+        'scratchpad',
+        [createExternalLocation('/tmp/run/ocr_result.tex')],
+      );
+
+    expect(outputs.map((output) => output.source)).toEqual(['ocr_result.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/ocr_result.tex')).resolves.toBe(
+      'Page one transcription.\n\nPage two transcription.\n',
     );
   });
 

--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -33,6 +33,10 @@ async function initFakePlatform(files: Record<string, string> = {}) {
 function createXmlManager(
   documentTag = 'document',
   inputFiles: string[] = ['paper.tex'],
+  options: {
+    outputFiles?: string[];
+    logger?: AgentTrace;
+  } = {},
 ): XmlOutputManager {
   return new XmlOutputManager(
     {
@@ -51,13 +55,14 @@ function createXmlManager(
     },
     {
       inputFiles,
-      outputFiles: [],
+      outputFiles: options.outputFiles ?? [],
     } as unknown as AgentConfig,
-    {
-      debug: vi.fn(),
-      info: vi.fn(),
-      domain: vi.fn(),
-    } as unknown as AgentTrace,
+    options.logger ??
+      ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        domain: vi.fn(),
+      } as unknown as AgentTrace),
     new TaskRunFileService(),
   );
 }
@@ -1230,6 +1235,33 @@ Appendix.
     );
   });
 
+  it('ignores bare labels inside pre-output example fences', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        'Here is the label format:',
+        '```text',
+        'main.tex:',
+        'example body',
+        '```',
+        '',
+        'main.tex:',
+        '```latex',
+        'Real output.',
+        '```',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents', ['main.tex']);
+
+    const outputs = await splitDocuments(manager);
+
+    expect(outputs.map((output) => output.source)).toEqual(['main.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      'Real output.\n',
+    );
+    await expect(AbsoluteFS.exists('/tmp/run/main-2.tex')).resolves.toBe(false);
+  });
+
   it('drops a bare label that triggers single-input prefix synthesis', async () => {
     await AbsoluteFS.write(
       '/tmp/run/output.xml',
@@ -1464,6 +1496,37 @@ Appendix.
     expect(outputs.map((output) => output.source)).toEqual(['ocr_result.tex']);
     await expect(AbsoluteFS.read('/tmp/run/ocr_result.tex')).resolves.toBe(
       'Transcribed content.\n',
+    );
+  });
+
+  it('concatenates multiple unlabeled fences under the sole declared output', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        'page1.png:',
+        '```latex',
+        'Page one transcription.',
+        '```',
+        '',
+        'page2.png:',
+        '```latex',
+        'Page two transcription.',
+        '```',
+      ].join('\n'),
+    );
+
+    const outputs =
+      await createSingleArtifactManager().splitScratchpadMultipleOutputXml(
+        createExternalLocation('/tmp/run/output.xml'),
+        'documents',
+        0,
+        'scratchpad',
+        [createExternalLocation('/tmp/run/ocr_result.tex')],
+      );
+
+    expect(outputs.map((output) => output.source)).toEqual(['ocr_result.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/ocr_result.tex')).resolves.toBe(
+      'Page one transcription.\n\nPage two transcription.\n',
     );
   });
 
@@ -1702,6 +1765,76 @@ Appendix.
     );
 
     expect(outputs.map((output) => output.source)).toEqual(['cost.tex']);
+  });
+
+  it('reports expected files left unmatched by filename-header recovery', async () => {
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      domain: vi.fn(),
+    } as unknown as AgentTrace;
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        'main.tex:',
+        '```latex',
+        'Main body.',
+        '```',
+        '',
+        '```latex',
+        'Appendix body with no label.',
+        '```',
+      ].join('\n'),
+    );
+    const manager = createXmlManager(
+      'documents',
+      ['main.tex', 'appendix.tex'],
+      { logger },
+    );
+
+    const outputs = await splitDocuments(manager);
+
+    expect(outputs.map((output) => output.source)).toEqual(['main.tex']);
+    expect(logger.domain).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: 'missingOutputs',
+        data: expect.objectContaining({ missing: ['appendix.tex'] }),
+      }),
+    );
+  });
+
+  it('logs discarded unclosed latex fences during similarity recovery', async () => {
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      domain: vi.fn(),
+    } as unknown as AgentTrace;
+    await AbsoluteFS.write('/tmp/run/a.tex', 'Original A.');
+    await AbsoluteFS.write('/tmp/run/b.tex', 'Original B.');
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      ['```latex', 'Unclosed revised content.'].join('\n'),
+    );
+    const manager = createXmlManager('documents', ['a.tex', 'b.tex'], {
+      logger,
+    });
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+      'scratchpad',
+      [
+        createExternalLocation('/tmp/run/a.tex'),
+        createExternalLocation('/tmp/run/b.tex'),
+      ],
+    );
+
+    expect(outputs).toEqual([]);
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('Dropped unclosed LaTeX fence'),
+      expect.anything(),
+    );
   });
 });
 

--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -1879,4 +1879,18 @@ describe('assignByContentSimilarity', () => {
     expect(assigned[0]?.name).toBe('f.tex');
     expect(assigned[1]).toBeNull();
   });
+
+  it('can assign a candidate after another block resolves its initial tie', () => {
+    const assigned = assignByContentSimilarity(
+      ['common common common', 'AAA weak'],
+      [
+        { name: 'a.tex', content: 'AAA common common common' },
+        { name: 'b.tex', content: 'BBB common common common' },
+      ],
+    );
+
+    expect(assigned.filter(Boolean)).toHaveLength(2);
+    expect(assigned[0]?.name).toBe('b.tex');
+    expect(assigned[1]?.name).toBe('a.tex');
+  });
 });

--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -1262,6 +1262,122 @@ Appendix.
     await expect(AbsoluteFS.exists('/tmp/run/main-2.tex')).resolves.toBe(false);
   });
 
+  it('does not strip unrelated example and output fences as one wrapper', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '```text',
+        'main.tex:',
+        'example body',
+        '```',
+        '',
+        'main.tex:',
+        '```latex',
+        'Real output.',
+        '```',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents', ['main.tex']);
+
+    const outputs = await splitDocuments(manager);
+
+    expect(outputs.map((output) => output.source)).toEqual(['main.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      'Real output.\n',
+    );
+    await expect(AbsoluteFS.exists('/tmp/run/main-2.tex')).resolves.toBe(false);
+  });
+
+  it('preserves a shared outer fence across filename-label splits', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        'Here are the files:',
+        '```latex',
+        'main.tex:',
+        'Main body.',
+        'appendix.tex:',
+        'Appendix body.',
+        '```',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents', ['main.tex', 'appendix.tex']);
+
+    const outputs = await splitDocuments(manager);
+
+    expect(outputs.map((output) => output.source)).toEqual([
+      'main.tex',
+      'appendix.tex',
+    ]);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      'Main body.\n',
+    );
+    await expect(AbsoluteFS.read('/tmp/run/appendix.tex')).resolves.toBe(
+      'Appendix body.\n',
+    );
+  });
+
+  it('recovers headers after an unclosed non-LaTeX example fence', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        'Example:',
+        '```text',
+        'The response should then provide the real file.',
+        'main.tex:',
+        'Real body.',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents', ['main.tex']);
+
+    const outputs = await splitDocuments(manager);
+
+    expect(outputs.map((output) => output.source)).toEqual(['main.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      'Real body.\n',
+    );
+  });
+
+  it('keeps inner fence delimiters inside fenced LaTeX fragments', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        'main.tex:',
+        '```latex',
+        '\\begin{verbatim}',
+        '```',
+        '\\end{verbatim}',
+        'Tail.',
+        '```',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents', ['main.tex']);
+
+    const outputs = await splitDocuments(manager);
+
+    expect(outputs.map((output) => output.source)).toEqual(['main.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      '\\begin{verbatim}\n```\n\\end{verbatim}\nTail.\n',
+    );
+  });
+
+  it('strips an outer documents envelope before filename-label recovery', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      ['<documents>', 'main.tex:', 'Recovered body.', '</documents>'].join(
+        '\n',
+      ),
+    );
+    const manager = createXmlManager('documents', ['main.tex']);
+
+    const outputs = await splitDocuments(manager);
+
+    expect(outputs.map((output) => output.source)).toEqual(['main.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      'Recovered body.\n',
+    );
+  });
+
   it('drops a bare label that triggers single-input prefix synthesis', async () => {
     await AbsoluteFS.write(
       '/tmp/run/output.xml',
@@ -1496,6 +1612,64 @@ Appendix.
     expect(outputs.map((output) => output.source)).toEqual(['ocr_result.tex']);
     await expect(AbsoluteFS.read('/tmp/run/ocr_result.tex')).resolves.toBe(
       'Transcribed content.\n',
+    );
+  });
+
+  it('coalesces repeated labels for the sole declared output', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        'ocr_result.tex:',
+        '```latex',
+        'Page one transcription.',
+        '```',
+        '',
+        'ocr_result.tex:',
+        '```latex',
+        'Page two transcription.',
+        '```',
+      ].join('\n'),
+    );
+
+    const outputs =
+      await createSingleArtifactManager().splitScratchpadMultipleOutputXml(
+        createExternalLocation('/tmp/run/output.xml'),
+        'documents',
+        0,
+        'scratchpad',
+        [createExternalLocation('/tmp/run/ocr_result.tex')],
+      );
+
+    expect(outputs.map((output) => output.source)).toEqual(['ocr_result.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/ocr_result.tex')).resolves.toBe(
+      'Page one transcription.\n\nPage two transcription.\n',
+    );
+    await expect(AbsoluteFS.exists('/tmp/run/ocr_result-2.tex')).resolves.toBe(
+      false,
+    );
+  });
+
+  it('does not concatenate later explanatory fences for single-input edits', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '```latex',
+        'Revised paper body.',
+        '```',
+        '',
+        'Explanation:',
+        '```latex',
+        '\\LaTeX{} example, not output.',
+        '```',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents', ['paper.tex']);
+
+    const outputs = await splitDocuments(manager);
+
+    expect(outputs.map((output) => output.source)).toEqual(['paper.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/paper.tex')).resolves.toBe(
+      'Revised paper body.\n',
     );
   });
 
@@ -1892,5 +2066,25 @@ describe('assignByContentSimilarity', () => {
     expect(assigned.filter(Boolean)).toHaveLength(2);
     expect(assigned[0]?.name).toBe('b.tex');
     expect(assigned[1]?.name).toBe('a.tex');
+  });
+
+  it('does not route a repeated block to a weaker secondary file', () => {
+    const main =
+      '\\documentclass{article}\n\\begin{document}\nMain result.\n\\end{document}';
+    const mainRevision =
+      '\\documentclass{article}\n\\begin{document}\nRevised main result.\n\\end{document}';
+    const appendix =
+      '\\documentclass{article}\n\\begin{document}\nAppendix result.\n\\end{document}';
+
+    const assigned = assignByContentSimilarity(
+      [mainRevision, mainRevision],
+      [
+        { name: 'main.tex', content: main },
+        { name: 'appendix.tex', content: appendix },
+      ],
+    );
+
+    expect(assigned[0]?.name).toBe('main.tex');
+    expect(assigned[1]).toBeNull();
   });
 });

--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -1282,7 +1282,9 @@ Appendix.
   // accepting several attached input files. runReflectionFlow.ts then builds
   // baseFiles from outputFiles, not inputFiles, so baseFiles[i] no longer
   // corresponds to inputFiles[i].
-  function createSingleArtifactManager(): XmlOutputManager {
+  function createSingleArtifactManager(
+    inputFiles: string[] = ['page1.png', 'page2.png'],
+  ): XmlOutputManager {
     return new XmlOutputManager(
       {
         agentCategory: AgentCategory.Workflow,
@@ -1299,7 +1301,7 @@ Appendix.
         prefills: [],
       },
       {
-        inputFiles: ['page1.png', 'page2.png'],
+        inputFiles,
         outputFiles: ['ocr_result.tex'],
       } as unknown as AgentConfig,
       {
@@ -1312,9 +1314,11 @@ Appendix.
     );
   }
 
-  it('skips content-similarity matching for single-artifact-from-many-inputs agents', async () => {
-    // Content-similarity matching must not run in this shape, or it would
-    // label a block with the wrong name.
+  it('recovers an unlabeled fence under the declared output name for single-artifact agents', async () => {
+    // Content-similarity matching against inputFiles must not run in this
+    // shape (it would label the block with an input media name); instead the
+    // single-document recovery names the block after the sole declared
+    // output.
     await AbsoluteFS.write(
       '/tmp/run/output.xml',
       ['```latex', 'Unlabeled recovered content.', '```'].join('\n'),
@@ -1329,12 +1333,17 @@ Appendix.
         [createExternalLocation('/tmp/run/ocr_result.tex')],
       );
 
-    expect(outputs).toEqual([]);
+    expect(outputs.map((output) => output.source)).toEqual(['ocr_result.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/ocr_result.tex')).resolves.toBe(
+      'Unlabeled recovered content.\n',
+    );
   });
 
   it('ignores bare labels naming an input when the agent declares outputFiles', async () => {
     // For single-artifact agents the inputs can be media files the response
-    // mentions in prose; a `page1.png:` line must not become a document.
+    // mentions in prose; a `page1.png:` line must never become a document
+    // named after the input. The fenced content is still recovered, but
+    // under the sole declared output name.
     await AbsoluteFS.write(
       '/tmp/run/output.xml',
       ['page1.png:', '```latex', 'Transcribed content.', '```'].join('\n'),
@@ -1349,7 +1358,34 @@ Appendix.
         [createExternalLocation('/tmp/run/ocr_result.tex')],
       );
 
-    expect(outputs).toEqual([]);
+    expect(outputs.map((output) => output.source)).toEqual(['ocr_result.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/ocr_result.tex')).resolves.toBe(
+      'Transcribed content.\n',
+    );
+  });
+
+  it('synthesizes an unlabeled prefix under the declared output name, not the input', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      ['\\section{Transcription}', 'Intro.', 'ocr_result.tex:', 'More.'].join(
+        '\n',
+      ),
+    );
+
+    const outputs = await createSingleArtifactManager([
+      'paper.tex',
+    ]).splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+      'scratchpad',
+      [createExternalLocation('/tmp/run/ocr_result.tex')],
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual(['ocr_result.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/ocr_result.tex')).resolves.toBe(
+      '\\section{Transcription}\nIntro.\nMore.\n',
+    );
   });
 
   it('recovers a bare label naming a declared output file', async () => {
@@ -1455,6 +1491,129 @@ Appendix.
     );
   });
 
+  it('matches later-round unlabeled fences against the previous round outputs', async () => {
+    // Round-0 originals are placeholders that no longer resemble the content
+    // being revised; only the previous round's outputs do. The similarity
+    // fallback must compare against those, or every later-round recovery
+    // would score below the threshold and drop the round.
+    await AbsoluteFS.ensureDir('/tmp/run/r0');
+    await AbsoluteFS.ensureDir('/tmp/run/r1');
+    await AbsoluteFS.write('/tmp/run/appendices.tex', 'placeholder A');
+    await AbsoluteFS.write('/tmp/run/cost_section.tex', 'placeholder B');
+    await AbsoluteFS.write(
+      '/tmp/run/r0/appendices.tex',
+      '\\appendix\n\\section{Agent architecture}\nThe formalization system uses a multi-agent architecture with shared memory.\n',
+    );
+    await AbsoluteFS.write(
+      '/tmp/run/r0/cost_section.tex',
+      '% !TEX root = Draft3SM.tex\n\\section{Computational cost}\nPreliminary numbers from the interactive logs.\n',
+    );
+    await AbsoluteFS.write(
+      '/tmp/run/r1/output.xml',
+      [
+        '```latex',
+        '% !TEX root = Draft3SM.tex',
+        '\\section{Computational cost}',
+        'Final numbers from the interactive logs.',
+        '```',
+        '',
+        '```latex',
+        '\\appendix',
+        '\\section{Agent architecture}',
+        'The formalization system uses a revised multi-agent architecture with shared memory.',
+        '```',
+      ].join('\n'),
+    );
+
+    const manager = createXmlManager('documents', [
+      'appendices.tex',
+      'cost_section.tex',
+    ]);
+    const roundDataByRound = new Map<number, RoundOutput>();
+    const ensureRound = (round: number): RoundOutput => {
+      const existing = roundDataByRound.get(round);
+      if (existing) return existing;
+      const data: RoundOutput = {
+        round,
+        rawOutput: null,
+        outputs: [],
+        compileFailures: [],
+        xmlSummary: {
+          tagContents: {},
+          documents: [],
+          singleOutputFile: null,
+          sourceLocation: null,
+        },
+      };
+      roundDataByRound.set(round, data);
+      return data;
+    };
+    ensureRound(0).outputs = [
+      {
+        source: 'appendices.tex',
+        round: 0,
+        location: createExternalLocation('/tmp/run/r0/appendices.tex'),
+        lineage: null,
+        diff: null,
+      },
+      {
+        source: 'cost_section.tex',
+        round: 0,
+        location: createExternalLocation('/tmp/run/r0/cost_section.tex'),
+        lineage: null,
+        diff: null,
+      },
+    ];
+    let roundOutputs: OutputFileInfo[] = [];
+    const processor = new OutputFileProcessor({
+      agentSetting: {
+        agentCategory: AgentCategory.Workflow,
+        documentTag: 'documents',
+        endTag: '</documents>',
+        temperature: 0,
+        requiredFiles: {},
+        requiredFilesInternal: {},
+        defaultOutputFiles: [],
+        filePatternsContain: [],
+        tools: [],
+        isRewrite: true,
+        rounds: 2,
+        prefills: [],
+      },
+      baseFiles: [
+        createExternalLocation('/tmp/run/appendices.tex'),
+        createExternalLocation('/tmp/run/cost_section.tex'),
+      ],
+      streamId: 'stream',
+      runtimeHost: { emit: vi.fn() } as unknown as AgentRuntimeHost,
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        domain: vi.fn(),
+      } as unknown as AgentTrace,
+      xmlManager: manager,
+      setRoundOutputs: (_round, outputs) => {
+        roundOutputs = outputs;
+      },
+      ensureRoundData: ensureRound,
+    });
+
+    await processor.processMultipleOutputs(
+      createExternalLocation('/tmp/run/r1/output.xml'),
+      1,
+      createExternalLocation('/tmp/run/r1/output.xml'),
+    );
+
+    expect(roundOutputs.map((output) => output.source).sort()).toEqual([
+      'appendices.tex',
+      'cost_section.tex',
+    ]);
+    await expect(AbsoluteFS.read('/tmp/run/r1/cost_section.tex')).resolves.toBe(
+      '% !TEX root = Draft3SM.tex\n\\section{Computational cost}\nFinal numbers from the interactive logs.\n',
+    );
+  });
+
   it('reports input files left unmatched by content-similarity recovery', async () => {
     const costOriginal =
       '\\section{Computational cost}\nPreliminary numbers from the local interactive logs.\n';
@@ -1510,5 +1669,23 @@ describe('assignByContentSimilarity', () => {
     // above the threshold through the shared boilerplate).
     expect(assigned[1]?.name).toBe('cost.tex');
     expect(assigned[0]).toBeNull();
+  });
+
+  it('keeps an exact unchanged output over a weak stray snippet', () => {
+    const original =
+      'line one shared\nline two original content here\nline three original content here';
+    const snippet =
+      'line one shared\nwholly different discussion\nabout unrelated things';
+
+    const assigned = assignByContentSimilarity(
+      [original, snippet],
+      [{ name: 'f.tex', content: `${original}\n` }],
+    );
+
+    // The snippet clears the routing threshold but is far too dissimilar to
+    // be a credible revision, so it must not displace the exact copy (a
+    // legitimately unchanged output) from its file.
+    expect(assigned[0]?.name).toBe('f.tex');
+    expect(assigned[1]).toBeNull();
   });
 });

--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -50,6 +50,7 @@ function createXmlManager(
     },
     {
       inputFiles,
+      outputFiles: [],
     } as AgentConfig,
     { debug: vi.fn(), info: vi.fn() } as unknown as AgentTrace,
     new TaskRunFileService(),
@@ -1171,5 +1172,49 @@ Appendix.
     await expect(AbsoluteFS.read('/tmp/run/cost_section.tex')).resolves.toBe(
       '% !TEX root = Draft3SM.tex\n\\section{Computational cost}\nRevised numbers from the local interactive logs.\n',
     );
+  });
+
+  it('skips content-similarity matching for single-artifact-from-many-inputs agents', async () => {
+    // Agents like ocr/paper2slide declare one defaultOutputFiles entry while
+    // accepting several attached input files. runReflectionFlow.ts then
+    // builds baseFiles from outputFiles, not inputFiles, so baseFiles[i] no
+    // longer corresponds to inputFiles[i] — content-similarity matching must
+    // not run in this shape, or it would label a block with the wrong name.
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      ['```latex', 'Unlabeled recovered content.', '```'].join('\n'),
+    );
+    const manager = new XmlOutputManager(
+      {
+        agentCategory: AgentCategory.Workflow,
+        documentTag: 'documents',
+        endTag: '</documents>',
+        temperature: 0,
+        requiredFiles: {},
+        requiredFilesInternal: {},
+        defaultOutputFiles: ['ocr_result.tex'],
+        filePatternsContain: [],
+        tools: [],
+        isRewrite: true,
+        rounds: 1,
+        prefills: [],
+      },
+      {
+        inputFiles: ['page1.png', 'page2.png'],
+        outputFiles: ['ocr_result.tex'],
+      } as AgentConfig,
+      { debug: vi.fn(), info: vi.fn(), warn: vi.fn() } as unknown as AgentTrace,
+      new TaskRunFileService(),
+    );
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+      'scratchpad',
+      [createExternalLocation('/tmp/run/ocr_result.tex')],
+    );
+
+    expect(outputs).toEqual([]);
   });
 });

--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AgentTrace } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { assignByContentSimilarity } from '@agent/output/extraction/contentSimilarity';
 import { OutputFileProcessor } from '@agent/output/OutputFileProcessor';
 import { XmlOutputManager } from '@agent/output/XmlOutputManager';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
@@ -1171,6 +1172,53 @@ Appendix.
     );
   });
 
+  it('drops a bare label that triggers single-input prefix synthesis', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      ['\\section{Intro}', 'Text.', 'paper.tex:', 'More text.'].join('\n'),
+    );
+    const manager = createXmlManager('documents', ['paper.tex']);
+
+    const outputs = await splitDocuments(manager);
+
+    expect(outputs.map((output) => output.source)).toEqual(['paper.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/paper.tex')).resolves.toBe(
+      '\\section{Intro}\nText.\nMore text.\n',
+    );
+  });
+
+  it('splits on a bare label even after preamble-only content', async () => {
+    // Unlike a % header, a bare label is never a LaTeX comment, so the
+    // "maybe this is a preamble comment" lookahead must not swallow the
+    // label separating a preamble-only file from the next document.
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        'main.tex:',
+        '\\documentclass{article}',
+        '\\usepackage{amsmath}',
+        'body.tex:',
+        '\\begin{document}',
+        'Hi.',
+        '\\end{document}',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents', ['main.tex', 'body.tex']);
+
+    const outputs = await splitDocuments(manager);
+
+    expect(outputs.map((output) => output.source)).toEqual([
+      'main.tex',
+      'body.tex',
+    ]);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      '\\documentclass{article}\n\\usepackage{amsmath}\n',
+    );
+    await expect(AbsoluteFS.read('/tmp/run/body.tex')).resolves.toBe(
+      '\\begin{document}\nHi.\n\\end{document}\n',
+    );
+  });
+
   it('falls back to content-similarity matching for unlabeled fenced blocks against the original inputs', async () => {
     const appendicesOriginal =
       '\\appendix\n\\section{Agent architecture}\nThe formalization system uses a multi-agent architecture with a shared Lean repository.\n';
@@ -1437,5 +1485,30 @@ Appendix.
     );
 
     expect(outputs.map((output) => output.source)).toEqual(['cost.tex']);
+  });
+});
+
+describe('assignByContentSimilarity', () => {
+  it('never routes a quoted original to a different, merely-similar file', () => {
+    const costOriginal =
+      'shared preamble line\ncontent about cost analysis\nshared footer line';
+    const archOriginal =
+      'shared preamble line\ncontent about system architecture\nshared footer line';
+    const costRevision =
+      'shared preamble line\ncontent about revised cost analysis\nshared footer line';
+
+    const assigned = assignByContentSimilarity(
+      [costOriginal, costRevision],
+      [
+        { name: 'cost.tex', content: `${costOriginal}\n` },
+        { name: 'arch.tex', content: `${archOriginal}\n` },
+      ],
+    );
+
+    // The revision claims cost.tex; the verbatim quote of cost.tex must stay
+    // unmatched instead of falling back to arch.tex (which it resembles well
+    // above the threshold through the shared boilerplate).
+    expect(assigned[1]?.name).toBe('cost.tex');
+    expect(assigned[0]).toBeNull();
   });
 });

--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -1186,7 +1186,7 @@ Appendix.
         'Macro definitions.',
         '```',
         '',
-        '**_helpers.tex**:',
+        '**_helpers.tex_**:',
         '```latex',
         'Helper macros.',
         '```',
@@ -1396,6 +1396,28 @@ Appendix.
       ['<documents>', 'main.tex:', 'Recovered body.', '</documents>'].join(
         '\n',
       ),
+    );
+    const manager = createXmlManager('documents', ['main.tex']);
+
+    const outputs = await splitDocuments(manager);
+
+    expect(outputs.map((output) => output.source)).toEqual(['main.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      'Recovered body.\n',
+    );
+  });
+
+  it('strips an outer documents envelope inside a markdown wrapper', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '```xml',
+        '<documents>',
+        'main.tex:',
+        'Recovered body.',
+        '</documents>',
+        '```',
+      ].join('\n'),
     );
     const manager = createXmlManager('documents', ['main.tex']);
 
@@ -1706,6 +1728,37 @@ Appendix.
     expect(outputs.map((output) => output.source)).toEqual(['ocr_result.tex']);
     await expect(AbsoluteFS.read('/tmp/run/ocr_result.tex')).resolves.toBe(
       'Page one transcription.\n\nPage two transcription.\n',
+    );
+  });
+
+  it('does not coalesce explanatory fences after a sole-output header chunk', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        'ocr_result.tex:',
+        '```latex',
+        'Page one transcription.',
+        '```',
+        '',
+        'Explanation:',
+        '```latex',
+        '\\LaTeX{} example, not output.',
+        '```',
+      ].join('\n'),
+    );
+
+    const outputs =
+      await createSingleArtifactManager().splitScratchpadMultipleOutputXml(
+        createExternalLocation('/tmp/run/output.xml'),
+        'documents',
+        0,
+        'scratchpad',
+        [createExternalLocation('/tmp/run/ocr_result.tex')],
+      );
+
+    expect(outputs.map((output) => output.source)).toEqual(['ocr_result.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/ocr_result.tex')).resolves.toBe(
+      'Page one transcription.\n',
     );
   });
 

--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -1054,4 +1054,122 @@ Appendix.
       '\\[\n  f(x)=x^4-2x^2+1.\n\\]\n',
     );
   });
+
+  it('recovers documents from bare filename labels with no % prefix', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '## Reflection',
+        '',
+        'Some narrative text about what changed.',
+        '',
+        'Draft/LeanMPSPaper/Draft3.tex:',
+        '```latex',
+        '\\documentclass{article}',
+        '\\begin{document}',
+        'Body one.',
+        '\\end{document}',
+        '```',
+        '',
+        'Draft/LeanMPSPaper/endmatter.tex:',
+        '```latex',
+        'End matter body.',
+        '```',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents', [
+      'Draft/LeanMPSPaper/Draft3.tex',
+      'Draft/LeanMPSPaper/endmatter.tex',
+    ]);
+
+    const outputs = await splitDocuments(manager);
+
+    expect(outputs.map((output) => output.source)).toEqual([
+      'Draft/LeanMPSPaper/Draft3.tex',
+      'Draft/LeanMPSPaper/endmatter.tex',
+    ]);
+    await expect(
+      AbsoluteFS.read('/tmp/run/Draft/LeanMPSPaper/Draft3.tex'),
+    ).resolves.toBe(
+      '\\documentclass{article}\n\\begin{document}\nBody one.\n\\end{document}\n',
+    );
+    await expect(
+      AbsoluteFS.read('/tmp/run/Draft/LeanMPSPaper/endmatter.tex'),
+    ).resolves.toBe('End matter body.\n');
+  });
+
+  it('matches a bare label by basename when the model drops the directory prefix', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      ['Draft3.tex:', '```latex', 'Recovered by basename.', '```'].join('\n'),
+    );
+    const manager = createXmlManager('documents', [
+      'Draft/LeanMPSPaper/Draft3.tex',
+    ]);
+
+    const outputs = await splitDocuments(manager);
+
+    expect(outputs.map((output) => output.source)).toEqual([
+      'Draft/LeanMPSPaper/Draft3.tex',
+    ]);
+  });
+
+  it('falls back to content-similarity matching for unlabeled fenced blocks against the original inputs', async () => {
+    const appendicesOriginal =
+      '\\appendix\n\\section{Agent architecture}\nThe formalization system uses a multi-agent architecture with a shared Lean repository.\n';
+    const costSectionOriginal =
+      '% !TEX root = Draft3SM.tex\n\\section{Computational cost}\nPreliminary numbers from the local interactive logs.\n';
+
+    await AbsoluteFS.write('/tmp/run/appendices.tex', appendicesOriginal);
+    await AbsoluteFS.write('/tmp/run/cost_section.tex', costSectionOriginal);
+
+    // Response order is deliberately swapped relative to inputFiles, and
+    // neither fence carries any filename label, to prove the match is
+    // driven by content rather than declaration or response order.
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '# Phase 2: Revised Documents',
+        '',
+        '```latex',
+        '% !TEX root = Draft3SM.tex',
+        '\\section{Computational cost}',
+        'Revised numbers from the local interactive logs.',
+        '```',
+        '',
+        '```latex',
+        '\\appendix',
+        '\\section{Agent architecture}',
+        'The formalization system uses a multi-agent architecture with a persistent shared memory.',
+        '```',
+      ].join('\n'),
+    );
+
+    const manager = createXmlManager('documents', [
+      'appendices.tex',
+      'cost_section.tex',
+    ]);
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+      'scratchpad',
+      [
+        createExternalLocation('/tmp/run/appendices.tex'),
+        createExternalLocation('/tmp/run/cost_section.tex'),
+      ],
+    );
+
+    expect(outputs.map((output) => output.source).sort()).toEqual([
+      'appendices.tex',
+      'cost_section.tex',
+    ]);
+    await expect(AbsoluteFS.read('/tmp/run/appendices.tex')).resolves.toBe(
+      '\\appendix\n\\section{Agent architecture}\nThe formalization system uses a multi-agent architecture with a persistent shared memory.\n',
+    );
+    await expect(AbsoluteFS.read('/tmp/run/cost_section.tex')).resolves.toBe(
+      '% !TEX root = Draft3SM.tex\n\\section{Computational cost}\nRevised numbers from the local interactive logs.\n',
+    );
+  });
 });

--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -1172,6 +1172,64 @@ Appendix.
     );
   });
 
+  it('matches bare labels with leading underscores and emphasis decoration', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '_macros.tex:',
+        '```latex',
+        'Macro definitions.',
+        '```',
+        '',
+        '**_helpers.tex**:',
+        '```latex',
+        'Helper macros.',
+        '```',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents', [
+      '_macros.tex',
+      '_helpers.tex',
+    ]);
+
+    const outputs = await splitDocuments(manager);
+
+    expect(outputs.map((output) => output.source)).toEqual([
+      '_macros.tex',
+      '_helpers.tex',
+    ]);
+  });
+
+  it('keeps a bare label inside a verbatim block instead of splitting the fragment', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        'main.tex:',
+        '\\section{Listing}',
+        '\\begin{verbatim}',
+        'appendix.tex:',
+        '\\end{verbatim}',
+        'Tail.',
+        'appendix.tex:',
+        'Appendix content.',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents', ['main.tex', 'appendix.tex']);
+
+    const outputs = await splitDocuments(manager);
+
+    expect(outputs.map((output) => output.source)).toEqual([
+      'main.tex',
+      'appendix.tex',
+    ]);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      '\\section{Listing}\n\\begin{verbatim}\nappendix.tex:\n\\end{verbatim}\nTail.\n',
+    );
+    await expect(AbsoluteFS.read('/tmp/run/appendix.tex')).resolves.toBe(
+      'Appendix content.\n',
+    );
+  });
+
   it('drops a bare label that triggers single-input prefix synthesis', async () => {
     await AbsoluteFS.write(
       '/tmp/run/output.xml',

--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -1367,6 +1367,27 @@ Appendix.
     );
   });
 
+  it('recovers a single plain output inside a prefaced text fence', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        'Here is the file:',
+        '```text',
+        'main.tex:',
+        'A plain paragraph with no command-looking LaTeX.',
+        '```',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents', ['main.tex']);
+
+    const outputs = await splitDocuments(manager);
+
+    expect(outputs.map((output) => output.source)).toEqual(['main.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      'A plain paragraph with no command-looking LaTeX.\n',
+    );
+  });
+
   it('keeps inner fence delimiters inside fenced LaTeX fragments', async () => {
     await AbsoluteFS.write(
       '/tmp/run/output.xml',
@@ -1422,6 +1443,30 @@ Appendix.
     const manager = createXmlManager('documents', ['main.tex']);
 
     const outputs = await splitDocuments(manager);
+
+    expect(outputs.map((output) => output.source)).toEqual(['main.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
+      'Recovered body.\n',
+    );
+  });
+
+  it('strips the configured outer wrapper before filename-label recovery', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '<latex_documents>',
+        'main.tex:',
+        'Recovered body.',
+        '</latex_documents>',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('latex_documents', ['main.tex']);
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'latex_documents',
+      0,
+    );
 
     expect(outputs.map((output) => output.source)).toEqual(['main.tex']);
     await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
@@ -2160,9 +2205,8 @@ describe('assignByContentSimilarity', () => {
       [{ name: 'f.tex', content: `${original}\n` }],
     );
 
-    // The snippet clears the routing threshold but is far too dissimilar to
-    // be a credible revision, so it must not displace the exact copy (a
-    // legitimately unchanged output) from its file.
+    // The snippet is too weak to be a credible revision, so it must not
+    // displace the exact copy (a legitimately unchanged output) from its file.
     expect(assigned[0]?.name).toBe('f.tex');
     expect(assigned[1]).toBeNull();
   });
@@ -2197,6 +2241,20 @@ describe('assignByContentSimilarity', () => {
       ],
     );
 
+    expect(assigned[0]?.name).toBe('main.tex');
+    expect(assigned[1]).toBeNull();
+  });
+
+  it('keeps one exact copy when unchanged output is repeated', () => {
+    const original =
+      '\\documentclass{article}\n\\begin{document}\nUnchanged.\n\\end{document}';
+
+    const assigned = assignByContentSimilarity(
+      [original, original],
+      [{ name: 'main.tex', content: original }],
+    );
+
+    expect(assigned.filter(Boolean)).toHaveLength(1);
     expect(assigned[0]?.name).toBe('main.tex');
     expect(assigned[1]).toBeNull();
   });

--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -51,8 +51,12 @@ function createXmlManager(
     {
       inputFiles,
       outputFiles: [],
-    } as AgentConfig,
-    { debug: vi.fn(), info: vi.fn() } as unknown as AgentTrace,
+    } as unknown as AgentConfig,
+    {
+      debug: vi.fn(),
+      info: vi.fn(),
+      domain: vi.fn(),
+    } as unknown as AgentTrace,
     new TaskRunFileService(),
   );
 }
@@ -1115,6 +1119,58 @@ Appendix.
     ]);
   });
 
+  it('matches a bare label whose path uses Windows separators or a ./ prefix', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        'Draft\\LeanMPSPaper\\Draft3.tex:',
+        '```latex',
+        'Body via backslashes.',
+        '```',
+        '',
+        './Draft/LeanMPSPaper/endmatter.tex:',
+        '```latex',
+        'Body via dot-slash.',
+        '```',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents', [
+      'Draft/LeanMPSPaper/Draft3.tex',
+      'Draft/LeanMPSPaper/endmatter.tex',
+    ]);
+
+    const outputs = await splitDocuments(manager);
+
+    expect(outputs.map((output) => output.source)).toEqual([
+      'Draft/LeanMPSPaper/Draft3.tex',
+      'Draft/LeanMPSPaper/endmatter.tex',
+    ]);
+  });
+
+  it('drops a bare label line inside a synthesized single-input document body', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '\\section{Intro}',
+        'Text.',
+        '% paper.tex',
+        'More text.',
+        'paper.tex:',
+        'Final text.',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents', ['paper.tex']);
+
+    const outputs = await splitDocuments(manager);
+
+    expect(outputs.map((output) => output.source)).toEqual(['paper.tex']);
+    // The % header stays (it is a valid LaTeX comment); the bare label is
+    // not LaTeX and must not leak into the recovered document.
+    await expect(AbsoluteFS.read('/tmp/run/paper.tex')).resolves.toBe(
+      '\\section{Intro}\nText.\n% paper.tex\nMore text.\nFinal text.\n',
+    );
+  });
+
   it('falls back to content-similarity matching for unlabeled fenced blocks against the original inputs', async () => {
     const appendicesOriginal =
       '\\appendix\n\\section{Agent architecture}\nThe formalization system uses a multi-agent architecture with a shared Lean repository.\n';
@@ -1174,17 +1230,12 @@ Appendix.
     );
   });
 
-  it('skips content-similarity matching for single-artifact-from-many-inputs agents', async () => {
-    // Agents like ocr/paper2slide declare one defaultOutputFiles entry while
-    // accepting several attached input files. runReflectionFlow.ts then
-    // builds baseFiles from outputFiles, not inputFiles, so baseFiles[i] no
-    // longer corresponds to inputFiles[i] — content-similarity matching must
-    // not run in this shape, or it would label a block with the wrong name.
-    await AbsoluteFS.write(
-      '/tmp/run/output.xml',
-      ['```latex', 'Unlabeled recovered content.', '```'].join('\n'),
-    );
-    const manager = new XmlOutputManager(
+  // Agents like ocr/paper2slide declare one defaultOutputFiles entry while
+  // accepting several attached input files. runReflectionFlow.ts then builds
+  // baseFiles from outputFiles, not inputFiles, so baseFiles[i] no longer
+  // corresponds to inputFiles[i].
+  function createSingleArtifactManager(): XmlOutputManager {
+    return new XmlOutputManager(
       {
         agentCategory: AgentCategory.Workflow,
         documentTag: 'documents',
@@ -1202,19 +1253,189 @@ Appendix.
       {
         inputFiles: ['page1.png', 'page2.png'],
         outputFiles: ['ocr_result.tex'],
-      } as AgentConfig,
-      { debug: vi.fn(), info: vi.fn(), warn: vi.fn() } as unknown as AgentTrace,
+      } as unknown as AgentConfig,
+      {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        domain: vi.fn(),
+      } as unknown as AgentTrace,
       new TaskRunFileService(),
     );
+  }
+
+  it('skips content-similarity matching for single-artifact-from-many-inputs agents', async () => {
+    // Content-similarity matching must not run in this shape, or it would
+    // label a block with the wrong name.
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      ['```latex', 'Unlabeled recovered content.', '```'].join('\n'),
+    );
+
+    const outputs =
+      await createSingleArtifactManager().splitScratchpadMultipleOutputXml(
+        createExternalLocation('/tmp/run/output.xml'),
+        'documents',
+        0,
+        'scratchpad',
+        [createExternalLocation('/tmp/run/ocr_result.tex')],
+      );
+
+    expect(outputs).toEqual([]);
+  });
+
+  it('ignores bare labels naming an input when the agent declares outputFiles', async () => {
+    // For single-artifact agents the inputs can be media files the response
+    // mentions in prose; a `page1.png:` line must not become a document.
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      ['page1.png:', '```latex', 'Transcribed content.', '```'].join('\n'),
+    );
+
+    const outputs =
+      await createSingleArtifactManager().splitScratchpadMultipleOutputXml(
+        createExternalLocation('/tmp/run/output.xml'),
+        'documents',
+        0,
+        'scratchpad',
+        [createExternalLocation('/tmp/run/ocr_result.tex')],
+      );
+
+    expect(outputs).toEqual([]);
+  });
+
+  it('recovers a bare label naming a declared output file', async () => {
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      ['ocr_result.tex:', '```latex', 'Transcribed content.', '```'].join('\n'),
+    );
+
+    const outputs =
+      await createSingleArtifactManager().splitScratchpadMultipleOutputXml(
+        createExternalLocation('/tmp/run/output.xml'),
+        'documents',
+        0,
+        'scratchpad',
+        [createExternalLocation('/tmp/run/ocr_result.tex')],
+      );
+
+    expect(outputs.map((output) => output.source)).toEqual(['ocr_result.tex']);
+    await expect(AbsoluteFS.read('/tmp/run/ocr_result.tex')).resolves.toBe(
+      'Transcribed content.\n',
+    );
+  });
+
+  it('leaves an unlabeled block unmatched when identical base files make the match ambiguous', async () => {
+    const stub = '\\section{Stub}\nShared template content.\n';
+    await AbsoluteFS.write('/tmp/run/a.tex', stub);
+    await AbsoluteFS.write('/tmp/run/b.tex', stub);
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '```latex',
+        '\\section{Stub}',
+        'Shared template content, revised.',
+        '```',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents', ['a.tex', 'b.tex']);
 
     const outputs = await manager.splitScratchpadMultipleOutputXml(
       createExternalLocation('/tmp/run/output.xml'),
       'documents',
       0,
       'scratchpad',
-      [createExternalLocation('/tmp/run/ocr_result.tex')],
+      [
+        createExternalLocation('/tmp/run/a.tex'),
+        createExternalLocation('/tmp/run/b.tex'),
+      ],
     );
 
+    // Both base files score identically, so there is no evidence which one
+    // the block revises — refusing to guess beats corrupting one of them.
     expect(outputs).toEqual([]);
+  });
+
+  it('routes the revision, not the echoed original, when the model quotes both', async () => {
+    const costOriginal =
+      '\\section{Computational cost}\nPreliminary numbers from the local interactive logs.\n';
+    const archOriginal =
+      '\\appendix\n\\section{Agent architecture}\nThe formalization system uses a multi-agent architecture.\n';
+    await AbsoluteFS.write('/tmp/run/cost.tex', costOriginal);
+    await AbsoluteFS.write('/tmp/run/arch.tex', archOriginal);
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        'The original cost section for reference:',
+        '```latex',
+        '\\section{Computational cost}',
+        'Preliminary numbers from the local interactive logs.',
+        '```',
+        '',
+        'And my revision:',
+        '```latex',
+        '\\section{Computational cost}',
+        'Final numbers from the local interactive logs.',
+        '```',
+        '',
+        '```latex',
+        '\\appendix',
+        '\\section{Agent architecture}',
+        'The formalization system uses a revised multi-agent architecture.',
+        '```',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents', ['cost.tex', 'arch.tex']);
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+      'scratchpad',
+      [
+        createExternalLocation('/tmp/run/cost.tex'),
+        createExternalLocation('/tmp/run/arch.tex'),
+      ],
+    );
+
+    expect(outputs.map((output) => output.source).sort()).toEqual([
+      'arch.tex',
+      'cost.tex',
+    ]);
+    await expect(AbsoluteFS.read('/tmp/run/cost.tex')).resolves.toBe(
+      '\\section{Computational cost}\nFinal numbers from the local interactive logs.\n',
+    );
+  });
+
+  it('reports input files left unmatched by content-similarity recovery', async () => {
+    const costOriginal =
+      '\\section{Computational cost}\nPreliminary numbers from the local interactive logs.\n';
+    const archOriginal =
+      '\\appendix\n\\section{Agent architecture}\nThe formalization system uses a multi-agent architecture.\n';
+    await AbsoluteFS.write('/tmp/run/cost.tex', costOriginal);
+    await AbsoluteFS.write('/tmp/run/arch.tex', archOriginal);
+    await AbsoluteFS.write(
+      '/tmp/run/output.xml',
+      [
+        '```latex',
+        '\\section{Computational cost}',
+        'Final numbers from the local interactive logs.',
+        '```',
+      ].join('\n'),
+    );
+    const manager = createXmlManager('documents', ['cost.tex', 'arch.tex']);
+
+    const outputs = await manager.splitScratchpadMultipleOutputXml(
+      createExternalLocation('/tmp/run/output.xml'),
+      'documents',
+      0,
+      'scratchpad',
+      [
+        createExternalLocation('/tmp/run/cost.tex'),
+        createExternalLocation('/tmp/run/arch.tex'),
+      ],
+    );
+
+    expect(outputs.map((output) => output.source)).toEqual(['cost.tex']);
   });
 });


### PR DESCRIPTION
## Summary
- Reflection-flow agents sometimes return revised documents as bare filename labels (`path/to/file.tex:`) with no `%` prefix, or as fully unlabeled ```latex fences, instead of the expected `<document name="...">` tags or `%`-comment headers. Before this PR, those rounds could silently drop all extracted files.
- Add a fallback tier that recognizes a header line naming one of the agent's expected output files (declared `outputFiles` when present, else the inputs), with or without the `%` prefix. Matching normalizes separators and `./`, allows unambiguous basename matches, and avoids interpreting labels inside literal LaTeX or pre-output example fences as document boundaries.
- Add a last-resort fallback for multi-input agents: match fully unlabeled fenced blocks against the base files by content similarity, using `diff-match-patch`. Assignment is greedy, highest-confidence pair first; it refuses exact score ties, demotes echoed originals, logs unmatched files, and logs discarded unclosed fences at debug level.
- For single-artifact agents with one declared output and several unlabeled fenced chunks, concatenate or coalesce the chunks into the sole output instead of silently taking only the first fence; in-place single-input edits keep the legacy first-document behavior.
- Refactor: the fallback-extraction machinery moved out of `XmlOutputManager.ts` into focused modules under `src/agent/output/extraction/` (`responseText`, `markdownFences`, `latexHeuristics`, `filenameHeaders`, `contentSimilarity`). The fence/header recovery now strips only matching outer fences, preserves shared fences across label splits, ignores unclosed example fences when real headers follow, and strips an outer `<documents>` envelope before header recovery. `XmlOutputManager` keeps the tier pipeline, XML parsing, and file writing.

Verified against the two real-world raw model outputs that originally surfaced this bug (both previously extracted zero files; both now recover correctly) in addition to new unit tests.

## Test plan
- [x] `CI=true corepack pnpm vitest run src/test-kernel/agent/output/` — 7 files, 95 tests pass
- [x] `corepack pnpm exec eslint src/agent/output/XmlOutputManager.ts src/agent/output/extraction/contentSimilarity.ts src/agent/output/extraction/filenameHeaders.ts src/agent/output/extraction/markdownFences.ts src/test-kernel/agent/output/XmlOutputManager.vitest.ts`
- [x] `corepack pnpm exec prettier --check src/agent/output/XmlOutputManager.ts src/agent/output/extraction/contentSimilarity.ts src/agent/output/extraction/filenameHeaders.ts src/agent/output/extraction/markdownFences.ts src/test-kernel/agent/output/XmlOutputManager.vitest.ts`
- [x] `CI=true corepack pnpm run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how agent rounds persist workspace files from malformed model output; wrong heuristics could mis-route LaTeX, but the design favors refusing ambiguous matches and logging gaps over guessing.
> 
> **Overview**
> Fixes reflection rounds that returned **zero extracted files** when models skipped `<document name="…">` tags and `%` comment headers, using bare labels (`path/file.tex:`) or unlabeled ` ```latex ` fences instead.
> 
> **New fallback tiers** in `splitScratchpadMultipleOutputXml`: filename-header recovery ( `%` and bare known-file labels, with fence/LaTeX/verbatim guards), then—for multi-input agents with no declared outputs—**content-similarity** pairing of `latex`/`tex` fenced blocks to base files via `diff-match-patch` (greedy assignment, no ties, echo-of-original demotion). Single declared-output agents get coalesced/concatenated unlabeled chunks under that output name, not input media names.
> 
> **Refactor:** inline logic moved to `src/agent/output/extraction/` (`filenameHeaders`, `contentSimilarity`, `markdownFences`, `latexHeuristics`, `responseText`). `OutputFileProcessor` passes `similarityBaseFiles(currRound)` so later rounds compare against **previous round outputs**, not stale originals. Partial recovery logs missing expected files instead of silent success.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f74d7c727df0a32201b2e71dfd8ad1e4684c5eb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



