### PR TITLE
Simplify repo-wide: modern TS idioms, dead code, pass-through cleanup

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -3,13 +3,7 @@
 // Tab / Shift-Tab cycles focus across subagent streams.
 
 import { Box, useApp, useInput, useStdin, useWindowSize } from 'ink';
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import { defaultShortcutModifierLabel } from '@cli/runtime/shortcutLabels';
 import {
@@ -719,9 +713,6 @@ export function App(props: AppProps): React.JSX.Element {
     childControlMode !== undefined
       ? childControlTargets[childControlMode]
       : undefined;
-  const updateChildControlEscapeAction = useCallback((action: string) => {
-    setChildControlEscapeAction(action);
-  }, []);
   useEffect(() => {
     if (childControlMode === undefined) setChildControlEscapeAction('close');
   }, [childControlMode]);
@@ -800,7 +791,7 @@ export function App(props: AppProps): React.JSX.Element {
             availableRows={foregroundRows}
             mode={childControlMode}
             onClose={() => setChildControlMode(undefined)}
-            onEscapeActionChange={updateChildControlEscapeAction}
+            onEscapeActionChange={setChildControlEscapeAction}
             onFocusStream={(streamId) => cliState.activeStreamId.set(streamId)}
             onViewStream={(streamId) =>
               cliState.transcriptViewerStreamId.set(streamId)

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -81,10 +81,15 @@ function runFormSelection<T>({
     onDone(value);
   }
 
-  // Starting from a resolved promise routes both a synchronous throw and an
-  // async rejection from `action` through the single `.catch`.
-  void Promise.resolve()
-    .then(action)
+  const runAction = (): Promise<void> => {
+    try {
+      return Promise.resolve(action());
+    } catch (error: unknown) {
+      return Promise.reject(error);
+    }
+  };
+
+  void runAction()
     .catch((error: unknown) => onError?.(error))
     .finally(() => {
       if (completion === 'afterAction') {

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -77,19 +77,14 @@ function runFormSelection<T>({
   readonly onError?: ErrorHandler;
   readonly completion?: SelectionCompletion;
 }): void {
-  const runAction = (): Promise<void> => {
-    try {
-      return Promise.resolve(action());
-    } catch (error: unknown) {
-      return Promise.reject(error);
-    }
-  };
-
   if (completion === 'beforeAction') {
     onDone(value);
   }
 
-  void runAction()
+  // Starting from a resolved promise routes both a synchronous throw and an
+  // async rejection from `action` through the single `.catch`.
+  void Promise.resolve()
+    .then(action)
     .catch((error: unknown) => onError?.(error))
     .finally(() => {
       if (completion === 'afterAction') {

--- a/packages/cli/src/chat/tui/history/inputHistory.ts
+++ b/packages/cli/src/chat/tui/history/inputHistory.ts
@@ -77,10 +77,7 @@ export async function loadInputHistory(): Promise<InputHistory> {
     async push(line: string) {
       const trimmed = line.trim();
       if (!trimmed) return;
-      const stored =
-        trimmed.length > MAX_LINE_CHARS
-          ? trimmed.slice(0, MAX_LINE_CHARS)
-          : trimmed;
+      const stored = trimmed.slice(0, MAX_LINE_CHARS);
       if (entries.at(-1) === stored) return;
       const record: HistoryRecord = { t: Date.now(), v: stored };
       entries.push(stored);

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -331,10 +331,7 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
 
   const isControlled = props.cursor !== undefined;
   const [internalCursor, setInternalCursor] = useState<number>(value.length);
-  const cursor = clampCursor(
-    isControlled ? (props.cursor as number) : internalCursor,
-    value.length,
-  );
+  const cursor = clampCursor(props.cursor ?? internalCursor, value.length);
 
   // Mirror the latest value/cursor for async handlers (image paste): a
   // clipboard probe that resolves after the user keeps typing must insert at

--- a/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
+++ b/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
@@ -266,13 +266,8 @@ export function ExternalInquiry(
     questionScrollable,
   });
 
-  function scrollQuestion(
-    next: number | ((currentOffset: number) => number),
-  ): void {
-    setQuestionOffset((current) => {
-      const requested = typeof next === 'function' ? next(current) : next;
-      return clamp(requested, 0, maxQuestionOffset);
-    });
+  function scrollQuestion(next: (currentOffset: number) => number): void {
+    setQuestionOffset((current) => clamp(next(current), 0, maxQuestionOffset));
   }
 
   async function copyQuestion(): Promise<void> {

--- a/packages/cli/src/chat/tui/modals/UserQuestionState.ts
+++ b/packages/cli/src/chat/tui/modals/UserQuestionState.ts
@@ -16,7 +16,7 @@ export function updateUserQuestionAnswers(
 }
 
 export function toggleUserQuestionSelection(
-  selected: ReadonlyArray<string>,
+  selected: readonly string[],
   label: string,
 ): string[] {
   return selected.includes(label)

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -147,14 +147,14 @@ export function ConversationPane(
   // stealing rows reserved for the footer chrome.
   return (
     <Box flexDirection="column" height={visibleRows} overflowY="hidden">
-      {visibleEntries.entries.map((entry) => {
-        return renderConversationPaneEntry({
+      {visibleEntries.entries.map((entry) =>
+        renderConversationPaneEntry({
           colorEnabled: props.colorEnabled,
           entry,
           rowLimit: visibleEntries.rowLimits.get(entry.id),
           width: props.width,
-        });
-      })}
+        }),
+      )}
       {showThinking ? <ThinkingRow /> : null}
     </Box>
   );

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -212,14 +212,10 @@ export function SubagentList(
     );
   }
 
+  // Reached only when maxRows is undefined (the compact branch above owns every
+  // bounded case), so the panel renders uncapped with a trailing margin.
   return (
-    <Box
-      flexDirection="column"
-      height={props.maxRows}
-      overflowY={props.maxRows === undefined ? undefined : 'hidden'}
-      paddingX={1}
-      marginBottom={props.maxRows === undefined ? 1 : 0}
-    >
+    <Box flexDirection="column" paddingX={1} marginBottom={1}>
       {subagents.length > 0 ? (
         <Box flexDirection="column">
           <Text bold dimColor>

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -417,18 +417,10 @@ export function liveChildExecutionElapsedKey(
 ): string | undefined {
   if (slice === undefined) return undefined;
 
-  const liveKeys: string[] = [];
-  for (const child of slice.activeSubagents) {
-    if (hasLiveChildElapsed(child)) {
-      liveKeys.push(`${child.executionId}:${child.startedAt}`);
-    }
-  }
-  for (const child of slice.activeProcesses) {
-    if (hasLiveChildElapsed(child)) {
-      liveKeys.push(`${child.executionId}:${child.startedAt}`);
-    }
-  }
-  liveKeys.sort();
+  const liveKeys = [...slice.activeSubagents, ...slice.activeProcesses]
+    .filter(hasLiveChildElapsed)
+    .map((child) => `${child.executionId}:${child.startedAt}`)
+    .sort();
   return liveKeys.length > 0 ? liveKeys.join(',') : undefined;
 }
 

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -115,11 +115,8 @@ export function nextWrappingHighlightIndex({
 }): number {
   if (itemCount <= 0) return 0;
   const clampedHighlight = clampIndex(highlight, itemCount);
-  return direction === 1
-    ? (clampedHighlight + 1) % itemCount
-    : clampedHighlight <= 0
-      ? itemCount - 1
-      : clampedHighlight - 1;
+  if (direction === 1) return (clampedHighlight + 1) % itemCount;
+  return clampedHighlight <= 0 ? itemCount - 1 : clampedHighlight - 1;
 }
 
 export function visibleSelectRange({

--- a/packages/cli/src/orchestration/runOrchestrationTui.tsx
+++ b/packages/cli/src/orchestration/runOrchestrationTui.tsx
@@ -71,13 +71,7 @@ export function orchestrationBlockRowCost(
   columns: number,
 ): number {
   if (lines.length === 0) return 0;
-  return (
-    1 +
-    lines.reduce(
-      (rows, line) => rows + orchestrationWrappedLineRows(line, columns),
-      0,
-    )
-  );
+  return 1 + orchestrationLinesRowCost(lines, columns);
 }
 
 export interface OrchestrationLauncherLayout {

--- a/packages/cli/src/runtime/cliConfig.ts
+++ b/packages/cli/src/runtime/cliConfig.ts
@@ -39,16 +39,12 @@ export interface LoadedCliConfig {
 }
 
 export function isKnownCliModel(model: string): boolean {
-  return isCliSupportedModelId(model);
+  const config = MODEL_CONFIGS[model];
+  return config != null && config.provider !== ModelProvider.COPILOT;
 }
 
 export function knownCliModelIds(): string[] {
-  return Object.keys(MODEL_CONFIGS).filter(isCliSupportedModelId);
-}
-
-function isCliSupportedModelId(model: string): boolean {
-  const config = MODEL_CONFIGS[model];
-  return config != null && config.provider !== ModelProvider.COPILOT;
+  return Object.keys(MODEL_CONFIGS).filter(isKnownCliModel);
 }
 
 function normalizeCliModelLookupKey(value: string): string {
@@ -68,7 +64,7 @@ function modelLookupKeys(id: string): string[] {
 export function resolveKnownCliModelId(model: string): string | undefined {
   const trimmed = model.trim();
   if (!trimmed) return undefined;
-  if (isCliSupportedModelId(trimmed)) return trimmed;
+  if (isKnownCliModel(trimmed)) return trimmed;
 
   const lower = trimmed.toLowerCase();
   const ids = knownCliModelIds();

--- a/packages/cli/src/runtime/exitCodes.ts
+++ b/packages/cli/src/runtime/exitCodes.ts
@@ -1,5 +1,3 @@
-// Local imports - CLI runtime
-
 /** Canonical CLI process exit codes. */
 export const CliExitCode = {
   Success: 0,

--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -338,8 +338,8 @@ function formatActiveChildren(
   const first = namedChildren[0];
   if (!first) return undefined;
 
-  const label =
-    namedChildren.length === 1 ? kind : kind === 'tool' ? 'tools' : 'subagents';
+  const plural = kind === 'tool' ? 'tools' : 'subagents';
+  const label = namedChildren.length === 1 ? kind : plural;
   const suffix =
     namedChildren.length > 1 ? ` +${namedChildren.length - 1}` : '';
   return `${label}: ${first}${suffix}`;

--- a/packages/cli/src/runtime/tools.ts
+++ b/packages/cli/src/runtime/tools.ts
@@ -136,7 +136,7 @@ export async function setCliToolEnabled(
   enabled: boolean,
 ): Promise<boolean> {
   const def = findCliToolDef(id);
-  if (!def || !def.toggleable) return false;
+  if (!def?.toggleable) return false;
   await setToolEnabled(id, enabled);
   return true;
 }

--- a/packages/cli/src/runtime/userQuestionAnswer.ts
+++ b/packages/cli/src/runtime/userQuestionAnswer.ts
@@ -14,8 +14,7 @@ export function parseUserQuestionAnswer(
 
   const selected = parts.every((part) => /^\d+$/.test(part))
     ? parts
-        .map((part) => Number(part))
-        .map((index) => question.options[index - 1]?.label)
+        .map((part) => question.options[Number(part) - 1]?.label)
         .filter((value): value is string => Boolean(value))
     : [];
 

--- a/packages/desktop/src/main/desktopAppLog.ts
+++ b/packages/desktop/src/main/desktopAppLog.ts
@@ -20,12 +20,11 @@ import { redactSecrets, type LogRedactionOptions } from '@logger/redaction';
 
 import type { DesktopLogSnapshot } from '../desktopLogMessages.js';
 
-type ConsoleLevel = 'debug' | 'error' | 'info' | 'log' | 'warn';
-
 const LOG_FILE_NAME = 'texra-desktop.log';
 const MAX_LOG_BYTES = 5 * 1024 * 1024;
 const MAX_VIEWER_LOG_BYTES = 160 * 1024;
 const CONSOLE_LEVELS = ['debug', 'error', 'info', 'log', 'warn'] as const;
+type ConsoleLevel = (typeof CONSOLE_LEVELS)[number];
 
 let logFilePath: string | undefined;
 let consoleInstalled = false;

--- a/packages/desktop/src/main/desktopFileSelection.ts
+++ b/packages/desktop/src/main/desktopFileSelection.ts
@@ -140,16 +140,12 @@ export function createDesktopFileSelection(
   }
 
   async function updateEditedFiles(baseFile?: string) {
-    if (!baseFile) {
-      postFileList('edited', []);
-      return;
-    }
     const workspacePath = getWorkspacePath();
-    const config = getEditedFileListConfig(loadFileListSettings(getConfig));
-    if (!workspacePath) {
+    if (!baseFile || !workspacePath) {
       postFileList('edited', []);
       return;
     }
+    const config = getEditedFileListConfig(loadFileListSettings(getConfig));
     const files = (await listFiles(workspacePath, config)).filter((file) =>
       matchesEditedFile(file, baseFile),
     );

--- a/packages/desktop/src/main/desktopLogIpc.ts
+++ b/packages/desktop/src/main/desktopLogIpc.ts
@@ -41,23 +41,17 @@ export function createDesktopLogIpc(
     return log;
   }
 
-  function copyLog() {
-    const log = postSnapshot();
-    void options.copyLog?.(log.text).catch(reportAsyncError);
-  }
-
-  function exportLog() {
-    const log = postSnapshot();
-    void options.exportLog?.(log.text).catch(reportAsyncError);
-  }
-
   return createCommandHandler(
     {
       [DESKTOP_LOG_COMMANDS.REQUEST_LOG]: () => {
         postSnapshot();
       },
-      [DESKTOP_LOG_COMMANDS.COPY_LOG]: () => copyLog(),
-      [DESKTOP_LOG_COMMANDS.EXPORT_LOG]: () => exportLog(),
+      [DESKTOP_LOG_COMMANDS.COPY_LOG]: () => {
+        void options.copyLog?.(postSnapshot().text).catch(reportAsyncError);
+      },
+      [DESKTOP_LOG_COMMANDS.EXPORT_LOG]: () => {
+        void options.exportLog?.(postSnapshot().text).catch(reportAsyncError);
+      },
     },
     { onAsyncError: options.onAsyncError },
   );

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -106,28 +106,27 @@ export function createDesktopAuthCallbackState(
     await store.update(DESKTOP_PENDING_OAUTH_STATE_KEY, state);
   };
 
+  // True only while a non-expired sign-in attempt is pending; clears and
+  // best-effort persists the reset once the stored attempt has expired.
+  const hasValidPendingState = (): boolean => {
+    if (!pendingState) return false;
+    if (isPendingOAuthStateExpired(pendingState)) {
+      pendingState = null;
+      void persistPendingState(null).catch(() => {});
+      return false;
+    }
+    return true;
+  };
+
   return {
-    hasPendingSignIn: () => {
-      if (!pendingState) return false;
-      if (isPendingOAuthStateExpired(pendingState)) {
-        pendingState = null;
-        void persistPendingState(null).catch(() => {});
-        return false;
-      }
-      return true;
-    },
+    hasPendingSignIn: hasValidPendingState,
     async beginAuthAttempt(nonce: string) {
       pendingState = { createdAt: Date.now(), nonce };
       await persistPendingState(pendingState);
     },
     matchesPendingNonce: (nonce: string | undefined) => {
-      if (!nonce || !pendingState) return false;
-      if (isPendingOAuthStateExpired(pendingState)) {
-        pendingState = null;
-        void persistPendingState(null).catch(() => {});
-        return false;
-      }
-      return pendingState.nonce === nonce;
+      if (!nonce) return false;
+      return hasValidPendingState() && pendingState?.nonce === nonce;
     },
     async clearAwaitingCallback() {
       pendingState = null;

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -333,6 +333,9 @@ function createWindow(options: {
   const showErrorMessage = async (message: string) => {
     await dialog.showMessageBox(window, { message, type: 'error' });
   };
+  const showInfoMessage = async (message: string) => {
+    await dialog.showMessageBox(window, { type: 'info', message });
+  };
   const setupCommandCwd = options.workspacePath ?? app.getPath('home');
   const setupTerminalRunner = createDesktopTerminalRunner({
     cwd: setupCommandCwd,
@@ -404,9 +407,7 @@ function createWindow(options: {
     coordinator: options.authCoordinator,
     secrets: platform().secrets,
     openExternalUrl: (url) => previewHost.openExternal(url),
-    showInfoMessage: async (message) => {
-      await dialog.showMessageBox(window, { type: 'info', message });
-    },
+    showInfoMessage,
     showErrorMessage,
     onSessionChanged: refreshDesktopAuthSurfaces,
     log: console,
@@ -493,9 +494,7 @@ function createWindow(options: {
       });
       return result.response === 0;
     },
-    showInfoMessage: async (message) => {
-      await dialog.showMessageBox(window, { type: 'info', message });
-    },
+    showInfoMessage,
     showErrorMessage,
     streamSnapshotStore: options.streamSnapshotStore,
     progressSnapshotStore: options.progressSnapshotStore,
@@ -576,12 +575,8 @@ function createWindow(options: {
     promptSecret: (input) =>
       promptInRenderer(window, { ...input, password: true }),
     promptText: (input) => promptInRenderer(window, input),
-    showInfoMessage: async (message) => {
-      await dialog.showMessageBox(window, { type: 'info', message });
-    },
-    showErrorMessage: async (message) => {
-      await dialog.showMessageBox(window, { type: 'error', message });
-    },
+    showInfoMessage,
+    showErrorMessage,
     confirmAction: async (message, confirmLabel = 'OK') => {
       const result = await dialog.showMessageBox(window, {
         type: 'warning',
@@ -816,9 +811,7 @@ function createWindow(options: {
       openWorkspaceFolder,
       signIn: () => desktopAuth.signIn(),
       getRecentCommits: () => gitHost.getRecentCommits(),
-      showInfoMessage: async (message) => {
-        await dialog.showMessageBox(window, { type: 'info', message });
-      },
+      showInfoMessage,
       onAsyncError: reportAsyncError,
     },
   );

--- a/packages/extension/src/commands/history/stateRestoreCommand.ts
+++ b/packages/extension/src/commands/history/stateRestoreCommand.ts
@@ -6,7 +6,7 @@ import * as vscode from 'vscode';
 import { buildMainViewState } from '@controllers/mainView/MainViewStateRestoreController';
 
 // Local imports
-import { TaskStateSchema, type TaskState } from '@agent/core/state/TaskState';
+import { TaskStateSchema } from '@agent/core/state/TaskState';
 import { registerCommands } from '@commands/_shared/registerCommands';
 import { setPendingState } from '@common/state';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
@@ -46,7 +46,7 @@ async function restoreState(
   }
 
   try {
-    const nextState = buildMainViewState(parsed.data as TaskState);
+    const nextState = buildMainViewState(parsed.data);
 
     await vscode.commands.executeCommand('texra.showMainView');
 

--- a/packages/extension/src/frontend/agents/remoteAgentUtils.ts
+++ b/packages/extension/src/frontend/agents/remoteAgentUtils.ts
@@ -33,7 +33,7 @@ export async function selectAgentInMainView(
     source = 'remote',
   } = options;
 
-  const agentValue = createKey(source as AgentSource, agentName);
+  const agentValue = createKey(source, agentName);
 
   // Focus main view first - triggers initialization if needed
   await vscode.commands.executeCommand('texra.showMainView');

--- a/packages/extension/src/frontend/files/fileLister.ts
+++ b/packages/extension/src/frontend/files/fileLister.ts
@@ -53,18 +53,13 @@ export class FileLister {
     );
   }
 
-  /** Get file listing config for each file type */
-  private getListConfig(fileType: ListableFileType) {
-    return getFileListConfig(fileType, this.settings);
-  }
-
   public async list(fileType: ListableFileType): Promise<string[]> {
     if (!this.workspacePath) {
       logger.warn(CHANNEL, 'No workspace folder found');
       return [];
     }
 
-    const config = this.getListConfig(fileType);
+    const config = getFileListConfig(fileType, this.settings);
     if (!config) {
       return [];
     }

--- a/packages/extension/src/frontend/git/gitAuthorSetup.ts
+++ b/packages/extension/src/frontend/git/gitAuthorSetup.ts
@@ -18,9 +18,7 @@ export function readGitAuthorSettings(): GitAuthorSettings {
 }
 
 /** Apply settings and return them so callers can forward without re-reading. */
-export function applyGitAuthorConfig(): ReturnType<
-  typeof readGitAuthorSettings
-> {
+export function applyGitAuthorConfig(): GitAuthorSettings {
   const settings = readGitAuthorSettings();
   return applyGitAuthorSettings(settings);
 }

--- a/packages/extension/src/frontend/vscode/vscodeConfig.ts
+++ b/packages/extension/src/frontend/vscode/vscodeConfig.ts
@@ -26,10 +26,6 @@ function workspaceConfiguration(
   return vscode.workspace.getConfiguration(section, null);
 }
 
-function inspectKey<T>(key: string): VscodeConfigInspection<T> | undefined {
-  return workspaceConfiguration().inspect<T>(key);
-}
-
 function toConfigurationTarget(
   target: ConfigTarget,
 ): vscode.ConfigurationTarget {
@@ -91,7 +87,7 @@ export class VscodeConfigProvider implements ConfigProvider {
 
   inspect<T = unknown>(key: string): ConfigInspection<T> | undefined {
     const inspection = configKeys(key)
-      .map((item) => inspectKey<T>(item))
+      .map((item) => workspaceConfiguration().inspect<T>(item))
       .find((item) => item !== undefined);
     return normalizeInspection(inspection, this.get<T>(key));
   }

--- a/packages/extension/src/progressView/frontend/components/BashRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BashRequestPanel.ts
@@ -24,8 +24,6 @@ import { buildCodeBlock } from '../formatters/htmlBuilders';
 // Local imports - base class
 import { BaseFeedbackPanel } from './BaseFeedbackPanel';
 
-// Local imports - shared schemas
-
 @customElement('bash-request-panel')
 export class BashRequestPanel extends BaseFeedbackPanel {
   static override styles = [

--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -85,7 +85,6 @@ const STORAGE_HINT_DISMISS_KEY = 'generatedFilesStorageHint.dismissed';
 interface ParsedPath {
   dir: string;
   basename: string;
-  normalized: string;
 }
 
 /** Parse a path into directory and basename components */
@@ -95,7 +94,6 @@ function parsePath(path: string): ParsedPath {
   return {
     dir: lastSlash >= 0 ? normalized.slice(0, lastSlash + 1) : '',
     basename: lastSlash >= 0 ? normalized.slice(lastSlash + 1) : normalized,
-    normalized,
   };
 }
 

--- a/packages/extension/src/progressView/frontend/components/PlanView.ts
+++ b/packages/extension/src/progressView/frontend/components/PlanView.ts
@@ -97,7 +97,9 @@ export class PlanView extends LitElement {
 
   /** Kept to one line so the pre-wrap body gets no template whitespace. */
   private renderDocument(text: string): TemplateResult {
-    return html`<div id=${ELEMENT_IDS.PLAN_VIEW} class="plan-document">${text}</div>`;
+    return html`<div id=${ELEMENT_IDS.PLAN_VIEW} class="plan-document">
+      ${text}
+    </div>`;
   }
 
   private handleShow(e: Event): void {

--- a/packages/extension/src/progressView/frontend/components/PlanView.ts
+++ b/packages/extension/src/progressView/frontend/components/PlanView.ts
@@ -97,8 +97,7 @@ export class PlanView extends LitElement {
 
   /** Kept to one line so the pre-wrap body gets no template whitespace. */
   private renderDocument(text: string): TemplateResult {
-    const id = ELEMENT_IDS.PLAN_VIEW;
-    return html`<div id=${id} class="plan-document">${text}</div>`;
+    return html`<div id=${ELEMENT_IDS.PLAN_VIEW} class="plan-document">${text}</div>`;
   }
 
   private handleShow(e: Event): void {

--- a/packages/extension/src/progressView/frontend/components/PlanView.ts
+++ b/packages/extension/src/progressView/frontend/components/PlanView.ts
@@ -97,9 +97,8 @@ export class PlanView extends LitElement {
 
   /** Kept to one line so the pre-wrap body gets no template whitespace. */
   private renderDocument(text: string): TemplateResult {
-    return html`<div id=${ELEMENT_IDS.PLAN_VIEW} class="plan-document">
-      ${text}
-    </div>`;
+    // prettier-ignore
+    return html`<div id=${ELEMENT_IDS.PLAN_VIEW} class="plan-document">${text}</div>`;
   }
 
   private handleShow(e: Event): void {

--- a/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
@@ -21,9 +21,9 @@ import {
 import type { ProviderErrorPartial, RetryPermission } from '@shared/schemas';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 import { renderDotMeta, type MetaPart } from '@shared/wa/metaStrip';
-import { BaseRequestPanel } from './BaseRequestPanel';
 
 // Local imports - base class
+import { BaseRequestPanel } from './BaseRequestPanel';
 
 @customElement('retry-request-panel')
 export class RetryRequestPanel extends BaseRequestPanel {
@@ -163,7 +163,7 @@ export class RetryRequestPanel extends BaseRequestPanel {
       const maxTailChars = 1024;
       const isTruncated = partialText.length > maxTailChars;
       const tail = isTruncated
-        ? '…' + partialText.slice(partialText.length - maxTailChars)
+        ? '…' + partialText.slice(-maxTailChars)
         : partialText;
       const header = isTruncated
         ? `--- Partial Output (last ${maxTailChars} of ${partialText.length} chars) ---`

--- a/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
@@ -169,8 +169,8 @@ export class UserQuestionPanel extends BaseFeedbackPanel {
   }
 
   private updateFreeText(question: string, event: Event): void {
-    const value = ((event.currentTarget as HTMLElement & { value?: string })
-      .value ?? '') as string;
+    const value =
+      (event.currentTarget as HTMLElement & { value?: string }).value ?? '';
     this.freeText = { ...this.freeText, [question]: value };
   }
 

--- a/packages/extension/src/progressView/frontend/components/messageIndex.ts
+++ b/packages/extension/src/progressView/frontend/components/messageIndex.ts
@@ -284,7 +284,7 @@ export class MessageIndex {
       if (!('msg' in item)) continue;
       const fresh = this.ungroupedById.get(item.key);
       if (fresh && fresh !== item.msg) {
-        (item as { msg: LogMessageData }).msg = fresh;
+        item.msg = fresh;
       }
     }
   }

--- a/packages/extension/src/progressView/frontend/eventHandlers.ts
+++ b/packages/extension/src/progressView/frontend/eventHandlers.ts
@@ -12,15 +12,7 @@ import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import type { ExtractedClipboardImage } from '@shared/utils/clipboardImages';
 
 // Local imports - progress view
-import {
-  firstStreamId,
-  getStreamState,
-  isToolUseState,
-  type ProgressState,
-  type StreamFilter,
-  type StreamLogs,
-  type StreamState,
-} from './store';
+import { firstStreamId, getStreamState, isToolUseState } from './store';
 import { addResolvedProposalId, removePrompt } from './slices/permissionSlice';
 import { updateToolUseState } from './stateUtils';
 import { clearInquiryDraft } from './components/ExternalInquiryPanel';
@@ -241,9 +233,16 @@ export function handlePermissionAction(
   event: CustomEvent<PermissionActionDetail>,
   ctx: MessageHandlerContext,
 ): void {
-  const { permission, action, feedback, modelOverride, agentOverride, answer } =
-    event.detail;
-  const { answers, sessionLinks } = event.detail;
+  const {
+    permission,
+    action,
+    feedback,
+    modelOverride,
+    agentOverride,
+    answer,
+    answers,
+    sessionLinks,
+  } = event.detail;
 
   switch (permission.kind) {
     case PERMISSION_KIND.TOOL_EDIT:

--- a/packages/extension/src/progressView/frontend/formatters/progressBadgeFormatter.ts
+++ b/packages/extension/src/progressView/frontend/formatters/progressBadgeFormatter.ts
@@ -1,5 +1,4 @@
-import { html, type TemplateResult } from 'lit';
-import { nothing } from 'lit';
+import { html, nothing, type TemplateResult } from 'lit';
 import type { ConversationProgress } from '@shared/schemas';
 
 /**

--- a/packages/extension/src/progressView/frontend/formatters/wordDiff.ts
+++ b/packages/extension/src/progressView/frontend/formatters/wordDiff.ts
@@ -16,9 +16,7 @@ type DiffMatchPatch = InstanceType<typeof diff_match_patch>;
 let dmpInstance: DiffMatchPatch | null = null;
 
 function getDmp(): DiffMatchPatch {
-  if (!dmpInstance) {
-    dmpInstance = new diff_match_patch();
-  }
+  dmpInstance ??= new diff_match_patch();
   return dmpInstance;
 }
 

--- a/packages/extension/src/progressView/frontend/slices/logSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/logSlice.ts
@@ -179,9 +179,7 @@ export const logHandlers: HandlerRegistry = {
         const updatedMessageIndices = new Set<number>();
         const updatedMessageBaseGeneration = streamLogs.generation;
 
-        // `entries` (appends/upserts) and `updates` (in-place edits) get
-        // identical treatment; process them in order in a single pass.
-        for (const entry of [...entries, ...updates]) {
+        const processEntry = (entry: StreamLogEntry) => {
           const existingIndex = streamLogs.logIndex.get(entry.id);
           const changed = applyEntry(entry, streamLogs, streamState);
           logChanged ||= changed.logChanged;
@@ -189,7 +187,13 @@ export const logHandlers: HandlerRegistry = {
           if (changed.logChanged && existingIndex !== undefined) {
             updatedMessageIndices.add(existingIndex);
           }
-        }
+        };
+
+        // `entries` (appends/upserts) and `updates` (in-place edits) get
+        // identical treatment; keep their ordering without allocating a
+        // combined array in the streaming update path.
+        for (const entry of entries) processEntry(entry);
+        for (const entry of updates) processEntry(entry);
 
         if (logChanged) {
           draft.streamLogs.set(streamId, {

--- a/packages/extension/src/progressView/frontend/slices/logSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/logSlice.ts
@@ -179,17 +179,9 @@ export const logHandlers: HandlerRegistry = {
         const updatedMessageIndices = new Set<number>();
         const updatedMessageBaseGeneration = streamLogs.generation;
 
-        for (const entry of entries) {
-          const existingIndex = streamLogs.logIndex.get(entry.id);
-          const changed = applyEntry(entry, streamLogs, streamState);
-          logChanged ||= changed.logChanged;
-          stateChanged ||= changed.stateChanged;
-          if (changed.logChanged && existingIndex !== undefined) {
-            updatedMessageIndices.add(existingIndex);
-          }
-        }
-
-        for (const entry of updates) {
+        // `entries` (appends/upserts) and `updates` (in-place edits) get
+        // identical treatment; process them in order in a single pass.
+        for (const entry of [...entries, ...updates]) {
           const existingIndex = streamLogs.logIndex.get(entry.id);
           const changed = applyEntry(entry, streamLogs, streamState);
           logChanged ||= changed.logChanged;

--- a/packages/extension/src/settingsView/frontend/components/history/HistoryList.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryList.ts
@@ -245,6 +245,16 @@ export class HistoryList extends LitElement {
     this.page = event.detail.page;
   }
 
+  private renderPagination(): TemplateResult | string {
+    if (!this.paginated) return '';
+    return html`<list-pagination
+      .page=${this.page}
+      .totalItems=${this.items.length}
+      .pageSize=${HISTORY_PAGE_SIZE}
+      @page-change=${this.handlePageChange}
+    ></list-pagination>`;
+  }
+
   override render(): TemplateResult {
     if (!this.items.length) {
       return html`<div class="empty-state">
@@ -275,16 +285,7 @@ export class HistoryList extends LitElement {
     }
 
     return html`
-      ${
-        this.paginated
-          ? html`<list-pagination
-              .page=${this.page}
-              .totalItems=${this.items.length}
-              .pageSize=${HISTORY_PAGE_SIZE}
-              @page-change=${this.handlePageChange}
-            ></list-pagination>`
-          : ''
-      }
+      ${this.renderPagination()}
       <div class="history-container">
         ${repeat(
           displayItems,
@@ -301,16 +302,7 @@ export class HistoryList extends LitElement {
           `,
         )}
       </div>
-      ${
-        this.paginated
-          ? html`<list-pagination
-              .page=${this.page}
-              .totalItems=${this.items.length}
-              .pageSize=${HISTORY_PAGE_SIZE}
-              @page-change=${this.handlePageChange}
-            ></list-pagination>`
-          : ''
-      }
+      ${this.renderPagination()}
     `;
   }
 }

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryList.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryList.ts
@@ -74,6 +74,15 @@ export class MemoryList extends LitElement {
     this.page = event.detail.page;
   }
 
+  private renderPagination(): TemplateResult {
+    return html`<list-pagination
+      .page=${this.page}
+      .totalItems=${this.items.length}
+      .pageSize=${DEFAULT_PAGE_SIZE}
+      @page-change=${this.handlePageChange}
+    ></list-pagination>`;
+  }
+
   override render(): TemplateResult {
     if (!this.items.length) {
       return html`<div class="empty-state">
@@ -89,12 +98,7 @@ export class MemoryList extends LitElement {
     const { paged } = paginate(this.items, this.page, DEFAULT_PAGE_SIZE);
 
     return html`
-      <list-pagination
-        .page=${this.page}
-        .totalItems=${this.items.length}
-        .pageSize=${DEFAULT_PAGE_SIZE}
-        @page-change=${this.handlePageChange}
-      ></list-pagination>
+      ${this.renderPagination()}
       <div class="memory-list">
         ${repeat(
           paged,
@@ -102,12 +106,7 @@ export class MemoryList extends LitElement {
           (item) => html`<memory-item .item=${item}></memory-item>`,
         )}
       </div>
-      <list-pagination
-        .page=${this.page}
-        .totalItems=${this.items.length}
-        .pageSize=${DEFAULT_PAGE_SIZE}
-        @page-change=${this.handlePageChange}
-      ></list-pagination>
+      ${this.renderPagination()}
     `;
   }
 }

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
@@ -30,14 +30,6 @@ import { resolveProviderKeyRows } from './providerKeyRows';
 import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
 import type WaSwitch from '@awesome.me/webawesome/dist/components/switch/switch.js';
 
-const STATUS_LABELS: Record<
-  Exclude<ProviderKeyStatus['status'], 'set'>,
-  string
-> = {
-  env: 'Env',
-  'not-set': 'Not set',
-};
-
 @customElement('provider-key-list')
 export class ProviderKeyList extends LitElement {
   static override styles = [
@@ -64,8 +56,8 @@ export class ProviderKeyList extends LitElement {
       status,
       title: 'Key set',
       fallbacks: {
-        env: { label: STATUS_LABELS.env },
-        'not-set': { label: STATUS_LABELS['not-set'] },
+        env: { label: 'Env' },
+        'not-set': { label: 'Not set' },
       },
     });
   }

--- a/packages/extension/src/settingsView/frontend/components/shared/Pagination.ts
+++ b/packages/extension/src/settingsView/frontend/components/shared/Pagination.ts
@@ -35,7 +35,7 @@ export function paginate<T>(
   const safePage = clamp(page, 0, totalPages - 1);
   const start = safePage * pageSize;
   return {
-    paged: items.slice(start, start + pageSize) as T[],
+    paged: items.slice(start, start + pageSize),
     totalPages,
   };
 }

--- a/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
@@ -366,18 +366,18 @@ export class GitTab extends LitElement {
                                             >
                                             <wa-button
                                               appearance="outlined"
-                                            variant="neutral"
-                                            size="small"
-                                            @click=${() =>
-                                              this.handleOpenPRSubscriptionStream(
-                                                owner.streamId,
-                                              )}
-                                          >
-                                            ${waIcon('comment-discussion', {
-                                              slot: 'start',
-                                            })}
-                                            Jump to agent
-                                          </wa-button>
+                                              variant="neutral"
+                                              size="small"
+                                              @click=${() =>
+                                                this.handleOpenPRSubscriptionStream(
+                                                  owner.streamId,
+                                                )}
+                                            >
+                                              ${waIcon('comment-discussion', {
+                                                slot: 'start',
+                                              })}
+                                              Jump to agent
+                                            </wa-button>
                                           </div>
                                         `,
                                       )}

--- a/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
@@ -366,18 +366,18 @@ export class GitTab extends LitElement {
                                             >
                                             <wa-button
                                               appearance="outlined"
-                                              variant="neutral"
-                                              size="small"
-                                              @click=${() =>
-                                                this.handleOpenPRSubscriptionStream(
-                                                  owner.streamId,
-                                                )}
-                                            >
-                                              ${waIcon('comment-discussion', {
-                                                slot: 'start',
-                                              })}
-                                              Jump to agent
-                                            </wa-button>
+                                            variant="neutral"
+                                            size="small"
+                                            @click=${() =>
+                                              this.handleOpenPRSubscriptionStream(
+                                                owner.streamId,
+                                              )}
+                                          >
+                                            ${waIcon('comment-discussion', {
+                                              slot: 'start',
+                                            })}
+                                            Jump to agent
+                                          </wa-button>
                                           </div>
                                         `,
                                       )}

--- a/packages/extension/src/webview/MainViewMessageHandler.ts
+++ b/packages/extension/src/webview/MainViewMessageHandler.ts
@@ -113,14 +113,10 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
   private createHandlerRegistry(): MainViewInboundHandlerRegistry {
     return {
       // Common messages
-      [MAIN_VIEW_COMMANDS.THEME_SET]: (m) => {
-        const view = this.getActiveView();
-        if (view) return this.handleTheme(m, view);
-      },
-      [MAIN_VIEW_COMMANDS.DEBUG_MODE_SET]: (m) => {
-        const view = this.getActiveView();
-        if (view) return this.handleDebugMode(m, view);
-      },
+      [MAIN_VIEW_COMMANDS.THEME_SET]: (m) =>
+        this.runWithActiveView((view) => this.handleTheme(m, view)),
+      [MAIN_VIEW_COMMANDS.DEBUG_MODE_SET]: (m) =>
+        this.runWithActiveView((view) => this.handleDebugMode(m, view)),
       [MAIN_VIEW_COMMANDS.WEBVIEW_READY]: () => this.handleWebviewReady(),
       [MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE]: (m) => {
         vscode.window.showInformationMessage(m.text);
@@ -234,14 +230,10 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       [MAIN_VIEW_COMMANDS.CLIPBOARD_IMAGE]: (m) =>
         this.instructionManager.handleClipboardImage(m),
 
-      [MAIN_VIEW_COMMANDS.START_RECORDING]: () => {
-        const view = this.getActiveView();
-        if (view) return this.recordingManager.start(view);
-      },
-      [MAIN_VIEW_COMMANDS.STOP_RECORDING]: () => {
-        const view = this.getActiveView();
-        if (view) return this.recordingManager.stop(view);
-      },
+      [MAIN_VIEW_COMMANDS.START_RECORDING]: () =>
+        this.runWithActiveView((view) => this.recordingManager.start(view)),
+      [MAIN_VIEW_COMMANDS.STOP_RECORDING]: () =>
+        this.runWithActiveView((view) => this.recordingManager.stop(view)),
 
       [MAIN_VIEW_COMMANDS.OPEN_SET_API_KEY]: async () => {
         await safeExecuteCommand('texra.setApiKey');
@@ -416,6 +408,14 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
     value: boolean;
   }): Promise<void> {
     await updateConfig(configUpdate.key, configUpdate.value);
+  }
+
+  /** Run `fn` with the active webview view, or no-op when none is attached. */
+  private runWithActiveView<T>(
+    fn: (view: vscode.WebviewView) => T,
+  ): T | undefined {
+    const view = this.getActiveView();
+    return view ? fn(view) : undefined;
   }
 
   /**

--- a/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
+++ b/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
@@ -122,8 +122,7 @@ export class FileSelectGroup extends LitElement {
   }
 
   private get currentFiles(): string[] {
-    const key =
-      `${this.config.type}Files` as keyof FileStateContextValue['multiFiles'];
+    const key = this.listId as keyof FileStateContextValue['multiFiles'];
     return this.fileState?.multiFiles[key] ?? [];
   }
 

--- a/packages/extension/src/webview/frontend/fileDropHandler.ts
+++ b/packages/extension/src/webview/frontend/fileDropHandler.ts
@@ -70,7 +70,7 @@ export function hasDroppedFilePayload(
   dataTransfer: DataTransfer | null,
 ): boolean {
   if (!dataTransfer) return false;
-  const types = dataTransfer.types ?? [];
+  const types = [...(dataTransfer.types ?? [])];
   return (
     types.includes('Files') ||
     types.includes('application/vnd.code.tree.resource') ||

--- a/packages/extension/src/webview/frontend/fileDropHandler.ts
+++ b/packages/extension/src/webview/frontend/fileDropHandler.ts
@@ -70,12 +70,13 @@ export function hasDroppedFilePayload(
   dataTransfer: DataTransfer | null,
 ): boolean {
   if (!dataTransfer) return false;
-  const types = [...(dataTransfer.types ?? [])];
-  if (types.includes('Files')) return true;
-  if (types.includes('application/vnd.code.tree.resource')) return true;
-  return types.includes('text/uri-list')
-    ? hasFileUri(dataTransfer, 'text/uri-list')
-    : false;
+  const types = dataTransfer.types ?? [];
+  return (
+    types.includes('Files') ||
+    types.includes('application/vnd.code.tree.resource') ||
+    (types.includes('text/uri-list') &&
+      hasFileUri(dataTransfer, 'text/uri-list'))
+  );
 }
 
 /** Extract absolute paths or file URIs from a drop payload. */

--- a/src/agent/implementations/flows/reflection/nodes/MediaExtractionNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/MediaExtractionNode.ts
@@ -94,7 +94,7 @@ export class MediaExtractionNode<C = unknown> extends Node<
   ): Promise<string | undefined> {
     shared.workspaceSnapshot = prepRes.workspaceState.toSnapshot();
 
-    if (mediaFiles && mediaFiles.length > 0 && shared.context) {
+    if (mediaFiles?.length && shared.context) {
       await this.services.modelHandler.addMediaToUserMessage(
         shared.context.messages,
         mediaFiles,

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -51,7 +51,7 @@ export class ToolUseCycleNode<C> extends Node<
   }
 
   async exec(prepRes: CyclePrepResult): Promise<ToolUseCycleOutcome> {
-    const { setting, resolvedTools, modelHandler, config } = this.services;
+    const { setting, resolvedTools, modelHandler } = this.services;
     const { streamId, runtimeHost } = useLaunchRunContext();
 
     if (prepRes.shouldSkip) {

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -385,8 +385,7 @@ export async function runToolUseFlow<C = unknown>(
       shared.lastResponse ||
       undefined;
     totalCostUsd =
-      shared.stateSlices?.runStateSnapshot.usageAccumulator.totals.totalCost ??
-      undefined;
+      shared.stateSlices?.runStateSnapshot.usageAccumulator.totals.totalCost;
     const extractedTouchedFiles = extractTouchedFiles(shared.stateSlices);
     touchedFiles = extractedTouchedFiles.length
       ? extractedTouchedFiles

--- a/src/agent/index/remoteAgentMeta.ts
+++ b/src/agent/index/remoteAgentMeta.ts
@@ -25,11 +25,7 @@ export function persistRemoteAgentMeta(
   agentName: string,
   meta: { tools?: string[]; defaultOutputFiles?: string[] },
 ): void {
-  const stored =
-    platform().globalState.get<RemoteAgentMetaCache>(
-      GlobalStateKey.REMOTE_AGENT_META_CACHE,
-      {},
-    ) ?? {};
+  const stored = getPersistedRemoteAgentMeta();
   stored[agentName] = { ...stored[agentName], ...meta };
   void platform().globalState.update(
     GlobalStateKey.REMOTE_AGENT_META_CACHE,

--- a/src/agent/modelHandlers/anthropic/anthropicContextManagement.ts
+++ b/src/agent/modelHandlers/anthropic/anthropicContextManagement.ts
@@ -79,9 +79,7 @@ export function ensureBeta(
   options: MessageCreateParams,
   beta: AnthropicBeta,
 ): void {
-  if (!options.betas) {
-    options.betas = [];
-  }
+  options.betas ??= [];
   if (!options.betas.includes(beta)) {
     options.betas.push(beta);
   }
@@ -255,7 +253,7 @@ export function enforceCacheControlLimit(
     MAX_CACHE_BREAKPOINT_SLOTS - reservedSlots,
   );
   const excess = Math.max(0, compactionBlocks.length - availableSlots);
-  for (let idx = 0; idx < excess; idx += 1) {
-    delete compactionBlocks[idx].cache_control;
+  for (const block of compactionBlocks.slice(0, excess)) {
+    delete block.cache_control;
   }
 }

--- a/src/agent/modelHandlers/google/googleHandlerShared.ts
+++ b/src/agent/modelHandlers/google/googleHandlerShared.ts
@@ -71,11 +71,11 @@ export async function resolveGoogleClient(
     setCached,
   } = params;
 
-  if (shouldUseServerSideKeys) {
+  const createClient = async (relayAuth: boolean): Promise<GoogleGenAI> => {
     const credential = await getApiKey();
     const baseUrl = getBaseUrl();
     logger.debug(
-      `Using Google GenAI ${sdkLabel} SDK with relay auth. Base URL: ${baseUrl}`,
+      `Using Google GenAI ${sdkLabel} SDK${relayAuth ? ' with relay auth' : ''}. Base URL: ${baseUrl}`,
     );
     return new GoogleGenAI({
       apiKey: credential,
@@ -84,23 +84,19 @@ export async function resolveGoogleClient(
         retryOptions: { attempts: 1 },
       },
     });
+  };
+
+  if (shouldUseServerSideKeys) {
+    return createClient(true);
   }
 
-  if (!cached) {
-    const credential = await getApiKey();
-    const baseUrl = getBaseUrl();
-    logger.debug(`Using Google GenAI ${sdkLabel} SDK. Base URL: ${baseUrl}`);
-    const client = new GoogleGenAI({
-      apiKey: credential,
-      httpOptions: {
-        baseUrl: baseUrl ?? undefined,
-        retryOptions: { attempts: 1 },
-      },
-    });
-    setCached(client);
-    return client;
+  if (cached) {
+    return cached;
   }
-  return cached;
+
+  const client = await createClient(false);
+  setCached(client);
+  return client;
 }
 
 interface ResolveGeminiThinkingLevelParams<T> {

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -757,7 +757,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       lastMessage?.role === 'user' &&
       this.containCutOffMessage(
         (lastMessage.parts ?? [])
-          .filter((part): part is Part & { text: string } => isTextPart(part))
+          .filter(isTextPart)
           .map((part) => part.text)
           .join(''),
       )

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -618,18 +618,12 @@ export class ModelHandlerOpenAI<
     await this.applyTokenCountLimit({
       countTokens: () =>
         this.estimateTokenCount(messages, { client, systemPrompt, signal }),
-      currentMaxTokens: this.isOReasoningModel
-        ? (baseParams.max_completion_tokens ??
-          this.getEffectiveMaxOutputTokens())
-        : (baseParams.max_tokens ?? this.getEffectiveMaxOutputTokens()),
+      currentMaxTokens:
+        baseParams[maxTokensKey] ?? this.getEffectiveMaxOutputTokens(),
       contextWindow: this.config.contextWindow,
       detailLabel: `OpenAI: ${maxTokensKey} reduced to fit context window`,
       applyReduced: (adjusted) => {
-        if (this.isOReasoningModel) {
-          baseParams.max_completion_tokens = adjusted;
-        } else {
-          baseParams.max_tokens = adjusted;
-        }
+        baseParams[maxTokensKey] = adjusted;
       },
     });
 

--- a/src/agent/modelHandlers/openai/openAIChatHelpers.ts
+++ b/src/agent/modelHandlers/openai/openAIChatHelpers.ts
@@ -3,7 +3,7 @@ import type { ChatCompletionChunk } from 'openai/resources/chat/completions';
 import type { ChatCompletionSnapshot } from 'openai/lib/ChatCompletionStream';
 
 // Reasoning content type for DeepSeek, o1 models (not in SDK)
-type ReasoningContent = string | Array<{ type: string; text?: string }>;
+type ReasoningContent = string | { type: string; text?: string }[];
 
 function extractReasoningText(content: ReasoningContent | undefined): string {
   if (!content) return '';

--- a/src/agent/modelHandlers/openai/openAIMessageUtils.ts
+++ b/src/agent/modelHandlers/openai/openAIMessageUtils.ts
@@ -15,7 +15,7 @@ type MessageLike = {
   reasoning_content?: unknown;
 };
 
-type ContentArray = Array<Record<string, unknown>>;
+type ContentArray = Record<string, unknown>[];
 
 /** Type guard for text content items in message content arrays. */
 function isTextContentItem(
@@ -173,7 +173,7 @@ export function normalizeOpenAIMessageContent<T extends MessageLike>(
     for (const message of working) {
       if (Array.isArray(message.content)) {
         // Extract text from content array items and join with newlines
-        message.content = (message.content as Array<unknown>)
+        message.content = (message.content as unknown[])
           .filter(isTextContentItem)
           .map((item) => item.text)
           .join('\n');

--- a/src/agent/modelHandlers/openrouter/openRouterStreaming.ts
+++ b/src/agent/modelHandlers/openrouter/openRouterStreaming.ts
@@ -81,9 +81,7 @@ export class OpenRouterStreamAggregator {
     // Reasoning - try reasoningDetails first, then reasoning string
     let reasoningDelta = '';
     if (delta.reasoningDetails?.length) {
-      for (const detail of delta.reasoningDetails) {
-        this.reasoningDetails.push(detail);
-      }
+      this.reasoningDetails.push(...delta.reasoningDetails);
       reasoningDelta = extractTextFromReasoningDetails(delta.reasoningDetails);
     } else if (delta.reasoning) {
       reasoningDelta = delta.reasoning;

--- a/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
+++ b/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
@@ -432,7 +432,7 @@ export class AnthropicStreamHandler {
       this.state.pendingSearches,
       this.state.pendingFetches,
     ]) {
-      for (const [, data] of pendingMap) {
+      for (const data of pendingMap.values()) {
         if (data.index === blockIndex) {
           if (data.input.length < MAX_SERVER_TOOL_INPUT_SIZE) {
             const remaining = MAX_SERVER_TOOL_INPUT_SIZE - data.input.length;

--- a/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
+++ b/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
@@ -208,10 +208,10 @@ export function extractToolAttachments(
   // Strip binary data from file references, keep metadata
   if (status === 'executed' && attachments.length > 0) {
     sanitizedResult.files = attachments.map(
-      ({ base64Data, bytes, ...rest }): FileReference => ({
-        path: rest.path,
-        mimeType: rest.mimeType,
-        ...(rest.description ? { description: rest.description } : {}),
+      (file): FileReference => ({
+        path: file.path,
+        mimeType: file.mimeType,
+        ...(file.description ? { description: file.description } : {}),
       }),
     );
   } else {

--- a/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
+++ b/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
@@ -207,13 +207,11 @@ export function extractToolAttachments(
 
   // Strip binary data from file references, keep metadata
   if (status === 'executed' && attachments.length > 0) {
-    sanitizedResult.files = attachments.map(
-      (file): FileReference => ({
-        path: file.path,
-        mimeType: file.mimeType,
-        ...(file.description ? { description: file.description } : {}),
-      }),
-    );
+    sanitizedResult.files = attachments.map((file): FileReference => ({
+      path: file.path,
+      mimeType: file.mimeType,
+      ...(file.description ? { description: file.description } : {}),
+    }));
   } else {
     // Remove files key if no valid attachments
     delete sanitizedResult.files;

--- a/src/agent/output/extraction/filenameHeaders.ts
+++ b/src/agent/output/extraction/filenameHeaders.ts
@@ -96,11 +96,7 @@ function makeUniquePercentHeaderName(
   reservedFinalPaths: Set<string>,
   roundDir: string,
 ): string {
-  const normalized = source.replaceAll('\\', '/');
-  const safeName = getSafeDocumentRelativePath(normalized).replaceAll(
-    '\\',
-    '/',
-  );
+  const safeName = safeDocumentName(source);
   let candidate = safeName;
   let suffix = 2;
 

--- a/src/agent/output/lineageMapping.ts
+++ b/src/agent/output/lineageMapping.ts
@@ -76,7 +76,7 @@ function findMatchingBaseFile(
 ): FileLocation | undefined {
   const src = computePathKeys(source);
 
-  const matchers: Array<(entry: BaseEntry) => boolean> = [
+  const matchers: ((entry: BaseEntry) => boolean)[] = [
     (entry) => entry.relativePath === src.relativePath,
     (entry) => entry.relativePathNoExt === src.relativePathNoExt,
     (entry) => entry.baseName === src.relativePath,

--- a/src/agent/runtime/runCoordinators.ts
+++ b/src/agent/runtime/runCoordinators.ts
@@ -211,7 +211,7 @@ interface CoordinatorRequest {
 function matchingRequests(
   requests: ReadonlyMap<string, CoordinatorRequest>,
   streamId: string,
-): Array<[string, CoordinatorRequest]> {
+): [string, CoordinatorRequest][] {
   return [...requests.entries()].filter(
     ([, entry]) => entry.streamId === streamId,
   );

--- a/src/agent/runtime/textEnhancement.ts
+++ b/src/agent/runtime/textEnhancement.ts
@@ -52,7 +52,7 @@ function formatFileContext(ctx: FileContext): string {
 
   const fileEntries: string[] = [];
 
-  const arrays: Array<[string, string[] | undefined]> = [
+  const arrays: [string, string[] | undefined][] = [
     ['Input Files', ctx.inputFiles],
     ['Context Files', ctx.contextFiles],
     ['Media Files', ctx.mediaFiles],

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -84,8 +84,6 @@ export async function buildUserVars(
   logger: AgentTrace,
   workspacePath?: string,
 ): Promise<UserVars> {
-  const allLoadedFiles: LoadedFileEntry[] = [];
-
   // Parallelize independent I/O: required files, pattern files, rules, and memories
   const [
     { vars: requiredVars, files: requiredFiles },
@@ -110,8 +108,7 @@ export async function buildUserVars(
       ? loadRuntimeSkillCatalog(logger)
       : Promise.resolve(''),
   ]);
-  allLoadedFiles.push(...requiredFiles);
-  allLoadedFiles.push(...patternFiles);
+  const allLoadedFiles: LoadedFileEntry[] = [...requiredFiles, ...patternFiles];
 
   // Merge all variable sources using spread operator.
   // LATEX_STYLE_RULES is placed last to prevent silent overrides from spreads.

--- a/src/common/files/index.ts
+++ b/src/common/files/index.ts
@@ -1,6 +1,6 @@
 // Barrel export for common file utilities
 export {
-  ExtensionCategory,
+  type ExtensionCategory,
   EXTENSION_CATEGORIES,
   getFilterExtensions,
   getIncludedExtensions,

--- a/src/controllers/settingsView/SettingsModelSelectionController.ts
+++ b/src/controllers/settingsView/SettingsModelSelectionController.ts
@@ -92,11 +92,16 @@ export class SettingsModelSelectionController {
     enabled: boolean;
   }): Promise<void> {
     const current = this.getVisibleModels();
-    const updated = input.enabled
-      ? current.includes(input.modelName)
-        ? current
-        : [...current, input.modelName]
-      : current.filter((modelName) => modelName !== input.modelName);
+
+    let updated: string[];
+    if (!input.enabled) {
+      updated = current.filter((modelName) => modelName !== input.modelName);
+    } else if (current.includes(input.modelName)) {
+      updated = current;
+    } else {
+      updated = [...current, input.modelName];
+    }
+
     const wasHelper =
       !input.enabled &&
       this.getEffectiveHelperModel(current) === input.modelName;

--- a/src/housekeeping/pack.ts
+++ b/src/housekeeping/pack.ts
@@ -202,8 +202,8 @@ function buildFileListLog(movedFiles: string[], copiedFiles: string[]): string {
 function packDestinationName(file: string): string {
   const base = path.basename(file);
   const segments = path.dirname(file).split(/[\\/]+/);
-  for (let i = segments.length - 1; i >= 0; i--) {
-    const round = parseWorkflowOutputRoundDir(segments[i]);
+  for (const segment of segments.toReversed()) {
+    const round = parseWorkflowOutputRoundDir(segment);
     if (round !== null) return `r${round}_${base}`;
   }
   return base;

--- a/src/latex/latexdiff/diffFileNameManager.ts
+++ b/src/latex/latexdiff/diffFileNameManager.ts
@@ -79,10 +79,10 @@ export function detectGeneratedLatexdiffArtifact(
   const parsed = path.parse(filePath);
   if (parsed.ext.toLowerCase() !== '.tex') return null;
 
-  const patterns: Array<{
+  const patterns: {
     kind: GeneratedLatexdiffArtifactKind;
     regex: RegExp;
-  }> = [
+  }[] = [
     { kind: 'versionControlDiff', regex: /^(.+)-diff[0-9a-f]{6,40}$/i },
     { kind: 'betweenRoundDiff', regex: /^(.+)_diffr\d+r\d+$/i },
     { kind: 'workspaceDiff', regex: /^(.+)_diff$/i },

--- a/src/latex/latexdiff/diffFileProcessor.ts
+++ b/src/latex/latexdiff/diffFileProcessor.ts
@@ -37,7 +37,7 @@ const PREAMBLE_SKIP_MARKERS = ['%DIF ADD', 'Here is', '以下是'];
 const DOCUMENT_START_MARKERS = ['\\documentclass', '\\input'];
 
 /** Patterns to fix broken document endings after latexdiff processing. */
-const DOCUMENT_END_FIXES: Array<[RegExp, string]> = [
+const DOCUMENT_END_FIXES: [RegExp, string][] = [
   [/\\end\{document\}\s*\\chapter/g, '\\chapter'],
   [/\\end\{document\}\s*\\addcontentsline/g, '\\addcontentsline'],
 ];

--- a/src/latex/latexdiff/outputDiscovery.ts
+++ b/src/latex/latexdiff/outputDiscovery.ts
@@ -59,16 +59,11 @@ export async function collectTexFiles(
     // Skip symlinks — they are mirrored dependency copies placed by
     // ensureMirroredInRoundDir, not revised outputs.
     if (await fs.isSymlink(absPath).catch(() => false)) continue;
-    if (isFile(type)) {
-      if (hasExtension(name, '.tex')) {
-        results.push(prefix ? `${prefix}/${name}` : name);
-      }
+    const relative = prefix ? `${prefix}/${name}` : name;
+    if (isFile(type) && hasExtension(name, '.tex')) {
+      results.push(relative);
     } else if (isDirectory(type)) {
-      const sub = await collectTexFiles(
-        absPath,
-        prefix ? `${prefix}/${name}` : name,
-      );
-      results.push(...sub);
+      results.push(...(await collectTexFiles(absPath, relative)));
     }
   }
   return results;

--- a/src/replacement/rules/forbiddenCommands.ts
+++ b/src/replacement/rules/forbiddenCommands.ts
@@ -10,7 +10,5 @@ export const LATEX_FORBIDDEN_REPLACEMENTS: ReplacementCategory = {
   description:
     'Removes LaTeX commands that should never appear, such as section endings',
   isRegex: false,
-  patterns: {
-    ...generateInvalidSectionEndingFixes(SECTION_TYPES),
-  },
+  patterns: generateInvalidSectionEndingFixes(SECTION_TYPES),
 };

--- a/src/replacement/rulesRegex.ts
+++ b/src/replacement/rulesRegex.ts
@@ -8,10 +8,6 @@ import {
 const EQUATION_ENVIRONMENT_PATTERN =
   '(?:align\\*?|aligned\\*?|alignat\\*?|flalign\\*?|gather\\*?|multline\\*?|equation\\*?|eqnarray\\*?|split\\*?)';
 
-function getSafeString(value: string | undefined): string {
-  return typeof value === 'string' ? value : '';
-}
-
 const convertFencedLatexBlock: ReplacementFunction = (
   match,
   leadingBreak,
@@ -21,10 +17,10 @@ const convertFencedLatexBlock: ReplacementFunction = (
   inlineBody,
 ) => {
   const newline = match.includes('\r\n') ? '\r\n' : '\n';
-  const safeLeadingBreak = getSafeString(leadingBreak);
-  const safeIndent = getSafeString(indent);
-  const safeEnvironment = getSafeString(environment);
-  const safeBody = getSafeString(multilineBody) || getSafeString(inlineBody);
+  const safeLeadingBreak = leadingBreak ?? '';
+  const safeIndent = indent ?? '';
+  const safeEnvironment = environment ?? '';
+  const safeBody = multilineBody || inlineBody || '';
 
   let bodyWithTrailingBreak = '';
   if (safeBody !== '') {

--- a/src/shared/highlighting/lightweightMd.ts
+++ b/src/shared/highlighting/lightweightMd.ts
@@ -11,14 +11,12 @@ import { highlightCode } from './highlightCode';
 let md: MarkdownIt | null = null;
 
 /** Returns a shared, lazily-initialized MarkdownIt instance. */
-export const getLightweightMd = (): MarkdownIt => {
-  if (!md) {
-    md = new MarkdownIt({
-      breaks: false,
-      linkify: true,
-      html: false,
-      highlight: highlightCode,
-    });
-  }
+export function getLightweightMd(): MarkdownIt {
+  md ??= new MarkdownIt({
+    breaks: false,
+    linkify: true,
+    html: false,
+    highlight: highlightCode,
+  });
   return md;
-};
+}

--- a/src/shared/litControllers/CopyButtonController.ts
+++ b/src/shared/litControllers/CopyButtonController.ts
@@ -104,8 +104,7 @@ export class CopyButtonController implements ReactiveController {
    * Automatically resets to default state after the configured delay.
    */
   copy = async (text: string): Promise<boolean> => {
-    const trimmed = text.trim();
-    if (!trimmed) {
+    if (!text.trim()) {
       return false;
     }
 

--- a/src/shared/markdown/createMarkdownProcessor.ts
+++ b/src/shared/markdown/createMarkdownProcessor.ts
@@ -226,8 +226,7 @@ export function createMarkdownProcessor(
     const rendered = renderWithEnv.call(config.renderer, formatted, {
       restoreProtectedLatex,
     });
-    let result = rendered;
-    result = restoreProtectedLatex(result);
+    const result = restoreProtectedLatex(rendered);
 
     // lru-cache's `sizeCalculation` rejects zero, so skip caching the empty
     // render (e.g. content that's only a link-reference definition).

--- a/src/shared/progressView/backend/ApprovalRequestHandler.ts
+++ b/src/shared/progressView/backend/ApprovalRequestHandler.ts
@@ -49,7 +49,7 @@ export class ApprovalRequestHandler<
    *  is either new or lost state, so everything must be (re-)delivered. */
   replay(): void {
     this.delivered.clear();
-    for (const [id, item] of this.pending.entries()) {
+    for (const [id, item] of this.pending) {
       this.delivered.add(id);
       this.sendShow(item);
     }

--- a/src/shared/schemas/memoryViewMessages.ts
+++ b/src/shared/schemas/memoryViewMessages.ts
@@ -91,33 +91,28 @@ export const GetMemoryDataMessageSchema = commandOnly(
   MEMORY_VIEW_COMMANDS.GET_MEMORY_DATA,
 );
 
-export const GetMemoryPreviewMessageSchema = z.object({
+export const GetMemoryPreviewMessageSchema = MemoryPathMessageSchema.extend({
   command: z.literal(MEMORY_VIEW_COMMANDS.GET_MEMORY_PREVIEW),
-  storagePath: z.string().min(1),
 });
 
-export const OpenMemoryFileMessageSchema = z.object({
+export const OpenMemoryFileMessageSchema = MemoryPathMessageSchema.extend({
   command: z.literal(MEMORY_VIEW_COMMANDS.OPEN_MEMORY_FILE),
-  storagePath: z.string().min(1),
 });
 
 export const OpenMemoryFolderMessageSchema = commandOnly(
   MEMORY_VIEW_COMMANDS.OPEN_MEMORY_FOLDER,
 );
 
-export const DeleteMemoryMessageSchema = z.object({
+export const DeleteMemoryMessageSchema = MemoryDeleteMessageSchema.extend({
   command: z.literal(MEMORY_VIEW_COMMANDS.DELETE_MEMORY),
-  storagePath: z.string().min(1),
-  displayPath: z.string().min(1),
 });
 
 export const GetMemoryEnabledMessageSchema = commandOnly(
   MEMORY_VIEW_COMMANDS.GET_MEMORY_ENABLED,
 );
 
-export const SetMemoryEnabledMessageSchema = z.object({
+export const SetMemoryEnabledMessageSchema = MemoryEnabledMessageSchema.extend({
   command: z.literal(MEMORY_VIEW_COMMANDS.SET_MEMORY_ENABLED),
-  enabled: z.boolean(),
 });
 
 export const PinMemoryMessageSchema = MemoryPathMessageSchema.extend({

--- a/src/shared/state/PersistedState.ts
+++ b/src/shared/state/PersistedState.ts
@@ -184,7 +184,7 @@ function describeStored(value: unknown): string {
 }
 
 /** First few zod issues, trimmed so the console stays readable. */
-function summarizeIssues(error: z.ZodError): Array<Record<string, unknown>> {
+function summarizeIssues(error: z.ZodError): Record<string, unknown>[] {
   return error.issues.slice(0, 5).map((issue) => ({
     path: issue.path.join('.') || '(root)',
     code: issue.code,

--- a/src/shared/state/ToggleStateStore.ts
+++ b/src/shared/state/ToggleStateStore.ts
@@ -28,11 +28,11 @@ export class ToggleStateStore {
     this.saveCallback?.();
   }
 
-  entries(): Array<[string, boolean]> {
+  entries(): [string, boolean][] {
     return [...this.states.entries()];
   }
 
-  load(data: Array<[string, boolean]>): void {
+  load(data: [string, boolean][]): void {
     this.states = new Map(data);
   }
 }

--- a/src/shared/subagentFollowup.ts
+++ b/src/shared/subagentFollowup.ts
@@ -147,8 +147,9 @@ function resultResponsePreview(response: string): string {
 
   if (!lineLimited && !charLimited) return decoded;
 
+  const extraLines = lines.length - RESULT_RESPONSE_PREVIEW_LINES;
   const hidden = lineLimited
-    ? `${lines.length - RESULT_RESPONSE_PREVIEW_LINES} more line${lines.length - RESULT_RESPONSE_PREVIEW_LINES === 1 ? '' : 's'}`
+    ? `${extraLines} more line${extraLines === 1 ? '' : 's'}`
     : 'more text';
   return `${preview}\n… ${hidden}; open the subagent transcript for the full response`;
 }

--- a/src/shared/tools/toolStatusLabels.ts
+++ b/src/shared/tools/toolStatusLabels.ts
@@ -7,16 +7,12 @@ const TOOL_STATUS_FALLBACK_LABELS = {
   'coming-soon': 'Coming soon',
 } satisfies Record<ToolStatus, string>;
 
-function toolStatusFallbackLabel(status: string): string {
-  if (Object.hasOwn(TOOL_STATUS_FALLBACK_LABELS, status)) {
-    return TOOL_STATUS_FALLBACK_LABELS[status as ToolStatus];
-  }
-  return status;
-}
-
 export function toolStatusLabel(
   status: string,
   statusLabel: string | undefined,
 ): string {
-  return statusLabel ?? toolStatusFallbackLabel(status);
+  if (statusLabel != null) return statusLabel;
+  return Object.hasOwn(TOOL_STATUS_FALLBACK_LABELS, status)
+    ? TOOL_STATUS_FALLBACK_LABELS[status as ToolStatus]
+    : status;
 }

--- a/src/shared/wa/walkthroughDialog.ts
+++ b/src/shared/wa/walkthroughDialog.ts
@@ -98,12 +98,6 @@ export function createWalkthroughDialog({
     dialog.open = false;
   };
 
-  const headerClass = classes?.header;
-  const iconClass = classes?.icon;
-  const stepsClass = classes?.steps;
-  const stepIndexClass = classes?.stepIndex;
-  const actionsClass = classes?.actions;
-
   const actionTemplate = (action: WalkthroughAction): TemplateResult => html`
     <wa-button
       class=${action.className ?? ''}
@@ -121,18 +115,18 @@ export function createWalkthroughDialog({
 
   render(
     html`
-      <header class=${headerClass ?? ''}>
-        ${waIcon(icon, { className: iconClass })}
+      <header class=${classes?.header ?? ''}>
+        ${waIcon(icon, { className: classes?.icon })}
         <div>
           <h1 id=${titleId}>${title}</h1>
           <p>${description}</p>
         </div>
       </header>
-      <ol class=${stepsClass ?? ''}>
+      <ol class=${classes?.steps ?? ''}>
         ${steps.map(
           (step) => html`
             <li>
-              <span class=${stepIndexClass ?? ''}>${step.index}</span>
+              <span class=${classes?.stepIndex ?? ''}>${step.index}</span>
               <div>
                 <strong>${step.title}</strong>
                 <span>${step.body}</span>
@@ -144,7 +138,7 @@ export function createWalkthroughDialog({
       ${
         actions.length > 0
           ? html`
-              <div slot="footer" class=${actionsClass ?? ''}>
+              <div slot="footer" class=${classes?.actions ?? ''}>
                 ${actions.map(actionTemplate)}
               </div>
             `

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -437,10 +437,7 @@ describe('ToolUseWaitNode', () => {
 
     try {
       const continuationCycles = 25;
-      for (const cycle of Array.from(
-        { length: continuationCycles },
-        (_, index) => index,
-      )) {
+      for (let cycle = 0; cycle < continuationCycles; cycle += 1) {
         const prep = await node.prep(shared);
         const exec = await withTestRunContext(
           services.runtimeHost,

--- a/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
@@ -78,11 +78,7 @@ describe('OpenAI model handler routing', () => {
   });
 
   it('routes switchable OpenAI models to Responses when the setting is unset', async () => {
-    const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
-      import('@platform/platform'),
-      import('@test/support/FakePlatform'),
-    ]);
-    initPlatform(createFakePlatform());
+    await initFakePlatform();
 
     expect(
       shouldUseResponsesAPI(modelConfig(ModelProvider.OPENAI), false),
@@ -159,15 +155,9 @@ describe('OpenAI model handler routing', () => {
   });
 
   it('uses short-name routing when computing compatibility keys', async () => {
-    const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
-      import('@platform/platform'),
-      import('@test/support/FakePlatform'),
-    ]);
-    initPlatform(
-      createFakePlatform({
-        config: { 'texra.model.useOpenAIResponsesAPI': false },
-      }),
-    );
+    await initFakePlatform({
+      config: { 'texra.model.useOpenAIResponsesAPI': false },
+    });
 
     expect(
       modelHandlerCompatibilityKey(
@@ -273,25 +263,19 @@ describe('OpenAI model handler routing', () => {
   });
 
   it('uses the Codex endpoint for a signed-in preferred subscription even when relay access is selected', async () => {
-    const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
-      import('@platform/platform'),
-      import('@test/support/FakePlatform'),
-    ]);
     const codexSession: CodexSession = {
       accessToken: 'access-token',
       refreshToken: 'refresh-token',
       expiresAtMs: Date.now() + 60_000,
       accountId: 'account-id',
     };
-    initPlatform(
-      createFakePlatform({
-        config: { 'texra.chatgptCodex.preferSubscription': true },
-        globalState: { 'texra.useIncludedModelAccess': true },
-        secrets: {
-          [CODEX_SESSION_SECRET_KEY]: JSON.stringify(codexSession),
-        },
-      }),
-    );
+    await initFakePlatform({
+      config: { 'texra.chatgptCodex.preferSubscription': true },
+      globalState: { 'texra.useIncludedModelAccess': true },
+      secrets: {
+        [CODEX_SESSION_SECRET_KEY]: JSON.stringify(codexSession),
+      },
+    });
 
     const handler = await createModelHandler(codexEligibleConfig);
     try {
@@ -306,24 +290,18 @@ describe('OpenAI model handler routing', () => {
   });
 
   it('does not let the Codex subscription override an explicit legacy OpenAI compatibility key', async () => {
-    const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
-      import('@platform/platform'),
-      import('@test/support/FakePlatform'),
-    ]);
     const codexSession: CodexSession = {
       accessToken: 'access-token',
       refreshToken: 'refresh-token',
       expiresAtMs: Date.now() + 60_000,
       accountId: 'account-id',
     };
-    initPlatform(
-      createFakePlatform({
-        config: { 'texra.chatgptCodex.preferSubscription': true },
-        secrets: {
-          [CODEX_SESSION_SECRET_KEY]: JSON.stringify(codexSession),
-        },
-      }),
-    );
+    await initFakePlatform({
+      config: { 'texra.chatgptCodex.preferSubscription': true },
+      secrets: {
+        [CODEX_SESSION_SECRET_KEY]: JSON.stringify(codexSession),
+      },
+    });
 
     const handler = await createModelHandlerForCompatibilityKey(
       codexEligibleConfig,
@@ -340,28 +318,22 @@ describe('OpenAI model handler routing', () => {
   });
 
   it('keeps Responses-compatible resumes on the Codex endpoint when subscription access is preferred', async () => {
-    const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
-      import('@platform/platform'),
-      import('@test/support/FakePlatform'),
-    ]);
     const codexSession: CodexSession = {
       accessToken: 'access-token',
       refreshToken: 'refresh-token',
       expiresAtMs: Date.now() + 60_000,
       accountId: 'account-id',
     };
-    initPlatform(
-      createFakePlatform({
-        config: { 'texra.chatgptCodex.preferSubscription': true },
-        globalState: {
-          'texra.useIncludedModelAccess': true,
-          'texra.useOpenRouter': true,
-        },
-        secrets: {
-          [CODEX_SESSION_SECRET_KEY]: JSON.stringify(codexSession),
-        },
-      }),
-    );
+    await initFakePlatform({
+      config: { 'texra.chatgptCodex.preferSubscription': true },
+      globalState: {
+        'texra.useIncludedModelAccess': true,
+        'texra.useOpenRouter': true,
+      },
+      secrets: {
+        [CODEX_SESSION_SECRET_KEY]: JSON.stringify(codexSession),
+      },
+    });
 
     const handler = await createModelHandlerForCompatibilityKey(
       codexEligibleConfig,

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerGoogleGenAI.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerGoogleGenAI.vitest.ts
@@ -247,10 +247,6 @@ describe('ModelHandlerGoogleGenAI media uploads', () => {
     const loggedResults: Array<Array<{ path: string; ok: boolean }>> = [];
 
     class RecordingHandler extends ModelHandlerGoogleGenAI {
-      constructor(config: ModelConfig) {
-        super(config);
-      }
-
       override async getClient(): Promise<any> {
         throw new Error('getClient should not be called in this test');
       }

--- a/src/test-kernel/agent/modelHandlers/OpenAIMessageUtils.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIMessageUtils.vitest.ts
@@ -2,10 +2,6 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'vitest';
 
-// Standard library imports
-
-// (none needed)
-
 // Local imports - agent
 import { normalizeOpenAIMessageContent } from '@agent/modelHandlers/openai/openAIMessageUtils';
 

--- a/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
@@ -115,16 +115,24 @@ function createRoundDataStore() {
   return { roundData, ensureRoundData, setRoundOutputs };
 }
 
+function createOutputNode(
+  streamId: string,
+  host: ReturnType<typeof createRecordingHost>['host'],
+  workflowOutputPolicy: typeof defaultWorkflowOutputPolicy = defaultWorkflowOutputPolicy,
+): OutputNode {
+  return new OutputNode().setServices({
+    streamId,
+    logger: { warn: () => {} },
+    outputState: createOutputState(),
+    runtimeHost: host,
+    workflowOutputPolicy,
+  } as unknown as ReflectionServices);
+}
+
 describe('output progress events', () => {
   it('publishes reflection output-node events through the runtime host', async () => {
     const { events, host } = createRecordingHost();
-    const outputNode = new OutputNode().setServices({
-      streamId: 'stream:output-node',
-      logger: { warn: () => {} },
-      outputState: createOutputState(),
-      runtimeHost: host,
-      workflowOutputPolicy: defaultWorkflowOutputPolicy,
-    } as unknown as ReflectionServices);
+    const outputNode = createOutputNode('stream:output-node', host);
     const outputLocation = createAgentLocation('/tmp/output.xml');
     const openedLocation = createLocation('/tmp/rendered.tex');
     const fileInfo: OutputFileInfo = {
@@ -188,13 +196,7 @@ describe('output progress events', () => {
 
   it('stores compile failure context for the next reflection round', async () => {
     const { host } = createRecordingHost();
-    const outputNode = new OutputNode().setServices({
-      streamId: 'stream:compile-context',
-      logger: { warn: () => {} },
-      outputState: createOutputState(),
-      runtimeHost: host,
-      workflowOutputPolicy: defaultWorkflowOutputPolicy,
-    } as unknown as ReflectionServices);
+    const outputNode = createOutputNode('stream:compile-context', host);
     const {
       outputLocation,
       compileFailure,
@@ -232,16 +234,10 @@ describe('output progress events', () => {
 
   it('honors disabled compile-failure repair context setting', async () => {
     const { host } = createRecordingHost();
-    const outputNode = new OutputNode().setServices({
-      streamId: 'stream:compile-context-disabled',
-      logger: { warn: () => {} },
-      outputState: createOutputState(),
-      runtimeHost: host,
-      workflowOutputPolicy: {
-        ...defaultWorkflowOutputPolicy,
-        shouldRejectOnCompileFailure: () => false,
-      },
-    } as unknown as ReflectionServices);
+    const outputNode = createOutputNode('stream:compile-context-disabled', host, {
+      ...defaultWorkflowOutputPolicy,
+      shouldRejectOnCompileFailure: () => false,
+    });
     const {
       outputLocation,
       compileFailure,
@@ -276,13 +272,7 @@ describe('output progress events', () => {
 
   it('clears stale compile failure context after a successful compile result', async () => {
     const { host } = createRecordingHost();
-    const outputNode = new OutputNode().setServices({
-      streamId: 'stream:compile-context-ok',
-      logger: { warn: () => {} },
-      outputState: createOutputState(),
-      runtimeHost: host,
-      workflowOutputPolicy: defaultWorkflowOutputPolicy,
-    } as unknown as ReflectionServices);
+    const outputNode = createOutputNode('stream:compile-context-ok', host);
     const { outputLocation, roundOutput, summary } =
       createCompileFailureFixture();
     const compileResult: CompileResult = { status: 'ok', round: 1 };

--- a/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
@@ -234,10 +234,14 @@ describe('output progress events', () => {
 
   it('honors disabled compile-failure repair context setting', async () => {
     const { host } = createRecordingHost();
-    const outputNode = createOutputNode('stream:compile-context-disabled', host, {
-      ...defaultWorkflowOutputPolicy,
-      shouldRejectOnCompileFailure: () => false,
-    });
+    const outputNode = createOutputNode(
+      'stream:compile-context-disabled',
+      host,
+      {
+        ...defaultWorkflowOutputPolicy,
+        shouldRejectOnCompileFailure: () => false,
+      },
+    );
     const {
       outputLocation,
       compileFailure,

--- a/src/test-kernel/agent/runtime/UsageMonitorLastTotals.vitest.ts
+++ b/src/test-kernel/agent/runtime/UsageMonitorLastTotals.vitest.ts
@@ -44,10 +44,6 @@ function createMonitorWithEvents() {
   return { monitor, events };
 }
 
-function createMonitor(): UsageMonitor {
-  return createMonitorWithEvents().monitor;
-}
-
 describe('UsageMonitor.lastTotals (SDK Step 7d PR 5)', () => {
   beforeAll(async () => {
     const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
@@ -58,7 +54,7 @@ describe('UsageMonitor.lastTotals (SDK Step 7d PR 5)', () => {
   });
 
   it('is undefined before any round and caches the totals after recordUsage', async () => {
-    const monitor = createMonitor();
+    const { monitor } = createMonitorWithEvents();
     expect(monitor.lastTotals()).toBeUndefined();
 
     const state = AgentRunStateSnapshotSchema.parse({});

--- a/src/test-kernel/model/ComputeModelOptions.vitest.ts
+++ b/src/test-kernel/model/ComputeModelOptions.vitest.ts
@@ -99,13 +99,11 @@ async function initSubscriptionPlatform(
 }
 
 describe('computeModelOptionsData relay quota state', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     invalidateApiKeyCache();
     invalidateModelOptionsCache();
     resetCodexCoordinator();
-  });
 
-  beforeEach(async () => {
     const { initPlatform } = await import('@platform/platform');
     initPlatform(
       createFakePlatform({

--- a/src/test-kernel/support/asyncTestUtils.ts
+++ b/src/test-kernel/support/asyncTestUtils.ts
@@ -2,15 +2,17 @@
  * Shared async polling utilities for test suites.
  */
 
+import { setImmediate } from 'node:timers/promises';
+
 /** Poll until a recorded event with the given name appears, or throw after 10 attempts. */
 export async function waitForRecordedEvent<TEvent extends string>(
-  events: Array<{ event: TEvent; payload: unknown }>,
+  events: { event: TEvent; payload: unknown }[],
   eventName: TEvent,
 ): Promise<{ event: TEvent; payload: any }> {
   for (let attempt = 0; attempt < 10; attempt++) {
     const event = events.find((entry) => entry.event === eventName);
     if (event) return event;
-    await new Promise((resolve) => setImmediate(resolve));
+    await setImmediate();
   }
   throw new Error(`Timed out waiting for ${eventName}`);
 }

--- a/src/test-kernel/tools/ArxivDownloadTool.vitest.ts
+++ b/src/test-kernel/tools/ArxivDownloadTool.vitest.ts
@@ -2,8 +2,6 @@
 import * as assert from 'node:assert';
 import { describe, it, afterEach, vi } from 'vitest';
 
-// Node.js built-in imports
-
 const gitignoreMock = vi.hoisted(() => ({
   ignoredPaths: new Set<string>(),
 }));

--- a/src/test-kernel/tools/ArxivSearchTool.vitest.ts
+++ b/src/test-kernel/tools/ArxivSearchTool.vitest.ts
@@ -2,8 +2,6 @@
 import * as assert from 'node:assert';
 import { describe, it, afterEach, vi } from 'vitest';
 
-// Node.js built-in imports
-
 // Local imports - tools
 import * as arxivShared from '@tools/latex/arxivShared';
 import * as rateLimiter from '@tools/citation/rateLimiter';

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -2,8 +2,6 @@
 import { strict as assert } from 'node:assert';
 import { describe, it, beforeAll, afterEach, vi } from 'vitest';
 
-// Node.js built-in imports
-
 // Local imports - tests
 import { createFakePlatform } from '@test/support/FakePlatform';
 

--- a/src/test-kernel/tools/InquiryStorage.vitest.ts
+++ b/src/test-kernel/tools/InquiryStorage.vitest.ts
@@ -209,7 +209,6 @@ describe('InquiryStorage', () => {
       parentStreamId: STREAM_A,
       question: 'Q2',
     });
-    void t2;
 
     const t3 = await recordOpenQuestion({
       parentStreamId: STREAM_B,

--- a/src/test-kernel/tools/latex/ExtractBibliographyTool.vitest.ts
+++ b/src/test-kernel/tools/latex/ExtractBibliographyTool.vitest.ts
@@ -2,8 +2,6 @@
 import * as assert from 'node:assert';
 import { describe, it, afterEach, vi } from 'vitest';
 
-// Node.js built-in imports
-
 // Local imports - tests
 import { createFakePlatform } from '@test/support/FakePlatform';
 

--- a/src/test-kernel/tools/latex/ExtractFiguresTool.vitest.ts
+++ b/src/test-kernel/tools/latex/ExtractFiguresTool.vitest.ts
@@ -2,8 +2,6 @@
 import * as assert from 'node:assert';
 import { describe, it, afterEach, vi } from 'vitest';
 
-// Node.js built-in imports
-
 // Local imports - tests
 import { createFakePlatform } from '@test/support/FakePlatform';
 

--- a/src/test-kernel/tools/latex/ExtractTikzFiguresTool.vitest.ts
+++ b/src/test-kernel/tools/latex/ExtractTikzFiguresTool.vitest.ts
@@ -2,8 +2,6 @@
 import * as assert from 'node:assert';
 import { describe, it, afterEach, vi } from 'vitest';
 
-// Node.js built-in imports
-
 // Local imports - tests
 import { createFakePlatform } from '@test/support/FakePlatform';
 

--- a/src/test-kernel/tools/lean/JsonRpcConnection.vitest.ts
+++ b/src/test-kernel/tools/lean/JsonRpcConnection.vitest.ts
@@ -12,7 +12,7 @@ function makePair(): {
   serverIn: PassThrough;
   serverOut: PassThrough;
   serverSends: (json: unknown) => void;
-  collectClientFrames: () => Promise<Array<Record<string, unknown>>>;
+  collectClientFrames: () => Promise<Record<string, unknown>[]>;
 } {
   const serverIn = new PassThrough(); // what the client writes (i.e. the server reads)
   const serverOut = new PassThrough(); // what the server writes (i.e. the client reads)
@@ -28,7 +28,7 @@ function makePair(): {
   /** Wait until serverIn has data, then parse and return all LSP frames. */
   const collectClientFrames = () =>
     vi.waitFor(
-      (): Array<Record<string, unknown>> => {
+      (): Record<string, unknown>[] => {
         let raw = serverIn.read() as Buffer | string | null;
         while (raw) {
           clientFrameBuffer += Buffer.isBuffer(raw)
@@ -37,7 +37,7 @@ function makePair(): {
           raw = serverIn.read() as Buffer | string | null;
         }
         if (!clientFrameBuffer) throw new Error('no data in serverIn yet');
-        const frames: Array<Record<string, unknown>> = [];
+        const frames: Record<string, unknown>[] = [];
         let offset = 0;
         while (offset < clientFrameBuffer.length) {
           const headerEnd = clientFrameBuffer.indexOf('\r\n\r\n', offset);

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -698,15 +698,14 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
     // Running process: read live output from ephemeral temp files
     const handle = currentSession().executions.getHandle(executionId);
     if (handle instanceof ProcessExecutionHandle && handle.outputPaths) {
+      const readText = (filePath: string): Promise<string> =>
+        platform()
+          .fs.readFile(filePath)
+          .then((bytes) => Buffer.from(bytes).toString('utf8'))
+          .catch(() => '');
       const [stdout, stderr] = await Promise.all([
-        platform()
-          .fs.readFile(handle.outputPaths.stdout)
-          .then((bytes) => Buffer.from(bytes).toString('utf8'))
-          .catch(() => ''),
-        platform()
-          .fs.readFile(handle.outputPaths.stderr)
-          .then((bytes) => Buffer.from(bytes).toString('utf8'))
-          .catch(() => ''),
+        readText(handle.outputPaths.stdout),
+        readText(handle.outputPaths.stderr),
       ]);
       const sections: string[] = [`Output for ${executionId}:`];
       if (stdout) sections.push('', '<stdout>', stdout, '</stdout>');

--- a/src/tools/agentWorkspaceOptions.ts
+++ b/src/tools/agentWorkspaceOptions.ts
@@ -30,11 +30,14 @@ export function buildAgentWorkspaceOptions(
     return trimmed ? { workingDirectory: trimmed } : {};
   }
 
-  const workingDirectory = trimmed
-    ? path.isAbsolute(trimmed)
-      ? trimmed
-      : path.resolve(workspacePath, trimmed)
-    : workspacePath;
+  let workingDirectory: string;
+  if (!trimmed) {
+    workingDirectory = workspacePath;
+  } else if (path.isAbsolute(trimmed)) {
+    workingDirectory = trimmed;
+  } else {
+    workingDirectory = path.resolve(workspacePath, trimmed);
+  }
 
   const resolvedWorkspacePath = path.resolve(workspacePath);
   const resolvedWorkingDirectory = path.resolve(workingDirectory);

--- a/src/tools/arxiv/ArxivSearchTool.ts
+++ b/src/tools/arxiv/ArxivSearchTool.ts
@@ -75,7 +75,7 @@ export class ArxivSearchTool extends defineTool({
       author: authorQuery,
       title: titleQuery,
       abstract: abstractQuery,
-      all: all,
+      all,
     } as const;
     const fieldQueryFn = fieldQueryFns[input.field];
 
@@ -107,7 +107,6 @@ export class ArxivSearchTool extends defineTool({
               `Ignoring invalid arxiv category filter "${trimmed}"`,
               { data: error },
             );
-            continue;
           }
         }
       }

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -183,13 +183,17 @@ function finalizeChildStream(args: FinalizeChildStreamArgs): void {
   const requestedStatus =
     options?.status ?? (hasError ? STREAM_STATUS.ERROR : STREAM_STATUS.READY);
   const currentStatus = session.executions.getStatus(handle).status;
-  const finalStatus =
+  let finalStatus: ChildStreamTerminalStatus;
+  if (
     currentStatus === STREAM_STATUS.STOPPED ||
     requestedStatus === STREAM_STATUS.STOPPED
-      ? STREAM_STATUS.STOPPED
-      : hasError
-        ? STREAM_STATUS.ERROR
-        : requestedStatus;
+  ) {
+    finalStatus = STREAM_STATUS.STOPPED;
+  } else if (hasError) {
+    finalStatus = STREAM_STATUS.ERROR;
+  } else {
+    finalStatus = requestedStatus;
+  }
   const outcome = deriveRunOutcome({
     failed: finalStatus === STREAM_STATUS.ERROR,
     cancelled: finalStatus === STREAM_STATUS.STOPPED,

--- a/src/tools/github/githubAuth.ts
+++ b/src/tools/github/githubAuth.ts
@@ -20,7 +20,7 @@ export function normalizeGitHubToken(
   token: string | undefined,
 ): string | undefined {
   const trimmed = token?.trim();
-  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+  return trimmed ? trimmed : undefined;
 }
 
 export function getGitHubEnvToken(): string | undefined {

--- a/src/tools/github/githubClient.ts
+++ b/src/tools/github/githubClient.ts
@@ -99,7 +99,7 @@ export async function ghGet<T>(
         request: { signal },
       },
     );
-    const newEtag = (res.headers.etag as string | undefined) ?? undefined;
+    const newEtag = res.headers.etag as string | undefined;
     return { status: 200, data: res.data as T, etag: newEtag };
   } catch (err) {
     if (err instanceof RequestError) {

--- a/src/tools/inquiry/externalInquiryResultFormatter.ts
+++ b/src/tools/inquiry/externalInquiryResultFormatter.ts
@@ -14,7 +14,7 @@ export function collectKnownSessionLinks(
   const known: string[] = [];
   const seen = new Set<string>();
 
-  for (const turn of [...manifest.turns].reverse()) {
+  for (const turn of manifest.turns.toReversed()) {
     for (const link of turn.sessionLinks ?? []) {
       if (seen.has(link)) continue;
       seen.add(link);

--- a/src/tools/latex/figureExtractionShared.ts
+++ b/src/tools/latex/figureExtractionShared.ts
@@ -42,8 +42,7 @@ export async function buildLimitedAttachments(
     return { attachments: [], limitedPaths: [], limitReached: false };
   }
 
-  const limitCount = Math.min(paths.length, limit);
-  const limitedPaths = paths.slice(0, limitCount);
+  const limitedPaths = paths.slice(0, limit);
   const attachments = await Promise.all(
     limitedPaths.map((filePath) =>
       buildFileAttachment({
@@ -57,6 +56,6 @@ export async function buildLimitedAttachments(
   return {
     attachments,
     limitedPaths,
-    limitReached: paths.length > limitCount,
+    limitReached: paths.length > limit,
   };
 }

--- a/src/tools/subagentDiffs.ts
+++ b/src/tools/subagentDiffs.ts
@@ -95,7 +95,7 @@ export async function computeAndWriteWorkflowDiffs(
   outputs: OutputFileSummary[],
 ): Promise<Map<string, DiffFileInfo>> {
   const results = new Map<string, DiffFileInfo>();
-  const diffsToWrite: Array<{ diffRelPath: string; content: string }> = [];
+  const diffsToWrite: { diffRelPath: string; content: string }[] = [];
 
   // First pass: compute diffs and decide which to write.
   await Promise.all(

--- a/src/tools/zotero/ZoteroAddTool.ts
+++ b/src/tools/zotero/ZoteroAddTool.ts
@@ -388,12 +388,9 @@ export class ZoteroAddTool extends defineTool({
     const errorCount = results.length - successCount;
 
     const output = results
-      .map((r) => {
-        if (r.status === 'success') {
-          return `✓ ${r.item}`;
-        }
-        return `✗ ${r.item}: ${r.message}`;
-      })
+      .map((r) =>
+        r.status === 'success' ? `✓ ${r.item}` : `✗ ${r.item}: ${r.message}`,
+      )
       .join('\n');
 
     // Throw ToolError if all items failed

--- a/src/tools/zotero/ZoteroCollectionsTool.ts
+++ b/src/tools/zotero/ZoteroCollectionsTool.ts
@@ -207,15 +207,14 @@ export class ZoteroCollectionsTool extends defineTool({
       outputParts.push(...formatTree(tree));
     }
 
+    const context = query ? ` matching "${query}"` : '';
     if (outputParts.length === 0) {
-      const context = query ? ` matching "${query}"` : '';
       return {
         summary: `No collections found${context}.`,
         output: `No collections found${context}.`,
       };
     }
 
-    const context = query ? ` matching "${query}"` : '';
     return {
       summary: `Found ${formatResultCount(totalCollections, 'collection')}${context} across ${formatResultCount(librariesWithResults, 'library', 'libraries')}.`,
       output: outputParts.join('\n'),

--- a/src/utils/files/baseFS.ts
+++ b/src/utils/files/baseFS.ts
@@ -51,7 +51,7 @@ export abstract class BaseFS {
     try {
       await platform().fs.stat(this.preparePath(target));
       return true;
-    } catch (_err) {
+    } catch {
       return false;
     }
   }
@@ -184,7 +184,7 @@ export abstract class BaseFS {
     try {
       const stats = await this.stat(target);
       return isDirectory(stats.type);
-    } catch (_err) {
+    } catch {
       return false;
     }
   }
@@ -196,7 +196,7 @@ export abstract class BaseFS {
     try {
       const stats = await this.stat(target);
       return isFile(stats.type);
-    } catch (_err) {
+    } catch {
       return false;
     }
   }
@@ -208,7 +208,7 @@ export abstract class BaseFS {
     try {
       const stats = await this.stat(target);
       return (stats.type & FileType.SymbolicLink) === FileType.SymbolicLink;
-    } catch (_err) {
+    } catch {
       return false;
     }
   }

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -312,7 +312,6 @@ export class TaskRunFileService {
       return;
     }
 
-    const destinationSegment = relativeDirectory;
     const runDir = getRunDir(executionId);
 
     await Promise.all(
@@ -331,7 +330,7 @@ export class TaskRunFileService {
         ) {
           logger.debug(
             CHANNEL,
-            `Skipping run-dir mirror of ${relativePath}: would clobber primary output in ${destinationSegment}`,
+            `Skipping run-dir mirror of ${relativePath}: would clobber primary output in ${relativeDirectory}`,
           );
           return;
         }
@@ -358,7 +357,7 @@ export class TaskRunFileService {
         }
         const destinationAbsolute = path.join(
           runDir,
-          destinationSegment,
+          relativeDirectory,
           relativePath,
         );
 
@@ -372,7 +371,7 @@ export class TaskRunFileService {
           if (!stat.isSymbolicLink()) {
             logger.debug(
               CHANNEL,
-              `Skipping run-dir mirror of ${relativePath}: destination in ${destinationSegment} is an existing real file`,
+              `Skipping run-dir mirror of ${relativePath}: destination in ${relativeDirectory} is an existing real file`,
             );
             return;
           }
@@ -391,7 +390,7 @@ export class TaskRunFileService {
         } catch (error) {
           logger.debug(
             CHANNEL,
-            `Unable to mirror ${relativePath} into ${destinationSegment}: ${toErrorMessage(error)}`,
+            `Unable to mirror ${relativePath} into ${relativeDirectory}: ${toErrorMessage(error)}`,
           );
         }
       }),

--- a/src/utils/system/binaryResolver.ts
+++ b/src/utils/system/binaryResolver.ts
@@ -78,12 +78,8 @@ export class BinaryResolverService {
       hasExtension(resolvedPath, '.pl') ||
       (this.options.isWindows &&
         path.extname(resolvedPath) === '' &&
-        this.isKnownPerlScript(toolName))
+        WINDOWS_EXTENSIONLESS_PERL_TOOLS.has(toolName))
     );
-  }
-
-  private isKnownPerlScript(toolName: string): boolean {
-    return WINDOWS_EXTENSIONLESS_PERL_TOOLS.has(toolName);
   }
 }
 


### PR DESCRIPTION
## Summary

- Applies repo-wide TypeScript simplifications from the existing `simplify/repo-wide-phase-1` branch: modern idioms, dead-code removal, and trivial pass-through cleanup across 109 files.
- Keeps the automated formatting commit already present on the remote branch.
- Fixes a behavior regression from the simplification pass by preserving synchronous slash-form selection side effects while still routing thrown/rejected action errors through the shared catch path.

## Host impact

Extension: mechanical cleanup in webview/progress/settings helpers and shared runtime-adjacent code.
Desktop: mechanical cleanup in main-process helpers and logging/auth paths.
CLI: mechanical cleanup in TUI/runtime helpers; `/model` selection remains synchronously reflected in session state.

## Validation

- `npm run typecheck`
- `npm run lint` (0 errors, 20 warnings)
- `npx vitest run --config vitest.config.mjs src/test-kernel/cli/SlashRegistry.vitest.mts`
- `npx vitest run --config vitest.config.mjs src/test-kernel/agent/runtime/ProcessOutputPoller.vitest.ts`
- `npm test` (final rerun passed: 552 files, 4325 tests, 4 skipped)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are overwhelmingly mechanical across many files; the main behavioral nuance is slash-form `beforeAction` ordering, which the PR explicitly preserves and validates with targeted tests.
> 
> **Overview**
> This PR applies a broad **repo-wide cleanup pass**: modern TypeScript idioms (`??=`, optional chaining, `readonly` arrays, `toReversed`), removal of redundant wrappers and unused imports, and small control-flow flattening across **~100+ files** in the CLI TUI, desktop main process, VS Code extension webviews, agent/model handlers, tools, and tests.
> 
> **CLI / TUI:** Drops unnecessary `useCallback` for child-control escape state, simplifies cursor/history helpers, deduplicates orchestration row math, inlines CLI “known model” checks in `cliConfig`, and refactors `runFormSelection` so **`beforeAction` completions call `onDone` before the async action** (preserving immediate session updates for approval/login/memory/resume/skills while errors still route through `.catch`).
> 
> **Desktop:** Hoists shared `showInfoMessage` in main setup, inlines log IPC copy/export handlers, and **centralizes expired OAuth pending-state checks** in `hasValidPendingState` for sign-in nonce matching.
> 
> **Extension:** Adds `runWithActiveView` for theme/debug/recording handlers, deduplicates history/memory pagination markup, trims unused types/helpers in progress/settings views, and tightens a few Lit/template and event-handler destructuring patterns.
> 
> **Core agent / shared:** Mostly equivalent refactors in streaming, OpenAI/Google handlers, log slice entry processing, schema message definitions, and filesystem helpers—no intentional feature changes beyond readability and consistency.
> 
> **Tests:** Reuses helpers like `initFakePlatform`, `createOutputNode`, and simpler loops instead of duplicated platform bootstrap boilerplate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 393f6886dd71b772631a9dce0ef8a17369a89da4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->