### PR TITLE
docs: add 2026-07 tech-debt audit of undocumented debts

### DIFF
--- a/docs/proposals/session-scoped-runtime-architecture.md
+++ b/docs/proposals/session-scoped-runtime-architecture.md
@@ -139,7 +139,7 @@ interface SessionEventHub {
   `buildAgentLaunchContext` immediately after `createRunTrace` and **before**
   the first emit (today's hub attach happens after `setActiveStream`, which is
   why the buffer exists).
-- **`AgentEvent` gains two arms** for facts that are genuinely run lifecycle
+- **`AgentEvent` gains three arms** for facts that are genuinely run lifecycle
   but currently bus-only: `status` (emitted by plane 3's machine — subsumes
   `updateStreamStatus`, including non-terminal transitions and
   `terminalStatus`, ending the terminal dual-emit) and `child.activity`

--- a/docs/proposals/session-scoped-runtime-architecture.md
+++ b/docs/proposals/session-scoped-runtime-architecture.md
@@ -1,0 +1,441 @@
+# Session-scoped runtime architecture: facts, interactions, and status ownership
+
+Status: proposal (2026-07-03). Companion to the diagnosis in
+`tech-debt-audit-2026-07.md` (Part B1/B5 + appendix); this document is the
+target design. It covers the event/logger chain, the approval/interaction RPC
+machinery, stream status, and the execution registries — and how all of them
+couple to the UI backends.
+
+## 1. Diagnosis: one root cause, many symptoms
+
+Every debt found in the deep dives reduces to the same defect: **run facts,
+host interactions, and status live on process-global singletons while the UI
+backends are per-window**, and the gap is bridged by per-run patches and
+defensive guards instead of ownership.
+
+The evidence, condensed (file:line references in the audit appendix):
+
+**Genuine cross-session leaks (live bugs in multi-window desktop):**
+
+- L1. `getDefaultStreamLogStore()` is process-global and last-writer-wins
+  (`ProgressViewState.ts:153` calls `setDefaultStreamLogStore(this.streamLogs)`
+  per window; `runTrace.ts:34` defaults to it). A run's transcript appends to
+  whichever window's store was constructed last.
+- L2. Desktop re-emits every progress event onto the shared process `bus`
+  (`desktopAgentExecution.ts:811`) and every window's backend subscribes to
+  that same bus (`:295`). Window A's run events mutate window B's
+  `ProgressViewState` (ghost streams, badge churn).
+- L3. `StreamStatusService` is one shared instance: every window's
+  `ExecutionRegistry` subscribes to its global `onDidChange`
+  (`executionRegistry.ts:161`), and one window's delete-all calls
+  `StreamStatusService.clearAll` (`ProgressViewState.ts:344`), resetting every
+  window's streams.
+
+**Structural duplication held together by guards:**
+
+- Three request/response mechanisms for the same job: (i) platform-port +
+  host-local promise maps (toolEdit/bash), (ii) `BasePromiseCoordinator`
+  show/resolve event pairs + `RunCoordinatorBridge` id index
+  (plan/proposal/retry), (iii) `ApprovalRequestHandler.pending/delivered`
+  backend replay registry — a third copy of pending state kept solely for
+  webview-reload redisplay.
+- The same fact emitted in two vocabularies: terminal outcome
+  (`ResultEvent` at `AgentRunLifecycle.ts:83` vs `updateStreamStatus` +
+  `terminalStatus` at `StreamStatusService.ts:76`); usage three ways
+  (`UsageMonitor.ts:170` bus, `:182` trace, `ResultEvent.usage`).
+- STOPPED written by two subsystems (registry stop path, lifecycle arms),
+  coordinated only by STOPPED-wins guards; UI backends write status through an
+  `emit:false` backdoor for restart repair (`ProgressEventHandler.ts:469,621`)
+  because the design gives them no legitimate voice.
+- The bus's 1000-event pre-subscription buffer exists only because the sink
+  subscribes lazily to a process-global emitter; it is a symptom, not a
+  feature.
+- Session invariants enforced by comments, not types: the per-session
+  subscription binder reads the process-static streamId-keyed
+  `ToolUseFollowUpQueue` (`SessionHandle.ts:99-104`); `handles`
+  (executionId-keyed) and `InterruptRegistry` (streamTabId-keyed) must be
+  populated in tandem or a stream is discoverable but uninterruptible.
+
+**What is already right (build on it, don't replace it):**
+
+- `SessionHandle` is a real composition root (owns per-session
+  interrupts/executions/coordinators/subscriptions) with the
+  `defaultSession()` aliasing strategy proven by the 7d migration.
+- The 12-variant `AgentEvent` trace is a clean one-way fact stream with
+  per-run subscribers; `conversationProgressHub` proves the trace→bus
+  projection pattern; `AgentExecutionHandle` already carries `trace`,
+  `result`, `coordinators`.
+- `runFlowWithLifecycle` + `RUN_OUTCOME_PROJECTION` is a working
+  single-writer terminal transition.
+- Emit discipline holds: zero raw `bus.emit` in VS Code-free zones.
+- The logger is done: 308 lines, one sink boundary, two entry points that
+  converge.
+
+## 2. Target architecture: three planes, one owner each
+
+The design keeps three fundamentally different kinds of traffic apart, gives
+each exactly one owner, and scopes all three to the `SessionHandle`:
+
+```
+                        ┌──────────────────────────────────────────────┐
+                        │              SessionHandle                   │
+                        │  (one per VS Code window / CLI process /     │
+                        │   desktop BrowserWindow — already exists)    │
+                        │                                              │
+  agent core            │  PLANE 1  session.events  (facts, one-way)  │      hosts
+  (VS Code-free)        │  ───────────────────────────────────────►   │
+                        │     · per-run AgentTrace auto-forwarded      │  projector per window
+  flows / tools ──────► │     · session facts (goal, inquiry, …)      │  ► ProgressViewState
+  lifecycle    ──────►  │     · status transitions (see plane 3)      │  ► StreamSnapshotStore
+                        │                                              │  ► CLI renderer
+                        │  PLANE 2  session.interactions (RPC, await) │  ► status bar, badges
+  tools ─── await ────► │  ◄───────────────────────────────────────   │
+                        │     · Promise-returning request methods      │  one implementation
+                        │     · one pending registry (replayable)      │  per host
+                        │     · resolve requires the session           │
+                        │                                              │
+                        │  PLANE 3  session.runs + session.status     │
+                        │     · RunTable (handles, waiters, stop)      │
+                        │     · StreamStatusMachine (single writer,    │
+                        │       named causes, rules inside)            │
+                        │     · session.followUps, session.transcripts │
+                        └──────────────────────────────────────────────┘
+```
+
+Rules of the architecture (each replaces a family of today's guards):
+
+1. **Facts flow one way.** Core emits onto plane 1; hosts subscribe;
+   subscribers never mutate core state in response to a fact (commands go
+   through planes 2/3 APIs).
+2. **Requests are awaited calls, not event pairs.** Anything with a reply is a
+   method on `session.interactions`. Events are never used as RPC.
+3. **Status has one writer with named causes.** Every transition — lifecycle,
+   user stop, restart repair, tab delete — is a call into the status machine
+   that names its cause; the machine owns STOPPED-wins/preserve rules.
+4. **Nothing run- or session-scoped lives on a process global.** Process-wide
+   surfaces are limited to: the `Platform` ports, an explicit `liveSessions`
+   list for cross-session aggregation, and true app signals (below).
+
+### Plane 1 — `session.events`: one fact hub, session-scoped
+
+A typed multicast hub constructed with the session (therefore before any run
+— this deletes the bus buffer by construction, not by re-implementing it):
+
+```ts
+type SessionEvent =
+  | { scope: 'run'; streamId: StreamTabId; event: AgentEvent } // forwarded traces
+  | { scope: 'session'; event: SessionFact }; // non-run facts
+
+interface SessionEventHub {
+  emit(event: SessionEvent): void; // internal producers only
+  subscribe(sub: (e: SessionEvent) => void): () => void;
+}
+```
+
+- **Run facts** stay `AgentEvent` on the run's `TraceEmitter` — the SDK
+  contract is unchanged. `SessionHandle.attachRunTrace` (which already
+  forwards `result` to `onResult`) generalizes: it forwards the _whole_ trace
+  into the hub, tagged with the streamId, attached inside
+  `buildAgentLaunchContext` immediately after `createRunTrace` and **before**
+  the first emit (today's hub attach happens after `setActiveStream`, which is
+  why the buffer exists).
+- **`AgentEvent` gains two arms** for facts that are genuinely run lifecycle
+  but currently bus-only: `status` (emitted by plane 3's machine — subsumes
+  `updateStreamStatus`, including non-terminal transitions and
+  `terminalStatus`, ending the terminal dual-emit) and `child.activity`
+  (subagent/process registration and progress — subsumes
+  `updateActiveSubagents` / `updateActiveProcesses` / `setParentStream`,
+  emitted by the session's RunTable which, being session-owned, emits into its
+  own session's hub; no parent-trace lookup gymnastics). `updateProcessOutput`
+  becomes a `process.output` arm carried on the owning run's trace via the
+  per-process handle's parent stream.
+- **`SessionFact`** is the new, previously missing surface for facts emitted
+  outside any run: `goalStateChanged` from the Goal tab,
+  `inquiryThreadUpdated` on async inquiry resume, `clearMissingOutputs` from
+  the command palette, command-path `updateQueuedFollowUps`, host-driven
+  `setActiveStream`. Today these fall through `emitRuntimeEvent` to the
+  process bus; here they are first-class session facts.
+- **Usage becomes single-emit**: `UsageMonitor` emits only the trace `usage`
+  event; the sidebar totals are a projector concern. `ResultEvent.usage`
+  remains as the run summary (that is aggregation, not duplication).
+- **Log lines are unchanged**: `log` events on the trace, fanned to the
+  channel sink and the transcript recorder. That is one fact with two
+  subscribers — correct under rule 1, not duplication.
+
+**Consumers.** Each window's `ProgressEventHandler` becomes a _projector_
+subscribing to its own session's hub — same handler bodies, same
+`ProgressViewState`/`WebviewUpdater` machinery, different (and correctly
+scoped) feed. The CLI renderer, `StreamSnapshotStore`, the extension status
+bar, and file decorations subscribe the same way. This directly fixes L2 and
+L3's fan-out half. Deliberately **per-host** projectors: this preserves the
+coupling audit's rejection of a single shared CLI/webview reducer
+(`agent-runtime-ui-coupling-audit.md:76`) — hosts keep their own persistence,
+race handling, and derived UI state; what they share is the correctly-scoped,
+well-typed feed (and, per audit B2, an optional per-tool display-model layer
+on top). The webview transcript-delta path
+(`StreamLogStore.onChange → WebviewBridge`) stays as-is — it is already a
+correctly-directed store-to-view channel; it just gains a correctly-scoped
+store (below).
+
+**What remains process-global**: a small `AppSignals` emitter for the 10
+genuinely app-scoped events (`extensionDeactivating`, `toolAvailabilityChanged`,
+`workspaceFilesWritten`, GitHub subscription churn, `githubTokenInvalid`).
+These are about the process, not a session; naming them stops the bus from
+being the junk drawer that made its taxonomy illegible.
+
+`ProgressEventPayloads` and the bus survive during migration as a projection
+target (extension byte-identical via `defaultSession()`), and are deleted at
+the end — not redefined.
+
+### Plane 2 — `session.interactions`: one interaction port
+
+One session-scoped port subsumes all three RPC mechanisms:
+
+```ts
+interface HostInteractions {
+  // One method per interaction kind; all return promises, all accept
+  // { timeoutMs?, signal? }. Payload/decision types are the existing ones.
+  requestToolEditApproval(
+    req: ToolEditApprovalRequest,
+    o?: ReqOpts,
+  ): Promise<ToolEditApprovalResult>;
+  requestBashApproval(
+    req: BashApprovalRequest,
+    o?: ReqOpts,
+  ): Promise<BashApprovalResult>;
+  requestPlanApproval(
+    req: PlanApprovalRequest,
+    o?: ReqOpts,
+  ): Promise<PlanApprovalResult>;
+  requestProposal(
+    req: AgentProposalRequest,
+    o?: ReqOpts,
+  ): Promise<ProposalResult>;
+  requestRetry(req: RetryRequest, o?: ReqOpts): Promise<RetryDecision>;
+  askUserQuestion(
+    req: UserQuestionRequest,
+    o?: ReqOpts,
+  ): Promise<UserQuestionResult>;
+  openExternalInquiry(req: InquiryRequest): Promise<InquiryThreadHandle>; // durable, thread-shaped
+
+  // The single pending registry (replaces coordinator maps + host promise
+  // maps + ApprovalRequestHandler.pending/delivered):
+  pending(): readonly PendingInteraction[]; // host re-display on reload
+  resolve(requestId: string, result: unknown): boolean; // any surface, first-wins
+  cancelForStream(streamId: StreamTabId, cause: 'stopped' | 'deleted'): void;
+}
+```
+
+Design points, grounded in the RPC trace:
+
+- **The show/resolve event pairs become an implementation detail** of the
+  default webview-backed implementation (it may keep posting the same
+  payloads to the same panels). They leave the public contract. The CLI
+  implements the port directly on its modal queue — deleting the
+  `installTuiApprovals` monkey-patch of `host.emit`, which is the clearest
+  sign the current contract is wrong.
+- **Tool-edit keeps its port shape** — the trace showed it is not a pure
+  decision (the extension host opens a live diff editor, captures in-place
+  user edits, treats tab-close as reject). That is precisely why the port
+  belongs to the _host_: `requestToolEditApproval` returns the existing rich
+  `ToolEditApprovalResult` (`appliedContent`/`userPatch`), and mid-flight
+  actions (openDiff, preview, latexdiff) are internal to the host
+  implementation, reachable from its own UI. The existing
+  `ToolEditApprovalPort` + per-run handler override collapses into this —
+  the port is per-session, so the per-run override patch (added for
+  multi-window) becomes unnecessary.
+- **Resolution requires the session.** Today proposals resolve through the
+  process-global `runCoordinatorBridge` import and tool-edits through
+  module-global maps — any surface, no session needed, which is exactly what
+  makes multi-window fragile. `session.interactions.resolve(id, result)` is
+  the only door; surfaces that today import the bridge get the session
+  instead (they all have one in reach — desktop already does this).
+- **One pending registry, replay built in.** `pending()` is the reload
+  redisplay source (`replayPendingPrompts` reads it instead of a third copy);
+  the first-wins `isSettled` semantics move inside. External inquiry stays
+  thread-shaped and durable — it is the one interaction that is a
+  conversation, not a decision, and the port returns a handle rather than
+  pretending otherwise.
+- **Serialization scope becomes per-session** (the `PQueue{concurrency:1}` in
+  `streamApprovalQueue` is currently process-wide). One prompt at a time _per
+  session_ is the behavior users actually want in multi-window; noted as a
+  deliberate behavior change.
+- `BasePromiseCoordinator`'s internals (pDefer + pTimeout + replace-pending +
+  first-wins) are the right mechanics — they become the port's shared request
+  bookkeeping instead of one of three competing systems.
+
+### Plane 3 — `session.runs` + `session.status`: one table, one state machine
+
+**`RunTable`** (the renamed `ExecutionRegistry` core, clusters A+C+D — which
+the dissection showed are one cohesive object) keeps tracking, waiters, and
+stop/kill. Changes:
+
+- **The interrupt capability moves onto the handle.** `IInterruptible` is
+  registered via `session.runs.get(streamId).attachInterrupt(cb)` (flows and
+  background bash both already have the stream's handle in reach). One index;
+  the discoverable-but-uninterruptible state and the untested two-map pairing
+  invariant become unrepresentable. `InterruptRegistry` (35 lines) is
+  deleted.
+- **Follow-up routing closes its race.** `getToolUseFollowUpTarget` +
+  `appendFollowUp` fuse into `session.runs.deliverFollowUp(streamId, item)`,
+  which re-checks liveness and enqueues-or-appends in one synchronous tick —
+  the decision-then-act window disappears rather than being guarded.
+- **`session.followUps`** is a per-session instance of the follow-up queue —
+  still streamId-keyed, because a queue must outlive runs to serve WAITING
+  streams; that is a stream-level concept and stays one. The binder↔queue
+  keying invariant becomes internal to one object instead of a cross-module
+  comment. Same move for `session.transcripts` (per-session `StreamLogStore`;
+  the `StreamSnapshotStore` sidecars stay a separate format per audit A6 and
+  get the same session scoping): `createRunTrace` takes the store from the
+  launching session, deleting `getDefaultStreamLogStore` and fixing L1.
+- The two read-only methods (`requestManualCompaction`,
+  follow-up-target queries where still needed externally) are exposed via
+  narrow `Pick<>` interfaces, the pattern the repo already uses twice.
+
+**`StreamStatusMachine`** replaces the shared `StreamStatusService` with a
+session-owned machine whose API is transitions-with-causes, not a settable
+map:
+
+```ts
+type TransitionCause =
+  | 'lifecycle' // runFlowWithLifecycle: RUNNING, terminal projection
+  | 'wait'
+  | 'resume' // ToolUseWaitNode, resumeQueuedToolUse
+  | 'user-stop' // RunTable stop path *requests*; machine writes
+  | 'restart-repair' // host recovery: RUNNING→WAITING/ERROR after reload
+  | 'admission' // tryAcquire / releaseIfInitializing (launch saga)
+  | 'clear'; // tab delete / delete-all (this session only)
+
+interface StreamStatusMachine {
+  transition(
+    streamId: StreamTabId,
+    to: StreamStatus,
+    cause: TransitionCause,
+    terminalStatus?: ExecutionStatus,
+  ): boolean; // false = rejected by rules
+  get(streamId: StreamTabId): StreamStatus | undefined;
+  tryAcquire(streamId: StreamTabId): boolean; // admission lock, unchanged
+}
+```
+
+- **The rules move inside**: STOPPED-wins, `shouldPreserveOnCompletion`,
+  stale-handle guards become the machine's transition table instead of
+  call-site checks in the registry and lifecycle. Illegal transitions return
+  `false`; today's scattered guards are deleted.
+- **The `emit:false` backdoor becomes a named cause.** Restart repair and
+  ghost hydration are legitimate host-authored transitions — the current
+  design just has no vocabulary for them. `cause: 'restart-repair'` gives the
+  UI backend its voice _through the front door_, and every transition emits a
+  `status` event on the session hub (no silent writes, no split between
+  "emitting" and "non-emitting" mutations).
+- **One writer for STOPPED**: the RunTable stop path calls
+  `transition(…, 'user-stop')`; the lifecycle calls
+  `transition(…, 'lifecycle')`; the machine arbitrates. The dual-write
+  coordination problem becomes one function.
+- **Session-scoped, with explicit aggregation**: cross-session reads (the only
+  legitimate use of today's sharing) go through the existing
+  `liveSessions`-style aggregation, mirroring `getAllActiveExecutionIds()`.
+  One window's delete-all can no longer sweep another window's streams (L3);
+  the RunTable subscribes to _its own session's_ machine, so window A's
+  status changes stop firing window B's waiters.
+
+**Bag/context unification** (the split-brain fix, mechanical per the DI
+audit): the launch context builds one frozen `RunScope` — identity
+(streamId/executionId), `session`, `trace`, `workingDirectory`, model config
+accessor — and both access paths carry _the same object_: the ALS
+`RunContext` holds it, and flow service bags hold a reference to it instead
+of copying 7–8 fields. Adding the trace to `RunScope` also closes the gap the
+projector analysis found (ALS callers today can never reach the trace). Nodes
+declare narrowed interfaces over it; the `{...this.services}` wholesale
+spreads are replaced by explicit selection.
+
+## 3. What each existing artifact becomes
+
+| Today                                                                        | Becomes                                                                                                                    |
+| ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `ProgressEventBus` (54 keys) + 1000-event buffer                             | Migration-period projection target; deleted at end. Buffer never reimplemented.                                            |
+| `ProgressEventPayloads` run-fact keys (22)                                   | `AgentEvent` (existing + `status`, `child.activity`, `process.output` arms) and `SessionFact`                              |
+| show/resolve pairs + bypass toggles (22 keys)                                | Internal to `HostInteractions` implementations; bypass state is port-owned                                                 |
+| App-lifecycle keys (10)                                                      | `AppSignals` (small, explicitly process-scoped emitter)                                                                    |
+| `emitRuntimeEvent`                                                           | `runScope.trace.*` (in-run) / `session.events.emit` (host-path); the three-way fallback resolution disappears              |
+| `BasePromiseCoordinator` + 3 coordinators + `RunCoordinatorBridge`           | `HostInteractions` request bookkeeping + pending registry                                                                  |
+| `platform().toolEditApproval` + per-run handler override + host promise maps | The session's `HostInteractions` implementation                                                                            |
+| `ApprovalRequestHandler.pending/delivered` + `replayPendingPrompts`          | `session.interactions.pending()` + host redisplay                                                                          |
+| `StreamStatusService` (shared singleton)                                     | `session.status` (`StreamStatusMachine`); cross-session reads via explicit aggregation                                     |
+| `ExecutionRegistry`                                                          | `session.runs` (`RunTable`); E/F behind `Pick<>`; constructor `onDidChange` bridge → subscription to own session's machine |
+| `InterruptRegistry`                                                          | deleted — capability lives on the run handle                                                                               |
+| `ToolUseFollowUpQueue` (static)                                              | `session.followUps` instance                                                                                               |
+| `getDefaultStreamLogStore` (last-writer-wins)                                | `session.transcripts`, threaded into `createRunTrace`                                                                      |
+| `conversationProgressHub`, `terminalResultToast`                             | First-class projector subscribers on `session.events` (the pattern, generalized)                                           |
+| `installTuiApprovals` emit monkey-patch (CLI)                                | CLI `HostInteractions` implementation                                                                                      |
+| STOPPED-wins / preserve / stale-handle guards                                | `StreamStatusMachine` transition table                                                                                     |
+| `UsageMonitor` dual emit                                                     | Single trace `usage` emit; sidebar totals are a projector                                                                  |
+
+Invariants that become true _by construction_ (each currently held by a guard,
+a comment, or luck): no event exists before its subscriber (hub is built with
+the session); a pending interaction always has exactly one settlement path and
+survives webview reload from one registry; a live stream is always
+interruptible if discoverable; a status transition always has a cause and is
+always observed; a run's transcript always lands in its session's store; one
+window's actions never mutate another window's runtime state.
+
+## 4. Migration (each stage shippable; extension byte-identical throughout)
+
+The `defaultSession()` aliasing strategy from the 7d migration carries every
+stage: the extension keeps one default session, so wiring changes are
+invisible to it while desktop/CLI gain correctness.
+
+1. **Hub + projection of the easy seven.** Add `SessionEventHub` +
+   `attachRunTrace` generalization (attach before first emit). Project the
+   seven drop-in run-facts (`updateTodos`, `updatePlan`, `updateStreamUsage`
+   single-emit, `addOutputFiles`, `updateMissingOutputs`,
+   `updateCompileFailures`, `goalPaused`) via the `conversationProgressHub`
+   pattern onto the bus. Nothing downstream changes.
+2. **Status machine.** Introduce `StreamStatusMachine` per session wrapping
+   the shared instance's data; move guards into the transition table; convert
+   `emit:false` writers to `restart-repair`/`clear` causes; add the `status`
+   trace arm and make `updateStreamStatus` a projection. RunTable stop path
+   switches from writing to requesting.
+3. **Session facts + registry facts.** `SessionFact` channel for the non-run
+   emitters; `child.activity`/`process.output` arms; `session.transcripts`
+   and `session.followUps` instances (fixes L1; deletes the static queue and
+   the binder invariant comment).
+4. **Interactions port.** Introduce `HostInteractions` per session; implement
+   for CLI first (deletes the monkey-patch and exercises the contract), then
+   desktop (deletes the per-window handler plumbing), then extension.
+   Coordinators/bridge/pending-registries fold in; resolution surfaces switch
+   to `session.interactions.resolve`.
+5. **Projector switchover + deletion.** Point each window's
+   `ProgressEventHandler`, `StreamSnapshotStore`, CLI renderer, and the
+   scattered frontend `bus.on` consumers at their session's hub (fixes L2/L3
+   fan-out). Delete `ProgressEventPayloads` run-fact/RPC keys, the buffer,
+   `emitRuntimeEvent`'s fallback chain, `InterruptRegistry`, and the
+   `RunContext`/bag field copies (RunScope lands here or with 2).
+
+Stages 1–2 are low-risk and deliver the single-writer status + single-emit
+facts immediately; 3–4 are where multi-window desktop becomes actually
+correct; 5 is the payoff deletion.
+
+## 5. Rejected alternatives
+
+- **Collapse the bus into the trace** (the naive fix): rejected — 22 keys are
+  bidirectional RPC and 10 are app-scoped; a trace has no reply channel and
+  no home for non-run facts. The bus's real successor is three surfaces, not
+  one.
+- **Keep event-pair RPC but unify the coordinators**: rejected — it preserves
+  the wrong contract (fire-and-forget events simulating calls), keeps
+  resolution possible without a session, and keeps three pending registries
+  needing three replay paths.
+- **Split `ExecutionRegistry` into lifecycle/follow-up/compaction services**:
+  rejected — the dissection showed tracking+waiters+stop are one cohesive
+  object (stop reads the map; every mutation notifies; status re-enters
+  synchronously). Only the two read-only methods lift out.
+- **Per-run follow-up mailboxes on the handle**: rejected — queues must
+  outlive runs to serve WAITING streams across restarts; the queue is
+  stream-scoped by nature and session-owned by residence.
+- **A global event bus with session-id filtering**: rejected — filtering
+  re-implements scoping at every consumer and keeps the leak class alive;
+  ownership is the fix, not routing metadata.
+- **New process-wide `setX` ports for the missing trace access**: rejected —
+  the DI cleanup direction is fewer ambient globals, not more; `RunScope`
+  carries the trace instead.

--- a/docs/proposals/session-scoped-runtime-architecture.md
+++ b/docs/proposals/session-scoped-runtime-architecture.md
@@ -274,7 +274,7 @@ stop/kill. Changes:
   registered via `session.runs.get(streamId).attachInterrupt(cb)` (flows and
   background bash both already have the stream's handle in reach). One index;
   the discoverable-but-uninterruptible state and the untested two-map pairing
-  invariant become unrepresentable. `InterruptRegistry` (35 lines) is
+  invariant become unrepresentable. `InterruptRegistry` (34 lines) is
   deleted.
 - **Follow-up routing closes its race.** `getToolUseFollowUpTarget` +
   `appendFollowUp` fuse into `session.runs.deliverFollowUp(streamId, item)`,

--- a/docs/proposals/tech-debt-audit-2026-07.md
+++ b/docs/proposals/tech-debt-audit-2026-07.md
@@ -183,22 +183,52 @@ versa). Also fixes the CLI's synthetic-entry dedup at the source (see B2).
 
 ## Part B — documented debts where a much better solution exists
 
-### B1. Dual run-event taxonomy: stop maintaining two rails, make the bus a projection
+### B1. Dual run-event taxonomy: a full collapse is NOT feasible — target the three duplicated facts instead
 
-Documented state: `error-pipeline-and-ownership.md` ruled that new facts extend
-`AgentEvent` **or** `ProgressEventPayloads` (never new `bus.emit` from free
-zones), and SDK-readiness F-1 deferred the host-path re-routes — i.e. the two
-systems are treated as permanent parallel rails. Reality: the bus has 54+ event
-keys and ~110 emit sites plus a 645-line `ProgressEventHandler`, while
-`src/agent/trace/` is a clean 4-variant discriminated union already exported as
-the SDK contract. Every new run-visible fact is a two-vocabulary decision.
+_(Revised after the mechanism-level deep dive; see the appendix below for the
+full map.)_ Documented state: `error-pipeline-and-ownership.md` ruled that new
+facts extend `AgentEvent` **or** `ProgressEventPayloads`, and SDK-readiness F-1
+deferred host-path re-routes. The deep dive shows the naive "make the bus a
+trace projection" idea is wrong: of the bus's **54** keys, **22** are
+bidirectional approval/host RPC (`show*`/`resolve*` pairs with promise
+coordinators) and **10** are app-lifecycle signals emitted outside any run —
+neither can ever be append-only trace facts. The bus also provides
+pre-subscription buffering (`ProgressEventBus.ts:329-351`, 1000-event replay)
+that `TraceEmitter` lacks. And the discipline already holds: zero raw
+`bus.emit` in VS Code-free zones; everything routes via
+`runtimeHost`/`emitRuntimeEvent`.
 
-**Better solution:** declare the trace the _only_ emit path and reduce
-`ProgressEventPayloads` to a host-side projection — one adapter subscribing to
-`AgentEvent` and invoking UI callbacks. Per-event `bus.emit` sites delete
-incrementally (the `emitRuntimeEvent()` migration in `src/tools` already
-proved the mechanics). This turns the standing F-1 deferral into a terminal
-state instead of an indefinite dual-write discipline.
+The _actual_ debt is **the same fact emitted in two vocabularies at three
+spots**:
+
+1. **Terminal outcome dual-emit** — `AgentRunLifecycle.ts:83` emits the trace
+   `ResultEvent` while `StreamStatusService.set → runtimeHost.emit('updateStreamStatus')`
+   (`StreamStatusService.ts:76`) publishes the same fact as
+   `StreamStatus`+`terminalStatus`. Two shapes, two channels, guard-coordinated.
+2. **Usage triple-emit** — `UsageMonitor.ts:170` (bus `updateStreamUsage`) +
+   `UsageMonitor.ts:182` (trace `usage`) + `ResultEvent.usage`
+   (`events.ts:183`), already flagged "genuine duplication" in
+   `docs/agent-sdk-readiness-audit.md:226`.
+3. **Every `trace.info()` on a run writes two sinks** — output channel (via
+   `attachChannelSubscriber`) and transcript (`TexraTranscriptRecorder` →
+   `StreamLogStore`). Intentional, but a per-call double write.
+
+**Better solution:** keep the bus, but (a) make the remaining overlapping
+run-facts _projections_ of trace events, following the in-repo reference
+implementation `conversationProgressHub.ts:36-45` (one trace domain emit →
+hub republishes onto the bus); (b) collapse usage to a single trace emit
+projected to the bus; (c) split `ProgressEventPayloads` into three explicit
+interfaces — `RunFactEvents` (22), `ApprovalRpcEvents` (22),
+`AppSignalEvents` (10) — so the taxonomy is in the types and nobody proposes
+the wrong collapse again. Non-terminal stream status (INITIALIZING/RUNNING/
+WAITING) has no trace representation and its handler performs memory-eviction
+side effects (`ProgressEventHandler.ts:580-584`), so it stays bus-native
+unless a `status` trace variant is added deliberately.
+
+Note the logger itself is **no longer debt**: `src/logger/` is 308 lines, 4
+files, one sink boundary (`writeLine`), with `AgentLogger`/`structuredLogger`
+genuinely deleted. The remaining cost is fact duplication across pipelines,
+not stacked modules.
 
 ### B2. CLI↔extension sharing: the documented rung-ladder targets approvals; the real duplication is the projection layer
 
@@ -258,16 +288,53 @@ the snapshot+invariants scripts entirely (a codegen diff check replaces them).
 Same SSOT the proposal wants, but it deletes ~two scripts, a 70 KB artifact,
 and the whole silent-rename failure mode instead of adding a third surface.
 
-### B5. `ExecutionRegistry`: the SessionHandle work fixed _global-ness_, not cohesion
+### B5. `ExecutionRegistry`: the SessionHandle work fixed _global-ness_; the remaining debt is narrower than "split the class"
 
-The documented Step 7a–d/SessionHandle program (landed) made the registries
-injectable — but `src/agent/runtime/executionRegistry.ts` remains one 809-line
-class with 42 methods spanning 4–5 responsibilities: execution tracking,
-stop/kill/cascade-vs-detach policy, tool-use follow-up queueing, and manual
-compaction requests. **Better solution:** finish the job with a cohesion split
-(`ExecutionLifecycle`, `FollowUpRouter`, `CompactionRequests`) now that
-injection exists; the DI-cleanup doc's ISP step points here but never names
-this class as its largest instance.
+_(Revised after the mechanism-level deep dive; see appendix.)_ Corrections to
+the first pass: the class is ~33 methods over 7 fields (not 42), and it
+contains **no follow-up queue** — `getToolUseFollowUpTarget` is a pure
+read-only routing _decision_; the queue is the separate static
+`ToolUseFollowUpQueue` (`src/agent/followUp/ToolUseFollowUpQueueManager.ts`).
+The tracking + waiter-notification + stop/kill clusters are genuinely one
+cohesive object (stop reads the handle map, every mutation notifies waiters,
+`streamStatus.set` re-enters the registry synchronously via `onDidChange`) —
+a full split would add abstraction without isolating anything.
+
+What actually remains:
+
+- **Two clean lift-outs**: `getToolUseFollowUpTarget` and
+  `requestManualCompaction` are read-only, disjoint-caller methods; the repo
+  already narrows the registry via `Pick<ExecutionRegistry, …>` in two places
+  (`runCoordinators.ts:39`, `ExecutionSubscriptionBinder.ts:48`) — same
+  pattern, copy-move.
+- **Double bookkeeping of STOPPED**: both the registry stop path
+  (`terminate` :740, `interruptRegisteredStream` :761, `stopAgentStream`
+  :622) and the lifecycle arms (`AgentRunLifecycle.ts:157/215/280`) write the
+  shared `StreamStatusService` for the same stream, coordinated only by
+  STOPPED-wins guards. One writer (the lifecycle) with the stop path
+  _requesting_ rather than writing would remove a whole class of guard code.
+- **Two live-run indices that must stay coherent**: `handles`
+  (executionId-keyed) and `InterruptRegistry.entries` (streamTabId-keyed). A
+  stream present in only one is discoverable-but-uninterruptible
+  (`terminate` returns false at :738). No test enforces the pairing.
+- **Decision-then-act window**: `getToolUseFollowUpTarget` returns `active`,
+  then `appendFollowUp` runs (`ToolUseFollowUp.ts:192,199`) with no liveness
+  re-check between — a stop landing in that window appends to a terminating
+  flow.
+- **Unenforced session invariant**: `SessionHandle.ts:99-104` documents that
+  the per-session `ExecutionSubscriptionBinder` reads the _process-static_,
+  streamId-keyed follow-up queue as its release source — coherent only while
+  the queue stays streamId-keyed, flagged in a comment but not by any test.
+- **Bimodal tests**: registry unit tests construct fresh injected instances
+  (`ExecutionRegistry.vitest.ts:24,46`), while follow-up/integration suites
+  still mutate the exported singleton (`ToolUseFollowUp.vitest.ts:51,81`) —
+  a migration-in-progress footprint worth finishing.
+- **The remaining true cross-session singletons** are deliberate but
+  undocumented as such in the DI plan: `StreamStatusService` (same instance
+  injected into every `SessionHandle`, :92) and the static
+  `ToolUseFollowUpQueue`. (Also: the DI doc still lists
+  `idleContinuationRegistry` as a live singleton — that module has been
+  deleted; the doc reference is stale.)
 
 ### B6. The PocketFlow `shared` bag: DI-cleanup targets the AgentCore bag; the flow bag is the bigger untyped surface
 
@@ -284,6 +351,94 @@ slice accessors) instead of the loose bag, and an expiry date for
 
 ---
 
+## Appendix — deep dive (2026-07-03): event/logger pipelines and the execution cluster
+
+Mechanism-level findings behind the B1/B5 revisions above.
+
+### Event architecture as it actually runs
+
+Two independent delivery systems, meeting only at two bridges:
+
+- **Pipeline A (bus):** `ProgressEventBus` — synchronous Node `EventEmitter`,
+  54 typed payloads, pre-subscription buffer (1000 events, replayed on first
+  `on()`). Consumed by the host-agnostic `ProgressEventHandler` (~22 run-fact
+  handlers via `registerHandlers.ts`, 18 approval callbacks via `UIEvents.ts`)
+  plus host-specific subscribers (status bar, file decorations, desktop
+  window bridge, CLI `subscribeRuntimeHost`).
+- **Pipeline B (trace):** `TraceEmitter` implementing the 12-variant
+  `AgentEvent` union (`log`, `stage.*`, `tool.*`, `usage`, `context.state`,
+  `stream.*`, `domain`, `result`). Per-run subscribers: channel logger
+  (`attachChannelSubscriber` → `writeLine` sink), transcript recorder
+  (`TexraTranscriptRecorder` → `StreamLogStore`, which each host UI reads
+  directly), `conversationProgressHub` (trace→bus projection), and
+  `SessionHandle.attachRunTrace` (`result` → `session.onResult`).
+- **Key structural fact:** the bus carries **no log lines and no model stream
+  text** — all transcript content flows trace→`StreamLogStore`. So "merge the
+  log pipeline into the bus" and "collapse the bus into the trace" are both
+  non-problems; the systems partition cleanly except for the three duplicated
+  facts listed in B1.
+- **Emit discipline is fully enforced**: zero raw `bus.emit` under `src/`
+  outside `emitRuntimeEvent.ts:31` (the sanctioned single-session fallback);
+  `src/tools` (~30 sites) and `src/agent` (~28 sites) all route through
+  `runtimeHost.emit`/`emitRuntimeEvent`. Raw bus access exists only in the
+  three host packages, which bind the bus by design
+  (`extensionAgentRuntimeHost.ts:5`, `desktopAgentExecution.ts:811`,
+  `runExecution.ts:70`).
+- Migration hazards for any future projection work: the bus's buffering and
+  per-handler `withEventErrorHandling` wrapping must be reproduced;
+  `ProgressEventHandler` handlers are not pure renderers (they drive
+  `streamLogs.ensureLoaded/releaseEntries` eviction and
+  `StreamStatusService.set(emit:false)`); `setActiveStream` is half fact,
+  half UI command (tab switching, `suppressViewSwitch` gating) and is emitted
+  from non-run contexts; `updateProcessOutput` is high-frequency process
+  output with no trace analogue — folding it into `stream.chunk` would
+  conflate model text with process output.
+
+### Execution cluster as it actually runs
+
+- **Ownership map:** `SessionHandle` (289 lines) composes per-session
+  `InterruptRegistry`, `ExecutionRegistry`, `RunCoordinatorBridge`,
+  `ExecutionSubscriptionBinder` in forced dependency order
+  (`SessionHandle.ts:86-118`); `defaultSession()` aliases the process
+  singletons so unmigrated call sites stay byte-identical. Deliberately NOT
+  session-owned: `StreamStatusService` (shared instance injected into every
+  session), static `ToolUseFollowUpQueue`, `subagentDeliveryRegistry`
+  (explicit rationale comment), `toolInjectionRegistry`.
+- **Lifecycle single-writer (landed):** `runFlowWithLifecycle` is the sole
+  owner of RUNNING and of the terminal transition; `RunOutcome` is projected
+  through the declarative `RUN_OUTCOME_PROJECTION` table to
+  execution/group/stream statuses, with emit-before-untrack ordering and a
+  `resultEmitted` double-publish guard. Terminal fan-out
+  (`handle.settleResult`, `session.onResult`, `writeTerminalStatus`,
+  `streamStatus.set`) stays consistent only because all four route through
+  one projection — this is the invariant to protect in any refactor.
+- **Stop propagation:** host → `stopAgentStream` → child sweep
+  (cascade/detach sharing one `visited` set) → `terminate` → look up
+  `interrupts.get(streamTabId)` → `interrupt()` → flow's
+  `InterruptManager` closure sets `isInterrupted` + aborts the
+  `AbortController` the model handler streams under.
+- **Known safe-but-fragile spots (all currently guarded by synchronous
+  single-tick execution):** `streamStatus.set → onDidChange → handles` walk
+  re-enters the registry mid-cascade; `untrackHandle` defers the final
+  process-output flush across an await (`executionRegistry.ts:273-280`);
+  `ExecutionSubscriptionBinder.ts:116-124` re-checks the handle after
+  `addListener` (TOCTOU); `wakeAttempts` serializes concurrent resume wakes
+  (`ToolUseFollowUp.ts:52,78-90`).
+- **AgentCore/RunContext split-brain, concretely:** flow nodes read the
+  services bag while tools read the ALS `RunContext`; both are populated from
+  the same `AgentLaunchContext` (`agentContextToRunContext`,
+  `AgentLaunchContext.ts:153-172`). Same-fact-two-paths examples: `streamId`
+  (`BaseFlowServices.ts:53` vs `tryUseRunContext()?.streamId` in
+  `bashApproval.ts:72`, `PlanTool.ts:112`), `executionId`
+  (`CommonCycleTypes.ts:98` vs `MemoryTool.ts:197`, `bash.ts:157`),
+  `workingDirectory` (`AgentCore.workingDirectory` vs `bash.ts:134`,
+  `DiagnosticsTool.ts:120`). Each duplicated field has exactly one write
+  site, so per-field collapse is mechanical. The bag over-carry is wholesale
+  spreads (`{...this.services}`) inflating declared ~13 fields to ~31-35 at
+  runtime with 70-90% unread per node — also mechanical to narrow.
+
+---
+
 ## Suggested priority
 
 1. **A2 host-adapter factories** — highest bug-yield per line deleted; purely
@@ -292,8 +447,15 @@ slice accessors) instead of the loose bag, and an expiry date for
    OpenAIResponse/Google collaborator splits) — largest raw mass; every
    provider feature currently pays 4–5×.
 3. **B2 shared projection/display-model layer** — unblocks CLI feature parity
-   and deletes the synthetic-entry hacks; sequence after (or with) B1 so the
-   reducer folds the right event type.
+   and deletes the synthetic-entry hacks; B1's taxonomy split
+   (RunFacts/ApprovalRpc/AppSignals) is a natural prerequisite so the shared
+   reducer folds a well-typed event set.
+   3a. **B1/B5 targeted fixes** (small, high-safety-value): usage single-emit +
+   projection; terminal-status single-writer; a test enforcing the
+   handles/interrupts pairing and the binder↔queue keying invariant; close
+   the follow-up decision-then-act window; lift
+   `getToolUseFollowUpTarget`/`requestManualCompaction` behind `Pick<>`
+   interfaces; migrate the singleton-bound follow-up tests to fresh sessions.
 4. **B4 config codegen** — deletes tooling and a whole failure mode; small.
 5. **A4 test-infra** (`memfs` + global setup) — cheap, pays on every suite.
 6. **A3 MainApp slice migration, B3 boundary enforcement, A6 transcript store

--- a/docs/proposals/tech-debt-audit-2026-07.md
+++ b/docs/proposals/tech-debt-audit-2026-07.md
@@ -115,11 +115,11 @@ history export/rerun, provider-key differences, and similar platform seams).
 
 ### A3. `MainApp.ts`: 1,915-line god component running three state mechanisms at once
 
-`packages/extension/src/webview/frontend/MainApp.ts` mixes about 32 ad-hoc
-`signal(...)` fields around the class state block, 4 distinct
-`@state`/`@provide` context fields, and a `PersistedState`/
-`createWebviewStorage` manager, with restore logic sprawled over three methods.
-The repo already contains the correct pattern —
+`packages/extension/src/webview/frontend/MainApp.ts` mixes 18 ad-hoc
+`signal(...)` fields in the class state block, 4 `@state()` fields (2 also
+`@provide()` context fields), and a `PersistedState`/`createWebviewStorage`
+manager, with restore logic sprawled over three methods. The repo already
+contains the correct pattern —
 `progressView/frontend/` uses a store + 10 slice files with `mutative` — and
 MainApp simply predates it. Same story in miniature for
 `settingsView/frontend/SettingsApp.ts` (1,140) +
@@ -144,7 +144,7 @@ architecture needed.
   JSON-comment stripper in `aliasUtils.mjs` (reimplements `strip-json-comments`)
   whose own header admits the extension tsconfig "will silently follow the
   root" on divergence.
-- Root `tsconfig.json` has **54 path aliases**; `@/*` and `~/*` are exact
+- Root `tsconfig.json` has **46 path aliases**; `@/*` and `~/*` are exact
   duplicates, and several "shared" aliases (`@webview/*`, `@commands/*`,
   `@settingsView/*`, …) point into `packages/extension/`, coupling core to one
   host. `packages/desktop/tsconfig.paths.json` is a second hand-maintained copy.
@@ -482,7 +482,8 @@ Two independent delivery systems, meeting only at two bridges:
    the follow-up decision-then-act window; lift
    `getToolUseFollowUpTarget`/`requestManualCompaction` behind `Pick<>`
    interfaces; migrate the singleton-bound follow-up tests to fresh sessions.
-4. **B4 config codegen** — deletes tooling and a whole failure mode; small.
+4. **B4 config codegen** — deletes the snapshot artifact and silent-rename
+   failure mode while preserving package-resource checks; small.
 5. **A4 test-infra** (`memfs` + global setup) — cheap, pays on every suite.
 6. **A3 MainApp slice migration, B3 boundary enforcement, A6 transcript facade,
    B5/B6 cohesion splits** — as-touched.

--- a/docs/proposals/tech-debt-audit-2026-07.md
+++ b/docs/proposals/tech-debt-audit-2026-07.md
@@ -31,14 +31,14 @@ one `createFakePlatform`, not a service-locator god object.
 pipeline — message assembly, media attachment, tool-result blocks, streaming,
 continuation — against its SDK types:
 
-| File | LoC |
-| --- | ---: |
-| `openai/modelHandlerOpenAIResponse.ts` | 2,871 |
-| `google/modelHandlerGoogleInteractions.ts` | 2,154 |
-| `anthropic/modelHandlerAnthropic.ts` | 1,692 |
-| `openai/modelHandlerOpenAI.ts` | 1,513 |
-| `google/modelHandlerGoogleGenAI.ts` | 1,204 |
-| `openrouter/modelHandlerOpenRouterNative.ts` | 957 |
+| File                                         |   LoC |
+| -------------------------------------------- | ----: |
+| `openai/modelHandlerOpenAIResponse.ts`       | 2,871 |
+| `google/modelHandlerGoogleInteractions.ts`   | 2,154 |
+| `anthropic/modelHandlerAnthropic.ts`         | 1,692 |
+| `openai/modelHandlerOpenAI.ts`               | 1,513 |
+| `google/modelHandlerGoogleGenAI.ts`          | 1,204 |
+| `openrouter/modelHandlerOpenRouterNative.ts` |   957 |
 
 Concrete sub-debts, each independently fixable:
 
@@ -193,7 +193,7 @@ keys and ~110 emit sites plus a 645-line `ProgressEventHandler`, while
 `src/agent/trace/` is a clean 4-variant discriminated union already exported as
 the SDK contract. Every new run-visible fact is a two-vocabulary decision.
 
-**Better solution:** declare the trace the *only* emit path and reduce
+**Better solution:** declare the trace the _only_ emit path and reduce
 `ProgressEventPayloads` to a host-side projection — one adapter subscribing to
 `AgentEvent` and invoking UI callbacks. Per-event `bus.emit` sites delete
 incrementally (the `emitRuntimeEvent()` migration in `src/tools` already
@@ -251,14 +251,14 @@ hand-maintained manifest (65 settings + 67 commands) synced by
 by raw string key (`config.get('texra.files.exclude', …)`), with feature-flag
 wrappers existing solely to hide that.
 
-**Better solution:** make the catalog generate *both* directions —
+**Better solution:** make the catalog generate _both_ directions —
 `contributes.configuration`/`contributes.commands` in package.json **and** a
 typed `SettingKey` accessor map consumed via `platform().config` — then retire
 the snapshot+invariants scripts entirely (a codegen diff check replaces them).
 Same SSOT the proposal wants, but it deletes ~two scripts, a 70 KB artifact,
 and the whole silent-rename failure mode instead of adding a third surface.
 
-### B5. `ExecutionRegistry`: the SessionHandle work fixed *global-ness*, not cohesion
+### B5. `ExecutionRegistry`: the SessionHandle work fixed _global-ness_, not cohesion
 
 The documented Step 7a–d/SessionHandle program (landed) made the registries
 injectable — but `src/agent/runtime/executionRegistry.ts` remains one 809-line

--- a/docs/proposals/tech-debt-audit-2026-07.md
+++ b/docs/proposals/tech-debt-audit-2026-07.md
@@ -55,8 +55,11 @@ Concrete sub-debts, each independently fixable:
   (28 in the base alone: `supportsToolResultFileUpload`,
   `supportsResponseChaining`, `shouldIncludeReasoningInToolCalls`, …) are
   individually overridable toggles. A new provider means auditing dozens of
-  independent booleans. **Fix:** one declarative `ProviderCapabilities` record
-  per handler.
+  independent booleans. **Fix:** one declarative `ProviderCapabilities` source
+  per handler, with entries allowed to be runtime resolvers over config/auth
+  mode rather than only static constants. `ModelHandlerCodex` is the concrete
+  warning: subscription and API-key routes do not advertise the same
+  capabilities.
 - **`modelHandlerOpenAIResponse.ts` god class.** 94 methods; header comment
   admits non-thread-safe instance state (`previousResponseId`,
   `pendingBackgroundResponseId`, `conversationState`); juggles streaming vs
@@ -71,8 +74,11 @@ Concrete sub-debts, each independently fixable:
   predicates. **Fix:** unify behind one handler with an explicit
   `InteractionChain` collaborator, or record a sunset date for the GenAI path.
 - **Dual contract.** `types/IModelHandler.ts` (475 LoC, 33 signatures)
-  duplicates the abstract class surface by hand. **Fix:** derive one from the
-  other or delete the interface.
+  duplicates most of the abstract class surface by hand. **Fix:** derive the
+  common surface from one source, while preserving interface-only extension
+  ports such as `createBatchedToolUseFollowUpMessages?`, which
+  `ToolUseDispatchNode` feature-detects for providers requiring batched
+  parallel tool-result messages.
 
 Caveat, honoring this repo's documented "rejected traps" discipline: the fix is
 **not** a grand unified handler framework (call sites genuinely diverge per
@@ -102,17 +108,22 @@ desktop" bugs (the coupling audit's #6887 crash-repair gap was exactly this
 class of drift). **Fix:** a shared
 `createSettingsViewHost({ postMessage, secrets, state })` /
 `createAgentExecutionHost(...)` factory in `src/controllers/`, parameterized by
-a thin host-capability interface; each host shrinks to a ~100-line adapter.
+a thin host-capability interface. Scope it to repeated controller/command
+wiring, not to deliberate host-specific flows already called out in
+`agent-runtime-ui-coupling-audit.md` (GitHub subscriptions, crash reporting,
+history export/rerun, provider-key differences, and similar platform seams).
 
 ### A3. `MainApp.ts`: 1,915-line god component running three state mechanisms at once
 
-`packages/extension/src/webview/frontend/MainApp.ts` mixes 18 ad-hoc
-`signal(...)` fields (`:162-227`), 5 `@state`/`@provide` context fields, and a
-`PersistedState`/`createWebviewStorage` manager, with restore logic sprawled
-over three methods. The repo already contains the correct pattern —
+`packages/extension/src/webview/frontend/MainApp.ts` mixes about 32 ad-hoc
+`signal(...)` fields around the class state block, 4 distinct
+`@state`/`@provide` context fields, and a `PersistedState`/
+`createWebviewStorage` manager, with restore logic sprawled over three methods.
+The repo already contains the correct pattern —
 `progressView/frontend/` uses a store + 10 slice files with `mutative` — and
 MainApp simply predates it. Same story in miniature for
-`settingsView/frontend/SettingsApp.ts` (1,140) + `LaTeXTab.ts` (848).
+`settingsView/frontend/SettingsApp.ts` (1,140) +
+`settingsView/frontend/tabs/LaTeXTab.ts` (848).
 **Fix:** migrate MainApp/SettingsApp to the in-repo slice-store pattern; no new
 architecture needed.
 
@@ -129,11 +140,11 @@ architecture needed.
 
 ### A5. Build/script/alias sprawl
 
-- `scripts/` holds ~30 `.mjs` files, ~7,850 lines, including a hand-rolled
+- `scripts/` holds ~30 `.mjs` files, ~5,000 lines, including a hand-rolled
   JSON-comment stripper in `aliasUtils.mjs` (reimplements `strip-json-comments`)
   whose own header admits the extension tsconfig "will silently follow the
   root" on divergence.
-- Root `tsconfig.json` has **45 path aliases**; `@/*` and `~/*` are exact
+- Root `tsconfig.json` has **54 path aliases**; `@/*` and `~/*` are exact
   duplicates, and several "shared" aliases (`@webview/*`, `@commands/*`,
   `@settingsView/*`, …) point into `packages/extension/`, coupling core to one
   host. `packages/desktop/tsconfig.paths.json` is a second hand-maintained copy.
@@ -143,25 +154,34 @@ architecture needed.
   re-evaluation trigger on ink bumps).
 
 **Fixes:** use `tsconfck`/`strip-json-comments`; drop `~/*`; move host aliases
-into host tsconfigs and generate the desktop table from root; consolidate
-desktop tsconfigs via project references; document the ink-patch exit plan.
+into host tsconfigs only after the root typecheck is split or taught to read
+the host project configs (today `tsc --noEmit` still includes extension files
+that import `@commands/*`, `@frontend/*`, `@progressView/*`, etc.); generate
+the desktop table from root; consolidate desktop tsconfigs via project
+references; document the ink-patch exit plan.
 
 ### A6. Transcript persistence: four overlapping stores (2,856 LoC)
 
 `src/transcript/` — `StreamSnapshotStore.ts` (1,046), `StreamLogStore.ts`
-(814), `streamSnapshotRead.ts` (218), `StreamLog.ts` (185) — two big stores
-persisting the same conceptual per-run stream data plus a separate read path.
-The coupling audit's #6889 (vestigial pub-sub, headless sidecar gap) touches
-this area but not the structural overlap. **Fix:** one store interface with a
-single serialization format; the snapshot becomes a view over the log (or vice
-versa). Also fixes the CLI's synthetic-entry dedup at the source (see B2).
+(814), `streamSnapshotRead.ts` (218), `StreamLog.ts` (185) — carries two durable
+per-run stores plus a separate read path. They are not interchangeable:
+`StreamSnapshotStore` owns sidecars under `streamData/{id}/*` (output files,
+usage, todos/plan, task state), while `StreamLogStore` is the append-only
+transcript under `streamLogs`. The coupling audit's #6889 (vestigial pub-sub,
+headless sidecar gap) touches this area but not the narrower duplicated
+read/write paths. **Fix:** one facade over both formats, with explicit
+ownership of sidecars vs transcript entries; do not force sidecar-only restore
+data into the append-only log. Also fixes the CLI's synthetic-entry dedup at
+the source (see B2).
 
 ### A7. Smaller, contained items
 
 - **Command-surface dual bookkeeping:** `extensionCommandSurface.ts` (538 LoC,
   40 aliased imports, 111 command-id strings) hand-mirrors
   `src/shared/commands/catalog.ts`, which desktop already consumes cleanly.
-  Drive extension registration fully from the catalog.
+  Drive extension registration from the catalog plus explicit hidden-alias
+  metadata/table, so compatibility ids such as `texra.showSettingsView` remain
+  registered even when they are intentionally absent from the public catalog.
 - **CSS-in-TS sprawl:** ~6,000 LoC across 25+ `*Styles.ts` files;
   `src/shared/styles/requestPanelStyles.ts` alone is 1,058. Split per-panel,
   colocate, finish `designTokens` adoption.
@@ -243,11 +263,13 @@ so feature parity is a port, not a rewrite" — the shapes have already forked
 (one 25-field map-of-structs vs 10 slices). Only `normalizeToolUseData` is
 genuinely shared.
 
-**Better solution:** one host-neutral reducer in `src/shared` that folds
-`ProgressEventPayloads` (or, post-B1, `AgentEvent`) into a normalized
-per-stream view model, plus a shared per-tool **display model** (title,
-sections, status, elided output); the CLI and webview become thin ANSI/Lit
-paint layers. This also dissolves the CLI's fragile synthetic-entry machinery
+**Better solution:** not the broad "single reducer for CLI and webview" rejected
+in `agent-runtime-ui-coupling-audit.md:76` (that rejection is still correct for
+async disk I/O, race handling, host-specific derived fields, and persistence
+ownership). The viable target is narrower: one shared projection/display-model
+layer for common run facts and per-tool presentation facts (title, sections,
+status, elided output), while each host keeps its own persistence and derived
+UI state. This also dissolves the CLI's fragile synthetic-entry machinery
 (`state/transcript.ts:35` dedup-by-normalized-text,
 `syntheticAfterSeq` splicing in `subscribeStreamLog.ts:385-411`) — the correct
 fix is upstream: emit the finalized assistant message into `StreamLogStore`
@@ -283,10 +305,12 @@ wrappers existing solely to hide that.
 
 **Better solution:** make the catalog generate _both_ directions —
 `contributes.configuration`/`contributes.commands` in package.json **and** a
-typed `SettingKey` accessor map consumed via `platform().config` — then retire
-the snapshot+invariants scripts entirely (a codegen diff check replaces them).
-Same SSOT the proposal wants, but it deletes ~two scripts, a 70 KB artifact,
-and the whole silent-rename failure mode instead of adding a third surface.
+typed `SettingKey` accessor map consumed via `platform().config` — then replace
+the snapshot part of the invariant machinery with a codegen diff check while
+preserving package-resource checks that are not catalog-derived (required
+agents/docs/templates/webview assets and `.vscodeignore` allow-list lines).
+Same SSOT the proposal wants, but it removes the 70 KB generated artifact and
+the silent-rename failure mode without weakening VSIX resource validation.
 
 ### B5. `ExecutionRegistry`: the SessionHandle work fixed _global-ness_; the remaining debt is narrower than "split the class"
 
@@ -441,15 +465,17 @@ Two independent delivery systems, meeting only at two bridges:
 
 ## Suggested priority
 
-1. **A2 host-adapter factories** — highest bug-yield per line deleted; purely
-   mechanical; no design debate.
+1. **A2 host-adapter factories** — highest bug-yield per line deleted when
+   limited to duplicated controller/command wiring; deliberate platform seams
+   remain host-owned.
 2. **A1 model-handler hoists** (prefill template method → capabilities struct →
    OpenAIResponse/Google collaborator splits) — largest raw mass; every
    provider feature currently pays 4–5×.
 3. **B2 shared projection/display-model layer** — unblocks CLI feature parity
-   and deletes the synthetic-entry hacks; B1's taxonomy split
+   without reviving the rejected full-reducer extraction, and deletes the
+   synthetic-entry hacks; B1's taxonomy split
    (RunFacts/ApprovalRpc/AppSignals) is a natural prerequisite so the shared
-   reducer folds a well-typed event set.
+   projection layer folds a well-typed event set.
    3a. **B1/B5 targeted fixes** (small, high-safety-value): usage single-emit +
    projection; terminal-status single-writer; a test enforcing the
    handles/interrupts pairing and the binder↔queue keying invariant; close
@@ -458,5 +484,5 @@ Two independent delivery systems, meeting only at two bridges:
    interfaces; migrate the singleton-bound follow-up tests to fresh sessions.
 4. **B4 config codegen** — deletes tooling and a whole failure mode; small.
 5. **A4 test-infra** (`memfs` + global setup) — cheap, pays on every suite.
-6. **A3 MainApp slice migration, B3 boundary enforcement, A6 transcript store
-   unification, B5/B6 cohesion splits** — as-touched.
+6. **A3 MainApp slice migration, B3 boundary enforcement, A6 transcript facade,
+   B5/B6 cohesion splits** — as-touched.

--- a/docs/proposals/tech-debt-audit-2026-07.md
+++ b/docs/proposals/tech-debt-audit-2026-07.md
@@ -1,0 +1,300 @@
+# Tech-debt audit: largest debts not previously uncovered (2026-07)
+
+Full-repo sweep (repo-root `src/` ~245k LoC non-test, `packages/extension` 57k,
+`packages/cli`, `packages/desktop` 10.9k) cross-referenced against the existing
+debt corpus (`docs/proposals/*`, `docs/tui-performance-audit.md`,
+`docs/dev/standalone-trajectory-audit.md`, coupling/SDK-readiness audits and the
+2026-07-03 checkpoint). Two buckets:
+
+- **Part A — debts not documented anywhere** in the proposal/audit corpus.
+- **Part B — debts already documented, but where a materially better solution
+  exists** than the one on file.
+
+Ruled out up front (checked, healthy — don't spend time here): type-safety is
+clean (27 `as any`/`as unknown as` in all non-test code, zero
+`@ts-ignore`/`@ts-expect-error`); the VS Code-free zones really are free of
+`vscode` imports; webview IPC is typed (Zod schemas + `createDispatcher`, no
+stringly `postMessage` switches); the three webviews share Lit components and
+`@controllers` cores across extension and desktop; the tool registry, usage
+normalization (`UsageNormalizer`), and tool→provider conversion
+(`toolConversion.ts`) are already unified; `Platform` is 17 small ports behind
+one `createFakePlatform`, not a service-locator god object.
+
+---
+
+## Part A — largest debts not previously uncovered
+
+### A1. The model-handler layer: one pipeline implemented four-to-five times (~20.7k LoC)
+
+`src/agent/modelHandlers/` is 20,660 LoC. `ModelHandler.ts` (1,349) declares
+**19 abstract methods**, and each provider re-implements the same conceptual
+pipeline — message assembly, media attachment, tool-result blocks, streaming,
+continuation — against its SDK types:
+
+| File | LoC |
+| --- | ---: |
+| `openai/modelHandlerOpenAIResponse.ts` | 2,871 |
+| `google/modelHandlerGoogleInteractions.ts` | 2,154 |
+| `anthropic/modelHandlerAnthropic.ts` | 1,692 |
+| `openai/modelHandlerOpenAI.ts` | 1,513 |
+| `google/modelHandlerGoogleGenAI.ts` | 1,204 |
+| `openrouter/modelHandlerOpenRouterNative.ts` | 957 |
+
+Concrete sub-debts, each independently fixable:
+
+- **Prefill/continuation re-implemented 5×.** Six abstract methods
+  (`initializeOutputAndPrefill`, `updateMessageContentWith/WithoutPrefill`,
+  `addContinueMessageWith/WithoutPrefill`, `shouldContinue`,
+  `ModelHandler.ts:842-1033`) form a mini-subsystem every provider writes from
+  scratch ("prefill" occurs 30× in the Anthropic handler, 19×/18× OpenAI,
+  17× each Google). `support/openAiCompatiblePrefill.ts` exists but only
+  OpenAI-shaped providers use it. **Fix:** hoist prefill/continuation into the
+  base as a template method; providers supply only the "append text to last
+  assistant message" primitive.
+- **87 scattered capability booleans.** `supports*/should*/is*/use*` predicates
+  (28 in the base alone: `supportsToolResultFileUpload`,
+  `supportsResponseChaining`, `shouldIncludeReasoningInToolCalls`, …) are
+  individually overridable toggles. A new provider means auditing dozens of
+  independent booleans. **Fix:** one declarative `ProviderCapabilities` record
+  per handler.
+- **`modelHandlerOpenAIResponse.ts` god class.** 94 methods; header comment
+  admits non-thread-safe instance state (`previousResponseId`,
+  `pendingBackgroundResponseId`, `conversationState`); juggles streaming vs
+  non-streaming, background polling, WebSocket transport, store:true chaining
+  vs encrypted-reasoning replay, and OpenRouter routing — and `ModelHandlerCodex`
+  extends it. **Fix:** extract the response-chaining state machine and the
+  background-poll lifecycle into collaborators (the WebSocket transport was
+  already split out; follow that precedent).
+- **Two Google handlers** (`GoogleInteractions` 2,154 + `GoogleGenAI` 1,204)
+  with overlapping-but-divergent chain/stateless logic for one vendor, plus a
+  hand-rolled chain-invalidation state machine expressed as scattered boolean
+  predicates. **Fix:** unify behind one handler with an explicit
+  `InteractionChain` collaborator, or record a sunset date for the GenAI path.
+- **Dual contract.** `types/IModelHandler.ts` (475 LoC, 33 signatures)
+  duplicates the abstract class surface by hand. **Fix:** derive one from the
+  other or delete the interface.
+
+Caveat, honoring this repo's documented "rejected traps" discipline: the fix is
+**not** a grand unified handler framework (call sites genuinely diverge per
+SDK). It's the three targeted hoists above — prefill template method,
+capabilities struct, chain-state collaborators — which shrink all handlers
+simultaneously without inventing a leaky abstraction. The usage layer
+(`UsageNormalizer` + thin adapters) already proves the pattern works here.
+
+### A2. Host-adapter wiring duplicated between extension and desktop (~4.5k LoC of drift-prone glue)
+
+The hard part was done right — controllers are shared — but each host
+hand-writes a 1,000+ LoC wiring layer around them:
+
+- Settings: `packages/extension/src/settingsView/SettingsViewMessageHandler.ts`
+  (1,012) and `packages/desktop/src/main/desktopSettingsIpc.ts` (1,286) **both**
+  call `createSettingsViewCommandHandlers(...)` (extension `:236`, desktop
+  `:1081`) and both instantiate the same controller factories, then each adds
+  ~500 LoC of bespoke `sendXData`/`postMessage` glue.
+- Execution/progress: `desktopAgentExecution.ts` (1,279) mirrors what the
+  extension spreads across `ProgressViewMessageHandler.ts` (889) +
+  `MainViewProvider.ts` + `agentEventListeners.ts`.
+- `src/shared/ipc/settingsViewCommands.ts` defines ~126 commands whose
+  command→handler mapping is authored twice, once per host.
+
+This seam is the single largest source of "works in extension, broken in
+desktop" bugs (the coupling audit's #6887 crash-repair gap was exactly this
+class of drift). **Fix:** a shared
+`createSettingsViewHost({ postMessage, secrets, state })` /
+`createAgentExecutionHost(...)` factory in `src/controllers/`, parameterized by
+a thin host-capability interface; each host shrinks to a ~100-line adapter.
+
+### A3. `MainApp.ts`: 1,915-line god component running three state mechanisms at once
+
+`packages/extension/src/webview/frontend/MainApp.ts` mixes 18 ad-hoc
+`signal(...)` fields (`:162-227`), 5 `@state`/`@provide` context fields, and a
+`PersistedState`/`createWebviewStorage` manager, with restore logic sprawled
+over three methods. The repo already contains the correct pattern —
+`progressView/frontend/` uses a store + 10 slice files with `mutative` — and
+MainApp simply predates it. Same story in miniature for
+`settingsView/frontend/SettingsApp.ts` (1,140) + `LaTeXTab.ts` (848).
+**Fix:** migrate MainApp/SettingsApp to the in-repo slice-store pattern; no new
+architecture needed.
+
+### A4. Test infrastructure: hand-rolled in-memory filesystem + 75 per-suite platform bootstraps
+
+- `src/test-kernel/support/FakePlatform.ts` is 788 lines, ~377 of which
+  (`:282-659`) are a bespoke in-memory filesystem (posix path math, error
+  codes, dir trees) that all **359** vitest suites (~62k LoC) trust and that can
+  silently diverge from `nodeFilesystem.ts` semantics. **Fix:** back
+  `FakeFileSystemProvider` with `memfs`.
+- `vitest.config.mjs` has no `setupFiles`, so platform bootstrap is repeated at
+  **75** `beforeEach`/`initPlatform` sites. **Fix:** a global setup installing a
+  default fake platform; suites override rather than re-init.
+
+### A5. Build/script/alias sprawl
+
+- `scripts/` holds ~30 `.mjs` files, ~7,850 lines, including a hand-rolled
+  JSON-comment stripper in `aliasUtils.mjs` (reimplements `strip-json-comments`)
+  whose own header admits the extension tsconfig "will silently follow the
+  root" on divergence.
+- Root `tsconfig.json` has **45 path aliases**; `@/*` and `~/*` are exact
+  duplicates, and several "shared" aliases (`@webview/*`, `@commands/*`,
+  `@settingsView/*`, …) point into `packages/extension/`, coupling core to one
+  host. `packages/desktop/tsconfig.paths.json` is a second hand-maintained copy.
+- Desktop carries 5 tsconfigs; `scripts/extension-package-invariants.snapshot.json`
+  is a 70 KB committed generated artifact (see B4 for the better end-state).
+- `patches/ink@7.1.0.patch` has no documented exit plan (upstream issue or
+  re-evaluation trigger on ink bumps).
+
+**Fixes:** use `tsconfck`/`strip-json-comments`; drop `~/*`; move host aliases
+into host tsconfigs and generate the desktop table from root; consolidate
+desktop tsconfigs via project references; document the ink-patch exit plan.
+
+### A6. Transcript persistence: four overlapping stores (2,856 LoC)
+
+`src/transcript/` — `StreamSnapshotStore.ts` (1,046), `StreamLogStore.ts`
+(814), `streamSnapshotRead.ts` (218), `StreamLog.ts` (185) — two big stores
+persisting the same conceptual per-run stream data plus a separate read path.
+The coupling audit's #6889 (vestigial pub-sub, headless sidecar gap) touches
+this area but not the structural overlap. **Fix:** one store interface with a
+single serialization format; the snapshot becomes a view over the log (or vice
+versa). Also fixes the CLI's synthetic-entry dedup at the source (see B2).
+
+### A7. Smaller, contained items
+
+- **Command-surface dual bookkeeping:** `extensionCommandSurface.ts` (538 LoC,
+  40 aliased imports, 111 command-id strings) hand-mirrors
+  `src/shared/commands/catalog.ts`, which desktop already consumes cleanly.
+  Drive extension registration fully from the catalog.
+- **CSS-in-TS sprawl:** ~6,000 LoC across 25+ `*Styles.ts` files;
+  `src/shared/styles/requestPanelStyles.ts` alone is 1,058. Split per-panel,
+  colocate, finish `designTokens` adoption.
+- **CLI god files:** `cliState.ts` (510) is a monolithic ~25-field
+  `StreamSlice` store where the extension deliberately uses 10 slices;
+  `App.tsx` (1,056) holds 11 signals **and** 15 props plus local `useState` for
+  view toggles (violates the CLAUDE.md signal-state rule);
+  `ChildControlPicker.tsx` (1,198) contains a third bespoke scroll/tail state
+  machine paralleling `useScrollableOffset.ts` and `transcriptScroll.ts`.
+- **Stray per-component interval:** `StatusBar.tsx:865` codex-subscription
+  poll bypasses the shared `useLiveNowMs` ticker (which otherwise landed —
+  the CLAUDE.md "shared Clock" item is ~done; ref-counted raw mode is not:
+  `runChatTui.tsx:900,:909` and `terminalCapabilities.ts:102,:132` still
+  toggle `setRawMode` directly).
+- **`ExecutionsTool.ts`** (951) and `extension.ts` `activate()` (814) /
+  desktop `main/index.ts` (978) are accretion files worth phase-splitting.
+
+---
+
+## Part B — documented debts where a much better solution exists
+
+### B1. Dual run-event taxonomy: stop maintaining two rails, make the bus a projection
+
+Documented state: `error-pipeline-and-ownership.md` ruled that new facts extend
+`AgentEvent` **or** `ProgressEventPayloads` (never new `bus.emit` from free
+zones), and SDK-readiness F-1 deferred the host-path re-routes — i.e. the two
+systems are treated as permanent parallel rails. Reality: the bus has 54+ event
+keys and ~110 emit sites plus a 645-line `ProgressEventHandler`, while
+`src/agent/trace/` is a clean 4-variant discriminated union already exported as
+the SDK contract. Every new run-visible fact is a two-vocabulary decision.
+
+**Better solution:** declare the trace the *only* emit path and reduce
+`ProgressEventPayloads` to a host-side projection — one adapter subscribing to
+`AgentEvent` and invoking UI callbacks. Per-event `bus.emit` sites delete
+incrementally (the `emitRuntimeEvent()` migration in `src/tools` already
+proved the mechanics). This turns the standing F-1 deferral into a terminal
+state instead of an indefinite dual-write discipline.
+
+### B2. CLI↔extension sharing: the documented rung-ladder targets approvals; the real duplication is the projection layer
+
+`tui-extension-sharing.md` (rungs 3–4 open) shares approval/proposal
+orchestration. But both frontends independently re-project the **entire**
+`ProgressEventPayloads` stream into view state: CLI
+`chat/tui/state/` (4,352 LoC: `subscribeApprovals` 534, `subscribeStreamLog`
+443, `subscribeRuntimeHost` 298, …) + `toolRenderers.tsx` (623 ANSI) versus the
+extension's `progressView/frontend/` (**18,788 LoC**: 10 slices + 3,196 LoC of
+formatters). `cliState.ts:1-6` still claims it "mirrors the webview's shape …
+so feature parity is a port, not a rewrite" — the shapes have already forked
+(one 25-field map-of-structs vs 10 slices). Only `normalizeToolUseData` is
+genuinely shared.
+
+**Better solution:** one host-neutral reducer in `src/shared` that folds
+`ProgressEventPayloads` (or, post-B1, `AgentEvent`) into a normalized
+per-stream view model, plus a shared per-tool **display model** (title,
+sections, status, elided output); the CLI and webview become thin ANSI/Lit
+paint layers. This also dissolves the CLI's fragile synthetic-entry machinery
+(`state/transcript.ts:35` dedup-by-normalized-text,
+`syntheticAfterSeq` splicing in `subscribeStreamLog.ts:385-411`) — the correct
+fix is upstream: emit the finalized assistant message into `StreamLogStore`
+with a stable id so synthetics/dedup disappear entirely.
+
+### B3. `@texra/core` "SDK boundary": declared done, but nothing enforces it
+
+`agent-sdk-readiness.md` marks Steps 1–7 landed and the checkpoint concludes
+"SDK-ready in shape." The artifact, though, is a single 134-line re-export
+barrel — `"private": true`, `main`/`exports` pointing at raw `./src/index.ts`,
+no emit build, excluded from root tsconfig — and its own header concedes deep
+`@agent/*` imports "are not being migrated in bulk." An unenforced boundary
+drifts by default.
+
+**Better solution:** pick one honestly. Either (a) enforce: an ESLint
+`no-restricted-imports` rule banning deep `@agent/*`/`@platform` imports from
+`packages/{cli,desktop,extension}` (allowlist the current offenders, ratchet
+down) plus a real build so the package is publishable; or (b) demote the
+framing from "curated public SDK" to "internal convenience barrel" in docs and
+CLAUDE.md. The costly state is the current middle: SDK claims without SDK
+guarantees.
+
+### B4. Config catalog: extend the documented plan to code-generate the manifest and delete the snapshot machinery
+
+`config-catalog-unification.md` proposes a catalog SSOT feeding the extension
+settings view and a CLI `/config`. The audit found the deeper cost sits in what
+that plan doesn't yet subsume: `packages/extension/package.json` is a 72 KB
+hand-maintained manifest (65 settings + 67 commands) synced by
+`sync-settings-configuration.mjs` and guarded by a **70 KB committed snapshot**
+(`extension-package-invariants.snapshot.json`) — and core still reads settings
+by raw string key (`config.get('texra.files.exclude', …)`), with feature-flag
+wrappers existing solely to hide that.
+
+**Better solution:** make the catalog generate *both* directions —
+`contributes.configuration`/`contributes.commands` in package.json **and** a
+typed `SettingKey` accessor map consumed via `platform().config` — then retire
+the snapshot+invariants scripts entirely (a codegen diff check replaces them).
+Same SSOT the proposal wants, but it deletes ~two scripts, a 70 KB artifact,
+and the whole silent-rename failure mode instead of adding a third surface.
+
+### B5. `ExecutionRegistry`: the SessionHandle work fixed *global-ness*, not cohesion
+
+The documented Step 7a–d/SessionHandle program (landed) made the registries
+injectable — but `src/agent/runtime/executionRegistry.ts` remains one 809-line
+class with 42 methods spanning 4–5 responsibilities: execution tracking,
+stop/kill/cascade-vs-detach policy, tool-use follow-up queueing, and manual
+compaction requests. **Better solution:** finish the job with a cohesion split
+(`ExecutionLifecycle`, `FollowUpRouter`, `CompactionRequests`) now that
+injection exists; the DI-cleanup doc's ISP step points here but never names
+this class as its largest instance.
+
+### B6. The PocketFlow `shared` bag: DI-cleanup targets the AgentCore bag; the flow bag is the bigger untyped surface
+
+`dependency-injection-cleanup.md` attacks the fat `AgentCore` context. The
+adjacent, undocumented instance: flow nodes make **184** `shared.X` accesses
+across **41 distinct keys** while the canonical `ToolUseRunShared`
+(`implementations/flows/tooluse/nodes/types.ts:38`) types only ~10 of them —
+ordering bugs between a node's `post()` write and a later node's `prep()` read
+surface only at runtime (guarded ad hoc by `assertPreparedShared`). The same
+file still carries `migrateSharedState` handling **three** legacy on-disk
+shapes. **Better solution:** typed per-flow context objects (or Zod-validated
+slice accessors) instead of the loose bag, and an expiry date for
+`migrateSharedState` once persisted runs age out.
+
+---
+
+## Suggested priority
+
+1. **A2 host-adapter factories** — highest bug-yield per line deleted; purely
+   mechanical; no design debate.
+2. **A1 model-handler hoists** (prefill template method → capabilities struct →
+   OpenAIResponse/Google collaborator splits) — largest raw mass; every
+   provider feature currently pays 4–5×.
+3. **B2 shared projection/display-model layer** — unblocks CLI feature parity
+   and deletes the synthetic-entry hacks; sequence after (or with) B1 so the
+   reducer folds the right event type.
+4. **B4 config codegen** — deletes tooling and a whole failure mode; small.
+5. **A4 test-infra** (`memfs` + global setup) — cheap, pays on every suite.
+6. **A3 MainApp slice migration, B3 boundary enforcement, A6 transcript store
+   unification, B5/B6 cohesion splits** — as-touched.

--- a/docs/proposals/tech-debt-audit-2026-07.md
+++ b/docs/proposals/tech-debt-audit-2026-07.md
@@ -113,9 +113,9 @@ wiring, not to deliberate host-specific flows already called out in
 `agent-runtime-ui-coupling-audit.md` (GitHub subscriptions, crash reporting,
 history export/rerun, provider-key differences, and similar platform seams).
 
-### A3. `MainApp.ts`: 1,915-line god component running three state mechanisms at once
+### A3. `MainApp.ts`: 1,887-line god component running three state mechanisms at once
 
-`packages/extension/src/webview/frontend/MainApp.ts` mixes 18 ad-hoc
+`packages/extension/src/webview/frontend/MainApp.ts` mixes 31 ad-hoc
 `signal(...)` fields in the class state block, 4 `@state()` fields (2 also
 `@provide()` context fields), and a `PersistedState`/`createWebviewStorage`
 manager, with restore logic sprawled over three methods. The repo already


### PR DESCRIPTION
Full-repo sweep cross-referenced against the existing proposal/audit corpus.
Part A: debts absent from the docs (model-handler 4-5x pipeline duplication,
extension/desktop host-adapter wiring duplication, MainApp tri-state god
component, hand-rolled test filesystem, build/alias sprawl, transcript store
overlap). Part B: documented debts with materially better end-states (trace
as single event rail, shared CLI/webview projection layer, enforced SDK
boundary, config codegen replacing the invariants snapshot, ExecutionRegistry
cohesion split, typed flow contexts).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NUaqvLGpbhRVpkVWBegH6B

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only additions with no runtime, build, or test changes.
> 
> **Overview**
> Adds two **documentation-only** proposals under `docs/proposals/`.
> 
> **`tech-debt-audit-2026-07.md`** is a full-repo sweep split into **Part A** (debts not previously in the corpus: model-handler 4–5× duplication, extension/desktop host wiring drift, MainApp tri-state, test `FakePlatform`/`memfs`, build aliases, transcript store overlap, etc.) and **Part B** (revised end-states for documented debts: trace/bus duplication targets, shared CLI/webview projection layer, `@texra/core` enforcement, config codegen vs snapshot, narrowed `ExecutionRegistry` debt, typed flow `shared` bag). It includes an appendix on event/logger and execution mechanics and a suggested priority order.
> 
> **`session-scoped-runtime-architecture.md`** is the companion **target design** for B1/B5: scope run facts, host RPC, and status to `SessionHandle` via three planes (`session.events`, `session.interactions`, `session.runs` + `session.status`), document multi-window leak symptoms (global stream log store, shared bus, shared `StreamStatusService`), map current artifacts to replacements, a five-stage shippable migration (via `defaultSession()`), and rejected alternatives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d3a4dbfd28ef5b1a43f8874b26bc3f250ae1321. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->