### PR TITLE
refactor: centralize backend text diffs

### DIFF
--- a/src/agent/output/diffComputation.ts
+++ b/src/agent/output/diffComputation.ts
@@ -5,8 +5,6 @@
  * using the diff-match-patch library.
  */
 
-import { diff_match_patch } from 'diff-match-patch';
-
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import type { OutputFileInfo, FileLocation } from '@shared/schemas';
@@ -18,6 +16,7 @@ import {
   getComparablePath,
   WorkspaceFS,
 } from '@utils/files';
+import { diffLineChanges } from '@utils/text/diff';
 import { countLines } from '@utils/text/stringUtils';
 
 import { traceFileLineage } from './lineageMapping';
@@ -48,18 +47,8 @@ async function computeDiffStats(
       flexibleFS.read(outputLocation),
     ]);
 
-    const dmp = new diff_match_patch();
-    const diffs = dmp.diff_main(baseContent, outContent);
-    let added = 0;
-    let removed = 0;
-    for (const [op, text] of diffs) {
-      if (op === 1) {
-        added += countLines(text);
-      } else if (op === -1) {
-        removed += countLines(text);
-      }
-    }
-    return { added, removed };
+    // Preserve diff-match-patch's omitted-argument default: checkLines=true.
+    return diffLineChanges(baseContent, outContent, { checkLines: true });
   } catch (err) {
     logger.debug(
       CHANNEL,

--- a/src/agent/output/extraction/contentSimilarity.ts
+++ b/src/agent/output/extraction/contentSimilarity.ts
@@ -6,8 +6,7 @@
  * diff, so blocks can be routed to filenames without trusting response order.
  */
 
-import { diff_match_patch } from 'diff-match-patch';
-
+import { diffLevenshtein, diffTextByChar } from '@utils/text/diff';
 import {
   isClosingMarkdownFence,
   type MarkdownFence,
@@ -63,15 +62,11 @@ export function collectLatexFencedBlocks(
  * `diff_levenshtein` counts a substitution as delete-plus-insert, which can
  * exceed the longer length for very different documents.
  */
-function documentSimilarity(
-  dmp: InstanceType<typeof diff_match_patch>,
-  a: string,
-  b: string,
-): number {
+function documentSimilarity(a: string, b: string): number {
   if (a === b) return 1;
   const maxLength = Math.max(a.length, b.length, 1);
-  const diffs = dmp.diff_main(a, b, true);
-  return Math.max(0, 1 - dmp.diff_levenshtein(diffs) / maxLength);
+  const diffs = diffTextByChar(a, b, { checkLines: true });
+  return Math.max(0, 1 - diffLevenshtein(diffs) / maxLength);
 }
 
 /**
@@ -87,9 +82,8 @@ export function assignByContentSimilarity(
   files: ReadonlyArray<{ name: string; content: string }>,
   minSimilarity = 0.15,
 ): Array<{ content: string; name: string } | null> {
-  const dmp = new diff_match_patch();
   const scores = candidates.map((candidate) =>
-    files.map((file) => documentSimilarity(dmp, candidate, file.content)),
+    files.map((file) => documentSimilarity(candidate, file.content)),
   );
   const bestScoreOf = scores.map((row) => Math.max(...row));
 

--- a/src/agent/output/extraction/contentSimilarity.ts
+++ b/src/agent/output/extraction/contentSimilarity.ts
@@ -6,7 +6,7 @@
  * diff, so blocks can be routed to filenames without trusting response order.
  */
 
-import { diffLevenshtein, diffTextByChar } from '@utils/text/diff';
+import { diffTextLevenshtein } from '@utils/text/diff';
 import {
   isClosingMarkdownFence,
   type MarkdownFence,
@@ -65,8 +65,8 @@ export function collectLatexFencedBlocks(
 function documentSimilarity(a: string, b: string): number {
   if (a === b) return 1;
   const maxLength = Math.max(a.length, b.length, 1);
-  const diffs = diffTextByChar(a, b, { checkLines: true });
-  return Math.max(0, 1 - diffLevenshtein(diffs) / maxLength);
+  const distance = diffTextLevenshtein(a, b, { checkLines: true });
+  return Math.max(0, 1 - distance / maxLength);
 }
 
 /**

--- a/src/test-kernel/utils/TextDiffCallers.vitest.ts
+++ b/src/test-kernel/utils/TextDiffCallers.vitest.ts
@@ -1,0 +1,164 @@
+// Standard library imports
+import path from 'node:path';
+
+// Third-party imports
+import { beforeEach, describe, expect, it } from 'vitest';
+
+// Local imports - tests
+import { createFakePlatform } from '@test/support/FakePlatform';
+
+// Local imports - agent output
+import { computeOutputDiffStats } from '@agent/output/diffComputation';
+import { assignByContentSimilarity } from '@agent/output/extraction/contentSimilarity';
+import { createOutputState, ensureRoundData } from '@agent/output/outputState';
+import type { RoundFileMapping } from '@agent/output/types';
+
+// Local imports - shared schemas
+import type { ExecutionId } from '@shared/schemas';
+
+// Local imports - tools
+import { computeAndWriteWorkflowDiffs } from '@tools/subagentDiffs';
+import {
+  computeLineChangeSummary,
+  computeUserPatch,
+  firstChangedLine,
+  writeApprovedContent,
+} from '@tools/approval/toolEditApproval';
+
+// Local imports - utils
+import {
+  AbsoluteFS,
+  createExternalLocation,
+  getComparablePath,
+} from '@utils/files';
+import { getRunDir } from '@utils/files/taskRunStorage';
+
+async function installFakePlatform(
+  files: Record<string, string> = {},
+): Promise<void> {
+  const { initPlatform } = await import('@platform/platform');
+  initPlatform(
+    createFakePlatform({
+      files,
+      storagePath: '/workspace/.texra/storage',
+      workspacePath: '/workspace',
+    }),
+  );
+}
+
+describe('shared text-diff caller fixtures', () => {
+  beforeEach(async () => {
+    await installFakePlatform();
+  });
+
+  it('preserves output diff line-change stats', async () => {
+    await installFakePlatform({
+      '/workspace/base.tex': 'one\ntwo\nthree\n',
+      '/workspace/out.tex': 'one\nTWO\nthree\nfour\n',
+    });
+    const state = createOutputState();
+    const outputLocation = createExternalLocation('/workspace/out.tex');
+    ensureRoundData(state, 0).outputs = [
+      {
+        source: 'out.tex',
+        round: 0,
+        location: outputLocation,
+        lineage: null,
+        diff: null,
+      },
+    ];
+    const baseLocation = createExternalLocation('/workspace/base.tex');
+    const mapping: RoundFileMapping = new Map([
+      [getComparablePath(outputLocation), { base: baseLocation }],
+    ]);
+
+    const [output] = await computeOutputDiffStats(
+      state,
+      [baseLocation],
+      0,
+      mapping,
+    );
+
+    expect(output?.diff).toEqual({ added: 2, removed: 1 });
+  });
+
+  it('preserves content-similarity assignment output', () => {
+    const revision = 'Intro\nrevised result\nConclusion\n';
+    const unrelated = 'Detached notes about something else entirely.';
+
+    const assigned = assignByContentSimilarity(
+      [revision, unrelated],
+      [
+        {
+          name: 'paper.tex',
+          content: 'Intro\noriginal result\nConclusion\n',
+        },
+      ],
+      0.5,
+    );
+
+    expect(assigned).toEqual([{ content: revision, name: 'paper.tex' }, null]);
+  });
+
+  it('preserves subagent line-mode diff files', async () => {
+    await installFakePlatform({
+      '/workspace/original.tex': 'one\ntwo\nthree\n',
+      '/workspace/out/section/paper.tex': 'one\nTWO\nthree\nfour\n',
+    });
+    const executionId = 'abcdef' as ExecutionId;
+
+    const result = await computeAndWriteWorkflowDiffs(executionId, [
+      {
+        round: 0,
+        relativePath: 'section/paper.tex',
+        absolutePath: '/workspace/out/section/paper.tex',
+        location: 'workspace',
+        originalPath: '/workspace/original.tex',
+        added: 2,
+        removed: 1,
+      },
+    ]);
+
+    expect(result.get('/workspace/out/section/paper.tex')).toEqual({
+      diffRelPath: 'diffs/section_paper.tex.diff',
+      largeChange: true,
+    });
+    await expect(
+      AbsoluteFS.read(
+        path.join(getRunDir(executionId), 'diffs/section_paper.tex.diff'),
+      ),
+    ).resolves.toBe(' one\n-two\n+TWO\n three\n+four');
+  });
+
+  it('preserves tool-edit approval diff summaries and patch application', async () => {
+    const original = 'alpha\nbeta\nomega\n';
+    const final = 'alpha\nBETA\nomega\n';
+
+    expect(computeLineChangeSummary(original, final)).toEqual({
+      added: 1,
+      removed: 1,
+    });
+    expect(
+      firstChangedLine('alpha\nbeta\nomega\n', 'alpha\ninsert\nbeta\nomega\n'),
+    ).toBe(1);
+    expect(computeUserPatch(original, final)).toContain('-beta');
+    expect(computeUserPatch(original, final)).toContain('+BETA');
+
+    await installFakePlatform({
+      '/workspace/paper.tex': 'alpha\nbeta\nomega\nlocal\n',
+    });
+    const writeResult = await writeApprovedContent(
+      'paper.tex',
+      original,
+      final,
+    );
+
+    expect(writeResult).toEqual({
+      appliedContent: 'alpha\nBETA\nomega\nlocal\n',
+      baseContent: 'alpha\nbeta\nomega\nlocal\n',
+    });
+    await expect(AbsoluteFS.read('/workspace/paper.tex')).resolves.toBe(
+      'alpha\nBETA\nomega\nlocal\n',
+    );
+  });
+});

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -10,7 +10,7 @@ import { WorkspaceFS } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
 import {
   applyPatchToText,
-  diffTextByChar,
+  diffTextByCharWithSemanticCleanup,
   DIFF_DELETE,
   DIFF_EQUAL,
   DIFF_INSERT,
@@ -131,9 +131,8 @@ export function emitToolEditApprovalPrompt(
 // ============================================================================
 
 function createSemanticDiffs(original: string, proposed: string): TextDiff[] {
-  return diffTextByChar(original, proposed, {
+  return diffTextByCharWithSemanticCleanup(original, proposed, {
     checkLines: true,
-    cleanupSemantic: true,
   });
 }
 

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -1,10 +1,3 @@
-import {
-  diff_match_patch,
-  DIFF_DELETE,
-  DIFF_EQUAL,
-  DIFF_INSERT,
-} from 'diff-match-patch';
-
 import { platform } from '@platform/platform';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { tryUseRunContext } from '@agent/runtime/RunContext';
@@ -15,6 +8,16 @@ import type { LineChanges } from '@shared/schemas/lineChanges';
 import { type ToolResult } from '@shared/schemas/toolResult';
 import { WorkspaceFS } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
+import {
+  applyPatchToText,
+  cleanupSemanticDiffs,
+  diffTextByChar,
+  DIFF_DELETE,
+  DIFF_EQUAL,
+  DIFF_INSERT,
+  makePatchText,
+  type TextDiff,
+} from '@utils/text/diff';
 import { countLines } from '@utils/text/stringUtils';
 
 import { bashApprovalController } from './bashApproval';
@@ -128,14 +131,10 @@ export function emitToolEditApprovalPrompt(
 // Pure diff helpers (exported for use by native handler in @frontend/)
 // ============================================================================
 
-function createSemanticDiffs(
-  original: string,
-  proposed: string,
-): ReturnType<InstanceType<typeof diff_match_patch>['diff_main']> {
-  const dmp = new diff_match_patch();
-  const diffs = dmp.diff_main(original, proposed);
-  dmp.diff_cleanupSemantic(diffs);
-  return diffs;
+function createSemanticDiffs(original: string, proposed: string): TextDiff[] {
+  return cleanupSemanticDiffs(
+    diffTextByChar(original, proposed, { checkLines: true }),
+  );
 }
 
 export function computeLineChangeSummary(
@@ -200,14 +199,7 @@ export function computeUserPatch(
     return undefined;
   }
 
-  const dmp = new diff_match_patch();
-  const patches = dmp.patch_make(suggestedContent, appliedContent);
-
-  if (patches.length === 0) {
-    return undefined;
-  }
-
-  return dmp.patch_toText(patches);
+  return makePatchText(suggestedContent, appliedContent);
 }
 
 // ============================================================================
@@ -325,9 +317,11 @@ export async function writeApprovedContent(
     return { appliedContent: finalContent, baseContent: currentContent };
   }
 
-  const dmp = new diff_match_patch();
-  const patches = dmp.patch_make(originalContent, finalContent);
-  const [patchedContent, results] = dmp.patch_apply(patches, currentContent);
+  const { content: patchedContent, results } = applyPatchToText(
+    originalContent,
+    finalContent,
+    currentContent,
+  );
 
   if (results.every(Boolean)) {
     await WorkspaceFS.write(path, patchedContent);

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -10,7 +10,6 @@ import { WorkspaceFS } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
 import {
   applyPatchToText,
-  cleanupSemanticDiffs,
   diffTextByChar,
   DIFF_DELETE,
   DIFF_EQUAL,
@@ -132,9 +131,10 @@ export function emitToolEditApprovalPrompt(
 // ============================================================================
 
 function createSemanticDiffs(original: string, proposed: string): TextDiff[] {
-  return cleanupSemanticDiffs(
-    diffTextByChar(original, proposed, { checkLines: true }),
-  );
+  return diffTextByChar(original, proposed, {
+    checkLines: true,
+    cleanupSemantic: true,
+  });
 }
 
 export function computeLineChangeSummary(

--- a/src/tools/subagentDiffs.ts
+++ b/src/tools/subagentDiffs.ts
@@ -1,11 +1,15 @@
 import path from 'node:path';
 
-import { diff_match_patch } from 'diff-match-patch';
-
 import type { ExecutionId } from '@shared/schemas';
 import type { OutputFileSummary } from '@shared/schemas/output';
 import { AbsoluteFS } from '@utils/files';
 import { getRunDir, ensureRunDir } from '@utils/files/taskRunStorage';
+import {
+  diffTextByLine,
+  DIFF_DELETE,
+  DIFF_EQUAL,
+  DIFF_INSERT,
+} from '@utils/text/diff';
 import { countLines } from '@utils/text/stringUtils';
 
 /** Maximum lines of diff to include per file in deliveries. */
@@ -31,21 +35,18 @@ function computeReadableDiff(
   original: string,
   modified: string,
 ): string | null {
-  const dmp = new diff_match_patch();
-
-  // Convert to line-mode: each line becomes a single "character" so
-  // diff_main operates on whole lines, not individual characters.
-  const { chars1, chars2, lineArray } = dmp.diff_linesToChars_(
-    original,
-    modified,
-  );
-  const diffs = dmp.diff_main(chars1, chars2, false);
-  dmp.diff_charsToLines_(diffs, lineArray);
+  const diffs = diffTextByLine(original, modified, {
+    cleanupSemantic: false,
+  });
 
   // Check if there are any actual changes.
-  if (diffs.every(([op]) => op === 0)) return null;
+  if (diffs.every(([op]) => op === DIFF_EQUAL)) return null;
 
-  const PREFIX: Record<number, string> = { 1: '+', [-1]: '-', 0: ' ' };
+  const PREFIX: Record<number, string> = {
+    [DIFF_INSERT]: '+',
+    [DIFF_DELETE]: '-',
+    [DIFF_EQUAL]: ' ',
+  };
   const lines: string[] = [];
   for (const [op, text] of diffs) {
     const prefix = PREFIX[op] ?? ' ';

--- a/src/utils/text/diff.ts
+++ b/src/utils/text/diff.ts
@@ -57,11 +57,6 @@ function applySemanticCleanup(
   return diffs;
 }
 
-/** Run diff-match-patch semantic cleanup on an existing diff. */
-export function cleanupSemanticDiffs(diffs: TextDiff[]): TextDiff[] {
-  return applySemanticCleanup(createDiffMatcher(), diffs);
-}
-
 /**
  * Compute a character diff. By default this is the raw diff-match-patch
  * `diff_main(oldText, newText, false)` behavior.
@@ -77,6 +72,21 @@ export function diffTextByChar(
     applySemanticCleanup(dmp, diffs);
   }
   return diffs;
+}
+
+/**
+ * Compute a character diff with semantic cleanup enabled. Callers still choose
+ * the `checkLines` mode explicitly.
+ */
+export function diffTextByCharWithSemanticCleanup(
+  oldText: string,
+  newText: string,
+  options: Pick<CharDiffOptions, 'checkLines'> = {},
+): TextDiff[] {
+  return diffTextByChar(oldText, newText, {
+    ...options,
+    cleanupSemantic: true,
+  });
 }
 
 /**
@@ -99,11 +109,6 @@ export function diffTextByLine(
   }
   dmp.diff_charsToLines_(diffs, lineArray);
   return diffs;
-}
-
-/** Compute diff-match-patch Levenshtein distance for an existing diff. */
-export function diffLevenshtein(diffs: TextDiff[]): number {
-  return createDiffMatcher().diff_levenshtein(diffs);
 }
 
 /**

--- a/src/utils/text/diff.ts
+++ b/src/utils/text/diff.ts
@@ -1,0 +1,155 @@
+// Third-party imports
+import {
+  diff_match_patch,
+  DIFF_DELETE,
+  DIFF_EQUAL,
+  DIFF_INSERT,
+} from 'diff-match-patch';
+
+// Local imports - utils
+import { countLines } from './stringUtils';
+
+export { DIFF_DELETE, DIFF_EQUAL, DIFF_INSERT };
+
+type DiffMatchPatch = InstanceType<typeof diff_match_patch>;
+
+export type TextDiff = ReturnType<DiffMatchPatch['diff_main']>[number];
+
+export interface TextDiffOptions {
+  /**
+   * Run diff-match-patch semantic cleanup after diffing.
+   *
+   * Defaults to false so callers preserve the library's raw diff unless they
+   * explicitly need the edit-preview behavior.
+   */
+  cleanupSemantic?: boolean;
+}
+
+export interface CharDiffOptions extends TextDiffOptions {
+  /**
+   * Pass diff-match-patch's line-check speedup flag to `diff_main`.
+   *
+   * Defaults to false for explicit raw char-mode diffing. Callers preserving
+   * diff-match-patch's omitted-argument behavior pass `checkLines: true`.
+   */
+  checkLines?: boolean;
+}
+
+export interface DiffLineChanges {
+  added: number;
+  removed: number;
+}
+
+export interface PatchApplyResult {
+  content: string;
+  results: boolean[];
+}
+
+function createDiffMatcher(): DiffMatchPatch {
+  return new diff_match_patch();
+}
+
+function applySemanticCleanup(
+  dmp: DiffMatchPatch,
+  diffs: TextDiff[],
+): TextDiff[] {
+  dmp.diff_cleanupSemantic(diffs);
+  return diffs;
+}
+
+/** Run diff-match-patch semantic cleanup on an existing diff. */
+export function cleanupSemanticDiffs(diffs: TextDiff[]): TextDiff[] {
+  return applySemanticCleanup(createDiffMatcher(), diffs);
+}
+
+/**
+ * Compute a character diff. By default this is the raw diff-match-patch
+ * `diff_main(oldText, newText, false)` behavior.
+ */
+export function diffTextByChar(
+  oldText: string,
+  newText: string,
+  options: CharDiffOptions = {},
+): TextDiff[] {
+  const dmp = createDiffMatcher();
+  const diffs = dmp.diff_main(oldText, newText, options.checkLines ?? false);
+  if (options.cleanupSemantic === true) {
+    applySemanticCleanup(dmp, diffs);
+  }
+  return diffs;
+}
+
+/**
+ * Compute a line-mode diff by mapping whole lines to synthetic characters
+ * before running `diff_main`. By default no semantic cleanup is applied.
+ */
+export function diffTextByLine(
+  oldText: string,
+  newText: string,
+  options: TextDiffOptions = {},
+): TextDiff[] {
+  const dmp = createDiffMatcher();
+  const { chars1, chars2, lineArray } = dmp.diff_linesToChars_(
+    oldText,
+    newText,
+  );
+  const diffs = dmp.diff_main(chars1, chars2, false);
+  if (options.cleanupSemantic === true) {
+    applySemanticCleanup(dmp, diffs);
+  }
+  dmp.diff_charsToLines_(diffs, lineArray);
+  return diffs;
+}
+
+/** Compute diff-match-patch Levenshtein distance for an existing diff. */
+export function diffLevenshtein(diffs: TextDiff[]): number {
+  return createDiffMatcher().diff_levenshtein(diffs);
+}
+
+/** Count added and removed lines from a diff. */
+export function countDiffLineChanges(diffs: TextDiff[]): DiffLineChanges {
+  let added = 0;
+  let removed = 0;
+  for (const [op, text] of diffs) {
+    if (op === DIFF_INSERT) {
+      added += countLines(text);
+    } else if (op === DIFF_DELETE) {
+      removed += countLines(text);
+    }
+  }
+  return { added, removed };
+}
+
+/**
+ * Compute line-change stats from a char diff. Defaults to raw char-mode diffing
+ * with no semantic cleanup; callers opt in to cleanup explicitly.
+ */
+export function diffLineChanges(
+  oldText: string,
+  newText: string,
+  options: CharDiffOptions = {},
+): DiffLineChanges {
+  return countDiffLineChanges(diffTextByChar(oldText, newText, options));
+}
+
+/** Build a diff-match-patch patch text, or undefined when there is no patch. */
+export function makePatchText(
+  oldText: string,
+  newText: string,
+): string | undefined {
+  const dmp = createDiffMatcher();
+  const patches = dmp.patch_make(oldText, newText);
+  return patches.length > 0 ? dmp.patch_toText(patches) : undefined;
+}
+
+/** Apply the patch from oldText to newText onto a target string. */
+export function applyPatchToText(
+  oldText: string,
+  newText: string,
+  targetText: string,
+): PatchApplyResult {
+  const dmp = createDiffMatcher();
+  const patches = dmp.patch_make(oldText, newText);
+  const [content, results] = dmp.patch_apply(patches, targetText);
+  return { content, results };
+}

--- a/src/utils/text/diff.ts
+++ b/src/utils/text/diff.ts
@@ -106,8 +106,25 @@ export function diffLevenshtein(diffs: TextDiff[]): number {
   return createDiffMatcher().diff_levenshtein(diffs);
 }
 
+/**
+ * Compute diff-match-patch Levenshtein distance directly from two strings
+ * using a single matcher instance.
+ */
+export function diffTextLevenshtein(
+  oldText: string,
+  newText: string,
+  options: CharDiffOptions = {},
+): number {
+  const dmp = createDiffMatcher();
+  const diffs = dmp.diff_main(oldText, newText, options.checkLines ?? false);
+  if (options.cleanupSemantic === true) {
+    applySemanticCleanup(dmp, diffs);
+  }
+  return dmp.diff_levenshtein(diffs);
+}
+
 /** Count added and removed lines from a diff. */
-export function countDiffLineChanges(diffs: TextDiff[]): DiffLineChanges {
+function countDiffLineChanges(diffs: TextDiff[]): DiffLineChanges {
   let added = 0;
   let removed = 0;
   for (const [op, text] of diffs) {


### PR DESCRIPTION
## Summary

Adds `@utils/text/diff` as the backend owner for diff-match-patch usage: char diffs, line-mode diffs, semantic cleanup, line-change stats, patch text, and patch application. Routes the four #6977 backend callers through it while preserving each caller's existing diff mode and cleanup behavior.

## Issue acceptance gates

- Addresses #6977 / audit C2a.
- Re-verified the cited sites before implementation; the citations still matched with no material upstream drift.
- Backend `new diff_match_patch()` now appears only in `src/utils/text/diff.ts`.
- Existing caller modes are preserved explicitly: output stats and tool-edit semantic previews use `checkLines: true`, content similarity keeps `checkLines: true`, and subagent delivery keeps whole-line diffing with no semantic cleanup.
- Added caller-level fixtures for output diff stats, content-similarity routing, subagent diff files, and tool-edit approval patch/apply behavior.

## Single source of truth

`src/utils/text/diff.ts` now owns backend diff-match-patch construction and the named diff operations used by backend callers.

## Duplication and abstraction budget

Removed four backend direct diff-match-patch setup patterns from output diff stats, content similarity, subagent diff files, and tool-edit approval. The PR is net-positive because the added mass lives in the shared utility and caller fixtures; the production callers themselves are smaller. No shim, alias, dual-write, fallback, or migration path was introduced, so no #6981 ledger row is needed.

## Host impact

Extension: No behavior change. Output stats and native tool-edit approval keep their prior diff and patch semantics. Frontend `wordDiff.ts` is intentionally out of scope.

Desktop: No behavior change. Desktop approval line changes and patch text continue through the shared tool-edit approval helpers.

CLI: No behavior change. Shared tool code continues to satisfy the headless `texra run` validation contract.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec prettier --write src/utils/text/diff.ts src/agent/output/diffComputation.ts src/agent/output/extraction/contentSimilarity.ts src/tools/subagentDiffs.ts src/tools/approval/toolEditApproval.ts src/test-kernel/utils/TextDiffCallers.vitest.ts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/utils/TextDiffCallers.vitest.ts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/agent/output/XmlOutputManager.vitest.ts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/tools/ToolEditApprovalGate.vitest.ts`
- `npm run typecheck`
- `npm test` (576 files passed, 1 skipped; 4504 tests passed, 4 skipped)
- `npm run lint` (exits 0; reports existing warnings in untouched files)
- `npm run compile:fast`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `git diff --check`
- `rg "new diff_match_patch\\(" src packages/desktop packages/cli packages/core -g'*.ts' -g'*.mts'`

Closes #6977

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with preserved per-caller diff modes and new regression fixtures; no intentional product behavior change beyond consolidation.
> 
> **Overview**
> Introduces **`@utils/text/diff`** as the single backend wrapper around `diff-match-patch`, with named helpers for char/line diffs, semantic cleanup, Levenshtein distance, line-change counts, patch text, and patch apply.
> 
> **Output diff stats**, **LaTeX fenced-block similarity routing**, **subagent workflow `.diff` files**, and **tool-edit approval** (line summaries, user patches, `writeApprovedContent` merge) no longer construct `diff_match_patch` locally; they call the shared module while keeping prior modes explicit (`checkLines: true` where the old default applied, line-mode subagent diffs without semantic cleanup).
> 
> Adds **`TextDiffCallers.vitest.ts`** integration-style fixtures so those four call paths stay behavior-stable after the move.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35840b9bfffecc1504ccdaf3b12eb842e5bfa6e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->