### PR TITLE
Consolidate setup-model credential resolution into one host-neutral function

### DIFF
--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -63,11 +63,15 @@ interface LaunchModelResolution {
  * The caller surfaces that as a clear preflight error rather than
  * launching with a model that will crash on tier enforcement.
  *
- * Order (the middle three steps are the host-shared priority scan in
- * `resolveSetupModelFromDirectCredentials` — see that function for the
- * ChatGPT/Researcher Access/direct-key detail):
- *   0. ChatGPT subscription, Researcher Access, then a direct provider key.
- *   1. Only if `openRouter` is the sole provider with a key, report a
+ * Order:
+ *   0. If the global `useOpenRouter` flag is already on, use the
+ *      OpenRouter-routed default (the caller's `ensureRoutingConfigured`
+ *      already validated a key is present).
+ *   1. Otherwise, ChatGPT subscription, Researcher Access, then a direct
+ *      provider key — the host-shared priority scan in
+ *      `resolveSetupModelFromDirectCredentials` (see that function for the
+ *      ChatGPT/Researcher Access/direct-key detail).
+ *   2. Only if `openRouter` is the sole provider with a key, report a
  *      router-backed default and let the caller temporarily flip the flag.
  */
 async function resolveLaunchModel(): Promise<LaunchModelResolution | null> {

--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports
-import { resolveSetupModelFromDirectCredentials } from '@controllers/onboarding/setupLaunch';
+import { resolveSetupModelExcludingOpenRouter } from '@controllers/onboarding/setupLaunch';
 import { platform } from '@platform/platform';
 import { loadAgents } from '@agent/index';
 import { registerExecution } from '@agent/storage';
@@ -69,7 +69,7 @@ interface LaunchModelResolution {
  *      already validated a key is present).
  *   1. Otherwise, ChatGPT subscription, Researcher Access, then a direct
  *      provider key — the host-shared priority scan in
- *      `resolveSetupModelFromDirectCredentials` (see that function for the
+ *      `resolveSetupModelExcludingOpenRouter` (see that function for the
  *      ChatGPT/Researcher Access/direct-key detail).
  *   2. Only if `openRouter` is the sole provider with a key, report a
  *      router-backed default and let the caller temporarily flip the flag.
@@ -90,7 +90,7 @@ async function resolveLaunchModel(): Promise<LaunchModelResolution | null> {
     };
   }
 
-  const model = await resolveSetupModelFromDirectCredentials(
+  const model = await resolveSetupModelExcludingOpenRouter(
     platform().secrets,
   );
   if (model) {

--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -2,6 +2,8 @@
 import * as vscode from 'vscode';
 
 // Local imports
+import { resolveSetupModelFromDirectCredentials } from '@controllers/onboarding/setupLaunch';
+import { platform } from '@platform/platform';
 import { loadAgents } from '@agent/index';
 import { registerExecution } from '@agent/storage';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
@@ -27,7 +29,6 @@ import {
   ONBOARDING_CHOICE_CHATGPT,
   ONBOARDING_CHOICE_SIGN_IN,
 } from '@shared/copy/onboarding';
-import { DEFAULT_AGENT_MODEL } from '@shared/constants/providers';
 import { SETUP_AGENT_NAME } from '@shared/constants/agents';
 import { agentName } from '@shared/schemas/agent';
 import { generateExecutionId } from '@utils/core/executionId';
@@ -62,28 +63,14 @@ interface LaunchModelResolution {
  * The caller surfaces that as a clear preflight error rather than
  * launching with a model that will crash on tier enforcement.
  *
- * Order:
- *   0. ChatGPT subscription — when enabled and signed in, use the
- *      Codex-eligible OpenAI setup model.
- *   1. Researcher Access — only when "Use Included Access" is actually
- *      on AND the signed-in setup model is in the user's tier. A plain
- *      `canUseServerSideKeys()` pass is insufficient because a lower-tier
- *      user may have server-side access to *some* models but not
- *      `DEFAULT_AGENT_MODEL`; we'd otherwise fall through preflight
- *      and fail at runtime when tier enforcement kicks in.
- *   2. If the user is signed in but `DEFAULT_AGENT_MODEL` is not in
- *      tier, scan `SETUP_MODEL_BY_PROVIDER` for any model that IS in
- *      tier so a lower-tier signed-in user still gets a working launch.
- *   3. Any direct API key for a provider whose default model routes
- *      through that same provider directly (iterating
- *      `SecretManager.API_PROVIDERS` for deterministic ordering). Preferred
- *      over OpenRouter so we don't need to touch the routing flag at all.
- *   4. Only if `openRouter` is the sole provider with a key, report a
+ * Order (the middle three steps are the host-shared priority scan in
+ * `resolveSetupModelFromDirectCredentials` — see that function for the
+ * ChatGPT/Researcher Access/direct-key detail):
+ *   0. ChatGPT subscription, Researcher Access, then a direct provider key.
+ *   1. Only if `openRouter` is the sole provider with a key, report a
  *      router-backed default and let the caller temporarily flip the flag.
  */
 async function resolveLaunchModel(): Promise<LaunchModelResolution | null> {
-  const serverKeys = getServerSideKeyService();
-
   // When global OR routing is on, every model call is re-routed through
   // OpenRouter at the ModelFactory level regardless of what we pick for
   // "direct" here — so a server-side or direct-provider pick would be
@@ -99,47 +86,15 @@ async function resolveLaunchModel(): Promise<LaunchModelResolution | null> {
     };
   }
 
-  if (await isCodexSubscriptionActive(CHATGPT_SETUP_MODEL)) {
-    return {
-      model: CHATGPT_SETUP_MODEL,
-      requiresOpenRouter: false,
-    };
+  const model = await resolveSetupModelFromDirectCredentials(
+    platform().secrets,
+  );
+  if (model) {
+    return { model, requiresOpenRouter: false };
   }
 
-  if (await serverKeys.canUseServerSideKeysForModel(DEFAULT_AGENT_MODEL)) {
-    return { model: DEFAULT_AGENT_MODEL, requiresOpenRouter: false };
-  }
-
-  // Step 2: signed-in user whose tier excludes the default signed-in
-  // model. Look for any tier-available *directly-routed* model among the
-  // per-provider defaults. Skip the `openRouter` entry because that
-  // model (e.g. `sonnet46T`) is specifically for OR-routed calls and
-  // routing it direct via server-side keys would pick the wrong backend.
-  if (await serverKeys.canUseServerSideKeys()) {
-    for (const [provider, model] of Object.entries(SETUP_MODEL_BY_PROVIDER)) {
-      if (provider === 'openRouter') continue;
-      if (serverKeys.canUseModelSync(model)) {
-        return { model, requiresOpenRouter: false };
-      }
-    }
-  }
-
-  // Step 3: direct provider key. Only consider providers we know how to
-  // map to a default model — silently falling back to `DEFAULT_AGENT_MODEL`
-  // (a Google model) for an unmapped provider would produce a runtime
-  // auth failure with a credential that can't reach Google.
-  for (const provider of SecretManager.API_PROVIDERS) {
-    if (provider === 'openRouter') continue;
-    const model = SETUP_MODEL_BY_PROVIDER[provider];
-    if (!model) continue;
-    if (await SecretManager.hasUsableApiKey(provider)) {
-      return { model, requiresOpenRouter: false };
-    }
-  }
-
-  // Step 4: only OpenRouter key present. The `openRouter` entry is
-  // statically declared in `SETUP_MODEL_BY_PROVIDER`, so no fallback
-  // is needed.
+  // Only OpenRouter key present. The `openRouter` entry is statically
+  // declared in `SETUP_MODEL_BY_PROVIDER`, so no fallback model is needed.
   if (await SecretManager.hasUsableApiKey('openRouter')) {
     return {
       model: SETUP_MODEL_BY_PROVIDER.openRouter,

--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -90,9 +90,7 @@ async function resolveLaunchModel(): Promise<LaunchModelResolution | null> {
     };
   }
 
-  const model = await resolveSetupModelExcludingOpenRouter(
-    platform().secrets,
-  );
+  const model = await resolveSetupModelExcludingOpenRouter(platform().secrets);
   if (model) {
     return { model, requiresOpenRouter: false };
   }

--- a/src/controllers/onboarding/setupLaunch.ts
+++ b/src/controllers/onboarding/setupLaunch.ts
@@ -34,6 +34,11 @@ export const SETUP_INSTRUCTION =
  * agent model, server-side keys for any per-provider setup model, then a
  * direct provider API key. Returns `null` when none resolve.
  *
+ * Named for what it excludes, not just "direct" keys: it also covers the
+ * ChatGPT subscription and server-side-key paths, which aren't
+ * secrets-lookup credentials either. The one thing every path here shares
+ * is that none of them need the OpenRouter routing flag.
+ *
  * This is the credential-priority core shared by every host's setup-model
  * resolution: the VS Code extension's `resolveLaunchModel`
  * (`setupAssistantCommand.ts`) layers its interactive OpenRouter-flag flip
@@ -42,7 +47,7 @@ export const SETUP_INSTRUCTION =
  * priority order in one place means the two hosts can't silently drift on
  * which credential wins.
  */
-export async function resolveSetupModelFromDirectCredentials(
+export async function resolveSetupModelExcludingOpenRouter(
   secrets: PlatformSecrets,
 ): Promise<string | null> {
   if (await isCodexSubscriptionActive(CHATGPT_SETUP_MODEL)) {
@@ -101,9 +106,9 @@ export async function resolveDesktopSetupModel(): Promise<string | null> {
   // above). A bare OpenRouter key with the flag off can't be used: the desktop
   // launch passes only a model string to `handleExecute` and never flips the
   // routing flag, so an OR model would run unrouted and fail at inference.
-  // `resolveSetupModelFromDirectCredentials` already skips the `openRouter`
+  // `resolveSetupModelExcludingOpenRouter` already skips the `openRouter`
   // entry, so it naturally refuses instead of picking a doomed model.
-  return resolveSetupModelFromDirectCredentials(secrets);
+  return resolveSetupModelExcludingOpenRouter(secrets);
 }
 
 /**

--- a/src/controllers/onboarding/setupLaunch.ts
+++ b/src/controllers/onboarding/setupLaunch.ts
@@ -21,6 +21,8 @@ import type { MainViewExecuteMessage } from '@shared/mainView';
 import { DEFAULT_AGENT_MODEL } from '@shared/constants/providers';
 import { SETUP_AGENT_NAME } from '@shared/constants/agents';
 import { isNonEmptyString } from '@utils/core';
+// Used only by `resolveDesktopSetupModel` below — the shared
+// `resolveSetupModelExcludingOpenRouter` scan has no routing-flag dependency.
 import { getUseOpenRouter } from '@utils/config/providerConfig';
 import type { PlatformSecrets } from '@platform/secrets';
 

--- a/src/controllers/onboarding/setupLaunch.ts
+++ b/src/controllers/onboarding/setupLaunch.ts
@@ -22,10 +22,55 @@ import { DEFAULT_AGENT_MODEL } from '@shared/constants/providers';
 import { SETUP_AGENT_NAME } from '@shared/constants/agents';
 import { isNonEmptyString } from '@utils/core';
 import { getUseOpenRouter } from '@utils/config/providerConfig';
+import type { PlatformSecrets } from '@platform/secrets';
 
 /** Instruction handed to the setup agent when launched (mirrors the extension). */
 export const SETUP_INSTRUCTION =
   'Please help me finish installing TeXRA. Probe my environment, install anything missing, and get me a working credential.';
+
+/**
+ * Pick a model from the user's non-OpenRouter credentials, in priority
+ * order: ChatGPT/Codex subscription, server-side keys for the default
+ * agent model, server-side keys for any per-provider setup model, then a
+ * direct provider API key. Returns `null` when none resolve.
+ *
+ * This is the credential-priority core shared by every host's setup-model
+ * resolution: the VS Code extension's `resolveLaunchModel`
+ * (`setupAssistantCommand.ts`) layers its interactive OpenRouter-flag flip
+ * on top of this, and `resolveDesktopSetupModel` below layers desktop's
+ * flag-only (non-interactive) OpenRouter handling on top of it. Keeping the
+ * priority order in one place means the two hosts can't silently drift on
+ * which credential wins.
+ */
+export async function resolveSetupModelFromDirectCredentials(
+  secrets: PlatformSecrets,
+): Promise<string | null> {
+  if (await isCodexSubscriptionActive(CHATGPT_SETUP_MODEL)) {
+    return CHATGPT_SETUP_MODEL;
+  }
+
+  const serverKeys = getServerSideKeyService();
+  if (await serverKeys.canUseServerSideKeysForModel(DEFAULT_AGENT_MODEL)) {
+    return DEFAULT_AGENT_MODEL;
+  }
+  if (await serverKeys.canUseServerSideKeys()) {
+    for (const [provider, model] of Object.entries(SETUP_MODEL_BY_PROVIDER)) {
+      if (provider === 'openRouter') continue;
+      if (serverKeys.canUseModelSync(model)) return model;
+    }
+  }
+
+  for (const provider of API_PROVIDERS) {
+    if (provider === 'openRouter') continue;
+    const model = SETUP_MODEL_BY_PROVIDER[provider];
+    if (!model) continue;
+    if (isNonEmptyString(await lookupApiKey(secrets, provider))) {
+      return model;
+    }
+  }
+
+  return null;
+}
 
 /**
  * Pick a model the setup agent can actually call given the user's current
@@ -52,37 +97,13 @@ export async function resolveDesktopSetupModel(): Promise<string | null> {
     return null;
   }
 
-  if (await isCodexSubscriptionActive(CHATGPT_SETUP_MODEL)) {
-    return CHATGPT_SETUP_MODEL;
-  }
-
-  const serverKeys = getServerSideKeyService();
-  if (await serverKeys.canUseServerSideKeysForModel(DEFAULT_AGENT_MODEL)) {
-    return DEFAULT_AGENT_MODEL;
-  }
-  if (await serverKeys.canUseServerSideKeys()) {
-    for (const [provider, model] of Object.entries(SETUP_MODEL_BY_PROVIDER)) {
-      if (provider === 'openRouter') continue;
-      if (serverKeys.canUseModelSync(model)) return model;
-    }
-  }
-
-  for (const provider of API_PROVIDERS) {
-    if (provider === 'openRouter') continue;
-    const model = SETUP_MODEL_BY_PROVIDER[provider];
-    if (!model) continue;
-    if (isNonEmptyString(await lookupApiKey(secrets, provider))) {
-      return model;
-    }
-  }
-
   // OpenRouter is only a valid pick when `useOpenRouter` routing is on (handled
-  // at the top). A bare OpenRouter key with the flag off can't be used: the
-  // desktop launch passes only a model string to `handleExecute` and never flips
-  // the routing flag, so an OR model would run unrouted and fail at inference.
-  // Refuse instead (the caller surfaces "no runnable model"); the user enables
-  // OpenRouter routing or adds a directly-usable key.
-  return null;
+  // above). A bare OpenRouter key with the flag off can't be used: the desktop
+  // launch passes only a model string to `handleExecute` and never flips the
+  // routing flag, so an OR model would run unrouted and fail at inference.
+  // `resolveSetupModelFromDirectCredentials` already skips the `openRouter`
+  // entry, so it naturally refuses instead of picking a doomed model.
+  return resolveSetupModelFromDirectCredentials(secrets);
 }
 
 /**

--- a/src/test-kernel/controllers/SetupLaunch.vitest.ts
+++ b/src/test-kernel/controllers/SetupLaunch.vitest.ts
@@ -14,7 +14,10 @@ const mocks = vi.hoisted(() => ({
   canUseServerSideKeys: vi.fn<() => Promise<boolean>>(),
   canUseServerSideKeysForModel: vi.fn<() => Promise<boolean>>(),
   canUseModelSync: vi.fn<(model: string) => boolean>(),
-  lookupApiKey: vi.fn<(secrets: unknown, provider: string) => Promise<string | undefined>>(),
+  lookupApiKey:
+    vi.fn<
+      (secrets: unknown, provider: string) => Promise<string | undefined>
+    >(),
   getUseOpenRouter: vi.fn<() => boolean>(),
 }));
 
@@ -43,10 +46,8 @@ vi.mock('@utils/config/providerConfig', () => ({
   getUseOpenRouter: mocks.getUseOpenRouter,
 }));
 
-const {
-  resolveSetupModelFromDirectCredentials,
-  resolveDesktopSetupModel,
-} = await import('@controllers/onboarding/setupLaunch');
+const { resolveSetupModelFromDirectCredentials, resolveDesktopSetupModel } =
+  await import('@controllers/onboarding/setupLaunch');
 
 describe('resolveSetupModelFromDirectCredentials', () => {
   beforeEach(() => {
@@ -63,9 +64,9 @@ describe('resolveSetupModelFromDirectCredentials', () => {
     mocks.canUseServerSideKeysForModel.mockResolvedValue(true);
     mocks.lookupApiKey.mockResolvedValue('sk-test');
 
-    await expect(resolveSetupModelFromDirectCredentials({} as never)).resolves.toBe(
-      'gpt55',
-    );
+    await expect(
+      resolveSetupModelFromDirectCredentials({} as never),
+    ).resolves.toBe('gpt55');
   });
 
   it('falls back to the default agent model when server-side keys cover it', async () => {
@@ -81,9 +82,9 @@ describe('resolveSetupModelFromDirectCredentials', () => {
     mocks.canUseServerSideKeys.mockResolvedValue(true);
     mocks.canUseModelSync.mockImplementation((model) => model === 'gemini31p');
 
-    await expect(resolveSetupModelFromDirectCredentials({} as never)).resolves.toBe(
-      'gemini31p',
-    );
+    await expect(
+      resolveSetupModelFromDirectCredentials({} as never),
+    ).resolves.toBe('gemini31p');
   });
 
   it('skips the openRouter entry when scanning per-provider server-side models', async () => {
@@ -102,9 +103,9 @@ describe('resolveSetupModelFromDirectCredentials', () => {
       provider === 'anthropic' ? 'sk-ant-test' : undefined,
     );
 
-    await expect(resolveSetupModelFromDirectCredentials({} as never)).resolves.toBe(
-      'opus48T',
-    );
+    await expect(
+      resolveSetupModelFromDirectCredentials({} as never),
+    ).resolves.toBe('opus48T');
     expect(mocks.lookupApiKey).not.toHaveBeenCalledWith(
       expect.anything(),
       'openRouter',

--- a/src/test-kernel/controllers/SetupLaunch.vitest.ts
+++ b/src/test-kernel/controllers/SetupLaunch.vitest.ts
@@ -1,7 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import {
+  CHATGPT_SETUP_MODEL,
+  SETUP_MODEL_BY_PROVIDER,
+} from '@model/setupModelDefaults';
+import { DEFAULT_AGENT_MODEL } from '@shared/constants/providers';
+
 /**
- * `resolveSetupModelFromDirectCredentials` is the credential-priority core
+ * `resolveSetupModelExcludingOpenRouter` is the credential-priority core
  * shared by the VS Code extension (`resolveLaunchModel`) and desktop
  * (`resolveDesktopSetupModel`) setup-launch paths. Exercising it directly
  * guards the priority order (ChatGPT subscription > server-side default >
@@ -12,7 +18,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   isCodexSubscriptionActive: vi.fn<() => Promise<boolean>>(),
   canUseServerSideKeys: vi.fn<() => Promise<boolean>>(),
-  canUseServerSideKeysForModel: vi.fn<() => Promise<boolean>>(),
+  canUseServerSideKeysForModel: vi.fn<(model: string) => Promise<boolean>>(),
   canUseModelSync: vi.fn<(model: string) => boolean>(),
   lookupApiKey:
     vi.fn<
@@ -46,10 +52,10 @@ vi.mock('@utils/config/providerConfig', () => ({
   getUseOpenRouter: mocks.getUseOpenRouter,
 }));
 
-const { resolveSetupModelFromDirectCredentials, resolveDesktopSetupModel } =
+const { resolveSetupModelExcludingOpenRouter, resolveDesktopSetupModel } =
   await import('@controllers/onboarding/setupLaunch');
 
-describe('resolveSetupModelFromDirectCredentials', () => {
+describe('resolveSetupModelExcludingOpenRouter', () => {
   beforeEach(() => {
     mocks.isCodexSubscriptionActive.mockReset().mockResolvedValue(false);
     mocks.canUseServerSideKeys.mockReset().mockResolvedValue(false);
@@ -65,36 +71,43 @@ describe('resolveSetupModelFromDirectCredentials', () => {
     mocks.lookupApiKey.mockResolvedValue('sk-test');
 
     await expect(
-      resolveSetupModelFromDirectCredentials({} as never),
-    ).resolves.toBe('gpt55');
+      resolveSetupModelExcludingOpenRouter({} as never),
+    ).resolves.toBe(CHATGPT_SETUP_MODEL);
   });
 
   it('falls back to the default agent model when server-side keys cover it', async () => {
     mocks.canUseServerSideKeysForModel.mockResolvedValue(true);
 
-    const model = await resolveSetupModelFromDirectCredentials({} as never);
-    expect(model).toBeTruthy();
-    expect(mocks.canUseServerSideKeysForModel).toHaveBeenCalled();
+    await expect(
+      resolveSetupModelExcludingOpenRouter({} as never),
+    ).resolves.toBe(DEFAULT_AGENT_MODEL);
+    expect(mocks.canUseServerSideKeysForModel).toHaveBeenCalledWith(
+      DEFAULT_AGENT_MODEL,
+    );
   });
 
   it('scans per-provider setup models when the default is out of tier', async () => {
     mocks.canUseServerSideKeysForModel.mockResolvedValue(false);
     mocks.canUseServerSideKeys.mockResolvedValue(true);
-    mocks.canUseModelSync.mockImplementation((model) => model === 'gemini31p');
+    mocks.canUseModelSync.mockImplementation(
+      (model) => model === SETUP_MODEL_BY_PROVIDER.google,
+    );
 
     await expect(
-      resolveSetupModelFromDirectCredentials({} as never),
-    ).resolves.toBe('gemini31p');
+      resolveSetupModelExcludingOpenRouter({} as never),
+    ).resolves.toBe(SETUP_MODEL_BY_PROVIDER.google);
   });
 
   it('skips the openRouter entry when scanning per-provider server-side models', async () => {
     mocks.canUseServerSideKeys.mockResolvedValue(true);
     // Only the openRouter-mapped model would satisfy this — it must never
     // be picked here, since server-side keys route directly, not via OR.
-    mocks.canUseModelSync.mockImplementation((model) => model === 'sonnet46T');
+    mocks.canUseModelSync.mockImplementation(
+      (model) => model === SETUP_MODEL_BY_PROVIDER.openRouter,
+    );
 
     await expect(
-      resolveSetupModelFromDirectCredentials({} as never),
+      resolveSetupModelExcludingOpenRouter({} as never),
     ).resolves.toBeNull();
   });
 
@@ -104,8 +117,8 @@ describe('resolveSetupModelFromDirectCredentials', () => {
     );
 
     await expect(
-      resolveSetupModelFromDirectCredentials({} as never),
-    ).resolves.toBe('opus48T');
+      resolveSetupModelExcludingOpenRouter({} as never),
+    ).resolves.toBe(SETUP_MODEL_BY_PROVIDER.anthropic);
     expect(mocks.lookupApiKey).not.toHaveBeenCalledWith(
       expect.anything(),
       'openRouter',
@@ -114,7 +127,7 @@ describe('resolveSetupModelFromDirectCredentials', () => {
 
   it('returns null when no credential resolves to a runnable model', async () => {
     await expect(
-      resolveSetupModelFromDirectCredentials({} as never),
+      resolveSetupModelExcludingOpenRouter({} as never),
     ).resolves.toBeNull();
   });
 });
@@ -135,7 +148,9 @@ describe('resolveDesktopSetupModel', () => {
       provider === 'openRouter' ? 'or-test' : undefined,
     );
 
-    await expect(resolveDesktopSetupModel()).resolves.toBe('sonnet46T');
+    await expect(resolveDesktopSetupModel()).resolves.toBe(
+      SETUP_MODEL_BY_PROVIDER.openRouter,
+    );
   });
 
   it('refuses launch when the OpenRouter flag is on without a key, without falling back', async () => {
@@ -149,6 +164,8 @@ describe('resolveDesktopSetupModel', () => {
   it('delegates to the shared credential scan when the flag is off', async () => {
     mocks.isCodexSubscriptionActive.mockResolvedValue(true);
 
-    await expect(resolveDesktopSetupModel()).resolves.toBe('gpt55');
+    await expect(resolveDesktopSetupModel()).resolves.toBe(
+      CHATGPT_SETUP_MODEL,
+    );
   });
 });

--- a/src/test-kernel/controllers/SetupLaunch.vitest.ts
+++ b/src/test-kernel/controllers/SetupLaunch.vitest.ts
@@ -164,8 +164,6 @@ describe('resolveDesktopSetupModel', () => {
   it('delegates to the shared credential scan when the flag is off', async () => {
     mocks.isCodexSubscriptionActive.mockResolvedValue(true);
 
-    await expect(resolveDesktopSetupModel()).resolves.toBe(
-      CHATGPT_SETUP_MODEL,
-    );
+    await expect(resolveDesktopSetupModel()).resolves.toBe(CHATGPT_SETUP_MODEL);
   });
 });

--- a/src/test-kernel/controllers/SetupLaunch.vitest.ts
+++ b/src/test-kernel/controllers/SetupLaunch.vitest.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `resolveSetupModelFromDirectCredentials` is the credential-priority core
+ * shared by the VS Code extension (`resolveLaunchModel`) and desktop
+ * (`resolveDesktopSetupModel`) setup-launch paths. Exercising it directly
+ * guards the priority order (ChatGPT subscription > server-side default >
+ * server-side per-provider > direct provider key) against silently
+ * drifting between hosts again.
+ */
+
+const mocks = vi.hoisted(() => ({
+  isCodexSubscriptionActive: vi.fn<() => Promise<boolean>>(),
+  canUseServerSideKeys: vi.fn<() => Promise<boolean>>(),
+  canUseServerSideKeysForModel: vi.fn<() => Promise<boolean>>(),
+  canUseModelSync: vi.fn<(model: string) => boolean>(),
+  lookupApiKey: vi.fn<(secrets: unknown, provider: string) => Promise<string | undefined>>(),
+  getUseOpenRouter: vi.fn<() => boolean>(),
+}));
+
+vi.mock('@auth/codex', () => ({
+  isCodexSubscriptionActive: mocks.isCodexSubscriptionActive,
+}));
+
+vi.mock('@auth/serverKeys', () => ({
+  getServerSideKeyService: () => ({
+    canUseServerSideKeys: mocks.canUseServerSideKeys,
+    canUseServerSideKeysForModel: mocks.canUseServerSideKeysForModel,
+    canUseModelSync: mocks.canUseModelSync,
+  }),
+}));
+
+vi.mock('@model/apiProviders', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@model/apiProviders')>();
+  return { ...actual, lookupApiKey: mocks.lookupApiKey };
+});
+
+vi.mock('@platform/platform', () => ({
+  platform: () => ({ secrets: {} }),
+}));
+
+vi.mock('@utils/config/providerConfig', () => ({
+  getUseOpenRouter: mocks.getUseOpenRouter,
+}));
+
+const {
+  resolveSetupModelFromDirectCredentials,
+  resolveDesktopSetupModel,
+} = await import('@controllers/onboarding/setupLaunch');
+
+describe('resolveSetupModelFromDirectCredentials', () => {
+  beforeEach(() => {
+    mocks.isCodexSubscriptionActive.mockReset().mockResolvedValue(false);
+    mocks.canUseServerSideKeys.mockReset().mockResolvedValue(false);
+    mocks.canUseServerSideKeysForModel.mockReset().mockResolvedValue(false);
+    mocks.canUseModelSync.mockReset().mockReturnValue(false);
+    mocks.lookupApiKey.mockReset().mockResolvedValue(undefined);
+    mocks.getUseOpenRouter.mockReset().mockReturnValue(false);
+  });
+
+  it('prefers an active ChatGPT subscription over every other credential', async () => {
+    mocks.isCodexSubscriptionActive.mockResolvedValue(true);
+    mocks.canUseServerSideKeysForModel.mockResolvedValue(true);
+    mocks.lookupApiKey.mockResolvedValue('sk-test');
+
+    await expect(resolveSetupModelFromDirectCredentials({} as never)).resolves.toBe(
+      'gpt55',
+    );
+  });
+
+  it('falls back to the default agent model when server-side keys cover it', async () => {
+    mocks.canUseServerSideKeysForModel.mockResolvedValue(true);
+
+    const model = await resolveSetupModelFromDirectCredentials({} as never);
+    expect(model).toBeTruthy();
+    expect(mocks.canUseServerSideKeysForModel).toHaveBeenCalled();
+  });
+
+  it('scans per-provider setup models when the default is out of tier', async () => {
+    mocks.canUseServerSideKeysForModel.mockResolvedValue(false);
+    mocks.canUseServerSideKeys.mockResolvedValue(true);
+    mocks.canUseModelSync.mockImplementation((model) => model === 'gemini31p');
+
+    await expect(resolveSetupModelFromDirectCredentials({} as never)).resolves.toBe(
+      'gemini31p',
+    );
+  });
+
+  it('skips the openRouter entry when scanning per-provider server-side models', async () => {
+    mocks.canUseServerSideKeys.mockResolvedValue(true);
+    // Only the openRouter-mapped model would satisfy this — it must never
+    // be picked here, since server-side keys route directly, not via OR.
+    mocks.canUseModelSync.mockImplementation((model) => model === 'sonnet46T');
+
+    await expect(
+      resolveSetupModelFromDirectCredentials({} as never),
+    ).resolves.toBeNull();
+  });
+
+  it('falls back to a direct provider API key, skipping openRouter', async () => {
+    mocks.lookupApiKey.mockImplementation(async (_secrets, provider) =>
+      provider === 'anthropic' ? 'sk-ant-test' : undefined,
+    );
+
+    await expect(resolveSetupModelFromDirectCredentials({} as never)).resolves.toBe(
+      'opus48T',
+    );
+    expect(mocks.lookupApiKey).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'openRouter',
+    );
+  });
+
+  it('returns null when no credential resolves to a runnable model', async () => {
+    await expect(
+      resolveSetupModelFromDirectCredentials({} as never),
+    ).resolves.toBeNull();
+  });
+});
+
+describe('resolveDesktopSetupModel', () => {
+  beforeEach(() => {
+    mocks.isCodexSubscriptionActive.mockReset().mockResolvedValue(false);
+    mocks.canUseServerSideKeys.mockReset().mockResolvedValue(false);
+    mocks.canUseServerSideKeysForModel.mockReset().mockResolvedValue(false);
+    mocks.canUseModelSync.mockReset().mockReturnValue(false);
+    mocks.lookupApiKey.mockReset().mockResolvedValue(undefined);
+    mocks.getUseOpenRouter.mockReset().mockReturnValue(false);
+  });
+
+  it('routes through OpenRouter only when the flag is on and a key exists', async () => {
+    mocks.getUseOpenRouter.mockReturnValue(true);
+    mocks.lookupApiKey.mockImplementation(async (_secrets, provider) =>
+      provider === 'openRouter' ? 'or-test' : undefined,
+    );
+
+    await expect(resolveDesktopSetupModel()).resolves.toBe('sonnet46T');
+  });
+
+  it('refuses launch when the OpenRouter flag is on without a key, without falling back', async () => {
+    mocks.getUseOpenRouter.mockReturnValue(true);
+    mocks.isCodexSubscriptionActive.mockResolvedValue(true);
+
+    await expect(resolveDesktopSetupModel()).resolves.toBeNull();
+    expect(mocks.isCodexSubscriptionActive).not.toHaveBeenCalled();
+  });
+
+  it('delegates to the shared credential scan when the flag is off', async () => {
+    mocks.isCodexSubscriptionActive.mockResolvedValue(true);
+
+    await expect(resolveDesktopSetupModel()).resolves.toBe('gpt55');
+  });
+});


### PR DESCRIPTION
## Summary

This was found during a codebase-wide sweep for overlapping/duplicated responsibilities (see full findings list below). The most significant hit: `resolveLaunchModel` (VS Code extension, `setupAssistantCommand.ts`) and `resolveDesktopSetupModel` (desktop, `src/controllers/onboarding/setupLaunch.ts`) independently implemented the *identical* multi-step credential-priority algorithm for picking which model the setup assistant should launch with — ChatGPT/Codex subscription → server-side keys for the default model → server-side keys per-provider → direct provider API key. `setupLaunch.ts`'s own doc comment already flagged this as an intentional mirror ("Mirrors the extension's `resolveLaunchModel`"), which is a tell that the logic should live in one place instead of two that must be kept in sync by hand.

This PR extracts that shared priority scan into `resolveSetupModelExcludingOpenRouter()` in `src/controllers/onboarding/setupLaunch.ts` (already a host-neutral module) and has both the extension and desktop call it, layering only their host-specific OpenRouter-flag handling on top (the extension can interactively flip the flag; desktop can't, so it only routes through OpenRouter when the flag is already on and a key exists). The function is named for what it excludes — OpenRouter routing — since it covers more than just direct secret lookups (ChatGPT subscription and server-side keys too); it was renamed from an earlier, narrower `resolveSetupModelFromDirectCredentials` during review.

No behavior change intended — verified line-by-line that `SecretManager.hasUsableApiKey(provider)` (extension) and `isNonEmptyString(await lookupApiKey(secrets, provider))` (desktop) are literally the same call, and `SecretManager.API_PROVIDERS` is a re-export of `API_PROVIDERS` from `@model/apiProviders`.

## Issue acceptance gates

Ad-hoc audit request: "identify areas with confusing/overlapped responsibilities, document them, and fix the most significant one." Full findings from the audit (three parallel research passes over `src/tools/`, `src/agent/`, and `src/controllers/` vs `packages/extension/src/commands/`):

1. **[Fixed here] Duplicate credential-resolution logic** — `setupAssistantCommand.ts` vs `setupLaunch.ts`, both scanning ChatGPT subscription → server-side keys → direct provider key in the same order. Real drift risk on a security-relevant path (which model/credential a run uses).
2. **[Not fixed — doc-only, lower urgency]** `src/agent/core/README.md`'s dependency diagram says only `BaseFlowServices.ts`/`RetryState.ts` take narrow outside dependencies; in reality every file in `core/flows/` imports value bindings from `@agent/node`, `@agent/trace`, `@agent/modelHandlers`, `@agent/followUp`, `@agent/index`, and `@agent/utils`. The README's exception list undersells how coupled `core/flows/` actually is — worth a follow-up docs pass.
3. **[Not fixed — cosmetic]** `src/tools/executionFormatters.ts` is a single-consumer helper for `ExecutionsTool.ts` sitting at top level next to the `src/tools/executions/` subdirectory that exists for exactly this purpose — looks like it predates that subdirectory.
4. **[Not fixed — partial/nuanced]** CLI's `packages/cli/src/runtime/history.ts` reimplements "shape an execution into a display entry" independently of `src/controllers/settingsView/HistoryMessageBuilder.ts` (shared by extension + desktop); their filtering already diverges (`HistoryMessageBuilder` excludes `category === 'process'` entries, CLI's version doesn't). Worth a shared base builder if the two need to agree on status semantics.
5. **[Not fixed — naming only]** `src/agent/goal/` (prompt-rendering shim) vs `src/tools/goal/` (actual `GoalStore`/state) share the "goal" name across two top-level trees; `src/tools/delegationAgentAvailability.ts` etc. sit outside the `src/tools/delegation/` subdirectory with no doc explaining the public/private split; `approvalGatedTools.ts` (a static allowlist) vs `approval/` (the actual approval flow machinery) read as the same concern from their names alone.

Items 2–5 are naming/documentation confusions or partial duplications with real but smaller blast radius; item 1 was the only one with concrete correctness risk (silent drift in which model gets picked), so it's the one fixed in this PR.

## Single source of truth

`resolveSetupModelExcludingOpenRouter()` in `src/controllers/onboarding/setupLaunch.ts` now owns the ChatGPT-subscription → server-side-keys → direct-provider-key priority order. Both `resolveLaunchModel` (extension) and `resolveDesktopSetupModel` (desktop) call it and only add their own OpenRouter-flag-specific branches around it.

## Duplication and abstraction budget

Removed: ~35 lines of duplicated credential-scan logic from `setupAssistantCommand.ts` (now delegates to the shared function). No new abstraction layer beyond the one function — `setupLaunch.ts` was already the correct host-neutral home, so this consolidates into an existing module rather than adding a new one.

## Host impact

Extension: `resolveLaunchModel` now calls the shared scan instead of duplicating it; behavior unchanged (verified the underlying calls are identical).

Desktop: `resolveDesktopSetupModel` now calls the shared scan for its non-OpenRouter branches instead of inlining them; behavior unchanged.

CLI: not involved in setup-assistant launch; no change.

## Scheduled refactoring

None filed. Findings 2–5 above are candidates for future follow-up but weren't judged significant enough (or safe enough for an unattended change) to bundle into this PR.

## Validation

- `npm run typecheck` — passes (root, `tsconfig.test-kernel.json`, extension, and CLI packages).
- `npx eslint <changed files>` — clean after `--fix` (import-order only).
- `npx vitest run src/test-kernel/controllers/SetupLaunch.vitest.ts` — 9/9 passing, then updated to reflect review feedback (canonical constants, exact-value assertions) — 9/9 still passing.
- `npx vitest run src/test-kernel/commands/setup src/test-kernel/controllers` — 197/197 passing, including the pre-existing `SetupAssistantRouting.vitest.ts`.
- `npm test` (full suite) — 4372/4380 passing; the one failure (`execUtils.vitest.ts` process-group abort test) is unrelated to this change and reproduces on `main` in this sandboxed container (process-group signal delivery quirk), not touched by this diff.
- Addressed all review feedback (Copilot naming/test-constant/assertion-strength comments, claude[bot] doc-wording and import-scoping nits) across follow-up commits; each was independently re-verified by subsequent automated review passes.
