### PR TITLE
refactor: fold tool-edit approval into Platform port

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -9,9 +9,9 @@
 // `never` auto-rejects with `denyMessage(...)`. Only `ask` (or interactive
 // non-print) reaches the queue.
 //
-// Tool-edit goes through `setToolEditApprovalHandler` (separate API since
-// it returns a typed Promise<ToolEditApprovalResult>, not a fire-and-forget
-// event).
+// Tool-edit goes through the Platform approval port (installed per active CLI
+// session) because it returns a typed Promise<ToolEditApprovalResult>, not a
+// fire-and-forget event.
 
 import { platform } from '@platform/platform';
 import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
@@ -30,6 +30,7 @@ import {
   isCliApprovalEvent,
   type CliApprovalEvent,
 } from '@cli/runtime/approvalEvents';
+import { setActiveCliToolEditApprovalHandler } from '@cli/runtime/initPlatform';
 import type { CliContext } from '@cli/runtime/cliContext';
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
@@ -43,7 +44,6 @@ import {
   handleProgressViewBashApprovalAction,
   setBashApprovalSessionBypass,
   setToolEditApprovalSessionBypass,
-  setToolEditApprovalHandler,
 } from '@tools/approval';
 import { handleUserQuestionAction } from '@tools/userQuestion';
 import { handleExternalInquiryAction } from '@tools/inquiry/ExternalInquiryTool';
@@ -150,7 +150,7 @@ export function installTuiApprovals(
     originalEmit(event, payload);
   }) as CliRuntimeHost['emit'];
 
-  setToolEditApprovalHandler(async (request) => {
+  setActiveCliToolEditApprovalHandler(async (request) => {
     let decision: ApprovalDecision | undefined = immediateDecision(context);
     if (!decision) {
       decision = await enqueueTuiApproval({ kind: 'toolEdit', request }, host);
@@ -172,7 +172,7 @@ export function installTuiApprovals(
     invalidateRetryRoutes({ cancel: false });
     disposeApprovalClearListener();
     host.emit = originalEmit;
-    setToolEditApprovalHandler();
+    setActiveCliToolEditApprovalHandler(undefined);
   };
 }
 

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -5,10 +5,10 @@
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
 import {
-  setToolEditApprovalHandler,
   type ToolEditApprovalRequest,
   type ToolEditApprovalResult,
 } from '@tools/approval/toolEditApproval';
+import { setActiveCliToolEditApprovalHandler } from './initPlatform';
 
 import { isCliDecisionApprovalEvent } from './approvalEvents';
 import { type CliContext } from './cliContext';
@@ -83,11 +83,11 @@ export function installCliApprovalHandlers(
   context: CliContext,
   hooks: CliApprovalPromptHooks = {},
 ): () => void {
-  setToolEditApprovalHandler((request) =>
+  setActiveCliToolEditApprovalHandler((request) =>
     decideToolEdit(request, context, hooks),
   );
   return () => {
-    setToolEditApprovalHandler();
+    setActiveCliToolEditApprovalHandler(undefined);
   };
 }
 

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -56,6 +56,7 @@ import { CliExitCode } from './exitCodes';
 
 // Type imports - platform and CLI runtime
 import type { LifecycleHost } from '@platform/interfaces/lifecycle';
+import type { ToolEditApprovalPort } from '@platform/interfaces/toolEditApproval';
 import type { LogBackend } from './supabaseAuth';
 import type { CliContext } from './cliContext';
 
@@ -65,6 +66,49 @@ let cliWorkspaceCwd = '';
 let quietPlatformLogs = false;
 let shutdownHandlersInstalled = false;
 type CliShutdownSignal = 'SIGINT' | 'SIGTERM';
+
+// ---------------------------------------------------------------------------
+// Session-scoped tool-edit approval handler
+// ---------------------------------------------------------------------------
+//
+// The Platform port `toolEditApproval` is frozen at initPlatform time, but the
+// actual approval UI is session-scoped — the CLI opens and closes a TUI session
+// (or a headless approval prompt) independently of the platform life span.
+//
+// We bridge the two lifetimes with a single mutable reference: `initCliPlatform`
+// installs a delegating handler that reads this reference; `subscribeApprovals`
+// (TUI) and `installCliApprovalHandlers` (headless) write and clear it per
+// session, exactly as they did with the defunct `setToolEditApprovalHandler`.
+
+let activeCliToolEditApprovalHandler: ToolEditApprovalPort | undefined;
+
+/** Install the active session's tool-edit approval handler (or clear it). */
+export function setActiveCliToolEditApprovalHandler(
+  handler: ToolEditApprovalPort | undefined,
+): void {
+  activeCliToolEditApprovalHandler = handler;
+}
+
+/**
+ * Return a Platform-compatible `toolEditApproval` port that delegates to the
+ * handler installed by {@link setActiveCliToolEditApprovalHandler}.
+ *
+ * Used both by {@link initCliPlatform} (wired into the frozen Platform at
+ * startup) and by unit tests that exercise the CLI approval adapter against a
+ * {@link createFakePlatform}.
+ */
+export function createCliToolEditApprovalPort(): ToolEditApprovalPort {
+  return (request) => {
+    const handler = activeCliToolEditApprovalHandler;
+    if (!handler) {
+      throw new Error(
+        'No active session for tool edit approval. ' +
+          'Start a chat session or use --print with an approval policy.',
+      );
+    }
+    return handler(request);
+  };
+}
 
 type CliPlatformInitOptions = Pick<
   CliContext,
@@ -204,6 +248,7 @@ export async function initCliPlatform(
           isTexraCliEntrypoint: () =>
             isTexraCliEntrypointPath(readCliEntrypointPath()),
         },
+        toolEditApproval: createCliToolEditApprovalPort(),
       }),
     );
     if (context.installSignalHandlers !== false) {

--- a/packages/desktop/src/main/desktopToolEditApproval.ts
+++ b/packages/desktop/src/main/desktopToolEditApproval.ts
@@ -21,13 +21,13 @@ import {
   computeUserPatch,
   emitToolEditApprovalPrompt,
   registerPendingApproval,
-  setToolEditApprovalHandler,
   unregisterPendingApproval,
   type ToolEditApprovalRequest,
   type ToolEditApprovalResult,
 } from '@tools/approval/toolEditApproval';
 import { WorkspaceFS } from '@utils/files';
 import { normalizeLineEndings } from '@utils/text/stringUtils';
+import { setDesktopToolEditApprovalHandler } from './platform/index.js';
 
 export interface DesktopToolEditApprovalOptions {
   runtimeHost: AgentRuntimeHost;
@@ -63,7 +63,9 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
   private disposed = false;
 
   constructor(private readonly options: DesktopToolEditApprovalOptions) {
-    setToolEditApprovalHandler((request) => this.requestApproval(request));
+    setDesktopToolEditApprovalHandler((request) =>
+      this.requestApproval(request),
+    );
   }
 
   async requestApproval(
@@ -147,7 +149,7 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
-    setToolEditApprovalHandler();
+    setDesktopToolEditApprovalHandler(undefined);
     for (const requestId of [...this.pending.keys()]) {
       this.settle(requestId, { accepted: false });
     }

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -31,6 +31,7 @@ import {
 
 // Type imports - platform
 import type { LifecycleHost } from '@platform/interfaces/lifecycle';
+import type { ToolEditApprovalPort } from '@platform/interfaces/toolEditApproval';
 
 export interface ElectronPlatformInitResult {
   workspacePath: string | undefined;
@@ -51,6 +52,37 @@ export interface ElectronPlatformInitResult {
 
 const WORKSPACE_CONFIG_MIGRATED_KEY =
   'desktop.workspaceConfigMigratedToProject';
+
+// ---------------------------------------------------------------------------
+// Session-scoped tool-edit approval handler
+// ---------------------------------------------------------------------------
+//
+// The Platform port `toolEditApproval` is frozen at initPlatform time, but the
+// DesktopToolEditApprovalController is created per session.  The delegating
+// handler installed below reads this mutable reference so the active controller
+// can register and unregister itself via `setDesktopToolEditApprovalHandler`.
+
+let activeDesktopToolEditApprovalHandler: ToolEditApprovalPort | undefined;
+
+/**
+ * Register the active session's desktop tool-edit approval handler.
+ * Called by {@link DesktopToolEditApprovalControllerImpl} constructor / dispose.
+ */
+export function setDesktopToolEditApprovalHandler(
+  handler: ToolEditApprovalPort | undefined,
+): void {
+  activeDesktopToolEditApprovalHandler = handler;
+}
+
+export function createDesktopToolEditApprovalPort(): ToolEditApprovalPort {
+  return (request) => {
+    const handler = activeDesktopToolEditApprovalHandler;
+    if (!handler) {
+      throw new Error('No active desktop tool-edit approval controller.');
+    }
+    return handler(request);
+  };
+}
 
 export async function initializeElectronPlatform(
   mainDirname: string,
@@ -147,6 +179,7 @@ export async function initializeElectronPlatform(
         isResumeInFlight: isDesktopResumeInFlight,
       },
       getWorkspacePath: () => workspacePath,
+      toolEditApproval: createDesktopToolEditApprovalPort(),
     }),
   );
 

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -62,7 +62,10 @@ import { killActiveRecording } from '@frontend/media/audio';
 import { disposeDiffRefresh } from '@frontend/ui/diffView';
 import { registerFileDecorations } from '@frontend/ui/fileDecorations';
 import { registerWelcomeView } from '@frontend/ui/welcomeView';
-import { initializeNativeToolEditApproval } from '@frontend/approval/nativeToolEditApproval';
+import {
+  initializeNativeToolEditApproval,
+  nativeRequestApproval,
+} from '@frontend/approval/nativeToolEditApproval';
 import { SupabaseAuthProvider } from '@frontend/auth/SupabaseAuthProvider';
 import { SupabaseUriHandler } from '@frontend/auth/UriHandler';
 import { registerAgentEventListeners } from '@frontend/events/agentEventListeners';
@@ -260,6 +263,7 @@ export async function activate(context: vscode.ExtensionContext) {
         void vscode.window.showInformationMessage(message);
       }
     },
+    toolEditApproval: nativeRequestApproval,
   });
   registerAgentFeatures();
   // `disposeStatusListener` and `statusBarItem` are owned solely by

--- a/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
+++ b/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
@@ -36,7 +36,6 @@ import {
   emitToolEditApprovalPrompt,
   firstChangedLine,
   registerPendingApproval,
-  setToolEditApprovalHandler,
   unregisterPendingApproval,
   type ToolEditApprovalRequest,
   type ToolEditApprovalResult,
@@ -124,7 +123,7 @@ function resolveProgressViewApprovalPrompt(requestId: string): void {
   getRuntimeHost().emit('resolveToolEditPermission', { requestId });
 }
 
-async function nativeRequestApproval(
+export async function nativeRequestApproval(
   request: ToolEditApprovalRequest,
 ): Promise<ToolEditApprovalResult> {
   getStorageDir(); // Validates initialization
@@ -374,7 +373,11 @@ export async function handleProgressViewToolEditApprovalAction(
 
 /**
  * Initialize the native VS Code tool edit approval handler.
- * Sets up storage directory and registers the native approval handler.
+ *
+ * Sets up the storage directory and runtime host used by {@link nativeRequestApproval},
+ * which is wired into the Platform at {@link initPlatform} time.  The wiring itself
+ * lives in the extension's `initPlatform` call — this function only supplies the
+ * module-level dependencies `nativeRequestApproval` closes over.
  */
 export function initializeNativeToolEditApproval(
   context: vscode.ExtensionContext,
@@ -383,5 +386,4 @@ export function initializeNativeToolEditApproval(
   const baseDir = context.storageUri ?? context.globalStorageUri;
   storageDirectory = path.join(baseDir.fsPath, 'tool-edit-previews');
   runtimeHost = host;
-  setToolEditApprovalHandler(nativeRequestApproval);
 }

--- a/src/platform/defaults/nodeHost.ts
+++ b/src/platform/defaults/nodeHost.ts
@@ -34,6 +34,7 @@ import type { LifecycleHost } from '../interfaces/lifecycle';
 import type { StateStore } from '../interfaces/state';
 import type { StorageProvider } from '../interfaces/storage';
 import type { ToolAvailabilityHost } from '../interfaces/toolAvailability';
+import type { ToolEditApprovalPort } from '../interfaces/toolEditApproval';
 import type { Platform } from '../platform';
 import type { PlatformSecrets } from '../secrets';
 
@@ -55,6 +56,13 @@ export interface NodePlatformServices {
   readonly getWorkspacePath: () => string | undefined;
   /** Host-specific availability overrides merged over the no-op defaults. */
   readonly toolAvailability?: Partial<ToolAvailabilityHost>;
+  /**
+   * Tool-edit approval handler override.  If omitted, the returned Platform
+   * object carries a default that throws — hosts that run agents with tool-use
+   * must provide a real handler here, wired either directly (extension) or via a
+   * session-scoped indirection (CLI, desktop).
+   */
+  readonly toolEditApproval?: ToolEditApprovalPort;
 }
 
 /**
@@ -88,6 +96,17 @@ export function createNodePlatform(services: NodePlatformServices): Platform {
     addCriticismSink: () => ({ accepted: false, resolvedPath: '' }),
     toolMissingHandler: () => {},
     toolNotificationHandler: () => {},
+    // Default handler throws — a host must override this to support tool-edit
+    // approvals.  CLI and desktop override via a session-scoped indirection
+    // (see the host's own initPlatform code); the extension wires its native
+    // handler directly.
+    toolEditApproval:
+      services.toolEditApproval ??
+      (() => {
+        throw new Error(
+          'Tool edit approval is not available: no handler has been configured.',
+        );
+      }),
   };
 }
 

--- a/src/platform/interfaces/toolEditApproval.ts
+++ b/src/platform/interfaces/toolEditApproval.ts
@@ -1,0 +1,36 @@
+/**
+ * Tool-edit approval handler, wired at `initPlatform` once per process and
+ * consumed by the shared `requestToolEditApproval` entry point.
+ *
+ * The handler receives the proposed edit (already carrying a `streamId` for
+ * session routing, and enough content context to let the host surface the
+ * change before returning a decision).  It replaces the prior
+ * `setToolEditApprovalHandler` module-global singleton.
+ *
+ * Request / result shapes are defined here as the single Platform contract;
+ * `@tools/approval/toolEditApproval` re-exports these types for existing
+ * approval call sites.
+ */
+
+/** Platform-level contract for a tool-edit approval request. */
+export interface ToolEditApprovalRequest {
+  readonly path: string;
+  readonly originalContent: string;
+  readonly proposedContent: string;
+  readonly sourceTool: string;
+  readonly streamId?: string | null;
+}
+
+/** Platform-level contract for a tool-edit approval result. */
+export interface ToolEditApprovalResult {
+  readonly accepted: boolean;
+  readonly userMessage?: string;
+  readonly appliedContent?: string;
+  readonly userPatch?: string;
+  readonly lineChanges?: { readonly added: number; readonly removed: number };
+  readonly startLine?: number;
+}
+
+export type ToolEditApprovalPort = (
+  request: ToolEditApprovalRequest,
+) => Promise<ToolEditApprovalResult>;

--- a/src/platform/platform.ts
+++ b/src/platform/platform.ts
@@ -18,6 +18,7 @@ import type {
   ToolMissingHandler,
   ToolNotificationHandler,
 } from './interfaces/toolNotifications';
+import type { ToolEditApprovalPort } from './interfaces/toolEditApproval';
 import type { WorkspaceProvider } from './interfaces/workspace';
 import type { StorageProvider } from './interfaces/storage';
 import type { LifecycleHost } from './interfaces/lifecycle';
@@ -52,6 +53,8 @@ export interface Platform {
   readonly toolMissingHandler: ToolMissingHandler;
   /** Surfaces a tool-group-unavailable notification to the user. */
   readonly toolNotificationHandler: ToolNotificationHandler;
+  /** Host-provided tool-edit approval UI (diff viewer + accept/reject). */
+  readonly toolEditApproval: ToolEditApprovalPort;
 }
 
 let _platform: Readonly<Platform> | null = null;

--- a/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
@@ -9,10 +9,40 @@ import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { AcceptRunFilesTool } from '@tools/AcceptRunFilesTool';
 import {
   cleanupAllApprovals,
-  setToolEditApprovalHandler,
+  type ToolEditApprovalRequest,
+  type ToolEditApprovalResult,
 } from '@tools/approval';
 import { AbsoluteFS, flexibleFS, StorageFS, WorkspaceFS } from '@utils/files';
 import { createRecordingHost } from '../progressTestUtils';
+
+let testApprovalHandler:
+  | ((request: ToolEditApprovalRequest) => Promise<ToolEditApprovalResult>)
+  | undefined;
+
+async function installTestPlatform(): Promise<void> {
+  const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
+    import('@platform/platform'),
+    import('@test/support/FakePlatform'),
+  ]);
+  initPlatform(
+    createFakePlatform(
+      {
+        workspacePath,
+        storagePath,
+        globalStoragePath: '/global/.texra/storage',
+      },
+      {
+        toolEditApproval: (request) => {
+          const handler = testApprovalHandler;
+          if (!handler) {
+            throw new Error('No test handler. Set `testApprovalHandler`.');
+          }
+          return handler(request);
+        },
+      },
+    ),
+  );
+}
 
 const executionId = 'abcdef' as ExecutionId;
 const streamId = 'stream:accept-run-files' as StreamTabId;
@@ -46,7 +76,7 @@ describe('accept_run_files progress events', () => {
   let originalAbsoluteRead: typeof AbsoluteFS.read;
   let originalFlexibleRead: typeof flexibleFS.read;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     originalStorageExists = StorageFS.exists;
     originalStorageFullPath = StorageFS.fullPath;
     originalWorkspaceLocatePath = WorkspaceFS.locatePath;
@@ -59,6 +89,8 @@ describe('accept_run_files progress events', () => {
     originalAbsoluteRead = AbsoluteFS.read;
     originalFlexibleRead = flexibleFS.read;
     AbsoluteFS.isSymbolicLink = async () => false;
+    testApprovalHandler = undefined;
+    await installTestPlatform();
     cleanupAllApprovals();
   });
 
@@ -74,7 +106,7 @@ describe('accept_run_files progress events', () => {
     AbsoluteFS.isSymbolicLink = originalAbsoluteIsSymbolicLink;
     AbsoluteFS.read = originalAbsoluteRead;
     flexibleFS.read = originalFlexibleRead;
-    setToolEditApprovalHandler();
+    testApprovalHandler = undefined;
     cleanupAllApprovals();
   });
 
@@ -97,7 +129,7 @@ describe('accept_run_files progress events', () => {
     WorkspaceFS.delete = async () => undefined;
     flexibleFS.read = async () => 'accepted content';
 
-    setToolEditApprovalHandler(async () => ({ accepted: true }));
+    testApprovalHandler = async () => ({ accepted: true });
 
     const result = await runAccept(tool, explicit.host, [
       { path: 'output.tex', original: 'paper.tex' },
@@ -152,11 +184,11 @@ describe('accept_run_files progress events', () => {
       target === `${storagePath}/executions/${executionId}/original/draft.tex`;
     AbsoluteFS.read = async () => 'old content';
     flexibleFS.read = async () => 'new content';
-    setToolEditApprovalHandler(async (request) => {
+    testApprovalHandler = async (request) => {
       approvalOriginal = request.originalContent;
       approvalProposed = request.proposedContent;
       return { accepted: true };
-    });
+    };
 
     const result = await runAccept(tool, explicit.host, [
       { path: 'draft.tex', original: 'draft.tex' },
@@ -193,10 +225,10 @@ describe('accept_run_files progress events', () => {
     WorkspaceFS.delete = async () => undefined;
     AbsoluteFS.isFile = async () => false;
     flexibleFS.read = async () => 'same content';
-    setToolEditApprovalHandler(async () => {
+    testApprovalHandler = async () => {
       approvals++;
       return { accepted: true };
-    });
+    };
 
     const result = await runAccept(tool, explicit.host, [
       { path: 'draft.tex', original: 'draft.tex' },
@@ -234,10 +266,10 @@ describe('accept_run_files progress events', () => {
     AbsoluteFS.isSymbolicLink = async (target) =>
       target ===
       `${storagePath}/executions/${executionId}/r1/Draft/appendices.tex`;
-    setToolEditApprovalHandler(async () => {
+    testApprovalHandler = async () => {
       approvals++;
       return { accepted: true };
-    });
+    };
 
     const result = await runAccept(tool, explicit.host, [
       { path: 'r1/Draft/appendices.tex', original: 'Draft/appendices.tex' },

--- a/src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 // Local imports
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
@@ -24,10 +24,38 @@ import {
 } from '@tools/approval/bashApproval';
 import {
   requestToolEditApproval,
-  setToolEditApprovalHandler,
+  type ToolEditApprovalRequest,
+  type ToolEditApprovalResult,
 } from '@tools/approval/toolEditApproval';
 import { createRecordingHost } from '../progressTestUtils';
 import { waitForRecordedEvent } from '@test/support/asyncTestUtils';
+
+let testApprovalHandler:
+  | ((request: ToolEditApprovalRequest) => Promise<ToolEditApprovalResult>)
+  | undefined;
+
+async function installTestPlatform(): Promise<void> {
+  const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
+    import('@platform/platform'),
+    import('@test/support/FakePlatform'),
+  ]);
+  initPlatform(
+    createFakePlatform(
+      {},
+      {
+        toolEditApproval: (request) => {
+          const handler = testApprovalHandler;
+          if (!handler) {
+            throw new Error(
+              'No test approval handler. Set `testApprovalHandler` first.',
+            );
+          }
+          return handler(request);
+        },
+      },
+    ),
+  );
+}
 
 function inToolContext<T>(
   host: AgentRuntimeHost,
@@ -40,8 +68,14 @@ function inToolContext<T>(
 }
 
 describe('human prompt progress events', () => {
+  beforeEach(async () => {
+    testApprovalHandler = undefined;
+    await installTestPlatform();
+  });
+
   afterEach(() => {
     cleanupAllApprovals();
+    testApprovalHandler = undefined;
   });
 
   it('publishes bash approval events through the tool runtime host', async () => {
@@ -221,13 +255,13 @@ describe('human prompt progress events', () => {
       });
 
       let editApprovalRequests = 0;
-      setToolEditApprovalHandler(async (request) => {
+      testApprovalHandler = async (request) => {
         editApprovalRequests += 1;
         return {
           accepted: true,
           appliedContent: request.proposedContent,
         };
-      });
+      };
 
       const editApproval = await withRunContext(
         createRunContext({ runtimeHost: explicit.host, streamId }),
@@ -246,7 +280,7 @@ describe('human prompt progress events', () => {
         appliedContent: 'new',
       });
     } finally {
-      setToolEditApprovalHandler();
+      testApprovalHandler = undefined;
     }
   });
 

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.mts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.mts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const handleExternalInquiryActionMock = vi.hoisted(() => vi.fn());
 
@@ -6,6 +6,10 @@ vi.mock('@tools/inquiry/ExternalInquiryTool', () => ({
   handleExternalInquiryAction: handleExternalInquiryActionMock,
 }));
 
+import {
+  setActiveCliToolEditApprovalHandler,
+  createCliToolEditApprovalPort,
+} from '@cli/runtime/initPlatform';
 import {
   appendCliApiSwitchHint,
   approvalPromptAllowed,
@@ -22,10 +26,7 @@ import {
 import type { CliContext } from '@cli/runtime/cliContext';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import { AgentCategory, DEFAULT_TOOL_CONFIG } from '@shared/schemas';
-import {
-  requestToolEditApproval,
-  setToolEditApprovalHandler,
-} from '@tools/approval/toolEditApproval';
+import { requestToolEditApproval } from '@tools/approval/toolEditApproval';
 
 function context(overrides: Partial<CliContext> = {}): CliContext {
   return {
@@ -54,8 +55,21 @@ const credentialExhaustedRetry: ProgressEventPayloads['showRetryRequest'] = {
   },
 };
 
+beforeEach(async () => {
+  // Wire the Platform with a delegating port that reads the CLI's active
+  // approval handler — the same pattern used by `initCliPlatform`.
+  const { initPlatform: init } = await import('@platform/platform');
+  const { createFakePlatform } = await import('@test/support/FakePlatform');
+  init(
+    createFakePlatform(
+      {},
+      { toolEditApproval: createCliToolEditApprovalPort() },
+    ),
+  );
+});
+
 afterEach(() => {
-  setToolEditApprovalHandler();
+  setActiveCliToolEditApprovalHandler(undefined);
   handleExternalInquiryActionMock.mockClear();
 });
 

--- a/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
+++ b/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
@@ -40,6 +40,10 @@ interface DesktopToolEditApprovalModule {
   };
 }
 
+interface DesktopPlatformModule {
+  createDesktopToolEditApprovalPort(): import('@platform/interfaces/toolEditApproval').ToolEditApprovalPort;
+}
+
 function createBusRuntimeHost(bus: ProgressEventBusLike): AgentRuntimeHost {
   return {
     emit: (event, payload) => bus.emit(event, payload),
@@ -123,13 +127,29 @@ async function loadApprovalModules(workspacePath = '/workspace') {
     };
   });
 
-  const [{ initPlatform }, { createFakePlatform }, { nodeFilesystem }] =
-    await Promise.all([
-      import('@platform/platform'),
-      import('@test/support/FakePlatform'),
-      import('@platform/defaults/nodeFilesystem'),
-    ]);
-  initPlatform(createFakePlatform({ workspacePath }, { fs: nodeFilesystem }));
+  const [
+    { initPlatform },
+    { createFakePlatform },
+    { nodeFilesystem },
+    desktopPlatformModule,
+  ] = await Promise.all([
+    import('@platform/platform'),
+    import('@test/support/FakePlatform'),
+    import('@platform/defaults/nodeFilesystem'),
+    import(
+      moduleFileUrl(desktopSourcePath('main', 'platform', 'index.ts'))
+    ) as Promise<DesktopPlatformModule>,
+  ]);
+  initPlatform(
+    createFakePlatform(
+      { workspacePath },
+      {
+        fs: nodeFilesystem,
+        toolEditApproval:
+          desktopPlatformModule.createDesktopToolEditApprovalPort(),
+      },
+    ),
+  );
 
   const [
     { bus },

--- a/src/test-kernel/desktop/ElectronAgentDirectories.vitest.mts
+++ b/src/test-kernel/desktop/ElectronAgentDirectories.vitest.mts
@@ -123,6 +123,9 @@ describe('desktop agent directory bootstrap', () => {
       addCriticismSink: () => ({ accepted: false, resolvedPath: '' }),
       toolMissingHandler: () => {},
       toolNotificationHandler: () => {},
+      toolEditApproval: () => {
+        throw new Error('Tool edit approval not available in this test.');
+      },
     });
 
     return {

--- a/src/test-kernel/support/FakePlatform.ts
+++ b/src/test-kernel/support/FakePlatform.ts
@@ -762,6 +762,12 @@ export function createFakePlatform(
     addCriticismSink: () => ({ accepted: false, resolvedPath: '' }),
     toolMissingHandler: () => {},
     toolNotificationHandler: () => {},
+    toolEditApproval: () => {
+      throw new Error(
+        'Tool edit approval is not available in the fake platform. ' +
+          'Override with `createFakePlatform({}, { toolEditApproval: ... })`.',
+      );
+    },
     ...overrides,
   };
 }

--- a/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
+++ b/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
@@ -15,23 +15,44 @@ import { TextEditorTool } from '@tools/TextEditorTool';
 import { WriteFileTool } from '@tools/WriteTool';
 import {
   cleanupAllApprovals,
-  setToolEditApprovalHandler,
   setToolEditApprovalSessionBypass,
   toggleToolEditApprovalSessionBypass,
   type ToolEditApprovalRequest,
+  type ToolEditApprovalResult,
 } from '@tools/approval';
 import { WorkspaceFS } from '@utils/files';
 
 // Test stream ID for per-stream YOLO mode tests
 const TEST_STREAM_ID = 'TestAgent@model: test.tex' as StreamTabId;
 
+// Mutable test handler reference — the Platform is frozen at init time, so
+// tests inject a delegating handler that reads this reference, mirroring the
+// pattern used by the CLI and desktop hosts.
+let testApprovalHandler:
+  | ((request: ToolEditApprovalRequest) => Promise<ToolEditApprovalResult>)
+  | undefined;
+
 async function installPlatform(
   config: Record<string, unknown> = {},
   files: Record<string, string | Uint8Array> = {},
 ) {
   const { initPlatform } = await import('@platform/platform');
+  testApprovalHandler = undefined;
   initPlatform(
-    createFakePlatform({ workspacePath: '/workspace', config, files }),
+    createFakePlatform(
+      { workspacePath: '/workspace', config, files },
+      {
+        toolEditApproval: (request) => {
+          const handler = testApprovalHandler;
+          if (!handler) {
+            throw new Error(
+              'No test approval handler configured. Set `testApprovalHandler` first.',
+            );
+          }
+          return handler(request);
+        },
+      },
+    ),
   );
 }
 
@@ -70,7 +91,7 @@ describe('Tool edit approval gating', () => {
     WorkspaceFS.read = originalRead;
     WorkspaceFS.write = originalWrite;
     WorkspaceFS.appendFile = originalAppend;
-    setToolEditApprovalHandler();
+    testApprovalHandler = undefined;
     cleanupAllApprovals();
   });
 
@@ -85,10 +106,10 @@ describe('Tool edit approval gating', () => {
       writtenContent = content;
     };
 
-    setToolEditApprovalHandler(async (request) => {
+    testApprovalHandler = async (request) => {
       capturedRequest = request;
       return { accepted: true };
-    });
+    };
 
     const result = await tool.call({ path: 'doc.txt', content: 'new content' });
 
@@ -110,10 +131,10 @@ describe('Tool edit approval gating', () => {
       writeCalled = true;
     };
 
-    setToolEditApprovalHandler(async () => ({
+    testApprovalHandler = async () => ({
       accepted: false,
       userMessage: 'Rejected by user',
-    }));
+    });
 
     const result = await tool.call({
       path: 'summary.txt',
@@ -142,10 +163,10 @@ describe('Tool edit approval gating', () => {
       writtenContent = content;
     };
 
-    setToolEditApprovalHandler(async () => {
+    testApprovalHandler = async () => {
       handlerCalled = true;
       return { accepted: true };
-    });
+    };
 
     const result = await tool.call({ path: 'doc.txt', content: 'new content' });
 
@@ -165,10 +186,10 @@ describe('Tool edit approval gating', () => {
       writtenContent = content;
     };
 
-    setToolEditApprovalHandler(async () => {
+    testApprovalHandler = async () => {
       handlerCalled = true;
       return { accepted: true };
-    });
+    };
 
     setToolEditApprovalSessionBypass(
       TEST_STREAM_ID,
@@ -201,7 +222,7 @@ describe('Tool edit approval gating', () => {
     );
     const tool = new TextEditorTool();
 
-    setToolEditApprovalHandler(async () => ({ accepted: true }));
+    testApprovalHandler = async () => ({ accepted: true });
 
     const parentEdit = await callTextEditorInRun(tool, 'aaaaaa', {
       command: 'str_replace',
@@ -245,9 +266,9 @@ describe('Tool edit approval gating', () => {
     );
     const tool = new TextEditorTool();
 
-    setToolEditApprovalHandler(async () => {
+    testApprovalHandler = async () => {
       throw new Error('approval should not be requested');
-    });
+    };
 
     const result = await tool.call({
       command: 'str_replace',

--- a/src/tools/approval/index.ts
+++ b/src/tools/approval/index.ts
@@ -127,7 +127,6 @@ export {
 
 export {
   // Tool edit approval
-  setToolEditApprovalHandler,
   setToolEditApprovalSessionBypass,
   toggleToolEditApprovalSessionBypass,
   isApprovalBypassedForStream,

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -4,17 +4,14 @@ import {
   DIFF_EQUAL,
   DIFF_INSERT,
 } from 'diff-match-patch';
-import { z } from 'zod';
 
+import { platform } from '@platform/platform';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { tryUseRunContext } from '@agent/runtime/RunContext';
 import { isLatexFile } from '@common/files/fileTypeUtils';
-import { StreamTabIdSchema, type StreamTabId } from '@shared/schemas';
+import type { StreamTabId } from '@shared/schemas';
 import type { ToolEditApprovalAction } from '@shared/schemas/prompts';
-import {
-  LineChangesSchema,
-  type LineChanges,
-} from '@shared/schemas/lineChanges';
+import type { LineChanges } from '@shared/schemas/lineChanges';
 import { type ToolResult } from '@shared/schemas/toolResult';
 import { WorkspaceFS } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
@@ -22,30 +19,12 @@ import { countLines } from '@utils/text/stringUtils';
 
 import { bashApprovalController } from './bashApproval';
 import { createStreamApprovalController } from './streamApprovalQueue';
+import type {
+  ToolEditApprovalRequest,
+  ToolEditApprovalResult,
+} from '@platform/interfaces/toolEditApproval';
 
-const ToolEditApprovalRequestSchema = z.object({
-  path: z.string(),
-  originalContent: z.string(),
-  proposedContent: z.string(),
-  sourceTool: z.string(),
-  streamId: StreamTabIdSchema.nullish(),
-});
-export type ToolEditApprovalRequest = z.infer<
-  typeof ToolEditApprovalRequestSchema
->;
-
-const ToolEditApprovalResultSchema = z.object({
-  accepted: z.boolean(),
-  userMessage: z.string().optional(),
-  appliedContent: z.string().optional(),
-  userPatch: z.string().optional(),
-  lineChanges: LineChangesSchema.optional(),
-  /** 1-based line number where the first change occurs (for navigation) */
-  startLine: z.int().positive().optional(),
-});
-export type ToolEditApprovalResult = z.infer<
-  typeof ToolEditApprovalResultSchema
->;
+export type { ToolEditApprovalRequest, ToolEditApprovalResult };
 
 const TOOL_EDIT_APPROVAL_CONFIG_KEY = 'texra.toolUse.requireEditApproval';
 
@@ -56,10 +35,6 @@ export const toolEditApprovalController =
     rejectionResult: () => ({ accepted: false }),
     bypassEvent: 'updateToolEditApprovalBypassState',
   });
-
-let customHandler:
-  | ((request: ToolEditApprovalRequest) => Promise<ToolEditApprovalResult>)
-  | undefined;
 
 /** Register a pending approval entry for rejection tracking. */
 export function registerPendingApproval(
@@ -147,14 +122,6 @@ export function emitToolEditApprovalPrompt(
     removedLines: lineChanges.removed,
     isLatex: isLatexFile(request.path),
   });
-}
-
-export function setToolEditApprovalHandler(
-  handler?: (
-    request: ToolEditApprovalRequest,
-  ) => Promise<ToolEditApprovalResult>,
-): void {
-  customHandler = handler;
 }
 
 // ============================================================================
@@ -269,12 +236,7 @@ export async function requestToolEditApproval(
   }
 
   const result = await toolEditApprovalController.enqueue(async () => {
-    if (!customHandler) {
-      throw new Error(
-        'No approval handler registered. Call initializeNativeToolEditApproval first.',
-      );
-    }
-    return customHandler(preparedRequest);
+    return platform().toolEditApproval(preparedRequest);
   });
   return finalizeApprovalResult(result, preparedRequest);
 }


### PR DESCRIPTION
## Summary

This PR closes #6890 by moving tool-edit approval off the shared `setToolEditApprovalHandler` module-global and into the typed `Platform` surface.

The tool layer now asks `platform().toolEditApproval(...)` for an approval decision. Each host wires that port explicitly:

- the extension provides the native approval implementation at platform initialization;
- the CLI installs a session-scoped delegating port for TUI and headless approval flows;
- the desktop host installs a session-scoped delegating port whose active controller can register and dispose itself.

The remaining mutable handler references live only inside host composition roots. They are not exported from the shared approval module and exist only to bridge a fixed Platform object to a per-session UI controller.

## Design Notes

The approval request and result types are now owned by `src/platform/interfaces/toolEditApproval.ts`, and `@tools/approval/toolEditApproval` re-exports those types for existing call sites. This avoids two parallel schemas for the same boundary.

Node and fake platforms keep an explicit throwing default for hosts or tests that do not support interactive edit approval. This makes missing wiring fail at the port boundary with a direct error instead of silently falling back to stale global state.

## Validation

- `corepack pnpm exec tsc --noEmit -p tsconfig.json --pretty false`
- `corepack pnpm exec eslint packages/cli/src/chat/tui/state/subscribeApprovals.ts packages/desktop/src/main/platform/index.ts src/platform/interfaces/toolEditApproval.ts src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts src/tools/approval/toolEditApproval.ts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ApprovalAdapter.vitest.mts src/test-kernel/tools/ToolEditApprovalGate.vitest.ts src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts src/test-kernel/desktop/ElectronAgentDirectories.vitest.mts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ApprovalAdapter.vitest.mts src/test-kernel/tools/ToolEditApprovalGate.vitest.ts src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the agent tool-edit gate used before workspace writes across CLI, desktop, and extension; miswired or missing handlers now throw at the port instead of failing via stale globals.
> 
> **Overview**
> Moves tool-edit approval off the shared **`setToolEditApprovalHandler`** module global and onto the frozen **`Platform`** surface as **`toolEditApproval`**, with request/result types owned by **`src/platform/interfaces/toolEditApproval.ts`** (re-exported from **`@tools/approval`**).
> 
> The shared **`requestToolEditApproval`** path now calls **`platform().toolEditApproval(...)`** instead of a tools-layer singleton. **Extension** wires **`nativeRequestApproval`** at **`initPlatform`**; **CLI** and **desktop** install session-scoped delegating ports (**`createCliToolEditApprovalPort`** / **`createDesktopToolEditApprovalPort`**) that TUI, headless CLI, or per-session desktop controllers register and clear. **`createNodePlatform`** defaults to a throwing handler when no port is supplied. Tests inject approval via **`createFakePlatform`** overrides rather than the removed setter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41f37d0984fa355e1f4488d8e6618d33965c3623. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->