### PR TITLE
refactor(runtime): scope tool edit approval to run context

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -975,6 +975,8 @@ export class DesktopProgressBridge {
           runtimeHost: this.runtimeHost,
           session: this.session,
           runtimeUnavailableTools: DESKTOP_UNAVAILABLE_TOOLS,
+          toolEditApprovalHandler: (approvalRequest) =>
+            this.toolEditApprovals.requestApproval(approvalRequest),
           reportFailure: (error) => this.reportResumeFailure(streamId, error),
         }),
       executeWorkflow: (config, executionId, modelHandlerCompatibilityKey) =>
@@ -1185,6 +1187,8 @@ export class DesktopProgressBridge {
       runtimeHost: this.runtimeHost,
       session: this.session,
       runtimeUnavailableTools: DESKTOP_UNAVAILABLE_TOOLS,
+      toolEditApprovalHandler: (approvalRequest) =>
+        this.toolEditApprovals.requestApproval(approvalRequest),
       modelHandlerCompatibilityKey: options.modelHandlerCompatibilityKey,
       openWorkflowOutput: async (result) => {
         // Gate, outcome check, and final-output selection are shared policy

--- a/packages/desktop/src/main/desktopToolEditApproval.ts
+++ b/packages/desktop/src/main/desktopToolEditApproval.ts
@@ -44,6 +44,15 @@ export interface DesktopToolEditApprovalController {
     action: ToolEditApprovalAction;
     feedback?: string;
   }): boolean;
+  /**
+   * This window's tool-edit approval handler. Pass this to `runAgent`/
+   * `resumeToolUseSnapshot` as `toolEditApprovalHandler` so a request always
+   * resolves through this window's controller, not whichever window's
+   * controller last wrote the shared `platform().toolEditApproval` fallback.
+   */
+  requestApproval(
+    request: ToolEditApprovalRequest,
+  ): Promise<ToolEditApprovalResult>;
   dispose(): void;
 }
 

--- a/src/agent/core/flows/BaseFlowServices.ts
+++ b/src/agent/core/flows/BaseFlowServices.ts
@@ -28,6 +28,19 @@ export type RoundFinalizedCallback = (
   run: AgentRunStateSnapshot,
 ) => void | Promise<void>;
 
+/** Delegation-scoped policy flags, grouped so they travel together on `AgentCore`. */
+export interface DelegationPolicy {
+  /**
+   * Delegation depth: 0 for root (user-initiated), N for a subagent N levels deep.
+   * Set by executeAgent from ExecuteAgentOptions.delegationDepth. Used by the
+   * tool-use flow to gate delegation tools and by the delegation tool itself
+   * to compute the child's depth.
+   */
+  delegationDepth?: number;
+  /** Whether approval or user prompts cannot be answered by the current host. */
+  approvalPromptsUnavailable?: boolean;
+}
+
 export interface AgentCore<C = unknown> {
   modelHandler: IModelHandler<ProviderMessage, unknown, SdkToolCall, C>;
   config: AgentConfig;
@@ -41,15 +54,7 @@ export interface AgentCore<C = unknown> {
   userVarChannels: UserVariableChannels;
   /** Working directory override for subagent tool calls (e.g. a git worktree). */
   workingDirectory?: string;
-  /**
-   * Delegation depth: 0 for root (user-initiated), N for a subagent N levels deep.
-   * Set by executeAgent from ExecuteAgentOptions.delegationDepth. Used by the
-   * tool-use flow to gate delegation tools and by the delegation tool itself
-   * to compute the child's depth.
-   */
-  delegationDepth?: number;
-  /** Whether approval or user prompts cannot be answered by the current host. */
-  approvalPromptsUnavailable?: boolean;
+  delegation?: DelegationPolicy;
   /** Tools unavailable because the current host/runtime cannot support them. */
   runtimeUnavailableTools?: readonly string[];
   /** Get active subagent and process children for a parent stream. */

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -196,10 +196,7 @@ type ContinuationNodeResult = SkippableNodeResult<{
 export function responseCycleToolsForModel<C>(
   services: Pick<
     ResponseCycleServices<C>,
-    | 'approvalPromptsUnavailable'
-    | 'modelHandler'
-    | 'runtimeUnavailableTools'
-    | 'setting'
+    'delegation' | 'modelHandler' | 'runtimeUnavailableTools' | 'setting'
   >,
 ): ToolDefinition[] | undefined {
   if (!services.modelHandler.capabilities.supportsFunctionCalling) {
@@ -209,7 +206,7 @@ export function responseCycleToolsForModel<C>(
   return services.setting.tools.filter(
     (tool) =>
       !runtimeUnavailable.has(tool.name) &&
-      (services.approvalPromptsUnavailable !== true ||
+      (services.delegation?.approvalPromptsUnavailable !== true ||
         !isApprovalGatedToolName(tool.name)),
   );
 }

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -62,8 +62,6 @@ export interface RunToolUseFlowInput<
   onFollowUpConsumed?: () => void;
   /** When true, delegation tools are filtered out to prevent nesting. */
   isSubagent?: boolean;
-  /** When true, approval-gated tools are filtered out before model invocation. */
-  approvalPromptsUnavailable?: boolean;
   /** Tools unavailable because the current host/runtime cannot support them. */
   runtimeUnavailableTools?: readonly string[];
   /** Fires before the subagent enters WAITING, delivering the last response to the orchestrator. */
@@ -152,14 +150,14 @@ export async function runToolUseFlow<C = unknown>(
   const runSession = currentSession();
   const sessionLifecycle = new ToolUseSessionLifecycle(streamId);
   const registry = toolRegistry ?? getDefaultToolRegistry();
-  const delegationDepth = input.delegationDepth ?? 0;
+  const delegationDepth = input.delegation?.delegationDepth ?? 0;
   const delegationGate = evaluateCurrentDelegationGate(delegationDepth);
   const { tools: resolvedTools, delegationTrimmed } = await resolveAgentTools({
     tools: setting.tools,
     registry,
     logger,
     delegationBlocked: !delegationGate.allowed,
-    approvalPromptsUnavailable: input.approvalPromptsUnavailable,
+    approvalPromptsUnavailable: input.delegation?.approvalPromptsUnavailable,
     runtimeUnavailableTools: input.runtimeUnavailableTools,
     toolInjections: input.toolInjections,
   });
@@ -176,7 +174,7 @@ export async function runToolUseFlow<C = unknown>(
     onRoundFinalized: input.onRoundFinalized ?? (async () => {}),
     persistTodos: (todos) => kv.writeTodos(todos),
     fileService: new TaskRunFileService(executionId),
-    delegationDepth,
+    delegation: { ...input.delegation, delegationDepth },
     delegationTrimmed,
   };
   const switchedHandlers = new Set<ToolUseServices<C>['modelHandler']>();

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -41,6 +41,7 @@ import { UsageMonitor } from '@agent/utils/UsageMonitor';
 import { AgentError, getSdkErrorMessage, toErrorMessage } from '@common/errors';
 import { normalizeRunId } from '@common/constants/runIds';
 import { INSTRUCTION_ACTION } from '@eventBus/ProgressEventBus';
+import type { ToolEditApprovalPort } from '@platform/interfaces/toolEditApproval';
 import {
   STREAM_STATUS,
   type ExecutionId,
@@ -84,6 +85,11 @@ export interface AgentLaunchContext extends AgentCore {
   approvalPromptsUnavailable?: boolean;
   /** Whether this tool-use run exits after one cycle instead of idling. */
   stopAfterCycle?: boolean;
+  /**
+   * Per-run override for the host's tool-edit approval UI, projected onto the
+   * ambient {@link RunContext}. See `RunContext.toolEditApprovalHandler`.
+   */
+  toolEditApprovalHandler?: ToolEditApprovalPort;
   /**
    * Session that owns this run's coordination state. Always populated by
    * {@link buildAgentLaunchContext} (defaults to `currentSession()` — the
@@ -160,6 +166,7 @@ function agentContextToRunContext(
     runtimeUnavailableTools: ctx.runtimeUnavailableTools,
     stopAfterCycle: ctx.stopAfterCycle,
     session: ctx.session,
+    toolEditApprovalHandler: ctx.toolEditApprovalHandler,
   };
 }
 

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -41,7 +41,6 @@ import { UsageMonitor } from '@agent/utils/UsageMonitor';
 import { AgentError, getSdkErrorMessage, toErrorMessage } from '@common/errors';
 import { normalizeRunId } from '@common/constants/runIds';
 import { INSTRUCTION_ACTION } from '@eventBus/ProgressEventBus';
-import type { ToolEditApprovalPort } from '@platform/interfaces/toolEditApproval';
 import {
   STREAM_STATUS,
   type ExecutionId,
@@ -72,6 +71,7 @@ import {
 } from './StreamStatusService';
 import { currentSession, type SessionHandle } from './SessionHandle';
 import { attachConversationProgressHub } from './conversationProgressHub';
+import type { ToolEditApprovalPort } from '@platform/interfaces/toolEditApproval';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 
 export interface AgentLaunchContext extends AgentCore {

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -81,8 +81,6 @@ export interface AgentLaunchContext extends AgentCore {
   streamStatus: StreamStatusRegistry;
   coordinators: RunCoordinators;
   attachedMemoryMisses: AttachedMemoryMiss[];
-  /** Whether approval or user prompts cannot be answered by the current host. */
-  approvalPromptsUnavailable?: boolean;
   /** Whether this tool-use run exits after one cycle instead of idling. */
   stopAfterCycle?: boolean;
   /**
@@ -161,8 +159,8 @@ function agentContextToRunContext(
     getModel: () => ctx.config.model,
     agentName: ctx.config.agent,
     workingDirectory: ctx.workingDirectory,
-    delegationDepth: ctx.delegationDepth,
-    approvalPromptsUnavailable: ctx.approvalPromptsUnavailable,
+    delegationDepth: ctx.delegation?.delegationDepth,
+    approvalPromptsUnavailable: ctx.delegation?.approvalPromptsUnavailable,
     runtimeUnavailableTools: ctx.runtimeUnavailableTools,
     stopAfterCycle: ctx.stopAfterCycle,
     session: ctx.session,

--- a/src/agent/runtime/RunContext.ts
+++ b/src/agent/runtime/RunContext.ts
@@ -1,7 +1,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 
-import type { ToolEditApprovalPort } from '@platform/interfaces/toolEditApproval';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import type { ToolEditApprovalPort } from '@platform/interfaces/toolEditApproval';
 
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 import type { AgentProposalCoordinator } from './AgentProposalCoordinator';

--- a/src/agent/runtime/RunContext.ts
+++ b/src/agent/runtime/RunContext.ts
@@ -1,5 +1,6 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 
+import type { ToolEditApprovalPort } from '@platform/interfaces/toolEditApproval';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
@@ -23,6 +24,15 @@ interface RunContextCommon {
   readonly approvalPromptsUnavailable?: boolean;
   readonly runtimeUnavailableTools?: readonly string[];
   readonly stopAfterCycle?: boolean;
+  /**
+   * Per-run override for the host's tool-edit approval UI. Takes priority over
+   * `platform().toolEditApproval` when present — hosts that manage more than
+   * one concurrent session per process (e.g. desktop's one window per
+   * `DesktopAgentExecution`) thread their session-scoped handler here instead
+   * of relying on the frozen, process-wide Platform port, which only ever
+   * holds one active handler at a time.
+   */
+  readonly toolEditApprovalHandler?: ToolEditApprovalPort;
 }
 
 export interface LaunchRunContext extends RunContextCommon {
@@ -74,6 +84,7 @@ interface CreateRunContextBase {
   runtimeUnavailableTools?: readonly string[];
   stopAfterCycle?: boolean;
   session?: SessionHandle;
+  toolEditApprovalHandler?: ToolEditApprovalPort;
 }
 
 type CreateLaunchRunContextFields = Required<
@@ -136,6 +147,7 @@ export function createRunContext(options: CreateRunContextOptions): RunContext {
       runtimeUnavailableTools: options.runtimeUnavailableTools,
       stopAfterCycle: options.stopAfterCycle,
       session: options.session,
+      toolEditApprovalHandler: options.toolEditApprovalHandler,
     });
   }
 
@@ -156,6 +168,7 @@ export function createRunContext(options: CreateRunContextOptions): RunContext {
     runtimeUnavailableTools: options.runtimeUnavailableTools,
     stopAfterCycle: options.stopAfterCycle,
     session: options.session,
+    toolEditApprovalHandler: options.toolEditApprovalHandler,
   });
 }
 

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -408,8 +408,10 @@ export async function executeAgent(
     session: options.session,
     modelHandlerCompatibilityKey: options.modelHandlerCompatibilityKey,
   });
-  ctx.delegationDepth = options.delegationDepth ?? 0;
-  ctx.approvalPromptsUnavailable = options.approvalPromptsUnavailable;
+  ctx.delegation = {
+    delegationDepth: options.delegationDepth ?? 0,
+    approvalPromptsUnavailable: options.approvalPromptsUnavailable,
+  };
   ctx.runtimeUnavailableTools = options.runtimeUnavailableTools;
   ctx.stopAfterCycle = options.stopAfterCycle;
   ctx.toolEditApprovalHandler = options.toolEditApprovalHandler;
@@ -509,10 +511,12 @@ export async function resumeToolUseFromSnapshot(
   // Recover delegation depth from the persisted parent-execution chain
   // so resumed subagents remain gated by the nested-delegation policy
   // instead of silently promoting to root.
-  ctx.delegationDepth = await computeDelegationDepthFromStorage(
-    snapshot.executionId,
-  );
-  ctx.approvalPromptsUnavailable = options.approvalPromptsUnavailable;
+  ctx.delegation = {
+    delegationDepth: await computeDelegationDepthFromStorage(
+      snapshot.executionId,
+    ),
+    approvalPromptsUnavailable: options.approvalPromptsUnavailable,
+  };
   ctx.runtimeUnavailableTools = options.runtimeUnavailableTools;
   ctx.toolEditApprovalHandler = options.toolEditApprovalHandler;
   const { setting, streamId } = ctx;
@@ -524,7 +528,7 @@ export async function resumeToolUseFromSnapshot(
       );
     }
 
-    const isSubagent = (ctx.delegationDepth ?? 0) > 0;
+    const isSubagent = (ctx.delegation?.delegationDepth ?? 0) > 0;
     await runFlowWithLifecycle(
       ctx,
       async (handle) => {

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -29,7 +29,6 @@ import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 import { AgentError, getSdkErrorMessage } from '@common/errors';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import { createChannelTrace } from '@logger';
-import type { ToolEditApprovalPort } from '@platform/interfaces/toolEditApproval';
 import {
   type StreamTabId,
   type ExecutionId,
@@ -58,6 +57,7 @@ import {
   buildOptionalFlowResultFields,
   type AgentFlowResult,
 } from './AgentFlowResult';
+import type { ToolEditApprovalPort } from '@platform/interfaces/toolEditApproval';
 import type { AgentExecutionHandle, AgentRunHandle } from './executionRegistry';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 import type { ModelHandlerCompatibilityKey } from './modelHandlerCompatibilityKey';

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -29,6 +29,7 @@ import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 import { AgentError, getSdkErrorMessage } from '@common/errors';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import { createChannelTrace } from '@logger';
+import type { ToolEditApprovalPort } from '@platform/interfaces/toolEditApproval';
 import {
   type StreamTabId,
   type ExecutionId,
@@ -370,6 +371,13 @@ export interface ExecuteAgentOptions {
   runtimeUnavailableTools?: readonly string[];
   /** Session owning this run's coordination state. Defaults to the process session. */
   session?: SessionHandle;
+  /**
+   * Per-run override for the host's tool-edit approval UI. Hosts that manage
+   * more than one concurrent session per process (e.g. desktop, one window per
+   * run) pass their session-scoped handler here instead of relying on the
+   * frozen, process-wide `platform().toolEditApproval` port.
+   */
+  toolEditApprovalHandler?: ToolEditApprovalPort;
   /** Resume using this persisted provider-message format instead of today's default route. */
   modelHandlerCompatibilityKey?: ModelHandlerCompatibilityKey | null;
   /** Fires after flow completes but before executionRegistry.untrack, so follow-ups are enqueued before waiters resolve. */
@@ -404,6 +412,7 @@ export async function executeAgent(
   ctx.approvalPromptsUnavailable = options.approvalPromptsUnavailable;
   ctx.runtimeUnavailableTools = options.runtimeUnavailableTools;
   ctx.stopAfterCycle = options.stopAfterCycle;
+  ctx.toolEditApprovalHandler = options.toolEditApprovalHandler;
   return withExecutionRunContext(ctx, async () => {
     const { setting, streamId, config } = ctx;
     const { isSubagent } = options;
@@ -469,6 +478,8 @@ export interface ResumeToolUseFromSnapshotOptions {
   readonly runtimeUnavailableTools?: readonly string[];
   /** Session owning this run's coordination state. Defaults to the process session. */
   readonly session?: SessionHandle;
+  /** Per-run override for the host's tool-edit approval UI — see `ExecuteAgentOptions.toolEditApprovalHandler`. */
+  readonly toolEditApprovalHandler?: ToolEditApprovalPort;
   readonly onRun?: (handle: AgentRunHandle) => void | Promise<void>;
   readonly setupSession?: (session: IToolUseSession) => void;
 }
@@ -503,6 +514,7 @@ export async function resumeToolUseFromSnapshot(
   );
   ctx.approvalPromptsUnavailable = options.approvalPromptsUnavailable;
   ctx.runtimeUnavailableTools = options.runtimeUnavailableTools;
+  ctx.toolEditApprovalHandler = options.toolEditApprovalHandler;
   const { setting, streamId } = ctx;
 
   await withExecutionRunContext(ctx, async () => {

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -1,13 +1,13 @@
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
 import type { FollowUpQueueInput } from '@agent/followUp/FollowUpQueue';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
-import type { ToolEditApprovalPort } from '@platform/interfaces/toolEditApproval';
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+import { resumeToolUseFromSnapshot } from './executeAgent';
+import { StreamStatusService } from './StreamStatusService';
+import type { ToolEditApprovalPort } from '@platform/interfaces/toolEditApproval';
 
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
-import { resumeToolUseFromSnapshot } from './executeAgent';
 import type { SessionHandle } from './SessionHandle';
-import { StreamStatusService } from './StreamStatusService';
 
 export interface ResumeQueuedToolUseOptions {
   /** Session owning this run's coordination state. Defaults to the process session. */

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -1,6 +1,7 @@
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
 import type { FollowUpQueueInput } from '@agent/followUp/FollowUpQueue';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
+import type { ToolEditApprovalPort } from '@platform/interfaces/toolEditApproval';
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
@@ -13,6 +14,8 @@ export interface ResumeQueuedToolUseOptions {
   readonly session?: SessionHandle;
   /** Tools hidden because the current host/runtime cannot support them. */
   readonly runtimeUnavailableTools?: readonly string[];
+  /** Per-run override for the host's tool-edit approval UI — see `ExecuteAgentOptions.toolEditApprovalHandler`. */
+  readonly toolEditApprovalHandler?: ToolEditApprovalPort;
   /**
    * Follow-ups to replay ahead of any items already queued for the stream
    * (e.g. an explicit follow-up typed alongside a manual resume). Seeded before
@@ -61,6 +64,7 @@ export async function resumeQueuedToolUseSnapshot(
     await resumeToolUseFromSnapshot(snapshot, runtimeHost, {
       session: options.session,
       runtimeUnavailableTools: options.runtimeUnavailableTools,
+      toolEditApprovalHandler: options.toolEditApprovalHandler,
       setupSession: (session) => {
         for (const item of followUps) {
           session.appendFollowUp(item);

--- a/src/agent/runtime/resumeToolUseSnapshot.ts
+++ b/src/agent/runtime/resumeToolUseSnapshot.ts
@@ -14,9 +14,9 @@
  * not change either host's pre-unification resume behavior.
  */
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
+import { resumeQueuedToolUseSnapshot } from './resumeQueuedToolUse';
 import type { ToolEditApprovalPort } from '@platform/interfaces/toolEditApproval';
 
-import { resumeQueuedToolUseSnapshot } from './resumeQueuedToolUse';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 import type { SessionHandle } from './SessionHandle';
 

--- a/src/agent/runtime/resumeToolUseSnapshot.ts
+++ b/src/agent/runtime/resumeToolUseSnapshot.ts
@@ -14,6 +14,7 @@
  * not change either host's pre-unification resume behavior.
  */
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
+import type { ToolEditApprovalPort } from '@platform/interfaces/toolEditApproval';
 
 import { resumeQueuedToolUseSnapshot } from './resumeQueuedToolUse';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
@@ -26,6 +27,8 @@ export interface ResumeToolUseHostOptions {
   readonly explicitFollowUp?: string;
   /** Tools hidden because the current host/runtime cannot support them. */
   readonly runtimeUnavailableTools?: readonly string[];
+  /** Per-run override for the host's tool-edit approval UI — see `ExecuteAgentOptions.toolEditApprovalHandler`. */
+  readonly toolEditApprovalHandler?: ToolEditApprovalPort;
   /**
    * Session owning this run's coordination state. Host-path callers (e.g. the
    * desktop progress-view IPC handler) thread their window session; defaults to
@@ -56,6 +59,7 @@ export async function resumeToolUseSnapshot(
     {
       session: options.session,
       runtimeUnavailableTools: options.runtimeUnavailableTools,
+      toolEditApprovalHandler: options.toolEditApprovalHandler,
       extraFollowUps:
         options.explicitFollowUp !== undefined
           ? [{ text: options.explicitFollowUp, origin: 'user' as const }]

--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -1,11 +1,11 @@
 import { registerExecution } from '@agent/storage';
 
 import type { ValidatedExecutionRequest } from '@agent/core/state/executionRequests';
-import type { ToolEditApprovalPort } from '@platform/interfaces/toolEditApproval';
 import type { ExecutionId } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core/executionId';
 import { applyHelperModelPreference } from './helperModelPreference';
 import { executeAgent } from './executeAgent';
+import type { ToolEditApprovalPort } from '@platform/interfaces/toolEditApproval';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 import type { AgentFlowResult, WorkflowFlowResult } from './AgentFlowResult';
 import type { AgentRunHandle } from './executionRegistry';

--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -1,6 +1,7 @@
 import { registerExecution } from '@agent/storage';
 
 import type { ValidatedExecutionRequest } from '@agent/core/state/executionRequests';
+import type { ToolEditApprovalPort } from '@platform/interfaces/toolEditApproval';
 import type { ExecutionId } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core/executionId';
 import { applyHelperModelPreference } from './helperModelPreference';
@@ -19,6 +20,11 @@ export interface RunAgentOptions {
   stopAfterCycle?: boolean;
   approvalPromptsUnavailable?: boolean;
   runtimeUnavailableTools?: readonly string[];
+  /**
+   * Per-run override for the host's tool-edit approval UI — see
+   * `ExecuteAgentOptions.toolEditApprovalHandler`.
+   */
+  toolEditApprovalHandler?: ToolEditApprovalPort;
   /**
    * Opt-in set by the "fix LaTeX" VS Code actions (Fix-Compilation command, the
    * progress-view compile fixer): run the launched agent on the configured
@@ -85,6 +91,7 @@ export async function runAgent(
     stopAfterCycle: options.stopAfterCycle,
     approvalPromptsUnavailable: options.approvalPromptsUnavailable,
     runtimeUnavailableTools: options.runtimeUnavailableTools,
+    toolEditApprovalHandler: options.toolEditApprovalHandler,
     session: options.session,
     modelHandlerCompatibilityKey: options.modelHandlerCompatibilityKey,
     onRun: options.onRun,

--- a/src/test-kernel/agent/ResponseCycleTools.vitest.mts
+++ b/src/test-kernel/agent/ResponseCycleTools.vitest.mts
@@ -17,7 +17,7 @@ function responseServices({
   supportsFunctionCalling?: boolean;
 }) {
   return {
-    approvalPromptsUnavailable,
+    delegation: { approvalPromptsUnavailable },
     runtimeUnavailableTools,
     modelHandler: {
       capabilities: { supportsFunctionCalling },

--- a/src/test-kernel/tools/ConcurrentToolEditApprovalHandlers.vitest.ts
+++ b/src/test-kernel/tools/ConcurrentToolEditApprovalHandlers.vitest.ts
@@ -1,0 +1,117 @@
+// Third-party imports
+import * as assert from 'node:assert';
+import { describe, it, beforeEach, afterEach } from 'vitest';
+
+// Local imports - tests
+import { createFakePlatform } from '@test/support/FakePlatform';
+
+// Local imports - agent types
+import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
+
+// Local imports - tools
+import type { StreamTabId } from '@shared/schemas';
+import { cleanupAllApprovals } from '@tools/approval';
+import {
+  requestToolEditApproval,
+  type ToolEditApprovalRequest,
+  type ToolEditApprovalResult,
+} from '@tools/approval/toolEditApproval';
+
+/**
+ * Proves the desktop multi-window fix: two runs with distinct
+ * `toolEditApprovalHandler`s on their `RunContext` never cross-talk, even when
+ * both requests are in flight at once (the shared approval queue serializes
+ * execution but must not leak which handler a given request resolves through).
+ * Before this fix, every host routed through the single process-wide
+ * `platform().toolEditApproval` port, so a second window's handler silently
+ * stole the first window's in-flight prompt.
+ */
+describe('Concurrent per-run tool edit approval handlers', () => {
+  beforeEach(async () => {
+    const { initPlatform } = await import('@platform/platform');
+    initPlatform(
+      createFakePlatform(
+        { workspacePath: '/workspace', config: {}, files: {} },
+        {
+          toolEditApproval: () => {
+            throw new Error(
+              'platform().toolEditApproval should not be reached when the ' +
+                'RunContext supplies its own toolEditApprovalHandler',
+            );
+          },
+        },
+      ),
+    );
+    cleanupAllApprovals();
+  });
+
+  afterEach(() => {
+    cleanupAllApprovals();
+  });
+
+  it('routes each in-flight request through its own run handler, never the other', async () => {
+    const seenByA: ToolEditApprovalRequest[] = [];
+    const seenByB: ToolEditApprovalRequest[] = [];
+
+    const handlerA = async (
+      request: ToolEditApprovalRequest,
+    ): Promise<ToolEditApprovalResult> => {
+      seenByA.push(request);
+      return { accepted: true, appliedContent: 'from-a' };
+    };
+    const handlerB = async (
+      request: ToolEditApprovalRequest,
+    ): Promise<ToolEditApprovalResult> => {
+      seenByB.push(request);
+      return { accepted: true, appliedContent: 'from-b' };
+    };
+
+    const contextA = createRunContext({
+      runtimeHost: noopAgentRuntimeHost,
+      streamId: 'windowA@model: test.tex' as StreamTabId,
+      toolEditApprovalHandler: handlerA,
+    });
+    const contextB = createRunContext({
+      runtimeHost: noopAgentRuntimeHost,
+      streamId: 'windowB@model: test.tex' as StreamTabId,
+      toolEditApprovalHandler: handlerB,
+    });
+
+    const requestA: ToolEditApprovalRequest = {
+      path: 'a.tex',
+      originalContent: 'old-a',
+      proposedContent: 'new-a',
+      sourceTool: 'write_file',
+    };
+    const requestB: ToolEditApprovalRequest = {
+      path: 'b.tex',
+      originalContent: 'old-b',
+      proposedContent: 'new-b',
+      sourceTool: 'write_file',
+    };
+
+    // Fire both without awaiting between them — the shared approval queue
+    // serializes execution, but each call must still resolve through the
+    // handler captured from its own RunContext, not whichever ran last.
+    const resultAPromise = withRunContext(contextA, () =>
+      requestToolEditApproval(requestA),
+    );
+    const resultBPromise = withRunContext(contextB, () =>
+      requestToolEditApproval(requestB),
+    );
+
+    const [resultA, resultB] = await Promise.all([
+      resultAPromise,
+      resultBPromise,
+    ]);
+
+    assert.strictEqual(seenByA.length, 1);
+    assert.strictEqual(seenByA[0]?.path, 'a.tex');
+    assert.strictEqual(seenByB.length, 1);
+    assert.strictEqual(seenByB[0]?.path, 'b.tex');
+
+    assert.strictEqual(resultA.appliedContent, 'from-a');
+    assert.strictEqual(resultB.appliedContent, 'from-b');
+  });
+});

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -240,7 +240,8 @@ export async function requestToolEditApproval(
     // than one concurrent session per process, e.g. desktop's one window per
     // run) over the frozen, process-wide Platform port, which only ever holds
     // one active handler at a time.
-    const handler = context?.toolEditApprovalHandler ?? platform().toolEditApproval;
+    const handler =
+      context?.toolEditApprovalHandler ?? platform().toolEditApproval;
     return handler(preparedRequest);
   });
   return finalizeApprovalResult(result, preparedRequest);

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -236,7 +236,12 @@ export async function requestToolEditApproval(
   }
 
   const result = await toolEditApprovalController.enqueue(async () => {
-    return platform().toolEditApproval(preparedRequest);
+    // Prefer the run's own approval channel (set by hosts that manage more
+    // than one concurrent session per process, e.g. desktop's one window per
+    // run) over the frozen, process-wide Platform port, which only ever holds
+    // one active handler at a time.
+    const handler = context?.toolEditApprovalHandler ?? platform().toolEditApproval;
+    return handler(preparedRequest);
   });
   return finalizeApprovalResult(result, preparedRequest);
 }

--- a/src/tools/delegation/subagentExecution.ts
+++ b/src/tools/delegation/subagentExecution.ts
@@ -299,6 +299,7 @@ export async function executeSubagent(
         delegationDepth: parentDelegationDepth + 1,
         approvalPromptsUnavailable: parentContext.approvalPromptsUnavailable,
         runtimeUnavailableTools: parentContext.runtimeUnavailableTools,
+        toolEditApprovalHandler: parentContext.toolEditApprovalHandler,
         stopAfterCycle: true,
         onStreamResolved: inheritChildStreamApprovals,
         onError: (err) => {
@@ -433,6 +434,7 @@ export async function executeSubagent(
     delegationDepth: parentDelegationDepth + 1,
     approvalPromptsUnavailable: parentContext.approvalPromptsUnavailable,
     runtimeUnavailableTools: parentContext.runtimeUnavailableTools,
+    toolEditApprovalHandler: parentContext.toolEditApprovalHandler,
     onStreamResolved: (resolvedStreamId) => {
       childStreamId = resolvedStreamId;
       inheritChildStreamApprovals(resolvedStreamId);


### PR DESCRIPTION
## Summary

Routes tool-edit approval through the active run context before falling back to the process-wide platform port. This is intended to prevent desktop multi-window approval cross-talk: each window/session can provide its own `DesktopToolEditApprovalController.requestApproval`, and subagent launches inherit the parent run's handler.

Also groups delegation-related runtime settings into a `DelegationPolicy` object on `AgentCore` instead of carrying the fields as loose top-level values.

## Single source of truth

- Per-run tool edit approval ownership lives on `RunContext.toolEditApprovalHandler`.
- The platform `toolEditApproval` port remains the host fallback.
- Delegation runtime policy is grouped under `AgentCore.delegation`.

## Host impact

Extension: keeps the platform fallback behavior.

Desktop: passes each window/session approval controller into launch and resume paths.

CLI: should retain the no-op platform fallback.

## Validation

Existing PR checks are lightweight so far. Do not merge until the branch has been rebased and full CI/review has run cleanly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how edit-approval UI is bound across launch, resume, and subagent runs; wrong wiring could show prompts on the wrong window or fall back to the global port.
> 
> **Overview**
> Adds a **per-run `toolEditApprovalHandler`** on ambient `RunContext`, threaded from `executeAgent` / `runAgent` / resume helpers through launch context. **`requestToolEditApproval`** now resolves **`RunContext.toolEditApprovalHandler` before `platform().toolEditApproval`**, so concurrent runs (especially desktop multi-window) do not fight over a single process-wide port.
> 
> **Desktop** passes each window’s `DesktopToolEditApprovalController.requestApproval` on launch and resume. **Subagent launches** inherit the parent run’s handler. **`DelegationPolicy`** on `AgentCore` groups `delegationDepth` and `approvalPromptsUnavailable` (replacing loose top-level fields in flows/tests).
> 
> New test **`ConcurrentToolEditApprovalHandlers`** asserts two in-flight approvals stay on their own handlers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33fcfee2c79b2e312ac7f1b19e0a42519a0076ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->