### PR TITLE
[codex] Delete opt-in inquiry hydration flag

### DIFF
--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -384,9 +384,7 @@ export class ProgressViewProvider
 
     for (const summary of open) {
       try {
-        const manifest = await readExternalInquiryThread(summary.threadId, {
-          hydrate: true,
-        });
+        const manifest = await readExternalInquiryThread(summary.threadId);
         if (!manifest || manifest.status !== 'open') continue;
         if (!manifest.parentStreamId) continue;
         const lastTurn = manifest.turns.at(-1);

--- a/src/test-kernel/tools/InquiryReadBoundary.vitest.ts
+++ b/src/test-kernel/tools/InquiryReadBoundary.vitest.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sendFollowUpMock = vi.hoisted(() =>
+  vi.fn<(...args: unknown[]) => Promise<unknown>>(async () => ({
+    status: 'sent' as const,
+  })),
+);
+const wakeQueuedFollowUpStreamMock = vi.hoisted(() =>
+  vi.fn<(...args: unknown[]) => Promise<unknown>>(async () => ({
+    kind: 'not_required' as const,
+  })),
+);
+
+vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
+  sendFollowUp: sendFollowUpMock,
+  wakeQueuedFollowUpStream: wakeQueuedFollowUpStreamMock,
+}));
+
+import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
+import {
+  type ExternalInquiryPermission,
+  type ExternalInquiryThreadId,
+  type StreamTabId,
+} from '@shared/schemas';
+import { ExternalInquiryTool } from '@tools/inquiry/ExternalInquiryTool';
+import { injectContinuationForAnsweredThread } from '@tools/inquiry/inquiryContinuation';
+
+import { createFakePlatform } from '../support/FakePlatform';
+
+const THREAD = 'ei_aabbccdd0011' as ExternalInquiryThreadId;
+const OPEN_THREAD = 'ei_aabbccdd0022' as ExternalInquiryThreadId;
+const STREAM = 'stream:inquiry-read-boundary' as StreamTabId;
+
+async function seedThread(
+  threadId: ExternalInquiryThreadId,
+  manifest: Record<string, unknown>,
+  answers: Record<string, string>,
+): Promise<void> {
+  const { platform } = await import('@platform/platform');
+  const storage = platform().storage.getGlobalStoragePath();
+  const threadDir = `${storage}/ei_threads/${threadId}`;
+  await platform().fs.createDirectory(threadDir);
+
+  for (const [relativePath, content] of Object.entries(answers)) {
+    const segments = relativePath.split('/');
+    const filename = segments.pop();
+    if (!filename) continue;
+    let current = threadDir;
+    for (const segment of segments) {
+      current = `${current}/${segment}`;
+      await platform().fs.createDirectory(current);
+    }
+    await platform().fs.writeFile(
+      `${current}/${filename}`,
+      Buffer.from(content, 'utf8'),
+    );
+  }
+
+  await platform().fs.writeFile(
+    `${threadDir}/manifest.json`,
+    Buffer.from(JSON.stringify(manifest), 'utf8'),
+  );
+}
+
+function answeredLegacyManifest(
+  threadId: ExternalInquiryThreadId = THREAD,
+): Record<string, unknown> {
+  return {
+    threadId,
+    parentStreamId: STREAM,
+    status: 'answered',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:01:00.000Z',
+    turns: [
+      {
+        turnIndex: 1,
+        timestamp: '2026-01-01T00:00:00.000Z',
+        question: 'Legacy Q',
+        questionRelativePath: 't1/question.txt',
+        answerRelativePath: 't1/answer.txt',
+      },
+    ],
+  };
+}
+
+function openFollowUpLegacyManifest(): Record<string, unknown> {
+  return {
+    threadId: OPEN_THREAD,
+    parentStreamId: STREAM,
+    status: 'open',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:02:00.000Z',
+    turns: [
+      {
+        turnIndex: 1,
+        timestamp: '2026-01-01T00:00:00.000Z',
+        question: 'Legacy Q',
+        questionRelativePath: 't1/question.txt',
+        answerRelativePath: 't1/answer.txt',
+      },
+      {
+        turnIndex: 2,
+        timestamp: '2026-01-01T00:02:00.000Z',
+        question: 'Follow-up Q',
+        questionRelativePath: 't2/question.txt',
+      },
+    ],
+  };
+}
+
+function createProgressProviderShell(): {
+  hydrate: () => Promise<void>;
+  show: ReturnType<typeof vi.fn>;
+} {
+  const provider = Object.create(
+    ProgressViewProvider.prototype,
+  ) as ProgressViewProvider;
+  const show = vi.fn();
+  const shell = provider as unknown as {
+    hydrateOpenInquiries(): Promise<void>;
+    webviewUpdater: { isAvailable(): boolean };
+    approvalHandlers: {
+      externalInquiry: {
+        pendingSize: number;
+        show(permission: ExternalInquiryPermission): void;
+      };
+    };
+    logger: { debug(message: string): void };
+  };
+  shell.webviewUpdater = { isAvailable: () => true };
+  shell.approvalHandlers = {
+    externalInquiry: {
+      pendingSize: 0,
+      show,
+    },
+  };
+  shell.logger = { debug: vi.fn() };
+  return { hydrate: () => shell.hydrateOpenInquiries(), show };
+}
+
+describe('external inquiry read boundary', () => {
+  beforeEach(async () => {
+    const { initPlatform } = await import('@platform/platform');
+    initPlatform(createFakePlatform());
+    sendFollowUpMock.mockClear();
+    wakeQueuedFollowUpStreamMock.mockClear();
+  });
+
+  it('hydrates legacy answers through inquiry read', async () => {
+    await seedThread(THREAD, answeredLegacyManifest(), {
+      't1/answer.txt': 'Legacy A',
+    });
+
+    const result = await new ExternalInquiryTool().call({
+      command: 'read',
+      thread_id: THREAD,
+    });
+
+    expect(result.output).toContain('Legacy A');
+    expect(result.output).not.toContain('(awaiting user answer)');
+  });
+
+  it('hydrates legacy answers through continuation injection', async () => {
+    await seedThread(THREAD, answeredLegacyManifest(), {
+      't1/answer.txt': 'Legacy A',
+    });
+
+    const outcome = await injectContinuationForAnsweredThread(THREAD);
+
+    expect(outcome).toBe('sent');
+    expect(sendFollowUpMock).toHaveBeenCalledWith(
+      STREAM,
+      expect.stringContaining('Legacy A'),
+      undefined,
+      undefined,
+      undefined,
+    );
+  });
+
+  it('hydrates legacy answers through progress-view inquiry hydration', async () => {
+    await seedThread(OPEN_THREAD, openFollowUpLegacyManifest(), {
+      't1/answer.txt': 'Legacy A',
+    });
+    const { hydrate, show } = createProgressProviderShell();
+
+    await hydrate();
+
+    expect(show).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: 'followUp',
+        threadId: OPEN_THREAD,
+        question: 'Follow-up Q',
+        transcript: expect.arrayContaining([
+          expect.objectContaining({ question: 'Legacy Q', answer: 'Legacy A' }),
+        ]),
+      }),
+    );
+  });
+});

--- a/src/test-kernel/tools/InquiryStorage.vitest.ts
+++ b/src/test-kernel/tools/InquiryStorage.vitest.ts
@@ -269,12 +269,15 @@ describe('InquiryStorage', () => {
     expect(manifest).not.toBeNull();
     expect(manifest!.status).toBe('answered');
     expect(manifest!.parentStreamId).toBeNull();
-
-    const hydrated = await readExternalInquiryThread('ei_aabbccdd0011', {
-      hydrate: true,
-    });
-    expect(manifestToTranscript(hydrated!)).toMatchObject([
+    expect(manifestToTranscript(manifest!)).toMatchObject([
       { turnIndex: 1, question: 'Legacy Q', answer: 'Legacy A' },
     ]);
+
+    const persisted = JSON.parse(
+      Buffer.from(
+        await platform.fs.readFile(`${threadDir}/manifest.json`),
+      ).toString('utf8'),
+    ) as { turns: Array<{ answer?: string }> };
+    expect(persisted.turns[0]?.answer).toBe('Legacy A');
   });
 });

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -350,9 +350,8 @@ export class ExternalInquiryTool extends defineTool({
       attachFiles: input.attachFiles ?? undefined,
     });
     const manifest =
-      (await readExternalInquiryThread(persisted.threadId, {
-        hydrate: true,
-      })) ?? persisted.manifest;
+      (await readExternalInquiryThread(persisted.threadId)) ??
+      persisted.manifest;
 
     // Mirror to execution so the agent can read prior turns via the executions tool.
     if (executionId) {
@@ -422,11 +421,7 @@ export class ExternalInquiryTool extends defineTool({
     input: Extract<InquiryInput, { command: 'read' }>;
     executionId?: string;
   }): Promise<ToolResult> {
-    // Hydrate inline answer text from disk for legacy manifests whose
-    // turns only stored an `answerRelativePath`.
-    const manifest = await readExternalInquiryThread(args.input.thread_id, {
-      hydrate: true,
-    });
+    const manifest = await readExternalInquiryThread(args.input.thread_id);
     if (!manifest) {
       throw new ToolError(
         `External inquiry thread not found: ${args.input.thread_id}`,

--- a/src/tools/inquiry/externalInquiryStorage.ts
+++ b/src/tools/inquiry/externalInquiryStorage.ts
@@ -193,7 +193,11 @@ function threadTurnDir(
 async function hydrateAnswersFromDisk(
   threadId: ExternalInquiryThreadId,
   manifest: ExternalInquiryThreadManifest,
-): Promise<ExternalInquiryThreadManifest> {
+): Promise<{
+  manifest: ExternalInquiryThreadManifest;
+  didHydrate: boolean;
+}> {
+  let didHydrate = false;
   const turns = await Promise.all(
     manifest.turns.map(async (turn) => {
       if (turn.answer || !turn.answerRelativePath) return turn;
@@ -201,6 +205,7 @@ async function hydrateAnswersFromDisk(
         const content = await GlobalStorageFS.read(
           path.join(threadDir(threadId), turn.answerRelativePath),
         );
+        didHydrate = true;
         return { ...turn, answer: content };
       } catch {
         // Answer file unreadable/missing — leave the turn unhydrated (benign:
@@ -209,7 +214,7 @@ async function hydrateAnswersFromDisk(
       }
     }),
   );
-  return { ...manifest, turns };
+  return { manifest: { ...manifest, turns }, didHydrate };
 }
 
 async function readThreadManifest(
@@ -586,24 +591,24 @@ export function manifestToTranscript(
 // ============================================================================
 
 /**
- * Read a thread manifest. When `hydrate` is true, fills in inline
- * `answer` text from `answerRelativePath` for legacy manifests so
- * callers don't see "(awaiting user answer)" for migrated threads.
- * Continuation injection uses the canonical inline `answer` field
- * already, so hydration is opt-in to keep the hot path cheap.
+ * Read a thread manifest and normalize legacy answer files at the boundary.
+ * Legacy turns with only `answerRelativePath` are hydrated once and written
+ * back so callers always see inline answers when answer text is available.
  */
 export async function readExternalInquiryThread(
   threadId: string,
-  options?: { hydrate?: boolean },
 ): Promise<ExternalInquiryThreadManifest | null> {
   const parsed = ExternalInquiryThreadIdSchema.safeParse(threadId);
   if (!parsed.success) return null;
-  const manifest = await readThreadManifest(parsed.data);
-  if (!manifest) return null;
-  if (options?.hydrate) {
-    return hydrateAnswersFromDisk(parsed.data, manifest);
-  }
-  return manifest;
+  return withThreadLock(parsed.data, async () => {
+    const manifest = await readThreadManifest(parsed.data);
+    if (!manifest) return null;
+    const hydrated = await hydrateAnswersFromDisk(parsed.data, manifest);
+    if (hydrated.didHydrate) {
+      await writeThreadManifest(hydrated.manifest);
+    }
+    return hydrated.manifest;
+  });
 }
 
 function manifestToSummary(


### PR DESCRIPTION
## Summary

Normalize legacy external-inquiry answers inside `readExternalInquiryThread` instead of requiring callers to opt into `hydrate: true`. Legacy `answerRelativePath`-only turns are hydrated at the manifest read boundary and written back once under the existing thread lock, so later reads see the canonical inline `answer` shape.

Evidence was reverified before implementation; the current line drift was recorded on #7000.

## Issue acceptance gates

Addresses #7000.

- `readExternalInquiryThread` has no `hydrate` option.
- `grep -rn 'hydrate: true' src packages/*/src` has zero matches.
- Legacy manifest fixture coverage now exercises tool read, continuation injection, and progress-view hydration paths.
- #6981 has a legacy retirement ledger row for `answerRelativePath`-only manifest hydration/write-back, with an age-based D3 removal trigger.

## Single source of truth

`src/tools/inquiry/externalInquiryStorage.ts` owns legacy manifest normalization at the read boundary. Callers receive canonical manifests and no longer decide whether answer hydration is required.

## Duplication and abstraction budget

Removed the per-caller hydration flag and the repeated caller-side decision. No new abstraction layer was added. This PR is net-positive in lines because the added mass is boundary coverage for all three required caller paths.

## Host impact

Extension: progress-view inquiry hydration now receives inline legacy answers without passing an opt-in flag.

Desktop: no desktop-specific behavior change; shared inquiry reads normalize legacy manifests consistently.

CLI: no CLI output contract change; shared inquiry reads normalize legacy manifests consistently.

## Scheduled refactoring

Tracked in #6981: delete the legacy `answerRelativePath`-only hydration branch after one minor-release window once read write-back has migrated surviving threads; D3 verifies no `answerRelativePath`-only answered turns remain.

## Validation

- `corepack pnpm exec prettier --write packages/extension/src/progressView/ProgressViewProvider.ts src/tools/inquiry/ExternalInquiryTool.ts src/tools/inquiry/externalInquiryStorage.ts src/test-kernel/tools/InquiryStorage.vitest.ts src/test-kernel/tools/InquiryReadBoundary.vitest.ts`
- `grep -rn 'hydrate: true' src packages/*/src` (zero matches)
- `rg -n "readExternalInquiryThread\([^\n]+,\s*\{" src packages --glob '!node_modules/**'` (zero matches)
- `npm test -- --run src/test-kernel/tools/InquiryStorage.vitest.ts src/test-kernel/tools/InquiryReadBoundary.vitest.ts src/test-kernel/tools/InquiryContinuationSession.vitest.ts src/test-kernel/tools/InquiryContinuation.vitest.ts`
- `npm run typecheck -- --pretty false`
- `npm test`
- `npm run lint` (passes with 16 pre-existing warnings)
- `npm run compile:fast`
- `git diff --check HEAD~1 HEAD`

Closes #7000

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Every thread read can mutate `manifest.json` under a lock when legacy data is present; behavior is centralized but touches durable inquiry storage used across extension and agent paths.
> 
> **Overview**
> **`readExternalInquiryThread` is now the single place that turns legacy disk-only answers into inline manifest fields.** The optional `{ hydrate: true }` flag is gone; every caller (`ExternalInquiryTool`, progress-view open-inquiry replay, continuation paths) just reads the thread and gets a canonical manifest.
> 
> On read, turns that only have `answerRelativePath` are loaded from disk under the existing per-thread lock, and the manifest is **written back once** when anything was hydrated so later reads stay cheap.
> 
> New **`InquiryReadBoundary.vitest.ts`** covers tool `read`, continuation injection, and progress-view hydration for legacy fixtures; **`InquiryStorage.vitest.ts`** now asserts persistence of inlined answers after read.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8657dc7522e707a5bce3eb4f4d1d5b7c9967a7e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->