### PR TITLE
Refactor: extract shared logic and consolidate command definitions

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -199,6 +199,18 @@ export function createChatSessionController(
     });
   };
 
+  // Shared tail of the run/resume `.catch()` handlers: surface the error to
+  // the local transcript unless the run was stopped intentionally, and set
+  // the exit code accordingly.
+  const reportRunFailure = (error: unknown): void => {
+    if (!session.stopRequested) {
+      appendLocalErrorTranscript(toErrorMessage(error));
+    }
+    session.runExitCode = session.stopRequested
+      ? CliExitCode.Success
+      : CliExitCode.AgentError;
+  };
+
   // Build the wrapped runtime host shared by start and resume: attach the
   // terminal-result toast and the TUI approval pipeline, and return a
   // `finalize` teardown that both run promises invoke from their `.finally`.
@@ -302,12 +314,7 @@ export function createChatSessionController(
           executionRegistered,
           agentSettled,
         });
-        if (!session.stopRequested) {
-          appendLocalErrorTranscript(toErrorMessage(error));
-        }
-        session.runExitCode = session.stopRequested
-          ? CliExitCode.Success
-          : CliExitCode.AgentError;
+        reportRunFailure(error);
       })
       .finally(finalize);
     markChatTuiRunPending(session, runPromise, wrapped);
@@ -389,14 +396,7 @@ export function createChatSessionController(
         session.runExitCode = CliExitCode.Success;
         notify({ kind: 'agentFinished' });
       })
-      .catch((error: unknown) => {
-        if (!session.stopRequested) {
-          appendLocalErrorTranscript(toErrorMessage(error));
-        }
-        session.runExitCode = session.stopRequested
-          ? CliExitCode.Success
-          : CliExitCode.AgentError;
-      })
+      .catch(reportRunFailure)
       .finally(finalize);
     publishChatTuiRootRunStartAvailability(session);
   };

--- a/packages/extension/src/progressView/frontend/components/LogList.ts
+++ b/packages/extension/src/progressView/frontend/components/LogList.ts
@@ -35,6 +35,7 @@ import { postMessage } from '@shared/hostBridge';
 import { ToggleStateStore } from '@shared/state/ToggleStateStore';
 import { copyWithFeedback } from '@shared/utils/clipboard';
 import { webviewStorage } from '../webviewStorage';
+import { getComposedPathElement } from '../utils';
 
 // Local imports - progress view contexts
 import {
@@ -255,7 +256,7 @@ export class LogList extends LitElement {
     if (this.activateLinkFromEvent(event)) return;
 
     // Handle copy buttons - content is stored in the copy registry
-    const copyButton = this.findTargetInPath<HTMLElement>(
+    const copyButton = getComposedPathElement<HTMLElement>(
       event,
       '[data-copy-id]',
     );
@@ -288,7 +289,7 @@ export class LogList extends LitElement {
     if (event.key !== 'Enter' && event.key !== ' ') return;
     if (event.defaultPrevented) return;
     if (
-      !this.findTargetInPath<Element>(
+      !getComposedPathElement<Element>(
         event,
         '.file-link, .latex-ref, .proposal-restore-link',
       )
@@ -304,7 +305,7 @@ export class LogList extends LitElement {
    * click or keydown event. Returns true when one was handled.
    */
   private activateLinkFromEvent(event: Event): boolean {
-    const fileLink = this.findTargetInPath<HTMLElement>(event, '.file-link');
+    const fileLink = getComposedPathElement<HTMLElement>(event, '.file-link');
     if (fileLink?.dataset.file) {
       postMessage(PROGRESS_VIEW_COMMANDS.OPEN_FILE, {
         file: fileLink.dataset.file,
@@ -315,7 +316,7 @@ export class LogList extends LitElement {
       return true;
     }
 
-    const latexRef = this.findTargetInPath<HTMLElement>(event, '.latex-ref');
+    const latexRef = getComposedPathElement<HTMLElement>(event, '.latex-ref');
     if (latexRef?.dataset.label) {
       postMessage(PROGRESS_VIEW_COMMANDS.OPEN_LABEL, {
         label: latexRef.dataset.label,
@@ -324,7 +325,7 @@ export class LogList extends LitElement {
     }
 
     // Handle proposal restore links (may be inside <summary>, so prevent toggle)
-    const proposalLink = this.findTargetInPath<HTMLElement>(
+    const proposalLink = getComposedPathElement<HTMLElement>(
       event,
       '.proposal-restore-link',
     );
@@ -339,18 +340,6 @@ export class LogList extends LitElement {
       return true;
     }
     return false;
-  }
-
-  private findTargetInPath<T extends Element>(
-    event: Event,
-    selector: string,
-  ): T | null {
-    for (const node of event.composedPath()) {
-      if (node instanceof Element && node.matches(selector)) {
-        return node as T;
-      }
-    }
-    return null;
   }
 
   /** Handle file-click events from Shadow DOM components. */

--- a/src/agent/runtime/SessionResumeRetrieval.ts
+++ b/src/agent/runtime/SessionResumeRetrieval.ts
@@ -56,20 +56,18 @@ type WorkflowResumeData = z.infer<typeof WorkflowResumeDataSchema>;
 
 export type SessionResumeData = ToolUseResumeData | WorkflowResumeData;
 
+/** Fields shared by both `messages` (current) and `conversation` (legacy) branches. */
+const SharedToolUseFields = z.object({
+  modelHandlerCompatibilityKey: ModelHandlerCompatibilityKeySchema.nullish(),
+  stateSlices: StateSlicesSchema,
+});
+
 /** Core fields schema — accepts `messages` (current) or `conversation` (legacy), normalizing to `messages`. */
 const ToolUseStateFieldsSchema = z
   .union([
-    z.object({
-      messages: z.array(ProviderMessageSchema),
-      modelHandlerCompatibilityKey:
-        ModelHandlerCompatibilityKeySchema.nullish(),
-      stateSlices: StateSlicesSchema,
-    }),
-    z.object({
+    SharedToolUseFields.extend({ messages: z.array(ProviderMessageSchema) }),
+    SharedToolUseFields.extend({
       conversation: z.array(ProviderMessageSchema),
-      modelHandlerCompatibilityKey:
-        ModelHandlerCompatibilityKeySchema.nullish(),
-      stateSlices: StateSlicesSchema,
     }),
   ])
   .transform((data) => ({

--- a/src/common/errors/errorPredicates.ts
+++ b/src/common/errors/errorPredicates.ts
@@ -20,14 +20,30 @@ export function isModuleNotFoundError(err: unknown): boolean {
   return code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND';
 }
 
-/** Check if an error represents a "no space left on device" condition. */
-export function isDiskFullError(err: unknown): boolean {
+/** Walks `err` and its `cause` chain, returning the first defined result of
+ *  `extract`, or `undefined` if none of the nodes match. Shared traversal for
+ *  predicates/metadata lookups that may be attached at any depth of a wrapped
+ *  error's cause chain. */
+export function findInCauseChain<T>(
+  err: unknown,
+  extract: (node: unknown) => T | undefined,
+): T | undefined {
   for (
     let current: unknown = err;
     current != null && typeof current === 'object';
     current = (current as { cause?: unknown }).cause
   ) {
-    if ((current as { code?: string }).code === 'ENOSPC') return true;
+    const result = extract(current);
+    if (result !== undefined) return result;
   }
-  return false;
+  return undefined;
+}
+
+/** Check if an error represents a "no space left on device" condition. */
+export function isDiskFullError(err: unknown): boolean {
+  return (
+    findInCauseChain(err, (current) =>
+      (current as { code?: string }).code === 'ENOSPC' ? true : undefined,
+    ) ?? false
+  );
 }

--- a/src/common/files/fileListingRules.ts
+++ b/src/common/files/fileListingRules.ts
@@ -91,22 +91,29 @@ export function loadFileListSettings(
   };
 }
 
+function buildInputLikeConfig(
+  category: 'input' | 'edited',
+  settings: FileListSettings,
+): FileListConfig {
+  return {
+    extensions: getIncludedExtensions(category),
+    ignoredExtensions: settings.ignoredFileExtensions,
+    ignoredDirs: [
+      ...settings.ignoredDirectories,
+      ...settings.ignoredInputDirectories,
+    ],
+    ignoredKeywords: settings.ignoredKeywords,
+    ignoredFiles: settings.ignoredInputFiles,
+  };
+}
+
 export function getFileListConfig(
   fileType: ListableFileType,
   settings: FileListSettings,
 ): FileListConfig | null {
   switch (fileType) {
     case 'input':
-      return {
-        extensions: getIncludedExtensions('input'),
-        ignoredExtensions: settings.ignoredFileExtensions,
-        ignoredDirs: [
-          ...settings.ignoredDirectories,
-          ...settings.ignoredInputDirectories,
-        ],
-        ignoredKeywords: settings.ignoredKeywords,
-        ignoredFiles: settings.ignoredInputFiles,
-      };
+      return buildInputLikeConfig('input', settings);
     case 'context':
       return {
         extensions: getIncludedExtensions('context'),
@@ -137,16 +144,7 @@ export function getFileListConfig(
 export function getEditedFileListConfig(
   settings: FileListSettings,
 ): FileListConfig {
-  return {
-    extensions: getIncludedExtensions('edited'),
-    ignoredExtensions: settings.ignoredFileExtensions,
-    ignoredDirs: [
-      ...settings.ignoredDirectories,
-      ...settings.ignoredInputDirectories,
-    ],
-    ignoredKeywords: settings.ignoredKeywords,
-    ignoredFiles: settings.ignoredInputFiles,
-  };
+  return buildInputLikeConfig('edited', settings);
 }
 
 function sanitizeDirectories(directories: readonly string[]): string[] {

--- a/src/latex/extractFileDependencies.ts
+++ b/src/latex/extractFileDependencies.ts
@@ -7,14 +7,10 @@
  * so that output files can be compiled outside the workspace.
  */
 
-// Standard library imports
-import * as path from 'node:path';
-
 // Third-party imports
 import pMap from 'p-map';
 
 // Local imports
-import { platform } from '@platform/platform';
 import type { FileLocation } from '@shared/schemas';
 import { flexibleFS } from '@utils/files';
 import { ensureExtension, joinLatexPath } from '@utils/core/pathCore';
@@ -23,6 +19,7 @@ import { ensureExtension, joinLatexPath } from '@utils/core/pathCore';
 import {
   collectBibliographyPaths,
   existingExternalPath,
+  resolveLatexDir,
   stripLatexComments,
 } from './latexParsingUtils';
 
@@ -59,7 +56,7 @@ async function resolveTexInputPath(
  * Extract file dependencies (\input, \include, \bibliography, \addbibresource)
  * from a LaTeX file. Returns absolute paths to existing files.
  *
- * Uses the platform realpath operation to follow symlinks so that when the input file lives in
+ * Uses resolveLatexDir to follow symlinks so that when the input file lives in
  * run storage (as a symlink to the workspace), dependencies are resolved
  * relative to the original workspace location where they actually exist.
  */
@@ -67,8 +64,7 @@ export async function extractLatexFileDependencies(
   latexFileLocation: FileLocation,
 ): Promise<string[]> {
   // Follow symlinks so run-storage paths resolve against the workspace
-  const realPath = await platform().fs.realPath(latexFileLocation.absolutePath);
-  const latexDir = path.dirname(realPath);
+  const latexDir = await resolveLatexDir(latexFileLocation.absolutePath);
 
   const content = await flexibleFS.read(latexFileLocation);
   const uncommented = stripLatexComments(content);

--- a/src/shared/ipc/settingsViewCommands.ts
+++ b/src/shared/ipc/settingsViewCommands.ts
@@ -1,39 +1,46 @@
 import { COMMON_COMMANDS } from './commonCommands';
+import { MEMORY_VIEW_COMMANDS } from './memoryViewCommands';
+import { HISTORY_VIEW_COMMANDS } from './historyViewCommands';
+import { PROFILE_VIEW_COMMANDS } from './profileViewCommands';
 
 /**
  * Command string literals for settings view schema definitions.
  * Defined here (not in settingsViewMessages.ts) to avoid circular dependency:
  * commands.ts → settingsViewMessages.ts → memoryViewMessages.ts → commands.ts
+ *
+ * Memory/History/Profile inbound commands reference their own view's
+ * command map (the single source of truth for those literals) instead of
+ * repeating the string values, so the two can't drift.
  */
 export const SETTINGS_VIEW_CMD = {
   // Navigation commands
   SET_TAB: 'setTab',
   OPEN_VSCODE_SETTINGS: 'openVscodeSettings',
   // Memory commands
-  GET_MEMORY_DATA: 'getMemoryData',
-  GET_MEMORY_PREVIEW: 'getMemoryPreview',
-  OPEN_MEMORY_FILE: 'openMemoryFile',
-  OPEN_MEMORY_FOLDER: 'openMemoryFolder',
-  DELETE_MEMORY: 'deleteMemory',
-  GET_MEMORY_ENABLED: 'getMemoryEnabled',
-  SET_MEMORY_ENABLED: 'setMemoryEnabled',
-  PIN_MEMORY: 'pinMemory',
-  UNPIN_MEMORY: 'unpinMemory',
+  GET_MEMORY_DATA: MEMORY_VIEW_COMMANDS.GET_MEMORY_DATA,
+  GET_MEMORY_PREVIEW: MEMORY_VIEW_COMMANDS.GET_MEMORY_PREVIEW,
+  OPEN_MEMORY_FILE: MEMORY_VIEW_COMMANDS.OPEN_MEMORY_FILE,
+  OPEN_MEMORY_FOLDER: MEMORY_VIEW_COMMANDS.OPEN_MEMORY_FOLDER,
+  DELETE_MEMORY: MEMORY_VIEW_COMMANDS.DELETE_MEMORY,
+  GET_MEMORY_ENABLED: MEMORY_VIEW_COMMANDS.GET_MEMORY_ENABLED,
+  SET_MEMORY_ENABLED: MEMORY_VIEW_COMMANDS.SET_MEMORY_ENABLED,
+  PIN_MEMORY: MEMORY_VIEW_COMMANDS.PIN_MEMORY,
+  UNPIN_MEMORY: MEMORY_VIEW_COMMANDS.UNPIN_MEMORY,
   // History commands
-  GET_HISTORY_DATA: 'getHistoryData',
-  RERUN_AGENT: 'rerunAgent',
-  RESTORE_AGENT: 'restoreAgent',
-  DELETE_AGENT: 'deleteAgent',
-  CLEAR_HISTORY: 'clearHistory',
-  EXPORT_CHAT_MD: 'exportChatMd',
-  EXPORT_CHAT_TEX: 'exportChatTex',
-  EXPORT_CHAT_HTML: 'exportChatHtml',
+  GET_HISTORY_DATA: HISTORY_VIEW_COMMANDS.GET_HISTORY_DATA,
+  RERUN_AGENT: HISTORY_VIEW_COMMANDS.RERUN_AGENT,
+  RESTORE_AGENT: HISTORY_VIEW_COMMANDS.RESTORE_AGENT,
+  DELETE_AGENT: HISTORY_VIEW_COMMANDS.DELETE_AGENT,
+  CLEAR_HISTORY: HISTORY_VIEW_COMMANDS.CLEAR_HISTORY,
+  EXPORT_CHAT_MD: HISTORY_VIEW_COMMANDS.EXPORT_CHAT_MD,
+  EXPORT_CHAT_TEX: HISTORY_VIEW_COMMANDS.EXPORT_CHAT_TEX,
+  EXPORT_CHAT_HTML: HISTORY_VIEW_COMMANDS.EXPORT_CHAT_HTML,
   // Profile commands
-  GET_PROFILE_DATA: 'getProfileData',
-  SELECT_AGENT: 'selectAgent',
-  SIGN_IN: 'signIn',
-  SIGN_OUT: 'signOut',
-  SET_API_ACCESS_MODE: 'setApiAccessMode',
+  GET_PROFILE_DATA: PROFILE_VIEW_COMMANDS.GET_PROFILE_DATA,
+  SELECT_AGENT: PROFILE_VIEW_COMMANDS.SELECT_AGENT,
+  SIGN_IN: PROFILE_VIEW_COMMANDS.SIGN_IN,
+  SIGN_OUT: PROFILE_VIEW_COMMANDS.SIGN_OUT,
+  SET_API_ACCESS_MODE: PROFILE_VIEW_COMMANDS.SET_API_ACCESS_MODE,
   SET_PROVIDER_KEY: 'setProviderKey',
   REMOVE_PROVIDER_KEY: 'removeProviderKey',
   OPEN_PROVIDER_KEY_URL: 'openProviderKeyUrl',

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -14,7 +14,7 @@ import { z } from 'zod';
 // Local imports - agent
 import { currentSession } from '@agent/runtime/SessionHandle';
 import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
-import { tryUseRunContext, type RunContext } from '@agent/runtime/RunContext';
+import { tryUseRunContext } from '@agent/runtime/RunContext';
 import { sendFollowUp } from '@agent/followUp/ToolUseFollowUp';
 
 // Local imports - tools
@@ -25,11 +25,11 @@ import {
   ToolUseAgentProposalSchema,
   type WorkflowAgentProposal,
   type ToolUseAgentProposal,
-  type StreamTabId,
 } from '@shared/schemas';
 import type { ToolResult } from '@shared/schemas/toolResult';
 import { formatFollowUpInstruction } from '@tools/subagentResults';
 import { subagentDeliveryRegistry } from '@tools/subagentDeliveryState';
+import { requireRunStream } from '@tools/contextHelpers';
 import { defineTool } from '@tools/core/define';
 
 // Local imports - utils
@@ -54,19 +54,6 @@ import {
 
 export { rejectOversizedBibAttachments } from './delegation/inputFields';
 export type { WorkflowAgentInput };
-
-/** Get required context fields, throwing if unavailable. */
-function getRequiredContext(): RunContext & {
-  streamId: StreamTabId;
-} {
-  const ctx = tryUseRunContext();
-  if (!ctx?.streamId) {
-    throw new Error(
-      'Tool context unavailable. Cannot create proposal without active stream.',
-    );
-  }
-  return ctx as RunContext & { streamId: StreamTabId };
-}
 
 // ============================================================================
 // delegate_workflow tool - for document processing agents
@@ -96,11 +83,11 @@ Example: agent=correct, inputFiles=["paper.tex"], extractFigures=true, instructi
   protected async execute(input: WorkflowAgentInput): Promise<ToolResult> {
     const agent = requireVisibleAgent('workflow', input.agent);
     const agentName = agent.name;
-    const ctx = getRequiredContext();
+    const { streamId, context } = requireRunStream('delegate_workflow');
 
     const model = await resolveAvailableDelegationModel({
       requestedModel: input.model,
-      parentModel: ctx.model,
+      parentModel: context.model,
       agentCategory: AgentCategory.Workflow,
     });
 
@@ -153,7 +140,7 @@ Example: agent=correct, inputFiles=["paper.tex"], extractFigures=true, instructi
       memories: input.memories,
     } satisfies WorkflowAgentProposal);
 
-    return proposeAndExecute(proposal, agentName, ctx.streamId);
+    return proposeAndExecute(proposal, agentName, streamId);
   }
 }
 
@@ -236,11 +223,11 @@ Git worktree support: resolved from the active workspace at runtime.`,
     const agent = requireVisibleAgent('toolUse', input.agent);
     const agentName = agent.name;
 
-    const ctx = getRequiredContext();
+    const { streamId, context } = requireRunStream('delegate_agent');
 
     const model = await resolveAvailableDelegationModel({
       requestedModel: input.model,
-      parentModel: ctx.model,
+      parentModel: context.model,
       agentCategory: AgentCategory.ToolUse,
     });
 
@@ -255,7 +242,7 @@ Git worktree support: resolved from the active workspace at runtime.`,
       workingDirectory: input.working_directory,
     } satisfies ToolUseAgentProposal);
 
-    return proposeAndExecute(proposal, agentName, ctx.streamId);
+    return proposeAndExecute(proposal, agentName, streamId);
   }
 
   /** Queue follow-up instructions for a tool-use subagent. */

--- a/src/utils/system/workspaceInfo.ts
+++ b/src/utils/system/workspaceInfo.ts
@@ -83,6 +83,12 @@ async function getGitInfo(workspacePath: string): Promise<GitInfo | null> {
     executeCommand(['git', 'status', '--porcelain'], opts),
   ]);
 
+  // Unlike a non-zero exit (e.g. detached HEAD), a timeout means we couldn't
+  // determine dirty/branch state at all — report unknown (null) rather than
+  // silently defaulting `dirty` to false, which would misreport a repo as
+  // clean when `git status` merely timed out.
+  if (branchResult.timedOut || statusResult.timedOut) return null;
+
   const branch = branchResult.success ? branchResult.stdout : null;
   const dirty = statusResult.success && statusResult.stdout !== null;
 

--- a/src/utils/system/workspaceInfo.ts
+++ b/src/utils/system/workspaceInfo.ts
@@ -2,14 +2,12 @@
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-// Third-party imports
-import { execa } from 'execa';
-
 // Local imports
 import { escapeTextStrict } from '@shared/utils/xmlEscape';
 import { WorkspaceFS } from '@utils/files';
 import { listExternalRoots } from '@utils/files/externalRoots';
 import { isoDateOnly } from '@utils/text/stringUtils';
+import { executeCommand } from '@utils/system/execUtils';
 import { IS_WINDOWS } from './platformPaths';
 import { isWSL } from './wslDetect';
 
@@ -68,37 +66,27 @@ function getPlatformLabel(): string {
  * Returns null if the workspace is not a git repo or git is unavailable.
  */
 async function getGitInfo(workspacePath: string): Promise<GitInfo | null> {
-  try {
-    const opts = {
-      cwd: workspacePath,
-      reject: false,
-      timeout: GIT_TIMEOUT_MS,
-    } as const;
+  const opts = { cwd: workspacePath, timeout: GIT_TIMEOUT_MS } as const;
 
-    // Check if inside a git repo
-    const insideWorkTree = await execa(
-      'git',
-      ['rev-parse', '--is-inside-work-tree'],
-      opts,
-    );
-    if (insideWorkTree.exitCode !== 0) return null;
+  // Check if inside a git repo. executeCommand swallows spawn errors (e.g.
+  // git missing from PATH) and reports them as a failed result, so this also
+  // covers the "git not installed" case.
+  const insideWorkTree = await executeCommand(
+    ['git', 'rev-parse', '--is-inside-work-tree'],
+    opts,
+  );
+  if (!insideWorkTree.success) return null;
 
-    // Run branch and status checks in parallel
-    const [branchResult, statusResult] = await Promise.all([
-      execa('git', ['symbolic-ref', '--short', 'HEAD'], opts),
-      execa('git', ['status', '--porcelain'], opts),
-    ]);
+  // Run branch and status checks in parallel
+  const [branchResult, statusResult] = await Promise.all([
+    executeCommand(['git', 'symbolic-ref', '--short', 'HEAD'], opts),
+    executeCommand(['git', 'status', '--porcelain'], opts),
+  ]);
 
-    const branch =
-      branchResult.exitCode === 0 ? branchResult.stdout.trim() : null;
-    const dirty =
-      statusResult.exitCode === 0 && statusResult.stdout.trim().length > 0;
+  const branch = branchResult.success ? branchResult.stdout : null;
+  const dirty = statusResult.success && statusResult.stdout !== null;
 
-    return { branch, dirty };
-  } catch {
-    // git not installed or not on PATH (ENOENT), or timed out
-    return null;
-  }
+  return { branch, dirty };
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR keeps a small set of simplifications that survived rebasing onto current `main`:

- Settings view commands now reference the memory/history/profile command maps instead of duplicating those string literals.
- File listing rules share one `buildInputLikeConfig` helper for input and edited-file lists.
- Error cause-chain traversal is centralized in `findInCauseChain`, with `isDiskFullError` using that helper.
- Delegation tools use `requireRunStream` instead of a local context helper.
- CLI chat run and resume failures share one `reportRunFailure` tail.
- Progress view log clicks use the shared composed-path helper.
- Tool-use resume schemas share common Zod fields across current and legacy branches.
- LaTeX dependency extraction uses `resolveLatexDir` for symlink-aware directory resolution.
- CLI TUI removes an unnecessary `useCallback` wrapper.
- Workspace git info uses `executeCommand` and keeps timeout state unknown instead of reporting a timed-out repo as clean.

Net effect after rebase: 10 files changed, 136 insertions, 160 deletions.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/utils/system/WorkspaceInfo.vitest.ts src/test-kernel/utils/files/WorkflowPromptFileNames.vitest.mts src/test-kernel/tools/DelegationTools.vitest.ts src/test-kernel/progressView/WebviewBridge.vitest.ts src/test-kernel/agent/runtime/SessionResumeRetrieval.vitest.ts`
- `corepack pnpm exec eslint packages/cli/src/chat/chatSessionController.ts packages/cli/src/chat/tui/App.tsx packages/extension/src/progressView/frontend/components/LogList.ts src/agent/runtime/SessionResumeRetrieval.ts src/common/errors/errorPredicates.ts src/common/files/fileListingRules.ts src/latex/extractFileDependencies.ts src/shared/ipc/settingsViewCommands.ts src/tools/DelegationTools.ts src/utils/system/workspaceInfo.ts`
- `npm run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly mechanical refactors with equivalent behavior; the only intentional behavior change is omitting git metadata on command timeout instead of reporting a clean working tree.
> 
> **Overview**
> This PR **deduplicates small pieces of logic** across CLI, extension, agent, and utils code without changing product behavior, except for one **git workspace info** edge case.
> 
> **Shared failure handling and helpers:** CLI chat **start** and **resume** now share `reportRunFailure` for transcript errors and exit codes. Delegation tools drop a local context helper in favor of **`requireRunStream`**. Progress view **LogList** uses the shared **`getComposedPathElement`** instead of a private composed-path walker.
> 
> **Schemas and config:** Tool-use resume Zod parsing pulls **`SharedToolUseFields`** for current `messages` and legacy `conversation` shapes. File listing builds **input** and **edited** configs via **`buildInputLikeConfig`**. Settings view IPC literals for memory/history/profile **alias** those views’ command maps so strings cannot drift.
> 
> **Errors and LaTeX:** **`findInCauseChain`** centralizes walking wrapped error causes; **`isDiskFullError`** uses it. LaTeX dependency extraction resolves the base directory with **`resolveLatexDir`** (symlink-aware), aligned with other LaTeX utilities.
> 
> **Workspace git block:** Git probing goes through **`executeCommand`**. If **branch** or **status** **times out**, the PR returns **no git info** instead of implying a **clean** repo when `git status` never finished.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccd49e23f3237fa41275ed1c8d53470f9b3b4aa3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->