### PR TITLE
fix(cli): persist headless stream sidecars directly

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -222,7 +222,7 @@ export function createChatSessionController(
     readonly finalize: () => void;
   } => {
     const runtimeHost = createCliRuntimeHost(sessionContext);
-    const wrapped = wrapRuntimeHost(runtimeHost);
+    const wrapped = wrapRuntimeHost(runtimeHost, snapshotStore);
     const detachResultToast = attachTerminalResultToast(
       defaultSession(),
       wrapped,

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -53,7 +53,6 @@ import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
 import { formatCliApprovalPolicy } from '@cli/runtime/approvalPolicyText';
 import { isLiveElapsedStatus } from '@common/constants/streamStatus';
 import { toErrorMessage } from '@common/errors/errorMessage';
-import { bus } from '@eventBus/ProgressEventBus';
 import {
   STREAM_STATUS,
   type StreamStatus,
@@ -410,7 +409,6 @@ export async function runChat(
   disposers.push(installTerminalRestoreOnExit({ clearItermProgress }));
   disposers.push(subscribeStreamLog());
   disposers.push(subscribeStreamStatus());
-  disposers.push(snapshotStore.subscribe(bus));
 
   const session: TuiSession = {
     streamId: undefined,

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -8,7 +8,6 @@ import type {
   ProgressEvent,
   ProgressEventPayloads,
 } from '@eventBus/ProgressEventBus';
-import { bus } from '@eventBus/ProgressEventBus';
 import { diffActiveChildren } from '@shared/streams/childActivityReducer';
 import {
   reduceStreamMeta,
@@ -27,6 +26,7 @@ import { mergeChildStreams } from './childExecutions';
 import { appendCompletedProcessEntries } from './completedProcessTranscript';
 import { sumResumeUsageStats } from './resumeHint';
 import { appendLocalAssistantTranscript } from './transcript';
+import type { StreamSnapshotStore } from '@transcript';
 
 type Emit = <K extends ProgressEvent>(
   event: K,
@@ -87,11 +87,14 @@ function applyStreamMeta(
   );
 }
 
-export function wrapRuntimeHost(host: CliRuntimeHost): CliRuntimeHost {
+export function wrapRuntimeHost(
+  host: CliRuntimeHost,
+  snapshotStore?: StreamSnapshotStore,
+): CliRuntimeHost {
   const original = host.emit;
   const emit: Emit = (event, payload) => {
     applyToState(event, payload);
-    bus.emit(event, payload);
+    snapshotStore?.handleProgressEvent(event, payload);
     return original(event, payload);
   };
   return { ...host, emit };

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -1,5 +1,6 @@
 import { SHUTDOWN_PHASE } from '@platform/interfaces/lifecycle';
 import { tryPlatform } from '@platform/platform';
+import { StreamSnapshotStore } from '@transcript';
 import { writeTerminalStatus } from '@agent/storage';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
@@ -10,12 +11,16 @@ import { runAgent } from '@agent/runtime/runAgent';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
 import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
+import type {
+  ProgressEvent,
+  ProgressEventPayloads,
+} from '@eventBus/ProgressEventBus';
 import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core/executionId';
 
 import { approvalPromptsUnavailable } from './approvalPolicyAvailability';
 import { installCliApprovalHandlers } from './approvalAdapter';
-import { createCliRuntimeHost } from './runtimeHost';
+import { createCliRuntimeHost, type CliRuntimeHost } from './runtimeHost';
 import { CliExitCode } from './exitCodes';
 import { writeTextStderr } from './logSinks';
 import {
@@ -50,6 +55,20 @@ type ExecuteAgentResultForCategory<C extends AgentCategory | undefined> =
   C extends AgentCategory
     ? Extract<ExecuteAgentResult, { category: C }>
     : ExecuteAgentResult;
+
+function persistCliProgressEvents(
+  host: CliRuntimeHost,
+  snapshotStore: StreamSnapshotStore,
+): CliRuntimeHost {
+  const emit = <K extends ProgressEvent>(
+    event: K,
+    payload: ProgressEventPayloads[K],
+  ): void => {
+    snapshotStore.handleProgressEvent(event, payload);
+    host.emit(event, payload);
+  };
+  return { ...host, emit };
+}
 
 export interface CliConfigExecuteOptions<
   C extends AgentCategory | undefined = undefined,
@@ -128,7 +147,9 @@ export async function executeCliRequest(
   runContext: CliContext,
   options: CliExecuteOptions = {},
 ): Promise<{ result: ExecuteAgentResult; terminalStatus: ExecutionStatus }> {
-  const runtimeHost = createCliRuntimeHost(runContext);
+  const baseRuntimeHost = createCliRuntimeHost(runContext);
+  const snapshotStore = new StreamSnapshotStore();
+  const runtimeHost = persistCliProgressEvents(baseRuntimeHost, snapshotStore);
   // Present terminal-error toasts from the run's `result` event through the same
   // runtimeHost path the lifecycle used before (so ndjson / logger output is
   // unchanged); the lifecycle no longer emits them directly.
@@ -182,7 +203,11 @@ export async function executeCliRequest(
     }
     detachResultToast();
     uninstallApprovalHandlers();
-    await runtimeHost.close();
+    try {
+      await snapshotStore.flush();
+    } finally {
+      await runtimeHost.close();
+    }
   }
 
   const terminalStatus = await readCliTerminalStatus(result);

--- a/packages/desktop/src/main/desktopProgressEventBridge.ts
+++ b/packages/desktop/src/main/desktopProgressEventBridge.ts
@@ -137,7 +137,9 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
       });
     }
 
-    // Subscribe to progress-relevant event-bus channels.
+    // These events can be emitted on the process bus without an active desktop
+    // runtime host. Keep them subscribed here so all desktop windows see goal
+    // badge, progress-routing, and root-error updates.
     const unsubscribeGoal = bus.on('goalStateChanged', ({ streamId }) => {
       const goal = GoalStore.getForStream(streamId);
       opts.onGoalStateChanged(streamId, isGoalInFlight(goal), {
@@ -151,9 +153,6 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
         opts.routeToProgress();
       },
     );
-    // Run failures surface only through this event for root runs; without a
-    // subscriber the message dies in the main process and the rail shows a
-    // bare ERROR status.
     const unsubscribeShowError = bus.on('requestShowError', ({ message }) => {
       opts.onShowError(message);
     });

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -1,8 +1,20 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createFakePlatform } from '@test/support/FakePlatform';
+import { MemoryStateStore } from '@platform/defaults/memoryState';
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
+import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import type { CliContext } from '@cli/runtime/cliContext';
-import { EXECUTION_STATUS } from '@shared/schemas';
+import {
+  EXECUTION_STATUS,
+  type StreamTabId,
+  type TodoItem,
+} from '@shared/schemas';
 import { DIAGNOSTICS_ADD_RUNTIME_CAPABILITY } from '@tools/diagnosticsRuntimeCapabilities';
 
 const mocks = vi.hoisted(() => ({
@@ -15,6 +27,28 @@ const mocks = vi.hoisted(() => ({
   writeTextStderr: vi.fn(),
   writeTerminalStatus: vi.fn(),
 }));
+
+const tempDirs: string[] = [];
+
+async function installStoragePlatform(): Promise<void> {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'texra-run-'));
+  tempDirs.push(tempDir);
+  const workspaceDir = path.join(tempDir, 'workspace');
+  const storageRoot = path.join(tempDir, 'storage');
+  const { initPlatform } = await import('@platform/platform');
+  initPlatform(
+    createFakePlatform(
+      { workspacePath: workspaceDir },
+      {
+        fs: nodeFilesystem,
+        workspace: createNodeWorkspace(() => workspaceDir),
+        storage: new WorkspaceStorageProvider(storageRoot, workspaceDir),
+        globalState: new MemoryStateStore(),
+        workspaceState: new MemoryStateStore(),
+      },
+    ),
+  );
+}
 
 vi.mock('@agent/runtime/runAgent', () => ({
   runAgent: mocks.runAgent,
@@ -76,6 +110,14 @@ function stubRunExecutionDeps(): void {
 
 describe('executeCliRequest', () => {
   beforeEach(stubRunExecutionDeps);
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs
+        .splice(0)
+        .map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
 
   it('marks headless never runs as approval-unavailable for agent execution', async () => {
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
@@ -217,6 +259,76 @@ describe('executeCliRequest', () => {
     expect(uninstall.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.close.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
     );
+  });
+
+  it('persists headless stream sidecars emitted through the runtime host', async () => {
+    await installStoragePlatform();
+    const { executeCliRequest } = await import('@cli/runtime/runExecution');
+    const request = {
+      config: {},
+      executionId: 'exec-1',
+    } as Parameters<typeof executeCliRequest>[0];
+    const todo: TodoItem = {
+      content: 'Write the introduction',
+      status: 'in_progress',
+      activeForm: 'Writing the introduction',
+    };
+
+    mocks.runAgent.mockImplementationOnce(async (_request, options) => {
+      options.runtimeHost.emit('updateTodos', {
+        streamId: 'stream-1',
+        todos: [todo],
+      });
+      return {
+        category: 'toolUse',
+        executionId: 'exec-1',
+        status: 'completed',
+        streamId: 'stream-1',
+      };
+    });
+
+    await executeCliRequest(request, cliContext());
+
+    const { StreamSnapshotStore } = await import('@transcript');
+    const snapshot = await new StreamSnapshotStore().read(
+      'stream-1' as StreamTabId,
+    );
+    expect(snapshot.todos).toEqual([todo]);
+  });
+
+  it('closes the runtime host when sidecar flush fails', async () => {
+    vi.resetModules();
+    const flushError = new Error('flush failed');
+    vi.doMock('@transcript', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('@transcript')>();
+      return {
+        ...actual,
+        StreamSnapshotStore: class {
+          handleProgressEvent = vi.fn();
+
+          flush = vi.fn(async () => {
+            throw flushError;
+          });
+        },
+      };
+    });
+
+    try {
+      const { executeCliRequest } = await import('@cli/runtime/runExecution');
+      const request = {
+        config: {},
+        executionId: 'exec-1',
+      } as Parameters<typeof executeCliRequest>[0];
+
+      await expect(executeCliRequest(request, cliContext())).rejects.toThrow(
+        flushError,
+      );
+
+      expect(mocks.close).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.doUnmock('@transcript');
+      vi.resetModules();
+    }
   });
 
   it('marks owned executions interrupted during platform shutdown', async () => {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -2,13 +2,14 @@
 
 import { EventEmitter } from 'node:events';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   createRunTrace,
   getDefaultStreamLogStore,
   setDefaultStreamLogStore,
   StreamLogStore,
+  type StreamSnapshotStore,
 } from '@transcript';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
@@ -88,7 +89,6 @@ import {
   resolveLocalTranscriptStreamId,
 } from '@cli/chat/tui/state/transcript';
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
-import { bus } from '@eventBus/ProgressEventBus';
 import {
   AgentCategory,
   DEFAULT_TOOL_CONFIG,
@@ -2735,19 +2735,17 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
     } as unknown as CliRuntimeHost;
   }
 
-  it('mirrors runtime events to the shared progress bus', () => {
-    const seen: unknown[] = [];
-    const off = bus.on('updateTodos', (payload) => {
-      seen.push(payload);
-    });
-    const wrapped = wrapRuntimeHost(makeHost());
+  it('feeds runtime events to the snapshot store directly', () => {
+    const snapshotStore = {
+      handleProgressEvent: vi.fn(),
+    } as unknown as StreamSnapshotStore;
+    const wrapped = wrapRuntimeHost(makeHost(), snapshotStore);
 
-    try {
-      wrapped.emit('updateTodos', { streamId: root, todos: [] });
-      expect(seen).toEqual([{ streamId: root, todos: [] }]);
-    } finally {
-      off();
-    }
+    wrapped.emit('updateTodos', { streamId: root, todos: [] });
+    expect(snapshotStore.handleProgressEvent).toHaveBeenCalledWith(
+      'updateTodos',
+      { streamId: root, todos: [] },
+    );
   });
 
   it('registers suppressed child streams without switching away from the parent page', () => {

--- a/src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts
@@ -43,6 +43,9 @@ type BridgeOptions = Parameters<
   typeof import('@desktop/main/desktopProgressEventBridge').createDesktopProgressEventBridge
 >[0];
 type SnapshotStore = NonNullable<BridgeOptions['streamSnapshotStore']>;
+type MockBusHandler = (payload: any) => void;
+
+const mockBusHandlers = new Map<string, MockBusHandler>();
 
 function createSnapshotStore(
   overrides: Partial<SnapshotStore> = {},
@@ -108,6 +111,7 @@ async function loadBridgeModule(): Promise<
   typeof import('@desktop/main/desktopProgressEventBridge')
 > {
   vi.resetModules();
+  mockBusHandlers.clear();
   vi.doMock('@logger', () => ({
     createChannelTrace: () => makeLogger(),
     setDefaultStreamLogStore: () => {},
@@ -121,7 +125,14 @@ async function loadBridgeModule(): Promise<
   }));
   vi.doMock('@eventBus/ProgressEventBus', () => ({
     bus: {
-      on: vi.fn(() => () => undefined),
+      on: vi.fn((event: string, handler: MockBusHandler) => {
+        mockBusHandlers.set(event, handler);
+        return () => {
+          if (mockBusHandlers.get(event) === handler) {
+            mockBusHandlers.delete(event);
+          }
+        };
+      }),
       emit: vi.fn(),
     },
   }));
@@ -382,6 +393,45 @@ describe('DesktopProgressEventBridge', () => {
           command: 'setActiveStream',
           activeStream: '',
         });
+      } finally {
+        bridge.dispose();
+      }
+    });
+  });
+
+  // ── Process-bus events ──────────────────────────────────────────────────
+
+  describe('process-bus events', () => {
+    it('subscribes to desktop-wide goal, routing, and root-error events', () => {
+      const routeToProgress = vi.fn();
+      const onGoalStateChanged = vi.fn();
+      const onShowError = vi.fn();
+      const bridge = createBridge({
+        routeToProgress,
+        onGoalStateChanged,
+        onShowError,
+      });
+
+      try {
+        mockBusHandlers.get('goalStateChanged')?.({
+          streamId: 'goal-stream',
+        });
+        mockBusHandlers.get('requestEnsureProgressView')?.({});
+        mockBusHandlers.get('requestShowError')?.({
+          message: 'Root run failed',
+        });
+
+        expect(onGoalStateChanged).toHaveBeenCalledWith('goal-stream', false, {
+          status: undefined,
+          objective: undefined,
+        });
+        expect(routeToProgress).toHaveBeenCalledTimes(1);
+        expect(onShowError).toHaveBeenCalledWith('Root run failed');
+
+        bridge.dispose();
+        expect(mockBusHandlers.has('goalStateChanged')).toBe(false);
+        expect(mockBusHandlers.has('requestEnsureProgressView')).toBe(false);
+        expect(mockBusHandlers.has('requestShowError')).toBe(false);
       } finally {
         bridge.dispose();
       }

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -11,7 +11,6 @@ import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import { createFakePlatform } from '@test/support/FakePlatform';
 import { StreamSnapshotStore, streamDataDir } from '@transcript';
 import { TaskStateSchema, type TaskState } from '@agent/core/state/TaskState';
-import { bus } from '@eventBus/ProgressEventBus';
 import type {
   ExecutionId,
   OutputFileInfo,
@@ -93,28 +92,29 @@ describe('StreamSnapshotStore', () => {
     );
   });
 
-  it('persists todos/plan/usage via the bus and reassembles them on a fresh store', async () => {
+  it('persists todos/plan/usage from progress events and reassembles them on a fresh store', async () => {
     await installPlatform();
 
     const writer = new StreamSnapshotStore();
-    const off = writer.subscribe(bus);
 
-    bus.emit('updateTodos', { streamId: STREAM, todos: [TODO] });
-    bus.emit('updatePlan', { streamId: STREAM, plan: PLAN });
+    writer.handleProgressEvent('updateTodos', {
+      streamId: STREAM,
+      todos: [TODO],
+    });
+    writer.handleProgressEvent('updatePlan', { streamId: STREAM, plan: PLAN });
     // Two deltas for the same run must accumulate, not overwrite.
-    bus.emit('updateStreamUsage', {
+    writer.handleProgressEvent('updateStreamUsage', {
       streamId: STREAM,
       storageKey: RUN,
       usage: usage(100, 20, 0.5),
     });
-    bus.emit('updateStreamUsage', {
+    writer.handleProgressEvent('updateStreamUsage', {
       streamId: STREAM,
       storageKey: RUN,
       usage: usage(50, 10, 0.25),
     });
 
     await writer.flush();
-    off();
 
     // A second store reads only from disk — the resume path.
     const reader = new StreamSnapshotStore();
@@ -176,7 +176,7 @@ describe('StreamSnapshotStore', () => {
     });
   });
 
-  it('seeds existing disk data before an unloaded bus mutation, so it is not erased', async () => {
+  it('seeds existing disk data before an unloaded progress mutation, so it is not erased', async () => {
     await installPlatform();
     const dir = streamDataDir(STREAM);
     await StorageFS.ensureDir(dir);
@@ -186,16 +186,14 @@ describe('StreamSnapshotStore', () => {
       JSON.stringify({ 'run-1': usage(100, 20, 0.5) }),
     );
 
-    // A fresh store (NOT load()ed) subscribes and gets a delta for a NEW run.
+    // A fresh store (NOT load()ed) handles a delta for a NEW run.
     const store = new StreamSnapshotStore();
-    const off = store.subscribe(bus);
-    bus.emit('updateStreamUsage', {
+    store.handleProgressEvent('updateStreamUsage', {
       streamId: STREAM,
       storageKey: 'run-2' as StorageKey,
       usage: usage(50, 10, 0.25),
     });
     await store.flush();
-    off();
 
     // run-1 (prior) survives — the unseeded write did not clobber it.
     const raw = await StorageFS.readJson(path.join(dir, 'usageStats.json'));

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1,12 +1,12 @@
 /**
- * Host-agnostic, bus-driven per-stream sidecar persistence.
+ * Host-agnostic per-stream sidecar persistence.
  *
  * One store, shared by the CLI TUI, VS Code extension, and Electron desktop
  * app, that is the SINGLE writer of `streamData/{id}/*` and the reader that
- * reassembles a {@link StreamSnapshot} for resume. It subscribes to the shared
- * {@link ProgressEventBus} and persists the same field-scoped files the
+ * reassembles a {@link StreamSnapshot} for resume. Runtime events are fed into
+ * {@link handleProgressEvent}, which persists the same field-scoped files the
  * extension already writes (so all three hosts produce identical on-disk data),
- * plus the one new `workPlan.json` giving todos/plan a durable home.
+ * plus the `workPlan.json` giving todos/plan a durable home.
  *
  * It consolidates the accumulation logic previously split across the extension's
  * `OutputFilesManager` / `UsageStatsManager` / `StreamMetaManager`, talking to
@@ -26,7 +26,10 @@ import {
   type TaskState,
 } from '@agent/core/state/TaskState';
 import { KVStore } from '@common/storage/KVStore';
-import type { ProgressEventBusLike } from '@eventBus/ProgressEventBus';
+import type {
+  ProgressEvent,
+  ProgressEventPayloads,
+} from '@eventBus/ProgressEventBus';
 import * as logger from '@logger/logUtils';
 import {
   CompileFailureSchema,
@@ -77,15 +80,17 @@ type UsageUpdateResult =
 
 /**
  * Round-keyed delta shape carried by the `addOutputFiles` /
- * `updateMissingOutputs` / `updateCompileFailures` bus events. Stated once here
- * so the store's mutators don't each restate the `{ [round: number]: T[] }`
- * literal. Mirrors the inline payload fields in `ProgressEventPayloads`.
+ * `updateMissingOutputs` / `updateCompileFailures` progress events. Stated
+ * once here so the store's mutators don't each restate the
+ * `{ [round: number]: T[] }` literal. Mirrors the inline payload fields in
+ * `ProgressEventPayloads`.
  */
 type RoundKeyedList<T> = { [round: number]: T[] };
 
 /**
  * Match criteria for {@link StreamSnapshotStore.findWorkflowStreamsMatching}.
- * Mirrors the `streamConfig` payload on the `clearMissingOutputs` bus event.
+ * Mirrors the `streamConfig` payload on the `clearMissingOutputs` progress
+ * event.
  */
 interface WorkflowStreamMatch {
   agent: string;
@@ -178,78 +183,67 @@ export class StreamSnapshotStore {
   }
 
   // ==========================================================================
-  // Bus subscription
+  // Runtime event ingestion
   // ==========================================================================
 
   /**
-   * Subscribe to the progress bus and persist durable per-stream state. Each
-   * mutation goes through the same public store mutators used by the extension
-   * and desktop, so all hosts share the same seed-before-write policy. Returns
-   * a disposer.
+   * Persist durable state carried by a runtime progress event. Each mutation
+   * goes through the public store mutators used by the extension and desktop,
+   * so all hosts share the same seed-before-write policy.
    */
-  subscribe(
-    bus: ProgressEventBusLike,
-    options?: { signal?: AbortSignal },
-  ): () => void {
-    const offs: Array<() => void> = [
-      bus.on(
-        'addOutputFiles',
-        ({ streamId, filesByRound }) =>
-          this.addOutputFiles(streamId, filesByRound),
-        options,
-      ),
-      bus.on(
-        'updateMissingOutputs',
-        ({ streamId, filesByRound }) =>
-          this.updateMissingOutputs(streamId, filesByRound),
-        options,
-      ),
-      bus.on(
-        'updateCompileFailures',
-        ({ streamId, filesByRound }) =>
-          this.updateCompileFailures(streamId, filesByRound),
-        options,
-      ),
-      bus.on(
-        'updateStreamUsage',
-        ({ streamId, storageKey, usage }) => {
-          void this.addUsage(streamId, storageKey, usage);
-        },
-        options,
-      ),
-      bus.on(
-        'updateTodos',
-        ({ streamId, todos }) => this.setTodos(streamId, todos),
-        options,
-      ),
-      bus.on(
-        'updatePlan',
-        ({ streamId, plan }) => this.setPlan(streamId, plan),
-        options,
-      ),
-      bus.on(
-        'setTaskState',
-        ({ streamId, executionId, taskState }) =>
-          this.setTaskState(streamId, taskState, executionId),
-        options,
-      ),
-      bus.on(
-        'updateStreamDescription',
-        ({ streamId, description }) =>
-          this.setDescription(streamId, description),
-        options,
-      ),
-      bus.on(
-        'setParentStream',
-        ({ childStreamId, parentStreamId }) =>
-          this.setParentStream(childStreamId, parentStreamId),
-        options,
-      ),
-    ];
-
-    return () => {
-      for (const off of offs) off();
-    };
+  handleProgressEvent<K extends ProgressEvent>(
+    event: K,
+    payload: ProgressEventPayloads[K],
+  ): void {
+    switch (event) {
+      case 'addOutputFiles': {
+        const p = payload as ProgressEventPayloads['addOutputFiles'];
+        this.addOutputFiles(p.streamId, p.filesByRound);
+        return;
+      }
+      case 'updateMissingOutputs': {
+        const p = payload as ProgressEventPayloads['updateMissingOutputs'];
+        this.updateMissingOutputs(p.streamId, p.filesByRound);
+        return;
+      }
+      case 'updateCompileFailures': {
+        const p = payload as ProgressEventPayloads['updateCompileFailures'];
+        this.updateCompileFailures(p.streamId, p.filesByRound);
+        return;
+      }
+      case 'updateStreamUsage': {
+        const p = payload as ProgressEventPayloads['updateStreamUsage'];
+        void this.addUsage(p.streamId, p.storageKey, p.usage);
+        return;
+      }
+      case 'updateTodos': {
+        const p = payload as ProgressEventPayloads['updateTodos'];
+        this.setTodos(p.streamId, p.todos);
+        return;
+      }
+      case 'updatePlan': {
+        const p = payload as ProgressEventPayloads['updatePlan'];
+        this.setPlan(p.streamId, p.plan);
+        return;
+      }
+      case 'setTaskState': {
+        const p = payload as ProgressEventPayloads['setTaskState'];
+        this.setTaskState(p.streamId, p.taskState, p.executionId);
+        return;
+      }
+      case 'updateStreamDescription': {
+        const p = payload as ProgressEventPayloads['updateStreamDescription'];
+        this.setDescription(p.streamId, p.description);
+        return;
+      }
+      case 'setParentStream': {
+        const p = payload as ProgressEventPayloads['setParentStream'];
+        this.setParentStream(p.childStreamId, p.parentStreamId);
+        return;
+      }
+      default:
+        return;
+    }
   }
 
   /**
@@ -846,11 +840,11 @@ export class StreamSnapshotStore {
 
   /**
    * Reassemble the durable display snapshot for a stream. Once a stream is
-   * seeded (via {@link load} or a bus event) its in-memory accumulators are the
-   * single source of truth — they already hold the disk state plus any newer
-   * deltas — so we assemble from memory and skip a redundant disk re-read (the
-   * CLI resume path calls `load` then `read` back-to-back). Only an unseeded
-   * stream (a display-only read that was never resumed) hits disk.
+   * seeded (via {@link load} or a progress event) its in-memory accumulators
+   * are the single source of truth — they already hold the disk state plus any
+   * newer deltas — so we assemble from memory and skip a redundant disk re-read.
+   * The CLI resume path calls `load` then `read` back-to-back. Only an unseeded
+   * stream, such as a display-only read that was never resumed, hits disk.
    */
   async read(streamId: StreamTabId): Promise<StreamSnapshot> {
     const seedChain = this.seedChains.get(streamId);


### PR DESCRIPTION
## Summary

Closes #6889 by making per-stream sidecar persistence consume runtime progress events directly instead of depending on the global progress bus.

The behavioral fix is for headless `texra run` / `texra agents run`: those runs now construct a `StreamSnapshotStore`, feed runtime progress events into it, and flush it before closing the CLI runtime host. A stream created headlessly can therefore be reopened later with its todos, plan, usage, output files, missing outputs, and compile-failure sidecars intact.

## Design

`StreamSnapshotStore.subscribe(bus)` is removed. The store now exposes `handleProgressEvent(event, payload)`, which is the persistence boundary used by both CLI paths:

- the interactive TUI wrapper updates local CLI state and then calls `snapshotStore.handleProgressEvent(...)`;
- the headless CLI runtime wraps its runtime host with the same persistence call;
- the global bus mirror in the TUI is gone.

Desktop keeps its process-bus subscriptions for `goalStateChanged`, `requestEnsureProgressView`, and `requestShowError`. Those are desktop-wide UI events, not stream sidecar persistence; they can occur without an active runtime host and must still fan out to all desktop windows. A regression test now covers that distinction.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/transcript/StreamSnapshotStore.vitest.ts src/test-kernel/cli/RunExecution.vitest.mts src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts`
- `corepack pnpm exec tsc --noEmit -p tsconfig.json --pretty false`
- `corepack pnpm exec eslint packages/desktop/src/main/desktopProgressEventBridge.ts src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts`
- `corepack pnpm exec eslint packages/cli/src/chat/chatSessionController.ts packages/cli/src/chat/tui/runChatTui.tsx packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts packages/cli/src/runtime/runExecution.ts packages/desktop/src/main/desktopProgressEventBridge.ts src/transcript/StreamSnapshotStore.ts src/test-kernel/cli/RunExecution.vitest.mts src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts src/test-kernel/transcript/StreamSnapshotStore.vitest.ts`
- `git diff --check`
- `rg -n "\.subscribe\(bus\)|StreamSnapshotStore.*subscribe|subscribe\(\s*bus|bus-driven|bus mutation" src packages src/test-kernel -S` returns no matches

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persistence and teardown order for all headless CLI executions and the TUI snapshot path; incorrect wiring could drop or corrupt resume sidecars, though new integration tests cover the main paths.
> 
> **Overview**
> **Headless `texra run` / `agents run`** now create a `StreamSnapshotStore`, persist progress events from the wrapped runtime host, and **`flush()` before closing the host**, so todos, plan, usage, and related `streamData/{id}/*` sidecars survive for later resume.
> 
> **`StreamSnapshotStore.subscribe(bus)` is removed** in favor of **`handleProgressEvent(event, payload)`** as the persistence boundary. The interactive TUI passes the store into `wrapRuntimeHost`, which updates CLI state and calls the store directly; the separate **`snapshotStore.subscribe(bus)` in `runChatTui` is dropped**.
> 
> Desktop **keeps** process-bus subscriptions for `goalStateChanged`, `requestEnsureProgressView`, and `requestShowError` (UI fan-out without an active runtime host), with an added regression test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4398cb1c087284bee309fbc6a5a1cbec492229c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->