### PR TITLE
refactor: remove empty tool session state

### DIFF
--- a/src/agent/core/state/TaskState.ts
+++ b/src/agent/core/state/TaskState.ts
@@ -8,8 +8,6 @@ import {
 import { AgentCategory } from '../definition/AgentDataclass';
 import { AgentConfigSchema, type AgentConfig } from '../definition/AgentConfig';
 
-const ToolSessionStateSchema = z.object({});
-
 const ActiveFilesSchema = z
   .partialRecord(z.enum(MULTIPLE_DOCUMENT_FILE_TYPES), z.boolean())
   .transform((partial) => {
@@ -35,7 +33,6 @@ export interface WorkflowTaskState {
 
 export interface ToolUseTaskState {
   agentConfig: ToolUseAgentConfig;
-  toolSessionState?: ToolSessionState;
 }
 
 export type TaskState = WorkflowTaskState | ToolUseTaskState;
@@ -57,15 +54,12 @@ const WorkflowTaskStateSchema = z.object({
 
 const ToolUseTaskStateSchema = z.object({
   agentConfig: ToolUseAgentConfigSchema,
-  toolSessionState: ToolSessionStateSchema.optional(),
 }) satisfies z.ZodType<ToolUseTaskState>;
 
 export const TaskStateSchema = z.union([
   WorkflowTaskStateSchema,
   ToolUseTaskStateSchema,
 ]) satisfies z.ZodType<TaskState>;
-
-export type ToolSessionState = z.infer<typeof ToolSessionStateSchema>;
 
 export function isWorkflowTaskState(
   taskState: TaskState,

--- a/src/agent/utils/agentConfigToTaskState.ts
+++ b/src/agent/utils/agentConfigToTaskState.ts
@@ -14,7 +14,6 @@ export function agentConfigToTaskState(config: AgentConfig): TaskState {
     case AgentCategory.ToolUse:
       return {
         agentConfig: config as ToolUseTaskState['agentConfig'],
-        toolSessionState: {},
       };
     case AgentCategory.Workflow:
       return {

--- a/src/test-kernel/agent/AgentConfigToTaskState.vitest.ts
+++ b/src/test-kernel/agent/AgentConfigToTaskState.vitest.ts
@@ -13,6 +13,7 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
   isToolUseTaskState,
   isWorkflowTaskState,
+  TaskStateSchema,
 } from '@agent/core/state/TaskState';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 
@@ -65,7 +66,24 @@ describe('agentConfigToTaskState', () => {
       assert.fail('Expected a tool-use task state');
     }
     assert.equal(taskState.agentConfig, config);
-    assert.deepEqual(taskState.toolSessionState, {});
+    assert.deepEqual(taskState, { agentConfig: config });
+  });
+
+  it('accepts old tool-use task states with the removed empty session placeholder', () => {
+    const config = AgentConfigSchema.parse({
+      agentCategory: AgentCategory.ToolUse,
+      agent: 'assistant',
+      model: 'sonnet46T',
+      instruction: 'Check the proof.',
+      toolConfig: DEFAULT_TOOL_CONFIG,
+    });
+
+    const taskState = TaskStateSchema.parse({
+      agentConfig: config,
+      toolSessionState: {},
+    });
+
+    assert.deepEqual(taskState, { agentConfig: config });
   });
 
   it('tolerates minimal workflow configs from tests and legacy callers', () => {

--- a/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
@@ -113,7 +113,6 @@ describe('child stream progress events', () => {
         executionId,
         taskState: {
           agentConfig: config,
-          toolSessionState: {},
         },
       },
     });


### PR DESCRIPTION
## Summary

- Remove the permanently empty `toolSessionState` placeholder from `ToolUseTaskState`.
- Stop emitting `toolSessionState: {}` from `agentConfigToTaskState()` and child stream progress events.
- Keep old persisted tool-use task states compatible by asserting `TaskStateSchema` still accepts and normalizes the former empty placeholder.

Closes #6892.

## Validation

- `corepack pnpm exec prettier --write src/agent/core/state/TaskState.ts src/agent/utils/agentConfigToTaskState.ts src/test-kernel/agent/AgentConfigToTaskState.vitest.ts src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts`
- `corepack pnpm exec eslint src/agent/core/state/TaskState.ts src/agent/utils/agentConfigToTaskState.ts src/test-kernel/agent/AgentConfigToTaskState.vitest.ts src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/agent/AgentConfigToTaskState.vitest.ts src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts src/test-kernel/agent/SessionResumeRetrieval.vitest.ts src/test-kernel/transcript/StreamSnapshotStore.vitest.ts src/test-kernel/cli/SessionResumeResolution.vitest.mts`
- `npm run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type and payload cleanup with a regression test for legacy persisted state; no auth, security, or business-logic changes.
> 
> **Overview**
> **Tool-use task state** no longer carries an always-empty `toolSessionState` placeholder. `ToolUseTaskState` and its Zod schema now only include `agentConfig`, and `agentConfigToTaskState()` no longer adds `toolSessionState: {}`.
> 
> **Runtime events** for child streams match that shape: `setTaskState` payloads for tool-use children emit `{ agentConfig }` only.
> 
> **Backward compatibility:** parsing persisted task state that still includes `toolSessionState: {}` is covered by a test asserting `TaskStateSchema` normalizes to `{ agentConfig }` (extra field dropped on parse).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08a29045a3ded87dd80861b1bfb8665b0c39a2d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->