### PR TITLE
[codex] Send per-stream progress metadata patches

### DIFF
--- a/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
@@ -18,6 +18,7 @@ import {
 import { firstStreamId, type ProgressState, type StreamState } from '../store';
 import { clearResolvedProposalIds } from './permissionSlice';
 import { pendingDescriptions, takePendingDescription } from './streamMetaSlice';
+import { mergeBackendOwnedState } from './streamStateMerge';
 import { clearCopyContentStore } from '../formatters/copyContentStore';
 import { clearProposalInputStore } from '../formatters/proposalInputStore';
 import {
@@ -29,30 +30,6 @@ import type { HandlerRegistry } from '../messageHandlerTypes';
 // ============================================================
 // Helpers
 // ============================================================
-
-function mergeBackendOwnedState(
-  existing: StreamState,
-  metadata: StreamMetadata,
-): StreamState {
-  if (existing.kind !== metadata.kind) {
-    // Kind changed — create fresh state with new-kind defaults, overlay metadata,
-    // and preserve frontend-owned taskGroups.
-    return createStreamState(metadata.kind, {
-      ...metadata,
-      taskGroups: existing.taskGroups,
-    });
-  }
-  // Overlay every backend-owned field from metadata (its own keys include
-  // every required BackendOwnedFieldsSchema field plus `kind`, which the guard
-  // above already ensures matches `existing.kind`) so a new field added to
-  // that schema is picked up here without also updating this call site.
-  return create(existing, (draft) => {
-    Object.assign(draft, metadata);
-    if (!Object.hasOwn(metadata, 'substate')) {
-      delete draft.substate;
-    }
-  });
-}
 
 function updateStreamInfo(
   state: ProgressState,

--- a/packages/extension/src/progressView/frontend/slices/streamMetaSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamMetaSlice.ts
@@ -6,7 +6,12 @@
 import { create } from 'mutative';
 
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
-import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+import {
+  createStreamState,
+  STREAM_STATUS,
+  type StreamTabId,
+  type StreamTabInfo,
+} from '@shared/schemas';
 import {
   EMPTY_STREAM_META,
   reduceStreamMeta,
@@ -18,6 +23,7 @@ import {
   isToolUseState,
   type ProcessOutputMap,
 } from '../store';
+import { mergeBackendOwnedState } from './streamStateMerge';
 import type { HandlerRegistry } from '../messageHandlerTypes';
 
 /**
@@ -42,7 +48,72 @@ export function takePendingDescription(
  */
 const WEBVIEW_OUTPUT_CAP = { maxChars: 100_000, retainChars: 80_000 } as const;
 
+function compareByNewestCreationTime(
+  a: StreamTabInfo,
+  b: StreamTabInfo,
+): number {
+  return (
+    b.creationTimestamp - a.creationTimestamp || a.name.localeCompare(b.name)
+  );
+}
+
+function upsertSortedStreamInfo(
+  streams: Map<StreamTabId, StreamTabInfo>,
+  streamInfo: StreamTabInfo,
+): Map<StreamTabId, StreamTabInfo> {
+  const streamsWithoutPatch = [...streams.values()].filter(
+    (stream) => stream.name !== streamInfo.name,
+  );
+  const ordered = [...streamsWithoutPatch, streamInfo].toSorted(
+    compareByNewestCreationTime,
+  );
+
+  return new Map(ordered.map((stream) => [stream.name, stream]));
+}
+
 export const streamMetaHandlers: HandlerRegistry = {
+  [PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA]: (data, ctx) => {
+    const name = data.streamInfo.name;
+    const pending = takePendingDescription(name);
+
+    ctx.setState((prev) => {
+      const existingInfo = prev.streamById.get(name);
+      const description =
+        data.streamInfo.description ?? pending ?? existingInfo?.description;
+      const streamInfo =
+        description !== data.streamInfo.description
+          ? { ...data.streamInfo, description }
+          : data.streamInfo;
+      const existingState = prev.streamStates.get(name);
+      const mergedState = existingState
+        ? mergeBackendOwnedState(existingState, data.streamState)
+        : createStreamState(data.streamState.kind, data.streamState);
+
+      return create(prev, (draft) => {
+        if (
+          !existingInfo ||
+          existingInfo.creationTimestamp !== streamInfo.creationTimestamp
+        ) {
+          draft.streamById = upsertSortedStreamInfo(
+            prev.streamById,
+            streamInfo,
+          );
+        } else {
+          draft.streamById.set(name, streamInfo);
+        }
+
+        draft.streamStates.set(name, mergedState);
+
+        if (data.activeStream !== undefined) {
+          draft.activeStreamId = data.activeStream || null;
+        }
+        if (data.agentFilter !== undefined) {
+          draft.streamFilter = data.agentFilter;
+        }
+      });
+    });
+  },
+
   [PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_STATUS]: (data, ctx) => {
     const { stream, status, lastTimestamp, substate } = data;
     const state = ctx.getState();

--- a/packages/extension/src/progressView/frontend/slices/streamStateMerge.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamStateMerge.ts
@@ -1,0 +1,30 @@
+import { create } from 'mutative';
+
+import { createStreamState, type StreamMetadata } from '@shared/schemas';
+
+import type { StreamState } from '../store';
+
+export function mergeBackendOwnedState(
+  existing: StreamState,
+  metadata: StreamMetadata,
+): StreamState {
+  if (existing.kind !== metadata.kind) {
+    // Kind changed: create fresh state with new-kind defaults, overlay metadata,
+    // and preserve frontend-owned taskGroups.
+    return createStreamState(metadata.kind, {
+      ...metadata,
+      taskGroups: existing.taskGroups,
+    });
+  }
+
+  // Overlay every backend-owned field from metadata (its own keys include
+  // every required BackendOwnedFieldsSchema field plus `kind`, which the guard
+  // above already ensures matches `existing.kind`) so a new field added to
+  // that schema is picked up here without also updating this call site.
+  return create(existing, (draft) => {
+    Object.assign(draft, metadata);
+    if (!Object.hasOwn(metadata, 'substate')) {
+      delete draft.substate;
+    }
+  });
+}

--- a/src/shared/ipc/progressViewCommands.ts
+++ b/src/shared/ipc/progressViewCommands.ts
@@ -8,6 +8,7 @@ export const PROGRESS_VIEW_COMMANDS = {
   CLEAN_STREAM: 'cleanStream',
   STOP_STREAM: 'stopStream',
   UPDATE_STREAMS: 'updateStreams',
+  UPDATE_STREAM_METADATA: 'updateStreamMetadata',
   DELETE_ALL: 'deleteAll',
 
   LOG_DELTA: 'logDelta',

--- a/src/shared/progressView/backend/WebviewUpdater.ts
+++ b/src/shared/progressView/backend/WebviewUpdater.ts
@@ -19,7 +19,10 @@ import type {
   TodoItem,
   TokenUsageStats,
 } from '@shared/schemas';
-import { buildStreamInfos } from '@shared/progressView/backend/streamInfoUtils';
+import {
+  buildStreamInfo,
+  buildStreamInfos,
+} from '@shared/progressView/backend/streamInfoUtils';
 import {
   type ActiveStreamId,
   ProgressViewState,
@@ -85,6 +88,9 @@ export interface SyncStreamContentPayload extends LogContentExtras {
  * Targets a single active webview at a time (sidebar OR editor panel).
  */
 export class WebviewUpdater {
+  private readonly streamInfoCache = new Map<StreamTabId, StreamTabInfo>();
+  private readonly streamMetadataCache = new Map<StreamTabId, StreamMetadata>();
+
   constructor(
     private readonly send: ProgressViewMessageSender,
     private readonly hasTarget: () => boolean,
@@ -115,6 +121,36 @@ export class WebviewUpdater {
       activeStream,
       agentFilter,
       streamStates,
+    });
+  }
+
+  updateStreamMetadata(
+    state: ProgressViewState,
+    streamId: StreamTabId,
+    statuses?: Map<string, StreamPhase>,
+    substates?: Map<string, StreamSubstate>,
+    options?: {
+      activeStream?: ActiveStreamId;
+      agentFilter?: AgentCategoryFilter;
+    },
+  ): void {
+    const streamInfo = buildStreamInfo(state, streamId, 'all');
+    if (!streamInfo) return;
+
+    const streamState = this.buildStreamMetadataForStream(
+      state,
+      streamInfo,
+      statuses,
+      substates,
+    );
+    this.cacheStreamSnapshot(streamInfo, streamState);
+
+    this.sendMessage({
+      command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA,
+      streamInfo,
+      streamState,
+      activeStream: options?.activeStream,
+      agentFilter: options?.agentFilter,
     });
   }
 
@@ -429,22 +465,20 @@ export class WebviewUpdater {
     }
 
     // Send lightweight metadata — only backend-owned fields the frontend merges.
-    const allStates = state.getAllStreamStates();
     const streamMetadata: Record<StreamTabId, StreamMetadata> = {};
-    for (const { name, agentCategory } of streams) {
-      const current = allStates.get(name);
-      streamMetadata[name] = buildStreamMetadata({
-        kind: agentCategory,
-        status: statuses?.get(name),
-        substate: substates?.get(name),
-        lastTimestamp: state.streamLogs.getLastTimestamp(name),
-        conversationProgress: current?.conversationProgress,
-        activeSubagents: current?.activeSubagents,
-        finishedSubagentCount: current?.finishedSubagentCount,
-        activeProcesses: current?.activeProcesses,
-        finishedProcessCount: current?.finishedProcessCount,
-      });
+    const liveStreams = new Set<StreamTabId>();
+    for (const streamInfo of streams) {
+      liveStreams.add(streamInfo.name);
+      const metadata = this.buildStreamMetadataForStream(
+        state,
+        streamInfo,
+        statuses,
+        substates,
+      );
+      streamMetadata[streamInfo.name] = metadata;
+      this.cacheStreamSnapshot(streamInfo, metadata);
     }
+    this.pruneStreamSnapshotCache(liveStreams);
 
     this.updateStreams(
       streams,
@@ -458,5 +492,41 @@ export class WebviewUpdater {
 
   isAvailable(): boolean {
     return this.hasTarget();
+  }
+
+  private buildStreamMetadataForStream(
+    state: ProgressViewState,
+    streamInfo: StreamTabInfo,
+    statuses?: Map<string, StreamPhase>,
+    substates?: Map<string, StreamSubstate>,
+  ): StreamMetadata {
+    const current = state.getStreamState(streamInfo.name);
+    return buildStreamMetadata({
+      kind: streamInfo.agentCategory,
+      status: statuses?.get(streamInfo.name),
+      substate: substates?.get(streamInfo.name),
+      lastTimestamp: state.streamLogs.getLastTimestamp(streamInfo.name),
+      conversationProgress: current?.conversationProgress,
+      activeSubagents: current?.activeSubagents,
+      finishedSubagentCount: current?.finishedSubagentCount,
+      activeProcesses: current?.activeProcesses,
+      finishedProcessCount: current?.finishedProcessCount,
+    });
+  }
+
+  private cacheStreamSnapshot(
+    streamInfo: StreamTabInfo,
+    metadata: StreamMetadata,
+  ): void {
+    this.streamInfoCache.set(streamInfo.name, streamInfo);
+    this.streamMetadataCache.set(streamInfo.name, metadata);
+  }
+
+  private pruneStreamSnapshotCache(liveStreams: Set<StreamTabId>): void {
+    for (const streamId of this.streamInfoCache.keys()) {
+      if (liveStreams.has(streamId)) continue;
+      this.streamInfoCache.delete(streamId);
+      this.streamMetadataCache.delete(streamId);
+    }
   }
 }

--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -346,11 +346,17 @@ export class ProgressEventHandler {
 
     const filterChanged = this.state.agentCategoryFilter !== previousFilter;
     if (!wasKnownStream || filterChanged) {
-      this.webviewUpdater.sendStreamMetadata(
+      this.webviewUpdater.updateStreamMetadata(
         this.state,
+        streamId,
         this.state.streamStatus.getAll(),
-        undefined,
         this.state.streamStatus.getAllSubstates(),
+        {
+          activeStream: shouldSwitch ? this.state.activeStream : undefined,
+          agentFilter: filterChanged
+            ? this.state.agentCategoryFilter
+            : undefined,
+        },
       );
     } else if (shouldSwitch) {
       this.webviewUpdater.setActiveStream(streamId);
@@ -383,16 +389,19 @@ export class ProgressEventHandler {
     }
 
     if (this.webviewUpdater.isAvailable()) {
-      // sendStreamMetadata rebuilds StreamTabInfo[] for all visible streams.
-      // This fires once per run start (not during streaming) so the O(N)
-      // cost is acceptable. We need it here because setTaskState may change
-      // agentConfig (agent name, model, label) which the frontend tabs display,
-      // including for background subagents that are not the active stream.
-      this.webviewUpdater.sendStreamMetadata(
+      // setTaskState may change agentConfig (agent name, model, label), which
+      // the frontend tabs display even for background subagents. Patch only
+      // the affected stream instead of rebuilding all historical stream tabs.
+      this.webviewUpdater.updateStreamMetadata(
         this.state,
+        streamId,
         this.state.streamStatus.getAll(),
-        undefined,
         this.state.streamStatus.getAllSubstates(),
+        {
+          agentFilter: isActiveStream
+            ? this.state.agentCategoryFilter
+            : undefined,
+        },
       );
     }
   }
@@ -603,7 +612,13 @@ export class ProgressEventHandler {
     this.state.getOrCreateStreamState(streamId, category);
 
     if (isNewStream) {
-      this.maybeUpdateFilterForCategory(this.getStreamCategory(streamId));
+      this.maybeUpdateFilterForCategory(category);
+      const matchesFilter =
+        this.state.agentCategoryFilter === 'all' ||
+        this.state.agentCategoryFilter === category;
+      if (!this.state.activeStream && matchesFilter) {
+        this.state.activeStream = streamId;
+      }
       const statusesForRefresh = this.state.streamStatus.getAll();
       statusesForRefresh.set(streamId, status);
       const substatesForRefresh = this.state.streamStatus.getAllSubstates();
@@ -612,11 +627,18 @@ export class ProgressEventHandler {
       } else {
         substatesForRefresh.delete(streamId);
       }
-      this.webviewUpdater.sendStreamMetadata(
+      this.webviewUpdater.updateStreamMetadata(
         this.state,
+        streamId,
         statusesForRefresh,
-        undefined,
         substatesForRefresh,
+        {
+          activeStream:
+            !this.state.activeStream || this.state.activeStream === streamId
+              ? this.state.activeStream
+              : undefined,
+          agentFilter: this.state.agentCategoryFilter,
+        },
       );
     } else {
       const lastTimestamp = this.state.streamLogs.getLastTimestamp(streamId);

--- a/src/shared/progressView/backend/state/ProgressViewState.ts
+++ b/src/shared/progressView/backend/state/ProgressViewState.ts
@@ -236,7 +236,10 @@ export class ProgressViewState {
   clearStreamHints(streamTabId: StreamTabId): void {
     const state = this._sessionState.get(streamTabId);
     if (state) {
-      state.hints = {};
+      state.hints =
+        state.hints.creationTimestamp === undefined
+          ? {}
+          : { creationTimestamp: state.hints.creationTimestamp };
     }
   }
 

--- a/src/shared/schemas/progressView/outbound.ts
+++ b/src/shared/schemas/progressView/outbound.ts
@@ -49,6 +49,14 @@ export const UpdateStreamsMessageSchema = z.object({
   streamStates: z.record(z.string(), StreamMetadataSchema).optional(),
 });
 
+export const UpdateStreamMetadataMessageSchema = z.object({
+  command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA),
+  streamInfo: StreamTabInfoSchema,
+  streamState: StreamMetadataSchema,
+  activeStream: z.union([StreamTabIdSchema, z.literal('')]).optional(),
+  agentFilter: AgentCategoryFilterSchema.optional(),
+});
+
 export const SetActiveStreamMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM),
   activeStream: z.union([StreamTabIdSchema, z.literal('')]),
@@ -327,6 +335,7 @@ export const ProgressViewOutboundMessageSchema = z.discriminatedUnion(
   'command',
   [
     UpdateStreamsMessageSchema,
+    UpdateStreamMetadataMessageSchema,
     SetActiveStreamMessageSchema,
     UpdateConversationProgressMessageSchema,
     UpdateStreamBadgesMessageSchema,

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -164,6 +164,7 @@ type ProgressMessage = {
   reset?: boolean;
   streams?: Array<{ name: string; creationTimestamp: number }>;
   streamStates?: Record<string, unknown>;
+  streamState?: unknown;
 };
 
 function mockLoggerModule(): void {
@@ -669,10 +670,12 @@ describe('DesktopProgressBridge', () => {
 
       expect(
         messages.map((message) => (message as ProgressMessage).command),
-      ).toEqual([PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS]);
+      ).toEqual([PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA]);
       expect(
-        progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS)[0]
-          ?.streamStates?.['new-stream'],
+        progressMessages(
+          messages,
+          PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA,
+        )[0]?.streamState,
       ).toMatchObject({ status: STREAM_STATUS.RUNNING });
     } finally {
       bridge.dispose();

--- a/src/test-kernel/progressView/ProcessOutputState.vitest.ts
+++ b/src/test-kernel/progressView/ProcessOutputState.vitest.ts
@@ -97,6 +97,100 @@ function dispatch(
 }
 
 describe('process output frontend state', () => {
+  it('patches one stream metadata record without replacing siblings', () => {
+    const streamId = 'stream-a' as StreamTabId;
+    const siblingId = 'stream-b' as StreamTabId;
+    const state = createInitialState();
+    state.activeStreamId = streamId;
+    state.streamFilter = 'workflow';
+    state.streamById.set(siblingId, {
+      name: siblingId,
+      label: 'old sibling',
+      agentCategory: AgentCategory.ToolUse,
+      creationTimestamp: 2,
+    });
+    state.streamById.set(streamId, {
+      name: streamId,
+      label: 'stream-a',
+      agentCategory: AgentCategory.Workflow,
+      creationTimestamp: 1,
+    });
+    state.streamStates.set(streamId, createStreamState(AgentCategory.Workflow));
+    state.streamStates.set(
+      siblingId,
+      createStreamState(AgentCategory.ToolUse, {
+        status: STREAM_PHASE.RUNNING,
+        activeSubagents: [
+          {
+            executionId: 'old-child',
+            agentName: 'old child',
+          },
+        ],
+      } satisfies Partial<StreamState>),
+    );
+    const { ctx, getState } = createContext(state);
+
+    dispatch(
+      streamMetaHandlers,
+      {
+        command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA,
+        streamInfo: {
+          name: siblingId,
+          label: 'search',
+          agent: 'search',
+          model: 'deepseekproT',
+          agentCategory: AgentCategory.ToolUse,
+          creationTimestamp: 2,
+        },
+        streamState: {
+          kind: AgentCategory.ToolUse,
+          status: STREAM_PHASE.WAITING,
+          lastTimestamp: 9,
+          conversationProgress: {
+            conversationTurns: 2,
+            toolCallCount: 3,
+          },
+          activeSubagents: [],
+          finishedSubagentCount: 1,
+          activeProcesses: [
+            {
+              executionId: 'process-a',
+              agentName: 'bash',
+            },
+          ],
+          finishedProcessCount: 0,
+        },
+        activeStream: siblingId,
+        agentFilter: 'toolUse',
+      },
+      ctx,
+    );
+
+    expect(getState().streamById.get(streamId)?.label).toBe('stream-a');
+    expect(getState().streamById.get(siblingId)).toMatchObject({
+      label: 'search',
+      model: 'deepseekproT',
+    });
+    expect(getState().streamStates.get(siblingId)).toMatchObject({
+      status: STREAM_PHASE.WAITING,
+      lastTimestamp: 9,
+      conversationProgress: {
+        conversationTurns: 2,
+        toolCallCount: 3,
+      },
+      finishedSubagentCount: 1,
+      activeProcesses: [
+        {
+          executionId: 'process-a',
+          agentName: 'bash',
+        },
+      ],
+    });
+    expect(getState().activeStreamId).toBe(siblingId);
+    expect(getState().streamFilter).toBe('toolUse');
+    expect([...getState().streamById.keys()]).toEqual([siblingId, streamId]);
+  });
+
   it('appends output without pruning sibling process entries', () => {
     const streamId = 'stream-a' as StreamTabId;
     const { ctx, getState } = createContext(createProcessState(streamId));

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -146,7 +146,54 @@ describe('ProgressBackend', () => {
     backend.dispose();
   });
 
-  it('refreshes stream metadata when inactive stream task state arrives', async () => {
+  it('sends the full metadata set once for full-view sync', () => {
+    const messages: ProgressViewOutboundMessage[] = [];
+    const backend = new ProgressBackend({
+      storage: new MemoryMementoStorage(),
+      sendMessage: (message) => {
+        messages.push(message);
+        return true;
+      },
+      hasTarget: () => true,
+      configureUi: () => createUiConfig(),
+    });
+
+    for (let i = 0; i < 20; i += 1) {
+      backend.state.streamLogs.ensureStream(`history-${i}`);
+    }
+
+    backend.webviewUpdater.sendStreamMetadata(
+      backend.state,
+      backend.eventHandler.getAllStreamStatuses(),
+      undefined,
+      backend.eventHandler.getAllStreamSubstates(),
+    );
+
+    expect(
+      messages.filter(
+        (message) => message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+      ),
+    ).toHaveLength(1);
+    expect(
+      messages.filter(
+        (message) =>
+          message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA,
+      ),
+    ).toHaveLength(0);
+
+    const fullSync = messages.find(
+      (message) => message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+    );
+    if (fullSync?.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS) {
+      expect(fullSync.streams).toHaveLength(20);
+    } else {
+      throw new Error('Expected full stream metadata sync');
+    }
+
+    backend.dispose();
+  });
+
+  it('patches one stream for subagent registration and run-start metadata', async () => {
     const messages: ProgressViewOutboundMessage[] = [];
     const backend = new ProgressBackend({
       storage: new MemoryMementoStorage(),
@@ -160,6 +207,10 @@ describe('ProgressBackend', () => {
     const subscription = backend.setupEventListeners(bus);
 
     try {
+      for (let i = 0; i < 20; i += 1) {
+        backend.state.streamLogs.ensureStream(`history-${i}`);
+      }
+
       bus.emit('setActiveStream', {
         streamId: 'root',
         agentCategory: AgentCategory.Workflow,
@@ -168,10 +219,11 @@ describe('ProgressBackend', () => {
         expect(
           messages.some(
             (message) =>
-              message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+              message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA,
           ),
         ).toBe(true),
       );
+      messages.length = 0;
 
       bus.emit('setActiveStream', {
         streamId: 'child',
@@ -180,13 +232,20 @@ describe('ProgressBackend', () => {
       });
       await vi.waitFor(() =>
         expect(
-          messages.some(
+          messages.find(
             (message) =>
-              message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS &&
-              message.streams.some((stream) => stream.name === 'child'),
+              message.command ===
+                PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA &&
+              message.streamInfo.name === 'child',
           ),
-        ).toBe(true),
+        ).toBeDefined(),
       );
+      expect(
+        messages.some(
+          (message) =>
+            message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+        ),
+      ).toBe(false);
       messages.length = 0;
 
       bus.emit('setTaskState', {
@@ -199,21 +258,52 @@ describe('ProgressBackend', () => {
         expect(
           messages.find(
             (message) =>
-              message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+              message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA,
           ),
         ).toMatchObject({
-          activeStream: 'root',
-          streams: expect.arrayContaining([
-            expect.objectContaining({
-              name: 'child',
-              label: 'search',
-              agent: 'search',
-              model: 'deepseekproT',
-              executionId: 'exec-child',
-            }),
-          ]),
+          streamInfo: {
+            name: 'child',
+            label: 'search',
+            agent: 'search',
+            model: 'deepseekproT',
+            executionId: 'exec-child',
+          },
         }),
       );
+      expect(
+        messages.some(
+          (message) =>
+            message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+        ),
+      ).toBe(false);
+
+      const patch = messages.find(
+        (message) =>
+          message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA,
+      );
+      messages.length = 0;
+
+      backend.webviewUpdater.sendStreamMetadata(
+        backend.state,
+        backend.eventHandler.getAllStreamStatuses(),
+        undefined,
+        backend.eventHandler.getAllStreamSubstates(),
+      );
+      const fullSync = messages.find(
+        (message) => message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+      );
+
+      if (
+        patch?.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA &&
+        fullSync?.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS
+      ) {
+        expect(
+          fullSync.streams.find((stream) => stream.name === 'child'),
+        ).toEqual(patch.streamInfo);
+        expect(fullSync.streamStates?.child).toEqual(patch.streamState);
+      } else {
+        throw new Error('Expected patch and full sync messages');
+      }
     } finally {
       subscription.dispose();
       backend.dispose();


### PR DESCRIPTION
## Summary

Adds a per-stream progress metadata update path so run-start and new/subagent stream registration no longer rebuild and send every historical stream tab. Full metadata sync remains for webview ready/filter/delete refreshes.

Note: #6952 requires #6991 before or with #6970; this PR should merge after #7004 lands.

## Issue acceptance gates

#6970:
- Run start and subagent spawn no longer trigger a full-set rebuild: covered by `ProgressBackend.vitest.ts`, which asserts those paths emit `UPDATE_STREAM_METADATA` and no `UPDATE_STREAMS` with many persisted streams.
- Startup/full-view sync with N persisted streams sends the full set exactly once: covered by `ProgressBackend.vitest.ts`.
- Tab labels/model chips/badges identical before/after: covered by the patch-vs-full metadata snapshot assertion and the frontend reducer patch test.

## Single source of truth

`WebviewUpdater` now owns both full stream metadata sync (`sendStreamMetadata`) and one-stream metadata patches (`updateStreamMetadata`) using the same `StreamMetadata` builder and outbound schema family.

## Duplication and abstraction budget

The frontend backend-owned metadata merge was moved into `streamStateMerge.ts` so full sync and one-stream patches share the same merge semantics. No shim/projection/dual-write/migration path was added, so no #6981 ledger row is needed. This PR is net-positive in lines because the added mass is the new message contract plus regression tests for the three acceptance gates.

## Host impact

Extension: progress view receives targeted stream metadata patches for run-start/new-stream updates instead of full stream lists.

Desktop: shared progress backend emits the same targeted metadata message; desktop tests were updated for the new announcement command.

CLI: no CLI/headless output behavior change.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write src/shared/ipc/progressViewCommands.ts src/shared/schemas/progressView/outbound.ts src/shared/progressView/backend/WebviewUpdater.ts src/shared/progressView/backend/events/ProgressEventHandler.ts src/shared/progressView/backend/state/ProgressViewState.ts packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts packages/extension/src/progressView/frontend/slices/streamMetaSlice.ts packages/extension/src/progressView/frontend/slices/streamStateMerge.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/progressView/ProcessOutputState.vitest.ts`
- `npm test -- --run src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/progressView/ProcessOutputState.vitest.ts`
- `npm run typecheck -- --pretty false`
- `npm test`
- `npm run lint` (passes with 16 pre-existing warnings)
- `npm run compile:fast`
- `git diff --check`

Closes #6970

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes progress view IPC and frontend merge/ordering behavior for stream tabs; regression risk is mitigated by dedicated backend and reducer tests, but tab metadata and active-stream edge cases need careful review.
> 
> **Overview**
> Adds **`UPDATE_STREAM_METADATA`** so the progress backend can push **one stream’s** tab info and backend-owned state instead of rebuilding and sending every historical tab on run start, subagent registration, and first status for a new stream. **`sendStreamMetadata` / `UPDATE_STREAMS`** remain for full-view sync (startup, filter/delete refresh).
> 
> **Backend:** `WebviewUpdater.updateStreamMetadata` builds a single `StreamTabInfo` + `StreamMetadata`, optionally carries `activeStream` / `agentFilter`, and caches snapshots during full sync. **`ProgressEventHandler`** routes those incremental cases to patches instead of full metadata rebuilds; new streams can set active stream when none is selected.
> 
> **Frontend:** New reducer handler upserts one tab (sorted by creation time), merges state via shared **`mergeBackendOwnedState`** in **`streamStateMerge.ts`**, and leaves sibling streams untouched. **`clearStreamHints`** now keeps **`creationTimestamp`** when clearing other hints.
> 
> Tests assert patch-vs-full parity and that many persisted streams no longer trigger **`UPDATE_STREAMS`** on incremental paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 817393e0e9f606e49ea747068cde1f5317e6599a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->