### PR TITLE
fix: clarify CLI API status labels

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -982,7 +982,7 @@ const SCENARIOS = [
   {
     name: 'approval-policy-status-bar',
     env: { HARNESS_APPROVAL_POLICY: 'never', HARNESS_ENTRIES: '4' },
-    expect: ['byok', 'deny', '[/status]details'],
+    expect: ['personal', 'deny', '[/status]details'],
     unexpect: ['keys deny', 'approval: deny privileged actions'],
   },
   {
@@ -2531,8 +2531,8 @@ const SCENARIOS = [
     bootExpect: 'TeXRA',
     keys: [ESC + 's'], // Esc/Alt-s
     frame: 'tail',
-    expect: ['◆ running 1m 15s byok 3 sub'],
-    unexpect: ['◆running', 'byok3', '3 sub 1 proc'],
+    expect: ['◆ running 1m', 'personal'],
+    unexpect: ['◆running', 'personal3', '3 sub 1 proc'],
   },
   {
     name: 'tiny-task-subworkflow-detail',
@@ -2868,7 +2868,7 @@ const SCENARIOS = [
     expect: [
       'Harness interrupt requested.',
       '[main](stopped)',
-      '◆ stopped byok',
+      '◆ stopped personal',
       '[Ctrl-C]exit',
     ],
     unexpect: ['[Ctrl-C]stop'],

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -452,6 +452,11 @@ function statusBarBindingsText(
     ? '[Shift-Enter]newline'
     : '[Ctrl-J]newline';
   const ctrlC = `[Ctrl-C]${ctrlCAction}`;
+  const setupControlsOnly =
+    agentSelectionAvailable &&
+    !taskControlsAvailable &&
+    !subagentControlsAvailable &&
+    !hasMultipleStreams;
   const candidates = [
     // Stream cycling / numeric focus only do something when there is more
     // than one stream — hide the hints in a plain single-stream chat.
@@ -468,8 +473,9 @@ function statusBarBindingsText(
       newline,
       ctrlC,
     ]),
-    agentSelectionAvailable &&
+    setupControlsOnly &&
       statusBarBindingRow([transcript, agent, model, api, newline, ctrlC]),
+    setupControlsOnly && statusBarBindingRow([agent, model, api, ctrlC]),
     statusBarBindingRow([
       streamTabs,
       transcript,

--- a/packages/cli/src/runtime/apiAccessMode.ts
+++ b/packages/cli/src/runtime/apiAccessMode.ts
@@ -6,10 +6,10 @@ import { GlobalStateKey } from '@shared/state/stateKeys';
 export type CliApiMode = 'included' | 'personal';
 
 // Two canonical names per mode: the descriptive `included`/`personal` (used in
-// labels and config) plus the common shorthand `relay`/`byok` (surfaced by
-// `shortCliApiMode` and the `--api-mode` help). Earlier builds also accepted
-// `texra`/`direct`/`api`/`key`/`keys`, but those undocumented synonyms only
-// bloated the accepted-value list without adding clarity.
+// labels and config) plus the common shorthand `relay`/`byok` (accepted as
+// input aliases). Earlier builds also accepted `texra`/`direct`/`api`/`key`/
+// `keys`, but those undocumented synonyms only bloated the accepted-value list
+// without adding clarity.
 const CLI_API_MODE_BY_INPUT = {
   included: 'included',
   relay: 'included',
@@ -40,7 +40,7 @@ export function formatCliApiMode(mode: CliApiMode): string {
 }
 
 export function shortCliApiMode(mode: CliApiMode): string {
-  return mode === 'included' ? 'relay' : 'byok';
+  return mode === 'included' ? 'relay' : 'personal';
 }
 
 export function parseCliApiMode(input: string): CliApiMode | undefined {

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -103,7 +103,7 @@ describe('CLI StatusBar display model', () => {
 
   it('uses clear compact labels for API access mode', () => {
     expect(shortCliApiMode('included')).toBe('relay');
-    expect(shortCliApiMode('personal')).toBe('byok');
+    expect(shortCliApiMode('personal')).toBe('personal');
   });
 
   it('surfaces non-default approval policies in the durable status row', () => {
@@ -230,6 +230,7 @@ describe('CLI StatusBar display model', () => {
     const display = buildStatusBarDisplay(
       statusInput({
         agentSelectionAvailable: true,
+        taskControlsAvailable: false,
         model: 'gpt54',
         width: 80,
       }),
@@ -240,13 +241,14 @@ describe('CLI StatusBar display model', () => {
     );
   });
 
-  it('does not let setup bindings hide the transcript viewer', () => {
+  it('does not let setup bindings hide the transcript viewer when it fits', () => {
     const display = buildStatusBarDisplay(
       statusInput({
         agentSelectionAvailable: true,
+        taskControlsAvailable: false,
         model: 'gpt54',
         transcriptAvailable: true,
-        width: 80,
+        width: 100,
       }),
     );
 
@@ -254,10 +256,45 @@ describe('CLI StatusBar display model', () => {
     expect(display.bindings).toContain('[/agent]agents');
   });
 
+  it('keeps model and API controls visible after local-command transcript rows', () => {
+    const display = buildStatusBarDisplay(
+      statusInput({
+        agentSelectionAvailable: true,
+        taskControlsAvailable: false,
+        transcriptAvailable: true,
+        width: 80,
+      }),
+    );
+
+    expect(display.bindings).toBe(
+      '[/agent]agents  [/model]models  [/api]api  [Ctrl-C]exit',
+    );
+  });
+
+  it('keeps child controls ahead of setup bindings after a root run completes', () => {
+    const display = buildStatusBarDisplay(
+      statusInput({
+        agentSelectionAvailable: true,
+        taskControlsAvailable: true,
+        subagentControlsAvailable: true,
+        hasMultipleStreams: true,
+        transcriptAvailable: true,
+        width: 80,
+      }),
+    );
+
+    expect(display.bindings).toContain('[Tab]streams');
+    expect(display.bindings).toContain('[Alt-p]tasks');
+    expect(display.bindings).toContain('[Alt-s]subagents');
+    expect(display.bindings).not.toContain('[/model]models');
+    expect(display.bindings).not.toContain('[/api]api');
+  });
+
   it('keeps root agent selection visible when setup bindings get narrow', () => {
     const display = buildStatusBarDisplay(
       statusInput({
         agentSelectionAvailable: true,
+        taskControlsAvailable: false,
         model: 'gpt54',
         width: 50,
       }),
@@ -433,7 +470,7 @@ describe('CLI StatusBar display model', () => {
         subagentControlsAvailable: true,
         hasMultipleStreams: true,
         ctrlCAction: 'stop',
-        width: 30,
+        width: 34,
         shortcutsActive: false,
       }),
     );
@@ -1013,7 +1050,7 @@ describe('CLI StatusBar display model', () => {
         status: STREAM_STATUS.RUNNING,
         bypass: { bash: false, superYolo: true, toolEdit: true },
         queuedFollowUpMessages: ['Keep the proof under one page.'],
-        width: 61,
+        width: 65,
       }),
     );
 


### PR DESCRIPTION
## Summary

- Keep `byok` accepted as a CLI API-mode alias, but display `personal` in compact TUI status text and session headers.
- Add an intermediate setup/footer binding row that keeps `/agent`, `/model`, and `/api` visible after local-command transcript rows at ordinary terminal widths.
- Update status-bar width-budget tests for the longer reader-facing API label.

Closes #6896.
Closes #6897.

## Validation

- `corepack pnpm exec prettier --write packages/cli/src/runtime/apiAccessMode.ts packages/cli/src/chat/tui/panes/StatusBar.tsx src/test-kernel/cli/StatusBar.vitest.mts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/ApiAccessMode.vitest.mts src/test-kernel/cli/ConversationPane.vitest.mts`
- `corepack pnpm exec eslint packages/cli/src/runtime/apiAccessMode.ts packages/cli/src/chat/tui/panes/StatusBar.tsx src/test-kernel/cli/StatusBar.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Label and footer-binding UX changes with test coverage; no auth or API routing behavior changes.
> 
> **Overview**
> Personal API mode now shows **`personal`** in compact TUI status text and session headers instead of **`byok`**, while **`byok`** remains a valid CLI input alias for that mode.
> 
> The status bar adds a **`setupControlsOnly`** footer path so that when only root agent setup is available (no tasks/subagents/multi-stream), **`/agent`**, **`/model`**, and **`/api`** stay visible at typical widths—including after local-command transcript rows where the full binding row used to drop model/API hints.
> 
> Tests and TUI harness expectations were updated for the longer label and the new binding cascade (including slightly wider width budgets where compact status text grew).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fabfd2909931b551d71a7436b3111d57fdc30c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->