### PR TITLE
Fix high-severity data-structure findings from complexity review

### DIFF
--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -79,7 +79,7 @@ function renderConversationPaneEntry({
         />
       );
     }
-    if (entry.role === 'tool' && entry.toolUse) {
+    if (entry.role === 'tool') {
       return <ToolUseRow toolUse={entry.toolUse} width={width} />;
     }
     if (entry.role === 'assistant') {

--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -280,27 +280,21 @@ export const TranscriptEntry = memo(function TranscriptEntry({
       );
     }
     case 'tool':
-      if (entry.toolUse) {
-        return (
-          <ToolUseRow
-            fillWidth={fillWidth}
-            toolUse={entry.toolUse}
-            width={width}
-          />
-        );
-      }
-      break;
+      return (
+        <ToolUseRow
+          fillWidth={fillWidth}
+          toolUse={entry.toolUse}
+          width={width}
+        />
+      );
     case 'process':
-      if (entry.process) {
-        return (
-          <ProcessEntryRow
-            fillWidth={fillWidth}
-            process={entry.process}
-            width={width}
-          />
-        );
-      }
-      break;
+      return (
+        <ProcessEntryRow
+          fillWidth={fillWidth}
+          process={entry.process}
+          width={width}
+        />
+      );
   }
   return (
     <Box marginBottom={ASSISTANT_ENTRY_MARGIN_BOTTOM_ROWS}>
@@ -430,7 +424,7 @@ export const BoundedTranscriptEntry = memo(function BoundedTranscriptEntry({
       />
     );
   }
-  if (entry.role === 'tool' && entry.toolUse) {
+  if (entry.role === 'tool') {
     const cols = entryCols(width, 2);
     return (
       <Box flexDirection="column" paddingX={1}>
@@ -444,7 +438,7 @@ export const BoundedTranscriptEntry = memo(function BoundedTranscriptEntry({
       </Box>
     );
   }
-  if (entry.role === 'process' && entry.process) {
+  if (entry.role === 'process') {
     const cols = entryCols(width, 2);
     return (
       <Box flexDirection="column" paddingX={1}>

--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -69,9 +69,8 @@ export function isRenderableTranscriptEntry(entry: ConversationEntry): boolean {
     case 'user':
       return terminalVisibleTranscriptText(entry.text).trim().length > 0;
     case 'process':
-      return entry.process !== undefined;
     case 'tool':
-      return entry.toolUse !== undefined;
+      return true;
   }
 }
 

--- a/packages/cli/src/chat/tui/panes/transcriptViewport.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptViewport.ts
@@ -40,14 +40,14 @@ export function estimateTranscriptEntryRows(
   entry: ConversationEntry,
   width = 80,
 ): number {
-  if (entry.role === 'tool' && entry.toolUse) {
+  if (entry.role === 'tool') {
     const toolUse = entry.toolUse;
     return estimateEntryRows(() => {
       const lines = toolUseDisplayLines(toolUse);
       return lines.length + (lines.length > 1 ? 1 : 0);
     });
   }
-  if (entry.role === 'process' && entry.process) {
+  if (entry.role === 'process') {
     const process = entry.process;
     return estimateEntryRows(() => {
       return (

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -24,20 +24,15 @@ import {
   type TokenUsageStats,
 } from '@shared/schemas';
 
-export interface ConversationEntry {
+interface ConversationEntryBase {
   /** Same id as the upstream `StreamLogEntry.id` — stable across deltas. */
   readonly id: string;
-  readonly role: 'assistant' | 'error' | 'process' | 'tool' | 'user';
   /** Concatenated text for `MODEL_RESPONSE` entries. Empty for tool rows. */
   readonly text: string;
   /** True while rendered assistant text is hiding an incomplete protocol block. */
   readonly pendingEmbeddedSubagentFollowup?: boolean;
   /** True once the stream transitions to `WAITING`/`COMPLETED`. */
   readonly finalized: boolean;
-  /** Populated only when `role === 'tool'`. */
-  readonly toolUse?: NormalizedToolUse;
-  /** Populated only when `role === 'process'`. */
-  readonly process?: CompletedProcessTranscript;
   /** Entry was synthesized by the CLI and is not present in StreamLogStore. */
   readonly synthetic?: boolean;
   /** Why the CLI synthesized this entry. */
@@ -45,6 +40,22 @@ export interface ConversationEntry {
   /** StreamLog head at the moment a synthetic entry was appended. */
   readonly syntheticAfterSeq?: number;
 }
+
+/**
+ * Discriminated on `role` so `toolUse`/`process` are required exactly for
+ * the rows that need them, instead of independently-optional fields every
+ * consumer has to null-check regardless of role.
+ */
+export type ConversationEntry =
+  | (ConversationEntryBase & { readonly role: 'assistant' | 'error' | 'user' })
+  | (ConversationEntryBase & {
+      readonly role: 'tool';
+      readonly toolUse: NormalizedToolUse;
+    })
+  | (ConversationEntryBase & {
+      readonly role: 'process';
+      readonly process: CompletedProcessTranscript;
+    });
 
 export interface CompletedProcessTranscript {
   readonly executionId: string;

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -137,11 +137,10 @@ function entriesEqual(
   ) {
     return false;
   }
-  if (prev.role === 'tool') {
-    if (!prev.toolUse || !next.toolUse) return prev.toolUse === next.toolUse;
+  if (prev.role === 'tool' && next.role === 'tool') {
     return toolUseEqual(prev.toolUse, next.toolUse);
   }
-  if (prev.role === 'process') {
+  if (prev.role === 'process' && next.role === 'process') {
     return prev.process === next.process;
   }
   return true;
@@ -149,14 +148,14 @@ function entriesEqual(
 
 function logEntryRole(
   messageType: string | undefined,
-): ConversationEntry['role'] {
+): 'assistant' | 'error' | 'user' {
   if (messageType === MESSAGE_TYPES.USER_MESSAGE) return 'user';
   if (messageType === MESSAGE_TYPES.ERROR) return 'error';
   return 'assistant';
 }
 
 function renderLogEntryText(
-  role: ConversationEntry['role'],
+  role: 'assistant' | 'error' | 'user',
   text: string,
 ): string {
   switch (role) {
@@ -168,8 +167,6 @@ function renderLogEntryText(
       return appendCliApiSwitchHint(text);
     case 'user':
       return summarizeFollowupMessage(text);
-    default:
-      return text;
   }
 }
 
@@ -181,7 +178,7 @@ function renderLogEntry(
     // Cache hit: same `data` reference as last sync, no re-normalize.
     // Promotion to `<Static>` is decided later by `finalizeSettledPrefix`
     // over the ordered slice, so a cache hit just returns `prev` as-is.
-    if (prev?.toolUse && toolUseSourceCache.get(prev) === entry.data) {
+    if (prev?.role === 'tool' && toolUseSourceCache.get(prev) === entry.data) {
       return prev;
     }
 

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -252,7 +252,7 @@ function isSettledEntry(
     case 'process':
       return true;
     case 'tool':
-      return entry.toolUse?.status === TOOL_USE_STATUS.COMPLETED;
+      return entry.toolUse.status === TOOL_USE_STATUS.COMPLETED;
     case 'assistant':
       return (
         !entry.pendingEmbeddedSubagentFollowup && index < entries.length - 1

--- a/packages/cli/src/chat/tui/state/transcriptLines.ts
+++ b/packages/cli/src/chat/tui/state/transcriptLines.ts
@@ -83,13 +83,12 @@ function computeTranscriptEntryLines(
 ): readonly string[] {
   switch (entry.role) {
     case 'tool':
-      return entry.toolUse
-        ? wrapLines(toolUseDisplayLines(entry.toolUse, { elide: false }), cols)
-        : [];
+      return wrapLines(
+        toolUseDisplayLines(entry.toolUse, { elide: false }),
+        cols,
+      );
     case 'process':
-      return entry.process
-        ? wrapLines(completedProcessDisplayLines(entry.process), cols)
-        : [];
+      return wrapLines(completedProcessDisplayLines(entry.process), cols);
     case 'user':
       return wrapWithPrefix(entry.text, cols, '› ');
     case 'error':

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -161,18 +161,32 @@ interface ProcessPrepResult {
   accumulatedOutput: string;
 }
 
-interface ProcessResult {
+interface ProcessResultCommon {
   stopReason: ProviderStopReason;
-  newResponse?: string;
-  processedResponse?: string;
-  bestConnector?: string;
   thinkingContent?: string | null;
   useStreaming: boolean;
   responseUsage: ProviderUsage;
   normalizedUsage?: NormalizedUsage;
-  updatedLastResponse?: string;
-  updatedAccumulatedOutput?: string;
 }
+
+/**
+ * Discriminated on `hasResponse`: `newResponse`/`processedResponse`/
+ * `bestConnector`/`updatedLastResponse`/`updatedAccumulatedOutput` are only
+ * ever set together (see the `if (newResponse)` block below), so modeling
+ * them as one correlated variant instead of five independently-optional
+ * fields removes the need to re-derive that correlation with separate null
+ * checks in `post()`.
+ */
+type ProcessResult =
+  | (ProcessResultCommon & { hasResponse: false })
+  | (ProcessResultCommon & {
+      hasResponse: true;
+      newResponse: string;
+      processedResponse: string;
+      bestConnector: string;
+      updatedLastResponse: string;
+      updatedAccumulatedOutput: string;
+    });
 
 type ProcessNodeResult = SkippableNodeResult<ProcessResult>;
 
@@ -288,39 +302,40 @@ class ResponseProcessNode<C> extends BaseNode<
         });
       }
 
-      let processedResponse: string | undefined;
-      let bestConnector: string | undefined;
-      let updatedLastResponse: string | undefined;
-      let updatedAccumulatedOutput: string | undefined;
+      const common = {
+        stopReason,
+        thinkingContent,
+        useStreaming,
+        responseUsage,
+        normalizedUsage,
+      };
 
-      if (newResponse) {
-        // Text cleanup (replacementEngine.applyAll) is applied once inside each
-        // handler's extractResponse, so newResponse is already cleaned here.
-        // Re-applying would run non-idempotent custom replacements twice.
-        processedResponse = newResponse;
-
-        const connector = await this.services.bestConnectionMethod(
-          prepRes.lastResponse.slice(-K_SLICE),
-          processedResponse.slice(0, K_SLICE),
-        );
-        bestConnector = connector.connector;
-        updatedLastResponse = processedResponse;
-        updatedAccumulatedOutput =
-          prepRes.accumulatedOutput + (bestConnector ?? '') + processedResponse;
+      if (!newResponse) {
+        return { kind: 'success', value: { ...common, hasResponse: false } };
       }
+
+      // Text cleanup (replacementEngine.applyAll) is applied once inside each
+      // handler's extractResponse, so newResponse is already cleaned here.
+      // Re-applying would run non-idempotent custom replacements twice.
+      const processedResponse = newResponse;
+
+      const connector = await this.services.bestConnectionMethod(
+        prepRes.lastResponse.slice(-K_SLICE),
+        processedResponse.slice(0, K_SLICE),
+      );
+      const bestConnector = connector.connector;
+      const updatedAccumulatedOutput =
+        prepRes.accumulatedOutput + bestConnector + processedResponse;
 
       return {
         kind: 'success',
         value: {
-          stopReason,
+          ...common,
+          hasResponse: true,
           newResponse,
           processedResponse,
           bestConnector,
-          thinkingContent,
-          useStreaming,
-          responseUsage,
-          normalizedUsage,
-          updatedLastResponse,
+          updatedLastResponse: processedResponse,
           updatedAccumulatedOutput,
         },
       };
@@ -349,25 +364,21 @@ class ResponseProcessNode<C> extends BaseNode<
       round.normalizedUsage = result.normalizedUsage;
     }
 
-    if (result.updatedLastResponse != null) {
-      workspace.assembly.lastResponse = result.updatedLastResponse;
-    }
-
-    if (result.updatedAccumulatedOutput != null) {
-      workspace.assembly.accumulatedOutput = result.updatedAccumulatedOutput;
-    }
-
     shared.stopReason = result.stopReason;
-    shared.processedResponse = result.processedResponse;
 
-    if (!result.processedResponse) {
+    if (!result.hasResponse) {
+      shared.processedResponse = undefined;
       shared.endTurn = false;
       shared.shouldStop = true;
       return FlowTransition.COMPLETE;
     }
 
+    workspace.assembly.lastResponse = result.updatedLastResponse;
+    workspace.assembly.accumulatedOutput = result.updatedAccumulatedOutput;
+    shared.processedResponse = result.processedResponse;
+
     const outputLocation = shared.outputLocation!;
-    const connector = result.bestConnector ?? '';
+    const connector = result.bestConnector;
 
     await AbsoluteFS.ensureDir(dirname(outputLocation.absolutePath));
 

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -1541,14 +1541,20 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
         return withUpdated(result);
       }
 
-      const params: CreateModelInteractionParamsNonStreaming = {
+      // Not annotated with `CreateModelInteractionParamsNonStreaming`: the
+      // SDK's public export of that name (`Interactions.*`) is only the
+      // request-body subset and doesn't line up with the (unexported)
+      // parameter type its own `create()` overload for this shape expects,
+      // so an explicit annotation here would make TS fall through to
+      // `create()`'s most general overload and lose the precise response type.
+      // Leaving `params` inferred keeps its structural type (which does
+      // include `model`/`input`/`store` from `commonParams`) matching that
+      // overload, so `response` comes back correctly typed with no cast.
+      const params = {
         ...commonParams,
-        stream: false,
+        stream: false as const,
       };
-      const response = (await client.interactions.create(
-        params,
-        requestOptions,
-      )) as unknown as GoogleGenAIInteraction;
+      const response = await client.interactions.create(params, requestOptions);
       this.finalizeChain(response, base.length, stateful);
       return withUpdated({ response });
     } catch (error) {
@@ -1602,9 +1608,17 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
    * commonParams, so chaining composes with background unchanged. Cancels the
    * in-flight interaction on abort. Mirrors ModelHandlerOpenAIResponse.
    */
-  private async executeBackgroundPath(
+  // Generic (rather than annotating `commonParams` with the public
+  // `CreateModelInteractionParamsNonStreaming` alias) so the caller's actual
+  // request-shape fields (`model`/`input`/`store`/…) survive into
+  // `submitParams` below — see the comment on the sibling non-streaming
+  // `create()` call in `createResponseImpl` for why the public alias by
+  // itself would make TS pick `create()`'s most general overload.
+  private async executeBackgroundPath<
+    P extends Omit<CreateModelInteractionParamsNonStreaming, 'stream'>,
+  >(
     client: GoogleGenAI,
-    commonParams: Omit<CreateModelInteractionParamsNonStreaming, 'stream'>,
+    commonParams: P,
     totalStepCount: number,
     stateful: boolean,
     requestOptions: { fetchOptions: { signal: AbortSignal } } | undefined,
@@ -1620,9 +1634,9 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
     }
 
     // background:true forces store:true (already true under `stateful`).
-    const submitParams: CreateModelInteractionParamsNonStreaming = {
+    const submitParams = {
       ...commonParams,
-      stream: false,
+      stream: false as const,
       store: true,
       background: true,
     };
@@ -1634,10 +1648,10 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
     // SMOKE-TEST: the initial status of a background:true create, and whether
     // background:true is accepted with store:true (and rejected/ignored with
     // store:false), are unconfirmed offline; verify on a real-key run.
-    const submitted = (await client.interactions.create(
+    const submitted = await client.interactions.create(
       submitParams,
       requestOptions,
-    )) as unknown as GoogleGenAIInteraction;
+    );
 
     const completed = await this.pollBackgroundInteraction(
       client,
@@ -1687,11 +1701,11 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
         retrieve: async (id, sig) => {
           const opts = sig ? { fetchOptions: { signal: sig } } : requestOptions;
           try {
-            return (await client.interactions.get(
+            return await client.interactions.get(
               id,
               ModelHandlerGoogleInteractions.BACKGROUND_GET_PARAMS,
               opts,
-            )) as unknown as GoogleGenAIInteraction;
+            );
           } catch (err) {
             // Tag and rethrow — a user-abort surfaces as-is; a transient poll
             // error (5xx/429/network) re-enters createResponse via PocketFlow's
@@ -1878,11 +1892,10 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
             break;
 
           case 'interaction.completed':
-            // The completed event carries the final status/usage/steps. Cast to
-            // the handler's Resp shape (steps non-optional downstream is tolerated
-            // via the `?? []` reads in extractors).
-            completedInteraction =
-              event.interaction as unknown as GoogleGenAIInteraction;
+            // The completed event's `interaction` field is already structurally
+            // compatible with GoogleGenAIInteraction (same required id/status,
+            // same optional usage/steps), so no cast is needed here.
+            completedInteraction = event.interaction;
             break;
 
           case 'error': {
@@ -1921,7 +1934,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
           finalizedSteps.length > 0
             ? finalizedSteps
             : (completedInteraction?.steps ?? []),
-      } as unknown as GoogleGenAIInteraction;
+      };
 
       const finalReasoning = this.processThinkingBlock(response);
       thinking.finalize(finalReasoning ?? undefined);

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -14,6 +14,7 @@ import type {
   UsageRoute,
 } from '@shared/schemas';
 import { roundTo } from '@utils/core';
+import type { UsageLogStats } from '@telemetry/UsageLogTypes';
 import type { ModelCapabilities, ModelConfig } from 'llm-zoo';
 
 /**
@@ -243,16 +244,16 @@ export class UsageMonitor {
    */
   private async logToBackend(
     totalResponseTimeMs: number,
-    usage: {
-      inputTokens: number;
-      outputTokens: number;
-      cachedInputTokens?: number;
-      cacheMissInputTokens?: number;
-      cacheCreationInputTokens?: number;
-      reasoningTokens?: number;
-      cost: number;
-      usageRoute?: UsageRoute;
-    },
+    usage: Pick<
+      UsageLogStats,
+      | 'inputTokens'
+      | 'outputTokens'
+      | 'cachedInputTokens'
+      | 'cacheMissInputTokens'
+      | 'cacheCreationInputTokens'
+      | 'reasoningTokens'
+      | 'cost'
+    > & { usageRoute?: UsageRoute },
   ): Promise<void> {
     try {
       const { config } = this.modelInfo;

--- a/src/telemetry/UsageLogTypes.ts
+++ b/src/telemetry/UsageLogTypes.ts
@@ -15,7 +15,7 @@ const UsageLogMetadataSchema = z.object({
   streamId: z.string().optional(),
 });
 
-const UsageLogStatsSchema = z.object({
+export const UsageLogStatsSchema = z.object({
   inputTokens: z.int().nonnegative(),
   outputTokens: z.int().nonnegative(),
   cost: z.number().nonnegative(),
@@ -25,6 +25,16 @@ const UsageLogStatsSchema = z.object({
   cacheCreationInputTokens: z.int().nonnegative().optional(),
   reasoningTokens: z.int().nonnegative().optional(),
 });
+
+/**
+ * Field names here intentionally follow this wire schema, not
+ * `NormalizedUsage`'s (e.g. `cacheCreationInputTokens` vs.
+ * `cacheCreationTokens`) — this is the persisted/billing log contract, so
+ * renaming it isn't free. Callers building a log payload from
+ * `NormalizedUsage` should type their intermediate object as (a `Pick` of)
+ * `UsageLogStats` rather than hand-duplicating this field list.
+ */
+export type UsageLogStats = z.infer<typeof UsageLogStatsSchema>;
 
 export const UsageLogEntrySchema = UsageLogMetadataSchema.extend(
   UsageLogStatsSchema.shape,

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -67,7 +67,7 @@ const SESSION_META = {
 
 function entry(
   id: string,
-  role: ConversationEntry['role'],
+  role: 'assistant' | 'error' | 'user',
   text: string,
   finalized: boolean,
 ): ConversationEntry {
@@ -78,7 +78,7 @@ function toolEntry(
   id: string,
   status: NormalizedToolUse['status'],
   outputText = status === 'completed' ? 'ok' : '',
-): ConversationEntry {
+): Extract<ConversationEntry, { role: 'tool' }> {
   return {
     id,
     role: 'tool',
@@ -99,7 +99,10 @@ function toolEntry(
   };
 }
 
-function compactExecutionsEntry(id: string, path: string): ConversationEntry {
+function compactExecutionsEntry(
+  id: string,
+  path: string,
+): Extract<ConversationEntry, { role: 'tool' }> {
   return {
     id,
     role: 'tool',
@@ -120,7 +123,9 @@ function compactExecutionsEntry(id: string, path: string): ConversationEntry {
   };
 }
 
-function processEntry(id: string): ConversationEntry {
+function processEntry(
+  id: string,
+): Extract<ConversationEntry, { role: 'process' }> {
   return {
     id,
     role: 'process',


### PR DESCRIPTION
## Summary

Follow-up to a codebase-wide data-structure complexity review. Fixes the 5 highest-severity findings (one already-fixed finding — `ToolResultSchema`'s missing status discriminant — was resolved upstream in #7028 before this branch was rebased, so it's not included here).

- **CLI TUI (`packages/cli/src/chat/tui/**`)**: `ConversationEntry` was a flat interface with `role: 'assistant'|'error'|'process'|'tool'|'user'` next to always-optional `toolUse?`/`process?` fields only valid for specific roles. `TranscriptEntry.tsx` had `case 'tool': if (entry.toolUse) {...} break;`, which silently rendered nothing if a tool-role entry ever lacked `toolUse` — nothing in the type system prevented that. Converted `ConversationEntry` into a discriminated union keyed on `role`, so `toolUse`/`process` are required exactly where they apply, and removed the now-redundant guards across `TranscriptEntry.tsx`, `ConversationPane.tsx`, `transcriptViewport.ts`, `transcriptLines.ts`, `transcriptEntries.ts`, and `subscribeStreamLog.ts`.

- **`src/agent/core/flows/ResponseCycleFlow.ts`**: `ProcessResult` declared 7 fields as independently optional, but 5 of them (`newResponse`, `processedResponse`, `bestConnector`, `updatedLastResponse`, `updatedAccumulatedOutput`) were only ever set together as a block. `post()` re-derived that correlation with 5 separate null checks. Replaced with a discriminated union on a new `hasResponse` flag; `post()` now narrows once instead of re-checking each field.

- **`src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts`**: removed all 5 `as unknown as GoogleGenAIInteraction` casts. 3 were unnecessary — the real Google GenAI SDK values (the SSE `interaction.completed` payload, the `.get()` response, and a hand-built fallback object) already structurally satisfy our reconstructed type once you check the SDK's actual `.d.ts`. The remaining 2 (`.create()` calls) only needed the cast because annotating the request params with the SDK's *public* alias for that type loses fields (`model`, `input`, `store`, …) that its own overload set requires to resolve to the precise non-streaming return type — annotating `params` with that public alias silently pushed overload resolution to the SDK's most general signature (`GoogleGenAIInteraction | Stream<...>`). Letting `params`'s type be inferred instead preserves those fields and resolves the correct overload, so no cast is needed. Left explanatory comments at both sites since this is a real quirk in the SDK's own type exports, not something obvious from reading our code alone.

- **`src/agent/utils/UsageMonitor.ts` / `src/telemetry/UsageLogTypes.ts`**: `logToBackend`'s `usage` parameter was a hand-duplicated inline type that happened to match a subset of `UsageLogStatsSchema`'s fields, with no compiler link between the two. Exported `UsageLogStats` (the schema's inferred type) and changed the parameter to `Pick<UsageLogStats, ...>` so it can't silently drift from the schema. Field *names* were intentionally left as-is (kept distinct from `NormalizedUsage`'s naming) since this schema is the persisted/billing log wire contract — renaming isn't free.

## Single source of truth

- `ConversationEntry`'s discriminant (`role`) now owns whether `toolUse`/`process` exist, instead of every reader re-deriving it.
- `ProcessResult`'s `hasResponse` flag owns whether the correlated response fields exist.
- `UsageLogStats` (derived from `UsageLogStatsSchema`) is now the single declared shape for `logToBackend`'s stats fields.

## Duplication and abstraction budget

Removed 5 unsafe type casts, 1 redundant type-then-cast double-annotation, and ~8 now-provably-unreachable optional-field guards. No new abstractions were introduced — the discriminated unions replace existing flat types in place, and `UsageLogStats` is just an export of an already-existing schema's inferred type.

## Host impact

Extension: none (no touched files).

Desktop: none (no touched files).

CLI: `ConversationEntry`/transcript rendering — a tool-role transcript row can no longer silently render as blank; behavior for well-formed entries is unchanged (verified by the existing 43-test `ConversationPane` suite, updated only to reflect the stricter type).

## Scheduled refactoring

None. The remaining medium/low-severity findings from the original review (schema duplication in `SyncStreamContentPayload`, the "files" shapes, `DiffResult`/`DiffResultDisplay`, etc.) were intentionally left out of this PR's scope and can be tackled separately if wanted.

## Validation

- `npm run typecheck` (full workspace, including `packages/cli` and `packages/extension`) — clean.
- `npm run lint` — 0 errors (pre-existing warnings only, none introduced by this change).
- `npm test` (full suite, 4505 tests) — 1 pre-existing failure (`execUtils.vitest.ts` process-group abort test), confirmed to fail identically on unmodified `main` in this sandbox; unrelated to this diff.
- Targeted re-runs after each change: CLI `ConversationPane` suite (43/43), full `src/test-kernel/agent` suite (932/936, 4 pre-existing skips), all `GoogleInteractions*` handler tests (45/49, 4 pre-existing skips) and the broader `modelHandlers` suite (361/365), and the usage-logging/monitor tests (35/35).


---
_Generated by [Claude Code](https://claude.ai/code/session_01BPuyoZqLExqbTcmvarmuJ6)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent response assembly (`ResponseCycleFlow`) and Google Interactions API calls where typing/cast changes could hide SDK mismatches; CLI changes are mostly compile-time narrowing with behavior unchanged for well-formed entries.
> 
> **Overview**
> Follow-up to a data-structure complexity review: replaces several “flat + optional fields” shapes with **discriminated unions** and tightens a few typing/cast hotspots so consumers don’t re-derive correlations at runtime.
> 
> **CLI TUI:** `ConversationEntry` is now keyed on `role`, with **`toolUse` / `process` required only for tool and process rows**. Transcript rendering, viewport math, stream-log sync, and related helpers drop redundant `entry.toolUse` / `entry.process` guards; tool/process rows are always treated as renderable when role matches.
> 
> **Agent flow:** `ProcessResult` in `ResponseCycleFlow` uses a **`hasResponse` flag** so response text, connector, and assembly updates are one variant; `post()` branches once instead of five separate null checks.
> 
> **Google Interactions handler:** Removes **`as unknown as GoogleGenAIInteraction`** casts by relying on structural SDK types and **inferred `create()` params** (`stream: false as const`) so overload resolution returns the non-streaming interaction type without widening to the general union.
> 
> **Telemetry:** Exports **`UsageLogStats`** from the Zod schema and types `UsageMonitor.logToBackend` as a **`Pick` of that shape** so billing log fields can’t drift from the wire contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30cf40646e58e9f0ce1dbc12cf91342841651d0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->