### PR TITLE
[codex] Normalize usage route at parse boundary

### DIFF
--- a/packages/extension/src/progressView/frontend/components/UsagePanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UsagePanel.ts
@@ -8,11 +8,7 @@ import { when } from 'lit/directives/when.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
 // Local imports - shared schemas
-import {
-  resolveUsageRoute,
-  type TokenUsageStats,
-  type UsageRoute,
-} from '@shared/schemas';
+import type { TokenUsageStats, UsageRoute } from '@shared/schemas';
 
 // Local imports - shared styles
 import { designTokens } from '@shared/styles';
@@ -290,7 +286,7 @@ export class UsagePanel extends LitElement {
   }
 
   private renderCostRoute(cost: number): TemplateResult {
-    const route = resolveUsageRoute(this.usage);
+    const route = this.usage?.usageRoute;
     const badge = usageRouteBadge(route);
     if (!badge) return html`${formatCostUsd(cost)}`;
 
@@ -346,7 +342,7 @@ export class UsagePanel extends LitElement {
   private buildUsageLabel(): string {
     if (!this.usage) return '';
     const { inputTokens, outputTokens, cost } = this.usage;
-    const costLabel = usageCostLabel(cost, resolveUsageRoute(this.usage));
+    const costLabel = usageCostLabel(cost, this.usage.usageRoute);
     return `Total usage: ${formatCompactTokenCount(inputTokens)} input tokens, ${formatCompactTokenCount(outputTokens)} output tokens, ${costLabel}`;
   }
 }

--- a/src/agent/modelHandlers/openai/modelHandlerCodex.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerCodex.ts
@@ -356,10 +356,8 @@ export class ModelHandlerCodex extends ModelHandlerOpenAIResponse {
 
   /**
    * Tag subscription rounds so downstream usage logging and the UI can record
-   * them while making clear they are free (the cost above is already 0). The
-   * flag rides {@link NormalizedUsage} through `latestUsage` to
-   * {@link UsageMonitor}; on the API-key fallback it is omitted and real cost
-   * applies.
+   * them while making clear they are free (the cost above is already 0). On the
+   * API-key fallback the route is omitted and real cost applies.
    */
   public override normalizeUsage(
     rawUsage: ResponseUsage,
@@ -367,7 +365,7 @@ export class ModelHandlerCodex extends ModelHandlerOpenAIResponse {
   ): NormalizedUsage {
     const usage = super.normalizeUsage(rawUsage, responseTimeMs);
     return this.usingSubscription()
-      ? { ...usage, viaChatGptSubscription: true }
+      ? { ...usage, usageRoute: 'chatgpt-subscription' }
       : usage;
   }
 

--- a/src/agent/types/NormalizedUsage.ts
+++ b/src/agent/types/NormalizedUsage.ts
@@ -4,7 +4,11 @@
  */
 import { z } from 'zod';
 
-import { TokenCountSchema, TokenUsageStatsSchema } from '@shared/schemas';
+import {
+  TokenCountSchema,
+  TokenUsageStatsBaseSchema,
+  UsageRouteSchema,
+} from '@shared/schemas';
 
 /** Provider identifiers for usage tracking. */
 export const UsageProviderSchema = z.enum([
@@ -28,13 +32,13 @@ export type UsageProvider = z.infer<typeof UsageProviderSchema>;
  * Normalized usage statistics from any model provider.
  *
  * Reuses only the required base fields via `.pick()` — the optional cache
- * fields on `TokenUsageStatsSchema` (`cacheReadInputTokens` /
+ * fields on `TokenUsageStatsBaseSchema` (`cacheReadInputTokens` /
  * `cacheCreationInputTokens`) are never populated for a NormalizedUsage; the
  * live cache metrics below (`cachedInputTokens` / `cacheCreationTokens`) are
  * the authoritative names. Extending the full base instead would inherit
  * those dead fields and duplicate `cacheMissInputTokens`.
  */
-export const NormalizedUsageSchema = TokenUsageStatsSchema.pick({
+const NormalizedUsageBaseSchema = TokenUsageStatsBaseSchema.pick({
   inputTokens: true,
   outputTokens: true,
   cost: true,
@@ -59,15 +63,19 @@ export const NormalizedUsageSchema = TokenUsageStatsSchema.pick({
   toolUsePromptTokens: TokenCountSchema.optional(),
   /** Number of server-side tool executions (Anthropic web search) */
   serverToolRequests: TokenCountSchema.optional(),
-  /**
-   * True when this round ran on the user's ChatGPT subscription (Codex
-   * backend), so `cost` is 0 because the tokens are covered by the
-   * subscription rather than billed. Carried through to usage logging and the
-   * UI so subscription rounds are recorded but clearly shown as free.
-   */
-  viaChatGptSubscription: z.boolean().optional(),
+  /** Canonical route used for usage display and telemetry. */
+  usageRoute: UsageRouteSchema.optional(),
   /** Original API response payload (for debugging) */
   _native: z.unknown().optional(),
+});
+
+export const NormalizedUsageSchema = NormalizedUsageBaseSchema.extend({
+  viaChatGptSubscription: z.boolean().optional(),
+}).transform(({ viaChatGptSubscription, ...usage }) => {
+  const usageRoute =
+    usage.usageRoute ??
+    (viaChatGptSubscription === true ? 'chatgpt-subscription' : undefined);
+  return usageRoute == null ? usage : { ...usage, usageRoute };
 });
 
 export type NormalizedUsage = z.infer<typeof NormalizedUsageSchema>;

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -11,7 +11,6 @@ import type {
   ExtendedTokenUsageStats,
   StorageKey,
   StreamTabId,
-  TokenUsageStats,
   UsageRoute,
 } from '@shared/schemas';
 import { roundTo } from '@utils/core';
@@ -121,9 +120,7 @@ export class UsageMonitor {
       const roundReasoningTokens = latestUsage?.reasoningTokens ?? 0;
       const roundCost = latestUsage?.cost ?? 0;
       const toolUseTokens = latestUsage?.toolUsePromptTokens ?? 0;
-      const viaChatGptSubscription =
-        latestUsage?.viaChatGptSubscription ?? false;
-      const usageRoute = this.resolveUsageRoute(viaChatGptSubscription);
+      const usageRoute = latestUsage?.usageRoute ?? this.currentUsageRoute();
 
       const { capabilities } = this.modelInfo;
       const supportsCaching =
@@ -158,7 +155,6 @@ export class UsageMonitor {
           reasoningTokens: roundReasoningTokens,
         }),
         ...(toolUseTokens > 0 && { toolUseTokens }),
-        ...(viaChatGptSubscription && { viaChatGptSubscription: true }),
         ...(usageRoute != null && { usageRoute }),
       };
 
@@ -194,9 +190,6 @@ export class UsageMonitor {
         cacheCreationInputTokens: roundCacheCreationTokens,
         reasoningTokens: roundReasoningTokens,
         cost: roundCost,
-        // Free ChatGPT-subscription round: still logged (cost is 0), but marked
-        // so analytics can tell it apart from any other zero-cost row.
-        viaChatGptSubscription,
         usageRoute,
       });
     } catch (error) {
@@ -222,10 +215,7 @@ export class UsageMonitor {
     return (totals.totalCacheReadInputTokens / totalCacheableTokens) * 100;
   }
 
-  private resolveUsageRoute(
-    viaChatGptSubscription: boolean,
-  ): UsageRoute | undefined {
-    if (viaChatGptSubscription) return 'chatgpt-subscription';
+  private currentUsageRoute(): UsageRoute | undefined {
     try {
       return this.usesRelayRoute() ? 'relay' : 'api-key';
     } catch (error) {
@@ -261,7 +251,6 @@ export class UsageMonitor {
       cacheCreationInputTokens?: number;
       reasoningTokens?: number;
       cost: number;
-      viaChatGptSubscription?: boolean;
       usageRoute?: UsageRoute;
     },
   ): Promise<void> {
@@ -275,10 +264,7 @@ export class UsageMonitor {
         usage.cacheMissInputTokens ??
         Math.max(0, usage.inputTokens - cachedInputTokens);
 
-      const usedRelay =
-        usage.usageRoute != null
-          ? usage.usageRoute === 'relay'
-          : !usage.viaChatGptSubscription && this.usesRelayRoute();
+      const usedRelay = usage.usageRoute === 'relay';
 
       UsageLogService.log({
         model: config.fullName,
@@ -296,9 +282,7 @@ export class UsageMonitor {
         cacheCreationInputTokens: usage.cacheCreationInputTokens ?? 0,
         reasoningTokens: usage.reasoningTokens ?? 0,
         usedRelay,
-        ...(usage.viaChatGptSubscription && {
-          viaChatGptSubscription: true,
-        }),
+        ...(usage.usageRoute != null && { usageRoute: usage.usageRoute }),
         streamId: this.context.streamId,
       });
 

--- a/src/shared/schemas/streamData.ts
+++ b/src/shared/schemas/streamData.ts
@@ -20,7 +20,7 @@ import { z } from 'zod';
 
 import { CompileFailureSchema, OutputFileInfoSchema } from './output';
 import {
-  TokenUsageStatsSchema,
+  TokenUsageStatsBaseSchema,
   UsageRouteSchema,
   emptyUsageStats,
   isEmptyUsage,
@@ -259,7 +259,7 @@ function isNumericUsageField(schema: z.ZodType): boolean {
 }
 
 const numericUsageParsingShape = Object.fromEntries(
-  Object.entries(TokenUsageStatsSchema.shape)
+  Object.entries(TokenUsageStatsBaseSchema.shape)
     .filter(([, schema]) => isNumericUsageField(schema))
     .map(([key, schema]) => [
       key,
@@ -270,13 +270,21 @@ const numericUsageParsingShape = Object.fromEntries(
 );
 
 /** Parsing schema with safe number coercion. */
-const TokenUsageStatsParsingBaseSchema = z.object({
-  ...numericUsageParsingShape,
-  viaChatGptSubscription: z.boolean().catch(false).prefault(false),
-  usageRoute: UsageRouteSchema.optional().catch(undefined),
-  // The numeric fields are derived from `TokenUsageStatsSchema.shape` above;
-  // TypeScript cannot recover the required keys through `Object.fromEntries`.
-}) as unknown as z.ZodType<TokenUsageStats>;
+const TokenUsageStatsParsingBaseSchema = z
+  .object({
+    ...numericUsageParsingShape,
+    viaChatGptSubscription: z.boolean().catch(false).prefault(false),
+    usageRoute: UsageRouteSchema.optional().catch(undefined),
+    // The numeric fields are derived from `TokenUsageStatsBaseSchema.shape` above;
+    // TypeScript cannot recover the required keys through `Object.fromEntries`.
+  })
+  .transform(({ viaChatGptSubscription, ...usage }): TokenUsageStats => {
+    const stats = usage as TokenUsageStats;
+    const usageRoute =
+      stats.usageRoute ??
+      (viaChatGptSubscription === true ? 'chatgpt-subscription' : undefined);
+    return usageRoute == null ? stats : { ...stats, usageRoute };
+  }) as z.ZodType<TokenUsageStats>;
 
 export const TokenUsageStatsParsingSchema =
   TokenUsageStatsParsingBaseSchema.catch(emptyUsageStats());

--- a/src/shared/schemas/usage.ts
+++ b/src/shared/schemas/usage.ts
@@ -10,23 +10,30 @@ export const UsageRouteSchema = z.enum([
 
 export type UsageRoute = z.infer<typeof UsageRouteSchema>;
 
-export const TokenUsageStatsSchema = z.strictObject({
+export const TokenUsageStatsBaseSchema = z.strictObject({
   inputTokens: TokenCountSchema,
   outputTokens: TokenCountSchema,
   cost: z.number().nonnegative(),
   cacheReadInputTokens: TokenCountSchema.optional(),
   cacheMissInputTokens: TokenCountSchema.optional(),
   cacheCreationInputTokens: TokenCountSchema.optional(),
-  viaChatGptSubscription: z.boolean().optional(),
   usageRoute: UsageRouteSchema.optional(),
 });
 
-export type TokenUsageStats = z.infer<typeof TokenUsageStatsSchema>;
+export type TokenUsageStats = z.infer<typeof TokenUsageStatsBaseSchema>;
 
-type UsageRouteInput = Pick<
-  TokenUsageStats,
-  'usageRoute' | 'viaChatGptSubscription'
->;
+const TokenUsageStatsInputSchema = TokenUsageStatsBaseSchema.extend({
+  viaChatGptSubscription: z.boolean().optional(),
+});
+
+export const TokenUsageStatsSchema = TokenUsageStatsInputSchema.transform(
+  ({ viaChatGptSubscription, ...usage }): TokenUsageStats => {
+    const usageRoute =
+      usage.usageRoute ??
+      (viaChatGptSubscription === true ? 'chatgpt-subscription' : undefined);
+    return usageRoute == null ? usage : { ...usage, usageRoute };
+  },
+);
 
 type EmptyUsageStats = Required<Omit<TokenUsageStats, 'usageRoute'>> &
   Pick<TokenUsageStats, 'usageRoute'>;
@@ -40,7 +47,6 @@ export function emptyUsageStats(): EmptyUsageStats {
     cacheReadInputTokens: 0,
     cacheMissInputTokens: 0,
     cacheCreationInputTokens: 0,
-    viaChatGptSubscription: false,
   };
 }
 
@@ -60,24 +66,12 @@ export function isEmptyUsage(usage: TokenUsageStats): boolean {
   return !hasUsageActivity(usage);
 }
 
-export function resolveUsageRoute(
-  usage: UsageRouteInput | null | undefined,
-): UsageRoute | undefined {
-  return (
-    usage?.usageRoute ??
-    (usage?.viaChatGptSubscription === true
-      ? 'chatgpt-subscription'
-      : undefined)
-  );
-}
-
 /** Accumulates usage stats from an iterable into a single total. */
 export function sumUsageStats(
   items: Iterable<TokenUsageStats>,
 ): TokenUsageStats {
   const total = emptyUsageStats();
   let sawUsageActivity = false;
-  let allRoundsViaChatGptSubscription = true;
   let commonUsageRoute: UsageRoute | undefined;
   let sawUsageRoute = false;
   let hasMixedOrMissingUsageRoute = false;
@@ -94,11 +88,8 @@ export function sumUsageStats(
       (usage.cacheCreationInputTokens ?? 0);
     if (hasUsageActivity(usage)) {
       sawUsageActivity = true;
-      allRoundsViaChatGptSubscription =
-        allRoundsViaChatGptSubscription &&
-        usage.viaChatGptSubscription === true;
 
-      const usageRoute = resolveUsageRoute(usage);
+      const usageRoute = usage.usageRoute;
       if (usageRoute == null) {
         hasMixedOrMissingUsageRoute = true;
       } else if (!sawUsageRoute) {
@@ -110,10 +101,6 @@ export function sumUsageStats(
       }
     }
   }
-  // Only true when every non-empty accumulated round used the subscription;
-  // zero baselines are neutral, while API-key or relay rounds make the total mixed.
-  total.viaChatGptSubscription =
-    sawUsageActivity && allRoundsViaChatGptSubscription;
   if (
     sawUsageActivity &&
     sawUsageRoute &&
@@ -134,7 +121,7 @@ export type RunUsageMap = z.infer<typeof RunUsageMapSchema>;
  * Extended token usage with per-round deltas. Note: percentageCached is
  * calculated from accumulated session totals for overall caching effectiveness.
  */
-export const ExtendedTokenUsageStatsSchema = TokenUsageStatsSchema.extend({
+export const ExtendedTokenUsageStatsSchema = TokenUsageStatsBaseSchema.extend({
   elapsedTime: z.number().nonnegative().optional(),
   percentageCached: z.number().nonnegative().optional(),
   reasoningTokens: TokenCountSchema.optional(),

--- a/src/telemetry/UsageLogTypes.ts
+++ b/src/telemetry/UsageLogTypes.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { UsageProviderSchema } from '@agent/types/NormalizedUsage';
+import { UsageRouteSchema } from '@shared/schemas';
 
 const UsageLogMetadataSchema = z.object({
   model: z.string(),
@@ -9,13 +10,8 @@ const UsageLogMetadataSchema = z.object({
   agentName: z.string().optional(),
   agentCategory: z.enum(AgentCategory).optional(),
   usedRelay: z.boolean().optional(),
-  /**
-   * True when the round ran on the user's ChatGPT subscription (Codex backend):
-   * recorded so analytics can account for subscription usage even though its
-   * `cost` is 0. Distinguishes a free subscription round from any other
-   * zero-cost row.
-   */
-  viaChatGptSubscription: z.boolean().optional(),
+  /** Canonical route used to account for relay/API-key/subscription usage. */
+  usageRoute: UsageRouteSchema.optional(),
   streamId: z.string().optional(),
 });
 

--- a/src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts
@@ -287,16 +287,16 @@ describe('ModelHandlerCodex subscription fallback', () => {
     expect(handler.computePrice(ONE_MILLION_INPUT_TOKENS)).toBe(0);
   });
 
-  it('tags normalized usage as a free subscription round while the preference is on', async () => {
+  it('tags normalized usage with the subscription route while the preference is on', async () => {
     await initFakePlatformWithSubscription();
 
     const handler = new ModelHandlerCodex(config);
     handler.setAgentCategory(AgentCategory.ToolUse);
     const usage = handler.normalizeUsage(RAW_USAGE, 1000);
 
-    // Recorded (tokens present) but free and marked, so logging/UI can tell it
+    // Recorded (tokens present) but free and routed, so logging/UI can tell it
     // apart from any other zero-cost row.
-    expect(usage.viaChatGptSubscription).toBe(true);
+    expect(usage.usageRoute).toBe('chatgpt-subscription');
     expect(usage.cost).toBe(0);
     expect(usage.inputTokens).toBe(1_000_000);
   });
@@ -309,7 +309,7 @@ describe('ModelHandlerCodex subscription fallback', () => {
     await setPreferCodexSubscription(false);
     const usage = handler.normalizeUsage(RAW_USAGE, 1000);
 
-    expect(usage.viaChatGptSubscription).toBeUndefined();
+    expect(usage.usageRoute).toBeUndefined();
     expect(usage.cost).toBeGreaterThan(0);
   });
 });

--- a/src/test-kernel/agent/runtime/UsageMonitorLastTotals.vitest.ts
+++ b/src/test-kernel/agent/runtime/UsageMonitorLastTotals.vitest.ts
@@ -84,7 +84,7 @@ describe('UsageMonitor.lastTotals (SDK Step 7d PR 5)', () => {
     }
   });
 
-  it('forwards the ChatGPT subscription marker to progress usage events', async () => {
+  it('forwards the ChatGPT subscription route to progress usage events', async () => {
     const { dispose, events, monitor } = createMonitorWithEvents();
     try {
       const state = AgentRunStateSnapshotSchema.parse({});
@@ -94,7 +94,7 @@ describe('UsageMonitor.lastTotals (SDK Step 7d PR 5)', () => {
         cost: 0,
         responseTimeMs: 50,
         provider: 'openai-response',
-        viaChatGptSubscription: true,
+        usageRoute: 'chatgpt-subscription',
       });
 
       await monitor.recordUsage(state);
@@ -102,12 +102,14 @@ describe('UsageMonitor.lastTotals (SDK Step 7d PR 5)', () => {
       const usageEvent = events.find(
         (event) => event.event === 'updateStreamUsage',
       );
-      expect(usageEvent?.payload).toMatchObject({
+      const usagePayload = usageEvent?.payload as
+        { usage?: Record<string, unknown> } | undefined;
+      expect(usagePayload).toMatchObject({
         usage: {
-          viaChatGptSubscription: true,
           usageRoute: 'chatgpt-subscription',
         },
       });
+      expect(usagePayload?.usage).not.toHaveProperty('viaChatGptSubscription');
     } finally {
       dispose();
     }

--- a/src/test-kernel/cli/ResumeHint.vitest.mts
+++ b/src/test-kernel/cli/ResumeHint.vitest.mts
@@ -282,7 +282,6 @@ describe('collectResumeUsage', () => {
       cacheReadInputTokens: 10,
       cacheMissInputTokens: 0,
       cacheCreationInputTokens: 0,
-      viaChatGptSubscription: false,
       reasoningTokens: 5,
     });
   });
@@ -311,7 +310,6 @@ describe('collectResumeUsage', () => {
       cacheReadInputTokens: 0,
       cacheMissInputTokens: 0,
       cacheCreationInputTokens: 0,
-      viaChatGptSubscription: false,
     });
   });
 });

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -2875,7 +2875,6 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
       cacheReadInputTokens: 35,
       cacheMissInputTokens: 0,
       cacheCreationInputTokens: 7,
-      viaChatGptSubscription: false,
     });
   });
 

--- a/src/test-kernel/progressView/UsagePanel.vitest.mts
+++ b/src/test-kernel/progressView/UsagePanel.vitest.mts
@@ -5,7 +5,11 @@ import { describe, expect, it } from 'vitest';
 import type { UsagePanel } from '@progressView/frontend/components/UsagePanel';
 
 // Local imports - shared schemas
-import type { TokenUsageStats, UsageRoute } from '@shared/schemas';
+import {
+  TokenUsageStatsSchema,
+  type TokenUsageStats,
+  type UsageRoute,
+} from '@shared/schemas';
 
 // Local imports - test utilities
 import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
@@ -45,12 +49,13 @@ function usageAriaLabel(element: UsagePanel): string {
 
 describe('usage-panel route badges', () => {
   it('shows subscription-backed usage as Free · ChatGPT', async () => {
-    const element = await mountUsagePanel(
-      usage({
-        cost: 0,
-        viaChatGptSubscription: true,
-      }),
-    );
+    const legacyUsage = TokenUsageStatsSchema.parse({
+      inputTokens: 1200,
+      outputTokens: 80,
+      cost: 0,
+      viaChatGptSubscription: true,
+    });
+    const element = await mountUsagePanel(legacyUsage);
 
     expect(panelText(element)).toContain('Free · ChatGPT');
     expect(usageAriaLabel(element)).toContain('Free via ChatGPT');

--- a/src/test-kernel/schemas/StreamDataUsage.vitest.ts
+++ b/src/test-kernel/schemas/StreamDataUsage.vitest.ts
@@ -23,7 +23,6 @@ describe('stream data usage parsing', () => {
       cacheReadInputTokens: 0,
       cacheMissInputTokens: 0,
       cacheCreationInputTokens: 0,
-      viaChatGptSubscription: false,
     });
   });
 
@@ -55,40 +54,28 @@ describe('stream data usage parsing', () => {
       cacheReadInputTokens: 3,
       cacheMissInputTokens: 0,
       cacheCreationInputTokens: 0,
-      viaChatGptSubscription: true,
       usageRoute: 'chatgpt-subscription',
     });
+    expect(usage.get('run')).not.toHaveProperty('viaChatGptSubscription');
   });
 
-  it('marks accumulated usage as subscription usage only when every round is subscription usage', () => {
-    expect(
-      sumUsageStats([
-        emptyUsageStats(),
-        {
-          inputTokens: 10,
-          outputTokens: 2,
-          cost: 0,
-          viaChatGptSubscription: true,
-        },
-        {
-          inputTokens: 1,
-          outputTokens: 1,
-          cost: 0.001,
-          viaChatGptSubscription: false,
-        },
-      ]).viaChatGptSubscription,
-    ).toBe(false);
+  it('normalizes persisted legacy subscription markers to usageRoute', () => {
+    const usage = UsageDataSchema.parse({
+      run: {
+        inputTokens: 10,
+        outputTokens: 2,
+        cost: 0,
+        viaChatGptSubscription: true,
+      },
+    });
 
-    expect(
-      sumUsageStats([
-        {
-          inputTokens: 10,
-          outputTokens: 2,
-          cost: 0,
-          viaChatGptSubscription: true,
-        },
-      ]).viaChatGptSubscription,
-    ).toBe(true);
+    expect(usage.get('run')).toMatchObject({
+      inputTokens: 10,
+      outputTokens: 2,
+      cost: 0,
+      usageRoute: 'chatgpt-subscription',
+    });
+    expect(usage.get('run')).not.toHaveProperty('viaChatGptSubscription');
   });
 
   it('keeps route badges only for unambiguous accumulated usage', () => {
@@ -133,7 +120,7 @@ describe('stream data usage parsing', () => {
           inputTokens: 10,
           outputTokens: 2,
           cost: 0,
-          viaChatGptSubscription: true,
+          usageRoute: 'chatgpt-subscription',
         },
       ]).usageRoute,
     ).toBe('chatgpt-subscription');

--- a/supabase/functions/log-usage/index.ts
+++ b/supabase/functions/log-usage/index.ts
@@ -45,8 +45,9 @@ function optional<T extends z.ZodType>(schema: T) {
 const optionalString = optional(z.string());
 const optionalNonnegativeInt = optional(z.int().nonnegative());
 const optionalBoolean = optional(z.boolean());
+const UsageRouteSchema = z.enum(['chatgpt-subscription', 'relay', 'api-key']);
 
-const UsageLogEntrySchema = z.object({
+const UsageLogEntryInputSchema = z.object({
   timestamp: z.iso.datetime(),
   model: z.string(),
   provider: z.string(),
@@ -60,6 +61,7 @@ const UsageLogEntrySchema = z.object({
   cachedInputTokens: optionalNonnegativeInt,
   reasoningTokens: optionalNonnegativeInt,
   usedRelay: optionalBoolean,
+  usageRoute: optional(UsageRouteSchema),
   viaChatGptSubscription: z
     .boolean()
     .nullish()
@@ -74,6 +76,15 @@ const UsageLogEntrySchema = z.object({
   editorType: optionalString,
 });
 
+const UsageLogEntrySchema = UsageLogEntryInputSchema.transform(
+  ({ viaChatGptSubscription, ...entry }) => ({
+    ...entry,
+    usageRoute:
+      entry.usageRoute ??
+      (viaChatGptSubscription ? 'chatgpt-subscription' : undefined),
+  }),
+);
+
 const UsageBatchSchema = z.object({
   entries: z.array(z.unknown()),
   batchId: z.uuid(),
@@ -85,13 +96,15 @@ const UsageDestinations = {
   paid: {
     table: 'usage_logs',
     rpc: 'usage_logs_upsert',
-    accepts: (entry: UsageLogEntry) => !entry.viaChatGptSubscription,
+    accepts: (entry: UsageLogEntry) =>
+      entry.usageRoute !== 'chatgpt-subscription',
     toRows: toDbRows,
   },
   subscription: {
     table: 'subscription_usage_logs',
     rpc: 'subscription_usage_logs_upsert',
-    accepts: (entry: UsageLogEntry) => entry.viaChatGptSubscription,
+    accepts: (entry: UsageLogEntry) =>
+      entry.usageRoute === 'chatgpt-subscription',
     toRows: (
       userId: string,
       batchId: string,


### PR DESCRIPTION
## Summary

Normalizes legacy subscription-backed usage records at parse boundaries so downstream code carries `usageRoute` instead of re-deriving `usageRoute ?? viaChatGptSubscription` at every read. New Codex subscription usage now emits `usageRoute: 'chatgpt-subscription'`, the progress panel/backend usage log/Supabase log-usage edge function read the canonical route directly, and persisted legacy records still parse and display as ChatGPT-backed usage.

## Issue acceptance gates

Addresses #6995.

- `grep -rn 'resolveUsageRoute' src packages/*/src` returns zero matches.
- `viaChatGptSubscription` reads are confined to schema transforms for legacy parse support, including the Supabase edge-function payload boundary; no runtime consumer branches on it.
- Persisted legacy usage records parse into `usageRoute: 'chatgpt-subscription'`, and the UsagePanel fixture renders `Free · ChatGPT` from that parsed canonical value.
- Added a #6981 ledger row for legacy `viaChatGptSubscription` parse support with an age-based next-minor-release removal trigger.

## Single source of truth

`TokenUsageStatsSchema` and the stream/normalized usage parse entry points own legacy-to-canonical route normalization. Runtime consumers use `usage.usageRoute` directly.

## Duplication and abstraction budget

Removed both `resolveUsageRoute` implementations and the downstream legacy boolean fan-out. No new pass-through layer was added; the small schema transforms are the compatibility boundary. This PR is net-negative in lines.

## Host impact

Extension: Progress usage badges read `usageRoute` directly; legacy persisted subscription usage still displays as ChatGPT-backed after parsing.

Desktop: Shared stream and accumulator parsing still accepts legacy usage sidecars/run state and normalizes them to the canonical route.

Supabase: `log-usage` accepts canonical `usageRoute` while still normalizing legacy `viaChatGptSubscription`; subscription rows continue routing to `subscription_usage_logs`.

CLI: Resume/TUI cumulative usage no longer materializes `viaChatGptSubscription: false`; byte-facing CLI behavior is otherwise unchanged.

## Scheduled refactoring

#6981 now tracks legacy `viaChatGptSubscription` usage-route parse support for deletion after the next minor-release window once older persisted usage sidecars and run accumulators are outside support.

## Validation

- `corepack pnpm exec prettier --write` on touched files
- `grep -rn 'resolveUsageRoute' src packages/*/src || true`
- `rg -n "viaChatGptSubscription" src packages --glob '!node_modules/**'`
- `npm test -- --run src/test-kernel/schemas/StreamDataUsage.vitest.ts src/test-kernel/progressView/UsagePanel.vitest.mts src/test-kernel/agent/runtime/UsageMonitorLastTotals.vitest.ts src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts src/test-kernel/cli/ResumeHint.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `npm run typecheck -- --pretty false`
- `npm test`
- `npm run lint` (passes with existing warnings)
- `npm run compile:fast`
- `git diff --check`
- `supabase functions --help` (checked for lightweight local function validation support)
- `deno --version` (not available locally, so `deno check` could not be run)

Closes #6995

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes usage telemetry, relay flush behavior, and subscription vs paid log routing; legacy fields are normalized at parse time so older persisted data should still display correctly.
> 
> **Overview**
> Standardizes **how billing/display route is represented** by making `usageRoute` the single field runtime code reads, instead of mixing `usageRoute` with legacy `viaChatGptSubscription` and `resolveUsageRoute()` at every call site.
> 
> **Parse-time legacy support:** `TokenUsageStatsSchema`, stream sidecar parsing, `NormalizedUsageSchema`, and the `log-usage` edge function still accept `viaChatGptSubscription` on input but **transform it to** `usageRoute: 'chatgpt-subscription'` and drop the boolean from canonical objects.
> 
> **Runtime emitters:** Codex subscription rounds now tag **`usageRoute: 'chatgpt-subscription'`** (not `viaChatGptSubscription`). `UsageMonitor` forwards `usageRoute` to the UI and backend; relay detection uses **`usageRoute === 'relay'`** with a fallback when the route is missing. The progress **UsagePanel** reads `usage.usageRoute` directly for badges like “Free · ChatGPT”.
> 
> **Aggregation:** `sumUsageStats` only propagates `usageRoute` when all active rounds share the same route; it no longer materializes `viaChatGptSubscription` on totals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7d226055cee3b83fea8f2d5d4afb59dd7cd52e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

