### PR TITLE
refactor(webview): derive execute message from schema

### DIFF
--- a/packages/desktop/src/main/desktopExecutionIpc.ts
+++ b/packages/desktop/src/main/desktopExecutionIpc.ts
@@ -39,7 +39,7 @@ export function createDesktopExecutionIpc(
           );
           return;
         }
-        return options.executeAgent?.(parsed.data as MainViewExecuteMessage);
+        return options.executeAgent?.(parsed.data);
       },
     },
     { onAsyncError: options.onAsyncError },

--- a/packages/extension/src/webview/MainViewMessageHandler.ts
+++ b/packages/extension/src/webview/MainViewMessageHandler.ts
@@ -26,7 +26,6 @@ import {
   MainViewInboundHandlerRegistry,
   type GettingStartedAction,
 } from '@shared/schemas';
-import type { MainViewExecuteMessage } from '@shared/mainView';
 import { PROVIDER_URLS } from '@shared/constants/providers';
 import { getConfig, updateConfig, SETTINGS_QUERY } from '@utils/config';
 import { checkCoreDependencies, getToolDocsCommand } from '@utils/system';
@@ -169,13 +168,7 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       [MAIN_VIEW_COMMANDS.OPEN_INSTALLATION_DOCS]: () =>
         safeExecuteCommand('texra.openDoc', ['installation'], this.viewName),
 
-      // EXECUTE is still validated as a loose `{ command }` object (payload
-      // typed nearer the handler), so the dispatcher can't infer the rich
-      // shape — cast to the handler's declared input type rather than
-      // discarding all checking with `any`. MERGE/COMPARE/ACCEPT_EDITED have
-      // real per-command Zod schemas now, so those flow through pre-narrowed.
-      [MAIN_VIEW_COMMANDS.EXECUTE]: (m) =>
-        executionHandlers.handleExecute(m as MainViewExecuteMessage),
+      [MAIN_VIEW_COMMANDS.EXECUTE]: (m) => executionHandlers.handleExecute(m),
       [MAIN_VIEW_COMMANDS.MERGE]: (m) =>
         executionHandlers.handleFileOperation(m),
       [MAIN_VIEW_COMMANDS.COMPARE]: (m) =>

--- a/src/shared/mainView/executeMessage.ts
+++ b/src/shared/mainView/executeMessage.ts
@@ -1,6 +1,9 @@
-// Local imports - shared schemas
 import { MULTIPLE_DOCUMENT_FILE_TYPES } from '../schemas/fileTypes';
-import type { ToolConfigSchema } from '../schemas/toolConfig';
+import type {
+  MainViewExecuteFiles,
+  MainViewExecuteMessage,
+  MainViewExecuteSession,
+} from '../schemas/mainView/executeMessage';
 import type {
   CheckboxValues,
   MultiFiles,
@@ -8,55 +11,10 @@ import type {
   SingleFiles,
 } from '../schemas/mainView/state';
 
-// Third-party imports
-import type { z } from 'zod';
-
-/**
- * File-selection fields sent from the main view's file pickers: the
- * multi-file lists (input/context/media/output), their "active" UI toggles,
- * and the single base/edited-file slots used by diff-oriented flows.
- */
-export type MainViewExecuteFiles = {
-  readonly inputFiles?: string[];
-  readonly contextFiles?: string[];
-  readonly mediaFiles?: (string | null)[];
-  readonly outputFiles?: string[];
-  readonly editedFile?: string;
-  readonly editedFiles?: string[];
-  readonly baseFile?: string;
-  readonly inputFilesActive?: boolean;
-  readonly contextFilesActive?: boolean;
-  readonly mediaFilesActive?: boolean;
-  readonly outputFilesActive?: boolean;
-};
-
-/** Session/run metadata that rides along with the execution request. */
-export type MainViewExecuteSession = {
-  readonly workingDirectory?: string | null;
-  readonly cliOutputFile?: string | null;
-  readonly cliMultiAgentPresetId?: string | null;
-};
-
-/**
- * Message shape from the main view for agent execution. File selection,
- * session metadata, and tool config are grouped into their own sub-objects
- * (mirroring how `prepareMainViewExecutionRequest` consumes them) instead of
- * one flat 26-field bag.
- *
- * Keep this aligned with prepareMainViewExecutionRequest. Agent-owned fields
- * such as agentCategory are derived there, not sent by the UI.
- */
-export type MainViewExecuteMessage = {
-  readonly agent?: string;
-  readonly model?: string;
-  readonly instruction?: string;
-  readonly displayInstruction?: string | null;
-  /** UI toggle indicating tool-use vs workflow agent. */
-  readonly isToolUseAgent?: boolean;
-  readonly memories?: string[];
-  readonly files?: MainViewExecuteFiles;
-  readonly session?: MainViewExecuteSession;
-  readonly toolConfig?: z.input<typeof ToolConfigSchema>;
+export type {
+  MainViewExecuteFiles,
+  MainViewExecuteMessage,
+  MainViewExecuteSession,
 };
 
 export interface MainViewExecutionFormState {

--- a/src/shared/schemas/mainView/executeMessage.ts
+++ b/src/shared/schemas/mainView/executeMessage.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+
+import { MAIN_VIEW_COMMANDS } from '@shared/ipc/mainViewCommands';
+
+import { ToolConfigInputFieldsSchema } from '../toolConfig';
+
+const MainViewExecuteToolConfigSchema = ToolConfigInputFieldsSchema.partial();
+
+export const MainViewExecuteFilesSchema = z.object({
+  inputFiles: z.array(z.string()).optional(),
+  contextFiles: z.array(z.string()).optional(),
+  mediaFiles: z.array(z.string().nullable()).optional(),
+  outputFiles: z.array(z.string()).optional(),
+  editedFile: z.string().optional(),
+  editedFiles: z.array(z.string()).optional(),
+  baseFile: z.string().optional(),
+  inputFilesActive: z.boolean().optional(),
+  contextFilesActive: z.boolean().optional(),
+  mediaFilesActive: z.boolean().optional(),
+  outputFilesActive: z.boolean().optional(),
+});
+export type MainViewExecuteFiles = z.infer<typeof MainViewExecuteFilesSchema>;
+
+export const MainViewExecuteSessionSchema = z.object({
+  workingDirectory: z.string().nullable().optional(),
+  cliOutputFile: z.string().nullable().optional(),
+  cliMultiAgentPresetId: z.string().nullable().optional(),
+});
+export type MainViewExecuteSession = z.infer<
+  typeof MainViewExecuteSessionSchema
+>;
+
+/**
+ * Payload from the main view for agent execution. The IPC dispatcher adds the
+ * command discriminant separately; keeping the payload schema command-free
+ * matches the browser-side builder and the execution controller.
+ */
+export const MainViewExecuteMessageSchema = z.object({
+  agent: z.string().optional(),
+  model: z.string().optional(),
+  instruction: z.string().optional(),
+  displayInstruction: z.string().nullable().optional(),
+  isToolUseAgent: z.boolean().optional(),
+  memories: z.array(z.string()).optional(),
+  files: MainViewExecuteFilesSchema.optional(),
+  session: MainViewExecuteSessionSchema.optional(),
+  toolConfig: MainViewExecuteToolConfigSchema.optional(),
+});
+export type MainViewExecuteMessage = z.infer<
+  typeof MainViewExecuteMessageSchema
+>;
+
+export const MainViewExecuteInboundMessageSchema =
+  MainViewExecuteMessageSchema.extend({
+    command: z.literal(MAIN_VIEW_COMMANDS.EXECUTE),
+  });
+export type MainViewExecuteInboundMessage = z.infer<
+  typeof MainViewExecuteInboundMessageSchema
+>;

--- a/src/shared/schemas/mainView/inbound.ts
+++ b/src/shared/schemas/mainView/inbound.ts
@@ -25,6 +25,7 @@ import {
   MultipleDocumentFileTypeSchema,
 } from '../fileTypes';
 import { GettingStartedActionSchema, SessionTypeSchema } from './state';
+import { MainViewExecuteInboundMessageSchema } from './executeMessage';
 
 const CommonMessages = [
   commandOnly(MAIN_VIEW_COMMANDS.WEBVIEW_READY),
@@ -106,7 +107,7 @@ export type FileOperationMessage =
   MergeMessage | CompareMessage | AcceptEditedMessage;
 
 const ExecutionMessages = [
-  z.looseObject({ command: z.literal(MAIN_VIEW_COMMANDS.EXECUTE) }),
+  MainViewExecuteInboundMessageSchema,
   MergeMessageSchema,
   CompareMessageSchema,
   AcceptEditedMessageSchema,

--- a/src/shared/schemas/mainView/index.ts
+++ b/src/shared/schemas/mainView/index.ts
@@ -27,5 +27,6 @@ export {
   type MultipleDocumentFileType,
 } from '../fileTypes';
 export * from './state';
+export * from './executeMessage';
 export * from './outbound';
 export * from './inbound';

--- a/src/shared/schemas/toolConfig.ts
+++ b/src/shared/schemas/toolConfig.ts
@@ -11,25 +11,28 @@ export const DEFAULT_TOOL_CONFIG = {
   autoCompileInputPdf: false,
 } as const;
 
+type ToolConfigField = keyof typeof DEFAULT_TOOL_CONFIG;
+
+const ToolConfigBooleanFieldsShape = Object.fromEntries(
+  Object.keys(DEFAULT_TOOL_CONFIG).map((key) => [key, z.boolean()]),
+) as Record<ToolConfigField, z.ZodBoolean>;
+
+export const ToolConfigInputFieldsSchema = z.object(
+  ToolConfigBooleanFieldsShape,
+);
+
+const ToolConfigPrefaultFieldsShape = Object.fromEntries(
+  Object.entries(ToolConfigBooleanFieldsShape).map(([key, schema]) => [
+    key,
+    schema.prefault(DEFAULT_TOOL_CONFIG[key as ToolConfigField]),
+  ]),
+) as { [K in ToolConfigField]: z.ZodPrefault<z.ZodBoolean> };
+
 /**
  * Base tool config object schema (exposes .shape for composition).
  * Field-level prefaults handle partial inputs.
  */
-export const ToolConfigFieldsSchema = z.object({
-  autoExtractFigure: z
-    .boolean()
-    .prefault(DEFAULT_TOOL_CONFIG.autoExtractFigure),
-  autoExtractTikzFigure: z
-    .boolean()
-    .prefault(DEFAULT_TOOL_CONFIG.autoExtractTikzFigure),
-  attachTeXCount: z.boolean().prefault(DEFAULT_TOOL_CONFIG.attachTeXCount),
-  attachDiagnostics: z
-    .boolean()
-    .prefault(DEFAULT_TOOL_CONFIG.attachDiagnostics),
-  autoCompileInputPdf: z
-    .boolean()
-    .prefault(DEFAULT_TOOL_CONFIG.autoCompileInputPdf),
-});
+export const ToolConfigFieldsSchema = z.object(ToolConfigPrefaultFieldsShape);
 
 /**
  * Tool config schema with object-level prefault for standalone use.

--- a/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
+++ b/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
@@ -423,6 +423,20 @@ describe('desktop IPC adapters', () => {
     await Promise.resolve();
     expect(executeAgent).toHaveBeenCalledWith(executeMessage);
 
+    const malformedError = vi.fn();
+    const malformedExecutionIpc = createDesktopExecutionIpc({
+      executeAgent,
+      onAsyncError: malformedError,
+    });
+    expect(
+      malformedExecutionIpc.handleMessage({
+        command: MAIN_VIEW_COMMANDS.EXECUTE,
+        files: { inputFiles: 'main.tex' },
+      }),
+    ).toBe(true);
+    expect(executeAgent).toHaveBeenCalledTimes(1);
+    expect(malformedError).toHaveBeenCalledWith(expect.any(Error));
+
     const error = new Error('execution failed');
     const onAsyncError = vi.fn();
     createDesktopExecutionIpc({

--- a/src/test-kernel/shared/MainViewExecuteMessage.vitest.ts
+++ b/src/test-kernel/shared/MainViewExecuteMessage.vitest.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import { buildMainViewExecuteMessage } from '@shared/mainView';
+import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
+import {
+  MainViewExecuteInboundMessageSchema,
+  MainViewExecuteMessageSchema,
+} from '@shared/schemas/mainView';
 
 describe('MainView execute message builder', () => {
   it('builds tool-use execute messages from form state', () => {
@@ -76,5 +81,49 @@ describe('MainView execute message builder', () => {
     expect(message.agent).toBe('correct');
     expect(message.isToolUseAgent).toBe(false);
     expect(message.files?.inputFilesActive).toBe(false);
+  });
+
+  it('derives execute payload validation from the shared schema', () => {
+    const message = buildMainViewExecuteMessage({
+      sessionType: 'toolUse',
+      workflowAgent: 'correct',
+      toolUseAgent: 'orchestrator',
+      model: 'gpt-5.4',
+      instruction: 'Search for a short proof.',
+      singleFiles: { baseFile: '', editedFile: '' },
+      multiFiles: {
+        inputFiles: [],
+        contextFiles: [],
+        mediaFiles: ['diagram.png'],
+        outputFiles: [],
+      },
+      checkboxValues: {
+        autoExtractFigure: false,
+        autoExtractTikzFigure: false,
+        autoCompileInputPdf: false,
+        attachTeXCount: false,
+      },
+    });
+
+    expect(MainViewExecuteMessageSchema.parse(message)).toEqual(message);
+    expect(
+      MainViewExecuteInboundMessageSchema.parse({
+        command: MAIN_VIEW_COMMANDS.EXECUTE,
+        ...message,
+      }),
+    ).toMatchObject({
+      command: MAIN_VIEW_COMMANDS.EXECUTE,
+      agent: 'orchestrator',
+      files: { mediaFiles: ['diagram.png'] },
+    });
+  });
+
+  it('rejects malformed nested execute payload fields', () => {
+    expect(
+      MainViewExecuteInboundMessageSchema.safeParse({
+        command: MAIN_VIEW_COMMANDS.EXECUTE,
+        files: { inputFiles: 'main.tex' },
+      }).success,
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Defines `MainViewExecuteMessageSchema` as the schema-owned execute payload shape.
- Derives `MainViewExecuteMessage` and related file/session types from Zod instead of maintaining a parallel TypeScript interface.
- Uses the execute schema inside the main-view inbound dispatcher, so desktop IPC validates nested execute payload fields before forwarding.
- Removes the execute-message casts in desktop IPC and the extension main-view message handler.

## Validation

- `npx vitest run src/test-kernel/shared/MainViewExecuteMessage.vitest.ts src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts`
- `npx eslint src/shared/schemas/mainView/executeMessage.ts src/shared/schemas/mainView/index.ts src/shared/schemas/mainView/inbound.ts src/shared/mainView/executeMessage.ts packages/desktop/src/main/desktopExecutionIpc.ts packages/extension/src/webview/MainViewMessageHandler.ts src/test-kernel/shared/MainViewExecuteMessage.vitest.ts src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts`
- `npx tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `npm run lint` (passes with existing unrelated warnings)
- `npm run typecheck`
- `npm run compile:fast`

Closes #6924

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema tightening at the IPC boundary may reject previously accepted malformed EXECUTE messages; behavior for valid payloads is unchanged and covered by tests.
> 
> **Overview**
> **EXECUTE** IPC now uses a single Zod-owned payload: `MainViewExecuteMessageSchema` (plus files/session/toolConfig sub-schemas) replaces hand-written TypeScript types re-exported from `@shared/mainView`. The main-view inbound union swaps the loose `{ command: EXECUTE }` object for `MainViewExecuteInboundMessageSchema`, so nested fields (e.g. `files.inputFiles` as an array) are validated at dispatch.
> 
> Desktop execution IPC and the extension `MainViewMessageHandler` drop `as MainViewExecuteMessage` casts because parsed inbound messages narrow correctly. `ToolConfigInputFieldsSchema` is introduced (generated from `DEFAULT_TOOL_CONFIG`) for partial execute `toolConfig`; full prefaulted `ToolConfigFieldsSchema` is built the same way to avoid duplicated field definitions.
> 
> Tests cover schema acceptance of `buildMainViewExecuteMessage` output, rejection of malformed nested `files`, and desktop IPC ignoring bad EXECUTE payloads without calling `executeAgent`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 182c72cb3c1a6e465a3aaa7e04a4dd1293b1088f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->