### PR TITLE
[codex] Route original snapshots through storage helper

### DIFF
--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -17,6 +17,7 @@ import {
   ensureParentDir,
   ensureRunDir,
   getRunDir,
+  getOriginalSnapshotPath,
   getRunStorageAbsolutePath,
   shouldSkipRelocation,
   snapshotExists,
@@ -165,10 +166,9 @@ export class TaskRunFileService {
       const stats = await fs.stat(target.absolutePath);
       if (!stats.isFile()) return;
 
-      const snapshotRelative = path.join('original', target.relativePath);
-      const snapshotAbsolute = getRunStorageAbsolutePath(
+      const snapshotAbsolute = getOriginalSnapshotPath(
         executionId,
-        snapshotRelative,
+        target.relativePath,
       );
 
       if (await snapshotExists(snapshotAbsolute)) return;
@@ -327,9 +327,9 @@ export class TaskRunFileService {
         // (cls/sty/bib/figures) have no snapshot and fall through to the
         // workspace mirror at `runDir/<rel>`, which is correct — those
         // are never written to.
-        const snapshotAbsolute = getRunStorageAbsolutePath(
+        const snapshotAbsolute = getOriginalSnapshotPath(
           executionId,
-          path.join('original', relativePath),
+          relativePath,
         );
         const workspaceMirrorAbsolute = getRunStorageAbsolutePath(
           executionId,


### PR DESCRIPTION
## Summary

Fixes #7039 by routing TaskRunFileService original-snapshot path construction through `getOriginalSnapshotPath`, which wraps the storage-layout owner for `original` snapshots.

I re-verified the cited evidence before implementation and recorded the same-file drift on #7039: the cited ensureMirroredInRunSubdir literal was still live, and captureOriginalSnapshot had a sibling hardcoded original-snapshot path that is included in this same cleanup.

## Issue acceptance gates

- #7039: ensureMirroredInRunSubdir no longer builds original snapshot paths with a hardcoded original directory literal.
- #7039: captureOriginalSnapshot now uses the same helper, so taskRunStorage has no same-file bypass for original snapshot paths.
- #7039: resulting paths remain byte-identical through existing run-storage mirror tests.

## Single source of truth

`resolveRunOriginalSnapshotPath`, reached here through `getOriginalSnapshotPath`, remains the single owner for the per-run original snapshot directory layout.

## Duplication and abstraction budget

No shim, fallback, alias, dual-write, or migration path was added, so no #6981 ledger row is needed. The PR is line-neutral and removes two local string-literal path constructions in favor of the existing storage helper.

## Host impact

Extension: no behavior change; original snapshot paths resolve to the same storage locations.

Desktop: no behavior change; shared run-storage helpers remain byte-identical.

CLI: no intended behavior change; CLI headless validation was run to preserve the run contract.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write src/utils/files/taskRunStorage.ts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/utils/RoundDirOwnership.vitest.ts src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts src/test-kernel/platform/WorkspaceStorage.vitest.ts`
- `npm run typecheck`
- `npm test` (passes with the pre-existing workflow metadata persistence warning)
- `npm run lint` (passes with 15 pre-existing warnings, none in touched files)
- `npm run compile:fast`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `git diff --check origin/main...HEAD`

Closes #7039