### PR TITLE
Centralize conversation progress reporting via domain events (F-1b)

### DIFF
--- a/docs/prds/2026-05-06-prd-logger-v2.md
+++ b/docs/prds/2026-05-06-prd-logger-v2.md
@@ -513,7 +513,7 @@ The single `idle` promise resolves only when the queue is genuinely empty — th
 | **Total to CLI v1.1** | + Phase 4 (when `2026-05-06-prd-runcontext-refactor.md` Phase 2 lands)                                                                                  | **~3.0**        |
 | **Total with MCP**    | + Phase 5 (when `texra mcp serve` ships, post-v1.x)                                                                                                     | **~3.3**        |
 
-Net code reduction vs round 1: Phase 2 cut saves ~30 LOC, simpler bootstrap saves ~50 LOC, simpler shim saves ~80 LOC of mechanical changes. Round-1 §9 estimated +600/-290 ≈ +310 net; round-2 estimate is **~+200 net** to v1.0, **~+220 net** to v1.1 (Phase 4 only — Phase 5 / `McpProgressSink` is no longer in v1.x; it adds ~+80 net whenever MCP eventually ships).
+Net code reduction vs round 1: Phase 2 cut saves \~30 LOC, simpler bootstrap saves \~50 LOC, simpler shim saves \~80 LOC of mechanical changes. Round-1 §9 estimated +600/-290 ≈ +310 net; round-2 estimate is **\~+200 net** to v1.0, **\~+220 net** to v1.1 (Phase 4 only — Phase 5 / `McpProgressSink` is no longer in v1.x; it adds \~+80 net whenever MCP eventually ships).
 
 ### 15.7 What round 2 does NOT change
 

--- a/docs/prds/2026-05-06-prd-logger-v2.md
+++ b/docs/prds/2026-05-06-prd-logger-v2.md
@@ -513,7 +513,7 @@ The single `idle` promise resolves only when the queue is genuinely empty — th
 | **Total to CLI v1.1** | + Phase 4 (when `2026-05-06-prd-runcontext-refactor.md` Phase 2 lands)                                                                                  | **~3.0**        |
 | **Total with MCP**    | + Phase 5 (when `texra mcp serve` ships, post-v1.x)                                                                                                     | **~3.3**        |
 
-Net code reduction vs round 1: Phase 2 cut saves ~30 LOC, simpler bootstrap saves ~~50 LOC, simpler shim saves ~~80 LOC of mechanical changes. Round-1 §9 estimated +600/-290 ≈ +310 net; round-2 estimate is **~~+200 net** to v1.0, **~~+220 net** to v1.1 (Phase 4 only — Phase 5 / `McpProgressSink` is no longer in v1.x; it adds ~+80 net whenever MCP eventually ships).
+Net code reduction vs round 1: Phase 2 cut saves ~30 LOC, simpler bootstrap saves ~50 LOC, simpler shim saves ~80 LOC of mechanical changes. Round-1 §9 estimated +600/-290 ≈ +310 net; round-2 estimate is **~+200 net** to v1.0, **~+220 net** to v1.1 (Phase 4 only — Phase 5 / `McpProgressSink` is no longer in v1.x; it adds ~+80 net whenever MCP eventually ships).
 
 ### 15.7 What round 2 does NOT change
 

--- a/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
@@ -284,10 +284,12 @@ export class AIAgentsTab extends LitElement {
                       return html`
                         <tool-card .item=${item}>
                           ${
-                          inlineSettings
-                            ? html`<div slot="details">${inlineSettings}</div>`
-                            : nothing
-                        }
+                            inlineSettings
+                              ? html`<div slot="details">
+                                  ${inlineSettings}
+                                </div>`
+                              : nothing
+                          }
                         </tool-card>
                       `;
                     },

--- a/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
@@ -358,28 +358,29 @@ export class GitTab extends LitElement {
                                 ? html`
                                     <div class="subscription-owners">
                                       ${subscription.owners.map(
-                                      (owner) => html`
-                                        <div class="subscription-owner-row">
-                                          <span class="subscription-owner-label"
-                                            >${owner.label}</span
-                                          >
-                                          <wa-button
-                                            appearance="outlined"
-                                            variant="neutral"
-                                            size="small"
-                                            @click=${() =>
-                                              this.handleOpenPRSubscriptionStream(
-                                                owner.streamId,
-                                              )}
-                                          >
-                                            ${waIcon('comment-discussion', {
-                                              slot: 'start',
-                                            })}
-                                            Jump to agent
-                                          </wa-button>
-                                        </div>
-                                      `,
-                                    )}
+                                        (owner) => html`
+                                          <div class="subscription-owner-row">
+                                            <span
+                                              class="subscription-owner-label"
+                                              >${owner.label}</span
+                                            >
+                                            <wa-button
+                                              appearance="outlined"
+                                              variant="neutral"
+                                              size="small"
+                                              @click=${() =>
+                                                this.handleOpenPRSubscriptionStream(
+                                                  owner.streamId,
+                                                )}
+                                            >
+                                              ${waIcon('comment-discussion', {
+                                                slot: 'start',
+                                              })}
+                                              Jump to agent
+                                            </wa-button>
+                                          </div>
+                                        `,
+                                      )}
                                     </div>
                                   `
                                 : html`

--- a/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
@@ -354,10 +354,10 @@ export class GitTab extends LitElement {
                               >${subscription.key}</code
                             >
                             ${
-                            subscription.owners.length > 0
-                              ? html`
-                                  <div class="subscription-owners">
-                                    ${subscription.owners.map(
+                              subscription.owners.length > 0
+                                ? html`
+                                    <div class="subscription-owners">
+                                      ${subscription.owners.map(
                                       (owner) => html`
                                         <div class="subscription-owner-row">
                                           <span class="subscription-owner-label"
@@ -368,34 +368,34 @@ export class GitTab extends LitElement {
                                             variant="neutral"
                                             size="small"
                                             @click=${() =>
-                                            this.handleOpenPRSubscriptionStream(
-                                              owner.streamId,
-                                            )}
+                                              this.handleOpenPRSubscriptionStream(
+                                                owner.streamId,
+                                              )}
                                           >
                                             ${waIcon('comment-discussion', {
-                                            slot: 'start',
-                                          })}
+                                              slot: 'start',
+                                            })}
                                             Jump to agent
                                           </wa-button>
                                         </div>
                                       `,
                                     )}
-                                  </div>
-                                `
-                              : html`
-                                  <p class="subscription-owner-placeholder">
-                                    Started by an agent that is no longer
-                                    active.
-                                  </p>
-                                `
-                          }
+                                    </div>
+                                  `
+                                : html`
+                                    <p class="subscription-owner-placeholder">
+                                      Started by an agent that is no longer
+                                      active.
+                                    </p>
+                                  `
+                            }
                           </div>
                           <wa-button
                             appearance="outlined"
                             variant="neutral"
                             size="small"
                             @click=${() =>
-                            this.handleUnsubscribePR(subscription.key)}
+                              this.handleUnsubscribePR(subscription.key)}
                           >
                             ${waIcon('debug-stop', { slot: 'start' })} Stop
                           </wa-button>

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -70,6 +70,7 @@ import {
   type StreamStatusRegistry,
 } from './StreamStatusService';
 import { currentSession, type SessionHandle } from './SessionHandle';
+import { attachConversationProgressHub } from './conversationProgressHub';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 
 export interface AgentLaunchContext extends AgentCore {
@@ -578,9 +579,18 @@ export async function buildAgentLaunchContext(
     // returns a context) can never publish a result event. Bundle the detach
     // into the run's trace teardown.
     const detachResultHub = ctx.session.attachRunTrace(ctx.logger);
+    // Single derivation point for `updateConversationProgress` (F-1b): flow
+    // code reports counters via `logConversationProgress`, this hub is the
+    // only place that turns them into the host UI event.
+    const detachProgressHub = attachConversationProgressHub(
+      ctx.logger,
+      ctx.runtimeHost,
+      ctx.streamId,
+    );
     const disposeTrace = ctx.disposeTrace;
     ctx.disposeTrace = () => {
       detachResultHub();
+      detachProgressHub();
       disposeTrace();
     };
     return ctx;

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -235,7 +235,8 @@ export async function runFlowWithLifecycle(
     // flow-exit rethrows (T2-2) when one was attached, or formats a fresh one
     // otherwise; either way sdkMsg is unchanged from the prior getSdkErrorMessage
     // call (it reads the same .message).
-    const { message: sdkMsg, ...providerErrorInfo } = normalizeProviderError(err);
+    const { message: sdkMsg, ...providerErrorInfo } =
+      normalizeProviderError(err);
     const errorMsg = `Error executing agent ${agentIdentifier}: ${sdkMsg}`;
 
     // Root-agent failures are surfaced in the stream log. Subagent failures

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -18,6 +18,7 @@ import { createChannelTrace } from '@logger';
 import {
   RUN_OUTCOME,
   STREAM_STATUS,
+  toRetryErrorInfo,
   type RunOutcome,
   type StreamTabId,
 } from '@shared/schemas';
@@ -234,9 +235,12 @@ export async function runFlowWithLifecycle(
     // normalizeProviderError recovers the structured shape attached at the
     // flow-exit rethrows (T2-2) when one was attached, or formats a fresh one
     // otherwise; either way sdkMsg is unchanged from the prior getSdkErrorMessage
-    // call (it reads the same .message).
-    const { message: sdkMsg, ...providerErrorInfo } =
-      normalizeProviderError(err);
+    // call (it reads the same .message). toRetryErrorInfo strips rawErrorBody —
+    // the ResultEvent.error type omits it (bulky, not worth persisting) and a
+    // bare object spread would silently smuggle it through past the type check.
+    const { message: sdkMsg, ...providerErrorInfo } = toRetryErrorInfo(
+      normalizeProviderError(err),
+    );
     const errorMsg = `Error executing agent ${agentIdentifier}: ${sdkMsg}`;
 
     // Root-agent failures are surfaced in the stream log. Subagent failures

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -11,7 +11,7 @@ import {
   AgentError,
   classifyAgentError,
   getSdkErrorMessage,
-  type AgentErrorKind,
+  normalizeProviderError,
 } from '@common/errors';
 import { projectRunOutcome } from '@common/constants/streamStatus';
 import { createChannelTrace } from '@logger';
@@ -65,7 +65,7 @@ function emitRunResult(
   category: 'toolUse' | 'workflow',
   outcome: ResultEvent['outcome'],
   isSubagent: boolean,
-  error?: { kind: AgentErrorKind; message?: string },
+  error?: ResultEvent['error'],
 ): ResultEvent {
   const usage = ctx.usageMonitor.lastTotals();
   const event: ResultEvent = {
@@ -231,7 +231,11 @@ export async function runFlowWithLifecycle(
       ctx.executionId,
       projection.executionStatus,
     ).catch(() => {});
-    const sdkMsg = getSdkErrorMessage(err);
+    // normalizeProviderError recovers the structured shape attached at the
+    // flow-exit rethrows (T2-2) when one was attached, or formats a fresh one
+    // otherwise; either way sdkMsg is unchanged from the prior getSdkErrorMessage
+    // call (it reads the same .message).
+    const { message: sdkMsg, ...providerErrorInfo } = normalizeProviderError(err);
     const errorMsg = `Error executing agent ${agentIdentifier}: ${sdkMsg}`;
 
     // Root-agent failures are surfaced in the stream log. Subagent failures
@@ -259,7 +263,11 @@ export async function runFlowWithLifecycle(
           category,
           toResultOutcome(outcome),
           options?.isSubagent ?? false,
-          { kind, message: kind === 'unexpected' ? errorMsg : sdkMsg },
+          {
+            kind,
+            message: kind === 'unexpected' ? errorMsg : sdkMsg,
+            ...providerErrorInfo,
+          },
         ),
       );
     }

--- a/src/agent/runtime/conversationProgressHub.ts
+++ b/src/agent/runtime/conversationProgressHub.ts
@@ -22,8 +22,8 @@ import type { AgentRuntimeHost } from './AgentRuntimeHost';
 function isConversationProgress(data: unknown): data is ConversationProgress {
   return (
     isObject(data) &&
-    typeof data.conversationTurns === 'number' &&
-    typeof data.toolCallCount === 'number'
+    Number.isFinite(data.conversationTurns) &&
+    Number.isFinite(data.toolCallCount)
   );
 }
 

--- a/src/agent/runtime/conversationProgressHub.ts
+++ b/src/agent/runtime/conversationProgressHub.ts
@@ -1,0 +1,31 @@
+/**
+ * Bridge a run's `conversationProgress` domain events to its host's
+ * `updateConversationProgress` UI event — the single derivation point (F-1b)
+ * for both agent categories. Workflow and tool-use flows count turns
+ * differently (round index vs. tool-call-bearing overview updates) and keep
+ * computing their own numbers via {@link logConversationProgress}; this hub
+ * is the only place that turns that single producer emission into the host
+ * event, replacing the two call sites that used to call `runtimeHost.emit`
+ * directly from `executeAgent.ts`.
+ */
+import type { AgentTrace } from '@agent/trace';
+import type { ConversationProgress, StreamTabId } from '@shared/schemas';
+
+import type { AgentRuntimeHost } from './AgentRuntimeHost';
+
+/** Returns a detach disposer; callers bundle it into the run's trace teardown. */
+export function attachConversationProgressHub(
+  trace: AgentTrace,
+  runtimeHost: AgentRuntimeHost,
+  streamId: StreamTabId,
+): () => void {
+  return trace.subscribe((event) => {
+    if (event.type !== 'domain' || event.key !== 'conversationProgress') {
+      return;
+    }
+    runtimeHost.emit('updateConversationProgress', {
+      streamId,
+      progress: event.data as ConversationProgress,
+    });
+  });
+}

--- a/src/agent/runtime/conversationProgressHub.ts
+++ b/src/agent/runtime/conversationProgressHub.ts
@@ -10,8 +10,22 @@
  */
 import type { AgentTrace } from '@agent/trace';
 import type { ConversationProgress, StreamTabId } from '@shared/schemas';
+import { isObject } from '@utils/core';
 
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
+
+/** Narrows a domain event's untyped `data` to the shape `logConversationProgress`
+ *  always sends. `DomainEvent.data` is `unknown` because the channel is a
+ *  general escape hatch shared by every domain key; only this hub's own
+ *  producer emits `conversationProgress`, but the check keeps a malformed or
+ *  missing payload from forwarding `undefined`/partial data to the host. */
+function isConversationProgress(data: unknown): data is ConversationProgress {
+  return (
+    isObject(data) &&
+    typeof data.conversationTurns === 'number' &&
+    typeof data.toolCallCount === 'number'
+  );
+}
 
 /** Returns a detach disposer; callers bundle it into the run's trace teardown. */
 export function attachConversationProgressHub(
@@ -23,9 +37,10 @@ export function attachConversationProgressHub(
     if (event.type !== 'domain' || event.key !== 'conversationProgress') {
       return;
     }
+    if (!isConversationProgress(event.data)) return;
     runtimeHost.emit('updateConversationProgress', {
       streamId,
-      progress: event.data as ConversationProgress,
+      progress: event.data,
     });
   });
 }

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -154,7 +154,7 @@ function buildToolUseFlowResult(
 /** Create an onRoundCompleted callback that feeds progress into the execution registry and orchestrator. */
 function createRoundProgressCallback(
   executionId: ExecutionId,
-  logger: AgentTrace,
+  trace: AgentTrace,
   onProgress?: (update: SubagentProgressUpdate) => void,
 ): (
   roundIndex: number,
@@ -175,7 +175,7 @@ function createRoundProgressCallback(
     // Single producer emission (F-1b): the conversationProgressHub attached in
     // AgentLaunchContext derives the host `updateConversationProgress` event
     // from this instead of emitting to the runtimeHost directly.
-    logConversationProgress(logger, {
+    logConversationProgress(trace, {
       conversationTurns: roundIndex + 1,
       toolCallCount: 0,
     });

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 
+import { logConversationProgress, type AgentTrace } from '@agent/trace';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
 import {
   getToolUseFlowErrorResult,
@@ -153,8 +154,7 @@ function buildToolUseFlowResult(
 /** Create an onRoundCompleted callback that feeds progress into the execution registry and orchestrator. */
 function createRoundProgressCallback(
   executionId: ExecutionId,
-  streamId: StreamTabId,
-  runtimeHost: AgentRuntimeHost,
+  logger: AgentTrace,
   onProgress?: (update: SubagentProgressUpdate) => void,
 ): (
   roundIndex: number,
@@ -172,12 +172,12 @@ function createRoundProgressCallback(
       totalRounds,
       outputPaths: outputPaths ?? [],
     });
-    runtimeHost.emit('updateConversationProgress', {
-      streamId,
-      progress: {
-        conversationTurns: roundIndex + 1,
-        toolCallCount: 0,
-      },
+    // Single producer emission (F-1b): the conversationProgressHub attached in
+    // AgentLaunchContext derives the host `updateConversationProgress` event
+    // from this instead of emitting to the runtimeHost directly.
+    logConversationProgress(logger, {
+      conversationTurns: roundIndex + 1,
+      toolCallCount: 0,
     });
   };
 }
@@ -223,12 +223,10 @@ async function runToolUseAgent(
         onProgress: (update) => {
           if (update.kind === 'overview') {
             toolUseTurns++;
-            ctx.runtimeHost.emit('updateConversationProgress', {
-              streamId,
-              progress: {
-                conversationTurns: toolUseTurns,
-                toolCallCount: update.toolCallCount,
-              },
+            // Single producer emission (F-1b): see createRoundProgressCallback.
+            logConversationProgress(ctx.logger, {
+              conversationTurns: toolUseTurns,
+              toolCallCount: update.toolCallCount,
             });
           }
           options.onProgress?.(update);
@@ -291,8 +289,7 @@ async function runReflectionAgent(
   const { streamId } = ctx;
   const onRoundCompleted = createRoundProgressCallback(
     ctx.executionId,
-    streamId,
-    ctx.runtimeHost,
+    ctx.logger,
     options.onProgress,
   );
   const onRoundFinalized = createUsageRecordingCallback(ctx);

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -161,10 +161,12 @@ export interface DomainEvent extends StageStamp {
  * is a sibling of `failed` (a user interrupt is not a failure). `error.kind` is
  * the classified terminal-error discriminant; the rest of `error` is the
  * `RetryErrorInfo` normalized at the same boundary (statusCode, provider,
- * isCredentialExhausted, partialText, …) — present whenever `normalizeProviderError`
- * recovers a structured shape, absent (beyond `kind`/`message`) for kinds that
- * never carry one (e.g. `missing-api-key`, `disk-full`). `usage` is the run
- * totals (present once at least one round recorded usage, including on failures).
+ * isCredentialExhausted, partialText, …). `normalizeProviderError` always
+ * returns a structured shape, so baseline fields like `userRetryable`/
+ * `isRelayError` are present for every kind, including `missing-api-key` and
+ * `disk-full` — only genuine SDK/provider failures also populate `statusCode`/
+ * `provider`/`requestId`/`partialText`. `usage` is the run totals (present
+ * once at least one round recorded usage, including on failures).
  */
 export interface ResultEvent extends StageStamp {
   readonly type: 'result';

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -10,7 +10,7 @@
  */
 import type { RunUsageTotals } from '@agent/core/usage/RunUsageAccumulator';
 import type { AgentErrorKind } from '@common/errors';
-import type { EndGroupStatus } from '@shared/schemas';
+import type { EndGroupStatus, RetryErrorInfo } from '@shared/schemas';
 
 /** Status assigned to a tool call when it completes. */
 export type ToolStatus = 'completed' | 'failed' | 'in_progress';
@@ -159,10 +159,12 @@ export interface DomainEvent extends StageStamp {
  * Terminal run outcome as data — emitted exactly once at the run-lifecycle
  * boundary (`runFlowWithLifecycle`), never from flows or the bus. `cancelled`
  * is a sibling of `failed` (a user interrupt is not a failure). `error.kind` is
- * the classified terminal-error discriminant; the optional `RetryErrorInfo`
- * enrichment is deferred to the error-pipeline T2-2 work, so the shape carries
- * only what is genuinely populated today. `usage` is the run totals (present
- * once at least one round recorded usage, including on failures).
+ * the classified terminal-error discriminant; the rest of `error` is the
+ * `RetryErrorInfo` normalized at the same boundary (statusCode, provider,
+ * isCredentialExhausted, partialText, …) — present whenever `normalizeProviderError`
+ * recovers a structured shape, absent (beyond `kind`/`message`) for kinds that
+ * never carry one (e.g. `missing-api-key`, `disk-full`). `usage` is the run
+ * totals (present once at least one round recorded usage, including on failures).
  */
 export interface ResultEvent extends StageStamp {
   readonly type: 'result';
@@ -172,7 +174,10 @@ export interface ResultEvent extends StageStamp {
   readonly agentName: string;
   readonly category: 'toolUse' | 'workflow';
   readonly isSubagent: boolean;
-  readonly error?: { readonly kind: AgentErrorKind; readonly message?: string };
+  readonly error?: Readonly<Partial<Omit<RetryErrorInfo, 'message'>>> & {
+    readonly kind: AgentErrorKind;
+    readonly message?: string;
+  };
   readonly usage?: RunUsageTotals;
 }
 

--- a/src/agent/trace/helpers.ts
+++ b/src/agent/trace/helpers.ts
@@ -16,6 +16,7 @@ import { buildErrorLogData } from '@common/errors/sdkErrorUtils';
 import {
   MESSAGE_TYPES,
   type ContextManagementData,
+  type ConversationProgress,
   type ErrorContext,
   type FileListEntry,
 } from '@shared/schemas';
@@ -164,6 +165,23 @@ export function logFileCategory(
     sourceDisplay: category,
   }));
   logFilesLoaded(trace, category, entries, stageId);
+}
+
+/**
+ * Report conversation-progress counters (round/turn count, tool-call count).
+ * The single producer emission for `updateConversationProgress` — a per-run
+ * hub subscriber ({@link attachConversationProgressHub}) derives the host UI
+ * event from this instead of flow code calling `runtimeHost.emit` directly,
+ * so workflow and tool-use agents share one emission path even though they
+ * count turns differently. Never rendered as a transcript row (suppressed in
+ * `TexraTranscriptRecorder`) — it is a UI-only signal, not a log line.
+ */
+export function logConversationProgress(
+  trace: AgentTrace,
+  data: ConversationProgress,
+  stageId?: string,
+): void {
+  trace.domain({ key: 'conversationProgress', data, stageId });
 }
 
 /** Missing-outputs notification — counts `missing` entries for the label. */

--- a/src/agent/trace/index.ts
+++ b/src/agent/trace/index.ts
@@ -35,6 +35,7 @@ export {
   logInternal,
   debugInternal,
   logContextManagementEvent,
+  logConversationProgress,
   logWebSearch,
   logWebFetch,
   logLatexdiff,

--- a/src/test-kernel/agent/runtime/ConversationProgressHub.vitest.ts
+++ b/src/test-kernel/agent/runtime/ConversationProgressHub.vitest.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { logConversationProgress, TraceEmitter } from '@agent/trace';
+import { attachConversationProgressHub } from '@agent/runtime/conversationProgressHub';
+import type { StreamTabId } from '@shared/schemas';
+
+import { createRecordingHost } from '../progressTestUtils';
+
+describe('attachConversationProgressHub (F-1b)', () => {
+  it('derives updateConversationProgress from a conversationProgress domain event', () => {
+    const trace = new TraceEmitter();
+    const { events, host } = createRecordingHost();
+    const streamId = 'stream:hub-test' as StreamTabId;
+    const detach = attachConversationProgressHub(trace, host, streamId);
+
+    try {
+      logConversationProgress(trace, {
+        conversationTurns: 2,
+        toolCallCount: 5,
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        event: 'updateConversationProgress',
+        payload: {
+          streamId,
+          progress: { conversationTurns: 2, toolCallCount: 5 },
+        },
+      });
+    } finally {
+      detach();
+    }
+  });
+
+  it('ignores unrelated domain events and stops forwarding after detach', () => {
+    const trace = new TraceEmitter();
+    const { events, host } = createRecordingHost();
+    const streamId = 'stream:hub-test-2' as StreamTabId;
+    const detach = attachConversationProgressHub(trace, host, streamId);
+
+    trace.domain({ key: 'webSearch', data: { query: 'irrelevant' } });
+    expect(events).toHaveLength(0);
+
+    detach();
+    logConversationProgress(trace, { conversationTurns: 1, toolCallCount: 0 });
+    expect(events).toHaveLength(0);
+  });
+});

--- a/src/test-kernel/agent/runtime/ConversationProgressHub.vitest.ts
+++ b/src/test-kernel/agent/runtime/ConversationProgressHub.vitest.ts
@@ -45,4 +45,24 @@ describe('attachConversationProgressHub (F-1b)', () => {
     logConversationProgress(trace, { conversationTurns: 1, toolCallCount: 0 });
     expect(events).toHaveLength(0);
   });
+
+  it('drops a conversationProgress event with missing or malformed data instead of forwarding it', () => {
+    const trace = new TraceEmitter();
+    const { events, host } = createRecordingHost();
+    const streamId = 'stream:hub-test-3' as StreamTabId;
+    const detach = attachConversationProgressHub(trace, host, streamId);
+
+    try {
+      trace.domain({ key: 'conversationProgress', data: undefined });
+      trace.domain({
+        key: 'conversationProgress',
+        data: { conversationTurns: 1 },
+      });
+      trace.domain({ key: 'conversationProgress', data: 'not an object' });
+
+      expect(events).toHaveLength(0);
+    } finally {
+      detach();
+    }
+  });
 });

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -340,6 +340,10 @@ export function attachTranscriptRecorder(
 
       case 'domain': {
         // Subscribers that care about specific keys can switch on event.key.
+        // conversationProgress is a UI-only signal consumed by the host's
+        // conversationProgressHub (F-1b) — it fires on every round/turn and
+        // would spam a transcript row per tick, so it adds none here.
+        if (event.key === 'conversationProgress') return;
         // filesLoaded has a richer payload shape; format the text accordingly.
         if (event.key === 'filesLoaded') {
           const payload = event.data as


### PR DESCRIPTION
## Summary

Consolidates conversation progress reporting into a single derivation point by introducing a `conversationProgressHub` that bridges `conversationProgress` domain events to host UI events. This replaces direct `runtimeHost.emit` calls scattered across workflow and tool-use agent flows, ensuring both agent categories share one emission path despite counting turns differently.

Changes include:
- New `attachConversationProgressHub` module that subscribes to `conversationProgress` domain events and emits `updateConversationProgress` to the host
- New `logConversationProgress` trace helper that agents call instead of emitting directly to the host
- Updated `executeAgent.ts` and `runToolUseAgent` to use `logConversationProgress` instead of direct host emission
- Updated `ResultEvent` type to carry normalized provider error info (statusCode, provider, isCredentialExhausted, etc.) recovered at the run-lifecycle boundary
- Suppressed `conversationProgress` events from transcript recording (UI-only signal, not a log line)

## Issue acceptance gates

Implements F-1b: Single derivation point for `updateConversationProgress` — flow code reports counters via `logConversationProgress`, the hub is the only place that turns them into the host UI event.

## Single source of truth

`attachConversationProgressHub` in `src/agent/runtime/conversationProgressHub.ts` is now the sole owner of the `conversationProgress` → `updateConversationProgress` derivation. All agent flows report via `logConversationProgress` trace helper.

## Duplication and abstraction budget

Removed two direct `runtimeHost.emit('updateConversationProgress', ...)` call sites from `executeAgent.ts` and `runToolUseAgent`. Introduced `logConversationProgress` as the single producer emission point, with the hub as the single consumer that derives the host event. This eliminates duplication and ensures workflow and tool-use agents share one emission path.

## Host impact

Extension: No user-facing changes; internal refactoring of progress event flow.

Desktop: No user-facing changes; internal refactoring of progress event flow.

CLI: No user-facing changes; internal refactoring of progress event flow.

## Scheduled refactoring

None.

## Validation

- Added `ConversationProgressHub.vitest.ts` test suite covering:
  - Derivation of `updateConversationProgress` from `conversationProgress` domain events
  - Filtering of unrelated domain events
  - Proper cleanup after detach
- Existing agent execution tests continue to pass
- Type checking passes with updated `ResultEvent` shape

https://claude.ai/code/session_01XaTJ8rza5rxeryP1f6g7dG

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the path from agent runs to progress UI and expands persisted `result` error payloads that hosts may consume; mitigated by focused hub tests and existing retry error normalization.
> 
> **Overview**
> **Conversation progress (F-1b)** routes turn/tool counters through `logConversationProgress` on the run trace instead of calling `runtimeHost.emit('updateConversationProgress')` from workflow and tool-use flows. `attachConversationProgressHub` is wired at launch and torn down with the trace; it is the only place that maps `conversationProgress` domain events to the host UI event. `TexraTranscriptRecorder` ignores that domain key so progress ticks do not create transcript rows.
> 
> **Terminal run results** now attach normalized provider metadata on `ResultEvent.error` (`normalizeProviderError` + `toRetryErrorInfo`, omitting bulky `rawErrorBody`) at the lifecycle boundary, with an updated `ResultEvent` type and docs.
> 
> Also includes a Logger v2 PRD markdown fix and Lit template formatting in extension settings tabs (no behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dc929b72b8496fceb39986a122f5b91d461033a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->