### PR TITLE
chore: remove unused @lit-labs/virtualizer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
     "@jamesgopsill/crossref-client": "^1.1.0",
     "@lit-labs/signals": "^0.3.0",
     "@lit-labs/ssr": "^4.1.0",
-    "@lit-labs/virtualizer": "^2.1.1",
     "@lit/context": "^1.1.6",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@octokit/request": "^10.0.11",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1974,7 +1974,6 @@
     "@jamesgopsill/crossref-client": "^1.1.0",
     "@lit-labs/signals": "^0.3.0",
     "@lit-labs/ssr": "^4.1.0",
-    "@lit-labs/virtualizer": "^2.1.1",
     "@lit/context": "^1.1.6",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@openai/codex-sdk": "^0.142.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,9 +38,6 @@ importers:
       '@lit-labs/ssr':
         specifier: ^4.1.0
         version: 4.1.0(@types/node@22.19.17)
-      '@lit-labs/virtualizer':
-        specifier: ^2.1.1
-        version: 2.1.1
       '@lit/context':
         specifier: ^1.1.6
         version: 1.1.6
@@ -550,9 +547,6 @@ importers:
       '@lit-labs/ssr':
         specifier: ^4.1.0
         version: 4.1.0(@types/node@22.19.17)
-      '@lit-labs/virtualizer':
-        specifier: ^2.1.1
-        version: 2.1.1
       '@lit/context':
         specifier: ^1.1.6
         version: 1.1.6
@@ -1677,9 +1671,6 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
-
-  '@lit-labs/virtualizer@2.1.1':
-    resolution: {integrity: sha512-JWxMwnlouLdwpw8spLTuax53WMnSP3xt0dCyxAS7GJr5Otda9MGgR/ghAdfwhSY75TmjbE1T2TqChwoGCw3ggw==}
 
   '@lit/context@1.1.6':
     resolution: {integrity: sha512-M26qDE6UkQbZA2mQ3RjJ3Gzd8TxP+/0obMgE5HfkfLhEEyYE3Bui4A5XHiGPjy0MUGAyxB3QgVuw2ciS0kHn6A==}
@@ -7235,11 +7226,6 @@ snapshots:
       parse5: 7.3.0
     optionalDependencies:
       '@types/node': 22.19.17
-
-  '@lit-labs/virtualizer@2.1.1':
-    dependencies:
-      lit: 3.3.2
-      tslib: 2.8.1
 
   '@lit/context@1.1.6':
     dependencies:


### PR DESCRIPTION
## Summary

Executes the recorded #6950 quick-win decision for #6960: **remove**. `@lit-labs/virtualizer` is declared in root and extension manifests with no active source imports; long transcripts continue to use the existing manual windowing in `TaskGroupList`.

## Issue acceptance gates

- [x] #6960 gate "No unused dependency remains, OR the virtualizer is actually rendering the transcript list" — satisfied via removal.
- [x] #6960 gate `npm run typecheck` + `npm test` — both green after rebasing onto current `main`.

## Single source of truth

N/A — dependency removal. The transcript windowing strategy remains in `TaskGroupList.ts`.

## Duplication and abstraction budget

Net negative: removes the unused dependency from both manifests and the lockfile. No abstraction, shim, projection, dual-write, alias, fallback, or migration path is introduced, so no #6981 ledger row is required.

## Host impact

Extension: no runtime behavior change; the package was not imported.

Desktop: no runtime behavior change.

CLI: no runtime behavior change.

## Scheduled refactoring

None. If virtualization is desired later, #6960 documents the mount path and validation burden.

## Validation

- `corepack pnpm install --lockfile-only`
- `corepack pnpm exec prettier --write package.json packages/extension/package.json pnpm-lock.yaml`
- `rg -n "@lit-labs/virtualizer|virtualizer" package.json packages/extension/package.json pnpm-lock.yaml src packages/*/src --glob '*.{ts,tsx,js,json,yaml}'` after the change returns no hits
- `npm run typecheck -- --pretty false`
- `npm run lint` (passes with 16 pre-existing warnings)
- `npm test`
- `npm run compile:fast`
- `git diff --check`

Closes #6960

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest and lockfile-only change with no source edits; removes an unused dependency with zero call sites.
> 
> **Overview**
> Removes **`@lit-labs/virtualizer`** from the workspace root and extension `package.json` files and drops its lockfile entries. The package was never imported in application source; long transcripts still rely on existing manual windowing in **`TaskGroupList`**.
> 
> This is dependency-only cleanup (closes #6960): no runtime behavior change, slightly leaner install/VSIX graph.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d2fd7712453e2a206c6d545b726ced2cde5b879. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->