### PR TITLE
[codex] Remove unused API-key provider capability

### DIFF
--- a/src/model/providerCapabilities.ts
+++ b/src/model/providerCapabilities.ts
@@ -3,7 +3,7 @@ import { ModelProvider, type ModelConfig } from 'llm-zoo';
 import type { UsageRoute } from '@shared/schemas';
 import type { AgentCategory } from '@shared/schemas/agent';
 
-export type ProviderAuthMode = 'api-key' | 'chatgpt-subscription';
+export type ProviderAuthMode = 'chatgpt-subscription';
 
 export interface OpenAIResponseProviderCapabilities {
   readonly backgroundMode: 'base' | 'disabled';
@@ -80,16 +80,6 @@ export function isCodexSubscriptionEligible(fullName: string): boolean {
   return /codex/i.test(fullName);
 }
 
-const openAIApiKeyCapabilities: ProviderCapabilityResolver = ({ model }) => {
-  if (model.provider !== ModelProvider.OPENAI) return null;
-  return {
-    authMode: 'api-key',
-    contextWindow: model.contextWindow,
-    inputPrice: model.inputPrice,
-    outputPrice: model.outputPrice,
-  };
-};
-
 const openAIChatGptSubscriptionCapabilities: ProviderCapabilityResolver = ({
   model,
   useOpenRouter,
@@ -130,7 +120,6 @@ export const ProviderCapabilities: Partial<
   >
 > = {
   [ModelProvider.OPENAI]: {
-    'api-key': openAIApiKeyCapabilities,
     'chatgpt-subscription': openAIChatGptSubscriptionCapabilities,
   },
 };

--- a/src/test-kernel/model/ProviderCapabilities.vitest.ts
+++ b/src/test-kernel/model/ProviderCapabilities.vitest.ts
@@ -52,19 +52,4 @@ describe('provider capabilities', () => {
       },
     });
   });
-
-  it('keeps API-key profile on llm-zoo model metadata', () => {
-    const capabilities = resolveProviderCapabilities({
-      model: gpt55Config,
-      authMode: 'api-key',
-      useOpenRouter: false,
-    });
-
-    expect(capabilities).toMatchObject({
-      authMode: 'api-key',
-      contextWindow: 1_050_000,
-      inputPrice: 5,
-      outputPrice: 30,
-    });
-  });
 });


### PR DESCRIPTION
## Summary

Removes the unused OpenAI `api-key` provider-capability resolver and its dedicated test. I re-verified #7027 against current `origin/main` and recorded drift on the issue: the cited model-handler files moved under `src/agent/modelHandlers/openai/` and `src/auth/codex/`, but the unused resolver claim remains live.

## Issue acceptance gates

- #7027: `openAIApiKeyCapabilities` is deleted from `src/model/providerCapabilities.ts`.
- #7027: `ProviderAuthMode` no longer advertises the unused `api-key` table key.
- #7027: the resolver table keeps only the production-used `chatgpt-subscription` profile.
- #7027: the test-only API-key resolver case is removed.

## Single source of truth

`src/model/providerCapabilities.ts` remains the single source of truth for provider capability profiles, now limited to the ChatGPT subscription profile that has production callers. Standard OpenAI API-key behavior remains owned by the existing `ModelHandler` / `ModelHandlerOpenAIResponse` defaults rather than a speculative capability row.

## Duplication and abstraction budget

Deleted a test-only resolver row instead of wiring a new production path. No new abstraction, wrapper, shim, or migration path was added.

## Host impact

Extension: no behavior change; OpenAI API-key models continue through the existing base handler defaults, and ChatGPT subscription routing is unchanged.

Desktop: no behavior change; the provider capability table still only affects subscription routing.

CLI: no behavior change; model execution and provider routing remain unchanged.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write src/model/providerCapabilities.ts src/test-kernel/model/ProviderCapabilities.vitest.ts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/model/ProviderCapabilities.vitest.ts src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts`
- `npm run typecheck`
- `npm test`
- `npm run lint` (passes with 15 pre-existing warnings, none in touched files)
- `npm run compile:fast`
- `git diff --check`

Closes #7027