### PR TITLE
[codex] Inline semantic char diff wrapper

### DIFF
--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -10,7 +10,7 @@ import { WorkspaceFS } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
 import {
   applyPatchToText,
-  diffTextByCharWithSemanticCleanup,
+  diffTextByChar,
   DIFF_DELETE,
   DIFF_EQUAL,
   DIFF_INSERT,
@@ -131,8 +131,9 @@ export function emitToolEditApprovalPrompt(
 // ============================================================================
 
 function createSemanticDiffs(original: string, proposed: string): TextDiff[] {
-  return diffTextByCharWithSemanticCleanup(original, proposed, {
+  return diffTextByChar(original, proposed, {
     checkLines: true,
+    cleanupSemantic: true,
   });
 }
 

--- a/src/utils/text/diff.ts
+++ b/src/utils/text/diff.ts
@@ -75,21 +75,6 @@ export function diffTextByChar(
 }
 
 /**
- * Compute a character diff with semantic cleanup enabled. Callers still choose
- * the `checkLines` mode explicitly.
- */
-export function diffTextByCharWithSemanticCleanup(
-  oldText: string,
-  newText: string,
-  options: Pick<CharDiffOptions, 'checkLines'> = {},
-): TextDiff[] {
-  return diffTextByChar(oldText, newText, {
-    ...options,
-    cleanupSemantic: true,
-  });
-}
-
-/**
  * Compute a line-mode diff by mapping whole lines to synthetic characters
  * before running `diff_main`. By default no semantic cleanup is applied.
  */


### PR DESCRIPTION
## Summary

Inlines the single caller of `diffTextByCharWithSemanticCleanup` and removes the forwarding wrapper from `@utils/text/diff`. I re-verified #7030 against current `origin/main`; the wrapper still had one caller and no material evidence drift.

## Issue acceptance gates

- #7030: `diffTextByCharWithSemanticCleanup` is removed from `src/utils/text/diff.ts`.
- #7030: `createSemanticDiffs` calls `diffTextByChar(original, proposed, { checkLines: true, cleanupSemantic: true })` directly.
- #7030: repository grep has no remaining `diffTextByCharWithSemanticCleanup` references.

## Single source of truth

`diffTextByChar` remains the single character-diff entry point. Semantic cleanup is now expressed as an option at the only call site that needs it.

## Duplication and abstraction budget

Deleted a single-caller forwarding export. No new abstraction, wrapper, shim, or migration path was added.

## Host impact

Extension: no behavior change; tool-edit approval previews still use character diffs with semantic cleanup.

Desktop: no behavior change; shared tool-edit approval logic is equivalent.

CLI: no behavior change; no CLI surface uses this approval helper directly.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write src/utils/text/diff.ts src/tools/approval/toolEditApproval.ts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/utils/TextDiffCallers.vitest.ts`
- `npm run typecheck`
- `npm test`
- `npm run lint` (passes with 15 pre-existing warnings, none in touched files)
- `npm run compile:fast`
- `git diff --check`

Closes #7030