### PR TITLE
docs: document intentional ~ prefix difference in compaction log lines

### DIFF
--- a/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
@@ -284,10 +284,12 @@ export class AIAgentsTab extends LitElement {
                       return html`
                         <tool-card .item=${item}>
                           ${
-                          inlineSettings
-                            ? html`<div slot="details">${inlineSettings}</div>`
-                            : nothing
-                        }
+                            inlineSettings
+                              ? html`<div slot="details">
+                                  ${inlineSettings}
+                                </div>`
+                              : nothing
+                          }
                         </tool-card>
                       `;
                     },

--- a/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
@@ -354,10 +354,10 @@ export class GitTab extends LitElement {
                               >${subscription.key}</code
                             >
                             ${
-                            subscription.owners.length > 0
-                              ? html`
-                                  <div class="subscription-owners">
-                                    ${subscription.owners.map(
+                              subscription.owners.length > 0
+                                ? html`
+                                    <div class="subscription-owners">
+                                      ${subscription.owners.map(
                                       (owner) => html`
                                         <div class="subscription-owner-row">
                                           <span class="subscription-owner-label"
@@ -368,34 +368,34 @@ export class GitTab extends LitElement {
                                             variant="neutral"
                                             size="small"
                                             @click=${() =>
-                                            this.handleOpenPRSubscriptionStream(
-                                              owner.streamId,
-                                            )}
+                                              this.handleOpenPRSubscriptionStream(
+                                                owner.streamId,
+                                              )}
                                           >
                                             ${waIcon('comment-discussion', {
-                                            slot: 'start',
-                                          })}
+                                              slot: 'start',
+                                            })}
                                             Jump to agent
                                           </wa-button>
                                         </div>
                                       `,
                                     )}
-                                  </div>
-                                `
-                              : html`
-                                  <p class="subscription-owner-placeholder">
-                                    Started by an agent that is no longer
-                                    active.
-                                  </p>
-                                `
-                          }
+                                    </div>
+                                  `
+                                : html`
+                                    <p class="subscription-owner-placeholder">
+                                      Started by an agent that is no longer
+                                      active.
+                                    </p>
+                                  `
+                            }
                           </div>
                           <wa-button
                             appearance="outlined"
                             variant="neutral"
                             size="small"
                             @click=${() =>
-                            this.handleUnsubscribePR(subscription.key)}
+                              this.handleUnsubscribePR(subscription.key)}
                           >
                             ${waIcon('debug-stop', { slot: 'start' })} Stop
                           </wa-button>

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -937,6 +937,12 @@ export abstract class ModelHandler<
       const reductionPercent =
         tokensBefore > 0 ? ((reduction / tokensBefore) * 100).toFixed(1) : '0';
 
+      // NOTE: estimatedTokensAfter comes from the summarize() function's
+      // output token count — it approximates the size of the summary text,
+      // not the exact token count when re-submitting compacted messages.
+      // The "~" prefix reflects this approximate nature. Contrast with the
+      // OpenAI Responses API path in modelHandlerOpenAIResponse.ts, which
+      // re-counts tokens precisely via estimateTokenCount() and omits "~".
       logContextManagementEvent(
         this.logger,
         `Compacted conversation: ${tokensBefore.toLocaleString()} → ~${estimatedTokensAfter.toLocaleString()} tokens (${reductionPercent}% reduction)`,

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -958,7 +958,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       const reduction = tokensBefore - tokensAfter;
       const reductionPercent = ((reduction / tokensBefore) * 100).toFixed(1);
 
-      // Log context management event with structured data
+      // NOTE: tokensAfter comes from estimateTokenCount() on the actual
+      // compacted messages, so it is a precise count — no "~" prefix needed.
+      // Contrast with ModelHandler.ts, which uses the summarize() function's
+      // approximate output token count and adds "~" to indicate it.
       logContextManagementEvent(
         this.logger,
         `Compacted conversation: ${tokensBefore.toLocaleString()} → ${tokensAfter.toLocaleString()} tokens (${reductionPercent}% reduction)`,


### PR DESCRIPTION
Documents the intentional `~` prefix difference between the two compaction log sites.

- `ModelHandler.ts` uses `~` because the post-compaction token count is an estimate from `summarize()` output
- `modelHandlerOpenAIResponse.ts` omits `~` because it re-counts tokens precisely via `estimateTokenCount()`

Cross-referencing comments at both sites so future readers don't need to re-discover this.

Closes #6873.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only documentation in model handlers plus cosmetic template formatting in settings UI; no runtime logic changes.
> 
> **Overview**
> Adds **cross-referencing comments** at the two conversation-compaction log lines so the intentional difference in post-compaction token display is obvious without re-reading both implementations.
> 
> In **`ModelHandler.runClientCompaction`**, the log keeps **`~`** before the “after” count because **`tokensAfter`** is derived from **`summarize()`** output tokens (an approximation of summary size, not a re-submit count). In **`modelHandlerOpenAIResponse.compactConversation`**, the log omits **`~`** because **`tokensAfter`** comes from **`estimateTokenCount()`** on the compacted messages (treated as precise). Each site points to the other.
> 
> **`AIAgentsTab`** and **`GitTab`** only re-indent nested Lit `html` template branches; behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ca7a568cf6ef0e8e304ecfb014b56865857ef7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->