### PR TITLE
perf: stream transcript text deltas

### DIFF
--- a/packages/extension/src/progressView/frontend/formatters/index.ts
+++ b/packages/extension/src/progressView/frontend/formatters/index.ts
@@ -4,7 +4,11 @@
  */
 
 // Local imports - formatter helpers
-import type { LogMessageData, MessageType } from '@shared/schemas';
+import {
+  MESSAGE_TYPES,
+  type LogMessageData,
+  type MessageType,
+} from '@shared/schemas';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { isObject } from '@utils/core';
 import { safeFormat, type FormatOptions } from './baseLogFormatter';
@@ -52,6 +56,28 @@ const NULLABLE_TYPES: Set<MessageType> = new Set([
   'contextState',
   'contextManagement',
 ]);
+
+const STREAMING_TEXT_TYPES = new Set<string>([
+  MESSAGE_TYPES.THINKING,
+  MESSAGE_TYPES.SCRATCHPAD,
+  MESSAGE_TYPES.MODEL_RESPONSE,
+]);
+
+function isRunningData(data: unknown): boolean {
+  return (
+    data !== null &&
+    typeof data === 'object' &&
+    'status' in data &&
+    data.status === 'running'
+  );
+}
+
+export function isStreamingTextLogMessage(message: LogMessageData): boolean {
+  return (
+    STREAMING_TEXT_TYPES.has(message.messageType ?? '') &&
+    isRunningData(message.data)
+  );
+}
 
 /** Create an error fallback template when formatting fails. */
 function formatRenderError(label: string, errorMsg: string): TemplateResult {
@@ -144,6 +170,11 @@ export function formatLogEntry(
   logMessage: LogMessageData,
   options: FormatOptions = {},
 ): TemplateResult | typeof nothing {
+  if (isStreamingTextLogMessage(logMessage)) {
+    if (!logMessage.text.trim()) return nothing;
+    return formatDefaultLogMessageTemplate(logMessage) ?? nothing;
+  }
+
   const { messageType } = logMessage;
 
   // Determine if details should be open (undefined = no preference)

--- a/packages/extension/src/progressView/frontend/slices/logSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/logSlice.ts
@@ -9,6 +9,7 @@ import {
   type ContextStateData,
   type LogMessageData,
   type StreamLogEntry,
+  type StreamLogTextDelta,
 } from '@shared/schemas';
 
 import type { StreamLogs, StreamState } from '../store';
@@ -154,9 +155,27 @@ function applyEntry(
   return { logChanged: true, stateChanged };
 }
 
+function applyTextDelta(
+  delta: StreamLogTextDelta,
+  streamLogs: StreamLogs,
+): number | undefined {
+  const existingIndex = streamLogs.logIndex.get(delta.id);
+  if (existingIndex === undefined) return undefined;
+
+  const current = streamLogs.logs[existingIndex];
+  if (!current) return undefined;
+
+  streamLogs.logs[existingIndex] = {
+    ...current,
+    text: `${current.text}${delta.appendText}`,
+  };
+  return existingIndex;
+}
+
 export const logHandlers: HandlerRegistry = {
   [PROGRESS_VIEW_COMMANDS.LOG_DELTA]: (data, ctx) => {
     const { streamId, entries, updates } = data;
+    const textDeltas = data.textDeltas ?? [];
 
     ctx.setState((prev) =>
       create(prev, (draft) => {
@@ -193,6 +212,13 @@ export const logHandlers: HandlerRegistry = {
         // combined array in the streaming update path.
         for (const entry of entries) processEntry(entry);
         for (const entry of updates) processEntry(entry);
+        for (const delta of textDeltas) {
+          const existingIndex = applyTextDelta(delta, streamLogs);
+          if (existingIndex !== undefined) {
+            logChanged = true;
+            updatedMessageIndices.add(existingIndex);
+          }
+        }
 
         if (logChanged) {
           draft.streamLogs.set(streamId, {

--- a/src/shared/progressView/backend/WebviewBridge.ts
+++ b/src/shared/progressView/backend/WebviewBridge.ts
@@ -3,6 +3,7 @@ import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import type {
   ProgressViewOutboundMessage,
   StreamLogEntry,
+  StreamLogTextDelta,
   StreamTabId,
 } from '@shared/schemas';
 
@@ -18,7 +19,12 @@ export interface ProgressLogSource {
   readonly head: number;
   getRange(fromSeq: number, toSeq: number): StreamLogEntry[];
   getDirtyUpdates(maxSeqInclusive: number): StreamLogEntry[];
+  getDirtyTextDeltas(maxSeqInclusive: number): StreamLogTextDelta[];
   ackDirtyUpdates(updates: readonly StreamLogEntry[]): void;
+  ackDirtyTextDeltas(
+    deltas: readonly StreamLogTextDelta[],
+    fullEntries: readonly StreamLogEntry[],
+  ): void;
 }
 
 export interface ProgressLogStore {
@@ -130,8 +136,13 @@ export class WebviewBridge {
     const nextCursor = log.head;
     const entries = log.getRange(cursor, nextCursor);
     const updates = log.getDirtyUpdates(cursor);
+    const textDeltas = log.getDirtyTextDeltas(cursor);
 
-    if (entries.length === 0 && updates.length === 0) {
+    if (
+      entries.length === 0 &&
+      updates.length === 0 &&
+      textDeltas.length === 0
+    ) {
       entry.dirty = false;
       return true;
     }
@@ -141,11 +152,13 @@ export class WebviewBridge {
       streamId: activeStream,
       entries,
       updates,
+      textDeltas,
     } as const;
 
     if (!(await this.deliver(payload))) return false;
 
     log.ackDirtyUpdates(updates);
+    log.ackDirtyTextDeltas(textDeltas, entries);
     entry.cursor = nextCursor;
     entry.dirty = this.flushRequested;
     return true;

--- a/src/shared/schemas/log.ts
+++ b/src/shared/schemas/log.ts
@@ -83,6 +83,12 @@ export const StreamLogEntrySchema = z.strictObject({
 
 export type StreamLogEntry = z.infer<typeof StreamLogEntrySchema>;
 
+export const StreamLogTextDeltaSchema = z.strictObject({
+  id: z.string().min(1),
+  appendText: z.string().min(1),
+});
+export type StreamLogTextDelta = z.infer<typeof StreamLogTextDeltaSchema>;
+
 export const LogMessageDataSchema = z.strictObject({
   id: z.string().min(1),
   text: z.string(),

--- a/src/shared/schemas/progressView/outbound.ts
+++ b/src/shared/schemas/progressView/outbound.ts
@@ -8,7 +8,7 @@ import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import { GoalStatusSchema } from '../goal';
 
 import { StreamTabIdSchema } from '../identifiers';
-import { StreamLogEntrySchema } from '../log';
+import { StreamLogEntrySchema, StreamLogTextDeltaSchema } from '../log';
 import { AgentOptionDataSchema, ModelOptionDataSchema } from '../mainView';
 import { CompileFailureSchema, OutputFileInfoSchema } from '../output';
 import { InquiryThreadUpdatedEventSchema } from '../inquiry';
@@ -93,6 +93,7 @@ export const LogDeltaMessageSchema = z.object({
   streamId: StreamTabIdSchema,
   entries: z.array(StreamLogEntrySchema),
   updates: z.array(StreamLogEntrySchema).prefault([]),
+  textDeltas: z.array(StreamLogTextDeltaSchema).prefault([]),
 });
 
 // Round-keyed update messages share one shape: a stream id, an optional

--- a/src/test-kernel/progressView/LogDeltaTextDeltas.vitest.ts
+++ b/src/test-kernel/progressView/LogDeltaTextDeltas.vitest.ts
@@ -1,0 +1,161 @@
+import { create } from 'mutative';
+import { describe, expect, it } from 'vitest';
+
+import { isStreamingTextLogMessage } from '@progressView/frontend/formatters';
+import type {
+  HandlerRegistry,
+  MessageHandlerContext,
+} from '@progressView/frontend/messageHandlerTypes';
+import { logHandlers } from '@progressView/frontend/slices/logSlice';
+import {
+  createInitialState,
+  type ProgressState,
+  type StreamLogs,
+} from '@progressView/frontend/store';
+import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import {
+  AgentCategory,
+  LOG_LEVELS,
+  MESSAGE_TYPES,
+  STREAM_LOG_ENTRY_TYPES,
+  createStreamState,
+  type ProgressViewOutboundMessage,
+  type StreamLogEntry,
+  type StreamTabId,
+} from '@shared/schemas';
+
+function createContext(initialState: ProgressState): {
+  ctx: MessageHandlerContext;
+  getState: () => ProgressState;
+} {
+  let state = initialState;
+  const ctx: MessageHandlerContext = {
+    getState: () => state,
+    setState: (updater) => {
+      state = updater(state);
+    },
+    setStreamState: (streamId, updater) => {
+      const current = state.streamStates.get(streamId);
+      if (!current) return;
+      const updated = updater(current);
+      if (updated === current) return;
+      state = create(state, (draft) => {
+        draft.streamStates.set(streamId, updated);
+      });
+    },
+    setStreamLogs: (
+      _streamId,
+      _updater: (prev: StreamLogs) => StreamLogs,
+    ) => {},
+    savePrefs: () => {},
+    getPermissions: () => [],
+    setPermissions: () => {},
+    setPlacement: () => {},
+  };
+  return { ctx, getState: () => state };
+}
+
+function dispatch(
+  handlers: HandlerRegistry,
+  message: ProgressViewOutboundMessage,
+  ctx: MessageHandlerContext,
+) {
+  const handler = handlers[message.command];
+  expect(handler).toBeDefined();
+  handler?.(message as never, ctx);
+}
+
+function modelResponseEntry(
+  text: string,
+  status: 'running' | 'completed',
+): StreamLogEntry {
+  return {
+    seqNo: 1,
+    id: 'model-response',
+    type: STREAM_LOG_ENTRY_TYPES.LOG,
+    level: LOG_LEVELS.INFO,
+    timestamp: 100,
+    messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+    text,
+    data: { status },
+  };
+}
+
+describe('LOG_DELTA text deltas', () => {
+  it('accepts legacy logDelta messages with no textDeltas field', () => {
+    const streamId = 'stream-a' as StreamTabId;
+    const state = createInitialState();
+    state.activeStreamId = streamId;
+    state.streamStates.set(streamId, createStreamState(AgentCategory.Workflow));
+    const { ctx, getState } = createContext(state);
+
+    dispatch(
+      logHandlers,
+      {
+        command: PROGRESS_VIEW_COMMANDS.LOG_DELTA,
+        streamId,
+        entries: [modelResponseEntry('hello', 'running')],
+        updates: [],
+      } as unknown as ProgressViewOutboundMessage,
+      ctx,
+    );
+
+    expect(getState().streamLogs.get(streamId)?.logs[0]?.text).toBe('hello');
+  });
+
+  it('appends streamed text without whole-entry replacement and finalizes via full update', () => {
+    const streamId = 'stream-a' as StreamTabId;
+    const state = createInitialState();
+    state.activeStreamId = streamId;
+    state.streamStates.set(streamId, createStreamState(AgentCategory.Workflow));
+    const { ctx, getState } = createContext(state);
+
+    dispatch(
+      logHandlers,
+      {
+        command: PROGRESS_VIEW_COMMANDS.LOG_DELTA,
+        streamId,
+        entries: [modelResponseEntry('hello', 'running')],
+        updates: [],
+        textDeltas: [],
+      },
+      ctx,
+    );
+
+    dispatch(
+      logHandlers,
+      {
+        command: PROGRESS_VIEW_COMMANDS.LOG_DELTA,
+        streamId,
+        entries: [],
+        updates: [],
+        textDeltas: [{ id: 'model-response', appendText: ' world' }],
+      },
+      ctx,
+    );
+
+    const streamedLogs = getState().streamLogs.get(streamId);
+    const streamed = streamedLogs?.logs[0];
+    expect(streamed?.text).toBe('hello world');
+    expect(streamedLogs?.updatedMessageIndices).toEqual([0]);
+    expect(streamed && isStreamingTextLogMessage(streamed)).toBe(true);
+
+    dispatch(
+      logHandlers,
+      {
+        command: PROGRESS_VIEW_COMMANDS.LOG_DELTA,
+        streamId,
+        entries: [],
+        updates: [modelResponseEntry('hello world', 'completed')],
+        textDeltas: [],
+      },
+      ctx,
+    );
+
+    const finalizedLogs = getState().streamLogs.get(streamId);
+    const finalized = finalizedLogs?.logs[0];
+    expect(finalized?.text).toBe('hello world');
+    expect(finalizedLogs?.updatedMessageIndices).toEqual([0]);
+    expect(finalized && isStreamingTextLogMessage(finalized)).toBe(false);
+  });
+});

--- a/src/test-kernel/progressView/WebviewBridge.vitest.ts
+++ b/src/test-kernel/progressView/WebviewBridge.vitest.ts
@@ -71,6 +71,7 @@ describe('WebviewBridge', () => {
         }),
       ],
       updates: [],
+      textDeltas: [],
     });
 
     bridge.dispose();
@@ -119,6 +120,36 @@ describe('WebviewBridge', () => {
         }),
       ],
       updates: [],
+      textDeltas: [],
+    });
+
+    bridge.dispose();
+  });
+
+  it('replays full streamed text when a webview syncs mid-stream', async () => {
+    const store = new StreamLogStore();
+    const activeStream = 'active' as StreamTabId;
+    const sendMessage = vi.fn(() => true);
+    const bridge = new WebviewBridge(store, sendMessage, () => activeStream);
+
+    store.append(activeStream, logEntry('active-1', '', 100));
+    store.appendText(activeStream, 'active-1', 'hello ');
+    store.appendText(activeStream, 'active-1', 'world');
+
+    bridge.syncStream(activeStream);
+    await vi.advanceTimersByTimeAsync(20);
+
+    expect(sendMessage).toHaveBeenCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.LOG_DELTA,
+      streamId: activeStream,
+      entries: [
+        expect.objectContaining({
+          id: 'active-1',
+          text: 'hello world',
+        }),
+      ],
+      updates: [],
+      textDeltas: [],
     });
 
     bridge.dispose();
@@ -163,6 +194,7 @@ describe('WebviewBridge', () => {
           text: 'edited log',
         }),
       ],
+      textDeltas: [],
     });
 
     bridge.dispose();
@@ -203,7 +235,45 @@ describe('WebviewBridge', () => {
           text: 'edited while sending',
         }),
       ],
+      textDeltas: [],
     });
+
+    bridge.dispose();
+  });
+
+  it('ships streamed text as O(L) append deltas instead of full updates', async () => {
+    const store = new StreamLogStore();
+    const activeStream = 'active' as StreamTabId;
+    let deliveredBytes = 0;
+    const sendMessage = vi.fn((message) => {
+      deliveredBytes += JSON.stringify(message).length;
+      return true;
+    });
+    const bridge = new WebviewBridge(store, sendMessage, () => activeStream);
+    const chunk = 'x'.repeat(1024);
+
+    bridge.syncStream(activeStream);
+    store.append(activeStream, logEntry('active-1', '', 100));
+    await vi.advanceTimersByTimeAsync(20);
+
+    for (let i = 0; i < 40; i++) {
+      store.appendText(activeStream, 'active-1', chunk);
+      await vi.advanceTimersByTimeAsync(20);
+    }
+
+    const streamedFrames = sendMessage.mock.calls.slice(1).map(([message]) => {
+      expect(message).toEqual(
+        expect.objectContaining({
+          entries: [],
+          updates: [],
+          textDeltas: [{ id: 'active-1', appendText: chunk }],
+        }),
+      );
+      return JSON.stringify(message).length;
+    });
+
+    expect(streamedFrames).toHaveLength(40);
+    expect(deliveredBytes).toBeLessThan(90_000);
 
     bridge.dispose();
   });

--- a/src/test-kernel/transcript/StreamLog.vitest.ts
+++ b/src/test-kernel/transcript/StreamLog.vitest.ts
@@ -75,4 +75,65 @@ describe('StreamLog', () => {
     expect(log.update('message', { text: 'unchanged' })).toBeUndefined();
     expect(log.drainDirtyUpdates()).toEqual([]);
   });
+
+  it('tracks text appends separately from whole-entry updates', () => {
+    const log = new StreamLog();
+    log.append({
+      id: 'message',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 1,
+      text: '',
+      messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+    });
+
+    log.appendText('message', 'hello');
+    log.appendText('message', ' world');
+
+    expect(log.getRange(0, log.head)[0]?.text).toBe('hello world');
+    expect(log.getDirtyUpdates()).toEqual([]);
+    expect(log.getDirtyTextDeltas()).toEqual([
+      { id: 'message', appendText: 'hello world' },
+    ]);
+  });
+
+  it('keeps text appended while a delta frame is in flight', () => {
+    const log = new StreamLog();
+    log.append({
+      id: 'message',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 1,
+      text: '',
+      messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+    });
+
+    log.appendText('message', 'hello');
+    const inFlight = log.getDirtyTextDeltas();
+    log.appendText('message', ' world');
+    log.ackDirtyTextDeltas(inFlight);
+
+    expect(log.getDirtyTextDeltas()).toEqual([
+      { id: 'message', appendText: ' world' },
+    ]);
+  });
+
+  it('drops pending text deltas when a full entry replay covers them', () => {
+    const log = new StreamLog();
+    log.append({
+      id: 'message',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 1,
+      text: '',
+      messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+    });
+
+    log.appendText('message', 'hello');
+    const [entry] = log.getRange(0, log.head);
+    if (!entry) throw new Error('expected delivered entry');
+    log.ackDirtyTextDeltas([], [entry]);
+
+    expect(log.getDirtyTextDeltas()).toEqual([]);
+  });
 });

--- a/src/transcript/StreamLog.ts
+++ b/src/transcript/StreamLog.ts
@@ -1,4 +1,8 @@
-import { STREAM_LOG_ENTRY_TYPES, type StreamLogEntry } from '@shared/schemas';
+import {
+  STREAM_LOG_ENTRY_TYPES,
+  type StreamLogEntry,
+  type StreamLogTextDelta,
+} from '@shared/schemas';
 import { isObject } from '@utils/core';
 
 export type StreamLogAppendInput = Omit<StreamLogEntry, 'seqNo'>;
@@ -18,6 +22,7 @@ export class StreamLog {
   private seqCounter = 0;
   private readonly indexById = new Map<string, number>();
   private readonly dirtyUpdates = new Set<string>();
+  private readonly dirtyTextDeltas = new Map<string, StreamLogTextDelta>();
   private runningGroupCount = 0;
 
   constructor(entries: StreamLogEntry[] = []) {
@@ -110,6 +115,32 @@ export class StreamLog {
 
     this.entries[index] = updated;
     this.dirtyUpdates.add(id);
+    this.dirtyTextDeltas.delete(id);
+    return updated;
+  }
+
+  appendText(id: string, appendText: string): StreamLogEntry | undefined {
+    if (appendText.length === 0) return undefined;
+
+    const index = this.indexById.get(id);
+    if (index === undefined) return undefined;
+
+    const current = this.entries[index];
+    if (current.type !== STREAM_LOG_ENTRY_TYPES.LOG) return undefined;
+
+    const updated: StreamLogEntry = {
+      ...current,
+      text: `${current.text ?? ''}${appendText}`,
+    };
+
+    this.entries[index] = updated;
+    if (!this.dirtyUpdates.has(id)) {
+      const currentDelta = this.dirtyTextDeltas.get(id);
+      this.dirtyTextDeltas.set(id, {
+        id,
+        appendText: `${currentDelta?.appendText ?? ''}${appendText}`,
+      });
+    }
     return updated;
   }
 
@@ -137,6 +168,28 @@ export class StreamLog {
     return updates;
   }
 
+  getDirtyTextDeltas(
+    maxSeqInclusive: number = this.seqCounter,
+  ): StreamLogTextDelta[] {
+    const deltas: Array<{
+      delta: StreamLogTextDelta;
+      seqNo: number;
+    }> = [];
+    for (const [id, delta] of this.dirtyTextDeltas) {
+      const index = this.indexById.get(id);
+      if (index === undefined) {
+        this.dirtyTextDeltas.delete(id);
+        continue;
+      }
+      const entry = this.entries[index];
+      if (entry.seqNo <= maxSeqInclusive) {
+        deltas.push({ delta, seqNo: entry.seqNo });
+      }
+    }
+    deltas.sort((a, b) => a.seqNo - b.seqNo);
+    return deltas.map(({ delta }) => delta);
+  }
+
   drainDirtyUpdates(
     maxSeqInclusive: number = this.seqCounter,
   ): StreamLogEntry[] {
@@ -156,6 +209,17 @@ export class StreamLog {
         this.dirtyUpdates.delete(id);
       }
     }
+
+    for (const id of this.dirtyTextDeltas.keys()) {
+      const index = this.indexById.get(id);
+      if (index === undefined) {
+        this.dirtyTextDeltas.delete(id);
+        continue;
+      }
+      if (this.entries[index].seqNo <= maxSeqInclusive) {
+        this.dirtyTextDeltas.delete(id);
+      }
+    }
   }
 
   ackDirtyUpdates(updates: readonly StreamLogEntry[]): void {
@@ -167,6 +231,35 @@ export class StreamLog {
       }
       if (this.entries[index] === update) {
         this.dirtyUpdates.delete(update.id);
+      }
+    }
+  }
+
+  ackDirtyTextDeltas(
+    deltas: readonly StreamLogTextDelta[],
+    fullEntries: readonly StreamLogEntry[] = [],
+  ): void {
+    for (const entry of fullEntries) {
+      const index = this.indexById.get(entry.id);
+      if (index !== undefined && this.entries[index] === entry) {
+        this.dirtyTextDeltas.delete(entry.id);
+      }
+    }
+
+    for (const delta of deltas) {
+      const current = this.dirtyTextDeltas.get(delta.id);
+      if (!current) continue;
+
+      if (current.appendText === delta.appendText) {
+        this.dirtyTextDeltas.delete(delta.id);
+        continue;
+      }
+
+      if (current.appendText.startsWith(delta.appendText)) {
+        this.dirtyTextDeltas.set(delta.id, {
+          id: delta.id,
+          appendText: current.appendText.slice(delta.appendText.length),
+        });
       }
     }
   }

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -283,6 +283,24 @@ export class StreamLogStore {
     return updated;
   }
 
+  appendText(
+    streamId: StreamTabId,
+    id: string,
+    appendText: string,
+  ): StreamLogEntry | undefined {
+    const logInstance = this.logs.get(streamId);
+    if (!logInstance) return undefined;
+
+    const updated = logInstance.appendText(id, appendText);
+    if (!updated) return undefined;
+
+    this.refreshSummary(streamId, logInstance);
+    this.markDirty(streamId);
+    void this.save();
+    this.notify(streamId);
+    return updated;
+  }
+
   clearDirtyUpdates(streamId: StreamTabId): void {
     this.logs.get(streamId)?.clearDirtyUpdates();
   }

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -111,8 +111,9 @@ export function attachTranscriptRecorder(
       clearTimeout(state.updateTimer);
       state.updateTimer = null;
     }
+    const pendingText = state.pending.join('');
     if (state.pending.length > 0) {
-      state.buffer += state.pending.join('');
+      state.buffer += pendingText;
       state.pending = [];
     }
     if (!state.enabled) return;
@@ -134,10 +135,17 @@ export function attachTranscriptRecorder(
       return;
     }
 
-    store.update(streamId, id, {
-      text: state.buffer,
-      data: { status: state.ended ? 'completed' : 'running' },
-    });
+    if (!state.ended && pendingText.length > 0) {
+      store.appendText(streamId, id, pendingText);
+      return;
+    }
+
+    if (state.ended) {
+      store.update(streamId, id, {
+        text: state.buffer,
+        data: { status: 'completed' },
+      });
+    }
   };
 
   const scheduleStreamUpdate = (state: StreamSinkState, id: string): void => {


### PR DESCRIPTION
## Summary

Adds a text-delta path for in-flight transcript rows so streamed model text no longer resends and reparses the full accumulated buffer on every tick.

The store still keeps the full text for persistence/reload. The bridge now sends `LOG_DELTA.textDeltas` for append-only streaming chunks, whole-entry updates remain the path for tool-card patches and final stream completion, and the frontend uses a plain-text fast path for running model/thinking/scratchpad rows before returning to the existing formatter on finalization.

Evidence drift was re-verified and noted on #6969 before implementation: the cited behavior still existed, but the live paths are now `src/transcript/TexraTranscriptRecorder.ts`, `src/transcript/StreamLog.ts`, `src/shared/progressView/backend/WebviewBridge.ts`, and `packages/extension/src/progressView/frontend/slices/logSlice.ts`.

## Issue acceptance gates

Addresses #6969.

- [x] IPC bytes for a synthetic 40KB streamed response are O(L): `WebviewBridge.vitest.ts` asserts each streaming frame contains only one `{ id, appendText }` delta and total delivered JSON stays below 90KB.
- [x] Live-row render cost avoids full markdown re-parse per tick: running streamed text rows use the `isStreamingTextLogMessage` plain-text fast path, and the final whole-entry update exits that fast path.
- [x] Webview reload mid-stream reconstructs complete text from the store: bridge sync test replays the full current row text with no stale deltas.
- [x] Final rendered entry path remains byte-compatible with today: finalization still sends a whole `StreamLogEntry`, so the existing formatter receives the same completed row shape.
- [x] C4d follow-up noted on #6952: https://github.com/LionSR/TeXRA/issues/6952#issuecomment-4879732022

## Single source of truth

`StreamLog` owns both the persisted full row text and the dirty append-delta bookkeeping. `StreamLogTextDeltaSchema` in `src/shared/schemas/log.ts` owns the wire shape used by `LOG_DELTA.textDeltas`.

## Duplication and abstraction budget

This removes the duplicate per-tick whole-buffer transport/render work for streaming rows. The added mass lives mostly in acceptance tests covering O(L) bytes, mid-stream reload, delta ack behavior, and frontend finalization semantics.

## Host impact

Extension: Progress-view transcript rows receive append deltas for active streamed text and render running model/thinking/scratchpad rows through a plain-text fast path until finalization.

Desktop: Desktop uses the same progress bridge/store path, so streamed progress-view rows get the lower-byte delta protocol without changing persisted stream logs or restart reload behavior.

CLI: No CLI contract change; the CLI/TUI continues reading complete text from `StreamLogStore`.

## Scheduled refactoring

No new temporary shim, projection, dual-write, alias, fallback, or migration path was introduced. The C4d timing-policy follow-up is recorded on #6952 and intentionally kept out of this protocol PR.

## Validation

- `corepack pnpm exec prettier --write` on touched files
- `corepack pnpm exec vitest run src/test-kernel/transcript/StreamLog.vitest.ts src/test-kernel/progressView/WebviewBridge.vitest.ts src/test-kernel/progressView/LogDeltaTextDeltas.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `npm run typecheck`
- `npm test`
- `npm run lint` (passed with 16 pre-existing warnings)
- `npm run compile:fast`
- `corepack pnpm --filter texra vite:webviews`
- `corepack pnpm run smoke:webviews:run`
- `git diff --check`

Closes #6969

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the hot streaming path (IPC, store, recorder, and progress UI) but keeps persistence and completion on whole entries; behavior is covered by new vitest cases for O(L) bytes, delta acks, and finalization.
> 
> **Overview**
> Adds an **append-only text delta** path for in-flight transcript rows so streaming model/thinking/scratchpad text no longer resends the full accumulated buffer on every tick.
> 
> **Backend:** `StreamLog` tracks dirty `StreamLogTextDelta` chunks alongside whole-entry updates; `TexraTranscriptRecorder` calls `appendText` while a stream is running and only uses a full `update` when the stream completes. `LOG_DELTA` now includes a `textDeltas` array (schema in `log.ts`), and `WebviewBridge` flushes and acks those deltas with logic for in-flight frames and mid-stream webview sync (full row text replayed on `syncStream`).
> 
> **Frontend:** `logSlice` merges `textDeltas` into existing log row text. Running thinking/scratchpad/model-response rows with `data.status === 'running'` render through a **plain-text fast path** (`isStreamingTextLogMessage`) until a final whole-entry update marks completion and restores the normal formatters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eda01a3733ebe4341563a725d44975e2b55355a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
