### PR TITLE
fix: scope child stream activation guard

### DIFF
--- a/src/agent/runtime/SessionEventHub.ts
+++ b/src/agent/runtime/SessionEventHub.ts
@@ -14,6 +14,7 @@ export type SessionEvent =
 
 export interface SessionEventSubscriptionFilter {
   readonly scope?: SessionEvent['scope'];
+  readonly streamId?: StreamTabId;
   readonly types?: readonly AgentEvent['type'][];
 }
 
@@ -22,6 +23,7 @@ export type SessionEventSubscriber = (event: SessionEvent) => void;
 interface SubscriberRegistration {
   readonly subscriber: SessionEventSubscriber;
   readonly scope?: SessionEvent['scope'];
+  readonly streamId?: StreamTabId;
   readonly types?: ReadonlySet<AgentEvent['type']>;
 }
 
@@ -38,11 +40,20 @@ function isDevAssertionMode(): boolean {
  */
 export class SessionEventHub {
   private readonly subscribers = new Set<SubscriberRegistration>();
-  private runScopeSubscriberCount = 0;
+  private readonly runScopeSubscriberCountsByStream = new Map<
+    StreamTabId,
+    number
+  >();
 
   emit(event: SessionEvent): void {
     for (const registration of this.subscribers) {
       if (registration.scope && registration.scope !== event.scope) continue;
+      if (
+        registration.streamId &&
+        (event.scope !== 'run' || registration.streamId !== event.streamId)
+      ) {
+        continue;
+      }
       if (
         registration.types &&
         (event.scope !== 'run' || !registration.types.has(event.event.type))
@@ -64,17 +75,32 @@ export class SessionEventHub {
     const registration: SubscriberRegistration = {
       subscriber,
       scope: filter.scope,
+      streamId: filter.scope === 'session' ? undefined : filter.streamId,
       types: filter.types ? new Set(filter.types) : undefined,
     };
     this.subscribers.add(registration);
-    if (filter.scope !== 'session') {
-      this.runScopeSubscriberCount += 1;
+    if (registration.streamId) {
+      this.runScopeSubscriberCountsByStream.set(
+        registration.streamId,
+        (this.runScopeSubscriberCountsByStream.get(registration.streamId) ??
+          0) + 1,
+      );
     }
 
     return () => {
       if (!this.subscribers.delete(registration)) return;
-      if (filter.scope !== 'session') {
-        this.runScopeSubscriberCount -= 1;
+      if (registration.streamId) {
+        const nextCount =
+          (this.runScopeSubscriberCountsByStream.get(registration.streamId) ??
+            1) - 1;
+        if (nextCount > 0) {
+          this.runScopeSubscriberCountsByStream.set(
+            registration.streamId,
+            nextCount,
+          );
+        } else {
+          this.runScopeSubscriberCountsByStream.delete(registration.streamId);
+        }
       }
     };
   }
@@ -85,9 +111,9 @@ export class SessionEventHub {
    * violation so startup can continue; tests and opt-in dev runs throw.
    */
   assertRunSubscribersAttachedBeforeActivation(streamId: StreamTabId): void {
-    if (this.runScopeSubscriberCount > 0) return;
+    if ((this.runScopeSubscriberCountsByStream.get(streamId) ?? 0) > 0) return;
 
-    const message = `No run-scoped session event subscribers attached before activating ${streamId}`;
+    const message = `No run-scoped session event subscribers attached for ${streamId} before activation`;
     if (isDevAssertionMode()) {
       throw new Error(message);
     }

--- a/src/agent/runtime/SessionRunFactProjector.ts
+++ b/src/agent/runtime/SessionRunFactProjector.ts
@@ -60,6 +60,6 @@ export function attachSessionRunFactProjector(
         event.data as ProgressEventPayloads[typeof factName],
       );
     },
-    { scope: 'run', types: ['domain', 'usage'] },
+    { scope: 'run', streamId: projectedStreamId, types: ['domain', 'usage'] },
   );
 }

--- a/src/agent/runtime/conversationProgressHub.ts
+++ b/src/agent/runtime/conversationProgressHub.ts
@@ -49,6 +49,6 @@ export function attachConversationProgressHub(
         progress: sessionEvent.event.data,
       });
     },
-    { scope: 'run', types: ['domain'] },
+    { scope: 'run', streamId, types: ['domain'] },
   );
 }

--- a/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import {
@@ -23,6 +23,8 @@ import { createRecordingHost } from '../progressTestUtils';
 const executionId = 'exec:child-stream' as ExecutionId;
 const parentStreamId = 'stream:parent' as StreamTabId;
 const childStreamId = 'bash#exec:child-stream' as StreamTabId;
+const orderingExecutionId = 'exec:child-stream-ordering' as ExecutionId;
+const orderingChildStreamId = 'bash#exec:child-stream-ordering' as StreamTabId;
 const loopExecutionId = 'exec:child-stream-loop' as ExecutionId;
 const loopChildStreamId = 'codex#exec:child-stream-loop' as StreamTabId;
 const stoppedExecutionId = 'exec:child-stream-stopped' as ExecutionId;
@@ -62,6 +64,7 @@ describe('child stream progress events', () => {
   afterEach(() => {
     for (const streamId of [
       childStreamId,
+      orderingChildStreamId,
       loopChildStreamId,
       stoppedChildStreamId,
       cancelledChildStreamId,
@@ -69,6 +72,56 @@ describe('child stream progress events', () => {
       normalizedErrorChildStreamId,
     ]) {
       clearStreamStatusForTest(StreamStatusService, streamId);
+    }
+  });
+
+  it('attaches child run subscribers before activating the stream', () => {
+    const active = createRecordingHost();
+    const session = defaultSession();
+    const sequence: string[] = [];
+    const originalAssert =
+      session.events.assertRunSubscribersAttachedBeforeActivation.bind(
+        session.events,
+      );
+    const assertSpy = vi
+      .spyOn(session.events, 'assertRunSubscribersAttachedBeforeActivation')
+      .mockImplementation((streamId) => {
+        sequence.push(`assert:${streamId}`);
+        expect(active.events.map((entry) => entry.event)).not.toContain(
+          'setActiveStream',
+        );
+        originalAssert(streamId);
+      });
+    const host: AgentRuntimeHost = {
+      emit: (event, payload) => {
+        sequence.push(`emit:${event}`);
+        active.host.emit(event, payload);
+      },
+    };
+
+    try {
+      const childStream = createChildStream(
+        orderingExecutionId,
+        parentStreamId,
+        {
+          runtimeHost: host,
+          streamPrefix: 'bash',
+          streamCategory: AgentCategory.ToolUse,
+          agentName: 'test-agent',
+          description: 'Run a background bash command',
+          config,
+          toolName: 'bash',
+        },
+      );
+      childStream.finalize({ autoClose: true });
+
+      expect(assertSpy).toHaveBeenCalledWith(orderingChildStreamId);
+      expect(sequence.slice(0, 2)).toEqual([
+        `assert:${orderingChildStreamId}`,
+        'emit:setActiveStream',
+      ]);
+    } finally {
+      assertSpy.mockRestore();
     }
   });
 

--- a/src/test-kernel/agent/runtime/SessionEventHub.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionEventHub.vitest.ts
@@ -12,6 +12,7 @@ import { type StreamTabId } from '@shared/schemas';
 import { createRecordingHost } from '../progressTestUtils';
 
 const streamId = 'stream:hub' as StreamTabId;
+const otherStreamId = 'stream:other' as StreamTabId;
 
 describe('SessionEventHub', () => {
   it('filters high-volume stream chunks away from typed subscribers', () => {
@@ -20,6 +21,7 @@ describe('SessionEventHub', () => {
 
     hub.subscribe((event) => seen.push(event), {
       scope: 'run',
+      streamId,
       types: ['domain'],
     });
 
@@ -27,6 +29,11 @@ describe('SessionEventHub', () => {
       scope: 'run',
       streamId,
       event: { type: 'stream.chunk', id: 'chunk-1', text: 'a' },
+    });
+    hub.emit({
+      scope: 'run',
+      streamId: otherStreamId,
+      event: { type: 'domain', key: 'other-stream', data: { ignored: true } },
     });
     hub.emit({
       scope: 'run',
@@ -41,7 +48,7 @@ describe('SessionEventHub', () => {
     });
   });
 
-  it('asserts that a run-scope subscriber exists before activation', () => {
+  it('asserts that a run-scope subscriber exists for the activating stream', () => {
     const hub = new SessionEventHub();
 
     expect(() =>
@@ -56,11 +63,35 @@ describe('SessionEventHub', () => {
     ).toThrow(/No run-scoped session event subscribers/);
     detachSessionOnly();
 
-    const detachRun = hub.subscribe(() => undefined, { scope: 'run' });
+    const detachUnscopedRun = hub.subscribe(() => undefined, { scope: 'run' });
+    expect(() =>
+      hub.assertRunSubscribersAttachedBeforeActivation(streamId),
+    ).toThrow(/No run-scoped session event subscribers/);
+    detachUnscopedRun();
+
+    const detachOtherRun = hub.subscribe(() => undefined, {
+      scope: 'run',
+      streamId: otherStreamId,
+    });
+    expect(() =>
+      hub.assertRunSubscribersAttachedBeforeActivation(streamId),
+    ).toThrow(/No run-scoped session event subscribers/);
+    expect(() =>
+      hub.assertRunSubscribersAttachedBeforeActivation(otherStreamId),
+    ).not.toThrow();
+    detachOtherRun();
+
+    const detachRun = hub.subscribe(() => undefined, {
+      scope: 'run',
+      streamId,
+    });
     expect(() =>
       hub.assertRunSubscribersAttachedBeforeActivation(streamId),
     ).not.toThrow();
     detachRun();
+    expect(() =>
+      hub.assertRunSubscribersAttachedBeforeActivation(streamId),
+    ).toThrow(/No run-scoped session event subscribers/);
   });
 
   it('projects run facts and usage from trace events to the runtime host', () => {

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -77,24 +77,6 @@ export function createChildStream(
   const childStreamId = `${options.streamPrefix}#${executionId}` as StreamTabId;
   const { runtimeHost } = options;
 
-  // Register the child stream (state, logs, hints) without switching the
-  // active tab. Background child streams (bash, codex) shouldn't yank the
-  // user away from whatever they're viewing — the tab simply appears.
-  runtimeHost.emit('setActiveStream', {
-    streamId: childStreamId,
-    agentCategory: options.streamCategory,
-    suppressViewSwitch: true,
-  });
-  runtimeHost.emit('setTaskState', {
-    streamId: childStreamId,
-    executionId,
-    taskState: agentConfigToTaskState(options.config),
-  });
-  runtimeHost.emit('updateStreamDescription', {
-    streamId: childStreamId,
-    description: truncateWithEllipsis(options.description, 80),
-  });
-
   // Capture the run's session at creation (inside the parent run's ALS); the
   // status-update and finalize closures below fire later, possibly outside it.
   const session = currentSession();
@@ -113,6 +95,26 @@ export function createChildStream(
     detachSessionTrace();
     runTrace.dispose();
   };
+  session.events.assertRunSubscribersAttachedBeforeActivation(childStreamId);
+
+  // Register the child stream (state, logs, hints) without switching the
+  // active tab. Background child streams (bash, codex) shouldn't yank the
+  // user away from whatever they're viewing — the tab simply appears.
+  runtimeHost.emit('setActiveStream', {
+    streamId: childStreamId,
+    agentCategory: options.streamCategory,
+    suppressViewSwitch: true,
+  });
+  runtimeHost.emit('setTaskState', {
+    streamId: childStreamId,
+    executionId,
+    taskState: agentConfigToTaskState(options.config),
+  });
+  runtimeHost.emit('updateStreamDescription', {
+    streamId: childStreamId,
+    description: truncateWithEllipsis(options.description, 80),
+  });
+
   const handle = new AgentExecutionHandle(
     executionId,
     parentStreamId,


### PR DESCRIPTION
## Summary

Make the session event hub activation guard actually stream-scoped, and make `createChildStream` follow the same attach-before-activate order as `AgentLaunchContext`.

Child streams now attach their trace/projector subscribers, assert the target stream has a run-scoped subscriber, and only then emit `setActiveStream`.

## Issue acceptance gates

- Addresses #6993.
- Re-verified the cited `childStream` and `SessionEventHub` evidence on current `main`; no citation drift found.
- `SessionEventHub.assertRunSubscribersAttachedBeforeActivation(streamId)` now checks subscribers for that exact stream instead of a hub-wide run-subscriber tally.
- `attachSessionRunFactProjector` and `attachConversationProgressHub` declare their `streamId` in the subscription filter.
- `createChildStream` now attaches the child trace/projector and calls the activation-ordering assertion before emitting `setActiveStream`.
- Added regressions for stream-scoped hub assertions and child-stream attach-before-activation ordering.

## Single source of truth

`SessionEventHub` now owns stream-scoped subscription filtering and the per-stream activation subscriber count. `createChildStream` mirrors `AgentLaunchContext` by treating `setActiveStream` as the activation point after session subscribers are attached.

## Duplication and abstraction budget

Removed the false hub-wide assertion path that could be satisfied by an unrelated run in the same session. The only new surface is `SessionEventSubscriptionFilter.streamId`, which owns the invariant that a run subscriber can declare the stream it serves. No pass-through layer, factory, or speculative cache was added. The added line count lives in the stream-scoped guard bookkeeping and focused regression tests.

No #6981 ledger row is needed: this PR does not introduce a shim, dual-write, alias, fallback, or migration path.

## Host impact

Extension: Child stream progress tabs keep the same host events, but the ordering now matches the session-hub invariant before activation.

Desktop: Same as extension for child streams; no host wiring changes.

CLI: Child streams created by CLI tools keep the same events, with trace/projector subscribers attached before the stream activates.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write src/agent/runtime/SessionEventHub.ts src/agent/runtime/SessionRunFactProjector.ts src/agent/runtime/conversationProgressHub.ts src/tools/childStream.ts src/test-kernel/agent/runtime/SessionEventHub.vitest.ts src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts`
- `npm test -- --run src/test-kernel/agent/runtime/SessionEventHub.vitest.ts src/test-kernel/agent/runtime/ConversationProgressHub.vitest.ts src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts`
- `npm run typecheck -- --pretty false`
- `git diff --check`
- `npm test`
- `npm run lint` (passes with 16 pre-existing warnings)
- `npm run compile:fast`

Closes #6993

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches event routing and activation ordering for child streams and multi-stream sessions; wrong filtering could drop progress/UI updates for a stream.
> 
> **Overview**
> **Session event hub** subscriptions can now declare a **`streamId`**, and **`emit`** skips callbacks when the run event’s stream doesn’t match. The pre-activation guard no longer treats *any* run-scoped subscriber as sufficient—it requires at least one subscriber registered for **that** stream (unscoped run subscribers no longer count).
> 
> **Run fact** and **conversation progress** projectors register with their target **`streamId`** in the filter so they participate in the per-stream activation check and receive fewer unrelated events.
> 
> **`createChildStream`** matches **`AgentLaunchContext`**: attach trace and run-fact projector, call **`assertRunSubscribersAttachedBeforeActivation`**, then emit **`setActiveStream`** and related registration events. Tests cover stream-scoped hub assertions and attach-before-activate ordering for child streams.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b387fde60c6cfa0e02fd9a05918c1f111b092c27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->