### PR TITLE
[codex] fix(desktop): route session host events through window host

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -231,7 +231,7 @@ export class DesktopProgressBridge {
    * from other windows and torn down on window close. Cross-window "is this
    * execution running anywhere" checks use `getAllActiveExecutionIds()`.
    */
-  private readonly session: SessionHandle = new SessionHandle();
+  private readonly session: SessionHandle;
   /** Detaches the session→toast consumer; called on dispose. */
   private detachResultToast: (() => void) | undefined;
 
@@ -239,6 +239,10 @@ export class DesktopProgressBridge {
     private readonly postToRenderer: (message: unknown) => boolean | void,
     private readonly options: DesktopProgressBridgeOptions = {},
   ) {
+    this.runtimeHost = {
+      emit: (event, payload) => this.handleProgressEvent(event, payload),
+    };
+    this.session = new SessionHandle({ hostChannel: this.runtimeHost });
     setProgressViewBridge({ isViewVisible: () => true });
     this.backend = new ProgressBackend({
       session: this.session,
@@ -326,9 +330,6 @@ export class DesktopProgressBridge {
       backendSubscription.dispose();
       this.progressEvents.dispose();
       unsubscribeResult();
-    };
-    this.runtimeHost = {
-      emit: (event, payload) => this.handleProgressEvent(event, payload),
     };
     // Present terminal-error toasts from this window's run results (the run
     // lifecycle no longer emits them directly) through the same runtimeHost

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -1,6 +1,9 @@
 // Third-party imports
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+// Local imports - agent state
+import { TaskStateSchema } from '@agent/core/state/TaskState';
+
 // Local imports - progress schemas
 import { DESKTOP_SHELL_COMMANDS } from '@desktop/desktopShellMessages';
 import {
@@ -17,7 +20,6 @@ import { COMMON_COMMANDS } from '@shared/ipc/commonCommands';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc/progressViewCommands';
 import type { ProgressViewInboundHandlerRegistry } from '@shared/schemas/progressView';
 import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
-import { TaskStateSchema } from '@agent/core/state/TaskState';
 import { DIAGNOSTICS_ADD_RUNTIME_CAPABILITY } from '@tools/diagnosticsRuntimeCapabilities';
 
 // Local imports - desktop test paths
@@ -53,6 +55,9 @@ type TestableBridge = Bridge & {
 
 type BridgeWithSession = TestableBridge & {
   session: {
+    hostChannel?: {
+      emit(event: string, payload: unknown): void;
+    };
     coordinators: {
       cleanupAllRequests(): void;
     };
@@ -472,6 +477,42 @@ describe('DesktopProgressBridge', () => {
       expect(seen).toEqual([{ streamId: 'parent', todos: [] }]);
     } finally {
       off();
+      bridge.dispose();
+    }
+  });
+
+  it('routes host-path runtime events through the desktop session host channel', async () => {
+    const messages: unknown[] = [];
+    const streamSnapshotStore = createStreamSnapshotStore([]);
+    const bridge = (await createBridge(messages, {
+      streamSnapshotStore,
+    })) as BridgeWithSession;
+    const { emitRuntimeEvent } =
+      await import('@agent/runtime/emitRuntimeEvent');
+    const session = bridge.session as unknown as Parameters<
+      typeof emitRuntimeEvent
+    >[2];
+
+    try {
+      emitRuntimeEvent(
+        'setTaskState',
+        {
+          streamId: 'desktop-host-stream',
+          executionId: 'desktop-host-exec',
+          taskState: TaskStateSchema.parse(workflowTaskState()),
+        },
+        session,
+      );
+
+      await vi.waitFor(() => {
+        expect(streamSnapshotStore.upsert).toHaveBeenCalledWith(
+          expect.objectContaining({
+            streamId: 'desktop-host-stream',
+            executionId: 'desktop-host-exec',
+          }),
+        );
+      });
+    } finally {
       bridge.dispose();
     }
   });


### PR DESCRIPTION
## Summary

This PR wires the desktop `SessionHandle` to the existing per-window `runtimeHost`. Host-path runtime events that are emitted with the desktop window session now enter the same desktop bridge path as in-run events.

This is a narrow #5972 slice. It does not attempt the broader `hostChannel` or follow-up state-machine convergence work.

## Root Cause

`emitRuntimeEvent(...)` already prefers `session.hostChannel`, but `DesktopProgressBridge` created its isolated per-window `SessionHandle` before assigning the bridge runtime host. The desktop session therefore had no host channel, so non-run-scoped events with an explicit desktop session could not use the window-owned runtime path.

## Changes

- Construct `DesktopProgressBridge.runtimeHost` before the per-window session.
- Create the desktop `SessionHandle` with `{ hostChannel: this.runtimeHost }`.
- Add a focused desktop test showing that a host-path `setTaskState` event emitted through the session reaches the desktop progress-event bridge and persists the stream snapshot.

## Validation

- `npx tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `npx eslint packages/desktop/src/main/desktopAgentExecution.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `npx vitest run src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`

Refs #5972

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Constructor ordering and session wiring only; behavior is aligning desktop with existing `emitRuntimeEvent` / `hostChannel` routing, covered by a focused integration test.
> 
> **Overview**
> Fixes desktop windows where **`emitRuntimeEvent`** could not reach the progress bridge when callers passed that window’s **`SessionHandle`**, because the session was created without a **`hostChannel`**.
> 
> **`DesktopProgressBridge`** now builds **`runtimeHost`** first (emit → **`handleProgressEvent`** / progress bus + snapshot bridge), then constructs **`new SessionHandle({ hostChannel: this.runtimeHost })`**. The late constructor assignment of **`runtimeHost`** is removed.
> 
> A desktop test asserts a host-path **`setTaskState`** emitted via **`emitRuntimeEvent`** persists through **`streamSnapshotStore.upsert`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d288e6648c4721dbac9873748de4ddaf65404401. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->