### PR TITLE
[codex] Guard inquiry hydration write-back

### DIFF
--- a/src/test-kernel/tools/InquiryStorage.vitest.ts
+++ b/src/test-kernel/tools/InquiryStorage.vitest.ts
@@ -3,7 +3,7 @@
  * dropped path, follow-up turn semantics, legacy manifest migration,
  * and listing filters.
  */
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createFakePlatform } from '@test/support/FakePlatform';
 import {
@@ -279,5 +279,59 @@ describe('InquiryStorage', () => {
       ).toString('utf8'),
     ) as { turns: Array<{ answer?: string }> };
     expect(persisted.turns[0]?.answer).toBe('Legacy A');
+  });
+
+  it('returns a hydrated legacy manifest when write-back fails', async () => {
+    const platform = (await import('@platform/platform')).platform();
+    const threadDir = `${platform.storage.getGlobalStoragePath()}/ei_threads/ei_aabbccdd0022`;
+    const manifestPath = `${threadDir}/manifest.json`;
+    const legacy = {
+      threadId: 'ei_aabbccdd0022',
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-02T00:00:00.000Z',
+      turns: [
+        {
+          turnIndex: 1,
+          timestamp: '2025-01-01T00:00:00.000Z',
+          question: 'Legacy Q',
+          questionRelativePath: 't1/question.txt',
+          answerRelativePath: 't1/answer.txt',
+        },
+      ],
+    };
+    await platform.fs.createDirectory(threadDir);
+    await platform.fs.createDirectory(`${threadDir}/t1`);
+    await platform.fs.writeFile(
+      `${threadDir}/t1/answer.txt`,
+      Buffer.from('Legacy A', 'utf8'),
+    );
+    await platform.fs.writeFile(
+      manifestPath,
+      Buffer.from(JSON.stringify(legacy), 'utf8'),
+    );
+    const originalWriteFile = platform.fs.writeFile.bind(platform.fs);
+    const writeFileSpy = vi
+      .spyOn(platform.fs, 'writeFile')
+      .mockImplementation(async (target, content) => {
+        if (target === manifestPath) {
+          throw new Error('metadata disk full');
+        }
+        await originalWriteFile(target, content);
+      });
+
+    try {
+      const manifest = await readExternalInquiryThread('ei_aabbccdd0022');
+      expect(manifest).not.toBeNull();
+      expect(manifestToTranscript(manifest!)).toMatchObject([
+        { turnIndex: 1, question: 'Legacy Q', answer: 'Legacy A' },
+      ]);
+    } finally {
+      writeFileSpy.mockRestore();
+    }
+
+    const persisted = JSON.parse(
+      Buffer.from(await platform.fs.readFile(manifestPath)).toString('utf8'),
+    ) as { turns: Array<{ answer?: string }> };
+    expect(persisted.turns[0]?.answer).toBeUndefined();
   });
 });

--- a/src/tools/inquiry/externalInquiryStorage.ts
+++ b/src/tools/inquiry/externalInquiryStorage.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import { Mutex } from 'async-mutex';
 import { z } from 'zod';
 
+import { createChannelTrace } from '@logger';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import {
   ExternalInquirySessionLinksSchema,
@@ -25,6 +26,7 @@ import { isDirectory, isFile } from '@utils/files/fsEntryType';
 const THREADS_DIR = 'ei_threads';
 const EXEC_DIR = 'ei';
 const QUESTION_PREVIEW_CHARS = 200;
+const logger = createChannelTrace('ExternalInquiryStorage');
 
 // ============================================================================
 // Schemas
@@ -605,7 +607,14 @@ export async function readExternalInquiryThread(
     if (!manifest) return null;
     const hydrated = await hydrateAnswersFromDisk(parsed.data, manifest);
     if (hydrated.didHydrate) {
-      await writeThreadManifest(hydrated.manifest);
+      try {
+        await writeThreadManifest(hydrated.manifest);
+      } catch (err) {
+        logger.warn(
+          `Failed to persist hydrated inquiry manifest for ${parsed.data}`,
+          { data: err },
+        );
+      }
     }
     return hydrated.manifest;
   });


### PR DESCRIPTION
## Summary

Makes legacy inquiry-answer hydration write-back best-effort in `readExternalInquiryThread`.

If the manifest rewrite fails after an answer was hydrated from disk, the read now logs a warning and still returns the hydrated manifest instead of failing the read/ask flow. This preserves the existing read-side degradation model: transient write failures should mean "answer not yet inlined", not "the inquiry panel never opens".

## Issue acceptance gates

Addresses #7005.

- Reverified the cited read/write-back evidence before implementation.
- Guarded the hydrated manifest write-back with `try`/`catch` and warning telemetry.
- Added a regression test that forces the manifest write-back to fail and verifies `readExternalInquiryThread` still returns the hydrated transcript while leaving the on-disk manifest unchanged.

## Single source of truth

`readExternalInquiryThread` remains the boundary that normalizes legacy inquiry manifests for callers; the manifest file remains the persisted source of truth when write-back succeeds.

## Duplication and abstraction budget

No new abstraction or pass-through layer was added. The added mass is one inline warning path plus focused regression coverage for the transient write failure. No shim, projection, dual-write, alias, fallback, or migration path was introduced, so no #6981 ledger row is needed.

## Host impact

Extension: Inquiry panel dispatch/read flows no longer fail solely because a hydrated manifest rewrite hits a transient filesystem error.

Desktop: Same shared inquiry storage behavior as extension; no desktop-specific API or storage format impact.

CLI: No runtime, headless byte output, `--print`, or JSON output impact.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write src/tools/inquiry/externalInquiryStorage.ts src/test-kernel/tools/InquiryStorage.vitest.ts`
- `npm test -- --run src/test-kernel/tools/InquiryStorage.vitest.ts`
- `npm run typecheck -- --pretty false`
- `git diff --check`
- `npm test`
- `npm run lint` (0 errors, 16 pre-existing warnings in unrelated files)
- `npm run compile:fast`

Closes #7005

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to inquiry storage read-path error handling; no auth, schema, or dual-write behavior beyond swallowing transient manifest write failures.
> 
> **Overview**
> **`readExternalInquiryThread` no longer fails when persisting a hydrated legacy manifest hits a transient filesystem error.**
> 
> After answers are inlined from on-disk `answer.txt` files, the manifest rewrite is now **best-effort**: failures are logged via `ExternalInquiryStorage` warning telemetry, and callers still receive the **hydrated** manifest and transcript. On-disk `manifest.json` stays unchanged when write-back fails (same as before successful migration).
> 
> Adds a regression test that mocks `writeFile` on the manifest path and asserts the read still returns the hydrated answer while the persisted manifest omits the inlined `answer` field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e43b3569ce0c7cb384625e52415d20c15e7c9c87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->