### PR TITLE
fix(openai): fall back to polling when the SDK throws on an unrecognized stream event

### DIFF
--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import OpenAI from 'openai';
+import OpenAI, { OpenAIError } from 'openai';
 // Exported by openai@6.x via the package's ./lib/* subpath; keep typecheck
 // coverage around SDK upgrades because this is not a top-level public helper.
 import { addOutputText } from 'openai/lib/ResponsesParser';
@@ -117,6 +117,7 @@ import type {
   ResponseCreateParamsBase,
   ResponseCreateParamsNonStreaming,
   ResponseReasoningItem,
+  ResponseRetrieveParamsNonStreaming,
   ResponseFunctionToolCall,
   ResponseInputItem,
   ResponseInputContent,
@@ -184,6 +185,29 @@ function collectWebSearchPairedBlocks(
     blocks.push(item);
   }
   return blocks;
+}
+
+/**
+ * The SDK's response-stream accumulator (`client.responses.stream()`) throws
+ * on any event `type` outside its typed union — including heartbeat/keepalive
+ * frames a long-running or background response can emit that predate this SDK
+ * release adding support for them. That's a transport-level signal, not a
+ * failed response, so callers holding a response id should poll by id instead
+ * of failing the turn.
+ */
+function isUnhandledStreamEventError(error: unknown): boolean {
+  // The SDK currently exposes this accumulator failure only through its
+  // message; keep the prefix check narrow until it publishes a stable code.
+  return (
+    error instanceof OpenAIError &&
+    error.message.startsWith('Unhandled response stream event')
+  );
+}
+
+function responseRetrieveParamsFor(
+  params: ResponseCreateParamsBase,
+): ResponseRetrieveParamsNonStreaming | undefined {
+  return params.include ? { include: params.include } : undefined;
 }
 
 function responseOutputItemKey(item: ResponseOutputItem): string | undefined {
@@ -1711,6 +1735,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         client,
         response,
         signal,
+        responseRetrieveParamsFor(params),
       );
     }
 
@@ -1765,9 +1790,14 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       streamConnected = true;
     };
     let removeConnectListener: (() => void) | undefined;
+    // Captured from `response.created` so a stream event outside the SDK's
+    // typed union (see isUnhandledStreamEventError) can fall back to polling
+    // by id instead of failing an otherwise-healthy turn.
+    let responseId: string | undefined;
     try {
       const { stream: _stream, ...rest } = params;
       const streamParams: ResponseStreamParams = { ...rest, stream: true };
+      const retrieveParams = responseRetrieveParamsFor(params);
       const stream = await client.responses.stream(streamParams, { signal });
       if (typeof stream.on === 'function') {
         stream.on('connect', onConnect);
@@ -1780,17 +1810,53 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       // GPT can: think → web_search → think more → web_search → text
       processor = this.createStreamProcessor();
 
-      for await (const event of stream) {
-        streamEventObserved = true;
-        processor.process(event);
-        if (event.type === 'response.output_text.delta') {
-          streamedText += event.delta;
-        } else if (event.type === 'response.output_item.done') {
-          streamedItems.push(event.item);
+      const retrieveAfterUnhandledStreamEvent = async (
+        streamError: unknown,
+      ): Promise<Response> => {
+        if (!responseId || !isUnhandledStreamEventError(streamError)) {
+          throw streamError;
         }
+        if (!this.storesResponsesServerSide) {
+          this.logger.debug(
+            `OpenAI stream emitted an event outside the SDK's typed union for stateless response ${responseId}; polling fallback is unavailable: ${getSdkErrorMessage(streamError)}`,
+          );
+          throw streamError;
+        }
+        this.logger.debug(
+          `OpenAI stream emitted an event outside the SDK's typed union for response ${responseId} — falling back to polling: ${getSdkErrorMessage(streamError)}`,
+        );
+        return client.responses.retrieve(
+          responseId,
+          retrieveParams,
+          signal ? { signal } : undefined,
+        );
+      };
+
+      let response: Response | undefined;
+      try {
+        for await (const event of stream) {
+          streamEventObserved = true;
+          if (event.type === 'response.created') {
+            responseId = event.response.id;
+          }
+          processor.process(event);
+          if (event.type === 'response.output_text.delta') {
+            streamedText += event.delta;
+          } else if (event.type === 'response.output_item.done') {
+            streamedItems.push(event.item);
+          }
+        }
+      } catch (streamError) {
+        response = await retrieveAfterUnhandledStreamEvent(streamError);
       }
 
-      let response = await stream.finalResponse();
+      if (!response) {
+        try {
+          response = await stream.finalResponse();
+        } catch (streamError) {
+          response = await retrieveAfterUnhandledStreamEvent(streamError);
+        }
+      }
 
       // If the stream ended before the response completed (e.g., relay timeout
       // during slow GPT-5 requests), poll until it finishes instead of silently
@@ -1803,6 +1869,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           client,
           response,
           signal,
+          retrieveParams,
         );
       }
 
@@ -1882,6 +1949,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         client,
         response,
         signal,
+        responseRetrieveParamsFor(params),
       );
     }
 
@@ -2060,6 +2128,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     client: OpenAI,
     initialResponse: T,
     signal?: AbortSignal,
+    retrieveParams?: ResponseRetrieveParamsNonStreaming,
   ): Promise<T> {
     if (!initialResponse.id) {
       return initialResponse;
@@ -2078,7 +2147,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           try {
             return (await client.responses.retrieve(
               responseId,
-              undefined,
+              retrieveParams,
               sig ? { signal: sig } : undefined,
             )) as T;
           } catch (err) {

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -369,6 +369,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    * Do not share a handler instance across concurrent agent invocations.
    */
   private pendingBackgroundResponseId: string | null = null;
+  private pendingBackgroundRetrieveParams:
+    | ResponseRetrieveParamsNonStreaming
+    | undefined;
 
   /**
    * Guards against concurrent createResponse() calls on the same handler.
@@ -385,6 +388,15 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   /** Clears the pending background response ID. Single point of mutation. */
   private clearPendingBackgroundResponse(): void {
     this.pendingBackgroundResponseId = null;
+    this.pendingBackgroundRetrieveParams = undefined;
+  }
+
+  private rememberPendingBackgroundResponse(
+    responseId: string,
+    retrieveParams?: ResponseRetrieveParamsNonStreaming,
+  ): void {
+    this.pendingBackgroundResponseId = responseId;
+    this.pendingBackgroundRetrieveParams = retrieveParams;
   }
 
   // =========================================================================
@@ -464,6 +476,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     if (!pendingId) {
       return null;
     }
+    const retrieveParams = this.pendingBackgroundRetrieveParams;
 
     this.logger.debug(
       `Resuming polling for pending background response ${pendingId}`,
@@ -473,7 +486,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     try {
       pendingResponse = await client.responses.retrieve(
         pendingId,
-        undefined,
+        retrieveParams,
         signal ? { signal } : undefined,
       );
     } catch (err) {
@@ -523,6 +536,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         client,
         pendingResponse,
         signal,
+        retrieveParams,
       );
       // Note: clearPendingBackgroundResponse() called by finalizeResponse() in caller
       return response;
@@ -1330,11 +1344,36 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   protected override async createResponseImpl(
     options: CreateResponseOptions<ResponseInputItem, OpenAI>,
   ): Promise<CreateResponseResult<Response, ResponseInputItem>> {
-    // Clear any stale compaction result from previous attempts (ensures clean state on retries)
-    this.compactionResult = undefined;
-
     const { client, messages, temperature, systemPrompt, signal, tools } =
       options;
+
+    if (this.pendingBackgroundResponseId) {
+      const resumeContext: ResponseFinalizeContext = {
+        effectiveMessagesLength:
+          this.compactionResult?.compactedMessages.length ?? messages.length,
+        compactedThisCall: this.compactionResult !== undefined,
+        compactedMessages: this.compactionResult?.compactedMessages,
+      };
+      try {
+        const resumed = await this.tryResumeBackgroundIfPending(
+          client,
+          signal,
+          resumeContext,
+        );
+        if (resumed) return resumed;
+      } catch (error) {
+        return await this.handleCreateResponseError(
+          error,
+          options,
+          resumeContext.compactedThisCall,
+        );
+      }
+    }
+
+    // Clear any stale compaction result from previous attempts. A retained
+    // pending response is handled above before this state can be discarded.
+    this.compactionResult = undefined;
+
     // Route through isBackgroundModeActive() so subclass overrides (e.g. the
     // Codex subscription handler) actually gate the request, not just the
     // predicate.
@@ -1593,18 +1632,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     // Wrap execution in a try/catch so the error handler can recover from an
     // invalid/expired previous_response_id or a context-window overflow.
     try {
-      // Try to resume a pending background response (retry after connection error)
-      if (useBackgroundResponses && this.pendingBackgroundResponseId) {
-        const resumed = await this.tryResumeBackgroundIfPending(
-          client,
-          signal,
-          finalizeContext,
-        );
-        // Null means nothing to resume (or it failed remotely) — fall through
-        // to create a fresh request.
-        if (resumed) return resumed;
-      }
-
       // WebSocket transport: persistent connection for lower-latency tool-use loops
       if (useWebSocket) {
         return await this.executeWebSocketPath(
@@ -1825,11 +1852,28 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         this.logger.debug(
           `OpenAI stream emitted an event outside the SDK's typed union for response ${responseId} — falling back to polling: ${getSdkErrorMessage(streamError)}`,
         );
-        return client.responses.retrieve(
-          responseId,
-          retrieveParams,
-          signal ? { signal } : undefined,
-        );
+        this.rememberPendingBackgroundResponse(responseId, retrieveParams);
+        try {
+          return await client.responses.retrieve(
+            responseId,
+            retrieveParams,
+            signal ? { signal } : undefined,
+          );
+        } catch (err) {
+          tagOpenAISdkError(err, this.config.provider);
+          if (isUserAbort(err)) {
+            this.clearPendingBackgroundResponse();
+            throw err;
+          }
+          const { shouldRetainPendingResponse } =
+            classifyOpenAIBackgroundResumeError(err, this.config.provider);
+          if (!shouldRetainPendingResponse) {
+            this.clearPendingBackgroundResponse();
+          } else {
+            attachFlowAutoRetryRequired(err);
+          }
+          throw err;
+        }
       };
 
       let response: Response | undefined;
@@ -2136,7 +2180,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
     // Track which response is being polled so retry logic can resume via
     // tryResumeBackgroundResponse instead of creating a new request.
-    this.pendingBackgroundResponseId = initialResponse.id;
+    this.rememberPendingBackgroundResponse(initialResponse.id, retrieveParams);
 
     let pollStats: BackgroundPollStats | undefined;
     let polled: T;

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
@@ -11,6 +11,7 @@ import {
   type ModelConfig,
   ModelProvider,
 } from 'llm-zoo';
+import { OpenAIError } from 'openai';
 
 // Local imports - platform
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
@@ -27,6 +28,7 @@ import {
 } from '@agent/core/definition/AgentDataclass';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/openai/modelHandlerOpenAIResponse';
+import { BackgroundPoller } from '@agent/modelHandlers/support/BackgroundPoller';
 
 // Type imports
 import { pathToLocation } from '@utils/files';
@@ -112,10 +114,25 @@ class NonChainingResponseHandler extends ModelHandlerOpenAIResponse {
   }
 }
 
+class StatelessResponseHandler extends ModelHandlerOpenAIResponse {
+  protected override get storesResponsesServerSide(): boolean {
+    return false;
+  }
+}
+
 function createNonChainingHandler(
   configOverrides: Partial<ModelConfig> = {},
 ): ModelHandlerOpenAIResponse {
   const handler = new NonChainingResponseHandler(createConfig(configOverrides));
+  handler.setLogger(createLoggerStub() as unknown as AgentTrace);
+  handler.getStreamingConfig = () => false;
+  return handler;
+}
+
+function createStatelessHandler(
+  configOverrides: Partial<ModelConfig> = {},
+): ModelHandlerOpenAIResponse {
+  const handler = new StatelessResponseHandler(createConfig(configOverrides));
   handler.setLogger(createLoggerStub() as unknown as AgentTrace);
   handler.getStreamingConfig = () => false;
   return handler;
@@ -328,6 +345,204 @@ describe('ModelHandlerOpenAIResponse.createResponse', () => {
     });
 
     assert.deepEqual(result.response.output, [reasoningItem, functionCallItem]);
+  });
+
+  it('keeps healthy streams on finalResponse after response.created', async () => {
+    const handler = createHandler();
+    handler.getStreamingConfig = () => true;
+
+    let finalResponseCalls = 0;
+    let retrieveCalls = 0;
+    const finalResponse = createResponse('resp-stream-ok', {
+      input_tokens: 12,
+    });
+    const client = {
+      responses: {
+        stream: () => ({
+          async *[Symbol.asyncIterator]() {
+            yield {
+              type: 'response.created',
+              response: { id: 'resp-stream-ok' },
+            };
+            yield { type: 'response.output_text.delta', delta: 'ok' };
+          },
+          finalResponse: async () => {
+            finalResponseCalls += 1;
+            return finalResponse;
+          },
+        }),
+        retrieve: async () => {
+          retrieveCalls += 1;
+          throw new Error('healthy stream should not retrieve by id');
+        },
+      },
+    };
+
+    const result = await handler.createResponse({
+      client: client as any,
+      messages: createMessages(1),
+      temperature: 0,
+    });
+
+    assert.equal(result.response.id, 'resp-stream-ok');
+    assert.equal(finalResponseCalls, 1);
+    assert.equal(retrieveCalls, 0);
+  });
+
+  it('falls back to retrieve when finalResponse sees an unhandled stream event', async () => {
+    const handler = createHandler();
+    handler.getStreamingConfig = () => true;
+
+    const retrieveCalls: string[] = [];
+    const recoveredResponse = createResponse('resp-final-fallback', {
+      input_tokens: 12,
+    });
+    const client = {
+      responses: {
+        stream: () => ({
+          async *[Symbol.asyncIterator]() {
+            yield {
+              type: 'response.created',
+              response: { id: 'resp-final-fallback' },
+            };
+          },
+          finalResponse: async () => {
+            throw new OpenAIError(
+              'Unhandled response stream event: response.keepalive',
+            );
+          },
+        }),
+        retrieve: async (id: string) => {
+          retrieveCalls.push(id);
+          return recoveredResponse;
+        },
+      },
+    };
+
+    const result = await handler.createResponse({
+      client: client as any,
+      messages: createMessages(1),
+      temperature: 0,
+    });
+
+    assert.equal(result.response.id, 'resp-final-fallback');
+    assert.deepEqual(retrieveCalls, ['resp-final-fallback']);
+  });
+
+  it('does not retrieve stateless responses after an unhandled stream event', async () => {
+    const handler = createStatelessHandler();
+    handler.getStreamingConfig = () => true;
+
+    let retrieveCalls = 0;
+    const client = {
+      responses: {
+        stream: () => ({
+          async *[Symbol.asyncIterator]() {
+            yield {
+              type: 'response.created',
+              response: { id: 'resp-stateless-fallback' },
+            };
+            throw new OpenAIError(
+              'Unhandled response stream event: response.keepalive',
+            );
+          },
+          finalResponse: async () => {
+            throw new Error('stateless stream should not call finalResponse');
+          },
+        }),
+        retrieve: async () => {
+          retrieveCalls += 1;
+          throw new Error('stateless stream should not retrieve by id');
+        },
+      },
+    };
+
+    await assert.rejects(
+      handler.createResponse({
+        client: client as any,
+        messages: createMessages(1),
+        temperature: 0,
+      }),
+      /Unhandled response stream event/,
+    );
+    assert.equal(retrieveCalls, 0);
+  });
+
+  it('preserves include fields when polling after an unhandled stream event', async () => {
+    const handler = createHandler({
+      capabilities: {
+        ...DEFAULT_MODEL_CAPABILITIES,
+        supportsNativeWebSearch: true,
+      },
+    });
+    handler.getStreamingConfig = () => true;
+    (
+      handler as unknown as { backgroundPoller: BackgroundPoller<any> }
+    ).backgroundPoller = new BackgroundPoller({
+      pollIntervalMs: 0,
+      maxDurationMs: 1000,
+      isPending: (response: { status?: string | null }) =>
+        response.status === 'queued' || response.status === 'in_progress',
+      logger: createLoggerStub() as unknown as AgentTrace,
+    });
+
+    const retrieveCalls: Array<{
+      id: string;
+      params: unknown;
+      options: unknown;
+    }> = [];
+    const pendingResponse = {
+      ...createResponse('resp-stream-fallback', { input_tokens: 12 }),
+      status: 'in_progress',
+    };
+    const recoveredResponse = createResponse('resp-stream-fallback', {
+      input_tokens: 12,
+    });
+    const retrievedResponses = [pendingResponse, recoveredResponse];
+    const client = {
+      responses: {
+        stream: () => ({
+          async *[Symbol.asyncIterator]() {
+            yield {
+              type: 'response.created',
+              response: { id: 'resp-stream-fallback' },
+            };
+            throw new OpenAIError(
+              'Unhandled response stream event: response.keepalive',
+            );
+          },
+          finalResponse: async () => {
+            throw new Error('fallback stream should retrieve by id');
+          },
+        }),
+        retrieve: async (id: string, params: unknown, options: unknown) => {
+          retrieveCalls.push({ id, params, options });
+          const response = retrievedResponses.shift();
+          if (!response) throw new Error('unexpected extra retrieve');
+          return response;
+        },
+      },
+    };
+
+    const result = await handler.createResponse({
+      client: client as any,
+      messages: createMessages(1),
+      temperature: 0,
+    });
+
+    assert.equal(result.response.id, 'resp-stream-fallback');
+    assert.deepEqual(retrieveCalls, [
+      {
+        id: 'resp-stream-fallback',
+        params: { include: ['web_search_call.action.sources'] },
+        options: undefined,
+      },
+      {
+        id: 'resp-stream-fallback',
+        params: { include: ['web_search_call.action.sources'] },
+        options: undefined,
+      },
+    ]);
   });
 
   it('uses the preserved token baseline after an invalid previous response id clears chaining', async () => {

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
@@ -429,6 +429,82 @@ describe('ModelHandlerOpenAIResponse.createResponse', () => {
     assert.deepEqual(retrieveCalls, ['resp-final-fallback']);
   });
 
+  it('rethrows unhandled stream events before response.created', async () => {
+    const handler = createHandler();
+    handler.getStreamingConfig = () => true;
+
+    let retrieveCalls = 0;
+    const client = {
+      responses: {
+        stream: () => ({
+          [Symbol.asyncIterator]() {
+            return {
+              async next() {
+                throw new OpenAIError(
+                  'Unhandled response stream event: response.keepalive',
+                );
+              },
+            };
+          },
+          finalResponse: async () => {
+            throw new Error('stream failure should not call finalResponse');
+          },
+        }),
+        retrieve: async () => {
+          retrieveCalls += 1;
+          throw new Error('stream without response id should not retrieve');
+        },
+      },
+    };
+
+    await assert.rejects(
+      handler.createResponse({
+        client: client as any,
+        messages: createMessages(1),
+        temperature: 0,
+      }),
+      /Unhandled response stream event/,
+    );
+    assert.equal(retrieveCalls, 0);
+  });
+
+  it('rethrows non-OpenAI stream errors without polling', async () => {
+    const handler = createHandler();
+    handler.getStreamingConfig = () => true;
+
+    let retrieveCalls = 0;
+    const client = {
+      responses: {
+        stream: () => ({
+          async *[Symbol.asyncIterator]() {
+            yield {
+              type: 'response.created',
+              response: { id: 'resp-network-error' },
+            };
+            throw new TypeError('network unavailable');
+          },
+          finalResponse: async () => {
+            throw new Error('stream failure should not call finalResponse');
+          },
+        }),
+        retrieve: async () => {
+          retrieveCalls += 1;
+          throw new Error('non-OpenAI stream error should not retrieve');
+        },
+      },
+    };
+
+    await assert.rejects(
+      handler.createResponse({
+        client: client as any,
+        messages: createMessages(1),
+        temperature: 0,
+      }),
+      /network unavailable/,
+    );
+    assert.equal(retrieveCalls, 0);
+  });
+
   it('does not retrieve stateless responses after an unhandled stream event', async () => {
     const handler = createStatelessHandler();
     handler.getStreamingConfig = () => true;

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
@@ -621,6 +621,176 @@ describe('ModelHandlerOpenAIResponse.createResponse', () => {
     ]);
   });
 
+  it('resumes a fallback response when the first retrieve fails', async () => {
+    const handler = createHandler({
+      openRouterOnly: false,
+      capabilities: {
+        ...DEFAULT_MODEL_CAPABILITIES,
+        supportsNativeWebSearch: true,
+      },
+    });
+    handler.getStreamingConfig = () => true;
+
+    let streamCalls = 0;
+    let tokenCountCalls = 0;
+    const retrieveCalls: Array<{ id: string; params: unknown }> = [];
+    const client = {
+      responses: {
+        inputTokens: {
+          count: async () => {
+            tokenCountCalls += 1;
+            return { input_tokens: 100 };
+          },
+        },
+        stream: () => {
+          streamCalls += 1;
+          return {
+            async *[Symbol.asyncIterator]() {
+              yield {
+                type: 'response.created',
+                response: { id: 'resp-retrieve-retry' },
+              };
+              throw new OpenAIError(
+                'Unhandled response stream event: response.keepalive',
+              );
+            },
+            finalResponse: async () => {
+              throw new Error('fallback stream should retrieve by id');
+            },
+          };
+        },
+        retrieve: async (id: string, params: unknown) => {
+          retrieveCalls.push({ id, params });
+          if (retrieveCalls.length === 1) {
+            throw new TypeError('retrieve unavailable');
+          }
+          return createResponse('resp-retrieve-retry', {
+            input_tokens: 12,
+          });
+        },
+      },
+    };
+
+    await assert.rejects(
+      handler.createResponse({
+        client: client as any,
+        messages: createMessages(1),
+        temperature: 0,
+      }),
+      /retrieve unavailable/,
+    );
+
+    const result = await handler.createResponse({
+      client: client as any,
+      messages: createMessages(1),
+      temperature: 0,
+    });
+
+    assert.equal(result.response.id, 'resp-retrieve-retry');
+    assert.equal(streamCalls, 1);
+    assert.equal(tokenCountCalls, 1);
+    assert.deepEqual(retrieveCalls, [
+      {
+        id: 'resp-retrieve-retry',
+        params: { include: ['web_search_call.action.sources'] },
+      },
+      {
+        id: 'resp-retrieve-retry',
+        params: { include: ['web_search_call.action.sources'] },
+      },
+    ]);
+  });
+
+  it('resumes fallback polling with include fields after a poll failure', async () => {
+    const handler = createHandler({
+      capabilities: {
+        ...DEFAULT_MODEL_CAPABILITIES,
+        supportsNativeWebSearch: true,
+      },
+    });
+    handler.getStreamingConfig = () => true;
+    (
+      handler as unknown as { backgroundPoller: BackgroundPoller<any> }
+    ).backgroundPoller = new BackgroundPoller({
+      pollIntervalMs: 0,
+      maxDurationMs: 1000,
+      isPending: (response: { status?: string | null }) =>
+        response.status === 'queued' || response.status === 'in_progress',
+      logger: createLoggerStub() as unknown as AgentTrace,
+    });
+
+    let streamCalls = 0;
+    const retrieveCalls: Array<{ id: string; params: unknown }> = [];
+    const pendingResponse = {
+      ...createResponse('resp-poll-retry', { input_tokens: 12 }),
+      status: 'in_progress',
+    };
+    const completedResponse = createResponse('resp-poll-retry', {
+      input_tokens: 12,
+    });
+    const client = {
+      responses: {
+        stream: () => {
+          streamCalls += 1;
+          return {
+            async *[Symbol.asyncIterator]() {
+              yield {
+                type: 'response.created',
+                response: { id: 'resp-poll-retry' },
+              };
+              throw new OpenAIError(
+                'Unhandled response stream event: response.keepalive',
+              );
+            },
+            finalResponse: async () => {
+              throw new Error('fallback stream should retrieve by id');
+            },
+          };
+        },
+        retrieve: async (id: string, params: unknown) => {
+          retrieveCalls.push({ id, params });
+          if (retrieveCalls.length === 1) return pendingResponse;
+          if (retrieveCalls.length === 2) {
+            throw new TypeError('poll unavailable');
+          }
+          return completedResponse;
+        },
+      },
+    };
+
+    await assert.rejects(
+      handler.createResponse({
+        client: client as any,
+        messages: createMessages(1),
+        temperature: 0,
+      }),
+      /poll unavailable/,
+    );
+
+    const result = await handler.createResponse({
+      client: client as any,
+      messages: createMessages(1),
+      temperature: 0,
+    });
+
+    assert.equal(result.response.id, 'resp-poll-retry');
+    assert.equal(streamCalls, 1);
+    assert.deepEqual(retrieveCalls, [
+      {
+        id: 'resp-poll-retry',
+        params: { include: ['web_search_call.action.sources'] },
+      },
+      {
+        id: 'resp-poll-retry',
+        params: { include: ['web_search_call.action.sources'] },
+      },
+      {
+        id: 'resp-poll-retry',
+        params: { include: ['web_search_call.action.sources'] },
+      },
+    ]);
+  });
+
   it('uses the preserved token baseline after an invalid previous response id clears chaining', async () => {
     const handler = createHandler({
       openRouterOnly: false,


### PR DESCRIPTION
## Summary
- `openai@6.45.0` can throw `Unhandled response stream event: ...` from its Responses stream accumulator when a long-running stream contains an event type that the SDK has not typed yet. TeXRA now catches only that SDK failure mode after a `response.created` id has been seen.
- Healthy streams continue through `stream.finalResponse()`. The polling fallback is used only after the guarded SDK accumulator error, and stateless backends such as ChatGPT subscription Codex (`store: false`) rethrow instead of attempting a doomed `responses.retrieve()`.
- Fallback `responses.retrieve()` and background polling preserve the original request `include` fields, so recovered responses retain web-search sources and replayable reasoning fields where requested.
- The WebSocket transport path remains independent of the SDK stream accumulator; TeXRA's `ResponseStreamProcessor.process()` already ignores unrecognized event types there.
- After rebasing over the dependency PRs, this PR no longer changes package manifests or the lockfile; it is now only the OpenAI streaming fallback and its regression tests.

## Follow-up
- #6868 tracks replacing the string-prefix guard with a stable OpenAI SDK discriminator if the SDK exposes one later.

## Verification
- `CI=true corepack pnpm vitest run src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts`
- `CI=true corepack pnpm run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the hot path for OpenAI Responses streaming and background resume, but behavior is gated (SDK message shape, response id, server-side store) and heavily covered by new tests.
> 
> **Overview**
> When the OpenAI Responses **HTTP stream** hits an SDK accumulator error for an event type outside its typed union (e.g. `response.keepalive`), the handler now **recovers by id** instead of failing the turn—**only** after `response.created` has provided a response id and only for the narrow `OpenAIError` message prefix `Unhandled response stream event`.
> 
> Healthy streams are unchanged (`finalResponse()` as before). **Stateless** backends (`store: false`, e.g. Codex subscription) still **rethrow** because `responses.retrieve()` is not viable.
> 
> Fallback **`responses.retrieve()`** and **background polling** now pass through the original request **`include`** params (web-search sources, encrypted reasoning, etc.), and pending-response resume state stores those params so retries resume the same id with the same shape. Pending background resume is attempted **earlier** in `createResponseImpl` so compaction state is not cleared before a resume path runs.
> 
> Regression tests cover happy path, fallback, pre-`response.created` failures, non-OpenAI errors, stateless behavior, `include` preservation, and retry after retrieve/poll failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 160179a599384c8d38ffc9fce8de93f81cc36e16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->