### PR TITLE
fix(ci): harden release workflow follow-ups

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   publish-extension:
     name: Publish VS Code extension (Marketplace + Open VSX)
-    if: ${{ startsWith(github.event.release.tag_name, 'v') && !contains(github.event.release.tag_name, '-') }}
+    if: ${{ !github.event.release.prerelease && startsWith(github.event.release.tag_name, 'v') && !contains(github.event.release.tag_name, '-') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -41,16 +41,20 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
 
       - name: Verify release tag matches extension package version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          tag="${{ github.event.release.tag_name }}"
           version=$(node -p "require('./packages/extension/package.json').version")
-          if [ "$tag" != "v$version" ]; then
-            echo "::error::Release tag '$tag' does not match packages/extension/package.json version '$version' (expected 'v$version')"
+          if [ "$RELEASE_TAG" != "v$version" ]; then
+            echo "::error::Release tag '$RELEASE_TAG' does not match packages/extension/package.json version '$version' (expected 'v$version')"
             exit 1
           fi
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm run typecheck
 
       - name: Build extension VSIX
         run: pnpm --filter texra build:fast
@@ -84,7 +88,7 @@ jobs:
 
   publish-cli:
     name: Publish CLI to npm (Trusted Publishing)
-    if: ${{ startsWith(github.event.release.tag_name, 'cli-v') }}
+    if: ${{ !github.event.release.prerelease && startsWith(github.event.release.tag_name, 'cli-v') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -108,11 +112,12 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Verify release tag matches CLI package version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          tag="${{ github.event.release.tag_name }}"
           version=$(node -p "require('./packages/cli/package.json').version")
-          if [ "$tag" != "cli-v$version" ]; then
-            echo "::error::Release tag '$tag' does not match packages/cli/package.json version '$version' (expected 'cli-v$version')"
+          if [ "$RELEASE_TAG" != "cli-v$version" ]; then
+            echo "::error::Release tag '$RELEASE_TAG' does not match packages/cli/package.json version '$version' (expected 'cli-v$version')"
             exit 1
           fi
 
@@ -124,4 +129,4 @@ jobs:
 
       - name: Publish @texra-ai/cli
         working-directory: packages/cli
-        run: npm publish --provenance
+        run: npm publish


### PR DESCRIPTION
## Summary
- Skips production publishing jobs for GitHub prereleases.
- Passes the release tag through `env` before shell comparisons, avoiding direct expression interpolation in bash.
- Runs `pnpm run typecheck` before packaging the extension VSIX for marketplace publishing.
- Drops forced `npm publish --provenance` and lets npm Trusted Publishing decide provenance behaviour.

## Release note
- None. These are release-infrastructure safeguards, not user-facing product changes.

## Test plan
- `npx prettier --check .github/workflows/release.yml`

## Notes
- Follow-up for #6934 and review comments on #6932.
- The failed `cli-v0.39.2` release run reached `npm publish` after a successful build, then failed with npm `E404`/permission on `@texra-ai/cli@0.39.2`. The package is still published only up to `0.39.1`, so the remaining release blocker appears to be npm Trusted Publishing/package authorization rather than repository code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect release automation (guards, env usage, typecheck gate, npm flags) with no application runtime impact.
> 
> **Overview**
> Hardens the **Release** workflow so marketplace/extension and npm/CLI publish jobs **do not run on GitHub prereleases**, by adding `!github.event.release.prerelease` to both job `if` conditions.
> 
> Release tag checks now pass the tag through **`RELEASE_TAG` env** instead of embedding the GitHub expression in shell scripts. The extension publish path runs **`pnpm run typecheck`** before building the VSIX. CLI publish uses plain **`npm publish`** (no forced `--provenance`), relying on npm Trusted Publishing for provenance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19ad95f3dcfa205ceff6a906a14775e78069ced4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->