### PR TITLE
[codex] Skip setup credential scan for OpenRouter route

### DIFF
--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -53,19 +53,21 @@ interface LaunchModelResolution {
  */
 async function selectLaunchModel(): Promise<LaunchModelResolution | null> {
   const useOpenRouter = getUseOpenRouter();
-  const openRouterModel =
-    useOpenRouter || (await SecretManager.hasUsableApiKey('openRouter'))
+  const openRouterModel = useOpenRouter
+    ? SETUP_MODEL_BY_PROVIDER.openRouter
+    : (await SecretManager.hasUsableApiKey('openRouter'))
       ? SETUP_MODEL_BY_PROVIDER.openRouter
       : undefined;
+  const credentialModel = useOpenRouter
+    ? undefined
+    : await selectSetupCredentialModelExcludingOpenRouter(platform().secrets);
   const decision = decideRunModel([
     {
       model: useOpenRouter ? openRouterModel : undefined,
       reason: 'router-config',
     },
     {
-      model: await selectSetupCredentialModelExcludingOpenRouter(
-        platform().secrets,
-      ),
+      model: credentialModel,
       reason: 'credential',
     },
     {

--- a/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
+++ b/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
@@ -19,6 +19,8 @@ const mocks = vi.hoisted(() => ({
   showInformationMessage: vi.fn<() => Promise<unknown>>(),
   showErrorMessage: vi.fn<() => Promise<unknown>>(),
   executeCommand: vi.fn<() => Promise<unknown>>(),
+  selectSetupCredentialModelExcludingOpenRouter:
+    vi.fn<() => Promise<string | null>>(),
   logError: vi.fn(),
 }));
 
@@ -38,6 +40,11 @@ vi.mock('@agent/runtime/executionRegistry', () => ({
   executionRegistry: {
     getAgentHandles: () => agentHandles(),
   },
+}));
+
+vi.mock('@controllers/onboarding/setupLaunch', () => ({
+  selectSetupCredentialModelExcludingOpenRouter:
+    mocks.selectSetupCredentialModelExcludingOpenRouter,
 }));
 
 vi.mock('@auth/codex', () => ({
@@ -161,6 +168,7 @@ await import('vscode');
 await import('@utils/config/providerConfig');
 await import('@frontend/secretManager');
 await import('@agent/runtime/executionRegistry');
+await import('@controllers/onboarding/setupLaunch');
 await import('@auth/codex');
 await import('@auth/serverKeys');
 await import('@common/state');
@@ -180,6 +188,9 @@ describe('setup assistant routing check ordering', () => {
     mocks.showInformationMessage.mockReset();
     mocks.showErrorMessage.mockReset();
     mocks.executeCommand.mockReset();
+    mocks.selectSetupCredentialModelExcludingOpenRouter
+      .mockReset()
+      .mockResolvedValue(null);
     mocks.logError.mockReset();
     // Default: no OpenRouter, no keys — safe baseline.
     mocks.getUseOpenRouter.mockReturnValue(false);
@@ -243,5 +254,23 @@ describe('setup assistant routing check ordering', () => {
     expect(mocks.createQuickPick).not.toHaveBeenCalled();
     expect(mocks.showErrorMessage).not.toHaveBeenCalled();
     expect(result).toBe('launched');
+  });
+
+  it('does not scan non-OpenRouter credentials when OpenRouter routing is already on', async () => {
+    mocks.getUseOpenRouter.mockReturnValue(true);
+    mocks.hasUsableApiKey.mockImplementation(
+      async (provider: string) => provider === 'openRouter',
+    );
+    mocks.selectSetupCredentialModelExcludingOpenRouter.mockRejectedValue(
+      new Error('credential scan unavailable'),
+    );
+
+    const result = await launchSetupAssistant();
+
+    expect(result).toBe('launched');
+    expect(
+      mocks.selectSetupCredentialModelExcludingOpenRouter,
+    ).not.toHaveBeenCalled();
+    expect(mocks.showErrorMessage).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Restores the setup assistant OpenRouter short-circuit from #7033. When global OpenRouter routing is already enabled, `selectLaunchModel` no longer awaits the non-OpenRouter credential scan before the `router-config` candidate wins.

I re-verified #7033 against current `origin/main` before implementation and recorded drift on the issue: the OpenRouter key check already short-circuits today; the live regression is the extension credential-scan candidate.

## Issue acceptance gates

- #7033: `selectSetupCredentialModelExcludingOpenRouter(...)` is skipped when `getUseOpenRouter()` is true.
- #7033: OpenRouter-on launch still succeeds if the skipped credential scan would throw.
- #7033: shared/desktop setup launch needed no change; it already short-circuits the OpenRouter path.

## Single source of truth

`decideRunModel` remains the model-precedence owner. The extension setup launcher now only builds candidates whose prerequisites are valid for the active route instead of doing work for a lower-priority route first.

## Duplication and abstraction budget

No new abstraction, shim, or compatibility path was added. The change removes an unnecessary lower-priority credential probe from the OpenRouter route and pins the route behavior with one focused regression test.

## Host impact

Extension: fixes a setup launch regression where OpenRouter-enabled users could fail setup because a non-OpenRouter credential scan threw before OpenRouter won.

Desktop: no behavior change; the desktop shared setup path already skipped non-OpenRouter scans while OpenRouter routing is enabled.

CLI: no behavior change; CLI headless validation was run to preserve byte-parity expectations.

## Scheduled refactoring

None. No #6981 row is needed because this PR introduces no shim, projection, dual-write, alias, fallback, or migration path.

## Validation

- `corepack pnpm exec prettier --write packages/extension/src/commands/setup/setupAssistantCommand.ts src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts src/test-kernel/controllers/SetupLaunch.vitest.ts`
- `npm run typecheck`
- `npm test`
- `npm run lint` (passes with 15 pre-existing warnings, none in touched files)
- `npm run compile:fast`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `git diff --check`

Closes #7033