### PR TITLE
[codex] Fix streamed text delta ack race

### DIFF
--- a/src/test-kernel/progressView/WebviewBridge.vitest.ts
+++ b/src/test-kernel/progressView/WebviewBridge.vitest.ts
@@ -241,6 +241,54 @@ describe('WebviewBridge', () => {
     bridge.dispose();
   });
 
+  it('does not resend streamed text already covered by an in-flight full entry', async () => {
+    const store = new StreamLogStore();
+    const activeStream = 'active' as StreamTabId;
+    const firstDelivery = deferredBoolean();
+    const sendMessage = vi
+      .fn()
+      .mockReturnValueOnce(firstDelivery.promise)
+      .mockResolvedValue(true);
+    const bridge = new WebviewBridge(store, sendMessage, () => activeStream);
+
+    bridge.syncStream(activeStream);
+    store.append(activeStream, logEntry('active-1', '', 100));
+    store.appendText(activeStream, 'active-1', 'hello');
+    await vi.advanceTimersByTimeAsync(20);
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenLastCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.LOG_DELTA,
+      streamId: activeStream,
+      entries: [
+        expect.objectContaining({
+          id: 'active-1',
+          text: 'hello',
+        }),
+      ],
+      updates: [],
+      textDeltas: [],
+    });
+
+    store.appendText(activeStream, 'active-1', ' world');
+    await vi.advanceTimersByTimeAsync(20);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+
+    firstDelivery.resolve(true);
+    await vi.advanceTimersByTimeAsync(20);
+
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(sendMessage).toHaveBeenLastCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.LOG_DELTA,
+      streamId: activeStream,
+      entries: [],
+      updates: [],
+      textDeltas: [{ id: 'active-1', appendText: ' world' }],
+    });
+
+    bridge.dispose();
+  });
+
   it('ships streamed text as O(L) append deltas instead of full updates', async () => {
     const store = new StreamLogStore();
     const activeStream = 'active' as StreamTabId;

--- a/src/test-kernel/transcript/StreamLog.vitest.ts
+++ b/src/test-kernel/transcript/StreamLog.vitest.ts
@@ -136,4 +136,26 @@ describe('StreamLog', () => {
 
     expect(log.getDirtyTextDeltas()).toEqual([]);
   });
+
+  it('keeps only text appended while a full entry replay is in flight', () => {
+    const log = new StreamLog();
+    log.append({
+      id: 'message',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 1,
+      text: 'prefix ',
+      messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+    });
+
+    log.appendText('message', 'hello');
+    const [entry] = log.getRange(0, log.head);
+    if (!entry) throw new Error('expected delivered entry');
+    log.appendText('message', ' world');
+    log.ackDirtyTextDeltas([], [entry]);
+
+    expect(log.getDirtyTextDeltas()).toEqual([
+      { id: 'message', appendText: ' world' },
+    ]);
+  });
 });

--- a/src/transcript/StreamLog.ts
+++ b/src/transcript/StreamLog.ts
@@ -241,8 +241,41 @@ export class StreamLog {
   ): void {
     for (const entry of fullEntries) {
       const index = this.indexById.get(entry.id);
-      if (index !== undefined && this.entries[index] === entry) {
+      if (index === undefined) {
         this.dirtyTextDeltas.delete(entry.id);
+        continue;
+      }
+
+      if (this.entries[index] === entry) {
+        this.dirtyTextDeltas.delete(entry.id);
+        continue;
+      }
+
+      const current = this.dirtyTextDeltas.get(entry.id);
+      if (!current) continue;
+      const currentEntry = this.entries[index];
+      const currentText =
+        typeof currentEntry.text === 'string' ? currentEntry.text : '';
+      const deliveredText = typeof entry.text === 'string' ? entry.text : '';
+      // A full-entry frame covers all appended text between the stable base
+      // prefix and the delivered text, even if later appends replaced the row.
+      const baseLength = currentText.length - current.appendText.length;
+      const deliveredDeltaLength = deliveredText.length - baseLength;
+
+      if (
+        baseLength >= 0 &&
+        deliveredDeltaLength > 0 &&
+        currentText.endsWith(current.appendText) &&
+        currentText.startsWith(deliveredText)
+      ) {
+        if (deliveredDeltaLength >= current.appendText.length) {
+          this.dirtyTextDeltas.delete(entry.id);
+          continue;
+        }
+        this.dirtyTextDeltas.set(entry.id, {
+          id: entry.id,
+          appendText: current.appendText.slice(deliveredDeltaLength),
+        });
       }
     }
 


### PR DESCRIPTION
## Summary

Fix the transient duplicate-text race from #6991. When a full streamed row is delivered while a later `appendText()` races the in-flight frame, `StreamLog.ackDirtyTextDeltas` now trims the already-covered prefix from the pending text delta instead of relying only on entry object identity.

This keeps the next `LOG_DELTA` frame from replaying text already present in the delivered full entry, while preserving suffix text appended during delivery.

## Issue acceptance gates

Addresses #6991.

- `appendText` racing an in-flight full-entry delivery no longer causes the already-delivered text prefix to remain queued as a text delta.
- Unit coverage asserts only the suffix appended during delivery remains dirty.
- `WebviewBridge` coverage reproduces the async delivery race and verifies the next frame sends only `" world"`, not the prior `"hello"` prefix again.

## Single source of truth

`src/transcript/StreamLog.ts` remains the owner of dirty text-delta acknowledgement. `WebviewBridge` still asks the log for deltas and acks delivered frames; it does not duplicate delta reconciliation.

## Duplication and abstraction budget

No new abstraction layer or compatibility shim was added. The fix extends the existing ack boundary and adds focused regression tests.

## Host impact

Extension: progress-view streamed rows no longer show transient duplicated text when append deltas race an in-flight full-row frame.

Desktop: same shared progress-log bridge behavior; no desktop-specific contract change.

CLI: no CLI output contract change.

## Scheduled refactoring

None. This removes a hardening bug in the existing text-delta path and does not add a shim, projection, alias, or migration path.

## Validation

- `corepack pnpm exec prettier --write src/transcript/StreamLog.ts src/test-kernel/transcript/StreamLog.vitest.ts src/test-kernel/progressView/WebviewBridge.vitest.ts`
- `npm test -- --run src/test-kernel/transcript/StreamLog.vitest.ts src/test-kernel/progressView/WebviewBridge.vitest.ts`
- `npm run typecheck -- --pretty false`
- `npm test`
- `npm run lint` (passes with 16 pre-existing warnings)
- `npm run compile:fast`
- `git diff --check HEAD~1 HEAD`

Closes #6991

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to dirty text-delta acknowledgement in StreamLog with regression tests; no auth, persistence, or API contract changes.
> 
> **Overview**
> Fixes a race where **progress view** streamed rows could briefly show **duplicate text** when `appendText()` ran while a full-row `LOG_DELTA` was still in flight (#6991).
> 
> **`StreamLog.ackDirtyTextDeltas`** no longer clears dirty text deltas only when the delivered full entry is the **same object** as the live row. When the row was updated by later appends, it now compares **delivered text** to the pending delta and **drops or trims** the prefix already covered by the in-flight full entry, leaving only suffix text (e.g. `" world"`) for the next frame.
> 
> Adds unit tests on **`StreamLog`** and an async **`WebviewBridge`** test that the follow-up flush sends only the uncovered suffix, not `"hello"` again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 303aa522bc9fab53244e7e5de648423c36fe214f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->