### PR TITLE
refactor: delegate API key resolution

### DIFF
--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -92,7 +92,6 @@ import {
   apiKeyExists,
   apiKeySecretName,
   lookupApiKey,
-  type ApiProvider,
 } from '@model/apiProviders';
 import { refreshModelListStateIfNeeded } from '@model/modelListRefresh';
 import { type StreamStatus, type TokenUsageStats } from '@shared/schemas';
@@ -535,8 +534,6 @@ export async function activate(context: vscode.ExtensionContext) {
       );
     }
   };
-  const hasResolvedUsableApiKey = async (provider: ApiProvider) =>
-    isNonEmptyString(await lookupApiKey(platform().secrets, provider));
   setSetupPlatform({
     secrets: {
       providers: SecretManager.API_PROVIDERS,
@@ -545,7 +542,8 @@ export async function activate(context: vscode.ExtensionContext) {
       deleteApiKey: (provider) =>
         platform().secrets.delete(apiKeySecretName(provider)),
       apiKeyExists: (provider) => apiKeyExists(platform().secrets, provider),
-      hasUsableApiKey: hasResolvedUsableApiKey,
+      hasUsableApiKey: async (provider) =>
+        isNonEmptyString(await lookupApiKey(platform().secrets, provider)),
       storedApiKeyExists: async (provider) => {
         const stored = await SecretManager.get(apiKeySecretName(provider));
         return stored !== undefined;

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -6,7 +6,7 @@ import * as vscode from 'vscode';
 import dotenv from 'dotenv';
 
 // Local imports - core
-import { initPlatform } from '@platform/platform';
+import { initPlatform, platform } from '@platform/platform';
 import { createLifecycleHost } from '@platform/defaults/lifecycleHost';
 import {
   SHUTDOWN_PHASE,
@@ -88,6 +88,12 @@ import { VscodeStorage } from '@frontend/vscode/vscodeStorage';
 import { VscodeSecrets } from '@frontend/vscode/vscodeSecrets';
 import { VscodeConfigProvider } from '@frontend/vscode/vscodeConfig';
 import * as logger from '@logger/logUtils';
+import {
+  apiKeyExists,
+  apiKeySecretName,
+  lookupApiKey,
+  type ApiProvider,
+} from '@model/apiProviders';
 import { refreshModelListStateIfNeeded } from '@model/modelListRefresh';
 import { type StreamStatus, type TokenUsageStats } from '@shared/schemas';
 import { GlobalStateKey } from '@shared/state/stateKeys';
@@ -104,6 +110,7 @@ import { setLeanLanguageServices } from '@tools/lean/leanLanguageServices';
 import { setOpenBuildDisplay } from '@tools/approval/latexPreview';
 import { StorageFS } from '@utils/files';
 import { getConfig } from '@utils/config';
+import { isNonEmptyString } from '@utils/core';
 import { TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
 
 // Local imports - components
@@ -528,19 +535,19 @@ export async function activate(context: vscode.ExtensionContext) {
       );
     }
   };
+  const hasResolvedUsableApiKey = async (provider: ApiProvider) =>
+    isNonEmptyString(await lookupApiKey(platform().secrets, provider));
   setSetupPlatform({
     secrets: {
       providers: SecretManager.API_PROVIDERS,
       setApiKey: (provider, key) =>
-        SecretManager.set(SecretManager.getApiKeySecretName(provider), key),
+        platform().secrets.set(apiKeySecretName(provider), key),
       deleteApiKey: (provider) =>
-        SecretManager.delete(SecretManager.getApiKeySecretName(provider)),
-      apiKeyExists: (provider) => SecretManager.apiKeyExists(provider),
-      hasUsableApiKey: (provider) => SecretManager.hasUsableApiKey(provider),
+        platform().secrets.delete(apiKeySecretName(provider)),
+      apiKeyExists: (provider) => apiKeyExists(platform().secrets, provider),
+      hasUsableApiKey: hasResolvedUsableApiKey,
       storedApiKeyExists: async (provider) => {
-        const stored = await SecretManager.get(
-          SecretManager.getApiKeySecretName(provider),
-        );
+        const stored = await SecretManager.get(apiKeySecretName(provider));
         return stored !== undefined;
       },
       anyUsableCredentialExists: () => hasAnyUsableSetupCredential(),

--- a/packages/extension/src/frontend/secretManager.ts
+++ b/packages/extension/src/frontend/secretManager.ts
@@ -82,6 +82,12 @@ export class SecretManager {
     try {
       return await requireApiKey(platform().secrets, provider);
     } catch (err) {
+      if (
+        !(err instanceof Error) ||
+        !err.message.startsWith(`No API key found for ${provider}.`)
+      ) {
+        throw err;
+      }
       throw new Error(
         `No API key found for ${provider}. Please set it using the "Set API Key" command or ${apiKeyEnvName(provider)} environment variable.`,
         { cause: err },
@@ -104,12 +110,10 @@ export class SecretManager {
   }
 
   /**
-   * Like `apiKeyExists` but rejects empty / whitespace-only values. A
-   * stale `PROVIDER_API_KEY=""` env var is "present" but not usable at
-   * launch — every runtime auth path falls over on a blank key. Callers
-   * that gate on "can this credential actually authenticate?" (the
-   * setup flow, per-provider probes, preflight checks) must use this
-   * helper rather than the looser `apiKeyExists`.
+   * Like `apiKeyExists` but also rejects whitespace-only values from any
+   * resolved credential. The canonical resolver already treats empty env vars
+   * as missing; this helper is for launch checks that need an actually usable
+   * authentication value.
    */
   public static async hasUsableApiKey(provider: ApiProvider): Promise<boolean> {
     const key = await lookupApiKey(platform().secrets, provider);

--- a/packages/extension/src/frontend/secretManager.ts
+++ b/packages/extension/src/frontend/secretManager.ts
@@ -7,6 +7,7 @@ import { getServerSideKeyService } from '@auth/serverKeys';
 import {
   API_PROVIDERS,
   apiKeyExists as resolvedApiKeyExists,
+  apiKeyEnvName,
   apiKeySecretName,
   getApiKey as requireApiKey,
   lookupApiKey,
@@ -78,7 +79,14 @@ export class SecretManager {
   }
 
   public static async getApiKey(provider: ApiProvider): Promise<string> {
-    return requireApiKey(platform().secrets, provider);
+    try {
+      return await requireApiKey(platform().secrets, provider);
+    } catch (err) {
+      throw new Error(
+        `No API key found for ${provider}. Please set it using the "Set API Key" command or ${apiKeyEnvName(provider)} environment variable.`,
+        { cause: err },
+      );
+    }
   }
 
   public static async anyApiKeyExists(): Promise<boolean> {

--- a/packages/extension/src/frontend/secretManager.ts
+++ b/packages/extension/src/frontend/secretManager.ts
@@ -2,8 +2,16 @@
 import * as vscode from 'vscode';
 
 // Local imports
+import { platform } from '@platform';
 import { getServerSideKeyService } from '@auth/serverKeys';
-import { API_PROVIDERS, type ApiProvider } from '@model/apiProviders';
+import {
+  API_PROVIDERS,
+  apiKeyExists as resolvedApiKeyExists,
+  apiKeySecretName,
+  getApiKey as requireApiKey,
+  lookupApiKey,
+  type ApiProvider,
+} from '@model/apiProviders';
 import {
   GITHUB_TOKEN_STORAGE_KEY,
   getGitHubEnvToken,
@@ -48,7 +56,7 @@ export class SecretManager {
   public static readonly GITHUB_TOKEN_KEY = GITHUB_TOKEN_STORAGE_KEY;
 
   public static getApiKeySecretName(provider: ApiProvider): string {
-    return `apiKey.${provider}`;
+    return apiKeySecretName(provider);
   }
 
   public static async listKeys(): Promise<readonly string[]> {
@@ -69,24 +77,8 @@ export class SecretManager {
     return 'none';
   }
 
-  /**
-   * Lookup API key from secret storage or environment variable.
-   */
-  private static async lookupApiKey(
-    provider: ApiProvider,
-  ): Promise<string | undefined> {
-    const secretKey = await this.get(this.getApiKeySecretName(provider));
-    return secretKey ?? process.env[`${provider.toUpperCase()}_API_KEY`];
-  }
-
   public static async getApiKey(provider: ApiProvider): Promise<string> {
-    const key = await this.lookupApiKey(provider);
-    if (!key) {
-      throw new Error(
-        `No API key found for ${provider}. Please set it using the "Set API Key" command or ${provider.toUpperCase()}_API_KEY environment variable.`,
-      );
-    }
-    return key;
+    return requireApiKey(platform().secrets, provider);
   }
 
   public static async anyApiKeyExists(): Promise<boolean> {
@@ -100,8 +92,7 @@ export class SecretManager {
   }
 
   public static async apiKeyExists(provider: ApiProvider): Promise<boolean> {
-    const key = await this.lookupApiKey(provider);
-    return key !== undefined;
+    return resolvedApiKeyExists(platform().secrets, provider);
   }
 
   /**
@@ -113,7 +104,7 @@ export class SecretManager {
    * helper rather than the looser `apiKeyExists`.
    */
   public static async hasUsableApiKey(provider: ApiProvider): Promise<boolean> {
-    const key = await this.lookupApiKey(provider);
+    const key = await lookupApiKey(platform().secrets, provider);
     return isNonEmptyString(key);
   }
 


### PR DESCRIPTION
## Summary

This PR removes the duplicate API-key resolver in `SecretManager` and makes the extension setup adapter use the canonical resolver in `src/model/apiProviders.ts`. `SecretManager` remains responsible for VS Code-specific secret storage access, provider picker metadata, GitHub token status, and SecretStorage key enumeration.

The setup adapter now uses `apiKeySecretName`, `apiKeyExists`, and `lookupApiKey` with `platform().secrets` for provider-key resolution. The stored-only check intentionally stays on `SecretManager.get(...)` because `PlatformSecrets.get(...)` can include host environment overrides, while the setup tool needs to know whether a SecretStorage entry exists.

Closes #6891.

## Validation

- `corepack pnpm exec eslint packages/extension/src/frontend/secretManager.ts packages/extension/src/extension.ts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/model/ApiProviders.vitest.ts src/test-kernel/tools/setup/ListApiKeysTool.vitest.ts src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts`
- `corepack pnpm --filter texra typecheck`
- `npm run lint` (passes with existing warnings outside this change)
- `npm run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor that centralizes credential resolution; setup intentionally preserves stored-only semantics for one check, limiting behavior drift.
> 
> **Overview**
> **Consolidates provider API key resolution** so the extension no longer maintains a second lookup path in `SecretManager`.
> 
> The setup assistant adapter in `extension.ts` now reads and writes keys through `platform().secrets` with the shared helpers in `@model/apiProviders` (`apiKeySecretName`, `apiKeyExists`, `lookupApiKey`). **Usable-key checks** use `lookupApiKey` plus `isNonEmptyString` instead of `SecretManager.hasUsableApiKey`. **`storedApiKeyExists`** still calls `SecretManager.get` so setup can tell whether a **SecretStorage** entry exists without counting host env overrides that `PlatformSecrets` may surface.
> 
> `SecretManager` drops its private env/secret resolver and forwards `getApiKey`, `apiKeyExists`, and `hasUsableApiKey` to the canonical module, while keeping VS Code–specific concerns (raw storage, GitHub token status, key enumeration, quick-pick metadata). Missing-key errors now reference `apiKeyEnvName(provider)` for the env var hint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41467425c197d91da752813d0a23aa2456b4eaf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->