### PR TITLE
fix(tools): stop str_replace editor from corrupting `$` sequences

### DIFF
--- a/src/test-kernel/tools/EditPrimitives.vitest.ts
+++ b/src/test-kernel/tools/EditPrimitives.vitest.ts
@@ -53,6 +53,10 @@ describe('editPrimitives literal replacement', () => {
     );
   });
 
+  it('replaceFirstLiteral rejects an empty search string', () => {
+    expect(() => replaceFirstLiteral('abc', '', 'x')).toThrow(ToolError);
+  });
+
   it('replaceAllLiteral rejects an empty search string', () => {
     expect(() => replaceAllLiteral('abc', '', 'x')).toThrow(ToolError);
   });
@@ -66,5 +70,9 @@ describe('findOccurrenceLineNumbers', () => {
 
   it('returns an empty array when the needle is absent', () => {
     expect(findOccurrenceLineNumbers('a\nb\nc', 'zzz')).toEqual([]);
+  });
+
+  it('returns an empty array for an empty needle', () => {
+    expect(findOccurrenceLineNumbers('a\nb\nc', '')).toEqual([]);
   });
 });

--- a/src/test-kernel/tools/EditPrimitives.vitest.ts
+++ b/src/test-kernel/tools/EditPrimitives.vitest.ts
@@ -1,0 +1,70 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - edit primitives under test
+import { ToolError } from '@shared/schemas/toolResult';
+import {
+  findOccurrenceLineNumbers,
+  replaceAllLiteral,
+  replaceFirstLiteral,
+} from '@tools/editPrimitives';
+
+describe('editPrimitives literal replacement', () => {
+  // Regression: String.prototype.replace interprets $$, $&, $', `$\`` and
+  // $<name> in the replacement string, silently corrupting LaTeX/code edits.
+  // The primitives must insert the replacement verbatim.
+  const dollarPatterns = [
+    ['$&', '$&'],
+    ["$'", "$'"],
+    ['$`', '$`'],
+    ['$$', '$$'],
+    ['$1', '$1'],
+    ['a$&b$$c', 'a$&b$$c'],
+    ['\\sum_{i=1}^{n} $x_i$', '\\sum_{i=1}^{n} $x_i$'],
+  ] as const;
+
+  it.each(dollarPatterns)(
+    'replaceFirstLiteral inserts %j verbatim',
+    (replacement) => {
+      expect(replaceFirstLiteral('before OLD after', 'OLD', replacement)).toBe(
+        `before ${replacement} after`,
+      );
+    },
+  );
+
+  it.each(dollarPatterns)(
+    'replaceAllLiteral inserts %j verbatim for every occurrence',
+    (replacement) => {
+      expect(replaceAllLiteral('OLD and OLD', 'OLD', replacement)).toBe(
+        `${replacement} and ${replacement}`,
+      );
+    },
+  );
+
+  it('replaceFirstLiteral only replaces the first occurrence', () => {
+    expect(replaceFirstLiteral('x OLD y OLD z', 'OLD', 'NEW')).toBe(
+      'x NEW y OLD z',
+    );
+  });
+
+  it('replaceFirstLiteral returns content unchanged when needle is absent', () => {
+    expect(replaceFirstLiteral('nothing here', 'OLD', 'NEW')).toBe(
+      'nothing here',
+    );
+  });
+
+  it('replaceAllLiteral rejects an empty search string', () => {
+    expect(() => replaceAllLiteral('abc', '', 'x')).toThrow(ToolError);
+  });
+});
+
+describe('findOccurrenceLineNumbers', () => {
+  it('returns 1-indexed line numbers of every matching line', () => {
+    const content = 'foo\nbar foo\nbaz\nfoo again';
+    expect(findOccurrenceLineNumbers(content, 'foo')).toEqual([1, 2, 4]);
+  });
+
+  it('returns an empty array when the needle is absent', () => {
+    expect(findOccurrenceLineNumbers('a\nb\nc', 'zzz')).toEqual([]);
+  });
+});

--- a/src/test-kernel/tools/EditPrimitives.vitest.ts
+++ b/src/test-kernel/tools/EditPrimitives.vitest.ts
@@ -14,13 +14,13 @@ describe('editPrimitives literal replacement', () => {
   // $<name> in the replacement string, silently corrupting LaTeX/code edits.
   // The primitives must insert the replacement verbatim.
   const dollarPatterns = [
-    ['$&', '$&'],
-    ["$'", "$'"],
-    ['$`', '$`'],
-    ['$$', '$$'],
-    ['$1', '$1'],
-    ['a$&b$$c', 'a$&b$$c'],
-    ['\\sum_{i=1}^{n} $x_i$', '\\sum_{i=1}^{n} $x_i$'],
+    '$&',
+    "$'",
+    '$`',
+    '$$',
+    '$1',
+    'a$&b$$c',
+    '\\sum_{i=1}^{n} $x_i$',
   ] as const;
 
   it.each(dollarPatterns)(

--- a/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
+++ b/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
@@ -236,6 +236,31 @@ describe('Tool edit approval gating', () => {
     assert.strictEqual(await WorkspaceFS.read('shared.tex'), 'parent\n');
   });
 
+  it('text editor str_replace rejects an empty old_str before approval', async () => {
+    await installPlatform(
+      {},
+      {
+        '/workspace/shared.tex': 'alpha\n',
+      },
+    );
+    const tool = new TextEditorTool();
+
+    setToolEditApprovalHandler(async () => {
+      throw new Error('approval should not be requested');
+    });
+
+    const result = await tool.call({
+      command: 'str_replace',
+      path: 'shared.tex',
+      old_str: '',
+      new_str: 'beta',
+    });
+
+    assert.strictEqual(result.isError, true);
+    assert.match(result.error ?? '', /old_str must not be empty/);
+    assert.strictEqual(await WorkspaceFS.read('shared.tex'), 'alpha\n');
+  });
+
   it('toggleToolEditApprovalSessionBypass toggles state and returns new value', () => {
     // Test toggle mechanics (per-stream state)
     // Initially bypass is off (cleared in beforeEach)

--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -23,6 +23,7 @@ import { pluralize } from '@utils/text/stringUtils';
 
 // Local file imports
 import { defineTool } from './core/define';
+import { replaceAllLiteral, replaceFirstLiteral } from './editPrimitives';
 
 const EditInputSchema = z.strictObject({
   path: z
@@ -94,18 +95,11 @@ export class EditFileTool extends defineTool({
       );
     }
 
-    // Use split/join and indexOf/slice for literal replacement
-    // (String.replace has special patterns like $$, $&, $' that corrupt LaTeX)
-    let updatedContent: string;
-    if (replace_all) {
-      updatedContent = currentContent.split(old_str).join(new_str);
-    } else {
-      const idx = currentContent.indexOf(old_str);
-      updatedContent =
-        currentContent.slice(0, idx) +
-        new_str +
-        currentContent.slice(idx + old_str.length);
-    }
+    // Literal replacement (String.replace would interpret $$, $&, $', `$\``
+    // patterns and corrupt LaTeX/code); see editPrimitives.
+    const updatedContent = replace_all
+      ? replaceAllLiteral(currentContent, old_str, new_str)
+      : replaceFirstLiteral(currentContent, old_str, new_str);
 
     const outcome = await requestApprovedEditContent({
       path: targetPath,

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -28,13 +28,17 @@ import { splitContentLines } from '@utils/text/stringUtils';
 
 // Local file imports
 import { defineTool } from './core/define';
+import {
+  findOccurrenceLineNumbers,
+  replaceFirstLiteral,
+} from './editPrimitives';
 import { formatFileView, formatLinesWithNumbers } from './formatting';
 import {
   assertWritable,
   resolveAndFormat,
   currentToolRoot,
 } from './pathResolution';
-import { requireField } from './utils';
+import { countOccurrences, requireField } from './utils';
 
 // Constants
 const CHANNEL = 'TextEditorTool';
@@ -422,7 +426,7 @@ export class TextEditorTool extends defineTool({
       const expandedOldStr = oldStr.replaceAll('\t', '    ');
       const expandedNewStr = newStr.replaceAll('\t', '    ');
 
-      const occurrences = expandedFileContent.split(expandedOldStr).length - 1;
+      const occurrences = countOccurrences(expandedFileContent, expandedOldStr);
 
       if (occurrences === 0) {
         throw new ToolError(
@@ -431,19 +435,20 @@ export class TextEditorTool extends defineTool({
       }
 
       if (occurrences > 1) {
-        const lines = expandedFileContent.split('\n');
-        const lineNumbers = lines
-          .map((line, index) =>
-            line.includes(expandedOldStr) ? index + 1 : -1,
-          )
-          .filter((num) => num !== -1);
+        const lineNumbers = findOccurrenceLineNumbers(
+          expandedFileContent,
+          expandedOldStr,
+        );
 
         throw new ToolError(
           `No replacement was performed. Multiple occurrences of old_str \`${oldStr}\` in lines ${lineNumbers.join(', ')}. Please ensure it is unique`,
         );
       }
 
-      const newFileContent = expandedFileContent.replace(
+      // Literal replacement (String.replace would interpret $$, $&, $', `$\``
+      // patterns and corrupt LaTeX/code); see editPrimitives.
+      const newFileContent = replaceFirstLiteral(
+        expandedFileContent,
         expandedOldStr,
         expandedNewStr,
       );

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -426,6 +426,12 @@ export class TextEditorTool extends defineTool({
       const expandedOldStr = oldStr.replaceAll('\t', '    ');
       const expandedNewStr = newStr.replaceAll('\t', '    ');
 
+      if (expandedOldStr.length === 0) {
+        throw new ToolError(
+          `old_str must not be empty for ${displayPath}. Provide the exact text to replace.`,
+        );
+      }
+
       const occurrences = countOccurrences(expandedFileContent, expandedOldStr);
 
       if (occurrences === 0) {

--- a/src/tools/editPrimitives.ts
+++ b/src/tools/editPrimitives.ts
@@ -17,13 +17,18 @@ import { ToolError } from '@shared/schemas/toolResult';
  *
  * `newStr` is inserted verbatim — replacement patterns are NOT interpreted.
  * Returns the content unchanged when `oldStr` does not occur; callers that
- * require a match should validate occurrences first (see {@link countOccurrences}).
+ * require a match should validate occurrences first with `countOccurrences`.
  */
 export function replaceFirstLiteral(
   content: string,
   oldStr: string,
   newStr: string,
 ): string {
+  if (oldStr.length === 0) {
+    throw new ToolError(
+      'replaceFirstLiteral requires a non-empty search string.',
+    );
+  }
   const idx = content.indexOf(oldStr);
   if (idx === -1) {
     return content;
@@ -60,6 +65,9 @@ export function findOccurrenceLineNumbers(
   content: string,
   needle: string,
 ): number[] {
+  if (needle.length === 0) {
+    return [];
+  }
   return content
     .split('\n')
     .flatMap((line, index) => (line.includes(needle) ? [index + 1] : []));

--- a/src/tools/editPrimitives.ts
+++ b/src/tools/editPrimitives.ts
@@ -1,0 +1,66 @@
+// Local imports - tools
+import { ToolError } from '@shared/schemas/toolResult';
+
+/**
+ * Shared literal string-edit primitives for the file-editing tools
+ * (TextEditorTool, EditFileTool, MemoryTool).
+ *
+ * These deliberately avoid `String.prototype.replace`: its replacement string
+ * interprets the special patterns `$$`, `$&`, `` $` ``, `$'`, and `$<name>`,
+ * which silently corrupt any `new_str` that legitimately contains `$` — a
+ * routine occurrence in LaTeX and code. Replacing via `indexOf`/`slice` (or
+ * `split`/`join`) inserts the replacement verbatim.
+ */
+
+/**
+ * Replace the first literal occurrence of `oldStr` with `newStr`.
+ *
+ * `newStr` is inserted verbatim — replacement patterns are NOT interpreted.
+ * Returns the content unchanged when `oldStr` does not occur; callers that
+ * require a match should validate occurrences first (see {@link countOccurrences}).
+ */
+export function replaceFirstLiteral(
+  content: string,
+  oldStr: string,
+  newStr: string,
+): string {
+  const idx = content.indexOf(oldStr);
+  if (idx === -1) {
+    return content;
+  }
+  return content.slice(0, idx) + newStr + content.slice(idx + oldStr.length);
+}
+
+/**
+ * Replace every literal occurrence of `oldStr` with `newStr`.
+ *
+ * `newStr` is inserted verbatim — replacement patterns are NOT interpreted.
+ * `oldStr` must be non-empty; an empty needle throws to avoid the pathological
+ * `''.split('')` behavior.
+ */
+export function replaceAllLiteral(
+  content: string,
+  oldStr: string,
+  newStr: string,
+): string {
+  if (oldStr.length === 0) {
+    throw new ToolError(
+      'replaceAllLiteral requires a non-empty search string.',
+    );
+  }
+  return content.split(oldStr).join(newStr);
+}
+
+/**
+ * 1-indexed line numbers of every line that contains `needle`. Used to build
+ * the "not unique — found in lines X, Y" guidance when a search string matches
+ * more than once.
+ */
+export function findOccurrenceLineNumbers(
+  content: string,
+  needle: string,
+): number[] {
+  return content
+    .split('\n')
+    .flatMap((line, index) => (line.includes(needle) ? [index + 1] : []));
+}

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -16,6 +16,10 @@ import { splitContentLines } from '@utils/text/stringUtils';
 // Local imports - tool core
 import { defineTool } from '../core/define';
 import {
+  findOccurrenceLineNumbers,
+  replaceFirstLiteral,
+} from '../editPrimitives';
+import {
   recordToolFileRead,
   requireFileReadForEdit,
 } from '../fileInteractions';
@@ -348,20 +352,15 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
     }
 
     if (occurrences > 1) {
-      const lines = content.split('\n');
-      const lineNumbers = lines.flatMap((line, index) =>
-        line.includes(oldStr) ? [index + 1] : [],
-      );
+      const lineNumbers = findOccurrenceLineNumbers(content, oldStr);
       throw new ToolError(
         `old_str is not unique within ${inputPath} (found in lines ${lineNumbers.join(', ')}). Include more surrounding context to make it unique.`,
       );
     }
 
-    // Use indexOf/slice for literal replacement
-    // (String.replace has special patterns like $$, $&, $' that corrupt content)
-    const idx = content.indexOf(oldStr);
-    const updated =
-      content.slice(0, idx) + newStr + content.slice(idx + oldStr.length);
+    // Literal replacement (String.replace would interpret $$, $&, $', `$\``
+    // patterns and corrupt LaTeX/content); see editPrimitives.
+    const updated = replaceFirstLiteral(content, oldStr, newStr);
     await this.writeMemoryFile(resolvedPath, updated, meta);
     recordToolFileRead(inputPath);
 


### PR DESCRIPTION
TextEditorTool.strReplace used String.prototype.replace, which interprets
the replacement patterns `$$`, `$&`, `` $` ``, `$'`, and `$<name>` — silently
mangling any new_str containing `$` (routine in LaTeX and code). The sibling
EditFileTool and MemoryTool already avoided this with indexOf/slice.

Extract the shared literal-edit logic into src/tools/editPrimitives.ts
(replaceFirstLiteral, replaceAllLiteral, findOccurrenceLineNumbers) and route
all three tools through it, so the fix lives in one place and the triplicated
occurrence-count / line-number / splice logic is no longer duplicated. Add
regression coverage asserting the corrupting `$` patterns are inserted verbatim.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017qaoLdiQZY1C9vvBfQq16o

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core file-edit paths used by agents; behavior is intentionally corrected for `$` in replacements, with a small new validation surface for empty `old_str`.
> 
> **Overview**
> **TextEditorTool** `str_replace` no longer uses `String.prototype.replace`, which was mangling `new_str` values containing `$` (e.g. LaTeX). **EditFileTool** and **MemoryTool** already used literal splice/split logic; that behavior is now centralized in **`editPrimitives.ts`** (`replaceFirstLiteral`, `replaceAllLiteral`, `findOccurrenceLineNumbers`) and all three tools call into it.
> 
> **TextEditorTool** also rejects an empty `old_str` before edit approval (with **`countOccurrences`** for match counting), matching the other editors. Regression tests cover verbatim `$` patterns and the new primitives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc7e6c8daa79b9f23d1ee0f6f760b512d62a58ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->