### PR TITLE
[codex] Sync content after filter-driven stream switch

### DIFF
--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -582,14 +582,14 @@ export class ProgressEventHandler {
     };
   }
 
-  setStreamStatus(
+  async setStreamStatus(
     streamId: StreamTabId,
     status: StreamPhase,
     // Kept until Stage 5 removes the legacy bus projection; the status machine
     // now owns repair writes, so this projection no longer consumes it.
     _previousStatus?: StreamPhase,
     substate?: StreamSubstate,
-  ): void {
+  ): Promise<void> {
     // Keep memory bounded by stream status:
     //  - returning to in-flight (e.g., background resume) eagerly rehydrates
     //    previously-released entries so pending appends from the agent
@@ -627,6 +627,7 @@ export class ProgressEventHandler {
         !this.state.activeStream || this.state.activeStream === streamId
           ? this.state.activeStream
           : undefined;
+      let activeStreamToSync: ActiveStreamId | undefined;
       if (filterChanged) {
         const selectableStreams = buildStreamInfos(
           this.state,
@@ -639,6 +640,7 @@ export class ProgressEventHandler {
         const previousActiveStream = this.state.activeStream;
         if (nextActiveStream !== previousActiveStream) {
           this.state.activeStream = nextActiveStream;
+          activeStreamToSync = nextActiveStream;
           if (
             previousActiveStream &&
             previousActiveStream !== nextActiveStream
@@ -666,6 +668,9 @@ export class ProgressEventHandler {
           agentFilter: this.state.agentCategoryFilter,
         },
       );
+      if (activeStreamToSync !== undefined) {
+        await this.syncFilterDrivenActiveStreamContent(activeStreamToSync);
+      }
     } else {
       const lastTimestamp = this.state.streamLogs.getLastTimestamp(streamId);
       this.webviewUpdater.updateStreamStatus(
@@ -675,6 +680,24 @@ export class ProgressEventHandler {
         substate,
       );
     }
+  }
+
+  private async syncFilterDrivenActiveStreamContent(
+    stream: ActiveStreamId,
+  ): Promise<void> {
+    if (!stream) {
+      if (this.state.activeStream === '') {
+        this.syncStreamContent('');
+      }
+      return;
+    }
+
+    await this.state.streamLogs.ensureLoaded(stream);
+
+    // A newer tab switch may have happened while the released log was loading.
+    if (this.state.activeStream !== stream) return;
+
+    this.syncStreamContent(stream, { includeActiveState: true });
   }
 
   private getStreamCategory(streamId: StreamTabId): AgentCategory | undefined {

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -311,7 +311,7 @@ describe('ProgressBackend', () => {
     }
   });
 
-  it('does not switch category filters for unknown-category status streams', () => {
+  it('does not switch category filters for unknown-category status streams', async () => {
     const messages: ProgressViewOutboundMessage[] = [];
     const backend = new ProgressBackend({
       storage: new MemoryMementoStorage(),
@@ -335,7 +335,7 @@ describe('ProgressBackend', () => {
       backend.state.activeStream = 'tool-stream';
       backend.state.agentCategoryFilter = 'toolUse';
 
-      backend.eventHandler.setStreamStatus(
+      await backend.eventHandler.setStreamStatus(
         'unknown-stream',
         STREAM_PHASE.RUNNING,
       );
@@ -360,7 +360,7 @@ describe('ProgressBackend', () => {
     }
   });
 
-  it('revalidates the active stream when status registration changes the filter', () => {
+  it('revalidates and syncs the active stream when status registration changes the filter', async () => {
     const messages: ProgressViewOutboundMessage[] = [];
     const backend = new ProgressBackend({
       storage: new MemoryMementoStorage(),
@@ -383,11 +383,22 @@ describe('ProgressBackend', () => {
       );
       backend.state.activeStream = 'tool-stream';
       backend.state.agentCategoryFilter = 'toolUse';
+      backend.state.streamLogs.ensureStream('workflow-existing');
+      backend.state.updateStreamHints('workflow-existing', {
+        agentCategory: AgentCategory.Workflow,
+      });
+      backend.state.getOrCreateStreamState(
+        'workflow-existing',
+        AgentCategory.Workflow,
+      );
       backend.state.updateStreamHints('workflow-stream', {
         agentCategory: AgentCategory.Workflow,
       });
+      vi.spyOn(backend.state, 'pickValidActiveStream').mockReturnValue(
+        'workflow-existing',
+      );
 
-      backend.eventHandler.setStreamStatus(
+      await backend.eventHandler.setStreamStatus(
         'workflow-stream',
         STREAM_PHASE.RUNNING,
       );
@@ -398,14 +409,23 @@ describe('ProgressBackend', () => {
           message.streamInfo.name === 'workflow-stream',
       );
       expect(backend.state.agentCategoryFilter).toBe('workflow');
-      expect(backend.state.activeStream).toBe('workflow-stream');
+      expect(backend.state.activeStream).toBe('workflow-existing');
       expect(patch).toMatchObject({
         agentFilter: 'workflow',
-        activeStream: 'workflow-stream',
+        activeStream: 'workflow-existing',
         streamInfo: {
           name: 'workflow-stream',
           agentCategory: AgentCategory.Workflow,
         },
+      });
+      expect(
+        messages.find(
+          (message) =>
+            message.command === PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT,
+        ),
+      ).toMatchObject({
+        stream: 'workflow-existing',
+        action: 'render',
       });
     } finally {
       backend.dispose();


### PR DESCRIPTION
## Summary

Fixes the follow-up regression from #7013 where `setStreamStatus` could switch `activeStream` because of a category-filter change but only send a metadata patch.

When that filter-driven switch changes the active stream, the handler now rehydrates the selected stream and sends the same batched content sync used by explicit tab switches, guarded so a newer active-stream change cannot receive stale content.

## Issue acceptance gates

Addresses #7014.

- Reverified the cited `setStreamStatus` and `handleSetActiveStream` paths before implementation.
- Made `setStreamStatus` await the filter-driven content sync path when it changes `activeStream`.
- Added a regression test where the filter change selects a previously inactive workflow stream instead of the newly registered stream, then asserts both the metadata patch and `syncStreamContent` payload.

## Single source of truth

`ProgressEventHandler.setStreamStatus` remains the owner of status-driven active-stream changes, and `syncStreamContent` remains the single content-sync path for rendering an active stream.

## Duplication and abstraction budget

This avoids adding a second content rendering path by reusing `syncStreamContent`. The added mass is the guarded async rehydrate/sync helper plus regression coverage for the previously unsynced branch. No shim, projection, dual-write, alias, fallback, or migration path was introduced, so no #6981 ledger row is needed.

## Host impact

Extension: Progress view tabs selected by status/filter changes now receive full content immediately instead of blank or stale content.

Desktop: Same shared progress backend behavior as extension; no desktop-specific API or storage format impact.

CLI: No runtime, headless byte output, `--print`, or JSON output impact.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write src/shared/progressView/backend/events/ProgressEventHandler.ts src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `npm test -- --run src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `npm run typecheck -- --pretty false`
- `git diff --check`
- `npm test`
- `npm run lint` (0 errors, 16 pre-existing warnings in unrelated files)
- `npm run compile:fast`

Closes #7014

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to progress webview delivery when status events change the category filter; reuses existing syncStreamContent with a stale-tab guard and no auth or persistence changes.
> 
> **Overview**
> Fixes a progress-view regression where **`setStreamStatus`** could change **`activeStream`** because of a category-filter update but only push a metadata patch, leaving the newly selected tab blank or stale.
> 
> **`setStreamStatus`** is now **async** and, when a new stream’s status registration changes the filter and **`pickValidActiveStream`** picks a different active tab, it **awaits** a new **`syncFilterDrivenActiveStreamContent`** helper. That path **rehydrates** the chosen stream’s log from disk and reuses **`syncStreamContent`** (with **`includeActiveState: true`**)—the same batched **`SYNC_STREAM_CONTENT`** / render path as explicit tab switches. A guard skips the sync if **`activeStream`** changed again while the log was loading.
> 
> Regression tests were extended to **`await`** **`setStreamStatus`**, mock filter-driven selection of an existing workflow stream, and assert a **`syncStreamContent`** payload is sent—not only the metadata patch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42e8cc632ad54dcb022bd510bb6af8c3b9b07c14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->