### PR TITLE
refactor: tighten agent sync ownership

### DIFF
--- a/packages/extension/src/frontend/secretManager.ts
+++ b/packages/extension/src/frontend/secretManager.ts
@@ -7,9 +7,7 @@ import { getServerSideKeyService } from '@auth/serverKeys';
 import {
   API_PROVIDERS,
   apiKeyExists as resolvedApiKeyExists,
-  apiKeyEnvName,
   apiKeySecretName,
-  getApiKey as requireApiKey,
   lookupApiKey,
   type ApiProvider,
 } from '@model/apiProviders';
@@ -76,23 +74,6 @@ export class SecretManager {
     if (stored) return 'secret';
     if (getGitHubEnvToken()) return 'env';
     return 'none';
-  }
-
-  public static async getApiKey(provider: ApiProvider): Promise<string> {
-    try {
-      return await requireApiKey(platform().secrets, provider);
-    } catch (err) {
-      if (
-        !(err instanceof Error) ||
-        !err.message.startsWith(`No API key found for ${provider}.`)
-      ) {
-        throw err;
-      }
-      throw new Error(
-        `No API key found for ${provider}. Please set it using the "Set API Key" command or ${apiKeyEnvName(provider)} environment variable.`,
-        { cause: err },
-      );
-    }
   }
 
   public static async anyApiKeyExists(): Promise<boolean> {

--- a/src/agent/index/AgentDirectorySync.ts
+++ b/src/agent/index/AgentDirectorySync.ts
@@ -1,7 +1,10 @@
 import * as path from 'node:path';
 
+import { z } from 'zod';
+
 import { platform } from '@platform/platform';
 import { toErrorMessage } from '@common/errors';
+import { isFileNotFoundError } from '@common/errors/errorPredicates';
 import { GlobalStorageFS } from '@utils/files/storageFS';
 
 import {
@@ -18,6 +21,16 @@ const LEGACY_AGENT_FILES = [
   'agents/write/paper2cover.yaml',
   'agents/write/write_slide.yaml',
 ];
+const SYNC_MARKER_FILE = '.bundled-agent-sync.json';
+const RECENT_EXTERNAL_SYNC_MS = 5 * 60 * 1000;
+
+const AgentDirectorySyncMarkerSchema = z.object({
+  completedAt: z.number().nonnegative(),
+  ownerPid: z.int().nonnegative(),
+  version: z.string().nullish(),
+});
+
+type AgentDirectorySyncMarker = z.output<typeof AgentDirectorySyncMarkerSchema>;
 
 export interface AgentDirectoryBundleSource {
   copyDirectory(
@@ -29,6 +42,8 @@ export interface AgentDirectoryBundleSource {
 export interface AgentDirectoryStorage {
   ensureDir(relativePath: string): Promise<void>;
   exists(relativePath: string): Promise<boolean>;
+  read(relativePath: string): Promise<string>;
+  write(relativePath: string, content: string): Promise<void>;
   delete(relativePath: string): Promise<void>;
   fullPath(relativePath: string): string;
 }
@@ -74,6 +89,14 @@ export class GlobalStorageAgentDirectoryStorage implements AgentDirectoryStorage
     return GlobalStorageFS.exists(relativePath);
   }
 
+  read(relativePath: string): Promise<string> {
+    return GlobalStorageFS.read(relativePath);
+  }
+
+  write(relativePath: string, content: string): Promise<void> {
+    return GlobalStorageFS.write(relativePath, content);
+  }
+
   delete(relativePath: string): Promise<void> {
     return GlobalStorageFS.delete(relativePath);
   }
@@ -84,10 +107,42 @@ export class GlobalStorageAgentDirectoryStorage implements AgentDirectoryStorage
 }
 
 export class BundledAgentDirectorySync {
+  private static readonly reconcileByStorageRoot = new Map<
+    string,
+    Promise<boolean>
+  >();
+
   constructor(private readonly options: BundledAgentDirectorySyncOptions) {}
 
   async reconcile(currentVersion: string | undefined): Promise<boolean> {
+    const storageRoot = this.options.storage.fullPath('');
+    const previous =
+      BundledAgentDirectorySync.reconcileByStorageRoot.get(storageRoot) ??
+      Promise.resolve(true);
+    const current = previous
+      .catch(() => true)
+      .then(() => this.reconcileUnlocked(currentVersion));
+    const tracked = current.finally(() => {
+      if (
+        BundledAgentDirectorySync.reconcileByStorageRoot.get(storageRoot) ===
+        tracked
+      ) {
+        BundledAgentDirectorySync.reconcileByStorageRoot.delete(storageRoot);
+      }
+    });
+    tracked.catch(() => undefined);
+    BundledAgentDirectorySync.reconcileByStorageRoot.set(storageRoot, tracked);
+    return current;
+  }
+
+  private async reconcileUnlocked(
+    currentVersion: string | undefined,
+  ): Promise<boolean> {
     await this.deleteLegacyAgentFiles();
+    if (await this.hasRecentExternalSync(currentVersion)) {
+      await this.options.versionStore.update(currentVersion);
+      return false;
+    }
 
     for (const directoryName of BUNDLED_AGENT_DIRECTORY_NAMES) {
       await this.options.storage.ensureDir(directoryName);
@@ -98,7 +153,54 @@ export class BundledAgentDirectorySync {
     }
 
     await this.options.versionStore.update(currentVersion);
+    await this.writeSyncMarker(currentVersion);
     return true;
+  }
+
+  private async hasRecentExternalSync(
+    currentVersion: string | undefined,
+  ): Promise<boolean> {
+    const marker = await this.readSyncMarker();
+    if (!marker || marker.ownerPid === process.pid) return false;
+    if ((marker.version ?? undefined) !== currentVersion) return false;
+    return Date.now() - marker.completedAt < RECENT_EXTERNAL_SYNC_MS;
+  }
+
+  private async readSyncMarker(): Promise<
+    AgentDirectorySyncMarker | undefined
+  > {
+    try {
+      const raw = await this.options.storage.read(SYNC_MARKER_FILE);
+      return AgentDirectorySyncMarkerSchema.optional()
+        .catch(undefined)
+        .parse(JSON.parse(raw));
+    } catch (error) {
+      if (isFileNotFoundError(error)) return undefined;
+      this.options.logger.warn(
+        `Ignoring bundled agent sync marker: ${toErrorMessage(error)}`,
+      );
+      return undefined;
+    }
+  }
+
+  private async writeSyncMarker(
+    currentVersion: string | undefined,
+  ): Promise<void> {
+    try {
+      await this.options.storage.ensureDir('');
+      await this.options.storage.write(
+        SYNC_MARKER_FILE,
+        `${JSON.stringify({
+          completedAt: Date.now(),
+          ownerPid: process.pid,
+          version: currentVersion,
+        })}\n`,
+      );
+    } catch (error) {
+      this.options.logger.warn(
+        `Failed to write bundled agent sync marker: ${toErrorMessage(error)}`,
+      );
+    }
   }
 
   private async deleteLegacyAgentFiles(): Promise<void> {

--- a/src/test-kernel/agent/AgentDirectorySync.vitest.ts
+++ b/src/test-kernel/agent/AgentDirectorySync.vitest.ts
@@ -1,0 +1,234 @@
+// Node imports
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+// Third-party imports
+import { afterEach, describe, expect, it } from 'vitest';
+
+// Local imports - agent
+import {
+  BundledAgentDirectorySync,
+  type AgentDirectoryBundleSource,
+  type AgentDirectoryStorage,
+} from '@agent/index/AgentDirectorySync';
+import type { BundledAgentDirectoryName } from '@agent/index/BundledAgentDirectories';
+
+function pendingReconcileCount(): number {
+  return (
+    BundledAgentDirectorySync as unknown as {
+      reconcileByStorageRoot: Map<string, Promise<boolean>>;
+    }
+  ).reconcileByStorageRoot.size;
+}
+
+class FsAgentDirectoryStorage implements AgentDirectoryStorage {
+  constructor(private readonly root: string) {}
+
+  async ensureDir(relativePath: string): Promise<void> {
+    await mkdir(this.fullPath(relativePath), { recursive: true });
+  }
+
+  async exists(relativePath: string): Promise<boolean> {
+    try {
+      await access(this.fullPath(relativePath));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  read(relativePath: string): Promise<string> {
+    return readFile(this.fullPath(relativePath), 'utf8');
+  }
+
+  write(relativePath: string, content: string): Promise<void> {
+    return writeFile(this.fullPath(relativePath), content);
+  }
+
+  delete(relativePath: string): Promise<void> {
+    return rm(this.fullPath(relativePath), { recursive: true, force: true });
+  }
+
+  fullPath(relativePath: string): string {
+    return join(this.root, relativePath);
+  }
+}
+
+describe('BundledAgentDirectorySync', () => {
+  let tempDir: string | undefined;
+
+  afterEach(async () => {
+    if (tempDir == null) return;
+    await rm(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  });
+
+  it('serializes concurrent copies into the same storage root', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'texra-agent-sync-'));
+    const storage = new FsAgentDirectoryStorage(tempDir);
+    const copied: BundledAgentDirectoryName[] = [];
+    let activeCopies = 0;
+    let maxActiveCopies = 0;
+
+    const bundleSource: AgentDirectoryBundleSource = {
+      async copyDirectory(directoryName, destinationPath) {
+        activeCopies += 1;
+        maxActiveCopies = Math.max(maxActiveCopies, activeCopies);
+        try {
+          await sleep(20);
+          await mkdir(destinationPath, { recursive: true });
+          await writeFile(join(destinationPath, 'agent.yaml'), 'name: agent\n');
+          copied.push(directoryName);
+        } finally {
+          activeCopies -= 1;
+        }
+      },
+    };
+    const sync = new BundledAgentDirectorySync({
+      bundleSource,
+      storage,
+      versionStore: {
+        get: () => undefined,
+        update: async () => undefined,
+      },
+      logger: {
+        info: () => undefined,
+        warn: () => undefined,
+      },
+    });
+
+    await Promise.all([
+      sync.reconcile('1.0.0'),
+      sync.reconcile('1.0.0'),
+      sync.reconcile('1.0.0'),
+    ]);
+
+    expect(maxActiveCopies).toBe(1);
+    expect(copied).toEqual([
+      'agents',
+      'tool_use_agents',
+      'agents',
+      'tool_use_agents',
+      'agents',
+      'tool_use_agents',
+    ]);
+    expect(pendingReconcileCount()).toBe(0);
+  });
+
+  it('skips a recent same-version sync from another process', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'texra-agent-sync-'));
+    const storage = new FsAgentDirectoryStorage(tempDir);
+    const copied: BundledAgentDirectoryName[] = [];
+    let storedVersion: string | undefined;
+    await writeFile(
+      join(tempDir, '.bundled-agent-sync.json'),
+      `${JSON.stringify({
+        completedAt: Date.now(),
+        ownerPid: process.pid + 1,
+        version: '1.0.0',
+      })}\n`,
+    );
+
+    const sync = new BundledAgentDirectorySync({
+      bundleSource: {
+        async copyDirectory(directoryName) {
+          copied.push(directoryName);
+        },
+      },
+      storage,
+      versionStore: {
+        get: () => undefined,
+        update: async (version) => {
+          storedVersion = version;
+        },
+      },
+      logger: {
+        info: () => undefined,
+        warn: () => undefined,
+      },
+    });
+
+    await sync.reconcile('1.0.0');
+
+    expect(copied).toEqual([]);
+    expect(storedVersion).toBe('1.0.0');
+    expect(pendingReconcileCount()).toBe(0);
+  });
+
+  it('clears the reconcile lock after copy failure', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'texra-agent-sync-'));
+    const storage = new FsAgentDirectoryStorage(tempDir);
+    const sync = new BundledAgentDirectorySync({
+      bundleSource: {
+        async copyDirectory() {
+          throw new Error('copy failed');
+        },
+      },
+      storage,
+      versionStore: {
+        get: () => undefined,
+        update: async () => undefined,
+      },
+      logger: {
+        info: () => undefined,
+        warn: () => undefined,
+      },
+    });
+
+    await expect(sync.reconcile('1.0.0')).rejects.toThrow('copy failed');
+
+    expect(pendingReconcileCount()).toBe(0);
+  });
+
+  it('does not fail reconciliation when the marker write fails', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'texra-agent-sync-'));
+    const storage = new (class extends FsAgentDirectoryStorage {
+      override write(relativePath: string, content: string): Promise<void> {
+        if (relativePath === '.bundled-agent-sync.json') {
+          throw new Error('marker unwritable');
+        }
+        return super.write(relativePath, content);
+      }
+    })(tempDir);
+    const copied: BundledAgentDirectoryName[] = [];
+    let storedVersion: string | undefined;
+    const warnings: string[] = [];
+    const sync = new BundledAgentDirectorySync({
+      bundleSource: {
+        async copyDirectory(directoryName, destinationPath) {
+          await mkdir(destinationPath, { recursive: true });
+          copied.push(directoryName);
+        },
+      },
+      storage,
+      versionStore: {
+        get: () => undefined,
+        update: async (version) => {
+          storedVersion = version;
+        },
+      },
+      logger: {
+        info: () => undefined,
+        warn: (message) => warnings.push(message),
+      },
+    });
+
+    await expect(sync.reconcile('1.0.0')).resolves.toBe(true);
+
+    expect(copied).toEqual(['agents', 'tool_use_agents']);
+    expect(storedVersion).toBe('1.0.0');
+    expect(warnings).toEqual([
+      'Failed to write bundled agent sync marker: marker unwritable',
+    ]);
+    expect(pendingReconcileCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- serialize bundled-agent directory reconciliation per storage root and record a short-lived completed-sync marker so another process can avoid repeating the same bundled copy immediately
- add focused coverage for concurrent reconcile calls and recent same-version external sync markers
- remove unused `SecretManager.getApiKey()`, leaving API-key retrieval errors owned by the canonical provider resolver

## Notes

PR #6886 is broad and currently dirty against main, so this PR keeps out of its model-handler and subprocess refactor surface. The only overlap is `AgentDirectorySync.ts`, where this change is a focused ownership fix backed by a new test.

## Verification

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/agent/AgentDirectorySync.vitest.ts`
- `corepack pnpm exec eslint src/agent/index/AgentDirectorySync.ts src/test-kernel/agent/AgentDirectorySync.vitest.ts packages/extension/src/frontend/secretManager.ts`
- `corepack pnpm exec tsc --noEmit -p tsconfig.json --pretty false`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Agent sync behavior changes how and when bundled directories are copied across processes; the SecretManager removal is low risk if nothing still called the removed API.
> 
> **Overview**
> **Bundled agent directory sync** now serializes `reconcile` per storage root so concurrent callers cannot overlap copies, and writes a short-lived `.bundled-agent-sync.json` marker (PID, version, timestamp) so another process can skip repeating the same bundled copy within five minutes while still updating the version store.
> 
> New vitest coverage exercises concurrent reconcile serialization, cross-process marker skip, lock cleanup on copy failure, and non-fatal marker write failures.
> 
> **Extension cleanup:** removes unused `SecretManager.getApiKey()` so missing-key messaging stays with the canonical `@model/apiProviders` resolver.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec707b7cc25fee2eceb834bcf83920af63e73c21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->