### PR TITLE
[codex] Back fake platform filesystem with memfs

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "globals": "^17.7.0",
     "jsdom": "^29.1.1",
     "knip": "^6.24.0",
+    "memfs": "^4.57.8",
     "nunjucks": "^3.2.4",
     "prettier": "^3.9.4",
     "typescript": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  ink@7.1.0:
-    hash: db8f5740efe4e780f6517316175dfed1e68d62e76e533c06bf0b8f5e94b48aa6
-    path: patches/ink@7.1.0.patch
+  ink@7.1.0: db8f5740efe4e780f6517316175dfed1e68d62e76e533c06bf0b8f5e94b48aa6
 
 importers:
 
@@ -362,6 +360,9 @@ importers:
       knip:
         specifier: ^6.24.0
         version: 6.24.0
+      memfs:
+        specifier: ^4.57.8
+        version: 4.57.8(tslib@2.8.1)
       nunjucks:
         specifier: ^3.2.4
         version: 3.2.4(chokidar@3.6.0)
@@ -1526,6 +1527,126 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@jsonjoy.com/base64@1.1.2':
+    resolution: {integrity: sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/base64@17.67.0':
+    resolution: {integrity: sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/buffers@1.2.1':
+    resolution: {integrity: sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/buffers@17.67.0':
+    resolution: {integrity: sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/codegen@1.0.0':
+    resolution: {integrity: sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/codegen@17.67.0':
+    resolution: {integrity: sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-core@4.57.8':
+    resolution: {integrity: sha512-YzVbwggV9452VCeHgo0bjsTaUt1O7JE0XpEsPar93nn/+RAwXk0mb1Y+f5EDJ3TRtRCFe+Ck5RuojdfB4jeHVw==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-fsa@4.57.8':
+    resolution: {integrity: sha512-vmClyvCQMxgqz7uamDiGtRfp4MjzOznk3pcQjCxlIwJcw7TWeyr+bF30hI0x8NxdtNOGMg1pHM74VDIXOeyjuw==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-node-builtins@4.57.8':
+    resolution: {integrity: sha512-mxXSXw8zZwRVakcjLqR2I/psy4gURFSASZS10kKJ2kJw05GC2nXGroGrWVHxwgkxXgQLsFQnB74QaLzsxzdL/w==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-node-to-fsa@4.57.8':
+    resolution: {integrity: sha512-AWZcT/4+H+iDl4XCukbXrarvwEgOrf/prFI5/7eg4ix9FxqVsZysIDJd1Kjd+AjlCeHKHJOaRqjLd5HiGSCJEw==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-node-utils@4.57.8':
+    resolution: {integrity: sha512-E/bJ7sQAb4pu9nbeJhbULU3WnqWrswte4N9Js/oHt7aHB746S8/XBqKlcbrqIgnD3095XluovNEZuu5ONT230g==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-node@4.57.8':
+    resolution: {integrity: sha512-IPEOlDYSnTDYpjQlQg2F8h+eqxKQN3sdbroI0WrteRiQZ462HzVpBo9ZZX485njz4nAacoe3fd4iDiIhk+k5Hg==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-print@4.57.8':
+    resolution: {integrity: sha512-DfzhOBpmvNu5P/KSe4NNQaOnvNliTdcf0qrh/4EReErF/XUQXYkd0vZl/OiJCm/qjEEo8DWRstliw2/JNS84dA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-snapshot@4.57.8':
+    resolution: {integrity: sha512-L+eqKaWOHLDaiMv1dh/EWQ4hA+o6xAhWSumTo3Teg7OM18jU/KE13/e8Mfal+eAZ/pSl4wIhKHcDiwapJzC8Wg==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/json-pack@1.21.0':
+    resolution: {integrity: sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/json-pack@17.67.0':
+    resolution: {integrity: sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/json-pointer@1.0.2':
+    resolution: {integrity: sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/json-pointer@17.67.0':
+    resolution: {integrity: sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/util@1.9.0':
+    resolution: {integrity: sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/util@17.67.0':
+    resolution: {integrity: sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
 
   '@keyv/serialize@1.1.1':
     resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
@@ -3901,6 +4022,12 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob-to-regex.js@1.2.0:
+    resolution: {integrity: sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
@@ -4033,6 +4160,10 @@ packages:
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
+
+  hyperdyperid@1.2.0:
+    resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
+    engines: {node: '>=10.18'}
 
   iceberg-js@0.8.1:
     resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
@@ -4525,6 +4656,11 @@ packages:
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
+
+  memfs@4.57.8:
+    resolution: {integrity: sha512-bApYhn8BLpFAnAQmFfEl/NPN+8qx5Ar3V4Qt3ek23mVwBEElzV7c6XoPkb/PCG8ZFpowCEpHcPwMFTwHS7tSMA==}
+    peerDependencies:
+      tslib: '2'
 
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
@@ -5561,6 +5697,12 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  thingies@2.6.0:
+    resolution: {integrity: sha512-rMHRjmlFLM1R96UYPvpmnc3LYtdFrT33JIB7L9hetGue1qAPfn1N2LJeEjxUSidu1Iku+haLZXDuEXUHNGO/lg==}
+    engines: {node: '>=10.18'}
+    peerDependencies:
+      tslib: ^2
+
   tiny-async-pool@1.3.0:
     resolution: {integrity: sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==}
 
@@ -5612,6 +5754,12 @@ packages:
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
+
+  tree-dump@1.1.0:
+    resolution: {integrity: sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -6920,6 +7068,133 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@jsonjoy.com/base64@1.1.2(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/base64@17.67.0(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/buffers@1.2.1(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/buffers@17.67.0(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/codegen@1.0.0(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/codegen@17.67.0(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-core@4.57.8(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-node-builtins': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.8(tslib@2.8.1)
+      thingies: 2.6.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-fsa@4.57.8(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-core': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.8(tslib@2.8.1)
+      thingies: 2.6.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-node-builtins@4.57.8(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-node-to-fsa@4.57.8(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-fsa': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.8(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-node-utils@4.57.8(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-node-builtins': 4.57.8(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-node@4.57.8(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-core': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-print': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-snapshot': 4.57.8(tslib@2.8.1)
+      glob-to-regex.js: 1.2.0(tslib@2.8.1)
+      thingies: 2.6.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-print@4.57.8(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-node-utils': 4.57.8(tslib@2.8.1)
+      tree-dump: 1.1.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-snapshot@4.57.8(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/buffers': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/json-pack': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/util': 17.67.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/json-pack@1.21.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/base64': 1.1.2(tslib@2.8.1)
+      '@jsonjoy.com/buffers': 1.2.1(tslib@2.8.1)
+      '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
+      '@jsonjoy.com/json-pointer': 1.0.2(tslib@2.8.1)
+      '@jsonjoy.com/util': 1.9.0(tslib@2.8.1)
+      hyperdyperid: 1.2.0
+      thingies: 2.6.0(tslib@2.8.1)
+      tree-dump: 1.1.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/json-pack@17.67.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/base64': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/buffers': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/codegen': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/json-pointer': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/util': 17.67.0(tslib@2.8.1)
+      hyperdyperid: 1.2.0
+      thingies: 2.6.0(tslib@2.8.1)
+      tree-dump: 1.1.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/json-pointer@1.0.2(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
+      '@jsonjoy.com/util': 1.9.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/json-pointer@17.67.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/util': 17.67.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/util@1.9.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/buffers': 1.2.1(tslib@2.8.1)
+      '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/util@17.67.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/buffers': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/codegen': 17.67.0(tslib@2.8.1)
+      tslib: 2.8.1
 
   '@keyv/serialize@1.1.1': {}
 
@@ -9442,6 +9717,10 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob-to-regex.js@1.2.0(tslib@2.8.1):
+    dependencies:
+      tslib: 2.8.1
+
   glob@13.0.6:
     dependencies:
       minimatch: 10.2.5
@@ -9613,6 +9892,8 @@ snapshots:
   human-signals@2.1.0: {}
 
   human-signals@8.0.1: {}
+
+  hyperdyperid@1.2.0: {}
 
   iceberg-js@0.8.1: {}
 
@@ -10070,6 +10351,23 @@ snapshots:
   mdurl@2.0.0: {}
 
   media-typer@1.1.0: {}
+
+  memfs@4.57.8(tslib@2.8.1):
+    dependencies:
+      '@jsonjoy.com/fs-core': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-fsa': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-node': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-to-fsa': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-print': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-snapshot': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/json-pack': 1.21.0(tslib@2.8.1)
+      '@jsonjoy.com/util': 1.9.0(tslib@2.8.1)
+      glob-to-regex.js: 1.2.0(tslib@2.8.1)
+      thingies: 2.6.0(tslib@2.8.1)
+      tree-dump: 1.1.0(tslib@2.8.1)
+      tslib: 2.8.1
 
   merge-descriptors@2.0.0: {}
 
@@ -11153,6 +11451,10 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  thingies@2.6.0(tslib@2.8.1):
+    dependencies:
+      tslib: 2.8.1
+
   tiny-async-pool@1.3.0:
     dependencies:
       semver: 5.7.2
@@ -11198,6 +11500,10 @@ snapshots:
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
+
+  tree-dump@1.1.0(tslib@2.8.1):
+    dependencies:
+      tslib: 2.8.1
 
   tree-kill@1.2.2: {}
 

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -91,6 +91,36 @@ function storedConfig(
   };
 }
 
+async function initNodeBackedPlatform(options: {
+  storagePath: string;
+  globalStoragePath: string;
+}): Promise<void> {
+  const [{ initPlatform }, { nodeFilesystem }, { createFakePlatform }] =
+    await Promise.all([
+      import('@platform/platform'),
+      import('@platform/defaults/nodeFilesystem'),
+      import('@test/support/FakePlatform'),
+    ]);
+  initPlatform(
+    createFakePlatform(
+      {
+        workspacePath: process.cwd(),
+        storagePath: options.storagePath,
+        globalStoragePath: options.globalStoragePath,
+      },
+      { fs: nodeFilesystem },
+    ),
+  );
+}
+
+async function initDefaultFakePlatform(): Promise<void> {
+  const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
+    import('@platform/platform'),
+    import('@test/support/FakePlatform'),
+  ]);
+  initPlatform(createFakePlatform());
+}
+
 describe('CLI root argument routing', () => {
   it('routes top-level --logout to the logout subcommand', () => {
     expect(normalizeRootShortcuts(['--logout'])).toEqual(['logout']);
@@ -1165,8 +1195,16 @@ describe('runCli usage output stream routing', () => {
   let stderrSpy: ReturnType<typeof vi.spyOn>;
   let consoleLogSpy: ReturnType<typeof vi.spyOn>;
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let platformStorageRoot = '';
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    platformStorageRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'texra-cli-root-'),
+    );
+    await initNodeBackedPlatform({
+      storagePath: path.join(platformStorageRoot, 'storage'),
+      globalStoragePath: path.join(platformStorageRoot, 'global-storage'),
+    });
     stdout = '';
     stderr = '';
     stdoutSpy = vi
@@ -1200,11 +1238,16 @@ describe('runCli usage output stream routing', () => {
       });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     stdoutSpy.mockRestore();
     stderrSpy.mockRestore();
     consoleLogSpy.mockRestore();
     consoleErrorSpy.mockRestore();
+    if (platformStorageRoot) {
+      await fs.rm(platformStorageRoot, { recursive: true, force: true });
+      platformStorageRoot = '';
+    }
+    await initDefaultFakePlatform();
   });
 
   it('routes usage text to stderr (not stdout) on a usage error', async () => {

--- a/src/test-kernel/platform/FakePlatform.vitest.ts
+++ b/src/test-kernel/platform/FakePlatform.vitest.ts
@@ -1,11 +1,17 @@
 // Third-party imports
 import { strict as assert } from 'node:assert';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { describe, it } from 'vitest';
 
-// Standard library imports
-
 // Local imports - platform
-import { FileType } from '@platform/interfaces/filesystem';
+import {
+  FileType,
+  type FileSystemProvider,
+} from '@platform/interfaces/filesystem';
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { platform } from '@platform/platform';
 
 // Local imports - test support
 import {
@@ -13,20 +19,75 @@ import {
   createFakePlatform,
 } from '../support/FakePlatform';
 
-type FsRecord = {
-  type: number;
-  ctime: number;
-  mtime: number;
-  content?: Uint8Array;
+type ProviderCase = {
+  name: string;
+  provider: FileSystemProvider;
+  resolve(testPath: string): string;
+  expectedRealPath(testPath: string): Promise<string>;
+  cleanup(): Promise<void>;
 };
 
-// Reaches into the in-memory provider's private record map for timestamp and
-// implicit-directory assertions.
-function fsRecords(fs: FakeFileSystemProvider): Map<string, FsRecord> {
-  return (fs as unknown as { records: Map<string, FsRecord> }).records;
+async function createProviderCase(
+  name: 'fake' | 'node',
+): Promise<ProviderCase> {
+  if (name === 'fake') {
+    return {
+      name,
+      provider: new FakeFileSystemProvider(),
+      resolve: (testPath) => testPath,
+      expectedRealPath: async (testPath) => testPath,
+      cleanup: async () => {},
+    };
+  }
+
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-fs-'));
+  return {
+    name,
+    provider: nodeFilesystem,
+    resolve: (testPath) => path.join(root, testPath.slice(1)),
+    expectedRealPath: (testPath) =>
+      fs.realpath(path.join(root, testPath.slice(1))),
+    cleanup: () => fs.rm(root, { recursive: true, force: true }),
+  };
+}
+
+async function withProviders(
+  run: (ctx: ProviderCase) => Promise<void>,
+): Promise<void> {
+  for (const name of ['fake', 'node'] as const) {
+    const ctx = await createProviderCase(name);
+    try {
+      await run(ctx);
+    } finally {
+      await ctx.cleanup();
+    }
+  }
+}
+
+function text(content: Uint8Array): string {
+  return Buffer.from(content).toString('utf8');
+}
+
+function sortedEntries(entries: [string, number][]): [string, number][] {
+  return entries.toSorted(([left], [right]) => left.localeCompare(right));
+}
+
+async function rejectsWithCode(
+  operation: () => Promise<unknown>,
+  code: string,
+): Promise<void> {
+  await assert.rejects(operation, (err: unknown) => {
+    assert.equal((err as NodeJS.ErrnoException).code, code);
+    return true;
+  });
 }
 
 describe('FakePlatform', () => {
+  it('installs a default fake platform from vitest setup', () => {
+    assert.equal(platform().workspace.getWorkspacePath(), '/workspace');
+    assert.equal(platform().fs instanceof FakeFileSystemProvider, true);
+  });
+
   it('provides overridable platform services for tests', async () => {
     const platform = createFakePlatform({
       config: { enabled: true },
@@ -153,283 +214,207 @@ describe('FakePlatform', () => {
     assert.ok(platform.secrets);
   });
 
-  it('implements in-memory filesystem operations', async () => {
-    const fs = new FakeFileSystemProvider();
+  it('keeps fake-only convenience helpers backed by the provider', async () => {
+    const fakeFs = new FakeFileSystemProvider();
 
-    await fs.createDirectory('/workspace/docs');
-    await fs.writeFile('/workspace/docs/a.txt', Buffer.from('A'));
-    await fs.copy('/workspace/docs/a.txt', '/workspace/docs/b.txt');
-    await fs.rename('/workspace/docs/b.txt', '/workspace/docs/c.txt');
+    fakeFs.setFile('/workspace/missing/a.txt', 'seed');
+    await fakeFs.writeFile('/workspace/missing/a.txt', Buffer.from('updated'));
 
-    assert.equal(fs.exists('/workspace/docs/b.txt'), false);
-    assert.equal(fs.getText('/workspace/docs/c.txt'), 'A');
-    assert.deepEqual(await fs.readDirectory('/workspace/docs'), [
-      ['a.txt', FileType.File],
-      ['c.txt', FileType.File],
-    ]);
-
-    const stat = await fs.stat('/workspace/docs');
-    assert.equal(stat.type, FileType.Directory);
+    assert.equal(fakeFs.exists('/workspace/missing/a.txt'), true);
+    assert.equal(fakeFs.getText('/workspace/missing/a.txt'), 'updated');
   });
 
-  it('preserves file timestamps when renaming files', async () => {
-    const fs = new FakeFileSystemProvider({
-      '/workspace/docs/a.txt': 'A',
+  it('matches node filesystem semantics for file reads, writes, stats, and directories', async () => {
+    await withProviders(async ({ provider, resolve, expectedRealPath }) => {
+      await provider.createDirectory(resolve('/workspace/docs'));
+      await provider.writeFile(
+        resolve('/workspace/docs/a.txt'),
+        Buffer.from('A'),
+      );
+      await provider.appendFile(
+        resolve('/workspace/docs/a.txt'),
+        Buffer.from('B'),
+      );
+      await provider.writeFileAtomic(
+        resolve('/workspace/docs/atomic.txt'),
+        Buffer.from('atomic'),
+      );
+
+      assert.equal(
+        text(await provider.readFile(resolve('/workspace/docs/a.txt'))),
+        'AB',
+      );
+      assert.equal(
+        text(
+          await provider.readFileChunk(resolve('/workspace/docs/a.txt'), 1, 1),
+        ),
+        'B',
+      );
+      assert.deepEqual(
+        sortedEntries(await provider.readDirectory(resolve('/workspace/docs'))),
+        [
+          ['a.txt', FileType.File],
+          ['atomic.txt', FileType.File],
+        ],
+      );
+      assert.equal(
+        (await provider.stat(resolve('/workspace/docs'))).type,
+        FileType.Directory,
+      );
+      assert.equal(
+        (await provider.stat(resolve('/workspace/docs/a.txt'))).size,
+        2,
+      );
+      assert.equal(
+        await provider.isSymlink(resolve('/workspace/docs/a.txt')),
+        false,
+      );
+      assert.equal(
+        await provider.realPath(resolve('/workspace/docs/a.txt')),
+        await expectedRealPath('/workspace/docs/a.txt'),
+      );
     });
-    const sourceRecord = fsRecords(fs).get('/workspace/docs/a.txt');
-    assert.ok(sourceRecord);
-    sourceRecord.ctime = 1;
-    sourceRecord.mtime = 2;
-
-    await fs.rename('/workspace/docs/a.txt', '/workspace/docs/b.txt');
-
-    const renamed = await fs.stat('/workspace/docs/b.txt');
-    assert.equal(renamed.ctime, 1);
-    assert.equal(renamed.mtime, 2);
   });
 
-  it('matches real writeFile parent directory semantics', async () => {
-    const fs = new FakeFileSystemProvider();
+  it('matches node filesystem semantics for copy, rename, and delete', async () => {
+    await withProviders(async ({ provider, resolve }) => {
+      await provider.createDirectory(resolve('/workspace/source/nested'));
+      await provider.writeFile(
+        resolve('/workspace/source/a.txt'),
+        Buffer.from('A'),
+      );
+      await provider.writeFile(
+        resolve('/workspace/source/nested/b.txt'),
+        Buffer.from('B'),
+      );
 
-    await assert.rejects(
-      () => fs.writeFile('/workspace/missing/a.txt', Buffer.from('A')),
-      /Parent directory not found/,
-    );
-
-    fs.setFile('/workspace/missing/a.txt', 'seed');
-    await fs.writeFile('/workspace/missing/a.txt', Buffer.from('updated'));
-
-    assert.equal(fs.getText('/workspace/missing/a.txt'), 'updated');
-  });
-
-  it('rejects directory operations into self descendants', async () => {
-    const fs = new FakeFileSystemProvider({
-      '/workspace/source/a.txt': 'A',
-    });
-
-    await assert.rejects(
-      () => fs.copy('/workspace/source', '/workspace/source/nested'),
-      /Cannot copy a directory into itself/,
-    );
-    await assert.rejects(
-      () => fs.rename('/workspace/source', '/workspace/source/nested'),
-      /Cannot rename a directory into itself/,
-    );
-
-    assert.equal(fs.getText('/workspace/source/a.txt'), 'A');
-    assert.equal(fs.exists('/workspace/source/nested'), false);
-  });
-
-  it('rejects directory rename over non-empty targets', async () => {
-    const fs = new FakeFileSystemProvider({
-      '/workspace/source/a.txt': 'A',
-      '/workspace/dest/existing.txt': 'B',
-    });
-
-    await assert.rejects(
-      () =>
-        fs.rename('/workspace/source', '/workspace/dest', { overwrite: true }),
-      /Directory is not empty/,
-    );
-
-    assert.equal(fs.getText('/workspace/source/a.txt'), 'A');
-    assert.equal(fs.getText('/workspace/dest/existing.txt'), 'B');
-  });
-
-  it('rejects directory rename when destination parent is missing', async () => {
-    const fs = new FakeFileSystemProvider({
-      '/workspace/source/a.txt': 'A',
-    });
-
-    await assert.rejects(
-      () =>
-        fs.rename('/workspace/source', '/workspace/missing/dest', {
+      await provider.copy(
+        resolve('/workspace/source'),
+        resolve('/workspace/dest'),
+        {
           overwrite: true,
-        }),
-      /Parent directory not found/,
-    );
+        },
+      );
+      assert.equal(
+        text(await provider.readFile(resolve('/workspace/dest/a.txt'))),
+        'A',
+      );
+      assert.equal(
+        text(await provider.readFile(resolve('/workspace/dest/nested/b.txt'))),
+        'B',
+      );
+      await provider.copy(
+        resolve('/workspace/source/a.txt'),
+        resolve('/workspace/file-copy.txt'),
+      );
+      assert.equal(
+        text(await provider.readFile(resolve('/workspace/file-copy.txt'))),
+        'A',
+      );
+      await rejectsWithCode(
+        () =>
+          provider.copy(
+            resolve('/workspace/source/a.txt'),
+            resolve('/workspace/file-copy.txt'),
+          ),
+        'EEXIST',
+      );
 
-    assert.equal(fs.getText('/workspace/source/a.txt'), 'A');
-    assert.equal(fs.exists('/workspace/missing'), false);
-  });
-
-  it('creates missing destination parents when copying directories', async () => {
-    const fs = new FakeFileSystemProvider({
-      '/workspace/source/a.txt': 'A',
-    });
-
-    await fs.copy('/workspace/source', '/workspace/missing/dest', {
-      overwrite: true,
-    });
-
-    assert.equal(fs.getText('/workspace/source/a.txt'), 'A');
-    assert.equal(fs.getText('/workspace/missing/dest/a.txt'), 'A');
-  });
-
-  it('rejects directory copy onto itself with overwrite', async () => {
-    const fs = new FakeFileSystemProvider({
-      '/workspace/source/a.txt': 'A',
-    });
-
-    await assert.rejects(
-      () =>
-        fs.copy('/workspace/source', '/workspace/source', {
+      await provider.rename(
+        resolve('/workspace/dest/a.txt'),
+        resolve('/workspace/dest/c.txt'),
+        {
           overwrite: true,
-        }),
-      /Cannot copy a directory onto itself/,
-    );
+        },
+      );
+      await rejectsWithCode(
+        () => provider.stat(resolve('/workspace/dest/a.txt')),
+        'ENOENT',
+      );
+      assert.equal(
+        text(await provider.readFile(resolve('/workspace/dest/c.txt'))),
+        'A',
+      );
 
-    assert.equal(fs.getText('/workspace/source/a.txt'), 'A');
-  });
-
-  it('copies directories into existing destination directories', async () => {
-    const fs = new FakeFileSystemProvider({
-      '/workspace/source/a.txt': 'A',
-      '/workspace/dest/existing.txt': 'existing',
+      await provider.delete(resolve('/workspace/dest'), { recursive: true });
+      await rejectsWithCode(
+        () => provider.stat(resolve('/workspace/dest/c.txt')),
+        'ENOENT',
+      );
+      await provider.delete(resolve('/workspace/dest'), { recursive: true });
     });
-
-    await fs.copy('/workspace/source', '/workspace/dest');
-
-    assert.equal(fs.getText('/workspace/dest/a.txt'), 'A');
-    assert.equal(fs.getText('/workspace/dest/existing.txt'), 'existing');
   });
 
-  it('assigns fresh timestamps when copying directory children', async () => {
-    const fs = new FakeFileSystemProvider({
-      '/workspace/source/a.txt': 'A',
-      '/workspace/source/nested/b.txt': 'B',
+  it('matches node filesystem error codes for common failures', async () => {
+    await withProviders(async ({ provider, resolve }) => {
+      await rejectsWithCode(
+        () =>
+          provider.writeFile(
+            resolve('/workspace/missing/a.txt'),
+            Buffer.from('A'),
+          ),
+        'ENOENT',
+      );
+
+      await provider.createDirectory(resolve('/workspace/source'));
+      await provider.writeFile(
+        resolve('/workspace/source/a.txt'),
+        Buffer.from('A'),
+      );
+      await provider.writeFile(
+        resolve('/workspace/source/b.txt'),
+        Buffer.from('B'),
+      );
+
+      await rejectsWithCode(
+        () => provider.readFile(resolve('/workspace/source')),
+        'EISDIR',
+      );
+      await rejectsWithCode(
+        () =>
+          provider.rename(
+            resolve('/workspace/source/a.txt'),
+            resolve('/workspace/source/b.txt'),
+          ),
+        'EEXIST',
+      );
+      await rejectsWithCode(
+        () =>
+          provider.copy(
+            resolve('/workspace/source'),
+            resolve('/workspace/source/nested'),
+          ),
+        'ERR_FS_CP_EINVAL',
+      );
+      await rejectsWithCode(
+        () =>
+          provider.copy(
+            resolve('/workspace/missing'),
+            resolve('/workspace/missing/nested'),
+          ),
+        'ENOENT',
+      );
+      await rejectsWithCode(
+        () =>
+          provider.rename(
+            resolve('/workspace/missing'),
+            resolve('/workspace/missing/nested'),
+          ),
+        'ENOENT',
+      );
     });
-    for (const record of fsRecords(fs).values()) {
-      record.ctime = 1;
-      record.mtime = 1;
-    }
-
-    await fs.copy('/workspace/source', '/workspace/dest');
-
-    assert.equal((await fs.stat('/workspace/dest/a.txt')).mtime > 1, true);
-    assert.equal((await fs.stat('/workspace/dest/nested')).mtime > 1, true);
-    assert.equal(
-      (await fs.stat('/workspace/dest/nested/b.txt')).mtime > 1,
-      true,
-    );
   });
 
-  it('rejects directory copy when a destination file already exists', async () => {
-    const fs = new FakeFileSystemProvider({
-      '/workspace/source/a.txt': 'A',
-      '/workspace/dest/a.txt': 'existing',
-    });
-
-    await assert.rejects(
-      () => fs.copy('/workspace/source', '/workspace/dest'),
-      /Target already exists/,
-    );
-
-    assert.equal(fs.getText('/workspace/dest/a.txt'), 'existing');
-  });
-
-  it('keeps earlier directory copy writes when a later child fails', async () => {
-    const fs = new FakeFileSystemProvider({
-      '/workspace/source/a.txt': 'A',
-      '/workspace/source/z.txt': 'Z',
-      '/workspace/dest/z.txt': 'existing',
-    });
-
-    await assert.rejects(
-      () => fs.copy('/workspace/source', '/workspace/dest'),
-      /Target already exists/,
-    );
-
-    assert.equal(fs.getText('/workspace/dest/a.txt'), 'A');
-    assert.equal(fs.getText('/workspace/dest/z.txt'), 'existing');
-  });
-
-  it('rejects file copy onto itself with overwrite', async () => {
-    const fs = new FakeFileSystemProvider({
-      '/workspace/source/a.txt': 'A',
-    });
-
-    await assert.rejects(
-      () =>
-        fs.copy('/workspace/source/a.txt', '/workspace/source/a.txt', {
-          overwrite: true,
-        }),
-      /Cannot copy a file onto itself/,
-    );
-
-    assert.equal(fs.getText('/workspace/source/a.txt'), 'A');
-  });
-
-  it('rejects same-path rename when the source is missing', async () => {
-    const fs = new FakeFileSystemProvider();
-
-    await assert.rejects(
-      () => fs.rename('/workspace/missing.txt', '/workspace/missing.txt'),
-      /File not found/,
-    );
-  });
-
-  it('rejects deleting the filesystem root', async () => {
-    const fs = new FakeFileSystemProvider({
+  it('rejects deleting the fake filesystem root', async () => {
+    const fakeFs = new FakeFileSystemProvider({
       '/workspace/source/a.txt': 'A',
     });
 
-    await assert.rejects(
-      () => fs.delete('/', { recursive: true }),
-      /Cannot delete filesystem root/,
+    await rejectsWithCode(
+      () => fakeFs.delete('/', { recursive: true }),
+      'EPERM',
     );
 
-    assert.equal(fs.getText('/workspace/source/a.txt'), 'A');
-  });
-
-  it('reports implicit readDirectory path prefixes as directories', async () => {
-    const fs = new FakeFileSystemProvider();
-    await fs.createDirectory('/workspace');
-    fsRecords(fs).set('/workspace/implicit/file.txt', {
-      type: FileType.File,
-      ctime: Date.now(),
-      mtime: Date.now(),
-      content: Buffer.from('A'),
-    });
-
-    assert.deepEqual(await fs.readDirectory('/workspace'), [
-      ['implicit', FileType.Directory],
-    ]);
-  });
-
-  it('rejects directory copy when a destination file blocks a source directory', async () => {
-    const fs = new FakeFileSystemProvider({
-      '/workspace/source/item/a.txt': 'A',
-      '/workspace/dest/item': 'existing file',
-    });
-
-    await assert.rejects(
-      () =>
-        fs.copy('/workspace/source', '/workspace/dest', { overwrite: true }),
-      /Path is a file/,
-    );
-
-    assert.equal(fs.getText('/workspace/source/item/a.txt'), 'A');
-    assert.equal(fs.getText('/workspace/dest/item'), 'existing file');
-    assert.equal(fs.exists('/workspace/dest/item/a.txt'), false);
-  });
-
-  it('rejects directory copy when a destination directory blocks a source file', async () => {
-    const fs = new FakeFileSystemProvider({
-      '/workspace/source/item': 'source file',
-      '/workspace/dest/item/existing.txt': 'existing nested file',
-    });
-
-    await assert.rejects(
-      () =>
-        fs.copy('/workspace/source', '/workspace/dest', { overwrite: true }),
-      /Path is a directory/,
-    );
-
-    assert.equal(fs.getText('/workspace/source/item'), 'source file');
-    assert.equal(
-      fs.getText('/workspace/dest/item/existing.txt'),
-      'existing nested file',
-    );
+    assert.equal(fakeFs.getText('/workspace/source/a.txt'), 'A');
   });
 });

--- a/src/test-kernel/support/FakePlatform.ts
+++ b/src/test-kernel/support/FakePlatform.ts
@@ -1,6 +1,9 @@
 // Standard library imports
 import * as path from 'node:path';
 
+// Third-party imports
+import { createFsFromVolume, Volume, type IFs } from 'memfs';
+
 // Local imports - platform
 import {
   FileType,
@@ -22,19 +25,6 @@ import type { Platform } from '@platform/platform';
 import type { PlatformSecrets } from '@platform/secrets';
 import type { AgentDirectoriesPort } from '@platform/interfaces/agentDirectories';
 
-type FakeFileRecord =
-  | {
-      type: typeof FileType.Directory;
-      ctime: number;
-      mtime: number;
-    }
-  | {
-      type: typeof FileType.File;
-      ctime: number;
-      mtime: number;
-      content: Uint8Array;
-    };
-
 export type RecordingLogLevel = 'debug' | 'info' | 'warn' | 'error';
 
 export interface RecordingLogEntry {
@@ -46,20 +36,8 @@ function fakeFsError(code: string, message: string): Error {
   return Object.assign(new Error(message), { code });
 }
 
-function now(): number {
-  return Date.now();
-}
-
-function cloneBytes(content: Uint8Array): Uint8Array {
-  return new Uint8Array(content);
-}
-
 function normalizePath(target: string): string {
   return path.posix.resolve('/', target.replaceAll('\\', '/'));
-}
-
-function parentPath(target: string): string {
-  return path.posix.dirname(normalizePath(target));
 }
 
 function relativeChildPath(
@@ -81,51 +59,35 @@ function hasChildPath(parent: string, candidate: string): boolean {
   return relativeChildPath(parent, candidate) !== undefined;
 }
 
-function directChildName(
-  parent: string,
-  candidate: string,
-): string | undefined {
-  return relativeChildPath(parent, candidate)?.split(path.posix.sep).at(0);
-}
+type FileTypeProbe = {
+  isSymbolicLink(): boolean;
+  isFile(): boolean;
+  isDirectory(): boolean;
+};
 
-function fileSize(record: FakeFileRecord): number {
-  return record.type === FileType.File ? record.content.byteLength : 0;
-}
+type DirectoryEntryProbe = FileTypeProbe & { name: string };
 
-function fileStat(record: FakeFileRecord): FileStat {
-  return {
-    type: record.type,
-    ctime: record.ctime,
-    mtime: record.mtime,
-    size: fileSize(record),
-  };
-}
-
-function cloneRecord(record: FakeFileRecord): FakeFileRecord {
-  if (record.type === FileType.File) {
-    return {
-      ...record,
-      content: cloneBytes(record.content),
-    };
+async function resolveSymlinkType(fs: IFs, target: string): Promise<number> {
+  let targetType: number = FileType.Unknown;
+  try {
+    const stats = await fs.promises.stat(target);
+    if (stats.isFile()) targetType = FileType.File;
+    else if (stats.isDirectory()) targetType = FileType.Directory;
+  } catch {
+    // Dangling symlink: preserve the symlink bit with an unknown target type.
   }
-  return { ...record };
+  return FileType.SymbolicLink | targetType;
 }
 
-function copyRecord(record: FakeFileRecord): FakeFileRecord {
-  const timestamp = now();
-  if (record.type === FileType.File) {
-    return {
-      type: FileType.File,
-      ctime: timestamp,
-      mtime: timestamp,
-      content: cloneBytes(record.content),
-    };
-  }
-  return {
-    type: FileType.Directory,
-    ctime: timestamp,
-    mtime: timestamp,
-  };
+async function fileTypeFor(
+  fs: IFs,
+  entry: FileTypeProbe,
+  target: string,
+): Promise<number> {
+  if (entry.isSymbolicLink()) return resolveSymlinkType(fs, target);
+  if (entry.isFile()) return FileType.File;
+  if (entry.isDirectory()) return FileType.Directory;
+  return FileType.Unknown;
 }
 
 export class FakeConfigProvider implements ConfigProvider {
@@ -280,35 +242,44 @@ export class FakeStateStore implements StateStore {
 }
 
 export class FakeFileSystemProvider implements FileSystemProvider {
-  private readonly records = new Map<string, FakeFileRecord>();
+  private readonly fs: IFs;
 
   constructor(files: Record<string, string | Uint8Array> = {}) {
-    this.createDirectorySync('/');
+    this.fs = createFsFromVolume(new Volume());
+    this.fs.mkdirSync('/', { recursive: true });
     for (const [target, content] of Object.entries(files)) {
       this.setFile(target, content);
     }
   }
 
   async stat(target: string): Promise<FileStat> {
-    return fileStat(this.requireRecord(target));
+    const normalized = normalizePath(target);
+    const lstats = await this.fs.promises.lstat(normalized);
+    const type = await fileTypeFor(this.fs, lstats, normalized);
+    const stats = lstats.isSymbolicLink()
+      ? await this.fs.promises.stat(normalized).catch(() => lstats)
+      : lstats;
+    return {
+      type,
+      ctime: Number(stats.ctimeMs),
+      mtime: Number(stats.mtimeMs),
+      size: Number(stats.size),
+    };
   }
 
-  async isSymlink(_target: string): Promise<boolean> {
-    // FakeFileSystemProvider does not model symlinks.
-    return false;
+  async isSymlink(target: string): Promise<boolean> {
+    const stats = await this.fs.promises.lstat(normalizePath(target));
+    return stats.isSymbolicLink();
   }
 
   async realPath(target: string): Promise<string> {
-    this.requireRecord(target);
-    return normalizePath(target);
+    const resolved = await this.fs.promises.realpath(normalizePath(target));
+    return resolved.toString();
   }
 
   async readFile(target: string): Promise<Uint8Array> {
-    const record = this.requireRecord(target);
-    if (record.type !== FileType.File) {
-      throw fakeFsError('EISDIR', `Path is a directory: ${target}`);
-    }
-    return cloneBytes(record.content);
+    const content = await this.fs.promises.readFile(normalizePath(target));
+    return typeof content === 'string' ? Buffer.from(content) : content;
   }
 
   async readFileChunk(
@@ -321,25 +292,23 @@ export class FakeFileSystemProvider implements FileSystemProvider {
   }
 
   async writeFile(target: string, content: Uint8Array): Promise<void> {
-    this.writeFileSync(target, content, { overwrite: true });
+    await this.fs.promises.writeFile(
+      normalizePath(target),
+      Buffer.from(content),
+    );
   }
 
   async writeFileAtomic(target: string, content: Uint8Array): Promise<void> {
     // In-memory: the temp+rename of a real atomic write has no observable
     // intermediate state here, so a direct write is equivalent.
-    this.writeFileSync(target, content, { overwrite: true });
+    await this.writeFile(target, content);
   }
 
   async appendFile(target: string, content: Uint8Array): Promise<void> {
-    const existing = this.records.get(normalizePath(target));
-    if (existing && existing.type !== FileType.File) {
-      throw fakeFsError('EISDIR', `Path is a directory: ${target}`);
-    }
-    const base = existing?.content ?? new Uint8Array(0);
-    const merged = new Uint8Array(base.length + content.length);
-    merged.set(base, 0);
-    merged.set(content, base.length);
-    this.writeFileSync(target, merged, { overwrite: true });
+    await this.fs.promises.appendFile(
+      normalizePath(target),
+      Buffer.from(content),
+    );
   }
 
   async delete(
@@ -350,50 +319,33 @@ export class FakeFileSystemProvider implements FileSystemProvider {
     if (normalized === '/') {
       throw fakeFsError('EPERM', 'Cannot delete filesystem root');
     }
-    const record = this.records.get(normalized);
-    if (!record) {
-      return;
-    }
-
-    if (record.type === FileType.File) {
-      this.records.delete(normalized);
-      return;
-    }
-
-    const children = this.childPaths(normalized);
-    if (children.length > 0 && !options?.recursive) {
-      throw fakeFsError('ENOTEMPTY', `Directory is not empty: ${target}`);
-    }
-    for (const child of children) {
-      this.records.delete(child);
-    }
-    if (normalized !== '/') {
-      this.records.delete(normalized);
-    }
+    await this.fs.promises.rm(normalized, {
+      recursive: options?.recursive ?? false,
+      force: true,
+    });
   }
 
   async createDirectory(target: string): Promise<void> {
-    this.createDirectorySync(target);
+    await this.fs.promises.mkdir(normalizePath(target), { recursive: true });
   }
 
   async readDirectory(target: string): Promise<[string, number][]> {
     const normalized = normalizePath(target);
-    const record = this.requireRecord(normalized);
-    if (record.type !== FileType.Directory) {
-      throw fakeFsError('ENOTDIR', `Path is not a directory: ${target}`);
-    }
-
-    const entries = new Map<string, number>();
-    for (const candidate of this.records.keys()) {
-      const name = directChildName(normalized, candidate);
-      if (name == null) continue;
-      const childPath = path.posix.join(normalized, name);
-      const childRecord = this.records.get(childPath);
-      entries.set(name, childRecord?.type ?? FileType.Directory);
-    }
-    return [...entries.entries()].sort(([left], [right]) =>
-      left.localeCompare(right),
+    const entries = await this.fs.promises.readdir(normalized, {
+      withFileTypes: true,
+    });
+    const dirents = entries as DirectoryEntryProbe[];
+    const resolved = await Promise.all(
+      dirents.map(async (entry) => {
+        const type = await fileTypeFor(
+          this.fs,
+          entry,
+          path.posix.join(normalized, entry.name),
+        );
+        return [entry.name, type] as [string, number];
+      }),
     );
+    return resolved.toSorted(([left], [right]) => left.localeCompare(right));
   }
 
   async copy(
@@ -403,38 +355,31 @@ export class FakeFileSystemProvider implements FileSystemProvider {
   ): Promise<void> {
     const normalizedSource = normalizePath(source);
     const normalizedDest = normalizePath(dest);
-    const sourceRecord = this.requireRecord(normalizedSource);
-    if (normalizedSource === normalizedDest) {
-      throw fakeFsError(
-        'EINVAL',
-        sourceRecord.type === FileType.Directory
-          ? `Cannot copy a directory onto itself: ${source} -> ${dest}`
-          : `Cannot copy a file onto itself: ${source} -> ${dest}`,
-      );
-    }
-
-    if (sourceRecord.type === FileType.File) {
-      this.assertWritableTarget(normalizedDest, options?.overwrite);
-      this.writeFileSync(normalizedDest, sourceRecord.content, {
-        overwrite: options?.overwrite,
+    const sourceStats = await this.fs.promises.stat(normalizedSource);
+    if (sourceStats.isDirectory()) {
+      if (normalizedSource === normalizedDest) {
+        throw fakeFsError(
+          'ERR_FS_CP_EINVAL',
+          `Cannot copy a path onto itself: ${source} -> ${dest}`,
+        );
+      }
+      if (hasChildPath(normalizedSource, normalizedDest)) {
+        throw fakeFsError(
+          'ERR_FS_CP_EINVAL',
+          `Cannot copy a directory into itself: ${source} -> ${dest}`,
+        );
+      }
+      await this.fs.promises.cp(normalizedSource, normalizedDest, {
+        recursive: true,
+        force: options?.overwrite ?? false,
+        errorOnExist: !(options?.overwrite ?? false),
+        dereference: options?.dereference ?? false,
       });
       return;
     }
 
-    this.assertNotSelfDescendant(normalizedSource, normalizedDest, 'copy');
-    this.assertDirectoryCopyRootTarget(normalizedDest);
-    this.createDirectorySync(normalizedDest);
-    for (const child of this.childPaths(normalizedSource)) {
-      const relative = path.posix.relative(normalizedSource, child);
-      const childDest = path.posix.join(normalizedDest, relative);
-      const childRecord = this.requireRecord(child);
-      this.assertDirectoryCopyChildTarget(
-        childDest,
-        childRecord,
-        options?.overwrite,
-      );
-      this.records.set(childDest, copyRecord(childRecord));
-    }
+    const flag = options?.overwrite ? 0 : this.fs.constants.COPYFILE_EXCL;
+    await this.fs.promises.copyFile(normalizedSource, normalizedDest, flag);
   }
 
   async rename(
@@ -444,215 +389,40 @@ export class FakeFileSystemProvider implements FileSystemProvider {
   ): Promise<void> {
     const normalizedSource = normalizePath(source);
     const normalizedDest = normalizePath(dest);
-    const sourceRecord = this.requireRecord(normalizedSource);
-    if (normalizedSource === normalizedDest) {
-      return;
-    }
-
-    this.assertWritableTarget(normalizedDest, options?.overwrite);
-
-    if (sourceRecord.type === FileType.File) {
-      const existing = this.records.get(normalizedDest);
-      if (existing?.type === FileType.Directory) {
-        throw fakeFsError('EISDIR', `Path is a directory: ${dest}`);
+    if (!options?.overwrite) {
+      try {
+        await this.fs.promises.lstat(normalizedDest);
+        throw fakeFsError('EEXIST', `Target already exists: ${dest}`);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
       }
-      this.assertParentDirectoryExists(normalizedDest);
-      this.records.set(normalizedDest, cloneRecord(sourceRecord));
-      this.records.delete(normalizedSource);
-      return;
     }
-
-    this.assertNotSelfDescendant(normalizedSource, normalizedDest, 'rename');
-    this.assertDirectoryRenameTarget(normalizedDest);
-    this.assertParentDirectoryExists(normalizedDest);
-    this.createDirectorySync(normalizedDest);
-    for (const child of this.childPaths(normalizedSource)) {
-      const relative = path.posix.relative(normalizedSource, child);
-      const childDest = path.posix.join(normalizedDest, relative);
-      this.records.set(childDest, cloneRecord(this.requireRecord(child)));
+    const sourceStats = await this.fs.promises.lstat(normalizedSource);
+    if (
+      sourceStats.isDirectory() &&
+      hasChildPath(normalizedSource, normalizedDest)
+    ) {
+      throw fakeFsError(
+        'EINVAL',
+        `Cannot rename a directory into itself: ${source} -> ${dest}`,
+      );
     }
-    await this.delete(normalizedSource, { recursive: true });
+    await this.fs.promises.rename(normalizedSource, normalizedDest);
   }
 
   exists(target: string): boolean {
-    return this.records.has(normalizePath(target));
+    return this.fs.existsSync(normalizePath(target));
   }
 
   setFile(target: string, content: string | Uint8Array): void {
-    this.writeFileSync(target, stringToBytes(content), {
-      createParent: true,
-      overwrite: true,
-    });
+    const normalized = normalizePath(target);
+    this.fs.mkdirSync(path.posix.dirname(normalized), { recursive: true });
+    this.fs.writeFileSync(normalized, Buffer.from(stringToBytes(content)));
   }
 
   getText(target: string): string {
-    return Buffer.from(this.requireFile(target).content).toString('utf8');
-  }
-
-  private requireRecord(target: string): FakeFileRecord {
-    const normalized = normalizePath(target);
-    const record = this.records.get(normalized);
-    if (!record) {
-      throw fakeFsError('ENOENT', `File not found: ${target}`);
-    }
-    return record;
-  }
-
-  private requireFile(
-    target: string,
-  ): Extract<FakeFileRecord, { content: Uint8Array }> {
-    const record = this.requireRecord(target);
-    if (record.type !== FileType.File) {
-      throw fakeFsError('EISDIR', `Path is a directory: ${target}`);
-    }
-    return record;
-  }
-
-  private writeFileSync(
-    target: string,
-    content: Uint8Array,
-    options: { createParent?: boolean; overwrite?: boolean } = {},
-  ): void {
-    const normalized = normalizePath(target);
-    const existing = this.records.get(normalized);
-    if (existing?.type === FileType.Directory) {
-      throw fakeFsError('EISDIR', `Path is a directory: ${target}`);
-    }
-    if (existing && !options.overwrite) {
-      throw fakeFsError('EEXIST', `Target already exists: ${target}`);
-    }
-
-    const parent = parentPath(normalized);
-    if (options.createParent) {
-      this.createDirectorySync(parent);
-    } else {
-      const parentRecord = this.records.get(parent);
-      if (!parentRecord) {
-        throw fakeFsError('ENOENT', `Parent directory not found: ${parent}`);
-      }
-      if (parentRecord.type !== FileType.Directory) {
-        throw fakeFsError(
-          'ENOTDIR',
-          `Parent path is not a directory: ${parent}`,
-        );
-      }
-    }
-
-    const timestamp = now();
-    this.records.set(normalized, {
-      type: FileType.File,
-      ctime: timestamp,
-      mtime: timestamp,
-      content: cloneBytes(content),
-    });
-  }
-
-  private createDirectorySync(target: string): void {
-    const normalized = normalizePath(target);
-    const existing = this.records.get(normalized);
-    if (existing?.type === FileType.File) {
-      throw fakeFsError('ENOTDIR', `Path is a file: ${target}`);
-    }
-
-    const parts = normalized.split(path.posix.sep).filter(Boolean);
-    let current: string = path.posix.sep;
-    this.ensureDirectoryRecord(current);
-    for (const part of parts) {
-      current = path.posix.join(current, part);
-      this.ensureDirectoryRecord(current);
-    }
-  }
-
-  private ensureDirectoryRecord(target: string): void {
-    const existing = this.records.get(target);
-    if (existing?.type === FileType.File) {
-      throw fakeFsError('ENOTDIR', `Path is a file: ${target}`);
-    }
-    if (!existing) {
-      const timestamp = now();
-      this.records.set(target, {
-        type: FileType.Directory,
-        ctime: timestamp,
-        mtime: timestamp,
-      });
-    }
-  }
-
-  private childPaths(parent: string): string[] {
-    return [...this.records.keys()].filter((candidate) =>
-      hasChildPath(parent, candidate),
-    );
-  }
-
-  private assertWritableTarget(target: string, overwrite?: boolean): void {
-    if (!overwrite && this.records.has(target)) {
-      throw fakeFsError('EEXIST', `Target already exists: ${target}`);
-    }
-  }
-
-  private assertNotSelfDescendant(
-    source: string,
-    dest: string,
-    operation: string,
-  ): void {
-    if (hasChildPath(source, dest)) {
-      throw fakeFsError(
-        'EINVAL',
-        `Cannot ${operation} a directory into itself: ${source} -> ${dest}`,
-      );
-    }
-  }
-
-  private assertDirectoryRenameTarget(dest: string): void {
-    const destRecord = this.records.get(dest);
-    if (destRecord?.type === FileType.File) {
-      throw fakeFsError('ENOTDIR', `Path is a file: ${dest}`);
-    }
-    if (
-      destRecord?.type === FileType.Directory &&
-      this.childPaths(dest).length > 0
-    ) {
-      throw fakeFsError('ENOTEMPTY', `Directory is not empty: ${dest}`);
-    }
-  }
-
-  private assertDirectoryCopyRootTarget(dest: string): void {
-    const destRecord = this.records.get(dest);
-    if (destRecord?.type === FileType.File) {
-      throw fakeFsError('ENOTDIR', `Path is a file: ${dest}`);
-    }
-  }
-
-  private assertDirectoryCopyChildTarget(
-    dest: string,
-    sourceRecord: FakeFileRecord,
-    overwrite?: boolean,
-  ): void {
-    const destRecord = this.records.get(dest);
-    if (!destRecord) {
-      return;
-    }
-    if (destRecord.type === sourceRecord.type) {
-      if (sourceRecord.type === FileType.File && !overwrite) {
-        throw fakeFsError('EEXIST', `Target already exists: ${dest}`);
-      }
-      return;
-    }
-    if (destRecord.type === FileType.Directory) {
-      throw fakeFsError('EISDIR', `Path is a directory: ${dest}`);
-    }
-    throw fakeFsError('ENOTDIR', `Path is a file: ${dest}`);
-  }
-
-  private assertParentDirectoryExists(target: string): void {
-    const parent = parentPath(target);
-    const parentRecord = this.records.get(parent);
-    if (!parentRecord) {
-      throw fakeFsError('ENOENT', `Parent directory not found: ${parent}`);
-    }
-    if (parentRecord.type !== FileType.Directory) {
-      throw fakeFsError('ENOTDIR', `Parent path is not a directory: ${parent}`);
-    }
+    const content = this.fs.readFileSync(normalizePath(target));
+    return typeof content === 'string' ? content : content.toString('utf8');
   }
 }
 

--- a/src/test-kernel/support/setupFakePlatform.ts
+++ b/src/test-kernel/support/setupFakePlatform.ts
@@ -1,0 +1,7 @@
+const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
+  import('@platform/platform'),
+  import('./FakePlatform'),
+]);
+initPlatform(createFakePlatform());
+
+export {};

--- a/src/test-kernel/utils/ExecUtils.vitest.ts
+++ b/src/test-kernel/utils/ExecUtils.vitest.ts
@@ -1,8 +1,62 @@
-import { describe, expect, it } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { executeCommandSync } from '@utils/system/execUtils';
 
+async function initDefaultFakePlatform(): Promise<void> {
+  const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
+    import('@platform/platform'),
+    import('@test/support/FakePlatform'),
+  ]);
+  initPlatform(createFakePlatform());
+}
+
+async function initNodeBackedPlatform(options: {
+  storagePath: string;
+  globalStoragePath: string;
+}): Promise<void> {
+  const [{ initPlatform }, { nodeFilesystem }, { createFakePlatform }] =
+    await Promise.all([
+      import('@platform/platform'),
+      import('@platform/defaults/nodeFilesystem'),
+      import('@test/support/FakePlatform'),
+    ]);
+  initPlatform(
+    createFakePlatform(
+      {
+        workspacePath: process.cwd(),
+        storagePath: options.storagePath,
+        globalStoragePath: options.globalStoragePath,
+      },
+      { fs: nodeFilesystem },
+    ),
+  );
+}
+
 describe('executeCommandSync', () => {
+  let platformStorageRoot = '';
+
+  beforeEach(async () => {
+    platformStorageRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'texra-exec-utils-'),
+    );
+    await initNodeBackedPlatform({
+      storagePath: path.join(platformStorageRoot, 'storage'),
+      globalStoragePath: path.join(platformStorageRoot, 'global-storage'),
+    });
+  });
+
+  afterEach(async () => {
+    if (platformStorageRoot) {
+      await fs.rm(platformStorageRoot, { recursive: true, force: true });
+      platformStorageRoot = '';
+    }
+    await initDefaultFakePlatform();
+  });
+
   it('returns normalized stdout for successful commands', () => {
     const result = executeCommandSync([
       process.execPath,

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -19,6 +19,7 @@ export default defineConfig({
     environment: 'node',
     include: ['src/test-kernel/**/*.vitest.{ts,mts}'],
     passWithNoTests: false,
+    setupFiles: ['src/test-kernel/support/setupFakePlatform.ts'],
     testTimeout: 10000,
   },
 });


### PR DESCRIPTION
## Summary

Backs the test fake filesystem with `memfs` and installs a default fake platform through Vitest setup. The fake provider keeps the existing `FileSystemProvider` surface, while the platform tests now run the same file-operation matrix against both the fake provider and the real `nodeFilesystem` on a temp directory.

## Issue acceptance gates

Addresses #6971.

- [x] Fake FS is `memfs`-backed; conformance matrix is green against the real implementation.
- [x] Global setup is in place via `vitest.config.mjs`; new test suites can call `platform()` without local bootstrap.
- [x] Full `npm test` is green with current suite semantics. Local runtime after review fixes: 32.22s for 573 files / 4479 tests; nearest recent pre-#6971 local full-suite run was 31.58s, so the observed local delta is about +0.6s.

## Single source of truth

`FakeFileSystemProvider` now delegates filesystem state and Node-style behavior to a `memfs` `Volume`. `src/test-kernel/support/setupFakePlatform.ts` owns the default test platform bootstrap for Vitest.

## Duplication and abstraction budget

Removed the bespoke record-map filesystem, path tree bookkeeping, timestamp preservation, and hand-written directory traversal from `FakePlatform.ts`. The remaining adapter code only normalizes TeXRA's provider interface around `memfs` and mirrors the real provider where the interface needs a project-specific error or type shape.

This PR is net-positive because the added mass is the new `memfs` dependency lock entries plus the real/fake conformance matrix that guards the replacement. No #6981 ledger row is required: this PR adds no shim, projection, dual-write, alias, fallback, or migration path.

## Host impact

Extension: no runtime behavior change; test support only.

Desktop: no runtime behavior change; test support only.

CLI: no runtime behavior change. CLI tests that require real disk behavior now explicitly install a node-backed platform for that suite.

## Scheduled refactoring

None beyond the incremental deletion path already scoped by #6971: existing explicit `initPlatform` calls can be removed opportunistically as suites are touched.

## Validation

- `corepack pnpm exec prettier --write package.json pnpm-lock.yaml vitest.config.mjs src/test-kernel/support/FakePlatform.ts src/test-kernel/support/setupFakePlatform.ts src/test-kernel/platform/FakePlatform.vitest.ts src/test-kernel/utils/ExecUtils.vitest.ts src/test-kernel/cli/CliRootArgs.vitest.mts`
- `npm test -- --run src/test-kernel/platform/FakePlatform.vitest.ts src/test-kernel/utils/ExecUtils.vitest.ts src/test-kernel/cli/CliRootArgs.vitest.mts`
- `npm test -- --run src/test-kernel/cli/CliInitPlatform.vitest.mts`
- `npm run lint` (passes with 16 pre-existing warnings)
- `npm run typecheck -- --pretty false`
- `npm test`
- `npm run compile:fast`
- `git diff --check`

Closes #6971
