### PR TITLE
[codex] refactor(agent): keep run identity in launch context

### DIFF
--- a/src/agent/core/flows/BaseFlowServices.ts
+++ b/src/agent/core/flows/BaseFlowServices.ts
@@ -39,16 +39,19 @@ export interface AgentCore<C = unknown> {
   setting: AgentSetting;
   prompt: AgentPrompt;
   logger: AgentTrace;
-  runtimeHost: AgentRuntimeHost;
   streamStatus: StreamStatusRegistry;
-  streamId: StreamTabId;
-  executionId: ExecutionId;
   userVarChannels: UserVariableChannels;
   /** Working directory override for subagent tool calls (e.g. a git worktree). */
   workingDirectory?: string;
   delegation?: DelegationPolicy;
   /** Tools unavailable because the current host/runtime cannot support them. */
   runtimeUnavailableTools?: readonly string[];
+}
+
+export interface AgentRunIdentity {
+  readonly runtimeHost: AgentRuntimeHost;
+  readonly streamId: StreamTabId;
+  readonly executionId: ExecutionId;
 }
 
 export interface BaseFlowContextInit<C = unknown> extends AgentCore<C> {

--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -95,12 +95,13 @@ export async function saveCycleDebug(
   services: AgentCore,
   fileOptions: CycleDebugFileOptions,
 ): Promise<void> {
+  const { executionId } = useLaunchRunContext();
   await maybeSaveDebugObject({
     object,
     objectType,
     context: {
       logger: services.logger,
-      executionId: services.executionId,
+      executionId,
       modelName: services.config.model,
       isRemote: isRemoteAgent(services.config.agent),
     },

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -4,7 +4,6 @@ import { StatusCodes } from 'http-status-codes';
 
 import { Node, type NonIterableObject } from '@agent/node';
 import { logErrorData, logProgressStatus, type AgentTrace } from '@agent/trace';
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { useLaunchRunContext } from '@agent/runtime/RunContext';
 import type { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
 import { SupabaseClient } from '@auth/SupabaseClient';
@@ -43,8 +42,6 @@ export type InvocationResult<TSuccess> =
   | { kind: 'skipped' };
 
 interface RetryableNodeServices {
-  streamId: string;
-  runtimeHost: AgentRuntimeHost;
   streamStatus: StreamStatusRegistry;
   logger: AgentTrace;
   setAbortController: (ac: AbortController | null) => void;
@@ -254,7 +251,8 @@ export abstract class RetryableInvocationNode<
   protected async handleManualRetryPrompt(
     error: Error,
   ): Promise<ManualRetryPromptResult> {
-    const { streamId, logger, runtimeHost, streamStatus } = this.services;
+    const { logger, streamStatus } = this.services;
+    const { runtimeHost, session, streamId } = useLaunchRunContext();
     const operationName = this.getOperationName();
     const formatted = normalizeProviderError(error);
 
@@ -267,7 +265,6 @@ export abstract class RetryableInvocationNode<
     streamStatus.set(streamId, STREAM_STATUS.WAITING, {
       runtimeHost,
     });
-    const { session } = useLaunchRunContext();
     const result = await session.coordinators.waitForRetry(streamId, {
       operation: operationName,
       errorMessage: formatted.message,

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -8,6 +8,7 @@ import {
   hasRoundOutputs,
   getStorageKey,
   setCompileFailures,
+  type OutputDependencies,
 } from '@agent/output/outputState';
 import { runCompileCheck } from '@agent/output/compileCheck';
 import { extractFilesFromXml } from '@agent/output/outputFileExtraction';
@@ -60,6 +61,22 @@ export class OutputNode<C = unknown> extends Node<
   FlowParams,
   ReflectionServices<C>
 > {
+  private outputDependencies(): OutputDependencies {
+    const { executionId, runtimeHost, streamId } = useLaunchRunContext();
+    const { baseFiles, config, fileService, logger, setting } = this.services;
+
+    return {
+      baseFiles,
+      config,
+      executionId,
+      fileService,
+      logger,
+      runtimeHost,
+      setting,
+      streamId,
+    };
+  }
+
   async prep(shared: ReflectionFlowShared): Promise<OutputPrepInput> {
     if (!shared.outputLocation) {
       throw new Error(
@@ -77,6 +94,7 @@ export class OutputNode<C = unknown> extends Node<
   async exec(prepRes: OutputPrepInput): Promise<OutputExecResult> {
     const { outputState, xmlManager, diffManager, setting, logger, baseFiles } =
       this.services;
+    const outputDependencies = this.outputDependencies();
     const { outputLocation, currentRound, endTurn } = prepRes;
 
     // Resolve to pre-run snapshots once so mapping, latexdiff, and diff
@@ -109,7 +127,7 @@ export class OutputNode<C = unknown> extends Node<
         () =>
           extractFilesFromXml(
             outputState,
-            this.services,
+            outputDependencies,
             xmlManager,
             outputLocation,
             currentRound,
@@ -136,7 +154,7 @@ export class OutputNode<C = unknown> extends Node<
             currentRound,
           );
           const compileResult = await runCompileCheck(
-            this.services,
+            { ...outputDependencies, outputState },
             currentRound,
           );
           compileFailures = compileResult.failures;
@@ -152,7 +170,7 @@ export class OutputNode<C = unknown> extends Node<
     // Summarize round (pure data — no events)
     const summary = await summarizeRound(
       outputState,
-      this.services,
+      outputDependencies,
       outputLocation,
       currentRound,
       {
@@ -186,6 +204,7 @@ export class OutputNode<C = unknown> extends Node<
     error: Error,
   ): Promise<OutputExecResult> {
     const { logger, outputState, setting } = this.services;
+    const outputDependencies = this.outputDependencies();
     const { outputLocation, currentRound, endTurn } = prepRes;
     logger.warn(`Output processing failed: ${error.message}`, { data: error });
 
@@ -194,7 +213,7 @@ export class OutputNode<C = unknown> extends Node<
     try {
       summary = await summarizeRound(
         outputState,
-        this.services,
+        outputDependencies,
         outputLocation,
         currentRound,
         { endTurn, isRewrite: setting.isRewrite },
@@ -243,7 +262,8 @@ export class OutputNode<C = unknown> extends Node<
     execRes: OutputExecResult,
   ): Promise<string | undefined> {
     const { outputState, workflowOutputPolicy } = this.services;
-    const { streamId, runtimeHost } = useLaunchRunContext();
+    const outputDependencies = this.outputDependencies();
+    const { runtimeHost, streamId } = outputDependencies;
     const { outputLocation, currentRound, endTurn } = prepRes;
     const { summary, roundOutput } = execRes;
 
@@ -288,7 +308,7 @@ export class OutputNode<C = unknown> extends Node<
       await tryOperation(async () => {
         const validationResult = await checkExpectedOutputs(
           outputState,
-          this.services,
+          outputDependencies,
           outputLocation,
           currentRound,
           summary.stage,

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -12,6 +12,7 @@ import { LatexDiffManager } from '@agent/output/LatexDiffManager';
 import { type IInterruptible } from '@agent/runtime/InterruptRegistry';
 import type { BaseFlowContextInit } from '@agent/core/flows/BaseFlowServices';
 import { currentSession } from '@agent/runtime/SessionHandle';
+import { useLaunchRunContext } from '@agent/runtime/RunContext';
 import { activeModelHandlerCompatibilityKey } from '@agent/runtime/ModelFactory';
 import { inferPersistedModelHandlerCompatibilityKey } from '@agent/runtime/modelHandlerCompatibilityInference';
 import { getOutputFileName } from '@agent/utils/outputFileUtils';
@@ -92,15 +93,13 @@ export async function runReflectionFlow<C = unknown>(
     setting,
     prompt,
     logger,
-    runtimeHost,
-    streamId,
-    executionId,
     storageKey,
     parentStage,
     userVarChannels,
     checkInterruption,
     onRoundFinalized = async () => {},
   } = input;
+  const { runtimeHost, streamId, executionId } = useLaunchRunContext();
   // Capture the run's session at setup (inside the run's ALS); the interrupt
   // closure below fires from the host thread outside the ALS.
   const runSession = currentSession();
@@ -285,7 +284,6 @@ export async function runReflectionFlow<C = unknown>(
 
     services = {
       ...input,
-      runtimeHost,
       onRoundFinalized,
       outputState,
       xmlManager,

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -10,6 +10,8 @@ import {
 } from '@agent/runtime/ModelFactory';
 import { inferPersistedModelHandlerCompatibilityKey } from '@agent/runtime/modelHandlerCompatibilityInference';
 import { currentSession } from '@agent/runtime/SessionHandle';
+import { useLaunchRunContext } from '@agent/runtime/RunContext';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
   PersistedFlow,
   flowKey,
@@ -112,7 +114,7 @@ export function getToolUseFlowErrorResult(
 export interface ToolUseFlowContext {
   readonly session: ToolUseSessionLifecycle;
   readonly modelHandler: ToolUseServices['modelHandler'];
-  readonly runtimeHost: ToolUseServices['runtimeHost'];
+  readonly runtimeHost: AgentRuntimeHost;
   readonly model: string;
   interrupt(): void;
   requestImmediateCompaction(): void;
@@ -142,8 +144,8 @@ export async function runToolUseFlow<C = unknown>(
   toolRegistry?: IToolRegistry,
   onSetup?: ToolUseFlowSetupCallback,
 ): Promise<RunToolUseFlowResult> {
-  const { logger, runtimeHost, streamId, executionId, setting, onInterrupt } =
-    input;
+  const { logger, setting, onInterrupt } = input;
+  const { runtimeHost, streamId, executionId } = useLaunchRunContext();
   // Capture the run's session at setup (inside the run's ALS). The interrupt
   // closure below fires from the host thread outside the ALS, so it must use
   // this captured handle, not a fresh currentSession() lookup.
@@ -166,7 +168,6 @@ export async function runToolUseFlow<C = unknown>(
 
   const services: ToolUseServices<C> = {
     ...input,
-    runtimeHost,
     session: sessionLifecycle,
     resolvedTools,
     toolRegistry: registry,

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -16,7 +16,10 @@ import {
   type StageHandle,
 } from '@agent/trace';
 import { getExecutionStore } from '@agent/storage';
-import type { AgentCore } from '@agent/core/flows/BaseFlowServices';
+import type {
+  AgentCore,
+  AgentRunIdentity,
+} from '@agent/core/flows/BaseFlowServices';
 import {
   AgentConfigSchema,
   type AgentConfig,
@@ -74,7 +77,7 @@ import { attachConversationProgressHub } from './conversationProgressHub';
 import type { ToolEditApprovalPort } from '@platform/interfaces/toolEditApproval';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 
-export interface AgentLaunchContext extends AgentCore {
+export interface AgentLaunchContext extends AgentCore, AgentRunIdentity {
   usageMonitor: UsageMonitor;
   storageKey: StorageKey;
   parentStage: StageHandle;

--- a/src/test-kernel/agent/followUp/ToolUseRoundFollowUpMedia.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseRoundFollowUpMedia.vitest.ts
@@ -14,6 +14,7 @@ import { MapToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
+import { withTestRunContext } from '../progressTestUtils';
 
 describe('ToolUseRoundFlow queued follow-ups', () => {
   it('attaches media from follow-ups queued at round start', async () => {
@@ -30,7 +31,6 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
       checkInterruption: () => false,
       client: {},
       config: { agent: 'test-agent', model: 'test-model' },
-      executionId: 'test-exec',
       fileService: {
         createLocation: (filePath: string) => ({ absolutePath: filePath }),
       },
@@ -44,7 +44,6 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
       },
       prompt: { systemPrompt: '', userPrefix: '', userRequest: '' },
       run: AgentRunStateSnapshotSchema.parse({}),
-      runtimeHost: noopAgentRuntimeHost,
       session: {
         hasQueuedFollowUp: () => true,
         waitForFollowUp: async () => ({
@@ -60,7 +59,6 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
       },
       setAbortController: () => {},
       setting: { temperature: 0, tools: [] },
-      streamId: 'test-stream',
       streamStatus: new StreamStatusRegistry(),
       toolRegistry: new MapToolRegistry({}),
       userVarChannels: { input: {}, transient: {} },
@@ -69,7 +67,7 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
 
     const shared = createShared([]);
 
-    await createToolUseRoundFlow().setServices(services).run(shared);
+    await runRound(services, shared);
 
     expect(createUserFollowUpMessages).toHaveBeenCalledWith(
       [],
@@ -113,6 +111,15 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
     };
   }
 
+  function runRound(
+    services: ToolUseRoundServices,
+    shared: ToolUseRoundShared,
+  ): Promise<string | undefined> {
+    return withTestRunContext(noopAgentRuntimeHost, 'test-stream', () =>
+      createToolUseRoundFlow().setServices(services).run(shared),
+    );
+  }
+
   function createBlankTurnServices(
     responses: Array<{ id: string; text?: string; toolCall?: boolean }>,
   ): {
@@ -147,7 +154,6 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
       checkInterruption: () => false,
       client: {},
       config: { agent: 'test-agent', model: 'test-model' },
-      executionId: 'test-exec',
       fileService: {
         createLocation: (filePath: string) => ({ absolutePath: filePath }),
       },
@@ -192,13 +198,11 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
       },
       prompt: { systemPrompt: '', userPrefix: '', userRequest: '' },
       run: AgentRunStateSnapshotSchema.parse({}),
-      runtimeHost: noopAgentRuntimeHost,
       session: {
         hasQueuedFollowUp: () => false,
       },
       setAbortController: () => {},
       setting: { temperature: 0, tools: [{ name: 'again' }] },
-      streamId: 'test-stream',
       streamStatus: new StreamStatusRegistry(),
       toolRegistry: new MapToolRegistry({
         again: {
@@ -221,7 +225,7 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
       ]);
     const shared = createShared([toolResultMessage('executions-1')]);
 
-    await createToolUseRoundFlow().setServices(services).run(shared);
+    await runRound(services, shared);
 
     expect(createResponse).toHaveBeenCalledTimes(2);
     expect(createUserFollowUpMessages).toHaveBeenCalledWith(
@@ -246,7 +250,7 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
       interactionsFunctionResultMessage('executions-1'),
     ]);
 
-    await createToolUseRoundFlow().setServices(services).run(shared);
+    await runRound(services, shared);
 
     expect(createResponse).toHaveBeenCalledTimes(2);
     expect(createUserFollowUpMessages).toHaveBeenCalledWith(
@@ -269,7 +273,7 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
       ]);
     const shared = createShared([toolResultMessage('executions-1')]);
 
-    await createToolUseRoundFlow().setServices(services).run(shared);
+    await runRound(services, shared);
 
     expect(createResponse).toHaveBeenCalledTimes(2);
     expect(createUserFollowUpMessages).toHaveBeenCalledTimes(1);
@@ -290,9 +294,9 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
       new Error('follow-up append failed'),
     );
 
-    await expect(
-      createToolUseRoundFlow().setServices(services).run(shared),
-    ).rejects.toThrow('follow-up append failed');
+    await expect(runRound(services, shared)).rejects.toThrow(
+      'follow-up append failed',
+    );
 
     expect(createUserFollowUpMessages).toHaveBeenCalledTimes(1);
     expect(shared.blankToolResultContinuationMessageIndex).toBeUndefined();
@@ -309,7 +313,7 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
       ]);
     const shared = createShared([toolResultMessage('executions-1')]);
 
-    await createToolUseRoundFlow().setServices(services).run(shared);
+    await runRound(services, shared);
 
     expect(createResponse).toHaveBeenCalledTimes(4);
     expect(createUserFollowUpMessages).toHaveBeenCalledTimes(2);

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -36,6 +36,7 @@ describe('ToolUseWaitNode', () => {
     const memoryMisses: AttachedMemoryMiss[] = [
       { path: '/memories/missing.md', reason: 'not found' },
     ];
+    const runtimeHost = { emit: vi.fn() };
 
     const services = {
       attachedMemoryMisses: memoryMisses,
@@ -44,7 +45,7 @@ describe('ToolUseWaitNode', () => {
       logger: { error: vi.fn() },
       modelHandler: { extractAssistantText: () => undefined },
       onBeforeWaiting,
-      runtimeHost: { emit: vi.fn() },
+      runtimeHost,
       session: {
         hasQueuedFollowUp: () => false,
         waitForFollowUp: async () => {
@@ -60,7 +61,7 @@ describe('ToolUseWaitNode', () => {
 
     const prep = await node.prep(shared);
     const transition = await withTestRunContext(
-      services.runtimeHost,
+      runtimeHost,
       'test-stream',
       async () => {
         const exec = await node.exec(prep);
@@ -86,6 +87,7 @@ describe('ToolUseWaitNode', () => {
       .fn()
       .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce(true);
+    const runtimeHost = { emit: vi.fn() };
 
     const services = {
       checkInterruption: () => interrupted,
@@ -96,7 +98,7 @@ describe('ToolUseWaitNode', () => {
         extractAssistantText: () => undefined,
       },
       onBeforeWaiting,
-      runtimeHost: { emit: vi.fn() },
+      runtimeHost,
       session: {
         hasQueuedFollowUp: () => waitCalls === 0,
         waitForFollowUp: async () => {
@@ -119,7 +121,7 @@ describe('ToolUseWaitNode', () => {
 
     const firstPrep = await node.prep(shared);
     const firstTransition = await withTestRunContext(
-      services.runtimeHost,
+      runtimeHost,
       'test-stream',
       async () => {
         const firstExec = await node.exec(firstPrep);
@@ -131,7 +133,7 @@ describe('ToolUseWaitNode', () => {
 
     const secondPrep = await node.prep(shared);
     const secondTransition = await withTestRunContext(
-      services.runtimeHost,
+      runtimeHost,
       'test-stream',
       async () => {
         const secondExec = await node.exec(secondPrep);
@@ -152,6 +154,7 @@ describe('ToolUseWaitNode', () => {
       stateSlices: null,
     };
     const onBeforeWaiting = vi.fn(async () => true);
+    const runtimeHost = { emit: vi.fn() };
 
     const services = {
       checkInterruption: () => true,
@@ -159,7 +162,7 @@ describe('ToolUseWaitNode', () => {
       logger: { error: vi.fn(), info: vi.fn() },
       modelHandler: { extractAssistantText: () => undefined },
       onBeforeWaiting,
-      runtimeHost: { emit: vi.fn() },
+      runtimeHost,
       session: {
         hasQueuedFollowUp: () => false,
         waitForFollowUp: vi.fn(),
@@ -172,7 +175,7 @@ describe('ToolUseWaitNode', () => {
 
     const prep = await node.prep(shared);
     const transition = await withTestRunContext(
-      services.runtimeHost,
+      runtimeHost,
       'test-stream',
       async () => {
         const exec = await node.exec(prep);
@@ -193,6 +196,7 @@ describe('ToolUseWaitNode', () => {
     };
     const warn = vi.fn();
     const addMediaToUserMessage = vi.fn(async () => {});
+    const runtimeHost = { emit: vi.fn() };
 
     const services = {
       checkInterruption: () => false,
@@ -208,14 +212,14 @@ describe('ToolUseWaitNode', () => {
         },
         createUserFollowUpMessages: vi.fn(async () => []),
       },
-      runtimeHost: { emit: vi.fn() },
+      runtimeHost,
       streamStatus: new StreamStatusRegistry(),
       streamId: 'test-stream',
     } as unknown as ToolUseServices;
 
     const node = new ToolUseWaitNode().setServices(services);
     const transition = await withTestRunContext(
-      services.runtimeHost,
+      runtimeHost,
       'test-stream',
       () =>
         node.post(
@@ -329,6 +333,7 @@ describe('ToolUseWaitNode', () => {
     const onFollowUpConsumed = vi.fn();
     const waitForFollowUp = vi.fn();
     const streamStatus = new StreamStatusRegistry();
+    const runtimeHost = { emit: vi.fn() };
     const services = {
       checkInterruption: () => false,
       isSubagent: false,
@@ -338,7 +343,7 @@ describe('ToolUseWaitNode', () => {
         extractAssistantText: () => undefined,
       },
       onFollowUpConsumed,
-      runtimeHost: { emit: vi.fn() },
+      runtimeHost,
       session: {
         hasQueuedFollowUp: () => false,
         waitForFollowUp,
@@ -350,10 +355,8 @@ describe('ToolUseWaitNode', () => {
 
     try {
       const prep = await node.prep(shared);
-      const exec = await withTestRunContext(
-        services.runtimeHost,
-        streamId,
-        () => node.exec(prep),
+      const exec = await withTestRunContext(runtimeHost, streamId, () =>
+        node.exec(prep),
       );
 
       expect(exec.kind).toBe('continue');
@@ -368,10 +371,8 @@ describe('ToolUseWaitNode', () => {
       expect(waitForFollowUp).not.toHaveBeenCalled();
       expect(streamStatus.get(streamId)).toBeUndefined();
 
-      const transition = await withTestRunContext(
-        services.runtimeHost,
-        streamId,
-        () => node.post(shared, prep, exec),
+      const transition = await withTestRunContext(runtimeHost, streamId, () =>
+        node.post(shared, prep, exec),
       );
 
       expect(transition).toBe(FlowTransition.CONTINUE);
@@ -417,6 +418,7 @@ describe('ToolUseWaitNode', () => {
       ],
     );
     const waitForFollowUp = vi.fn(async () => null);
+    const runtimeHost = { emit: vi.fn() };
     const services = {
       checkInterruption: () => false,
       isSubagent: false,
@@ -425,7 +427,7 @@ describe('ToolUseWaitNode', () => {
         createUserFollowUpMessages,
         extractAssistantText: () => undefined,
       },
-      runtimeHost: { emit: vi.fn() },
+      runtimeHost,
       session: {
         hasQueuedFollowUp: () => false,
         waitForFollowUp,
@@ -439,10 +441,8 @@ describe('ToolUseWaitNode', () => {
       const continuationCycles = 25;
       for (let cycle = 0; cycle < continuationCycles; cycle += 1) {
         const prep = await node.prep(shared);
-        const exec = await withTestRunContext(
-          services.runtimeHost,
-          streamId,
-          () => node.exec(prep),
+        const exec = await withTestRunContext(runtimeHost, streamId, () =>
+          node.exec(prep),
         );
 
         expect(exec.kind).toBe('continue');
@@ -452,10 +452,8 @@ describe('ToolUseWaitNode', () => {
           'Keep solving the hard problem until verification is complete.',
         );
 
-        const transition = await withTestRunContext(
-          services.runtimeHost,
-          streamId,
-          () => node.post(shared, prep, exec),
+        const transition = await withTestRunContext(runtimeHost, streamId, () =>
+          node.post(shared, prep, exec),
         );
         expect(transition).toBe(FlowTransition.CONTINUE);
         expect(createUserFollowUpMessages).toHaveBeenCalledTimes(cycle + 1);
@@ -470,10 +468,8 @@ describe('ToolUseWaitNode', () => {
       await GoalStore.setStatus(streamId, 'paused');
 
       const prep = await node.prep(shared);
-      const exec = await withTestRunContext(
-        services.runtimeHost,
-        streamId,
-        () => node.exec(prep),
+      const exec = await withTestRunContext(runtimeHost, streamId, () =>
+        node.exec(prep),
       );
 
       expect(waitForFollowUp).toHaveBeenCalledOnce();
@@ -494,11 +490,12 @@ describe('ToolUseWaitNode', () => {
       items: [{ text: 'user correction', origin: 'user' }],
       synthetic: false,
     }));
+    const runtimeHost = { emit: vi.fn() };
     const services = {
       checkInterruption: () => false,
       logger: { error: vi.fn() },
       modelHandler: { extractAssistantText: () => undefined },
-      runtimeHost: { emit: vi.fn() },
+      runtimeHost,
       session: {
         hasQueuedFollowUp: () => true,
         waitForFollowUp,
@@ -509,16 +506,13 @@ describe('ToolUseWaitNode', () => {
     const node = new ToolUseWaitNode().setServices(services);
 
     try {
-      const exec = await withTestRunContext(
-        services.runtimeHost,
-        streamId,
-        () =>
-          node.exec({
-            afterError: false,
-            lastResponse: undefined,
-            previouslyDeliveredToOrchestrator: false,
-            touchedFiles: [],
-          }),
+      const exec = await withTestRunContext(runtimeHost, streamId, () =>
+        node.exec({
+          afterError: false,
+          lastResponse: undefined,
+          previouslyDeliveredToOrchestrator: false,
+          touchedFiles: [],
+        }),
       );
 
       expect(waitForFollowUp).toHaveBeenCalledOnce();
@@ -540,12 +534,13 @@ describe('ToolUseWaitNode', () => {
     await GoalStore.start(streamId, 'Parent-owned objective.');
 
     const waitForFollowUp = vi.fn(async () => null);
+    const runtimeHost = { emit: vi.fn() };
     const services = {
       checkInterruption: () => false,
       isSubagent: true,
       logger: { error: vi.fn() },
       modelHandler: { extractAssistantText: () => undefined },
-      runtimeHost: { emit: vi.fn() },
+      runtimeHost,
       session: {
         hasQueuedFollowUp: () => false,
         waitForFollowUp,
@@ -556,16 +551,13 @@ describe('ToolUseWaitNode', () => {
     const node = new ToolUseWaitNode().setServices(services);
 
     try {
-      const exec = await withTestRunContext(
-        services.runtimeHost,
-        streamId,
-        () =>
-          node.exec({
-            afterError: false,
-            lastResponse: undefined,
-            previouslyDeliveredToOrchestrator: false,
-            touchedFiles: [],
-          }),
+      const exec = await withTestRunContext(runtimeHost, streamId, () =>
+        node.exec({
+          afterError: false,
+          lastResponse: undefined,
+          previouslyDeliveredToOrchestrator: false,
+          touchedFiles: [],
+        }),
       );
 
       expect(waitForFollowUp).toHaveBeenCalledOnce();
@@ -585,6 +577,7 @@ describe('ToolUseWaitNode', () => {
       stateSlices: null,
     };
     const createUserFollowUpMessages = vi.fn(async () => []);
+    const runtimeHost = { emit: vi.fn() };
     const services = {
       checkInterruption: () => false,
       logger: { error: vi.fn() },
@@ -592,7 +585,7 @@ describe('ToolUseWaitNode', () => {
         createUserFollowUpMessages,
         extractAssistantText: () => undefined,
       },
-      runtimeHost: { emit: vi.fn() },
+      runtimeHost,
       session: {
         hasQueuedFollowUp: () => false,
         waitForFollowUp: async () => ({
@@ -612,15 +605,13 @@ describe('ToolUseWaitNode', () => {
       });
 
       const prep = await node.prep(shared);
-      const exec = await withTestRunContext(
-        services.runtimeHost,
-        streamId,
-        () => node.exec(prep),
+      const exec = await withTestRunContext(runtimeHost, streamId, () =>
+        node.exec(prep),
       );
       expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.WAITING);
       expect(StreamStatusService.get(streamId)).toBe(STREAM_STATUS.STOPPED);
 
-      await withTestRunContext(services.runtimeHost, streamId, () =>
+      await withTestRunContext(runtimeHost, streamId, () =>
         node.post(shared, prep, exec),
       );
       expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.RUNNING);

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -43,6 +43,7 @@ import type { ExecResult } from '@shared/schemas/opResults';
 import { BashTool } from '@tools/bash';
 import { TaskRunFileService } from '@utils/files';
 import * as execUtils from '@utils/system/execUtils';
+import { withTestRunContext } from '../agent/progressTestUtils';
 
 // Type imports
 import type OpenAI from 'openai';
@@ -163,15 +164,12 @@ function roundServices(opts: {
     } satisfies AgentPrompt,
     userVarChannels: { input: {}, transient: {} },
     logger: opts.logger,
-    runtimeHost: noopAgentRuntimeHost,
     streamStatus: new StreamStatusRegistry(),
     client: {} as OpenAI,
-    fileService: new TaskRunFileService('test-execution-id'),
+    fileService: new TaskRunFileService('deadbeef'),
     toolRegistry: opts.toolRegistry,
     checkInterruption: opts.checkInterruption ?? (() => false),
     setAbortController: opts.setAbortController ?? (() => {}),
-    streamId: opts.streamId,
-    executionId: 'test-execution-id',
     run: AgentRunStateSnapshotSchema.parse({}),
     workspace: AgentWorkspaceState.create(),
   };
@@ -249,7 +247,9 @@ describe('BashTool', () => {
     // Create and run the flow directly
     const flow = createToolUseRoundFlow();
     flow.setServices(options);
-    await flow.run(shared);
+    await withTestRunContext(noopAgentRuntimeHost, 'bash-tool', () =>
+      flow.run(shared),
+    );
 
     const toolOutputMessage = messages.find(
       (msg) => (msg as any).type === 'function_call_output',
@@ -301,25 +301,27 @@ describe('BashTool', () => {
 
       const node = new ToolUseDispatchNode<OpenAI>();
       node.setServices(options);
-      await node.post(
-        shared,
-        [call],
-        [
-          {
-            call,
-            result: {},
-            parsedInput: {},
-            extracted: {
-              attachments: [],
-              sanitizedResult: { status: 'executed' },
-            },
-            editedFiles: [],
-            logRef: {
-              logId: undefined,
-              groupId: runTrace.trace.activeStageId(),
-            },
-          } as any,
-        ],
+      await withTestRunContext(noopAgentRuntimeHost, 'tool-status-log', () =>
+        node.post(
+          shared,
+          [call],
+          [
+            {
+              call,
+              result: {},
+              parsedInput: {},
+              extracted: {
+                attachments: [],
+                sanitizedResult: { status: 'executed' },
+              },
+              editedFiles: [],
+              logRef: {
+                logId: undefined,
+                groupId: runTrace.trace.activeStageId(),
+              },
+            } as any,
+          ],
+        ),
       );
 
       const completedEvent = events.findLast(
@@ -411,7 +413,11 @@ describe('BashTool', () => {
 
     try {
       node.setServices(options);
-      const result = await node.exec(call);
+      const result = await withTestRunContext(
+        noopAgentRuntimeHost,
+        'bash-tool',
+        () => node.exec(call),
+      );
 
       assert.equal(result, null);
       assert.ok(receivedSignal, 'Bash command should receive an abort signal');


### PR DESCRIPTION
## Summary

- Moves run identity (`runtimeHost`, `streamId`, `executionId`) out of the general node-facing flow service bag and keeps it owned by the launch/run context.
- Keeps identity-bearing dependencies only at explicit boundaries such as reflection output processing, where UI/file events must be emitted.
- Updates direct node tests to provide a launch run context instead of reading identity from typed services.

## Why

Issue #6921 tracks the fat `AgentCore` service bag. This is a small, behavior-preserving step: run identity is not a computational service, so ordinary flow nodes should read it from the run context rather than receive it as part of every service interface.

## Validation

- `npx tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `npx eslint src/agent/core/flows/BaseFlowServices.ts src/agent/core/flows/CommonCycleTypes.ts src/agent/core/flows/RetryState.ts src/agent/runtime/AgentLaunchContext.ts src/agent/implementations/flows/tooluse/runToolUseFlow.ts src/agent/implementations/flows/reflection/runReflectionFlow.ts src/agent/implementations/flows/reflection/nodes/OutputNode.ts src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts src/test-kernel/tools/BashTool.vitest.ts`
- `npx vitest run src/test-kernel/agent/runtime/RetryState.vitest.ts src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts src/test-kernel/tools/BashTool.vitest.ts src/test-kernel/agent/ReflectionOutputLocation.vitest.ts src/test-kernel/agent/output/OutputProgressEvents.vitest.ts`
- `npm run lint` (passes with existing repository warnings outside this PR)

Closes #6921 only in part; this is one narrow slice of the service-bag cleanup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core flow wiring and every path that emitted UI/events or waited on retry by stream id; mistakes would surface as missing run context or wrong stream targeting, but the change is largely a structural move with test coverage updated.
> 
> **Overview**
> **Narrows the flow service bag** by dropping `runtimeHost`, `streamId`, and `executionId` from `AgentCore` and introducing `AgentRunIdentity`, which `AgentLaunchContext` still carries at launch.
> 
> **Runtime behavior is unchanged in intent:** `runToolUseFlow` / `runReflectionFlow` pull identity from `useLaunchRunContext()` instead of flow inputs; retry manual prompts, cycle debug saves, and reflection `OutputNode` build explicit `OutputDependencies` from the launch context rather than spreading identity through every node service type.
> 
> **Tests** wrap node/round execution in `withTestRunContext` so code that now depends on ambient run context keeps working without stubbing identity on service mocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51ebc3197d827e300c9779b479e665fcf7c0167a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->