### PR TITLE
refactor(cli): dedupe SlashPalette highlight stepping into ui/Select

### DIFF
--- a/packages/cli/src/chat/tui/commands/SlashPalette.tsx
+++ b/packages/cli/src/chat/tui/commands/SlashPalette.tsx
@@ -15,6 +15,7 @@ import {
 import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
 import { KeyHints } from '../ui/KeyHints';
 import { POINTER } from '../ui/glyphs';
+import { nextSelectHighlightIndex } from '../ui/Select';
 
 export interface SlashPaletteProps {
   /** The current input value (excluding the leading `/`, after the slash). */
@@ -36,21 +37,13 @@ export interface SlashPaletteWindow {
   readonly hiddenAfter: number;
 }
 
-export function nextSlashPaletteHighlight({
-  direction,
-  highlight,
-  itemCount,
-}: {
-  readonly direction: -1 | 1;
-  readonly highlight: number;
-  readonly itemCount: number;
-}): number {
-  if (itemCount <= 0) return 0;
-  const clamped = clamp(highlight, 0, itemCount - 1);
-  if (direction === 1) return (clamped + 1) % itemCount;
-  return clamped <= 0 ? itemCount - 1 : clamped - 1;
-}
-
+// Wrap-around highlight stepping is shared with `ui/Select.tsx` — slash
+// commands never carry a `disabled` flag, so `nextSelectHighlightIndex`
+// degenerates to the same plain wraparound this palette needs. The window
+// below stays local: scrolling through the middle of a long list shows one
+// fewer row than at the edges, on purpose, so both overflow markers ("… N
+// earlier" / "… N more") can be visible at once — unlike `Select`'s simple
+// centered `visibleSelectRange`.
 export function slashPaletteWindow({
   highlight,
   itemCount,
@@ -128,6 +121,12 @@ export function SlashPalette(
   const matches = matchSlashCommands(props.query);
   const [highlight, setHighlight] = useState(0);
   const matchCount = matches.length;
+  // Slash commands have no `disabled` concept, so this is just enough shape
+  // to drive `nextSelectHighlightIndex`'s shared wraparound stepping.
+  const highlightItems = matches.map((cmd) => ({
+    value: cmd,
+    label: cmd.name,
+  }));
 
   // Whenever the match list resizes (user kept typing), clamp the cursor
   // so it doesn't point past the end.
@@ -149,20 +148,20 @@ export function SlashPalette(
       }
       if (key.upArrow) {
         setHighlight((h) =>
-          nextSlashPaletteHighlight({
+          nextSelectHighlightIndex({
             direction: -1,
             highlight: h,
-            itemCount: matchCount,
+            items: highlightItems,
           }),
         );
         return;
       }
       if (key.downArrow) {
         setHighlight((h) =>
-          nextSlashPaletteHighlight({
+          nextSelectHighlightIndex({
             direction: 1,
             highlight: h,
-            itemCount: matchCount,
+            items: highlightItems,
           }),
         );
         return;

--- a/packages/cli/src/chat/tui/commands/SlashPalette.tsx
+++ b/packages/cli/src/chat/tui/commands/SlashPalette.tsx
@@ -15,7 +15,7 @@ import {
 import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
 import { KeyHints } from '../ui/KeyHints';
 import { POINTER } from '../ui/glyphs';
-import { nextSelectHighlightIndex } from '../ui/Select';
+import { nextWrappingHighlightIndex } from '../ui/Select';
 
 export interface SlashPaletteProps {
   /** The current input value (excluding the leading `/`, after the slash). */
@@ -37,9 +37,7 @@ export interface SlashPaletteWindow {
   readonly hiddenAfter: number;
 }
 
-// Wrap-around highlight stepping is shared with `ui/Select.tsx` — slash
-// commands never carry a `disabled` flag, so `nextSelectHighlightIndex`
-// degenerates to the same plain wraparound this palette needs. The window
+// Wraparound highlight stepping is shared with `ui/Select.tsx`. The window
 // below stays local: scrolling through the middle of a long list shows one
 // fewer row than at the edges, on purpose, so both overflow markers ("… N
 // earlier" / "… N more") can be visible at once — unlike `Select`'s simple
@@ -121,12 +119,6 @@ export function SlashPalette(
   const matches = matchSlashCommands(props.query);
   const [highlight, setHighlight] = useState(0);
   const matchCount = matches.length;
-  // Slash commands have no `disabled` concept, so this is just enough shape
-  // to drive `nextSelectHighlightIndex`'s shared wraparound stepping.
-  const highlightItems = matches.map((cmd) => ({
-    value: cmd,
-    label: cmd.name,
-  }));
 
   // Whenever the match list resizes (user kept typing), clamp the cursor
   // so it doesn't point past the end.
@@ -148,20 +140,20 @@ export function SlashPalette(
       }
       if (key.upArrow) {
         setHighlight((h) =>
-          nextSelectHighlightIndex({
+          nextWrappingHighlightIndex({
             direction: -1,
             highlight: h,
-            items: highlightItems,
+            itemCount: matchCount,
           }),
         );
         return;
       }
       if (key.downArrow) {
         setHighlight((h) =>
-          nextSelectHighlightIndex({
+          nextWrappingHighlightIndex({
             direction: 1,
             highlight: h,
-            items: highlightItems,
+            itemCount: matchCount,
           }),
         );
         return;

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -87,11 +87,11 @@ export function nextSelectHighlightIndex<T>({
     items.every((item) => item.disabled) ||
     items.every((item) => !item.disabled)
   ) {
-    return direction === 1
-      ? (clampedHighlight + 1) % items.length
-      : clampedHighlight <= 0
-        ? items.length - 1
-        : clampedHighlight - 1;
+    return nextWrappingHighlightIndex({
+      direction,
+      highlight: clampedHighlight,
+      itemCount: items.length,
+    });
   }
 
   for (
@@ -102,6 +102,24 @@ export function nextSelectHighlightIndex<T>({
     if (!items[next]?.disabled) return next;
   }
   return clampedHighlight;
+}
+
+export function nextWrappingHighlightIndex({
+  direction,
+  highlight,
+  itemCount,
+}: {
+  readonly direction: -1 | 1;
+  readonly highlight: number;
+  readonly itemCount: number;
+}): number {
+  if (itemCount <= 0) return 0;
+  const clampedHighlight = clampIndex(highlight, itemCount);
+  return direction === 1
+    ? (clampedHighlight + 1) % itemCount
+    : clampedHighlight <= 0
+      ? itemCount - 1
+      : clampedHighlight - 1;
 }
 
 export function visibleSelectRange({

--- a/src/test-kernel/cli/SlashPalette.vitest.mts
+++ b/src/test-kernel/cli/SlashPalette.vitest.mts
@@ -5,14 +5,7 @@ import {
   slashPaletteEnterHintAction,
   slashPaletteWindow,
 } from '@cli/chat/tui/commands/SlashPalette';
-import { nextSelectHighlightIndex } from '@cli/chat/tui/ui/Select';
-
-function itemsOfLength(itemCount: number): { value: number; label: string }[] {
-  return Array.from({ length: itemCount }, (_, i) => ({
-    value: i,
-    label: String(i),
-  }));
-}
+import { nextWrappingHighlightIndex } from '@cli/chat/tui/ui/Select';
 
 describe('SlashPalette navigation', () => {
   it('continues down into commands hidden behind the overflow marker', () => {
@@ -30,10 +23,10 @@ describe('SlashPalette navigation', () => {
       hiddenAfter: 7,
     });
 
-    const next = nextSelectHighlightIndex({
+    const next = nextWrappingHighlightIndex({
       direction: 1,
       highlight: 7,
-      items: itemsOfLength(itemCount),
+      itemCount,
     });
 
     expect(next).toBe(8);
@@ -53,17 +46,17 @@ describe('SlashPalette navigation', () => {
 
   it('wraps navigation across the full match list', () => {
     expect(
-      nextSelectHighlightIndex({
+      nextWrappingHighlightIndex({
         direction: 1,
         highlight: 14,
-        items: itemsOfLength(15),
+        itemCount: 15,
       }),
     ).toBe(0);
     expect(
-      nextSelectHighlightIndex({
+      nextWrappingHighlightIndex({
         direction: -1,
         highlight: 0,
-        items: itemsOfLength(15),
+        itemCount: 15,
       }),
     ).toBe(14);
   });

--- a/src/test-kernel/cli/SlashPalette.vitest.mts
+++ b/src/test-kernel/cli/SlashPalette.vitest.mts
@@ -1,11 +1,18 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  nextSlashPaletteHighlight,
   slashPaletteCommandLabelWidth,
   slashPaletteEnterHintAction,
   slashPaletteWindow,
 } from '@cli/chat/tui/commands/SlashPalette';
+import { nextSelectHighlightIndex } from '@cli/chat/tui/ui/Select';
+
+function itemsOfLength(itemCount: number): { value: number; label: string }[] {
+  return Array.from({ length: itemCount }, (_, i) => ({
+    value: i,
+    label: String(i),
+  }));
+}
 
 describe('SlashPalette navigation', () => {
   it('continues down into commands hidden behind the overflow marker', () => {
@@ -23,10 +30,10 @@ describe('SlashPalette navigation', () => {
       hiddenAfter: 7,
     });
 
-    const next = nextSlashPaletteHighlight({
+    const next = nextSelectHighlightIndex({
       direction: 1,
       highlight: 7,
-      itemCount,
+      items: itemsOfLength(itemCount),
     });
 
     expect(next).toBe(8);
@@ -46,17 +53,17 @@ describe('SlashPalette navigation', () => {
 
   it('wraps navigation across the full match list', () => {
     expect(
-      nextSlashPaletteHighlight({
+      nextSelectHighlightIndex({
         direction: 1,
         highlight: 14,
-        itemCount: 15,
+        items: itemsOfLength(15),
       }),
     ).toBe(0);
     expect(
-      nextSlashPaletteHighlight({
+      nextSelectHighlightIndex({
         direction: -1,
         highlight: 0,
-        itemCount: 15,
+        items: itemsOfLength(15),
       }),
     ).toBe(14);
   });


### PR DESCRIPTION
## Summary

`SlashPalette` (`packages/cli/src/chat/tui/commands/SlashPalette.tsx`) hand-rolled its own arrow-key wraparound logic (`nextSlashPaletteHighlight`) that was a byte-for-byte duplicate of `ui/Select.tsx`'s `nextSelectHighlightIndex` for all-enabled item lists — slash commands never carry a `disabled` flag, so the two functions always produced identical results. `Select`'s helper is already reused consistently across 12 other files (all `forms/*ListForm.tsx`, `ChildControlPicker.tsx`, `UserQuestion.tsx`, `ConfigForm.tsx`).

## Issue acceptance gates

Found during a routine UI-consistency audit of the codebase (Font Awesome / Web Awesome / Ink standardization). The extension webview side turned up nothing significant — recent PRs already did a thorough Web Awesome migration. This was the one real duplicated-logic finding on the CLI TUI side.

## Single source of truth

`ui/Select.tsx`'s `nextSelectHighlightIndex` is now the single implementation of wraparound highlight stepping; `SlashPalette.tsx` delegates to it instead of maintaining a parallel copy.

## Duplication and abstraction budget

Removed: `nextSlashPaletteHighlight` (14 lines) and its dedicated test cases were duplicating `nextSelectHighlightIndex`.

Not touched: `slashPaletteWindow`'s visible-window/scroll math stays local. It's a deliberately different, test-covered "sticky-edge" scroll algorithm (one fewer row visible in the middle of a long list so both overflow markers can show at once) versus `Select`'s simpler centered `visibleSelectRange` — merging these would have changed scroll behavior, so I left it as-is and added a comment explaining why it doesn't route through `Select` too.

## Host impact

Extension: none.

Desktop: none.

CLI: `SlashPalette`'s arrow-key navigation behavior is unchanged (same wraparound semantics), now backed by the shared implementation instead of a parallel one.

## Scheduled refactoring

None.

## Validation

- `CI=true pnpm vitest run src/test-kernel/cli/SlashPalette.vitest.mts src/test-kernel/cli/SelectHotkeys.vitest.mts src/test-kernel/cli/ModelListForm.vitest.mts` — 33 tests pass
- `npm run typecheck` — clean
- `eslint` on changed files — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_0123gCpaAhnDKVE3PRsXJDpn)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of CLI TUI keyboard navigation with existing test coverage; no auth, data, or API surface changes.
> 
> **Overview**
> **Wraparound list highlight stepping** is consolidated: `nextWrappingHighlightIndex` is exported from `ui/Select.tsx`, and `SlashPalette` arrow-key handling calls it instead of local `nextSlashPaletteHighlight` (removed).
> 
> `nextSelectHighlightIndex` now uses the same helper when every item is enabled or disabled, so palette and select menus share one implementation without changing wrap semantics.
> 
> `slashPaletteWindow` scroll math stays in `SlashPalette` with a short comment that it intentionally differs from `Select`'s `visibleSelectRange` (dual overflow markers). Tests import `nextWrappingHighlightIndex` from `Select`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3ed70d62e981f6ed0327d7cf72fa0b8ea3ae243. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->