### PR TITLE
docs: clarify ProgressEventBus's mixed responsibility, fix stale bus.emit doc claim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -405,7 +405,7 @@ For good separation of concerns, testability, and platform independence, core bu
 - Use `isFileNotFoundError()` from `@common/errors` instead of `instanceof vscode.FileSystemError`
 - Return error results instead of calling `vscode.window.show*Message()` from business logic — let the caller (command layer) handle UI
 - Add typed `Platform` ports (like `toolAvailability.isVscodeExtensionInstalled`) for platform-specific capabilities needed in agnostic code
-- New run-scoped facts extend `AgentEvent` (trace) or `ProgressEventPayloads` emitted via the run's `runtimeHost` — never a new `bus.emit` from a VS Code-free zone, and never a new subscribe surface. (Ruled in `docs/proposals/error-pipeline-and-ownership.md`; the existing direct `bus.emit` sites in `src/tools` are grandfathered until SDK Step 7d.)
+- New run-scoped facts extend `AgentEvent` (trace) or `ProgressEventPayloads` emitted via the run's `runtimeHost` — never a new `bus.emit` from a VS Code-free zone, and never a new subscribe surface. (Ruled in `docs/proposals/error-pipeline-and-ownership.md`. The direct `bus.emit` sites in `src/tools` that this rule once grandfathered have since been migrated to `emitRuntimeEvent()` — see `src/agent/runtime/emitRuntimeEvent.ts` — so the exception no longer applies; a new direct `bus.emit` from a VS Code-free zone is a rule violation, not a grandfathered pattern.)
 
 ### Path Aliases
 

--- a/src/agent/core/README.md
+++ b/src/agent/core/README.md
@@ -28,15 +28,17 @@ depend on neither. Don't introduce imports that point back outward (e.g.
 
 This diagram covers dependencies _within_ `core`. Two `flows/` files also take
 narrow, accepted dependencies on host-agnostic collaborators outside `core`
-that aren't otherwise abstracted: `BaseFlowServices.ts`/`CycleServices.ts` take
-`type`-only imports of `AgentRuntimeHost`/`StreamStatusRegistry` from
+that aren't otherwise abstracted: `BaseFlowServices.ts` and `RetryState.ts`
+take `type`-only imports of `AgentRuntimeHost`/`StreamStatusRegistry` from
 `@agent/runtime` (the shared service-injection contract every flow node
-receives), and `RetryState.ts` additionally calls `@auth/SupabaseClient`
-directly for relay-401 token refresh — the same pattern `@agent/modelHandlers`
-already uses, not a `core`-specific exception. None of this pulls in `vscode`
-or `packages/*`; it's still host-agnostic, just not self-contained within
-`core`'s own module boundaries. Don't read the diagram above as "flows never
-imports outside `core`."
+receives; `CycleServices.ts` only inherits these transitively through
+`BaseFlowContextInit`, not via its own import), and `RetryState.ts`
+additionally calls `@auth/SupabaseClient` directly for relay-401 token
+refresh — the same pattern `@agent/modelHandlers` already uses, not a
+`core`-specific exception. None of this pulls in `vscode` or `packages/*`;
+it's still host-agnostic, just not self-contained within `core`'s own module
+boundaries. Don't read the diagram above as "flows never imports outside
+`core`."
 
 Files kept at the `core/` root are limited infrastructure helpers or shared
 constants, not domain types:

--- a/src/agent/core/README.md
+++ b/src/agent/core/README.md
@@ -37,7 +37,7 @@ additionally calls `@auth/SupabaseClient` directly for relay-401 token
 refresh — the same pattern `@agent/modelHandlers` already uses, not a
 `core`-specific exception. None of this pulls in `vscode` or `packages/*`;
 it's still host-agnostic, just not self-contained within `core`'s own module
-boundaries. Don't read the diagram above as "flows never imports outside
+boundaries. Don't read the diagram above as "flow files never import outside
 `core`."
 
 Files kept at the `core/` root are limited infrastructure helpers or shared

--- a/src/agent/core/README.md
+++ b/src/agent/core/README.md
@@ -26,6 +26,18 @@ flows ──▶ state ──▶ definition
 depend on neither. Don't introduce imports that point back outward (e.g.
 `definition` importing from `state`).
 
+This diagram covers dependencies _within_ `core`. Two `flows/` files also take
+narrow, accepted dependencies on host-agnostic collaborators outside `core`
+that aren't otherwise abstracted: `BaseFlowServices.ts`/`CycleServices.ts` take
+`type`-only imports of `AgentRuntimeHost`/`StreamStatusRegistry` from
+`@agent/runtime` (the shared service-injection contract every flow node
+receives), and `RetryState.ts` additionally calls `@auth/SupabaseClient`
+directly for relay-401 token refresh — the same pattern `@agent/modelHandlers`
+already uses, not a `core`-specific exception. None of this pulls in `vscode`
+or `packages/*`; it's still host-agnostic, just not self-contained within
+`core`'s own module boundaries. Don't read the diagram above as "flows never
+imports outside `core`."
+
 Files kept at the `core/` root are limited infrastructure helpers or shared
 constants, not domain types:
 

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -158,9 +158,9 @@ export interface ProgressEventPayloads {
   inquiryThreadUpdated: InquiryThreadUpdatedEvent;
   showUserQuestion: UserQuestionPermission;
   resolveUserQuestion: { requestId: string };
+  // ── Run/stream progress (part 2) ──
   updateTodos: UpdateTodosPayload;
   updatePlan: UpdatePlanPayload;
-  // ── Run/stream progress (part 2) ──
   updateConversationProgress: {
     streamId: StreamTabId;
     progress: ConversationProgress;

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -76,7 +76,20 @@ export const INSTRUCTION_ACTION = {
 export type InstructionAction =
   (typeof INSTRUCTION_ACTION)[keyof typeof INSTRUCTION_ACTION];
 
+/**
+ * Every payload this bus carries, grouped below by what it actually reports —
+ * not one channel with one owner. It mixes run/stream progress facts, approval
+ * request/resolve RPC pairs, app-lifecycle and integration signals, and
+ * host-presentation requests, with delivery depending on which host
+ * re-published a given event rather than on what kind of event it is. This is
+ * a known, tracked shape, not an oversight: see `docs/proposals/
+ * error-pipeline-and-ownership.md` (Map 3) for the audit and the planned
+ * run-scoped/app-scoped split gated on SDK Step 7d. Until that split lands,
+ * treat the section comments below as the de facto ownership boundaries when
+ * deciding where a new event belongs.
+ */
 export interface ProgressEventPayloads {
+  // ── Run/stream progress (part 1) ──
   setActiveStream: SetActiveStreamPayload;
   updateStreamStatus: {
     streamId: StreamTabId;
@@ -116,6 +129,7 @@ export interface ProgressEventPayloads {
   updateStreamUsage: UsageScopedPayload & {
     usage: TokenUsageStats;
   };
+  // ── Approval / permission RPC (show*/resolve* request-response pairs) ──
   showRetryRequest: RetryPermission;
   resolveRetryRequest: { streamId: StreamTabId };
   showToolEditPermission: ToolEditPermission;
@@ -146,6 +160,7 @@ export interface ProgressEventPayloads {
   resolveUserQuestion: { requestId: string };
   updateTodos: UpdateTodosPayload;
   updatePlan: UpdatePlanPayload;
+  // ── Run/stream progress (part 2) ──
   updateConversationProgress: {
     streamId: StreamTabId;
     progress: ConversationProgress;
@@ -194,6 +209,7 @@ export interface ProgressEventPayloads {
    *  back to the UI. */
   goalStateChanged: { streamId: StreamTabId };
 
+  // ── App/session lifecycle + integration signals ──
   extensionDeactivating: undefined;
 
   /**


### PR DESCRIPTION
## Summary

This is the output of an audit for confusing or overlapping module responsibilities across TeXRA, run via four parallel research passes (core/controllers/tools boundary, tools/toolUse boundary, common/utils/platform boundary, transcript/trace/eventBus/telemetry boundary) followed by manual verification of every finding against the current code and the repo's existing internal audit doc (`docs/proposals/error-pipeline-and-ownership.md`).

**Verified** (files opened, not just grepped): `src/agent/core/README.md`, `src/agent/core/flows/{RetryState,BaseFlowServices,CycleServices}.ts`, `src/eventBus/ProgressEventBus.ts`, `src/agent/runtime/{AgentLaunchContext,terminalResultToast,emitRuntimeEvent}.ts`, `CLAUDE.md`, `src/agent/modelHandlers/openai/openAIResponseFileUploads.ts`, `packages/extension/src/commands/agent/executeCommand.ts`, `src/hosts/uiHosts.ts` + its ~17 consumers, `src/tools/setup/platform.ts`, `src/auth/{SupabaseClient,TokenProvider}.ts`, `src/controllers/progressView/ProgressFollowUpController.ts`, `src/common/errors/errorPredicates.ts`.

Most candidate findings from the initial parallel sweep turned out, on direct verification, to be already fixed, deliberately designed, or consistent with established codebase convention:
- The "double `requestShowError` toast" on launch failure is **not** a live bug — `AgentLaunchContext.ts:576-579` explicitly attaches the result-hub only after a successful launch specifically so a launch failure can never also publish a `result` event; the terminal-result-toast consolidation (T3-2 in the audit doc) has already landed.
- `Tier 1` items from the audit doc (duplicate error logging in `openAIResponseFileUploads.ts` / `executeCommand.ts`, the duplicated `RUNNING` status-set blocks) have already landed — their code now matches the doc's prescribed fix, comments and all.
- `src/hosts/` vs `src/platform/interfaces/` looked like a near-dead duplicate composition root from a narrow grep, but has ~17 real consumers across extension/desktop/tools and a coherent split (system/infra ports vs. interactive UI ports).
- `src/tools/setup/platform.ts`'s second `getSetupPlatform()/setSetupPlatform()` singleton is a documented, VS-Code-only adapter for setup-tool capabilities not in the cross-host `Platform` interface — not an accidental duplicate.
- `RetryState.ts` importing `@auth/SupabaseClient` directly turned out to match the same pattern already used in `@agent/modelHandlers/ModelHandler.ts`, not an isolated violation.
- Raw `ENOENT` checks bypassing `isFileNotFoundError()` exist at exactly 2 call sites (not the ~30 files an unqualified grep suggested — the rest were comments/unrelated matches), too small to be "significant."
- Duplicated tool-call parsing across the 4 model-handler providers is real but the audit doc explicitly rejects consolidating it as a standing trap ("OpenRouter↔OpenAI merge") — the asymmetry is deliberate, provider-contract-specific parsing confined to one file each.

**What's left and genuinely real:** two documentation-accuracy issues where the repo's own architecture docs had drifted from the code, which is itself a "confusing responsibility" problem since contributors and reviewers trust these docs to describe current ownership:

1. `CLAUDE.md` still claimed the direct `bus.emit` sites in `src/tools` are "grandfathered until SDK Step 7d." A grep confirms zero such sites remain — they were migrated to `emitRuntimeEvent()` (`src/agent/runtime/emitRuntimeEvent.ts`, whose own docstring says exactly this). The stale claim risks a future reviewer treating a new violation as an accepted exception.
2. `src/eventBus/ProgressEventBus.ts` has no top-level doc explaining that its ~40 event payloads mix four unrelated concerns (run/stream progress, approval RPC, app-lifecycle/integration signals, host-presentation requests) — a defect already flagged internally in `docs/proposals/error-pipeline-and-ownership.md` (Map 3: "not statable in one sentence") but never surfaced at the point where a contributor actually adds a new event.

## Issue acceptance gates

- [x] Fix the stale `bus.emit` grandfather-clause claim in `CLAUDE.md` so it matches current code.
- [x] Add a scope-clarifying doc comment + section groupings to `ProgressEventPayloads` so the mixed responsibility is visible in-place, with a pointer to the tracked doc for the real fix (gated on SDK Step 7d, out of scope here).
- [x] Note in `src/agent/core/README.md` that `flows/` takes two narrow, already-accepted dependencies outside `core`'s own module boundaries, so the dependency diagram isn't read as stricter than it actually is.

## Single source of truth

No new module or coordinator — this PR only makes existing ownership (already correct in code) legible in the docs that describe it. `emitRuntimeEvent()` remains the single emit path; `docs/proposals/error-pipeline-and-ownership.md` remains the tracked plan for the real `ProgressEventBus` split.

## Duplication and abstraction budget

No duplication removed or added; this is a doc/comment-only change. No new abstraction introduced.

## Host impact

Extension: none (comment/doc only).

Desktop: none (comment/doc only).

CLI: none (comment/doc only).

## Scheduled refactoring

None beyond what's already tracked in `docs/proposals/error-pipeline-and-ownership.md` (the `ProgressEventBus` run-scoped/app-scoped split, gated on SDK Step 7d).

## Validation

- `npx prettier --check` on all three touched files (passes).
- Diffed `src/eventBus/ProgressEventBus.ts` to confirm the change is comment-only (no field reordering, renaming, or removal).
- `npx tsc --noEmit` could not run in this sandbox (workspace `node_modules` not installed), but the only `.ts` diff is comment insertions, which cannot introduce a type error.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XZEszpBFWYdWSowxDmYifS)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and markdown edits only; no executable logic, APIs, or host wiring changed.
> 
> **Overview**
> **Documentation-only** PR that brings contributor-facing architecture text in line with the code after an internal responsibility audit—no runtime or type behavior changes.
> 
> **`CLAUDE.md`** updates the VS Code-free emit rule: it no longer says direct `bus.emit` in `src/tools` is grandfathered until SDK Step 7d. That exception is removed because those call sites are gone; **`emitRuntimeEvent()`** is now the documented path, and a new direct `bus.emit` from a VS Code-free zone is called out as a **rule violation**.
> 
> **`ProgressEventBus.ts`** adds a top-level doc on **`ProgressEventPayloads`** explaining the bus mixes run/stream progress, approval RPC pairs, app/integration signals, and host-presentation requests, with section comments as interim ownership boundaries and a pointer to **`docs/proposals/error-pipeline-and-ownership.md`** (Map 3) for the planned Step 7d split.
> 
> **`src/agent/core/README.md`** clarifies that two **`flows/`** files have narrow, accepted dependencies outside **`core`** (`@agent/runtime` type imports and **`RetryState`**’s **`@auth/SupabaseClient`** usage), so the inward dependency diagram is not read as “flows never import outside core.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f50fa2a304b2b7ac179e93c5705f92da3358b07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->