### PR TITLE
[codex] Trim provider capabilities and tool errors

### DIFF
--- a/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
@@ -19,7 +19,7 @@ import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
 
 // Local imports - logging
 import type { FileLocation } from '@shared/schemas';
-import { toolError, type ToolResult } from '@shared/schemas/toolResult';
+import type { ToolResult } from '@shared/schemas/toolResult';
 import { AbsoluteFS, pathToLocation } from '@utils/files';
 import { isNonEmptyString } from '@utils/core';
 
@@ -142,12 +142,16 @@ export class ToolUseDispatchNode<C> extends BatchNode<
     // Skip duplicate parallel calls — return a synthetic error result so
     // the model is informed and can retry sequentially if needed.
     if (this._duplicateCallIds.has(call.callId)) {
+      const duplicateResult: ToolResult = {
+        status: 'error',
+        error: DUPLICATE_CALL_ERROR,
+      };
       return {
         call,
-        result: toolError(DUPLICATE_CALL_ERROR),
+        result: duplicateResult,
         parsedInput: call.input,
         extracted: {
-          sanitizedResult: { status: 'error', error: DUPLICATE_CALL_ERROR },
+          sanitizedResult: duplicateResult,
           attachments: [],
         },
         editedFiles: [],
@@ -188,7 +192,10 @@ export class ToolUseDispatchNode<C> extends BatchNode<
     signal?: AbortSignal,
   ): Promise<ToolResult> {
     if (!tool) {
-      return toolError(`Unknown tool ${call.name}`);
+      return {
+        status: 'error',
+        error: `Unknown tool ${call.name}`,
+      };
     }
 
     try {
@@ -213,7 +220,11 @@ export class ToolUseDispatchNode<C> extends BatchNode<
       );
     } catch (err) {
       const { message, diagnostics } = normalizeToolCallError(call.name, err);
-      return toolError(message, diagnostics);
+      return {
+        status: 'error',
+        error: message.trim() || 'Tool execution failed.',
+        ...(diagnostics !== undefined ? { diagnostics } : {}),
+      };
     }
   }
 

--- a/src/agent/core/tools/ToolTypes.ts
+++ b/src/agent/core/tools/ToolTypes.ts
@@ -7,7 +7,10 @@ import type { ToolResult } from '@shared/schemas/toolResult';
 
 /**
  * Contract for tool implementations.
- * BaseTool provides the canonical implementation with Zod validation.
+ * BaseTool provides the canonical implementation with Zod validation. Expected
+ * tool failures are returned as literal `{ status: 'error', error: ... }`
+ * ToolResult values; unexpected/programmer failures should throw and let
+ * BaseTool convert them at the boundary.
  */
 export interface ITool {
   readonly definition: ToolDefinition;

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -202,10 +202,6 @@ export abstract class ModelHandler<
     this.agentCategory = agentCategory ?? undefined;
   }
 
-  protected getAgentCategory(): AgentCategory | undefined {
-    return this.agentCategory;
-  }
-
   /** Common pricing fields used by providers with standard cache-read rebates. */
   protected standardPricingConfig(): StandardPricingConfig {
     return {

--- a/src/agent/modelHandlers/openai/modelHandlerCodex.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerCodex.ts
@@ -214,9 +214,7 @@ export class ModelHandlerCodex extends ModelHandlerOpenAIResponse {
     if (isCodexSubscriptionToolUseOnly() && !this.isToolUseMode()) return null;
     return resolveProviderCapabilities({
       model: this.config,
-      authMode: 'chatgpt-subscription',
       useOpenRouter: false,
-      agentCategory: this.getAgentCategory(),
     });
   }
 

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -8,7 +8,10 @@ import {
   internalValidationModelHandlerEnvName,
   shouldUseInternalValidationModelHandler,
 } from '@agent/runtime/internalValidationOverride';
-import { isCodexSignedIn, shouldUseCodexSubscription } from '@auth/codex';
+import {
+  isCodexSignedIn,
+  resolveCodexSubscriptionCapabilities,
+} from '@auth/codex';
 import * as logger from '@logger/logUtils';
 import { isGpt5ModelName } from '@model/modelNames';
 import { DEFAULT_CORE_SETTINGS } from '@shared/schemas/coreSettings';
@@ -435,7 +438,7 @@ async function createModelHandlerForResolvedCompatibilityKey(
   if (
     options.allowCodexSubscriptionOverride &&
     compatibilityKey !== 'ModelHandlerValidation' &&
-    shouldUseCodexSubscription(config, useOpenRouter) &&
+    resolveCodexSubscriptionCapabilities(config, useOpenRouter) &&
     (await isCodexSignedIn())
   ) {
     logger.debug(CHANNEL, 'Using ChatGPT subscription (Codex) Handler');

--- a/src/auth/codex/codexActive.ts
+++ b/src/auth/codex/codexActive.ts
@@ -1,7 +1,7 @@
 /**
  * Live "is this model routing through the ChatGPT subscription right now?"
- * check: the (sync) routing predicate from {@link shouldUseCodexSubscription}
- * AND a current ChatGPT sign-in. Async because it reads the stored session.
+ * check: the (sync) capability resolver AND a current ChatGPT sign-in. Async
+ * because it reads the stored session.
  *
  * Shared by the CLI status bar badge and the `/status` text command so the two
  * never disagree, and the single place that pairs the routing predicate with
@@ -12,7 +12,7 @@ import { MODEL_CONFIGS } from 'llm-zoo';
 import { getUseOpenRouter } from '@utils/config/providerConfig';
 
 import { isCodexSignedIn } from './codexAuthAccess';
-import { shouldUseCodexSubscription } from './codexRouting';
+import { resolveCodexSubscriptionCapabilities } from './codexRouting';
 
 /**
  * Whether a request for `modelId` would be served by the ChatGPT subscription
@@ -24,6 +24,8 @@ export async function isCodexSubscriptionActive(
 ): Promise<boolean> {
   const config = MODEL_CONFIGS[modelId];
   if (!config) return false;
-  if (!shouldUseCodexSubscription(config, getUseOpenRouter())) return false;
+  if (!resolveCodexSubscriptionCapabilities(config, getUseOpenRouter())) {
+    return false;
+  }
   return isCodexSignedIn();
 }

--- a/src/auth/codex/codexRouting.ts
+++ b/src/auth/codex/codexRouting.ts
@@ -21,18 +21,6 @@ import {
 } from './codexPreference';
 import type { ModelConfig } from 'llm-zoo';
 
-/**
- * Whether this model, under the current routing context, should go through the
- * ChatGPT subscription. Does NOT check sign-in (callers handle that): true means
- * "the user asked to prefer the subscription and this model can use it".
- */
-export function shouldUseCodexSubscription(
-  config: ModelConfig,
-  useOpenRouter: boolean,
-): boolean {
-  return resolveCodexSubscriptionCapabilities(config, useOpenRouter) !== null;
-}
-
 export function resolveCodexSubscriptionCapabilities(
   config: ModelConfig,
   useOpenRouter: boolean,
@@ -40,23 +28,8 @@ export function resolveCodexSubscriptionCapabilities(
   if (!isPreferCodexSubscription()) return null;
   return resolveProviderCapabilities({
     model: config,
-    authMode: 'chatgpt-subscription',
     useOpenRouter,
   });
-}
-
-export function shouldUseCodexSubscriptionForAgentCategory(
-  config: ModelConfig,
-  useOpenRouter: boolean,
-  agentCategory: AgentCategory | undefined,
-): boolean {
-  return (
-    resolveCodexSubscriptionCapabilitiesForAgentCategory(
-      config,
-      useOpenRouter,
-      agentCategory,
-    ) !== null
-  );
 }
 
 export function resolveCodexSubscriptionCapabilitiesForAgentCategory(

--- a/src/auth/codex/index.ts
+++ b/src/auth/codex/index.ts
@@ -65,8 +65,6 @@ export {
 export {
   resolveCodexSubscriptionCapabilities,
   resolveCodexSubscriptionCapabilitiesForAgentCategory,
-  shouldUseCodexSubscription,
-  shouldUseCodexSubscriptionForAgentCategory,
 } from './codexRouting';
 export { isCodexSubscriptionActive } from './codexActive';
 export {

--- a/src/model/providerCapabilities.ts
+++ b/src/model/providerCapabilities.ts
@@ -1,7 +1,6 @@
 import { ModelProvider, type ModelConfig } from 'llm-zoo';
 
 import type { UsageRoute } from '@shared/schemas';
-import type { AgentCategory } from '@shared/schemas/agent';
 
 export type ProviderAuthMode = 'chatgpt-subscription';
 
@@ -29,9 +28,7 @@ export interface ProviderCapabilityProfile {
 
 export interface ProviderCapabilityKey {
   readonly model: ModelConfig;
-  readonly authMode: ProviderAuthMode;
   readonly useOpenRouter: boolean;
-  readonly agentCategory?: AgentCategory;
 }
 
 type ProviderCapabilityResolver = (
@@ -80,7 +77,7 @@ export function isCodexSubscriptionEligible(fullName: string): boolean {
   return /codex/i.test(fullName);
 }
 
-const openAIChatGptSubscriptionCapabilities: ProviderCapabilityResolver = ({
+const resolveChatGptSubscriptionCapabilities: ProviderCapabilityResolver = ({
   model,
   useOpenRouter,
 }) => {
@@ -113,22 +110,9 @@ const openAIChatGptSubscriptionCapabilities: ProviderCapabilityResolver = ({
   };
 };
 
-export const ProviderCapabilities: Partial<
-  Record<
-    ModelProvider,
-    Partial<Record<ProviderAuthMode, ProviderCapabilityResolver>>
-  >
-> = {
-  [ModelProvider.OPENAI]: {
-    'chatgpt-subscription': openAIChatGptSubscriptionCapabilities,
-  },
-};
-
-/** Resolve the active provider profile for a model/auth-mode pair. */
+/** Resolve the active ChatGPT-subscription provider profile. */
 export function resolveProviderCapabilities(
   key: ProviderCapabilityKey,
 ): ProviderCapabilityProfile | null {
-  return (
-    ProviderCapabilities[key.model.provider]?.[key.authMode]?.(key) ?? null
-  );
+  return resolveChatGptSubscriptionCapabilities(key);
 }

--- a/src/shared/schemas/toolResult.ts
+++ b/src/shared/schemas/toolResult.ts
@@ -187,18 +187,6 @@ export const ToolResultSchema = z.discriminatedUnion('status', [
 ]);
 export type ToolResult = z.infer<typeof ToolResultSchema>;
 
-export function toolError(message: string, diagnostics?: unknown): ToolResult {
-  const normalizedMessage = message.trim();
-  return {
-    status: 'error',
-    error:
-      normalizedMessage.length > 0
-        ? normalizedMessage
-        : 'Tool execution failed.',
-    ...(diagnostics !== undefined ? { diagnostics } : {}),
-  };
-}
-
 export class ToolError extends Error {
   constructor(message: string, options?: { cause?: unknown }) {
     super(message, options);

--- a/src/test-kernel/agent/modelHandlers/utils/toolAttachmentUtils.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/utils/toolAttachmentUtils.vitest.ts
@@ -9,7 +9,6 @@ import {
   formatToolResultAsText,
 } from '@agent/modelHandlers/utils/toolAttachmentUtils';
 import { MAX_TOOL_RESULT_TEXT_LENGTH } from '@agent/modelHandlers/contextManagementConstants';
-import { toolError, ToolResultSchema } from '@shared/schemas/toolResult';
 
 describe('checkToolResultTextLimit', () => {
   it('returns null for text within limit', () => {
@@ -202,19 +201,6 @@ describe('extractToolAttachments', () => {
           },
         ],
       } as never),
-    );
-  });
-});
-
-describe('toolError', () => {
-  it('normalizes blank messages to a schema-valid fallback', () => {
-    const result = toolError('   ');
-
-    assert.equal(result.status, 'error');
-    assert.equal(result.error, 'Tool execution failed.');
-    assert.equal(
-      ToolResultSchema.parse(result).error,
-      'Tool execution failed.',
     );
   });
 });

--- a/src/test-kernel/model/ProviderCapabilities.vitest.ts
+++ b/src/test-kernel/model/ProviderCapabilities.vitest.ts
@@ -25,10 +25,9 @@ const gpt55Config: ModelConfig = {
 };
 
 describe('provider capabilities', () => {
-  it('resolves ChatGPT subscription profile from model and auth mode', () => {
+  it('resolves ChatGPT subscription profile from model routing context', () => {
     const capabilities = resolveProviderCapabilities({
       model: gpt55Config,
-      authMode: 'chatgpt-subscription',
       useOpenRouter: false,
     });
 

--- a/src/tools/core/base.ts
+++ b/src/tools/core/base.ts
@@ -8,7 +8,6 @@ import type { ToolDefinition } from '@model/ToolDefinition';
 import {
   DIAGNOSTIC_TYPE_VALIDATION_ERROR,
   formatZodIssuesForDiagnostics,
-  toolError,
   type ToolResult,
 } from '@shared/schemas/toolResult';
 
@@ -57,16 +56,24 @@ export abstract class BaseTool<T> implements ITool {
       return await this.execute(input);
     } catch (err) {
       if (err instanceof ZodError) {
-        return toolError(`Invalid input:\n${z.prettifyError(err)}`, {
-          type: DIAGNOSTIC_TYPE_VALIDATION_ERROR,
-          issues: err.issues,
-          formatted: formatZodIssuesForDiagnostics(err.issues),
-        });
+        return {
+          status: 'error',
+          error: `Invalid input:\n${z.prettifyError(err)}`,
+          diagnostics: {
+            type: DIAGNOSTIC_TYPE_VALIDATION_ERROR,
+            issues: err.issues,
+            formatted: formatZodIssuesForDiagnostics(err.issues),
+          },
+        };
       }
-      const message = toErrorMessage(err);
+      const message = toErrorMessage(err).trim();
       // Only include error name - stack traces waste tokens and aren't actionable by models
       const diagnostics = err instanceof Error ? { name: err.name } : undefined;
-      return toolError(message, diagnostics);
+      return {
+        status: 'error',
+        error: message || 'Tool execution failed.',
+        ...(diagnostics !== undefined ? { diagnostics } : {}),
+      };
     }
   }
 


### PR DESCRIPTION
## Summary

Trims the remaining F4/F5 follow-up generality: the ChatGPT-subscription provider profile now resolves through the single live resolver instead of an exported nested registry, Codex callers use resolver presence directly instead of boolean pass-through wrappers, and tool error results are documented as literal `ToolResult` values with the unused `toolError()` builder deleted.

## Issue acceptance gates

- Addresses #7043.
- `git grep -n 'openAIApiKeyCapabilities\|shouldUseCodexSubscription' -- src` has no matches.
- `src/tools` now has one documented convention for expected tool failures: literal `{ status: 'error', error: ... }` `ToolResult` values. The competing `toolError()` builder is deleted, and remaining message-only `status: 'error'` shapes are internal Zotero connector results, not `ToolResult`.
- #6981 has a row for the legacy `src/shared/toolUse.ts:85` `isError` sniff with a D3 age-based removal trigger.
- Net LoC is negative: 50 insertions, 102 deletions.

## Single source of truth

`src/model/providerCapabilities.ts` is the only provider-profile resolver for the ChatGPT-subscription path, and `ITool` documents the literal error-result contract for tool implementations.

## Duplication and abstraction budget

Removed the exported `ProviderCapabilities` registry shape while only one provider/auth-mode exists, removed the `shouldUseCodexSubscription*` boolean wrapper pair, and deleted the unused `toolError()` result builder. No new pass-through layer was added.

## Host impact

Extension: no user-visible behavior change; Codex subscription routing still uses the same profile and sign-in gate.

Desktop: no user-visible behavior change; shared model factory routing is unchanged except for inlining the boolean wrapper.

CLI: no output-format behavior change; tool-use error payloads keep the same schema and CLI headless run parity passed.

## Scheduled refactoring

Added the #6981 ledger row for `src/shared/toolUse.ts:85`: delete the legacy `isError` sniff once pre-F5 tool-use transcript/log entries without source `status` are outside supported persisted-run retention, with D3 (#6984) verifying no supported `isError`-only entries remain.

## Validation

- `corepack pnpm exec prettier --write` on touched files
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/model/ProviderCapabilities.vitest.ts src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts src/test-kernel/agent/modelHandlers/utils/toolAttachmentUtils.vitest.ts src/test-kernel/tools/ReportReviewIssueTool.vitest.ts src/test-kernel/agent/trace/EmitToolUseCard.vitest.ts`
- `npm run typecheck`
- `npm test`
- `npm run lint` (0 errors, 15 pre-existing warnings)
- `npm run compile:fast`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `git diff --check`
- `git grep -n 'openAIApiKeyCapabilities\|shouldUseCodexSubscription' -- src` (no matches)
- `rg -n "toolError" src --glob '*.ts' --glob '*.mts'` (no matches)
- `gh issue view 6981 --json body --jq .body | rg -n "Legacy tool-use error sniff|src/shared/toolUse.ts:85"`

Closes #7043

