### PR TITLE
docs: fix VS Code state path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,7 +392,7 @@ For good separation of concerns, testability, and platform independence, core bu
 - `packages/extension/src/commands/` (VS Code command handlers)
 - `packages/extension/src/frontend/` (VS Code UI utilities)
 - `src/common/webview/` (webview base classes)
-- `src/common/state/` (state managers backed by VS Code Memento)
+- `packages/extension/src/common/state/` (state managers backed by VS Code Memento)
 - `src/utils/config/` (wraps `vscode.workspace.getConfiguration`)
 - `src/utils/files/workspaceFS.ts`, `storageFS.ts` (wraps `vscode.workspace.fs`)
 - `src/auth/` (authentication providers)


### PR DESCRIPTION
## Summary

- Update the VS Code-allowed zone list in `CLAUDE.md` to point at the actual extension state-manager directory.
- Keep the policy wording unchanged; this is only a stale-path correction.

Closes #6893.

## Validation

- `corepack pnpm exec prettier --check CLAUDE.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only path correction with no runtime or build behavior changes.
> 
> **Overview**
> Updates **CLAUDE.md** so the VS Code-allowed zones list names the real extension state-manager location instead of the stale repo-root `src/common/state/` path.
> 
> The **VS Code coupling** policy is unchanged; only the directory reference is fixed so it matches `@common/state` resolution in `tsconfig.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be4aa962ed35472d94d3fe6e04c5d52b4ba20a70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->