### PR TITLE
[codex] Fix progress metadata filter patch regressions

### DIFF
--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -20,6 +20,7 @@ import {
   WebviewUpdater,
   type LogContentExtras,
 } from '@shared/progressView/backend/WebviewUpdater';
+import { buildStreamInfos } from '@shared/progressView/backend/streamInfoUtils';
 import { mapToRecord } from '@shared/progressView/backend/persistence/serializationUtils';
 import {
   ProgressViewState,
@@ -608,16 +609,44 @@ export class ProgressEventHandler {
     this.state.streamLogs.ensureStream(streamId);
     // Persisted streams may be in stream logs but missing from _streamStates;
     // getOrCreateStreamState is idempotent so safe to call unconditionally.
-    const category = this.getStreamCategory(streamId) ?? AgentCategory.Workflow;
+    const streamCategory = this.getStreamCategory(streamId);
+    const category = streamCategory ?? AgentCategory.Workflow;
     this.state.getOrCreateStreamState(streamId, category);
 
     if (isNewStream) {
-      this.maybeUpdateFilterForCategory(category);
+      const previousFilter = this.state.agentCategoryFilter;
+      this.maybeUpdateFilterForCategory(streamCategory);
+      const filterChanged = this.state.agentCategoryFilter !== previousFilter;
       const matchesFilter =
         this.state.agentCategoryFilter === 'all' ||
         this.state.agentCategoryFilter === category;
       if (!this.state.activeStream && matchesFilter) {
         this.state.activeStream = streamId;
+      }
+      let activeStream: ActiveStreamId | undefined =
+        !this.state.activeStream || this.state.activeStream === streamId
+          ? this.state.activeStream
+          : undefined;
+      if (filterChanged) {
+        const selectableStreams = buildStreamInfos(
+          this.state,
+          this.state.agentCategoryFilter,
+        ).map((stream) => stream.name);
+        const nextActiveStream =
+          selectableStreams.length === 0
+            ? ''
+            : this.state.pickValidActiveStream(selectableStreams);
+        const previousActiveStream = this.state.activeStream;
+        if (nextActiveStream !== previousActiveStream) {
+          this.state.activeStream = nextActiveStream;
+          if (
+            previousActiveStream &&
+            previousActiveStream !== nextActiveStream
+          ) {
+            this.state.releasePreviousActive(previousActiveStream);
+          }
+        }
+        activeStream = nextActiveStream;
       }
       const statusesForRefresh = this.state.streamStatus.getAll();
       statusesForRefresh.set(streamId, status);
@@ -633,10 +662,7 @@ export class ProgressEventHandler {
         statusesForRefresh,
         substatesForRefresh,
         {
-          activeStream:
-            !this.state.activeStream || this.state.activeStream === streamId
-              ? this.state.activeStream
-              : undefined,
+          activeStream,
           agentFilter: this.state.agentCategoryFilter,
         },
       );

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -9,6 +9,7 @@ import { bus } from '@eventBus/ProgressEventBus';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   AgentCategory,
+  STREAM_PHASE,
   type ProgressViewOutboundMessage,
 } from '@shared/schemas';
 import {
@@ -306,6 +307,107 @@ describe('ProgressBackend', () => {
       }
     } finally {
       subscription.dispose();
+      backend.dispose();
+    }
+  });
+
+  it('does not switch category filters for unknown-category status streams', () => {
+    const messages: ProgressViewOutboundMessage[] = [];
+    const backend = new ProgressBackend({
+      storage: new MemoryMementoStorage(),
+      sendMessage: (message) => {
+        messages.push(message);
+        return true;
+      },
+      hasTarget: () => true,
+      configureUi: () => createUiConfig(),
+    });
+
+    try {
+      backend.state.streamLogs.ensureStream('tool-stream');
+      backend.state.updateStreamHints('tool-stream', {
+        agentCategory: AgentCategory.ToolUse,
+      });
+      backend.state.getOrCreateStreamState(
+        'tool-stream',
+        AgentCategory.ToolUse,
+      );
+      backend.state.activeStream = 'tool-stream';
+      backend.state.agentCategoryFilter = 'toolUse';
+
+      backend.eventHandler.setStreamStatus(
+        'unknown-stream',
+        STREAM_PHASE.RUNNING,
+      );
+
+      const patch = messages.find(
+        (message) =>
+          message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA &&
+          message.streamInfo.name === 'unknown-stream',
+      );
+      expect(backend.state.agentCategoryFilter).toBe('toolUse');
+      expect(backend.state.activeStream).toBe('tool-stream');
+      expect(patch).toMatchObject({
+        agentFilter: 'toolUse',
+        activeStream: undefined,
+        streamInfo: {
+          name: 'unknown-stream',
+          agentCategory: AgentCategory.Workflow,
+        },
+      });
+    } finally {
+      backend.dispose();
+    }
+  });
+
+  it('revalidates the active stream when status registration changes the filter', () => {
+    const messages: ProgressViewOutboundMessage[] = [];
+    const backend = new ProgressBackend({
+      storage: new MemoryMementoStorage(),
+      sendMessage: (message) => {
+        messages.push(message);
+        return true;
+      },
+      hasTarget: () => true,
+      configureUi: () => createUiConfig(),
+    });
+
+    try {
+      backend.state.streamLogs.ensureStream('tool-stream');
+      backend.state.updateStreamHints('tool-stream', {
+        agentCategory: AgentCategory.ToolUse,
+      });
+      backend.state.getOrCreateStreamState(
+        'tool-stream',
+        AgentCategory.ToolUse,
+      );
+      backend.state.activeStream = 'tool-stream';
+      backend.state.agentCategoryFilter = 'toolUse';
+      backend.state.updateStreamHints('workflow-stream', {
+        agentCategory: AgentCategory.Workflow,
+      });
+
+      backend.eventHandler.setStreamStatus(
+        'workflow-stream',
+        STREAM_PHASE.RUNNING,
+      );
+
+      const patch = messages.find(
+        (message) =>
+          message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA &&
+          message.streamInfo.name === 'workflow-stream',
+      );
+      expect(backend.state.agentCategoryFilter).toBe('workflow');
+      expect(backend.state.activeStream).toBe('workflow-stream');
+      expect(patch).toMatchObject({
+        agentFilter: 'workflow',
+        activeStream: 'workflow-stream',
+        streamInfo: {
+          name: 'workflow-stream',
+          agentCategory: AgentCategory.Workflow,
+        },
+      });
+    } finally {
       backend.dispose();
     }
   });


### PR DESCRIPTION
## Summary

Fixes the per-stream progress metadata patch path introduced by #7006 so new-stream status registration preserves the old full-sync semantics:

- unknown-category streams no longer force the progress view category filter to workflow
- when a known stream changes the category filter, the backend recomputes and patches a valid active stream
- backend regression tests cover both correctness gaps from #7008

## Issue acceptance gates

Addresses #7008.

- Passed the un-defaulted stream category to `maybeUpdateFilterForCategory`, keeping the workflow default only for stream-state registration.
- Recomputed the active stream when a new-stream status registration changes `agentCategoryFilter`, matching the old `sendStreamMetadata` behavior.
- Added regression coverage for unknown-category status streams and filter-driven active-stream revalidation.

## Single source of truth

`ProgressEventHandler.setStreamStatus` remains the backend owner for new-stream status registration and the metadata patch it sends to the progress view.

## Duplication and abstraction budget

Avoided adding a new abstraction or pass-through layer. The added mass is regression coverage plus a small inline revalidation path that mirrors the existing full-sync active-stream selection invariant. No shim, projection, dual-write, alias, fallback, or migration path was introduced, so no #6981 ledger row is needed.

## Host impact

Extension: Progress board metadata patches preserve user-selected category filters for unknown streams and keep the active tab valid after filter-changing stream registration.

Desktop: Same shared progress backend behavior as extension; no desktop-specific API or storage impact.

CLI: No runtime, headless byte output, `--print`, or JSON output impact.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write src/shared/progressView/backend/events/ProgressEventHandler.ts src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `npm test -- --run src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `npm run typecheck -- --pretty false`
- `git diff --check`
- `npm test`
- `npm run lint` (0 errors, 16 pre-existing warnings in unrelated files)
- `npm run compile:fast`

Closes #7008

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to progress view metadata patching and active-tab selection; regression tests lock behavior with no auth or data-path changes.
> 
> **Overview**
> Fixes regressions in **`ProgressEventHandler.setStreamStatus`** when a **new** stream is registered via status updates (per-stream metadata patches from #7006).
> 
> **Unknown-category streams** no longer drive the agent category filter: only the resolved hint is passed to `maybeUpdateFilterForCategory`, while **`AgentCategory.Workflow`** is still used only when creating stream state. The user’s filter (e.g. tool use) and active tab stay put.
> 
> When a **known** new stream **does** change the filter, the backend **revalidates the active stream** with `buildStreamInfos` and `pickValidActiveStream`, releases the previous active stream if needed, and includes the updated **`activeStream`** in the metadata patch—matching prior full-sync behavior.
> 
> Two **ProgressBackend** regression tests cover unknown-category registration and filter-driven active-stream switching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc5203196d40e1ddf9e2e8560b4fc8980208bd28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->