### PR TITLE
fix: select team root agents in launcher

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -336,10 +336,13 @@ export function createDesktopSettingsIpc(
     });
   }
 
-  async function postMainAgentOptionsData(): Promise<void> {
+  async function postMainAgentOptionsData(
+    selectedToolUseAgent?: string,
+  ): Promise<void> {
     options.postToRenderer({
       command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
       optionsData: await loadAgentOptionsData(),
+      ...(selectedToolUseAgent ? { selectedToolUseAgent } : {}),
     });
   }
 
@@ -1030,7 +1033,14 @@ export function createDesktopSettingsIpc(
       await options.showErrorMessage?.(`Unknown team: ${presetId}`);
       return;
     }
-    await Promise.all([postAgentSelectionData(), postMainAgentOptionsData()]);
+    await Promise.all([
+      postAgentSelectionData(),
+      postMainAgentOptionsData(
+        agentCatalogController.getPresetToolUseRoot(
+          result.preset.toolUseAgents,
+        ),
+      ),
+    ]);
     await options.showInfoMessage?.(`Applied "${result.preset.name}" team`);
   }
 

--- a/packages/extension/src/commands/system/mainViewCommands.ts
+++ b/packages/extension/src/commands/system/mainViewCommands.ts
@@ -27,6 +27,9 @@ type ModelOptionsByCategory = Awaited<
   ReturnType<typeof loadMainViewModelOptions>
 >;
 type AgentOptionsData = Awaited<ReturnType<typeof computeAgentOptionsData>>;
+interface RefreshAllOptionsArgs {
+  readonly selectedToolUseAgent?: string;
+}
 
 function postModelOptions(
   webview: vscode.WebviewView,
@@ -42,10 +45,12 @@ function postModelOptions(
 function postAgentOptions(
   webview: vscode.WebviewView,
   optionsData: AgentOptionsData,
+  selectedToolUseAgent?: string,
 ): void {
   webview.webview.postMessage({
     command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
     optionsData,
+    ...(selectedToolUseAgent && { selectedToolUseAgent }),
   });
 }
 
@@ -90,7 +95,7 @@ export function registerMainViewCommands(
     },
     {
       id: mainViewCommands.refreshAllOptions,
-      handler: () =>
+      handler: (args?: RefreshAllOptionsArgs) =>
         runRefresh('options', async (webview) => {
           await refresh();
           const [modelOptionsByCategory, agentOptionsData] = await Promise.all([
@@ -98,7 +103,11 @@ export function registerMainViewCommands(
             computeAgentOptionsData(),
           ]);
           postModelOptions(webview, modelOptionsByCategory);
-          postAgentOptions(webview, agentOptionsData);
+          postAgentOptions(
+            webview,
+            agentOptionsData,
+            args?.selectedToolUseAgent,
+          );
         }),
     },
   ]);

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -187,8 +187,8 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       deleteSecret: (key) => SecretManager.delete(key),
       refreshAfterKeyChange: () => this.refreshAfterKeyChange(),
     });
-    this.agentHandlers = new AgentHandlers(ctx, () =>
-      this.refreshAfterAgentMutation(),
+    this.agentHandlers = new AgentHandlers(ctx, (selectedToolUseAgent) =>
+      this.refreshAfterAgentMutation(selectedToolUseAgent),
     );
     this.latexHandlers = new LatexSettingsHandlers(ctx);
     this.historyHandlers = new HistoryHandlers(ctx);
@@ -903,12 +903,18 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   }
 
   /** Refresh settings-view agent list and main-view dropdown after agent mutations. */
-  private async refreshAfterAgentMutation(): Promise<void> {
+  private async refreshAfterAgentMutation(
+    selectedToolUseAgent?: string,
+  ): Promise<void> {
     await Promise.all([
       this.withActiveWebview((w) =>
         this.agentHandlers.sendAgentSelectionData(w),
       ),
-      safeExecuteCommand('texra.refreshAllOptions', [], this.viewName),
+      safeExecuteCommand(
+        'texra.refreshAllOptions',
+        selectedToolUseAgent ? [{ selectedToolUseAgent }] : [],
+        this.viewName,
+      ),
     ]);
   }
 

--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -50,7 +50,9 @@ export class AgentHandlers {
 
   constructor(
     private readonly ctx: SettingsHandlerContext,
-    private readonly refreshAfterAgentMutation: () => Promise<void>,
+    private readonly refreshAfterAgentMutation: (
+      selectedToolUseAgent?: string,
+    ) => Promise<void>,
   ) {
     const controllers = createSettingsAgentControllers({
       workspaceState: workspaceSM,
@@ -406,7 +408,9 @@ export class AgentHandlers {
         return;
       }
 
-      await this.refreshAfterAgentMutation();
+      await this.refreshAfterAgentMutation(
+        this.getPresetToolUseRoot(result.preset.toolUseAgents),
+      );
 
       void vscode.window.showInformationMessage(
         `Applied "${result.preset.name}" team`,
@@ -445,6 +449,17 @@ export class AgentHandlers {
         error,
       );
     }
+  }
+
+  private getPresetToolUseRoot(toolUseAgents: string[]): string | undefined {
+    const orchestratorNames = new Set(
+      this.catalogController.getOrchestratorAgentNames(),
+    );
+    return toolUseAgents.find(
+      (name) =>
+        orchestratorNames.has(name) ||
+        name.toLowerCase().includes('orchestrator'),
+    );
   }
 
   async handleDeleteAgentModePreset(

--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -409,7 +409,9 @@ export class AgentHandlers {
       }
 
       await this.refreshAfterAgentMutation(
-        this.getPresetToolUseRoot(result.preset.toolUseAgents),
+        this.catalogController.getPresetToolUseRoot(
+          result.preset.toolUseAgents,
+        ),
       );
 
       void vscode.window.showInformationMessage(
@@ -449,17 +451,6 @@ export class AgentHandlers {
         error,
       );
     }
-  }
-
-  private getPresetToolUseRoot(toolUseAgents: string[]): string | undefined {
-    const orchestratorNames = new Set(
-      this.catalogController.getOrchestratorAgentNames(),
-    );
-    return toolUseAgents.find(
-      (name) =>
-        orchestratorNames.has(name) ||
-        name.toLowerCase().includes('orchestrator'),
-    );
   }
 
   async handleDeleteAgentModePreset(

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -863,17 +863,36 @@ export class MainApp extends MainAppBase {
 
     if (optionsData.toolUse) {
       this.toolUseAgentOptions.set(optionsData.toolUse);
+      const selectedToolUseAgent = message.selectedToolUseAgent
+        ? this.findAgentSelection(
+            optionsData.toolUse,
+            message.selectedToolUseAgent,
+          )
+        : undefined;
       this.toolUseAgent.set(
-        this.validateAgentSelection(
-          optionsData.toolUse,
-          this.toolUseAgent.get(),
-          // State 2 sanity (PRD: agent-native onboarding): a persisted agent
-          // that no longer resolves (e.g. BYOK user with the sign-in-only
-          // 'orchestrator' default) falls back along the preferred list
-          // instead of leaving the dropdown with no selection.
-          PREFERRED_TOOL_USE_AGENTS,
-        ),
+        selectedToolUseAgent ??
+          this.validateAgentSelection(
+            optionsData.toolUse,
+            this.toolUseAgent.get(),
+            // State 2 sanity (PRD: agent-native onboarding): a persisted agent
+            // that no longer resolves (e.g. BYOK user with the sign-in-only
+            // 'orchestrator' default) falls back along the preferred list
+            // instead of leaving the dropdown with no selection.
+            PREFERRED_TOOL_USE_AGENTS,
+          ),
       );
+      if (selectedToolUseAgent) {
+        this.swapModeInstruction(
+          this.sessionType.get(),
+          SESSION_TYPES.TOOL_USE,
+        );
+        this.sessionType.set(SESSION_TYPES.TOOL_USE);
+        this.outputFilesActive.set(false);
+        this.updateMultiFiles('outputFiles', []);
+        this.refreshModelSelectionForActiveSession();
+        this.refreshInstructionPlaceholder();
+        this.saveState();
+      }
     }
   }
 
@@ -903,6 +922,16 @@ export class MainApp extends MainAppBase {
     // No match — keep stale value so the UI shows no selection.
     // Execution will error with "unknown agent" if the user proceeds.
     return currentValue;
+  }
+
+  private findAgentSelection(
+    options: AgentOptionData[],
+    candidate: string,
+  ): string | undefined {
+    const exact = options.find((opt) => opt.value === candidate);
+    if (exact) return exact.value;
+    const name = agentName(candidate);
+    return options.find((opt) => agentName(opt.value) === name)?.value;
   }
 
   private handleSetEditedFileOptions(

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -882,16 +882,7 @@ export class MainApp extends MainAppBase {
           ),
       );
       if (selectedToolUseAgent) {
-        this.swapModeInstruction(
-          this.sessionType.get(),
-          SESSION_TYPES.TOOL_USE,
-        );
-        this.sessionType.set(SESSION_TYPES.TOOL_USE);
-        this.outputFilesActive.set(false);
-        this.updateMultiFiles('outputFiles', []);
-        this.refreshModelSelectionForActiveSession();
-        this.refreshInstructionPlaceholder();
-        this.saveState();
+        this.enterToolUseSession();
       }
     }
   }
@@ -932,6 +923,19 @@ export class MainApp extends MainAppBase {
     if (exact) return exact.value;
     const name = agentName(candidate);
     return options.find((opt) => agentName(opt.value) === name)?.value;
+  }
+
+  private enterToolUseSession(): void {
+    if (this.sessionType.get() !== SESSION_TYPES.TOOL_USE) {
+      this.swapModeInstruction(this.sessionType.get(), SESSION_TYPES.TOOL_USE);
+      this.sessionType.set(SESSION_TYPES.TOOL_USE);
+      this.fileSelectionOpen.set(false);
+      this.outputFilesActive.set(false);
+      this.updateMultiFiles('outputFiles', []);
+      this.refreshModelSelectionForActiveSession();
+    }
+    this.refreshInstructionPlaceholder();
+    this.saveState();
   }
 
   private handleSetEditedFileOptions(

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -691,7 +691,7 @@ function filterVisible(
  * Ensures cache is loaded first.
  */
 export async function computeAgentOptionsData(): Promise<AgentOptionsDataPayload> {
-  if (!initialized) {
+  if (!initialized || !cacheIncludesRemote) {
     await (initPromise ?? loadAgents());
   }
 

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -691,9 +691,8 @@ function filterVisible(
  * Ensures cache is loaded first.
  */
 export async function computeAgentOptionsData(): Promise<AgentOptionsDataPayload> {
-  if (!initialized || !cacheIncludesRemote) {
-    await (initPromise ?? loadAgents());
-  }
+  if (initPromise) await initPromise;
+  if (!initialized || !cacheIncludesRemote) await loadAgents();
 
   return {
     workflow: entriesToOptionData(

--- a/src/controllers/settingsView/SettingsAgentCatalogController.ts
+++ b/src/controllers/settingsView/SettingsAgentCatalogController.ts
@@ -236,6 +236,5 @@ export class SettingsAgentCatalogController {
 }
 
 function isOrchestratorLikeName(name: string): boolean {
-  const lowerName = name.toLowerCase();
-  return lowerName === 'orchestrator' || lowerName.endsWith('orchestrator');
+  return name.toLowerCase().endsWith('orchestrator');
 }

--- a/src/controllers/settingsView/SettingsAgentCatalogController.ts
+++ b/src/controllers/settingsView/SettingsAgentCatalogController.ts
@@ -146,6 +146,15 @@ export class SettingsAgentCatalogController {
     return [...names].sort();
   }
 
+  getPresetToolUseRoot(toolUseAgents: string[]): string | undefined {
+    const orchestratorNames = new Set(this.getOrchestratorAgentNames());
+    return toolUseAgents.find(
+      (name) =>
+        orchestratorNames.has(name) ||
+        name.toLowerCase().includes('orchestrator'),
+    );
+  }
+
   async applyPreset(presetId: string): Promise<SettingsAgentPresetApplyResult> {
     const preset = this.getPreset(presetId);
     if (!preset) return { ok: false, reason: 'unknownPreset' };

--- a/src/controllers/settingsView/SettingsAgentCatalogController.ts
+++ b/src/controllers/settingsView/SettingsAgentCatalogController.ts
@@ -149,9 +149,7 @@ export class SettingsAgentCatalogController {
   getPresetToolUseRoot(toolUseAgents: string[]): string | undefined {
     const orchestratorNames = new Set(this.getOrchestratorAgentNames());
     return toolUseAgents.find(
-      (name) =>
-        orchestratorNames.has(name) ||
-        name.toLowerCase().includes('orchestrator'),
+      (name) => orchestratorNames.has(name) || isOrchestratorLikeName(name),
     );
   }
 
@@ -235,4 +233,9 @@ export class SettingsAgentCatalogController {
       AGENT_MODE_PRESETS_BY_ID.get(presetId) ?? this.getCustomPreset(presetId)
     );
   }
+}
+
+function isOrchestratorLikeName(name: string): boolean {
+  const lowerName = name.toLowerCase();
+  return lowerName === 'orchestrator' || lowerName.endsWith('orchestrator');
 }

--- a/src/shared/schemas/mainView/outbound.ts
+++ b/src/shared/schemas/mainView/outbound.ts
@@ -37,6 +37,7 @@ export const SetAgentOptionsMessageSchema = z.object({
       toolUse: z.array(AgentOptionDataSchema).optional(),
     })
     .optional(),
+  selectedToolUseAgent: z.string().optional(),
 });
 
 export const SetEditedFileMessageSchema = withFilesArray(

--- a/src/test-kernel/agent/AgentRegistryAlias.vitest.mts
+++ b/src/test-kernel/agent/AgentRegistryAlias.vitest.mts
@@ -5,7 +5,7 @@ import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 // Third-party imports
-import { beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
@@ -17,6 +17,7 @@ import {
   setAgentDirectories,
 } from '@agent/index/agentDirectoriesRegistry';
 import {
+  computeAgentOptionsData,
   getAgent,
   getVisibleAgent,
   getVisibleAgents,
@@ -25,6 +26,21 @@ import {
   refresh,
 } from '@agent/index/agentRegistry';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
+
+vi.mock('@agent/remote/RemoteAgentLoader', () => ({
+  RemoteAgentLoader: {
+    listRemoteAgents: vi.fn(async () => [
+      {
+        id: 'remote-orchestrator',
+        name: 'orchestrator',
+        description: 'Remote team root',
+        visibility: ['researcher'],
+        tools: ['delegate_agent'],
+        agentCategory: 'toolUse',
+      },
+    ]),
+  },
+}));
 
 const REPO_ROOT = resolve(
   fileURLToPath(new URL('.', import.meta.url)),
@@ -141,6 +157,36 @@ describe('agent registry legacy aliases', () => {
     expect(getAgent('assistant')?.name).toBe('assistant');
 
     useAgentDirectories();
+  });
+
+  it('includes remote agents in launcher options after local-only startup load', async () => {
+    const originalEnabledToolUseAgents = platform().workspaceState.get<
+      string[]
+    >(WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS);
+
+    try {
+      await platform().workspaceState.update(
+        WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
+        ['orchestrator', 'research', 'review'],
+      );
+
+      await refresh({ includeRemote: false });
+      expect(
+        getVisibleAgents('toolUse').map((agent) => agent.name),
+      ).not.toContain('orchestrator');
+
+      const options = await computeAgentOptionsData();
+
+      expect(options.toolUse.map((option) => option.label)).toContain(
+        'orchestrator',
+      );
+    } finally {
+      await platform().workspaceState.update(
+        WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
+        originalEnabledToolUseAgents,
+      );
+      await refresh({ includeRemote: false });
+    }
   });
 
   it('migrates persisted legacy keys at load time', () => {

--- a/src/test-kernel/agent/AgentRegistryAlias.vitest.mts
+++ b/src/test-kernel/agent/AgentRegistryAlias.vitest.mts
@@ -189,6 +189,50 @@ describe('agent registry legacy aliases', () => {
     }
   });
 
+  it('includes remote agents in launcher options after pending local-only startup load', async () => {
+    const originalEnabledToolUseAgents = platform().workspaceState.get<
+      string[]
+    >(WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS);
+
+    let releaseBuiltInToolUseDir: (() => void) | undefined;
+    const waitForBuiltInToolUseDir = new Promise<void>((resolveWait) => {
+      releaseBuiltInToolUseDir = resolveWait;
+    });
+
+    try {
+      await platform().workspaceState.update(
+        WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
+        ['orchestrator', 'research', 'review'],
+      );
+      useAgentDirectories({
+        builtInToolUse: async () => {
+          await waitForBuiltInToolUseDir;
+          return BUILTIN_TOOL_USE_AGENTS_DIR;
+        },
+      });
+
+      const pendingRefresh = refresh({ includeRemote: false });
+      await new Promise((resolveNextTick) => setTimeout(resolveNextTick, 0));
+      const optionsPromise = computeAgentOptionsData();
+
+      releaseBuiltInToolUseDir?.();
+      await pendingRefresh;
+      const options = await optionsPromise;
+
+      expect(options.toolUse.map((option) => option.label)).toContain(
+        'orchestrator',
+      );
+    } finally {
+      releaseBuiltInToolUseDir?.();
+      await platform().workspaceState.update(
+        WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
+        originalEnabledToolUseAgents,
+      );
+      useAgentDirectories();
+      await refresh({ includeRemote: false });
+    }
+  });
+
   it('migrates persisted legacy keys at load time', () => {
     // Stale chat keys would desync the Agents settings UI (which matches
     // keys literally) from picker visibility — loadAgents rewrites them.

--- a/src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts
@@ -212,6 +212,28 @@ describe('SettingsAgentCatalogController', () => {
     ]);
   });
 
+  it('selects preset roots without matching arbitrary orchestrator substrings', () => {
+    const { controller } = createController({
+      builtInOrchestratorAgentNames: ['engineer'],
+    });
+
+    assert.equal(
+      controller.getPresetToolUseRoot([
+        'nonOrchestratorHelper',
+        'engineer',
+        'leanOrchestrator',
+      ]),
+      'engineer',
+    );
+    assert.equal(
+      controller.getPresetToolUseRoot([
+        'nonOrchestratorHelper',
+        'leanOrchestrator',
+      ]),
+      'leanOrchestrator',
+    );
+  });
+
   it('drops only invalid custom presets', () => {
     const { controller } = createController({
       customPresets: [

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -1375,6 +1375,7 @@ describe('desktop settings IPC', () => {
       ),
     ).toMatchObject({
       command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+      selectedToolUseAgent: 'orchestrator',
       optionsData: {
         workflow: [
           expect.objectContaining({ value: 'builtInWorkflow:correct' }),


### PR DESCRIPTION
## Summary

Applying a multi-agent team preset refreshed the launcher agent options but could leave the tool-use picker on a still-valid prior agent. For example, the Physicist team includes `research`, so the launcher could stay on `research` even though the team root is `orchestrator`.

This PR makes team application pass an explicit `selectedToolUseAgent` through the existing launcher-refresh path. The main view resolves that request against the refreshed options, selects the requested team root, and enters tool-use mode through a shared helper that keeps the Files and output panels consistent.

The same behavior is now wired for the desktop settings IPC path. The root-selection rule lives in the shared settings catalog controller, where it prefers catalog-discovered orchestrators and only falls back to exact or suffix `orchestrator` names.

The launcher option builder also reloads the registry when startup initialized a local-only cache, so a fresh workspace can show remote team-root agents before the user manually changes a team.

## Validation

- `CI=true corepack pnpm vitest run src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts src/test-kernel/agent/AgentRegistryAlias.vitest.mts src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts src/test-kernel/controllers/MainViewStartupController.vitest.ts`
- `corepack pnpm exec eslint packages/extension/src/webview/frontend/MainApp.ts src/agent/index/agentRegistry.ts src/test-kernel/agent/AgentRegistryAlias.vitest.mts packages/desktop/src/main/desktopSettingsIpc.ts packages/extension/src/settingsView/handlers/agentHandlers.ts src/controllers/settingsView/SettingsAgentCatalogController.ts src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts`
- `corepack pnpm exec prettier --check packages/extension/src/webview/frontend/MainApp.ts src/agent/index/agentRegistry.ts src/test-kernel/agent/AgentRegistryAlias.vitest.mts packages/desktop/src/main/desktopSettingsIpc.ts packages/extension/src/settingsView/handlers/agentHandlers.ts src/controllers/settingsView/SettingsAgentCatalogController.ts src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts`
- `CI=true corepack pnpm run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Launcher and settings refresh behavior only; no auth, persistence schema, or execution-path changes beyond selecting the intended agent after team apply.
> 
> **Overview**
> Fixes a case where **applying an agent team preset** refreshed launcher options but could leave the tool-use picker on a still-valid member (e.g. `research`) instead of the team root (`orchestrator`).
> 
> **Team apply → launcher:** After a preset is applied (extension settings and desktop IPC), the refresh path now passes an optional **`selectedToolUseAgent`**. The root is chosen in **`SettingsAgentCatalogController.getPresetToolUseRoot`**, preferring catalog orchestrators (delegation tools / built-in names) and only then names ending in `orchestrator` (suffix match, not arbitrary substrings).
> 
> **Wire + UI:** `SET_AGENT_OPTIONS` / `texra.refreshAllOptions` accept that hint. **`MainApp`** resolves it against refreshed tool-use options (exact key or plain name), sets the picker, and **`enterToolUseSession()`** switches to tool-use mode and resets file/output UI consistently.
> 
> **Registry:** **`computeAgentOptionsData`** waits on in-flight loads and reloads when the cache was built **local-only**, so remote team roots can appear in the launcher without a manual refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c4eff2c75a9d4cce91d4969837272ffa2fa7452. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->