### PR TITLE
[codex] F5: require ToolResult status at source

### DIFF
--- a/packages/extension/src/commands/system/textEditorCommands.ts
+++ b/packages/extension/src/commands/system/textEditorCommands.ts
@@ -205,7 +205,7 @@ export async function handleTestTextEditor(): Promise<void> {
 
     const result = await textEditorTool.call(input);
 
-    if (result.isError) {
+    if (result.status === 'error') {
       await showLoggedErrorMessage(
         CHANNEL,
         'Error from text editor tool',

--- a/packages/extension/src/frontend/lm/registerLanguageModelTools.ts
+++ b/packages/extension/src/frontend/lm/registerLanguageModelTools.ts
@@ -27,8 +27,8 @@ const LM_TOOL_NAMES: Record<string, string> = {
 
 /** Flatten a TeXRA ToolResult into the plain text VS Code chat expects. */
 function toResultText(result: ToolResult): string {
-  if (result.isError || result.error) {
-    return result.error ?? result.output ?? 'Tool reported an error.';
+  if (result.status === 'error') {
+    return result.error;
   }
   return result.output ?? result.summary ?? '(no output)';
 }

--- a/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
@@ -19,7 +19,7 @@ import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
 
 // Local imports - logging
 import type { FileLocation } from '@shared/schemas';
-import type { ToolResult } from '@shared/schemas/toolResult';
+import { toolError, type ToolResult } from '@shared/schemas/toolResult';
 import { AbsoluteFS, pathToLocation } from '@utils/files';
 import { isNonEmptyString } from '@utils/core';
 
@@ -144,7 +144,7 @@ export class ToolUseDispatchNode<C> extends BatchNode<
     if (this._duplicateCallIds.has(call.callId)) {
       return {
         call,
-        result: { error: DUPLICATE_CALL_ERROR, isError: true as const },
+        result: toolError(DUPLICATE_CALL_ERROR),
         parsedInput: call.input,
         extracted: {
           sanitizedResult: { status: 'error', error: DUPLICATE_CALL_ERROR },
@@ -188,7 +188,7 @@ export class ToolUseDispatchNode<C> extends BatchNode<
     signal?: AbortSignal,
   ): Promise<ToolResult> {
     if (!tool) {
-      return { error: `Unknown tool ${call.name}`, isError: true };
+      return toolError(`Unknown tool ${call.name}`);
     }
 
     try {
@@ -213,7 +213,7 @@ export class ToolUseDispatchNode<C> extends BatchNode<
       );
     } catch (err) {
       const { message, diagnostics } = normalizeToolCallError(call.name, err);
-      return { error: message, isError: true, diagnostics };
+      return toolError(message, diagnostics);
     }
   }
 
@@ -302,7 +302,9 @@ export class ToolUseDispatchNode<C> extends BatchNode<
             toolName: call.name,
             input: parsedInput ?? call.raw,
             output:
-              result.error ?? result.output ?? 'Tool execution cancelled.',
+              result.status === 'error'
+                ? result.error
+                : (result.output ?? 'Tool execution cancelled.'),
             isError: true,
           },
           'failed',
@@ -311,8 +313,14 @@ export class ToolUseDispatchNode<C> extends BatchNode<
       return null;
     }
 
-    const trackedEdits = tracker.recordEdits(result.edits);
-    if (!result.lineChanges && trackedEdits.lineChanges) {
+    const trackedEdits = tracker.recordEdits(
+      result.status === 'executed' ? result.edits : undefined,
+    );
+    if (
+      result.status === 'executed' &&
+      !result.lineChanges &&
+      trackedEdits.lineChanges
+    ) {
       result.lineChanges = trackedEdits.lineChanges;
     }
 
@@ -375,7 +383,7 @@ export class ToolUseDispatchNode<C> extends BatchNode<
     }
 
     // Collect and add valid media file locations
-    if (result.files?.length) {
+    if (result.status === 'executed' && result.files?.length) {
       const validLocations: FileLocation[] = [];
       for (const attachment of result.files) {
         if (!isNonEmptyString(attachment.path)) {

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -52,7 +52,10 @@ import { MESSAGE_TYPES } from '@shared/schemas';
 
 // Local imports - tools
 import type { FileLocation } from '@shared/schemas';
-import type { ToolFileAttachment } from '@shared/schemas/toolResult';
+import type {
+  ToolFileAttachment,
+  ToolResult,
+} from '@shared/schemas/toolResult';
 
 import { AbsoluteFS, flexibleFS } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
@@ -89,7 +92,6 @@ import { isTokenLimitStopReason } from './utils/stopReasonUtils';
 // Type imports
 import type { ProviderStopReason } from './types/StopReasonTypes';
 import type { ProviderMessage } from './types/ProviderMessage';
-import type { ToolResultPayload } from './utils/toolAttachmentUtils';
 import type {
   IModelHandler,
   CreateResponseOptions,
@@ -1268,7 +1270,7 @@ export abstract class ModelHandler<
   abstract createToolUseFollowUpMessages(
     client: C | undefined,
     call: T,
-    result: ToolResultPayload,
+    result: ToolResult,
     attachments: ToolFileAttachment[],
     workspaceState?: AgentWorkspaceState,
     text?: string,

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -34,7 +34,10 @@ import replacementEngine from '@replacement/engine';
 
 // Local imports - tools
 import type { FileLocation } from '@shared/schemas';
-import type { ToolFileAttachment } from '@shared/schemas/toolResult';
+import type {
+  ToolFileAttachment,
+  ToolResult,
+} from '@shared/schemas/toolResult';
 
 // Local imports - utils
 import { getConfig } from '@utils/config/configUtils';
@@ -67,7 +70,6 @@ import {
   describeAttachments,
   formatAttachmentSummaryFromNotes,
   formatToolResultAsText,
-  type ToolResultPayload,
 } from '../utils/toolAttachmentUtils';
 import { tagAnthropicSdkError } from './anthropicSdkError';
 import {
@@ -1315,7 +1317,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
   async createToolUseFollowUpMessages(
     client: Anthropic | undefined,
     call: AnthropicToolCall,
-    result: ToolResultPayload,
+    result: ToolResult,
     attachments: ToolFileAttachment[],
     workspaceState?: AgentWorkspaceState,
     text?: string,
@@ -1373,7 +1375,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     // Result is already sanitized by source - use the passed attachments
     // Create mutable copy with explicit type to avoid type assertions later
-    const sanitizedResult: ToolResultPayload = { ...result };
+    const sanitizedResult: ToolResult = { ...result };
     const canUploadFiles = this.supportsToolResultFileUpload;
 
     let uploadedAttachments: UploadedAnthropicAttachment[] = [];

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -34,7 +34,10 @@ import replacementEngine from '@replacement/engine';
 
 // Local imports - tools
 import type { FileLocation } from '@shared/schemas';
-import type { ToolFileAttachment } from '@shared/schemas/toolResult';
+import type {
+  ToolFileAttachment,
+  ToolResult,
+} from '@shared/schemas/toolResult';
 // Local imports - utils
 import { getShortDisplayPath } from '@utils/files';
 import { joinNonEmpty, pluralize } from '@utils/text/stringUtils';
@@ -58,7 +61,6 @@ import {
   formatAttachmentSummary,
   formatToolResultAsText,
   loadAttachmentBuffer,
-  type ToolResultPayload,
 } from '../utils/toolAttachmentUtils';
 import { toGoogleTools } from '../toolConversion';
 import type {
@@ -902,7 +904,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
    */
   private async buildFunctionResponsePart(
     call: GoogleToolCall,
-    result: ToolResultPayload,
+    result: ToolResult,
     attachments: ToolFileAttachment[],
   ): Promise<Part> {
     let attachmentParts: FunctionResponsePart[] = [];
@@ -960,7 +962,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
   async createToolUseFollowUpMessages(
     _client: GoogleGenAI | undefined,
     call: GoogleToolCall,
-    result: ToolResultPayload,
+    result: ToolResult,
     attachments: ToolFileAttachment[],
     workspaceState?: AgentWorkspaceState,
     text?: string,
@@ -1015,7 +1017,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
    */
   async createBatchedToolUseFollowUpMessages(
     calls: GoogleToolCall[],
-    results: ToolResultPayload[],
+    results: ToolResult[],
     attachmentsPerCall: ToolFileAttachment[][],
     workspaceState?: AgentWorkspaceState,
     text?: string,

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -33,7 +33,10 @@ import replacementEngine from '@replacement/engine';
 
 // Local imports - tools
 import type { FileLocation } from '@shared/schemas';
-import type { ToolFileAttachment } from '@shared/schemas/toolResult';
+import type {
+  ToolFileAttachment,
+  ToolResult,
+} from '@shared/schemas/toolResult';
 
 // Local imports - utils
 import { filterNotNull, isNonEmptyString, isObject } from '@utils/core';
@@ -66,7 +69,6 @@ import {
   formatAttachmentSummary,
   formatToolResultAsText,
   loadAttachmentBuffer,
-  type ToolResultPayload,
 } from '../utils/toolAttachmentUtils';
 import { convertToolSchema, toGoogleTools } from '../toolConversion';
 import { GOOGLE_FINISH } from '../types/StopReasonTypes';
@@ -1103,7 +1105,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
   async createToolUseFollowUpMessages(
     _client: GoogleGenAI | undefined,
     call: GoogleToolCall,
-    result: ToolResultPayload,
+    result: ToolResult,
     attachments: ToolFileAttachment[],
     workspaceState?: AgentWorkspaceState,
     text?: string,
@@ -1145,7 +1147,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
    */
   async createBatchedToolUseFollowUpMessages(
     calls: GoogleToolCall[],
-    results: ToolResultPayload[],
+    results: ToolResult[],
     attachmentsPerCall: ToolFileAttachment[][],
     workspaceState?: AgentWorkspaceState,
     text?: string,
@@ -1243,7 +1245,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
   /** Build a `function_result` step, embedding tool-result images inline. */
   private async buildFunctionResultStep(
     call: GoogleToolCall,
-    result: ToolResultPayload,
+    result: ToolResult,
     attachments: ToolFileAttachment[],
   ): Promise<FunctionResultStep> {
     const subcontent: FunctionResultSubcontent[] = [];

--- a/src/agent/modelHandlers/modelHandlerValidation.ts
+++ b/src/agent/modelHandlers/modelHandlerValidation.ts
@@ -10,7 +10,10 @@ import type { MediaEntry } from '@agent/utils/mediaTypes';
 // Local imports - tools and utils
 import replacementEngine from '@replacement/engine';
 import type { FileLocation } from '@shared/schemas';
-import type { ToolFileAttachment } from '@shared/schemas/toolResult';
+import type {
+  ToolFileAttachment,
+  ToolResult,
+} from '@shared/schemas/toolResult';
 
 // Local imports - model handlers
 import { ModelHandler } from './ModelHandler';
@@ -24,7 +27,6 @@ import type {
   SdkToolCall,
 } from './types/IModelHandler';
 import type { ProviderStopReason } from './types/StopReasonTypes';
-import type { ToolResultPayload } from './utils/toolAttachmentUtils';
 
 interface ValidationResponse {
   text: string;
@@ -201,7 +203,7 @@ export class ModelHandlerValidation extends ModelHandler<
   async createToolUseFollowUpMessages(
     _client: unknown,
     _call: SdkToolCall,
-    result: ToolResultPayload,
+    result: ToolResult,
     _attachments: ToolFileAttachment[],
     _workspaceState?: AgentWorkspaceState,
     text?: string,

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -26,7 +26,10 @@ import type { ToolDefinition } from '@model';
 // Local imports - tools and utils
 import replacementEngine from '@replacement/engine';
 import type { FileLocation } from '@shared/schemas';
-import type { ToolFileAttachment } from '@shared/schemas/toolResult';
+import type {
+  ToolFileAttachment,
+  ToolResult,
+} from '@shared/schemas/toolResult';
 import { isNonEmptyString } from '@utils/core';
 import { getConfig } from '@utils/config/configUtils';
 import { extractMimeSubtype, joinNonEmpty } from '@utils/text/stringUtils';
@@ -46,7 +49,6 @@ import { toOpenAITools } from '../toolConversion';
 import {
   formatAttachmentSummary,
   formatToolResultAsText,
-  type ToolResultPayload,
 } from '../utils/toolAttachmentUtils';
 import { parseToolArguments } from '../utils/parseArguments';
 import { ModelHandler } from '../ModelHandler';
@@ -1268,7 +1270,7 @@ export class ModelHandlerOpenAI<
   async createToolUseFollowUpMessages(
     _client: OpenAI | undefined,
     call: TCall,
-    result: ToolResultPayload,
+    result: ToolResult,
     attachments: ToolFileAttachment[],
     workspaceState?: AgentWorkspaceState,
     text?: string,
@@ -1305,7 +1307,7 @@ export class ModelHandlerOpenAI<
    */
   async createBatchedToolUseFollowUpMessages(
     calls: TCall[],
-    results: ToolResultPayload[],
+    results: ToolResult[],
     _attachmentsPerCall: ToolFileAttachment[][],
     workspaceState?: AgentWorkspaceState,
     text?: string,

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -37,7 +37,10 @@ import replacementEngine from '@replacement/engine';
 
 // Type imports
 import type { FileLocation } from '@shared/schemas';
-import type { ToolFileAttachment } from '@shared/schemas/toolResult';
+import type {
+  ToolFileAttachment,
+  ToolResult,
+} from '@shared/schemas/toolResult';
 
 // Local imports - utils
 import { clamp, filterNotNullish } from '@utils/core';
@@ -63,7 +66,6 @@ import {
 import {
   formatAttachmentSummary,
   formatToolResultAsText,
-  type ToolResultPayload,
 } from '../utils/toolAttachmentUtils';
 import { parseToolArguments } from '../utils/parseArguments';
 import { OPENAI_CHAT_FINISH } from '../types/StopReasonTypes';
@@ -2538,7 +2540,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   async createToolUseFollowUpMessages(
     client: OpenAI | undefined,
     call: OpenAIResponseToolCall,
-    result: ToolResultPayload,
+    result: ToolResult,
     attachments: ToolFileAttachment[],
     workspaceState?: AgentWorkspaceState,
     text?: string,
@@ -2585,7 +2587,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     };
 
     // Create mutable copy for adding attachmentSummary/files
-    const finalResult: ToolResultPayload = { ...result };
+    const finalResult: ToolResult = { ...result };
     const canUploadFiles = this.supportsToolResultFileUpload;
 
     let uploadedAttachments: UploadedOpenAIResponseAttachment[] = [];

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -22,7 +22,10 @@ import replacementEngine from '@replacement/engine';
 
 // Local imports - tools and utils
 import type { FileLocation } from '@shared/schemas';
-import type { ToolFileAttachment } from '@shared/schemas/toolResult';
+import type {
+  ToolFileAttachment,
+  ToolResult,
+} from '@shared/schemas/toolResult';
 import { isNonEmptyString } from '@utils/core';
 import { extractMimeSubtype, joinNonEmpty } from '@utils/text/stringUtils';
 import {
@@ -37,7 +40,6 @@ import { toOpenAITools } from '../toolConversion';
 import {
   formatAttachmentSummary,
   formatToolResultAsText,
-  type ToolResultPayload,
 } from '../utils/toolAttachmentUtils';
 import { parseToolArguments } from '../utils/parseArguments';
 import { extractTextFromReasoningDetails } from '../utils/openRouterReasoning';
@@ -658,7 +660,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
   async createToolUseFollowUpMessages(
     _client: OpenRouter | undefined,
     call: OpenRouterToolCall,
-    result: ToolResultPayload,
+    result: ToolResult,
     attachments: ToolFileAttachment[],
     _workspaceState?: AgentWorkspaceState,
     text?: string,
@@ -685,7 +687,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
 
   async createBatchedToolUseFollowUpMessages(
     calls: OpenRouterToolCall[],
-    results: ToolResultPayload[],
+    results: ToolResult[],
     _attachmentsPerCall: ToolFileAttachment[][],
     _workspaceState?: AgentWorkspaceState,
     text?: string,

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -12,10 +12,12 @@ import type {
 import type { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import type { ProviderUsage } from '@agent/core/usage/ResponseUsage';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
-import type { ToolResultPayload } from '@agent/modelHandlers/utils/toolAttachmentUtils';
 import type { ToolDefinition } from '@model';
 import type { FileLocation } from '@shared/schemas';
-import type { ToolFileAttachment } from '@shared/schemas/toolResult';
+import type {
+  ToolFileAttachment,
+  ToolResult,
+} from '@shared/schemas/toolResult';
 import type { ModelConfig, ModelCapabilities } from 'llm-zoo';
 import type { ProviderMessage } from './ProviderMessage';
 import type { ProviderStopReason } from './StopReasonTypes';
@@ -377,7 +379,7 @@ export interface IModelHandler<
   createToolUseFollowUpMessages(
     client: C | undefined,
     call: T,
-    result: ToolResultPayload,
+    result: ToolResult,
     attachments: ToolFileAttachment[],
     workspaceState?: AgentWorkspaceState,
     text?: string,
@@ -401,7 +403,7 @@ export interface IModelHandler<
    */
   createBatchedToolUseFollowUpMessages?(
     calls: T[],
-    results: ToolResultPayload[],
+    results: ToolResult[],
     attachmentsPerCall: ToolFileAttachment[][],
     workspaceState?: AgentWorkspaceState,
     text?: string,

--- a/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
+++ b/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
@@ -1,18 +1,11 @@
-// Third-party imports
-import { z } from 'zod';
-
-import { LineChangesSchema } from '@shared/schemas/lineChanges';
-
 // Local imports - tools (single source of truth for file/attachment schemas)
 import {
   type ToolFileAttachment,
   type ToolResult,
   type FileReference,
   ToolFileAttachmentSchema,
-  FileReferenceSchema,
-  EditRecordSchema,
+  ToolResultSchema,
   DIAGNOSTIC_TYPE_VALIDATION_ERROR,
-  NormalizedToolResultSchema,
 } from '@shared/schemas/toolResult';
 
 // Local imports - utils
@@ -24,39 +17,6 @@ import { MAX_TOOL_RESULT_TEXT_LENGTH } from '../contextManagementConstants';
 
 export const DEFAULT_ATTACHMENT_MIME_TYPE = 'application/octet-stream';
 
-// ============================================================================
-// Additional Schemas (specific to tool attachment handling)
-// ============================================================================
-
-/**
- * Schema for records of files edited during tool execution.
- * Specific to logging/tracking edited files in handler context.
- */
-const EditedFileRecordSchema = z.object({
-  /** Path to the edited file */
-  path: z.string(),
-  /** Whether the edit succeeded */
-  ok: z.boolean(),
-  /** Source identifier for the edit */
-  source: z.string(),
-  /** Human readable display name for the source */
-  sourceDisplay: z.string(),
-});
-
-/**
- * Shared fields present in every tool result payload variant.
- */
-const ToolResultPayloadSharedFields = {
-  /** User instruction that was processed */
-  userInstruction: z.string().optional(),
-  /** User-provided patch content */
-  userPatch: z.string().optional(),
-  /** Additional diagnostic information (type varies by context) */
-  diagnostics: z.unknown().optional(),
-  /** Summary added by handlers when attachments are available */
-  attachmentSummary: z.string().optional(),
-};
-
 const ERROR_PAYLOAD_STRIPPED_KEYS = new Set([
   'output',
   'summary',
@@ -67,42 +27,6 @@ const ERROR_PAYLOAD_STRIPPED_KEYS = new Set([
 ]);
 
 /**
- * Schema for strongly-typed tool result payloads sent to model handlers.
- * Uses a discriminated union on `status` so callers can narrow on
- * `result.status === 'error'` vs `'executed'` and get the right fields.
- * Each variant is a looseObject to preserve unknown keys for forward
- * compatibility.
- *
- * This is what gets passed to handlers: no binary data, properly typed fields.
- */
-export const ToolResultPayloadSchema = z.discriminatedUnion('status', [
-  z.looseObject({
-    status: z.literal('executed'),
-    /** Brief summary of the tool execution result */
-    summary: z.string().optional(),
-    /** Detailed output from the tool */
-    output: z.string().optional(),
-    /** Statistics about line changes made */
-    lineChanges: LineChangesSchema.optional(),
-    /** Records of edits made during tool execution */
-    edits: z.array(EditRecordSchema).optional(),
-    /** File references (binary data stripped) */
-    files: z.array(FileReferenceSchema).optional(),
-    /** Files edited during tool execution (for logging/tracking) */
-    editedFiles: z.array(EditedFileRecordSchema).optional(),
-    ...ToolResultPayloadSharedFields,
-  }),
-  z.looseObject({
-    status: z.literal('error'),
-    /** Error message if tool execution failed */
-    error: z.string().min(1),
-    ...ToolResultPayloadSharedFields,
-  }),
-]);
-
-export type ToolResultPayload = z.infer<typeof ToolResultPayloadSchema>;
-
-/**
  * Result from extracting attachments from a tool result.
  * Simple interface - no runtime validation needed for this structure.
  */
@@ -110,7 +34,7 @@ export interface ExtractedToolAttachments {
   /** Extracted file attachments with binary data */
   attachments: ToolFileAttachment[];
   /** Sanitized result payload without binary data */
-  sanitizedResult: ToolResultPayload;
+  sanitizedResult: ToolResult;
 }
 
 /**
@@ -125,10 +49,8 @@ function isToolFileAttachment(value: unknown): value is ToolFileAttachment {
  * Extracts file attachments from a tool result and returns a typed payload.
  * Binary data (base64Data, bytes) is stripped from the result.
  *
- * Uses a Zod looseObject schema so unknown fields are preserved for forward
- * compatibility. The result is first normalized via `NormalizedToolResultSchema`,
- * whose computed discriminator always wins over any stray raw `status` key,
- * so it cannot invalidate the normalized payload.
+ * Uses the source-level `ToolResultSchema` discriminator; tools declare
+ * success vs error before this projection sees the result.
  *
  * @param result - Raw tool result (may contain binary data)
  * @returns Extracted attachments and typed payload (without binary data)
@@ -142,18 +64,8 @@ export function extractToolAttachments(
     ? attachmentsCandidate.filter(isToolFileAttachment)
     : [];
 
-  // Normalize the ambiguous raw result (no reliable `status` field; only
-  // `output`/`summary`/`error`/`isError` set ad hoc by tool implementations)
-  // into a `{ status, ... }` shape. The precedence rules that used to live
-  // here as an inline heuristic now live once, in
-  // `NormalizedToolResultSchema` (shared/schemas/toolResult.ts), so this is
-  // just a parse + narrow on `status`.
-  const normalized = NormalizedToolResultSchema.parse(result);
-  const status = normalized.status;
-
-  // Re-validate against the discriminated union so downstream consumers get
-  // a properly typed, narrowable `ToolResultPayload`.
-  const parsed = ToolResultPayloadSchema.parse(normalized);
+  const parsed = ToolResultSchema.parse(result);
+  const status = parsed.status;
 
   // Build sanitized result, stripping binary data, undefined values, and redundant fields
   const sanitizedResult: Record<string, unknown> = { status };
@@ -162,10 +74,6 @@ export function extractToolAttachments(
     if (value === undefined) continue;
     // Skip binary fields (these belong in files array attachments)
     if (key === 'base64Data' || key === 'bytes') {
-      continue;
-    }
-    // Skip legacy isError once the normalized status discriminator is present.
-    if (key === 'isError') {
       continue;
     }
     // Keep runtime values aligned with the discriminated union shape.
@@ -204,7 +112,7 @@ export function extractToolAttachments(
 
   return {
     attachments,
-    sanitizedResult: ToolResultPayloadSchema.parse(sanitizedResult),
+    sanitizedResult: ToolResultSchema.parse(sanitizedResult),
   };
 }
 
@@ -331,7 +239,7 @@ export function checkToolResultTextLimit(
  * @returns Formatted plain text string (truncated if exceeds limit)
  */
 export function formatToolResultAsText(
-  result: ToolResultPayload,
+  result: ToolResult,
   attachmentSummary?: string,
 ): string {
   const textPieces: string[] = [];

--- a/src/shared/schemas/toolResult.ts
+++ b/src/shared/schemas/toolResult.ts
@@ -1,9 +1,6 @@
 // Third-party imports
 import { z } from 'zod';
 
-// Local imports - utils
-import { isNonEmptyString } from '@utils/core';
-
 // Local imports - shared schemas
 import { LineChangesSchema, LineCountSchema } from './lineChanges';
 
@@ -14,7 +11,7 @@ import type { ZodIssue } from 'zod';
  * Base schema for file references (metadata only, no binary data).
  * Used when binary data has been stripped for serialization/logging.
  */
-export const FileReferenceSchema = z.object({
+export const FileReferenceSchema = z.looseObject({
   /** Workspace-relative or descriptive path for the file */
   path: z.string(),
   /** MIME type for the file */
@@ -46,6 +43,14 @@ export const EditRecordSchema = z.object({
   startLine: z.int().positive().optional(),
 });
 export type EditRecord = z.infer<typeof EditRecordSchema>;
+
+export const EditedFileRecordSchema = z.object({
+  path: z.string(),
+  ok: z.boolean(),
+  source: z.string(),
+  sourceDisplay: z.string(),
+});
+export type EditedFileRecord = z.infer<typeof EditedFileRecordSchema>;
 
 /**
  * Schema for flattened edit records used in state snapshots.
@@ -124,78 +129,75 @@ export function formatZodIssuesForDiagnostics(
  * Schema for tool execution results.
  * Uses looseObject to allow additional properties for forward compatibility.
  */
-export const ToolResultSchema = z.looseObject({
-  /** Detailed output from the tool */
-  output: z.string().optional(),
-  /** Brief summary of the tool execution result */
-  summary: z.string().optional(),
-  /** Error message if tool execution failed */
-  error: z.string().optional(),
+const ToolResultSharedFields = {
   /** User instruction that was processed */
   userInstruction: z.string().optional(),
   /** User-provided patch content */
   userPatch: z.string().optional(),
-  /** Statistics about line changes made */
-  lineChanges: LineChangesSchema.optional(),
-  /** Records of edits made during tool execution */
-  edits: z.array(EditRecordSchema).optional(),
-  /** Whether this result represents an error */
-  isError: z.boolean().optional(),
   /** Additional diagnostic information */
   diagnostics: z.unknown().optional(),
-  /** File attachments (may contain binary data) */
-  files: z.array(ToolFileAttachmentSchema).optional(),
-});
-export type ToolResult = z.infer<typeof ToolResultSchema>;
+  /** Summary added by handlers when attachments are available */
+  attachmentSummary: z.string().optional(),
+};
 
-// ============================================================================
-// ToolResult Normalization (status inference for ambiguous legacy results)
-// ============================================================================
-
-/**
- * Tool result status discriminant. `executed` results carry output/summary/
- * files etc.; `error` results carry a required non-empty `error` message.
- */
 export const TOOL_RESULT_STATUSES = ['executed', 'error'] as const;
 export type ToolResultStatus = (typeof TOOL_RESULT_STATUSES)[number];
 
-/**
- * Normalizes an ambiguous `ToolResultSchema` shape (no reliable `status`
- * field; only `output`/`summary`/`error`/`isError` populated ad hoc by tool
- * implementations) into a `{ status, ... }` shape that can be narrowed on
- * `status` directly.
- *
- * The computed discriminator always wins over any incidental raw `status`
- * key a result object might carry (no current tool implementation sets one,
- * but this keeps behavior unambiguous rather than trusting an unverified
- * field) — precedence rules are the single source of truth now, previously
- * duplicated as a heuristic inline in `toolAttachmentUtils.ts`: an explicit
- * `isError: true`, or non-empty `error` text with no `output`, wins as
- * `'error'`; otherwise the result is `'executed'`. When `'error'`, the
- * surfaced error text prefers `error`, then `output`, then `summary`, then a
- * generic fallback — this preserves historical behavior for tools that only
- * ever set `output`/`summary` while failing.
- */
-export const NormalizedToolResultSchema = ToolResultSchema.transform((raw) => {
-  const hasError = isNonEmptyString(raw.error);
-  const hasOutput = isNonEmptyString(raw.output);
-  const hasSummary = isNonEmptyString(raw.summary);
-  const isError = raw.isError === true;
-  const status: ToolResultStatus =
-    isError || (hasError && !hasOutput) ? 'error' : 'executed';
+export const ExecutedToolResultSchema = z
+  .object({
+    status: z.literal('executed'),
+    /** Detailed output from the tool */
+    output: z.string().optional(),
+    /** Brief summary of the tool execution result */
+    summary: z.string().optional(),
+    error: z.undefined().optional(),
+    /** Statistics about line changes made */
+    lineChanges: LineChangesSchema.optional(),
+    /** Records of edits made during tool execution */
+    edits: z.array(EditRecordSchema).optional(),
+    /** File attachments (may contain binary data) */
+    files: z.array(ToolFileAttachmentSchema).optional(),
+    /** Files edited during tool execution (for logging/tracking) */
+    editedFiles: z.array(EditedFileRecordSchema).optional(),
+    ...ToolResultSharedFields,
+  })
+  .catchall(z.unknown());
+export type ExecutedToolResult = z.infer<typeof ExecutedToolResultSchema>;
 
-  if (status !== 'error') {
-    return { ...raw, status };
-  }
+export const ErrorToolResultSchema = z
+  .object({
+    status: z.literal('error'),
+    /** Error message if tool execution failed */
+    error: z.string().min(1),
+    /** Brief summary for human-facing logs */
+    summary: z.string().optional(),
+    output: z.undefined().optional(),
+    lineChanges: z.undefined().optional(),
+    edits: z.undefined().optional(),
+    files: z.undefined().optional(),
+    editedFiles: z.undefined().optional(),
+    ...ToolResultSharedFields,
+  })
+  .catchall(z.unknown());
+export type ErrorToolResult = z.infer<typeof ErrorToolResultSchema>;
 
-  let errorText: string;
-  if (isNonEmptyString(raw.error)) errorText = raw.error;
-  else if (isNonEmptyString(raw.output)) errorText = raw.output;
-  else if (isNonEmptyString(raw.summary)) errorText = raw.summary;
-  else errorText = 'Tool failed';
+export const ToolResultSchema = z.discriminatedUnion('status', [
+  ExecutedToolResultSchema,
+  ErrorToolResultSchema,
+]);
+export type ToolResult = z.infer<typeof ToolResultSchema>;
 
-  return { ...raw, status, error: errorText };
-});
+export function toolError(message: string, diagnostics?: unknown): ToolResult {
+  const normalizedMessage = message.trim();
+  return {
+    status: 'error',
+    error:
+      normalizedMessage.length > 0
+        ? normalizedMessage
+        : 'Tool execution failed.',
+    ...(diagnostics !== undefined ? { diagnostics } : {}),
+  };
+}
 
 export class ToolError extends Error {
   constructor(message: string, options?: { cause?: unknown }) {

--- a/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
@@ -135,7 +135,7 @@ describe('accept_run_files progress events', () => {
       { path: 'output.tex', original: 'paper.tex' },
     ]);
 
-    expect(result.isError).toBeUndefined();
+    expect(result.status).toBe('executed');
     expect(explicit.events).toContainEqual({
       event: 'workspaceFilesWritten',
       payload: { absolutePaths: [`${workspacePath}/paper.tex`] },
@@ -155,7 +155,7 @@ describe('accept_run_files progress events', () => {
       files: [{ path: 'output.tex', original: 'paper.tex' }],
     });
 
-    expect(result.isError).toBe(true);
+    expect(result.status).toBe('error');
     expect(result.error).toContain('requires a tool runtime host');
     expect(writes).toBe(0);
   });
@@ -194,7 +194,7 @@ describe('accept_run_files progress events', () => {
       { path: 'draft.tex', original: 'draft.tex' },
     ]);
 
-    expect(result.isError).toBeUndefined();
+    expect(result.status).toBe('executed');
     expect(approvalOriginal).toBe('old content');
     expect(approvalProposed).toBe('new content');
     expect(result.edits?.[0]?.lineChanges).toEqual({
@@ -234,7 +234,7 @@ describe('accept_run_files progress events', () => {
       { path: 'draft.tex', original: 'draft.tex' },
     ]);
 
-    expect(result.isError).toBeUndefined();
+    expect(result.status).toBe('executed');
     expect(result.output).toContain('No changes to accept');
     expect(result.output).toContain('unchanged: draft.tex');
     expect(approvals).toBe(0);
@@ -275,7 +275,7 @@ describe('accept_run_files progress events', () => {
       { path: 'r1/Draft/appendices.tex', original: 'Draft/appendices.tex' },
     ]);
 
-    expect(result.isError).toBe(true);
+    expect(result.status).toBe('error');
     expect(result.error).toContain('symlink');
     expect(result.error).toContain('did not emit');
     expect(approvals).toBe(0);

--- a/src/test-kernel/agent/followUp/ToolUseRoundFollowUpMedia.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseRoundFollowUpMedia.vitest.ts
@@ -206,7 +206,10 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
       streamStatus: new StreamStatusRegistry(),
       toolRegistry: new MapToolRegistry({
         again: {
-          call: vi.fn(async () => ({ output: 'again result' })),
+          call: vi.fn(async () => ({
+            status: 'executed',
+            output: 'again result',
+          })),
           definition: { name: 'again' },
         } as never,
       }),

--- a/src/test-kernel/agent/followUp/ToolUseToolResolution.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseToolResolution.vitest.ts
@@ -14,6 +14,7 @@ function testTool(name: string): ITool {
   return {
     definition: { name },
     call: async (): Promise<ToolResult> => ({
+      status: 'executed',
       summary: `${name} called`,
       output: '',
     }),

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsToolUse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsToolUse.vitest.ts
@@ -9,7 +9,7 @@ import type { AgentTrace } from '@agent/trace';
 import type { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import { ModelHandlerGoogleInteractions } from '@agent/modelHandlers/google/modelHandlerGoogleInteractions';
 import type { GoogleToolCall } from '@agent/modelHandlers/types/IModelHandler';
-import type { ToolResultPayload } from '@agent/modelHandlers/utils/toolAttachmentUtils';
+import type { ToolResult } from '@shared/schemas/toolResult';
 import * as configModule from '@utils/config/configUtils';
 import type { Interactions } from '@google/genai';
 
@@ -248,7 +248,7 @@ describe('ModelHandlerGoogleInteractions tool use', () => {
       input: { q: 'x' },
     });
 
-    const result: ToolResultPayload = {
+    const result: ToolResult = {
       status: 'executed',
       output: 'found it',
     };
@@ -318,7 +318,7 @@ describe('ModelHandlerGoogleInteractions tool use', () => {
         raw: { id: 'call_2', name: 'fetch', args: { u: 'y' } },
       },
     ];
-    const results: ToolResultPayload[] = [
+    const results: ToolResult[] = [
       { status: 'executed', output: 'a' },
       { status: 'executed', output: 'b' },
     ];

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerGoogleGenAI.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerGoogleGenAI.vitest.ts
@@ -466,6 +466,7 @@ describe('ModelHandlerGoogleGenAI tool attachments', () => {
 
     const attachmentBytes = new Uint8Array([1, 2, 3, 4]);
     const toolResult = {
+      status: 'executed' as const,
       output: 'generated figures',
       files: [
         {

--- a/src/test-kernel/agent/modelHandlers/utils/toolAttachmentUtils.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/utils/toolAttachmentUtils.vitest.ts
@@ -9,6 +9,7 @@ import {
   formatToolResultAsText,
 } from '@agent/modelHandlers/utils/toolAttachmentUtils';
 import { MAX_TOOL_RESULT_TEXT_LENGTH } from '@agent/modelHandlers/contextManagementConstants';
+import { toolError, ToolResultSchema } from '@shared/schemas/toolResult';
 
 describe('checkToolResultTextLimit', () => {
   it('returns null for text within limit', () => {
@@ -116,52 +117,67 @@ describe('formatToolResultAsText', () => {
 });
 
 describe('extractToolAttachments', () => {
-  it('treats isError results with output as error payloads', () => {
+  it('projects source error payloads', () => {
     const { sanitizedResult } = extractToolAttachments({
-      isError: true,
-      output: 'kill failed',
+      status: 'error',
+      error: 'kill failed',
     });
 
     assert.equal(sanitizedResult.status, 'error');
     assert.equal(sanitizedResult.error, 'kill failed');
-    assert.equal(Object.hasOwn(sanitizedResult, 'isError'), false);
     assert.equal(Object.hasOwn(sanitizedResult, 'output'), false);
   });
 
-  it('lets the computed discriminator override raw status fields', () => {
+  it('rejects legacy results without a source status', () => {
+    assert.throws(() =>
+      extractToolAttachments({
+        output: 'done',
+      } as never),
+    );
+  });
+
+  it('rejects raw status values outside the source contract', () => {
+    assert.throws(() =>
+      extractToolAttachments({
+        status: 'completed',
+        output: 'done',
+      } as never),
+    );
+  });
+
+  it('projects executed payloads directly from their source status', () => {
     const { sanitizedResult } = extractToolAttachments({
-      status: 'completed',
+      status: 'executed',
       output: 'done',
-    } as never);
+    });
 
     assert.equal(sanitizedResult.status, 'executed');
     assert.equal(sanitizedResult.output, 'done');
   });
 
-  it('drops error from executed payloads when output takes priority', () => {
-    const { sanitizedResult } = extractToolAttachments({
-      output: 'usable output',
-      error: 'secondary warning',
-    });
-
-    assert.equal(sanitizedResult.status, 'executed');
-    assert.equal(sanitizedResult.output, 'usable output');
-    assert.equal(Object.hasOwn(sanitizedResult, 'error'), false);
+  it('rejects executed payloads with error fields', () => {
+    assert.throws(() =>
+      extractToolAttachments({
+        status: 'executed',
+        output: 'usable output',
+        error: 'secondary warning',
+      } as never),
+    );
   });
 
-  it('uses a non-empty fallback error for empty failing results', () => {
-    const { sanitizedResult } = extractToolAttachments({
-      isError: true,
-      error: '',
-    });
-
-    assert.equal(sanitizedResult.status, 'error');
-    assert.equal(sanitizedResult.error, 'Tool failed');
+  it('rejects empty source error text', () => {
+    assert.throws(() =>
+      extractToolAttachments({
+        status: 'error',
+        error: '',
+      } as never),
+    );
   });
 
-  it('uses summary as the error text for summary-only failures', () => {
+  it('keeps error summaries out of model payloads', () => {
     const { sanitizedResult } = extractToolAttachments({
-      isError: true,
+      status: 'error',
+      error: 'The operation failed before producing output.',
       summary: 'The operation failed before producing output.',
     });
 
@@ -173,22 +189,32 @@ describe('extractToolAttachments', () => {
     assert.equal(Object.hasOwn(sanitizedResult, 'summary'), false);
   });
 
-  it('keeps extracted attachments out of error payloads', () => {
-    const { attachments, sanitizedResult } = extractToolAttachments({
-      isError: true,
-      error: 'The operation failed.',
-      files: [
-        {
-          path: 'plot.png',
-          mimeType: 'image/png',
-          base64Data: 'aW1hZ2U=',
-        },
-      ],
-    });
+  it('rejects error payloads with file attachments', () => {
+    assert.throws(() =>
+      extractToolAttachments({
+        status: 'error',
+        error: 'The operation failed.',
+        files: [
+          {
+            path: 'plot.png',
+            mimeType: 'image/png',
+            base64Data: 'aW1hZ2U=',
+          },
+        ],
+      } as never),
+    );
+  });
+});
 
-    assert.equal(attachments.length, 1);
-    assert.equal(sanitizedResult.status, 'error');
-    assert.equal(sanitizedResult.error, 'The operation failed.');
-    assert.equal(Object.hasOwn(sanitizedResult, 'files'), false);
+describe('toolError', () => {
+  it('normalizes blank messages to a schema-valid fallback', () => {
+    const result = toolError('   ');
+
+    assert.equal(result.status, 'error');
+    assert.equal(result.error, 'Tool execution failed.');
+    assert.equal(
+      ToolResultSchema.parse(result).error,
+      'Tool execution failed.',
+    );
   });
 });

--- a/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
+++ b/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
@@ -86,7 +86,7 @@ describe('BashTool error feedback', () => {
     });
 
     const result = await new BashTool().call({ command: 'echo long' });
-    expect(result.isError).toBe(true);
+    expect(result.status).toBe('error');
     expect(result.error).toContain('Command failed');
     expect(result.error).toContain('stderr failure details');
     expect(result.error).toContain('stdout failure guidance');
@@ -117,7 +117,7 @@ describe('BashTool error feedback', () => {
         'nohup python verify_residual_order.py > verify_residual_order_run.log 2>&1 &\necho "PID: $!"',
     });
 
-    expect(result.isError).toBe(true);
+    expect(result.status).toBe('error');
     expect(result.error).toContain('shell-level backgrounding');
     expect(result.error).toContain('run_in_background: true');
     expect(executeSpy).not.toHaveBeenCalled();
@@ -137,7 +137,7 @@ describe('BashTool error feedback', () => {
       command: 'nohup longtask; echo done &',
     });
 
-    expect(result.isError).not.toBe(true);
+    expect(result.status).toBe('executed');
     expect(executeSpy).toHaveBeenCalledOnce();
   });
 });

--- a/src/test-kernel/tools/DelegationAgentAvailability.vitest.mts
+++ b/src/test-kernel/tools/DelegationAgentAvailability.vitest.mts
@@ -52,7 +52,7 @@ function delegationRegistry(names: readonly string[]) {
         name,
         {
           definition: { name },
-          call: async () => ({ summary: '', output: '' }),
+          call: async () => ({ status: 'executed', summary: '', output: '' }),
         },
       ]),
     ),

--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -302,11 +302,14 @@ describe('headless delegation', () => {
     );
 
     expect(result.summary).toBe("Subagent 'review' failed");
-    expect(result.isError).toBe(true);
+    expect(result.status).toBe('error');
     expect(result.error).toBe('review model failed');
-    expect(result.output).toContain('<subagent-error');
-    expect(result.output).toContain('review model failed');
-    expect(mocks.writeReport).toHaveBeenCalledWith(result.output);
+    expect(mocks.writeReport).toHaveBeenCalledWith(
+      expect.stringContaining('<subagent-error'),
+    );
+    expect(mocks.writeReport).toHaveBeenCalledWith(
+      expect.stringContaining('review model failed'),
+    );
     expect(recordSubagentCost).toHaveBeenCalledTimes(1);
     expect(recordSubagentCost).toHaveBeenCalledWith(0.42);
   });
@@ -339,7 +342,7 @@ describe('headless delegation', () => {
     );
 
     expect(result.summary).toBe("Subagent 'review' failed");
-    expect(result.isError).toBe(true);
+    expect(result.status).toBe('error');
     expect(result.error).toBe('review model failed');
     expect(recordSubagentCost).toHaveBeenCalledTimes(1);
     expect(recordSubagentCost).toHaveBeenCalledWith(0.57);
@@ -420,12 +423,12 @@ describe('headless delegation', () => {
     );
 
     expect(result.summary).toBe("User rejected delegation to 'review'");
-    expect(result.isError).toBe(true);
-    expect(result.output).toContain('No feedback provided.');
-    expect(result.output).toContain(
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('No feedback provided.');
+    expect(result.error).toContain(
       'Do not retry the same or equivalent delegation',
     );
-    expect(result.output).toContain('continue directly with available context');
+    expect(result.error).toContain('continue directly with available context');
     expect(mocks.executeAgent).not.toHaveBeenCalled();
   });
 
@@ -466,7 +469,7 @@ describe('headless delegation', () => {
       () => callDelegateReview(),
     );
 
-    expect(result.isError).toBe(true);
+    expect(result.status).toBe('error');
     expect(result.summary).toBe(
       "Approved model override 'gpt5' is not available",
     );
@@ -509,7 +512,7 @@ describe('headless delegation', () => {
       () => callDelegateReview(),
     );
 
-    expect(result.isError).toBeFalsy();
+    expect(result.status).toBe('executed');
     expect(result.summary).toBe("Launched 'review' (async)");
     expect(mocks.executeAgent).toHaveBeenCalledWith(
       expect.objectContaining({ model: 'gpt5' }),

--- a/src/test-kernel/tools/DelegationTools.vitest.ts
+++ b/src/test-kernel/tools/DelegationTools.vitest.ts
@@ -51,13 +51,12 @@ describe('DelegationTools', () => {
       contextFiles: ['references.bib'],
     });
 
-    assert.strictEqual(result?.isError, true);
+    assert.strictEqual(result?.status, 'error');
     assert.strictEqual(result?.summary, 'Rejected oversized BibTeX attachment');
     assert.strictEqual(
       result?.error,
       'references.bib is 102401 bytes (100 KiB), over the 102400 byte (100 KiB) limit. Call extract_bib_entries first if citations are needed, then re-propose without the full .bib file.',
     );
-    assert.strictEqual(result?.output, result?.error);
     assert.deepStrictEqual(result?.diagnostics, {
       type: 'oversized_bib_attachment',
       path: 'references.bib',
@@ -74,7 +73,7 @@ describe('DelegationTools', () => {
       contextFiles: ['paper.tex', 'bibliography/main.bib'],
     });
 
-    assert.strictEqual(result?.isError, true);
+    assert.strictEqual(result?.status, 'error');
     assert.deepStrictEqual(result?.diagnostics, {
       type: 'oversized_bib_attachment',
       path: 'bibliography/main.bib',

--- a/src/test-kernel/tools/DelegationWorktreeAvailability.vitest.mts
+++ b/src/test-kernel/tools/DelegationWorktreeAvailability.vitest.mts
@@ -131,7 +131,7 @@ describe('resolveAgentTools worktree annotation', () => {
       registry: new MapToolRegistry({
         delegate_agent: {
           definition: { name: 'delegate_agent' },
-          call: async () => ({ summary: '', output: '' }),
+          call: async () => ({ status: 'executed', summary: '', output: '' }),
         },
       }),
       logger: { warn: () => {} },

--- a/src/test-kernel/tools/DiagnosticsTool.vitest.ts
+++ b/src/test-kernel/tools/DiagnosticsTool.vitest.ts
@@ -60,7 +60,7 @@ describe('DiagnosticsTool', () => {
       path: 'paper.tex',
     });
 
-    expect(result.isError).toBe(true);
+    expect(result.status).toBe('error');
     // Now caught by DiagnosticsInputSchema's discriminated union (the `add`
     // variant requires these fields) rather than a hand-rolled message, so
     // the structured Zod diagnostics list each missing field individually.

--- a/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
@@ -87,7 +87,7 @@ describe('ExecutionsTool', () => {
         timeout,
       });
 
-      expect(result.isError).not.toBe(true);
+      expect(result.status).toBe('executed');
       expect(result.error).toBeUndefined();
       expect(result.output).toBe('No execution history found.');
     },
@@ -100,7 +100,7 @@ describe('ExecutionsTool', () => {
       timeout: Number.NaN,
     });
 
-    expect(result.isError).toBe(true);
+    expect(result.status).toBe('error');
     expect(result.error).toContain('Invalid input');
   });
 
@@ -109,7 +109,7 @@ describe('ExecutionsTool', () => {
       path: '/executions/abc123def456/files/../../../../../../etc/passwd',
     });
 
-    expect(result.isError).toBe(true);
+    expect(result.status).toBe('error');
     expect(result.error).toContain("must not contain '..'");
   });
 
@@ -258,7 +258,7 @@ describe('ExecutionsTool', () => {
         path: '/executions/abc123/workspace-files/secret.md',
       });
 
-      expect(result.isError).toBe(true);
+      expect(result.status).toBe('error');
       expect(result.error).toContain('Workspace file not found');
     } finally {
       await rm(workspace, { recursive: true, force: true });

--- a/src/test-kernel/tools/InlineCommentTool.vitest.ts
+++ b/src/test-kernel/tools/InlineCommentTool.vitest.ts
@@ -69,12 +69,12 @@ describe('InlineCommentTool.call', () => {
     setInlineCommentProvider(fakeProvider({ available: () => false }));
     const result = await tool.call({ command: 'list' });
     expect(result.summary).toBe('Inline comments unavailable');
-    expect(result.isError).toBeUndefined();
+    expect(result.status).toBe('executed');
   });
 
   it('validates required fields for add', async () => {
     const result = await tool.call({ command: 'add', path: 'p.tex', line: 3 });
-    expect(result.isError).toBe(true);
+    expect(result.status).toBe('error');
     expect(result.error).toContain('requires path, line, and body');
   });
 

--- a/src/test-kernel/tools/OpenPdfTool.vitest.ts
+++ b/src/test-kernel/tools/OpenPdfTool.vitest.ts
@@ -39,7 +39,7 @@ describe('OpenPdfTool', () => {
     const result = await tool.call({ path: 'paper.tex' });
 
     expect(result).toMatchObject({
-      isError: true,
+      status: 'error',
       error: expect.stringContaining('open_pdf is not available'),
     });
   });
@@ -138,7 +138,7 @@ describe('OpenPdfTool', () => {
     );
 
     expect(result).toMatchObject({
-      isError: true,
+      status: 'error',
       error: expect.stringContaining(
         'Path must stay within the working directory',
       ),
@@ -154,7 +154,7 @@ describe('OpenPdfTool', () => {
     const result = await tool.call({ path: 'paper.tex' });
 
     expect(result).toMatchObject({
-      isError: true,
+      status: 'error',
       error: expect.stringContaining('open_pdf only opens PDF files'),
     });
     expect(openPdf).not.toHaveBeenCalled();

--- a/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
+++ b/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
@@ -101,7 +101,7 @@ describe('PlanTool — update (plan approval)', () => {
     );
 
     const result = await resultPromise;
-    expect(result.isError).toBeFalsy();
+    expect(result.status).toBe('executed');
     expect(result.output).toContain('todo tool');
     expect(workPlanState.plan).toEqual(plan);
     expect(workPlanState.planSummary).toBe(planSummaryLine(plan.objective));
@@ -119,7 +119,7 @@ describe('PlanTool — update (plan approval)', () => {
     );
 
     const result = await resultPromise;
-    expect(result.isError).toBe(true);
+    expect(result.status).toBe('error');
     expect(workPlanState.plan).toBeNull();
     expect(workPlanState.planSummary).toBeNull();
   });
@@ -144,7 +144,7 @@ describe('PlanTool — update (plan approval)', () => {
       );
 
       const result = await resultPromise;
-      expect(result.isError).not.toBe(true);
+      expect(result.status).toBe('executed');
 
       const goal = GoalStore.getForStream(streamId);
       expect(goal).not.toBeNull();
@@ -177,7 +177,7 @@ describe('PlanTool — update (plan approval)', () => {
       );
 
       const result = await resultPromise;
-      expect(result.isError).not.toBe(true);
+      expect(result.status).toBe('executed');
       expect(result.summary).toMatch(/retargeted/i);
 
       const goal = GoalStore.getForStream(streamId);
@@ -216,7 +216,7 @@ describe('PlanTool — update (plan approval)', () => {
       );
 
       const result = await resultPromise;
-      expect(result.isError).not.toBe(true);
+      expect(result.status).toBe('executed');
       expect(result.summary).toMatch(/autonomous run unavailable/i);
       expect(result.output).toContain('feature flag is currently disabled');
       expect(GoalStore.getForStream(streamId)).toBeNull();
@@ -237,7 +237,7 @@ describe('PlanTool — update (plan approval)', () => {
     );
 
     const result = await resultPromise;
-    expect(result.isError).toBe(true);
+    expect(result.status).toBe('error');
     expect(workPlanState.plan).toBeNull();
     expect(workPlanState.planSummary).toBeNull();
   });
@@ -272,7 +272,7 @@ describe('PlanTool — pause/complete (goal lifecycle)', () => {
       command: 'pause',
       reason: 'Need API credentials from the user.',
     });
-    expect(result.isError).toBeFalsy();
+    expect(result.status).toBe('executed');
     expect(GoalStore.getForStream(STREAM_ID)?.status).toBe('paused');
   });
 
@@ -282,7 +282,7 @@ describe('PlanTool — pause/complete (goal lifecycle)', () => {
       command: 'complete',
       reason: 'Ran pnpm test; all 142 tests pass.',
     });
-    expect(result.isError).toBeFalsy();
+    expect(result.status).toBe('executed');
     expect(result.output).toContain('all 142 tests pass');
     // Completing is `forget()` — a finished goal is not archived, so no
     // record remains and the wait-node loop has nothing to continue.
@@ -294,7 +294,7 @@ describe('PlanTool — pause/complete (goal lifecycle)', () => {
       command: 'complete',
       reason: 'I think I am done.',
     });
-    expect(result.isError).toBeFalsy();
+    expect(result.status).toBe('executed');
     expect(result.summary).toBe(
       'Plan-only work complete — summarize the result.',
     );
@@ -308,7 +308,7 @@ describe('PlanTool — pause/complete (goal lifecycle)', () => {
       command: 'pause',
       reason: 'Need user input.',
     });
-    expect(result.isError).toBeFalsy();
+    expect(result.status).toBe('executed');
     expect(result.summary).toBe('No autonomous goal to pause.');
     expect(result.output).toContain('ask the user directly');
   });
@@ -316,7 +316,7 @@ describe('PlanTool — pause/complete (goal lifecycle)', () => {
   it('rejects whitespace-only reason on pause', async () => {
     await GoalStore.start(STREAM_ID, 'objective');
     const result = await callTool({ command: 'pause', reason: '   ' });
-    expect(result.isError).toBe(true);
+    expect(result.status).toBe('error');
     expect(result.error).toMatch(/empty/i);
   });
 });

--- a/src/test-kernel/tools/ReportReviewIssueTool.vitest.ts
+++ b/src/test-kernel/tools/ReportReviewIssueTool.vitest.ts
@@ -79,7 +79,7 @@ describe('ReportReviewIssueTool', () => {
 
     const result = await tool.call({ ...REPORT, severity: 'fatal' });
 
-    expect(result).toMatchObject({ isError: true });
+    expect(result).toMatchObject({ status: 'error' });
     expect(sink).not.toHaveBeenCalled();
   });
 });

--- a/src/test-kernel/tools/TexcountTool.vitest.ts
+++ b/src/test-kernel/tools/TexcountTool.vitest.ts
@@ -69,7 +69,7 @@ describe('TexcountTool', () => {
     const tool = new TexcountTool();
     const result = await tool.call({ files: ['missing.tex'], mode: 'sum' });
 
-    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.status, 'error');
     assert.ok(result.error?.includes('missing.tex'));
   });
 

--- a/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
+++ b/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
@@ -142,7 +142,7 @@ describe('Tool edit approval gating', () => {
     });
 
     assert.strictEqual(writeCalled, false);
-    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.status, 'error');
     assert.strictEqual(
       result.error,
       'User rejected write_file for summary.txt.',
@@ -230,7 +230,7 @@ describe('Tool edit approval gating', () => {
       old_str: 'alpha',
       new_str: 'parent',
     });
-    assert.notStrictEqual(parentEdit.isError, true);
+    assert.strictEqual(parentEdit.status, 'executed');
     assert.strictEqual(await WorkspaceFS.read('shared.tex'), 'parent\n');
 
     const childEdit = await callTextEditorInRun(tool, 'bbbbbb', {
@@ -239,21 +239,21 @@ describe('Tool edit approval gating', () => {
       old_str: 'parent',
       new_str: 'child',
     });
-    assert.notStrictEqual(childEdit.isError, true);
+    assert.strictEqual(childEdit.status, 'executed');
     assert.strictEqual(await WorkspaceFS.read('shared.tex'), 'child\n');
 
     const parentUndo = await callTextEditorInRun(tool, 'aaaaaa', {
       command: 'undo_edit',
       path: 'shared.tex',
     });
-    assert.notStrictEqual(parentUndo.isError, true);
+    assert.strictEqual(parentUndo.status, 'executed');
     assert.strictEqual(await WorkspaceFS.read('shared.tex'), 'alpha\n');
 
     const childUndo = await callTextEditorInRun(tool, 'bbbbbb', {
       command: 'undo_edit',
       path: 'shared.tex',
     });
-    assert.notStrictEqual(childUndo.isError, true);
+    assert.strictEqual(childUndo.status, 'executed');
     assert.strictEqual(await WorkspaceFS.read('shared.tex'), 'parent\n');
   });
 
@@ -277,7 +277,7 @@ describe('Tool edit approval gating', () => {
       new_str: 'beta',
     });
 
-    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.status, 'error');
     assert.match(result.error ?? '', /old_str must not be empty/);
     assert.strictEqual(await WorkspaceFS.read('shared.tex'), 'alpha\n');
   });

--- a/src/test-kernel/tools/WolframToolApproval.vitest.ts
+++ b/src/test-kernel/tools/WolframToolApproval.vitest.ts
@@ -80,7 +80,7 @@ describe('WolframTool approval', () => {
     });
 
     await expect(result).resolves.toMatchObject({
-      isError: true,
+      status: 'error',
       userInstruction: 'Use the requested node check instead.',
     });
     expect(execute).not.toHaveBeenCalled();
@@ -97,7 +97,7 @@ describe('WolframTool approval', () => {
     });
 
     await expect(result).resolves.toMatchObject({
-      isError: true,
+      status: 'error',
       userInstruction: expect.stringContaining('Do not retry'),
     });
     expect(execute).not.toHaveBeenCalled();

--- a/src/test-kernel/tools/latex/ExtractBibliographyTool.vitest.ts
+++ b/src/test-kernel/tools/latex/ExtractBibliographyTool.vitest.ts
@@ -96,7 +96,7 @@ describe('ExtractBibliographyTool', () => {
     const tool = new ExtractBibliographyTool();
     const result = await tool.call({ texPath: 'missing.tex' });
 
-    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.status, 'error');
     assert.ok(result.error?.includes('LaTeX file not found'));
   });
 

--- a/src/test-kernel/tools/latex/ExtractFiguresTool.vitest.ts
+++ b/src/test-kernel/tools/latex/ExtractFiguresTool.vitest.ts
@@ -64,7 +64,7 @@ describe('ExtractLatexFiguresTool', () => {
     const tool = new ExtractLatexFiguresTool();
     const result = await tool.call({ texPath: 'missing.tex' });
 
-    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.status, 'error');
     assert.ok(result.error?.includes('LaTeX file not found'));
   });
 });

--- a/src/test-kernel/tools/latex/ExtractTikzFiguresTool.vitest.ts
+++ b/src/test-kernel/tools/latex/ExtractTikzFiguresTool.vitest.ts
@@ -70,7 +70,7 @@ describe('ExtractTikzFiguresTool', () => {
     const tool = new ExtractTikzFiguresTool();
     const result = await tool.call({ texPath: 'absent.tex' });
 
-    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.status, 'error');
     assert.ok(result.error?.includes('LaTeX file not found'));
   });
 });

--- a/src/test-kernel/tools/setup/ApplyTeamTool.vitest.mts
+++ b/src/test-kernel/tools/setup/ApplyTeamTool.vitest.mts
@@ -92,7 +92,7 @@ describe('apply_team', () => {
   it('applies the starter roster as source-qualified workspace keys', async () => {
     const result = await new ApplyTeamTool().call({ teamId: 'starter' });
 
-    expect(result.isError).toBeFalsy();
+    expect(result.status).toBe('executed');
     const roster = workspaceRoster();
     expect(roster.workflow?.toSorted()).toEqual(STARTER_WORKFLOW);
     // `orchestrator` is remote-only and unresolved while signed out: it is
@@ -119,7 +119,7 @@ describe('apply_team', () => {
   it('reports the relay-served orchestrator as available after sign-in', async () => {
     const result = await new ApplyTeamTool().call({ teamId: 'starter' });
 
-    expect(result.isError).toBeFalsy();
+    expect(result.status).toBe('executed');
     expect(result.summary).toMatch(/sign-in/);
     expect(result.output).toMatch(/orchestrator/);
     expect(result.output).toMatch(/sign-in/);
@@ -128,7 +128,7 @@ describe('apply_team', () => {
   it('rejects an unknown teamId without writing any state', async () => {
     const result = await new ApplyTeamTool().call({ teamId: 'astrologer' });
 
-    expect(result.isError).toBe(true);
+    expect(result.status).toBe('error');
     const roster = workspaceRoster();
     expect(roster.workflow).toBeUndefined();
     expect(roster.toolUse).toBeUndefined();

--- a/src/test-kernel/tools/setup/ConfigTools.vitest.ts
+++ b/src/test-kernel/tools/setup/ConfigTools.vitest.ts
@@ -42,7 +42,7 @@ describe('ConfigTools — read_config', () => {
 
     const result = await tool.call({ key: 'texra.bib.zoteroPort' });
 
-    assert.ok(!('isError' in result) || !result.isError);
+    assert.equal(result.status, 'executed');
     assert.match(result.output ?? '', /23119/);
   });
 
@@ -53,7 +53,7 @@ describe('ConfigTools — read_config', () => {
 
     const result = await tool.call({ key: 'editor.fontSize' });
 
-    assert.ok(result.isError, 'should report an error');
+    assert.equal(result.status, 'error');
   });
 });
 
@@ -71,7 +71,7 @@ describe('ConfigTools — update_config allowlist', () => {
       target: 'user',
     });
 
-    assert.ok(!('isError' in result) || !result.isError);
+    assert.equal(result.status, 'executed');
     assert.equal(updates.length, 1);
     assert.equal(updates[0].key, 'texra.bib.zoteroPort');
     assert.equal(updates[0].value, 23200);
@@ -93,7 +93,7 @@ describe('ConfigTools — update_config allowlist', () => {
       target: 'user',
     });
 
-    assert.ok(result.isError, 'should reject off-allowlist key');
+    assert.equal(result.status, 'error');
     assert.equal(updates.length, 0, 'must not call platform.update');
   });
 
@@ -108,7 +108,7 @@ describe('ConfigTools — update_config allowlist', () => {
       target: 'user',
     });
 
-    assert.ok(result.isError, 'string value should be rejected');
+    assert.equal(result.status, 'error');
     assert.equal(updates.length, 0);
   });
 
@@ -124,7 +124,7 @@ describe('ConfigTools — update_config allowlist', () => {
         value: port,
         target: 'user',
       });
-      assert.ok(result.isError, `${port} should be rejected`);
+      assert.equal(result.status, 'error');
     }
 
     assert.equal(updates.length, 0);

--- a/src/test-kernel/tools/setup/CredentialReporting.vitest.ts
+++ b/src/test-kernel/tools/setup/CredentialReporting.vitest.ts
@@ -29,7 +29,7 @@ describe('setup credential reporting', () => {
 
     const result = await new ProbeEnvironmentTool().call({});
 
-    assert.ok(!result.isError, result.output);
+    assert.equal(result.status, 'executed');
     assert.match(result.output ?? '', /credentials: usable credential/);
     assert.match(result.output ?? '', /"hasAnyUsableCredential": true/);
     assert.match(result.output ?? '', /"anyApiKeySet": false/);
@@ -40,7 +40,7 @@ describe('setup credential reporting', () => {
 
     const result = await new VerifySetupTool().call({});
 
-    assert.ok(!result.isError, result.output);
+    assert.equal(result.status, 'executed');
     assert.match(
       result.output ?? '',
       /Credentials: usable model credential available\./,

--- a/src/test-kernel/tools/setup/InvokeCommandTool.vitest.ts
+++ b/src/test-kernel/tools/setup/InvokeCommandTool.vitest.ts
@@ -40,7 +40,7 @@ describe('InvokeCommandTool allowlist', () => {
       args: ['openai', fakeSecret],
     });
 
-    assert.ok(!result.isError);
+    assert.equal(result.status, 'executed');
     assert.equal(invocations[0].args.length, 2, 'args still forwarded');
     assert.ok(
       !(result.summary ?? '').includes(fakeSecret),
@@ -63,7 +63,7 @@ describe('InvokeCommandTool allowlist', () => {
       args: ['openai'],
     });
 
-    assert.ok(!('isError' in result) || !result.isError, 'should not error');
+    assert.equal(result.status, 'executed');
     assert.equal(invocations.length, 1);
     assert.equal(invocations[0].command, 'texra.setApiKey');
     assert.deepEqual(invocations[0].args, ['openai']);
@@ -86,7 +86,7 @@ describe('InvokeCommandTool allowlist', () => {
       args: ['ms-python.python'],
     });
 
-    assert.ok(result.isError, 'should report an error');
+    assert.equal(result.status, 'error');
     assert.match(
       result.error ?? '',
       /not in the setup allowlist/,
@@ -107,7 +107,7 @@ describe('InvokeCommandTool allowlist', () => {
       'texra.refreshAllOptions',
     ]) {
       const result = await tool.call({ command: cmd, args: [] });
-      assert.ok(result.isError, `${cmd} should be rejected`);
+      assert.equal(result.status, 'error');
     }
     assert.equal(invocations.length, 0);
   });
@@ -116,9 +116,9 @@ describe('InvokeCommandTool allowlist', () => {
     const { tool, invocations } = setupTool();
 
     const empty = await tool.call({ command: '', args: [] });
-    assert.ok(empty.isError);
+    assert.equal(empty.status, 'error');
     const blank = await tool.call({ command: '   ', args: [] });
-    assert.ok(blank.isError);
+    assert.equal(blank.status, 'error');
     assert.equal(invocations.length, 0);
   });
 

--- a/src/test-kernel/tools/setup/ListApiKeysTool.vitest.ts
+++ b/src/test-kernel/tools/setup/ListApiKeysTool.vitest.ts
@@ -39,7 +39,7 @@ describe('list_api_keys tool', () => {
   it('reports empty SecretStorage', async () => {
     installPlatformWithKeys([]);
     const result = await tool.call({});
-    assert.ok(!result.isError, result.output);
+    assert.equal(result.status, 'executed');
     assert.equal(result.summary, 'No secrets stored');
     assert.match(result.output ?? '', /SecretStorage is empty/);
   });
@@ -51,7 +51,7 @@ describe('list_api_keys tool', () => {
 
     const result = await tool.call({});
 
-    assert.equal(result.isError, true);
+    assert.equal(result.status, 'error');
     assert.match(result.error ?? '', /enumeration is not supported/);
     assert.doesNotMatch(result.output ?? '', /SecretStorage is empty/);
   });
@@ -59,7 +59,7 @@ describe('list_api_keys tool', () => {
   it('shows known provider keys by provider name, not raw SecretStorage key', async () => {
     installPlatformWithKeys([apiKeySecretName('anthropic')]);
     const result = await tool.call({});
-    assert.ok(!result.isError, result.output);
+    assert.equal(result.status, 'executed');
     assert.match(result.output ?? '', /Provider API keys stored/);
     assert.match(result.output ?? '', /^\s+anthropic$/m);
     assert.doesNotMatch(result.output ?? '', /apiKey\.anthropic/);
@@ -68,7 +68,7 @@ describe('list_api_keys tool', () => {
   it('lists providers without a stored key', async () => {
     installPlatformWithKeys([apiKeySecretName('anthropic')]);
     const result = await tool.call({});
-    assert.ok(!result.isError, result.output);
+    assert.equal(result.status, 'executed');
     assert.match(result.output ?? '', /Providers without a stored key/);
     assert.match(result.output ?? '', /openai/);
   });
@@ -76,14 +76,14 @@ describe('list_api_keys tool', () => {
   it('recognises the GitHub token', async () => {
     installPlatformWithKeys([GITHUB_TOKEN_STORAGE_KEY]);
     const result = await tool.call({});
-    assert.ok(!result.isError, result.output);
+    assert.equal(result.status, 'executed');
     assert.match(result.output ?? '', /GitHub token: stored/);
   });
 
   it('reports stale apiKey.* entries as diagnostic rather than removable providers', async () => {
     installPlatformWithKeys(['apiKey.oldprovider']);
     const result = await tool.call({});
-    assert.ok(!result.isError, result.output);
+    assert.equal(result.status, 'executed');
     assert.match(result.output ?? '', /diagnostic only/);
     assert.match(result.output ?? '', /not unset_api_key providers/);
     assert.match(result.output ?? '', /apiKey\.oldprovider/);
@@ -92,7 +92,7 @@ describe('list_api_keys tool', () => {
   it('redacts non-provider non-github secret key names under Other', async () => {
     installPlatformWithKeys(['texra.supabase.session']);
     const result = await tool.call({});
-    assert.ok(!result.isError, result.output);
+    assert.equal(result.status, 'executed');
     assert.match(
       result.output ?? '',
       /Other stored secrets: 1 redacted key name/,
@@ -108,7 +108,7 @@ describe('list_api_keys tool', () => {
       'texra.supabase.session',
     ]);
     const result = await tool.call({});
-    assert.ok(!result.isError, result.output);
+    assert.equal(result.status, 'executed');
     assert.match(result.output ?? '', /Provider API keys stored/);
     assert.match(result.output ?? '', /GitHub token: stored/);
     assert.match(result.output ?? '', /Unrecognised apiKey\.\*/);
@@ -122,7 +122,7 @@ describe('list_api_keys tool', () => {
   it('summary counts reflect platform.secrets.providers, not the global import', async () => {
     installPlatformWithKeys([apiKeySecretName('anthropic')]);
     const result = await tool.call({});
-    assert.ok(!result.isError, result.output);
+    assert.equal(result.status, 'executed');
     assert.equal(result.summary, '1 stored secret: 1/2 provider keys');
   });
 
@@ -132,14 +132,14 @@ describe('list_api_keys tool', () => {
       apiKeySecretName('openai'),
     ]);
     const result = await tool.call({});
-    assert.ok(!result.isError, result.output);
+    assert.equal(result.status, 'executed');
     assert.equal(result.summary, '2 stored secrets: 2/2 provider keys');
   });
 
   it('shows missing providers even when no provider keys are stored', async () => {
     installPlatformWithKeys([GITHUB_TOKEN_STORAGE_KEY]);
     const result = await tool.call({});
-    assert.ok(!result.isError, result.output);
+    assert.equal(result.status, 'executed');
     assert.match(result.output ?? '', /No provider API keys stored/);
     assert.match(result.output ?? '', /Providers without a stored key/);
     assert.match(result.output ?? '', /anthropic/);
@@ -149,7 +149,7 @@ describe('list_api_keys tool', () => {
   it('summary reads "no provider keys" when only non-provider secrets are stored', async () => {
     installPlatformWithKeys(['texra.supabase.session']);
     const result = await tool.call({});
-    assert.ok(!result.isError, result.output);
+    assert.equal(result.status, 'executed');
     assert.match(result.summary ?? '', /no provider keys/);
   });
 });

--- a/src/test-kernel/tools/setup/SendToTerminalTool.vitest.ts
+++ b/src/test-kernel/tools/setup/SendToTerminalTool.vitest.ts
@@ -94,7 +94,7 @@ describe('SendToTerminalTool', () => {
       command: 'sudo apt-get install -y perl',
     });
 
-    assert.ok(!result.isError);
+    assert.equal(result.status, 'executed');
     assert.equal(runs.length, 1);
     assert.equal(runs[0].command, 'sudo apt-get install -y perl');
     assert.equal(runs[0].name, 'TeXRA: setup');
@@ -124,7 +124,7 @@ describe('SendToTerminalTool', () => {
       command: 'sudo apt-get install -y fakepkg',
     });
 
-    assert.ok(!result.isError);
+    assert.equal(result.status, 'executed');
     assert.match(result.summary ?? '', /exited 100/);
     assert.match(result.output ?? '', /Unable to locate package/);
   });
@@ -141,7 +141,7 @@ describe('SendToTerminalTool', () => {
       timeout: 1000,
     });
 
-    assert.ok(!result.isError);
+    assert.equal(result.status, 'executed');
     assert.match(result.summary ?? '', /timed out/);
   });
 
@@ -154,7 +154,11 @@ describe('SendToTerminalTool', () => {
       'first\rsecond',
     ]) {
       const result = await tool.call({ command });
-      assert.ok(result.isError, `must reject ${JSON.stringify(command)}`);
+      assert.equal(
+        result.status,
+        'error',
+        `must reject ${JSON.stringify(command)}`,
+      );
     }
     assert.equal(runs.length, 0);
   });
@@ -174,7 +178,7 @@ describe('SendToTerminalTool', () => {
       command: 'sudo apt-get install -y perl',
     });
 
-    assert.ok(!result.isError);
+    assert.equal(result.status, 'executed');
     assert.ok(
       (result.output ?? '').includes('END_MARKER'),
       'tail (success line) must survive truncation',

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -23,7 +23,11 @@ import { generateDiffFileName } from '@latex/latexdiff/diffFileNameManager';
 import { stripCriticizeAnnotations } from '@replacement/advanced';
 import { ExecutionIdSchema } from '@shared/schemas';
 import type { ExecutionId, FileLocation } from '@shared/schemas';
-import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
+import {
+  ToolError,
+  type EditRecord,
+  type ToolResult,
+} from '@shared/schemas/toolResult';
 
 // Local imports - tools
 import { requireRuntimeHost } from '@tools/contextHelpers';
@@ -212,7 +216,7 @@ Optional:
 
     // Phase 2: Request approval and write each file
     const results: string[] = [];
-    const edits: ToolResult['edits'] = [];
+    const edits: EditRecord[] = [];
     const acceptedEntries: {
       outputPath: string;
       originalPath: string;
@@ -288,6 +292,7 @@ Optional:
     if (changed === 0) {
       const summary = `No changes to accept from run ${executionId}`;
       return {
+        status: 'executed',
         summary,
         output: `${summary}:\n${results.map((r) => `  - ${r}`).join('\n')}`,
         edits,
@@ -320,6 +325,7 @@ Optional:
         : '';
     const summary = `Accepted ${accepted}/${changed} changed ${pluralize(changed, 'file')} from run ${executionId}${strippedSuffix}${unchangedSuffix}`;
     return {
+      status: 'executed',
       summary,
       output: `${summary}:\n${results.map((r) => `  - ${r}`).join('\n')}`,
       edits,

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -299,6 +299,7 @@ Git worktree support: resolved from the active workspace at runtime.`,
       case 'sent':
         deliveryState.markPending();
         return {
+          status: 'executed',
           summary: `Follow-up sent to '${handle.agentName}'`,
           output: [
             `Follow-up instruction sent to '${handle.agentName}'. The subagent will process it and deliver a new result automatically.`,
@@ -308,6 +309,7 @@ Git worktree support: resolved from the active workspace at runtime.`,
       case 'queued':
         deliveryState.markPending();
         return {
+          status: 'executed',
           summary: `Follow-up queued for '${handle.agentName}'`,
           output: [
             `Follow-up instruction queued for '${handle.agentName}' (${result.reason}). The subagent will process it and deliver a new result automatically.`,

--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -140,12 +140,18 @@ export class DiagnosticsTool extends defineTool({
       };
 
       if (command === 'count') {
-        return { summary, output: header, diagnostics: baseDiagnostics };
+        return {
+          status: 'executed',
+          summary,
+          output: header,
+          diagnostics: baseDiagnostics,
+        };
       }
 
       const messageDetails =
         messages.length > 0 ? `\n\n${formatMessageList(messages)}` : '';
       return {
+        status: 'executed',
         summary,
         output: `${header}${messageDetails}`,
         diagnostics: { ...baseDiagnostics, messages },
@@ -176,6 +182,7 @@ export class DiagnosticsTool extends defineTool({
       });
       if (!result.accepted) {
         return {
+          status: 'executed',
           summary: 'Criticism not accepted',
           output:
             'Inline criticism diagnostics are disabled. Enable "texra.inlineCriticism.enabled" in settings to surface critiques as diagnostics.',
@@ -183,7 +190,7 @@ export class DiagnosticsTool extends defineTool({
       }
       const where = result.resolvedPath || absolutePath;
       const summary = `Added criticism for ${where}:${line} (S${severity}/C${confidence})`;
-      return { summary, output: summary };
+      return { status: 'executed', summary, output: summary };
     } catch (error) {
       const detail = toErrorMessage(error);
       logger.error(CHANNEL, `Failed to add criticism: ${detail}`);

--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -136,6 +136,7 @@ export class EditFileTool extends defineTool({
       : replacementSummary;
 
     return {
+      status: 'executed',
       summary,
       output,
       userPatch: approval.userPatch,

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -399,7 +399,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
     const entries = await listExecutions();
 
     if (entries.length === 0) {
-      return { output: 'No execution history found.' };
+      return { status: 'executed', output: 'No execution history found.' };
     }
 
     const { page, start, end, total } = paginateToolListing(
@@ -421,6 +421,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
 
     const header = `Executions (showing ${start}\u2013${end} of ${total}${bgSuffix}, most recent first):`;
     return {
+      status: 'executed',
       output: `${header}\n\n${lines.join('\n')}${formatPaginationHint(end, total)}`,
     };
   }
@@ -473,7 +474,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
         },
       );
 
-      return { output: lines.join('\n') };
+      return { status: 'executed', output: lines.join('\n') };
     }
 
     // Completed execution: full KV fetch
@@ -492,6 +493,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
         throw new ToolError(`Execution not found: ${executionId}`);
       }
       return {
+        status: 'executed',
         output: `Execution: ${executionId}\nStatus: completed\n(No metadata available - use /executions/${executionId}/conversation to view messages)`,
       };
     }
@@ -532,7 +534,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
       },
     );
 
-    return { output: lines.join('\n') };
+    return { status: 'executed', output: lines.join('\n') };
   }
 
   /**
@@ -601,24 +603,24 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
 
     if (ctx?.executionId === executionId) {
       return {
-        output: `Cannot kill your own execution (${executionId}).`,
-        isError: true,
+        status: 'error',
+        error: `Cannot kill your own execution (${executionId}).`,
       };
     }
 
     const target = currentSession().executions.getHandle(executionId);
     if (!target) {
       return {
-        output: `Execution ${executionId} not found or already completed.`,
-        isError: true,
+        status: 'error',
+        error: `Execution ${executionId} not found or already completed.`,
       };
     }
 
     // Scope: can only kill your own children. Deny if no context.
     if (!callerStreamId || target.parentStreamId !== callerStreamId) {
       return {
-        output: `Cannot kill execution ${executionId}: not a child of this session.`,
-        isError: true,
+        status: 'error',
+        error: `Cannot kill execution ${executionId}: not a child of this session.`,
       };
     }
 
@@ -631,9 +633,9 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
       )
     ) {
       return {
-        output:
+        status: 'error',
+        error:
           'Killing subagents is disabled. Enable it in Settings > Multi-Agent.',
-        isError: true,
       };
     }
 
@@ -641,11 +643,14 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
       detachActiveChildren: detachSubagentsOnStop(),
     });
     if (success) {
-      return { output: `Execution ${executionId} terminated.` };
+      return {
+        status: 'executed',
+        output: `Execution ${executionId} terminated.`,
+      };
     }
     return {
-      output: `Execution ${executionId} could not be terminated.`,
-      isError: true,
+      status: 'error',
+      error: `Execution ${executionId} could not be terminated.`,
     };
   }
 
@@ -669,6 +674,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
       throw new ToolError(toErrorMessage(err));
     }
     return {
+      status: 'executed',
       summary: `Subscribed to ${executionId}`,
       output: `Subscribed to ${executionId}. Status, round, and termination events will arrive as follow-ups wrapped in <execution-activity>. Auto-disposes when the execution finishes or this stream is released. Call again with action='unsubscribe' to stop sooner.`,
     };
@@ -686,6 +692,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
       executionId,
     );
     return {
+      status: 'executed',
       output: removed
         ? `Unsubscribed from ${executionId}.`
         : `No active subscription to ${executionId} on this stream.`,
@@ -712,11 +719,15 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
       if (stdout) sections.push('', '<stdout>', stdout, '</stdout>');
       if (stderr) sections.push('', '<stderr>', stderr, '</stderr>');
       if (!stdout && !stderr) sections.push('', '(no output yet)');
-      return { output: applyViewRange(sections.join('\n'), viewRange) };
+      return {
+        status: 'executed',
+        output: applyViewRange(sections.join('\n'), viewRange),
+      };
     }
 
     // Completed process: temp files already cleaned up
     return {
+      status: 'executed',
       output: `Output for ${executionId} is no longer available (ephemeral output is cleaned up on completion). Use /executions/${executionId}/report to view the result summary.`,
     };
   }
@@ -725,35 +736,41 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
     const todos = await getExecutionStore(executionId).readTodos();
 
     if (todos.length === 0) {
-      return { output: `No task list found for execution ${executionId}.` };
+      return {
+        status: 'executed',
+        output: `No task list found for execution ${executionId}.`,
+      };
     }
 
     const lines = formatTodoSection(todos);
     const header = formatTodoHeader(executionId, todos);
 
-    return { output: `${header}\n\n${lines.join('\n')}` };
+    return { status: 'executed', output: `${header}\n\n${lines.join('\n')}` };
   }
 
   private async showReport(executionId: ExecutionId): Promise<ToolResult> {
     const report = await getExecutionStore(executionId).readReport();
     if (!report) {
       return {
+        status: 'executed',
         output: `No report found for execution ${executionId}. Reports are persisted when subagents or background processes complete.`,
       };
     }
-    return { output: report };
+    return { status: 'executed', output: report };
   }
 
   private async showChildren(executionId: ExecutionId): Promise<ToolResult> {
     const children = await getExecutionStore(executionId).readChildren();
     if (children.length === 0) {
       return {
+        status: 'executed',
         output: `No child executions found for ${executionId}.`,
       };
     }
 
     const lines = await this.formatChildren(children);
     return {
+      status: 'executed',
       output: `Children of ${executionId} (${children.length}):\n\n${lines.join('\n')}`,
     };
   }
@@ -770,7 +787,10 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
       config.agent,
       config.agentCategory,
     );
-    return { output: serializeFilteredConfig(config, category) };
+    return {
+      status: 'executed',
+      output: serializeFilteredConfig(config, category),
+    };
   }
 
   private async showConversation(
@@ -789,24 +809,33 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
       if (!exists) {
         throw new ToolError(`Execution not found: ${executionId}`);
       }
-      return { output: '(No conversation history available)' };
+      return {
+        status: 'executed',
+        output: '(No conversation history available)',
+      };
     }
 
     const output = applyViewRange(formatConversation(conversation), viewRange);
 
-    return { output };
+    return { status: 'executed', output };
   }
 
   private async listFiles(executionId: ExecutionId): Promise<ToolResult> {
     const runDir = await resolveStoragePath(executionId);
     if (!runDir) {
-      return { output: 'No files generated for this execution.' };
+      return {
+        status: 'executed',
+        output: 'No files generated for this execution.',
+      };
     }
 
     const entries = await listRunDirectoryFiles(runDir);
 
     if (entries.length === 0) {
-      return { output: 'No files generated for this execution.' };
+      return {
+        status: 'executed',
+        output: 'No files generated for this execution.',
+      };
     }
 
     const lines = entries.map((entry) => {
@@ -815,6 +844,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
     });
 
     return {
+      status: 'executed',
       output: `Files in /executions/${executionId}/files:\n\n${lines.join('\n')}`,
     };
   }
@@ -861,6 +891,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
 
     if (entries.length === 0) {
       return {
+        status: 'executed',
         output: `No workspace files recorded for execution ${executionId}.`,
       };
     }
@@ -871,6 +902,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
     });
 
     return {
+      status: 'executed',
       output:
         `Workspace files for /executions/${executionId}/workspace-files:\n\n` +
         lines.join('\n'),

--- a/src/tools/OpenPdfTool.ts
+++ b/src/tools/OpenPdfTool.ts
@@ -62,7 +62,7 @@ export class OpenPdfTool extends defineTool({
   protected async execute(input: OpenPdfInput): Promise<ToolResult> {
     if (!openPdfOpener) {
       return {
-        isError: true,
+        status: 'error',
         error:
           'open_pdf is not available in this host. Open the PDF manually, or use a host that registers a PDF opener.',
       };
@@ -84,6 +84,7 @@ export class OpenPdfTool extends defineTool({
     });
 
     return {
+      status: 'executed',
       summary: `Opened PDF: ${displayPath}`,
       output: `Opened PDF: ${displayPath}`,
     };

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -228,7 +228,7 @@ export class ReadFileTool extends defineTool({
       ? `${copy.rangeOutput} ${copy.coreOutput}`
       : copy.coreOutput;
 
-    return { summary, output, files: [attachment] };
+    return { status: 'executed', summary, output, files: [attachment] };
   }
 }
 

--- a/src/tools/ReportReviewIssueTool.ts
+++ b/src/tools/ReportReviewIssueTool.ts
@@ -89,12 +89,13 @@ export class ReportReviewIssueTool extends defineTool({
       });
       if (!result.accepted) {
         return {
+          status: 'executed',
           summary: 'Review issue not accepted',
           output: result.reason ?? 'The review issue was not accepted.',
         };
       }
       const summary = `Reported review issue ${input.file}:${input.startLine} [${input.severity}] ${input.title}`;
-      return { summary, output: summary };
+      return { status: 'executed', summary, output: summary };
     } catch (error) {
       const detail = toErrorMessage(error);
       logger.error(CHANNEL, `Failed to report review issue: ${detail}`);

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -221,6 +221,7 @@ export class TextEditorTool extends defineTool({
           .join('\n');
 
         return {
+          status: 'executed',
           summary: `Listed directory: ${displayPath}`,
           output: formattedContents,
         };
@@ -336,6 +337,7 @@ export class TextEditorTool extends defineTool({
         : `File created successfully at: ${displayPath}`;
 
       return {
+        status: 'executed',
         summary: `Created file ${displayPath}`,
         output,
         userPatch: approval.userPatch,
@@ -492,6 +494,7 @@ export class TextEditorTool extends defineTool({
       );
 
       return {
+        status: 'executed',
         summary: `Updated ${displayPath}`,
         output,
         userPatch: approval.userPatch,
@@ -568,6 +571,7 @@ export class TextEditorTool extends defineTool({
       );
 
       return {
+        status: 'executed',
         summary: `Inserted text into ${displayPath}`,
         output,
         userPatch: approval.userPatch,
@@ -634,6 +638,7 @@ export class TextEditorTool extends defineTool({
         : baseOutput;
 
       return {
+        status: 'executed',
         summary: `Undid edit on ${displayPath}`,
         output,
         userPatch: approval.userPatch,

--- a/src/tools/WriteTool.ts
+++ b/src/tools/WriteTool.ts
@@ -98,6 +98,7 @@ export class WriteFileTool extends defineTool({
         : undefined;
 
     return {
+      status: 'executed',
       summary,
       output,
       userPatch: approval.userPatch,

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -195,6 +195,7 @@ export function resumeAgentCliSession(
 
   const preview = truncateWithEllipsis(prompt, 60);
   return {
+    status: 'executed',
     summary: `Follow-up queued for ${labels.summaryLabel}: ${preview}`,
     output: [
       `Follow-up instruction queued for ${labels.queuedLabel} '${id}'. The agent will process it and deliver a new result automatically.`,
@@ -255,6 +256,7 @@ export async function launchAgentCliSession(
   await params.startLoop({ childStream, executionId });
 
   return {
+    status: 'executed',
     summary: params.summary,
     output: [
       params.launchedLine,

--- a/src/tools/applyPath.ts
+++ b/src/tools/applyPath.ts
@@ -30,6 +30,7 @@ export class ApplyPathTool extends defineTool({
 
     if (result.success) {
       return {
+        status: 'executed',
         summary: 'Applied patch',
         output: result.stdout ?? '',
       };

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -156,10 +156,9 @@ export function buildBashApprovalRejectedResult(
   const message = `User rejected bash command: ${preview}`;
   const feedback = userMessage?.trim();
   return {
-    output: message,
+    status: 'error',
     summary: message,
     error: message,
-    isError: true,
     userInstruction: feedback || DEFAULT_BASH_REJECTION_INSTRUCTION,
   };
 }

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -346,10 +346,9 @@ export function buildApprovalRejectedResult(
   const baseMessage = `User rejected ${sourceTool} for ${path}.`;
   const feedback = userMessage?.trim();
   const result: ToolResult = {
-    output: baseMessage,
+    status: 'error',
     summary: baseMessage,
     error: baseMessage,
-    isError: true,
   };
   if (feedback) {
     result.userInstruction = feedback;

--- a/src/tools/arxiv/ArxivDownloadTool.ts
+++ b/src/tools/arxiv/ArxivDownloadTool.ts
@@ -102,6 +102,7 @@ export class ArxivDownloadTool extends defineTool({
     ].join('\n');
 
     return {
+      status: 'executed',
       summary,
       output,
     };

--- a/src/tools/arxiv/ArxivMetadataTool.ts
+++ b/src/tools/arxiv/ArxivMetadataTool.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 // Local imports - latex
 import { toErrorMessage } from '@common/errors';
 import { arxivProcessor } from '@latex/arxivProcessor';
-import { ToolError } from '@shared/schemas/toolResult';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import {
   type ArxivPaperMetadata,
   createArxivClient,
@@ -37,7 +37,7 @@ export class ArxivMetadataTool extends defineTool({
   description: 'Fetch bibliographic metadata for an arXiv paper.',
   schema: ArxivMetadataInputSchema,
 }) {
-  protected async execute(input: ArxivMetadataInput) {
+  protected async execute(input: ArxivMetadataInput): Promise<ToolResult> {
     const rawId = input.id.trim();
     const validationError = arxivProcessor.validateId(rawId);
     if (validationError) {
@@ -79,6 +79,7 @@ export class ArxivMetadataTool extends defineTool({
     };
 
     return {
+      status: 'executed',
       summary: `Retrieved: ${metadata.id}`,
       output: JSON.stringify(metadata, null, 2),
     };

--- a/src/tools/arxiv/ArxivSearchTool.ts
+++ b/src/tools/arxiv/ArxivSearchTool.ts
@@ -11,6 +11,7 @@ import { z } from 'zod';
 
 // Local imports
 import { warn } from '@logger/logUtils';
+import type { ToolResult } from '@shared/schemas/toolResult';
 import { requireNonEmptyString, wrapApiCall } from '@tools/utils';
 import { ARXIV_CONSTANTS } from '@tools/citation/constants';
 import { waitForRateLimit } from '@tools/citation/rateLimiter';
@@ -67,7 +68,7 @@ export class ArxivSearchTool extends defineTool({
     'Search arXiv for papers and return basic metadata for each hit. Use field="author" for author name searches.',
   schema: ArxivSearchInputSchema,
 }) {
-  protected async execute(input: ArxivSearchInput) {
+  protected async execute(input: ArxivSearchInput): Promise<ToolResult> {
     const trimmedQuery = requireNonEmptyString(input.query, 'Search query');
 
     // Select the query function based on the field parameter
@@ -156,6 +157,7 @@ export class ArxivSearchTool extends defineTool({
 
     const fieldLabel = input.field !== 'all' ? ` (${input.field})` : '';
     return {
+      status: 'executed',
       summary: `Found: ${results.length} ${pluralize(results.length, 'result')} for "${trimmedQuery}"${fieldLabel}`,
       output: JSON.stringify(payload, null, 2),
     };

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -199,6 +199,7 @@ export class BashTool extends defineTool({
     if (result.success) {
       const preview = truncateWithEllipsis(command, 60);
       return {
+        status: 'executed',
         summary: `Executed: ${preview} (exit 0, ${duration})`,
         output: result.stdout ?? '',
       };
@@ -415,6 +416,7 @@ export class BashTool extends defineTool({
     })();
 
     return {
+      status: 'executed',
       summary: `Launched background: ${preview}`,
       output: [
         `Command launched in background.`,

--- a/src/tools/citation/CrossrefDoiTool.ts
+++ b/src/tools/citation/CrossrefDoiTool.ts
@@ -3,7 +3,7 @@ import { type Work } from '@jamesgopsill/crossref-client';
 import { z } from 'zod';
 
 // Local imports
-import { ToolError } from '@shared/schemas/toolResult';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { requireNonEmptyString, wrapApiCall } from '@tools/utils';
 import { defineTool } from '@tools/core/define';
 
@@ -22,7 +22,7 @@ export class CrossrefDoiTool extends defineTool({
   description: 'Look up detailed metadata for a DOI using Crossref.',
   schema: CrossrefDoiInputSchema,
 }) {
-  protected async execute(input: CrossrefDoiInput) {
+  protected async execute(input: CrossrefDoiInput): Promise<ToolResult> {
     const trimmedDoi = requireNonEmptyString(input.doi, 'DOI');
 
     const response = await wrapApiCall(async () => {
@@ -56,6 +56,7 @@ export class CrossrefDoiTool extends defineTool({
     };
 
     return {
+      status: 'executed',
       summary: `Retrieved: DOI ${metadata.doi}`,
       output: JSON.stringify(metadata, null, 2),
     };

--- a/src/tools/citation/CrossrefSearchTool.ts
+++ b/src/tools/citation/CrossrefSearchTool.ts
@@ -7,7 +7,7 @@ import {
 import { z } from 'zod';
 
 // Local imports
-import { ToolError } from '@shared/schemas/toolResult';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { requireNonEmptyString, wrapApiCall } from '@tools/utils';
 import { defineTool } from '@tools/core/define';
 import { pluralize } from '@utils/text/stringUtils';
@@ -55,7 +55,7 @@ export class CrossrefSearchTool extends defineTool({
   description: 'Search Crossref works and return top matches.',
   schema: CrossrefSearchInputSchema,
 }) {
-  protected async execute(input: CrossrefSearchInput) {
+  protected async execute(input: CrossrefSearchInput): Promise<ToolResult> {
     const trimmedQuery = requireNonEmptyString(input.query, 'Search query');
 
     const options: ExtendedQueryWorksParams = {
@@ -100,6 +100,7 @@ export class CrossrefSearchTool extends defineTool({
     };
 
     return {
+      status: 'executed',
       summary: `Found: ${results.length} ${pluralize(results.length, 'result')} for "${trimmedQuery}"`,
       output: JSON.stringify(payload, null, 2),
     };

--- a/src/tools/comment/InlineCommentTool.ts
+++ b/src/tools/comment/InlineCommentTool.ts
@@ -137,6 +137,7 @@ export class InlineCommentTool extends defineTool({
   protected async execute(input: InlineCommentInput): Promise<ToolResult> {
     if (!provider.available()) {
       return {
+        status: 'executed',
         summary: 'Inline comments unavailable',
         output:
           'Inline comments require the VS Code extension host and are not available in this environment.',
@@ -179,6 +180,7 @@ export class InlineCommentTool extends defineTool({
       const where = result.resolvedPath || resolved.absolute;
       const summary = `Opened comment thread ${result.threadId} at ${where}:${line}`;
       return {
+        status: 'executed',
         summary,
         output: `${summary}\nThe user can reply or resolve it in the editor; read replies with the "list" command.`,
       };
@@ -199,7 +201,7 @@ export class InlineCommentTool extends defineTool({
       return this.threadNotFound(threadId);
     }
     const summary = `Replied to comment thread ${threadId}`;
-    return { summary, output: summary };
+    return { status: 'executed', summary, output: summary };
   }
 
   private setResolved(
@@ -216,7 +218,7 @@ export class InlineCommentTool extends defineTool({
       return this.threadNotFound(threadId);
     }
     const summary = `${resolved ? 'Resolved' : 'Reopened'} comment thread ${threadId}`;
-    return { summary, output: summary };
+    return { status: 'executed', summary, output: summary };
   }
 
   private list(input: InlineCommentInput): ToolResult {
@@ -231,6 +233,7 @@ export class InlineCommentTool extends defineTool({
     const threads = provider.list({ absolutePath });
     if (threads.length === 0) {
       return {
+        status: 'executed',
         summary: 'No comment threads',
         output: input.path
           ? `No comment threads in ${input.path}.`
@@ -240,11 +243,16 @@ export class InlineCommentTool extends defineTool({
     const summary = `${threads.length} comment thread${
       threads.length === 1 ? '' : 's'
     }`;
-    return { summary, output: threads.map(formatThread).join('\n\n') };
+    return {
+      status: 'executed',
+      summary,
+      output: threads.map(formatThread).join('\n\n'),
+    };
   }
 
   private threadNotFound(threadId: string): ToolResult {
     return {
+      status: 'executed',
       summary: 'Thread not found',
       output: `No comment thread with id "${threadId}". Use the "list" command to see open threads.`,
     };

--- a/src/tools/core/base.ts
+++ b/src/tools/core/base.ts
@@ -8,6 +8,7 @@ import type { ToolDefinition } from '@model/ToolDefinition';
 import {
   DIAGNOSTIC_TYPE_VALIDATION_ERROR,
   formatZodIssuesForDiagnostics,
+  toolError,
   type ToolResult,
 } from '@shared/schemas/toolResult';
 
@@ -56,24 +57,16 @@ export abstract class BaseTool<T> implements ITool {
       return await this.execute(input);
     } catch (err) {
       if (err instanceof ZodError) {
-        return {
-          error: `Invalid input:\n${z.prettifyError(err)}`,
-          isError: true,
-          diagnostics: {
-            type: DIAGNOSTIC_TYPE_VALIDATION_ERROR,
-            issues: err.issues,
-            formatted: formatZodIssuesForDiagnostics(err.issues),
-          },
-        };
+        return toolError(`Invalid input:\n${z.prettifyError(err)}`, {
+          type: DIAGNOSTIC_TYPE_VALIDATION_ERROR,
+          issues: err.issues,
+          formatted: formatZodIssuesForDiagnostics(err.issues),
+        });
       }
       const message = toErrorMessage(err);
       // Only include error name - stack traces waste tokens and aren't actionable by models
       const diagnostics = err instanceof Error ? { name: err.name } : undefined;
-      return {
-        error: message,
-        isError: true,
-        diagnostics,
-      };
+      return toolError(message, diagnostics);
     }
   }
 

--- a/src/tools/delegation/inputFields.ts
+++ b/src/tools/delegation/inputFields.ts
@@ -197,10 +197,9 @@ export async function rejectOversizedBibAttachments(
 
     const message = `${bibFile} is ${stats.size} bytes (${formatBytes(stats.size)}), over the ${LARGE_BIB_LIMIT_BYTES} byte (${formatBytes(LARGE_BIB_LIMIT_BYTES)}) limit. Call extract_bib_entries first if citations are needed, then re-propose without the full .bib file.`;
     return {
+      status: 'error',
       summary: `Rejected oversized BibTeX attachment`,
       error: message,
-      output: message,
-      isError: true,
       diagnostics: {
         type: 'oversized_bib_attachment',
         path: bibFile,

--- a/src/tools/delegation/proposalFlow.ts
+++ b/src/tools/delegation/proposalFlow.ts
@@ -116,19 +116,20 @@ function proposalResultToToolResult(
         ? `\nUser feedback: ${feedback}`
         : `\n${DEFAULT_DELEGATION_REJECTION_FEEDBACK}`;
       return {
+        status: 'error',
         summary: `User rejected delegation to '${agentName}'`,
-        output: `Delegation to '${agentName}' was rejected.\nYour delegation was: ${echo}${feedbackLine}`,
-        isError: true,
+        error: `Delegation to '${agentName}' was rejected.\nYour delegation was: ${echo}${feedbackLine}`,
       };
     }
     case 'timeout':
       return {
+        status: 'error',
         summary: `Delegation to '${agentName}' timed out`,
-        output: `Delegation to '${agentName}' timed out waiting for user approval.\nYour delegation was: ${echo}`,
-        isError: true,
+        error: `Delegation to '${agentName}' timed out waiting for user approval.\nYour delegation was: ${echo}`,
       };
     case 'setup':
       return {
+        status: 'executed',
         summary: `User opened '${agentName}' for editing`,
         output: `Delegation opened for editing. The user will run it manually when ready.\nYour delegation was: ${echo}`,
       };
@@ -188,9 +189,9 @@ export async function proposeAndExecute(
       });
     } catch (err) {
       return {
+        status: 'error',
         summary: `Approved model override '${result.model}' is not available`,
-        output: `Cannot launch with model '${result.model}': ${toErrorMessage(err)} Re-propose the delegation.`,
-        isError: true,
+        error: `Cannot launch with model '${result.model}': ${toErrorMessage(err)} Re-propose the delegation.`,
       };
     }
   }
@@ -206,9 +207,9 @@ export async function proposeAndExecute(
   // synchronously instead of after an async launch.
   if (agentOverride && !resolvedAgentOverride) {
     return {
+      status: 'error',
       summary: `Approved agent override '${agentOverride}' is not available`,
-      output: `Cannot launch '${agentOverride}': it is not currently a visible ${proposal.agentCategory} agent (removed, renamed, or disabled since the proposal was shown). Re-propose the delegation.`,
-      isError: true,
+      error: `Cannot launch '${agentOverride}': it is not currently a visible ${proposal.agentCategory} agent (removed, renamed, or disabled since the proposal was shown). Re-propose the delegation.`,
     };
   }
 

--- a/src/tools/delegation/subagentExecution.ts
+++ b/src/tools/delegation/subagentExecution.ts
@@ -165,13 +165,13 @@ export function depthGateError(
         'or complete this task directly without delegating.',
       ].join(' ');
   return {
+    status: 'error',
     error: [
       `Delegation depth cap reached (current depth ${gate.depth},`,
       `max depth ${gate.maxDepth}).`,
       reason,
       remediation,
     ].join(' '),
-    isError: true,
     diagnostics: {
       type: 'delegation_depth_cap',
       currentDepth: gate.depth,
@@ -205,10 +205,10 @@ export async function executeSubagent(
   const parentContext = tryUseRunContext();
   if (!parentContext?.runtimeHost) {
     return {
+      status: 'error',
       summary: 'Delegation tool runtime host unavailable',
       error:
         'delegate_agent and delegate_workflow require an active tool runtime host. Run delegation from an active agent session, or ensure the tool run context provides runtimeHost.',
-      isError: true,
       diagnostics: {
         type: 'missing_runtime_host',
         tools: ['delegate_agent', 'delegate_workflow'],
@@ -269,10 +269,9 @@ export async function executeSubagent(
       });
       await writeSubagentReport(executionId, msg);
       return {
+        status: 'error',
         summary: `Subagent '${agentName}' failed`,
-        output: msg,
         error: toErrorMessage(err),
-        isError: true,
       };
     };
     try {
@@ -307,6 +306,7 @@ export async function executeSubagent(
       );
       await writeSubagentReport(executionId, msg);
       return {
+        status: 'executed',
         summary:
           result.outcome === 'cancelled'
             ? `Cancelled '${agentName}'`
@@ -513,6 +513,7 @@ export async function executeSubagent(
     );
   }
   return {
+    status: 'executed',
     summary: `Launched '${agentName}' (async)`,
     output: [
       `Subagent '${agentName}' launched. Result will be delivered automatically as a follow-up message when complete.`,

--- a/src/tools/fileInteractions.ts
+++ b/src/tools/fileInteractions.ts
@@ -20,11 +20,11 @@ export function requireFileReadForEdit(
     return null;
   }
   return {
+    status: 'error',
     summary: `Read ${path} before editing`,
-    output:
+    error:
       errorMessage ??
       'Edits to existing files require a prior read in this session. Please call read_file first.',
-    isError: true,
     diagnostics: { reason: 'unread-file', path },
   };
 }

--- a/src/tools/formatting.ts
+++ b/src/tools/formatting.ts
@@ -46,6 +46,7 @@ export interface FileViewOptions {
 
 export interface FileViewResult {
   [key: string]: unknown;
+  status: 'executed';
   output: string;
   summary: string;
 }
@@ -111,7 +112,7 @@ export function formatFileView({
     summary += summarySuffix;
   }
 
-  return { output: segments.join('\n'), summary };
+  return { status: 'executed', output: segments.join('\n'), summary };
 }
 
 /**

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -166,6 +166,7 @@ async function execSubscribe(
     const created = bindRepoSubscription(streamId, target, runtimeHost);
     const slug = `${target.owner}/${target.repo}`;
     return {
+      status: 'executed',
       summary: created
         ? `Subscribed to repo ${slug}`
         : `Already subscribed to repo ${slug}`,
@@ -187,6 +188,7 @@ async function execSubscribe(
     const annotationLevelDescription =
       ANNOTATION_LEVEL_DESCRIPTIONS[minAnnotationLevel];
     return {
+      status: 'executed',
       summary: created
         ? `Subscribed to ${slug}`
         : `Already subscribed to ${slug}`,
@@ -229,6 +231,7 @@ async function execSubscribe(
     const annotationLevelDescription =
       ANNOTATION_LEVEL_DESCRIPTIONS[minAnnotationLevel];
     return {
+      status: 'executed',
       summary: created
         ? wasIssuePath
           ? `Subscribed to ${prSlug} (was /issues/${target.issueNumber}; resolved to PR)`
@@ -241,6 +244,7 @@ async function execSubscribe(
   }
   const created = bindIssueSubscription(streamId, target, runtimeHost);
   return {
+    status: 'executed',
     summary: created
       ? `Subscribed to ${issueSlug}`
       : `Already subscribed to ${issueSlug}`,
@@ -277,6 +281,7 @@ function execUnsubscribe(input: GitHubSubscriptionInput): ToolResult {
     const removed = unbindRepoSubscription(streamId, target, runtimeHost);
     const slug = `${target.owner}/${target.repo}`;
     return {
+      status: 'executed',
       summary: removed
         ? `Unsubscribed from repo ${slug}`
         : `Was not subscribed to repo ${slug}`,
@@ -286,6 +291,7 @@ function execUnsubscribe(input: GitHubSubscriptionInput): ToolResult {
     const removed = unbindPRSubscription(streamId, target, runtimeHost);
     const slug = `${target.owner}/${target.repo}/pulls/${target.pullNumber}`;
     return {
+      status: 'executed',
       summary: removed
         ? `Unsubscribed from ${slug}`
         : `Was not subscribed to ${slug}`,
@@ -305,6 +311,7 @@ function execUnsubscribe(input: GitHubSubscriptionInput): ToolResult {
   );
   const slug = `${target.owner}/${target.repo}/issues/${target.issueNumber}`;
   return {
+    status: 'executed',
     summary:
       issueRemoved || prRemoved
         ? `Unsubscribed from ${slug}`
@@ -328,11 +335,13 @@ function execList(): ToolResult {
   const all = [...repoKeys, ...prKeys, ...issueKeys];
   if (all.length === 0) {
     return {
+      status: 'executed',
       summary: 'No active subscriptions on this stream.',
       output: 'No active subscriptions on this stream.',
     };
   }
   return {
+    status: 'executed',
     summary: `${all.length} active subscription(s).`,
     output: all.map((k) => `- ${k}`).join('\n'),
   };
@@ -498,6 +507,7 @@ async function execFindCurrent(
   }
   const path = `${remote.owner}/${remote.repo}/pulls/${pr.number}`;
   return {
+    status: 'executed',
     summary: path,
     output: `path: ${path}\nurl: ${pr.html_url}\n\nPass this path to command="subscribe" to start watching the PR.`,
   };

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -101,6 +101,7 @@ export class GlobTool extends defineTool({
     const count = lines.length;
     const header = `Found ${count} ${pluralize(count, 'file')} matching "${input.pattern}" under ${display}`;
     return {
+      status: 'executed',
       summary: `Found ${count} ${pluralize(count, 'file')} for "${input.pattern}" in ${display}`,
       output: formatToolOutput(header, lines, '(no matches)'),
     };

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -157,6 +157,7 @@ export class GrepTool extends defineTool({
 
     if (totalCount === 0) {
       return {
+        status: 'executed',
         summary: `No matches for "${input.pattern}" in ${display}`,
         output:
           `No matches found for "${input.pattern}" in ${display}. ` +
@@ -175,6 +176,7 @@ export class GrepTool extends defineTool({
     const hasMore = returnedCount < totalCount;
 
     const toolResult: ToolResult = {
+      status: 'executed',
       summary,
       output: paginatedLines.join('\n'),
     };

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -237,6 +237,7 @@ function buildReadOutput(manifest: ExternalInquiryThreadManifest): ToolResult {
   }
 
   return {
+    status: 'executed',
     summary: `Inquiry thread ${manifest.threadId} (${manifest.status}, ${formatResultCount(manifest.turns.length, 'turn')})`,
     output: lines.join('\n'),
   };
@@ -249,6 +250,7 @@ function buildListOutput(
 ): ToolResult {
   if (summaries.length === 0) {
     return {
+      status: 'executed',
       summary: `No inquiry threads (${filterStatus}, scope=${scope})`,
       output: '(no threads)',
     };
@@ -263,6 +265,7 @@ function buildListOutput(
     lines.push(`    "${s.lastQuestionPreview}"`);
   }
   return {
+    status: 'executed',
     summary: `Inquiry threads: ${summaries.length}`,
     output: lines.join('\n'),
   };
@@ -412,6 +415,7 @@ export class ExternalInquiryTool extends defineTool({
       'otherwise proceed with independent work.';
 
     return {
+      status: 'executed',
       summary: `Inquiry dispatched (${persisted.threadId})`,
       output: `status: dispatched\nthread_id: ${persisted.threadId}\n\n${message}`,
     };

--- a/src/tools/latex/ExtractBibliographyTool.ts
+++ b/src/tools/latex/ExtractBibliographyTool.ts
@@ -7,6 +7,7 @@ import {
   loadBibliographyEntries,
   summarizeBibliographyEntries,
 } from '@latex/extractBibliography';
+import type { ToolResult } from '@shared/schemas/toolResult';
 import { formatToolOutput } from '@tools/formatting';
 import { resolveAndFormat } from '@tools/pathResolution';
 import { defineTool } from '@tools/core/define';
@@ -47,7 +48,10 @@ export class ExtractBibliographyTool extends defineTool({
     'Collect BibTeX records for citations referenced in a LaTeX document.',
   schema: ExtractBibliographyInputSchema,
 }) {
-  protected async execute({ texPath, bibPath }: ExtractBibliographyInput) {
+  protected async execute({
+    texPath,
+    bibPath,
+  }: ExtractBibliographyInput): Promise<ToolResult> {
     const { path, display } = await resolveLatexFileOrThrow(texPath);
 
     const context = await extractBibliographyContext(path.relative);
@@ -78,6 +82,7 @@ export class ExtractBibliographyTool extends defineTool({
     ) {
       const summary = `No citations or bibliography directives found in ${display}.`;
       return {
+        status: 'executed',
         summary,
         output: formatToolOutput(`BibTeX entries in ${display}`, null),
       };
@@ -91,6 +96,7 @@ export class ExtractBibliographyTool extends defineTool({
           ? `\n\nNote: Missing bibliography files: ${formatPathList(missingBibliographyFiles)}.`
           : '';
       return {
+        status: 'executed',
         summary,
         output: `${baseOutput}${missingNote}`,
       };
@@ -135,6 +141,7 @@ export class ExtractBibliographyTool extends defineTool({
       instructions.length > 0 ? `\n\nNote: ${instructions.join(' ')}` : '';
 
     return {
+      status: 'executed',
       summary,
       output: `${output}${notes}`,
     };

--- a/src/tools/latex/ExtractFiguresTool.ts
+++ b/src/tools/latex/ExtractFiguresTool.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 // Local imports - tools
 import { extractFigurePathsFromLatex } from '@latex/extractFigure';
+import type { ToolResult } from '@shared/schemas/toolResult';
 import { formatToolOutput } from '@tools/formatting';
 import { resolveAndFormat } from '@tools/pathResolution';
 import { defineTool } from '@tools/core/define';
@@ -31,7 +32,9 @@ export class ExtractLatexFiguresTool extends defineTool({
     'Resolve and list figure assets referenced by a LaTeX document, returning attachments when available.',
   schema: ExtractFiguresInputSchema,
 }) {
-  protected async execute({ texPath }: ExtractFiguresInput) {
+  protected async execute({
+    texPath,
+  }: ExtractFiguresInput): Promise<ToolResult> {
     const { path, display } = await resolveLatexFileOrThrow(texPath);
 
     const figurePaths = await extractFigurePathsFromLatex(
@@ -42,6 +45,7 @@ export class ExtractLatexFiguresTool extends defineTool({
     if (uniqueFigures.length === 0) {
       const summary = `No figures found in ${display}.`;
       return {
+        status: 'executed',
         summary,
         output: formatToolOutput('Figures', null),
       };
@@ -65,6 +69,7 @@ export class ExtractLatexFiguresTool extends defineTool({
       : output;
 
     return {
+      status: 'executed',
       summary,
       output: fullOutput,
       files: attachments,

--- a/src/tools/latex/ExtractTikzFiguresTool.ts
+++ b/src/tools/latex/ExtractTikzFiguresTool.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 
 // Local imports - tools
 import { tikzPictureManager } from '@latex/TikzPictureManager';
-import { type ToolFileAttachment } from '@shared/schemas/toolResult';
+import {
+  type ToolFileAttachment,
+  type ToolResult,
+} from '@shared/schemas/toolResult';
 import { formatToolOutput } from '@tools/formatting';
 import { defineTool } from '@tools/core/define';
 import { pathToLocation } from '@utils/files';
@@ -34,7 +37,10 @@ export class ExtractTikzFiguresTool extends defineTool({
     'Discover TikZ figures inside a LaTeX document and optionally compile them into standalone PDFs.',
   schema: ExtractTikzInputSchema,
 }) {
-  protected async execute({ texPath, compile = true }: ExtractTikzInput) {
+  protected async execute({
+    texPath,
+    compile = true,
+  }: ExtractTikzInput): Promise<ToolResult> {
     const { path, display } = await resolveLatexFileOrThrow(texPath);
 
     const tikzFigures = await tikzPictureManager.extract(
@@ -43,6 +49,7 @@ export class ExtractTikzFiguresTool extends defineTool({
     if (tikzFigures.length === 0) {
       const summary = `No TikZ figures found in ${display}.`;
       return {
+        status: 'executed',
         summary,
         output: formatToolOutput('TikZ figures', null),
       };
@@ -99,6 +106,7 @@ export class ExtractTikzFiguresTool extends defineTool({
     }
 
     return {
+      status: 'executed',
       summary: summaryParts.join(' '),
       output: outputs.join('\n'),
       files: attachments,

--- a/src/tools/lean/LoogleTool.ts
+++ b/src/tools/lean/LoogleTool.ts
@@ -203,9 +203,9 @@ Useful for finding the right lemma when you know roughly what type it should hav
         return {
           query,
           result: {
+            status: 'error',
             summary: 'No results',
-            output: `Error: ${data.error}${suggestionText}`,
-            isError: true,
+            error: `Error: ${data.error}${suggestionText}`,
           },
         };
       }
@@ -216,6 +216,7 @@ Useful for finding the right lemma when you know roughly what type it should hav
         return {
           query,
           result: {
+            status: 'executed',
             summary: 'No results',
             output: `No theorems found matching: ${query}\n\nTry a different type signature or name pattern.`,
           },
@@ -229,6 +230,7 @@ Useful for finding the right lemma when you know roughly what type it should hav
       return {
         query,
         result: {
+          status: 'executed',
           summary: `${hits.length} result${hits.length > 1 ? 's' : ''}`,
           output: formatted,
           results: hits,
@@ -243,21 +245,21 @@ Useful for finding the right lemma when you know roughly what type it should hav
         return {
           query,
           result: {
+            status: 'error',
             summary: 'Timeout',
-            output:
+            error:
               `Loogle API request timed out after ${LOOGLE_TIMEOUT_MS / 1000}s. ` +
               `The Loogle server may be overloaded. Retry the request. ` +
               `If it persists, try a simpler type signature or search by name instead.`,
-            isError: true,
           },
         };
       }
       return {
         query,
         result: {
+          status: 'error',
           summary: 'Loogle search failed',
-          output: `Error: ${toErrorMessage(err)}`,
-          isError: true,
+          error: `Error: ${toErrorMessage(err)}`,
         },
       };
     }
@@ -283,8 +285,10 @@ Useful for finding the right lemma when you know roughly what type it should hav
     let errorCount = 0;
 
     for (const { query: q, result } of results) {
-      sections.push(`## Query: \`${q}\`\n\n${result.output}`);
-      if (result.isError) {
+      const resultText =
+        result.status === 'error' ? result.error : (result.output ?? '');
+      sections.push(`## Query: \`${q}\`\n\n${resultText}`);
+      if (result.status === 'error') {
         errorCount++;
       }
       if (result.results) {
@@ -303,11 +307,21 @@ Useful for finding the right lemma when you know roughly what type it should hav
       summary = `No results across ${queries.length} queries`;
     }
 
+    const output = sections.join('\n\n---\n\n');
+    if (allFailed) {
+      return {
+        status: 'error',
+        summary,
+        error: output,
+        results: totalHits > 0 ? allResults : undefined,
+      };
+    }
+
     return {
+      status: 'executed',
       summary,
-      output: sections.join('\n\n---\n\n'),
+      output,
       results: totalHits > 0 ? allResults : undefined,
-      isError: allFailed ? true : undefined,
     };
   }
 }

--- a/src/tools/lean/LspTools.ts
+++ b/src/tools/lean/LspTools.ts
@@ -127,9 +127,9 @@ Tips:
         await getLeanLanguageServices().fetchDiagnosticsForFile(file);
       if (!diagnostics) {
         return {
+          status: 'error',
           summary: 'Failed to open file',
-          output: `Could not open file: ${file}\n\nMake sure the file exists and is accessible.`,
-          isError: true,
+          error: `Could not open file: ${file}\n\nMake sure the file exists and is accessible.`,
         };
       }
 
@@ -139,13 +139,18 @@ Tips:
       const countsStr = formatCounts(counts);
 
       if (diagnostics.length === 0) {
-        return { summary: '✓ No diagnostics', output: NO_DIAGNOSTICS_HELP };
+        return {
+          status: 'executed',
+          summary: '✓ No diagnostics',
+          output: NO_DIAGNOSTICS_HELP,
+        };
       }
 
       const baseDiagnostics = { ...counts, total: diagnostics.length };
 
       if (command === 'count') {
         return {
+          status: 'executed',
           summary: countsStr,
           output: `${file}: ${countsStr}`,
           diagnostics: baseDiagnostics,
@@ -153,15 +158,16 @@ Tips:
       }
 
       return {
+        status: 'executed',
         summary: countsStr,
         output: formatGroupedSections(diagnostics),
         diagnostics: { ...baseDiagnostics, details: diagnostics },
       };
     } catch (error) {
       return {
+        status: 'error',
         summary: 'Failed to get diagnostics',
-        output: `Error: ${toErrorMessage(error)}\n\nIn VS Code: install the Lean 4 extension (leanprover.lean4). In CLI/desktop: install elan so that \`lake\` is on PATH, and make sure the file is inside a Lake project (lakefile.lean / lakefile.toml).`,
-        isError: true,
+        error: `Error: ${toErrorMessage(error)}\n\nIn VS Code: install the Lean 4 extension (leanprover.lean4). In CLI/desktop: install elan so that \`lake\` is on PATH, and make sure the file is inside a Lake project (lakefile.lean / lakefile.toml).`,
       };
     }
   }
@@ -189,20 +195,21 @@ Requires: Lean 4 VS Code extension installed and active.`,
       );
       if (!success) {
         return {
+          status: 'error',
           summary: 'Command failed',
-          output: `Could not execute "${command}". Is the file open and the Lean 4 extension active?`,
-          isError: true,
+          error: `Could not execute "${command}". Is the file open and the Lean 4 extension active?`,
         };
       }
       return {
+        status: 'executed',
         summary: description,
         output: `Executed "${command}" on ${file}`,
       };
     } catch (error) {
       return {
+        status: 'error',
         summary: 'Command failed',
-        output: `Error: ${toErrorMessage(error)}`,
-        isError: true,
+        error: `Error: ${toErrorMessage(error)}`,
       };
     }
   }
@@ -242,20 +249,22 @@ Requires: Lean 4 VS Code extension installed.`,
 
       if (command === 'build') {
         return {
+          status: 'executed',
           summary: description,
           output: `Build started. Note: this command does not capture build output directly.\n\nTo check for errors and warnings, run lean_diagnostics on the relevant .lean files.`,
         };
       }
 
       return {
+        status: 'executed',
         summary: description,
         output: `Executed "${command}" successfully`,
       };
     } catch (error) {
       return {
+        status: 'error',
         summary: 'Command failed',
-        output: `Error executing "${command}": ${toErrorMessage(error)}`,
-        isError: true,
+        error: `Error executing "${command}": ${toErrorMessage(error)}`,
       };
     }
   }
@@ -298,9 +307,9 @@ Requires: Lean 4 VS Code extension installed and active.`,
       }
     } catch (error) {
       return {
+        status: 'error',
         summary: `Failed to get ${type}`,
-        output: `Error: ${toErrorMessage(error)}`,
-        isError: true,
+        error: `Error: ${toErrorMessage(error)}`,
       };
     }
   }
@@ -319,14 +328,15 @@ Requires: Lean 4 VS Code extension installed and active.`,
 
     if (!data) {
       return {
+        status: 'error',
         summary: 'No goal state',
-        output: `Could not get goal state at ${location}${error ? `\nError: ${error}` : ''}`,
-        isError: true,
+        error: `Could not get goal state at ${location}${error ? `\nError: ${error}` : ''}`,
       };
     }
 
     if (data.goals.length === 0) {
       return {
+        status: 'executed',
         summary: 'No goals',
         output: 'No goals at this position. The proof may be complete here.',
         goalState: { goals: [], count: 0, status: 'noGoals' as const },
@@ -335,6 +345,7 @@ Requires: Lean 4 VS Code extension installed and active.`,
 
     const goalCount = data.goals.length;
     return {
+      status: 'executed',
       summary: `${goalCount} goal${goalCount > 1 ? 's' : ''}`,
       output: data.rendered,
       goalState: {
@@ -359,13 +370,13 @@ Requires: Lean 4 VS Code extension installed and active.`,
 
     if (!data) {
       return {
+        status: 'error',
         summary: 'No term goal',
-        output: `No expected type at ${location}${error ? `\nError: ${error}` : ''}`,
-        isError: true,
+        error: `No expected type at ${location}${error ? `\nError: ${error}` : ''}`,
       };
     }
 
-    return { summary: 'Term goal', output: data.goal };
+    return { status: 'executed', summary: 'Term goal', output: data.goal };
   }
 
   private async executeHover(
@@ -382,21 +393,21 @@ Requires: Lean 4 VS Code extension installed and active.`,
 
     if (!data) {
       return {
+        status: 'error',
         summary: 'No hover info',
-        output: `No information at ${location}${error ? `\nError: ${error}` : ''}`,
-        isError: true,
+        error: `No information at ${location}${error ? `\nError: ${error}` : ''}`,
       };
     }
 
     const text = extractHoverText(data.contents);
     if (!text) {
       return {
+        status: 'error',
         summary: 'No hover info',
-        output: `Empty hover response at ${location}`,
-        isError: true,
+        error: `Empty hover response at ${location}`,
       };
     }
 
-    return { summary: 'Hover info', output: text };
+    return { status: 'executed', summary: 'Hover info', output: text };
   }
 }

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -252,6 +252,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
     if (!exists) {
       if (resolvedPath === MEMORY_STORAGE_ROOT) {
         return {
+          status: 'executed',
           summary: 'Viewed empty memory directory',
           output: `The memory directory is empty. This is a fresh start - use the create command to add memory files.`,
         };
@@ -274,6 +275,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
 
       const header = `Contents of ${inputPath} (showing ${start}\u2013${end} of ${total}, up to 2 levels deep):`;
       return {
+        status: 'executed',
         summary: `Listed directory: ${inputPath} (${start}\u2013${end} of ${total})`,
         output: `${header}\nSIZE\tMODIFIED\tBY\tPATH\n${page.join('\n')}${formatPaginationHint(end, total)}`,
       };
@@ -321,6 +323,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
     recordToolFileRead(inputPath);
 
     return {
+      status: 'executed',
       summary: `Created memory file: ${inputPath}`,
       output: `File created successfully at: ${inputPath}`,
     };
@@ -368,6 +371,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
     const numbered = formatLinesWithNumbers(updatedLines);
 
     return {
+      status: 'executed',
       summary: `Replaced text in: ${inputPath}`,
       output: `The file has been edited.\n${numbered.join('\n')}`,
     };
@@ -404,6 +408,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
     recordToolFileRead(inputPath);
 
     return {
+      status: 'executed',
       summary: `Inserted text at line ${insertLine} in: ${inputPath}`,
       output: `The file ${inputPath} has been edited.`,
     };
@@ -421,6 +426,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
 
     await StorageFS.delete(resolvedPath, { recursive: true });
     return {
+      status: 'executed',
       summary: `Deleted: ${inputPath}`,
       output: `Successfully deleted ${inputPath}`,
     };
@@ -448,6 +454,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
 
     await StorageFS.rename(resolvedOldPath, resolvedNewPath);
     return {
+      status: 'executed',
       summary: `Renamed: ${oldPathInput} to ${newPathInput}`,
       output: `Successfully renamed ${oldPathInput} to ${newPathInput}`,
     };
@@ -460,6 +467,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
     const { meta, content } = await this.readMemoryFile(resolvedPath);
     if (meta?.pinned) {
       return {
+        status: 'executed',
         summary: `Already pinned: ${inputPath}`,
         output: `The memory file ${inputPath} is already pinned.`,
       };
@@ -476,6 +484,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
     await StorageFS.write(resolvedPath, buildFile(content, updatedMeta));
 
     return {
+      status: 'executed',
       summary: `Pinned memory: ${inputPath}`,
       output: `Successfully pinned ${inputPath} as a core long-term memory. (${pinnedCount + 1}/${MAX_PINNED_MEMORIES} pinned)`,
     };
@@ -488,6 +497,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
     const { meta, content } = await this.readMemoryFile(resolvedPath);
     if (!meta?.pinned) {
       return {
+        status: 'executed',
         summary: `Not pinned: ${inputPath}`,
         output: `The memory file ${inputPath} is not pinned.`,
       };
@@ -497,6 +507,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
     await StorageFS.write(resolvedPath, buildFile(content, updatedMeta));
 
     return {
+      status: 'executed',
       summary: `Unpinned memory: ${inputPath}`,
       output: `Successfully unpinned ${inputPath}.`,
     };

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -147,6 +147,7 @@ Best practices:
         'plan called without workPlanState in context — plan will not persist or display in UI',
       );
       return {
+        status: 'executed',
         summary: 'Created plan (no active session)',
         output: this.formatPlan(plan),
         diagnostics: {
@@ -182,6 +183,7 @@ Best practices:
     const goal = GoalStore.getForStream(streamId);
     if (!goal) {
       return {
+        status: 'executed',
         summary: 'No autonomous goal to pause.',
         output:
           'No autonomous goal is currently running on this stream, so there is nothing to pause. ' +
@@ -190,6 +192,7 @@ Best practices:
     }
     if (goal.status !== 'active') {
       return {
+        status: 'executed',
         summary: `Goal already ${goal.status} — pause is a no-op.`,
         output: `Goal is ${goal.status}; pause is a no-op.\n\n${formatGoalView(goal)}`,
       };
@@ -197,6 +200,7 @@ Best practices:
     const updated = (await GoalStore.setStatus(streamId, 'paused')) ?? goal;
     await this.setBashAutoApproval(streamId, false);
     return {
+      status: 'executed',
       summary: 'Goal paused.',
       output: `Goal paused: ${reason}\n\n${formatGoalView(updated)}`,
     };
@@ -224,6 +228,7 @@ Best practices:
     const goal = GoalStore.getForStream(streamId);
     if (!goal) {
       return {
+        status: 'executed',
         summary: 'Plan-only work complete — summarize the result.',
         output:
           'No autonomous goal is currently running on this stream, so there is nothing to mark complete. ' +
@@ -236,6 +241,7 @@ Best practices:
     await GoalStore.forget(streamId);
     await this.setBashAutoApproval(streamId, false);
     return {
+      status: 'executed',
       summary: 'Goal complete.',
       output:
         `Goal ${goal.goalId} marked complete.\n\n` +
@@ -281,10 +287,10 @@ Best practices:
     if (result.action === 'timeout') {
       logger.warn('Plan approval timed out');
       return {
+        status: 'error',
         summary: 'Plan approval timed out',
-        output:
+        error:
           'The plan approval request timed out before the user responded. Please try again or proceed without a plan.',
-        isError: true,
       };
     }
 
@@ -300,9 +306,9 @@ Best practices:
     }
 
     return {
+      status: 'error',
       summary: 'Plan rejected — revise approach',
-      output: `The user rejected this plan.${feedbackNote}\nPlease revise your approach based on the feedback and create an updated plan.`,
-      isError: true,
+      error: `The user rejected this plan.${feedbackNote}\nPlease revise your approach based on the feedback and create an updated plan.`,
       ...(feedback ? { userInstruction: feedback } : {}),
     };
   }
@@ -323,6 +329,7 @@ Best practices:
           'continuing without an autonomous goal.',
       );
       return {
+        status: 'executed',
         summary: 'Plan approved — autonomous run unavailable',
         output:
           `The user selected Approve & Run, but the goal feature flag is ` +
@@ -348,6 +355,7 @@ Best practices:
             : retargeted;
         await this.setBashAutoApproval(streamId, true);
         return {
+          status: 'executed',
           summary: `Plan approved — goal ${active.goalId} retargeted`,
           output:
             `The user approved a new plan while goal ${active.goalId} ` +
@@ -368,15 +376,15 @@ Best practices:
           { data: err },
         );
         return {
+          status: 'error',
           summary:
             'Plan approved — goal could not be retargeted, proceeding without it',
-          output:
+          error:
             `The user approved this plan and requested autonomous execution, ` +
             `but the in-flight goal could not be retargeted: ${reason}\n\n` +
             `Work toward the new objective turn-by-turn. The pre-existing ` +
             `goal is still active and will keep injecting continuations ` +
             `against its previous objective until the user pauses or abandons it.`,
-          isError: true,
         };
       }
     }
@@ -385,6 +393,7 @@ Best practices:
       const goal = await GoalStore.start(streamId, objective);
       await this.setBashAutoApproval(streamId, true);
       return {
+        status: 'executed',
         summary: `Plan approved — goal ${goal.goalId} started`,
         output:
           `The user approved this plan and started an autonomous goal ` +
@@ -403,6 +412,7 @@ Best practices:
         { data: err },
       );
       return {
+        status: 'executed',
         summary:
           'Plan approved — goal could not be started, proceeding without it',
         output:
@@ -423,6 +433,7 @@ Best practices:
       ? 'Plan auto-approved via delegated-task auto-approval (user did not review).'
       : 'Plan approved by the user.';
     return {
+      status: 'executed',
       summary: autoApproved
         ? 'Plan auto-approved — proceed with implementation'
         : 'Plan approved — proceed with implementation',

--- a/src/tools/setup/ApplyTeamTool.ts
+++ b/src/tools/setup/ApplyTeamTool.ts
@@ -128,6 +128,6 @@ ${describeTeams()}`,
       ...(signInNote ? [signInNote] : []),
     ].join(' ');
 
-    return { summary, output: lines.join('\n') };
+    return { status: 'executed', summary, output: lines.join('\n') };
   }
 }

--- a/src/tools/setup/ConfigTools.ts
+++ b/src/tools/setup/ConfigTools.ts
@@ -109,6 +109,7 @@ Accepts any key starting with \`texra.\`. Returns the current resolved value (wo
     const value = getSetupPlatform().config.get(input.key);
     const json = JSON.stringify(value, null, 2) ?? 'undefined';
     return {
+      status: 'executed',
       summary: `Read ${input.key}`,
       output: `${input.key}:\n${json}`,
     };
@@ -164,6 +165,7 @@ Anything outside this list must be changed through the settings UI — invoke \`
     const before = JSON.stringify(previous);
     const after = JSON.stringify(parsed.data);
     return {
+      status: 'executed',
       summary: `Updated ${input.key} (${input.target})`,
       output: `Updated ${input.key} (${input.target} scope): ${before ?? 'undefined'} → ${after}.`,
     };

--- a/src/tools/setup/InstallVscodeExtensionTool.ts
+++ b/src/tools/setup/InstallVscodeExtensionTool.ts
@@ -52,6 +52,7 @@ export class InstallVscodeExtensionTool extends defineTool({
 
     if (platform.extensions.isInstalled(id)) {
       return {
+        status: 'executed',
         summary: `Extension ${id} already installed`,
         output: `The "${id}" extension is already installed. No action taken.`,
       };
@@ -64,6 +65,7 @@ export class InstallVscodeExtensionTool extends defineTool({
     const installed = platform.extensions.isInstalled(id);
 
     return {
+      status: 'executed',
       summary: installed
         ? `Installed extension ${id}`
         : `Install issued for ${id} (verify manually)`,

--- a/src/tools/setup/InvokeCommandTool.ts
+++ b/src/tools/setup/InvokeCommandTool.ts
@@ -87,6 +87,7 @@ export class InvokeCommandTool extends defineTool({
       input.args.length > 0 ? ` (${input.args.length} arg(s), redacted)` : '';
 
     return {
+      status: 'executed',
       summary: `Invoked ${commandId}${argPreview}`,
       output: `Invoked VS Code command "${commandId}"${argPreview}. If this opens a UI prompt, wait for the user's response before continuing.`,
     };

--- a/src/tools/setup/ListApiKeysTool.ts
+++ b/src/tools/setup/ListApiKeysTool.ts
@@ -36,6 +36,7 @@ export class ListApiKeysTool extends defineTool({
 
     if (storedKeys.length === 0) {
       return {
+        status: 'executed',
         summary: 'No secrets stored',
         output: 'SecretStorage is empty — no API keys or tokens are stored.',
       };
@@ -105,6 +106,7 @@ export class ListApiKeysTool extends defineTool({
         : `${providerKeys.length}/${providers.length} provider keys`;
 
     return {
+      status: 'executed',
       summary: `${storedKeys.length} stored secret${storedKeys.length === 1 ? '' : 's'}: ${providerSummary}`,
       output: lines.join('\n'),
     };

--- a/src/tools/setup/ProbeEnvironmentTool.ts
+++ b/src/tools/setup/ProbeEnvironmentTool.ts
@@ -155,6 +155,7 @@ export class ProbeEnvironmentTool extends defineTool({
     const headline = buildHeadline(summary);
 
     return {
+      status: 'executed',
       summary: headline,
       output:
         headline +

--- a/src/tools/setup/SendToTerminalTool.ts
+++ b/src/tools/setup/SendToTerminalTool.ts
@@ -79,6 +79,6 @@ export class SendToTerminalTool extends defineTool({
       ? '\n\n' + tailWithEllipsis(output, OUTPUT_PREVIEW_MAX)
       : '';
 
-    return { summary, output: summary + tail };
+    return { status: 'executed', summary, output: summary + tail };
   }
 }

--- a/src/tools/setup/SetApiKeyTool.ts
+++ b/src/tools/setup/SetApiKeyTool.ts
@@ -83,6 +83,7 @@ export class SetApiKeyTool extends defineTool({
 
     const masked = maskKey(input.key);
     return {
+      status: 'executed',
       summary: `Stored ${provider} API key (${masked})`,
       output: `Stored API key for provider "${provider}" in SecretStorage as ${masked}. You can now run agents that use ${provider} models.`,
     };

--- a/src/tools/setup/UnsetApiKeyTool.ts
+++ b/src/tools/setup/UnsetApiKeyTool.ts
@@ -39,11 +39,13 @@ export class UnsetApiKeyTool extends defineTool({
       const envExists = await platform.secrets.hasUsableApiKey(provider);
       if (envExists) {
         return {
+          status: 'executed',
           summary: `${provider} key is env-var-backed`,
           output: `No stored API key for "${provider}" to remove, but one is still active via the ${envVar} environment variable. SecretStorage has nothing to clear — unset ${envVar} in your shell (or the source that sets it) to remove this credential.`,
         };
       }
       return {
+        status: 'executed',
         summary: `No stored ${provider} API key`,
         output: `There was no stored API key for provider "${provider}" to remove.`,
       };
@@ -62,12 +64,14 @@ export class UnsetApiKeyTool extends defineTool({
     const stillPresent = await platform.secrets.hasUsableApiKey(provider);
     if (stillPresent) {
       return {
+        status: 'executed',
         summary: `Removed stored ${provider} key (env var still active)`,
         output: `Removed stored API key for provider "${provider}", but the ${envVar} environment variable is still set and will continue to provide a credential. Unset ${envVar} in your shell to fully remove it.`,
       };
     }
 
     return {
+      status: 'executed',
       summary: `Removed ${provider} API key`,
       output: `Removed stored API key for provider "${provider}".`,
     };

--- a/src/tools/setup/VerifySetupTool.ts
+++ b/src/tools/setup/VerifySetupTool.ts
@@ -45,6 +45,7 @@ export class VerifySetupTool extends defineTool({
         ]);
         const ok = gm || magick;
         return {
+          status: 'executed',
           summary: `Verify gm/magick: ${ok ? 'ok' : 'missing'}`,
           output: ok
             ? `Verified: ${gm ? '"gm"' : '"magick"'} is installed and on PATH.`
@@ -62,6 +63,7 @@ export class VerifySetupTool extends defineTool({
       }
       const ok = await isToolPresent(name);
       return {
+        status: 'executed',
         summary: `Verify ${name}: ${ok ? 'ok' : 'missing'}`,
         output: ok
           ? `Verified: "${name}" is installed and on PATH.`
@@ -126,6 +128,7 @@ export class VerifySetupTool extends defineTool({
     }
 
     return {
+      status: 'executed',
       summary: verificationSummary,
       output: lines.join('\n'),
     };

--- a/src/tools/texcount/TexcountTool.ts
+++ b/src/tools/texcount/TexcountTool.ts
@@ -46,12 +46,13 @@ export class TexcountTool extends defineTool({
         errors.join('\n') ||
         'texcount did not return any output. Ensure the files exist.';
       return {
+        status: 'error',
         error: errorMessage,
-        isError: true,
       };
     }
 
     return {
+      status: 'executed',
       summary: `Analyzed: ${formatResultCount(files.length, 'file')}`,
       output:
         input.format === 'stats'

--- a/src/tools/todo/TodoTool.ts
+++ b/src/tools/todo/TodoTool.ts
@@ -87,6 +87,7 @@ Best practices:
         'todo_write called without workPlanState in context - todos will not persist or display in UI',
       );
       return {
+        status: 'executed',
         summary: 'Updated todo list (no active session)',
         output: this.formatTodoList(input.todos),
         diagnostics: {
@@ -103,6 +104,7 @@ Best practices:
 
     // Return minimal output - the UI already shows the input, no need to repeat the list
     return {
+      status: 'executed',
       summary: `Todo list updated: ${completed} completed, ${inProgress} in progress, ${pending} pending`,
       output: 'OK',
     };

--- a/src/tools/userQuestion/UserQuestionTool.ts
+++ b/src/tools/userQuestion/UserQuestionTool.ts
@@ -152,6 +152,7 @@ The tool returns a JSON object whose keys are the original question texts and wh
 
       if (!result.submitted) {
         return {
+          status: 'executed',
           output: result.feedback
             ? `The user declined to answer: ${result.feedback}`
             : 'The user declined to answer.',
@@ -161,11 +162,13 @@ The tool returns a JSON object whose keys are the original question texts and wh
       const answers = UserQuestionAnswersSchema.parse(result.answers ?? {});
       if (Object.keys(answers).length === 0) {
         return {
+          status: 'executed',
           output: 'The user submitted no answers.',
         };
       }
 
       return {
+        status: 'executed',
         output: JSON.stringify({ answers }, null, 2),
         summary: `Answered ${Object.keys(answers).length} user question(s).`,
       };

--- a/src/tools/web/WebFetchTool.ts
+++ b/src/tools/web/WebFetchTool.ts
@@ -219,6 +219,7 @@ export class WebFetchTool extends defineTool({
     }
 
     return {
+      status: 'executed',
       summary: `Fetched: ${url}`,
       output: sections.join('\n\n'),
     };

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -149,12 +149,14 @@ export class WebSearchTool extends defineTool({
 
     if (results.length === 0) {
       return {
+        status: 'executed',
         summary: `Searched: "${query}" (no results)`,
         output:
           'No results found. Note: This search uses DuckDuckGo Instant Answers API which works best for factual/entity queries. For general web searches, try rephrasing the query or use more specific terms.',
       };
     }
     return {
+      status: 'executed',
       summary: `Searched: "${query}"`,
       output: results.slice(0, max_results).join('\n\n'),
     };

--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -74,6 +74,7 @@ export class WolframTool extends defineTool({
     });
     if (result.success) {
       return {
+        status: 'executed',
         summary: wolframRunSummary(input.code),
         output: result.output ?? '',
       };

--- a/src/tools/zotero/ZoteroAddTool.ts
+++ b/src/tools/zotero/ZoteroAddTool.ts
@@ -25,7 +25,7 @@ import { z } from 'zod';
 // Local imports - core
 import pTimeout from 'p-timeout';
 import { toErrorMessage } from '@common/errors';
-import { ToolError } from '@shared/schemas/toolResult';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { isTimeoutError } from '@tools/timeouts';
 import { waitForRateLimit } from '@tools/citation/rateLimiter';
 import { CROSSREF_CONSTANTS, crossrefClient } from '@tools/citation/constants';
@@ -329,7 +329,10 @@ export class ZoteroAddTool extends defineTool({
     'Add literature items to Zotero library. Requires Zotero to be running with the Connector enabled. Supports adding items by DOI (recommended), URL, or manual metadata entry. When possible, check for duplicates first (via zotero_search or grepping .bib files). Use itemType "preprint" for arXiv papers and preprints — never "webpage".',
   schema: ZoteroAddInputSchema,
 }) {
-  protected async execute({ items, collection }: ZoteroAddInput) {
+  protected async execute({
+    items,
+    collection,
+  }: ZoteroAddInput): Promise<ToolResult> {
     const port = getZoteroPort();
 
     // Check if Zotero is running (throws ToolError if not)
@@ -406,6 +409,7 @@ export class ZoteroAddTool extends defineTool({
         : `Added ${successCount} ${pluralize(successCount, 'item')}, failed to add ${errorCount} ${pluralize(errorCount, 'item')} to Zotero.`;
 
     return {
+      status: 'executed',
       summary,
       output,
     };

--- a/src/tools/zotero/ZoteroCollectionsTool.ts
+++ b/src/tools/zotero/ZoteroCollectionsTool.ts
@@ -13,6 +13,7 @@
 import { z } from 'zod';
 
 // Local imports - core
+import type { ToolResult } from '@shared/schemas/toolResult';
 import { defineTool } from '@tools/core/define';
 import { filterNotNull } from '@utils/core';
 import { formatResultCount } from '@utils/text/stringUtils';
@@ -155,7 +156,10 @@ export class ZoteroCollectionsTool extends defineTool({
     'Requires Better BibTeX plugin to be installed in Zotero.',
   schema: ZoteroCollectionsInputSchema,
 }) {
-  protected async execute({ query, library }: ZoteroCollectionsInput) {
+  protected async execute({
+    query,
+    library,
+  }: ZoteroCollectionsInput): Promise<ToolResult> {
     const port = getZoteroPort();
 
     const libraries = await callBetterBibTeX(
@@ -167,6 +171,7 @@ export class ZoteroCollectionsTool extends defineTool({
 
     if (libraries.length === 0) {
       return {
+        status: 'executed',
         summary: 'No libraries found in Zotero.',
         output:
           'No libraries found. Is Zotero running with items in your library?',
@@ -182,6 +187,7 @@ export class ZoteroCollectionsTool extends defineTool({
     if (targetLibraries.length === 0) {
       const available = libraries.map((lib) => lib.name).join(', ');
       return {
+        status: 'executed',
         summary: `Library "${library}" not found.`,
         output: `Library "${library}" not found. Available libraries: ${available}`,
       };
@@ -210,12 +216,14 @@ export class ZoteroCollectionsTool extends defineTool({
     const context = query ? ` matching "${query}"` : '';
     if (outputParts.length === 0) {
       return {
+        status: 'executed',
         summary: `No collections found${context}.`,
         output: `No collections found${context}.`,
       };
     }
 
     return {
+      status: 'executed',
       summary: `Found ${formatResultCount(totalCollections, 'collection')}${context} across ${formatResultCount(librariesWithResults, 'library', 'libraries')}.`,
       output: outputParts.join('\n'),
     };

--- a/src/tools/zotero/ZoteroExportTool.ts
+++ b/src/tools/zotero/ZoteroExportTool.ts
@@ -9,7 +9,7 @@
 import { z } from 'zod';
 
 // Local imports - core
-import { ToolError } from '@shared/schemas/toolResult';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { defineTool } from '@tools/core/define';
 import { pluralize } from '@utils/text/stringUtils';
 
@@ -45,7 +45,11 @@ export class ZoteroExportTool extends defineTool({
     'Requires Better BibTeX plugin to be installed in Zotero.',
   schema: ZoteroExportInputSchema,
 }) {
-  protected async execute({ citekeys, format, library }: ZoteroExportInput) {
+  protected async execute({
+    citekeys,
+    format,
+    library,
+  }: ZoteroExportInput): Promise<ToolResult> {
     const port = getZoteroPort();
     const translator = format || 'biblatex';
 
@@ -70,6 +74,7 @@ export class ZoteroExportTool extends defineTool({
     }
 
     return {
+      status: 'executed',
       summary: `Exported ${citekeys.length} ${pluralize(citekeys.length, 'entry')} as ${translator}`,
       output: exported,
     };

--- a/src/tools/zotero/ZoteroSearchTool.ts
+++ b/src/tools/zotero/ZoteroSearchTool.ts
@@ -9,6 +9,7 @@
 import { z } from 'zod';
 
 // Local imports - core
+import type { ToolResult } from '@shared/schemas/toolResult';
 import { defineTool } from '@tools/core/define';
 import { formatResultCount } from '@utils/text/stringUtils';
 
@@ -141,7 +142,7 @@ export class ZoteroSearchTool extends defineTool({
     year,
     library,
     include_collections,
-  }: ZoteroSearchInput) {
+  }: ZoteroSearchInput): Promise<ToolResult> {
     const port = getZoteroPort();
 
     // Build search params: use advanced tuple search when structured fields
@@ -168,6 +169,7 @@ export class ZoteroSearchTool extends defineTool({
 
     if (result.length === 0) {
       return {
+        status: 'executed',
         summary: `No results found for ${label}`,
         output: 'No matching items in Zotero library.',
       };
@@ -193,6 +195,7 @@ export class ZoteroSearchTool extends defineTool({
     });
 
     return {
+      status: 'executed',
       summary: `Found ${formatResultCount(result.length, 'item')} matching ${label}`,
       output: items.join('\n'),
     };


### PR DESCRIPTION
## Summary

Makes `ToolResultSchema` the source-of-truth discriminated union for tool results. Tool producers now return `status: 'executed'` or `status: 'error'` at the source, and expected tool failures use the shared `toolError(message, diagnostics?)` builder.

This also fixes the cited `ExecutionsTool.handleKill` placement bug by returning the error message in `error` rather than `output`.

## Issue acceptance gates

Addresses #6975.

- One result schema: `ToolResultSchema` now owns the executed/error union, `NormalizedToolResultSchema` and `ToolResultPayloadSchema` were deleted, and the old ToolResult `isError` producer/schema field is gone.
- Projection paths: updated model-handler attachment tests, progress/transcript tests, delegation headless tests, and CLI run validation cover success/error/diagnostics result projection without changing host output contracts.
- Required gates: `npm run typecheck` and full `npm test` are green.

## Single source of truth

`src/shared/schemas/toolResult.ts` owns the discriminated ToolResult contract and the `toolError()` helper for expected tool failures.

## Duplication and abstraction budget

Removed the downstream status-inference bridge: `NormalizedToolResultSchema`, the model-handler `ToolResultPayloadSchema`, and the fallback ladder that inferred errors from `isError || (error && !output)`.

No shim, projection, dual-write, alias, fallback, or migration path is introduced, so no #6981 ledger row is needed. The PR is net-positive because the added mass is mechanical source-level `status` declarations and fixture updates across the tool surface; the duplicated normalizer/schema path was deleted.

## Host impact

Extension: VS Code LM and text-editor call sites now branch on `status`; transcript/progress behavior is intended to remain byte-identical.

Desktop: No host behavior change; desktop consumes the same sanitized result data with source-declared status.

CLI: `texra run --print` plus JSON/NDJSON validation remains green through `corepack pnpm --filter @texra-ai/cli validate:run`.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write` on touched files
- `npm run typecheck -- --pretty false`
- `npm test`
- `npm run lint` (0 errors, 16 warnings)
- `npm run compile:fast`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `git diff --check`
- `rg -n "ToolResultPayload|NormalizedToolResultSchema|ToolResultPayloadSchema|export type ToolResult = ToolResult" src packages` (no matches)
- `rg -n "isError" src/shared/schemas/toolResult.ts src/agent/modelHandlers/utils/toolAttachmentUtils.ts` (no matches)

Closes #6975

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide mechanical change across the agent tool pipeline and all model handlers; incorrect `status` on a tool would mis-route follow-ups, logging, and edits, though schema validation and updated tests reduce that risk.
> 
> **Overview**
> **`ToolResult` is now a strict discriminated union** in `toolResult.ts`: producers return `status: 'executed'` or `status: 'error'`, and expected failures go through **`toolError()`**. The old **`isError` flag**, **`NormalizedToolResultSchema`**, and model-handler **`ToolResultPayload`** / status-inference path are removed; **`extractToolAttachments`** parses with **`ToolResultSchema`** only.
> 
> **Call sites are updated end-to-end**: every tool and approval/delegation helper sets `status` explicitly; **`ToolUseDispatchNode`** narrows on `status` for edits, files, and logging; model handlers take **`ToolResult`** instead of **`ToolResultPayload`**. The extension LM bridge and text-editor test command branch on **`result.status === 'error'`**.
> 
> **Tests and fixtures** assert `status` instead of `isError`, and attachment tests reject ambiguous legacy shapes. **`ExecutionsTool.handleKill`** (and similar paths) put failure text in **`error`**, not **`output`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e51ddaf0561bb0b65c598657be48d8c84c4243b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->