### PR TITLE
refactor: simplification sweep over recently-refactored code (post-0.39.1)

### DIFF
--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -81,12 +81,8 @@ function runFormSelection<T>({
     onDone(value);
   }
 
-  const runAction = (): Promise<void> => {
-    try {
-      return Promise.resolve(action());
-    } catch (error: unknown) {
-      return Promise.reject(error);
-    }
+  const runAction = async (): Promise<void> => {
+    await action();
   };
 
   void runAction()

--- a/packages/cli/src/chat/tui/state/completedProcessTranscript.ts
+++ b/packages/cli/src/chat/tui/state/completedProcessTranscript.ts
@@ -5,6 +5,7 @@ import {
   completedChildExecutionStatus,
   isChildExecutionErrorStatus,
 } from './childExecutionStatus';
+import { processTailLines } from './childControls';
 import { childExecutionLabel } from './childExecutions';
 import { TOOL_OUTPUT_CORNER } from '../ui/glyphs';
 import type {
@@ -18,13 +19,8 @@ export const COMPLETED_PROCESS_TAIL_LINES = 20;
 
 function completedProcessTailLines(
   tail: ProcessOutputTail | undefined,
-): string[] {
-  if (!tail) return [];
-  return `${tail.stdout}\n${tail.stderr}`
-    .split('\n')
-    .map((line) => line.trimEnd())
-    .filter((line) => line.length > 0)
-    .slice(-COMPLETED_PROCESS_TAIL_LINES);
+): readonly string[] {
+  return processTailLines(tail).slice(-COMPLETED_PROCESS_TAIL_LINES);
 }
 
 export function buildCompletedProcessTranscript(

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -862,14 +862,17 @@ export class DesktopProgressBridge {
     return this.session.status.getAllSubstates();
   }
 
-  syncFullView(): void {
-    const activeStream = this.backend.webviewUpdater.sendStreamMetadata(
+  private updateStreamMetadata(): StreamTabId | '' {
+    return this.backend.webviewUpdater.sendStreamMetadata(
       this.state,
       this.streamStatusSnapshot(),
       undefined,
       this.streamSubstateSnapshot(),
     );
-    this.syncStreamContent(activeStream);
+  }
+
+  syncFullView(): void {
+    this.syncStreamContent(this.updateStreamMetadata());
   }
 
   setActiveStream(streamId: StreamTabId): void {
@@ -881,25 +884,14 @@ export class DesktopProgressBridge {
       this.state.releasePreviousActive(previous);
     }
     this.state.activeStream = streamId;
-    this.backend.webviewUpdater.sendStreamMetadata(
-      this.state,
-      this.streamStatusSnapshot(),
-      undefined,
-      this.streamSubstateSnapshot(),
-    );
+    this.updateStreamMetadata();
     this.backend.webviewUpdater.setActiveStream(streamId);
     this.syncStreamContent(streamId);
   }
 
   private setAgentFilter(filter: AgentCategoryFilter): void {
     this.state.agentCategoryFilter = filter;
-    const activeStream = this.backend.webviewUpdater.sendStreamMetadata(
-      this.state,
-      this.streamStatusSnapshot(),
-      undefined,
-      this.streamSubstateSnapshot(),
-    );
-    this.syncStreamContent(activeStream);
+    this.syncStreamContent(this.updateStreamMetadata());
   }
 
   async deleteStream(streamId: StreamTabId): Promise<void> {
@@ -924,13 +916,7 @@ export class DesktopProgressBridge {
       command: PROGRESS_VIEW_COMMANDS.DELETE_STREAM,
       stream: streamId,
     });
-    const activeStream = this.backend.webviewUpdater.sendStreamMetadata(
-      this.state,
-      this.streamStatusSnapshot(),
-      undefined,
-      this.streamSubstateSnapshot(),
-    );
-    this.syncStreamContent(activeStream);
+    this.syncStreamContent(this.updateStreamMetadata());
   }
 
   async deleteAllStreams(): Promise<void> {
@@ -967,12 +953,7 @@ export class DesktopProgressBridge {
     this.clearDesktopSessionMaps();
     this.workflowFileActions.clearAllBackups();
     this.send({ command: PROGRESS_VIEW_COMMANDS.DELETE_ALL });
-    this.backend.webviewUpdater.sendStreamMetadata(
-      this.state,
-      this.streamStatusSnapshot(),
-      undefined,
-      this.streamSubstateSnapshot(),
-    );
+    this.updateStreamMetadata();
   }
 
   private syncStreamContent(streamId: StreamTabId | ''): void {

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -368,6 +368,20 @@ function createWindow(options: {
     });
     await showSetupCommandResult(window, command, result);
   };
+  // `installDesktopHostBridge.postToRenderer` is itself a no-op when
+  // `webContents.isDestroyed()`. Without checking that here too, callers would
+  // falsely report success and skip their external-viewer fallback. Bot
+  // review (#3816) caught it. Shared by the preview host and agent-execution
+  // wiring below; the diff host keeps its own narrower check (no
+  // `webContents.isDestroyed()`) per bot review #3815, so it is not folded in.
+  const postToRendererIfAlive = (message: unknown): boolean => {
+    const ipc = ipcRef.current;
+    if (!ipc || window.isDestroyed() || window.webContents.isDestroyed()) {
+      return false;
+    }
+    ipc.postToRenderer(message);
+    return true;
+  };
   const previewHost = createDesktopPreviewHost({
     shell,
     showErrorMessage,
@@ -382,19 +396,7 @@ function createWindow(options: {
     // race) or the BrowserWindow has been destroyed; the host then
     // falls back to the external viewer so previews never silently
     // disappear.
-    postToRenderer: (message) => {
-      const ipc = ipcRef.current;
-      if (!ipc) return false;
-      // `installDesktopHostBridge.postToRenderer` is itself a no-op when
-      // `webContents.isDestroyed()`. Without checking that here too, this
-      // wrapper would falsely report success and the preview host would
-      // skip the external-viewer fallback. Bot review (#3816) caught it.
-      if (window.isDestroyed() || window.webContents.isDestroyed()) {
-        return false;
-      }
-      ipc.postToRenderer(message);
-      return true;
-    },
+    postToRenderer: postToRendererIfAlive,
   });
   const refreshDesktopAuthSurfaces = async () => {
     const authenticated = await SupabaseClient.isAuthenticated();
@@ -463,14 +465,7 @@ function createWindow(options: {
   };
   attachRendererConsoleLog(window.webContents);
   const agentExecutionOptions: DesktopAgentExecutionOptions = {
-    postToRenderer: (message) => {
-      const ipc = ipcRef.current;
-      if (!ipc || window.isDestroyed() || window.webContents.isDestroyed()) {
-        return false;
-      }
-      ipc.postToRenderer(message);
-      return true;
-    },
+    postToRenderer: postToRendererIfAlive,
     opener: previewHost,
     diff: createDesktopDiffHost({
       openPath: previewHost.openPath,

--- a/src/agent/core/state/AgentWorkspaceState.ts
+++ b/src/agent/core/state/AgentWorkspaceState.ts
@@ -328,19 +328,10 @@ export class WorkPlanState {
 }
 
 const AgentWorkspaceSnapshotFieldsSchema = z.object({
-  assembly: ResponseAssemblyStateSchema.prefault({
-    lastResponse: '',
-    accumulatedOutput: '',
-  }),
-  media: MediaAttachmentStateSnapshotSchema.prefault({ files: [] }),
-  reasoning: ReasoningCacheStateSchema.prefault({
-    thinkingBlocks: [],
-    thinkingAdded: false,
-  }),
-  interactions: FileInteractionStateSnapshotSchema.prefault({
-    readFiles: [],
-    edits: [],
-  }),
+  assembly: ResponseAssemblyStateSchema.prefault({}),
+  media: MediaAttachmentStateSnapshotSchema.prefault({}),
+  reasoning: ReasoningCacheStateSchema.prefault({}),
+  interactions: FileInteractionStateSnapshotSchema.prefault({}),
   workPlan: WorkPlanSnapshotSchema,
 });
 

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -139,12 +139,11 @@ export async function runReflectionFlow<C = unknown>(
 
   const latexMediaManager = new LatexMediaManager(logger, fileService);
 
-  let requestCount: number;
-  if (Array.isArray(prompt.userRequest)) {
-    requestCount = prompt.userRequest.length;
-  } else {
-    requestCount = prompt.userRequest ? 1 : 0;
-  }
+  const requestCount = Array.isArray(prompt.userRequest)
+    ? prompt.userRequest.length
+    : prompt.userRequest
+      ? 1
+      : 0;
   const totalRounds = Math.max(setting.rounds ?? 2, requestCount);
 
   const getOutputFileLocation =

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -1189,14 +1189,6 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
   }
 
   /**
-   * Reconstruct the model-generated steps of the just-finished turn: the
-   * thought steps (carrying their signatures, sourced from the reasoning cache
-   * populated by `processThinkingBlock`), optional assistant text, then the
-   * function-call steps. Carried verbatim in the transcript so the backend can
-   * validate reasoning across tool turns (resent each round in stateless mode;
-   * retained server-side once sent in chained mode).
-   */
-  /**
    * Build a `thought` step from an optional signature and thinking summary, or
    * `undefined` when both are empty (an empty thought step is noise on the wire).
    */
@@ -1212,6 +1204,14 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
     } satisfies ThoughtStep;
   }
 
+  /**
+   * Reconstruct the model-generated steps of the just-finished turn: the
+   * thought steps (carrying their signatures, sourced from the reasoning cache
+   * populated by `processThinkingBlock`), optional assistant text, then the
+   * function-call steps. Carried verbatim in the transcript so the backend can
+   * validate reasoning across tool turns (resent each round in stateless mode;
+   * retained server-side once sent in chained mode).
+   */
   private buildAssistantTurnSteps(
     calls: GoogleToolCall[],
     workspaceState: AgentWorkspaceState | undefined,

--- a/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
+++ b/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
@@ -48,10 +48,6 @@ interface AnthropicStreamState {
   pendingSearches: Map<string, { index: number; input: string }>;
   /** Track web fetch: tool_use_id → { index, accumulated input JSON } */
   pendingFetches: Map<string, { index: number; input: string }>;
-  /** Track emitted search IDs to prevent duplicate logging in flow */
-  emittedSearchIds: Set<string>;
-  /** Track emitted fetch IDs to prevent duplicate logging in flow */
-  emittedFetchIds: Set<string>;
   /** Flag to prevent processing events after finalize */
   finalized: boolean;
 }
@@ -111,8 +107,6 @@ export class AnthropicStreamHandler {
     lastBlockIndex: -1,
     pendingSearches: new Map(),
     pendingFetches: new Map(),
-    emittedSearchIds: new Set(),
-    emittedFetchIds: new Set(),
     finalized: false,
   };
   private readonly diagnostics: StreamDiagnosticsState = {
@@ -143,20 +137,6 @@ export class AnthropicStreamHandler {
     stream.on('streamEvent', (event: BetaRawMessageStreamEvent) => {
       this.handleStreamEvent(event);
     });
-  }
-
-  /**
-   * Gets the set of emitted search IDs for duplicate prevention in flow.
-   */
-  getEmittedSearchIds(): Set<string> {
-    return this.state.emittedSearchIds;
-  }
-
-  /**
-   * Gets the set of emitted fetch IDs for duplicate prevention in flow.
-   */
-  getEmittedFetchIds(): Set<string> {
-    return this.state.emittedFetchIds;
   }
 
   /**
@@ -206,8 +186,6 @@ export class AnthropicStreamHandler {
     // Clear state to prevent memory leaks
     this.state.pendingSearches.clear();
     this.state.pendingFetches.clear();
-    this.state.emittedSearchIds.clear();
-    this.state.emittedFetchIds.clear();
   }
 
   /**
@@ -373,7 +351,6 @@ export class AnthropicStreamHandler {
         callId: block.tool_use_id,
         status: 'completed',
       });
-      this.state.emittedSearchIds.add(block.tool_use_id);
     }
 
     // Clean up
@@ -412,7 +389,6 @@ export class AnthropicStreamHandler {
     // Emit to progress view
     if (result.url || result.status === 'failed') {
       this.emitWebFetchResult(result);
-      this.state.emittedFetchIds.add(block.tool_use_id);
     }
 
     // Clean up

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -279,9 +279,7 @@ export class StreamStatusMachine {
         substate: STREAM_SUBSTATE.STARTING,
       };
     }
-    const state = this.phases.get(stream);
-    if (state) return state;
-    return undefined;
+    return this.phases.get(stream);
   }
 
   private publishStatus(

--- a/src/common/errors/sdkError/errorMetadata.ts
+++ b/src/common/errors/sdkError/errorMetadata.ts
@@ -82,9 +82,7 @@ export function attachFlowAutoRetryRequired(err: unknown): void {
 export function requiresFlowAutoRetry(err: unknown): boolean {
   return (
     findInCauseChain(err, (current) =>
-      flowAutoRetryRequiredMetadata.detect(current) === true
-        ? true
-        : undefined,
+      flowAutoRetryRequiredMetadata.detect(current) === true ? true : undefined,
     ) ?? false
   );
 }

--- a/src/common/errors/sdkError/errorMetadata.ts
+++ b/src/common/errors/sdkError/errorMetadata.ts
@@ -1,6 +1,7 @@
 import { type ProviderError, type StreamDiagnostics } from '@shared/schemas';
 import { isObject, isString } from '@utils/core';
 
+import { findInCauseChain } from '../errorPredicates';
 import { type SdkErrorMetadata, isSdkErrorMetadata } from './sdkErrorKinds';
 
 /** Factory for symbol-keyed error metadata. Creates matched attach/detect
@@ -79,14 +80,13 @@ export function attachFlowAutoRetryRequired(err: unknown): void {
 }
 
 export function requiresFlowAutoRetry(err: unknown): boolean {
-  for (
-    let current: unknown = err;
-    current != null && typeof current === 'object';
-    current = (current as { cause?: unknown }).cause
-  ) {
-    if (flowAutoRetryRequiredMetadata.detect(current) === true) return true;
-  }
-  return false;
+  return (
+    findInCauseChain(err, (current) =>
+      flowAutoRetryRequiredMetadata.detect(current) === true
+        ? true
+        : undefined,
+    ) ?? false
+  );
 }
 
 export const providerErrorMetadata =

--- a/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
@@ -92,6 +92,15 @@ describe('accept_run_files progress events', () => {
     testApprovalHandler = undefined;
     await installTestPlatform();
     cleanupAllApprovals();
+    // Shared by every test below that stubs the execution/workspace paths;
+    // the test that doesn't need it (missing runtime host) fails before
+    // reaching either function.
+    StorageFS.fullPath = (target) => `${storagePath}/${target}`;
+    WorkspaceFS.locatePath = (target) => ({
+      kind: 'workspace',
+      absolutePath: `${workspacePath}/${target}`,
+      relativePath: target,
+    });
   });
 
   afterEach(() => {
@@ -117,12 +126,6 @@ describe('accept_run_files progress events', () => {
     StorageFS.exists = async (target) =>
       target === `executions/${executionId}` ||
       target === `executions/${executionId}/output.tex`;
-    StorageFS.fullPath = (target) => `${storagePath}/${target}`;
-    WorkspaceFS.locatePath = (target) => ({
-      kind: 'workspace',
-      absolutePath: `${workspacePath}/${target}`,
-      relativePath: target,
-    });
     WorkspaceFS.exists = async () => false;
     WorkspaceFS.read = async () => '';
     WorkspaceFS.write = async () => undefined;
@@ -168,12 +171,6 @@ describe('accept_run_files progress events', () => {
     let writes = 0;
 
     StorageFS.exists = async (target) => target === `executions/${executionId}`;
-    StorageFS.fullPath = (target) => `${storagePath}/${target}`;
-    WorkspaceFS.locatePath = (target) => ({
-      kind: 'workspace',
-      absolutePath: `${workspacePath}/${target}`,
-      relativePath: target,
-    });
     WorkspaceFS.exists = async () => true;
     WorkspaceFS.read = async () => 'new content';
     WorkspaceFS.write = async () => {
@@ -211,12 +208,6 @@ describe('accept_run_files progress events', () => {
     let writes = 0;
 
     StorageFS.exists = async (target) => target === `executions/${executionId}`;
-    StorageFS.fullPath = (target) => `${storagePath}/${target}`;
-    WorkspaceFS.locatePath = (target) => ({
-      kind: 'workspace',
-      absolutePath: `${workspacePath}/${target}`,
-      relativePath: target,
-    });
     WorkspaceFS.exists = async () => true;
     WorkspaceFS.read = async () => 'same content';
     WorkspaceFS.write = async () => {
@@ -251,12 +242,6 @@ describe('accept_run_files progress events', () => {
     StorageFS.exists = async (target) =>
       target === `executions/${executionId}` ||
       target === `executions/${executionId}/r1/Draft/appendices.tex`;
-    StorageFS.fullPath = (target) => `${storagePath}/${target}`;
-    WorkspaceFS.locatePath = (target) => ({
-      kind: 'workspace',
-      absolutePath: `${workspacePath}/${target}`,
-      relativePath: target,
-    });
     WorkspaceFS.exists = async () => true;
     WorkspaceFS.read = async () => '';
     WorkspaceFS.write = async () => {

--- a/src/test-kernel/agent/followUp/GitHubSubscriptionProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/GitHubSubscriptionProgressEvents.vitest.ts
@@ -36,8 +36,6 @@ class TestPollingSource extends PollingSourceBase<
   string,
   BasePollSubscriptionState
 > {
-  private keysChangedEventCount = 0;
-
   constructor() {
     super({
       name: 'TestPollingSource',
@@ -58,7 +56,7 @@ class TestPollingSource extends PollingSourceBase<
   }
 
   protected emitKeysChangedEvent(): void {
-    this.keysChangedEventCount += 1;
+    // No-op: this test double doesn't need to observe key-change events.
   }
 
   failWithAuthError(state: BasePollSubscriptionState): void {

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsChaining.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsChaining.vitest.ts
@@ -136,6 +136,21 @@ function userStep(text: string): Step {
   return { type: 'user_input', content: [{ type: 'text', text }] };
 }
 
+/** Shorthand for the `handler.createResponse({ client, messages, temperature: 0 })`
+ * call every test in this file makes (the fake `client` never matches the SDK
+ * client type, hence the `as never` cast). */
+function respond(
+  handler: ModelHandlerGoogleInteractions,
+  client: unknown,
+  messages: Step[],
+) {
+  return handler.createResponse({
+    client: client as never,
+    messages,
+    temperature: 0,
+  });
+}
+
 /** Extract the first text of a user_input/model_output step (for slice asserts). */
 function stepText(step: Step): string | undefined {
   return (step as { content?: { text?: string }[] }).content?.[0]?.text;
@@ -166,11 +181,7 @@ describe('ModelHandlerGoogleInteractions store:true chaining', () => {
     const client = capturingClient(calls, () => completedEvents('int_1'));
 
     const messages = [userStep('a'), userStep('b')];
-    await handler.createResponse({
-      client: client as never,
-      messages,
-      temperature: 0,
-    });
+    await respond(handler, client, messages);
 
     expect(calls).toHaveLength(1);
     expect(calls[0].store).toBe(true);
@@ -187,19 +198,11 @@ describe('ModelHandlerGoogleInteractions store:true chaining', () => {
 
     // Round 1: two steps sent in full, id captured.
     const messages: Step[] = [userStep('a'), userStep('b')];
-    await handler.createResponse({
-      client: client as never,
-      messages,
-      temperature: 0,
-    });
+    await respond(handler, client, messages);
 
     // Round 2: the flow appends two new steps to the same array.
     messages.push(userStep('c'), userStep('d'));
-    await handler.createResponse({
-      client: client as never,
-      messages,
-      temperature: 0,
-    });
+    await respond(handler, client, messages);
 
     expect(calls).toHaveLength(2);
     // First call: full, no chain.
@@ -223,11 +226,7 @@ describe('ModelHandlerGoogleInteractions store:true chaining', () => {
     );
 
     const messages: Step[] = [userStep('a')];
-    await handler.createResponse({
-      client: client as never,
-      messages,
-      temperature: 0,
-    });
+    await respond(handler, client, messages);
 
     // Mimic the flow appending the model-generated turn (server-held) + a tool
     // result + a new user turn before the next round.
@@ -246,11 +245,7 @@ describe('ModelHandlerGoogleInteractions store:true chaining', () => {
       } as Step,
       userStep('b'),
     );
-    await handler.createResponse({
-      client: client as never,
-      messages,
-      temperature: 0,
-    });
+    await respond(handler, client, messages);
 
     expect(calls[1].previousId).toBe('int_1');
     // thought + function_call (server-held) are dropped; only the result + new user remain.
@@ -270,18 +265,10 @@ describe('ModelHandlerGoogleInteractions store:true chaining', () => {
     );
 
     const messages: Step[] = [userStep('a')];
-    await handler.createResponse({
-      client: client as never,
-      messages,
-      temperature: 0,
-    });
+    await respond(handler, client, messages);
 
     messages.push(userStep('b'));
-    await handler.createResponse({
-      client: client as never,
-      messages,
-      temperature: 0,
-    });
+    await respond(handler, client, messages);
 
     // Second call full-resends both steps, no previous_interaction_id.
     expect(calls[1].previousId).toBeUndefined();
@@ -300,19 +287,11 @@ describe('ModelHandlerGoogleInteractions store:true chaining', () => {
     );
 
     const messages: Step[] = [userStep('a')];
-    await handler.createResponse({
-      client: client as never,
-      messages,
-      temperature: 0,
-    });
+    await respond(handler, client, messages);
 
     // The flow appends the model-generated steps; round 2 continues the chain.
     messages.push(userStep('b'));
-    await handler.createResponse({
-      client: client as never,
-      messages,
-      temperature: 0,
-    });
+    await respond(handler, client, messages);
 
     expect(calls[1].store).toBe(true);
     expect(calls[1].previousId).toBe('int_1'); // chained onto the tool round
@@ -335,18 +314,10 @@ describe('ModelHandlerGoogleInteractions store:true chaining', () => {
     });
 
     const messages: Step[] = [userStep('a')];
-    await handler.createResponse({
-      client: client as never,
-      messages,
-      temperature: 0,
-    });
+    await respond(handler, client, messages);
 
     messages.push(userStep('b'));
-    const result = await handler.createResponse({
-      client: client as never,
-      messages,
-      temperature: 0,
-    });
+    const result = await respond(handler, client, messages);
 
     // 3 create calls total: initial + failed-chained + retried-full.
     expect(calls).toHaveLength(3);
@@ -372,20 +343,12 @@ describe('ModelHandlerGoogleInteractions store:true chaining', () => {
     });
 
     const messages: Step[] = [userStep('a')];
-    await handler.createResponse({
-      client: client as never,
-      messages,
-      temperature: 0,
-    });
+    await respond(handler, client, messages);
 
     messages.push(userStep('b'));
-    await expect(
-      handler.createResponse({
-        client: client as never,
-        messages,
-        temperature: 0,
-      }),
-    ).rejects.toThrow(/previous_interaction_id/);
+    await expect(respond(handler, client, messages)).rejects.toThrow(
+      /previous_interaction_id/,
+    );
 
     // Exactly 3 create calls: initial + failed-chained + failed-retry (no 4th).
     // The retry sent a full resend (no previous_interaction_id), so it cannot
@@ -410,22 +373,14 @@ describe('ModelHandlerGoogleInteractions store:true chaining', () => {
 
     // Round 1 establishes a chain.
     const messages: Step[] = [userStep('a'), userStep('b'), userStep('c')];
-    await handler.createResponse({
-      client: client as never,
-      messages,
-      temperature: 0,
-    });
+    await respond(handler, client, messages);
     expect(calls[0].previousId).toBeUndefined();
 
     // Round 2: request manual compaction. The handler must clear the chain
     // (full resend, no previous_interaction_id) and return updatedMessages.
     handler.requestCompaction();
     messages.push(userStep('d'), userStep('e'));
-    const result = await handler.createResponse({
-      client: client as never,
-      messages,
-      temperature: 0,
-    });
+    const result = await respond(handler, client, messages);
 
     expect(result.updatedMessages).toBeDefined();
     expect(result.updatedMessages!.length).toBeLessThan(messages.length);
@@ -438,11 +393,7 @@ describe('ModelHandlerGoogleInteractions store:true chaining', () => {
     // i.e. compaction must not permanently disable chaining.
     const compacted = result.updatedMessages!;
     const round3: Step[] = [...compacted, userStep('f')];
-    await handler.createResponse({
-      client: client as never,
-      messages: round3,
-      temperature: 0,
-    });
+    await respond(handler, client, round3);
     expect(calls[2].store).toBe(true);
     expect(calls[2].previousId).toBe('int_2'); // chained onto the compaction response
     expect(calls[2].input).toHaveLength(1); // only the newly appended step
@@ -456,18 +407,10 @@ describe('ModelHandlerGoogleInteractions store:true chaining', () => {
     const client = capturingClient(calls, () => completedEvents('int_1'));
 
     const messages: Step[] = [userStep('a')];
-    await handler.createResponse({
-      client: client as never,
-      messages,
-      temperature: 0,
-    });
+    await respond(handler, client, messages);
 
     messages.push(userStep('b'));
-    await handler.createResponse({
-      client: client as never,
-      messages,
-      temperature: 0,
-    });
+    await respond(handler, client, messages);
 
     for (const call of calls) {
       expect(call.store).toBe(false);
@@ -482,22 +425,22 @@ describe('ModelHandlerGoogleInteractions store:true chaining', () => {
     // First instance establishes a chain.
     const first = createHandler();
     const callsA: RecordedCall[] = [];
-    await first.createResponse({
-      client: capturingClient(callsA, () => completedEvents('int_1')) as never,
-      messages: [userStep('a')],
-      temperature: 0,
-    });
+    await respond(
+      first,
+      capturingClient(callsA, () => completedEvents('int_1')),
+      [userStep('a')],
+    );
     expect(callsA[0].previousId).toBeUndefined();
 
     // A brand-new instance (simulating resume-from-snapshot) sees the same
     // transcript but has no chain id, so it full-resends with no chaining.
     const restored = createHandler();
     const callsB: RecordedCall[] = [];
-    await restored.createResponse({
-      client: capturingClient(callsB, () => completedEvents('int_2')) as never,
-      messages: [userStep('a'), userStep('b')],
-      temperature: 0,
-    });
+    await respond(
+      restored,
+      capturingClient(callsB, () => completedEvents('int_2')),
+      [userStep('a'), userStep('b')],
+    );
     expect(callsB[0].previousId).toBeUndefined();
     expect(callsB[0].input).toHaveLength(2);
   });
@@ -527,30 +470,22 @@ describe('ModelHandlerGoogleInteractions store:true chaining', () => {
       models: {},
     };
 
-    const inFlight = handler.createResponse({
-      client: client as never,
-      messages: [userStep('a')],
-      temperature: 0,
-    });
+    const inFlight = respond(handler, client, [userStep('a')]);
 
-    await expect(
-      handler.createResponse({
-        client: client as never,
-        messages: [userStep('b')],
-        temperature: 0,
-      }),
-    ).rejects.toThrow(/single-turn/);
+    await expect(respond(handler, client, [userStep('b')])).rejects.toThrow(
+      /single-turn/,
+    );
 
     release();
     await inFlight;
 
     // The guard reset in finally: a serial call now succeeds.
     await expect(
-      handler.createResponse({
-        client: capturingClient([], () => completedEvents('int_2')) as never,
-        messages: [userStep('c')],
-        temperature: 0,
-      }),
+      respond(
+        handler,
+        capturingClient([], () => completedEvents('int_2')),
+        [userStep('c')],
+      ),
     ).resolves.toBeDefined();
   });
 });

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsToolUse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsToolUse.vitest.ts
@@ -105,6 +105,21 @@ function fakeClient(events: Interactions.InteractionSSEEvent[]): unknown {
   };
 }
 
+/** Drive a single `createResponse` round from a canned SSE event list, using
+ * the single-turn "go" user message every non-store:false test in this file
+ * sends. */
+function createGoResponse(
+  handler: ModelHandlerGoogleInteractions,
+  events: Interactions.InteractionSSEEvent[],
+) {
+  return handler.createResponse({
+    client: fakeClient(events) as never,
+    messages: [{ type: 'user_input', content: [{ type: 'text', text: 'go' }] }],
+    temperature: 0,
+    tools: [],
+  });
+}
+
 describe('ModelHandlerGoogleInteractions tool use', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -162,14 +177,7 @@ describe('ModelHandlerGoogleInteractions tool use', () => {
       },
     ];
 
-    const result = await handler.createResponse({
-      client: fakeClient(events) as never,
-      messages: [
-        { type: 'user_input', content: [{ type: 'text', text: 'go' }] },
-      ],
-      temperature: 0,
-      tools: [],
-    });
+    const result = await createGoResponse(handler, events);
 
     const calls = handler.extractToolUse(result.response);
     expect(calls).toHaveLength(2);
@@ -228,16 +236,7 @@ describe('ModelHandlerGoogleInteractions tool use', () => {
     ];
 
     const workspace = fakeWorkspace();
-    const response = (
-      await handler.createResponse({
-        client: fakeClient(events) as never,
-        messages: [
-          { type: 'user_input', content: [{ type: 'text', text: 'go' }] },
-        ],
-        temperature: 0,
-        tools: [],
-      })
-    ).response;
+    const response = (await createGoResponse(handler, events)).response;
 
     // Mirror the cycle: reasoning is captured into the workspace before dispatch.
     handler.processThinkingBlock(response, workspace);
@@ -384,14 +383,7 @@ describe('ModelHandlerGoogleInteractions tool use', () => {
       },
     ];
 
-    const result = await handler.createResponse({
-      client: fakeClient(events) as never,
-      messages: [
-        { type: 'user_input', content: [{ type: 'text', text: 'go' }] },
-      ],
-      temperature: 0,
-      tools: [],
-    });
+    const result = await createGoResponse(handler, events);
 
     const calls = handler.extractToolUse(result.response);
     expect(calls).toHaveLength(1);
@@ -458,16 +450,7 @@ describe('ModelHandlerGoogleInteractions tool use', () => {
       },
     ];
 
-    const response = (
-      await handler.createResponse({
-        client: fakeClient(events) as never,
-        messages: [
-          { type: 'user_input', content: [{ type: 'text', text: 'go' }] },
-        ],
-        temperature: 0,
-        tools: [],
-      })
-    ).response;
+    const response = (await createGoResponse(handler, events)).response;
 
     const workspace = fakeWorkspace();
     handler.processThinkingBlock(response, workspace);

--- a/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
@@ -198,6 +198,13 @@ describe('OpenAI model handler routing', () => {
     requiresResponsesAPI: true,
   };
 
+  const signedInCodexSession = (): CodexSession => ({
+    accessToken: 'access-token',
+    refreshToken: 'refresh-token',
+    expiresAtMs: Date.now() + 60_000,
+    accountId: 'account-id',
+  });
+
   it('keeps Codex-eligible subscription models on the Responses compatibility key', async () => {
     await initFakePlatform({
       config: { 'texra.chatgptCodex.preferSubscription': true },
@@ -235,12 +242,7 @@ describe('OpenAI model handler routing', () => {
   });
 
   it('preserves the API fullName on Codex handler config even when shortName is absent', async () => {
-    const codexSession: CodexSession = {
-      accessToken: 'access-token',
-      refreshToken: 'refresh-token',
-      expiresAtMs: Date.now() + 60_000,
-      accountId: 'account-id',
-    };
+    const codexSession = signedInCodexSession();
     await initFakePlatform({
       config: { 'texra.chatgptCodex.preferSubscription': true },
       secrets: {
@@ -263,12 +265,7 @@ describe('OpenAI model handler routing', () => {
   });
 
   it('uses the Codex endpoint for a signed-in preferred subscription even when relay access is selected', async () => {
-    const codexSession: CodexSession = {
-      accessToken: 'access-token',
-      refreshToken: 'refresh-token',
-      expiresAtMs: Date.now() + 60_000,
-      accountId: 'account-id',
-    };
+    const codexSession = signedInCodexSession();
     await initFakePlatform({
       config: { 'texra.chatgptCodex.preferSubscription': true },
       globalState: { 'texra.useIncludedModelAccess': true },
@@ -290,12 +287,7 @@ describe('OpenAI model handler routing', () => {
   });
 
   it('does not let the Codex subscription override an explicit legacy OpenAI compatibility key', async () => {
-    const codexSession: CodexSession = {
-      accessToken: 'access-token',
-      refreshToken: 'refresh-token',
-      expiresAtMs: Date.now() + 60_000,
-      accountId: 'account-id',
-    };
+    const codexSession = signedInCodexSession();
     await initFakePlatform({
       config: { 'texra.chatgptCodex.preferSubscription': true },
       secrets: {
@@ -318,12 +310,7 @@ describe('OpenAI model handler routing', () => {
   });
 
   it('keeps Responses-compatible resumes on the Codex endpoint when subscription access is preferred', async () => {
-    const codexSession: CodexSession = {
-      accessToken: 'access-token',
-      refreshToken: 'refresh-token',
-      expiresAtMs: Date.now() + 60_000,
-      accountId: 'account-id',
-    };
+    const codexSession = signedInCodexSession();
     await initFakePlatform({
       config: { 'texra.chatgptCodex.preferSubscription': true },
       globalState: {

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -1343,61 +1343,22 @@ describe('ModelHandlerAnthropic output prefill initialization', () => {
   });
 
   it('skips assistant prefill message when prefill is empty', async () => {
-    await withTempOutputPath(
-      'anthropic-prefill-empty-',
-      async (outputPath) => {
-        const handler = createAnthropicHandler({
-          supportsAssistantPrefill: true,
-        });
-        stubHandlerForTest(handler);
+    await withTempOutputPath('anthropic-prefill-empty-', async (outputPath) => {
+      const handler = createAnthropicHandler({
+        supportsAssistantPrefill: true,
+      });
+      stubHandlerForTest(handler);
 
-        const agentSetting = createLatexAgentSetting();
-        const userMessage: MessageParam = {
-          role: 'user',
-          content: [{ type: 'text', text: 'revise the document' }],
-        };
-        const messages: MessageParam[] = [userMessage];
-        const workspaceState = AgentWorkspaceState.create();
+      const agentSetting = createLatexAgentSetting();
+      const userMessage: MessageParam = {
+        role: 'user',
+        content: [{ type: 'text', text: 'revise the document' }],
+      };
+      const messages: MessageParam[] = [userMessage];
+      const workspaceState = AgentWorkspaceState.create();
 
-        const [isComplete, updatedMessages] =
-          await handler.initializeOutputAndPrefill(
-            {} as AgentConfig,
-            agentSetting,
-            messages,
-            workspaceState,
-            pathToLocation(outputPath),
-            '',
-          );
-
-        assert.equal(isComplete, false);
-        assert.equal(fs.existsSync(outputPath), false);
-        assert.equal(workspaceState.assembly.accumulatedOutput, '');
-        assert.equal(updatedMessages.length, 1);
-        assert.equal(updatedMessages.at(-1)?.role, 'user');
-      },
-    );
-  });
-
-  it('skips pseudo-prefill instruction when prefill is empty (thinking-only models)', async () => {
-    await withTempOutputPath(
-      'anthropic-pseudo-empty-',
-      async (outputPath) => {
-        const handler = createAnthropicHandler({
-          supportsAssistantPrefill: false,
-        });
-        stubHandlerForTest(handler);
-
-        const agentSetting = createLatexAgentSetting();
-        const userText = 'revise the document';
-        const messages: MessageParam[] = [
-          {
-            role: 'user',
-            content: [{ type: 'text', text: userText }],
-          },
-        ];
-        const workspaceState = AgentWorkspaceState.create();
-
-        const [, updatedMessages] = await handler.initializeOutputAndPrefill(
+      const [isComplete, updatedMessages] =
+        await handler.initializeOutputAndPrefill(
           {} as AgentConfig,
           agentSetting,
           messages,
@@ -1406,12 +1367,45 @@ describe('ModelHandlerAnthropic output prefill initialization', () => {
           '',
         );
 
-        assert.equal(updatedMessages.length, 1);
-        const last = updatedMessages.at(-1);
-        assert.equal(last?.role, 'user');
-        assert.deepEqual(last?.content, [{ type: 'text', text: userText }]);
-      },
-    );
+      assert.equal(isComplete, false);
+      assert.equal(fs.existsSync(outputPath), false);
+      assert.equal(workspaceState.assembly.accumulatedOutput, '');
+      assert.equal(updatedMessages.length, 1);
+      assert.equal(updatedMessages.at(-1)?.role, 'user');
+    });
+  });
+
+  it('skips pseudo-prefill instruction when prefill is empty (thinking-only models)', async () => {
+    await withTempOutputPath('anthropic-pseudo-empty-', async (outputPath) => {
+      const handler = createAnthropicHandler({
+        supportsAssistantPrefill: false,
+      });
+      stubHandlerForTest(handler);
+
+      const agentSetting = createLatexAgentSetting();
+      const userText = 'revise the document';
+      const messages: MessageParam[] = [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: userText }],
+        },
+      ];
+      const workspaceState = AgentWorkspaceState.create();
+
+      const [, updatedMessages] = await handler.initializeOutputAndPrefill(
+        {} as AgentConfig,
+        agentSetting,
+        messages,
+        workspaceState,
+        pathToLocation(outputPath),
+        '',
+      );
+
+      assert.equal(updatedMessages.length, 1);
+      const last = updatedMessages.at(-1);
+      assert.equal(last?.role, 'user');
+      assert.deepEqual(last?.content, [{ type: 'text', text: userText }]);
+    });
   });
 });
 

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -28,6 +28,7 @@ import type { AgentTrace } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import {
   AgentCategory,
+  type AgentSetting,
   AgentSettingSchema,
 } from '@agent/core/definition/AgentDataclass';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
@@ -1276,24 +1277,42 @@ describe('ModelHandlerAnthropic message guards', () => {
   });
 });
 
+/**
+ * Creates a fresh temp directory with an `r0/output.xml` path for prefill
+ * tests, invokes `run` with that path, and removes the directory afterward
+ * regardless of outcome.
+ */
+async function withTempOutputPath(
+  prefix: string,
+  run: (outputPath: string) => Promise<void>,
+): Promise<void> {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const outputPath = path.join(tempDir, 'r0', 'output.xml');
+  try {
+    await run(outputPath);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+/** Build the workflow AgentSetting shared by the latex_document prefill tests. */
+function createLatexAgentSetting(): AgentSetting {
+  return AgentSettingSchema.parse({
+    agentCategory: AgentCategory.Workflow,
+    documentTag: 'latex_document',
+    endTag: '</latex_document>',
+  });
+}
+
 describe('ModelHandlerAnthropic output prefill initialization', () => {
   it('writes assistant prefills for non-XML workflow outputs', async () => {
-    const tempDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), 'anthropic-prefill-'),
-    );
-    const outputPath = path.join(tempDir, 'r0', 'output.xml');
-
-    try {
+    await withTempOutputPath('anthropic-prefill-', async (outputPath) => {
       const handler = createAnthropicHandler({
         supportsAssistantPrefill: true,
       });
       stubHandlerForTest(handler);
 
-      const agentSetting = AgentSettingSchema.parse({
-        agentCategory: AgentCategory.Workflow,
-        documentTag: 'latex_document',
-        endTag: '</latex_document>',
-      });
+      const agentSetting = createLatexAgentSetting();
       const messages: MessageParam[] = [
         {
           role: 'user',
@@ -1320,37 +1339,65 @@ describe('ModelHandlerAnthropic output prefill initialization', () => {
       assert.deepEqual(updatedMessages.at(-1)?.content, [
         { type: 'text', text: prefill },
       ]);
-    } finally {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it('skips assistant prefill message when prefill is empty', async () => {
-    const tempDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), 'anthropic-prefill-empty-'),
+    await withTempOutputPath(
+      'anthropic-prefill-empty-',
+      async (outputPath) => {
+        const handler = createAnthropicHandler({
+          supportsAssistantPrefill: true,
+        });
+        stubHandlerForTest(handler);
+
+        const agentSetting = createLatexAgentSetting();
+        const userMessage: MessageParam = {
+          role: 'user',
+          content: [{ type: 'text', text: 'revise the document' }],
+        };
+        const messages: MessageParam[] = [userMessage];
+        const workspaceState = AgentWorkspaceState.create();
+
+        const [isComplete, updatedMessages] =
+          await handler.initializeOutputAndPrefill(
+            {} as AgentConfig,
+            agentSetting,
+            messages,
+            workspaceState,
+            pathToLocation(outputPath),
+            '',
+          );
+
+        assert.equal(isComplete, false);
+        assert.equal(fs.existsSync(outputPath), false);
+        assert.equal(workspaceState.assembly.accumulatedOutput, '');
+        assert.equal(updatedMessages.length, 1);
+        assert.equal(updatedMessages.at(-1)?.role, 'user');
+      },
     );
-    const outputPath = path.join(tempDir, 'r0', 'output.xml');
+  });
 
-    try {
-      const handler = createAnthropicHandler({
-        supportsAssistantPrefill: true,
-      });
-      stubHandlerForTest(handler);
+  it('skips pseudo-prefill instruction when prefill is empty (thinking-only models)', async () => {
+    await withTempOutputPath(
+      'anthropic-pseudo-empty-',
+      async (outputPath) => {
+        const handler = createAnthropicHandler({
+          supportsAssistantPrefill: false,
+        });
+        stubHandlerForTest(handler);
 
-      const agentSetting = AgentSettingSchema.parse({
-        agentCategory: AgentCategory.Workflow,
-        documentTag: 'latex_document',
-        endTag: '</latex_document>',
-      });
-      const userMessage: MessageParam = {
-        role: 'user',
-        content: [{ type: 'text', text: 'revise the document' }],
-      };
-      const messages: MessageParam[] = [userMessage];
-      const workspaceState = AgentWorkspaceState.create();
+        const agentSetting = createLatexAgentSetting();
+        const userText = 'revise the document';
+        const messages: MessageParam[] = [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: userText }],
+          },
+        ];
+        const workspaceState = AgentWorkspaceState.create();
 
-      const [isComplete, updatedMessages] =
-        await handler.initializeOutputAndPrefill(
+        const [, updatedMessages] = await handler.initializeOutputAndPrefill(
           {} as AgentConfig,
           agentSetting,
           messages,
@@ -1359,58 +1406,12 @@ describe('ModelHandlerAnthropic output prefill initialization', () => {
           '',
         );
 
-      assert.equal(isComplete, false);
-      assert.equal(fs.existsSync(outputPath), false);
-      assert.equal(workspaceState.assembly.accumulatedOutput, '');
-      assert.equal(updatedMessages.length, 1);
-      assert.equal(updatedMessages.at(-1)?.role, 'user');
-    } finally {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
-  });
-
-  it('skips pseudo-prefill instruction when prefill is empty (thinking-only models)', async () => {
-    const tempDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), 'anthropic-pseudo-empty-'),
+        assert.equal(updatedMessages.length, 1);
+        const last = updatedMessages.at(-1);
+        assert.equal(last?.role, 'user');
+        assert.deepEqual(last?.content, [{ type: 'text', text: userText }]);
+      },
     );
-    const outputPath = path.join(tempDir, 'r0', 'output.xml');
-
-    try {
-      const handler = createAnthropicHandler({
-        supportsAssistantPrefill: false,
-      });
-      stubHandlerForTest(handler);
-
-      const agentSetting = AgentSettingSchema.parse({
-        agentCategory: AgentCategory.Workflow,
-        documentTag: 'latex_document',
-        endTag: '</latex_document>',
-      });
-      const userText = 'revise the document';
-      const messages: MessageParam[] = [
-        {
-          role: 'user',
-          content: [{ type: 'text', text: userText }],
-        },
-      ];
-      const workspaceState = AgentWorkspaceState.create();
-
-      const [, updatedMessages] = await handler.initializeOutputAndPrefill(
-        {} as AgentConfig,
-        agentSetting,
-        messages,
-        workspaceState,
-        pathToLocation(outputPath),
-        '',
-      );
-
-      assert.equal(updatedMessages.length, 1);
-      const last = updatedMessages.at(-1);
-      assert.equal(last?.role, 'user');
-      assert.deepEqual(last?.content, [{ type: 'text', text: userText }]);
-    } finally {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
   });
 });
 

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerGoogleGenAI.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerGoogleGenAI.vitest.ts
@@ -110,6 +110,13 @@ function buildGoogleConfig(
   };
 }
 
+function createGoogleGenAIHandler(): ModelHandlerGoogleGenAI {
+  const handler = new ModelHandlerGoogleGenAI(buildGoogleConfig());
+  const { logger } = createLoggerStub();
+  handler.setLogger(logger);
+  return handler;
+}
+
 class GoogleHandlerTestDouble extends ModelHandlerGoogleGenAI {
   constructor(
     config: ModelConfig,
@@ -405,9 +412,7 @@ describe('validateGoogleMessageHistory', () => {
 
 describe('ModelHandlerGoogleGenAI createUserFollowUpMessages', () => {
   it('merges with existing user message to maintain alternating turns', async () => {
-    const handler = new ModelHandlerGoogleGenAI(buildGoogleConfig());
-    const { logger } = createLoggerStub();
-    handler.setLogger(logger);
+    const handler = createGoogleGenAIHandler();
 
     // Start with messages ending in user (simulating after tool response)
     const messages: Content[] = [
@@ -434,9 +439,7 @@ describe('ModelHandlerGoogleGenAI createUserFollowUpMessages', () => {
   });
 
   it('adds new user message when last message is model', async () => {
-    const handler = new ModelHandlerGoogleGenAI(buildGoogleConfig());
-    const { logger } = createLoggerStub();
-    handler.setLogger(logger);
+    const handler = createGoogleGenAIHandler();
 
     // Start with messages ending in model
     const messages: Content[] = [
@@ -460,9 +463,7 @@ describe('ModelHandlerGoogleGenAI createUserFollowUpMessages', () => {
 
 describe('ModelHandlerGoogleGenAI tool attachments', () => {
   it('embeds tool attachments as function response parts with inline data', async () => {
-    const handler = new ModelHandlerGoogleGenAI(buildGoogleConfig());
-    const { logger } = createLoggerStub();
-    handler.setLogger(logger);
+    const handler = createGoogleGenAIHandler();
 
     const attachmentBytes = new Uint8Array([1, 2, 3, 4]);
     const toolResult = {

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
@@ -95,13 +95,18 @@ function createConfig(overrides: Partial<ModelConfig> = {}): ModelConfig {
   };
 }
 
-function createHandler(
-  configOverrides: Partial<ModelConfig> = {},
-): ModelHandlerOpenAIResponse {
-  const handler = new ModelHandlerOpenAIResponse(createConfig(configOverrides));
+function setupHandler<T extends ModelHandlerOpenAIResponse>(handler: T): T {
   handler.setLogger(createLoggerStub() as unknown as AgentTrace);
   handler.getStreamingConfig = () => false;
   return handler;
+}
+
+function createHandler(
+  configOverrides: Partial<ModelConfig> = {},
+): ModelHandlerOpenAIResponse {
+  return setupHandler(
+    new ModelHandlerOpenAIResponse(createConfig(configOverrides)),
+  );
 }
 
 class NonChainingResponseHandler extends ModelHandlerOpenAIResponse {
@@ -123,19 +128,17 @@ class StatelessResponseHandler extends ModelHandlerOpenAIResponse {
 function createNonChainingHandler(
   configOverrides: Partial<ModelConfig> = {},
 ): ModelHandlerOpenAIResponse {
-  const handler = new NonChainingResponseHandler(createConfig(configOverrides));
-  handler.setLogger(createLoggerStub() as unknown as AgentTrace);
-  handler.getStreamingConfig = () => false;
-  return handler;
+  return setupHandler(
+    new NonChainingResponseHandler(createConfig(configOverrides)),
+  );
 }
 
 function createStatelessHandler(
   configOverrides: Partial<ModelConfig> = {},
 ): ModelHandlerOpenAIResponse {
-  const handler = new StatelessResponseHandler(createConfig(configOverrides));
-  handler.setLogger(createLoggerStub() as unknown as AgentTrace);
-  handler.getStreamingConfig = () => false;
-  return handler;
+  return setupHandler(
+    new StatelessResponseHandler(createConfig(configOverrides)),
+  );
 }
 
 function createResponse(id: string, usage?: { input_tokens: number }) {

--- a/src/test-kernel/agent/modelHandlers/OpenAIResponseBackgroundAbort.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIResponseBackgroundAbort.vitest.ts
@@ -143,15 +143,12 @@ describe('OpenAI Responses background abort handling', () => {
       } as unknown as AgentTrace,
     });
 
-    let thrown: unknown;
-    try {
-      await target.waitForBackgroundCompletion(
+    const thrown = await target
+      .waitForBackgroundCompletion(
         { responses: { retrieve: vi.fn() } } as unknown as OpenAI,
         { id: 'resp_timeout', status: 'in_progress' },
-      );
-    } catch (err) {
-      thrown = err;
-    }
+      )
+      .catch((err: unknown) => err);
 
     expect(thrown).toBeInstanceOf(Error);
     expect(requiresFlowAutoRetry(thrown)).toBe(true);

--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -30,6 +30,27 @@ async function initFakePlatform(files: Record<string, string> = {}) {
   initPlatform(createFakePlatform({ files, workspacePath: '/workspace' }));
 }
 
+function createWorkflowAgentSetting(
+  documentTag: string,
+  overrides: { rounds?: number; defaultOutputFiles?: string[] } = {},
+) {
+  return {
+    agentCategory: AgentCategory.Workflow,
+    documentTag,
+    endTag: '</documents>',
+    temperature: 0,
+    requiredFiles: {},
+    requiredFilesInternal: {},
+    defaultOutputFiles: [],
+    filePatternsContain: [],
+    tools: [],
+    isRewrite: true,
+    rounds: 1,
+    prefills: [],
+    ...overrides,
+  };
+}
+
 function createXmlManager(
   documentTag = 'document',
   inputFiles: string[] = ['paper.tex'],
@@ -39,20 +60,7 @@ function createXmlManager(
   } = {},
 ): XmlOutputManager {
   return new XmlOutputManager(
-    {
-      agentCategory: AgentCategory.Workflow,
-      documentTag,
-      endTag: '</documents>',
-      temperature: 0,
-      requiredFiles: {},
-      requiredFilesInternal: {},
-      defaultOutputFiles: [],
-      filePatternsContain: [],
-      tools: [],
-      isRewrite: true,
-      rounds: 1,
-      prefills: [],
-    },
+    createWorkflowAgentSetting(documentTag),
     {
       inputFiles,
       outputFiles: options.outputFiles ?? [],
@@ -1028,20 +1036,7 @@ Appendix.
       },
     };
     const processor = new OutputFileProcessor({
-      agentSetting: {
-        agentCategory: AgentCategory.Workflow,
-        documentTag: 'documents',
-        endTag: '</documents>',
-        temperature: 0,
-        requiredFiles: {},
-        requiredFilesInternal: {},
-        defaultOutputFiles: [],
-        filePatternsContain: [],
-        tools: [],
-        isRewrite: true,
-        rounds: 1,
-        prefills: [],
-      },
+      agentSetting: createWorkflowAgentSetting('documents'),
       baseFiles: [],
       streamId: 'stream',
       runtimeHost: { emit: vi.fn() } as unknown as AgentRuntimeHost,
@@ -1588,20 +1583,9 @@ Appendix.
     inputFiles: string[] = ['page1.png', 'page2.png'],
   ): XmlOutputManager {
     return new XmlOutputManager(
-      {
-        agentCategory: AgentCategory.Workflow,
-        documentTag: 'documents',
-        endTag: '</documents>',
-        temperature: 0,
-        requiredFiles: {},
-        requiredFilesInternal: {},
+      createWorkflowAgentSetting('documents', {
         defaultOutputFiles: ['ocr_result.tex'],
-        filePatternsContain: [],
-        tools: [],
-        isRewrite: true,
-        rounds: 1,
-        prefills: [],
-      },
+      }),
       {
         inputFiles,
         outputFiles: ['ocr_result.tex'],
@@ -2019,20 +2003,7 @@ Appendix.
     ];
     let roundOutputs: OutputFileInfo[] = [];
     const processor = new OutputFileProcessor({
-      agentSetting: {
-        agentCategory: AgentCategory.Workflow,
-        documentTag: 'documents',
-        endTag: '</documents>',
-        temperature: 0,
-        requiredFiles: {},
-        requiredFilesInternal: {},
-        defaultOutputFiles: [],
-        filePatternsContain: [],
-        tools: [],
-        isRewrite: true,
-        rounds: 2,
-        prefills: [],
-      },
+      agentSetting: createWorkflowAgentSetting('documents', { rounds: 2 }),
       baseFiles: [
         createExternalLocation('/tmp/run/appendices.tex'),
         createExternalLocation('/tmp/run/cost_section.tex'),

--- a/src/test-kernel/agent/runtime/ConversationProgressHub.vitest.ts
+++ b/src/test-kernel/agent/runtime/ConversationProgressHub.vitest.ts
@@ -7,24 +7,28 @@ import type { StreamTabId } from '@shared/schemas';
 
 import { createRecordingHost } from '../progressTestUtils';
 
-function attachTraceToHub(
-  trace: TraceEmitter,
-  hub: SessionEventHub,
-  streamId: StreamTabId,
-): () => void {
-  return trace.subscribe((event) =>
+function setupHub(streamId: StreamTabId) {
+  const trace = new TraceEmitter();
+  const hub = new SessionEventHub();
+  const { events, host } = createRecordingHost();
+  const detachTrace = trace.subscribe((event) =>
     hub.emit({ scope: 'run', streamId, event }),
   );
+  const detach = attachConversationProgressHub(hub, host, streamId);
+  return {
+    trace,
+    events,
+    detachAll: () => {
+      detach();
+      detachTrace();
+    },
+  };
 }
 
 describe('attachConversationProgressHub (F-1b)', () => {
   it('derives updateConversationProgress from a conversationProgress domain event', () => {
-    const trace = new TraceEmitter();
-    const hub = new SessionEventHub();
-    const { events, host } = createRecordingHost();
     const streamId = 'stream:hub-test' as StreamTabId;
-    const detachTrace = attachTraceToHub(trace, hub, streamId);
-    const detach = attachConversationProgressHub(hub, host, streamId);
+    const { trace, events, detachAll } = setupHub(streamId);
 
     try {
       logConversationProgress(trace, {
@@ -41,35 +45,25 @@ describe('attachConversationProgressHub (F-1b)', () => {
         },
       });
     } finally {
-      detach();
-      detachTrace();
+      detachAll();
     }
   });
 
   it('ignores unrelated domain events and stops forwarding after detach', () => {
-    const trace = new TraceEmitter();
-    const hub = new SessionEventHub();
-    const { events, host } = createRecordingHost();
     const streamId = 'stream:hub-test-2' as StreamTabId;
-    const detachTrace = attachTraceToHub(trace, hub, streamId);
-    const detach = attachConversationProgressHub(hub, host, streamId);
+    const { trace, events, detachAll } = setupHub(streamId);
 
     trace.domain({ key: 'webSearch', data: { query: 'irrelevant' } });
     expect(events).toHaveLength(0);
 
-    detach();
+    detachAll();
     logConversationProgress(trace, { conversationTurns: 1, toolCallCount: 0 });
     expect(events).toHaveLength(0);
-    detachTrace();
   });
 
   it('drops a conversationProgress event with missing or malformed data instead of forwarding it', () => {
-    const trace = new TraceEmitter();
-    const hub = new SessionEventHub();
-    const { events, host } = createRecordingHost();
     const streamId = 'stream:hub-test-3' as StreamTabId;
-    const detachTrace = attachTraceToHub(trace, hub, streamId);
-    const detach = attachConversationProgressHub(hub, host, streamId);
+    const { trace, events, detachAll } = setupHub(streamId);
 
     try {
       trace.domain({ key: 'conversationProgress', data: undefined });
@@ -81,8 +75,7 @@ describe('attachConversationProgressHub (F-1b)', () => {
 
       expect(events).toHaveLength(0);
     } finally {
-      detach();
-      detachTrace();
+      detachAll();
     }
   });
 });

--- a/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
@@ -120,6 +120,19 @@ function collectResults(logger: TraceEmitter): ResultEvent[] {
   return results;
 }
 
+/** Fresh logger + result collector + launch context, wired together. */
+function setupResultCase(): {
+  logger: TraceEmitter;
+  results: ResultEvent[];
+  ctx: AgentLaunchContext;
+  streamStatus: StreamStatusRegistry;
+} {
+  const logger = new TraceEmitter();
+  const results = collectResults(logger);
+  const { ctx, streamStatus } = createCtx({ logger });
+  return { logger, results, ctx, streamStatus };
+}
+
 describe('terminal result event (SDK Step 7d PR 6)', () => {
   beforeAll(async () => {
     const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
@@ -134,9 +147,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
   });
 
   it('emits exactly one completed result on a successful run', async () => {
-    const logger = new TraceEmitter();
-    const results = collectResults(logger);
-    const { ctx, streamStatus } = createCtx({ logger });
+    const { ctx, streamStatus, results } = setupResultCase();
     try {
       await runFlowWithLifecycle(ctx, async () => ({
         category: 'toolUse',
@@ -159,9 +170,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
   });
 
   it('emits exactly one completed result even if terminal stream-status cleanup throws', async () => {
-    const logger = new TraceEmitter();
-    const results = collectResults(logger);
-    const { ctx, streamStatus } = createCtx({ logger });
+    const { ctx, streamStatus, results } = setupResultCase();
     // A status subscriber that throws on the terminal (COMPLETED) transition,
     // not the initial RUNNING one — models a host emit / status listener throwing
     // during post-completion cleanup. The run already emitted `completed`, so
@@ -189,9 +198,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
   });
 
   it('emits the completed result even if ending the parent stage throws', async () => {
-    const logger = new TraceEmitter();
-    const results = collectResults(logger);
-    const { ctx, streamStatus } = createCtx({ logger });
+    const { ctx, streamStatus, results } = setupResultCase();
     vi.spyOn(ctx.parentStage, 'end').mockImplementation(() => {
       throw new Error('stage listener boom');
     });
@@ -217,8 +224,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
   });
 
   it('exposes the per-run handle via onRun and settles handle.result (F-2)', async () => {
-    const logger = new TraceEmitter();
-    const { ctx, streamStatus } = createCtx({ logger });
+    const { logger, ctx, streamStatus } = setupResultCase();
     let handle: AgentRunHandle | undefined;
     try {
       await runFlowWithLifecycle(
@@ -250,9 +256,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
   });
 
   it('keeps running when onRun throws synchronously', async () => {
-    const logger = new TraceEmitter();
-    const results = collectResults(logger);
-    const { ctx, streamStatus } = createCtx({ logger });
+    const { ctx, streamStatus, results } = setupResultCase();
     try {
       await expect(
         runFlowWithLifecycle(
@@ -283,9 +287,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
   });
 
   it('keeps running when onRun rejects asynchronously', async () => {
-    const logger = new TraceEmitter();
-    const results = collectResults(logger);
-    const { ctx, streamStatus } = createCtx({ logger });
+    const { ctx, streamStatus, results } = setupResultCase();
     try {
       await expect(
         runFlowWithLifecycle(
@@ -317,9 +319,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
   });
 
   it('keeps the completed result when the completion hook throws', async () => {
-    const logger = new TraceEmitter();
-    const results = collectResults(logger);
-    const { ctx, streamStatus } = createCtx({ logger });
+    const { ctx, streamStatus, results } = setupResultCase();
     try {
       await expect(
         runFlowWithLifecycle(
@@ -349,9 +349,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
   });
 
   it('emits the failed result before terminal error status listeners run', async () => {
-    const logger = new TraceEmitter();
-    const results = collectResults(logger);
-    const { ctx, streamStatus } = createCtx({ logger });
+    const { ctx, streamStatus, results } = setupResultCase();
     const off = streamStatus.onDidChange((change) => {
       if (change.status === STREAM_PHASE.FAILED) {
         throw new Error('status listener boom');
@@ -376,9 +374,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
   });
 
   it('emits the failed result even if ending the parent stage throws', async () => {
-    const logger = new TraceEmitter();
-    const results = collectResults(logger);
-    const { ctx, streamStatus } = createCtx({ logger });
+    const { ctx, streamStatus, results } = setupResultCase();
     vi.spyOn(ctx.parentStage, 'end').mockImplementation(() => {
       throw new Error('stage listener boom');
     });
@@ -401,8 +397,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
   });
 
   it('settles handle.result as failed on a thrown run (always resolves)', async () => {
-    const logger = new TraceEmitter();
-    const { ctx, streamStatus } = createCtx({ logger });
+    const { ctx, streamStatus } = setupResultCase();
     let handle: AgentRunHandle | undefined;
     try {
       await expect(
@@ -428,9 +423,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
   });
 
   it('maps a returned cancellation to a cancelled result (sibling of failed)', async () => {
-    const logger = new TraceEmitter();
-    const results = collectResults(logger);
-    const { ctx, streamStatus } = createCtx({ logger });
+    const { ctx, streamStatus, results } = setupResultCase();
     try {
       await runFlowWithLifecycle(ctx, async () => ({
         category: 'toolUse',
@@ -446,9 +439,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
   });
 
   it('emits a cancelled result with kind=abort on a thrown abort', async () => {
-    const logger = new TraceEmitter();
-    const results = collectResults(logger);
-    const { ctx, streamStatus } = createCtx({ logger });
+    const { ctx, streamStatus, results } = setupResultCase();
     try {
       await runFlowWithLifecycle(ctx, async () => {
         throw new DOMException('Request aborted', 'AbortError');
@@ -462,9 +453,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
   });
 
   it('emits a failed result with usage on an unexpected throw after a round', async () => {
-    const logger = new TraceEmitter();
-    const results = collectResults(logger);
-    const { ctx, streamStatus } = createCtx({ logger });
+    const { ctx, streamStatus, results } = setupResultCase();
     // Record one round of usage so the failed result still carries totals.
     await ctx.usageMonitor.recordUsage(AgentRunStateSnapshotSchema.parse({}));
     try {

--- a/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
+++ b/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
@@ -23,6 +23,19 @@ import {
 
 import { createRecordingHost } from '../progressTestUtils';
 
+/** Fresh registry + recording host, keyed to a per-test stream id. */
+function setupMachine(streamId: string): {
+  machine: StreamStatusRegistry;
+  explicit: ReturnType<typeof createRecordingHost>;
+  streamId: StreamTabId;
+} {
+  return {
+    machine: new StreamStatusRegistry(),
+    explicit: createRecordingHost(),
+    streamId: streamId as StreamTabId,
+  };
+}
+
 describe('StreamStatusRegistry', () => {
   const phases = Object.values(STREAM_PHASE) as StreamPhase[];
   const causes = Object.values(
@@ -102,9 +115,9 @@ describe('StreamStatusRegistry', () => {
   });
 
   it('repairs terminal streams to waiting through resume then wait', () => {
-    const machine = new StreamStatusRegistry();
-    const explicit = createRecordingHost();
-    const streamId = 'stream-status-terminal-waiting-repair' as StreamTabId;
+    const { machine, explicit, streamId } = setupMachine(
+      'stream-status-terminal-waiting-repair',
+    );
 
     seedStreamStatusForTest(machine, streamId, STREAM_PHASE.CANCELLED);
 
@@ -138,9 +151,9 @@ describe('StreamStatusRegistry', () => {
   });
 
   it('terminalizes waiting streams through resume then lifecycle', () => {
-    const machine = new StreamStatusRegistry();
-    const explicit = createRecordingHost();
-    const streamId = 'stream-status-waiting-terminal-repair' as StreamTabId;
+    const { machine, explicit, streamId } = setupMachine(
+      'stream-status-waiting-terminal-repair',
+    );
 
     seedStreamStatusForTest(machine, streamId, STREAM_PHASE.WAITING);
 
@@ -174,9 +187,9 @@ describe('StreamStatusRegistry', () => {
   });
 
   it('terminalizes visible streams that were not started yet', () => {
-    const machine = new StreamStatusRegistry();
-    const explicit = createRecordingHost();
-    const streamId = 'stream-status-undefined-terminal-repair' as StreamTabId;
+    const { machine, explicit, streamId } = setupMachine(
+      'stream-status-undefined-terminal-repair',
+    );
 
     expect(
       machine.transitionToTerminal(streamId, STREAM_PHASE.FAILED, {
@@ -207,9 +220,9 @@ describe('StreamStatusRegistry', () => {
   });
 
   it('accepts already-matching terminal outcomes without warning callers', () => {
-    const machine = new StreamStatusRegistry();
-    const explicit = createRecordingHost();
-    const streamId = 'stream-status-matching-terminal' as StreamTabId;
+    const { machine, explicit, streamId } = setupMachine(
+      'stream-status-matching-terminal',
+    );
 
     seedStreamStatusForTest(machine, streamId, STREAM_PHASE.CANCELLED);
 
@@ -224,9 +237,9 @@ describe('StreamStatusRegistry', () => {
   });
 
   it('clears transient running substates without changing phase', () => {
-    const machine = new StreamStatusRegistry();
-    const explicit = createRecordingHost();
-    const streamId = 'stream-status-clear-running-substate' as StreamTabId;
+    const { machine, explicit, streamId } = setupMachine(
+      'stream-status-clear-running-substate',
+    );
 
     seedStreamStatusForTest(machine, streamId, STREAM_STATUS.RESUMING);
 
@@ -252,9 +265,9 @@ describe('StreamStatusRegistry', () => {
   });
 
   it('publishes rollback when a visible reservation is released', () => {
-    const machine = new StreamStatusRegistry();
-    const explicit = createRecordingHost();
-    const streamId = 'stream-status-reservation-rollback' as StreamTabId;
+    const { machine, explicit, streamId } = setupMachine(
+      'stream-status-reservation-rollback',
+    );
 
     expect(machine.tryAcquire(streamId, { runtimeHost: explicit.host })).toBe(
       true,
@@ -285,9 +298,9 @@ describe('StreamStatusRegistry', () => {
   });
 
   it('overlays reservations on stale terminal phases and restores them on rollback', () => {
-    const machine = new StreamStatusRegistry();
-    const explicit = createRecordingHost();
-    const streamId = 'stream-status-reservation-overlay' as StreamTabId;
+    const { machine, explicit, streamId } = setupMachine(
+      'stream-status-reservation-overlay',
+    );
 
     seedStreamStatusForTest(machine, streamId, STREAM_PHASE.COMPLETED);
 

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -84,6 +84,19 @@ const config = {
   toolConfig: DEFAULT_TOOL_CONFIG,
 } as AgentConfig;
 
+/** Creates a temp dir for the test body, then removes it (recursively) after. */
+async function withTempDir(
+  prefix: string,
+  fn: (dir: string) => Promise<void>,
+): Promise<void> {
+  const dir = await mkdtemp(path.join(tmpdir(), prefix));
+  try {
+    await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
 describe('CLI history runtime', () => {
   beforeEach(async () => {
     const [{ initPlatform }, { nodeFilesystem }, { createFakePlatform }] =
@@ -685,8 +698,7 @@ describe('CLI history runtime', () => {
   });
 
   it('surfaces persisted workspace files without parsing provider messages', async () => {
-    const workspace = await mkdtemp(path.join(tmpdir(), 'texra-history-'));
-    try {
+    await withTempDir('texra-history-', async (workspace) => {
       await writeFile(path.join(workspace, 'durable.md'), '# durable');
       mocks.readConfig.mockResolvedValue({
         ...config,
@@ -714,14 +726,11 @@ describe('CLI history runtime', () => {
       expect(details?.files).toEqual([
         { path: 'workspace/durable.md', size: 9, isDirectory: false },
       ]);
-    } finally {
-      await rm(workspace, { recursive: true, force: true });
-    }
+    });
   });
 
   it('preserves persisted paths inside a top-level workspace directory', async () => {
-    const workspace = await mkdtemp(path.join(tmpdir(), 'texra-history-'));
-    try {
+    await withTempDir('texra-history-', async (workspace) => {
       await mkdir(path.join(workspace, 'workspace'));
       await writeFile(path.join(workspace, 'review.md'), 'wrong');
       await writeFile(path.join(workspace, 'workspace', 'review.md'), 'nested');
@@ -737,14 +746,11 @@ describe('CLI history runtime', () => {
       expect(details?.files).toEqual([
         { path: 'workspace/workspace/review.md', size: 6, isDirectory: false },
       ]);
-    } finally {
-      await rm(workspace, { recursive: true, force: true });
-    }
+    });
   });
 
   it('surfaces workspace files written by tool-use calls', async () => {
-    const workspace = await mkdtemp(path.join(tmpdir(), 'texra-history-'));
-    try {
+    await withTempDir('texra-history-', async (workspace) => {
       await writeFile(path.join(workspace, 'review.md'), '# report');
       await writeFile(path.join(workspace, 'draft.tex'), 'old text');
       mocks.readConfig.mockResolvedValue({
@@ -790,14 +796,11 @@ describe('CLI history runtime', () => {
       expect(formatCliHistoryDetailsText(details!)).toContain(
         '8\tworkspace/review.md',
       );
-    } finally {
-      await rm(workspace, { recursive: true, force: true });
-    }
+    });
   });
 
   it('surfaces workspace files from Responses function call records', async () => {
-    const workspace = await mkdtemp(path.join(tmpdir(), 'texra-history-'));
-    try {
+    await withTempDir('texra-history-', async (workspace) => {
       await writeFile(path.join(workspace, 'response.md'), 'response');
       mocks.readConfig.mockResolvedValue({
         ...config,
@@ -818,14 +821,11 @@ describe('CLI history runtime', () => {
       expect(details?.files).toEqual([
         { path: 'workspace/response.md', size: 8, isDirectory: false },
       ]);
-    } finally {
-      await rm(workspace, { recursive: true, force: true });
-    }
+    });
   });
 
   it('surfaces workspace files from Google functionCall parts', async () => {
-    const workspace = await mkdtemp(path.join(tmpdir(), 'texra-history-'));
-    try {
+    await withTempDir('texra-history-', async (workspace) => {
       await mkdir(path.join(workspace, 'subdir'));
       await writeFile(path.join(workspace, 'subdir', 'gemini.md'), 'gemini');
       mocks.readConfig.mockResolvedValue({
@@ -853,16 +853,13 @@ describe('CLI history runtime', () => {
       expect(details?.files).toEqual([
         { path: 'workspace/subdir/gemini.md', size: 6, isDirectory: false },
       ]);
-    } finally {
-      await rm(workspace, { recursive: true, force: true });
-    }
+    });
   });
 
   it('does not surface missing files or tool paths outside the workspace', async () => {
-    const root = await mkdtemp(path.join(tmpdir(), 'texra-history-root-'));
-    const workspace = path.join(root, 'workspace');
-    const outsidePath = path.join(root, 'outside.md');
-    try {
+    await withTempDir('texra-history-root-', async (root) => {
+      const workspace = path.join(root, 'workspace');
+      const outsidePath = path.join(root, 'outside.md');
       await mkdir(workspace);
       await writeFile(outsidePath, 'outside');
       mocks.readConfig.mockResolvedValue({
@@ -902,9 +899,7 @@ describe('CLI history runtime', () => {
       const details = await readCliHistoryDetails('a1' as ExecutionId);
 
       expect(details?.files).toEqual([]);
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('reports not-found deletion through the structured result', async () => {

--- a/src/test-kernel/cli/InitCommand.vitest.mts
+++ b/src/test-kernel/cli/InitCommand.vitest.mts
@@ -65,8 +65,15 @@ function modelAccess(
   };
 }
 
-async function makeTempProject(): Promise<string> {
-  return fs.mkdtemp(path.join(os.tmpdir(), 'texra-init-test-'));
+async function withTempProject<T>(
+  run: (root: string) => Promise<T>,
+): Promise<T> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-init-test-'));
+  try {
+    return await run(root);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
 }
 
 function expectUnavailableDefaultRecovery(output: string): void {
@@ -248,8 +255,7 @@ describe('CLI init command', () => {
   });
 
   it('emits valid NDJSON for non-interactive init', async () => {
-    const root = await makeTempProject();
-    try {
+    await withTempProject(async (root) => {
       const workspaceRoot = await fs.realpath(root);
       const result = await runCli([
         '--cwd',
@@ -304,14 +310,11 @@ describe('CLI init command', () => {
       await expect(
         fs.readFile(path.join(root, '.gitignore'), 'utf8'),
       ).resolves.toBe('.texra/\n');
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('keeps the legacy text init summary for human output', async () => {
-    const root = await makeTempProject();
-    try {
+    await withTempProject(async (root) => {
       const workspaceRoot = await fs.realpath(root);
       const result = await runCli([
         '--cwd',
@@ -332,9 +335,7 @@ describe('CLI init command', () => {
       );
       expect(stdout).toContain('  agent: assistant');
       expect(stdout).toContain('Next: run `texra` for the launcher');
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('points non-interactive init at model recovery when the default model is unavailable', async () => {
@@ -350,8 +351,7 @@ describe('CLI init command', () => {
         },
       }),
     ]);
-    const root = await makeTempProject();
-    try {
+    await withTempProject(async (root) => {
       const result = await runCli([
         '--cwd',
         root,
@@ -366,9 +366,7 @@ describe('CLI init command', () => {
       expect(result.exitCode).toBe(0);
       expect(stderr).toBe('');
       expectUnavailableDefaultRecovery(stdout);
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('points init at model recovery when the fallback default has no access entry', async () => {
@@ -384,8 +382,7 @@ describe('CLI init command', () => {
         },
       }),
     ]);
-    const root = await makeTempProject();
-    try {
+    await withTempProject(async (root) => {
       const result = await runCli([
         '--cwd',
         root,
@@ -400,8 +397,6 @@ describe('CLI init command', () => {
       expect(result.exitCode).toBe(0);
       expect(stderr).toBe('');
       expectUnavailableDefaultRecovery(stdout);
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 });

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -36,6 +36,10 @@ function agent(
   };
 }
 
+function findPreset(id: string) {
+  return findCliMultiAgentPreset(cliMultiAgentPresets(undefined), id)!;
+}
+
 describe('CLI multi-agent presets', () => {
   it('lists planned built-in team presets with stable counts', () => {
     const presets = cliMultiAgentPresets(undefined);
@@ -68,10 +72,7 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('lists missing preset members as unavailable when no team can launch', () => {
-    const preset = findCliMultiAgentPreset(
-      cliMultiAgentPresets(undefined),
-      'lean-project',
-    )!;
+    const preset = findPreset('lean-project');
     const plan = planCliMultiAgentPresetRun(preset, {
       workflowAgents: [],
       toolUseAgents: [
@@ -93,10 +94,7 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('omits the login recovery hint after a remote agent load was attempted', () => {
-    const preset = findCliMultiAgentPreset(
-      cliMultiAgentPresets(undefined),
-      'lean-project',
-    )!;
+    const preset = findPreset('lean-project');
     const plan = planCliMultiAgentPresetRun(preset, {
       workflowAgents: [],
       toolUseAgents: [
@@ -114,10 +112,7 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('marks missing team roots as unavailable', () => {
-    const preset = findCliMultiAgentPreset(
-      cliMultiAgentPresets(undefined),
-      'lean-project',
-    )!;
+    const preset = findPreset('lean-project');
     const plan = planCliMultiAgentPresetRun(preset, {
       workflowAgents: [],
       toolUseAgents: [
@@ -135,10 +130,7 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('keeps degraded presets launchable when they still have delegation', () => {
-    const preset = findCliMultiAgentPreset(
-      cliMultiAgentPresets(undefined),
-      'physicist',
-    )!;
+    const preset = findPreset('physicist');
     const plan = planCliMultiAgentPresetRun(preset, {
       workflowAgents: [],
       toolUseAgents: [
@@ -152,10 +144,7 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('formats compact launcher summaries from planned availability', () => {
-    const preset = findCliMultiAgentPreset(
-      cliMultiAgentPresets(undefined),
-      'physicist',
-    )!;
+    const preset = findPreset('physicist');
     const plan = planCliMultiAgentPresetRun(preset, {
       workflowAgents: [agent('correct', AgentCategory.Workflow)],
       toolUseAgents: [
@@ -174,10 +163,7 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('formats run warnings from planned missing team members', () => {
-    const preset = findCliMultiAgentPreset(
-      cliMultiAgentPresets(undefined),
-      'physicist',
-    )!;
+    const preset = findPreset('physicist');
     const plan = planCliMultiAgentPresetRun(preset, {
       workflowAgents: [],
       toolUseAgents: [
@@ -193,10 +179,7 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('omits degraded run warnings when only the root is available', () => {
-    const preset = findCliMultiAgentPreset(
-      cliMultiAgentPresets(undefined),
-      'physicist',
-    )!;
+    const preset = findPreset('physicist');
     const plan = planCliMultiAgentPresetRun(preset, {
       workflowAgents: [],
       toolUseAgents: [
@@ -210,10 +193,7 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('marks complete built-in teams available', () => {
-    const preset = findCliMultiAgentPreset(
-      cliMultiAgentPresets(undefined),
-      'physicist',
-    )!;
+    const preset = findPreset('physicist');
     const plan = planCliMultiAgentPresetRun(preset, {
       workflowAgents: preset.workflowAgents.map((name) =>
         agent(name, AgentCategory.Workflow),
@@ -235,10 +215,7 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('launches the software-engineer team on its bundled engineer root', () => {
-    const preset = findCliMultiAgentPreset(
-      cliMultiAgentPresets(undefined),
-      'software-engineer',
-    )!;
+    const preset = findPreset('software-engineer');
     const plan = planCliMultiAgentPresetRun(preset, {
       workflowAgents: [],
       toolUseAgents: preset.toolUseAgents.map((name) =>
@@ -261,10 +238,7 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('keeps unavailable preset facts separate from launcher guidance', () => {
-    const preset = findCliMultiAgentPreset(
-      cliMultiAgentPresets(undefined),
-      'physicist',
-    )!;
+    const preset = findPreset('physicist');
     const plan = planCliMultiAgentPresetRun(preset, {
       workflowAgents: [],
       toolUseAgents: [],
@@ -281,10 +255,7 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('formats team launch block messages from the planned preset state', () => {
-    const preset = findCliMultiAgentPreset(
-      cliMultiAgentPresets(undefined),
-      'lean-project',
-    )!;
+    const preset = findPreset('lean-project');
     const plan = planCliMultiAgentPresetRun(preset, {
       workflowAgents: [],
       toolUseAgents: [agent('lean', AgentCategory.ToolUse)],
@@ -302,10 +273,7 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('formats explicit non-delegating team roots without old fallback wording', () => {
-    const preset = findCliMultiAgentPreset(
-      cliMultiAgentPresets(undefined),
-      'mathematician',
-    )!;
+    const preset = findPreset('mathematician');
     const plan = planCliMultiAgentPresetRun(preset, {
       workflowAgents: [],
       toolUseAgents: [agent('lean', AgentCategory.ToolUse)],
@@ -325,10 +293,7 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('rejects launch block message formatting for launchable plans', () => {
-    const preset = findCliMultiAgentPreset(
-      cliMultiAgentPresets(undefined),
-      'lean-project',
-    )!;
+    const preset = findPreset('lean-project');
     const plan = planCliMultiAgentPresetRun(preset, {
       workflowAgents: [],
       toolUseAgents: preset.toolUseAgents.map((name) =>
@@ -380,10 +345,7 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('serializes planned availability for machine-readable list output', () => {
-    const preset = findCliMultiAgentPreset(
-      cliMultiAgentPresets(undefined),
-      'lean-project',
-    )!;
+    const preset = findPreset('lean-project');
     const plan = planCliMultiAgentPresetRun(preset, {
       workflowAgents: [],
       toolUseAgents: [
@@ -420,10 +382,7 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('includes planned availability in ndjson preset records', () => {
-    const preset = findCliMultiAgentPreset(
-      cliMultiAgentPresets(undefined),
-      'lean-project',
-    )!;
+    const preset = findPreset('lean-project');
     const plan = planCliMultiAgentPresetRun(preset, {
       workflowAgents: [],
       toolUseAgents: [agent('lean', AgentCategory.ToolUse)],
@@ -516,10 +475,7 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('formats an inspection plan with root and missing members', () => {
-    const preset = findCliMultiAgentPreset(
-      cliMultiAgentPresets(undefined),
-      'physicist',
-    )!;
+    const preset = findPreset('physicist');
     const plan = planCliMultiAgentPresetRun(preset, {
       workflowAgents: [
         agent('correct', AgentCategory.Workflow),
@@ -559,10 +515,7 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('omits inspection login recovery hint after a remote agent load was attempted', () => {
-    const preset = findCliMultiAgentPreset(
-      cliMultiAgentPresets(undefined),
-      'physicist',
-    )!;
+    const preset = findPreset('physicist');
     const plan = planCliMultiAgentPresetRun(preset, {
       workflowAgents: [],
       toolUseAgents: [agent('review', AgentCategory.ToolUse)],
@@ -577,10 +530,7 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('plans a preset run with canonical visibility keys and an orchestrator root', () => {
-    const preset = findCliMultiAgentPreset(
-      cliMultiAgentPresets(undefined),
-      'physicist',
-    )!;
+    const preset = findPreset('physicist');
     const plan = planCliMultiAgentPresetRun(preset, {
       workflowAgents: [
         agent('correct', AgentCategory.Workflow),
@@ -605,10 +555,7 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('flags a gap when a built-in preset has members but no root', () => {
-    const preset = findCliMultiAgentPreset(
-      cliMultiAgentPresets(undefined),
-      'physicist',
-    )!;
+    const preset = findPreset('physicist');
     // A local-only registry can expose team members before relay-served
     // orchestrators are available. The members should still count as available,
     // but they should not be promoted to the built-in team root.
@@ -622,10 +569,7 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('does not select built-in team specialists as implicit roots', () => {
-    const preset = findCliMultiAgentPreset(
-      cliMultiAgentPresets(undefined),
-      'physicist',
-    )!;
+    const preset = findPreset('physicist');
     const plan = planCliMultiAgentPresetRun(preset, {
       workflowAgents: [],
       toolUseAgents: [
@@ -646,10 +590,7 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('keeps delegating built-in specialists as members instead of roots', () => {
-    const preset = findCliMultiAgentPreset(
-      cliMultiAgentPresets(undefined),
-      'lean-project',
-    )!;
+    const preset = findPreset('lean-project');
     const plan = planCliMultiAgentPresetRun(preset, {
       workflowAgents: [],
       toolUseAgents: [
@@ -756,10 +697,7 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('reports no gaps when every preset member resolves', () => {
-    const preset = findCliMultiAgentPreset(
-      cliMultiAgentPresets(undefined),
-      'lean-project',
-    )!;
+    const preset = findPreset('lean-project');
     const plan = planCliMultiAgentPresetRun(preset, {
       workflowAgents: [],
       toolUseAgents: preset.toolUseAgents.map((name) =>
@@ -777,10 +715,7 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('flags a gap when no root agent can be selected', () => {
-    const preset = findCliMultiAgentPreset(
-      cliMultiAgentPresets(undefined),
-      'physicist',
-    )!;
+    const preset = findPreset('physicist');
     const plan = planCliMultiAgentPresetRun(preset, {
       workflowAgents: [],
       toolUseAgents: [],
@@ -791,10 +726,7 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('adds an explicit root override to the visible tool-use team', () => {
-    const preset = findCliMultiAgentPreset(
-      cliMultiAgentPresets(undefined),
-      'lean-project',
-    )!;
+    const preset = findPreset('lean-project');
     const plan = planCliMultiAgentPresetRun(preset, {
       workflowAgents: [],
       toolUseAgents: [
@@ -819,10 +751,7 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('allows a preset member when explicitly requested as the root', () => {
-    const preset = findCliMultiAgentPreset(
-      cliMultiAgentPresets(undefined),
-      'physicist',
-    )!;
+    const preset = findPreset('physicist');
     const plan = planCliMultiAgentPresetRun(preset, {
       workflowAgents: [],
       toolUseAgents: [
@@ -837,10 +766,7 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('tracks a missing root override as a plan gap', () => {
-    const preset = findCliMultiAgentPreset(
-      cliMultiAgentPresets(undefined),
-      'lean-project',
-    )!;
+    const preset = findPreset('lean-project');
     const plan = planCliMultiAgentPresetRun(preset, {
       workflowAgents: [],
       toolUseAgents: preset.toolUseAgents.map((name) =>

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -11,6 +11,7 @@ import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import type { CliContext } from '@cli/runtime/cliContext';
+import type { executeCliRequest } from '@cli/runtime/runExecution';
 import {
   EXECUTION_STATUS,
   type StreamTabId,
@@ -92,6 +93,13 @@ function cliContext(overrides: Partial<CliContext> = {}): CliContext {
   };
 }
 
+function baseRequest(): Parameters<typeof executeCliRequest>[0] {
+  return {
+    config: {},
+    executionId: 'exec-1',
+  } as Parameters<typeof executeCliRequest>[0];
+}
+
 function toolUseConfig() {
   return {
     agent: 'chat',
@@ -135,10 +143,7 @@ describe('executeCliRequest', () => {
 
   it('marks headless never runs as approval-unavailable for agent execution', async () => {
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
-    const request = {
-      config: {},
-      executionId: 'exec-1',
-    } as Parameters<typeof executeCliRequest>[0];
+    const request = baseRequest();
 
     await executeCliRequest(request, cliContext());
 
@@ -152,10 +157,7 @@ describe('executeCliRequest', () => {
 
   it('marks headless ask runs as approval-unavailable for agent execution', async () => {
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
-    const request = {
-      config: {},
-      executionId: 'exec-1',
-    } as Parameters<typeof executeCliRequest>[0];
+    const request = baseRequest();
 
     await executeCliRequest(request, cliContext({ approvalPolicy: 'ask' }));
 
@@ -169,10 +171,7 @@ describe('executeCliRequest', () => {
 
   it('keeps yolo runs approval-available for agent execution', async () => {
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
-    const request = {
-      config: {},
-      executionId: 'exec-1',
-    } as Parameters<typeof executeCliRequest>[0];
+    const request = baseRequest();
 
     await executeCliRequest(request, cliContext({ approvalPolicy: 'yolo' }));
 
@@ -186,10 +185,7 @@ describe('executeCliRequest', () => {
 
   it('hides host-unavailable tools in CLI execution', async () => {
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
-    const request = {
-      config: {},
-      executionId: 'exec-1',
-    } as Parameters<typeof executeCliRequest>[0];
+    const request = baseRequest();
 
     await executeCliRequest(
       request,
@@ -212,10 +208,7 @@ describe('executeCliRequest', () => {
 
   it('preserves caller-provided runtime tool exclusions', async () => {
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
-    const request = {
-      config: {},
-      executionId: 'exec-1',
-    } as Parameters<typeof executeCliRequest>[0];
+    const request = baseRequest();
 
     await executeCliRequest(request, cliContext(), {
       runtimeUnavailableTools: ['custom_tool'],
@@ -237,10 +230,7 @@ describe('executeCliRequest', () => {
 
   it('installs CLI approval handlers with the runtime prompt hook', async () => {
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
-    const request = {
-      config: {},
-      executionId: 'exec-1',
-    } as Parameters<typeof executeCliRequest>[0];
+    const request = baseRequest();
     const context = cliContext({ mode: 'interactive', approvalPolicy: 'ask' });
 
     await executeCliRequest(request, context);
@@ -259,10 +249,7 @@ describe('executeCliRequest', () => {
 
   it('restores CLI approval handlers before closing the runtime host', async () => {
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
-    const request = {
-      config: {},
-      executionId: 'exec-1',
-    } as Parameters<typeof executeCliRequest>[0];
+    const request = baseRequest();
     const uninstall = vi.fn();
     mocks.installCliApprovalHandlers.mockReturnValue(uninstall);
 
@@ -278,10 +265,7 @@ describe('executeCliRequest', () => {
   it('persists headless stream sidecars emitted through the runtime host', async () => {
     await installStoragePlatform();
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
-    const request = {
-      config: {},
-      executionId: 'exec-1',
-    } as Parameters<typeof executeCliRequest>[0];
+    const request = baseRequest();
     const todo: TodoItem = {
       content: 'Write the introduction',
       status: 'in_progress',
@@ -329,10 +313,7 @@ describe('executeCliRequest', () => {
 
     try {
       const { executeCliRequest } = await import('@cli/runtime/runExecution');
-      const request = {
-        config: {},
-        executionId: 'exec-1',
-      } as Parameters<typeof executeCliRequest>[0];
+      const request = baseRequest();
 
       await expect(executeCliRequest(request, cliContext())).rejects.toThrow(
         flushError,
@@ -350,10 +331,7 @@ describe('executeCliRequest', () => {
     const platform = createFakePlatform();
     initPlatform(platform);
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
-    const request = {
-      config: {},
-      executionId: 'exec-1',
-    } as Parameters<typeof executeCliRequest>[0];
+    const request = baseRequest();
     let resolveRun:
       | ((result: Awaited<ReturnType<typeof mocks.runAgent>>) => void)
       | undefined;
@@ -393,10 +371,7 @@ describe('executeCliRequest', () => {
     const platform = createFakePlatform();
     initPlatform(platform);
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
-    const request = {
-      config: {},
-      executionId: 'exec-1',
-    } as Parameters<typeof executeCliRequest>[0];
+    const request = baseRequest();
 
     await executeCliRequest(request, cliContext(), {
       registerExecution: true,

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -112,6 +112,16 @@ function toolUseTaskState(
   };
 }
 
+function outputBuffer(): { write: (chunk: string) => void; text: string } {
+  const buffer = {
+    text: '',
+    write: (chunk: string) => {
+      buffer.text += chunk;
+    },
+  };
+  return buffer;
+}
+
 async function captureStreamWrites(
   stream: NodeJS.WriteStream,
   action: () => Promise<void>,
@@ -155,57 +165,51 @@ describe('CLI run progress renderer', () => {
 
   it('renders a single ANSI status line and clears it on close', () => {
     let now = 0;
-    let output = '';
+    const output = outputBuffer();
     const renderer = createRunProgressRenderer(context(), {
       colorEnabled: true,
-      write: (text) => {
-        output += text;
-      },
+      write: output.write,
       nowMs: () => now,
     });
 
     expect(renderer).toBeDefined();
     renderer?.handle('setTaskState', workflowTaskState());
-    expect(output).toBe('\r\x1b[2Kpolish paper.tex · 0s');
+    expect(output.text).toBe('\r\x1b[2Kpolish paper.tex · 0s');
 
     now = 1200;
     renderer?.handle('updateConversationProgress', {
       streamId: 'stream-1',
       progress: { conversationTurns: 2, toolCallCount: 0 },
     });
-    expect(output).toContain('\r\x1b[2K[r2] · polish paper.tex · 1s');
+    expect(output.text).toContain('\r\x1b[2K[r2] · polish paper.tex · 1s');
 
     renderer?.clear();
-    expect(output.endsWith('\r\x1b[2K')).toBe(true);
+    expect(output.text.endsWith('\r\x1b[2K')).toBe(true);
   });
 
   it('keeps long elapsed times in minute-second form', () => {
     let now = 0;
-    let output = '';
+    const output = outputBuffer();
     const renderer = createRunProgressRenderer(context(), {
       colorEnabled: true,
-      write: (text) => {
-        output += text;
-      },
+      write: output.write,
       nowMs: () => now,
     });
 
     now = 3_600_000;
     renderer?.handle('setTaskState', workflowTaskState());
 
-    expect(output).toContain('\r\x1b[2Kpolish paper.tex · 60m 00s');
+    expect(output.text).toContain('\r\x1b[2Kpolish paper.tex · 60m 00s');
   });
 
   it('ticks the ANSI status line while a root workflow is quiet', () => {
     let now = 0;
-    let output = '';
+    const output = outputBuffer();
     let heartbeat: (() => void) | undefined;
     let clearCount = 0;
     const renderer = createRunProgressRenderer(context(), {
       colorEnabled: true,
-      write: (text) => {
-        output += text;
-      },
+      write: output.write,
       nowMs: () => now,
       setInterval: ((callback: () => void) => {
         heartbeat = callback;
@@ -224,8 +228,8 @@ describe('CLI run progress renderer', () => {
     now = 2300;
     heartbeat?.();
 
-    expect(output).toContain('\r\x1b[2Kpolish paper.tex · 1s');
-    expect(output).toContain('\r\x1b[2Kpolish paper.tex · 2s');
+    expect(output.text).toContain('\r\x1b[2Kpolish paper.tex · 1s');
+    expect(output.text).toContain('\r\x1b[2Kpolish paper.tex · 2s');
 
     renderer?.handle('updateStreamStatus', {
       streamId: 'stream-1',
@@ -236,14 +240,12 @@ describe('CLI run progress renderer', () => {
   });
 
   it('summarizes multi-input workflow progress without hiding extra files', () => {
-    let output = '';
+    const output = outputBuffer();
     const renderer = createRunProgressRenderer(
       context({ colorEnabled: false }),
       {
         colorEnabled: false,
-        write: (text) => {
-          output += text;
-        },
+        write: output.write,
         nowMs: () => 0,
       },
     );
@@ -255,21 +257,19 @@ describe('CLI run progress renderer', () => {
       }),
     );
 
-    expect(output).toBe('polish number-theory.tex +1 · 0s\n');
+    expect(output.text).toBe('polish number-theory.tex +1 · 0s\n');
   });
 
   it('shows planned workflow rounds before the first model turn', () => {
     mocks.getAgent.mockReturnValue({
       rounds: 2,
     });
-    let output = '';
+    const output = outputBuffer();
     const renderer = createRunProgressRenderer(
       context({ colorEnabled: false }),
       {
         colorEnabled: false,
-        write: (text) => {
-          output += text;
-        },
+        write: output.write,
         minIntervalMs: 0,
         nowMs: () => 0,
       },
@@ -285,7 +285,7 @@ describe('CLI run progress renderer', () => {
       'polish',
       AgentCategory.Workflow,
     );
-    expect(output).toBe(
+    expect(output.text).toBe(
       'polish paper.tex · 2 rounds · 0s\n' + '[r1/2] · polish paper.tex · 0s\n',
     );
   });
@@ -294,14 +294,12 @@ describe('CLI run progress renderer', () => {
     mocks.getAgent.mockReturnValue({
       rounds: 2,
     });
-    let output = '';
+    const output = outputBuffer();
     const renderer = createRunProgressRenderer(
       context({ colorEnabled: false }),
       {
         colorEnabled: false,
-        write: (text) => {
-          output += text;
-        },
+        write: output.write,
         nowMs: () => 0,
       },
     );
@@ -314,18 +312,16 @@ describe('CLI run progress renderer', () => {
     );
 
     expect(mocks.getAgent).not.toHaveBeenCalled();
-    expect(output).toBe('polish · 0s\n');
+    expect(output.text).toBe('polish · 0s\n');
   });
 
   it('prints phase changes on separate lines when ANSI is disabled', () => {
-    let output = '';
+    const output = outputBuffer();
     const renderer = createRunProgressRenderer(
       context({ colorEnabled: false }),
       {
         colorEnabled: false,
-        write: (text) => {
-          output += text;
-        },
+        write: output.write,
         nowMs: () => 0,
       },
     );
@@ -347,7 +343,7 @@ describe('CLI run progress renderer', () => {
       ],
     });
 
-    expect(output).toBe(
+    expect(output.text).toBe(
       'polish paper.tex · 0s\n' +
         'polish paper.tex · drafting · 0s\n' +
         'polish paper.tex · drafting · tool: Bash · 0s\n',
@@ -355,14 +351,12 @@ describe('CLI run progress renderer', () => {
   });
 
   it('keeps the root run visible when child streams update progress', () => {
-    let output = '';
+    const output = outputBuffer();
     const renderer = createRunProgressRenderer(
       context({ colorEnabled: false }),
       {
         colorEnabled: false,
-        write: (text) => {
-          output += text;
-        },
+        write: output.write,
         nowMs: () => 0,
       },
     );
@@ -411,7 +405,7 @@ describe('CLI run progress renderer', () => {
       ],
     });
 
-    expect(output).toBe(
+    expect(output.text).toBe(
       'coordinator main.tex · 0s\n' +
         'coordinator main.tex · subagents: reviewer +2 · 0s\n',
     );
@@ -419,14 +413,12 @@ describe('CLI run progress renderer', () => {
 
   it('ticks the ANSI status line while an active subagent is quiet', () => {
     let now = 0;
-    let output = '';
+    const output = outputBuffer();
     let heartbeat: (() => void) | undefined;
     let clearCount = 0;
     const renderer = createRunProgressRenderer(context(), {
       colorEnabled: true,
-      write: (text) => {
-        output += text;
-      },
+      write: output.write,
       nowMs: () => now,
       setInterval: ((callback: () => void) => {
         heartbeat = callback;
@@ -464,8 +456,12 @@ describe('CLI run progress renderer', () => {
     now = 2300;
     heartbeat?.();
 
-    expect(output).toContain('\r\x1b[2Korchestrator · subagent: review · 1s');
-    expect(output).toContain('\r\x1b[2Korchestrator · subagent: review · 2s');
+    expect(output.text).toContain(
+      '\r\x1b[2Korchestrator · subagent: review · 1s',
+    );
+    expect(output.text).toContain(
+      '\r\x1b[2Korchestrator · subagent: review · 2s',
+    );
 
     renderer?.handle('updateStreamStatus', {
       streamId: 'root-stream',
@@ -477,13 +473,11 @@ describe('CLI run progress renderer', () => {
 
   it('keeps heartbeat alive when active child names are unavailable', () => {
     let now = 0;
-    let output = '';
+    const output = outputBuffer();
     let heartbeat: (() => void) | undefined;
     const renderer = createRunProgressRenderer(context(), {
       colorEnabled: true,
-      write: (text) => {
-        output += text;
-      },
+      write: output.write,
       nowMs: () => now,
       setInterval: ((callback: () => void) => {
         heartbeat = callback;
@@ -515,17 +509,15 @@ describe('CLI run progress renderer', () => {
     now = 1200;
     heartbeat?.();
 
-    expect(output).toContain('\r\x1b[2Korchestrator · 1s');
+    expect(output.text).toContain('\r\x1b[2Korchestrator · 1s');
   });
 
   it('stops active-child heartbeat when preserving the live line', () => {
-    let output = '';
+    const output = outputBuffer();
     let clearCount = 0;
     const renderer = createRunProgressRenderer(context(), {
       colorEnabled: true,
-      write: (text) => {
-        output += text;
-      },
+      write: output.write,
       nowMs: () => 0,
       setInterval: (() => {
         return { unref() {} } as unknown as ReturnType<typeof setInterval>;
@@ -558,18 +550,16 @@ describe('CLI run progress renderer', () => {
     renderer?.preserve();
 
     expect(clearCount).toBe(1);
-    expect(output.endsWith('\n')).toBe(true);
+    expect(output.text.endsWith('\n')).toBe(true);
   });
 
   it('can claim the root stream from conversation progress', () => {
-    let output = '';
+    const output = outputBuffer();
     const renderer = createRunProgressRenderer(
       context({ colorEnabled: false }),
       {
         colorEnabled: false,
-        write: (text) => {
-          output += text;
-        },
+        write: output.write,
         minIntervalMs: 0,
         nowMs: () => 0,
       },
@@ -588,18 +578,16 @@ describe('CLI run progress renderer', () => {
       }),
     );
 
-    expect(output).toBe('[r2] · running · tools: 4 · 0s\n');
+    expect(output.text).toBe('[r2] · running · tools: 4 · 0s\n');
   });
 
   it('keeps named active children visible when earlier entries are unnamed', () => {
-    let output = '';
+    const output = outputBuffer();
     const renderer = createRunProgressRenderer(
       context({ colorEnabled: false }),
       {
         colorEnabled: false,
-        write: (text) => {
-          output += text;
-        },
+        write: output.write,
         nowMs: () => 0,
       },
     );
@@ -622,21 +610,19 @@ describe('CLI run progress renderer', () => {
       ],
     });
 
-    expect(output).toBe(
+    expect(output.text).toBe(
       'polish paper.tex · 0s\npolish paper.tex · tool: latexmk · 0s\n',
     );
   });
 
   it('shows completed terminal stream stops as done', () => {
     let now = 0;
-    let output = '';
+    const output = outputBuffer();
     const renderer = createRunProgressRenderer(
       context({ colorEnabled: false }),
       {
         colorEnabled: false,
-        write: (text) => {
-          output += text;
-        },
+        write: output.write,
         minIntervalMs: 0,
         nowMs: () => now,
       },
@@ -690,7 +676,7 @@ describe('CLI run progress renderer', () => {
       ],
     });
 
-    expect(output).toBe(
+    expect(output.text).toBe(
       'orchestrator · 0s\n' +
         'orchestrator · tool: Bash · 0s\n' +
         'orchestrator · done · 11s\n',
@@ -698,14 +684,12 @@ describe('CLI run progress renderer', () => {
   });
 
   it('keeps interrupted terminal stream stops distinct from completion', () => {
-    let output = '';
+    const output = outputBuffer();
     const renderer = createRunProgressRenderer(
       context({ colorEnabled: false }),
       {
         colorEnabled: false,
-        write: (text) => {
-          output += text;
-        },
+        write: output.write,
         minIntervalMs: 0,
         nowMs: () => 0,
       },
@@ -725,7 +709,9 @@ describe('CLI run progress renderer', () => {
       previousStatus: STREAM_STATUS.RUNNING,
     });
 
-    expect(output).toBe('orchestrator · 0s\norchestrator · interrupted · 0s\n');
+    expect(output.text).toBe(
+      'orchestrator · 0s\norchestrator · interrupted · 0s\n',
+    );
   });
 
   it('uses a separate render flag from platform log suppression', () => {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -2,7 +2,7 @@
 
 import { EventEmitter } from 'node:events';
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   createRunTrace,
@@ -1752,6 +1752,21 @@ describe('finalizeSettledPrefix', () => {
 });
 
 describe('CLI transcript state', () => {
+  // Several tests below log through `createRunTrace`/`syncStreamLog`, which
+  // read and write the *default* stream log store. Give every test in this
+  // block a fresh store up front and restore the original afterward, so
+  // store-backed tests don't need to repeat that swap individually.
+  let previousStore: StreamLogStore;
+
+  beforeEach(() => {
+    previousStore = getDefaultStreamLogStore();
+    setDefaultStreamLogStore(new StreamLogStore());
+  });
+
+  afterEach(() => {
+    setDefaultStreamLogStore(previousStore);
+  });
+
   it('renders orchestrator follow-ups without protocol tags', () => {
     expect(
       stripOrchestratorFollowup(
@@ -1764,253 +1779,189 @@ describe('CLI transcript state', () => {
   });
 
   it('summarizes subagent protocol continuations in the visible transcript', () => {
-    const previousStore = getDefaultStreamLogStore();
-    const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
+    const logger = createRunTrace(root).trace;
+    logger.info('Please solve the problem.', {
+      messageType: MESSAGE_TYPES.USER_MESSAGE,
+    });
+    logger.info(
+      '<subagent-result id="abc" agent="review" category="toolUse" status="completed">\nDone.\n</subagent-result>',
+      { messageType: MESSAGE_TYPES.USER_MESSAGE },
+    );
 
-    try {
-      const logger = createRunTrace(root).trace;
-      logger.info('Please solve the problem.', {
-        messageType: MESSAGE_TYPES.USER_MESSAGE,
-      });
-      logger.info(
-        '<subagent-result id="abc" agent="review" category="toolUse" status="completed">\nDone.\n</subagent-result>',
-        { messageType: MESSAGE_TYPES.USER_MESSAGE },
-      );
+    syncStreamLog(root);
 
-      syncStreamLog(root);
-
-      const entries = cliState.streams.get().get(root)?.entries ?? [];
-      expect(entries.map((entry) => entry.text)).toEqual([
-        'Please solve the problem.',
-        '✓ review completed',
-      ]);
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
+    const entries = cliState.streams.get().get(root)?.entries ?? [];
+    expect(entries.map((entry) => entry.text)).toEqual([
+      'Please solve the problem.',
+      '✓ review completed',
+    ]);
   });
 
   it('summarizes embedded subagent progress blocks in assistant transcript text', () => {
-    const previousStore = getDefaultStreamLogStore();
-    const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
+    const logger = createRunTrace(root).trace;
+    logger.info(
+      [
+        'Waiting for the child.',
+        '<subagent-progress id="abc" agent="prover" type="todos">',
+        '[{"content":"check","status":"completed"},{"content":"prove","status":"in_progress"}]',
+        '</subagent-progress>',
+        '<subagent-progress id="abc" agent="prover" type="activity">Subagent prover is proving completeness.</subagent-progress>',
+      ].join('\n'),
+      { messageType: MESSAGE_TYPES.MODEL_RESPONSE },
+    );
 
-    try {
-      const logger = createRunTrace(root).trace;
-      logger.info(
-        [
-          'Waiting for the child.',
-          '<subagent-progress id="abc" agent="prover" type="todos">',
-          '[{"content":"check","status":"completed"},{"content":"prove","status":"in_progress"}]',
-          '</subagent-progress>',
-          '<subagent-progress id="abc" agent="prover" type="activity">Subagent prover is proving completeness.</subagent-progress>',
-        ].join('\n'),
-        { messageType: MESSAGE_TYPES.MODEL_RESPONSE },
-      );
+    syncStreamLog(root);
 
-      syncStreamLog(root);
-
-      const entries = cliState.streams.get().get(root)?.entries ?? [];
-      expect(entries.map((entry) => entry.text)).toEqual([
-        [
-          'Waiting for the child.',
-          '⟳ prover · todos · 1 done, 1 active, 0 pending',
-          '⟳ prover · Subagent prover is proving completeness.',
-        ].join('\n'),
-      ]);
-      expect(entries[0]?.text).not.toContain('<subagent-progress');
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
+    const entries = cliState.streams.get().get(root)?.entries ?? [];
+    expect(entries.map((entry) => entry.text)).toEqual([
+      [
+        'Waiting for the child.',
+        '⟳ prover · todos · 1 done, 1 active, 0 pending',
+        '⟳ prover · Subagent prover is proving completeness.',
+      ].join('\n'),
+    ]);
+    expect(entries[0]?.text).not.toContain('<subagent-progress');
   });
 
   it('normalizes common HTML before assistant text reaches the live transcript', () => {
-    const previousStore = getDefaultStreamLogStore();
-    const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
+    const logger = createRunTrace(root).trace;
+    logger.info(
+      '<h3>Verification Report</h3>The proof is <b>fully verified</b>.',
+      { messageType: MESSAGE_TYPES.MODEL_RESPONSE },
+    );
 
-    try {
-      const logger = createRunTrace(root).trace;
-      logger.info(
-        '<h3>Verification Report</h3>The proof is <b>fully verified</b>.',
-        { messageType: MESSAGE_TYPES.MODEL_RESPONSE },
-      );
+    syncStreamLog(root);
 
-      syncStreamLog(root);
-
-      const entries = cliState.streams.get().get(root)?.entries ?? [];
-      expect(entries.map((entry) => entry.text)).toEqual([
-        '### Verification Report\n\nThe proof is **fully verified**.',
-      ]);
-      expect(entries[0]?.text).not.toContain('<h3>');
-      expect(entries[0]?.text).not.toContain('<b>');
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
+    const entries = cliState.streams.get().get(root)?.entries ?? [];
+    expect(entries.map((entry) => entry.text)).toEqual([
+      '### Verification Report\n\nThe proof is **fully verified**.',
+    ]);
+    expect(entries[0]?.text).not.toContain('<h3>');
+    expect(entries[0]?.text).not.toContain('<b>');
   });
 
   it('bounds long subagent result responses in the visible transcript', () => {
-    const previousStore = getDefaultStreamLogStore();
-    const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
+    const logger = createRunTrace(root).trace;
+    const response = Array.from(
+      { length: 20 },
+      (_, index) => `proof line ${index + 1}`,
+    ).join('\n');
+    logger.info(
+      [
+        '<subagent-result id="abc" agent="prover" category="toolUse" status="completed">',
+        '<wall-time>2m</wall-time>',
+        '<response>',
+        response,
+        '</response>',
+        '</subagent-result>',
+      ].join('\n'),
+      { messageType: MESSAGE_TYPES.USER_MESSAGE },
+    );
 
-    try {
-      const logger = createRunTrace(root).trace;
-      const response = Array.from(
-        { length: 20 },
-        (_, index) => `proof line ${index + 1}`,
-      ).join('\n');
-      logger.info(
-        [
-          '<subagent-result id="abc" agent="prover" category="toolUse" status="completed">',
-          '<wall-time>2m</wall-time>',
-          '<response>',
-          response,
-          '</response>',
-          '</subagent-result>',
-        ].join('\n'),
-        { messageType: MESSAGE_TYPES.USER_MESSAGE },
-      );
+    syncStreamLog(root);
 
-      syncStreamLog(root);
-
-      const entries = cliState.streams.get().get(root)?.entries ?? [];
-      expect(entries).toHaveLength(1);
-      expect(entries[0]?.text).toContain('✓ prover completed · 2m');
-      expect(entries[0]?.text).toContain('proof line 12');
-      expect(entries[0]?.text).not.toContain('proof line 13');
-      expect(entries[0]?.text).toContain(
-        '… 8 more lines; open the subagent transcript for the full response',
-      );
-      expect(entries[0]?.text).not.toContain('<subagent-result');
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
+    const entries = cliState.streams.get().get(root)?.entries ?? [];
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.text).toContain('✓ prover completed · 2m');
+    expect(entries[0]?.text).toContain('proof line 12');
+    expect(entries[0]?.text).not.toContain('proof line 13');
+    expect(entries[0]?.text).toContain(
+      '… 8 more lines; open the subagent transcript for the full response',
+    );
+    expect(entries[0]?.text).not.toContain('<subagent-result');
   });
 
   it('mirrors error log entries into the transcript', () => {
-    const previousStore = getDefaultStreamLogStore();
-    const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
+    const logger = createRunTrace(root).trace;
+    logger.error('Model request failed', {
+      messageType: MESSAGE_TYPES.ERROR,
+    });
 
-    try {
-      const logger = createRunTrace(root).trace;
-      logger.error('Model request failed', {
-        messageType: MESSAGE_TYPES.ERROR,
-      });
+    syncStreamLog(root);
 
-      syncStreamLog(root);
-
-      const entries = cliState.streams.get().get(root)?.entries ?? [];
-      expect(entries).toHaveLength(1);
-      expect(entries[0]).toMatchObject({
-        role: 'error',
-        text: 'Model request failed',
-        finalized: true,
-      });
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
+    const entries = cliState.streams.get().get(root)?.entries ?? [];
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      role: 'error',
+      text: 'Model request failed',
+      finalized: true,
+    });
   });
 
   it('tracks hidden thinking activity without rendering thinking text', () => {
-    const previousStore = getDefaultStreamLogStore();
-    const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
+    const logger = createRunTrace(root).trace;
+    const thinking = logger.openStream(MESSAGE_TYPES.THINKING);
 
-    try {
-      const logger = createRunTrace(root).trace;
-      const thinking = logger.openStream(MESSAGE_TYPES.THINKING);
+    // Opening the stream alone marks the phase — hidden reasoning (e.g.
+    // gpt-5 without summaries) may never produce a text delta.
+    syncStreamLog(root);
 
-      // Opening the stream alone marks the phase — hidden reasoning (e.g.
-      // gpt-5 without summaries) may never produce a text delta.
-      syncStreamLog(root);
+    let slice = cliState.streams.get().get(root);
+    expect(slice?.thinkingActive).toBe(true);
+    expect(slice?.entries).toEqual([]);
 
-      let slice = cliState.streams.get().get(root);
-      expect(slice?.thinkingActive).toBe(true);
-      expect(slice?.entries).toEqual([]);
+    thinking.append('private reasoning summary');
 
-      thinking.append('private reasoning summary');
+    syncStreamLog(root);
 
-      syncStreamLog(root);
+    slice = cliState.streams.get().get(root);
+    expect(slice?.thinkingActive).toBe(true);
+    expect(slice?.entries).toEqual([]);
 
-      slice = cliState.streams.get().get(root);
-      expect(slice?.thinkingActive).toBe(true);
-      expect(slice?.entries).toEqual([]);
+    thinking.finalize();
+    syncStreamLog(root);
 
-      thinking.finalize();
-      syncStreamLog(root);
+    slice = cliState.streams.get().get(root);
+    expect(slice?.thinkingActive).toBe(false);
+    expect(slice?.entries).toEqual([]);
 
-      slice = cliState.streams.get().get(root);
-      expect(slice?.thinkingActive).toBe(false);
-      expect(slice?.entries).toEqual([]);
+    const output = logger.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
+    output.append('Visible answer.');
 
-      const output = logger.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
-      output.append('Visible answer.');
+    syncStreamLog(root);
 
-      syncStreamLog(root);
-
-      slice = cliState.streams.get().get(root);
-      expect(slice?.thinkingActive).toBe(false);
-      expect(slice?.entries.map((entry) => entry.text)).toEqual([
-        'Visible answer.',
-      ]);
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
+    slice = cliState.streams.get().get(root);
+    expect(slice?.thinkingActive).toBe(false);
+    expect(slice?.entries.map((entry) => entry.text)).toEqual([
+      'Visible answer.',
+    ]);
   });
 
   it('does not project empty assistant responses into transcript rows', () => {
-    const previousStore = getDefaultStreamLogStore();
-    const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
+    const logger = createRunTrace(root).trace;
+    logger.info('', { messageType: MESSAGE_TYPES.MODEL_RESPONSE });
 
-    try {
-      const logger = createRunTrace(root).trace;
-      logger.info('', { messageType: MESSAGE_TYPES.MODEL_RESPONSE });
+    syncStreamLog(root);
 
-      syncStreamLog(root);
+    let slice = cliState.streams.get().get(root);
+    expect(slice?.entries ?? []).toEqual([]);
 
-      let slice = cliState.streams.get().get(root);
-      expect(slice?.entries ?? []).toEqual([]);
+    logger.info('Visible answer.', {
+      messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+    });
 
-      logger.info('Visible answer.', {
-        messageType: MESSAGE_TYPES.MODEL_RESPONSE,
-      });
+    syncStreamLog(root);
 
-      syncStreamLog(root);
-
-      slice = cliState.streams.get().get(root);
-      expect(slice?.entries.map((entry) => entry.text)).toEqual([
-        'Visible answer.',
-      ]);
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
+    slice = cliState.streams.get().get(root);
+    expect(slice?.entries.map((entry) => entry.text)).toEqual([
+      'Visible answer.',
+    ]);
   });
 
   it('trims leading blank assistant rows at turn start', () => {
-    const previousStore = getDefaultStreamLogStore();
-    const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
+    const logger = createRunTrace(root).trace;
+    logger.info('Why?', { messageType: MESSAGE_TYPES.USER_MESSAGE });
+    logger.info('\n\n  The answer starts here.', {
+      messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+    });
 
-    try {
-      const logger = createRunTrace(root).trace;
-      logger.info('Why?', { messageType: MESSAGE_TYPES.USER_MESSAGE });
-      logger.info('\n\n  The answer starts here.', {
-        messageType: MESSAGE_TYPES.MODEL_RESPONSE,
-      });
+    syncStreamLog(root);
 
-      syncStreamLog(root);
-
-      const entries = cliState.streams.get().get(root)?.entries ?? [];
-      expect(entries.map((entry) => entry.text)).toEqual([
-        'Why?',
-        '  The answer starts here.',
-      ]);
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
+    const entries = cliState.streams.get().get(root)?.entries ?? [];
+    expect(entries.map((entry) => entry.text)).toEqual([
+      'Why?',
+      '  The answer starts here.',
+    ]);
   });
 
   // Regression: a sync tick that fires after `finalizeAssistantTranscriptEntries`
@@ -2020,37 +1971,29 @@ describe('CLI transcript state', () => {
   // `splitTranscriptEntries` once status flipped to WAITING and silently
   // disappear from the transcript.
   it('preserves the finalized flag through a post-finalize sync tick', () => {
-    const previousStore = getDefaultStreamLogStore();
-    const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
+    const logger = createRunTrace(root).trace;
+    logger.info('streaming assistant chunk', {
+      messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+    });
+    syncStreamLog(root);
 
-    try {
-      const logger = createRunTrace(root).trace;
-      logger.info('streaming assistant chunk', {
-        messageType: MESSAGE_TYPES.MODEL_RESPONSE,
-      });
-      syncStreamLog(root);
+    // Stream-level finalize promotes the deferred-finalization entries.
+    patchStream(root, (slice) => ({
+      ...slice,
+      entries: slice.entries.map((entry) =>
+        entry.role === 'assistant' ? { ...entry, finalized: true } : entry,
+      ),
+    }));
 
-      // Stream-level finalize promotes the deferred-finalization entries.
-      patchStream(root, (slice) => ({
-        ...slice,
-        entries: slice.entries.map((entry) =>
-          entry.role === 'assistant' ? { ...entry, finalized: true } : entry,
-        ),
-      }));
+    // A second sync after finalize must not regress the flag.
+    syncStreamLog(root);
 
-      // A second sync after finalize must not regress the flag.
-      syncStreamLog(root);
-
-      const entries = cliState.streams.get().get(root)?.entries ?? [];
-      expect(entries).toHaveLength(1);
-      expect(entries[0]).toMatchObject({
-        role: 'assistant',
-        finalized: true,
-      });
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
+    const entries = cliState.streams.get().get(root)?.entries ?? [];
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      role: 'assistant',
+      finalized: true,
+    });
   });
 
   it('adds a final assistant response only when the stream log did not render it', () => {
@@ -2108,228 +2051,167 @@ describe('CLI transcript state', () => {
   });
 
   it('keeps repeated final responses from distinct turns visible', () => {
-    const previousStore = getDefaultStreamLogStore();
-    const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
+    const logger = createRunTrace(root).trace;
+    logger.info('first prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
+    syncStreamLog(root);
+    appendAssistantTranscriptIfMissing(root, 'Done.', 'final:first');
 
-    try {
-      const logger = createRunTrace(root).trace;
-      logger.info('first prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
-      syncStreamLog(root);
-      appendAssistantTranscriptIfMissing(root, 'Done.', 'final:first');
+    logger.info('second prompt', {
+      messageType: MESSAGE_TYPES.USER_MESSAGE,
+    });
+    syncStreamLog(root);
+    appendAssistantTranscriptIfMissing(root, 'Done.', 'final:second');
 
-      logger.info('second prompt', {
-        messageType: MESSAGE_TYPES.USER_MESSAGE,
-      });
-      syncStreamLog(root);
-      appendAssistantTranscriptIfMissing(root, 'Done.', 'final:second');
+    logger.info('third prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
+    syncStreamLog(root);
 
-      logger.info('third prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
-      syncStreamLog(root);
-
-      const entries = cliState.streams.get().get(root)?.entries ?? [];
-      expect(entries.map((entry) => entry.text)).toEqual([
-        'first prompt',
-        'Done.',
-        'second prompt',
-        'Done.',
-        'third prompt',
-      ]);
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
+    const entries = cliState.streams.get().get(root)?.entries ?? [];
+    expect(entries.map((entry) => entry.text)).toEqual([
+      'first prompt',
+      'Done.',
+      'second prompt',
+      'Done.',
+      'third prompt',
+    ]);
   });
 
   it('does not duplicate a final response already present in the stream log', () => {
-    const previousStore = getDefaultStreamLogStore();
-    const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
+    const logger = createRunTrace(root).trace;
+    logger.info('Done.', { messageType: MESSAGE_TYPES.MODEL_RESPONSE });
+    syncStreamLog(root);
+    appendAssistantTranscriptIfMissing(root, 'Done.', 'final:first');
 
-    try {
-      const logger = createRunTrace(root).trace;
-      logger.info('Done.', { messageType: MESSAGE_TYPES.MODEL_RESPONSE });
-      syncStreamLog(root);
-      appendAssistantTranscriptIfMissing(root, 'Done.', 'final:first');
-
-      const entries = cliState.streams.get().get(root)?.entries ?? [];
-      expect(entries.map((entry) => entry.text)).toEqual(['Done.']);
-      expect(entries[0]?.synthetic).toBeUndefined();
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
+    const entries = cliState.streams.get().get(root)?.entries ?? [];
+    expect(entries.map((entry) => entry.text)).toEqual(['Done.']);
+    expect(entries[0]?.synthetic).toBeUndefined();
   });
 
   it('lets the stream-log assistant own final text even when fallback text differs', () => {
-    const previousStore = getDefaultStreamLogStore();
-    const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
+    const logger = createRunTrace(root).trace;
+    logger.info('| x | Check |\n|---|---|\n| 3 | 1 ✓ |', {
+      messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+    });
+    syncStreamLog(root);
+    appendAssistantTranscriptIfMissing(
+      root,
+      '| x | Check |\n|---|---|\n| 3 | 1 \\checkmark |',
+      'final:first',
+    );
 
-    try {
-      const logger = createRunTrace(root).trace;
-      logger.info('| x | Check |\n|---|---|\n| 3 | 1 ✓ |', {
-        messageType: MESSAGE_TYPES.MODEL_RESPONSE,
-      });
-      syncStreamLog(root);
-      appendAssistantTranscriptIfMissing(
-        root,
-        '| x | Check |\n|---|---|\n| 3 | 1 \\checkmark |',
-        'final:first',
-      );
-
-      const entries = cliState.streams.get().get(root)?.entries ?? [];
-      expect(entries.map((entry) => entry.text)).toEqual([
-        '| x | Check |\n|---|---|\n| 3 | 1 ✓ |',
-      ]);
-      expect(entries[0]?.synthetic).toBeUndefined();
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
+    const entries = cliState.streams.get().get(root)?.entries ?? [];
+    expect(entries.map((entry) => entry.text)).toEqual([
+      '| x | Check |\n|---|---|\n| 3 | 1 ✓ |',
+    ]);
+    expect(entries[0]?.synthetic).toBeUndefined();
   });
 
   it('does not let a pre-tool stream assistant suppress final fallback text', () => {
-    const previousStore = getDefaultStreamLogStore();
-    const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
+    const logger = createRunTrace(root).trace;
+    logger.info('| x | Check |\n|---|---|\n| 3 | 1 ✓ |', {
+      messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+    });
+    logger.info('', {
+      messageType: MESSAGE_TYPES.TOOL_USE,
+      data: {
+        toolName: 'bash',
+        input: { command: 'true' },
+        output: { summary: 'Executed: true', output: 'ok' },
+        status: 'completed',
+      },
+    });
+    syncStreamLog(root);
+    appendAssistantTranscriptIfMissing(
+      root,
+      'Final answer after the tool.',
+      'final:first',
+    );
 
-    try {
-      const logger = createRunTrace(root).trace;
-      logger.info('| x | Check |\n|---|---|\n| 3 | 1 ✓ |', {
-        messageType: MESSAGE_TYPES.MODEL_RESPONSE,
-      });
-      logger.info('', {
-        messageType: MESSAGE_TYPES.TOOL_USE,
-        data: {
-          toolName: 'bash',
-          input: { command: 'true' },
-          output: { summary: 'Executed: true', output: 'ok' },
-          status: 'completed',
-        },
-      });
-      syncStreamLog(root);
-      appendAssistantTranscriptIfMissing(
-        root,
-        'Final answer after the tool.',
-        'final:first',
-      );
-
-      const entries = cliState.streams.get().get(root)?.entries ?? [];
-      expect(entries.map((entry) => entry.role)).toEqual([
-        'assistant',
-        'tool',
-        'assistant',
-      ]);
-      expect(entries.map((entry) => entry.text)).toEqual([
-        '| x | Check |\n|---|---|\n| 3 | 1 ✓ |',
-        '',
-        'Final answer after the tool.',
-      ]);
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
+    const entries = cliState.streams.get().get(root)?.entries ?? [];
+    expect(entries.map((entry) => entry.role)).toEqual([
+      'assistant',
+      'tool',
+      'assistant',
+    ]);
+    expect(entries.map((entry) => entry.text)).toEqual([
+      '| x | Check |\n|---|---|\n| 3 | 1 ✓ |',
+      '',
+      'Final answer after the tool.',
+    ]);
   });
 
   it('dedupes fallback text that already appeared before a tool row', () => {
-    const previousStore = getDefaultStreamLogStore();
-    const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
+    const logger = createRunTrace(root).trace;
+    logger.info('Intermediate result ✓', {
+      messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+    });
+    logger.info('', {
+      messageType: MESSAGE_TYPES.TOOL_USE,
+      data: {
+        toolName: 'bash',
+        input: { command: 'true' },
+        output: { summary: 'Executed: true', output: 'ok' },
+        status: 'completed',
+      },
+    });
+    syncStreamLog(root);
+    appendAssistantTranscriptIfMissing(
+      root,
+      'Intermediate result \\checkmark',
+      'final:matching',
+    );
+    appendAssistantTranscriptIfMissing(
+      root,
+      'Final answer after the tool.',
+      'final:actual',
+    );
 
-    try {
-      const logger = createRunTrace(root).trace;
-      logger.info('Intermediate result ✓', {
-        messageType: MESSAGE_TYPES.MODEL_RESPONSE,
-      });
-      logger.info('', {
-        messageType: MESSAGE_TYPES.TOOL_USE,
-        data: {
-          toolName: 'bash',
-          input: { command: 'true' },
-          output: { summary: 'Executed: true', output: 'ok' },
-          status: 'completed',
-        },
-      });
-      syncStreamLog(root);
-      appendAssistantTranscriptIfMissing(
-        root,
-        'Intermediate result \\checkmark',
-        'final:matching',
-      );
-      appendAssistantTranscriptIfMissing(
-        root,
-        'Final answer after the tool.',
-        'final:actual',
-      );
-
-      const entries = cliState.streams.get().get(root)?.entries ?? [];
-      expect(entries.map((entry) => entry.text)).toEqual([
-        'Intermediate result ✓',
-        '',
-        'Final answer after the tool.',
-      ]);
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
+    const entries = cliState.streams.get().get(root)?.entries ?? [];
+    expect(entries.map((entry) => entry.text)).toEqual([
+      'Intermediate result ✓',
+      '',
+      'Final answer after the tool.',
+    ]);
   });
 
   it('does not let a prior-turn stream assistant suppress fallback text', () => {
-    const previousStore = getDefaultStreamLogStore();
-    const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
+    const logger = createRunTrace(root).trace;
+    logger.info('first prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
+    logger.info('Done ✓', { messageType: MESSAGE_TYPES.MODEL_RESPONSE });
+    syncStreamLog(root);
 
-    try {
-      const logger = createRunTrace(root).trace;
-      logger.info('first prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
-      logger.info('Done ✓', { messageType: MESSAGE_TYPES.MODEL_RESPONSE });
-      syncStreamLog(root);
+    logger.info('second prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
+    syncStreamLog(root);
+    appendAssistantTranscriptIfMissing(root, 'Done \\checkmark', 'final:2');
 
-      logger.info('second prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
-      syncStreamLog(root);
-      appendAssistantTranscriptIfMissing(root, 'Done \\checkmark', 'final:2');
-
-      const entries = cliState.streams.get().get(root)?.entries ?? [];
-      expect(entries.map((entry) => entry.text)).toEqual([
-        'first prompt',
-        'Done ✓',
-        'second prompt',
-        'Done \\checkmark',
-      ]);
-      expect(entries.at(-1)).toMatchObject({
-        synthetic: true,
-        syntheticKind: 'final',
-      });
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
+    const entries = cliState.streams.get().get(root)?.entries ?? [];
+    expect(entries.map((entry) => entry.text)).toEqual([
+      'first prompt',
+      'Done ✓',
+      'second prompt',
+      'Done \\checkmark',
+    ]);
+    expect(entries.at(-1)).toMatchObject({
+      synthetic: true,
+      syntheticKind: 'final',
+    });
   });
 
   it('projects a turn boundary without duplicating fallback assistant text', () => {
-    const previousStore = getDefaultStreamLogStore();
-    const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
+    const logger = createRunTrace(root).trace;
+    logger.info('What is 1 + 1?', {
+      messageType: MESSAGE_TYPES.USER_MESSAGE,
+    });
+    logger.info('2', { messageType: MESSAGE_TYPES.MODEL_RESPONSE });
 
-    try {
-      const logger = createRunTrace(root).trace;
-      logger.info('What is 1 + 1?', {
-        messageType: MESSAGE_TYPES.USER_MESSAGE,
-      });
-      logger.info('2', { messageType: MESSAGE_TYPES.MODEL_RESPONSE });
+    projectStreamTranscript(root, {
+      fallbackAssistant: { text: '2', idPrefix: 'final:turn' },
+      finalize: true,
+    });
 
-      projectStreamTranscript(root, {
-        fallbackAssistant: { text: '2', idPrefix: 'final:turn' },
-        finalize: true,
-      });
-
-      const entries = cliState.streams.get().get(root)?.entries ?? [];
-      expect(entries.map((entry) => entry.text)).toEqual([
-        'What is 1 + 1?',
-        '2',
-      ]);
-      expect(entries.map((entry) => entry.finalized)).toEqual([true, true]);
-      expect(entries.some((entry) => entry.id === 'final:turn:root')).toBe(
-        false,
-      );
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
+    const entries = cliState.streams.get().get(root)?.entries ?? [];
+    expect(entries.map((entry) => entry.text)).toEqual(['What is 1 + 1?', '2']);
+    expect(entries.map((entry) => entry.finalized)).toEqual([true, true]);
+    expect(entries.some((entry) => entry.id === 'final:turn:root')).toBe(false);
   });
 
   it('keeps repeated local slash-command responses visible', () => {
@@ -2453,89 +2335,63 @@ describe('CLI transcript state', () => {
   });
 
   it('flushes pending model-response chunks before transcript sync', () => {
-    const previousStore = getDefaultStreamLogStore();
-    const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
+    const logger = createRunTrace(root).trace;
+    const stream = logger.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
+    stream.append('A short final answer.');
 
-    try {
-      const logger = createRunTrace(root).trace;
-      const stream = logger.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
-      stream.append('A short final answer.');
+    syncStreamLog(root);
 
-      syncStreamLog(root);
-
-      const entries = cliState.streams.get().get(root)?.entries ?? [];
-      expect(entries.map((entry) => entry.text)).toEqual([
-        'A short final answer.',
-      ]);
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
+    const entries = cliState.streams.get().get(root)?.entries ?? [];
+    expect(entries.map((entry) => entry.text)).toEqual([
+      'A short final answer.',
+    ]);
   });
 
   it('finalizes a delayed first model-response sync after the stream is idle', () => {
-    const previousStore = getDefaultStreamLogStore();
-    const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
+    const logger = createRunTrace(root).trace;
+    logger.info('A delayed final answer.', {
+      messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+    });
+    patchStream(root, (slice) => ({
+      ...slice,
+      status: STREAM_STATUS.WAITING,
+    }));
 
-    try {
-      const logger = createRunTrace(root).trace;
-      logger.info('A delayed final answer.', {
-        messageType: MESSAGE_TYPES.MODEL_RESPONSE,
-      });
-      patchStream(root, (slice) => ({
-        ...slice,
-        status: STREAM_STATUS.WAITING,
-      }));
+    syncStreamLog(root);
 
-      syncStreamLog(root);
-
-      const entries = cliState.streams.get().get(root)?.entries ?? [];
-      expect(entries).toHaveLength(1);
-      expect(entries[0]).toMatchObject({
-        role: 'assistant',
-        text: 'A delayed final answer.',
-        finalized: true,
-      });
-      const split = splitTranscriptEntries(entries, STREAM_STATUS.WAITING);
-      expect(split.finalized.map((entry) => entry.id)).toEqual([
-        entries[0]?.id,
-      ]);
-      expect(split.pending).toEqual([]);
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
+    const entries = cliState.streams.get().get(root)?.entries ?? [];
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      role: 'assistant',
+      text: 'A delayed final answer.',
+      finalized: true,
+    });
+    const split = splitTranscriptEntries(entries, STREAM_STATUS.WAITING);
+    expect(split.finalized.map((entry) => entry.id)).toEqual([entries[0]?.id]);
+    expect(split.pending).toEqual([]);
   });
 
   it('keeps repeated local slash-command responses after stream-log syncs', () => {
-    const previousStore = getDefaultStreamLogStore();
-    const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
+    const logger = createRunTrace(root).trace;
+    logger.info('prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
+    syncStreamLog(root);
+    cliState.activeStreamId.set(root);
 
-    try {
-      const logger = createRunTrace(root).trace;
-      logger.info('prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
-      syncStreamLog(root);
-      cliState.activeStreamId.set(root);
+    appendLocalAssistantTranscript('Available commands: /help');
+    logger.info('partial response', {
+      messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+    });
+    syncStreamLog(root);
 
-      appendLocalAssistantTranscript('Available commands: /help');
-      logger.info('partial response', {
-        messageType: MESSAGE_TYPES.MODEL_RESPONSE,
-      });
-      syncStreamLog(root);
+    appendLocalAssistantTranscript('Available commands: /help');
+    syncStreamLog(root);
 
-      appendLocalAssistantTranscript('Available commands: /help');
-      syncStreamLog(root);
-
-      const entries = cliState.streams.get().get(root)?.entries ?? [];
-      expect(
-        entries
-          .filter((entry) => entry.syntheticKind === 'local')
-          .map((entry) => entry.text),
-      ).toEqual(['Available commands: /help', 'Available commands: /help']);
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
+    const entries = cliState.streams.get().get(root)?.entries ?? [];
+    expect(
+      entries
+        .filter((entry) => entry.syntheticKind === 'local')
+        .map((entry) => entry.text),
+    ).toEqual(['Available commands: /help', 'Available commands: /help']);
   });
 
   it('keeps a model response live when local output follows it', () => {
@@ -2686,61 +2542,45 @@ describe('CLI transcript state', () => {
   });
 
   it('preserves synthetic final responses across later log syncs', () => {
-    const previousStore = getDefaultStreamLogStore();
-    const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
+    const logger = createRunTrace(root).trace;
+    logger.info('1+1', { messageType: MESSAGE_TYPES.USER_MESSAGE });
+    syncStreamLog(root);
+    appendAssistantTranscriptIfMissing(root, 'The answer is 2.', 'final');
 
-    try {
-      const logger = createRunTrace(root).trace;
-      logger.info('1+1', { messageType: MESSAGE_TYPES.USER_MESSAGE });
-      syncStreamLog(root);
-      appendAssistantTranscriptIfMissing(root, 'The answer is 2.', 'final');
+    logger.info('next prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
+    syncStreamLog(root);
 
-      logger.info('next prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
-      syncStreamLog(root);
-
-      const entries = cliState.streams.get().get(root)?.entries ?? [];
-      expect(entries.map((entry) => entry.text)).toEqual([
-        '1+1',
-        'The answer is 2.',
-        'next prompt',
-      ]);
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
+    const entries = cliState.streams.get().get(root)?.entries ?? [];
+    expect(entries.map((entry) => entry.text)).toEqual([
+      '1+1',
+      'The answer is 2.',
+      'next prompt',
+    ]);
   });
 
   it('orders multiple synthetic responses relative to their stream-log anchors', () => {
-    const previousStore = getDefaultStreamLogStore();
-    const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
+    const logger = createRunTrace(root).trace;
+    logger.info('first prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
+    syncStreamLog(root);
+    appendAssistantTranscriptIfMissing(root, 'first answer', 'final-1');
 
-    try {
-      const logger = createRunTrace(root).trace;
-      logger.info('first prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
-      syncStreamLog(root);
-      appendAssistantTranscriptIfMissing(root, 'first answer', 'final-1');
+    logger.info('second prompt', {
+      messageType: MESSAGE_TYPES.USER_MESSAGE,
+    });
+    syncStreamLog(root);
+    appendAssistantTranscriptIfMissing(root, 'second answer', 'final-2');
 
-      logger.info('second prompt', {
-        messageType: MESSAGE_TYPES.USER_MESSAGE,
-      });
-      syncStreamLog(root);
-      appendAssistantTranscriptIfMissing(root, 'second answer', 'final-2');
+    logger.info('third prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
+    syncStreamLog(root);
 
-      logger.info('third prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
-      syncStreamLog(root);
-
-      const entries = cliState.streams.get().get(root)?.entries ?? [];
-      expect(entries.map((entry) => entry.text)).toEqual([
-        'first prompt',
-        'first answer',
-        'second prompt',
-        'second answer',
-        'third prompt',
-      ]);
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
+    const entries = cliState.streams.get().get(root)?.entries ?? [];
+    expect(entries.map((entry) => entry.text)).toEqual([
+      'first prompt',
+      'first answer',
+      'second prompt',
+      'second answer',
+      'third prompt',
+    ]);
   });
 });
 

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -167,6 +167,14 @@ type ProgressMessage = {
   streamState?: unknown;
 };
 
+/** Shared fixture for the tool-use "search" agentConfig used across several
+ * resume tests below. */
+const SEARCH_TOOL_USE_AGENT_CONFIG = {
+  agent: 'search',
+  model: 'deepseekproT',
+  agentCategory: AgentCategory.ToolUse,
+} as const;
+
 function mockLoggerModule(): void {
   vi.doMock('@logger', () => ({
     createChannelTrace: () => ({
@@ -1521,13 +1529,7 @@ describe('DesktopProgressBridge', () => {
   });
 
   it('does not resume a stream deleted in this desktop session', async () => {
-    const taskState = {
-      agentConfig: {
-        agent: 'search',
-        model: 'deepseekproT',
-        agentCategory: AgentCategory.ToolUse,
-      },
-    };
+    const taskState = { agentConfig: SEARCH_TOOL_USE_AGENT_CONFIG };
     const retrieveSessionResumeData = vi.fn(async () => ({
       type: 'toolUse',
       snapshot: {
@@ -2114,11 +2116,7 @@ describe('DesktopProgressBridge', () => {
       snapshot: {
         executionId: 'exec-1',
         streamId: 'stream-1',
-        agentConfig: {
-          agent: 'search',
-          model: 'deepseekproT',
-          agentCategory: AgentCategory.ToolUse,
-        },
+        agentConfig: SEARCH_TOOL_USE_AGENT_CONFIG,
       },
     }));
     const resumeToolUseFromSnapshot = vi.fn(async () => {});
@@ -2129,13 +2127,7 @@ describe('DesktopProgressBridge', () => {
     });
     const { ToolUseFollowUpQueue } =
       await import('@agent/followUp/ToolUseFollowUpQueueManager');
-    const taskState = {
-      agentConfig: {
-        agent: 'search',
-        model: 'deepseekproT',
-        agentCategory: AgentCategory.ToolUse,
-      },
-    };
+    const taskState = { agentConfig: SEARCH_TOOL_USE_AGENT_CONFIG };
 
     try {
       bridge.handleProgressEvent('setTaskState', {
@@ -2197,11 +2189,7 @@ describe('DesktopProgressBridge', () => {
       snapshot: {
         executionId: 'exec-1',
         streamId: 'stream-1',
-        agentConfig: {
-          agent: 'search',
-          model: 'deepseekproT',
-          agentCategory: AgentCategory.ToolUse,
-        },
+        agentConfig: SEARCH_TOOL_USE_AGENT_CONFIG,
       },
     }));
     const resumeToolUseFromSnapshot = vi.fn(async () => {
@@ -2218,13 +2206,7 @@ describe('DesktopProgressBridge', () => {
       bridge.handleProgressEvent('setTaskState', {
         streamId: 'stream-1',
         executionId: 'exec-1',
-        taskState: {
-          agentConfig: {
-            agent: 'search',
-            model: 'deepseekproT',
-            agentCategory: AgentCategory.ToolUse,
-          },
-        },
+        taskState: { agentConfig: SEARCH_TOOL_USE_AGENT_CONFIG },
       });
       ToolUseFollowUpQueue.enqueue(
         'stream-1',
@@ -2280,11 +2262,7 @@ describe('DesktopProgressBridge', () => {
         snapshot: {
           executionId: 'exec-1',
           streamId: 'stream-1',
-          agentConfig: {
-            agent: 'search',
-            model: 'deepseekproT',
-            agentCategory: AgentCategory.ToolUse,
-          },
+          agentConfig: SEARCH_TOOL_USE_AGENT_CONFIG,
         },
       };
     });
@@ -2294,13 +2272,7 @@ describe('DesktopProgressBridge', () => {
       bridge.handleProgressEvent('setTaskState', {
         streamId: 'stream-1',
         executionId: 'exec-1',
-        taskState: {
-          agentConfig: {
-            agent: 'search',
-            model: 'deepseekproT',
-            agentCategory: AgentCategory.ToolUse,
-          },
-        },
+        taskState: { agentConfig: SEARCH_TOOL_USE_AGENT_CONFIG },
       });
 
       const firstResume = bridge.tryResumeStream('stream-1');

--- a/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
+++ b/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
@@ -172,6 +172,15 @@ function createMemoryState() {
   return { values, update, state };
 }
 
+// Shared setup for onboarding tests that only need a fresh memory-backed
+// state store and a postToRenderer spy (no seeded values, no update spy).
+async function createOnboardingHarness() {
+  const { createDesktopOnboardingIpc } = await loadDesktopOnboardingIpc();
+  const { state } = createMemoryState();
+  const postToRenderer = vi.fn();
+  return { createDesktopOnboardingIpc, state, postToRenderer };
+}
+
 describe('desktop IPC adapters', () => {
   afterEach(() => {
     vi.doUnmock('electron');
@@ -529,9 +538,8 @@ describe('desktop IPC adapters', () => {
   });
 
   it('derives State 1 (setup) when hasCredential is true on fresh install', async () => {
-    const { createDesktopOnboardingIpc } = await loadDesktopOnboardingIpc();
-    const { state } = createMemoryState();
-    const postToRenderer = vi.fn();
+    const { createDesktopOnboardingIpc, state, postToRenderer } =
+      await createOnboardingHarness();
     const selectSetupAgent = vi.fn(async () => {});
     const onboarding = createDesktopOnboardingIpc(
       { postToRenderer },
@@ -628,9 +636,8 @@ describe('desktop IPC adapters', () => {
   });
 
   it('calls onboarding run-setup / sign-in-chatgpt callbacks', async () => {
-    const { createDesktopOnboardingIpc } = await loadDesktopOnboardingIpc();
-    const { state } = createMemoryState();
-    const postToRenderer = vi.fn();
+    const { createDesktopOnboardingIpc, state, postToRenderer } =
+      await createOnboardingHarness();
     const runSetupCalled = vi.fn(async () => {});
     const signInCalled = vi.fn(async () => {});
     const onboarding = createDesktopOnboardingIpc(
@@ -668,9 +675,8 @@ describe('desktop IPC adapters', () => {
   });
 
   it('runs the real kickoff path on ONBOARDING_RUN_SETUP and refreshes after', async () => {
-    const { createDesktopOnboardingIpc } = await loadDesktopOnboardingIpc();
-    const { state } = createMemoryState();
-    const postToRenderer = vi.fn();
+    const { createDesktopOnboardingIpc, state, postToRenderer } =
+      await createOnboardingHarness();
     const callOrder: string[] = [];
     const selectSetupAgent = vi.fn(async () => {
       callOrder.push('select');
@@ -709,9 +715,8 @@ describe('desktop IPC adapters', () => {
   });
 
   it('opens the getting-started docs on ONBOARDING_OPEN_GETTING_STARTED', async () => {
-    const { createDesktopOnboardingIpc } = await loadDesktopOnboardingIpc();
-    const { state } = createMemoryState();
-    const postToRenderer = vi.fn();
+    const { createDesktopOnboardingIpc, state, postToRenderer } =
+      await createOnboardingHarness();
     const openGettingStarted = vi.fn(async () => {});
     const onboarding = createDesktopOnboardingIpc(
       { postToRenderer },
@@ -735,9 +740,8 @@ describe('desktop IPC adapters', () => {
   });
 
   it('serializes overlapping funnel refreshes to one consistent terminal state', async () => {
-    const { createDesktopOnboardingIpc } = await loadDesktopOnboardingIpc();
-    const { state } = createMemoryState();
-    const postToRenderer = vi.fn();
+    const { createDesktopOnboardingIpc, state, postToRenderer } =
+      await createOnboardingHarness();
     // A credential probe that resolves on the next macrotask, so two refreshes
     // started back-to-back genuinely overlap in flight. `selectSetupAgent`
     // would only fire when `previous !== 'setup'`; if the two refreshes

--- a/src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts
@@ -61,6 +61,19 @@ function createSnapshotStore(
   };
 }
 
+/** Build a minimal mock `streamLogs` slice, overridable per test. */
+function createStreamLogs(overrides: Record<string, any> = {}): any {
+  return {
+    ensureStream: vi.fn(),
+    keys: () => [].values(),
+    has: () => false,
+    getFirstTimestamp: () => undefined,
+    getLastTimestamp: () => undefined,
+    ensureLoaded: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
 /**
  * Build a minimal mock state object.  We use `as any` because the real
  * ProgressViewState is a large, deeply-typed class and we only need a
@@ -69,14 +82,7 @@ function createSnapshotStore(
 function makeMockState(overrides: Record<string, any> = {}): any {
   return {
     activeStream: '',
-    streamLogs: {
-      ensureStream: vi.fn(),
-      keys: () => [].values(),
-      has: () => false,
-      getFirstTimestamp: () => undefined,
-      getLastTimestamp: () => undefined,
-      ensureLoaded: vi.fn(async () => {}),
-    },
+    streamLogs: createStreamLogs(),
     updateStreamHints: vi.fn(),
     snapshots: {
       getTaskState: vi.fn(() => undefined),
@@ -247,14 +253,7 @@ describe('DesktopProgressEventBridge', () => {
 
       const bridge = createBridge({
         state: makeMockState({
-          streamLogs: {
-            ensureStream,
-            keys: () => [].values(),
-            has: () => false,
-            getFirstTimestamp: () => undefined,
-            getLastTimestamp: () => undefined,
-            ensureLoaded: vi.fn(async () => {}),
-          },
+          streamLogs: createStreamLogs({ ensureStream }),
           updateStreamHints,
         }),
         streamSnapshotStore: createSnapshotStore({
@@ -321,14 +320,7 @@ describe('DesktopProgressEventBridge', () => {
       const ensureStream = vi.fn();
       const bridge = createBridge({
         state: makeMockState({
-          streamLogs: {
-            ensureStream,
-            keys: () => [].values(),
-            has: () => false,
-            getFirstTimestamp: () => undefined,
-            getLastTimestamp: () => undefined,
-            ensureLoaded: vi.fn(async () => {}),
-          },
+          streamLogs: createStreamLogs({ ensureStream }),
         }),
         streamSnapshotStore: createSnapshotStore({
           hydrated: [
@@ -397,14 +389,10 @@ describe('DesktopProgressEventBridge', () => {
 
       const bridge = createBridge({
         state: makeMockState({
-          streamLogs: {
-            ensureStream: vi.fn(),
-            keys: () => [].values(),
+          streamLogs: createStreamLogs({
             has: () => true,
-            getFirstTimestamp: () => undefined,
             getLastTimestamp: () => 3_000,
-            ensureLoaded: vi.fn(async () => {}),
-          },
+          }),
         }),
         streamSnapshotStore: createSnapshotStore({
           hydrated: [createSnapshot({ streamId: 'task-stream' })],
@@ -437,14 +425,10 @@ describe('DesktopProgressEventBridge', () => {
 
       const bridge = createBridge({
         state: makeMockState({
-          streamLogs: {
-            ensureStream: vi.fn(),
-            keys: () => [].values(),
+          streamLogs: createStreamLogs({
             has: () => true,
-            getFirstTimestamp: () => undefined,
             getLastTimestamp: () => 3_000,
-            ensureLoaded: vi.fn(async () => {}),
-          },
+          }),
         }),
         streamStatus,
         streamSnapshotStore: createSnapshotStore({

--- a/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
+++ b/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
@@ -66,6 +66,17 @@ async function waitForEmptyDir(dir: string): Promise<void> {
   }
 }
 
+function trackShownApprovals(bus: ProgressEventBusLike): {
+  shown: ProgressEventPayloads['showToolEditPermission'][];
+  offShow: () => void;
+} {
+  const shown: ProgressEventPayloads['showToolEditPermission'][] = [];
+  const offShow = bus.on('showToolEditPermission', (payload) =>
+    shown.push(payload),
+  );
+  return { shown, offShow };
+}
+
 async function loadApprovalModules(workspacePath = '/workspace') {
   vi.resetModules();
   type MockLocation =
@@ -248,10 +259,7 @@ describe('desktop tool edit approval', () => {
         opened.push(filePath);
       },
     });
-    const shown: ProgressEventPayloads['showToolEditPermission'][] = [];
-    const offShow = bus.on('showToolEditPermission', (payload) =>
-      shown.push(payload),
-    );
+    const { shown, offShow } = trackShownApprovals(bus);
 
     try {
       const resultPromise = requestToolEditApproval({
@@ -318,10 +326,7 @@ describe('desktop tool edit approval', () => {
       openPath,
       openDiff,
     });
-    const shown: ProgressEventPayloads['showToolEditPermission'][] = [];
-    const offShow = bus.on('showToolEditPermission', (payload) =>
-      shown.push(payload),
-    );
+    const { shown, offShow } = trackShownApprovals(bus);
 
     try {
       const resultPromise = requestToolEditApproval({
@@ -369,10 +374,7 @@ describe('desktop tool edit approval', () => {
         opened.push(filePath);
       },
     });
-    const shown: ProgressEventPayloads['showToolEditPermission'][] = [];
-    const offShow = bus.on('showToolEditPermission', (payload) =>
-      shown.push(payload),
-    );
+    const { shown, offShow } = trackShownApprovals(bus);
 
     try {
       const resultPromise = requestToolEditApproval({
@@ -435,10 +437,7 @@ describe('desktop tool edit approval', () => {
         messages.push(message);
       },
     });
-    const shown: ProgressEventPayloads['showToolEditPermission'][] = [];
-    const offShow = bus.on('showToolEditPermission', (payload) =>
-      shown.push(payload),
-    );
+    const { shown, offShow } = trackShownApprovals(bus);
 
     try {
       const resultPromise = requestToolEditApproval({
@@ -534,10 +533,7 @@ describe('desktop tool edit approval', () => {
       runtimeHost: createBusRuntimeHost(bus),
       tempRoot,
     });
-    const shown: ProgressEventPayloads['showToolEditPermission'][] = [];
-    const offShow = bus.on('showToolEditPermission', (payload) =>
-      shown.push(payload),
-    );
+    const { shown, offShow } = trackShownApprovals(bus);
 
     try {
       const resultPromise = requestToolEditApproval({

--- a/src/test-kernel/desktop/ElectronAgentDirectories.vitest.mts
+++ b/src/test-kernel/desktop/ElectronAgentDirectories.vitest.mts
@@ -6,10 +6,6 @@ import { dirname, join } from 'node:path';
 // Third-party imports
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-// Local imports - agent
-
-// Local imports - common
-
 // Local imports - platform
 import { createLifecycleHost } from '@platform/defaults/lifecycleHost';
 import { NO_TOOL_AVAILABILITY_HOST } from '@platform/interfaces/toolAvailability';

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
@@ -94,6 +94,57 @@ function createDeferred(): {
   return { promise, resolve };
 }
 
+type RendererListener = (
+  event: { sender: unknown },
+  message: unknown,
+) => void;
+
+function createIpcMainMock(onMessage: (listener: RendererListener) => void) {
+  return {
+    on: vi.fn((_channel: string, listener: RendererListener) => {
+      onMessage(listener);
+    }),
+    off: vi.fn(),
+  };
+}
+
+function createNativeThemeMock(
+  options: {
+    shouldUseDarkColors?: boolean;
+    shouldUseHighContrastColors?: boolean;
+    onUpdated?: (listener: () => void) => void;
+  } = {},
+) {
+  return {
+    shouldUseDarkColors: options.shouldUseDarkColors ?? false,
+    shouldUseHighContrastColors: options.shouldUseHighContrastColors ?? false,
+    on: vi.fn((_event: 'updated', listener: () => void) => {
+      options.onUpdated?.(listener);
+    }),
+    off: vi.fn(),
+  };
+}
+
+function createWindowMock(
+  sends: Array<{ channel: string; message: unknown }>,
+  onClosed?: (listener: () => void) => void,
+) {
+  const webContents = {
+    isDestroyed: () => false,
+    send: vi.fn((channel: string, message: unknown) =>
+      sends.push({ channel, message }),
+    ),
+  };
+  const window = {
+    isDestroyed: () => false,
+    once: vi.fn((_event: 'closed', listener: () => void) => {
+      onClosed?.(listener);
+    }),
+    webContents,
+  };
+  return { window, webContents };
+}
+
 describe('desktop main-view IPC', () => {
   afterEach(() => {
     vi.doUnmock('electron');
@@ -103,23 +154,17 @@ describe('desktop main-view IPC', () => {
   });
 
   it('pushes theme and debug state over the fixed host bridge channel', async () => {
-    let rendererListener:
-      ((event: { sender: unknown }, message: unknown) => void) | undefined;
+    let rendererListener: RendererListener | undefined;
     let themeListener: (() => void) | undefined;
-    const ipcMain = {
-      on: vi.fn((channel, listener) => {
-        rendererListener = listener;
-      }),
-      off: vi.fn(),
-    };
-    const nativeTheme = {
+    const ipcMain = createIpcMainMock((listener) => {
+      rendererListener = listener;
+    });
+    const nativeTheme = createNativeThemeMock({
       shouldUseDarkColors: true,
-      shouldUseHighContrastColors: false,
-      on: vi.fn((_event: 'updated', listener: () => void) => {
+      onUpdated: (listener) => {
         themeListener = listener;
-      }),
-      off: vi.fn(),
-    };
+      },
+    });
     const {
       ELECTRON_WEBVIEW_MESSAGE_CHANNEL,
       ELECTRON_WEBVIEW_PUSH_CHANNEL,
@@ -145,18 +190,10 @@ describe('desktop main-view IPC', () => {
       ),
     };
     const executeAgent = vi.fn(async (_message: unknown) => {});
-    const webContents = {
-      isDestroyed: () => false,
-      send: vi.fn((channel, message) => sends.push({ channel, message })),
-    };
     const closedListeners: Array<() => void> = [];
-    const window = {
-      isDestroyed: () => false,
-      once: vi.fn((_event: 'closed', listener: () => void) => {
-        closedListeners.push(listener);
-      }),
-      webContents,
-    };
+    const { window, webContents } = createWindowMock(sends, (listener) => {
+      closedListeners.push(listener);
+    });
 
     const ipc = installDesktopMainViewIpc(window, {
       debugMode: true,
@@ -397,32 +434,15 @@ describe('desktop main-view IPC', () => {
   });
 
   it('uses desktop auth status when posting main-view startup login state', async () => {
-    let rendererListener:
-      ((event: { sender: unknown }, message: unknown) => void) | undefined;
-    const ipcMain = {
-      on: vi.fn((channel, listener) => {
-        rendererListener = listener;
-      }),
-      off: vi.fn(),
-    };
-    const nativeTheme = {
-      shouldUseDarkColors: false,
-      shouldUseHighContrastColors: false,
-      on: vi.fn(),
-      off: vi.fn(),
-    };
+    let rendererListener: RendererListener | undefined;
+    const ipcMain = createIpcMainMock((listener) => {
+      rendererListener = listener;
+    });
+    const nativeTheme = createNativeThemeMock();
     const { ELECTRON_WEBVIEW_PUSH_CHANNEL, installDesktopMainViewIpc } =
       await loadDesktopMainViewIpcModule({ ipcMain, nativeTheme });
     const sends: Array<{ channel: string; message: unknown }> = [];
-    const webContents = {
-      isDestroyed: () => false,
-      send: vi.fn((channel, message) => sends.push({ channel, message })),
-    };
-    const window = {
-      isDestroyed: () => false,
-      once: vi.fn(),
-      webContents,
-    };
+    const { window, webContents } = createWindowMock(sends);
 
     installDesktopMainViewIpc(window, {
       getAuthStatus: async () => ({ authenticated: true }),
@@ -468,20 +488,11 @@ describe('desktop main-view IPC', () => {
   });
 
   it('waits for desktop model-list refresh before posting main-view model options', async () => {
-    let rendererListener:
-      ((event: { sender: unknown }, message: unknown) => void) | undefined;
-    const ipcMain = {
-      on: vi.fn((channel, listener) => {
-        rendererListener = listener;
-      }),
-      off: vi.fn(),
-    };
-    const nativeTheme = {
-      shouldUseDarkColors: false,
-      shouldUseHighContrastColors: false,
-      on: vi.fn(),
-      off: vi.fn(),
-    };
+    let rendererListener: RendererListener | undefined;
+    const ipcMain = createIpcMainMock((listener) => {
+      rendererListener = listener;
+    });
+    const nativeTheme = createNativeThemeMock();
     const modelListRefresh = createDeferred();
     vi.doMock('@agent/index/agentRegistry', () => ({
       computeAgentOptionsData: vi.fn(async () => ({
@@ -495,15 +506,7 @@ describe('desktop main-view IPC', () => {
     const { ELECTRON_WEBVIEW_PUSH_CHANNEL, installDesktopMainViewIpc } =
       await loadDesktopMainViewIpcModule({ ipcMain, nativeTheme });
     const sends: Array<{ channel: string; message: unknown }> = [];
-    const webContents = {
-      isDestroyed: () => false,
-      send: vi.fn((channel, message) => sends.push({ channel, message })),
-    };
-    const window = {
-      isDestroyed: () => false,
-      once: vi.fn(),
-      webContents,
-    };
+    const { window, webContents } = createWindowMock(sends);
 
     installDesktopMainViewIpc(window, {
       modelListRefresh: modelListRefresh.promise,

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
@@ -94,10 +94,7 @@ function createDeferred(): {
   return { promise, resolve };
 }
 
-type RendererListener = (
-  event: { sender: unknown },
-  message: unknown,
-) => void;
+type RendererListener = (event: { sender: unknown }, message: unknown) => void;
 
 function createIpcMainMock(onMessage: (listener: RendererListener) => void) {
   return {

--- a/src/test-kernel/progressView/ProcessOutputState.vitest.ts
+++ b/src/test-kernel/progressView/ProcessOutputState.vitest.ts
@@ -96,6 +96,18 @@ function dispatch(
   handler?.(message as never, ctx);
 }
 
+function registerWorkflowStream(
+  state: ProgressState,
+  streamId: StreamTabId,
+): void {
+  state.streamById.set(streamId, {
+    name: streamId,
+    label: 'stream-a',
+    agentCategory: AgentCategory.Workflow,
+    creationTimestamp: 1,
+  });
+}
+
 describe('process output frontend state', () => {
   it('patches one stream metadata record without replacing siblings', () => {
     const streamId = 'stream-a' as StreamTabId;
@@ -109,12 +121,7 @@ describe('process output frontend state', () => {
       agentCategory: AgentCategory.ToolUse,
       creationTimestamp: 2,
     });
-    state.streamById.set(streamId, {
-      name: streamId,
-      label: 'stream-a',
-      agentCategory: AgentCategory.Workflow,
-      creationTimestamp: 1,
-    });
+    registerWorkflowStream(state, streamId);
     state.streamStates.set(streamId, createStreamState(AgentCategory.Workflow));
     state.streamStates.set(
       siblingId,
@@ -249,12 +256,7 @@ describe('process output frontend state', () => {
   it('updates and clears stream substate with status changes', () => {
     const streamId = 'stream-a' as StreamTabId;
     const state = createInitialState();
-    state.streamById.set(streamId, {
-      name: streamId,
-      label: 'stream-a',
-      agentCategory: AgentCategory.Workflow,
-      creationTimestamp: 1,
-    });
+    registerWorkflowStream(state, streamId);
     state.streamStates.set(
       streamId,
       createStreamState(AgentCategory.Workflow, {
@@ -298,12 +300,7 @@ describe('process output frontend state', () => {
     const streamId = 'stream-a' as StreamTabId;
     const state = createInitialState();
     state.activeStreamId = streamId;
-    state.streamById.set(streamId, {
-      name: streamId,
-      label: 'stream-a',
-      agentCategory: AgentCategory.Workflow,
-      creationTimestamp: 1,
-    });
+    registerWorkflowStream(state, streamId);
     state.streamStates.set(
       streamId,
       createStreamState(AgentCategory.Workflow, {

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -71,6 +71,23 @@ function toolUseTaskState(agent: string, model: string): TaskState {
   } as TaskState;
 }
 
+function createRecordingBackend(): {
+  backend: ProgressBackend;
+  messages: ProgressViewOutboundMessage[];
+} {
+  const messages: ProgressViewOutboundMessage[] = [];
+  const backend = new ProgressBackend({
+    storage: new MemoryMementoStorage(),
+    sendMessage: (message) => {
+      messages.push(message);
+      return true;
+    },
+    hasTarget: () => true,
+    configureUi: () => createUiConfig(),
+  });
+  return { backend, messages };
+}
+
 describe('ProgressBackend', () => {
   it('constructs the shared progress backend service graph', () => {
     let servicesFromConfig: ProgressBackendServices | undefined;
@@ -148,16 +165,7 @@ describe('ProgressBackend', () => {
   });
 
   it('sends the full metadata set once for full-view sync', () => {
-    const messages: ProgressViewOutboundMessage[] = [];
-    const backend = new ProgressBackend({
-      storage: new MemoryMementoStorage(),
-      sendMessage: (message) => {
-        messages.push(message);
-        return true;
-      },
-      hasTarget: () => true,
-      configureUi: () => createUiConfig(),
-    });
+    const { backend, messages } = createRecordingBackend();
 
     for (let i = 0; i < 20; i += 1) {
       backend.state.streamLogs.ensureStream(`history-${i}`);
@@ -195,16 +203,7 @@ describe('ProgressBackend', () => {
   });
 
   it('patches one stream for subagent registration and run-start metadata', async () => {
-    const messages: ProgressViewOutboundMessage[] = [];
-    const backend = new ProgressBackend({
-      storage: new MemoryMementoStorage(),
-      sendMessage: (message) => {
-        messages.push(message);
-        return true;
-      },
-      hasTarget: () => true,
-      configureUi: () => createUiConfig(),
-    });
+    const { backend, messages } = createRecordingBackend();
     const subscription = backend.setupEventListeners(bus);
 
     try {
@@ -312,16 +311,7 @@ describe('ProgressBackend', () => {
   });
 
   it('does not switch category filters for unknown-category status streams', async () => {
-    const messages: ProgressViewOutboundMessage[] = [];
-    const backend = new ProgressBackend({
-      storage: new MemoryMementoStorage(),
-      sendMessage: (message) => {
-        messages.push(message);
-        return true;
-      },
-      hasTarget: () => true,
-      configureUi: () => createUiConfig(),
-    });
+    const { backend, messages } = createRecordingBackend();
 
     try {
       backend.state.streamLogs.ensureStream('tool-stream');
@@ -361,16 +351,7 @@ describe('ProgressBackend', () => {
   });
 
   it('revalidates and syncs the active stream when status registration changes the filter', async () => {
-    const messages: ProgressViewOutboundMessage[] = [];
-    const backend = new ProgressBackend({
-      storage: new MemoryMementoStorage(),
-      sendMessage: (message) => {
-        messages.push(message);
-        return true;
-      },
-      hasTarget: () => true,
-      configureUi: () => createUiConfig(),
-    });
+    const { backend, messages } = createRecordingBackend();
 
     try {
       backend.state.streamLogs.ensureStream('tool-stream');

--- a/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
@@ -57,6 +57,18 @@ const config = {
   toolConfig: DEFAULT_TOOL_CONFIG,
 } as AgentConfig;
 
+/** Creates a temp workspace dir for the test body, then always removes it. */
+async function withTempWorkspace(
+  run: (workspace: string) => Promise<void>,
+): Promise<void> {
+  const workspace = await mkdtemp(path.join(tmpdir(), 'texra-exec-files-'));
+  try {
+    await run(workspace);
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+}
+
 describe('ExecutionsTool', () => {
   beforeEach(async () => {
     const [{ initPlatform }, { nodeFilesystem }, { createFakePlatform }] =
@@ -217,8 +229,7 @@ describe('ExecutionsTool', () => {
   });
 
   it('lists and reads persisted workspace files for tool-use executions', async () => {
-    const workspace = await mkdtemp(path.join(tmpdir(), 'texra-exec-files-'));
-    try {
+    await withTempWorkspace(async (workspace) => {
       await writeFile(path.join(workspace, 'review.md'), '# report\n');
       mocks.readConfig.mockResolvedValue({
         ...config,
@@ -239,14 +250,11 @@ describe('ExecutionsTool', () => {
         'Read /executions/abc123/workspace-files/review.md',
       );
       expect(readResult.output).toContain('# report');
-    } finally {
-      await rm(workspace, { recursive: true, force: true });
-    }
+    });
   });
 
   it('refuses unrecorded workspace file reads', async () => {
-    const workspace = await mkdtemp(path.join(tmpdir(), 'texra-exec-files-'));
-    try {
+    await withTempWorkspace(async (workspace) => {
       await writeFile(path.join(workspace, 'secret.md'), 'secret');
       mocks.readConfig.mockResolvedValue({
         ...config,
@@ -260,14 +268,11 @@ describe('ExecutionsTool', () => {
 
       expect(result.isError).toBe(true);
       expect(result.error).toContain('Workspace file not found');
-    } finally {
-      await rm(workspace, { recursive: true, force: true });
-    }
+    });
   });
 
   it('reads recorded files inside a top-level workspace directory', async () => {
-    const workspace = await mkdtemp(path.join(tmpdir(), 'texra-exec-files-'));
-    try {
+    await withTempWorkspace(async (workspace) => {
       await mkdir(path.join(workspace, 'workspace'));
       await writeFile(path.join(workspace, 'review.md'), 'wrong');
       await writeFile(path.join(workspace, 'workspace', 'review.md'), 'nested');
@@ -286,8 +291,6 @@ describe('ExecutionsTool', () => {
       );
       expect(result.output).toContain('nested');
       expect(result.output).not.toContain('wrong');
-    } finally {
-      await rm(workspace, { recursive: true, force: true });
-    }
+    });
   });
 });

--- a/src/test-kernel/transcript/StreamLog.vitest.ts
+++ b/src/test-kernel/transcript/StreamLog.vitest.ts
@@ -7,6 +7,19 @@ import {
   STREAM_LOG_ENTRY_TYPES,
 } from '@shared/schemas';
 
+function logWithMessage(text = ''): StreamLog {
+  const log = new StreamLog();
+  log.append({
+    id: 'message',
+    type: STREAM_LOG_ENTRY_TYPES.LOG,
+    level: LOG_LEVELS.INFO,
+    timestamp: 1,
+    text,
+    messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+  });
+  return log;
+}
+
 describe('StreamLog', () => {
   it('appends trusted entries while preserving sequence and lookup invariants', () => {
     const log = new StreamLog();
@@ -77,15 +90,7 @@ describe('StreamLog', () => {
   });
 
   it('tracks text appends separately from whole-entry updates', () => {
-    const log = new StreamLog();
-    log.append({
-      id: 'message',
-      type: STREAM_LOG_ENTRY_TYPES.LOG,
-      level: LOG_LEVELS.INFO,
-      timestamp: 1,
-      text: '',
-      messageType: MESSAGE_TYPES.MODEL_RESPONSE,
-    });
+    const log = logWithMessage();
 
     log.appendText('message', 'hello');
     log.appendText('message', ' world');
@@ -98,15 +103,7 @@ describe('StreamLog', () => {
   });
 
   it('keeps text appended while a delta frame is in flight', () => {
-    const log = new StreamLog();
-    log.append({
-      id: 'message',
-      type: STREAM_LOG_ENTRY_TYPES.LOG,
-      level: LOG_LEVELS.INFO,
-      timestamp: 1,
-      text: '',
-      messageType: MESSAGE_TYPES.MODEL_RESPONSE,
-    });
+    const log = logWithMessage();
 
     log.appendText('message', 'hello');
     const inFlight = log.getDirtyTextDeltas();
@@ -119,15 +116,7 @@ describe('StreamLog', () => {
   });
 
   it('drops pending text deltas when a full entry replay covers them', () => {
-    const log = new StreamLog();
-    log.append({
-      id: 'message',
-      type: STREAM_LOG_ENTRY_TYPES.LOG,
-      level: LOG_LEVELS.INFO,
-      timestamp: 1,
-      text: '',
-      messageType: MESSAGE_TYPES.MODEL_RESPONSE,
-    });
+    const log = logWithMessage();
 
     log.appendText('message', 'hello');
     const [entry] = log.getRange(0, log.head);
@@ -138,15 +127,7 @@ describe('StreamLog', () => {
   });
 
   it('keeps only text appended while a full entry replay is in flight', () => {
-    const log = new StreamLog();
-    log.append({
-      id: 'message',
-      type: STREAM_LOG_ENTRY_TYPES.LOG,
-      level: LOG_LEVELS.INFO,
-      timestamp: 1,
-      text: 'prefix ',
-      messageType: MESSAGE_TYPES.MODEL_RESPONSE,
-    });
+    const log = logWithMessage('prefix ');
 
     log.appendText('message', 'hello');
     const [entry] = log.getRange(0, log.head);

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -176,9 +176,9 @@ export async function checkToolInstalled(
   showError: boolean = true,
 ): Promise<boolean> {
   // Get the config object - either passed directly or looked up by string key
-  const isStringKey = typeof toolOrConfig === 'string';
-  const toolName = isStringKey ? toolOrConfig : null;
-  const config = isStringKey ? TOOL_CONFIGS[toolOrConfig] : toolOrConfig;
+  const toolName = typeof toolOrConfig === 'string' ? toolOrConfig : null;
+  const config: ToolConfig | undefined =
+    typeof toolOrConfig === 'string' ? TOOL_CONFIGS[toolOrConfig] : toolOrConfig;
 
   if (!config) {
     if (showError) {

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -178,7 +178,9 @@ export async function checkToolInstalled(
   // Get the config object - either passed directly or looked up by string key
   const toolName = typeof toolOrConfig === 'string' ? toolOrConfig : null;
   const config: ToolConfig | undefined =
-    typeof toolOrConfig === 'string' ? TOOL_CONFIGS[toolOrConfig] : toolOrConfig;
+    typeof toolOrConfig === 'string'
+      ? TOOL_CONFIGS[toolOrConfig]
+      : toolOrConfig;
 
   if (!config) {
     if (showError) {


### PR DESCRIPTION
Multi-agent quality-only pass over the ~560 non-test source files changed
since v0.39.1, scoped to local low-risk simplification: dead code removal,
duplicate-logic consolidation, direct control flow, and a Zod prefault
cleanup. No behavior changes; typecheck, lint, and affected test suites
(CLI, desktop, agent, common) all pass.

- AnthropicStreamHandler: drop write-only emittedSearchIds/emittedFetchIds
- modelHandlerGoogleInteractions: fix a JSDoc block left orphaned on the
  wrong method by a prior refactor
- StreamStatusService.stateFor: collapse to a direct Map.get() return
- AgentWorkspaceState: collapse redundant hand-duplicated prefault
  defaults now that each inner field already prefaults itself
- runReflectionFlow: collapse requestCount if/else into a ternary
- errorMetadata.requiresFlowAutoRetry: reuse the shared findInCauseChain
  helper instead of a duplicated hand-rolled cause-chain walk
- toolUtils.checkToolInstalled: drop an unnecessary intermediate variable
- CLI registerBuiltins: remove a redundant try/catch around an already
  promise-returning action
- CLI completedProcessTranscript: reuse the cached processTailLines
  helper from childControls instead of re-implementing the split/trim
- desktop DesktopProgressBridge: extract the repeated sendStreamMetadata
  call (5 call sites) into one updateStreamMetadata() helper
- desktop main/index: dedupe the identical postToRenderer closure shared
  by the preview host and agent-execution wiring

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GG5HcayPBxxJLD9iMZgtUM

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactors and test consolidation only; no new features or auth/data-path changes, and the PR describes intentional behavior parity with passing targeted suites.
> 
> **Overview**
> Quality-only cleanup across agent, CLI, desktop, and common code, plus a large test-suite DRY pass. **Production changes** are small refactors: remove unused Anthropic stream duplicate-ID tracking; simplify `requiresFlowAutoRetry` via `findInCauseChain`; collapse workspace snapshot Zod prefaults; extract desktop `updateStreamMetadata()` and shared `postToRendererIfAlive`; reuse cached `processTailLines` for completed process transcripts; minor control-flow/doc tidy-ups.
> 
> **Tests** gain shared helpers (`respond` / `createGoResponse`, `setupHub`, `setupMachine`, `setupResultCase`, `withTempDir` / `withTempProject`, `findPreset`, `signedInCodexSession`, `outputBuffer`, onboarding harness, block-level default `StreamLogStore` in CLI transcript tests, etc.) so repeated fixtures and boilerplate are not copy-pasted per case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ad0c0ef4362d8750aeaf9285640fa9ed326bfcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->