### PR TITLE
Generalize subscription usage logs and simplify supabase edge functions

### DIFF
--- a/supabase/functions/auth-bridge/index.ts
+++ b/supabase/functions/auth-bridge/index.ts
@@ -196,12 +196,8 @@ const PAGE_STYLE = `
   }
 `;
 
-/**
- * The bridge page. Server-validated `ext`/`id` are JSON-embedded for the inline
- * script; both are also re-validated client-side before building the href, so a
- * mismatched or tampered URL never produces a javascript:/data: link.
- */
-function bridgePageHtml(ext: string, id: string): string {
+/** Wrap page body markup in the shared document shell (head + theme-aware style). */
+function htmlDocument(bodyHtml: string): string {
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -211,7 +207,18 @@ function bridgePageHtml(ext: string, id: string): string {
 <style>${PAGE_STYLE}</style>
 </head>
 <body>
-<h1 id="heading">Finish signing in to TeXRA</h1>
+${bodyHtml}
+</body>
+</html>`;
+}
+
+/**
+ * The bridge page. Server-validated `ext`/`id` are JSON-embedded for the inline
+ * script; both are also re-validated client-side before building the href, so a
+ * mismatched or tampered URL never produces a javascript:/data: link.
+ */
+function bridgePageHtml(ext: string, id: string): string {
+  return htmlDocument(`<h1 id="heading">Finish signing in to TeXRA</h1>
 <p id="lede" class="muted">Click the button below to return to your editor and complete sign-in.</p>
 <div class="actions">
   <a id="open" class="button primary" rel="noopener">Open in your editor</a>
@@ -327,27 +334,14 @@ function bridgePageHtml(ext: string, id: string): string {
       }
     });
   }
-</script>
-</body>
-</html>`;
+</script>`);
 }
 
 /** Generic error page that never reflects raw request input. */
 function errorPageHtml(message: string): string {
-  return `<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>TeXRA sign-in</title>
-<style>${PAGE_STYLE}</style>
-</head>
-<body>
-<h1>Sign-in could not be completed</h1>
+  return htmlDocument(`<h1>Sign-in could not be completed</h1>
 <p class="error">${escapeHtml(message)}</p>
-<p class="muted">Return to your editor and start sign-in again.</p>
-</body>
-</html>`;
+<p class="muted">Return to your editor and start sign-in again.</p>`);
 }
 
 function escapeHtml(value: string): string {

--- a/supabase/functions/auth-bridge/index.ts
+++ b/supabase/functions/auth-bridge/index.ts
@@ -224,7 +224,7 @@ function bridgePageHtml(ext: string, id: string): string {
   <a id="open" class="button primary" rel="noopener">Open in your editor</a>
   <button id="copy" type="button">Copy link</button>
 </div>
-<p class="muted">If nothing happens, copy this and run <strong>Open URL</strong> in your editor.</p>
+<p class="muted">If nothing happens, copy this link, open the Command Palette (<strong>Cmd/Ctrl+Shift+P</strong>), run <strong>Open URL</strong>, and paste the link into the box that appears.</p>
 <p><code id="link"></code></p>
 <p id="status" aria-live="polite"></p>
 <script>

--- a/supabase/functions/auth-device/index.ts
+++ b/supabase/functions/auth-device/index.ts
@@ -73,19 +73,19 @@ const supabaseUrl = Deno.env.get('SUPABASE_URL');
 const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
 const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY');
 
-const adminSupabase =
-  supabaseUrl && supabaseServiceKey
-    ? createClient<any>(supabaseUrl, supabaseServiceKey, {
-        auth: { autoRefreshToken: false, persistSession: false },
-      })
-    : null;
+/** Stateless server client (no token refresh, no persisted session). */
+function createEdgeClient(
+  url: string | undefined,
+  key: string | undefined,
+): SupabaseClient<any> | null {
+  if (!url || !key) return null;
+  return createClient<any>(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
 
-const anonSupabase =
-  supabaseUrl && supabaseAnonKey
-    ? createClient<any>(supabaseUrl, supabaseAnonKey, {
-        auth: { autoRefreshToken: false, persistSession: false },
-      })
-    : null;
+const adminSupabase = createEdgeClient(supabaseUrl, supabaseServiceKey);
+const anonSupabase = createEdgeClient(supabaseUrl, supabaseAnonKey);
 
 // =============================================================================
 // Hono App

--- a/supabase/functions/auth-github/index.ts
+++ b/supabase/functions/auth-github/index.ts
@@ -165,6 +165,22 @@ function githubAppMetadata(
   };
 }
 
+/**
+ * Build the admin `updateUserById` payload that merges the fresh GitHub
+ * profile onto an existing user: GitHub fields win in user_metadata, and the
+ * github provider is recorded in app_metadata.
+ */
+function githubProfileUpdate(
+  existingUserMetadata: MetadataRecord | null | undefined,
+  existingAppMetadata: MetadataRecord | null | undefined,
+  githubUserMetadata: MetadataRecord,
+): MetadataRecord {
+  return {
+    user_metadata: { ...(existingUserMetadata ?? {}), ...githubUserMetadata },
+    app_metadata: githubAppMetadata(existingAppMetadata),
+  };
+}
+
 async function validateGitHubToken(
   token: string,
 ): Promise<{ user: GitHubUser; email: string } | { error: string }> {
@@ -288,13 +304,11 @@ app.post('/exchange', async (c) => {
         return errorResponse(c, 'Failed to load linked user', 500);
       }
       const storedEmail = userData.user.email?.trim();
-      const identityUpdate: MetadataRecord = {
-        user_metadata: {
-          ...userData.user.user_metadata,
-          ...githubUserMetadata,
-        },
-        app_metadata: githubAppMetadata(userData.user.app_metadata),
-      };
+      const identityUpdate: MetadataRecord = githubProfileUpdate(
+        userData.user.user_metadata,
+        userData.user.app_metadata,
+        githubUserMetadata,
+      );
       if (storedEmail) {
         userEmail = storedEmail;
       } else {
@@ -336,13 +350,11 @@ app.post('/exchange', async (c) => {
         userEmail = authUser.email ?? email;
         const { error: updateError } = await supabase.auth.admin.updateUserById(
           userId,
-          {
-            user_metadata: {
-              ...authUser.raw_user_meta_data,
-              ...githubUserMetadata,
-            },
-            app_metadata: githubAppMetadata(authUser.raw_app_meta_data),
-          },
+          githubProfileUpdate(
+            authUser.raw_user_meta_data,
+            authUser.raw_app_meta_data,
+            githubUserMetadata,
+          ),
         );
         if (updateError) {
           console.error(

--- a/supabase/functions/before-user-created/index.ts
+++ b/supabase/functions/before-user-created/index.ts
@@ -41,6 +41,10 @@ interface HookRequest {
   user?: HookUser;
 }
 
+function warn(message: string): void {
+  console.warn(`[before-user-created] ${message}`);
+}
+
 function allow(): Response {
   return new Response('{}', {
     status: 200,
@@ -68,16 +72,14 @@ async function fetchGitHubCreatedAt(login: string): Promise<string | null> {
       },
     );
     if (!resp.ok) {
-      console.warn(
-        `[before-user-created] GitHub /users/${login} returned ${resp.status}`,
-      );
+      warn(`GitHub /users/${login} returned ${resp.status}`);
       return null;
     }
     const data = await resp.json();
     return typeof data?.created_at === 'string' ? data.created_at : null;
   } catch (e) {
-    console.warn(
-      `[before-user-created] GitHub fetch failed for ${login}: ${e instanceof Error ? e.message : String(e)}`,
+    warn(
+      `GitHub fetch failed for ${login}: ${e instanceof Error ? e.message : String(e)}`,
     );
     return null;
   }
@@ -119,13 +121,13 @@ Deno.serve(async (req) => {
         'webhook-signature': req.headers.get('webhook-signature') ?? '',
       });
     } catch {
-      console.warn('[before-user-created] Signature verification failed');
+      warn('Signature verification failed');
       return new Response('Unauthorized', { status: 401 });
     }
   } else {
-    console.warn(
-      '[before-user-created] BEFORE_USER_CREATED_HOOK_SECRET is not set; ' +
-        'allowing unsigned requests. Configure the hook secret to enforce verification.',
+    warn(
+      'BEFORE_USER_CREATED_HOOK_SECRET is not set; allowing unsigned requests. ' +
+        'Configure the hook secret to enforce verification.',
     );
   }
 
@@ -137,9 +139,7 @@ Deno.serve(async (req) => {
 
   const emailDecision = checkEmailDomain(user.email);
   if (!emailDecision.allowed) {
-    console.warn(
-      `[before-user-created] Rejected ${user.email}: ${emailDecision.reason}`,
-    );
+    warn(`Rejected ${user.email}: ${emailDecision.reason}`);
     return block(emailDecision.userMessage);
   }
 
@@ -150,21 +150,17 @@ Deno.serve(async (req) => {
       if (createdAt) {
         const ageDecision = checkGitHubAccountAge(createdAt);
         if (!ageDecision.allowed) {
-          console.warn(
-            `[before-user-created] Rejected ${user.email} (gh=${login}): ${ageDecision.reason}`,
-          );
+          warn(`Rejected ${user.email} (gh=${login}): ${ageDecision.reason}`);
           return block(ageDecision.userMessage);
         }
       } else {
         // GitHub unavailable / rate-limited / 404. Fail-open rather than
         // block real signups when the network is the problem.
-        console.warn(
-          `[before-user-created] Could not fetch GitHub created_at for ${login}; allowing`,
-        );
+        warn(`Could not fetch GitHub created_at for ${login}; allowing`);
       }
     } else {
-      console.warn(
-        `[before-user-created] GitHub OAuth but no user_name in metadata for ${user.email}; allowing`,
+      warn(
+        `GitHub OAuth but no user_name in metadata for ${user.email}; allowing`,
       );
     }
   }

--- a/supabase/functions/log-usage/index.ts
+++ b/supabase/functions/log-usage/index.ts
@@ -13,8 +13,8 @@
  * - POST /log-usage - Log a batch of usage entries
  *
  * Database Requirements:
- * - Tables: usage_logs, chatgpt_subscription_usage_logs
- * - RPCs: usage_logs_upsert, chatgpt_subscription_usage_logs_upsert (service role only)
+ * - Tables: usage_logs, subscription_usage_logs
+ * - RPCs: usage_logs_upsert, subscription_usage_logs_upsert (service role only)
  */
 
 import { createClient } from '@supabase/supabase-js';
@@ -28,7 +28,7 @@ import { versionedJsonResponse } from '../_shared/responses.ts';
 // Constants
 // =============================================================================
 
-const LOG_USAGE_VERSION = '1.4.0';
+const LOG_USAGE_VERSION = '1.5.0';
 
 // =============================================================================
 // Schemas
@@ -36,22 +36,15 @@ const LOG_USAGE_VERSION = '1.4.0';
 
 // Invalid optional fields are dropped (`.catch(undefined)`) rather than
 // rejecting the whole entry; invalid required fields reject the entry.
-const optionalString = z
-  .string()
-  .nullish()
-  .catch(undefined)
-  .transform((value) => value ?? undefined);
-const optionalNonnegativeInt = z
-  .int()
-  .nonnegative()
-  .nullish()
-  .catch(undefined)
-  .transform((value) => value ?? undefined);
-const optionalBoolean = z
-  .boolean()
-  .nullish()
-  .catch(undefined)
-  .transform((value) => value ?? undefined);
+function optional<T extends z.ZodType>(schema: T) {
+  return schema
+    .nullish()
+    .catch(undefined)
+    .transform((value): z.infer<T> | undefined => value ?? undefined);
+}
+const optionalString = optional(z.string());
+const optionalNonnegativeInt = optional(z.int().nonnegative());
+const optionalBoolean = optional(z.boolean());
 
 const UsageLogEntrySchema = z.object({
   timestamp: z.iso.datetime(),
@@ -61,11 +54,7 @@ const UsageLogEntrySchema = z.object({
   outputTokens: z.int().nonnegative(),
   cost: z.number().nonnegative(),
   agentName: optionalString,
-  agentCategory: z
-    .enum(['workflow', 'toolUse'])
-    .nullish()
-    .catch(undefined)
-    .transform((value) => value ?? undefined),
+  agentCategory: optional(z.enum(['workflow', 'toolUse'])),
   isMultipleOutput: optionalBoolean,
   responseTimeMs: optionalNonnegativeInt,
   cachedInputTokens: optionalNonnegativeInt,
@@ -76,6 +65,10 @@ const UsageLogEntrySchema = z.object({
     .nullish()
     .catch(false)
     .transform((value) => value ?? false),
+  // Explicit subscription source (e.g. 'copilot') for future non-ChatGPT
+  // subscription clients. Omitted entries fall back to 'chatgpt' since
+  // that's the only subscription source today.
+  subscriptionSource: optionalString,
   streamId: optionalString,
   extensionVersion: optionalString,
   editorType: optionalString,
@@ -93,11 +86,21 @@ const UsageDestinations = {
     table: 'usage_logs',
     rpc: 'usage_logs_upsert',
     accepts: (entry: UsageLogEntry) => !entry.viaChatGptSubscription,
+    toRows: toDbRows,
   },
-  chatgptSubscription: {
-    table: 'chatgpt_subscription_usage_logs',
-    rpc: 'chatgpt_subscription_usage_logs_upsert',
+  subscription: {
+    table: 'subscription_usage_logs',
+    rpc: 'subscription_usage_logs_upsert',
     accepts: (entry: UsageLogEntry) => entry.viaChatGptSubscription,
+    toRows: (
+      userId: string,
+      batchId: string,
+      entries: readonly UsageLogEntry[],
+    ) =>
+      toDbRows(userId, batchId, entries).map((row, index) => ({
+        ...row,
+        source: entries[index].subscriptionSource ?? 'chatgpt',
+      })),
   },
 } as const;
 
@@ -290,7 +293,7 @@ Deno.serve(async (req: Request) => {
           entries.length === 0 ||
           (await batchExists(destination, userId, batch.batchId))
             ? []
-            : toDbRows(userId, batch.batchId, entries);
+            : destination.toRows(userId, batch.batchId, entries);
         return { destination, rows };
       }),
     );
@@ -318,7 +321,7 @@ Deno.serve(async (req: Request) => {
       return errorResponse(req, 'Failed to store usage logs', 500);
     }
 
-    // 8. Return success response
+    // 7. Return success response
     return successResponse(req, validEntries.length);
   } catch (error) {
     console.error('[LOG_USAGE] Unexpected error:', error);

--- a/supabase/functions/relay-tokens/index.ts
+++ b/supabase/functions/relay-tokens/index.ts
@@ -222,6 +222,7 @@ app.get('/list', async (c) => {
 // POST /revoke - Revoke one of the signed-in user's tokens by id.
 app.post('/revoke', async (c) => {
   try {
+    const userId = c.get('userId');
     const body = await c.req.json().catch(() => null);
     const id = typeof body?.id === 'string' ? body.id : '';
     if (!id) {
@@ -233,7 +234,7 @@ app.post('/revoke', async (c) => {
       .from('relay_ci_tokens')
       .update({ revoked_at: new Date().toISOString() })
       .eq('id', id)
-      .eq('user_id', c.get('userId'))
+      .eq('user_id', userId)
       .is('revoked_at', null)
       .select('id, name');
     if (error) {
@@ -244,9 +245,7 @@ app.post('/revoke', async (c) => {
       return errorResponse(c, 'Token not found or already revoked', 404);
     }
 
-    console.log(
-      `[RELAY_TOKENS] revoked token ${id} for user ${c.get('userId')}`,
-    );
+    console.log(`[RELAY_TOKENS] revoked token ${id} for user ${userId}`);
     return versionedJsonResponse(c.req.raw, VERSION, { revoked: data[0] }, 200);
   } catch (error) {
     console.error('[RELAY_TOKENS] revoke error:', error);

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -130,6 +130,37 @@ const OPENAI_GPT5_REASONING_EFFORT_CAPS: Record<string, ReasoningEffortCap> = {
   [MAX_TIER]: 'high',
 };
 
+// Hop-by-hop and auth headers stripped before forwarding to the upstream
+// provider (auth is re-added from the server-side key).
+const SKIP_REQUEST_HEADERS = new Set([
+  'host',
+  'connection',
+  'keep-alive',
+  'transfer-encoding',
+  'te',
+  'trailer',
+  'upgrade',
+  'proxy-authorization',
+  'proxy-connection',
+  'authorization',
+  'content-length',
+  'x-api-key',
+  'x-goog-api-key',
+  'x-texra-auth',
+  'x-client-info',
+  'apikey',
+]);
+
+// Hop-by-hop headers stripped from the upstream response before returning it.
+const SKIP_RESPONSE_HEADERS = new Set([
+  'connection',
+  'keep-alive',
+  'transfer-encoding',
+  'te',
+  'trailer',
+  'upgrade',
+]);
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -802,27 +833,8 @@ app.all('/:provider{[^/]+}/*', async (c) => {
 
   // 9. Prepare upstream headers
   const upstreamHeaders = new Headers();
-  const SKIP_HEADERS = new Set([
-    'host',
-    'connection',
-    'keep-alive',
-    'transfer-encoding',
-    'te',
-    'trailer',
-    'upgrade',
-    'proxy-authorization',
-    'proxy-connection',
-    'authorization',
-    'content-length',
-    'x-api-key',
-    'x-goog-api-key',
-    'x-texra-auth',
-    'x-client-info',
-    'apikey',
-  ]);
-
   c.req.raw.headers.forEach((value, key) => {
-    if (!SKIP_HEADERS.has(key.toLowerCase())) {
+    if (!SKIP_REQUEST_HEADERS.has(key.toLowerCase())) {
       upstreamHeaders.set(key, value);
     }
   });
@@ -870,15 +882,6 @@ app.all('/:provider{[^/]+}/*', async (c) => {
 
   // 11. Forward response with headers
   const responseHeaders = new Headers();
-  const SKIP_RESPONSE_HEADERS = new Set([
-    'connection',
-    'keep-alive',
-    'transfer-encoding',
-    'te',
-    'trailer',
-    'upgrade',
-  ]);
-
   upstreamResponse.headers.forEach((value, key) => {
     if (!SKIP_RESPONSE_HEADERS.has(key.toLowerCase())) {
       responseHeaders.set(key, value);

--- a/supabase/functions/relay/requestLimits.ts
+++ b/supabase/functions/relay/requestLimits.ts
@@ -15,8 +15,6 @@ const BYTES_PER_MIB = BYTES_PER_KIB * 1024;
 export const FREE_TIER_REQUEST_BODY_LIMIT_BYTES = 2 * BYTES_PER_MIB;
 export const FREE_TIER_MAX_OUTPUT_TOKENS = 8192;
 
-const textEncoder = new TextEncoder();
-
 export interface RequestBodySizeCheck {
   allowed: boolean;
   limitBytes: number;
@@ -26,28 +24,6 @@ export interface RequestBodySizeCheck {
 export type RequestBodyReadResult =
   | (RequestBodySizeCheck & { allowed: true; body: Uint8Array })
   | (RequestBodySizeCheck & { allowed: false; body: null });
-
-export type RequestBodyForSizeCheck =
-  string | ArrayBuffer | ArrayBufferView | null;
-
-function requestBodyByteLength(body: RequestBodyForSizeCheck): number {
-  if (body == null) return 0;
-  if (typeof body === 'string') return textEncoder.encode(body).byteLength;
-  return body.byteLength;
-}
-
-export function checkRequestBodySizeLimit(
-  body: RequestBodyForSizeCheck,
-  limitBytes: number = FREE_TIER_REQUEST_BODY_LIMIT_BYTES,
-): RequestBodySizeCheck {
-  const requestBytes = requestBodyByteLength(body);
-
-  return {
-    allowed: requestBytes <= limitBytes,
-    limitBytes,
-    requestBytes,
-  };
-}
 
 function concatChunks(chunks: Uint8Array[], byteLength: number): Uint8Array {
   const body = new Uint8Array(byteLength);

--- a/supabase/functions/relay/requestLimits.ts
+++ b/supabase/functions/relay/requestLimits.ts
@@ -15,6 +15,8 @@ const BYTES_PER_MIB = BYTES_PER_KIB * 1024;
 export const FREE_TIER_REQUEST_BODY_LIMIT_BYTES = 2 * BYTES_PER_MIB;
 export const FREE_TIER_MAX_OUTPUT_TOKENS = 8192;
 
+const textEncoder = new TextEncoder();
+
 export interface RequestBodySizeCheck {
   allowed: boolean;
   limitBytes: number;
@@ -24,6 +26,28 @@ export interface RequestBodySizeCheck {
 export type RequestBodyReadResult =
   | (RequestBodySizeCheck & { allowed: true; body: Uint8Array })
   | (RequestBodySizeCheck & { allowed: false; body: null });
+
+export type RequestBodyForSizeCheck =
+  string | ArrayBuffer | ArrayBufferView | null;
+
+function requestBodyByteLength(body: RequestBodyForSizeCheck): number {
+  if (body == null) return 0;
+  if (typeof body === 'string') return textEncoder.encode(body).byteLength;
+  return body.byteLength;
+}
+
+export function checkRequestBodySizeLimit(
+  body: RequestBodyForSizeCheck,
+  limitBytes: number = FREE_TIER_REQUEST_BODY_LIMIT_BYTES,
+): RequestBodySizeCheck {
+  const requestBytes = requestBodyByteLength(body);
+
+  return {
+    allowed: requestBytes <= limitBytes,
+    limitBytes,
+    requestBytes,
+  };
+}
 
 function concatChunks(chunks: Uint8Array[], byteLength: number): Uint8Array {
   const body = new Uint8Array(byteLength);

--- a/supabase/migrations/20260703120000_generalize_subscription_usage_logs.sql
+++ b/supabase/migrations/20260703120000_generalize_subscription_usage_logs.sql
@@ -45,6 +45,20 @@ ALTER POLICY "Users can read own ChatGPT subscription usage logs"
   ON public.subscription_usage_logs
   RENAME TO "Users can read own subscription usage logs";
 
+-- Temporary read compatibility for old log-usage deployments. The previous
+-- edge function checks batch existence with `.from('chatgpt_subscription_usage_logs')`
+-- before it calls the upsert RPC, so the old relation name must remain readable
+-- during a migration-then-function rollout.
+CREATE OR REPLACE VIEW public.chatgpt_subscription_usage_logs
+WITH (security_invoker = on)
+AS
+SELECT *
+FROM public.subscription_usage_logs
+WHERE source = 'chatgpt';
+
+GRANT SELECT ON public.chatgpt_subscription_usage_logs
+  TO authenticated, service_role;
+
 CREATE OR REPLACE FUNCTION public.subscription_usage_logs_upsert(p_rows JSONB)
 RETURNS INTEGER
 LANGUAGE plpgsql

--- a/supabase/migrations/20260703120000_generalize_subscription_usage_logs.sql
+++ b/supabase/migrations/20260703120000_generalize_subscription_usage_logs.sql
@@ -1,0 +1,341 @@
+-- Generalize the ChatGPT-only subscription usage table into a multi-source
+-- one. More subscription-backed providers (e.g. GitHub Copilot) are coming;
+-- the table was deployed today with zero rows, so it can be reshaped in
+-- place rather than requiring a data migration.
+
+ALTER TABLE public.chatgpt_subscription_usage_logs
+  RENAME TO subscription_usage_logs;
+
+ALTER TABLE public.subscription_usage_logs
+  ADD COLUMN source TEXT NOT NULL;
+
+ALTER INDEX public.idx_chatgpt_subscription_usage_logs_user_id
+  RENAME TO idx_subscription_usage_logs_user_id;
+ALTER INDEX public.idx_chatgpt_subscription_usage_logs_logged_at
+  RENAME TO idx_subscription_usage_logs_logged_at;
+ALTER INDEX public.idx_chatgpt_subscription_usage_logs_user_logged_at
+  RENAME TO idx_subscription_usage_logs_user_logged_at;
+ALTER INDEX public.idx_chatgpt_subscription_usage_logs_model
+  RENAME TO idx_subscription_usage_logs_model;
+ALTER INDEX public.idx_chatgpt_subscription_usage_logs_provider
+  RENAME TO idx_subscription_usage_logs_provider;
+ALTER INDEX public.idx_chatgpt_subscription_usage_logs_batch_id
+  RENAME TO idx_subscription_usage_logs_batch_id;
+ALTER INDEX public.idx_chatgpt_subscription_usage_logs_user_batch
+  RENAME TO idx_subscription_usage_logs_user_batch;
+
+CREATE INDEX idx_subscription_usage_logs_source
+  ON public.subscription_usage_logs(source);
+CREATE INDEX idx_subscription_usage_logs_user_source
+  ON public.subscription_usage_logs(user_id, source);
+
+DROP INDEX IF EXISTS public.chatgpt_subscription_usage_logs_user_stream_unique;
+CREATE UNIQUE INDEX subscription_usage_logs_user_source_stream_unique
+  ON public.subscription_usage_logs(user_id, source, stream_id)
+  WHERE stream_id IS NOT NULL;
+
+ALTER POLICY "Users can read own ChatGPT subscription usage logs"
+  ON public.subscription_usage_logs
+  RENAME TO "Users can read own subscription usage logs";
+
+DROP FUNCTION IF EXISTS public.chatgpt_subscription_usage_logs_upsert(jsonb);
+
+CREATE OR REPLACE FUNCTION public.subscription_usage_logs_upsert(p_rows JSONB)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  affected INTEGER := 0;
+BEGIN
+  WITH parsed AS (
+    SELECT
+      row_ordinal,
+      (r->>'user_id')::uuid AS user_id,
+      COALESCE(NULLIF(r->>'source', ''), 'chatgpt') AS source,
+      (r->>'logged_at')::timestamptz AS logged_at,
+      r->>'model' AS model,
+      r->>'provider' AS provider,
+      NULLIF(r->>'agent_name', '') AS agent_name,
+      NULLIF(r->>'agent_category', '') AS agent_category,
+      CASE WHEN r ? 'is_multiple_output' AND r->>'is_multiple_output' <> ''
+           THEN (r->>'is_multiple_output')::boolean END AS is_multiple_output,
+      COALESCE((r->>'input_tokens')::int, 0) AS input_tokens,
+      COALESCE((r->>'output_tokens')::int, 0) AS output_tokens,
+      COALESCE((r->>'cost')::numeric, 0) AS cost,
+      CASE WHEN r ? 'response_time_ms' AND r->>'response_time_ms' <> ''
+           THEN (r->>'response_time_ms')::int END AS response_time_ms,
+      CASE WHEN r ? 'cached_input_tokens' AND r->>'cached_input_tokens' <> ''
+           THEN (r->>'cached_input_tokens')::int END AS cached_input_tokens,
+      CASE WHEN r ? 'reasoning_tokens' AND r->>'reasoning_tokens' <> ''
+           THEN (r->>'reasoning_tokens')::int END AS reasoning_tokens,
+      COALESCE(NULLIF(r->>'used_relay', '')::boolean, false) AS used_relay,
+      NULLIF(r->>'stream_id', '') AS stream_id,
+      NULLIF(r->>'extension_version', '') AS extension_version,
+      NULLIF(r->>'batch_id', '')::uuid AS batch_id,
+      NULLIF(r->>'editor_type', '') AS editor_type
+    FROM jsonb_array_elements(p_rows) WITH ORDINALITY AS input(r, row_ordinal)
+  ),
+  agg AS (
+    SELECT
+      user_id, source, stream_id,
+      MIN(logged_at) AS logged_at,
+      MAX(model) AS model,
+      MAX(provider) AS provider,
+      MAX(agent_name) AS agent_name,
+      MAX(agent_category) AS agent_category,
+      BOOL_OR(is_multiple_output) AS is_multiple_output,
+      CASE WHEN BOOL_OR(public.is_relay_delta_client(extension_version))
+           THEN SUM(input_tokens)::int ELSE MAX(input_tokens) END AS input_tokens,
+      CASE WHEN BOOL_OR(public.is_relay_delta_client(extension_version))
+           THEN SUM(output_tokens)::int ELSE MAX(output_tokens) END AS output_tokens,
+      CASE WHEN BOOL_OR(public.is_relay_delta_client(extension_version))
+           THEN SUM(cost)::numeric ELSE MAX(cost) END AS cost,
+      CASE WHEN BOOL_OR(public.is_relay_delta_client(extension_version))
+           THEN SUM(COALESCE(cached_input_tokens, 0))::int
+           ELSE MAX(cached_input_tokens) END AS cached_input_tokens,
+      CASE WHEN BOOL_OR(public.is_relay_delta_client(extension_version))
+           THEN SUM(COALESCE(reasoning_tokens, 0))::int
+           ELSE MAX(reasoning_tokens) END AS reasoning_tokens,
+      MAX(response_time_ms) AS response_time_ms,
+      BOOL_OR(used_relay) AS used_relay,
+      MAX(extension_version) AS extension_version,
+      MAX(batch_id::text)::uuid AS batch_id,
+      MAX(editor_type) AS editor_type
+    FROM parsed
+    GROUP BY user_id, source, stream_id, CASE WHEN stream_id IS NULL THEN row_ordinal END
+  )
+  INSERT INTO public.subscription_usage_logs (
+    user_id, source, logged_at, model, provider, agent_name, agent_category,
+    is_multiple_output, input_tokens, output_tokens, cost,
+    response_time_ms, cached_input_tokens, reasoning_tokens,
+    used_relay, stream_id, extension_version, batch_id, editor_type
+  )
+  SELECT
+    user_id, source, logged_at, model, provider, agent_name, agent_category,
+    is_multiple_output, input_tokens, output_tokens, cost,
+    response_time_ms, cached_input_tokens, reasoning_tokens,
+    used_relay, stream_id, extension_version, batch_id, editor_type
+  FROM agg
+  ON CONFLICT (user_id, source, stream_id) WHERE stream_id IS NOT NULL DO UPDATE SET
+    input_tokens = CASE
+      WHEN public.is_relay_delta_client(EXCLUDED.extension_version)
+      THEN public.subscription_usage_logs.input_tokens + EXCLUDED.input_tokens
+      ELSE GREATEST(public.subscription_usage_logs.input_tokens, EXCLUDED.input_tokens) END,
+    output_tokens = CASE
+      WHEN public.is_relay_delta_client(EXCLUDED.extension_version)
+      THEN public.subscription_usage_logs.output_tokens + EXCLUDED.output_tokens
+      ELSE GREATEST(public.subscription_usage_logs.output_tokens, EXCLUDED.output_tokens) END,
+    cost = CASE
+      WHEN public.is_relay_delta_client(EXCLUDED.extension_version)
+      THEN public.subscription_usage_logs.cost + EXCLUDED.cost
+      ELSE GREATEST(public.subscription_usage_logs.cost, EXCLUDED.cost) END,
+    cached_input_tokens = CASE
+      WHEN public.is_relay_delta_client(EXCLUDED.extension_version)
+      THEN COALESCE(public.subscription_usage_logs.cached_input_tokens, 0)
+        + COALESCE(EXCLUDED.cached_input_tokens, 0)
+      ELSE GREATEST(
+        COALESCE(public.subscription_usage_logs.cached_input_tokens, 0),
+        COALESCE(EXCLUDED.cached_input_tokens, 0)
+      ) END,
+    reasoning_tokens = CASE
+      WHEN public.is_relay_delta_client(EXCLUDED.extension_version)
+      THEN COALESCE(public.subscription_usage_logs.reasoning_tokens, 0) + COALESCE(EXCLUDED.reasoning_tokens, 0)
+      ELSE GREATEST(
+        COALESCE(public.subscription_usage_logs.reasoning_tokens, 0),
+        COALESCE(EXCLUDED.reasoning_tokens, 0)
+      ) END,
+    response_time_ms = GREATEST(
+      COALESCE(public.subscription_usage_logs.response_time_ms, 0),
+      COALESCE(EXCLUDED.response_time_ms, 0)),
+    used_relay =
+      COALESCE(public.subscription_usage_logs.used_relay, false)
+      OR COALESCE(EXCLUDED.used_relay, false),
+    logged_at = LEAST(public.subscription_usage_logs.logged_at, EXCLUDED.logged_at),
+    batch_id = COALESCE(EXCLUDED.batch_id, public.subscription_usage_logs.batch_id),
+    extension_version = COALESCE(EXCLUDED.extension_version, public.subscription_usage_logs.extension_version),
+    model = COALESCE(public.subscription_usage_logs.model, EXCLUDED.model),
+    provider = COALESCE(public.subscription_usage_logs.provider, EXCLUDED.provider),
+    agent_name = COALESCE(public.subscription_usage_logs.agent_name, EXCLUDED.agent_name),
+    agent_category = COALESCE(public.subscription_usage_logs.agent_category, EXCLUDED.agent_category),
+    is_multiple_output = COALESCE(
+      public.subscription_usage_logs.is_multiple_output,
+      EXCLUDED.is_multiple_output
+    ),
+    editor_type = COALESCE(public.subscription_usage_logs.editor_type, EXCLUDED.editor_type);
+
+  GET DIAGNOSTICS affected = ROW_COUNT;
+  RETURN affected;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.subscription_usage_logs_upsert(jsonb)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.subscription_usage_logs_upsert(jsonb)
+  TO service_role;
+
+COMMENT ON TABLE public.subscription_usage_logs IS
+  'Subscription-backed (ChatGPT, Copilot, ...) usage logs kept separate from paid relay/API-key usage';
+COMMENT ON COLUMN public.subscription_usage_logs.source IS
+  'Subscription product this usage ran under, e.g. chatgpt, copilot';
+COMMENT ON COLUMN public.subscription_usage_logs.user_id IS
+  'User who made the subscription-backed request';
+COMMENT ON COLUMN public.subscription_usage_logs.logged_at IS
+  'When the request completed (client time)';
+COMMENT ON COLUMN public.subscription_usage_logs.cost IS
+  'Computed cost in USD; subscription rows are expected to be zero-cost';
+COMMENT ON COLUMN public.subscription_usage_logs.used_relay IS
+  'Whether server-side relay keys were used; normally false for subscription rows';
+COMMENT ON COLUMN public.subscription_usage_logs.stream_id IS
+  'Session identifier for grouping requests';
+COMMENT ON COLUMN public.subscription_usage_logs.batch_id IS
+  'Batch ID for deduplication';
+
+-- Admin analytics views over the subscription usage table, generalized by
+-- source, mirroring the relay_spending_*/byok_spending_* view family shape
+-- (supabase/migrations/20260609212200_drop_usage_base_view.sql).
+
+CREATE OR REPLACE VIEW public.subscription_usage_summary
+WITH (security_invoker = on)
+AS
+SELECT
+    p.user_id,
+    p.email,
+    p.tier,
+    COUNT(s.id) AS total_requests,
+    COUNT(DISTINCT s.source) AS sources_used,
+    COALESCE(SUM(s.input_tokens + COALESCE(s.cached_input_tokens, 0)), 0)
+      AS total_input_tokens,
+    COALESCE(SUM(s.input_tokens), 0) AS total_net_input_tokens,
+    COALESCE(SUM(s.output_tokens), 0) AS total_output_tokens,
+    COALESCE(SUM(s.cached_input_tokens), 0) AS total_cached_tokens,
+    COALESCE(SUM(s.reasoning_tokens), 0) AS total_reasoning_tokens,
+    COALESCE(SUM(s.cost), 0) AS total_cost_usd,
+    MIN(s.logged_at) AS first_request_at,
+    MAX(s.logged_at) AS last_request_at
+FROM public.profiles p
+LEFT JOIN public.subscription_usage_logs s
+    ON p.user_id = s.user_id
+GROUP BY p.user_id, p.email, p.tier;
+
+COMMENT ON VIEW public.subscription_usage_summary IS
+'Per-user subscription-backed usage totals across all sources (ADMIN ONLY)';
+
+CREATE OR REPLACE VIEW public.subscription_usage_by_source
+WITH (security_invoker = on)
+AS
+SELECT
+    p.user_id,
+    p.email,
+    p.tier,
+    s.source,
+    COUNT(s.id) AS request_count,
+    COALESCE(SUM(s.input_tokens + COALESCE(s.cached_input_tokens, 0)), 0)
+      AS input_tokens,
+    COALESCE(SUM(s.input_tokens), 0) AS net_input_tokens,
+    COALESCE(SUM(s.output_tokens), 0) AS output_tokens,
+    COALESCE(SUM(s.cost), 0) AS cost_usd,
+    MIN(s.logged_at) AS first_request_at,
+    MAX(s.logged_at) AS last_request_at
+FROM public.profiles p
+INNER JOIN public.subscription_usage_logs s
+    ON p.user_id = s.user_id
+GROUP BY p.user_id, p.email, p.tier, s.source;
+
+COMMENT ON VIEW public.subscription_usage_by_source IS
+'Subscription-backed usage by user and source, e.g. chatgpt/copilot (ADMIN ONLY)';
+
+CREATE OR REPLACE VIEW public.subscription_usage_by_model
+WITH (security_invoker = on)
+AS
+SELECT
+    p.user_id,
+    p.email,
+    p.tier,
+    s.source,
+    s.model,
+    s.provider,
+    COUNT(s.id) AS request_count,
+    COALESCE(SUM(s.input_tokens + COALESCE(s.cached_input_tokens, 0)), 0)
+      AS input_tokens,
+    COALESCE(SUM(s.input_tokens), 0) AS net_input_tokens,
+    COALESCE(SUM(s.output_tokens), 0) AS output_tokens,
+    COALESCE(SUM(s.cost), 0) AS cost_usd,
+    AVG(s.response_time_ms) AS avg_response_time_ms
+FROM public.profiles p
+INNER JOIN public.subscription_usage_logs s
+    ON p.user_id = s.user_id
+GROUP BY p.user_id, p.email, p.tier, s.source, s.model, s.provider;
+
+COMMENT ON VIEW public.subscription_usage_by_model IS
+'Subscription-backed usage by user, source, and model (ADMIN ONLY)';
+
+CREATE OR REPLACE VIEW public.subscription_usage_daily
+WITH (security_invoker = on)
+AS
+SELECT
+    p.user_id,
+    p.email,
+    s.source,
+    DATE_TRUNC('day', s.logged_at AT TIME ZONE 'UTC')::DATE AS day,
+    COUNT(s.id) AS request_count,
+    COALESCE(SUM(s.input_tokens + COALESCE(s.cached_input_tokens, 0)), 0)
+      AS input_tokens,
+    COALESCE(SUM(s.input_tokens), 0) AS net_input_tokens,
+    COALESCE(SUM(s.output_tokens), 0) AS output_tokens,
+    COALESCE(SUM(s.cost), 0) AS cost_usd
+FROM public.profiles p
+INNER JOIN public.subscription_usage_logs s
+    ON p.user_id = s.user_id
+GROUP BY p.user_id, p.email, s.source, DATE_TRUNC('day', s.logged_at AT TIME ZONE 'UTC')::DATE;
+
+COMMENT ON VIEW public.subscription_usage_daily IS
+'Daily subscription-backed usage per user and source (ADMIN ONLY)';
+
+CREATE OR REPLACE VIEW public.subscription_usage_monthly
+WITH (security_invoker = on)
+AS
+SELECT
+    p.user_id,
+    p.email,
+    p.tier,
+    s.source,
+    DATE_TRUNC('month', s.logged_at AT TIME ZONE 'UTC')::DATE AS month,
+    COUNT(s.id) AS request_count,
+    COALESCE(SUM(s.input_tokens + COALESCE(s.cached_input_tokens, 0)), 0)
+      AS input_tokens,
+    COALESCE(SUM(s.input_tokens), 0) AS net_input_tokens,
+    COALESCE(SUM(s.output_tokens), 0) AS output_tokens,
+    COALESCE(SUM(s.cached_input_tokens), 0) AS cached_tokens,
+    COALESCE(SUM(s.reasoning_tokens), 0) AS reasoning_tokens,
+    COALESCE(SUM(s.cost), 0) AS cost_usd,
+    COUNT(DISTINCT s.model) AS models_used
+FROM public.profiles p
+INNER JOIN public.subscription_usage_logs s
+    ON p.user_id = s.user_id
+GROUP BY p.user_id, p.email, p.tier, s.source, DATE_TRUNC('month', s.logged_at AT TIME ZONE 'UTC')::DATE;
+
+COMMENT ON VIEW public.subscription_usage_monthly IS
+'Monthly subscription-backed usage per user and source (ADMIN ONLY)';
+
+CREATE OR REPLACE VIEW public.subscription_usage_totals
+WITH (security_invoker = on)
+AS
+SELECT
+    DATE_TRUNC('day', s.logged_at AT TIME ZONE 'UTC')::DATE AS day,
+    s.source,
+    COUNT(DISTINCT s.user_id) AS active_users,
+    COUNT(s.id) AS total_requests,
+    COALESCE(SUM(s.input_tokens + COALESCE(s.cached_input_tokens, 0)), 0)
+      AS total_input_tokens,
+    COALESCE(SUM(s.input_tokens), 0) AS total_net_input_tokens,
+    COALESCE(SUM(s.output_tokens), 0) AS total_output_tokens,
+    COALESCE(SUM(s.cost), 0) AS total_cost_usd,
+    COUNT(DISTINCT s.model) AS models_used
+FROM public.subscription_usage_logs s
+GROUP BY DATE_TRUNC('day', s.logged_at AT TIME ZONE 'UTC')::DATE, s.source
+ORDER BY day DESC, source;
+
+COMMENT ON VIEW public.subscription_usage_totals IS
+'Daily global subscription-backed usage totals by source (ADMIN ONLY)';

--- a/supabase/migrations/20260703120000_generalize_subscription_usage_logs.sql
+++ b/supabase/migrations/20260703120000_generalize_subscription_usage_logs.sql
@@ -1,13 +1,20 @@
 -- Generalize the ChatGPT-only subscription usage table into a multi-source
 -- one. More subscription-backed providers (e.g. GitHub Copilot) are coming;
--- the table was deployed today with zero rows, so it can be reshaped in
--- place rather than requiring a data migration.
+-- existing ChatGPT subscription rows are backfilled to the new source before
+-- the column is made mandatory.
 
 ALTER TABLE public.chatgpt_subscription_usage_logs
   RENAME TO subscription_usage_logs;
 
 ALTER TABLE public.subscription_usage_logs
-  ADD COLUMN source TEXT NOT NULL;
+  ADD COLUMN source TEXT DEFAULT 'chatgpt';
+
+UPDATE public.subscription_usage_logs
+SET source = 'chatgpt'
+WHERE source IS NULL OR source = '';
+
+ALTER TABLE public.subscription_usage_logs
+  ALTER COLUMN source SET NOT NULL;
 
 ALTER INDEX public.idx_chatgpt_subscription_usage_logs_user_id
   RENAME TO idx_subscription_usage_logs_user_id;
@@ -37,8 +44,6 @@ CREATE UNIQUE INDEX subscription_usage_logs_user_source_stream_unique
 ALTER POLICY "Users can read own ChatGPT subscription usage logs"
   ON public.subscription_usage_logs
   RENAME TO "Users can read own subscription usage logs";
-
-DROP FUNCTION IF EXISTS public.chatgpt_subscription_usage_logs_upsert(jsonb);
 
 CREATE OR REPLACE FUNCTION public.subscription_usage_logs_upsert(p_rows JSONB)
 RETURNS INTEGER
@@ -173,6 +178,26 @@ $$;
 REVOKE ALL ON FUNCTION public.subscription_usage_logs_upsert(jsonb)
   FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.subscription_usage_logs_upsert(jsonb)
+  TO service_role;
+
+-- Temporary compatibility wrapper for old log-usage deployments that still
+-- call the ChatGPT-specific RPC name during a coordinated rollout.
+CREATE OR REPLACE FUNCTION public.chatgpt_subscription_usage_logs_upsert(
+  p_rows JSONB
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  RETURN public.subscription_usage_logs_upsert(p_rows);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.chatgpt_subscription_usage_logs_upsert(jsonb)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.chatgpt_subscription_usage_logs_upsert(jsonb)
   TO service_role;
 
 COMMENT ON TABLE public.subscription_usage_logs IS


### PR DESCRIPTION
## Summary

- Generalizes subscription-backed usage logging by renaming the physical storage from `chatgpt_subscription_usage_logs` to `subscription_usage_logs`, adding a source-aware schema, and replacing the ChatGPT-specific upsert RPC/views with source-aware equivalents. Existing rows are backfilled to `source = chatgpt` before the column is made mandatory.
- Updates the `log-usage` edge function to write subscription rows through `subscription_usage_logs_upsert` and accept an optional `subscriptionSource` field, defaulting to `chatgpt` for the current ChatGPT subscription producer.
- Keeps temporary compatibility for old `log-usage` deployments: an old-name read view `chatgpt_subscription_usage_logs` for batch checks and an old-name RPC wrapper `chatgpt_subscription_usage_logs_upsert(jsonb)` that delegates to the new RPC.
- Simplifies six Supabase edge functions without changing request or response behavior: shared HTML shell in `auth-bridge`, shared client creation in `auth-device`, shared GitHub metadata merge in `auth-github`, shared warning prefix in `before-user-created`, hoisted relay header skip sets, and cached revoke user id in `relay-tokens`.

## Deployment note

The migration is tolerant of existing ChatGPT subscription rows and of brief old-function/new-migration overlap. The old-name compatibility view and RPC wrapper can be removed in a later cleanup once all `log-usage` deployments use `subscription_usage_logs` and `subscription_usage_logs_upsert`.

## Validation

- Migration applied to and verified against the linked Supabase project before the rollout-compatibility view/wrapper was added: table, function, and views confirmed via `to_regclass`, `to_regprocedure`, and `pg_views`.
- `log-usage` edge function deployed and live.
- `deno check` passed for the touched edge functions, except for one pre-existing unrelated `TS2769` type error in `relay/index.ts` confirmed present on `main` before this PR.
- CI passed before the latest migration-only review fix; the latest CI run is pending.

Refs subscription usage tracking for future non-ChatGPT subscription sources.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The migration and upsert RPC change how subscription usage is stored and deduplicated; rollout relies on compatibility views/wrappers until all `log-usage` deployments are updated.
> 
> **Overview**
> **Subscription usage** is generalized from ChatGPT-only to multi-source: the DB migration renames `chatgpt_subscription_usage_logs` to `subscription_usage_logs`, adds a required `source` column (existing rows backfilled to `chatgpt`), updates stream dedup to `(user_id, source, stream_id)`, and introduces `subscription_usage_logs_upsert` plus admin analytics views. A read-only view and RPC wrapper keep old `log-usage` deployments working during rollout.
> 
> **`log-usage` (v1.5.0)** routes subscription batches to the new table/RPC, accepts optional `subscriptionSource` (default `chatgpt`), and refactors optional Zod fields via a shared helper.
> 
> **Edge-function cleanups** (no intended API behavior change): shared HTML shell in `auth-bridge` with clearer manual deep-link instructions; `createEdgeClient` in `auth-device`; `githubProfileUpdate` in `auth-github`; `warn()` in `before-user-created`; module-level hop-by-hop header skip sets in `relay`; cached `userId` in `relay-tokens` revoke.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70971628ee12cc86dfe2324402a05036d79971db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->