### PR TITLE
refactor: consolidate duplicate logic and fix weaker LaTeX comment strip

### DIFF
--- a/packages/extension/src/commands/latex/arXivCommands.ts
+++ b/packages/extension/src/commands/latex/arXivCommands.ts
@@ -3,7 +3,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 
 // Local imports
-import { toErrorMessage } from '@common/errors';
+import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import {
   arxivProcessor,
   type ArxivDownloadDestination,
@@ -99,10 +99,10 @@ export async function downloadArXivSource(): Promise<void> {
       );
     }
   } catch (error) {
-    const message = toErrorMessage(error);
-    vscode.window.showErrorMessage(
-      `Failed to download arXiv source: ${message}`,
+    await showLoggedErrorMessage(
+      CHANNEL,
+      'Failed to download arXiv source',
+      error,
     );
-    logger.error(CHANNEL, `Error downloading arXiv source: ${message}`);
   }
 }

--- a/packages/extension/src/commands/system/mainViewCommands.ts
+++ b/packages/extension/src/commands/system/mainViewCommands.ts
@@ -6,10 +6,9 @@ import { computeAgentOptionsData, refresh } from '@agent/index';
 import { arXivCommands } from '@commands/latex';
 import { registerCommands } from '@commands/_shared/registerCommands';
 import { gitCommands } from '@commands/git/gitCommands';
-import { toErrorMessage } from '@common/errors';
 import { loadMainViewModelOptions } from '@frontend/agents/optionsLoader';
 import { getMainWebview } from '@frontend/system/commandUtils';
-import * as logger from '@logger/logUtils';
+import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
 
 import { sampleProjectCommands } from './sampleProjectCommands';
@@ -60,9 +59,7 @@ async function runRefresh(
   try {
     await apply(webview);
   } catch (error) {
-    const message = toErrorMessage(error);
-    logger.error(CHANNEL, `Failed to refresh ${label}: ${message}`);
-    vscode.window.showErrorMessage(`Failed to refresh ${label}: ${message}`);
+    await showLoggedErrorMessage(CHANNEL, `Failed to refresh ${label}`, error);
   }
 }
 

--- a/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
@@ -13,8 +13,7 @@ import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 
 // Local imports - logging
 import { MESSAGE_TYPES } from '@shared/schemas';
-import { isNonEmptyString } from '@utils/core';
-import { isObject } from '@utils/core/typeGuards';
+import { isNonEmptyString, isObject } from '@utils/core';
 import { formatContent } from '@utils/text/xmlUtils';
 
 // Local file imports

--- a/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
@@ -14,6 +14,7 @@ import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 // Local imports - logging
 import { MESSAGE_TYPES } from '@shared/schemas';
 import { isNonEmptyString } from '@utils/core';
+import { isObject } from '@utils/core/typeGuards';
 import { formatContent } from '@utils/text/xmlUtils';
 
 // Local file imports
@@ -24,20 +25,16 @@ import type { ToolUseRoundShared } from './roundShared';
 const BLANK_TOOL_RESULT_CONTINUATION =
   'The previous assistant turn after a tool result was blank. Continue now with the final answer or next required action.';
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
-
 function hasToolResultContent(value: unknown): boolean {
   if (!Array.isArray(value)) return false;
   return value.some((item) => {
-    if (!isRecord(item)) return false;
-    return item.type === 'tool_result' || isRecord(item.functionResponse);
+    if (!isObject(item)) return false;
+    return item.type === 'tool_result' || isObject(item.functionResponse);
   });
 }
 
 function isToolResultMessage(message: ProviderMessage | undefined): boolean {
-  if (!isRecord(message)) return false;
+  if (!isObject(message)) return false;
   const record: Record<string, unknown> = message;
 
   if (

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -55,6 +55,7 @@ import {
   getGlobalStreaming,
 } from '@utils/config/providerConfig';
 import { getConfig } from '@utils/config/configUtils';
+import { computeUtilizationPercent } from './support/contextUtilization';
 import { MediaAttachmentProcessor } from './support/MediaAttachmentProcessor';
 import {
   resolveBaseUrl,
@@ -921,9 +922,12 @@ export abstract class ModelHandler<
           tokensBefore,
           tokensAfter: estimatedTokensAfter,
           contextWindow,
-          utilizationBefore: roundTo((tokensBefore / contextWindow) * 100, 1),
+          utilizationBefore: roundTo(
+            computeUtilizationPercent(tokensBefore, contextWindow),
+            1,
+          ),
           utilizationAfter: roundTo(
-            (estimatedTokensAfter / contextWindow) * 100,
+            computeUtilizationPercent(estimatedTokensAfter, contextWindow),
             1,
           ),
           details: `Client-side compaction: ${conversationMessages.length} messages summarized`,
@@ -1158,7 +1162,10 @@ export abstract class ModelHandler<
       );
     }
 
-    const utilizationPercent = (inputTokens / contextWindow) * 100;
+    const utilizationPercent = computeUtilizationPercent(
+      inputTokens,
+      contextWindow,
+    );
     const availableTokens = contextWindow - inputTokens;
 
     if (availableTokens >= maxTokens) {
@@ -1256,7 +1263,7 @@ export abstract class ModelHandler<
             contextWindow,
             utilizationBefore:
               validation.utilizationPercent ??
-              (inputTokens / contextWindow) * 100,
+              computeUtilizationPercent(inputTokens, contextWindow),
             originalMaxTokens: currentMaxTokens,
             reducedMaxTokens: validation.adjustedMaxTokens,
             details: detailLabel,

--- a/src/agent/modelHandlers/anthropic/anthropicContextManagement.ts
+++ b/src/agent/modelHandlers/anthropic/anthropicContextManagement.ts
@@ -1,5 +1,6 @@
 // Type imports - agent
 import { logContextManagementEvent, type AgentTrace } from '@agent/trace';
+import { computeUtilizationPercent } from '../support/contextUtilization';
 
 // Type imports - Anthropic SDK
 import type { AnthropicBeta } from '@anthropic-ai/sdk/resources/beta/beta';
@@ -198,8 +199,11 @@ export function logContextManagementFromResponse(
       tokensBefore,
       tokensAfter: totalInputTokens,
       contextWindow,
-      utilizationBefore: (tokensBefore / contextWindow) * 100,
-      utilizationAfter: (totalInputTokens / contextWindow) * 100,
+      utilizationBefore: computeUtilizationPercent(tokensBefore, contextWindow),
+      utilizationAfter: computeUtilizationPercent(
+        totalInputTokens,
+        contextWindow,
+      ),
       details,
       summary,
     },

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -35,6 +35,7 @@ import {
   joinNonEmpty,
   objectToLogString,
 } from '@utils/text/stringUtils';
+import { computeUtilizationPercent } from '../support/contextUtilization';
 import { toOpenAIReasoningEffort } from '../support/reasoningEffort';
 import { initializeOpenAiCompatibleOutputAndPrefill } from '../support/openAiCompatiblePrefill';
 import { tagOpenAISdkError } from './openAISdkError';
@@ -146,8 +147,12 @@ export class ModelHandlerOpenAI<
     didCompact: boolean;
   }> {
     const tokensBefore = this.lastKnownInputTokens;
+    const utilizationBefore = computeUtilizationPercent(
+      tokensBefore,
+      this.config.contextWindow,
+    );
     this.logger.debug(
-      `Compacting conversation with ${tokensBefore} input tokens (${((tokensBefore / this.config.contextWindow) * 100).toFixed(1)}% of ${this.config.contextWindow} context window)`,
+      `Compacting conversation with ${tokensBefore} input tokens (${utilizationBefore.toFixed(1)}% of ${this.config.contextWindow} context window)`,
     );
 
     return this.runClientCompaction(

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -38,6 +38,7 @@ import type { ToolFileAttachment } from '@shared/schemas/toolResult';
 import { clamp, filterNotNullish, roundTo } from '@utils/core';
 import { getConfig } from '@utils/config/configUtils';
 import { getWebSocketEnabled } from '@utils/config/providerConfig';
+import { computeUtilizationPercent } from '../support/contextUtilization';
 import { shouldUseOpenRouter } from '../support/ProxyConfigResolver';
 import { toOpenAIReasoningEffort } from '../support/reasoningEffort';
 import {
@@ -852,7 +853,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   ): Promise<ResponseInputItem[]> {
     const tokensBefore = this.conversationState.cumulativeInputTokens;
     const contextWindow = this.getEffectiveContextWindow();
-    const utilizationBefore = (tokensBefore / contextWindow) * 100;
+    const utilizationBefore = computeUtilizationPercent(
+      tokensBefore,
+      contextWindow,
+    );
 
     this.logger.debug(
       `Compacting conversation with ${tokensBefore} input tokens (${utilizationBefore.toFixed(1)}% of ${contextWindow} context window)`,
@@ -910,7 +914,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         tokensAfter = compactedResponse.usage.output_tokens;
       }
 
-      const utilizationAfter = (tokensAfter / contextWindow) * 100;
+      const utilizationAfter = computeUtilizationPercent(
+        tokensAfter,
+        contextWindow,
+      );
       const reduction = tokensBefore - tokensAfter;
       const reductionPercent = ((reduction / tokensBefore) * 100).toFixed(1);
 
@@ -1268,7 +1275,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         contextWindow,
         utilizationBefore:
           validation.utilizationPercent ??
-          (inputEstimate / contextWindow) * 100,
+          computeUtilizationPercent(inputEstimate, contextWindow),
         originalMaxTokens: maxOutputTokens,
         reducedMaxTokens: capped,
         details:

--- a/src/agent/modelHandlers/support/contextUtilization.ts
+++ b/src/agent/modelHandlers/support/contextUtilization.ts
@@ -1,0 +1,7 @@
+/** Percentage of the context window consumed by `tokens`. */
+export function computeUtilizationPercent(
+  tokens: number,
+  contextWindow: number,
+): number {
+  return (tokens / contextWindow) * 100;
+}

--- a/src/agent/runtime/modelHandlerCompatibilityInference.ts
+++ b/src/agent/runtime/modelHandlerCompatibilityInference.ts
@@ -3,17 +3,14 @@ import { MODEL_CONFIGS, ModelProvider } from 'llm-zoo';
 
 // Local imports
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import { isObject } from '@utils/core/typeGuards';
 import {
   ModelHandlerCompatibilityKeySchema,
   type ModelHandlerCompatibilityKey,
 } from './modelHandlerCompatibilityKey';
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
-
 function isGoogleGenAIContentMessage(message: ProviderMessage): boolean {
-  if (!isRecord(message)) return false;
+  if (!isObject(message)) return false;
   const record = message as Record<string, unknown>;
   if ('type' in record) return false;
   const role = record.role;
@@ -24,7 +21,7 @@ function isGoogleGenAIContentMessage(message: ProviderMessage): boolean {
 }
 
 function isGoogleInteractionsStepMessage(message: ProviderMessage): boolean {
-  if (!isRecord(message)) return false;
+  if (!isObject(message)) return false;
   const type = (message as Record<string, unknown>).type;
   return (
     type === 'user_input' ||
@@ -36,7 +33,7 @@ function isGoogleInteractionsStepMessage(message: ProviderMessage): boolean {
 }
 
 function isOpenRouterChatMessage(message: ProviderMessage): boolean {
-  if (!isRecord(message)) return false;
+  if (!isObject(message)) return false;
   const record = message as Record<string, unknown>;
   if ('type' in record || 'parts' in record) return false;
   const role = record.role;
@@ -78,20 +75,20 @@ function currentModelFromRawSharedState(
   shared: Record<string, unknown>,
 ): string | undefined {
   const stateSlices = shared.stateSlices;
-  if (!isRecord(stateSlices)) return undefined;
+  if (!isObject(stateSlices)) return undefined;
   const userChannels = stateSlices.userChannels;
-  if (!isRecord(userChannels)) return undefined;
+  if (!isObject(userChannels)) return undefined;
   const transient = userChannels.transient;
   const input = userChannels.input;
   return (
-    (isRecord(transient) ? stringValue(transient.MODEL) : undefined) ??
-    (isRecord(input) ? stringValue(input.MODEL) : undefined)
+    (isObject(transient) ? stringValue(transient.MODEL) : undefined) ??
+    (isObject(input) ? stringValue(input.MODEL) : undefined)
   );
 }
 
 function unwrapSharedState(shared: unknown): Record<string, unknown> | null {
-  if (!isRecord(shared)) return null;
-  return isRecord(shared.state)
+  if (!isObject(shared)) return null;
+  return isObject(shared.state)
     ? (shared.state as Record<string, unknown>)
     : shared;
 }

--- a/src/agent/runtime/modelHandlerCompatibilityInference.ts
+++ b/src/agent/runtime/modelHandlerCompatibilityInference.ts
@@ -3,7 +3,7 @@ import { MODEL_CONFIGS, ModelProvider } from 'llm-zoo';
 
 // Local imports
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
-import { isObject } from '@utils/core/typeGuards';
+import { isObject } from '@utils/core';
 import {
   ModelHandlerCompatibilityKeySchema,
   type ModelHandlerCompatibilityKey,

--- a/src/latex/extractFigure.ts
+++ b/src/latex/extractFigure.ts
@@ -5,7 +5,11 @@ import type { FileLocation } from '@shared/schemas';
 import { flexibleFS } from '@utils/files';
 import { joinLatexPath } from '@utils/core/pathCore';
 
-import { findExistingLatexPath, resolveLatexDir } from './latexParsingUtils';
+import {
+  findExistingLatexPath,
+  resolveLatexDir,
+  stripLatexComments,
+} from './latexParsingUtils';
 
 const FIGURE_EXTENSIONS = ['.pdf', '.png', '.jpg', '.jpeg'];
 
@@ -85,17 +89,15 @@ export async function extractFigurePathsFromLatex(
     graphicspaths.push(joinLatexPath(latexDir, p));
   }
 
-  // Pre-process content to remove commented lines
-  const processedLines = content
-    .split('\n')
-    .filter((line) => !/^\s*%/.test(line)) // Remove lines that start with whitespace + %
-    .join('\n');
+  // Pre-process content to remove commented-out text (including inline
+  // comments and escaped `\%`, unlike a naive whole-line strip).
+  const processedContent = stripLatexComments(content);
 
   // Find all matches in the processed content for both patterns
   const discovered = new Set<string>();
 
   for (const pattern of figurePatterns) {
-    for (const match of processedLines.matchAll(pattern)) {
+    for (const match of processedContent.matchAll(pattern)) {
       const resolved = await resolveFigurePath(
         match[1],
         graphicspaths,

--- a/src/latex/extractFigure.ts
+++ b/src/latex/extractFigure.ts
@@ -83,15 +83,15 @@ export async function extractFigurePathsFromLatex(
 
   const content = await flexibleFS.read(latexFileLocation);
 
-  // Parse graphicspaths
-  const paths = parseGraphicspath(content);
-  for (const p of paths) {
-    graphicspaths.push(joinLatexPath(latexDir, p));
-  }
-
   // Pre-process content to remove commented-out text (including inline
   // comments and escaped `\%`, unlike a naive whole-line strip).
   const processedContent = stripLatexComments(content);
+
+  // Parse graphicspaths
+  const paths = parseGraphicspath(processedContent);
+  for (const p of paths) {
+    graphicspaths.push(joinLatexPath(latexDir, p));
+  }
 
   // Find all matches in the processed content for both patterns
   const discovered = new Set<string>();


### PR DESCRIPTION
## Summary

A proactive consolidation pass (no linked issue) after scanning `src/utils`, `src/common`, `src/agent`, `src/tools`, `src/latex`, `src/model`, and `packages/extension/src/commands` / `packages/cli` / `packages/desktop` for duplicate logic and hand-rolled reimplementations of already-shared helpers. Most of the codebase was already well-factored (retry/backoff, sleep, JSON parsing, and usage normalization all funnel through shared helpers or installed dependencies); this PR fixes the small number of genuine findings that survived verification against existing tests:

- **Bug fix**: `src/latex/extractFigure.ts` stripped comments with a naive `/^\s*%/` line-start regex, missing inline comments (`\includegraphics{fig} % note`) and not respecting escaped `\%`. Switched to the shared `stripLatexComments` helper already used correctly by three other LaTeX parsing call sites.
- **New shared helper**: `computeUtilizationPercent(tokens, contextWindow)` in `src/agent/modelHandlers/support/contextUtilization.ts`, replacing five independent `(tokens / contextWindow) * 100` calculations across `ModelHandler.ts`, `anthropicContextManagement.ts`, and both OpenAI handlers.
- **Duplicate type guard removal**: local `isRecord()` functions in `ToolUseProcessNode.ts` and `modelHandlerCompatibilityInference.ts` replaced with the shared `isObject()` guard from `@utils/core/typeGuards` (verified no call site relies on arrays passing the check).
- **Error-handling consolidation**: `mainViewCommands.ts` and `arXivCommands.ts` now route through the existing `showLoggedErrorMessage()` helper instead of separately calling `logger.error()` and `vscode.window.showErrorMessage()` with hand-built strings.

Explicitly **not** touched (verified but judged unsafe or low-value):
- `conversationFormat.ts`'s `truncate()` and `subagentDiffs.ts`'s `truncateDiff()` were flagged as similar to `truncateWithEllipsis`, but a test (`ExecutionsConversationFormat.vitest.ts`) explicitly pins the ASCII `...` truncation behavior and asserts it must *not* contain the shared helper's `…` character — this divergence is intentional.
- `showCleanResult`/`showPackResult` in `cleanCommands.ts`/`packCommands.ts` share 3 of 4 branches, but the success branch differs materially (plain message vs. message + "Open Folder" action); forcing a shared helper for two call sites didn't clear the bar over the repo's stated anti-abstraction guidance.
- The "Compacted conversation: X → Y tokens" log line duplicated between `ModelHandler.ts` and `modelHandlerOpenAIResponse.ts` has already slightly diverged (one uses a `~` prefix, the other doesn't) — left as a follow-up rather than risk masking real behavior differences.

## Issue acceptance gates

None — this is a proactive cleanup pass, not tied to a filed issue.

## Single source of truth

- `computeUtilizationPercent()` (`src/agent/modelHandlers/support/contextUtilization.ts`) is now the single place the context-window-utilization formula lives.
- `isObject()` (`src/utils/core/typeGuards.ts`) is the single record-type guard used by both files that previously redefined `isRecord()` locally.
- `stripLatexComments()` (`src/latex/latexParsingUtils.ts`) is now used by all LaTeX comment-stripping call sites, including `extractFigure.ts`.

## Duplication and abstraction budget

Removed: 5 duplicated utilization-percent calculations, 2 duplicated `isRecord` type-guard definitions (12 lines), 1 weaker duplicate comment-stripping regex, and 2 duplicated log-then-show error-handling blocks. No new cross-cutting abstractions were introduced — `computeUtilizationPercent` is a one-line pure function with a single, unambiguous formula; the other changes route existing call sites to helpers that already existed and were already used elsewhere in the same files' neighborhoods.

## Host impact

Extension: `arXivCommands.ts` / `mainViewCommands.ts` error-message wording is now consistently `"<prefix>: <error detail>"` (previously slightly different shown-vs-logged text in one case).

Desktop: None.

CLI: None.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — passes (0 errors)
- `npm run lint` — passes (0 errors; pre-existing unrelated warnings only)
- `npm test` (full vitest suite, 4246 tests) — 1 unrelated pre-existing failure (`execUtils.vitest.ts` process-group abort test, fails in this sandboxed container due to process-signal delivery limitations, unrelated to any file touched here)
- Targeted suites re-run individually: `ExecutionsConversationFormat`, `LatexProcessingHelpers`, `ExtractFiguresTool`, `ModelHandlerAnthropic`, `AnthropicCacheBeta`, `CodexRequestRewrite`, `ModelHandlerCompatibilityInference`, plus the full `src/test-kernel/agent` and `src/test-kernel/latex` suites (876 tests) — all pass


---
_Generated by [Claude Code](https://claude.ai/code/session_012zLDMK34v2muztFncxBG7v)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly mechanical deduplication with unchanged formulas; the only user-visible behavior change is more accurate LaTeX figure extraction and slightly standardized extension error messages.
> 
> **Overview**
> Consolidates small duplicated patterns and fixes figure discovery when LaTeX comments hide or decorate `\includegraphics` paths.
> 
> **LaTeX:** `extractFigure.ts` now strips comments via shared `stripLatexComments` instead of dropping whole lines that start with `%`, so inline comments and escaped `\%` no longer cause missed or false figure matches.
> 
> **Agent / model handlers:** Context-window utilization logging and validation route through new `computeUtilizationPercent()` instead of repeated `(tokens / contextWindow) * 100` math in the base handler, Anthropic context management, and OpenAI chat/Responses compaction paths. Local `isRecord` guards in `ToolUseProcessNode` and `modelHandlerCompatibilityInference` are replaced with shared `isObject()` from `@utils/core`.
> 
> **Extension:** `arXivCommands` and `mainViewCommands` use `showLoggedErrorMessage()` for failures instead of separate `logger.error` + `showErrorMessage` calls, aligning user-visible and logged error text with other commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac2f8f5ff49fce968c36fa922fe8f78ed5f77492. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->