### PR TITLE
fix: honor resolved CLI terminal status

### DIFF
--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -152,6 +152,7 @@ export async function executeCliToolUseConfig(
   return {
     ok: true,
     displayResult: createCliRunResult(result, {
+      terminalStatus,
       workingDirectory: runContext.cwd,
     }),
     exitCode: terminalStatusExitCode(terminalStatus, runContext),

--- a/packages/cli/src/runtime/terminalStatus.ts
+++ b/packages/cli/src/runtime/terminalStatus.ts
@@ -7,6 +7,7 @@ import {
 } from '@common/constants/streamStatus';
 import {
   EXECUTION_STATUS,
+  executionStatusToRunOutcome,
   type ExecutionStatus,
   type RunOutcome,
 } from '@shared/schemas';
@@ -60,19 +61,24 @@ export function cliTerminalStatus(
 export function createCliRunResult<T extends ExecuteAgentResult>(
   result: T,
   extras: {
+    readonly terminalStatus?: ExecutionStatus;
     readonly workingDirectory?: string;
     readonly runDirectory?: string;
     readonly copiedOutput?: string;
     readonly copiedOutputs?: string[];
   } = {},
 ): T extends ExecuteAgentResult ? CliRunResultFor<T> : never {
-  const terminalStatus = runOutcomeToExecutionStatus(result.outcome);
+  const { terminalStatus: resolvedTerminalStatus, ...metadata } = extras;
+  const terminalStatus =
+    resolvedTerminalStatus ?? runOutcomeToExecutionStatus(result.outcome);
+  const terminalOutcome =
+    executionStatusToRunOutcome(terminalStatus) ?? result.outcome;
   return {
     ...result,
     status: terminalStatus,
-    endGroupStatus: legacyEndGroupStatusForOutcome(result.outcome),
+    endGroupStatus: legacyEndGroupStatusForOutcome(terminalOutcome),
     terminalStatus,
-    ...extras,
+    ...metadata,
   } as T extends ExecuteAgentResult ? CliRunResultFor<T> : never;
 }
 

--- a/packages/cli/src/runtime/workflowOutput.ts
+++ b/packages/cli/src/runtime/workflowOutput.ts
@@ -205,6 +205,7 @@ export async function resolveWorkflowOutput(
   if (result.outputs.length === 0 && (outputFile || outputDir)) {
     if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) {
       return createCliRunResult(result, {
+        terminalStatus,
         workingDirectory: context.cwd,
       });
     }
@@ -256,6 +257,7 @@ export async function resolveWorkflowOutput(
     }
 
     return createCliRunResult(result, {
+      terminalStatus,
       workingDirectory: context.cwd,
       runDirectory,
       copiedOutputs,
@@ -264,6 +266,7 @@ export async function resolveWorkflowOutput(
 
   if (!outputFile) {
     return createCliRunResult(result, {
+      terminalStatus,
       workingDirectory: context.cwd,
       runDirectory,
     });
@@ -272,6 +275,7 @@ export async function resolveWorkflowOutput(
   const finalOutput = latestWorkflowOutput(result.outputs);
   if (!finalOutput) {
     return createCliRunResult(result, {
+      terminalStatus,
       workingDirectory: context.cwd,
       runDirectory,
     });
@@ -284,6 +288,7 @@ export async function resolveWorkflowOutput(
   }
 
   return createCliRunResult(result, {
+    terminalStatus,
     workingDirectory: context.cwd,
     runDirectory,
     copiedOutput: targetPath,

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -933,6 +933,30 @@ describe('CLI root argument routing', () => {
     });
   });
 
+  it('uses a caller-resolved terminal status in CLI run results', () => {
+    const result = createCliRunResult(
+      {
+        outcome: RUN_OUTCOME.COMPLETED,
+        category: AgentCategory.ToolUse,
+        executionId: 'completed-after-shutdown',
+        streamId: 'stream-after-shutdown',
+        lastResponse: 'done',
+      } as Parameters<typeof createCliRunResult>[0],
+      {
+        terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+        workingDirectory: '/tmp/project',
+      },
+    );
+
+    expect(result).toMatchObject({
+      executionId: 'completed-after-shutdown',
+      workingDirectory: '/tmp/project',
+      terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+      status: EXECUTION_STATUS.INTERRUPTED,
+      endGroupStatus: 'stopped',
+    });
+  });
+
   it('restores one requested workflow output path for resume', () => {
     expect(
       resumeWorkflowOutputFile(

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -9,6 +9,7 @@ import { MemoryStateStore } from '@platform/defaults/memoryState';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
+import { CliExitCode } from '@cli/runtime/exitCodes';
 import type { CliContext } from '@cli/runtime/cliContext';
 import {
   EXECUTION_STATUS,
@@ -456,6 +457,42 @@ describe('executeCliConfig', () => {
         terminalStatus: EXECUTION_STATUS.COMPLETED,
         workingDirectory: '/tmp/project',
         lastResponse: 'Done.',
+      },
+    });
+  });
+
+  it('uses the resolved terminal status for tool-use JSON output', async () => {
+    const { AgentCategory } =
+      await import('@agent/core/definition/AgentDataclass');
+    const { executeCliToolUseConfig } =
+      await import('@cli/runtime/runExecution');
+    mocks.runAgent.mockResolvedValueOnce({
+      category: AgentCategory.ToolUse,
+      executionId: 'exec-1',
+      outcome: 'completed',
+      lastResponse: 'Done.',
+    });
+    mocks.readCliTerminalStatus.mockResolvedValueOnce(
+      EXECUTION_STATUS.INTERRUPTED,
+    );
+
+    const result = await executeCliToolUseConfig(
+      toolUseConfig(),
+      cliContext(),
+      {
+        registerExecution: true,
+        stopAfterCycle: true,
+      },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      exitCode: CliExitCode.Interrupted,
+      displayResult: {
+        status: EXECUTION_STATUS.INTERRUPTED,
+        terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+        endGroupStatus: 'stopped',
+        workingDirectory: '/tmp/project',
       },
     });
   });

--- a/src/test-kernel/cli/WorkflowOutputResolution.vitest.mts
+++ b/src/test-kernel/cli/WorkflowOutputResolution.vitest.mts
@@ -94,6 +94,28 @@ describe('CLI workflow output resolution', () => {
     ).rejects.toThrow(/b\.tex/);
   });
 
+  it('uses resolved interrupted status for missing workflow output results', async () => {
+    const cwd = await makeTempDir();
+
+    const displayResult = await resolveWorkflowOutput(
+      'out.tex',
+      undefined,
+      workflowResult([]),
+      testContext(cwd),
+      {
+        terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+      },
+    );
+
+    expect(displayResult).toMatchObject({
+      status: EXECUTION_STATUS.INTERRUPTED,
+      endGroupStatus: END_GROUP_STATUS.STOPPED,
+      terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+      workingDirectory: cwd,
+    });
+    expect(Object.hasOwn(displayResult, 'copiedOutput')).toBe(false);
+  });
+
   it('copies every expected --output-dir workflow output', async () => {
     const cwd = await makeTempDir();
     const runA1 = join(cwd, 'run', 'r1', 'a.tex');


### PR DESCRIPTION
## Summary

Thread the caller-resolved CLI terminal status into JSON display-result construction instead of letting `createCliRunResult` recompute the deprecated JSON status fields from `result.outcome`.

This keeps `status`, `terminalStatus`, and `endGroupStatus` aligned with the process exit code when shutdown records an interrupted terminal status after a run outcome has already settled as completed.

## Issue acceptance gates

- Addresses #6989.
- Re-verified the cited sites on current `main` before implementation; no citation drift found.
- `executeCliToolUseConfig` now passes the resolved `terminalStatus` into `createCliRunResult`.
- Every `resolveWorkflowOutput` display-result path now passes `options.terminalStatus` into `createCliRunResult`.
- Added regressions for direct display-result construction, tool-use JSON output, and workflow missing-output display results when `result.outcome` diverges from the resolved terminal status.

## Single source of truth

The already-resolved `terminalStatus` from `readCliTerminalStatus` / workflow resolution is now the source of truth for CLI JSON compatibility fields. `createCliRunResult` still owns the frozen JSON projection, but it consumes that decision instead of re-deriving it from `result.outcome` when a caller has already resolved the terminal status.

## Duplication and abstraction budget

Removed the duplicate terminal-status recomputation in CLI display-result construction for the command paths that already had the resolved value. No pass-through layer or new abstraction was added. The added line count lives in focused regression tests for the shutdown-interrupt race.

No #6981 ledger row is needed: this PR does not introduce a shim, dual-write, alias, fallback, or migration path.

## Host impact

Extension: No runtime impact; CLI-only display-result projection.

Desktop: No runtime impact; CLI-only display-result projection.

CLI: JSON output for `texra run`, `--print`, and workflow output now reports the same terminal status used for the process exit code during shutdown-interrupt races. Existing behavior is unchanged when no resolved terminal status is supplied.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write packages/cli/src/runtime/terminalStatus.ts packages/cli/src/runtime/runExecution.ts packages/cli/src/runtime/workflowOutput.ts src/test-kernel/cli/RunExecution.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/WorkflowOutputResolution.vitest.mts`
- `npm test -- --run src/test-kernel/cli/RunExecution.vitest.mts src/test-kernel/cli/CliRootArgs.vitest.mts src/test-kernel/cli/WorkflowOutputResolution.vitest.mts`
- `npm run typecheck -- --pretty false`
- `git diff --check`
- `npm test`
- `npm run lint` (passes with 16 pre-existing warnings)
- `npm run compile:fast`

Closes #6989

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only JSON projection and display metadata; no auth, persistence, or agent execution logic changes beyond threading an existing resolved status.
> 
> **Overview**
> CLI JSON output for tool-use runs and workflow output resolution now uses the **already-resolved** `terminalStatus` (from storage/shutdown handling) when building display results, instead of recomputing `status`, `terminalStatus`, and `endGroupStatus` from `result.outcome` alone.
> 
> **`createCliRunResult`** accepts an optional `terminalStatus` override, maps it through `executionStatusToRunOutcome` for **`endGroupStatus`**, and keeps metadata separate so the override is not overwritten. **`executeCliToolUseConfig`** and every **`resolveWorkflowOutput`** return path pass the resolved status through.
> 
> Regression tests cover outcome vs. resolved status divergence (e.g. completed outcome with interrupted terminal status after shutdown).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58119462466b6a8defbbce0c42aff9a7c5fffc0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->