### PR TITLE
refactor: tighten data-structure design across schemas and state

### DIFF
--- a/packages/desktop/src/main/desktopExecutionIpc.ts
+++ b/packages/desktop/src/main/desktopExecutionIpc.ts
@@ -1,7 +1,9 @@
 import type { MainViewExecuteMessage } from '@shared/mainView';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc/mainViewCommands';
+import { MainViewInboundMessageSchema } from '@shared/schemas/mainView';
 import {
   createCommandHandler,
+  createDesktopErrorReporter,
   type DesktopMessageHandler,
 } from './desktopIpcTypes.js';
 
@@ -13,10 +15,32 @@ export interface DesktopExecutionIpcOptions {
 export function createDesktopExecutionIpc(
   options: DesktopExecutionIpcOptions = {},
 ): DesktopMessageHandler {
+  const reportAsyncError = createDesktopErrorReporter(options.onAsyncError);
+
   return createCommandHandler(
     {
-      [MAIN_VIEW_COMMANDS.EXECUTE]: (message) =>
-        options.executeAgent?.(message as MainViewExecuteMessage),
+      [MAIN_VIEW_COMMANDS.EXECUTE]: (message) => {
+        // Validate at the IPC boundary against the shared inbound schema
+        // (the same schema desktopShellIpc/desktopProgressIpc/desktopSettingsIpc
+        // parse against) instead of blindly casting untrusted renderer input.
+        const parsed = MainViewInboundMessageSchema.safeParse(message);
+        if (
+          !parsed.success ||
+          parsed.data.command !== MAIN_VIEW_COMMANDS.EXECUTE
+        ) {
+          reportAsyncError(
+            new Error(
+              `Ignoring malformed ${MAIN_VIEW_COMMANDS.EXECUTE} message: ${
+                parsed.success
+                  ? `unexpected command ${String(parsed.data.command)}`
+                  : parsed.error.message
+              }`,
+            ),
+          );
+          return;
+        }
+        return options.executeAgent?.(parsed.data as MainViewExecuteMessage);
+      },
     },
     { onAsyncError: options.onAsyncError },
   );

--- a/packages/extension/src/commands/latex/latexdiffCommands.ts
+++ b/packages/extension/src/commands/latex/latexdiffCommands.ts
@@ -33,7 +33,6 @@ import { CHANNEL, service } from '@latex/latexdiff/service';
 import { runLatexdiffForExecution } from '@latex/latexdiff/runLatexdiff';
 import type { RunLatexdiffCommandConfig } from '@latex/latexdiff/types';
 import * as logger from '@logger/logUtils';
-import { RoundKeySchema } from '@shared/schemas';
 import type { FileLocation, OutputFileInfo } from '@shared/schemas';
 import { LATEX_CONFIG_DEFAULTS } from '@shared/constants/latex';
 import { flexibleFS, pathToLocation } from '@utils/files';
@@ -372,21 +371,10 @@ async function handleRunLatexdiff(
 
     const runId = config.runId ?? undefined;
 
-    let outputsByRound: Map<number, OutputFileInfo[]> | null = null;
-    if (config.outputsByRound) {
-      const roundMap = new Map<number, OutputFileInfo[]>();
-      for (const [roundKey, value] of Object.entries(config.outputsByRound)) {
-        const roundResult = RoundKeySchema.safeParse(roundKey);
-        if (roundResult.success && Array.isArray(value) && value.length > 0) {
-          roundMap.set(roundResult.data, value);
-        }
-      }
-      if (roundMap.size > 0) {
-        outputsByRound = new Map(
-          [...roundMap.entries()].sort((a, b) => a[0] - b[0]),
-        );
-      }
-    }
+    const outputsByRound: Map<number, OutputFileInfo[]> | null = config
+      .outputsByRound?.length
+      ? new Map(config.outputsByRound)
+      : null;
 
     const { outcome } = await vscode.window.withProgress(
       {

--- a/packages/extension/src/commands/latex/latexdiffCommands.ts
+++ b/packages/extension/src/commands/latex/latexdiffCommands.ts
@@ -371,10 +371,20 @@ async function handleRunLatexdiff(
 
     const runId = config.runId ?? undefined;
 
-    const outputsByRound: Map<number, OutputFileInfo[]> | null = config
-      .outputsByRound?.length
-      ? new Map(config.outputsByRound)
-      : null;
+    // `config` arrives as an arbitrary VS Code command argument (any caller
+    // can invoke `texra.runLatexdiff` with a malformed payload), so validate
+    // each round entry's shape rather than trusting the declared type.
+    const validRounds = (config.outputsByRound ?? [])
+      .filter(
+        (entry): entry is [number, OutputFileInfo[]] =>
+          Array.isArray(entry) &&
+          typeof entry[0] === 'number' &&
+          Array.isArray(entry[1]) &&
+          entry[1].length > 0,
+      )
+      .sort((a, b) => a[0] - b[0]);
+    const outputsByRound: Map<number, OutputFileInfo[]> | null =
+      validRounds.length > 0 ? new Map(validRounds) : null;
 
     const { outcome } = await vscode.window.withProgress(
       {

--- a/packages/extension/src/commands/latex/latexdiffCommands.ts
+++ b/packages/extension/src/commands/latex/latexdiffCommands.ts
@@ -23,6 +23,7 @@ import {
   type LatexdiffPackResult,
 } from '@housekeeping';
 import type { LaTeXdiffResult } from '@latex/latexdiff';
+import { normalizeRunLatexdiffOutputsByRound } from '@latex/latexdiff/commandConfig';
 import {
   DEFAULT_MATH_MARKUP,
   MATH_MARKUP_OPTIONS,
@@ -33,7 +34,7 @@ import { CHANNEL, service } from '@latex/latexdiff/service';
 import { runLatexdiffForExecution } from '@latex/latexdiff/runLatexdiff';
 import type { RunLatexdiffCommandConfig } from '@latex/latexdiff/types';
 import * as logger from '@logger/logUtils';
-import type { FileLocation, OutputFileInfo } from '@shared/schemas';
+import type { FileLocation } from '@shared/schemas';
 import { LATEX_CONFIG_DEFAULTS } from '@shared/constants/latex';
 import { flexibleFS, pathToLocation } from '@utils/files';
 import { checkToolInstalled } from '@utils/system';
@@ -371,20 +372,9 @@ async function handleRunLatexdiff(
 
     const runId = config.runId ?? undefined;
 
-    // `config` arrives as an arbitrary VS Code command argument (any caller
-    // can invoke `texra.runLatexdiff` with a malformed payload), so validate
-    // each round entry's shape rather than trusting the declared type.
-    const validRounds = (config.outputsByRound ?? [])
-      .filter(
-        (entry): entry is [number, OutputFileInfo[]] =>
-          Array.isArray(entry) &&
-          typeof entry[0] === 'number' &&
-          Array.isArray(entry[1]) &&
-          entry[1].length > 0,
-      )
-      .sort((a, b) => a[0] - b[0]);
-    const outputsByRound: Map<number, OutputFileInfo[]> | null =
-      validRounds.length > 0 ? new Map(validRounds) : null;
+    const outputsByRound = normalizeRunLatexdiffOutputsByRound(
+      config.outputsByRound,
+    );
 
     const { outcome } = await vscode.window.withProgress(
       {

--- a/packages/extension/src/progressView/frontend/components/BaseFeedbackPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseFeedbackPanel.ts
@@ -10,7 +10,10 @@ import '@awesome.me/webawesome/dist/components/textarea/textarea.js';
 import './ApproveSplitButton';
 
 // Local imports - shared utilities
-import { FEEDBACK_ELIGIBLE_KINDS } from '@shared/utils/uiConstants';
+import {
+  FEEDBACK_ELIGIBLE_KINDS,
+  PERMISSION_KIND,
+} from '@shared/utils/uiConstants';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 
 // Local imports - progress view events
@@ -19,7 +22,44 @@ import { APPROVE_SESSION_ACTION } from '../events';
 // Local imports - base class
 import { BaseRequestPanel } from './BaseRequestPanel';
 
-export abstract class BaseFeedbackPanel extends BaseRequestPanel {
+// Local imports - progress view component types
+import type { PermissionState } from '../permissionState';
+
+/**
+ * `allowBypass` / `streamId` are structurally present on every permission
+ * kind whose schema extends `PermissionBaseSchema` (toolEdit, bash,
+ * externalInquiry, userQuestion) — see `src/shared/schemas/prompts.ts`. The
+ * remaining kinds (retry, proposal, planApproval) don't carry them at all.
+ * `BaseFeedbackPanel` is the shared base for every feedback-eligible panel
+ * (all of the above except retry), so it can't be generically constrained to
+ * "just the kinds with these fields" — `PlanApprovalRequestPanel` inherits
+ * `canBypass` without overriding it. An exhaustive switch here (rather than a
+ * cast on `this.permission.data`) keeps the "which kinds have this" list
+ * type-checked against the real union instead of hand-rolled.
+ */
+function getBypassInfo(permission: PermissionState): {
+  allowBypass?: boolean;
+  streamId?: string;
+} {
+  switch (permission.kind) {
+    case PERMISSION_KIND.TOOL_EDIT:
+    case PERMISSION_KIND.BASH:
+    case PERMISSION_KIND.EXTERNAL_INQUIRY:
+    case PERMISSION_KIND.USER_QUESTION:
+      return {
+        allowBypass: permission.data.allowBypass,
+        streamId: permission.data.streamId,
+      };
+    case PERMISSION_KIND.RETRY:
+    case PERMISSION_KIND.PROPOSAL:
+    case PERMISSION_KIND.PLAN_APPROVAL:
+      return {};
+  }
+}
+
+export abstract class BaseFeedbackPanel<
+  K extends PermissionState['kind'] = PermissionState['kind'],
+> extends BaseRequestPanel<K> {
   @query('[data-feedback-input]') private feedbackInput?: HTMLElement;
   @state() protected showFeedback = false;
 
@@ -152,11 +192,8 @@ export abstract class BaseFeedbackPanel extends BaseRequestPanel {
    * there is nothing to scope it to and the button would silently no-op.
    */
   protected get canBypass(): boolean {
-    const data = this.permission.data as {
-      allowBypass?: boolean;
-      streamId?: string;
-    };
-    return Boolean(data.allowBypass && data.streamId);
+    const { allowBypass, streamId } = getBypassInfo(this.permission);
+    return Boolean(allowBypass && streamId);
   }
 
   /**

--- a/packages/extension/src/progressView/frontend/components/BaseRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseRequestPanel.ts
@@ -10,8 +10,13 @@ import { ProgressEvents } from '../events';
 // Local imports - progress view component types
 import type { PermissionState } from '../permissionState';
 
-export abstract class BaseRequestPanel extends LitElement {
-  @property({ attribute: false }) permission!: PermissionState;
+export abstract class BaseRequestPanel<
+  K extends PermissionState['kind'] = PermissionState['kind'],
+> extends LitElement {
+  @property({ attribute: false }) permission!: Extract<
+    PermissionState,
+    { kind: K }
+  >;
 
   /** Handle keyboard shortcut from container. Returns true if handled. */
   abstract handleKeyboardShortcut(key: string): boolean;

--- a/packages/extension/src/progressView/frontend/components/BashRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BashRequestPanel.ts
@@ -15,7 +15,6 @@ import {
 } from '@shared/styles';
 
 // Local imports - progress view styles
-import type { BashPermission } from '@shared/schemas';
 import { codeBlockStyles } from '../styles/codeBlockStyles';
 
 // Local imports - progress view formatters
@@ -25,7 +24,7 @@ import { buildCodeBlock } from '../formatters/htmlBuilders';
 import { BaseFeedbackPanel } from './BaseFeedbackPanel';
 
 @customElement('bash-request-panel')
-export class BashRequestPanel extends BaseFeedbackPanel {
+export class BashRequestPanel extends BaseFeedbackPanel<'bash'> {
   static override styles = [
     designTokens,
     commonViewStyles,
@@ -34,7 +33,7 @@ export class BashRequestPanel extends BaseFeedbackPanel {
   ];
 
   override render(): TemplateResult {
-    const data = this.permission.data as BashPermission;
+    const data = this.permission.data;
 
     return this.renderRequestShell({
       prefix: 'bash-approval-request',

--- a/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -92,7 +92,7 @@ export function clearInquiryDraft(requestId: string): void {
 // ── Component ──
 
 @customElement('external-inquiry-panel')
-export class ExternalInquiryPanel extends BaseFeedbackPanel {
+export class ExternalInquiryPanel extends BaseFeedbackPanel<'externalInquiry'> {
   static override styles = [designTokens, commonViewStyles, requestPanelStyles];
 
   @state() private answerText = '';
@@ -122,7 +122,7 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
     // Restore draft once on first update (avoids the extra render from connectedCallback).
     if (!this.draftRestored) {
       this.draftRestored = true;
-      const data = this.permission.data as ExternalInquiryPermission;
+      const data = this.permission.data;
       const draft = draftCache.get(getRequestId(this.permission)) ?? data.draft;
       if (draft) {
         this.answerText = draft.answer;
@@ -228,7 +228,7 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
   }
 
   override render(): TemplateResult {
-    const data = this.permission.data as ExternalInquiryPermission;
+    const data = this.permission.data;
 
     return html`
       <div

--- a/packages/extension/src/progressView/frontend/components/PlanApprovalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/PlanApprovalRequestPanel.ts
@@ -11,9 +11,6 @@ import {
   requestPanelStyles,
 } from '@shared/styles';
 
-// Local imports - shared schemas
-import type { PlanApprovalPermission } from '@shared/schemas';
-
 // Local imports - shared utilities
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 
@@ -21,12 +18,12 @@ import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 import { BaseFeedbackPanel } from './BaseFeedbackPanel';
 
 @customElement('plan-approval-request-panel')
-export class PlanApprovalRequestPanel extends BaseFeedbackPanel {
+export class PlanApprovalRequestPanel extends BaseFeedbackPanel<'planApproval'> {
   static override styles = [designTokens, commonViewStyles, requestPanelStyles];
 
   protected override handleExtraKey(key: string): boolean {
     if (key === 'r') {
-      const data = this.permission.data as PlanApprovalPermission;
+      const data = this.permission.data;
       if (data.goalEnabled) {
         this.emitAction('approve_and_goal');
         return true;
@@ -36,7 +33,7 @@ export class PlanApprovalRequestPanel extends BaseFeedbackPanel {
   }
 
   override render(): TemplateResult {
-    const data = this.permission.data as PlanApprovalPermission;
+    const data = this.permission.data;
     const { plan, goalEnabled } = data;
 
     return this.renderRequestShell({

--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -67,7 +67,7 @@ function readSelectValue(event: Event): string {
 }
 
 @customElement('proposal-request-panel')
-export class ProposalRequestPanel extends BaseFeedbackPanel {
+export class ProposalRequestPanel extends BaseFeedbackPanel<'proposal'> {
   static override styles = [
     designTokens,
     commonViewStyles,
@@ -125,15 +125,9 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
   }
 
   override render(): TemplateResult {
-    const data = this.permission.data as AgentProposalPermission;
-    const modelOptions =
-      this.permission.kind === PERMISSION_KIND.PROPOSAL
-        ? (this.permission.modelOptions ?? [])
-        : [];
-    const agentOptions =
-      this.permission.kind === PERMISSION_KIND.PROPOSAL
-        ? (this.permission.agentOptions ?? [])
-        : [];
+    const data = this.permission.data;
+    const modelOptions = this.permission.modelOptions ?? [];
+    const agentOptions = this.permission.agentOptions ?? [];
     const isWorkflow = data.agentCategory === AgentCategory.Workflow;
     const categoryLabel = isWorkflow ? 'Workflow' : 'Tool-Use';
     const currentModel = this.selectedModel ?? data.model;
@@ -331,7 +325,7 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
       super.emitAction(action, feedback);
       return;
     }
-    const data = this.permission.data as AgentProposalPermission;
+    const data = this.permission.data;
     const pickIfChanged = (
       selected: string | null,
       original: string,

--- a/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
@@ -18,7 +18,7 @@ import {
 } from '@shared/styles';
 
 // Local imports - shared schemas
-import type { ProviderErrorPartial, RetryPermission } from '@shared/schemas';
+import type { ProviderErrorPartial } from '@shared/schemas';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 import { renderDotMeta, type MetaPart } from '@shared/wa/metaStrip';
 
@@ -26,11 +26,11 @@ import { renderDotMeta, type MetaPart } from '@shared/wa/metaStrip';
 import { BaseRequestPanel } from './BaseRequestPanel';
 
 @customElement('retry-request-panel')
-export class RetryRequestPanel extends BaseRequestPanel {
+export class RetryRequestPanel extends BaseRequestPanel<'retry'> {
   static override styles = [designTokens, commonViewStyles, requestPanelStyles];
 
   override handleKeyboardShortcut(key: string): boolean {
-    const data = this.permission.data as RetryPermission;
+    const data = this.permission.data;
     switch (key) {
       case 'r':
         this.emitAction('retry');
@@ -50,7 +50,7 @@ export class RetryRequestPanel extends BaseRequestPanel {
   }
 
   override render(): TemplateResult {
-    const data = this.permission.data as RetryPermission;
+    const data = this.permission.data;
     const isRelay = data.errorDetails?.isRelayError === true;
     const isCredentialExhausted =
       data.errorDetails?.isCredentialExhausted === true;

--- a/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
@@ -31,7 +31,7 @@ import { BaseFeedbackPanel } from './BaseFeedbackPanel';
 import { monacoLanguageForPath } from './monacoLanguage';
 
 @customElement('tool-edit-request-panel')
-export class ToolEditRequestPanel extends BaseFeedbackPanel {
+export class ToolEditRequestPanel extends BaseFeedbackPanel<'toolEdit'> {
   static override styles = [designTokens, commonViewStyles, requestPanelStyles];
 
   @state() private inlineDiffOpen = false;
@@ -45,7 +45,7 @@ export class ToolEditRequestPanel extends BaseFeedbackPanel {
   }
 
   override render(): TemplateResult {
-    const data = this.permission.data as ToolEditPermission;
+    const data = this.permission.data;
     const diffMeta = this.renderDiffMeta(data);
     const metaParts: MetaPart[] = [];
     if (data.sourceTool) metaParts.push(`Requested by ${data.sourceTool}`);
@@ -71,7 +71,7 @@ export class ToolEditRequestPanel extends BaseFeedbackPanel {
   // ===========================================================================
 
   private renderDiffActions(): TemplateResult {
-    const data = this.permission.data as ToolEditPermission;
+    const data = this.permission.data;
     const showDropdown = Boolean(data.isLatex);
     const hasInlineDiff = this.hasInlineDiff(data);
 
@@ -200,7 +200,7 @@ export class ToolEditRequestPanel extends BaseFeedbackPanel {
   };
 
   private handleDiffAction = (): void => {
-    const data = this.permission.data as ToolEditPermission;
+    const data = this.permission.data;
     if (this.hasInlineDiff(data)) {
       this.inlineDiffOpen = !this.inlineDiffOpen;
       return;

--- a/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
@@ -30,14 +30,14 @@ import { ProgressEvents } from '../events';
 import { BaseFeedbackPanel } from './BaseFeedbackPanel';
 
 @customElement('user-question-panel')
-export class UserQuestionPanel extends BaseFeedbackPanel {
+export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
   static override styles = [designTokens, commonViewStyles, requestPanelStyles];
 
   @state() private selections: Record<string, string[]> = {};
   @state() private freeText: Record<string, string> = {};
 
   override render(): TemplateResult {
-    const data = this.permission.data as UserQuestionPermission;
+    const data = this.permission.data;
     const canSubmit = this.hasAnyAnswer(data);
 
     return html`
@@ -81,7 +81,7 @@ export class UserQuestionPanel extends BaseFeedbackPanel {
   override handleKeyboardShortcut(key: string): boolean {
     if (key === 'y') {
       if (this.showFeedback) return false;
-      if (!this.hasAnyAnswer(this.permission.data as UserQuestionPermission)) {
+      if (!this.hasAnyAnswer(this.permission.data)) {
         return true;
       }
       this.submitAnswers();
@@ -175,7 +175,7 @@ export class UserQuestionPanel extends BaseFeedbackPanel {
   }
 
   private submitAnswers(): void {
-    const data = this.permission.data as UserQuestionPermission;
+    const data = this.permission.data;
     const answers: UserQuestionAnswers = {};
 
     for (const question of data.questions) {

--- a/packages/extension/src/webview/MainViewMessageHandler.ts
+++ b/packages/extension/src/webview/MainViewMessageHandler.ts
@@ -35,7 +35,6 @@ import { DiffManager } from './managers/DiffManager';
 import * as executionHandlers from './managers/executionHandlers';
 import { FileManager } from './managers/FileManager';
 import { InstructionManager } from './managers/InstructionManager';
-import type { CommandMessage } from './managers/executionHandlers';
 
 export interface MainViewOnboardingHooks {
   /**
@@ -170,18 +169,19 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       [MAIN_VIEW_COMMANDS.OPEN_INSTALLATION_DOCS]: () =>
         safeExecuteCommand('texra.openDoc', ['installation'], this.viewName),
 
-      // The execution/file-op commands are validated as loose `{ command }`
-      // objects (payload typed nearer the handlers), so the dispatcher can't
-      // infer the rich shape — cast to the handler's declared input type
-      // rather than discarding all checking with `any`.
+      // EXECUTE is still validated as a loose `{ command }` object (payload
+      // typed nearer the handler), so the dispatcher can't infer the rich
+      // shape — cast to the handler's declared input type rather than
+      // discarding all checking with `any`. MERGE/COMPARE/ACCEPT_EDITED have
+      // real per-command Zod schemas now, so those flow through pre-narrowed.
       [MAIN_VIEW_COMMANDS.EXECUTE]: (m) =>
         executionHandlers.handleExecute(m as MainViewExecuteMessage),
       [MAIN_VIEW_COMMANDS.MERGE]: (m) =>
-        executionHandlers.handleFileOperation(m as CommandMessage),
+        executionHandlers.handleFileOperation(m),
       [MAIN_VIEW_COMMANDS.COMPARE]: (m) =>
-        executionHandlers.handleFileOperation(m as CommandMessage),
+        executionHandlers.handleFileOperation(m),
       [MAIN_VIEW_COMMANDS.ACCEPT_EDITED]: (m) =>
-        executionHandlers.handleFileOperation(m as CommandMessage),
+        executionHandlers.handleFileOperation(m),
 
       [MAIN_VIEW_COMMANDS.SELECT_EDITED_FILE]: () =>
         this.fileManager.handleEditedFileSelection(),

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -393,13 +393,11 @@ export class MainApp extends MainAppBase {
     );
 
   private readonly onRemoveFile = this.detailHandler<RemoveFileDetail>(
-    ({ listId, file }) =>
-      this.handleRemoveFile(listId as keyof MultiFiles, file),
+    ({ listId, file }) => this.handleRemoveFile(listId, file),
   );
 
   private readonly onFilesReordered = this.detailHandler<ReorderFilesDetail>(
-    ({ listId, files }) =>
-      this.updateMultiFiles(listId as keyof MultiFiles, files),
+    ({ listId, files }) => this.updateMultiFiles(listId, files),
   );
 
   private readonly onCheckboxChange = this.detailHandler<CheckboxChangeDetail>(
@@ -1459,21 +1457,22 @@ export class MainApp extends MainAppBase {
     if (!instructionText.trim()) return;
 
     const executionMessage = this.buildExecuteMessage();
+    const files = executionMessage.files ?? {};
     this.isPolishing.set(true);
     postMessage(MAIN_VIEW_COMMANDS.POLISH_INSTRUCTION_TEXT, {
       text: instructionText,
       agent: executionMessage.agent,
       model: this.model.get(),
-      editedFile: executionMessage.editedFile,
-      baseFile: executionMessage.baseFile,
-      inputFiles: executionMessage.inputFiles,
-      inputFilesActive: executionMessage.inputFilesActive,
-      contextFiles: executionMessage.contextFiles,
-      contextFilesActive: executionMessage.contextFilesActive,
-      mediaFiles: executionMessage.mediaFiles,
-      mediaFilesActive: executionMessage.mediaFilesActive,
-      outputFiles: executionMessage.outputFiles,
-      outputFilesActive: executionMessage.outputFilesActive,
+      editedFile: files.editedFile,
+      baseFile: files.baseFile,
+      inputFiles: files.inputFiles,
+      inputFilesActive: files.inputFilesActive,
+      contextFiles: files.contextFiles,
+      contextFilesActive: files.contextFilesActive,
+      mediaFiles: files.mediaFiles,
+      mediaFilesActive: files.mediaFilesActive,
+      outputFiles: files.outputFiles,
+      outputFilesActive: files.outputFilesActive,
     });
   }
 

--- a/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
+++ b/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
@@ -10,7 +10,11 @@ import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 
 import { SortableController } from '@shared/litControllers';
 import { designTokens } from '@shared/styles';
-import type { CheckboxValues, FileSelectConfig } from '@shared/schemas';
+import type {
+  CheckboxValues,
+  DocumentFileType,
+  FileSelectConfig,
+} from '@shared/schemas';
 import { getBasename, normalizeFilePath } from '@shared/utils/path';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
 import { type TeXRAIconName, waIcon } from '@shared/wa/webAwesomeIcons';
@@ -80,7 +84,7 @@ export class FileSelectGroup extends LitElement {
     }
   }
 
-  private get listId(): string {
+  private get listId(): `${DocumentFileType}Files` {
     return `${this.config.type}Files`;
   }
 
@@ -122,8 +126,7 @@ export class FileSelectGroup extends LitElement {
   }
 
   private get currentFiles(): string[] {
-    const key = this.listId as keyof FileStateContextValue['multiFiles'];
-    return this.fileState?.multiFiles[key] ?? [];
+    return this.fileState?.multiFiles[this.listId] ?? [];
   }
 
   private get isFileInputDisabled(): boolean {

--- a/packages/extension/src/webview/managers/executionHandlers.ts
+++ b/packages/extension/src/webview/managers/executionHandlers.ts
@@ -4,18 +4,18 @@ import { prepareMainViewExecutionRequest } from '@controllers/mainView/MainViewE
 import { logErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import type { MainViewExecuteMessage } from '@shared/mainView';
+import type { FileOperationMessage } from '@shared/schemas/mainView/inbound';
 
 const CHANNEL = 'ExecutionHandlers';
 logger.initialize(CHANNEL);
 
-/** Message shape for command-based operations. */
+/** Message shape for command-based operations without a validated payload
+ * schema (housekeeping/pack/clean commands). */
 export interface CommandMessage {
   command: string;
-  inputFile?: string;
-  baseFile?: string;
-  editedFile?: string;
   agent?: string;
   model?: string;
+  inputFile?: string;
   inputFiles?: string[];
   outputFiles?: string[];
 }
@@ -51,11 +51,11 @@ export async function handleExecute(
   await vscode.commands.executeCommand('texra.execute', preparation.request);
 }
 
-export function handleFileOperation(message: CommandMessage): void {
+export function handleFileOperation(message: FileOperationMessage): void {
   void vscode.commands.executeCommand(
     `texra.${message.command}`,
-    message.inputFile,
-    message.baseFile,
+    'inputFile' in message ? message.inputFile : undefined,
+    'baseFile' in message ? message.baseFile : undefined,
     message.editedFile,
   );
 }

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -40,7 +40,7 @@ export class ToolUseCycleNode<C> extends Node<
     assertPreparedShared(shared);
 
     return {
-      shouldSkip: shared.shouldSkipCycle,
+      shouldSkipCycle: shared.shouldSkipCycle,
       messages: shared.messages,
       runState: shared.stateSlices.runStateSnapshot,
       workspaceState: AgentWorkspaceState.fromSnapshot(
@@ -54,7 +54,7 @@ export class ToolUseCycleNode<C> extends Node<
     const { setting, resolvedTools, modelHandler } = this.services;
     const { streamId, runtimeHost } = useLaunchRunContext();
 
-    if (prepRes.shouldSkip) {
+    if (prepRes.shouldSkipCycle) {
       const { todos, plan } = prepRes.workspaceState.workPlan;
       if (todos.length) {
         runtimeHost.emit('updateTodos', { streamId, todos });
@@ -151,7 +151,7 @@ export class ToolUseCycleNode<C> extends Node<
     prepRes: CyclePrepResult,
     execRes: ToolUseCycleOutcome,
   ): Promise<string | undefined> {
-    if (prepRes.shouldSkip) {
+    if (prepRes.shouldSkipCycle) {
       shared.shouldSkipCycle = false;
     }
 

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -8,10 +8,11 @@ import { hasDelegationTool } from '@shared/constants/delegationTools';
 import { buildInitialToolUsePrompts } from '@utils/prompt';
 
 import type { ToolUseServices } from '../ToolUseServices';
-import type { ToolUseRunShared, PrepareResult } from './types';
+import type { ToolUseRunShared, CyclePrepResult } from './types';
 
 type PrepareExecResult =
-  { kind: 'success'; result: PrepareResult } | { kind: 'error'; error: Error };
+  | { kind: 'success'; result: CyclePrepResult }
+  | { kind: 'error'; error: Error };
 
 /**
  * Session-init node: runs **once per tool-use session** to build the initial
@@ -28,7 +29,7 @@ export class ToolUsePrepareNode<C> extends Node<
 > {
   async exec(
     _prepRes: void,
-  ): Promise<{ kind: 'success'; result: PrepareResult }> {
+  ): Promise<{ kind: 'success'; result: CyclePrepResult }> {
     const { userVarChannels, logger, snapshot, config, fileService } =
       this.services;
     const resolvedToolNames = this.services.resolvedTools.map((t) => t.name);

--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -49,14 +49,6 @@ export interface ToolUseRunShared {
   deliveredToOrchestrator?: boolean;
 }
 
-export interface PrepareResult {
-  runState: AgentRunStateSnapshot;
-  workspaceState: AgentWorkspaceState;
-  userChannels: UserVariableChannels;
-  messages: ProviderMessage[];
-  shouldSkipCycle: boolean;
-}
-
 export type WaitExecResult =
   | {
       kind: 'continue';
@@ -71,12 +63,18 @@ export type WaitExecResult =
     }
   | { kind: 'stop' };
 
+/**
+ * Prepared shared state needed to run one tool-use cycle: produced by
+ * `ToolUsePrepareNode`'s one-time session init and re-derived by
+ * `ToolUseCycleNode.prep()` from `shared.stateSlices` on every subsequent
+ * cycle.
+ */
 export interface CyclePrepResult {
   runState: AgentRunStateSnapshot;
   workspaceState: AgentWorkspaceState;
   userChannels: UserVariableChannels;
   messages: ProviderMessage[];
-  shouldSkip: boolean;
+  shouldSkipCycle: boolean;
 }
 
 export type PreparedShared = ToolUseRunShared & {

--- a/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
+++ b/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
@@ -12,6 +12,7 @@ import {
   FileReferenceSchema,
   EditRecordSchema,
   DIAGNOSTIC_TYPE_VALIDATION_ERROR,
+  NormalizedToolResultSchema,
 } from '@shared/schemas/toolResult';
 
 // Local imports - utils
@@ -125,8 +126,9 @@ function isToolFileAttachment(value: unknown): value is ToolFileAttachment {
  * Binary data (base64Data, bytes) is stripped from the result.
  *
  * Uses a Zod looseObject schema so unknown fields are preserved for forward
- * compatibility. The computed discriminator is stamped after raw fields so a
- * stray raw `status` key cannot invalidate the normalized payload.
+ * compatibility. The result is first normalized via `NormalizedToolResultSchema`,
+ * whose computed discriminator always wins over any stray raw `status` key,
+ * so it cannot invalidate the normalized payload.
  *
  * @param result - Raw tool result (may contain binary data)
  * @returns Extracted attachments and typed payload (without binary data)
@@ -140,35 +142,18 @@ export function extractToolAttachments(
     ? attachmentsCandidate.filter(isToolFileAttachment)
     : [];
 
-  // Determine the discriminator before parsing. Explicit tool failure status
-  // wins; otherwise output takes priority over error text for compatibility
-  // with formatToolResultAsText.
-  const hasError = isNonEmptyString(result.error);
-  const hasOutput = isNonEmptyString(result.output);
-  const hasSummary = isNonEmptyString(result.summary);
-  const isError = result.isError === true;
-  const status =
-    isError || (hasError && !hasOutput)
-      ? ('error' as const)
-      : ('executed' as const);
+  // Normalize the ambiguous raw result (no reliable `status` field; only
+  // `output`/`summary`/`error`/`isError` set ad hoc by tool implementations)
+  // into a `{ status, ... }` shape. The precedence rules that used to live
+  // here as an inline heuristic now live once, in
+  // `NormalizedToolResultSchema` (shared/schemas/toolResult.ts), so this is
+  // just a parse + narrow on `status`.
+  const normalized = NormalizedToolResultSchema.parse(result);
+  const status = normalized.status;
 
-  // Error text precedence: explicit error, then output, then summary, then a
-  // generic fallback. Computed here to keep the discriminator stamp below flat.
-  let errorText: string | undefined;
-  if (status === 'error') {
-    if (hasError) errorText = result.error;
-    else if (hasOutput) errorText = result.output;
-    else if (hasSummary) errorText = result.summary;
-    else errorText = 'Tool failed';
-  }
-
-  // Stamp the discriminator onto the raw result so the discriminated union
-  // schema validates the correct variant.
-  const parsed = ToolResultPayloadSchema.parse({
-    ...result,
-    ...(status === 'error' ? { error: errorText } : {}),
-    status,
-  });
+  // Re-validate against the discriminated union so downstream consumers get
+  // a properly typed, narrowable `ToolResultPayload`.
+  const parsed = ToolResultPayloadSchema.parse(normalized);
 
   // Build sanitized result, stripping binary data, undefined values, and redundant fields
   const sanitizedResult: Record<string, unknown> = { status };

--- a/src/controllers/mainView/MainViewExecutionController.ts
+++ b/src/controllers/mainView/MainViewExecutionController.ts
@@ -41,7 +41,8 @@ export function prepareMainViewExecutionRequest(
   }
 
   const isToolUse = Boolean(message.isToolUseAgent);
-  if (!isToolUse && (message.inputFiles?.length ?? 0) === 0) {
+  const files = message.files ?? {};
+  if (!isToolUse && (files.inputFiles?.length ?? 0) === 0) {
     return {
       valid: false,
       message: 'Please select an input file.',
@@ -51,7 +52,7 @@ export function prepareMainViewExecutionRequest(
 
   const toolConfigResult = isToolUse
     ? { success: true as const, data: DEFAULT_TOOL_CONFIG }
-    : ToolConfigSchema.safeParse(message);
+    : ToolConfigSchema.safeParse(message.toolConfig);
   if (!toolConfigResult.success) {
     const issue = toolConfigResult.error.issues[0];
     const path = issue?.path.join('.') || 'toolConfig';
@@ -63,13 +64,19 @@ export function prepareMainViewExecutionRequest(
 
   const validation = validateExecutionRequest({
     config: {
-      ...message,
+      agent: message.agent,
+      model: message.model,
+      instruction: message.instruction,
+      displayInstruction: message.displayInstruction,
+      memories: message.memories,
+      ...message.session,
+      ...files,
       agentCategory: isToolUse ? AgentCategory.ToolUse : AgentCategory.Workflow,
       // Workflow output paths are implicit in the input list. Agent settings
       // may still declare generated filenames later during prompt rendering.
       outputFiles: [],
       toolConfig: { ...toolConfigResult.data, attachDiagnostics: false },
-      mediaFiles: (message.mediaFiles ?? [])
+      mediaFiles: (files.mediaFiles ?? [])
         .map(mapMediaFile)
         .filter(filterNotNull),
       editedFile: null,

--- a/src/controllers/progressView/ProgressWorkflowActionsController.ts
+++ b/src/controllers/progressView/ProgressWorkflowActionsController.ts
@@ -18,7 +18,7 @@ export interface WorkflowDiffRequest {
   outputFilesActive: boolean;
   streamId: StreamTabId;
   runId?: string;
-  outputsByRound?: Record<string, OutputFileInfo[]>;
+  outputsByRound?: [round: number, files: OutputFileInfo[]][];
 }
 
 export type WorkflowFileOperation = 'pack' | 'clean';
@@ -78,7 +78,7 @@ export class ProgressWorkflowActionsController {
     await this.withWorkflowTaskState(stream, async (taskState) => {
       const runOutputs = this.deps.state.getOutputFiles(stream);
       const outputsByRound = runOutputs.size
-        ? Object.fromEntries(runOutputs.entries())
+        ? [...runOutputs.entries()]
         : undefined;
 
       await this.deps.runDiff({

--- a/src/controllers/progressView/ProgressWorkflowActionsController.ts
+++ b/src/controllers/progressView/ProgressWorkflowActionsController.ts
@@ -78,7 +78,7 @@ export class ProgressWorkflowActionsController {
     await this.withWorkflowTaskState(stream, async (taskState) => {
       const runOutputs = this.deps.state.getOutputFiles(stream);
       const outputsByRound = runOutputs.size
-        ? [...runOutputs.entries()]
+        ? [...runOutputs.entries()].sort((a, b) => a[0] - b[0])
         : undefined;
 
       await this.deps.runDiff({

--- a/src/latex/latexdiff/commandConfig.ts
+++ b/src/latex/latexdiff/commandConfig.ts
@@ -16,7 +16,7 @@ export function normalizeRunLatexdiffOutputsByRound(
       (entry): entry is [number, OutputFileInfo[]] =>
         Array.isArray(entry) &&
         typeof entry[0] === 'number' &&
-        Number.isFinite(entry[0]) &&
+        Number.isInteger(entry[0]) &&
         Array.isArray(entry[1]) &&
         entry[1].length > 0,
     )

--- a/src/latex/latexdiff/commandConfig.ts
+++ b/src/latex/latexdiff/commandConfig.ts
@@ -1,0 +1,26 @@
+import type { OutputFileInfo } from '@shared/schemas';
+
+/**
+ * Normalize arbitrary command payload metadata into the internal round map.
+ * VS Code commands can be invoked with any argument shape, so only the current
+ * tuple-array form is trusted; malformed or legacy map-shaped values fall back
+ * to discovery instead of crashing the command handler.
+ */
+export function normalizeRunLatexdiffOutputsByRound(
+  value: unknown,
+): Map<number, OutputFileInfo[]> | null {
+  if (!Array.isArray(value)) return null;
+
+  const validRounds = value
+    .filter(
+      (entry): entry is [number, OutputFileInfo[]] =>
+        Array.isArray(entry) &&
+        typeof entry[0] === 'number' &&
+        Number.isFinite(entry[0]) &&
+        Array.isArray(entry[1]) &&
+        entry[1].length > 0,
+    )
+    .sort((a, b) => a[0] - b[0]);
+
+  return validRounds.length > 0 ? new Map(validRounds) : null;
+}

--- a/src/latex/latexdiff/diffOperations.ts
+++ b/src/latex/latexdiff/diffOperations.ts
@@ -75,7 +75,7 @@ export async function executeDiffOperations(
         ? await service.runDiffForRound(
             operation.base,
             operation.revised,
-            operation.round ?? 0,
+            operation.round,
             mathMarkup,
             { cwd: operation.cwd },
           )

--- a/src/latex/latexdiff/types.ts
+++ b/src/latex/latexdiff/types.ts
@@ -19,7 +19,7 @@ export interface RunLatexdiffCommandConfig {
   outputFilesActive?: string[];
   streamId?: string;
   runId?: string | null;
-  outputsByRound?: Record<string, OutputFileInfo[]>;
+  outputsByRound?: [round: number, files: OutputFileInfo[]][];
 }
 
 export interface DiffRunResult {
@@ -37,13 +37,22 @@ export interface DiffRunOutcome {
 
 export type DiffOperationType = 'round' | 'between-rounds';
 
-export interface DiffOperation {
-  type: DiffOperationType;
+interface DiffOperationBase {
   base: FileLocation;
   revised: FileLocation;
   description: string;
-  cwd?: string;
-  round?: number;
-  fromRound?: number;
-  toRound?: number;
+  cwd: string;
 }
+
+export interface RoundDiffOperation extends DiffOperationBase {
+  type: 'round';
+  round: number;
+}
+
+export interface BetweenRoundsDiffOperation extends DiffOperationBase {
+  type: 'between-rounds';
+  fromRound: number;
+  toRound: number;
+}
+
+export type DiffOperation = RoundDiffOperation | BetweenRoundsDiffOperation;

--- a/src/shared/mainView/executeMessage.ts
+++ b/src/shared/mainView/executeMessage.ts
@@ -12,39 +12,52 @@ import type {
 import type { z } from 'zod';
 
 /**
- * Message shape from the main view for agent execution.
- * ToolConfig fields are sent flat from the UI form.
- *
- * Keep this aligned with prepareMainViewExecutionRequest. Agent-owned fields
- * such as agentCategory are derived there, not sent by the UI.
+ * File-selection fields sent from the main view's file pickers: the
+ * multi-file lists (input/context/media/output), their "active" UI toggles,
+ * and the single base/edited-file slots used by diff-oriented flows.
  */
-type MainViewExecuteFiles = {
+export type MainViewExecuteFiles = {
   readonly inputFiles?: string[];
   readonly contextFiles?: string[];
   readonly mediaFiles?: (string | null)[];
   readonly outputFiles?: string[];
   readonly editedFile?: string;
+  readonly editedFiles?: string[];
+  readonly baseFile?: string;
+  readonly inputFilesActive?: boolean;
+  readonly contextFilesActive?: boolean;
+  readonly mediaFilesActive?: boolean;
+  readonly outputFilesActive?: boolean;
 };
 
-export type MainViewExecuteMessage = MainViewExecuteFiles & {
+/** Session/run metadata that rides along with the execution request. */
+export type MainViewExecuteSession = {
+  readonly workingDirectory?: string | null;
+  readonly cliOutputFile?: string | null;
+  readonly cliMultiAgentPresetId?: string | null;
+};
+
+/**
+ * Message shape from the main view for agent execution. File selection,
+ * session metadata, and tool config are grouped into their own sub-objects
+ * (mirroring how `prepareMainViewExecutionRequest` consumes them) instead of
+ * one flat 26-field bag.
+ *
+ * Keep this aligned with prepareMainViewExecutionRequest. Agent-owned fields
+ * such as agentCategory are derived there, not sent by the UI.
+ */
+export type MainViewExecuteMessage = {
   readonly agent?: string;
   readonly model?: string;
   readonly instruction?: string;
   readonly displayInstruction?: string | null;
   /** UI toggle indicating tool-use vs workflow agent. */
   readonly isToolUseAgent?: boolean;
-  /** File used as the base/reference for diff-oriented flows. */
-  readonly baseFile?: string;
-  readonly inputFilesActive?: boolean;
-  readonly contextFilesActive?: boolean;
-  readonly mediaFilesActive?: boolean;
-  readonly outputFilesActive?: boolean;
-  readonly editedFiles?: string[];
   readonly memories?: string[];
-  readonly workingDirectory?: string | null;
-  readonly cliOutputFile?: string | null;
-  readonly cliMultiAgentPresetId?: string | null;
-} & z.input<typeof ToolConfigSchema>;
+  readonly files?: MainViewExecuteFiles;
+  readonly session?: MainViewExecuteSession;
+  readonly toolConfig?: z.input<typeof ToolConfigSchema>;
+};
 
 export interface MainViewExecutionFormState {
   readonly sessionType: SessionType;
@@ -68,10 +81,12 @@ export function buildMainViewExecuteMessage(
     model: state.model,
     instruction: state.instruction,
     isToolUseAgent,
-    editedFile: state.singleFiles.editedFile,
-    baseFile: state.singleFiles.baseFile,
-    ...buildMainViewMultipleFileSelections(state.multiFiles),
-    ...state.checkboxValues,
+    files: {
+      editedFile: state.singleFiles.editedFile,
+      baseFile: state.singleFiles.baseFile,
+      ...buildMainViewMultipleFileSelections(state.multiFiles),
+    },
+    toolConfig: state.checkboxValues,
   };
 }
 

--- a/src/shared/schemas/mainView/inbound.ts
+++ b/src/shared/schemas/mainView/inbound.ts
@@ -74,11 +74,44 @@ const SettingsMessages = [
   }),
 ] as const;
 
+// MERGE sends the primary input plus the edited file (planMerge); COMPARE
+// and ACCEPT_EDITED send the base/edited pair (planCompare). Each command
+// needs a distinct required-field shape, so they get their own schemas
+// instead of a shared loose object — file paths flowing straight into VS
+// Code commands (see executionHandlers.handleFileOperation) must be
+// validated at the dispatch boundary like every other inbound message.
+export const MergeMessageSchema = z.object({
+  command: z.literal(MAIN_VIEW_COMMANDS.MERGE),
+  inputFile: z.string(),
+  editedFile: z.string(),
+});
+export type MergeMessage = z.infer<typeof MergeMessageSchema>;
+
+export const CompareMessageSchema = z.object({
+  command: z.literal(MAIN_VIEW_COMMANDS.COMPARE),
+  baseFile: z.string(),
+  editedFile: z.string(),
+});
+export type CompareMessage = z.infer<typeof CompareMessageSchema>;
+
+export const AcceptEditedMessageSchema = z.object({
+  command: z.literal(MAIN_VIEW_COMMANDS.ACCEPT_EDITED),
+  baseFile: z.string(),
+  editedFile: z.string(),
+});
+export type AcceptEditedMessage = z.infer<typeof AcceptEditedMessageSchema>;
+
+/** Union consumed by `executionHandlers.handleFileOperation`. */
+export type FileOperationMessage =
+  | MergeMessage
+  | CompareMessage
+  | AcceptEditedMessage;
+
 const ExecutionMessages = [
   z.looseObject({ command: z.literal(MAIN_VIEW_COMMANDS.EXECUTE) }),
-  z.looseObject({ command: z.literal(MAIN_VIEW_COMMANDS.MERGE) }),
-  z.looseObject({ command: z.literal(MAIN_VIEW_COMMANDS.COMPARE) }),
-  z.looseObject({ command: z.literal(MAIN_VIEW_COMMANDS.ACCEPT_EDITED) }),
+  MergeMessageSchema,
+  CompareMessageSchema,
+  AcceptEditedMessageSchema,
 ] as const;
 
 const FileSelectionMessages = [

--- a/src/shared/schemas/mainView/inbound.ts
+++ b/src/shared/schemas/mainView/inbound.ts
@@ -103,9 +103,7 @@ export type AcceptEditedMessage = z.infer<typeof AcceptEditedMessageSchema>;
 
 /** Union consumed by `executionHandlers.handleFileOperation`. */
 export type FileOperationMessage =
-  | MergeMessage
-  | CompareMessage
-  | AcceptEditedMessage;
+  MergeMessage | CompareMessage | AcceptEditedMessage;
 
 const ExecutionMessages = [
   z.looseObject({ command: z.literal(MAIN_VIEW_COMMANDS.EXECUTE) }),

--- a/src/shared/schemas/mainView/state.ts
+++ b/src/shared/schemas/mainView/state.ts
@@ -186,6 +186,12 @@ export const MultiFilesSchema = z.object({
 });
 export type MultiFiles = z.infer<typeof MultiFilesSchema>;
 
+// Enumerates the four `MultiFiles` keys (`inputFiles` / `contextFiles` /
+// `mediaFiles` / `outputFiles`) so `listId` fields below are constrained to
+// valid `keyof MultiFiles` values instead of an unconstrained `z.string()`.
+export const MultiFilesKeySchema = MultiFilesSchema.keyof();
+export type MultiFilesKey = z.infer<typeof MultiFilesKeySchema>;
+
 export const FileStateContextSchema = z.object({
   sessionType: SessionTypeSchema,
   checkboxValues: CheckboxValuesSchema,
@@ -229,7 +235,7 @@ export const FileActionDetailSchema = z.object({
 export type FileActionDetail = z.infer<typeof FileActionDetailSchema>;
 
 export const MultipleFilesActionDetailSchema = z.object({
-  listId: z.string(),
+  listId: MultiFilesKeySchema,
 });
 export type MultipleFilesActionDetail = z.infer<
   typeof MultipleFilesActionDetailSchema
@@ -243,13 +249,13 @@ export type MultipleFilesTypeActionDetail = z.infer<
 >;
 
 export const RemoveFileDetailSchema = z.object({
-  listId: z.string(),
+  listId: MultiFilesKeySchema,
   file: z.string(),
 });
 export type RemoveFileDetail = z.infer<typeof RemoveFileDetailSchema>;
 
 export const ReorderFilesDetailSchema = z.object({
-  listId: z.string(),
+  listId: MultiFilesKeySchema,
   files: z.array(z.string()),
 });
 export type ReorderFilesDetail = z.infer<typeof ReorderFilesDetailSchema>;

--- a/src/shared/schemas/toolResult.ts
+++ b/src/shared/schemas/toolResult.ts
@@ -176,28 +176,26 @@ export type ToolResultStatus = (typeof TOOL_RESULT_STATUSES)[number];
  * generic fallback — this preserves historical behavior for tools that only
  * ever set `output`/`summary` while failing.
  */
-export const NormalizedToolResultSchema = ToolResultSchema.transform(
-  (raw) => {
-    const hasError = isNonEmptyString(raw.error);
-    const hasOutput = isNonEmptyString(raw.output);
-    const hasSummary = isNonEmptyString(raw.summary);
-    const isError = raw.isError === true;
-    const status: ToolResultStatus =
-      isError || (hasError && !hasOutput) ? 'error' : 'executed';
+export const NormalizedToolResultSchema = ToolResultSchema.transform((raw) => {
+  const hasError = isNonEmptyString(raw.error);
+  const hasOutput = isNonEmptyString(raw.output);
+  const hasSummary = isNonEmptyString(raw.summary);
+  const isError = raw.isError === true;
+  const status: ToolResultStatus =
+    isError || (hasError && !hasOutput) ? 'error' : 'executed';
 
-    if (status !== 'error') {
-      return { ...raw, status };
-    }
+  if (status !== 'error') {
+    return { ...raw, status };
+  }
 
-    let errorText: string;
-    if (isNonEmptyString(raw.error)) errorText = raw.error;
-    else if (isNonEmptyString(raw.output)) errorText = raw.output;
-    else if (isNonEmptyString(raw.summary)) errorText = raw.summary;
-    else errorText = 'Tool failed';
+  let errorText: string;
+  if (isNonEmptyString(raw.error)) errorText = raw.error;
+  else if (isNonEmptyString(raw.output)) errorText = raw.output;
+  else if (isNonEmptyString(raw.summary)) errorText = raw.summary;
+  else errorText = 'Tool failed';
 
-    return { ...raw, status, error: errorText };
-  },
-);
+  return { ...raw, status, error: errorText };
+});
 
 export class ToolError extends Error {
   constructor(message: string, options?: { cause?: unknown }) {

--- a/src/shared/schemas/toolResult.ts
+++ b/src/shared/schemas/toolResult.ts
@@ -1,6 +1,9 @@
 // Third-party imports
 import { z } from 'zod';
 
+// Local imports - utils
+import { isNonEmptyString } from '@utils/core';
+
 // Local imports - shared schemas
 import { LineChangesSchema, LineCountSchema } from './lineChanges';
 
@@ -144,6 +147,57 @@ export const ToolResultSchema = z.looseObject({
   files: z.array(ToolFileAttachmentSchema).optional(),
 });
 export type ToolResult = z.infer<typeof ToolResultSchema>;
+
+// ============================================================================
+// ToolResult Normalization (status inference for ambiguous legacy results)
+// ============================================================================
+
+/**
+ * Tool result status discriminant. `executed` results carry output/summary/
+ * files etc.; `error` results carry a required non-empty `error` message.
+ */
+export const TOOL_RESULT_STATUSES = ['executed', 'error'] as const;
+export type ToolResultStatus = (typeof TOOL_RESULT_STATUSES)[number];
+
+/**
+ * Normalizes an ambiguous `ToolResultSchema` shape (no reliable `status`
+ * field; only `output`/`summary`/`error`/`isError` populated ad hoc by tool
+ * implementations) into a `{ status, ... }` shape that can be narrowed on
+ * `status` directly.
+ *
+ * The computed discriminator always wins over any incidental raw `status`
+ * key a result object might carry (no current tool implementation sets one,
+ * but this keeps behavior unambiguous rather than trusting an unverified
+ * field) — precedence rules are the single source of truth now, previously
+ * duplicated as a heuristic inline in `toolAttachmentUtils.ts`: an explicit
+ * `isError: true`, or non-empty `error` text with no `output`, wins as
+ * `'error'`; otherwise the result is `'executed'`. When `'error'`, the
+ * surfaced error text prefers `error`, then `output`, then `summary`, then a
+ * generic fallback — this preserves historical behavior for tools that only
+ * ever set `output`/`summary` while failing.
+ */
+export const NormalizedToolResultSchema = ToolResultSchema.transform(
+  (raw) => {
+    const hasError = isNonEmptyString(raw.error);
+    const hasOutput = isNonEmptyString(raw.output);
+    const hasSummary = isNonEmptyString(raw.summary);
+    const isError = raw.isError === true;
+    const status: ToolResultStatus =
+      isError || (hasError && !hasOutput) ? 'error' : 'executed';
+
+    if (status !== 'error') {
+      return { ...raw, status };
+    }
+
+    let errorText: string;
+    if (isNonEmptyString(raw.error)) errorText = raw.error;
+    else if (isNonEmptyString(raw.output)) errorText = raw.output;
+    else if (isNonEmptyString(raw.summary)) errorText = raw.summary;
+    else errorText = 'Tool failed';
+
+    return { ...raw, status, error: errorText };
+  },
+);
 
 export class ToolError extends Error {
   constructor(message: string, options?: { cause?: unknown }) {

--- a/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
@@ -29,7 +29,7 @@ function createPrepResult(
   workspaceState: AgentWorkspaceState,
 ): CyclePrepResult {
   return {
-    shouldSkip: true,
+    shouldSkipCycle: true,
     messages: [],
     runState: { totalRounds: 0 } as CyclePrepResult['runState'],
     workspaceState,

--- a/src/test-kernel/controllers/MainViewExecutionController.vitest.ts
+++ b/src/test-kernel/controllers/MainViewExecutionController.vitest.ts
@@ -32,9 +32,11 @@ describe('MainViewExecutionController', () => {
     const result = prepareMainViewExecutionRequest({
       agent: 'direct-agent',
       model: 'gpt-5.4',
-      inputFiles: ['paper/main.tex'],
-      mediaFiles: ['diagram.png', null],
-      attachDiagnostics: true,
+      files: {
+        inputFiles: ['paper/main.tex'],
+        mediaFiles: ['diagram.png', null],
+      },
+      toolConfig: { attachDiagnostics: true },
     });
 
     expect(result.valid).toBe(true);
@@ -57,8 +59,10 @@ describe('MainViewExecutionController', () => {
     const result = prepareMainViewExecutionRequest({
       agent: 'direct-agent',
       model: 'gpt-5.4',
-      inputFiles: ['paper/main.tex'],
-      outputFiles: ['paper/old-output.tex'],
+      files: {
+        inputFiles: ['paper/main.tex'],
+        outputFiles: ['paper/old-output.tex'],
+      },
     });
 
     expect(result.valid).toBe(true);

--- a/src/test-kernel/controllers/ProgressWorkflowActionsController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressWorkflowActionsController.vitest.ts
@@ -87,7 +87,7 @@ describe('ProgressWorkflowActionsController', () => {
         outputFilesActive: false,
         streamId: 'stream-a',
         runId: 'exec-123',
-        outputsByRound: { 1: [output] },
+        outputsByRound: [[1, [output]]],
       },
     ]);
   });

--- a/src/test-kernel/latex/CriticismParser.vitest.mts
+++ b/src/test-kernel/latex/CriticismParser.vitest.mts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import { parseCriticismAnnotations } from '@latex/criticismParser';
-import { DiagnosticsInputSchema } from '@tools/DiagnosticsTool';
+import {
+  DiagnosticsInputSchema,
+  type DiagnosticsInput,
+} from '@tools/DiagnosticsTool';
 
 describe('parseCriticismAnnotations', () => {
   it('accepts whitespace before arguments and severity zero', () => {
@@ -43,15 +46,14 @@ describe('DiagnosticsInputSchema add command', () => {
       }),
     ).toThrow();
 
-    expect(
-      DiagnosticsInputSchema.parse({
-        command: 'add',
-        path: 'paper.tex',
-        line: 1,
-        message: 'verified',
-        severity: 0,
-        confidence: 5,
-      }).severity,
-    ).toBe(0);
+    const parsed = DiagnosticsInputSchema.parse({
+      command: 'add',
+      path: 'paper.tex',
+      line: 1,
+      message: 'verified',
+      severity: 0,
+      confidence: 5,
+    }) as Extract<DiagnosticsInput, { command: 'add' }>;
+    expect(parsed.severity).toBe(0);
   });
 });

--- a/src/test-kernel/latex/RunLatexdiffCommandConfig.vitest.mts
+++ b/src/test-kernel/latex/RunLatexdiffCommandConfig.vitest.mts
@@ -29,4 +29,15 @@ describe('normalizeRunLatexdiffOutputsByRound', () => {
     ).toBeNull();
     expect(normalizeRunLatexdiffOutputsByRound('not-rounds')).toBeNull();
   });
+
+  it('drops non-integer round entries', () => {
+    const valid = createOutputFile({ round: 1 });
+
+    expect(
+      normalizeRunLatexdiffOutputsByRound([
+        [1.5, [createOutputFile({ round: 1.5 })]],
+        [1, [valid]],
+      ]),
+    ).toEqual(new Map([[1, [valid]]]));
+  });
 });

--- a/src/test-kernel/latex/RunLatexdiffCommandConfig.vitest.mts
+++ b/src/test-kernel/latex/RunLatexdiffCommandConfig.vitest.mts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeRunLatexdiffOutputsByRound } from '@latex/latexdiff/commandConfig';
+
+import { createOutputFile } from '../support/ProgressControllerHarnesses';
+
+describe('normalizeRunLatexdiffOutputsByRound', () => {
+  it('keeps non-empty tuple-array rounds in numeric order', () => {
+    const first = createOutputFile({ round: 1 });
+    const second = createOutputFile({ round: 2 });
+
+    expect(
+      normalizeRunLatexdiffOutputsByRound([
+        [2, [second]],
+        [1, [first]],
+        [3, []],
+      ]),
+    ).toEqual(
+      new Map([
+        [1, [first]],
+        [2, [second]],
+      ]),
+    );
+  });
+
+  it('falls back for malformed or legacy map-shaped command payloads', () => {
+    expect(
+      normalizeRunLatexdiffOutputsByRound({ 1: [createOutputFile()] }),
+    ).toBeNull();
+    expect(normalizeRunLatexdiffOutputsByRound('not-rounds')).toBeNull();
+  });
+});

--- a/src/test-kernel/progressView/BashRequestPanel.vitest.mts
+++ b/src/test-kernel/progressView/BashRequestPanel.vitest.mts
@@ -2,7 +2,6 @@
 import { describe, expect, it } from 'vitest';
 
 // Local imports - progress view component types
-import type { PermissionState } from '@progressView/frontend/permissionState';
 import type { BashRequestPanel } from '@progressView/frontend/components/BashRequestPanel';
 
 // Local imports - shared schemas
@@ -11,7 +10,9 @@ import type { BashPermission } from '@shared/schemas';
 // Local imports - test utilities
 import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
 
-function createPermission(data: Partial<BashPermission>): PermissionState {
+function createPermission(
+  data: Partial<BashPermission>,
+): BashRequestPanel['permission'] {
   return {
     kind: 'bash',
     data: {
@@ -25,7 +26,7 @@ function createPermission(data: Partial<BashPermission>): PermissionState {
 }
 
 async function mountPanel(
-  permission: PermissionState,
+  permission: BashRequestPanel['permission'],
 ): Promise<BashRequestPanel> {
   const element = document.createElement(
     'bash-request-panel',

--- a/src/test-kernel/progressView/RetryRequestPanel.vitest.mts
+++ b/src/test-kernel/progressView/RetryRequestPanel.vitest.mts
@@ -2,7 +2,6 @@
 import { describe, expect, it } from 'vitest';
 
 // Local imports - progress view component types
-import type { PermissionState } from '@progressView/frontend/permissionState';
 import type { RetryRequestPanel } from '@progressView/frontend/components/RetryRequestPanel';
 
 // Local imports - shared constants
@@ -15,7 +14,7 @@ useLitComponentTestDom(
   () => import('@progressView/frontend/components/RetryRequestPanel'),
 );
 
-function createRetryPermission(): PermissionState {
+function createRetryPermission(): RetryRequestPanel['permission'] {
   return {
     kind: PERMISSION_KIND.RETRY,
     data: {

--- a/src/test-kernel/progressView/ToolEditRequestPanel.vitest.mts
+++ b/src/test-kernel/progressView/ToolEditRequestPanel.vitest.mts
@@ -2,7 +2,6 @@
 import { describe, expect, it } from 'vitest';
 
 // Local imports - progress view component types
-import type { PermissionState } from '@progressView/frontend/permissionState';
 import type { ToolEditRequestPanel } from '@progressView/frontend/components/ToolEditRequestPanel';
 
 // Local imports - shared schemas
@@ -11,7 +10,9 @@ import type { ToolEditPermission } from '@shared/schemas';
 // Local imports - test utilities
 import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
 
-function createPermission(data: Partial<ToolEditPermission>): PermissionState {
+function createPermission(
+  data: Partial<ToolEditPermission>,
+): ToolEditRequestPanel['permission'] {
   return {
     kind: 'toolEdit',
     data: {
@@ -30,7 +31,7 @@ function createPermission(data: Partial<ToolEditPermission>): PermissionState {
 }
 
 async function mountPanel(
-  permission: PermissionState,
+  permission: ToolEditRequestPanel['permission'],
 ): Promise<ToolEditRequestPanel> {
   const element = document.createElement(
     'tool-edit-request-panel',

--- a/src/test-kernel/progressView/UserQuestionPanel.vitest.mts
+++ b/src/test-kernel/progressView/UserQuestionPanel.vitest.mts
@@ -3,7 +3,6 @@ import { JSDOM } from 'jsdom';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 // Local imports - progress view component types
-import type { PermissionState } from '@progressView/frontend/permissionState';
 import type { UserQuestionPanel } from '@progressView/frontend/components/UserQuestionPanel';
 
 // Local imports - shared constants
@@ -76,7 +75,7 @@ function restoreDom(): void {
   }
 }
 
-function createPermission(): PermissionState {
+function createPermission(): UserQuestionPanel['permission'] {
   return {
     kind: PERMISSION_KIND.USER_QUESTION,
     data: {

--- a/src/test-kernel/shared/MainViewExecuteMessage.vitest.ts
+++ b/src/test-kernel/shared/MainViewExecuteMessage.vitest.ts
@@ -30,20 +30,24 @@ describe('MainView execute message builder', () => {
       model: 'gpt-5.4',
       instruction: 'Solve a small enumeration problem.',
       isToolUseAgent: true,
-      baseFile: 'old.tex',
-      editedFile: 'new.tex',
-      inputFiles: ['main.tex'],
-      inputFilesActive: true,
-      contextFiles: ['refs.bib'],
-      contextFilesActive: true,
-      mediaFiles: ['figure.png'],
-      mediaFilesActive: true,
-      outputFiles: [],
-      outputFilesActive: false,
-      autoExtractFigure: true,
-      autoExtractTikzFigure: false,
-      autoCompileInputPdf: true,
-      attachTeXCount: false,
+      files: {
+        baseFile: 'old.tex',
+        editedFile: 'new.tex',
+        inputFiles: ['main.tex'],
+        inputFilesActive: true,
+        contextFiles: ['refs.bib'],
+        contextFilesActive: true,
+        mediaFiles: ['figure.png'],
+        mediaFilesActive: true,
+        outputFiles: [],
+        outputFilesActive: false,
+      },
+      toolConfig: {
+        autoExtractFigure: true,
+        autoExtractTikzFigure: false,
+        autoCompileInputPdf: true,
+        attachTeXCount: false,
+      },
     });
   });
 
@@ -71,6 +75,6 @@ describe('MainView execute message builder', () => {
 
     expect(message.agent).toBe('correct');
     expect(message.isToolUseAgent).toBe(false);
-    expect(message.inputFilesActive).toBe(false);
+    expect(message.files?.inputFilesActive).toBe(false);
   });
 });

--- a/src/test-kernel/tools/DiagnosticsTool.vitest.ts
+++ b/src/test-kernel/tools/DiagnosticsTool.vitest.ts
@@ -61,9 +61,13 @@ describe('DiagnosticsTool', () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(result.error).toContain(
-      'requires line, message, severity, and confidence',
-    );
+    // Now caught by DiagnosticsInputSchema's discriminated union (the `add`
+    // variant requires these fields) rather than a hand-rolled message, so
+    // the structured Zod diagnostics list each missing field individually.
+    expect(result.error).toContain('at line');
+    expect(result.error).toContain('at message');
+    expect(result.error).toContain('at severity');
+    expect(result.error).toContain('at confidence');
   });
 
   it('reports when the criticism sink does not accept (feature disabled)', async () => {

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -155,7 +155,7 @@ const DelegateAgentInputSchema = z
       .string()
       .nullish()
       .describe(
-        'Name of the tool-use agent to delegate to. Required for new delegations, ignored when resuming via execution_id.',
+        'Name of the tool-use agent to delegate to. Required for new delegations; omit when resuming via execution_id.',
       ),
     model: z
       .string()

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -149,33 +149,38 @@ Example: agent=correct, inputFiles=["paper.tex"], extractFigures=true, instructi
 // ============================================================================
 
 /** Schema for delegate_agent tool (tool-use agents). */
-const DelegateAgentInputSchema = z.strictObject({
-  agent: z
-    .string()
-    .nullish()
-    .describe(
-      'Name of the tool-use agent to delegate to. Required for new delegations, ignored when resuming via execution_id.',
-    ),
-  model: z
-    .string()
-    .nullish()
-    .describe(
-      'Model short name from the Available models line. Omit unless the user explicitly requested a model; defaults to the current model when available.',
-    ),
-  instruction: z
-    .string()
-    .describe(
-      'Plain prose instruction for the agent. For new delegations, include file paths naturally and copy every relevant parent constraint into this field: tool/network/file/approval limits, output format, and scope. The subagent does not automatically inherit the parent conversation or hidden constraints. For resumes, reference previous work freely — the subagent retains its full history.',
-    ),
-  memories: memoriesField,
-  working_directory: workingDirectoryField,
-  execution_id: z
-    .string()
-    .nullish()
-    .describe(
-      'If set, sends follow-up instructions to a tool-use subagent instead of starting a new one. Busy subagents queue the follow-up for their next turn. Use the execution ID from the original delegation result or /executions.',
-    ),
-});
+const DelegateAgentInputSchema = z
+  .strictObject({
+    agent: z
+      .string()
+      .nullish()
+      .describe(
+        'Name of the tool-use agent to delegate to. Required for new delegations, ignored when resuming via execution_id.',
+      ),
+    model: z
+      .string()
+      .nullish()
+      .describe(
+        'Model short name from the Available models line. Omit unless the user explicitly requested a model; defaults to the current model when available.',
+      ),
+    instruction: z
+      .string()
+      .describe(
+        'Plain prose instruction for the agent. For new delegations, include file paths naturally and copy every relevant parent constraint into this field: tool/network/file/approval limits, output format, and scope. The subagent does not automatically inherit the parent conversation or hidden constraints. For resumes, reference previous work freely — the subagent retains its full history.',
+      ),
+    memories: memoriesField,
+    working_directory: workingDirectoryField,
+    execution_id: z
+      .string()
+      .nullish()
+      .describe(
+        'If set, sends follow-up instructions to a tool-use subagent instead of starting a new one. Busy subagents queue the follow-up for their next turn. Use the execution ID from the original delegation result or /executions.',
+      ),
+  })
+  .refine((data) => Boolean(data.agent) !== Boolean(data.execution_id), {
+    error:
+      "Provide exactly one of 'agent' (to start a new delegation) or 'execution_id' (to resume an existing one) — not both, not neither.",
+  });
 
 export type DelegateAgentInput = z.infer<typeof DelegateAgentInputSchema>;
 
@@ -213,14 +218,10 @@ Git worktree support: resolved from the active workspace at runtime.`,
       return this.resumeAgent(input.execution_id, input.instruction);
     }
 
-    // Delegate path: agent is required
-    if (!input.agent) {
-      throw new Error(
-        `'agent' is required when starting a new delegation. Provide an agent name, or set 'execution_id' to resume an existing subagent.`,
-      );
-    }
-
-    const agent = requireVisibleAgent('toolUse', input.agent);
+    // New-delegation path: the schema's refine() guarantees exactly one of
+    // agent/execution_id is set, so agent is defined here — refine() doesn't
+    // narrow types, hence the assertion.
+    const agent = requireVisibleAgent('toolUse', input.agent!);
     const agentName = agent.name;
 
     const { streamId, context } = requireRunStream('delegate_agent');

--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -37,39 +37,52 @@ export const DiagnosticsReadInputSchema = z.strictObject({
 const DIAGNOSTICS_READ_ONLY_DESCRIPTION =
   'Inspect diagnostics for a file. Use "list" to retrieve linter diagnostics or "count" for a severity summary.';
 
-export const DiagnosticsInputSchema = DiagnosticsReadInputSchema.extend({
+const DiagnosticsListSchema = z.strictObject({
   command: z
-    .enum(['list', 'count', 'add'])
+    .literal('list')
+    .describe('Retrieve full linter diagnostics for a file.'),
+  path: DiagnosticsPathSchema,
+});
+
+const DiagnosticsCountSchema = z.strictObject({
+  command: z
+    .literal('count')
     .describe(
-      'Use "list" for full diagnostics, "count" for a summary, or "add" to push a critique annotation as a diagnostic (squiggle + Problems panel) without inserting a literal \\criticize{...}{...}{...} macro into the document.',
+      'Retrieve a severity-count summary of linter diagnostics for a file.',
     ),
-  line: z
-    .int()
-    .min(1)
-    .nullish()
-    .describe('add: 1-based line number where the issue occurs.'),
-  message: z
-    .string()
-    .min(1)
-    .nullish()
-    .describe('add: description of the issue.'),
+  path: DiagnosticsPathSchema,
+});
+
+const DiagnosticsAddSchema = z.strictObject({
+  command: z
+    .literal('add')
+    .describe(
+      'Push a critique annotation as a diagnostic (squiggle + Problems panel entry) without inserting a literal \\criticize{...}{...}{...} macro into the document.',
+    ),
+  path: DiagnosticsPathSchema,
+  line: z.int().min(1).describe('1-based line number where the issue occurs.'),
+  message: z.string().min(1).describe('Description of the issue.'),
   severity: z
     .int()
     .min(0)
     .max(5)
-    .nullish()
     .describe(
-      'add: severity 0–5: 5=desk-rejection risk, 4=significantly weakens, 3=worth addressing, 2=minor polish, 1=cosmetic, 0=verified/correct.',
+      'Severity 0–5: 5=desk-rejection risk, 4=significantly weakens, 3=worth addressing, 2=minor polish, 1=cosmetic, 0=verified/correct.',
     ),
   confidence: z
     .int()
     .min(1)
     .max(5)
-    .nullish()
     .describe(
-      'add: confidence 1–5: 5=certain, 4=high certainty with minor subjectivity, 3=reasonable but field-dependent, 2=subjective, 1=speculative.',
+      'Confidence 1–5: 5=certain, 4=high certainty with minor subjectivity, 3=reasonable but field-dependent, 2=subjective, 1=speculative.',
     ),
 });
+
+export const DiagnosticsInputSchema = z.discriminatedUnion('command', [
+  DiagnosticsListSchema,
+  DiagnosticsCountSchema,
+  DiagnosticsAddSchema,
+]);
 
 export type DiagnosticsInput = z.infer<typeof DiagnosticsInputSchema>;
 
@@ -108,7 +121,9 @@ export class DiagnosticsTool extends defineTool({
     return resolveWorkspaceRelativePath(filePath, workingDirectory).absolute;
   }
 
-  private async readDiagnostics(input: DiagnosticsInput): Promise<ToolResult> {
+  private async readDiagnostics(
+    input: Extract<DiagnosticsInput, { command: 'list' | 'count' }>,
+  ): Promise<ToolResult> {
     const { command, path } = input;
     const diagnosticsPath = this.resolveAbsolutePath(path);
 
@@ -145,18 +160,10 @@ export class DiagnosticsTool extends defineTool({
     }
   }
 
-  private async addCriticism(input: DiagnosticsInput): Promise<ToolResult> {
+  private async addCriticism(
+    input: Extract<DiagnosticsInput, { command: 'add' }>,
+  ): Promise<ToolResult> {
     const { path, line, message, severity, confidence } = input;
-    if (
-      line == null ||
-      message == null ||
-      severity == null ||
-      confidence == null
-    ) {
-      throw new ToolError(
-        'The "add" command requires line, message, severity, and confidence.',
-      );
-    }
 
     try {
       const absolutePath = this.resolveAbsolutePath(path);


### PR DESCRIPTION
## Summary

Follow-up to a code-review audit (12 findings, grouped High/Medium/Low) into loose or duplicated data-structure designs across the codebase. Each finding forced call sites into type assertions, null-guards, or heuristic reconstruction to work around an undisciplined shape. 11 of the 12 are fixed with real changes below; the 12th (`FlowRecord.shared`) was attempted, then reverted after review feedback identified the fix as dead code (see note).

- **DiagnosticsInputSchema** (`src/tools/DiagnosticsTool.ts`): converted to `z.discriminatedUnion('command', ...)` so the `add` variant's four fields are required only when relevant, instead of `.nullish()` everywhere plus a manual null-check in `addCriticism()`.
- **DelegateAgentInputSchema** (`src/tools/DelegationTools.ts`): added `.refine()` enforcing exactly one of `agent`/`execution_id`, replacing a hand-branched `if/else` in `execute()`. Kept both fields `.nullish()` (no LLM-facing schema change).
- **DiffOperation** (`src/latex/latexdiff/types.ts`): converted to a proper discriminated TS union (`round` vs. `between-rounds` variants), removing the silent `operation.round ?? 0` fallback in `diffOperations.ts`.
- **outputsByRound**: replaced the `Map<number,...>` → `Record<string,...>` → re-parse-via-`RoundKeySchema` → `Map` round-trip with a `[round, files][]` tuple array carried end-to-end (`ProgressWorkflowActionsController.ts`, `latexdiffCommands.ts`, `latex/latexdiff/types.ts`). The producer sorts ascending and the command-boundary consumer filters/sorts defensively (since `texra.runLatexdiff` accepts arbitrary command args) — restored after review feedback flagged the initial version as losing determinism and trusting an unvalidated payload shape.
- **listId**: typed as `MultiFilesKeySchema` (`keyof MultiFiles`) instead of raw `z.string()`, removing now-redundant `as keyof MultiFiles` casts in `MainApp.ts` and `FileSelectGroup.ts`.
- ~~**FlowRecord.shared**~~ (`src/agent/node/persistedFlow.ts`): initially threaded an optional `validateShared` callback, but reverted — review feedback correctly identified it as a speculative seam with zero callers (the one `PersistedFlow` instantiation site omits it, and `attach()` is never invoked anywhere), i.e. dead code per this repo's "no future-flexibility hooks without a concrete consumer" convention. The file is unchanged from `main` on this point; a real fix needs a caller with an actual schema for its `S`.
- **Electron IPC EXECUTE handler** (`packages/desktop/src/main/desktopExecutionIpc.ts`): validates against `MainViewInboundMessageSchema` instead of casting an unvalidated renderer message.
- **tooluse PrepareResult/CyclePrepResult**: consolidated two identical, independently-maintained interfaces into one (`CyclePrepResult`, field `shouldSkipCycle`).
- **MERGE/COMPARE/ACCEPT_EDITED webview commands**: replaced `z.looseObject({command: literal})` with real per-command schemas requiring `inputFile`/`baseFile`/`editedFile`, so file paths reach VS Code commands only after validation.
- **MainViewExecuteMessage**: regrouped 26 flat optional fields into `files`/`session`/`toolConfig` sub-objects matching how `MainViewExecutionController` actually consumes them.
- **ToolResultSchema**: centralized the ambiguous-result status-inference heuristic into `NormalizedToolResultSchema`, deleting the duplicated inline heuristic in `toolAttachmentUtils.ts`. Left the ~50 tool-producer files' `ToolResultSchema` shape unchanged (too large a blast radius to touch directly) and instead fixed the one consumer that needed disambiguation.
- **PermissionState casts**: made `BaseRequestPanel`/`BaseFeedbackPanel` generic over the permission `kind`, eliminating 15+ unsafe `this.permission.data as X` casts across progress-view panels (`ToolEditRequestPanel`, `BashRequestPanel`, `RetryRequestPanel`, `ProposalRequestPanel`, `PlanApprovalRequestPanel`, `ExternalInquiryPanel`, `UserQuestionPanel`).

## Issue acceptance gates

11 of the 12 original audit findings are addressed with real (not stubbed) changes, covered by the existing or updated test suite. The 12th (`FlowRecord.shared`) is intentionally left as-is (see above) — reopening it is deferred to whichever future PR introduces a real caller needing validation.

## Single source of truth

- `NormalizedToolResultSchema` (`src/shared/schemas/toolResult.ts`) is now the single place the tool-result status-inference precedence rules live.
- `MultiFilesKeySchema` (`src/shared/schemas/mainView/state.ts`) is the single derivation of valid `listId` values (`MultiFilesSchema.keyof()`), replacing scattered `as keyof MultiFiles` casts.
- `BaseRequestPanel<K>`'s generic `permission: Extract<PermissionState, {kind: K}>` is the single narrowing point for permission data; subclasses no longer re-derive it via casts.

## Duplication and abstraction budget

Removed: duplicate `PrepareResult`/`CyclePrepResult` interfaces; the Map↔Record↔re-parse round-trip for `outputsByRound`; the duplicated status-inference heuristic (schema vs. consumer). No new pass-through wrapper layers were added — `BaseRequestPanel`/`BaseFeedbackPanel` became generic in place rather than gaining a new abstraction layer, and `getBypassInfo()` is a single exhaustive-switch helper (not a wrapper) for the one case (`BaseFeedbackPanel`) that legitimately spans multiple permission kinds. A speculative `validateShared` seam was added and then removed in the same PR once review feedback showed it had no consumer — net budget impact is zero for that item.

## Host impact

Extension: webview panel generics (`progressView/frontend/components/*`), `MainApp.ts`, `MainViewMessageHandler.ts`, `executionHandlers.ts`, `latexdiffCommands.ts`.

Desktop: `desktopExecutionIpc.ts` now validates the EXECUTE message at the IPC boundary instead of casting.

CLI: unaffected — no CLI-specific files touched.

## Scheduled refactoring

None required for this PR. Two follow-up opportunities noted but out of scope:
1. `MainViewExecuteMessage` is still a hand-written TS type rather than schema-first (`z.infer`); a future PR could define `MainViewExecuteMessageSchema` and derive the type, enabling full field-level validation at the Electron IPC boundary (currently only the `command` discriminant is deep-validated there).
2. `FlowRecord.shared` (`src/agent/node/persistedFlow.ts`) is still an unchecked `unknown` cast to `S`. Fixing it for real needs a caller-specific schema/validator wired in at the point a caller actually needs one — not a schema-less generic hook.

## Validation

- `npx tsc --noEmit` (root) — clean
- `npx tsc --noEmit -p tsconfig.test-kernel.json` — clean
- `corepack pnpm --filter texra typecheck` — clean
- `corepack pnpm --filter @texra-ai/cli typecheck` — clean
- `npm run lint` — 0 errors (pre-existing warnings only, in files untouched by this PR)
- `npm test` — 4363 passed, 7 skipped, 1 failed; the failure (`execUtils.vitest.ts` "aborts shell command process groups") reproduces identically on a clean `git stash` of this branch, confirming it's a pre-existing sandbox/environment flake unrelated to this change, not a regression.
- Addressed review feedback from Cursor Bugbot, Copilot, and an automated Claude reviewer in a follow-up commit (empty-round metadata fallback, round ordering/defensive validation at the command boundary, `validateShared` revert) — all four threads verified against the code and resolved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches execution IPC, webview→command file paths, and main-view execute payload shape; changes are mostly validation and typing but affect user-facing run/merge/diff flows if payloads drift from the UI.
> 
> **Overview**
> This PR tightens loose shapes that previously forced casts, heuristics, or silent defaults across extension, desktop, and shared packages.
> 
> **Validation and boundaries:** Desktop **EXECUTE** IPC now parses `MainViewInboundMessageSchema` and rejects malformed renderer input instead of casting. Main-view **MERGE**, **COMPARE**, and **ACCEPT_EDITED** get per-command Zod schemas so file paths are validated before `handleFileOperation` runs VS Code commands. **Diagnostics** and **delegate_agent** tool inputs use discriminated unions / `.refine()` so required fields and mutual exclusivity are schema-enforced, not runtime branches.
> 
> **Message and execution shapes:** `MainViewExecuteMessage` is regrouped into **`files`**, **`session`**, and **`toolConfig`**; `MainViewExecutionController` and the webview builder follow that layout. **`listId`** is typed as `MultiFilesKeySchema` (`keyof MultiFiles`), dropping `as keyof MultiFiles` in the UI.
> 
> **LaTeX diff:** `outputsByRound` is a sorted **`[round, files][]`** tuple end-to-end, normalized at the command boundary via `normalizeRunLatexdiffOutputsByRound`. **`DiffOperation`** is a proper TS discriminated union; the **`operation.round ?? 0`** fallback is removed.
> 
> **Progress view:** `BaseRequestPanel` / `BaseFeedbackPanel` are generic over permission **`kind`**, removing many `permission.data as …` casts; **`getBypassInfo`** exhaustively switches on kinds for session bypass.
> 
> **Agent / tools:** Duplicate **`PrepareResult`** / **`CyclePrepResult`** merge into **`CyclePrepResult`** with **`shouldSkipCycle`**. Tool-result status inference moves to **`NormalizedToolResultSchema`**; **`extractToolAttachments`** delegates to it instead of duplicating heuristics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0d76630e4c86e4b74eee3671fa63505107c33b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->