### PR TITLE
[codex] Silence no-op RUNNING resume transitions

### DIFF
--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -125,9 +125,6 @@ function transitionRunStart(ctx: AgentLaunchContext): void {
   if (resumed) {
     return;
   }
-  if (ctx.streamStatus.clearRunningSubstate(ctx.streamId, 'resume', options)) {
-    return;
-  }
   if (ctx.streamStatus.get(ctx.streamId) === STREAM_PHASE.RUNNING) {
     return;
   }

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -104,25 +104,14 @@ export class StreamStatusMachine {
     this.reservations.delete(stream);
   }
 
-  clearRunningSubstate(
-    stream: StreamTabId,
-    cause: StreamTransitionCause,
-    options: StreamStatusEmitOptions = {},
-  ): boolean {
-    const state = this.phases.get(stream);
-    if (state?.phase !== STREAM_PHASE.RUNNING || !state.substate) {
-      return false;
-    }
-    return this.transition(stream, STREAM_PHASE.RUNNING, cause, options);
-  }
-
   transition(
     stream: StreamTabId,
     to: StreamPhase,
     cause: StreamTransitionCause,
     options: StreamStatusEmitOptions = {},
   ): boolean {
-    const from = this.phases.get(stream)?.phase;
+    const previousState = this.phases.get(stream);
+    const from = previousState?.phase;
     const fromReservation = this.reservations.has(stream);
     const tableFrom = fromReservation
       ? to === STREAM_PHASE.RUNNING
@@ -132,6 +121,17 @@ export class StreamStatusMachine {
     if (!canTransitionStreamPhase(tableFrom, to, cause)) return false;
 
     this.reservations.delete(stream);
+    // The table decides whether a transition is permitted, but not whether a
+    // permitted transition changes state. A steady RUNNING resume with no
+    // substate to clear must stay silent, while a real substate clear still
+    // writes and publishes from this single status owner.
+    if (
+      !fromReservation &&
+      from === to &&
+      previousState?.substate === options.substate
+    ) {
+      return true;
+    }
     this.phases.set(stream, {
       phase: to,
       ...(options.substate ? { substate: options.substate } : {}),

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -74,7 +74,10 @@ function createLifecycleContext({
   streamId: StreamTabId;
   streamStatus: StreamStatusRegistry;
   agent?: string;
-}): AgentLaunchContext {
+}): {
+  ctx: AgentLaunchContext;
+  explicit: ReturnType<typeof createRecordingHost>;
+} {
   const explicit = createRecordingHost();
   const config = AgentConfigSchema.parse({
     agent,
@@ -103,7 +106,7 @@ function createLifecycleContext({
     },
   };
 
-  return {
+  const ctx: AgentLaunchContext = {
     config,
     setting,
     prompt,
@@ -143,6 +146,7 @@ function createLifecycleContext({
       retry: new RetryRequestCoordinatorImpl(explicit.host),
     },
   };
+  return { ctx, explicit };
 }
 
 function lifecycleFixture(
@@ -153,17 +157,18 @@ function lifecycleFixture(
   streamId: StreamTabId;
   streamStatus: StreamStatusRegistry;
   ctx: AgentLaunchContext;
+  explicit: ReturnType<typeof createRecordingHost>;
 } {
   const executionId = `execution-${slug}` as ExecutionId;
   const streamId = `stream-${slug}` as StreamTabId;
   const streamStatus = new StreamStatusRegistry();
-  const ctx = createLifecycleContext({
+  const { ctx, explicit } = createLifecycleContext({
     executionId,
     streamId,
     streamStatus,
     agent,
   });
-  return { executionId, streamId, streamStatus, ctx };
+  return { executionId, streamId, streamStatus, ctx, explicit };
 }
 
 describe('runFlowWithLifecycle', () => {
@@ -275,6 +280,31 @@ describe('runFlowWithLifecycle', () => {
       await runFlowWithLifecycle(ctx, async () => {
         expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.RUNNING);
         expect(streamStatus.getSubstate(streamId)).toBeUndefined();
+        return {
+          category: 'toolUse',
+          outcome: RUN_OUTCOME.COMPLETED,
+          executionId,
+          streamId,
+        };
+      });
+
+      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.COMPLETED);
+    } finally {
+      clearStreamStatusForTest(streamStatus, streamId);
+    }
+  });
+
+  it('does not emit a status event when starting an already-running stream with no substate', async () => {
+    const { executionId, streamId, streamStatus, ctx, explicit } =
+      lifecycleFixture('lifecycle-steady-running-no-substate');
+
+    try {
+      seedStreamStatusForTest(streamStatus, streamId, STREAM_PHASE.RUNNING);
+
+      await runFlowWithLifecycle(ctx, async () => {
+        expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.RUNNING);
+        expect(streamStatus.getSubstate(streamId)).toBeUndefined();
+        expect(explicit.events).toEqual([]);
         return {
           category: 'toolUse',
           outcome: RUN_OUTCOME.COMPLETED,

--- a/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
+++ b/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
@@ -236,7 +236,7 @@ describe('StreamStatusMachine', () => {
     expect(explicit.events).toEqual([]);
   });
 
-  it('clears transient running substates without changing phase', () => {
+  it('clears a transient running substate through the table-checked resume transition', () => {
     const { machine, explicit, streamId } = setupMachine(
       'stream-status-clear-running-substate',
     );
@@ -244,7 +244,7 @@ describe('StreamStatusMachine', () => {
     seedStreamStatusForTest(machine, streamId, STREAM_STATUS.RESUMING);
 
     expect(
-      machine.clearRunningSubstate(streamId, 'resume', {
+      machine.transition(streamId, STREAM_PHASE.RUNNING, 'resume', {
         runtimeHost: explicit.host,
       }),
     ).toBe(true);
@@ -262,6 +262,24 @@ describe('StreamStatusMachine', () => {
         },
       },
     ]);
+  });
+
+  it('skips the write and publish for a no-op RUNNING resume with no substate to clear', () => {
+    const { machine, explicit, streamId } = setupMachine(
+      'stream-status-noop-running-resume',
+    );
+
+    seedStreamStatusForTest(machine, streamId, STREAM_PHASE.RUNNING);
+
+    expect(
+      machine.transition(streamId, STREAM_PHASE.RUNNING, 'resume', {
+        runtimeHost: explicit.host,
+      }),
+    ).toBe(true);
+
+    expect(machine.get(streamId)).toBe(STREAM_PHASE.RUNNING);
+    expect(machine.getSubstate(streamId)).toBeUndefined();
+    expect(explicit.events).toEqual([]);
   });
 
   it('rolls back reservation state identically with and without observers', () => {


### PR DESCRIPTION
## Summary

Fixes #7053 by making StreamStatusMachine.transition publish only when a permitted transition actually changes the stored phase or substate. A steady RUNNING resume with no substate to clear now returns true silently instead of firing a spurious updateStreamStatus event.

The dead clearRunningSubstate method and its unreachable transitionRunStart call site are removed because real RUNNING substate clearing now goes through transition itself.

## Issue acceptance gates

- #7053: a steadily RUNNING stream with no substate no longer emits a RUNNING to RUNNING resume status event during run start.
- #7053: transitionRunStart no longer contains the unreachable clearRunningSubstate step.
- #7053: regression coverage exercises transitionRunStart itself through runFlowWithLifecycle and asserts no updateStreamStatus event fires.
- #7053: StreamStatusMachine coverage still verifies a real RESUMING substate clear publishes exactly one status event through transition.

## Single source of truth

StreamStatusMachine.transition remains the single writer for stream phase state and the single place that decides whether a permitted transition produces a stored-state change and status publication. canTransitionStreamPhase remains the transition-table permission source.

## Duplication and abstraction budget

Removed the consumer-less clearRunningSubstate entry point instead of keeping a second write path. No new abstraction was added. No shim, fallback, alias, dual-write, or migration path was introduced, so no #6981 ledger row is needed. The PR is net positive in lines because the added mass is regression coverage for the no-op run-start event and the real substate-clear case.

## Host impact

Extension: removes a spurious updateStreamStatus event for already-running streams with no substate; valid status transitions are unchanged.

Desktop: same shared runtime path; removes the same spurious status event before it can reach desktop progress projections.

CLI: same shared runtime path; CLI headless validation was run to preserve the run contract.

## Scheduled refactoring

None.

## Validation

- corepack pnpm exec prettier --write src/agent/runtime/StreamStatusService.ts src/agent/runtime/AgentRunLifecycle.ts src/test-kernel/agent/runtime/StreamStatusService.vitest.ts src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
- corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/agent/runtime/StreamStatusService.vitest.ts src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
- npm run typecheck
- npm test, passes with the pre-existing workflow metadata persistence warning
- npm run lint, passes with 15 pre-existing warnings, none in touched files
- npm run compile:fast
- corepack pnpm --filter @texra-ai/cli validate:run
- git diff --check
- rg -n clearRunningSubstate src packages --glob *.ts --glob *.mts, no matches

Closes #7053