### PR TITLE
[codex] Remove unused progress metadata caches

### DIFF
--- a/src/shared/progressView/backend/WebviewUpdater.ts
+++ b/src/shared/progressView/backend/WebviewUpdater.ts
@@ -88,9 +88,6 @@ export interface SyncStreamContentPayload extends LogContentExtras {
  * Targets a single active webview at a time (sidebar OR editor panel).
  */
 export class WebviewUpdater {
-  private readonly streamInfoCache = new Map<StreamTabId, StreamTabInfo>();
-  private readonly streamMetadataCache = new Map<StreamTabId, StreamMetadata>();
-
   constructor(
     private readonly send: ProgressViewMessageSender,
     private readonly hasTarget: () => boolean,
@@ -143,7 +140,6 @@ export class WebviewUpdater {
       statuses,
       substates,
     );
-    this.cacheStreamSnapshot(streamInfo, streamState);
 
     this.sendMessage({
       command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA,
@@ -466,9 +462,7 @@ export class WebviewUpdater {
 
     // Send lightweight metadata — only backend-owned fields the frontend merges.
     const streamMetadata: Record<StreamTabId, StreamMetadata> = {};
-    const liveStreams = new Set<StreamTabId>();
     for (const streamInfo of streams) {
-      liveStreams.add(streamInfo.name);
       const metadata = this.buildStreamMetadataForStream(
         state,
         streamInfo,
@@ -476,9 +470,7 @@ export class WebviewUpdater {
         substates,
       );
       streamMetadata[streamInfo.name] = metadata;
-      this.cacheStreamSnapshot(streamInfo, metadata);
     }
-    this.pruneStreamSnapshotCache(liveStreams);
 
     this.updateStreams(
       streams,
@@ -512,21 +504,5 @@ export class WebviewUpdater {
       activeProcesses: current?.activeProcesses,
       finishedProcessCount: current?.finishedProcessCount,
     });
-  }
-
-  private cacheStreamSnapshot(
-    streamInfo: StreamTabInfo,
-    metadata: StreamMetadata,
-  ): void {
-    this.streamInfoCache.set(streamInfo.name, streamInfo);
-    this.streamMetadataCache.set(streamInfo.name, metadata);
-  }
-
-  private pruneStreamSnapshotCache(liveStreams: Set<StreamTabId>): void {
-    for (const streamId of this.streamInfoCache.keys()) {
-      if (liveStreams.has(streamId)) continue;
-      this.streamInfoCache.delete(streamId);
-      this.streamMetadataCache.delete(streamId);
-    }
   }
 }


### PR DESCRIPTION
## Summary

Removes the write-only `streamInfoCache` and `streamMetadataCache` state from `WebviewUpdater`.

The caches were populated by both the per-stream patch path and the full metadata sync path, but no code read them. Deleting them removes stream-count-proportional memory growth without changing the outbound metadata messages.

## Issue acceptance gates

Addresses #7009.

- Removed `streamInfoCache` and `streamMetadataCache`.
- Removed `cacheStreamSnapshot()` and `pruneStreamSnapshotCache()`.
- Removed the cache write/prune call sites from `updateStreamMetadata()` and `sendStreamMetadata()`.
- Reverified with `rg` that no cache symbols remain in `src/` or `packages/`.

## Single source of truth

`WebviewUpdater` now builds stream metadata directly from `ProgressViewState` for the message being sent; there is no parallel cached copy of stream metadata.

## Duplication and abstraction budget

Removed a speculative duplicate metadata store and its maintenance helper methods. This PR is net-negative by 24 lines and adds no abstraction. No shim, projection, dual-write, alias, fallback, or migration path was introduced, so no #6981 ledger row is needed.

## Host impact

Extension: Progress view metadata messages are unchanged; removes unused backend memory growth.

Desktop: Same shared progress backend cleanup as extension; no desktop-specific behavior or API impact.

CLI: No runtime, headless byte output, `--print`, or JSON output impact.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write src/shared/progressView/backend/WebviewUpdater.ts`
- `npm test -- --run src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/progressView/SessionRunFactProjectorEquivalence.vitest.ts src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts`
- `npm run typecheck -- --pretty false`
- `git diff --check`
- `npm test`
- `npm run lint` (0 errors, 16 pre-existing warnings in unrelated files)
- `npm run compile:fast`

Closes #7009

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral change is limited to removing unused in-memory caches; outbound progress view messages and metadata construction paths are unchanged.
> 
> **Overview**
> **Removes dead backend state** in `WebviewUpdater` that duplicated stream tab info and metadata on every per-stream and full sync path but was never read.
> 
> Deletes `streamInfoCache`, `streamMetadataCache`, `cacheStreamSnapshot()`, and `pruneStreamSnapshotCache()`, along with their call sites in `updateStreamMetadata()` and `sendStreamMetadata()`. Metadata for IPC messages is still built on demand from `ProgressViewState` via `buildStreamMetadataForStream()`—only the parallel cached copy and stream-count-proportional memory growth are gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a46bdb12898dcb40fd90792540a95e09ab5b8268. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->