### PR TITLE
[Stage 2.5] Write inquiry manifests atomically

### DIFF
--- a/src/test-kernel/tools/InquiryStorage.vitest.ts
+++ b/src/test-kernel/tools/InquiryStorage.vitest.ts
@@ -309,14 +309,16 @@ describe('InquiryStorage', () => {
       manifestPath,
       Buffer.from(JSON.stringify(legacy), 'utf8'),
     );
-    const originalWriteFile = platform.fs.writeFile.bind(platform.fs);
-    const writeFileSpy = vi
-      .spyOn(platform.fs, 'writeFile')
+    const originalWriteFileAtomic = platform.fs.writeFileAtomic.bind(
+      platform.fs,
+    );
+    const writeFileAtomicSpy = vi
+      .spyOn(platform.fs, 'writeFileAtomic')
       .mockImplementation(async (target, content) => {
         if (target === manifestPath) {
           throw new Error('metadata disk full');
         }
-        await originalWriteFile(target, content);
+        await originalWriteFileAtomic(target, content);
       });
 
     try {
@@ -325,8 +327,12 @@ describe('InquiryStorage', () => {
       expect(manifestToTranscript(manifest!)).toMatchObject([
         { turnIndex: 1, question: 'Legacy Q', answer: 'Legacy A' },
       ]);
+      expect(writeFileAtomicSpy).toHaveBeenCalledWith(
+        manifestPath,
+        expect.any(Uint8Array),
+      );
     } finally {
-      writeFileSpy.mockRestore();
+      writeFileAtomicSpy.mockRestore();
     }
 
     const persisted = JSON.parse(

--- a/src/tools/inquiry/externalInquiryStorage.ts
+++ b/src/tools/inquiry/externalInquiryStorage.ts
@@ -233,9 +233,9 @@ async function writeThreadManifest(
   manifest: ExternalInquiryThreadManifest,
 ): Promise<void> {
   await GlobalStorageFS.ensureDir(threadDir(manifest.threadId));
-  await GlobalStorageFS.writeJson(
+  await GlobalStorageFS.writeAtomic(
     threadManifestPath(manifest.threadId),
-    manifest,
+    JSON.stringify(manifest, null, 2),
   );
 }
 


### PR DESCRIPTION
## Summary

Make external-inquiry manifest write-back crash-safe by writing `manifest.json` through the existing atomic filesystem path. Hydrated legacy manifests still return to the caller if persistence fails, but the previous on-disk manifest is left intact instead of risking a partial JSON file.

## Issue acceptance gates

Addresses #7020:
- Re-verified the cited storage and filesystem call chain on current `main` before implementation.
- Swapped `writeThreadManifest` from `GlobalStorageFS.writeJson` to `GlobalStorageFS.writeAtomic` with the same JSON serialization.
- Extended the inquiry storage regression test so write-back failure is injected at `writeFileAtomic` and the prior manifest remains unchanged.

## Single source of truth

`writeThreadManifest` remains the single persistence point for external inquiry thread manifests; it now owns the decision that manifest writes use the durable atomic storage path.

## Duplication and abstraction budget

No new abstraction was added. I avoided a single-caller `writeJsonAtomic` wrapper and called the existing atomic primitive directly at the manifest persistence boundary. The small positive line delta lives in the regression assertion that proves the atomic path is used.

## Host impact

Extension: external inquiry manifests are less likely to become corrupt after an interrupted hydration write-back; no UI or command behavior changes.

Desktop: same shared inquiry storage improvement; no desktop-specific behavior changes.

CLI: same shared inquiry storage improvement; `texra run`, `--print`, and `--output-format json` output contracts are unchanged.

## Scheduled refactoring

None. No shim, projection, dual-write, alias, fallback, or migration path was introduced, so no #6981 ledger row is needed.

## Validation

- `corepack pnpm exec prettier --write src/tools/inquiry/externalInquiryStorage.ts src/test-kernel/tools/InquiryStorage.vitest.ts`
- `npm test -- --run src/test-kernel/tools/InquiryStorage.vitest.ts`
- `npm run typecheck -- --pretty false`
- `npm run lint` (0 errors; 16 pre-existing warnings)
- `git diff --check`
- `npm test`
- `npm run compile:fast`

Closes #7020

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows manifest persistence to the existing atomic global-storage primitive; behavior on successful writes is unchanged aside from crash safety.
> 
> **Overview**
> External inquiry thread **`manifest.json`** persistence now goes through **`GlobalStorageFS.writeAtomic`** (temp file + rename) instead of a direct JSON write, so an interrupted hydration write-back cannot leave a truncated manifest on disk.
> 
> **`writeThreadManifest`** is still the only write path; serialization is unchanged (`JSON.stringify` with pretty-print). When legacy manifests are hydrated in memory, callers still get the hydrated manifest if persistence fails, but the on-disk file stays the previous version.
> 
> The inquiry storage regression test now fails **`writeFileAtomic`** on the manifest path and asserts the atomic API was invoked while the legacy on-disk manifest remains intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2357c9fb000b970d10185efe46155df2feefec62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->