### PR TITLE
[codex] serialize goal index mutations

### DIFF
--- a/src/test-kernel/tools/GoalStoreConcurrency.vitest.ts
+++ b/src/test-kernel/tools/GoalStoreConcurrency.vitest.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import { createFakePlatform } from '@test/support/FakePlatform';
+import type { StreamTabId } from '@shared/schemas';
+import { GoalStore } from '@tools/goal';
+import type { StateStore } from '@platform/interfaces/state';
+
+const STREAM_A = 'stream:concurrent-goal-a' as StreamTabId;
+const STREAM_B = 'stream:concurrent-goal-b' as StreamTabId;
+
+class BlockingFirstIndexWriteState implements StateStore {
+  private readonly values = new Map<string, unknown>();
+
+  private pendingIndexWrite: {
+    value: unknown;
+    resolve: () => void;
+  } | null = null;
+
+  private readonly pendingWaiters: Array<() => void> = [];
+
+  private shouldBlockNextIndexWrite = true;
+
+  get<T>(key: string, defaultValue?: T): T {
+    if (!this.values.has(key)) {
+      return defaultValue as T;
+    }
+    return this.values.get(key) as T;
+  }
+
+  update(key: string, value: unknown): Promise<void> {
+    if (key === 'goals:index' && this.shouldBlockNextIndexWrite) {
+      this.shouldBlockNextIndexWrite = false;
+      return new Promise((resolve) => {
+        this.pendingIndexWrite = { value, resolve };
+        for (const waiter of this.pendingWaiters.splice(0)) waiter();
+      });
+    }
+
+    this.applyUpdate(key, value);
+    return Promise.resolve();
+  }
+
+  waitForBlockedIndexWrite(): Promise<void> {
+    if (this.pendingIndexWrite) {
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      this.pendingWaiters.push(resolve);
+    });
+  }
+
+  releaseBlockedIndexWrite(): void {
+    if (!this.pendingIndexWrite) {
+      throw new Error('No blocked index write to release.');
+    }
+    const pending = this.pendingIndexWrite;
+    this.pendingIndexWrite = null;
+    this.applyUpdate('goals:index', pending.value);
+    pending.resolve();
+  }
+
+  private applyUpdate(key: string, value: unknown): void {
+    if (value === undefined) {
+      this.values.delete(key);
+      return;
+    }
+    this.values.set(key, value);
+  }
+}
+
+describe('GoalStore index concurrency', () => {
+  it('keeps both entries when concurrent start() calls overlap during the index write', async () => {
+    const { initPlatform } = await import('@platform/platform');
+    const state = new BlockingFirstIndexWriteState();
+    initPlatform(createFakePlatform({}, { workspaceState: state }));
+
+    const firstStart = GoalStore.start(STREAM_A, 'objective a');
+    await state.waitForBlockedIndexWrite();
+
+    const secondStart = GoalStore.start(STREAM_B, 'objective b');
+    await Promise.resolve();
+
+    state.releaseBlockedIndexWrite();
+    await Promise.all([firstStart, secondStart]);
+
+    expect(
+      GoalStore.list()
+        .map((goal) => goal.streamId)
+        .toSorted(),
+    ).toEqual([STREAM_A, STREAM_B].toSorted());
+    expect(state.get<StreamTabId[]>('goals:index', []).toSorted()).toEqual(
+      [STREAM_A, STREAM_B].toSorted(),
+    );
+  });
+});

--- a/src/tools/goal/goalStore.ts
+++ b/src/tools/goal/goalStore.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { Mutex } from 'async-mutex';
 
 import { platform, tryWorkspaceState } from '@platform/platform';
 import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
@@ -27,6 +28,7 @@ const LEGACY_INDEX_KEY = 'odysseys:index';
 // Stream index growth is user-driven (one entry per stream that ever had
 // a Goal). `forget()` removes entries; callers that delete a stream
 // without calling `forget()` leave dangling entries until next manual cleanup.
+const indexMutex = new Mutex();
 
 function streamKey(streamId: StreamTabId): string {
   return `${STREAM_KEY_PREFIX}${streamId}`;
@@ -107,9 +109,9 @@ function readIndex(): StreamTabId[] {
 }
 
 async function addToIndex(streamId: StreamTabId): Promise<void> {
-  const index = readIndex();
-  if (index.includes(streamId)) return;
-  await platform().workspaceState.update(INDEX_KEY, [...index, streamId]);
+  await mutateIndex((index) =>
+    index.includes(streamId) ? index : [...index, streamId],
+  );
 }
 
 /**
@@ -134,12 +136,20 @@ function buildIndexWriteOps(
 }
 
 async function removeFromIndex(streamId: StreamTabId): Promise<void> {
-  const state = tryWorkspaceState();
-  if (!state) return;
-  const hasLegacyIndex = state.get<unknown>(LEGACY_INDEX_KEY) != null;
-  const index = readIndex();
-  const next = index.filter((id) => id !== streamId);
-  await Promise.all(buildIndexWriteOps(state, index, next, hasLegacyIndex));
+  await mutateIndex((index) => index.filter((id) => id !== streamId));
+}
+
+async function mutateIndex(
+  mutate: (index: StreamTabId[]) => StreamTabId[],
+): Promise<void> {
+  await indexMutex.runExclusive(async () => {
+    const state = tryWorkspaceState();
+    if (!state) return;
+    const hasLegacyIndex = state.get<unknown>(LEGACY_INDEX_KEY) != null;
+    const index = readIndex();
+    const next = mutate(index);
+    await Promise.all(buildIndexWriteOps(state, index, next, hasLegacyIndex));
+  });
 }
 
 /**
@@ -306,14 +316,11 @@ export const GoalStore = {
         state.get<unknown>(legacyStreamKey(id)) != null,
     );
     if (toRemove.length === 0) return;
-    const hasLegacyIndex = state.get<unknown>(LEGACY_INDEX_KEY) != null;
-    const index = readIndex();
     const dropped = new Set(toRemove);
-    const nextIndex = index.filter((id) => !dropped.has(id));
     await Promise.all([
       ...toRemove.map((id) => state.update(streamKey(id), undefined)),
       ...toRemove.map((id) => state.update(legacyStreamKey(id), undefined)),
-      ...buildIndexWriteOps(state, index, nextIndex, hasLegacyIndex),
+      mutateIndex((index) => index.filter((id) => !dropped.has(id))),
     ]);
     for (const id of toRemove)
       emitRuntimeEvent('goalStateChanged', { streamId: id });


### PR DESCRIPTION
## Summary

Serialize GoalStore stream-index read-modify-write cycles through one in-module mutex. This prevents overlapping `GoalStore.start()` calls from both reading the same pre-write index and losing one stream entry.

Re-verified the cited #6956 evidence against the current tree before implementing: `goalStore.addToIndex` still performed `readIndex()` -> membership check -> `workspaceState.update(INDEX_KEY, ...)`, and `removeFromIndex` / `forgetMany` were the other index mutation paths.

## Issue acceptance gates

- #6956 concurrent `start()` on two streams results in both entries present: added `GoalStoreConcurrency.vitest.ts` with a delayed first index write and overlapping second start.
- `npm run typecheck`: green.
- `npm test`: green.

## Single source of truth

`src/tools/goal/goalStore.ts` now owns `goals:index` mutation through `mutateIndex(...)`; add, remove, and bulk-remove all share that path.

## Duplication and abstraction budget

Removed three separate index read-modify-write implementations for add/remove/bulk-remove. The new helper owns the invariant "read the unioned current+legacy index and write the next index under one lock"; it is not a pass-through layer. This PR is line-positive because the added mass lives in the focused regression harness that recreates the dropped-entry interleaving.

## Host impact

Extension:

- No host API or UI changes; goal index persistence becomes race-safe.

Desktop:

- No host API or UI changes; same `GoalStore` behavior.

CLI:

- No headless output changes; same `GoalStore` persistence behavior.

## Scheduled refactoring

None. No shim, fallback, dual-write, projection, or migration path added.

## Validation

- `corepack pnpm exec prettier --write src/tools/goal/goalStore.ts src/test-kernel/tools/GoalStoreConcurrency.vitest.ts`
- `npm test -- src/test-kernel/tools/GoalStoreConcurrency.vitest.ts src/test-kernel/tools/GoalForget.vitest.ts src/test-kernel/tools/GoalLegacyMigration.vitest.ts`
- `npm run typecheck`
- `npm test`
- `npm run compile:fast`
- `npm run lint` (0 errors; 17 pre-existing warnings outside touched files)
- `npm test -- src/test-kernel/tools/GoalStoreConcurrency.vitest.ts`
- `git diff --check`

Closes #6956

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workspace persistence for the goal stream index; behavior is localized to GoalStore but incorrect indexing could hide goals until fixed.
> 
> **Overview**
> Fixes a race where overlapping **`GoalStore.start()`** calls could both read the same **`goals:index`** snapshot and drop one stream from the index.
> 
> **`goalStore.ts`** routes all index read-modify-write work through a shared **`mutateIndex`** helper guarded by an in-module **`async-mutex`** mutex. **`addToIndex`**, **`removeFromIndex`**, and the index step in **`forgetMany`** now use that path instead of duplicating index logic.
> 
> Adds **`GoalStoreConcurrency.vitest.ts`**, which uses a fake **`StateStore`** that blocks the first **`goals:index`** write so two concurrent **`start()`** calls must both appear in **`GoalStore.list()`** and persisted index state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 918c3c09f168e871a2acbaef2081efb59a1bebaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->