### PR TITLE
[codex] Centralize storage layout paths

### DIFF
--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -12,7 +12,7 @@ import { writeTextStdout } from '../runtime/logSinks';
 import {
   formatCliMemoryList,
   formatCliMemoryPreview,
-  resolveCliMemoryStoragePath,
+  cliMemoryStoragePathFromInput,
 } from '../runtime/memory';
 
 import { defineCliCommand } from './_helpers/defineCliCommand';
@@ -46,7 +46,7 @@ async function runMemoryShow(
     return CliExitCode.Success;
   }
 
-  const storagePath = resolveCliMemoryStoragePath(inputPath);
+  const storagePath = cliMemoryStoragePathFromInput(inputPath);
   const preview = await loadMemoryPreview(storagePath);
   const record = {
     path: toDisplayPath(storagePath),

--- a/packages/cli/src/runtime/history/generatedFiles.ts
+++ b/packages/cli/src/runtime/history/generatedFiles.ts
@@ -9,7 +9,7 @@ import { StorageFS } from '@utils/files';
 import { byStringProp } from '@utils/core/comparators';
 import { isObject } from '@utils/core/typeGuards';
 import { isDirectory } from '@utils/files/fsEntryType';
-import { resolveStoragePath } from '@utils/files/taskRunStorage';
+import { findExistingRunStoragePath } from '@utils/files/taskRunStorage';
 
 import type { CliHistoryFile } from '../history';
 
@@ -35,7 +35,7 @@ function isHistoryKvFile(name: string): boolean {
 export async function listGeneratedFiles(
   id: ExecutionId,
 ): Promise<CliHistoryFile[]> {
-  const runDir = await resolveStoragePath(id);
+  const runDir = await findExistingRunStoragePath(id);
   if (!runDir) return [];
   return walkStorageDirectory(runDir, '', HISTORY_FILE_SCAN_DEPTH);
 }

--- a/packages/cli/src/runtime/memory.ts
+++ b/packages/cli/src/runtime/memory.ts
@@ -1,3 +1,4 @@
+import { resolveMemoryStoragePath } from '@platform/defaults/workspaceStorage';
 import type { MemoryViewItem } from '@shared/schemas';
 import { normalizeFilePath } from '@shared/utils/path';
 import { MEMORY_DISPLAY_ROOT } from '@tools/memory/constants';
@@ -5,7 +6,6 @@ import { loadMemoryPreview } from '@tools/memory/memoryFileSystem';
 import {
   displayToStoragePath,
   formatSize,
-  resolveMemoryStoragePath,
   toDisplayPath,
 } from '@tools/memory/memoryUtils';
 import { filterNotNullish } from '@utils/core';
@@ -60,7 +60,7 @@ export function formatCliMemoryList(
   return lines.join('\n');
 }
 
-export function resolveCliMemoryStoragePath(inputPath: string): string {
+export function cliMemoryStoragePathFromInput(inputPath: string): string {
   const trimmed = normalizeFilePath(inputPath.trim());
   if (!trimmed) {
     return displayToStoragePath(MEMORY_DISPLAY_ROOT);
@@ -90,7 +90,7 @@ export function resolveCliMemoryStoragePath(inputPath: string): string {
 export async function formatCliMemoryPreview(
   inputPath: string,
 ): Promise<string> {
-  const storagePath = resolveCliMemoryStoragePath(inputPath);
+  const storagePath = cliMemoryStoragePathFromInput(inputPath);
   const preview = await loadMemoryPreview(storagePath);
   const displayPath = toDisplayPath(storagePath);
   const lines = [`Memory: ${displayPath}`];

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -1,4 +1,5 @@
 import { platform, tryPlatform } from '@platform/platform';
+import { resolveMemoryStoragePath } from '@platform/defaults/workspaceStorage';
 
 import { LatexConfigPersistenceController } from '@controllers/settingsView/LatexConfigPersistenceController';
 import {
@@ -83,7 +84,6 @@ import {
 import { buildChatGptAuthStatusMessage } from '@shared/settingsView/handlers/chatGptHandlers';
 import type { ExternalToolCheckResult } from '@tools/toolAvailability';
 import { MEMORY_STORAGE_ROOT } from '@tools/memory/constants';
-import { resolveMemoryStoragePath } from '@tools/memory/memoryUtils';
 import { StorageFS } from '@utils/files';
 import {
   applyGitAuthorSettings,

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -20,6 +20,7 @@ import {
   buildToolDashboardTerminalAction,
 } from '@controllers/settingsView/ToolDashboardData';
 import { platform } from '@platform/platform';
+import { resolveMemoryStoragePath } from '@platform/defaults/workspaceStorage';
 import { createSettingsMemoryController } from '@controllers/settingsView/SettingsMemoryControllerFactory';
 import {
   buildModelSelectionMessage,
@@ -80,7 +81,6 @@ import {
   refreshDisabledToolCache,
 } from '@tools/toolAvailability';
 import { MEMORY_STORAGE_ROOT } from '@tools/memory/constants';
-import { resolveMemoryStoragePath } from '@tools/memory/memoryUtils';
 import { StorageFS } from '@utils/files';
 import { hasExtension } from '@utils/core/pathCore';
 import {

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -92,11 +92,6 @@ export class LatexDiffManager {
     return path.dirname(location.absolutePath);
   }
 
-  private resolveRunStorageSourceDir(location: FileLocation): string | null {
-    if (location.kind !== 'runStorage') return null;
-    return path.dirname(location.absolutePath);
-  }
-
   private logLatexdiffResult(
     result: LaTeXdiffResult,
     operation: string = 'latexdiff',
@@ -418,7 +413,9 @@ export class LatexDiffManager {
     // round directory first so same-round sibling edits win, then fall back to
     // the original source tree for unchanged inputs and bibliographies.
     const extraInputDirs = [
-      this.resolveRunStorageSourceDir(sourceLocation),
+      sourceLocation.kind === 'runStorage'
+        ? path.dirname(sourceLocation.absolutePath)
+        : null,
       this.resolveWorkspaceSourceDir(referenceLocation),
     ].filter((dir): dir is string => dir !== null);
     const ok = await compileLatex2Pdf(diffLocation, {

--- a/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
+++ b/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
@@ -8,7 +8,7 @@ import * as logger from '@logger/logUtils';
 import type { OutputFileInfo, StreamTabId } from '@shared/schemas';
 
 // Local imports - utilities
-import { ensureRunDir, getRunDir, resolveRunDir } from '@utils/files';
+import { ensureRunDir, findRunDir, getRunDir } from '@utils/files';
 
 /** Agent + model for the run that produced a file, used to build the
  *  legacy `<base>_<agent>_r<round>_<model>` postfix when accepting a copy. */
@@ -72,7 +72,7 @@ export class ProgressWorkflowFileActionsController {
       let directoryToReveal: string | undefined;
 
       if (executionId) {
-        directoryToReveal = await resolveRunDir(executionId);
+        directoryToReveal = await findRunDir(executionId);
         if (!directoryToReveal) {
           await ensureRunDir(executionId);
           directoryToReveal = getRunDir(executionId);

--- a/src/controllers/settingsView/SettingsMemoryController.ts
+++ b/src/controllers/settingsView/SettingsMemoryController.ts
@@ -25,7 +25,7 @@ export interface SettingsMemoryControllerDeps {
   loadMemoryPreview(storagePath: string): Promise<MemoryPreview>;
   isMemoryEnabled(): boolean;
   setMemoryEnabled(enabled: boolean): Promise<void>;
-  resolveStoragePath(storagePath: string): string;
+  memoryStoragePath(storagePath: string): string;
   storage: SettingsMemoryStorage;
   maxPinnedMemories: number;
   parseMemoryFile(raw: string): {
@@ -67,7 +67,7 @@ export class SettingsMemoryController {
   async getMemoryPreviewMessage(
     storagePath: string,
   ): Promise<SettingsMemoryMessage> {
-    const resolvedPath = this.deps.resolveStoragePath(storagePath);
+    const resolvedPath = this.deps.memoryStoragePath(storagePath);
     return {
       command: SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY_PREVIEW,
       preview: await this.deps.loadMemoryPreview(resolvedPath),
@@ -78,7 +78,7 @@ export class SettingsMemoryController {
     return {
       command: SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY_PREVIEW,
       preview: {
-        storagePath: this.deps.resolveStoragePath(storagePath),
+        storagePath: this.deps.memoryStoragePath(storagePath),
         error: true,
       },
     };
@@ -105,7 +105,7 @@ export class SettingsMemoryController {
     if (!confirmed) return null;
 
     await this.deps.storage.delete(
-      this.deps.resolveStoragePath(input.storagePath),
+      this.deps.memoryStoragePath(input.storagePath),
       {
         recursive: true,
       },
@@ -132,7 +132,7 @@ export class SettingsMemoryController {
     storagePath: string,
     pinned: boolean,
   ): Promise<SettingsMemoryMessage | null> {
-    const resolvedPath = this.deps.resolveStoragePath(storagePath);
+    const resolvedPath = this.deps.memoryStoragePath(storagePath);
     const raw = await this.deps.storage.read(resolvedPath);
     const { meta, content } = this.deps.parseMemoryFile(raw);
 

--- a/src/controllers/settingsView/SettingsMemoryControllerFactory.ts
+++ b/src/controllers/settingsView/SettingsMemoryControllerFactory.ts
@@ -7,6 +7,8 @@
  * free of tool-layer implementation imports.
  */
 
+import { resolveMemoryStoragePath } from '@platform/defaults/workspaceStorage';
+
 // Local imports - shared state
 import { GlobalStateKey } from '@shared/state/stateKeys';
 
@@ -22,7 +24,6 @@ import {
   parseFrontmatter,
   setPinnedMeta,
 } from '@tools/memory/memoryMeta';
-import { resolveMemoryStoragePath } from '@tools/memory/memoryUtils';
 
 // Local imports - file system
 import { StorageFS } from '@utils/files';
@@ -59,7 +60,7 @@ export function createSettingsMemoryController(
       (async (enabled) => {
         await globalState.update(GlobalStateKey.MEMORY_ENABLED, enabled);
       }),
-    resolveStoragePath: resolveMemoryStoragePath,
+    memoryStoragePath: resolveMemoryStoragePath,
     storage: StorageFS,
     maxPinnedMemories: MAX_PINNED_MEMORIES,
     parseMemoryFile: parseFrontmatter,

--- a/src/housekeeping/runDirOps.ts
+++ b/src/housekeeping/runDirOps.ts
@@ -9,7 +9,7 @@ import type { ExecutionId } from '@shared/schemas';
 import type { FileOpResult } from '@shared/schemas/opResults';
 import { getCleanAgentName } from '@shared/schemas/agent';
 import { WorkspaceFS } from '@utils/files';
-import { resolveRunDir } from '@utils/files/taskRunStorage';
+import { findRunDir } from '@utils/files/taskRunStorage';
 
 import { HISTORY_DIR } from './constants';
 import { generateTimestamp } from './utils';
@@ -32,7 +32,7 @@ export async function runPackRunDir(
     `Packing runDir for execution ${executionId} (agent=${agent}, model=${model}, inputFile=${inputFile})`,
   );
 
-  const runDirAbsolute = await resolveRunDir(executionId);
+  const runDirAbsolute = await findRunDir(executionId);
   if (!runDirAbsolute) {
     logger.warn(
       CHANNEL,
@@ -73,13 +73,13 @@ export async function runPackRunDir(
 
 /**
  * Delete a run's runDir. Irreversible. Used when the user discards a run
- * from the progress-view toolbar. Resolves through `resolveRunDir` so the
+ * from the progress-view toolbar. Uses `findRunDir` so the
  * legacy `taskRuns/` location is cleaned up too.
  */
 export async function runCleanRunDir(
   executionId: ExecutionId,
 ): Promise<FileOpResult> {
-  const runDirAbsolute = await resolveRunDir(executionId);
+  const runDirAbsolute = await findRunDir(executionId);
   if (!runDirAbsolute) {
     logger.warn(
       CHANNEL,

--- a/src/latex/latexdiff/outputDiscovery.ts
+++ b/src/latex/latexdiff/outputDiscovery.ts
@@ -26,8 +26,8 @@ import type {
 import {
   WorkspaceFS,
   createRunStorageLocation,
+  findRunDir,
   pathToLocation,
-  resolveRunDir,
 } from '@utils/files';
 import { hasExtension } from '@utils/core/pathCore';
 import { isDirectory, isFile } from '@utils/files/fsEntryType';
@@ -85,7 +85,7 @@ export async function scanRunDirForOutputs(
   extraBaseFiles?: string[],
 ): Promise<Map<number, OutputFileInfo[]> | null> {
   try {
-    const runDirAbsolute = await resolveRunDir(executionId);
+    const runDirAbsolute = await findRunDir(executionId);
     if (!runDirAbsolute) return null;
 
     const fs = platform().fs;

--- a/src/platform/defaults/workspaceStorage.ts
+++ b/src/platform/defaults/workspaceStorage.ts
@@ -1,13 +1,25 @@
 // Node imports
 import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, renameSync, writeFileSync } from 'node:fs';
-import { basename, join } from 'node:path';
+import { basename, isAbsolute, join, normalize, relative } from 'node:path';
 
 // Local imports - platform
 import type { StorageProvider } from '../interfaces/storage';
 
-export const GLOBAL_STORAGE_DIR = 'global-storage';
-export const WORKSPACE_STORAGE_DIR = 'workspace-storage';
+export const STORAGE_LAYOUT = {
+  global: 'global-storage',
+  workspace: 'workspace-storage',
+  memory: 'memories',
+  runs: 'executions',
+  legacyRuns: 'taskRuns',
+  original: 'original',
+} as const;
+
+export const GLOBAL_STORAGE_DIR = STORAGE_LAYOUT.global;
+export const WORKSPACE_STORAGE_DIR = STORAGE_LAYOUT.workspace;
+export const MEMORY_STORAGE_DIR = STORAGE_LAYOUT.memory;
+export const RUNS_STORAGE_DIR = STORAGE_LAYOUT.runs;
+export const LEGACY_RUNS_STORAGE_DIR = STORAGE_LAYOUT.legacyRuns;
 
 type WorkspacePathSource = string | undefined | (() => string | undefined);
 
@@ -51,6 +63,70 @@ export function resolveWorkspaceStoragePath(
     WORKSPACE_STORAGE_DIR,
     workspaceStorageId(workspacePath),
   );
+}
+
+export function resolveMemoryStoragePath(storagePath: string): string {
+  const normalized = normalize(storagePath);
+  const memoryRelative = relative(MEMORY_STORAGE_DIR, normalized);
+  if (memoryRelative.startsWith('..') || isAbsolute(memoryRelative)) {
+    throw new Error(`Invalid memory path: ${storagePath}`);
+  }
+  return memoryRelative
+    ? join(MEMORY_STORAGE_DIR, memoryRelative)
+    : MEMORY_STORAGE_DIR;
+}
+
+export function resolveMemoryStorageRelativePath(relativePath: string): string {
+  return relativePath
+    ? join(MEMORY_STORAGE_DIR, relativePath)
+    : MEMORY_STORAGE_DIR;
+}
+
+export function resolveRunStoragePath(...segments: string[]): string {
+  return segments.length
+    ? join(RUNS_STORAGE_DIR, ...segments)
+    : RUNS_STORAGE_DIR;
+}
+
+export function resolveLegacyRunStoragePath(...segments: string[]): string {
+  return segments.length
+    ? join(LEGACY_RUNS_STORAGE_DIR, ...segments)
+    : LEGACY_RUNS_STORAGE_DIR;
+}
+
+export function resolveRunOriginalSnapshotPath(
+  executionId: string,
+  workspaceRelativePath: string,
+): string {
+  return resolveRunStoragePath(
+    executionId,
+    STORAGE_LAYOUT.original,
+    workspaceRelativePath,
+  );
+}
+
+export function resolveRunStorageRelativePath(
+  absolutePath: string,
+  runDirectory: string,
+): string | undefined {
+  const relativePath = relative(runDirectory, absolutePath).replaceAll(
+    '\\',
+    '/',
+  );
+  if (relativePath.startsWith('..') || isAbsolute(relativePath))
+    return undefined;
+  return relativePath || undefined;
+}
+
+export async function resolveExistingRunStoragePath(
+  segments: readonly string[],
+  exists: (storagePath: string) => Promise<boolean>,
+): Promise<string | undefined> {
+  const primary = resolveRunStoragePath(...segments);
+  if (await exists(primary)) return primary;
+  const legacy = resolveLegacyRunStoragePath(...segments);
+  if (await exists(legacy)) return legacy;
+  return undefined;
 }
 
 function resolveLegacyWorkspaceStoragePath(

--- a/src/test-kernel/cli/CliMemory.vitest.mts
+++ b/src/test-kernel/cli/CliMemory.vitest.mts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import {
   cliMemoryItemDescription,
+  cliMemoryStoragePathFromInput,
   formatCliMemoryList,
-  resolveCliMemoryStoragePath,
 } from '@cli/runtime/memory';
 import { memorySelectWindow } from '@cli/chat/tui/forms/MemoryListForm';
 import type { MemoryViewItem } from '@shared/schemas';
@@ -60,12 +60,12 @@ describe('CLI memory formatting', () => {
       'memories\\project.md',
       'project.md',
     ]) {
-      expect(resolveCliMemoryStoragePath(input)).toBe('memories/project.md');
+      expect(cliMemoryStoragePathFromInput(input)).toBe('memories/project.md');
     }
   });
 
   it('rejects absolute paths outside the memory display root', () => {
-    expect(() => resolveCliMemoryStoragePath('/memoriesExtra')).toThrow(
+    expect(() => cliMemoryStoragePathFromInput('/memoriesExtra')).toThrow(
       'Invalid memory path',
     );
   });

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -46,7 +46,7 @@ vi.mock('@agent/storage', async () => {
 });
 
 vi.mock('@utils/files/taskRunStorage', () => ({
-  resolveStoragePath: vi.fn(async () => undefined),
+  findExistingRunStoragePath: vi.fn(async () => undefined),
 }));
 
 vi.mock('@cli/runtime/toolUseResumeData', () => ({

--- a/src/test-kernel/controllers/SettingsMemoryController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsMemoryController.vitest.ts
@@ -110,7 +110,7 @@ function createController(options?: {
       setMemoryEnabled: async (enabled) => {
         memoryEnabled = enabled;
       },
-      resolveStoragePath: (storagePath) => `mem/${storagePath}`,
+      memoryStoragePath: (storagePath) => `mem/${storagePath}`,
       storage,
       maxPinnedMemories: 3,
       parseMemoryFile,

--- a/src/test-kernel/latex/OutputDiscovery.vitest.mts
+++ b/src/test-kernel/latex/OutputDiscovery.vitest.mts
@@ -14,7 +14,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // r0/r1 outputs on disk (the same source the `--run-id` path scans).
 const mocks = vi.hoisted(() => ({
   listExecutions: vi.fn(),
-  resolveRunDir: vi.fn(),
+  findRunDir: vi.fn(),
   readOutputFiles: vi.fn(),
 }));
 
@@ -25,7 +25,7 @@ vi.mock('@agent/storage', async (importActual) => ({
 
 vi.mock('@utils/files', async (importActual) => ({
   ...(await importActual<typeof import('@utils/files')>()),
-  resolveRunDir: mocks.resolveRunDir,
+  findRunDir: mocks.findRunDir,
 }));
 
 vi.mock('@transcript', async (importActual) => {
@@ -95,7 +95,7 @@ describe('discoverLatestExecutionOutputs', () => {
     mocks.listExecutions.mockResolvedValue([
       matchingExecution('exec-headless'),
     ]);
-    mocks.resolveRunDir.mockResolvedValue(runDir);
+    mocks.findRunDir.mockResolvedValue(runDir);
 
     const result = await discoverLatestExecutionOutputs({
       agent: 'polish',
@@ -107,14 +107,14 @@ describe('discoverLatestExecutionOutputs', () => {
     expect([...(result?.rounds.keys() ?? [])].sort((a, b) => a - b)).toEqual([
       0, 1,
     ]);
-    expect(mocks.resolveRunDir).toHaveBeenCalledWith('exec-headless');
+    expect(mocks.findRunDir).toHaveBeenCalledWith('exec-headless');
   });
 
   it('returns null when neither the snapshot nor the run directory has outputs', async () => {
     const emptyDir = await makeTempDir();
 
     mocks.listExecutions.mockResolvedValue([matchingExecution('exec-empty')]);
-    mocks.resolveRunDir.mockResolvedValue(emptyDir);
+    mocks.findRunDir.mockResolvedValue(emptyDir);
 
     const result = await discoverLatestExecutionOutputs({
       agent: 'polish',

--- a/src/test-kernel/platform/WorkspaceStorage.vitest.ts
+++ b/src/test-kernel/platform/WorkspaceStorage.vitest.ts
@@ -16,9 +16,17 @@ import { afterEach, describe, expect, it } from 'vitest';
 // Local imports - platform
 import { createNodeStorageProvider } from '@platform/defaults/nodeStorage';
 import {
+  LEGACY_RUNS_STORAGE_DIR,
+  MEMORY_STORAGE_DIR,
+  resolveExistingRunStoragePath,
   WorkspaceStorageProvider,
   resolveGlobalStoragePath,
+  resolveLegacyRunStoragePath,
+  resolveMemoryStoragePath,
+  resolveRunOriginalSnapshotPath,
+  resolveRunStoragePath,
   resolveWorkspaceStoragePath,
+  RUNS_STORAGE_DIR,
   workspaceStorageId,
 } from '@platform/defaults/workspaceStorage';
 
@@ -71,13 +79,45 @@ describe('workspace storage defaults', () => {
     expect(workspaceStorageId(undefined)).toMatch(/^no-workspace-[0-9a-f]{8}$/);
   });
 
-  it('resolves global and workspace storage paths from one root', async () => {
+  it('snapshots global, workspace, memory, and run storage layout paths', async () => {
     const root = await makeTempDir();
     const workspacePath = '/workspace/a';
+    const existingCurrent = await resolveExistingRunStoragePath(
+      ['run-1', 'result.json'],
+      async (storagePath) => storagePath === 'executions/run-1/result.json',
+    );
+    const existingLegacy = await resolveExistingRunStoragePath(
+      ['legacy-run'],
+      async (storagePath) => storagePath === 'taskRuns/legacy-run',
+    );
 
-    expect(resolveGlobalStoragePath(root)).toBe(join(root, 'global-storage'));
-    expect(resolveWorkspaceStoragePath(root, workspacePath)).toBe(
+    expect([
+      resolveGlobalStoragePath(root),
+      resolveWorkspaceStoragePath(root, workspacePath),
+      MEMORY_STORAGE_DIR,
+      resolveMemoryStoragePath('memories/project.md'),
+      RUNS_STORAGE_DIR,
+      resolveRunStoragePath('run-1', 'result.json'),
+      resolveRunOriginalSnapshotPath('run-1', 'Draft/Draft.tex'),
+      LEGACY_RUNS_STORAGE_DIR,
+      resolveLegacyRunStoragePath('legacy-run'),
+      existingCurrent,
+      existingLegacy,
+    ]).toEqual([
+      join(root, 'global-storage'),
       join(root, 'workspace-storage', workspaceStorageId(workspacePath)),
+      'memories',
+      'memories/project.md',
+      'executions',
+      'executions/run-1/result.json',
+      'executions/run-1/original/Draft/Draft.tex',
+      'taskRuns',
+      'taskRuns/legacy-run',
+      'executions/run-1/result.json',
+      'taskRuns/legacy-run',
+    ]);
+    expect(() => resolveMemoryStoragePath('not-memories/project.md')).toThrow(
+      'Invalid memory path',
     );
   });
 

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -52,8 +52,8 @@ import {
 import { filterNotNull } from '@utils/core';
 import { formatResultCount, pluralize } from '@utils/text/stringUtils';
 import {
+  findExistingRunStoragePath,
   getOriginalSnapshotPath,
-  resolveStoragePath,
 } from '@utils/files/taskRunStorage';
 
 // ============================================================================
@@ -137,7 +137,7 @@ Optional:
     const { execution_id: executionId, files, strip_criticize } = input;
     const runtimeHost = requireRuntimeHost('accept_run_files');
 
-    const runDir = await resolveStoragePath(executionId);
+    const runDir = await findExistingRunStoragePath(executionId);
     const runDirExists = runDir !== undefined;
 
     // Verify execution exists — run dir may not exist in workspace storage mode
@@ -344,7 +344,7 @@ Optional:
   ): Promise<{ sourceAbsolute: string; sourceLocation: FileLocation }> {
     // Try run storage first (primary then legacy)
     if (runDirExists) {
-      const rel = await resolveStoragePath(executionId, runPath);
+      const rel = await findExistingRunStoragePath(executionId, runPath);
       if (rel) {
         const abs = StorageFS.fullPath(rel);
         // Symlinks in run storage mean the round didn't emit the file —

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -48,7 +48,7 @@ import { assertNoParentTraversal } from '@tools/pathResolution';
 import { AbsoluteFS, StorageFS } from '@utils/files';
 import { clamp, unique } from '@utils/core';
 import { isDirectory } from '@utils/files/fsEntryType';
-import { resolveStoragePath } from '@utils/files/taskRunStorage';
+import { findExistingRunStoragePath } from '@utils/files/taskRunStorage';
 import { getPathSegments } from '@utils/core/pathCore';
 import {
   formatResultCount,
@@ -821,7 +821,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
   }
 
   private async listFiles(executionId: ExecutionId): Promise<ToolResult> {
-    const runDir = await resolveStoragePath(executionId);
+    const runDir = await findExistingRunStoragePath(executionId);
     if (!runDir) {
       return {
         status: 'executed',
@@ -856,7 +856,7 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
   ): Promise<ToolResult> {
     const displayPath = `/executions/${executionId}/files/${filePath}`;
     assertNoParentTraversal(filePath);
-    const fullPath = await resolveStoragePath(executionId, filePath);
+    const fullPath = await findExistingRunStoragePath(executionId, filePath);
     if (!fullPath) {
       throw new ToolError(`File not found: ${displayPath}`);
     }

--- a/src/tools/OpenPdfTool.ts
+++ b/src/tools/OpenPdfTool.ts
@@ -1,6 +1,3 @@
-// Standard library imports
-import * as path from 'node:path';
-
 // Third-party imports
 import { z } from 'zod';
 
@@ -9,20 +6,19 @@ import { tryUseRunContext } from '@agent/runtime/RunContext';
 
 // Type imports
 import type { FileLocation } from '@shared/schemas';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 
 // Local imports - tools
 import {
   currentToolRoot,
   resolveWorkspaceRelativePath,
 } from '@tools/pathResolution';
-import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 
 // Local imports - utilities
 import {
   AbsoluteFS,
-  createRunStorageLocation,
-  getRunDir,
   pathToLocation,
+  runStorageLocationFromAbsolutePath,
 } from '@utils/files';
 import { hasExtension } from '@utils/core/pathCore';
 
@@ -97,7 +93,10 @@ function resolvePdfLocation(rawPath: string): FileLocation {
     throw new ToolError('path is required.');
   }
 
-  const runStorageLocation = resolveRunStorageLocation(trimmed);
+  const executionId = tryUseRunContext()?.executionId;
+  const runStorageLocation = executionId
+    ? runStorageLocationFromAbsolutePath(trimmed, executionId)
+    : undefined;
   if (runStorageLocation) {
     return runStorageLocation;
   }
@@ -105,27 +104,6 @@ function resolvePdfLocation(rawPath: string): FileLocation {
   const root = currentToolRoot();
   const resolved = resolveWorkspaceRelativePath(trimmed, root);
   return pathToLocation(resolved.absolute);
-}
-
-function resolveRunStorageLocation(rawPath: string): FileLocation | undefined {
-  if (!path.isAbsolute(rawPath)) return undefined;
-
-  const executionId = tryUseRunContext()?.executionId;
-  if (!executionId) return undefined;
-
-  const runDirectory = getRunDir(executionId);
-  const relativePath = path
-    .relative(runDirectory, rawPath)
-    .replaceAll('\\', '/');
-  if (
-    relativePath.startsWith('..') ||
-    path.isAbsolute(relativePath) ||
-    relativePath === ''
-  ) {
-    return undefined;
-  }
-
-  return createRunStorageLocation(rawPath, relativePath, executionId);
 }
 
 function displayPdfLocation(location: FileLocation): string {

--- a/src/tools/memory/constants.ts
+++ b/src/tools/memory/constants.ts
@@ -1,34 +1,19 @@
-/**
- * Shared constants for memory tool and memory view.
- * Single source of truth for memory-related paths and limits.
- *
- * Memory is shared across all agents in a session (orchestrator and subagents).
- */
+import { MEMORY_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 
-/** Virtual path prefix shown to users and models (e.g., /memories/notes.md) */
 export const MEMORY_DISPLAY_ROOT = '/memories';
 
-/** Physical storage path relative to workspace storage (e.g., memories/notes.md) */
-export const MEMORY_STORAGE_ROOT = 'memories';
+export const MEMORY_STORAGE_ROOT = MEMORY_STORAGE_DIR;
 
-/** Maximum lines to display in tool view output */
 export const MAX_VIEW_LINES = 999_999;
 
-/** Maximum directory depth for listings */
 export const DIRECTORY_LISTING_DEPTH = 2;
 
-/** Maximum preview lines for memory view UI */
 export const MAX_PREVIEW_LINES = 120;
 
-/** Maximum preview characters for memory view UI */
 export const MAX_PREVIEW_CHARS = 8000;
 
-/** Maximum number of pinned memories allowed */
 export const MAX_PINNED_MEMORIES = 10;
 
-/**
- * Check if a directory entry should be skipped during traversal.
- */
 export function shouldSkipEntry(name: string): boolean {
   return name.startsWith('.') || name === 'node_modules';
 }

--- a/src/tools/memory/memoryUtils.ts
+++ b/src/tools/memory/memoryUtils.ts
@@ -1,26 +1,13 @@
-/**
- * Shared utilities for memory tool and memory view.
- */
 import * as path from 'node:path';
 
+import {
+  resolveMemoryStoragePath,
+  resolveMemoryStorageRelativePath,
+} from '@platform/defaults/workspaceStorage';
 import { normalizeFilePath } from '@shared/utils/path';
 
 import { MEMORY_DISPLAY_ROOT, MEMORY_STORAGE_ROOT } from './constants';
 
-/**
- * Build a storage path from a relative path within the memory root.
- */
-function toStoragePath(relative: string): string {
-  return relative
-    ? path.join(MEMORY_STORAGE_ROOT, relative)
-    : MEMORY_STORAGE_ROOT;
-}
-
-/**
- * Convert a relative path (within memories) to a display path.
- * @param relativePath - Path relative to memories folder (e.g., "notes.md")
- * @returns Display path with virtual prefix (e.g., "/memories/notes.md")
- */
 export function relativeToDisplayPath(relativePath: string): string {
   if (!relativePath) {
     return MEMORY_DISPLAY_ROOT;
@@ -28,21 +15,11 @@ export function relativeToDisplayPath(relativePath: string): string {
   return `${MEMORY_DISPLAY_ROOT}/${normalizeFilePath(relativePath)}`;
 }
 
-/**
- * Convert a storage path to a display path.
- * @param storagePath - Path relative to storage root (e.g., "memories/notes.md")
- * @returns Display path with virtual prefix (e.g., "/memories/notes.md")
- */
 export function toDisplayPath(storagePath: string): string {
   const relative = path.relative(MEMORY_STORAGE_ROOT, storagePath);
   return relativeToDisplayPath(relative);
 }
 
-/**
- * Format bytes to human-readable size string.
- * @param bytes - Size in bytes
- * @returns Formatted string (e.g., "1.5K", "2.3M")
- */
 export function formatSize(bytes: number): string {
   if (bytes < 1024) {
     return `${bytes}B`;
@@ -58,37 +35,6 @@ export function formatSize(bytes: number): string {
   return `${value.toFixed(1)}${units[unitIndex]}`;
 }
 
-/**
- * Validate that a relative path stays within the memory root (no escaping via ..).
- * @param relative - Relative path to validate
- * @param originalPath - Original path for error messages
- * @throws Error if path escapes the memory storage root
- */
-function validateRelativePath(relative: string, originalPath: string): void {
-  if (relative.startsWith('..') || path.isAbsolute(relative)) {
-    throw new Error(`Invalid memory path: ${originalPath}`);
-  }
-}
-
-/**
- * Validate and resolve a storage path, ensuring it stays within MEMORY_STORAGE_ROOT.
- * @param storagePath - Path to validate (should be within memories/)
- * @returns Resolved path within MEMORY_STORAGE_ROOT
- * @throws Error if path escapes the memory storage root
- */
-export function resolveMemoryStoragePath(storagePath: string): string {
-  const normalized = path.normalize(storagePath);
-  const relative = path.relative(MEMORY_STORAGE_ROOT, normalized);
-  validateRelativePath(relative, storagePath);
-  return toStoragePath(relative);
-}
-
-/**
- * Convert a display path to a storage path.
- * @param displayPath - Virtual path (e.g., "/memories/notes.md")
- * @returns Storage path (e.g., "memories/notes.md")
- * @throws Error if path is outside the memory namespace
- */
 export function displayToStoragePath(displayPath: string): string {
   if (
     displayPath !== MEMORY_DISPLAY_ROOT &&
@@ -105,6 +51,5 @@ export function displayToStoragePath(displayPath: string): string {
   const resolved = path.resolve(MEMORY_STORAGE_ROOT, suffix);
   const base = path.resolve(MEMORY_STORAGE_ROOT);
   const relative = path.relative(base, resolved);
-  validateRelativePath(relative, displayPath);
-  return toStoragePath(relative);
+  return resolveMemoryStoragePath(resolveMemoryStorageRelativePath(relative));
 }

--- a/src/utils/files/runStorageFs.ts
+++ b/src/utils/files/runStorageFs.ts
@@ -2,98 +2,77 @@
 import * as path from 'node:path';
 import { promises as fs } from 'node:fs';
 
+import {
+  LEGACY_RUNS_STORAGE_DIR,
+  resolveExistingRunStoragePath,
+  resolveRunOriginalSnapshotPath,
+  resolveRunStoragePath,
+  resolveRunStorageRelativePath,
+  RUNS_STORAGE_DIR,
+} from '@platform/defaults/workspaceStorage';
 import { isFileNotFoundError, toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
-import { type ExecutionId } from '@shared/schemas';
+import { type ExecutionId, type RunStorageFileLocation } from '@shared/schemas';
 import { getPathSegments } from '@utils/core/pathCore';
+import { createRunStorageLocation } from './fileLocation';
 import { StorageFS } from './storageFS';
 
 export const CHANNEL = 'taskRunStorage';
 
-/**
- * Directory for all per-execution artifacts (KV data, debug JSONs, logs, workflow outputs, etc.).
- * NOTE: This is 'executions', NOT 'taskRuns'. Name kept for import compatibility;
- * the legacy 'taskRuns' directory is LEGACY_RUNS_DIR below.
- */
-export const TASK_RUNS_DIR = 'executions';
+export const TASK_RUNS_DIR = RUNS_STORAGE_DIR;
 
-/** Legacy directory name — checked as read fallback for pre-consolidation data. */
-export const LEGACY_RUNS_DIR = 'taskRuns';
+export const LEGACY_RUNS_DIR = LEGACY_RUNS_STORAGE_DIR;
 
-/**
- * Get the full path to a specific execution's run directory.
- * @param id - The execution ID
- * @returns The full path to the run directory (always under TASK_RUNS_DIR)
- */
 export function getRunDir(id: ExecutionId): string {
-  return StorageFS.fullPath(path.join(TASK_RUNS_DIR, id));
+  return StorageFS.fullPath(resolveRunStoragePath(id));
 }
 
-/**
- * Absolute path of the immutable pre-run snapshot for a base file. The
- * snapshot is captured by {@link TaskRunFileService.prepareRunWorkspace}
- * before any agent modifications, so diffs against it remain accurate
- * even for in-place workflows where the live workspace file has since
- * been overwritten by the agent.
- *
- * Returns the candidate path unconditionally; callers should `stat` it
- * before reading because `prepareRunWorkspace` skips files that were
- * absent or non-regular at snapshot time.
- */
 export function getOriginalSnapshotPath(
   executionId: ExecutionId,
   workspaceRelativePath: string,
 ): string {
   return StorageFS.fullPath(
-    path.join(TASK_RUNS_DIR, executionId, 'original', workspaceRelativePath),
+    resolveRunOriginalSnapshotPath(executionId, workspaceRelativePath),
   );
 }
 
-/**
- * Resolve a storage-relative path, checking `executions/` first then
- * legacy `taskRuns/`. Returns the storage-relative path that exists,
- * or `undefined` if neither location has the target.
- */
-export async function resolveStoragePath(
+export async function findExistingRunStoragePath(
   ...segments: string[]
 ): Promise<string | undefined> {
-  const primary = path.join(TASK_RUNS_DIR, ...segments);
-  if (await StorageFS.exists(primary)) return primary;
-  const legacy = path.join(LEGACY_RUNS_DIR, ...segments);
-  if (await StorageFS.exists(legacy)) return legacy;
-  return undefined;
+  return resolveExistingRunStoragePath(
+    segments,
+    StorageFS.exists.bind(StorageFS),
+  );
 }
 
-/**
- * Resolve the full filesystem path for an execution's run directory,
- * checking `executions/` first then legacy `taskRuns/`.
- * Returns `undefined` if neither location exists.
- */
-export async function resolveRunDir(
-  id: ExecutionId,
-): Promise<string | undefined> {
-  const rel = await resolveStoragePath(id);
+export async function findRunDir(id: ExecutionId): Promise<string | undefined> {
+  const rel = await findExistingRunStoragePath(id);
   return rel ? StorageFS.fullPath(rel) : undefined;
 }
 
-/**
- * Ensure an execution's run directory exists, creating it if necessary.
- * Also ensures the parent executions directory exists.
- * @param id - The execution ID
- */
 export async function ensureRunDir(id: ExecutionId): Promise<void> {
   await StorageFS.ensureDir(TASK_RUNS_DIR);
-  await StorageFS.ensureDir(path.join(TASK_RUNS_DIR, id));
+  await StorageFS.ensureDir(resolveRunStoragePath(id));
 }
 
-/**
- * @internal Used internally by TaskRunFileService
- */
 export function getRunStorageAbsolutePath(
   id: ExecutionId,
   workspaceRelative: string,
 ): string {
-  return StorageFS.fullPath(path.join(TASK_RUNS_DIR, id, workspaceRelative));
+  return StorageFS.fullPath(resolveRunStoragePath(id, workspaceRelative));
+}
+
+export function runStorageLocationFromAbsolutePath(
+  absolutePath: string,
+  executionId: ExecutionId,
+): RunStorageFileLocation | undefined {
+  if (!path.isAbsolute(absolutePath)) return undefined;
+  const relativePath = resolveRunStorageRelativePath(
+    absolutePath,
+    getRunDir(executionId),
+  );
+  if (!relativePath) return undefined;
+  return createRunStorageLocation(absolutePath, relativePath, executionId);
 }
 
 export async function ensureParentDir(filePath: string): Promise<void> {

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -40,8 +40,9 @@ export {
   getOriginalSnapshotPath,
   getRunDir,
   LEGACY_RUNS_DIR,
-  resolveRunDir,
-  resolveStoragePath,
+  findRunDir,
+  findExistingRunStoragePath,
+  runStorageLocationFromAbsolutePath,
   TASK_RUNS_DIR,
 } from './runStorageFs';
 
@@ -183,20 +184,7 @@ export class TaskRunFileService {
     }
   }
 
-  /**
-   * Create a FileLocation for a workflow output file. Routes to run storage
-   * when an executionId is available (the normal case); falls back to the
-   * workspace only when no execution context exists (e.g., ad-hoc utility
-   * calls made before any run is registered).
-   *
-   * Accepts both absolute and workspace-relative paths. Absolute paths
-   * within the workspace are converted to relative paths internally. Paths
-   * outside the workspace are returned as external locations. Path
-   * normalization is handled internally.
-   *
-   * @param inputPath - Absolute or workspace-relative path
-   * @returns FileLocation (runStorage, workspace, or external)
-   */
+  /** Create a FileLocation for a workflow output file. */
   public createLocation(inputPath: string): FileLocation {
     const resolved = WorkspaceFS.locatePath(inputPath);
 
@@ -206,8 +194,8 @@ export class TaskRunFileService {
 
     const executionId = this.metadata.executionId;
     if (executionId) {
-      const runAbsolute = path.join(
-        getRunDir(executionId),
+      const runAbsolute = getRunStorageAbsolutePath(
+        executionId,
         resolved.relativePath,
       );
       return createRunStorageLocation(
@@ -312,8 +300,6 @@ export class TaskRunFileService {
       return;
     }
 
-    const runDir = getRunDir(executionId);
-
     await Promise.all(
       [...this.mirroredDependencies].map(async (relativePath) => {
         // A dep whose path ends at `output.{ext}` (no subdirectory within the
@@ -341,8 +327,14 @@ export class TaskRunFileService {
         // (cls/sty/bib/figures) have no snapshot and fall through to the
         // workspace mirror at `runDir/<rel>`, which is correct — those
         // are never written to.
-        const snapshotAbsolute = path.join(runDir, 'original', relativePath);
-        const workspaceMirrorAbsolute = path.join(runDir, relativePath);
+        const snapshotAbsolute = getRunStorageAbsolutePath(
+          executionId,
+          path.join('original', relativePath),
+        );
+        const workspaceMirrorAbsolute = getRunStorageAbsolutePath(
+          executionId,
+          relativePath,
+        );
         let sourceAbsolute = workspaceMirrorAbsolute;
         try {
           await fs.stat(snapshotAbsolute);
@@ -355,10 +347,9 @@ export class TaskRunFileService {
             );
           }
         }
-        const destinationAbsolute = path.join(
-          runDir,
-          relativeDirectory,
-          relativePath,
+        const destinationAbsolute = getRunStorageAbsolutePath(
+          executionId,
+          path.join(relativeDirectory, relativePath),
         );
 
         // Guard against clobbering a real file already written to the round


### PR DESCRIPTION
## Summary

Centralizes TeXRA storage layout path construction in `src/platform/defaults/workspaceStorage.ts` and routes memory, run-storage, CLI memory, settings memory, OpenPdf, latexdiff discovery, executions, accept-run-files, and housekeeping callers through that owner.

I re-verified #6998 against current `origin/main` and recorded drift on the issue: several cited run-storage resolver names moved or no longer exist in the cited file, while the storage-layout spread remains live.

## Issue acceptance gates

- #6998: the storage directory tree is owned as data by `src/platform/defaults/workspaceStorage.ts` (`STORAGE_LAYOUT`, memory path helpers, run path helpers, and current-then-legacy run fallback candidates).
- #6998: old non-owner resolver names are gone from production (`resolveCliMemoryStoragePath`, `resolveRunStorageLocation`, `resolveRunStorageSourceDir`, run-storage `resolveRunDir`/`resolveStoragePath` wrappers).
- #6998: legacy workspace migration remains in one workspace-layout function, and run-storage current-vs-legacy fallback is decided by one layout helper.
- #6998: storage paths remain byte-identical, covered by the layout snapshot test in `WorkspaceStorage.vitest.ts` plus existing persistence/path tests.
- #6998: net LoC is negative: committed diff is 233 insertions / 241 deletions (net -8).
- #6998: #6981 ledger row will track the pre-existing legacy workspace/run storage fallbacks with an explicit removal trigger.

## Single source of truth

`src/platform/defaults/workspaceStorage.ts` is now the single source of truth for TeXRA storage layout names and path construction: global storage, workspace storage, memory storage, run storage, legacy run storage, original snapshots, and current-then-legacy run fallback candidates.

## Duplication and abstraction budget

Removed local layout decisions from memory utilities, CLI memory parsing, run-storage helpers, OpenPdf, latexdiff source lookup, and run-directory consumers. No new service wrapper or host-specific layout layer was added; the new functions own the invariant that path strings are constructed from the layout table once and remain byte-compatible with existing storage.

## Host impact

Extension: settings memory and progress workflow file actions route through the shared layout helpers; storage paths and UI behavior are unchanged.

Desktop: settings memory routes through the shared layout helper; storage paths and behavior are unchanged.

CLI: memory commands and history/generated-file discovery use the shared layout helpers; `texra run`, `--print`, and JSON output behavior are unchanged.

## Scheduled refactoring

#6981 ledger row for legacy workspace/run storage fallbacks; removal trigger: D3/Checkpoint C after the support window for hash-only workspace storage directories and `taskRuns/` persisted runs expires.

## Validation

- `corepack pnpm exec prettier --write $(git diff --name-only --diff-filter=ACM)`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/platform/WorkspaceStorage.vitest.ts src/test-kernel/cli/CliMemory.vitest.mts src/test-kernel/tools/OpenPdfTool.vitest.ts src/test-kernel/latex/OutputDiscovery.vitest.mts src/test-kernel/controllers/SettingsMemoryController.vitest.ts src/test-kernel/utils/RoundDirOwnership.vitest.ts src/test-kernel/cli/History.vitest.mts`
- `npm run typecheck`
- `npm test`
- `npm run lint` (passes with 15 pre-existing warnings, none in touched files)
- `npm run compile:fast`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `git diff --check`
- `rg -n "resolveCliMemoryStoragePath|resolveRunStorageLocation|resolveRunStorageSourceDir|resolveRunDir|resolveStoragePath\(|resolveStoragePath:|rootModelSelection" src packages -g'*.ts' -g'*.mts'` (no hits)
- `grep -rn 'texra' src packages/*/src --include='*.ts' | grep -i 'join.*storage\|storagePath'` (test/support hits only; no production layout construction outside the owner)

Closes #6998