### PR TITLE
fix(anthropic): stop mislabeling post-message_start stream failures

### DIFF
--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -666,14 +666,20 @@ export class ModelHandlerAnthropic extends ModelHandler<
         );
         const requestId = stream.request_id;
 
-        // Wrap only non-APIError, non-abort stream failures. APIError
-        // subclasses carry status/headers/requestID/type needed for retry
-        // classification; aborts are identified through the metadata tag
-        // attached above (isUserAbort), which wrapping would hide.
+        // Wrap only non-APIError, non-abort stream failures that happened
+        // before message_start. APIError subclasses carry status/headers/
+        // requestID/type needed for retry classification; aborts are
+        // identified through the metadata tag attached above (isUserAbort),
+        // which wrapping would hide. Gate on diagnostics.messageStartReceived
+        // (tracked from the actual message_start SSE event) rather than
+        // stream.currentMessage, which the SDK does not keep populated once
+        // finalMessage() has settled — using it here previously mislabeled
+        // post-message_start failures (e.g. the message_stop guard above) as
+        // "closed before message_start", clobbering the more accurate error.
         const isAbort = isUserAbort(streamError);
         let enrichedError: unknown = streamError;
         if (
-          !stream.currentMessage &&
+          !diagnostics.messageStartReceived &&
           streamError instanceof Error &&
           !(streamError instanceof AnthropicAPIError) &&
           !isAbort

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -1472,17 +1472,32 @@ describe('ModelHandlerAnthropic pre-message_start error handling', () => {
   /**
    * Builds a minimal stream stub that mimics the surface of the Anthropic
    * SDK's MessageStream used by ModelHandlerAnthropic.createResponse:
-   *   - `.on()` for event listener registration (no-op)
+   *   - `.on()` for event listener registration; captures the `streamEvent`
+   *     handler so the option below can simulate a real message_start event
    *   - `.controller.abort()` (no-op)
    *   - `.finalMessage()` returning a promise that rejects with `error`
-   *   - `.currentMessage` undefined (simulates no message_start received)
+   *     (after emitting message_start first, if requested)
+   *   - `.currentMessage` undefined, mirroring the SDK not keeping this
+   *     populated once finalMessage() has resolved/rejected
    *   - `.request_id` undefined
    */
-  function buildStreamStub(error: unknown): unknown {
+  function buildStreamStub(
+    error: unknown,
+    options: { emitMessageStart?: boolean } = {},
+  ): unknown {
+    let streamEventHandler: ((event: unknown) => void) | undefined;
     return {
-      on: () => {},
+      on: (eventName: string, handler: (event: unknown) => void) => {
+        if (eventName === 'streamEvent') streamEventHandler = handler;
+      },
       controller: { abort: () => {} },
       finalMessage: async () => {
+        if (options.emitMessageStart) {
+          streamEventHandler?.({
+            type: 'message_start',
+            message: { id: 'msg_test123' },
+          });
+        }
         throw error;
       },
       currentMessage: undefined,
@@ -1552,6 +1567,70 @@ describe('ModelHandlerAnthropic pre-message_start error handling', () => {
           ),
           'abort error must not be wrapped with the pre-message_start sentinel message',
         );
+        return true;
+      },
+    );
+  });
+
+  it('preserves the original error message once message_start was received (does not mislabel a post-start stream failure)', async () => {
+    vi.spyOn(serverKeysModule, 'getServerSideKeyService').mockReturnValue({
+      shouldUseServerSideKeysSync: () => false,
+      getUseIncludedModelAccess: () => false,
+      canUseServerSideKeys: async () => false,
+      getRelayBaseUrl: (provider: string) =>
+        `https://relay.example.com/functions/v1/relay/${provider}/v1`,
+    } as unknown as ReturnType<
+      typeof serverKeysModule.getServerSideKeyService
+    >);
+
+    const handler = createAnthropicHandler({
+      supportsTokenCounting: false,
+      supportsReasoning: false,
+    });
+    handler.setLogger(createLoggerStub() as unknown as AgentTrace);
+    (handler as any).getStreamingConfig = () => true;
+
+    // Simulates the message_stop guard above: message_start (and content)
+    // was received, but the stream was truncated (e.g. proxy idle timeout
+    // during extended thinking) before message_stop ever arrived.
+    const droppedStreamError = new Error(
+      'Stream ended without message_stop after 400s (462 events, ' +
+        '37004 thinking chars, 0 text chars). Stream truncated, likely ' +
+        'proxy idle timeout during extended thinking.',
+    );
+    const streamStub = buildStreamStub(droppedStreamError, {
+      emitMessageStart: true,
+    });
+
+    const client = {
+      beta: {
+        messages: {
+          stream: () => streamStub,
+        },
+      },
+    } as any;
+
+    const messages: MessageParam[] = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'hello', citations: null }],
+      },
+    ];
+
+    await assert.rejects(
+      handler.createResponse({ client, messages, temperature: 0 }),
+      (err: unknown) => {
+        assert.ok(err instanceof Error, 'expected an Error to be thrown');
+        // The fix under test: once message_start was actually received, the
+        // pre-message_start wrap guard must not fire and clobber a more
+        // specific, more accurate error (previously this mislabeled the
+        // message_stop-guard error as "closed before message_start", even
+        // though message_start diagnostics showed it had, in fact, started).
+        assert.ok(
+          !/Stream closed before message_start/.test((err as Error).message),
+          `expected the original message_stop-guard error to survive unwrapped, got: ${(err as Error).message}`,
+        );
+        assert.equal((err as Error).message, droppedStreamError.message);
         return true;
       },
     );


### PR DESCRIPTION
## Summary
- The Anthropic streaming error-wrap guard checked `stream.currentMessage`, which the SDK does not keep populated once `finalMessage()` has resolved/rejected — this caused genuinely informative errors thrown *after* `message_start` (most notably the message_stop guard's "proxy idle timeout during extended thinking" message) to be silently overwritten with a generic, misleading "Stream closed before message_start / connection dropped before the API responded" message, even when diagnostics confirmed `message_start` had in fact been received.
- Gate the wrap on `diagnostics.messageStartReceived` instead — tracked directly from the `message_start` SSE event, unaffected by the SDK's internal stream-state bookkeeping.
- User-visible effect: long extended-thinking streams that get cut off mid-generation (e.g. by a proxy/VPN idle timeout) now surface the accurate "stream ended without message_stop, likely proxy idle timeout" diagnostic instead of the misleading "connection dropped before the API responded" message.

## Test plan
- [x] Added a regression test simulating `message_start` received + a subsequent generic stream failure (the message_stop-guard scenario) — asserts the original, more specific error message survives unwrapped.
- [x] Existing "preserves AnthropicUserAbortError thrown before message_start" test still passes unchanged.
- [x] `npx vitest run src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts` — 33/33 passing.
- [x] `npx tsc --noEmit -p tsconfig.json` — clean.
- [x] `npx prettier --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to streaming error enrichment in the Anthropic handler plus tests; no auth, billing, or API contract changes.
> 
> **Overview**
> Fixes **misleading Anthropic streaming error messages** when a stream fails after `message_start` (e.g. truncated extended-thinking runs).
> 
> The catch-path guard that wraps generic failures as *"Stream closed before message_start"* now keys off **`diagnostics.messageStartReceived`** (set from the real `message_start` SSE event) instead of **`stream.currentMessage`**, which the SDK clears after `finalMessage()` settles. That mismatch used to **overwrite** more specific errors—especially the **`message_stop` guard** text about proxy idle timeout—with the generic pre-start message.
> 
> Adds a **regression test** that emits `message_start` then fails, asserting the original error message is preserved; the stream stub can optionally fire `message_start` via a captured `streamEvent` handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 029bd75bead69a824c29ffb08b49504f59b82aed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->