### PR TITLE
Centralize Codex subscription capabilities

### DIFF
--- a/src/agent/modelHandlers/openai/modelHandlerCodex.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerCodex.ts
@@ -6,7 +6,7 @@
  * (unofficial) Codex backend. EXPERIMENTAL — see
  * docs/proposals/chatgpt-subscription-codex-auth.md.
  *
- * Only three things differ from the base Responses handler:
+ * Handler-local differences from the base Responses handler:
  *  1. credential — the OAuth access token is passed as the SDK `apiKey` (the
  *     SDK derives `Authorization: Bearer <token>` from it), refreshed per turn;
  *  2. endpoint + headers — `…/codex/responses`, plus `chatgpt-account-id`,
@@ -23,11 +23,12 @@
  * per request: if the user turns it off mid-run (e.g. the "Use your own API
  * key" switch after a `usage_limit_reached` error), this handler transparently
  * falls back to the base Responses handler's OpenAI API-key path on the same
- * instance — no handler swap needed.
+ * instance — no handler swap needed. Subscription capability differences
+ * (context cap, zero pricing, stateless storage, streaming/background policy)
+ * live in the provider capability profile rather than handler-local predicates.
  */
 import OpenAI from 'openai';
 
-import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import {
   CODEX_ACCOUNT_ID_HEADER,
   CODEX_BACKEND_BASE_URL,
@@ -35,22 +36,21 @@ import {
   CODEX_BETA_VALUE,
   CODEX_ORIGINATOR,
   CODEX_ORIGINATOR_HEADER,
-  CODEX_SUBSCRIPTION_CONTEXT_WINDOW,
   CodexAuthError,
-  codexBackendModelId,
   codexCoordinator,
   isCodexSubscriptionToolUseOnly,
   isPreferCodexSubscription,
 } from '@auth/codex';
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
-import { getWebSocketEnabled } from '@utils/config/providerConfig';
+import {
+  codexBackendModelId,
+  resolveProviderCapabilities,
+  type ProviderCapabilityProfile,
+} from '@model/providerCapabilities';
 
 import { ModelHandlerOpenAIResponse } from './modelHandlerOpenAIResponse';
-import type {
-  ResponseCreateParamsBase,
-  ResponseUsage,
-} from 'openai/resources/responses/responses';
+import type { ResponseCreateParamsBase } from 'openai/resources/responses/responses';
 
 const CHANNEL = 'ModelHandlerCodex';
 logger.initialize(CHANNEL);
@@ -192,94 +192,38 @@ const codexFetch = (async (input, init) => {
 
 export class ModelHandlerCodex extends ModelHandlerOpenAIResponse {
   /**
-   * The Codex backend has no background mode — a direct probe returns
-   * `400 {"detail":"Unsupported parameter: background"}` even with store:false
-   * and stream:true satisfied (and `400 Store must be set to false` before
-   * that, since background polling needs the server-side state the backend
-   * refuses). So while the subscription drives the request, never enter
-   * background mode and keep the working default streaming path (the shared
-   * `model.useBackgroundResponses` toggle stays default-on for the real OpenAI
-   * Responses models, just not for this backend). This is the single gate the
-   * request path reads — see {@link ModelHandlerOpenAIResponse.isBackgroundModeActive}.
-   * Once the subscription is off, the request runs on the user's OpenAI API key,
-   * where the base handler decides background mode normally.
-   */
-  public override isBackgroundModeActive(): boolean {
-    return this.usingSubscription() ? false : super.isBackgroundModeActive();
-  }
-
-  /**
-   * Clamp the effective context window to the subscription ceiling
-   * ({@link CODEX_SUBSCRIPTION_CONTEXT_WINDOW}) while the subscription drives the
-   * request. Without it the handler trusts the larger llm-zoo `contextWindow`,
-   * so its own token accounting never trips and the first signal of overflow is
-   * the backend's opaque `400 context_length_exceeded`. {@link Math.min} keeps
-   * it a cap so a model already below the cap is left untouched, and the clamp
-   * lifts on the API-key fallback like every other subscription-gated override.
-   */
-  public override getEffectiveContextWindow(): number {
-    const base = super.getEffectiveContextWindow();
-    return this.usingSubscription()
-      ? Math.min(CODEX_SUBSCRIPTION_CONTEXT_WINDOW, base)
-      : base;
-  }
-
-  /**
-   * Whether this handler should still drive the ChatGPT subscription. Re-read
-   * per request (not cached at construction) so that turning the preference off
-   * mid-run — e.g. via the "Use your own API key" retry switch after a
-   * `usage_limit_reached` error — makes the next attempt fall back to the
-   * user's OpenAI API key on this same handler instance. The OpenAI client is
-   * rebuilt every request from `getApiKey()`/`getBaseUrl()`, so re-resolving
-   * here is enough to reroute the in-place retry, mirroring how the base
-   * handler re-resolves relay vs direct credentials per request.
+   * Re-read the active profile per request (not cached at construction) so that
+   * turning the preference off mid-run — e.g. via the "Use your own API key"
+   * retry switch after a `usage_limit_reached` error — makes the next attempt
+   * fall back to the user's OpenAI API key on this same handler instance. The
+   * OpenAI client is rebuilt every request from `getApiKey()`/`getBaseUrl()`, so
+   * re-resolving here is enough to reroute the in-place retry, mirroring how the
+   * base handler re-resolves relay vs direct credentials per request.
    *
-   * EVERY Codex-specific override below is gated on this so the fallback is a
-   * genuine drop to the base handler — once the subscription is off the request
-   * runs against the normal OpenAI Responses endpoint with the base handler's
-   * full capabilities (token counting, compaction, response chaining, file
-   * upload, store:true, WebSocket eligibility), not Codex-restricted ones.
-   *
-   * (Sign-in is intentionally not re-checked: the switch flips this preference,
+   * Sign-in is intentionally not re-checked: the switch flips this preference,
    * not the stored session, and an auth lapse still surfaces as an actionable
-   * error from {@link resolveAccessToken}.)
+   * error from {@link resolveAccessToken}.
    *
-   * Also gated on agent category: when {@link isCodexSubscriptionToolUseOnly} is
-   * on, only handlers explicitly tagged as tool-use drive the
-   * subscription. Workflow and untagged helper handlers fall back to the base
-   * API-key / relay path. The Codex backend has no background mode (which
-   * workflow runs lean on) and is less stable for long runs, so workflows stay
-   * on the more robust path until the subscription backend proves itself. The
-   * category is set on launched agents at activation
-   * (`AgentLaunchContext.setAgentCategory`); helpers that never launch as
-   * agents remain untagged and therefore outside the scoped subscription.
+   * The profile owns subscription behavior: context cap, zero-rate pricing,
+   * token-counting/compaction/chaining/file-upload disables, stateless storage,
+   * streaming/background/websocket policy, and usage-route tagging. Once the
+   * profile is inactive the inherited OpenAI Responses API-key behavior applies.
    */
-  private usingSubscription(): boolean {
-    if (!isPreferCodexSubscription()) return false;
-    if (isCodexSubscriptionToolUseOnly()) return this.isToolUseMode();
-    return true;
+  protected override getActiveProviderCapabilities(): ProviderCapabilityProfile | null {
+    if (!isPreferCodexSubscription()) return null;
+    if (isCodexSubscriptionToolUseOnly() && !this.isToolUseMode()) return null;
+    return resolveProviderCapabilities({
+      model: this.config,
+      authMode: 'chatgpt-subscription',
+      useOpenRouter: false,
+      agentCategory: this.getAgentCategory(),
+    });
   }
 
-  // The Codex backend is streaming-only (`400 Stream must be set to true`
-  // otherwise) and has no background mode, so the subscription always streams.
-  // After the fallback to the API key, the base streaming logic applies.
-  public override getStreamingConfig(): boolean {
-    return this.usingSubscription() ? true : super.getStreamingConfig();
-  }
-
-  /**
-   * Allow WebSocket transport against the Codex backend whenever the SAME global
-   * `texra.websocket.openai` toggle is on (`getWebSocketEnabled()`) — no
-   * Codex-specific flag. The SDK derives the WebSocket URL + auth from the
-   * (Codex) client, so this targets the Codex endpoint; whether that endpoint
-   * speaks WebSocket is what's being tested. Gated on the subscription: once it
-   * is off, the base rule (default OpenAI endpoint only) applies, so WebSocket
-   * is never attempted against a relay/proxy/custom base URL.
-   */
-  protected override isWebSocketModeEnabled(): boolean {
-    return this.usingSubscription()
-      ? getWebSocketEnabled()
-      : super.isWebSocketModeEnabled();
+  private hasSubscriptionProfile(): boolean {
+    return (
+      this.getActiveProviderCapabilities()?.authMode === 'chatgpt-subscription'
+    );
   }
 
   /**
@@ -293,7 +237,7 @@ export class ModelHandlerCodex extends ModelHandlerOpenAIResponse {
   protected override prepareWireParams(
     params: ResponseCreateParamsBase,
   ): ResponseCreateParamsBase {
-    if (!this.usingSubscription()) return params;
+    if (!this.hasSubscriptionProfile()) return params;
     // `rewriteCodexRequestBody` works on the parsed JSON body (a plain record),
     // matching the HTTP `codexFetch` path; the SDK param type has no index
     // signature, so round-trip it through `Record` at this single boundary.
@@ -301,92 +245,24 @@ export class ModelHandlerCodex extends ModelHandlerOpenAIResponse {
     return rewritten as ResponseCreateParamsBase;
   }
 
-  // The Codex backend has no `/responses/input_tokens` or `/compact` endpoint
-  // (they return 403); rely on the handler's heuristic fallbacks instead. After
-  // the fallback to the OpenAI API key the base capabilities are restored.
-  public override get supportsTokenCounting(): boolean {
-    return this.usingSubscription() ? false : super.supportsTokenCounting;
-  }
-
-  protected override shouldFailWhenFallbackOutputBudgetIsReduced(
-    inputEstimate: number,
-    _maxOutputTokens: number,
-    contextWindow: number,
-    buffer: number,
-  ): boolean {
-    return this.usingSubscription() && inputEstimate + buffer >= contextWindow;
-  }
-
-  public override get supportsManualCompaction(): boolean {
-    return this.usingSubscription() ? false : super.supportsManualCompaction;
-  }
-
-  protected override get supportsResponseChaining(): boolean {
-    return this.usingSubscription() ? false : super.supportsResponseChaining;
-  }
-
-  // The Codex backend keeps no server-side state: it mandates store:false
-  // (verified by probe — store:true returns `400 Store must be set to false`)
-  // and has no background mode to require otherwise. This drives the base
-  // request `store` field and gates the encrypted-reasoning replay path: with no
-  // previous_response_id chaining, reasoning continuity comes from replaying
-  // `reasoning.encrypted_content` blobs in each turn's input instead. Once the
-  // subscription is off entirely, the base store:true + chaining is restored.
-  protected override get storesResponsesServerSide(): boolean {
-    return this.usingSubscription() ? false : super.storesResponsesServerSide;
-  }
-
-  protected override get supportsInlineInputFileUpload(): boolean {
-    return this.usingSubscription()
-      ? false
-      : super.supportsInlineInputFileUpload;
-  }
-
-  protected override get supportsToolResultFileUpload(): boolean {
-    return this.usingSubscription()
-      ? false
-      : super.supportsToolResultFileUpload;
-  }
-
-  /** Subscription usage consumes ChatGPT quota, not TeXRA-tracked API spend;
-   *  once switched to the API key, fall back to real per-token pricing. */
-  public override computePrice(responseUsage: ResponseUsage): number {
-    return this.usingSubscription() ? 0 : super.computePrice(responseUsage);
-  }
-
-  /**
-   * Tag subscription rounds so downstream usage logging and the UI can record
-   * them while making clear they are free (the cost above is already 0). On the
-   * API-key fallback the route is omitted and real cost applies.
-   */
-  public override normalizeUsage(
-    rawUsage: ResponseUsage,
-    responseTimeMs: number,
-  ): NormalizedUsage {
-    const usage = super.normalizeUsage(rawUsage, responseTimeMs);
-    return this.usingSubscription()
-      ? { ...usage, usageRoute: 'chatgpt-subscription' }
-      : usage;
-  }
-
   /** OAuth access token in place of an API key (becomes the Bearer header),
    *  or the user's OpenAI API key once the subscription preference is off. */
   protected override async getApiKey(): Promise<string> {
-    return this.usingSubscription()
+    return this.hasSubscriptionProfile()
       ? this.resolveAccessToken()
       : super.getApiKey();
   }
 
-  /** The Codex backend while the subscription is active (also disables the
-   *  WebSocket transport path), else the default OpenAI base from the parent. */
+  /** The Codex backend while the subscription is active, else the default
+   *  OpenAI base from the parent. */
   public override getBaseUrl(): string | null {
-    return this.usingSubscription()
+    return this.hasSubscriptionProfile()
       ? CODEX_BACKEND_BASE_URL
       : super.getBaseUrl();
   }
 
   protected override async createOpenAIClient(): Promise<OpenAI> {
-    if (!this.usingSubscription()) {
+    if (!this.hasSubscriptionProfile()) {
       // Preference switched off (e.g. after a usage limit) — route this request
       // through the user's OpenAI API key via the standard Responses client.
       this.logger.debug(

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -29,6 +29,10 @@ import {
   PARTIAL_TEXT_TAIL_MAX,
 } from '@common/errors/sdkErrorUtils';
 import { isGpt5ModelName, isGptFamilyModelName } from '@model/modelNames';
+import type {
+  OpenAIResponseProviderCapabilities,
+  ProviderCapabilityProfile,
+} from '@model/providerCapabilities';
 import replacementEngine from '@replacement/engine';
 
 // Type imports
@@ -264,25 +268,48 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   OpenAI,
   Response
 > {
+  protected getActiveProviderCapabilities(): ProviderCapabilityProfile | null {
+    return null;
+  }
+
+  private getOpenAIResponseCapabilities():
+    OpenAIResponseProviderCapabilities | undefined {
+    return this.getActiveProviderCapabilities()?.openAIResponses;
+  }
+
   private isOpenRouterRoutingEnabled(): boolean {
     return shouldUseOpenRouter(this.config);
+  }
+
+  public override getEffectiveContextWindow(): number {
+    return (
+      this.getActiveProviderCapabilities()?.contextWindow ??
+      super.getEffectiveContextWindow()
+    );
   }
 
   /**
    * OpenAI Response API supports file uploads.
    */
   protected override get supportsToolResultFileUpload(): boolean {
-    return true;
+    return (
+      this.getOpenAIResponseCapabilities()?.supportsToolResultFileUpload ?? true
+    );
   }
 
   /** Whether inline input files can be uploaded before the response request. */
   protected get supportsInlineInputFileUpload(): boolean {
-    return true;
+    return (
+      this.getOpenAIResponseCapabilities()?.supportsInlineInputFileUpload ??
+      true
+    );
   }
 
   /** Whether this backend can retain responses for `previous_response_id`. */
   protected get supportsResponseChaining(): boolean {
-    return true;
+    return (
+      this.getOpenAIResponseCapabilities()?.supportsResponseChaining ?? true
+    );
   }
 
   /**
@@ -297,7 +324,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    * Single source for the `store` request field and the encrypted-reasoning gate.
    */
   protected get storesResponsesServerSide(): boolean {
-    return true;
+    return (
+      this.getOpenAIResponseCapabilities()?.storesResponsesServerSide ?? true
+    );
   }
 
   /**
@@ -305,6 +334,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    * Background responses use polling for completed results, incompatible with streaming.
    */
   public override getStreamingConfig(): boolean {
+    if (this.getOpenAIResponseCapabilities()?.streaming === 'forced') {
+      return true;
+    }
     return !this.isBackgroundModeActive() && super.getStreamingConfig();
   }
 
@@ -315,11 +347,14 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    *
    * Single source of truth for the background-mode decision: the request path
    * (`createResponseImpl`), `getStreamingConfig`, and `storesResponsesServerSide`
-   * all route through this method, so a subclass override (e.g. the Codex
-   * subscription handler forcing it off) takes effect on the actual request —
-   * not just on this predicate.
+   * all route through this method, so provider-profile policy (e.g. the Codex
+   * subscription profile forcing it off) takes effect on the actual request, not
+   * just on this predicate.
    */
   public override isBackgroundModeActive(): boolean {
+    if (this.getOpenAIResponseCapabilities()?.backgroundMode === 'disabled') {
+      return false;
+    }
     return (
       this.backgroundModeSupported &&
       this.isBackgroundModeToggleEnabled() &&
@@ -334,7 +369,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   protected override backgroundModeSupported = true;
 
   override get supportsManualCompaction(): boolean {
-    return !this.isOpenRouterRoutingEnabled();
+    return (
+      this.getOpenAIResponseCapabilities()?.supportsManualCompaction ??
+      !this.isOpenRouterRoutingEnabled()
+    );
   }
 
   /**
@@ -453,6 +491,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    * backend) can opt into trying WebSocket against its own base URL.
    */
   protected isWebSocketModeEnabled(): boolean {
+    if (this.getOpenAIResponseCapabilities()?.webSocket === 'global-toggle') {
+      return getWebSocketEnabled();
+    }
     return getWebSocketEnabled() && this.getBaseUrl() === null;
   }
 
@@ -1196,7 +1237,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    * for exact token counts instead of heuristics.
    */
   override get supportsTokenCounting(): boolean {
-    return !this.isOpenRouterRoutingEnabled();
+    return (
+      this.getOpenAIResponseCapabilities()?.supportsTokenCounting ??
+      !this.isOpenRouterRoutingEnabled()
+    );
   }
 
   /**
@@ -1212,6 +1256,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     _contextWindow: number,
     _buffer: number,
   ): boolean {
+    if (
+      this.getOpenAIResponseCapabilities()
+        ?.failWhenFallbackOutputBudgetIsReduced
+    ) {
+      return _inputEstimate + _buffer >= _contextWindow;
+    }
     return false;
   }
 
@@ -1387,9 +1437,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     // pending response is handled above before this state can be discarded.
     this.compactionResult = undefined;
 
-    // Route through isBackgroundModeActive() so subclass overrides (e.g. the
-    // Codex subscription handler) actually gate the request, not just the
-    // predicate.
+    // Route through isBackgroundModeActive() so provider-profile policy actually
+    // gates the request, not just the predicate.
     const useBackgroundResponses = this.isBackgroundModeActive();
     const streamingToggleEnabled = useBackgroundResponses
       ? super.getStreamingConfig()
@@ -2173,9 +2222,16 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
   /** Price computation adapted for Responses API token fields. */
   computePrice(responseUsage: ResponseUsage): number {
+    const providerCapabilities = this.getActiveProviderCapabilities();
     return computeOpenAIResponsePrice(
       responseUsage,
-      this.standardPricingConfig(),
+      providerCapabilities
+        ? {
+            inputPrice: providerCapabilities.inputPrice,
+            outputPrice: providerCapabilities.outputPrice,
+            cacheDiscountFactor: this.capabilities.cacheDiscountFactor,
+          }
+        : this.standardPricingConfig(),
     );
   }
 
@@ -2184,9 +2240,13 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     rawUsage: ResponseUsage,
     responseTimeMs: number,
   ): NormalizedUsage {
-    return normalizeOpenAIResponseUsage(rawUsage, responseTimeMs, (usage) =>
-      this.computePrice(usage),
+    const usage = normalizeOpenAIResponseUsage(
+      rawUsage,
+      responseTimeMs,
+      (usage) => this.computePrice(usage),
     );
+    const usageRoute = this.getActiveProviderCapabilities()?.usageRoute;
+    return usageRoute == null ? usage : { ...usage, usageRoute };
   }
 
   private isBackgroundPending(response: Response): boolean {

--- a/src/auth/codex/codexConstants.ts
+++ b/src/auth/codex/codexConstants.ts
@@ -67,17 +67,6 @@ export const CODEX_ORIGINATOR = 'texra';
  */
 export const CODEX_BACKEND_BASE_URL = 'https://chatgpt.com/backend-api/codex';
 
-/**
- * Context window the ChatGPT-subscription (Codex) backend enforces, regardless
- * of the model's own (larger) API context window in llm-zoo — e.g. gpt-5.5
- * declares 1,050,000 over the OpenAI API but the subscription backend caps the
- * request at 272,000 and answers `400 context_length_exceeded` past it. Matches
- * the Codex CLI's hardcoded `model_context_window`. Applied as a cap (never
- * inflates a smaller model) via the handler's effective-context-window override,
- * gated on the subscription path so the API-key fallback keeps the full window.
- */
-export const CODEX_SUBSCRIPTION_CONTEXT_WINDOW = 272_000;
-
 /** Non-auth request headers for the Codex backend. */
 export const CODEX_ACCOUNT_ID_HEADER = 'chatgpt-account-id';
 export const CODEX_ORIGINATOR_HEADER = 'originator';
@@ -114,50 +103,3 @@ export const CODEX_PREFER_SUBSCRIPTION_KEY =
  */
 export const CODEX_SUBSCRIPTION_TOOL_USE_ONLY_KEY =
   'texra.chatgptCodex.subscriptionToolUseOnly';
-
-/**
- * OpenAI models the Codex backend currently serves to ChatGPT subscribers. This
- * is a hardcoded mirror of openai/codex's bundled models.json picker set and
- * WILL go stale; the backend also rejects models above the account's tier. Keep
- * it small and easy to edit. Matched against the model id passed to
- * `isCodexSubscriptionEligible`, which callers derive with
- * {@link codexBackendModelId} (`shortName`, else date-pin-stripped `fullName`)
- * so date-pinned llm-zoo names still match these bare Codex backend ids.
- */
-export const CODEX_SUBSCRIPTION_MODEL_FULLNAMES: ReadonlySet<string> = new Set([
-  'gpt-5.5',
-  'gpt-5.4',
-  'gpt-5.4-mini',
-  'gpt-5.3-codex-spark',
-  'gpt-5.3-codex',
-  'gpt-5.2-codex',
-]);
-
-/** Trailing llm-zoo date pin (`-2026-04-23`) on a model `fullName`. */
-const CODEX_MODEL_DATE_PIN = /-\d{4}-\d{2}-\d{2}$/;
-
-/**
- * The bare model id the Codex backend keys on: the `shortName` when present,
- * else the `fullName` with its llm-zoo date pin stripped (`gpt-5.5-2026-04-23`
- * → `gpt-5.5`). The single source of truth for that mapping, shared by
- * eligibility ({@link isCodexSubscriptionEligible}) and handler dispatch
- * (ModelFactory) so the id a model is judged eligible under is the same id it
- * is dispatched with.
- */
-export function codexBackendModelId(config: {
-  readonly shortName?: string;
-  readonly fullName: string;
-}): string {
-  return config.shortName || config.fullName.replace(CODEX_MODEL_DATE_PIN, '');
-}
-
-/**
- * Whether a model id is eligible to route through the ChatGPT subscription.
- * True for the curated set above, date-pinned variants of those ids, or any
- * `*-codex*` name so newer Codex models are picked up without a code change.
- */
-export function isCodexSubscriptionEligible(fullName: string): boolean {
-  const unpinnedName = fullName.replace(CODEX_MODEL_DATE_PIN, '');
-  if (CODEX_SUBSCRIPTION_MODEL_FULLNAMES.has(unpinnedName)) return true;
-  return /codex/i.test(fullName);
-}

--- a/src/auth/codex/codexRouting.ts
+++ b/src/auth/codex/codexRouting.ts
@@ -1,6 +1,7 @@
 /**
- * The single predicate that decides whether a model request should be served by
- * the ChatGPT subscription (Codex backend) instead of the normal OpenAI path.
+ * The single route/profile resolver that decides whether a model request should
+ * be served by the ChatGPT subscription (Codex backend) instead of the normal
+ * OpenAI path.
  *
  * Shared by the handler dispatch (ModelFactory) and the picker availability
  * gate (computeModelOptions) so the two never drift. Deliberately synchronous
@@ -8,18 +9,17 @@
  * request time in the handler and in the async availability context, so the
  * conversation-compatibility key can stay sync.
  */
-import { ModelProvider, type ModelConfig } from 'llm-zoo';
-
+import {
+  resolveProviderCapabilities,
+  type ProviderCapabilityProfile,
+} from '@model/providerCapabilities';
 import { AgentCategory } from '@shared/schemas/agent';
 
-import {
-  codexBackendModelId,
-  isCodexSubscriptionEligible,
-} from './codexConstants';
 import {
   isCodexSubscriptionToolUseOnly,
   isPreferCodexSubscription,
 } from './codexPreference';
+import type { ModelConfig } from 'llm-zoo';
 
 /**
  * Whether this model, under the current routing context, should go through the
@@ -30,13 +30,19 @@ export function shouldUseCodexSubscription(
   config: ModelConfig,
   useOpenRouter: boolean,
 ): boolean {
-  if (useOpenRouter) return false;
-  if (config.provider !== ModelProvider.OPENAI) return false;
-  if (config.openRouterOnly) return false;
-  if (!isPreferCodexSubscription()) return false;
-  // Match the bare id the Codex backend keys on (`gpt-5.5`), not the date-pinned
-  // llm-zoo `fullName` (`gpt-5.5-2026-04-23`) — the same derivation dispatch uses.
-  return isCodexSubscriptionEligible(codexBackendModelId(config));
+  return resolveCodexSubscriptionCapabilities(config, useOpenRouter) !== null;
+}
+
+export function resolveCodexSubscriptionCapabilities(
+  config: ModelConfig,
+  useOpenRouter: boolean,
+): ProviderCapabilityProfile | null {
+  if (!isPreferCodexSubscription()) return null;
+  return resolveProviderCapabilities({
+    model: config,
+    authMode: 'chatgpt-subscription',
+    useOpenRouter,
+  });
 }
 
 export function shouldUseCodexSubscriptionForAgentCategory(
@@ -44,7 +50,25 @@ export function shouldUseCodexSubscriptionForAgentCategory(
   useOpenRouter: boolean,
   agentCategory: AgentCategory | undefined,
 ): boolean {
-  if (!shouldUseCodexSubscription(config, useOpenRouter)) return false;
-  if (!isCodexSubscriptionToolUseOnly()) return true;
-  return agentCategory === AgentCategory.ToolUse;
+  return (
+    resolveCodexSubscriptionCapabilitiesForAgentCategory(
+      config,
+      useOpenRouter,
+      agentCategory,
+    ) !== null
+  );
+}
+
+export function resolveCodexSubscriptionCapabilitiesForAgentCategory(
+  config: ModelConfig,
+  useOpenRouter: boolean,
+  agentCategory: AgentCategory | undefined,
+): ProviderCapabilityProfile | null {
+  const capabilities = resolveCodexSubscriptionCapabilities(
+    config,
+    useOpenRouter,
+  );
+  if (!capabilities) return null;
+  if (!isCodexSubscriptionToolUseOnly()) return capabilities;
+  return agentCategory === AgentCategory.ToolUse ? capabilities : null;
 }

--- a/src/auth/codex/index.ts
+++ b/src/auth/codex/index.ts
@@ -63,6 +63,8 @@ export {
   type CodexSubscriptionPreferenceUpdate,
 } from './codexPreference';
 export {
+  resolveCodexSubscriptionCapabilities,
+  resolveCodexSubscriptionCapabilitiesForAgentCategory,
   shouldUseCodexSubscription,
   shouldUseCodexSubscriptionForAgentCategory,
 } from './codexRouting';

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -5,7 +5,7 @@ import { getServerSideKeyService } from '@auth/serverKeys';
 import {
   isCodexSignedIn,
   isPreferCodexSubscription,
-  shouldUseCodexSubscriptionForAgentCategory,
+  resolveCodexSubscriptionCapabilitiesForAgentCategory,
 } from '@auth/codex';
 import type { ModelAvailabilityKind, ModelOptionData } from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas/agent';
@@ -24,6 +24,7 @@ import {
 } from './modelOptionsBasic';
 import { getVisibleModels } from './modelOptionsState';
 import { shouldRouteModelThroughOpenRouter } from './openRouterRouting';
+import type { ProviderCapabilityProfile } from './providerCapabilities';
 import type { PlatformSecrets } from '@platform/secrets';
 
 type PersonalModelAccessKind = 'provider-key' | 'openrouter-key';
@@ -54,6 +55,7 @@ interface ModelAvailabilityStatus {
   label: string;
   available: boolean;
   requiresKey: boolean;
+  providerCapabilities?: ProviderCapabilityProfile;
 }
 
 /**
@@ -177,15 +179,19 @@ async function resolveModelAvailability(
   // ChatGPT subscription (Codex) is a preference, not a hard requirement. When
   // the host is not signed in, continue through the normal API-key/relay paths
   // so the switch cannot disable models that are otherwise runnable.
-  if (
-    ctx.codexSignedIn &&
-    shouldUseCodexSubscriptionForAgentCategory(
-      config,
-      ctx.useOpenRouter,
-      ctx.agentCategory,
-    )
-  ) {
-    return availabilityStatus('subscription-access');
+  if (ctx.codexSignedIn) {
+    const subscriptionCapabilities =
+      resolveCodexSubscriptionCapabilitiesForAgentCategory(
+        config,
+        ctx.useOpenRouter,
+        ctx.agentCategory,
+      );
+    if (subscriptionCapabilities) {
+      return {
+        ...availabilityStatus('subscription-access'),
+        providerCapabilities: subscriptionCapabilities,
+      };
+    }
   }
 
   // OpenRouter routing is intentionally outside included access; a configured
@@ -331,8 +337,16 @@ async function buildModelOptionData(
   }
 
   const availability = await resolveModelAvailability(model, config, ctx);
+  const optionConfig = availability.providerCapabilities
+    ? {
+        ...config,
+        contextWindow: availability.providerCapabilities.contextWindow,
+        inputPrice: availability.providerCapabilities.inputPrice,
+        outputPrice: availability.providerCapabilities.outputPrice,
+      }
+    : config;
   return {
-    ...buildBaseModelOption(model, config),
+    ...buildBaseModelOption(model, optionConfig),
     availability: availability.kind,
     availabilityLabel: availability.label,
     requiresKey: availability.requiresKey,

--- a/src/model/providerCapabilities.ts
+++ b/src/model/providerCapabilities.ts
@@ -1,0 +1,145 @@
+import { ModelProvider, type ModelConfig } from 'llm-zoo';
+
+import type { UsageRoute } from '@shared/schemas';
+import type { AgentCategory } from '@shared/schemas/agent';
+
+export type ProviderAuthMode = 'api-key' | 'chatgpt-subscription';
+
+export interface OpenAIResponseProviderCapabilities {
+  readonly backgroundMode: 'base' | 'disabled';
+  readonly streaming: 'base' | 'forced';
+  readonly webSocket: 'base' | 'global-toggle';
+  readonly supportsTokenCounting: boolean;
+  readonly supportsManualCompaction: boolean;
+  readonly supportsResponseChaining: boolean;
+  readonly storesResponsesServerSide: boolean;
+  readonly supportsInlineInputFileUpload: boolean;
+  readonly supportsToolResultFileUpload: boolean;
+  readonly failWhenFallbackOutputBudgetIsReduced: boolean;
+}
+
+export interface ProviderCapabilityProfile {
+  readonly authMode: ProviderAuthMode;
+  readonly contextWindow: number;
+  readonly inputPrice: number;
+  readonly outputPrice: number;
+  readonly usageRoute?: UsageRoute;
+  readonly openAIResponses?: OpenAIResponseProviderCapabilities;
+}
+
+export interface ProviderCapabilityKey {
+  readonly model: ModelConfig;
+  readonly authMode: ProviderAuthMode;
+  readonly useOpenRouter: boolean;
+  readonly agentCategory?: AgentCategory;
+}
+
+type ProviderCapabilityResolver = (
+  key: ProviderCapabilityKey,
+) => ProviderCapabilityProfile | null;
+
+/** Context window the ChatGPT-subscription (Codex) backend enforces. */
+export const CODEX_SUBSCRIPTION_CONTEXT_WINDOW = 272_000;
+
+/**
+ * OpenAI models the Codex backend currently serves to ChatGPT subscribers. This
+ * is a hardcoded mirror of openai/codex's bundled models.json picker set and
+ * WILL go stale; the backend also rejects models above the account's tier.
+ */
+const CODEX_SUBSCRIPTION_MODEL_FULLNAMES: ReadonlySet<string> = new Set([
+  'gpt-5.5',
+  'gpt-5.4',
+  'gpt-5.4-mini',
+  'gpt-5.3-codex-spark',
+  'gpt-5.3-codex',
+  'gpt-5.2-codex',
+]);
+
+/** Trailing llm-zoo date pin (`-2026-04-23`) on a model `fullName`. */
+const CODEX_MODEL_DATE_PIN = /-\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * The bare model id the Codex backend keys on: the `shortName` when present,
+ * else the `fullName` with its llm-zoo date pin stripped.
+ */
+export function codexBackendModelId(config: {
+  readonly shortName?: string;
+  readonly fullName: string;
+}): string {
+  return config.shortName || config.fullName.replace(CODEX_MODEL_DATE_PIN, '');
+}
+
+/**
+ * Whether a model id is eligible to route through the ChatGPT subscription.
+ * True for the curated set above, date-pinned variants of those ids, or any
+ * `*-codex*` name so newer Codex models are picked up without a code change.
+ */
+export function isCodexSubscriptionEligible(fullName: string): boolean {
+  const unpinnedName = fullName.replace(CODEX_MODEL_DATE_PIN, '');
+  if (CODEX_SUBSCRIPTION_MODEL_FULLNAMES.has(unpinnedName)) return true;
+  return /codex/i.test(fullName);
+}
+
+const openAIApiKeyCapabilities: ProviderCapabilityResolver = ({ model }) => {
+  if (model.provider !== ModelProvider.OPENAI) return null;
+  return {
+    authMode: 'api-key',
+    contextWindow: model.contextWindow,
+    inputPrice: model.inputPrice,
+    outputPrice: model.outputPrice,
+  };
+};
+
+const openAIChatGptSubscriptionCapabilities: ProviderCapabilityResolver = ({
+  model,
+  useOpenRouter,
+}) => {
+  if (useOpenRouter) return null;
+  if (model.provider !== ModelProvider.OPENAI) return null;
+  if (model.openRouterOnly) return null;
+  if (!isCodexSubscriptionEligible(codexBackendModelId(model))) return null;
+
+  return {
+    authMode: 'chatgpt-subscription',
+    contextWindow: Math.min(
+      CODEX_SUBSCRIPTION_CONTEXT_WINDOW,
+      model.contextWindow,
+    ),
+    inputPrice: 0,
+    outputPrice: 0,
+    usageRoute: 'chatgpt-subscription',
+    openAIResponses: {
+      backgroundMode: 'disabled',
+      streaming: 'forced',
+      webSocket: 'global-toggle',
+      supportsTokenCounting: false,
+      supportsManualCompaction: false,
+      supportsResponseChaining: false,
+      storesResponsesServerSide: false,
+      supportsInlineInputFileUpload: false,
+      supportsToolResultFileUpload: false,
+      failWhenFallbackOutputBudgetIsReduced: true,
+    },
+  };
+};
+
+export const ProviderCapabilities: Partial<
+  Record<
+    ModelProvider,
+    Partial<Record<ProviderAuthMode, ProviderCapabilityResolver>>
+  >
+> = {
+  [ModelProvider.OPENAI]: {
+    'api-key': openAIApiKeyCapabilities,
+    'chatgpt-subscription': openAIChatGptSubscriptionCapabilities,
+  },
+};
+
+/** Resolve the active provider profile for a model/auth-mode pair. */
+export function resolveProviderCapabilities(
+  key: ProviderCapabilityKey,
+): ProviderCapabilityProfile | null {
+  return (
+    ProviderCapabilities[key.model.provider]?.[key.authMode]?.(key) ?? null
+  );
+}

--- a/src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts
@@ -8,11 +8,11 @@ import {
 import { ModelHandlerCodex } from '@agent/modelHandlers/openai/modelHandlerCodex';
 import {
   CODEX_BACKEND_BASE_URL,
-  CODEX_SUBSCRIPTION_CONTEXT_WINDOW,
   resetCodexCoordinator,
   setPreferCodexSubscription,
 } from '@auth/codex';
 import { setServerSideKeyService } from '@auth/serverKeys';
+import { CODEX_SUBSCRIPTION_CONTEXT_WINDOW } from '@model/providerCapabilities';
 import { AgentCategory } from '@shared/schemas/agent';
 
 import type { ResponseUsage } from 'openai/resources/responses/responses';

--- a/src/test-kernel/auth/CodexPkce.vitest.ts
+++ b/src/test-kernel/auth/CodexPkce.vitest.ts
@@ -7,8 +7,8 @@ import {
   generateCodeVerifier,
   generateOAuthState,
   generatePkcePair,
-  isCodexSubscriptionEligible,
 } from '@auth/codex';
+import { isCodexSubscriptionEligible } from '@model/providerCapabilities';
 
 const BASE64URL = /^[A-Za-z0-9_-]+$/;
 

--- a/src/test-kernel/model/ComputeModelOptions.vitest.ts
+++ b/src/test-kernel/model/ComputeModelOptions.vitest.ts
@@ -11,6 +11,7 @@ import {
   type CodexSession,
 } from '@auth/codex';
 import { apiKeySecretName, invalidateApiKeyCache } from '@model/apiProviders';
+import { CODEX_SUBSCRIPTION_CONTEXT_WINDOW } from '@model/providerCapabilities';
 import {
   computeModelOptionsData,
   getModelUnavailableReason,
@@ -244,6 +245,10 @@ describe('computeModelOptionsData relay quota state', () => {
     const [model] = await computeModelOptionsData(['gpt55'], access);
 
     expect(model.availability).toBe('subscription-access');
+    expect(model.context).toBe(
+      `${Math.round(CODEX_SUBSCRIPTION_CONTEXT_WINDOW / 1000)}K`,
+    );
+    expect(model.cost).toBe('$0.000/$0.000');
     expect(model.disabled).toBe(false);
   });
 

--- a/src/test-kernel/model/ProviderCapabilities.vitest.ts
+++ b/src/test-kernel/model/ProviderCapabilities.vitest.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_MODEL_CAPABILITIES,
+  ModelProvider,
+  type ModelConfig,
+} from 'llm-zoo';
+
+import {
+  CODEX_SUBSCRIPTION_CONTEXT_WINDOW,
+  resolveProviderCapabilities,
+} from '@model/providerCapabilities';
+
+const gpt55Config: ModelConfig = {
+  name: 'gpt55',
+  label: 'GPT-5.5',
+  fullName: 'gpt-5.5-2026-04-23',
+  shortName: 'gpt-5.5',
+  provider: ModelProvider.OPENAI,
+  maxOutputTokens: 128_000,
+  inputPrice: 5,
+  outputPrice: 30,
+  contextWindow: 1_050_000,
+  capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
+  openRouterOnly: false,
+};
+
+describe('provider capabilities', () => {
+  it('resolves ChatGPT subscription profile from model and auth mode', () => {
+    const capabilities = resolveProviderCapabilities({
+      model: gpt55Config,
+      authMode: 'chatgpt-subscription',
+      useOpenRouter: false,
+    });
+
+    expect(capabilities).toMatchObject({
+      authMode: 'chatgpt-subscription',
+      contextWindow: CODEX_SUBSCRIPTION_CONTEXT_WINDOW,
+      inputPrice: 0,
+      outputPrice: 0,
+      usageRoute: 'chatgpt-subscription',
+      openAIResponses: {
+        backgroundMode: 'disabled',
+        streaming: 'forced',
+        webSocket: 'global-toggle',
+        supportsTokenCounting: false,
+        supportsManualCompaction: false,
+        supportsResponseChaining: false,
+        storesResponsesServerSide: false,
+        supportsInlineInputFileUpload: false,
+        supportsToolResultFileUpload: false,
+        failWhenFallbackOutputBudgetIsReduced: true,
+      },
+    });
+  });
+
+  it('keeps API-key profile on llm-zoo model metadata', () => {
+    const capabilities = resolveProviderCapabilities({
+      model: gpt55Config,
+      authMode: 'api-key',
+      useOpenRouter: false,
+    });
+
+    expect(capabilities).toMatchObject({
+      authMode: 'api-key',
+      contextWindow: 1_050_000,
+      inputPrice: 5,
+      outputPrice: 30,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Centralizes the ChatGPT subscription/Codex auth-mode behavior in a `ProviderCapabilities` profile keyed by model and auth mode. The OpenAI Responses handler now reads that resolved profile for subscription context, pricing, storage, streaming/background, token-counting, compaction, response chaining, file-upload, and usage-route behavior instead of carrying a Codex-specific predicate override cluster.

The picker now projects subscription-access models through the same profile, fixing the bug where a signed-in subscription route was labeled as ChatGPT subscription but still advertised API-key context and cost.

## Issue acceptance gates

- Addresses #6974 F4.
- Removed the `usingSubscription()` override cluster from `ModelHandlerCodex`; subscription behavior is expressed through one `ProviderCapabilities` profile and consumed by `ModelHandlerOpenAIResponse`.
- Moved the 272k subscription context cap and eligible Codex model set out of `codexConstants.ts` into the provider profile source of truth.
- Picker output now shows subscription-accurate context/cost for active subscription routing: `272K` and `$0.000/$0.000` for `gpt55` in the signed-in route.
- Handler predicate count is reduced: the Codex class no longer overrides the 13 subscription-gated behavior/pricing/usage predicates; it keeps only credential, base URL, active profile, and wire-rewrite responsibilities.

## Single source of truth

`src/model/providerCapabilities.ts` is now the source of truth for OpenAI/Codex provider capabilities by `(model, auth-mode)`. `src/auth/codex/codexRouting.ts`, `ModelHandlerOpenAIResponse`, and `computeModelOptionsData` all consume the resolved profile.

## Duplication and abstraction budget

Removed duplicated Codex subscription facts from handler predicates, auth constants, and picker projection. The new abstraction owns a real invariant: provider behavior changes by auth mode, and both runtime handlers and host-facing picker data must resolve the same profile. It is not a pass-through layer.

This refactor is net-positive in lines because the added mass lives in the explicit profile record and focused contract tests; the Codex handler itself shrinks substantially. No shim, dual-write, alias, fallback, or migration path was introduced, so no #6981 ledger row is required.

## Host impact

Extension: model pickers show subscription-accurate context and zero cost when ChatGPT subscription routing is active; runtime behavior remains byte-equivalent aside from that corrected metadata.

Desktop: same shared model option and runtime handler behavior as extension; no desktop-specific files touched.

CLI: headless execution path is unchanged behaviorally; `texra run --print` plus JSON/NDJSON validation passed through the existing validation harness.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write` on touched files
- `npm test -- --run src/test-kernel/model/ProviderCapabilities.vitest.ts src/test-kernel/model/ComputeModelOptions.vitest.ts src/test-kernel/auth/CodexPkce.vitest.ts src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts src/test-kernel/agent/modelHandlers/CodexExperimentalTransports.vitest.ts src/test-kernel/agent/modelHandlers/CodexRequestRewrite.vitest.ts src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts`
- `npm run typecheck -- --pretty false`
- `npm run lint` (0 errors; 16 pre-existing warnings)
- `npm test` (575 passed, 1 skipped; 4497 passed, 4 skipped)
- `npm run compile:fast`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `git diff --check`
- `git diff --cached --check`

Closes #6974

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core OpenAI Responses request behavior and ChatGPT subscription routing; behavior is intended to be equivalent but centralized, with picker metadata as the user-visible fix.
> 
> **Overview**
> Introduces **`src/model/providerCapabilities.ts`** as the single profile for OpenAI auth modes (`api-key` vs `chatgpt-subscription`), including the 272K context cap, eligible Codex model ids, zero pricing, `usageRoute`, and OpenAI Responses limits (no background, forced streaming, no server-side store/chaining/token count/compaction/uploads).
> 
> **`ModelHandlerCodex`** drops a large `usingSubscription()` override cluster and only resolves the active profile plus Codex-specific credential, base URL, and wire rewrites. **`ModelHandlerOpenAIResponse`** reads `getActiveProviderCapabilities()` for context window, streaming/background/WebSocket, feature flags, pricing, and usage tagging.
> 
> **`codexRouting`** and **`computeModelOptions`** resolve the same profile; subscription-access picker rows now show **272K** and **$0** instead of API-key metadata. Codex subscription constants/eligibility move out of **`codexConstants`** into the profile module; tests follow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c86a862d20c178e83c84afe32be5d4da2ff4bc55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->