### PR TITLE
refactor(agent): read session callbacks from run context

### DIFF
--- a/src/agent/core/flows/BaseFlowServices.ts
+++ b/src/agent/core/flows/BaseFlowServices.ts
@@ -12,16 +12,8 @@ import type {
 import type { UserVariableChannels } from '@agent/core/definition/AgentCycleOptions';
 import type { AgentRunStateSnapshot } from '@agent/core/state/AgentState';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import type {
-  RetryRequestOptions,
-  RetryResult,
-} from '@agent/runtime/RetryRequestCoordinator';
 import type { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
-import type {
-  ActiveChildInfo,
-  ExecutionId,
-  StreamTabId,
-} from '@shared/schemas';
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
 /** Callback invoked when a round/cycle completes for usage tracking. */
 export type RoundFinalizedCallback = (
@@ -57,16 +49,6 @@ export interface AgentCore<C = unknown> {
   delegation?: DelegationPolicy;
   /** Tools unavailable because the current host/runtime cannot support them. */
   runtimeUnavailableTools?: readonly string[];
-  /** Get active subagent and process children for a parent stream. */
-  getActiveChildren: (parentStreamId: StreamTabId) => {
-    subagents: ActiveChildInfo[];
-    processes: ActiveChildInfo[];
-  };
-  /** Wait for user decision on a retry prompt (resolve-side bridge to run coordinators). */
-  waitForRetry: (
-    streamId: StreamTabId,
-    options: RetryRequestOptions,
-  ) => Promise<RetryResult>;
 }
 
 export interface BaseFlowContextInit<C = unknown> extends AgentCore<C> {

--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -6,6 +6,7 @@ import { logContextStateSnapshot } from '@agent/trace';
 import { isRemoteAgent } from '@agent/index/agentRegistry';
 import type { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import type { AgentCore } from '@agent/core/flows/BaseFlowServices';
+import { useLaunchRunContext } from '@agent/runtime/RunContext';
 import {
   ProviderMessageSchema,
   type ProviderMessage,
@@ -110,9 +111,9 @@ export async function saveCycleDebug(
 export function defaultPostCompactionContext(
   services: CycleServices,
 ): string | null {
-  const { subagents, processes } = services.getActiveChildren(
-    services.streamId,
-  );
+  const { session, streamId } = useLaunchRunContext();
+  const { subagents, processes } =
+    session.executions.getActiveChildren(streamId);
   return formatPostCompactionContext(
     subagents,
     processes,

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -5,10 +5,7 @@ import { StatusCodes } from 'http-status-codes';
 import { Node, type NonIterableObject } from '@agent/node';
 import { logErrorData, logProgressStatus, type AgentTrace } from '@agent/trace';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import {
-  type RetryResult,
-  type RetryRequestOptions,
-} from '@agent/runtime/RetryRequestCoordinator';
+import { useLaunchRunContext } from '@agent/runtime/RunContext';
 import type { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { ensureError, normalizeProviderError } from '@common/errors';
@@ -52,10 +49,6 @@ interface RetryableNodeServices {
   logger: AgentTrace;
   setAbortController: (ac: AbortController | null) => void;
   refreshClient?: () => Promise<void>;
-  waitForRetry: (
-    streamId: string,
-    options: RetryRequestOptions,
-  ) => Promise<RetryResult>;
 }
 
 /**
@@ -274,7 +267,8 @@ export abstract class RetryableInvocationNode<
     streamStatus.set(streamId, STREAM_STATUS.WAITING, {
       runtimeHost,
     });
-    const result: RetryResult = await this.services.waitForRetry(streamId, {
+    const { session } = useLaunchRunContext();
+    const result = await session.coordinators.waitForRetry(streamId, {
       operation: operationName,
       errorMessage: formatted.message,
       logger,

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -441,10 +441,6 @@ async function assembleAgentLaunchContext(
     },
     session,
     disposeTrace: runTrace.dispose,
-    getActiveChildren: (parentStreamId) =>
-      session.executions.getActiveChildren(parentStreamId),
-    waitForRetry: (streamId, options) =>
-      session.coordinators.waitForRetry(streamId, options),
   };
 }
 

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -137,8 +137,6 @@ function createLifecycleContext({
       proposal: new AgentProposalCoordinator(explicit.host),
       retry: new RetryRequestCoordinatorImpl(explicit.host),
     },
-    getActiveChildren: () => ({ subagents: [], processes: [] }),
-    waitForRetry: vi.fn(),
   };
 }
 

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -7,7 +7,16 @@ import type { NonIterableObject } from '@agent/node';
 import type { BaseCycleFields } from '@agent/core/flows/CommonCycleTypes';
 import { ModelInvocationNode } from '@agent/core/flows/ModelInvocationNode';
 import { RetryableInvocationNode } from '@agent/core/flows/RetryState';
-import type { RetryResult } from '@agent/runtime/RetryRequestCoordinator';
+import {
+  RetryRequestCoordinatorImpl,
+  type RetryResult,
+} from '@agent/runtime/RetryRequestCoordinator';
+import {
+  createRunContext,
+  withRunContext,
+  type RunCoordinators,
+} from '@agent/runtime/RunContext';
+import { SessionHandle } from '@agent/runtime/SessionHandle';
 import {
   StreamStatusRegistry,
   StreamStatusService,
@@ -17,7 +26,11 @@ import {
   type AgentRuntimeHost,
 } from '@agent/runtime/AgentRuntimeHost';
 import { attachFlowAutoRetryRequired } from '@common/errors/sdkErrorUtils';
-import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+import {
+  STREAM_STATUS,
+  type ExecutionId,
+  type StreamTabId,
+} from '@shared/schemas';
 
 interface TestRetryServices {
   streamId: StreamTabId;
@@ -25,10 +38,6 @@ interface TestRetryServices {
   streamStatus: StreamStatusRegistry;
   logger: AgentTrace;
   setAbortController: (ac: AbortController | null) => void;
-  waitForRetry: (
-    streamId: string,
-    options: { operation: string; errorMessage?: string; logger: AgentTrace },
-  ) => Promise<RetryResult>;
 }
 
 class ExposedRetryNode extends RetryableInvocationNode<
@@ -52,21 +61,72 @@ class ExposedRetryNode extends RetryableInvocationNode<
 interface RetryNodeKit {
   node: ExposedRetryNode;
   streamStatus: StreamStatusRegistry;
-  waitForRetry: Mock<TestRetryServices['waitForRetry']>;
+  waitForRetry: Mock<
+    (
+      streamId: string,
+      options: { operation: string; errorMessage?: string; logger: AgentTrace },
+    ) => Promise<RetryResult>
+  >;
 }
 
 function createRetryNode(streamId: StreamTabId): RetryNodeKit {
   const streamStatus = new StreamStatusRegistry();
-  const waitForRetry = vi.fn<TestRetryServices['waitForRetry']>();
+  const waitForRetry = vi.fn<RetryNodeKit['waitForRetry']>();
   const node = new ExposedRetryNode().setServices({
     streamId,
     runtimeHost: noopAgentRuntimeHost,
     streamStatus,
     logger: noopTrace,
     setAbortController: vi.fn(),
-    waitForRetry,
   });
   return { node, streamStatus, waitForRetry };
+}
+
+async function withRetryRunContext<T>(
+  streamId: StreamTabId,
+  waitForRetry: RetryNodeKit['waitForRetry'],
+  fn: () => T | Promise<T>,
+): Promise<T> {
+  const coordinators: RunCoordinators = {
+    plan: {} as RunCoordinators['plan'],
+    proposal: {} as RunCoordinators['proposal'],
+    retry: { waitForRetry } as unknown as RunCoordinators['retry'],
+  };
+  const context = createRunContext({
+    modelSource: 'live',
+    getModel: () => undefined,
+    runtimeHost: noopAgentRuntimeHost,
+    streamId,
+    executionId: `${streamId}-execution` as ExecutionId,
+    agentName: 'retry-test',
+    session: new SessionHandle(),
+    coordinators,
+  });
+  return await withRunContext(context, fn);
+}
+
+async function withSessionRetryRunContext<T>(
+  streamId: StreamTabId,
+  session: SessionHandle,
+  retry: RetryRequestCoordinatorImpl,
+  fn: () => T | Promise<T>,
+): Promise<T> {
+  const coordinators: RunCoordinators = {
+    plan: {} as RunCoordinators['plan'],
+    proposal: {} as RunCoordinators['proposal'],
+    retry,
+  };
+  const context = createRunContext({
+    modelSource: 'live',
+    getModel: () => undefined,
+    runtimeHost: noopAgentRuntimeHost,
+    streamId,
+    executionId: `${streamId}-execution` as ExecutionId,
+    agentName: 'retry-test',
+    session,
+    coordinators,
+  });
+  return await withRunContext(context, fn);
 }
 
 function createModelInvocationNode(input: {
@@ -148,7 +208,9 @@ describe('RetryState', () => {
         emit: false,
       });
 
-      await node.promptFor(new Error('temporary provider failure'));
+      await withRetryRunContext(streamId, waitForRetry, () =>
+        node.promptFor(new Error('temporary provider failure')),
+      );
 
       expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.RUNNING);
       expect(StreamStatusService.get(streamId)).toBe(STREAM_STATUS.STOPPED);
@@ -164,6 +226,34 @@ describe('RetryState', () => {
     }
   });
 
+  it('registers manual retries on the session coordinator bridge', async () => {
+    const streamId = 'retry-state-session-bridge' as StreamTabId;
+    const session = new SessionHandle();
+    const retry = new RetryRequestCoordinatorImpl(noopAgentRuntimeHost);
+    const { node, streamStatus } = createRetryNode(streamId);
+
+    try {
+      streamStatus.set(streamId, STREAM_STATUS.RUNNING, { emit: false });
+
+      const prompt = withSessionRetryRunContext(streamId, session, retry, () =>
+        node.promptFor(new Error('temporary provider failure')),
+      );
+
+      expect(session.coordinators.triggerRetry(streamId, 'try again')).toBe(
+        true,
+      );
+
+      await expect(prompt).resolves.toMatchObject({
+        shouldRetry: true,
+        userCancelled: false,
+      });
+      expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.RUNNING);
+    } finally {
+      session.dispose();
+      streamStatus.clear(streamId, { emit: false });
+    }
+  });
+
   it.each(['cancel', 'timeout'] as const)(
     'stops the stream after manual retry %s',
     async (action) => {
@@ -175,7 +265,9 @@ describe('RetryState', () => {
       try {
         streamStatus.set(streamId, STREAM_STATUS.RUNNING, { emit: false });
 
-        await node.promptFor(new Error('temporary provider failure'));
+        await withRetryRunContext(streamId, waitForRetry, () =>
+          node.promptFor(new Error('temporary provider failure')),
+        );
 
         expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.STOPPED);
       } finally {

--- a/src/test-kernel/agent/runtime/SessionIsolation.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionIsolation.vitest.ts
@@ -121,8 +121,6 @@ function createLifecycleContext(
       retry: new RetryRequestCoordinatorImpl(explicit.host),
     },
     session,
-    getActiveChildren: () => ({ subagents: [], processes: [] }),
-    waitForRetry: vi.fn(),
   };
 }
 

--- a/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
@@ -106,8 +106,6 @@ function createCtx(overrides?: { logger?: TraceEmitter }): {
       proposal: new AgentProposalCoordinator(explicit.host),
       retry: new RetryRequestCoordinatorImpl(explicit.host),
     },
-    getActiveChildren: () => ({ subagents: [], processes: [] }),
-    waitForRetry: vi.fn(),
   };
   return { ctx, streamStatus };
 }

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -174,8 +174,6 @@ function roundServices(opts: {
     executionId: 'test-execution-id',
     run: AgentRunStateSnapshotSchema.parse({}),
     workspace: AgentWorkspaceState.create(),
-    getActiveChildren: () => ({ subagents: [], processes: [] }),
-    waitForRetry: vi.fn(),
   };
 }
 


### PR DESCRIPTION
## Summary

- Removes `getActiveChildren` and `waitForRetry` from the node-facing `AgentCore` service bag.
- Reads active child streams from the launch `RunContext` session in `defaultPostCompactionContext()`.
- Reads manual retry coordination from the launch `RunContext` coordinators in `RetryableInvocationNode`.
- Updates fixtures so tests no longer fake session-owned callbacks on `AgentCore`.

## Scope

This is a small Phase 1 slice of #6921. It does not attempt the full service-bag split; it removes two fields that were already owned by the per-run session/coordinators.

## Validation

- `npx vitest run src/test-kernel/agent/runtime/RetryState.vitest.ts src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts src/test-kernel/agent/runtime/SessionIsolation.vitest.ts src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts src/test-kernel/tools/BashTool.vitest.ts`
- `npx eslint src/agent/core/flows/BaseFlowServices.ts src/agent/core/flows/RetryState.ts src/agent/core/flows/CommonCycleTypes.ts src/agent/runtime/AgentLaunchContext.ts src/test-kernel/agent/runtime/RetryState.vitest.ts src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts src/test-kernel/agent/runtime/SessionIsolation.vitest.ts src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts src/test-kernel/tools/BashTool.vitest.ts`
- `npx tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `npm run typecheck`
- `npm run lint` (passes with existing unrelated warnings)
- `npm run compile:fast`

Refs #6921

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how compaction context and manual retry resolve session state at runtime; behavior should match when code runs inside launch `RunContext`, but mis-wired tests or non-launch callers would fail loudly via `useLaunchRunContext()`.
> 
> **Overview**
> **Phase 1 slice** of the service-bag refactor: flow code no longer receives session-owned behavior through the node-facing `AgentCore` bag.
> 
> `getActiveChildren` and `waitForRetry` are dropped from `AgentCore`, `RetryableInvocationNode` services, and `buildAgentLaunchContext` wiring. **Post-compaction context** now calls `session.executions.getActiveChildren(streamId)` via `useLaunchRunContext()`. **Manual retry prompts** call `session.coordinators.waitForRetry(...)` the same way.
> 
> Tests stop stubbing those fields on fake `AgentCore` objects; `RetryState` tests wrap nodes in `withRunContext` and add coverage that `session.coordinators.triggerRetry` resolves the real coordinator bridge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 968dba759c39e0d912ececec758570eaa2906413. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->