### PR TITLE
Route env-var API-key fallback through PlatformSecrets

### DIFF
--- a/packages/cli/src/runtime/cliSecrets.ts
+++ b/packages/cli/src/runtime/cliSecrets.ts
@@ -50,6 +50,10 @@ export class CliSecrets implements PlatformSecrets {
     });
   }
 
+  getEnv(name: string): string | undefined {
+    return cliEnvValue(name);
+  }
+
   private async updateSecrets(
     mutator: (data: SecretFileData) => void,
   ): Promise<void> {

--- a/packages/desktop/src/main/desktopSettingsIpcHelpers.ts
+++ b/packages/desktop/src/main/desktopSettingsIpcHelpers.ts
@@ -14,6 +14,7 @@ export const emptySecrets: PlatformSecrets = {
   get: () => Promise.resolve(undefined),
   set: () => Promise.resolve(),
   delete: () => Promise.resolve(),
+  getEnv: () => undefined,
 };
 
 export function defaultOnError(error: unknown): void {

--- a/packages/desktop/src/main/platform/electronSecrets.ts
+++ b/packages/desktop/src/main/platform/electronSecrets.ts
@@ -137,6 +137,10 @@ export class ElectronSecrets implements PlatformSecrets {
     await this.store.set(key, undefined);
   }
 
+  getEnv(name: string): string | undefined {
+    return process.env[name];
+  }
+
   private async warnAboutBasicTextStorage(): Promise<void> {
     if (this.warnedAboutBasicText) return;
     this.warnedAboutBasicText = true;

--- a/packages/extension/src/frontend/vscode/vscodeSecrets.ts
+++ b/packages/extension/src/frontend/vscode/vscodeSecrets.ts
@@ -29,4 +29,8 @@ export class VscodeSecrets implements PlatformSecrets {
   async delete(key: string): Promise<void> {
     await this.storage.delete(key);
   }
+
+  getEnv(name: string): string | undefined {
+    return process.env[name];
+  }
 }

--- a/src/model/apiProviders.ts
+++ b/src/model/apiProviders.ts
@@ -67,7 +67,7 @@ async function resolveApiKeyUncached(
 ): Promise<ResolvedApiKey> {
   const stored = await secrets.get(apiKeySecretName(provider));
   if (stored) return { value: stored, origin: 'secret' };
-  const envValue = process.env[apiKeyEnvName(provider)];
+  const envValue = secrets.getEnv(apiKeyEnvName(provider));
   if (envValue) return { value: envValue, origin: 'env' };
   return { value: undefined, origin: 'none' };
 }

--- a/src/platform/secrets.ts
+++ b/src/platform/secrets.ts
@@ -17,4 +17,15 @@ export interface PlatformSecrets {
 
   /** Delete a secret. */
   delete(key: string): Promise<void>;
+
+  /**
+   * Read a conventional environment variable (e.g. `ANTHROPIC_API_KEY`).
+   * Distinct from `get()`, which is keyed by the internal secret-storage
+   * name (e.g. `apiKey.anthropic`) and already applies its own env override
+   * for that name. Callers that fall back to a differently-named
+   * conventional env var (see `apiKeyEnvName`) go through this seam instead
+   * of reading `process.env` directly, so the fallback stays host-agnostic
+   * and mockable in tests.
+   */
+  getEnv(name: string): string | undefined;
 }

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -183,6 +183,10 @@ class MemorySecrets {
   async delete(key: string): Promise<void> {
     this.values.delete(key);
   }
+
+  getEnv(): string | undefined {
+    return undefined;
+  }
 }
 
 async function loadDesktopSettingsIpc(): Promise<DesktopSettingsIpcModule> {

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
@@ -49,6 +49,7 @@ function createSecrets() {
     get: vi.fn(async () => undefined),
     set: vi.fn(async () => {}),
     delete: vi.fn(async () => {}),
+    getEnv: vi.fn(() => undefined),
   };
 }
 

--- a/src/test-kernel/model/ApiProviders.vitest.ts
+++ b/src/test-kernel/model/ApiProviders.vitest.ts
@@ -14,7 +14,10 @@ import { UnsetApiKeyTool } from '@tools/setup/UnsetApiKeyTool';
 import { setSetupPlatform, type SetupPlatform } from '@tools/setup/platform';
 import type { PlatformSecrets } from '@platform/secrets';
 
-function createSecrets(initial: Record<string, string> = {}): {
+function createSecrets(
+  initial: Record<string, string> = {},
+  env: Record<string, string> = {},
+): {
   secrets: PlatformSecrets;
   store: Map<string, string>;
 } {
@@ -30,6 +33,9 @@ function createSecrets(initial: Record<string, string> = {}): {
       },
       async delete(key) {
         store.delete(key);
+      },
+      getEnv(name) {
+        return env[name];
       },
     },
   };
@@ -111,23 +117,12 @@ function setupApiKeyToolPlatform(store: Map<string, string>): void {
 }
 
 describe('API provider key caches', () => {
-  let hadOpenAiApiKey = false;
-  let originalOpenAiApiKey: string | undefined;
-
   beforeEach(() => {
-    hadOpenAiApiKey = Object.hasOwn(process.env, 'OPENAI_API_KEY');
-    originalOpenAiApiKey = process.env.OPENAI_API_KEY;
     invalidateApiKeyCache();
-    delete process.env.OPENAI_API_KEY;
   });
 
   afterEach(() => {
     invalidateApiKeyCache();
-    if (hadOpenAiApiKey && originalOpenAiApiKey !== undefined) {
-      process.env.OPENAI_API_KEY = originalOpenAiApiKey;
-    } else {
-      delete process.env.OPENAI_API_KEY;
-    }
   });
 
   it('derives provider status from the canonical API-key origin cache', async () => {
@@ -140,8 +135,7 @@ describe('API provider key caches', () => {
     });
 
     invalidateApiKeyCache();
-    const empty = createSecrets();
-    process.env.OPENAI_API_KEY = 'from-env';
+    const empty = createSecrets({}, { OPENAI_API_KEY: 'from-env' });
 
     await expect(
       loadApiKeyStatusMap(empty.secrets, ['openai']),
@@ -151,11 +145,9 @@ describe('API provider key caches', () => {
   });
 
   it('treats empty env keys as missing in uncached lookups', async () => {
-    process.env.OPENAI_API_KEY = '';
+    const { secrets } = createSecrets({}, { OPENAI_API_KEY: '' });
 
-    await expect(
-      apiKeyExistsUncached(createSecrets().secrets, 'openai'),
-    ).resolves.toBe(false);
+    await expect(apiKeyExistsUncached(secrets, 'openai')).resolves.toBe(false);
   });
 
   it('set_api_key invalidates stale missing-key lookups', async () => {
@@ -183,6 +175,9 @@ describe('API provider key caches', () => {
       },
       async delete(key) {
         store.delete(key);
+      },
+      getEnv() {
+        return undefined;
       },
     };
 

--- a/src/test-kernel/model/ComputeModelOptions.vitest.ts
+++ b/src/test-kernel/model/ComputeModelOptions.vitest.ts
@@ -66,6 +66,7 @@ function createModelOptionsAccess(
       get: async (key) => secrets[key],
       set: async () => {},
       delete: async () => {},
+      getEnv: () => undefined,
     },
     useOpenRouter: false,
     serverSideKeyService: createServerSideKeyService(options),
@@ -289,36 +290,26 @@ describe('computeModelOptionsData relay quota state', () => {
   });
 
   it('does not reuse cached provider keys for injected access', async () => {
-    const previousDeepseekKey = process.env.DEEPSEEK_API_KEY;
-    delete process.env.DEEPSEEK_API_KEY;
-    try {
-      installServerSideKeyService({
+    installServerSideKeyService({
+      useIncludedAccess: false,
+      relayQuotaExceeded: false,
+      quotaAutoSwitched: false,
+    });
+    await computeModelOptionsData(['deepseekproT']);
+
+    const access = createModelOptionsAccess(
+      {
         useIncludedAccess: false,
         relayQuotaExceeded: false,
         quotaAutoSwitched: false,
-      });
-      await computeModelOptionsData(['deepseekproT']);
+      },
+      {},
+    );
 
-      const access = createModelOptionsAccess(
-        {
-          useIncludedAccess: false,
-          relayQuotaExceeded: false,
-          quotaAutoSwitched: false,
-        },
-        {},
-      );
+    const [model] = await computeModelOptionsData(['deepseekproT'], access);
 
-      const [model] = await computeModelOptionsData(['deepseekproT'], access);
-
-      expect(model.availability).toBe('missing-key');
-      expect(model.disabled).toBe(true);
-    } finally {
-      if (previousDeepseekKey === undefined) {
-        delete process.env.DEEPSEEK_API_KEY;
-      } else {
-        process.env.DEEPSEEK_API_KEY = previousDeepseekKey;
-      }
-    }
+    expect(model.availability).toBe('missing-key');
+    expect(model.disabled).toBe(true);
   });
 
   it('caches explicit model-list availability until invalidated', async () => {

--- a/src/test-kernel/support/FakePlatform.ts
+++ b/src/test-kernel/support/FakePlatform.ts
@@ -694,10 +694,16 @@ export class FakeStorageProvider implements StorageProvider {
 export class FakeSecrets implements PlatformSecrets {
   private readonly values = new Map<string, string>();
 
-  constructor(values: Record<string, string> = {}) {
+  private readonly env: Record<string, string>;
+
+  constructor(
+    values: Record<string, string> = {},
+    env: Record<string, string> = {},
+  ) {
     for (const [key, value] of Object.entries(values)) {
       this.values.set(key, value);
     }
+    this.env = env;
   }
 
   async get(key: string): Promise<string | undefined> {
@@ -711,6 +717,10 @@ export class FakeSecrets implements PlatformSecrets {
   async delete(key: string): Promise<void> {
     this.values.delete(key);
   }
+
+  getEnv(name: string): string | undefined {
+    return this.env[name];
+  }
 }
 
 export interface FakePlatformOptions {
@@ -719,6 +729,8 @@ export interface FakePlatformOptions {
   workspaceState?: Record<string, unknown>;
   files?: Record<string, string | Uint8Array>;
   secrets?: Record<string, string>;
+  /** Conventional env-var fallbacks (e.g. `ANTHROPIC_API_KEY`) surfaced via `PlatformSecrets.getEnv`. */
+  secretsEnv?: Record<string, string>;
   workspacePath?: string | undefined;
   storagePath?: string;
   globalStoragePath?: string;
@@ -742,7 +754,7 @@ export function createFakePlatform(
       options.storagePath,
       options.globalStoragePath,
     ),
-    secrets: new FakeSecrets(options.secrets),
+    secrets: new FakeSecrets(options.secrets, options.secretsEnv),
     lifecycle: createLifecycleHost(),
     agentResume: { tryResumeStream: async () => false },
     toolAvailability: NO_TOOL_AVAILABILITY_HOST,


### PR DESCRIPTION
## Summary

An abstraction-layer audit of the codebase found one real (if minor) violation: `resolveApiKeyUncached()` in `src/model/apiProviders.ts` read `process.env[apiKeyEnvName(provider)]` directly for the conventional env-var fallback (e.g. `ANTHROPIC_API_KEY`), bypassing the `platform()` abstraction that every other secret lookup in this file already goes through (`secrets.get()` for the internal `apiKey.<provider>` storage key). This PR closes that gap.

Everything else surfaced by the audit (VS Code coupling, PocketFlow flattening, factory-pattern misuse, render-time workarounds, duplicate UI controls, commands bypassing `executeAgent`) checked out clean — no changes needed there. One related candidate (`getGitHubEnvToken()` in `src/tools/github/githubAuth.ts`) was investigated and intentionally left alone: its tests show it must resolve `GH_TOKEN`/`GITHUB_TOKEN` *before* `initPlatform()` runs, so routing it through `platform().secrets` would be a functional regression, not a cleanup.

## Issue acceptance gates

No linked issue — this is a self-directed cleanup from a requested codebase audit. Gate: the conventional-env-var API key fallback no longer reads `process.env` directly in `src/model/` (a VS Code-free zone); it goes through the same `platform()` seam as every other secret read.

## Single source of truth

`PlatformSecrets.getEnv(name)` is now the single seam for reading a conventional environment variable (as opposed to `get(key)`, which reads the internal secret-storage key and already applies its own same-name env override). Each host (`VscodeSecrets`, `ElectronSecrets`, `CliSecrets`) implements it as a thin `process.env` read; `FakeSecrets` implements it against an injectable in-memory map instead of real `process.env`.

## Duplication and abstraction budget

No new abstraction layer — `getEnv` is one method added to the existing `PlatformSecrets` interface, mirroring the pattern already used for `get`/`set`/`delete`. This also fixed a latent test-isolation bug: because the old code always read real `process.env` regardless of which `secrets` implementation was injected, any test using `createFakePlatform` for API-key checks could have silently picked up real host environment variables (e.g. `DEEPSEEK_API_KEY`, `OPENAI_API_KEY`) if a developer or CI runner happened to have them set. Several tests were carrying explicit `process.env` save/delete/restore boilerplate to guard against exactly this; that boilerplate is now removed since `FakeSecrets.getEnv()` never touches the real environment.

## Host impact

Extension: `VscodeSecrets.getEnv()` added (thin `process.env` wrapper, same as its existing `get()` override).

Desktop: `ElectronSecrets.getEnv()` added (same pattern); `emptySecrets` helper in `desktopSettingsIpcHelpers.ts` updated to satisfy the extended interface.

CLI: `CliSecrets.getEnv()` added, delegating to the existing `cliEnvValue()` helper (no new env-reading code path).

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` (root + `packages/desktop` + `packages/cli` typecheck) — clean.
- `npx vitest run` (full suite) — all green except one pre-existing, unrelated flake in `execUtils.vitest.ts` (`aborts shell command process groups including children`), which fails on process-group signal handling inside this sandboxed environment and is unaffected by this diff (verified the failure is about `SIGKILL`-ing a spawned process group, not secrets/env handling).
- `npm run lint` — 0 errors (21 pre-existing warnings, none in touched files).
- `npx prettier --check` on all touched files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01E8CDjUfCLfnKWFfaSPWZzA)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small interface extension with thin host wrappers; behavior should match prior env fallback except tests now control env via mocks instead of the real process environment.
> 
> **Overview**
> Adds **`PlatformSecrets.getEnv(name)`** as the shared way to read conventional env vars (e.g. `OPENAI_API_KEY`), separate from **`get()`** on internal secret keys like `apiKey.openai`.
> 
> **`resolveApiKeyUncached`** in `apiProviders.ts` now uses **`secrets.getEnv(apiKeyEnvName(provider))`** instead of **`process.env`**, so model-layer key resolution stays on the platform secrets seam.
> 
> Each host implements **`getEnv`**: VS Code and Electron delegate to **`process.env`**; CLI uses **`cliEnvValue`**. Stubs (`emptySecrets`, test doubles) return **`undefined`** or an injectable map.
> 
> Tests and **`FakeSecrets`** gain optional **`secretsEnv`** / **`getEnv`** wiring so API-key tests no longer mutate real **`process.env`** (fixes flaky isolation when CI or dev machines have keys set).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2157c56c1df91b64faf81827d1f69fb20c610f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->