### PR TITLE
fix(codex): separate subscription usage accounting

### DIFF
--- a/src/agent/modelHandlers/openai/modelHandlerCodex.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerCodex.ts
@@ -308,8 +308,13 @@ export class ModelHandlerCodex extends ModelHandlerOpenAIResponse {
     return this.usingSubscription() ? false : super.supportsTokenCounting;
   }
 
-  protected override shouldFailWhenFallbackOutputBudgetIsReduced(): boolean {
-    return this.usingSubscription();
+  protected override shouldFailWhenFallbackOutputBudgetIsReduced(
+    inputEstimate: number,
+    _maxOutputTokens: number,
+    contextWindow: number,
+    buffer: number,
+  ): boolean {
+    return this.usingSubscription() && inputEstimate + buffer >= contextWindow;
   }
 
   public override get supportsManualCompaction(): boolean {

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -1161,7 +1161,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    * but such routes cannot enforce a reduced budget. They should fail locally
    * instead of sending a request that the backend will reject opaquely.
    */
-  protected shouldFailWhenFallbackOutputBudgetIsReduced(): boolean {
+  protected shouldFailWhenFallbackOutputBudgetIsReduced(
+    _inputEstimate: number,
+    _maxOutputTokens: number,
+    _contextWindow: number,
+    _buffer: number,
+  ): boolean {
     return false;
   }
 
@@ -1232,7 +1237,14 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     );
     if (capped === maxOutputTokens) return maxOutputTokens;
 
-    if (this.shouldFailWhenFallbackOutputBudgetIsReduced()) {
+    if (
+      this.shouldFailWhenFallbackOutputBudgetIsReduced(
+        inputEstimate,
+        maxOutputTokens,
+        contextWindow,
+        buffer,
+      )
+    ) {
       throw new Error(
         `Token estimate (${inputEstimate}) + output budget (${maxOutputTokens}) + safety buffer (${buffer}) exceeds context window (${contextWindow}), and this route cannot enforce a reduced output budget locally.`,
       );

--- a/src/telemetry/UsageLogService.ts
+++ b/src/telemetry/UsageLogService.ts
@@ -36,6 +36,7 @@ const DEFAULT_CONFIG: UsageLogConfig = {
 
 class UsageLogServiceImpl {
   private queue: UsageLogEntry[] = [];
+  private retryBatch: UsageLogBatch | null = null;
   private flushTimer: NodeJS.Timeout | null = null;
   private activeFlush: Promise<boolean> | null = null;
   private config: UsageLogConfig = DEFAULT_CONFIG;
@@ -85,7 +86,7 @@ class UsageLogServiceImpl {
   }
 
   async flush(): Promise<boolean> {
-    while (this.queue.length > 0 || this.activeFlush) {
+    while (this.retryBatch || this.queue.length > 0 || this.activeFlush) {
       if (this.activeFlush) {
         const madeProgress = await this.activeFlush;
         if (!madeProgress) return false;
@@ -105,7 +106,7 @@ class UsageLogServiceImpl {
   }
 
   private async flushQueuedBatch(): Promise<boolean> {
-    let entries: UsageLogEntry[] = [];
+    let batch: UsageLogBatch | null = null;
     try {
       const token = await SupabaseClient.getRelayAccessToken();
       if (!token) {
@@ -113,18 +114,23 @@ class UsageLogServiceImpl {
         return false;
       }
 
-      entries = this.queue;
-      this.queue = [];
-      if (entries.length === 0) return false;
+      batch = this.retryBatch;
+      if (batch) {
+        this.retryBatch = null;
+      } else {
+        const entries = this.queue;
+        this.queue = [];
+        if (entries.length === 0) return false;
 
-      const batch: UsageLogBatch = {
-        entries,
-        batchId: randomUUID(),
-      };
+        batch = {
+          entries,
+          batchId: randomUUID(),
+        };
+      }
 
       logger.debug(
         CHANNEL,
-        `Flushing ${entries.length} entries (batch: ${batch.batchId})`,
+        `Flushing ${batch.entries.length} entries (batch: ${batch.batchId})`,
       );
 
       const response = await this.sendBatch(batch, token);
@@ -136,13 +142,13 @@ class UsageLogServiceImpl {
       } else {
         logger.warn(
           CHANNEL,
-          `Batch rejected; dropped ${entries.length} queued entries: ${response.error}`,
+          `Batch rejected; dropped ${batch.entries.length} queued entries: ${response.error}`,
         );
       }
       return true;
     } catch (error) {
-      const requeued = entries.length;
-      if (requeued > 0) this.restoreFailedBatch(entries);
+      const requeued = batch?.entries.length ?? 0;
+      if (batch) this.retryBatch = batch;
       const requeuedMessage =
         requeued > 0 ? `; requeued ${requeued} entries` : '';
       logger.warn(
@@ -151,19 +157,6 @@ class UsageLogServiceImpl {
       );
       return false;
     }
-  }
-
-  private restoreFailedBatch(entries: UsageLogEntry[]): void {
-    this.queue = [...entries, ...this.queue];
-
-    const overflow = this.queue.length - MAX_QUEUE_SIZE;
-    if (overflow <= 0) return;
-
-    this.queue.splice(0, overflow);
-    logger.warn(
-      CHANNEL,
-      `Queue full while restoring failed batch, dropped ${overflow} oldest entries`,
-    );
   }
 
   private async sendBatch(

--- a/src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts
@@ -68,6 +68,23 @@ const RAW_USAGE = {
   output_tokens: 1_000_000,
 } as ResponseUsage;
 
+function createResponse(inputTokens: number) {
+  return {
+    id: 'response-id',
+    status: 'completed',
+    output: [],
+    output_text: 'ok',
+    usage: { input_tokens: inputTokens, output_tokens: 1 },
+  };
+}
+
+function createResponseStream(response: ReturnType<typeof createResponse>) {
+  return {
+    async *[Symbol.asyncIterator]() {},
+    finalResponse: async () => response,
+  };
+}
+
 /** Seed the handler's running input-token tally (a private field). */
 function setCumulativeInputTokens(
   handler: ModelHandlerCodex,
@@ -230,6 +247,32 @@ describe('ModelHandlerCodex subscription fallback', () => {
       }),
     ).rejects.toThrow(/safety buffer/);
     expect(requestSpy).not.toHaveBeenCalled();
+  });
+
+  it('sends subscription requests when only the stripped output budget exceeds the Codex cap', async () => {
+    await initFakePlatformWithSubscription();
+
+    const handler = new ModelHandlerCodex(largeWindowConfig);
+    handler.setAgentCategory(AgentCategory.ToolUse);
+    const streamSpy = vi
+      .fn()
+      .mockResolvedValue(
+        createResponseStream(
+          createResponse(CODEX_SUBSCRIPTION_CONTEXT_WINDOW - 1),
+        ),
+      );
+    setCumulativeInputTokens(handler, CODEX_SUBSCRIPTION_CONTEXT_WINDOW - 3000);
+
+    await handler.createResponse({
+      client: { responses: { stream: streamSpy } } as never,
+      messages: [],
+      temperature: 0,
+    });
+
+    expect(streamSpy).toHaveBeenCalledOnce();
+    expect(streamSpy.mock.calls[0]?.[0]?.max_output_tokens).toBeLessThan(
+      config.maxOutputTokens,
+    );
   });
 
   it('keeps workflow agents on the subscription when the tool-use-only switch is off', async () => {

--- a/src/test-kernel/telemetry/UsageLogService.vitest.ts
+++ b/src/test-kernel/telemetry/UsageLogService.vitest.ts
@@ -29,6 +29,10 @@ function batchModels(batch: unknown): string[] {
   return entries.map((entry) => entry.model);
 }
 
+function batchId(batch: unknown): string {
+  return (batch as { batchId: string }).batchId;
+}
+
 // ky passes a Request object; read each batch body from it. `beforeRespond`
 // lets a test stall or fail a specific call before the success response.
 function stubFetch(
@@ -131,5 +135,32 @@ describe('UsageLogService', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(batches.map(batchModels)).toEqual([['first'], ['first']]);
+    expect(batchId(batches[1])).toBe(batchId(batches[0]));
+  });
+
+  it('keeps a failed batch id separate from later queued entries', async () => {
+    vi.spyOn(SupabaseClient, 'getRelayAccessToken').mockResolvedValue('token');
+
+    const batches: unknown[] = [];
+    const fetchMock = stubFetch(batches, (callCount) => {
+      if (callCount === 1) {
+        throw new Error('network unavailable');
+      }
+    });
+
+    UsageLogService.log(usageEntry('first'));
+    await expect(UsageLogService.flush()).resolves.toBe(false);
+
+    UsageLogService.log(usageEntry('second'));
+    await expect(UsageLogService.flush()).resolves.toBe(true);
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(batches.map(batchModels)).toEqual([
+      ['first'],
+      ['first'],
+      ['second'],
+    ]);
+    expect(batchId(batches[1])).toBe(batchId(batches[0]));
+    expect(batchId(batches[2])).not.toBe(batchId(batches[0]));
   });
 });

--- a/supabase/functions/log-usage/index.ts
+++ b/supabase/functions/log-usage/index.ts
@@ -47,12 +47,6 @@ const optionalNonnegativeInt = z
   .nullish()
   .catch(undefined)
   .transform((value) => value ?? undefined);
-const optionalNonnegativeNumber = z
-  .number()
-  .nonnegative()
-  .nullish()
-  .catch(undefined)
-  .transform((value) => value ?? undefined);
 const optionalBoolean = z
   .boolean()
   .nullish()
@@ -73,7 +67,7 @@ const UsageLogEntrySchema = z.object({
     .catch(undefined)
     .transform((value) => value ?? undefined),
   isMultipleOutput: optionalBoolean,
-  responseTimeMs: optionalNonnegativeNumber,
+  responseTimeMs: optionalNonnegativeInt,
   cachedInputTokens: optionalNonnegativeInt,
   reasoningTokens: optionalNonnegativeInt,
   usedRelay: optionalBoolean,
@@ -98,15 +92,18 @@ const UsageDestinations = {
   paid: {
     table: 'usage_logs',
     rpc: 'usage_logs_upsert',
+    accepts: (entry: UsageLogEntry) => !entry.viaChatGptSubscription,
   },
   chatgptSubscription: {
     table: 'chatgpt_subscription_usage_logs',
     rpc: 'chatgpt_subscription_usage_logs_upsert',
+    accepts: (entry: UsageLogEntry) => entry.viaChatGptSubscription,
   },
 } as const;
 
 type UsageDestination =
   (typeof UsageDestinations)[keyof typeof UsageDestinations];
+const usageDestinations = Object.values(UsageDestinations);
 
 // =============================================================================
 // Helpers
@@ -170,12 +167,17 @@ async function batchExists(
   userId: string,
   batchId: string,
 ): Promise<boolean> {
-  const { data: existingBatch } = await adminClient!
+  const { data: existingBatch, error } = await adminClient!
     .from(destination.table)
     .select('id')
     .eq('user_id', userId)
     .eq('batch_id', batchId)
     .limit(1);
+  if (error) {
+    throw new Error(
+      `Failed to check ${destination.table} batch deduplication: ${error.message}`,
+    );
+  }
   return (existingBatch?.length ?? 0) > 0;
 }
 
@@ -258,7 +260,7 @@ Deno.serve(async (req: Request) => {
     if (!batchResult.success) {
       return errorResponse(
         req,
-        'Invalid batch format: expected { entries: [], batchId: string }',
+        'Invalid batch format: expected { entries: [], batchId: UUID }',
         400,
       );
     }
@@ -275,36 +277,25 @@ Deno.serve(async (req: Request) => {
       return successResponse(req, 0, 'No valid entries in batch');
     }
 
-    // 6. Split paid relay/API-key usage from ChatGPT-subscription usage.
-    const paidEntries = validEntries.filter(
-      (entry) => !entry.viaChatGptSubscription,
-    );
-    const chatgptSubscriptionEntries = validEntries.filter(
-      (entry) => entry.viaChatGptSubscription,
-    );
-
-    // 7. Check for duplicate batch (idempotency for client retries).
+    // 6. Check for duplicate batch (idempotency for client retries).
     // After per-stream compaction the canonical row keeps only one batch_id
     // out of the inputs that produced it, so this is best-effort: it catches
     // the common case of an immediate retry of an in-flight request. Each
     // destination is checked separately so a retry after a partial write can
     // still fill the missing table.
-    const paidRows = (await batchExists(
-      UsageDestinations.paid,
-      userId,
-      batch.batchId,
-    ))
-      ? []
-      : toDbRows(userId, batch.batchId, paidEntries);
-    const chatgptSubscriptionRows = (await batchExists(
-      UsageDestinations.chatgptSubscription,
-      userId,
-      batch.batchId,
-    ))
-      ? []
-      : toDbRows(userId, batch.batchId, chatgptSubscriptionEntries);
+    const destinationRows = await Promise.all(
+      usageDestinations.map(async (destination) => {
+        const entries = validEntries.filter(destination.accepts);
+        const rows =
+          entries.length === 0 ||
+          (await batchExists(destination, userId, batch.batchId))
+            ? []
+            : toDbRows(userId, batch.batchId, entries);
+        return { destination, rows };
+      }),
+    );
 
-    if (paidRows.length === 0 && chatgptSubscriptionRows.length === 0) {
+    if (destinationRows.every(({ rows }) => rows.length === 0)) {
       return successResponse(
         req,
         validEntries.length,
@@ -315,13 +306,11 @@ Deno.serve(async (req: Request) => {
     // Server-side aggregation: rows with the same (user_id, stream_id) update
     // the canonical row instead of producing per-round duplicates.
     const upsertErrors = (
-      await Promise.all([
-        upsertUsageRows(UsageDestinations.paid, paidRows),
-        upsertUsageRows(
-          UsageDestinations.chatgptSubscription,
-          chatgptSubscriptionRows,
+      await Promise.all(
+        destinationRows.map(({ destination, rows }) =>
+          upsertUsageRows(destination, rows),
         ),
-      ])
+      )
     ).filter((message): message is string => message != null);
 
     if (upsertErrors.length > 0) {

--- a/supabase/functions/log-usage/index.ts
+++ b/supabase/functions/log-usage/index.ts
@@ -2,8 +2,9 @@
  * Log Usage Edge Function - Records API usage for analytics and rate limiting.
  *
  * Receives batched usage entries from the TeXRA extension and stores them
- * via the public.usage_logs_upsert RPC, which aggregates per-stream so the
- * table grows by run rather than by round.
+ * via service-role RPCs, which aggregate per-stream so the tables grow by run
+ * rather than by round. ChatGPT-subscription usage is kept in a separate table
+ * from paid relay/API-key usage.
  *
  * Authentication: JWT token in Authorization header (Bearer {jwt}), or a
  * CI relay token minted by `texra setup-token` (prefix `texra_relay_`)
@@ -12,8 +13,8 @@
  * - POST /log-usage - Log a batch of usage entries
  *
  * Database Requirements:
- * - Table: usage_logs with unique index on (user_id, stream_id) where stream_id IS NOT NULL
- * - RPC: usage_logs_upsert (service role only)
+ * - Tables: usage_logs, chatgpt_subscription_usage_logs
+ * - RPCs: usage_logs_upsert, chatgpt_subscription_usage_logs_upsert (service role only)
  */
 
 import { createClient } from '@supabase/supabase-js';
@@ -27,7 +28,7 @@ import { versionedJsonResponse } from '../_shared/responses.ts';
 // Constants
 // =============================================================================
 
-const LOG_USAGE_VERSION = '1.3.0';
+const LOG_USAGE_VERSION = '1.4.0';
 
 // =============================================================================
 // Schemas
@@ -35,29 +36,77 @@ const LOG_USAGE_VERSION = '1.3.0';
 
 // Invalid optional fields are dropped (`.catch(undefined)`) rather than
 // rejecting the whole entry; invalid required fields reject the entry.
+const optionalString = z
+  .string()
+  .nullish()
+  .catch(undefined)
+  .transform((value) => value ?? undefined);
+const optionalNonnegativeInt = z
+  .int()
+  .nonnegative()
+  .nullish()
+  .catch(undefined)
+  .transform((value) => value ?? undefined);
+const optionalNonnegativeNumber = z
+  .number()
+  .nonnegative()
+  .nullish()
+  .catch(undefined)
+  .transform((value) => value ?? undefined);
+const optionalBoolean = z
+  .boolean()
+  .nullish()
+  .catch(undefined)
+  .transform((value) => value ?? undefined);
+
 const UsageLogEntrySchema = z.object({
-  timestamp: z.string(),
+  timestamp: z.iso.datetime(),
   model: z.string(),
   provider: z.string(),
-  inputTokens: z.number().nonnegative(),
-  outputTokens: z.number().nonnegative(),
+  inputTokens: z.int().nonnegative(),
+  outputTokens: z.int().nonnegative(),
   cost: z.number().nonnegative(),
-  agentName: z.string().optional().catch(undefined),
-  agentCategory: z.enum(['workflow', 'toolUse']).optional().catch(undefined),
-  isMultipleOutput: z.boolean().optional().catch(undefined),
-  responseTimeMs: z.number().nonnegative().optional().catch(undefined),
-  cachedInputTokens: z.number().nonnegative().optional().catch(undefined),
-  reasoningTokens: z.number().nonnegative().optional().catch(undefined),
-  usedRelay: z.boolean().optional().catch(undefined),
-  streamId: z.string().optional().catch(undefined),
-  extensionVersion: z.string().optional().catch(undefined),
-  editorType: z.string().optional().catch(undefined),
+  agentName: optionalString,
+  agentCategory: z
+    .enum(['workflow', 'toolUse'])
+    .nullish()
+    .catch(undefined)
+    .transform((value) => value ?? undefined),
+  isMultipleOutput: optionalBoolean,
+  responseTimeMs: optionalNonnegativeNumber,
+  cachedInputTokens: optionalNonnegativeInt,
+  reasoningTokens: optionalNonnegativeInt,
+  usedRelay: optionalBoolean,
+  viaChatGptSubscription: z
+    .boolean()
+    .nullish()
+    .catch(false)
+    .transform((value) => value ?? false),
+  streamId: optionalString,
+  extensionVersion: optionalString,
+  editorType: optionalString,
 });
 
 const UsageBatchSchema = z.object({
   entries: z.array(z.unknown()),
-  batchId: z.string(),
+  batchId: z.uuid(),
 });
+
+type UsageLogEntry = z.infer<typeof UsageLogEntrySchema>;
+
+const UsageDestinations = {
+  paid: {
+    table: 'usage_logs',
+    rpc: 'usage_logs_upsert',
+  },
+  chatgptSubscription: {
+    table: 'chatgpt_subscription_usage_logs',
+    rpc: 'chatgpt_subscription_usage_logs_upsert',
+  },
+} as const;
+
+type UsageDestination =
+  (typeof UsageDestinations)[keyof typeof UsageDestinations];
 
 // =============================================================================
 // Helpers
@@ -87,6 +136,59 @@ function errorResponse(req: Request, error: string, status: number): Response {
     { success: false, accepted: 0, error },
     status,
   );
+}
+
+function toDbRows(
+  userId: string,
+  batchId: string,
+  entries: readonly UsageLogEntry[],
+) {
+  return entries.map((entry) => ({
+    user_id: userId,
+    logged_at: entry.timestamp,
+    model: entry.model,
+    provider: entry.provider,
+    agent_name: entry.agentName ?? null,
+    agent_category: entry.agentCategory ?? null,
+    is_multiple_output: entry.isMultipleOutput ?? null,
+    input_tokens: entry.inputTokens,
+    output_tokens: entry.outputTokens,
+    cost: entry.cost,
+    response_time_ms: entry.responseTimeMs ?? null,
+    cached_input_tokens: entry.cachedInputTokens ?? null,
+    reasoning_tokens: entry.reasoningTokens ?? null,
+    used_relay: entry.usedRelay ?? false,
+    stream_id: entry.streamId ?? null,
+    extension_version: entry.extensionVersion ?? null,
+    editor_type: entry.editorType ?? null,
+    batch_id: batchId,
+  }));
+}
+
+async function batchExists(
+  destination: UsageDestination,
+  userId: string,
+  batchId: string,
+): Promise<boolean> {
+  const { data: existingBatch } = await adminClient!
+    .from(destination.table)
+    .select('id')
+    .eq('user_id', userId)
+    .eq('batch_id', batchId)
+    .limit(1);
+  return (existingBatch?.length ?? 0) > 0;
+}
+
+async function upsertUsageRows(
+  destination: UsageDestination,
+  rows: ReturnType<typeof toDbRows>,
+): Promise<string | undefined> {
+  if (rows.length === 0) return undefined;
+
+  const { error: rpcError } = await adminClient!.rpc(destination.rpc, {
+    p_rows: rows,
+  });
+  return rpcError?.message;
 }
 
 // =============================================================================
@@ -163,7 +265,7 @@ Deno.serve(async (req: Request) => {
     const batch = batchResult.data;
 
     // 5. Validate and transform entries
-    const validEntries: z.infer<typeof UsageLogEntrySchema>[] = [];
+    const validEntries: UsageLogEntry[] = [];
     for (const entry of batch.entries) {
       const result = UsageLogEntrySchema.safeParse(entry);
       if (result.success) validEntries.push(result.data);
@@ -173,18 +275,36 @@ Deno.serve(async (req: Request) => {
       return successResponse(req, 0, 'No valid entries in batch');
     }
 
-    // 6. Check for duplicate batch (idempotency for client retries).
+    // 6. Split paid relay/API-key usage from ChatGPT-subscription usage.
+    const paidEntries = validEntries.filter(
+      (entry) => !entry.viaChatGptSubscription,
+    );
+    const chatgptSubscriptionEntries = validEntries.filter(
+      (entry) => entry.viaChatGptSubscription,
+    );
+
+    // 7. Check for duplicate batch (idempotency for client retries).
     // After per-stream compaction the canonical row keeps only one batch_id
     // out of the inputs that produced it, so this is best-effort: it catches
-    // the common case of an immediate retry of an in-flight request.
-    const { data: existingBatch } = await adminClient
-      .from('usage_logs')
-      .select('id')
-      .eq('user_id', userId)
-      .eq('batch_id', batch.batchId)
-      .limit(1);
+    // the common case of an immediate retry of an in-flight request. Each
+    // destination is checked separately so a retry after a partial write can
+    // still fill the missing table.
+    const paidRows = (await batchExists(
+      UsageDestinations.paid,
+      userId,
+      batch.batchId,
+    ))
+      ? []
+      : toDbRows(userId, batch.batchId, paidEntries);
+    const chatgptSubscriptionRows = (await batchExists(
+      UsageDestinations.chatgptSubscription,
+      userId,
+      batch.batchId,
+    ))
+      ? []
+      : toDbRows(userId, batch.batchId, chatgptSubscriptionEntries);
 
-    if (existingBatch && existingBatch.length > 0) {
+    if (paidRows.length === 0 && chatgptSubscriptionRows.length === 0) {
       return successResponse(
         req,
         validEntries.length,
@@ -192,39 +312,24 @@ Deno.serve(async (req: Request) => {
       );
     }
 
-    const rows = validEntries.map((entry) => ({
-      user_id: userId,
-      logged_at: entry.timestamp,
-      model: entry.model,
-      provider: entry.provider,
-      agent_name: entry.agentName ?? null,
-      agent_category: entry.agentCategory ?? null,
-      is_multiple_output: entry.isMultipleOutput ?? null,
-      input_tokens: entry.inputTokens,
-      output_tokens: entry.outputTokens,
-      cost: entry.cost,
-      response_time_ms: entry.responseTimeMs ?? null,
-      cached_input_tokens: entry.cachedInputTokens ?? null,
-      reasoning_tokens: entry.reasoningTokens ?? null,
-      used_relay: entry.usedRelay ?? false,
-      stream_id: entry.streamId ?? null,
-      extension_version: entry.extensionVersion ?? null,
-      editor_type: entry.editorType ?? null,
-      batch_id: batch.batchId,
-    }));
-
     // Server-side aggregation: rows with the same (user_id, stream_id) update
     // the canonical row instead of producing per-round duplicates.
-    const { error: rpcError } = await adminClient.rpc('usage_logs_upsert', {
-      p_rows: rows,
-    });
+    const upsertErrors = (
+      await Promise.all([
+        upsertUsageRows(UsageDestinations.paid, paidRows),
+        upsertUsageRows(
+          UsageDestinations.chatgptSubscription,
+          chatgptSubscriptionRows,
+        ),
+      ])
+    ).filter((message): message is string => message != null);
 
-    if (rpcError) {
-      console.error('[LOG_USAGE] Upsert error:', rpcError.message);
+    if (upsertErrors.length > 0) {
+      console.error('[LOG_USAGE] Upsert error:', upsertErrors.join('; '));
       return errorResponse(req, 'Failed to store usage logs', 500);
     }
 
-    // 7. Return success response
+    // 8. Return success response
     return successResponse(req, validEntries.length);
   } catch (error) {
     console.error('[LOG_USAGE] Unexpected error:', error);

--- a/supabase/migrations/20260701101356_subscription_usage_logs.sql
+++ b/supabase/migrations/20260701101356_subscription_usage_logs.sql
@@ -1,0 +1,216 @@
+-- Store ChatGPT-subscription usage outside the paid relay/API-key usage table.
+--
+-- These rows still matter for analytics and user-visible run accounting, but
+-- their zero cost should not enter the relay spending table or any downstream
+-- paid-usage view that reads public.usage_logs.
+
+CREATE TABLE IF NOT EXISTS public.chatgpt_subscription_usage_logs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+
+    logged_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    model TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    agent_name TEXT,
+    agent_category TEXT,
+    is_multiple_output BOOLEAN,
+
+    input_tokens INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    cached_input_tokens INTEGER,
+    reasoning_tokens INTEGER,
+
+    cost DECIMAL(10, 6) NOT NULL DEFAULT 0,
+    response_time_ms INTEGER,
+
+    used_relay BOOLEAN DEFAULT FALSE,
+    stream_id TEXT,
+    extension_version TEXT,
+    batch_id UUID,
+    editor_type TEXT,
+
+    CONSTRAINT chatgpt_subscription_usage_logs_positive_tokens
+      CHECK (input_tokens >= 0 AND output_tokens >= 0),
+    CONSTRAINT chatgpt_subscription_usage_logs_positive_cost
+      CHECK (cost >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_chatgpt_subscription_usage_logs_user_id
+  ON public.chatgpt_subscription_usage_logs(user_id);
+CREATE INDEX IF NOT EXISTS idx_chatgpt_subscription_usage_logs_logged_at
+  ON public.chatgpt_subscription_usage_logs(logged_at DESC);
+CREATE INDEX IF NOT EXISTS idx_chatgpt_subscription_usage_logs_user_logged_at
+  ON public.chatgpt_subscription_usage_logs(user_id, logged_at DESC);
+CREATE INDEX IF NOT EXISTS idx_chatgpt_subscription_usage_logs_model
+  ON public.chatgpt_subscription_usage_logs(model);
+CREATE INDEX IF NOT EXISTS idx_chatgpt_subscription_usage_logs_provider
+  ON public.chatgpt_subscription_usage_logs(provider);
+CREATE INDEX IF NOT EXISTS idx_chatgpt_subscription_usage_logs_batch_id
+  ON public.chatgpt_subscription_usage_logs(batch_id);
+CREATE INDEX IF NOT EXISTS idx_chatgpt_subscription_usage_logs_user_batch
+  ON public.chatgpt_subscription_usage_logs(user_id, batch_id);
+CREATE UNIQUE INDEX IF NOT EXISTS chatgpt_subscription_usage_logs_user_stream_unique
+  ON public.chatgpt_subscription_usage_logs(user_id, stream_id)
+  WHERE stream_id IS NOT NULL;
+
+ALTER TABLE public.chatgpt_subscription_usage_logs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can read own ChatGPT subscription usage logs"
+ON public.chatgpt_subscription_usage_logs FOR SELECT
+TO authenticated
+USING ((select auth.uid()) = user_id);
+
+GRANT SELECT ON public.chatgpt_subscription_usage_logs TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.chatgpt_subscription_usage_logs TO service_role;
+
+CREATE OR REPLACE FUNCTION public.chatgpt_subscription_usage_logs_upsert(p_rows JSONB)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  affected INTEGER := 0;
+BEGIN
+  WITH parsed AS (
+    SELECT
+      row_ordinal,
+      (r->>'user_id')::uuid AS user_id,
+      (r->>'logged_at')::timestamptz AS logged_at,
+      r->>'model' AS model,
+      r->>'provider' AS provider,
+      NULLIF(r->>'agent_name', '') AS agent_name,
+      NULLIF(r->>'agent_category', '') AS agent_category,
+      CASE WHEN r ? 'is_multiple_output' AND r->>'is_multiple_output' <> ''
+           THEN (r->>'is_multiple_output')::boolean END AS is_multiple_output,
+      COALESCE((r->>'input_tokens')::int, 0) AS input_tokens,
+      COALESCE((r->>'output_tokens')::int, 0) AS output_tokens,
+      COALESCE((r->>'cost')::numeric, 0) AS cost,
+      CASE WHEN r ? 'response_time_ms' AND r->>'response_time_ms' <> ''
+           THEN (r->>'response_time_ms')::int END AS response_time_ms,
+      CASE WHEN r ? 'cached_input_tokens' AND r->>'cached_input_tokens' <> ''
+           THEN (r->>'cached_input_tokens')::int END AS cached_input_tokens,
+      CASE WHEN r ? 'reasoning_tokens' AND r->>'reasoning_tokens' <> ''
+           THEN (r->>'reasoning_tokens')::int END AS reasoning_tokens,
+      COALESCE(NULLIF(r->>'used_relay', '')::boolean, false) AS used_relay,
+      NULLIF(r->>'stream_id', '') AS stream_id,
+      NULLIF(r->>'extension_version', '') AS extension_version,
+      (r->>'batch_id')::uuid AS batch_id,
+      NULLIF(r->>'editor_type', '') AS editor_type
+    FROM jsonb_array_elements(p_rows) WITH ORDINALITY AS input(r, row_ordinal)
+  ),
+  agg AS (
+    SELECT
+      user_id, stream_id,
+      MIN(logged_at) AS logged_at,
+      MAX(model) AS model,
+      MAX(provider) AS provider,
+      MAX(agent_name) AS agent_name,
+      MAX(agent_category) AS agent_category,
+      BOOL_OR(is_multiple_output) AS is_multiple_output,
+      CASE WHEN BOOL_OR(public.is_relay_delta_client(extension_version))
+           THEN SUM(input_tokens)::int ELSE MAX(input_tokens) END AS input_tokens,
+      CASE WHEN BOOL_OR(public.is_relay_delta_client(extension_version))
+           THEN SUM(output_tokens)::int ELSE MAX(output_tokens) END AS output_tokens,
+      CASE WHEN BOOL_OR(public.is_relay_delta_client(extension_version))
+           THEN SUM(cost)::numeric ELSE MAX(cost) END AS cost,
+      CASE WHEN BOOL_OR(public.is_relay_delta_client(extension_version))
+           THEN SUM(COALESCE(cached_input_tokens, 0))::int
+           ELSE MAX(cached_input_tokens) END AS cached_input_tokens,
+      CASE WHEN BOOL_OR(public.is_relay_delta_client(extension_version))
+           THEN SUM(COALESCE(reasoning_tokens, 0))::int
+           ELSE MAX(reasoning_tokens) END AS reasoning_tokens,
+      MAX(response_time_ms) AS response_time_ms,
+      BOOL_OR(used_relay) AS used_relay,
+      MAX(extension_version) AS extension_version,
+      MAX(batch_id::text)::uuid AS batch_id,
+      MAX(editor_type) AS editor_type
+    FROM parsed
+    GROUP BY user_id, stream_id, CASE WHEN stream_id IS NULL THEN row_ordinal END
+  )
+  INSERT INTO public.chatgpt_subscription_usage_logs (
+    user_id, logged_at, model, provider, agent_name, agent_category,
+    is_multiple_output, input_tokens, output_tokens, cost,
+    response_time_ms, cached_input_tokens, reasoning_tokens,
+    used_relay, stream_id, extension_version, batch_id, editor_type
+  )
+  SELECT
+    user_id, logged_at, model, provider, agent_name, agent_category,
+    is_multiple_output, input_tokens, output_tokens, cost,
+    response_time_ms, cached_input_tokens, reasoning_tokens,
+    used_relay, stream_id, extension_version, batch_id, editor_type
+  FROM agg
+  ON CONFLICT (user_id, stream_id) WHERE stream_id IS NOT NULL DO UPDATE SET
+    input_tokens = CASE
+      WHEN public.is_relay_delta_client(EXCLUDED.extension_version)
+      THEN public.chatgpt_subscription_usage_logs.input_tokens + EXCLUDED.input_tokens
+      ELSE GREATEST(public.chatgpt_subscription_usage_logs.input_tokens, EXCLUDED.input_tokens) END,
+    output_tokens = CASE
+      WHEN public.is_relay_delta_client(EXCLUDED.extension_version)
+      THEN public.chatgpt_subscription_usage_logs.output_tokens + EXCLUDED.output_tokens
+      ELSE GREATEST(public.chatgpt_subscription_usage_logs.output_tokens, EXCLUDED.output_tokens) END,
+    cost = CASE
+      WHEN public.is_relay_delta_client(EXCLUDED.extension_version)
+      THEN public.chatgpt_subscription_usage_logs.cost + EXCLUDED.cost
+      ELSE GREATEST(public.chatgpt_subscription_usage_logs.cost, EXCLUDED.cost) END,
+    cached_input_tokens = CASE
+      WHEN public.is_relay_delta_client(EXCLUDED.extension_version)
+      THEN COALESCE(public.chatgpt_subscription_usage_logs.cached_input_tokens, 0)
+        + COALESCE(EXCLUDED.cached_input_tokens, 0)
+      ELSE GREATEST(
+        COALESCE(public.chatgpt_subscription_usage_logs.cached_input_tokens, 0),
+        COALESCE(EXCLUDED.cached_input_tokens, 0)
+      ) END,
+    reasoning_tokens = CASE
+      WHEN public.is_relay_delta_client(EXCLUDED.extension_version)
+      THEN COALESCE(public.chatgpt_subscription_usage_logs.reasoning_tokens, 0) + COALESCE(EXCLUDED.reasoning_tokens, 0)
+      ELSE GREATEST(
+        COALESCE(public.chatgpt_subscription_usage_logs.reasoning_tokens, 0),
+        COALESCE(EXCLUDED.reasoning_tokens, 0)
+      ) END,
+    response_time_ms = GREATEST(
+      COALESCE(public.chatgpt_subscription_usage_logs.response_time_ms, 0),
+      COALESCE(EXCLUDED.response_time_ms, 0)),
+    used_relay =
+      COALESCE(public.chatgpt_subscription_usage_logs.used_relay, false)
+      OR COALESCE(EXCLUDED.used_relay, false),
+    logged_at = LEAST(public.chatgpt_subscription_usage_logs.logged_at, EXCLUDED.logged_at),
+    batch_id = COALESCE(EXCLUDED.batch_id, public.chatgpt_subscription_usage_logs.batch_id),
+    extension_version = COALESCE(EXCLUDED.extension_version, public.chatgpt_subscription_usage_logs.extension_version),
+    model = COALESCE(public.chatgpt_subscription_usage_logs.model, EXCLUDED.model),
+    provider = COALESCE(public.chatgpt_subscription_usage_logs.provider, EXCLUDED.provider),
+    agent_name = COALESCE(public.chatgpt_subscription_usage_logs.agent_name, EXCLUDED.agent_name),
+    agent_category = COALESCE(public.chatgpt_subscription_usage_logs.agent_category, EXCLUDED.agent_category),
+    is_multiple_output = COALESCE(
+      public.chatgpt_subscription_usage_logs.is_multiple_output,
+      EXCLUDED.is_multiple_output
+    ),
+    editor_type = COALESCE(public.chatgpt_subscription_usage_logs.editor_type, EXCLUDED.editor_type);
+
+  GET DIAGNOSTICS affected = ROW_COUNT;
+  RETURN affected;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.chatgpt_subscription_usage_logs_upsert(jsonb)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.chatgpt_subscription_usage_logs_upsert(jsonb)
+  TO service_role;
+
+COMMENT ON TABLE public.chatgpt_subscription_usage_logs IS
+  'ChatGPT-subscription Codex usage logs kept separate from paid relay/API-key usage';
+COMMENT ON COLUMN public.chatgpt_subscription_usage_logs.user_id IS
+  'User who made the ChatGPT-subscription-backed request';
+COMMENT ON COLUMN public.chatgpt_subscription_usage_logs.logged_at IS
+  'When the request completed (client time)';
+COMMENT ON COLUMN public.chatgpt_subscription_usage_logs.cost IS
+  'Computed cost in USD; ChatGPT-subscription rows are expected to be zero-cost';
+COMMENT ON COLUMN public.chatgpt_subscription_usage_logs.used_relay IS
+  'Whether server-side relay keys were used; normally false for subscription rows';
+COMMENT ON COLUMN public.chatgpt_subscription_usage_logs.stream_id IS
+  'Session identifier for grouping requests';
+COMMENT ON COLUMN public.chatgpt_subscription_usage_logs.batch_id IS
+  'Batch ID for deduplication';

--- a/supabase/migrations/20260701101356_subscription_usage_logs.sql
+++ b/supabase/migrations/20260701101356_subscription_usage_logs.sql
@@ -98,7 +98,7 @@ BEGIN
       COALESCE(NULLIF(r->>'used_relay', '')::boolean, false) AS used_relay,
       NULLIF(r->>'stream_id', '') AS stream_id,
       NULLIF(r->>'extension_version', '') AS extension_version,
-      (r->>'batch_id')::uuid AS batch_id,
+      NULLIF(r->>'batch_id', '')::uuid AS batch_id,
       NULLIF(r->>'editor_type', '') AS editor_type
     FROM jsonb_array_elements(p_rows) WITH ORDINALITY AS input(r, row_ordinal)
   ),


### PR DESCRIPTION
## Summary
- Routes ChatGPT-subscription usage rows from the `log-usage` edge function into a new Supabase table, `chatgpt_subscription_usage_logs`, with its matching service-role upsert RPC, RLS policy, explicit grants, and per-stream aggregation.
- Keeps the Edge Function routing declarative through destination metadata, so paid and ChatGPT-subscription usage share the same validation, dedupe, row-mapping, and upsert flow.
- Retries failed usage batches with their original `batchId` while keeping later queued entries separate, so a partial paid/subscription write can be retried without double-counting the side that already committed.
- Relaxes the Codex subscription fallback guard so requests do not fail solely because an output budget that is stripped before reaching the Codex backend would exceed the local estimate.

## Verification
- `deno check --config supabase/functions/log-usage/deno.json supabase/functions/log-usage/index.ts`
- `CI=true corepack pnpm vitest run src/test-kernel/telemetry/UsageLogService.vitest.ts src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts`
- `CI=true corepack pnpm run typecheck`

## Notes
- `supabase db lint --local` was attempted earlier, but this worktree has no running local Postgres instance for the Supabase CLI to connect to.
- The migration includes explicit grants because new public tables should not rely on default Data API exposure.
