### PR TITLE
[codex] Keep subscription model hints on original metadata

### DIFF
--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -346,7 +346,7 @@ async function buildModelOptionData(
       }
     : config;
   return {
-    ...buildBaseModelOption(model, optionConfig),
+    ...buildBaseModelOption(model, optionConfig, config),
     availability: availability.kind,
     availabilityLabel: availability.label,
     requiresKey: availability.requiresKey,

--- a/src/model/modelOptionsBasic.ts
+++ b/src/model/modelOptionsBasic.ts
@@ -76,6 +76,7 @@ function buildModelHint(config: ModelConfig): string {
 export function buildBaseModelOption(
   model: string,
   config: ModelConfig,
+  hintConfig: ModelConfig = config,
 ): ModelOptionData {
   return {
     value: model,
@@ -83,7 +84,7 @@ export function buildBaseModelOption(
     provider: config.provider,
     context: formatContext(config.contextWindow),
     cost: formatCost(config.inputPrice, config.outputPrice),
-    hint: buildModelHint(config),
+    hint: buildModelHint(hintConfig),
   };
 }
 

--- a/src/test-kernel/model/ComputeModelOptions.vitest.ts
+++ b/src/test-kernel/model/ComputeModelOptions.vitest.ts
@@ -19,6 +19,7 @@ import {
   type ModelOptionsAccess,
   type ModelOptionsServerAccess,
 } from '@model/computeModelOptions';
+import { FAST_FIRST_RESPONSE_HINT } from '@shared/constants/fastModels';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { AgentCategory } from '@shared/schemas/agent';
 
@@ -249,6 +250,7 @@ describe('computeModelOptionsData relay quota state', () => {
       `${Math.round(CODEX_SUBSCRIPTION_CONTEXT_WINDOW / 1000)}K`,
     );
     expect(model.cost).toBe('$0.000/$0.000');
+    expect(model.hint).not.toContain(FAST_FIRST_RESPONSE_HINT);
     expect(model.disabled).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

Fixes #7026 by keeping model-picker speed hints tied to the original llm-zoo model metadata while still using ChatGPT-subscription provider capabilities for displayed context and cost.

I re-verified the cited #7026 evidence against current origin/main before implementation. The citations still matched: subscription provider capabilities project zero pricing into option display data, and the fast-first-response hint used that same projected input price.

## Issue acceptance gates

- #7026: subscription-access models keep projected subscription context and zero-dollar cost display.
- #7026: the fast-first-response hint is computed from the original unprojected model config.
- #7026: gpt-5.5 subscription access is covered by a regression assertion that rejects the fast hint.

## Single source of truth

Original llm-zoo model metadata remains the single source of truth for model speed hints. Provider capability projections remain limited to availability/display facts such as subscription context and billing.

## Duplication and abstraction budget

No shim, fallback, alias, dual-write, or migration path was added, so no #6981 ledger row is needed. The net added code is confined to one optional helper parameter and one regression assertion documenting the display-vs-hint split.

## Host impact

Extension: model picker tooltips no longer advertise large subscription-routed GPT models as fast solely because subscription billing is zeroed.

Desktop: shared model option data gets the same corrected hint behavior if surfaced there; subscription context/cost display is unchanged.

CLI: no intended behavior change; CLI headless validation was run to preserve the run contract.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write src/model/modelOptionsBasic.ts src/model/computeModelOptions.ts src/test-kernel/model/ComputeModelOptions.vitest.ts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/model/ComputeModelOptions.vitest.ts`
- `npm run typecheck`
- `npm test` (passes with the pre-existing workflow metadata persistence warning)
- `npm run lint` (passes with 15 pre-existing warnings, none in touched files)
- `npm run compile:fast`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `git diff --check origin/main...HEAD`

Closes #7026