### PR TITLE
Consolidate latexdiff diff result schemas

### DIFF
--- a/src/shared/schemas/diffResult.ts
+++ b/src/shared/schemas/diffResult.ts
@@ -28,8 +28,7 @@ export const DiffResultSchema = DiffMetadataSchema.extend({
 
 export type DiffResult = z.infer<typeof DiffResultSchema>;
 
-/** Flattened display data for rendering latexdiff entries */
-export const DiffResultDisplaySchema = DiffMetadataSchema.extend({
+const DiffResultDisplayShapeSchema = DiffMetadataSchema.extend({
   baseFile: z.string(),
   revisedFile: z.string(),
   diffFile: z.string(),
@@ -38,7 +37,28 @@ export const DiffResultDisplaySchema = DiffMetadataSchema.extend({
   revisedRound: z.number(),
 });
 
-export type DiffResultDisplay = z.infer<typeof DiffResultDisplaySchema>;
+export type DiffResultDisplay = z.infer<typeof DiffResultDisplayShapeSchema>;
+
+function diffResultToDisplay(entry: DiffResult): DiffResultDisplay {
+  return DiffResultDisplayShapeSchema.parse({
+    baseFile: getAbsolutePath(entry.baseLocation),
+    revisedFile: getAbsolutePath(entry.revised.location),
+    diffFile: getAbsolutePath(entry.diffLocation),
+    displayName: getDisplayName(entry.revised, entry.baseLocation),
+    baseRound: entry.baseRound,
+    revisedRound: entry.revised.round,
+    status: entry.status,
+    message: entry.message,
+    runId: entry.runId,
+  });
+}
+
+/**
+ * Transform canonical latexdiff entries into flattened display entries for the
+ * progress view. Use {@link DiffResultDisplay} for the output shape.
+ */
+export const DiffResultDisplaySchema =
+  DiffResultSchema.transform(diffResultToDisplay);
 
 function getAbsolutePath(location: FileLocation | null): string {
   return location?.absolutePath ?? '';
@@ -70,20 +90,6 @@ function getDisplayName(
   return 'unknown';
 }
 
-function transformDiffResultToDisplay(entry: DiffResult): DiffResultDisplay {
-  return {
-    baseFile: getAbsolutePath(entry.baseLocation),
-    revisedFile: getAbsolutePath(entry.revised.location),
-    diffFile: getAbsolutePath(entry.diffLocation),
-    displayName: getDisplayName(entry.revised, entry.baseLocation),
-    baseRound: entry.baseRound,
-    revisedRound: entry.revised.round,
-    status: entry.status,
-    message: entry.message,
-    runId: entry.runId,
-  };
-}
-
 const LegacyLocationSchema = z.looseObject({
   absolutePath: z.string().optional(),
 });
@@ -103,75 +109,113 @@ function parseRoundFromLabel(label: string | undefined): number | null {
   return match ? Number.parseInt(match[1], 10) : null;
 }
 
-/** Legacy DiffResult format - transforms to DiffResultDisplay on parse */
-export const LegacyDiffResultSchema = z
-  .object({
-    locations: LegacyLocationsSchema,
-    basePath: z.string().optional(),
-    revisedPath: z.string().optional(),
-    diffPath: z.string().optional(),
-    baseLabel: z.string().optional(),
-    revisedLabel: z.string().optional(),
-    baseRound: z.number().optional(),
-    revisedRound: z.number().optional(),
-    originalFileName: z.string().optional(),
-    status: z.string().optional(),
-    message: z.string().optional(),
-    runId: z.string().optional(),
-  })
-  .transform((entry): DiffResultDisplay => {
-    // Extract file paths with fallbacks
-    const baseFile =
-      entry.locations?.base?.absolutePath ?? entry.basePath ?? '';
-    const revisedFile =
-      entry.locations?.revised?.absolutePath ?? entry.revisedPath ?? '';
-    const diffFile =
-      entry.locations?.diff?.absolutePath ?? entry.diffPath ?? '';
+const LegacyDiffResultInputBaseSchema = z.looseObject({
+  locations: LegacyLocationsSchema,
+  basePath: z.string().optional(),
+  revisedPath: z.string().optional(),
+  diffPath: z.string().optional(),
+  baseLabel: z.string().optional(),
+  revisedLabel: z.string().optional(),
+  baseRound: z.number().optional(),
+  revisedRound: z.number().optional(),
+  originalFileName: z.string().optional(),
+  status: z.string().optional(),
+  message: z.string().optional(),
+  runId: z.string().optional(),
+});
 
-    // Extract rounds from fields or labels
-    const baseRound =
-      entry.baseRound ?? parseRoundFromLabel(entry.baseLabel) ?? null;
-    const revisedRound =
-      entry.revisedRound ?? parseRoundFromLabel(entry.revisedLabel) ?? 0;
+type LegacyDiffResultInput = z.infer<typeof LegacyDiffResultInputBaseSchema>;
 
-    // Determine display name: originalFileName > stripped label > basename
-    let displayName = entry.originalFileName ?? '';
-    if (!displayName && entry.baseLabel) {
-      displayName = entry.baseLabel.replace(/\s*\[r\d+\]/, '');
-    }
-    if (!displayName && baseFile) {
-      displayName = getBasename(baseFile) || 'unknown';
-    }
-    if (!displayName) {
-      displayName = 'unknown';
-    }
+function hasLegacyDiffIdentity(entry: LegacyDiffResultInput): boolean {
+  return Boolean(
+    entry.locations?.base?.absolutePath ||
+    entry.locations?.revised?.absolutePath ||
+    entry.locations?.diff?.absolutePath ||
+    entry.basePath ||
+    entry.revisedPath ||
+    entry.diffPath ||
+    entry.baseLabel ||
+    entry.originalFileName,
+  );
+}
 
-    return {
-      baseFile,
-      revisedFile,
-      diffFile,
-      displayName,
-      baseRound,
-      revisedRound,
-      status:
-        entry.status === 'success' || entry.status === 'error'
-          ? entry.status
-          : 'error',
-      message: entry.message,
-      runId: entry.runId,
-    };
+const LegacyDiffResultInputSchema = LegacyDiffResultInputBaseSchema.refine(
+  hasLegacyDiffIdentity,
+);
+
+function externalLocation(absolutePath: string): FileLocation {
+  return { kind: 'external', absolutePath };
+}
+
+function nullableExternalLocation(
+  absolutePath: string | undefined,
+): FileLocation | null {
+  return absolutePath ? externalLocation(absolutePath) : null;
+}
+
+function legacyDisplayName(entry: LegacyDiffResultInput): string {
+  if (entry.originalFileName) return entry.originalFileName;
+  if (entry.baseLabel) return entry.baseLabel.replace(/\s*\[r\d+\]/, '');
+  return '';
+}
+
+function legacyPath(
+  location: { absolutePath?: string } | undefined,
+  fallback: string | undefined,
+): string {
+  return location?.absolutePath ?? fallback ?? '';
+}
+
+function legacyDiffResultToCanonical(entry: LegacyDiffResultInput): DiffResult {
+  const baseFile = legacyPath(entry.locations?.base, entry.basePath);
+  const revisedFile = legacyPath(entry.locations?.revised, entry.revisedPath);
+  const diffFile = legacyPath(entry.locations?.diff, entry.diffPath);
+  const baseRound =
+    entry.baseRound ?? parseRoundFromLabel(entry.baseLabel) ?? null;
+  const revisedRound =
+    entry.revisedRound ?? parseRoundFromLabel(entry.revisedLabel) ?? 0;
+  const originalDisplayName = legacyDisplayName(entry);
+
+  return DiffResultSchema.parse({
+    baseLocation: nullableExternalLocation(baseFile),
+    baseRound,
+    revised: {
+      source: revisedFile,
+      location: externalLocation(revisedFile),
+      round: revisedRound,
+      lineage: {
+        original: nullableExternalLocation(originalDisplayName),
+        diffBase: nullableExternalLocation(baseFile),
+        diffFile: nullableExternalLocation(diffFile),
+      },
+      diff: null,
+    },
+    diffLocation: nullableExternalLocation(diffFile),
+    status:
+      entry.status === 'success' || entry.status === 'error'
+        ? entry.status
+        : 'error',
+    message: entry.message,
+    runId: entry.runId,
   });
+}
+
+const LegacyDiffResultDisplaySchema = LegacyDiffResultInputSchema.transform(
+  (entry): DiffResultDisplay => {
+    const display = diffResultToDisplay(legacyDiffResultToCanonical(entry));
+    const displayName = legacyDisplayName(entry);
+    return displayName ? { ...display, displayName } : display;
+  },
+);
+
+const DiffResultEntrySchema = z.union([
+  DiffResultDisplaySchema,
+  LegacyDiffResultDisplaySchema,
+]);
 
 /** Parse a diff result entry from either new or legacy format, or null if neither matches. */
 function parseDiffResultEntry(data: unknown): DiffResultDisplay | null {
-  // Try new format first (canonical)
-  const newResult = DiffResultSchema.safeParse(data);
-  if (newResult.success) {
-    return transformDiffResultToDisplay(newResult.data);
-  }
-
-  // Try legacy format (transforms to display)
-  return LegacyDiffResultSchema.nullable().catch(null).parse(data);
+  return DiffResultEntrySchema.nullable().catch(null).parse(data);
 }
 
 /** Parse an array of diff result entries, skipping invalid ones */

--- a/src/test-kernel/schemas/DiffResultTransforms.vitest.ts
+++ b/src/test-kernel/schemas/DiffResultTransforms.vitest.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DiffResultDisplaySchema,
+  parseDiffResultEntries,
+} from '@shared/schemas';
+
+const canonicalDiffResult = {
+  status: 'success',
+  runId: 'abcdef',
+  baseLocation: {
+    kind: 'workspace',
+    absolutePath: '/repo/main.tex',
+    relativePath: 'main.tex',
+  },
+  baseRound: 1,
+  revised: {
+    source: 'main.tex',
+    location: {
+      kind: 'runStorage',
+      absolutePath: '/tmp/texra/abcdef/r2/main.tex',
+      relativePath: 'r2/main.tex',
+      executionId: 'abcdef',
+    },
+    round: 2,
+    lineage: {
+      original: {
+        kind: 'workspace',
+        absolutePath: '/repo/src/main.tex',
+        relativePath: 'src/main.tex',
+      },
+      diffBase: {
+        kind: 'workspace',
+        absolutePath: '/repo/main.tex',
+        relativePath: 'main.tex',
+      },
+      diffFile: {
+        kind: 'external',
+        absolutePath: '/tmp/texra/abcdef/diff/main-diff.tex',
+      },
+    },
+    diff: null,
+  },
+  diffLocation: {
+    kind: 'external',
+    absolutePath: '/tmp/texra/abcdef/diff/main-diff.tex',
+  },
+} as const;
+
+describe('DiffResult transforms', () => {
+  it('derives display data from the canonical schema', () => {
+    expect(DiffResultDisplaySchema.parse(canonicalDiffResult)).toEqual({
+      baseFile: '/repo/main.tex',
+      revisedFile: '/tmp/texra/abcdef/r2/main.tex',
+      diffFile: '/tmp/texra/abcdef/diff/main-diff.tex',
+      displayName: 'main.tex',
+      baseRound: 1,
+      revisedRound: 2,
+      status: 'success',
+      message: undefined,
+      runId: 'abcdef',
+    });
+  });
+
+  it('parses canonical entries through the public parser', () => {
+    expect(parseDiffResultEntries([canonicalDiffResult])).toEqual([
+      {
+        baseFile: '/repo/main.tex',
+        revisedFile: '/tmp/texra/abcdef/r2/main.tex',
+        diffFile: '/tmp/texra/abcdef/diff/main-diff.tex',
+        displayName: 'main.tex',
+        baseRound: 1,
+        revisedRound: 2,
+        status: 'success',
+        message: undefined,
+        runId: 'abcdef',
+      },
+    ]);
+  });
+
+  it('normalizes legacy entries through the canonical transform path', () => {
+    const [entry] = parseDiffResultEntries([
+      {
+        locations: {
+          base: { absolutePath: '/repo/current/main.tex' },
+          revised: { absolutePath: '/repo/current/main-revised.tex' },
+          diff: { absolutePath: '/repo/current/main-diff.tex' },
+        },
+        basePath: '/repo/stale/base.tex',
+        revisedPath: '/repo/stale/revised.tex',
+        diffPath: '/repo/stale/diff.tex',
+        baseLabel: 'main.tex [r4]',
+        revisedLabel: '[r5]',
+        originalFileName: 'original-main.tex',
+        status: 'success',
+        message: 'generated',
+        runId: 'legacy-run',
+      },
+    ]);
+
+    expect(entry).toEqual({
+      baseFile: '/repo/current/main.tex',
+      revisedFile: '/repo/current/main-revised.tex',
+      diffFile: '/repo/current/main-diff.tex',
+      displayName: 'original-main.tex',
+      baseRound: 4,
+      revisedRound: 5,
+      status: 'success',
+      message: 'generated',
+      runId: 'legacy-run',
+    });
+  });
+
+  it('preserves legacy status fallback and explicit round precedence', () => {
+    const [entry] = parseDiffResultEntries([
+      {
+        basePath: '/repo/base.tex',
+        revisedPath: '/repo/revised.tex',
+        diffPath: '/repo/diff.tex',
+        baseLabel: 'base-label.tex [r1]',
+        revisedLabel: '[r2]',
+        baseRound: 7,
+        revisedRound: 8,
+        status: 'unknown',
+      },
+    ]);
+
+    expect(entry).toMatchObject({
+      baseFile: '/repo/base.tex',
+      revisedFile: '/repo/revised.tex',
+      diffFile: '/repo/diff.tex',
+      displayName: 'base-label.tex',
+      baseRound: 7,
+      revisedRound: 8,
+      status: 'error',
+    });
+  });
+
+  it('preserves path-qualified legacy display labels verbatim', () => {
+    const entries = parseDiffResultEntries([
+      {
+        basePath: '/repo/base.tex',
+        revisedPath: '/repo/revised.tex',
+        originalFileName: 'chapters/intro.tex',
+      },
+      {
+        basePath: '/repo/base.tex',
+        revisedPath: '/repo/revised.tex',
+        baseLabel: 'sections/method.tex [r3]',
+      },
+    ]);
+
+    expect(entries.map((entry) => entry.displayName)).toEqual([
+      'chapters/intro.tex',
+      'sections/method.tex',
+    ]);
+  });
+
+  it('falls back to the base filename for legacy display names', () => {
+    const [entry] = parseDiffResultEntries([
+      {
+        basePath: '/repo/fallback.tex',
+        revisedPath: '/repo/revised.tex',
+      },
+    ]);
+
+    expect(entry?.displayName).toBe('fallback.tex');
+    expect(entry?.baseRound).toBeNull();
+    expect(entry?.revisedRound).toBe(0);
+  });
+
+  it('skips invalid non-object entries', () => {
+    expect(parseDiffResultEntries([null, 'not an entry', 1])).toEqual([]);
+  });
+
+  it('skips invalid object entries without diff-result fields', () => {
+    expect(
+      parseDiffResultEntries([{}, { foo: 'bar' }, { revisedLabel: '[r5]' }]),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Consolidates latexdiff result parsing so the canonical `DiffResultSchema` owns the backend shape and `DiffResultDisplaySchema` is derived from it through a Zod transform. Legacy latexdiff payloads are normalized into the canonical shape inside the parser union before display projection, preserving the existing progress-view rendering contract for entries with file identity.

Malformed legacy objects that carry no file identity are now skipped instead of rendering empty-path `unknown` rows; this includes `revisedLabel`-only objects, where the label only encodes a round number.

## Issue acceptance gates

- Addresses #7068: `DiffResultDisplaySchema` is now derived from `DiffResultSchema` instead of being a standalone public display schema.
- The hand-written `transformDiffResultToDisplay()` mapper was removed.
- The separate exported `LegacyDiffResultSchema` display parser was folded into the canonical union/transform parser path.
- `parseDiffResultEntries()` remains the public UI-facing parser and keeps canonical-first parsing with legacy compatibility.
- Added focused tests for canonical projection, legacy path precedence, round extraction, status fallback, display-name fallback, and invalid non-object/object skipping.

## Single source of truth

`src/shared/schemas/diffResult.ts` now uses `DiffResultSchema` as the canonical latexdiff result shape. Display entries are produced by `DiffResultDisplaySchema`, a transform over that canonical schema.

## Duplication and abstraction budget

Deleted the duplicated manual canonical-to-display mapper and removed the separately exported legacy display parser. The remaining legacy branch is the existing backward-compat read path refactored to normalize into the canonical schema, not a new shim or migration path. This refactor is net-positive only because the added mass is focused regression coverage in `DiffResultTransforms.vitest.ts`.

## Host impact

Extension: Valid progress-view latexdiff entries keep the same flattened display fields. Malformed legacy entries with no file identity are intentionally omitted instead of rendering empty `unknown` rows.

Desktop: Same as extension; desktop progress rendering receives the same latexdiff display entries for valid payloads and skips malformed no-identity legacy entries.

CLI: No output contract change; this parser is for progress-view latexdiff rendering, and CLI run output is unchanged.

## Scheduled refactoring

None. No #6981 ledger row is needed because this PR does not introduce a new compatibility shim, projection layer, dual-write, alias, fallback, or migration path; it refactors the existing legacy parser into the canonical path.

## Validation

- `corepack pnpm exec prettier --write src/shared/schemas/diffResult.ts src/test-kernel/schemas/DiffResultTransforms.vitest.ts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/schemas/DiffResultTransforms.vitest.ts`
- `npm run typecheck`
- `npm run lint` (passes with the existing 15 warnings)
- `npm run compile:fast`
- `npm test`
- `git diff --check`
- `corepack pnpm --filter @texra-ai/cli validate:run` not run; this PR does not touch runtime or CLI output paths.

Closes #7068
