### PR TITLE
chore: bump CLI version to 0.39.3

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@texra-ai/cli",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "TeXRA CLI — your AI theorist in the terminal.",
   "license": "SEE LICENSE IN LICENSE.txt",
   "author": "TeXRA.ai",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  ink@7.1.0: db8f5740efe4e780f6517316175dfed1e68d62e76e533c06bf0b8f5e94b48aa6
+  ink@7.1.0:
+    hash: db8f5740efe4e780f6517316175dfed1e68d62e76e533c06bf0b8f5e94b48aa6
+    path: patches/ink@7.1.0.patch
 
 importers:
 


### PR DESCRIPTION
## Summary
- The `0.39.2` CLI release (#6947) was cut manually by deleting/recreating the `cli-v0.39.2` tag after fixing the provenance-publish bug, so `version-bump.yml` (which only fires off the plain `vX.Y.Z` extension tag) never ran for it.
- Every other manifest had already moved to `0.39.3` from the prior auto-bump; `packages/cli/package.json` was left behind at `0.39.2`. This brings it back in line.

## Test plan
- N/A — version/lockfile bump only, `npm view @texra-ai/cli versions` already confirms `0.39.2` published successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and lockfile-only changes with no runtime or application logic updates.
> 
> **Overview**
> Aligns **`@texra-ai/cli`** in `packages/cli/package.json` with **`0.39.3`** after the manual `0.39.2` release skipped the normal version-bump workflow.
> 
> Also updates **`pnpm-lock.yaml`** so the **`ink@7.1.0`** patched dependency entry uses the expanded `hash` / `path` form instead of the single-line mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7311b0564a8c94bac09de7468fa06ef3b3bc2ba7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->