### PR TITLE
fix: sync claude.yml auto-create-PR inputs with TNLean's version

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -125,4 +125,9 @@ jobs:
           repo: ${{ github.repository }}
           branch-prefix: 'claude/issue-'
           creator-name: 'Claude Code action'
+          autofix-label: 'auto-fix-claude'
+          event-name: ${{ github.event_name }}
+          comment-body: ${{ github.event.comment.body || '' }}
+          issue-body: ${{ github.event.issue.body || '' }}
+          issue-title: ${{ github.event.issue.title || '' }}
           gh-token: ${{ env.BOT_PAT }}


### PR DESCRIPTION
## Summary
- The `Auto-create PR for completed issue work` step in `claude.yml` was missing `autofix-label`, `event-name`, `comment-body`, `issue-body`, and `issue-title` inputs that TNLean's copy of this workflow already passes to the same `LionSR/agent-ci-actions/auto-create-issue-pr@v1` action.
- Brings the two in parity; `gh-token` intentionally stays on `BOT_PAT` (coauthor-specific, already guarded by the existing `env.BOT_PAT != ''` condition).

## Test plan
- [ ] Trigger the `claude` workflow via an `@claude`-tagged issue and confirm the auto-created PR picks up the `auto-fix-claude` label

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only input wiring with no application or auth logic changes beyond enabling existing third-party action behavior.
> 
> **Overview**
> Aligns the **Auto-create PR for completed issue work** step in `claude.yml` with the same `LionSR/agent-ci-actions/auto-create-issue-pr@v1` contract used elsewhere by passing five inputs that were previously omitted: `autofix-label` (`auto-fix-claude`), `event-name`, and the issue/comment `body`/`title` fields from the triggering GitHub event.
> 
> This lets the composite action label auto-created PRs and branch/metadata logic from the actual issue or comment context instead of relying on defaults. **`gh-token`** stays on `BOT_PAT` behind the existing non-empty guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68d59d6eb304d6486a8267815edb76750e116ea6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->