### PR TITLE
Unify webview and settingsView API key set/remove into one controller

### DIFF
--- a/packages/extension/src/commands/api/apiKeyCommands.ts
+++ b/packages/extension/src/commands/api/apiKeyCommands.ts
@@ -2,11 +2,11 @@
 import * as vscode from 'vscode';
 
 // Local imports
+import { SettingsProfileKeyController } from '@controllers/settingsView/SettingsProfileKeyController';
 import {
   settleQuickInput,
   showQuickPick,
 } from '@commands/_shared/quickInputUtils';
-import { SettingsProfileKeyController } from '@controllers/settingsView/SettingsProfileKeyController';
 import { SecretManager, ApiProvider } from '@frontend/secretManager';
 import { VscodeExternalOpener } from '@frontend/hosts/VscodeExternalOpener';
 import { VscodePromptHost } from '@frontend/hosts/VscodePromptHost';
@@ -20,6 +20,10 @@ import {
   PROVIDER_DISPLAY_NAMES,
   PROVIDER_URLS,
 } from '@shared/constants/providers';
+import {
+  getProviderDisplayName,
+  getProviderKeyUrl,
+} from '@utils/config/providerConfig';
 
 const CHANNEL = 'ApiKeyCommands';
 logger.initialize(CHANNEL);
@@ -46,8 +50,14 @@ function createProfileKeyController(): SettingsProfileKeyController {
     prompt: new VscodePromptHost(),
     externalOpener: new VscodeExternalOpener(),
     getProviderDisplayName: (provider) =>
-      PROVIDER_DISPLAY_NAMES[provider] ?? provider,
-    getProviderKeyUrl: (provider) => PROVIDER_URLS[provider],
+      getProviderDisplayName(
+        provider,
+        PROVIDER_DISPLAY_NAMES[provider] ?? provider,
+      ),
+    getProviderKeyUrl: (provider) => {
+      const defaultUrl = PROVIDER_URLS[provider];
+      return defaultUrl ? getProviderKeyUrl(provider, defaultUrl) : undefined;
+    },
     getApiKeySecretName: (provider) =>
       SecretManager.getApiKeySecretName(provider as ApiProvider),
     setSecret: (key, value) => SecretManager.set(key, value),

--- a/packages/extension/src/commands/api/apiKeyCommands.ts
+++ b/packages/extension/src/commands/api/apiKeyCommands.ts
@@ -6,14 +6,20 @@ import {
   settleQuickInput,
   showQuickPick,
 } from '@commands/_shared/quickInputUtils';
+import { SettingsProfileKeyController } from '@controllers/settingsView/SettingsProfileKeyController';
 import { SecretManager, ApiProvider } from '@frontend/secretManager';
+import { VscodeExternalOpener } from '@frontend/hosts/VscodeExternalOpener';
+import { VscodePromptHost } from '@frontend/hosts/VscodePromptHost';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { getMainWebview } from '@frontend/system/commandUtils';
 import * as logger from '@logger/logUtils';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { invalidateApiKeyCache } from '@model/apiProviders';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
-import { PROVIDER_URLS } from '@shared/constants/providers';
+import {
+  PROVIDER_DISPLAY_NAMES,
+  PROVIDER_URLS,
+} from '@shared/constants/providers';
 
 const CHANNEL = 'ApiKeyCommands';
 logger.initialize(CHANNEL);
@@ -30,6 +36,35 @@ async function refreshApiKeyUI(): Promise<void> {
   await vscode.commands.executeCommand('texra.refreshAllOptions');
 }
 
+/**
+ * Delegates the write/delete/confirm/notify sequence to the same controller
+ * settingsView's Profile tab uses, so the two surfaces can't drift apart on
+ * confirmation prompts or messaging (see SettingsProfileKeyController).
+ */
+function createProfileKeyController(): SettingsProfileKeyController {
+  return new SettingsProfileKeyController({
+    prompt: new VscodePromptHost(),
+    externalOpener: new VscodeExternalOpener(),
+    getProviderDisplayName: (provider) =>
+      PROVIDER_DISPLAY_NAMES[provider] ?? provider,
+    getProviderKeyUrl: (provider) => PROVIDER_URLS[provider],
+    getApiKeySecretName: (provider) =>
+      SecretManager.getApiKeySecretName(provider as ApiProvider),
+    setSecret: (key, value) => SecretManager.set(key, value),
+    deleteSecret: (key) => SecretManager.delete(key),
+    refreshAfterKeyChange: async () => {
+      await refreshApiKeyUI();
+      const view = await getMainWebview();
+      const anyKeyExists = await SecretManager.anyApiKeyExists();
+      view?.webview.postMessage({
+        command: anyKeyExists
+          ? MAIN_VIEW_COMMANDS.HIDE_API_KEY_BANNER
+          : MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER,
+      });
+    },
+  });
+}
+
 async function setApiKeyForProvider(
   provider: ApiProvider,
   showNavigationFallback = false,
@@ -41,16 +76,7 @@ async function setApiKeyForProvider(
   }
 
   try {
-    await SecretManager.set(
-      SecretManager.getApiKeySecretName(provider),
-      apiKey,
-    );
-    vscode.window.showInformationMessage(`${provider} API key has been set`);
-    await refreshApiKeyUI();
-    const view = await getMainWebview();
-    view?.webview.postMessage({
-      command: MAIN_VIEW_COMMANDS.HIDE_API_KEY_BANNER,
-    });
+    await createProfileKeyController().commitProviderKey(provider, apiKey);
   } catch (err) {
     await showLoggedErrorMessage(
       CHANNEL,
@@ -164,27 +190,8 @@ export async function removeApiKey(): Promise<void> {
     return;
   }
 
-  const confirm = await vscode.window.showWarningMessage(
-    `Remove the ${provider} API key? This cannot be undone.`,
-    'Remove',
-    'Cancel',
-  );
-  if (confirm !== 'Remove') {
-    return;
-  }
-
   try {
-    await SecretManager.delete(SecretManager.getApiKeySecretName(provider));
-    vscode.window.showInformationMessage(
-      `${provider} API key has been removed`,
-    );
-    await refreshApiKeyUI();
-    const view = await getMainWebview();
-    view?.webview.postMessage({
-      command: (await SecretManager.anyApiKeyExists())
-        ? MAIN_VIEW_COMMANDS.HIDE_API_KEY_BANNER
-        : MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER,
-    });
+    await createProfileKeyController().removeProviderKey(provider);
   } catch (err) {
     await showLoggedErrorMessage(
       CHANNEL,

--- a/src/controllers/settingsView/SettingsProfileKeyController.ts
+++ b/src/controllers/settingsView/SettingsProfileKeyController.ts
@@ -2,7 +2,7 @@
 import type { ExternalOpener, PromptHost } from '@hosts/uiHosts';
 
 export interface SettingsProfileKeyControllerDeps {
-  prompt: Pick<PromptHost, 'input' | 'info'>;
+  prompt: Pick<PromptHost, 'input' | 'info' | 'confirm'>;
   externalOpener: Pick<ExternalOpener, 'openExternal'>;
   getProviderDisplayName(provider: string): string;
   getProviderKeyUrl(provider: string): string | undefined;
@@ -12,6 +12,13 @@ export interface SettingsProfileKeyControllerDeps {
   refreshAfterKeyChange(): Promise<void>;
 }
 
+/**
+ * Canonical "commit/remove a provider key" logic, shared by every surface
+ * that lets a user set or remove an API key (settingsView's Profile tab and
+ * the main webview's API key banner). Each surface injects its own prompt
+ * flow and refresh behavior; the write/delete/confirm/notify sequence lives
+ * here once so it can't drift between surfaces.
+ */
 export class SettingsProfileKeyController {
   constructor(private readonly deps: SettingsProfileKeyControllerDeps) {}
 
@@ -25,6 +32,11 @@ export class SettingsProfileKeyController {
 
     if (!apiKey) return;
 
+    await this.commitProviderKey(provider, apiKey);
+  }
+
+  async commitProviderKey(provider: string, apiKey: string): Promise<void> {
+    const displayName = this.deps.getProviderDisplayName(provider);
     await this.deps.setSecret(this.deps.getApiKeySecretName(provider), apiKey);
     void this.deps.prompt.info(`${displayName} API key has been set`);
     await this.deps.refreshAfterKeyChange();
@@ -32,6 +44,12 @@ export class SettingsProfileKeyController {
 
   async removeProviderKey(provider: string): Promise<void> {
     const displayName = this.deps.getProviderDisplayName(provider);
+    const confirmed = await this.deps.prompt.confirm(
+      `Remove the ${displayName} API key? This cannot be undone.`,
+      { confirmLabel: 'Remove', cancelLabel: 'Cancel' },
+    );
+    if (!confirmed) return;
+
     await this.deps.deleteSecret(this.deps.getApiKeySecretName(provider));
     void this.deps.prompt.info(`${displayName} API key has been removed`);
     await this.deps.refreshAfterKeyChange();

--- a/src/controllers/settingsView/SettingsProfileKeyController.ts
+++ b/src/controllers/settingsView/SettingsProfileKeyController.ts
@@ -36,6 +36,8 @@ export class SettingsProfileKeyController {
   }
 
   async commitProviderKey(provider: string, apiKey: string): Promise<void> {
+    if (!apiKey) return;
+
     const displayName = this.deps.getProviderDisplayName(provider);
     await this.deps.setSecret(this.deps.getApiKeySecretName(provider), apiKey);
     void this.deps.prompt.info(`${displayName} API key has been set`);
@@ -46,7 +48,7 @@ export class SettingsProfileKeyController {
     const displayName = this.deps.getProviderDisplayName(provider);
     const confirmed = await this.deps.prompt.confirm(
       `Remove the ${displayName} API key? This cannot be undone.`,
-      { confirmLabel: 'Remove', cancelLabel: 'Cancel' },
+      { confirmLabel: 'Remove', cancelLabel: 'Cancel', modal: false },
     );
     if (!confirmed) return;
 

--- a/src/test-kernel/controllers/SettingsProfileKeyController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsProfileKeyController.vitest.ts
@@ -103,6 +103,7 @@ describe('SettingsProfileKeyController', () => {
       hosts.prompt.confirms[0]?.message,
       'Remove the OpenAI API key? This cannot be undone.',
     );
+    assert.equal(hosts.prompt.confirms[0]?.options?.modal, false);
     assert.equal(
       hosts.prompt.messages.at(-1)?.message,
       'OpenAI API key has been removed',
@@ -133,6 +134,16 @@ describe('SettingsProfileKeyController', () => {
       hosts.prompt.messages.at(-1)?.message,
       'OpenAI API key has been set',
     );
+  });
+
+  it('does nothing when committing an empty provider key', async () => {
+    const { controller, secrets, refreshCount, hosts } = createController();
+
+    await controller.commitProviderKey('openai', '');
+
+    assert.equal(secrets.size, 0);
+    assert.equal(refreshCount(), 0);
+    assert.equal(hosts.prompt.messages.length, 0);
   });
 
   it('opens provider key URLs when configured', async () => {

--- a/src/test-kernel/controllers/SettingsProfileKeyController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsProfileKeyController.vitest.ts
@@ -12,6 +12,7 @@ import { createFakeUIHosts } from '../support/FakeHosts';
 
 function createController(options?: {
   inputResponses?: readonly (string | undefined)[];
+  confirmResponses?: readonly boolean[];
   urls?: Record<string, string | undefined>;
   setError?: Error;
   deleteError?: Error;
@@ -24,6 +25,7 @@ function createController(options?: {
 } {
   const hosts = createFakeUIHosts({
     inputResponses: options?.inputResponses,
+    confirmResponses: options?.confirmResponses ?? [true],
   });
   const secrets = new Map<string, string>();
   const deleted: string[] = [];
@@ -90,7 +92,7 @@ describe('SettingsProfileKeyController', () => {
     assert.equal(hosts.prompt.messages.length, 0);
   });
 
-  it('removes provider keys and refreshes dependent state', async () => {
+  it('removes provider keys after confirmation and refreshes dependent state', async () => {
     const { controller, deleted, refreshCount, hosts } = createController();
 
     await controller.removeProviderKey('openai');
@@ -98,8 +100,38 @@ describe('SettingsProfileKeyController', () => {
     assert.deepEqual(deleted, ['openai-secret']);
     assert.equal(refreshCount(), 1);
     assert.equal(
+      hosts.prompt.confirms[0]?.message,
+      'Remove the OpenAI API key? This cannot be undone.',
+    );
+    assert.equal(
       hosts.prompt.messages.at(-1)?.message,
       'OpenAI API key has been removed',
+    );
+  });
+
+  it('does nothing when provider key removal is not confirmed', async () => {
+    const { controller, deleted, refreshCount, hosts } = createController({
+      confirmResponses: [false],
+    });
+
+    await controller.removeProviderKey('openai');
+
+    assert.deepEqual(deleted, []);
+    assert.equal(refreshCount(), 0);
+    assert.equal(hosts.prompt.messages.length, 0);
+  });
+
+  it('commits a provider key without prompting for input', async () => {
+    const { controller, hosts, secrets, refreshCount } = createController();
+
+    await controller.commitProviderKey('openai', 'sk-direct');
+
+    assert.equal(secrets.get('openai-secret'), 'sk-direct');
+    assert.equal(hosts.prompt.inputs.length, 0);
+    assert.equal(refreshCount(), 1);
+    assert.equal(
+      hosts.prompt.messages.at(-1)?.message,
+      'OpenAI API key has been set',
     );
   });
 


### PR DESCRIPTION
## Summary

The main webview's API key banner (`apiKeyCommands.ts`, `texra.setApiKey`/`texra.removeApiKey`) and settingsView's Profile tab (`SettingsProfileKeyController`) each independently reimplemented "set/remove a provider API key." A codebase-wide abstraction-layer review found they had already drifted: removing a key from Settings deleted it immediately, while the webview path warned "This cannot be undone" behind a confirmation dialog first.

## Issue acceptance gates

- Both surfaces show the same confirmation prompt before deleting a provider key. ✅
- Both surfaces show the same success/failure messaging for set and remove. ✅
- No behavior change to the VS Code-specific prompting UI (InputBox "Get API Key" title button, QuickPick provider picker, command-palette fallback). ✅

## Single source of truth

`SettingsProfileKeyController` (`src/controllers/settingsView/SettingsProfileKeyController.ts`, host-neutral) now owns the write/delete/confirm/notify sequence for provider keys. It gained a `commitProviderKey(provider, apiKey)` method (set-secret step without its own prompt, so callers can supply their own key-entry UI) and `removeProviderKey` now confirms via `PromptHost.confirm()` before deleting.

## Duplication and abstraction budget

Removed: `apiKeyCommands.ts` no longer calls `SecretManager.set`/`SecretManager.delete` or shows its own success/confirmation messages directly — it constructs a `SettingsProfileKeyController` (VS Code-specific `PromptHost`/`ExternalOpener` deps) and delegates. No new abstraction layer was introduced; the existing host-neutral controller absorbed the duplicated logic. VS Code-specific UI (title-button InputBox, QuickPick) stays in `apiKeyCommands.ts`, which is a declared VS Code-allowed zone.

## Host impact

Extension: `apiKeyCommands.ts` (webview API key banner, command palette `texra.setApiKey`/`texra.removeApiKey`) now delegates to `SettingsProfileKeyController` instead of duplicating secret read/write and messaging.

Desktop: No change — `SettingsProfileKeyController` remains host-neutral and unaffected desktop wiring is untouched.

CLI: Not applicable.

## Scheduled refactoring

None.

## Validation

- `npx vitest run src/test-kernel/controllers/SettingsProfileKeyController.vitest.ts` — 9/9 passing (added 3 new cases: confirmation message/flow, declined-removal no-op, and `commitProviderKey` without a prompt).
- `npm run typecheck` — passes.


---
_Generated by [Claude Code](https://claude.ai/code/session_016vLPD5wAwvRLy9eHri1uXa)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how API keys are stored and removed across two user-facing entry points; behavior is intentionally aligned but still touches encrypted secret handling and post-change UI refresh.
> 
> **Overview**
> **Unifies provider API key persistence** so the webview/command palette path (`texra.setApiKey` / `texra.removeApiKey`) and the settings Profile tab share one write/delete/confirm/notify flow instead of duplicating `SecretManager` calls and messages.
> 
> `apiKeyCommands.ts` now builds a `SettingsProfileKeyController` with VS Code `PromptHost` / `ExternalOpener` deps and calls **`commitProviderKey`** after its existing InputBox/QuickPick key entry, and **`removeProviderKey`** after provider selection—dropping inline delete confirmation and banner refresh logic in favor of the controller’s **`refreshAfterKeyChange`** hook (still invalidates caches, refreshes commands, and toggles the API key banner).
> 
> **`SettingsProfileKeyController`** gains **`commitProviderKey(provider, apiKey)`** for callers that collect the key elsewhere; **`setProviderKey`** delegates to it. **`removeProviderKey`** now requires **`PromptHost.confirm`** (“Remove …? This cannot be undone.”) before delete, aligning Settings with the webview behavior that had drifted.
> 
> Tests cover confirmation (accept/decline), direct commit, and empty-key no-ops.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f2e23193b374e54e89d35e7a4233dba88591893. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->