### PR TITLE
refactor: move host-agnostic error helpers from common to utils

### DIFF
--- a/packages/extension/src/progressView/frontend/components/TexraDiffView.ts
+++ b/packages/extension/src/progressView/frontend/components/TexraDiffView.ts
@@ -3,9 +3,6 @@ import { LitElement, css, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { consume } from '@lit/context';
 
-// Local imports - errors
-import { extractErrorMessage } from '@common/errors';
-
 // Local imports - shared modules
 import { themeContext } from '@shared/BaseWebviewApp';
 import { commonViewStyles, designTokens } from '@shared/styles';
@@ -13,6 +10,9 @@ import { DESKTOP_THEME_KIND } from '@shared/constants/desktopTheme';
 
 // Local imports - shared Web Awesome helpers
 import { renderLoadingState } from '@shared/wa/loadingState';
+
+// Local imports - errors
+import { extractErrorMessage } from '@utils/errors/errorMessage';
 
 type MonacoModule = typeof import('monaco-editor/esm/vs/editor/editor.api.js');
 type MonacoWorkerModule = { default: new () => Worker };

--- a/packages/extension/src/progressView/frontend/formatters/baseLogFormatter.ts
+++ b/packages/extension/src/progressView/frontend/formatters/baseLogFormatter.ts
@@ -1,7 +1,7 @@
 /**
  * Base log formatter utilities for open state management and error handling.
  */
-import { toErrorMessage } from '@common/errors';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 
 export type FormatOptions = {
   preservedOpen?: boolean;

--- a/src/common/errors/errorMessage.ts
+++ b/src/common/errors/errorMessage.ts
@@ -1,31 +1,13 @@
-import { isNonEmptyString } from '@utils/core';
-
-/** Normalize any thrown value into a user-friendly error message string. */
-export function toErrorMessage(err: unknown): string {
-  if (err instanceof Error) {
-    return err.message;
-  }
-  return String(err);
-}
-
-/** Coerce any thrown value to an Error instance. */
-export function ensureError(err: unknown): Error {
-  return err instanceof Error ? err : new Error(toErrorMessage(err));
-}
-
 /**
- * Extract error message from Error objects or strings.
- * Returns `undefined` if the value is neither an Error nor a non-empty string.
- *
- * Use this when you need optional extraction. For a guaranteed string, use
- * {@link toErrorMessage}.
+ * `toErrorMessage`/`ensureError`/`extractErrorMessage` are host-agnostic and
+ * used from webview frontend (browser) code as well as the extension host,
+ * so they live canonically in `@utils/errors/errorMessage` (the shared
+ * location) rather than here in `common`, which is backend-only. Re-exported
+ * for the existing `@common/errors` and `@common/errors/errorMessage`
+ * consumers.
  */
-export function extractErrorMessage(err: unknown): string | undefined {
-  if (err instanceof Error && isNonEmptyString(err.message)) {
-    return err.message.trim();
-  }
-  if (isNonEmptyString(err)) {
-    return err.trim();
-  }
-  return undefined;
-}
+export {
+  toErrorMessage,
+  ensureError,
+  extractErrorMessage,
+} from '@utils/errors/errorMessage';

--- a/src/utils/errors/errorMessage.ts
+++ b/src/utils/errors/errorMessage.ts
@@ -1,0 +1,31 @@
+import { isNonEmptyString } from '@utils/core';
+
+/** Normalize any thrown value into a user-friendly error message string. */
+export function toErrorMessage(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return String(err);
+}
+
+/** Coerce any thrown value to an Error instance. */
+export function ensureError(err: unknown): Error {
+  return err instanceof Error ? err : new Error(toErrorMessage(err));
+}
+
+/**
+ * Extract error message from Error objects or strings.
+ * Returns `undefined` if the value is neither an Error nor a non-empty string.
+ *
+ * Use this when you need optional extraction. For a guaranteed string, use
+ * {@link toErrorMessage}.
+ */
+export function extractErrorMessage(err: unknown): string | undefined {
+  if (err instanceof Error && isNonEmptyString(err.message)) {
+    return err.message.trim();
+  }
+  if (isNonEmptyString(err)) {
+    return err.trim();
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary

A routine codebase-responsibility audit found that `packages/extension/src/progressView/frontend/components/TexraDiffView.ts` and `.../formatters/baseLogFormatter.ts` — both bundled into the webview (browser) — imported `extractErrorMessage`/`toErrorMessage` from `src/common/errors`. CLAUDE.md documents `src/common/` as backend-only ("Backend-only helpers: errors, state, files, webview base classes") and `src/utils/` as the directory actually shared between the extension host and webview frontends. These two functions (plus `ensureError`) are pure and host-agnostic, so their real home is `src/utils/`, not `src/common/`.

This PR relocates the implementation and fixes the two frontend files to import from the correct shared location.

## Issue acceptance gates

- No tracked issue; this is a self-initiated hygiene fix from a scheduled codebase-review routine.
- Gate: webview frontend code no longer imports from `src/common/` (backend-only per CLAUDE.md). Satisfied — verified via `grep` that only these two frontend files under a `frontend/` directory imported `@common/errors`, and both are now fixed.

## Single source of truth

`src/utils/errors/errorMessage.ts` is now the canonical definition of `toErrorMessage` / `ensureError` / `extractErrorMessage`. `src/common/errors/errorMessage.ts` is a documented re-export shim, so the ~190 existing backend consumers of `@common/errors` and the ~30 that deep-import `@common/errors/errorMessage` are unaffected.

## Duplication and abstraction budget

No new abstraction — this only relocates an existing module to its correct directory and leaves a one-line re-export shim (not a pass-through layer with logic) so no call site outside the two fixed frontend files needed to change.

## Host impact

Extension: fixes a documented backend/frontend boundary violation in the progress webview (`TexraDiffView.ts`, `baseLogFormatter.ts`); no behavior change.

Desktop: unaffected (no imports of the moved module from desktop code).

CLI: unaffected (CLI imports `@common/errors`/`@common/errors/errorMessage` directly from Node-side backend code, which the shim keeps working).

## Scheduled refactoring

None. The broader `src/utils` vs `src/common` boundary has other pre-existing overlaps (bidirectional imports, near-duplicate helper names) surfaced during this audit that are lower-severity and out of scope for this PR.

## Validation

- `npm run typecheck` — clean.
- `npm run lint` — no new errors; one new warning was introduced by the import reorder and was fixed (import/order in `TexraDiffView.ts`); confirmed 0 lint issues on all four touched files.
- `npm test` (full Vitest suite, 4487 tests) — 4479 passed, 7 skipped, 1 pre-existing failure (`execUtils.vitest.ts` process-group abort test, a sandbox/container process-signaling flake unrelated to this change and not touching any file in this diff).


---
_Generated by [Claude Code](https://claude.ai/code/session_01FgaBMoHNRMNj4yQSoH3D65)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure relocation with a re-export shim; only import paths change for two webview files, with no logic changes.
> 
> **Overview**
> Moves **`toErrorMessage`**, **`ensureError`**, and **`extractErrorMessage`** into **`src/utils/errors/errorMessage.ts`** as the canonical shared implementation, since they are pure and used from webview (browser) code as well as the extension host.
> 
> **`src/common/errors/errorMessage.ts`** now only re-exports those symbols so existing **`@common/errors`** imports stay unchanged. **`TexraDiffView`** and **`baseLogFormatter`** in the progress webview import directly from **`@utils/errors/errorMessage`** instead of backend-only **`@common/errors`**.
> 
> No intended behavior change—directory boundary hygiene per CLAUDE.md.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ac6bb7fb4275f829f275d0d2406164f5730f9c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->