### PR TITLE
[codex] Carry subagent delivery target as data

### DIFF
--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -393,7 +393,7 @@ function parentStreamMapUpdate(
   for (const { childStreamId, parentStreamId } of updates) {
     if (!childStreamId) continue;
     const readable = out ?? current;
-    if (parentStreamId == null || childStreamId === parentStreamId) {
+    if (parentStreamId == null) {
       if (!readable.has(childStreamId)) continue;
       out ??= new Map(current);
       out.delete(childStreamId);

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -73,6 +73,7 @@ export class AgentExecutionHandle implements ExecutionHandle {
   readonly startedAt = Date.now();
   private progress: ExecutionProgress = {};
   private _parentStreamId: StreamTabId;
+  private _deliveryTargetStreamId: StreamTabId | undefined;
   private toolUseFlowContext?: LiveToolUseFlowContext;
 
   /** Stable tool name for UI identification (e.g. "bash", "codex"). */
@@ -100,6 +101,8 @@ export class AgentExecutionHandle implements ExecutionHandle {
     readonly trace?: AgentTrace,
   ) {
     this._parentStreamId = parentStreamId;
+    this._deliveryTargetStreamId =
+      parentStreamId === childStreamId ? undefined : parentStreamId;
   }
 
   /** Settle {@link result} with the terminal outcome (idempotent). */
@@ -111,8 +114,17 @@ export class AgentExecutionHandle implements ExecutionHandle {
     return this._parentStreamId;
   }
 
+  get isChildExecution(): boolean {
+    return this._deliveryTargetStreamId !== undefined;
+  }
+
+  get deliveryTargetStreamId(): StreamTabId | undefined {
+    return this._deliveryTargetStreamId;
+  }
+
   /** Promote this subagent to a top-level execution (detach from parent). */
   detach(): void {
+    this._deliveryTargetStreamId = undefined;
     this._parentStreamId = this.childStreamId;
   }
 
@@ -196,10 +208,8 @@ export function isChildExecution(
   parentStreamId: StreamTabId,
 ): boolean {
   if (handle.parentStreamId !== parentStreamId) return false;
-  // AgentExecutionHandles where childStreamId === parentStreamId represent
-  // the parent itself, not a child.
   if (handle instanceof AgentExecutionHandle) {
-    return handle.childStreamId !== parentStreamId;
+    return handle.isChildExecution;
   }
   return true;
 }

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -170,7 +170,7 @@ export class ExecutionRegistry {
             handle.childStreamId === streamId
           ) {
             this.notifyWaiters(executionId);
-            if (handle.parentStreamId !== handle.childStreamId) {
+            if (handle.isChildExecution) {
               this.emitActiveSubagentsUpdate(
                 handle.parentStreamId,
                 handle.runtimeHost,
@@ -201,7 +201,7 @@ export class ExecutionRegistry {
     const { runtimeHost } = handle;
 
     if (handle instanceof AgentExecutionHandle) {
-      if (handle.parentStreamId !== handle.childStreamId) {
+      if (handle.isChildExecution) {
         this.emitActiveSubagentsUpdate(handle.parentStreamId, runtimeHost);
         runtimeHost.emit('setParentStream', {
           childStreamId: handle.childStreamId,
@@ -275,10 +275,7 @@ export class ExecutionRegistry {
     this.notifyWaiters(handle.executionId);
     const { runtimeHost } = handle;
 
-    if (
-      handle instanceof AgentExecutionHandle &&
-      handle.parentStreamId !== handle.childStreamId
-    ) {
+    if (handle instanceof AgentExecutionHandle && handle.isChildExecution) {
       this.emitActiveSubagentsUpdate(handle.parentStreamId, runtimeHost);
       return;
     }
@@ -570,11 +567,8 @@ export class ExecutionRegistry {
     visited: Set<string> = new Set(),
   ): void {
     for (const handle of this.handles.values()) {
-      if (handle.parentStreamId !== parentStreamId) continue;
-      if (
-        handle instanceof AgentExecutionHandle &&
-        handle.childStreamId !== parentStreamId
-      ) {
+      if (!isChildExecution(handle, parentStreamId)) continue;
+      if (handle instanceof AgentExecutionHandle) {
         handle.detach();
         runtimeHost.emit('setParentStream', {
           childStreamId: handle.childStreamId,

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -955,7 +955,9 @@ describe('executionRegistry', () => {
       );
 
       registry.track(handle);
+      expect(handle.deliveryTargetStreamId).toBe(parentStreamId);
       registry.detachActiveChildren(parentStreamId, explicit.host);
+      expect(handle.deliveryTargetStreamId).toBeUndefined();
 
       expect(explicit.events.map((entry) => entry.event)).toEqual([
         'updateActiveSubagents',

--- a/src/tools/delegation/subagentExecution.ts
+++ b/src/tools/delegation/subagentExecution.ts
@@ -134,20 +134,6 @@ async function writeSubagentReport(
   }
 }
 
-function resolveDeliveryStreamId(
-  executionId: string,
-  fallbackStreamId: StreamTabId,
-): StreamTabId | undefined {
-  const handle = currentSession().executions.getHandle(executionId);
-  if (!(handle instanceof AgentExecutionHandle)) return fallbackStreamId;
-  // AgentExecutionHandle.detach() promotes a child by setting
-  // parentStreamId === childStreamId. Do not enqueue the formatted result
-  // back into the detached child's own prompt as a synthetic follow-up.
-  return handle.parentStreamId === handle.childStreamId
-    ? undefined
-    : handle.parentStreamId;
-}
-
 /**
  * Runtime depth gate shared by fresh delegations and resumes.
  * Evaluates against the current workspace delegation policy.
@@ -352,10 +338,11 @@ export async function executeSubagent(
     followUp: FollowUpQueueInput,
     options?: { wake?: boolean },
   ): Promise<boolean> {
-    const targetStreamId = resolveDeliveryStreamId(
-      executionId,
-      orchestratorStreamId,
-    );
+    const handle = currentSession().executions.getHandle(executionId);
+    const targetStreamId =
+      handle instanceof AgentExecutionHandle
+        ? handle.deliveryTargetStreamId
+        : orchestratorStreamId;
     if (!targetStreamId) return false;
 
     const result = await sendFollowUp(


### PR DESCRIPTION
## Summary

Moves the subagent delivery target decision onto `AgentExecutionHandle` instead of re-deriving detach state from `parentStreamId === childStreamId` at delivery time. `detach()` now clears the carried `deliveryTargetStreamId`, delivery reads that field directly, and registry child checks use the named handle fact instead of repeating the identity encoding.

## Issue acceptance gates

Addresses #6996.

- `grep -rn 'resolveDeliveryStreamId' src packages/*/src` returns zero matches.
- Parent/child identity comparisons for detached/is-parent state are reduced to one owner: the `AgentExecutionHandle` constructor that initializes the carried delivery target.
- Existing subagent delivery tests pass, including the detach delivery case; `ExecutionRegistry` now also asserts the delivery target is cleared by detach.

## Single source of truth

`AgentExecutionHandle.detach()` owns the detachment decision by clearing `deliveryTargetStreamId`; delivery and registry code read the named fact.

## Duplication and abstraction budget

Deleted the single-call `resolveDeliveryStreamId` helper and removed duplicated identity checks from registry paths. No new layer was added; the added handle field is the carried fact requested by the issue. This PR is net-negative in lines.

## Host impact

Extension: Subagent result delivery skips detached children by reading the explicit handle delivery target; active-subagent UI updates still use the registry path.

Desktop: Same shared registry semantics; detach still emits `setParentStream` with `parentStreamId: null`.

CLI: Parent-edge state now relies on the current null detach signal rather than accepting self-parent as a detach alias.

## Scheduled refactoring

None. This deletes the alias/fallback path rather than adding a new shim.

## Validation

- `corepack pnpm exec prettier --write` on touched files
- `grep -rn 'resolveDeliveryStreamId' src packages/*/src || true`
- `rg -n "parentStreamId === childStreamId|parentStreamId !== childStreamId|childStreamId !== parentStreamId|childStreamId === parentStreamId" src packages --glob '!node_modules/**'`
- `npm test -- --run src/test-kernel/tools/DelegationHeadless.vitest.mts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `npm run typecheck -- --pretty false`
- `npm test`
- `npm run lint` (passes with existing warnings)
- `npm run compile:fast`
- `git diff --check`

Closes #6996

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subagent follow-up routing and detach behavior across runtime, delegation delivery, and CLI parent-stream state; incorrect targeting could mis-route or duplicate results, though tests cover detach clearing the delivery target.
> 
> **Overview**
> Subagent **where to deliver results** is now explicit on `AgentExecutionHandle` via `deliveryTargetStreamId` and `isChildExecution`, instead of inferring detach state from `parentStreamId === childStreamId` at delivery and registry sites.
> 
> `detach()` clears `deliveryTargetStreamId` while promoting `parentStreamId` to the child stream; follow-up delivery reads `handle.deliveryTargetStreamId` directly and **removes** `resolveDeliveryStreamId`. The execution registry and `isChildExecution()` use the handle’s named facts for child tracking and `detachActiveChildren`.
> 
> The CLI parent-stream map update **no longer treats** `childStreamId === parentStreamId` as “remove edge”—only `parentStreamId == null` clears the parent link, aligning with detach emitting `parentStreamId: null` rather than a self-parent alias.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6f7f55ee72ee92adc1fae49b3cb11232250508d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->