### PR TITLE
refactor(webview): use wa-badge and waIcon() instead of ad-hoc markup

### DIFF
--- a/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -20,6 +20,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { live } from 'lit/directives/live.js';
 import { repeat } from 'lit/directives/repeat.js';
 
+import '@awesome.me/webawesome/dist/components/badge/badge.js';
 import '@awesome.me/webawesome/dist/components/details/details.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
@@ -263,9 +264,9 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel<'externalInquiry'> {
 
   private renderHeader(data: ExternalInquiryPermission): TemplateResult {
     return html`
-      <div class="external-inquiry-request__mode-badge">
+      <wa-badge variant="neutral" appearance="filled">
         ${data.mode === 'followUp' ? 'follow-up' : 'new question'}
-      </div>
+      </wa-badge>
     `;
   }
 

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -27,11 +27,7 @@ import {
   type StreamStatusDisplayKey,
 } from '@shared/streams/streamStatusDisplay';
 import { statusIndicatorStyles } from '@shared/styles/statusIndicatorStyles';
-import {
-  TEXRA_ICON_LIBRARY,
-  type TeXRAIconName,
-  waIcon,
-} from '@shared/wa/webAwesomeIcons';
+import { type TeXRAIconName, waIcon } from '@shared/wa/webAwesomeIcons';
 
 // Side-effect imports - register WA icon component
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
@@ -484,12 +480,7 @@ export class StreamHeader extends LitElement {
       size="small"
       title=${ifDefined(getProgressBadgeTitle(this.progress))}
     >
-      <wa-icon
-        library=${TEXRA_ICON_LIBRARY}
-        name="pulse"
-        aria-hidden="true"
-      ></wa-icon>
-      ${renderProgressBadgeContent(this.progress)}
+      ${waIcon('pulse')} ${renderProgressBadgeContent(this.progress)}
     </wa-tag>`;
   }
 
@@ -509,12 +500,7 @@ export class StreamHeader extends LitElement {
         title="Go to parent: ${displayName}"
         @click=${this.navigateToParent}
       >
-        <wa-icon
-          library=${TEXRA_ICON_LIBRARY}
-          name="arrow-left"
-          aria-hidden="true"
-        ></wa-icon>
-        ${displayName}
+        ${waIcon('arrow-left')} ${displayName}
       </span>
     `;
   }

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -65,7 +65,6 @@ const ACTIONS = selectorGroup(ITEM_NAMES, '__actions');
 const FEEDBACKS = selectorGroup(ITEM_NAMES, '__feedback');
 const FEEDBACK_INPUTS = selectorGroup(ITEM_NAMES, '__feedback-input');
 const FEEDBACK_ACTIVE = selectorGroup(ITEM_NAMES, '--feedback-active');
-const BADGES = unsafeCSS('.external-inquiry-request__mode-badge');
 const SCROLLABLE_DETAILS = selectorGroup(
   ITEM_NAMES.filter((n) => n !== 'workflow-proposal'),
   '__details',
@@ -240,17 +239,6 @@ export const requestPanelStyles: CSSResult = css`
     :is(${ACTIONS})
     wa-button[data-action='reject']::part(base) {
     color: var(--wa-color-warning-border-quiet);
-  }
-
-  /* Shared badge base */
-  :is(${BADGES}) {
-    font-size: var(--font-size-xs);
-    font-weight: var(--font-weight-semibold);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    padding: ${sp.tiny} var(--border-radius-large);
-    border-radius: var(--border-radius);
-    white-space: nowrap;
   }
 
   /* Type-specific item accent + matching header icon color (see PANEL_TYPES / ACCENT_RULES) */
@@ -661,11 +649,6 @@ export const requestPanelStyles: CSSResult = css`
     font-variant-numeric: tabular-nums;
     min-width: 3ch;
     text-align: center;
-  }
-
-  .external-inquiry-request__mode-badge {
-    background: var(--wa-color-neutral-fill-quiet);
-    color: var(--wa-color-neutral-on-quiet);
   }
 
   .external-inquiry-request__context {


### PR DESCRIPTION
## Summary

A UI-consistency audit of the webview frontends turned up two spots that duplicated markup/styling the codebase already standardizes on (`wa-badge` and the `waIcon()` helper). This PR replaces both with the standard.

- `ExternalInquiryPanel.ts` rendered its follow-up/new-question label as a plain `<div class="external-inquiry-request__mode-badge">` with bespoke uppercase/padding/border-radius CSS, while the sibling `ProposalRequestPanel.ts` already renders the equivalent category pill with a real `<wa-badge>`. Swapped to `<wa-badge variant="neutral" appearance="filled">` and removed the now-dead CSS (`requestPanelStyles.ts`).
- `StreamHeader.ts` hand-built two `<wa-icon library=${TEXRA_ICON_LIBRARY} name="..." aria-hidden="true">` elements even though the same file already imports and correctly uses the `waIcon()` helper elsewhere (`renderGoalChip()`). Replaced both with `waIcon('pulse')` / `waIcon('arrow-left')` and dropped the now-unused `TEXRA_ICON_LIBRARY` import.

Not touched: a third candidate (`EntryErrorBoundary.tsx` in the CLI's Ink TUI truncating error text via a raw `.slice()` instead of `truncateSummaryToWidth`) was deliberately left as-is — that file has an explicit in-code comment stating the error-boundary fallback must "never do width math or anything that could itself throw," so the manual slice is an intentional design choice, not an inconsistency.

## Issue acceptance gates

Ad-hoc UI audit requested: scan for custom icons/inline styles/one-off components that duplicate the Font Awesome (`waIcon()`) / Web Awesome (`wa-*`) standard, and consolidate. Both confirmed findings are fixed; no other genuine duplication was found across the webview or CLI TUI trees.

## Single source of truth

`wa-badge` (via `@awesome.me/webawesome`) is now the sole renderer for the inquiry mode pill, matching `ProposalRequestPanel`. `waIcon()` in `src/shared/wa/webAwesomeIcons.ts` is now the sole call site for icon markup in `StreamHeader.ts`.

## Duplication and abstraction budget

Removed: one bespoke badge CSS rule set + one bespoke class override, and two hand-rolled `<wa-icon>` blocks. No new abstractions added.

## Host impact

Extension: `ExternalInquiryPanel` and `StreamHeader` (progress view) render markup slightly differently but functionally/visually equivalently (native `wa-badge` styling vs. the old bespoke CSS).

Desktop: none (shares the same webview frontend code).

CLI: none.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — pass
- `eslint` on changed files — clean
- `prettier --check` — clean (one file auto-formatted)
- `npm test` (full Vitest suite) — 4497 passed / 1 unrelated pre-existing flaky failure (`execUtils.vitest.ts` process-group abort timing, unrelated to this change) / 7 skipped


---
_Generated by [Claude Code](https://claude.ai/code/session_01HZ21xm3GiYbRH1wLHJuMA1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only markup and CSS cleanup in the progress webview; no permission, stream, or IPC behavior changes.
> 
> **Overview**
> Aligns two progress-view spots with existing Web Awesome patterns: **external inquiry mode labels** and **stream header icons**.
> 
> **External inquiry** — The follow-up / new-question pill is now a `<wa-badge variant="neutral" appearance="filled">` (same approach as `ProposalRequestPanel` category badges). The bespoke `external-inquiry-request__mode-badge` div and its shared badge CSS in `requestPanelStyles.ts` are removed.
> 
> **Stream header** — Progress badge and parent-link icons use `waIcon('pulse')` and `waIcon('arrow-left')` instead of hand-built `<wa-icon library=…>` markup; the unused `TEXRA_ICON_LIBRARY` import is dropped from this file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae156c9c33bdf256a0a5572c7a20f049d30b0430. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->