### PR TITLE
refactor: route run facts through session event hub

### DIFF
--- a/docs/proposals/session-scoped-runtime-architecture.md
+++ b/docs/proposals/session-scoped-runtime-architecture.md
@@ -1,8 +1,9 @@
 # Session-scoped runtime architecture: facts, interactions, and status ownership
 
-> **Status:** Open proposal (2026-07-03; status refreshed 2026-07-04). Companion
-> to the diagnosis in `tech-debt-audit-2026-07.md` (Part B1/B5 + appendix); this
-> document is the target design. It covers the event/logger chain, the
+> **Status:** Partially landed proposal (Stages 0-1; status refreshed
+> 2026-07-04). Companion to the diagnosis in
+> `tech-debt-audit-2026-07.md` (Part B1/B5 + appendix); this document is the
+> target design. It covers the event/logger chain, the
 > approval/interaction RPC machinery, stream status, and the execution registries
 > — and how all of them couple to the UI backends.
 

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -1,5 +1,6 @@
 import { Node } from '@agent/node';
 import { useLaunchRunContext } from '@agent/runtime/RunContext';
+import { emitRunFact } from '@agent/runtime/runFactEvents';
 import type { RoundFileMapping } from '@agent/output/types';
 import type { CompiledPdfArtifact } from '@agent/output/compiledPdfArtifacts';
 import type { LatexDiffManager } from '@agent/output/LatexDiffManager';
@@ -261,20 +262,20 @@ export class OutputNode<C = unknown> extends Node<
     prepRes: OutputPrepInput,
     execRes: OutputExecResult,
   ): Promise<string | undefined> {
-    const { outputState, workflowOutputPolicy } = this.services;
+    const { logger, outputState, workflowOutputPolicy } = this.services;
     const outputDependencies = this.outputDependencies();
     const { runtimeHost, streamId } = outputDependencies;
     const { outputLocation, currentRound, endTurn } = prepRes;
     const { summary, roundOutput } = execRes;
 
     // Emit output files event
-    runtimeHost.emit('addOutputFiles', {
+    emitRunFact(logger, 'addOutputFiles', {
       streamId,
       filesByRound: { [currentRound]: summary.fileInfos },
     });
 
     if (execRes.emitCompileFailures) {
-      runtimeHost.emit('updateCompileFailures', {
+      emitRunFact(logger, 'updateCompileFailures', {
         streamId,
         filesByRound: { [currentRound]: execRes.compileFailures },
       });
@@ -314,7 +315,7 @@ export class OutputNode<C = unknown> extends Node<
           summary.stage,
         );
 
-        runtimeHost.emit('updateMissingOutputs', {
+        emitRunFact(logger, 'updateMissingOutputs', {
           streamId,
           filesByRound: { [currentRound]: validationResult.missing },
         });

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -1,6 +1,7 @@
 import { Node } from '@agent/node';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { useLaunchRunContext } from '@agent/runtime/RunContext';
+import { emitRunFact } from '@agent/runtime/runFactEvents';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import {
   createToolUseRoundFlow,
@@ -52,15 +53,15 @@ export class ToolUseCycleNode<C> extends Node<
 
   async exec(prepRes: CyclePrepResult): Promise<ToolUseCycleOutcome> {
     const { setting, resolvedTools, modelHandler } = this.services;
-    const { streamId, runtimeHost } = useLaunchRunContext();
+    const { streamId } = useLaunchRunContext();
 
     if (prepRes.shouldSkipCycle) {
       const { todos, plan } = prepRes.workspaceState.workPlan;
       if (todos.length) {
-        runtimeHost.emit('updateTodos', { streamId, todos });
+        emitRunFact(this.services.logger, 'updateTodos', { streamId, todos });
       }
       if (plan) {
-        runtimeHost.emit('updatePlan', { streamId, plan });
+        emitRunFact(this.services.logger, 'updatePlan', { streamId, plan });
       }
       return { outcome: 'skipped' };
     }
@@ -90,7 +91,7 @@ export class ToolUseCycleNode<C> extends Node<
     let todoPersistChain = Promise.resolve();
     prepRes.workspaceState.workPlan.setOnUpdate({
       onTodosUpdate: (todos) => {
-        runtimeHost.emit('updateTodos', { streamId, todos });
+        emitRunFact(this.services.logger, 'updateTodos', { streamId, todos });
         if (persistTodos) {
           todoPersistChain = todoPersistChain
             .then(() => persistTodos(todos))
@@ -105,7 +106,7 @@ export class ToolUseCycleNode<C> extends Node<
         onProgress?.({ kind: 'todos', todos });
       },
       onPlanUpdate: (plan) => {
-        runtimeHost.emit('updatePlan', { streamId, plan });
+        emitRunFact(this.services.logger, 'updatePlan', { streamId, plan });
         onProgress?.({ kind: 'plan', plan });
       },
     });

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -3,6 +3,7 @@ import { Node } from '@agent/node';
 import { logUserMessage } from '@agent/trace';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { useLaunchRunContext } from '@agent/runtime/RunContext';
+import { emitRunFact } from '@agent/runtime/runFactEvents';
 import {
   appendFollowUpAsUserMessage,
   followUpDisplayText,
@@ -86,7 +87,7 @@ export class ToolUseWaitNode<C> extends Node<
       if (goal?.status === 'active') {
         await GoalStore.setStatus(streamId, 'paused');
         await setGoalSessionBashAutoApproval(streamId, false, runtimeHost);
-        runtimeHost.emit('goalPaused', { streamId });
+        emitRunFact(this.services.logger, 'goalPaused', { streamId });
       }
     } else {
       const delivered = await onBeforeWaiting?.(

--- a/src/agent/output/OutputFileProcessor.ts
+++ b/src/agent/output/OutputFileProcessor.ts
@@ -1,6 +1,7 @@
 import { logMissingOutputs, type AgentTrace } from '@agent/trace';
 import type { AgentWorkflowSetting } from '@agent/core/definition/AgentDataclass';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { emitRunFact } from '@agent/runtime/runFactEvents';
 import {
   type FileLocation,
   type OutputFileInfo,
@@ -159,7 +160,7 @@ export class OutputFileProcessor {
       xmlFile: outputLocation.absolutePath,
       documentTag: this.ctx.agentSetting.documentTag,
     });
-    this.ctx.runtimeHost.emit('updateMissingOutputs', {
+    emitRunFact(this.ctx.logger, 'updateMissingOutputs', {
       streamId: this.ctx.streamId,
       filesByRound: { [currRound]: [] },
     });

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -74,6 +74,7 @@ import {
 } from './StreamStatusService';
 import { currentSession, type SessionHandle } from './SessionHandle';
 import { attachConversationProgressHub } from './conversationProgressHub';
+import { attachSessionRunFactProjector } from './SessionRunFactProjector';
 import type { ToolEditApprovalPort } from '@platform/interfaces/toolEditApproval';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 
@@ -333,12 +334,36 @@ async function assembleAgentLaunchContext(
   // runs outside any ALS, so it resolves to the process default. Either way the
   // child is tracked in the same session as its launcher.
   const session = input.session ?? currentSession();
-  const runTrace = createRunTrace(streamId, undefined, session.flushers);
+  const rawRunTrace = createRunTrace(streamId, undefined, session.flushers);
+  const detachSessionTrace = session.attachRunTrace(
+    rawRunTrace.trace,
+    streamId,
+  );
+  const detachRunFactProjector = attachSessionRunFactProjector(
+    session.events,
+    runtimeHost,
+    streamId,
+  );
+  const detachProgressHub = attachConversationProgressHub(
+    session.events,
+    runtimeHost,
+    streamId,
+  );
+  const runTrace: RunTrace = {
+    trace: rawRunTrace.trace,
+    dispose: () => {
+      detachProgressHub();
+      detachRunFactProjector();
+      detachSessionTrace();
+      rawRunTrace.dispose();
+    },
+  };
   onRunTraceCreated(runTrace);
   const agentLogger = runTrace.trace;
   modelHandler.setAgentCategory(setting.agentCategory);
   modelHandler.setLogger(agentLogger);
 
+  session.events.assertRunSubscribersAttachedBeforeActivation(streamId);
   input.onBeforeActivation?.(streamId);
 
   runtimeHost.emit('setActiveStream', {
@@ -578,25 +603,6 @@ export async function buildAgentLaunchContext(
         runTrace = rt;
       },
     );
-    // Attach the session result-hub only after a successful launch, so a
-    // launch failure (which disposes the trace via the catch below and never
-    // returns a context) can never publish a result event. Bundle the detach
-    // into the run's trace teardown.
-    const detachResultHub = ctx.session.attachRunTrace(ctx.logger);
-    // Single derivation point for `updateConversationProgress` (F-1b): flow
-    // code reports counters via `logConversationProgress`, this hub is the
-    // only place that turns them into the host UI event.
-    const detachProgressHub = attachConversationProgressHub(
-      ctx.logger,
-      ctx.runtimeHost,
-      ctx.streamId,
-    );
-    const disposeTrace = ctx.disposeTrace;
-    ctx.disposeTrace = () => {
-      detachResultHub();
-      detachProgressHub();
-      disposeTrace();
-    };
     return ctx;
   } catch (err) {
     compensateFailedActivation({

--- a/src/agent/runtime/SessionEventHub.ts
+++ b/src/agent/runtime/SessionEventHub.ts
@@ -1,0 +1,96 @@
+import process from 'node:process';
+
+import type { AgentEvent } from '@agent/trace';
+import { createChannelTrace } from '@logger';
+import type { StreamTabId } from '@shared/schemas';
+
+const logger = createChannelTrace('SessionEventHub');
+
+export type SessionFact = never;
+
+export type SessionEvent =
+  | { scope: 'run'; streamId: StreamTabId; event: AgentEvent }
+  | { scope: 'session'; event: SessionFact };
+
+export interface SessionEventSubscriptionFilter {
+  readonly scope?: SessionEvent['scope'];
+  readonly types?: readonly AgentEvent['type'][];
+}
+
+export type SessionEventSubscriber = (event: SessionEvent) => void;
+
+interface SubscriberRegistration {
+  readonly subscriber: SessionEventSubscriber;
+  readonly scope?: SessionEvent['scope'];
+  readonly types?: ReadonlySet<AgentEvent['type']>;
+}
+
+function isDevAssertionMode(): boolean {
+  return (
+    process.env.NODE_ENV === 'test' || process.env.TEXRA_DEV_ASSERTIONS === '1'
+  );
+}
+
+/**
+ * Session-scoped one-way fact hub. Filters are applied before subscriber
+ * callbacks so high-volume stream chunks only reach consumers that explicitly
+ * asked for them.
+ */
+export class SessionEventHub {
+  private readonly subscribers = new Set<SubscriberRegistration>();
+  private runScopeSubscriberCount = 0;
+
+  emit(event: SessionEvent): void {
+    for (const registration of this.subscribers) {
+      if (registration.scope && registration.scope !== event.scope) continue;
+      if (
+        registration.types &&
+        (event.scope !== 'run' || !registration.types.has(event.event.type))
+      ) {
+        continue;
+      }
+      try {
+        registration.subscriber(event);
+      } catch (err) {
+        logger.warn('Session event subscriber threw', { data: err });
+      }
+    }
+  }
+
+  subscribe(
+    subscriber: SessionEventSubscriber,
+    filter: SessionEventSubscriptionFilter = {},
+  ): () => void {
+    const registration: SubscriberRegistration = {
+      subscriber,
+      scope: filter.scope,
+      types: filter.types ? new Set(filter.types) : undefined,
+    };
+    this.subscribers.add(registration);
+    if (filter.scope !== 'session') {
+      this.runScopeSubscriberCount += 1;
+    }
+
+    return () => {
+      if (!this.subscribers.delete(registration)) return;
+      if (filter.scope !== 'session') {
+        this.runScopeSubscriberCount -= 1;
+      }
+    };
+  }
+
+  /**
+   * Dev/test guard for startup-resume ordering: run-scoped projectors must be
+   * attached before a launch activates the stream. Production logs the
+   * violation so startup can continue; tests and opt-in dev runs throw.
+   */
+  assertRunSubscribersAttachedBeforeActivation(streamId: StreamTabId): void {
+    if (this.runScopeSubscriberCount > 0) return;
+
+    const message = `No run-scoped session event subscribers attached before activating ${streamId}`;
+    if (isDevAssertionMode()) {
+      throw new Error(message);
+    }
+    logger.warn(message);
+  }
+}

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -31,6 +31,7 @@ import { getActiveFlushers, unregisterFlushers } from '@transcript';
 import type { AgentTrace, ResultEvent } from '@agent/trace';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import { createChannelTrace } from '@logger';
+import type { StreamTabId } from '@shared/schemas';
 
 import { tryUseRunContext } from './RunContext';
 import { ExecutionRegistry, executionRegistry } from './executionRegistry';
@@ -41,6 +42,7 @@ import {
   executionSubscriptionBinder,
 } from './ExecutionSubscriptionBinder';
 import { StreamStatusService } from './StreamStatusService';
+import { SessionEventHub } from './SessionEventHub';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 
 const logger = createChannelTrace('sessionHandle');
@@ -53,6 +55,7 @@ export type SessionHandleInit = Partial<
     | 'executions'
     | 'coordinators'
     | 'subscriptions'
+    | 'events'
     | 'flushers'
     | 'hostChannel'
   >
@@ -75,6 +78,8 @@ export class SessionHandle {
   readonly coordinators: RunCoordinatorBridge;
   /** Execution-status subscriptions bound to agent stream lifecycles. */
   readonly subscriptions: ExecutionSubscriptionBinder;
+  /** Session-scoped one-way fact plane. */
+  readonly events: SessionEventHub;
   /** This session's trace-flush callbacks (drained on dispose / shutdown). */
   readonly flushers: Set<() => void>;
   /**
@@ -110,6 +115,7 @@ export class SessionHandle {
         session: this,
       });
     this.subscriptions = subscriptions;
+    this.events = init.events ?? new SessionEventHub();
     // A fresh session owns its own flusher set; the default session aliases the
     // process-module set so `createRunTrace`'s default writes still drain.
     this.flushers = init.flushers ?? new Set<() => void>();
@@ -142,8 +148,9 @@ export class SessionHandle {
    * `result` events to the session's listeners. Returns a detach disposer the
    * run bundles into its trace teardown.
    */
-  attachRunTrace(trace: AgentTrace): () => void {
+  attachRunTrace(trace: AgentTrace, streamId: StreamTabId): () => void {
     return trace.subscribe((event) => {
+      this.events.emit({ scope: 'run', streamId, event });
       if (event.type !== 'result') return;
       // Guard each listener so one throwing consumer can't starve the rest:
       // the whole fan-out is a single trace subscriber, so without this a throw

--- a/src/agent/runtime/SessionRunFactProjector.ts
+++ b/src/agent/runtime/SessionRunFactProjector.ts
@@ -1,0 +1,65 @@
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import { type StorageKey, type StreamTabId } from '@shared/schemas';
+import { isObject } from '@utils/core';
+
+import { fromRunFactDomainKey } from './runFactEvents';
+import type { SessionEventHub } from './SessionEventHub';
+
+type UpdateStreamUsagePayload = ProgressEventPayloads['updateStreamUsage'];
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function toUpdateStreamUsagePayload(
+  data: unknown,
+  fallbackStreamId: StreamTabId,
+): UpdateStreamUsagePayload | undefined {
+  if (!isObject(data)) return undefined;
+  const storageKey = asString(data.storageKey);
+  const usage = isObject(data.usage) ? data.usage : undefined;
+  if (!storageKey || !usage) return undefined;
+
+  const streamId = asString(data.streamId) ?? fallbackStreamId;
+  const executionId = asString(data.executionId);
+  return {
+    streamId: streamId as StreamTabId,
+    storageKey: storageKey as StorageKey,
+    ...(executionId ? { executionId } : {}),
+    usage: usage as UpdateStreamUsagePayload['usage'],
+  };
+}
+
+/**
+ * Project run-scoped trace facts back onto the current host event surface.
+ * Downstream progress handlers remain unchanged during the migration.
+ */
+export function attachSessionRunFactProjector(
+  events: SessionEventHub,
+  runtimeHost: AgentRuntimeHost,
+  projectedStreamId: StreamTabId,
+): () => void {
+  return events.subscribe(
+    (sessionEvent) => {
+      if (sessionEvent.scope !== 'run') return;
+      if (sessionEvent.streamId !== projectedStreamId) return;
+      const { event, streamId } = sessionEvent;
+
+      if (event.type === 'usage') {
+        const payload = toUpdateStreamUsagePayload(event.data, streamId);
+        if (payload) runtimeHost.emit('updateStreamUsage', payload);
+        return;
+      }
+
+      if (event.type !== 'domain') return;
+      const factName = fromRunFactDomainKey(event.key);
+      if (!factName || !isObject(event.data)) return;
+      runtimeHost.emit(
+        factName,
+        event.data as ProgressEventPayloads[typeof factName],
+      );
+    },
+    { scope: 'run', types: ['domain', 'usage'] },
+  );
+}

--- a/src/agent/runtime/conversationProgressHub.ts
+++ b/src/agent/runtime/conversationProgressHub.ts
@@ -8,11 +8,11 @@
  * event, replacing the two call sites that used to call `runtimeHost.emit`
  * directly from `executeAgent.ts`.
  */
-import type { AgentTrace } from '@agent/trace';
 import type { ConversationProgress, StreamTabId } from '@shared/schemas';
 import { isObject } from '@utils/core';
 
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
+import type { SessionEventHub } from './SessionEventHub';
 
 /** Narrows a domain event's untyped `data` to the shape `logConversationProgress`
  *  always sends. `DomainEvent.data` is `unknown` because the channel is a
@@ -29,18 +29,26 @@ function isConversationProgress(data: unknown): data is ConversationProgress {
 
 /** Returns a detach disposer; callers bundle it into the run's trace teardown. */
 export function attachConversationProgressHub(
-  trace: AgentTrace,
+  events: SessionEventHub,
   runtimeHost: AgentRuntimeHost,
   streamId: StreamTabId,
 ): () => void {
-  return trace.subscribe((event) => {
-    if (event.type !== 'domain' || event.key !== 'conversationProgress') {
-      return;
-    }
-    if (!isConversationProgress(event.data)) return;
-    runtimeHost.emit('updateConversationProgress', {
-      streamId,
-      progress: event.data,
-    });
-  });
+  return events.subscribe(
+    (sessionEvent) => {
+      if (
+        sessionEvent.scope !== 'run' ||
+        sessionEvent.streamId !== streamId ||
+        sessionEvent.event.type !== 'domain' ||
+        sessionEvent.event.key !== 'conversationProgress'
+      ) {
+        return;
+      }
+      if (!isConversationProgress(sessionEvent.event.data)) return;
+      runtimeHost.emit('updateConversationProgress', {
+        streamId,
+        progress: sessionEvent.event.data,
+      });
+    },
+    { scope: 'run', types: ['domain'] },
+  );
 }

--- a/src/agent/runtime/runFactEvents.ts
+++ b/src/agent/runtime/runFactEvents.ts
@@ -1,0 +1,42 @@
+import type { AgentTrace } from '@agent/trace';
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+
+export const RUN_FACT_DOMAIN_PREFIX = 'runFact.';
+
+export const RUN_FACT_EVENT_NAMES = [
+  'updateTodos',
+  'updatePlan',
+  'addOutputFiles',
+  'updateMissingOutputs',
+  'updateCompileFailures',
+  'goalPaused',
+] as const satisfies readonly (keyof ProgressEventPayloads)[];
+
+export type RunFactEventName = (typeof RUN_FACT_EVENT_NAMES)[number];
+
+const RUN_FACT_EVENT_SET = new Set<string>(RUN_FACT_EVENT_NAMES);
+
+export function toRunFactDomainKey(event: RunFactEventName): string {
+  return `${RUN_FACT_DOMAIN_PREFIX}${event}`;
+}
+
+export function fromRunFactDomainKey(
+  key: string,
+): RunFactEventName | undefined {
+  if (!key.startsWith(RUN_FACT_DOMAIN_PREFIX)) return undefined;
+  const event = key.slice(RUN_FACT_DOMAIN_PREFIX.length);
+  return RUN_FACT_EVENT_SET.has(event)
+    ? (event as RunFactEventName)
+    : undefined;
+}
+
+export function emitRunFact<K extends RunFactEventName>(
+  trace: AgentTrace,
+  event: K,
+  payload: ProgressEventPayloads[K],
+): void {
+  trace.domain({
+    key: toRunFactDomainKey(event),
+    data: payload,
+  });
+}

--- a/src/agent/trace/AgentTrace.ts
+++ b/src/agent/trace/AgentTrace.ts
@@ -136,6 +136,11 @@ export interface StagedEmitOptions {
   readonly stageId?: string;
 }
 
+export interface UsageEmitOptions extends StagedEmitOptions {
+  readonly data?: unknown;
+  readonly recordTranscript?: boolean;
+}
+
 /**
  * Agent-general SDK surface. Every method ultimately reduces to `emit()` so
  * the trace channel is a single source of truth. TeXRA-specific helpers are
@@ -158,7 +163,7 @@ export interface AgentTrace {
   error(message: string, options?: LogOptions): void;
 
   // ─── First-class agent-general union arms ───────────────────────────
-  usage(stats: TokenUsageStats, options?: StagedEmitOptions): void;
+  usage(stats: TokenUsageStats, options?: UsageEmitOptions): void;
   contextState(snapshot: ContextStateData, options?: StagedEmitOptions): void;
   toolStart(
     input: { logId: string; toolName: string; input: unknown },

--- a/src/agent/trace/TraceEmitter.ts
+++ b/src/agent/trace/TraceEmitter.ts
@@ -35,6 +35,7 @@ import type {
   StageOptions,
   StreamHandle,
   StreamOptions,
+  UsageEmitOptions,
 } from './AgentTrace';
 
 export class TraceEmitter implements AgentTrace {
@@ -139,8 +140,14 @@ export class TraceEmitter implements AgentTrace {
 
   // ─── Structured emitters ───────────────────────────────────────────
 
-  usage(stats: TokenUsageStats, options: StagedEmitOptions = {}): void {
-    this.emit({ type: 'usage', stats, stageId: options.stageId });
+  usage(stats: TokenUsageStats, options: UsageEmitOptions = {}): void {
+    this.emit({
+      type: 'usage',
+      stats,
+      data: options.data,
+      recordTranscript: options.recordTranscript,
+      stageId: options.stageId,
+    });
   }
 
   contextState(

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -109,6 +109,14 @@ export interface ToolEndEvent extends StageStamp {
 export interface UsageEvent extends StageStamp {
   readonly type: 'usage';
   readonly stats: TokenUsageStats;
+  /**
+   * Host/product-specific usage projection payload. Agent-general consumers can
+   * ignore this; TeXRA uses it to project sidebar totals from the same trace
+   * event that records transcript statistics.
+   */
+  readonly data?: unknown;
+  /** False when this usage report should not create a transcript stats row. */
+  readonly recordTranscript?: boolean;
 }
 
 /** Context window utilisation snapshot. */

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -59,8 +59,7 @@ export interface UsageMonitorModelInfo {
  * Runtime dependencies for UsageMonitor.
  *
  * Takes individual fields instead of full AgentExecutionContext:
- * - logger: For error logging and the workflow-mode `usage` trace event
- * - runtimeHost: For the `updateStreamUsage` progress-view event
+ * - logger: For error logging and the single `usage` trace event
  * - storageKey: The storage key for this execution (immutable)
  * - streamId: For backend logging
  */
@@ -103,7 +102,7 @@ export class UsageMonitor {
   }
 
   async recordUsage(stateGlobal: AgentRunStateSnapshot): Promise<void> {
-    const { logger, runtimeHost, storageKey, streamId } = this.context;
+    const { logger, storageKey, streamId } = this.context;
     const { agentCategory } = this.metadata;
     const runKind: UsageMonitorRunKind =
       agentCategory === AgentCategory.ToolUse ? 'tool-use' : 'workflow';
@@ -163,26 +162,25 @@ export class UsageMonitor {
         ...(usageRoute != null && { usageRoute }),
       };
 
-      // Two surfaces for usage: the progress-view sidebar (via runtimeHost
-      // event) and — for workflow agents — the transcript's statistics line
-      // (via the trace channel). Tool-use agents skip the transcript copy
-      // because their UI surface is the tool-use cards, not a stats line.
-      runtimeHost.emit('updateStreamUsage', {
-        streamId,
-        storageKey,
-        usage: payload,
-      });
-      if (agentCategory === AgentCategory.Workflow) {
-        const transcriptPayload = Object.fromEntries(
-          Object.entries(payload).filter(([, v]) => typeof v === 'number'),
-        ) as Record<string, number>;
+      const transcriptPayload = Object.fromEntries(
+        Object.entries(payload).filter(([, v]) => typeof v === 'number'),
+      ) as Record<string, number>;
+      // One trace event feeds both surfaces: the transcript recorder consumes
+      // `stats` for workflow agents, and the session projector consumes `data`
+      // for sidebar totals. Tool-use agents keep their existing no-stats-row UI
+      // by opting out of transcript recording.
+      logger.usage(transcriptPayload, {
+        data: {
+          streamId,
+          storageKey,
+          usage: payload,
+        },
+        recordTranscript: agentCategory === AgentCategory.Workflow,
         // The round stage's AsyncLocalStorage scope already stamps the active
         // round id (r0/r1...) onto emitted events; fall back to storageKey for
         // any usage logged outside a round stage.
-        logger.usage(transcriptPayload, {
-          stageId: logger.activeStageId() ?? storageKey,
-        });
-      }
+        stageId: logger.activeStageId() ?? storageKey,
+      });
 
       // Log to backend for analytics/billing. Relay-backed rounds wait for the
       // flush because the next relay request enforces the cap from DB state.

--- a/src/test-kernel/agent/followUp/CodexProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/CodexProgressEvents.vitest.ts
@@ -8,6 +8,9 @@ import {
   setDefaultStreamLogStore,
   StreamLogStore,
 } from '@transcript';
+import { TraceEmitter } from '@agent/trace';
+import { SessionEventHub } from '@agent/runtime/SessionEventHub';
+import { attachSessionRunFactProjector } from '@agent/runtime/SessionRunFactProjector';
 
 // Local imports - shared
 import { MESSAGE_TYPES } from '@shared/schemas';
@@ -58,11 +61,21 @@ async function* streamEvents(
 }
 
 describe('codex progress events', () => {
-  it('publishes todos and usage through the explicit runtime host', () => {
+  it('publishes todos and usage through the session fact projector', () => {
     const active = createRecordingHost();
+    const trace = new TraceEmitter();
+    const hub = new SessionEventHub();
+    const detachTrace = trace.subscribe((event) =>
+      hub.emit({ scope: 'run', streamId, event }),
+    );
+    const detachProjector = attachSessionRunFactProjector(
+      hub,
+      active.host,
+      streamId,
+    );
 
-    publishCodexTodos(streamId, todos, active.host);
-    publishAgentCliStreamUsage(streamId, executionId, usage, active.host);
+    publishCodexTodos(streamId, todos, trace);
+    publishAgentCliStreamUsage(streamId, executionId, usage, trace);
 
     expect(active.events).toEqual([
       {
@@ -79,6 +92,9 @@ describe('codex progress events', () => {
         },
       },
     ]);
+
+    detachProjector();
+    detachTrace();
   });
 
   it('updates in-flight Codex command items in place', async () => {
@@ -88,7 +104,6 @@ describe('codex progress events', () => {
     await store.clear();
 
     const logger = createRunTrace(streamId).trace;
-    const runtime = createRecordingHost();
     const startedCommand: CommandExecutionItem = {
       id: 'cmd-1',
       type: 'command_execution',
@@ -139,7 +154,6 @@ describe('codex progress events', () => {
         'Build the project',
         streamId,
         logger,
-        runtime.host,
       );
 
       expect(result.finalResponse).toBe('Build succeeded.');

--- a/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
@@ -2,15 +2,23 @@
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
-import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
+import { TraceEmitter } from '@agent/trace';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
+import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import { ToolUseCycleNode } from '@agent/implementations/flows/tooluse/nodes/ToolUseCycleNode';
+import { SessionEventHub } from '@agent/runtime/SessionEventHub';
+import { attachSessionRunFactProjector } from '@agent/runtime/SessionRunFactProjector';
 import type {
   CyclePrepResult,
   ToolUseRunShared,
 } from '@agent/implementations/flows/tooluse/nodes/types';
 import type { ToolUseServices } from '@agent/implementations/flows/tooluse/ToolUseServices';
-import { MESSAGE_TYPES, type Plan, type TodoItem } from '@shared/schemas';
+import {
+  MESSAGE_TYPES,
+  type Plan,
+  type StreamTabId,
+  type TodoItem,
+} from '@shared/schemas';
 import { createRecordingHost, withTestRunContext } from '../progressTestUtils';
 
 const todo: TodoItem = {
@@ -40,40 +48,53 @@ function createPrepResult(
 describe('tool-use progress events', () => {
   it('publishes skipped-cycle todo and plan events through the runtime host', async () => {
     const { events, host } = createRecordingHost();
+    const logger = new TraceEmitter();
+    const hub = new SessionEventHub();
+    const streamId = 'stream:tool-use-cycle' as StreamTabId;
+    const detachTrace = logger.subscribe((event) =>
+      hub.emit({ scope: 'run', streamId, event }),
+    );
+    const detachProjector = attachSessionRunFactProjector(hub, host, streamId);
     const workspaceState = AgentWorkspaceState.create();
     workspaceState.workPlan.updateTodos([todo]);
     workspaceState.workPlan.updatePlan(plan);
 
     const node = new ToolUseCycleNode().setServices({
-      streamId: 'stream:tool-use-cycle',
+      streamId,
       runtimeHost: host,
+      logger,
       modelHandler: { getClient: vi.fn() },
       config: { model: 'test-model', agent: 'test-agent' },
       setting: { tools: [] },
       resolvedTools: [],
     } as unknown as ToolUseServices);
 
-    const result = await withTestRunContext(host, 'stream:tool-use-cycle', () =>
-      node.exec(createPrepResult(workspaceState)),
-    );
+    try {
+      const result = await withTestRunContext(host, streamId, () =>
+        node.exec(createPrepResult(workspaceState)),
+      );
 
-    expect(result).toEqual({ outcome: 'skipped' });
-    expect(events).toEqual([
-      {
-        event: 'updateTodos',
-        payload: {
-          streamId: 'stream:tool-use-cycle',
-          todos: [todo],
+      expect(result).toEqual({ outcome: 'skipped' });
+      expect(events).toEqual([
+        {
+          event: 'updateTodos',
+          payload: {
+            streamId,
+            todos: [todo],
+          },
         },
-      },
-      {
-        event: 'updatePlan',
-        payload: {
-          streamId: 'stream:tool-use-cycle',
-          plan,
+        {
+          event: 'updatePlan',
+          payload: {
+            streamId,
+            plan,
+          },
         },
-      },
-    ]);
+      ]);
+    } finally {
+      detachProjector();
+      detachTrace();
+    }
   });
 
   it('logs failed cycle outcomes as transcript errors', async () => {

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import { createFakePlatform } from '@test/support/FakePlatform';
+import { TraceEmitter } from '@agent/trace';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { ToolUseWaitNode } from '@agent/implementations/flows/tooluse/nodes/ToolUseWaitNode';
 import {
@@ -14,6 +15,8 @@ import {
   StreamStatusRegistry,
   StreamStatusService,
 } from '@agent/runtime/StreamStatusService';
+import { SessionEventHub } from '@agent/runtime/SessionEventHub';
+import { attachSessionRunFactProjector } from '@agent/runtime/SessionRunFactProjector';
 import type { AttachedMemoryMiss } from '@agent/types/AttachedMemory';
 import {
   MESSAGE_TYPES,
@@ -264,11 +267,21 @@ describe('ToolUseWaitNode', () => {
       stateSlices: null,
     };
     const runtimeHost = { emit: vi.fn() };
+    const logger = new TraceEmitter();
+    const hub = new SessionEventHub();
+    const detachTrace = logger.subscribe((event) =>
+      hub.emit({ scope: 'run', streamId, event }),
+    );
+    const detachProjector = attachSessionRunFactProjector(
+      hub,
+      runtimeHost,
+      streamId,
+    );
     const waitForFollowUp = vi.fn();
     const services = {
       checkInterruption: () => false,
       isSubagent: false,
-      logger: { error: vi.fn(), info: vi.fn() },
+      logger,
       modelHandler: { extractAssistantText: () => undefined },
       runtimeHost,
       session: {
@@ -307,6 +320,8 @@ describe('ToolUseWaitNode', () => {
         { streamId, bypassActive: false },
       );
     } finally {
+      detachProjector();
+      detachTrace();
       await GoalStore.forget(streamId);
       cleanupApprovalsForStream(streamId);
     }

--- a/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
@@ -2,7 +2,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
-import type { AgentTrace } from '@agent/trace';
+import { noopTrace, TraceEmitter, type AgentTrace } from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { OutputNode } from '@agent/implementations/flows/reflection/nodes/OutputNode';
 import type { ReflectionFlowShared } from '@agent/implementations/flows/reflection/ReflectionFlowState';
@@ -13,6 +13,8 @@ import {
   type ProcessingContext,
 } from '@agent/output/OutputFileProcessor';
 import type { XmlOutputManager } from '@agent/output/XmlOutputManager';
+import { SessionEventHub } from '@agent/runtime/SessionEventHub';
+import { attachSessionRunFactProjector } from '@agent/runtime/SessionRunFactProjector';
 import { normalizeRunId } from '@common/constants/runIds';
 import type {
   AgentFileLocation,
@@ -22,6 +24,7 @@ import type {
   OutputFileInfo,
   OutputXmlSummary,
   RoundOutput,
+  StreamTabId,
 } from '@shared/schemas';
 import { flexibleFS } from '@utils/files';
 import { createRecordingHost, withTestRunContext } from '../progressTestUtils';
@@ -119,20 +122,51 @@ function createOutputNode(
   streamId: string,
   host: ReturnType<typeof createRecordingHost>['host'],
   workflowOutputPolicy: typeof defaultWorkflowOutputPolicy = defaultWorkflowOutputPolicy,
+  logger: AgentTrace = noopTrace,
 ): OutputNode {
   return new OutputNode().setServices({
     streamId,
-    logger: { warn: () => {} },
+    logger,
     outputState: createOutputState(),
     runtimeHost: host,
     workflowOutputPolicy,
   } as unknown as ReflectionServices);
 }
 
+function createProjectedRuntime(streamId: string) {
+  const { events, host } = createRecordingHost();
+  const logger = new TraceEmitter();
+  const hub = new SessionEventHub();
+  const typedStreamId = streamId as StreamTabId;
+  const detachTrace = logger.subscribe((event) =>
+    hub.emit({ scope: 'run', streamId: typedStreamId, event }),
+  );
+  const detachProjector = attachSessionRunFactProjector(
+    hub,
+    host,
+    typedStreamId,
+  );
+  return {
+    events,
+    host,
+    logger,
+    dispose: () => {
+      detachProjector();
+      detachTrace();
+    },
+  };
+}
+
 describe('output progress events', () => {
   it('publishes reflection output-node events through the runtime host', async () => {
-    const { events, host } = createRecordingHost();
-    const outputNode = createOutputNode('stream:output-node', host);
+    const projected = createProjectedRuntime('stream:output-node');
+    const { events, host, logger } = projected;
+    const outputNode = createOutputNode(
+      'stream:output-node',
+      host,
+      defaultWorkflowOutputPolicy,
+      logger,
+    );
     const outputLocation = createAgentLocation('/tmp/output.xml');
     const openedLocation = createLocation('/tmp/rendered.tex');
     const fileInfo: OutputFileInfo = {
@@ -150,48 +184,52 @@ describe('output progress events', () => {
       xmlSummary: emptyXmlSummary,
     };
 
-    const transition = await withTestRunContext(
-      host,
-      'stream:output-node',
-      () =>
-        outputNode.post(
-          { roundOutputs: [] } as never,
-          {
-            outputLocation,
-            currentRound: 2,
-            endTurn: false,
-          },
-          {
-            roundOutput,
-            summary: {
-              storageKey: normalizeRunId('run:output-node'),
-              currRound: 2,
-              fileInfos: [fileInfo],
-              filesToOpen: [openedLocation],
-              outputFile: outputLocation,
+    try {
+      const transition = await withTestRunContext(
+        host,
+        'stream:output-node',
+        () =>
+          outputNode.post(
+            { roundOutputs: [] } as never,
+            {
+              outputLocation,
+              currentRound: 2,
               endTurn: false,
             },
-            compileFailures: [],
-            compiledArtifacts: [],
-            emitCompileFailures: false,
-          },
-        ),
-    );
+            {
+              roundOutput,
+              summary: {
+                storageKey: normalizeRunId('run:output-node'),
+                currRound: 2,
+                fileInfos: [fileInfo],
+                filesToOpen: [openedLocation],
+                outputFile: outputLocation,
+                endTurn: false,
+              },
+              compileFailures: [],
+              compiledArtifacts: [],
+              emitCompileFailures: false,
+            },
+          ),
+      );
 
-    expect(transition).toBe('default');
-    expect(events).toEqual([
-      {
-        event: 'addOutputFiles',
-        payload: {
-          streamId: 'stream:output-node',
-          filesByRound: { 2: [fileInfo] },
+      expect(transition).toBe('default');
+      expect(events).toEqual([
+        {
+          event: 'addOutputFiles',
+          payload: {
+            streamId: 'stream:output-node',
+            filesByRound: { 2: [fileInfo] },
+          },
         },
-      },
-      {
-        event: 'requestOpenFile',
-        payload: { location: openedLocation, preserveFocus: true },
-      },
-    ]);
+        {
+          event: 'requestOpenFile',
+          payload: { location: openedLocation, preserveFocus: true },
+        },
+      ]);
+    } finally {
+      projected.dispose();
+    }
   });
 
   it('stores compile failure context for the next reflection round', async () => {
@@ -315,13 +353,10 @@ describe('output progress events', () => {
   });
 
   it('publishes missing-output processing events through the runtime host', async () => {
-    const { events, host } = createRecordingHost();
+    const projected = createProjectedRuntime('stream:processor');
+    const { events, host, logger } = projected;
     const { roundData, ensureRoundData, setRoundOutputs } =
       createRoundDataStore();
-    const logger = {
-      debug: () => {},
-      domain: () => {},
-    } as unknown as AgentTrace;
     const xmlManager = {
       splitScratchpadMultipleOutputXml: async () => {
         throw new Error('invalid xml');
@@ -338,32 +373,33 @@ describe('output progress events', () => {
       ensureRoundData,
     };
 
-    await new OutputFileProcessor(context).processMultipleOutputs(
-      createLocation('/tmp/broken-output.xml'),
-      3,
-      createLocation('/tmp/raw-output.xml'),
-    );
+    try {
+      await new OutputFileProcessor(context).processMultipleOutputs(
+        createLocation('/tmp/broken-output.xml'),
+        3,
+        createLocation('/tmp/raw-output.xml'),
+      );
 
-    expect(events).toEqual([
-      {
-        event: 'updateMissingOutputs',
-        payload: {
-          streamId: 'stream:processor',
-          filesByRound: { 3: [] },
+      expect(events).toEqual([
+        {
+          event: 'updateMissingOutputs',
+          payload: {
+            streamId: 'stream:processor',
+            filesByRound: { 3: [] },
+          },
         },
-      },
-    ]);
-    expect(roundData.get(3)?.outputs).toEqual([]);
+      ]);
+      expect(roundData.get(3)?.outputs).toEqual([]);
+    } finally {
+      projected.dispose();
+    }
   });
 
   it('emits missing-output events when extraction yields no files (no exception)', async () => {
-    const { events, host } = createRecordingHost();
+    const projected = createProjectedRuntime('stream:processor');
+    const { events, host, logger } = projected;
     const { roundData, ensureRoundData, setRoundOutputs } =
       createRoundDataStore();
-    const logger = {
-      debug: () => {},
-      domain: () => {},
-    } as unknown as AgentTrace;
     const xmlManager = {
       splitScratchpadMultipleOutputXml: async () => [],
     } as unknown as XmlOutputManager;
@@ -378,22 +414,26 @@ describe('output progress events', () => {
       ensureRoundData,
     };
 
-    await new OutputFileProcessor(context).processMultipleOutputs(
-      createLocation('/tmp/empty-output.xml'),
-      4,
-      createLocation('/tmp/raw-output.xml'),
-    );
+    try {
+      await new OutputFileProcessor(context).processMultipleOutputs(
+        createLocation('/tmp/empty-output.xml'),
+        4,
+        createLocation('/tmp/raw-output.xml'),
+      );
 
-    expect(events).toEqual([
-      {
-        event: 'updateMissingOutputs',
-        payload: {
-          streamId: 'stream:processor',
-          filesByRound: { 4: [] },
+      expect(events).toEqual([
+        {
+          event: 'updateMissingOutputs',
+          payload: {
+            streamId: 'stream:processor',
+            filesByRound: { 4: [] },
+          },
         },
-      },
-    ]);
-    expect(roundData.get(4)?.outputs).toEqual([]);
+      ]);
+      expect(roundData.get(4)?.outputs).toEqual([]);
+    } finally {
+      projected.dispose();
+    }
   });
 
   it('warns when a non-empty response yields zero extracted files', async () => {
@@ -404,15 +444,16 @@ describe('output progress events', () => {
     const readSpy = vi
       .spyOn(flexibleFS, 'read')
       .mockResolvedValue('% chunk.tex\n\\section{Untagged content}\n');
+    const projected = createProjectedRuntime('stream:processor');
+    const { events, host, logger } = projected;
+    const warnings: string[] = [];
+    const detachWarnings = logger.subscribe((event) => {
+      if (event.type === 'log' && event.level === 'warn') {
+        warnings.push(event.message);
+      }
+    });
     try {
-      const { events, host } = createRecordingHost();
-      const warnings: string[] = [];
       const { ensureRoundData, setRoundOutputs } = createRoundDataStore();
-      const logger = {
-        debug: () => {},
-        domain: () => {},
-        warn: (message: string) => warnings.push(message),
-      } as unknown as AgentTrace;
       const xmlManager = {
         splitScratchpadMultipleOutputXml: async () => [],
       } as unknown as XmlOutputManager;
@@ -443,6 +484,8 @@ describe('output progress events', () => {
         },
       ]);
     } finally {
+      detachWarnings();
+      projected.dispose();
       readSpy.mockRestore();
     }
   });

--- a/src/test-kernel/agent/runtime/ConversationProgressHub.vitest.ts
+++ b/src/test-kernel/agent/runtime/ConversationProgressHub.vitest.ts
@@ -2,16 +2,29 @@ import { describe, expect, it } from 'vitest';
 
 import { logConversationProgress, TraceEmitter } from '@agent/trace';
 import { attachConversationProgressHub } from '@agent/runtime/conversationProgressHub';
+import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import type { StreamTabId } from '@shared/schemas';
 
 import { createRecordingHost } from '../progressTestUtils';
 
+function attachTraceToHub(
+  trace: TraceEmitter,
+  hub: SessionEventHub,
+  streamId: StreamTabId,
+): () => void {
+  return trace.subscribe((event) =>
+    hub.emit({ scope: 'run', streamId, event }),
+  );
+}
+
 describe('attachConversationProgressHub (F-1b)', () => {
   it('derives updateConversationProgress from a conversationProgress domain event', () => {
     const trace = new TraceEmitter();
+    const hub = new SessionEventHub();
     const { events, host } = createRecordingHost();
     const streamId = 'stream:hub-test' as StreamTabId;
-    const detach = attachConversationProgressHub(trace, host, streamId);
+    const detachTrace = attachTraceToHub(trace, hub, streamId);
+    const detach = attachConversationProgressHub(hub, host, streamId);
 
     try {
       logConversationProgress(trace, {
@@ -29,14 +42,17 @@ describe('attachConversationProgressHub (F-1b)', () => {
       });
     } finally {
       detach();
+      detachTrace();
     }
   });
 
   it('ignores unrelated domain events and stops forwarding after detach', () => {
     const trace = new TraceEmitter();
+    const hub = new SessionEventHub();
     const { events, host } = createRecordingHost();
     const streamId = 'stream:hub-test-2' as StreamTabId;
-    const detach = attachConversationProgressHub(trace, host, streamId);
+    const detachTrace = attachTraceToHub(trace, hub, streamId);
+    const detach = attachConversationProgressHub(hub, host, streamId);
 
     trace.domain({ key: 'webSearch', data: { query: 'irrelevant' } });
     expect(events).toHaveLength(0);
@@ -44,13 +60,16 @@ describe('attachConversationProgressHub (F-1b)', () => {
     detach();
     logConversationProgress(trace, { conversationTurns: 1, toolCallCount: 0 });
     expect(events).toHaveLength(0);
+    detachTrace();
   });
 
   it('drops a conversationProgress event with missing or malformed data instead of forwarding it', () => {
     const trace = new TraceEmitter();
+    const hub = new SessionEventHub();
     const { events, host } = createRecordingHost();
     const streamId = 'stream:hub-test-3' as StreamTabId;
-    const detach = attachConversationProgressHub(trace, host, streamId);
+    const detachTrace = attachTraceToHub(trace, hub, streamId);
+    const detach = attachConversationProgressHub(hub, host, streamId);
 
     try {
       trace.domain({ key: 'conversationProgress', data: undefined });
@@ -63,6 +82,7 @@ describe('attachConversationProgressHub (F-1b)', () => {
       expect(events).toHaveLength(0);
     } finally {
       detach();
+      detachTrace();
     }
   });
 });

--- a/src/test-kernel/agent/runtime/SessionEventHub.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionEventHub.vitest.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { TraceEmitter } from '@agent/trace';
+import {
+  SessionEventHub,
+  type SessionEvent,
+} from '@agent/runtime/SessionEventHub';
+import { attachSessionRunFactProjector } from '@agent/runtime/SessionRunFactProjector';
+import { emitRunFact } from '@agent/runtime/runFactEvents';
+import { type StreamTabId } from '@shared/schemas';
+
+import { createRecordingHost } from '../progressTestUtils';
+
+const streamId = 'stream:hub' as StreamTabId;
+
+describe('SessionEventHub', () => {
+  it('filters high-volume stream chunks away from typed subscribers', () => {
+    const hub = new SessionEventHub();
+    const seen: SessionEvent[] = [];
+
+    hub.subscribe((event) => seen.push(event), {
+      scope: 'run',
+      types: ['domain'],
+    });
+
+    hub.emit({
+      scope: 'run',
+      streamId,
+      event: { type: 'stream.chunk', id: 'chunk-1', text: 'a' },
+    });
+    hub.emit({
+      scope: 'run',
+      streamId,
+      event: { type: 'domain', key: 'sample', data: { ok: true } },
+    });
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({
+      scope: 'run',
+      event: { type: 'domain', key: 'sample' },
+    });
+  });
+
+  it('asserts that a run-scope subscriber exists before activation', () => {
+    const hub = new SessionEventHub();
+
+    expect(() =>
+      hub.assertRunSubscribersAttachedBeforeActivation(streamId),
+    ).toThrow(/No run-scoped session event subscribers/);
+
+    const detachSessionOnly = hub.subscribe(() => undefined, {
+      scope: 'session',
+    });
+    expect(() =>
+      hub.assertRunSubscribersAttachedBeforeActivation(streamId),
+    ).toThrow(/No run-scoped session event subscribers/);
+    detachSessionOnly();
+
+    const detachRun = hub.subscribe(() => undefined, { scope: 'run' });
+    expect(() =>
+      hub.assertRunSubscribersAttachedBeforeActivation(streamId),
+    ).not.toThrow();
+    detachRun();
+  });
+
+  it('projects run facts and usage from trace events to the runtime host', () => {
+    const trace = new TraceEmitter();
+    const hub = new SessionEventHub();
+    const host = createRecordingHost();
+    const detachTrace = trace.subscribe((event) =>
+      hub.emit({ scope: 'run', streamId, event }),
+    );
+    const detachProjector = attachSessionRunFactProjector(
+      hub,
+      host.host,
+      streamId,
+    );
+    const todos = [
+      {
+        content: 'route facts',
+        status: 'pending' as const,
+        activeForm: 'routing facts',
+      },
+    ];
+    const plan = { objective: 'Project every easy run fact.' };
+
+    emitRunFact(trace, 'updateTodos', { streamId, todos });
+    emitRunFact(trace, 'updatePlan', { streamId, plan });
+    emitRunFact(trace, 'addOutputFiles', {
+      streamId,
+      filesByRound: { 1: [] },
+    });
+    emitRunFact(trace, 'updateMissingOutputs', {
+      streamId,
+      filesByRound: { 1: [] },
+    });
+    emitRunFact(trace, 'updateCompileFailures', {
+      streamId,
+      filesByRound: { 1: [] },
+    });
+    emitRunFact(trace, 'goalPaused', { streamId });
+    trace.usage(
+      { inputTokens: 10, outputTokens: 5 },
+      {
+        data: {
+          streamId,
+          storageKey: 'run:usage',
+          usage: { inputTokens: 10, outputTokens: 5, cost: 0 },
+        },
+        recordTranscript: false,
+      },
+    );
+    trace.emit({ type: 'stream.chunk', id: 'ignored', text: 'x' });
+
+    expect(host.events).toEqual([
+      {
+        event: 'updateTodos',
+        payload: { streamId, todos },
+      },
+      {
+        event: 'updatePlan',
+        payload: { streamId, plan },
+      },
+      {
+        event: 'addOutputFiles',
+        payload: { streamId, filesByRound: { 1: [] } },
+      },
+      {
+        event: 'updateMissingOutputs',
+        payload: { streamId, filesByRound: { 1: [] } },
+      },
+      {
+        event: 'updateCompileFailures',
+        payload: { streamId, filesByRound: { 1: [] } },
+      },
+      {
+        event: 'goalPaused',
+        payload: { streamId },
+      },
+      {
+        event: 'updateStreamUsage',
+        payload: {
+          streamId,
+          storageKey: 'run:usage',
+          usage: { inputTokens: 10, outputTokens: 5, cost: 0 },
+        },
+      },
+    ]);
+
+    detachProjector();
+    detachTrace();
+  });
+
+  it('detaches projector subscriptions cleanly', () => {
+    const trace = new TraceEmitter();
+    const hub = new SessionEventHub();
+    const host = createRecordingHost();
+    const detachTrace = trace.subscribe((event) =>
+      hub.emit({ scope: 'run', streamId, event }),
+    );
+    const detachProjector = attachSessionRunFactProjector(
+      hub,
+      host.host,
+      streamId,
+    );
+
+    detachProjector();
+    emitRunFact(trace, 'goalPaused', { streamId });
+
+    expect(host.events).toEqual([]);
+    detachTrace();
+  });
+});

--- a/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
@@ -69,6 +69,7 @@ describe('SessionHandle', () => {
     expect(defaultSession().executions).toBe(executionRegistry);
     expect(defaultSession().coordinators).toBe(runCoordinatorBridge);
     expect(defaultSession().subscriptions).toBe(executionSubscriptionBinder);
+    expect(defaultSession().events).toBeDefined();
     expect(defaultSession().flushers).toBe(getActiveFlushers());
     expect(defaultSession().hostChannel).toBeUndefined();
   });
@@ -80,6 +81,7 @@ describe('SessionHandle', () => {
       expect(fresh.executions).not.toBe(executionRegistry);
       expect(fresh.coordinators).not.toBe(runCoordinatorBridge);
       expect(fresh.subscriptions).not.toBe(executionSubscriptionBinder);
+      expect(fresh.events).not.toBe(defaultSession().events);
       expect(fresh.flushers).not.toBe(getActiveFlushers());
       expect(fresh.hostChannel).toBeUndefined();
     } finally {

--- a/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
@@ -484,9 +484,9 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
     const session = new SessionHandle();
     const logger = new TraceEmitter();
     const onResult = vi.fn();
-    const detach = session.attachRunTrace(logger);
-    session.onResult(onResult);
     const { ctx, streamStatus } = createCtx({ logger });
+    const detach = session.attachRunTrace(logger, ctx.streamId);
+    session.onResult(onResult);
     try {
       await runFlowWithLifecycle(
         ctx,

--- a/src/test-kernel/agent/runtime/UsageMonitorLastTotals.vitest.ts
+++ b/src/test-kernel/agent/runtime/UsageMonitorLastTotals.vitest.ts
@@ -3,10 +3,12 @@ import { ModelProvider } from 'llm-zoo';
 import { beforeAll, describe, expect, it } from 'vitest';
 
 // Local imports
-import { noopTrace } from '@agent/trace';
+import { TraceEmitter } from '@agent/trace';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
 import { recordNormalizedUsage } from '@agent/core/usage/RunUsageAccumulator';
 import { UsageMonitor } from '@agent/utils/UsageMonitor';
+import { SessionEventHub } from '@agent/runtime/SessionEventHub';
+import { attachSessionRunFactProjector } from '@agent/runtime/SessionRunFactProjector';
 import {
   AgentCategory,
   type StorageKey,
@@ -34,14 +36,27 @@ const modelInfo = {
 
 function createMonitorWithEvents() {
   const { host, events } = createRecordingHost();
+  const logger = new TraceEmitter();
+  const hub = new SessionEventHub();
   const storageKey = 'usage-last-totals' as StorageKey;
   const streamId = 'stream:usage-last-totals' as StreamTabId;
+  const detachTrace = logger.subscribe((event) =>
+    hub.emit({ scope: 'run', streamId, event }),
+  );
+  const detachProjector = attachSessionRunFactProjector(hub, host, streamId);
   const monitor = new UsageMonitor(
     modelInfo,
-    { logger: noopTrace, runtimeHost: host, storageKey, streamId },
+    { logger, runtimeHost: host, storageKey, streamId },
     { agentName: 'assistant', agentCategory: AgentCategory.ToolUse },
   );
-  return { monitor, events };
+  return {
+    monitor,
+    events,
+    dispose: () => {
+      detachProjector();
+      detachTrace();
+    },
+  };
 }
 
 describe('UsageMonitor.lastTotals (SDK Step 7d PR 5)', () => {
@@ -54,39 +69,47 @@ describe('UsageMonitor.lastTotals (SDK Step 7d PR 5)', () => {
   });
 
   it('is undefined before any round and caches the totals after recordUsage', async () => {
-    const { monitor } = createMonitorWithEvents();
-    expect(monitor.lastTotals()).toBeUndefined();
+    const { dispose, monitor } = createMonitorWithEvents();
+    try {
+      expect(monitor.lastTotals()).toBeUndefined();
 
-    const state = AgentRunStateSnapshotSchema.parse({});
-    await monitor.recordUsage(state);
+      const state = AgentRunStateSnapshotSchema.parse({});
+      await monitor.recordUsage(state);
 
-    // The cache holds the exact totals object the accumulator exposed, so a
-    // failed run's terminal `result` event can report usage from the catch arm.
-    expect(monitor.lastTotals()).toBe(state.usageAccumulator.totals);
+      // The cache holds the exact totals object the accumulator exposed, so a
+      // failed run's terminal `result` event can report usage from the catch arm.
+      expect(monitor.lastTotals()).toBe(state.usageAccumulator.totals);
+    } finally {
+      dispose();
+    }
   });
 
   it('forwards the ChatGPT subscription marker to progress usage events', async () => {
-    const { monitor, events } = createMonitorWithEvents();
-    const state = AgentRunStateSnapshotSchema.parse({});
-    recordNormalizedUsage(state.usageAccumulator, {
-      inputTokens: 10,
-      outputTokens: 2,
-      cost: 0,
-      responseTimeMs: 50,
-      provider: 'openai-response',
-      viaChatGptSubscription: true,
-    });
-
-    await monitor.recordUsage(state);
-
-    const usageEvent = events.find(
-      (event) => event.event === 'updateStreamUsage',
-    );
-    expect(usageEvent?.payload).toMatchObject({
-      usage: {
+    const { dispose, events, monitor } = createMonitorWithEvents();
+    try {
+      const state = AgentRunStateSnapshotSchema.parse({});
+      recordNormalizedUsage(state.usageAccumulator, {
+        inputTokens: 10,
+        outputTokens: 2,
+        cost: 0,
+        responseTimeMs: 50,
+        provider: 'openai-response',
         viaChatGptSubscription: true,
-        usageRoute: 'chatgpt-subscription',
-      },
-    });
+      });
+
+      await monitor.recordUsage(state);
+
+      const usageEvent = events.find(
+        (event) => event.event === 'updateStreamUsage',
+      );
+      expect(usageEvent?.payload).toMatchObject({
+        usage: {
+          viaChatGptSubscription: true,
+          usageRoute: 'chatgpt-subscription',
+        },
+      });
+    } finally {
+      dispose();
+    }
   });
 });

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -91,9 +91,12 @@ type RunExecutionRequest = (
     // This window's SessionHandle. The onboarding run-completion test drives a
     // terminal `result` event through it via `attachRunTrace`.
     session: {
-      attachRunTrace(trace: {
-        subscribe(fn: (event: unknown) => void): unknown;
-      }): () => void;
+      attachRunTrace(
+        trace: {
+          subscribe(fn: (event: unknown) => void): unknown;
+        },
+        streamId: string,
+      ): () => void;
     };
     runtimeUnavailableTools?: readonly string[];
   },
@@ -1800,7 +1803,7 @@ describe('DesktopProgressBridge', () => {
     // result — exactly what the lifecycle does after persisting firstRunDone.
     const runAgent = vi.fn(async (_request, options) => {
       const trace = makeFakeTrace();
-      options.session.attachRunTrace(trace);
+      options.session.attachRunTrace(trace, 'stream-1');
       trace.emit({
         type: 'result',
         outcome: RUN_OUTCOME.COMPLETED,
@@ -1836,7 +1839,7 @@ describe('DesktopProgressBridge', () => {
     const onRunCompleted = vi.fn();
     const runAgent = vi.fn(async (_request, options) => {
       const trace = makeFakeTrace();
-      options.session.attachRunTrace(trace);
+      options.session.attachRunTrace(trace, 'stream-2');
       trace.emit({
         type: 'result',
         outcome: RUN_OUTCOME.FAILED,

--- a/src/test-kernel/progressView/SessionRunFactProjectorEquivalence.vitest.ts
+++ b/src/test-kernel/progressView/SessionRunFactProjectorEquivalence.vitest.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { TraceEmitter } from '@agent/trace';
+import { SessionEventHub } from '@agent/runtime/SessionEventHub';
+import { attachSessionRunFactProjector } from '@agent/runtime/SessionRunFactProjector';
+import { emitRunFact } from '@agent/runtime/runFactEvents';
+import type {
+  ProgressEvent,
+  ProgressEventBusLike,
+  ProgressEventPayloads,
+} from '@eventBus/ProgressEventBus';
+import {
+  AgentCategory,
+  type CompileFailure,
+  type FileLocation,
+  type OutputFileInfo,
+  type Plan,
+  type StorageKey,
+  type StreamTabId,
+  type TodoItem,
+} from '@shared/schemas';
+import {
+  ProgressEventHandler,
+  type UICallbacks,
+} from '@shared/progressView/backend/events/ProgressEventHandler';
+import type { MementoStorage } from '@shared/progressView/backend/persistence/PersistentMapManager';
+import { ProgressViewState } from '@shared/progressView/backend/state/ProgressViewState';
+import type { WebviewBridge } from '@shared/progressView/backend/WebviewBridge';
+import type {
+  SyncStreamContentPayload,
+  WebviewUpdater,
+} from '@shared/progressView/backend/WebviewUpdater';
+
+class MemoryMementoStorage implements MementoStorage {
+  private readonly values = new Map<string, unknown>();
+
+  get<T>(key: string): T | undefined;
+  get<T>(key: string, defaultValue: T): T;
+  get<T>(key: string, defaultValue?: T): T | undefined {
+    return this.values.has(key) ? (this.values.get(key) as T) : defaultValue;
+  }
+
+  update<T>(key: string, value: T): Thenable<void> {
+    this.values.set(key, value);
+    return Promise.resolve();
+  }
+}
+
+class MemoryProgressBus implements ProgressEventBusLike {
+  private readonly listeners = new Map<
+    ProgressEvent,
+    Set<(payload: ProgressEventPayloads[ProgressEvent]) => void>
+  >();
+
+  on<K extends ProgressEvent>(
+    event: K,
+    listener: (payload: ProgressEventPayloads[K]) => void,
+    options?: { signal?: AbortSignal },
+  ): () => void {
+    if (options?.signal?.aborted) return () => {};
+    const listeners = this.listeners.get(event) ?? new Set();
+    listeners.add(
+      listener as (payload: ProgressEventPayloads[ProgressEvent]) => void,
+    );
+    this.listeners.set(event, listeners);
+    const cleanup = () => {
+      listeners.delete(
+        listener as (payload: ProgressEventPayloads[ProgressEvent]) => void,
+      );
+    };
+    options?.signal?.addEventListener('abort', cleanup, { once: true });
+    return cleanup;
+  }
+
+  emit<K extends ProgressEvent>(
+    event: K,
+    payload: ProgressEventPayloads[K],
+  ): void {
+    for (const listener of this.listeners.get(event) ?? []) {
+      listener(payload);
+    }
+  }
+}
+
+const streamId = 'stream:projector-equivalence' as StreamTabId;
+const usageStorageKey = 'run:usage' as StorageKey;
+const todos: TodoItem[] = [
+  {
+    content: 'Keep projector output identical',
+    status: 'pending',
+    activeForm: 'Keeping projector output identical',
+  },
+];
+const plan: Plan = { objective: 'Project easy run facts through the hub.' };
+
+function workspaceFile(relativePath: string): FileLocation {
+  return {
+    kind: 'workspace',
+    absolutePath: `/workspace/${relativePath}`,
+    relativePath,
+  };
+}
+
+const outputFile: OutputFileInfo = {
+  source: 'paper.tex',
+  location: workspaceFile('paper.tex'),
+  round: 1,
+  lineage: null,
+  diff: null,
+};
+
+const compileFailure: CompileFailure = {
+  round: 1,
+  displayName: 'paper.tex',
+  output: workspaceFile('paper.pdf'),
+  log: workspaceFile('paper.log'),
+  logRelativePath: 'paper.log',
+};
+
+interface Harness {
+  bus: MemoryProgressBus;
+  handler: ProgressEventHandler;
+  messages: SyncStreamContentPayload[];
+}
+
+async function createHarness(): Promise<Harness> {
+  const state = new ProgressViewState(new MemoryMementoStorage());
+  await state.snapshots.load([]);
+  state.activeStream = streamId;
+  state.streamLogs.ensureStream(streamId);
+  state.updateStreamHints(streamId, { agentCategory: AgentCategory.Workflow });
+  state.getOrCreateStreamState(streamId, AgentCategory.Workflow);
+
+  const messages: SyncStreamContentPayload[] = [];
+  const updater = {
+    isAvailable: () => true,
+    updateFiles: vi.fn(),
+    updateMissingOutputs: vi.fn(),
+    updateCompileFailures: vi.fn(),
+    updateRunUsage: vi.fn(),
+    updateTodos: vi.fn(),
+    updatePlan: vi.fn(),
+    sendSyncStreamContent: (payload: SyncStreamContentPayload) => {
+      messages.push(payload);
+    },
+  } as unknown as WebviewUpdater;
+  const bridge = {
+    syncStream: vi.fn(),
+    clearAll: vi.fn(),
+  } as unknown as WebviewBridge;
+  const bus = new MemoryProgressBus();
+  const handler = new ProgressEventHandler(
+    state,
+    updater,
+    bridge,
+    {} as UICallbacks,
+    () => false,
+  );
+  handler.setupEventListeners(bus);
+  return { bus, handler, messages };
+}
+
+function emitDirectFacts(bus: ProgressEventBusLike): void {
+  bus.emit('updateTodos', { streamId, todos });
+  bus.emit('updatePlan', { streamId, plan });
+  bus.emit('addOutputFiles', { streamId, filesByRound: { 1: [outputFile] } });
+  bus.emit('updateMissingOutputs', {
+    streamId,
+    filesByRound: { 1: ['paper.pdf'] },
+  });
+  bus.emit('updateCompileFailures', {
+    streamId,
+    filesByRound: { 1: [compileFailure] },
+  });
+  bus.emit('updateStreamUsage', {
+    streamId,
+    storageKey: usageStorageKey,
+    usage: { inputTokens: 10, outputTokens: 5, cost: 0.01 },
+  });
+}
+
+function emitHubFacts(trace: TraceEmitter): void {
+  emitRunFact(trace, 'updateTodos', { streamId, todos });
+  emitRunFact(trace, 'updatePlan', { streamId, plan });
+  emitRunFact(trace, 'addOutputFiles', {
+    streamId,
+    filesByRound: { 1: [outputFile] },
+  });
+  emitRunFact(trace, 'updateMissingOutputs', {
+    streamId,
+    filesByRound: { 1: ['paper.pdf'] },
+  });
+  emitRunFact(trace, 'updateCompileFailures', {
+    streamId,
+    filesByRound: { 1: [compileFailure] },
+  });
+  trace.usage(
+    { inputTokens: 10, outputTokens: 5, cost: 0.01 },
+    {
+      data: {
+        streamId,
+        storageKey: usageStorageKey,
+        usage: { inputTokens: 10, outputTokens: 5, cost: 0.01 },
+      },
+      recordTranscript: false,
+    },
+  );
+}
+
+async function settleUsageProjection(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('SessionRunFactProjector', () => {
+  it('produces the same progress backend state as direct bus events', async () => {
+    const direct = await createHarness();
+    emitDirectFacts(direct.bus);
+    await settleUsageProjection();
+    direct.handler.syncStreamContent(streamId);
+
+    const hubFed = await createHarness();
+    const hub = new SessionEventHub();
+    const trace = new TraceEmitter();
+    const detachTrace = trace.subscribe((event) =>
+      hub.emit({ scope: 'run', streamId, event }),
+    );
+    const detachProjector = attachSessionRunFactProjector(
+      hub,
+      {
+        emit: (event, payload) => hubFed.bus.emit(event, payload),
+      },
+      streamId,
+    );
+    emitHubFacts(trace);
+    await settleUsageProjection();
+    hubFed.handler.syncStreamContent(streamId);
+
+    expect(hubFed.messages.at(-1)).toEqual(direct.messages.at(-1));
+
+    detachProjector();
+    detachTrace();
+  });
+});

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -114,13 +114,19 @@ export function publishAgentCliStreamUsage(
   childStreamId: StreamTabId,
   executionId: ExecutionId,
   usage: TokenUsageStats,
-  runtimeHost: AgentRuntimeHost,
+  logger: AgentTrace,
 ): void {
-  runtimeHost.emit('updateStreamUsage', {
-    streamId: childStreamId,
-    storageKey: executionId as StorageKey,
-    executionId,
-    usage,
+  const stats = Object.fromEntries(
+    Object.entries(usage).filter(([, value]) => typeof value === 'number'),
+  ) as Record<string, number>;
+  logger.usage(stats, {
+    data: {
+      streamId: childStreamId,
+      storageKey: executionId as StorageKey,
+      executionId,
+      usage,
+    },
+    recordTranscript: false,
   });
 }
 

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -5,6 +5,7 @@ import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
+import { attachSessionRunFactProjector } from '@agent/runtime/SessionRunFactProjector';
 import {
   currentSession,
   type SessionHandle,
@@ -98,6 +99,20 @@ export function createChildStream(
   // status-update and finalize closures below fire later, possibly outside it.
   const session = currentSession();
   const runTrace = createRunTrace(childStreamId, undefined, session.flushers);
+  const detachSessionTrace = session.attachRunTrace(
+    runTrace.trace,
+    childStreamId,
+  );
+  const detachRunFactProjector = attachSessionRunFactProjector(
+    session.events,
+    runtimeHost,
+    childStreamId,
+  );
+  const disposeTrace = () => {
+    detachRunFactProjector();
+    detachSessionTrace();
+    runTrace.dispose();
+  };
   const handle = new AgentExecutionHandle(
     executionId,
     parentStreamId,
@@ -141,7 +156,7 @@ export function createChildStream(
         handle,
         session,
         logger: runTrace.trace,
-        disposeTrace: runTrace.dispose,
+        disposeTrace,
         options: finalizeOptions,
       });
     },

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -444,7 +444,7 @@ function startClaudeAgentLoop(params: {
           childStreamId,
           executionId,
           buildClaudeUsageStats(turn.usage),
-          runtimeHost,
+          logger,
         );
       }
     },

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -29,6 +29,7 @@ import {
   type ToolUseCardRef,
 } from '@agent/trace';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { emitRunFact } from '@agent/runtime/runFactEvents';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type {
   StreamTabId,
@@ -153,9 +154,9 @@ type ToolUseStatus = NonNullable<ToolUseLog['status']>;
 export function publishCodexTodos(
   childStreamId: StreamTabId,
   todos: TodoItem[],
-  runtimeHost: AgentRuntimeHost,
+  logger: AgentTrace,
 ): void {
-  runtimeHost.emit('updateTodos', { streamId: childStreamId, todos });
+  emitRunFact(logger, 'updateTodos', { streamId: childStreamId, todos });
 }
 
 function toProgressTodos(item: TodoListItem): TodoItem[] {
@@ -171,7 +172,6 @@ function logCodexItem(
   item: ThreadItem,
   childStreamId: StreamTabId,
   logger: AgentTrace,
-  runtimeHost: AgentRuntimeHost,
 ): void {
   switch (item.type) {
     case 'command_execution': {
@@ -200,7 +200,7 @@ function logCodexItem(
       publishCodexTodos(
         childStreamId,
         toProgressTodos(item as TodoListItem),
-        runtimeHost,
+        logger,
       );
       break;
     }
@@ -252,15 +252,14 @@ function publishCodexItemProgress(params: {
   childStreamId: StreamTabId;
   logger: AgentTrace;
   refs: Map<string, CodexToolLogRef>;
-  runtimeHost: AgentRuntimeHost;
 }): boolean {
-  const { item, status, childStreamId, logger, refs, runtimeHost } = params;
+  const { item, status, childStreamId, logger, refs } = params;
 
   if (item.type === 'todo_list') {
     publishCodexTodos(
       childStreamId,
       toProgressTodos(item as TodoListItem),
-      runtimeHost,
+      logger,
     );
   }
 
@@ -281,7 +280,6 @@ export async function runStreamedTurn(
   prompt: string,
   childStreamId: StreamTabId,
   logger: AgentTrace,
-  runtimeHost: AgentRuntimeHost,
   signal?: AbortSignal,
 ): Promise<RunResult> {
   logger.info(prompt, { messageType: MESSAGE_TYPES.USER_MESSAGE });
@@ -300,7 +298,6 @@ export async function runStreamedTurn(
           childStreamId,
           logger,
           refs: itemLogRefs,
-          runtimeHost,
         });
         break;
       case 'item.completed': {
@@ -311,10 +308,9 @@ export async function runStreamedTurn(
           childStreamId,
           logger,
           refs: itemLogRefs,
-          runtimeHost,
         });
         if (!wasRenderedAsProgress) {
-          logCodexItem(item, childStreamId, logger, runtimeHost);
+          logCodexItem(item, childStreamId, logger);
         }
         if (item.type === 'agent_message') {
           responseParts.push(item.text);
@@ -392,7 +388,6 @@ function startCodexLoop(params: {
         prompt,
         childStreamId,
         logger,
-        runtimeHost,
         abortController.signal,
       ),
     getUsage: (turn) => turn.usage,
@@ -403,7 +398,7 @@ function startCodexLoop(params: {
           childStreamId,
           executionId,
           buildCodexUsageStats(turn.usage),
-          runtimeHost,
+          logger,
         );
       }
     },

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -36,6 +36,7 @@ import {
 import { type StreamLogStore } from './StreamLogStore';
 
 const STREAM_UPDATE_THROTTLE_MS = 50;
+const RUN_FACT_DOMAIN_PREFIX = 'runFact.';
 
 const KNOWN_MESSAGE_TYPES = new Set<string>(Object.values(MESSAGE_TYPES));
 
@@ -270,6 +271,7 @@ export function attachTranscriptRecorder(
       }
 
       case 'usage':
+        if (event.recordTranscript === false) return;
         appendLog({
           groupId: event.stageId,
           messageType: MESSAGE_TYPES.STATISTICS,
@@ -352,6 +354,7 @@ export function attachTranscriptRecorder(
         // conversationProgressHub (F-1b) — it fires on every round/turn and
         // would spam a transcript row per tick, so it adds none here.
         if (event.key === 'conversationProgress') return;
+        if (event.key.startsWith(RUN_FACT_DOMAIN_PREFIX)) return;
         // filesLoaded has a richer payload shape; format the text accordingly.
         if (event.key === 'filesLoaded') {
           const payload = event.data as


### PR DESCRIPTION
## Summary

Implements Stage 1 of the session-scoped runtime architecture by adding `SessionEventHub` to `SessionHandle`, attaching run traces before stream activation, and moving the easy-seven run facts from direct runtime host emissions to trace facts projected back onto the existing progress bus. Conversation progress now consumes the session hub as well, and usage totals are emitted once as a trace usage event whose payload is projected for the sidebar while workflow transcript stats remain unchanged.

The proposal status header is refreshed to show Stages 0-1 as landed.

## Issue acceptance gates

- Addresses #6962.
- Reverified the cited evidence before implementation. The issue header had drifted because Stage 0 merged, but the cited `AgentLaunchContext` startup ordering and `UsageMonitor` duplicate usage emit sites were still live; I commented the drift/unblock note on the issue before coding.
- Adds a session-owned event hub on `SessionHandle` and attaches run trace forwarding before the first `setActiveStream` activation event.
- Adds a dev/test activation-ordering assertion that run-scoped session subscribers are attached before activation.
- Migrates the easy-seven run facts: `updateTodos`, `updatePlan`, `addOutputFiles`, `updateMissingOutputs`, `updateCompileFailures`, `goalPaused`, and `updateStreamUsage`.
- Ships the Stage 1 test gates in this PR, including subscriber filtering, activation ordering, all-seven fact projection, projector detach, and progress-view projector equivalence coverage.
- Preserves the CLI headless surface for `texra run`, `--print`, and `--output-format json`; focused CLI run tests passed.

## Single source of truth

`SessionEventHub` on `SessionHandle` now owns session-scoped run event fanout. `src/agent/runtime/runFactEvents.ts` owns the easy-seven trace fact keys. `SessionRunFactProjector` is the single temporary legacy projection point back to the existing `ProgressEventBus` surface.

## Duplication and abstraction budget

This removes duplicate direct progress-bus emissions from tool-use/output/usage producers for the easy-seven facts. `UsageMonitor` no longer emits both trace stats and a separate runtime-host usage event; one trace usage event carries transcript stats plus the projected sidebar payload.

The new line count lives in the hub/projector boundary and the required migration tests. That added mass buys an explicit invariant: high-volume trace events are filtered before subscriber callbacks, and legacy projection is pinned to the matching stream so concurrent runs do not duplicate facts. The projector-equivalence tests are temporary migration scaffolding scheduled for removal with the projection path.

## Host impact

Extension: existing progress bus payloads remain unchanged downstream; the easy-seven facts now reach the extension through trace -> session hub -> projector.

Desktop: existing runtime-host emissions remain unchanged downstream; desktop tests were updated only for the `attachRunTrace(trace, streamId)` contract.

CLI: headless command output contracts remain unchanged; child-agent usage/todos now use the same trace -> session hub -> projector route, and the focused CLI `run`/print/json tests passed.

## Scheduled refactoring

No new shim row is needed. #6981 already contains the Stage 1 rows for `Trace→bus projections for the easy seven` and `Projector-equivalence test rigs`, both with Stage 5/#6968 as the removal trigger.

## Validation

- `corepack pnpm exec prettier --write` on touched files
- `corepack pnpm exec vitest run src/test-kernel/agent/runtime/SessionEventHub.vitest.ts src/test-kernel/progressView/SessionRunFactProjectorEquivalence.vitest.ts src/test-kernel/agent/runtime/ConversationProgressHub.vitest.ts src/test-kernel/agent/runtime/UsageMonitorLastTotals.vitest.ts src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts src/test-kernel/agent/output/OutputProgressEvents.vitest.ts src/test-kernel/agent/followUp/CodexProgressEvents.vitest.ts src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts src/test-kernel/agent/runtime/SessionHandle.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `corepack pnpm exec vitest run src/test-kernel/cli/RunExecution.vitest.mts src/test-kernel/cli/WorkflowRunCommand.vitest.mts src/test-kernel/cli/AgentsRunCommand.vitest.mts src/test-kernel/cli/MultiAgentRunCommand.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/RunProgressRenderer.vitest.mts`
- `npm run typecheck`
- `npm test`
- `npm run compile:fast`
- `npm run lint` (passes with the repo's existing 16 warnings)
- `git diff --check`

Closes #6962

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches launch ordering, all major progress UI feeds, and usage recording; behavior is intended to stay bus-equivalent but regressions would show as missing or duplicated sidebar/todo/output state.
> 
> **Overview**
> **Stage 1** of the session-scoped runtime work: run progress facts no longer go straight from flows/tools to `runtimeHost.emit` for the “easy seven” events.
> 
> Each `SessionHandle` gets a **`SessionEventHub`**. On launch, the run trace is attached to the session (with `streamId`) **before** `setActiveStream`, and **`SessionRunFactProjector`** plus the conversation-progress hub subscribe on that hub and re-emit the same legacy progress payloads. A dev/test guard asserts run-scoped subscribers exist before activation.
> 
> Producers now call **`emitRunFact(logger, …)`** (domain keys under `runFact.*`) for todos, plan, output files, missing/compile failures, and goal paused—across tool-use, reflection output, Codex/CLI child streams, etc. **`UsageMonitor`** and CLI usage publishing emit one **`usage`** trace event with optional `data` for sidebar projection and `recordTranscript` to keep tool-use stats rows off the transcript; the recorder skips `runFact.*` domain keys.
> 
> Interactive host commands (open file, show instruction) are unchanged. Tests were updated to exercise hub → projector paths and equivalence with direct bus events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73b3260980cb980b7d703734fa6d97f0374a25fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->