### PR TITLE
Stage 0: add StreamPhase vocabulary shims

### DIFF
--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -151,7 +151,7 @@ export async function executeCliToolUseConfig(
   const { result, terminalStatus } = execution;
   return {
     ok: true,
-    displayResult: createCliRunResult(result, terminalStatus, {
+    displayResult: createCliRunResult(result, {
       workingDirectory: runContext.cwd,
     }),
     exitCode: terminalStatusExitCode(terminalStatus, runContext),

--- a/packages/cli/src/runtime/terminalStatus.ts
+++ b/packages/cli/src/runtime/terminalStatus.ts
@@ -1,11 +1,14 @@
 import { getExecutionStore } from '@agent/storage';
 import { runAgent } from '@agent/runtime/runAgent';
 
-import { projectRunOutcome } from '@common/constants/streamStatus';
+import {
+  legacyEndGroupStatusForOutcome,
+  runOutcomeToExecutionStatus,
+} from '@common/constants/streamStatus';
 import {
   EXECUTION_STATUS,
-  ExecutionStatusSchema,
   type ExecutionStatus,
+  type RunOutcome,
 } from '@shared/schemas';
 
 import { hasCliApprovalDenied } from './approvalAdapter';
@@ -15,9 +18,11 @@ import type { CliContext } from './cliContext';
 export type ExecuteAgentResult = Awaited<ReturnType<typeof runAgent>>;
 
 type CliRunResultFor<T extends ExecuteAgentResult> = T & {
+  /** @deprecated Use `outcome`; this is a frozen projection for JSON-output compatibility. */
   status: ExecutionStatus;
-  /** Legacy 2-value projection kept for JSON-output compatibility. */
+  /** @deprecated Use `outcome`; this is a frozen 2-value projection for JSON-output compatibility. */
   endGroupStatus: 'error' | 'stopped';
+  /** @deprecated Use `outcome`; this is a frozen projection for JSON-output compatibility. */
   terminalStatus: ExecutionStatus;
   workingDirectory?: string;
   runDirectory?: string;
@@ -30,13 +35,6 @@ export type CliRunResult = ExecuteAgentResult extends infer T
     ? CliRunResultFor<T>
     : never
   : never;
-
-function isExecutionStatus(
-  value: string | undefined,
-): value is ExecutionStatus {
-  // Schema is the source of truth — no hand-maintained value list.
-  return ExecutionStatusSchema.safeParse(value).success;
-}
 
 export type CliToolUseRunResult = Extract<
   CliRunResult,
@@ -54,15 +52,13 @@ export function toolUseResultText(result: CliToolUseRunResult): string {
 
 export function cliTerminalStatus(
   result: ExecuteAgentResult,
-  storedTerminalStatus?: string,
+  storedOutcome?: RunOutcome,
 ): ExecutionStatus {
-  if (isExecutionStatus(storedTerminalStatus)) return storedTerminalStatus;
-  return projectRunOutcome(result.outcome).executionStatus;
+  return runOutcomeToExecutionStatus(storedOutcome ?? result.outcome);
 }
 
 export function createCliRunResult<T extends ExecuteAgentResult>(
   result: T,
-  terminalStatus: ExecutionStatus,
   extras: {
     readonly workingDirectory?: string;
     readonly runDirectory?: string;
@@ -70,10 +66,11 @@ export function createCliRunResult<T extends ExecuteAgentResult>(
     readonly copiedOutputs?: string[];
   } = {},
 ): T extends ExecuteAgentResult ? CliRunResultFor<T> : never {
+  const terminalStatus = runOutcomeToExecutionStatus(result.outcome);
   return {
     ...result,
     status: terminalStatus,
-    endGroupStatus: projectRunOutcome(result.outcome).endGroupStatus,
+    endGroupStatus: legacyEndGroupStatusForOutcome(result.outcome),
     terminalStatus,
     ...extras,
   } as T extends ExecuteAgentResult ? CliRunResultFor<T> : never;
@@ -102,5 +99,5 @@ export async function readCliTerminalStatus(
   const meta = await getExecutionStore(result.executionId)
     .readMeta()
     .catch(() => undefined);
-  return cliTerminalStatus(result, meta?.terminalStatus);
+  return cliTerminalStatus(result, meta?.outcome);
 }

--- a/packages/cli/src/runtime/workflowOutput.ts
+++ b/packages/cli/src/runtime/workflowOutput.ts
@@ -204,7 +204,7 @@ export async function resolveWorkflowOutput(
   const { terminalStatus } = options;
   if (result.outputs.length === 0 && (outputFile || outputDir)) {
     if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) {
-      return createCliRunResult(result, terminalStatus, {
+      return createCliRunResult(result, {
         workingDirectory: context.cwd,
       });
     }
@@ -255,7 +255,7 @@ export async function resolveWorkflowOutput(
       );
     }
 
-    return createCliRunResult(result, terminalStatus, {
+    return createCliRunResult(result, {
       workingDirectory: context.cwd,
       runDirectory,
       copiedOutputs,
@@ -263,7 +263,7 @@ export async function resolveWorkflowOutput(
   }
 
   if (!outputFile) {
-    return createCliRunResult(result, terminalStatus, {
+    return createCliRunResult(result, {
       workingDirectory: context.cwd,
       runDirectory,
     });
@@ -271,7 +271,7 @@ export async function resolveWorkflowOutput(
 
   const finalOutput = latestWorkflowOutput(result.outputs);
   if (!finalOutput) {
-    return createCliRunResult(result, terminalStatus, {
+    return createCliRunResult(result, {
       workingDirectory: context.cwd,
       runDirectory,
     });
@@ -283,7 +283,7 @@ export async function resolveWorkflowOutput(
     await fs.copyFile(finalOutput.absolutePath, targetPath);
   }
 
-  return createCliRunResult(result, terminalStatus, {
+  return createCliRunResult(result, {
     workingDirectory: context.cwd,
     runDirectory,
     copiedOutput: targetPath,

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -54,12 +54,14 @@ import type { DiffViewHost, ExternalOpener } from '@hosts/uiHosts';
 import { createChannelTrace } from '@logger';
 import type { MainViewExecuteMessage } from '@shared/mainView';
 import {
+  STREAM_PHASE,
   STREAM_STATUS,
   type AgentProposalPermission,
   type AgentCategoryFilter,
   type MainViewPersistedState,
   type ProgressViewOutboundMessage,
   type ExecutionId,
+  type StreamPhase,
   type StreamTabId,
   streamStatusesWithTrait,
 } from '@shared/schemas';
@@ -112,6 +114,10 @@ const DESKTOP_UNAVAILABLE_TOOLS: readonly DesktopUnavailableTool[] = [
   DIAGNOSTICS_ADD_RUNTIME_CAPABILITY,
 ];
 const RESTART_REPAIR_STATUSES = streamStatusesWithTrait('inFlight');
+const RESTART_REPAIR_PHASES: ReadonlySet<StreamPhase> = new Set([
+  STREAM_PHASE.RUNNING,
+  STREAM_PHASE.WAITING,
+]);
 
 export interface DesktopAgentExecutionOptions {
   postToRenderer(message: unknown): boolean | void;
@@ -677,7 +683,7 @@ export class DesktopProgressBridge {
       }
       const currentStatus = StreamStatusService.get(streamId);
       if (
-        RESTART_REPAIR_STATUSES.has(snapshot.lastKnownStatus) ||
+        RESTART_REPAIR_PHASES.has(snapshot.lastKnownStatus) ||
         (currentStatus != null && RESTART_REPAIR_STATUSES.has(currentStatus))
       ) {
         repairStreams.add(streamId);

--- a/packages/desktop/src/main/desktopProgressEventBridge.ts
+++ b/packages/desktop/src/main/desktopProgressEventBridge.ts
@@ -14,7 +14,9 @@ import type { AgentTrace } from '@agent/trace';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { bus, type ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import {
-  STREAM_STATUS,
+  STREAM_PHASE,
+  streamPhaseToStreamStatus,
+  streamStatusToPhase,
   type ProgressViewOutboundMessage,
   type RestoredStreamSnapshot,
   type StreamTabId,
@@ -179,9 +181,11 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
         parentStreamId: snapshot.parentStreamId,
         description: snapshot.description,
       });
-      StreamStatusService.set(snapshot.streamId, snapshot.lastKnownStatus, {
-        emit: false,
-      });
+      StreamStatusService.set(
+        snapshot.streamId,
+        streamPhaseToStreamStatus(snapshot.lastKnownStatus),
+        { emit: false },
+      );
     }
   }
 
@@ -386,6 +390,7 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
     const taskState = this.opts.state.snapshots.getTaskState(streamId);
     const info = buildStreamInfo(this.opts.state, streamId, 'all');
     const restored = this.restoredStreams.get(streamId);
+    const currentStatus = StreamStatusService.get(streamId);
     const snapshot: RestoredStreamSnapshot = {
       streamId,
       label: info?.label ?? restored?.label ?? streamId,
@@ -396,10 +401,9 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
         AgentCategory.Workflow,
       inputFile: info?.inputFile || restored?.inputFile,
       instruction: taskState?.agentConfig.instruction || restored?.instruction,
-      lastKnownStatus:
-        StreamStatusService.get(streamId) ??
-        restored?.lastKnownStatus ??
-        STREAM_STATUS.STOPPED,
+      lastKnownStatus: currentStatus
+        ? streamStatusToPhase(currentStatus)
+        : (restored?.lastKnownStatus ?? STREAM_PHASE.COMPLETED),
       description: info?.description ?? restored?.description,
       executionId: info?.executionId ?? restored?.executionId,
       parentStreamId: info?.parentStreamId ?? restored?.parentStreamId,

--- a/packages/desktop/src/main/desktopStreamSnapshot.ts
+++ b/packages/desktop/src/main/desktopStreamSnapshot.ts
@@ -25,15 +25,18 @@ import { z } from 'zod';
 import { JsonStore } from '@platform/defaults/jsonStore';
 import {
   RestoredStreamsFileSchema,
-  STREAM_STATUS,
-  streamStatusesWithTrait,
+  STREAM_PHASE,
   type RestoredStreamSnapshot,
   type RestoredStreamsFile,
+  type StreamPhase,
   type StreamTabId,
 } from '@shared/schemas';
 
 const STREAMS_KEY = 'restoredStreams';
-const RESTART_REPAIR_STATUSES = streamStatusesWithTrait('inFlight');
+const RESTART_REPAIR_PHASES: ReadonlySet<StreamPhase> = new Set([
+  STREAM_PHASE.RUNNING,
+  STREAM_PHASE.WAITING,
+]);
 
 export interface DesktopStreamSnapshotStore {
   /**
@@ -138,12 +141,12 @@ function parseHydrated(
     );
     return [];
   }
-  // Preserve in-flight states so startup repair can classify them. A finished
-  // or already-inert prior state remains an inactive ghost on the next launch.
+  // Preserve in-flight phases so startup repair can classify them. A finished
+  // or already-inert prior phase remains an inactive ghost on the next launch.
   return parsed.data.streams.map((s) => ({
     ...s,
-    lastKnownStatus: RESTART_REPAIR_STATUSES.has(s.lastKnownStatus)
+    lastKnownStatus: RESTART_REPAIR_PHASES.has(s.lastKnownStatus)
       ? s.lastKnownStatus
-      : STREAM_STATUS.STOPPED,
+      : STREAM_PHASE.COMPLETED,
   }));
 }

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -13,11 +13,18 @@ import {
   commonViewStyles,
 } from '@shared/styles';
 import {
+  STREAM_PHASE,
   STREAM_STATUS,
+  STREAM_SUBSTATE,
   type ConversationProgress,
   type StreamTabInfo,
 } from '@shared/schemas';
-import { formatStreamStatusLabel } from '@shared/streams/streamStatusDisplay';
+import {
+  formatStreamStatusLabel,
+  streamStatusDisplayKey,
+  streamStatusIndicatorClass,
+  type StreamStatusDisplayKey,
+} from '@shared/streams/streamStatusDisplay';
 import { statusIndicatorStyles } from '@shared/styles/statusIndicatorStyles';
 import {
   TEXRA_ICON_LIBRARY,
@@ -53,15 +60,18 @@ interface ToolbarButton {
 }
 
 /**
- * Buttons enabled per status - pre-computed as Sets to avoid
+ * Buttons enabled per phase/substate - pre-computed as Sets to avoid
  * allocating a new Set on every getButtonState() call during render.
  */
-const ENABLED_BUTTONS_BY_STATUS: Record<string, Set<string>> = {
-  [STREAM_STATUS.INITIALIZING]: new Set([
+const ENABLED_BUTTONS_BY_DISPLAY_KEY: Record<
+  StreamStatusDisplayKey,
+  Set<string>
+> = {
+  [STREAM_SUBSTATE.STARTING]: new Set([
     ELEMENT_IDS.STOP_STREAM_BTN,
     ELEMENT_IDS.CLEAN_STREAM_BTN,
   ]),
-  [STREAM_STATUS.RUNNING]: new Set([
+  [STREAM_PHASE.RUNNING]: new Set([
     ELEMENT_IDS.STOP_STREAM_BTN,
     ELEMENT_IDS.YOLO_TOGGLE_BTN,
     ELEMENT_IDS.SUPER_YOLO_TOGGLE_BTN,
@@ -69,7 +79,7 @@ const ENABLED_BUTTONS_BY_STATUS: Record<string, Set<string>> = {
     ELEMENT_IDS.RESTORE_STATE_BTN,
     ELEMENT_IDS.OPEN_TASK_STORAGE_BTN,
   ]),
-  [STREAM_STATUS.ERROR]: new Set([
+  [STREAM_PHASE.FAILED]: new Set([
     ELEMENT_IDS.RUN_NEW_BTN,
     ELEMENT_IDS.RESUME_BTN,
     ELEMENT_IDS.PACK_STREAM_BTN,
@@ -78,7 +88,7 @@ const ENABLED_BUTTONS_BY_STATUS: Record<string, Set<string>> = {
     ELEMENT_IDS.DIFF_STREAM_BTN,
     ELEMENT_IDS.OPEN_TASK_STORAGE_BTN,
   ]),
-  [STREAM_STATUS.STOPPED]: new Set([
+  [STREAM_PHASE.COMPLETED]: new Set([
     ELEMENT_IDS.RUN_NEW_BTN,
     ELEMENT_IDS.RESUME_BTN,
     ELEMENT_IDS.PACK_STREAM_BTN,
@@ -87,7 +97,16 @@ const ENABLED_BUTTONS_BY_STATUS: Record<string, Set<string>> = {
     ELEMENT_IDS.DIFF_STREAM_BTN,
     ELEMENT_IDS.OPEN_TASK_STORAGE_BTN,
   ]),
-  [STREAM_STATUS.READY]: new Set([
+  [STREAM_PHASE.CANCELLED]: new Set([
+    ELEMENT_IDS.RUN_NEW_BTN,
+    ELEMENT_IDS.RESUME_BTN,
+    ELEMENT_IDS.PACK_STREAM_BTN,
+    ELEMENT_IDS.CLEAN_STREAM_BTN,
+    ELEMENT_IDS.RESTORE_STATE_BTN,
+    ELEMENT_IDS.DIFF_STREAM_BTN,
+    ELEMENT_IDS.OPEN_TASK_STORAGE_BTN,
+  ]),
+  ready: new Set([
     ELEMENT_IDS.RUN_NEW_BTN,
     ELEMENT_IDS.PACK_STREAM_BTN,
     ELEMENT_IDS.CLEAN_STREAM_BTN,
@@ -95,7 +114,7 @@ const ENABLED_BUTTONS_BY_STATUS: Record<string, Set<string>> = {
     ELEMENT_IDS.DIFF_STREAM_BTN,
     ELEMENT_IDS.OPEN_TASK_STORAGE_BTN,
   ]),
-  [STREAM_STATUS.WAITING]: new Set([
+  [STREAM_PHASE.WAITING]: new Set([
     ELEMENT_IDS.STOP_STREAM_BTN,
     ELEMENT_IDS.YOLO_TOGGLE_BTN,
     ELEMENT_IDS.SUPER_YOLO_TOGGLE_BTN,
@@ -103,7 +122,7 @@ const ENABLED_BUTTONS_BY_STATUS: Record<string, Set<string>> = {
     ELEMENT_IDS.RESTORE_STATE_BTN,
     ELEMENT_IDS.OPEN_TASK_STORAGE_BTN,
   ]),
-  [STREAM_STATUS.RESUMING]: new Set([
+  [STREAM_SUBSTATE.RESUMING]: new Set([
     ELEMENT_IDS.STOP_STREAM_BTN,
     ELEMENT_IDS.YOLO_TOGGLE_BTN,
     ELEMENT_IDS.SUPER_YOLO_TOGGLE_BTN,
@@ -318,6 +337,7 @@ export class StreamHeader extends LitElement {
     const statusLabel = formatStreamStatusLabel(status, {
       style: 'progressHeader',
     });
+    const statusClass = streamStatusIndicatorClass(status);
     const hasExecutionId = Boolean(this.stream.executionId);
     const agentCategory = this.stream.agentCategory;
     const toolbarButtons =
@@ -371,7 +391,7 @@ export class StreamHeader extends LitElement {
               id=${ELEMENT_IDS.STATUS_INDICATOR}
               class=${classMap({
                 'status-indicator': true,
-                [`is-${status}`]: Boolean(status),
+                ...(statusClass ? { [statusClass]: true } : {}),
               })}
             ></span>
             <wa-tooltip for=${ELEMENT_IDS.STATUS_INDICATOR}>
@@ -424,7 +444,10 @@ export class StreamHeader extends LitElement {
     status: string,
     hasExecutionId: boolean,
   ): { disabled: boolean; hidden: boolean } {
-    const enabledButtons = ENABLED_BUTTONS_BY_STATUS[status];
+    const displayKey = streamStatusDisplayKey(status);
+    const enabledButtons = displayKey
+      ? ENABLED_BUTTONS_BY_DISPLAY_KEY[displayKey]
+      : undefined;
     const hidden = EXECUTION_DEPENDENT_BUTTONS.has(buttonId) && !hasExecutionId;
     const disabled = hidden || !enabledButtons?.has(buttonId);
     return { disabled, hidden };

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -10,6 +10,7 @@ import { SupabaseClient } from '@auth/SupabaseClient';
 import { ensureError, normalizeProviderError } from '@common/errors';
 import { isUserAbort } from '@common/errors/sdkErrorUtils';
 import {
+  EXECUTION_STATUS,
   STREAM_STATUS,
   toRetryErrorInfo,
   type RetryErrorInfo,
@@ -287,6 +288,7 @@ export abstract class RetryableInvocationNode<
     logProgressStatus(logger, message);
     streamStatus.set(streamId, STREAM_STATUS.STOPPED, {
       runtimeHost,
+      terminalStatus: EXECUTION_STATUS.INTERRUPTED,
     });
     return { shouldRetry: false, userCancelled: true };
   }

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -13,7 +13,11 @@ import {
   getSdkErrorMessage,
   normalizeProviderError,
 } from '@common/errors';
-import { projectRunOutcome } from '@common/constants/streamStatus';
+import {
+  legacyEndGroupStatusForOutcome,
+  projectRunOutcome,
+  terminalStreamStatusForOutcome,
+} from '@common/constants/streamStatus';
 import { createChannelTrace } from '@logger';
 import {
   RUN_OUTCOME,
@@ -184,7 +188,11 @@ export async function runFlowWithLifecycle(
       }
     }
 
-    endParentStageSafely(ctx, agentIdentifier, projection.endGroupStatus);
+    endParentStageSafely(
+      ctx,
+      agentIdentifier,
+      legacyEndGroupStatusForOutcome(result.outcome),
+    );
     // Emit the terminal result BEFORE untrack so the registry's terminal
     // listener event never precedes the result event, and settle the handle's
     // `result` promise with the same event (F-2: per-run control handle).
@@ -212,10 +220,14 @@ export async function runFlowWithLifecycle(
     try {
       session.executions.untrack(ctx.executionId);
       if (!ctx.streamStatus.shouldPreserveOnCompletion(streamId)) {
-        ctx.streamStatus.set(streamId, projection.streamStatus, {
-          runtimeHost: ctx.runtimeHost,
-          terminalStatus: projection.executionStatus,
-        });
+        ctx.streamStatus.set(
+          streamId,
+          terminalStreamStatusForOutcome(result.outcome),
+          {
+            runtimeHost: ctx.runtimeHost,
+            terminalStatus: projection.executionStatus,
+          },
+        );
       }
     } catch (cleanupErr) {
       logger.warn('Post-completion cleanup threw', {
@@ -252,7 +264,11 @@ export async function runFlowWithLifecycle(
       });
     }
 
-    endParentStageSafely(ctx, agentIdentifier, projection.endGroupStatus);
+    endParentStageSafely(
+      ctx,
+      agentIdentifier,
+      legacyEndGroupStatusForOutcome(outcome),
+    );
     // One emission covers all three exits below (subagent / abort / throw);
     // untrack follows in each branch, preserving emit-before-untrack. Outcome
     // routes through the same canonical mapper as the success arm
@@ -277,7 +293,7 @@ export async function runFlowWithLifecycle(
       );
     }
     try {
-      ctx.streamStatus.set(streamId, projection.streamStatus, {
+      ctx.streamStatus.set(streamId, terminalStreamStatusForOutcome(outcome), {
         runtimeHost: ctx.runtimeHost,
         terminalStatus: projection.executionStatus,
       });

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -16,6 +16,7 @@ import {
 } from '@agent/runtime/InterruptRegistry';
 import { isInFlightStatus } from '@common/constants/streamStatus';
 import {
+  EXECUTION_STATUS,
   STREAM_STATUS,
   LIVE_ELAPSED_STREAM_STATUSES,
   type ActiveChildInfo,
@@ -49,6 +50,8 @@ export interface StopAgentStreamOptions {
   readonly detachActiveChildren?: boolean;
   readonly runtimeHost?: AgentRuntimeHost;
 }
+
+const USER_STOP_TERMINAL_STATUS = EXECUTION_STATUS.INTERRUPTED;
 
 export type StopAgentChildPolicy = 'cascade' | 'detach';
 
@@ -619,7 +622,10 @@ export class ExecutionRegistry {
     if (!runtimeHost) {
       return { kind: 'no_target', streamId, childPolicy };
     }
-    this.streamStatus.set(streamId, STREAM_STATUS.STOPPED, { runtimeHost });
+    this.streamStatus.set(streamId, STREAM_STATUS.STOPPED, {
+      runtimeHost,
+      terminalStatus: USER_STOP_TERMINAL_STATUS,
+    });
     return { kind: 'marked_stopped', streamId, childPolicy };
   }
 
@@ -739,6 +745,7 @@ export class ExecutionRegistry {
       interruptible.interrupt();
       this.streamStatus.set(handle.childStreamId, STREAM_STATUS.STOPPED, {
         runtimeHost: handle.runtimeHost,
+        terminalStatus: USER_STOP_TERMINAL_STATUS,
       });
       return true;
     }
@@ -758,7 +765,10 @@ export class ExecutionRegistry {
     if (!interruptible) return false;
     interruptible.interrupt();
     if (runtimeHost) {
-      this.streamStatus.set(streamId, STREAM_STATUS.STOPPED, { runtimeHost });
+      this.streamStatus.set(streamId, STREAM_STATUS.STOPPED, {
+        runtimeHost,
+        terminalStatus: USER_STOP_TERMINAL_STATUS,
+      });
     }
     return true;
   }

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -16,7 +16,13 @@ import {
   AgentConfigSchema,
 } from '@agent/core/definition/AgentConfig';
 import { KVStore } from '@common/storage/KVStore';
-import { ExecutionIdSchema, type ExecutionId } from '@shared/schemas';
+import {
+  ExecutionIdSchema,
+  RunOutcomeSchema,
+  executionStatusToRunOutcome,
+  type ExecutionId,
+  type RunOutcome,
+} from '@shared/schemas';
 import { normalizeFilePath } from '@shared/utils/path';
 import {
   CompileFailureSummarySchema,
@@ -45,11 +51,13 @@ const KEYS = {
 // ============================================================================
 
 /** Execution metadata stored alongside config at launch time. */
-const ExecutionMetaSchema = z.object({
+const ExecutionMetaBaseSchema = z.object({
   timestamp: z.string(),
   parentExecutionId: ExecutionIdSchema.optional(),
   /** Persisted when execution reaches a terminal state (success or error). */
   terminalStatus: z.string().optional(),
+  /** Canonical terminal outcome; legacy meta files derive this from terminalStatus. */
+  outcome: RunOutcomeSchema.optional(),
   /** Runtime category override (e.g. 'process' for background bash). */
   category: z.string().optional(),
   /** AI-generated summary of what the session aimed to accomplish. */
@@ -62,6 +70,16 @@ const ExecutionMetaSchema = z.object({
    */
   delegationDepth: z.int().nonnegative().optional(),
 });
+
+const ExecutionMetaSchema = ExecutionMetaBaseSchema.transform(
+  (
+    meta,
+  ): z.infer<typeof ExecutionMetaBaseSchema> & { outcome?: RunOutcome } => {
+    const outcome =
+      meta.outcome ?? executionStatusToRunOutcome(meta.terminalStatus);
+    return outcome ? { ...meta, outcome } : meta;
+  },
+);
 export type ExecutionMeta = z.infer<typeof ExecutionMetaSchema>;
 
 /** Shape of a persisted todo item from tool-use flow state. */

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -10,7 +10,11 @@
  */
 import type { RunUsageTotals } from '@agent/core/usage/RunUsageAccumulator';
 import type { AgentErrorKind } from '@common/errors';
-import type { EndGroupStatus, RetryErrorInfo } from '@shared/schemas';
+import type {
+  EndGroupStatus,
+  RetryErrorInfo,
+  RunOutcome,
+} from '@shared/schemas';
 
 /** Status assigned to a tool call when it completes. */
 export type ToolStatus = 'completed' | 'failed' | 'in_progress';
@@ -170,7 +174,7 @@ export interface DomainEvent extends StageStamp {
  */
 export interface ResultEvent extends StageStamp {
   readonly type: 'result';
-  readonly outcome: 'completed' | 'failed' | 'cancelled';
+  readonly outcome: RunOutcome;
   readonly executionId: string;
   readonly streamId: string;
   readonly agentName: string;

--- a/src/common/constants/streamStatus.ts
+++ b/src/common/constants/streamStatus.ts
@@ -5,11 +5,15 @@
 import {
   EXECUTION_STATUS,
   RUN_OUTCOME,
+  STREAM_PHASE,
   STREAM_STATUS,
+  STREAM_SUBSTATE,
   STREAM_STATUS_TRAITS,
   type ExecutionStatus,
   type RunOutcome,
+  type StreamPhase,
   type StreamStatus,
+  type StreamSubstate,
 } from '@shared/schemas';
 
 // ============================================================================
@@ -37,23 +41,14 @@ export function deriveRunOutcome(facts: {
 export interface RunOutcomeProjection {
   /** Persisted-history projection (`ExecutionMeta.terminalStatus`). */
   readonly executionStatus: ExecutionStatus;
-  /** Transcript-group projection (`stage.end()` / group-end rows). */
-  readonly endGroupStatus: 'error' | 'stopped';
-  /** Live stream-state projection for the terminal transition. */
-  readonly streamStatus: StreamStatus;
 }
 
 /**
- * Projection table: one row per outcome, one column per legacy vocabulary.
+ * Projection table: one row per outcome, one injective legacy vocabulary.
  *
- * Reading the columns:
- * - `executionStatus` is the only injective projection — persisted history
- *   keeps all three outcomes apart.
- * - `endGroupStatus` and `streamStatus` are isomorphic (completed/cancelled
- *   fold to the same neutral value; only failed is distinct): a cancelled run
- *   ends neutral, never red — a user stop is not a failure. If the transcript
- *   group vocabulary ever learns a third value, consolidate these two columns
- *   into one.
+ * `executionStatus` is the only injective projection — persisted history keeps
+ * all three outcomes apart. The non-injective legacy transcript/stream shapes
+ * are derived by helpers below so the completed/cancelled fold has one source.
  *
  * The `Record` key type keeps the table compile-time exhaustive; read it
  * through {@link projectRunOutcome} so an out-of-vocabulary value (stale
@@ -65,18 +60,12 @@ export const RUN_OUTCOME_PROJECTION: Readonly<
 > = {
   [RUN_OUTCOME.COMPLETED]: {
     executionStatus: EXECUTION_STATUS.COMPLETED,
-    endGroupStatus: 'stopped',
-    streamStatus: STREAM_STATUS.STOPPED,
   },
   [RUN_OUTCOME.CANCELLED]: {
     executionStatus: EXECUTION_STATUS.INTERRUPTED,
-    endGroupStatus: 'stopped',
-    streamStatus: STREAM_STATUS.STOPPED,
   },
   [RUN_OUTCOME.FAILED]: {
     executionStatus: EXECUTION_STATUS.ERROR,
-    endGroupStatus: 'error',
-    streamStatus: STREAM_STATUS.ERROR,
   },
 };
 
@@ -87,6 +76,117 @@ export function projectRunOutcome(outcome: RunOutcome): RunOutcomeProjection {
     throw new Error(`Unhandled run outcome: ${String(outcome)}`);
   }
   return projection;
+}
+
+export function runOutcomeToExecutionStatus(
+  outcome: RunOutcome,
+): ExecutionStatus {
+  return projectRunOutcome(outcome).executionStatus;
+}
+
+export function groupEndStatusForOutcome(outcome: RunOutcome): 'ok' | 'error' {
+  return outcome === RUN_OUTCOME.FAILED ? 'error' : 'ok';
+}
+
+export function legacyEndGroupStatusForOutcome(
+  outcome: RunOutcome,
+): 'error' | 'stopped' {
+  return groupEndStatusForOutcome(outcome) === 'error' ? 'error' : 'stopped';
+}
+
+export function terminalStreamStatusForOutcome(
+  outcome: RunOutcome,
+): StreamStatus {
+  return groupEndStatusForOutcome(outcome) === 'error'
+    ? STREAM_STATUS.ERROR
+    : STREAM_STATUS.STOPPED;
+}
+
+// ============================================================================
+// StreamPhase transition algebra (stage 0 vocabulary only)
+// ============================================================================
+
+export const STREAM_TRANSITION_CAUSE = {
+  LIFECYCLE: 'lifecycle',
+  WAIT: 'wait',
+  RESUME: 'resume',
+  USER_STOP: 'user-stop',
+  RESTART_REPAIR: 'restart-repair',
+} as const;
+
+export type StreamTransitionCause =
+  (typeof STREAM_TRANSITION_CAUSE)[keyof typeof STREAM_TRANSITION_CAUSE];
+
+function isTerminalOutcomePhase(
+  phase: StreamPhase | undefined,
+): phase is RunOutcome {
+  return (
+    phase === STREAM_PHASE.COMPLETED ||
+    phase === STREAM_PHASE.CANCELLED ||
+    phase === STREAM_PHASE.FAILED
+  );
+}
+
+export function isActivePhase(phase: StreamPhase | undefined): boolean {
+  return phase === STREAM_PHASE.RUNNING;
+}
+
+export function isInFlightPhase(phase: StreamPhase | undefined): boolean {
+  return phase === STREAM_PHASE.RUNNING || phase === STREAM_PHASE.WAITING;
+}
+
+export function isTerminalPhase(phase: StreamPhase | undefined): boolean {
+  return phase === STREAM_PHASE.WAITING || isTerminalOutcomePhase(phase);
+}
+
+export function canAcquireStreamReservation(
+  phase: StreamPhase | undefined,
+): boolean {
+  return !isInFlightPhase(phase);
+}
+
+export function canReleaseStreamReservation(state: {
+  readonly phase: StreamPhase | undefined;
+  readonly substate?: StreamSubstate;
+}): boolean {
+  return (
+    state.phase === STREAM_PHASE.RUNNING &&
+    state.substate === STREAM_SUBSTATE.STARTING
+  );
+}
+
+export function canTransitionStreamPhase(
+  from: StreamPhase | undefined,
+  to: StreamPhase,
+  cause: StreamTransitionCause,
+): boolean {
+  if (cause === STREAM_TRANSITION_CAUSE.USER_STOP) {
+    return isInFlightPhase(from) && to === STREAM_PHASE.CANCELLED;
+  }
+
+  if (isTerminalOutcomePhase(from)) {
+    return (
+      cause === STREAM_TRANSITION_CAUSE.RESUME && to === STREAM_PHASE.RUNNING
+    );
+  }
+
+  switch (cause) {
+    case STREAM_TRANSITION_CAUSE.LIFECYCLE:
+      if (from === undefined) return to === STREAM_PHASE.RUNNING;
+      return from === STREAM_PHASE.RUNNING && isTerminalOutcomePhase(to);
+    case STREAM_TRANSITION_CAUSE.WAIT:
+      return from === STREAM_PHASE.RUNNING && to === STREAM_PHASE.WAITING;
+    case STREAM_TRANSITION_CAUSE.RESUME:
+      return (
+        (from === STREAM_PHASE.WAITING || isTerminalOutcomePhase(from)) &&
+        to === STREAM_PHASE.RUNNING
+      );
+    case STREAM_TRANSITION_CAUSE.RESTART_REPAIR:
+      return (
+        from === STREAM_PHASE.RUNNING &&
+        (to === STREAM_PHASE.WAITING || to === STREAM_PHASE.FAILED)
+      );
+  }
 }
 
 // ============================================================================

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -145,6 +145,90 @@ export const RUN_OUTCOME = {
 export const RunOutcomeSchema = z.enum(RUN_OUTCOME);
 export type RunOutcome = z.infer<typeof RunOutcomeSchema>;
 
+export const STREAM_PHASE = {
+  RUNNING: STREAM_STATUS.RUNNING,
+  WAITING: STREAM_STATUS.WAITING,
+  COMPLETED: RUN_OUTCOME.COMPLETED,
+  CANCELLED: RUN_OUTCOME.CANCELLED,
+  FAILED: RUN_OUTCOME.FAILED,
+} as const;
+
+export const StreamPhaseSchema = z.enum(STREAM_PHASE);
+export type StreamPhase = z.infer<typeof StreamPhaseSchema>;
+
+export const STREAM_SUBSTATE = {
+  STARTING: 'starting',
+  RESUMING: 'resuming',
+} as const;
+
+export const StreamSubstateSchema = z.enum(STREAM_SUBSTATE);
+export type StreamSubstate = z.infer<typeof StreamSubstateSchema>;
+
+export function isRunOutcome(value: string | undefined): value is RunOutcome {
+  return RunOutcomeSchema.safeParse(value).success;
+}
+
+export function executionStatusToRunOutcome(
+  status: string | undefined,
+): RunOutcome | undefined {
+  if (isRunOutcome(status)) return status;
+
+  const parsed = ExecutionStatusSchema.safeParse(status);
+  if (!parsed.success) return undefined;
+
+  switch (parsed.data) {
+    case EXECUTION_STATUS.COMPLETED:
+      return RUN_OUTCOME.COMPLETED;
+    case EXECUTION_STATUS.INTERRUPTED:
+      return RUN_OUTCOME.CANCELLED;
+    case EXECUTION_STATUS.ERROR:
+      return RUN_OUTCOME.FAILED;
+  }
+}
+
+export function streamStatusToPhase(status: StreamStatus): StreamPhase {
+  switch (status) {
+    case STREAM_STATUS.RUNNING:
+    case STREAM_STATUS.RESUMING:
+    case STREAM_STATUS.INITIALIZING:
+      return STREAM_PHASE.RUNNING;
+    case STREAM_STATUS.WAITING:
+      return STREAM_PHASE.WAITING;
+    case STREAM_STATUS.ERROR:
+      return STREAM_PHASE.FAILED;
+    case STREAM_STATUS.STOPPED:
+    case STREAM_STATUS.READY:
+      return STREAM_PHASE.COMPLETED;
+  }
+}
+
+export function streamStatusToSubstate(
+  status: StreamStatus,
+): StreamSubstate | undefined {
+  switch (status) {
+    case STREAM_STATUS.INITIALIZING:
+      return STREAM_SUBSTATE.STARTING;
+    case STREAM_STATUS.RESUMING:
+      return STREAM_SUBSTATE.RESUMING;
+    default:
+      return undefined;
+  }
+}
+
+export function streamPhaseToStreamStatus(phase: StreamPhase): StreamStatus {
+  switch (phase) {
+    case STREAM_PHASE.RUNNING:
+      return STREAM_STATUS.RUNNING;
+    case STREAM_PHASE.WAITING:
+      return STREAM_STATUS.WAITING;
+    case STREAM_PHASE.FAILED:
+      return STREAM_STATUS.ERROR;
+    case STREAM_PHASE.COMPLETED:
+    case STREAM_PHASE.CANCELLED:
+      return STREAM_STATUS.STOPPED;
+  }
+}
+
 export const WORKTREE_PR_STATE = {
   OPEN: 'open',
   MERGED: 'merged',

--- a/src/shared/schemas/streamRestoration.ts
+++ b/src/shared/schemas/streamRestoration.ts
@@ -17,9 +17,18 @@ import { z } from 'zod';
 
 import { AgentCategorySchema } from './agent';
 import { ExecutionIdSchema, StreamTabIdSchema } from './identifiers';
-import { StreamStatusSchema } from './stream';
+import {
+  StreamPhaseSchema,
+  StreamStatusSchema,
+  streamStatusToPhase,
+} from './stream';
 
 export const RESTORED_STREAM_FILE_VERSION = 1;
+
+const PersistedLastKnownStreamPhaseSchema = z.union([
+  StreamPhaseSchema,
+  StreamStatusSchema.transform(streamStatusToPhase),
+]);
 
 /**
  * Slim subset of `StreamTabInfo` + `StreamMetadata` that's safe to
@@ -39,9 +48,8 @@ export const RestoredStreamSnapshotSchema = z.object({
   inputFile: z.string().optional(),
   /** Original instruction text — useful for "start fresh" fallback. */
   instruction: z.string().optional(),
-  /** Last known status before shutdown. We mark it explicitly stopped
-   * on hydrate so the UI doesn't claim the run is still running. */
-  lastKnownStatus: StreamStatusSchema,
+  /** Last known phase before shutdown. Kept under the legacy on-disk key. */
+  lastKnownStatus: PersistedLastKnownStreamPhaseSchema,
   /** AI-generated description, if any. */
   description: z.string().optional(),
   /** Execution id for storage lookup (powers resume / transcript view). */

--- a/src/shared/streams/streamStatusDisplay.ts
+++ b/src/shared/streams/streamStatusDisplay.ts
@@ -1,35 +1,107 @@
-import { STREAM_STATUS } from '@shared/schemas';
+import {
+  STREAM_PHASE,
+  STREAM_STATUS,
+  STREAM_SUBSTATE,
+  StreamPhaseSchema,
+  StreamStatusSchema,
+  streamStatusToPhase,
+  streamStatusToSubstate,
+  type StreamPhase,
+  type StreamSubstate,
+} from '@shared/schemas';
 
-// cli and cliCompact share every label except the INITIALIZING ellipsis, so
+export type StreamStatusDisplayKey = StreamPhase | StreamSubstate | 'ready';
+
+export interface StreamStatusDisplayState {
+  readonly phase?: StreamPhase;
+  readonly substate?: StreamSubstate;
+  readonly key?: StreamStatusDisplayKey;
+  readonly legacyStatus?: string;
+}
+
+function phaseDisplayKey(phase: StreamPhase): StreamStatusDisplayKey {
+  return phase;
+}
+
+export function streamStatusDisplayState(
+  status: string | undefined,
+): StreamStatusDisplayState {
+  if (status == null) return {};
+  if (status === STREAM_STATUS.READY) {
+    return { key: 'ready' };
+  }
+
+  const phase = StreamPhaseSchema.safeParse(status);
+  if (phase.success) {
+    return { phase: phase.data, key: phaseDisplayKey(phase.data) };
+  }
+
+  const legacyStatus = StreamStatusSchema.safeParse(status);
+  if (!legacyStatus.success) return {};
+
+  const legacyPhase = streamStatusToPhase(legacyStatus.data);
+  const substate = streamStatusToSubstate(legacyStatus.data);
+  return {
+    phase: legacyPhase,
+    ...(substate ? { substate } : {}),
+    legacyStatus: legacyStatus.data,
+    key: substate ?? phaseDisplayKey(legacyPhase),
+  };
+}
+
+export function streamStatusDisplayKey(
+  status: string | undefined,
+): StreamStatusDisplayKey | undefined {
+  return streamStatusDisplayState(status).key;
+}
+
+export function streamStatusIndicatorClass(
+  status: string | undefined,
+): string | undefined {
+  const key = streamStatusDisplayKey(status);
+  return key ? `is-${key}` : undefined;
+}
+
+// cli and cliCompact share every label except the STARTING ellipsis, so
 // cliCompact is derived from cli rather than hand-synced.
-const cliStreamStatusLabels = {
-  [STREAM_STATUS.INITIALIZING]: 'starting\u2026',
-  [STREAM_STATUS.RUNNING]: 'running',
-  [STREAM_STATUS.ERROR]: 'error',
-  [STREAM_STATUS.STOPPED]: 'stopped',
-  [STREAM_STATUS.READY]: 'ready',
-  [STREAM_STATUS.WAITING]: 'idle',
-  [STREAM_STATUS.RESUMING]: 'resuming',
+const cliStreamStatusLabels: Record<StreamStatusDisplayKey, string> = {
+  [STREAM_SUBSTATE.STARTING]: 'starting\u2026',
+  [STREAM_PHASE.RUNNING]: 'running',
+  [STREAM_PHASE.FAILED]: 'error',
+  [STREAM_PHASE.COMPLETED]: 'completed',
+  [STREAM_PHASE.CANCELLED]: 'stopped',
+  ready: 'ready',
+  [STREAM_PHASE.WAITING]: 'idle',
+  [STREAM_SUBSTATE.RESUMING]: 'resuming',
 } as const;
 
 const STREAM_STATUS_LABELS = {
   cli: cliStreamStatusLabels,
   cliCompact: {
     ...cliStreamStatusLabels,
-    [STREAM_STATUS.INITIALIZING]: 'starting',
+    [STREAM_SUBSTATE.STARTING]: 'starting',
   },
   progressHeader: {
-    [STREAM_STATUS.INITIALIZING]: 'Initializing',
-    [STREAM_STATUS.RUNNING]: 'Running',
-    [STREAM_STATUS.ERROR]: 'Error',
-    [STREAM_STATUS.STOPPED]: 'Stopped',
-    [STREAM_STATUS.READY]: 'Ready',
-    [STREAM_STATUS.WAITING]: 'Waiting for follow-up',
-    [STREAM_STATUS.RESUMING]: 'Resuming',
+    [STREAM_SUBSTATE.STARTING]: 'Initializing',
+    [STREAM_PHASE.RUNNING]: 'Running',
+    [STREAM_PHASE.FAILED]: 'Error',
+    [STREAM_PHASE.COMPLETED]: 'Completed',
+    [STREAM_PHASE.CANCELLED]: 'Stopped',
+    ready: 'Ready',
+    [STREAM_PHASE.WAITING]: 'Waiting for follow-up',
+    [STREAM_SUBSTATE.RESUMING]: 'Resuming',
   },
 } as const;
 
 export type StreamStatusLabelStyle = keyof typeof STREAM_STATUS_LABELS;
+
+function legacyStatusLabel(
+  status: string | undefined,
+  style: StreamStatusLabelStyle,
+): string | undefined {
+  if (status !== STREAM_STATUS.STOPPED) return undefined;
+  return style === 'progressHeader' ? 'Stopped' : 'stopped';
+}
 
 export function formatStreamStatusLabel(
   status: string | undefined,
@@ -63,9 +135,13 @@ export function formatStreamStatusLabel(
   } = {},
 ): string | undefined {
   if (status == null) return options.missingLabel;
-  return (
-    STREAM_STATUS_LABELS[options.style ?? 'progressHeader'][
-      status as keyof (typeof STREAM_STATUS_LABELS)['progressHeader']
-    ] ?? status
+  const state = streamStatusDisplayState(status);
+  const legacyLabel = legacyStatusLabel(
+    state.legacyStatus,
+    options.style ?? 'progressHeader',
   );
+  if (legacyLabel) return legacyLabel;
+  const key = state.key;
+  if (!key) return status;
+  return STREAM_STATUS_LABELS[options.style ?? 'progressHeader'][key] ?? status;
 }

--- a/src/shared/styles/statusIndicatorStyles.ts
+++ b/src/shared/styles/statusIndicatorStyles.ts
@@ -16,12 +16,13 @@ export const statusIndicatorStyles: CSSResult = css`
     opacity: var(--opacity-full);
   }
 
-  .status-indicator.is-stopped {
+  .status-indicator.is-completed,
+  .status-indicator.is-cancelled {
     background-color: var(--wa-color-text-quiet);
     opacity: var(--opacity-subtle, 0.7);
   }
 
-  .status-indicator.is-error {
+  .status-indicator.is-failed {
     background-color: var(--color-error);
     opacity: var(--opacity-full);
   }
@@ -32,7 +33,7 @@ export const statusIndicatorStyles: CSSResult = css`
     opacity: var(--opacity-full);
   }
 
-  .status-indicator.is-initializing {
+  .status-indicator.is-starting {
     background-color: var(--wa-color-text-quiet);
     opacity: var(--opacity-full);
   }

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -11,7 +11,11 @@ import {
 import { InterruptRegistry } from '@agent/runtime/InterruptRegistry';
 import { ProcessOutputPoller } from '@agent/runtime/ProcessOutputPoller';
 import { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
-import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+import {
+  EXECUTION_STATUS,
+  STREAM_STATUS,
+  type StreamTabId,
+} from '@shared/schemas';
 
 import { createRecordingHost } from '../progressTestUtils';
 
@@ -117,6 +121,18 @@ describe('executionRegistry', () => {
       expect(childInterrupt).toHaveBeenCalledOnce();
       expect(streamStatus.get(rootStreamId)).toBe(STREAM_STATUS.STOPPED);
       expect(streamStatus.get(childStreamId)).toBe(STREAM_STATUS.STOPPED);
+      expect(
+        explicit.events
+          .filter((event) => event.event === 'updateStreamStatus')
+          .map((event) => event.payload),
+      ).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            status: STREAM_STATUS.STOPPED,
+            terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+          }),
+        ]),
+      );
     } finally {
       registry.dispose();
     }
@@ -350,6 +366,10 @@ describe('executionRegistry', () => {
 
       expect(interrupt).toHaveBeenCalledOnce();
       expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.STOPPED);
+      expect(explicit.events.at(-1)?.payload).toMatchObject({
+        status: STREAM_STATUS.STOPPED,
+        terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+      });
     } finally {
       registry.dispose();
     }
@@ -372,6 +392,10 @@ describe('executionRegistry', () => {
         childPolicy: 'cascade',
       });
       expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.STOPPED);
+      expect(explicit.events.at(-1)?.payload).toMatchObject({
+        status: STREAM_STATUS.STOPPED,
+        terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+      });
     } finally {
       registry.dispose();
     }

--- a/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { createFakePlatform } from '@test/support/FakePlatform';
+import { clearStoreCache, getExecutionStore } from '@agent/storage';
+import {
+  EXECUTION_STATUS,
+  RUN_OUTCOME,
+  type ExecutionId,
+  type RunOutcome,
+} from '@shared/schemas';
+
+beforeEach(async () => {
+  const { initPlatform } = await import('@platform/platform');
+  initPlatform(createFakePlatform({ workspacePath: '/workspace' }));
+  clearStoreCache();
+});
+
+describe('ExecutionKVStore meta read shims', () => {
+  it.each([
+    [EXECUTION_STATUS.COMPLETED, RUN_OUTCOME.COMPLETED],
+    [EXECUTION_STATUS.INTERRUPTED, RUN_OUTCOME.CANCELLED],
+    [EXECUTION_STATUS.ERROR, RUN_OUTCOME.FAILED],
+  ] as const)(
+    'maps legacy terminalStatus %s to outcome %s',
+    async (terminalStatus, outcome) => {
+      const id = `legacy-${terminalStatus}` as ExecutionId;
+      await getExecutionStore(id).write('meta', {
+        timestamp: '2026-07-04T00:00:00.000Z',
+        terminalStatus,
+      });
+
+      await expect(getExecutionStore(id).readMeta()).resolves.toMatchObject({
+        terminalStatus,
+        outcome,
+      });
+    },
+  );
+
+  it.each(Object.values(RUN_OUTCOME) as RunOutcome[])(
+    'preserves canonical outcome %s',
+    async (outcome) => {
+      const id = `canonical-${outcome}` as ExecutionId;
+      await getExecutionStore(id).write('meta', {
+        timestamp: '2026-07-04T00:00:00.000Z',
+        outcome,
+      });
+
+      await expect(getExecutionStore(id).readMeta()).resolves.toMatchObject({
+        outcome,
+      });
+    },
+  );
+});

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -871,13 +871,13 @@ describe('CLI root argument routing', () => {
     ).toBe(EXECUTION_STATUS.ERROR);
   });
 
-  it('honors stored interrupted terminal status', () => {
+  it('honors stored cancelled outcome', () => {
     expect(
       cliTerminalStatus(
         {
           outcome: RUN_OUTCOME.COMPLETED,
         } as Parameters<typeof cliTerminalStatus>[0],
-        EXECUTION_STATUS.INTERRUPTED,
+        RUN_OUTCOME.CANCELLED,
       ),
     ).toBe(EXECUTION_STATUS.INTERRUPTED);
   });
@@ -891,7 +891,6 @@ describe('CLI root argument routing', () => {
         streamId: 'stream-without-output',
         lastResponse: 'done',
       } as Parameters<typeof createCliRunResult>[0],
-      EXECUTION_STATUS.COMPLETED,
       { workingDirectory: '/tmp/project' },
     );
 
@@ -899,6 +898,8 @@ describe('CLI root argument routing', () => {
       executionId: 'completed-without-output',
       workingDirectory: '/tmp/project',
       terminalStatus: EXECUTION_STATUS.COMPLETED,
+      status: EXECUTION_STATUS.COMPLETED,
+      endGroupStatus: 'stopped',
     });
   });
 

--- a/src/test-kernel/common/RunOutcomeAlgebra.vitest.ts
+++ b/src/test-kernel/common/RunOutcomeAlgebra.vitest.ts
@@ -3,21 +3,33 @@ import { describe, expect, it } from 'vitest';
 
 // Local imports
 import {
+  canAcquireStreamReservation,
+  canReleaseStreamReservation,
+  canTransitionStreamPhase,
   deriveRunOutcome,
+  groupEndStatusForOutcome,
   isActiveStatus,
   isInFlightStatus,
   isLiveElapsedStatus,
   isTerminalStatus,
+  legacyEndGroupStatusForOutcome,
   projectRunOutcome,
   RUN_OUTCOME_PROJECTION,
+  STREAM_TRANSITION_CAUSE,
+  terminalStreamStatusForOutcome,
+  type StreamTransitionCause,
 } from '@common/constants/streamStatus';
 import {
   EXECUTION_STATUS,
   LIVE_ELAPSED_STREAM_STATUSES,
   RUN_OUTCOME,
+  STREAM_PHASE,
   STREAM_STATUS,
+  STREAM_SUBSTATE,
+  StreamPhaseSchema,
   streamStatusesWithTrait,
   type RunOutcome,
+  type StreamPhase,
 } from '@shared/schemas';
 
 describe('run outcome algebra', () => {
@@ -38,30 +50,148 @@ describe('run outcome algebra', () => {
     );
   });
 
-  it('projects each outcome into the three legacy vocabularies', () => {
+  it('projects each outcome into the injective legacy execution vocabulary', () => {
     expect(RUN_OUTCOME_PROJECTION[RUN_OUTCOME.COMPLETED]).toEqual({
       executionStatus: EXECUTION_STATUS.COMPLETED,
-      endGroupStatus: 'stopped',
-      streamStatus: STREAM_STATUS.STOPPED,
     });
     // A user stop persists 'interrupted' and ends the transcript group
     // neutral — cancelled is a sibling of failed, never folded into it.
     expect(RUN_OUTCOME_PROJECTION[RUN_OUTCOME.CANCELLED]).toEqual({
       executionStatus: EXECUTION_STATUS.INTERRUPTED,
-      endGroupStatus: 'stopped',
-      streamStatus: STREAM_STATUS.STOPPED,
     });
     expect(RUN_OUTCOME_PROJECTION[RUN_OUTCOME.FAILED]).toEqual({
       executionStatus: EXECUTION_STATUS.ERROR,
-      endGroupStatus: 'error',
-      streamStatus: STREAM_STATUS.ERROR,
     });
+  });
+
+  it('derives folded legacy group-end and stream-status projections from one helper', () => {
+    expect(groupEndStatusForOutcome(RUN_OUTCOME.COMPLETED)).toBe('ok');
+    expect(groupEndStatusForOutcome(RUN_OUTCOME.CANCELLED)).toBe('ok');
+    expect(groupEndStatusForOutcome(RUN_OUTCOME.FAILED)).toBe('error');
+
+    expect(legacyEndGroupStatusForOutcome(RUN_OUTCOME.COMPLETED)).toBe(
+      'stopped',
+    );
+    expect(legacyEndGroupStatusForOutcome(RUN_OUTCOME.CANCELLED)).toBe(
+      'stopped',
+    );
+    expect(legacyEndGroupStatusForOutcome(RUN_OUTCOME.FAILED)).toBe('error');
+
+    expect(terminalStreamStatusForOutcome(RUN_OUTCOME.COMPLETED)).toBe(
+      STREAM_STATUS.STOPPED,
+    );
+    expect(terminalStreamStatusForOutcome(RUN_OUTCOME.CANCELLED)).toBe(
+      STREAM_STATUS.STOPPED,
+    );
+    expect(terminalStreamStatusForOutcome(RUN_OUTCOME.FAILED)).toBe(
+      STREAM_STATUS.ERROR,
+    );
   });
 
   it('fails loudly on an out-of-vocabulary outcome', () => {
     expect(() => projectRunOutcome('bogus' as RunOutcome)).toThrow(
       'Unhandled run outcome: bogus',
     );
+  });
+});
+
+describe('stream phase transition table', () => {
+  const phases = StreamPhaseSchema.options;
+  const causes = Object.values(
+    STREAM_TRANSITION_CAUSE,
+  ) as StreamTransitionCause[];
+
+  const allowed: Record<
+    StreamPhase,
+    Record<StreamTransitionCause, readonly StreamPhase[]>
+  > = {
+    [STREAM_PHASE.RUNNING]: {
+      [STREAM_TRANSITION_CAUSE.LIFECYCLE]: [
+        STREAM_PHASE.COMPLETED,
+        STREAM_PHASE.CANCELLED,
+        STREAM_PHASE.FAILED,
+      ],
+      [STREAM_TRANSITION_CAUSE.WAIT]: [STREAM_PHASE.WAITING],
+      [STREAM_TRANSITION_CAUSE.RESUME]: [],
+      [STREAM_TRANSITION_CAUSE.USER_STOP]: [STREAM_PHASE.CANCELLED],
+      [STREAM_TRANSITION_CAUSE.RESTART_REPAIR]: [
+        STREAM_PHASE.WAITING,
+        STREAM_PHASE.FAILED,
+      ],
+    },
+    [STREAM_PHASE.WAITING]: {
+      [STREAM_TRANSITION_CAUSE.LIFECYCLE]: [],
+      [STREAM_TRANSITION_CAUSE.WAIT]: [],
+      [STREAM_TRANSITION_CAUSE.RESUME]: [STREAM_PHASE.RUNNING],
+      [STREAM_TRANSITION_CAUSE.USER_STOP]: [STREAM_PHASE.CANCELLED],
+      [STREAM_TRANSITION_CAUSE.RESTART_REPAIR]: [],
+    },
+    [STREAM_PHASE.COMPLETED]: {
+      [STREAM_TRANSITION_CAUSE.LIFECYCLE]: [],
+      [STREAM_TRANSITION_CAUSE.WAIT]: [],
+      [STREAM_TRANSITION_CAUSE.RESUME]: [STREAM_PHASE.RUNNING],
+      [STREAM_TRANSITION_CAUSE.USER_STOP]: [],
+      [STREAM_TRANSITION_CAUSE.RESTART_REPAIR]: [],
+    },
+    [STREAM_PHASE.CANCELLED]: {
+      [STREAM_TRANSITION_CAUSE.LIFECYCLE]: [],
+      [STREAM_TRANSITION_CAUSE.WAIT]: [],
+      [STREAM_TRANSITION_CAUSE.RESUME]: [STREAM_PHASE.RUNNING],
+      [STREAM_TRANSITION_CAUSE.USER_STOP]: [],
+      [STREAM_TRANSITION_CAUSE.RESTART_REPAIR]: [],
+    },
+    [STREAM_PHASE.FAILED]: {
+      [STREAM_TRANSITION_CAUSE.LIFECYCLE]: [],
+      [STREAM_TRANSITION_CAUSE.WAIT]: [],
+      [STREAM_TRANSITION_CAUSE.RESUME]: [STREAM_PHASE.RUNNING],
+      [STREAM_TRANSITION_CAUSE.USER_STOP]: [],
+      [STREAM_TRANSITION_CAUSE.RESTART_REPAIR]: [],
+    },
+  };
+
+  it('is exhaustive over every phase, cause, and destination phase', () => {
+    for (const from of phases) {
+      for (const cause of causes) {
+        for (const to of phases) {
+          expect(canTransitionStreamPhase(from, to, cause)).toBe(
+            allowed[from][cause].includes(to),
+          );
+        }
+      }
+    }
+  });
+
+  it('admits only lifecycle starts from idle', () => {
+    for (const cause of causes) {
+      for (const to of phases) {
+        expect(canTransitionStreamPhase(undefined, to, cause)).toBe(
+          cause === STREAM_TRANSITION_CAUSE.LIFECYCLE &&
+            to === STREAM_PHASE.RUNNING,
+        );
+      }
+    }
+  });
+
+  it('pins reservation invariants separately from transitions', () => {
+    expect(canAcquireStreamReservation(undefined)).toBe(true);
+    expect(canAcquireStreamReservation(STREAM_PHASE.RUNNING)).toBe(false);
+    expect(canAcquireStreamReservation(STREAM_PHASE.WAITING)).toBe(false);
+    expect(canAcquireStreamReservation(STREAM_PHASE.COMPLETED)).toBe(true);
+    expect(canAcquireStreamReservation(STREAM_PHASE.CANCELLED)).toBe(true);
+    expect(canAcquireStreamReservation(STREAM_PHASE.FAILED)).toBe(true);
+
+    for (const phase of [undefined, ...phases]) {
+      for (const substate of [
+        undefined,
+        STREAM_SUBSTATE.STARTING,
+        STREAM_SUBSTATE.RESUMING,
+      ]) {
+        expect(canReleaseStreamReservation({ phase, substate })).toBe(
+          phase === STREAM_PHASE.RUNNING &&
+            substate === STREAM_SUBSTATE.STARTING,
+        );
+      }
+    }
   });
 });
 

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -11,6 +11,7 @@ import {
   LOG_LEVELS,
   RUN_OUTCOME,
   STREAM_LOG_ENTRY_TYPES,
+  STREAM_PHASE,
   STREAM_STATUS,
   type RestoredStreamSnapshot,
   type RunOutcome,
@@ -408,7 +409,7 @@ function restoredSnapshot(
   return {
     label: overrides.streamId,
     agentCategory: AgentCategory.Workflow,
-    lastKnownStatus: STREAM_STATUS.STOPPED,
+    lastKnownStatus: STREAM_PHASE.COMPLETED,
     creationTimestamp: 1_000,
     persistedAt: 2_000,
     ...overrides,

--- a/src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts
@@ -15,6 +15,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // Local imports
 import {
   AgentCategory,
+  STREAM_PHASE,
   STREAM_STATUS,
   type RestoredStreamSnapshot,
   type StreamTabId,
@@ -32,7 +33,7 @@ function createSnapshot(
   return {
     label: overrides.streamId,
     agentCategory: AgentCategory.Workflow,
-    lastKnownStatus: STREAM_STATUS.STOPPED,
+    lastKnownStatus: STREAM_PHASE.COMPLETED,
     creationTimestamp: 1_000,
     persistedAt: 2_000,
     ...overrides,

--- a/src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts
+++ b/src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts
@@ -7,7 +7,11 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 // Local imports - shared schemas
-import { STREAM_STATUS } from '@shared/schemas';
+import {
+  STREAM_PHASE,
+  STREAM_STATUS,
+  StreamPhaseSchema,
+} from '@shared/schemas';
 
 // Local imports - desktop test paths
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
@@ -108,7 +112,7 @@ describe('DesktopStreamSnapshot', () => {
     expect(ids).toEqual(['toolUseAgent@2', 'workflowAgent@1']);
   });
 
-  it('preserves RUNNING on hydrate for startup repair', async () => {
+  it('preserves RUNNING phase on hydrate for startup repair', async () => {
     const filePath = await tempFilePath();
 
     const writer = await openDesktopStreamSnapshotStore(filePath);
@@ -117,32 +121,48 @@ describe('DesktopStreamSnapshot', () => {
     );
 
     const reopened = await openDesktopStreamSnapshotStore(filePath);
-    expect(reopened.hydrated[0]?.lastKnownStatus).toBe(STREAM_STATUS.RUNNING);
+    expect(reopened.hydrated[0]?.lastKnownStatus).toBe(STREAM_PHASE.RUNNING);
   });
 
   it.each([
-    STREAM_STATUS.RESUMING,
-    STREAM_STATUS.INITIALIZING,
-    STREAM_STATUS.WAITING,
-  ])('preserves %s on hydrate for startup repair', async (status) => {
+    [STREAM_STATUS.RESUMING, STREAM_PHASE.RUNNING],
+    [STREAM_STATUS.INITIALIZING, STREAM_PHASE.RUNNING],
+    [STREAM_STATUS.WAITING, STREAM_PHASE.WAITING],
+  ])('maps legacy %s to %s on hydrate', async (status, expectedPhase) => {
     const filePath = await tempFilePath();
 
     const writer = await openDesktopStreamSnapshotStore(filePath);
     await writer.upsert(makeSnapshot({ lastKnownStatus: status }));
 
     const reopened = await openDesktopStreamSnapshotStore(filePath);
-    expect(reopened.hydrated[0]?.lastKnownStatus).toBe(status);
+    expect(reopened.hydrated[0]?.lastKnownStatus).toBe(expectedPhase);
   });
 
-  it('normalises inactive statuses to STOPPED on hydrate', async () => {
+  it('normalises inactive phases to COMPLETED on hydrate', async () => {
     const filePath = await tempFilePath();
 
     const writer = await openDesktopStreamSnapshotStore(filePath);
     await writer.upsert(makeSnapshot({ lastKnownStatus: STREAM_STATUS.ERROR }));
 
     const reopened = await openDesktopStreamSnapshotStore(filePath);
-    expect(reopened.hydrated[0]?.lastKnownStatus).toBe(STREAM_STATUS.STOPPED);
+    expect(reopened.hydrated[0]?.lastKnownStatus).toBe(STREAM_PHASE.COMPLETED);
   });
+
+  it.each(Object.values(STREAM_STATUS))(
+    'read-shims legacy on-disk %s to a defined phase',
+    async (status) => {
+      const filePath = await tempFilePath();
+
+      const writer = await openDesktopStreamSnapshotStore(filePath);
+      await writer.upsert(makeSnapshot({ lastKnownStatus: status }));
+
+      const reopened = await openDesktopStreamSnapshotStore(filePath);
+      expect(
+        StreamPhaseSchema.safeParse(reopened.hydrated[0]?.lastKnownStatus)
+          .success,
+      ).toBe(true);
+    },
+  );
 
   it('preserves parent stream links on hydrate', async () => {
     const filePath = await tempFilePath();

--- a/src/test-kernel/shared/StreamStatusDisplay.vitest.ts
+++ b/src/test-kernel/shared/StreamStatusDisplay.vitest.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { STREAM_STATUS } from '@shared/schemas';
+import { STREAM_PHASE, STREAM_STATUS, STREAM_SUBSTATE } from '@shared/schemas';
 import {
   type StreamStatusLabelStyle,
   formatStreamStatusLabel,
+  streamStatusDisplayKey,
+  streamStatusIndicatorClass,
 } from '@shared/streams/streamStatusDisplay';
 
 describe('stream status display labels', () => {
@@ -14,6 +16,9 @@ describe('stream status display labels', () => {
     ['cliCompact', STREAM_STATUS.WAITING, 'idle'],
     ['progressHeader', STREAM_STATUS.WAITING, 'Waiting for follow-up'],
     ['progressHeader', STREAM_STATUS.INITIALIZING, 'Initializing'],
+    ['cliCompact', STREAM_PHASE.COMPLETED, 'completed'],
+    ['progressHeader', STREAM_PHASE.COMPLETED, 'Completed'],
+    ['cliCompact', STREAM_STATUS.STOPPED, 'stopped'],
   ];
 
   it.each(wordingCases)(
@@ -28,4 +33,19 @@ describe('stream status display labels', () => {
     expect(formatStreamStatusLabel('')).toBe('');
     expect(formatStreamStatusLabel(undefined, { missingLabel: '-' })).toBe('-');
   });
+
+  it.each([
+    [STREAM_STATUS.INITIALIZING, STREAM_SUBSTATE.STARTING, 'is-starting'],
+    [STREAM_STATUS.RESUMING, STREAM_SUBSTATE.RESUMING, 'is-resuming'],
+    [STREAM_STATUS.STOPPED, STREAM_PHASE.COMPLETED, 'is-completed'],
+    [STREAM_STATUS.ERROR, STREAM_PHASE.FAILED, 'is-failed'],
+    [STREAM_STATUS.WAITING, STREAM_PHASE.WAITING, 'is-waiting'],
+    [STREAM_STATUS.READY, 'ready', 'is-ready'],
+  ] as const)(
+    'maps legacy %s to display key %s and class %s',
+    (status, key, className) => {
+      expect(streamStatusDisplayKey(status)).toBe(key);
+      expect(streamStatusIndicatorClass(status)).toBe(className);
+    },
+  );
 });

--- a/src/tools/agentCliSessionLoop.ts
+++ b/src/tools/agentCliSessionLoop.ts
@@ -25,6 +25,7 @@ import type { FollowUpQueue } from '@agent/followUp/FollowUpQueue';
 import { toErrorMessage } from '@common/errors';
 import {
   deriveRunOutcome,
+  legacyEndGroupStatusForOutcome,
   projectRunOutcome,
 } from '@common/constants/streamStatus';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
@@ -322,13 +323,12 @@ export function runAgentCliSession<TTurn>(
       // are projections of it. The child-stream finalize below is NOT a
       // projection: child streams reset to READY on clean exit so the tab
       // clears, which has no outcome equivalent.
-      const projection = projectRunOutcome(
-        deriveRunOutcome({
-          failed: sawTurnFailure,
-          cancelled: session.isInterrupted(),
-        }),
-      );
-      sessionStage.end(projection.endGroupStatus);
+      const outcome = deriveRunOutcome({
+        failed: sawTurnFailure,
+        cancelled: session.isInterrupted(),
+      });
+      const projection = projectRunOutcome(outcome);
+      sessionStage.end(legacyEndGroupStatusForOutcome(outcome));
       runSession.interrupts.unregister(childStreamId);
       ToolUseFollowUpQueue.release(childStreamId);
       strategy.onSessionCleanup?.();


### PR DESCRIPTION
## Summary

Adds the Stage 0 `StreamPhase`/`StreamSubstate` vocabulary while keeping the old `StreamStatusService` runtime contract in place. The patch adds compatibility shims for desktop persisted stream snapshots and execution meta reads, freezes CLI legacy JSON fields as derived projections from `outcome`, and re-keys progress display code through phase/substate adapters during migration.

Before implementation, I re-verified the cited evidence in #6961. The desktop `streamRestoration.ts:44` citation had drifted to `src/shared/schemas/streamRestoration.ts`, and I noted that drift on the issue before changing code.

## Issue acceptance gates

Addresses #6961.

- [x] Exhaustive phase x cause transition-table test plus reservation invariant pair in `RunOutcomeAlgebra.vitest.ts`.
- [x] Tier-3 read-shim round trips: old desktop on-disk stream statuses parse to defined phases, and legacy execution `terminalStatus` reads populate canonical `outcome`.
- [x] CLI headless byte-parity suites covering `texra run`, `--print`, and `--output-format json` stayed green.
- [x] `RUN_OUTCOME_PROJECTION` now owns only the injective execution-status mapping; legacy group-end and terminal stream values derive from the canonical outcome helpers.

## Single source of truth

`src/shared/schemas/stream.ts` now owns `StreamPhaseSchema`, `StreamSubstateSchema`, and the legacy status-to-phase conversion helpers. `src/common/constants/streamStatus.ts` owns the outcome projection algebra and Stage 0 phase transition guards.

## Duplication and abstraction budget

The duplicated `completed/cancelled -> stopped` and `failed -> error` columns were removed from `RUN_OUTCOME_PROJECTION`; callers now derive legacy transcript and stream projections through one helper path. The added mass is concentrated in acceptance tests for transition-table exhaustiveness and shim round trips, plus compatibility scaffolding required for Stage 0 migration.

## Host impact

Extension: Progress header display keys and indicator classes now resolve through phase/substate mappings, while legacy stream statuses still render during migration.

Desktop: `streams.json` reads accept old seven-value statuses and hydrate to phases; the old in-memory `StreamStatusService` continues to run, and restart repair checks the phase-backed snapshot without changing intended behavior.

CLI: `CliRunResult.status`, `terminalStatus`, and `endGroupStatus` remain present for frozen JSON compatibility and are marked deprecated projections derived from `outcome`.

## Scheduled refactoring

Tracked in #6981. The existing ledger rows cover the Stage 0 tier-3 read shims, legacy display mappings, old stream-status vocabulary/projection scaffolding, and frozen CLI JSON fields with explicit removal triggers.

## Validation

- `corepack pnpm exec prettier --write` on touched files
- `corepack pnpm exec vitest run src/test-kernel/common/RunOutcomeAlgebra.vitest.ts src/test-kernel/shared/StreamStatusDisplay.vitest.ts src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/cli/CliRootArgs.vitest.mts`
- `corepack pnpm exec vitest run src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/RunExecution.vitest.mts src/test-kernel/cli/WorkflowRunCommand.vitest.mts src/test-kernel/cli/RunProgressRenderer.vitest.mts`
- `npm run typecheck`
- `npm test`
- `npm run lint` (passed with 16 pre-existing warnings)
- `npm run compile:fast`
- `git diff --check`

Closes #6961

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches stream lifecycle, persisted execution meta, desktop restart repair, and CLI frozen JSON fields across many hosts; behavior is heavily shimmed and tested but migration surface is broad.
> 
> **Overview**
> Introduces **Stage 0** `StreamPhase` / `StreamSubstate` as the migration vocabulary while **`StreamStatusService` and live seven-value statuses stay unchanged** for now.
> 
> **Canonical `RunOutcome`** is tightened as the terminal fact: `RUN_OUTCOME_PROJECTION` only maps to **execution status**; legacy transcript group-end and terminal stream values come from **`legacyEndGroupStatusForOutcome`** / **`terminalStreamStatusForOutcome`**. CLI **`createCliRunResult`** no longer takes a separate terminal status—it derives deprecated `status`, `terminalStatus`, and `endGroupStatus` from **`result.outcome`**, and meta reads prefer **`outcome`** with **`terminalStatus` → outcome** shims in execution KV.
> 
> **Desktop** persists and hydrates stream snapshots in **phases** (legacy on-disk statuses parse via union + transform); restart repair keys off **running/waiting phases** while still driving the in-memory status service through **phase ↔ status** converters.
> 
> **Progress UI** (extension `StreamHeader`, labels, indicator CSS) routes toolbar enablement and styling through **display keys** (phase/substate/`ready`) instead of raw legacy status strings, with distinct **completed vs cancelled** presentation where the old model collapsed them.
> 
> **Runtime** sets **`EXECUTION_STATUS.INTERRUPTED`** on user stop paths (registry, retry cancel) and adds **phase transition guards** (`canTransitionStreamPhase`, reservation helpers) plus exhaustive tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d1ca8ab07be80436f2683ce9ebd3e181c0dc962. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->