### PR TITLE
refactor(model): consolidate compaction log formatting

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -48,14 +48,13 @@ import { MESSAGE_TYPES } from '@shared/schemas';
 import type { FileLocation } from '@shared/schemas';
 import type { ToolFileAttachment } from '@shared/schemas/toolResult';
 
-// Local imports - utils
-import { roundTo } from '@utils/core';
 import {
   getProviderStreaming,
   getGlobalStreaming,
 } from '@utils/config/providerConfig';
 import { getConfig } from '@utils/config/configUtils';
 import { computeUtilizationPercent } from './support/contextUtilization';
+import { logCompactionEvent } from './support/compactionLogging';
 import { MediaAttachmentProcessor } from './support/MediaAttachmentProcessor';
 import {
   resolveBaseUrl,
@@ -943,29 +942,14 @@ export abstract class ModelHandler<
       ];
 
       const estimatedTokensAfter = Math.max(1, outputTokens);
-      const reduction = tokensBefore - estimatedTokensAfter;
-      const reductionPercent =
-        tokensBefore > 0 ? ((reduction / tokensBefore) * 100).toFixed(1) : '0';
-
-      logContextManagementEvent(
-        this.logger,
-        `Compacted conversation: ${tokensBefore.toLocaleString()} → ~${estimatedTokensAfter.toLocaleString()} tokens (${reductionPercent}% reduction)`,
-        {
-          action: 'compaction',
-          tokensBefore,
-          tokensAfter: estimatedTokensAfter,
-          contextWindow,
-          utilizationBefore: roundTo(
-            computeUtilizationPercent(tokensBefore, contextWindow),
-            1,
-          ),
-          utilizationAfter: roundTo(
-            computeUtilizationPercent(estimatedTokensAfter, contextWindow),
-            1,
-          ),
-          details: `Client-side compaction: ${conversationMessages.length} messages summarized`,
-        },
-      );
+      logCompactionEvent({
+        logger: this.logger,
+        tokensBefore,
+        tokensAfter: estimatedTokensAfter,
+        contextWindow,
+        details: `Client-side compaction: ${conversationMessages.length} messages summarized`,
+        tokensAfterIsEstimate: true,
+      });
 
       return { compactedMessages, didCompact: true };
     } catch (err) {

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -36,10 +36,11 @@ import type { FileLocation } from '@shared/schemas';
 import type { ToolFileAttachment } from '@shared/schemas/toolResult';
 
 // Local imports - utils
-import { clamp, filterNotNullish, roundTo } from '@utils/core';
+import { clamp, filterNotNullish } from '@utils/core';
 import { getConfig } from '@utils/config/configUtils';
 import { getWebSocketEnabled } from '@utils/config/providerConfig';
 import { computeUtilizationPercent } from '../support/contextUtilization';
+import { logCompactionEvent } from '../support/compactionLogging';
 import { shouldUseOpenRouter } from '../support/ProxyConfigResolver';
 import { toOpenAIReasoningEffort } from '../support/reasoningEffort';
 import {
@@ -959,27 +960,13 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         tokensAfter = compactedResponse.usage.output_tokens;
       }
 
-      const utilizationAfter = computeUtilizationPercent(
+      logCompactionEvent({
+        logger: this.logger,
+        tokensBefore,
         tokensAfter,
         contextWindow,
-      );
-      const reduction = tokensBefore - tokensAfter;
-      const reductionPercent = ((reduction / tokensBefore) * 100).toFixed(1);
-
-      // Log context management event with structured data
-      logContextManagementEvent(
-        this.logger,
-        `Compacted conversation: ${tokensBefore.toLocaleString()} → ${tokensAfter.toLocaleString()} tokens (${reductionPercent}% reduction)`,
-        {
-          action: 'compaction',
-          tokensBefore,
-          tokensAfter,
-          contextWindow,
-          utilizationBefore: roundTo(utilizationBefore, 1),
-          utilizationAfter: roundTo(utilizationAfter, 1),
-          details: `OpenAI Responses API compaction: ${compactedResponse.output.length} items`,
-        },
-      );
+        details: `OpenAI Responses API compaction: ${compactedResponse.output.length} items`,
+      });
 
       // Store compacted messages for use in this request.
       // Mark as pending compaction - state will be finalized after successful API call.

--- a/src/agent/modelHandlers/support/compactionLogging.ts
+++ b/src/agent/modelHandlers/support/compactionLogging.ts
@@ -1,0 +1,47 @@
+import { logContextManagementEvent, type AgentTrace } from '@agent/trace';
+import { roundTo } from '@utils/core';
+
+import { computeUtilizationPercent } from './contextUtilization';
+
+interface LogCompactionEventOptions {
+  readonly logger: AgentTrace;
+  readonly tokensBefore: number;
+  readonly tokensAfter: number;
+  readonly contextWindow: number;
+  readonly details: string;
+  readonly tokensAfterIsEstimate?: boolean;
+}
+
+export function logCompactionEvent({
+  logger,
+  tokensBefore,
+  tokensAfter,
+  contextWindow,
+  details,
+  tokensAfterIsEstimate = false,
+}: LogCompactionEventOptions): void {
+  const reduction = tokensBefore - tokensAfter;
+  const reductionPercent =
+    tokensBefore > 0 ? ((reduction / tokensBefore) * 100).toFixed(1) : '0';
+  const afterPrefix = tokensAfterIsEstimate ? '~' : '';
+
+  logContextManagementEvent(
+    logger,
+    `Compacted conversation: ${tokensBefore.toLocaleString()} → ${afterPrefix}${tokensAfter.toLocaleString()} tokens (${reductionPercent}% reduction)`,
+    {
+      action: 'compaction',
+      tokensBefore,
+      tokensAfter,
+      contextWindow,
+      utilizationBefore: roundTo(
+        computeUtilizationPercent(tokensBefore, contextWindow),
+        1,
+      ),
+      utilizationAfter: roundTo(
+        computeUtilizationPercent(tokensAfter, contextWindow),
+        1,
+      ),
+      details,
+    },
+  );
+}

--- a/src/test-kernel/agent/modelHandlers/support/CompactionLogging.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/support/CompactionLogging.vitest.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AgentTrace } from '@agent/trace';
+import { logCompactionEvent } from '@agent/modelHandlers/support/compactionLogging';
+
+function captureTrace(): {
+  trace: AgentTrace;
+  events: Array<{ key: string; text?: string; data?: unknown }>;
+} {
+  const events: Array<{ key: string; text?: string; data?: unknown }> = [];
+  return {
+    events,
+    trace: {
+      domain(event: { key: string; text?: string; data?: unknown }) {
+        events.push(event);
+      },
+    } as AgentTrace,
+  };
+}
+
+describe('logCompactionEvent', () => {
+  it('marks client-side compaction token counts as estimated', () => {
+    const { trace, events } = captureTrace();
+
+    logCompactionEvent({
+      logger: trace,
+      tokensBefore: 120_000,
+      tokensAfter: 3_200,
+      contextWindow: 200_000,
+      details: 'Client-side compaction: 8 messages summarized',
+      tokensAfterIsEstimate: true,
+    });
+
+    expect(events).toEqual([
+      {
+        key: 'contextManagement',
+        text: 'Compacted conversation: 120,000 → ~3,200 tokens (97.3% reduction)',
+        data: {
+          action: 'compaction',
+          tokensBefore: 120_000,
+          tokensAfter: 3_200,
+          contextWindow: 200_000,
+          utilizationBefore: 60,
+          utilizationAfter: 1.6,
+          details: 'Client-side compaction: 8 messages summarized',
+        },
+      },
+    ]);
+  });
+
+  it('logs measured compaction token counts without an estimate marker', () => {
+    const { trace, events } = captureTrace();
+
+    logCompactionEvent({
+      logger: trace,
+      tokensBefore: 80_000,
+      tokensAfter: 6_000,
+      contextWindow: 100_000,
+      details: 'OpenAI Responses API compaction: 4 items',
+    });
+
+    expect(events[0]?.text).toBe(
+      'Compacted conversation: 80,000 → 6,000 tokens (92.5% reduction)',
+    );
+    expect(events[0]?.data).toMatchObject({
+      tokensBefore: 80_000,
+      tokensAfter: 6_000,
+      utilizationBefore: 80,
+      utilizationAfter: 6,
+      details: 'OpenAI Responses API compaction: 4 items',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6873.

This consolidates the duplicated compaction log formatting in `ModelHandler` and `ModelHandlerOpenAIResponse` into one shared helper: `logCompactionEvent` in `src/agent/modelHandlers/support/compactionLogging.ts`.

The `~` marker difference was intentional rather than accidental drift: the base client-side compaction path logs a token count derived from summarization output tokens, so the post-compaction count is an estimate. The OpenAI Responses path tries to count the compacted messages before logging, so it logs a measured count. The shared helper makes that distinction explicit through `tokensAfterIsEstimate`.

## Design

- The support helper owns the visible compaction log line and structured context-management payload.
- Callers only provide the count, context window, details text, and whether the post-compaction count is estimated.
- This removes duplicated reduction/utilization formatting while preserving both existing meanings.

## Validation

- `corepack pnpm exec tsc --noEmit -p tsconfig.json --pretty false`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `corepack pnpm exec eslint src/agent/modelHandlers/support/compactionLogging.ts src/agent/modelHandlers/ModelHandler.ts src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts src/test-kernel/agent/modelHandlers/support/CompactionLogging.vitest.ts`
- `corepack pnpm exec vitest run src/test-kernel/agent/modelHandlers/OpenAIResponseCompaction.vitest.ts src/test-kernel/agent/modelHandlers/GoogleInteractionsChaining.vitest.ts src/test-kernel/agent/modelHandlers/support/CompactionLogging.vitest.ts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of observability only; compaction behavior is unchanged aside from centralizing log formatting.
> 
> **Overview**
> Duplicated compaction success logging in **`ModelHandler.runClientCompaction`** and **`ModelHandlerOpenAIResponse.compactConversation`** is replaced by a shared **`logCompactionEvent`** helper in `compactionLogging.ts`.
> 
> The helper still emits the same **`contextManagement`** event (human-readable line plus structured `tokensBefore` / `tokensAfter`, utilization, and `details`). Callers only pass counts, context window, detail text, and **`tokensAfterIsEstimate`**, which adds a **`~`** prefix on the post-compaction count when client-side compaction uses summarization output tokens rather than a measured recount.
> 
> Vitest coverage locks in both the estimated and measured log formats.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 658b543624165227330bc4f2c9cae904342c1014. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->