### PR TITLE
[codex] Inline memory storage path pass-through

### DIFF
--- a/src/platform/defaults/workspaceStorage.ts
+++ b/src/platform/defaults/workspaceStorage.ts
@@ -76,12 +76,6 @@ export function resolveMemoryStoragePath(storagePath: string): string {
     : MEMORY_STORAGE_DIR;
 }
 
-export function resolveMemoryStorageRelativePath(relativePath: string): string {
-  return relativePath
-    ? join(MEMORY_STORAGE_DIR, relativePath)
-    : MEMORY_STORAGE_DIR;
-}
-
 export function resolveRunStoragePath(...segments: string[]): string {
   return segments.length
     ? join(RUNS_STORAGE_DIR, ...segments)

--- a/src/test-kernel/cli/CliMemory.vitest.mts
+++ b/src/test-kernel/cli/CliMemory.vitest.mts
@@ -69,6 +69,12 @@ describe('CLI memory formatting', () => {
       'Invalid memory path',
     );
   });
+
+  it('reports the original display path when a memory path escapes the root', () => {
+    expect(() =>
+      cliMemoryStoragePathFromInput('/memories/../outside.md'),
+    ).toThrow('Invalid memory path: /memories/../outside.md');
+  });
 });
 
 describe('memorySelectWindow', () => {

--- a/src/tools/memory/memoryUtils.ts
+++ b/src/tools/memory/memoryUtils.ts
@@ -1,9 +1,5 @@
 import * as path from 'node:path';
 
-import {
-  resolveMemoryStoragePath,
-  resolveMemoryStorageRelativePath,
-} from '@platform/defaults/workspaceStorage';
 import { normalizeFilePath } from '@shared/utils/path';
 
 import { MEMORY_DISPLAY_ROOT, MEMORY_STORAGE_ROOT } from './constants';
@@ -51,5 +47,10 @@ export function displayToStoragePath(displayPath: string): string {
   const resolved = path.resolve(MEMORY_STORAGE_ROOT, suffix);
   const base = path.resolve(MEMORY_STORAGE_ROOT);
   const relative = path.relative(base, resolved);
-  return resolveMemoryStoragePath(resolveMemoryStorageRelativePath(relative));
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`Invalid memory path: ${displayPath}`);
+  }
+  return relative
+    ? path.join(MEMORY_STORAGE_ROOT, relative)
+    : MEMORY_STORAGE_ROOT;
 }


### PR DESCRIPTION
## Summary

Fixes #7038 by deleting the single-caller resolveMemoryStorageRelativePath pass-through and letting displayToStoragePath build the memory storage path directly after its root-escape check.

The escaped-path error now reports the original display path the user supplied, and the PR adds a regression assertion for that behavior.

## Issue acceptance gates

- #7038: resolveMemoryStorageRelativePath is deleted from workspaceStorage.
- #7038: the lone memoryUtils caller is inlined instead of routing through a pass-through helper.
- #7038: escaping memory display paths report the original display path in the error.

## Single source of truth

src/tools/memory/memoryUtils.ts now owns display-to-storage conversion for memory display paths. src/platform/defaults/workspaceStorage.ts continues to own validation of already-storage-relative memory paths.

## Duplication and abstraction budget

Removed one single-caller pass-through helper and did not add any new abstraction. No shim, fallback, alias, dual-write, or migration path was added, so no #6981 ledger row is needed. The PR is net +1 line because the added mass is a regression test pinning the corrected escaped-path error text.

## Host impact

Extension: no behavior change for valid memory paths; invalid escaped display paths now show the original display path.

Desktop: no behavior change for valid memory paths; shared memory path formatting remains host-neutral.

CLI: no behavior change for valid memory paths; CLI headless validation was run to preserve the run contract.

## Scheduled refactoring

None.

## Validation

- corepack pnpm exec prettier --write src/platform/defaults/workspaceStorage.ts src/tools/memory/memoryUtils.ts src/test-kernel/cli/CliMemory.vitest.mts
- corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/CliMemory.vitest.mts src/test-kernel/platform/WorkspaceStorage.vitest.ts
- npm run typecheck
- npm test, passes with the pre-existing workflow metadata persistence warning
- npm run lint, passes with 15 pre-existing warnings, none in touched files
- npm run compile:fast
- corepack pnpm --filter @texra-ai/cli validate:run
- git diff --check origin/main...HEAD

Closes #7038