### PR TITLE
[codex] Add StreamStatusMachine single writer

### DIFF
--- a/docs/proposals/session-scoped-runtime-architecture.md
+++ b/docs/proposals/session-scoped-runtime-architecture.md
@@ -1,6 +1,6 @@
 # Session-scoped runtime architecture: facts, interactions, and status ownership
 
-> **Status:** Partially landed proposal (Stages 0-1; status refreshed
+> **Status:** Partially landed proposal (Stages 0-2; status refreshed
 > 2026-07-04). Companion to the diagnosis in
 > `tech-debt-audit-2026-07.md` (Part B1/B5 + appendix); this document is the
 > target design. It covers the event/logger chain, the

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -12,7 +12,7 @@ import {
 } from '@common/constants/streamStatus';
 import {
   TODO_STATUS,
-  type StreamStatus,
+  type StreamLifecycleStatus,
   type StreamTabId,
   type TodoItem,
 } from '@shared/schemas';
@@ -310,7 +310,7 @@ export function shouldShowTodosPlanPanel({
 }: {
   readonly foregroundOpen: boolean;
   readonly hasPlan: boolean;
-  readonly status: StreamStatus | undefined;
+  readonly status: StreamLifecycleStatus | undefined;
   readonly todos: readonly TodoItem[];
 }): boolean {
   if (foregroundOpen) return false;

--- a/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
+++ b/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
@@ -163,6 +163,7 @@ export async function handleTuiSlashCommand(
           approval: formatCliApprovalPolicy(context.getApprovalPolicy()),
           approvalBypasses: slice?.bypass,
           status: slice?.status ?? 'not started',
+          substate: slice?.substate,
           goal: activeStreamId
             ? GoalStore.getForStream(activeStreamId)
             : undefined,

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -15,7 +15,8 @@ import { isLiveElapsedStatus } from '@common/constants/streamStatus';
 import {
   STREAM_STATUS,
   type ConversationProgress,
-  type StreamStatus,
+  type StreamLifecycleStatus,
+  type StreamSubstate,
   type StreamTabId,
   type TokenUsageStats,
 } from '@shared/schemas';
@@ -72,6 +73,7 @@ interface StatusBarSegment {
 
 export interface StatusBarDisplayInput {
   readonly status: string | undefined;
+  readonly substate?: StreamSubstate;
   /** Milliseconds since the running turn began. When set and `status` is
    *  `running`, the bar shows a live `Ns` segment so a long token-less
    *  "thinking" turn still reads as alive. Omitted in tests/headless. */
@@ -609,7 +611,7 @@ function approvalPolicySegment(
 }
 
 interface StatusBarVisibleStream {
-  readonly status: StreamStatus | undefined;
+  readonly status: StreamLifecycleStatus | undefined;
 }
 
 interface StatusBarStreamTarget {
@@ -683,7 +685,10 @@ export function buildStatusBarDisplay(
       });
     }
   } else {
-    left.push({ text: formatCliStatusLabel(input.status), color: 'dim' });
+    left.push({
+      text: formatCliStatusLabel(input.status, input.substate),
+      color: 'dim',
+    });
     if (
       input.status === STREAM_STATUS.RUNNING &&
       input.elapsedMs !== undefined
@@ -878,6 +883,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
 
   const display = buildStatusBarDisplay({
     status: statusSlice?.status,
+    substate: statusSlice?.substate,
     elapsedMs: runStartedAt !== undefined ? now - runStartedAt : undefined,
     pendingExitHint,
     pendingExitResumeId,

--- a/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
+++ b/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
@@ -190,6 +190,7 @@ export function streamTabsDisplayItems(init: {
     const slice = view.slice;
     const status = formatStreamStatusLabel(slice?.status, {
       style: 'cliCompact',
+      ...(slice?.substate ? { substate: slice.substate } : {}),
     });
     return {
       id: view.id,

--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -2,7 +2,7 @@ import stripAnsi from 'strip-ansi';
 
 import { ANSI_ESCAPE_START, ansiEscapeEnd } from '@cli/runtime/ansiEscapes';
 import { isLiveElapsedStatus } from '@common/constants/streamStatus';
-import { type StreamStatus } from '@shared/schemas';
+import { type StreamLifecycleStatus } from '@shared/schemas';
 
 import type { ConversationEntry } from '../state/cliState';
 
@@ -85,7 +85,7 @@ export function nextRenderableTranscriptEntry(
 export function userPromptAwaitsLiveContinuation(
   entries: readonly ConversationEntry[],
   index: number,
-  status: StreamStatus | undefined,
+  status: StreamLifecycleStatus | undefined,
 ): boolean {
   const entry = entries[index];
   if (
@@ -101,7 +101,7 @@ export function userPromptAwaitsLiveContinuation(
 
 export function splitTranscriptEntries(
   entries: readonly ConversationEntry[],
-  status: StreamStatus | undefined,
+  status: StreamLifecycleStatus | undefined,
 ): {
   readonly finalized: ConversationEntry[];
   /** Non-finalized entries in original stream order. The renderer must

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -55,8 +55,8 @@ import { isLiveElapsedStatus } from '@common/constants/streamStatus';
 import { toErrorMessage } from '@common/errors/errorMessage';
 import {
   STREAM_STATUS,
-  type StreamStatus,
   type ExecutionId,
+  type StreamLifecycleStatus,
   type StreamTabId,
 } from '@shared/schemas';
 import { escapeText } from '@shared/utils/xmlEscape';
@@ -423,7 +423,7 @@ export async function runChat(
   const followUpQueue = new PQueue({ concurrency: 1 });
   const pendingSkillActivations = new Map<string, string>();
   let pendingSkillActivationClearEpoch = 0;
-  const rootStreamStatus = (): StreamStatus | undefined =>
+  const rootStreamStatus = (): StreamLifecycleStatus | undefined =>
     session.streamId
       ? cliState.streams.get().get(session.streamId)?.status
       : undefined;

--- a/packages/cli/src/chat/tui/sessionStatus.ts
+++ b/packages/cli/src/chat/tui/sessionStatus.ts
@@ -1,4 +1,5 @@
 import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
+import type { StreamSubstate } from '@shared/schemas';
 import { summarizeFollowupMessage } from '@shared/subagentFollowup';
 import { formatStreamStatusLabel } from '@shared/streams/streamStatusDisplay';
 import { truncateSummary } from '@utils/text/stringUtils';
@@ -25,6 +26,7 @@ export interface CliSessionStatusInput {
   readonly approval: string;
   readonly approvalBypasses?: Partial<BypassState>;
   readonly status: string;
+  readonly substate?: StreamSubstate;
   readonly goal?: CliSessionGoalStatus | null;
   readonly queuedFollowUpMessages: readonly string[];
   /** Root execution id, when a run has started. Surfaces the resume command
@@ -36,10 +38,14 @@ export interface CliSessionStatusInput {
   readonly approvalPolicy?: CliApprovalPolicy;
 }
 
-export function formatCliStatusLabel(status: string | undefined): string {
+export function formatCliStatusLabel(
+  status: string | undefined,
+  substate?: StreamSubstate,
+): string {
   return formatStreamStatusLabel(status, {
     style: 'cli',
     missingLabel: '—',
+    ...(substate ? { substate } : {}),
   });
 }
 
@@ -83,7 +89,7 @@ export function formatCliSessionStatus(input: CliSessionStatusInput): string {
     ...(bypassLabels.length > 0
       ? [`auto-approvals: ${bypassLabels.join(', ')}`]
       : []),
-    `status: ${formatCliStatusLabel(input.status)}`,
+    `status: ${formatCliStatusLabel(input.status, input.substate)}`,
     ...(input.goal
       ? [
           `goal: ${input.goal.status}`,

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -17,7 +17,8 @@ import {
   type ConversationProgress,
   type NormalizedToolUse,
   type Plan,
-  type StreamStatus,
+  type StreamLifecycleStatus,
+  type StreamSubstate,
   type StreamTabId,
   type TodoItem,
   type TokenUsageStats,
@@ -85,7 +86,8 @@ export interface StreamSlice {
    *  from `setTaskState` or `setActiveStream`. Lets the exit hint list only
    *  resumable tool-use subagents (workflows don't resume). */
   readonly category: AgentCategory | undefined;
-  readonly status: StreamStatus | undefined;
+  readonly status: StreamLifecycleStatus | undefined;
+  readonly substate?: StreamSubstate;
   /** Epoch ms when this stream last entered `RUNNING`; cleared on any other
    *  status. Drives the StatusBar's live elapsed-time segment so a long
    *  token-less "thinking" turn still shows liveness. */
@@ -254,6 +256,7 @@ function emptySlice(streamId: StreamTabId): StreamSlice {
     model: undefined,
     category: undefined,
     status: undefined,
+    substate: undefined,
     runStartedAt: undefined,
     description: undefined,
     thinkingActive: false,
@@ -288,23 +291,28 @@ export function patchStream(
 
 function streamSliceWithStatus(
   slice: StreamSlice,
-  status: StreamStatus,
+  status: StreamLifecycleStatus,
+  substate: StreamSubstate | undefined,
   nowMs: number,
 ): StreamSlice {
   const runStartedAt =
     status === STREAM_STATUS.RUNNING
       ? (slice.runStartedAt ?? nowMs)
       : undefined;
-  if (slice.status === status && slice.runStartedAt === runStartedAt) {
+  if (
+    slice.status === status &&
+    slice.substate === substate &&
+    slice.runStartedAt === runStartedAt
+  ) {
     return slice;
   }
-  return { ...slice, status, runStartedAt };
+  return { ...slice, status, substate, runStartedAt };
 }
 
 function updateChildStatusReferences(
   children: readonly ActiveChildInfo[],
   childStreamId: StreamTabId,
-  status: StreamStatus,
+  status: StreamLifecycleStatus,
 ): readonly ActiveChildInfo[] {
   let out: ActiveChildInfo[] | undefined;
   children.forEach((child, index) => {
@@ -320,7 +328,7 @@ function updateChildStatusReferences(
 function withMirroredChildStreamStatus(
   slice: StreamSlice,
   childStreamId: StreamTabId,
-  status: StreamStatus,
+  status: StreamLifecycleStatus,
 ): StreamSlice {
   return mapChildStreamReferenceLists(slice, (children) =>
     updateChildStatusReferences(children, childStreamId, status),
@@ -338,10 +346,12 @@ function withMirroredChildStreamStatus(
 export function setStreamStatusInCliState({
   nowMs = Date.now(),
   status,
+  substate,
   streamId,
 }: {
   readonly nowMs?: number;
-  readonly status: StreamStatus;
+  readonly status: StreamLifecycleStatus;
+  readonly substate?: StreamSubstate;
   readonly streamId: StreamTabId;
 }): void {
   const current = cliState.streams.get();
@@ -351,6 +361,7 @@ export function setStreamStatusInCliState({
   const targetSlice = streamSliceWithStatus(
     existingSlice ?? emptySlice(streamId),
     status,
+    substate,
     nowMs,
   );
   if (targetSlice !== existingSlice) {

--- a/packages/cli/src/chat/tui/state/focusedChildFollowUp.ts
+++ b/packages/cli/src/chat/tui/state/focusedChildFollowUp.ts
@@ -3,7 +3,7 @@ import {
   metaChordLabel,
 } from '@cli/runtime/shortcutLabels';
 import { isInFlightStatus } from '@common/constants/streamStatus';
-import type { StreamStatus, StreamTabId } from '@shared/schemas';
+import type { StreamLifecycleStatus, StreamTabId } from '@shared/schemas';
 
 import { resolveChildControlDisplayTargets } from './childControls';
 import { activeStreamScope } from './streamViews';
@@ -40,7 +40,7 @@ export function focusedChildInputDisabledMessage(init: {
   readonly activeStreamId: StreamTabId | undefined;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
   readonly shortcutModifierLabel?: string;
-  readonly status: StreamStatus | undefined;
+  readonly status: StreamLifecycleStatus | undefined;
   readonly subagentControlsAvailable?: boolean;
   readonly taskControlsAvailable?: boolean;
 }): string | undefined {

--- a/packages/cli/src/chat/tui/state/sessionRunState.ts
+++ b/packages/cli/src/chat/tui/state/sessionRunState.ts
@@ -3,7 +3,7 @@ import { CliExitCode } from '@cli/runtime/exitCodes';
 import { isLiveElapsedStatus } from '@common/constants/streamStatus';
 import {
   STREAM_STATUS,
-  type StreamStatus,
+  type StreamLifecycleStatus,
   type StreamTabId,
 } from '@shared/schemas';
 
@@ -75,7 +75,7 @@ export function chatTuiCanInterruptActiveRun(
 
 export function chatTuiCanStopActiveRun(
   session: InterruptibleTuiSessionState,
-  status: StreamStatus | undefined,
+  status: StreamLifecycleStatus | undefined,
 ): boolean {
   if (!session.runPromise || session.runCompleted) return false;
   if (!session.streamId) return true;
@@ -84,7 +84,7 @@ export function chatTuiCanStopActiveRun(
 
 export function chatTuiCanStopVisibleRun(
   session: InterruptibleTuiSessionState,
-  status: StreamStatus | undefined,
+  status: StreamLifecycleStatus | undefined,
 ): boolean {
   return (
     chatTuiCanStopActiveRun(session, status) ||
@@ -107,7 +107,7 @@ export function publishChatTuiRootRunStartAvailability(
 export function chatTuiCanSelectModel(input: {
   readonly canStartRootRun: boolean;
   readonly streamId: StreamTabId | undefined;
-  readonly status: StreamStatus | undefined;
+  readonly status: StreamLifecycleStatus | undefined;
   readonly hasActiveToolUseFlow: boolean;
 }): boolean {
   return (

--- a/packages/cli/src/chat/tui/state/streamStatus.ts
+++ b/packages/cli/src/chat/tui/state/streamStatus.ts
@@ -8,6 +8,7 @@ export function applyStreamStatusChange(change: StreamStatusChange): void {
   setStreamStatusInCliState({
     streamId: change.streamId,
     status: change.status,
+    ...(change.substate ? { substate: change.substate } : {}),
   });
 }
 

--- a/packages/cli/src/chat/tui/state/transcript.ts
+++ b/packages/cli/src/chat/tui/state/transcript.ts
@@ -1,6 +1,6 @@
 import { getDefaultStreamLogStore } from '@transcript';
 import { isTerminalStatus } from '@common/constants/streamStatus';
-import { type StreamStatus, type StreamTabId } from '@shared/schemas';
+import { type StreamLifecycleStatus, type StreamTabId } from '@shared/schemas';
 
 import {
   cliState,
@@ -21,7 +21,7 @@ export const CLI_LOCAL_STREAM_ID = 'cli-local' as StreamTabId;
  * (not re-declared) so the membership stays single-sourced across all hosts.
  */
 export function isFinalTranscriptStatus(
-  status: StreamStatus | undefined,
+  status: StreamLifecycleStatus | undefined,
 ): boolean {
   return isTerminalStatus(status);
 }

--- a/packages/cli/src/chat/tui/state/transcriptProjection.ts
+++ b/packages/cli/src/chat/tui/state/transcriptProjection.ts
@@ -1,4 +1,4 @@
-import type { StreamStatus, StreamTabId } from '@shared/schemas';
+import type { StreamLifecycleStatus, StreamTabId } from '@shared/schemas';
 
 import { syncStreamLog } from './subscribeStreamLog';
 import {
@@ -49,7 +49,7 @@ export function projectStreamTranscript(
 /** Project a stream after a status transition. Final statuses promote rows. */
 export function projectStreamTranscriptForStatus(
   streamId: StreamTabId,
-  status: StreamStatus,
+  status: StreamLifecycleStatus,
 ): void {
   projectStreamTranscript(streamId, {
     finalize: isFinalTranscriptStatus(status),

--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -8,12 +8,7 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
 // Local imports - shared schemas
-import {
-  EXECUTION_STATUS,
-  STREAM_STATUS,
-  type ExecutionStatus,
-  type StreamStatus,
-} from '@shared/schemas';
+import { STREAM_PHASE, STREAM_STATUS, type StreamPhase } from '@shared/schemas';
 
 // Local imports - CLI runtime
 import { writeRawStderr } from './logSinks';
@@ -135,10 +130,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
           const data = payload as ProgressEventPayloads['updateStreamStatus'];
           if (!this.isRootStream(data.streamId)) return true;
           const { status } = data;
-          this.state.phase = formatRunProgressStatus(
-            status,
-            data.terminalStatus,
-          );
+          this.state.phase = formatRunProgressStatus(status);
           this.rootStreamTerminal = isTerminalStreamStatus(status);
           if (this.rootStreamTerminal) {
             this.state.activeProcesses = undefined;
@@ -308,17 +300,18 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
   }
 }
 
-function isTerminalStreamStatus(status: StreamStatus): boolean {
-  return status === STREAM_STATUS.STOPPED || status === STREAM_STATUS.ERROR;
+function isTerminalStreamStatus(status: StreamPhase): boolean {
+  return (
+    status === STREAM_PHASE.COMPLETED ||
+    status === STREAM_PHASE.CANCELLED ||
+    status === STREAM_PHASE.FAILED
+  );
 }
 
-function formatRunProgressStatus(
-  status: StreamStatus,
-  terminalStatus?: ExecutionStatus,
-): string {
-  if (status !== STREAM_STATUS.STOPPED) return status;
-  if (terminalStatus === EXECUTION_STATUS.COMPLETED) return 'done';
-  if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) return 'interrupted';
+function formatRunProgressStatus(status: StreamPhase): string {
+  if (status === STREAM_PHASE.COMPLETED) return 'done';
+  if (status === STREAM_PHASE.CANCELLED) return 'interrupted';
+  if (status === STREAM_PHASE.FAILED) return STREAM_STATUS.ERROR;
   return status;
 }
 

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -34,7 +34,6 @@ import {
   getAllActiveExecutionIds,
   SessionHandle,
 } from '@agent/runtime/SessionHandle';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { setProgressViewBridge } from '@agent/runtime/ProgressViewBridge';
 import {
   sendFollowUp,
@@ -55,15 +54,14 @@ import { createChannelTrace } from '@logger';
 import type { MainViewExecuteMessage } from '@shared/mainView';
 import {
   STREAM_PHASE,
-  STREAM_STATUS,
   type AgentProposalPermission,
   type AgentCategoryFilter,
   type MainViewPersistedState,
   type ProgressViewOutboundMessage,
   type ExecutionId,
   type StreamPhase,
+  type StreamSubstate,
   type StreamTabId,
-  streamStatusesWithTrait,
 } from '@shared/schemas';
 import type { ProgressViewInboundHandlerRegistry } from '@shared/schemas/progressView';
 import { ProgressBackend } from '@shared/progressView/backend/ProgressBackend';
@@ -113,7 +111,6 @@ const DESKTOP_UNAVAILABLE_TOOLS: readonly DesktopUnavailableTool[] = [
   'inline_comment',
   DIAGNOSTICS_ADD_RUNTIME_CAPABILITY,
 ];
-const RESTART_REPAIR_STATUSES = streamStatusesWithTrait('inFlight');
 const RESTART_REPAIR_PHASES: ReadonlySet<StreamPhase> = new Set([
   STREAM_PHASE.RUNNING,
   STREAM_PHASE.WAITING,
@@ -305,6 +302,7 @@ export class DesktopProgressBridge {
     // → rail-update translation.  See #6329.
     this.progressEvents = createDesktopProgressEventBridge({
       state: this.state,
+      streamStatus: this.session.status,
       streamSnapshotStore: options.streamSnapshotStore,
       sendMessage: (message) => this.send(message),
       logger: this.logger,
@@ -647,25 +645,58 @@ export class DesktopProgressBridge {
     waitingStreams: ReadonlySet<StreamTabId>,
   ): StreamTabId[] {
     const affectedStreams: StreamTabId[] = [];
+    const statusEmitOptions = {
+      runtimeHost: this.runtimeHost,
+      trace: this.logger,
+    };
     for (const streamId of repairStreams) {
-      const currentStatus = StreamStatusService.get(streamId);
-      if (!currentStatus || !RESTART_REPAIR_STATUSES.has(currentStatus)) {
+      const currentStatus = this.session.status.get(streamId);
+      if (!currentStatus || !RESTART_REPAIR_PHASES.has(currentStatus)) {
         continue;
       }
       if (waitingStreams.has(streamId)) {
-        StreamStatusService.set(streamId, STREAM_STATUS.WAITING, {
-          emit: false,
-        });
+        this.session.status.transition(
+          streamId,
+          STREAM_PHASE.WAITING,
+          'restart-repair',
+          statusEmitOptions,
+        );
         this.logger.debug(
           `Stream ${streamId} restored to WAITING after reload`,
         );
         continue;
       }
-      StreamStatusService.set(streamId, STREAM_STATUS.ERROR, { emit: false });
-      affectedStreams.push(streamId);
-      this.logger.debug(
-        `Stream ${streamId} set to ERROR during desktop restart recovery`,
+      let markedFailed = this.session.status.transition(
+        streamId,
+        STREAM_PHASE.FAILED,
+        'restart-repair',
+        statusEmitOptions,
       );
+      if (!markedFailed && currentStatus === STREAM_PHASE.WAITING) {
+        markedFailed =
+          this.session.status.transition(
+            streamId,
+            STREAM_PHASE.RUNNING,
+            'resume',
+            statusEmitOptions,
+          ) &&
+          this.session.status.transition(
+            streamId,
+            STREAM_PHASE.FAILED,
+            'lifecycle',
+            statusEmitOptions,
+          );
+      }
+      if (markedFailed) {
+        affectedStreams.push(streamId);
+        this.logger.debug(
+          `Stream ${streamId} set to FAILED during desktop restart recovery`,
+        );
+      } else {
+        this.logger.warn(
+          `Failed to repair stream ${streamId} during desktop restart recovery`,
+        );
+      }
     }
     return affectedStreams;
   }
@@ -681,10 +712,10 @@ export class DesktopProgressBridge {
       if (executionId && activeExecutionIds.has(executionId)) {
         continue;
       }
-      const currentStatus = StreamStatusService.get(streamId);
+      const currentStatus = this.session.status.get(streamId);
       if (
         RESTART_REPAIR_PHASES.has(snapshot.lastKnownStatus) ||
-        (currentStatus != null && RESTART_REPAIR_STATUSES.has(currentStatus))
+        (currentStatus != null && RESTART_REPAIR_PHASES.has(currentStatus))
       ) {
         repairStreams.add(streamId);
       }
@@ -763,12 +794,12 @@ export class DesktopProgressBridge {
         this.syncFullView();
       }
     } catch (error) {
-      const waitingStreams = new Set(
-        [...this.progressEvents.restoredStreams.keys()].filter(
-          (streamId) =>
-            StreamStatusService.get(streamId) === STREAM_STATUS.WAITING,
-        ),
-      );
+      const waitingStreams = new Set<StreamTabId>();
+      for (const [streamId, status] of this.session.status.entries()) {
+        if (status === STREAM_PHASE.WAITING) {
+          waitingStreams.add(streamId);
+        }
+      }
       this.progressEvents.hydrateRestoredStreams();
       const activeExecutionIds = new Set(getAllActiveExecutionIds());
       const allExecutionIds = this.getRestartRepairExecutionIdMap();
@@ -823,10 +854,20 @@ export class DesktopProgressBridge {
     this.progressEvents.onProgressEvent(event, payload);
   }
 
+  private streamStatusSnapshot(): Map<StreamTabId, StreamPhase> {
+    return this.session.status.getAll();
+  }
+
+  private streamSubstateSnapshot(): Map<StreamTabId, StreamSubstate> {
+    return this.session.status.getAllSubstates();
+  }
+
   syncFullView(): void {
     const activeStream = this.backend.webviewUpdater.sendStreamMetadata(
       this.state,
-      this.backend.eventHandler.getAllStreamStatuses(),
+      this.streamStatusSnapshot(),
+      undefined,
+      this.streamSubstateSnapshot(),
     );
     this.syncStreamContent(activeStream);
   }
@@ -842,7 +883,9 @@ export class DesktopProgressBridge {
     this.state.activeStream = streamId;
     this.backend.webviewUpdater.sendStreamMetadata(
       this.state,
-      this.backend.eventHandler.getAllStreamStatuses(),
+      this.streamStatusSnapshot(),
+      undefined,
+      this.streamSubstateSnapshot(),
     );
     this.backend.webviewUpdater.setActiveStream(streamId);
     this.syncStreamContent(streamId);
@@ -852,7 +895,9 @@ export class DesktopProgressBridge {
     this.state.agentCategoryFilter = filter;
     const activeStream = this.backend.webviewUpdater.sendStreamMetadata(
       this.state,
-      this.backend.eventHandler.getAllStreamStatuses(),
+      this.streamStatusSnapshot(),
+      undefined,
+      this.streamSubstateSnapshot(),
     );
     this.syncStreamContent(activeStream);
   }
@@ -881,7 +926,9 @@ export class DesktopProgressBridge {
     });
     const activeStream = this.backend.webviewUpdater.sendStreamMetadata(
       this.state,
-      this.backend.eventHandler.getAllStreamStatuses(),
+      this.streamStatusSnapshot(),
+      undefined,
+      this.streamSubstateSnapshot(),
     );
     this.syncStreamContent(activeStream);
   }
@@ -922,7 +969,9 @@ export class DesktopProgressBridge {
     this.send({ command: PROGRESS_VIEW_COMMANDS.DELETE_ALL });
     this.backend.webviewUpdater.sendStreamMetadata(
       this.state,
-      this.backend.eventHandler.getAllStreamStatuses(),
+      this.streamStatusSnapshot(),
+      undefined,
+      this.streamSubstateSnapshot(),
     );
   }
 

--- a/packages/desktop/src/main/desktopProgressEventBridge.ts
+++ b/packages/desktop/src/main/desktopProgressEventBridge.ts
@@ -11,12 +11,10 @@
  */
 
 import type { AgentTrace } from '@agent/trace';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import { bus, type ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import {
   STREAM_PHASE,
-  streamPhaseToStreamStatus,
-  streamStatusToPhase,
   type ProgressViewOutboundMessage,
   type RestoredStreamSnapshot,
   type StreamTabId,
@@ -34,6 +32,8 @@ import type { DesktopStreamSnapshotStore } from './desktopStreamSnapshot.js';
 export interface DesktopProgressEventBridgeOptions {
   /** The owning bridge's progress-view state. */
   state: ProgressViewState;
+  /** Session-owned stream status plane for this desktop window. */
+  streamStatus: Pick<StreamStatusMachine, 'get' | 'transition'>;
   /** Snapshot store for cross-launch persistence (may be undefined). */
   streamSnapshotStore?: DesktopStreamSnapshotStore;
   /** Sends a progress-view outbound message to the renderer. */
@@ -181,10 +181,10 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
         parentStreamId: snapshot.parentStreamId,
         description: snapshot.description,
       });
-      StreamStatusService.set(
+      this.opts.streamStatus.transition(
         snapshot.streamId,
-        streamPhaseToStreamStatus(snapshot.lastKnownStatus),
-        { emit: false },
+        snapshot.lastKnownStatus,
+        'restart-repair',
       );
     }
   }
@@ -390,7 +390,7 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
     const taskState = this.opts.state.snapshots.getTaskState(streamId);
     const info = buildStreamInfo(this.opts.state, streamId, 'all');
     const restored = this.restoredStreams.get(streamId);
-    const currentStatus = StreamStatusService.get(streamId);
+    const currentStatus = this.opts.streamStatus.get(streamId);
     const snapshot: RestoredStreamSnapshot = {
       streamId,
       label: info?.label ?? restored?.label ?? streamId,
@@ -401,9 +401,8 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
         AgentCategory.Workflow,
       inputFile: info?.inputFile || restored?.inputFile,
       instruction: taskState?.agentConfig.instruction || restored?.instruction,
-      lastKnownStatus: currentStatus
-        ? streamStatusToPhase(currentStatus)
-        : (restored?.lastKnownStatus ?? STREAM_PHASE.COMPLETED),
+      lastKnownStatus:
+        currentStatus ?? restored?.lastKnownStatus ?? STREAM_PHASE.COMPLETED,
       description: info?.description ?? restored?.description,
       executionId: info?.executionId ?? restored?.executionId,
       parentStreamId: info?.parentStreamId ?? restored?.parentStreamId,

--- a/packages/extension/src/commands/agent/followUpCommand.ts
+++ b/packages/extension/src/commands/agent/followUpCommand.ts
@@ -14,7 +14,7 @@ import { registerCommands } from '@commands/_shared/registerCommands';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { createChannelTrace } from '@logger';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
-import { STREAM_STATUS } from '@shared/schemas';
+import { STREAM_PHASE } from '@shared/schemas';
 import type { StreamTabId } from '@shared/schemas';
 
 const logger = createChannelTrace('followUpCommand');
@@ -25,7 +25,7 @@ async function lazyDetectWaitingStatus(
   streamId: StreamTabId,
 ): Promise<boolean> {
   const currentStatus = StreamStatusService.get(streamId);
-  if (currentStatus === STREAM_STATUS.WAITING) {
+  if (currentStatus === STREAM_PHASE.WAITING) {
     return true;
   }
   if (!shouldProbePersistedFlowForFollowUp(currentStatus)) {
@@ -47,12 +47,19 @@ async function lazyDetectWaitingStatus(
   try {
     const hasFlow = await hasPersistedFlowRecord(executionId);
     if (hasFlow) {
-      StreamStatusService.set(streamId, STREAM_STATUS.WAITING, {
-        runtimeHost: extensionAgentRuntimeHost,
-      });
-      logger.debug(`Lazy detected waiting session for stream: ${streamId}`);
+      const repaired = StreamStatusService.transitionToWaiting(
+        streamId,
+        'restart-repair',
+        {
+          runtimeHost: extensionAgentRuntimeHost,
+        },
+      );
+      if (repaired) {
+        logger.debug(`Lazy detected waiting session for stream: ${streamId}`);
+      }
+      return repaired;
     }
-    return hasFlow;
+    return false;
   } finally {
     inFlightDetections.delete(streamId);
   }

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -97,7 +97,10 @@ import {
   hasUsableApiKey,
 } from '@model/apiProviders';
 import { refreshModelListStateIfNeeded } from '@model/modelListRefresh';
-import { type StreamStatus, type TokenUsageStats } from '@shared/schemas';
+import {
+  type StreamLifecycleStatus,
+  type TokenUsageStats,
+} from '@shared/schemas';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { setOpenPdfOpener } from '@tools/OpenPdfTool';
 import { refreshToolAvailability } from '@tools/toolAvailability';
@@ -717,7 +720,13 @@ export async function activate(context: vscode.ExtensionContext) {
 
   const disposeStreamStatusListener = bus.on(
     'updateStreamStatus',
-    ({ streamId, status }: { streamId: string; status: StreamStatus }) => {
+    ({
+      streamId,
+      status,
+    }: {
+      streamId: string;
+      status: StreamLifecycleStatus;
+    }) => {
       statusBarUsageTracker.updateStreamStatus(streamId, status);
       updateStatusBarTooltip();
       updateStatusBarText();

--- a/packages/extension/src/frontend/statusBar/StatusBarUsageTracker.ts
+++ b/packages/extension/src/frontend/statusBar/StatusBarUsageTracker.ts
@@ -4,7 +4,7 @@ import {
   isInFlightStatus,
   isTerminalStatus,
 } from '@common/constants/streamStatus';
-import type { StreamStatus } from '@shared/schemas/stream';
+import type { StreamLifecycleStatus } from '@shared/schemas/stream';
 import type { TokenUsageStats } from '@shared/schemas/usage';
 
 export interface StatusBarUsageTotals {
@@ -22,10 +22,13 @@ const ZERO_USAGE: StatusBarUsageTotals = {
 /** Tracks active streams and usage totals for the extension status bar. */
 export class StatusBarUsageTracker {
   private readonly activeStreams = new Set<string>();
-  private readonly streamStatuses = new Map<string, StreamStatus>();
+  private readonly streamStatuses = new Map<string, StreamLifecycleStatus>();
   private readonly usageByStream = new Map<string, StatusBarUsageTotals>();
 
-  public updateStreamStatus(streamId: string, status: StreamStatus): void {
+  public updateStreamStatus(
+    streamId: string,
+    status: StreamLifecycleStatus,
+  ): void {
     if (isActiveStatus(status)) {
       this.activeStreams.add(streamId);
     } else {

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -297,6 +297,7 @@ export class ProgressViewProvider
       this.state,
       this.eventHandler.getAllStreamStatuses(),
       theme,
+      this.eventHandler.getAllStreamSubstates(),
     );
 
     // Skip content sync when streams exist but filter excludes all of them

--- a/packages/extension/src/progressView/frontend/components/ProcessStreamContent.ts
+++ b/packages/extension/src/progressView/frontend/components/ProcessStreamContent.ts
@@ -41,6 +41,7 @@ export class ProcessStreamContent extends LitElement {
       <stream-header
         .stream=${streamInfo}
         .status=${streamState.status}
+        .substate=${streamState.substate}
         .progress=${streamState.conversationProgress}
         .yoloActive=${Boolean(toolUse?.toolEditBypass)}
         .superYoloActive=${Boolean(toolUse?.superYoloBypass)}

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -17,6 +17,7 @@ import {
   STREAM_STATUS,
   STREAM_SUBSTATE,
   type ConversationProgress,
+  type StreamSubstate,
   type StreamTabInfo,
 } from '@shared/schemas';
 import {
@@ -321,6 +322,7 @@ export class StreamHeader extends LitElement {
 
   @property({ attribute: false }) stream: StreamTabInfo | null = null;
   @property({ attribute: false }) status: string = STREAM_STATUS.READY;
+  @property({ attribute: false }) substate: StreamSubstate | undefined;
   @property({ attribute: false }) progress: ConversationProgress | undefined;
   @property({ attribute: false }) yoloActive = false;
   @property({ attribute: false }) superYoloActive = false;
@@ -336,8 +338,9 @@ export class StreamHeader extends LitElement {
     const status = this.status || STREAM_STATUS.READY;
     const statusLabel = formatStreamStatusLabel(status, {
       style: 'progressHeader',
+      ...(this.substate ? { substate: this.substate } : {}),
     });
-    const statusClass = streamStatusIndicatorClass(status);
+    const statusClass = streamStatusIndicatorClass(status, this.substate);
     const hasExecutionId = Boolean(this.stream.executionId);
     const agentCategory = this.stream.agentCategory;
     const toolbarButtons =
@@ -354,6 +357,7 @@ export class StreamHeader extends LitElement {
         const { disabled, hidden } = this.getButtonState(
           btn.id,
           status,
+          this.substate,
           hasExecutionId,
         );
         const isActive = Boolean(
@@ -442,9 +446,10 @@ export class StreamHeader extends LitElement {
   private getButtonState(
     buttonId: string,
     status: string,
+    substate: StreamSubstate | undefined,
     hasExecutionId: boolean,
   ): { disabled: boolean; hidden: boolean } {
-    const displayKey = streamStatusDisplayKey(status);
+    const displayKey = streamStatusDisplayKey(status, substate);
     const enabledButtons = displayKey
       ? ENABLED_BUTTONS_BY_DISPLAY_KEY[displayKey]
       : undefined;

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -14,6 +14,7 @@ import { when } from 'lit/directives/when.js';
 // Local imports
 import {
   STREAM_STATUS,
+  type StreamSubstate,
   type StreamTabId,
   type StreamTabInfo,
 } from '@shared/schemas';
@@ -22,6 +23,10 @@ import {
   animationStyles,
   commonViewStyles,
 } from '@shared/styles';
+import {
+  formatStreamStatusLabel,
+  streamStatusDisplayKey,
+} from '@shared/streams/streamStatusDisplay';
 import {
   AGENT_DECORATORS,
   getAgentCategoryDecorator,
@@ -55,11 +60,11 @@ import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 function buildTooltip(
   info: StreamTabInfo,
   lastTimestamp: number | undefined,
-  status: string,
+  statusLabel: string,
 ): string {
   const mainLine = [
     info.label,
-    `Status: ${status}`,
+    `Status: ${statusLabel}`,
     info.model && `Model: ${info.modelLabel ?? info.model}`,
     info.inputFile && `Input: ${info.inputFile}`,
   ]
@@ -92,6 +97,7 @@ export class StreamTab extends LitElement {
 
   @property({ attribute: false }) info!: StreamTabInfo;
   @property({ type: String }) status: string = STREAM_STATUS.READY;
+  @property({ attribute: false }) substate: StreamSubstate | undefined;
   @property({ attribute: false }) lastTimestamp: number | undefined = undefined;
   @property({ type: Boolean }) active = false;
   @property({ type: Boolean }) compact = false;
@@ -108,6 +114,7 @@ export class StreamTab extends LitElement {
     if (
       !changed.has('info') &&
       !changed.has('status') &&
+      !changed.has('substate') &&
       !changed.has('lastTimestamp')
     )
       return;
@@ -115,12 +122,18 @@ export class StreamTab extends LitElement {
       this._agentDecorator = getAgentCategoryDecorator(this.info.agentCategory);
     }
     const status = this.status || STREAM_STATUS.READY;
-    this._tooltip = buildTooltip(this.info, this.lastTimestamp, status);
+    const statusLabel =
+      formatStreamStatusLabel(status, {
+        style: 'progressHeader',
+        ...(this.substate ? { substate: this.substate } : {}),
+      }) ?? status;
+    this._tooltip = buildTooltip(this.info, this.lastTimestamp, statusLabel);
   }
 
   override render(): TemplateResult {
     const stream = this.info;
     const status = this.status || STREAM_STATUS.READY;
+    const statusKey = streamStatusDisplayKey(status, this.substate) ?? status;
     const tooltip = this._tooltip;
     const agentDecorator = this._agentDecorator;
     const hasChildren = this.childCount > 0 && !this.compact;
@@ -133,7 +146,7 @@ export class StreamTab extends LitElement {
           'is-active': this.active,
           'is-compact': this.compact,
           'has-children': hasChildren,
-          [`status-${status}`]: Boolean(status),
+          [`status-${statusKey}`]: Boolean(statusKey),
           'has-pending-approval': this.hasPendingApproval,
         })}
       >
@@ -324,6 +337,10 @@ export class StreamTabs extends LitElement {
     return this.streamStates.get(name)?.status ?? STREAM_STATUS.READY;
   }
 
+  private getSubstate(name: StreamTabId): StreamSubstate | undefined {
+    return this.streamStates.get(name)?.substate;
+  }
+
   private getTimestamp(name: StreamTabId): number | undefined {
     return this.streamStates.get(name)?.lastTimestamp;
   }
@@ -368,6 +385,7 @@ export class StreamTabs extends LitElement {
         .info=${stream}
         .compact=${options.compact}
         .status=${this.getStatus(stream.name)}
+        .substate=${this.getSubstate(stream.name)}
         .lastTimestamp=${this.getTimestamp(stream.name)}
         ?active=${stream.name === this.activeStreamId}
         .hasPendingApproval=${this.pendingApprovalStreamIds.has(stream.name)}

--- a/packages/extension/src/progressView/frontend/components/ToolUseStreamContent.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolUseStreamContent.ts
@@ -41,6 +41,7 @@ export class ToolUseStreamContent extends BaseStreamContent {
       <stream-header
         .stream=${streamInfo}
         .status=${currentState.status}
+        .substate=${currentState.substate}
         .progress=${currentState.conversationProgress}
         .yoloActive=${Boolean(currentState.toolEditBypass)}
         .superYoloActive=${Boolean(currentState.superYoloBypass)}

--- a/packages/extension/src/progressView/frontend/components/WorkflowStreamContent.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowStreamContent.ts
@@ -42,6 +42,7 @@ export class WorkflowStreamContent extends BaseStreamContent {
       <stream-header
         .stream=${streamInfo}
         .status=${state.status}
+        .substate=${state.substate}
         .progress=${state.conversationProgress}
         .yoloActive=${false}
       ></stream-header>

--- a/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
@@ -16,7 +16,11 @@ import '@awesome.me/webawesome/dist/components/select/select.js';
 import '@awesome.me/webawesome/dist/components/option/option.js';
 import '@awesome.me/webawesome/dist/components/textarea/textarea.js';
 
-import { STREAM_STATUS, type StreamStatus } from '@shared/schemas';
+import {
+  STREAM_PHASE,
+  STREAM_STATUS,
+  type StreamLifecycleStatus,
+} from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { selectStyles } from '@shared/styles/selectStyles';
 import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
@@ -96,7 +100,7 @@ export class WorkflowToolUseFollowupSection extends LitElement {
     `,
   ];
 
-  @property({ attribute: false }) status: StreamStatus | null = null;
+  @property({ attribute: false }) status: StreamLifecycleStatus | null = null;
   @property({ type: Boolean }) hasOutputFiles = false;
   @property({ attribute: false }) options: FollowupOptionsState | null = null;
   @property({ attribute: false }) streamModel: string | null = null;
@@ -210,8 +214,9 @@ export class WorkflowToolUseFollowupSection extends LitElement {
       this.hasOutputFiles &&
       (this.status == null ||
         this.status === STREAM_STATUS.READY ||
-        this.status === STREAM_STATUS.ERROR ||
-        this.status === STREAM_STATUS.STOPPED)
+        this.status === STREAM_PHASE.FAILED ||
+        this.status === STREAM_PHASE.COMPLETED ||
+        this.status === STREAM_PHASE.CANCELLED)
     );
   }
 

--- a/packages/extension/src/progressView/frontend/components/streamTabsStyles.ts
+++ b/packages/extension/src/progressView/frontend/components/streamTabsStyles.ts
@@ -50,7 +50,8 @@ export const streamTabStyles = css`
     border-left-color: var(--color-success);
   }
 
-  .tab-container.status-error {
+  .tab-container.status-error,
+  .tab-container.status-failed {
     border-left-color: var(--color-error);
   }
 
@@ -60,11 +61,14 @@ export const streamTabStyles = css`
   }
 
   .tab-container.status-stopped,
+  .tab-container.status-completed,
+  .tab-container.status-cancelled,
   .tab-container.status-ready {
     border-left-color: var(--color-border);
   }
 
-  .tab-container.status-initializing {
+  .tab-container.status-initializing,
+  .tab-container.status-starting {
     border-left-color: var(--color-warning);
   }
 

--- a/packages/extension/src/progressView/frontend/constants.ts
+++ b/packages/extension/src/progressView/frontend/constants.ts
@@ -1,5 +1,5 @@
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
-import { STREAM_STATUS, type AgentCategoryFilter } from '@shared/schemas';
+import { STREAM_PHASE, type AgentCategoryFilter } from '@shared/schemas';
 
 /**
  * DOM element IDs used across the progress view.
@@ -52,10 +52,8 @@ export const GROUP_DOM_IDS = Object.freeze({
 });
 
 export const ACTIVE_STREAM_STATUSES: ReadonlySet<string> = new Set([
-  STREAM_STATUS.INITIALIZING,
-  STREAM_STATUS.RUNNING,
-  STREAM_STATUS.RESUMING,
-  STREAM_STATUS.WAITING,
+  STREAM_PHASE.RUNNING,
+  STREAM_PHASE.WAITING,
 ]);
 
 const STOP_STREAM_BUTTON = Object.freeze({

--- a/packages/extension/src/progressView/frontend/contexts/streamContexts.ts
+++ b/packages/extension/src/progressView/frontend/contexts/streamContexts.ts
@@ -11,7 +11,7 @@ import { createContext } from '@lit/context';
 import type {
   LogMessageData,
   InquiryThreadUpdatedEvent,
-  StreamStatus,
+  StreamLifecycleStatus,
   StreamTabId,
   StreamTabInfo,
   TaskGroup,
@@ -68,7 +68,7 @@ export interface StreamLogContextValue {
   /** Stream name for switch detection in LogList */
   streamName: string | null;
   /** Current active stream status for pre-output empty states. */
-  streamStatus: StreamStatus | null;
+  streamStatus: StreamLifecycleStatus | null;
   /** Render log output in terminal style (monospace, no timestamps, etc). */
   terminalMode: boolean;
 }

--- a/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
@@ -43,11 +43,14 @@ function mergeBackendOwnedState(
     });
   }
   // Overlay every backend-owned field from metadata (its own keys include
-  // every BackendOwnedFieldsSchema field plus `kind`, which the guard above
-  // already ensures matches `existing.kind`) so a new field added to that
-  // schema is picked up here without also updating this call site.
+  // every required BackendOwnedFieldsSchema field plus `kind`, which the guard
+  // above already ensures matches `existing.kind`) so a new field added to
+  // that schema is picked up here without also updating this call site.
   return create(existing, (draft) => {
     Object.assign(draft, metadata);
+    if (!Object.hasOwn(metadata, 'substate')) {
+      delete draft.substate;
+    }
   });
 }
 

--- a/packages/extension/src/progressView/frontend/slices/streamMetaSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamMetaSlice.ts
@@ -44,7 +44,7 @@ const WEBVIEW_OUTPUT_CAP = { maxChars: 100_000, retainChars: 80_000 } as const;
 
 export const streamMetaHandlers: HandlerRegistry = {
   [PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_STATUS]: (data, ctx) => {
-    const { stream, status, lastTimestamp } = data;
+    const { stream, status, lastTimestamp, substate } = data;
     const state = ctx.getState();
     const isActiveStream = stream === state.activeStreamId;
     const shouldFocus = isActiveStream && status === STREAM_STATUS.WAITING;
@@ -59,6 +59,11 @@ export const streamMetaHandlers: HandlerRegistry = {
       const resolvedTimestamp = lastTimestamp ?? current.lastTimestamp;
       const updatedState = create(current, (draft) => {
         draft.status = status;
+        if (substate) {
+          draft.substate = substate;
+        } else {
+          delete draft.substate;
+        }
         draft.lastTimestamp = resolvedTimestamp;
         if (isToolUseState(current) && shouldFocus) {
           (draft as typeof current).ui.shouldFocusFollowUp = true;

--- a/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
@@ -14,6 +14,7 @@ import {
   createWorkflowStreamState,
   LOG_LEVELS,
   MESSAGE_TYPES,
+  STREAM_PHASE,
   STREAM_STATUS,
   type LogMessageData,
   type OutputFileInfo,
@@ -166,21 +167,21 @@ const SAMPLE_STREAM_STATES: Map<string, StreamState> = new Map([
   [
     'figures',
     createWorkflowStreamState({
-      status: STREAM_STATUS.STOPPED,
+      status: STREAM_PHASE.COMPLETED,
       lastTimestamp: BASE_TIME - 10 * 60_000,
     }),
   ],
   [
     'review',
     createWorkflowStreamState({
-      status: STREAM_STATUS.STOPPED,
+      status: STREAM_PHASE.COMPLETED,
       lastTimestamp: BASE_TIME - 52 * 60_000,
     }),
   ],
   [
     'bib',
     createWorkflowStreamState({
-      status: STREAM_STATUS.STOPPED,
+      status: STREAM_PHASE.COMPLETED,
       lastTimestamp: BASE_TIME - 2 * 60 * 60_000,
     }),
   ],

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -10,8 +10,7 @@ import { SupabaseClient } from '@auth/SupabaseClient';
 import { ensureError, normalizeProviderError } from '@common/errors';
 import { isUserAbort } from '@common/errors/sdkErrorUtils';
 import {
-  EXECUTION_STATUS,
-  STREAM_STATUS,
+  STREAM_PHASE,
   toRetryErrorInfo,
   type RetryErrorInfo,
 } from '@shared/schemas';
@@ -263,8 +262,9 @@ export abstract class RetryableInvocationNode<
 
     logErrorData(logger, `${operationName} failed`, formatted);
 
-    streamStatus.set(streamId, STREAM_STATUS.WAITING, {
+    streamStatus.transition(streamId, STREAM_PHASE.WAITING, 'wait', {
       runtimeHost,
+      trace: logger,
     });
     const result = await session.coordinators.waitForRetry(streamId, {
       operation: operationName,
@@ -275,8 +275,9 @@ export abstract class RetryableInvocationNode<
 
     if (result.action === 'retry') {
       logger.debug('Manual retry triggered');
-      streamStatus.set(streamId, STREAM_STATUS.RUNNING, {
+      streamStatus.transition(streamId, STREAM_PHASE.RUNNING, 'resume', {
         runtimeHost,
+        trace: logger,
       });
       return { shouldRetry: true, userCancelled: false };
     }
@@ -286,9 +287,9 @@ export abstract class RetryableInvocationNode<
         ? 'Retry timed out (no response)'
         : 'Retry cancelled by user';
     logProgressStatus(logger, message);
-    streamStatus.set(streamId, STREAM_STATUS.STOPPED, {
+    streamStatus.transition(streamId, STREAM_PHASE.CANCELLED, 'user-stop', {
       runtimeHost,
-      terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+      trace: logger,
     });
     return { shouldRetry: false, userCancelled: true };
   }

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -9,7 +9,7 @@ import {
   followUpDisplayText,
 } from '@agent/followUp/followUpMessages';
 import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
-import { STREAM_STATUS } from '@shared/schemas';
+import { STREAM_PHASE } from '@shared/schemas';
 import { GoalStore, setGoalSessionBashAutoApproval } from '@tools/goal';
 
 import { findLastAssistantText, extractTouchedFiles } from './types';
@@ -120,8 +120,9 @@ export class ToolUseWaitNode<C> extends Node<
     }
 
     if (!session.hasQueuedFollowUp()) {
-      streamStatus.set(streamId, STREAM_STATUS.WAITING, {
+      streamStatus.transitionToWaiting(streamId, 'wait', {
         runtimeHost,
+        trace: this.services.logger,
       });
     }
 
@@ -169,8 +170,9 @@ export class ToolUseWaitNode<C> extends Node<
       shared.deliveredToOrchestrator = true;
     }
 
-    streamStatus.set(streamId, STREAM_STATUS.RUNNING, {
+    streamStatus.transition(streamId, STREAM_PHASE.RUNNING, 'resume', {
       runtimeHost,
+      trace: logger,
     });
 
     // Synthesized continuations don't come from the user queue, so they

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -45,7 +45,8 @@ import { AgentError, getSdkErrorMessage, toErrorMessage } from '@common/errors';
 import { normalizeRunId } from '@common/constants/runIds';
 import { INSTRUCTION_ACTION } from '@eventBus/ProgressEventBus';
 import {
-  STREAM_STATUS,
+  STREAM_PHASE,
+  STREAM_SUBSTATE,
   type ExecutionId,
   type StorageKey,
   type StreamTabId,
@@ -68,13 +69,10 @@ import {
   shouldWarnMediaNeedsVision,
 } from './mediaVisionWarning';
 import { getStreamTabId } from './streamTab';
-import {
-  StreamStatusService,
-  type StreamStatusRegistry,
-} from './StreamStatusService';
 import { currentSession, type SessionHandle } from './SessionHandle';
 import { attachConversationProgressHub } from './conversationProgressHub';
 import { attachSessionRunFactProjector } from './SessionRunFactProjector';
+import type { StreamStatusRegistry } from './StreamStatusService';
 import type { ToolEditApprovalPort } from '@platform/interfaces/toolEditApproval';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 
@@ -130,10 +128,13 @@ export interface AgentLaunchInput {
 }
 
 const STATUS_MESSAGES: Record<string, string> = {
-  [STREAM_STATUS.INITIALIZING]: 'already launching',
-  [STREAM_STATUS.RESUMING]: 'resuming',
-  [STREAM_STATUS.RUNNING]: 'already running',
-  [STREAM_STATUS.WAITING]: 'waiting for retry',
+  [STREAM_SUBSTATE.STARTING]: 'already launching',
+  [STREAM_SUBSTATE.RESUMING]: 'resuming',
+  [STREAM_PHASE.RUNNING]: 'already running',
+  [STREAM_PHASE.WAITING]: 'waiting for retry',
+  [STREAM_PHASE.COMPLETED]: 'completed',
+  [STREAM_PHASE.CANCELLED]: 'stopped',
+  [STREAM_PHASE.FAILED]: 'failed',
 };
 
 /**
@@ -486,7 +487,12 @@ function acquireStreamOrThrow(
     return;
   }
 
-  const status = streamStatus.get(streamId) ?? '';
+  const substate = streamStatus.getSubstate(streamId);
+  const status =
+    substate === STREAM_SUBSTATE.STARTING ||
+    substate === STREAM_SUBSTATE.RESUMING
+      ? substate
+      : (streamStatus.get(streamId) ?? '');
   const statusMsg = STATUS_MESSAGES[status] || 'already running';
   throw new AgentError(
     `${taskType} "${streamId}" is ${statusMsg}. Please wait for it to complete or stop it first.`,
@@ -497,12 +503,12 @@ function acquireStreamOrThrow(
  * Saga-style compensation for a failed stream activation.
  *
  *  - Pre-activation failure (no `activatedStreamId`): the UI tab was never
- *    registered. Release the reserved lock if we held it; the caller won't
- *    ever see a stream.
+ *    registered. Release the reserved lock if we held it, and publish a
+ *    terminal rollback only if acquisition already emitted a visible status.
  *
  *  - Post-activation failure (`activatedStreamId` set): the UI tab is
- *    visible. Surface the failure on it and transition to ERROR so the
- *    tab doesn't hang in INITIALIZING.
+ *    visible. Surface the failure on it and transition to FAILED so the
+ *    tab doesn't hang in STARTING.
  */
 function compensateFailedActivation(args: {
   configPayload: AgentConfigPayload;
@@ -538,14 +544,28 @@ function compensateFailedActivation(args: {
         { operation: `start ${configPayload.agent}` },
       );
     }
-    streamStatus.set(activatedStreamId, STREAM_STATUS.ERROR, {
-      runtimeHost,
-    });
+    if (
+      !streamStatus.transitionToTerminal(
+        activatedStreamId,
+        STREAM_PHASE.FAILED,
+        {
+          runtimeHost,
+          trace: runTrace?.trace,
+        },
+      )
+    ) {
+      runTrace?.trace.warn('Failed to mark activation failure terminal', {
+        data: {
+          agentIdentifier: configPayload.agent,
+          streamId: activatedStreamId,
+        },
+      });
+    }
     return;
   }
 
   if (reservedStreamId) {
-    streamStatus.releaseIfInitializing(reservedStreamId, {
+    streamStatus.releaseIfReserved(reservedStreamId, {
       runtimeHost,
     });
   }
@@ -563,7 +583,8 @@ export async function buildAgentLaunchContext(
   input: AgentLaunchInput,
 ): Promise<AgentLaunchContext> {
   const { configPayload, runtimeHost } = input;
-  const streamStatus = StreamStatusService;
+  const launchSession = input.session ?? currentSession();
+  const streamStatus = launchSession.status;
   const executionId = input.executionId ?? generateExecutionId();
   if (
     !input.streamTabIdOverride &&
@@ -591,7 +612,7 @@ export async function buildAgentLaunchContext(
   let runTrace: RunTrace | undefined;
   try {
     const ctx = await assembleAgentLaunchContext(
-      input,
+      { ...input, session: launchSession },
       executionId,
       streamStatus,
       runtimeHost,

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -16,12 +16,11 @@ import {
 import {
   legacyEndGroupStatusForOutcome,
   projectRunOutcome,
-  terminalStreamStatusForOutcome,
 } from '@common/constants/streamStatus';
 import { createChannelTrace } from '@logger';
 import {
   RUN_OUTCOME,
-  STREAM_STATUS,
+  STREAM_PHASE,
   toRetryErrorInfo,
   type RunOutcome,
   type StreamTabId,
@@ -102,6 +101,44 @@ function endParentStageSafely(
   }
 }
 
+function transitionRunStart(ctx: AgentLaunchContext): void {
+  const options = {
+    runtimeHost: ctx.runtimeHost,
+    trace: ctx.logger,
+  };
+  if (
+    ctx.streamStatus.transition(
+      ctx.streamId,
+      STREAM_PHASE.RUNNING,
+      'lifecycle',
+      options,
+    )
+  ) {
+    return;
+  }
+  const resumed = ctx.streamStatus.transition(
+    ctx.streamId,
+    STREAM_PHASE.RUNNING,
+    'resume',
+    options,
+  );
+  if (resumed) {
+    return;
+  }
+  if (ctx.streamStatus.clearRunningSubstate(ctx.streamId, 'resume', options)) {
+    return;
+  }
+  if (ctx.streamStatus.get(ctx.streamId) === STREAM_PHASE.RUNNING) {
+    return;
+  }
+  logger.warn('Failed to transition run to RUNNING', {
+    data: {
+      agentIdentifier: ctx.config.agent,
+      streamId: ctx.streamId,
+    },
+  });
+}
+
 /**
  * Wraps a flow runner with full agent run lifecycle management: execution
  * registry tracking, stream-status transitions, error classification, user
@@ -158,9 +195,7 @@ export async function runFlowWithLifecycle(
     // The lifecycle owns every stream-status transition: RUNNING here,
     // terminal states in the success/error arms below. Runners must not
     // set stream status themselves.
-    ctx.streamStatus.set(streamId, STREAM_STATUS.RUNNING, {
-      runtimeHost: ctx.runtimeHost,
-    });
+    transitionRunStart(ctx);
     const result = await runner(handle);
     // The flow's outcome is the canonical terminal fact; everything below is
     // one row of the projection table. No other layer may re-derive these.
@@ -219,15 +254,15 @@ export async function runFlowWithLifecycle(
     // re-throw) for an already-completed run.
     try {
       session.executions.untrack(ctx.executionId);
-      if (!ctx.streamStatus.shouldPreserveOnCompletion(streamId)) {
-        ctx.streamStatus.set(
-          streamId,
-          terminalStreamStatusForOutcome(result.outcome),
-          {
-            runtimeHost: ctx.runtimeHost,
-            terminalStatus: projection.executionStatus,
-          },
-        );
+      if (
+        !ctx.streamStatus.transitionToTerminal(streamId, result.outcome, {
+          runtimeHost: ctx.runtimeHost,
+          trace: ctx.logger,
+        })
+      ) {
+        logger.warn('Failed to set terminal stream status', {
+          data: { agentIdentifier, streamId, status: result.outcome },
+        });
       }
     } catch (cleanupErr) {
       logger.warn('Post-completion cleanup threw', {
@@ -293,10 +328,16 @@ export async function runFlowWithLifecycle(
       );
     }
     try {
-      ctx.streamStatus.set(streamId, terminalStreamStatusForOutcome(outcome), {
-        runtimeHost: ctx.runtimeHost,
-        terminalStatus: projection.executionStatus,
-      });
+      if (
+        !ctx.streamStatus.transitionToTerminal(streamId, outcome, {
+          runtimeHost: ctx.runtimeHost,
+          trace: ctx.logger,
+        })
+      ) {
+        logger.warn('Failed to set terminal error status', {
+          data: { agentIdentifier, streamId, status: outcome },
+        });
+      }
     } catch (statusErr) {
       logger.warn('Failed to set terminal error status', {
         data: { agentIdentifier, error: statusErr },

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -41,7 +41,10 @@ import {
   ExecutionSubscriptionBinder,
   executionSubscriptionBinder,
 } from './ExecutionSubscriptionBinder';
-import { StreamStatusService } from './StreamStatusService';
+import {
+  StreamStatusMachine,
+  StreamStatusService,
+} from './StreamStatusService';
 import { SessionEventHub } from './SessionEventHub';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 
@@ -56,6 +59,7 @@ export type SessionHandleInit = Partial<
     | 'coordinators'
     | 'subscriptions'
     | 'events'
+    | 'status'
     | 'flushers'
     | 'hostChannel'
   >
@@ -80,6 +84,8 @@ export class SessionHandle {
   readonly subscriptions: ExecutionSubscriptionBinder;
   /** Session-scoped one-way fact plane. */
   readonly events: SessionEventHub;
+  /** Session-scoped status plane; wraps shared status data during migration. */
+  readonly status: StreamStatusMachine;
   /** This session's trace-flush callbacks (drained on dispose / shutdown). */
   readonly flushers: Set<() => void>;
   /**
@@ -92,9 +98,10 @@ export class SessionHandle {
     // Forced dependency order, every cross-reference explicit — never let a
     // member fall back to a neighboring module singleton (silent-state-split).
     const interrupts = init.interrupts ?? new InterruptRegistry();
+    const status = init.status ?? new StreamStatusMachine();
     const executions =
       init.executions ??
-      new ExecutionRegistry({ interrupts, streamStatus: StreamStatusService });
+      new ExecutionRegistry({ interrupts, streamStatus: status });
     const coordinators =
       init.coordinators ?? new RunCoordinatorBridge(executions);
 
@@ -116,6 +123,7 @@ export class SessionHandle {
       });
     this.subscriptions = subscriptions;
     this.events = init.events ?? new SessionEventHub();
+    this.status = status;
     // A fresh session owns its own flusher set; the default session aliases the
     // process-module set so `createRunTrace`'s default writes still drain.
     this.flushers = init.flushers ?? new Set<() => void>();
@@ -278,6 +286,7 @@ export function defaultSession(): SessionHandle {
     executions: executionRegistry,
     coordinators: runCoordinatorBridge,
     subscriptions: executionSubscriptionBinder,
+    status: StreamStatusService,
     flushers: getActiveFlushers(),
   }));
 }

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -1,115 +1,268 @@
+import type { AgentTrace, StatusEvent } from '@agent/trace';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
-  isActiveStatus,
-  isInFlightStatus,
+  canAcquireStreamReservation,
+  canTransitionStreamPhase,
+  isActivePhase,
+  isInFlightPhase,
+  STREAM_TRANSITION_CAUSE,
+  type StreamTransitionCause,
 } from '@common/constants/streamStatus';
 import {
-  STREAM_STATUS,
-  type ExecutionStatus,
+  STREAM_PHASE,
+  STREAM_SUBSTATE,
+  type StreamPhase,
+  type StreamSubstate,
   type StreamTabId,
-  type StreamStatus,
 } from '@shared/schemas';
 
 export interface StreamStatusChange {
   streamId: StreamTabId;
-  status: StreamStatus;
-  previousStatus: StreamStatus;
-  terminalStatus?: ExecutionStatus;
+  status: StreamPhase;
+  previousStatus?: StreamPhase;
+  cause: StreamTransitionCause;
+  substate?: StreamSubstate;
 }
 
-interface EmitSetOptions {
-  emit?: true;
-  runtimeHost: AgentRuntimeHost;
-  terminalStatus?: ExecutionStatus;
-}
-
-interface SilentSetOptions {
-  emit: false;
+export interface StreamStatusEmitOptions {
   runtimeHost?: AgentRuntimeHost;
-  terminalStatus?: ExecutionStatus;
+  trace?: AgentTrace;
+  substate?: StreamSubstate;
 }
 
-type SetOptions = EmitSetOptions | SilentSetOptions;
+type WaitingTransitionCause = Extract<
+  StreamTransitionCause,
+  'wait' | 'restart-repair'
+>;
 
-export class StreamStatusRegistry {
-  private readonly statusMemory = new Map<StreamTabId, StreamStatus>();
+interface StreamPhaseState {
+  readonly phase: StreamPhase;
+  readonly substate?: StreamSubstate;
+}
+
+export function projectStatusEvent(event: StatusEvent): StreamStatusChange {
+  return {
+    streamId: event.streamId,
+    status: event.phase,
+    ...(event.previousPhase ? { previousStatus: event.previousPhase } : {}),
+    cause: event.cause,
+    ...(event.substate ? { substate: event.substate } : {}),
+  };
+}
+
+export class StreamStatusMachine {
+  private readonly phases = new Map<StreamTabId, StreamPhaseState>();
+  private readonly reservations = new Set<StreamTabId>();
   private readonly statusListeners = new Set<
     (change: StreamStatusChange) => void
   >();
 
-  get(stream: StreamTabId): StreamStatus | undefined {
-    return this.statusMemory.get(stream);
+  get(stream: StreamTabId): StreamPhase | undefined {
+    return this.stateFor(stream)?.phase;
   }
 
-  tryAcquire(stream: StreamTabId, options: SetOptions): boolean {
-    if (isInFlightStatus(this.statusMemory.get(stream))) {
+  getSubstate(stream: StreamTabId): StreamSubstate | undefined {
+    return this.stateFor(stream)?.substate;
+  }
+
+  tryAcquire(
+    stream: StreamTabId,
+    options: StreamStatusEmitOptions = {},
+  ): boolean {
+    if (this.reservations.has(stream)) return false;
+    if (!canAcquireStreamReservation(this.phases.get(stream)?.phase)) {
       return false;
     }
-    this.set(stream, STREAM_STATUS.INITIALIZING, options);
+    const previousPhase = this.phases.get(stream)?.phase;
+    this.reservations.add(stream);
+    this.publishStatus(stream, STREAM_PHASE.RUNNING, {
+      ...options,
+      cause: STREAM_TRANSITION_CAUSE.LIFECYCLE,
+      ...(previousPhase ? { previousPhase } : {}),
+      substate: STREAM_SUBSTATE.STARTING,
+    });
     return true;
   }
 
-  releaseIfInitializing(stream: StreamTabId, options: SetOptions): void {
-    if (this.statusMemory.get(stream) === STREAM_STATUS.INITIALIZING) {
-      this.clear(stream, options);
+  releaseIfReserved(
+    stream: StreamTabId,
+    options: StreamStatusEmitOptions = {},
+  ): void {
+    if (!this.reservations.has(stream)) return;
+    const rollbackPhase =
+      this.phases.get(stream)?.phase ?? STREAM_PHASE.CANCELLED;
+    if (options.runtimeHost || options.trace || this.statusListeners.size > 0) {
+      if (
+        this.transition(
+          stream,
+          rollbackPhase,
+          STREAM_TRANSITION_CAUSE.LIFECYCLE,
+          options,
+        )
+      ) {
+        return;
+      }
+      this.reservations.delete(stream);
+      return;
     }
+    this.reservations.delete(stream);
   }
 
-  set(stream: StreamTabId, status: StreamStatus, options: SetOptions): void {
-    const previousStatus = this.statusMemory.get(stream) ?? STREAM_STATUS.READY;
-
-    if (status === STREAM_STATUS.READY) {
-      this.statusMemory.delete(stream);
-    } else {
-      this.statusMemory.set(stream, status);
+  clearRunningSubstate(
+    stream: StreamTabId,
+    cause: StreamTransitionCause,
+    options: StreamStatusEmitOptions = {},
+  ): boolean {
+    const state = this.phases.get(stream);
+    if (state?.phase !== STREAM_PHASE.RUNNING || !state.substate) {
+      return false;
     }
+    this.phases.set(stream, { phase: STREAM_PHASE.RUNNING });
+    this.publishStatus(stream, STREAM_PHASE.RUNNING, {
+      ...options,
+      cause,
+      previousPhase: STREAM_PHASE.RUNNING,
+    });
+    return true;
+  }
 
-    if (options.emit !== false) {
-      const change: StreamStatusChange = {
-        streamId: stream,
-        status,
-        previousStatus,
-        ...(options.terminalStatus
-          ? { terminalStatus: options.terminalStatus }
-          : {}),
-      };
-      options.runtimeHost.emit('updateStreamStatus', change);
-      for (const listener of this.statusListeners) {
-        listener(change);
+  transition(
+    stream: StreamTabId,
+    to: StreamPhase,
+    cause: StreamTransitionCause,
+    options: StreamStatusEmitOptions = {},
+  ): boolean {
+    const from = this.phases.get(stream)?.phase;
+    const fromReservation = this.reservations.has(stream);
+    const tableFrom = fromReservation
+      ? to === STREAM_PHASE.RUNNING
+        ? undefined
+        : STREAM_PHASE.RUNNING
+      : from;
+    if (!canTransitionStreamPhase(tableFrom, to, cause)) return false;
+
+    this.reservations.delete(stream);
+    this.phases.set(stream, {
+      phase: to,
+      ...(options.substate ? { substate: options.substate } : {}),
+    });
+    const previousPhase = fromReservation ? STREAM_PHASE.RUNNING : from;
+    this.publishStatus(stream, to, {
+      ...options,
+      cause,
+      ...(previousPhase ? { previousPhase } : {}),
+    });
+    return true;
+  }
+
+  transitionToWaiting(
+    stream: StreamTabId,
+    cause: WaitingTransitionCause,
+    options: StreamStatusEmitOptions = {},
+  ): boolean {
+    if (this.transition(stream, STREAM_PHASE.WAITING, cause, options)) {
+      return true;
+    }
+    if (
+      !this.transition(
+        stream,
+        STREAM_PHASE.RUNNING,
+        STREAM_TRANSITION_CAUSE.RESUME,
+        options,
+      )
+    ) {
+      return false;
+    }
+    return this.transition(stream, STREAM_PHASE.WAITING, cause, options);
+  }
+
+  transitionToTerminal(
+    stream: StreamTabId,
+    to: StreamPhase,
+    options: StreamStatusEmitOptions = {},
+  ): boolean {
+    const current = this.get(stream);
+    if (current === to) {
+      return true;
+    }
+    if (
+      this.transition(stream, to, STREAM_TRANSITION_CAUSE.LIFECYCLE, options)
+    ) {
+      return true;
+    }
+    if (current === undefined) {
+      return (
+        this.transition(
+          stream,
+          STREAM_PHASE.RUNNING,
+          STREAM_TRANSITION_CAUSE.LIFECYCLE,
+          options,
+        ) &&
+        this.transition(stream, to, STREAM_TRANSITION_CAUSE.LIFECYCLE, options)
+      );
+    }
+    if (current !== STREAM_PHASE.WAITING) {
+      return false;
+    }
+    return (
+      this.transition(
+        stream,
+        STREAM_PHASE.RUNNING,
+        STREAM_TRANSITION_CAUSE.RESUME,
+        options,
+      ) &&
+      this.transition(stream, to, STREAM_TRANSITION_CAUSE.LIFECYCLE, options)
+    );
+  }
+
+  clearStream(stream: StreamTabId): void {
+    this.reservations.delete(stream);
+    this.phases.delete(stream);
+  }
+
+  clearAll(): void {
+    this.reservations.clear();
+    this.phases.clear();
+  }
+
+  entries(): IterableIterator<[StreamTabId, StreamPhase]> {
+    return this.getAll().entries();
+  }
+
+  getAll(): Map<StreamTabId, StreamPhase> {
+    const values = new Map<StreamTabId, StreamPhase>();
+    for (const [stream, state] of this.phases) {
+      values.set(stream, state.phase);
+    }
+    for (const stream of this.reservations) {
+      values.set(stream, STREAM_PHASE.RUNNING);
+    }
+    return values;
+  }
+
+  getAllSubstates(): Map<StreamTabId, StreamSubstate> {
+    const values = new Map<StreamTabId, StreamSubstate>();
+    for (const [stream, state] of this.phases) {
+      if (state.substate) {
+        values.set(stream, state.substate);
       }
     }
-  }
-
-  clear(stream: StreamTabId, options: SetOptions): void {
-    this.set(stream, STREAM_STATUS.READY, options);
-  }
-
-  /** Reset every stream to READY. Used by ProgressViewState.clearAll(). */
-  clearAll(options: SetOptions): void {
-    for (const stream of [...this.statusMemory.keys()]) {
-      this.clear(stream, options);
+    for (const stream of this.reservations) {
+      values.set(stream, STREAM_SUBSTATE.STARTING);
     }
-  }
-
-  entries(): IterableIterator<[StreamTabId, StreamStatus]> {
-    return this.statusMemory.entries();
-  }
-
-  getAll(): Map<StreamTabId, StreamStatus> {
-    return new Map(this.statusMemory);
+    return values;
   }
 
   has(stream: StreamTabId): boolean {
-    return this.statusMemory.has(stream);
+    return this.phases.has(stream) || this.reservations.has(stream);
   }
 
   isActiveOrResuming(stream: StreamTabId): boolean {
-    return isActiveStatus(this.statusMemory.get(stream));
+    return isActivePhase(this.get(stream));
   }
 
-  shouldPreserveOnCompletion(stream: StreamTabId): boolean {
-    const status = this.statusMemory.get(stream);
-    return status === STREAM_STATUS.WAITING || status === STREAM_STATUS.STOPPED;
+  isInFlight(stream: StreamTabId): boolean {
+    return isInFlightPhase(this.get(stream));
   }
 
   onDidChange(listener: (change: StreamStatusChange) => void): () => void {
@@ -118,6 +271,47 @@ export class StreamStatusRegistry {
       this.statusListeners.delete(listener);
     };
   }
+
+  private stateFor(stream: StreamTabId): StreamPhaseState | undefined {
+    if (this.reservations.has(stream)) {
+      return {
+        phase: STREAM_PHASE.RUNNING,
+        substate: STREAM_SUBSTATE.STARTING,
+      };
+    }
+    const state = this.phases.get(stream);
+    if (state) return state;
+    return undefined;
+  }
+
+  private publishStatus(
+    stream: StreamTabId,
+    phase: StreamPhase,
+    options: StreamStatusEmitOptions & {
+      cause: StreamTransitionCause;
+      previousPhase?: StreamPhase;
+    },
+  ): void {
+    const event: StatusEvent = {
+      type: 'status',
+      streamId: stream,
+      phase,
+      cause: options.cause,
+      ...(options.previousPhase
+        ? { previousPhase: options.previousPhase }
+        : {}),
+      ...(options.substate ? { substate: options.substate } : {}),
+    };
+    options.trace?.emit(event);
+
+    const change = projectStatusEvent(event);
+    options.runtimeHost?.emit('updateStreamStatus', change);
+    for (const listener of this.statusListeners) {
+      listener(change);
+    }
+  }
 }
 
-export const StreamStatusService = new StreamStatusRegistry();
+export { StreamStatusMachine as StreamStatusRegistry };
+
+export const StreamStatusService = new StreamStatusMachine();

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -14,13 +14,16 @@ import {
   interruptRegistry,
   type InterruptRegistry,
 } from '@agent/runtime/InterruptRegistry';
-import { isInFlightStatus } from '@common/constants/streamStatus';
 import {
-  EXECUTION_STATUS,
+  isInFlightStatus,
+  isLiveElapsedStatus,
+} from '@common/constants/streamStatus';
+import {
+  STREAM_PHASE,
   STREAM_STATUS,
-  LIVE_ELAPSED_STREAM_STATUSES,
+  STREAM_SUBSTATE,
   type ActiveChildInfo,
-  type StreamStatus,
+  type StreamPhase,
   type StreamTabId,
 } from '@shared/schemas';
 import { formatDuration } from '@utils/core';
@@ -51,8 +54,6 @@ export interface StopAgentStreamOptions {
   readonly runtimeHost?: AgentRuntimeHost;
 }
 
-const USER_STOP_TERMINAL_STATUS = EXECUTION_STATUS.INTERRUPTED;
-
 export type StopAgentChildPolicy = 'cascade' | 'detach';
 
 export type StopAgentStreamResult =
@@ -82,11 +83,11 @@ export interface KillExecutionOptions {
 }
 
 export interface TrackAgentExecutionOptions {
-  readonly status?: StreamStatus;
+  readonly status?: StreamPhase;
 }
 
 export interface FinishAgentExecutionOptions {
-  readonly status: StreamStatus;
+  readonly status: StreamPhase;
 }
 
 interface TerminateOptions {
@@ -107,7 +108,7 @@ export type ToolUseFollowUpTarget =
     }
   | {
       readonly kind: 'no_session';
-      readonly streamStatus: StreamStatus | undefined;
+      readonly streamStatus: StreamPhase | undefined;
     };
 
 export type ManualCompactionRequestResult =
@@ -222,9 +223,15 @@ export class ExecutionRegistry {
     options: TrackAgentExecutionOptions = {},
   ): void {
     if (options.status) {
-      this.streamStatus.set(handle.childStreamId, options.status, {
-        runtimeHost: handle.runtimeHost,
-      });
+      this.streamStatus.transition(
+        handle.childStreamId,
+        options.status,
+        'lifecycle',
+        {
+          runtimeHost: handle.runtimeHost,
+          trace: handle.trace,
+        },
+      );
     }
     this.track(handle);
   }
@@ -236,16 +243,20 @@ export class ExecutionRegistry {
    */
   updateAgentExecutionStatus(
     handle: AgentExecutionHandle,
-    status: StreamStatus,
+    status: StreamPhase,
   ): boolean {
     if (this.handles.get(handle.executionId) !== handle) return false;
-    if (this.streamStatus.get(handle.childStreamId) === STREAM_STATUS.STOPPED) {
-      return false;
-    }
-    this.streamStatus.set(handle.childStreamId, status, {
+    const previous = this.streamStatus.get(handle.childStreamId);
+    const cause =
+      status === STREAM_PHASE.WAITING
+        ? 'wait'
+        : status === STREAM_PHASE.RUNNING && previous === STREAM_PHASE.WAITING
+          ? 'resume'
+          : 'lifecycle';
+    return this.streamStatus.transition(handle.childStreamId, status, cause, {
       runtimeHost: handle.runtimeHost,
+      trace: handle.trace,
     });
-    return true;
   }
 
   /** Remove an execution handle and notify waiters. */
@@ -295,29 +306,27 @@ export class ExecutionRegistry {
     handle: AgentExecutionHandle,
     options: FinishAgentExecutionOptions,
   ): void {
-    const currentStatus = this.streamStatus.get(handle.childStreamId);
-    const shouldUpdateStatus =
-      currentStatus !== STREAM_STATUS.STOPPED &&
-      currentStatus !== options.status;
-
-    // READY clears the status store. Do it after untracking so the status
-    // listener cannot summarize the still-tracked child via the RUNNING
-    // fallback before the removal update.
-    if (options.status !== STREAM_STATUS.READY && shouldUpdateStatus) {
-      this.streamStatus.set(handle.childStreamId, options.status, {
-        runtimeHost: handle.runtimeHost,
-      });
-    }
-
     if (this.handles.get(handle.executionId) === handle) {
       this.untrackHandle(handle);
     } else {
       this.notifyWaiters(handle.executionId);
     }
 
-    if (options.status === STREAM_STATUS.READY && shouldUpdateStatus) {
-      this.streamStatus.set(handle.childStreamId, options.status, {
-        runtimeHost: handle.runtimeHost,
+    const emitOptions = {
+      runtimeHost: handle.runtimeHost,
+      trace: handle.trace,
+    };
+    const terminalized = this.streamStatus.transitionToTerminal(
+      handle.childStreamId,
+      options.status,
+      emitOptions,
+    );
+    if (!terminalized) {
+      handle.trace?.warn('Failed to finalize waiting stream status', {
+        data: {
+          streamId: handle.childStreamId,
+          status: options.status,
+        },
       });
     }
   }
@@ -329,10 +338,10 @@ export class ExecutionRegistry {
   getStatus(handle: ExecutionHandle): ExecutionStatusInfo {
     const status =
       handle instanceof AgentExecutionHandle
-        ? (this.streamStatus.get(handle.childStreamId) ?? STREAM_STATUS.RUNNING)
-        : STREAM_STATUS.RUNNING;
+        ? (this.streamStatus.get(handle.childStreamId) ?? STREAM_PHASE.RUNNING)
+        : STREAM_PHASE.RUNNING;
 
-    if (!LIVE_ELAPSED_STREAM_STATUSES.has(status)) {
+    if (!isLiveElapsedStatus(status)) {
       return { status, elapsed: null };
     }
 
@@ -416,10 +425,10 @@ export class ExecutionRegistry {
     const context = this.getToolUseFlowContext(streamId);
     if (context) return { kind: 'active', context };
 
-    if (status === STREAM_STATUS.RESUMING) {
+    if (this.streamStatus.getSubstate(streamId) === STREAM_SUBSTATE.RESUMING) {
       return { kind: 'queue', reason: 'resuming' };
     }
-    if (status === STREAM_STATUS.WAITING) {
+    if (status === STREAM_PHASE.WAITING) {
       return { kind: 'queue', reason: 'waiting' };
     }
     if (hasActiveChildren) {
@@ -622,10 +631,14 @@ export class ExecutionRegistry {
     if (!runtimeHost) {
       return { kind: 'no_target', streamId, childPolicy };
     }
-    this.streamStatus.set(streamId, STREAM_STATUS.STOPPED, {
-      runtimeHost,
-      terminalStatus: USER_STOP_TERMINAL_STATUS,
-    });
+    this.streamStatus.transition(
+      streamId,
+      STREAM_PHASE.CANCELLED,
+      'user-stop',
+      {
+        runtimeHost,
+      },
+    );
     return { kind: 'marked_stopped', streamId, childPolicy };
   }
 
@@ -704,10 +717,12 @@ export class ExecutionRegistry {
         continue;
       }
       const { status, elapsed } = this.getStatus(handle);
+      const summaryStatus =
+        status === STREAM_PHASE.CANCELLED ? STREAM_STATUS.STOPPED : status;
       const info: ActiveChildInfo = {
         executionId: handle.executionId,
         agentName: handle.agentName,
-        status,
+        status: summaryStatus,
         startedAt: handle.startedAt,
         elapsed: elapsed ?? null,
       };
@@ -743,10 +758,15 @@ export class ExecutionRegistry {
       const interruptible = this.interrupts.get(handle.childStreamId);
       if (!interruptible) return false;
       interruptible.interrupt();
-      this.streamStatus.set(handle.childStreamId, STREAM_STATUS.STOPPED, {
-        runtimeHost: handle.runtimeHost,
-        terminalStatus: USER_STOP_TERMINAL_STATUS,
-      });
+      this.streamStatus.transition(
+        handle.childStreamId,
+        STREAM_PHASE.CANCELLED,
+        'user-stop',
+        {
+          runtimeHost: handle.runtimeHost,
+          trace: handle.trace,
+        },
+      );
       return true;
     }
 
@@ -765,10 +785,14 @@ export class ExecutionRegistry {
     if (!interruptible) return false;
     interruptible.interrupt();
     if (runtimeHost) {
-      this.streamStatus.set(streamId, STREAM_STATUS.STOPPED, {
-        runtimeHost,
-        terminalStatus: USER_STOP_TERMINAL_STATUS,
-      });
+      this.streamStatus.transition(
+        streamId,
+        STREAM_PHASE.CANCELLED,
+        'user-stop',
+        {
+          runtimeHost,
+        },
+      );
     }
     return true;
   }

--- a/src/agent/runtime/followUpResumeDetection.ts
+++ b/src/agent/runtime/followUpResumeDetection.ts
@@ -1,12 +1,12 @@
 import { isInFlightStatus } from '@common/constants/streamStatus';
-import { STREAM_STATUS, type StreamStatus } from '@shared/schemas';
+import type { StreamPhase } from '@shared/schemas';
 
 /**
  * Return true when a follow-up should check persistent flow state before
  * declaring that no session can continue.
  */
 export function shouldProbePersistedFlowForFollowUp(
-  status: StreamStatus | undefined,
+  status: StreamPhase | undefined,
 ): boolean {
-  return status !== STREAM_STATUS.READY && !isInFlightStatus(status);
+  return !isInFlightStatus(status);
 }

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -1,7 +1,11 @@
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
 import type { FollowUpQueueInput } from '@agent/followUp/FollowUpQueue';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
-import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+import {
+  STREAM_PHASE,
+  STREAM_SUBSTATE,
+  type StreamTabId,
+} from '@shared/schemas';
 import { resumeToolUseFromSnapshot } from './executeAgent';
 import { StreamStatusService } from './StreamStatusService';
 import type { ToolEditApprovalPort } from '@platform/interfaces/toolEditApproval';
@@ -51,8 +55,13 @@ export async function resumeQueuedToolUseSnapshot(
   runtimeHost: AgentRuntimeHost,
   options: ResumeQueuedToolUseOptions,
 ): Promise<boolean> {
+  const streamStatus = options.session?.status ?? StreamStatusService;
+
   ToolUseFollowUpQueue.acquire(streamId);
-  StreamStatusService.set(streamId, STREAM_STATUS.RESUMING, { runtimeHost });
+  streamStatus.transition(streamId, STREAM_PHASE.RUNNING, 'resume', {
+    runtimeHost,
+    substate: STREAM_SUBSTATE.RESUMING,
+  });
 
   const seed = options.extraFollowUps ?? [];
   let followUps: readonly FollowUpQueueInput[] = seed;
@@ -85,8 +94,10 @@ export async function resumeQueuedToolUseSnapshot(
     // Only the early-failure path leaves the stream RESUMING (a started run
     // owns its own status); settle it back to WAITING before surfacing the
     // error so a blocking host dialog cannot hold the stream in RESUMING.
-    if (StreamStatusService.get(streamId) === STREAM_STATUS.RESUMING) {
-      StreamStatusService.set(streamId, STREAM_STATUS.WAITING, { runtimeHost });
+    if (streamStatus.getSubstate(streamId) === STREAM_SUBSTATE.RESUMING) {
+      streamStatus.transition(streamId, STREAM_PHASE.WAITING, 'wait', {
+        runtimeHost,
+      });
     }
   }
 

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -10,10 +10,14 @@
  */
 import type { RunUsageTotals } from '@agent/core/usage/RunUsageAccumulator';
 import type { AgentErrorKind } from '@common/errors';
+import type { StreamTransitionCause } from '@common/constants/streamStatus';
 import type {
   EndGroupStatus,
   RetryErrorInfo,
   RunOutcome,
+  StreamPhase,
+  StreamSubstate,
+  StreamTabId,
 } from '@shared/schemas';
 
 /** Status assigned to a tool call when it completes. */
@@ -119,6 +123,16 @@ export interface UsageEvent extends StageStamp {
   readonly recordTranscript?: boolean;
 }
 
+/** Stream lifecycle phase change emitted by the session-owned status machine. */
+export interface StatusEvent extends StageStamp {
+  readonly type: 'status';
+  readonly streamId: StreamTabId;
+  readonly phase: StreamPhase;
+  readonly previousPhase?: StreamPhase;
+  readonly cause: StreamTransitionCause;
+  readonly substate?: StreamSubstate;
+}
+
 /** Context window utilisation snapshot. */
 export interface ContextStateEvent extends StageStamp {
   readonly type: 'context.state';
@@ -203,6 +217,7 @@ export type AgentEvent =
   | ToolStartEvent
   | ToolEndEvent
   | UsageEvent
+  | StatusEvent
   | ContextStateEvent
   | StreamStartEvent
   | StreamChunkEvent

--- a/src/agent/trace/index.ts
+++ b/src/agent/trace/index.ts
@@ -10,7 +10,7 @@
  *
  * See `docs/proposals/agent-trace-sdk-surface.md` for the design.
  */
-export type { AgentEvent, LogEvent, ResultEvent } from './events';
+export type { AgentEvent, LogEvent, ResultEvent, StatusEvent } from './events';
 
 export type {
   AgentTrace,

--- a/src/common/constants/streamStatus.ts
+++ b/src/common/constants/streamStatus.ts
@@ -7,13 +7,12 @@ import {
   RUN_OUTCOME,
   STREAM_PHASE,
   STREAM_STATUS,
-  STREAM_SUBSTATE,
   STREAM_STATUS_TRAITS,
+  StreamPhaseSchema,
   type ExecutionStatus,
   type RunOutcome,
   type StreamPhase,
   type StreamStatus,
-  type StreamSubstate,
 } from '@shared/schemas';
 
 // ============================================================================
@@ -145,23 +144,16 @@ export function canAcquireStreamReservation(
   return !isInFlightPhase(phase);
 }
 
-export function canReleaseStreamReservation(state: {
-  readonly phase: StreamPhase | undefined;
-  readonly substate?: StreamSubstate;
-}): boolean {
-  return (
-    state.phase === STREAM_PHASE.RUNNING &&
-    state.substate === STREAM_SUBSTATE.STARTING
-  );
-}
-
 export function canTransitionStreamPhase(
   from: StreamPhase | undefined,
   to: StreamPhase,
   cause: StreamTransitionCause,
 ): boolean {
   if (cause === STREAM_TRANSITION_CAUSE.USER_STOP) {
-    return isInFlightPhase(from) && to === STREAM_PHASE.CANCELLED;
+    return (
+      (from === undefined || isInFlightPhase(from)) &&
+      to === STREAM_PHASE.CANCELLED
+    );
   }
 
   if (isTerminalOutcomePhase(from)) {
@@ -178,13 +170,17 @@ export function canTransitionStreamPhase(
       return from === STREAM_PHASE.RUNNING && to === STREAM_PHASE.WAITING;
     case STREAM_TRANSITION_CAUSE.RESUME:
       return (
-        (from === STREAM_PHASE.WAITING || isTerminalOutcomePhase(from)) &&
+        (from === undefined || from === STREAM_PHASE.WAITING) &&
         to === STREAM_PHASE.RUNNING
       );
     case STREAM_TRANSITION_CAUSE.RESTART_REPAIR:
+      if (from === undefined) return true;
+      if (from === to) return true;
       return (
         from === STREAM_PHASE.RUNNING &&
-        (to === STREAM_PHASE.WAITING || to === STREAM_PHASE.FAILED)
+        (to === STREAM_PHASE.WAITING ||
+          to === STREAM_PHASE.FAILED ||
+          to === STREAM_PHASE.CANCELLED)
       );
   }
 }
@@ -198,25 +194,45 @@ export function canTransitionStreamPhase(
 // new status lists by hand — add a trait column instead.
 
 /** Check if a status indicates active execution (running or resuming). */
-export function isActiveStatus(status: StreamStatus | undefined): boolean {
-  return status !== undefined && STREAM_STATUS_TRAITS[status].active;
+export function isActiveStatus(status: string | undefined): boolean {
+  const phase = StreamPhaseSchema.safeParse(status);
+  if (phase.success) return isActivePhase(phase.data);
+  return (
+    status !== undefined &&
+    Object.hasOwn(STREAM_STATUS_TRAITS, status) &&
+    STREAM_STATUS_TRAITS[status as StreamStatus].active
+  );
 }
 
 /**
  * Statuses during which an agent cycle may still be appending to the stream
  * and it must not be evicted from memory or acquired by a new run.
  */
-export function isInFlightStatus(status: StreamStatus | undefined): boolean {
-  return status !== undefined && STREAM_STATUS_TRAITS[status].inFlight;
+export function isInFlightStatus(status: string | undefined): boolean {
+  const phase = StreamPhaseSchema.safeParse(status);
+  if (phase.success) return isInFlightPhase(phase.data);
+  return (
+    status !== undefined &&
+    Object.hasOwn(STREAM_STATUS_TRAITS, status) &&
+    STREAM_STATUS_TRAITS[status as StreamStatus].inFlight
+  );
 }
 
 /** Check if a status is terminal (execution ended). */
-export function isTerminalStatus(status: StreamStatus | undefined): boolean {
-  return status !== undefined && STREAM_STATUS_TRAITS[status].terminal;
+export function isTerminalStatus(status: string | undefined): boolean {
+  const phase = StreamPhaseSchema.safeParse(status);
+  if (phase.success) return isTerminalPhase(phase.data);
+  return (
+    status !== undefined &&
+    Object.hasOwn(STREAM_STATUS_TRAITS, status) &&
+    STREAM_STATUS_TRAITS[status as StreamStatus].terminal
+  );
 }
 
 /** Check if elapsed-time displays should keep advancing for this status. */
 export function isLiveElapsedStatus(status: string | undefined): boolean {
+  const phase = StreamPhaseSchema.safeParse(status);
+  if (phase.success) return phase.data === STREAM_PHASE.RUNNING;
   return (
     status !== undefined &&
     Object.hasOwn(STREAM_STATUS_TRAITS, status) &&

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -9,7 +9,6 @@ import type {
   CompileFailure,
   ConversationProgress,
   ExecutionId,
-  ExecutionStatus,
   ExternalInquiryPermission,
   FileLocation,
   InquiryThreadUpdatedEvent,
@@ -17,7 +16,8 @@ import type {
   PlanApprovalPermission,
   RetryPermission,
   StorageKey,
-  StreamStatus,
+  StreamPhase,
+  StreamSubstate,
   StreamTabId,
   TokenUsageStats,
   ToolEditPermission,
@@ -93,11 +93,11 @@ export interface ProgressEventPayloads {
   setActiveStream: SetActiveStreamPayload;
   updateStreamStatus: {
     streamId: StreamTabId;
-    status: StreamStatus;
-    /** Previous status before this update, for detecting transitions */
-    previousStatus: StreamStatus;
-    /** Terminal execution outcome when the stream ended, if known. */
-    terminalStatus?: ExecutionStatus;
+    status: StreamPhase;
+    /** Previous phase before this update, for detecting transitions. */
+    previousStatus?: StreamPhase;
+    /** Narrower in-flight display state for launch/resume overlays. */
+    substate?: StreamSubstate;
   };
   addOutputFiles: StreamScopedPayload & {
     filesByRound: { [key: number]: OutputFileInfo[] };

--- a/src/shared/progressView/backend/WebviewUpdater.ts
+++ b/src/shared/progressView/backend/WebviewUpdater.ts
@@ -11,7 +11,8 @@ import type {
   ProgressViewPlacement,
   ProgressViewOutboundMessage,
   StreamMetadata,
-  StreamStatus,
+  StreamPhase,
+  StreamSubstate,
   StreamTabId,
   StreamTabInfo,
   Plan,
@@ -239,14 +240,16 @@ export class WebviewUpdater {
    */
   updateStreamStatus(
     stream: StreamTabId,
-    status: StreamStatus,
+    status: StreamPhase,
     lastTimestamp?: number,
+    substate?: StreamSubstate,
   ): void {
     this.sendMessage({
       command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_STATUS,
       stream,
       status,
       lastTimestamp,
+      ...(substate ? { substate } : {}),
     });
   }
 
@@ -381,8 +384,9 @@ export class WebviewUpdater {
    */
   sendStreamMetadata(
     state: ProgressViewState,
-    statuses?: Map<string, StreamStatus>,
+    statuses?: Map<string, StreamPhase>,
     theme?: 'dark' | 'light',
+    substates?: Map<string, StreamSubstate>,
   ): ActiveStreamId {
     // Send every stream so streamById stays comprehensive for consumers like
     // BackgroundTasksPanel that need to render cross-filter subagent children
@@ -432,6 +436,7 @@ export class WebviewUpdater {
       streamMetadata[name] = buildStreamMetadata({
         kind: agentCategory,
         status: statuses?.get(name),
+        substate: substates?.get(name),
         lastTimestamp: state.streamLogs.getLastTimestamp(name),
         conversationProgress: current?.conversationProgress,
         activeSubagents: current?.activeSubagents,

--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -1,6 +1,5 @@
 import type { AgentTrace } from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import { isInFlightStatus } from '@common/constants/streamStatus';
 import type {
@@ -9,10 +8,11 @@ import type {
 } from '@eventBus/ProgressEventBus';
 import { createChannelTrace } from '@logger';
 import {
-  STREAM_STATUS,
+  STREAM_PHASE,
   type ConversationProgress,
   type GoalStatus,
-  type StreamStatus,
+  type StreamPhase,
+  type StreamSubstate,
   type StreamTabId,
 } from '@shared/schemas';
 import { diffActiveChildren } from '@shared/streams/childActivityReducer';
@@ -106,8 +106,10 @@ export class ProgressEventHandler {
         // Stream lifecycle — these handlers use this.state/this.webviewUpdater
         // (same objects as ctx), so ctx is unused but required by the signature.
         setActiveStream: (_, payload) => this.handleSetActiveStream(payload),
-        updateStreamStatus: (_, { streamId, status, previousStatus }) =>
-          this.setStreamStatus(streamId, status, previousStatus),
+        updateStreamStatus: (
+          _,
+          { streamId, status, previousStatus, substate },
+        ) => this.setStreamStatus(streamId, status, previousStatus, substate),
         setTaskState: (_, data) => this.handleSetTaskState(data),
         updateConversationProgress: (_, data) =>
           this.handleUpdateConversationProgress(data),
@@ -346,7 +348,9 @@ export class ProgressEventHandler {
     if (!wasKnownStream || filterChanged) {
       this.webviewUpdater.sendStreamMetadata(
         this.state,
-        StreamStatusService.getAll(),
+        this.state.streamStatus.getAll(),
+        undefined,
+        this.state.streamStatus.getAllSubstates(),
       );
     } else if (shouldSwitch) {
       this.webviewUpdater.setActiveStream(streamId);
@@ -386,7 +390,9 @@ export class ProgressEventHandler {
       // including for background subagents that are not the active stream.
       this.webviewUpdater.sendStreamMetadata(
         this.state,
-        StreamStatusService.getAll(),
+        this.state.streamStatus.getAll(),
+        undefined,
+        this.state.streamStatus.getAllSubstates(),
       );
     }
   }
@@ -466,9 +472,14 @@ export class ProgressEventHandler {
   }
 
   private markAllRunningTasksAsCancelled(): void {
-    for (const [stream, status] of StreamStatusService.entries()) {
-      if (status === STREAM_STATUS.RUNNING) {
-        StreamStatusService.set(stream, STREAM_STATUS.STOPPED, { emit: false });
+    for (const [stream, status] of this.state.streamStatus.entries()) {
+      if (status === STREAM_PHASE.RUNNING) {
+        this.state.streamStatus.transition(
+          stream,
+          STREAM_PHASE.CANCELLED,
+          'restart-repair',
+          { trace: this.logger },
+        );
       }
     }
   }
@@ -563,13 +574,12 @@ export class ProgressEventHandler {
 
   setStreamStatus(
     streamId: StreamTabId,
-    status: StreamStatus,
-    previousStatus?: StreamStatus,
+    status: StreamPhase,
+    // Kept until Stage 5 removes the legacy bus projection; the status machine
+    // now owns repair writes, so this projection no longer consumes it.
+    _previousStatus?: StreamPhase,
+    substate?: StreamSubstate,
   ): void {
-    if (previousStatus === undefined) {
-      StreamStatusService.set(streamId, status, { emit: false });
-    }
-
     // Keep memory bounded by stream status:
     //  - returning to in-flight (e.g., background resume) eagerly rehydrates
     //    previously-released entries so pending appends from the agent
@@ -594,12 +604,28 @@ export class ProgressEventHandler {
 
     if (isNewStream) {
       this.maybeUpdateFilterForCategory(this.getStreamCategory(streamId));
-      const statusesForRefresh = StreamStatusService.getAll();
+      const statusesForRefresh = this.state.streamStatus.getAll();
       statusesForRefresh.set(streamId, status);
-      this.webviewUpdater.sendStreamMetadata(this.state, statusesForRefresh);
+      const substatesForRefresh = this.state.streamStatus.getAllSubstates();
+      if (substate) {
+        substatesForRefresh.set(streamId, substate);
+      } else {
+        substatesForRefresh.delete(streamId);
+      }
+      this.webviewUpdater.sendStreamMetadata(
+        this.state,
+        statusesForRefresh,
+        undefined,
+        substatesForRefresh,
+      );
     } else {
       const lastTimestamp = this.state.streamLogs.getLastTimestamp(streamId);
-      this.webviewUpdater.updateStreamStatus(streamId, status, lastTimestamp);
+      this.webviewUpdater.updateStreamStatus(
+        streamId,
+        status,
+        lastTimestamp,
+        substate,
+      );
     }
   }
 
@@ -611,29 +637,39 @@ export class ProgressEventHandler {
     );
   }
 
-  getAllStreamStatuses(): Map<StreamTabId, StreamStatus> {
-    return StreamStatusService.getAll();
+  getAllStreamStatuses(): Map<StreamTabId, StreamPhase> {
+    return this.state.streamStatus.getAll();
+  }
+
+  getAllStreamSubstates(): Map<StreamTabId, StreamSubstate> {
+    return this.state.streamStatus.getAllSubstates();
   }
 
   resetRunningTasksToError(waitingStreams: Set<StreamTabId>): StreamTabId[] {
     const affectedStreams: StreamTabId[] = [];
 
-    for (const [streamId, status] of StreamStatusService.entries()) {
-      if (status !== STREAM_STATUS.RUNNING) continue;
+    for (const [streamId, status] of this.state.streamStatus.entries()) {
+      if (status !== STREAM_PHASE.RUNNING) continue;
 
       if (waitingStreams.has(streamId)) {
-        StreamStatusService.set(streamId, STREAM_STATUS.WAITING, {
-          emit: false,
-        });
+        this.state.streamStatus.transition(
+          streamId,
+          STREAM_PHASE.WAITING,
+          'restart-repair',
+          { trace: this.logger },
+        );
         this.logger.debug(
           `Stream ${streamId} restored to WAITING after reload`,
         );
         continue;
       }
 
-      StreamStatusService.set(streamId, STREAM_STATUS.ERROR, {
-        emit: false,
-      });
+      this.state.streamStatus.transition(
+        streamId,
+        STREAM_PHASE.FAILED,
+        'restart-repair',
+        { trace: this.logger },
+      );
       affectedStreams.push(streamId);
       this.logger.debug(
         `Stream ${streamId} set to ERROR during restart recovery`,

--- a/src/shared/progressView/backend/state/ProgressViewState.ts
+++ b/src/shared/progressView/backend/state/ProgressViewState.ts
@@ -7,7 +7,7 @@ import {
 } from '@transcript';
 import type { AgentTrace } from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import {
   defaultSession,
   type SessionHandle,
@@ -134,6 +134,8 @@ export class ProgressViewState {
   private _streamStates = new Map<StreamTabId, StreamExecutionState>();
   private _sessionState = new Map<StreamTabId, StreamSessionState>();
 
+  readonly streamStatus: StreamStatusMachine;
+
   private readonly logger: AgentTrace;
   private readonly session: SessionHandle;
 
@@ -144,6 +146,7 @@ export class ProgressViewState {
   ) {
     this.logger = createChannelTrace('ProgressViewState');
     this.session = session;
+    this.streamStatus = session.status;
     this._prefs = new PersistedState(
       createBackendStorage(storage),
       WorkspaceStateKey.PROGRESS_VIEW_PREFS,
@@ -187,7 +190,7 @@ export class ProgressViewState {
    * call this on the stream being moved away from to close the loop.
    */
   releasePreviousActive(streamId: StreamTabId): void {
-    if (!isInFlightStatus(StreamStatusService.get(streamId))) {
+    if (!isInFlightStatus(this.streamStatus.get(streamId))) {
       this.streamLogs.releaseEntries(streamId);
     }
   }
@@ -315,7 +318,7 @@ export class ProgressViewState {
 
   async clearStream(stream: StreamTabId): Promise<void> {
     // Clear in-memory state
-    StreamStatusService.clear(stream, { emit: false });
+    this.streamStatus.clearStream(stream);
     this._sessionState.delete(stream);
     this._streamStates.delete(stream);
 
@@ -341,7 +344,7 @@ export class ProgressViewState {
     );
 
     // Clear in-memory state
-    StreamStatusService.clearAll({ emit: false });
+    this.streamStatus.clearAll();
     this._sessionState.clear();
     this._streamStates.clear();
     this._prefs.reset();

--- a/src/shared/schemas/progressView/outbound.ts
+++ b/src/shared/schemas/progressView/outbound.ts
@@ -21,7 +21,11 @@ import {
   ToolEditPermissionSchema,
   UserQuestionPermissionSchema,
 } from '../prompts';
-import { StreamStatusSchema, StreamTabInfoSchema } from '../stream';
+import {
+  StreamPhaseSchema,
+  StreamSubstateSchema,
+  StreamTabInfoSchema,
+} from '../stream';
 import {
   ActiveChildInfoSchema,
   ConversationProgressSchema,
@@ -84,7 +88,8 @@ export const UpdateStreamDescriptionMessageSchema =
 
 export const UpdateStreamStatusMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_STATUS),
-  status: StreamStatusSchema,
+  status: StreamPhaseSchema,
+  substate: StreamSubstateSchema.optional(),
   lastTimestamp: z.number().optional(),
 });
 

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -229,6 +229,22 @@ export function streamPhaseToStreamStatus(phase: StreamPhase): StreamStatus {
   }
 }
 
+export type StreamLifecycleStatus = StreamPhase | typeof STREAM_STATUS.READY;
+
+export function streamStatusToLifecycleStatus(
+  status: StreamStatus,
+): StreamLifecycleStatus {
+  return status === STREAM_STATUS.READY
+    ? STREAM_STATUS.READY
+    : streamStatusToPhase(status);
+}
+
+export const StreamLifecycleStatusSchema = z.union([
+  StreamPhaseSchema,
+  z.literal(STREAM_STATUS.READY),
+  StreamStatusSchema.transform(streamStatusToLifecycleStatus),
+]);
+
 export const WORKTREE_PR_STATE = {
   OPEN: 'open',
   MERGED: 'merged',

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -7,7 +7,11 @@ import {
   OutputFileInfoSchema,
   roundIndexedRecord,
 } from './output';
-import { STREAM_STATUS, StreamStatusSchema } from './stream';
+import {
+  STREAM_STATUS,
+  StreamLifecycleStatusSchema,
+  StreamSubstateSchema,
+} from './stream';
 import { TaskGroupSchema } from './taskGroup';
 import { PlanSchema } from './plan';
 import { TodoItemSchema } from './todo';
@@ -56,7 +60,8 @@ export const DEFAULT_FINISHED_CHILD_COUNT = 0;
 // Contains only backend-owned fields that mergeBackendOwnedState() actually reads.
 
 const BackendOwnedFieldsSchema = z.object({
-  status: StreamStatusSchema.prefault(DEFAULT_STREAM_METADATA_STATUS),
+  status: StreamLifecycleStatusSchema.prefault(DEFAULT_STREAM_METADATA_STATUS),
+  substate: StreamSubstateSchema.optional(),
   lastTimestamp: z.number().optional(),
   conversationProgress: ConversationProgressSchema.prefault(
     DEFAULT_CONVERSATION_PROGRESS,

--- a/src/shared/streams/streamMetadata.ts
+++ b/src/shared/streams/streamMetadata.ts
@@ -6,7 +6,8 @@ import {
   type AgentCategory,
   type ConversationProgress,
   type StreamMetadata,
-  type StreamStatus,
+  type StreamLifecycleStatus,
+  type StreamSubstate,
 } from '@shared/schemas';
 
 /**
@@ -15,7 +16,8 @@ import {
  */
 export interface StreamMetadataInputs {
   kind: AgentCategory;
-  status?: StreamStatus;
+  status?: StreamLifecycleStatus;
+  substate?: StreamSubstate;
   lastTimestamp?: number;
   conversationProgress?: ConversationProgress;
   activeSubagents?: ActiveChildInfo[];
@@ -30,6 +32,7 @@ export function buildStreamMetadata(
   return {
     kind: inputs.kind,
     status: inputs.status ?? DEFAULT_STREAM_METADATA_STATUS,
+    substate: inputs.substate,
     lastTimestamp: inputs.lastTimestamp,
     conversationProgress: inputs.conversationProgress ?? {
       ...DEFAULT_CONVERSATION_PROGRESS,

--- a/src/shared/streams/streamStatusDisplay.ts
+++ b/src/shared/streams/streamStatusDisplay.ts
@@ -25,6 +25,7 @@ function phaseDisplayKey(phase: StreamPhase): StreamStatusDisplayKey {
 
 export function streamStatusDisplayState(
   status: string | undefined,
+  substate?: StreamSubstate,
 ): StreamStatusDisplayState {
   if (status == null) return {};
   if (status === STREAM_STATUS.READY) {
@@ -33,32 +34,38 @@ export function streamStatusDisplayState(
 
   const phase = StreamPhaseSchema.safeParse(status);
   if (phase.success) {
-    return { phase: phase.data, key: phaseDisplayKey(phase.data) };
+    return {
+      phase: phase.data,
+      ...(substate ? { substate } : {}),
+      key: substate ?? phaseDisplayKey(phase.data),
+    };
   }
 
   const legacyStatus = StreamStatusSchema.safeParse(status);
   if (!legacyStatus.success) return {};
 
   const legacyPhase = streamStatusToPhase(legacyStatus.data);
-  const substate = streamStatusToSubstate(legacyStatus.data);
+  const legacySubstate = streamStatusToSubstate(legacyStatus.data);
   return {
     phase: legacyPhase,
-    ...(substate ? { substate } : {}),
+    ...(legacySubstate ? { substate: legacySubstate } : {}),
     legacyStatus: legacyStatus.data,
-    key: substate ?? phaseDisplayKey(legacyPhase),
+    key: legacySubstate ?? phaseDisplayKey(legacyPhase),
   };
 }
 
 export function streamStatusDisplayKey(
   status: string | undefined,
+  substate?: StreamSubstate,
 ): StreamStatusDisplayKey | undefined {
-  return streamStatusDisplayState(status).key;
+  return streamStatusDisplayState(status, substate).key;
 }
 
 export function streamStatusIndicatorClass(
   status: string | undefined,
+  substate?: StreamSubstate,
 ): string | undefined {
-  const key = streamStatusDisplayKey(status);
+  const key = streamStatusDisplayKey(status, substate);
   return key ? `is-${key}` : undefined;
 }
 
@@ -108,6 +115,7 @@ export function formatStreamStatusLabel(
   options: {
     readonly style?: StreamStatusLabelStyle;
     readonly missingLabel: string;
+    readonly substate?: StreamSubstate;
   },
 ): string;
 
@@ -116,6 +124,7 @@ export function formatStreamStatusLabel(
   options?: {
     readonly style?: StreamStatusLabelStyle;
     readonly missingLabel?: string;
+    readonly substate?: StreamSubstate;
   },
 ): string;
 
@@ -124,6 +133,7 @@ export function formatStreamStatusLabel(
   options?: {
     readonly style?: StreamStatusLabelStyle;
     readonly missingLabel?: string;
+    readonly substate?: StreamSubstate;
   },
 ): string | undefined;
 
@@ -132,10 +142,11 @@ export function formatStreamStatusLabel(
   options: {
     readonly style?: StreamStatusLabelStyle;
     readonly missingLabel?: string;
+    readonly substate?: StreamSubstate;
   } = {},
 ): string | undefined {
   if (status == null) return options.missingLabel;
-  const state = streamStatusDisplayState(status);
+  const state = streamStatusDisplayState(status, options.substate);
   const legacyLabel = legacyStatusLabel(
     state.legacyStatus,
     options.style ?? 'progressHeader',

--- a/src/test-kernel/agent/FollowUpResumeDetection.vitest.mts
+++ b/src/test-kernel/agent/FollowUpResumeDetection.vitest.mts
@@ -1,32 +1,32 @@
 import { describe, expect, it } from 'vitest';
 
 import { shouldProbePersistedFlowForFollowUp } from '@agent/runtime/followUpResumeDetection';
-import { STREAM_STATUS } from '@shared/schemas';
+import { STREAM_PHASE } from '@shared/schemas';
 
 describe('shouldProbePersistedFlowForFollowUp', () => {
   it.each([
     { label: 'no in-memory status is available', status: undefined },
     {
-      label: 'a terminal error status may still have a persisted flow record',
-      status: STREAM_STATUS.ERROR,
+      label: 'a terminal failed phase may still have a persisted flow record',
+      status: STREAM_PHASE.FAILED,
     },
     {
-      label: 'a terminal stopped status may still have a persisted flow record',
-      status: STREAM_STATUS.STOPPED,
+      label:
+        'a terminal cancelled phase may still have a persisted flow record',
+      status: STREAM_PHASE.CANCELLED,
+    },
+    {
+      label:
+        'a terminal completed phase may still have a persisted flow record',
+      status: STREAM_PHASE.COMPLETED,
     },
   ])('probes when $label', ({ status }) => {
     expect(shouldProbePersistedFlowForFollowUp(status)).toBe(true);
   });
 
   it.each([
-    { label: 'the explicit ready status', status: STREAM_STATUS.READY },
-    {
-      label: 'the active initializing status',
-      status: STREAM_STATUS.INITIALIZING,
-    },
-    { label: 'the active running status', status: STREAM_STATUS.RUNNING },
-    { label: 'the active resuming status', status: STREAM_STATUS.RESUMING },
-    { label: 'the already waiting status', status: STREAM_STATUS.WAITING },
+    { label: 'the active running phase', status: STREAM_PHASE.RUNNING },
+    { label: 'the already waiting phase', status: STREAM_PHASE.WAITING },
   ])('does not probe $label', ({ status }) => {
     expect(shouldProbePersistedFlowForFollowUp(status)).toBe(false);
   });

--- a/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
@@ -2,12 +2,17 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
 // Local imports
+import {
+  clearStreamStatusForTest,
+  seedStreamStatusForTest,
+} from '@test/helpers/streamStatusTestUtils';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
+  STREAM_PHASE,
   STREAM_STATUS,
   type ExecutionId,
   type StreamTabId,
@@ -63,7 +68,7 @@ describe('child stream progress events', () => {
       failedChildStreamId,
       normalizedErrorChildStreamId,
     ]) {
-      StreamStatusService.clear(streamId, { emit: false });
+      clearStreamStatusForTest(StreamStatusService, streamId);
     }
   });
 
@@ -121,7 +126,7 @@ describe('child stream progress events', () => {
       payload: {
         streamId: childStreamId,
         status: STREAM_STATUS.RUNNING,
-        previousStatus: STREAM_STATUS.READY,
+        cause: 'lifecycle',
       },
     });
     expect(events[4].payload).toEqual({
@@ -144,8 +149,9 @@ describe('child stream progress events', () => {
       event: 'updateStreamStatus',
       payload: {
         streamId: childStreamId,
-        status: STREAM_STATUS.READY,
+        status: STREAM_PHASE.COMPLETED,
         previousStatus: STREAM_STATUS.RUNNING,
+        cause: 'lifecycle',
       },
     });
     expect(events[8]).toEqual({
@@ -181,10 +187,10 @@ describe('child stream progress events', () => {
     expect(statuses).toEqual([
       STREAM_STATUS.WAITING,
       STREAM_STATUS.RUNNING,
-      STREAM_STATUS.ERROR,
+      STREAM_PHASE.FAILED,
     ]);
     expect(StreamStatusService.get(loopChildStreamId)).toBe(
-      STREAM_STATUS.ERROR,
+      STREAM_PHASE.FAILED,
     );
     expect(active.events.at(-1)).toEqual({
       event: 'updateActiveSubagents',
@@ -211,9 +217,11 @@ describe('child stream progress events', () => {
     const handle =
       defaultSession().executions.getAgentHandleByStream(stoppedChildStreamId);
     expect(handle).toBeDefined();
-    StreamStatusService.set(stoppedChildStreamId, STREAM_STATUS.STOPPED, {
-      emit: false,
-    });
+    seedStreamStatusForTest(
+      StreamStatusService,
+      stoppedChildStreamId,
+      STREAM_PHASE.CANCELLED,
+    );
     active.events.splice(0);
 
     childStream.waitForInput();
@@ -222,7 +230,7 @@ describe('child stream progress events', () => {
     childStream.finalize({ status: STREAM_STATUS.ERROR });
 
     expect(StreamStatusService.get(stoppedChildStreamId)).toBe(
-      STREAM_STATUS.STOPPED,
+      STREAM_PHASE.CANCELLED,
     );
     expect(
       active.events.filter((entry) => entry.event === 'updateStreamStatus'),
@@ -303,7 +311,7 @@ describe('child stream progress events', () => {
     });
 
     expect(StreamStatusService.get(normalizedErrorChildStreamId)).toBe(
-      STREAM_STATUS.ERROR,
+      STREAM_PHASE.FAILED,
     );
     await expect(handle?.result).resolves.toMatchObject({
       type: 'result',

--- a/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
@@ -6,6 +6,10 @@ import { describe, it, afterEach } from 'vitest';
 
 // Local imports - agent
 import { createFakePlatform } from '@test/support/FakePlatform';
+import {
+  clearStreamStatusForTest,
+  seedStreamStatusForTest,
+} from '@test/helpers/streamStatusTestUtils';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
@@ -313,9 +317,11 @@ describe('ToolUseFollowUp', () => {
     const waitingStreamId = 'parent-stream-wake-waiting' as StreamTabId;
 
     await initResumePlatform({ tryResumeStream: async () => false });
-    StreamStatusService.set(waitingStreamId, STREAM_STATUS.WAITING, {
-      emit: false,
-    });
+    seedStreamStatusForTest(
+      StreamStatusService,
+      waitingStreamId,
+      STREAM_STATUS.WAITING,
+    );
 
     try {
       const result = await sendFollowUp(
@@ -335,7 +341,7 @@ describe('ToolUseFollowUp', () => {
         'queued while waiting',
       ]);
     } finally {
-      StreamStatusService.clear(waitingStreamId, { emit: false });
+      clearStreamStatusForTest(StreamStatusService, waitingStreamId);
       ToolUseFollowUpQueue.release(waitingStreamId);
     }
   });

--- a/src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts
@@ -3,6 +3,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import {
+  clearAllStreamStatusesForTest,
+  seedStreamStatusForTest,
+} from '@test/helpers/streamStatusTestUtils';
+import {
   noopAgentRuntimeHost,
   type AgentRuntimeHost,
 } from '@agent/runtime/AgentRuntimeHost';
@@ -14,7 +18,7 @@ import {
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { onFollowUpSent, sendFollowUp } from '@agent/followUp/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
-import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+import { STREAM_PHASE, STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 import { createRecordingHost } from '../progressTestUtils';
 
 const streamId = 'stream:follow-up' as StreamTabId;
@@ -30,7 +34,7 @@ describe('tool-use follow-up progress events', () => {
       executionRegistry.untrack(executionId);
     }
     trackedExecutionIds.clear();
-    StreamStatusService.clearAll({ emit: false });
+    clearAllStreamStatusesForTest(StreamStatusService);
   });
 
   function trackToolUseFlow({
@@ -107,14 +111,18 @@ describe('tool-use follow-up progress events', () => {
     const { host } = createRecordingHost();
     const appendFollowUp = vi.fn();
 
-    StreamStatusService.set(streamId, STREAM_STATUS.STOPPED, { emit: false });
+    seedStreamStatusForTest(
+      StreamStatusService,
+      streamId,
+      STREAM_PHASE.COMPLETED,
+    );
     trackToolUseFlow({ host, appendFollowUp });
 
     const result = await sendFollowUp(streamId, 'late follow-up');
 
     expect(result).toEqual({
       status: 'no_session',
-      streamStatus: STREAM_STATUS.STOPPED,
+      streamStatus: STREAM_PHASE.COMPLETED,
     });
     expect(appendFollowUp).not.toHaveBeenCalled();
   });
@@ -122,9 +130,11 @@ describe('tool-use follow-up progress events', () => {
   it('queues follow-ups for resuming streams through registry admission', async () => {
     const resumingStreamId = 'stream:resuming-follow-up' as StreamTabId;
 
-    StreamStatusService.set(resumingStreamId, STREAM_STATUS.RESUMING, {
-      emit: false,
-    });
+    seedStreamStatusForTest(
+      StreamStatusService,
+      resumingStreamId,
+      STREAM_STATUS.RESUMING,
+    );
 
     try {
       const result = await sendFollowUp(
@@ -157,9 +167,11 @@ describe('tool-use follow-up progress events', () => {
       noopAgentRuntimeHost,
     );
 
-    StreamStatusService.set(parentStreamId, STREAM_STATUS.STOPPED, {
-      emit: false,
-    });
+    seedStreamStatusForTest(
+      StreamStatusService,
+      parentStreamId,
+      STREAM_STATUS.STOPPED,
+    );
     executionRegistry.track(handle);
 
     try {

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -3,6 +3,10 @@ import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import { createFakePlatform } from '@test/support/FakePlatform';
+import {
+  clearStreamStatusForTest,
+  seedStreamStatusForTest,
+} from '@test/helpers/streamStatusTestUtils';
 import { TraceEmitter } from '@agent/trace';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { ToolUseWaitNode } from '@agent/implementations/flows/tooluse/nodes/ToolUseWaitNode';
@@ -20,6 +24,7 @@ import { attachSessionRunFactProjector } from '@agent/runtime/SessionRunFactProj
 import type { AttachedMemoryMiss } from '@agent/types/AttachedMemory';
 import {
   MESSAGE_TYPES,
+  STREAM_PHASE,
   STREAM_STATUS,
   type StreamTabId,
 } from '@shared/schemas';
@@ -45,7 +50,7 @@ describe('ToolUseWaitNode', () => {
       attachedMemoryMisses: memoryMisses,
       checkInterruption: () => interrupted,
       isSubagent: true,
-      logger: { error: vi.fn() },
+      logger: { emit: vi.fn(), error: vi.fn() },
       modelHandler: { extractAssistantText: () => undefined },
       onBeforeWaiting,
       runtimeHost,
@@ -95,7 +100,7 @@ describe('ToolUseWaitNode', () => {
     const services = {
       checkInterruption: () => interrupted,
       isSubagent: true,
-      logger: { error: vi.fn(), info: vi.fn() },
+      logger: { emit: vi.fn(), error: vi.fn(), info: vi.fn() },
       modelHandler: {
         createUserFollowUpMessages: vi.fn(async () => []),
         extractAssistantText: () => undefined,
@@ -162,7 +167,7 @@ describe('ToolUseWaitNode', () => {
     const services = {
       checkInterruption: () => true,
       isSubagent: true,
-      logger: { error: vi.fn(), info: vi.fn() },
+      logger: { emit: vi.fn(), error: vi.fn(), info: vi.fn() },
       modelHandler: { extractAssistantText: () => undefined },
       onBeforeWaiting,
       runtimeHost,
@@ -206,7 +211,7 @@ describe('ToolUseWaitNode', () => {
       fileService: {
         createLocation: (filePath: string) => ({ absolutePath: filePath }),
       },
-      logger: { info: vi.fn(), warn },
+      logger: { emit: vi.fn(), info: vi.fn(), warn },
       modelHandler: {
         addMediaToUserMessage,
         capabilities: {
@@ -352,7 +357,7 @@ describe('ToolUseWaitNode', () => {
     const services = {
       checkInterruption: () => false,
       isSubagent: false,
-      logger: { error: vi.fn(), info: vi.fn() },
+      logger: { emit: vi.fn(), error: vi.fn(), info: vi.fn() },
       modelHandler: {
         createUserFollowUpMessages,
         extractAssistantText: () => undefined,
@@ -369,6 +374,7 @@ describe('ToolUseWaitNode', () => {
     const node = new ToolUseWaitNode().setServices(services);
 
     try {
+      seedStreamStatusForTest(streamStatus, streamId, STREAM_PHASE.RUNNING);
       const prep = await node.prep(shared);
       const exec = await withTestRunContext(runtimeHost, streamId, () =>
         node.exec(prep),
@@ -384,7 +390,7 @@ describe('ToolUseWaitNode', () => {
         },
       ]);
       expect(waitForFollowUp).not.toHaveBeenCalled();
-      expect(streamStatus.get(streamId)).toBeUndefined();
+      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.RUNNING);
 
       const transition = await withTestRunContext(runtimeHost, streamId, () =>
         node.post(shared, prep, exec),
@@ -437,7 +443,7 @@ describe('ToolUseWaitNode', () => {
     const services = {
       checkInterruption: () => false,
       isSubagent: false,
-      logger: { error: vi.fn(), info: vi.fn() },
+      logger: { emit: vi.fn(), error: vi.fn(), info: vi.fn() },
       modelHandler: {
         createUserFollowUpMessages,
         extractAssistantText: () => undefined,
@@ -508,7 +514,7 @@ describe('ToolUseWaitNode', () => {
     const runtimeHost = { emit: vi.fn() };
     const services = {
       checkInterruption: () => false,
-      logger: { error: vi.fn() },
+      logger: { emit: vi.fn(), error: vi.fn() },
       modelHandler: { extractAssistantText: () => undefined },
       runtimeHost,
       session: {
@@ -553,7 +559,7 @@ describe('ToolUseWaitNode', () => {
     const services = {
       checkInterruption: () => false,
       isSubagent: true,
-      logger: { error: vi.fn() },
+      logger: { emit: vi.fn(), error: vi.fn() },
       modelHandler: { extractAssistantText: () => undefined },
       runtimeHost,
       session: {
@@ -595,7 +601,7 @@ describe('ToolUseWaitNode', () => {
     const runtimeHost = { emit: vi.fn() };
     const services = {
       checkInterruption: () => false,
-      logger: { error: vi.fn() },
+      logger: { emit: vi.fn(), error: vi.fn() },
       modelHandler: {
         createUserFollowUpMessages,
         extractAssistantText: () => undefined,
@@ -614,27 +620,85 @@ describe('ToolUseWaitNode', () => {
     const node = new ToolUseWaitNode().setServices(services);
 
     try {
-      streamStatus.set(streamId, STREAM_STATUS.RUNNING, { emit: false });
-      StreamStatusService.set(streamId, STREAM_STATUS.STOPPED, {
-        emit: false,
-      });
+      seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.RUNNING);
+      seedStreamStatusForTest(
+        StreamStatusService,
+        streamId,
+        STREAM_PHASE.CANCELLED,
+      );
 
       const prep = await node.prep(shared);
       const exec = await withTestRunContext(runtimeHost, streamId, () =>
         node.exec(prep),
       );
       expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.WAITING);
-      expect(StreamStatusService.get(streamId)).toBe(STREAM_STATUS.STOPPED);
+      expect(StreamStatusService.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
 
       await withTestRunContext(runtimeHost, streamId, () =>
         node.post(shared, prep, exec),
       );
       expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.RUNNING);
-      expect(StreamStatusService.get(streamId)).toBe(STREAM_STATUS.STOPPED);
+      expect(StreamStatusService.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
       expect(createUserFollowUpMessages).toHaveBeenCalledOnce();
     } finally {
-      streamStatus.clear(streamId, { emit: false });
-      StreamStatusService.clear(streamId, { emit: false });
+      clearStreamStatusForTest(streamStatus, streamId);
+      clearStreamStatusForTest(StreamStatusService, streamId);
+    }
+  });
+
+  it('repairs retry-cancelled parent cycles to waiting before blocking', async () => {
+    const streamId = 'wait-node-retry-cancelled-wait' as StreamTabId;
+    const streamStatus = new StreamStatusRegistry();
+    const runtimeHost = { emit: vi.fn() };
+    const waitForFollowUp = vi.fn(async () => null);
+    const services = {
+      checkInterruption: () => false,
+      isSubagent: false,
+      logger: { emit: vi.fn(), error: vi.fn(), info: vi.fn() },
+      modelHandler: { extractAssistantText: () => undefined },
+      runtimeHost,
+      session: {
+        hasQueuedFollowUp: () => false,
+        waitForFollowUp,
+      },
+      streamId,
+      streamStatus,
+    } as unknown as ToolUseServices;
+    const node = new ToolUseWaitNode().setServices(services);
+
+    try {
+      seedStreamStatusForTest(streamStatus, streamId, STREAM_PHASE.CANCELLED);
+
+      const exec = await withTestRunContext(runtimeHost, streamId, () =>
+        node.exec({
+          afterError: true,
+          lastResponse: undefined,
+          previouslyDeliveredToOrchestrator: false,
+          touchedFiles: [],
+        }),
+      );
+
+      expect(exec.kind).toBe('stop');
+      expect(waitForFollowUp).toHaveBeenCalledOnce();
+      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.WAITING);
+      expect(runtimeHost.emit).toHaveBeenCalledWith(
+        'updateStreamStatus',
+        expect.objectContaining({
+          status: STREAM_PHASE.RUNNING,
+          previousStatus: STREAM_PHASE.CANCELLED,
+          cause: 'resume',
+        }),
+      );
+      expect(runtimeHost.emit).toHaveBeenCalledWith(
+        'updateStreamStatus',
+        expect.objectContaining({
+          status: STREAM_PHASE.WAITING,
+          previousStatus: STREAM_PHASE.RUNNING,
+          cause: 'wait',
+        }),
+      );
+    } finally {
+      clearStreamStatusForTest(streamStatus, streamId);
     }
   });
 
@@ -655,7 +719,7 @@ describe('ToolUseWaitNode', () => {
     const streamStatus = new StreamStatusRegistry();
     const services = {
       checkInterruption: () => false,
-      logger: { error: vi.fn(), info },
+      logger: { emit: vi.fn(), error: vi.fn(), info },
       modelHandler: {
         capabilities: { supportsVision: true },
         createUserFollowUpMessages,
@@ -682,6 +746,11 @@ describe('ToolUseWaitNode', () => {
       streamId: 'test-stream',
     } as unknown as ToolUseServices;
     const node = new ToolUseWaitNode().setServices(services);
+    seedStreamStatusForTest(
+      streamStatus,
+      'test-stream' as StreamTabId,
+      STREAM_PHASE.WAITING,
+    );
 
     const prep = await node.prep(shared);
     const transition = await withTestRunContext(

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -3,6 +3,10 @@ import { ModelProvider } from 'llm-zoo';
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - runtime
+import {
+  clearStreamStatusForTest,
+  seedStreamStatusForTest,
+} from '@test/helpers/streamStatusTestUtils';
 import { noopTrace } from '@agent/trace';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import {
@@ -26,6 +30,7 @@ import { UsageMonitor } from '@agent/utils/UsageMonitor';
 import {
   EXECUTION_STATUS,
   RUN_OUTCOME,
+  STREAM_PHASE,
   STREAM_STATUS,
   type ExecutionId,
   type StorageKey,
@@ -200,7 +205,7 @@ describe('runFlowWithLifecycle', () => {
           fake.globalState.get(GlobalStateKey.ONBOARDING_FIRST_RUN_DONE),
         ).toBe(expectedDone);
       } finally {
-        streamStatus.clear(streamId, { emit: false });
+        clearStreamStatusForTest(streamStatus, streamId);
       }
     });
   }
@@ -211,9 +216,11 @@ describe('runFlowWithLifecycle', () => {
     );
 
     try {
-      StreamStatusService.set(streamId, STREAM_STATUS.WAITING, {
-        emit: false,
-      });
+      seedStreamStatusForTest(
+        StreamStatusService,
+        streamId,
+        STREAM_STATUS.WAITING,
+      );
 
       // The lifecycle owns the whole transition (RUNNING on entry, terminal
       // on exit) against the ctx-owned registry; the module-global
@@ -225,11 +232,60 @@ describe('runFlowWithLifecycle', () => {
         streamId,
       }));
 
-      expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.STOPPED);
+      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.COMPLETED);
       expect(StreamStatusService.get(streamId)).toBe(STREAM_STATUS.WAITING);
     } finally {
-      streamStatus.clear(streamId, { emit: false });
-      StreamStatusService.clear(streamId, { emit: false });
+      clearStreamStatusForTest(streamStatus, streamId);
+      clearStreamStatusForTest(StreamStatusService, streamId);
+    }
+  });
+
+  it('admits run start from a stale terminal phase via resume semantics', async () => {
+    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+      'lifecycle-stale-terminal-start',
+    );
+
+    try {
+      seedStreamStatusForTest(streamStatus, streamId, STREAM_PHASE.FAILED);
+
+      await runFlowWithLifecycle(ctx, async () => {
+        expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.RUNNING);
+        return {
+          category: 'toolUse',
+          outcome: RUN_OUTCOME.COMPLETED,
+          executionId,
+          streamId,
+        };
+      });
+
+      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.COMPLETED);
+    } finally {
+      clearStreamStatusForTest(streamStatus, streamId);
+    }
+  });
+
+  it('clears a stale resuming substate when a resumed run starts', async () => {
+    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+      'lifecycle-resuming-substate-start',
+    );
+
+    try {
+      seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.RESUMING);
+
+      await runFlowWithLifecycle(ctx, async () => {
+        expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.RUNNING);
+        expect(streamStatus.getSubstate(streamId)).toBeUndefined();
+        return {
+          category: 'toolUse',
+          outcome: RUN_OUTCOME.COMPLETED,
+          executionId,
+          streamId,
+        };
+      });
+
+      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.COMPLETED);
+    } finally {
+      clearStreamStatusForTest(streamStatus, streamId);
     }
   });
 
@@ -253,11 +309,11 @@ describe('runFlowWithLifecycle', () => {
 
       expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
       expect(result.memoryMisses).toEqual(ctx.attachedMemoryMisses);
-      expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.STOPPED);
+      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
       expect(onError).toHaveBeenCalledOnce();
       expect(onError.mock.calls[0][1]).toEqual(result);
     } finally {
-      streamStatus.clear(streamId, { emit: false });
+      clearStreamStatusForTest(streamStatus, streamId);
     }
   });
 
@@ -279,12 +335,12 @@ describe('runFlowWithLifecycle', () => {
       );
 
       expect(result.outcome).toBe(RUN_OUTCOME.FAILED);
-      expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.ERROR);
+      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
       expect(onError).toHaveBeenCalledOnce();
       expect(executionRegistry.getHandle(executionId)).toBeUndefined();
     } finally {
       executionRegistry.untrack(executionId);
-      streamStatus.clear(streamId, { emit: false });
+      clearStreamStatusForTest(streamStatus, streamId);
     }
   });
 
@@ -298,19 +354,19 @@ describe('runFlowWithLifecycle', () => {
         outcome: RUN_OUTCOME.COMPLETED,
         terminal: EXECUTION_STATUS.COMPLETED,
         stageEnd: 'stopped',
-        stream: STREAM_STATUS.STOPPED,
+        stream: STREAM_PHASE.COMPLETED,
       },
       {
         outcome: RUN_OUTCOME.CANCELLED,
         terminal: EXECUTION_STATUS.INTERRUPTED,
         stageEnd: 'stopped',
-        stream: STREAM_STATUS.STOPPED,
+        stream: STREAM_PHASE.CANCELLED,
       },
       {
         outcome: RUN_OUTCOME.FAILED,
         terminal: EXECUTION_STATUS.ERROR,
         stageEnd: 'error',
-        stream: STREAM_STATUS.ERROR,
+        stream: STREAM_PHASE.FAILED,
       },
     ] as const;
 
@@ -337,7 +393,7 @@ describe('runFlowWithLifecycle', () => {
         expect(stageEnd).toHaveBeenCalledWith(expected.stageEnd);
         expect(streamStatus.get(streamId)).toBe(expected.stream);
       } finally {
-        streamStatus.clear(streamId, { emit: false });
+        clearStreamStatusForTest(streamStatus, streamId);
       }
     }
   });
@@ -360,9 +416,9 @@ describe('runFlowWithLifecycle', () => {
         EXECUTION_STATUS.INTERRUPTED,
       );
       expect(stageEnd).toHaveBeenCalledWith('stopped');
-      expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.STOPPED);
+      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
     } finally {
-      streamStatus.clear(streamId, { emit: false });
+      clearStreamStatusForTest(streamStatus, streamId);
     }
   });
 
@@ -385,9 +441,30 @@ describe('runFlowWithLifecycle', () => {
         EXECUTION_STATUS.ERROR,
       );
       expect(stageEnd).toHaveBeenCalledWith('error');
-      expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.ERROR);
+      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
     } finally {
-      streamStatus.clear(streamId, { emit: false });
+      clearStreamStatusForTest(streamStatus, streamId);
+    }
+  });
+
+  it('terminalizes a waiting stream when the lifecycle catch path fails', async () => {
+    const { streamId, streamStatus, ctx } = lifecycleFixture(
+      'outcome-waiting-thrown-error',
+    );
+
+    try {
+      await expect(
+        runFlowWithLifecycle(ctx, async () => {
+          expect(
+            streamStatus.transition(streamId, STREAM_PHASE.WAITING, 'wait'),
+          ).toBe(true);
+          throw new Error('wait node failed');
+        }),
+      ).rejects.toThrow('wait node failed');
+
+      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
+    } finally {
+      clearStreamStatusForTest(streamStatus, streamId);
     }
   });
 
@@ -405,7 +482,7 @@ describe('runFlowWithLifecycle', () => {
     const onError = vi.fn();
 
     try {
-      streamStatus.set(streamId, STREAM_STATUS.RUNNING, { emit: false });
+      seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.RUNNING);
 
       const result = await runFlowWithLifecycle(
         ctx,
@@ -422,7 +499,7 @@ describe('runFlowWithLifecycle', () => {
       );
     } finally {
       executionRegistry.untrack(executionId);
-      streamStatus.clear(streamId, { emit: false });
+      clearStreamStatusForTest(streamStatus, streamId);
     }
   });
 });

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
+import { seedStreamStatusForTest } from '@test/helpers/streamStatusTestUtils';
 import {
   AgentExecutionHandle,
   ExecutionRegistry,
@@ -11,11 +12,7 @@ import {
 import { InterruptRegistry } from '@agent/runtime/InterruptRegistry';
 import { ProcessOutputPoller } from '@agent/runtime/ProcessOutputPoller';
 import { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
-import {
-  EXECUTION_STATUS,
-  STREAM_STATUS,
-  type StreamTabId,
-} from '@shared/schemas';
+import { STREAM_PHASE, STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 
 import { createRecordingHost } from '../progressTestUtils';
 
@@ -66,7 +63,7 @@ describe('executionRegistry', () => {
       expect(registry.kill(executionId)).toBe(true);
 
       expect(interrupt).toHaveBeenCalledOnce();
-      expect(streamStatus.get(childStreamId)).toBe(STREAM_STATUS.STOPPED);
+      expect(streamStatus.get(childStreamId)).toBe(STREAM_PHASE.CANCELLED);
     } finally {
       registry.dispose();
       interrupts.unregister(childStreamId);
@@ -119,8 +116,8 @@ describe('executionRegistry', () => {
 
       expect(rootInterrupt).toHaveBeenCalledOnce();
       expect(childInterrupt).toHaveBeenCalledOnce();
-      expect(streamStatus.get(rootStreamId)).toBe(STREAM_STATUS.STOPPED);
-      expect(streamStatus.get(childStreamId)).toBe(STREAM_STATUS.STOPPED);
+      expect(streamStatus.get(rootStreamId)).toBe(STREAM_PHASE.CANCELLED);
+      expect(streamStatus.get(childStreamId)).toBe(STREAM_PHASE.CANCELLED);
       expect(
         explicit.events
           .filter((event) => event.event === 'updateStreamStatus')
@@ -128,8 +125,7 @@ describe('executionRegistry', () => {
       ).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            status: STREAM_STATUS.STOPPED,
-            terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+            status: STREAM_PHASE.CANCELLED,
           }),
         ]),
       );
@@ -179,8 +175,8 @@ describe('executionRegistry', () => {
 
       expect(childInterrupt).toHaveBeenCalledOnce();
       expect(grandchildInterrupt).toHaveBeenCalledOnce();
-      expect(streamStatus.get(childStreamId)).toBe(STREAM_STATUS.STOPPED);
-      expect(streamStatus.get(grandchildStreamId)).toBe(STREAM_STATUS.STOPPED);
+      expect(streamStatus.get(childStreamId)).toBe(STREAM_PHASE.CANCELLED);
+      expect(streamStatus.get(grandchildStreamId)).toBe(STREAM_PHASE.CANCELLED);
     } finally {
       registry.dispose();
       interrupts.unregister(childStreamId);
@@ -233,7 +229,7 @@ describe('executionRegistry', () => {
 
       expect(childInterrupt).toHaveBeenCalledOnce();
       expect(grandchildInterrupt).not.toHaveBeenCalled();
-      expect(streamStatus.get(childStreamId)).toBe(STREAM_STATUS.STOPPED);
+      expect(streamStatus.get(childStreamId)).toBe(STREAM_PHASE.CANCELLED);
       expect(streamStatus.get(grandchildStreamId)).toBeUndefined();
       expect(
         registry.getAgentHandleByStream(grandchildStreamId)?.parentStreamId,
@@ -328,7 +324,7 @@ describe('executionRegistry', () => {
       expect(registry.getActiveChildren(childStreamId).subagents).toEqual([
         expect.objectContaining({ childStreamId: grandchildStreamId }),
       ]);
-      expect(streamStatus.get(rootStreamId)).toBe(STREAM_STATUS.STOPPED);
+      expect(streamStatus.get(rootStreamId)).toBe(STREAM_PHASE.CANCELLED);
       expect(streamStatus.get(childStreamId)).toBeUndefined();
       expect(streamStatus.get(grandchildStreamId)).toBeUndefined();
       expect(explicit.events).toContainEqual({
@@ -365,10 +361,9 @@ describe('executionRegistry', () => {
       });
 
       expect(interrupt).toHaveBeenCalledOnce();
-      expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.STOPPED);
+      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
       expect(explicit.events.at(-1)?.payload).toMatchObject({
-        status: STREAM_STATUS.STOPPED,
-        terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+        status: STREAM_PHASE.CANCELLED,
       });
     } finally {
       registry.dispose();
@@ -391,10 +386,9 @@ describe('executionRegistry', () => {
         streamId,
         childPolicy: 'cascade',
       });
-      expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.STOPPED);
+      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
       expect(explicit.events.at(-1)?.payload).toMatchObject({
-        status: STREAM_STATUS.STOPPED,
-        terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+        status: STREAM_PHASE.CANCELLED,
       });
     } finally {
       registry.dispose();
@@ -427,7 +421,11 @@ describe('executionRegistry', () => {
     const executionId = 'exec-owned-status-test';
 
     try {
-      streamStatus.set(childStreamId, STREAM_STATUS.WAITING, { emit: false });
+      seedStreamStatusForTest(
+        streamStatus,
+        childStreamId,
+        STREAM_STATUS.WAITING,
+      );
       registry.track(
         new AgentExecutionHandle(
           executionId,
@@ -507,14 +505,28 @@ describe('executionRegistry', () => {
       ).toBe(true);
       expect(streamStatus.get(childStreamId)).toBe(STREAM_STATUS.WAITING);
 
-      streamStatus.set(childStreamId, STREAM_STATUS.STOPPED, { emit: false });
+      seedStreamStatusForTest(
+        streamStatus,
+        childStreamId,
+        STREAM_PHASE.CANCELLED,
+      );
+      expect(registry.getActiveChildren(parentStreamId).subagents).toEqual([
+        expect.objectContaining({
+          executionId,
+          status: STREAM_STATUS.STOPPED,
+        }),
+      ]);
       expect(
         registry.updateAgentExecutionStatus(handle, STREAM_STATUS.RUNNING),
       ).toBe(false);
-      expect(streamStatus.get(childStreamId)).toBe(STREAM_STATUS.STOPPED);
+      expect(streamStatus.get(childStreamId)).toBe(STREAM_PHASE.CANCELLED);
 
       registry.untrack(executionId);
-      streamStatus.set(childStreamId, STREAM_STATUS.WAITING, { emit: false });
+      seedStreamStatusForTest(
+        streamStatus,
+        childStreamId,
+        STREAM_STATUS.WAITING,
+      );
       expect(
         registry.updateAgentExecutionStatus(handle, STREAM_STATUS.RUNNING),
       ).toBe(false);
@@ -542,14 +554,64 @@ describe('executionRegistry', () => {
 
     try {
       registry.track(handle);
-      streamStatus.set(childStreamId, STREAM_STATUS.STOPPED, { emit: false });
+      seedStreamStatusForTest(
+        streamStatus,
+        childStreamId,
+        STREAM_PHASE.CANCELLED,
+      );
 
       registry.finishAgentExecution(handle, {
-        status: STREAM_STATUS.READY,
+        status: STREAM_PHASE.COMPLETED,
       });
 
-      expect(streamStatus.get(childStreamId)).toBe(STREAM_STATUS.STOPPED);
+      expect(streamStatus.get(childStreamId)).toBe(STREAM_PHASE.CANCELLED);
       expect(registry.getHandle(executionId)).toBeUndefined();
+    } finally {
+      registry.dispose();
+    }
+  });
+
+  it('finishes waiting agent executions through a lifecycle terminal phase', () => {
+    const explicit = createRecordingHost();
+    const streamStatus = new StreamStatusRegistry();
+    const registry = new ExecutionRegistry({ streamStatus });
+    const parentStreamId = 'parent-finish-waiting-agent-test' as StreamTabId;
+    const childStreamId = 'child-finish-waiting-agent-test' as StreamTabId;
+    const executionId = 'exec-finish-waiting-agent-test';
+    const handle = new AgentExecutionHandle(
+      executionId,
+      parentStreamId,
+      childStreamId,
+      'test-subagent',
+      'toolUse',
+      explicit.host,
+    );
+
+    try {
+      registry.trackAgentExecution(handle, { status: STREAM_PHASE.RUNNING });
+
+      expect(
+        registry.updateAgentExecutionStatus(handle, STREAM_PHASE.WAITING),
+      ).toBe(true);
+
+      registry.finishAgentExecution(handle, {
+        status: STREAM_PHASE.COMPLETED,
+      });
+
+      expect(streamStatus.get(childStreamId)).toBe(STREAM_PHASE.COMPLETED);
+      expect(registry.getHandle(executionId)).toBeUndefined();
+      expect(
+        explicit.events
+          .filter((event) => event.event === 'updateStreamStatus')
+          .slice(-2),
+      ).toEqual([
+        expect.objectContaining({
+          payload: expect.objectContaining({ status: STREAM_PHASE.RUNNING }),
+        }),
+        expect.objectContaining({
+          payload: expect.objectContaining({ status: STREAM_PHASE.COMPLETED }),
+        }),
+      ]);
     } finally {
       registry.dispose();
     }
@@ -579,10 +641,10 @@ describe('executionRegistry', () => {
       ).length;
 
       registry.finishAgentExecution(handle, {
-        status: STREAM_STATUS.ERROR,
+        status: STREAM_PHASE.FAILED,
       });
 
-      expect(streamStatus.get(childStreamId)).toBe(STREAM_STATUS.ERROR);
+      expect(streamStatus.get(childStreamId)).toBe(STREAM_PHASE.FAILED);
       expect(
         explicit.events.filter(
           (event) => event.event === 'updateActiveSubagents',
@@ -810,42 +872,52 @@ describe('executionRegistry', () => {
       );
       activeHandle.attachToolUseFlow(context);
       registry.track(activeHandle);
-      streamStatus.set(activeStreamId, STREAM_STATUS.RUNNING, {
-        emit: false,
-      });
+      seedStreamStatusForTest(
+        streamStatus,
+        activeStreamId,
+        STREAM_STATUS.RUNNING,
+      );
 
       expect(registry.getToolUseFollowUpTarget(activeStreamId)).toEqual({
         kind: 'active',
         context,
       });
 
-      streamStatus.set(resumingStreamId, STREAM_STATUS.RESUMING, {
-        emit: false,
-      });
+      seedStreamStatusForTest(
+        streamStatus,
+        resumingStreamId,
+        STREAM_STATUS.RESUMING,
+      );
       expect(registry.getToolUseFollowUpTarget(resumingStreamId)).toEqual({
         kind: 'queue',
         reason: 'resuming',
       });
 
-      streamStatus.set(waitingStreamId, STREAM_STATUS.WAITING, {
-        emit: false,
-      });
+      seedStreamStatusForTest(
+        streamStatus,
+        waitingStreamId,
+        STREAM_STATUS.WAITING,
+      );
       expect(registry.getToolUseFollowUpTarget(waitingStreamId)).toEqual({
         kind: 'queue',
         reason: 'waiting',
       });
 
-      streamStatus.set(stoppedStreamId, STREAM_STATUS.STOPPED, {
-        emit: false,
-      });
+      seedStreamStatusForTest(
+        streamStatus,
+        stoppedStreamId,
+        STREAM_PHASE.CANCELLED,
+      );
       expect(registry.getToolUseFollowUpTarget(stoppedStreamId)).toEqual({
         kind: 'no_session',
-        streamStatus: STREAM_STATUS.STOPPED,
+        streamStatus: STREAM_PHASE.CANCELLED,
       });
 
-      streamStatus.set(parentStreamId, STREAM_STATUS.STOPPED, {
-        emit: false,
-      });
+      seedStreamStatusForTest(
+        streamStatus,
+        parentStreamId,
+        STREAM_PHASE.CANCELLED,
+      );
       registry.track(
         new AgentExecutionHandle(
           'exec-follow-up-child-test',
@@ -925,9 +997,14 @@ describe('executionRegistry', () => {
     registry.dispose();
     explicit.events.length = 0;
 
-    streamStatus.set(childStreamId, STREAM_STATUS.WAITING, {
-      runtimeHost: explicit.host,
-    });
+    streamStatus.transition(
+      childStreamId,
+      STREAM_PHASE.WAITING,
+      'restart-repair',
+      {
+        runtimeHost: explicit.host,
+      },
+    );
 
     expect(
       explicit.events.some((entry) => entry.event === 'updateActiveSubagents'),

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -2,6 +2,10 @@
 import { describe, expect, it, vi, type Mock } from 'vitest';
 
 // Local imports - agent runtime
+import {
+  clearStreamStatusForTest,
+  seedStreamStatusForTest,
+} from '@test/helpers/streamStatusTestUtils';
 import { noopTrace, type AgentTrace } from '@agent/trace';
 import type { NonIterableObject } from '@agent/node';
 import type { BaseCycleFields } from '@agent/core/flows/CommonCycleTypes';
@@ -27,6 +31,7 @@ import {
 } from '@agent/runtime/AgentRuntimeHost';
 import { attachFlowAutoRetryRequired } from '@common/errors/sdkErrorUtils';
 import {
+  STREAM_PHASE,
   STREAM_STATUS,
   type ExecutionId,
   type StreamTabId,
@@ -203,17 +208,19 @@ describe('RetryState', () => {
     waitForRetry.mockResolvedValueOnce({ action: 'retry' });
 
     try {
-      streamStatus.set(streamId, STREAM_STATUS.RUNNING, { emit: false });
-      StreamStatusService.set(streamId, STREAM_STATUS.STOPPED, {
-        emit: false,
-      });
+      seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.RUNNING);
+      seedStreamStatusForTest(
+        StreamStatusService,
+        streamId,
+        STREAM_PHASE.CANCELLED,
+      );
 
       await withRetryRunContext(streamId, waitForRetry, () =>
         node.promptFor(new Error('temporary provider failure')),
       );
 
       expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.RUNNING);
-      expect(StreamStatusService.get(streamId)).toBe(STREAM_STATUS.STOPPED);
+      expect(StreamStatusService.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
       expect(waitForRetry).toHaveBeenCalledWith(
         streamId,
         expect.objectContaining({
@@ -221,8 +228,8 @@ describe('RetryState', () => {
         }),
       );
     } finally {
-      streamStatus.clear(streamId, { emit: false });
-      StreamStatusService.clear(streamId, { emit: false });
+      clearStreamStatusForTest(streamStatus, streamId);
+      clearStreamStatusForTest(StreamStatusService, streamId);
     }
   });
 
@@ -233,7 +240,7 @@ describe('RetryState', () => {
     const { node, streamStatus } = createRetryNode(streamId);
 
     try {
-      streamStatus.set(streamId, STREAM_STATUS.RUNNING, { emit: false });
+      seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.RUNNING);
 
       const prompt = withSessionRetryRunContext(streamId, session, retry, () =>
         node.promptFor(new Error('temporary provider failure')),
@@ -250,7 +257,7 @@ describe('RetryState', () => {
       expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.RUNNING);
     } finally {
       session.dispose();
-      streamStatus.clear(streamId, { emit: false });
+      clearStreamStatusForTest(streamStatus, streamId);
     }
   });
 
@@ -263,15 +270,15 @@ describe('RetryState', () => {
       waitForRetry.mockResolvedValueOnce({ action });
 
       try {
-        streamStatus.set(streamId, STREAM_STATUS.RUNNING, { emit: false });
+        seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.RUNNING);
 
         await withRetryRunContext(streamId, waitForRetry, () =>
           node.promptFor(new Error('temporary provider failure')),
         );
 
-        expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.STOPPED);
+        expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
       } finally {
-        streamStatus.clear(streamId, { emit: false });
+        clearStreamStatusForTest(streamStatus, streamId);
       }
     },
   );

--- a/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
@@ -25,6 +25,7 @@ import {
 import { interruptRegistry } from '@agent/runtime/InterruptRegistry';
 import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
 import { executionSubscriptionBinder } from '@agent/runtime/ExecutionSubscriptionBinder';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { type Plan, type StreamTabId } from '@shared/schemas';
 
 import { createRecordingHost } from '../progressTestUtils';
@@ -69,6 +70,7 @@ describe('SessionHandle', () => {
     expect(defaultSession().executions).toBe(executionRegistry);
     expect(defaultSession().coordinators).toBe(runCoordinatorBridge);
     expect(defaultSession().subscriptions).toBe(executionSubscriptionBinder);
+    expect(defaultSession().status).toBe(StreamStatusService);
     expect(defaultSession().events).toBeDefined();
     expect(defaultSession().flushers).toBe(getActiveFlushers());
     expect(defaultSession().hostChannel).toBeUndefined();
@@ -81,6 +83,7 @@ describe('SessionHandle', () => {
       expect(fresh.executions).not.toBe(executionRegistry);
       expect(fresh.coordinators).not.toBe(runCoordinatorBridge);
       expect(fresh.subscriptions).not.toBe(executionSubscriptionBinder);
+      expect(fresh.status).not.toBe(StreamStatusService);
       expect(fresh.events).not.toBe(defaultSession().events);
       expect(fresh.flushers).not.toBe(getActiveFlushers());
       expect(fresh.hostChannel).toBeUndefined();

--- a/src/test-kernel/agent/runtime/SessionIsolation.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionIsolation.vitest.ts
@@ -3,6 +3,7 @@ import { ModelProvider } from 'llm-zoo';
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - runtime
+import { clearStreamStatusForTest } from '@test/helpers/streamStatusTestUtils';
 import { noopTrace } from '@agent/trace';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import {
@@ -199,7 +200,7 @@ describe('session isolation (SDK Step 7d PR 2)', () => {
         defaultSession().executions.getHandle(executionId),
       ).toBeUndefined();
     } finally {
-      streamStatus.clear(streamId, { emit: false });
+      clearStreamStatusForTest(streamStatus, streamId);
       sessionB.dispose();
     }
   });

--- a/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
@@ -3,6 +3,7 @@ import { ModelProvider } from 'llm-zoo';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 
 // Local imports
+import { clearStreamStatusForTest } from '@test/helpers/streamStatusTestUtils';
 import { TraceEmitter, type ResultEvent } from '@agent/trace';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import {
@@ -22,6 +23,7 @@ import type { AgentLaunchContext } from '@agent/runtime/AgentLaunchContext';
 import { UsageMonitor } from '@agent/utils/UsageMonitor';
 import {
   RUN_OUTCOME,
+  STREAM_PHASE,
   STREAM_STATUS,
   type ExecutionId,
   type StorageKey,
@@ -152,7 +154,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
       });
       expect(results[0].error).toBeUndefined();
     } finally {
-      streamStatus.clear(ctx.streamId, { emit: false });
+      clearStreamStatusForTest(streamStatus, ctx.streamId);
     }
   });
 
@@ -160,12 +162,12 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
     const logger = new TraceEmitter();
     const results = collectResults(logger);
     const { ctx, streamStatus } = createCtx({ logger });
-    // A status subscriber that throws on the terminal (STOPPED) transition, not
-    // the initial RUNNING one — models a host emit / status listener throwing
+    // A status subscriber that throws on the terminal (COMPLETED) transition,
+    // not the initial RUNNING one — models a host emit / status listener throwing
     // during post-completion cleanup. The run already emitted `completed`, so
     // this must NOT re-enter the catch arm and publish a second `failed`.
     const off = streamStatus.onDidChange((change) => {
-      if (change.status === STREAM_STATUS.STOPPED) {
+      if (change.status === STREAM_PHASE.COMPLETED) {
         throw new Error('status listener boom');
       }
     });
@@ -182,7 +184,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
       expect(results[0].outcome).toBe('completed');
     } finally {
       off();
-      streamStatus.clear(ctx.streamId, { emit: false });
+      clearStreamStatusForTest(streamStatus, ctx.streamId);
     }
   });
 
@@ -210,7 +212,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
         executionId: ctx.executionId,
       });
     } finally {
-      streamStatus.clear(ctx.streamId, { emit: false });
+      clearStreamStatusForTest(streamStatus, ctx.streamId);
     }
   });
 
@@ -243,7 +245,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
         executionId: ctx.executionId,
       });
     } finally {
-      streamStatus.clear(ctx.streamId, { emit: false });
+      clearStreamStatusForTest(streamStatus, ctx.streamId);
     }
   });
 
@@ -276,7 +278,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
         executionId: ctx.executionId,
       });
     } finally {
-      streamStatus.clear(ctx.streamId, { emit: false });
+      clearStreamStatusForTest(streamStatus, ctx.streamId);
     }
   });
 
@@ -310,7 +312,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
         executionId: ctx.executionId,
       });
     } finally {
-      streamStatus.clear(ctx.streamId, { emit: false });
+      clearStreamStatusForTest(streamStatus, ctx.streamId);
     }
   });
 
@@ -342,7 +344,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
         executionId: ctx.executionId,
       });
     } finally {
-      streamStatus.clear(ctx.streamId, { emit: false });
+      clearStreamStatusForTest(streamStatus, ctx.streamId);
     }
   });
 
@@ -351,7 +353,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
     const results = collectResults(logger);
     const { ctx, streamStatus } = createCtx({ logger });
     const off = streamStatus.onDidChange((change) => {
-      if (change.status === STREAM_STATUS.ERROR) {
+      if (change.status === STREAM_PHASE.FAILED) {
         throw new Error('status listener boom');
       }
     });
@@ -369,7 +371,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
       });
     } finally {
       off();
-      streamStatus.clear(ctx.streamId, { emit: false });
+      clearStreamStatusForTest(streamStatus, ctx.streamId);
     }
   });
 
@@ -394,7 +396,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
         executionId: ctx.executionId,
       });
     } finally {
-      streamStatus.clear(ctx.streamId, { emit: false });
+      clearStreamStatusForTest(streamStatus, ctx.streamId);
     }
   });
 
@@ -421,7 +423,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
         outcome: 'failed',
       });
     } finally {
-      streamStatus.clear(ctx.streamId, { emit: false });
+      clearStreamStatusForTest(streamStatus, ctx.streamId);
     }
   });
 
@@ -439,7 +441,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
       expect(results).toHaveLength(1);
       expect(results[0].outcome).toBe('cancelled');
     } finally {
-      streamStatus.clear(ctx.streamId, { emit: false });
+      clearStreamStatusForTest(streamStatus, ctx.streamId);
     }
   });
 
@@ -455,7 +457,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
       expect(results[0].outcome).toBe('cancelled');
       expect(results[0].error?.kind).toBe('abort');
     } finally {
-      streamStatus.clear(ctx.streamId, { emit: false });
+      clearStreamStatusForTest(streamStatus, ctx.streamId);
     }
   });
 
@@ -476,7 +478,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
       expect(results[0].error?.kind).toBeDefined();
       expect(results[0].usage).toBeDefined();
     } finally {
-      streamStatus.clear(ctx.streamId, { emit: false });
+      clearStreamStatusForTest(streamStatus, ctx.streamId);
     }
   });
 
@@ -505,7 +507,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
       });
     } finally {
       detach();
-      streamStatus.clear(ctx.streamId, { emit: false });
+      clearStreamStatusForTest(streamStatus, ctx.streamId);
       session.dispose();
     }
   });

--- a/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
+++ b/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
@@ -2,18 +2,39 @@
 import { describe, expect, it } from 'vitest';
 
 // Local imports
-import { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
-import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+import { seedStreamStatusForTest } from '@test/helpers/streamStatusTestUtils';
+import { TraceEmitter, type StatusEvent } from '@agent/trace';
+import {
+  projectStatusEvent,
+  StreamStatusRegistry,
+} from '@agent/runtime/StreamStatusService';
+import {
+  canTransitionStreamPhase,
+  STREAM_TRANSITION_CAUSE,
+  type StreamTransitionCause,
+} from '@common/constants/streamStatus';
+import {
+  STREAM_PHASE,
+  STREAM_STATUS,
+  STREAM_SUBSTATE,
+  type StreamPhase,
+  type StreamTabId,
+} from '@shared/schemas';
 
 import { createRecordingHost } from '../progressTestUtils';
 
 describe('StreamStatusRegistry', () => {
+  const phases = Object.values(STREAM_PHASE) as StreamPhase[];
+  const causes = Object.values(
+    STREAM_TRANSITION_CAUSE,
+  ) as StreamTransitionCause[];
+
   it('keeps stream status state per instance', () => {
     const first = new StreamStatusRegistry();
     const second = new StreamStatusRegistry();
     const streamId = 'stream-status-instance-test' as StreamTabId;
 
-    first.set(streamId, STREAM_STATUS.WAITING, { emit: false });
+    seedStreamStatusForTest(first, streamId, STREAM_STATUS.WAITING);
 
     expect(first.get(streamId)).toBe(STREAM_STATUS.WAITING);
     expect(second.get(streamId)).toBeUndefined();
@@ -27,7 +48,7 @@ describe('StreamStatusRegistry', () => {
     const changes: string[] = [];
 
     first.onDidChange((change) => changes.push(change.streamId));
-    second.set(streamId, STREAM_STATUS.WAITING, {
+    second.transition(streamId, STREAM_PHASE.WAITING, 'restart-repair', {
       runtimeHost: explicit.host,
     });
 
@@ -35,5 +56,297 @@ describe('StreamStatusRegistry', () => {
     expect(explicit.events.map((entry) => entry.event)).toEqual([
       'updateStreamStatus',
     ]);
+  });
+
+  it('exercises the live machine against the exhaustive transition table', () => {
+    for (const from of [undefined, ...phases]) {
+      for (const to of phases) {
+        for (const cause of causes) {
+          const machine = new StreamStatusRegistry();
+          const streamId =
+            `stream-status-table:${from ?? 'none'}:${to}:${cause}` as StreamTabId;
+          if (from) seedStreamStatusForTest(machine, streamId, from);
+
+          const accepted = machine.transition(streamId, to, cause);
+
+          expect(accepted, `${from ?? 'undefined'} -> ${to} by ${cause}`).toBe(
+            canTransitionStreamPhase(from, to, cause),
+          );
+          expect(machine.get(streamId)).toBe(accepted ? to : from);
+        }
+      }
+    }
+  });
+
+  it('keeps reservations outside the transition table', () => {
+    const machine = new StreamStatusRegistry();
+    const streamId = 'stream-status-reservation-test' as StreamTabId;
+
+    expect(machine.tryAcquire(streamId)).toBe(true);
+    expect(machine.get(streamId)).toBe(STREAM_PHASE.RUNNING);
+    expect(machine.getSubstate(streamId)).toBe(STREAM_SUBSTATE.STARTING);
+    expect(machine.getAllSubstates().get(streamId)).toBe(
+      STREAM_SUBSTATE.STARTING,
+    );
+    expect(machine.tryAcquire(streamId)).toBe(false);
+
+    machine.releaseIfReserved(streamId);
+    expect(machine.get(streamId)).toBeUndefined();
+
+    expect(machine.tryAcquire(streamId)).toBe(true);
+    expect(machine.transition(streamId, STREAM_PHASE.WAITING, 'wait')).toBe(
+      true,
+    );
+    expect(machine.get(streamId)).toBe(STREAM_PHASE.WAITING);
+    expect(machine.tryAcquire(streamId)).toBe(false);
+  });
+
+  it('repairs terminal streams to waiting through resume then wait', () => {
+    const machine = new StreamStatusRegistry();
+    const explicit = createRecordingHost();
+    const streamId = 'stream-status-terminal-waiting-repair' as StreamTabId;
+
+    seedStreamStatusForTest(machine, streamId, STREAM_PHASE.CANCELLED);
+
+    expect(
+      machine.transitionToWaiting(streamId, 'restart-repair', {
+        runtimeHost: explicit.host,
+      }),
+    ).toBe(true);
+
+    expect(machine.get(streamId)).toBe(STREAM_PHASE.WAITING);
+    expect(explicit.events).toEqual([
+      {
+        event: 'updateStreamStatus',
+        payload: {
+          streamId,
+          status: STREAM_PHASE.RUNNING,
+          previousStatus: STREAM_PHASE.CANCELLED,
+          cause: 'resume',
+        },
+      },
+      {
+        event: 'updateStreamStatus',
+        payload: {
+          streamId,
+          status: STREAM_PHASE.WAITING,
+          previousStatus: STREAM_PHASE.RUNNING,
+          cause: 'restart-repair',
+        },
+      },
+    ]);
+  });
+
+  it('terminalizes waiting streams through resume then lifecycle', () => {
+    const machine = new StreamStatusRegistry();
+    const explicit = createRecordingHost();
+    const streamId = 'stream-status-waiting-terminal-repair' as StreamTabId;
+
+    seedStreamStatusForTest(machine, streamId, STREAM_PHASE.WAITING);
+
+    expect(
+      machine.transitionToTerminal(streamId, STREAM_PHASE.FAILED, {
+        runtimeHost: explicit.host,
+      }),
+    ).toBe(true);
+
+    expect(machine.get(streamId)).toBe(STREAM_PHASE.FAILED);
+    expect(explicit.events).toEqual([
+      {
+        event: 'updateStreamStatus',
+        payload: {
+          streamId,
+          status: STREAM_PHASE.RUNNING,
+          previousStatus: STREAM_PHASE.WAITING,
+          cause: 'resume',
+        },
+      },
+      {
+        event: 'updateStreamStatus',
+        payload: {
+          streamId,
+          status: STREAM_PHASE.FAILED,
+          previousStatus: STREAM_PHASE.RUNNING,
+          cause: 'lifecycle',
+        },
+      },
+    ]);
+  });
+
+  it('terminalizes visible streams that were not started yet', () => {
+    const machine = new StreamStatusRegistry();
+    const explicit = createRecordingHost();
+    const streamId = 'stream-status-undefined-terminal-repair' as StreamTabId;
+
+    expect(
+      machine.transitionToTerminal(streamId, STREAM_PHASE.FAILED, {
+        runtimeHost: explicit.host,
+      }),
+    ).toBe(true);
+
+    expect(machine.get(streamId)).toBe(STREAM_PHASE.FAILED);
+    expect(explicit.events).toEqual([
+      {
+        event: 'updateStreamStatus',
+        payload: {
+          streamId,
+          status: STREAM_PHASE.RUNNING,
+          cause: 'lifecycle',
+        },
+      },
+      {
+        event: 'updateStreamStatus',
+        payload: {
+          streamId,
+          status: STREAM_PHASE.FAILED,
+          previousStatus: STREAM_PHASE.RUNNING,
+          cause: 'lifecycle',
+        },
+      },
+    ]);
+  });
+
+  it('accepts already-matching terminal outcomes without warning callers', () => {
+    const machine = new StreamStatusRegistry();
+    const explicit = createRecordingHost();
+    const streamId = 'stream-status-matching-terminal' as StreamTabId;
+
+    seedStreamStatusForTest(machine, streamId, STREAM_PHASE.CANCELLED);
+
+    expect(
+      machine.transitionToTerminal(streamId, STREAM_PHASE.CANCELLED, {
+        runtimeHost: explicit.host,
+      }),
+    ).toBe(true);
+
+    expect(machine.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
+    expect(explicit.events).toEqual([]);
+  });
+
+  it('clears transient running substates without changing phase', () => {
+    const machine = new StreamStatusRegistry();
+    const explicit = createRecordingHost();
+    const streamId = 'stream-status-clear-running-substate' as StreamTabId;
+
+    seedStreamStatusForTest(machine, streamId, STREAM_STATUS.RESUMING);
+
+    expect(
+      machine.clearRunningSubstate(streamId, 'resume', {
+        runtimeHost: explicit.host,
+      }),
+    ).toBe(true);
+
+    expect(machine.get(streamId)).toBe(STREAM_PHASE.RUNNING);
+    expect(machine.getSubstate(streamId)).toBeUndefined();
+    expect(explicit.events).toEqual([
+      {
+        event: 'updateStreamStatus',
+        payload: {
+          streamId,
+          status: STREAM_PHASE.RUNNING,
+          previousStatus: STREAM_PHASE.RUNNING,
+          cause: 'resume',
+        },
+      },
+    ]);
+  });
+
+  it('publishes rollback when a visible reservation is released', () => {
+    const machine = new StreamStatusRegistry();
+    const explicit = createRecordingHost();
+    const streamId = 'stream-status-reservation-rollback' as StreamTabId;
+
+    expect(machine.tryAcquire(streamId, { runtimeHost: explicit.host })).toBe(
+      true,
+    );
+    machine.releaseIfReserved(streamId, { runtimeHost: explicit.host });
+
+    expect(machine.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
+    expect(explicit.events).toEqual([
+      {
+        event: 'updateStreamStatus',
+        payload: {
+          streamId,
+          status: STREAM_PHASE.RUNNING,
+          cause: 'lifecycle',
+          substate: STREAM_SUBSTATE.STARTING,
+        },
+      },
+      {
+        event: 'updateStreamStatus',
+        payload: {
+          streamId,
+          status: STREAM_PHASE.CANCELLED,
+          previousStatus: STREAM_PHASE.RUNNING,
+          cause: 'lifecycle',
+        },
+      },
+    ]);
+  });
+
+  it('overlays reservations on stale terminal phases and restores them on rollback', () => {
+    const machine = new StreamStatusRegistry();
+    const explicit = createRecordingHost();
+    const streamId = 'stream-status-reservation-overlay' as StreamTabId;
+
+    seedStreamStatusForTest(machine, streamId, STREAM_PHASE.COMPLETED);
+
+    expect(machine.tryAcquire(streamId, { runtimeHost: explicit.host })).toBe(
+      true,
+    );
+    expect(machine.get(streamId)).toBe(STREAM_PHASE.RUNNING);
+    expect(
+      machine.transition(streamId, STREAM_PHASE.RUNNING, 'lifecycle'),
+    ).toBe(true);
+
+    seedStreamStatusForTest(machine, streamId, STREAM_PHASE.COMPLETED);
+    expect(machine.tryAcquire(streamId, { runtimeHost: explicit.host })).toBe(
+      true,
+    );
+    machine.releaseIfReserved(streamId, { runtimeHost: explicit.host });
+
+    expect(machine.get(streamId)).toBe(STREAM_PHASE.COMPLETED);
+    expect(explicit.events.at(-1)).toEqual({
+      event: 'updateStreamStatus',
+      payload: {
+        streamId,
+        status: STREAM_PHASE.COMPLETED,
+        previousStatus: STREAM_PHASE.RUNNING,
+        cause: 'lifecycle',
+      },
+    });
+  });
+
+  it('projects status trace events to updateStreamStatus payloads', () => {
+    const machine = new StreamStatusRegistry();
+    const explicit = createRecordingHost();
+    const trace = new TraceEmitter();
+    const streamId = 'stream-status-projection-test' as StreamTabId;
+    const statusEvents: StatusEvent[] = [];
+    const changes: ReturnType<typeof projectStatusEvent>[] = [];
+
+    trace.subscribe((event) => {
+      if (event.type === 'status') statusEvents.push(event);
+    });
+    machine.onDidChange((change) => changes.push(change));
+
+    expect(
+      machine.transition(streamId, STREAM_PHASE.RUNNING, 'lifecycle', {
+        runtimeHost: explicit.host,
+        trace,
+      }),
+    ).toBe(true);
+
+    const projected = projectStatusEvent(statusEvents[0]!);
+    expect(statusEvents[0]).toMatchObject({
+      type: 'status',
+      streamId,
+      phase: STREAM_PHASE.RUNNING,
+      cause: 'lifecycle',
+    });
+    expect(explicit.events).toEqual([
+      { event: 'updateStreamStatus', payload: projected },
+    ]);
+    expect(changes).toEqual([projected]);
   });
 });

--- a/src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts
+++ b/src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts
@@ -7,6 +7,10 @@ vi.mock('@agent/runtime/SessionResumeRetrieval', () => ({
 }));
 
 import {
+  clearStreamStatusForTest,
+  seedStreamStatusForTest,
+} from '@test/helpers/streamStatusTestUtils';
+import {
   isResumeInFlight,
   resolveAndResumeStream,
   type ResumeStreamPorts,
@@ -41,7 +45,7 @@ describe('resolveAndResumeStream', () => {
   });
 
   afterEach(() => {
-    StreamStatusService.clear(STREAM, { emit: false });
+    clearStreamStatusForTest(StreamStatusService, STREAM);
   });
 
   it('routes a tool-use snapshot to the resume port', async () => {
@@ -86,7 +90,11 @@ describe('resolveAndResumeStream', () => {
     // `resumeInFlight` (held here) cannot catch that, so the post-retrieval
     // re-check must bail before touching the resume ports.
     retrieveSessionResumeDataMock.mockImplementation(async () => {
-      StreamStatusService.set(STREAM, STREAM_STATUS.RUNNING, { emit: false });
+      seedStreamStatusForTest(
+        StreamStatusService,
+        STREAM,
+        STREAM_STATUS.RUNNING,
+      );
       return { type: 'toolUse', snapshot: { streamId: STREAM } };
     });
     const ports = basePorts();
@@ -97,7 +105,7 @@ describe('resolveAndResumeStream', () => {
   });
 
   it('skips resume without resolving when the stream is already active', async () => {
-    StreamStatusService.set(STREAM, STREAM_STATUS.RUNNING, { emit: false });
+    seedStreamStatusForTest(StreamStatusService, STREAM, STREAM_STATUS.RUNNING);
     const ports = basePorts();
 
     await expect(resolveAndResumeStream(STREAM, ports)).resolves.toBe(false);

--- a/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
+++ b/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
@@ -6,7 +6,12 @@ vi.mock('@agent/runtime/executeAgent', () => ({
   resumeToolUseFromSnapshot: resumeToolUseFromSnapshotMock,
 }));
 
+import {
+  clearStreamStatusForTest,
+  seedStreamStatusForTest,
+} from '@test/helpers/streamStatusTestUtils';
 import { resumeToolUseSnapshot } from '@agent/runtime/resumeToolUseSnapshot';
+import { SessionHandle } from '@agent/runtime/SessionHandle';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
@@ -40,7 +45,7 @@ describe('resumeToolUseSnapshot', () => {
 
   afterEach(() => {
     ToolUseFollowUpQueue.release(STREAM);
-    StreamStatusService.clear(STREAM, { emit: false });
+    clearStreamStatusForTest(StreamStatusService, STREAM);
   });
 
   it('drains queued follow-ups, replays them, and notifies the UI', async () => {
@@ -113,9 +118,35 @@ describe('resumeToolUseSnapshot', () => {
     expect(queueUpdates).toHaveLength(2);
   });
 
+  it('uses the supplied session status plane for resume markers', async () => {
+    const failure = new Error('session-scoped resume failed');
+    resumeToolUseFromSnapshotMock.mockRejectedValue(failure);
+    const session = new SessionHandle();
+
+    try {
+      await expect(
+        resumeToolUseSnapshot(snapshot(), {
+          runtimeHost,
+          session,
+          reportFailure: vi.fn(),
+        }),
+      ).resolves.toBe(false);
+
+      expect(session.status.get(STREAM)).toBe(STREAM_STATUS.WAITING);
+      expect(StreamStatusService.get(STREAM)).toBeUndefined();
+    } finally {
+      session.status.clearStream(STREAM);
+      session.dispose();
+    }
+  });
+
   it('leaves the status alone when the started run has taken it over', async () => {
     resumeToolUseFromSnapshotMock.mockImplementation(async () => {
-      StreamStatusService.set(STREAM, STREAM_STATUS.RUNNING, { emit: false });
+      seedStreamStatusForTest(
+        StreamStatusService,
+        STREAM,
+        STREAM_STATUS.RUNNING,
+      );
     });
 
     await expect(

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -45,6 +45,7 @@ import {
   finalizeAssistantTranscriptEntries,
 } from '@cli/chat/tui/state/transcript';
 import { subscribeStreamStatus } from '@cli/chat/tui/state/subscribeStreamStatus';
+import { STREAM_PHASE } from '@shared/schemas';
 import {
   STREAM_STATUS,
   TOOL_USE_STATUS,
@@ -185,9 +186,14 @@ describe('CLI conversation transcript splitting', () => {
     const dispose = subscribeStreamStatus();
 
     try {
-      StreamStatusService.set(STREAM_ID, STREAM_STATUS.READY, {
-        runtimeHost: { emit: () => undefined },
-      });
+      StreamStatusService.transition(
+        STREAM_ID,
+        STREAM_PHASE.COMPLETED,
+        'restart-repair',
+        {
+          runtimeHost: { emit: () => undefined },
+        },
+      );
 
       expect(
         cliState.streams
@@ -216,9 +222,14 @@ describe('CLI conversation transcript splitting', () => {
     const dispose = subscribeStreamStatus();
 
     try {
-      StreamStatusService.set(STREAM_ID, STREAM_STATUS.RUNNING, {
-        runtimeHost: { emit: () => undefined },
-      });
+      StreamStatusService.transition(
+        STREAM_ID,
+        STREAM_PHASE.RUNNING,
+        'resume',
+        {
+          runtimeHost: { emit: () => undefined },
+        },
+      );
 
       expect(cliState.streams.get().get(STREAM_ID)?.status).toBe(
         STREAM_STATUS.RUNNING,

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -8,7 +8,7 @@ import {
 } from '@cli/runtime/runProgressRenderer';
 import { createCliRuntimeHost } from '@cli/runtime/runtimeHost';
 import type { CliContext } from '@cli/runtime/cliContext';
-import { EXECUTION_STATUS, STREAM_STATUS } from '@shared/schemas';
+import { STREAM_PHASE, STREAM_STATUS } from '@shared/schemas';
 
 const mocks = vi.hoisted(() => ({
   getAgent: vi.fn(),
@@ -229,8 +229,8 @@ describe('CLI run progress renderer', () => {
 
     renderer?.handle('updateStreamStatus', {
       streamId: 'stream-1',
-      status: STREAM_STATUS.STOPPED,
-      previousStatus: STREAM_STATUS.RUNNING,
+      status: STREAM_PHASE.CANCELLED,
+      previousStatus: STREAM_PHASE.RUNNING,
     });
     expect(clearCount).toBe(1);
   });
@@ -469,8 +469,8 @@ describe('CLI run progress renderer', () => {
 
     renderer?.handle('updateStreamStatus', {
       streamId: 'root-stream',
-      status: STREAM_STATUS.STOPPED,
-      previousStatus: STREAM_STATUS.RUNNING,
+      status: STREAM_PHASE.CANCELLED,
+      previousStatus: STREAM_PHASE.RUNNING,
     });
     expect(clearCount).toBe(1);
   });
@@ -664,9 +664,8 @@ describe('CLI run progress renderer', () => {
     now = 11000;
     renderer?.handle('updateStreamStatus', {
       streamId: 'root-stream',
-      status: STREAM_STATUS.STOPPED,
+      status: STREAM_PHASE.COMPLETED,
       previousStatus: STREAM_STATUS.RUNNING,
-      terminalStatus: EXECUTION_STATUS.COMPLETED,
     });
     renderer?.handle('updateStreamDescription', {
       streamId: 'root-stream',
@@ -722,9 +721,8 @@ describe('CLI run progress renderer', () => {
     );
     renderer?.handle('updateStreamStatus', {
       streamId: 'root-stream',
-      status: STREAM_STATUS.STOPPED,
+      status: STREAM_PHASE.CANCELLED,
       previousStatus: STREAM_STATUS.RUNNING,
-      terminalStatus: EXECUTION_STATUS.INTERRUPTED,
     });
 
     expect(output).toBe('orchestrator · 0s\norchestrator · interrupted · 0s\n');
@@ -862,8 +860,7 @@ describe('CLI run progress renderer', () => {
       );
       host.emit('updateStreamStatus', {
         streamId: 'stream-1',
-        status: STREAM_STATUS.RUNNING,
-        previousStatus: STREAM_STATUS.READY,
+        status: STREAM_PHASE.RUNNING,
       });
       await host.close();
       host.emit('updateStreamDescription', {

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -11,7 +11,7 @@ import {
 import { defaultShortcutModifierLabel } from '@cli/runtime/shortcutLabels';
 import { shortCliApiMode } from '@cli/runtime/apiAccessMode';
 import { NO_BYPASS, type StreamSlice } from '@cli/chat/tui/state/cliState';
-import { STREAM_STATUS } from '@shared/schemas';
+import { STREAM_PHASE, STREAM_STATUS } from '@shared/schemas';
 
 const PERSONAL_API_MODE_LABEL = shortCliApiMode('personal');
 const COMPLETED_REVIEW_FOLLOWUP =
@@ -585,7 +585,7 @@ describe('CLI StatusBar display model', () => {
     ).toBe('exit');
 
     const baseDisplayInput = statusInput({
-      status: STREAM_STATUS.STOPPED,
+      status: STREAM_PHASE.CANCELLED,
       subagentControlsAvailable: true,
       hasMultipleStreams: true,
       ctrlCAction: 'stop root',
@@ -627,11 +627,11 @@ describe('CLI StatusBar display model', () => {
     } as StreamSlice;
     const childSlice = {
       streamId: child,
-      status: STREAM_STATUS.STOPPED,
+      status: STREAM_PHASE.CANCELLED,
     } as StreamSlice;
     const grandchildSlice = {
       streamId: grandchild,
-      status: STREAM_STATUS.STOPPED,
+      status: STREAM_PHASE.CANCELLED,
     } as StreamSlice;
     const streams = new Map<StreamSlice['streamId'], StreamSlice>([
       [root, rootSlice],
@@ -777,11 +777,11 @@ describe('CLI StatusBar display model', () => {
 
     const stoppedRootSlice = {
       streamId: root,
-      status: STREAM_STATUS.STOPPED,
+      status: STREAM_PHASE.CANCELLED,
     } as StreamSlice;
     const stoppedChildSlice = {
       streamId: child,
-      status: STREAM_STATUS.STOPPED,
+      status: STREAM_PHASE.CANCELLED,
     } as StreamSlice;
     const stoppedStreams = new Map<StreamSlice['streamId'], StreamSlice>([
       [root, stoppedRootSlice],
@@ -834,7 +834,7 @@ describe('CLI StatusBar display model', () => {
       status: STREAM_STATUS.RUNNING,
     } as StreamSlice;
     const childSlice = {
-      status: STREAM_STATUS.STOPPED,
+      status: STREAM_PHASE.CANCELLED,
     } as StreamSlice;
     const waitingChildSlice = {
       status: STREAM_STATUS.WAITING,

--- a/src/test-kernel/cli/StreamTabsStrip.vitest.mts
+++ b/src/test-kernel/cli/StreamTabsStrip.vitest.mts
@@ -15,6 +15,7 @@ import {
 } from '@cli/chat/tui/panes/StreamTabsStrip';
 import { textDisplayWidth } from '@cli/chat/tui/render/terminalText';
 import {
+  STREAM_PHASE,
   STREAM_STATUS,
   type ActiveChildInfo,
   type StreamTabId,
@@ -336,7 +337,7 @@ describe('CLI stream tabs strip', () => {
       [
         root,
         slice('root', {
-          status: STREAM_STATUS.STOPPED,
+          status: STREAM_PHASE.CANCELLED,
           childStreams: [
             child({
               executionId: 'r1',
@@ -346,7 +347,7 @@ describe('CLI stream tabs strip', () => {
           ],
         }),
       ],
-      [child1, slice('child-1', { status: STREAM_STATUS.STOPPED })],
+      [child1, slice('child-1', { status: STREAM_PHASE.CANCELLED })],
     ]);
 
     const items = streamTabsDisplayItems({
@@ -379,7 +380,7 @@ describe('CLI stream tabs strip', () => {
           ],
         }),
       ],
-      [child1, slice('child-1', { status: STREAM_STATUS.ERROR })],
+      [child1, slice('child-1', { status: STREAM_PHASE.FAILED })],
     ]);
 
     const items = streamTabsDisplayItems({

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -11,6 +11,7 @@ import {
   StreamLogStore,
   type StreamSnapshotStore,
 } from '@transcript';
+import { clearAllStreamStatusesForTest } from '@test/helpers/streamStatusTestUtils';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import {
@@ -93,6 +94,7 @@ import {
   AgentCategory,
   DEFAULT_TOOL_CONFIG,
   MESSAGE_TYPES,
+  STREAM_PHASE,
   STREAM_STATUS,
   TODO_STATUS,
   type StorageKey,
@@ -106,7 +108,7 @@ const child1 = 'child-1' as StreamTabId;
 const child2 = 'child-2' as StreamTabId;
 
 afterEach(() => {
-  StreamStatusService.clearAll({ emit: false });
+  clearAllStreamStatusesForTest(StreamStatusService);
   resetCliState();
 });
 
@@ -227,18 +229,23 @@ describe('cliState Phase 4 fields', () => {
       }));
       patchStream(root, (s) => ({ ...s, activeSubagents: [] }));
 
-      StreamStatusService.set(child1, STREAM_STATUS.ERROR, {
-        runtimeHost: wrapped,
-      });
+      StreamStatusService.transition(
+        child1,
+        STREAM_PHASE.FAILED,
+        'restart-repair',
+        {
+          runtimeHost: wrapped,
+        },
+      );
 
       const parent = cliState.streams.get().get(root);
       expect(parent?.activeSubagents).toEqual([]);
-      expect(parent?.childStreams[0]?.status).toBe(STREAM_STATUS.ERROR);
+      expect(parent?.childStreams[0]?.status).toBe(STREAM_PHASE.FAILED);
       expect(visibleSubagentRows(parent!)).toMatchObject([
         {
           executionId: 'agent-1',
           childStreamId: child1,
-          status: STREAM_STATUS.ERROR,
+          status: STREAM_PHASE.FAILED,
         },
       ]);
     } finally {
@@ -692,7 +699,7 @@ describe('CLI TUI row allocation', () => {
       shouldShowTodosPlanPanel({
         foregroundOpen: false,
         hasPlan: true,
-        status: STREAM_STATUS.RESUMING,
+        status: STREAM_PHASE.RUNNING,
         todos: [],
       }),
     ).toBe(true);
@@ -708,7 +715,7 @@ describe('CLI TUI row allocation', () => {
       shouldShowTodosPlanPanel({
         foregroundOpen: false,
         hasPlan: false,
-        status: STREAM_STATUS.STOPPED,
+        status: STREAM_PHASE.COMPLETED,
         todos: [openTodo],
       }),
     ).toBe(false);
@@ -1253,7 +1260,7 @@ describe('CLI TUI row allocation', () => {
           runPromise,
           streamId: root,
         },
-        STREAM_STATUS.INITIALIZING,
+        STREAM_PHASE.RUNNING,
       ),
     ).toBe(true);
     expect(
@@ -1263,7 +1270,7 @@ describe('CLI TUI row allocation', () => {
           runPromise,
           streamId: root,
         },
-        STREAM_STATUS.RESUMING,
+        STREAM_PHASE.RUNNING,
       ),
     ).toBe(true);
     expect(
@@ -1283,7 +1290,7 @@ describe('CLI TUI row allocation', () => {
           runPromise,
           streamId: root,
         },
-        STREAM_STATUS.ERROR,
+        STREAM_PHASE.FAILED,
       ),
     ).toBe(false);
     expect(
@@ -1293,7 +1300,7 @@ describe('CLI TUI row allocation', () => {
           runPromise,
           streamId: root,
         },
-        STREAM_STATUS.STOPPED,
+        STREAM_PHASE.CANCELLED,
       ),
     ).toBe(false);
     expect(
@@ -1336,7 +1343,7 @@ describe('CLI TUI row allocation', () => {
           runPromise: undefined,
           streamId: root,
         },
-        STREAM_STATUS.INITIALIZING,
+        STREAM_PHASE.RUNNING,
       ),
     ).toBe(true);
     expect(
@@ -1421,7 +1428,7 @@ describe('CLI TUI row allocation', () => {
           executionId: 'child-exec-1',
           agentName: 'critic',
           childStreamId: child1,
-          status: STREAM_STATUS.STOPPED,
+          status: STREAM_PHASE.COMPLETED,
         },
       ],
     }));
@@ -1448,7 +1455,7 @@ describe('CLI TUI row allocation', () => {
         },
       ],
     }));
-    patchStream(child1, (s) => ({ ...s, status: STREAM_STATUS.STOPPED }));
+    patchStream(child1, (s) => ({ ...s, status: STREAM_PHASE.CANCELLED }));
     setParentStream(child1, root);
 
     cliState.activeStreamId.set(child1);
@@ -1465,7 +1472,7 @@ describe('CLI TUI row allocation', () => {
       focusedChildInputDisabledMessage({
         activeStreamId: root,
         parentStream: cliState.parentStream.get(),
-        status: STREAM_STATUS.STOPPED,
+        status: STREAM_PHASE.COMPLETED,
       }),
     ).toBeUndefined();
 
@@ -1490,7 +1497,7 @@ describe('CLI TUI row allocation', () => {
         activeStreamId: child1,
         parentStream: cliState.parentStream.get(),
         shortcutModifierLabel: 'Esc',
-        status: STREAM_STATUS.STOPPED,
+        status: STREAM_PHASE.COMPLETED,
       }),
     ).toBe(
       'Subagent is no longer accepting follow-ups; press Tab to switch streams or Esc s to choose another.',
@@ -1501,7 +1508,7 @@ describe('CLI TUI row allocation', () => {
         activeStreamId: child1,
         parentStream: cliState.parentStream.get(),
         shortcutModifierLabel: 'Alt',
-        status: STREAM_STATUS.STOPPED,
+        status: STREAM_PHASE.COMPLETED,
       }),
     ).toBe(
       'Subagent is no longer accepting follow-ups; press Tab to switch streams or Alt-s to choose another.',
@@ -1512,7 +1519,7 @@ describe('CLI TUI row allocation', () => {
         activeStreamId: child1,
         parentStream: cliState.parentStream.get(),
         shortcutModifierLabel: 'Esc',
-        status: STREAM_STATUS.STOPPED,
+        status: STREAM_PHASE.COMPLETED,
         subagentControlsAvailable: false,
       }),
     ).toBe(
@@ -1524,7 +1531,7 @@ describe('CLI TUI row allocation', () => {
         activeStreamId: child1,
         parentStream: cliState.parentStream.get(),
         shortcutModifierLabel: 'Esc',
-        status: STREAM_STATUS.STOPPED,
+        status: STREAM_PHASE.COMPLETED,
         subagentControlsAvailable: false,
         taskControlsAvailable: true,
       }),
@@ -1537,7 +1544,7 @@ describe('CLI TUI row allocation', () => {
         activeStreamId: child1,
         parentStream: cliState.parentStream.get(),
         shortcutModifierLabel: 'Esc',
-        status: STREAM_STATUS.STOPPED,
+        status: STREAM_PHASE.COMPLETED,
         taskControlsAvailable: true,
       }),
     ).toBe(
@@ -1559,17 +1566,22 @@ describe('CLI TUI row allocation', () => {
           executionId: 'child-exec-1',
           agentName: 'critic',
           childStreamId: child1,
-          status: STREAM_STATUS.STOPPED,
+          status: STREAM_PHASE.COMPLETED,
         },
       ],
     }));
-    patchStream(child1, (s) => ({ ...s, status: STREAM_STATUS.STOPPED }));
+    patchStream(child1, (s) => ({ ...s, status: STREAM_PHASE.CANCELLED }));
     setParentStream(child1, root);
 
     try {
-      StreamStatusService.set(child1, STREAM_STATUS.RUNNING, {
-        runtimeHost: wrapped,
-      });
+      StreamStatusService.transition(
+        child1,
+        STREAM_PHASE.RUNNING,
+        'restart-repair',
+        {
+          runtimeHost: wrapped,
+        },
+      );
 
       cliState.activeStreamId.set(child1);
       expect(cliState.streams.get().get(child1)?.status).toBe(
@@ -1609,16 +1621,21 @@ describe('CLI TUI row allocation', () => {
     setParentStream(child1, root);
 
     try {
-      StreamStatusService.set(child1, STREAM_STATUS.STOPPED, {
-        runtimeHost: wrapped,
-      });
+      StreamStatusService.transition(
+        child1,
+        STREAM_PHASE.CANCELLED,
+        'restart-repair',
+        {
+          runtimeHost: wrapped,
+        },
+      );
 
       cliState.activeStreamId.set(child1);
       expect(cliState.streams.get().get(child1)?.status).toBe(
-        STREAM_STATUS.STOPPED,
+        STREAM_PHASE.CANCELLED,
       );
       expect(cliState.streams.get().get(root)?.childStreams[0]?.status).toBe(
-        STREAM_STATUS.STOPPED,
+        STREAM_PHASE.CANCELLED,
       );
       expect(chatTuiFocusedChildFollowUpRoute()).toEqual({
         kind: 'reject',

--- a/src/test-kernel/common/RunOutcomeAlgebra.vitest.ts
+++ b/src/test-kernel/common/RunOutcomeAlgebra.vitest.ts
@@ -4,7 +4,6 @@ import { describe, expect, it } from 'vitest';
 // Local imports
 import {
   canAcquireStreamReservation,
-  canReleaseStreamReservation,
   canTransitionStreamPhase,
   deriveRunOutcome,
   groupEndStatusForOutcome,
@@ -25,7 +24,6 @@ import {
   RUN_OUTCOME,
   STREAM_PHASE,
   STREAM_STATUS,
-  STREAM_SUBSTATE,
   StreamPhaseSchema,
   streamStatusesWithTrait,
   type RunOutcome,
@@ -115,8 +113,10 @@ describe('stream phase transition table', () => {
       [STREAM_TRANSITION_CAUSE.RESUME]: [],
       [STREAM_TRANSITION_CAUSE.USER_STOP]: [STREAM_PHASE.CANCELLED],
       [STREAM_TRANSITION_CAUSE.RESTART_REPAIR]: [
+        STREAM_PHASE.RUNNING,
         STREAM_PHASE.WAITING,
         STREAM_PHASE.FAILED,
+        STREAM_PHASE.CANCELLED,
       ],
     },
     [STREAM_PHASE.WAITING]: {
@@ -124,7 +124,7 @@ describe('stream phase transition table', () => {
       [STREAM_TRANSITION_CAUSE.WAIT]: [],
       [STREAM_TRANSITION_CAUSE.RESUME]: [STREAM_PHASE.RUNNING],
       [STREAM_TRANSITION_CAUSE.USER_STOP]: [STREAM_PHASE.CANCELLED],
-      [STREAM_TRANSITION_CAUSE.RESTART_REPAIR]: [],
+      [STREAM_TRANSITION_CAUSE.RESTART_REPAIR]: [STREAM_PHASE.WAITING],
     },
     [STREAM_PHASE.COMPLETED]: {
       [STREAM_TRANSITION_CAUSE.LIFECYCLE]: [],
@@ -161,12 +161,17 @@ describe('stream phase transition table', () => {
     }
   });
 
-  it('admits only lifecycle starts from idle', () => {
+  it('admits only named start causes from idle', () => {
     for (const cause of causes) {
       for (const to of phases) {
         expect(canTransitionStreamPhase(undefined, to, cause)).toBe(
-          cause === STREAM_TRANSITION_CAUSE.LIFECYCLE &&
-            to === STREAM_PHASE.RUNNING,
+          (cause === STREAM_TRANSITION_CAUSE.LIFECYCLE &&
+            to === STREAM_PHASE.RUNNING) ||
+            (cause === STREAM_TRANSITION_CAUSE.RESUME &&
+              to === STREAM_PHASE.RUNNING) ||
+            (cause === STREAM_TRANSITION_CAUSE.USER_STOP &&
+              to === STREAM_PHASE.CANCELLED) ||
+            cause === STREAM_TRANSITION_CAUSE.RESTART_REPAIR,
         );
       }
     }
@@ -179,19 +184,6 @@ describe('stream phase transition table', () => {
     expect(canAcquireStreamReservation(STREAM_PHASE.COMPLETED)).toBe(true);
     expect(canAcquireStreamReservation(STREAM_PHASE.CANCELLED)).toBe(true);
     expect(canAcquireStreamReservation(STREAM_PHASE.FAILED)).toBe(true);
-
-    for (const phase of [undefined, ...phases]) {
-      for (const substate of [
-        undefined,
-        STREAM_SUBSTATE.STARTING,
-        STREAM_SUBSTATE.RESUMING,
-      ]) {
-        expect(canReleaseStreamReservation({ phase, substate })).toBe(
-          phase === STREAM_PHASE.RUNNING &&
-            substate === STREAM_SUBSTATE.STARTING,
-        );
-      }
-    }
   });
 });
 

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -2,7 +2,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - agent state
+import { seedStreamStatusForTest } from '@test/helpers/streamStatusTestUtils';
 import { TaskStateSchema } from '@agent/core/state/TaskState';
+import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 
 // Local imports - progress schemas
 import { DESKTOP_SHELL_COMMANDS } from '@desktop/desktopShellMessages';
@@ -71,8 +73,15 @@ type BridgeWithSession = TestableBridge & {
     coordinators: {
       cleanupAllRequests(): void;
     };
+    status: StreamStatusMachine;
   };
 };
+
+function bridgeStatus(
+  bridge: TestableBridge,
+): BridgeWithSession['session']['status'] {
+  return (bridge as BridgeWithSession).session.status;
+}
 
 type DesktopExecution = {
   handleExecute(message: unknown): Promise<void>;
@@ -160,6 +169,7 @@ type ProgressMessage = {
 function mockLoggerModule(): void {
   vi.doMock('@logger', () => ({
     createChannelTrace: () => ({
+      emit: vi.fn(),
       debug: () => {},
       info: () => {},
       warn: () => {},
@@ -695,33 +705,33 @@ describe('DesktopProgressBridge', () => {
         }),
       ]),
     });
-    const { StreamStatusService } =
-      await import('@agent/runtime/StreamStatusService');
 
     try {
       await vi.waitFor(() => {
         expect(detectWaitingStreams).toHaveBeenCalledOnce();
-        expect(StreamStatusService.get('waiting-stream')).toBe(
+        expect(bridgeStatus(bridge).get('waiting-stream')).toBe(
           STREAM_STATUS.WAITING,
         );
-        expect(StreamStatusService.get('dead-stream')).toBe(
-          STREAM_STATUS.ERROR,
+        expect(bridgeStatus(bridge).get('dead-stream')).toBe(
+          STREAM_PHASE.FAILED,
         );
       });
 
-      const streamSync = progressMessages(
-        messages,
-        PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
-      ).at(-1);
-      expect(streamSync?.streamStates?.['waiting-stream']).toMatchObject({
-        status: STREAM_STATUS.WAITING,
-      });
-      expect(streamSync?.streamStates?.['dead-stream']).toMatchObject({
-        status: STREAM_STATUS.ERROR,
+      await vi.waitFor(() => {
+        const streamSync = progressMessages(
+          messages,
+          PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+        ).at(-1);
+        expect(streamSync?.streamStates?.['waiting-stream']).toMatchObject({
+          status: STREAM_STATUS.WAITING,
+        });
+        expect(streamSync?.streamStates?.['dead-stream']).toMatchObject({
+          status: STREAM_PHASE.FAILED,
+        });
       });
     } finally {
-      StreamStatusService.clear('waiting-stream', { emit: false });
-      StreamStatusService.clear('dead-stream', { emit: false });
+      bridgeStatus(bridge).clearStream('waiting-stream');
+      bridgeStatus(bridge).clearStream('dead-stream');
       bridge.dispose();
     }
   });
@@ -782,18 +792,42 @@ describe('DesktopProgressBridge', () => {
         }),
       ]),
     });
-    const { StreamStatusService } =
-      await import('@agent/runtime/StreamStatusService');
 
     try {
       await vi.waitFor(() => {
         expect(detectWaitingStreams).toHaveBeenCalledOnce();
-        expect(StreamStatusService.get('broken-stream')).toBe(
-          STREAM_STATUS.ERROR,
+        expect(bridgeStatus(bridge).get('broken-stream')).toBe(
+          STREAM_PHASE.FAILED,
         );
       });
     } finally {
-      StreamStatusService.clear('broken-stream', { emit: false });
+      bridgeStatus(bridge).clearStream('broken-stream');
+      bridge.dispose();
+    }
+  });
+
+  it('marks restored waiting streams as failed when no waiting session remains', async () => {
+    const detectWaitingStreams = vi.fn(async () => new Set<StreamTabId>());
+    const bridge = await createBridge([], {
+      detectWaitingStreams,
+      streamSnapshotStore: createStreamSnapshotStore([
+        restoredSnapshot({
+          streamId: 'stale-waiting-stream',
+          executionId: 'abc123',
+          lastKnownStatus: STREAM_PHASE.WAITING,
+        }),
+      ]),
+    });
+
+    try {
+      await vi.waitFor(() => {
+        expect(detectWaitingStreams).toHaveBeenCalledOnce();
+        expect(bridgeStatus(bridge).get('stale-waiting-stream')).toBe(
+          STREAM_PHASE.FAILED,
+        );
+      });
+    } finally {
+      bridgeStatus(bridge).clearStream('stale-waiting-stream');
       bridge.dispose();
     }
   });
@@ -823,22 +857,20 @@ describe('DesktopProgressBridge', () => {
         }),
       ]),
     });
-    const { StreamStatusService } =
-      await import('@agent/runtime/StreamStatusService');
 
     try {
       await vi.waitFor(() => {
         expect(detectWaitingStreams).toHaveBeenCalledOnce();
-        expect(StreamStatusService.get('active-stream')).toBe(
+        expect(bridgeStatus(bridge).get('active-stream')).toBe(
           STREAM_STATUS.RUNNING,
         );
-        expect(StreamStatusService.get('dead-stream')).toBe(
-          STREAM_STATUS.ERROR,
+        expect(bridgeStatus(bridge).get('dead-stream')).toBe(
+          STREAM_PHASE.FAILED,
         );
       });
     } finally {
-      StreamStatusService.clear('active-stream', { emit: false });
-      StreamStatusService.clear('dead-stream', { emit: false });
+      bridgeStatus(bridge).clearStream('active-stream');
+      bridgeStatus(bridge).clearStream('dead-stream');
       bridge.dispose();
     }
   });
@@ -874,22 +906,20 @@ describe('DesktopProgressBridge', () => {
         }),
       ]),
     });
-    const { StreamStatusService } =
-      await import('@agent/runtime/StreamStatusService');
 
     try {
       await vi.waitFor(() => {
         expect(detectWaitingStreams).toHaveBeenCalledOnce();
-        expect(StreamStatusService.get('active-stream')).toBe(
+        expect(bridgeStatus(bridge).get('active-stream')).toBe(
           STREAM_STATUS.RUNNING,
         );
-        expect(StreamStatusService.get('dead-stream')).toBe(
-          STREAM_STATUS.ERROR,
+        expect(bridgeStatus(bridge).get('dead-stream')).toBe(
+          STREAM_PHASE.FAILED,
         );
       });
     } finally {
-      StreamStatusService.clear('active-stream', { emit: false });
-      StreamStatusService.clear('dead-stream', { emit: false });
+      bridgeStatus(bridge).clearStream('active-stream');
+      bridgeStatus(bridge).clearStream('dead-stream');
       bridge.dispose();
     }
   });
@@ -912,8 +942,6 @@ describe('DesktopProgressBridge', () => {
         }),
       ]),
     });
-    const { StreamStatusService } =
-      await import('@agent/runtime/StreamStatusService');
 
     try {
       await vi.waitFor(() => expect(detectWaitingStreams).toHaveBeenCalled());
@@ -921,13 +949,13 @@ describe('DesktopProgressBridge', () => {
       finishDetection(new Set<StreamTabId>(['race-stream']));
 
       await vi.waitFor(() => {
-        expect(StreamStatusService.get('race-stream')).toBe(
+        expect(bridgeStatus(bridge).get('race-stream')).toBe(
           STREAM_STATUS.RUNNING,
         );
       });
     } finally {
       finishDetection(new Set());
-      StreamStatusService.clear('race-stream', { emit: false });
+      bridgeStatus(bridge).clearStream('race-stream');
       bridge.dispose();
     }
   });
@@ -998,15 +1026,13 @@ describe('DesktopProgressBridge', () => {
       .spyOn(streamLogs, 'endRunningGroupsForStreams')
       .mockRejectedValueOnce(new Error('group close failed'))
       .mockResolvedValueOnce(['waiting-stream']);
-    const { StreamStatusService } =
-      await import('@agent/runtime/StreamStatusService');
 
     try {
       await vi.waitFor(() => expect(detectWaitingStreams).toHaveBeenCalled());
       finishDetection(new Set<StreamTabId>(['waiting-stream']));
 
       await vi.waitFor(() => {
-        expect(StreamStatusService.get('waiting-stream')).toBe(
+        expect(bridgeStatus(bridge).get('waiting-stream')).toBe(
           STREAM_STATUS.WAITING,
         );
         expect(closeSpy).toHaveBeenCalledTimes(2);
@@ -1017,7 +1043,7 @@ describe('DesktopProgressBridge', () => {
       });
     } finally {
       finishDetection(new Set());
-      StreamStatusService.clear('waiting-stream', { emit: false });
+      bridgeStatus(bridge).clearStream('waiting-stream');
       bridge.dispose();
     }
   });
@@ -1033,18 +1059,16 @@ describe('DesktopProgressBridge', () => {
         }),
       ]),
     });
-    const { StreamStatusService } =
-      await import('@agent/runtime/StreamStatusService');
 
     try {
       await vi.waitFor(() => {
         expect(detectWaitingStreams).toHaveBeenCalledWith(new Map());
-        expect(StreamStatusService.get('no-execution-stream')).toBe(
-          STREAM_STATUS.ERROR,
+        expect(bridgeStatus(bridge).get('no-execution-stream')).toBe(
+          STREAM_PHASE.FAILED,
         );
       });
     } finally {
-      StreamStatusService.clear('no-execution-stream', { emit: false });
+      bridgeStatus(bridge).clearStream('no-execution-stream');
       bridge.dispose();
     }
   });
@@ -1972,8 +1996,6 @@ describe('DesktopProgressBridge', () => {
       retrieveSessionResumeData,
       runAgent,
     });
-    const { StreamStatusService } =
-      await import('@agent/runtime/StreamStatusService');
 
     try {
       await expect(bridge.tryResumeStream('stream-1')).resolves.toBe(true);
@@ -1993,7 +2015,7 @@ describe('DesktopProgressBridge', () => {
       );
       expectWorkflowResume(runAgent, taskState, executionId);
     } finally {
-      StreamStatusService.clear('stream-1', { emit: false });
+      bridgeStatus(bridge).clearStream('stream-1');
       bridge.dispose();
     }
   });
@@ -2060,8 +2082,6 @@ describe('DesktopProgressBridge', () => {
         }),
       ]),
     });
-    const { StreamStatusService } =
-      await import('@agent/runtime/StreamStatusService');
 
     try {
       await expect(bridge.tryResumeStream('stream-1')).resolves.toBe(true);
@@ -2080,7 +2100,7 @@ describe('DesktopProgressBridge', () => {
       );
       expectWorkflowResume(runAgent, taskState, executionId);
     } finally {
-      StreamStatusService.clear('stream-1', { emit: false });
+      bridgeStatus(bridge).clearStream('stream-1');
       bridge.dispose();
     }
   });
@@ -2106,8 +2126,6 @@ describe('DesktopProgressBridge', () => {
     });
     const { ToolUseFollowUpQueue } =
       await import('@agent/followUp/ToolUseFollowUpQueueManager');
-    const { StreamStatusService } =
-      await import('@agent/runtime/StreamStatusService');
     const taskState = {
       agentConfig: {
         agent: 'search',
@@ -2165,7 +2183,7 @@ describe('DesktopProgressBridge', () => {
       });
     } finally {
       ToolUseFollowUpQueue.release('stream-1');
-      StreamStatusService.clear('stream-1', { emit: false });
+      bridgeStatus(bridge).clearStream('stream-1');
       bridge.dispose();
     }
   });
@@ -2192,8 +2210,6 @@ describe('DesktopProgressBridge', () => {
     });
     const { ToolUseFollowUpQueue } =
       await import('@agent/followUp/ToolUseFollowUpQueueManager');
-    const { StreamStatusService } =
-      await import('@agent/runtime/StreamStatusService');
 
     try {
       bridge.handleProgressEvent('setTaskState', {
@@ -2217,10 +2233,10 @@ describe('DesktopProgressBridge', () => {
       expect(ToolUseFollowUpQueue.getAll('stream-1')).toEqual([
         'queued follow-up',
       ]);
-      expect(StreamStatusService.get('stream-1')).toBe(STREAM_STATUS.WAITING);
+      expect(bridgeStatus(bridge).get('stream-1')).toBe(STREAM_STATUS.WAITING);
     } finally {
       ToolUseFollowUpQueue.release('stream-1');
-      StreamStatusService.clear('stream-1', { emit: false });
+      bridgeStatus(bridge).clearStream('stream-1');
       bridge.dispose();
     }
   });
@@ -2228,18 +2244,18 @@ describe('DesktopProgressBridge', () => {
   it('does not launch a duplicate resume for active streams', async () => {
     const retrieveSessionResumeData = vi.fn(async () => null);
     const bridge = await createBridge([], { retrieveSessionResumeData });
-    const { StreamStatusService } =
-      await import('@agent/runtime/StreamStatusService');
 
     try {
-      StreamStatusService.set('stream-1', STREAM_STATUS.RUNNING, {
-        emit: false,
-      });
+      seedStreamStatusForTest(
+        bridgeStatus(bridge),
+        'stream-1',
+        STREAM_STATUS.RUNNING,
+      );
 
       await expect(bridge.tryResumeStream('stream-1')).resolves.toBe(false);
       expect(retrieveSessionResumeData).not.toHaveBeenCalled();
     } finally {
-      StreamStatusService.clear('stream-1', { emit: false });
+      bridgeStatus(bridge).clearStream('stream-1');
       bridge.dispose();
     }
   });
@@ -2270,8 +2286,6 @@ describe('DesktopProgressBridge', () => {
       };
     });
     const bridge = await createBridge([], { retrieveSessionResumeData });
-    const { StreamStatusService } =
-      await import('@agent/runtime/StreamStatusService');
 
     try {
       bridge.handleProgressEvent('setTaskState', {
@@ -2293,7 +2307,7 @@ describe('DesktopProgressBridge', () => {
       await expect(firstResume).resolves.toBe(true);
       expect(retrieveSessionResumeData).toHaveBeenCalledTimes(1);
     } finally {
-      StreamStatusService.clear('stream-1', { emit: false });
+      bridgeStatus(bridge).clearStream('stream-1');
       bridge.dispose();
     }
   });

--- a/src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts
@@ -119,8 +119,8 @@ async function loadBridgeModule(): Promise<
   }));
   vi.doMock('@agent/runtime/StreamStatusService', () => ({
     StreamStatusService: {
-      set: vi.fn(),
-      get: vi.fn(() => STREAM_STATUS.STOPPED),
+      transition: vi.fn(),
+      get: vi.fn(() => STREAM_PHASE.CANCELLED),
       isActiveOrResuming: vi.fn(() => false),
     },
   }));
@@ -176,6 +176,10 @@ describe('DesktopProgressEventBridge', () => {
   function createBridge(overrides: Partial<BridgeOptions> = {}) {
     return module.createDesktopProgressEventBridge({
       state: makeMockState(),
+      streamStatus: {
+        get: vi.fn(() => STREAM_PHASE.CANCELLED),
+        transition: vi.fn(() => true),
+      },
       streamSnapshotStore: undefined,
       sendMessage: () => {},
       logger: makeLogger(),
@@ -284,6 +288,35 @@ describe('DesktopProgressEventBridge', () => {
       }
     });
 
+    it('hydrates stream status through the injected session status plane', () => {
+      const streamStatus = {
+        get: vi.fn(() => STREAM_PHASE.CANCELLED),
+        transition: vi.fn(() => true),
+      };
+
+      const bridge = createBridge({
+        streamStatus,
+        streamSnapshotStore: createSnapshotStore({
+          hydrated: [
+            createSnapshot({
+              streamId: 'status-ghost',
+              lastKnownStatus: STREAM_PHASE.WAITING,
+            }),
+          ],
+        }),
+      });
+
+      try {
+        expect(streamStatus.transition).toHaveBeenCalledWith(
+          'status-ghost',
+          STREAM_PHASE.WAITING,
+          'restart-repair',
+        );
+      } finally {
+        bridge.dispose();
+      }
+    });
+
     it('does not resurrect streams that became live in this bridge', () => {
       const ensureStream = vi.fn();
       const bridge = createBridge({
@@ -310,7 +343,7 @@ describe('DesktopProgressEventBridge', () => {
         bridge.onProgressEvent('updateStreamStatus', {
           streamId: 'live-stream',
           status: STREAM_STATUS.RUNNING,
-          previousStatus: STREAM_STATUS.STOPPED,
+          previousStatus: STREAM_PHASE.CANCELLED,
         });
         bridge.hydrateRestoredStreams();
 
@@ -397,6 +430,10 @@ describe('DesktopProgressEventBridge', () => {
 
     it('removes ghost and persists snapshot on updateStreamStatus', async () => {
       const upsert = vi.fn(async () => {});
+      const streamStatus = {
+        get: vi.fn(() => STREAM_PHASE.WAITING),
+        transition: vi.fn(() => true),
+      };
 
       const bridge = createBridge({
         state: makeMockState({
@@ -409,6 +446,7 @@ describe('DesktopProgressEventBridge', () => {
             ensureLoaded: vi.fn(async () => {}),
           },
         }),
+        streamStatus,
         streamSnapshotStore: createSnapshotStore({
           hydrated: [createSnapshot({ streamId: 'status-stream' })],
           upsert,
@@ -419,12 +457,17 @@ describe('DesktopProgressEventBridge', () => {
         bridge.onProgressEvent('updateStreamStatus', {
           streamId: 'status-stream',
           status: STREAM_STATUS.RUNNING,
-          previousStatus: STREAM_STATUS.STOPPED,
+          previousStatus: STREAM_PHASE.CANCELLED,
         });
 
         expect(bridge.hasRestoredStream('status-stream')).toBe(false);
         await settleMicrotasks();
-        expect(upsert).toHaveBeenCalled();
+        expect(upsert).toHaveBeenCalledWith(
+          expect.objectContaining({
+            streamId: 'status-stream',
+            lastKnownStatus: STREAM_PHASE.WAITING,
+          }),
+        );
       } finally {
         bridge.dispose();
       }

--- a/src/test-kernel/helpers/streamStatusTestUtils.ts
+++ b/src/test-kernel/helpers/streamStatusTestUtils.ts
@@ -1,0 +1,64 @@
+import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
+import {
+  STREAM_STATUS,
+  StreamPhaseSchema,
+  type StreamPhase,
+  type StreamStatus,
+  type StreamSubstate,
+  type StreamTabId,
+  streamStatusToPhase,
+  streamStatusToSubstate,
+} from '@shared/schemas';
+
+interface StreamStatusMachineInternals {
+  readonly phases: Map<
+    StreamTabId,
+    { readonly phase: StreamPhase; readonly substate?: StreamSubstate }
+  >;
+  readonly reservations: Set<StreamTabId>;
+}
+
+function internals(machine: StreamStatusMachine): StreamStatusMachineInternals {
+  return machine as unknown as StreamStatusMachineInternals;
+}
+
+export function clearStreamStatusForTest(
+  machine: StreamStatusMachine,
+  streamId: StreamTabId,
+): void {
+  const state = internals(machine);
+  state.reservations.delete(streamId);
+  state.phases.delete(streamId);
+}
+
+export function clearAllStreamStatusesForTest(
+  machine: StreamStatusMachine,
+): void {
+  const state = internals(machine);
+  state.reservations.clear();
+  state.phases.clear();
+}
+
+export function seedStreamStatusForTest(
+  machine: StreamStatusMachine,
+  streamId: StreamTabId,
+  status: StreamPhase | StreamStatus,
+): void {
+  const state = internals(machine);
+  state.reservations.delete(streamId);
+  if (status === STREAM_STATUS.READY) {
+    state.phases.delete(streamId);
+    return;
+  }
+
+  const phase = StreamPhaseSchema.safeParse(status);
+  const substate = phase.success
+    ? undefined
+    : streamStatusToSubstate(status as StreamStatus);
+  state.phases.set(streamId, {
+    phase: phase.success
+      ? phase.data
+      : streamStatusToPhase(status as StreamStatus),
+    ...(substate ? { substate } : {}),
+  });
+}

--- a/src/test-kernel/progressView/ProcessOutputState.vitest.ts
+++ b/src/test-kernel/progressView/ProcessOutputState.vitest.ts
@@ -23,6 +23,8 @@ import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   AgentCategory,
   createStreamState,
+  STREAM_PHASE,
+  STREAM_SUBSTATE,
   STREAM_STATUS,
   type ProgressViewOutboundMessage,
   type StreamTabId,
@@ -148,6 +150,112 @@ describe('process output frontend state', () => {
     const outputs = getState().processOutputs.get(streamId);
     expect(outputs?.has('active-process')).toBe(true);
     expect(outputs?.has('stale-process')).toBe(false);
+  });
+
+  it('updates and clears stream substate with status changes', () => {
+    const streamId = 'stream-a' as StreamTabId;
+    const state = createInitialState();
+    state.streamById.set(streamId, {
+      name: streamId,
+      label: 'stream-a',
+      agentCategory: AgentCategory.Workflow,
+      creationTimestamp: 1,
+    });
+    state.streamStates.set(
+      streamId,
+      createStreamState(AgentCategory.Workflow, {
+        status: STREAM_PHASE.RUNNING,
+      } satisfies Partial<StreamState>),
+    );
+    const { ctx, getState } = createContext(state);
+
+    dispatch(
+      streamMetaHandlers,
+      {
+        command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_STATUS,
+        stream: streamId,
+        status: STREAM_PHASE.RUNNING,
+        substate: STREAM_SUBSTATE.STARTING,
+      },
+      ctx,
+    );
+
+    expect(getState().streamStates.get(streamId)?.substate).toBe(
+      STREAM_SUBSTATE.STARTING,
+    );
+
+    dispatch(
+      streamMetaHandlers,
+      {
+        command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_STATUS,
+        stream: streamId,
+        status: STREAM_PHASE.COMPLETED,
+      },
+      ctx,
+    );
+
+    expect(getState().streamStates.get(streamId)?.status).toBe(
+      STREAM_PHASE.COMPLETED,
+    );
+    expect(getState().streamStates.get(streamId)?.substate).toBeUndefined();
+  });
+
+  it('clears stream substate when full metadata sync omits it', () => {
+    const streamId = 'stream-a' as StreamTabId;
+    const state = createInitialState();
+    state.activeStreamId = streamId;
+    state.streamById.set(streamId, {
+      name: streamId,
+      label: 'stream-a',
+      agentCategory: AgentCategory.Workflow,
+      creationTimestamp: 1,
+    });
+    state.streamStates.set(
+      streamId,
+      createStreamState(AgentCategory.Workflow, {
+        status: STREAM_PHASE.RUNNING,
+        substate: STREAM_SUBSTATE.STARTING,
+      } satisfies Partial<StreamState>),
+    );
+    const { ctx, getState } = createContext(state);
+
+    dispatch(
+      streamLifecycleHandlers,
+      {
+        command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+        streams: [
+          {
+            name: streamId,
+            label: 'stream-a',
+            agentCategory: AgentCategory.Workflow,
+            creationTimestamp: 1,
+          },
+        ],
+        activeStream: streamId,
+        agentFilter: 'all',
+        streamStates: {
+          [streamId]: {
+            kind: AgentCategory.Workflow,
+            status: STREAM_PHASE.COMPLETED,
+            lastTimestamp: 2,
+            conversationProgress: {
+              conversationTurns: 0,
+              toolCallCount: 0,
+            },
+            activeSubagents: [],
+            finishedSubagentCount: 0,
+            activeProcesses: [],
+            finishedProcessCount: 0,
+          },
+        },
+      },
+      ctx,
+    );
+
+    expect(getState().streamStates.get(streamId)?.status).toBe(
+      STREAM_PHASE.COMPLETED,
+    );
+    expect(getState().streamStates.get(streamId)?.substate).toBeUndefined();
   });
 
   it('clears a stream parent when update parent stream receives null', () => {

--- a/src/test-kernel/progressView/StreamTree.vitest.ts
+++ b/src/test-kernel/progressView/StreamTree.vitest.ts
@@ -9,8 +9,9 @@ import type { StreamState } from '@progressView/frontend/store';
 import {
   AgentCategory,
   createStreamState,
+  STREAM_PHASE,
   STREAM_STATUS,
-  type StreamStatus,
+  type StreamLifecycleStatus,
   type StreamTabInfo,
 } from '@shared/schemas';
 
@@ -24,7 +25,7 @@ function stream(name: string, parentStreamId?: string): StreamTabInfo {
   };
 }
 
-function streamState(status: StreamStatus): StreamState {
+function streamState(status: StreamLifecycleStatus): StreamState {
   return createStreamState(AgentCategory.ToolUse, { status });
 }
 
@@ -53,8 +54,8 @@ describe('progress stream tree policy', () => {
       ['root', [stream('child-a', 'root'), stream('child-b', 'root')]],
     ]);
     const streamStates = new Map([
-      ['child-a', streamState(STREAM_STATUS.STOPPED)],
-      ['child-b', streamState(STREAM_STATUS.ERROR)],
+      ['child-a', streamState(STREAM_PHASE.CANCELLED)],
+      ['child-b', streamState(STREAM_PHASE.FAILED)],
     ]);
 
     const projection = computeStreamTreeProjection({
@@ -74,7 +75,7 @@ describe('progress stream tree policy', () => {
       ['child', [stream('grandchild', 'child')]],
     ]);
     const streamStates = new Map([
-      ['child', streamState(STREAM_STATUS.STOPPED)],
+      ['child', streamState(STREAM_PHASE.CANCELLED)],
       ['grandchild', streamState(STREAM_STATUS.RUNNING)],
     ]);
 
@@ -112,7 +113,7 @@ describe('progress stream tree policy', () => {
   it('allows users to keep a finished parent expanded', () => {
     const childStreamsByParent = new Map([['root', [stream('child', 'root')]]]);
     const streamStates = new Map([
-      ['child', streamState(STREAM_STATUS.STOPPED)],
+      ['child', streamState(STREAM_PHASE.CANCELLED)],
     ]);
 
     const projection = computeStreamTreeProjection({
@@ -130,8 +131,8 @@ describe('progress stream tree policy', () => {
       ['child', [stream('root', 'child')]],
     ]);
     const streamStates = new Map([
-      ['root', streamState(STREAM_STATUS.STOPPED)],
-      ['child', streamState(STREAM_STATUS.STOPPED)],
+      ['root', streamState(STREAM_PHASE.CANCELLED)],
+      ['child', streamState(STREAM_PHASE.CANCELLED)],
     ]);
 
     assert.equal(
@@ -147,7 +148,7 @@ describe('progress stream tree policy', () => {
   it('guards direct self-loops', () => {
     const childStreamsByParent = new Map([['root', [stream('root', 'root')]]]);
     const streamStates = new Map([
-      ['root', streamState(STREAM_STATUS.STOPPED)],
+      ['root', streamState(STREAM_PHASE.CANCELLED)],
     ]);
 
     assert.equal(

--- a/src/test-kernel/shared/StreamMetadata.vitest.ts
+++ b/src/test-kernel/shared/StreamMetadata.vitest.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   AgentCategory,
+  STREAM_SUBSTATE,
   STREAM_STATUS,
   type ActiveChildInfo,
 } from '@shared/schemas';
@@ -9,17 +10,19 @@ import { buildStreamMetadata } from '@shared/streams/streamMetadata';
 
 describe('buildStreamMetadata', () => {
   it('fills backend-owned defaults for a stream state metadata payload', () => {
-    expect(buildStreamMetadata({ kind: AgentCategory.Workflow })).toMatchObject(
-      {
-        kind: AgentCategory.Workflow,
-        status: STREAM_STATUS.READY,
-        conversationProgress: { conversationTurns: 0, toolCallCount: 0 },
-        activeSubagents: [],
-        finishedSubagentCount: 0,
-        activeProcesses: [],
-        finishedProcessCount: 0,
-      },
-    );
+    const metadata = buildStreamMetadata({ kind: AgentCategory.Workflow });
+
+    expect(metadata).toMatchObject({
+      kind: AgentCategory.Workflow,
+      status: STREAM_STATUS.READY,
+      conversationProgress: { conversationTurns: 0, toolCallCount: 0 },
+      activeSubagents: [],
+      finishedSubagentCount: 0,
+      activeProcesses: [],
+      finishedProcessCount: 0,
+    });
+    expect(Object.hasOwn(metadata, 'substate')).toBe(true);
+    expect(metadata.substate).toBeUndefined();
   });
 
   it('preserves supplied status, progress, child badges, and timestamps', () => {
@@ -33,6 +36,7 @@ describe('buildStreamMetadata', () => {
       buildStreamMetadata({
         kind: AgentCategory.ToolUse,
         status: STREAM_STATUS.RUNNING,
+        substate: STREAM_SUBSTATE.STARTING,
         lastTimestamp: 123,
         conversationProgress: { conversationTurns: 2, toolCallCount: 5 },
         activeSubagents: [child],
@@ -43,6 +47,7 @@ describe('buildStreamMetadata', () => {
     ).toEqual({
       kind: AgentCategory.ToolUse,
       status: STREAM_STATUS.RUNNING,
+      substate: STREAM_SUBSTATE.STARTING,
       lastTimestamp: 123,
       conversationProgress: { conversationTurns: 2, toolCallCount: 5 },
       activeSubagents: [child],

--- a/src/test-kernel/shared/StreamStatusDisplay.vitest.ts
+++ b/src/test-kernel/shared/StreamStatusDisplay.vitest.ts
@@ -34,6 +34,30 @@ describe('stream status display labels', () => {
     expect(formatStreamStatusLabel(undefined, { missingLabel: '-' })).toBe('-');
   });
 
+  it('uses substate display keys for current running phases', () => {
+    expect(
+      formatStreamStatusLabel(STREAM_PHASE.RUNNING, {
+        style: 'progressHeader',
+        substate: STREAM_SUBSTATE.STARTING,
+      }),
+    ).toBe('Initializing');
+    expect(
+      formatStreamStatusLabel(STREAM_PHASE.RUNNING, {
+        style: 'cli',
+        substate: STREAM_SUBSTATE.RESUMING,
+      }),
+    ).toBe('resuming');
+    expect(
+      streamStatusDisplayKey(STREAM_PHASE.RUNNING, STREAM_SUBSTATE.STARTING),
+    ).toBe(STREAM_SUBSTATE.STARTING);
+    expect(
+      streamStatusIndicatorClass(
+        STREAM_PHASE.RUNNING,
+        STREAM_SUBSTATE.RESUMING,
+      ),
+    ).toBe('is-resuming');
+  });
+
   it.each([
     [STREAM_STATUS.INITIALIZING, STREAM_SUBSTATE.STARTING, 'is-starting'],
     [STREAM_STATUS.RESUMING, STREAM_SUBSTATE.RESUMING, 'is-resuming'],

--- a/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
@@ -4,11 +4,12 @@ import * as path from 'node:path';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { seedStreamStatusForTest } from '@test/helpers/streamStatusTestUtils';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
-import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+import { STREAM_PHASE, type StreamTabId } from '@shared/schemas';
 import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
 import { ExecutionsTool } from '@tools/ExecutionsTool';
 
@@ -129,9 +130,12 @@ describe('ExecutionsTool', () => {
     );
 
     try {
-      session.executions.trackAgentExecution(handle, {
-        status: STREAM_STATUS.WAITING,
-      });
+      session.executions.track(handle);
+      seedStreamStatusForTest(
+        session.status,
+        childStreamId,
+        STREAM_PHASE.WAITING,
+      );
       mocks.readMeta.mockResolvedValue({
         timestamp: '2026-06-15T09:36:02.345Z',
         category: 'toolUse',

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -20,7 +20,7 @@ import { deriveRunOutcome } from '@common/constants/streamStatus';
 
 // Local imports - shared
 import type { ExecutionId, StreamTabId, StorageKey } from '@shared/schemas';
-import { STREAM_STATUS } from '@shared/schemas';
+import { RUN_OUTCOME, STREAM_PHASE, STREAM_STATUS } from '@shared/schemas';
 
 // Local imports - utils
 import { formatDuration } from '@utils/core';
@@ -125,7 +125,7 @@ export function createChildStream(
   );
   if (options.toolName) handle.toolName = options.toolName;
   session.executions.trackAgentExecution(handle, {
-    status: STREAM_STATUS.RUNNING,
+    status: STREAM_PHASE.RUNNING,
   });
 
   return {
@@ -136,19 +136,19 @@ export function createChildStream(
     waitForInput: () => {
       session.executions.updateAgentExecutionStatus(
         handle,
-        STREAM_STATUS.WAITING,
+        STREAM_PHASE.WAITING,
       );
     },
     beginTurn: () => {
       session.executions.updateAgentExecutionStatus(
         handle,
-        STREAM_STATUS.RUNNING,
+        STREAM_PHASE.RUNNING,
       );
     },
     failTurn: () => {
       session.executions.updateAgentExecutionStatus(
         handle,
-        STREAM_STATUS.ERROR,
+        STREAM_PHASE.FAILED,
       );
     },
     finalize: (finalizeOptions) => {
@@ -203,7 +203,7 @@ function finalizeChildStream(args: FinalizeChildStreamArgs): void {
   const currentStatus = session.executions.getStatus(handle).status;
   let finalStatus: ChildStreamTerminalStatus;
   if (
-    currentStatus === STREAM_STATUS.STOPPED ||
+    currentStatus === STREAM_PHASE.CANCELLED ||
     requestedStatus === STREAM_STATUS.STOPPED
   ) {
     finalStatus = STREAM_STATUS.STOPPED;
@@ -238,7 +238,14 @@ function finalizeChildStream(args: FinalizeChildStreamArgs): void {
     ...(error ? { error } : {}),
   });
 
-  session.executions.finishAgentExecution(handle, { status: finalStatus });
+  session.executions.finishAgentExecution(handle, {
+    status:
+      outcome === RUN_OUTCOME.FAILED
+        ? STREAM_PHASE.FAILED
+        : outcome === RUN_OUTCOME.CANCELLED
+          ? STREAM_PHASE.CANCELLED
+          : STREAM_PHASE.COMPLETED,
+  });
   disposeTrace();
 
   if (options?.autoClose) {

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -280,6 +280,9 @@ export function attachTranscriptRecorder(
         });
         return;
 
+      case 'status':
+        return;
+
       case 'context.state': {
         const utilizationPercent =
           (event.inputTokens / event.contextWindow) * 100;


### PR DESCRIPTION
## Summary

Implements #6963 Stage 2 by moving stream phase ownership into `StreamStatusMachine`. Runtime lifecycle, wait/resume, user-stop, restart repair, desktop hydration, and progress/webview updates now go through named transitions over the five-value `StreamPhase` model, with `clearStream()` remaining absence handling rather than a transition.

The PR also adds the trace `status` event arm and makes `updateStreamStatus` a projection of that event. The webview/progress surfaces now receive `completed` and `cancelled` as distinct phases; that display distinction is the one intentional behavior change flagged by the architecture proposal.

## Issue acceptance gates

Addresses #6963.

- One writer: `rg -n "\\bstreamStatus\\.set\\b|\\bStreamStatusService\\.set\\b" src packages --glob '!node_modules/**'` has no matches.
- Transition-table coverage: the exhaustive stage-0 table now exercises the live machine, with the acquire/release reservation invariant pair in `StreamStatusService.vitest.ts`.
- Projector equivalence: status trace events and progress bus projection are asserted in the same runtime test file.
- CLI byte parity: focused `texra run`/workflow/headless CLI tests passed, including `RunExecution`, `WorkflowRunCommand`, `AgentsRunCommand`, `MultiAgentRunCommand`, `CliRootArgs`, and `RunProgressRenderer`.

## Single source of truth

`StreamStatusMachine` on `SessionHandle.status` is now the single source of truth for stream phase transitions, transition causes, reservation ownership, substate, and completion preservation.

## Duplication and abstraction budget

Removed direct mutable status writes, per-call-site terminal guards, silent `emit:false` repairs, and the `terminalStatus` progress side-channel. The added mass lives in the transition machine and acceptance tests that enforce the migration contract while Stage 5 still needs bus projections.

## Host impact

Extension: stream status updates flow through the machine and `StatusEvent` projection; progress/webview display distinguishes completed and cancelled.

Desktop: restart repair and snapshot hydration use named machine transitions instead of direct status writes. Persisted snapshots read the owning window's session status plane rather than the process-global compatibility alias.

CLI: headless result formatting remains byte-compatible; renderer projections map phases back to existing terminal output categories.

## Scheduled refactoring

Legacy ledger #6981 gets the Stage 2 row for the `StatusEvent` to `updateStreamStatus` projection and the `StreamStatusRegistry` compatibility alias. Removal triggers: Stage 5 (#6968) deletes the bus projection with the legacy bus keys; D1 (#6982) removes the alias once hosts construct/use sessions explicitly.

## Validation

- `corepack pnpm exec prettier --write` on touched files
- `npm run typecheck -- --pretty false`
- `npm test`
- `npm test -- --run src/test-kernel/agent/runtime/StreamStatusService.vitest.ts src/test-kernel/progressView/SessionRunFactProjectorEquivalence.vitest.ts src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/cli/RunProgressRenderer.vitest.mts`
- `npm test -- --run src/test-kernel/progressView/ProcessOutputState.vitest.ts src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts`
- `npm test -- --run src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/cli/SubagentListDisplay.vitest.mts`
- `npm run lint` (passes with existing warnings outside this patch)
- `npm run compile:fast`
- `git diff --check`

Closes #6963

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Centralizes all stream lifecycle and restart-repair behavior in a new state machine; incorrect transitions or projection could leave tabs stuck or show wrong terminal states across CLI, desktop, and extension.
> 
> **Overview**
> **Stage 2 of the session-scoped runtime work:** stream phase is owned by **`StreamStatusMachine`** on **`SessionHandle.status`**, replacing direct `StreamStatusService.set` / `streamStatus.set` calls with named **`transition`**, **`transitionToWaiting`**, **`transitionToTerminal`**, acquire/release reservation, and **`clearStream`** for absence.
> 
> Runtime paths (launch, lifecycle, wait/resume, user-stop, retry, restart repair, child streams, follow-up resume) and hosts (**desktop**, **extension**, **CLI**) read/write through the machine. Progress payloads use **`StreamPhase`** plus optional **`substate`** (`starting` / `resuming`); **`terminalStatus`** on the bus is dropped. Trace emits **`StatusEvent`**, which projects to **`updateStreamStatus`**.
> 
> **UI:** status bars, tabs, headers, and slash **`/status`** pass **`substate`** into **`formatStreamStatusLabel`** so launch/resume overlays show correctly. **Completed** vs **cancelled** terminal phases are shown distinctly in progress views (intentional display change). CLI state mirrors **`StreamLifecycleStatus`** and substates; headless progress renderer maps phases to existing terminal labels.
> 
> **Docs:** proposal status bumped to Stages 0–2 landed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94c34f50b1c5d9436e6dfb490a0d44f89dcb86ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

