### PR TITLE
refactor: use Zod catch for simple fallbacks

### DIFF
--- a/packages/cli/src/chat/tui/history/inputHistory.ts
+++ b/packages/cli/src/chat/tui/history/inputHistory.ts
@@ -40,8 +40,7 @@ function parseRecord(raw: string): HistoryRecord | undefined {
     // ignore malformed line
     return undefined;
   }
-  const parsed = HistoryRecordSchema.safeParse(obj);
-  return parsed.success ? parsed.data : undefined;
+  return HistoryRecordSchema.optional().catch(undefined).parse(obj);
 }
 
 /** Serialise the in-memory ring back to JSONL. Records keep their original

--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -115,8 +115,7 @@ export type CliHistoryDeleteResult =
     };
 
 export function parseCliHistoryId(raw: string): ExecutionId | undefined {
-  const parsed = ExecutionIdSchema.safeParse(raw);
-  return parsed.success ? parsed.data : undefined;
+  return ExecutionIdSchema.optional().catch(undefined).parse(raw);
 }
 
 export async function listCliHistoryEntries(): Promise<CliHistoryEntry[]> {

--- a/packages/extension/src/progressView/frontend/slices/logSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/logSlice.ts
@@ -30,8 +30,7 @@ function isTaskGroupStatus(
 }
 
 function asContextStateData(data: unknown): ContextStateData | undefined {
-  const result = ContextStateDataSchema.safeParse(data);
-  return result.success ? result.data : undefined;
+  return ContextStateDataSchema.optional().catch(undefined).parse(data);
 }
 
 function toLogMessage(entry: StreamLogEntry): LogMessageData {

--- a/packages/extension/src/webview/frontend/constants.ts
+++ b/packages/extension/src/webview/frontend/constants.ts
@@ -24,6 +24,5 @@ export { MULTIPLE_DOCUMENT_FILE_TYPES };
 export function parseSessionType(
   sessionType: string | null | undefined,
 ): SessionType | undefined {
-  const result = SessionTypeSchema.safeParse(sessionType);
-  return result.success ? result.data : undefined;
+  return SessionTypeSchema.optional().catch(undefined).parse(sessionType);
 }

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -179,8 +179,7 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
   ): Promise<T | null> {
     const raw = await this.read(key);
     if (!raw) return null;
-    const result = schema.safeParse(raw);
-    return result.success ? result.data : null;
+    return schema.nullable().catch(null).parse(raw);
   }
 
   async readMeta(): Promise<ExecutionMeta | null> {

--- a/src/auth/codex/codexJwt.ts
+++ b/src/auth/codex/codexJwt.ts
@@ -62,8 +62,7 @@ export function decodeJwtPayload(token: string): CodexJwtClaims {
     const parts = token.split('.');
     if (parts.length !== 3) return {};
     const json = Buffer.from(parts[1], 'base64url').toString('utf-8');
-    const result = CodexJwtClaimsSchema.safeParse(JSON.parse(json));
-    return result.success ? result.data : {};
+    return CodexJwtClaimsSchema.catch({}).parse(JSON.parse(json));
   } catch {
     return {};
   }

--- a/src/shared/config/settingsAccess.ts
+++ b/src/shared/config/settingsAccess.ts
@@ -59,8 +59,7 @@ export function readSetting(
   if (raw === undefined) {
     return settingDefault(entry);
   }
-  const parsed = entry.schema.safeParse(raw);
-  return parsed.success ? parsed.data : settingDefault(entry);
+  return entry.schema.catch(() => settingDefault(entry)).parse(raw);
 }
 
 /**

--- a/src/shared/progressView/backend/persistence/StreamTabStore.ts
+++ b/src/shared/progressView/backend/persistence/StreamTabStore.ts
@@ -76,8 +76,7 @@ class StreamTabKVStore extends KVStore {
   async readMeta(): Promise<StreamTabMeta | null> {
     const raw = await this.tryRead(STREAM_DATA_KEYS.META);
     if (!raw) return null;
-    const result = StreamTabMetaSchema.safeParse(raw);
-    return result.success ? result.data : null;
+    return StreamTabMetaSchema.nullable().catch(null).parse(raw);
   }
 
   // -- Legacy per-run instructions (preserved from pre-refactor memento) ---

--- a/src/shared/schemas/diffResult.ts
+++ b/src/shared/schemas/diffResult.ts
@@ -171,8 +171,7 @@ function parseDiffResultEntry(data: unknown): DiffResultDisplay | null {
   }
 
   // Try legacy format (transforms to display)
-  const legacyResult = LegacyDiffResultSchema.safeParse(data);
-  return legacyResult.success ? legacyResult.data : null;
+  return LegacyDiffResultSchema.nullable().catch(null).parse(data);
 }
 
 /** Parse an array of diff result entries, skipping invalid ones */

--- a/src/tools/inquiry/externalInquiryStorage.ts
+++ b/src/tools/inquiry/externalInquiryStorage.ts
@@ -219,8 +219,7 @@ async function readThreadManifest(
   const raw = await GlobalStorageFS.readJson<unknown>(
     threadManifestPath(threadId),
   ).catch(() => undefined);
-  const result = ExternalInquiryThreadManifestSchema.safeParse(raw);
-  return result.success ? result.data : null;
+  return ExternalInquiryThreadManifestSchema.nullable().catch(null).parse(raw);
 }
 
 async function writeThreadManifest(

--- a/src/transcript/streamSnapshotRead.ts
+++ b/src/transcript/streamSnapshotRead.ts
@@ -116,8 +116,10 @@ function readPersistedWorkPlan(raw: unknown): WorkPlanSnapshot {
       ? raw.schemaVersion
       : STREAM_SNAPSHOT_SCHEMA_VERSION;
   if (version > STREAM_SNAPSHOT_SCHEMA_VERSION) return EMPTY_WORK_PLAN;
-  const parsed = PersistedWorkPlanSchema.safeParse(raw);
-  return parsed.success ? parsed.data : EMPTY_WORK_PLAN;
+  return PersistedWorkPlanSchema.catch({
+    schemaVersion: STREAM_SNAPSHOT_SCHEMA_VERSION,
+    ...EMPTY_WORK_PLAN,
+  }).parse(raw);
 }
 
 /** Read every per-stream sidecar file ONCE, flattening any legacy nested data. */

--- a/src/utils/config/configUtils.ts
+++ b/src/utils/config/configUtils.ts
@@ -56,8 +56,7 @@ export function getValidatedConfig<T>(
   schema: ZodType<T>,
   defaultValue: T,
 ): T {
-  const result = schema.safeParse(getConfig<unknown>(path));
-  return result.success ? result.data : defaultValue;
+  return schema.catch(defaultValue).parse(getConfig<unknown>(path));
 }
 
 /**


### PR DESCRIPTION
## Summary

- Replace simple `safeParse` result ternaries with Zod v4 `.catch()` fallbacks.
- Cover the eight sites listed in #6882 plus four additional same-shape fallback sites found by audit.
- Keep nontrivial `safeParse` branches intact where they preserve error details, logging, or multi-step validation.

Closes #6882.

## Validation

- `corepack pnpm exec prettier --write ...`
- `corepack pnpm exec tsc --noEmit -p tsconfig.json --pretty false`
- `corepack pnpm exec eslint ...`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/InputHistory.vitest.mts src/test-kernel/cli/History.vitest.mts src/test-kernel/tools/ExternalInquiryResultFormatter.vitest.ts src/test-kernel/tools/InquiryContinuationSession.vitest.ts src/test-kernel/schemas/StreamDataRoundMaps.vitest.ts`
- `rg -n -U --pcre2 "const (\w+) = [^\n]*\.safeParse\([^\n]+\);\n\s*return \1\.success \? \1\.data :" src packages`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactors at validation boundaries; no new auth or data paths, with nontrivial validation branches intentionally left intact.
> 
> **Overview**
> Replaces repetitive **`safeParse` + success ternary** fallbacks with **Zod `.catch()`** (and `.optional().catch()` / `.nullable().catch()` where needed) so invalid or missing values resolve to the same defaults in one expression.
> 
> Touches **CLI** (TUI input history, history ID parsing), **extension** (progress log context state, session type parsing), and **shared/core** paths: execution KV reads, Codex JWT claims, settings reads, stream tab meta, diff legacy parsing, external inquiry manifests, persisted work plans, and `getValidatedConfig`.
> 
> **Unchanged:** multi-step or diagnostic validation still uses `safeParse` (e.g. canonical diff format before legacy, `readChildren` per-child filtering, legacy instruction empty checks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9a9b4528eaa88d15b5c3da3d2a5fb6a4f4ccde0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->