### PR TITLE
[codex] Type run model decisions explicitly

### DIFF
--- a/packages/cli/src/runtime/runModel.ts
+++ b/packages/cli/src/runtime/runModel.ts
@@ -1,5 +1,8 @@
 import { toErrorMessage } from '@common/errors/errorMessage';
-import { decideRunModel } from '@model/runModelDecision';
+import {
+  decideRunModel,
+  type RunModelDecisionReason,
+} from '@model/runModelDecision';
 import { AgentCategory } from '@shared/schemas/agent';
 
 import {
@@ -25,17 +28,25 @@ export interface CliRunModelCandidate {
   readonly source: CliRunModelCandidateSource;
 }
 
-function cliSourceForDecision(source: string): CliRunModelCandidateSource {
-  switch (source) {
-    case 'explicit-override':
-      return 'override';
-    case 'environment':
-      return 'env';
-    case 'command-config':
-      return 'config';
-    default:
-      return 'builtin';
-  }
+const cliSourceForDecisionReason = {
+  'explicit-override': 'override',
+  environment: 'env',
+  'agent-config': 'builtin',
+  'command-config': 'config',
+  'workspace-config': 'builtin',
+  'user-config': 'builtin',
+  history: 'builtin',
+  'parent-run': 'builtin',
+  'router-config': 'builtin',
+  credential: 'builtin',
+  'builtin-default': 'builtin',
+  'access-list-default': 'builtin',
+} satisfies Record<RunModelDecisionReason, CliRunModelCandidateSource>;
+
+function cliSourceForDecision(
+  source: RunModelDecisionReason,
+): CliRunModelCandidateSource {
+  return cliSourceForDecisionReason[source];
 }
 
 /** Trim `-m`; throw a Usage error for unknown ids; undefined when absent. */

--- a/src/model/runModelDecision.ts
+++ b/src/model/runModelDecision.ts
@@ -26,6 +26,15 @@ type NormalizedRunModelCandidate = RunModelCandidate & {
   readonly model: string;
 };
 
+export interface RunModelDecision {
+  readonly model: string;
+  readonly reason: RunModelDecisionReason;
+  readonly unavailable?: true;
+  readonly fallbackFrom?: NormalizedRunModelCandidate & {
+    readonly mode: RunModelFallbackMode;
+  };
+}
+
 function normalizeCandidate(
   candidate: RunModelCandidate,
 ): NormalizedRunModelCandidate | null {
@@ -36,7 +45,7 @@ function normalizeCandidate(
 export function decideRunModel(
   candidates: readonly RunModelCandidate[],
   isRunnable: (model: string) => boolean = () => true,
-) {
+): RunModelDecision | null {
   const ordered = candidates
     .map(normalizeCandidate)
     .filter((candidate) => candidate != null)


### PR DESCRIPTION
## Summary

Adds an explicit `RunModelDecision` return type for `decideRunModel` and narrows the CLI source mapping to `RunModelDecisionReason`. I re-verified #7034 against current `origin/main`; both cited type gaps were still live.

## Issue acceptance gates

- #7034: `decideRunModel(...)` now declares `RunModelDecision | null` at the definition site.
- #7034: the decision shape is exported as `RunModelDecision`, including `model`, `reason`, `unavailable`, and `fallbackFrom`.
- #7034: `cliSourceForDecision` now accepts `RunModelDecisionReason`, not `string`.
- #7034: CLI source mapping is exhaustively checked with `satisfies Record<RunModelDecisionReason, CliRunModelCandidateSource>`.

## Single source of truth

`src/model/runModelDecision.ts` remains the single source of truth for model-run precedence and now also owns the public decision contract. The CLI maps that reason union into CLI source buckets with an exhaustive local table.

## Duplication and abstraction budget

No new runtime abstraction or wrapper was added. This PR is not net-negative in lines because the added mass lives in type contracts: one exported decision interface and one exhaustive reason-to-CLI-source map that replaces a permissive `string` switch/default.

## Host impact

Extension: no behavior change; shared model decision output has the same runtime shape.

Desktop: no behavior change; shared model decision output has the same runtime shape.

CLI: no behavior change; `texra run`, `--print`, and JSON behavior are unchanged, with stricter compile-time coverage for decision reasons.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write src/model/runModelDecision.ts packages/cli/src/runtime/runModel.ts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/cliModelResolution.vitest.mts`
- `npm run typecheck`
- `npm test`
- `npm run lint` (passes with 15 pre-existing warnings, none in touched files)
- `npm run compile:fast`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `git diff --check`

Closes #7034

