### PR TITLE
Consolidate duplicate logic onto existing shared helpers

### DIFF
--- a/packages/cli/src/chat/tui/history/inputHistory.ts
+++ b/packages/cli/src/chat/tui/history/inputHistory.ts
@@ -7,6 +7,7 @@
 // Local imports - filesystem
 import { z } from 'zod';
 
+import { parseJsonWith } from '@common/parsing/safeParseJson';
 import { GlobalStorageFS } from '@utils/files/storageFS';
 
 const HISTORY_DIR = 'tui';
@@ -33,14 +34,7 @@ export interface InputHistory {
 }
 
 function parseRecord(raw: string): HistoryRecord | undefined {
-  let obj: unknown;
-  try {
-    obj = JSON.parse(raw);
-  } catch {
-    // ignore malformed line
-    return undefined;
-  }
-  return HistoryRecordSchema.optional().catch(undefined).parse(obj);
+  return parseJsonWith(raw, HistoryRecordSchema).unwrapOr(undefined);
 }
 
 /** Serialise the in-memory ring back to JSONL. Records keep their original

--- a/packages/cli/src/runtime/browser.ts
+++ b/packages/cli/src/runtime/browser.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcess } from 'node:child_process';
 
-import { toErrorMessage } from '@common/errors';
+import { extractErrorMessage } from '@common/errors';
 
 export interface BrowserLaunchCommand {
   readonly command: string;
@@ -67,9 +67,7 @@ function launchBrowser(url: string): Promise<void> {
 
     function rejectBrowserLaunch(error: unknown): void {
       const message =
-        error instanceof Error
-          ? toErrorMessage(error)
-          : 'unknown browser launch error';
+        extractErrorMessage(error) ?? 'unknown browser launch error';
       reject(new Error(`Could not open the browser automatically: ${message}`));
     }
   });
@@ -82,9 +80,7 @@ export function openBrowser(
 ): Promise<void> {
   return launchBrowser(url).catch((error: unknown) => {
     const message =
-      error instanceof Error
-        ? toErrorMessage(error)
-        : 'unknown browser launch error';
+      extractErrorMessage(error) ?? 'unknown browser launch error';
     log?.debug('cli-auth', message);
     throw new Error(
       `${message}. Run ${manualBrowserHint} to open the sign-in URL manually.`,

--- a/packages/cli/src/runtime/cliConfig.ts
+++ b/packages/cli/src/runtime/cliConfig.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import { workspaceTexraConfigPath } from '@platform/defaults/nodeStorage';
 import { isFileNotFoundError } from '@common/errors';
 import { toErrorMessage } from '@common/errors/errorMessage';
+import { safeParseJson } from '@common/parsing/safeParseJson';
 import { configKeyVariants } from '@shared/config/configKeys';
 import { isObject } from '@utils/core/typeGuards';
 
@@ -252,16 +253,17 @@ export async function loadWorkspaceCliConfig(
     };
   }
 
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch (error) {
+  const parseResult = safeParseJson(raw);
+  if (parseResult.isErr()) {
     return {
       path: filePath,
       values: {},
-      warnings: [`Could not parse ${filePath}: ${toErrorMessage(error)}`],
+      warnings: [
+        `Could not parse ${filePath}: ${toErrorMessage(parseResult.error)}`,
+      ],
     };
   }
+  const parsed = parseResult.value;
 
   if (!isObject(parsed)) {
     return {

--- a/packages/cli/src/runtime/history/generatedFiles.ts
+++ b/packages/cli/src/runtime/history/generatedFiles.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import { listExecutionWorkspaceFiles } from '@agent/storage';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { isFileNotFoundError } from '@common/errors';
+import { safeParseJson } from '@common/parsing/safeParseJson';
 import type { ExecutionId } from '@shared/schemas';
 import { StorageFS } from '@utils/files';
 import { byStringProp } from '@utils/core/comparators';
@@ -173,12 +174,8 @@ function parseToolArguments(
 ): Record<string, unknown> | undefined {
   if (isObject(argumentsValue)) return argumentsValue;
   if (typeof argumentsValue !== 'string') return undefined;
-  try {
-    const parsed: unknown = JSON.parse(argumentsValue);
-    return isObject(parsed) ? parsed : undefined;
-  } catch {
-    return undefined;
-  }
+  const parsed = safeParseJson(argumentsValue).unwrapOr(undefined);
+  return isObject(parsed) ? parsed : undefined;
 }
 
 export function mergeHistoryFiles(

--- a/packages/cli/src/runtime/supabaseAuthCallbackServer.ts
+++ b/packages/cli/src/runtime/supabaseAuthCallbackServer.ts
@@ -16,6 +16,7 @@ import {
   type SupabaseSessionCoordinator,
 } from '@auth/SupabaseSession';
 import { toErrorMessage } from '@common/errors/errorMessage';
+import { parseJsonWith } from '@common/parsing/safeParseJson';
 import { escapeHtml } from '@shared/utils/xmlEscape';
 
 const LOOPBACK_HOST = '127.0.0.1';
@@ -191,24 +192,16 @@ function parseCallbackBody(rawBody: string): {
   fragment?: string;
   nonce?: string;
 } {
-  let json: unknown;
-  try {
-    json = JSON.parse(rawBody);
-  } catch {
-    throw new RecoverableCallbackRequestError(
-      'Authentication callback request was malformed.',
-    );
-  }
-  const parsed = CallbackBodySchema.safeParse(json);
-  if (!parsed.success) {
+  const parsed = parseJsonWith(rawBody, CallbackBodySchema);
+  if (parsed.isErr()) {
     throw new RecoverableCallbackRequestError(
       'Authentication callback request was malformed.',
     );
   }
   return {
-    query: parsed.data.query ?? undefined,
-    fragment: parsed.data.fragment ?? undefined,
-    nonce: parsed.data.nonce ?? undefined,
+    query: parsed.value.query ?? undefined,
+    fragment: parsed.value.fragment ?? undefined,
+    nonce: parsed.value.nonce ?? undefined,
   };
 }
 

--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -4,6 +4,8 @@ import { fileURLToPath } from 'node:url';
 import { gt as semverGt, valid as semverValid } from 'semver';
 import { z } from 'zod';
 
+import { parseJsonWith } from '@common/parsing/safeParseJson';
+
 import {
   cliEnvValue,
   readCliAmbientState,
@@ -140,14 +142,9 @@ export async function fetchLatestCliVersion(options?: {
 }): Promise<string | undefined> {
   const registry = options?.registry ?? DEFAULT_REGISTRY;
   const fetchImpl = options?.fetchImpl ?? fetch;
-  const controller = new AbortController();
-  const timer = setTimeout(
-    () => controller.abort(),
-    options?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-  );
   try {
     const response = await fetchImpl(`${registry}/${CLI_PACKAGE_NAME}/latest`, {
-      signal: controller.signal,
+      signal: AbortSignal.timeout(options?.timeoutMs ?? DEFAULT_TIMEOUT_MS),
       headers: { accept: 'application/json' },
     });
     if (!response.ok) return undefined;
@@ -155,8 +152,6 @@ export async function fetchLatestCliVersion(options?: {
     return typeof body.version === 'string' ? body.version : undefined;
   } catch {
     return undefined;
-  } finally {
-    clearTimeout(timer);
   }
 }
 
@@ -221,15 +216,9 @@ function parseHomebrewFormulaVersion(
   stdout: string,
   formula = CLI_HOMEBREW_FORMULA,
 ): string | undefined {
-  let raw: unknown;
-  try {
-    raw = JSON.parse(stdout);
-  } catch {
-    return undefined;
-  }
-  const parsed = HomebrewInfoSchema.safeParse(raw);
-  if (!parsed.success) return undefined;
-  const entry = parsed.data.formulae?.find((f) => f?.name === formula);
+  const parsed = parseJsonWith(stdout, HomebrewInfoSchema);
+  if (parsed.isErr()) return undefined;
+  const entry = parsed.value.formulae?.find((f) => f?.name === formula);
   return entry?.versions?.stable ?? undefined;
 }
 

--- a/packages/extension/src/frontend/agents/remoteAgentUtils.ts
+++ b/packages/extension/src/frontend/agents/remoteAgentUtils.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 
 import { createKey, getAgent, type AgentSource } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import { toErrorMessage } from '@common/errors';
+import { extractErrorMessage } from '@common/errors';
 import { getMainWebview } from '@frontend/system/commandUtils';
 import * as logger from '@logger/logUtils';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
@@ -80,8 +80,7 @@ export async function selectAgentInMainView(
       message: `Agent "${agentName}" selected successfully`,
     };
   } catch (error) {
-    const errorMessage =
-      error instanceof Error ? toErrorMessage(error) : 'Unknown error';
+    const errorMessage = extractErrorMessage(error) ?? 'Unknown error';
     logger.error(CHANNEL, `Failed to select agent: ${errorMessage}`);
     return handleFallback(
       agentName,

--- a/packages/extension/src/progressView/frontend/components/TexraDiffView.ts
+++ b/packages/extension/src/progressView/frontend/components/TexraDiffView.ts
@@ -4,7 +4,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { consume } from '@lit/context';
 
 // Local imports - errors
-import { toErrorMessage } from '@common/errors';
+import { extractErrorMessage } from '@common/errors';
 
 // Local imports - shared modules
 import { themeContext } from '@shared/BaseWebviewApp';
@@ -231,9 +231,7 @@ export class TexraDiffView extends LitElement {
       this.observeResize(container);
     } catch (error) {
       this.errorMessage =
-        error instanceof Error
-          ? toErrorMessage(error)
-          : 'Failed to load diff editor.';
+        extractErrorMessage(error) ?? 'Failed to load diff editor.';
     } finally {
       if (generation === this.loadGeneration) this.loading = false;
     }

--- a/packages/extension/src/progressView/frontend/utils/boundedIdSet.ts
+++ b/packages/extension/src/progressView/frontend/utils/boundedIdSet.ts
@@ -1,8 +1,10 @@
+import { LRUCache } from 'lru-cache';
+
 /**
- * A Set<string> capped at a maximum size, evicting the oldest entry (in
- * insertion order) once the cap is exceeded. Used to bound "seen id" guards
- * (out-of-order message guards, resolved-id tracking) that would otherwise
- * grow unbounded over a long-running webview session.
+ * A Set<string> capped at a maximum size, evicting the oldest entry once the
+ * cap is exceeded. Used to bound "seen id" guards (out-of-order message
+ * guards, resolved-id tracking) that would otherwise grow unbounded over a
+ * long-running webview session.
  */
 export interface BoundedIdSet {
   has(id: string): boolean;
@@ -12,18 +14,14 @@ export interface BoundedIdSet {
 }
 
 export function createBoundedIdSet(cap: number): BoundedIdSet {
-  const ids = new Set<string>();
+  const ids = new LRUCache<string, true>({ max: cap });
   return {
     has: (id) => ids.has(id),
     delete: (id) => ids.delete(id),
     clear: () => ids.clear(),
-    add(id) {
-      ids.add(id);
-      if (ids.size > cap) {
-        // Set iteration order is insertion order — first value is oldest
-        const oldest = ids.values().next().value;
-        if (oldest !== undefined) ids.delete(oldest);
-      }
+    add: (id) => {
+      if (ids.has(id)) return;
+      ids.set(id, true);
     },
   };
 }

--- a/packages/extension/src/settingsView/frontend/components/history/SearchBar.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/SearchBar.ts
@@ -9,9 +9,14 @@ import { commonViewStyles, designTokens } from '@shared/styles';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
 import { historyStyles } from '@shared/styles/historyStyles';
 
+// Local imports - utils
+import { debounce } from '@utils/core';
+
 // Local imports - history view events
 import { HistoryViewEvents } from './events';
 import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
+
+const SEARCH_DEBOUNCE_MS = 300;
 
 @customElement('history-search-bar')
 export class SearchBar extends LitElement {
@@ -21,25 +26,19 @@ export class SearchBar extends LitElement {
   @property({ attribute: false }) matchCount = '';
   @property({ type: Boolean, attribute: false }) canClearHistory = false;
 
-  private searchTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  private readonly debouncedDispatchSearch = debounce((term: string) => {
+    this.dispatchEvent(HistoryViewEvents.searchChange({ term }));
+  }, SEARCH_DEBOUNCE_MS);
 
   override disconnectedCallback(): void {
-    if (this.searchTimeoutId) {
-      clearTimeout(this.searchTimeoutId);
-      this.searchTimeoutId = null;
-    }
+    this.debouncedDispatchSearch.cancel();
     super.disconnectedCallback();
   }
 
   private handleInput(event: Event): void {
     const target = event.currentTarget as WaInput | null;
     const term = target?.value?.trim() ?? '';
-    if (this.searchTimeoutId) {
-      clearTimeout(this.searchTimeoutId);
-    }
-    this.searchTimeoutId = setTimeout(() => {
-      this.dispatchEvent(HistoryViewEvents.searchChange({ term }));
-    }, 300);
+    void this.debouncedDispatchSearch(term);
   }
 
   private handleNext(): void {

--- a/src/common/errors/sdkError/errorInspection.ts
+++ b/src/common/errors/sdkError/errorInspection.ts
@@ -1,4 +1,5 @@
 import { getReasonPhrase } from 'http-status-codes';
+import { safeParseJson } from '@common/parsing/safeParseJson';
 import { isObject, isString } from '@utils/core';
 
 import { pickStatus } from './sdkErrorKinds';
@@ -203,11 +204,7 @@ export function detectRawErrorBody(err: unknown): unknown {
 
   // Google GenAI SDK may embed JSON in the error message
   if (candidate.message && candidate.message.startsWith('{')) {
-    try {
-      return JSON.parse(candidate.message);
-    } catch {
-      // Not valid JSON, ignore
-    }
+    return safeParseJson(candidate.message).unwrapOr(undefined);
   }
 
   return undefined;

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -179,6 +179,23 @@ describe('CLI run progress renderer', () => {
     expect(output.endsWith('\r\x1b[2K')).toBe(true);
   });
 
+  it('keeps long elapsed times in minute-second form', () => {
+    let now = 0;
+    let output = '';
+    const renderer = createRunProgressRenderer(context(), {
+      colorEnabled: true,
+      write: (text) => {
+        output += text;
+      },
+      nowMs: () => now,
+    });
+
+    now = 3_600_000;
+    renderer?.handle('setTaskState', workflowTaskState());
+
+    expect(output).toContain('\r\x1b[2Kpolish paper.tex · 60m 00s');
+  });
+
   it('ticks the ANSI status line while a root workflow is quiet', () => {
     let now = 0;
     let output = '';

--- a/src/test-kernel/progressView/BoundedIdSet.vitest.ts
+++ b/src/test-kernel/progressView/BoundedIdSet.vitest.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { createBoundedIdSet } from '@progressView/frontend/utils/boundedIdSet';
+
+describe('createBoundedIdSet', () => {
+  it('evicts by first insertion, not by repeated add recency', () => {
+    const ids = createBoundedIdSet(2);
+
+    ids.add('a');
+    ids.add('b');
+    ids.add('a');
+    ids.add('c');
+
+    expect(ids.has('a')).toBe(false);
+    expect(ids.has('b')).toBe(true);
+    expect(ids.has('c')).toBe(true);
+  });
+});

--- a/src/tools/delegation/inputFields.ts
+++ b/src/tools/delegation/inputFields.ts
@@ -6,7 +6,7 @@
 import { z } from 'zod';
 
 // Local imports - logger
-import { toErrorMessage } from '@common/errors';
+import { extractErrorMessage, toErrorMessage } from '@common/errors';
 
 // Local imports - tools
 import type { ToolResult } from '@shared/schemas/toolResult';
@@ -44,10 +44,7 @@ export const memoriesField = z
         ctx.addIssue({
           code: 'custom',
           path: [i],
-          message:
-            e instanceof Error
-              ? toErrorMessage(e)
-              : `Invalid memory path: ${memory}`,
+          message: extractErrorMessage(e) ?? `Invalid memory path: ${memory}`,
         });
       }
     }


### PR DESCRIPTION
## Summary

This PR consolidates small duplicated helper logic where an existing utility or dependency already expresses the same operation:

- Replaces repeated `err instanceof Error ? ...` message extraction with `extractErrorMessage` / `toErrorMessage` from `@common/errors`.
- Replaces repeated `JSON.parse` try/catch blocks in CLI/common code with `safeParseJson` / `parseJsonWith`.
- Uses the shared `debounce` helper in the settings history search bar.
- Backs `boundedIdSet` with `lru-cache` while preserving the previous FIFO eviction contract by not refreshing existing ids on repeated `add`.
- Uses native `AbortSignal.timeout()` in the CLI update checker instead of manual `AbortController` timer wiring.

No new abstraction layer is introduced; the changes route call sites through helpers or dependencies already present in the repository.

## Review Follow-Up

Two review concerns were addressed after rebasing onto `main`:

- `boundedIdSet` keeps first-in eviction semantics. Re-adding an existing id no longer refreshes it, and a regression test covers this case.
- The CLI run-progress elapsed formatter was restored to the previous minute/second rendering contract, including durations above one hour. The attempted shared-duration substitution was removed from this PR.

## Host Impact

Extension: history search debounce, progress-view bounded id tracking, diff-view error display, and remote-agent error normalization only.

CLI: config/history/auth JSON parsing, browser-launch error normalization, and update-check timeout plumbing only. Run-progress elapsed formatting is intentionally unchanged from `main`.

Desktop: no desktop-specific files are changed.

## Validation

- `corepack pnpm exec tsc --noEmit -p tsconfig.json --pretty false`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `corepack pnpm exec eslint` on the touched files
- `corepack pnpm exec vitest run src/test-kernel/cli/RunProgressRenderer.vitest.mts src/test-kernel/progressView/BoundedIdSet.vitest.ts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactors to established helpers; the OAuth callback and bounded-id eviction paths have explicit tests or equivalent error handling, with no new security or data-model changes.
> 
> **Overview**
> This PR replaces ad-hoc **JSON.parse** try/catch blocks and **`instanceof Error` message ternaries** with **`safeParseJson` / `parseJsonWith`** and **`extractErrorMessage`** across CLI runtime, SDK error inspection, and a few extension/tool call sites.
> 
> **CLI & common:** Config loading, TUI input history, history file tool-args parsing, OAuth callback body parsing, and Homebrew version JSON now go through the shared parse helpers. Browser launch errors use **`extractErrorMessage`**. The update checker’s npm fetch uses **`AbortSignal.timeout`** instead of a manual **`AbortController`**.
> 
> **Extension:** History search debouncing uses shared **`debounce`** from **`@utils/core`**. Progress view **`boundedIdSet`** eviction is backed by **`lru-cache`** (with a test that repeated adds do not refresh LRU order). Diff view and remote agent selection use **`extractErrorMessage`** for user-facing errors.
> 
> **Tests:** Adds coverage for bounded-id eviction semantics and for long elapsed times on the CLI run progress line (**`60m 00s`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6879bf5944d6d9149c040493c19940b4ace4535. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->