### PR TITLE
[codex] Consolidate CLI model decisions

### DIFF
--- a/packages/cli/src/chat/tui/commands/handlers/agentModelCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/agentModelCommands.ts
@@ -80,7 +80,7 @@ export async function applyCliModelSelection(
     try {
       const { apiMode } = cliState.sessionMeta.get();
       const selection = await selectCliRunnableModel(nextModel, {
-        fallbackSource: 'override',
+        fallbackReason: 'explicit-override',
         apiMode,
         noAvailableModelsMessage: formatCliNoAvailableModelsRecovery(
           apiMode,

--- a/packages/cli/src/chat/tui/commands/handlers/apiModeCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/apiModeCommands.ts
@@ -31,7 +31,7 @@ async function reconcileRootModelAfterApiModeChange(
 
   const { model: currentModel, modelSource } = cliState.sessionMeta.get();
   const selection = await selectCliRunnableModel(currentModel, {
-    fallbackSource: modelSource,
+    fallbackReason: modelSource,
     apiMode,
     noAvailableModelsMessage: formatCliNoAvailableModelsRecovery(
       apiMode,

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -298,7 +298,7 @@ export async function runChat(
   let modelSelection: CliRunnableModelResolution;
   try {
     modelSelection = await selectCliRunnableModel(defaults.model, {
-      fallbackSource: defaults.modelSource,
+      fallbackReason: defaults.modelSource,
       apiMode,
       noAvailableModelsMessage: formatCliNoAvailableModelsRecovery(
         apiMode,
@@ -562,7 +562,7 @@ export async function runChat(
         const currentAgent = meta.agent || agent;
         const currentModel = meta.model || model;
         const selection = await selectCliRunnableModel(currentModel, {
-          fallbackSource: meta.model ? meta.modelSource : defaults.modelSource,
+          fallbackReason: meta.model ? meta.modelSource : defaults.modelSource,
           apiMode: meta.apiMode,
           noAvailableModelsMessage: formatCliNoAvailableModelsRecovery(
             meta.apiMode,

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -8,8 +8,8 @@
 import { signal, Signal } from '@lit-labs/signals';
 
 import type { CliApiMode } from '@cli/runtime/apiAccessMode';
-import type { CliModelSelectionSource } from '@cli/runtime/modelAccess';
 import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
+import type { RunModelDecisionReason } from '@model/runModelDecision';
 import {
   STREAM_STATUS,
   type ActiveChildInfo,
@@ -69,7 +69,7 @@ export interface CompletedProcessTranscript {
 export interface SessionMeta {
   readonly agent: string;
   readonly model: string;
-  readonly modelSource: CliModelSelectionSource;
+  readonly modelSource: RunModelDecisionReason;
   readonly cwd: string;
   readonly apiMode: CliApiMode;
   readonly approvalPolicy: CliApprovalPolicy;
@@ -154,7 +154,7 @@ export function thinkingIndicatorVisible(
 const EMPTY_SESSION_META: SessionMeta = {
   agent: '',
   model: '',
-  modelSource: 'builtin',
+  modelSource: 'builtin-default',
   cwd: '',
   apiMode: 'personal',
   approvalPolicy: 'ask',
@@ -251,7 +251,7 @@ export function setCliSessionModelOverride(model: string): void {
   cliState.sessionMeta.set({
     ...cliState.sessionMeta.get(),
     model,
-    modelSource: 'override',
+    modelSource: 'explicit-override',
   });
 }
 

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -64,7 +64,7 @@ async function canLaunchWithDefaultModel(
   });
   try {
     await selectCliRunnableModel(defaults.model, {
-      fallbackSource: defaults.modelSource,
+      fallbackReason: defaults.modelSource,
       apiMode,
       accessList: models,
       agentCategory: AgentCategory.ToolUse,

--- a/packages/cli/src/runtime/chatDefaults.ts
+++ b/packages/cli/src/runtime/chatDefaults.ts
@@ -1,7 +1,10 @@
 import { TEXRA_CONFIG_FILE_NAME } from '@platform/defaults/nodeStorage';
 import { listExecutions } from '@agent/storage';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import { decideRunModel } from '@model/runModelDecision';
+import {
+  decideRunModel,
+  type RunModelDecisionReason,
+} from '@model/runModelDecision';
 import { toNewestFirstByTimestamp } from '@utils/core';
 import { GlobalStorageFS } from '@utils/files/storageFS';
 import {
@@ -16,7 +19,6 @@ import {
   isImplicitDefaultEligible,
   pickDefaultToolUseAgent,
 } from './defaultAgents';
-import type { CliModelSelectionSource } from './modelAccess';
 
 /**
  * A configured or environment agent value, trimmed and dropped if it can't be
@@ -43,13 +45,16 @@ export interface ChatDefaults {
 export type ChatDefaultSource =
   'workspace' | 'user' | 'history' | 'builtin' | 'mixed';
 
-export type ChatDefaultValueSource =
-  | 'override'
-  | 'env'
-  | Extract<
-      CliModelSelectionSource,
-      'workspace' | 'user' | 'history' | 'builtin'
-    >;
+/** Chat default value sources are the shared run-model decision reasons. */
+export type ChatDefaultValueSource = Extract<
+  RunModelDecisionReason,
+  | 'explicit-override'
+  | 'environment'
+  | 'workspace-config'
+  | 'user-config'
+  | 'history'
+  | 'builtin-default'
+>;
 
 interface PartialDefaults {
   readonly agent?: string;
@@ -104,16 +109,33 @@ function deriveSource(sources: {
   readonly agent: ChatDefaultValueSource;
   readonly model: ChatDefaultValueSource;
 }): ChatDefaultSource {
-  const source = sources.agent === sources.model ? sources.agent : 'mixed';
-  return source === 'override' || source === 'env' ? 'mixed' : source;
+  const agentSource = chatDefaultSource(sources.agent);
+  const modelSource = chatDefaultSource(sources.model);
+  return agentSource === modelSource ? agentSource : 'mixed';
+}
+
+function chatDefaultSource(source: ChatDefaultValueSource): ChatDefaultSource {
+  switch (source) {
+    case 'workspace-config':
+      return 'workspace';
+    case 'user-config':
+      return 'user';
+    case 'history':
+      return 'history';
+    case 'builtin-default':
+      return 'builtin';
+    case 'explicit-override':
+    case 'environment':
+      return 'mixed';
+  }
 }
 
 function sourceForOverride(
   override: string | undefined,
   env: string | undefined,
 ): ChatDefaultValueSource | undefined {
-  if (override) return 'override';
-  if (env) return 'env';
+  if (override) return 'explicit-override';
+  if (env) return 'environment';
   return undefined;
 }
 
@@ -124,8 +146,8 @@ function buildChatDefaults(init: {
   readonly modelSource: ChatDefaultValueSource | undefined;
   readonly visibleToolUseAgents?: readonly { readonly name: string }[];
 }): ChatDefaults {
-  const agentSource = init.agentSource ?? 'builtin';
-  const modelSource = init.modelSource ?? 'builtin';
+  const agentSource = init.agentSource ?? 'builtin-default';
+  const modelSource = init.modelSource ?? 'builtin-default';
   return {
     agent: init.agent ?? pickDefaultToolUseAgent(init.visibleToolUseAgents),
     model: init.model ?? BUILTIN_DEFAULT_CHAT_MODEL,
@@ -159,19 +181,9 @@ export async function resolveChatDefaults(
   const envAgent = usableConfiguredAgent(init.envAgent);
   const envModel = init.envModel?.trim();
   let agent = overrideAgent || envAgent;
-  let model = overrideModel || envModel;
+  let model: string | undefined;
   let agentSource = sourceForOverride(overrideAgent, envAgent);
-  let modelSource = sourceForOverride(overrideModel, envModel);
-
-  if (agent && model) {
-    return buildChatDefaults({
-      agent,
-      model,
-      agentSource,
-      modelSource,
-      visibleToolUseAgents: init.visibleToolUseAgents,
-    });
-  }
+  let modelSource: ChatDefaultValueSource | undefined;
 
   // Tiers are independent I/O — fan out in parallel.
   // Workspace defaults use the same .texra/config.json reader as the CLI
@@ -184,8 +196,8 @@ export async function resolveChatDefaults(
   const tiers: ReadonlyArray<
     readonly [ChatDefaultValueSource, PartialDefaults]
   > = [
-    ['workspace', workspace],
-    ['user', user],
+    ['workspace-config', workspace],
+    ['user-config', user],
     ['history', history],
   ];
 
@@ -194,10 +206,11 @@ export async function resolveChatDefaults(
       agent = defaults.agent;
       agentSource = source;
     }
-    if (agent && model) break;
   }
 
   const modelDecision = decideRunModel([
+    { model: overrideModel, reason: 'explicit-override' },
+    { model: envModel, reason: 'environment' },
     { model: workspace.model, reason: 'workspace-config' },
     { model: user.model, reason: 'user-config' },
     { model: history.model, reason: 'history' },
@@ -205,14 +218,8 @@ export async function resolveChatDefaults(
   ]);
   if (!model && modelDecision) {
     model = modelDecision.model;
-    modelSource =
-      modelDecision.reason === 'workspace-config'
-        ? 'workspace'
-        : modelDecision.reason === 'user-config'
-          ? 'user'
-          : modelDecision.reason === 'history'
-            ? 'history'
-            : 'builtin';
+    // The candidate list above only uses reasons in ChatDefaultValueSource.
+    modelSource = modelDecision.reason as ChatDefaultValueSource;
   }
 
   return buildChatDefaults({

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -33,28 +33,20 @@ export interface CliRunnableModelResolution {
 
 type CliModelFallbackMode = 'reject' | 'notice' | 'silent';
 
-export type CliModelSelectionSource =
-  'override' | 'env' | 'config' | 'workspace' | 'user' | 'history' | 'builtin';
-
-const CLI_MODEL_FALLBACK_MODE_BY_SOURCE = {
-  override: 'reject',
-  env: 'reject',
-  config: 'notice',
-  workspace: 'notice',
-  user: 'notice',
+const CLI_MODEL_FALLBACK_MODE_BY_REASON = {
+  'explicit-override': 'reject',
+  environment: 'reject',
+  'agent-config': 'notice',
+  'command-config': 'notice',
+  'workspace-config': 'notice',
+  'user-config': 'notice',
   history: 'notice',
-  builtin: 'silent',
-} satisfies Record<CliModelSelectionSource, CliModelFallbackMode>;
-
-const CLI_MODEL_DECISION_REASON_BY_SOURCE = {
-  override: 'explicit-override',
-  env: 'environment',
-  config: 'command-config',
-  workspace: 'workspace-config',
-  user: 'user-config',
-  history: 'history',
-  builtin: 'builtin-default',
-} satisfies Record<CliModelSelectionSource, RunModelDecisionReason>;
+  'parent-run': 'notice',
+  'router-config': 'reject',
+  credential: 'reject',
+  'builtin-default': 'silent',
+  'access-list-default': 'silent',
+} satisfies Record<RunModelDecisionReason, CliModelFallbackMode>;
 
 export interface CliModelAccessListOptions {
   readonly apiMode?: CliApiMode;
@@ -71,8 +63,8 @@ export interface CliRunnableModelOptions extends Pick<
   CliModelAccessEntryOptions,
   'apiMode' | 'agentCategory' | 'accessList'
 > {
-  /** Source category that owns unavailable-model fallback behavior. */
-  readonly fallbackSource: CliModelSelectionSource;
+  /** Decision reason that owns unavailable-model fallback behavior. */
+  readonly fallbackReason?: RunModelDecisionReason;
   readonly noAvailableModelsMessage?: string;
 }
 
@@ -600,38 +592,75 @@ function formatUnavailableModelMessage(
   return `Model "${model}" is not available in the active API mode${status}. ${formatAvailableModels(availableIds, options)}`;
 }
 
-function cliModelDecisionCandidate(
-  model: string,
-  source: CliModelSelectionSource,
-): RunModelCandidate {
-  return {
-    model,
-    reason: CLI_MODEL_DECISION_REASON_BY_SOURCE[source],
-    fallbackMode: CLI_MODEL_FALLBACK_MODE_BY_SOURCE[source],
-  };
+type NormalizedCliModelCandidate = RunModelCandidate & {
+  readonly model: string;
+};
+
+function rawCliModelDecisionCandidates(
+  request: string | readonly RunModelCandidate[],
+  options: CliRunnableModelOptions,
+): readonly RunModelCandidate[] {
+  if (typeof request !== 'string') return request;
+  if (!options.fallbackReason) {
+    throw new Error('fallbackReason is required for single-model resolution');
+  }
+  return [{ model: request, reason: options.fallbackReason }];
 }
 
 export async function selectCliRunnableModel(
-  model: string,
+  request: string | readonly RunModelCandidate[],
   options: CliRunnableModelOptions,
 ): Promise<CliRunnableModelResolution> {
   const models = await loadCliModelAccessList(options);
-  const trimmed = model.trim();
-  const modelEntry = await loadCliModelAccessEntry(trimmed, {
-    apiMode: options.apiMode,
-    agentCategory: options.agentCategory,
-    accessList: models,
-  });
-  const modelsWithHiddenEntry = withModelAccess(models, modelEntry);
+  const requestedCandidates: NormalizedCliModelCandidate[] =
+    rawCliModelDecisionCandidates(request, options).flatMap((candidate) => {
+      const model = candidate.model?.trim();
+      return model
+        ? [
+            {
+              ...candidate,
+              model,
+              fallbackMode:
+                candidate.fallbackMode ??
+                CLI_MODEL_FALLBACK_MODE_BY_REASON[candidate.reason],
+            },
+          ]
+        : [];
+    });
+  const requestedModels = [
+    ...new Set(requestedCandidates.map((candidate) => candidate.model)),
+  ];
+  const hiddenEntries = await Promise.allSettled(
+    requestedModels.map((model) =>
+      loadCliModelAccessEntry(model, {
+        apiMode: options.apiMode,
+        agentCategory: options.agentCategory,
+        accessList: models,
+      }),
+    ),
+  );
+  const entryErrorByModel = new Map<string, unknown>();
+  let modelsWithHiddenEntry = models;
+  for (const [index, result] of hiddenEntries.entries()) {
+    const model = requestedModels[index];
+    if (!model) continue;
+    if (result.status === 'fulfilled') {
+      modelsWithHiddenEntry = withModelAccess(
+        modelsWithHiddenEntry,
+        result.value,
+      );
+    } else {
+      entryErrorByModel.set(model, result.reason);
+    }
+  }
   const runnableEntries = runnableCliModelAccessEntries(
     modelsWithHiddenEntry,
     options.apiMode,
   );
   const availableIds = modelIds(runnableEntries);
-  const entry = findCliModelAccessEntry(modelsWithHiddenEntry, trimmed);
   const decision = decideRunModel(
     [
-      cliModelDecisionCandidate(trimmed, options.fallbackSource),
+      ...requestedCandidates,
       { model: availableIds[0], reason: 'access-list-default' },
     ],
     (candidate) => findCliModelAccessEntry(runnableEntries, candidate) != null,
@@ -645,9 +674,17 @@ export async function selectCliRunnableModel(
       return { model: selectedModel };
     }
 
+    const fallbackLoadError = entryErrorByModel.get(
+      decision.fallbackFrom.model,
+    );
+    if (fallbackLoadError) throw fallbackLoadError;
+
     const unavailableMessage = formatUnavailableModelMessage(
       decision.fallbackFrom.model,
-      entry,
+      findCliModelAccessEntry(
+        modelsWithHiddenEntry,
+        decision.fallbackFrom.model,
+      ),
       availableIds,
       options,
     );
@@ -657,9 +694,19 @@ export async function selectCliRunnableModel(
     };
   }
 
+  const selectedLoadError = decision
+    ? entryErrorByModel.get(decision.model)
+    : undefined;
+  if (selectedLoadError) throw selectedLoadError;
+
+  const requestedModel =
+    (decision?.model ??
+      requestedCandidates[0]?.model ??
+      (typeof request === 'string' ? request.trim() : '')) ||
+    '<empty>';
   const unavailableMessage = formatUnavailableModelMessage(
-    trimmed,
-    entry,
+    requestedModel,
+    findCliModelAccessEntry(modelsWithHiddenEntry, requestedModel),
     availableIds,
     options,
   );

--- a/packages/cli/src/runtime/runModel.ts
+++ b/packages/cli/src/runtime/runModel.ts
@@ -1,8 +1,5 @@
 import { toErrorMessage } from '@common/errors/errorMessage';
-import {
-  decideRunModel,
-  type RunModelDecisionReason,
-} from '@model/runModelDecision';
+import type { RunModelCandidate } from '@model/runModelDecision';
 import { AgentCategory } from '@shared/schemas/agent';
 
 import {
@@ -16,38 +13,6 @@ import { writeTextStderr } from './logSinks';
 import { effectiveCliApiMode } from './apiAccessMode';
 import { selectCliRunnableModel } from './modelAccess';
 import { shouldRenderRunProgress } from './runProgressRenderer';
-import type { CliModelSelectionSource } from './modelAccess';
-
-export type CliRunModelCandidateSource = Extract<
-  CliModelSelectionSource,
-  'override' | 'env' | 'config' | 'builtin'
->;
-
-export interface CliRunModelCandidate {
-  readonly model: string;
-  readonly source: CliRunModelCandidateSource;
-}
-
-const cliSourceForDecisionReason = {
-  'explicit-override': 'override',
-  environment: 'env',
-  'agent-config': 'builtin',
-  'command-config': 'config',
-  'workspace-config': 'builtin',
-  'user-config': 'builtin',
-  history: 'builtin',
-  'parent-run': 'builtin',
-  'router-config': 'builtin',
-  credential: 'builtin',
-  'builtin-default': 'builtin',
-  'access-list-default': 'builtin',
-} satisfies Record<RunModelDecisionReason, CliRunModelCandidateSource>;
-
-function cliSourceForDecision(
-  source: RunModelDecisionReason,
-): CliRunModelCandidateSource {
-  return cliSourceForDecisionReason[source];
-}
 
 /** Trim `-m`; throw a Usage error for unknown ids; undefined when absent. */
 export function assertExplicitModelKnown(
@@ -64,19 +29,13 @@ export function assertExplicitModelKnown(
   return resolved;
 }
 
-/**
- * Resolve the model candidate for a headless runner with the shared
- * precedence: explicit `-m` > `TEXRA_MODEL` env > configured `chat`/`run`
- * model > builtin. The source is part of the contract because model access
- * fallback policy depends on where the value came from.
- */
-export function chooseCliRunModelCandidate(
+function cliRunModelCandidates(
   context: CliContext,
   modelOverride: string | undefined,
   role: 'chat' | 'run',
-): CliRunModelCandidate {
+): RunModelCandidate[] {
   const explicit = assertExplicitModelKnown(modelOverride);
-  const decision = decideRunModel([
+  return [
     { model: explicit, reason: 'explicit-override' },
     { model: context.envModel, reason: 'environment' },
     {
@@ -84,14 +43,7 @@ export function chooseCliRunModelCandidate(
       reason: 'command-config',
     },
     { model: CLI_BUILTIN_DEFAULT_MODEL, reason: 'builtin-default' },
-  ]);
-  if (!decision) {
-    return { model: CLI_BUILTIN_DEFAULT_MODEL, source: 'builtin' };
-  }
-  return {
-    model: decision.model,
-    source: cliSourceForDecision(decision.reason),
-  };
+  ];
 }
 
 export async function selectCliRunModel(
@@ -99,16 +51,17 @@ export async function selectCliRunModel(
   modelOverride: string | undefined,
   role: 'chat' | 'run',
 ): Promise<string> {
-  const candidate = chooseCliRunModelCandidate(context, modelOverride, role);
   await initCliPlatform({ ...context, quietLogs: true });
   const apiMode = effectiveCliApiMode(context);
   try {
-    const resolution = await selectCliRunnableModel(candidate.model, {
-      fallbackSource: candidate.source,
-      apiMode,
-      agentCategory:
-        role === 'chat' ? AgentCategory.ToolUse : AgentCategory.Workflow,
-    });
+    const resolution = await selectCliRunnableModel(
+      cliRunModelCandidates(context, modelOverride, role),
+      {
+        apiMode,
+        agentCategory:
+          role === 'chat' ? AgentCategory.ToolUse : AgentCategory.Workflow,
+      },
+    );
     if (resolution.notice && context.quietLogs !== true) {
       writeTextStderr(resolution.notice);
     }

--- a/src/controllers/onboarding/setupLaunch.ts
+++ b/src/controllers/onboarding/setupLaunch.ts
@@ -59,25 +59,26 @@ export async function selectSetupCredentialModelExcludingOpenRouter(
  */
 export async function selectDesktopSetupModel(): Promise<string | null> {
   const secrets = platform().secrets;
+  const useOpenRouter = getUseOpenRouter();
 
-  if (getUseOpenRouter()) {
-    if (isNonEmptyString(await lookupApiKey(secrets, 'openRouter'))) {
-      return (
-        decideRunModel([
-          {
-            model: SETUP_MODEL_BY_PROVIDER.openRouter,
-            reason: 'router-config',
-          },
-        ])?.model ?? null
-      );
-    }
+  const routerModel =
+    useOpenRouter && isNonEmptyString(await lookupApiKey(secrets, 'openRouter'))
+      ? SETUP_MODEL_BY_PROVIDER.openRouter
+      : null;
+  if (useOpenRouter && !routerModel) {
     return null;
   }
 
   return (
     decideRunModel([
       {
-        model: await selectSetupCredentialModelExcludingOpenRouter(secrets),
+        model: routerModel,
+        reason: 'router-config',
+      },
+      {
+        model: useOpenRouter
+          ? null
+          : await selectSetupCredentialModelExcludingOpenRouter(secrets),
         reason: 'credential',
       },
     ])?.model ?? null

--- a/src/test-kernel/cli/ChatDefaults.vitest.mts
+++ b/src/test-kernel/cli/ChatDefaults.vitest.mts
@@ -68,8 +68,8 @@ describe('CLI chat defaults', () => {
       agent: 'assistant',
       model: 'deepseekproT',
       source: 'builtin',
-      agentSource: 'builtin',
-      modelSource: 'builtin',
+      agentSource: 'builtin-default',
+      modelSource: 'builtin-default',
     });
   });
 
@@ -83,7 +83,7 @@ describe('CLI chat defaults', () => {
       agent: 'research',
       model: 'deepseekproT',
       source: 'builtin',
-      agentSource: 'builtin',
+      agentSource: 'builtin-default',
     });
   });
 
@@ -99,8 +99,8 @@ describe('CLI chat defaults', () => {
       agent: 'assistant',
       model: 'deepseekproT',
       source: 'mixed',
-      agentSource: 'workspace',
-      modelSource: 'builtin',
+      agentSource: 'workspace-config',
+      modelSource: 'builtin-default',
     });
   });
 
@@ -117,8 +117,8 @@ describe('CLI chat defaults', () => {
       agent: 'assistant',
       model: 'sonnet46T',
       source: 'mixed',
-      agentSource: 'workspace',
-      modelSource: 'env',
+      agentSource: 'workspace-config',
+      modelSource: 'environment',
     });
   });
 
@@ -133,7 +133,7 @@ describe('CLI chat defaults', () => {
       agent: 'assistant',
       model: 'sonnet46T',
       source: 'mixed',
-      agentSource: 'builtin',
+      agentSource: 'builtin-default',
       modelSource: 'history',
     });
   });
@@ -171,7 +171,7 @@ describe('CLI chat defaults', () => {
     ).resolves.toMatchObject({
       agent: 'assistant',
       model: 'sonnet46T',
-      agentSource: 'builtin',
+      agentSource: 'builtin-default',
       modelSource: 'history',
     });
   });
@@ -193,7 +193,7 @@ describe('CLI chat defaults', () => {
     ).resolves.toMatchObject({
       agent: 'assistant',
       model: 'sonnet46T',
-      agentSource: 'builtin',
+      agentSource: 'builtin-default',
       modelSource: 'history',
     });
   });
@@ -209,7 +209,7 @@ describe('CLI chat defaults', () => {
     ).resolves.toMatchObject({
       agent: 'assistant',
       model: 'sonnet46T',
-      agentSource: 'builtin',
+      agentSource: 'builtin-default',
       modelSource: 'history',
     });
   });
@@ -224,8 +224,8 @@ describe('CLI chat defaults', () => {
     ).resolves.toMatchObject({
       agent: 'assistant',
       model: 'sonnet46T',
-      agentSource: 'builtin',
-      modelSource: 'workspace',
+      agentSource: 'builtin-default',
+      modelSource: 'workspace-config',
     });
 
     mockedReadJson.mockResolvedValueOnce({
@@ -239,8 +239,8 @@ describe('CLI chat defaults', () => {
     ).resolves.toMatchObject({
       agent: 'assistant',
       model: 'sonnet46T',
-      agentSource: 'builtin',
-      modelSource: 'user',
+      agentSource: 'builtin-default',
+      modelSource: 'user-config',
     });
   });
 
@@ -252,7 +252,7 @@ describe('CLI chat defaults', () => {
       }),
     ).resolves.toMatchObject({
       agent: 'assistant',
-      agentSource: 'builtin',
+      agentSource: 'builtin-default',
     });
   });
 
@@ -265,7 +265,7 @@ describe('CLI chat defaults', () => {
       }),
     ).resolves.toMatchObject({
       agent: 'simplifier',
-      agentSource: 'override',
+      agentSource: 'explicit-override',
     });
   });
 
@@ -300,8 +300,8 @@ describe('CLI chat defaults', () => {
       agent: 'assistant',
       model: 'deepseekT',
       source: 'user',
-      agentSource: 'user',
-      modelSource: 'user',
+      agentSource: 'user-config',
+      modelSource: 'user-config',
     });
   });
 });

--- a/src/test-kernel/cli/ConfigForm.vitest.mts
+++ b/src/test-kernel/cli/ConfigForm.vitest.mts
@@ -332,7 +332,7 @@ describe('/config slash command wiring', () => {
     resetCliState({
       agent: 'chat',
       model: 'deepseekT',
-      modelSource: 'builtin',
+      modelSource: 'builtin-default',
       cwd: '/tmp/workspace',
       apiMode: 'included',
       approvalPolicy: 'ask',

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -57,7 +57,7 @@ const STREAM_ID = 'cli-test-stream' as StreamTabId;
 const SESSION_META = {
   agent: 'research',
   model: 'deepseekT',
-  modelSource: 'builtin',
+  modelSource: 'builtin-default',
   cwd: '/tmp/project',
   apiMode: 'personal',
   approvalPolicy: 'ask',

--- a/src/test-kernel/cli/ModelAccess.vitest.mts
+++ b/src/test-kernel/cli/ModelAccess.vitest.mts
@@ -94,7 +94,7 @@ describe('CLI model access resolution', () => {
       resolveModelFromAccessList(
         [model('sonnet46T'), model('opus48T')],
         'opus48T',
-        { fallbackSource: 'override' },
+        { fallbackReason: 'explicit-override' },
       ),
     ).resolves.toEqual({ model: 'opus48T' });
   });
@@ -115,21 +115,21 @@ describe('CLI model access resolution', () => {
 
     await expect(
       resolveModelFromAccessList(entries, 'missingModel', {
-        fallbackSource: 'override',
+        fallbackReason: 'explicit-override',
       }),
     ).rejects.toThrow(
       'Model "missingModel" is not available in the active API mode (missing api key). Available models: deepseekT.',
     );
     await expect(
       resolveModelFromAccessList(entries, 'missingModel', {
-        fallbackSource: 'env',
+        fallbackReason: 'environment',
       }),
     ).rejects.toThrow(
       'Model "missingModel" is not available in the active API mode (missing api key). Available models: deepseekT.',
     );
     await expect(
       resolveModelFromAccessList(entries, 'missingModel', {
-        fallbackSource: 'config',
+        fallbackReason: 'command-config',
       }),
     ).resolves.toEqual({
       model: 'deepseekT',
@@ -138,7 +138,7 @@ describe('CLI model access resolution', () => {
     });
     await expect(
       resolveModelFromAccessList(entries, 'missingModel', {
-        fallbackSource: 'history',
+        fallbackReason: 'history',
       }),
     ).resolves.toEqual({
       model: 'deepseekT',
@@ -147,7 +147,7 @@ describe('CLI model access resolution', () => {
     });
     await expect(
       resolveModelFromAccessList(entries, 'missingModel', {
-        fallbackSource: 'builtin',
+        fallbackReason: 'builtin-default',
       }),
     ).resolves.toEqual({ model: 'deepseekT' });
   });
@@ -167,7 +167,7 @@ describe('CLI model access resolution', () => {
           }),
         ],
         'opus48T',
-        { fallbackSource: 'override' },
+        { fallbackReason: 'explicit-override' },
       ),
     ).rejects.toThrow(
       'Model "opus48T" is not available in the active API mode (not included). Available models: sonnet46T.',
@@ -190,7 +190,7 @@ describe('CLI model access resolution', () => {
           model('sonnet46T'),
         ],
         'opus48T',
-        { fallbackSource: 'config' },
+        { fallbackReason: 'command-config' },
       ),
     ).resolves.toEqual({
       model: 'deepseekT',
@@ -215,7 +215,7 @@ describe('CLI model access resolution', () => {
           model('gpt55'),
         ],
         'deepseekT',
-        { fallbackSource: 'builtin' },
+        { fallbackReason: 'builtin-default' },
       ),
     ).resolves.toEqual({ model: 'gpt55' });
   });
@@ -688,7 +688,7 @@ describe('CLI model access resolution', () => {
           }),
         ],
         'deepseekT',
-        { fallbackSource: 'override', apiMode: 'included' },
+        { fallbackReason: 'explicit-override', apiMode: 'included' },
       ),
     ).rejects.toThrow(
       'Model "deepseekT" is not available in the active API mode (api key set). Available models: sonnet46T.',
@@ -713,7 +713,7 @@ describe('CLI model access resolution', () => {
           }),
         ],
         'sonnet46T',
-        { fallbackSource: 'config', apiMode: 'personal' },
+        { fallbackReason: 'command-config', apiMode: 'personal' },
       ),
     ).resolves.toEqual({
       model: 'deepseekT',
@@ -737,7 +737,7 @@ describe('CLI model access resolution', () => {
           }),
         ],
         'gemini31p',
-        { fallbackSource: 'config' },
+        { fallbackReason: 'command-config' },
       ),
     ).rejects.toThrow(
       'Model "gemini31p" is not available in the active API mode (missing api key). No models are currently available. Run `texra login` for included relay access, retry with `--api-mode included`, or add a provider API key with `texra setup`.',
@@ -762,7 +762,7 @@ describe('CLI model access resolution', () => {
           }),
         ],
         'gemini31p',
-        { fallbackSource: 'config', apiMode: 'personal' },
+        { fallbackReason: 'command-config', apiMode: 'personal' },
       ),
     ).rejects.toThrow(
       'Model "gemini31p" is not available in the active API mode (missing api key). No models are currently available. Add a provider API key with `texra setup` for personal mode, or retry with `--api-mode included` and run `texra login` for included relay access.',
@@ -785,7 +785,7 @@ describe('CLI model access resolution', () => {
         ],
         'gemini31p',
         {
-          fallbackSource: 'config',
+          fallbackReason: 'command-config',
           noAvailableModelsMessage:
             'Run `texra login` for included relay access.',
         },
@@ -871,7 +871,7 @@ describe('CLI model access resolution', () => {
 
     await expect(
       selectCliRunnableModel('haiku3', {
-        fallbackSource: 'override',
+        fallbackReason: 'explicit-override',
         apiMode: 'included',
         accessList: [],
       }),
@@ -894,7 +894,7 @@ describe('CLI model access resolution', () => {
 
     await expect(
       selectCliRunnableModel('haiku3', {
-        fallbackSource: 'override',
+        fallbackReason: 'explicit-override',
         apiMode: 'included',
         accessList: [],
       }),
@@ -1222,7 +1222,7 @@ describe('CLI model access resolution', () => {
 
     await expect(
       selectCliRunnableModel('HIDDENFIXTUREMODEL', {
-        fallbackSource: 'override',
+        fallbackReason: 'explicit-override',
       }),
     ).resolves.toEqual({ model: 'hiddenFixtureModel' });
     expect(computeModelOptionsDataMock).toHaveBeenNthCalledWith(
@@ -1243,7 +1243,7 @@ describe('CLI model access resolution', () => {
 
     await expect(
       selectCliRunnableModel('hiddenFixtureModel', {
-        fallbackSource: 'override',
+        fallbackReason: 'explicit-override',
         apiMode: 'personal',
         accessList: [
           model('deepseekT', {
@@ -1263,6 +1263,22 @@ describe('CLI model access resolution', () => {
       undefined,
       { agentCategory: undefined },
     );
+  });
+
+  it('ignores stale lower-priority hidden candidates after a runnable winner', async () => {
+    computeModelOptionsDataMock.mockResolvedValueOnce([]);
+
+    await expect(
+      selectCliRunnableModel(
+        [
+          { model: 'sonnet46T', reason: 'explicit-override' },
+          { model: 'hiddenFixtureModel', reason: 'environment' },
+        ],
+        {
+          accessList: [model('sonnet46T')],
+        },
+      ),
+    ).resolves.toEqual({ model: 'sonnet46T' });
   });
 
   it('resolves hidden model entries for diagnostic commands', async () => {
@@ -1301,7 +1317,7 @@ describe('CLI model access resolution', () => {
       resolveModelFromAccessList(
         [model('userFacingFixture')],
         'user-facing-fixture',
-        { fallbackSource: 'override' },
+        { fallbackReason: 'explicit-override' },
       ),
     ).resolves.toEqual({ model: 'userFacingFixture' });
 
@@ -1342,7 +1358,7 @@ describe('CLI model access resolution', () => {
 
     await expect(
       selectCliRunnableModel('hiddenFixtureModel', {
-        fallbackSource: 'override',
+        fallbackReason: 'explicit-override',
       }),
     ).rejects.toThrow(
       'Model "hiddenFixtureModel" is configured but has no option data.',

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -31,7 +31,7 @@ import { toErrorMessage } from '@common/errors';
 const INCLUDED_CHAT_SESSION: SessionMeta = {
   agent: 'chat',
   model: 'deepseekT',
-  modelSource: 'builtin',
+  modelSource: 'builtin-default',
   cwd: '/tmp/workspace',
   apiMode: 'included',
   approvalPolicy: 'ask',
@@ -285,7 +285,7 @@ describe('slashRegistry', () => {
     expect(modelNode.props).toMatchObject({ selectable: true });
     expect(cliState.sessionMeta.get()).toMatchObject({
       model: 'gpt55',
-      modelSource: 'override',
+      modelSource: 'explicit-override',
     });
   });
 
@@ -293,7 +293,7 @@ describe('slashRegistry', () => {
     resetCliState({
       agent: 'chat',
       model: 'gpt54',
-      modelSource: 'override',
+      modelSource: 'explicit-override',
       cwd: '/tmp/workspace',
       apiMode: 'personal',
       approvalPolicy: 'ask',

--- a/src/test-kernel/cli/cliModelResolution.vitest.mts
+++ b/src/test-kernel/cli/cliModelResolution.vitest.mts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   buildHeadlessRunContext,
-  chooseCliRunModelCandidate,
   selectCliRunModel,
 } from '@cli/runtime/runModel';
 import {
@@ -70,76 +69,57 @@ describe('selectCliRunModel precedence', () => {
     mocks.writeTextStderr.mockReset();
     mocks.initCliPlatform.mockResolvedValue(undefined);
     mocks.getCliApiMode.mockReturnValue('personal');
-    selectCliRunnableModelMock.mockImplementation(async (model) => ({
-      model,
+    selectCliRunnableModelMock.mockImplementation(async (request) => ({
+      model: Array.isArray(request)
+        ? (request.find((candidate) => candidate.model)?.model ??
+          CLI_BUILTIN_DEFAULT_MODEL)
+        : request,
     }));
   });
 
-  it('prefers the explicit model over env and config', () => {
+  it('passes the full run-model candidate list to model access', async () => {
     const context = makeContext({
       envModel: OTHER_MODEL,
       cliConfig: runConfig('deepseekR'),
     });
-    expect(chooseCliRunModelCandidate(context, KNOWN_MODEL, 'run')).toEqual({
-      model: KNOWN_MODEL,
-      source: 'override',
-    });
-  });
 
-  it('falls back to env when no explicit model is given', () => {
-    const context = makeContext({
-      envModel: OTHER_MODEL,
-      cliConfig: runConfig('deepseekR'),
-    });
-    expect(chooseCliRunModelCandidate(context, undefined, 'run')).toEqual({
-      model: OTHER_MODEL,
-      source: 'env',
-    });
-  });
+    await selectCliRunModel(context, KNOWN_MODEL, 'run');
 
-  it('uses the configured model when no explicit or env model', () => {
-    const context = makeContext({ cliConfig: runConfig('deepseekR') });
-    expect(chooseCliRunModelCandidate(context, undefined, 'run')).toEqual({
-      model: 'deepseekR',
-      source: 'config',
-    });
-  });
-
-  it('reads the role-specific config section', () => {
-    const context = makeContext({
-      cliConfig: { chat: { model: OTHER_MODEL }, run: { model: 'deepseekR' } },
-    });
-    expect(chooseCliRunModelCandidate(context, undefined, 'chat')).toEqual({
-      model: OTHER_MODEL,
-      source: 'config',
-    });
-    expect(chooseCliRunModelCandidate(context, undefined, 'run')).toEqual({
-      model: 'deepseekR',
-      source: 'config',
-    });
-  });
-
-  it('falls back to the builtin default when nothing else is set', () => {
-    expect(chooseCliRunModelCandidate(makeContext(), undefined, 'run')).toEqual(
+    expect(selectCliRunnableModelMock).toHaveBeenCalledWith(
+      [
+        { model: KNOWN_MODEL, reason: 'explicit-override' },
+        { model: OTHER_MODEL, reason: 'environment' },
+        { model: 'deepseekR', reason: 'command-config' },
+        { model: CLI_BUILTIN_DEFAULT_MODEL, reason: 'builtin-default' },
+      ],
       {
-        model: CLI_BUILTIN_DEFAULT_MODEL,
-        source: 'builtin',
+        agentCategory: AgentCategory.Workflow,
+        apiMode: 'personal',
       },
     );
   });
 
-  it('suppresses fallback notices for the implicit builtin default', async () => {
-    const context = makeContext();
+  it('reads the role-specific config section', async () => {
+    const context = makeContext({
+      cliConfig: { chat: { model: OTHER_MODEL }, run: { model: 'deepseekR' } },
+    });
 
+    await selectCliRunModel(context, undefined, 'chat');
     await selectCliRunModel(context, undefined, 'run');
 
-    expect(selectCliRunnableModelMock).toHaveBeenCalledWith(
-      CLI_BUILTIN_DEFAULT_MODEL,
-      {
-        agentCategory: AgentCategory.Workflow,
-        apiMode: 'personal',
-        fallbackSource: 'builtin',
-      },
+    expect(selectCliRunnableModelMock).toHaveBeenNthCalledWith(
+      1,
+      expect.arrayContaining([
+        { model: OTHER_MODEL, reason: 'command-config' },
+      ]),
+      expect.objectContaining({ agentCategory: AgentCategory.ToolUse }),
+    );
+    expect(selectCliRunnableModelMock).toHaveBeenNthCalledWith(
+      2,
+      expect.arrayContaining([
+        { model: 'deepseekR', reason: 'command-config' },
+      ]),
+      expect.objectContaining({ agentCategory: AgentCategory.Workflow }),
     );
   });
 
@@ -156,8 +136,10 @@ describe('selectCliRunModel precedence', () => {
       'deepseekT',
     );
     expect(selectCliRunnableModelMock).toHaveBeenCalledWith(
-      'staleConfiguredModel',
-      expect.objectContaining({ fallbackSource: 'config' }),
+      expect.arrayContaining([
+        { model: 'staleConfiguredModel', reason: 'command-config' },
+      ]),
+      expect.objectContaining({ agentCategory: AgentCategory.Workflow }),
     );
     expect(mocks.initCliPlatform).toHaveBeenCalledWith({
       ...context,
@@ -181,26 +163,15 @@ describe('selectCliRunModel precedence', () => {
     await expect(selectCliRunModel(context, 'opus48T', 'run')).rejects.toThrow(
       CliUsageError,
     );
-    expect(selectCliRunnableModelMock).toHaveBeenCalledWith('opus48T', {
-      agentCategory: AgentCategory.Workflow,
-      apiMode: 'personal',
-      fallbackSource: 'override',
-    });
-  });
-
-  it('treats TEXRA_MODEL as an explicit model request', async () => {
-    const context = makeContext({
-      envModel: 'opus48T',
-      cliConfig: runConfig('deepseekT'),
-    });
-
-    await selectCliRunModel(context, undefined, 'run');
-
-    expect(selectCliRunnableModelMock).toHaveBeenCalledWith('opus48T', {
-      agentCategory: AgentCategory.Workflow,
-      apiMode: 'personal',
-      fallbackSource: 'env',
-    });
+    expect(selectCliRunnableModelMock).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        { model: 'opus48T', reason: 'explicit-override' },
+      ]),
+      {
+        agentCategory: AgentCategory.Workflow,
+        apiMode: 'personal',
+      },
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Consolidates the remaining CLI, chat-default, and desktop setup model decision paths behind the shared run-model decision vocabulary. CLI run now passes all candidate tiers to model access instead of choosing a tier first, chat defaults store shared decision reasons directly, desktop setup uses one real model decision for the router/credential launch path, and model access ignores stale lower-priority hidden candidate lookup failures after a higher-priority runnable winner is already selected.

## Issue acceptance gates

- Addresses #7041.
- CLI run, chat defaults, desktop setup, delegation, and follow-up now have a single decision owner per launch path.
- `cliSourceForDecision` and `CLI_MODEL_DECISION_REASON_BY_SOURCE` are gone from `packages/cli/src`.
- `ChatDefaultValueSource` is now a documented alias of the shared `RunModelDecisionReason` subset, with no ternary reason remapping.
- `setupLaunch.ts` has no single-candidate `decideRunModel` calls; desktop setup uses one router/credential candidate list.
- Net LoC is negative: 279 insertions, 284 deletions.

## Single source of truth

`src/model/runModelDecision.ts` now owns the model precedence vocabulary for these paths through `RunModelDecisionReason` and `decideRunModel`.

## Duplication and abstraction budget

Removed the CLI-local source vocabulary and source-to-reason mapping, plus the pre-deciding `chooseCliRunModelCandidate` helper. No new pass-through layer was added; `selectCliRunnableModel` now owns only the host/access-list boundary by attaching fallback policy to shared decision reasons.

## Host impact

Extension: no extension behavior change; shared setup helpers keep the same launch model priority.

Desktop: setup launch preserves OpenRouter flag semantics, including no fallback when the flag is on without a key, while using one shared decision call.

CLI: run, chat defaults, TUI model reconciliation, orchestration, and model slash commands use shared decision reasons directly. Headless run byte-parity validation passed.

## Scheduled refactoring

None. This PR introduces no shim, dual-write, alias, fallback migration path, or ledger item.

## Validation

- `corepack pnpm exec prettier --write` on touched files
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/cliModelResolution.vitest.mts src/test-kernel/cli/ModelAccess.vitest.mts src/test-kernel/cli/ChatDefaults.vitest.mts src/test-kernel/controllers/SetupLaunch.vitest.ts src/test-kernel/cli/SlashRegistry.vitest.mts src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/ConfigForm.vitest.mts`
- `npm run typecheck`
- `npm test`
- `npm run lint` (0 errors, 15 pre-existing warnings)
- `npm run compile:fast`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `git diff --check`
- `rg -n "cliSourceForDecision|CLI_MODEL_DECISION_REASON_BY_SOURCE" packages/cli/src` (no matches)
- `rg -n "chooseCliRunModelCandidate|CliModelSelectionSource|fallbackSource" packages/cli/src src/test-kernel --glob '*.ts' --glob '*.tsx' --glob '*.mts'` (no matches)

Closes #7041
