### PR TITLE
[codex] refactor: delegate inquiry follow-up wake policy

### DIFF
--- a/src/test-kernel/tools/InquiryContinuationSession.vitest.ts
+++ b/src/test-kernel/tools/InquiryContinuationSession.vitest.ts
@@ -1,7 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const sendFollowUpMock = vi.hoisted(() =>
-  vi.fn(async () => ({ status: 'sent' as const })),
+  vi.fn<(...args: unknown[]) => Promise<unknown>>(async () => ({
+    status: 'sent' as const,
+  })),
+);
+const wakeQueuedFollowUpStreamMock = vi.hoisted(() =>
+  vi.fn<(...args: unknown[]) => Promise<unknown>>(async () => ({
+    kind: 'not_required' as const,
+  })),
 );
 const getThreadSummaryMock = vi.hoisted(() => vi.fn());
 const listOpenThreadsForStreamMock = vi.hoisted(() => vi.fn(async () => []));
@@ -9,6 +16,7 @@ const readExternalInquiryThreadMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
   sendFollowUp: sendFollowUpMock,
+  wakeQueuedFollowUpStream: wakeQueuedFollowUpStreamMock,
 }));
 
 vi.mock('@eventBus/ProgressEventBus', () => ({
@@ -61,6 +69,10 @@ function answeredManifest(): ExternalInquiryThreadManifest {
 describe('external inquiry continuation session routing', () => {
   beforeEach(() => {
     sendFollowUpMock.mockClear();
+    wakeQueuedFollowUpStreamMock.mockReset();
+    wakeQueuedFollowUpStreamMock.mockResolvedValue({
+      kind: 'not_required' as const,
+    });
     getThreadSummaryMock.mockResolvedValue({
       threadId: THREAD,
       parentStreamId: STREAM,
@@ -90,5 +102,46 @@ describe('external inquiry continuation session routing', () => {
       undefined,
       session,
     );
+    expect(wakeQueuedFollowUpStreamMock).toHaveBeenCalledWith(STREAM, {
+      status: 'sent',
+    });
+  });
+
+  it('delegates queued wake decisions to the follow-up owner', async () => {
+    sendFollowUpMock.mockResolvedValueOnce({
+      status: 'queued',
+      reason: 'waiting',
+    });
+    wakeQueuedFollowUpStreamMock.mockResolvedValueOnce({
+      kind: 'resumed' as const,
+    });
+
+    const outcome = await injectContinuationForAnsweredThread(
+      THREAD,
+      answeredManifest(),
+    );
+
+    expect(outcome).toBe('resumed');
+    expect(wakeQueuedFollowUpStreamMock).toHaveBeenCalledWith(STREAM, {
+      status: 'queued',
+      reason: 'waiting',
+    });
+  });
+
+  it('archives inquiries when the follow-up owner drops a stale queue', async () => {
+    sendFollowUpMock.mockResolvedValueOnce({
+      status: 'queued',
+      reason: 'children_running',
+    });
+    wakeQueuedFollowUpStreamMock.mockResolvedValueOnce({
+      kind: 'dropped' as const,
+    });
+
+    const outcome = await injectContinuationForAnsweredThread(
+      THREAD,
+      answeredManifest(),
+    );
+
+    expect(outcome).toBe('archived');
   });
 });

--- a/src/tools/inquiry/inquiryContinuation.ts
+++ b/src/tools/inquiry/inquiryContinuation.ts
@@ -12,9 +12,11 @@
  * forward it to the UI via the `inquiryThreadUpdated` event.
  */
 
-import { platform } from '@platform/platform';
-
-import { sendFollowUp } from '@agent/followUp/ToolUseFollowUp';
+import {
+  sendFollowUp,
+  wakeQueuedFollowUpStream,
+  type FollowUpWakeResult,
+} from '@agent/followUp/ToolUseFollowUp';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import { createChannelTrace } from '@logger';
@@ -111,6 +113,30 @@ async function emitInquiryThreadUpdate(
   emitRuntimeEvent('inquiryThreadUpdated', { ...summary, ...extra }, session);
 }
 
+function mapWakeResultToInquiryOutcome(
+  result: FollowUpWakeResult,
+): InjectionOutcome {
+  switch (result.kind) {
+    case 'not_required':
+      return 'sent';
+    case 'resumed':
+      return 'resumed';
+    case 'dropped':
+      return 'archived';
+    case 'queued_without_wake':
+    case 'resume_in_flight':
+    case 'active_or_resuming':
+    case 'queued_resume_failed':
+      return 'queued';
+  }
+}
+
+function mapInjectionOutcomeToResumeOutcome(
+  outcome: InjectionOutcome,
+): InquiryResumeOutcome {
+  return outcome === 'archived' ? 'parent_finished' : outcome;
+}
+
 async function deliverContinuation(params: {
   parentStreamId: StreamTabId;
   text: string;
@@ -137,25 +163,13 @@ async function deliverContinuation(params: {
     return 'archived';
   }
 
-  // 'sent' resolves immediately. A 'queued' follow-up whose cycle has exited
-  // (waiting / children_running) is nudged via tryResumeStream so the parent
-  // stream actually picks the message up.
-  let outcome: 'sent' | 'queued' | 'resumed' = 'queued';
-  if (result.status === 'sent') {
-    outcome = 'sent';
-  } else if (
-    result.reason === 'waiting' ||
-    result.reason === 'children_running'
-  ) {
-    const resumed = await platform().agentResume.tryResumeStream(
-      params.parentStreamId,
-    );
-    outcome = resumed ? 'resumed' : 'queued';
-  }
+  const outcome = mapWakeResultToInquiryOutcome(
+    await wakeQueuedFollowUpStream(params.parentStreamId, result),
+  );
 
   await emitInquiryThreadUpdate(
     params.threadId,
-    { resumeOutcome: outcome },
+    { resumeOutcome: mapInjectionOutcomeToResumeOutcome(outcome) },
     params.session,
   );
   return outcome;

--- a/src/tools/inquiry/inquiryContinuation.ts
+++ b/src/tools/inquiry/inquiryContinuation.ts
@@ -3,10 +3,10 @@
  *
  * Host-neutral. When the user submits an answer (or drops an open
  * inquiry), this module synthesizes the `[inquiry] …` continuation
- * text, hands it to `sendFollowUp` for the parent stream, and — for
- * the cases where the cycle has exited (WAITING / children_running) —
- * triggers `AgentResumePort.tryResumeStream` so the parent stream
- * picks the message up.
+ * text, hands it to `sendFollowUp` for the parent stream, and delegates
+ * queued-stream wake/release policy to the follow-up owner so exited
+ * cycles (WAITING / children_running) can pick the message up when the
+ * parent stream is still resumable.
  *
  * Returns an `InjectionOutcome` so the caller (action handler) can
  * forward it to the UI via the `inquiryThreadUpdated` event.


### PR DESCRIPTION
## Summary

This PR makes inquiry continuation delegate queued-follow-up wake/release policy to `wakeQueuedFollowUpStream`, the existing owner in `ToolUseFollowUp`. Inquiry continuation now only maps that declarative wake result to inquiry UI outcomes.

## Why

`deliverContinuation` previously re-derived part of the follow-up queue policy by calling `platform().agentResume.tryResumeStream` directly for waiting and children-running parents. That duplicated ownership with `wakeQueuedFollowUpStream`, which also knows how to serialize wake attempts, detect in-flight resumes, and release stale children-running queues.

## Changes

- Remove the direct platform resume call from `inquiryContinuation`.
- Map `FollowUpWakeResult` to inquiry outcomes in one small local projection.
- Add tests for host-session forwarding, delegated wake behavior, and stale-queue archival.

## Validation

- `npx tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `npx eslint src/tools/inquiry/inquiryContinuation.ts src/test-kernel/tools/InquiryContinuationSession.vitest.ts`
- `npx vitest run src/test-kernel/tools/InquiryContinuationSession.vitest.ts src/test-kernel/tools/InquiryContinuation.vitest.ts src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts`

Refs #5972, #6680

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when answered inquiries resume vs queue vs archive, but behavior is centralized in the existing follow-up owner with new routing tests.
> 
> **Overview**
> Inquiry continuation no longer calls **`platform().agentResume.tryResumeStream`** when a follow-up is queued on a waiting or children-running parent. After **`sendFollowUp`**, **`deliverContinuation`** now calls **`wakeQueuedFollowUpStream`** and maps **`FollowUpWakeResult`** to inquiry **`InjectionOutcome`** values (including **`archived`** when the owner drops a stale queue).
> 
> UI **`inquiryThreadUpdated`** events still use **`InquiryResumeOutcome`**: **`archived`** is projected to **`parent_finished`** via a small mapper. Session tests mock **`wakeQueuedFollowUpStream`** and cover sent, resumed, and archived paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1da379a36445e6077efb8f9cd2705b764f1362de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->