### PR TITLE
ci: switch Claude-powered actions to Sonnet 5

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -105,7 +105,7 @@ jobs:
         uses: LionSR/agent-ci-actions@v1
         with:
           provider: ${{ matrix.provider }}
-          model-tier: opus
+          model-tier: sonnet
           allowed-bots: 'claude[bot],cursor[bot],cursor,copilot-pull-request-reviewer[bot]'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'

--- a/.github/workflows/claude-dispatch.yml
+++ b/.github/workflows/claude-dispatch.yml
@@ -36,8 +36,8 @@ jobs:
           # Optional: Specify an API key, otherwise we'll use your Claude account automatically
           # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          model: 'claude-opus-4-7'
+          # Optional: Specify model (defaults to Claude Sonnet 4)
+          model: 'claude-sonnet-5'
 
           # Optional: Allow Claude to run specific commands
           allowed_tools: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -79,7 +79,7 @@ jobs:
         uses: LionSR/agent-ci-actions@v1
         with:
           provider: ${{ env.CLAUDE_CODE_PROVIDER }}
-          model-tier: opus
+          model-tier: sonnet
           allowed-bots: 'claude[bot],cursor[bot],cursor,copilot-pull-request-reviewer[bot]'
           branch-name-template: '{{prefix}}{{entityType}}-{{entityNumber}}-{{description}}'
           allowed_tools_preset: claude-interactive

--- a/.github/workflows/issue-tracker.yml
+++ b/.github/workflows/issue-tracker.yml
@@ -138,7 +138,7 @@ jobs:
         uses: LionSR/agent-ci-actions@v1
         with:
           provider: ${{ env.CLAUDE_CODE_PROVIDER }}
-          model-tier: opus
+          model-tier: sonnet
           allowed-bots: 'dependabot[bot],github-actions[bot],Copilot,claude[bot],cursor[bot]'
           allowed_tools_preset: issue-tracker
           allowed_tools_preset_map_file: .trusted-actions/.github/allowed-tools.json

--- a/.github/workflows/repository-quality-improver.yml
+++ b/.github/workflows/repository-quality-improver.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: LionSR/agent-ci-actions@v1
         with:
           provider: ${{ env.CLAUDE_CODE_PROVIDER }}
-          model-tier: opus
+          model-tier: sonnet
           allowed-bots: 'github-actions[bot]'
           allowed_tools_preset: quality-improver
           allowed_tools_preset_map_file: .github/allowed-tools.json


### PR DESCRIPTION
## Summary
- Switches `model-tier` from `opus` to `sonnet` in `claude-code-review.yml`, `claude.yml`, `issue-tracker.yml`, and `repository-quality-improver.yml`. `issue-tree.yml` was already `sonnet`-tier.
- Switches `claude-dispatch.yml`'s hardcoded `model: 'claude-opus-4-7'` to `model: 'claude-sonnet-5'` (this workflow uses `anthropics/claude-code-action` directly, not the tiered wrapper).
- Paired with two repo variable changes (already applied, not part of this diff):
  - `CLAUDE_SONNET_MODEL=claude-sonnet-5` — all five wrapper-based workflows already thread `vars.CLAUDE_SONNET_MODEL` into env; without this the `sonnet` tier would resolve to the wrapper's old default (`claude-sonnet-4-6`).
  - `CLAUDE_CODE_PROVIDER=anthropic` (was `deepseek`) — `claude.yml`, `issue-tracker.yml`, `repository-quality-improver.yml`, and `issue-tree.yml` all read this var to select their provider, so it had to move off `deepseek` for the Sonnet 5 override to actually take effect.
- `claude-code-review.yml` keeps its existing `anthropic` + `deepseek` provider matrix as-is — running both is fine there since review comments are read-only/additive. The other four workflows stay single-provider on purpose: they take actions (filing follow-up issues, pushing commits, editing issues), so running two providers would double-execute those side effects.

## Test plan
- Open a PR to see `claude-code-review.yml`'s anthropic leg run Sonnet 5.
- Mention `@claude` on an issue/PR to exercise `claude.yml`.
- Merge a PR to exercise `issue-tracker.yml`'s Playbook B2 follow-up scan.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only model selection changes with no application code or security logic touched; main risk is different model quality/cost on the same bot side effects.
> 
> **Overview**
> Moves all **LionSR/agent-ci-actions** workflows from **`model-tier: opus`** to **`model-tier: sonnet`**: PR code review, `@claude` interactive runs, issue tracker, and the scheduled quality improver. **`claude-dispatch.yml`** (direct **`anthropics/claude-code-action`**) now pins **`claude-sonnet-5`** instead of **`claude-opus-4-7`**, with a small comment cleanup.
> 
> Behavior and permissions are unchanged—only which model tier/name the bots use. Effective Sonnet 5 resolution still depends on repo variables such as **`CLAUDE_SONNET_MODEL`** and **`CLAUDE_CODE_PROVIDER`** (not in this diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50a43b83b003873edba2dae433d8a787198aae08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->