### PR TITLE
[codex] Derive workflow output summaries in schema

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -32,13 +32,11 @@ import { createChannelTrace } from '@logger';
 import {
   type StreamTabId,
   type ExecutionId,
-  type OutputFileInfo,
-  type RoundOutput,
   type SubagentProgressUpdate,
 } from '@shared/schemas';
-import type {
-  CompileFailureSummary,
-  OutputFileSummary,
+import {
+  roundOutputsToCompileFailureSummaries,
+  roundOutputsToOutputSummaries,
 } from '@shared/schemas/output';
 import { ensureRunDir } from '@utils/files/taskRunStorage';
 
@@ -65,57 +63,6 @@ import type { ModelHandlerCompatibilityKey } from './modelHandlerCompatibilityKe
 const CHANNEL = 'executeAgent';
 const logger = createChannelTrace(CHANNEL);
 
-/**
- * Project `RoundOutput[]` → `OutputFileSummary[]` for inclusion in `AgentFlowResult`.
- *
- * `relativePath` falls back to `absolutePath` for `external` locations that have
- * no relative path. `originalPath` prefers `lineage.diffBase` (the snapshot used
- * for latexdiff) over `lineage.original` (the workspace source).
- */
-function toOutputSummaries(roundOutputs: RoundOutput[]): OutputFileSummary[] {
-  return roundOutputs.flatMap((r) =>
-    r.outputs.map((o: OutputFileInfo) => ({
-      round: r.round,
-      relativePath:
-        'relativePath' in o.location
-          ? o.location.relativePath
-          : o.location.absolutePath,
-      absolutePath: o.location.absolutePath,
-      location: o.location.kind,
-      originalPath:
-        o.lineage?.diffBase?.absolutePath ??
-        o.lineage?.original?.absolutePath ??
-        null,
-      added: o.diff?.added ?? null,
-      removed: o.diff?.removed ?? null,
-    })),
-  );
-}
-
-/**
- * Project `RoundOutput[]` → `CompileFailureSummary[]` for inclusion in `AgentFlowResult`.
- *
- * `outputPath` is workspace-relative for workspace/runStorage files and absolute
- * for external files (which have no meaningful relative path). `logPath` is always
- * relative; `logAbsolutePath` is provided separately for direct file-open calls.
- */
-function toCompileFailureSummaries(
-  roundOutputs: RoundOutput[],
-): CompileFailureSummary[] {
-  return roundOutputs.flatMap((r) =>
-    r.compileFailures.map((failure) => ({
-      round: failure.round,
-      displayName: failure.displayName,
-      outputPath:
-        failure.output.kind === 'external'
-          ? failure.output.absolutePath
-          : failure.output.relativePath,
-      logPath: failure.logRelativePath,
-      logAbsolutePath: failure.log.absolutePath,
-    })),
-  );
-}
-
 /** Build a workflow AgentFlowResult from a reflection flow run. */
 function buildWorkflowFlowResult(
   result: RunReflectionFlowResult,
@@ -126,8 +73,8 @@ function buildWorkflowFlowResult(
   return {
     category: 'workflow',
     outcome: result.outcome,
-    outputs: toOutputSummaries(result.roundOutputs),
-    compileFailures: toCompileFailureSummaries(result.roundOutputs),
+    outputs: roundOutputsToOutputSummaries(result.roundOutputs),
+    compileFailures: roundOutputsToCompileFailureSummaries(result.roundOutputs),
     executionId,
     streamId,
     ...buildOptionalFlowResultFields(memoryMisses, result.totalCostUsd),

--- a/src/shared/schemas/output.ts
+++ b/src/shared/schemas/output.ts
@@ -147,3 +147,56 @@ export const RoundOutputSchema = z.strictObject({
   xmlSummary: OutputXmlSummarySchema,
 });
 export type RoundOutput = z.infer<typeof RoundOutputSchema>;
+
+function displayPath(location: FileLocation): string {
+  return location.kind === 'external'
+    ? location.absolutePath
+    : location.relativePath;
+}
+
+export const OutputFileSummaryFromInfoSchema = OutputFileInfoSchema.transform(
+  (output) => ({
+    round: output.round,
+    relativePath: displayPath(output.location),
+    absolutePath: output.location.absolutePath,
+    location: output.location.kind,
+    originalPath:
+      output.lineage?.diffBase?.absolutePath ??
+      output.lineage?.original?.absolutePath ??
+      null,
+    added: output.diff?.added ?? null,
+    removed: output.diff?.removed ?? null,
+  }),
+).pipe(OutputFileSummarySchema);
+
+export const CompileFailureSummaryFromFailureSchema =
+  CompileFailureSchema.transform((failure) => ({
+    round: failure.round,
+    displayName: failure.displayName,
+    outputPath: displayPath(failure.output),
+    logPath: failure.logRelativePath,
+    logAbsolutePath: failure.log.absolutePath,
+  })).pipe(CompileFailureSummarySchema);
+
+export function roundOutputsToOutputSummaries(
+  roundOutputs: RoundOutput[],
+): OutputFileSummary[] {
+  return roundOutputs.flatMap((roundOutput) =>
+    roundOutput.outputs.map((output) =>
+      OutputFileSummaryFromInfoSchema.parse({
+        ...output,
+        round: roundOutput.round,
+      }),
+    ),
+  );
+}
+
+export function roundOutputsToCompileFailureSummaries(
+  roundOutputs: RoundOutput[],
+): CompileFailureSummary[] {
+  return roundOutputs.flatMap((roundOutput) =>
+    roundOutput.compileFailures.map((failure) =>
+      CompileFailureSummaryFromFailureSchema.parse(failure),
+    ),
+  );
+}

--- a/src/test-kernel/schemas/OutputSummaryTransforms.vitest.ts
+++ b/src/test-kernel/schemas/OutputSummaryTransforms.vitest.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CompileFailureSummaryFromFailureSchema,
+  OutputFileSummaryFromInfoSchema,
+  roundOutputsToCompileFailureSummaries,
+  roundOutputsToOutputSummaries,
+  type CompileFailure,
+  type FileLocation,
+  type OutputFileInfo,
+  type RoundOutput,
+} from '@shared/schemas';
+
+const workspace = (
+  relativePath: string,
+  absolutePath = `/workspace/${relativePath}`,
+): FileLocation => ({
+  kind: 'workspace',
+  absolutePath,
+  relativePath,
+});
+
+const external = (absolutePath: string): FileLocation => ({
+  kind: 'external',
+  absolutePath,
+});
+
+function outputFile(overrides: Partial<OutputFileInfo> = {}): OutputFileInfo {
+  return {
+    source: 'document',
+    location: workspace('out/main.pdf'),
+    round: 1,
+    lineage: null,
+    diff: null,
+    ...overrides,
+  };
+}
+
+function compileFailure(
+  overrides: Partial<CompileFailure> = {},
+): CompileFailure {
+  return {
+    round: 1,
+    displayName: 'main.tex',
+    output: workspace('out/main.pdf'),
+    log: workspace('logs/main.log'),
+    logRelativePath: 'logs/main.log',
+    ...overrides,
+  };
+}
+
+function roundOutput(overrides: Partial<RoundOutput> = {}): RoundOutput {
+  return {
+    round: 2,
+    rawOutput: null,
+    outputs: [],
+    compileFailures: [],
+    xmlSummary: {
+      tagContents: {},
+      documents: [],
+      singleOutputFile: null,
+      sourceLocation: null,
+    },
+    ...overrides,
+  };
+}
+
+describe('output summary transforms', () => {
+  it('projects rich output metadata to the flattened summary shape', () => {
+    const summary = OutputFileSummaryFromInfoSchema.parse(
+      outputFile({
+        lineage: {
+          original: workspace('src/main.tex', '/workspace/src/main.tex'),
+          diffBase: workspace(
+            'snapshots/main.tex',
+            '/run/r1/original/main.tex',
+          ),
+          diffFile: null,
+        },
+        diff: { added: 7, removed: 3 },
+      }),
+    );
+
+    expect(summary).toEqual({
+      round: 1,
+      relativePath: 'out/main.pdf',
+      absolutePath: '/workspace/out/main.pdf',
+      location: 'workspace',
+      originalPath: '/run/r1/original/main.tex',
+      added: 7,
+      removed: 3,
+    });
+  });
+
+  it('falls back to the absolute path for external output locations', () => {
+    const summary = OutputFileSummaryFromInfoSchema.parse(
+      outputFile({
+        location: external('/tmp/main.pdf'),
+      }),
+    );
+
+    expect(summary.relativePath).toBe('/tmp/main.pdf');
+    expect(summary.absolutePath).toBe('/tmp/main.pdf');
+    expect(summary.location).toBe('external');
+  });
+
+  it('uses the round output round for persisted output summaries', () => {
+    const summaries = roundOutputsToOutputSummaries([
+      roundOutput({
+        round: 4,
+        outputs: [outputFile({ round: 99 })],
+      }),
+    ]);
+
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]?.round).toBe(4);
+  });
+
+  it('projects compile failures to flattened paths', () => {
+    const workspaceSummary = CompileFailureSummaryFromFailureSchema.parse(
+      compileFailure({
+        output: workspace('build/main.pdf', '/workspace/build/main.pdf'),
+      }),
+    );
+    const externalSummary = CompileFailureSummaryFromFailureSchema.parse(
+      compileFailure({
+        output: external('/tmp/main.pdf'),
+      }),
+    );
+
+    expect(workspaceSummary.outputPath).toBe('build/main.pdf');
+    expect(workspaceSummary.logPath).toBe('logs/main.log');
+    expect(workspaceSummary.logAbsolutePath).toBe('/workspace/logs/main.log');
+    expect(externalSummary.outputPath).toBe('/tmp/main.pdf');
+  });
+
+  it('projects compile failures from round outputs', () => {
+    const summaries = roundOutputsToCompileFailureSummaries([
+      roundOutput({
+        compileFailures: [compileFailure({ round: 3 })],
+      }),
+    ]);
+
+    expect(summaries).toEqual([
+      {
+        round: 3,
+        displayName: 'main.tex',
+        outputPath: 'out/main.pdf',
+        logPath: 'logs/main.log',
+        logAbsolutePath: '/workspace/logs/main.log',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Moves workflow output and compile-failure summary projection out of `executeAgent.ts` and into schema-owned transforms beside the rich output schemas. `executeAgent` now asks `output.ts` to derive the flattened workflow result summaries from `RoundOutput[]`, preserving the existing persisted and CLI-visible summary format.

## Issue acceptance gates

- Addresses #7067: output and compile-failure summaries are now produced through Zod transform schemas derived from `OutputFileInfoSchema` and `CompileFailureSchema`.
- The manual field-by-field mapper functions in `executeAgent.ts` were deleted.
- Persisted/consumer summary schemas remain the validation surface for existing `AgentFlowResult` and result-meta readers.
- Added focused tests for round override, external path fallback, diff-base original precedence, and compile-failure path selection.

## Single source of truth

`src/shared/schemas/output.ts` now owns the rich-to-summary projection through `OutputFileSummaryFromInfoSchema`, `CompileFailureSummaryFromFailureSchema`, `roundOutputsToOutputSummaries`, and `roundOutputsToCompileFailureSummaries`.

## Duplication and abstraction budget

Deleted the duplicated projection logic from `executeAgent.ts`; the transform rules now live with the schemas they project from and validate back through the flattened summary schemas. No shim, alias, fallback, dual-write, or migration path was introduced. This refactor is net-positive only because the added mass is focused regression coverage in `OutputSummaryTransforms.vitest.ts`.

## Host impact

Extension: No user-facing behavior change; completed workflow output summaries keep the same flattened shape.

Desktop: No user-facing behavior change; desktop receives the same workflow result summaries.

CLI: No output contract change; `texra run`, `--print`, and JSON output keep the same summary fields.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write src/shared/schemas/output.ts src/agent/runtime/executeAgent.ts src/test-kernel/schemas/OutputSummaryTransforms.vitest.ts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/schemas/OutputSummaryTransforms.vitest.ts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/schemas/OutputSummaryTransforms.vitest.ts src/test-kernel/cli/WorkflowOutputResolution.vitest.mts src/test-kernel/cli/WorkflowRunCommand.vitest.mts src/test-kernel/cli/History.vitest.mts src/test-kernel/tools/SubagentResults.vitest.ts`
- `npm run typecheck`
- `npm run lint` (passes with the existing 15 warnings)
- `npm run compile:fast`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `npm test`
- `git diff --check`

Closes #7067