### PR TITLE
fix(cli): route agent proposals through shared controller

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -18,6 +18,7 @@ import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
 import { setCliApiMode } from '@cli/runtime/apiAccessMode';
 import {
   approvalPromptAllowed,
+  handleCliAgentProposalDecision,
   humanInputDenialFeedback,
   immediateDecision,
   immediateDecisionForApproval,
@@ -409,11 +410,7 @@ function dispatchProposal(
   payload: ProgressEventPayloads['showAgentProposal'],
   decision: ApprovalDecision,
 ): void {
-  const feedback = feedbackOnReject(decision);
-  runCoordinatorBridge.resolveProposal(payload.proposalId, {
-    action: decision.accepted ? 'approve' : 'reject',
-    ...(feedback ? { feedback } : {}),
-  });
+  void handleCliAgentProposalDecision(payload.proposalId, decision);
 }
 
 function dispatchRetry(

--- a/packages/cli/src/runtime/approval/agentProposalController.ts
+++ b/packages/cli/src/runtime/approval/agentProposalController.ts
@@ -1,0 +1,29 @@
+import { ProgressAgentProposalController } from '@controllers/progressView/ProgressAgentProposalController';
+import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
+
+import type { ApprovalDecision } from './approvalPolicy';
+
+const cliAgentProposalController = new ProgressAgentProposalController({
+  // The CLI currently exposes approve/reject only. Keeping the setup hooks
+  // explicit lets future setup support live behind the same controller.
+  getPendingProposal: () => undefined,
+  restoreTaskState: async () => false,
+  resolveProposal: (proposalId, result) => {
+    runCoordinatorBridge.resolveProposal(proposalId, result);
+  },
+});
+
+export function handleCliAgentProposalDecision(
+  proposalId: string,
+  decision: ApprovalDecision,
+): Promise<boolean> {
+  return cliAgentProposalController.handleAction(
+    decision.accepted
+      ? { proposalId, action: 'approve' }
+      : {
+          proposalId,
+          action: 'reject',
+          feedback: decision.userMessage,
+        },
+  );
+}

--- a/packages/cli/src/runtime/approval/eventDispatch.ts
+++ b/packages/cli/src/runtime/approval/eventDispatch.ts
@@ -8,6 +8,7 @@ import { writeTextStderr } from '../logSinks';
 
 import { type ApprovalDecision } from './approvalPolicy';
 import { formatAgentProposalApprovalSummary } from './approvalSummaries';
+import { handleCliAgentProposalDecision } from './agentProposalController';
 
 export function summarizeApprovalEvent<K extends CliDecisionApprovalEvent>(
   event: K,
@@ -65,10 +66,7 @@ export function dispatchApprovalDecision<K extends CliDecisionApprovalEvent>(
     }
     case 'showAgentProposal': {
       const data = payload as ProgressEventPayloads['showAgentProposal'];
-      runCoordinatorBridge.resolveProposal(data.proposalId, {
-        action,
-        ...(decision.userMessage ? { feedback: decision.userMessage } : {}),
-      });
+      void handleCliAgentProposalDecision(data.proposalId, decision);
       return;
     }
     case 'showRetryRequest': {

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -48,6 +48,7 @@ export {
   isCliChatGptSubscriptionRetry,
   markApprovalDenied,
 } from './approval/approvalPolicy';
+export { handleCliAgentProposalDecision } from './approval/agentProposalController';
 export {
   formatAgentProposalApprovalSummary,
   formatRetryRequestMessage,

--- a/src/controllers/progressView/ProgressAgentProposalController.ts
+++ b/src/controllers/progressView/ProgressAgentProposalController.ts
@@ -36,14 +36,14 @@ export class ProgressAgentProposalController {
       case 'approve':
         this.deps.resolveProposal(input.proposalId, {
           action: 'approve',
-          model: input.model,
-          agent: input.agent,
+          ...(input.model ? { model: input.model } : {}),
+          ...(input.agent ? { agent: input.agent } : {}),
         });
         return true;
       case 'reject':
         this.deps.resolveProposal(input.proposalId, {
           action: 'reject',
-          feedback: input.feedback,
+          ...(input.feedback ? { feedback: input.feedback } : {}),
         });
         return true;
       default:

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.mts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.mts
@@ -1,9 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const handleExternalInquiryActionMock = vi.hoisted(() => vi.fn());
+const runCoordinatorMocks = vi.hoisted(() => ({
+  cancelRetry: vi.fn(),
+  resolvePlanApproval: vi.fn(),
+  resolveProposal: vi.fn(),
+  triggerRetry: vi.fn(),
+}));
 
 vi.mock('@tools/inquiry/ExternalInquiryTool', () => ({
   handleExternalInquiryAction: handleExternalInquiryActionMock,
+}));
+
+vi.mock('@agent/runtime/runCoordinators', () => ({
+  runCoordinatorBridge: runCoordinatorMocks,
 }));
 
 import {
@@ -71,6 +81,10 @@ beforeEach(async () => {
 afterEach(() => {
   setActiveCliToolEditApprovalHandler(undefined);
   handleExternalInquiryActionMock.mockClear();
+  runCoordinatorMocks.cancelRetry.mockClear();
+  runCoordinatorMocks.resolvePlanApproval.mockClear();
+  runCoordinatorMocks.resolveProposal.mockClear();
+  runCoordinatorMocks.triggerRetry.mockClear();
 });
 
 describe('immediateDecisionForApproval', () => {
@@ -189,6 +203,27 @@ describe('approval prompt hooks', () => {
 
     expect(handled).toBe(true);
     expect(events).toEqual([]);
+    expect(runCoordinatorMocks.resolveProposal).toHaveBeenCalledWith(
+      'proposal-1',
+      { action: 'approve' },
+    );
+  });
+
+  it('routes automatic proposal rejection through the shared proposal controller', () => {
+    const handled = handleCliApprovalEvent(
+      'showAgentProposal',
+      proposal,
+      context({ approvalPolicy: 'never' }),
+    );
+
+    expect(handled).toBe(true);
+    expect(runCoordinatorMocks.resolveProposal).toHaveBeenCalledWith(
+      'proposal-1',
+      {
+        action: 'reject',
+        feedback: 'Denied by CLI approval policy.',
+      },
+    );
   });
 
   it('does not prompt for external inquiry in non-TUI CLI runs', async () => {

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -55,6 +55,7 @@ vi.mock('@cli/runtime/approvalAdapter', () => {
       mode: string;
     }) => context.approvalPolicy === 'ask' && context.mode === 'interactive',
     humanInputDenialFeedback: () => 'Denied by CLI approval policy.',
+    handleCliAgentProposalDecision: vi.fn(async () => true),
     immediateDecision: (context: { approvalPolicy: string }) => {
       if (context.approvalPolicy === 'yolo') return { accepted: true };
       if (context.approvalPolicy === 'ask') return undefined;

--- a/src/test-kernel/controllers/ProgressAgentProposalController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressAgentProposalController.vitest.ts
@@ -174,4 +174,31 @@ describe('ProgressAgentProposalController', () => {
       },
     ]);
   });
+
+  it('omits absent optional fields when approving or rejecting', async () => {
+    const resolved: { result: Record<string, unknown> }[] = [];
+    const controller = new ProgressAgentProposalController({
+      getPendingProposal: () => createWorkflowProposal(),
+      restoreTaskState: async () => {
+        throw new Error('restore should not run');
+      },
+      resolveProposal: (_proposalId, result) => {
+        resolved.push({ result });
+      },
+    });
+
+    await controller.handleAction({
+      proposalId: 'proposal-approve',
+      action: 'approve',
+    });
+    await controller.handleAction({
+      proposalId: 'proposal-reject',
+      action: 'reject',
+    });
+
+    assert.deepEqual(resolved, [
+      { result: { action: 'approve' } },
+      { result: { action: 'reject' } },
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary

Routes the CLI agent-proposal approve/reject paths through the shared `ProgressAgentProposalController` instead of resolving proposals directly from the TUI and headless dispatchers.

- Adds a small CLI proposal adapter that owns the CLI-specific controller dependencies.
- Reuses that adapter from both `subscribeApprovals` and headless `eventDispatch`.
- Keeps CLI setup-action support explicit as future work: the CLI still exposes approve/reject only, but the setup hooks now live behind the same controller boundary.

Closes #6888.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ApprovalAdapter.vitest.mts src/test-kernel/cli/TuiApprovalRetry.vitest.mts src/test-kernel/controllers/ProgressAgentProposalController.vitest.ts`
- `corepack pnpm exec eslint packages/cli/src/runtime/approval/agentProposalController.ts packages/cli/src/runtime/approval/eventDispatch.ts packages/cli/src/runtime/approvalAdapter.ts packages/cli/src/chat/tui/state/subscribeApprovals.ts src/test-kernel/cli/ApprovalAdapter.vitest.mts src/test-kernel/cli/TuiApprovalRetry.vitest.mts`
- `corepack pnpm exec tsc --noEmit -p tsconfig.json --pretty false`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactors approval wiring behind an existing shared controller with behavior-preserving tests; no new auth or data paths.
> 
> **Overview**
> CLI **agent proposal** approve/reject no longer calls `runCoordinatorBridge.resolveProposal` directly from the TUI (`subscribeApprovals`) or headless approval dispatch (`eventDispatch`). Both paths now use **`handleCliAgentProposalDecision`**, which wraps the same **`ProgressAgentProposalController`** used by the progress view, with CLI-only deps (setup hooks stubbed for future work).
> 
> **`ProgressAgentProposalController`** now omits optional `model`, `agent`, and `feedback` on resolve when they are absent, so coordinator payloads stay minimal.
> 
> Tests assert auto-approve/reject and policy-driven proposal handling still reach `resolveProposal` with the expected shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98c070bed6e55e680aa4002aaf31e28e69087222. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->