### PR TITLE
[codex] Derive sync stream payload from schema

### DIFF
--- a/src/shared/progressView/backend/WebviewUpdater.ts
+++ b/src/shared/progressView/backend/WebviewUpdater.ts
@@ -1,11 +1,10 @@
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import type {
   AgentCategoryFilter,
-  ConversationProgress,
-  ContextStateData,
-  OutputFileInfo,
   CompileFailure,
+  ConversationProgress,
   InquiryThreadUpdatedEvent,
+  OutputFileInfo,
   PermissionPayload,
   ProgressPermissionKind,
   ProgressViewPlacement,
@@ -17,6 +16,7 @@ import type {
   StreamTabInfo,
   Plan,
   TodoItem,
+  SyncStreamContentPayload,
   TokenUsageStats,
 } from '@shared/schemas';
 import {
@@ -43,43 +43,14 @@ export type ProgressViewMessageSender = (
  * batched here. This ensures critical UI feedback (status) isn't blocked by
  * potentially large log payloads and provides fault isolation.
  */
-export interface LogContentExtras {
-  /** Workflow output files by round (one run per tab) */
-  workflowFiles?: Record<string, OutputFileInfo[]>;
-  /** Workflow missing outputs by round */
-  workflowMissingOutputs?: Record<string, string[]>;
-  /** Workflow compile failures by round */
-  workflowCompileFailures?: Record<string, CompileFailure[]>;
-  /** Per-run usage map (both workflow and tool-use; frontend derives sum) */
-  runUsage?: Record<string, TokenUsageStats>;
-  /** Context window utilization state */
-  contextState?: ContextStateData;
-}
-
-/**
- * Payload for batched stream content hydration (tab switch).
- *
- * Extends {@link LogContentExtras} so the workflow files / usage / context
- * fields shared with incremental log updates have a single definition.
- */
-export interface SyncStreamContentPayload extends LogContentExtras {
-  stream: StreamTabId | '';
-  action?: 'render' | 'clear';
-  todos: TodoItem[];
-  plan: Plan | null;
-  queuedFollowUps: string[];
-  agentCategory?: string;
-  /** Tab-switch state previously sent by syncActiveStreamState (R2). */
-  conversationProgress?: ConversationProgress;
-  badges?: StreamBadgeSnapshot;
-  parentStreamId?: StreamTabId;
-  /** Toggle bypass state (hydrated on tab switch so toggles display correctly). */
-  toolEditBypass?: boolean;
-  superYoloBypass?: boolean;
-  goalActive?: boolean;
-  goalStatus?: GoalStatus;
-  goalObjective?: string;
-}
+export type LogContentExtras = Pick<
+  SyncStreamContentPayload,
+  | 'workflowFiles'
+  | 'workflowMissingOutputs'
+  | 'workflowCompileFailures'
+  | 'runUsage'
+  | 'contextState'
+>;
 
 /**
  * Manages webview updates for the progress view.

--- a/src/shared/schemas/progressView/outbound.ts
+++ b/src/shared/schemas/progressView/outbound.ts
@@ -306,6 +306,11 @@ export const SyncStreamContentMessageSchema = z.object({
   goalObjective: z.string().optional(),
 });
 
+export type SyncStreamContentPayload = Omit<
+  z.infer<typeof SyncStreamContentMessageSchema>,
+  'command'
+>;
+
 const GoalActiveUpdatedMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.GOAL_ACTIVE_UPDATED),
   active: z.boolean(),

--- a/src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts
@@ -11,14 +11,12 @@ import type {
   Plan,
   StorageKey,
   StreamTabId,
+  SyncStreamContentPayload,
   TodoItem,
   TokenUsageStats,
 } from '@shared/schemas';
 import { ProgressEventHandler } from '@shared/progressView/backend/events/ProgressEventHandler';
-import type {
-  SyncStreamContentPayload,
-  WebviewUpdater,
-} from '@shared/progressView/backend/WebviewUpdater';
+import type { WebviewUpdater } from '@shared/progressView/backend/WebviewUpdater';
 import type { MementoStorage } from '@shared/progressView/backend/persistence/PersistentMapManager';
 import { ProgressViewState } from '@shared/progressView/backend/state/ProgressViewState';
 import type { WebviewBridge } from '@shared/progressView/backend/WebviewBridge';

--- a/src/test-kernel/progressView/SessionRunFactProjectorEquivalence.vitest.ts
+++ b/src/test-kernel/progressView/SessionRunFactProjectorEquivalence.vitest.ts
@@ -17,6 +17,7 @@ import {
   type Plan,
   type StorageKey,
   type StreamTabId,
+  type SyncStreamContentPayload,
   type TodoItem,
 } from '@shared/schemas';
 import {
@@ -26,10 +27,7 @@ import {
 import type { MementoStorage } from '@shared/progressView/backend/persistence/PersistentMapManager';
 import { ProgressViewState } from '@shared/progressView/backend/state/ProgressViewState';
 import type { WebviewBridge } from '@shared/progressView/backend/WebviewBridge';
-import type {
-  SyncStreamContentPayload,
-  WebviewUpdater,
-} from '@shared/progressView/backend/WebviewUpdater';
+import type { WebviewUpdater } from '@shared/progressView/backend/WebviewUpdater';
 
 class MemoryMementoStorage implements MementoStorage {
   private readonly values = new Map<string, unknown>();


### PR DESCRIPTION
## Summary

Derives the progress-view `syncStreamContent` payload type from the outbound Zod schema instead of maintaining a separate backend interface with the same field list. Existing backend callers keep using `sendSyncStreamContent`, while tests import the payload type from the schema barrel.

## Issue acceptance gates

- Addresses #7066: `SyncStreamContentPayload` is now derived from `SyncStreamContentMessageSchema`.
- The hand-duplicated backend payload field list was removed.
- Producer call sites and existing progress-view hydration tests remain green.

## Single source of truth

`src/shared/schemas/progressView/outbound.ts` now owns the sync-stream-content message shape through `SyncStreamContentMessageSchema`; `SyncStreamContentPayload` is `Omit<z.infer<typeof SyncStreamContentMessageSchema>, "command">`.

## Duplication and abstraction budget

Removed the duplicated `SyncStreamContentPayload extends LogContentExtras` interface from `WebviewUpdater.ts`. `LogContentExtras` is now a `Pick` of the schema-derived payload subset, so the shared extras cannot drift from the outbound message schema. No shim, alias, fallback, dual-write, or migration path was introduced; net code is negative.

## Host impact

Extension: No runtime behavior change; progress-view message typing now follows the outbound schema.

Desktop: No runtime behavior change; desktop progress messages use the same validated outbound shape.

CLI: No user-facing impact; this is progress-view schema/backend typing only.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write src/shared/progressView/backend/WebviewUpdater.ts src/shared/schemas/progressView/outbound.ts src/test-kernel/progressView/SessionRunFactProjectorEquivalence.vitest.ts src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/progressView/SessionRunFactProjectorEquivalence.vitest.ts src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts`
- `npm run typecheck`
- `npm run lint` (passes with the existing 15 warnings)
- `npm run compile:fast`
- `npm test`
- `git diff --check`

Closes #7066