### PR TITLE
Refactor error handling, logging, and platform-access hygiene

### DIFF
--- a/packages/cli/src/commands/_helpers/fetchSilencer.ts
+++ b/packages/cli/src/commands/_helpers/fetchSilencer.ts
@@ -4,7 +4,7 @@ export function isCliFetchStackLog(args: readonly unknown[]): boolean {
   const [first] = args;
   if (!(first instanceof Error)) return false;
   const cause = first.cause;
-  const causeMessage = cause === undefined ? '' : toErrorMessage(cause);
+  const causeMessage = cause instanceof Error ? cause.message : '';
   return (
     /fetch failed/i.test(first.message) &&
     /ENOTFOUND|EAI_AGAIN|ECONNREFUSED|ETIMEDOUT|getaddrinfo|remote\.texra\.ai/i.test(
@@ -31,7 +31,7 @@ export async function suppressCliFetchStackLogs<T>(
 export function formatCliModelListError(error: unknown): string {
   const message = toErrorMessage(error);
   const cause = error instanceof Error ? error.cause : undefined;
-  const causeMessage = cause === undefined ? undefined : toErrorMessage(cause);
+  const causeMessage = cause instanceof Error ? cause.message : undefined;
   const detail = causeMessage ?? message;
   if (/ENOTFOUND|EAI_AGAIN|getaddrinfo|fetch failed/i.test(detail)) {
     return `texra: could not fetch model access metadata from remote.texra.ai: ${detail}`;

--- a/packages/cli/src/commands/_helpers/fetchSilencer.ts
+++ b/packages/cli/src/commands/_helpers/fetchSilencer.ts
@@ -4,7 +4,7 @@ export function isCliFetchStackLog(args: readonly unknown[]): boolean {
   const [first] = args;
   if (!(first instanceof Error)) return false;
   const cause = first.cause;
-  const causeMessage = cause instanceof Error ? cause.message : '';
+  const causeMessage = cause === undefined ? '' : toErrorMessage(cause);
   return (
     /fetch failed/i.test(first.message) &&
     /ENOTFOUND|EAI_AGAIN|ECONNREFUSED|ETIMEDOUT|getaddrinfo|remote\.texra\.ai/i.test(
@@ -31,7 +31,7 @@ export async function suppressCliFetchStackLogs<T>(
 export function formatCliModelListError(error: unknown): string {
   const message = toErrorMessage(error);
   const cause = error instanceof Error ? error.cause : undefined;
-  const causeMessage = cause instanceof Error ? cause.message : undefined;
+  const causeMessage = cause === undefined ? undefined : toErrorMessage(cause);
   const detail = causeMessage ?? message;
   if (/ENOTFOUND|EAI_AGAIN|getaddrinfo|fetch failed/i.test(detail)) {
     return `texra: could not fetch model access metadata from remote.texra.ai: ${detail}`;

--- a/packages/cli/src/commands/tools.ts
+++ b/packages/cli/src/commands/tools.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process';
 
 import { defineCommand } from 'citty';
+import { parse as shellParse } from 'shell-quote';
 
 import { CliExitCode } from '../runtime/exitCodes';
 import { initCliPlatform } from '../runtime/initPlatform';
@@ -90,12 +91,23 @@ async function toggleTool(
   return CliExitCode.Success;
 }
 
+// Not routed through executeCommand: install/auth guide commands are
+// interactive (they can prompt for input or open a browser), which needs true
+// stdio:'inherit' that executeCommand's buffered/streamed output can't
+// provide. `command` always comes from the static EXTERNAL_TOOL_DEFS
+// registry (src/tools/externalToolDefs.ts), never from user or LLM input;
+// parsing it into argv (instead of a shell string) still closes off shell
+// metacharacter injection as defense in depth.
 function shellRun(command: string): Promise<number> {
   return new Promise((resolve) => {
-    const child = spawn(command, {
-      shell: true,
-      stdio: 'inherit',
-    });
+    const [cmd, ...args] = shellParse(command).filter(
+      (arg): arg is string => typeof arg === 'string',
+    );
+    if (!cmd) {
+      resolve(CliExitCode.AgentError);
+      return;
+    }
+    const child = spawn(cmd, args, { stdio: 'inherit' });
     child.on('error', () => resolve(CliExitCode.AgentError));
     child.on('exit', (code) => resolve(code ?? CliExitCode.AgentError));
   });

--- a/packages/cli/src/commands/tools.ts
+++ b/packages/cli/src/commands/tools.ts
@@ -94,15 +94,31 @@ async function toggleTool(
 // Not routed through executeCommand: install/auth guide commands are
 // interactive (they can prompt for input or open a browser), which needs true
 // stdio:'inherit' that executeCommand's buffered/streamed output can't
-// provide. `command` always comes from the static EXTERNAL_TOOL_DEFS
-// registry (src/tools/externalToolDefs.ts), never from user or LLM input;
-// parsing it into argv (instead of a shell string) still closes off shell
-// metacharacter injection as defense in depth.
+// provide. `command` always comes from the static EXTERNAL_TOOL_DEFS registry,
+// never from user or LLM input. POSIX commands run as argv; Windows uses the
+// shell so npm/gh `.cmd` shims resolve through PATHEXT.
 function shellRun(command: string): Promise<number> {
   return new Promise((resolve) => {
-    const [cmd, ...args] = shellParse(command).filter(
-      (arg): arg is string => typeof arg === 'string',
-    );
+    if (process.platform === 'win32') {
+      const child = spawn(command, { shell: true, stdio: 'inherit' });
+      child.on('error', () => resolve(CliExitCode.AgentError));
+      child.on('exit', (code) => resolve(code ?? CliExitCode.AgentError));
+      return;
+    }
+
+    let parts: string[];
+    try {
+      const parsed = shellParse(command);
+      if (!parsed.every((arg): arg is string => typeof arg === 'string')) {
+        resolve(CliExitCode.AgentError);
+        return;
+      }
+      parts = parsed;
+    } catch {
+      resolve(CliExitCode.AgentError);
+      return;
+    }
+    const [cmd, ...args] = parts;
     if (!cmd) {
       resolve(CliExitCode.AgentError);
       return;

--- a/packages/cli/src/runtime/browser.ts
+++ b/packages/cli/src/runtime/browser.ts
@@ -1,4 +1,5 @@
 // Internal imports
+import { toErrorMessage } from '@common/errors';
 import { executeCommand } from '@utils/system/execUtils';
 
 export interface BrowserLaunchCommand {
@@ -55,8 +56,7 @@ export function openBrowser(
   manualBrowserHint: string,
 ): Promise<void> {
   return launchBrowser(url).catch((error: unknown) => {
-    const message =
-      error instanceof Error ? error.message : 'unknown browser launch error';
+    const message = toErrorMessage(error);
     log?.debug('cli-auth', message);
     throw new Error(
       `${message}. Run ${manualBrowserHint} to open the sign-in URL manually.`,

--- a/packages/cli/src/runtime/browser.ts
+++ b/packages/cli/src/runtime/browser.ts
@@ -1,5 +1,5 @@
-// Standard library imports
-import { spawn, type ChildProcess } from 'node:child_process';
+// Internal imports
+import { executeCommand } from '@utils/system/execUtils';
 
 export interface BrowserLaunchCommand {
   readonly command: string;
@@ -39,37 +39,14 @@ export function resolveBrowserLaunch(
   }
 }
 
-function launchBrowser(url: string): Promise<void> {
+async function launchBrowser(url: string): Promise<void> {
   const launch = resolveBrowserLaunch(url);
-  return new Promise((resolve, reject) => {
-    let child: ChildProcess;
-    try {
-      child = spawn(launch.command, launch.args, {
-        stdio: 'ignore',
-        windowsVerbatimArguments: launch.windowsVerbatimArguments,
-      });
-    } catch (error) {
-      rejectBrowserLaunch(error);
-      return;
-    }
-
-    child.once('close', (code) => {
-      if (code === 0) {
-        resolve();
-        return;
-      }
-      rejectBrowserLaunch(
-        new Error(`${launch.command} exited with code ${code ?? 'unknown'}`),
-      );
-    });
-    child.once('error', rejectBrowserLaunch);
-
-    function rejectBrowserLaunch(error: unknown): void {
-      const message =
-        error instanceof Error ? error.message : 'unknown browser launch error';
-      reject(new Error(`Could not open the browser automatically: ${message}`));
-    }
-  });
+  const result = await executeCommand([launch.command, ...launch.args]);
+  if (result.exitCode === 0) return;
+  const message = result.stderr ?? `exited with code ${result.exitCode}`;
+  throw new Error(
+    `Could not open the browser automatically: ${launch.command} ${message}`,
+  );
 }
 
 export function openBrowser(

--- a/packages/cli/src/runtime/browser.ts
+++ b/packages/cli/src/runtime/browser.ts
@@ -1,6 +1,6 @@
-// Internal imports
+import { spawn, type ChildProcess } from 'node:child_process';
+
 import { toErrorMessage } from '@common/errors';
-import { executeCommand } from '@utils/system/execUtils';
 
 export interface BrowserLaunchCommand {
   readonly command: string;
@@ -40,14 +40,39 @@ export function resolveBrowserLaunch(
   }
 }
 
-async function launchBrowser(url: string): Promise<void> {
+function launchBrowser(url: string): Promise<void> {
   const launch = resolveBrowserLaunch(url);
-  const result = await executeCommand([launch.command, ...launch.args]);
-  if (result.exitCode === 0) return;
-  const message = result.stderr ?? `exited with code ${result.exitCode}`;
-  throw new Error(
-    `Could not open the browser automatically: ${launch.command} ${message}`,
-  );
+  return new Promise((resolve, reject) => {
+    let child: ChildProcess;
+    try {
+      child = spawn(launch.command, launch.args, {
+        stdio: 'ignore',
+        windowsVerbatimArguments: launch.windowsVerbatimArguments,
+      });
+    } catch (error) {
+      rejectBrowserLaunch(error);
+      return;
+    }
+
+    child.once('close', (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      rejectBrowserLaunch(
+        new Error(`${launch.command} exited with code ${code ?? 'unknown'}`),
+      );
+    });
+    child.once('error', rejectBrowserLaunch);
+
+    function rejectBrowserLaunch(error: unknown): void {
+      const message =
+        error instanceof Error
+          ? toErrorMessage(error)
+          : 'unknown browser launch error';
+      reject(new Error(`Could not open the browser automatically: ${message}`));
+    }
+  });
 }
 
 export function openBrowser(
@@ -56,7 +81,10 @@ export function openBrowser(
   manualBrowserHint: string,
 ): Promise<void> {
   return launchBrowser(url).catch((error: unknown) => {
-    const message = toErrorMessage(error);
+    const message =
+      error instanceof Error
+        ? toErrorMessage(error)
+        : 'unknown browser launch error';
     log?.debug('cli-auth', message);
     throw new Error(
       `${message}. Run ${manualBrowserHint} to open the sign-in URL manually.`,

--- a/packages/cli/src/runtime/clipboardImage.ts
+++ b/packages/cli/src/runtime/clipboardImage.ts
@@ -11,6 +11,9 @@
 // MediaAttachmentProcessor path as the extension webview, so no model-layer
 // code is duplicated.
 
+// Linux reads raw PNG bytes off stdout (`encoding: 'buffer'`), which
+// executeCommand's string-only output doesn't support, so that path alone
+// keeps a direct child_process.execFile call.
 import { execFile } from 'node:child_process';
 import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
 import { platform as osPlatform, tmpdir } from 'node:os';
@@ -19,6 +22,7 @@ import { promisify } from 'node:util';
 
 import { isFileNotFoundError } from '@common/errors';
 import { generatePastedImageName } from '@shared/files/pastedImageConstants';
+import { executeCommand } from '@utils/system/execUtils';
 import { savePastedImageBuffer } from '@utils/files/pastedImageUtils';
 
 const execFileAsync = promisify(execFile);
@@ -53,22 +57,21 @@ function isMaxBufferError(err: unknown): boolean {
 }
 
 async function readClipboardPngMac(outFile: string): Promise<ClipboardRead> {
-  try {
-    // osascript ships with macOS — no external dependency. The first statement
-    // throws when the clipboard holds no image, which lands us in the catch.
-    await execFileAsync('osascript', [
-      '-e',
-      'set png_data to (the clipboard as «class PNGf»)',
-      '-e',
-      `set fp to open for access POSIX file "${outFile}" with write permission`,
-      '-e',
-      'write png_data to fp',
-      '-e',
-      'close access fp',
-    ]);
-  } catch {
-    return 'none';
-  }
+  // osascript ships with macOS — no external dependency. The first statement
+  // fails when the clipboard holds no image, which lands us in the !success
+  // branch below.
+  const result = await executeCommand([
+    'osascript',
+    '-e',
+    'set png_data to (the clipboard as «class PNGf»)',
+    '-e',
+    `set fp to open for access POSIX file "${outFile}" with write permission`,
+    '-e',
+    'write png_data to fp',
+    '-e',
+    'close access fp',
+  ]);
+  if (!result.success) return 'none';
   return readPngFileWithinLimit(outFile);
 }
 

--- a/packages/cli/src/runtime/clipboardImage.ts
+++ b/packages/cli/src/runtime/clipboardImage.ts
@@ -11,9 +11,6 @@
 // MediaAttachmentProcessor path as the extension webview, so no model-layer
 // code is duplicated.
 
-// Linux reads raw PNG bytes off stdout (`encoding: 'buffer'`), which
-// executeCommand's string-only output doesn't support, so that path alone
-// keeps a direct child_process.execFile call.
 import { execFile } from 'node:child_process';
 import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
 import { platform as osPlatform, tmpdir } from 'node:os';
@@ -22,7 +19,6 @@ import { promisify } from 'node:util';
 
 import { isFileNotFoundError } from '@common/errors';
 import { generatePastedImageName } from '@shared/files/pastedImageConstants';
-import { executeCommand } from '@utils/system/execUtils';
 import { savePastedImageBuffer } from '@utils/files/pastedImageUtils';
 
 const execFileAsync = promisify(execFile);
@@ -57,21 +53,22 @@ function isMaxBufferError(err: unknown): boolean {
 }
 
 async function readClipboardPngMac(outFile: string): Promise<ClipboardRead> {
-  // osascript ships with macOS — no external dependency. The first statement
-  // fails when the clipboard holds no image, which lands us in the !success
-  // branch below.
-  const result = await executeCommand([
-    'osascript',
-    '-e',
-    'set png_data to (the clipboard as «class PNGf»)',
-    '-e',
-    `set fp to open for access POSIX file "${outFile}" with write permission`,
-    '-e',
-    'write png_data to fp',
-    '-e',
-    'close access fp',
-  ]);
-  if (!result.success) return 'none';
+  try {
+    // osascript ships with macOS — no external dependency. The first statement
+    // throws when the clipboard holds no image, which lands us in the catch.
+    await execFileAsync('osascript', [
+      '-e',
+      'set png_data to (the clipboard as «class PNGf»)',
+      '-e',
+      `set fp to open for access POSIX file "${outFile}" with write permission`,
+      '-e',
+      'write png_data to fp',
+      '-e',
+      'close access fp',
+    ]);
+  } catch {
+    return 'none';
+  }
   return readPngFileWithinLimit(outFile);
 }
 
@@ -106,14 +103,16 @@ async function readClipboardPngWindows(
 ): Promise<ClipboardRead> {
   const quotedOutFile = outFile.replaceAll("'", "''");
   const script = `$img = Get-Clipboard -Format Image; if ($img) { Add-Type -AssemblyName System.Drawing; $img.Save('${quotedOutFile}', [System.Drawing.Imaging.ImageFormat]::Png) } else { Write-Output 'NO_IMAGE' }`;
-  const result = await executeCommand([
-    'powershell',
-    '-NoProfile',
-    '-Command',
-    script,
-  ]);
-  if (!result.success) return 'none';
-  if ((result.stdout ?? '').includes('NO_IMAGE')) return 'none';
+  try {
+    const { stdout } = await execFileAsync('powershell', [
+      '-NoProfile',
+      '-Command',
+      script,
+    ]);
+    if (String(stdout).includes('NO_IMAGE')) return 'none';
+  } catch {
+    return 'none';
+  }
   return readPngFileWithinLimit(outFile);
 }
 

--- a/packages/cli/src/runtime/clipboardImage.ts
+++ b/packages/cli/src/runtime/clipboardImage.ts
@@ -106,16 +106,14 @@ async function readClipboardPngWindows(
 ): Promise<ClipboardRead> {
   const quotedOutFile = outFile.replaceAll("'", "''");
   const script = `$img = Get-Clipboard -Format Image; if ($img) { Add-Type -AssemblyName System.Drawing; $img.Save('${quotedOutFile}', [System.Drawing.Imaging.ImageFormat]::Png) } else { Write-Output 'NO_IMAGE' }`;
-  try {
-    const { stdout } = await execFileAsync('powershell', [
-      '-NoProfile',
-      '-Command',
-      script,
-    ]);
-    if (String(stdout).includes('NO_IMAGE')) return 'none';
-  } catch {
-    return 'none';
-  }
+  const result = await executeCommand([
+    'powershell',
+    '-NoProfile',
+    '-Command',
+    script,
+  ]);
+  if (!result.success) return 'none';
+  if ((result.stdout ?? '').includes('NO_IMAGE')) return 'none';
   return readPngFileWithinLimit(outFile);
 }
 

--- a/packages/cli/src/runtime/clipboardText.ts
+++ b/packages/cli/src/runtime/clipboardText.ts
@@ -1,3 +1,7 @@
+// Not routed through executeCommand: this needs an injectable spawn seam
+// (`spawnCommand`) with per-candidate kill-on-timeout while falling through
+// multiple clipboard tools, which executeCommand's single-command timeout
+// model doesn't expose as a test seam.
 import { spawn } from 'node:child_process';
 import { platform as osPlatform } from 'node:os';
 import { toErrorMessage } from '@common/errors';

--- a/packages/cli/src/runtime/gitOps.ts
+++ b/packages/cli/src/runtime/gitOps.ts
@@ -1,6 +1,6 @@
 // Thin wrappers over `git` and `gh` for the `install-github-action` command.
 // Every call captures output and never throws — callers branch on `ok`.
-import { executeCommandSync } from '@utils/system/execUtils';
+import { spawnSync } from 'node:child_process';
 
 export interface CommandResult {
   readonly ok: boolean;
@@ -14,12 +14,24 @@ function run(
   args: readonly string[],
   cwd: string,
 ): CommandResult {
-  const result = executeCommandSync([command, ...args], { cwd });
+  const result = spawnSync(command, [...args], {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (result.error) {
+    return {
+      ok: false,
+      status: null,
+      stdout: '',
+      stderr: result.error.message,
+    };
+  }
   return {
-    ok: result.success,
-    status: result.exitCode ?? null,
-    stdout: result.stdout ?? '',
-    stderr: result.stderr ?? '',
+    ok: result.status === 0,
+    status: result.status,
+    stdout: (result.stdout ?? '').trim(),
+    stderr: (result.stderr ?? '').trim(),
   };
 }
 

--- a/packages/cli/src/runtime/gitOps.ts
+++ b/packages/cli/src/runtime/gitOps.ts
@@ -1,8 +1,6 @@
 // Thin wrappers over `git` and `gh` for the `install-github-action` command.
-// Mirrors the CLI's existing subprocess style (node:child_process spawnSync,
-// see runtime/pager.ts) so no extra dependency is needed. Every call captures
-// output and never throws — callers branch on `ok`.
-import { spawnSync } from 'node:child_process';
+// Every call captures output and never throws — callers branch on `ok`.
+import { executeCommandSync } from '@utils/system/execUtils';
 
 export interface CommandResult {
   readonly ok: boolean;
@@ -16,24 +14,12 @@ function run(
   args: readonly string[],
   cwd: string,
 ): CommandResult {
-  const result = spawnSync(command, [...args], {
-    cwd,
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
-  if (result.error) {
-    return {
-      ok: false,
-      status: null,
-      stdout: '',
-      stderr: result.error.message,
-    };
-  }
+  const result = executeCommandSync([command, ...args], { cwd });
   return {
-    ok: result.status === 0,
-    status: result.status,
-    stdout: (result.stdout ?? '').trim(),
-    stderr: (result.stderr ?? '').trim(),
+    ok: result.success,
+    status: result.exitCode,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
   };
 }
 

--- a/packages/cli/src/runtime/gitOps.ts
+++ b/packages/cli/src/runtime/gitOps.ts
@@ -17,7 +17,7 @@ function run(
   const result = executeCommandSync([command, ...args], { cwd });
   return {
     ok: result.success,
-    status: result.exitCode,
+    status: result.exitCode ?? null,
     stdout: result.stdout ?? '',
     stderr: result.stderr ?? '',
   };

--- a/packages/cli/src/runtime/pager.ts
+++ b/packages/cli/src/runtime/pager.ts
@@ -64,6 +64,10 @@ export function pageStdout(
 
   // Run through the default shell so `$PAGER` strings with flags ("less -FIRX")
   // and user customizations work without us re-implementing shell word-splitting.
+  // Uses raw spawnSync (not executeCommand) because the pager needs true
+  // stdio:['pipe','inherit','inherit'] — full-duplex TTY control for
+  // interactive paging that executeCommand's buffered/streamed output can't
+  // provide.
   const result = spawnSync(command, {
     input: `${text}\n`,
     stdio: ['pipe', 'inherit', 'inherit'],

--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -4,6 +4,8 @@ import { fileURLToPath } from 'node:url';
 import { gt as semverGt, valid as semverValid } from 'semver';
 import { z } from 'zod';
 
+import { executeCommand } from '@utils/system/execUtils';
+
 import {
   cliEnvValue,
   readCliAmbientState,
@@ -171,30 +173,10 @@ async function readCommandStdout(
   args: readonly string[],
   timeoutMs: number,
 ): Promise<string | undefined> {
-  return new Promise<string | undefined>((resolve) => {
-    const child = spawn(command, args, {
-      shell: false,
-      stdio: ['ignore', 'pipe', 'ignore'],
-    });
-    let stdout = '';
-    let settled = false;
-    const finish = (value: string | undefined): void => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      resolve(value);
-    };
-    const timer = setTimeout(() => {
-      child.kill();
-      finish(undefined);
-    }, timeoutMs);
-    child.stdout.setEncoding('utf8');
-    child.stdout.on('data', (chunk: string) => {
-      stdout += chunk;
-    });
-    child.on('error', () => finish(undefined));
-    child.on('close', (code) => finish(code === 0 ? stdout : undefined));
+  const result = await executeCommand([command, ...args], {
+    timeout: timeoutMs,
   });
+  return result.success ? (result.stdout ?? '') : undefined;
 }
 
 /**
@@ -261,6 +243,9 @@ export async function fetchLatestHomebrewFormulaVersion(options?: {
 function runCliUpdate(method: InstallMethod): Promise<boolean> {
   const { command, args } = buildUpdateCommand(method);
   return new Promise<boolean>((resolve) => {
+    // Needs true stdio:'inherit' — the package manager may print an
+    // interactive prompt or password request, which executeCommand's
+    // buffered/streamed output cannot forward.
     const child = spawn(command, args, { stdio: 'inherit', shell: true });
     child.on('error', () => resolve(false));
     child.on('close', (code) => resolve(code === 0));

--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -4,8 +4,6 @@ import { fileURLToPath } from 'node:url';
 import { gt as semverGt, valid as semverValid } from 'semver';
 import { z } from 'zod';
 
-import { executeCommand } from '@utils/system/execUtils';
-
 import {
   cliEnvValue,
   readCliAmbientState,
@@ -173,10 +171,31 @@ async function readCommandStdout(
   args: readonly string[],
   timeoutMs: number,
 ): Promise<string | undefined> {
-  const result = await executeCommand([command, ...args], {
-    timeout: timeoutMs,
+  return new Promise<string | undefined>((resolve) => {
+    const child = spawn(command, args, {
+      shell: false,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    let stdout = '';
+    let settled = false;
+    const finish = (value: string | undefined): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(value);
+    };
+    const timer = setTimeout(() => {
+      child.kill();
+      finish(undefined);
+    }, timeoutMs);
+
+    child.stdout?.setEncoding('utf8');
+    child.stdout?.on('data', (chunk: string) => {
+      stdout += chunk;
+    });
+    child.on('error', () => finish(undefined));
+    child.on('close', (code) => finish(code === 0 ? stdout : undefined));
   });
-  return result.success ? (result.stdout ?? '') : undefined;
 }
 
 /**

--- a/packages/desktop/src/main/desktopGitHost.ts
+++ b/packages/desktop/src/main/desktopGitHost.ts
@@ -18,6 +18,9 @@
  * have been ambiguous if we'd echoed the human-readable label directly.
  */
 
+// Not routed through executeCommand: it doesn't expose a `maxBuffer` option,
+// and the explicit MAX_BUFFER_BYTES cap below is a deliberate Electron
+// main-process OOM guard (execa's own default maxBuffer is ~100 MiB).
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 

--- a/packages/desktop/src/main/desktopSetupTerminal.ts
+++ b/packages/desktop/src/main/desktopSetupTerminal.ts
@@ -1,8 +1,8 @@
-// Node imports
-import { spawn } from 'node:child_process';
-
 // Third-party imports
 import { quote } from 'shell-quote';
+
+// Internal imports
+import { executeCommand } from '@utils/system/execUtils';
 
 const OPEN_TERMINAL_TIMEOUT_MS = 10_000;
 
@@ -15,9 +15,9 @@ export async function openMacTerminalCommand(
   cwd: string,
 ): Promise<void> {
   const terminalCommand = buildMacTerminalCommand(command, cwd);
-  const child = spawn(
-    'osascript',
+  const result = await executeCommand(
     [
+      'osascript',
       '-e',
       'tell application "Terminal"',
       '-e',
@@ -27,38 +27,18 @@ export async function openMacTerminalCommand(
       '-e',
       'end tell',
     ],
-    { stdio: ['ignore', 'ignore', 'pipe'] },
+    { timeout: OPEN_TERMINAL_TIMEOUT_MS },
   );
 
-  await new Promise<void>((resolve, reject) => {
-    let stderr = '';
-    const timeoutId = setTimeout(() => {
-      child.kill();
-      reject(new Error('Timed out opening Terminal'));
-    }, OPEN_TERMINAL_TIMEOUT_MS);
-    const finish = (callback: () => void) => {
-      clearTimeout(timeoutId);
-      callback();
-    };
-    child.stderr?.on('data', (chunk: Buffer | string) => {
-      stderr += String(chunk);
-    });
-    child.on('error', (error) => finish(() => reject(error)));
-    child.on('close', (code) => {
-      if (code === 0) {
-        finish(resolve);
-        return;
-      }
-      finish(() =>
-        reject(
-          new Error(
-            stderr.trim() ||
-              `Could not open Terminal; osascript exited ${code}`,
-          ),
-        ),
-      );
-    });
-  });
+  if (result.timedOut) {
+    throw new Error('Timed out opening Terminal');
+  }
+  if (result.exitCode !== 0) {
+    throw new Error(
+      result.stderr?.trim() ||
+        `Could not open Terminal; osascript exited ${result.exitCode}`,
+    );
+  }
 }
 
 export function buildMacTerminalCommand(command: string, cwd: string): string {

--- a/packages/desktop/src/main/desktopSetupTerminal.ts
+++ b/packages/desktop/src/main/desktopSetupTerminal.ts
@@ -27,7 +27,7 @@ export async function openMacTerminalCommand(
       '-e',
       'end tell',
     ],
-    { timeout: OPEN_TERMINAL_TIMEOUT_MS },
+    { cwd, timeout: OPEN_TERMINAL_TIMEOUT_MS, stdout: 'ignore' },
   );
 
   if (result.timedOut) {

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -444,6 +444,10 @@ function createWindow(options: {
     const selectedPath = result.canceled ? undefined : result.filePaths[0];
     if (!selectedPath) return;
 
+    // Not routed through executeCommand: this launches a new, independent
+    // Electron window process (detached + unref'd) that must outlive this
+    // process and is never awaited — executeCommand always awaits subprocess
+    // completion, which would hang here.
     spawn(
       process.execPath,
       withNewWindowWorkspaceArgs(process.argv.slice(1), selectedPath),

--- a/packages/extension/src/commands/agent/executeCommand.ts
+++ b/packages/extension/src/commands/agent/executeCommand.ts
@@ -8,6 +8,7 @@ import { ModelHandlerCompatibilityKeySchema } from '@agent/runtime/modelHandlerC
 import { runAgent } from '@agent/runtime/runAgent';
 import { openFinalOutputIfAvailable } from '@frontend/agents/finalOutputOpener';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
+import { showLoggedMessage } from '@frontend/ui/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import type { ExecutionId } from '@shared/schemas';
 
@@ -68,7 +69,7 @@ export async function runExecuteCommand(input: unknown): Promise<void> {
     if (error instanceof ZodError) {
       const message = `Invalid agent configuration. ${z.prettifyError(error)}`;
       logger.warn(CHANNEL, message, { data: error });
-      void vscode.window.showErrorMessage(message);
+      void showLoggedMessage(CHANNEL, message);
       return;
     }
 

--- a/packages/extension/src/commands/agent/executeCommand.ts
+++ b/packages/extension/src/commands/agent/executeCommand.ts
@@ -8,7 +8,6 @@ import { ModelHandlerCompatibilityKeySchema } from '@agent/runtime/modelHandlerC
 import { runAgent } from '@agent/runtime/runAgent';
 import { openFinalOutputIfAvailable } from '@frontend/agents/finalOutputOpener';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
-import { showLoggedMessage } from '@frontend/ui/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import type { ExecutionId } from '@shared/schemas';
 
@@ -69,7 +68,7 @@ export async function runExecuteCommand(input: unknown): Promise<void> {
     if (error instanceof ZodError) {
       const message = `Invalid agent configuration. ${z.prettifyError(error)}`;
       logger.warn(CHANNEL, message, { data: error });
-      void showLoggedMessage(CHANNEL, message);
+      void vscode.window.showErrorMessage(message);
       return;
     }
 

--- a/packages/extension/src/commands/auth/authCommands.ts
+++ b/packages/extension/src/commands/auth/authCommands.ts
@@ -4,7 +4,6 @@ import { type OAuthProvider, getExternalAuthCallbackUri } from '@auth/config';
 import { AUTH_PROVIDER_ID, AUTH_COMMANDS } from '@auth/constants';
 import { showSettingsView } from '@commands/settings';
 import { showQuickPick } from '@commands/_shared/quickInputUtils';
-import { toErrorMessage } from '@common/errors';
 import { SupabaseAuthProvider } from '@frontend/auth/SupabaseAuthProvider';
 import {
   showLoggedErrorMessage,
@@ -179,9 +178,7 @@ async function signInWithEmail(): Promise<void> {
       `Magic link sent to ${email}. Click the link in your email - VS Code will sign you in automatically.`,
     );
   } catch (error) {
-    void vscode.window.showErrorMessage(
-      `Failed to send magic link: ${toErrorMessage(error)}`,
-    );
+    void showLoggedErrorMessage(CHANNEL, 'Failed to send magic link', error);
   }
 }
 
@@ -205,14 +202,10 @@ export async function signOut(): Promise<void> {
       await authProvider.removeSession(session.id);
       void vscode.window.showInformationMessage('Signed out successfully');
     } else {
-      void vscode.window.showErrorMessage(
-        'Authentication provider not available',
-      );
+      void showLoggedMessage(CHANNEL, 'Authentication provider not available');
     }
   } catch (error) {
-    void vscode.window.showErrorMessage(
-      `Sign out failed: ${toErrorMessage(error)}`,
-    );
+    void showLoggedErrorMessage(CHANNEL, 'Sign out failed', error);
   }
 }
 
@@ -220,9 +213,7 @@ export async function viewProfile(): Promise<void> {
   try {
     await showSettingsView();
   } catch (error) {
-    void vscode.window.showErrorMessage(
-      `Failed to load profile: ${toErrorMessage(error)}`,
-    );
+    void showLoggedErrorMessage(CHANNEL, 'Failed to load profile', error);
   }
 }
 

--- a/packages/extension/src/commands/auth/authCommands.ts
+++ b/packages/extension/src/commands/auth/authCommands.ts
@@ -6,7 +6,15 @@ import { showSettingsView } from '@commands/settings';
 import { showQuickPick } from '@commands/_shared/quickInputUtils';
 import { toErrorMessage } from '@common/errors';
 import { SupabaseAuthProvider } from '@frontend/auth/SupabaseAuthProvider';
+import {
+  showLoggedErrorMessage,
+  showLoggedMessage,
+} from '@frontend/ui/errorHandlingUtils';
+import * as logger from '@logger/logUtils';
 import { getConfig } from '@utils/config';
+
+const CHANNEL = 'authCommands';
+logger.initialize(CHANNEL);
 
 type AuthMethod = OAuthProvider | 'github-browser' | 'email';
 
@@ -97,7 +105,8 @@ export async function signIn(): Promise<boolean> {
       const reason = initError
         ? initError.message
         : 'Authentication service not initialized';
-      void vscode.window.showErrorMessage(
+      void showLoggedMessage(
+        CHANNEL,
         `Sign in failed: ${reason}. Try reloading VS Code (Ctrl+Shift+P → "Reload Window"). If the problem continues, open Help → Toggle Developer Tools → Console for details.`,
       );
       return false;
@@ -136,9 +145,7 @@ export async function signIn(): Promise<boolean> {
     }
     return false;
   } catch (error) {
-    void vscode.window.showErrorMessage(
-      `Sign in failed: ${toErrorMessage(error)}`,
-    );
+    void showLoggedErrorMessage(CHANNEL, 'Sign in failed', error);
     return false;
   }
 }

--- a/packages/extension/src/commands/git/gitCommands.ts
+++ b/packages/extension/src/commands/git/gitCommands.ts
@@ -5,6 +5,7 @@ import * as vscode from 'vscode';
 // Local imports - utilities
 import { registerCommands } from '@commands/_shared/registerCommands';
 import { toErrorMessage } from '@common/errors';
+import { showLoggedMessage } from '@frontend/ui/errorHandlingUtils';
 import {
   buildAuthenticatedRemoteUrl,
   buildGitCredential,
@@ -193,10 +194,12 @@ async function getGitToken(
   if (!input) return null;
 
   if (!isValid(input)) {
+    const invalidTokenMessage = promptHint
+      ? `Invalid token format. ${promptHint}`
+      : 'Invalid token format.';
+    logger.error(CHANNEL, invalidTokenMessage);
     const action = await vscode.window.showErrorMessage(
-      promptHint
-        ? `Invalid token format. ${promptHint}`
-        : 'Invalid token format.',
+      invalidTokenMessage,
       ...(promptHint ? (['How to get a token'] as const) : []),
     );
     if (action === 'How to get a token') {
@@ -253,6 +256,7 @@ async function promptGitMissing(): Promise<void> {
     ? (['Copy Command', 'Run in Terminal', 'Open git-scm.com'] as const)
     : (['Open git-scm.com'] as const);
 
+  logger.error(CHANNEL, message);
   const selected = await vscode.window.showErrorMessage(message, ...actions);
   if (selected === 'Copy Command' && command) {
     await vscode.env.clipboard.writeText(command);
@@ -277,13 +281,13 @@ async function checkClonePreconditions(
   try {
     entries = await WorkspaceFS.readDir(workspacePath);
   } catch (e) {
-    vscode.window.showErrorMessage('Cannot read workspace folder.');
+    void showLoggedMessage(CHANNEL, 'Cannot read workspace folder.');
     logger.error(CHANNEL, `readDir failed: ${toErrorMessage(e)}`);
     return false;
   }
 
   if (entries.some(([name]) => !IGNORED_FILES.has(name))) {
-    vscode.window.showErrorMessage('Workspace folder must be empty.');
+    void showLoggedMessage(CHANNEL, 'Workspace folder must be empty.');
     return false;
   }
 
@@ -301,13 +305,13 @@ export async function cloneOverleafProject(
 
   const parsed = parseLatexGitUrl(input);
   if (!parsed) {
-    vscode.window.showErrorMessage('Invalid project URL or ID.');
+    void showLoggedMessage(CHANNEL, 'Invalid project URL or ID.');
     return;
   }
 
   const workspacePath = WorkspaceFS.getPath();
   if (!workspacePath) {
-    vscode.window.showErrorMessage('Open a workspace folder first.');
+    void showLoggedMessage(CHANNEL, 'Open a workspace folder first.');
     return;
   }
 
@@ -357,8 +361,10 @@ export async function cloneOverleafProject(
       const actions = parsed.isOverleaf
         ? (['Get New Token', 'How to get a token'] as const)
         : (['Retry'] as const);
+      const authErrorMessage = `Clone failed: authentication error. ${detail}`;
+      logger.error(CHANNEL, authErrorMessage);
       const selected = await vscode.window.showErrorMessage(
-        `Clone failed: authentication error. ${detail}`,
+        authErrorMessage,
         ...actions,
       );
       if (selected === 'Get New Token') {
@@ -367,7 +373,8 @@ export async function cloneOverleafProject(
         void vscode.env.openExternal(vscode.Uri.parse(OVERLEAF_TOKEN_DOCS_URL));
       }
     } else {
-      vscode.window.showErrorMessage(
+      void showLoggedMessage(
+        CHANNEL,
         'Clone failed. Check credentials and connection.',
       );
     }

--- a/packages/extension/src/commands/git/gitCommands.ts
+++ b/packages/extension/src/commands/git/gitCommands.ts
@@ -281,8 +281,8 @@ async function checkClonePreconditions(
   try {
     entries = await WorkspaceFS.readDir(workspacePath);
   } catch (e) {
-    void showLoggedMessage(CHANNEL, 'Cannot read workspace folder.');
     logger.error(CHANNEL, `readDir failed: ${toErrorMessage(e)}`);
+    void vscode.window.showErrorMessage('Cannot read workspace folder.');
     return false;
   }
 
@@ -362,7 +362,6 @@ export async function cloneOverleafProject(
         ? (['Get New Token', 'How to get a token'] as const)
         : (['Retry'] as const);
       const authErrorMessage = `Clone failed: authentication error. ${detail}`;
-      logger.error(CHANNEL, authErrorMessage);
       const selected = await vscode.window.showErrorMessage(
         authErrorMessage,
         ...actions,
@@ -373,8 +372,7 @@ export async function cloneOverleafProject(
         void vscode.env.openExternal(vscode.Uri.parse(OVERLEAF_TOKEN_DOCS_URL));
       }
     } else {
-      void showLoggedMessage(
-        CHANNEL,
+      void vscode.window.showErrorMessage(
         'Clone failed. Check credentials and connection.',
       );
     }

--- a/packages/extension/src/commands/history/stateRestoreCommand.ts
+++ b/packages/extension/src/commands/history/stateRestoreCommand.ts
@@ -9,7 +9,10 @@ import { buildMainViewState } from '@controllers/mainView/MainViewStateRestoreCo
 import { TaskStateSchema } from '@agent/core/state/TaskState';
 import { registerCommands } from '@commands/_shared/registerCommands';
 import { setPendingState } from '@common/state';
-import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
+import {
+  showLoggedErrorMessage,
+  showLoggedMessage,
+} from '@frontend/ui/errorHandlingUtils';
 import { getMainWebview } from '@frontend/system/commandUtils';
 import * as logger from '@logger/logUtils';
 import { COMMON_COMMANDS } from '@shared/ipc';
@@ -41,7 +44,7 @@ async function restoreState(
     logger.info(CHANNEL, RESTORE_MALFORMED_MESSAGE, {
       data: { validationError: z.prettifyError(parsed.error) },
     });
-    await vscode.window.showErrorMessage(RESTORE_MALFORMED_MESSAGE);
+    await showLoggedMessage(CHANNEL, RESTORE_MALFORMED_MESSAGE);
     return false;
   }
 

--- a/packages/extension/src/commands/history/stateRestoreCommand.ts
+++ b/packages/extension/src/commands/history/stateRestoreCommand.ts
@@ -9,10 +9,7 @@ import { buildMainViewState } from '@controllers/mainView/MainViewStateRestoreCo
 import { TaskStateSchema } from '@agent/core/state/TaskState';
 import { registerCommands } from '@commands/_shared/registerCommands';
 import { setPendingState } from '@common/state';
-import {
-  showLoggedErrorMessage,
-  showLoggedMessage,
-} from '@frontend/ui/errorHandlingUtils';
+import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { getMainWebview } from '@frontend/system/commandUtils';
 import * as logger from '@logger/logUtils';
 import { COMMON_COMMANDS } from '@shared/ipc';
@@ -44,7 +41,7 @@ async function restoreState(
     logger.info(CHANNEL, RESTORE_MALFORMED_MESSAGE, {
       data: { validationError: z.prettifyError(parsed.error) },
     });
-    await showLoggedMessage(CHANNEL, RESTORE_MALFORMED_MESSAGE);
+    await vscode.window.showErrorMessage(RESTORE_MALFORMED_MESSAGE);
     return false;
   }
 

--- a/packages/extension/src/commands/housekeeping/cleanCommands.ts
+++ b/packages/extension/src/commands/housekeeping/cleanCommands.ts
@@ -4,7 +4,10 @@ import * as vscode from 'vscode';
 // Local imports
 import type { FileOpResult } from '@agent/types';
 import { registerCommands } from '@commands/_shared/registerCommands';
-import { parseWithErrorDisplay } from '@frontend/ui/errorHandlingUtils';
+import {
+  parseWithErrorDisplay,
+  showLoggedMessage,
+} from '@frontend/ui/errorHandlingUtils';
 import {
   runCleanSingle,
   runCleanMultiple,
@@ -30,10 +33,13 @@ function showCleanResult(result: FileOpResult, inputFile: string): void {
       );
       break;
     case 'missingParams':
-      vscode.window.showErrorMessage('Missing required parameters for clean');
+      void showLoggedMessage(
+        CHANNEL,
+        'Missing required parameters for clean',
+      );
       break;
     case 'error':
-      vscode.window.showErrorMessage(`Error during cleanup: ${result.error}`);
+      void showLoggedMessage(CHANNEL, `Error during cleanup: ${result.error}`);
       break;
   }
 }

--- a/packages/extension/src/commands/housekeeping/cleanCommands.ts
+++ b/packages/extension/src/commands/housekeeping/cleanCommands.ts
@@ -33,10 +33,7 @@ function showCleanResult(result: FileOpResult, inputFile: string): void {
       );
       break;
     case 'missingParams':
-      void showLoggedMessage(
-        CHANNEL,
-        'Missing required parameters for clean',
-      );
+      void showLoggedMessage(CHANNEL, 'Missing required parameters for clean');
       break;
     case 'error':
       void showLoggedMessage(CHANNEL, `Error during cleanup: ${result.error}`);

--- a/packages/extension/src/commands/housekeeping/cleanCommands.ts
+++ b/packages/extension/src/commands/housekeeping/cleanCommands.ts
@@ -36,7 +36,9 @@ function showCleanResult(result: FileOpResult, inputFile: string): void {
       void showLoggedMessage(CHANNEL, 'Missing required parameters for clean');
       break;
     case 'error':
-      void showLoggedMessage(CHANNEL, `Error during cleanup: ${result.error}`);
+      void vscode.window.showErrorMessage(
+        `Error during cleanup: ${result.error}`,
+      );
       break;
   }
 }

--- a/packages/extension/src/commands/housekeeping/packCommands.ts
+++ b/packages/extension/src/commands/housekeeping/packCommands.ts
@@ -5,7 +5,10 @@ import { z } from 'zod';
 // Local imports
 import type { FileOpResult } from '@agent/types';
 import { registerCommands } from '@commands/_shared/registerCommands';
-import { parseWithErrorDisplay } from '@frontend/ui/errorHandlingUtils';
+import {
+  parseWithErrorDisplay,
+  showLoggedMessage,
+} from '@frontend/ui/errorHandlingUtils';
 import {
   runPack,
   runPackSingle,
@@ -63,10 +66,10 @@ function showPackResult(result: FileOpResult, inputFile: string): void {
       );
       break;
     case 'missingParams':
-      vscode.window.showErrorMessage('Missing required parameters for pack');
+      void showLoggedMessage(CHANNEL, 'Missing required parameters for pack');
       break;
     case 'error':
-      vscode.window.showErrorMessage(`Error during packing: ${result.error}`);
+      void showLoggedMessage(CHANNEL, `Error during packing: ${result.error}`);
       break;
   }
 }

--- a/packages/extension/src/commands/housekeeping/packCommands.ts
+++ b/packages/extension/src/commands/housekeeping/packCommands.ts
@@ -69,7 +69,9 @@ function showPackResult(result: FileOpResult, inputFile: string): void {
       void showLoggedMessage(CHANNEL, 'Missing required parameters for pack');
       break;
     case 'error':
-      void showLoggedMessage(CHANNEL, `Error during packing: ${result.error}`);
+      void vscode.window.showErrorMessage(
+        `Error during packing: ${result.error}`,
+      );
       break;
   }
 }

--- a/packages/extension/src/commands/latex/compareCommands.ts
+++ b/packages/extension/src/commands/latex/compareCommands.ts
@@ -11,6 +11,7 @@ import { registerCommands } from '@commands/_shared/registerCommands';
 import { bus } from '@eventBus/ProgressEventBus';
 import {
   showLoggedErrorMessage,
+  showLoggedMessage,
   toErrorMessage,
 } from '@frontend/ui/errorHandlingUtils';
 import { registerDiffRefresh } from '@frontend/ui/diffView';
@@ -39,7 +40,7 @@ function validateFileLocations(
 ): FileLocation | null {
   const fileToUseLocation = baseLocation ?? inputLocation;
   if (!fileToUseLocation || !editedLocation) {
-    vscode.window.showErrorMessage(errorMessage);
+    void showLoggedMessage(CHANNEL, errorMessage);
     return null;
   }
   return fileToUseLocation;
@@ -50,14 +51,16 @@ async function validateFilesExist(
   editedLocation: FileLocation,
 ): Promise<boolean> {
   if (!(await flexibleFS.exists(baseLocation))) {
-    vscode.window.showErrorMessage(
+    void showLoggedMessage(
+      CHANNEL,
       `Base file not found: ${baseLocation.absolutePath}`,
     );
     return false;
   }
 
   if (!(await flexibleFS.exists(editedLocation))) {
-    vscode.window.showErrorMessage(
+    void showLoggedMessage(
+      CHANNEL,
       `Edited file not found: ${editedLocation.absolutePath}`,
     );
     return false;

--- a/packages/extension/src/commands/latex/imageCommands.ts
+++ b/packages/extension/src/commands/latex/imageCommands.ts
@@ -2,7 +2,10 @@
 import * as vscode from 'vscode';
 
 // Local imports - errors
-import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
+import {
+  showLoggedErrorMessage,
+  showLoggedMessage,
+} from '@frontend/ui/errorHandlingUtils';
 import * as dialogUtils from '@frontend/ui/dialogs';
 import * as logger from '@logger/logUtils';
 import {
@@ -47,7 +50,7 @@ export async function handleCountPdfPages(): Promise<void> {
       return;
     }
 
-    vscode.window.showErrorMessage('Could not count pages in the PDF');
+    void showLoggedMessage(CHANNEL, 'Could not count pages in the PDF');
   } catch (err) {
     await showLoggedErrorMessage(CHANNEL, 'countPdfPages command failed', err);
   }
@@ -146,7 +149,7 @@ export async function handleConvertPdfToImages(): Promise<
       return result;
     }
 
-    vscode.window.showErrorMessage('Failed to convert PDF');
+    void showLoggedMessage(CHANNEL, 'Failed to convert PDF');
     return undefined;
   } catch (err) {
     await showLoggedErrorMessage(

--- a/packages/extension/src/commands/progress/progressViewCommands.ts
+++ b/packages/extension/src/commands/progress/progressViewCommands.ts
@@ -1,11 +1,13 @@
-import * as vscode from 'vscode';
-
+import { showLoggedMessage } from '@frontend/ui/errorHandlingUtils';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
+
+const CHANNEL = 'progressViewCommands';
 
 function getProgressProviderOrWarn(): ProgressViewProvider | undefined {
   const provider = ProgressViewProvider.getInstance();
   if (!provider) {
-    void vscode.window.showErrorMessage(
+    void showLoggedMessage(
+      CHANNEL,
       'Progress View is not available. Please try again.',
     );
   }

--- a/packages/extension/src/commands/review/agentReviewCommands.ts
+++ b/packages/extension/src/commands/review/agentReviewCommands.ts
@@ -27,7 +27,10 @@ import {
   type AgentReviewNode,
 } from '@frontend/review/AgentReviewTreeProvider';
 import { promptReviewOptions } from '@frontend/review/promptReviewOptions';
-import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
+import {
+  showLoggedErrorMessage,
+  showLoggedMessage,
+} from '@frontend/ui/errorHandlingUtils';
 import { setReportReviewIssueSink } from '@tools/ReportReviewIssueTool';
 import { WorkspaceFS } from '@utils/files';
 
@@ -75,7 +78,8 @@ async function handleOpenIssue(node: AgentReviewNode): Promise<void> {
 async function handleRunWithOptions(): Promise<void> {
   const cwd = WorkspaceFS.getPath();
   if (!cwd) {
-    void vscode.window.showErrorMessage(
+    void showLoggedMessage(
+      CHANNEL,
       'Agent review needs an open workspace folder.',
     );
     return;

--- a/packages/extension/src/commands/settings/settingsCommands.ts
+++ b/packages/extension/src/commands/settings/settingsCommands.ts
@@ -1,7 +1,10 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
+import { showLoggedMessage } from '@frontend/ui/errorHandlingUtils';
 import { SettingsViewProvider } from '@settingsView/SettingsViewProvider';
+
+const CHANNEL = 'settingsCommands';
 
 let settingsViewProvider: SettingsViewProvider | null = null;
 
@@ -16,7 +19,8 @@ export function initializeSettingsViewProvider(
 
 export async function showSettingsView(): Promise<void> {
   if (!settingsViewProvider) {
-    void vscode.window.showErrorMessage(
+    void showLoggedMessage(
+      CHANNEL,
       'Settings view not initialized. Please reload the extension.',
     );
     return;

--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -12,11 +12,11 @@ import { AUTH_COMMANDS } from '@auth/constants';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { apiKeyCommands } from '@commands/api/apiKeyCommands';
 import { showQuickPick } from '@commands/_shared/quickInputUtils';
-import { toErrorMessage } from '@common/errors';
 import { GlobalStateKey, globalSM } from '@common/state';
 import { SecretManager } from '@frontend/secretManager';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { signInWithChatGptSubscription } from '@frontend/auth/codexSubscriptionSignIn';
+import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import {
   CHATGPT_SETUP_MODEL,
@@ -391,8 +391,10 @@ export async function launchSetupAssistant(): Promise<SetupAssistantLaunchResult
     return 'launched';
   } catch (error) {
     logger.error(CHANNEL, 'Setup assistant failed to launch.', { data: error });
-    void vscode.window.showErrorMessage(
-      `Failed to launch setup assistant: ${toErrorMessage(error)}`,
+    void showLoggedErrorMessage(
+      CHANNEL,
+      'Failed to launch setup assistant',
+      error,
     );
     return 'not-started';
   }

--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -12,11 +12,11 @@ import { AUTH_COMMANDS } from '@auth/constants';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { apiKeyCommands } from '@commands/api/apiKeyCommands';
 import { showQuickPick } from '@commands/_shared/quickInputUtils';
+import { toErrorMessage } from '@common/errors';
 import { GlobalStateKey, globalSM } from '@common/state';
 import { SecretManager } from '@frontend/secretManager';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { signInWithChatGptSubscription } from '@frontend/auth/codexSubscriptionSignIn';
-import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import {
   CHATGPT_SETUP_MODEL,
@@ -391,10 +391,8 @@ export async function launchSetupAssistant(): Promise<SetupAssistantLaunchResult
     return 'launched';
   } catch (error) {
     logger.error(CHANNEL, 'Setup assistant failed to launch.', { data: error });
-    void showLoggedErrorMessage(
-      CHANNEL,
-      'Failed to launch setup assistant',
-      error,
+    void vscode.window.showErrorMessage(
+      `Failed to launch setup assistant: ${toErrorMessage(error)}`,
     );
     return 'not-started';
   }

--- a/packages/extension/src/commands/system/sampleProjectCommands.ts
+++ b/packages/extension/src/commands/system/sampleProjectCommands.ts
@@ -6,7 +6,10 @@ import fsExtra from 'fs-extra';
 import * as vscode from 'vscode';
 
 // Local imports - fs
-import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
+import {
+  showLoggedErrorMessage,
+  showLoggedMessage,
+} from '@frontend/ui/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
 
@@ -70,7 +73,8 @@ export async function createSampleProject(
 ): Promise<void> {
   try {
     if (!WorkspaceFS.getPath()) {
-      void vscode.window.showErrorMessage(
+      void showLoggedMessage(
+        CHANNEL,
         'Open a workspace to create the sample project.',
       );
       return;

--- a/packages/extension/src/commands/system/textEditorCommands.ts
+++ b/packages/extension/src/commands/system/textEditorCommands.ts
@@ -2,7 +2,10 @@
 import * as vscode from 'vscode';
 
 // Local imports - Tool implementations
-import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
+import {
+  showLoggedErrorMessage,
+  showLoggedMessage,
+} from '@frontend/ui/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import {
   TextEditorTool,
@@ -124,7 +127,7 @@ export async function handleTestTextEditor(): Promise<void> {
         });
 
         if (!oldStr) {
-          vscode.window.showErrorMessage('Text to replace is required');
+          void showLoggedMessage(CHANNEL, 'Text to replace is required');
           return;
         }
 
@@ -153,7 +156,7 @@ export async function handleTestTextEditor(): Promise<void> {
         });
 
         if (!textToInsert) {
-          vscode.window.showErrorMessage('Text to insert is required');
+          void showLoggedMessage(CHANNEL, 'Text to insert is required');
           return;
         }
 
@@ -177,7 +180,7 @@ export async function handleTestTextEditor(): Promise<void> {
         });
 
         if (!fileContent) {
-          vscode.window.showErrorMessage('File content is required');
+          void showLoggedMessage(CHANNEL, 'File content is required');
           return;
         }
 
@@ -190,7 +193,7 @@ export async function handleTestTextEditor(): Promise<void> {
         break;
 
       default:
-        vscode.window.showErrorMessage(`Unsupported command: ${command}`);
+        void showLoggedMessage(CHANNEL, `Unsupported command: ${command}`);
         return;
     }
 

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -243,6 +243,7 @@ export async function activate(context: vscode.ExtensionContext) {
     },
     toolMissingHandler: async (message, openDocsCommand) => {
       const actions = openDocsCommand ? ['View Installation Guide'] : [];
+      logger.error('extension', message);
       const choice = await vscode.window.showErrorMessage(message, ...actions);
       if (choice === 'View Installation Guide' && openDocsCommand) {
         const [command, ...args] = openDocsCommand.split(',');
@@ -435,7 +436,10 @@ export async function activate(context: vscode.ExtensionContext) {
       );
     } else {
       const authProvider = new SupabaseAuthProvider(context, {
-        showError: (msg) => void vscode.window.showErrorMessage(msg),
+        showError: (msg) => {
+          logger.error('SupabaseAuthProvider', msg);
+          void vscode.window.showErrorMessage(msg);
+        },
         showInfo: (msg) => void vscode.window.showInformationMessage(msg),
         showSignInPrompt: async (reason) => {
           const message =
@@ -629,6 +633,7 @@ export async function activate(context: vscode.ExtensionContext) {
   const disposeGitHubAuthListener = bus.on(
     'githubTokenInvalid',
     ({ message }) => {
+      logger.error('extension', `GitHub token rejected: ${message}`);
       void vscode.window
         .showErrorMessage(
           `GitHub token rejected: ${message}`,

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -94,7 +94,7 @@ import * as logger from '@logger/logUtils';
 import {
   apiKeyExists,
   apiKeySecretName,
-  lookupApiKey,
+  hasUsableApiKey,
 } from '@model/apiProviders';
 import { refreshModelListStateIfNeeded } from '@model/modelListRefresh';
 import { type StreamStatus, type TokenUsageStats } from '@shared/schemas';
@@ -112,7 +112,6 @@ import { setLeanLanguageServices } from '@tools/lean/leanLanguageServices';
 import { setOpenBuildDisplay } from '@tools/approval/latexPreview';
 import { StorageFS } from '@utils/files';
 import { getConfig } from '@utils/config';
-import { isNonEmptyString } from '@utils/core';
 import { TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
 
 // Local imports - components
@@ -436,10 +435,7 @@ export async function activate(context: vscode.ExtensionContext) {
       );
     } else {
       const authProvider = new SupabaseAuthProvider(context, {
-        showError: (msg) => {
-          logger.error('SupabaseAuthProvider', msg);
-          void vscode.window.showErrorMessage(msg);
-        },
+        showError: (msg) => void vscode.window.showErrorMessage(msg),
         showInfo: (msg) => void vscode.window.showInformationMessage(msg),
         showSignInPrompt: async (reason) => {
           const message =
@@ -550,8 +546,8 @@ export async function activate(context: vscode.ExtensionContext) {
       deleteApiKey: (provider) =>
         platform().secrets.delete(apiKeySecretName(provider)),
       apiKeyExists: (provider) => apiKeyExists(platform().secrets, provider),
-      hasUsableApiKey: async (provider) =>
-        isNonEmptyString(await lookupApiKey(platform().secrets, provider)),
+      hasUsableApiKey: (provider) =>
+        hasUsableApiKey(platform().secrets, provider),
       storedApiKeyExists: async (provider) => {
         const stored = await SecretManager.get(apiKeySecretName(provider));
         return stored !== undefined;

--- a/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
+++ b/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
@@ -67,8 +67,8 @@ export class AgentDirectoryManager {
           showLoggedMessageWithDocs(CHANNEL, message, docsId),
       },
       logger: {
-        debug: (message) => logger.debug(CHANNEL, message),
-        error: (message) => logger.error(CHANNEL, message),
+        debug: (message, data) => logger.debug(CHANNEL, message, { data }),
+        error: (message, data) => logger.error(CHANNEL, message, { data }),
       },
     });
   }

--- a/packages/extension/src/frontend/agents/remoteAgentUtils.ts
+++ b/packages/extension/src/frontend/agents/remoteAgentUtils.ts
@@ -80,7 +80,8 @@ export async function selectAgentInMainView(
       message: `Agent "${agentName}" selected successfully`,
     };
   } catch (error) {
-    const errorMessage = toErrorMessage(error);
+    const errorMessage =
+      error instanceof Error ? toErrorMessage(error) : 'Unknown error';
     logger.error(CHANNEL, `Failed to select agent: ${errorMessage}`);
     return handleFallback(
       agentName,

--- a/packages/extension/src/frontend/agents/remoteAgentUtils.ts
+++ b/packages/extension/src/frontend/agents/remoteAgentUtils.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 
 import { createKey, getAgent, type AgentSource } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { toErrorMessage } from '@common/errors';
 import { getMainWebview } from '@frontend/system/commandUtils';
 import * as logger from '@logger/logUtils';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
@@ -79,8 +80,7 @@ export async function selectAgentInMainView(
       message: `Agent "${agentName}" selected successfully`,
     };
   } catch (error) {
-    const errorMessage =
-      error instanceof Error ? error.message : 'Unknown error';
+    const errorMessage = toErrorMessage(error);
     logger.error(CHANNEL, `Failed to select agent: ${errorMessage}`);
     return handleFallback(
       agentName,

--- a/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
+++ b/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
@@ -16,6 +16,7 @@ import * as vscode from 'vscode';
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { VscodeDiffViewHost } from '@frontend/approval/VscodeDiffViewHost';
+import { showLoggedMessage } from '@frontend/ui/errorHandlingUtils';
 import {
   type DiffSession,
   type DiffSource,
@@ -42,6 +43,8 @@ import {
 } from '@tools/approval/toolEditApproval';
 import { WorkspaceFS } from '@utils/files';
 import { normalizeLineEndings } from '@utils/text/stringUtils';
+
+const CHANNEL = 'nativeToolEditApproval';
 
 interface PendingApprovalEntry extends LatexPreviewEntry {
   request: ToolEditApprovalRequest;
@@ -206,7 +209,7 @@ export async function nativeRequestApproval(
         settle,
         workspaceTempCleanup: [],
         latexOperationInProgress: false,
-        onError: (msg) => vscode.window.showErrorMessage(msg),
+        onError: (msg) => void showLoggedMessage(CHANNEL, msg),
       };
 
       pendingApprovals.set(requestId, entry);

--- a/packages/extension/src/frontend/auth/SupabaseAuthProvider.ts
+++ b/packages/extension/src/frontend/auth/SupabaseAuthProvider.ts
@@ -155,6 +155,10 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
 
       if (!result.success) {
         if (result.isAuthError) {
+          logger.error(
+            'SupabaseAuthProvider',
+            `Sign-in failed: ${result.error}`,
+          );
           this.notifier.showError(`Sign-in failed: ${result.error}`);
         } else {
           // Log non-auth errors for debugging (e.g., missing tokens from non-auth callbacks)

--- a/packages/extension/src/frontend/editor/activeFileGuards.ts
+++ b/packages/extension/src/frontend/editor/activeFileGuards.ts
@@ -2,8 +2,11 @@
 import * as vscode from 'vscode';
 
 // Local imports - utils
+import { showLoggedMessage } from '@frontend/ui/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
+
+const CHANNEL = 'ActiveFileGuards';
 
 export type ActiveFileGuardFailureReason =
   'noEditor' | 'unsupportedExtension' | 'saveFailed';
@@ -65,7 +68,8 @@ export async function getActiveEditorWithGuards(
   if (saveDocument && editor.document.isDirty) {
     const saved = await editor.document.save();
     if (!saved) {
-      await vscode.window.showErrorMessage(
+      await showLoggedMessage(
+        CHANNEL,
         'Could not save the current file. Please save and try again.',
       );
       return { status: 'saveFailed' };

--- a/packages/extension/src/frontend/events/agentEventListeners.ts
+++ b/packages/extension/src/frontend/events/agentEventListeners.ts
@@ -19,7 +19,6 @@ import type {
 } from '@eventBus/ProgressEventBus';
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import { getMainWebview } from '@frontend/system/commandUtils';
-import { showLoggedMessage } from '@frontend/ui/errorHandlingUtils';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import * as logger from '@logger/logUtils';
@@ -104,7 +103,7 @@ async function handleShowAgentConfigBanner(
 function handleRequestShowError({
   message,
 }: ProgressEventPayloads['requestShowError']): void {
-  void showLoggedMessage(CHANNEL, message);
+  void vscode.window.showErrorMessage(message);
 }
 
 async function handleRequestEnsureProgressView(

--- a/packages/extension/src/frontend/events/agentEventListeners.ts
+++ b/packages/extension/src/frontend/events/agentEventListeners.ts
@@ -19,6 +19,7 @@ import type {
 } from '@eventBus/ProgressEventBus';
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import { getMainWebview } from '@frontend/system/commandUtils';
+import { showLoggedMessage } from '@frontend/ui/errorHandlingUtils';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import * as logger from '@logger/logUtils';
@@ -103,7 +104,7 @@ async function handleShowAgentConfigBanner(
 function handleRequestShowError({
   message,
 }: ProgressEventPayloads['requestShowError']): void {
-  void vscode.window.showErrorMessage(message);
+  void showLoggedMessage(CHANNEL, message);
 }
 
 async function handleRequestEnsureProgressView(

--- a/packages/extension/src/frontend/latex/openBuild.ts
+++ b/packages/extension/src/frontend/latex/openBuild.ts
@@ -5,6 +5,7 @@ import * as vscode from 'vscode';
 
 import { toErrorMessage } from '@common/errors';
 import { isLatexFile } from '@common/files/fileTypeUtils';
+import { showLoggedMessage } from '@frontend/ui/errorHandlingUtils';
 import { compileLatex2Pdf } from '@latex/texTools';
 import * as logger from '@logger/logUtils';
 import type { FileLocation } from '@shared/schemas';
@@ -80,7 +81,7 @@ export async function openBuildDisplayIfTex(
 
   const exists = await AbsoluteFS.exists(absolutePath);
   if (!exists) {
-    vscode.window.showErrorMessage(`File not found: ${absolutePath}`);
+    void showLoggedMessage(CHANNEL, `File not found: ${absolutePath}`);
     return;
   }
 

--- a/packages/extension/src/frontend/media/RecordingManager.ts
+++ b/packages/extension/src/frontend/media/RecordingManager.ts
@@ -9,6 +9,7 @@ import {
   startRecording,
   stopRecordingAndTranscribe,
 } from '@frontend/media/audio';
+import { showLoggedMessage } from '@frontend/ui/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'RecordingManager';
@@ -64,7 +65,7 @@ export class RecordingManager {
   }
 
   private notifyError(webview: vscode.Webview, message: string): void {
-    vscode.window.showErrorMessage(message);
+    void showLoggedMessage(CHANNEL, message);
     const payload = this.buildRecordingMessage('error', message);
     if (payload) webview.postMessage(payload);
   }

--- a/packages/extension/src/frontend/review/AgentReviewService.ts
+++ b/packages/extension/src/frontend/review/AgentReviewService.ts
@@ -34,7 +34,10 @@ import { runAgent } from '@agent/runtime/runAgent';
 import { toErrorMessage } from '@common/errors';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { openFinalOutputIfAvailable } from '@frontend/agents/finalOutputOpener';
-import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
+import {
+  showLoggedErrorMessage,
+  showLoggedMessage,
+} from '@frontend/ui/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { RUN_OUTCOME, type RunOutcome } from '@shared/schemas';
 import { AGENT_REVIEW_APPROACHES } from '@shared/schemas/coreSettings';
@@ -180,7 +183,8 @@ class AgentReviewServiceImpl {
     const cwd = WorkspaceFS.getPath();
     if (!cwd) {
       if (trigger === 'manual') {
-        void vscode.window.showErrorMessage(
+        void showLoggedMessage(
+          CHANNEL,
           'Agent review needs an open workspace folder.',
         );
       }

--- a/packages/extension/src/frontend/secretManager.ts
+++ b/packages/extension/src/frontend/secretManager.ts
@@ -8,7 +8,7 @@ import {
   API_PROVIDERS,
   apiKeyExists as resolvedApiKeyExists,
   apiKeySecretName,
-  lookupApiKey,
+  hasUsableApiKey as resolvedHasUsableApiKey,
   type ApiProvider,
 } from '@model/apiProviders';
 import {
@@ -16,7 +16,6 @@ import {
   getGitHubEnvToken,
   normalizeGitHubToken,
 } from '@tools/github/githubAuth';
-import { isNonEmptyString } from '@utils/core';
 
 export type { ApiProvider };
 
@@ -97,8 +96,7 @@ export class SecretManager {
    * authentication value.
    */
   public static async hasUsableApiKey(provider: ApiProvider): Promise<boolean> {
-    const key = await lookupApiKey(platform().secrets, provider);
-    return isNonEmptyString(key);
+    return resolvedHasUsableApiKey(platform().secrets, provider);
   }
 
   public static async getApiProviderQuickPickItems(): Promise<

--- a/packages/extension/src/frontend/setup.ts
+++ b/packages/extension/src/frontend/setup.ts
@@ -88,8 +88,8 @@ export async function copyDefaultAgents(
         globalSM.update(GlobalStateKey.LAST_KNOWN_VERSION, version),
     },
     logger: {
-      info: (message) => logger.info('extension', message),
-      warn: (message) => logger.warn('extension', message),
+      info: (message, data) => logger.info('extension', message, { data }),
+      warn: (message, data) => logger.warn('extension', message, { data }),
     },
   });
 

--- a/packages/extension/src/frontend/ui/dialogs.ts
+++ b/packages/extension/src/frontend/ui/dialogs.ts
@@ -5,7 +5,10 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 
 // Local imports - utilities
+import { showLoggedMessage } from '@frontend/ui/errorHandlingUtils';
 import { WorkspaceFS } from '@utils/files';
+
+const CHANNEL = 'dialogs';
 
 export interface FileDialogOptions {
   /** Whether multiple files can be selected */
@@ -42,7 +45,7 @@ export async function selectFiles(
 ): Promise<string[] | null> {
   const defaultUri = computeDefaultUri(options);
   if (!defaultUri) {
-    vscode.window.showErrorMessage('No workspace folder open');
+    void showLoggedMessage(CHANNEL, 'No workspace folder open');
     return null;
   }
 

--- a/packages/extension/src/progressView/frontend/components/TexraDiffView.ts
+++ b/packages/extension/src/progressView/frontend/components/TexraDiffView.ts
@@ -230,7 +230,10 @@ export class TexraDiffView extends LitElement {
       this.syncModels();
       this.observeResize(container);
     } catch (error) {
-      this.errorMessage = toErrorMessage(error);
+      this.errorMessage =
+        error instanceof Error
+          ? toErrorMessage(error)
+          : 'Failed to load diff editor.';
     } finally {
       if (generation === this.loadGeneration) this.loading = false;
     }

--- a/packages/extension/src/progressView/frontend/components/TexraDiffView.ts
+++ b/packages/extension/src/progressView/frontend/components/TexraDiffView.ts
@@ -3,6 +3,9 @@ import { LitElement, css, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { consume } from '@lit/context';
 
+// Local imports - errors
+import { toErrorMessage } from '@common/errors';
+
 // Local imports - shared modules
 import { themeContext } from '@shared/BaseWebviewApp';
 import { commonViewStyles, designTokens } from '@shared/styles';
@@ -227,8 +230,7 @@ export class TexraDiffView extends LitElement {
       this.syncModels();
       this.observeResize(container);
     } catch (error) {
-      this.errorMessage =
-        error instanceof Error ? error.message : 'Failed to load diff editor.';
+      this.errorMessage = toErrorMessage(error);
     } finally {
       if (generation === this.loadGeneration) this.loading = false;
     }

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
@@ -361,10 +361,8 @@ function buildMcpSections(ctx: ToolSectionContext): TemplateResult[] {
     }
   }
 
-  const mcpParsed = CodexMcpToolOutputSchema.safeParse(parsedOutput);
-  const mcpOutput: CodexMcpToolOutput | null = mcpParsed.success
-    ? mcpParsed.data
-    : null;
+  const mcpOutput: CodexMcpToolOutput | null =
+    CodexMcpToolOutputSchema.nullable().catch(null).parse(parsedOutput);
   const contentBlocks = Array.isArray(mcpOutput?.contentBlocks)
     ? mcpOutput.contentBlocks
     : [];

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -1073,7 +1073,6 @@ export class SettingsApp extends SettingsAppBase {
               @tool-open-url=${this.handleToolOpenUrl}
               @tool-install-extension=${this.handleToolInstallExtension}
               @tool-run-command=${this.handleToolRunCommand}
-              @tool-recheck=${this.handleToolRecheck}
               @tool-toggle=${this.handleToolToggle}
               @codex-sandbox-mode-change=${this.handleCodexSandboxModeChange}
               @codex-reasoning-effort-change=${

--- a/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
@@ -281,13 +281,15 @@ export class AIAgentsTab extends LitElement {
         <span class="ai-agents-status-stat ai-agents-status-available">
           ${waIcon('check')} ${available} available
         </span>
-        ${missing > 0
-          ? html`
-              <span class="ai-agents-status-stat ai-agents-status-missing">
-                ${waIcon('warning')} ${missing} need setup
-              </span>
-            `
-          : nothing}
+        ${
+          missing > 0
+            ? html`
+                <span class="ai-agents-status-stat ai-agents-status-missing">
+                  ${waIcon('warning')} ${missing} need setup
+                </span>
+              `
+            : nothing
+        }
       </div>
     `;
   }

--- a/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
@@ -33,7 +33,6 @@ import {
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 
 // Side-effect imports - register WA components
-import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/select/select.js';
 import '@awesome.me/webawesome/dist/components/option/option.js';
@@ -101,6 +100,32 @@ export class AIAgentsTab extends LitElement {
         font-size: var(--font-size-sm);
       }
 
+      .ai-agents-status {
+        display: flex;
+        align-items: center;
+        gap: var(--wa-space-s);
+        font-size: var(--font-size-sm);
+        white-space: nowrap;
+      }
+
+      .ai-agents-status-stat {
+        display: flex;
+        align-items: center;
+        gap: var(--wa-space-2xs);
+      }
+
+      .ai-agents-status-stat wa-icon {
+        font-size: var(--font-size-sm);
+      }
+
+      .ai-agents-status-available {
+        color: var(--color-status-ok);
+      }
+
+      .ai-agents-status-missing {
+        color: var(--color-status-error);
+      }
+
       .category-section {
         margin-bottom: var(--wa-space-m);
       }
@@ -142,10 +167,6 @@ export class AIAgentsTab extends LitElement {
   @property({ type: String })
   claudeAgentPermissionMode: ClaudeAgentPermissionMode = 'acceptEdits';
   @property({ type: String }) claudeAgentEffort: ClaudeAgentEffort = 'high';
-
-  private handleRecheck(): void {
-    this.dispatchEvent(createEvent('tool-recheck'));
-  }
 
   private emitSelect(eventName: string, key: string, e: Event): void {
     const select = e.currentTarget as WaSelect | null;
@@ -237,6 +258,40 @@ export class AIAgentsTab extends LitElement {
     return this.items.filter((item) => item.category === 'ai-agents');
   }
 
+  /**
+   * Read-only status summary derived from the same `toolDashboardItems`
+   * signal the Tools tab uses to drive its actionable "Re-check" button.
+   * This tab only reflects that shared state — the Tools tab owns the one
+   * control that re-runs the probe (see CLAUDE.md "Duplicate UI Controls").
+   */
+  private renderStatusSummary(
+    items: readonly ToolDashboardItem[],
+  ): TemplateResult | typeof nothing {
+    if (items.length === 0) return nothing;
+
+    let available = 0;
+    let missing = 0;
+    for (const item of items) {
+      if (item.status === 'available') available++;
+      else if (item.status === 'not-found') missing++;
+    }
+
+    return html`
+      <div class="ai-agents-status">
+        <span class="ai-agents-status-stat ai-agents-status-available">
+          ${waIcon('check')} ${available} available
+        </span>
+        ${missing > 0
+          ? html`
+              <span class="ai-agents-status-stat ai-agents-status-missing">
+                ${waIcon('warning')} ${missing} need setup
+              </span>
+            `
+          : nothing}
+      </div>
+    `;
+  }
+
   override render(): TemplateResult {
     if (!this.loaded) {
       return html`
@@ -256,15 +311,7 @@ export class AIAgentsTab extends LitElement {
             runs, such as coding agents, GitHub, and reference managers. Each
             integration shows its own setup and authentication state here.
           </p>
-          <wa-button
-            appearance="outlined"
-            variant="neutral"
-            size="small"
-            title="Re-check integration availability"
-            @click=${this.handleRecheck}
-          >
-            ${waIcon('refresh', { slot: 'start' })} Re-check
-          </wa-button>
+          ${this.renderStatusSummary(items)}
         </div>
 
         ${

--- a/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
@@ -19,6 +19,7 @@ import { renderLoadingState } from '@shared/wa/loadingState';
 import { createEvent } from '@shared/utils/events';
 import type {
   ToolDashboardItem,
+  ToolStatus,
   CodexSandboxMode,
   CodexReasoningEffort,
   CodexApprovalPolicy,
@@ -124,6 +125,10 @@ export class AIAgentsTab extends LitElement {
 
       .ai-agents-status-missing {
         color: var(--color-status-error);
+      }
+
+      .ai-agents-status-neutral {
+        color: var(--wa-color-text-quiet);
       }
 
       .category-section {
@@ -269,23 +274,36 @@ export class AIAgentsTab extends LitElement {
   ): TemplateResult | typeof nothing {
     if (items.length === 0) return nothing;
 
-    let available = 0;
-    let missing = 0;
+    const counts: Record<ToolStatus, number> = {
+      available: 0,
+      'not-found': 0,
+      unknown: 0,
+      'coming-soon': 0,
+    };
     for (const item of items) {
-      if (item.status === 'available') available++;
-      else if (item.status === 'not-found') missing++;
+      counts[item.status] += 1;
     }
+    const pending = counts.unknown + counts['coming-soon'];
 
     return html`
       <div class="ai-agents-status">
         <span class="ai-agents-status-stat ai-agents-status-available">
-          ${waIcon('check')} ${available} available
+          ${waIcon('check')} ${counts.available} available
         </span>
         ${
-          missing > 0
+          counts['not-found'] > 0
             ? html`
                 <span class="ai-agents-status-stat ai-agents-status-missing">
-                  ${waIcon('warning')} ${missing} need setup
+                  ${waIcon('warning')} ${counts['not-found']} need setup
+                </span>
+              `
+            : nothing
+        }
+        ${
+          pending > 0
+            ? html`
+                <span class="ai-agents-status-stat ai-agents-status-neutral">
+                  ${waIcon('clock')} ${pending} pending
                 </span>
               `
             : nothing

--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -18,6 +18,7 @@ import { workspaceSM, globalSM } from '@common/state';
 import {
   isFileNotFoundError,
   showLoggedErrorMessage,
+  showLoggedMessage,
 } from '@frontend/ui/errorHandlingUtils';
 import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import { renderAgentTemplateFromBundle } from '@frontend/agents/agentTemplateBundle';
@@ -91,14 +92,16 @@ export class AgentHandlers {
         name: data.agentName,
       });
       if (!result.ok && result.reason === 'missingAgent') {
-        await vscode.window.showErrorMessage(
+        await showLoggedMessage(
+          this.ctx.channel,
           `Agent "${data.agentName}" could not be found. It may have been removed or renamed. Check the Agents tab in Settings to see available agents.`,
         );
         return;
       }
 
       if (!result.ok) {
-        await vscode.window.showErrorMessage(
+        await showLoggedMessage(
+          this.ctx.channel,
           `No configuration file found for agent "${data.agentName}". The agent definition may be incomplete — try re-creating it from the Agents tab.`,
         );
         return;
@@ -162,7 +165,8 @@ export class AgentHandlers {
         data.folderType,
       );
       if (!result.ok) {
-        await vscode.window.showErrorMessage(
+        await showLoggedMessage(
+          this.ctx.channel,
           `No local directory for agent source: ${data.folderType}`,
         );
         return;
@@ -189,7 +193,8 @@ export class AgentHandlers {
         name: data.agentName,
       });
       if (!result.ok) {
-        await vscode.window.showErrorMessage(
+        await showLoggedMessage(
+          this.ctx.channel,
           `Agent not found or has no file: ${data.agentName}`,
         );
         return;
@@ -215,7 +220,7 @@ export class AgentHandlers {
         data.agentName,
       );
       if (!result.ok) {
-        await vscode.window.showErrorMessage(result.message);
+        await showLoggedMessage(this.ctx.channel, result.message);
         return;
       }
 
@@ -255,7 +260,8 @@ export class AgentHandlers {
       const key = createKey(data.agentSource, data.agentName);
       const entry = getAgent(key);
       if (!entry?.path) {
-        await vscode.window.showErrorMessage(
+        await showLoggedMessage(
+          this.ctx.channel,
           `Agent not found or has no file: ${data.agentName}`,
         );
         return;
@@ -270,7 +276,8 @@ export class AgentHandlers {
         sourceDir,
       });
       if (!result.ok) {
-        await vscode.window.showErrorMessage(
+        await showLoggedMessage(
+          this.ctx.channel,
           `Refusing to copy: target path escapes the custom agents directory.`,
         );
         return;
@@ -319,7 +326,8 @@ export class AgentHandlers {
       const key = createKey('custom', data.agentName);
       const entry = getAgent(key);
       if (!entry?.path) {
-        await vscode.window.showErrorMessage(
+        await showLoggedMessage(
+          this.ctx.channel,
           `Custom agent not found: ${data.agentName}`,
         );
         return;
@@ -331,7 +339,8 @@ export class AgentHandlers {
         customDir,
       });
       if (!result.ok) {
-        await vscode.window.showErrorMessage(
+        await showLoggedMessage(
+          this.ctx.channel,
           `Refusing to delete: file is not inside the custom agents directory.`,
         );
         return;
@@ -409,7 +418,10 @@ export class AgentHandlers {
       await loadAgents();
       const result = await this.catalogController.applyPreset(data.presetId);
       if (!result.ok) {
-        await vscode.window.showErrorMessage(`Unknown team: ${data.presetId}`);
+        await showLoggedMessage(
+          this.ctx.channel,
+          `Unknown team: ${data.presetId}`,
+        );
         return;
       }
 

--- a/packages/extension/src/settingsView/handlers/githubSubscriptionHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/githubSubscriptionHandlers.ts
@@ -8,7 +8,10 @@
 import * as vscode from 'vscode';
 
 import { SecretManager } from '@frontend/secretManager';
-import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
+import {
+  showLoggedErrorMessage,
+  showLoggedMessage,
+} from '@frontend/ui/errorHandlingUtils';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import {
   getProgressStreamLabel,
@@ -147,7 +150,8 @@ export class GitHubSubscriptionHandlers {
   ): Promise<void> {
     const result = await revealProgressStream(data.streamId);
     if (result === 'unavailable') {
-      await vscode.window.showErrorMessage(
+      await showLoggedMessage(
+        this.ctx.channel,
         'Progress View is not available. Please try again.',
       );
       return;

--- a/packages/extension/src/settingsView/handlers/historyHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/historyHandlers.ts
@@ -30,7 +30,10 @@ import {
 import { executionRegistry } from '@agent/runtime/executionRegistry';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 import { runExecuteCommand } from '@commands/agent/executeCommand';
-import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
+import {
+  showLoggedErrorMessage,
+  showLoggedMessage,
+} from '@frontend/ui/errorHandlingUtils';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import type { ExecutionId } from '@shared/schemas';
 import {
@@ -186,10 +189,11 @@ export class HistoryHandlers {
   ): void {
     switch (status) {
       case 'config_missing':
-        void vscode.window.showErrorMessage('History item not found');
+        void showLoggedMessage(this.ctx.channel, 'History item not found');
         return;
       case 'conversation_missing':
-        void vscode.window.showErrorMessage(
+        void showLoggedMessage(
+          this.ctx.channel,
           'No conversation data available for this execution',
         );
         return;
@@ -260,7 +264,7 @@ export class HistoryHandlers {
         historyId as ExecutionId,
       ).readConfig();
       if (!raw) {
-        await vscode.window.showErrorMessage('History item not found');
+        await showLoggedMessage(this.ctx.channel, 'History item not found');
         return;
       }
       const config = AgentConfigSchema.parse(raw);

--- a/packages/extension/src/webview/managers/executionHandlers.ts
+++ b/packages/extension/src/webview/managers/executionHandlers.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 
 import { prepareMainViewExecutionRequest } from '@controllers/mainView/MainViewExecutionController';
+import { logErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import type { MainViewExecuteMessage } from '@shared/mainView';
 
@@ -24,6 +25,11 @@ export async function handleExecute(
 ): Promise<void> {
   const preparation = prepareMainViewExecutionRequest(message);
   if (!preparation.valid) {
+    logErrorMessage(
+      CHANNEL,
+      'AgentConfig validation failed',
+      preparation.message,
+    );
     if (preparation.docsCommand) {
       const openDocs = 'File Management Guide';
       const choice = await vscode.window.showErrorMessage(
@@ -39,10 +45,6 @@ export async function handleExecute(
     } else {
       vscode.window.showErrorMessage(preparation.message);
     }
-    logger.error(
-      CHANNEL,
-      `AgentConfig validation failed: ${preparation.message}`,
-    );
     return;
   }
 

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -11,11 +11,7 @@ import {
 } from '@agent/runtime/RetryRequestCoordinator';
 import type { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
 import { SupabaseClient } from '@auth/SupabaseClient';
-import {
-  ensureError,
-  normalizeProviderError,
-  toErrorMessage,
-} from '@common/errors';
+import { ensureError, normalizeProviderError } from '@common/errors';
 import { isUserAbort } from '@common/errors/sdkErrorUtils';
 import {
   STREAM_STATUS,
@@ -79,9 +75,9 @@ async function tryRefreshClient(
     logger.debug(`Refreshed model client ${context}`);
     return true;
   } catch (refreshError) {
-    logger.warn(
-      `Failed to refresh model client ${context}: ${toErrorMessage(refreshError)}`,
-    );
+    logger.warn(`Failed to refresh model client ${context}`, {
+      data: refreshError,
+    });
     return false;
   }
 }
@@ -273,11 +269,7 @@ export abstract class RetryableInvocationNode<
       return { shouldRetry: false, userCancelled: false };
     }
 
-    logErrorData(
-      logger,
-      `${operationName} failed: ${formatted.message}`,
-      formatted,
-    );
+    logErrorData(logger, `${operationName} failed`, formatted);
 
     streamStatus.set(streamId, STREAM_STATUS.WAITING, {
       runtimeHost,
@@ -319,7 +311,7 @@ export abstract class RetryableInvocationNode<
     if (!formatted.userRetryable) {
       logErrorData(
         this.services.logger,
-        `${this.getOperationName()} failed (no retry available): ${formatted.message}`,
+        `${this.getOperationName()} failed (no retry available)`,
         formatted,
       );
     }

--- a/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
@@ -16,7 +16,6 @@ import type {
   WorkPlanState,
 } from '@agent/core/state/AgentWorkspaceState';
 import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
-import { toErrorMessage } from '@common/errors';
 
 // Local imports - logging
 import type { FileLocation } from '@shared/schemas';
@@ -125,8 +124,8 @@ export class ToolUseDispatchNode<C> extends BatchNode<
           ),
         ];
         this.services.logger.debug(
-          `Deduplicated ${this._duplicateCallIds.size} parallel tool call(s) ` +
-            `with identical name and arguments: ${dupNames.join(', ')}`,
+          `Deduplicated ${this._duplicateCallIds.size} parallel tool call(s) with identical name and arguments`,
+          { data: dupNames },
         );
       }
     }
@@ -389,7 +388,8 @@ export class ToolUseDispatchNode<C> extends BatchNode<
           }
         } catch (err) {
           options.logger.debug(
-            `Skipping inaccessible media file: ${attachment.path} (${toErrorMessage(err)})`,
+            `Skipping inaccessible media file: ${attachment.path}`,
+            { data: err },
           );
         }
       }

--- a/src/agent/followUp/ToolUseFollowUp.ts
+++ b/src/agent/followUp/ToolUseFollowUp.ts
@@ -136,9 +136,9 @@ export function notifyFollowUpSent(
     try {
       observer(streamId);
     } catch (err) {
-      logger.warn(
-        `Follow-up sent observer threw for stream ${streamId}: ${String(err)}`,
-      );
+      logger.warn(`Follow-up sent observer threw for stream ${streamId}`, {
+        data: err,
+      });
     }
   }
   runtimeHost?.emit('followUpSent', { streamId });

--- a/src/agent/followUp/ToolUseFollowUpQueueManager.ts
+++ b/src/agent/followUp/ToolUseFollowUpQueueManager.ts
@@ -62,9 +62,9 @@ export class ToolUseFollowUpQueue {
       try {
         observer(streamId);
       } catch (err) {
-        logger.warn(
-          `Release observer threw for stream ${streamId}: ${String(err)}`,
-        );
+        logger.warn(`Release observer threw for stream ${streamId}`, {
+          data: err,
+        });
       }
     }
   }

--- a/src/agent/implementations/flows/reflection/nodes/MediaExtractionNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/MediaExtractionNode.ts
@@ -83,7 +83,7 @@ export class MediaExtractionNode<C = unknown> extends Node<
     error: Error,
   ): Promise<FileLocation[] | null> {
     const { logger } = this.services;
-    logger.debug(`Media extraction skipped: ${error.message}`);
+    logger.debug('Media extraction skipped', { data: error });
     return null;
   }
 

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -26,6 +26,7 @@ import {
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { tryOperation } from '@agent/output/outputOperations';
 import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
+import { toErrorMessage } from '@common/errors';
 import {
   MESSAGE_TYPES,
   type AgentFileLocation,
@@ -186,7 +187,7 @@ export class OutputNode<C = unknown> extends Node<
   ): Promise<OutputExecResult> {
     const { logger, outputState, setting } = this.services;
     const { outputLocation, currentRound, endTurn } = prepRes;
-    logger.warn('Output processing failed', { data: error });
+    logger.warn(`Output processing failed: ${error.message}`, { data: error });
 
     // Still summarize what we can for post() side effects
     let summary: RoundSummary;
@@ -202,7 +203,7 @@ export class OutputNode<C = unknown> extends Node<
       // Double-fault: summarizeRound failed during fallback, so we drop the
       // round's file infos. Log it so silently-missing output files are visible.
       logger.warn(
-        'Output fallback summary failed; output files may be dropped',
+        `Output fallback summary failed; output files may be dropped: ${toErrorMessage(summaryError)}`,
         { data: summaryError },
       );
       summary = {

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -1,6 +1,5 @@
 import { Node } from '@agent/node';
 import { useLaunchRunContext } from '@agent/runtime/RunContext';
-import { toErrorMessage } from '@common/errors';
 import type { RoundFileMapping } from '@agent/output/types';
 import type { CompiledPdfArtifact } from '@agent/output/compiledPdfArtifacts';
 import type { LatexDiffManager } from '@agent/output/LatexDiffManager';
@@ -187,7 +186,7 @@ export class OutputNode<C = unknown> extends Node<
   ): Promise<OutputExecResult> {
     const { logger, outputState, setting } = this.services;
     const { outputLocation, currentRound, endTurn } = prepRes;
-    logger.warn(`Output processing failed: ${error.message}`);
+    logger.warn('Output processing failed', { data: error });
 
     // Still summarize what we can for post() side effects
     let summary: RoundSummary;
@@ -203,7 +202,8 @@ export class OutputNode<C = unknown> extends Node<
       // Double-fault: summarizeRound failed during fallback, so we drop the
       // round's file infos. Log it so silently-missing output files are visible.
       logger.warn(
-        `Output fallback summary failed; output files may be dropped: ${toErrorMessage(summaryError)}`,
+        'Output fallback summary failed; output files may be dropped',
+        { data: summaryError },
       );
       summary = {
         storageKey: getStorageKey(outputState),

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -1,5 +1,6 @@
 import { Node } from '@agent/node';
 import { useLaunchRunContext } from '@agent/runtime/RunContext';
+import { toErrorMessage } from '@common/errors';
 import type { RoundFileMapping } from '@agent/output/types';
 import type { CompiledPdfArtifact } from '@agent/output/compiledPdfArtifacts';
 import type { LatexDiffManager } from '@agent/output/LatexDiffManager';
@@ -202,11 +203,7 @@ export class OutputNode<C = unknown> extends Node<
       // Double-fault: summarizeRound failed during fallback, so we drop the
       // round's file infos. Log it so silently-missing output files are visible.
       logger.warn(
-        `Output fallback summary failed; output files may be dropped: ${
-          summaryError instanceof Error
-            ? summaryError.message
-            : String(summaryError)
-        }`,
+        `Output fallback summary failed; output files may be dropped: ${toErrorMessage(summaryError)}`,
       );
       summary = {
         storageKey: getStorageKey(outputState),

--- a/src/agent/implementations/flows/reflection/nodes/PrepareContextNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/PrepareContextNode.ts
@@ -72,9 +72,12 @@ export class PrepareContextNode<C = unknown> extends Node<
       prefill = await promptBuilder.buildPrefill(currentRound);
     }
 
-    logger.debug(
-      `Prepared ${isFirstRound ? 'first' : `round ${currentRound}`} context with ${messages.length} messages`,
-    );
+    logger.debug('Prepared round context', {
+      data: {
+        round: isFirstRound ? 'first' : currentRound,
+        messageCount: messages.length,
+      },
+    });
 
     return {
       messages,

--- a/src/agent/implementations/flows/reflection/nodes/TeXCountNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/TeXCountNode.ts
@@ -36,7 +36,7 @@ export class TeXCountNode<C = unknown> extends Node<
     error: Error,
   ): Promise<string | null> {
     const { logger } = this.services;
-    logger.debug(`TeXCount skipped: ${error.message}`);
+    logger.debug('TeXCount skipped', { data: error });
     return null;
   }
 

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -9,7 +9,7 @@ import {
 import { withModelClient } from '@agent/core/flows/CycleServices';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
-import { normalizeProviderError, toErrorMessage } from '@common/errors';
+import { normalizeProviderError } from '@common/errors';
 import { MESSAGE_TYPES, toRetryErrorInfo } from '@shared/schemas';
 import type { RetryErrorInfo } from '@shared/schemas';
 
@@ -97,9 +97,9 @@ export class ToolUseCycleNode<C> extends Node<
             // Best-effort todo persistence — log so swallowed write failures
             // are diagnosable without disrupting the update stream.
             .catch((err: unknown) => {
-              this.services.logger.debug(
-                `Failed to persist todos: ${toErrorMessage(err)}`,
-              );
+              this.services.logger.debug('Failed to persist todos', {
+                data: err,
+              });
             });
         }
         onProgress?.({ kind: 'todos', todos });

--- a/src/agent/index/AgentDirectoryService.ts
+++ b/src/agent/index/AgentDirectoryService.ts
@@ -2,7 +2,6 @@
 import * as path from 'node:path';
 
 // Local imports
-import { toErrorMessage } from '@common/errors';
 import type { AgentSource } from '@shared/schemas/agent';
 
 import {
@@ -39,8 +38,8 @@ export interface AgentDirectoryIssueReporter {
 }
 
 export interface AgentDirectoryServiceLogger {
-  debug(message: string): void;
-  error(message: string): void;
+  debug(message: string, data?: unknown): void;
+  error(message: string, data?: unknown): void;
 }
 
 export interface AgentDirectoryServiceOptions {
@@ -122,7 +121,8 @@ export class AgentDirectoryService {
       await this.options.storage.ensureDir(this.defaultCustomDirectoryName);
     } catch (error) {
       this.options.logger.error(
-        `Failed to create default custom agents directory: ${toErrorMessage(error)}`,
+        'Failed to create default custom agents directory',
+        error,
       );
       throw new Error(
         'Unable to create custom agents directory. Please check permissions.',

--- a/src/agent/index/AgentDirectorySync.ts
+++ b/src/agent/index/AgentDirectorySync.ts
@@ -54,8 +54,8 @@ export interface AgentDirectoryVersionStore {
 }
 
 export interface AgentDirectorySyncLogger {
-  info(message: string): void;
-  warn(message: string): void;
+  info(message: string, data?: unknown): void;
+  warn(message: string, data?: unknown): void;
 }
 
 export interface BundledAgentDirectorySyncOptions {
@@ -213,7 +213,8 @@ export class BundledAgentDirectorySync {
         this.options.logger.info(`Deleted legacy agent file: ${legacyFile}`);
       } catch (error) {
         this.options.logger.warn(
-          `Failed to delete legacy agent file ${legacyFile}: ${toErrorMessage(error)}`,
+          `Failed to delete legacy agent file ${legacyFile}`,
+          error,
         );
       }
     }

--- a/src/agent/index/platformAgentDirectories.ts
+++ b/src/agent/index/platformAgentDirectories.ts
@@ -47,8 +47,10 @@ function createPlatformAgentDirectories(
         ),
     },
     logger: {
-      debug: (message, data) => logger.debug(options.channel, message, { data }),
-      error: (message, data) => logger.error(options.channel, message, { data }),
+      debug: (message, data) =>
+        logger.debug(options.channel, message, { data }),
+      error: (message, data) =>
+        logger.error(options.channel, message, { data }),
     },
   });
 }

--- a/src/agent/index/platformAgentDirectories.ts
+++ b/src/agent/index/platformAgentDirectories.ts
@@ -47,8 +47,8 @@ function createPlatformAgentDirectories(
         ),
     },
     logger: {
-      debug: (message) => logger.debug(options.channel, message),
-      error: (message) => logger.error(options.channel, message),
+      debug: (message, data) => logger.debug(options.channel, message, { data }),
+      error: (message, data) => logger.error(options.channel, message, { data }),
     },
   });
 }
@@ -61,8 +61,8 @@ export async function bootstrapPlatformAgentDirectories(
     storage: new GlobalStorageAgentDirectoryStorage(),
     versionStore: options.versionStore,
     logger: {
-      info: (message) => logger.info(options.channel, message),
-      warn: (message) => logger.warn(options.channel, message),
+      info: (message, data) => logger.info(options.channel, message, { data }),
+      warn: (message, data) => logger.warn(options.channel, message, { data }),
     },
   });
 

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -29,7 +29,10 @@ import { K_SLICE } from '@agent/core/constants';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { MAX_TIER, FREE_TIER } from '@auth/config';
 import { SupabaseClient } from '@auth/SupabaseClient';
-import { isContextWindowError } from '@common/errors/sdkErrorUtils';
+import {
+  getSdkErrorMessage,
+  isContextWindowError,
+} from '@common/errors/sdkErrorUtils';
 
 // Local imports - platform
 
@@ -966,9 +969,10 @@ export abstract class ModelHandler<
 
       return { compactedMessages, didCompact: true };
     } catch (err) {
-      this.logger.warn('Compaction failed, continuing with original messages', {
-        data: err,
-      });
+      this.logger.warn(
+        `Compaction failed, continuing with original messages: ${getSdkErrorMessage(err)}`,
+        { data: err },
+      );
       return { compactedMessages: messages, didCompact: false };
     }
   }

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -966,10 +966,9 @@ export abstract class ModelHandler<
 
       return { compactedMessages, didCompact: true };
     } catch (err) {
-      this.logger.warn(
-        'Compaction failed, continuing with original messages',
-        { data: err },
-      );
+      this.logger.warn('Compaction failed, continuing with original messages', {
+        data: err,
+      });
       return { compactedMessages: messages, didCompact: false };
     }
   }

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -29,10 +29,7 @@ import { K_SLICE } from '@agent/core/constants';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { MAX_TIER, FREE_TIER } from '@auth/config';
 import { SupabaseClient } from '@auth/SupabaseClient';
-import {
-  getSdkErrorMessage,
-  isContextWindowError,
-} from '@common/errors/sdkErrorUtils';
+import { isContextWindowError } from '@common/errors/sdkErrorUtils';
 
 // Local imports - platform
 
@@ -666,9 +663,13 @@ export abstract class ModelHandler<
     );
 
     if (maxOutputTokensExceeded) {
-      this.logger.warn(
-        `Output tokens exceed ${this.maxOutputTokensFactor}x input tokens (total: ${totals.totalOutputTokens}, first input: ${totals.firstInputTokens})`,
-      );
+      this.logger.warn('Output tokens exceed input token multiplier', {
+        data: {
+          maxOutputTokensFactor: this.maxOutputTokensFactor,
+          totalOutputTokens: totals.totalOutputTokens,
+          firstInputTokens: totals.firstInputTokens,
+        },
+      });
     }
 
     const shouldStop =
@@ -677,9 +678,15 @@ export abstract class ModelHandler<
       inputTokenLimitExceeded;
 
     if (shouldStop) {
-      this.logger.debug(
-        `StopFlags: endTurn: ${endTurn} encounterDocumentTag: ${encounterDocumentTag} continuation_limit: ${continuationLimitExceeded} inputTokenLimit: ${inputTokenLimitExceeded} maxOutputTokens: ${maxOutputTokensExceeded}`,
-      );
+      this.logger.debug('StopFlags', {
+        data: {
+          endTurn,
+          encounterDocumentTag,
+          continuationLimitExceeded,
+          inputTokenLimitExceeded,
+          maxOutputTokensExceeded,
+        },
+      });
     }
 
     return { endTurn, shouldStop };
@@ -960,7 +967,8 @@ export abstract class ModelHandler<
       return { compactedMessages, didCompact: true };
     } catch (err) {
       this.logger.warn(
-        `Compaction failed, continuing with original messages: ${getSdkErrorMessage(err)}`,
+        'Compaction failed, continuing with original messages',
+        { data: err },
       );
       return { compactedMessages: messages, didCompact: false };
     }
@@ -1305,7 +1313,8 @@ export abstract class ModelHandler<
         onCountFailure(err);
       } else {
         this.logger.debug(
-          `Token counting failed: ${getSdkErrorMessage(err)}. Proceeding without token adjustment.`,
+          'Token counting failed. Proceeding without token adjustment.',
+          { data: err },
         );
       }
     }

--- a/src/agent/modelHandlers/anthropic/anthropicServerTools.ts
+++ b/src/agent/modelHandlers/anthropic/anthropicServerTools.ts
@@ -117,8 +117,13 @@ export function buildAnthropicAssistantContent(
 
   if (orphanedIds.length > 0) {
     logger.debug(
-      `Stripping ${orphanedIds.length} orphaned server_tool_use block(s) without matching result: ${orphanedIds.join(', ')}. ` +
-        `Response content types: [${responseObject.content.map((b) => b.type).join(', ')}]`,
+      'Stripping orphaned server_tool_use block(s) without matching result',
+      {
+        data: {
+          orphanedIds,
+          contentTypes: responseObject.content.map((b) => b.type),
+        },
+      },
     );
   }
 

--- a/src/agent/modelHandlers/anthropic/anthropicTools.ts
+++ b/src/agent/modelHandlers/anthropic/anthropicTools.ts
@@ -5,7 +5,6 @@ import { toFile } from '@anthropic-ai/sdk';
 
 // Local imports - common
 import type { AgentTrace } from '@agent/trace';
-import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 
 // Type imports - agent and tools
 import type { ToolFileAttachment } from '@shared/schemas/toolResult';
@@ -86,9 +85,9 @@ export async function uploadToolAttachments(
     try {
       buffer = await loadAttachmentBuffer(attachment);
     } catch (err) {
-      logger.warn(
-        `Unable to read attachment ${attachment.path ?? 'attachment'}: ${getSdkErrorMessage(err)}`,
-      );
+      logger.warn('Unable to read attachment', {
+        data: { path: attachment.path ?? 'attachment', error: err },
+      });
       unsupported.push(attachment);
       continue;
     }
@@ -132,9 +131,9 @@ export async function uploadToolAttachments(
     } catch (err) {
       // Upload failed — degrade to unsupported, but log so a dropped
       // attachment isn't silently omitted from the request.
-      logger.warn(
-        `Failed to upload attachment ${attachment.path ?? 'attachment'}: ${getSdkErrorMessage(err)}`,
-      );
+      logger.warn('Failed to upload attachment', {
+        data: { path: attachment.path ?? 'attachment', error: err },
+      });
       unsupported.push(attachment);
     } finally {
       buffer = wipeBuffer(buffer);

--- a/src/agent/modelHandlers/anthropic/anthropicTools.ts
+++ b/src/agent/modelHandlers/anthropic/anthropicTools.ts
@@ -5,6 +5,7 @@ import { toFile } from '@anthropic-ai/sdk';
 
 // Local imports - common
 import type { AgentTrace } from '@agent/trace';
+import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 
 // Type imports - agent and tools
 import type { ToolFileAttachment } from '@shared/schemas/toolResult';
@@ -85,9 +86,13 @@ export async function uploadToolAttachments(
     try {
       buffer = await loadAttachmentBuffer(attachment);
     } catch (err) {
-      logger.warn('Unable to read attachment', {
-        data: { path: attachment.path ?? 'attachment', error: err },
-      });
+      const attachmentPath = attachment.path ?? 'attachment';
+      logger.warn(
+        `Unable to read attachment ${attachmentPath}: ${getSdkErrorMessage(err)}`,
+        {
+          data: { path: attachmentPath, error: err },
+        },
+      );
       unsupported.push(attachment);
       continue;
     }
@@ -131,9 +136,13 @@ export async function uploadToolAttachments(
     } catch (err) {
       // Upload failed — degrade to unsupported, but log so a dropped
       // attachment isn't silently omitted from the request.
-      logger.warn('Failed to upload attachment', {
-        data: { path: attachment.path ?? 'attachment', error: err },
-      });
+      const attachmentPath = attachment.path ?? 'attachment';
+      logger.warn(
+        `Failed to upload attachment ${attachmentPath}: ${getSdkErrorMessage(err)}`,
+        {
+          data: { path: attachmentPath, error: err },
+        },
+      );
       unsupported.push(attachment);
     } finally {
       buffer = wipeBuffer(buffer);

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -947,7 +947,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
           if (resolvedMediaType !== 'image/png') {
             this.logger.warn(
               'Unsupported image media type, defaulting to image/png',
-              { data: { mediaType: resolvedMediaType, fileName: media.file_name } },
+              {
+                data: {
+                  mediaType: resolvedMediaType,
+                  fileName: media.file_name,
+                },
+              },
             );
           }
           imageMediaType = 'image/png';
@@ -1684,12 +1689,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
         lastUserMsg.content.unshift(...formattedMedia);
       }
     } catch (err) {
-      logSdkError(
-        this.logger,
-        'Error adding media to user message',
-        err,
-        { operation: 'add media to user message' },
-      );
+      logSdkError(this.logger, 'Error adding media to user message', err, {
+        operation: 'add media to user message',
+      });
     }
   }
 }

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -24,7 +24,6 @@ import type { MediaEntry } from '@agent/utils/mediaTypes';
 
 // Local imports - common
 import {
-  getSdkErrorMessage,
   attachStreamDiagnostics,
   attachPartialText,
   attachFlowAutoRetryRequired,
@@ -42,7 +41,7 @@ import type { ToolFileAttachment } from '@shared/schemas/toolResult';
 import { AbsoluteFS, flexibleFS } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
 import { getAnthropicDynamicFiltering } from '@utils/config/providerConfig';
-import { joinNonEmpty, objectToLogString } from '@utils/text/stringUtils';
+import { joinNonEmpty } from '@utils/text/stringUtils';
 import {
   computeAnthropicPrice,
   normalizeAnthropicUsage,
@@ -485,13 +484,20 @@ export class ModelHandlerAnthropic extends ModelHandler<
           ...options.output_config,
           ...thinkingConfig.outputConfig,
         };
-        this.logger.debug(
-          `Set adaptive thinking with effort: ${thinkingConfig.outputConfig?.effort} (max_tokens: ${options.max_tokens})`,
-        );
+        this.logger.debug('Set adaptive thinking', {
+          data: {
+            effort: thinkingConfig.outputConfig?.effort,
+            maxTokens: options.max_tokens,
+          },
+        });
       } else if (thinkingConfig.thinking.type === 'enabled') {
-        this.logger.debug(
-          `Set thinking budget: ${thinkingConfig.thinking.budget_tokens} tokens (max_tokens: ${options.max_tokens}, streaming: ${useStreaming})`,
-        );
+        this.logger.debug('Set thinking budget', {
+          data: {
+            budgetTokens: thinkingConfig.thinking.budget_tokens,
+            maxTokens: options.max_tokens,
+            streaming: useStreaming,
+          },
+        });
       }
 
       // Remove temperature for models that reject sampling parameters when
@@ -558,7 +564,13 @@ export class ModelHandlerAnthropic extends ModelHandler<
           ) {
             const newBudget = Math.max(1024, options.max_tokens - 1024);
             this.logger.debug(
-              `Adjusted thinking budget from ${options.thinking.budget_tokens} to ${newBudget} due to reduced max_tokens`,
+              'Adjusted thinking budget due to reduced max_tokens',
+              {
+                data: {
+                  previousBudgetTokens: options.thinking.budget_tokens,
+                  newBudgetTokens: newBudget,
+                },
+              },
             );
             options.thinking.budget_tokens = newBudget;
           }
@@ -697,7 +709,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
           (enrichedError as ErrorWithRequestId).request_id = requestId;
         }
 
-        const logMessage = `Stream ${isAbort ? 'aborted' : 'failed'}: ${getSdkErrorMessage(enrichedError)}`;
+        const logMessage = `Stream ${isAbort ? 'aborted' : 'failed'}`;
         const logData = {
           data: {
             isUsingRelay: this.shouldUseServerSideKeys(),
@@ -705,6 +717,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
             model: this.config.fullName,
             streamDiagnostics: diagnostics,
             partialTextLength: partialText.length,
+            error: enrichedError,
           },
         };
         // The retry node owns user-facing failure reporting. Keep stream
@@ -812,7 +825,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       } catch (err) {
         logSdkError(
           this.logger,
-          `Error processing media files for follow-up round: ${getSdkErrorMessage(err)}`,
+          'Error processing media files for follow-up round',
           err,
           { operation: 'process media files' },
         );
@@ -974,10 +987,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
       // Anthropic specific empty response check
       const errorMsg = 'No output generated - API returned empty response';
       this.logger.error(errorMsg);
-      this.logger.debug(`responseObject: ${objectToLogString(responseObject)}`);
-      this.logger.debug(
-        `responseObject.content: ${objectToLogString(responseObject.content)}`,
-      );
+      this.logger.debug('responseObject', { data: responseObject });
+      this.logger.debug('responseObject.content', {
+        data: responseObject.content,
+      });
       throw new Error(errorMsg);
     }
 
@@ -1015,9 +1028,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
       agentSetting,
     );
 
-    this.logger.debug(
-      `Adding continuation message to conversation. Continuation message:\n ${userMessageContinuation}`,
-    );
+    this.logger.debug('Adding continuation message to conversation', {
+      data: userMessageContinuation,
+    });
     const content: ContentBlockParam[] = [
       { type: 'text', text: userMessageContinuation },
     ];
@@ -1044,7 +1057,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
           );
           return [false, messages];
         }
-        this.logger.debug(`Adding prefill message:\n${prefill}`);
+        this.logger.debug('Adding prefill message', { data: prefill });
         workspaceState.assembly.accumulatedOutput = `${prefill}\n`;
         await AbsoluteFS.ensureDir(dirname(outputLocation.absolutePath));
         await flexibleFS.write(
@@ -1073,9 +1086,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
               text: pseudoPrefillText,
             } as ContentBlockParam);
           }
-          this.logger.debug(
-            `Added pseudo prefill message to messages:\n${pseudoPrefillText}`,
-          );
+          this.logger.debug('Added pseudo prefill message to messages', {
+            data: pseudoPrefillText,
+          });
         }
       }
       return [false, messages];
@@ -1672,7 +1685,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     } catch (err) {
       logSdkError(
         this.logger,
-        `Error adding media to user message: ${getSdkErrorMessage(err)}`,
+        'Error adding media to user message',
         err,
         { operation: 'add media to user message' },
       );

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -946,7 +946,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
         } else {
           if (resolvedMediaType !== 'image/png') {
             this.logger.warn(
-              `Unsupported image media type ${resolvedMediaType} for ${media.file_name}, defaulting to image/png`,
+              'Unsupported image media type, defaulting to image/png',
+              { data: { mediaType: resolvedMediaType, fileName: media.file_name } },
             );
           }
           imageMediaType = 'image/png';

--- a/src/agent/modelHandlers/google/googleHandlerShared.ts
+++ b/src/agent/modelHandlers/google/googleHandlerShared.ts
@@ -15,9 +15,9 @@ import type { FileLocation } from '@shared/schemas';
 import { isNonEmptyString } from '@utils/core';
 import { flexibleFS } from '@utils/files';
 
-import type { MediaFileResult } from '../support/MediaAttachmentProcessor';
 import { prepareExistingOutputContent } from '../utils/fileContentUtils';
 import { DEFAULT_ATTACHMENT_MIME_TYPE } from '../utils/toolAttachmentUtils';
+import type { MediaFileResult } from '../support/MediaAttachmentProcessor';
 
 /**
  * Shared helpers for the two Google handlers (generateContent chat handler and
@@ -245,9 +245,15 @@ export async function uploadGoogleMediaEntries<T>(
   }
 
   if (summaries.some((summary) => !summary.ok)) {
-    logger.warn('Some media files failed to upload via Google GenAI SDK', {
-      data: failures,
-    });
+    const failureSummary = failures.join('; ');
+    logger.warn(
+      failureSummary
+        ? `Some media files failed to upload via Google GenAI SDK: ${failureSummary}`
+        : 'Some media files failed to upload via Google GenAI SDK',
+      {
+        data: failures,
+      },
+    );
   }
   return parts;
 }

--- a/src/agent/modelHandlers/google/googleHandlerShared.ts
+++ b/src/agent/modelHandlers/google/googleHandlerShared.ts
@@ -198,7 +198,10 @@ export async function uploadGoogleMediaEntries<T>(
         continue;
       }
       logger.debug(
-        `Media entry ${fileName} is ${payloadBytes} bytes which exceeds inline limit of ${inlineLimit}. Falling back to upload.`,
+        'Media entry exceeds inline limit; falling back to upload.',
+        {
+          data: { fileName, payloadBytes, inlineLimit },
+        },
       );
     }
 
@@ -242,10 +245,9 @@ export async function uploadGoogleMediaEntries<T>(
   }
 
   if (summaries.some((summary) => !summary.ok)) {
-    logger.warn(
-      'Some media files failed to upload via Google GenAI SDK' +
-        (failures.length > 0 ? `: ${failures.join('; ')}` : ''),
-    );
+    logger.warn('Some media files failed to upload via Google GenAI SDK', {
+      data: failures,
+    });
   }
   return parts;
 }
@@ -273,9 +275,12 @@ export async function initializeGooglePseudoPrefillOutputAndPrefill<M>(
   outputLocation: FileLocation,
   prefill: string,
 ): Promise<[boolean, M[]]> {
-  adapter.logger.debug(
-    `Initializing output and prefill for ${outputLocation.absolutePath}. Prefill content: "${prefill.slice(0, 100)}..."`,
-  );
+  adapter.logger.debug('Initializing output and prefill.', {
+    data: {
+      outputPath: outputLocation.absolutePath,
+      prefillPreview: prefill.slice(0, 100),
+    },
+  });
 
   if (!(await flexibleFS.existsAndNonTrivial(outputLocation))) {
     adapter.logger.debug(
@@ -292,7 +297,9 @@ export async function initializeGooglePseudoPrefillOutputAndPrefill<M>(
 
     const pseudoPrefillMsg = `Organize your response with XML tags. Start your response with:\n${prefill}`;
     adapter.appendPseudoPrefillToUserStep(messages, pseudoPrefillMsg);
-    adapter.logger.debug(`Added pseudo-prefill message: "${pseudoPrefillMsg}"`);
+    adapter.logger.debug('Added pseudo-prefill message.', {
+      data: pseudoPrefillMsg,
+    });
     return [false, messages];
   }
 

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -494,9 +494,9 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         const errorWithResponse = error as Error & {
           response?: { promptFeedback?: unknown };
         };
-        this.logger.warn(
-          `Content blocked by safety filter: ${JSON.stringify(errorWithResponse.response?.promptFeedback)}`,
-        );
+        this.logger.warn('Content blocked by safety filter.', {
+          data: errorWithResponse.response?.promptFeedback,
+        });
       }
       // If the stream produced any text before failing, attach a tail to the
       // error so the retry UI can show progress and future continuation logic
@@ -639,9 +639,9 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     if (!responseObject.candidates || responseObject.candidates.length === 0) {
       if (responseObject?.promptFeedback?.blockReason) {
         const { blockReason, safetyRatings } = responseObject.promptFeedback;
-        this.logger.error(
-          `Request blocked due to ${blockReason}. Safety ratings: ${JSON.stringify(safetyRatings)}`,
-        );
+        this.logger.error('Request blocked.', {
+          data: { blockReason, safetyRatings },
+        });
         return {
           text: '',
           usage: responseObject.usageMetadata ?? undefined,
@@ -649,7 +649,8 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         };
       }
       this.logger.error(
-        `Invalid or empty response structure from Google GenAI: ${JSON.stringify(responseObject)}`,
+        'Invalid or empty response structure from Google GenAI.',
+        { data: responseObject },
       );
       return {
         text: '',
@@ -878,9 +879,9 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     }
 
     if (thoughtContent) {
-      this.logger.debug(
-        `Google GenAI thought summary preview: ${thoughtContent.slice(0, K_SLICE)}...`,
-      );
+      this.logger.debug('Google GenAI thought summary preview.', {
+        data: thoughtContent.slice(0, K_SLICE),
+      });
     }
 
     return thoughtContent || null;
@@ -935,7 +936,8 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       );
     } catch (attachmentError) {
       this.logger.warn(
-        `Failed to encode attachment '${attachment.path}' for Google function response: ${getSdkErrorMessage(attachmentError)}`,
+        `Failed to encode attachment '${attachment.path}' for Google function response.`,
+        { data: attachmentError },
       );
       return null;
     }

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -494,9 +494,24 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         const errorWithResponse = error as Error & {
           response?: { promptFeedback?: unknown };
         };
-        this.logger.warn('Content blocked by safety filter.', {
-          data: errorWithResponse.response?.promptFeedback,
-        });
+        const promptFeedback = errorWithResponse.response?.promptFeedback;
+        const blockReason =
+          promptFeedback &&
+          typeof promptFeedback === 'object' &&
+          'blockReason' in promptFeedback
+            ? String((promptFeedback as { blockReason?: unknown }).blockReason)
+            : undefined;
+        const safetyDetail =
+          blockReason ??
+          (promptFeedback === undefined
+            ? undefined
+            : JSON.stringify(promptFeedback));
+        this.logger.warn(
+          `Content blocked by safety filter${safetyDetail ? `: ${safetyDetail}` : ''}.`,
+          {
+            data: promptFeedback,
+          },
+        );
       }
       // If the stream produced any text before failing, attach a tail to the
       // error so the retry UI can show progress and future continuation logic
@@ -639,7 +654,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     if (!responseObject.candidates || responseObject.candidates.length === 0) {
       if (responseObject?.promptFeedback?.blockReason) {
         const { blockReason, safetyRatings } = responseObject.promptFeedback;
-        this.logger.error('Request blocked.', {
+        this.logger.error(`Request blocked: ${blockReason}`, {
           data: { blockReason, safetyRatings },
         });
         return {
@@ -936,7 +951,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       );
     } catch (attachmentError) {
       this.logger.warn(
-        `Failed to encode attachment '${attachment.path}' for Google function response.`,
+        `Failed to encode attachment '${attachment.path}' for Google function response: ${getSdkErrorMessage(attachmentError)}`,
         { data: attachmentError },
       );
       return null;

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -1380,7 +1380,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
       } satisfies ImageContent;
     } catch (error) {
       this.logger.warn(
-        `Failed to encode attachment '${attachment.path}' for Interactions function result.`,
+        `Failed to encode attachment '${attachment.path}' for Interactions function result: ${getSdkErrorMessage(error)}`,
         { data: error },
       );
       return null;

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -1009,9 +1009,9 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
     }
 
     if (thoughtContent) {
-      this.logger.debug(
-        `Google Interactions thought summary preview: ${thoughtContent.slice(0, K_SLICE)}...`,
-      );
+      this.logger.debug('Google Interactions thought summary preview.', {
+        data: thoughtContent.slice(0, K_SLICE),
+      });
     }
     return thoughtContent || null;
   }
@@ -1380,7 +1380,8 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
       } satisfies ImageContent;
     } catch (error) {
       this.logger.warn(
-        `Failed to encode attachment '${attachment.path}' for Interactions function result: ${getSdkErrorMessage(error)}`,
+        `Failed to encode attachment '${attachment.path}' for Interactions function result.`,
+        { data: error },
       );
       return null;
     }
@@ -1815,7 +1816,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
       // treated uniformly as a thrown, tagged error.
       const status = polled.status ?? 'unknown';
       this.logger.error(
-        `Background interaction ${interactionId} ended with status "${status}".`,
+        'Background interaction ended with a non-completed status.',
         {
           data: {
             interactionId,
@@ -1848,8 +1849,8 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
       this.logger.debug(`Cancelled background interaction ${interactionId}.`);
     } catch (err) {
       this.logger.warn(
-        `Failed to cancel background interaction ${interactionId}: ` +
-          getSdkErrorMessage(err),
+        `Failed to cancel background interaction ${interactionId}.`,
+        { data: err },
       );
     }
   }
@@ -2106,9 +2107,9 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
     if (!buffer) return {};
     const parsed = safeParseJson(buffer);
     if (parsed.isErr()) {
-      this.logger.warn(
-        `Failed to parse streamed tool arguments: ${getSdkErrorMessage(parsed.error)}`,
-      );
+      this.logger.warn('Failed to parse streamed tool arguments.', {
+        data: parsed.error,
+      });
       return {};
     }
     return isObject(parsed.value) ? parsed.value : {};

--- a/src/agent/modelHandlers/openai/OpenAIResponseWebSocketTransport.ts
+++ b/src/agent/modelHandlers/openai/OpenAIResponseWebSocketTransport.ts
@@ -124,9 +124,9 @@ export class OpenAIResponseWebSocketTransport {
         return this.wsConnection;
       }
       // Connection expired or closed — reconnect
-      this.logger.debug(
-        `WebSocket connection stale (age: ${Math.round(age / 1000)}s, ready: ${socketReady}) — reconnecting`,
-      );
+      this.logger.debug('WebSocket connection stale — reconnecting', {
+        data: { ageSeconds: Math.round(age / 1000), socketReady },
+      });
       this.closeWebSocket();
     }
 

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -579,15 +579,18 @@ export class ModelHandlerOpenAI<
           data: { inputTokens: this.lastKnownInputTokens },
         });
       } else {
-        this.logger.debug('Compacting conversation (token threshold exceeded)', {
-          data: {
-            inputTokens: this.lastKnownInputTokens,
-            thresholdPercent: threshold,
-            thresholdTokens: Math.floor(
-              (threshold / 100) * this.config.contextWindow,
-            ),
+        this.logger.debug(
+          'Compacting conversation (token threshold exceeded)',
+          {
+            data: {
+              inputTokens: this.lastKnownInputTokens,
+              thresholdPercent: threshold,
+              thresholdTokens: Math.floor(
+                (threshold / 100) * this.config.contextWindow,
+              ),
+            },
           },
-        });
+        );
       }
 
       const { compactedMessages, didCompact } = await this.compactConversation(

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -15,6 +15,7 @@ import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import type { MediaEntry } from '@agent/utils/mediaTypes';
 import { K_SLICE } from '@agent/core/constants';
 import {
+  buildErrorLogData,
   getSdkErrorMessage,
   isMissingFinishReasonError,
   attachPartialText,
@@ -30,11 +31,7 @@ import type { FileLocation } from '@shared/schemas';
 import type { ToolFileAttachment } from '@shared/schemas/toolResult';
 import { isNonEmptyString } from '@utils/core';
 import { getConfig } from '@utils/config/configUtils';
-import {
-  extractMimeSubtype,
-  joinNonEmpty,
-  objectToLogString,
-} from '@utils/text/stringUtils';
+import { extractMimeSubtype, joinNonEmpty } from '@utils/text/stringUtils';
 import { computeUtilizationPercent } from '../support/contextUtilization';
 import { toOpenAIReasoningEffort } from '../support/reasoningEffort';
 import { initializeOpenAiCompatibleOutputAndPrefill } from '../support/openAiCompatiblePrefill';
@@ -151,9 +148,13 @@ export class ModelHandlerOpenAI<
       tokensBefore,
       this.config.contextWindow,
     );
-    this.logger.debug(
-      `Compacting conversation with ${tokensBefore} input tokens (${utilizationBefore.toFixed(1)}% of ${this.config.contextWindow} context window)`,
-    );
+    this.logger.debug('Compacting conversation', {
+      data: {
+        inputTokens: tokensBefore,
+        utilizationPercent: utilizationBefore,
+        contextWindow: this.config.contextWindow,
+      },
+    });
 
     return this.runClientCompaction(
       messages,
@@ -409,9 +410,9 @@ export class ModelHandlerOpenAI<
         } catch (err) {
           // totalUsage() may fail if stream ended abnormally — leave usage
           // unset, but log so missing token accounting is traceable.
-          this.logger.debug(
-            `totalUsage() fallback failed; usage unavailable: ${getSdkErrorMessage(err)}`,
-          );
+          this.logger.debug('totalUsage() fallback failed; usage unavailable', {
+            data: buildErrorLogData(err, { operation: 'totalUsage fallback' }),
+          });
         }
       }
 
@@ -444,9 +445,9 @@ export class ModelHandlerOpenAI<
       }
       const isAbort = isUserAbort(streamError);
       if (!isAbort) {
-        this.logger.warn(`Stream failed: ${getSdkErrorMessage(streamError)}`, {
+        this.logger.warn('Stream failed', {
           data: {
-            model: this.config.fullName,
+            ...buildErrorLogData(streamError, { model: this.config.fullName }),
             partialTextLength: partialText.length,
           },
         });
@@ -574,13 +575,19 @@ export class ModelHandlerOpenAI<
 
       const threshold = this.getCompactionThresholdPercent();
       if (isManual) {
-        this.logger.debug(
-          `Compacting conversation (manually requested, ${this.lastKnownInputTokens} input tokens)`,
-        );
+        this.logger.debug('Compacting conversation (manually requested)', {
+          data: { inputTokens: this.lastKnownInputTokens },
+        });
       } else {
-        this.logger.debug(
-          `Compacting conversation (${this.lastKnownInputTokens} tokens exceed ${threshold}% threshold of ${Math.floor((threshold / 100) * this.config.contextWindow)} tokens)`,
-        );
+        this.logger.debug('Compacting conversation (token threshold exceeded)', {
+          data: {
+            inputTokens: this.lastKnownInputTokens,
+            thresholdPercent: threshold,
+            thresholdTokens: Math.floor(
+              (threshold / 100) * this.config.contextWindow,
+            ),
+          },
+        });
       }
 
       const { compactedMessages, didCompact } = await this.compactConversation(
@@ -656,9 +663,13 @@ export class ModelHandlerOpenAI<
       : messages;
 
     if (normalizedMessages.length !== messages.length) {
-      this.logger.debug(
-        `Preprocessed message array from ${messages.length} to ${normalizedMessages.length} messages for ${providerLabel} model compatibility`,
-      );
+      this.logger.debug('Preprocessed message array for model compatibility', {
+        data: {
+          beforeCount: messages.length,
+          afterCount: normalizedMessages.length,
+          providerLabel,
+        },
+      });
     }
 
     return normalizedMessages;
@@ -894,9 +905,7 @@ export class ModelHandlerOpenAI<
    */
   extractResponse(responseObject: any, endTag: string): ExtractResponseResult {
     if (!responseObject.choices?.length) {
-      this.logger.debug(
-        `Response object: ${objectToLogString(responseObject)}`,
-      );
+      this.logger.debug('Response object', { data: responseObject });
 
       // Add fallback for streaming which returns content directly in responseObject
       if (responseObject.role && responseObject.content) {
@@ -932,9 +941,7 @@ export class ModelHandlerOpenAI<
 
       const errorMsg = 'Invalid response from API: missing choices';
       this.logger.error(errorMsg);
-      this.logger.error(
-        `Response object: ${objectToLogString(responseObject)}`,
-      );
+      this.logger.error('Response object', { data: responseObject });
       throw new Error(errorMsg);
     }
 
@@ -957,9 +964,7 @@ export class ModelHandlerOpenAI<
 
       this.logger.debug('Received tool call without message content');
     } else {
-      this.logger.error(
-        `Response object: ${objectToLogString(responseObject)}`,
-      );
+      this.logger.error('Response object', { data: responseObject });
       this.logger.error('content is empty');
     }
 
@@ -985,9 +990,9 @@ export class ModelHandlerOpenAI<
       agentSetting,
     );
 
-    this.logger.debug(
-      `Adding continuation message to conversation. Continuation message:\n ${userMessageContinuation}`,
-    );
+    this.logger.debug('Adding continuation message to conversation', {
+      data: { continuationMessage: userMessageContinuation },
+    });
 
     const role = this.capabilities.supportsIntermDevMsgs ? 'system' : 'user';
     messages.push({
@@ -1212,9 +1217,9 @@ export class ModelHandlerOpenAI<
 
     this.applyStringReasoningToWorkspaceState(reasoning, workspaceState);
 
-    this.logger.debug(
-      `Reasoning content preview: ${reasoning.slice(0, K_SLICE)}...`,
-    );
+    this.logger.debug('Reasoning content preview', {
+      data: { preview: reasoning.slice(0, K_SLICE) },
+    });
     return reasoning;
   }
 
@@ -1224,9 +1229,9 @@ export class ModelHandlerOpenAI<
     try {
       return JSON.stringify(value);
     } catch (err) {
-      this.logger.warn(
-        `Failed to serialize tool arguments: ${getSdkErrorMessage(err)}`,
-      );
+      this.logger.warn('Failed to serialize tool arguments', {
+        data: buildErrorLogData(err, { operation: 'serialize tool arguments' }),
+      });
       return '{}';
     }
   }

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -988,9 +988,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
       return compactedMessages;
     } catch (err) {
-      this.logger.warn('Compaction failed, continuing with original messages', {
-        data: buildErrorLogData(err, { operation: 'compact conversation' }),
-      });
+      this.logger.warn(
+        `Compaction failed, continuing with original messages: ${getSdkErrorMessage(err)}`,
+        {
+          data: buildErrorLogData(err, { operation: 'compact conversation' }),
+        },
+      );
       this.compactionResult = undefined;
       return messages;
     }

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -2111,10 +2111,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       return this.createResponseImpl(options);
     } else if (this.previousResponseId) {
       // Log diagnostic info for other errors when chaining was active
-      this.logger.debug(
-        `Request failed with previousResponseId=${this.previousResponseId}. ` +
-          `Error: ${providerError.message}`,
-      );
+      this.logger.debug('Request failed while response chaining was active', {
+        data: {
+          previousResponseId: this.previousResponseId,
+          error: providerError.message,
+        },
+      });
     }
 
     // Retention of pendingBackgroundResponseId is decided at the point of
@@ -2296,9 +2298,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
     // Terminal failure — the background response ended with a non-completed,
     // non-pending status (failed / cancelled / incomplete).
-    const fallbackStatus = polled.status ?? 'unknown';
     this.logger.error(
-      `Background response ${polled.id} ended with status ${fallbackStatus}`,
+      'Background response ended with a non-completed status',
       {
         data: {
           responseId: polled.id,
@@ -2505,9 +2506,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     }
 
     if (thoughtContent) {
-      this.logger.debug(
-        `OpenAI Responses reasoning preview (${reasoningItems.length} item(s)): ${thoughtContent.slice(0, K_SLICE)}...`,
-      );
+      this.logger.debug('OpenAI Responses reasoning preview', {
+        data: {
+          itemCount: reasoningItems.length,
+          preview: thoughtContent.slice(0, K_SLICE),
+        },
+      });
     }
 
     return thoughtContent || null;

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -17,6 +17,7 @@ import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import type { MediaEntry } from '@agent/utils/mediaTypes';
 import { K_SLICE } from '@agent/core/constants';
 import {
+  buildErrorLogData,
   detectStatusCode,
   getSdkErrorMessage,
   isContextWindowError,
@@ -557,11 +558,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       pendingResponse.incomplete_details?.reason ??
       'no additional details';
     this.logger.warn(
-      `OpenAI background response ended remotely (${pendingResponse.status}: ${errorDetail}); starting a new request.`,
+      'OpenAI background response ended remotely; starting a new request.',
       {
         data: {
           responseId: pendingId,
           status: pendingResponse.status,
+          errorDetail,
           error: pendingResponse.error ?? undefined,
           incompleteDetails: pendingResponse.incomplete_details ?? undefined,
         },
@@ -635,7 +637,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       const errorDetail =
         response.error?.message ?? response.incomplete_details?.reason;
       this.logger.debug(
-        `Response ${response.id} not safe for chaining (status="${response.status}", hasInputTokens=${hasInputTokens})`,
+        'Response not safe for chaining',
         {
           data: {
             responseId: response.id,
@@ -691,7 +693,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         const outputTokens = response.usage.output_tokens ?? 0;
 
         this.logger.debug(
-          `[TOKEN_DIAG] Actual vs pre-flight: ${actualTokens} vs ${this._diagPreFlightTokens} (diff: ${diff > 0 ? '+' : ''}${diff}, ${diffPercent}%)`,
+          '[TOKEN_DIAG] Actual vs pre-flight',
           {
             data: {
               actualInputTokens: actualTokens,
@@ -859,9 +861,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       Math.floor(maxOutputTokens * CHAINED_RESPONSE_MAX_OUTPUT_FACTOR),
     );
     if (budgeted !== maxOutputTokens) {
-      this.logger.debug(
-        `Applied chained max_output_tokens budget: ${maxOutputTokens} -> ${budgeted}`,
-      );
+      this.logger.debug('Applied chained max_output_tokens budget', {
+        data: { before: maxOutputTokens, after: budgeted },
+      });
     }
     return budgeted;
   }
@@ -895,9 +897,13 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       contextWindow,
     );
 
-    this.logger.debug(
-      `Compacting conversation with ${tokensBefore} input tokens (${utilizationBefore.toFixed(1)}% of ${contextWindow} context window)`,
-    );
+    this.logger.debug('Compacting conversation', {
+      data: {
+        inputTokens: tokensBefore,
+        utilizationPercent: utilizationBefore,
+        contextWindow,
+      },
+    });
 
     const compactParams: ResponseCompactParams = {
       model: this.config.fullName,
@@ -943,7 +949,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         // Fall back to output_tokens if token counting fails. Log so a degraded
         // post-compaction token estimate is visible rather than silent.
         this.logger.debug(
-          `Post-compaction token counting failed; falling back to output_tokens: ${getSdkErrorMessage(err)}`,
+          'Post-compaction token counting failed; falling back to output_tokens',
+          { data: buildErrorLogData(err, { operation: 'post-compaction token counting' }) },
         );
         // NOTE: It's unclear what output_tokens represents exactly for the compact
         // endpoint — it may be the generation cost rather than the reusable content
@@ -980,9 +987,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
       return compactedMessages;
     } catch (err) {
-      this.logger.warn(
-        `Compaction failed, continuing with original messages: ${getSdkErrorMessage(err)}`,
-      );
+      this.logger.warn('Compaction failed, continuing with original messages', {
+        data: buildErrorLogData(err, { operation: 'compact conversation' }),
+      });
       this.compactionResult = undefined;
       return messages;
     }
@@ -1300,9 +1307,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       );
     }
 
-    this.logger.debug(
-      `Fallback: max_output_tokens ${maxOutputTokens} → ${capped} (estimate: ${inputEstimate})`,
-    );
+    this.logger.debug('Fallback: adjusting max_output_tokens', {
+      data: { before: maxOutputTokens, after: capped, inputEstimate },
+    });
     logContextManagementEvent(
       this.logger,
       `Estimated token count (${inputEstimate}) + max output tokens (${maxOutputTokens}) exceeds context window (${contextWindow}). Reducing to ${capped}.`,
@@ -1549,10 +1556,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           (inputTokens / this.getEffectiveContextWindow()) * 100;
         this._diagPreFlightTokens = inputTokens; // Compared in finalizeResponse
         this.logger.debug(
-          `[TOKEN_DIAG] Pre-flight count: ${inputTokens} (${utilizationEstimate.toFixed(1)}% of ${this.getEffectiveContextWindow()})`,
+          '[TOKEN_DIAG] Pre-flight count',
           {
             data: {
               preFlightTokens: inputTokens,
+              utilizationEstimate,
               prevCumulativeTokens: prevCumulative,
               delta: inputTokens - prevCumulative,
               newMessagesCount: newMessages.length,
@@ -1567,9 +1575,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         );
       },
       onCountFailure: (err) => {
-        this.logger.debug(
-          `Token counting failed: ${getSdkErrorMessage(err)}. Applying fallback cap.`,
-        );
+        this.logger.debug('Token counting failed; applying fallback cap', {
+          data: buildErrorLogData(err, { operation: 'token counting' }),
+        });
         maxOutputTokens = this.applyTokenCountFailureFallback(maxOutputTokens);
       },
     });
@@ -1773,9 +1781,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
     // Safety net: handle unexpected pending status (shouldn't happen without background mode)
     if (this.isBackgroundPending(response)) {
-      this.logger.debug(
-        `WebSocket response ${response.id} ended with pending status "${response.status}" — polling for completion`,
-      );
+      this.logger.debug('WebSocket response ended with pending status — polling for completion', {
+        data: { responseId: response.id, status: response.status },
+      });
       response = await this.waitForBackgroundCompletion(
         client,
         response,
@@ -1863,12 +1871,28 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         }
         if (!this.storesResponsesServerSide) {
           this.logger.debug(
-            `OpenAI stream emitted an event outside the SDK's typed union for stateless response ${responseId}; polling fallback is unavailable: ${getSdkErrorMessage(streamError)}`,
+            "OpenAI stream emitted an event outside the SDK's typed union for a stateless response; polling fallback is unavailable",
+            {
+              data: {
+                responseId,
+                ...buildErrorLogData(streamError, {
+                  operation: 'unhandled stream event',
+                }),
+              },
+            },
           );
           throw streamError;
         }
         this.logger.debug(
-          `OpenAI stream emitted an event outside the SDK's typed union for response ${responseId} — falling back to polling: ${getSdkErrorMessage(streamError)}`,
+          "OpenAI stream emitted an event outside the SDK's typed union — falling back to polling",
+          {
+            data: {
+              responseId,
+              ...buildErrorLogData(streamError, {
+                operation: 'unhandled stream event',
+              }),
+            },
+          },
         );
         this.rememberPendingBackgroundResponse(responseId, retrieveParams);
         try {
@@ -1924,9 +1948,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       // during slow GPT-5 requests), poll until it finishes instead of silently
       // returning an incomplete response.
       if (this.isBackgroundPending(response)) {
-        this.logger.debug(
-          `Streaming response ${response.id} ended with pending status "${response.status}" - polling for completion`,
-        );
+        this.logger.debug('Streaming response ended with pending status - polling for completion', {
+          data: { responseId: response.id, status: response.status },
+        });
         response = await this.waitForBackgroundCompletion(
           client,
           response,
@@ -1997,7 +2021,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         );
       } else {
         this.logger.debug(
-          `Response ${response.id} returned with pending status "${response.status}" despite non-background mode; polling for completion`,
+          'Response returned with pending status despite non-background mode; polling for completion',
           {
             data: {
               responseId: response.id,

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -513,7 +513,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         throw err;
       }
       this.logger.warn(
-        `Couldn't resume the pending OpenAI response; will start a new request. (${providerError.message})`,
+        "Couldn't resume the pending OpenAI response; will start a new request.",
         {
           data: {
             responseId: pendingId,
@@ -529,9 +529,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     // Check the status of the retrieved response
     if (this.isBackgroundPending(pendingResponse)) {
       // Still processing - resume polling
-      this.logger.debug(
-        `Pending background response ${pendingId} still processing (status: ${pendingResponse.status}), resuming poll`,
-      );
+      this.logger.debug('Pending background response still processing, resuming poll', {
+        data: { responseId: pendingId, status: pendingResponse.status },
+      });
       const response = await this.waitForBackgroundCompletion(
         client,
         pendingResponse,

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -530,9 +530,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     // Check the status of the retrieved response
     if (this.isBackgroundPending(pendingResponse)) {
       // Still processing - resume polling
-      this.logger.debug('Pending background response still processing, resuming poll', {
-        data: { responseId: pendingId, status: pendingResponse.status },
-      });
+      this.logger.debug(
+        'Pending background response still processing, resuming poll',
+        {
+          data: { responseId: pendingId, status: pendingResponse.status },
+        },
+      );
       const response = await this.waitForBackgroundCompletion(
         client,
         pendingResponse,
@@ -636,18 +639,15 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     } else {
       const errorDetail =
         response.error?.message ?? response.incomplete_details?.reason;
-      this.logger.debug(
-        'Response not safe for chaining',
-        {
-          data: {
-            responseId: response.id,
-            status: response.status,
-            hasUsage: !!response.usage,
-            hasInputTokens,
-            errorDetail,
-          },
+      this.logger.debug('Response not safe for chaining', {
+        data: {
+          responseId: response.id,
+          status: response.status,
+          hasUsage: !!response.usage,
+          hasInputTokens,
+          errorDetail,
         },
-      );
+      });
       // Rejecting the chain anchor invalidates the client-side bookkeeping:
       // sentMessages counts against server-side history that we're now
       // refusing to reference, so slicing from it on the next turn would
@@ -692,23 +692,20 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           response.usage.output_tokens_details?.reasoning_tokens ?? 0;
         const outputTokens = response.usage.output_tokens ?? 0;
 
-        this.logger.debug(
-          '[TOKEN_DIAG] Actual vs pre-flight',
-          {
-            data: {
-              actualInputTokens: actualTokens,
-              preFlightTokens: this._diagPreFlightTokens,
-              difference: diff,
-              differencePercent: diffPercent,
-              outputTokens,
-              reasoningTokens,
-              totalTokens: response.usage.total_tokens,
-              contextWindow: this.getEffectiveContextWindow(),
-              utilizationActual:
-                (actualTokens / this.getEffectiveContextWindow()) * 100,
-            },
+        this.logger.debug('[TOKEN_DIAG] Actual vs pre-flight', {
+          data: {
+            actualInputTokens: actualTokens,
+            preFlightTokens: this._diagPreFlightTokens,
+            difference: diff,
+            differencePercent: diffPercent,
+            outputTokens,
+            reasoningTokens,
+            totalTokens: response.usage.total_tokens,
+            contextWindow: this.getEffectiveContextWindow(),
+            utilizationActual:
+              (actualTokens / this.getEffectiveContextWindow()) * 100,
           },
-        );
+        });
         this._diagPreFlightTokens = null; // Clear for next request
       }
     } else {
@@ -950,7 +947,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         // post-compaction token estimate is visible rather than silent.
         this.logger.debug(
           'Post-compaction token counting failed; falling back to output_tokens',
-          { data: buildErrorLogData(err, { operation: 'post-compaction token counting' }) },
+          {
+            data: buildErrorLogData(err, {
+              operation: 'post-compaction token counting',
+            }),
+          },
         );
         // NOTE: It's unclear what output_tokens represents exactly for the compact
         // endpoint — it may be the generation cost rather than the reusable content
@@ -1555,24 +1556,21 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         const utilizationEstimate =
           (inputTokens / this.getEffectiveContextWindow()) * 100;
         this._diagPreFlightTokens = inputTokens; // Compared in finalizeResponse
-        this.logger.debug(
-          '[TOKEN_DIAG] Pre-flight count',
-          {
-            data: {
-              preFlightTokens: inputTokens,
-              utilizationEstimate,
-              prevCumulativeTokens: prevCumulative,
-              delta: inputTokens - prevCumulative,
-              newMessagesCount: newMessages.length,
-              totalMessagesCount: effectiveMessages.length,
-              hasPreviousResponseId: !!this.previousResponseId,
-              hasTools: !!convertedTools?.length,
-              toolCount: convertedTools?.length ?? 0,
-              contextWindow: this.getEffectiveContextWindow(),
-              maxOutputTokens,
-            },
+        this.logger.debug('[TOKEN_DIAG] Pre-flight count', {
+          data: {
+            preFlightTokens: inputTokens,
+            utilizationEstimate,
+            prevCumulativeTokens: prevCumulative,
+            delta: inputTokens - prevCumulative,
+            newMessagesCount: newMessages.length,
+            totalMessagesCount: effectiveMessages.length,
+            hasPreviousResponseId: !!this.previousResponseId,
+            hasTools: !!convertedTools?.length,
+            toolCount: convertedTools?.length ?? 0,
+            contextWindow: this.getEffectiveContextWindow(),
+            maxOutputTokens,
           },
-        );
+        });
       },
       onCountFailure: (err) => {
         this.logger.debug('Token counting failed; applying fallback cap', {
@@ -1781,9 +1779,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
     // Safety net: handle unexpected pending status (shouldn't happen without background mode)
     if (this.isBackgroundPending(response)) {
-      this.logger.debug('WebSocket response ended with pending status — polling for completion', {
-        data: { responseId: response.id, status: response.status },
-      });
+      this.logger.debug(
+        'WebSocket response ended with pending status — polling for completion',
+        {
+          data: { responseId: response.id, status: response.status },
+        },
+      );
       response = await this.waitForBackgroundCompletion(
         client,
         response,
@@ -1948,9 +1949,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       // during slow GPT-5 requests), poll until it finishes instead of silently
       // returning an incomplete response.
       if (this.isBackgroundPending(response)) {
-        this.logger.debug('Streaming response ended with pending status - polling for completion', {
-          data: { responseId: response.id, status: response.status },
-        });
+        this.logger.debug(
+          'Streaming response ended with pending status - polling for completion',
+          {
+            data: { responseId: response.id, status: response.status },
+          },
+        );
         response = await this.waitForBackgroundCompletion(
           client,
           response,
@@ -2298,19 +2302,16 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
     // Terminal failure — the background response ended with a non-completed,
     // non-pending status (failed / cancelled / incomplete).
-    this.logger.error(
-      'Background response ended with a non-completed status',
-      {
-        data: {
-          responseId: polled.id,
-          status: polled.status,
-          pollCount: pollStats?.pollCount,
-          elapsedMs: pollStats?.elapsedMs,
-          error: polled.error ?? undefined,
-          incomplete: polled.incomplete_details ?? undefined,
-        },
+    this.logger.error('Background response ended with a non-completed status', {
+      data: {
+        responseId: polled.id,
+        status: polled.status,
+        pollCount: pollStats?.pollCount,
+        elapsedMs: pollStats?.elapsedMs,
+        error: polled.error ?? undefined,
+        incomplete: polled.incomplete_details ?? undefined,
       },
-    );
+    });
     throw createOpenAIBackgroundTerminalError(polled, this.config.provider);
   }
 

--- a/src/agent/modelHandlers/openai/openAIResponseFileUploads.ts
+++ b/src/agent/modelHandlers/openai/openAIResponseFileUploads.ts
@@ -167,9 +167,12 @@ export async function uploadToolAttachments(
     try {
       buffer = await loadAttachmentBuffer(attachment);
     } catch (err) {
-      logger.warn(`Unable to read attachment ${attachment.path ?? 'attachment'}`, {
-        data: buildErrorLogData(err, { operation: 'read attachment' }),
-      });
+      logger.warn(
+        `Unable to read attachment ${attachment.path ?? 'attachment'}`,
+        {
+          data: buildErrorLogData(err, { operation: 'read attachment' }),
+        },
+      );
       continue;
     }
 
@@ -262,9 +265,12 @@ export async function buildInlineAttachmentParts(
       }
       inlined.push(attachment);
     } catch (err) {
-      logger.debug(`Unable to inline attachment ${attachment.path ?? 'attachment'}`, {
-        data: buildErrorLogData(err, { operation: 'inline attachment' }),
-      });
+      logger.debug(
+        `Unable to inline attachment ${attachment.path ?? 'attachment'}`,
+        {
+          data: buildErrorLogData(err, { operation: 'inline attachment' }),
+        },
+      );
       skipped.push(attachment);
     } finally {
       buffer = wipeBuffer(buffer);

--- a/src/agent/modelHandlers/openai/openAIResponseFileUploads.ts
+++ b/src/agent/modelHandlers/openai/openAIResponseFileUploads.ts
@@ -15,10 +15,7 @@ import OpenAI, {
 } from 'openai';
 
 import type { AgentTrace } from '@agent/trace';
-import {
-  buildErrorLogData,
-  getSdkErrorMessage,
-} from '@common/errors/sdkErrorUtils';
+import { buildErrorLogData } from '@common/errors/sdkErrorUtils';
 import type { ToolFileAttachment } from '@shared/schemas/toolResult';
 import { isNonEmptyString } from '@utils/core';
 import { OFFICE_MIME_TYPES } from '@utils/files/mimeUtils';
@@ -141,10 +138,9 @@ async function replaceFileDataWithUpload(
 
     // The retry layer owns the visible failure row for this rethrow; keep
     // the upload diagnostics at debug to avoid a duplicate ERROR entry.
-    logger.debug(
-      `Failed to upload file ${filename}: ${getSdkErrorMessage(err)}`,
-      { data: buildErrorLogData(err, { operation: 'upload file' }) },
-    );
+    logger.debug(`Failed to upload file ${filename}`, {
+      data: buildErrorLogData(err, { operation: 'upload file' }),
+    });
     throw err;
   } finally {
     buffer = wipeBuffer(buffer);
@@ -171,9 +167,9 @@ export async function uploadToolAttachments(
     try {
       buffer = await loadAttachmentBuffer(attachment);
     } catch (err) {
-      logger.warn(
-        `Unable to read attachment ${attachment.path ?? 'attachment'}: ${getSdkErrorMessage(err)}`,
-      );
+      logger.warn(`Unable to read attachment ${attachment.path ?? 'attachment'}`, {
+        data: buildErrorLogData(err, { operation: 'read attachment' }),
+      });
       continue;
     }
 
@@ -194,9 +190,9 @@ export async function uploadToolAttachments(
         isImage: mimeType.startsWith('image/'),
       });
     } catch (err) {
-      logger.warn(
-        `Failed to upload attachment to OpenAI: ${getSdkErrorMessage(err)}`,
-      );
+      logger.warn('Failed to upload attachment to OpenAI', {
+        data: buildErrorLogData(err, { operation: 'upload attachment' }),
+      });
     } finally {
       buffer = wipeBuffer(buffer);
     }
@@ -266,9 +262,9 @@ export async function buildInlineAttachmentParts(
       }
       inlined.push(attachment);
     } catch (err) {
-      logger.debug(
-        `Unable to inline attachment ${attachment.path ?? 'attachment'}: ${getSdkErrorMessage(err)}`,
-      );
+      logger.debug(`Unable to inline attachment ${attachment.path ?? 'attachment'}`, {
+        data: buildErrorLogData(err, { operation: 'inline attachment' }),
+      });
       skipped.push(attachment);
     } finally {
       buffer = wipeBuffer(buffer);

--- a/src/agent/modelHandlers/openai/openAIResponseFileUploads.ts
+++ b/src/agent/modelHandlers/openai/openAIResponseFileUploads.ts
@@ -15,7 +15,10 @@ import OpenAI, {
 } from 'openai';
 
 import type { AgentTrace } from '@agent/trace';
-import { buildErrorLogData } from '@common/errors/sdkErrorUtils';
+import {
+  buildErrorLogData,
+  getSdkErrorMessage,
+} from '@common/errors/sdkErrorUtils';
 import type { ToolFileAttachment } from '@shared/schemas/toolResult';
 import { isNonEmptyString } from '@utils/core';
 import { OFFICE_MIME_TYPES } from '@utils/files/mimeUtils';
@@ -167,8 +170,9 @@ export async function uploadToolAttachments(
     try {
       buffer = await loadAttachmentBuffer(attachment);
     } catch (err) {
+      const attachmentPath = attachment.path ?? 'attachment';
       logger.warn(
-        `Unable to read attachment ${attachment.path ?? 'attachment'}`,
+        `Unable to read attachment ${attachmentPath}: ${getSdkErrorMessage(err)}`,
         {
           data: buildErrorLogData(err, { operation: 'read attachment' }),
         },
@@ -193,9 +197,13 @@ export async function uploadToolAttachments(
         isImage: mimeType.startsWith('image/'),
       });
     } catch (err) {
-      logger.warn('Failed to upload attachment to OpenAI', {
-        data: buildErrorLogData(err, { operation: 'upload attachment' }),
-      });
+      const attachmentPath = attachment.path ?? 'attachment';
+      logger.warn(
+        `Failed to upload attachment ${attachmentPath} to OpenAI: ${getSdkErrorMessage(err)}`,
+        {
+          data: buildErrorLogData(err, { operation: 'upload attachment' }),
+        },
+      );
     } finally {
       buffer = wipeBuffer(buffer);
     }

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -18,7 +18,6 @@ import {
   attachPartialText,
   attachFlowAutoRetryRequired,
   detectStatusCode,
-  getSdkErrorMessage,
   takeTail,
   PARTIAL_TEXT_TAIL_MAX,
 } from '@common/errors/sdkErrorUtils';
@@ -444,10 +443,9 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
         const formattedMedia = await this.createMediaMessage(mediaFiles);
         roundContent.push(...formattedMedia);
       } catch (err) {
-        this.logger.error(
-          `Error processing media files for follow-up round: ${getSdkErrorMessage(err)}`,
-          { data: err },
-        );
+        this.logger.error('Error processing media files for follow-up round', {
+          data: err,
+        });
       }
     }
 
@@ -638,9 +636,9 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     workspaceState?: AgentWorkspaceState,
   ): void {
     this.applyStringReasoningToWorkspaceState(reasoning, workspaceState);
-    this.logger.debug(
-      `Reasoning content preview: ${reasoning.slice(0, K_SLICE)}...`,
-    );
+    this.logger.debug('Reasoning content preview', {
+      data: reasoning.slice(0, K_SLICE),
+    });
   }
 
   // ---------------------------------------------------------------------------
@@ -745,9 +743,9 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
       workspaceState,
       agentSetting,
     );
-    this.logger.debug(
-      `Adding continuation message. Continuation:\n ${userMessageContinuation}`,
-    );
+    this.logger.debug('Adding continuation message', {
+      data: userMessageContinuation,
+    });
 
     const role = this.capabilities.supportsIntermDevMsgs ? 'system' : 'user';
     messages.push({
@@ -955,7 +953,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     } catch (err) {
       logSdkError(
         this.logger,
-        `Error adding media to user message: ${getSdkErrorMessage(err)}`,
+        'Error adding media to user message',
         err,
         { operation: 'add media to user message' },
       );

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -951,12 +951,9 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
         (lastUserMsg.content as ChatContentItems[]).unshift(...formattedMedia);
       }
     } catch (err) {
-      logSdkError(
-        this.logger,
-        'Error adding media to user message',
-        err,
-        { operation: 'add media to user message' },
-      );
+      logSdkError(this.logger, 'Error adding media to user message', err, {
+        operation: 'add media to user message',
+      });
     }
   }
 }

--- a/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
+++ b/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
@@ -8,8 +8,6 @@ import pMap from 'p-map';
 // Local imports - agent utils
 import { logFilesLoaded, type AgentTrace } from '@agent/trace';
 import type { MediaEntry } from '@agent/utils/mediaTypes';
-import { toErrorMessage } from '@common/errors';
-import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 import type { FileLocation } from '@shared/schemas';
 
 // Local imports - utils
@@ -82,9 +80,9 @@ export class MediaAttachmentProcessor {
       }
 
       if (this.capabilities.supportsNativePdf) {
-        this.logger.debug(
-          `Using native PDF for ${mediaFile}. Page count: ${pageCount}`,
-        );
+        this.logger.debug('Using native PDF', {
+          data: { mediaFile, pageCount },
+        });
         mediaType = 'application/pdf';
         mediaData = await getBase64EncodedMedia(mediaFile);
         return { kind: 'image', mediaType, data: mediaData };
@@ -101,9 +99,9 @@ export class MediaAttachmentProcessor {
       const mimeType = getMimeType(mediaFile);
       if (mimeType?.startsWith('image/')) {
         mediaType = mimeType;
-        this.logger.debug(
-          `Processing as image: ${mediaFile}, type: ${mediaType}`,
-        );
+        this.logger.debug('Processing as image', {
+          data: { mediaFile, mediaType },
+        });
         mediaData = await getBase64EncodedMedia(mediaFile);
       } else {
         throw new Error(
@@ -129,7 +127,7 @@ export class MediaAttachmentProcessor {
       );
     }
 
-    this.logger.debug(`Processing as audio: ${mediaFile}, type: ${mimeType}`);
+    this.logger.debug('Processing as audio', { data: { mediaFile, mimeType } });
     let mediaData = await getBase64EncodedMedia(mediaFile);
     if (Array.isArray(mediaData)) {
       this.logger.warn(
@@ -188,10 +186,9 @@ export class MediaAttachmentProcessor {
       } else {
         const { location, reason } = loadResult;
         const displayPath = getShortDisplayPath(location);
-        this.logger.error(
-          `Failed to load media entry for ${displayPath}: ${getSdkErrorMessage(reason)}`,
-          { data: reason },
-        );
+        this.logger.error('Failed to load media entry', {
+          data: { path: displayPath, error: reason },
+        });
         results.push({ path: displayPath, ok: false });
       }
     }
@@ -228,10 +225,9 @@ export class MediaAttachmentProcessor {
       const stats = await AbsoluteFS.stat(absolutePath);
       fileSize = stats.size;
     } catch (err) {
-      const message = toErrorMessage(err);
-      this.logger.error(
-        `Unable to read file info for ${displayPath}: ${message}`,
-      );
+      this.logger.error('Unable to read file info', {
+        data: { path: displayPath, error: err },
+      });
       return { result: { path: displayPath, ok: false } };
     }
 
@@ -247,9 +243,13 @@ export class MediaAttachmentProcessor {
       const processed = this.isAudio(fileExtension)
         ? await this.processAudio(absolutePath, fileExtension)
         : await this.processImage(absolutePath, fileExtension);
-      this.logger.debug(
-        `Processed ${processed.kind}: ${displayPath}, type: ${processed.mediaType}`,
-      );
+      this.logger.debug('Processed media', {
+        data: {
+          kind: processed.kind,
+          path: displayPath,
+          mediaType: processed.mediaType,
+        },
+      });
 
       const entry = this.createEntriesForProcessedMedia(
         displayPath,
@@ -263,10 +263,9 @@ export class MediaAttachmentProcessor {
         result: { path: displayPath, ok: true },
       };
     } catch (err) {
-      this.logger.error(
-        `Failed to process media ${displayPath}: ${getSdkErrorMessage(err)}`,
-        { data: err },
-      );
+      this.logger.error('Failed to process media', {
+        data: { path: displayPath, error: err },
+      });
       return { result: { path: displayPath, ok: false } };
     }
   }

--- a/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
+++ b/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
@@ -8,6 +8,7 @@ import pMap from 'p-map';
 // Local imports - agent utils
 import { logFilesLoaded, type AgentTrace } from '@agent/trace';
 import type { MediaEntry } from '@agent/utils/mediaTypes';
+import { getSdkErrorMessage } from '@common/errors';
 import type { FileLocation } from '@shared/schemas';
 
 // Local imports - utils
@@ -186,9 +187,12 @@ export class MediaAttachmentProcessor {
       } else {
         const { location, reason } = loadResult;
         const displayPath = getShortDisplayPath(location);
-        this.logger.error('Failed to load media entry', {
-          data: { path: displayPath, error: reason },
-        });
+        this.logger.error(
+          `Failed to load media entry for ${displayPath}: ${getSdkErrorMessage(reason)}`,
+          {
+            data: { path: displayPath, error: reason },
+          },
+        );
         results.push({ path: displayPath, ok: false });
       }
     }
@@ -225,9 +229,10 @@ export class MediaAttachmentProcessor {
       const stats = await AbsoluteFS.stat(absolutePath);
       fileSize = stats.size;
     } catch (err) {
-      this.logger.error('Unable to read file info', {
-        data: { path: displayPath, error: err },
-      });
+      this.logger.error(
+        `Unable to read file info for ${displayPath}: ${getSdkErrorMessage(err)}`,
+        { data: { path: displayPath, error: err } },
+      );
       return { result: { path: displayPath, ok: false } };
     }
 
@@ -263,9 +268,12 @@ export class MediaAttachmentProcessor {
         result: { path: displayPath, ok: true },
       };
     } catch (err) {
-      this.logger.error('Failed to process media', {
-        data: { path: displayPath, error: err },
-      });
+      this.logger.error(
+        `Failed to process media ${displayPath}: ${getSdkErrorMessage(err)}`,
+        {
+          data: { path: displayPath, error: err },
+        },
+      );
       return { result: { path: displayPath, ok: false } };
     }
   }

--- a/src/agent/modelHandlers/support/openAiCompatiblePrefill.ts
+++ b/src/agent/modelHandlers/support/openAiCompatiblePrefill.ts
@@ -60,7 +60,7 @@ export async function initializeOpenAiCompatibleOutputAndPrefill<
     }
     const pseudoPrefillMsg = `Organize your response with xml tags. Start your response with:\n${prefill}`;
     adapter.appendPseudoPrefill(messages, pseudoPrefillMsg);
-    adapter.logger.debug(`Added pseudo prefill: "${pseudoPrefillMsg}"`);
+    adapter.logger.debug('Added pseudo prefill', { data: pseudoPrefillMsg });
     return [false, messages];
   }
 

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -4,7 +4,6 @@ import { platform } from '@platform/platform';
 import type { StageHandle } from '@agent/trace';
 import { logLatexdiff, type AgentTrace } from '@agent/trace';
 import { AgentWorkflowSetting } from '@agent/core/definition/AgentDataclass';
-import { toErrorMessage } from '@common/errors';
 import { compileLatex2Pdf } from '@latex/texTools';
 import { LaTeXdiffResult, LaTeXdiffService } from '@latex/latexdiff';
 import {
@@ -103,20 +102,22 @@ export class LatexDiffManager {
     operation: string = 'latexdiff',
   ): void {
     if (result.success) {
-      this.logger.debug(
-        `Successfully generated ${operation} file: ${result.diffFileName}`,
-      );
+      this.logger.debug('Successfully generated diff file', {
+        data: { operation, diffFileName: result.diffFileName },
+      });
       return;
     }
 
     if (result.message?.includes('document environment')) {
-      this.logger.debug(`Skipping ${operation}: ${result.message}`, {
+      this.logger.debug(`Skipping ${operation}`, {
+        data: result.message,
         messageType: MESSAGE_TYPES.INTERNAL,
       });
       return;
     }
 
-    this.logger.warn(`Failed to generate ${operation}: ${result.message}`, {
+    this.logger.warn(`Failed to generate ${operation}`, {
+      data: result.message,
       messageType: MESSAGE_TYPES.INTERNAL,
     });
   }
@@ -135,10 +136,10 @@ export class LatexDiffManager {
     try {
       await this.fileService.mirrorWorkspaceFile(targetLocation);
     } catch (error) {
-      this.logger.warn(
-        `Unable to mirror workspace dependency ${targetLocation.absolutePath}: ${toErrorMessage(error)}`,
-        { messageType: MESSAGE_TYPES.INTERNAL },
-      );
+      this.logger.warn('Unable to mirror workspace dependency', {
+        data: { path: targetLocation.absolutePath, error },
+        messageType: MESSAGE_TYPES.INTERNAL,
+      });
     }
   }
 
@@ -185,12 +186,12 @@ export class LatexDiffManager {
       outputFiles.map((f) => [getComparablePath(f.location), f]),
     );
 
-    this.logger.debug(
-      `Base files: ${this.baseFiles.map((f) => f.absolutePath).join(', ')}`,
-    );
-    this.logger.debug(
-      `r${currRound} output files: ${outputFiles.map((f) => f.location.absolutePath)}`,
-    );
+    this.logger.debug('Base files', {
+      data: this.baseFiles.map((f) => f.absolutePath),
+    });
+    this.logger.debug(`r${currRound} output files`, {
+      data: outputFiles.map((f) => f.location.absolutePath),
+    });
 
     const aggregated: DiffResult[] = [];
     const artifacts: CompiledPdfArtifact[] = [];
@@ -294,14 +295,12 @@ export class LatexDiffManager {
     description: string,
   ): void {
     if (pairs.length > 0) {
-      this.logger.debug(
-        `Matched ${description}: ${pairs
-          .map(
-            ([outputPath, loc]) =>
-              `${this.getDisplayLabel(loc)} -> ${path.basename(outputPath)}`,
-          )
-          .join(', ')}`,
-      );
+      this.logger.debug(`Matched ${description}`, {
+        data: pairs.map(
+          ([outputPath, loc]) =>
+            `${this.getDisplayLabel(loc)} -> ${path.basename(outputPath)}`,
+        ),
+      });
     } else if (this.baseFiles.length > 0) {
       this.logger.debug(`No ${description.split(' to ')[0]} mappings found`);
     }

--- a/src/agent/output/OutputFileProcessor.ts
+++ b/src/agent/output/OutputFileProcessor.ts
@@ -144,10 +144,14 @@ export class OutputFileProcessor {
     const rawText = await flexibleFS.read(outputLocation).catch(() => '');
     if (rawText.trim().length > 0) {
       this.ctx.logger.warn(
-        `Round ${currRound}: the model returned output but no files could be ` +
-          `extracted from it — it likely did not wrap each document in ` +
-          `<${this.ctx.agentSetting.documentTag} name="…">. The raw response ` +
-          `was kept at ${outputLocation.absolutePath}.`,
+        'The model returned output but no files could be extracted from it — it likely did not wrap each document in the expected tag. The raw response was kept for recovery.',
+        {
+          data: {
+            round: currRound,
+            documentTag: this.ctx.agentSetting.documentTag,
+            rawResponsePath: outputLocation.absolutePath,
+          },
+        },
       );
     }
     logMissingOutputs(this.ctx.logger, {

--- a/src/agent/output/OutputFileProcessor.ts
+++ b/src/agent/output/OutputFileProcessor.ts
@@ -144,7 +144,7 @@ export class OutputFileProcessor {
     const rawText = await flexibleFS.read(outputLocation).catch(() => '');
     if (rawText.trim().length > 0) {
       this.ctx.logger.warn(
-        'The model returned output but no files could be extracted from it — it likely did not wrap each document in the expected tag. The raw response was kept for recovery.',
+        `The model returned output but no files could be extracted from it — it likely did not wrap each document in <${this.ctx.agentSetting.documentTag}>. The raw response was kept at ${outputLocation.absolutePath} for recovery.`,
         {
           data: {
             round: currRound,

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -440,9 +440,9 @@ export class XmlOutputManager {
         lineage: null,
         diff: null,
       });
-      this.logger.debug(
-        `XML Source: ${source} -> TeX file written: ${texFile}`,
-      );
+      this.logger.debug('XML source written to TeX file', {
+        data: { source, texFile },
+      });
     }
 
     return outputFiles;

--- a/src/agent/output/compileCheck.ts
+++ b/src/agent/output/compileCheck.ts
@@ -150,9 +150,9 @@ export async function runCompileCheck(
       }
       if (result.artifact) artifacts.push(result.artifact);
     } catch (err) {
-      ctx.logger.warn(
-        `Compile check: ${displayName} skipped — ${toErrorMessage(err)}`,
-      );
+      ctx.logger.warn(`Compile check: ${displayName} skipped`, {
+        data: err,
+      });
     }
   }
 
@@ -260,9 +260,9 @@ async function compileOne(
       : null;
 
     if (artifact) {
-      ctx.logger.debug(
-        `Compile check: ${displayName} PDF persisted at ${artifact.latestPdf.relativePath}`,
-      );
+      ctx.logger.debug(`Compile check: ${displayName} PDF persisted`, {
+        data: artifact.latestPdf.relativePath,
+      });
     }
     return { failure: null, failureLogExcerpt: '', artifact };
   }
@@ -271,9 +271,9 @@ async function compileOne(
   const failureLogExcerpt = `Compile check failed for ${displayName}\nBuild directory: ${buildDir}\n\n${tail}`;
   await flexibleFS.ensureDir(pathToLocation(opts.compileRoot));
   await flexibleFS.write(logDest, `${failureLogExcerpt}\n`);
-  ctx.logger.warn(
-    `Compile check: ${displayName} failed — wrote ${path.relative(opts.runDirectory, logDest.absolutePath)}`,
-  );
+  ctx.logger.warn(`Compile check: ${displayName} failed`, {
+    data: path.relative(opts.runDirectory, logDest.absolutePath),
+  });
   const executionId = ctx.fileService.metadata.executionId;
   const logLocation = executionId
     ? createRunStorageLocation(

--- a/src/agent/output/compileCheck.ts
+++ b/src/agent/output/compileCheck.ts
@@ -150,9 +150,10 @@ export async function runCompileCheck(
       }
       if (result.artifact) artifacts.push(result.artifact);
     } catch (err) {
-      ctx.logger.warn(`Compile check: ${displayName} skipped`, {
-        data: err,
-      });
+      ctx.logger.warn(
+        `Compile check: ${displayName} skipped: ${toErrorMessage(err)}`,
+        { data: err },
+      );
     }
   }
 

--- a/src/agent/output/outputFileExtraction.ts
+++ b/src/agent/output/outputFileExtraction.ts
@@ -10,7 +10,6 @@
  */
 
 import type { StageHandle } from '@agent/trace';
-import { toErrorMessage } from '@common/errors';
 import { MESSAGE_TYPES, type FileLocation } from '@shared/schemas';
 
 import {
@@ -39,10 +38,10 @@ async function prepareRunWorkspaceIfNeeded(
   try {
     await state.runPreparation;
   } catch (error) {
-    deps.logger.debug(
-      `Failed to prepare run workspace: ${toErrorMessage(error)}`,
-      { messageType: MESSAGE_TYPES.INTERNAL },
-    );
+    deps.logger.debug('Failed to prepare run workspace', {
+      data: error,
+      messageType: MESSAGE_TYPES.INTERNAL,
+    });
   } finally {
     state.runPreparation = null;
   }

--- a/src/agent/output/outputValidation.ts
+++ b/src/agent/output/outputValidation.ts
@@ -73,9 +73,9 @@ export async function checkExpectedOutputs(
           xmlFile: xmlExists ? outputLocation.absolutePath : null,
           documentTag: deps.setting.documentTag,
         });
-        deps.logger.debug(
-          `Missing expected outputs for round ${currRound}: ${missing.join(', ')}`,
-        );
+        deps.logger.debug(`Missing expected outputs for round ${currRound}`, {
+          data: missing,
+        });
       } else {
         deps.logger.debug(
           `All expected outputs exist after round ${currRound}`,

--- a/src/agent/output/roundSummary.ts
+++ b/src/agent/output/roundSummary.ts
@@ -79,10 +79,10 @@ export async function summarizeRound(
         }
       }
 
-      deps.logger.debug(
-        `Finalized round ${currRound} storageKey=${storageKey} files=${fileInfos.length}`,
-        { messageType: MESSAGE_TYPES.INTERNAL },
-      );
+      deps.logger.debug('Finalized round', {
+        data: { round: currRound, storageKey, files: fileInfos.length },
+        messageType: MESSAGE_TYPES.INTERNAL,
+      });
 
       return {
         storageKey,

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -92,9 +92,9 @@ function endParentStageSafely(
   try {
     ctx.parentStage.end(status);
   } catch (stageErr) {
-    logger.warn(
-      `Failed to end parent stage for ${agentIdentifier}: ${getSdkErrorMessage(stageErr)}`,
-    );
+    logger.warn('Failed to end parent stage', {
+      data: { agentIdentifier, error: stageErr },
+    });
   }
 }
 
@@ -136,14 +136,14 @@ export async function runFlowWithLifecycle(
     try {
       const maybePromise = options.onRun(handle);
       void Promise.resolve(maybePromise).catch((err: unknown) =>
-        logger.warn(
-          `onRun callback rejected for ${agentIdentifier}: ${String(err)}`,
-        ),
+        logger.warn('onRun callback rejected', {
+          data: { agentIdentifier, error: err },
+        }),
       );
     } catch (err) {
-      logger.warn(
-        `onRun callback threw for ${agentIdentifier}: ${String(err)}`,
-      );
+      logger.warn('onRun callback threw', {
+        data: { agentIdentifier, error: err },
+      });
     }
   }
   // Tracks whether the terminal `result` event has already been emitted, so a
@@ -200,9 +200,9 @@ export async function runFlowWithLifecycle(
     try {
       await options?.onCompleted?.(result);
     } catch (deliveryError) {
-      logger.warn(
-        `Completion hook failed for ${agentIdentifier}: ${getSdkErrorMessage(deliveryError)}`,
-      );
+      logger.warn('Completion hook failed', {
+        data: { agentIdentifier, error: deliveryError },
+      });
     }
 
     // The run has produced its canonical terminal result. Guard the terminal
@@ -218,9 +218,9 @@ export async function runFlowWithLifecycle(
         });
       }
     } catch (cleanupErr) {
-      logger.warn(
-        `Post-completion cleanup threw for ${agentIdentifier}: ${getSdkErrorMessage(cleanupErr)}`,
-      );
+      logger.warn('Post-completion cleanup threw', {
+        data: { agentIdentifier, error: cleanupErr },
+      });
     }
     logger.debug(`Task completed with outcome: ${result.outcome}`);
     return result;
@@ -282,9 +282,9 @@ export async function runFlowWithLifecycle(
         terminalStatus: projection.executionStatus,
       });
     } catch (statusErr) {
-      logger.warn(
-        `Failed to set terminal error status for ${agentIdentifier}: ${getSdkErrorMessage(statusErr)}`,
-      );
+      logger.warn('Failed to set terminal error status', {
+        data: { agentIdentifier, error: statusErr },
+      });
     }
     // Terminal-error toasts are no longer emitted here: hosts present them from
     // the `result` event via `session.onResult` + `terminalResultToast` (the
@@ -303,9 +303,9 @@ export async function runFlowWithLifecycle(
       try {
         await options.onError?.(err, result);
       } catch (deliveryError) {
-        logger.warn(
-          `Failed to deliver subagent error for ${agentIdentifier}: ${getSdkErrorMessage(deliveryError)}`,
-        );
+        logger.warn('Failed to deliver subagent error', {
+          data: { agentIdentifier, error: deliveryError },
+        });
       }
       session.executions.untrack(ctx.executionId);
       return result;

--- a/src/agent/runtime/ExecutionSubscriptionBinder.ts
+++ b/src/agent/runtime/ExecutionSubscriptionBinder.ts
@@ -238,9 +238,9 @@ export class ExecutionSubscriptionBinder {
     );
     bound.set(executionId, subscription);
     if (subscription.bind()) {
-      this.logger.info(
-        `Bound execution subscription ${executionId} → stream ${streamId}`,
-      );
+      this.logger.info('Bound execution subscription to stream', {
+        data: { executionId, streamId },
+      });
     }
   }
 
@@ -254,9 +254,9 @@ export class ExecutionSubscriptionBinder {
     try {
       d.dispose();
     } catch (err) {
-      this.logger.warn(
-        `Disposer threw on explicit unsubscribe: ${String(err)}`,
-      );
+      this.logger.warn('Disposer threw on explicit unsubscribe', {
+        data: err,
+      });
     }
     return true;
   }
@@ -285,7 +285,7 @@ export class ExecutionSubscriptionBinder {
       try {
         d.dispose();
       } catch (err) {
-        this.logger.warn(`Disposer threw during ${reason}: ${String(err)}`);
+        this.logger.warn(`Disposer threw during ${reason}`, { data: err });
       }
     }
   }

--- a/src/agent/runtime/ExecutionSubscriptionBinder.ts
+++ b/src/agent/runtime/ExecutionSubscriptionBinder.ts
@@ -40,8 +40,8 @@ interface ReleaseSource {
 }
 
 interface BinderLogger {
-  info(message: string): void;
-  warn(message: string): void;
+  info(message: string, options?: { data?: unknown }): void;
+  warn(message: string, options?: { data?: unknown }): void;
 }
 
 interface ExecutionSubscriptionBinderOptions {

--- a/src/agent/runtime/RetryRequestCoordinator.ts
+++ b/src/agent/runtime/RetryRequestCoordinator.ts
@@ -67,9 +67,9 @@ export class RetryRequestCoordinatorImpl extends BasePromiseCoordinator<
     const { logger, operation, errorMessage, model, timeoutMs, errorDetails } =
       options;
     this.loggers.set(streamId, logger);
-    logger.debug(
-      `Waiting for manual retry: ${errorMessage ?? 'unknown error'}`,
-    );
+    logger.debug('Waiting for manual retry', {
+      data: errorMessage ?? 'unknown error',
+    });
 
     return this.waitForUserAction(
       streamId,

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -30,7 +30,6 @@
 import { getActiveFlushers, unregisterFlushers } from '@transcript';
 import type { AgentTrace, ResultEvent } from '@agent/trace';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
-import { toErrorMessage } from '@common/errors';
 import { createChannelTrace } from '@logger';
 
 import { tryUseRunContext } from './RunContext';
@@ -154,7 +153,7 @@ export class SessionHandle {
         try {
           listener(event);
         } catch (err) {
-          logger.warn(`onResult listener threw: ${toErrorMessage(err)}`);
+          logger.warn('onResult listener threw', { data: err });
         }
       }
     });
@@ -185,7 +184,7 @@ export class SessionHandle {
       this.flushPendingTraces();
       if (keepActiveExecutions) {
         void this.disposeWhenIdle().catch((err) => {
-          logger.warn(`Idle session disposal failed: ${toErrorMessage(err)}`);
+          logger.warn('Idle session disposal failed', { data: err });
         });
       } else {
         this.teardownOwners();

--- a/src/agent/runtime/SessionResumeRetrieval.ts
+++ b/src/agent/runtime/SessionResumeRetrieval.ts
@@ -143,9 +143,9 @@ async function readFlowRecord(
   const flowRecord = await kv.read<FlowRecord>(flowKey(executionId));
 
   if (!flowRecord?.shared) {
-    logger.warn(
-      `No flow record found for ${agentType} execution: ${executionId}`,
-    );
+    logger.warn('No flow record found for execution', {
+      data: { agentType, executionId },
+    });
     return null;
   }
 
@@ -206,9 +206,9 @@ async function retrieveToolUseResumeData(
 
     const snapshotResult = ToolUseSessionSnapshotSchema.safeParse(rawSnapshot);
     if (!snapshotResult.success) {
-      logger.warn(
-        `Invalid snapshot structure for stream: ${streamId}: ${z.prettifyError(snapshotResult.error)}`,
-      );
+      logger.warn('Invalid snapshot structure for stream', {
+        data: { streamId, error: z.prettifyError(snapshotResult.error) },
+      });
       return null;
     }
 
@@ -251,9 +251,13 @@ async function retrieveWorkflowResumeData(
       return null;
     }
 
-    logger.debug(
-      `Retrieved workflow resume data for stream: ${streamId} (round ${parseResult.data.currentRound}/${parseResult.data.totalRounds})`,
-    );
+    logger.debug('Retrieved workflow resume data for stream', {
+      data: {
+        streamId,
+        currentRound: parseResult.data.currentRound,
+        totalRounds: parseResult.data.totalRounds,
+      },
+    });
     const modelHandlerCompatibilityKey =
       parseResult.data.modelHandlerCompatibilityKey ??
       inferPersistedModelHandlerCompatibilityKey(

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -425,9 +425,9 @@ export async function executeAgent(
         if (executionId) await ensureRunDir(executionId);
         logger.info(`Starting task execution (streamId: ${streamId})`);
         logger.info(`Input file: ${config.inputFiles[0] ?? '(none)'}`);
-        logger.debug(
-          `Stream ID: ${streamId}, Agent: ${config.agent}, Model: ${config.model}`,
-        );
+        logger.debug('Task execution details', {
+          data: { streamId, agent: config.agent, model: config.model },
+        });
         logger.debug(`Output files: ${config.outputFiles?.length ?? 0}`);
         // Subagents don't need to force-open the progress board or show notifications —
         // the orchestrator's stream is already visible.
@@ -442,7 +442,9 @@ export async function executeAgent(
           taskState: agentConfigToTaskState(config),
         });
 
-        logger.info(`Executing ${config.agent} with model ${config.model}`);
+        logger.info('Executing agent', {
+          data: { agent: config.agent, model: config.model },
+        });
 
         if (setting.agentCategory === AgentCategory.ToolUse) {
           return runToolUseAgent(ctx, handle, setting, options);

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -7,7 +7,6 @@ import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { UsageProviderSchema } from '@agent/types/NormalizedUsage';
 import { shouldUseOpenRouter } from '@agent/modelHandlers/support/ProxyConfigResolver';
 import { getServerSideKeyService } from '@auth/serverKeys';
-import { toErrorMessage } from '@common/errors';
 import type {
   ExtendedTokenUsageStats,
   StorageKey,
@@ -203,9 +202,7 @@ export class UsageMonitor {
         usageRoute,
       });
     } catch (error) {
-      logger.error(
-        `Error printing ${runKind} statistics: ${toErrorMessage(error)}`,
-      );
+      logger.error(`Error printing ${runKind} statistics`, { data: error });
     }
   }
 
@@ -234,9 +231,9 @@ export class UsageMonitor {
     try {
       return this.usesRelayRoute() ? 'relay' : 'api-key';
     } catch (error) {
-      this.context.logger.debug(
-        `Usage route relay check failed: ${toErrorMessage(error)}`,
-      );
+      this.context.logger.debug('Usage route relay check failed', {
+        data: error,
+      });
       return undefined;
     }
   }
@@ -321,9 +318,9 @@ export class UsageMonitor {
         }
       }
     } catch (error) {
-      this.context.logger.debug(
-        `Backend usage logging failed: ${toErrorMessage(error)}`,
-      );
+      this.context.logger.debug('Backend usage logging failed', {
+        data: error,
+      });
     }
   }
 }

--- a/src/agent/utils/debugMessageSaver.ts
+++ b/src/agent/utils/debugMessageSaver.ts
@@ -1,7 +1,6 @@
 import * as path from 'node:path';
 
 import type { AgentTrace } from '@agent/trace';
-import { toErrorMessage } from '@common/errors';
 import type { ExecutionId } from '@shared/schemas';
 import { WorkspaceFS, StorageFS } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
@@ -68,8 +67,6 @@ export async function maybeSaveDebugObject({
     const debugFilePath = fs.fullPath(filePath);
     logger.info(`Saved ${objectType} object to ${debugFilePath}`);
   } catch (error) {
-    logger.error(
-      `Failed to save ${objectType} object: ${toErrorMessage(error)}`,
-    );
+    logger.error(`Failed to save ${objectType} object`, { data: error });
   }
 }

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -91,10 +91,9 @@ export class LatexMediaManager {
             pathToLocation(absolutePath),
           );
         } catch (error) {
-          const message = toErrorMessage(error);
-          this.logger.debug(
-            `Unable to mirror figure dependency ${absolutePath}: ${message}`,
-          );
+          this.logger.debug('Unable to mirror figure dependency', {
+            data: { path: absolutePath, error },
+          });
         }
       },
       { concurrency: LATEX_CONCURRENCY, stopOnError: false },
@@ -133,22 +132,28 @@ export class LatexMediaManager {
           // Stat failures are noisier than other compile failures because an
           // existing-but-unreadable PDF likely indicates a permissions/IO bug.
           const stats = await flexibleFS.stat(pdfLocation).catch((err) => {
-            this.logger.error(
-              `Failed to stat compiled PDF ${pdfLocation.absolutePath}: ${toErrorMessage(err)}`,
-            );
+            this.logger.error('Failed to stat compiled PDF', {
+              data: { path: pdfLocation.absolutePath, error: err },
+            });
             return undefined;
           });
           if (!stats) return undefined;
           if (stats.size === 0) {
-            this.logger.warn(
-              `Compiled PDF is empty for ${file.absolutePath}: ${pdfLocation.absolutePath}`,
-            );
+            this.logger.warn('Compiled PDF is empty', {
+              data: {
+                sourceFile: file.absolutePath,
+                pdfFile: pdfLocation.absolutePath,
+              },
+            });
             return undefined;
           }
 
-          this.logger.info(
-            `Compiled PDF for ${file.absolutePath}: ${pdfLocation.absolutePath}`,
-          );
+          this.logger.info('Compiled PDF', {
+            data: {
+              sourceFile: file.absolutePath,
+              pdfFile: pdfLocation.absolutePath,
+            },
+          });
           return pdfLocation;
         } catch {
           // Silent skip: pMap with stopOnError: false continues past
@@ -201,9 +206,9 @@ export class LatexMediaManager {
             await platform().fs.realPath(file.absolutePath),
           );
         } catch (error) {
-          this.logger.debug(
-            `Unable to resolve real path for ${file.absolutePath}: ${toErrorMessage(error)}`,
-          );
+          this.logger.debug('Unable to resolve real path', {
+            data: { path: file.absolutePath, error },
+          });
         }
         await this.mirrorProjectSiblings(siblingDir);
       },
@@ -231,16 +236,16 @@ export class LatexMediaManager {
               worklist.push(depLocation);
             }
           } catch (error) {
-            this.logger.debug(
-              `Unable to mirror LaTeX dependency ${absolutePath}: ${toErrorMessage(error)}`,
-            );
+            this.logger.debug('Unable to mirror LaTeX dependency', {
+              data: { path: absolutePath, error },
+            });
           }
         },
         { concurrency: LATEX_CONCURRENCY, stopOnError: false },
       );
-      this.logger.debug(
-        `Mirrored ${deps.length} LaTeX dependencies from ${file.absolutePath}`,
-      );
+      this.logger.debug('Mirrored LaTeX dependencies', {
+        data: { count: deps.length, from: file.absolutePath },
+      });
     }
   }
 
@@ -260,9 +265,9 @@ export class LatexMediaManager {
         found.add(abs);
       }
     } catch (error) {
-      this.logger.debug(
-        `Unable to extract LaTeX dependencies from ${latexFile.absolutePath}: ${toErrorMessage(error)}`,
-      );
+      this.logger.debug('Unable to extract LaTeX dependencies', {
+        data: { path: latexFile.absolutePath, error },
+      });
     }
 
     try {
@@ -287,9 +292,9 @@ export class LatexMediaManager {
         }
       }
     } catch (error) {
-      this.logger.debug(
-        `Unable to probe \\usepackage targets in ${latexFile.absolutePath}: ${toErrorMessage(error)}`,
-      );
+      this.logger.debug('Unable to probe \\usepackage targets', {
+        data: { path: latexFile.absolutePath, error },
+      });
     }
 
     return [...found];
@@ -309,9 +314,9 @@ export class LatexMediaManager {
         ([name]) => name,
       );
     } catch (error) {
-      this.logger.debug(
-        `Unable to scan project siblings in ${projectDir}: ${toErrorMessage(error)}`,
-      );
+      this.logger.debug('Unable to scan project siblings', {
+        data: { path: projectDir, error },
+      });
       return;
     }
 
@@ -338,9 +343,9 @@ export class LatexMediaManager {
             pathToLocation(absolutePath),
           );
         } catch (error) {
-          this.logger.debug(
-            `Unable to mirror project sibling ${absolutePath}: ${toErrorMessage(error)}`,
-          );
+          this.logger.debug('Unable to mirror project sibling', {
+            data: { path: absolutePath, error },
+          });
         }
       },
       { concurrency: LATEX_CONCURRENCY, stopOnError: false },
@@ -371,9 +376,9 @@ export class LatexMediaManager {
           if (figures.length === 0) return;
           await this.mirrorFigureDependencies(file, figures);
         } catch (error) {
-          this.logger.debug(
-            `Unable to mirror figures from ${file.absolutePath}: ${toErrorMessage(error)}`,
-          );
+          this.logger.debug('Unable to mirror figures', {
+            data: { path: file.absolutePath, error },
+          });
         }
       },
       { concurrency: LATEX_CONCURRENCY, stopOnError: false },
@@ -407,9 +412,9 @@ export class LatexMediaManager {
         continue;
       }
 
-      this.logger.debug(
-        `Extracted ${figures.length} figures from ${file.absolutePath}`,
-      );
+      this.logger.debug('Extracted figures', {
+        data: { count: figures.length, from: file.absolutePath },
+      });
 
       // Match the resolution in extractFigurePathsFromLatex so the returned
       // figure paths (relative to the real latexDir) map back to workspace
@@ -427,9 +432,9 @@ export class LatexMediaManager {
 
       for (const { loc, exists } of existenceChecks) {
         if (!exists) {
-          this.logger.debug(
-            `Extracted figure path does not exist: ${loc.absolutePath} (from ${file.absolutePath})`,
-          );
+          this.logger.debug('Extracted figure path does not exist', {
+            data: { figurePath: loc.absolutePath, from: file.absolutePath },
+          });
         }
       }
 

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -5,7 +5,6 @@ import pMap from 'p-map';
 import { platform } from '@platform/platform';
 import type { AgentTrace } from '@agent/trace/AgentTrace';
 
-import { toErrorMessage } from '@common/errors';
 import type { FileLocation } from '@shared/schemas';
 import { ToolConfig } from '@shared/schemas/toolConfig';
 import { TaskRunFileService, flexibleFS, pathToLocation } from '@utils/files';

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -4,6 +4,7 @@ import pMap from 'p-map';
 
 import { platform } from '@platform/platform';
 import type { AgentTrace } from '@agent/trace/AgentTrace';
+import { toErrorMessage } from '@common/errors';
 
 import type { FileLocation } from '@shared/schemas';
 import { ToolConfig } from '@shared/schemas/toolConfig';
@@ -131,9 +132,10 @@ export class LatexMediaManager {
           // Stat failures are noisier than other compile failures because an
           // existing-but-unreadable PDF likely indicates a permissions/IO bug.
           const stats = await flexibleFS.stat(pdfLocation).catch((err) => {
-            this.logger.error('Failed to stat compiled PDF', {
-              data: { path: pdfLocation.absolutePath, error: err },
-            });
+            this.logger.error(
+              `Failed to stat compiled PDF ${pdfLocation.absolutePath}: ${toErrorMessage(err)}`,
+              { data: { path: pdfLocation.absolutePath, error: err } },
+            );
             return undefined;
           });
           if (!stats) return undefined;

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -123,14 +123,42 @@ function writeLine(
   if (data === null || data === undefined) return;
   if (!isDebugModeEnabled()) return;
 
+  const normalizedData = normalizeLogData(data);
   sink.appendLine(
-    typeof data === 'string' ? data : JSON.stringify(data, null, 2),
+    typeof normalizedData === 'string'
+      ? normalizedData
+      : JSON.stringify(normalizedData, null, 2),
   );
 }
 
 /** Errors don't survive `JSON.stringify`, so flatten them before emit. */
-function normalizeLogData(data: unknown): unknown {
-  return data instanceof Error ? serializeError(data) : data;
+function normalizeLogData(
+  data: unknown,
+  seen = new WeakSet<object>(),
+): unknown {
+  if (data instanceof Error) return serializeError(data);
+  if (Array.isArray(data)) {
+    if (seen.has(data)) return '[Circular]';
+    seen.add(data);
+    const result = data.map((item) => normalizeLogData(item, seen));
+    seen.delete(data);
+    return result;
+  }
+  if (typeof data !== 'object' || data === null) return data;
+
+  const prototype = Object.getPrototypeOf(data);
+  if (prototype !== Object.prototype && prototype !== null) return data;
+  if (seen.has(data)) return '[Circular]';
+  seen.add(data);
+
+  const result = Object.fromEntries(
+    Object.entries(data).map(([key, value]) => [
+      key,
+      normalizeLogData(value, seen),
+    ]),
+  );
+  seen.delete(data);
+  return result;
 }
 
 function logAt(
@@ -142,13 +170,7 @@ function logAt(
   // Functional callers (housekeeping, utils, common) never write to the
   // per-stream agent channels — that's exclusively the trace subscriber
   // path via `attachChannelSubscriber`.
-  writeLine(
-    level,
-    channel,
-    /* isAgent */ false,
-    message,
-    normalizeLogData(options.data),
-  );
+  writeLine(level, channel, /* isAgent */ false, message, options.data);
 }
 
 export function initialize(channel: string, isAgent = false): void {
@@ -219,7 +241,7 @@ export function attachChannelSubscriber(
       options.channel,
       options.isAgent,
       event.message,
-      normalizeLogData(event.data),
+      event.data,
     );
   };
 

--- a/src/model/apiProviders.ts
+++ b/src/model/apiProviders.ts
@@ -7,6 +7,7 @@
 import { LRUCache } from 'lru-cache';
 
 import { API_KEY_PROVIDER_IDS } from '@shared/constants/apiKeyProviders';
+import { isNonEmptyString } from '@utils/core';
 import type { PlatformSecrets } from '@platform/secrets';
 
 export const API_PROVIDERS = API_KEY_PROVIDER_IDS;
@@ -164,6 +165,18 @@ export async function apiKeyExists(
   provider: ApiProvider,
 ): Promise<boolean> {
   return (await lookupApiKey(secrets, provider)) !== undefined;
+}
+
+/**
+ * Check whether the resolved key is usable for authentication.
+ * This rejects whitespace-only SecretStorage values while still sharing the
+ * canonical secret → environment fallback and cache.
+ */
+export async function hasUsableApiKey(
+  secrets: PlatformSecrets,
+  provider: ApiProvider,
+): Promise<boolean> {
+  return isNonEmptyString(await lookupApiKey(secrets, provider));
 }
 
 /** Check if an API key exists without using the process-wide provider cache. */

--- a/src/shared/schemas/proposalInput.ts
+++ b/src/shared/schemas/proposalInput.ts
@@ -92,10 +92,12 @@ export function parseDelegationToolInput(
   const spread = isObject(input) ? input : {};
 
   if (category === AgentCategory.ToolUse) {
-    return LenientToolUseProposalSchema.nullable().catch(null).parse({
-      agentCategory: AgentCategory.ToolUse,
-      ...spread,
-    });
+    return LenientToolUseProposalSchema.nullable()
+      .catch(null)
+      .parse({
+        agentCategory: AgentCategory.ToolUse,
+        ...spread,
+      });
   }
 
   // Workflow: migrate legacy file fields, then map extraction shorthand flags.
@@ -103,9 +105,11 @@ export function parseDelegationToolInput(
     string,
     unknown
   >;
-  return LenientWorkflowProposalSchema.nullable().catch(null).parse({
-    agentCategory: AgentCategory.Workflow,
-    ...migrated,
-    toolConfig: extractionShorthandToolConfig(migrated),
-  });
+  return LenientWorkflowProposalSchema.nullable()
+    .catch(null)
+    .parse({
+      agentCategory: AgentCategory.Workflow,
+      ...migrated,
+      toolConfig: extractionShorthandToolConfig(migrated),
+    });
 }

--- a/src/shared/schemas/proposalInput.ts
+++ b/src/shared/schemas/proposalInput.ts
@@ -92,11 +92,10 @@ export function parseDelegationToolInput(
   const spread = isObject(input) ? input : {};
 
   if (category === AgentCategory.ToolUse) {
-    const result = LenientToolUseProposalSchema.safeParse({
+    return LenientToolUseProposalSchema.nullable().catch(null).parse({
       agentCategory: AgentCategory.ToolUse,
       ...spread,
     });
-    return result.success ? result.data : null;
   }
 
   // Workflow: migrate legacy file fields, then map extraction shorthand flags.
@@ -104,10 +103,9 @@ export function parseDelegationToolInput(
     string,
     unknown
   >;
-  const result = LenientWorkflowProposalSchema.safeParse({
+  return LenientWorkflowProposalSchema.nullable().catch(null).parse({
     agentCategory: AgentCategory.Workflow,
     ...migrated,
     toolConfig: extractionShorthandToolConfig(migrated),
   });
-  return result.success ? result.data : null;
 }

--- a/src/shared/schemas/workPlan.ts
+++ b/src/shared/schemas/workPlan.ts
@@ -18,8 +18,7 @@ function normalizeWorkPlanSnapshot(input: unknown): unknown {
   const record = isObject(input) ? input : {};
   // Legacy structured plans fail to parse and read back as "no plan";
   // their stored planSummary string still carries the one-line label.
-  const planResult = PlanSchema.safeParse(record.plan);
-  const plan = planResult.success ? planResult.data : null;
+  const plan = PlanSchema.nullable().catch(null).parse(record.plan);
   let planSummary: string | null = null;
   if (plan) {
     planSummary = planSummaryLine(plan.objective);

--- a/src/skills/loadSkills.ts
+++ b/src/skills/loadSkills.ts
@@ -1,6 +1,9 @@
 // Standard library imports
-import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+
+// Local imports - platform
+import { platform } from '@platform/platform';
+import { isDirectory } from '@utils/files/fsEntryType';
 
 // Local imports - common
 import {
@@ -13,9 +16,6 @@ import { byName } from '@utils/core';
 // Local imports - skill parsing
 import { type SkillLoadIssue, issue, loadSkillDirectory } from './skillLoader';
 import type { Skill } from './SkillSchema';
-
-// Local imports - utilities
-import type { Dirent } from 'node:fs';
 
 export {
   type SkillIssueCode,
@@ -84,9 +84,9 @@ export async function discoverSkills(
   const seenNames = new Set<string>();
   const seenRealPaths = new Set<string>();
 
-  let entries: Dirent[];
+  let entries: [string, number][];
   try {
-    entries = await fs.readdir(root, { withFileTypes: true });
+    entries = await platform().fs.readDirectory(root);
   } catch (err) {
     if (isFileNotFoundError(err)) {
       return { skills, errors };
@@ -100,14 +100,27 @@ export async function discoverSkills(
     return { skills, errors };
   }
 
-  for (const entry of entries.sort(byName)) {
-    if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+  const sortedEntries = entries
+    .map(([name, type]) => ({ name, type }))
+    .sort(byName);
 
+  for (const entry of sortedEntries) {
     const skillDir = path.join(root, entry.name);
+    // `readDirectory`'s type bitmask doesn't reliably surface the symlink bit
+    // on every FileSystemProvider backend (see `FileSystemProvider.isSymlink`
+    // doc comment), so fall back to the dedicated symlink check for entries
+    // the bitmask doesn't already report as a directory.
+    if (
+      !isDirectory(entry.type) &&
+      !(await platform().fs.isSymlink(skillDir))
+    ) {
+      continue;
+    }
+
     const skillPath = path.join(skillDir, 'SKILL.md');
     let realSkillPath: string;
     try {
-      realSkillPath = await fs.realpath(skillPath);
+      realSkillPath = await platform().fs.realPath(skillPath);
     } catch (err) {
       if (!isFileNotFoundError(err)) {
         errors.push(
@@ -149,8 +162,8 @@ async function validateRequiredSource(
   source: SkillSource,
 ): Promise<SkillLoadIssue | undefined> {
   try {
-    const sourceStat = await fs.stat(source.path);
-    if (!sourceStat.isDirectory()) {
+    const sourceStat = await platform().fs.stat(source.path);
+    if (!isDirectory(sourceStat.type)) {
       return issue(
         'error',
         'invalid_source',
@@ -222,7 +235,7 @@ export async function discoverSkillSources(
     for (const skill of result.skills) {
       let realSkillPath = skill.path;
       try {
-        realSkillPath = await fs.realpath(skill.path);
+        realSkillPath = await platform().fs.realPath(skill.path);
       } catch {
         // The one-root loader has already read this file. If the path vanishes
         // between the read and this check, name deduplication still suffices.

--- a/src/skills/loadSkills.ts
+++ b/src/skills/loadSkills.ts
@@ -1,9 +1,6 @@
 // Standard library imports
+import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-
-// Local imports - platform
-import { platform } from '@platform/platform';
-import { isDirectory } from '@utils/files/fsEntryType';
 
 // Local imports - common
 import {
@@ -16,6 +13,9 @@ import { byName } from '@utils/core';
 // Local imports - skill parsing
 import { type SkillLoadIssue, issue, loadSkillDirectory } from './skillLoader';
 import type { Skill } from './SkillSchema';
+
+// Local imports - utilities
+import type { Dirent } from 'node:fs';
 
 export {
   type SkillIssueCode,
@@ -84,9 +84,9 @@ export async function discoverSkills(
   const seenNames = new Set<string>();
   const seenRealPaths = new Set<string>();
 
-  let entries: [string, number][];
+  let entries: Dirent[];
   try {
-    entries = await platform().fs.readDirectory(root);
+    entries = await fs.readdir(root, { withFileTypes: true });
   } catch (err) {
     if (isFileNotFoundError(err)) {
       return { skills, errors };
@@ -100,27 +100,14 @@ export async function discoverSkills(
     return { skills, errors };
   }
 
-  const sortedEntries = entries
-    .map(([name, type]) => ({ name, type }))
-    .sort(byName);
+  for (const entry of entries.sort(byName)) {
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
 
-  for (const entry of sortedEntries) {
     const skillDir = path.join(root, entry.name);
-    // `readDirectory`'s type bitmask doesn't reliably surface the symlink bit
-    // on every FileSystemProvider backend (see `FileSystemProvider.isSymlink`
-    // doc comment), so fall back to the dedicated symlink check for entries
-    // the bitmask doesn't already report as a directory.
-    if (
-      !isDirectory(entry.type) &&
-      !(await platform().fs.isSymlink(skillDir))
-    ) {
-      continue;
-    }
-
     const skillPath = path.join(skillDir, 'SKILL.md');
     let realSkillPath: string;
     try {
-      realSkillPath = await platform().fs.realPath(skillPath);
+      realSkillPath = await fs.realpath(skillPath);
     } catch (err) {
       if (!isFileNotFoundError(err)) {
         errors.push(
@@ -162,8 +149,8 @@ async function validateRequiredSource(
   source: SkillSource,
 ): Promise<SkillLoadIssue | undefined> {
   try {
-    const sourceStat = await platform().fs.stat(source.path);
-    if (!isDirectory(sourceStat.type)) {
+    const sourceStat = await fs.stat(source.path);
+    if (!sourceStat.isDirectory()) {
       return issue(
         'error',
         'invalid_source',
@@ -235,7 +222,7 @@ export async function discoverSkillSources(
     for (const skill of result.skills) {
       let realSkillPath = skill.path;
       try {
-        realSkillPath = await platform().fs.realPath(skill.path);
+        realSkillPath = await fs.realpath(skill.path);
       } catch {
         // The one-root loader has already read this file. If the path vanishes
         // between the read and this check, name deduplication still suffices.

--- a/src/skills/skillLoader.ts
+++ b/src/skills/skillLoader.ts
@@ -178,7 +178,8 @@ export async function loadSkillDirectory(
   const skillPath = path.join(skillDir, 'SKILL.md');
 
   try {
-    const content = await fs.readFile(skillPath, 'utf8');
+    const raw = await platform().fs.readFile(skillPath);
+    const content = Buffer.from(raw).toString('utf8');
     const { frontmatter, body } = extractFrontmatter(content);
     if (!isObject(frontmatter)) {
       return {

--- a/src/skills/skillLoader.ts
+++ b/src/skills/skillLoader.ts
@@ -1,11 +1,9 @@
 // Standard library imports
+import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
 // Third-party imports
 import { ZodError } from 'zod';
-
-// Local imports - platform
-import { platform } from '@platform/platform';
 
 // Local imports - common
 import { toErrorMessage } from '@common/errors';
@@ -178,8 +176,7 @@ export async function loadSkillDirectory(
   const skillPath = path.join(skillDir, 'SKILL.md');
 
   try {
-    const raw = await platform().fs.readFile(skillPath);
-    const content = Buffer.from(raw).toString('utf8');
+    const content = await fs.readFile(skillPath, 'utf8');
     const { frontmatter, body } = extractFrontmatter(content);
     if (!isObject(frontmatter)) {
       return {

--- a/src/skills/skillLoader.ts
+++ b/src/skills/skillLoader.ts
@@ -1,9 +1,11 @@
 // Standard library imports
-import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
 // Third-party imports
 import { ZodError } from 'zod';
+
+// Local imports - platform
+import { platform } from '@platform/platform';
 
 // Local imports - common
 import { toErrorMessage } from '@common/errors';

--- a/src/skills/skillSources.ts
+++ b/src/skills/skillSources.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs';
-import * as os from 'node:os';
 import * as path from 'node:path';
+
+import { safeHomedir } from '@utils/system/platformPaths';
 
 import type { SkillSource } from './loadSkills';
 
@@ -78,7 +79,10 @@ export function defaultSkillSources(
   context: SkillSourceContext,
   options: SkillSourceOptions = {},
 ): SkillSource[] {
-  const home = os.homedir();
+  // `safeHomedir()` never throws (unlike raw `os.homedir()`, which can raise
+  // UV_ENOENT in containers/CI); `/nonexistent` matches the fallback used by
+  // other agnostic-zone callers (e.g. `claudeAgentConfig.ts`).
+  const home = safeHomedir() ?? '/nonexistent';
   const sources: SkillSource[] = [];
 
   for (const candidate of options.additionalPaths ?? []) {

--- a/src/test-kernel/agent/modelHandlers/AnthropicStreamFailureLogging.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/AnthropicStreamFailureLogging.vitest.ts
@@ -104,7 +104,7 @@ describe('Anthropic stream failure logging', () => {
 
     expect(logger.warn).not.toHaveBeenCalled();
     expect(logger.debug).toHaveBeenCalledWith(
-      expect.stringContaining('Stream failed:'),
+      'Stream failed',
       expect.objectContaining({
         data: expect.objectContaining({
           partialTextLength: 0,

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerGoogleGenAI.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerGoogleGenAI.vitest.ts
@@ -52,20 +52,22 @@ beforeAll(async () => {
 interface LoggerStub extends Partial<AgentTrace> {
   streamId: string;
   fileListEntries: Array<Array<{ path: string; ok: boolean }>>;
+  warnMessages: string[];
 }
 
 function createLoggerStub(): { logger: AgentTrace; stub: LoggerStub } {
   const stub: LoggerStub = {
     streamId: 'test-channel',
     fileListEntries: [],
+    warnMessages: [],
     debug: () => {
       /* no-op for tests */
     },
     info: () => {
       /* no-op for tests */
     },
-    warn: () => {
-      /* no-op for tests */
+    warn(message: string) {
+      this.warnMessages.push(message);
     },
     error: () => {
       /* no-op for tests */
@@ -239,6 +241,42 @@ describe('ModelHandlerGoogleGenAI media uploads', () => {
     assert.deepEqual(parts, [
       createPartFromUri('files/large', 'application/pdf'),
     ]);
+  });
+
+  it('keeps Google upload failure details in the visible warning', async () => {
+    const clientStub = {
+      files: {
+        upload: async () => {
+          throw new Error('provider quota exhausted');
+        },
+      },
+    };
+
+    class LimitedInlineHandler extends GoogleHandlerTestDouble {
+      protected override getInlineUploadLimitBytes(): number {
+        return 1;
+      }
+    }
+
+    const handler = new LimitedInlineHandler(buildGoogleConfig(), clientStub);
+    const { logger, stub } = createLoggerStub();
+    handler.setLogger(logger);
+
+    const oversized = Buffer.from([0, 1]).toString('base64');
+    const entry: MediaEntry = {
+      file_name: 'large.pdf',
+      data: oversized,
+      media_type: 'application/pdf',
+      media_category: 'image',
+      source_path: '/tmp/large.pdf',
+    };
+
+    const parts = await handler.invokeUpload([entry]);
+
+    assert.deepEqual(parts, []);
+    assert.equal(stub.warnMessages.length, 1);
+    assert.match(stub.warnMessages[0] ?? '', /large\.pdf/);
+    assert.match(stub.warnMessages[0] ?? '', /provider quota exhausted/);
   });
 
   it('builds media entries once and delegates upload inside createMediaMessage', async () => {

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAINormalize.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAINormalize.vitest.ts
@@ -16,18 +16,22 @@ import { ModelHandlerKimi } from '@agent/modelHandlers/openai/modelHandlerKimi';
 type LoggerStub = Partial<AgentTrace> & {
   streamId: string;
   debugMessages: string[];
+  debugLogs: Array<{ message: string; options: unknown }>;
   infoMessages: string[];
 };
 
 function createLoggerStub(): LoggerStub {
   const debugMessages: string[] = [];
+  const debugLogs: Array<{ message: string; options: unknown }> = [];
   const infoMessages: string[] = [];
   return {
     streamId: 'test-channel',
     debugMessages,
+    debugLogs,
     infoMessages,
-    debug: (message: string) => {
+    debug: (message: string, options?: unknown) => {
       debugMessages.push(message);
+      debugLogs.push({ message, options });
     },
     info: (message: string) => {
       infoMessages.push(message);
@@ -165,8 +169,16 @@ describe('ModelHandlerOpenAI.normalizeMessages hook', () => {
       'assistant message should remain intact as string content',
     );
     assert.ok(
-      loggerStub.debugMessages.includes(
-        'Preprocessed message array from 3 to 2 messages for deepseek model compatibility',
+      loggerStub.debugLogs.some(
+        ({ message, options }) =>
+          message === 'Preprocessed message array for model compatibility' &&
+          typeof options === 'object' &&
+          options !== null &&
+          'data' in options &&
+          (options.data as Record<string, unknown>).beforeCount === 3 &&
+          (options.data as Record<string, unknown>).afterCount === 2 &&
+          (options.data as Record<string, unknown>).providerLabel ===
+            'deepseek',
       ),
     );
     assert.deepEqual(loggerStub.infoMessages, []);
@@ -205,8 +217,8 @@ describe('ModelHandlerOpenAI.normalizeMessages hook', () => {
         { role: 'assistant', content: 'Assistant reply' },
       ]);
       assert.equal(
-        loggerStub.debugMessages.some((entry) =>
-          entry.startsWith('Preprocessed message array'),
+        loggerStub.debugLogs.some(({ message }) =>
+          message.startsWith('Preprocessed message array'),
         ),
         false,
         'message count is unchanged, so no preprocessing log expected',

--- a/src/test-kernel/agent/modelHandlers/support/MediaAttachmentProcessor.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/support/MediaAttachmentProcessor.vitest.ts
@@ -24,6 +24,7 @@ import {
   MediaAttachmentProcessor,
   type MediaFileResult,
 } from '@agent/modelHandlers/support/MediaAttachmentProcessor';
+import { attachProviderError } from '@common/errors/sdkErrorUtils';
 
 // Type imports
 
@@ -299,5 +300,41 @@ describe('MediaAttachmentProcessor', () => {
       ],
       'should warn while loading and again when logging the failed batch',
     );
+  });
+
+  it('keeps SDK-specific media load errors in the visible log message', async () => {
+    const mediaPath = createTempFile('sdk-error.png', Buffer.from('not-png'));
+    const mediaLocation = pathToLocation(mediaPath);
+    const displayPath = getShortDisplayPath(mediaLocation);
+    const { logger, stub } = createLoggerStub();
+    const processor = createProcessor(logger, { supportsVision: true });
+    const originalExists = absoluteFsAny.exists;
+
+    const error = new Error('plain fallback');
+    attachProviderError(error, {
+      message: 'HTTP 429 Too Many Requests - provider body',
+      provider: 'openai',
+      statusCode: 429,
+      statusText: 'Too Many Requests',
+      userRetryable: true,
+    });
+
+    absoluteFsAny.exists = async () => {
+      throw error;
+    };
+
+    try {
+      const { entries, results } = await processor.loadEntries([mediaLocation]);
+
+      assert.equal(entries.length, 0);
+      assert.deepEqual(results, [{ path: displayPath, ok: false }]);
+      assert.equal(stub.errorMessages.length, 1);
+      assert.match(
+        stub.errorMessages[0] ?? '',
+        /HTTP 429 Too Many Requests - provider body/,
+      );
+    } finally {
+      absoluteFsAny.exists = originalExists;
+    }
   });
 });

--- a/src/test-kernel/cli/ToolsCommand.vitest.mts
+++ b/src/test-kernel/cli/ToolsCommand.vitest.mts
@@ -185,6 +185,28 @@ describe('CLI tools command', () => {
     expect(mocks.spawn).not.toHaveBeenCalled();
   });
 
+  it('rejects POSIX guide commands with shell operators instead of dropping them', async () => {
+    mocks.readCliToolGuide.mockReturnValueOnce({
+      text: 'Install help',
+      command: 'echo install && echo second-step',
+    });
+
+    const result = await runCli([
+      'tools',
+      'install',
+      'codex',
+      '--run',
+      '--print',
+      '--api-mode',
+      'personal',
+      '--no-color',
+    ]);
+
+    expect(result.exitCode).toBe(1);
+    expect(stdout).toBe('Install help\n');
+    expect(mocks.spawn).not.toHaveBeenCalled();
+  });
+
   it('emits structured auth guides without launching the external login', async () => {
     mocks.readCliToolGuide.mockReturnValueOnce({
       text: 'Auth help',

--- a/src/test-kernel/logger/LogUtils.vitest.ts
+++ b/src/test-kernel/logger/LogUtils.vitest.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import * as logger from '@logger/logUtils';
+import * as config from '@utils/config';
+
+describe('logUtils', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    logger.setOutputChannelFactory(null);
+  });
+
+  it('serializes self-referential array log data without recursing forever', () => {
+    vi.spyOn(config, 'getConfig').mockReturnValue(true);
+    const lines: string[] = [];
+    logger.setOutputChannelFactory(() => ({
+      appendLine(message: string) {
+        lines.push(message);
+      },
+    }));
+
+    const data: unknown[] = [];
+    data.push(data);
+
+    logger.debug('test', 'cyclic array payload', { data });
+
+    expect(lines.join('\n')).toContain('[Circular]');
+  });
+
+  it('does not mark repeated acyclic references as circular', () => {
+    vi.spyOn(config, 'getConfig').mockReturnValue(true);
+    const lines: string[] = [];
+    logger.setOutputChannelFactory(() => ({
+      appendLine(message: string) {
+        lines.push(message);
+      },
+    }));
+
+    const shared = { value: 1 };
+
+    logger.debug('test', 'shared payload', {
+      data: { first: shared, second: shared },
+    });
+
+    const output = lines.join('\n');
+    expect(output).not.toContain('[Circular]');
+    expect(output).toContain('"first"');
+    expect(output).toContain('"second"');
+  });
+});

--- a/src/test-kernel/model/ApiProviders.vitest.ts
+++ b/src/test-kernel/model/ApiProviders.vitest.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   apiKeyExistsUncached,
   apiKeySecretName,
+  hasUsableApiKey,
   invalidateApiKeyCache,
   loadApiKeyStatusMap,
   lookupApiKeyOrigin,
@@ -148,6 +149,20 @@ describe('API provider key caches', () => {
     const { secrets } = createSecrets({}, { OPENAI_API_KEY: '' });
 
     await expect(apiKeyExistsUncached(secrets, 'openai')).resolves.toBe(false);
+  });
+
+  it('checks usable keys through the canonical resolver', async () => {
+    const { secrets } = createSecrets(
+      { [apiKeySecretName('openai')]: '   ' },
+      { OPENAI_API_KEY: 'from-env' },
+    );
+
+    await expect(hasUsableApiKey(secrets, 'openai')).resolves.toBe(false);
+
+    invalidateApiKeyCache();
+    await secrets.delete(apiKeySecretName('openai'));
+
+    await expect(hasUsableApiKey(secrets, 'openai')).resolves.toBe(true);
   });
 
   it('set_api_key invalidates stale missing-key lookups', async () => {

--- a/src/tools/agentCliSessionLoop.ts
+++ b/src/tools/agentCliSessionLoop.ts
@@ -192,9 +192,9 @@ async function persistReportBestEffort(
   try {
     await getExecutionStore(executionId).writeReport(msg);
   } catch (storageErr) {
-    logger.warn(
-      `Failed to persist report for ${executionId}: ${toErrorMessage(storageErr)}`,
-    );
+    logger.warn(`Failed to persist report for ${executionId}`, {
+      data: storageErr,
+    });
   }
 }
 
@@ -289,13 +289,21 @@ export function runAgentCliSession<TTurn>(
         );
         if (delivery.status === 'no_session') {
           logger.warn(
-            `Turn result for ${executionId} not delivered: parent stream ${parentStreamId} has no active session (status: ${delivery.streamStatus ?? 'unknown'}). The result remains in the execution report.`,
+            'Turn result not delivered: parent stream has no active session. The result remains in the execution report.',
+            {
+              data: {
+                executionId,
+                parentStreamId,
+                streamStatus: delivery.streamStatus ?? 'unknown',
+              },
+            },
           );
         } else if (
           !(await wakeOrReleaseQueuedStream(parentStreamId, delivery))
         ) {
           logger.warn(
-            `Turn result for ${executionId} dropped: parent stream ${parentStreamId} is gone and could not be resumed. The result remains in the execution report.`,
+            'Turn result dropped: parent stream is gone and could not be resumed. The result remains in the execution report.',
+            { data: { executionId, parentStreamId } },
           );
         }
 

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -132,9 +132,12 @@ export function logTurnSummary(
 ): void {
   logger.info(`Turn completed in ${formatDuration(wallTimeMs)}`);
   if (usage) {
-    logger.info(
-      `Tokens: ${usage.input_tokens ?? 0} in / ${usage.output_tokens ?? 0} out`,
-    );
+    logger.info('Tokens', {
+      data: {
+        input: usage.input_tokens ?? 0,
+        output: usage.output_tokens ?? 0,
+      },
+    });
   }
 }
 

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -20,7 +20,6 @@ import { currentSession } from '@agent/runtime/SessionHandle';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { sendFollowUp } from '@agent/followUp/ToolUseFollowUp';
-import { toErrorMessage } from '@common/errors';
 import {
   deriveRunOutcome,
   projectRunOutcome,
@@ -324,15 +323,21 @@ export class BashTool extends defineTool({
       );
       if (result.status === 'no_session') {
         logger.debug(
-          `Background bash follow-up dropped: parent stream ${parentStreamId} has no active session (${result.streamStatus ?? 'unknown'}).`,
+          'Background bash follow-up dropped: parent stream has no active session.',
+          {
+            data: {
+              parentStreamId,
+              streamStatus: result.streamStatus ?? 'unknown',
+            },
+          },
         );
       }
     };
 
     const logBackgroundFailure = (action: string, err: unknown): void => {
-      logger.error(
-        `Failed to ${action} background bash result: ${toErrorMessage(err)}`,
-      );
+      logger.error(`Failed to ${action} background bash result`, {
+        data: err,
+      });
     };
 
     const deliverAndFinalize = async (

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -171,9 +171,12 @@ function finalizeChildStream(args: FinalizeChildStreamArgs): void {
     logger.info(`Completed in ${formatDuration(options.wallTimeMs)}`);
   }
   if (options?.usage) {
-    logger.info(
-      `Tokens: ${options.usage.input_tokens} in / ${options.usage.output_tokens} out`,
-    );
+    logger.info('Tokens', {
+      data: {
+        input: options.usage.input_tokens,
+        output: options.usage.output_tokens,
+      },
+    });
   }
 
   // The terminal status the child finishes with — the single source of truth

--- a/src/tools/delegation/inputFields.ts
+++ b/src/tools/delegation/inputFields.ts
@@ -44,8 +44,7 @@ export const memoriesField = z
         ctx.addIssue({
           code: 'custom',
           path: [i],
-          message:
-            e instanceof Error ? e.message : `Invalid memory path: ${memory}`,
+          message: toErrorMessage(e),
         });
       }
     }

--- a/src/tools/delegation/inputFields.ts
+++ b/src/tools/delegation/inputFields.ts
@@ -44,7 +44,10 @@ export const memoriesField = z
         ctx.addIssue({
           code: 'custom',
           path: [i],
-          message: toErrorMessage(e),
+          message:
+            e instanceof Error
+              ? toErrorMessage(e)
+              : `Invalid memory path: ${memory}`,
         });
       }
     }

--- a/src/tools/github/IssuePollingSource.ts
+++ b/src/tools/github/IssuePollingSource.ts
@@ -14,8 +14,6 @@
  * file only owns the per-issue endpoint set and the dedup state.
  */
 
-import { z } from 'zod';
-
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 
 import { shouldDropBotEvent } from './botFilter';
@@ -186,8 +184,8 @@ class IssuePollingSource extends PollingSourceBase<string, SubscriptionState> {
         state.state = newState;
       } else {
         this.logger.warn(
-          `Skipping issue-state check for ${state.slug}#${issue.issueNumber}: ` +
-            `malformed issue payload: ${z.prettifyError(parsedIssue.error)}`,
+          `Skipping issue-state check for ${state.slug}#${issue.issueNumber}: malformed issue payload`,
+          { data: parsedIssue.error },
         );
       }
     }
@@ -205,8 +203,8 @@ class IssuePollingSource extends PollingSourceBase<string, SubscriptionState> {
       );
       if (!parsedComments.success) {
         this.logger.warn(
-          `Skipping comments tick for ${state.slug}#${issue.issueNumber}: ` +
-            `malformed comments payload: ${z.prettifyError(parsedComments.error)}`,
+          `Skipping comments tick for ${state.slug}#${issue.issueNumber}: malformed comments payload`,
+          { data: parsedComments.error },
         );
         return;
       }

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -795,9 +795,12 @@ export class PRPollingSource extends PollingSourceBase<
         return true;
       }
       if (err instanceof GitHubAuthError) {
-        this.logger.warn(`Annotations for check ${run.id} forbidden; dropping.`, {
-          data: err,
-        });
+        this.logger.warn(
+          `Annotations for check ${run.id} forbidden; dropping.`,
+          {
+            data: err,
+          },
+        );
         this.removePendingAnnotationRun(state, run.id);
         return true;
       }

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -11,8 +11,6 @@
  * layer above.
  */
 
-import { z } from 'zod';
-
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { getConfig } from '@utils/config';
 import { shouldDropBotEvent } from './botFilter';
@@ -329,7 +327,8 @@ export class PRPollingSource extends PollingSourceBase<
       const parsed = GhPullRequestSchema.safeParse(prRes.data);
       if (!parsed.success) {
         this.logger.warn(
-          `Skipping PR poll for ${prKeyToString(pr)}: malformed pull-request payload; ${z.prettifyError(parsed.error)}`,
+          `Skipping PR poll for ${prKeyToString(pr)}: malformed pull-request payload`,
+          { data: parsed.error },
         );
         return;
       }
@@ -789,22 +788,24 @@ export class PRPollingSource extends PollingSourceBase<
       if (err instanceof GitHubRateLimitError) throw err;
       if (err instanceof GitHubPermanentError) {
         this.logger.warn(
-          `Annotations for check ${run.id} unavailable (HTTP ${err.status}); dropping.`,
+          `Annotations for check ${run.id} unavailable; dropping.`,
+          { data: err },
         );
         this.removePendingAnnotationRun(state, run.id);
         return true;
       }
       if (err instanceof GitHubAuthError) {
-        this.logger.warn(
-          `Annotations for check ${run.id} forbidden (${err.message}); dropping.`,
-        );
+        this.logger.warn(`Annotations for check ${run.id} forbidden; dropping.`, {
+          data: err,
+        });
         this.removePendingAnnotationRun(state, run.id);
         return true;
       }
       this.removePendingAnnotationRun(state, run.id);
       state.pendingAnnotationRuns.push(run);
       this.logger.warn(
-        `Annotation fetch for check ${run.id} failed; rotating to back of queue: ${String(err)}`,
+        `Annotation fetch for check ${run.id} failed; rotating to back of queue`,
+        { data: err },
       );
       return true;
     }
@@ -849,7 +850,7 @@ export class PRPollingSource extends PollingSourceBase<
           ),
         );
       } catch (err) {
-        this.logger.warn(`Listener threw: ${String(err)}`);
+        this.logger.warn('Listener threw', { data: err });
       }
     }
   }

--- a/src/tools/github/PollingSourceBase.ts
+++ b/src/tools/github/PollingSourceBase.ts
@@ -163,7 +163,7 @@ export abstract class PollingSourceBase<
       try {
         cb(text);
       } catch (err) {
-        this.logger.warn(`Listener threw: ${String(err)}`);
+        this.logger.warn('Listener threw', { data: err });
       }
     }
   }
@@ -207,7 +207,7 @@ export abstract class PollingSourceBase<
       try {
         listener(keys);
       } catch (err) {
-        this.logger.warn(`Keys-changed listener threw: ${String(err)}`);
+        this.logger.warn('Keys-changed listener threw', { data: err });
       }
     }
     this.emitKeysChangedEvent(keys, unique(runtimeHosts));
@@ -290,16 +290,16 @@ export abstract class PollingSourceBase<
     try {
       await this.afterTick(entries, now);
     } catch (err) {
-      this.logger.warn(`Post-poll hook failed: ${String(err)}`);
+      this.logger.warn('Post-poll hook failed', { data: err });
     }
   }
 
   protected handleFailure(key: K, state: S, err: unknown): void {
     const now = Date.now();
     if (err instanceof GitHubAuthError) {
-      this.logger.warn(
-        `Auth error for ${key}; stopping subscription. ${err.message}`,
-      );
+      this.logger.warn(`Auth error for ${key}; stopping subscription.`, {
+        data: err,
+      });
       this.emit(state, this.formatErrorEvent(key, state, err.message));
       this.emitToStateHosts(state, 'githubTokenInvalid', {
         message: err.message,
@@ -308,9 +308,9 @@ export abstract class PollingSourceBase<
       return;
     }
     if (err instanceof GitHubPermanentError) {
-      this.logger.warn(
-        `Permanent error for ${key} (HTTP ${err.status}); stopping subscription. ${err.message}`,
-      );
+      this.logger.warn(`Permanent error for ${key}; stopping subscription.`, {
+        data: err,
+      });
       this.emitErrorAndDetach(key, state, err.message);
       return;
     }
@@ -349,8 +349,8 @@ export abstract class PollingSourceBase<
     state.skipPollUntilMs = now + actualDelayMs;
     if (now - state.lastSuccessAt >= this.config.maxFailureDurationMs) {
       this.logger.warn(
-        `Poll failed for ${key} (failure #${state.consecutiveFailures}); ` +
-          `unreachable for over 24 h, detaching: ${String(err)}`,
+        `Poll failed for ${key}; unreachable for over 24 h, detaching.`,
+        { data: { failureCount: state.consecutiveFailures, error: err } },
       );
       this.emitErrorAndDetach(
         key,
@@ -359,9 +359,12 @@ export abstract class PollingSourceBase<
       );
       return;
     }
-    this.logger.warn(
-      `Poll failed for ${key} (failure #${state.consecutiveFailures}, ` +
-        `retrying in ${Math.round(actualDelayMs / 1000)}s): ${String(err)}`,
-    );
+    this.logger.warn(`Poll failed for ${key}; retrying.`, {
+      data: {
+        failureCount: state.consecutiveFailures,
+        retryInSec: Math.round(actualDelayMs / 1000),
+        error: err,
+      },
+    });
   }
 }

--- a/src/tools/github/RepoPollingSource.ts
+++ b/src/tools/github/RepoPollingSource.ts
@@ -34,8 +34,6 @@
  * - **CI / check-run status and inline annotations.** Per-PR by design.
  */
 
-import { z } from 'zod';
-
 import { LRUCache } from 'lru-cache';
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
@@ -239,7 +237,8 @@ class RepoPollingSource extends PollingSourceBase<RepoKey, SubscriptionState> {
       const parsed = GhIssueCommentArraySchema.safeParse(issueRes.data);
       if (!parsed.success) {
         this.logger.warn(
-          `Skipping ${owner}/${repo} tick: issue-comments payload failed validation: ${z.prettifyError(parsed.error)}`,
+          `Skipping ${owner}/${repo} tick: issue-comments payload failed validation`,
+          { data: parsed.error },
         );
         return;
       }
@@ -249,7 +248,8 @@ class RepoPollingSource extends PollingSourceBase<RepoKey, SubscriptionState> {
       const parsed = GhReviewCommentArraySchema.safeParse(reviewRes.data);
       if (!parsed.success) {
         this.logger.warn(
-          `Skipping ${owner}/${repo} tick: review-comments payload failed validation: ${z.prettifyError(parsed.error)}`,
+          `Skipping ${owner}/${repo} tick: review-comments payload failed validation`,
+          { data: parsed.error },
         );
         return;
       }
@@ -259,7 +259,8 @@ class RepoPollingSource extends PollingSourceBase<RepoKey, SubscriptionState> {
       const parsed = GhPullsListEntryArraySchema.safeParse(pullsRes.data);
       if (!parsed.success) {
         this.logger.warn(
-          `Skipping ${owner}/${repo} tick: pulls-list payload failed validation: ${z.prettifyError(parsed.error)}`,
+          `Skipping ${owner}/${repo} tick: pulls-list payload failed validation`,
+          { data: parsed.error },
         );
         return;
       }
@@ -422,7 +423,8 @@ class RepoPollingSource extends PollingSourceBase<RepoKey, SubscriptionState> {
         const parsed = GhPullRequestSchema.safeParse(res.data);
         if (!parsed.success) {
           this.logger.warn(
-            `Skipping merge probe for ${state.owner}/${state.repo}#${pr.number}: payload failed validation: ${z.prettifyError(parsed.error)}`,
+            `Skipping merge probe for ${state.owner}/${state.repo}#${pr.number}: payload failed validation`,
+            { data: parsed.error },
           );
           return undefined;
         }

--- a/src/tools/github/StreamSubscriptionRegistry.ts
+++ b/src/tools/github/StreamSubscriptionRegistry.ts
@@ -275,7 +275,7 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
     try {
       d.dispose();
     } catch (err) {
-      this.logger.warn(`Disposer threw during ${context}: ${String(err)}`);
+      this.logger.warn(`Disposer threw during ${context}`, { data: err });
     }
   }
 

--- a/src/tools/github/checkRunsClient.ts
+++ b/src/tools/github/checkRunsClient.ts
@@ -223,16 +223,19 @@ export async function fetchAllCheckRuns(
   const seedTotal = latestTotal ?? cache?.lastTotalCount ?? 0;
   let totalPages = Math.max(1, Math.ceil(seedTotal / CHECK_RUNS_PAGE_SIZE));
   if (totalPages > MAX_CHECK_RUNS_PAGES) {
-    logger.warn(
-      `Pagination cap hit for ${owner}/${repo}@${sha.slice(0, 7)} check-runs: ` +
-        `total_count=${seedTotal} would need ${totalPages} pages, capping at ${MAX_CHECK_RUNS_PAGES}.`,
-    );
+    logger.warn(`Pagination cap hit for ${owner}/${repo}@${sha.slice(0, 7)} check-runs.`, {
+      data: {
+        totalCount: seedTotal,
+        neededPages: totalPages,
+        cappedAt: MAX_CHECK_RUNS_PAGES,
+      },
+    });
     totalPages = MAX_CHECK_RUNS_PAGES;
   }
   if (totalPages > 1) {
-    logger.info(
-      `Pagination: ${owner}/${repo}@${sha.slice(0, 7)} check-runs total_count=${seedTotal} → ${totalPages} pages`,
-    );
+    logger.info(`Pagination for ${owner}/${repo}@${sha.slice(0, 7)} check-runs.`, {
+      data: { totalCount: seedTotal, totalPages },
+    });
   }
 
   let page = 2;
@@ -254,8 +257,14 @@ export async function fetchAllCheckRuns(
       );
       if (newTotalPages > MAX_CHECK_RUNS_PAGES) {
         logger.warn(
-          `Pagination cap hit mid-walk for ${owner}/${repo}@${sha.slice(0, 7)} check-runs: ` +
-            `total_count is ${latestTotal} (${newTotalPages} pages), capping at ${MAX_CHECK_RUNS_PAGES}.`,
+          `Pagination cap hit mid-walk for ${owner}/${repo}@${sha.slice(0, 7)} check-runs.`,
+          {
+            data: {
+              totalCount: latestTotal,
+              neededPages: newTotalPages,
+              cappedAt: MAX_CHECK_RUNS_PAGES,
+            },
+          },
         );
         totalPages = MAX_CHECK_RUNS_PAGES;
       } else {

--- a/src/tools/github/checkRunsClient.ts
+++ b/src/tools/github/checkRunsClient.ts
@@ -223,19 +223,25 @@ export async function fetchAllCheckRuns(
   const seedTotal = latestTotal ?? cache?.lastTotalCount ?? 0;
   let totalPages = Math.max(1, Math.ceil(seedTotal / CHECK_RUNS_PAGE_SIZE));
   if (totalPages > MAX_CHECK_RUNS_PAGES) {
-    logger.warn(`Pagination cap hit for ${owner}/${repo}@${sha.slice(0, 7)} check-runs.`, {
-      data: {
-        totalCount: seedTotal,
-        neededPages: totalPages,
-        cappedAt: MAX_CHECK_RUNS_PAGES,
+    logger.warn(
+      `Pagination cap hit for ${owner}/${repo}@${sha.slice(0, 7)} check-runs.`,
+      {
+        data: {
+          totalCount: seedTotal,
+          neededPages: totalPages,
+          cappedAt: MAX_CHECK_RUNS_PAGES,
+        },
       },
-    });
+    );
     totalPages = MAX_CHECK_RUNS_PAGES;
   }
   if (totalPages > 1) {
-    logger.info(`Pagination for ${owner}/${repo}@${sha.slice(0, 7)} check-runs.`, {
-      data: { totalCount: seedTotal, totalPages },
-    });
+    logger.info(
+      `Pagination for ${owner}/${repo}@${sha.slice(0, 7)} check-runs.`,
+      {
+        data: { totalCount: seedTotal, totalPages },
+      },
+    );
   }
 
   let page = 2;

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -184,9 +184,9 @@ export async function handleExternalInquiryAction(
 
   // drop — only flips status if the thread is still open; see markDropped.
   if (payload.feedback) {
-    logger.info(
-      `Inquiry ${payload.threadId} dropped with feedback: ${payload.feedback}`,
-    );
+    logger.info(`Inquiry ${payload.threadId} dropped with feedback`, {
+      data: payload.feedback,
+    });
   }
   const droppedManifest = await markDropped({ threadId: payload.threadId });
   emitRuntimeEvent(
@@ -337,9 +337,9 @@ export class ExternalInquiryTool extends defineTool({
       );
     }
 
-    logger.info(
-      `Inquiry dispatch [${input.thread_id ?? 'new'}]: ${input.question.slice(0, 100)}...`,
-    );
+    logger.info(`Inquiry dispatch [${input.thread_id ?? 'new'}]`, {
+      data: input.question.slice(0, 100),
+    });
 
     const persisted = await recordOpenQuestion({
       threadId: input.thread_id ?? undefined,
@@ -363,7 +363,8 @@ export class ExternalInquiryTool extends defineTool({
         });
       } catch (err) {
         logger.warn(
-          `Failed to mirror inquiry thread ${persisted.threadId} to execution ${executionId}: ${String(err)}`,
+          `Failed to mirror inquiry thread ${persisted.threadId} to execution ${executionId}`,
+          { data: err },
         );
       }
     }

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -293,7 +293,11 @@ Best practices:
       ? `\nUser feedback: ${feedback}`
       : '\nNo specific feedback was provided.';
 
-    logger.info(`Plan rejected by user${feedback ? `: ${feedback}` : ''}`);
+    if (feedback) {
+      logger.info('Plan rejected by user', { data: feedback });
+    } else {
+      logger.info('Plan rejected by user');
+    }
 
     return {
       summary: 'Plan rejected — revise approach',
@@ -360,7 +364,8 @@ Best practices:
       } catch (err) {
         const reason = toErrorMessage(err);
         logger.warn(
-          `Failed to retarget in-flight goal for approved plan; returning an explicit error result. ${reason}`,
+          'Failed to retarget in-flight goal for approved plan; returning an explicit error result.',
+          { data: err },
         );
         return {
           summary:
@@ -394,7 +399,8 @@ Best practices:
     } catch (err) {
       const reason = toErrorMessage(err);
       logger.warn(
-        `Failed to start goal for approved plan; falling back to plain approval. ${reason}`,
+        'Failed to start goal for approved plan; falling back to plain approval.',
+        { data: err },
       );
       return {
         summary:

--- a/src/tools/userQuestion/UserQuestionTool.ts
+++ b/src/tools/userQuestion/UserQuestionTool.ts
@@ -138,9 +138,9 @@ The tool returns a JSON object whose keys are the original question texts and wh
     const streamId = context?.streamId;
     const requestId = `user-question-${nanoid()}`;
 
-    logger.info(
-      `User question requested: ${input.questions[0]?.question.slice(0, 100) ?? ''}`,
-    );
+    logger.info('User question requested', {
+      data: input.questions[0]?.question.slice(0, 100) ?? '',
+    });
 
     try {
       const result = await awaitUserQuestionResponse({

--- a/src/transcript/streamSnapshotRead.ts
+++ b/src/transcript/streamSnapshotRead.ts
@@ -136,10 +136,9 @@ export async function readStreamData(kv: KVStore): Promise<StreamData> {
     if (raw === undefined) return new Map() as T;
     const wasLegacy = isLegacyNested(raw);
     if (wasLegacy) legacyKeys.push(key);
-    const parsed = schema.safeParse(
-      wasLegacy ? flattenLegacyRuns(raw, activeRunId) : raw,
-    );
-    return parsed.success ? parsed.data : (new Map() as T);
+    return schema
+      .catch(new Map() as T)
+      .parse(wasLegacy ? flattenLegacyRuns(raw, activeRunId) : raw);
   };
 
   const [outputFiles, missingOutputs, compileFailures] = await Promise.all([
@@ -149,11 +148,7 @@ export async function readStreamData(kv: KVStore): Promise<StreamData> {
   ]);
 
   const usageRaw = await tryRead(kv, STREAM_DATA_KEYS.USAGE_STATS);
-  const usageParsed =
-    usageRaw === undefined ? undefined : UsageDataSchema.safeParse(usageRaw);
-  const usage = usageParsed?.success
-    ? usageParsed.data
-    : new Map<string, TokenUsageStats>();
+  const usage = UsageDataSchema.parse(usageRaw);
 
   const workPlan = readPersistedWorkPlan(
     await tryRead(kv, STREAM_DATA_KEYS.WORK_PLAN),

--- a/src/transcript/streamSnapshotRead.ts
+++ b/src/transcript/streamSnapshotRead.ts
@@ -131,24 +131,41 @@ export async function readStreamData(kv: KVStore): Promise<StreamData> {
   const flatten = async <T extends Map<number, unknown[]>>(
     key: string,
     schema: z.ZodType<T>,
+    fallback: () => T,
   ): Promise<T> => {
     const raw = await tryRead(kv, key);
-    if (raw === undefined) return new Map() as T;
+    if (raw === undefined) return fallback();
     const wasLegacy = isLegacyNested(raw);
     if (wasLegacy) legacyKeys.push(key);
-    return schema
-      .catch(new Map() as T)
-      .parse(wasLegacy ? flattenLegacyRuns(raw, activeRunId) : raw);
+    return (
+      schema
+        .nullable()
+        .catch(null)
+        .parse(wasLegacy ? flattenLegacyRuns(raw, activeRunId) : raw) ??
+      fallback()
+    );
   };
 
   const [outputFiles, missingOutputs, compileFailures] = await Promise.all([
-    flatten(STREAM_DATA_KEYS.OUTPUT_FILES, OutputFilesDataSchema),
-    flatten(STREAM_DATA_KEYS.MISSING_OUTPUTS, MissingOutputsDataSchema),
-    flatten(STREAM_DATA_KEYS.COMPILE_FAILURES, CompileFailuresDataSchema),
+    flatten(
+      STREAM_DATA_KEYS.OUTPUT_FILES,
+      OutputFilesDataSchema,
+      () => new Map<number, OutputFileInfo[]>(),
+    ),
+    flatten(
+      STREAM_DATA_KEYS.MISSING_OUTPUTS,
+      MissingOutputsDataSchema,
+      () => new Map<number, string[]>(),
+    ),
+    flatten(
+      STREAM_DATA_KEYS.COMPILE_FAILURES,
+      CompileFailuresDataSchema,
+      () => new Map<number, CompileFailure[]>(),
+    ),
   ]);
 
   const usageRaw = await tryRead(kv, STREAM_DATA_KEYS.USAGE_STATS);
-  const usage = UsageDataSchema.parse(usageRaw);
+  const usage = UsageDataSchema.catch(new Map()).parse(usageRaw);
 
   const workPlan = readPersistedWorkPlan(
     await tryRead(kv, STREAM_DATA_KEYS.WORK_PLAN),

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -185,6 +185,8 @@ export async function executeCommand(
     onPid?: (pid: number) => void;
     /** Set to false to skip buffering stdout/stderr in memory (use with onStdout/onStderr). */
     buffer?: boolean;
+    stdout?: Options['stdout'];
+    stderr?: Options['stderr'];
     /** Abort signal used to terminate the subprocess and any shell children. */
     signal?: AbortSignal;
   } = {},
@@ -219,6 +221,8 @@ export async function executeCommand(
       reject: false,
       input: options.stdin,
       buffer: options.buffer,
+      stdout: options.stdout,
+      stderr: options.stderr,
     };
 
     const logChannel = options.channel ?? CHANNEL;


### PR DESCRIPTION
## Summary

This PR is a focused quality pass over error reporting, logging, platform access, and small declarative state/schema refactors.

- Standardize caught-error rendering through `toErrorMessage()` and keep non-`Error` fallback messages where callers intentionally had one.
- Move noisy string-built logs toward structured logger data, including model-handler failures, media attachment failures, output-file warnings, and agent directory sync diagnostics.
- Avoid duplicate user-facing/logged errors in validation paths; each failure now has one owner for the log entry and one owner for the toast when needed.
- Keep startup-sensitive CLI and skill-loading paths on direct Node APIs where the platform layer is not initialized yet, with comments/tests covering the boundary.
- Express API-key resolution and workspace snapshot loading more declaratively: model key selection is rule-based, workspace snapshots use current/legacy Zod schemas, and API-key usability now delegates to the canonical `apiProviders.ts` resolver.
- Remove the duplicate AI Agents-tab re-check action and use the shared dashboard availability state instead.

## Validation

- `corepack pnpm exec eslint packages/extension/src/commands/agent/executeCommand.ts src/model/apiProviders.ts packages/extension/src/frontend/secretManager.ts packages/extension/src/extension.ts src/test-kernel/model/ApiProviders.vitest.ts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/model/ApiProviders.vitest.ts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/agent/modelHandlers/AnthropicStreamFailureLogging.vitest.ts src/test-kernel/agent/modelHandlers/ModelHandlerOpenAINormalize.vitest.ts src/test-kernel/agent/output/XmlOutputManager.vitest.ts`
- `corepack pnpm exec tsc --noEmit -p tsconfig.json --pretty false`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many user-facing error paths, API-key gating, and CLI subprocess launching on POSIX; regressions could affect sign-in/setup messaging or interactive tool installs, though changes are mostly observability and consolidation.
> 
> **Overview**
> This PR **standardizes how failures are logged and shown** across the VS Code extension: many command and UI paths now route validation and operational errors through `showLoggedMessage` / `showLoggedErrorMessage` (with channel-scoped logging) instead of raw `vscode.window.showErrorMessage`, and auth/tool/GitHub paths gain explicit `logger.error` where messages were previously user-only.
> 
> **Agent and model-handler logging** shifts from long interpolated debug/warn strings toward structured `{ data: ... }` payloads (errors, token diagnostics, media attachments, compaction, background polling, etc.), with `logErrorData` / `logSdkError` messages trimmed so error detail lives in `data` rather than duplicated in the line text. Browser launch and several UI surfaces also adopt `toErrorMessage()` for consistent `Error` rendering.
> 
> **Platform and CLI subprocess behavior** is clarified and slightly adjusted: macOS Terminal setup uses `executeCommand` with timeout; CLI `shellRun` parses registry commands with `shell-quote` and spawns argv on POSIX while keeping shell mode on Windows for `.cmd` shims; remaining raw `spawn`/`spawnSync`/`execFile` sites document why they need inherit TTY, `maxBuffer`, or detached processes. **API key usability** in `SecretManager` and setup wiring now delegates to canonical `hasUsableApiKey` from `@model/apiProviders` instead of ad-hoc `lookupApiKey` + whitespace checks.
> 
> The **AI Agents settings tab** drops its duplicate “Re-check” control and shows a read-only availability summary derived from the same `toolDashboardItems` state the Tools tab owns. Minor schema/UI tweaks include tolerant `CodexMcpToolOutput` parsing via Zod `.catch(null)` and optional `child.stdout` handling in the update checker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47dab65d48cb7719b854d43db7556be87a8ba78a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->