### PR TITLE
fix(desktop): repair orphaned streams on startup

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -21,6 +21,7 @@ import {
 } from '@agent/core/state/executionRequests';
 import { TaskStateSchema, type TaskState } from '@agent/core/state/TaskState';
 import { detachSubagentsOnStop } from '@agent/runtime/detachSubagentsOnStop';
+import { detectWaitingStreams } from '@agent/storage/detectWaitingStreams';
 import {
   isResumeInFlight as isStreamResumeInFlight,
   resolveAndResumeStream,
@@ -29,9 +30,16 @@ import type { ModelHandlerCompatibilityKey } from '@agent/runtime/modelHandlerCo
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { resumeToolUseSnapshot } from '@agent/runtime/resumeToolUseSnapshot';
 import { selectAutoOpenFinalOutput } from '@agent/runtime/selectAutoOpenFinalOutput';
-import { SessionHandle } from '@agent/runtime/SessionHandle';
+import {
+  getAllActiveExecutionIds,
+  SessionHandle,
+} from '@agent/runtime/SessionHandle';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { setProgressViewBridge } from '@agent/runtime/ProgressViewBridge';
-import { sendFollowUp } from '@agent/followUp/ToolUseFollowUp';
+import {
+  sendFollowUp,
+  wakeQueuedFollowUpStream,
+} from '@agent/followUp/ToolUseFollowUp';
 import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
 import { toErrorMessage } from '@common/errors';
 import {
@@ -53,6 +61,7 @@ import {
   type ProgressViewOutboundMessage,
   type ExecutionId,
   type StreamTabId,
+  streamStatusesWithTrait,
 } from '@shared/schemas';
 import type { ProgressViewInboundHandlerRegistry } from '@shared/schemas/progressView';
 import { ProgressBackend } from '@shared/progressView/backend/ProgressBackend';
@@ -102,6 +111,7 @@ const DESKTOP_UNAVAILABLE_TOOLS: readonly DesktopUnavailableTool[] = [
   'inline_comment',
   DIAGNOSTICS_ADD_RUNTIME_CAPABILITY,
 ];
+const RESTART_REPAIR_STATUSES = streamStatusesWithTrait('inFlight');
 
 export interface DesktopAgentExecutionOptions {
   postToRenderer(message: unknown): boolean | void;
@@ -210,6 +220,7 @@ export class DesktopProgressBridge {
    * progress-event → rail-update translation.  See #6329.
    */
   private readonly progressEvents: DesktopProgressEventBridge;
+  private readonly restartRepair: Promise<void>;
 
   readonly runtimeHost: AgentRuntimeHost;
   readonly progressViewInboundHandlers: ProgressViewInboundHandlerRegistry;
@@ -299,6 +310,7 @@ export class DesktopProgressBridge {
         void this.options.showErrorMessage?.(message);
       },
     });
+    this.restartRepair = this.repairOrphanedStreamsAfterRestart();
     // Onboarding funnel (PRD: agent-native onboarding): a completed run ends
     // State 1. `AgentRunLifecycle` persists `firstRunDone` BEFORE it emits the
     // terminal `result` event, so by the time this listener fires the funnel
@@ -605,6 +617,185 @@ export class DesktopProgressBridge {
     );
   }
 
+  private getRestartRepairExecutionIdMap(): ReadonlyMap<
+    StreamTabId,
+    ExecutionId
+  > {
+    const executionIds = new Map(this.state.snapshots.getExecutionIdMap());
+    for (const [streamId, snapshot] of this.progressEvents.restoredStreams) {
+      if (snapshot.executionId && !executionIds.has(streamId)) {
+        executionIds.set(streamId, snapshot.executionId);
+      }
+    }
+    return executionIds;
+  }
+
+  private resetRestartRepairStreamStatuses(
+    repairStreams: ReadonlySet<StreamTabId>,
+    waitingStreams: ReadonlySet<StreamTabId>,
+  ): StreamTabId[] {
+    const affectedStreams: StreamTabId[] = [];
+    for (const streamId of repairStreams) {
+      const currentStatus = StreamStatusService.get(streamId);
+      if (!currentStatus || !RESTART_REPAIR_STATUSES.has(currentStatus)) {
+        continue;
+      }
+      if (waitingStreams.has(streamId)) {
+        StreamStatusService.set(streamId, STREAM_STATUS.WAITING, {
+          emit: false,
+        });
+        this.logger.debug(
+          `Stream ${streamId} restored to WAITING after reload`,
+        );
+        continue;
+      }
+      StreamStatusService.set(streamId, STREAM_STATUS.ERROR, { emit: false });
+      affectedStreams.push(streamId);
+      this.logger.debug(
+        `Stream ${streamId} set to ERROR during desktop restart recovery`,
+      );
+    }
+    return affectedStreams;
+  }
+
+  private getRestartRepairStreamSet(
+    executionIdMap: ReadonlyMap<StreamTabId, ExecutionId>,
+    allExecutionIds: ReadonlyMap<StreamTabId, ExecutionId>,
+    activeExecutionIds: ReadonlySet<string>,
+  ): Set<StreamTabId> {
+    const repairStreams = new Set(executionIdMap.keys());
+    for (const [streamId, snapshot] of this.progressEvents.restoredStreams) {
+      const executionId = snapshot.executionId ?? allExecutionIds.get(streamId);
+      if (executionId && activeExecutionIds.has(executionId)) {
+        continue;
+      }
+      const currentStatus = StreamStatusService.get(streamId);
+      if (
+        RESTART_REPAIR_STATUSES.has(snapshot.lastKnownStatus) ||
+        RESTART_REPAIR_STATUSES.has(currentStatus)
+      ) {
+        repairStreams.add(streamId);
+      }
+    }
+    return repairStreams;
+  }
+
+  private async closeRunningTaskGroupsForStreams(
+    streamIds: readonly StreamTabId[],
+  ): Promise<StreamTabId[]> {
+    if (streamIds.length === 0) return [];
+    const closedGroups = await this.state.streamLogs.endRunningGroupsForStreams(
+      streamIds,
+      Date.now(),
+    );
+    if (closedGroups.length > 0) {
+      await this.state.streamLogs.save();
+    }
+    return closedGroups;
+  }
+
+  private async repairOrphanedStreamsAfterRestart(): Promise<void> {
+    try {
+      await this.state.streamLogs.load();
+      this.progressEvents.hydrateRestoredStreams();
+      const activeExecutionIds = new Set(getAllActiveExecutionIds());
+      const allExecutionIds = this.getRestartRepairExecutionIdMap();
+      this.progressEvents.forgetActiveRestoredStreams(
+        activeExecutionIds,
+        allExecutionIds,
+      );
+      const executionIdMap = new Map(
+        [...allExecutionIds].filter(
+          ([, executionId]) => !activeExecutionIds.has(executionId),
+        ),
+      );
+      const waitingStreams = await detectWaitingStreams(executionIdMap);
+      const repairActiveExecutionIds = new Set(getAllActiveExecutionIds());
+      const repairAllExecutionIds = this.getRestartRepairExecutionIdMap();
+      this.progressEvents.forgetActiveRestoredStreams(
+        repairActiveExecutionIds,
+        repairAllExecutionIds,
+      );
+      for (const [streamId, executionId] of repairAllExecutionIds) {
+        if (repairActiveExecutionIds.has(executionId)) {
+          waitingStreams.delete(streamId);
+        }
+      }
+      const repairExecutionIdMap = new Map(
+        [...repairAllExecutionIds].filter(
+          ([, executionId]) => !repairActiveExecutionIds.has(executionId),
+        ),
+      );
+      const repairStreams = this.getRestartRepairStreamSet(
+        repairExecutionIdMap,
+        repairAllExecutionIds,
+        repairActiveExecutionIds,
+      );
+      const affectedStreams = this.resetRestartRepairStreamStatuses(
+        repairStreams,
+        waitingStreams,
+      );
+      const closeGroupStreams = new Set([
+        ...affectedStreams,
+        ...waitingStreams,
+      ]);
+      const closedGroups = await this.closeRunningTaskGroupsForStreams([
+        ...closeGroupStreams,
+      ]);
+      if (
+        waitingStreams.size > 0 ||
+        affectedStreams.length > 0 ||
+        closedGroups.length > 0 ||
+        this.progressEvents.restoredStreams.size > 0
+      ) {
+        this.syncFullView();
+      }
+    } catch (error) {
+      const waitingStreams = new Set(
+        [...this.progressEvents.restoredStreams.keys()].filter(
+          (streamId) =>
+            StreamStatusService.get(streamId) === STREAM_STATUS.WAITING,
+        ),
+      );
+      this.progressEvents.hydrateRestoredStreams();
+      const activeExecutionIds = new Set(getAllActiveExecutionIds());
+      const allExecutionIds = this.getRestartRepairExecutionIdMap();
+      this.progressEvents.forgetActiveRestoredStreams(
+        activeExecutionIds,
+        allExecutionIds,
+      );
+      const affectedStreams = this.resetRestartRepairStreamStatuses(
+        new Set(this.progressEvents.restoredStreams.keys()),
+        waitingStreams,
+      );
+      const closeGroupStreams = new Set([
+        ...affectedStreams,
+        ...waitingStreams,
+      ]);
+      if (closeGroupStreams.size > 0) {
+        try {
+          await this.closeRunningTaskGroupsForStreams([...closeGroupStreams]);
+        } catch (groupError) {
+          this.logger.warn(
+            'Failed to close desktop stream groups after repair failure',
+            {
+              data:
+                groupError instanceof Error
+                  ? groupError
+                  : { error: groupError },
+            },
+          );
+        }
+      }
+      if (affectedStreams.length > 0 || waitingStreams.size > 0) {
+        this.syncFullView();
+      }
+      this.logger.warn('Failed to repair desktop streams after restart', {
+        data: error instanceof Error ? error : { error },
+      });
+    }
+  }
+
   private routeToProgress(): void {
     this.postToRenderer({
       command: DESKTOP_SHELL_COMMANDS.SET_ROUTE,
@@ -747,6 +938,7 @@ export class DesktopProgressBridge {
   }
 
   async tryResumeStream(streamId: StreamTabId): Promise<boolean> {
+    await this.restartRepair;
     // Desktop-only pre-check: a stream deleted in this window must never be
     // resurrected, even if its persisted meta.json survives on disk. The shared
     // orchestrator owns the active/resuming + in-flight guards.
@@ -943,6 +1135,7 @@ export class DesktopProgressBridge {
     text: string,
     mediaFiles?: readonly string[],
   ): Promise<void> {
+    await this.restartRepair;
     // Resolve the follow-up target against THIS window's session: the run's
     // handle is tracked in `this.session`, but this IPC path runs outside the
     // run ALS, so the module default (currentSession ⇒ defaultSession) would
@@ -956,6 +1149,20 @@ export class DesktopProgressBridge {
     );
     if (result.status === 'sent' || result.status === 'queued') {
       this.runtimeHost.emit('updateQueuedFollowUps', { streamId });
+      const wake = await wakeQueuedFollowUpStream(streamId, result, {
+        tryResumeStream: (id) => this.tryResumeStream(id),
+        isResumeInFlight: (id) => this.isResumeInFlight(id),
+      });
+      if (wake.kind === 'dropped') {
+        this.runtimeHost.emit('updateQueuedFollowUps', { streamId });
+        await this.options.showInfoMessage?.(
+          'Message dropped because no session was available to receive it. Start a new agent task to continue.',
+        );
+      } else if (wake.kind === 'queued_resume_failed') {
+        await this.options.showInfoMessage?.(
+          'Message queued. Auto-resume failed; start a new agent task to continue.',
+        );
+      }
       return;
     }
 
@@ -972,6 +1179,7 @@ export class DesktopProgressBridge {
     request: ValidatedExecutionRequest,
     options: DesktopRunExecutionOptions = {},
   ): Promise<void> {
+    await this.restartRepair;
     const { runAgent } = await import('@agent/runtime/runAgent');
     await runAgent(request, {
       runtimeHost: this.runtimeHost,

--- a/packages/desktop/src/main/desktopProgressEventBridge.ts
+++ b/packages/desktop/src/main/desktopProgressEventBridge.ts
@@ -61,6 +61,18 @@ export interface DesktopProgressEventBridge {
   /** All currently-hydrated ghost streams (keyed by streamId). */
   readonly restoredStreams: ReadonlyMap<StreamTabId, RestoredStreamSnapshot>;
 
+  /**
+   * Reapply restored stream placeholders, hints, and statuses from the snapshot
+   * store. This is idempotent and may run again after durable state is loaded.
+   */
+  hydrateRestoredStreams(): void;
+
+  /** Remove restored ghost ownership for executions already active in-process. */
+  forgetActiveRestoredStreams(
+    activeExecutionIds: ReadonlySet<string>,
+    streamExecutionIds?: ReadonlyMap<StreamTabId, string>,
+  ): void;
+
   /** True when a ghost stream with the given id exists. */
   hasRestoredStream(streamId: StreamTabId): boolean;
 
@@ -107,6 +119,8 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
   private readonly restoredDisplaySent = new Set<StreamTabId>();
   /** Ghost streams with an async persisted-display restore already pending. */
   private readonly restoredDisplayInFlight = new Set<StreamTabId>();
+  /** Streams that became live in this bridge and must not be restored as ghosts. */
+  private readonly liveStreams = new Set<StreamTabId>();
 
   private readonly unsubscribe: () => void;
 
@@ -119,23 +133,7 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
     // stopped/orphaned entries; "Resume run" funnels back through the
     // existing storage-backed resume path when an executionId is
     // available, otherwise falls back to "start fresh".
-    const hydrated = opts.streamSnapshotStore?.hydrated ?? [];
-    for (const snapshot of hydrated) {
-      this.restoredStreams.set(snapshot.streamId, snapshot);
-      opts.state.streamLogs.ensureStream(snapshot.streamId);
-      opts.state.updateStreamHints(snapshot.streamId, {
-        agent: snapshot.agent,
-        agentCategory: snapshot.agentCategory,
-        inputFile: snapshot.inputFile,
-        creationTimestamp: snapshot.creationTimestamp,
-        executionId: snapshot.executionId,
-        parentStreamId: snapshot.parentStreamId,
-        description: snapshot.description,
-      });
-      StreamStatusService.set(snapshot.streamId, snapshot.lastKnownStatus, {
-        emit: false,
-      });
-    }
+    this.hydrateRestoredStreams();
 
     // These events can be emitted on the process bus without an active desktop
     // runtime host. Keep them subscribed here so all desktop windows see goal
@@ -165,8 +163,46 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
 
   // ── Query ───────────────────────────────────────────────────────────────
 
+  hydrateRestoredStreams(): void {
+    const hydrated = this.opts.streamSnapshotStore?.hydrated ?? [];
+    this.restoredStreams.clear();
+    for (const snapshot of hydrated) {
+      if (this.liveStreams.has(snapshot.streamId)) continue;
+      this.restoredStreams.set(snapshot.streamId, snapshot);
+      this.opts.state.streamLogs.ensureStream(snapshot.streamId);
+      this.opts.state.updateStreamHints(snapshot.streamId, {
+        agent: snapshot.agent,
+        agentCategory: snapshot.agentCategory,
+        inputFile: snapshot.inputFile,
+        creationTimestamp: snapshot.creationTimestamp,
+        executionId: snapshot.executionId,
+        parentStreamId: snapshot.parentStreamId,
+        description: snapshot.description,
+      });
+      StreamStatusService.set(snapshot.streamId, snapshot.lastKnownStatus, {
+        emit: false,
+      });
+    }
+  }
+
   hasRestoredStream(streamId: StreamTabId): boolean {
     return this.restoredStreams.has(streamId);
+  }
+
+  forgetActiveRestoredStreams(
+    activeExecutionIds: ReadonlySet<string>,
+    streamExecutionIds?: ReadonlyMap<StreamTabId, string>,
+  ): void {
+    for (const [streamId, snapshot] of this.restoredStreams) {
+      const executionId =
+        snapshot.executionId ?? streamExecutionIds?.get(streamId);
+      if (!executionId || !activeExecutionIds.has(executionId)) {
+        continue;
+      }
+      this.restoredStreams.delete(streamId);
+      this.restoredDisplaySent.delete(streamId);
+      this.restoredDisplayInFlight.delete(streamId);
+    }
   }
 
   // ── Progress events ──────────────────────────────────────────────────────
@@ -194,6 +230,7 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
       }
       case 'setTaskState': {
         const data = payload as ProgressEventPayloads['setTaskState'];
+        this.liveStreams.add(data.streamId);
         this.opts.state.streamLogs.ensureStream(data.streamId);
         this.restoredStreams.delete(data.streamId);
         this.persistStreamSnapshot(data.streamId);
@@ -201,6 +238,7 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
       }
       case 'updateStreamStatus': {
         const data = payload as ProgressEventPayloads['updateStreamStatus'];
+        this.liveStreams.add(data.streamId);
         this.restoredStreams.delete(data.streamId);
         this.persistStreamSnapshot(data.streamId);
         return;
@@ -307,6 +345,7 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
   // ── Stream lifecycle ──────────────────────────────────────────────────────
 
   onStreamDeleted(streamId: StreamTabId): void {
+    this.liveStreams.delete(streamId);
     this.removePersistedStream(streamId);
     this.restoredDisplaySent.delete(streamId);
     this.restoredDisplayInFlight.delete(streamId);
@@ -316,6 +355,7 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
     this.restoredStreams.clear();
     this.restoredDisplaySent.clear();
     this.restoredDisplayInFlight.clear();
+    this.liveStreams.clear();
     if (this.opts.streamSnapshotStore) {
       try {
         await this.opts.streamSnapshotStore.replaceAll([]);
@@ -334,6 +374,7 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
     this.restoredStreams.clear();
     this.restoredDisplaySent.clear();
     this.restoredDisplayInFlight.clear();
+    this.liveStreams.clear();
   }
 
   // ── Private helpers ──────────────────────────────────────────────────────

--- a/packages/desktop/src/main/desktopStreamSnapshot.ts
+++ b/packages/desktop/src/main/desktopStreamSnapshot.ts
@@ -26,19 +26,20 @@ import { JsonStore } from '@platform/defaults/jsonStore';
 import {
   RestoredStreamsFileSchema,
   STREAM_STATUS,
+  streamStatusesWithTrait,
   type RestoredStreamSnapshot,
   type RestoredStreamsFile,
   type StreamTabId,
 } from '@shared/schemas';
 
 const STREAMS_KEY = 'restoredStreams';
+const RESTART_REPAIR_STATUSES = streamStatusesWithTrait('inFlight');
 
 export interface DesktopStreamSnapshotStore {
   /**
-   * All previously-persisted snapshots, with `lastKnownStatus`
-   * normalised to `stopped` because we cannot tell from cold start
-   * whether the agent actually finished — the renderer should treat
-   * them as inactive ghosts.
+   * All previously-persisted snapshots. Prior in-flight statuses are preserved
+   * only long enough for desktop startup repair to classify them as resumable
+   * (`waiting`) or dead (`error`); all other restored states are inert ghosts.
    */
   readonly hydrated: readonly RestoredStreamSnapshot[];
   /**
@@ -137,11 +138,12 @@ function parseHydrated(
     );
     return [];
   }
-  // Normalise status to "stopped" — we don't know if the agent
-  // actually finished, and we explicitly never want the rail to claim
-  // a run is still running just because it was running last time.
+  // Preserve in-flight states so startup repair can classify them. A finished
+  // or already-inert prior state remains an inactive ghost on the next launch.
   return parsed.data.streams.map((s) => ({
     ...s,
-    lastKnownStatus: STREAM_STATUS.STOPPED,
+    lastKnownStatus: RESTART_REPAIR_STATUSES.has(s.lastKnownStatus)
+      ? s.lastKnownStatus
+      : STREAM_STATUS.STOPPED,
   }));
 }

--- a/src/agent/followUp/ToolUseFollowUp.ts
+++ b/src/agent/followUp/ToolUseFollowUp.ts
@@ -43,6 +43,11 @@ export type FollowUpWakeResult =
   | { kind: 'queued_resume_failed' }
   | { kind: 'dropped' };
 
+export interface FollowUpResumePort {
+  tryResumeStream(streamId: StreamTabId): Promise<boolean>;
+  isResumeInFlight?(streamId: StreamTabId): boolean;
+}
+
 /** In-flight resume attempts per stream — see {@link wakeQueuedFollowUpStream}. */
 const wakeAttempts = new Map<StreamTabId, Promise<boolean>>();
 
@@ -60,6 +65,7 @@ const wakeAttempts = new Map<StreamTabId, Promise<boolean>>();
 export async function wakeQueuedFollowUpStream(
   streamId: StreamTabId,
   result: SendFollowUpResult,
+  resumePort?: FollowUpResumePort,
 ): Promise<FollowUpWakeResult> {
   if (
     result.status !== 'queued' ||
@@ -75,9 +81,9 @@ export async function wakeQueuedFollowUpStream(
   // outcome instead of re-poking the port and releasing the queue the
   // in-flight resume is about to drain.
   let attempt = wakeAttempts.get(streamId);
-  const resumePort = platform().agentResume;
+  const port = resumePort ?? platform().agentResume;
   if (!attempt) {
-    attempt = resumePort.tryResumeStream(streamId).finally(() => {
+    attempt = port.tryResumeStream(streamId).finally(() => {
       wakeAttempts.delete(streamId);
     });
     wakeAttempts.set(streamId, attempt);
@@ -86,7 +92,7 @@ export async function wakeQueuedFollowUpStream(
   if (resumed) {
     return { kind: 'resumed' };
   }
-  if (resumePort.isResumeInFlight?.(streamId) === true) {
+  if (port.isResumeInFlight?.(streamId) === true) {
     return { kind: 'resume_in_flight' };
   }
   if (StreamStatusService.isActiveOrResuming(streamId)) {

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -17,6 +17,7 @@ import { COMMON_COMMANDS } from '@shared/ipc/commonCommands';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc/progressViewCommands';
 import type { ProgressViewInboundHandlerRegistry } from '@shared/schemas/progressView';
 import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
+import { TaskStateSchema } from '@agent/core/state/TaskState';
 import { DIAGNOSTICS_ADD_RUNTIME_CAPABILITY } from '@tools/diagnosticsRuntimeCapabilities';
 
 // Local imports - desktop test paths
@@ -108,6 +109,8 @@ type CreateBridgeOptions = {
   runAgent?: RunExecutionRequest;
   streamSnapshotStore?: TestDesktopStreamSnapshotStore;
   configureProgressSnapshotStore?: (store: ProgressSnapshotStore) => void;
+  detectWaitingStreams?: ReturnType<typeof vi.fn>;
+  activeExecutionIds?: readonly string[] | (() => readonly string[]);
 };
 
 type TestDesktopStreamSnapshotStore = {
@@ -164,6 +167,23 @@ async function createBridge(
   }));
   vi.doMock('@agent/runtime/runAgent', () => ({
     runAgent: options.runAgent ?? vi.fn(),
+  }));
+  vi.doMock('@agent/runtime/SessionHandle', async () => {
+    const actual = await vi.importActual<
+      typeof import('@agent/runtime/SessionHandle')
+    >('@agent/runtime/SessionHandle');
+    return {
+      ...actual,
+      getAllActiveExecutionIds: vi.fn(() =>
+        typeof options.activeExecutionIds === 'function'
+          ? options.activeExecutionIds()
+          : (options.activeExecutionIds ?? []),
+      ),
+    };
+  });
+  vi.doMock('@agent/storage/detectWaitingStreams', () => ({
+    detectWaitingStreams:
+      options.detectWaitingStreams ?? vi.fn(async () => new Set()),
   }));
   vi.doMock('@common/storage/KVStore', () => ({
     KVStore: class {
@@ -427,6 +447,7 @@ describe('DesktopProgressBridge', () => {
     vi.doUnmock('@agent/runtime/SessionResumeRetrieval');
     vi.doUnmock('@agent/runtime/executeAgent');
     vi.doUnmock('@agent/runtime/runAgent');
+    vi.doUnmock('@agent/storage/detectWaitingStreams');
     vi.doUnmock('@common/storage/KVStore');
     vi.doUnmock('@controllers/mainView/MainViewExecutionController');
     vi.doUnmock('@logger');
@@ -570,6 +591,386 @@ describe('DesktopProgressBridge', () => {
     }
   });
 
+  it('repairs restored running streams after desktop startup', async () => {
+    const messages: unknown[] = [];
+    const detectWaitingStreams = vi.fn(
+      async (executionIds: ReadonlyMap<StreamTabId, string>) => {
+        expect([...executionIds.entries()].toSorted()).toEqual([
+          ['dead-stream', 'def456'],
+          ['waiting-stream', 'abc123'],
+        ]);
+        return new Set<StreamTabId>(['waiting-stream']);
+      },
+    );
+    const bridge = await createBridge(messages, {
+      detectWaitingStreams,
+      streamSnapshotStore: createStreamSnapshotStore([
+        restoredSnapshot({
+          streamId: 'waiting-stream',
+          executionId: 'abc123',
+          lastKnownStatus: STREAM_STATUS.RUNNING,
+        }),
+        restoredSnapshot({
+          streamId: 'dead-stream',
+          executionId: 'def456',
+          lastKnownStatus: STREAM_STATUS.RUNNING,
+        }),
+      ]),
+    });
+    const { StreamStatusService } =
+      await import('@agent/runtime/StreamStatusService');
+
+    try {
+      await vi.waitFor(() => {
+        expect(detectWaitingStreams).toHaveBeenCalledOnce();
+        expect(StreamStatusService.get('waiting-stream')).toBe(
+          STREAM_STATUS.WAITING,
+        );
+        expect(StreamStatusService.get('dead-stream')).toBe(
+          STREAM_STATUS.ERROR,
+        );
+      });
+
+      const streamSync = progressMessages(
+        messages,
+        PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+      ).at(-1);
+      expect(streamSync?.streamStates?.['waiting-stream']).toMatchObject({
+        status: STREAM_STATUS.WAITING,
+      });
+      expect(streamSync?.streamStates?.['dead-stream']).toMatchObject({
+        status: STREAM_STATUS.ERROR,
+      });
+    } finally {
+      StreamStatusService.clear('waiting-stream', { emit: false });
+      StreamStatusService.clear('dead-stream', { emit: false });
+      bridge.dispose();
+    }
+  });
+
+  it('waits for desktop startup repair before starting a run', async () => {
+    let finishRepair!: (value: Set<StreamTabId>) => void;
+    const repairGate = new Promise<Set<StreamTabId>>((resolve) => {
+      finishRepair = resolve;
+    });
+    const detectWaitingStreams = vi.fn(async () => repairGate);
+    const runAgent = vi.fn(async () => {});
+    const bridge = await createBridge([], {
+      detectWaitingStreams,
+      runAgent,
+    });
+    const taskState = workflowTaskState();
+
+    try {
+      bridge.handleProgressEvent('setTaskState', {
+        streamId: 'stream-new',
+        executionId: 'abc123',
+        taskState,
+      });
+
+      const runNew =
+        bridge.progressViewInboundHandlers[PROGRESS_VIEW_COMMANDS.RUN_NEW];
+      expect(runNew).toBeTypeOf('function');
+      const runPromise = runNew?.({
+        command: PROGRESS_VIEW_COMMANDS.RUN_NEW,
+        stream: 'stream-new',
+      });
+
+      await vi.waitFor(() => expect(detectWaitingStreams).toHaveBeenCalled());
+      await settleProgressEvents();
+      expect(runAgent).not.toHaveBeenCalled();
+
+      finishRepair(new Set());
+      await runPromise;
+
+      expect(runAgent).toHaveBeenCalledOnce();
+    } finally {
+      finishRepair(new Set());
+      bridge.dispose();
+    }
+  });
+
+  it('marks restored running streams as errored when startup repair fails', async () => {
+    const detectWaitingStreams = vi.fn(async () => {
+      throw new Error('flow store unavailable');
+    });
+    const bridge = await createBridge([], {
+      detectWaitingStreams,
+      streamSnapshotStore: createStreamSnapshotStore([
+        restoredSnapshot({
+          streamId: 'broken-stream',
+          executionId: 'abc123',
+          lastKnownStatus: STREAM_STATUS.RUNNING,
+        }),
+      ]),
+    });
+    const { StreamStatusService } =
+      await import('@agent/runtime/StreamStatusService');
+
+    try {
+      await vi.waitFor(() => {
+        expect(detectWaitingStreams).toHaveBeenCalledOnce();
+        expect(StreamStatusService.get('broken-stream')).toBe(
+          STREAM_STATUS.ERROR,
+        );
+      });
+    } finally {
+      StreamStatusService.clear('broken-stream', { emit: false });
+      bridge.dispose();
+    }
+  });
+
+  it('does not repair restored streams whose execution is active', async () => {
+    const detectWaitingStreams = vi.fn(
+      async (executionIds: ReadonlyMap<StreamTabId, string>) => {
+        expect([...executionIds.entries()]).toEqual([
+          ['dead-stream', 'def456'],
+        ]);
+        return new Set<StreamTabId>();
+      },
+    );
+    const bridge = await createBridge([], {
+      activeExecutionIds: ['abc123'],
+      detectWaitingStreams,
+      streamSnapshotStore: createStreamSnapshotStore([
+        restoredSnapshot({
+          streamId: 'active-stream',
+          executionId: 'abc123',
+          lastKnownStatus: STREAM_STATUS.RUNNING,
+        }),
+        restoredSnapshot({
+          streamId: 'dead-stream',
+          executionId: 'def456',
+          lastKnownStatus: STREAM_STATUS.RUNNING,
+        }),
+      ]),
+    });
+    const { StreamStatusService } =
+      await import('@agent/runtime/StreamStatusService');
+
+    try {
+      await vi.waitFor(() => {
+        expect(detectWaitingStreams).toHaveBeenCalledOnce();
+        expect(StreamStatusService.get('active-stream')).toBe(
+          STREAM_STATUS.RUNNING,
+        );
+        expect(StreamStatusService.get('dead-stream')).toBe(
+          STREAM_STATUS.ERROR,
+        );
+      });
+    } finally {
+      StreamStatusService.clear('active-stream', { emit: false });
+      StreamStatusService.clear('dead-stream', { emit: false });
+      bridge.dispose();
+    }
+  });
+
+  it('uses durable execution ids to keep active restored streams out of repair', async () => {
+    const detectWaitingStreams = vi.fn(
+      async (executionIds: ReadonlyMap<StreamTabId, string>) => {
+        expect([...executionIds.entries()]).toEqual([
+          ['dead-stream', 'def456'],
+        ]);
+        return new Set<StreamTabId>();
+      },
+    );
+    const bridge = await createBridge([], {
+      activeExecutionIds: ['abc123'],
+      configureProgressSnapshotStore: (store) => {
+        store.setTaskState(
+          'active-stream',
+          TaskStateSchema.parse(workflowTaskState()),
+          'abc123',
+        );
+      },
+      detectWaitingStreams,
+      streamSnapshotStore: createStreamSnapshotStore([
+        restoredSnapshot({
+          streamId: 'active-stream',
+          lastKnownStatus: STREAM_STATUS.RUNNING,
+        }),
+        restoredSnapshot({
+          streamId: 'dead-stream',
+          executionId: 'def456',
+          lastKnownStatus: STREAM_STATUS.RUNNING,
+        }),
+      ]),
+    });
+    const { StreamStatusService } =
+      await import('@agent/runtime/StreamStatusService');
+
+    try {
+      await vi.waitFor(() => {
+        expect(detectWaitingStreams).toHaveBeenCalledOnce();
+        expect(StreamStatusService.get('active-stream')).toBe(
+          STREAM_STATUS.RUNNING,
+        );
+        expect(StreamStatusService.get('dead-stream')).toBe(
+          STREAM_STATUS.ERROR,
+        );
+      });
+    } finally {
+      StreamStatusService.clear('active-stream', { emit: false });
+      StreamStatusService.clear('dead-stream', { emit: false });
+      bridge.dispose();
+    }
+  });
+
+  it('rechecks active executions after waiting detection before resetting streams', async () => {
+    let activeExecutionIds: readonly string[] = [];
+    let finishDetection!: (value: Set<StreamTabId>) => void;
+    const detectionGate = new Promise<Set<StreamTabId>>((resolve) => {
+      finishDetection = resolve;
+    });
+    const detectWaitingStreams = vi.fn(async () => detectionGate);
+    const bridge = await createBridge([], {
+      activeExecutionIds: () => activeExecutionIds,
+      detectWaitingStreams,
+      streamSnapshotStore: createStreamSnapshotStore([
+        restoredSnapshot({
+          streamId: 'race-stream',
+          executionId: 'abc123',
+          lastKnownStatus: STREAM_STATUS.RUNNING,
+        }),
+      ]),
+    });
+    const { StreamStatusService } =
+      await import('@agent/runtime/StreamStatusService');
+
+    try {
+      await vi.waitFor(() => expect(detectWaitingStreams).toHaveBeenCalled());
+      activeExecutionIds = ['abc123'];
+      finishDetection(new Set<StreamTabId>(['race-stream']));
+
+      await vi.waitFor(() => {
+        expect(StreamStatusService.get('race-stream')).toBe(
+          STREAM_STATUS.RUNNING,
+        );
+      });
+    } finally {
+      finishDetection(new Set());
+      StreamStatusService.clear('race-stream', { emit: false });
+      bridge.dispose();
+    }
+  });
+
+  it('closes running transcript groups for streams repaired to waiting', async () => {
+    let finishDetection!: (value: Set<StreamTabId>) => void;
+    const detectionGate = new Promise<Set<StreamTabId>>((resolve) => {
+      finishDetection = resolve;
+    });
+    const detectWaitingStreams = vi.fn(async () => detectionGate);
+    const bridge = await createBridge([], {
+      detectWaitingStreams,
+      streamSnapshotStore: createStreamSnapshotStore([
+        restoredSnapshot({
+          streamId: 'waiting-stream',
+          executionId: 'abc123',
+          lastKnownStatus: STREAM_STATUS.RUNNING,
+        }),
+      ]),
+    });
+    const streamLogs = bridge.streamLogs as typeof bridge.streamLogs & {
+      endRunningGroupsForStreams: (
+        streamIds: readonly StreamTabId[],
+        now?: number,
+      ) => Promise<StreamTabId[]>;
+    };
+    const closeSpy = vi.spyOn(streamLogs, 'endRunningGroupsForStreams');
+
+    try {
+      await vi.waitFor(() => expect(detectWaitingStreams).toHaveBeenCalled());
+      finishDetection(new Set<StreamTabId>(['waiting-stream']));
+
+      await vi.waitFor(() => {
+        expect(closeSpy).toHaveBeenCalledWith(
+          ['waiting-stream'],
+          expect.any(Number),
+        );
+      });
+    } finally {
+      finishDetection(new Set());
+      bridge.dispose();
+    }
+  });
+
+  it('keeps waiting repairs waiting when a later repair step fails', async () => {
+    let finishDetection!: (value: Set<StreamTabId>) => void;
+    const detectionGate = new Promise<Set<StreamTabId>>((resolve) => {
+      finishDetection = resolve;
+    });
+    const detectWaitingStreams = vi.fn(async () => detectionGate);
+    const bridge = await createBridge([], {
+      detectWaitingStreams,
+      streamSnapshotStore: createStreamSnapshotStore([
+        restoredSnapshot({
+          streamId: 'waiting-stream',
+          executionId: 'abc123',
+          lastKnownStatus: STREAM_STATUS.RUNNING,
+        }),
+      ]),
+    });
+    const streamLogs = bridge.streamLogs as typeof bridge.streamLogs & {
+      endRunningGroupsForStreams: (
+        streamIds: readonly StreamTabId[],
+        now?: number,
+      ) => Promise<StreamTabId[]>;
+    };
+    const closeSpy = vi
+      .spyOn(streamLogs, 'endRunningGroupsForStreams')
+      .mockRejectedValueOnce(new Error('group close failed'))
+      .mockResolvedValueOnce(['waiting-stream']);
+    const { StreamStatusService } =
+      await import('@agent/runtime/StreamStatusService');
+
+    try {
+      await vi.waitFor(() => expect(detectWaitingStreams).toHaveBeenCalled());
+      finishDetection(new Set<StreamTabId>(['waiting-stream']));
+
+      await vi.waitFor(() => {
+        expect(StreamStatusService.get('waiting-stream')).toBe(
+          STREAM_STATUS.WAITING,
+        );
+        expect(closeSpy).toHaveBeenCalledTimes(2);
+        expect(closeSpy).toHaveBeenLastCalledWith(
+          ['waiting-stream'],
+          expect.any(Number),
+        );
+      });
+    } finally {
+      finishDetection(new Set());
+      StreamStatusService.clear('waiting-stream', { emit: false });
+      bridge.dispose();
+    }
+  });
+
+  it('marks restored running streams without execution ids as errored', async () => {
+    const detectWaitingStreams = vi.fn(async () => new Set<StreamTabId>());
+    const bridge = await createBridge([], {
+      detectWaitingStreams,
+      streamSnapshotStore: createStreamSnapshotStore([
+        restoredSnapshot({
+          streamId: 'no-execution-stream',
+          lastKnownStatus: STREAM_STATUS.RUNNING,
+        }),
+      ]),
+    });
+    const { StreamStatusService } =
+      await import('@agent/runtime/StreamStatusService');
+
+    try {
+      await vi.waitFor(() => {
+        expect(detectWaitingStreams).toHaveBeenCalledWith(new Map());
+        expect(StreamStatusService.get('no-execution-stream')).toBe(
+          STREAM_STATUS.ERROR,
+        );
+      });
+    } finally {
+      StreamStatusService.clear('no-execution-stream', { emit: false });
+      bridge.dispose();
+    }
+  });
+
   it('ignores renderer switches to unknown streams', async () => {
     const messages: unknown[] = [];
     const bridge = await createBridge(messages);
@@ -699,11 +1100,14 @@ describe('DesktopProgressBridge', () => {
 
   it('restores ghost display from the backend snapshot store', async () => {
     const messages: unknown[] = [];
-    const kvRead = vi.fn(async () => {
+    const kvRead = vi.fn(async (key: string) => {
+      if (key === 'meta') return undefined;
       throw new Error('unexpected sidecar disk read');
     });
+    const detectWaitingStreams = vi.fn(async () => new Set<StreamTabId>());
     const bridge = await createBridge(messages, {
       kvRead,
+      detectWaitingStreams,
       configureProgressSnapshotStore: (store) => {
         store.setTodos('ghost-stream', [
           {
@@ -719,10 +1123,10 @@ describe('DesktopProgressBridge', () => {
     });
 
     try {
+      await vi.waitFor(() => expect(detectWaitingStreams).toHaveBeenCalled());
       bridge.setActiveStream('ghost-stream');
       await settleProgressEvents();
 
-      expect(kvRead).not.toHaveBeenCalled();
       expect(
         progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_TODOS).at(-1),
       ).toMatchObject({

--- a/src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts
@@ -246,6 +246,7 @@ describe('DesktopProgressEventBridge', () => {
             ensureStream,
             keys: () => [].values(),
             has: () => false,
+            getFirstTimestamp: () => undefined,
             getLastTimestamp: () => undefined,
             ensureLoaded: vi.fn(async () => {}),
           },
@@ -277,6 +278,77 @@ describe('DesktopProgressEventBridge', () => {
           parentStreamId: 'parent-456',
           description: 'A seeded ghost',
         });
+      } finally {
+        bridge.dispose();
+      }
+    });
+
+    it('does not resurrect streams that became live in this bridge', () => {
+      const ensureStream = vi.fn();
+      const bridge = createBridge({
+        state: makeMockState({
+          streamLogs: {
+            ensureStream,
+            keys: () => [].values(),
+            has: () => false,
+            getFirstTimestamp: () => undefined,
+            getLastTimestamp: () => undefined,
+            ensureLoaded: vi.fn(async () => {}),
+          },
+        }),
+        streamSnapshotStore: createSnapshotStore({
+          hydrated: [
+            createSnapshot({ streamId: 'live-stream' }),
+            createSnapshot({ streamId: 'ghost-stream' }),
+          ],
+        }),
+      });
+
+      try {
+        expect(bridge.hasRestoredStream('live-stream')).toBe(true);
+        bridge.onProgressEvent('updateStreamStatus', {
+          streamId: 'live-stream',
+          status: STREAM_STATUS.RUNNING,
+          previousStatus: STREAM_STATUS.STOPPED,
+        });
+        bridge.hydrateRestoredStreams();
+
+        expect(bridge.hasRestoredStream('live-stream')).toBe(false);
+        expect(bridge.hasRestoredStream('ghost-stream')).toBe(true);
+        expect(ensureStream).toHaveBeenCalledWith('ghost-stream');
+      } finally {
+        bridge.dispose();
+      }
+    });
+
+    it('forgets restored streams owned by active execution ids', () => {
+      const bridge = createBridge({
+        streamSnapshotStore: createSnapshotStore({
+          hydrated: [
+            createSnapshot({
+              streamId: 'active-ghost',
+              executionId: 'exec-active',
+            }),
+            createSnapshot({
+              streamId: 'inactive-ghost',
+              executionId: 'exec-inactive',
+            }),
+            createSnapshot({ streamId: 'mapped-active-ghost' }),
+            createSnapshot({ streamId: 'no-exec-ghost' }),
+          ],
+        }),
+      });
+
+      try {
+        bridge.forgetActiveRestoredStreams(
+          new Set(['exec-active', 'exec-mapped-active']),
+          new Map([['mapped-active-ghost', 'exec-mapped-active']]),
+        );
+
+        expect(bridge.hasRestoredStream('active-ghost')).toBe(false);
+        expect(bridge.hasRestoredStream('inactive-ghost')).toBe(true);
+        expect(bridge.hasRestoredStream('mapped-active-ghost')).toBe(false);
+        expect(bridge.hasRestoredStream('no-exec-ghost')).toBe(true);
       } finally {
         bridge.dispose();
       }

--- a/src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts
+++ b/src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts
@@ -108,7 +108,7 @@ describe('DesktopStreamSnapshot', () => {
     expect(ids).toEqual(['toolUseAgent@2', 'workflowAgent@1']);
   });
 
-  it('normalises status to STOPPED on hydrate', async () => {
+  it('preserves RUNNING on hydrate for startup repair', async () => {
     const filePath = await tempFilePath();
 
     const writer = await openDesktopStreamSnapshotStore(filePath);
@@ -117,9 +117,31 @@ describe('DesktopStreamSnapshot', () => {
     );
 
     const reopened = await openDesktopStreamSnapshotStore(filePath);
-    expect(
-      reopened.hydrated.every((s) => s.lastKnownStatus === 'stopped'),
-    ).toBe(true);
+    expect(reopened.hydrated[0]?.lastKnownStatus).toBe(STREAM_STATUS.RUNNING);
+  });
+
+  it.each([
+    STREAM_STATUS.RESUMING,
+    STREAM_STATUS.INITIALIZING,
+    STREAM_STATUS.WAITING,
+  ])('preserves %s on hydrate for startup repair', async (status) => {
+    const filePath = await tempFilePath();
+
+    const writer = await openDesktopStreamSnapshotStore(filePath);
+    await writer.upsert(makeSnapshot({ lastKnownStatus: status }));
+
+    const reopened = await openDesktopStreamSnapshotStore(filePath);
+    expect(reopened.hydrated[0]?.lastKnownStatus).toBe(status);
+  });
+
+  it('normalises inactive statuses to STOPPED on hydrate', async () => {
+    const filePath = await tempFilePath();
+
+    const writer = await openDesktopStreamSnapshotStore(filePath);
+    await writer.upsert(makeSnapshot({ lastKnownStatus: STREAM_STATUS.ERROR }));
+
+    const reopened = await openDesktopStreamSnapshotStore(filePath);
+    expect(reopened.hydrated[0]?.lastKnownStatus).toBe(STREAM_STATUS.STOPPED);
   });
 
   it('preserves parent stream links on hydrate', async () => {

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -364,6 +364,50 @@ describe('StreamLogStore load', () => {
     });
   });
 
+  it('can close running groups for only selected summarized streams', async () => {
+    const storage = mockStorage({
+      logs: {
+        alpha: [runningGroupEntry('alpha', 1, 100)],
+        beta: [runningGroupEntry('beta', 1, 110)],
+      },
+      summaries: {
+        alpha: {
+          firstTimestamp: 100,
+          lastTimestamp: 100,
+          hasRunningGroup: true,
+        },
+        beta: {
+          firstTimestamp: 110,
+          lastTimestamp: 110,
+          hasRunningGroup: true,
+        },
+      },
+    });
+
+    const store = new StreamLogStore();
+    await store.load();
+
+    const affected = await store.endRunningGroupsForStreams(['alpha'], 300);
+    await store.flush();
+
+    expect(affected).toEqual(['alpha']);
+    expect(storage.fullLogReads()).toBe(1);
+    expect(store.get('alpha')?.getRange(0).at(0)?.type).toBe(
+      STREAM_LOG_ENTRY_TYPES.GROUP_END,
+    );
+    expect(store.get('beta')).toBeUndefined();
+    expect(
+      storage.writes.get(storageFile(STREAM_LOG_SUMMARIES_DIR, 'alpha')),
+    ).toEqual({
+      firstTimestamp: 100,
+      lastTimestamp: 100,
+      hasRunningGroup: false,
+    });
+    expect(
+      storage.writes.get(storageFile(STREAM_LOG_SUMMARIES_DIR, 'beta')),
+    ).toBeUndefined();
+  });
+
   it('bounds stale running group rehydrates', async () => {
     const streamIds = Array.from(
       { length: 20 },

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -359,8 +359,38 @@ export class StreamLogStore {
       });
     }
 
+    const affected = this.endRunningGroupsInLoadedLogs(now);
+    if (affected.length > 0) {
+      void this.save();
+    }
+
+    return affected;
+  }
+
+  async endRunningGroupsForStreams(
+    streamIds: readonly StreamTabId[],
+    now: number = Date.now(),
+  ): Promise<StreamTabId[]> {
+    if (streamIds.length === 0) return [];
+    await pMap(streamIds, (id) => this.ensureLoaded(id), {
+      concurrency: STREAM_LOG_LOAD_CONCURRENCY,
+    });
+
+    const affected = this.endRunningGroupsInLoadedLogs(now, new Set(streamIds));
+    if (affected.length > 0) {
+      void this.save();
+    }
+
+    return affected;
+  }
+
+  private endRunningGroupsInLoadedLogs(
+    now: number,
+    streamIds?: ReadonlySet<StreamTabId>,
+  ): StreamTabId[] {
     const affected: StreamTabId[] = [];
     for (const [streamId, logInstance] of this.logs.entries()) {
+      if (streamIds && !streamIds.has(streamId)) continue;
       let updatedAny = false;
       for (const entry of logInstance.getRange(0, logInstance.head)) {
         if (!isRunningGroupEntry(entry)) continue;
@@ -378,10 +408,6 @@ export class StreamLogStore {
         this.markDirty(streamId);
         this.notify(streamId);
       }
-    }
-
-    if (affected.length > 0) {
-      void this.save();
     }
 
     return affected;


### PR DESCRIPTION
## Summary

This addresses the runtime part of #6887 without taking the broad directory/store renames from the stale Claude branch.

- run the desktop restart repair path after bridge construction
- preserve restored `RUNNING` status long enough to classify it as `WAITING` or `ERROR`
- rehydrate restored stream hints after loading transcript summaries, so stale running log groups can be closed without evicting preloaded sidecars
- add regression coverage for restored running streams and snapshot hydration

## Out of scope

The proposed `src/shared/progressView/backend/` move and `DesktopStreamSnapshotStore` rename are intentionally not included. They are broad mechanical changes and do not carry the bug fix.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts`
- `corepack pnpm exec eslint packages/desktop/src/main/desktopAgentExecution.ts packages/desktop/src/main/desktopProgressEventBridge.ts packages/desktop/src/main/desktopStreamSnapshot.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts`
- `corepack pnpm exec tsc --noEmit -p tsconfig.json --pretty false`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes startup ordering and stream status semantics for all desktop sessions after relaunch; mistakes could mislabel runs as waiting vs error or race resume/follow-up, but behavior is heavily covered by new vitest cases and includes failure fallbacks.
> 
> **Overview**
> Adds **desktop restart repair** so streams that looked in-flight when the app quit are reconciled on launch instead of staying stuck as fake “running” ghosts.
> 
> On bridge construction, `repairOrphanedStreamsAfterRestart` loads transcript summaries, re-hydrates restored snapshots, skips executions still active in-process, uses `detectWaitingStreams` to find resumable runs, then sets survivors to **WAITING** or **ERROR**. It closes stale running transcript groups for those streams and syncs the progress rail. **Resume**, **follow-up**, and **new runs** now `await` this repair so they don’t race startup.
> 
> **Snapshot hydration** no longer forces every restored status to `stopped`: in-flight statuses are kept briefly so repair can classify them; finished/inert states still become inactive ghosts.
> 
> The progress event bridge gains **idempotent `hydrateRestoredStreams`**, **`forgetActiveRestoredStreams`**, and a **`liveStreams`** guard so streams that go live in-session aren’t re-ghosted after rehydrate.
> 
> **Follow-ups**: `wakeQueuedFollowUpStream` accepts an optional `FollowUpResumePort` so desktop can wake queued messages via its window’s `tryResumeStream` / `isResumeInFlight`.
> 
> **Transcript**: `StreamLogStore.endRunningGroupsForStreams` closes open task groups only for selected streams (shared helper with existing bulk close).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d351f91ef3ee75f5b73c262f99ae55471373eefe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->