### PR TITLE
fix(ci): disable npm provenance for CLI publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,4 +129,9 @@ jobs:
 
       - name: Publish @texra-ai/cli
         working-directory: packages/cli
+        # Provenance attestation requires a public source repository; this repo
+        # is private, so trusted-publishing auth still works but provenance
+        # generation must be disabled or npm rejects the publish with a 422.
+        env:
+          NPM_CONFIG_PROVENANCE: 'false'
         run: npm publish

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@texra-ai/cli",
-  "version": "0.39.3",
+  "version": "0.39.2",
   "description": "TeXRA CLI — your AI theorist in the terminal.",
   "license": "SEE LICENSE IN LICENSE.txt",
   "author": "TeXRA.ai",


### PR DESCRIPTION
## Summary
- The new `release.yml` (#6932) publishes `@texra-ai/cli` via npm Trusted Publishing (OIDC). The first live run (`cli-v0.39.2`) failed: npm rejected the publish with `422 Unprocessable Entity — Unsupported GitHub Actions source repository visibility: "private". Only public source repositories are supported when publishing with provenance.` Trusted-publishing auth itself works fine from a private repo, but automatic provenance generation does not — npm's own docs confirm this is unsupported for private source repos, disable-able via `NPM_CONFIG_PROVENANCE=false`.
- Sets `NPM_CONFIG_PROVENANCE: 'false'` on the `Publish @texra-ai/cli` step so the OIDC-authenticated publish proceeds without attempting provenance.
- Reverts `packages/cli/package.json` from `0.39.3` back to `0.39.2` so the existing `cli-v0.39.2` tag/release/changelog entry can be retried once this merges, rather than skipping straight to `0.39.3` for a version that never actually shipped.

## Test plan
- After merge, delete + recreate the `cli-v0.39.2` tag/release pointing at this commit to retrigger `release.yml` with the fix, then verify `npm view @texra-ai/cli versions` includes `0.39.2`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release workflow and package version alignment only; no runtime or application logic changes.
> 
> **Overview**
> Fixes **failed `@texra-ai/cli` npm publishes** from the private repo: npm returns **422** when Trusted Publishing tries to attach provenance, which only supports **public** source repositories.
> 
> The **Publish @texra-ai/cli** step in `release.yml` now sets **`NPM_CONFIG_PROVENANCE: 'false'`** so OIDC trusted publishing still works without provenance generation.
> 
> **`packages/cli/package.json`** is bumped back from **`0.39.3` to `0.39.2`** so the existing **`cli-v0.39.2`** release can be retried instead of skipping a version that never shipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44867cf8806b7173502ac0cfc0e9692047e83519. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->