### PR TITLE
[codex] Skip chat defaults I/O for direct values

### DIFF
--- a/packages/cli/src/runtime/chatDefaults.ts
+++ b/packages/cli/src/runtime/chatDefaults.ts
@@ -184,27 +184,35 @@ export async function resolveChatDefaults(
   let model: string | undefined;
   let agentSource = sourceForOverride(overrideAgent, envAgent);
   let modelSource: ChatDefaultValueSource | undefined;
+  const directModel = overrideModel || envModel;
+  const skipDefaultTierIo = Boolean(agent && directModel);
 
-  // Tiers are independent I/O — fan out in parallel.
-  // Workspace defaults use the same .texra/config.json reader as the CLI
-  // context so startup does not depend on platform initialization.
-  const [workspace, user, history] = await Promise.all([
-    loadWorkspaceDefaults(init.cwd),
-    loadUserDefaults(),
-    loadHistoryDefaults(),
-  ]);
-  const tiers: ReadonlyArray<
-    readonly [ChatDefaultValueSource, PartialDefaults]
-  > = [
-    ['workspace-config', workspace],
-    ['user-config', user],
-    ['history', history],
-  ];
+  let workspace: PartialDefaults = {};
+  let user: PartialDefaults = {};
+  let history: PartialDefaults = {};
 
-  for (const [source, defaults] of tiers) {
-    if (!agent && defaults.agent) {
-      agent = defaults.agent;
-      agentSource = source;
+  if (!skipDefaultTierIo) {
+    // Tiers are independent I/O — fan out in parallel.
+    // Workspace defaults use the same .texra/config.json reader as the CLI
+    // context so startup does not depend on platform initialization.
+    [workspace, user, history] = await Promise.all([
+      loadWorkspaceDefaults(init.cwd),
+      loadUserDefaults(),
+      loadHistoryDefaults(),
+    ]);
+    const tiers: ReadonlyArray<
+      readonly [ChatDefaultValueSource, PartialDefaults]
+    > = [
+      ['workspace-config', workspace],
+      ['user-config', user],
+      ['history', history],
+    ];
+
+    for (const [source, defaults] of tiers) {
+      if (!agent && defaults.agent) {
+        agent = defaults.agent;
+        agentSource = source;
+      }
     }
   }
 

--- a/src/test-kernel/cli/ChatDefaults.vitest.mts
+++ b/src/test-kernel/cli/ChatDefaults.vitest.mts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MODEL_CONFIGS } from 'llm-zoo';
 
 import { listExecutions } from '@agent/storage';
@@ -45,6 +45,13 @@ vi.mock('@utils/files/storageFS', () => ({
 }));
 
 const mockedReadJson = vi.mocked(GlobalStorageFS.readJson);
+
+beforeEach(() => {
+  mockedListExecutions.mockReset();
+  mockedListExecutions.mockResolvedValue([]);
+  mockedReadJson.mockReset();
+  mockedReadJson.mockRejectedValue(new Error('no user defaults'));
+});
 
 async function workspaceWithConfig(config: unknown): Promise<string> {
   const workspace = await mkdtemp(join(tmpdir(), 'texra-chat-defaults-'));
@@ -267,6 +274,63 @@ describe('CLI chat defaults', () => {
       agent: 'simplifier',
       agentSource: 'explicit-override',
     });
+  });
+
+  it('skips user and history I/O when explicit overrides resolve agent and model', async () => {
+    const workspace = await workspaceWithConfig({
+      chat: { agent: 'assistant', model: 'sonnet46T' },
+    });
+
+    await expect(
+      resolveChatDefaults({
+        cwd: workspace,
+        agentOverride: 'simplifier',
+        modelOverride: 'deepseekT',
+      }),
+    ).resolves.toMatchObject({
+      agent: 'simplifier',
+      model: 'deepseekT',
+      source: 'mixed',
+      agentSource: 'explicit-override',
+      modelSource: 'explicit-override',
+    });
+    expect(mockedReadJson).not.toHaveBeenCalled();
+    expect(mockedListExecutions).not.toHaveBeenCalled();
+  });
+
+  it('skips user and history I/O when environment resolves agent and model', async () => {
+    await expect(
+      resolveChatDefaults({
+        cwd: '/tmp/no-such-texra-workspace',
+        envAgent: 'assistant',
+        envModel: 'sonnet46T',
+      }),
+    ).resolves.toMatchObject({
+      agent: 'assistant',
+      model: 'sonnet46T',
+      source: 'mixed',
+      agentSource: 'environment',
+      modelSource: 'environment',
+    });
+    expect(mockedReadJson).not.toHaveBeenCalled();
+    expect(mockedListExecutions).not.toHaveBeenCalled();
+  });
+
+  it('still loads history when only the agent is directly resolved', async () => {
+    mockedListExecutions.mockResolvedValueOnce([historyEntry('research')]);
+
+    await expect(
+      resolveChatDefaults({
+        cwd: '/tmp/no-such-texra-workspace',
+        agentOverride: 'simplifier',
+      }),
+    ).resolves.toMatchObject({
+      agent: 'simplifier',
+      model: 'sonnet46T',
+      agentSource: 'explicit-override',
+      modelSource: 'history',
+    });
+    expect(mockedListExecutions).toHaveBeenCalledOnce();
   });
 
   it('uses prefixed command-specific workspace defaults', async () => {

--- a/src/test-kernel/cli/ChatDefaultsFastPath.vitest.mts
+++ b/src/test-kernel/cli/ChatDefaultsFastPath.vitest.mts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { listExecutions } from '@agent/storage';
+import { loadWorkspaceCliConfig } from '@cli/runtime/cliConfig';
+import { resolveChatDefaults } from '@cli/runtime/chatDefaults';
+import { GlobalStorageFS } from '@utils/files/storageFS';
+
+vi.mock('@cli/runtime/cliConfig', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@cli/runtime/cliConfig')>();
+  return {
+    ...actual,
+    loadWorkspaceCliConfig: vi.fn(),
+  };
+});
+
+vi.mock('@agent/storage', () => ({
+  listExecutions: vi.fn(async () => []),
+}));
+
+vi.mock('@utils/files/storageFS', () => ({
+  GlobalStorageFS: {
+    readJson: vi.fn(async () => ({})),
+  },
+}));
+
+const mockedLoadWorkspaceCliConfig = vi.mocked(loadWorkspaceCliConfig);
+const mockedReadJson = vi.mocked(GlobalStorageFS.readJson);
+const mockedListExecutions = vi.mocked(listExecutions);
+
+beforeEach(() => {
+  mockedLoadWorkspaceCliConfig.mockReset();
+  mockedLoadWorkspaceCliConfig.mockResolvedValue({
+    values: { chat: { agent: 'assistant', model: 'sonnet46T' } },
+    warnings: [],
+  });
+  mockedReadJson.mockReset();
+  mockedReadJson.mockResolvedValue({
+    chat: { agent: 'assistant', model: 'sonnet46T' },
+  });
+  mockedListExecutions.mockReset();
+  mockedListExecutions.mockResolvedValue([]);
+});
+
+describe('CLI chat defaults direct-value fast path', () => {
+  it('skips workspace, user, and history loaders when direct values are complete', async () => {
+    await expect(
+      resolveChatDefaults({
+        cwd: '/tmp/workspace-with-defaults',
+        agentOverride: 'simplifier',
+        modelOverride: 'deepseekT',
+      }),
+    ).resolves.toMatchObject({
+      agent: 'simplifier',
+      model: 'deepseekT',
+      agentSource: 'explicit-override',
+      modelSource: 'explicit-override',
+    });
+
+    expect(mockedLoadWorkspaceCliConfig).not.toHaveBeenCalled();
+    expect(mockedReadJson).not.toHaveBeenCalled();
+    expect(mockedListExecutions).not.toHaveBeenCalled();
+  });
+
+  it('keeps default-tier loading when only one direct value is present', async () => {
+    await expect(
+      resolveChatDefaults({
+        cwd: '/tmp/workspace-with-defaults',
+        modelOverride: 'deepseekT',
+      }),
+    ).resolves.toMatchObject({
+      agent: 'assistant',
+      model: 'deepseekT',
+      agentSource: 'workspace-config',
+      modelSource: 'explicit-override',
+    });
+
+    expect(mockedLoadWorkspaceCliConfig).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a direct-values fast path to `resolveChatDefaults`: when the chat agent and model are already resolved from explicit overrides or environment values, the CLI skips workspace/user/history default loading while still routing model precedence through the single `decideRunModel` call.

## Issue acceptance gates

- Addresses #7072.
- Full direct values skip the default-tier fan-out: `loadWorkspaceDefaults`, `loadUserDefaults`, and `loadHistoryDefaults` are not called when agent and model are already direct.
- Partial direct values still preserve per-field independence; lower tiers can fill the missing agent or model.
- `decideRunModel(...)` remains the one model-precedence decision in `resolveChatDefaults`.

## Single source of truth

`resolveChatDefaults` remains the single owner for CLI chat defaults, and `decideRunModel` remains the single owner for model precedence inside that resolver.

## Duplication and abstraction budget

No new abstraction layer or pass-through helper was added. The positive line count lives in focused regression tests that pin the no-I/O fast path and the partial-override fallback behavior.

## Host impact

Extension: none.

Desktop: none.

CLI: `texra chat --agent X -m Y` and resume paths that already provide both values avoid unnecessary workspace/user/history default I/O. Headless `texra run` is unaffected because it does not use `resolveChatDefaults`.

## Scheduled refactoring

None. No shim, projection, dual-write, alias, fallback, or migration path was introduced, so no #6981 row is needed.

## Validation

- `corepack pnpm exec prettier --write packages/cli/src/runtime/chatDefaults.ts src/test-kernel/cli/ChatDefaults.vitest.mts src/test-kernel/cli/ChatDefaultsFastPath.vitest.mts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/ChatDefaults.vitest.mts src/test-kernel/cli/ChatDefaultsFastPath.vitest.mts`
- `npm run typecheck`
- `npm run lint` (0 errors, 15 pre-existing warnings)
- `npm run compile:fast`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `git diff --check`
- `npm test`

Closes #7072

