### PR TITLE
Migrate platform services to composition root, add test run context

### DIFF
--- a/docs/agent-sdk-readiness-audit.md
+++ b/docs/agent-sdk-readiness-audit.md
@@ -1766,7 +1766,7 @@ a wrapper, barrel, or run-entry indirection:
   change.
 - **`d7d6bc2` "simplify code changed since v0.38.7 (#5949)," `d6d4182` "share
   `clampOptional` and `joinNonEmpty."** Repo flatten/DRY rules applied — small, additive,
-  no surface change. **`4f75594` "Replace async-lock with async-mutex (#5953)"** is a
+no surface change. **`4f75594` "Replace async-lock with async-mutex (#5953)"** is a
   dependency swap, not a structural change to the audited surface.
 
 **Guardrails intact:** `find src/agent -name index.ts` shows **no new barrel** (the eight

--- a/docs/prds/2026-01-11-settings-view-unified.md
+++ b/docs/prds/2026-01-11-settings-view-unified.md
@@ -440,18 +440,19 @@ LaTeX settings (formatter, latexdiff, TikZ, replacements) and advanced settings 
 ```
 
 **Settings Mapping (for future implementation):**
-| UI Element | Storage |
-|------------|---------|
-| Auto-show remote agents | `globalState.autoShowRemoteAgents` |
-| Agent visibility | `workspaceState.enabledAgents`, `workspaceState.enabledToolUseAgents` |
-| Custom agents directory | `globalState.customAgentDir` |
-| Storage mode dropdown | `texra.agentOutputs.storageMode` (VS Code config) |
-| Require approval checkbox | `texra.toolUse.requireEditApproval` (VS Code config) |
-| Persist sessions checkbox | `texra.toolUse.persistence.enabled` (VS Code config) |
-| Session retention dropdown | `texra.toolUse.persistence.ttlHours` (VS Code config) |
-| Compaction threshold | `texra.model.compactionThresholdPercent` (VS Code config) |
-| Max attempts | `texra.model.retry.maxAttempts` (VS Code config) |
-| Backoff delay | `texra.model.retry.backoffMs` (VS Code config) |
+
+| UI Element                 | Storage                                                               |
+| -------------------------- | --------------------------------------------------------------------- |
+| Auto-show remote agents    | `globalState.autoShowRemoteAgents`                                    |
+| Agent visibility           | `workspaceState.enabledAgents`, `workspaceState.enabledToolUseAgents` |
+| Custom agents directory    | `globalState.customAgentDir`                                          |
+| Storage mode dropdown      | `texra.agentOutputs.storageMode` (VS Code config)                     |
+| Require approval checkbox  | `texra.toolUse.requireEditApproval` (VS Code config)                  |
+| Persist sessions checkbox  | `texra.toolUse.persistence.enabled` (VS Code config)                  |
+| Session retention dropdown | `texra.toolUse.persistence.ttlHours` (VS Code config)                 |
+| Compaction threshold       | `texra.model.compactionThresholdPercent` (VS Code config)             |
+| Max attempts               | `texra.model.retry.maxAttempts` (VS Code config)                      |
+| Backoff delay              | `texra.model.retry.backoffMs` (VS Code config)                        |
 
 **Storage:** State managers for agent settings, VS Code configuration for remaining settings
 
@@ -498,14 +499,15 @@ await config.update('agents', enabledAgents, ConfigurationTarget.Workspace);
 ```
 
 **Setting Scopes:**
-| Setting | ConfigurationTarget | Reason |
-|---------|---------------------|--------|
-| `texra.models` | Global | Same models everywhere |
-| Provider endpoints | Global | Same API setup everywhere |
-| Agent visibility | Workspace | Different projects need different agents |
-| `texra.agentOutputs.storageMode` | Workspace | Project-specific output location |
-| `texra.toolUse.*` | Global | Consistent behavior |
-| `texra.latex.*` | Global/Workspace | User choice |
+
+| Setting                          | ConfigurationTarget | Reason                                   |
+| -------------------------------- | ------------------- | ---------------------------------------- |
+| `texra.models`                   | Global              | Same models everywhere                   |
+| Provider endpoints               | Global              | Same API setup everywhere                |
+| Agent visibility                 | Workspace           | Different projects need different agents |
+| `texra.agentOutputs.storageMode` | Workspace           | Project-specific output location         |
+| `texra.toolUse.*`                | Global              | Consistent behavior                      |
+| `texra.latex.*`                  | Global/Workspace    | User choice                              |
 
 ### Secret Storage (`context.secrets`)
 

--- a/docs/prds/2026-01-24-prd-progressview-phase1.md
+++ b/docs/prds/2026-01-24-prd-progressview-phase1.md
@@ -672,9 +672,9 @@ export class StreamTabs extends LitElement {
         ${this.streams.map(
           (stream) => html`
             <div
-              class="stream-tab ${stream.name === this.activeStream
-                ? 'is-active'
-                : ''}"
+              class="stream-tab ${
+                stream.name === this.activeStream ? 'is-active' : ''
+              }"
               @click=${() => this.handleStreamClick(stream.name)}
             >
               <span class="tab-title">${stream.label}</span>

--- a/docs/prds/2026-01-24-prd-progressview-phase2.md
+++ b/docs/prds/2026-01-24-prd-progressview-phase2.md
@@ -715,11 +715,13 @@ export class ProgressApp extends LitElement {
     return html`
       <stream-tabs .streams=${this.state.streams}></stream-tabs>
 
-      ${this.isToolUse
-        ? html`<tooluse-content .state=${this.streamState}></tooluse-content>`
-        : html`<workflow-content
-            .state=${this.streamState}
-          ></workflow-content>`}
+      ${
+        this.isToolUse
+          ? html`<tooluse-content .state=${this.streamState}></tooluse-content>`
+          : html`<workflow-content
+              .state=${this.streamState}
+            ></workflow-content>`
+      }
 
       <prompt-overlay .prompt=${this.activePrompt}></prompt-overlay>
     `;
@@ -875,11 +877,13 @@ export class ProgressApp extends LitElement {
     return html`
       <stream-tabs .streams=${this.state.streams}></stream-tabs>
 
-      ${this.isToolUse
-        ? html`<tooluse-content .state=${this.streamState}></tooluse-content>`
-        : html`<workflow-content
-            .state=${this.streamState}
-          ></workflow-content>`}
+      ${
+        this.isToolUse
+          ? html`<tooluse-content .state=${this.streamState}></tooluse-content>`
+          : html`<workflow-content
+              .state=${this.streamState}
+            ></workflow-content>`
+      }
     `;
   }
 }

--- a/docs/prds/2026-02-05-plan-claude-server-compactization.md
+++ b/docs/prds/2026-02-05-plan-claude-server-compactization.md
@@ -333,8 +333,7 @@ if (compactionBlock) {
 
   // Get pre-compaction tokens from iterations array
   const iterations = (response.usage as any).iterations as
-    | Array<{ type: string; input_tokens: number }>
-    | undefined;
+    Array<{ type: string; input_tokens: number }> | undefined;
   const compactionIteration = iterations?.find((i) => i.type === 'compaction');
   const tokensBefore = compactionIteration?.input_tokens ?? totalInputTokens;
 

--- a/docs/prds/2026-02-21-logging-pipeline-refactor.md
+++ b/docs/prds/2026-02-21-logging-pipeline-refactor.md
@@ -612,8 +612,9 @@ export function runWithGroupContext<T>(
 - All call sites in `executeAgent.ts`, `RoundPersistedFlow`, `ToolUseCycleFlow` — no changes needed
 
 **Files modified:**
-| File | Change |
-|------|--------|
+
+| File                     | Change                                                                                                                                                                                                                     |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `src/logger/logUtils.ts` | Replace `pushGroup`/`popGroup`/`enterWith` with `contextStorage.run()` in `runWithGroupContext`. Remove `pushGroup`, `popGroup` functions. `startGroup` calls `runWithGroupContext` internally instead of raw `pushGroup`. |
 
 **Risk**: Low. The external API (`runWithGroupContext`, `getActiveGroupId`, `startGroup`, `endGroup`) is unchanged. Only the internal scoping mechanism changes. The `stage.within()` / `stage.run()` usage patterns in all call sites remain identical.
@@ -629,10 +630,11 @@ export function runWithGroupContext<T>(
 Implement `StreamLog`, `StreamLogStore`, and `WebviewBridge`. No existing code modified or removed.
 
 **Files created:**
-| File | Purpose |
-|------|---------|
-| `src/logger/StreamLog.ts` | Append-only store with seqNo, dirty tracking, delta reads |
-| `src/logger/StreamLogStore.ts` | Per-stream StreamLog manager with persistence |
+
+| File                                         | Purpose                                                     |
+| -------------------------------------------- | ----------------------------------------------------------- |
+| `src/logger/StreamLog.ts`                    | Append-only store with seqNo, dirty tracking, delta reads   |
+| `src/logger/StreamLogStore.ts`               | Per-stream StreamLog manager with persistence               |
 | `src/progressView/managers/WebviewBridge.ts` | Batched IPC with cursor tracking + dirty set, 16ms throttle |
 
 **Rollback**: Delete new files.
@@ -642,9 +644,10 @@ Implement `StreamLog`, `StreamLogStore`, and `WebviewBridge`. No existing code m
 `AgentLogger` writes to **both** old Winston path AND new store. Both paths active. This lets us verify the store captures every entry the old path does.
 
 **Files modified:**
-| File | Change |
-|------|--------|
-| `src/logger/AgentLogger.ts` | Add store writes alongside existing Winston/bus calls. Add `emit*` methods for structured events (initially calling both old + new paths). `createStream` writes to both old bus.emit and new store.update(). |
+
+| File                                       | Change                                                                                                                                                                                                                                                                                                      |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/logger/AgentLogger.ts`                | Add store writes alongside existing Winston/bus calls. Add `emit*` methods for structured events (initially calling both old + new paths). `createStream` writes to both old bus.emit and new store.update().                                                                                               |
 | `src/agent/core/flows/ToolUseCycleFlow.ts` | Route tool output through `options.logger.updateToolUse()` instead of direct `bus.emit('updateLogMessage')`. Removes the 500ms `STREAM_THROTTLE_MS` — bridge's 16ms frame cap handles rate limiting. Keeps `STREAM_BUFFER_MAX` truncation at call site (tool-output-specific, not a generic store concern). |
 
 **Rollback**: Remove store write calls from AgentLogger.
@@ -654,10 +657,11 @@ Implement `StreamLog`, `StreamLogStore`, and `WebviewBridge`. No existing code m
 Frontend receives `LOG_DELTA` alongside old `APPEND_LOG` / `UPDATE_LOG`. Verify parity — same entries appear in both paths.
 
 **Files modified:**
-| File | Change |
-|------|--------|
-| `src/progressView/frontend/slices/logSlice.ts` | Add `LOG_DELTA` handler (existing handlers stay for now) |
-| `src/progressView/events/ProgressEventHandler.ts` | Wire `WebviewBridge` into event handler lifecycle |
+
+| File                                              | Change                                                   |
+| ------------------------------------------------- | -------------------------------------------------------- |
+| `src/progressView/frontend/slices/logSlice.ts`    | Add `LOG_DELTA` handler (existing handlers stay for now) |
+| `src/progressView/events/ProgressEventHandler.ts` | Wire `WebviewBridge` into event handler lifecycle        |
 
 **Rollback**: Disable bridge, revert to old handlers only.
 
@@ -668,18 +672,20 @@ Remove old log path. Winston, VSCodeTransport, old bus emits, and old frontend l
 **Task group bridging**: `startGroup()` / `endGroup()` keep temporary direct `bus.emit('addTaskGroup')` / `bus.emit('updateTaskGroup')` calls (moved from deleted VSCodeTransport into AgentLogger). These stay until Phase 3 replaces them with store entries. Without this, task groups disappear from the UI between Phase 1 (VSCodeTransport deleted) and Phase 3 (store entries replace bus events).
 
 **Files modified:**
-| File | Change |
-|------|--------|
-| `src/logger/AgentLogger.ts` | Remove Winston delegation. Remove `createStream` 100ms throttle. Remove `startGroup` 50ms `delay()`. `emitContextState` replaces `logContextState`. Add temporary `bus.emit('addTaskGroup')` / `bus.emit('updateTaskGroup')` in `startGroup()` / `endGroup()` (removed in Phase 3). Remove `addLogMessage` / `updateLogMessage` bus imports. |
-| `src/progressView/events/ProgressEventHandler.ts` | Remove inline `addLogMessage`, `updateLogMessage`, `updateContextState` handlers from the unified `registerHandlers` call. `WebviewUpdater` retained for non-log messages. |
-| `src/eventBus/ProgressEventBus.ts` | Remove `addLogMessage` / `updateLogMessage` / `updateContextState` event types |
-| `src/progressView/managers/WebviewUpdater.ts` | Remove `appendLogMessage` / `updateLogMessage` / `updateContextState` methods. Strip log fields from `sendSyncStreamContent`. Keep all non-log methods. |
+
+| File                                              | Change                                                                                                                                                                                                                                                                                                                                       |
+| ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/logger/AgentLogger.ts`                       | Remove Winston delegation. Remove `createStream` 100ms throttle. Remove `startGroup` 50ms `delay()`. `emitContextState` replaces `logContextState`. Add temporary `bus.emit('addTaskGroup')` / `bus.emit('updateTaskGroup')` in `startGroup()` / `endGroup()` (removed in Phase 3). Remove `addLogMessage` / `updateLogMessage` bus imports. |
+| `src/progressView/events/ProgressEventHandler.ts` | Remove inline `addLogMessage`, `updateLogMessage`, `updateContextState` handlers from the unified `registerHandlers` call. `WebviewUpdater` retained for non-log messages.                                                                                                                                                                   |
+| `src/eventBus/ProgressEventBus.ts`                | Remove `addLogMessage` / `updateLogMessage` / `updateContextState` event types                                                                                                                                                                                                                                                               |
+| `src/progressView/managers/WebviewUpdater.ts`     | Remove `appendLogMessage` / `updateLogMessage` / `updateContextState` methods. Strip log fields from `sendSyncStreamContent`. Keep all non-log methods.                                                                                                                                                                                      |
 
 **Files removed:**
-| File | Reason |
-|------|--------|
+
+| File                                       | Reason                                          |
+| ------------------------------------------ | ----------------------------------------------- |
 | `src/logger/transports/VSCodeTransport.ts` | Replaced by direct OutputChannel + store writes |
-| `src/logger/LogChannelRegistry.ts` | Winston logger registry no longer needed |
+| `src/logger/LogChannelRegistry.ts`         | Winston logger registry no longer needed        |
 
 **Rollback**: Revert to dual-write (Phase 1b) — old path still works.
 
@@ -693,10 +699,11 @@ Remove old log path. Winston, VSCodeTransport, old bus emits, and old frontend l
 4. Remove `SYNC_STREAM_CONTENT` handler (WebviewBridge.syncStream handles hydration)
 
 **Files modified:**
-| File | Change |
-|------|--------|
-| `src/progressView/frontend/slices/logSlice.ts` | Remove old `APPEND_LOG` / `UPDATE_LOG` handlers, `pendingLogUpdates` Map, `clearPendingLogUpdatesForStream`/`clearAllPendingLogUpdates` helpers, and `applyLogUpdate` shared function |
-| `src/progressView/frontend/store.ts` | Add `generation` to `StreamLogs`, remove array spread |
+
+| File                                            | Change                                                                                                                                                                                 |
+| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/progressView/frontend/slices/logSlice.ts`  | Remove old `APPEND_LOG` / `UPDATE_LOG` handlers, `pendingLogUpdates` Map, `clearPendingLogUpdatesForStream`/`clearAllPendingLogUpdates` helpers, and `applyLogUpdate` shared function  |
+| `src/progressView/frontend/store.ts`            | Add `generation` to `StreamLogs`, remove array spread                                                                                                                                  |
 | `src/progressView/frontend/slices/syncSlice.ts` | Rewrite — `SYNC_STREAM_CONTENT` no longer delegates to `applyLogUpdate`; WebviewBridge.syncStream handles log hydration, sync handler only handles todos/follow-ups/instruction/badges |
 
 ### Phase 3: Task Groups as Store Entries
@@ -710,12 +717,13 @@ Remove old log path. Winston, VSCodeTransport, old bus emits, and old frontend l
 5. Frontend derives task group tree from log entries (filter by `type: 'group-start' | 'group-end'`)
 
 **Files modified/removed:**
-| File | Change |
-|------|--------|
-| `src/eventBus/StreamEventQueue.ts` | Remove entirely |
-| `src/eventBus/ProgressEventBus.ts` | Remove task group event types |
+
+| File                                              | Change                                                                                                                                                                                                                                  |
+| ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/eventBus/StreamEventQueue.ts`                | Remove entirely                                                                                                                                                                                                                         |
+| `src/eventBus/ProgressEventBus.ts`                | Remove task group event types                                                                                                                                                                                                           |
 | `src/progressView/events/ProgressEventHandler.ts` | Remove inline `addTaskGroup` / `updateTaskGroup` handlers, `pendingTaskGroups` buffer, `bufferTaskGroupForReplay`/`replayPendingTaskGroups`/`clearPendingTaskGroups`/`clearAllPendingTaskGroups` methods, and `streamEventQueue` import |
-| `src/progressView/frontend/slices/taskSlice.ts` | Remove `ADD_TASK_GROUP` / `UPDATE_TASK_GROUP` handlers (task groups now derived from `LOG_DELTA` entries) |
+| `src/progressView/frontend/slices/taskSlice.ts`   | Remove `ADD_TASK_GROUP` / `UPDATE_TASK_GROUP` handlers (task groups now derived from `LOG_DELTA` entries)                                                                                                                               |
 
 ### Phase 4: Cleanup
 

--- a/docs/prds/2026-05-04-prd-cli-app.md
+++ b/docs/prds/2026-05-04-prd-cli-app.md
@@ -1169,19 +1169,19 @@ Round 1 above defined the CLI as a thin Node shell over an already host-neutral 
 
 Round 2 lands six concrete deltas plus one cross-cutting kernel refactor that all three hosts (extension, desktop, CLI) benefit from. None of these change the round-1 LOC band by more than ~600 lines combined; most are about replacing ad-hoc patterns with the kernel-shaped abstractions the audit revealed are already partially in place.
 
-| Delta                                                                         | Round 1 status                                       | Round 2 position                                                                                                                                                                                           | New §      |
+| Delta | Round 1 status | Round 2 position | New § |
 | ----------------------------------------------------------------------------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ---- | ----- | ---------------------------------------------------------------------------------------------------------------------------- | --- |
-| Explicit `RunContext` replaces ambient ALS + singletons (§7.6 caveat / #3397) | Tracked as future work                               | **Promoted to standalone PRD — see [`2026-05-06-prd-runcontext-refactor.md`](./2026-05-06-prd-runcontext-refactor.md). CLI v1.0 consumes Phase 1; v1.1 consumes Phase 2 (gates concurrent MCP sessions).** | §22 (stub) |
-| Structured logger with explicit context, no module globals                    | Hand-waved as "consoleLog plus filter wrapper"       | **Promoted to standalone PRD — see [`2026-05-06-prd-logger-v2.md`](./2026-05-06-prd-logger-v2.md). CLI installs four sinks (stderr text, NDJSON stdout, Ink, MCP).**                                       | §23 (stub) |
-| `texra mcp serve` (callable from Claude Code, Codex, opencode)                | Listed as v1.1 future                                | **Promoted to v1; minimum surface = three tools (`run_workflow`, `run_chat`, `list_agents`)**                                                                                                              | §24        |
-| Hook system (SessionStart, PreToolUse, PostToolUse, …)                        | Not mentioned                                        | **v1.1 — copy Claude Code's contract verbatim; spec'd here so v1 doesn't paint itself into a corner**                                                                                                      | §25        |
-| Approval policy revisited (no 2D sandbox axis)                                | 1D `never                                            | ask                                                                                                                                                                                                        | auto-edits | auto | yolo` | **Stays 1D per user feedback. Round 2 sharpens the "in-project / outside-project" semantics with concrete file:line rules.** | §26 |
-| Session transcripts as JSONL under project-hash sharding                      | Implicit reuse of `RunStorageService` snapshot files | **Explicit format; `texra resume` / `--continue` / `--fork-session` semantics**                                                                                                                            | §27        |
-| GitHub Action: composite + Bun (not JS Action)                                | §12 picked JS Action                                 | **Reverse — match `claude-code-base-action`'s composite pattern; faster iteration, no `dist/` checked in**                                                                                                 | §28        |
-| Cross-platform shared structure refactor (kernel side)                        | Implicit                                             | **Promoted into [`2026-05-06-prd-runcontext-refactor.md`](./2026-05-06-prd-runcontext-refactor.md) §8 (three-ring kernel structure). CLI-side consumption details retained here.**                         | §29 (stub) |
-| Container / GitHub-runner target matrix (slim, alpine, texlive)               | Sketched in §12.3                                    | **Refined per survey; `node:20-alpine` is downgraded to "best-effort" because of glibc/Bun/native-deps issues**                                                                                            | §30        |
-| Phase plan delta + LOC delta                                                  | —                                                    | **Aggregated**                                                                                                                                                                                             | §31        |
-| Parking lot — unified agent-SDK / message-SDK / context compaction            | —                                                    | **Out of v1; sized in §32 for visibility**                                                                                                                                                                 | §32        |
+| Explicit `RunContext` replaces ambient ALS + singletons (§7.6 caveat / #3397) | Tracked as future work | **Promoted to standalone PRD — see [`2026-05-06-prd-runcontext-refactor.md`](./2026-05-06-prd-runcontext-refactor.md). CLI v1.0 consumes Phase 1; v1.1 consumes Phase 2 (gates concurrent MCP sessions).** | §22 (stub) |
+| Structured logger with explicit context, no module globals | Hand-waved as "consoleLog plus filter wrapper" | **Promoted to standalone PRD — see [`2026-05-06-prd-logger-v2.md`](./2026-05-06-prd-logger-v2.md). CLI installs four sinks (stderr text, NDJSON stdout, Ink, MCP).** | §23 (stub) |
+| `texra mcp serve` (callable from Claude Code, Codex, opencode) | Listed as v1.1 future | **Promoted to v1; minimum surface = three tools (`run_workflow`, `run_chat`, `list_agents`)** | §24 |
+| Hook system (SessionStart, PreToolUse, PostToolUse, …) | Not mentioned | **v1.1 — copy Claude Code's contract verbatim; spec'd here so v1 doesn't paint itself into a corner** | §25 |
+| Approval policy revisited (no 2D sandbox axis) | 1D `never                                            | ask                                                                                                                                                                                                        | auto-edits | auto | yolo` | **Stays 1D per user feedback. Round 2 sharpens the "in-project / outside-project" semantics with concrete file:line rules.** | §26 |
+| Session transcripts as JSONL under project-hash sharding | Implicit reuse of `RunStorageService` snapshot files | **Explicit format; `texra resume` / `--continue` / `--fork-session` semantics** | §27 |
+| GitHub Action: composite + Bun (not JS Action) | §12 picked JS Action | **Reverse — match `claude-code-base-action`'s composite pattern; faster iteration, no `dist/` checked in** | §28 |
+| Cross-platform shared structure refactor (kernel side) | Implicit | **Promoted into [`2026-05-06-prd-runcontext-refactor.md`](./2026-05-06-prd-runcontext-refactor.md) §8 (three-ring kernel structure). CLI-side consumption details retained here.** | §29 (stub) |
+| Container / GitHub-runner target matrix (slim, alpine, texlive) | Sketched in §12.3 | **Refined per survey; `node:20-alpine` is downgraded to "best-effort" because of glibc/Bun/native-deps issues** | §30 |
+| Phase plan delta + LOC delta | — | **Aggregated** | §31 |
+| Parking lot — unified agent-SDK / message-SDK / context compaction | — | **Out of v1; sized in §32 for visibility** | §32 |
 
 The rest of round 2 is the spec for these deltas, in dependency order: §22 → §23 unblock §24 (an MCP server can't safely host concurrent sessions until the kernel's ambient state is gone); §24 + §25 + §26 are independent hosts on the new context; §27 + §28 + §29 + §30 are deployment / packaging concerns that don't gate kernel work.
 
@@ -1225,12 +1225,12 @@ The kernel work is sized in `2026-05-06-prd-runcontext-refactor.md` §7 (~6.5 en
 
 ### 23.1 What the CLI installs
 
-| Mode                                 | Sink              | What it does                                                                                           |
+| Mode | Sink | What it does |
 | ------------------------------------ | ----------------- | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
-| Headless text (`--print` or non-TTY) | `StderrTextSink`  | picocolors-formatted; respects `--quiet` / `--verbose` / `NO_COLOR`; copies to `--log-file` if passed. |
-| JSON / NDJSON (`--output-format json | ndjson`)          | `NdjsonStdoutSink`                                                                                     | One `RunStreamEvent` per line on stdout (the same union the §11.2 progress stream uses). |
-| Interactive (Ink TUI)                | `InkLogSink`      | Routes records to the `<StreamPane />` component as `event === "log"` rows alongside progress events.  |
-| MCP server (`texra mcp serve`)       | `McpProgressSink` | Records become `notifications/progress` payloads bound to the request's progress token.                |
+| Headless text (`--print` or non-TTY) | `StderrTextSink` | picocolors-formatted; respects `--quiet` / `--verbose` / `NO_COLOR`; copies to `--log-file` if passed. |
+| JSON / NDJSON (`--output-format json | ndjson`) | `NdjsonStdoutSink` | One `RunStreamEvent` per line on stdout (the same union the §11.2 progress stream uses). |
+| Interactive (Ink TUI) | `InkLogSink` | Routes records to the `<StreamPane />` component as `event === "log"` rows alongside progress events. |
+| MCP server (`texra mcp serve`) | `McpProgressSink` | Records become `notifications/progress` payloads bound to the request's progress token. |
 
 All four CLI-side sinks live in `packages/cli/src/render/sinks/`. `BootstrapLogger` is constructed in `cli/src/bin/texra.ts` immediately and threaded through config-load, secret resolution, agent-directory bootstrap, and mode selection — its buffer flushes through whichever sink the resolved mode picks.
 
@@ -1377,17 +1377,17 @@ Hook contracts are easy to bolt on later in theory and a nightmare in practice �
 
 ### 25.3 Where hooks fire
 
-| Event                        | Fires from                                                                          | RunContext field                                     |
+| Event | Fires from | RunContext field |
 | ---------------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------- | ------ | ------ | ---------- | -------- |
-| `SessionStart`               | `executeAgent.ts` after `buildAgentLaunchContext`                                   | `runId`, `streamId`, `cwd`                           |
-| `UserPromptSubmit`           | Tool-use REPL on each user submit                                                   | `runId`, `instruction`                               |
-| `PreToolUse`                 | `requestToolEditApproval`, `requestBashApproval`, generic tool dispatch             | `runId`, `tool.name`, `tool.input`                   |
-| `PostToolUse`                | Tool dispatch after result                                                          | `runId`, `tool.name`, `tool.result.summary`          |
-| `Stop`                       | `executeAgent` finalizer                                                            | `runId`, `result.status`                             |
-| `SubagentStop`               | Delegation child completion                                                         | `runId`, `parentStreamId`, `childStreamId`, `result` |
-| `Notification`               | Any `requestShowError` / `requestShowInstruction` emission                          | `runId`, `message`                                   |
-| `PreCompact` / `PostCompact` | (Future, §32 — context compaction)                                                  | `runId`, `compactionStats`                           |
-| `PermissionRequest`          | The same gate `PreToolUse` covers, but specifically for the approval gates §9 lists | Same as `PreToolUse` plus `gate: "edit"              | "bash" | "plan" | "proposal" | "retry"` |
+| `SessionStart` | `executeAgent.ts` after `buildAgentLaunchContext` | `runId`, `streamId`, `cwd` |
+| `UserPromptSubmit` | Tool-use REPL on each user submit | `runId`, `instruction` |
+| `PreToolUse` | `requestToolEditApproval`, `requestBashApproval`, generic tool dispatch | `runId`, `tool.name`, `tool.input` |
+| `PostToolUse` | Tool dispatch after result | `runId`, `tool.name`, `tool.result.summary` |
+| `Stop` | `executeAgent` finalizer | `runId`, `result.status` |
+| `SubagentStop` | Delegation child completion | `runId`, `parentStreamId`, `childStreamId`, `result` |
+| `Notification` | Any `requestShowError` / `requestShowInstruction` emission | `runId`, `message` |
+| `PreCompact` / `PostCompact` | (Future, §32 — context compaction) | `runId`, `compactionStats` |
+| `PermissionRequest` | The same gate `PreToolUse` covers, but specifically for the approval gates §9 lists | Same as `PreToolUse` plus `gate: "edit"              | "bash" | "plan" | "proposal" | "retry"` |
 
 ### 25.4 Configuration
 

--- a/docs/prds/2026-05-06-prd-logger-v2.md
+++ b/docs/prds/2026-05-06-prd-logger-v2.md
@@ -191,14 +191,14 @@ Implications:
 
 Each host installs the sinks it wants. The mapping:
 
-| Host                                | Sink                      | Rendering                                                                                                      |
+| Host | Sink | Rendering |
 | ----------------------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| Extension                           | `VscodeOutputChannelSink` | Formatted string per line, written to one `vscode.OutputChannel` per agent (today's behavior).                 |
-| Desktop                             | `ElectronLogSink`         | Wraps `electron-log` (per `2026-05-02-prd-electron-app.md` §6.4); same channel-per-agent shape.                |
-| CLI headless (`--print` or non-TTY) | `StderrTextSink`          | picocolors-formatted; respects `--quiet` / `--verbose` / `NO_COLOR`; copies to `--log-file` if passed.         |
-| CLI JSON (`--output-format json     | ndjson`)                  | `NdjsonStdoutSink`                                                                                             | One `RunStreamEvent` per line on stdout; schema-validated. |
-| CLI MCP server (`texra mcp serve`)  | `McpProgressSink`         | Converts each record to an MCP `notifications/progress` payload; respects the client's progress-update opt-in. |
-| Tests                               | `MemorySink`              | Pushes records into an array; auto-installed via `withRunContext()` in `vitest.setup.ts`.                      |
+| Extension | `VscodeOutputChannelSink` | Formatted string per line, written to one `vscode.OutputChannel` per agent (today's behavior). |
+| Desktop | `ElectronLogSink` | Wraps `electron-log` (per `2026-05-02-prd-electron-app.md` §6.4); same channel-per-agent shape. |
+| CLI headless (`--print` or non-TTY) | `StderrTextSink` | picocolors-formatted; respects `--quiet` / `--verbose` / `NO_COLOR`; copies to `--log-file` if passed. |
+| CLI JSON (`--output-format json     | ndjson`) | `NdjsonStdoutSink` | One `RunStreamEvent` per line on stdout; schema-validated. |
+| CLI MCP server (`texra mcp serve`) | `McpProgressSink` | Converts each record to an MCP `notifications/progress` payload; respects the client's progress-update opt-in. |
+| Tests | `MemorySink` | Pushes records into an array; auto-installed via `withRunContext()` in `vitest.setup.ts`. |
 
 Per-host sinks live in their respective host packages (`packages/{extension,desktop,cli}/`); only the interface lives in `core/hosts/logSink.ts`.
 
@@ -513,7 +513,7 @@ The single `idle` promise resolves only when the queue is genuinely empty — th
 | **Total to CLI v1.1** | + Phase 4 (when `2026-05-06-prd-runcontext-refactor.md` Phase 2 lands)                                                                                  | **~3.0**        |
 | **Total with MCP**    | + Phase 5 (when `texra mcp serve` ships, post-v1.x)                                                                                                     | **~3.3**        |
 
-Net code reduction vs round 1: Phase 2 cut saves ~30 LOC, simpler bootstrap saves ~50 LOC, simpler shim saves ~80 LOC of mechanical changes. Round-1 §9 estimated +600/-290 ≈ +310 net; round-2 estimate is **~+200 net** to v1.0, **~+220 net** to v1.1 (Phase 4 only — Phase 5 / `McpProgressSink` is no longer in v1.x; it adds ~+80 net whenever MCP eventually ships).
+Net code reduction vs round 1: Phase 2 cut saves ~30 LOC, simpler bootstrap saves ~~50 LOC, simpler shim saves ~~80 LOC of mechanical changes. Round-1 §9 estimated +600/-290 ≈ +310 net; round-2 estimate is **~~+200 net** to v1.0, **~~+220 net** to v1.1 (Phase 4 only — Phase 5 / `McpProgressSink` is no longer in v1.x; it adds ~+80 net whenever MCP eventually ships).
 
 ### 15.7 What round 2 does NOT change
 

--- a/docs/proposals/openai-sdk-type-improvements.md
+++ b/docs/proposals/openai-sdk-type-improvements.md
@@ -101,8 +101,7 @@ interface ChatCompletionCreateParamsBase {
 ```typescript
 // Native union type for tool calls
 type ChatCompletionMessageToolCall =
-  | ChatCompletionMessageFunctionToolCall
-  | ChatCompletionMessageCustomToolCall;
+  ChatCompletionMessageFunctionToolCall | ChatCompletionMessageCustomToolCall;
 
 // Each has a discriminant 'type' field:
 interface ChatCompletionMessageFunctionToolCall {

--- a/docs/toolCalls/tool-format.md
+++ b/docs/toolCalls/tool-format.md
@@ -11,9 +11,7 @@ const tools: ToolDefinition[] = [
   {
     name: 'searchWeb',
     description: 'Perform a web search',
-    parameters: {
-      /* JSON schema */
-    },
+    parameters: {/* JSON schema */},
   },
 ];
 ```

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -406,10 +406,7 @@ export function digitFromMetaShortcut(value: string): number | undefined {
 }
 
 export type ForegroundSurfaceKind =
-  | 'transcript'
-  | 'childControls'
-  | 'form'
-  | 'approval';
+  'transcript' | 'childControls' | 'form' | 'approval';
 
 export function foregroundSurfaceKind({
   activeFormOpen,

--- a/packages/cli/src/chat/tui/forms/ConfigForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ConfigForm.tsx
@@ -29,12 +29,7 @@ import { FormFrame } from './_shared/FormFrame';
 import { computeSelectWindowSize } from './_shared/selectWindow';
 
 export type SettingEditKind =
-  | 'form'
-  | 'boolean'
-  | 'enum'
-  | 'string'
-  | 'number'
-  | 'readonly';
+  'form' | 'boolean' | 'enum' | 'string' | 'number' | 'readonly';
 
 export type SettingInputResult =
   | { readonly ok: true; readonly value: unknown }

--- a/packages/cli/src/chat/tui/forms/LoginForm.tsx
+++ b/packages/cli/src/chat/tui/forms/LoginForm.tsx
@@ -6,10 +6,7 @@ import { CompactFormKeyHints, FormFrame } from './_shared/FormFrame';
 import { isCompactFormRows } from './_shared/selectWindow';
 
 export type LoginFormValue =
-  | 'texra'
-  | 'chatgpt'
-  | 'texra --device'
-  | 'chatgpt --device';
+  'texra' | 'chatgpt' | 'texra --device' | 'chatgpt --device';
 
 export interface LoginFormProps {
   readonly availableRows?: number;

--- a/packages/cli/src/chat/tui/modals/AgentProposal.tsx
+++ b/packages/cli/src/chat/tui/modals/AgentProposal.tsx
@@ -76,12 +76,10 @@ export function agentProposalInstructionDisplayLines({
       line.length === 0
         ? ['']
         : wrapAnsiToWidth(line, instructionWidth).split('\n');
-    return wrapped.map(
-      (text): AgentProposalInstructionLine => ({
-        kind: 'instruction',
-        text,
-      }),
-    );
+    return wrapped.map((text): AgentProposalInstructionLine => ({
+      kind: 'instruction',
+      text,
+    }));
   });
 }
 

--- a/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
+++ b/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
@@ -2,11 +2,7 @@ import { KEY_HINT_SEPARATOR } from '../ui/KeyHints';
 import { isEscapeInput } from '../input/inputKeys';
 
 export type ConfirmCardKeyAction =
-  | 'approve'
-  | 'reject'
-  | 'approveAlways'
-  | 'feedback'
-  | 'ignore';
+  'approve' | 'reject' | 'approveAlways' | 'feedback' | 'ignore';
 
 export interface ConfirmCardKey {
   readonly escape?: boolean;

--- a/packages/cli/src/chat/tui/render/noColorOutput.ts
+++ b/packages/cli/src/chat/tui/render/noColorOutput.ts
@@ -20,7 +20,7 @@ function stripAnsiSgrChunk(text: string, state: SgrStripState): string {
   state.pending = '';
 
   let output = '';
-  for (let index = 0; index < input.length; ) {
+  for (let index = 0; index < input.length;) {
     if (input[index] !== ANSI_ESCAPE_START) {
       output += input[index];
       index += 1;

--- a/packages/cli/src/chat/tui/state/completedProcessTranscript.ts
+++ b/packages/cli/src/chat/tui/state/completedProcessTranscript.ts
@@ -84,12 +84,12 @@ function buildCompletedProcessEntry(params: {
 export function appendCompletedProcessEntries(
   streamId: StreamTabId,
   slice: StreamSlice,
-  liveExecutionIds: ReadonlySet<string>,
+  vanishedExecutionIds: ReadonlySet<string>,
 ): ConversationEntry[] {
   const next = [...slice.entries];
   const existingIds = new Set(next.map((entry) => entry.id));
   for (const info of slice.activeProcesses) {
-    if (liveExecutionIds.has(info.executionId)) continue;
+    if (!vanishedExecutionIds.has(info.executionId)) continue;
     const entry = buildCompletedProcessEntry({
       streamId,
       info,

--- a/packages/cli/src/chat/tui/state/sessionRunState.ts
+++ b/packages/cli/src/chat/tui/state/sessionRunState.ts
@@ -121,10 +121,7 @@ export function chatTuiCanSelectModel(input: {
 }
 
 export type ChatTuiSigintAction =
-  | 'clean-exit'
-  | 'force-exit'
-  | 'preserve-exit'
-  | 'interrupt-and-arm-exit';
+  'clean-exit' | 'force-exit' | 'preserve-exit' | 'interrupt-and-arm-exit';
 
 export function chatTuiSigintAction(input: {
   readonly exitArmed: boolean;

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -9,6 +9,7 @@ import type {
   ProgressEventPayloads,
 } from '@eventBus/ProgressEventBus';
 import { bus } from '@eventBus/ProgressEventBus';
+import { diffActiveChildren } from '@shared/streams/childActivityReducer';
 import {
   reduceStreamMeta,
   type StreamMetaCommand,
@@ -189,12 +190,15 @@ function applyToState<K extends ProgressEvent>(
       // The shared reducer drops tails for executions that left the active
       // list; the CLI also persists a bounded transcript for each finished
       // process before its tail is pruned (a CLI-only side effect).
-      const live = new Set(p.processes.map((c) => c.executionId));
       patchStream(p.parentStreamId, (s) => {
+        const { vanishedIds } = diffActiveChildren(
+          s.activeProcesses,
+          p.processes,
+        );
         const entries = appendCompletedProcessEntries(
           p.parentStreamId,
           s,
-          live,
+          vanishedIds,
         );
         const meta = applyStreamMeta(s, {
           kind: 'activeProcesses',

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -191,10 +191,7 @@ function applyToState<K extends ProgressEvent>(
       // list; the CLI also persists a bounded transcript for each finished
       // process before its tail is pruned (a CLI-only side effect).
       patchStream(p.parentStreamId, (s) => {
-        const { vanishedIds } = diffActiveChildren(
-          s.activeProcesses,
-          p.processes,
-        );
+        const vanishedIds = diffActiveChildren(s.activeProcesses, p.processes);
         const entries = appendCompletedProcessEntries(
           p.parentStreamId,
           s,

--- a/packages/cli/src/commands/_helpers/dispatch/argTokens.ts
+++ b/packages/cli/src/commands/_helpers/dispatch/argTokens.ts
@@ -62,7 +62,7 @@ export function collectLeadingGlobalFlags(
 export function firstPositionalIndex(
   rawArgs: readonly string[],
 ): number | undefined {
-  for (let i = 0; i < rawArgs.length; ) {
+  for (let i = 0; i < rawArgs.length;) {
     const arg = rawArgs[i];
     if (arg === undefined || arg === '--') return undefined;
     if (!arg.startsWith('-')) return i;

--- a/packages/cli/src/commands/_helpers/dispatch/unknownCommand.ts
+++ b/packages/cli/src/commands/_helpers/dispatch/unknownCommand.ts
@@ -50,7 +50,7 @@ export async function detectUnknownCliCommand(
   let cmd = rootCommand;
   const pathParts = ['texra'];
 
-  for (let i = 0; i < rawArgs.length; ) {
+  for (let i = 0; i < rawArgs.length;) {
     const token = rawArgs[i];
     if (token === undefined || token === '--') break;
 

--- a/packages/cli/src/commands/_helpers/dispatch/unknownFlag.ts
+++ b/packages/cli/src/commands/_helpers/dispatch/unknownFlag.ts
@@ -139,7 +139,7 @@ function validateShortFlag(
 }
 
 function helpTargetRawArgs(rawArgs: readonly string[]): readonly string[] {
-  for (let i = 0; i < rawArgs.length; ) {
+  for (let i = 0; i < rawArgs.length;) {
     const token = rawArgs[i];
     if (token === undefined || token === '--') break;
     if (token.startsWith('-')) {

--- a/packages/cli/src/commands/_helpers/dispatch/usage.ts
+++ b/packages/cli/src/commands/_helpers/dispatch/usage.ts
@@ -22,7 +22,7 @@ const usageSections = new WeakMap<AnyCommand, readonly UsageSection[]>();
 let usageColorOverride: boolean | undefined;
 
 export function hasUsageNoColorFlag(rawArgs: readonly string[]): boolean {
-  for (let index = 0; index < rawArgs.length; ) {
+  for (let index = 0; index < rawArgs.length;) {
     const arg = rawArgs[index];
     if (arg === undefined || arg === '--') return false;
     if (arg === '--no-color') return true;

--- a/packages/cli/src/runtime/chatDefaults.ts
+++ b/packages/cli/src/runtime/chatDefaults.ts
@@ -40,11 +40,7 @@ export interface ChatDefaults {
 }
 
 export type ChatDefaultSource =
-  | 'workspace'
-  | 'user'
-  | 'history'
-  | 'builtin'
-  | 'mixed';
+  'workspace' | 'user' | 'history' | 'builtin' | 'mixed';
 
 export type ChatDefaultValueSource =
   | 'override'

--- a/packages/cli/src/runtime/clipboardText.ts
+++ b/packages/cli/src/runtime/clipboardText.ts
@@ -4,8 +4,7 @@ import { toErrorMessage } from '@common/errors';
 import type { ChildProcess } from 'node:child_process';
 
 export type ClipboardTextWriteResult =
-  | { readonly ok: true }
-  | { readonly ok: false; readonly reason: string };
+  { readonly ok: true } | { readonly ok: false; readonly reason: string };
 
 const DEFAULT_CLIPBOARD_WRITE_TIMEOUT_MS = 5_000;
 

--- a/packages/cli/src/runtime/loginOptions.ts
+++ b/packages/cli/src/runtime/loginOptions.ts
@@ -29,8 +29,7 @@ export interface CliChatGptLoginSlashArgs {
 }
 
 export type CliLoginSlashArgs =
-  | CliTexraLoginSlashArgs
-  | CliChatGptLoginSlashArgs;
+  CliTexraLoginSlashArgs | CliChatGptLoginSlashArgs;
 
 const CHATGPT_LOGIN_TARGETS = new Set(['chatgpt', 'codex', 'subscription']);
 

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -29,13 +29,7 @@ export interface CliRunnableModelResolution {
 type CliModelFallbackMode = 'reject' | 'notice' | 'silent';
 
 export type CliModelSelectionSource =
-  | 'override'
-  | 'env'
-  | 'config'
-  | 'workspace'
-  | 'user'
-  | 'history'
-  | 'builtin';
+  'override' | 'env' | 'config' | 'workspace' | 'user' | 'history' | 'builtin';
 
 const CLI_MODEL_FALLBACK_MODE_BY_SOURCE = {
   override: 'reject',

--- a/packages/cli/src/runtime/unavailableTools.ts
+++ b/packages/cli/src/runtime/unavailableTools.ts
@@ -2,8 +2,7 @@ import type { RegisteredToolName } from '@tools/registry';
 import { DIAGNOSTICS_ADD_RUNTIME_CAPABILITY } from '@tools/diagnosticsRuntimeCapabilities';
 
 type CliUnavailableTool =
-  | RegisteredToolName
-  | typeof DIAGNOSTICS_ADD_RUNTIME_CAPABILITY;
+  RegisteredToolName | typeof DIAGNOSTICS_ADD_RUNTIME_CAPABILITY;
 
 /**
  * Tools hidden from every `texra` CLI run — both the headless command paths

--- a/packages/desktop/src/desktopCommandSurface.ts
+++ b/packages/desktop/src/desktopCommandSurface.ts
@@ -62,8 +62,7 @@ const DESKTOP_MENU_GROUPS = [
     'texra.cleanBuild',
   ],
 ] as const satisfies readonly (readonly (
-  | CommandId
-  | DesktopLocalCommandId
+  CommandId | DesktopLocalCommandId
 )[])[];
 
 const DESKTOP_FILE_COMMANDS = [
@@ -80,9 +79,7 @@ type DesktopMenuCommandId = (typeof DESKTOP_MENU_GROUPS)[number][number];
 type DesktopFileCommandId = (typeof DESKTOP_FILE_COMMANDS)[number];
 type DesktopHelpCommandId = (typeof DESKTOP_HELP_COMMANDS)[number];
 export type DesktopCommandId =
-  | DesktopFileCommandId
-  | DesktopMenuCommandId
-  | DesktopHelpCommandId;
+  DesktopFileCommandId | DesktopMenuCommandId | DesktopHelpCommandId;
 
 export const DESKTOP_COMMAND_IDS: readonly DesktopCommandId[] = [
   ...DESKTOP_FILE_COMMANDS,

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -95,8 +95,7 @@ import {
 import type { DesktopStreamSnapshotStore } from './desktopStreamSnapshot.js';
 
 type DesktopUnavailableTool =
-  | RegisteredToolName
-  | typeof DIAGNOSTICS_ADD_RUNTIME_CAPABILITY;
+  RegisteredToolName | typeof DIAGNOSTICS_ADD_RUNTIME_CAPABILITY;
 
 const DESKTOP_UNAVAILABLE_TOOLS: readonly DesktopUnavailableTool[] = [
   'list_api_keys',

--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -30,8 +30,7 @@ import {
 } from '../desktopCommandSurface.js';
 
 export type DesktopShellIpcOptions =
-  | DesktopShellActionFactoryOptions
-  | DesktopShellActionInstanceOptions;
+  DesktopShellActionFactoryOptions | DesktopShellActionInstanceOptions;
 
 export interface DesktopShellActionFactoryOptions {
   actions?: never;

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -360,13 +360,15 @@ function shellTemplate(): TemplateResult {
             data-pane="launcher"
             ?hidden=${showConversation}
           >
-            ${hasWorkspace
-              ? html`
-                  <section class="desktop-launcher-surface">
-                    ${mainView}
-                  </section>
-                `
-              : noWorkspacePlaceholder}
+            ${
+              hasWorkspace
+                ? html`
+                    <section class="desktop-launcher-surface">
+                      ${mainView}
+                    </section>
+                  `
+                : noWorkspacePlaceholder
+            }
           </section>
           <section
             class="desktop-pane"

--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -301,9 +301,7 @@ async function ensureRoutingConfigured(): Promise<boolean> {
 }
 
 export type SetupAssistantLaunchResult =
-  | 'launched'
-  | 'already-running'
-  | 'not-started';
+  'launched' | 'already-running' | 'not-started';
 
 export async function launchSetupAssistant(): Promise<SetupAssistantLaunchResult> {
   try {

--- a/packages/extension/src/common/webview/BaseViewMessageHandler.ts
+++ b/packages/extension/src/common/webview/BaseViewMessageHandler.ts
@@ -1,5 +1,6 @@
 // Third-party imports
 import * as vscode from 'vscode';
+import { ZodError } from 'zod';
 
 // Local imports - common
 import * as logger from '@logger/logUtils';
@@ -126,9 +127,18 @@ export abstract class BaseViewMessageHandler<
   }
 
   /**
+   * Extension point invoked at the start of {@link dispatchInbound}, before
+   * the dispatcher runs. Subclasses that need per-message setup against the
+   * active webview (e.g. attaching it to sub-managers) override this instead
+   * of reimplementing dispatch.
+   */
+  protected onDispatch?(webviewView: T): void;
+
+  /**
    * Schema-driven dispatch shared by views that route through a typed
    * {@link DispatcherFn}. Tracks the active view, runs the dispatcher, logs
-   * validation failures at debug, and warns on commands with no handler.
+   * Zod validation failures at debug (expected, frequent) and handler
+   * exceptions at error (a real bug), and warns on commands with no handler.
    */
   protected async dispatchInbound<TMessage extends CommandMessage>(
     message: unknown,
@@ -137,10 +147,18 @@ export abstract class BaseViewMessageHandler<
     handlers: HandlerRegistry<TMessage>,
   ): Promise<void> {
     await this.withActiveView(webviewView, () => {
+      this.onDispatch?.(webviewView);
+
       const handled = dispatcher(message, handlers, (error) => {
-        this.logger.debug(this.channel, 'Message validation failed', {
-          data: error,
-        });
+        if (error instanceof ZodError) {
+          this.logger.debug(this.channel, 'Message validation failed', {
+            data: error,
+          });
+        } else {
+          this.logger.error(this.channel, 'Error handling message', {
+            data: error,
+          });
+        }
       });
 
       if (!handled && isCommandMessage(message)) {

--- a/packages/extension/src/common/webview/BaseWebviewProvider.ts
+++ b/packages/extension/src/common/webview/BaseWebviewProvider.ts
@@ -11,9 +11,7 @@ export interface PanelOptions {
   column?: vscode.ViewColumn;
   retainContextWhenHidden?: boolean;
   iconPath?:
-    | vscode.ThemeIcon
-    | vscode.Uri
-    | { light: vscode.Uri; dark: vscode.Uri };
+    vscode.ThemeIcon | vscode.Uri | { light: vscode.Uri; dark: vscode.Uri };
 }
 
 /**

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -99,14 +99,11 @@ import {
   repoPollingSource,
   issuePollingSource,
 } from '@tools/github';
-import { setToolNotificationHandler } from '@tools/toolUnavailableNotification';
-import { setAddCriticismSink, setLinterProvider } from '@tools/DiagnosticsTool';
 import { setInlineCommentProvider } from '@tools/comment/InlineCommentTool';
 import { setLeanLanguageServices } from '@tools/lean/leanLanguageServices';
 import { setOpenBuildDisplay } from '@tools/approval/latexPreview';
 import { StorageFS } from '@utils/files';
 import { getConfig } from '@utils/config';
-import { setToolMissingHandler } from '@utils/system';
 import { TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
 
 // Local imports - components
@@ -223,6 +220,39 @@ export async function activate(context: vscode.ExtensionContext) {
       ...NO_TOOL_AVAILABILITY_HOST,
       isVscodeExtensionInstalled: (id) =>
         vscode.extensions.getExtension(id) !== undefined,
+    },
+    linter: getLinterMessages,
+    addCriticismSink: (payload) => {
+      const accepted = pushManualCriticism({
+        absolutePath: payload.absolutePath,
+        line: payload.line,
+        message: payload.message,
+        severity: payload.severity,
+        confidence: payload.confidence,
+      });
+      return { accepted, resolvedPath: payload.absolutePath };
+    },
+    toolMissingHandler: async (message, openDocsCommand) => {
+      const actions = openDocsCommand ? ['View Installation Guide'] : [];
+      const choice = await vscode.window.showErrorMessage(message, ...actions);
+      if (choice === 'View Installation Guide' && openDocsCommand) {
+        const [command, ...args] = openDocsCommand.split(',');
+        void vscode.commands.executeCommand(command, ...args);
+      }
+    },
+    toolNotificationHandler: (message, actionCommand, actionLabel) => {
+      if (actionCommand) {
+        const label = actionLabel ?? 'Open Tools Dashboard';
+        void vscode.window
+          .showInformationMessage(message, label)
+          .then((choice) => {
+            if (choice === label) {
+              void vscode.commands.executeCommand(actionCommand);
+            }
+          });
+      } else {
+        void vscode.window.showInformationMessage(message);
+      }
     },
   });
   registerAgentFeatures();
@@ -487,14 +517,6 @@ export async function activate(context: vscode.ExtensionContext) {
       } satisfies vscode.TextDocumentShowOptions,
     );
   });
-  setToolMissingHandler(async (message, openDocsCommand) => {
-    const actions = openDocsCommand ? ['View Installation Guide'] : [];
-    const choice = await vscode.window.showErrorMessage(message, ...actions);
-    if (choice === 'View Installation Guide' && openDocsCommand) {
-      const [command, ...args] = openDocsCommand.split(',');
-      void vscode.commands.executeCommand(command, ...args);
-    }
-  });
   // Defense in depth: the only consumers today validate keys before reaching
   // the config adapter, but the adapter is documented as `texra.*`-scoped and a
   // future tool wiring through `platform.config` should not be able to read or
@@ -611,37 +633,11 @@ export async function activate(context: vscode.ExtensionContext) {
     },
   );
   context.subscriptions.push({ dispose: disposeGitHubAuthListener });
-  setLinterProvider(getLinterMessages);
   setOpenBuildDisplay(openBuildDisplayIfTex);
   registerInlineCriticism(context);
   registerInlineComments(context);
   setInlineCommentProvider(getInlineCommentProvider());
-  setAddCriticismSink((payload) => {
-    const accepted = pushManualCriticism({
-      absolutePath: payload.absolutePath,
-      line: payload.line,
-      message: payload.message,
-      severity: payload.severity,
-      confidence: payload.confidence,
-    });
-    return { accepted, resolvedPath: payload.absolutePath };
-  });
   applyGitAuthorConfig();
-
-  setToolNotificationHandler((message, actionCommand, actionLabel) => {
-    if (actionCommand) {
-      const label = actionLabel ?? 'Open Tools Dashboard';
-      void vscode.window
-        .showInformationMessage(message, label)
-        .then((choice) => {
-          if (choice === label) {
-            void vscode.commands.executeCommand(actionCommand);
-          }
-        });
-    } else {
-      void vscode.window.showInformationMessage(message);
-    }
-  });
 
   statusBarItem = vscode.window.createStatusBarItem(
     vscode.StatusBarAlignment.Left,

--- a/packages/extension/src/frontend/editor/activeFileGuards.ts
+++ b/packages/extension/src/frontend/editor/activeFileGuards.ts
@@ -6,9 +6,7 @@ import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
 
 export type ActiveFileGuardFailureReason =
-  | 'noEditor'
-  | 'unsupportedExtension'
-  | 'saveFailed';
+  'noEditor' | 'unsupportedExtension' | 'saveFailed';
 
 export interface ActiveFileGuardOptions {
   allowedExtensions: string[];
@@ -23,8 +21,7 @@ export interface ActiveFileGuardSuccess {
 }
 
 export type ActiveFileGuardResult =
-  | ActiveFileGuardSuccess
-  | { status: ActiveFileGuardFailureReason };
+  ActiveFileGuardSuccess | { status: ActiveFileGuardFailureReason };
 
 /**
  * Retrieve the active text editor when available and ensure the document

--- a/packages/extension/src/frontend/latex/inlineCriticism.ts
+++ b/packages/extension/src/frontend/latex/inlineCriticism.ts
@@ -25,9 +25,9 @@ import { bus, type ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import { parseCriticismAnnotations } from '@latex/criticismParser';
 import * as logger from '@logger/logUtils';
 import type { OutputFileInfo } from '@shared/schemas';
-import type { ManualCriticismEntry } from '@tools/DiagnosticsTool';
 import { AbsoluteFS } from '@utils/files';
 import { hasExtension } from '@utils/core/pathCore';
+import type { ManualCriticismEntry } from '@platform/interfaces/criticism';
 
 const CHANNEL = 'InlineCriticism';
 const COLLECTION_NAME = 'texra-criticism';

--- a/packages/extension/src/frontend/review/promptReviewOptions.ts
+++ b/packages/extension/src/frontend/review/promptReviewOptions.ts
@@ -140,13 +140,11 @@ export async function promptReviewOptions(
       detail: "Diff against the repository's main branch (recommended).",
       ref: undefined,
     },
-    ...candidates.map(
-      (candidate): BranchItem => ({
-        label: `$(git-branch) ${candidate.ref}`,
-        description: candidate.current ? 'current branch' : undefined,
-        ref: candidate.ref,
-      }),
-    ),
+    ...candidates.map((candidate): BranchItem => ({
+      label: `$(git-branch) ${candidate.ref}`,
+      description: candidate.current ? 'current branch' : undefined,
+      ref: candidate.ref,
+    })),
   ];
   // VS Code 1.109+ can place a button in the QuickPick title area; offer a
   // one-click "use auto-detect" since most runs take the default.

--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -231,47 +231,49 @@ export class ProgressApp extends ProgressAppBase {
           </wa-button>
         </div>
 
-        ${hasAnyStreams
-          ? html`
-              <div class="split-container">
-                <wa-split-panel .position=${splitPosition}>
-                  <stream-conversation
-                    slot="start"
-                    @stream-switch=${this.onStreamSwitch}
-                    @toolbar-command=${this.onToolbarCommand}
-                    @permission-action=${this.onPermissionAction}
-                    @file-action=${handleFileAction}
-                    @compile-fixer-run=${this.onCompileFixerRun}
-                    @getting-started-action=${handleGettingStartedAction}
-                    @followup-request-options=${this.onFollowupRequestOptions}
-                    @followup-setup=${this.onFollowupSetup}
-                    @followup-run=${this.onFollowupRun}
-                    @followup-change=${this.onFollowUpChange}
-                    @followup-send=${this.onFollowUpSend}
-                    @followup-polish=${this.onFollowUpPolish}
-                    @followup-clear=${this.onFollowUpClear}
-                    @followup-focus-complete=${this.onFollowUpFocusComplete}
-                  ></stream-conversation>
+        ${
+          hasAnyStreams
+            ? html`
+                <div class="split-container">
+                  <wa-split-panel .position=${splitPosition}>
+                    <stream-conversation
+                      slot="start"
+                      @stream-switch=${this.onStreamSwitch}
+                      @toolbar-command=${this.onToolbarCommand}
+                      @permission-action=${this.onPermissionAction}
+                      @file-action=${handleFileAction}
+                      @compile-fixer-run=${this.onCompileFixerRun}
+                      @getting-started-action=${handleGettingStartedAction}
+                      @followup-request-options=${this.onFollowupRequestOptions}
+                      @followup-setup=${this.onFollowupSetup}
+                      @followup-run=${this.onFollowupRun}
+                      @followup-change=${this.onFollowUpChange}
+                      @followup-send=${this.onFollowUpSend}
+                      @followup-polish=${this.onFollowUpPolish}
+                      @followup-clear=${this.onFollowUpClear}
+                      @followup-focus-complete=${this.onFollowUpFocusComplete}
+                    ></stream-conversation>
 
-                  <stream-tabs
-                    slot="end"
-                    .heading=${compactTabs ? '' : 'Sessions'}
-                    .compact=${compactTabs}
-                    .streams=${tabStreams$.get()}
-                    .activeStreamId=${activeStreamId$.get()}
-                    .filter=${streamFilter$.get()}
-                    .streamStates=${streamStates$.get()}
-                    .pendingApprovalStreamIds=${pendingApprovalIds$.get()}
-                    .childStreamsByParent=${childStreamsByParent$.get()}
-                    @stream-switch=${this.onStreamSwitch}
-                    @stream-delete=${this.onStreamDelete}
-                    @filter-change=${this.onFilterChange}
-                    @delete-all=${handleDeleteAll}
-                  ></stream-tabs>
-                </wa-split-panel>
-              </div>
-            `
-          : this.renderEmptyState()}
+                    <stream-tabs
+                      slot="end"
+                      .heading=${compactTabs ? '' : 'Sessions'}
+                      .compact=${compactTabs}
+                      .streams=${tabStreams$.get()}
+                      .activeStreamId=${activeStreamId$.get()}
+                      .filter=${streamFilter$.get()}
+                      .streamStates=${streamStates$.get()}
+                      .pendingApprovalStreamIds=${pendingApprovalIds$.get()}
+                      .childStreamsByParent=${childStreamsByParent$.get()}
+                      @stream-switch=${this.onStreamSwitch}
+                      @stream-delete=${this.onStreamDelete}
+                      @filter-change=${this.onFilterChange}
+                      @delete-all=${handleDeleteAll}
+                    ></stream-tabs>
+                  </wa-split-panel>
+                </div>
+              `
+            : this.renderEmptyState()
+        }
       </div>
     `;
   }

--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -310,13 +310,15 @@ export class BackgroundTasksPanel extends LitElement {
             aria-hidden="true"
           ></wa-icon>
           <span
-            >Inquiries${openCount
-              ? html` &middot; ${openCount} open`
-              : nothing}${answeredCount
-              ? html` &middot; ${answeredCount} answered`
-              : nothing}${droppedCount
-              ? html` &middot; ${droppedCount} dropped`
-              : nothing}</span
+            >Inquiries${
+              openCount ? html` &middot; ${openCount} open` : nothing
+            }${
+              answeredCount
+                ? html` &middot; ${answeredCount} answered`
+                : nothing
+            }${
+              droppedCount ? html` &middot; ${droppedCount} dropped` : nothing
+            }</span
           >
         </div>
         <div class="section-content">
@@ -384,26 +386,30 @@ export class BackgroundTasksPanel extends LitElement {
             aria-hidden="true"
           ></wa-icon>
           <span
-            >${label}${hasActive
-              ? html` &middot; ${active.length} active`
-              : nothing}${hasFinished
-              ? html` &middot; ${finishedCount} done`
-              : nothing}</span
+            >${label}${
+              hasActive ? html` &middot; ${active.length} active` : nothing
+            }${
+              hasFinished ? html` &middot; ${finishedCount} done` : nothing
+            }</span
           >
         </div>
         <div class="section-content">
-          ${hasActive
-            ? repeat(
-                active,
-                (c) => c.executionId,
-                (c) => this.renderTaskItem(c, kind),
-              )
-            : nothing}
-          ${!hasActive && hasFinished
-            ? html`<div class="empty-message">
-                All ${finishedCount} ${label.toLowerCase()} completed
-              </div>`
-            : nothing}
+          ${
+            hasActive
+              ? repeat(
+                  active,
+                  (c) => c.executionId,
+                  (c) => this.renderTaskItem(c, kind),
+                )
+              : nothing
+          }
+          ${
+            !hasActive && hasFinished
+              ? html`<div class="empty-message">
+                  All ${finishedCount} ${label.toLowerCase()} completed
+                </div>`
+              : nothing
+          }
         </div>
       </wa-details>
     `;
@@ -442,27 +448,35 @@ export class BackgroundTasksPanel extends LitElement {
             title=${isClickable ? `Go to ${child.agentName}` : child.agentName}
             role=${isClickable ? 'link' : 'text'}
             tabindex=${isClickable ? '0' : '-1'}
-            @click=${isClickable
-              ? () => this.navigateToStream(child.childStreamId!)
-              : nothing}
-            @keydown=${isClickable
-              ? (e: KeyboardEvent) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault();
-                    this.navigateToStream(child.childStreamId!);
+            @click=${
+              isClickable
+                ? () => this.navigateToStream(child.childStreamId!)
+                : nothing
+            }
+            @keydown=${
+              isClickable
+                ? (e: KeyboardEvent) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      this.navigateToStream(child.childStreamId!);
+                    }
                   }
-                }
-              : nothing}
+                : nothing
+            }
             >${child.agentName}</span
           >
-          ${description
-            ? html`<span class="task-description" title=${description}
-                >(${description})</span
-              >`
-            : nothing}
-          ${child.elapsed
-            ? html`<span class="task-elapsed">(${child.elapsed})</span>`
-            : nothing}
+          ${
+            description
+              ? html`<span class="task-description" title=${description}
+                  >(${description})</span
+                >`
+              : nothing
+          }
+          ${
+            child.elapsed
+              ? html`<span class="task-elapsed">(${child.elapsed})</span>`
+              : nothing
+          }
           <wa-badge
             class="task-status"
             variant=${waiting ? 'neutral' : 'warning'}
@@ -470,12 +484,16 @@ export class BackgroundTasksPanel extends LitElement {
             >${waiting ? 'waiting' : 'running'}</wa-badge
           >
         </div>
-        ${entry?.stdout
-          ? this.renderOutputStream('stdout', entry.stdout)
-          : nothing}
-        ${entry?.stderr
-          ? this.renderOutputStream('stderr', entry.stderr)
-          : nothing}
+        ${
+          entry?.stdout
+            ? this.renderOutputStream('stdout', entry.stdout)
+            : nothing
+        }
+        ${
+          entry?.stderr
+            ? this.renderOutputStream('stderr', entry.stderr)
+            : nothing
+        }
       </div>
     `;
   }

--- a/packages/extension/src/progressView/frontend/components/BashRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BashRequestPanel.ts
@@ -41,11 +41,13 @@ export class BashRequestPanel extends BaseFeedbackPanel {
     return this.renderRequestShell({
       prefix: 'bash-approval-request',
       details: html`
-        ${data.cwd
-          ? html`<div class="bash-approval-request__cwd">
-              Directory: <span>${data.cwd}</span>
-            </div>`
-          : ''}
+        ${
+          data.cwd
+            ? html`<div class="bash-approval-request__cwd">
+                Directory: <span>${data.cwd}</span>
+              </div>`
+            : ''
+        }
         <div class="bash-approval-request__command">
           ${buildCodeBlock(data.command ?? '', { language: 'bash' })}
         </div>

--- a/packages/extension/src/progressView/frontend/components/ContextManagement.ts
+++ b/packages/extension/src/progressView/frontend/components/ContextManagement.ts
@@ -144,21 +144,23 @@ export class ContextManagement extends LitElement {
               </span>
             `,
           )}
-          ${this.summary
-            ? html`
-                <div class="summary-block">
-                  <div class="summary-title">
-                    <wa-icon
-                      library=${TEXRA_ICON_LIBRARY}
-                      name="note"
-                      aria-hidden="true"
-                    ></wa-icon>
-                    Compaction summary
+          ${
+            this.summary
+              ? html`
+                  <div class="summary-block">
+                    <div class="summary-title">
+                      <wa-icon
+                        library=${TEXRA_ICON_LIBRARY}
+                        name="note"
+                        aria-hidden="true"
+                      ></wa-icon>
+                      Compaction summary
+                    </div>
+                    <pre class="summary-text">${this.summary}</pre>
                   </div>
-                  <pre class="summary-text">${this.summary}</pre>
-                </div>
-              `
-            : nothing}
+                `
+              : nothing
+          }
         </div>
       </wa-details>
     `;

--- a/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -336,8 +336,8 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
             ? html`
                 <div class="external-inquiry-request__transcript-links">
                   ${turn.sessionLinks.map((link) =>
-                  this.renderKnownSessionLink(link),
-                )}
+                    this.renderKnownSessionLink(link),
+                  )}
                 </div>
               `
             : nothing
@@ -442,10 +442,10 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
                   </div>
                   <div class="external-inquiry-request__session-links-list">
                     ${repeat(
-                    sessionLinks,
-                    (link) => link,
-                    (link) => this.renderKnownSessionLink(link),
-                  )}
+                      sessionLinks,
+                      (link) => link,
+                      (link) => this.renderKnownSessionLink(link),
+                    )}
                   </div>
                 </div>
               `

--- a/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -113,8 +113,7 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
     super.willUpdate(changed);
     if (changed.has('permission')) {
       const previousPermission = changed.get('permission') as
-        | PermissionState
-        | undefined;
+        PermissionState | undefined;
       if (previousPermission) this.flushDraft(previousPermission);
       this.answerText = '';
       this.sessionLinksText = '';
@@ -244,9 +243,11 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
           ${this.renderTranscript(data.transcript ?? [])}
           ${this.renderQuestion(data.question)}
           ${data.suggestSearch ? this.renderSearchHint() : nothing}
-          ${data.attachFiles?.length
-            ? this.renderAttachFiles(data.attachFiles)
-            : nothing}
+          ${
+            data.attachFiles?.length
+              ? this.renderAttachFiles(data.attachFiles)
+              : nothing
+          }
           ${this.renderSessionLinks(data.sessionLinks ?? [])}
           ${this.renderAnswerArea()}
           ${this.renderFeedbackSection(
@@ -313,13 +314,15 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
         <div class="external-inquiry-request__transcript-turn-header">
           Turn ${turn.turnIndex}
         </div>
-        ${turn.context
-          ? html`
-              <div class="external-inquiry-request__transcript-context">
-                ${turn.context}
-              </div>
-            `
-          : nothing}
+        ${
+          turn.context
+            ? html`
+                <div class="external-inquiry-request__transcript-context">
+                  ${turn.context}
+                </div>
+              `
+            : nothing
+        }
         <div class="external-inquiry-request__transcript-label">Q</div>
         <div class="external-inquiry-request__transcript-text">
           ${turn.question}
@@ -328,15 +331,17 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
         <div class="external-inquiry-request__transcript-text">
           ${turn.answer}
         </div>
-        ${turn.sessionLinks?.length
-          ? html`
-              <div class="external-inquiry-request__transcript-links">
-                ${turn.sessionLinks.map((link) =>
+        ${
+          turn.sessionLinks?.length
+            ? html`
+                <div class="external-inquiry-request__transcript-links">
+                  ${turn.sessionLinks.map((link) =>
                   this.renderKnownSessionLink(link),
                 )}
-              </div>
-            `
-          : nothing}
+                </div>
+              `
+            : nothing
+        }
       </section>
     `;
   }
@@ -428,22 +433,24 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
   private renderSessionLinks(sessionLinks: string[]): TemplateResult {
     return html`
       <div class="external-inquiry-request__session-links">
-        ${sessionLinks.length
-          ? html`
-              <div class="external-inquiry-request__session-links-known">
-                <div class="external-inquiry-request__session-links-label">
-                  Known external session links:
-                </div>
-                <div class="external-inquiry-request__session-links-list">
-                  ${repeat(
+        ${
+          sessionLinks.length
+            ? html`
+                <div class="external-inquiry-request__session-links-known">
+                  <div class="external-inquiry-request__session-links-label">
+                    Known external session links:
+                  </div>
+                  <div class="external-inquiry-request__session-links-list">
+                    ${repeat(
                     sessionLinks,
                     (link) => link,
                     (link) => this.renderKnownSessionLink(link),
                   )}
+                  </div>
                 </div>
-              </div>
-            `
-          : nothing}
+              `
+            : nothing
+        }
         <div class="external-inquiry-request__session-links-input-group">
           <div class="external-inquiry-request__session-links-label">
             Save external session link for follow-ups:

--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -326,26 +326,28 @@ export class FileList extends LitElement {
             ([round, files]) => this.renderRound(round, files),
           )}
         </div>
-        ${this.failureByPath.size > 0
-          ? html`
-              <div class="compile-actions">
-                <wa-button
-                  appearance="filled"
-                  variant="brand"
-                  size="small"
-                  @click=${this.runLatexFixer}
-                >
-                  <wa-icon
-                    slot="start"
-                    library=${TEXRA_ICON_LIBRARY}
-                    name="tools"
-                    aria-hidden="true"
-                  ></wa-icon>
-                  Run latexFixer
-                </wa-button>
-              </div>
-            `
-          : nothing}
+        ${
+          this.failureByPath.size > 0
+            ? html`
+                <div class="compile-actions">
+                  <wa-button
+                    appearance="filled"
+                    variant="brand"
+                    size="small"
+                    @click=${this.runLatexFixer}
+                  >
+                    <wa-icon
+                      slot="start"
+                      library=${TEXRA_ICON_LIBRARY}
+                      name="tools"
+                      aria-hidden="true"
+                    ></wa-icon>
+                    Run latexFixer
+                  </wa-button>
+                </div>
+              `
+            : nothing
+        }
       </wa-details>
     `;
   }
@@ -463,15 +465,17 @@ export class FileList extends LitElement {
 
     return html`
       <div class="file-item">
-        ${failure
-          ? html`<wa-icon
-              library=${TEXRA_ICON_LIBRARY}
-              name="warning"
-              class="compile-warning"
-              title="Compile check failed"
-              aria-label="Compile check failed"
-            ></wa-icon>`
-          : nothing}
+        ${
+          failure
+            ? html`<wa-icon
+                library=${TEXRA_ICON_LIBRARY}
+                name="warning"
+                class="compile-warning"
+                title="Compile check failed"
+                aria-label="Compile check failed"
+              ></wa-icon>`
+            : nothing
+        }
         <span class="file-name">
           <span
             class="file-path clickable-link"
@@ -487,17 +491,19 @@ export class FileList extends LitElement {
         </span>
         ${diffStats}
         <div class="file-actions">
-          ${failure
-            ? renderFileActionButton({
-                icon: 'output',
-                label: 'Open compile log',
-                title: `Open compile log (${failure.logRelativePath})`,
-                className: '',
-                command: PROGRESS_VIEW_COMMANDS.OPEN_FILE,
-                file: failure.log.absolutePath,
-                idPrefix,
-              })
-            : nothing}
+          ${
+            failure
+              ? renderFileActionButton({
+                  icon: 'output',
+                  label: 'Open compile log',
+                  title: `Open compile log (${failure.logRelativePath})`,
+                  className: '',
+                  command: PROGRESS_VIEW_COMMANDS.OPEN_FILE,
+                  file: failure.log.absolutePath,
+                  idPrefix,
+                })
+              : nothing
+          }
           ${baseActions} ${previousAction}
         </div>
       </div>

--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -86,9 +86,7 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
     super.willUpdate(changed);
     if (!changed.has('permission')) return;
     const previous = changed.get('permission') as
-      | PermissionState
-      | null
-      | undefined;
+      PermissionState | null | undefined;
     if (proposalIdOf(previous) !== proposalIdOf(this.permission)) {
       this.selectedModel = null;
       this.selectedAgent = null;
@@ -153,42 +151,50 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
           >
             ${categoryLabel}
           </wa-badge>
-          ${hasAgentOptions
-            ? html`
-                <div class="workflow-proposal__agent-select">
-                  <wa-icon
-                    library=${TEXRA_ICON_LIBRARY}
-                    name="sparkle"
-                    aria-hidden="true"
-                  ></wa-icon>
-                  <wa-select
-                    class="proposal-agent-dropdown"
-                    .value=${currentAgent}
-                    @change=${this.handleAgentSelectChange}
-                  >
-                    ${renderAgentOptions(agentOptions)}
-                  </wa-select>
-                </div>
-              `
-            : html`<span class="workflow-proposal__agent">${data.agent}</span>`}
-          ${hasModelOptions
-            ? html`
-                <div class="workflow-proposal__model-select">
-                  <wa-icon
-                    library=${TEXRA_ICON_LIBRARY}
-                    name="robot"
-                    aria-hidden="true"
-                  ></wa-icon>
-                  <wa-select
-                    class="proposal-model-dropdown"
-                    .value=${currentModel}
-                    @change=${this.handleSelectChange}
-                  >
-                    ${renderModelOptions(modelOptions)}
-                  </wa-select>
-                </div>
-              `
-            : html`<span class="workflow-proposal__model">${data.model}</span>`}
+          ${
+            hasAgentOptions
+              ? html`
+                  <div class="workflow-proposal__agent-select">
+                    <wa-icon
+                      library=${TEXRA_ICON_LIBRARY}
+                      name="sparkle"
+                      aria-hidden="true"
+                    ></wa-icon>
+                    <wa-select
+                      class="proposal-agent-dropdown"
+                      .value=${currentAgent}
+                      @change=${this.handleAgentSelectChange}
+                    >
+                      ${renderAgentOptions(agentOptions)}
+                    </wa-select>
+                  </div>
+                `
+              : html`<span class="workflow-proposal__agent"
+                  >${data.agent}</span
+                >`
+          }
+          ${
+            hasModelOptions
+              ? html`
+                  <div class="workflow-proposal__model-select">
+                    <wa-icon
+                      library=${TEXRA_ICON_LIBRARY}
+                      name="robot"
+                      aria-hidden="true"
+                    ></wa-icon>
+                    <wa-select
+                      class="proposal-model-dropdown"
+                      .value=${currentModel}
+                      @change=${this.handleSelectChange}
+                    >
+                      ${renderModelOptions(modelOptions)}
+                    </wa-select>
+                  </div>
+                `
+              : html`<span class="workflow-proposal__model"
+                  >${data.model}</span
+                >`
+          }
         </div>
         ${this.renderInstruction(data.instruction)}
         ${isWorkflow ? this.renderExtractFlags(data) : nothing}
@@ -277,9 +283,9 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
           (file) => file,
           (file, i) =>
             html`${i > 0 ? ', ' : ''}<span
-                class="workflow-proposal__file-name${clickable
-                  ? ''
-                  : ' workflow-proposal__file-name--readonly'}"
+                class="workflow-proposal__file-name${
+                  clickable ? '' : ' workflow-proposal__file-name--readonly'
+                }"
                 title=${file}
                 data-file=${ifDefined(clickable ? file : undefined)}
                 >${getBasename(file)}</span

--- a/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
@@ -83,18 +83,20 @@ export class RetryRequestPanel extends BaseRequestPanel {
                 ${data.errorMessage}
               </div>`,
           )}
-          ${detailsText
-            ? html`
-                <wa-details
-                  class="retry-request__error-details collapsible-quiet"
-                >
-                  <span slot="summary" class="retry-request__error-summary">
-                    Error details
-                  </span>
-                  <div class="retry-request__error-body">${detailsText}</div>
-                </wa-details>
-              `
-            : nothing}
+          ${
+            detailsText
+              ? html`
+                  <wa-details
+                    class="retry-request__error-details collapsible-quiet"
+                  >
+                    <span slot="summary" class="retry-request__error-summary">
+                      Error details
+                    </span>
+                    <div class="retry-request__error-body">${detailsText}</div>
+                  </wa-details>
+                `
+              : nothing
+          }
         </div>
         <div class="retry-request__actions">
           ${when(isCredentialExhausted, () =>

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -144,8 +144,8 @@ export class StreamTab extends LitElement {
                 data-stream=${stream.name}
                 data-action="toggle-children"
                 title=${
-                this.expanded ? 'Collapse child streams' : childStreamLabel
-              }
+                  this.expanded ? 'Collapse child streams' : childStreamLabel
+                }
                 aria-expanded=${this.expanded ? 'true' : 'false'}
               >
                 <wa-icon
@@ -186,30 +186,32 @@ export class StreamTab extends LitElement {
               ? nothing
               : html`
                   ${
-                  stream.description
-                    ? html`<div class="tab-description">
-                        ${stream.description}
-                      </div>`
-                    : nothing
-                }
-                  ${
-                  stream.worktree
-                    ? html`<div class="worktree-chip-row">
-                        <worktree-chip .info=${stream.worktree}></worktree-chip>
-                      </div>`
-                    : nothing
-                }
-                  <div class="tab-meta">
-                    ${
-                    this.lastTimestamp
-                      ? html`<wa-relative-time
-                          class="last-active"
-                          .date=${new Date(this.lastTimestamp)}
-                          format="narrow"
-                          sync
-                        ></wa-relative-time>`
+                    stream.description
+                      ? html`<div class="tab-description">
+                          ${stream.description}
+                        </div>`
                       : nothing
                   }
+                  ${
+                    stream.worktree
+                      ? html`<div class="worktree-chip-row">
+                          <worktree-chip
+                            .info=${stream.worktree}
+                          ></worktree-chip>
+                        </div>`
+                      : nothing
+                  }
+                  <div class="tab-meta">
+                    ${
+                      this.lastTimestamp
+                        ? html`<wa-relative-time
+                            class="last-active"
+                            .date=${new Date(this.lastTimestamp)}
+                            format="narrow"
+                            sync
+                          ></wa-relative-time>`
+                        : nothing
+                    }
                     <span class="model"
                       >${stream.modelLabel ?? stream.model ?? ''}</span
                     >
@@ -221,17 +223,17 @@ export class StreamTab extends LitElement {
                       title=${`Category: ${agentDecorator.label}`}
                     ></wa-icon>
                     ${when(
-                    stream.isRemote,
-                    () => html`
-                      <wa-icon
-                        library=${TEXRA_ICON_LIBRARY}
-                        name=${AGENT_DECORATORS.properties.remote.icon}
-                        class="remote-agent"
-                        aria-hidden="true"
-                        title=${AGENT_DECORATORS.properties.remote.hint}
-                      ></wa-icon>
-                    `,
-                  )}
+                      stream.isRemote,
+                      () => html`
+                        <wa-icon
+                          library=${TEXRA_ICON_LIBRARY}
+                          name=${AGENT_DECORATORS.properties.remote.icon}
+                          class="remote-agent"
+                          aria-hidden="true"
+                          title=${AGENT_DECORATORS.properties.remote.hint}
+                        ></wa-icon>
+                      `,
+                    )}
                   </div>
                 `
           }
@@ -376,14 +378,14 @@ export class StreamTabs extends LitElement {
         !options.compact && childCount > 0
           ? html`<div class="child-streams" ?hidden=${!expanded}>
               ${repeat(
-              children,
-              (child) => child.name,
-              (child) =>
-                this.renderStreamNode(child, {
-                  compact: false,
-                  visited: nextVisited,
-                }),
-            )}
+                children,
+                (child) => child.name,
+                (child) =>
+                  this.renderStreamNode(child, {
+                    compact: false,
+                    visited: nextVisited,
+                  }),
+              )}
             </div>`
           : nothing
       }
@@ -432,29 +434,29 @@ export class StreamTabs extends LitElement {
                     @change=${this.handleFilterChange}
                   >
                     ${repeat(
-                    FILTER_BUTTONS,
-                    (btn) => btn.id,
-                    (btn) => html`
-                      <wa-radio
-                        id=${btn.id}
-                        value=${btn.filter}
-                        ?checked=${this.filter === btn.filter}
-                      >
-                        ${btn.label}
-                      </wa-radio>
-                    `,
-                  )}
+                      FILTER_BUTTONS,
+                      (btn) => btn.id,
+                      (btn) => html`
+                        <wa-radio
+                          id=${btn.id}
+                          value=${btn.filter}
+                          ?checked=${this.filter === btn.filter}
+                        >
+                          ${btn.label}
+                        </wa-radio>
+                      `,
+                    )}
                   </wa-radio-group>
 
                   <div class="stream-list-actions">
                     ${renderIconActionButton({
-                    id: ELEMENT_IDS.DELETE_ALL_BTN,
-                    icon: 'trash',
-                    label: 'Clear all streams',
-                    tooltip: 'Clear all streams',
-                    className: 'delete-all-streams',
-                    onClick: this.handleDeleteAll,
-                  })}
+                      id: ELEMENT_IDS.DELETE_ALL_BTN,
+                      icon: 'trash',
+                      label: 'Clear all streams',
+                      tooltip: 'Clear all streams',
+                      className: 'delete-all-streams',
+                      onClick: this.handleDeleteAll,
+                    })}
                   </div>
                 </div>
               </div>`

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -137,23 +137,25 @@ export class StreamTab extends LitElement {
           'has-pending-approval': this.hasPendingApproval,
         })}
       >
-        ${hasChildren
-          ? html`<button
-              class="tab-expand"
-              data-stream=${stream.name}
-              data-action="toggle-children"
-              title=${this.expanded
-                ? 'Collapse child streams'
-                : childStreamLabel}
-              aria-expanded=${this.expanded ? 'true' : 'false'}
-            >
-              <wa-icon
-                library=${TEXRA_ICON_LIBRARY}
-                name="chevron-right"
-                aria-hidden="true"
-              ></wa-icon>
-            </button>`
-          : nothing}
+        ${
+          hasChildren
+            ? html`<button
+                class="tab-expand"
+                data-stream=${stream.name}
+                data-action="toggle-children"
+                title=${
+                this.expanded ? 'Collapse child streams' : childStreamLabel
+              }
+                aria-expanded=${this.expanded ? 'true' : 'false'}
+              >
+                <wa-icon
+                  library=${TEXRA_ICON_LIBRARY}
+                  name="chevron-right"
+                  aria-hidden="true"
+                ></wa-icon>
+              </button>`
+            : nothing
+        }
         <button
           class="tab"
           data-stream=${stream.name}
@@ -162,53 +164,63 @@ export class StreamTab extends LitElement {
         >
           <div class="tab-header">
             <span class="tab-title"
-              >${stream.parentStreamId ? '↳ ' : ''}${stream.label ||
-              stream.name}</span
+              >${stream.parentStreamId ? '↳ ' : ''}${
+                stream.label || stream.name
+              }</span
             >
-            ${this.childCount > 0 && this.compact
-              ? html`<wa-icon
-                  library=${TEXRA_ICON_LIBRARY}
-                  name="chevron-right"
-                  class="compact-subagent-hint"
-                  role="img"
-                  aria-label=${childStreamLabel}
-                  title=${childStreamLabel}
-                ></wa-icon>`
-              : nothing}
-          </div>
-          ${this.compact
-            ? nothing
-            : html`
-                ${stream.description
-                  ? html`<div class="tab-description">
-                      ${stream.description}
-                    </div>`
-                  : nothing}
-                ${stream.worktree
-                  ? html`<div class="worktree-chip-row">
-                      <worktree-chip .info=${stream.worktree}></worktree-chip>
-                    </div>`
-                  : nothing}
-                <div class="tab-meta">
-                  ${this.lastTimestamp
-                    ? html`<wa-relative-time
-                        class="last-active"
-                        .date=${new Date(this.lastTimestamp)}
-                        format="narrow"
-                        sync
-                      ></wa-relative-time>`
-                    : nothing}
-                  <span class="model"
-                    >${stream.modelLabel ?? stream.model ?? ''}</span
-                  >
-                  <wa-icon
+            ${
+              this.childCount > 0 && this.compact
+                ? html`<wa-icon
                     library=${TEXRA_ICON_LIBRARY}
-                    name=${agentDecorator.icon}
-                    class="agent-category"
-                    aria-hidden="true"
-                    title=${`Category: ${agentDecorator.label}`}
-                  ></wa-icon>
-                  ${when(
+                    name="chevron-right"
+                    class="compact-subagent-hint"
+                    role="img"
+                    aria-label=${childStreamLabel}
+                    title=${childStreamLabel}
+                  ></wa-icon>`
+                : nothing
+            }
+          </div>
+          ${
+            this.compact
+              ? nothing
+              : html`
+                  ${
+                  stream.description
+                    ? html`<div class="tab-description">
+                        ${stream.description}
+                      </div>`
+                    : nothing
+                }
+                  ${
+                  stream.worktree
+                    ? html`<div class="worktree-chip-row">
+                        <worktree-chip .info=${stream.worktree}></worktree-chip>
+                      </div>`
+                    : nothing
+                }
+                  <div class="tab-meta">
+                    ${
+                    this.lastTimestamp
+                      ? html`<wa-relative-time
+                          class="last-active"
+                          .date=${new Date(this.lastTimestamp)}
+                          format="narrow"
+                          sync
+                        ></wa-relative-time>`
+                      : nothing
+                  }
+                    <span class="model"
+                      >${stream.modelLabel ?? stream.model ?? ''}</span
+                    >
+                    <wa-icon
+                      library=${TEXRA_ICON_LIBRARY}
+                      name=${agentDecorator.icon}
+                      class="agent-category"
+                      aria-hidden="true"
+                      title=${`Category: ${agentDecorator.label}`}
+                    ></wa-icon>
+                    ${when(
                     stream.isRemote,
                     () => html`
                       <wa-icon
@@ -220,8 +232,9 @@ export class StreamTab extends LitElement {
                       ></wa-icon>
                     `,
                   )}
-                </div>
-              `}
+                  </div>
+                `
+          }
         </button>
         <wa-button
           id="stream-tab-delete-button"
@@ -359,9 +372,10 @@ export class StreamTabs extends LitElement {
         .childCount=${childCount}
         ?expanded=${expanded}
       ></stream-tab>
-      ${!options.compact && childCount > 0
-        ? html`<div class="child-streams" ?hidden=${!expanded}>
-            ${repeat(
+      ${
+        !options.compact && childCount > 0
+          ? html`<div class="child-streams" ?hidden=${!expanded}>
+              ${repeat(
               children,
               (child) => child.name,
               (child) =>
@@ -370,19 +384,22 @@ export class StreamTabs extends LitElement {
                   visited: nextVisited,
                 }),
             )}
-          </div>`
-        : nothing}
+            </div>`
+          : nothing
+      }
     `;
   }
 
   override render(): TemplateResult {
     return html`
       <div class="tabs">
-        ${this.heading && !this.compact
-          ? html`<header class="stream-tabs-header" part="header">
-              <span class="stream-tabs-title">${this.heading}</span>
-            </header>`
-          : nothing}
+        ${
+          this.heading && !this.compact
+            ? html`<header class="stream-tabs-header" part="header">
+                <span class="stream-tabs-title">${this.heading}</span>
+              </header>`
+            : nothing
+        }
         <div class="tabs-content">
           <div id=${ELEMENT_IDS.STREAM_TABS} @click=${this.handleTabClick}>
             ${repeat(
@@ -403,17 +420,18 @@ export class StreamTabs extends LitElement {
               </div>`,
           )}
         </div>
-        ${this.compact || (this.streams.length === 0 && this.filter === 'all')
-          ? nothing
-          : html`<div class="stream-list-footer">
-              <div class="stream-list-controls">
-                <wa-radio-group
-                  id=${ELEMENT_IDS.AGENT_FILTER_CONTAINER}
-                  class="agent-filter-group"
-                  .value=${this.filter}
-                  @change=${this.handleFilterChange}
-                >
-                  ${repeat(
+        ${
+          this.compact || (this.streams.length === 0 && this.filter === 'all')
+            ? nothing
+            : html`<div class="stream-list-footer">
+                <div class="stream-list-controls">
+                  <wa-radio-group
+                    id=${ELEMENT_IDS.AGENT_FILTER_CONTAINER}
+                    class="agent-filter-group"
+                    .value=${this.filter}
+                    @change=${this.handleFilterChange}
+                  >
+                    ${repeat(
                     FILTER_BUTTONS,
                     (btn) => btn.id,
                     (btn) => html`
@@ -426,10 +444,10 @@ export class StreamTabs extends LitElement {
                       </wa-radio>
                     `,
                   )}
-                </wa-radio-group>
+                  </wa-radio-group>
 
-                <div class="stream-list-actions">
-                  ${renderIconActionButton({
+                  <div class="stream-list-actions">
+                    ${renderIconActionButton({
                     id: ELEMENT_IDS.DELETE_ALL_BTN,
                     icon: 'trash',
                     label: 'Clear all streams',
@@ -437,9 +455,10 @@ export class StreamTabs extends LitElement {
                     className: 'delete-all-streams',
                     onClick: this.handleDeleteAll,
                   })}
+                  </div>
                 </div>
-              </div>
-            </div>`}
+              </div>`
+        }
       </div>
     `;
   }

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -84,8 +84,7 @@ export class TaskGroupList extends LitElement {
    * to reference scans.
    */
   @property({ attribute: false }) updatedMessageIndices:
-    | readonly number[]
-    | null = null;
+    readonly number[] | null = null;
 
   /** Generation immediately before updatedMessageIndices was collected. */
   @property({ attribute: false }) updatedMessageBaseGeneration = 0;
@@ -175,8 +174,7 @@ export class TaskGroupList extends LitElement {
     if (this.terminal) {
       const fullText = (): string => this.messages.map((m) => m.text).join('');
       const prevMsgs = changedProperties.get('messages') as
-        | LogMessageData[]
-        | undefined;
+        LogMessageData[] | undefined;
       const prevCount = prevMsgs?.length ?? 0;
       if (changedProperties.has('terminal')) {
         this.terminalBuffer.rebuild(fullText());
@@ -356,15 +354,17 @@ export class TaskGroupList extends LitElement {
     const visibleMessages =
       hiddenCount > 0 ? messages.slice(hiddenCount) : messages;
 
-    return html`${hiddenCount > 0
-      ? this.renderRevealButton({
-          hiddenCount,
-          step: GROUP_MESSAGE_WINDOW_STEP,
-          scope,
-          kind: 'messages',
-          label: 'message',
-        })
-      : nothing}${repeat(
+    return html`${
+      hiddenCount > 0
+        ? this.renderRevealButton({
+            hiddenCount,
+            step: GROUP_MESSAGE_WINDOW_STEP,
+            scope,
+            kind: 'messages',
+            label: 'message',
+          })
+        : nothing
+    }${repeat(
       visibleMessages,
       (m) => m.id,
       (m) => guard([m], () => formatLogEntry(m)),
@@ -455,13 +455,15 @@ export class TaskGroupList extends LitElement {
     const statusIcon = getStatusIcon(group.status);
     return html`
       <span class="group-status-icon">
-        ${statusIcon
-          ? html`<wa-icon
-              library=${TEXRA_ICON_LIBRARY}
-              name=${statusIcon}
-              aria-hidden="true"
-            ></wa-icon>`
-          : html`<wa-spinner></wa-spinner>`}
+        ${
+          statusIcon
+            ? html`<wa-icon
+                library=${TEXRA_ICON_LIBRARY}
+                name=${statusIcon}
+                aria-hidden="true"
+              ></wa-icon>`
+            : html`<wa-spinner></wa-spinner>`
+        }
       </span>
       <span class="group-title">${group.name}</span>
       <span class="group-time">
@@ -473,9 +475,11 @@ export class TaskGroupList extends LitElement {
           ></wa-icon>
           ${formattedStartTime}
         </span>
-        ${durationText
-          ? html`<span class="group-duration">${durationText}</span>`
-          : nothing}
+        ${
+          durationText
+            ? html`<span class="group-duration">${durationText}</span>`
+            : nothing
+        }
       </span>
     `;
   }
@@ -535,16 +539,18 @@ export class TaskGroupList extends LitElement {
           ${this.renderGroupHeader(group)}
         </div>
         <div id=${contentId} class="log-group-content">
-          ${expanded
-            ? html`${this.renderMessageEntries(
-                messages,
-                this.groupMessageScope(group.id),
-              )}${repeat(
-                children,
-                (c) => c.group.id,
-                (c) => this.renderGroupNode(c),
-              )}`
-            : nothing}
+          ${
+            expanded
+              ? html`${this.renderMessageEntries(
+                  messages,
+                  this.groupMessageScope(group.id),
+                )}${repeat(
+                  children,
+                  (c) => c.group.id,
+                  (c) => this.renderGroupNode(c),
+                )}`
+              : nothing
+          }
         </div>
       </wa-details>
     `;
@@ -630,9 +636,11 @@ export class TaskGroupList extends LitElement {
           @scroll=${this.handleScroll}
         >
           <div class="log-placeholder">
-            ${active
-              ? 'Run is starting. Progress updates will appear here.'
-              : 'No log output for this stream yet.'}
+            ${
+              active
+                ? 'Run is starting. Progress updates will appear here.'
+                : 'No log output for this stream yet.'
+            }
           </div>
         </div>
       `;
@@ -664,15 +672,17 @@ export class TaskGroupList extends LitElement {
         class="log-container"
         @scroll=${this.handleScroll}
       >
-        ${hiddenTimelineCount > 0
-          ? this.renderRevealButton({
-              hiddenCount: hiddenTimelineCount,
-              step: TIMELINE_ITEM_WINDOW_STEP,
-              scope: 'timeline',
-              kind: 'timeline',
-              label: 'item',
-            })
-          : nothing}
+        ${
+          hiddenTimelineCount > 0
+            ? this.renderRevealButton({
+                hiddenCount: hiddenTimelineCount,
+                step: TIMELINE_ITEM_WINDOW_STEP,
+                scope: 'timeline',
+                kind: 'timeline',
+                label: 'item',
+              })
+            : nothing
+        }
         ${repeat(
           visibleTimeline,
           (item) => item.key,

--- a/packages/extension/src/progressView/frontend/components/TodoList.ts
+++ b/packages/extension/src/progressView/frontend/components/TodoList.ts
@@ -165,14 +165,16 @@ export class TodoList extends LitElement {
           'todo-item--completed': status === TODO_STATUS.COMPLETED,
         })}
       >
-        ${isInProgress
-          ? html`<wa-spinner class="todo-item__icon"></wa-spinner>`
-          : html`<wa-icon
-              library=${TEXRA_ICON_LIBRARY}
-              name=${icon}
-              class="todo-item__icon"
-              aria-hidden="true"
-            ></wa-icon>`}
+        ${
+          isInProgress
+            ? html`<wa-spinner class="todo-item__icon"></wa-spinner>`
+            : html`<wa-icon
+                library=${TEXRA_ICON_LIBRARY}
+                name=${icon}
+                class="todo-item__icon"
+                aria-hidden="true"
+              ></wa-icon>`
+        }
         <span class="todo-item__content">${content}</span>
       </div>
     `;

--- a/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
@@ -95,37 +95,39 @@ export class ToolEditRequestPanel extends BaseFeedbackPanel {
           className: 'diff-main-button',
           onClick: this.handleDiffAction,
         })}
-        ${showDropdown
-          ? html`
-              <wa-dropdown
-                class="diff-dropdown-menu"
-                placement="bottom-end"
-                @wa-select=${this.handleMenuSelect}
-              >
-                <wa-button
-                  id="tool-edit-diff-dropdown-trigger"
-                  slot="trigger"
-                  class="diff-dropdown-trigger"
-                  appearance="plain"
-                  variant="neutral"
-                  size="small"
-                  type="button"
-                  aria-label="More diff actions"
+        ${
+          showDropdown
+            ? html`
+                <wa-dropdown
+                  class="diff-dropdown-menu"
+                  placement="bottom-end"
+                  @wa-select=${this.handleMenuSelect}
                 >
-                  ${waIcon('chevron-down')}
-                </wa-button>
-                <wa-dropdown-item value="previewProposed">
-                  Preview
-                </wa-dropdown-item>
-                <wa-dropdown-item value="showLatexdiff">
-                  LaTeXdiff
-                </wa-dropdown-item>
-              </wa-dropdown>
-              <wa-tooltip for="tool-edit-diff-dropdown-trigger">
-                More diff actions
-              </wa-tooltip>
-            `
-          : nothing}
+                  <wa-button
+                    id="tool-edit-diff-dropdown-trigger"
+                    slot="trigger"
+                    class="diff-dropdown-trigger"
+                    appearance="plain"
+                    variant="neutral"
+                    size="small"
+                    type="button"
+                    aria-label="More diff actions"
+                  >
+                    ${waIcon('chevron-down')}
+                  </wa-button>
+                  <wa-dropdown-item value="previewProposed">
+                    Preview
+                  </wa-dropdown-item>
+                  <wa-dropdown-item value="showLatexdiff">
+                    LaTeXdiff
+                  </wa-dropdown-item>
+                </wa-dropdown>
+                <wa-tooltip for="tool-edit-diff-dropdown-trigger">
+                  More diff actions
+                </wa-tooltip>
+              `
+            : nothing
+        }
       </div>
     `;
   }

--- a/packages/extension/src/progressView/frontend/components/UserMessage.ts
+++ b/packages/extension/src/progressView/frontend/components/UserMessage.ts
@@ -258,29 +258,34 @@ export class UserMessage extends LitElement {
               className: `user-message-copy ${copyState.copied ? copyState.successClass : ''}`,
               onClick: () => this.copyController.copy(displayText),
             })}
-            ${hasRawMessage
-              ? renderIconActionButton({
-                  id: 'user-message-raw-copy-button',
-                  icon: 'code',
-                  label: rawMessageCopyState.ariaLabel,
-                  tooltip: rawMessageCopyState.title,
-                  className: `user-message-copy ${rawMessageCopyState.copied ? rawMessageCopyState.successClass : ''}`,
-                  onClick: () => this.rawMessageCopyController.copy(this.text),
-                })
-              : nothing}
+            ${
+              hasRawMessage
+                ? renderIconActionButton({
+                    id: 'user-message-raw-copy-button',
+                    icon: 'code',
+                    label: rawMessageCopyState.ariaLabel,
+                    tooltip: rawMessageCopyState.title,
+                    className: `user-message-copy ${rawMessageCopyState.copied ? rawMessageCopyState.successClass : ''}`,
+                    onClick: () =>
+                      this.rawMessageCopyController.copy(this.text),
+                  })
+                : nothing
+            }
           </div>
-          ${isStructuredDelivery
-            ? html`<div
-                class="user-message-content markdown-content"
-                data-log-id=${this.logId}
-              >
-                ${unsafeHTML(structuredMarkdownHtml)}
-              </div>`
-            : html`<div
-                class="user-message-content"
-                data-log-id=${this.logId}
-                .textContent=${displayText}
-              ></div>`}
+          ${
+            isStructuredDelivery
+              ? html`<div
+                  class="user-message-content markdown-content"
+                  data-log-id=${this.logId}
+                >
+                  ${unsafeHTML(structuredMarkdownHtml)}
+                </div>`
+              : html`<div
+                  class="user-message-content"
+                  data-log-id=${this.logId}
+                  .textContent=${displayText}
+                ></div>`
+          }
         </div>
       </div>
     `;

--- a/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
@@ -143,7 +143,7 @@ export class UserQuestionPanel extends BaseFeedbackPanel {
                 rows="2"
                 .value=${this.freeText[question.question] ?? ''}
                 @input=${(event: Event) =>
-                this.updateFreeText(question.question, event)}
+                  this.updateFreeText(question.question, event)}
               ></wa-textarea>`
             : nothing
         }

--- a/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
@@ -42,11 +42,13 @@ export class UserQuestionPanel extends BaseFeedbackPanel {
 
     return html`
       <div class="user-question-request">
-        ${data.context
-          ? html`<div class="user-question-request__context">
-              ${data.context}
-            </div>`
-          : nothing}
+        ${
+          data.context
+            ? html`<div class="user-question-request__context">
+                ${data.context}
+              </div>`
+            : nothing
+        }
         <div class="user-question-request__questions">
           ${repeat(
             data.questions,
@@ -99,11 +101,13 @@ export class UserQuestionPanel extends BaseFeedbackPanel {
     return html`
       <section class="user-question-request__question">
         <div class="user-question-request__heading">
-          ${question.header
-            ? html`<span class="user-question-request__header">
-                ${question.header}
-              </span>`
-            : nothing}
+          ${
+            question.header
+              ? html`<span class="user-question-request__header">
+                  ${question.header}
+                </span>`
+              : nothing
+          }
           <span>${question.question}</span>
         </div>
         <div class="user-question-request__options">
@@ -121,24 +125,28 @@ export class UserQuestionPanel extends BaseFeedbackPanel {
                 />
                 <span>
                   <strong>${option.label}</strong>
-                  ${option.description
-                    ? html`<small>${option.description}</small>`
-                    : nothing}
+                  ${
+                    option.description
+                      ? html`<small>${option.description}</small>`
+                      : nothing
+                  }
                 </span>
               </label>
             `,
           )}
         </div>
-        ${question.allowFreeText
-          ? html`<wa-textarea
-              class="user-question-request__free-text"
-              placeholder="Type another answer"
-              rows="2"
-              .value=${this.freeText[question.question] ?? ''}
-              @input=${(event: Event) =>
+        ${
+          question.allowFreeText
+            ? html`<wa-textarea
+                class="user-question-request__free-text"
+                placeholder="Type another answer"
+                rows="2"
+                .value=${this.freeText[question.question] ?? ''}
+                @input=${(event: Event) =>
                 this.updateFreeText(question.question, event)}
-            ></wa-textarea>`
-          : nothing}
+              ></wa-textarea>`
+            : nothing
+        }
       </section>
     `;
   }

--- a/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
+++ b/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
@@ -234,15 +234,15 @@ export class WorktreeChip extends LitElement {
         showStats
           ? html`<span class="diff-stats" title="Lines changed">
               ${
-              pr.additions != null
-                ? html`<span class="diff-added">+${pr.additions}</span>`
-                : nothing
-            }
+                pr.additions != null
+                  ? html`<span class="diff-added">+${pr.additions}</span>`
+                  : nothing
+              }
               ${
-              pr.deletions != null
-                ? html`<span class="diff-removed">−${pr.deletions}</span>`
-                : nothing
-            }
+                pr.deletions != null
+                  ? html`<span class="diff-removed">−${pr.deletions}</span>`
+                  : nothing
+              }
             </span>`
           : nothing
       }

--- a/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
+++ b/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
@@ -200,14 +200,16 @@ export class WorktreeChip extends LitElement {
     return html`<span class="branch" title=${tooltip}>
       ${waIcon('code-branch')}
       <span class="branch-name">${branch}</span>
-      ${this.info.dirty
-        ? html`<span
-              class="dirty-dot"
-              role="img"
-              aria-label="uncommitted changes"
-            ></span>
-            <span class="sr-only">uncommitted changes</span>`
-        : nothing}
+      ${
+        this.info.dirty
+          ? html`<span
+                class="dirty-dot"
+                role="img"
+                aria-label="uncommitted changes"
+              ></span>
+              <span class="sr-only">uncommitted changes</span>`
+          : nothing
+      }
     </span>`;
   }
 
@@ -223,28 +225,38 @@ export class WorktreeChip extends LitElement {
     const showStats = pr.additions != null || pr.deletions != null;
     return html`
       <span class="pr-number" title=${titleAttr}>#${pr.number}</span>
-      ${pr.title
-        ? html`<span class="pr-title" title=${pr.title}>${pr.title}</span>`
-        : nothing}
-      ${showStats
-        ? html`<span class="diff-stats" title="Lines changed">
-            ${pr.additions != null
-              ? html`<span class="diff-added">+${pr.additions}</span>`
-              : nothing}
-            ${pr.deletions != null
-              ? html`<span class="diff-removed">−${pr.deletions}</span>`
-              : nothing}
-          </span>`
-        : nothing}
-      ${pr.ciState
-        ? html`<wa-icon
-            library=${TEXRA_ICON_LIBRARY}
-            name=${CI_ICON[ci]}
-            class=${classMap({ 'ci-icon': true, [`ci-${ci}`]: true })}
-            title=${CI_LABEL[ci]}
-            aria-label=${CI_LABEL[ci]}
-          ></wa-icon>`
-        : nothing}
+      ${
+        pr.title
+          ? html`<span class="pr-title" title=${pr.title}>${pr.title}</span>`
+          : nothing
+      }
+      ${
+        showStats
+          ? html`<span class="diff-stats" title="Lines changed">
+              ${
+              pr.additions != null
+                ? html`<span class="diff-added">+${pr.additions}</span>`
+                : nothing
+            }
+              ${
+              pr.deletions != null
+                ? html`<span class="diff-removed">−${pr.deletions}</span>`
+                : nothing
+            }
+            </span>`
+          : nothing
+      }
+      ${
+        pr.ciState
+          ? html`<wa-icon
+              library=${TEXRA_ICON_LIBRARY}
+              name=${CI_ICON[ci]}
+              class=${classMap({ 'ci-icon': true, [`ci-${ci}`]: true })}
+              title=${CI_LABEL[ci]}
+              aria-label=${CI_LABEL[ci]}
+            ></wa-icon>`
+          : nothing
+      }
     `;
   }
 }

--- a/packages/extension/src/progressView/frontend/formatters/baseLogFormatter.ts
+++ b/packages/extension/src/progressView/frontend/formatters/baseLogFormatter.ts
@@ -10,8 +10,7 @@ export type FormatOptions = {
 
 /** Result of safeFormat - either success with value or failure with error. */
 export type SafeFormatResult<T> =
-  | { ok: true; value: T }
-  | { ok: false; error: string };
+  { ok: true; value: T } | { ok: false; error: string };
 
 /** Safely execute a formatting function with error handling. */
 export function safeFormat<T>(

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/helpers.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/helpers.ts
@@ -104,9 +104,9 @@ export function truncateHeaderSummary(text: string, maxLength: number): string {
 export function joinWithSeparator(sections: TemplateResult[]): TemplateResult {
   return html`${sections.map(
     (section, i) =>
-      html`${section}${i < sections.length - 1
-        ? html`<wa-divider></wa-divider>`
-        : ''}`,
+      html`${section}${
+        i < sections.length - 1 ? html`<wa-divider></wa-divider>` : ''
+      }`,
   )}`;
 }
 

--- a/packages/extension/src/progressView/frontend/formatters/progressBadgeFormatter.ts
+++ b/packages/extension/src/progressView/frontend/formatters/progressBadgeFormatter.ts
@@ -11,9 +11,11 @@ export function renderProgressBadgeContent(
 ): TemplateResult | typeof nothing {
   if (!progress?.conversationTurns) return nothing;
   return html`${progress.conversationTurns}
-  turns${progress.toolCallCount > 0
-    ? html`, ${progress.toolCallCount} tool calls`
-    : nothing}`;
+  turns${
+    progress.toolCallCount > 0
+      ? html`, ${progress.toolCallCount} tool calls`
+      : nothing
+  }`;
 }
 
 export function getProgressBadgeTitle(

--- a/packages/extension/src/progressView/frontend/languageForPath.ts
+++ b/packages/extension/src/progressView/frontend/languageForPath.ts
@@ -2,8 +2,7 @@
 import { getBasename } from '@shared/utils/path';
 
 type LanguageMap =
-  | ReadonlyMap<string, string>
-  | Readonly<Record<string, string>>;
+  ReadonlyMap<string, string> | Readonly<Record<string, string>>;
 
 interface LanguageForPathConfig {
   basenameLanguages: LanguageMap;

--- a/packages/extension/src/progressView/frontend/messageDispatcher.ts
+++ b/packages/extension/src/progressView/frontend/messageDispatcher.ts
@@ -61,8 +61,7 @@ export function dispatchMessage(
   ctx: MessageHandlerContext,
 ): void {
   const handler = handlers[message.command] as
-    | TypedHandler<typeof message>
-    | undefined;
+    TypedHandler<typeof message> | undefined;
 
   handler?.(message, ctx);
 }

--- a/packages/extension/src/progressView/progressNavigation.ts
+++ b/packages/extension/src/progressView/progressNavigation.ts
@@ -7,8 +7,7 @@ import {
 } from './ProgressViewProvider';
 
 export type ProgressNavigationRevealResult =
-  | ProgressStreamRevealResult
-  | 'unavailable';
+  ProgressStreamRevealResult | 'unavailable';
 
 export async function revealProgressStream(
   streamId: StreamTabId,

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -900,8 +900,9 @@ export class SettingsApp extends SettingsAppBase {
 
         <wa-tab-group
           class="settings-tabs"
-          .active=${SETTINGS_TAB_PANEL_NAMES[this.selectedTabIndex.get()] ??
-          'memory'}
+          .active=${
+            SETTINGS_TAB_PANEL_NAMES[this.selectedTabIndex.get()] ?? 'memory'
+          }
           @wa-tab-show=${this.handleTabShow}
         >
           ${SETTINGS_TABS.map(
@@ -960,20 +961,24 @@ export class SettingsApp extends SettingsAppBase {
               @provider-streaming-set=${this.handleSetProviderStreaming}
               @provider-endpoint-set=${this.handleSetProviderEndpoint}
               @provider-global-streaming-set=${this.handleSetGlobalStreaming}
-              @provider-vscode-setting-set=${this
-                .handleSetProviderVscodeSetting}
+              @provider-vscode-setting-set=${
+                this.handleSetProviderVscodeSetting
+              }
               @provider-open-url=${this.handleOpenUrl}
               @model-enabled-set=${this.handleSetModelEnabled}
               @helper-model-set=${this.handleSetHelperModel}
               @model-reasoning-level-set=${this.handleSetReasoningLevel}
-              @prefer-short-model-names-set=${this
-                .handleSetPreferShortModelNames}
+              @prefer-short-model-names-set=${
+                this.handleSetPreferShortModelNames
+              }
               @chatgpt-sign-in=${this.handleChatGptSignIn}
               @chatgpt-sign-out=${this.handleChatGptSignOut}
-              @chatgpt-prefer-subscription-set=${this
-                .handleSetChatGptPreferSubscription}
-              @chatgpt-subscription-tool-use-only-set=${this
-                .handleSetChatGptSubscriptionToolUseOnly}
+              @chatgpt-prefer-subscription-set=${
+                this.handleSetChatGptPreferSubscription
+              }
+              @chatgpt-subscription-tool-use-only-set=${
+                this.handleSetChatGptSubscriptionToolUseOnly
+              }
             ></models-tab>
           </wa-tab-panel>
 
@@ -1009,13 +1014,16 @@ export class SettingsApp extends SettingsAppBase {
               .detachSubagentsOnStop=${this.detachSubagentsOnStop.get()}
               .worktreeSupport=${this.gitWorktreeSupport.get()}
               .nestedDelegationMaxDepth=${this.nestedDelegationMaxDepth.get()}
-              @allow-orchestrator-kill-toggle=${this
-                .handleAllowOrchestratorKillToggle}
-              @detach-subagents-on-stop-toggle=${this
-                .handleDetachSubagentsOnStopToggle}
+              @allow-orchestrator-kill-toggle=${
+                this.handleAllowOrchestratorKillToggle
+              }
+              @detach-subagents-on-stop-toggle=${
+                this.handleDetachSubagentsOnStopToggle
+              }
               @worktree-support-toggle=${this.handleWorktreeSupportToggle}
-              @nested-delegation-max-depth-change=${this
-                .handleNestedDelegationMaxDepthChange}
+              @nested-delegation-max-depth-change=${
+                this.handleNestedDelegationMaxDepthChange
+              }
               @apply-agent-mode-preset=${this.handleApplyAgentModePreset}
               @delete-agent-mode-preset=${this.handleDeleteAgentModePreset}
             ></multi-agent-tab>
@@ -1035,10 +1043,12 @@ export class SettingsApp extends SettingsAppBase {
               @tool-recheck=${this.handleToolRecheck}
               @tool-toggle=${this.handleToolToggle}
               @bash-approval-toggle=${this.handleBashApprovalToggle}
-              @desktop-crash-reporting-toggle=${this
-                .handleDesktopCrashReportingToggle}
-              @desktop-crash-reporting-dsn-set=${this
-                .handleDesktopCrashReportingDsnSet}
+              @desktop-crash-reporting-toggle=${
+                this.handleDesktopCrashReportingToggle
+              }
+              @desktop-crash-reporting-dsn-set=${
+                this.handleDesktopCrashReportingDsnSet
+              }
             ></tools-tab>
           </wa-tab-panel>
 
@@ -1058,13 +1068,16 @@ export class SettingsApp extends SettingsAppBase {
               @tool-recheck=${this.handleToolRecheck}
               @tool-toggle=${this.handleToolToggle}
               @codex-sandbox-mode-change=${this.handleCodexSandboxModeChange}
-              @codex-reasoning-effort-change=${this
-                .handleCodexReasoningEffortChange}
-              @codex-approval-policy-change=${this
-                .handleCodexApprovalPolicyChange}
+              @codex-reasoning-effort-change=${
+                this.handleCodexReasoningEffortChange
+              }
+              @codex-approval-policy-change=${
+                this.handleCodexApprovalPolicyChange
+              }
               @claude-agent-model-change=${this.handleClaudeAgentModelChange}
-              @claude-agent-permission-mode-change=${this
-                .handleClaudeAgentPermissionModeChange}
+              @claude-agent-permission-mode-change=${
+                this.handleClaudeAgentPermissionModeChange
+              }
               @claude-agent-effort-change=${this.handleClaudeAgentEffortChange}
             ></ai-agents-tab>
           </wa-tab-panel>
@@ -1083,8 +1096,9 @@ export class SettingsApp extends SettingsAppBase {
               @github-token-remove=${this.handleGitHubTokenRemove}
               @github-token-open-url=${this.handleGitHubTokenOpenUrl}
               @unsubscribe-pr=${this.handleUnsubscribePR}
-              @open-pr-subscription-stream=${this
-                .handleOpenPRSubscriptionStream}
+              @open-pr-subscription-stream=${
+                this.handleOpenPRSubscriptionStream
+              }
               .githubTokenStatus=${this.githubTokenStatus.get()}
               .prSubscriptions=${this.prSubscriptions.get()}
             ></git-tab>

--- a/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
@@ -363,26 +363,26 @@ export class HistoryItemElement extends LitElement {
               isToolUse
                 ? html`
                     ${renderIconActionButton({
-                    id: 'history-export-md-button',
-                    icon: 'file-lines',
-                    label: 'Export Markdown',
-                    tooltip: 'Export as Markdown',
-                    action: 'export-md',
-                  })}
+                      id: 'history-export-md-button',
+                      icon: 'file-lines',
+                      label: 'Export Markdown',
+                      tooltip: 'Export as Markdown',
+                      action: 'export-md',
+                    })}
                     ${renderIconActionButton({
-                    id: 'history-export-pdf-button',
-                    icon: 'file-pdf',
-                    label: 'Export PDF',
-                    tooltip: 'Export as LaTeX/PDF',
-                    action: 'export-tex',
-                  })}
+                      id: 'history-export-pdf-button',
+                      icon: 'file-pdf',
+                      label: 'Export PDF',
+                      tooltip: 'Export as LaTeX/PDF',
+                      action: 'export-tex',
+                    })}
                     ${renderIconActionButton({
-                    id: 'history-export-html-button',
-                    icon: 'globe',
-                    label: 'Export HTML',
-                    tooltip: 'Export as shareable HTML webpage',
-                    action: 'export-html',
-                  })}
+                      id: 'history-export-html-button',
+                      icon: 'globe',
+                      label: 'Export HTML',
+                      tooltip: 'Export as shareable HTML webpage',
+                      action: 'export-html',
+                    })}
                   `
                 : nothing
             }

--- a/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
@@ -359,42 +359,48 @@ export class HistoryItemElement extends LitElement {
               tooltip: 'Rerun this task',
               action: 'rerun',
             })}
-            ${isToolUse
-              ? html`
-                  ${renderIconActionButton({
+            ${
+              isToolUse
+                ? html`
+                    ${renderIconActionButton({
                     id: 'history-export-md-button',
                     icon: 'file-lines',
                     label: 'Export Markdown',
                     tooltip: 'Export as Markdown',
                     action: 'export-md',
                   })}
-                  ${renderIconActionButton({
+                    ${renderIconActionButton({
                     id: 'history-export-pdf-button',
                     icon: 'file-pdf',
                     label: 'Export PDF',
                     tooltip: 'Export as LaTeX/PDF',
                     action: 'export-tex',
                   })}
-                  ${renderIconActionButton({
+                    ${renderIconActionButton({
                     id: 'history-export-html-button',
                     icon: 'globe',
                     label: 'Export HTML',
                     tooltip: 'Export as shareable HTML webpage',
                     action: 'export-html',
                   })}
-                `
-              : nothing}
+                  `
+                : nothing
+            }
           </div>
         </div>
         ${this.renderInstructionBlock(instructionText, titleText)}
-        ${summaryText
-          ? html`<div class="history-description">${summaryText}</div>`
-          : nothing}
-        ${extraDetails.length
-          ? html`<div class="history-details extra-details">
-              ${extraDetails}
-            </div>`
-          : nothing}
+        ${
+          summaryText
+            ? html`<div class="history-description">${summaryText}</div>`
+            : nothing
+        }
+        ${
+          extraDetails.length
+            ? html`<div class="history-details extra-details">
+                ${extraDetails}
+              </div>`
+            : nothing
+        }
       </div>
     `;
   }

--- a/packages/extension/src/settingsView/frontend/components/history/HistoryList.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryList.ts
@@ -275,14 +275,16 @@ export class HistoryList extends LitElement {
     }
 
     return html`
-      ${this.paginated
-        ? html`<list-pagination
-            .page=${this.page}
-            .totalItems=${this.items.length}
-            .pageSize=${HISTORY_PAGE_SIZE}
-            @page-change=${this.handlePageChange}
-          ></list-pagination>`
-        : ''}
+      ${
+        this.paginated
+          ? html`<list-pagination
+              .page=${this.page}
+              .totalItems=${this.items.length}
+              .pageSize=${HISTORY_PAGE_SIZE}
+              @page-change=${this.handlePageChange}
+            ></list-pagination>`
+          : ''
+      }
       <div class="history-container">
         ${repeat(
           displayItems,
@@ -290,22 +292,25 @@ export class HistoryList extends LitElement {
           (item) => html`
             <history-item
               .item=${item}
-              .open=${forceOpen ||
-              Boolean(this.state?.toggleStates.get(item.id))}
+              .open=${
+                forceOpen || Boolean(this.state?.toggleStates.get(item.id))
+              }
               .highlightedMatchIndex=${this.getHighlightedMatchIndex(item.id)}
               @history-toggle=${this.handleToggle}
             ></history-item>
           `,
         )}
       </div>
-      ${this.paginated
-        ? html`<list-pagination
-            .page=${this.page}
-            .totalItems=${this.items.length}
-            .pageSize=${HISTORY_PAGE_SIZE}
-            @page-change=${this.handlePageChange}
-          ></list-pagination>`
-        : ''}
+      ${
+        this.paginated
+          ? html`<list-pagination
+              .page=${this.page}
+              .totalItems=${this.items.length}
+              .pageSize=${HISTORY_PAGE_SIZE}
+              @page-change=${this.handlePageChange}
+            ></list-pagination>`
+          : ''
+      }
     `;
   }
 }

--- a/packages/extension/src/settingsView/frontend/components/history/SearchBar.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/SearchBar.ts
@@ -91,16 +91,18 @@ export class SearchBar extends LitElement {
             onClick: this.handleNext,
           })}
           <span class="match-count">${this.matchCount}</span>
-          ${this.canClearHistory
-            ? renderIconActionButton({
-                id: 'history-search-clear-button',
-                icon: 'trash',
-                label: 'Clear history',
-                tooltip: 'Clear all history',
-                action: 'clear-history',
-                onClick: this.handleClearHistory,
-              })
-            : ''}
+          ${
+            this.canClearHistory
+              ? renderIconActionButton({
+                  id: 'history-search-clear-button',
+                  icon: 'trash',
+                  label: 'Clear history',
+                  tooltip: 'Clear all history',
+                  action: 'clear-history',
+                  onClick: this.handleClearHistory,
+                })
+              : ''
+          }
         </div>
       </div>
     `;

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
@@ -170,8 +170,7 @@ export class MemoryItem extends LitElement {
   protected override willUpdate(changedProperties: PropertyValues<this>): void {
     if (!changedProperties.has('item')) return;
     const previous = changedProperties.get('item') as
-      | MemoryViewItem
-      | undefined;
+      MemoryViewItem | undefined;
     if (previous?.storagePath === this.item?.storagePath) {
       if (previous !== this.item && this.item?.preview === undefined) {
         this.requestedPreviewFor = null;
@@ -293,11 +292,13 @@ export class MemoryItem extends LitElement {
           @wa-show=${this.handleContentsShow}
           @wa-hide=${this.handleContentsHide}
         >
-          ${this.contentsOpened
-            ? html`<div class="memory-preview">
-                ${this.renderPreviewBody(this.item)}
-              </div>`
-            : nothing}
+          ${
+            this.contentsOpened
+              ? html`<div class="memory-preview">
+                  ${this.renderPreviewBody(this.item)}
+                </div>`
+              : nothing
+          }
         </wa-details>
       </div>
     `;

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryList.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryList.ts
@@ -63,8 +63,7 @@ export class MemoryList extends LitElement {
   protected override willUpdate(changedProperties: PropertyValues<this>): void {
     if (changedProperties.has('items')) {
       const previous = changedProperties.get('items') as
-        | MemoryViewItem[]
-        | undefined;
+        MemoryViewItem[] | undefined;
       if (!hasSameMemoryOrder(previous, this.items)) {
         this.page = 0;
       }

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -412,14 +412,14 @@ export class AgentSelectionPanel extends LitElement {
                   <div class="agent-detail-meta-value">
                     <div class="agent-detail-tools">
                       ${agent.tools.map(
-                      (t) =>
-                        html`<wa-tag
-                          class="agent-tool-badge"
-                          variant="neutral"
-                          size="small"
-                          >${t}</wa-tag
-                        >`,
-                    )}
+                        (t) =>
+                          html`<wa-tag
+                            class="agent-tool-badge"
+                            variant="neutral"
+                            size="small"
+                            >${t}</wa-tag
+                          >`,
+                      )}
                     </div>
                   </div>
                 `
@@ -432,12 +432,12 @@ export class AgentSelectionPanel extends LitElement {
             agent.hasPath
               ? html`
                   ${renderLabeledActionButton({
-                  icon: 'file-lines',
-                  text: 'Open YAML',
-                  label: 'Open agent YAML definition',
-                  className: 'agent-action-btn',
-                  onClick: () => this.handleOpenYaml(agent),
-                })}
+                    icon: 'file-lines',
+                    text: 'Open YAML',
+                    label: 'Open agent YAML definition',
+                    className: 'agent-action-btn',
+                    onClick: () => this.handleOpenYaml(agent),
+                  })}
                 `
               : nothing
           }
@@ -448,14 +448,14 @@ export class AgentSelectionPanel extends LitElement {
             !this.desktopHost
               ? html`
                   ${renderLabeledActionButton({
-                  icon: 'file-lines',
-                  text: 'View Prompt',
-                  label: "View the remote agent's prompt definition",
-                  title:
-                    "View the remote agent's prompt definition (read-only)",
-                  className: 'agent-action-btn',
-                  onClick: () => this.handleViewRemotePrompt(agent),
-                })}
+                    icon: 'file-lines',
+                    text: 'View Prompt',
+                    label: "View the remote agent's prompt definition",
+                    title:
+                      "View the remote agent's prompt definition (read-only)",
+                    className: 'agent-action-btn',
+                    onClick: () => this.handleViewRemotePrompt(agent),
+                  })}
                 `
               : nothing
           }
@@ -463,12 +463,12 @@ export class AgentSelectionPanel extends LitElement {
             agent.hasPath
               ? html`
                   ${renderLabeledActionButton({
-                  icon: 'folder-open',
-                  text: 'Reveal in File Explorer',
-                  title: 'Show this file in your system file explorer',
-                  className: 'agent-action-btn',
-                  onClick: () => this.handleRevealAgentFile(agent),
-                })}
+                    icon: 'folder-open',
+                    text: 'Reveal in File Explorer',
+                    title: 'Show this file in your system file explorer',
+                    className: 'agent-action-btn',
+                    onClick: () => this.handleRevealAgentFile(agent),
+                  })}
                 `
               : nothing
           }
@@ -476,15 +476,16 @@ export class AgentSelectionPanel extends LitElement {
             builtIn && !this.desktopHost
               ? html`
                   ${renderLabeledActionButton({
-                  icon: 'pencil',
-                  text: 'Customize',
-                  label: 'Customize agent',
-                  title: 'Create an editable copy in your custom agents folder',
-                  className: 'agent-action-btn',
-                  appearance: 'filled',
-                  variant: 'brand',
-                  onClick: () => this.handleCustomizeAgent(agent),
-                })}
+                    icon: 'pencil',
+                    text: 'Customize',
+                    label: 'Customize agent',
+                    title:
+                      'Create an editable copy in your custom agents folder',
+                    className: 'agent-action-btn',
+                    appearance: 'filled',
+                    variant: 'brand',
+                    onClick: () => this.handleCustomizeAgent(agent),
+                  })}
                 `
               : nothing
           }
@@ -492,13 +493,13 @@ export class AgentSelectionPanel extends LitElement {
             isCustom && !this.desktopHost
               ? html`
                   ${renderLabeledActionButton({
-                  icon: 'trash',
-                  text: 'Delete',
-                  label: 'Delete custom agent',
-                  title: 'Delete this custom agent',
-                  className: 'agent-action-btn agent-action-btn--danger',
-                  onClick: () => this.handleDeleteCustomAgent(agent),
-                })}
+                    icon: 'trash',
+                    text: 'Delete',
+                    label: 'Delete custom agent',
+                    title: 'Delete this custom agent',
+                    className: 'agent-action-btn agent-action-btn--danger',
+                    onClick: () => this.handleDeleteCustomAgent(agent),
+                  })}
                 `
               : nothing
           }
@@ -513,19 +514,19 @@ export class AgentSelectionPanel extends LitElement {
                   </span>
                   <div class="agent-delete-confirm-actions">
                     ${renderLabeledActionButton({
-                    icon: 'trash',
-                    text: 'Delete',
-                    label: 'Confirm delete custom agent',
-                    className: 'agent-action-btn agent-action-btn--danger',
-                    onClick: () => this.handleDeleteCustomAgent(agent),
-                  })}
+                      icon: 'trash',
+                      text: 'Delete',
+                      label: 'Confirm delete custom agent',
+                      className: 'agent-action-btn agent-action-btn--danger',
+                      onClick: () => this.handleDeleteCustomAgent(agent),
+                    })}
                     ${renderLabeledActionButton({
-                    icon: 'xmark',
-                    text: 'Cancel',
-                    label: 'Cancel delete custom agent',
-                    className: 'agent-action-btn',
-                    onClick: () => this.cancelDelete(),
-                  })}
+                      icon: 'xmark',
+                      text: 'Cancel',
+                      label: 'Cancel delete custom agent',
+                      className: 'agent-action-btn',
+                      onClick: () => this.cancelDelete(),
+                    })}
                   </div>
                 </div>
               `

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -260,22 +260,28 @@ export class AgentSelectionPanel extends LitElement {
             e.stopPropagation();
             this.handleToggleEnabled(agent);
           }}
-          title=${agent.enabled
-            ? 'Hide from agent selector'
-            : 'Show in agent selector'}
+          title=${
+            agent.enabled
+              ? 'Hide from agent selector'
+              : 'Show in agent selector'
+          }
         ></wa-checkbox>
         <span class="agent-list-item-name">${agent.name}</span>
         <span class="agent-list-item-badges">
-          ${agent.source === AGENT_SOURCE.REMOTE
-            ? html`<span title="Remote agent"
-                >${waIcon('cloud', { label: 'Remote agent' })}</span
-              >`
-            : nothing}
-          ${agent.source === AGENT_SOURCE.CUSTOM
-            ? html`<span title="Custom agent"
-                >${waIcon('star', { label: 'Custom agent' })}</span
-              >`
-            : nothing}
+          ${
+            agent.source === AGENT_SOURCE.REMOTE
+              ? html`<span title="Remote agent"
+                  >${waIcon('cloud', { label: 'Remote agent' })}</span
+                >`
+              : nothing
+          }
+          ${
+            agent.source === AGENT_SOURCE.CUSTOM
+              ? html`<span title="Custom agent"
+                  >${waIcon('star', { label: 'Custom agent' })}</span
+                >`
+              : nothing
+          }
         </span>
       </div>
     `;
@@ -302,28 +308,32 @@ export class AgentSelectionPanel extends LitElement {
             <div class="agent-list-section-header">
               <span>${sourceName}</span>
               <span class="agent-list-section-actions">
-                ${enabledInGroup < agents.length
-                  ? html`<wa-button
-                      class="agent-count-link"
-                      appearance="plain"
-                      size="small"
-                      @click=${() => this.handleSetAllEnabled(source, true)}
-                      title="Show all ${sourceName} agents"
-                    >
-                      All
-                    </wa-button>`
-                  : nothing}
-                ${enabledInGroup > 0
-                  ? html`<wa-button
-                      class="agent-count-link"
-                      appearance="plain"
-                      size="small"
-                      @click=${() => this.handleSetAllEnabled(source, false)}
-                      title="Hide all ${sourceName} agents"
-                    >
-                      None
-                    </wa-button>`
-                  : nothing}
+                ${
+                  enabledInGroup < agents.length
+                    ? html`<wa-button
+                        class="agent-count-link"
+                        appearance="plain"
+                        size="small"
+                        @click=${() => this.handleSetAllEnabled(source, true)}
+                        title="Show all ${sourceName} agents"
+                      >
+                        All
+                      </wa-button>`
+                    : nothing
+                }
+                ${
+                  enabledInGroup > 0
+                    ? html`<wa-button
+                        class="agent-count-link"
+                        appearance="plain"
+                        size="small"
+                        @click=${() => this.handleSetAllEnabled(source, false)}
+                        title="Hide all ${sourceName} agents"
+                      >
+                        None
+                      </wa-button>`
+                    : nothing
+                }
               </span>
             </div>
             ${agents.map((a) => this.renderListItem(a))}
@@ -353,31 +363,41 @@ export class AgentSelectionPanel extends LitElement {
       <div class="agent-detail-pane">
         <div class="agent-detail-header">
           <span class="agent-detail-name">${agent.name}</span>
-          ${builtIn
-            ? html`<wa-tag variant="neutral" size="small">Built-in</wa-tag>`
-            : nothing}
-          ${isCustom
-            ? html`<wa-tag variant="neutral" size="small" title="Custom agent"
-                >${waIcon('star')} Custom</wa-tag
-              >`
-            : nothing}
-          ${agent.source === AGENT_SOURCE.REMOTE
-            ? html`<wa-tag variant="neutral" size="small" title="Remote agent"
-                >${waIcon('cloud')} Remote</wa-tag
-              >`
-            : nothing}
+          ${
+            builtIn
+              ? html`<wa-tag variant="neutral" size="small">Built-in</wa-tag>`
+              : nothing
+          }
+          ${
+            isCustom
+              ? html`<wa-tag variant="neutral" size="small" title="Custom agent"
+                  >${waIcon('star')} Custom</wa-tag
+                >`
+              : nothing
+          }
+          ${
+            agent.source === AGENT_SOURCE.REMOTE
+              ? html`<wa-tag variant="neutral" size="small" title="Remote agent"
+                  >${waIcon('cloud')} Remote</wa-tag
+                >`
+              : nothing
+          }
         </div>
 
-        ${agent.description
-          ? html`<div class="agent-detail-description">
-              ${agent.description}
-            </div>`
-          : nothing}
-        ${agent.filePath
-          ? html`<div class="agent-detail-path" title=${agent.filePath}>
-              ${agent.filePath.split(/[/\\]/).pop() ?? agent.filePath}
-            </div>`
-          : nothing}
+        ${
+          agent.description
+            ? html`<div class="agent-detail-description">
+                ${agent.description}
+              </div>`
+            : nothing
+        }
+        ${
+          agent.filePath
+            ? html`<div class="agent-detail-path" title=${agent.filePath}>
+                ${agent.filePath.split(/[/\\]/).pop() ?? agent.filePath}
+              </div>`
+            : nothing
+        }
 
         <div class="agent-detail-meta">
           <span class="agent-detail-meta-label">Available</span>
@@ -385,12 +405,13 @@ export class AgentSelectionPanel extends LitElement {
             ${agent.enabled ? 'Yes' : 'No'}
           </span>
 
-          ${agent.tools && agent.tools.length > 0
-            ? html`
-                <span class="agent-detail-meta-label">Tools</span>
-                <div class="agent-detail-meta-value">
-                  <div class="agent-detail-tools">
-                    ${agent.tools.map(
+          ${
+            agent.tools && agent.tools.length > 0
+              ? html`
+                  <span class="agent-detail-meta-label">Tools</span>
+                  <div class="agent-detail-meta-value">
+                    <div class="agent-detail-tools">
+                      ${agent.tools.map(
                       (t) =>
                         html`<wa-tag
                           class="agent-tool-badge"
@@ -399,30 +420,34 @@ export class AgentSelectionPanel extends LitElement {
                           >${t}</wa-tag
                         >`,
                     )}
+                    </div>
                   </div>
-                </div>
-              `
-            : nothing}
+                `
+              : nothing
+          }
         </div>
 
         <div class="agent-detail-actions">
-          ${agent.hasPath
-            ? html`
-                ${renderLabeledActionButton({
+          ${
+            agent.hasPath
+              ? html`
+                  ${renderLabeledActionButton({
                   icon: 'file-lines',
                   text: 'Open YAML',
                   label: 'Open agent YAML definition',
                   className: 'agent-action-btn',
                   onClick: () => this.handleOpenYaml(agent),
                 })}
-              `
-            : nothing}
-          ${agent.source === AGENT_SOURCE.REMOTE &&
-          this.userTier === 'Ultra' &&
-          !agent.hasPath &&
-          !this.desktopHost
-            ? html`
-                ${renderLabeledActionButton({
+                `
+              : nothing
+          }
+          ${
+            agent.source === AGENT_SOURCE.REMOTE &&
+            this.userTier === 'Ultra' &&
+            !agent.hasPath &&
+            !this.desktopHost
+              ? html`
+                  ${renderLabeledActionButton({
                   icon: 'file-lines',
                   text: 'View Prompt',
                   label: "View the remote agent's prompt definition",
@@ -431,22 +456,26 @@ export class AgentSelectionPanel extends LitElement {
                   className: 'agent-action-btn',
                   onClick: () => this.handleViewRemotePrompt(agent),
                 })}
-              `
-            : nothing}
-          ${agent.hasPath
-            ? html`
-                ${renderLabeledActionButton({
+                `
+              : nothing
+          }
+          ${
+            agent.hasPath
+              ? html`
+                  ${renderLabeledActionButton({
                   icon: 'folder-open',
                   text: 'Reveal in File Explorer',
                   title: 'Show this file in your system file explorer',
                   className: 'agent-action-btn',
                   onClick: () => this.handleRevealAgentFile(agent),
                 })}
-              `
-            : nothing}
-          ${builtIn && !this.desktopHost
-            ? html`
-                ${renderLabeledActionButton({
+                `
+              : nothing
+          }
+          ${
+            builtIn && !this.desktopHost
+              ? html`
+                  ${renderLabeledActionButton({
                   icon: 'pencil',
                   text: 'Customize',
                   label: 'Customize agent',
@@ -456,11 +485,13 @@ export class AgentSelectionPanel extends LitElement {
                   variant: 'brand',
                   onClick: () => this.handleCustomizeAgent(agent),
                 })}
-              `
-            : nothing}
-          ${isCustom && !this.desktopHost
-            ? html`
-                ${renderLabeledActionButton({
+                `
+              : nothing
+          }
+          ${
+            isCustom && !this.desktopHost
+              ? html`
+                  ${renderLabeledActionButton({
                   icon: 'trash',
                   text: 'Delete',
                   label: 'Delete custom agent',
@@ -468,35 +499,38 @@ export class AgentSelectionPanel extends LitElement {
                   className: 'agent-action-btn agent-action-btn--danger',
                   onClick: () => this.handleDeleteCustomAgent(agent),
                 })}
-              `
-            : nothing}
+                `
+              : nothing
+          }
         </div>
 
-        ${showDeleteConfirm
-          ? html`
-              <div class="agent-delete-confirm">
-                <span class="agent-delete-confirm-text">
-                  Delete custom agent "${agent.name}"? This cannot be undone.
-                </span>
-                <div class="agent-delete-confirm-actions">
-                  ${renderLabeledActionButton({
+        ${
+          showDeleteConfirm
+            ? html`
+                <div class="agent-delete-confirm">
+                  <span class="agent-delete-confirm-text">
+                    Delete custom agent "${agent.name}"? This cannot be undone.
+                  </span>
+                  <div class="agent-delete-confirm-actions">
+                    ${renderLabeledActionButton({
                     icon: 'trash',
                     text: 'Delete',
                     label: 'Confirm delete custom agent',
                     className: 'agent-action-btn agent-action-btn--danger',
                     onClick: () => this.handleDeleteCustomAgent(agent),
                   })}
-                  ${renderLabeledActionButton({
+                    ${renderLabeledActionButton({
                     icon: 'xmark',
                     text: 'Cancel',
                     label: 'Cancel delete custom agent',
                     className: 'agent-action-btn',
                     onClick: () => this.cancelDelete(),
                   })}
+                  </div>
                 </div>
-              </div>
-            `
-          : nothing}
+              `
+            : nothing
+        }
       </div>
     `;
   }

--- a/packages/extension/src/settingsView/frontend/components/profile/ApiAccessSection.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ApiAccessSection.ts
@@ -60,26 +60,28 @@ export class ApiAccessSection extends LitElement {
             `,
           )}
         </wa-radio-group>
-        ${this.mode === 'included'
-          ? html`
-              <div class="api-access-support">
-                ${waIcon('heart', { className: 'api-access-support-icon' })}
-                <span class="api-access-support-copy">
-                  ${PROMO_NOTICE_LONG.supportLead}<a
-                    href=${PROMO_NOTICE_LONG.supportSponsorsUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    >${PROMO_NOTICE_LONG.supportSponsorsLabel}</a
-                  >${PROMO_NOTICE_LONG.supportMiddle}<a
-                    href=${PROMO_NOTICE_LONG.supportCoffeeUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    >${PROMO_NOTICE_LONG.supportCoffeeLabel}</a
-                  >${PROMO_NOTICE_LONG.supportTail}
-                </span>
-              </div>
-            `
-          : nothing}
+        ${
+          this.mode === 'included'
+            ? html`
+                <div class="api-access-support">
+                  ${waIcon('heart', { className: 'api-access-support-icon' })}
+                  <span class="api-access-support-copy">
+                    ${PROMO_NOTICE_LONG.supportLead}<a
+                      href=${PROMO_NOTICE_LONG.supportSponsorsUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      >${PROMO_NOTICE_LONG.supportSponsorsLabel}</a
+                    >${PROMO_NOTICE_LONG.supportMiddle}<a
+                      href=${PROMO_NOTICE_LONG.supportCoffeeUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      >${PROMO_NOTICE_LONG.supportCoffeeLabel}</a
+                    >${PROMO_NOTICE_LONG.supportTail}
+                  </span>
+                </div>
+              `
+            : nothing
+        }
       </div>
     `;
   }

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -311,10 +311,10 @@ export class ModelSelectionList extends LitElement {
                 <div class="provider-group-content">
                   ${group.current.map((m) => this.renderModelRow(m))}
                   ${
-                  group.deprecated.length > 0
-                    ? this.renderDeprecatedToggle(group)
-                    : nothing
-                }
+                    group.deprecated.length > 0
+                      ? this.renderDeprecatedToggle(group)
+                      : nothing
+                  }
                 </div>
               `
             : nothing

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -190,12 +190,14 @@ export class ModelSelectionList extends LitElement {
           `,
         )}
       </wa-select>
-      ${includedAccessCap
-        ? waIcon('warning', {
-            className: 'model-row-icon model-row-icon--warning',
-            title,
-          })
-        : nothing}
+      ${
+        includedAccessCap
+          ? waIcon('warning', {
+              className: 'model-row-icon model-row-icon--warning',
+              title,
+            })
+          : nothing
+      }
     `;
   }
 
@@ -237,18 +239,22 @@ export class ModelSelectionList extends LitElement {
           <span class="model-name">${model.label}</span>
           <span class="model-shortname">(${model.name})</span>
           ${this.renderAvailabilityIcon(model)}
-          ${isExpensiveModel(model.provider, model.name)
-            ? waIcon('warning', {
-                className: 'model-row-icon model-row-icon--warning',
-                title: EXPENSIVE_MODEL_HINT,
-              })
-            : nothing}
+          ${
+            isExpensiveModel(model.provider, model.name)
+              ? waIcon('warning', {
+                  className: 'model-row-icon model-row-icon--warning',
+                  title: EXPENSIVE_MODEL_HINT,
+                })
+              : nothing
+          }
         </wa-checkbox>
         ${this.renderReasoningDropdown(model)}
         <span class="model-metadata">
-          ${model.contextWindow
-            ? html`<span>${model.contextWindow}</span>`
-            : nothing}
+          ${
+            model.contextWindow
+              ? html`<span>${model.contextWindow}</span>`
+              : nothing
+          }
           ${model.cost ? html`<span>${model.cost}</span>` : nothing}
         </span>
       </div>
@@ -299,16 +305,20 @@ export class ModelSelectionList extends LitElement {
           </wa-button>
           <div class="provider-group-actions">${providerKeyStatus}</div>
         </div>
-        ${isExpanded
-          ? html`
-              <div class="provider-group-content">
-                ${group.current.map((m) => this.renderModelRow(m))}
-                ${group.deprecated.length > 0
-                  ? this.renderDeprecatedToggle(group)
-                  : nothing}
-              </div>
-            `
-          : nothing}
+        ${
+          isExpanded
+            ? html`
+                <div class="provider-group-content">
+                  ${group.current.map((m) => this.renderModelRow(m))}
+                  ${
+                  group.deprecated.length > 0
+                    ? this.renderDeprecatedToggle(group)
+                    : nothing
+                }
+                </div>
+              `
+            : nothing
+        }
       </div>
     `;
   }
@@ -330,11 +340,13 @@ export class ModelSelectionList extends LitElement {
         })}
         ${group.deprecated.length} deprecated
       </wa-button>
-      ${isOpen
-        ? html`<div class="deprecated-models">
-            ${group.deprecated.map((m) => this.renderModelRow(m))}
-          </div>`
-        : nothing}
+      ${
+        isOpen
+          ? html`<div class="deprecated-models">
+              ${group.deprecated.map((m) => this.renderModelRow(m))}
+            </div>`
+          : nothing
+      }
     `;
   }
 

--- a/packages/extension/src/settingsView/frontend/components/profile/ReliabilitySettingsSection.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ReliabilitySettingsSection.ts
@@ -98,9 +98,11 @@ export class ReliabilitySettingsSection extends LitElement {
           @change=${(event: Event) =>
             this.handleSettingChange(setting, event.target as WaInput)}
         ></wa-input>
-        ${setting.unit
-          ? html`<span class="setting-unit">${setting.unit}</span>`
-          : nothing}
+        ${
+          setting.unit
+            ? html`<span class="setting-unit">${setting.unit}</span>`
+            : nothing
+        }
       </div>
       <p class="setting-help">${setting.description}</p>
     `;

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -438,15 +438,15 @@ export class ToolCard extends LitElement {
             ? html`
                 <div class="tool-ids">
                   ${this.item.tools.map(
-                  (tool) =>
-                    html`<wa-badge
-                      class="tool-id-tag"
-                      variant="neutral"
-                      appearance="filled"
-                      title=${tool.description ?? tool.name}
-                      >${tool.name}</wa-badge
-                    >`,
-                )}
+                    (tool) =>
+                      html`<wa-badge
+                        class="tool-id-tag"
+                        variant="neutral"
+                        appearance="filled"
+                        title=${tool.description ?? tool.name}
+                        >${tool.name}</wa-badge
+                      >`,
+                  )}
                 </div>
               `
             : nothing

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -303,66 +303,78 @@ export class ToolCard extends LitElement {
         @wa-show=${this.handleGuideShow}
         @wa-hide=${this.handleGuideHide}
       >
-        ${this.item.installGuide
-          ? html`<div class="tool-guide">${this.item.installGuide}</div>`
-          : nothing}
+        ${
+          this.item.installGuide
+            ? html`<div class="tool-guide">${this.item.installGuide}</div>`
+            : nothing
+        }
         <div class="tool-guide-actions">
-          ${this.item.installCommand
-            ? html`
-                <wa-button
-                  appearance="filled"
-                  variant="brand"
-                  size="small"
-                  @click=${() => this.runCommand('install')}
-                  title=${this.item.installCommand}
-                >
-                  ${waIcon('terminal', { slot: 'start' })} Install in Terminal
-                </wa-button>
-              `
-            : nothing}
-          ${this.item.authCommand
-            ? html`
-                <wa-button
-                  appearance=${secondaryAppearance}
-                  variant=${secondaryVariant}
-                  size="small"
-                  @click=${() => this.runCommand('auth')}
-                  title=${this.item.authCommand}
-                >
-                  ${waIcon('right-to-bracket', { slot: 'start' })} Sign in
-                </wa-button>
-              `
-            : nothing}
-          ${this.item.installExtensionId
-            ? html`
-                <wa-button
-                  appearance="filled"
-                  variant="brand"
-                  size="small"
-                  @click=${this.handleInstallExtension}
-                >
-                  ${waIcon('cloud-arrow-down', { slot: 'start' })} Install
-                  Extension
-                </wa-button>
-              `
-            : nothing}
-          ${this.item.installUrl
-            ? html`
-                <wa-button
-                  appearance=${secondaryAppearance}
-                  variant=${secondaryVariant}
-                  size="small"
-                  @click=${this.handleInstallUrl}
-                >
-                  ${waIcon('arrow-up-right-from-square', { slot: 'start' })}
-                  Open Install Page
-                </wa-button>
-              `
-            : nothing}
+          ${
+            this.item.installCommand
+              ? html`
+                  <wa-button
+                    appearance="filled"
+                    variant="brand"
+                    size="small"
+                    @click=${() => this.runCommand('install')}
+                    title=${this.item.installCommand}
+                  >
+                    ${waIcon('terminal', { slot: 'start' })} Install in Terminal
+                  </wa-button>
+                `
+              : nothing
+          }
+          ${
+            this.item.authCommand
+              ? html`
+                  <wa-button
+                    appearance=${secondaryAppearance}
+                    variant=${secondaryVariant}
+                    size="small"
+                    @click=${() => this.runCommand('auth')}
+                    title=${this.item.authCommand}
+                  >
+                    ${waIcon('right-to-bracket', { slot: 'start' })} Sign in
+                  </wa-button>
+                `
+              : nothing
+          }
+          ${
+            this.item.installExtensionId
+              ? html`
+                  <wa-button
+                    appearance="filled"
+                    variant="brand"
+                    size="small"
+                    @click=${this.handleInstallExtension}
+                  >
+                    ${waIcon('cloud-arrow-down', { slot: 'start' })} Install
+                    Extension
+                  </wa-button>
+                `
+              : nothing
+          }
+          ${
+            this.item.installUrl
+              ? html`
+                  <wa-button
+                    appearance=${secondaryAppearance}
+                    variant=${secondaryVariant}
+                    size="small"
+                    @click=${this.handleInstallUrl}
+                  >
+                    ${waIcon('arrow-up-right-from-square', { slot: 'start' })}
+                    Open Install Page
+                  </wa-button>
+                `
+              : nothing
+          }
         </div>
-        ${this.item.configNotes
-          ? html`<div class="tool-config-note">${this.item.configNotes}</div>`
-          : nothing}
+        ${
+          this.item.configNotes
+            ? html`<div class="tool-config-note">${this.item.configNotes}</div>`
+            : nothing
+        }
       </wa-details>
     `;
   }
@@ -398,25 +410,34 @@ export class ToolCard extends LitElement {
       <div class="tool-card">
         <div class="tool-header">
           <div class="tool-title-group">
-            ${this.item.status === 'available'
-              ? this.renderAvailableStatusIcon()
-              : nothing}
+            ${
+              this.item.status === 'available'
+                ? this.renderAvailableStatusIcon()
+                : nothing
+            }
             <span class="tool-name">${this.item.name}</span>
-            ${this.item.status === 'available'
-              ? nothing
-              : this.renderStatusBadge()}
+            ${
+              this.item.status === 'available'
+                ? nothing
+                : this.renderStatusBadge()
+            }
             ${this.renderAuthNote()}
           </div>
           ${this.renderToggle()}
         </div>
         <div class="tool-description">${this.item.description}</div>
-        ${this.item.statusDetail
-          ? html`<div class="tool-config-note">${this.item.statusDetail}</div>`
-          : nothing}
-        ${this.item.tools.length > 0
-          ? html`
-              <div class="tool-ids">
-                ${this.item.tools.map(
+        ${
+          this.item.statusDetail
+            ? html`<div class="tool-config-note">
+                ${this.item.statusDetail}
+              </div>`
+            : nothing
+        }
+        ${
+          this.item.tools.length > 0
+            ? html`
+                <div class="tool-ids">
+                  ${this.item.tools.map(
                   (tool) =>
                     html`<wa-badge
                       class="tool-id-tag"
@@ -426,9 +447,10 @@ export class ToolCard extends LitElement {
                       >${tool.name}</wa-badge
                     >`,
                 )}
-              </div>
-            `
-          : nothing}
+                </div>
+              `
+            : nothing
+        }
         <slot name="details"></slot>
         ${this.renderGuide()}
       </div>

--- a/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
@@ -267,11 +267,14 @@ export class AIAgentsTab extends LitElement {
           </wa-button>
         </div>
 
-        ${items.length === 0
-          ? html`<div class="ai-agents-empty">No integrations registered.</div>`
-          : html`
-              <div class="category-section">
-                ${repeat(
+        ${
+          items.length === 0
+            ? html`<div class="ai-agents-empty">
+                No integrations registered.
+              </div>`
+            : html`
+                <div class="category-section">
+                  ${repeat(
                   items,
                   (item) => item.id,
                   (item) => {
@@ -280,15 +283,18 @@ export class AIAgentsTab extends LitElement {
                     );
                     return html`
                       <tool-card .item=${item}>
-                        ${inlineSettings
-                          ? html`<div slot="details">${inlineSettings}</div>`
-                          : nothing}
+                        ${
+                          inlineSettings
+                            ? html`<div slot="details">${inlineSettings}</div>`
+                            : nothing
+                        }
                       </tool-card>
                     `;
                   },
                 )}
-              </div>
-            `}
+                </div>
+              `
+        }
       </div>
     `;
   }

--- a/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
@@ -275,23 +275,23 @@ export class AIAgentsTab extends LitElement {
             : html`
                 <div class="category-section">
                   ${repeat(
-                  items,
-                  (item) => item.id,
-                  (item) => {
-                    const inlineSettings = this.renderInlineSettingsFor(
-                      item.id,
-                    );
-                    return html`
-                      <tool-card .item=${item}>
-                        ${
+                    items,
+                    (item) => item.id,
+                    (item) => {
+                      const inlineSettings = this.renderInlineSettingsFor(
+                        item.id,
+                      );
+                      return html`
+                        <tool-card .item=${item}>
+                          ${
                           inlineSettings
                             ? html`<div slot="details">${inlineSettings}</div>`
                             : nothing
                         }
-                      </tool-card>
-                    `;
-                  },
-                )}
+                        </tool-card>
+                      `;
+                    },
+                  )}
                 </div>
               `
         }

--- a/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
@@ -240,29 +240,31 @@ export class AgentsTab extends LitElement {
             >
               ${waIcon('save', { slot: 'start' })} Save Team
             </wa-button>
-            ${this.desktopHost
-              ? nothing
-              : html`
-                  <wa-button
-                    appearance="outlined"
-                    variant="neutral"
-                    size="small"
-                    title="Create a new agent from a blank YAML template"
-                    @click=${this.handleCreateFromTemplate}
-                  >
-                    ${waIcon('new-file', { slot: 'start' })} From Template
-                  </wa-button>
-                  <wa-button
-                    class="agents-create-btn"
-                    appearance="outlined"
-                    variant="neutral"
-                    size="small"
-                    title="Create a new agent with AI"
-                    @click=${this.handleCreateAgent}
-                  >
-                    ${waIcon('add', { slot: 'start' })} New Agent
-                  </wa-button>
-                `}
+            ${
+              this.desktopHost
+                ? nothing
+                : html`
+                    <wa-button
+                      appearance="outlined"
+                      variant="neutral"
+                      size="small"
+                      title="Create a new agent from a blank YAML template"
+                      @click=${this.handleCreateFromTemplate}
+                    >
+                      ${waIcon('new-file', { slot: 'start' })} From Template
+                    </wa-button>
+                    <wa-button
+                      class="agents-create-btn"
+                      appearance="outlined"
+                      variant="neutral"
+                      size="small"
+                      title="Create a new agent with AI"
+                      @click=${this.handleCreateAgent}
+                    >
+                      ${waIcon('add', { slot: 'start' })} New Agent
+                    </wa-button>
+                  `
+            }
           </div>
         </div>
 
@@ -273,14 +275,16 @@ export class AgentsTab extends LitElement {
           <span class="agents-dir-path" title=${this.customAgentDir}
             >${this.customAgentDir}</span
           >
-          ${this.customAgentDirIsDefault
-            ? html`<wa-tag
-                class="agents-dir-default-badge"
-                variant="neutral"
-                size="small"
-                >default</wa-tag
-              >`
-            : nothing}
+          ${
+            this.customAgentDirIsDefault
+              ? html`<wa-tag
+                  class="agents-dir-default-badge"
+                  variant="neutral"
+                  size="small"
+                  >default</wa-tag
+                >`
+              : nothing
+          }
           <div class="agents-dir-actions">
             <wa-button
               class="action-icon-button"
@@ -302,17 +306,19 @@ export class AgentsTab extends LitElement {
             >
               Change
             </wa-button>
-            ${!this.customAgentDirIsDefault
-              ? html`<wa-button
-                  appearance="outlined"
-                  variant="neutral"
-                  size="small"
-                  title="Reset to default directory"
-                  @click=${this.handleResetCustomDir}
-                >
-                  Reset
-                </wa-button>`
-              : nothing}
+            ${
+              !this.customAgentDirIsDefault
+                ? html`<wa-button
+                    appearance="outlined"
+                    variant="neutral"
+                    size="small"
+                    title="Reset to default directory"
+                    @click=${this.handleResetCustomDir}
+                  >
+                    Reset
+                  </wa-button>`
+                : nothing
+            }
           </div>
         </div>
 

--- a/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
@@ -246,110 +246,118 @@ export class GitTab extends LitElement {
     const tokenIsSet = this.githubTokenStatus !== 'none';
     return html`
       <div class="git-container">
-        ${this.desktopHost
-          ? nothing
-          : html`
-              <div class="setting-block">
-                <p class="section-title">GitHub personal access token</p>
-                <p class="setting-description">
-                  Used to poll GitHub for pull request events (comments,
-                  reviews, failed CI) when you subscribe to a PR.
-                </p>
-                <div class="token-row">
-                  <span class="token-row-label">Status:</span>
-                  ${this.renderTokenStatusBadge()}
-                  <span class="token-actions">
-                    <wa-button
-                      appearance="outlined"
-                      variant="neutral"
-                      size="small"
-                      @click=${this.handleSetGitHubToken}
-                    >
-                      ${waIcon('key', { slot: 'start' })}
-                      ${tokenIsSet ? 'Replace token' : 'Set token'}
-                    </wa-button>
-                    ${this.githubTokenStatus === 'secret'
-                      ? html`<wa-button
-                          class="token-remove-btn"
-                          appearance="outlined"
-                          variant="neutral"
-                          size="small"
-                          @click=${this.handleRemoveGitHubToken}
-                        >
-                          ${waIcon('trash', { slot: 'start' })} Remove
-                        </wa-button>`
-                      : nothing}
-                    <wa-button
-                      appearance="outlined"
-                      variant="neutral"
-                      size="small"
-                      @click=${this.handleOpenGitHubTokenUrl}
-                    >
-                      ${waIcon('github', { slot: 'start' })} Create on GitHub…
-                    </wa-button>
-                  </span>
+        ${
+          this.desktopHost
+            ? nothing
+            : html`
+                <div class="setting-block">
+                  <p class="section-title">GitHub personal access token</p>
+                  <p class="setting-description">
+                    Used to poll GitHub for pull request events (comments,
+                    reviews, failed CI) when you subscribe to a PR.
+                  </p>
+                  <div class="token-row">
+                    <span class="token-row-label">Status:</span>
+                    ${this.renderTokenStatusBadge()}
+                    <span class="token-actions">
+                      <wa-button
+                        appearance="outlined"
+                        variant="neutral"
+                        size="small"
+                        @click=${this.handleSetGitHubToken}
+                      >
+                        ${waIcon('key', { slot: 'start' })}
+                        ${tokenIsSet ? 'Replace token' : 'Set token'}
+                      </wa-button>
+                      ${
+                      this.githubTokenStatus === 'secret'
+                        ? html`<wa-button
+                            class="token-remove-btn"
+                            appearance="outlined"
+                            variant="neutral"
+                            size="small"
+                            @click=${this.handleRemoveGitHubToken}
+                          >
+                            ${waIcon('trash', { slot: 'start' })} Remove
+                          </wa-button>`
+                        : nothing
+                    }
+                      <wa-button
+                        appearance="outlined"
+                        variant="neutral"
+                        size="small"
+                        @click=${this.handleOpenGitHubTokenUrl}
+                      >
+                        ${waIcon('github', { slot: 'start' })} Create on GitHub…
+                      </wa-button>
+                    </span>
+                  </div>
+                  <div class="instructions">
+                    <strong>How to get a token:</strong>
+                    <ol>
+                      <li>
+                        Click <em>Create on GitHub…</em> to open the
+                        token-creation page in your browser.
+                      </li>
+                      <li>
+                        Choose scopes: <code>repo</code> for private repos or
+                        <code>public_repo</code> for public only. Read-only
+                        usage; no write scopes needed.
+                      </li>
+                      <li>
+                        Pick an expiration (90 days is common) and click
+                        <em>Generate token</em>.
+                      </li>
+                      <li>
+                        Copy the token (shown only once) and paste it here via
+                        <em>Set token</em>.
+                      </li>
+                    </ol>
+                    ${
+                    this.githubTokenStatus === 'env'
+                      ? html`<p>
+                          A token is currently being read from the
+                          <code>GITHUB_TOKEN</code> or <code>GH_TOKEN</code>
+                          environment variable. Setting one above will override
+                          it.
+                        </p>`
+                      : nothing
+                  }
+                  </div>
                 </div>
-                <div class="instructions">
-                  <strong>How to get a token:</strong>
-                  <ol>
-                    <li>
-                      Click <em>Create on GitHub…</em> to open the
-                      token-creation page in your browser.
-                    </li>
-                    <li>
-                      Choose scopes: <code>repo</code> for private repos or
-                      <code>public_repo</code> for public only. Read-only usage;
-                      no write scopes needed.
-                    </li>
-                    <li>
-                      Pick an expiration (90 days is common) and click
-                      <em>Generate token</em>.
-                    </li>
-                    <li>
-                      Copy the token (shown only once) and paste it here via
-                      <em>Set token</em>.
-                    </li>
-                  </ol>
-                  ${this.githubTokenStatus === 'env'
-                    ? html`<p>
-                        A token is currently being read from the
-                        <code>GITHUB_TOKEN</code> or <code>GH_TOKEN</code>
-                        environment variable. Setting one above will override
-                        it.
-                      </p>`
-                    : nothing}
-                </div>
-              </div>
-            `}
-        ${!this.desktopHost && this.prSubscriptions.length > 0
-          ? html`
-              <div class="setting-block">
-                <p class="section-title">Active GitHub subscriptions</p>
-                <p class="setting-description">
-                  An agent is monitoring these repositories
-                  (<code>owner/repo</code>), pull requests
-                  (<code>owner/repo/pulls/N</code>), or issues
-                  (<code>owner/repo/issues/N</code>) in the background, polling
-                  GitHub every ~30 seconds. New comments, reviews, and CI
-                  failures arrive as follow-up messages in the agent's
-                  conversation so it can investigate and act on them. PR
-                  subscriptions end automatically on close/merge; issue
-                  subscriptions stay active across close so reopens are caught.
-                  All kinds detach after 24 hours of continuous network failure.
-                  Click <em>Stop</em> to cancel one manually.
-                </p>
-                <ul class="subscriptions-list">
-                  ${this.prSubscriptions.map(
+              `
+        }
+        ${
+          !this.desktopHost && this.prSubscriptions.length > 0
+            ? html`
+                <div class="setting-block">
+                  <p class="section-title">Active GitHub subscriptions</p>
+                  <p class="setting-description">
+                    An agent is monitoring these repositories
+                    (<code>owner/repo</code>), pull requests
+                    (<code>owner/repo/pulls/N</code>), or issues
+                    (<code>owner/repo/issues/N</code>) in the background,
+                    polling GitHub every ~30 seconds. New comments, reviews, and
+                    CI failures arrive as follow-up messages in the agent's
+                    conversation so it can investigate and act on them. PR
+                    subscriptions end automatically on close/merge; issue
+                    subscriptions stay active across close so reopens are
+                    caught. All kinds detach after 24 hours of continuous
+                    network failure. Click <em>Stop</em> to cancel one manually.
+                  </p>
+                  <ul class="subscriptions-list">
+                    ${this.prSubscriptions.map(
                     (subscription) => html`
                       <li>
                         <div class="subscription-meta">
                           <code class="subscription-key"
                             >${subscription.key}</code
                           >
-                          ${subscription.owners.length > 0
-                            ? html`
-                                <div class="subscription-owners">
-                                  ${subscription.owners.map(
+                          ${
+                            subscription.owners.length > 0
+                              ? html`
+                                  <div class="subscription-owners">
+                                    ${subscription.owners.map(
                                     (owner) => html`
                                       <div class="subscription-owner-row">
                                         <span class="subscription-owner-label"
@@ -372,13 +380,15 @@ export class GitTab extends LitElement {
                                       </div>
                                     `,
                                   )}
-                                </div>
-                              `
-                            : html`
-                                <p class="subscription-owner-placeholder">
-                                  Started by an agent that is no longer active.
-                                </p>
-                              `}
+                                  </div>
+                                `
+                              : html`
+                                  <p class="subscription-owner-placeholder">
+                                    Started by an agent that is no longer
+                                    active.
+                                  </p>
+                                `
+                          }
                         </div>
                         <wa-button
                           appearance="outlined"
@@ -392,10 +402,11 @@ export class GitTab extends LitElement {
                       </li>
                     `,
                   )}
-                </ul>
-              </div>
-            `
-          : nothing}
+                  </ul>
+                </div>
+              `
+            : nothing
+        }
 
         <div class="setting-block">
           <wa-switch
@@ -411,33 +422,35 @@ export class GitTab extends LitElement {
           </p>
         </div>
 
-        ${this.markCommits
-          ? html`
-              <div class="setting-block">
-                <div class="input-row">
-                  <label>Name</label>
-                  <wa-input
-                    .value=${this.authorName}
-                    placeholder=${DEFAULT_GIT_AUTHOR_NAME}
-                    @change=${this.handleAuthorNameChange}
-                  ></wa-input>
+        ${
+          this.markCommits
+            ? html`
+                <div class="setting-block">
+                  <div class="input-row">
+                    <label>Name</label>
+                    <wa-input
+                      .value=${this.authorName}
+                      placeholder=${DEFAULT_GIT_AUTHOR_NAME}
+                      @change=${this.handleAuthorNameChange}
+                    ></wa-input>
+                  </div>
+                  <div class="input-row">
+                    <label>Email</label>
+                    <wa-input
+                      .value=${this.authorEmail}
+                      placeholder=${DEFAULT_GIT_AUTHOR_EMAIL}
+                      @change=${this.handleAuthorEmailChange}
+                    ></wa-input>
+                  </div>
+                  <p class="setting-description">
+                    These values are set as GIT_AUTHOR_NAME, GIT_AUTHOR_EMAIL,
+                    GIT_COMMITTER_NAME, and GIT_COMMITTER_EMAIL for all commands
+                    run by TeXRA.
+                  </p>
                 </div>
-                <div class="input-row">
-                  <label>Email</label>
-                  <wa-input
-                    .value=${this.authorEmail}
-                    placeholder=${DEFAULT_GIT_AUTHOR_EMAIL}
-                    @change=${this.handleAuthorEmailChange}
-                  ></wa-input>
-                </div>
-                <p class="setting-description">
-                  These values are set as GIT_AUTHOR_NAME, GIT_AUTHOR_EMAIL,
-                  GIT_COMMITTER_NAME, and GIT_COMMITTER_EMAIL for all commands
-                  run by TeXRA.
-                </p>
-              </div>
-            `
-          : nothing}
+              `
+            : nothing
+        }
       </div>
     `;
   }

--- a/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
@@ -270,18 +270,18 @@ export class GitTab extends LitElement {
                         ${tokenIsSet ? 'Replace token' : 'Set token'}
                       </wa-button>
                       ${
-                      this.githubTokenStatus === 'secret'
-                        ? html`<wa-button
-                            class="token-remove-btn"
-                            appearance="outlined"
-                            variant="neutral"
-                            size="small"
-                            @click=${this.handleRemoveGitHubToken}
-                          >
-                            ${waIcon('trash', { slot: 'start' })} Remove
-                          </wa-button>`
-                        : nothing
-                    }
+                        this.githubTokenStatus === 'secret'
+                          ? html`<wa-button
+                              class="token-remove-btn"
+                              appearance="outlined"
+                              variant="neutral"
+                              size="small"
+                              @click=${this.handleRemoveGitHubToken}
+                            >
+                              ${waIcon('trash', { slot: 'start' })} Remove
+                            </wa-button>`
+                          : nothing
+                      }
                       <wa-button
                         appearance="outlined"
                         variant="neutral"
@@ -314,15 +314,15 @@ export class GitTab extends LitElement {
                       </li>
                     </ol>
                     ${
-                    this.githubTokenStatus === 'env'
-                      ? html`<p>
-                          A token is currently being read from the
-                          <code>GITHUB_TOKEN</code> or <code>GH_TOKEN</code>
-                          environment variable. Setting one above will override
-                          it.
-                        </p>`
-                      : nothing
-                  }
+                      this.githubTokenStatus === 'env'
+                        ? html`<p>
+                            A token is currently being read from the
+                            <code>GITHUB_TOKEN</code> or <code>GH_TOKEN</code>
+                            environment variable. Setting one above will
+                            override it.
+                          </p>`
+                        : nothing
+                    }
                   </div>
                 </div>
               `
@@ -347,39 +347,39 @@ export class GitTab extends LitElement {
                   </p>
                   <ul class="subscriptions-list">
                     ${this.prSubscriptions.map(
-                    (subscription) => html`
-                      <li>
-                        <div class="subscription-meta">
-                          <code class="subscription-key"
-                            >${subscription.key}</code
-                          >
-                          ${
+                      (subscription) => html`
+                        <li>
+                          <div class="subscription-meta">
+                            <code class="subscription-key"
+                              >${subscription.key}</code
+                            >
+                            ${
                             subscription.owners.length > 0
                               ? html`
                                   <div class="subscription-owners">
                                     ${subscription.owners.map(
-                                    (owner) => html`
-                                      <div class="subscription-owner-row">
-                                        <span class="subscription-owner-label"
-                                          >${owner.label}</span
-                                        >
-                                        <wa-button
-                                          appearance="outlined"
-                                          variant="neutral"
-                                          size="small"
-                                          @click=${() =>
+                                      (owner) => html`
+                                        <div class="subscription-owner-row">
+                                          <span class="subscription-owner-label"
+                                            >${owner.label}</span
+                                          >
+                                          <wa-button
+                                            appearance="outlined"
+                                            variant="neutral"
+                                            size="small"
+                                            @click=${() =>
                                             this.handleOpenPRSubscriptionStream(
                                               owner.streamId,
                                             )}
-                                        >
-                                          ${waIcon('comment-discussion', {
+                                          >
+                                            ${waIcon('comment-discussion', {
                                             slot: 'start',
                                           })}
-                                          Jump to agent
-                                        </wa-button>
-                                      </div>
-                                    `,
-                                  )}
+                                            Jump to agent
+                                          </wa-button>
+                                        </div>
+                                      `,
+                                    )}
                                   </div>
                                 `
                               : html`
@@ -389,19 +389,19 @@ export class GitTab extends LitElement {
                                   </p>
                                 `
                           }
-                        </div>
-                        <wa-button
-                          appearance="outlined"
-                          variant="neutral"
-                          size="small"
-                          @click=${() =>
+                          </div>
+                          <wa-button
+                            appearance="outlined"
+                            variant="neutral"
+                            size="small"
+                            @click=${() =>
                             this.handleUnsubscribePR(subscription.key)}
-                        >
-                          ${waIcon('debug-stop', { slot: 'start' })} Stop
-                        </wa-button>
-                      </li>
-                    `,
-                  )}
+                          >
+                            ${waIcon('debug-stop', { slot: 'start' })} Stop
+                          </wa-button>
+                        </li>
+                      `,
+                    )}
                   </ul>
                 </div>
               `

--- a/packages/extension/src/settingsView/frontend/tabs/GoalTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GoalTab.ts
@@ -150,9 +150,11 @@ export class GoalTab extends LitElement {
       <div
         class=${'goal-row' + (inFlight ? ' is-clickable' : '')}
         @click=${inFlight ? () => this.handleReveal(item.streamId) : null}
-        @keydown=${inFlight
-          ? (e: KeyboardEvent) => this.handleRowKey(e, item.streamId)
-          : null}
+        @keydown=${
+          inFlight
+            ? (e: KeyboardEvent) => this.handleRowKey(e, item.streamId)
+            : null
+        }
         role=${inFlight ? 'button' : 'group'}
         tabindex=${inFlight ? 0 : -1}
       >
@@ -177,20 +179,22 @@ export class GoalTab extends LitElement {
     return html`
       <div class="tab-content-container">
         ${this.renderReminder()}
-        ${this.items.length === 0
-          ? html`<div class="empty-state">
-              ${waIcon('compass')}
-              <p>No Goals yet.</p>
-            </div>`
-          : html`
-              <div class="goal-list">
-                ${repeat(
+        ${
+          this.items.length === 0
+            ? html`<div class="empty-state">
+                ${waIcon('compass')}
+                <p>No Goals yet.</p>
+              </div>`
+            : html`
+                <div class="goal-list">
+                  ${repeat(
                   this.items,
                   (it) => it.goalId,
                   (it) => this.renderRow(it),
                 )}
-              </div>
-            `}
+                </div>
+              `
+        }
       </div>
     `;
   }

--- a/packages/extension/src/settingsView/frontend/tabs/GoalTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GoalTab.ts
@@ -188,10 +188,10 @@ export class GoalTab extends LitElement {
             : html`
                 <div class="goal-list">
                   ${repeat(
-                  this.items,
-                  (it) => it.goalId,
-                  (it) => this.renderRow(it),
-                )}
+                    this.items,
+                    (it) => it.goalId,
+                    (it) => this.renderRow(it),
+                  )}
                 </div>
               `
         }

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -315,12 +315,12 @@ export class LaTeXTab extends LitElement {
                       size="small"
                       title="${dep.actionLabel ?? 'Install'}"
                       @click=${() =>
-                      this.dispatchEvent(
-                        new CustomEvent(dep.actionEvent!, {
-                          bubbles: true,
-                          composed: true,
-                        }),
-                      )}
+                        this.dispatchEvent(
+                          new CustomEvent(dep.actionEvent!, {
+                            bubbles: true,
+                            composed: true,
+                          }),
+                        )}
                     >
                       ${waIcon('cloud-download', { slot: 'start' })}
                       ${dep.actionLabel ?? 'Install'}
@@ -530,8 +530,8 @@ export class LaTeXTab extends LitElement {
                 </div>
 
                 ${RECOMMENDED_SETTINGS.map((info) =>
-                this.renderSettingCard(info),
-              )}
+                  this.renderSettingCard(info),
+                )}
               `
         }
         ${this.renderInlineCriticismSetting()}

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -304,60 +304,66 @@ export class LaTeXTab extends LitElement {
               (p) => html`<div class="dependency-path">${p}</div>`,
             )}
           </div>
-          ${installed
-            ? nothing
-            : dep.actionEvent
-              ? html`
-                  <wa-button
-                    appearance="outlined"
-                    variant="neutral"
-                    size="small"
-                    title="${dep.actionLabel ?? 'Install'}"
-                    @click=${() =>
+          ${
+            installed
+              ? nothing
+              : dep.actionEvent
+                ? html`
+                    <wa-button
+                      appearance="outlined"
+                      variant="neutral"
+                      size="small"
+                      title="${dep.actionLabel ?? 'Install'}"
+                      @click=${() =>
                       this.dispatchEvent(
                         new CustomEvent(dep.actionEvent!, {
                           bubbles: true,
                           composed: true,
                         }),
                       )}
-                  >
-                    ${waIcon('cloud-download', { slot: 'start' })}
-                    ${dep.actionLabel ?? 'Install'}
-                  </wa-button>
-                `
-              : html`<wa-tag
-                  class="setting-badge"
-                  variant="neutral"
-                  size="small"
-                  >Not found</wa-tag
-                >`}
+                    >
+                      ${waIcon('cloud-download', { slot: 'start' })}
+                      ${dep.actionLabel ?? 'Install'}
+                    </wa-button>
+                  `
+                : html`<wa-tag
+                    class="setting-badge"
+                    variant="neutral"
+                    size="small"
+                    >Not found</wa-tag
+                  >`
+          }
         </div>
-        ${!installed && installCmd
-          ? html`
-              <div class="dependency-install-actions">
-                <wa-copy-button value=${installCmd.command}></wa-copy-button>
-                <wa-button
-                  appearance="outlined"
-                  variant="neutral"
-                  size="small"
-                  title="Run: ${installCmd.command}"
-                  @click=${() => this.handleRunInTerminal(installCmd.command)}
+        ${
+          !installed && installCmd
+            ? html`
+                <div class="dependency-install-actions">
+                  <wa-copy-button value=${installCmd.command}></wa-copy-button>
+                  <wa-button
+                    appearance="outlined"
+                    variant="neutral"
+                    size="small"
+                    title="Run: ${installCmd.command}"
+                    @click=${() => this.handleRunInTerminal(installCmd.command)}
+                  >
+                    ${waIcon('terminal', { slot: 'start' })} Run in Terminal
+                  </wa-button>
+                </div>
+              `
+            : nothing
+        }
+        ${
+          !installed && guideText
+            ? html`
+                <wa-details
+                  class="collapsible-quiet dependency-guide-details"
+                  summary="Installation Guide"
                 >
-                  ${waIcon('terminal', { slot: 'start' })} Run in Terminal
-                </wa-button>
-              </div>
-            `
-          : nothing}
-        ${!installed && guideText
-          ? html`
-              <wa-details
-                class="collapsible-quiet dependency-guide-details"
-                summary="Installation Guide"
-              >
-                <div class="dependency-guide">${guideText}</div>
-              </wa-details>
-            `
-          : nothing}
+                  <div class="dependency-guide">${guideText}</div>
+                </wa-details>
+              `
+            : nothing
+        }
       </div>
     `;
   }
@@ -412,9 +418,11 @@ export class LaTeXTab extends LitElement {
             appearance="outlined"
             variant="neutral"
             size="small"
-            title=${this.desktopHost
-              ? `Run ${pmName} installer`
-              : `Run ${pmName} installer in VS Code terminal`}
+            title=${
+              this.desktopHost
+                ? `Run ${pmName} installer`
+                : `Run ${pmName} installer in VS Code terminal`
+            }
             @click=${() => this.handleRunInTerminal(installCommand)}
           >
             ${waIcon('terminal', { slot: 'start' })} Run in Terminal
@@ -449,29 +457,31 @@ export class LaTeXTab extends LitElement {
           <div class="setting-value">${info.value}</div>
           <div class="setting-description">${info.description}</div>
         </div>
-        ${isSet
-          ? html`
-              <wa-button
-                appearance="outlined"
-                variant="neutral"
-                size="small"
-                title="Reset this setting to default"
-                @click=${() => this.handleApply(info.key, true)}
-              >
-                ${waIcon('discard', { slot: 'start' })} Reset
-              </wa-button>
-            `
-          : html`
-              <wa-button
-                appearance="outlined"
-                variant="neutral"
-                size="small"
-                title="Apply this setting"
-                @click=${() => this.handleApply(info.key)}
-              >
-                ${waIcon('check', { slot: 'start' })} Apply
-              </wa-button>
-            `}
+        ${
+          isSet
+            ? html`
+                <wa-button
+                  appearance="outlined"
+                  variant="neutral"
+                  size="small"
+                  title="Reset this setting to default"
+                  @click=${() => this.handleApply(info.key, true)}
+                >
+                  ${waIcon('discard', { slot: 'start' })} Reset
+                </wa-button>
+              `
+            : html`
+                <wa-button
+                  appearance="outlined"
+                  variant="neutral"
+                  size="small"
+                  title="Apply this setting"
+                  @click=${() => this.handleApply(info.key)}
+                >
+                  ${waIcon('check', { slot: 'start' })} Apply
+                </wa-button>
+              `
+        }
       </div>
     `;
   }
@@ -487,39 +497,43 @@ export class LaTeXTab extends LitElement {
 
     return html`
       <div class="tab-content-container">
-        ${!this.desktopHost && !this.allSettingsSet()
-          ? html`
-              <div class="latex-header">
-                <wa-button
-                  appearance="outlined"
-                  variant="neutral"
-                  size="small"
-                  title="Apply all recommended settings"
-                  @click=${() => this.handleApply()}
-                >
-                  ${waIcon('check-all', { slot: 'start' })} Apply All
-                </wa-button>
-              </div>
-            `
-          : nothing}
+        ${
+          !this.desktopHost && !this.allSettingsSet()
+            ? html`
+                <div class="latex-header">
+                  <wa-button
+                    appearance="outlined"
+                    variant="neutral"
+                    size="small"
+                    title="Apply all recommended settings"
+                    @click=${() => this.handleApply()}
+                  >
+                    ${waIcon('check-all', { slot: 'start' })} Apply All
+                  </wa-button>
+                </div>
+              `
+            : nothing
+        }
         ${this.renderDependencies()}
-        ${this.desktopHost
-          ? nothing
-          : html`
-              <div class="section-header spaced">
-                ${waIcon('settings-gear')} Recommended Settings
-              </div>
+        ${
+          this.desktopHost
+            ? nothing
+            : html`
+                <div class="section-header spaced">
+                  ${waIcon('settings-gear')} Recommended Settings
+                </div>
 
-              <div class="latex-description">
-                Agents create temporary files during compilation. The following
-                VS Code settings are recommended to keep your workspace tidy and
-                avoid distracting sidebar activity.
-              </div>
+                <div class="latex-description">
+                  Agents create temporary files during compilation. The
+                  following VS Code settings are recommended to keep your
+                  workspace tidy and avoid distracting sidebar activity.
+                </div>
 
-              ${RECOMMENDED_SETTINGS.map((info) =>
+                ${RECOMMENDED_SETTINGS.map((info) =>
                 this.renderSettingCard(info),
               )}
-            `}
+              `
+        }
         ${this.renderInlineCriticismSetting()}
         ${this.renderCompileDiffSettings()}
       </div>
@@ -688,9 +702,14 @@ export class LaTeXTab extends LitElement {
           }}
           title="Toggle"
         ></wa-switch>
-        ${isCustom
-          ? this.renderResetButton(opts.field, opts.defaultValue ? 'On' : 'Off')
-          : nothing}
+        ${
+          isCustom
+            ? this.renderResetButton(
+                opts.field,
+                opts.defaultValue ? 'On' : 'Off',
+              )
+            : nothing
+        }
       </div>
     `;
   }
@@ -765,9 +784,11 @@ export class LaTeXTab extends LitElement {
             class="setting-number-input"
           ></wa-input>
         </div>
-        ${isCustom
-          ? this.renderResetButton(opts.field, String(opts.defaultValue))
-          : nothing}
+        ${
+          isCustom
+            ? this.renderResetButton(opts.field, String(opts.defaultValue))
+            : nothing
+        }
       </div>
     `;
   }
@@ -805,9 +826,11 @@ export class LaTeXTab extends LitElement {
             )}
           </wa-select>
         </div>
-        ${isCustom
-          ? this.renderResetButton(opts.field, String(opts.defaultValue))
-          : nothing}
+        ${
+          isCustom
+            ? this.renderResetButton(opts.field, String(opts.defaultValue))
+            : nothing
+        }
       </div>
     `;
   }

--- a/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
@@ -116,9 +116,7 @@ export class ModelsTab extends LitElement {
 
   private scrollToSection(
     selector:
-      | 'api-access-section'
-      | 'provider-key-list'
-      | '#chatgpt-subscription',
+      'api-access-section' | 'provider-key-list' | '#chatgpt-subscription',
   ): void {
     const el = this.shadowRoot?.querySelector(selector);
     if (el instanceof HTMLElement) {
@@ -281,26 +279,28 @@ export class ModelsTab extends LitElement {
             Use subscription for tool-use agents only
           </wa-switch>
         </div>
-        ${signedIn
-          ? html`<div class="chatgpt-subscription__row">
-              <span class="chatgpt-subscription__account">
-                ${waIcon('circle-check')} Signed in as ${account}
-              </span>
-              <wa-button
-                appearance="outlined"
+        ${
+          signedIn
+            ? html`<div class="chatgpt-subscription__row">
+                <span class="chatgpt-subscription__account">
+                  ${waIcon('circle-check')} Signed in as ${account}
+                </span>
+                <wa-button
+                  appearance="outlined"
+                  size="small"
+                  @click=${() => this.dispatchEvent(ChatGptAuthEvents.signOut())}
+                >
+                  Sign out
+                </wa-button>
+              </div>`
+            : html`<wa-button
+                variant="brand"
                 size="small"
-                @click=${() => this.dispatchEvent(ChatGptAuthEvents.signOut())}
+                @click=${() => this.dispatchEvent(ChatGptAuthEvents.signIn())}
               >
-                Sign out
-              </wa-button>
-            </div>`
-          : html`<wa-button
-              variant="brand"
-              size="small"
-              @click=${() => this.dispatchEvent(ChatGptAuthEvents.signIn())}
-            >
-              Sign in with ChatGPT
-            </wa-button>`}
+                Sign in with ChatGPT
+              </wa-button>`
+        }
       </section>
     `;
   }

--- a/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -313,20 +313,20 @@ export class MultiAgentTab extends LitElement {
           orchestratorAgents.length > 0
             ? html`<div class="preset-card-orchestrators">
                 ${orchestratorAgents.map(
-                (name) => html`
-                  <wa-tag
-                    class="preset-agent-badge preset-agent-badge--orchestrator"
-                    variant="brand"
-                    size="small"
-                    title="${name} is the orchestrator for this team"
-                  >
-                    <span class="preset-orchestrator-icon" aria-hidden="true"
-                      >${waIcon('bullseye')}</span
+                  (name) => html`
+                    <wa-tag
+                      class="preset-agent-badge preset-agent-badge--orchestrator"
+                      variant="brand"
+                      size="small"
+                      title="${name} is the orchestrator for this team"
                     >
-                    ${name}
-                  </wa-tag>
-                `,
-              )}
+                      <span class="preset-orchestrator-icon" aria-hidden="true"
+                        >${waIcon('bullseye')}</span
+                      >
+                      ${name}
+                    </wa-tag>
+                  `,
+                )}
               </div>`
             : nothing
         }

--- a/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -296,20 +296,23 @@ export class MultiAgentTab extends LitElement {
         <div class="preset-card-header">
           ${waIcon(preset.icon, { className: 'preset-card-icon' })}
           <span class="preset-card-name">${preset.name}</span>
-          ${isActive
-            ? html`<wa-tag
-                class="preset-active-badge"
-                variant="brand"
-                size="small"
-              >
-                ${waIcon('check')} Active
-              </wa-tag>`
-            : nothing}
+          ${
+            isActive
+              ? html`<wa-tag
+                  class="preset-active-badge"
+                  variant="brand"
+                  size="small"
+                >
+                  ${waIcon('check')} Active
+                </wa-tag>`
+              : nothing
+          }
         </div>
         <p class="preset-card-description">${preset.description}</p>
-        ${orchestratorAgents.length > 0
-          ? html`<div class="preset-card-orchestrators">
-              ${orchestratorAgents.map(
+        ${
+          orchestratorAgents.length > 0
+            ? html`<div class="preset-card-orchestrators">
+                ${orchestratorAgents.map(
                 (name) => html`
                   <wa-tag
                     class="preset-agent-badge preset-agent-badge--orchestrator"
@@ -324,8 +327,9 @@ export class MultiAgentTab extends LitElement {
                   </wa-tag>
                 `,
               )}
-            </div>`
-          : nothing}
+              </div>`
+            : nothing
+        }
         <div class="preset-card-agents">
           ${teammateAgents.map(
             (name) =>
@@ -337,19 +341,21 @@ export class MultiAgentTab extends LitElement {
               >`,
           )}
         </div>
-        ${deletable
-          ? html`<wa-button
-              class="preset-delete-btn"
-              appearance="plain"
-              variant="neutral"
-              size="small"
-              @click=${(e: Event) => this.handleDeletePreset(e, preset)}
-              title="Delete team"
-              aria-label="Delete team"
-            >
-              ${waIcon('trash')}
-            </wa-button>`
-          : nothing}
+        ${
+          deletable
+            ? html`<wa-button
+                class="preset-delete-btn"
+                appearance="plain"
+                variant="neutral"
+                size="small"
+                @click=${(e: Event) => this.handleDeletePreset(e, preset)}
+                title="Delete team"
+                aria-label="Delete team"
+              >
+                ${waIcon('trash')}
+              </wa-button>`
+            : nothing
+        }
       </div>
     `;
   }

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -282,14 +282,14 @@ export class ToolsTab extends LitElement {
               Enable native crash reporting
             </wa-switch>
             <wa-tag
-              variant=${this.desktopCrashReportingConfigured
-                ? 'success'
-                : 'warning'}
+              variant=${
+                this.desktopCrashReportingConfigured ? 'success' : 'warning'
+              }
               size="small"
             >
-              ${this.desktopCrashReportingConfigured
-                ? 'DSN set'
-                : 'DSN missing'}
+              ${
+                this.desktopCrashReportingConfigured ? 'DSN set' : 'DSN missing'
+              }
             </wa-tag>
             <wa-button
               appearance="outlined"
@@ -298,9 +298,9 @@ export class ToolsTab extends LitElement {
               @click=${this.handleSetDesktopCrashReportingDsn}
             >
               ${waIcon('key', { slot: 'start' })}
-              ${this.desktopCrashReportingConfigured
-                ? 'Replace DSN'
-                : 'Set DSN'}
+              ${
+                this.desktopCrashReportingConfigured ? 'Replace DSN' : 'Set DSN'
+              }
             </wa-button>
           </div>
         </div>
@@ -360,29 +360,33 @@ export class ToolsTab extends LitElement {
               stroke-dasharray="${circ}"
               stroke-dashoffset="${availOffset}"
             />
-            ${missing > 0
-              ? html`<circle
-                  class="tools-health-ring__missing"
-                  cx="18"
-                  cy="18"
-                  r="${r}"
-                  stroke-dasharray="${circ}"
-                  stroke-dashoffset="${missOffset}"
-                  style=${styleMap({ transform: `rotate(${missRotation}deg)` })}
-                />`
-              : nothing}
+            ${
+              missing > 0
+                ? html`<circle
+                    class="tools-health-ring__missing"
+                    cx="18"
+                    cy="18"
+                    r="${r}"
+                    stroke-dasharray="${circ}"
+                    stroke-dashoffset="${missOffset}"
+                    style=${styleMap({ transform: `rotate(${missRotation}deg)` })}
+                  />`
+                : nothing
+            }
           </svg>
           <div class="tools-health-labels">
             <span class="tools-summary-stat tools-stat-available">
               ${waIcon('check')} ${available} available
             </span>
-            ${missing > 0
-              ? html`
-                  <span class="tools-summary-stat tools-stat-missing">
-                    ${waIcon('warning')} ${missing} need setup
-                  </span>
-                `
-              : nothing}
+            ${
+              missing > 0
+                ? html`
+                    <span class="tools-summary-stat tools-stat-missing">
+                      ${waIcon('warning')} ${missing} need setup
+                    </span>
+                  `
+                : nothing
+            }
           </div>
         </div>
       </div>

--- a/packages/extension/src/webview/MainViewMessageHandler.ts
+++ b/packages/extension/src/webview/MainViewMessageHandler.ts
@@ -61,6 +61,7 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
   private readonly instructionManager: InstructionManager;
   private readonly interactionController: MainViewInteractionController;
   private readonly startupController: MainViewStartupController;
+  private readonly handlerRegistry: MainViewInboundHandlerRegistry;
 
   constructor(
     private readonly context: vscode.ExtensionContext,
@@ -87,42 +88,39 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       loadOptions,
       getAuthStatus,
     });
+    this.handlerRegistry = this.createHandlerRegistry();
   }
 
   public override async handleMessage(
     message: unknown,
     webviewView: vscode.WebviewView,
   ): Promise<void> {
-    await this.withActiveView(webviewView, async () => {
-      this.fileManager.attachWebview(webviewView);
-      this.instructionManager.attachWebview(webviewView);
-      this.diffManager.attachWebview(webviewView);
-
-      const handled = dispatchMainViewInbound(
-        message,
-        this.createHandlerRegistry(webviewView),
-        (error) => {
-          this.logger.error(
-            this.channel,
-            `Error handling message: ${toErrorMessage(error)}`,
-          );
-        },
-      );
-
-      if (!handled) {
-        await super.handleMessage(message, webviewView);
-      }
-    });
+    await this.dispatchInbound(
+      message,
+      webviewView,
+      dispatchMainViewInbound,
+      this.handlerRegistry,
+    );
   }
 
-  private createHandlerRegistry(
-    webviewView: vscode.WebviewView,
-  ): MainViewInboundHandlerRegistry {
+  /** Attaches the current webview to the sub-managers before dispatch. */
+  protected override onDispatch(webviewView: vscode.WebviewView): void {
+    this.fileManager.attachWebview(webviewView);
+    this.instructionManager.attachWebview(webviewView);
+    this.diffManager.attachWebview(webviewView);
+  }
+
+  private createHandlerRegistry(): MainViewInboundHandlerRegistry {
     return {
       // Common messages
-      [MAIN_VIEW_COMMANDS.THEME_SET]: (m) => this.handleTheme(m, webviewView),
-      [MAIN_VIEW_COMMANDS.DEBUG_MODE_SET]: (m) =>
-        this.handleDebugMode(m, webviewView),
+      [MAIN_VIEW_COMMANDS.THEME_SET]: (m) => {
+        const view = this.getActiveView();
+        if (view) return this.handleTheme(m, view);
+      },
+      [MAIN_VIEW_COMMANDS.DEBUG_MODE_SET]: (m) => {
+        const view = this.getActiveView();
+        if (view) return this.handleDebugMode(m, view);
+      },
       [MAIN_VIEW_COMMANDS.WEBVIEW_READY]: () => this.handleWebviewReady(),
       [MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE]: (m) => {
         vscode.window.showInformationMessage(m.text);
@@ -236,10 +234,14 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       [MAIN_VIEW_COMMANDS.CLIPBOARD_IMAGE]: (m) =>
         this.instructionManager.handleClipboardImage(m),
 
-      [MAIN_VIEW_COMMANDS.START_RECORDING]: () =>
-        this.recordingManager.start(webviewView),
-      [MAIN_VIEW_COMMANDS.STOP_RECORDING]: () =>
-        this.recordingManager.stop(webviewView),
+      [MAIN_VIEW_COMMANDS.START_RECORDING]: () => {
+        const view = this.getActiveView();
+        if (view) return this.recordingManager.start(view);
+      },
+      [MAIN_VIEW_COMMANDS.STOP_RECORDING]: () => {
+        const view = this.getActiveView();
+        if (view) return this.recordingManager.stop(view);
+      },
 
       [MAIN_VIEW_COMMANDS.OPEN_SET_API_KEY]: async () => {
         await safeExecuteCommand('texra.setApiKey');

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -1764,8 +1764,9 @@ export class MainApp extends MainAppBase {
               @welcome-chatgpt=${this.onWelcomeChatGpt}
               @welcome-api-key=${this.onWelcomeApiKey}
               @welcome-skip=${this.onWelcomeSkip}
-              @onboarding-open-getting-started=${this
-                .onOnboardingOpenGettingStarted}
+              @onboarding-open-getting-started=${
+                this.onOnboardingOpenGettingStarted
+              }
             ></onboarding-welcome-card>
           </div>
         </div>
@@ -1793,14 +1794,17 @@ export class MainApp extends MainAppBase {
         ${this.renderViewHeader()}
 
         <div class="main-content">
-          ${onboardingState === 'setup'
-            ? html`<onboarding-setup-card
-                @onboarding-run-setup=${this.onOnboardingRunSetup}
-                @onboarding-open-getting-started=${this
-                  .onOnboardingOpenGettingStarted}
-                @onboarding-skip-setup=${this.onOnboardingSkipSetup}
-              ></onboarding-setup-card>`
-            : nothing}
+          ${
+            onboardingState === 'setup'
+              ? html`<onboarding-setup-card
+                  @onboarding-run-setup=${this.onOnboardingRunSetup}
+                  @onboarding-open-getting-started=${
+                  this.onOnboardingOpenGettingStarted
+                }
+                  @onboarding-skip-setup=${this.onOnboardingSkipSetup}
+                ></onboarding-setup-card>`
+              : nothing
+          }
 
           <instruction-panel
             .showSessionHint=${!this.sessionHintDismissed.get()}
@@ -1822,8 +1826,10 @@ export class MainApp extends MainAppBase {
             .apiKeyBanner=${akb}
             .agentConfigBanner=${acb}
             .dependencyBanner=${db}
-            .gettingStartedVisible=${this.gettingStartedVisible.get() &&
-            !this.gettingStartedDismissed.get()}
+            .gettingStartedVisible=${
+              this.gettingStartedVisible.get() &&
+              !this.gettingStartedDismissed.get()
+            }
             .loginBannerVisible=${this.loginBannerVisible.get()}
             @api-key-action=${this.onApiKeyAction}
             @agent-config-action=${this.onAgentConfigAction}
@@ -1879,29 +1885,31 @@ export class MainApp extends MainAppBase {
           </wa-details>
         </div>
 
-        ${this.isDesktopHost
-          ? nothing
-          : html`
-              <latexdiffs-section
-                .visible=${this.latexdiffsVisible.get()}
-                .baseFile=${sf.baseFile}
-                .baseFileOptions=${fo.baseFile ?? []}
-                .editedFile=${sf.editedFile}
-                .editedFileOptions=${fo.editedFile ?? []}
-                .commit=${this.commit.get()}
-                .commitOptions=${fo.commit ?? []}
-                .isGitRepo=${this.isGitRepo.get()}
-                @latexdiffs-toggle=${this.onLatexDiffsToggle}
-                @latexdiffs-action=${this.onLatexDiffsAction}
-                @base-file-change=${this.onBaseFileChange}
-                @edited-file-change=${this.onEditedFileChange}
-                @get-current-file=${this.onLatexdiffGetCurrentFile}
-                @empty-file=${this.onLatexdiffEmptyFile}
-                @refresh-edited-files=${this.onRefreshEditedFiles}
-                @commit-change=${this.onCommitChange}
-                @refresh-commits=${this.onRefreshCommits}
-              ></latexdiffs-section>
-            `}
+        ${
+          this.isDesktopHost
+            ? nothing
+            : html`
+                <latexdiffs-section
+                  .visible=${this.latexdiffsVisible.get()}
+                  .baseFile=${sf.baseFile}
+                  .baseFileOptions=${fo.baseFile ?? []}
+                  .editedFile=${sf.editedFile}
+                  .editedFileOptions=${fo.editedFile ?? []}
+                  .commit=${this.commit.get()}
+                  .commitOptions=${fo.commit ?? []}
+                  .isGitRepo=${this.isGitRepo.get()}
+                  @latexdiffs-toggle=${this.onLatexDiffsToggle}
+                  @latexdiffs-action=${this.onLatexDiffsAction}
+                  @base-file-change=${this.onBaseFileChange}
+                  @edited-file-change=${this.onEditedFileChange}
+                  @get-current-file=${this.onLatexdiffGetCurrentFile}
+                  @empty-file=${this.onLatexdiffEmptyFile}
+                  @refresh-edited-files=${this.onRefreshEditedFiles}
+                  @commit-change=${this.onCommitChange}
+                  @refresh-commits=${this.onRefreshCommits}
+                ></latexdiffs-section>
+              `
+        }
       </div>
     `;
   }

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -1799,8 +1799,8 @@ export class MainApp extends MainAppBase {
               ? html`<onboarding-setup-card
                   @onboarding-run-setup=${this.onOnboardingRunSetup}
                   @onboarding-open-getting-started=${
-                  this.onOnboardingOpenGettingStarted
-                }
+                    this.onOnboardingOpenGettingStarted
+                  }
                   @onboarding-skip-setup=${this.onOnboardingSkipSetup}
                 ></onboarding-setup-card>`
               : nothing

--- a/packages/extension/src/webview/frontend/components/AgentConfigBanner.ts
+++ b/packages/extension/src/webview/frontend/components/AgentConfigBanner.ts
@@ -32,9 +32,11 @@ export class AgentConfigBanner extends StateVisibleBanner<AgentConfigBannerState
       id: 'agentConfigBanner',
       body: html`
         <span>
-          ${this.state.agentName
-            ? `Agent file for "${this.state.agentName}" is missing.`
-            : 'Agent configuration is missing.'}
+          ${
+            this.state.agentName
+              ? `Agent file for "${this.state.agentName}" is missing.`
+              : 'Agent configuration is missing.'
+          }
         </span>
         <div class="actions">
           <wa-button

--- a/packages/extension/src/webview/frontend/components/ApiKeyBanner.ts
+++ b/packages/extension/src/webview/frontend/components/ApiKeyBanner.ts
@@ -32,9 +32,11 @@ export class ApiKeyBanner extends StateVisibleBanner<ApiKeyBannerState> {
       id: 'apiKeyBanner',
       body: html`
         <span>
-          ${provider
-            ? html`<strong>${providerLabel}</strong> API key missing.`
-            : 'TeXRA requires an API key to run.'}
+          ${
+            provider
+              ? html`<strong>${providerLabel}</strong> API key missing.`
+              : 'TeXRA requires an API key to run.'
+          }
         </span>
         <div class="actions">
           <wa-button

--- a/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
+++ b/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
@@ -142,8 +142,7 @@ export class FileSelectGroup extends LitElement {
   ): void => {
     event.preventDefault();
     const item = event.detail?.item as
-      | (HTMLElement & { value?: string; checked?: boolean })
-      | undefined;
+      (HTMLElement & { value?: string; checked?: boolean }) | undefined;
     const id = item?.value;
     if (!id) return;
     this.handleCheckboxChange(id, Boolean(item?.checked));
@@ -255,11 +254,13 @@ export class FileSelectGroup extends LitElement {
             <div class="file-item" data-path=${file} title=${file}>
               <span class="file-name">
                 <span class="file-name-main">${display.name}</span>
-                ${display.folder
-                  ? html`<span class="file-folder">
-                      ${waIcon('folder')} ${display.folder}
-                    </span>`
-                  : nothing}
+                ${
+                  display.folder
+                    ? html`<span class="file-folder">
+                        ${waIcon('folder')} ${display.folder}
+                      </span>`
+                    : nothing
+                }
               </span>
               <wa-button
                 id=${removeButtonId}
@@ -316,17 +317,25 @@ export class FileSelectGroup extends LitElement {
             </span>
             <label id="${this.listId}Label">${config.label}</label>
             <wa-tooltip for="${this.listId}Label">${config.tooltip}</wa-tooltip>
-            ${config.toolConfig === 'tool'
-              ? this.renderToolConfigMenu()
-              : nothing}
-            ${config.toolConfig === 'autoExtract'
-              ? this.renderAutoExtractMenu()
-              : nothing}
-            ${config.description
-              ? html`<span class="file-select-hint" title=${config.description}
-                  >${config.description}</span
-                >`
-              : nothing}
+            ${
+              config.toolConfig === 'tool'
+                ? this.renderToolConfigMenu()
+                : nothing
+            }
+            ${
+              config.toolConfig === 'autoExtract'
+                ? this.renderAutoExtractMenu()
+                : nothing
+            }
+            ${
+              config.description
+                ? html`<span
+                    class="file-select-hint"
+                    title=${config.description}
+                    >${config.description}</span
+                  >`
+                : nothing
+            }
           </div>
           <div class="file-select-actions">
             ${renderIconActionButton({

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -366,20 +366,20 @@ export class InstructionPanel extends LitElement {
               session.debugMode
                 ? html`
                     ${renderIconActionButton({
-                    id: 'packButton',
-                    icon: 'archive',
-                    label: 'Pack output to History',
-                    tooltip:
-                      'Pack the output for this agent into the History folder',
-                    action: 'pack',
-                  })}
+                      id: 'packButton',
+                      icon: 'archive',
+                      label: 'Pack output to History',
+                      tooltip:
+                        'Pack the output for this agent into the History folder',
+                      action: 'pack',
+                    })}
                     ${renderIconActionButton({
-                    id: 'cleanButton',
-                    icon: 'trash',
-                    label: 'Clean output',
-                    tooltip: 'Clean the output for this agent',
-                    action: 'clean',
-                  })}
+                      id: 'cleanButton',
+                      icon: 'trash',
+                      label: 'Clean output',
+                      tooltip: 'Clean the output for this agent',
+                      action: 'clean',
+                    })}
                   `
                 : nothing
             }

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -362,9 +362,10 @@ export class InstructionPanel extends LitElement {
             class="instruction-header-actions"
             @click=${this.handleActionClick}
           >
-            ${session.debugMode
-              ? html`
-                  ${renderIconActionButton({
+            ${
+              session.debugMode
+                ? html`
+                    ${renderIconActionButton({
                     id: 'packButton',
                     icon: 'archive',
                     label: 'Pack output to History',
@@ -372,15 +373,16 @@ export class InstructionPanel extends LitElement {
                       'Pack the output for this agent into the History folder',
                     action: 'pack',
                   })}
-                  ${renderIconActionButton({
+                    ${renderIconActionButton({
                     id: 'cleanButton',
                     icon: 'trash',
                     label: 'Clean output',
                     tooltip: 'Clean the output for this agent',
                     action: 'clean',
                   })}
-                `
-              : nothing}
+                  `
+                : nothing
+            }
             ${renderIconActionButton({
               id: 'magicPolishButton',
               icon: 'sparkle',
@@ -450,10 +452,10 @@ export class InstructionPanel extends LitElement {
                 placement="top"
                 aria-label="Model"
                 placeholder="Select model…"
-                title=${this.getModelTooltip(
-                  session.modelOptions,
-                  session.model,
-                ) || nothing}
+                title=${
+                  this.getModelTooltip(session.modelOptions, session.model) ||
+                  nothing
+                }
                 .value=${session.model}
                 @focus=${this.handleModelFocus}
                 @change=${this.handleModelChange}

--- a/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
+++ b/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
@@ -275,9 +275,7 @@ export class LatexDiffsSection extends LitElement {
     if (!fileButton) return;
     const fileAction = fileButton.dataset.fileAction;
     const fileType = fileButton.dataset.fileType as
-      | 'base'
-      | 'edited'
-      | undefined;
+      'base' | 'edited' | undefined;
     if (!fileType) return;
     if (fileAction === 'current') {
       this.dispatchEvent(MainViewEvents.getCurrentFile({ type: fileType }));

--- a/packages/extension/vite.config.ts
+++ b/packages/extension/vite.config.ts
@@ -52,8 +52,7 @@ function createWebviewConfig(webviewName: string, isDev: boolean) {
  * If not specified, defaults to building all webviews sequentially via npm script.
  */
 const targetWebview = process.env.VITE_WEBVIEW as
-  | (typeof webviews)[number]
-  | undefined;
+  (typeof webviews)[number] | undefined;
 
 export default defineConfig(({ mode }) => {
   const isDev = mode === 'development';

--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -32,8 +32,7 @@ export type BaseCycleFields = z.infer<typeof BaseCycleFieldsSchema>;
 
 /** Result type for nodes that can be skipped based on flow state. */
 export type SkippableNodeResult<T> =
-  | { kind: 'skipped' }
-  | { kind: 'success'; value: T };
+  { kind: 'skipped' } | { kind: 'success'; value: T };
 
 /** Reset cycle state to initial values, plus any flow-specific fields to undefined. */
 export function resetCycleState<T extends BaseCycleFields>(

--- a/src/agent/core/state/AgentWorkspaceState.ts
+++ b/src/agent/core/state/AgentWorkspaceState.ts
@@ -168,9 +168,8 @@ export class FileInteractionState {
 
 const MediaFileEntrySchema = z
   .union([z.string(), FileLocationSchema])
-  .transform(
-    (entry): FileLocation =>
-      typeof entry === 'string' ? pathToLocation(entry) : entry,
+  .transform((entry): FileLocation =>
+    typeof entry === 'string' ? pathToLocation(entry) : entry,
   );
 
 /** Internal schema for media attachment state snapshot. */

--- a/src/agent/core/usage/RunUsageAccumulator.ts
+++ b/src/agent/core/usage/RunUsageAccumulator.ts
@@ -71,21 +71,19 @@ const LegacyRunUsageAccumulatorSchema = z
         .catch({ usage: null }),
     ),
   })
-  .transform(
-    (legacy): RunUsageAccumulatorJSON => ({
-      totals: legacy.totals,
-      // Key-presence, not value-nullish: a hybrid payload carrying both an
-      // explicit `latestUsage` (even `null`, an already-migrated state) and
-      // snapshots must keep the canonical value. `.nullish()` parses an absent
-      // key as `undefined` and an explicit `null` as `null`, so `!== undefined`
-      // keeps an explicit null and only an absent key falls back to the latest
-      // snapshot. Matches the prior `'latestUsage' in raw` preprocess guard.
-      latestUsage:
-        legacy.latestUsage !== undefined
-          ? legacy.latestUsage
-          : (legacy.normalizedSnapshots.at(-1)?.usage ?? null),
-    }),
-  );
+  .transform((legacy): RunUsageAccumulatorJSON => ({
+    totals: legacy.totals,
+    // Key-presence, not value-nullish: a hybrid payload carrying both an
+    // explicit `latestUsage` (even `null`, an already-migrated state) and
+    // snapshots must keep the canonical value. `.nullish()` parses an absent
+    // key as `undefined` and an explicit `null` as `null`, so `!== undefined`
+    // keeps an explicit null and only an absent key falls back to the latest
+    // snapshot. Matches the prior `'latestUsage' in raw` preprocess guard.
+    latestUsage:
+      legacy.latestUsage !== undefined
+        ? legacy.latestUsage
+        : (legacy.normalizedSnapshots.at(-1)?.usage ?? null),
+  }));
 
 /**
  * Entry schema handling both formats in one place (per the backward-compat

--- a/src/agent/export/normalizeConversation.ts
+++ b/src/agent/export/normalizeConversation.ts
@@ -279,8 +279,7 @@ export function normalizeConversationForExport(
 
     // OpenAI Response API: top-level function_call items (not wrapped in a message)
     const responseToolCall = item as unknown as
-      | ResponseFunctionToolCallItem
-      | undefined;
+      ResponseFunctionToolCallItem | undefined;
     if (isResponseFunctionToolCallItem(responseToolCall)) {
       const args =
         typeof responseToolCall.arguments === 'string'

--- a/src/agent/followUp/FollowUpQueue.ts
+++ b/src/agent/followUp/FollowUpQueue.ts
@@ -9,8 +9,7 @@ import pDefer, { type DeferredPromise } from 'p-defer';
 /** Preserves visible follow-up provenance across queueing and resume replay. */
 export type VisibleFollowUpQueueItemOrigin = 'user' | 'subagent_result';
 export type FollowUpQueueItemOrigin =
-  | VisibleFollowUpQueueItemOrigin
-  | 'synthetic';
+  VisibleFollowUpQueueItemOrigin | 'synthetic';
 
 export interface FollowUpQueueInput {
   readonly text: string;

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -1,4 +1,5 @@
 import { Node } from '@agent/node';
+import { useLaunchRunContext } from '@agent/runtime/RunContext';
 import type { RoundFileMapping } from '@agent/output/types';
 import type { CompiledPdfArtifact } from '@agent/output/compiledPdfArtifacts';
 import type { LatexDiffManager } from '@agent/output/LatexDiffManager';
@@ -81,7 +82,7 @@ export class OutputNode<C = unknown> extends Node<
     // stats all see the same base locations (see snapshotResolution).
     const diffBaseFiles = await resolveBaseFilesForDiff(
       baseFiles,
-      this.services.executionId,
+      useLaunchRunContext().executionId,
     );
 
     let mapping: RoundFileMapping | undefined;
@@ -243,8 +244,8 @@ export class OutputNode<C = unknown> extends Node<
     prepRes: OutputPrepInput,
     execRes: OutputExecResult,
   ): Promise<string | undefined> {
-    const { streamId, outputState, runtimeHost, workflowOutputPolicy } =
-      this.services;
+    const { outputState, workflowOutputPolicy } = this.services;
+    const { streamId, runtimeHost } = useLaunchRunContext();
     const { outputLocation, currentRound, endTurn } = prepRes;
     const { summary, roundOutput } = execRes;
 

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -1,5 +1,6 @@
 import { Node } from '@agent/node';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
+import { useLaunchRunContext } from '@agent/runtime/RunContext';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import {
   createToolUseRoundFlow,
@@ -50,14 +51,8 @@ export class ToolUseCycleNode<C> extends Node<
   }
 
   async exec(prepRes: CyclePrepResult): Promise<ToolUseCycleOutcome> {
-    const {
-      streamId,
-      setting,
-      resolvedTools,
-      modelHandler,
-      config,
-      runtimeHost,
-    } = this.services;
+    const { setting, resolvedTools, modelHandler, config } = this.services;
+    const { streamId, runtimeHost } = useLaunchRunContext();
 
     if (prepRes.shouldSkip) {
       const { todos, plan } = prepRes.workspaceState.workPlan;

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -11,8 +11,7 @@ import type { ToolUseServices } from '../ToolUseServices';
 import type { ToolUseRunShared, PrepareResult } from './types';
 
 type PrepareExecResult =
-  | { kind: 'success'; result: PrepareResult }
-  | { kind: 'error'; error: Error };
+  { kind: 'success'; result: PrepareResult } | { kind: 'error'; error: Error };
 
 /**
  * Session-init node: runs **once per tool-use session** to build the initial

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -2,6 +2,7 @@ import { maybeBuildGoalContinuation } from '@agent/goal';
 import { Node } from '@agent/node';
 import { logUserMessage } from '@agent/trace';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
+import { useLaunchRunContext } from '@agent/runtime/RunContext';
 import {
   appendFollowUpAsUserMessage,
   followUpDisplayText,
@@ -53,12 +54,11 @@ export class ToolUseWaitNode<C> extends Node<
     const {
       checkInterruption,
       session,
-      streamId,
       streamStatus,
       onBeforeWaiting,
-      runtimeHost,
       isSubagent,
     } = this.services;
+    const { streamId, runtimeHost } = useLaunchRunContext();
 
     if (checkInterruption()) {
       if (prepRes.previouslyDeliveredToOrchestrator) {
@@ -149,8 +149,8 @@ export class ToolUseWaitNode<C> extends Node<
     prepRes: WaitPrepResult,
     execRes: WaitExecResult,
   ): Promise<string | undefined> {
-    const { onFollowUpConsumed, streamId, logger, runtimeHost, streamStatus } =
-      this.services;
+    const { onFollowUpConsumed, logger, streamStatus } = this.services;
+    const { streamId, runtimeHost } = useLaunchRunContext();
 
     if (execRes.kind === 'stop') {
       if (prepRes.deliveredToOrchestrator) {

--- a/src/agent/index/agentYamlScanner.ts
+++ b/src/agent/index/agentYamlScanner.ts
@@ -199,8 +199,7 @@ function scanYaml(
     const rawSettings = settingsBlock.value;
     const rawPrompts = promptsBlock.value;
     const defaultOutputFiles = rawSettings.defaultOutputFiles as
-      | string[]
-      | undefined;
+      string[] | undefined;
 
     const tools = extractToolNames(rawSettings.tools as unknown[] | undefined);
 

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -212,8 +212,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
       for (const block of extractDocumentBlocks(contentBlocks)) {
         const source = block.source as
-          | { type: string; file_id?: string }
-          | undefined;
+          { type: string; file_id?: string } | undefined;
         if (source?.type === 'file' && source.file_id) {
           liveFileIds.add(source.file_id);
         }
@@ -1253,8 +1252,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       );
       content.push(
         ...(thinkingBlocks as (
-          | ThinkingBlockParam
-          | RedactedThinkingBlockParam
+          ThinkingBlockParam | RedactedThinkingBlockParam
         )[]),
       );
       workspaceState.resetReasoning();
@@ -1453,8 +1451,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       ) {
         content.push(
           ...(workspaceState.reasoning.thinkingBlocks as (
-            | ThinkingBlockParam
-            | RedactedThinkingBlockParam
+            ThinkingBlockParam | RedactedThinkingBlockParam
           )[]),
         );
         workspaceState.resetReasoning();

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -2143,13 +2143,11 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
    * chat `toGoogleTools` wrapper (`[{ functionDeclarations }]`) is NOT reused.
    */
   private toInteractionsTools(defs: ToolDefinition[]): FunctionT[] {
-    return defs.map(
-      (d): FunctionT => ({
-        type: 'function',
-        name: d.name,
-        description: d.description,
-        parameters: convertToolSchema(d) ?? undefined,
-      }),
-    );
+    return defs.map((d): FunctionT => ({
+      type: 'function',
+      name: d.name,
+      description: d.description,
+      parameters: convertToolSchema(d) ?? undefined,
+    }));
   }
 }

--- a/src/agent/modelHandlers/openai/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerDeepSeek.ts
@@ -104,8 +104,7 @@ export class ModelHandlerDeepSeek extends ReasoningModelHandlerOpenAI<DeepSeekTo
    * else (`deepseek-reasoner`, V4 series) defaults ON.
    */
   protected override getThinkingParameter():
-    | { type: 'enabled' | 'disabled' }
-    | undefined {
+    { type: 'enabled' | 'disabled' } | undefined {
     const wantsThinking = this.capabilities.supportsReasoning;
     const defaultsOn = this.config.fullName !== 'deepseek-chat';
     if (defaultsOn === wantsThinking) return undefined;

--- a/src/agent/modelHandlers/openai/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerKimi.ts
@@ -45,8 +45,7 @@ export class ModelHandlerKimi extends ReasoningModelHandlerOpenAI {
   protected override readonly convertContentToStringUnlessVision = true;
 
   protected override getThinkingParameter():
-    | { type: 'enabled' | 'disabled' }
-    | undefined {
+    { type: 'enabled' | 'disabled' } | undefined {
     // Kimi K2.5 has thinking enabled by default on the Moonshot API.
     // Explicitly disable it for non-thinking variants.
     if (

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -241,8 +241,7 @@ export class ModelHandlerOpenAI<
    * @returns The thinking parameter object, or undefined to not send the parameter.
    */
   protected getThinkingParameter():
-    | { type: 'enabled' | 'disabled' }
-    | undefined {
+    { type: 'enabled' | 'disabled' } | undefined {
     return undefined;
   }
 
@@ -531,8 +530,7 @@ export class ModelHandlerOpenAI<
    * @returns Normalization options, or undefined to skip normalization
    */
   protected getMessageNormalizationOptions():
-    | NormalizeOpenAIMessageContentOptions
-    | undefined {
+    NormalizeOpenAIMessageContentOptions | undefined {
     const convertContentToString =
       this.convertContentToString ||
       (this.convertContentToStringUnlessVision &&

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -371,8 +371,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    */
   private pendingBackgroundResponseId: string | null = null;
   private pendingBackgroundRetrieveParams:
-    | ResponseRetrieveParamsNonStreaming
-    | undefined;
+    ResponseRetrieveParamsNonStreaming | undefined;
 
   /**
    * Guards against concurrent createResponse() calls on the same handler.

--- a/src/agent/modelHandlers/openai/openAIChatHelpers.ts
+++ b/src/agent/modelHandlers/openai/openAIChatHelpers.ts
@@ -14,8 +14,7 @@ function extractReasoningText(content: ReasoningContent | undefined): string {
 /** Extracts `reasoning_content` from a streaming chunk delta. */
 export function extractReasoningDelta(chunk: ChatCompletionChunk): string {
   const delta = chunk.choices[0]?.delta as
-    | { reasoning_content?: ReasoningContent }
-    | undefined;
+    { reasoning_content?: ReasoningContent } | undefined;
   if (!delta || !('reasoning_content' in delta)) return '';
   return extractReasoningText(delta.reasoning_content);
 }

--- a/src/agent/modelHandlers/openai/responseStreamEvents.ts
+++ b/src/agent/modelHandlers/openai/responseStreamEvents.ts
@@ -30,8 +30,7 @@ export function isResponseFunctionToolCallItem(
 export function isReasoningDeltaEvent(
   event: ResponseStreamEvent,
 ): event is
-  | ResponseReasoningTextDeltaEvent
-  | ResponseReasoningSummaryTextDeltaEvent {
+  ResponseReasoningTextDeltaEvent | ResponseReasoningSummaryTextDeltaEvent {
   return (
     event.type === 'response.reasoning_text.delta' ||
     event.type === 'response.reasoning_summary_text.delta'

--- a/src/agent/modelHandlers/types/ServerToolTypes.ts
+++ b/src/agent/modelHandlers/types/ServerToolTypes.ts
@@ -203,9 +203,7 @@ export function isOpenAIServerToolContent(
 export function isAnthropicServerToolContent(
   block: unknown,
 ): block is
-  | ServerToolUseBlock
-  | WebSearchToolResultBlock
-  | WebFetchToolResultBlock {
+  ServerToolUseBlock | WebSearchToolResultBlock | WebFetchToolResultBlock {
   return (
     isAnthropicServerToolUse(block) ||
     isAnthropicWebSearchResult(block) ||

--- a/src/agent/node/persistedFlow.ts
+++ b/src/agent/node/persistedFlow.ts
@@ -84,8 +84,7 @@ export class PersistedFlow<
    * Errors are swallowed — the authoritative flow blob is already written.
    */
   private projection:
-    | ((shared: S, kv: ExecutionKVStore) => Promise<void>)
-    | null = null;
+    ((shared: S, kv: ExecutionKVStore) => Promise<void>) | null = null;
 
   /**
    * Create a new PersistedFlow.

--- a/src/agent/review/reviewDiff.ts
+++ b/src/agent/review/reviewDiff.ts
@@ -70,8 +70,7 @@ export interface ReviewDiff {
 }
 
 export type CollectReviewDiffResult =
-  | { ok: true; value: ReviewDiff }
-  | { ok: false; reason: string };
+  { ok: true; value: ReviewDiff } | { ok: false; reason: string };
 
 function makeGit(cwd: string): SimpleGit {
   // makeMachineGitEnv() strips helper-invoking env keys and extends PATH so

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -45,8 +45,7 @@ const MODEL_HANDLER_COMPATIBILITY_PROPERTY =
 
 type ModelHandlerCompatibilityTagged = object & {
   readonly [MODEL_HANDLER_COMPATIBILITY_PROPERTY]?:
-    | ModelHandlerCompatibilityKey
-    | undefined;
+    ModelHandlerCompatibilityKey | undefined;
 };
 
 // Record (not Map) so TypeScript enforces exhaustiveness over ModelProvider.

--- a/src/agent/runtime/RunContext.ts
+++ b/src/agent/runtime/RunContext.ts
@@ -25,7 +25,7 @@ interface RunContextCommon {
   readonly stopAfterCycle?: boolean;
 }
 
-interface LaunchRunContext extends RunContextCommon {
+export interface LaunchRunContext extends RunContextCommon {
   readonly kind: 'launch';
   readonly streamId: StreamTabId;
   readonly executionId: ExecutionId;
@@ -189,4 +189,24 @@ export function useRunContext(): RunContext {
 /** Return the active run context when called from a run, otherwise undefined. */
 export function tryUseRunContext(): RunContext | undefined {
   return runContextScope.getStore();
+}
+
+/**
+ * Return the active run context, asserting it is a `launch` context (i.e.
+ * `streamId`/`executionId`/`runtimeHost` are guaranteed present).
+ *
+ * Flow nodes only ever execute inside `withExecutionRunContext` (in
+ * `AgentLaunchContext.ts`), which always projects a `launch` context — the
+ * `bare` variant of `createRunContext` is exclusively for manually
+ * constructed test/one-shot tool contexts. Use this instead of re-deriving
+ * these fields on the flow-service bag.
+ */
+export function useLaunchRunContext(): LaunchRunContext {
+  const context = useRunContext();
+  if (context.kind !== 'launch') {
+    throw new Error(
+      'useLaunchRunContext() called outside a launch RunContext',
+    );
+  }
+  return context;
 }

--- a/src/agent/runtime/RunContext.ts
+++ b/src/agent/runtime/RunContext.ts
@@ -204,9 +204,7 @@ export function tryUseRunContext(): RunContext | undefined {
 export function useLaunchRunContext(): LaunchRunContext {
   const context = useRunContext();
   if (context.kind !== 'launch') {
-    throw new Error(
-      'useLaunchRunContext() called outside a launch RunContext',
-    );
+    throw new Error('useLaunchRunContext() called outside a launch RunContext');
   }
   return context;
 }

--- a/src/agent/runtime/agentToolResolution.ts
+++ b/src/agent/runtime/agentToolResolution.ts
@@ -228,9 +228,7 @@ function runtimeNarrowToolDefinition(
 function annotateDelegationTool(
   tool: ToolDefinition,
   availableModelNames:
-    | ReadonlyMap<AgentCategory, readonly string[]>
-    | null
-    | undefined,
+    ReadonlyMap<AgentCategory, readonly string[]> | null | undefined,
 ): ToolDefinition {
   const category = DELEGATION_TOOL_CATEGORY[tool.name];
   if (!category) return tool;

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -91,9 +91,7 @@ interface TerminateOptions {
 }
 
 export type ToolUseFollowUpQueueReason =
-  | 'resuming'
-  | 'waiting'
-  | 'children_running';
+  'resuming' | 'waiting' | 'children_running';
 
 export type ToolUseFollowUpTarget =
   | {

--- a/src/agent/runtime/helperModel.ts
+++ b/src/agent/runtime/helperModel.ts
@@ -24,8 +24,7 @@ export interface HelperModelKit {
 }
 
 export type HelperModelResult =
-  | { kit: HelperModelKit }
-  | { kit: undefined; reason: string };
+  { kit: HelperModelKit } | { kit: undefined; reason: string };
 
 /** Resolve the configured helper model, create a non-streaming handler, and obtain a client. */
 export async function createHelperModelKit(): Promise<HelperModelResult> {

--- a/src/agent/runtime/resolveAndResumeStream.ts
+++ b/src/agent/runtime/resolveAndResumeStream.ts
@@ -40,9 +40,7 @@ export interface ResumeStreamPorts {
     config: AgentConfig,
     executionId: ExecutionId | undefined,
     modelHandlerCompatibilityKey:
-      | ModelHandlerCompatibilityKey
-      | null
-      | undefined,
+      ModelHandlerCompatibilityKey | null | undefined,
   ): Promise<void>;
   /**
    * Surface "this run has no resumable session state" when retrieval succeeds

--- a/src/auth/codex/codexJwt.ts
+++ b/src/auth/codex/codexJwt.ts
@@ -45,15 +45,13 @@ const CodexJwtClaimsSchema = z
       .catch(undefined),
     email: NonEmptyClaim,
   })
-  .transform(
-    (claims): CodexJwtClaims => ({
-      accountId:
-        claims.chatgpt_account_id ??
-        claims[CODEX_JWT_AUTH_CLAIM]?.chatgpt_account_id ??
-        claims.organizations?.[0]?.id,
-      email: claims.email,
-    }),
-  );
+  .transform((claims): CodexJwtClaims => ({
+    accountId:
+      claims.chatgpt_account_id ??
+      claims[CODEX_JWT_AUTH_CLAIM]?.chatgpt_account_id ??
+      claims.organizations?.[0]?.id,
+    email: claims.email,
+  }));
 
 /**
  * Decode + validate a JWT's claims (the middle base64url segment). Returns empty

--- a/src/auth/codex/codexSessionTypes.ts
+++ b/src/auth/codex/codexSessionTypes.ts
@@ -61,11 +61,7 @@ export type CodexDeviceToken = z.infer<typeof CodexDeviceTokenSchema>;
  * - `pending`   — device-code authorization not completed yet.
  */
 export type CodexAuthErrorKind =
-  | 'fatal'
-  | 'expired'
-  | 'transient'
-  | 'config'
-  | 'pending';
+  'fatal' | 'expired' | 'transient' | 'config' | 'pending';
 
 export class CodexAuthError extends Error {
   readonly kind: CodexAuthErrorKind;

--- a/src/auth/core/authCallback.ts
+++ b/src/auth/core/authCallback.ts
@@ -27,8 +27,7 @@ export interface AuthCallbackTokenParseError {
 }
 
 export type AuthCallbackTokenParseResult =
-  | AuthCallbackTokenParseSuccess
-  | AuthCallbackTokenParseError;
+  AuthCallbackTokenParseSuccess | AuthCallbackTokenParseError;
 
 export function getAuthCallbackBasePath(path: string): string {
   return path.split('?')[0];
@@ -121,8 +120,7 @@ export interface AuthCallbackCodeParseSuccess {
 }
 
 export type AuthCallbackCodeParseResult =
-  | AuthCallbackCodeParseSuccess
-  | AuthCallbackTokenParseError;
+  AuthCallbackCodeParseSuccess | AuthCallbackTokenParseError;
 
 /**
  * Extract the PKCE authorization code (or an auth error) from host-neutral URI

--- a/src/auth/supabaseSessionTypes.ts
+++ b/src/auth/supabaseSessionTypes.ts
@@ -70,8 +70,7 @@ export interface SupabaseCallbackParseError {
 }
 
 export type SupabaseCallbackResult =
-  | SupabaseCallbackParseResult
-  | SupabaseCallbackParseError;
+  SupabaseCallbackParseResult | SupabaseCallbackParseError;
 
 export function firstAccountLabel(
   ...candidates: readonly (string | null | undefined)[]

--- a/src/common/errors/agentErrorClassification.ts
+++ b/src/common/errors/agentErrorClassification.ts
@@ -5,10 +5,7 @@ import { isDiskFullError } from './errorPredicates';
 import { isUserAbort } from './sdkErrorUtils';
 
 export type AgentErrorKind =
-  | 'abort'
-  | 'disk-full'
-  | 'missing-api-key'
-  | 'unexpected';
+  'abort' | 'disk-full' | 'missing-api-key' | 'unexpected';
 
 /**
  * Canonical outcome of a run terminated by a thrown error, per error kind.

--- a/src/common/files/fileTypeUtils.ts
+++ b/src/common/files/fileTypeUtils.ts
@@ -16,11 +16,7 @@ import { hasExtension } from '@utils/core/pathCore';
  * which defines UI file input field types.
  */
 export type ExtensionCategory =
-  | 'input'
-  | 'context'
-  | 'media'
-  | 'audio'
-  | 'edited';
+  'input' | 'context' | 'media' | 'audio' | 'edited';
 
 const INCLUDED_EXTENSION_KEYS: Record<ExtensionCategory, string> = {
   input: 'texra.files.included.inputExtensions',

--- a/src/controllers/mainView/MainViewInteractionController.ts
+++ b/src/controllers/mainView/MainViewInteractionController.ts
@@ -16,8 +16,7 @@ export interface MainViewConfigUpdate {
 }
 
 export type MainViewAgentDirectoryAction =
-  | { kind: 'openAgentSettings' }
-  | { kind: 'revealCustomDirectory' };
+  { kind: 'openAgentSettings' } | { kind: 'revealCustomDirectory' };
 
 export interface MainViewInteractionControllerDeps {
   getProviderUrl(provider: string): string | undefined;

--- a/src/controllers/settingsView/ChatExportController.ts
+++ b/src/controllers/settingsView/ChatExportController.ts
@@ -42,9 +42,7 @@ import { StorageFS, pathToLocation } from '@utils/files';
 
 /** Outcome of loading execution data for export. */
 export type ExportInputStatus =
-  | 'ok'
-  | 'config_missing'
-  | 'conversation_missing';
+  'ok' | 'config_missing' | 'conversation_missing';
 
 export type ExportInputResult =
   | { readonly status: 'ok'; readonly exportInput: ChatExportInput }

--- a/src/controllers/settingsView/SettingsAgentDirectoryController.ts
+++ b/src/controllers/settingsView/SettingsAgentDirectoryController.ts
@@ -30,12 +30,10 @@ export type SettingsOpenAgentYamlResult =
   | { ok: false; reason: 'missingAgent' | 'missingPath' };
 
 export type SettingsRevealAgentFileResult =
-  | { ok: true; path: string }
-  | { ok: false; reason: 'missingFile' };
+  { ok: true; path: string } | { ok: false; reason: 'missingFile' };
 
 export type SettingsOpenAgentFolderResult =
-  | { ok: true; path: string }
-  | { ok: false; reason: 'missingLocalDirectory' };
+  { ok: true; path: string } | { ok: false; reason: 'missingLocalDirectory' };
 
 export class SettingsAgentDirectoryController {
   constructor(private readonly deps: SettingsAgentDirectoryControllerDeps) {}

--- a/src/hosts/uiHosts.ts
+++ b/src/hosts/uiHosts.ts
@@ -1,11 +1,6 @@
 // Third-party imports
 import stripAnsi from 'strip-ansi';
 
-export interface ClipboardHost {
-  readText(): Promise<string>;
-  writeText(text: string): Promise<void>;
-}
-
 export interface DiffSource {
   filePath: string;
 }
@@ -126,19 +121,6 @@ export interface TerminalRunResult {
   /** ANSI-stripped, length-capped tail of command output when available. */
   output: string;
   timedOut: boolean;
-}
-
-export interface TerminalHandle {
-  readonly name: string;
-  sendText(text: string, shouldExecute?: boolean): void;
-  show(preserveFocus?: boolean): void;
-  dispose(): void;
-}
-
-export interface TerminalHost {
-  createTerminal(options: TerminalOptions): TerminalHandle;
-  findTerminal(name: string): TerminalHandle | undefined;
-  getTerminals(): readonly TerminalHandle[];
 }
 
 export interface TerminalRunner {

--- a/src/latex/latexdiff/diffFileNameManager.ts
+++ b/src/latex/latexdiff/diffFileNameManager.ts
@@ -7,9 +7,7 @@ import {
 } from '@agent/utils/mergeFileUtils';
 
 export type GeneratedLatexdiffArtifactKind =
-  | 'workspaceDiff'
-  | 'versionControlDiff'
-  | 'betweenRoundDiff';
+  'workspaceDiff' | 'versionControlDiff' | 'betweenRoundDiff';
 
 export interface GeneratedLatexdiffArtifact {
   kind: GeneratedLatexdiffArtifactKind;

--- a/src/latex/latexdiff/runLatexdiff.ts
+++ b/src/latex/latexdiff/runLatexdiff.ts
@@ -27,9 +27,7 @@ import type { DiffProgressReporter, DiffRunOutcome } from './types';
 
 /** How the round outputs fed to the diff engine were resolved. */
 export type LatexdiffOutputsSource =
-  | 'metadata'
-  | 'run-dir-scan'
-  | 'workspace-scan';
+  'metadata' | 'run-dir-scan' | 'workspace-scan';
 
 export interface RunLatexdiffForExecutionParams {
   readonly agent: string;

--- a/src/platform/defaults/nodeHost.ts
+++ b/src/platform/defaults/nodeHost.ts
@@ -80,6 +80,14 @@ export function createNodePlatform(services: NodePlatformServices): Platform {
       ...NO_TOOL_AVAILABILITY_HOST,
       ...services.toolAvailability,
     },
+    // Neither Node host has a UI surface for these yet (linter diagnostics,
+    // inline criticism, tool-missing/unavailable toasts) — explicit no-ops
+    // here, in the one place both hosts share, rather than an invisible
+    // per-module default.
+    linter: async () => [],
+    addCriticismSink: () => ({ accepted: false, resolvedPath: '' }),
+    toolMissingHandler: () => {},
+    toolNotificationHandler: () => {},
   };
 }
 

--- a/src/platform/interfaces/criticism.ts
+++ b/src/platform/interfaces/criticism.ts
@@ -1,0 +1,28 @@
+/**
+ * Host-resolved shape for a single criticism entry pushed by the diagnostics
+ * tool's `add` command. The tool resolves the input `path` against the
+ * active working directory before handing the entry to the host as
+ * `absolutePath`.
+ */
+export interface ManualCriticismEntry {
+  /** Absolute path resolved by the tool. */
+  absolutePath: string;
+  /** 1-based line number. */
+  line: number;
+  message: string;
+  /** 0–5; mapped to DiagnosticSeverity by the host. */
+  severity: number;
+  /** 1–5; appended to the message as `(S/C)`. */
+  confidence: number;
+}
+
+/**
+ * Sink injected by the extension host for the `add` command. Returns
+ * `accepted: false` when the experimental setting is disabled (or the host
+ * has no inline-criticism surface, e.g. CLI/desktop) so the tool can surface
+ * that to the agent.
+ */
+export type AddCriticismSink = (input: ManualCriticismEntry) => {
+  accepted: boolean;
+  resolvedPath: string;
+};

--- a/src/platform/interfaces/linter.ts
+++ b/src/platform/interfaces/linter.ts
@@ -1,0 +1,8 @@
+import type { GenericDiagnostic } from '@utils/diagnostics/diagnosticFormatting';
+
+/**
+ * Host-injected linter diagnostics provider, consumed by the diagnostics
+ * tool's `list`/`count` commands. Hosts without a linter integration (CLI,
+ * desktop) return an empty array.
+ */
+export type LinterProvider = (path: string) => Promise<GenericDiagnostic[]>;

--- a/src/platform/interfaces/toolNotifications.ts
+++ b/src/platform/interfaces/toolNotifications.ts
@@ -1,0 +1,19 @@
+/**
+ * Pluggable handler for surfacing tool-missing errors to the user. Hosts
+ * without a UI for this (CLI, desktop) no-op.
+ */
+export type ToolMissingHandler = (
+  message: string,
+  openDocsCommand?: string,
+) => void | Promise<void>;
+
+/**
+ * Pluggable notification handler for tool groups excluded due to missing
+ * dependencies. `actionCommand`/`actionLabel` let a notification funnel the
+ * user to the right tab. Hosts without a UI for this (CLI, desktop) no-op.
+ */
+export type ToolNotificationHandler = (
+  message: string,
+  actionCommand?: string,
+  actionLabel?: string,
+) => void;

--- a/src/platform/platform.ts
+++ b/src/platform/platform.ts
@@ -9,9 +9,15 @@
  * Pattern: Composition Root (Mark Seemann) + Frozen Object.
  */
 import type { AgentResumePort } from './interfaces/agentResume';
+import type { AddCriticismSink } from './interfaces/criticism';
 import type { ConfigProvider } from './interfaces/config';
 import type { StateStore } from './interfaces/state';
 import type { FileSystemProvider } from './interfaces/filesystem';
+import type { LinterProvider } from './interfaces/linter';
+import type {
+  ToolMissingHandler,
+  ToolNotificationHandler,
+} from './interfaces/toolNotifications';
 import type { WorkspaceProvider } from './interfaces/workspace';
 import type { StorageProvider } from './interfaces/storage';
 import type { LifecycleHost } from './interfaces/lifecycle';
@@ -38,6 +44,14 @@ export interface Platform {
   readonly lifecycle: LifecycleHost;
   readonly agentResume: AgentResumePort;
   readonly toolAvailability: ToolAvailabilityHost;
+  /** Linter diagnostics provider for the diagnostics tool's `list`/`count` commands. */
+  readonly linter: LinterProvider;
+  /** Sink for the diagnostics tool's `add` (manual criticism) command. */
+  readonly addCriticismSink: AddCriticismSink;
+  /** Surfaces a tool-missing error to the user. */
+  readonly toolMissingHandler: ToolMissingHandler;
+  /** Surfaces a tool-group-unavailable notification to the user. */
+  readonly toolNotificationHandler: ToolNotificationHandler;
 }
 
 let _platform: Readonly<Platform> | null = null;

--- a/src/shared/htmlExport/components/ChatToolBlock.ts
+++ b/src/shared/htmlExport/components/ChatToolBlock.ts
@@ -18,11 +18,7 @@ import { customElement, property } from 'lit/decorators.js';
 import { bubbleFrame } from '../styles/tokens';
 
 export type ToolBlockKind =
-  | 'call'
-  | 'result'
-  | 'web-search'
-  | 'web-results'
-  | 'web-fetch';
+  'call' | 'result' | 'web-search' | 'web-results' | 'web-fetch';
 
 const ROLE_LABELS: Record<ToolBlockKind, string> = {
   call: 'Tool call',
@@ -73,9 +69,11 @@ export class ChatToolBlock extends LitElement {
     return html`
       <div class="frame">
         <div class="role">${label}</div>
-        ${this.name
-          ? html`<div class="tool-name">tool <code>${this.name}</code></div>`
-          : nothing}
+        ${
+          this.name
+            ? html`<div class="tool-name">tool <code>${this.name}</code></div>`
+            : nothing
+        }
         <div class="body"><slot></slot></div>
       </div>
     `;

--- a/src/shared/mainView/actionPlanner.ts
+++ b/src/shared/mainView/actionPlanner.ts
@@ -141,8 +141,7 @@ export type ComparePayload = {
 };
 
 export type CompareActionResult =
-  | CommandSuccess<ComparePayload>
-  | ActionValidationError;
+  CommandSuccess<ComparePayload> | ActionValidationError;
 
 export function planCompare(
   state: CompareState,

--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -15,6 +15,7 @@ import {
   type StreamStatus,
   type StreamTabId,
 } from '@shared/schemas';
+import { diffActiveChildren } from '@shared/streams/childActivityReducer';
 import {
   WebviewUpdater,
   type LogContentExtras,
@@ -436,15 +437,14 @@ export class ProgressEventHandler {
     let nextBadges: StreamBadgeSnapshot | null = null;
 
     this.state.updateStreamState(parentStreamId, (prev) => {
-      const prevIds = new Set(prev[opts.activeField].map((c) => c.executionId));
-      const nextIds = new Set(opts.next.map((c) => c.executionId));
-      const newlyFinished = [...prevIds].filter(
-        (id) => !nextIds.has(id),
-      ).length;
+      const { vanishedIds } = diffActiveChildren(
+        prev[opts.activeField],
+        opts.next,
+      );
       const updatedState = {
         ...prev,
         [opts.activeField]: opts.next,
-        [opts.countField]: (prev[opts.countField] ?? 0) + newlyFinished,
+        [opts.countField]: (prev[opts.countField] ?? 0) + vanishedIds.size,
       };
       nextBadges = this.toBadgeSnapshot(updatedState);
       return updatedState;

--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -437,10 +437,7 @@ export class ProgressEventHandler {
     let nextBadges: StreamBadgeSnapshot | null = null;
 
     this.state.updateStreamState(parentStreamId, (prev) => {
-      const { vanishedIds } = diffActiveChildren(
-        prev[opts.activeField],
-        opts.next,
-      );
+      const vanishedIds = diffActiveChildren(prev[opts.activeField], opts.next);
       const updatedState = {
         ...prev,
         [opts.activeField]: opts.next,

--- a/src/shared/schemas/errors.ts
+++ b/src/shared/schemas/errors.ts
@@ -118,9 +118,7 @@ export type ProviderErrorPartial = z.infer<typeof ProviderErrorPartialSchema>;
  *  so the predicate stays the one place that owns the verdict. */
 export function isChatGptSubscriptionLimitError(
   errorDetails:
-    | Pick<ProviderError, 'isChatGptSubscriptionLimited'>
-    | undefined
-    | null,
+    Pick<ProviderError, 'isChatGptSubscriptionLimited'> | undefined | null,
 ): boolean {
   return errorDetails?.isChatGptSubscriptionLimited === true;
 }

--- a/src/shared/schemas/log.ts
+++ b/src/shared/schemas/log.ts
@@ -114,20 +114,18 @@ const LegacyLogMessageSchema = z
     verbose: z.boolean().optional(),
     data: z.unknown().optional(),
   })
-  .transform(
-    (msg): StreamLogEntry => ({
-      seqNo: 0, // placeholder — StreamLog constructor renumbers
-      id: msg.id,
-      type: STREAM_LOG_ENTRY_TYPES.LOG,
-      level: msg.level,
-      timestamp: msg.timestamp,
-      groupId: msg.groupId,
-      messageType: msg.messageType,
-      text: msg.text,
-      verbose: msg.verbose,
-      data: msg.data,
-    }),
-  );
+  .transform((msg): StreamLogEntry => ({
+    seqNo: 0, // placeholder — StreamLog constructor renumbers
+    id: msg.id,
+    type: STREAM_LOG_ENTRY_TYPES.LOG,
+    level: msg.level,
+    timestamp: msg.timestamp,
+    groupId: msg.groupId,
+    messageType: msg.messageType,
+    text: msg.text,
+    verbose: msg.verbose,
+    data: msg.data,
+  }));
 
 /**
  * Accepts both current StreamLogEntry format and legacy log messages.

--- a/src/shared/streams/childActivityReducer.ts
+++ b/src/shared/streams/childActivityReducer.ts
@@ -11,28 +11,19 @@ export interface HasExecutionId {
   readonly executionId: string;
 }
 
-export interface ChildActivityDiff<T extends HasExecutionId> {
-  /** The next active-child list, passed through unchanged. */
-  readonly next: readonly T[];
-  /**
-   * Ids present in `previous` but absent from `next` — i.e. children that
-   * finished between the two snapshots. The caller decides what "vanished"
-   * means (count it, persist a transcript row, prune a side map, or several).
-   */
-  readonly vanishedIds: ReadonlySet<string>;
-}
-
 /**
- * Diff two active-child snapshots by executionId. Pure: never mutates either
- * input.
+ * Diff two active-child snapshots by executionId, returning ids present in
+ * `previous` but absent from `next` — i.e. children that finished between
+ * the two snapshots. The caller decides what "vanished" means (count it,
+ * persist a transcript row, prune a side map, or several). Pure: never
+ * mutates either input.
  */
-export function diffActiveChildren<T extends HasExecutionId>(
-  previous: readonly T[],
-  next: readonly T[],
-): ChildActivityDiff<T> {
+export function diffActiveChildren(
+  previous: readonly HasExecutionId[],
+  next: readonly HasExecutionId[],
+): ReadonlySet<string> {
   const nextIds = new Set(next.map((child) => child.executionId));
-  const vanishedIds = new Set(
+  return new Set(
     previous.map((child) => child.executionId).filter((id) => !nextIds.has(id)),
   );
-  return { next, vanishedIds };
 }

--- a/src/shared/streams/childActivityReducer.ts
+++ b/src/shared/streams/childActivityReducer.ts
@@ -1,0 +1,40 @@
+// Host-neutral "which active children vanished" diff, shared by the webview
+// progress-view backend and the CLI TUI. Both hosts independently computed
+// this same previous-vs-next id-set diff for subagent/process activity; this
+// module owns the one comparison so hosts stay on a single correct algorithm.
+//
+// NO host imports here (no vscode / electron / ink / immer): the diff is a
+// pure function over plain values.
+
+/** Anything with a stable per-execution id can be diffed by this reducer. */
+export interface HasExecutionId {
+  readonly executionId: string;
+}
+
+export interface ChildActivityDiff<T extends HasExecutionId> {
+  /** The next active-child list, passed through unchanged. */
+  readonly next: readonly T[];
+  /**
+   * Ids present in `previous` but absent from `next` — i.e. children that
+   * finished between the two snapshots. The caller decides what "vanished"
+   * means (count it, persist a transcript row, prune a side map, or several).
+   */
+  readonly vanishedIds: ReadonlySet<string>;
+}
+
+/**
+ * Diff two active-child snapshots by executionId. Pure: never mutates either
+ * input.
+ */
+export function diffActiveChildren<T extends HasExecutionId>(
+  previous: readonly T[],
+  next: readonly T[],
+): ChildActivityDiff<T> {
+  const nextIds = new Set(next.map((child) => child.executionId));
+  const vanishedIds = new Set(
+    previous
+      .map((child) => child.executionId)
+      .filter((id) => !nextIds.has(id)),
+  );
+  return { next, vanishedIds };
+}

--- a/src/shared/streams/childActivityReducer.ts
+++ b/src/shared/streams/childActivityReducer.ts
@@ -32,9 +32,7 @@ export function diffActiveChildren<T extends HasExecutionId>(
 ): ChildActivityDiff<T> {
   const nextIds = new Set(next.map((child) => child.executionId));
   const vanishedIds = new Set(
-    previous
-      .map((child) => child.executionId)
-      .filter((id) => !nextIds.has(id)),
+    previous.map((child) => child.executionId).filter((id) => !nextIds.has(id)),
   );
   return { next, vanishedIds };
 }

--- a/src/shared/utils/dispatcher.ts
+++ b/src/shared/utils/dispatcher.ts
@@ -49,8 +49,7 @@ export function createDispatcher<TMessage extends CommandMessage>(
 
     const message = parseResult.data;
     const handler = handlers[message.command as TMessage['command']] as
-      | MessageHandler<typeof message>
-      | undefined;
+      MessageHandler<typeof message> | undefined;
 
     if (!handler) {
       return false;

--- a/src/shared/utils/selectTemplates.ts
+++ b/src/shared/utils/selectTemplates.ts
@@ -45,14 +45,18 @@ function renderAgentOption(opt: AgentOptionData): TemplateResult {
       data-remote=${opt.isRemote ? 'true' : nothing}
       data-custom=${opt.isCustom ? 'true' : nothing}
     >
-      ${opt.isOrchestrator
-        ? html`<span class="agent-icon">${waIcon('bullseye')} </span>`
-        : nothing}${opt.label}
-      ${opt.isRemote
-        ? html`<span class="agent-icon">
-            ${waIcon(AGENT_DECORATORS.properties.remote.icon)}</span
-          >`
-        : nothing}
+      ${
+        opt.isOrchestrator
+          ? html`<span class="agent-icon">${waIcon('bullseye')} </span>`
+          : nothing
+      }${opt.label}
+      ${
+        opt.isRemote
+          ? html`<span class="agent-icon">
+              ${waIcon(AGENT_DECORATORS.properties.remote.icon)}</span
+            >`
+          : nothing
+      }
     </wa-option>
   `;
 }
@@ -67,16 +71,18 @@ export function renderAgentOptions(
       (opt) => opt.value,
       (opt) => renderAgentOption(opt),
     )}
-    ${includeBrowseAll
-      ? html`
-          <wa-option
-            value=${BROWSE_ALL_AGENTS_OPTION_VALUE}
-            title="Open Settings → Agents to browse the full catalog"
-          >
-            Browse all agents…
-          </wa-option>
-        `
-      : nothing}
+    ${
+      includeBrowseAll
+        ? html`
+            <wa-option
+              value=${BROWSE_ALL_AGENTS_OPTION_VALUE}
+              title="Open Settings → Agents to browse the full catalog"
+            >
+              Browse all agents…
+            </wa-option>
+          `
+        : nothing
+    }
   `;
 }
 
@@ -115,14 +121,18 @@ function renderModelOption(opt: ModelOptionData): TemplateResult {
       data-cost=${opt.cost || nothing}
       data-availability=${availability || nothing}
       data-requires-key=${opt.requiresKey ? 'true' : nothing}
-      aria-label=${availabilityLabel
-        ? `${opt.label} (${availabilityLabel})`
-        : opt.label}
+      aria-label=${
+        availabilityLabel ? `${opt.label} (${availabilityLabel})` : opt.label
+      }
     >
       ${display}
-      ${opt.disabled
-        ? html`<span class="model-option-status"> ${availabilityLabel} </span>`
-        : nothing}
+      ${
+        opt.disabled
+          ? html`<span class="model-option-status">
+              ${availabilityLabel}
+            </span>`
+          : nothing
+      }
     </wa-option>
   `;
 }

--- a/src/shared/wa/actionButtons.ts
+++ b/src/shared/wa/actionButtons.ts
@@ -109,12 +109,14 @@ function renderActionButtonBase({
   return html`
     <span class="action-icon-busy">
       ${button}
-      ${busy
-        ? html`<wa-spinner
-            class="action-busy-spinner"
-            aria-hidden="true"
-          ></wa-spinner>`
-        : nothing}
+      ${
+        busy
+          ? html`<wa-spinner
+              class="action-busy-spinner"
+              aria-hidden="true"
+            ></wa-spinner>`
+          : nothing
+      }
     </span>
     ${tooltipTemplate}
   `;

--- a/src/shared/wa/commandPalette.ts
+++ b/src/shared/wa/commandPalette.ts
@@ -31,8 +31,7 @@ export interface CommandPaletteEntry {
 }
 
 export type CommandPaletteEntrySource =
-  | readonly CommandPaletteEntry[]
-  | (() => readonly CommandPaletteEntry[]);
+  readonly CommandPaletteEntry[] | (() => readonly CommandPaletteEntry[]);
 
 export interface CommandPaletteOptions {
   readonly document: Document;
@@ -227,11 +226,13 @@ export function createCommandPalette({
           @keydown=${handleFilterKeydown}
         ></wa-input>
         <div class=${classes?.list ?? ''} role="listbox">
-          ${visibleEntries.length === 0
-            ? html`<div class=${classes?.empty ?? ''} role="status">
-                No matching commands
-              </div>`
-            : nothing}
+          ${
+            visibleEntries.length === 0
+              ? html`<div class=${classes?.empty ?? ''} role="status">
+                  No matching commands
+                </div>`
+              : nothing
+          }
           ${repeat(
             visibleEntries,
             (entry) => entry.id,

--- a/src/shared/wa/emptyState.ts
+++ b/src/shared/wa/emptyState.ts
@@ -89,9 +89,11 @@ export function renderEmptyState({
                       variant=${action.variant ?? 'neutral'}
                       @click=${action.onClick}
                     >
-                      ${action.icon
-                        ? waIcon(action.icon, { slot: 'start' })
-                        : nothing}
+                      ${
+                        action.icon
+                          ? waIcon(action.icon, { slot: 'start' })
+                          : nothing
+                      }
                       ${action.label}
                     </wa-button>
                   `,

--- a/src/shared/wa/statusIcons.ts
+++ b/src/shared/wa/statusIcons.ts
@@ -4,11 +4,7 @@ import '@awesome.me/webawesome/dist/components/tag/tag.js';
 import { css, html, type CSSResult, type TemplateResult } from 'lit';
 
 export type WaTagVariant =
-  | 'brand'
-  | 'neutral'
-  | 'success'
-  | 'warning'
-  | 'danger';
+  'brand' | 'neutral' | 'success' | 'warning' | 'danger';
 
 export interface SetStatusFallback {
   readonly label: string;

--- a/src/shared/wa/walkthroughDialog.ts
+++ b/src/shared/wa/walkthroughDialog.ts
@@ -141,13 +141,15 @@ export function createWalkthroughDialog({
           `,
         )}
       </ol>
-      ${actions.length > 0
-        ? html`
-            <div slot="footer" class=${actionsClass ?? ''}>
-              ${actions.map(actionTemplate)}
-            </div>
-          `
-        : nothing}
+      ${
+        actions.length > 0
+          ? html`
+              <div slot="footer" class=${actionsClass ?? ''}>
+                ${actions.map(actionTemplate)}
+              </div>
+            `
+          : nothing
+      }
     `,
     dialog,
   );

--- a/src/skills/loadSkills.ts
+++ b/src/skills/loadSkills.ts
@@ -29,11 +29,7 @@ export interface DiscoverSkillsResult {
 }
 
 export type SkillSourceScope =
-  | 'bundled'
-  | 'user'
-  | 'project'
-  | 'interop'
-  | 'custom';
+  'bundled' | 'user' | 'project' | 'interop' | 'custom';
 
 export interface SkillSource {
   scope: SkillSourceScope;

--- a/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
@@ -11,7 +11,7 @@ import type {
 } from '@agent/implementations/flows/tooluse/nodes/types';
 import type { ToolUseServices } from '@agent/implementations/flows/tooluse/ToolUseServices';
 import { MESSAGE_TYPES, type Plan, type TodoItem } from '@shared/schemas';
-import { createRecordingHost } from '../progressTestUtils';
+import { createRecordingHost, withTestRunContext } from '../progressTestUtils';
 
 const todo: TodoItem = {
   content: 'Wire progress events through runtime host',
@@ -53,7 +53,11 @@ describe('tool-use progress events', () => {
       resolvedTools: [],
     } as unknown as ToolUseServices);
 
-    const result = await node.exec(createPrepResult(workspaceState));
+    const result = await withTestRunContext(
+      host,
+      'stream:tool-use-cycle',
+      () => node.exec(createPrepResult(workspaceState)),
+    );
 
     expect(result).toEqual({ outcome: 'skipped' });
     expect(events).toEqual([

--- a/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
@@ -53,10 +53,8 @@ describe('tool-use progress events', () => {
       resolvedTools: [],
     } as unknown as ToolUseServices);
 
-    const result = await withTestRunContext(
-      host,
-      'stream:tool-use-cycle',
-      () => node.exec(createPrepResult(workspaceState)),
+    const result = await withTestRunContext(host, 'stream:tool-use-cycle', () =>
+      node.exec(createPrepResult(workspaceState)),
     );
 
     expect(result).toEqual({ outcome: 'skipped' });

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -22,6 +22,7 @@ import {
 } from '@shared/schemas';
 import { cleanupApprovalsForStream } from '@tools/approval';
 import { GoalStore } from '@tools/goal';
+import { withTestRunContext } from '../progressTestUtils';
 
 describe('ToolUseWaitNode', () => {
   it('marks a delivered subagent cycle before stopping on interruption', async () => {
@@ -58,8 +59,14 @@ describe('ToolUseWaitNode', () => {
     const node = new ToolUseWaitNode().setServices(services);
 
     const prep = await node.prep(shared);
-    const exec = await node.exec(prep);
-    const transition = await node.post(shared, prep, exec);
+    const transition = await withTestRunContext(
+      services.runtimeHost,
+      'test-stream',
+      async () => {
+        const exec = await node.exec(prep);
+        return node.post(shared, prep, exec);
+      },
+    );
 
     expect(onBeforeWaiting).toHaveBeenCalledOnce();
     expect(onBeforeWaiting).toHaveBeenCalledWith(undefined, [], memoryMisses);
@@ -111,14 +118,26 @@ describe('ToolUseWaitNode', () => {
     const node = new ToolUseWaitNode().setServices(services);
 
     const firstPrep = await node.prep(shared);
-    const firstExec = await node.exec(firstPrep);
-    const firstTransition = await node.post(shared, firstPrep, firstExec);
+    const firstTransition = await withTestRunContext(
+      services.runtimeHost,
+      'test-stream',
+      async () => {
+        const firstExec = await node.exec(firstPrep);
+        return node.post(shared, firstPrep, firstExec);
+      },
+    );
     expect(firstTransition).toBe(FlowTransition.CONTINUE);
     expect(shared.deliveredToOrchestrator).toBe(true);
 
     const secondPrep = await node.prep(shared);
-    const secondExec = await node.exec(secondPrep);
-    const secondTransition = await node.post(shared, secondPrep, secondExec);
+    const secondTransition = await withTestRunContext(
+      services.runtimeHost,
+      'test-stream',
+      async () => {
+        const secondExec = await node.exec(secondPrep);
+        return node.post(shared, secondPrep, secondExec);
+      },
+    );
 
     expect(onBeforeWaiting).toHaveBeenCalledTimes(2);
     expect(secondTransition).toBe(FlowTransition.COMPLETE);
@@ -152,8 +171,14 @@ describe('ToolUseWaitNode', () => {
     const node = new ToolUseWaitNode().setServices(services);
 
     const prep = await node.prep(shared);
-    const exec = await node.exec(prep);
-    const transition = await node.post(shared, prep, exec);
+    const transition = await withTestRunContext(
+      services.runtimeHost,
+      'test-stream',
+      async () => {
+        const exec = await node.exec(prep);
+        return node.post(shared, prep, exec);
+      },
+    );
 
     expect(onBeforeWaiting).not.toHaveBeenCalled();
     expect(transition).toBe(FlowTransition.COMPLETE);
@@ -189,24 +214,29 @@ describe('ToolUseWaitNode', () => {
     } as unknown as ToolUseServices;
 
     const node = new ToolUseWaitNode().setServices(services);
-    const transition = await node.post(
-      shared,
-      {
-        afterError: false,
-        lastResponse: undefined,
-        previouslyDeliveredToOrchestrator: false,
-        touchedFiles: [],
-      },
-      {
-        followUps: [
+    const transition = await withTestRunContext(
+      services.runtimeHost,
+      'test-stream',
+      () =>
+        node.post(
+          shared,
           {
-            text: 'please inspect this figure',
-            mediaFiles: ['/tmp/figure.png'],
-            origin: 'user',
+            afterError: false,
+            lastResponse: undefined,
+            previouslyDeliveredToOrchestrator: false,
+            touchedFiles: [],
           },
-        ],
-        kind: 'continue',
-      },
+          {
+            followUps: [
+              {
+                text: 'please inspect this figure',
+                mediaFiles: ['/tmp/figure.png'],
+                origin: 'user',
+              },
+            ],
+            kind: 'continue',
+          },
+        ),
     );
 
     expect(transition).toBe(FlowTransition.CONTINUE);
@@ -248,12 +278,14 @@ describe('ToolUseWaitNode', () => {
     const node = new ToolUseWaitNode().setServices(services);
 
     try {
-      const exec = await node.exec({
-        afterError: true,
-        lastResponse: undefined,
-        previouslyDeliveredToOrchestrator: false,
-        touchedFiles: [],
-      });
+      const exec = await withTestRunContext(runtimeHost, streamId, () =>
+        node.exec({
+          afterError: true,
+          lastResponse: undefined,
+          previouslyDeliveredToOrchestrator: false,
+          touchedFiles: [],
+        }),
+      );
 
       const goal = GoalStore.getForStream(streamId);
       expect(exec.kind).toBe('stop');
@@ -318,7 +350,11 @@ describe('ToolUseWaitNode', () => {
 
     try {
       const prep = await node.prep(shared);
-      const exec = await node.exec(prep);
+      const exec = await withTestRunContext(
+        services.runtimeHost,
+        streamId,
+        () => node.exec(prep),
+      );
 
       expect(exec.kind).toBe('continue');
       if (exec.kind !== 'continue') return;
@@ -332,7 +368,11 @@ describe('ToolUseWaitNode', () => {
       expect(waitForFollowUp).not.toHaveBeenCalled();
       expect(streamStatus.get(streamId)).toBeUndefined();
 
-      const transition = await node.post(shared, prep, exec);
+      const transition = await withTestRunContext(
+        services.runtimeHost,
+        streamId,
+        () => node.post(shared, prep, exec),
+      );
 
       expect(transition).toBe(FlowTransition.CONTINUE);
       expect(onFollowUpConsumed).not.toHaveBeenCalled();
@@ -402,7 +442,11 @@ describe('ToolUseWaitNode', () => {
         (_, index) => index,
       )) {
         const prep = await node.prep(shared);
-        const exec = await node.exec(prep);
+        const exec = await withTestRunContext(
+          services.runtimeHost,
+          streamId,
+          () => node.exec(prep),
+        );
 
         expect(exec.kind).toBe('continue');
         if (exec.kind !== 'continue') return;
@@ -411,7 +455,11 @@ describe('ToolUseWaitNode', () => {
           'Keep solving the hard problem until verification is complete.',
         );
 
-        const transition = await node.post(shared, prep, exec);
+        const transition = await withTestRunContext(
+          services.runtimeHost,
+          streamId,
+          () => node.post(shared, prep, exec),
+        );
         expect(transition).toBe(FlowTransition.CONTINUE);
         expect(createUserFollowUpMessages).toHaveBeenCalledTimes(cycle + 1);
       }
@@ -425,7 +473,11 @@ describe('ToolUseWaitNode', () => {
       await GoalStore.setStatus(streamId, 'paused');
 
       const prep = await node.prep(shared);
-      const exec = await node.exec(prep);
+      const exec = await withTestRunContext(
+        services.runtimeHost,
+        streamId,
+        () => node.exec(prep),
+      );
 
       expect(waitForFollowUp).toHaveBeenCalledOnce();
       expect(exec.kind).toBe('stop');
@@ -460,12 +512,17 @@ describe('ToolUseWaitNode', () => {
     const node = new ToolUseWaitNode().setServices(services);
 
     try {
-      const exec = await node.exec({
-        afterError: false,
-        lastResponse: undefined,
-        previouslyDeliveredToOrchestrator: false,
-        touchedFiles: [],
-      });
+      const exec = await withTestRunContext(
+        services.runtimeHost,
+        streamId,
+        () =>
+          node.exec({
+            afterError: false,
+            lastResponse: undefined,
+            previouslyDeliveredToOrchestrator: false,
+            touchedFiles: [],
+          }),
+      );
 
       expect(waitForFollowUp).toHaveBeenCalledOnce();
       expect(exec).toEqual({
@@ -502,12 +559,17 @@ describe('ToolUseWaitNode', () => {
     const node = new ToolUseWaitNode().setServices(services);
 
     try {
-      const exec = await node.exec({
-        afterError: false,
-        lastResponse: undefined,
-        previouslyDeliveredToOrchestrator: false,
-        touchedFiles: [],
-      });
+      const exec = await withTestRunContext(
+        services.runtimeHost,
+        streamId,
+        () =>
+          node.exec({
+            afterError: false,
+            lastResponse: undefined,
+            previouslyDeliveredToOrchestrator: false,
+            touchedFiles: [],
+          }),
+      );
 
       expect(waitForFollowUp).toHaveBeenCalledOnce();
       expect(exec.kind).toBe('stop');
@@ -553,11 +615,17 @@ describe('ToolUseWaitNode', () => {
       });
 
       const prep = await node.prep(shared);
-      const exec = await node.exec(prep);
+      const exec = await withTestRunContext(
+        services.runtimeHost,
+        streamId,
+        () => node.exec(prep),
+      );
       expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.WAITING);
       expect(StreamStatusService.get(streamId)).toBe(STREAM_STATUS.STOPPED);
 
-      await node.post(shared, prep, exec);
+      await withTestRunContext(services.runtimeHost, streamId, () =>
+        node.post(shared, prep, exec),
+      );
       expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.RUNNING);
       expect(StreamStatusService.get(streamId)).toBe(STREAM_STATUS.STOPPED);
       expect(createUserFollowUpMessages).toHaveBeenCalledOnce();
@@ -613,8 +681,14 @@ describe('ToolUseWaitNode', () => {
     const node = new ToolUseWaitNode().setServices(services);
 
     const prep = await node.prep(shared);
-    const exec = await node.exec(prep);
-    const transition = await node.post(shared, prep, exec);
+    const transition = await withTestRunContext(
+      runtimeHost,
+      'test-stream',
+      async () => {
+        const exec = await node.exec(prep);
+        return node.post(shared, prep, exec);
+      },
+    );
 
     expect(transition).toBe(FlowTransition.CONTINUE);
     expect(runtimeHost.emit).toHaveBeenCalledWith(

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsChaining.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsChaining.vitest.ts
@@ -61,10 +61,7 @@ function capturingClient(
 function completedEvents(
   id: string,
   status:
-    | 'completed'
-    | 'incomplete'
-    | 'failed'
-    | 'requires_action' = 'completed',
+    'completed' | 'incomplete' | 'failed' | 'requires_action' = 'completed',
   text = 'ok',
 ): SSEEvent[] {
   return [

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsToolUse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsToolUse.vitest.ts
@@ -555,8 +555,7 @@ describe('ModelHandlerGoogleInteractions tool use', () => {
 
     // --- Turn 2: capture exactly what the handler sends. ---
     let captured:
-      | Interactions.CreateModelInteractionParamsStreaming
-      | undefined;
+      Interactions.CreateModelInteractionParamsStreaming | undefined;
     const capturingClient = {
       interactions: {
         create: async (

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAINormalize.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAINormalize.vitest.ts
@@ -120,9 +120,7 @@ function buildConfig(
 }
 
 type NormalizingHandler =
-  | ModelHandlerDeepSeek
-  | ModelHandlerKimi
-  | ModelHandlerDashScope;
+  ModelHandlerDeepSeek | ModelHandlerKimi | ModelHandlerDashScope;
 
 async function runNormalize(handler: NormalizingHandler) {
   const loggerStub = createLoggerStub();

--- a/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
@@ -13,7 +13,6 @@ import {
   type ProcessingContext,
 } from '@agent/output/OutputFileProcessor';
 import type { XmlOutputManager } from '@agent/output/XmlOutputManager';
-import { flexibleFS } from '@utils/files';
 import { normalizeRunId } from '@common/constants/runIds';
 import type {
   AgentFileLocation,
@@ -24,7 +23,8 @@ import type {
   OutputXmlSummary,
   RoundOutput,
 } from '@shared/schemas';
-import { createRecordingHost } from '../progressTestUtils';
+import { flexibleFS } from '@utils/files';
+import { createRecordingHost, withTestRunContext } from '../progressTestUtils';
 
 function createLocation(path: string): FileLocation {
   return { kind: 'external', absolutePath: path };
@@ -142,27 +142,32 @@ describe('output progress events', () => {
       xmlSummary: emptyXmlSummary,
     };
 
-    const transition = await outputNode.post(
-      { roundOutputs: [] } as never,
-      {
-        outputLocation,
-        currentRound: 2,
-        endTurn: false,
-      },
-      {
-        roundOutput,
-        summary: {
-          storageKey: normalizeRunId('run:output-node'),
-          currRound: 2,
-          fileInfos: [fileInfo],
-          filesToOpen: [openedLocation],
-          outputFile: outputLocation,
-          endTurn: false,
-        },
-        compileFailures: [],
-        compiledArtifacts: [],
-        emitCompileFailures: false,
-      },
+    const transition = await withTestRunContext(
+      host,
+      'stream:output-node',
+      () =>
+        outputNode.post(
+          { roundOutputs: [] } as never,
+          {
+            outputLocation,
+            currentRound: 2,
+            endTurn: false,
+          },
+          {
+            roundOutput,
+            summary: {
+              storageKey: normalizeRunId('run:output-node'),
+              currRound: 2,
+              fileInfos: [fileInfo],
+              filesToOpen: [openedLocation],
+              outputFile: outputLocation,
+              endTurn: false,
+            },
+            compileFailures: [],
+            compiledArtifacts: [],
+            emitCompileFailures: false,
+          },
+        ),
     );
 
     expect(transition).toBe('default');
@@ -199,21 +204,23 @@ describe('output progress events', () => {
     } = createCompileFailureFixture();
     const shared = { roundOutputs: [] } as unknown as ReflectionFlowShared;
 
-    await outputNode.post(
-      shared,
-      {
-        outputLocation,
-        currentRound: 0,
-        endTurn: false,
-      },
-      {
-        roundOutput,
-        summary,
-        compileFailures: [compileFailure],
-        compileResult,
-        compiledArtifacts: [],
-        emitCompileFailures: false,
-      },
+    await withTestRunContext(host, 'stream:compile-context', () =>
+      outputNode.post(
+        shared,
+        {
+          outputLocation,
+          currentRound: 0,
+          endTurn: false,
+        },
+        {
+          roundOutput,
+          summary,
+          compileFailures: [compileFailure],
+          compileResult,
+          compiledArtifacts: [],
+          emitCompileFailures: false,
+        },
+      ),
     );
 
     expect(shared.lastCompileResult).toEqual(compileResult);
@@ -244,21 +251,23 @@ describe('output progress events', () => {
     } = createCompileFailureFixture();
     const shared = { roundOutputs: [] } as unknown as ReflectionFlowShared;
 
-    await outputNode.post(
-      shared,
-      {
-        outputLocation,
-        currentRound: 0,
-        endTurn: false,
-      },
-      {
-        roundOutput,
-        summary,
-        compileFailures: [compileFailure],
-        compileResult,
-        compiledArtifacts: [],
-        emitCompileFailures: false,
-      },
+    await withTestRunContext(host, 'stream:compile-context-disabled', () =>
+      outputNode.post(
+        shared,
+        {
+          outputLocation,
+          currentRound: 0,
+          endTurn: false,
+        },
+        {
+          roundOutput,
+          summary,
+          compileFailures: [compileFailure],
+          compileResult,
+          compiledArtifacts: [],
+          emitCompileFailures: false,
+        },
+      ),
     );
 
     expect(shared.lastCompileResult).toEqual(compileResult);
@@ -288,21 +297,23 @@ describe('output progress events', () => {
       },
     } as unknown as ReflectionFlowShared;
 
-    await outputNode.post(
-      shared,
-      {
-        outputLocation,
-        currentRound: 1,
-        endTurn: false,
-      },
-      {
-        roundOutput: { ...roundOutput, round: 1, compileFailures: [] },
-        summary: { ...summary, currRound: 1 },
-        compileFailures: [],
-        compileResult,
-        compiledArtifacts: [],
-        emitCompileFailures: false,
-      },
+    await withTestRunContext(host, 'stream:compile-context-ok', () =>
+      outputNode.post(
+        shared,
+        {
+          outputLocation,
+          currentRound: 1,
+          endTurn: false,
+        },
+        {
+          roundOutput: { ...roundOutput, round: 1, compileFailures: [] },
+          summary: { ...summary, currRound: 1 },
+          compileFailures: [],
+          compileResult,
+          compiledArtifacts: [],
+          emitCompileFailures: false,
+        },
+      ),
     );
 
     expect(shared.lastCompileResult).toEqual(compileResult);

--- a/src/test-kernel/agent/progressTestUtils.ts
+++ b/src/test-kernel/agent/progressTestUtils.ts
@@ -1,6 +1,13 @@
 // Local imports
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import {
+  createRunContext,
+  withRunContext,
+  type RunCoordinators,
+} from '@agent/runtime/RunContext';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
 export type RecordedProgressEvent = {
   event: keyof ProgressEventPayloads;
@@ -18,4 +25,32 @@ export function createRecordingHost(): {
       emit: (event, payload) => events.push({ event, payload }),
     },
   };
+}
+
+/**
+ * Run `fn` inside a launch `RunContext` carrying `runtimeHost`/`streamId`.
+ *
+ * Flow nodes read these from the ambient `RunContext` rather than the
+ * services bag (DI cleanup Step 2) — production always runs them inside
+ * `withExecutionRunContext`, which always projects a `launch` context. Tests
+ * that call a node's `exec`/`post` directly need the same scope.
+ */
+export function withTestRunContext<T>(
+  runtimeHost: AgentRuntimeHost,
+  streamId: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return withRunContext(
+    createRunContext({
+      runtimeHost,
+      streamId: streamId as StreamTabId,
+      executionId: 'test-execution' as ExecutionId,
+      coordinators: {} as RunCoordinators,
+      modelSource: 'live',
+      getModel: () => undefined,
+      agentName: 'test-agent',
+      session: {} as SessionHandle,
+    }),
+    fn,
+  ) as Promise<T>;
 }

--- a/src/test-kernel/agent/progressTestUtils.ts
+++ b/src/test-kernel/agent/progressTestUtils.ts
@@ -44,7 +44,7 @@ export function withTestRunContext<T>(
     createRunContext({
       runtimeHost,
       streamId: streamId as StreamTabId,
-      executionId: 'test-execution' as ExecutionId,
+      executionId: 'deadbeef' as ExecutionId,
       coordinators: {} as RunCoordinators,
       modelSource: 'live',
       getModel: () => undefined,

--- a/src/test-kernel/auth/TierService.vitest.ts
+++ b/src/test-kernel/auth/TierService.vitest.ts
@@ -144,20 +144,19 @@ describe('TierService', () => {
   });
 
   it('clears the synchronous snapshots on clearCache', async () => {
-    const fetchMock = vi.fn(
-      (): Promise<Response> =>
-        Promise.resolve(
-          jsonResponse(
-            tierConfig({
-              spendingStatus: {
-                currentSpend: 100,
-                limit: 300,
-                remaining: 200,
-                percentUsed: 33,
-              },
-            }),
-          ),
+    const fetchMock = vi.fn((): Promise<Response> =>
+      Promise.resolve(
+        jsonResponse(
+          tierConfig({
+            spendingStatus: {
+              currentSpend: 100,
+              limit: 300,
+              remaining: 200,
+              percentUsed: 33,
+            },
+          }),
         ),
+      ),
     );
     vi.stubGlobal('fetch', fetchMock);
 

--- a/src/test-kernel/cli/AuthCommand.vitest.mts
+++ b/src/test-kernel/cli/AuthCommand.vitest.mts
@@ -39,8 +39,7 @@ function spyOnStreamWrite(
     .mockImplementation((chunk: unknown, ...rest: unknown[]) => {
       append(String(chunk));
       const cb = rest.find((arg) => typeof arg === 'function') as
-        | ((err?: Error | null) => void)
-        | undefined;
+        ((err?: Error | null) => void) | undefined;
       cb?.(null);
       return true;
     }) as unknown as ReturnType<typeof vi.spyOn>;

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -1173,8 +1173,7 @@ describe('runCli usage output stream routing', () => {
       .mockImplementation((chunk: unknown, ...rest: unknown[]) => {
         stdout += String(chunk);
         const cb = rest.find((arg) => typeof arg === 'function') as
-          | ((err?: Error | null) => void)
-          | undefined;
+          ((err?: Error | null) => void) | undefined;
         cb?.(null);
         return true;
       }) as unknown as ReturnType<typeof vi.spyOn>;
@@ -1183,8 +1182,7 @@ describe('runCli usage output stream routing', () => {
       .mockImplementation((chunk: unknown, ...rest: unknown[]) => {
         stderr += String(chunk);
         const cb = rest.find((arg) => typeof arg === 'function') as
-          | ((err?: Error | null) => void)
-          | undefined;
+          ((err?: Error | null) => void) | undefined;
         cb?.(null);
         return true;
       }) as unknown as ReturnType<typeof vi.spyOn>;

--- a/src/test-kernel/cli/Doctor.vitest.mts
+++ b/src/test-kernel/cli/Doctor.vitest.mts
@@ -81,8 +81,7 @@ function captureDoctorStdout(
     .mockImplementation((chunk: unknown, ...rest: unknown[]) => {
       stdout += String(chunk);
       const cb = rest.find((arg) => typeof arg === 'function') as
-        | ((error?: Error | null) => void)
-        | undefined;
+        ((error?: Error | null) => void) | undefined;
       cb?.(null);
       return true;
     }) as unknown as ReturnType<typeof vi.spyOn>;

--- a/src/test-kernel/cli/InitCommand.vitest.mts
+++ b/src/test-kernel/cli/InitCommand.vitest.mts
@@ -111,8 +111,7 @@ describe('CLI init command', () => {
       .mockImplementation((chunk: unknown, ...rest: unknown[]) => {
         stdout += String(chunk);
         const cb = rest.find((arg) => typeof arg === 'function') as
-          | ((err?: Error | null) => void)
-          | undefined;
+          ((err?: Error | null) => void) | undefined;
         cb?.(null);
         return true;
       }) as unknown as ReturnType<typeof vi.spyOn>;
@@ -121,8 +120,7 @@ describe('CLI init command', () => {
       .mockImplementation((chunk: unknown, ...rest: unknown[]) => {
         stderr += String(chunk);
         const cb = rest.find((arg) => typeof arg === 'function') as
-          | ((err?: Error | null) => void)
-          | undefined;
+          ((err?: Error | null) => void) | undefined;
         cb?.(null);
         return true;
       }) as unknown as ReturnType<typeof vi.spyOn>;

--- a/src/test-kernel/cli/ToolsCommand.vitest.mts
+++ b/src/test-kernel/cli/ToolsCommand.vitest.mts
@@ -48,8 +48,7 @@ describe('CLI tools command', () => {
       .mockImplementation((chunk: unknown, ...rest: unknown[]) => {
         stdout += String(chunk);
         const cb = rest.find((arg) => typeof arg === 'function') as
-          | ((err?: Error | null) => void)
-          | undefined;
+          ((err?: Error | null) => void) | undefined;
         cb?.(null);
         return true;
       }) as unknown as ReturnType<typeof vi.spyOn>;
@@ -58,8 +57,7 @@ describe('CLI tools command', () => {
       .mockImplementation((chunk: unknown, ...rest: unknown[]) => {
         stderr += String(chunk);
         const cb = rest.find((arg) => typeof arg === 'function') as
-          | ((err?: Error | null) => void)
-          | undefined;
+          ((err?: Error | null) => void) | undefined;
         cb?.(null);
         return true;
       }) as unknown as ReturnType<typeof vi.spyOn>;

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -1124,8 +1124,7 @@ describe('desktop settings IPC', () => {
             toggleable: true,
             enabled: !(
               globalState.values.get(GlobalStateKey.DISABLED_TOOLS) as
-                | string[]
-                | undefined
+                string[] | undefined
             )?.includes('zotero'),
           },
         ];

--- a/src/test-kernel/desktop/ElectronAgentDirectories.vitest.mts
+++ b/src/test-kernel/desktop/ElectronAgentDirectories.vitest.mts
@@ -119,6 +119,10 @@ describe('desktop agent directory bootstrap', () => {
       lifecycle: createLifecycleHost(),
       agentResume: { tryResumeStream: async () => false },
       toolAvailability: NO_TOOL_AVAILABILITY_HOST,
+      linter: async () => [],
+      addCriticismSink: () => ({ accepted: false, resolvedPath: '' }),
+      toolMissingHandler: () => {},
+      toolNotificationHandler: () => {},
     });
 
     return {

--- a/src/test-kernel/desktop/ElectronHostBridge.vitest.mts
+++ b/src/test-kernel/desktop/ElectronHostBridge.vitest.mts
@@ -131,8 +131,7 @@ describe('desktop Electron host bridge', () => {
     const { ELECTRON_WEBVIEW_MESSAGE_CHANNEL, ELECTRON_WEBVIEW_PUSH_CHANNEL } =
       await loadHostBridgeModule();
     let rendererListener:
-      | ((event: { sender: unknown }, message: unknown) => void)
-      | undefined;
+      ((event: { sender: unknown }, message: unknown) => void) | undefined;
     const ipcMain = {
       on: vi.fn((channel, listener) => {
         expect(channel).toBe(ELECTRON_WEBVIEW_MESSAGE_CHANNEL);

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
@@ -104,8 +104,7 @@ describe('desktop main-view IPC', () => {
 
   it('pushes theme and debug state over the fixed host bridge channel', async () => {
     let rendererListener:
-      | ((event: { sender: unknown }, message: unknown) => void)
-      | undefined;
+      ((event: { sender: unknown }, message: unknown) => void) | undefined;
     let themeListener: (() => void) | undefined;
     const ipcMain = {
       on: vi.fn((channel, listener) => {
@@ -399,8 +398,7 @@ describe('desktop main-view IPC', () => {
 
   it('uses desktop auth status when posting main-view startup login state', async () => {
     let rendererListener:
-      | ((event: { sender: unknown }, message: unknown) => void)
-      | undefined;
+      ((event: { sender: unknown }, message: unknown) => void) | undefined;
     const ipcMain = {
       on: vi.fn((channel, listener) => {
         rendererListener = listener;
@@ -471,8 +469,7 @@ describe('desktop main-view IPC', () => {
 
   it('waits for desktop model-list refresh before posting main-view model options', async () => {
     let rendererListener:
-      | ((event: { sender: unknown }, message: unknown) => void)
-      | undefined;
+      ((event: { sender: unknown }, message: unknown) => void) | undefined;
     const ipcMain = {
       on: vi.fn((channel, listener) => {
         rendererListener = listener;

--- a/src/test-kernel/desktop/electronTestStub.mts
+++ b/src/test-kernel/desktop/electronTestStub.mts
@@ -7,10 +7,7 @@ import { join } from 'node:path';
 import { repoPath } from './desktopTestPaths.mjs';
 
 type SafeStorageBackend =
-  | 'basic_text'
-  | 'gnome_libsecret'
-  | 'kwallet'
-  | 'os_crypt';
+  'basic_text' | 'gnome_libsecret' | 'kwallet' | 'os_crypt';
 
 type MessageBoxOptions = { message: string; type?: string };
 

--- a/src/test-kernel/hosts/FakeHosts.vitest.ts
+++ b/src/test-kernel/hosts/FakeHosts.vitest.ts
@@ -3,7 +3,7 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'vitest';
 
 // Local imports - test support
-import { FakeTerminalHandle, createFakeUIHosts } from '../support/FakeHosts';
+import { createFakeUIHosts } from '../support/FakeHosts';
 
 describe('FakeHosts', () => {
   it('records prompt effects and returns queued responses', async () => {
@@ -64,9 +64,8 @@ describe('FakeHosts', () => {
     ]);
   });
 
-  it('records opener, clipboard, terminal, and diff effects', async () => {
+  it('records opener and diff effects', async () => {
     const hosts = createFakeUIHosts({
-      clipboardText: 'initial',
       proposedDiffContent: { '/tmp/proposed.tex': 'edited' },
     });
 
@@ -74,31 +73,6 @@ describe('FakeHosts', () => {
     await hosts.externalOpener.openPath('/workspace/main.pdf');
     assert.deepEqual(hosts.externalOpener.externalUrls, ['https://texra.ai']);
     assert.deepEqual(hosts.externalOpener.paths, ['/workspace/main.pdf']);
-
-    assert.equal(await hosts.clipboard.readText(), 'initial');
-    await hosts.clipboard.writeText('copied');
-    assert.equal(await hosts.clipboard.readText(), 'copied');
-    assert.deepEqual(hosts.clipboard.writes, ['copied']);
-
-    const terminal = hosts.terminal.createTerminal({ name: 'Setup' });
-    terminal.show(true);
-    terminal.sendText('npm install', true);
-    const foundTerminal = hosts.terminal.findTerminal('Setup');
-    const listedTerminals = hosts.terminal.getTerminals();
-    assert.ok(foundTerminal);
-    assert.notEqual(foundTerminal, terminal);
-    assert.equal(foundTerminal.name, 'Setup');
-    assert.equal(listedTerminals.length, 1);
-    assert.notEqual(listedTerminals[0], terminal);
-    assert.equal(listedTerminals[0]?.name, 'Setup');
-    assert.ok(terminal instanceof FakeTerminalHandle);
-    assert.deepEqual(terminal.showCalls, [{ preserveFocus: true }]);
-    assert.deepEqual(terminal.sentText, [
-      { text: 'npm install', shouldExecute: true },
-    ]);
-    terminal.dispose();
-    assert.equal(hosts.terminal.findTerminal('Setup'), undefined);
-    assert.deepEqual(hosts.terminal.getTerminals(), []);
 
     const session = await hosts.diff.openDiff(
       { filePath: '/tmp/original.tex' },

--- a/src/test-kernel/logger/errorData.vitest.ts
+++ b/src/test-kernel/logger/errorData.vitest.ts
@@ -21,8 +21,7 @@ describe('AgentTrace error data', () => {
     logger.error(`Error occurred: ${err.message}`, { data: err });
     const log = getDefaultStreamLogStore().get('TestErrorLogger');
     const captured = log?.getRange(0, log.head).at(-1) as
-      | { data: any }
-      | undefined;
+      { data: any } | undefined;
     assert.ok(captured);
     assert.strictEqual(captured.data.message, 'test failure');
     assert.ok(captured.data.stack);

--- a/src/test-kernel/settings/SettingsReliabilityPlacement.vitest.ts
+++ b/src/test-kernel/settings/SettingsReliabilityPlacement.vitest.ts
@@ -85,8 +85,7 @@ describe('settings reliability placement', () => {
     const section = await getReliabilitySection(tab);
 
     const input = section?.shadowRoot?.querySelector('wa-input') as
-      | (HTMLElement & { value: string })
-      | null;
+      (HTMLElement & { value: string }) | null;
     expect(input).not.toBeNull();
     input!.value = '101';
     input!.dispatchEvent(

--- a/src/test-kernel/settings/litComponentTestUtils.ts
+++ b/src/test-kernel/settings/litComponentTestUtils.ts
@@ -75,8 +75,7 @@ function installAnimationPolyfill(window: JSDOM['window']): void {
   // resolve immediately. Returning [] means "no animations" — animateWithClass
   // resolves on the next raf, which matches the visible behavior in tests.
   const proto = window.Element?.prototype as
-    | (Element & { getAnimations?: () => unknown[] })
-    | undefined;
+    (Element & { getAnimations?: () => unknown[] }) | undefined;
   if (!proto) return;
   if (typeof proto.getAnimations !== 'function') {
     proto.getAnimations = () => [];

--- a/src/test-kernel/shared/ChildActivityReducer.vitest.ts
+++ b/src/test-kernel/shared/ChildActivityReducer.vitest.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { diffActiveChildren } from '@shared/streams/childActivityReducer';
+
+interface Child {
+  readonly executionId: string;
+}
+
+function child(executionId: string): Child {
+  return { executionId };
+}
+
+describe('diffActiveChildren', () => {
+  it('reports no vanished ids when previous is empty', () => {
+    const { next, vanishedIds } = diffActiveChildren([], [child('a')]);
+
+    expect(next).toEqual([child('a')]);
+    expect(vanishedIds.size).toBe(0);
+  });
+
+  it('reports all previous ids as vanished when next is empty', () => {
+    const { vanishedIds } = diffActiveChildren([child('a'), child('b')], []);
+
+    expect(vanishedIds).toEqual(new Set(['a', 'b']));
+  });
+
+  it('reports only the ids that dropped out on partial overlap', () => {
+    const { vanishedIds } = diffActiveChildren(
+      [child('a'), child('b'), child('c')],
+      [child('b'), child('c'), child('d')],
+    );
+
+    expect(vanishedIds).toEqual(new Set(['a']));
+  });
+
+  it('is unaffected by duplicate ids in either input', () => {
+    const { vanishedIds } = diffActiveChildren(
+      [child('a'), child('a'), child('b')],
+      [child('a')],
+    );
+
+    expect(vanishedIds).toEqual(new Set(['b']));
+  });
+
+  it('reports nothing vanished when previous and next are identical', () => {
+    const { vanishedIds } = diffActiveChildren(
+      [child('a'), child('b')],
+      [child('a'), child('b')],
+    );
+
+    expect(vanishedIds.size).toBe(0);
+  });
+
+  it('passes next through unchanged', () => {
+    const nextList = [child('a')];
+    const { next } = diffActiveChildren([], nextList);
+
+    expect(next).toBe(nextList);
+  });
+});

--- a/src/test-kernel/shared/ChildActivityReducer.vitest.ts
+++ b/src/test-kernel/shared/ChildActivityReducer.vitest.ts
@@ -12,20 +12,19 @@ function child(executionId: string): Child {
 
 describe('diffActiveChildren', () => {
   it('reports no vanished ids when previous is empty', () => {
-    const { next, vanishedIds } = diffActiveChildren([], [child('a')]);
+    const vanishedIds = diffActiveChildren([], [child('a')]);
 
-    expect(next).toEqual([child('a')]);
     expect(vanishedIds.size).toBe(0);
   });
 
   it('reports all previous ids as vanished when next is empty', () => {
-    const { vanishedIds } = diffActiveChildren([child('a'), child('b')], []);
+    const vanishedIds = diffActiveChildren([child('a'), child('b')], []);
 
     expect(vanishedIds).toEqual(new Set(['a', 'b']));
   });
 
   it('reports only the ids that dropped out on partial overlap', () => {
-    const { vanishedIds } = diffActiveChildren(
+    const vanishedIds = diffActiveChildren(
       [child('a'), child('b'), child('c')],
       [child('b'), child('c'), child('d')],
     );
@@ -34,7 +33,7 @@ describe('diffActiveChildren', () => {
   });
 
   it('is unaffected by duplicate ids in either input', () => {
-    const { vanishedIds } = diffActiveChildren(
+    const vanishedIds = diffActiveChildren(
       [child('a'), child('a'), child('b')],
       [child('a')],
     );
@@ -43,18 +42,11 @@ describe('diffActiveChildren', () => {
   });
 
   it('reports nothing vanished when previous and next are identical', () => {
-    const { vanishedIds } = diffActiveChildren(
+    const vanishedIds = diffActiveChildren(
       [child('a'), child('b')],
       [child('a'), child('b')],
     );
 
     expect(vanishedIds.size).toBe(0);
-  });
-
-  it('passes next through unchanged', () => {
-    const nextList = [child('a')];
-    const { next } = diffActiveChildren([], nextList);
-
-    expect(next).toBe(nextList);
   });
 });

--- a/src/test-kernel/support/FakeHosts.ts
+++ b/src/test-kernel/support/FakeHosts.ts
@@ -1,6 +1,5 @@
 // Local imports - hosts
 import type {
-  ClipboardHost,
   DiffOptions,
   DiffSession,
   DiffSource,
@@ -10,9 +9,6 @@ import type {
   PromptHost,
   PromptInputOptions,
   PromptMessageOptions,
-  TerminalHandle,
-  TerminalHost,
-  TerminalOptions,
 } from '@hosts/uiHosts';
 
 export type PromptEventKind = 'info' | 'warning' | 'error';
@@ -44,20 +40,10 @@ export interface DiffRevealEvent {
   line: number;
 }
 
-export interface TerminalSendEvent {
-  text: string;
-  shouldExecute?: boolean;
-}
-
-export interface TerminalShowEvent {
-  preserveFocus?: boolean;
-}
-
 export interface FakeUIHostsOptions {
   promptResponses?: readonly string[];
   confirmResponses?: readonly boolean[];
   inputResponses?: readonly (string | undefined)[];
-  clipboardText?: string;
   proposedDiffContent?: Record<string, string>;
 }
 
@@ -149,21 +135,6 @@ export class FakeExternalOpener implements ExternalOpener {
   }
 }
 
-export class FakeClipboardHost implements ClipboardHost {
-  readonly writes: string[] = [];
-
-  constructor(private text = '') {}
-
-  async readText(): Promise<string> {
-    return this.text;
-  }
-
-  async writeText(text: string): Promise<void> {
-    this.text = text;
-    this.writes.push(text);
-  }
-}
-
 export class FakeDiffViewHost implements DiffViewHost {
   readonly opened: DiffOpenEvent[] = [];
 
@@ -211,80 +182,8 @@ export class FakeDiffViewHost implements DiffViewHost {
   }
 }
 
-export class FakeTerminalHost implements TerminalHost {
-  readonly created: FakeTerminalHandle[] = [];
-
-  createTerminal(options: TerminalOptions): FakeTerminalHandle {
-    const terminal = new FakeTerminalHandle(options);
-    this.created.push(terminal);
-    return terminal;
-  }
-
-  findTerminal(name: string): TerminalHandle | undefined {
-    const terminal = this.created.find(
-      (terminal) => terminal.name === name && !terminal.isDisposed,
-    );
-    return terminal?.createLookupHandle();
-  }
-
-  getTerminals(): readonly TerminalHandle[] {
-    return this.created
-      .filter((terminal) => !terminal.isDisposed)
-      .map((terminal) => terminal.createLookupHandle());
-  }
-}
-
-interface FakeTerminalState {
-  sentText: TerminalSendEvent[];
-  showCalls: TerminalShowEvent[];
-  isDisposed: boolean;
-}
-
-export class FakeTerminalHandle implements TerminalHandle {
-  constructor(
-    readonly options: TerminalOptions,
-    private readonly state: FakeTerminalState = {
-      sentText: [],
-      showCalls: [],
-      isDisposed: false,
-    },
-  ) {}
-
-  get sentText(): readonly TerminalSendEvent[] {
-    return this.state.sentText;
-  }
-
-  get showCalls(): readonly TerminalShowEvent[] {
-    return this.state.showCalls;
-  }
-
-  get isDisposed(): boolean {
-    return this.state.isDisposed;
-  }
-
-  get name(): string {
-    return this.options.name;
-  }
-
-  sendText(text: string, shouldExecute?: boolean): void {
-    this.state.sentText.push({ text, shouldExecute });
-  }
-
-  show(preserveFocus?: boolean): void {
-    this.state.showCalls.push({ preserveFocus });
-  }
-
-  dispose(): void {
-    this.state.isDisposed = true;
-  }
-
-  createLookupHandle(): FakeTerminalHandle {
-    return new FakeTerminalHandle(this.options, this.state);
-  }
-}
-
 /**
- * The five UI ports a host wires together. Production hosts (VS Code,
+ * The three UI ports a host wires together. Production hosts (VS Code,
  * desktop) inject each port individually; this aggregate exists only so
  * test support can assemble and pass them as a single bundle.
  */
@@ -292,16 +191,12 @@ export interface UIHosts {
   readonly prompt: PromptHost;
   readonly externalOpener: ExternalOpener;
   readonly diff: DiffViewHost;
-  readonly terminal: TerminalHost;
-  readonly clipboard: ClipboardHost;
 }
 
 export interface FakeUIHosts extends UIHosts {
   readonly prompt: FakePromptHost;
   readonly externalOpener: FakeExternalOpener;
   readonly diff: FakeDiffViewHost;
-  readonly terminal: FakeTerminalHost;
-  readonly clipboard: FakeClipboardHost;
 }
 
 export function createFakeUIHosts(
@@ -311,7 +206,5 @@ export function createFakeUIHosts(
     prompt: new FakePromptHost(options),
     externalOpener: new FakeExternalOpener(),
     diff: new FakeDiffViewHost(options.proposedDiffContent),
-    terminal: new FakeTerminalHost(),
-    clipboard: new FakeClipboardHost(options.clipboardText),
   };
 }

--- a/src/test-kernel/support/FakePlatform.ts
+++ b/src/test-kernel/support/FakePlatform.ts
@@ -758,6 +758,10 @@ export function createFakePlatform(
     lifecycle: createLifecycleHost(),
     agentResume: { tryResumeStream: async () => false },
     toolAvailability: NO_TOOL_AVAILABILITY_HOST,
+    linter: async () => [],
+    addCriticismSink: () => ({ accepted: false, resolvedPath: '' }),
+    toolMissingHandler: () => {},
+    toolNotificationHandler: () => {},
     ...overrides,
   };
 }

--- a/src/test-kernel/tools/DiagnosticsTool.vitest.ts
+++ b/src/test-kernel/tools/DiagnosticsTool.vitest.ts
@@ -1,16 +1,33 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
-import {
-  DiagnosticsTool,
-  setAddCriticismSink,
-  setLinterProvider,
-} from '@tools/DiagnosticsTool';
+import { DiagnosticsTool } from '@tools/DiagnosticsTool';
+import type { GenericDiagnostic } from '@utils/diagnostics/diagnosticFormatting';
+import { createFakePlatform } from '../support/FakePlatform';
+import type { AddCriticismSink } from '@platform/interfaces/criticism';
 
-afterEach(() => {
-  setLinterProvider(async () => []);
-  setAddCriticismSink(() => ({ accepted: false, resolvedPath: '' }));
+async function installPlatform(
+  overrides: Parameters<typeof createFakePlatform>[1] = {},
+): Promise<void> {
+  const { initPlatform } = await import('@platform/platform');
+  initPlatform(createFakePlatform({}, overrides));
+}
+
+afterEach(async () => {
+  await installPlatform();
 });
+
+function installLinter(
+  linter: (path: string) => Promise<GenericDiagnostic[]>,
+): Promise<void> {
+  return installPlatform({ linter });
+}
+
+function installAddCriticismSink(
+  addCriticismSink: AddCriticismSink,
+): Promise<void> {
+  return installPlatform({ addCriticismSink });
+}
 
 function worktreeContext() {
   return createRunContext({
@@ -22,7 +39,7 @@ function worktreeContext() {
 describe('DiagnosticsTool', () => {
   it('reads diagnostics from the active working directory root', async () => {
     const paths: string[] = [];
-    setLinterProvider(async (path) => {
+    await installLinter(async (path) => {
       paths.push(path);
       return [];
     });
@@ -50,7 +67,7 @@ describe('DiagnosticsTool', () => {
   });
 
   it('reports when the criticism sink does not accept (feature disabled)', async () => {
-    setAddCriticismSink(() => ({ accepted: false, resolvedPath: '' }));
+    await installAddCriticismSink(() => ({ accepted: false, resolvedPath: '' }));
 
     const result = await withRunContext(worktreeContext(), () =>
       new DiagnosticsTool().call({
@@ -68,7 +85,7 @@ describe('DiagnosticsTool', () => {
 
   it('resolves the path and summarizes an accepted criticism', async () => {
     const entries: unknown[] = [];
-    setAddCriticismSink((entry) => {
+    await installAddCriticismSink((entry) => {
       entries.push(entry);
       return { accepted: true, resolvedPath: entry.absolutePath };
     });

--- a/src/test-kernel/tools/DiagnosticsTool.vitest.ts
+++ b/src/test-kernel/tools/DiagnosticsTool.vitest.ts
@@ -67,7 +67,10 @@ describe('DiagnosticsTool', () => {
   });
 
   it('reports when the criticism sink does not accept (feature disabled)', async () => {
-    await installAddCriticismSink(() => ({ accepted: false, resolvedPath: '' }));
+    await installAddCriticismSink(() => ({
+      accepted: false,
+      resolvedPath: '',
+    }));
 
     const result = await withRunContext(worktreeContext(), () =>
       new DiagnosticsTool().call({

--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -2,13 +2,13 @@
 import { toJSONSchema, z } from 'zod';
 
 // Internal imports
+import { platform } from '@platform/platform';
 import { tryUseRunContext } from '@agent/runtime/RunContext';
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import type { ToolDefinition } from '@model';
 import { type ToolResult, ToolError } from '@shared/schemas/toolResult';
 import { resolveWorkspaceRelativePath } from '@tools/pathResolution';
-import type { GenericDiagnostic } from '@utils/diagnostics/diagnosticFormatting';
 import {
   countBySeverity,
   formatCounts,
@@ -20,49 +20,6 @@ import { defineTool } from './core/define';
 
 const CHANNEL = 'DiagnosticsTool';
 logger.initialize(CHANNEL);
-
-type LinterProvider = (path: string) => Promise<GenericDiagnostic[]>;
-let linterProvider: LinterProvider = async () => [];
-/** Inject the VS Code linter diagnostics provider. Default: returns empty. */
-export function setLinterProvider(provider: LinterProvider): void {
-  linterProvider = provider;
-}
-
-/**
- * Host-resolved shape for a single criticism entry pushed by the `add`
- * command. The tool resolves the input `path` against the active working
- * directory before handing the entry to the host as `absolutePath`.
- */
-export interface ManualCriticismEntry {
-  /** Absolute path resolved by the tool. */
-  absolutePath: string;
-  /** 1-based line number. */
-  line: number;
-  message: string;
-  /** 0–5; mapped to DiagnosticSeverity by the host. */
-  severity: number;
-  /** 1–5; appended to the message as `(S/C)`. */
-  confidence: number;
-}
-
-/**
- * Sink injected by the extension host for the `add` command. Returns
- * `accepted: false` when the experimental setting is disabled so the tool can
- * surface that to the agent.
- */
-export type AddCriticismSink = (input: ManualCriticismEntry) => {
-  accepted: boolean;
-  resolvedPath: string;
-};
-
-let criticismSink: AddCriticismSink = () => ({
-  accepted: false,
-  resolvedPath: '',
-});
-
-export function setAddCriticismSink(provider: AddCriticismSink): void {
-  criticismSink = provider;
-}
 
 const DiagnosticsPathSchema = z
   .string()
@@ -156,7 +113,7 @@ export class DiagnosticsTool extends defineTool({
     const diagnosticsPath = this.resolveAbsolutePath(path);
 
     try {
-      const messages = await linterProvider(diagnosticsPath);
+      const messages = await platform().linter(diagnosticsPath);
       const counts = countBySeverity(messages);
       const header = `${diagnosticsPath}: ${formatCounts(counts)}`;
       const summary = `Diagnostics ${command} for ${diagnosticsPath}`;
@@ -203,7 +160,7 @@ export class DiagnosticsTool extends defineTool({
 
     try {
       const absolutePath = this.resolveAbsolutePath(path);
-      const result = criticismSink({
+      const result = platform().addCriticismSink({
         absolutePath,
         line,
         message,

--- a/src/tools/github/githubClient.ts
+++ b/src/tools/github/githubClient.ts
@@ -18,8 +18,7 @@ const API_VERSION = '2022-11-28';
 const TIMEOUT_MS = 15_000;
 
 export type ConditionalResponse<T> =
-  | { status: 200; data: T; etag: string | undefined }
-  | { status: 304 };
+  { status: 200; data: T; etag: string | undefined } | { status: 304 };
 
 export class GitHubAuthError extends Error {
   constructor(message = 'GitHub authentication failed') {

--- a/src/tools/inquiry/externalInquiryStorage.ts
+++ b/src/tools/inquiry/externalInquiryStorage.ts
@@ -81,16 +81,14 @@ const LegacyManifestSchema = z
     updatedAt: z.string().min(1),
     turns: z.array(ExternalInquiryTurnRecordSchema),
   })
-  .transform(
-    (raw): ExternalInquiryThreadManifest => ({
-      threadId: raw.threadId,
-      parentStreamId: null,
-      status: 'answered' as const,
-      createdAt: raw.createdAt,
-      updatedAt: raw.updatedAt,
-      turns: raw.turns,
-    }),
-  );
+  .transform((raw): ExternalInquiryThreadManifest => ({
+    threadId: raw.threadId,
+    parentStreamId: null,
+    status: 'answered' as const,
+    createdAt: raw.createdAt,
+    updatedAt: raw.updatedAt,
+    turns: raw.turns,
+  }));
 
 /**
  * Entry-point schema: try canonical (new format) first, then legacy.

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -180,8 +180,7 @@ const VALID_TOOL_NAME = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
  * Object form must have a name and can include optional description/parameters.
  */
 export type RawToolConfig =
-  | string
-  | (Partial<ToolDefinition> & { name: string });
+  string | (Partial<ToolDefinition> & { name: string });
 
 /**
  * Resolve raw tool configurations to ToolDefinition objects.

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -148,8 +148,7 @@ async function runProbes(): Promise<ExternalToolCheckResult[]> {
 
 async function resolveOptionalStatus(
   getStatus:
-    | ((probeResult?: unknown) => Promise<string | undefined>)
-    | undefined,
+    ((probeResult?: unknown) => Promise<string | undefined>) | undefined,
   probeResult: unknown,
 ): Promise<string | undefined> {
   if (!getStatus) return undefined;

--- a/src/tools/toolUnavailableNotification.ts
+++ b/src/tools/toolUnavailableNotification.ts
@@ -5,7 +5,7 @@
  * the host UI layer. The notification handler is injected via `platform()`.
  */
 
-import { platform } from '@platform/platform';
+import { tryPlatform } from '@platform/platform';
 import { mapToolNamesToGroups } from '@tools/toolAvailability';
 
 /** Groups already surfaced in a notification this session — avoids repeat popups. */
@@ -44,7 +44,7 @@ export function notifyUnavailableTools(excludedToolNames: string[]): void {
   const hiddenGroups = fresh.filter((g) => g.hideFromDashboard);
   if (hiddenGroups.length > 0) {
     const label = formatGroupLabel(hiddenGroups.map((g) => g.name));
-    platform().toolNotificationHandler(
+    tryPlatform()?.toolNotificationHandler(
       `${label} excluded — external dependencies not installed.`,
     );
   }
@@ -65,7 +65,7 @@ export function notifyUnavailableTools(excludedToolNames: string[]): void {
   for (const [bucketKey, bucket] of byAction) {
     const [cmd, label] = bucketKey.split('\0');
     const names = formatGroupLabel(bucket.map((g) => g.name));
-    platform().toolNotificationHandler(
+    tryPlatform()?.toolNotificationHandler(
       `${names} excluded — external dependencies not installed.`,
       cmd,
       label,

--- a/src/tools/toolUnavailableNotification.ts
+++ b/src/tools/toolUnavailableNotification.ts
@@ -2,38 +2,14 @@
  * Notification for unavailable external tools.
  *
  * Separated from the tool-use flow so the flow runner stays decoupled from
- * the host UI layer. The notification callback is injected at activation.
+ * the host UI layer. The notification handler is injected via `platform()`.
  */
 
+import { platform } from '@platform/platform';
 import { mapToolNamesToGroups } from '@tools/toolAvailability';
 
 /** Groups already surfaced in a notification this session — avoids repeat popups. */
 const notifiedGroups = new Set<string>();
-
-/**
- * Pluggable notification handler for unavailable tools.
- * Set by the extension host at activation; defaults to no-op.
- *
- * `actionCommand` and `actionLabel` let a notification funnel the user to the
- * right tab — e.g. the Git tab for the GitHub token rather than the generic
- * Tools dashboard.
- */
-let notificationHandler: (
-  message: string,
-  actionCommand?: string,
-  actionLabel?: string,
-) => void = () => {};
-
-/** Register a platform-specific notification handler. */
-export function setToolNotificationHandler(
-  handler: (
-    message: string,
-    actionCommand?: string,
-    actionLabel?: string,
-  ) => void,
-): void {
-  notificationHandler = handler;
-}
 
 const DEFAULT_ACTION_COMMAND = 'texra.showTools';
 const DEFAULT_ACTION_LABEL = 'Open Tools Dashboard';
@@ -68,7 +44,7 @@ export function notifyUnavailableTools(excludedToolNames: string[]): void {
   const hiddenGroups = fresh.filter((g) => g.hideFromDashboard);
   if (hiddenGroups.length > 0) {
     const label = formatGroupLabel(hiddenGroups.map((g) => g.name));
-    notificationHandler(
+    platform().toolNotificationHandler(
       `${label} excluded — external dependencies not installed.`,
     );
   }
@@ -89,7 +65,7 @@ export function notifyUnavailableTools(excludedToolNames: string[]): void {
   for (const [bucketKey, bucket] of byAction) {
     const [cmd, label] = bucketKey.split('\0');
     const names = formatGroupLabel(bucket.map((g) => g.name));
-    notificationHandler(
+    platform().toolNotificationHandler(
       `${names} excluded — external dependencies not installed.`,
       cmd,
       label,

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -73,9 +73,7 @@ const SEED_IO_CONCURRENCY = 8;
 
 type OutputFilesPatch = Map<number, OutputFileInfo[] | null>;
 type UsageUpdateResult =
-  | TokenUsageStats
-  | undefined
-  | Promise<TokenUsageStats | undefined>;
+  TokenUsageStats | undefined | Promise<TokenUsageStats | undefined>;
 
 /**
  * Round-keyed delta shape carried by the `addOutputFiles` /

--- a/src/utils/files/externalRoots.ts
+++ b/src/utils/files/externalRoots.ts
@@ -44,10 +44,7 @@ import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
 /** Stable identifier for each registered root. Label strings are for display
  *  only and must not be used as keys. */
 export type ExternalRootKind =
-  | 'builtInWorkflow'
-  | 'builtInToolUse'
-  | 'custom'
-  | 'agentDocs';
+  'builtInWorkflow' | 'builtInToolUse' | 'custom' | 'agentDocs';
 
 export interface ExternalRoot {
   /** Stable key, independent of UI text. */

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -6,6 +6,7 @@ import { execa, execaSync } from 'execa';
 import { parse as shellParse } from 'shell-quote';
 
 // Local imports
+import { platform } from '@platform/platform';
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import type { ExecResult } from '@shared/schemas/opResults';
@@ -40,31 +41,12 @@ interface ToolConfig {
   openDocsCommand?: string; // Optional command to open documentation
 }
 
-/**
- * Pluggable handler for surfacing tool-missing errors to the user.
- * Set by the extension host at activation; defaults to a no-op so this
- * module remains free of platform-specific (vscode) dependencies.
- */
-export type ToolMissingHandler = (
-  message: string,
-  openDocsCommand?: string,
-) => void | Promise<void>;
-
-let toolMissingHandler: ToolMissingHandler = () => {
-  // No-op by default; the extension host registers a real handler.
-};
-
-/** Register a platform-specific handler for displaying tool-missing errors. */
-export function setToolMissingHandler(handler: ToolMissingHandler): void {
-  toolMissingHandler = handler;
-}
-
 async function reportMissingTool(
   message: string,
   openDocsCommand?: string,
 ): Promise<void> {
   try {
-    await toolMissingHandler(message, openDocsCommand);
+    await platform().toolMissingHandler(message, openDocsCommand);
   } catch (err) {
     logger.error(
       CHANNEL,

--- a/supabase/functions/_shared/emailPolicy.ts
+++ b/supabase/functions/_shared/emailPolicy.ts
@@ -48,8 +48,7 @@ const PRIVACY_RELAY_EMAIL_DOMAINS: ReadonlySet<string> = new Set([
 ]);
 
 export type EmailPolicyDecision =
-  | { allowed: true }
-  | { allowed: false; reason: string; userMessage: string };
+  { allowed: true } | { allowed: false; reason: string; userMessage: string };
 
 function normalizeDomain(email: string): string | null {
   const at = email.lastIndexOf('@');

--- a/supabase/functions/_shared/relayCiToken.ts
+++ b/supabase/functions/_shared/relayCiToken.ts
@@ -37,8 +37,7 @@ export async function sha256Hex(value: string): Promise<string> {
 }
 
 export type CiTokenAuthResult =
-  | { ok: true; userId: string }
-  | { ok: false; status: number; message: string };
+  { ok: true; userId: string } | { ok: false; status: number; message: string };
 
 /**
  * Validate a CI relay token: hash lookup, revocation, expiry, and scope.

--- a/supabase/functions/relay/requestLimits.ts
+++ b/supabase/functions/relay/requestLimits.ts
@@ -28,10 +28,7 @@ export type RequestBodyReadResult =
   | (RequestBodySizeCheck & { allowed: false; body: null });
 
 export type RequestBodyForSizeCheck =
-  | string
-  | ArrayBuffer
-  | ArrayBufferView
-  | null;
+  string | ArrayBuffer | ArrayBufferView | null;
 
 function requestBodyByteLength(body: RequestBodyForSizeCheck): number {
   if (body == null) return 0;


### PR DESCRIPTION
## Summary

This PR completes the platform abstraction layer migration by moving host-injected services (linter, criticism sink, tool notifications, tool-missing handler) from scattered setter functions into the centralized `platform()` composition root. It also adds `withTestRunContext()` to properly scope flow node tests with the ambient `RunContext` that production code expects.

## Issue acceptance gates

Completes the DI cleanup work started in earlier PRs:
- Removes `setLinterProvider()`, `setAddCriticismSink()`, `setToolNotificationHandler()`, `setToolMissingHandler()` setter functions
- Centralizes all host-injected services in `platform()` 
- Eliminates scattered global state in favor of composition root injection
- Adds `useLaunchRunContext()` helper for flow nodes to read `streamId`/`executionId`/`runtimeHost` from ambient context instead of service bag

## Single source of truth

**Platform composition root** (`src/platform/platform.ts`) now owns all host-injected services:
- `linter` (diagnostics provider)
- `addCriticismSink` (inline criticism sink)
- `toolMissingHandler` (tool-missing error UI)
- `toolNotificationHandler` (tool unavailability notifications)

**RunContext** (`src/agent/runtime/RunContext.ts`) now owns launch-scoped identifiers (`streamId`, `executionId`, `runtimeHost`) that flow nodes read via `useLaunchRunContext()` instead of deriving from service bags.

## Duplication and abstraction budget

**Removed:**
- 5 setter functions and their associated module-level state variables
- Duplicate `ManualCriticismEntry` and `AddCriticismSink` types (now in `src/platform/interfaces/criticism.ts`)
- Duplicate `ToolMissingHandler` type (now in `src/platform/interfaces/toolNotifications.ts`)
- Duplicate `LinterProvider` type (now in `src/platform/interfaces/linter.ts`)

**Added:**
- `withTestRunContext()` helper in `progressTestUtils.ts` to wrap flow node `exec`/`post` calls with proper `RunContext` scope (eliminates test boilerplate and matches production's `withExecutionRunContext` pattern)
- `useLaunchRunContext()` assertion helper to safely extract launch-scoped fields from ambient context
- New platform interface modules for criticism, linter, and tool notifications

**Abstraction invariant:** Platform interfaces own the contract between host and core; core code accesses them via `platform()` rather than module-level state.

## Host impact

**Extension:** 
- Moved handler registration from scattered `setX()` calls in `extension.ts` to a single `platform()` initialization block
- Removed `setLinterProvider()`, `setAddCriticismSink()`, `setToolNotificationHandler()`, `setToolMissingHandler()` calls
- Handlers now injected via `createPlatform()` options

**Desktop:**
- Updated `createNodePlatform()` to provide no-op implementations for linter/criticism/notifications (no UI surface yet)
- No behavioral change; desktop continues to work with stub handlers

**CLI:**
- Updated `createNodePlatform()` to provide no-op implementations
- No behavioral change; CLI continues to work with stub handlers

## Scheduled refactoring

None. This completes the DI cleanup phase.

## Validation

- All existing Vitest suites pass (flow node tests now wrapped with `withTestRunContext()`)
- `DiagnosticsTool.vitest.ts` updated to use `createFakePlatform()` overrides instead of `setLinterProvider()`/`setAddCriticismSink()`
- `OutputProgressEvents.vitest.ts` updated to wrap `post()` calls with `withTestRunContext()`
- `ToolUseWaitNode.vitest.ts` updated to wrap all `exec()`/`post()` calls with `withTestRunContext()`
- Removed unused `FakeClipboardHost`, `FakeTerminalHost`, `FakeTerminal

https://claude.ai/code/session_01DZBY8QzF4X8916CXQpJ69K

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches extension bootstrap, diagnostics/criticism tooling, and flow nodes that depend on ambient RunContext; behavior should be equivalent but mis-scoped tests or platform init order could break host UI and progress emission.
> 
> **Overview**
> **Platform DI:** Extension activation registers **linter**, **addCriticismSink**, **toolMissingHandler**, and **toolNotificationHandler** on `initPlatform()` instead of scattered `setX()` calls later in `extension.ts`. Core tools (e.g. diagnostics) call `platform().linter` / `platform().addCriticismSink`; criticism types live under `src/platform/interfaces/`.
> 
> **RunContext in flows:** Tool-use and reflection flow nodes use **`useLaunchRunContext()`** for `streamId`, `executionId`, and `runtimeHost` when emitting progress/output, rather than relying only on node service bags. Vitest flow tests wrap `exec`/`post` with **`withTestRunContext()`** so ambient context matches production.
> 
> **Progress / CLI:** **`diffActiveChildren`** drives which process executions “vanished” when active-process lists update—shared by extension progress handling and CLI `subscribeRuntimeHost` so completed-process transcript rows are appended correctly (renamed param `vanishedExecutionIds`).
> 
> **Webview:** `BaseViewMessageHandler` adds optional **`onDispatch`** before dispatch and logs **Zod** validation at debug vs other handler errors at error.
> 
> The diff also includes widespread **Prettier** (union types, Lit templates, doc tables) with no behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc85c6e2cd7ec6ecf37da91c97740f59d5ba79fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->