### PR TITLE
fix(agent): defer flow retries to provider retry owners

### DIFF
--- a/src/agent/core/flows/ModelInvocationNode.ts
+++ b/src/agent/core/flows/ModelInvocationNode.ts
@@ -8,6 +8,7 @@ import {
   saveCycleDebug,
 } from '@agent/core/flows/CommonCycleTypes';
 import type { BaseFlowContextInit } from '@agent/core/flows/BaseFlowServices';
+import { requiresFlowAutoRetry } from '@common/errors/sdkErrorUtils';
 import type { ToolDefinition } from '@model';
 
 import { FlowTransition } from './FlowTransitions';
@@ -64,6 +65,30 @@ export class ModelInvocationNode<
       this._config.backgroundModeAware === true &&
       this.services.modelHandler.isBackgroundModeActive()
     );
+  }
+
+  override shouldAutoRetry(error: Error): boolean {
+    if (!super.shouldAutoRetry(error)) return false;
+
+    if (requiresFlowAutoRetry(error)) {
+      this.services.logger.debug(
+        'Using flow-level auto-retry; the failure is outside the provider-managed retry boundary.',
+      );
+      return true;
+    }
+
+    const isProviderManagedAutoRetry =
+      this.services.modelHandler.isAutoRetryManagedByProvider?.(error) ??
+      this.services.modelHandler.usesProviderManagedAutoRetry === true;
+
+    if (isProviderManagedAutoRetry) {
+      this.services.logger.debug(
+        'Skipping flow-level auto-retry; the model handler uses provider-managed auto-retry.',
+      );
+      return false;
+    }
+
+    return true;
   }
 
   async prep(shared: TShared): Promise<BaseInvocationPrepResult> {

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -503,6 +503,14 @@ export abstract class ModelHandler<
     return false;
   }
 
+  get usesProviderManagedAutoRetry(): boolean {
+    return false;
+  }
+
+  isAutoRetryManagedByProvider(_error: Error): boolean {
+    return this.usesProviderManagedAutoRetry;
+  }
+
   /**
    * Flag to force compaction on the next API call, set by {@link requestCompaction}.
    * Read by the per-provider compaction paths and cleared once compaction is

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -27,6 +27,7 @@ import {
   getSdkErrorMessage,
   attachStreamDiagnostics,
   attachPartialText,
+  attachFlowAutoRetryRequired,
   takeTail,
   isUserAbort,
   PARTIAL_TEXT_TAIL_MAX,
@@ -249,8 +250,15 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const baseUrl = this.getBaseUrl();
     this.logger.debug(`Using Anthropic API. Base URL: ${baseUrl}`);
 
-    // For relay auth: credential is the user's JWT, SDK sends it via x-api-key header
-    return new Anthropic({ apiKey: credential, baseURL: baseUrl });
+    // For relay auth: credential is the user's JWT, SDK sends it via x-api-key header.
+    return new Anthropic({
+      apiKey: credential,
+      baseURL: baseUrl,
+    });
+  }
+
+  override get usesProviderManagedAutoRetry(): boolean {
+    return true;
   }
 
   /**
@@ -588,6 +596,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
         throw new AnthropicUserAbortError();
       }
 
+      let streamConnected = false;
+      const onConnect = (): void => {
+        streamConnected = true;
+      };
+      stream.on('connect', onConnect);
+
       let cleanupAbortListener: (() => void) | undefined;
       if (signal) {
         const abortListener = () => {
@@ -694,10 +708,16 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
         attachStreamDiagnostics(enrichedError, diagnostics);
         attachPartialText(enrichedError, partialText);
+        if (streamConnected || partialText) {
+          attachFlowAutoRetryRequired(enrichedError);
+        }
         throw enrichedError;
       } finally {
         // Always finalize stream handler to prevent memory leaks on error
         streamHandler.finalize();
+        if (typeof stream.off === 'function') {
+          stream.off('connect', onConnect);
+        }
         cleanupAbortListener?.();
       }
     } else {

--- a/src/agent/modelHandlers/openai/OpenAIResponseWebSocketTransport.ts
+++ b/src/agent/modelHandlers/openai/OpenAIResponseWebSocketTransport.ts
@@ -13,6 +13,7 @@ import { WebSocketError } from 'openai/resources/responses/internal-base';
 
 import type { AgentTrace } from '@agent/trace';
 import {
+  attachFlowAutoRetryRequired,
   attachPartialText,
   takeTail,
   PARTIAL_TEXT_TAIL_MAX,
@@ -157,6 +158,7 @@ export class OpenAIResponseWebSocketTransport {
       const onError = (err: Error): void => {
         cleanup();
         closeQuietly(ws);
+        attachFlowAutoRetryRequired(err);
         reject(err);
       };
       const onAbort = (): void => {
@@ -278,6 +280,7 @@ export class OpenAIResponseWebSocketTransport {
         if (streamedText) {
           attachPartialText(err, takeTail(streamedText, PARTIAL_TEXT_TAIL_MAX));
         }
+        attachFlowAutoRetryRequired(err);
         reject(err);
       };
 

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -18,6 +18,7 @@ import {
   getSdkErrorMessage,
   isMissingFinishReasonError,
   attachPartialText,
+  attachFlowAutoRetryRequired,
   isUserAbort,
   PARTIAL_TEXT_TAIL_MAX,
 } from '@common/errors/sdkErrorUtils';
@@ -202,6 +203,10 @@ export class ModelHandlerOpenAI<
     return this.createOpenAIClient();
   }
 
+  override get usesProviderManagedAutoRetry(): boolean {
+    return true;
+  }
+
   /**
    * Allows subclasses to provide a streaming aggregator implementation.
    */
@@ -354,6 +359,10 @@ export class ModelHandlerOpenAI<
     const stream = await client.chat.completions.stream(streamParams, {
       signal,
     });
+    let streamConnected = false;
+    const onConnect = (): void => {
+      streamConnected = true;
+    };
     const streamingAggregator = this.createStreamingAggregator();
 
     const onContentDelta = ({ delta }: ContentDeltaEvent): void => {
@@ -372,10 +381,12 @@ export class ModelHandlerOpenAI<
       }
     };
 
+    stream.on('connect', onConnect);
     stream.on('content.delta', onContentDelta);
     stream.on('chunk', onChunk);
 
     const cleanup = (): void => {
+      stream.off('connect', onConnect);
       stream.off('content.delta', onContentDelta);
       stream.off('chunk', onChunk);
     };
@@ -423,6 +434,9 @@ export class ModelHandlerOpenAI<
       );
       if (partialText) {
         attachPartialText(streamError, partialText);
+      }
+      if (streamConnected || partialText) {
+        attachFlowAutoRetryRequired(streamError);
       }
       const isAbort = isUserAbort(streamError);
       if (!isAbort) {

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -23,6 +23,7 @@ import {
   isPreviousResponseIdError,
   isUserAbort,
   attachPartialText,
+  attachFlowAutoRetryRequired,
   takeTail,
   PARTIAL_TEXT_TAIL_MAX,
 } from '@common/errors/sdkErrorUtils';
@@ -471,6 +472,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       const { providerError, shouldRetainPendingResponse } =
         classifyOpenAIBackgroundResumeError(err, this.config.provider);
       if (shouldRetainPendingResponse) {
+        attachFlowAutoRetryRequired(err);
         throw err;
       }
       this.logger.warn(
@@ -978,6 +980,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   /** Returns OpenAI client with configured API key. */
   async getClient(): Promise<OpenAI> {
     return this.createOpenAIClient();
+  }
+
+  override get usesProviderManagedAutoRetry(): boolean {
+    return true;
   }
 
   /** Reset conversation bookkeeping when starting a new session. */
@@ -1753,16 +1759,29 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     // Hoisted so the catch can finalize the progress streams on a mid-stream
     // failure (otherwise the progress view hangs in a loading state).
     let processor: ResponseStreamProcessor | undefined;
+    let streamConnected = false;
+    let streamEventObserved = false;
+    const onConnect = (): void => {
+      streamConnected = true;
+    };
+    let removeConnectListener: (() => void) | undefined;
     try {
       const { stream: _stream, ...rest } = params;
       const streamParams: ResponseStreamParams = { ...rest, stream: true };
       const stream = await client.responses.stream(streamParams, { signal });
+      if (typeof stream.on === 'function') {
+        stream.on('connect', onConnect);
+        if (typeof stream.off === 'function') {
+          removeConnectListener = () => stream.off('connect', onConnect);
+        }
+      }
 
       // Processor handles interleaved thinking and web search
       // GPT can: think → web_search → think more → web_search → text
       processor = this.createStreamProcessor();
 
       for await (const event of stream) {
+        streamEventObserved = true;
         processor.process(event);
         if (event.type === 'response.output_text.delta') {
           streamedText += event.delta;
@@ -1806,7 +1825,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       if (streamedText) {
         attachPartialText(error, takeTail(streamedText, PARTIAL_TEXT_TAIL_MAX));
       }
+      if (streamConnected || streamEventObserved || streamedText) {
+        attachFlowAutoRetryRequired(error);
+      }
       throw error;
+    } finally {
+      removeConnectListener?.();
     }
   }
 
@@ -2046,61 +2070,70 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     this.pendingBackgroundResponseId = initialResponse.id;
 
     let pollStats: BackgroundPollStats | undefined;
-    const polled = (await this.backgroundPoller.poll({
-      initialResponse,
-      retrieve: async (responseId, sig) => {
-        try {
-          return (await client.responses.retrieve(
-            responseId,
-            undefined,
-            sig ? { signal: sig } : undefined,
-          )) as T;
-        } catch (err) {
-          // Tag before checking: retrieve() throws the SDK's APIUserAbortError,
-          // not a DOMException, when the signal fires.
-          tagOpenAISdkError(err, this.config.provider);
-          if (isUserAbort(err)) {
-            // User cancelled during retrieve — clear pending ID to prevent
-            // ghost-resume on next call.
-            this.clearPendingBackgroundResponse();
+    let polled: T;
+    try {
+      polled = (await this.backgroundPoller.poll({
+        initialResponse,
+        retrieve: async (responseId, sig) => {
+          try {
+            return (await client.responses.retrieve(
+              responseId,
+              undefined,
+              sig ? { signal: sig } : undefined,
+            )) as T;
+          } catch (err) {
+            // Tag before checking: retrieve() throws the SDK's APIUserAbortError,
+            // not a DOMException, when the signal fires.
+            tagOpenAISdkError(err, this.config.provider);
+            if (isUserAbort(err)) {
+              // User cancelled during retrieve — clear pending ID to prevent
+              // ghost-resume on next call.
+              this.clearPendingBackgroundResponse();
+              throw err;
+            }
+            // 404 "response not found" during polling means the response is truly
+            // gone server-side. Clear the pending ID so the next retry creates a
+            // fresh background request instead of routing through
+            // tryResumeBackgroundResponse to rediscover the 404.
+            const statusCode = detectStatusCode(err);
+            if (statusCode === 404) {
+              this.clearPendingBackgroundResponse();
+              throw createOpenAIBackgroundPollingError(
+                responseId,
+                err,
+                this.config.provider,
+              );
+            }
+            attachFlowAutoRetryRequired(err);
+            // All other errors (401, 403, 5xx, network, etc.) propagate unchanged
+            // so downstream handlers (relay 401 token refresh, retryability checks,
+            // non-retryable classification) work correctly with full HTTP metadata.
+            // The ID is intentionally NOT cleared — retry may resume the same response.
             throw err;
           }
-          // 404 "response not found" during polling means the response is truly
-          // gone server-side. Clear the pending ID so the next retry creates a
-          // fresh background request instead of routing through
-          // tryResumeBackgroundResponse to rediscover the 404.
-          const statusCode = detectStatusCode(err);
-          if (statusCode === 404) {
-            this.clearPendingBackgroundResponse();
-            throw createOpenAIBackgroundPollingError(
-              responseId,
-              err,
-              this.config.provider,
-            );
-          }
-          // All other errors (401, 403, 5xx, network, etc.) propagate unchanged
-          // so downstream handlers (relay 401 token refresh, retryability checks,
-          // non-retryable classification) work correctly with full HTTP metadata.
-          // The ID is intentionally NOT cleared — retry may resume the same response.
-          throw err;
-        }
-      },
-      extractId: (r) => r.id,
-      extractStatus: (r) => r.status ?? 'unknown',
-      signal,
-      resourceLabel: 'response',
-      providerLabel: 'OpenAI',
-      onAbort: () => this.clearPendingBackgroundResponse(),
-      formatTimeoutError: ({ responseId, maxDurationMs }) =>
-        `OpenAI response ${responseId} exceeded maximum polling duration of ${maxDurationMs} ms. ` +
-        `Retry later or cancel the job with client.responses.cancel("${responseId}").`,
-      extraFinishData: (response) => ({
-        usage: response.usage ?? undefined,
-      }),
-      onFinished: (_response, stats) => {
-        pollStats = stats;
-      },
-    })) as T;
+        },
+        extractId: (r) => r.id,
+        extractStatus: (r) => r.status ?? 'unknown',
+        signal,
+        resourceLabel: 'response',
+        providerLabel: 'OpenAI',
+        onAbort: () => this.clearPendingBackgroundResponse(),
+        formatTimeoutError: ({ responseId, maxDurationMs }) =>
+          `OpenAI response ${responseId} exceeded maximum polling duration of ${maxDurationMs} ms. ` +
+          `Retry later or cancel the job with client.responses.cancel("${responseId}").`,
+        extraFinishData: (response) => ({
+          usage: response.usage ?? undefined,
+        }),
+        onFinished: (_response, stats) => {
+          pollStats = stats;
+        },
+      })) as T;
+    } catch (err) {
+      if (!isUserAbort(err)) {
+        attachFlowAutoRetryRequired(err);
+      }
+      throw err;
+    }
 
     if (polled.status === 'completed') {
       return polled;

--- a/src/agent/modelHandlers/openai/openAIResponseErrors.ts
+++ b/src/agent/modelHandlers/openai/openAIResponseErrors.ts
@@ -1,5 +1,6 @@
 // Local imports - common errors
 import {
+  attachFlowAutoRetryRequired,
   isRetryableStatusCode,
   normalizeProviderError,
 } from '@common/errors/sdkErrorUtils';
@@ -83,6 +84,7 @@ export function createOpenAIBackgroundPollingError(
   if (causeError.requestId) {
     pollingError.request_id = causeError.requestId;
   }
+  attachFlowAutoRetryRequired(pollingError);
   return pollingError;
 }
 
@@ -102,5 +104,6 @@ export function createOpenAIBackgroundTerminalError(
   if (response.error) {
     wrapped.error = response.error;
   }
+  attachFlowAutoRetryRequired(wrapped);
   return wrapped;
 }

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -1,9 +1,13 @@
 // Third-party imports
 import { OpenRouter } from '@openrouter/sdk';
+import {
+  ConnectionError as OpenRouterConnectionError,
+  RequestTimeoutError as OpenRouterRequestTimeoutError,
+} from '@openrouter/sdk/models/errors';
 import { ModelProvider } from 'llm-zoo';
 
 // Local imports - agent
-import { logSdkError } from '@agent/trace';
+import { logSdkError, type StreamHandle } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { AgentSetting } from '@agent/core/definition/AgentDataclass';
 import type { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
@@ -12,6 +16,8 @@ import type { MediaEntry } from '@agent/utils/mediaTypes';
 import { K_SLICE } from '@agent/core/constants';
 import {
   attachPartialText,
+  attachFlowAutoRetryRequired,
+  detectStatusCode,
   getSdkErrorMessage,
   takeTail,
   PARTIAL_TEXT_TAIL_MAX,
@@ -131,6 +137,24 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     });
   }
 
+  override get usesProviderManagedAutoRetry(): boolean {
+    return true;
+  }
+
+  override isAutoRetryManagedByProvider(error: Error): boolean {
+    if (
+      error instanceof OpenRouterConnectionError ||
+      error instanceof OpenRouterRequestTimeoutError
+    ) {
+      return true;
+    }
+
+    const statusCode = detectStatusCode(error);
+    // @openrouter/sdk v0.13.21 defaults chatSend retryCodes to ["5XX"];
+    // 429/408 HTTP responses remain owned by TeXRA's flow retry.
+    return statusCode !== undefined && statusCode >= 500;
+  }
+
   // ---------------------------------------------------------------------------
   // createResponse
   // ---------------------------------------------------------------------------
@@ -209,17 +233,22 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
         stream: true,
         streamOptions: { includeUsage: true },
       };
-      const stream = await client.chat.send(
-        { chatRequest: streamRequest },
-        { signal },
-      );
       const aggregator = new OpenRouterStreamAggregator();
-      // Opened before the request; the deferred starts fire (if ever) at the
-      // first reasoning/content delta — the phase signal for this API.
-      const thinking = this.createThinkingStream();
-      const output = this.createOutputStream();
+      let thinking: StreamHandle | undefined;
+      let output: StreamHandle | undefined;
+      let streamConnected = false;
 
       try {
+        const stream = await client.chat.send(
+          { chatRequest: streamRequest },
+          { signal },
+        );
+        streamConnected = true;
+        // Opened after the SDK request-retry boundary returns; the deferred
+        // starts fire (if ever) at the first reasoning/content delta.
+        thinking = this.createThinkingStream();
+        output = this.createOutputStream();
+
         for await (const chunk of stream) {
           const { contentDelta, reasoningDelta } =
             aggregator.consumeChunk(chunk);
@@ -246,8 +275,8 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
         // the progress view from being stuck in a loading state. No explicit
         // final text so any chunks already streamed are preserved (passing `''`
         // would overwrite the visible partial output).
-        thinking.finalize(undefined);
-        output.finalize();
+        thinking?.finalize(undefined);
+        output?.finalize();
         // Lift the accumulated partial text onto the error so the retry UI
         // can show the tail (parity with the other streaming providers).
         const partialTail = takeTail(
@@ -256,6 +285,9 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
         );
         if (partialTail) {
           attachPartialText(err, partialTail);
+        }
+        if (streamConnected || partialTail) {
+          attachFlowAutoRetryRequired(err);
         }
         throw err;
       }

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -214,6 +214,23 @@ export interface IModelHandler<
   readonly supportsManualCompaction: boolean;
 
   /**
+   * True when the provider client or handler already owns automatic transient
+   * retries. Flow-level model invocation should not add another automatic retry
+   * layer on top of it; manual retry remains available after the provider layer
+   * gives up. Provider handlers may still mark post-request failures, such as
+   * stream-consumption or background-polling errors, as requiring flow-level
+   * auto-retry because those failures are outside the SDK retry boundary.
+   */
+  readonly usesProviderManagedAutoRetry?: boolean;
+
+  /**
+   * Error-specific refinement for provider-managed retry ownership. Handlers
+   * whose SDK retries only a subset of transient failures can return false for
+   * errors that should still use TeXRA's flow-level automatic retry.
+   */
+  isAutoRetryManagedByProvider?(error: Error): boolean;
+
+  /**
    * Request context compaction on the next API call.
    * For handlers that support it, this forces compaction regardless of the
    * automatic threshold. No-op for handlers that don't support compaction.

--- a/src/common/errors/sdkError/errorMetadata.ts
+++ b/src/common/errors/sdkError/errorMetadata.ts
@@ -64,6 +64,31 @@ export function attachPartialText(err: unknown, text: string): void {
 
 export const detectPartialText = partialTextMetadata.detect;
 
+const flowAutoRetryRequiredMetadata = createErrorMetadata<boolean>(
+  'flowAutoRetryRequired',
+  (v): v is boolean => v === true,
+);
+
+/**
+ * Marks errors that are outside the provider SDK's automatic retry boundary.
+ * Examples include failures while consuming an already-open stream or polling
+ * an already-created background response.
+ */
+export function attachFlowAutoRetryRequired(err: unknown): void {
+  flowAutoRetryRequiredMetadata.attach(err, true);
+}
+
+export function requiresFlowAutoRetry(err: unknown): boolean {
+  for (
+    let current: unknown = err;
+    current != null && typeof current === 'object';
+    current = (current as { cause?: unknown }).cause
+  ) {
+    if (flowAutoRetryRequiredMetadata.detect(current) === true) return true;
+  }
+  return false;
+}
+
 export const providerErrorMetadata =
   createErrorMetadata<ProviderError>('providerError');
 

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -16,6 +16,8 @@ export {
   attachSdkErrorMetadata,
   attachStreamDiagnostics,
   attachPartialText,
+  attachFlowAutoRetryRequired,
+  requiresFlowAutoRetry,
   attachProviderError,
 } from './sdkError/errorMetadata';
 

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenRouterNative.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenRouterNative.vitest.ts
@@ -1,5 +1,9 @@
 // Third-party imports
 import { strict as assert } from 'node:assert';
+import {
+  ConnectionError as OpenRouterConnectionError,
+  RequestTimeoutError as OpenRouterRequestTimeoutError,
+} from '@openrouter/sdk/models/errors';
 import { describe, it, afterEach, vi } from 'vitest';
 import {
   DEFAULT_MODEL_CAPABILITIES,
@@ -42,6 +46,12 @@ function stubServerSideKeyService(): void {
   } as unknown as ReturnType<typeof serverKeysModule.getServerSideKeyService>);
 }
 
+function statusError(statusCode: number): Error {
+  return Object.assign(new Error(`OpenRouter HTTP ${statusCode}`), {
+    statusCode,
+  });
+}
+
 describe('ModelHandlerOpenRouterNative routing precedence', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -81,4 +91,28 @@ describe('ModelHandlerOpenRouterNative routing precedence', () => {
       assert.equal((handler as any).shouldUseServerSideKeys(), expected);
     },
   );
+});
+
+describe('ModelHandlerOpenRouterNative retry ownership', () => {
+  it('matches the OpenRouter SDK retry boundary', () => {
+    const handler = new ModelHandlerOpenRouterNative(buildConfig());
+
+    assert.equal(handler.usesProviderManagedAutoRetry, true);
+    assert.equal(handler.isAutoRetryManagedByProvider(statusError(500)), true);
+    assert.equal(handler.isAutoRetryManagedByProvider(statusError(529)), true);
+    assert.equal(handler.isAutoRetryManagedByProvider(statusError(429)), false);
+    assert.equal(handler.isAutoRetryManagedByProvider(statusError(408)), false);
+    assert.equal(
+      handler.isAutoRetryManagedByProvider(
+        new OpenRouterConnectionError('connection failed'),
+      ),
+      true,
+    );
+    assert.equal(
+      handler.isAutoRetryManagedByProvider(
+        new OpenRouterRequestTimeoutError('request timed out'),
+      ),
+      true,
+    );
+  });
 });

--- a/src/test-kernel/agent/modelHandlers/OpenAIResponseBackgroundAbort.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIResponseBackgroundAbort.vitest.ts
@@ -7,9 +7,13 @@ import { describe, expect, it, vi } from 'vitest';
 import type { AgentTrace } from '@agent/trace';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/openai/modelHandlerOpenAIResponse';
 import { tagOpenAISdkError } from '@agent/modelHandlers/openai/openAISdkError';
+import { BackgroundPoller } from '@agent/modelHandlers/support/BackgroundPoller';
 
 // Local imports - common errors
-import { isUserAbort } from '@common/errors/sdkErrorUtils';
+import {
+  isUserAbort,
+  requiresFlowAutoRetry,
+} from '@common/errors/sdkErrorUtils';
 
 // Type imports
 import type OpenAI from 'openai';
@@ -40,9 +44,18 @@ function createHandler(): ModelHandlerOpenAIResponse {
 }
 
 type BackgroundInternals = {
+  backgroundPoller: BackgroundPoller<{
+    id?: string;
+    status?: string | null;
+  }>;
   pendingBackgroundResponseId: string | null;
   tryResumeBackgroundResponse(
     client: OpenAI,
+    signal?: AbortSignal,
+  ): Promise<unknown>;
+  waitForBackgroundCompletion(
+    client: OpenAI,
+    initialResponse: { id?: string; status?: string | null },
     signal?: AbortSignal,
   ): Promise<unknown>;
 };
@@ -111,5 +124,36 @@ describe('OpenAI Responses background abort handling', () => {
     // No status code → likely still alive server-side → keep the ID so the
     // outer retry resumes the same response.
     expect(target.pendingBackgroundResponseId).toBe('resp_pending_transient');
+    expect(requiresFlowAutoRetry(transient)).toBe(true);
+  });
+
+  it('marks background polling timeouts for flow-level retry', async () => {
+    const handler = createHandler();
+    const target = internals(handler);
+    target.backgroundPoller = new BackgroundPoller({
+      pollIntervalMs: 1,
+      maxDurationMs: 0,
+      isPending: (response) => response.status === 'in_progress',
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        domain: vi.fn(),
+      } as unknown as AgentTrace,
+    });
+
+    let thrown: unknown;
+    try {
+      await target.waitForBackgroundCompletion(
+        { responses: { retrieve: vi.fn() } } as unknown as OpenAI,
+        { id: 'resp_timeout', status: 'in_progress' },
+      );
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect(requiresFlowAutoRetry(thrown)).toBe(true);
   });
 });

--- a/src/test-kernel/agent/modelHandlers/OpenAIResponseErrors.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIResponseErrors.vitest.ts
@@ -14,6 +14,7 @@ import {
 import {
   formatProviderHttpError,
   normalizeProviderError,
+  requiresFlowAutoRetry,
 } from '@common/errors/sdkErrorUtils';
 
 describe('OpenAI Responses error normalization', () => {
@@ -85,6 +86,7 @@ describe('OpenAI Responses error normalization', () => {
     expect(normalized.statusCode).toBeUndefined();
     expect(normalized.requestId).toBe('req_poll');
     expect(normalized.userRetryable).toBe(true);
+    expect(requiresFlowAutoRetry(wrapped)).toBe(true);
   });
 
   it('keeps terminal background statuses retryable without HTTP metadata', () => {
@@ -105,5 +107,6 @@ describe('OpenAI Responses error normalization', () => {
     expect(providerError.statusCode).toBeUndefined();
     expect(providerError.userRetryable).toBe(true);
     expect(providerError.message).toContain('resp_failed');
+    expect(requiresFlowAutoRetry(wrapped)).toBe(true);
   });
 });

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -4,6 +4,8 @@ import { describe, expect, it, vi, type Mock } from 'vitest';
 // Local imports - agent runtime
 import { noopTrace, type AgentTrace } from '@agent/trace';
 import type { NonIterableObject } from '@agent/node';
+import type { BaseCycleFields } from '@agent/core/flows/CommonCycleTypes';
+import { ModelInvocationNode } from '@agent/core/flows/ModelInvocationNode';
 import { RetryableInvocationNode } from '@agent/core/flows/RetryState';
 import type { RetryResult } from '@agent/runtime/RetryRequestCoordinator';
 import {
@@ -14,6 +16,7 @@ import {
   noopAgentRuntimeHost,
   type AgentRuntimeHost,
 } from '@agent/runtime/AgentRuntimeHost';
+import { attachFlowAutoRetryRequired } from '@common/errors/sdkErrorUtils';
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 
 interface TestRetryServices {
@@ -66,6 +69,24 @@ function createRetryNode(streamId: StreamTabId): RetryNodeKit {
   return { node, streamStatus, waitForRetry };
 }
 
+function createModelInvocationNode(input: {
+  usesProviderManagedAutoRetry: boolean;
+  isAutoRetryManagedByProvider?: (error: Error) => boolean;
+}): ModelInvocationNode<BaseCycleFields> {
+  return new ModelInvocationNode<BaseCycleFields>({
+    operationName: 'Model call',
+    streaming: false,
+    storeResponse: vi.fn(),
+  }).setServices({
+    modelHandler: {
+      usesProviderManagedAutoRetry: input.usesProviderManagedAutoRetry,
+      isAutoRetryManagedByProvider: input.isAutoRetryManagedByProvider,
+      isBackgroundModeActive: () => false,
+    },
+    logger: noopTrace,
+  } as never);
+}
+
 describe('RetryState', () => {
   it('treats user aborts as cancellations instead of failed invocations', () => {
     const node = new ExposedRetryNode();
@@ -73,6 +94,46 @@ describe('RetryState', () => {
 
     expect(node.shouldAutoRetry(abort)).toBe(false);
     expect(node.fallbackFor(abort)).toEqual({ kind: 'cancelled' });
+  });
+
+  it('skips flow-level auto-retry when the model handler delegates retries to the provider', () => {
+    const node = createModelInvocationNode({
+      usesProviderManagedAutoRetry: true,
+    });
+
+    expect(node.shouldAutoRetry(new Error('temporary provider failure'))).toBe(
+      false,
+    );
+  });
+
+  it('keeps flow-level auto-retry for errors outside the provider retry boundary', () => {
+    const node = createModelInvocationNode({
+      usesProviderManagedAutoRetry: true,
+    });
+    const streamError = new Error('stream closed after response started');
+
+    attachFlowAutoRetryRequired(streamError);
+
+    expect(node.shouldAutoRetry(streamError)).toBe(true);
+  });
+
+  it('keeps flow-level auto-retry when the handler predicate excludes an error', () => {
+    const node = createModelInvocationNode({
+      usesProviderManagedAutoRetry: true,
+      isAutoRetryManagedByProvider: () => false,
+    });
+
+    expect(node.shouldAutoRetry(new Error('rate limit'))).toBe(true);
+  });
+
+  it('uses flow-level auto-retry when the model handler has no provider-managed retry', () => {
+    const node = createModelInvocationNode({
+      usesProviderManagedAutoRetry: false,
+    });
+
+    expect(node.shouldAutoRetry(new Error('temporary provider failure'))).toBe(
+      true,
+    );
   });
 
   it('updates the injected stream status owner during manual retry', async () => {


### PR DESCRIPTION
## Summary
- Keeps provider SDK retry defaults for OpenAI-compatible, Responses, Anthropic, and OpenRouter handlers.
- Adds a declarative `usesProviderManagedAutoRetry` handler flag plus an error-specific `isAutoRetryManagedByProvider` predicate for providers whose SDK retries only part of the transient error space.
- Makes `ModelInvocationNode` skip TeXRA flow-level automatic retry when the provider owns that specific retry boundary.
- Preserves TeXRA flow-level automatic retry for post-request failures marked outside that provider boundary, including stream-consumption failures, WebSocket transport/handshake failures, and OpenAI Responses background polling/resume failures.
- Matches OpenRouter SDK behavior explicitly: the SDK owns 5xx HTTP retries plus connection/timeout retries, while TeXRA still owns 429/408 HTTP response retries and post-stream consumption failures.

## Rationale
Handlers with SDK-managed request retry should own the automatic retry budget for transient provider request failures. TeXRA flow-level automatic retry remains the fallback for handlers without provider-managed retry, such as the Google path where SDK retry is explicitly disabled.

Some failures occur after the provider retry layer can no longer replay the operation, for example an already-open stream dropping or an already-created background response failing during polling, timeout, or resume. Those errors are marked with flow-retry metadata so the outer retry loop still owns resumption, including the background-mode retry budget.

This avoids retry multiplication without removing SDK retries from helper-model calls, audio transcription, or provider-side file uploads that happen outside `ModelInvocationNode`.

## Verification
- `CI=true corepack pnpm vitest run src/test-kernel/agent/runtime/RetryState.vitest.ts src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts src/test-kernel/agent/modelHandlers/ModelHandlerOpenRouterNative.vitest.ts`
- `CI=true corepack pnpm run typecheck`
- `CI=true corepack pnpm run lint` (passes with existing unrelated warnings)
- `CI=true corepack pnpm run test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when automatic retries fire for live model calls and background polling; misclassification could either double-retry or skip recovery on stream/background failures.
> 
> **Overview**
> **Splits automatic retry ownership** between provider SDKs and TeXRA’s flow so transient request failures are not retried twice.
> 
> `ModelInvocationNode.shouldAutoRetry` now **skips** flow-level auto-retry when the model handler reports provider-managed retries (`usesProviderManagedAutoRetry` / `isAutoRetryManagedByProvider`), unless the error is tagged **`flowAutoRetryRequired`** via `requiresFlowAutoRetry`. Handlers for Anthropic, OpenAI chat, OpenAI Responses, and OpenRouter declare provider-managed retry; OpenRouter still treats **429/408** as flow-owned because its SDK only auto-retries **5xx**.
> 
> **Post-request failures** outside the SDK retry window are explicitly marked with `attachFlowAutoRetryRequired`: mid-stream drops after connect or partial output (Anthropic/OpenAI/OpenRouter), WebSocket handshake and transport errors, OpenAI Responses background **poll/retrieve/resume** failures (non-404), and terminal/polling error wrappers. OpenRouter also defers opening progress streams until after `chat.send` returns so deferred UI timing aligns with the SDK retry boundary.
> 
> Tests cover retry gating in `RetryState`, OpenRouter’s status-code boundary, and background polling metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ba48500d7516a658821ed8ed5a7aa0c219fcd24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->