### PR TITLE
refactor(agent/modelHandlers): centralize stream-failure envelope

### DIFF
--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -25,8 +25,8 @@ import type { MediaEntry } from '@agent/utils/mediaTypes';
 // Local imports - common
 import {
   attachStreamDiagnostics,
-  attachPartialText,
-  attachFlowAutoRetryRequired,
+  annotateStreamFailure,
+  trackStreamConnect,
   takeTail,
   isUserAbort,
   PARTIAL_TEXT_TAIL_MAX,
@@ -607,11 +607,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
         throw new AnthropicUserAbortError();
       }
 
-      let streamConnected = false;
-      const onConnect = (): void => {
-        streamConnected = true;
-      };
-      stream.on('connect', onConnect);
+      const connect = trackStreamConnect(stream);
 
       let cleanupAbortListener: (() => void) | undefined;
       if (signal) {
@@ -725,17 +721,16 @@ export class ModelHandlerAnthropic extends ModelHandler<
         this.logger.debug(logMessage, logData);
 
         attachStreamDiagnostics(enrichedError, diagnostics);
-        attachPartialText(enrichedError, partialText);
-        if (streamConnected || partialText) {
-          attachFlowAutoRetryRequired(enrichedError);
-        }
+        annotateStreamFailure(
+          enrichedError,
+          partialText,
+          connect.isConnected() || partialText.length > 0,
+        );
         throw enrichedError;
       } finally {
         // Always finalize stream handler to prevent memory leaks on error
         streamHandler.finalize();
-        if (typeof stream.off === 'function') {
-          stream.off('connect', onConnect);
-        }
+        connect.cleanup();
         cleanupAbortListener?.();
       }
     } else {

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -28,7 +28,7 @@ import type { MediaEntry } from '@agent/utils/mediaTypes';
 import { K_SLICE } from '@agent/core/constants';
 import {
   getSdkErrorMessage,
-  attachPartialText,
+  annotateStreamFailure,
   takeTail,
   PARTIAL_TEXT_TAIL_MAX,
 } from '@common/errors/sdkErrorUtils';
@@ -517,12 +517,14 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       // error so the retry UI can show progress and future continuation logic
       // can reference it. Google's SDK has no currentMessage accessor, so we
       // rely on the manually accumulated buffer above.
-      if (aggregatedText) {
-        attachPartialText(
-          error,
-          takeTail(aggregatedText, PARTIAL_TEXT_TAIL_MAX),
-        );
-      }
+      // Google's SDK never reaches the SDK-retry boundary here, so this catch
+      // does not opt into flow-level auto-retry (retryEligible = false); it only
+      // lifts any accumulated tail onto the error for the retry UI.
+      annotateStreamFailure(
+        error,
+        aggregatedText ? takeTail(aggregatedText, PARTIAL_TEXT_TAIL_MAX) : '',
+        false,
+      );
       throw error;
     }
   }

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -18,8 +18,8 @@ import {
   buildErrorLogData,
   getSdkErrorMessage,
   isMissingFinishReasonError,
-  attachPartialText,
-  attachFlowAutoRetryRequired,
+  annotateStreamFailure,
+  trackStreamConnect,
   isUserAbort,
   PARTIAL_TEXT_TAIL_MAX,
 } from '@common/errors/sdkErrorUtils';
@@ -364,10 +364,7 @@ export class ModelHandlerOpenAI<
     const stream = await client.chat.completions.stream(streamParams, {
       signal,
     });
-    let streamConnected = false;
-    const onConnect = (): void => {
-      streamConnected = true;
-    };
+    const connect = trackStreamConnect(stream);
     const streamingAggregator = this.createStreamingAggregator();
 
     const onContentDelta = ({ delta }: ContentDeltaEvent): void => {
@@ -386,12 +383,11 @@ export class ModelHandlerOpenAI<
       }
     };
 
-    stream.on('connect', onConnect);
     stream.on('content.delta', onContentDelta);
     stream.on('chunk', onChunk);
 
     const cleanup = (): void => {
-      stream.off('connect', onConnect);
+      connect.cleanup();
       stream.off('content.delta', onContentDelta);
       stream.off('chunk', onChunk);
     };
@@ -437,12 +433,11 @@ export class ModelHandlerOpenAI<
         stream.currentChatCompletionSnapshot,
         PARTIAL_TEXT_TAIL_MAX,
       );
-      if (partialText) {
-        attachPartialText(streamError, partialText);
-      }
-      if (streamConnected || partialText) {
-        attachFlowAutoRetryRequired(streamError);
-      }
+      annotateStreamFailure(
+        streamError,
+        partialText,
+        connect.isConnected() || partialText.length > 0,
+      );
       const isAbort = isUserAbort(streamError);
       if (!isAbort) {
         this.logger.warn('Stream failed', {

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -23,8 +23,10 @@ import {
   isContextWindowError,
   isPreviousResponseIdError,
   isUserAbort,
-  attachPartialText,
+  annotateStreamFailure,
   attachFlowAutoRetryRequired,
+  trackStreamConnect,
+  type StreamConnectTracker,
   takeTail,
   PARTIAL_TEXT_TAIL_MAX,
 } from '@common/errors/sdkErrorUtils';
@@ -1841,12 +1843,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     // Hoisted so the catch can finalize the progress streams on a mid-stream
     // failure (otherwise the progress view hangs in a loading state).
     let processor: ResponseStreamProcessor | undefined;
-    let streamConnected = false;
     let streamEventObserved = false;
-    const onConnect = (): void => {
-      streamConnected = true;
-    };
-    let removeConnectListener: (() => void) | undefined;
+    let connect: StreamConnectTracker | undefined;
     // Captured from `response.created` so a stream event outside the SDK's
     // typed union (see isUnhandledStreamEventError) can fall back to polling
     // by id instead of failing an otherwise-healthy turn.
@@ -1856,12 +1854,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       const streamParams: ResponseStreamParams = { ...rest, stream: true };
       const retrieveParams = responseRetrieveParamsFor(params);
       const stream = await client.responses.stream(streamParams, { signal });
-      if (typeof stream.on === 'function') {
-        stream.on('connect', onConnect);
-        if (typeof stream.off === 'function') {
-          removeConnectListener = () => stream.off('connect', onConnect);
-        }
-      }
+      connect = trackStreamConnect(stream);
 
       // Processor handles interleaved thinking and web search
       // GPT can: think → web_search → think more → web_search → text
@@ -1982,15 +1975,16 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       processor?.abort();
       // Attach a capped tail of any streamed text before it propagates so the
       // retry UI receives the same structured error shape downstream.
-      if (streamedText) {
-        attachPartialText(error, takeTail(streamedText, PARTIAL_TEXT_TAIL_MAX));
-      }
-      if (streamConnected || streamEventObserved || streamedText) {
-        attachFlowAutoRetryRequired(error);
-      }
+      annotateStreamFailure(
+        error,
+        streamedText ? takeTail(streamedText, PARTIAL_TEXT_TAIL_MAX) : '',
+        (connect?.isConnected() ?? false) ||
+          streamEventObserved ||
+          streamedText.length > 0,
+      );
       throw error;
     } finally {
-      removeConnectListener?.();
+      connect?.cleanup();
     }
   }
 

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -15,8 +15,7 @@ import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import type { MediaEntry } from '@agent/utils/mediaTypes';
 import { K_SLICE } from '@agent/core/constants';
 import {
-  attachPartialText,
-  attachFlowAutoRetryRequired,
+  annotateStreamFailure,
   detectStatusCode,
   takeTail,
   PARTIAL_TEXT_TAIL_MAX,
@@ -282,12 +281,11 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
           aggregator.partialContent,
           PARTIAL_TEXT_TAIL_MAX,
         );
-        if (partialTail) {
-          attachPartialText(err, partialTail);
-        }
-        if (streamConnected || partialTail) {
-          attachFlowAutoRetryRequired(err);
-        }
+        annotateStreamFailure(
+          err,
+          partialTail,
+          streamConnected || partialTail.length > 0,
+        );
         throw err;
       }
     }

--- a/src/common/errors/sdkError/streamFailure.ts
+++ b/src/common/errors/sdkError/streamFailure.ts
@@ -1,0 +1,71 @@
+import { attachFlowAutoRetryRequired, attachPartialText } from './errorMetadata';
+
+/**
+ * Minimal shape of a provider SDK stream that emits a `connect` event once the
+ * HTTP response has begun. The Anthropic (`beta.messages.stream`), OpenAI
+ * (`chat.completions.stream`, `responses.stream`) and OpenRouter streams all
+ * match this surface; `off` is optional because not every stream exposes it.
+ */
+export interface ConnectTrackableStream {
+  on(event: 'connect', listener: () => void): unknown;
+  off?(event: 'connect', listener: () => void): unknown;
+}
+
+export interface StreamConnectTracker {
+  /** True once the stream has emitted its `connect` event. */
+  isConnected(): boolean;
+  /** Removes the `connect` listener; safe to call in a `finally`. */
+  cleanup(): void;
+}
+
+/**
+ * Tracks whether a provider stream reached its `connect` event. The connected
+ * signal distinguishes a pre-response failure (still inside the SDK's own retry
+ * boundary) from a mid-stream failure (which the flow layer must retry itself),
+ * so it feeds the `retryEligible` argument of {@link annotateStreamFailure}.
+ *
+ * Replaces the `let streamConnected = false; const onConnect = …; stream.on(…)`
+ * boilerplate that each streaming handler previously hand-wired.
+ */
+export function trackStreamConnect(
+  stream: ConnectTrackableStream,
+): StreamConnectTracker {
+  let connected = false;
+  const onConnect = (): void => {
+    connected = true;
+  };
+  if (typeof stream.on === 'function') {
+    stream.on('connect', onConnect);
+  }
+  return {
+    isConnected: () => connected,
+    cleanup: () => {
+      if (typeof stream.off === 'function') {
+        stream.off('connect', onConnect);
+      }
+    },
+  };
+}
+
+/**
+ * Annotates a mid-stream failure before it propagates: lifts the partial text
+ * generated before the failure onto the error (so the retry UI can show the
+ * tail) and, when the failure fell outside the SDK's retry boundary, marks it
+ * for flow-level auto-retry.
+ *
+ * `partialTail` may be empty — {@link attachPartialText} no-ops on empty input.
+ * `retryEligible` is the per-provider "did we get far enough to owe a retry"
+ * decision (typically stream-connected OR partial-text-present); keeping it an
+ * explicit argument lets each handler add provider-specific terms (e.g. the
+ * Responses handler's `streamEventObserved`) while the attach policy stays here.
+ */
+export function annotateStreamFailure(
+  err: unknown,
+  partialTail: string,
+  retryEligible: boolean,
+): void {
+  attachPartialText(err, partialTail);
+  if (retryEligible) {
+    attachFlowAutoRetryRequired(err);
+  }
+}

--- a/src/common/errors/sdkError/streamFailure.ts
+++ b/src/common/errors/sdkError/streamFailure.ts
@@ -5,12 +5,17 @@ import {
 
 /**
  * Minimal shape of a provider SDK stream that emits a `connect` event once the
- * HTTP response has begun. The Anthropic (`beta.messages.stream`), OpenAI
- * (`chat.completions.stream`, `responses.stream`) and OpenRouter streams all
- * match this surface; `off` is optional because not every stream exposes it.
+ * HTTP response has begun. The Anthropic (`beta.messages.stream`) and OpenAI
+ * (`chat.completions.stream`, `responses.stream`) streams match this surface.
+ * OpenRouter is intentionally NOT tracked through here: its SDK emits no
+ * `connect` event, so its handler keeps a manual `streamConnected` flag instead.
+ * Both `on` and `off` are optional so the `typeof … === 'function'` guards in
+ * {@link trackStreamConnect} stay type-consistent: the OpenAI Responses stream
+ * reaches here through a wrapper that may not expose the emitter methods, and
+ * the pre-refactor handler guarded against exactly that.
  */
 export interface ConnectTrackableStream {
-  on(event: 'connect', listener: () => void): unknown;
+  on?(event: 'connect', listener: () => void): unknown;
   off?(event: 'connect', listener: () => void): unknown;
 }
 
@@ -34,8 +39,13 @@ export function trackStreamConnect(
   stream: ConnectTrackableStream,
 ): StreamConnectTracker {
   let connected = false;
+  // `live` gates the flag independently of listener removal: a stream that has
+  // no `off` cannot be detached, so after cleanup a late `connect` event would
+  // otherwise still flip `connected`. Gating keeps the tracker inert once
+  // cleaned up, whether or not the listener could actually be removed.
+  let live = true;
   const onConnect = (): void => {
-    connected = true;
+    if (live) connected = true;
   };
   if (typeof stream.on === 'function') {
     stream.on('connect', onConnect);
@@ -43,6 +53,7 @@ export function trackStreamConnect(
   return {
     isConnected: () => connected,
     cleanup: () => {
+      live = false;
       if (typeof stream.off === 'function') {
         stream.off('connect', onConnect);
       }

--- a/src/common/errors/sdkError/streamFailure.ts
+++ b/src/common/errors/sdkError/streamFailure.ts
@@ -1,4 +1,7 @@
-import { attachFlowAutoRetryRequired, attachPartialText } from './errorMetadata';
+import {
+  attachFlowAutoRetryRequired,
+  attachPartialText,
+} from './errorMetadata';
 
 /**
  * Minimal shape of a provider SDK stream that emits a `connect` event once the

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -16,10 +16,18 @@ export {
   attachSdkErrorMetadata,
   attachStreamDiagnostics,
   attachPartialText,
+  detectPartialText,
   attachFlowAutoRetryRequired,
   requiresFlowAutoRetry,
   attachProviderError,
 } from './sdkError/errorMetadata';
+
+export {
+  type ConnectTrackableStream,
+  type StreamConnectTracker,
+  annotateStreamFailure,
+  trackStreamConnect,
+} from './sdkError/streamFailure';
 
 export { detectStatusCode } from './sdkError/errorInspection';
 

--- a/src/test-kernel/common/StreamFailure.vitest.mts
+++ b/src/test-kernel/common/StreamFailure.vitest.mts
@@ -49,13 +49,17 @@ describe('trackStreamConnect', () => {
     expect(tracker.isConnected()).toBe(false);
   });
 
-  it('tolerates a stream without an off method', () => {
+  it('stays inert after cleanup even when the stream has no off method', () => {
     const listeners: Array<() => void> = [];
     const stream: ConnectTrackableStream = {
       on: (_e, listener) => listeners.push(listener),
     };
     const tracker = trackStreamConnect(stream);
     expect(() => tracker.cleanup()).not.toThrow();
+    // The listener can't be detached, but a late connect event must not flip
+    // the flag once the tracker has been cleaned up.
+    for (const l of listeners) l();
+    expect(tracker.isConnected()).toBe(false);
   });
 });
 

--- a/src/test-kernel/common/StreamFailure.vitest.mts
+++ b/src/test-kernel/common/StreamFailure.vitest.mts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  annotateStreamFailure,
+  detectPartialText,
+  requiresFlowAutoRetry,
+  trackStreamConnect,
+  type ConnectTrackableStream,
+} from '@common/errors/sdkErrorUtils';
+
+/** Minimal fake of a provider stream's `connect` event emitter. */
+function fakeStream(): ConnectTrackableStream & {
+  emitConnect: () => void;
+  offCalls: number;
+} {
+  const listeners: Array<() => void> = [];
+  return {
+    on(_event, listener) {
+      listeners.push(listener);
+    },
+    off(_event, listener) {
+      const i = listeners.indexOf(listener);
+      if (i >= 0) listeners.splice(i, 1);
+      this.offCalls += 1;
+    },
+    emitConnect() {
+      for (const l of listeners) l();
+    },
+    offCalls: 0,
+  };
+}
+
+describe('trackStreamConnect', () => {
+  it('reports connected only after the connect event fires', () => {
+    const stream = fakeStream();
+    const tracker = trackStreamConnect(stream);
+    expect(tracker.isConnected()).toBe(false);
+    stream.emitConnect();
+    expect(tracker.isConnected()).toBe(true);
+  });
+
+  it('cleanup removes the connect listener', () => {
+    const stream = fakeStream();
+    const tracker = trackStreamConnect(stream);
+    tracker.cleanup();
+    expect(stream.offCalls).toBe(1);
+    // A late connect event after cleanup must not flip the flag.
+    stream.emitConnect();
+    expect(tracker.isConnected()).toBe(false);
+  });
+
+  it('tolerates a stream without an off method', () => {
+    const listeners: Array<() => void> = [];
+    const stream: ConnectTrackableStream = {
+      on: (_e, listener) => listeners.push(listener),
+    };
+    const tracker = trackStreamConnect(stream);
+    expect(() => tracker.cleanup()).not.toThrow();
+  });
+});
+
+describe('annotateStreamFailure', () => {
+  it('attaches partial text and marks retry when eligible', () => {
+    const err = new Error('boom');
+    annotateStreamFailure(err, 'partial tail', true);
+    expect(detectPartialText(err)).toBe('partial tail');
+    expect(requiresFlowAutoRetry(err)).toBe(true);
+  });
+
+  it('does not mark retry when ineligible', () => {
+    const err = new Error('boom');
+    annotateStreamFailure(err, 'partial tail', false);
+    expect(detectPartialText(err)).toBe('partial tail');
+    expect(requiresFlowAutoRetry(err)).toBe(false);
+  });
+
+  it('no-ops partial-text attach for an empty tail', () => {
+    const err = new Error('boom');
+    annotateStreamFailure(err, '', true);
+    expect(detectPartialText(err)).toBeUndefined();
+    expect(requiresFlowAutoRetry(err)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Every streaming model handler hand-wired the same two fragments in its streaming path:

1. A `streamConnected` connect-flag listener (`let streamConnected = false; const onConnect = …; stream.on('connect', …)` plus a matching `off` in cleanup), and
2. A failure tail: `attachPartialText(err, tail)` followed by a conditional `attachFlowAutoRetryRequired(err)`.

The retry-eligibility expression behind that second fragment (`streamConnected || partialText`, `streamConnected || streamEventObserved || streamedText`, …) was copy-pasted across five providers with subtly divergent terms — a genuine drift risk, since a change to the "when do we owe a flow-level retry" policy had to be applied five times by hand.

This extracts two small shared helpers and routes all five handlers through them, so the policy lives in one place while each provider keeps only its own inputs.

## Issue acceptance gates

No linked issue — this is a self-contained refactor surfaced by a code-quality audit of the model-handler cluster. No behavior change intended.

## Single source of truth

`src/common/errors/sdkError/streamFailure.ts` now owns the stream-failure envelope:

- `trackStreamConnect(stream)` — owns the `connect`-listener lifecycle (registration + guarded cleanup) and exposes `isConnected()`. Used by the Anthropic, OpenAI chat, and OpenAI Responses streams, which all emit a `connect` event.
- `annotateStreamFailure(err, partialTail, retryEligible)` — owns the policy that a mid-stream failure first gets its partial-text tail lifted onto the error, then is marked for flow-level auto-retry **iff** eligible. `partialTail` may be empty (attach is a no-op); `retryEligible` stays an explicit per-provider argument so each handler contributes its own terms without re-implementing the attach sequence.

`detectPartialText` is re-exported from the `sdkErrorUtils` barrel so tests (and future consumers) can assert on the attached tail.

## Duplication and abstraction budget

Removed: the duplicated connect-flag wiring in 3 handlers and the duplicated `attachPartialText` + conditional `attachFlowAutoRetryRequired` tail in all 5 handlers (net −62 lines at the call sites).

Added: one focused module (two helpers, ~70 lines) plus unit coverage (~83 lines). The abstraction is justified under the repo's factory rules — it is called from 5 sites and owns a real invariant (the attach ordering + retry-eligibility policy), not a pass-through. Provider-specific behavior is deliberately kept at the call site: OpenRouter keeps its manual connect flag (its SDK has no `connect` event), and Google passes `retryEligible = false` (its path never reaches the SDK-retry boundary here).

## Host impact

Extension: none — shared core change; behavior preserved per provider.

Desktop: none — shared core change; behavior preserved per provider.

CLI: none — shared core change; behavior preserved per provider.

## Scheduled refactoring

None. This is one slice of a broader model-handler audit; larger follow-ups (OpenAI-compatible message-construction adapter, over-long `createResponseImpl` decomposition) are noted separately and are not part of this PR.

## Validation

- `npm run typecheck` — passes.
- `npx vitest run src/test-kernel/agent/modelHandlers/ src/test-kernel/common` — 450 passed, 4 skipped (includes the existing `AnthropicStreamFailureLogging` suite and 6 new `StreamFailure` unit tests for the two helpers: connect tracking, cleanup, and the attach/retry policy incl. the empty-tail no-op).
- `npx eslint` on all changed files — clean.
- Rebased onto the current `main` and re-ran typecheck + the suites above (green) before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wRd4fEpANcWWiyNAsb5L4

---
_Generated by [Claude Code](https://claude.ai/code/session_019wRd4fEpANcWWiyNAsb5L4)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches retry UI and flow-level auto-retry metadata on every streaming provider; behavior is intended to be unchanged but mistakes in `retryEligible` would affect when failed streams auto-retry.
> 
> **Overview**
> Streaming model handlers no longer duplicate **connect** listener wiring or the `attachPartialText` + conditional `attachFlowAutoRetryRequired` sequence on mid-stream errors.
> 
> A new `src/common/errors/sdkError/streamFailure.ts` module introduces **`trackStreamConnect`** (register/cleanup `connect`, expose `isConnected()`) and **`annotateStreamFailure`** (attach partial tail, then mark flow auto-retry when `retryEligible`). Anthropic, OpenAI chat, and OpenAI Responses use the connect tracker; all five streaming paths call the annotator with provider-specific `retryEligible` inputs (e.g. Google passes `false`; OpenRouter keeps a manual connect flag; Responses still includes `streamEventObserved`).
> 
> **`sdkErrorUtils`** re-exports the helpers and **`detectPartialText`** for tests. **`StreamFailure.vitest.mts`** adds unit coverage for connect tracking (including post-cleanup late events) and annotate policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 469001eb2f81096ec6653dee206b014e5df41d87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->