### PR TITLE
refactor(agent): drop dead PersistedFlow.attach/getRunId; 2026-07-03 SDK-readiness checkpoint

### DIFF
--- a/docs/proposals/agent-sdk-readiness-checkpoint-2026-07-03.md
+++ b/docs/proposals/agent-sdk-readiness-checkpoint-2026-07-03.md
@@ -60,10 +60,11 @@ at HEAD:
 - **PocketFlow `Node.exec → createFlow().run` shape** and the
   **lead-and-specialists delegation model** — unchanged.
 
-## Applied this pass — one unattended-safe pure deletion
+## Applied this pass — two confirmed-safe cleanups
 
-**`PersistedFlow.attach()` + `PersistedFlow.getRunId()` deleted**
-(`src/agent/node/persistedFlow.ts`). Both are genuine zero-caller dead code:
+### 1. `PersistedFlow.attach()` + `PersistedFlow.getRunId()` deleted (pure dead code)
+
+`src/agent/node/persistedFlow.ts`. Both are genuine zero-caller dead code:
 
 - `static async attach<S,P,Svc>(kv, runId, start)` (17 lines + JSDoc) — a
   documented "attach to an existing persisted flow for resume" factory. Verified
@@ -80,8 +81,32 @@ Both are absent from all prior readiness docs (grep: 0 hits in the canonical doc
 the detailed audit, the delta, and every checkpoint), so this is a genuinely-new
 find, not a re-open. This is the same **pure-deletion class the 06-30 checkpoint
 applied unattended**; the 07-02 checkpoint reported "no equivalent unattended-safe
-deletion" was found — this pass found one. `npm run typecheck` — **exit 0** across
-all projects after the deletion.
+deletion" was found — this pass found one.
+
+### 2. `PersistedFlow.init()` one-caller alias inlined
+
+`init(shared)` was a pure pass-through to the private `ensureRecord(shared)`
+with a single caller, `RoundPersistedFlow.run()` (`roundPersistedFlow.ts:138`).
+Since `RoundPersistedFlow extends PersistedFlow`, `ensureRecord` was promoted
+`private → protected`, `RoundPersistedFlow.run()` now calls it directly, and the
+`init()` wrapper was deleted. Behavior-identical (this was candidate #1 below,
+promoted to applied after confirming the single caller).
+
+**Verification:** `npm run typecheck` — **exit 0** across all projects
+(`tsc --noEmit`, test-kernel, `texra`, `@texra-ai/cli`) after both changes; the
+full agent test suite — **888 passed / 4 skipped** — after both changes. `runId`
+field retained (used internally by `flowKey(this.runId)`).
+
+**Attempted and reverted — `createMediaContent(): any[] → unknown[]` (candidate #3
+below).** Empirically **not** confirmed-safe: the abstract's `any` is load-bearing
+for the `createMediaMessage` wrapper's `Promise<ReturnType<typeof
+this.createMediaContent>>` return type — the base-class method resolves the
+_abstract_ signature, so `any` silently flows through to concrete call sites in
+`modelHandlerOpenAI` / `modelHandlerOpenRouterNative`. `unknown[]` produced 11
+`TS2345`/`TS2322` errors there. A correct fix requires making
+`createMediaContent` / `createMediaMessage` generic over the provider
+content-part type — reviewed-train, not an unattended one-liner. Reverted; the
+candidate is re-scoped below.
 
 ## Genuinely-new candidates — surfaced by this fan-out, absent from all prior docs
 
@@ -91,13 +116,11 @@ signature / surface changes or design-direction notes); none is unattended-safe.
 
 ### Core / runtime
 
-1. **`PersistedFlow.init()` is a one-caller public alias for private
-   `ensureRecord()`** _(LOW)_. `persistedFlow.ts` `init(shared)` is a pure
-   pass-through to the private `ensureRecord(shared)`; the sole caller is
-   `RoundPersistedFlow.run()` (`roundPersistedFlow.ts`). Since
-   `RoundPersistedFlow extends PersistedFlow`, making `ensureRecord` `protected`
-   and calling it directly lets `init()` be deleted. Not applied unattended:
-   changes a member's visibility on a base class. Reviewed-train.
+1. **`PersistedFlow.init()` one-caller alias** _(LOW)_ — **APPLIED this pass**
+   (see § Applied #2). Left here for the record: `init(shared)` was a pure
+   pass-through to private `ensureRecord(shared)` with the sole caller
+   `RoundPersistedFlow.run()`; `ensureRecord` promoted to `protected` and the
+   wrapper deleted. Typecheck + full suite green.
 
 2. **Two divergent round-loop mechanisms for the same control-flow shape**
    _(MEDIUM — design consistency, note-only)_. The reflection flow drives its
@@ -114,12 +137,18 @@ signature / surface changes or design-direction notes); none is unattended-safe.
 ### Model handlers
 
 3. **`createMediaContent` returns `any[]` on the abstract base member**
-   _(LOW)_. `ModelHandler.ts:814` — `abstract createMediaContent(mediaMessage:
+   _(MEDIUM — re-scoped after an empirical attempt this pass)_.
+   `ModelHandler.ts:814` — `abstract createMediaContent(mediaMessage:
 MediaEntry[]): any[]` — the lone `any` on an abstract member in a class that
-   otherwise preserves full `<M,U,T,C,Resp>` generic typing. Every provider
-   implements it with a concrete provider content-part type. Widen to the
-   provider content-part type (or at least `unknown[]`). Not on `IModelHandler`,
-   so self-contained. Reviewed-train (touches each provider's signature).
+   otherwise preserves full `<M,U,T,C,Resp>` generic typing. **The naive fix
+   (`any[] → unknown[]`) does not work** — see § Applied's revert note: the
+   abstract `any` flows through the `createMediaMessage` wrapper's
+   `ReturnType<typeof this.createMediaContent>` return type and `unknown` breaks
+   11 concrete call sites. The real fix is to make `createMediaContent` /
+   `createMediaMessage` generic over the provider content-part type (each
+   override already returns a concrete type: `ContentBlockParam[]`,
+   `ChatCompletionContentPart[]`, `ResponseInputContent[]`, `ChatContentItems[]`,
+   `MediaEntry[]`). Reviewed-train (a real generics refactor, not a one-liner).
 
 4. **`IModelHandler` role-split angle** _(MEDIUM surface — distinct from the
    adjudicated "delete `IModelHandler`" trap)_. The ~35-method port bundles two
@@ -229,14 +258,17 @@ Split points ranked by value/effort (unchanged from 06-26 → 07-02):
 
 ## Recommendation
 
-**SDK-ready in shape; no structural refactoring warranted.** One unattended-safe
-pure deletion applied this pass (`PersistedFlow.attach` + `getRunId`). Continue
-the canonical plan's surface / multi-tenant track through the reviewed PR train:
-port narrowing (incl. the new `IModelHandler` role-split and `createMediaContent`
-typing), per-session state relocation, the typed `delegateTo` primitive, and
-wiring `review` as the first Verifier delegation. Fold the six new candidates
-above into that train — none but the applied deletion is an unattended sweep. Do
-not re-open the adjudicated traps.
+**SDK-ready in shape; no structural refactoring warranted.** Two confirmed-safe
+cleanups applied this pass: the `PersistedFlow.attach` + `getRunId` dead-code
+deletion and the `PersistedFlow.init` one-caller-alias inline (both typecheck +
+full-suite green). A third attempt (`createMediaContent` typing) was made,
+empirically found unsafe as a one-liner, and reverted — re-scoped to a generics
+refactor. Continue the canonical plan's surface / multi-tenant track through the
+reviewed PR train: port narrowing (incl. the `IModelHandler` role-split and the
+`createMediaContent` generics), per-session state relocation, the typed
+`delegateTo` primitive, and wiring `review` as the first Verifier delegation.
+Fold the remaining candidates above into that train — none of them is an
+unattended sweep. Do not re-open the adjudicated traps.
 
 ## Verified (this checkpoint)
 
@@ -248,8 +280,14 @@ not re-open the adjudicated traps.
 src/agent/node/persistedFlow.ts` → **0** after edit; both had **0** callers
   across `src` + `packages` before deletion; absent from all prior readiness docs
   (0 grep hits). `runId` field retained.
-- New candidates verified in-tree: `PersistedFlow.init` → private `ensureRecord`
-  (1 caller `RoundPersistedFlow`); `RoundPersistedFlow` instantiated once
+- Applied inline verified: `PersistedFlow.init` had exactly **1** caller
+  (`RoundPersistedFlow.run()`, `roundPersistedFlow.ts:138`); `ensureRecord`
+  promoted `private → protected`; `grep "\.init(" src/agent/node` → **0** after
+  edit. `createMediaContent any[] → unknown[]` attempted → **11 TS errors**
+  (`modelHandlerOpenAI` / `modelHandlerOpenRouterNative`) → reverted.
+- Both applied changes verified green: `npm run typecheck` **exit 0** (all four
+  projects); `npx vitest run src/test-kernel/agent/` — **888 passed / 4 skipped**.
+- Other candidates verified in-tree: `RoundPersistedFlow` instantiated once
   (`runReflectionFlow.ts`); `createMediaContent(): any[]` (`ModelHandler.ts:814`);
   `Pick<IModelHandler, …>` already in `followUpMessages.ts`; `@platform` barrel
   4 importers vs 79 deep-path; `@logger/index.ts` 1 re-export vs 164 deep imports.

--- a/docs/proposals/agent-sdk-readiness-checkpoint-2026-07-03.md
+++ b/docs/proposals/agent-sdk-readiness-checkpoint-2026-07-03.md
@@ -1,0 +1,263 @@
+# Agent SDK Readiness — Verification Checkpoint (2026-07-03)
+
+**Status:** Verification checkpoint. Read alongside the canonical
+[`agent-sdk-readiness.md`](./agent-sdk-readiness.md), the detailed
+[`../agent-sdk-readiness-audit.md`](../agent-sdk-readiness-audit.md), the
+[`agent-sdk-readiness-delta-2026-06-24.md`](./agent-sdk-readiness-delta-2026-06-24.md)
+addendum, and the `-2026-06-25` / `-2026-06-26` / `-2026-06-30` / `-2026-07-01` /
+[`-2026-07-02`](./agent-sdk-readiness-checkpoint-2026-07-02.md) checkpoints.
+
+This pass re-verified the standing audit against the working tree at HEAD
+(`11e063e`, branch `claude/eager-noether-9y5i4s`), which contains the 07-02
+checkpoint's base plus the subsequent PR train (#6904 typed Platform port for
+tool-edit approval, #6905/#6906 CLI stream/proposal routing, #6908 desktop
+orphaned-stream repair, #6909 agent-sync ownership). None of those touch the four
+audit areas structurally.
+
+## Why this exists
+
+Another recurring "review and refactor for Agent SDK readiness" request landed,
+scoped (as before) against the same four areas: **agent core + runtime**,
+**`modelHandlers/`**, **logger + platform/public surface**, and **subagent
+boundaries**. As on every prior pass, this checkpoint ran a **fresh, uninformed
+3-way fan-out audit** (one reader for core+runtime, one for `modelHandlers/`, one
+for logger+platform+public surface), then reconciled every finding against the
+adjudicated rulings. The uninformed audit re-surfaced the known traps (filtered
+out below) and re-confirmed the tracked candidates — **and it went one level
+deeper into `src/agent/node/persistedFlow.ts` than any prior pass, surfacing a
+genuine, unattended-safe pure deletion that the 07-02 checkpoint had explicitly
+reported it could not find.** That deletion is applied this pass; everything else
+is recorded as reviewed-train class.
+
+## Verdict — unchanged
+
+**The codebase remains well-aligned and SDK-ready in shape. No structural
+refactoring is warranted.** The three fresh readers independently reached the
+same conclusion the standing plan holds — most notably the `modelHandlers` reader
+**rejected the "collapse the OpenAI-compatible subclasses" and "delete
+`IModelHandler`" premises on its own**, and the core reader found **no**
+`Node.exec → wrapper → coreFunction → createFlow → flow.run` ladders, **no**
+trivial identity factories, and **no** two-layer `buildX`-only-from-`createX`
+factories in the flow/node layer. The SDK-idiomatic spine is re-confirmed in-tree
+at HEAD:
+
+- **`createModelHandler` factory** — `PROVIDER_HANDLER_ROUTES` exhaustive
+  `Record<ModelProvider, …>` (`ModelFactory.ts:55`), single `createModelHandler`
+  entry (`:378`). Compatibility-key routing means an SDK-backed handler can drop
+  in behind one case with zero caller changes.
+- **`platform()` composition root** — `initPlatform` (`platform.ts:49`), frozen
+  `platform()` accessor (`:57`). The single-call-site ports (`linter`,
+  `addCriticismSink`, `toolMissingHandler`, `toolNotificationHandler`,
+  `toolEditApproval`) each re-verified to have **three genuinely different
+  implementations** (VS Code UI / Node no-op / test fake) — correct host seams,
+  not accidental abstraction.
+- **`AgentTrace` emit/subscribe channel** — `src/agent/trace/index.ts` still the
+  single `emit()`/`subscribe()` surface; `debug/info/warn/error`, stages,
+  streams, and domain helpers are sugar over `emit()`. This maps ~1:1 onto the
+  Agent SDK streamed-message model.
+- **No barrel regression** — `src/agent/core/index.ts` remains **absent**;
+  `@texra/core` (`packages/core/src/index.ts`) is the one curated surface.
+- **PocketFlow `Node.exec → createFlow().run` shape** and the
+  **lead-and-specialists delegation model** — unchanged.
+
+## Applied this pass — one unattended-safe pure deletion
+
+**`PersistedFlow.attach()` + `PersistedFlow.getRunId()` deleted**
+(`src/agent/node/persistedFlow.ts`). Both are genuine zero-caller dead code:
+
+- `static async attach<S,P,Svc>(kv, runId, start)` (17 lines + JSDoc) — a
+  documented "attach to an existing persisted flow for resume" factory. Verified
+  **zero callers** across `src` + `packages` (grep for `.attach(`, `.attach<`,
+  `PersistedFlow.attach` — only its own definition matched). The real resume path
+  does not use it: `runToolUseFlow` / `runReflectionFlow` construct the flow
+  directly and resume by reading the `FlowRecord` themselves. Speculative API
+  surface for a distributed/resume-by-attach scenario no consumer exercises.
+- `getRunId()` — verified **zero callers** repo-wide (only the definition
+  matched). The `runId` field is retained (used internally by `flowKey(this.runId)`
+  in `stepWithResult` / `getShared`).
+
+Both are absent from all prior readiness docs (grep: 0 hits in the canonical doc,
+the detailed audit, the delta, and every checkpoint), so this is a genuinely-new
+find, not a re-open. This is the same **pure-deletion class the 06-30 checkpoint
+applied unattended**; the 07-02 checkpoint reported "no equivalent unattended-safe
+deletion" was found — this pass found one. `npm run typecheck` — **exit 0** across
+all projects after the deletion.
+
+## Genuinely-new candidates — surfaced by this fan-out, absent from all prior docs
+
+Confirmed by grep to appear in none of the canonical doc, the detailed audit, the
+delta, or the 06-25 → 07-02 checkpoints. All are reviewed-train class (type /
+signature / surface changes or design-direction notes); none is unattended-safe.
+
+### Core / runtime
+
+1. **`PersistedFlow.init()` is a one-caller public alias for private
+   `ensureRecord()`** _(LOW)_. `persistedFlow.ts` `init(shared)` is a pure
+   pass-through to the private `ensureRecord(shared)`; the sole caller is
+   `RoundPersistedFlow.run()` (`roundPersistedFlow.ts`). Since
+   `RoundPersistedFlow extends PersistedFlow`, making `ensureRecord` `protected`
+   and calling it directly lets `init()` be deleted. Not applied unattended:
+   changes a member's visibility on a base class. Reviewed-train.
+
+2. **Two divergent round-loop mechanisms for the same control-flow shape**
+   _(MEDIUM — design consistency, note-only)_. The reflection flow drives its
+   round loop through a dedicated `RoundPersistedFlow` subclass (~250 LOC,
+   `run()` owns `while (shouldContinueNextRound) …`), while the tool-use flow
+   expresses the identical "run the cycle again" loop as an **in-graph edge**
+   (`waitNode.on(FlowTransition.CONTINUE, cycleNode)` in `runToolUseFlow.ts`).
+   `RoundPersistedFlow` is instantiated exactly once (`runReflectionFlow.ts`). A
+   reader must learn two mental models for one shape. Longer term, converging on
+   one looping mechanism (preferably the graph edge, see § SDK divergence) is the
+   highest-leverage structural move — but it is not a quick delete and is flagged
+   for direction, not action.
+
+### Model handlers
+
+3. **`createMediaContent` returns `any[]` on the abstract base member**
+   _(LOW)_. `ModelHandler.ts:814` — `abstract createMediaContent(mediaMessage:
+   MediaEntry[]): any[]` — the lone `any` on an abstract member in a class that
+   otherwise preserves full `<M,U,T,C,Resp>` generic typing. Every provider
+   implements it with a concrete provider content-part type. Widen to the
+   provider content-part type (or at least `unknown[]`). Not on `IModelHandler`,
+   so self-contained. Reviewed-train (touches each provider's signature).
+
+4. **`IModelHandler` role-split angle** _(MEDIUM surface — distinct from the
+   adjudicated "delete `IModelHandler`" trap)_. The ~35-method port bundles two
+   disjoint flow roles (reflection/workflow message-building vs tool-use
+   dispatch) plus usage/pricing, yet no single consumer needs all of them —
+   `followUpMessages.ts` **already** narrows via `Pick<IModelHandler,
+   'addMediaToUserMessage' | 'capabilities' | 'createUserFollowUpMessages'>`.
+   Extending that `Pick<>` pattern into named role slices (`ISamplingHandler` /
+   `IReflectionHandler` / `IToolUseHandler` / `IUsageHandler`, with
+   `ModelHandler` implementing the union) would let a minimal SDK-backed provider
+   satisfy only the slice it runs. **This is not the adjudicated trap** (which was
+   *removing* the interface as a duplicate of `ModelHandler` — still a trap; the
+   optional `createBatchedToolUseFollowUpMessages?` + `Pick<>` narrowing keep it
+   load-bearing). Type-only refactor, reviewed-train.
+
+### Logger / platform surface
+
+5. **`@platform` barrel is a near-dead facade** _(LOW surface)_.
+   `src/platform/index.ts` exists to make the CLAUDE.md-mandated
+   `import … from '@platform'` path real, but only **4 files** use it while **79**
+   bypass it via the deep `from '@platform/platform'`. Two valid paths for
+   identical symbols; the convention the barrel enforces is followed ~5% of the
+   time. Pick one — codemod the 79 deep imports to `@platform`, or delete the
+   barrel and bless `@platform/platform` in CLAUDE.md (the deep path is already
+   declared "stays valid," so deletion is lower-effort). Reviewed-train
+   (import-path churn).
+
+6. **`@logger/index.ts` is a 1-symbol barrel** _(TRIVIAL)_. It re-exports only
+   `createChannelTrace`; the real logger API (`debug/info/warn/error`,
+   `redactSecrets`, `setOutputChannelFactory`, …) is reached by 164 direct
+   imports of `@logger/logUtils` / `@logger/redaction`. The barrel gives a false
+   impression of being a curated facade. Either promote the real API into the
+   index or drop the 1-line index. Cosmetic; opportunistic.
+
+## Adjudicated traps the fan-out re-surfaced — rulings held
+
+The uninformed audit raised, and the standing rulings correctly filter, all of
+the following. No change.
+
+| Re-surfaced candidate                                                               | Ruling                                                                                                                                            |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Collapse OpenAI-compatible subclasses (DeepSeek/Kimi/MiniMax/GLM) to a config table | **Trap** — the `modelHandlers` reader rejected this itself: each carries real per-provider override points (`getThinkingParameter` shapes, reasoning-wire fields, temperatures, token-count APIs). Only DashScope (1 flag) + XAI are genuinely thin. |
+| Remove `IModelHandler` as a "duplicate" of `ModelHandler`                            | **Trap** — optional `createBatchedToolUseFollowUpMessages?` + `Pick<>` consumer narrowing make it load-bearing (see new candidate #4 for the distinct *split* angle).           |
+| Inline `createResponse → withCreateResponseGuard → sdkErrorTagger`                  | **Keep** — each hook has a distinct real overrider (OpenAIResponse in-flight guard; per-SDK tagger; per-handler impl).                            |
+| Provider getters `isGrokReasoningModel` / `isDeepSeek` / `isKimi` / `isMiniMax` are "dead" | **VERIFIED FALSE** (detailed audit) — used by `modelHandlerOpenAI` / `ModelHandlerOpenRouterNative`; the live angle is *placement* (07-02 candidate #7), still reviewed-train. |
+| `ModelFactory` two-layer / trivial-identity factories                               | **No violation** — `createModelHandler` + `createModelHandlerForCompatibilityKey` are two real entry points sharing logic (justified DRY); routes give compile-time exhaustiveness. |
+| Inline the cycle-wrapper nodes / `createXCycleFlow` factories                       | **Keep** — this *is* the mandated `Node.exec → createFlow → flow.run` shape.                                                                      |
+| Collapse `runAgent` / `runAgentStream` dual entry / add a `runtime/index.ts` barrel | **Trap** — deliberate naming; `@texra/core` **is** the curated barrel.                                                                            |
+| `AgentTrace` over-layered / platform single-call-site ports are over-abstraction    | **Keep** — trace is one `emit()` SSoT (SDK-shaped); the thin ports each have three divergent host impls.                                          |
+| Two logging idioms (`logUtils` vs `createChannelTrace`) are "redundant"             | **Known / tracked** — run-scope vs module-singleton split targeted by `docs/prds/2026-05-17-logger-surface-cleanup.md`; the reader's "narrow `createChannelTrace` to 4 methods for log-only singletons" is the same tracked cleanup, not novel. |
+| `runToolUseAgent` / `runReflectionAgent` are single-caller wrappers                 | **Keep** — each owns genuinely category-specific wiring (progress-turn counting / follow-up side effects vs per-round callback); inlining bloats `executeAgent`. The reader flagged them as defensible, not must-fix. |
+| Test-only injection seams on `runReflectionFlow` (`getOutputFileLocation?` etc.)    | **Keep** — legitimate DI-for-testability; production caller passes neither.                                                                       |
+
+## Structural divergence from the Agent SDK loop — re-stated (no new action)
+
+The three divergences remain the accurate picture of where TeXRA's shape differs
+from the SDK's flat `query()` generator loop; all are justified capability, not
+over-abstraction:
+
+1. **Nested two-flow execution.** The SDK's single "model call + tool dispatch"
+   loop is TeXRA's *inner* cycle flow (`createResponseCycleFlow` /
+   `createToolUseRoundFlow`); an outer persisted flow drives rounds and bridges
+   services across the boundary. The nesting exists for persistence, not
+   ceremony. Highest-leverage SDK-alignment move (candidate #2) is to converge
+   the two round loops and consider collapsing the inner cycle flow into nodes of
+   the outer flow, making "one model call + tool dispatch" a graph edge.
+2. **Persistence-first design.** Every node step is `structuredClone`'d to a KV
+   store so a run resumes after a VS Code reload — a real product requirement with
+   no SDK counterpart (this is *why* the loop can't be a plain generator, and why
+   the now-deleted `attach`/`getRunId` speculative resume surface was never
+   needed).
+3. **Rich human-in-the-loop coordination.** `BasePromiseCoordinator` +
+   plan-approval / proposal / manual-retry coordinators implement interactive
+   gates the SDK collapses to a single `canUseTool` permission callback. Additive
+   capability.
+
+## Subagent split points — re-confirmed, unchanged
+
+No change to the canonical/delta analysis. TeXRA already ships a **mature
+subagent mechanism**: YAML agent profiles ≈ SDK `AgentDefinition`; `delegate_agent`
+/ `delegate_workflow` + `executeSubagent` = the isolated-context delegation
+primitive (with `NESTED_DELEGATION_DEPTH_RANGE` depth policy and worktree
+isolation); the `claude_agent` tool embeds `@anthropic-ai/claude-agent-sdk`
+directly, and `codex` mirrors it. The three highest-confidence already-isolated
+units a formal decomposition would draw on are unchanged:
+
+- **`ModelFactory.createModelHandler`** — `(modelName) → handler`; the "model
+  provider" unit.
+- **`assembleAgentLaunchContext`** — `(launchInput) → launchContext`; the "define
+  an agent" half of the SDK model.
+- **`agentToolResolution`** — `(declaredTools, gates) → effectiveTools`; the SDK's
+  tools-as-data resolver, a pure pipeline.
+
+Split points ranked by value/effort (unchanged from 06-26 → 07-02):
+
+1. Wire the existing `review` tool-use agent as a post-draft Verifier delegation
+   (lowest risk; reuses `executeSubagent`, no new flow code).
+2. Introduce a typed `delegateTo(subagent, input, { maxDepth, tools })` primitive
+   over the existing plumbing.
+3. Formalize workflow agents (`polish` / `correct` / `merge`) as SDK actors with
+   typed I/O contracts.
+4. Relocate the remaining module-global registries onto the per-session handle —
+   gates concurrent in-process sessions (agent registry + `agentDirectoriesRegistry`
+   are the concrete targets).
+5. Decompose in-agent multi-phase workflow agents (`devise`, `verifyFix`) into
+   draft → Verifier → apply hand-offs — gated by #4.
+
+## Recommendation
+
+**SDK-ready in shape; no structural refactoring warranted.** One unattended-safe
+pure deletion applied this pass (`PersistedFlow.attach` + `getRunId`). Continue
+the canonical plan's surface / multi-tenant track through the reviewed PR train:
+port narrowing (incl. the new `IModelHandler` role-split and `createMediaContent`
+typing), per-session state relocation, the typed `delegateTo` primitive, and
+wiring `review` as the first Verifier delegation. Fold the six new candidates
+above into that train — none but the applied deletion is an unattended sweep. Do
+not re-open the adjudicated traps.
+
+## Verified (this checkpoint)
+
+- Spine re-confirmed by grep at HEAD `11e063e`: `PROVIDER_HANDLER_ROUTES` +
+  `createModelHandler` (`ModelFactory.ts:55/378`), `initPlatform` / `platform`
+  (`platform.ts:49/57`), `AgentTrace` emit/subscribe (`trace/index.ts`),
+  `src/agent/core/index.ts` **absent** (no barrel regression).
+- Applied deletion verified: `grep "static async attach\|getRunId"
+  src/agent/node/persistedFlow.ts` → **0** after edit; both had **0** callers
+  across `src` + `packages` before deletion; absent from all prior readiness docs
+  (0 grep hits). `runId` field retained.
+- New candidates verified in-tree: `PersistedFlow.init` → private `ensureRecord`
+  (1 caller `RoundPersistedFlow`); `RoundPersistedFlow` instantiated once
+  (`runReflectionFlow.ts`); `createMediaContent(): any[]` (`ModelHandler.ts:814`);
+  `Pick<IModelHandler, …>` already in `followUpMessages.ts`; `@platform` barrel
+  4 importers vs 79 deep-path; `@logger/index.ts` 1 re-export vs 164 deep imports.
+- Model-handler thin-subclass measurement corroborated independently: DashScope
+  14 LOC (1 config flag `convertContentToString`), XAI 38 LOC (1 debug log),
+  GLM 51, vs DeepSeek 113 / MiniMax 120 / Kimi 148 (real per-provider overrides)
+  — collapse remains lossy; the config-driven `PROVIDER_HANDLER_ROUTES` registry
+  is already the right shape and each thin class keeps a persisted
+  `compatibilityKey`.
+- `npm run typecheck` — **exit 0** across all projects (`tsc --noEmit`,
+  test-kernel, `texra`, `@texra-ai/cli`) after the deletion.

--- a/docs/proposals/agent-sdk-readiness-checkpoint-2026-07-03.md
+++ b/docs/proposals/agent-sdk-readiness-checkpoint-2026-07-03.md
@@ -42,11 +42,11 @@ factories in the flow/node layer. The SDK-idiomatic spine is re-confirmed in-tre
 at HEAD:
 
 - **`createModelHandler` factory** — `PROVIDER_HANDLER_ROUTES` exhaustive
-  `Record<ModelProvider, …>` (`ModelFactory.ts:55`), single `createModelHandler`
-  entry (`:378`). Compatibility-key routing means an SDK-backed handler can drop
+  `Record<ModelProvider, …>` (`ModelFactory.ts:54`), single `createModelHandler`
+  entry (`:377`). Compatibility-key routing means an SDK-backed handler can drop
   in behind one case with zero caller changes.
-- **`platform()` composition root** — `initPlatform` (`platform.ts:49`), frozen
-  `platform()` accessor (`:57`). The single-call-site ports (`linter`,
+- **`platform()` composition root** — `initPlatform` (`platform.ts:66`), frozen
+  `platform()` accessor (`:74`). The single-call-site ports (`linter`,
   `addCriticismSink`, `toolMissingHandler`, `toolNotificationHandler`,
   `toolEditApproval`) each re-verified to have **three genuinely different
   implementations** (VS Code UI / Node no-op / test fake) — correct host seams,
@@ -138,7 +138,7 @@ signature / surface changes or design-direction notes); none is unattended-safe.
 
 3. **`createMediaContent` returns `any[]` on the abstract base member**
    _(MEDIUM — re-scoped after an empirical attempt this pass)_.
-   `ModelHandler.ts:814` — `abstract createMediaContent(mediaMessage:
+   `ModelHandler.ts:823` — `abstract createMediaContent(mediaMessage:
 MediaEntry[]): any[]` — the lone `any` on an abstract member in a class that
    otherwise preserves full `<M,U,T,C,Resp>` generic typing. **The naive fix
    (`any[] → unknown[]`) does not work** — see § Applied's revert note: the
@@ -273,8 +273,8 @@ unattended sweep. Do not re-open the adjudicated traps.
 ## Verified (this checkpoint)
 
 - Spine re-confirmed by grep at HEAD `11e063e`: `PROVIDER_HANDLER_ROUTES` +
-  `createModelHandler` (`ModelFactory.ts:55/378`), `initPlatform` / `platform`
-  (`platform.ts:49/57`), `AgentTrace` emit/subscribe (`trace/index.ts`),
+  `createModelHandler` (`ModelFactory.ts:54/377`), `initPlatform` / `platform`
+  (`platform.ts:66/74`), `AgentTrace` emit/subscribe (`trace/index.ts`),
   `src/agent/core/index.ts` **absent** (no barrel regression).
 - Applied deletion verified: `grep "static async attach\|getRunId"
 src/agent/node/persistedFlow.ts` → **0** after edit; both had **0** callers
@@ -288,7 +288,7 @@ src/agent/node/persistedFlow.ts` → **0** after edit; both had **0** callers
 - Both applied changes verified green: `npm run typecheck` **exit 0** (all four
   projects); `npx vitest run src/test-kernel/agent/` — **888 passed / 4 skipped**.
 - Other candidates verified in-tree: `RoundPersistedFlow` instantiated once
-  (`runReflectionFlow.ts`); `createMediaContent(): any[]` (`ModelHandler.ts:814`);
+  (`runReflectionFlow.ts`); `createMediaContent(): any[]` (`ModelHandler.ts:823`);
   `Pick<IModelHandler, …>` already in `followUpMessages.ts`; `@platform` barrel
   4 importers vs 79 deep-path; `@logger/index.ts` 1 re-export vs 164 deep imports.
 - Model-handler thin-subclass measurement corroborated independently: DashScope

--- a/docs/proposals/agent-sdk-readiness-checkpoint-2026-07-03.md
+++ b/docs/proposals/agent-sdk-readiness-checkpoint-2026-07-03.md
@@ -115,7 +115,7 @@ signature / surface changes or design-direction notes); none is unattended-safe.
 
 3. **`createMediaContent` returns `any[]` on the abstract base member**
    _(LOW)_. `ModelHandler.ts:814` — `abstract createMediaContent(mediaMessage:
-   MediaEntry[]): any[]` — the lone `any` on an abstract member in a class that
+MediaEntry[]): any[]` — the lone `any` on an abstract member in a class that
    otherwise preserves full `<M,U,T,C,Resp>` generic typing. Every provider
    implements it with a concrete provider content-part type. Widen to the
    provider content-part type (or at least `unknown[]`). Not on `IModelHandler`,
@@ -126,12 +126,12 @@ signature / surface changes or design-direction notes); none is unattended-safe.
    disjoint flow roles (reflection/workflow message-building vs tool-use
    dispatch) plus usage/pricing, yet no single consumer needs all of them —
    `followUpMessages.ts` **already** narrows via `Pick<IModelHandler,
-   'addMediaToUserMessage' | 'capabilities' | 'createUserFollowUpMessages'>`.
+'addMediaToUserMessage' | 'capabilities' | 'createUserFollowUpMessages'>`.
    Extending that `Pick<>` pattern into named role slices (`ISamplingHandler` /
    `IReflectionHandler` / `IToolUseHandler` / `IUsageHandler`, with
    `ModelHandler` implementing the union) would let a minimal SDK-backed provider
    satisfy only the slice it runs. **This is not the adjudicated trap** (which was
-   *removing* the interface as a duplicate of `ModelHandler` — still a trap; the
+   _removing_ the interface as a duplicate of `ModelHandler` — still a trap; the
    optional `createBatchedToolUseFollowUpMessages?` + `Pick<>` narrowing keep it
    load-bearing). Type-only refactor, reviewed-train.
 
@@ -159,19 +159,19 @@ signature / surface changes or design-direction notes); none is unattended-safe.
 The uninformed audit raised, and the standing rulings correctly filter, all of
 the following. No change.
 
-| Re-surfaced candidate                                                               | Ruling                                                                                                                                            |
-| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Collapse OpenAI-compatible subclasses (DeepSeek/Kimi/MiniMax/GLM) to a config table | **Trap** — the `modelHandlers` reader rejected this itself: each carries real per-provider override points (`getThinkingParameter` shapes, reasoning-wire fields, temperatures, token-count APIs). Only DashScope (1 flag) + XAI are genuinely thin. |
-| Remove `IModelHandler` as a "duplicate" of `ModelHandler`                            | **Trap** — optional `createBatchedToolUseFollowUpMessages?` + `Pick<>` consumer narrowing make it load-bearing (see new candidate #4 for the distinct *split* angle).           |
-| Inline `createResponse → withCreateResponseGuard → sdkErrorTagger`                  | **Keep** — each hook has a distinct real overrider (OpenAIResponse in-flight guard; per-SDK tagger; per-handler impl).                            |
-| Provider getters `isGrokReasoningModel` / `isDeepSeek` / `isKimi` / `isMiniMax` are "dead" | **VERIFIED FALSE** (detailed audit) — used by `modelHandlerOpenAI` / `ModelHandlerOpenRouterNative`; the live angle is *placement* (07-02 candidate #7), still reviewed-train. |
-| `ModelFactory` two-layer / trivial-identity factories                               | **No violation** — `createModelHandler` + `createModelHandlerForCompatibilityKey` are two real entry points sharing logic (justified DRY); routes give compile-time exhaustiveness. |
-| Inline the cycle-wrapper nodes / `createXCycleFlow` factories                       | **Keep** — this *is* the mandated `Node.exec → createFlow → flow.run` shape.                                                                      |
-| Collapse `runAgent` / `runAgentStream` dual entry / add a `runtime/index.ts` barrel | **Trap** — deliberate naming; `@texra/core` **is** the curated barrel.                                                                            |
-| `AgentTrace` over-layered / platform single-call-site ports are over-abstraction    | **Keep** — trace is one `emit()` SSoT (SDK-shaped); the thin ports each have three divergent host impls.                                          |
-| Two logging idioms (`logUtils` vs `createChannelTrace`) are "redundant"             | **Known / tracked** — run-scope vs module-singleton split targeted by `docs/prds/2026-05-17-logger-surface-cleanup.md`; the reader's "narrow `createChannelTrace` to 4 methods for log-only singletons" is the same tracked cleanup, not novel. |
-| `runToolUseAgent` / `runReflectionAgent` are single-caller wrappers                 | **Keep** — each owns genuinely category-specific wiring (progress-turn counting / follow-up side effects vs per-round callback); inlining bloats `executeAgent`. The reader flagged them as defensible, not must-fix. |
-| Test-only injection seams on `runReflectionFlow` (`getOutputFileLocation?` etc.)    | **Keep** — legitimate DI-for-testability; production caller passes neither.                                                                       |
+| Re-surfaced candidate                                                                      | Ruling                                                                                                                                                                                                                                               |
+| ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Collapse OpenAI-compatible subclasses (DeepSeek/Kimi/MiniMax/GLM) to a config table        | **Trap** — the `modelHandlers` reader rejected this itself: each carries real per-provider override points (`getThinkingParameter` shapes, reasoning-wire fields, temperatures, token-count APIs). Only DashScope (1 flag) + XAI are genuinely thin. |
+| Remove `IModelHandler` as a "duplicate" of `ModelHandler`                                  | **Trap** — optional `createBatchedToolUseFollowUpMessages?` + `Pick<>` consumer narrowing make it load-bearing (see new candidate #4 for the distinct _split_ angle).                                                                                |
+| Inline `createResponse → withCreateResponseGuard → sdkErrorTagger`                         | **Keep** — each hook has a distinct real overrider (OpenAIResponse in-flight guard; per-SDK tagger; per-handler impl).                                                                                                                               |
+| Provider getters `isGrokReasoningModel` / `isDeepSeek` / `isKimi` / `isMiniMax` are "dead" | **VERIFIED FALSE** (detailed audit) — used by `modelHandlerOpenAI` / `ModelHandlerOpenRouterNative`; the live angle is _placement_ (07-02 candidate #7), still reviewed-train.                                                                       |
+| `ModelFactory` two-layer / trivial-identity factories                                      | **No violation** — `createModelHandler` + `createModelHandlerForCompatibilityKey` are two real entry points sharing logic (justified DRY); routes give compile-time exhaustiveness.                                                                  |
+| Inline the cycle-wrapper nodes / `createXCycleFlow` factories                              | **Keep** — this _is_ the mandated `Node.exec → createFlow → flow.run` shape.                                                                                                                                                                         |
+| Collapse `runAgent` / `runAgentStream` dual entry / add a `runtime/index.ts` barrel        | **Trap** — deliberate naming; `@texra/core` **is** the curated barrel.                                                                                                                                                                               |
+| `AgentTrace` over-layered / platform single-call-site ports are over-abstraction           | **Keep** — trace is one `emit()` SSoT (SDK-shaped); the thin ports each have three divergent host impls.                                                                                                                                             |
+| Two logging idioms (`logUtils` vs `createChannelTrace`) are "redundant"                    | **Known / tracked** — run-scope vs module-singleton split targeted by `docs/prds/2026-05-17-logger-surface-cleanup.md`; the reader's "narrow `createChannelTrace` to 4 methods for log-only singletons" is the same tracked cleanup, not novel.      |
+| `runToolUseAgent` / `runReflectionAgent` are single-caller wrappers                        | **Keep** — each owns genuinely category-specific wiring (progress-turn counting / follow-up side effects vs per-round callback); inlining bloats `executeAgent`. The reader flagged them as defensible, not must-fix.                                |
+| Test-only injection seams on `runReflectionFlow` (`getOutputFileLocation?` etc.)           | **Keep** — legitimate DI-for-testability; production caller passes neither.                                                                                                                                                                          |
 
 ## Structural divergence from the Agent SDK loop — re-stated (no new action)
 
@@ -180,7 +180,7 @@ from the SDK's flat `query()` generator loop; all are justified capability, not
 over-abstraction:
 
 1. **Nested two-flow execution.** The SDK's single "model call + tool dispatch"
-   loop is TeXRA's *inner* cycle flow (`createResponseCycleFlow` /
+   loop is TeXRA's _inner_ cycle flow (`createResponseCycleFlow` /
    `createToolUseRoundFlow`); an outer persisted flow drives rounds and bridges
    services across the boundary. The nesting exists for persistence, not
    ceremony. Highest-leverage SDK-alignment move (candidate #2) is to converge
@@ -188,7 +188,7 @@ over-abstraction:
    the outer flow, making "one model call + tool dispatch" a graph edge.
 2. **Persistence-first design.** Every node step is `structuredClone`'d to a KV
    store so a run resumes after a VS Code reload — a real product requirement with
-   no SDK counterpart (this is *why* the loop can't be a plain generator, and why
+   no SDK counterpart (this is _why_ the loop can't be a plain generator, and why
    the now-deleted `attach`/`getRunId` speculative resume surface was never
    needed).
 3. **Rich human-in-the-loop coordination.** `BasePromiseCoordinator` +
@@ -245,7 +245,7 @@ not re-open the adjudicated traps.
   (`platform.ts:49/57`), `AgentTrace` emit/subscribe (`trace/index.ts`),
   `src/agent/core/index.ts` **absent** (no barrel regression).
 - Applied deletion verified: `grep "static async attach\|getRunId"
-  src/agent/node/persistedFlow.ts` → **0** after edit; both had **0** callers
+src/agent/node/persistedFlow.ts` → **0** after edit; both had **0** callers
   across `src` + `packages` before deletion; absent from all prior readiness docs
   (0 grep hits). `runId` field retained.
 - New candidates verified in-tree: `PersistedFlow.init` → private `ensureRecord`

--- a/src/agent/node/persistedFlow.ts
+++ b/src/agent/node/persistedFlow.ts
@@ -191,31 +191,6 @@ export class PersistedFlow<
     };
   }
 
-  /**
-   * Attach to an existing persisted flow for resume.
-   *
-   * @param kv - Storage backend (ExecutionKVStore)
-   * @param runId - The run identifier to resume. Defaults to kv.getExecutionId().
-   * @param start - The starting node of the flow graph
-   */
-  static async attach<
-    S = Record<string, unknown>,
-    P extends Record<string, unknown> = Record<string, unknown>,
-    Svc = unknown,
-  >(
-    kv: ExecutionKVStore,
-    runId: string | undefined,
-    start: BaseNode,
-  ): Promise<PersistedFlow<S, P, Svc>> {
-    const effectiveRunId = runId ?? kv.getExecutionId();
-    const flow = await kv.read<FlowRecord>(flowKey(effectiveRunId));
-    if (!flow) throw new Error(`flow "${effectiveRunId}" not found`);
-    const pf = new PersistedFlow<S, P, Svc>(start, kv, effectiveRunId);
-    pf.setParams(flow.params as P);
-    pf.cachedRecord = flow;
-    return pf;
-  }
-
   async getShared(): Promise<S | undefined> {
     const flow =
       this.cachedRecord ??
@@ -226,10 +201,6 @@ export class PersistedFlow<
 
   async setShared(newShared: S): Promise<void> {
     await this.commitShared(newShared);
-  }
-
-  getRunId(): string {
-    return this.runId;
   }
 
   /**

--- a/src/agent/node/persistedFlow.ts
+++ b/src/agent/node/persistedFlow.ts
@@ -233,11 +233,7 @@ export class PersistedFlow<
     await this.fireProjection(shared);
   }
 
-  async init(shared: S): Promise<void> {
-    await this.ensureRecord(shared);
-  }
-
-  private async ensureRecord(shared: S): Promise<void> {
+  protected async ensureRecord(shared: S): Promise<void> {
     const key = flowKey(this.runId);
     const existing = await this.kv.read<FlowRecord>(key);
     if (existing) {

--- a/src/agent/node/roundPersistedFlow.ts
+++ b/src/agent/node/roundPersistedFlow.ts
@@ -135,7 +135,7 @@ export class RoundPersistedFlow<
   async run(shared: S): Promise<RunOutcome> {
     let outcome: RunOutcome = RUN_OUTCOME.COMPLETED;
 
-    await this.init(shared);
+    await this.ensureRecord(shared);
     let currentShared = shared;
 
     try {


### PR DESCRIPTION
The `PersistedFlow.attach()` static resume factory and `getRunId()` getter
have zero callers across src + packages — the real resume path reconstructs
the flow directly and reads the FlowRecord itself, never via attach(). The
runId field is retained (used internally by flowKey()). Pure deletion,
typecheck green.

Also records the 2026-07-03 verification checkpoint: a fresh 3-way fan-out
audit (core+runtime, modelHandlers, logger+platform+surface) that re-confirmed
the standing "SDK-ready in shape, no structural refactoring warranted" verdict,
filtered the re-surfaced adjudicated traps, and logged six reviewed-train
candidates plus this one unattended-safe deletion.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GVvPJW36REm9FMLwmbRqFq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, behavior-preserving deletions and a direct call swap in persisted flow setup; no auth, persistence protocol, or runtime loop changes.
> 
> **Overview**
> Removes unused **`PersistedFlow`** surface and tightens the round-flow init path, and adds a **2026-07-03 Agent SDK readiness verification checkpoint** doc.
> 
> **Code:** Deletes the unused static **`attach()`** resume factory and **`getRunId()`** (no callers; resume still builds flows and reads **`FlowRecord`** directly). Drops the **`init()`** pass-through on **`PersistedFlow`**; **`RoundPersistedFlow.run()`** now calls **`ensureRecord()`** directly after promoting **`ensureRecord`** from `private` to `protected`. Internal **`runId`** and **`flowKey(this.runId)`** behavior are unchanged.
> 
> **Docs:** The new checkpoint records a fresh 3-way audit, reaffirms “SDK-ready in shape / no structural refactor,” lists reviewed-train follow-ups, and notes a reverted attempt to narrow **`createMediaContent`** typing (`any[]` → `unknown[]` broke concrete handlers).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37dee9b05dfe9ec7bd2d2227b2d21acdd7d0125e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->