### PR TITLE
test(webview): characterize MainApp persistence/restore behavior

### DIFF
--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -6,35 +6,12 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/details/details.js';
 import '@awesome.me/webawesome/dist/components/divider/divider.js';
 import { COMMON_COMMANDS, MAIN_VIEW_COMMANDS } from '@shared/ipc';
-import {
-  buildMainViewExecuteMessage,
-  planCompare,
-  planLatexdiff,
-  planLatexdiffVC,
-  planLatexdiffVCPack,
-  planMerge,
-  planPackClean,
-  type MainViewExecuteMessage,
-} from '@shared/mainView';
-import { SignalWatcher, signal, Signal } from '@shared/signals';
+import { SignalWatcher } from '@shared/signals';
 import { BaseWebviewApp } from '@shared/BaseWebviewApp';
-import { hostBridge, postMessage } from '@shared/hostBridge';
-import { PersistedState, createWebviewStorage } from '@shared/state';
+import { postMessage } from '@shared/hostBridge';
 import { designTokens, commonViewStyles, viewTabStyles } from '@shared/styles';
 import {
-  mainViewMessages,
-  MainViewPersistedStateSchema,
-  type MainViewMessage,
-  type MainViewPersistedState,
-  type ApiKeyBannerState,
-  type AgentConfigBannerState,
-  type DependencyBannerState,
-  type ModelOptionData,
-  type AgentOptionData,
-  type SingleFiles,
-  type FileOptions,
-  type MultiFiles,
-  type CheckboxValues,
+  dispatchMainView,
   type ActionDetail,
   type AgentChangeDetail,
   type BannerActionDetail,
@@ -52,25 +29,18 @@ import {
   type ModelChangeDetail,
   type MultipleFilesActionDetail,
   type MultipleFilesTypeActionDetail,
-  type OnboardingFunnelState,
   type ReorderFilesDetail,
   type RemoveFileDetail,
   type SessionTypeChangeDetail,
-  dispatchMainView,
-  type MainViewHandlerRegistry,
 } from '@shared/schemas';
-import { PREFERRED_TOOL_USE_AGENTS } from '@shared/constants/agents';
-// Constants-only module: safe for the webview bundle (no platform imports).
 import {
   registerTeXRAWebAwesomeIcons,
   waIcon,
 } from '@shared/wa/webAwesomeIcons';
 import type { StateRestoreMessage } from '@shared/schemas/commonViewMessages';
-import { agentName } from '@shared/schemas/agent';
 import { renderViewHeader } from '@shared/wa/viewHeader';
 import type { MutableWaTabGroup, WaTabShowEvent } from '@shared/wa/tabs';
 import '@shared/wa/tabs';
-import { unique } from '@utils/core';
 
 import './components/FileSelectGroup';
 import './components/BannerGroup';
@@ -78,67 +48,69 @@ import './components/LatexDiffsSection';
 import './components/InstructionPanel';
 import './components/OnboardingWelcomeCard';
 import './components/OnboardingSetupCard';
+import { SESSION_TYPES, type DocumentFileType } from './constants';
 import {
-  DOCUMENT_FILE_TYPES,
-  MULTIPLE_DOCUMENT_FILE_TYPES,
-  SESSION_TYPES,
-  type DocumentFileType,
-  type MultipleDocumentFileType,
-  type SessionType,
-  parseSessionType,
-} from './constants';
-import {
+  agentConfigBanner$,
+  apiKeyBanner$,
+  commit$,
+  debugMode$,
+  dependencyBanner$,
+  fileOptions$,
+  fileSelectionOpen$,
   fileStateContext,
+  fileStateContext$,
+  gettingStartedDismissed$,
+  gettingStartedVisible$,
+  isGitRepo$,
+  latexdiffsVisible$,
+  loginBannerVisible$,
+  onboardingFunnelState$,
+  resetMainViewState,
   sessionContext,
+  sessionContext$,
+  sessionHintDismissed$,
+  sessionType$,
+  singleFiles$,
   type FileStateContextValue,
   type SessionContextValue,
-} from './contexts/mainViewContexts';
-import { SESSION_DEFAULTS } from './sessionDefaults';
+} from './mainViewState';
 import {
-  DEFAULT_STATE,
-  DEFAULT_SINGLE_FILES,
-  DEFAULT_FILE_OPTIONS,
-  DEFAULT_MULTI_FILES,
-  DEFAULT_CHECKBOX_VALUES,
-  FILE_UPDATE_COMMANDS,
-  MULTI_FILE_COMMAND_TO_KEY,
-  ONBOARDING_PLACEHOLDERS,
-  FILE_SELECT_CONFIGS,
-} from './store';
+  addOpenedFiles,
+  changeAgent,
+  changeModel,
+  changeSessionType,
+  emptyFile,
+  emptyFiles,
+  executeAgent,
+  getCurrentFile,
+  refreshEditedFiles,
+  refreshInstructionPlaceholder,
+  removeFile,
+  runAgentConfigAction,
+  runApiKeyBannerAction,
+  runLatexDiffsAction,
+  runPanelAction,
+  selectMultipleFiles,
+  setBaseFile,
+  setCommit,
+  setEditedFile,
+  setInstruction,
+  updateCheckboxValue,
+  updateMultiFiles,
+} from './mainViewActions';
+import {
+  flushPendingInstructionSave,
+  handleRestoreState,
+  resetPersistenceRuntime,
+  restorePersistedState,
+  saveState,
+  scheduleInstructionSave,
+} from './persistence';
+import { mainViewMessageHandlers } from './messageDispatcher';
+import { FILE_SELECT_CONFIGS } from './store';
 import { mainViewStyles } from './styles';
 
 registerTeXRAWebAwesomeIcons();
-
-type WebviewOnboardingFunnelState = OnboardingFunnelState | 'pending';
-
-// Helper type for extracting specific message type from union
-type MainViewMessageFor<C extends MainViewMessage['command']> = Extract<
-  MainViewMessage,
-  { command: C }
->;
-
-type SetEditedFileOptionsMessage = MainViewMessageFor<
-  typeof MAIN_VIEW_COMMANDS.SET_EDITED_FILE
->;
-
-type EditedFileSelectedMessage = MainViewMessageFor<
-  typeof MAIN_VIEW_COMMANDS.EDITED_FILE_SELECTED
->;
-
-type SetMultipleFilesMessage =
-  | MainViewMessageFor<typeof MAIN_VIEW_COMMANDS.SET_INPUT_FILES>
-  | MainViewMessageFor<typeof MAIN_VIEW_COMMANDS.SET_CONTEXT_FILES>
-  | MainViewMessageFor<typeof MAIN_VIEW_COMMANDS.SET_MEDIA_FILES>
-  | MainViewMessageFor<typeof MAIN_VIEW_COMMANDS.SET_OUTPUT_FILES>;
-
-type MainActionPlan =
-  | { readonly valid: false; readonly message: string }
-  | {
-      readonly valid: true;
-      readonly command: string;
-      readonly payload: Record<string, unknown>;
-      readonly infoText?: string;
-    };
 
 // Cast: BaseWebviewApp is abstract, but SignalWatcher expects a concrete constructor.
 // Safe because MainApp implements all abstract members below.
@@ -157,250 +129,62 @@ export class MainApp extends MainAppBase {
     mainViewStyles,
   ];
 
-  private readonly sessionType = signal<SessionType>(DEFAULT_STATE.sessionType);
-  private readonly workflowAgent = signal(DEFAULT_STATE.workflowAgent);
-  private readonly toolUseAgent = signal(DEFAULT_STATE.toolUseAgent);
-  private readonly model = signal(DEFAULT_STATE.model);
-  private readonly commit = signal(DEFAULT_STATE.commit);
-  private readonly instruction = signal(DEFAULT_STATE.instruction);
-  private readonly workflowInstruction = signal(
-    DEFAULT_STATE.workflowInstruction,
-  );
-  private readonly toolUseInstruction = signal(
-    DEFAULT_STATE.toolUseInstruction,
-  );
-  private readonly singleFiles = signal<SingleFiles>({
-    ...DEFAULT_SINGLE_FILES,
-  });
-  private readonly fileOptions = signal<FileOptions>({
-    ...DEFAULT_FILE_OPTIONS,
-  });
-  private readonly multiFiles = signal<MultiFiles>({ ...DEFAULT_MULTI_FILES });
-  private readonly outputFilesActive = signal(DEFAULT_STATE.outputFilesActive);
-  private readonly latexdiffsVisible = signal(DEFAULT_STATE.latexdiffsVisible);
-  private readonly checkboxValues = signal<CheckboxValues>({
-    ...DEFAULT_CHECKBOX_VALUES,
-  });
-  // Tracks whether the workflow Files <wa-details> is open. Initialized to
-  // match the initial session type and updated imperatively from
-  // wa-show/wa-hide so user toggles survive across re-renders. Without this,
-  // binding `?open=${isWorkflow}` would force the section open on every render
-  // pass, defeating user collapses.
-  private readonly fileSelectionOpen = signal(
-    DEFAULT_STATE.sessionType === SESSION_TYPES.WORKFLOW,
-  );
-  private readonly isRecording = signal(false);
-  private readonly isPolishing = signal(false);
-  private readonly modelOptions = signal<ModelOptionData[]>([]);
-  private readonly workflowModelOptions = signal<ModelOptionData[] | undefined>(
-    undefined,
-  );
-  private readonly toolUseModelOptions = signal<ModelOptionData[] | undefined>(
-    undefined,
-  );
-  private readonly workflowAgentOptions = signal<AgentOptionData[]>([]);
-  private readonly toolUseAgentOptions = signal<AgentOptionData[]>([]);
-  private readonly apiKeyBanner = signal<ApiKeyBannerState>({ visible: false });
-  private readonly agentConfigBanner = signal<AgentConfigBannerState>({
-    visible: false,
-  });
-  private readonly dependencyBanner = signal<DependencyBannerState>({
-    visible: false,
-  });
-  private readonly gettingStartedVisible = signal(false);
-  // Session-only: the host re-sends SHOW_GETTING_STARTED_BANNER on file
-  // refreshes, so dismissal is tracked separately and never persisted.
-  private readonly gettingStartedDismissed = signal(false);
-  private readonly sessionHintDismissed = signal(true);
-  private readonly loginBannerVisible = signal(false);
-  // Onboarding funnel (PRD: agent-native onboarding). The host owns the real
-  // state; 'pending' only suppresses first-paint launcher/welcome flashes until
-  // SET_ONBOARDING_FUNNEL arrives.
-  private readonly onboardingFunnelState =
-    signal<WebviewOnboardingFunnelState>('pending');
-  private readonly instructionPlaceholder = signal(
-    ONBOARDING_PLACEHOLDERS[DEFAULT_STATE.sessionType][0],
-  );
   @state() protected override debugMode = false;
   @state() private mocksGalleryLoaded = false;
-  private readonly isGitRepo = signal(true);
-  private instructionSaveTimer: number | null = null;
-
-  private readonly fileStateContext$ = new Signal.Computed(
-    (): FileStateContextValue => ({
-      sessionType: this.sessionType.get(),
-      checkboxValues: this.checkboxValues.get(),
-      singleFiles: this.singleFiles.get(),
-      fileOptions: this.fileOptions.get(),
-      multiFiles: this.multiFiles.get(),
-      outputFilesActive: this.outputFilesActive.get(),
-    }),
-  );
-
-  private readonly sessionContext$ = new Signal.Computed(
-    (): SessionContextValue => ({
-      sessionType: this.sessionType.get(),
-      instruction: this.instruction.get(),
-      placeholder: this.instructionPlaceholder.get(),
-      workflowAgent: this.workflowAgent.get(),
-      toolUseAgent: this.toolUseAgent.get(),
-      model: this.model.get(),
-      workflowAgentOptions: this.workflowAgentOptions.get(),
-      toolUseAgentOptions: this.toolUseAgentOptions.get(),
-      modelOptions: this.getModelOptionsForSession(this.sessionType.get()),
-      isRecording: this.isRecording.get(),
-      isPolishing: this.isPolishing.get(),
-      debugMode: this.debugMode,
-    }),
-  );
 
   @provide({ context: fileStateContext })
   @state()
-  private fileStateContextValue: FileStateContextValue =
-    this.fileStateContext$.get();
+  private fileStateContextValue: FileStateContextValue;
 
   @provide({ context: sessionContext })
   @state()
-  private sessionContextValue: SessionContextValue = this.sessionContext$.get();
+  private sessionContextValue: SessionContextValue;
 
-  private readonly stateManager = new PersistedState(
-    createWebviewStorage(hostBridge),
-    'mainViewState',
-    MainViewPersistedStateSchema,
-  );
-  private saveBlockCount = 0;
-
-  private readonly messageHandlers: MainViewHandlerRegistry = {
-    [MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS]: (data) =>
-      this.handleSetModelOptions(data),
-    [MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS]: (data) =>
-      this.handleSetAgentOptions(data),
-
-    [MAIN_VIEW_COMMANDS.SET_EDITED_FILE]: (data) =>
-      this.handleSetEditedFileOptions(data),
-    [MAIN_VIEW_COMMANDS.SET_BASE_FILE]: (data) => this.handleSetBaseFile(data),
-
-    [MAIN_VIEW_COMMANDS.EDITED_FILE_SELECTED]: (data) =>
-      this.handleEditedFileSelected(data),
-
-    [MAIN_VIEW_COMMANDS.SET_INPUT_FILES]: (data) =>
-      this.handleSetMultipleFiles(data),
-    [MAIN_VIEW_COMMANDS.SET_CONTEXT_FILES]: (data) =>
-      this.handleSetMultipleFiles(data),
-    [MAIN_VIEW_COMMANDS.SET_MEDIA_FILES]: (data) =>
-      this.handleSetMultipleFiles(data),
-    [MAIN_VIEW_COMMANDS.SET_OUTPUT_FILES]: (data) =>
-      this.handleSetMultipleFiles(data),
-    [MAIN_VIEW_COMMANDS.ADD_MEDIA_FILE]: (data) =>
-      this.handleAddMediaFile(data),
-
-    [MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS]: (data) =>
-      this.handleSetRecentCommits(data),
-    [MAIN_VIEW_COMMANDS.SET_CURRENT_FILE]: (data) =>
-      this.handleSetCurrentFile(data),
-    [MAIN_VIEW_COMMANDS.SET_SELECTED_COMMIT]: (data) =>
-      this.handleSetSelectedCommit(data),
-    [MAIN_VIEW_COMMANDS.SET_OPENED_FILES]: (data) =>
-      this.handleSetOpenedFiles(data),
-
-    [MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_POLISHED]: (data) =>
-      this.handleInstructionTextPolished(data),
-    [MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_POLISH_ERROR]: (data) =>
-      this.handleInstructionTextPolishError(data),
-    [MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_TRANSCRIBED]: (data) =>
-      this.handleInstructionTextTranscribed(data),
-
-    [MAIN_VIEW_COMMANDS.RECORDING_STARTED]: () => {
-      this.isRecording.set(true);
-    },
-    [MAIN_VIEW_COMMANDS.RECORDING_STOPPED]: () => {
-      this.isRecording.set(false);
-    },
-    [MAIN_VIEW_COMMANDS.RECORDING_ERROR]: () => {
-      this.isRecording.set(false);
-    },
-
-    [MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER]: (data) =>
-      this.handleShowApiKeyBanner(data),
-    [MAIN_VIEW_COMMANDS.HIDE_API_KEY_BANNER]: () => {
-      if (this.shouldForceApiKeyBanner()) {
-        return;
-      }
-      this.apiKeyBanner.set({ visible: false });
-    },
-    [MAIN_VIEW_COMMANDS.SHOW_AGENT_CONFIG_BANNER]: (data) =>
-      this.handleShowAgentConfigBanner(data),
-    [MAIN_VIEW_COMMANDS.HIDE_AGENT_CONFIG_BANNER]: () => {
-      this.agentConfigBanner.set({ visible: false });
-    },
-    [MAIN_VIEW_COMMANDS.SHOW_DEPENDENCY_BANNER]: (data) =>
-      this.handleShowDependencyBanner(data),
-    [MAIN_VIEW_COMMANDS.HIDE_DEPENDENCY_BANNER]: () => {
-      this.dependencyBanner.set({ visible: false });
-    },
-    [MAIN_VIEW_COMMANDS.SHOW_GETTING_STARTED_BANNER]: () => {
-      this.gettingStartedVisible.set(true);
-    },
-    [MAIN_VIEW_COMMANDS.HIDE_GETTING_STARTED_BANNER]: () => {
-      this.gettingStartedVisible.set(false);
-    },
-    [MAIN_VIEW_COMMANDS.HIDE_ORCHESTRATOR_BANNER]: () => {
-      this.sessionHintDismissed.set(true);
-    },
-    [MAIN_VIEW_COMMANDS.SHOW_ORCHESTRATOR_BANNER]: () => {
-      this.sessionHintDismissed.set(false);
-    },
-    [MAIN_VIEW_COMMANDS.SHOW_LOGIN_BANNER]: () => {
-      this.loginBannerVisible.set(true);
-    },
-    [MAIN_VIEW_COMMANDS.HIDE_LOGIN_BANNER]: () => {
-      this.loginBannerVisible.set(false);
-    },
-
-    [MAIN_VIEW_COMMANDS.SET_SELECTED_AGENT]: (data) =>
-      this.handleSetSelectedAgent(data),
-
-    [MAIN_VIEW_COMMANDS.SET_ONBOARDING_FUNNEL]: (data) => {
-      this.onboardingFunnelState.set(data.state);
-    },
-  };
+  constructor() {
+    super();
+    // Per-mount slate: state and persistence runtime live at module scope
+    // (see mainViewState.ts), so a remount in the same JS context (tests,
+    // hot reload) must reset them like fresh instance fields used to.
+    resetMainViewState();
+    resetPersistenceRuntime();
+    this.fileStateContextValue = fileStateContext$.get();
+    this.sessionContextValue = sessionContext$.get();
+  }
 
   private readonly onLatexdiffGetCurrentFile =
-    this.detailHandler<FileActionDetail>(({ type }) =>
-      this.handleGetCurrentFile(type),
-    );
+    this.detailHandler<FileActionDetail>(({ type }) => getCurrentFile(type));
 
   private readonly onLatexdiffEmptyFile = this.detailHandler<FileActionDetail>(
-    ({ type }) => this.handleEmptyFile(type),
+    ({ type }) => emptyFile(type),
   );
 
   private readonly onAddOpenedFiles =
     this.detailHandler<MultipleFilesTypeActionDetail>(({ type }) => {
       if (type !== 'output') {
-        this.handleAddOpenedFiles(type as DocumentFileType);
+        addOpenedFiles(type as DocumentFileType);
       }
     });
 
   private readonly onEmptyFiles =
     this.detailHandler<MultipleFilesTypeActionDetail>(({ type }) =>
-      this.handleEmptyFiles(type),
+      emptyFiles(type),
     );
 
   private readonly onSelectMultipleFiles =
     this.detailHandler<MultipleFilesActionDetail>(({ listId }) =>
-      this.handleSelectMultipleFiles(listId),
+      selectMultipleFiles(listId),
     );
 
   private readonly onRemoveFile = this.detailHandler<RemoveFileDetail>(
-    ({ listId, file }) => this.handleRemoveFile(listId, file),
+    ({ listId, file }) => removeFile(listId, file),
   );
 
   private readonly onFilesReordered = this.detailHandler<ReorderFilesDetail>(
-    ({ listId, files }) => this.updateMultiFiles(listId, files),
+    ({ listId, files }) => updateMultiFiles(listId, files),
   );
 
   private readonly onCheckboxChange = this.detailHandler<CheckboxChangeDetail>(
-    ({ id, checked }) => this.updateCheckboxValue(id, checked),
+    ({ id, checked }) => updateCheckboxValue(id, checked),
   );
 
   private readonly onFocusInstruction =
@@ -410,16 +194,15 @@ export class MainApp extends MainAppBase {
     );
 
   private readonly onApiKeyAction = this.detailHandler<BannerActionDetail>(
-    ({ action }) => this.handleApiKeyBannerAction(action as 'set' | 'guide'),
+    ({ action }) => runApiKeyBannerAction(action as 'set' | 'guide'),
   );
 
   private readonly onAgentConfigAction = this.detailHandler<BannerActionDetail>(
-    ({ action }) =>
-      this.handleAgentConfigAction(action as 'edit' | 'dir' | 'docs'),
+    ({ action }) => runAgentConfigAction(action as 'edit' | 'dir' | 'docs'),
   );
 
   private readonly onDependencyDismiss = (): void => {
-    this.dependencyBanner.set({ visible: false });
+    dependencyBanner$.set({ visible: false });
   };
 
   private readonly onRecheckDependencies = this.commandHandler(
@@ -462,13 +245,13 @@ export class MainApp extends MainAppBase {
 
   private readonly onDismissLogin = (): void => {
     postMessage(MAIN_VIEW_COMMANDS.DISMISS_LOGIN_BANNER);
-    this.loginBannerVisible.set(false);
+    loginBannerVisible$.set(false);
   };
 
   private readonly onDismissGettingStarted = (): void => {
     // Session-only dismissal; the host setting still gates whether FileManager
     // shows the empty-folder banner in the first place.
-    this.gettingStartedDismissed.set(true);
+    gettingStartedDismissed$.set(true);
   };
 
   private readonly onGettingStartedAction =
@@ -479,42 +262,35 @@ export class MainApp extends MainAppBase {
 
   private readonly onDismissSessionHint = (): void => {
     postMessage(MAIN_VIEW_COMMANDS.DISMISS_ORCHESTRATOR_BANNER);
-    this.sessionHintDismissed.set(true);
+    sessionHintDismissed$.set(true);
   };
 
   private readonly onLatexDiffsToggle =
     this.detailHandler<LatexDiffsToggleDetail>(({ visible }) => {
-      this.latexdiffsVisible.set(visible);
-      this.saveState();
+      latexdiffsVisible$.set(visible);
+      saveState();
     });
 
   private readonly onLatexDiffsAction =
     this.detailHandler<LatexDiffsActionDetail>(({ action }) =>
-      this.runLatexDiffsAction(action),
+      runLatexDiffsAction(action),
     );
 
   private readonly onBaseFileChange = this.detailHandler<BaseFileChangeDetail>(
-    ({ value }) => this.handleBaseFileChange(value),
+    ({ value }) => setBaseFile(value),
   );
 
   private readonly onEditedFileChange =
-    this.detailHandler<EditedFileChangeDetail>(({ value }) => {
-      this.singleFiles.set({
-        ...this.singleFiles.get(),
-        editedFile: value,
-      });
-      this.saveState();
-    });
+    this.detailHandler<EditedFileChangeDetail>(({ value }) =>
+      setEditedFile(value),
+    );
 
   private readonly onCommitChange = this.detailHandler<CommitChangeDetail>(
-    ({ value }) => {
-      this.commit.set(value);
-      this.saveState();
-    },
+    ({ value }) => setCommit(value),
   );
 
   private readonly onRefreshEditedFiles = (): void => {
-    this.handleRefreshEditedFiles();
+    refreshEditedFiles();
   };
 
   private readonly onRefreshCommits = this.commandHandler(
@@ -523,38 +299,42 @@ export class MainApp extends MainAppBase {
 
   private readonly onSessionTypeChange =
     this.detailHandler<SessionTypeChangeDetail>(({ value }) =>
-      this.handleSessionTypeChange(value),
+      changeSessionType(value),
     );
 
   private readonly onAgentChange = this.detailHandler<AgentChangeDetail>(
-    ({ sessionType, value }) => this.handleAgentChange(sessionType, value),
+    ({ sessionType, value }) => changeAgent(sessionType, value),
   );
 
   private readonly onModelChange = this.detailHandler<ModelChangeDetail>(
-    ({ value }) => this.handleModelChange(value),
+    ({ value }) => changeModel(value),
   );
 
   private readonly onInstructionInput =
     this.detailHandler<InstructionChangeDetail>(({ value }) => {
-      this.setInstruction(value);
-      this.scheduleInstructionSave();
+      setInstruction(value);
+      scheduleInstructionSave();
     });
 
+  private readonly onInstructionPaste = (): void => {
+    saveState();
+  };
+
   private readonly onPanelAction = this.detailHandler<ActionDetail>(
-    ({ action }) => this.runPanelAction(action),
+    ({ action }) => runPanelAction(action),
   );
 
   private readonly onExecute = (): void => {
-    this.executeAgent();
+    executeAgent();
   };
 
   private readonly onAgentSettings = (): void => {
-    this.handleAgentConfigAction('edit');
+    runAgentConfigAction('edit');
   };
 
   private readonly onBrowseAllAgents = (): void => {
     postMessage(MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS, {
-      sessionType: this.sessionType.get(),
+      sessionType: sessionType$.get(),
     });
   };
 
@@ -569,20 +349,16 @@ export class MainApp extends MainAppBase {
         this.mocksGalleryLoaded = true;
       });
     }
-    this.restorePersistedState();
+    restorePersistedState();
   }
 
   override disconnectedCallback(): void {
-    if (this.instructionSaveTimer) {
-      window.clearTimeout(this.instructionSaveTimer);
-      this.instructionSaveTimer = null;
-      this.saveState();
-    }
+    flushPendingInstructionSave();
     super.disconnectedCallback();
   }
 
   protected handleMessage(raw: unknown): void {
-    dispatchMainView(raw, this.messageHandlers, (error) => {
+    dispatchMainView(raw, mainViewMessageHandlers, (error) => {
       this.logSchemaError(
         '[MainApp] Main view message validation failed.',
         error,
@@ -592,7 +368,7 @@ export class MainApp extends MainAppBase {
 
   protected override firstUpdated(): void {
     this.requestInitialData();
-    this.refreshInstructionPlaceholder();
+    refreshInstructionPlaceholder();
   }
 
   /**
@@ -601,86 +377,11 @@ export class MainApp extends MainAppBase {
    * so this runs only when computed values actually propagate.
    */
   protected override willUpdate(): void {
-    this.fileStateContextValue = this.fileStateContext$.get();
-    this.sessionContextValue = this.sessionContext$.get();
-  }
-
-  private blockSave(): void {
-    this.saveBlockCount += 1;
-  }
-
-  private unblockSave(): void {
-    if (this.saveBlockCount > 0) {
-      this.saveBlockCount -= 1;
-    }
-  }
-
-  private saveState(): void {
-    if (this.saveBlockCount > 0) {
-      return;
-    }
-
-    const sf = this.singleFiles.get();
-    const mf = this.multiFiles.get();
-    const cv = this.checkboxValues.get();
-
-    const persisted: MainViewPersistedState = {
-      sessionType: this.sessionType.get(),
-      workflowAgent: this.workflowAgent.get(),
-      toolUseAgent: this.toolUseAgent.get(),
-      model: this.model.get(),
-      commit: this.commit.get(),
-      instruction: this.instruction.get(),
-      workflowInstruction: this.workflowInstruction.get(),
-      toolUseInstruction: this.toolUseInstruction.get(),
-      editedFile: sf.editedFile,
-      baseFile: sf.baseFile,
-      inputFiles: mf.inputFiles,
-      contextFiles: mf.contextFiles,
-      mediaFiles: mf.mediaFiles,
-      outputFiles: [],
-      outputFilesActive: false,
-      latexdiffsVisible: this.latexdiffsVisible.get(),
-      autoExtractFigure: cv.autoExtractFigure,
-      autoExtractTikzFigure: cv.autoExtractTikzFigure,
-      autoCompileInputPdf: cv.autoCompileInputPdf,
-      attachTeXCount: cv.attachTeXCount,
-    };
-
-    this.stateManager.setState(persisted);
-  }
-
-  private restorePersistedState(): void {
-    // State is parsed through MainViewPersistedStateSchema which provides all defaults.
-    // No manual fallbacks needed - schema handles missing/invalid values.
-    const state = this.stateManager.getState();
-
-    this.sessionType.set(state.sessionType);
-    this.fileSelectionOpen.set(state.sessionType === SESSION_TYPES.WORKFLOW);
-    this.workflowAgent.set(state.workflowAgent);
-    this.toolUseAgent.set(state.toolUseAgent);
-    this.model.set(state.model);
-    this.commit.set(state.commit);
-
-    this.restorePerModeInstructions(state);
-    this.singleFiles.set({
-      editedFile: state.editedFile,
-      baseFile: state.baseFile,
-    });
-    this.multiFiles.set({
-      inputFiles: state.inputFiles,
-      contextFiles: state.contextFiles,
-      mediaFiles: state.mediaFiles,
-      outputFiles: [],
-    });
-    this.outputFilesActive.set(false);
-    this.latexdiffsVisible.set(state.latexdiffsVisible);
-    this.checkboxValues.set({
-      autoExtractFigure: state.autoExtractFigure,
-      autoExtractTikzFigure: state.autoExtractTikzFigure,
-      autoCompileInputPdf: state.autoCompileInputPdf,
-      attachTeXCount: state.attachTeXCount,
-    });
+    // Mirror the host-pushed @state flag into the module-scope signal that
+    // feeds sessionContext$ (the signal graph can't observe plain fields).
+    debugMode$.set(this.debugMode);
+    this.fileStateContextValue = fileStateContext$.get();
+    this.sessionContextValue = sessionContext$.get();
   }
 
   private requestInitialData(): void {
@@ -694,25 +395,6 @@ export class MainApp extends MainAppBase {
       MAIN_VIEW_COMMANDS.REQUEST_BASE_FILE,
     ];
     commands.forEach((command) => postMessage(command));
-  }
-
-  private showInformation(text: string): void {
-    postMessage(MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE, {
-      text,
-    });
-  }
-
-  private postActionPlan(plan: MainActionPlan): boolean {
-    if (!plan.valid) {
-      this.showInformation(plan.message);
-      return false;
-    }
-
-    postMessage(plan.command, plan.payload);
-    if (plan.infoText) {
-      this.showInformation(plan.infoText);
-    }
-    return true;
   }
 
   private commandHandler(
@@ -735,919 +417,12 @@ export class MainApp extends MainAppBase {
     return (event) => postMessage(command, getPayload(event.detail));
   }
 
-  private updateCheckboxValue(id: string, checked: boolean): void {
-    const cv = this.checkboxValues.get();
-    if (!(id in cv)) return;
-    this.checkboxValues.set({
-      ...cv,
-      [id]: checked,
-    });
-    this.saveState();
-  }
-
-  private updateMultiFiles(listId: keyof MultiFiles, files: string[]): void {
-    this.multiFiles.set({ ...this.multiFiles.get(), [listId]: files });
-    this.saveState();
-
-    const fileType = listId.replace('Files', '') as MultipleDocumentFileType;
-    const command = FILE_UPDATE_COMMANDS[fileType];
-    if (command) {
-      postMessage(command, { fileType, files });
-    }
-  }
-
-  private setInstruction(value: string): void {
-    this.instruction.set(value);
-    if (this.sessionType.get() === SESSION_TYPES.WORKFLOW) {
-      this.workflowInstruction.set(value);
-    } else {
-      this.toolUseInstruction.set(value);
-    }
-  }
-
-  /** Stash instruction for the mode being left, restore for the mode being entered. */
-  private swapModeInstruction(from: SessionType, to: SessionType): void {
-    if (from === to) return;
-    if (from === SESSION_TYPES.WORKFLOW) {
-      this.workflowInstruction.set(this.instruction.get());
-    } else {
-      this.toolUseInstruction.set(this.instruction.get());
-    }
-    this.instruction.set(
-      to === SESSION_TYPES.WORKFLOW
-        ? this.workflowInstruction.get()
-        : this.toolUseInstruction.get(),
-    );
-  }
-
-  /**
-   * Restore per-mode instructions from persisted state, migrating the legacy
-   * single `instruction` field for users who haven't saved per-mode fields yet.
-   */
-  private restorePerModeInstructions(state: MainViewPersistedState): void {
-    const wf =
-      state.workflowInstruction ||
-      (state.sessionType === SESSION_TYPES.WORKFLOW ? state.instruction : '');
-    const tu =
-      state.toolUseInstruction ||
-      (state.sessionType !== SESSION_TYPES.WORKFLOW ? state.instruction : '');
-    this.workflowInstruction.set(wf);
-    this.toolUseInstruction.set(tu);
-    this.instruction.set(
-      state.sessionType === SESSION_TYPES.WORKFLOW ? wf : tu,
-    );
-  }
-
-  /**
-   * Validates that a selection exists in options.
-   * Returns current value if found, otherwise falls back to first available option.
-   */
-  private validateSelection<T extends { value: string; disabled?: boolean }>(
-    options: T[],
-    currentValue: string,
-    preferEnabled = false,
-  ): string {
-    const current = options.find((opt) => opt.value === currentValue);
-    if (current && (!preferEnabled || !current.disabled)) {
-      return currentValue;
-    }
-
-    // Fallback: prefer enabled options (for models with missing API keys)
-    if (preferEnabled) {
-      const firstEnabled = options.find((opt) => !opt.disabled);
-      if (firstEnabled) return firstEnabled.value;
-    }
-    if (current) return currentValue;
-    return options[0]?.value ?? '';
-  }
-
-  private handleSetModelOptions(
-    message: MainViewMessageFor<typeof MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS>,
-  ): void {
-    const optionsDataByCategory = message.optionsDataByCategory;
-    const fallbackOptions =
-      message.optionsData ??
-      optionsDataByCategory?.workflow ??
-      optionsDataByCategory?.toolUse;
-    if (!fallbackOptions) return;
-
-    this.modelOptions.set(fallbackOptions);
-    if (optionsDataByCategory) {
-      if (Object.hasOwn(optionsDataByCategory, SESSION_TYPES.WORKFLOW)) {
-        this.workflowModelOptions.set(optionsDataByCategory.workflow);
-      }
-      if (Object.hasOwn(optionsDataByCategory, SESSION_TYPES.TOOL_USE)) {
-        this.toolUseModelOptions.set(optionsDataByCategory.toolUse);
-      }
-    }
-    this.refreshModelSelectionForActiveSession();
-  }
-
-  private handleSetAgentOptions(
-    message: MainViewMessageFor<typeof MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS>,
-  ): void {
-    const optionsData = message.optionsData ?? {};
-
-    if (optionsData.workflow) {
-      this.workflowAgentOptions.set(optionsData.workflow);
-      this.workflowAgent.set(
-        this.validateAgentSelection(
-          optionsData.workflow,
-          this.workflowAgent.get(),
-        ),
-      );
-    }
-
-    if (optionsData.toolUse) {
-      this.toolUseAgentOptions.set(optionsData.toolUse);
-      const selectedToolUseAgent = message.selectedToolUseAgent
-        ? this.findAgentSelection(
-            optionsData.toolUse,
-            message.selectedToolUseAgent,
-          )
-        : undefined;
-      this.toolUseAgent.set(
-        selectedToolUseAgent ??
-          this.validateAgentSelection(
-            optionsData.toolUse,
-            this.toolUseAgent.get(),
-            // State 2 sanity (PRD: agent-native onboarding): a persisted agent
-            // that no longer resolves (e.g. BYOK user with the sign-in-only
-            // 'orchestrator' default) falls back along the preferred list
-            // instead of leaving the dropdown with no selection.
-            PREFERRED_TOOL_USE_AGENTS,
-          ),
-      );
-      if (selectedToolUseAgent) {
-        this.enterToolUseSession();
-      }
-    }
-  }
-
-  /**
-   * Exact value match first, then plain-name match (source changes and
-   * plain-name defaults), then the caller's preferred fallback list. With no
-   * fallback list (workflow), an unresolvable agent keeps the stale value so
-   * the dropdown shows no selection and execution errors explicitly.
-   */
-  private validateAgentSelection(
-    options: AgentOptionData[],
-    currentValue: string,
-    preferredFallback: readonly string[] = [],
-  ): string {
-    if (options.some((opt) => opt.value === currentValue)) {
-      return currentValue;
-    }
-    // Match by name: handles source changes, plain-name defaults, and remote
-    // rows whose value still carries legacy decorated storage names.
-    const name = agentName(currentValue);
-    const byName = options.find((opt) => agentName(opt.value) === name);
-    if (byName) return byName.value;
-    for (const preferred of preferredFallback) {
-      const match = options.find((opt) => agentName(opt.value) === preferred);
-      if (match) return match.value;
-    }
-    // No match — keep stale value so the UI shows no selection.
-    // Execution will error with "unknown agent" if the user proceeds.
-    return currentValue;
-  }
-
-  private findAgentSelection(
-    options: AgentOptionData[],
-    candidate: string,
-  ): string | undefined {
-    const exact = options.find((opt) => opt.value === candidate);
-    if (exact) return exact.value;
-    const name = agentName(candidate);
-    return options.find((opt) => agentName(opt.value) === name)?.value;
-  }
-
-  private enterToolUseSession(): void {
-    if (this.sessionType.get() !== SESSION_TYPES.TOOL_USE) {
-      this.swapModeInstruction(this.sessionType.get(), SESSION_TYPES.TOOL_USE);
-      this.sessionType.set(SESSION_TYPES.TOOL_USE);
-      this.fileSelectionOpen.set(false);
-      this.outputFilesActive.set(false);
-      this.updateMultiFiles('outputFiles', []);
-      this.refreshModelSelectionForActiveSession();
-    }
-    this.refreshInstructionPlaceholder();
-    this.saveState();
-  }
-
-  private handleSetEditedFileOptions(
-    message: SetEditedFileOptionsMessage,
-  ): void {
-    const files = message.files ?? [];
-    this.fileOptions.set({ ...this.fileOptions.get(), editedFile: files });
-    const currentValue = this.singleFiles.get().editedFile;
-    if (currentValue && !files.includes(currentValue)) {
-      this.singleFiles.set({ ...this.singleFiles.get(), editedFile: '' });
-    }
-    this.saveState();
-  }
-
-  private handleSetBaseFile(
-    message: MainViewMessageFor<typeof MAIN_VIEW_COMMANDS.SET_BASE_FILE>,
-  ): void {
-    const files = message.files ?? [];
-    this.fileOptions.set({ ...this.fileOptions.get(), baseFile: files });
-
-    if (
-      !message.preserveBaseFile &&
-      !files.includes(this.singleFiles.get().baseFile)
-    ) {
-      this.singleFiles.set({ ...this.singleFiles.get(), baseFile: '' });
-    }
-
-    this.saveState();
-  }
-
-  private handleEditedFileSelected(message: EditedFileSelectedMessage): void {
-    this.singleFiles.set({
-      ...this.singleFiles.get(),
-      editedFile: message.filePath,
-    });
-    this.saveState();
-  }
-
-  private handleSetMultipleFiles(message: SetMultipleFilesMessage): void {
-    const files = message.files ?? [];
-    const listId = MULTI_FILE_COMMAND_TO_KEY[
-      message.command
-    ] as keyof MultiFiles;
-    if (!listId) return;
-
-    this.multiFiles.set({ ...this.multiFiles.get(), [listId]: files });
-    if (listId === 'outputFiles') {
-      this.outputFilesActive.set(false);
-    }
-    this.saveState();
-  }
-
-  private handleAddMediaFile(
-    message: MainViewMessageFor<typeof MAIN_VIEW_COMMANDS.ADD_MEDIA_FILE>,
-  ): void {
-    const file = message.file;
-    const mf = this.multiFiles.get();
-    const existing = mf.mediaFiles;
-    if (existing.includes(file)) return;
-    this.multiFiles.set({
-      ...mf,
-      mediaFiles: [...existing, file],
-    });
-    this.saveState();
-  }
-
-  private handleSetRecentCommits(
-    message: MainViewMessageFor<typeof MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS>,
-  ): void {
-    const commits = message.commits;
-    const gitRepo = message.isGitRepo ?? true;
-    this.isGitRepo.set(gitRepo);
-
-    this.fileOptions.set({
-      ...this.fileOptions.get(),
-      commit: gitRepo ? commits : [],
-    });
-
-    const currentCommit = this.commit.get();
-    if (!gitRepo) {
-      this.commit.set('');
-    } else if (!currentCommit || !this.hasCommitValue(currentCommit)) {
-      this.commit.set('HEAD');
-    }
-    this.saveState();
-  }
-
-  private handleSetCurrentFile(
-    message: MainViewMessageFor<typeof MAIN_VIEW_COMMANDS.SET_CURRENT_FILE>,
-  ): void {
-    const { fileType, filePath } = message;
-    if (!filePath) return;
-
-    // Workflow categories (input/context/media): prepend the active editor's
-    // file to the multi-list head so it becomes the "primary" file.
-    if (DOCUMENT_FILE_TYPES.includes(fileType as DocumentFileType)) {
-      const listId = `${fileType}Files` as keyof MultiFiles;
-      const mf = this.multiFiles.get();
-      const existing = mf[listId] ?? [];
-      const next = [filePath, ...existing.filter((f) => f !== filePath)];
-      this.updateMultiFiles(listId, next);
-      return;
-    }
-
-    // Base/edited single-slot fields go through fileOptions like before.
-    const key = `${fileType}File` as keyof FileOptions;
-    const sf = this.singleFiles.get();
-    if (!(key in sf)) return;
-    const options = this.fileOptions.get()[key] ?? [];
-    if (!options.includes(filePath)) {
-      this.showInformation(
-        `The current file is not in the ${fileType} file list: ${filePath}`,
-      );
-      return;
-    }
-    this.singleFiles.set({ ...sf, [key]: filePath });
-    this.saveState();
-  }
-
-  private handleSetSelectedCommit(
-    message: MainViewMessageFor<typeof MAIN_VIEW_COMMANDS.SET_SELECTED_COMMIT>,
-  ): void {
-    const commitHash = message.commitHash;
-    const commitLabel = message.commitLabel ?? '';
-
-    if (!commitHash) return;
-    const fo = this.fileOptions.get();
-    const options = fo.commit ?? [];
-    if (!options.some((option) => option.startsWith(commitHash))) {
-      this.fileOptions.set({
-        ...fo,
-        commit: [...options, commitLabel || commitHash],
-      });
-    }
-    this.commit.set(commitHash);
-    this.saveState();
-  }
-
-  private handleSetOpenedFiles(
-    message: MainViewMessageFor<typeof MAIN_VIEW_COMMANDS.SET_OPENED_FILES>,
-  ): void {
-    const fileType = message.fileType;
-    const normalizedType = fileType.endsWith('Files')
-      ? fileType
-      : `${fileType}Files`;
-    const listId = normalizedType as keyof MultiFiles;
-    const mf = this.multiFiles.get();
-    if (!(listId in mf)) return;
-
-    const filesToAdd = message.files ?? [];
-    const existing = mf[listId] ?? [];
-    const merged = unique([...existing, ...filesToAdd]);
-    this.multiFiles.set({ ...mf, [listId]: merged });
-    this.saveState();
-  }
-
-  private handleInstructionTextPolished(
-    message: MainViewMessageFor<
-      typeof MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_POLISHED
-    >,
-  ): void {
-    this.isPolishing.set(false);
-    if (message.text.trim()) {
-      this.setInstruction(message.text);
-      this.showInformation('Instruction text has been polished!');
-      this.saveState();
-    }
-  }
-
-  private handleInstructionTextPolishError(
-    message: MainViewMessageFor<
-      typeof MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_POLISH_ERROR
-    >,
-  ): void {
-    this.isPolishing.set(false);
-    const errorText = message.error ?? '';
-    this.showInformation(
-      `Error polishing text: ${errorText || 'Unknown error'}`,
-    );
-  }
-
-  private handleInstructionTextTranscribed(
-    message: MainViewMessageFor<
-      typeof MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_TRANSCRIBED
-    >,
-  ): void {
-    if (!message.text) {
-      this.isRecording.set(false);
-      return;
-    }
-
-    const current = this.instruction.get();
-    const updated = current ? `${current} ${message.text}` : message.text;
-    this.setInstruction(updated);
-    this.isRecording.set(false);
-    this.showInformation('Instruction text transcribed!');
-    this.saveState();
-  }
-
   protected override onStateRestore(message: StateRestoreMessage): void {
-    this.handleRestoreState(message);
-  }
-
-  private handleRestoreState(message: StateRestoreMessage): void {
-    if (message.isResetOperation === true) {
-      this.clearForNewSession();
-      return;
-    }
-    if (!message.state) {
-      return;
-    }
-
-    const parsed = MainViewPersistedStateSchema.safeParse(message.state);
-    if (!parsed.success) {
-      this.logSchemaError(
-        '[MainApp] State restore validation failed.',
-        parsed.error,
-      );
-      return;
-    }
-    const state = parsed.data;
-    this.blockSave();
-    try {
-      this.sessionType.set(state.sessionType);
-      this.workflowAgent.set(state.workflowAgent);
-      this.toolUseAgent.set(state.toolUseAgent);
-      this.model.set(state.model);
-      this.commit.set(state.commit);
-      this.restorePerModeInstructions(state);
-      this.singleFiles.set({
-        editedFile: state.editedFile,
-        baseFile: state.baseFile,
-      });
-
-      this.checkboxValues.set({
-        autoExtractFigure: state.autoExtractFigure,
-        autoExtractTikzFigure: state.autoExtractTikzFigure,
-        autoCompileInputPdf: state.autoCompileInputPdf,
-        attachTeXCount: state.attachTeXCount,
-      });
-      this.outputFilesActive.set(false);
-      this.latexdiffsVisible.set(state.latexdiffsVisible);
-
-      this.restoreFileArrays(state);
-    } finally {
-      this.unblockSave();
-    }
-    this.saveState();
-
-    if (message.executeImmediately) {
-      this.executeAgent();
-    }
-  }
-
-  private restoreFileArrays(state: MainViewPersistedState): void {
-    this.multiFiles.set(
-      Object.fromEntries(
-        MULTIPLE_DOCUMENT_FILE_TYPES.map((type) => {
-          const key = `${type}Files` as keyof MultiFiles;
-          const files =
-            type === 'output' ? [] : state[key as keyof MainViewPersistedState];
-          return [key, Array.isArray(files) ? files : []];
-        }),
-      ) as MultiFiles,
+    const restored = handleRestoreState(message, (context, error) =>
+      this.logSchemaError(context, error),
     );
-  }
-
-  private clearForNewSession(): void {
-    this.instruction.set('');
-    this.workflowInstruction.set('');
-    this.toolUseInstruction.set('');
-    const defaults = SESSION_DEFAULTS[this.sessionType.get()];
-    if (defaults.resetFiles) {
-      this.singleFiles.set({
-        editedFile: '',
-        baseFile: '',
-      });
-      this.multiFiles.set({
-        inputFiles: [],
-        contextFiles: [],
-        mediaFiles: [],
-        outputFiles: [],
-      });
-      if (defaults.checkboxOverrides) {
-        this.checkboxValues.set({
-          ...this.checkboxValues.get(),
-          ...defaults.checkboxOverrides,
-        });
-      }
-      if (defaults.outputFilesActive !== undefined) {
-        this.outputFilesActive.set(false);
-      }
-    }
-    this.saveState();
-  }
-
-  private handleRemoveFile(listId: keyof MultiFiles, file: string): void {
-    const files = (this.multiFiles.get()[listId] ?? []).filter(
-      (f: string) => f !== file,
-    );
-    if (files.length === 0) {
-      if (listId === 'outputFiles') {
-        this.outputFilesActive.set(false);
-      }
-    }
-    this.updateMultiFiles(listId, files);
-  }
-
-  private handleSelectMultipleFiles(listId: string): void {
-    // Hint the OS dialog with the head of the multi-list (the "primary"
-    // file post-collapse) so it opens at the right folder.
-    const fileType = listId.replace('Files', '');
-    const mf = this.multiFiles.get();
-    const listKey = listId as keyof MultiFiles;
-    const currentFile = (mf[listKey] ?? [])[0];
-    postMessage(MAIN_VIEW_COMMANDS.SELECT_MULTIPLE_FILES, {
-      fileType,
-      currentFile,
-    });
-  }
-
-  private handleAddOpenedFiles(type: DocumentFileType): void {
-    postMessage(MAIN_VIEW_COMMANDS.ADD_OPENED_FILES, {
-      fileType: type,
-    });
-  }
-
-  private handleGetCurrentFile(
-    type: DocumentFileType | 'base' | 'edited',
-  ): void {
-    const payload: Record<string, unknown> = { fileType: type };
-    const sf = this.singleFiles.get();
-    if ((type === 'base' || type === 'edited') && sf.baseFile) {
-      payload.baseFile = sf.baseFile;
-    }
-    postMessage(MAIN_VIEW_COMMANDS.GET_CURRENT_FILE, payload);
-  }
-
-  // No-op for input/context/media so the LatexDiffsSection event signature
-  // (DocumentFileType union) stays compatible — only base/edited can be cleared.
-  private handleEmptyFile(type: DocumentFileType | 'base' | 'edited'): void {
-    if (type !== 'base' && type !== 'edited') return;
-    const sf = this.singleFiles.get();
-    this.singleFiles.set({
-      ...sf,
-      [type === 'base' ? 'baseFile' : 'editedFile']: '',
-    });
-    this.saveState();
-  }
-
-  private handleRefreshEditedFiles(): void {
-    postMessage(MAIN_VIEW_COMMANDS.REQUEST_EDITED_FILE, {
-      baseFile: this.singleFiles.get().baseFile,
-      notifyWhenEmpty: true,
-    });
-  }
-
-  private handleEmptyFiles(type: MultipleDocumentFileType): void {
-    const listId = `${type}Files`;
-    if (type === 'output') {
-      this.outputFilesActive.set(false);
-    }
-    this.updateMultiFiles(listId as keyof MultiFiles, []);
-  }
-
-  private handleBaseFileChange(value: string): void {
-    this.singleFiles.set({ ...this.singleFiles.get(), baseFile: value });
-    this.saveState();
-    postMessage(MAIN_VIEW_COMMANDS.REQUEST_EDITED_FILE, {
-      baseFile: value,
-    });
-  }
-
-  private handleSessionTypeChange(value: string): void {
-    const parsed = parseSessionType(value) ?? SESSION_TYPES.WORKFLOW;
-    const prev = this.sessionType.get();
-    if (parsed === prev) return;
-
-    this.swapModeInstruction(prev, parsed);
-    this.sessionType.set(parsed);
-    this.refreshModelSelectionForActiveSession();
-    // Auto-open the Files <wa-details> when the user enters workflow mode,
-    // and auto-close when leaving. This is the one-shot behavior the bound
-    // `?open` template expression used to encode — but tracking it here
-    // means subsequent user collapses survive re-renders.
-    this.fileSelectionOpen.set(parsed === SESSION_TYPES.WORKFLOW);
-    this.refreshInstructionPlaceholder();
-    if (parsed === SESSION_TYPES.TOOL_USE) {
-      this.outputFilesActive.set(false);
-      this.updateMultiFiles('outputFiles', []);
-    }
-    this.saveState();
-  }
-
-  private handleAgentChange(sessionType: SessionType, value: string): void {
-    if (sessionType === SESSION_TYPES.WORKFLOW) {
-      this.workflowAgent.set(value);
-    } else {
-      this.toolUseAgent.set(value);
-    }
-    this.swapModeInstruction(this.sessionType.get(), sessionType);
-    this.sessionType.set(sessionType);
-    this.refreshModelSelectionForActiveSession();
-    this.refreshInstructionPlaceholder();
-    this.saveState();
-    postMessage(MAIN_VIEW_COMMANDS.HIDE_AGENT_CONFIG_BANNER);
-  }
-
-  private handleModelChange(value: string): void {
-    this.model.set(value);
-    this.saveState();
-    postMessage(MAIN_VIEW_COMMANDS.MODEL_SELECTED, { model: value });
-  }
-
-  private handleShowApiKeyBanner(
-    message: MainViewMessageFor<typeof MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER>,
-  ): void {
-    this.apiKeyBanner.set({
-      visible: true,
-      provider: message.provider ?? '',
-      requiresKey: message.requiresKey ?? false,
-    });
-  }
-
-  private handleShowAgentConfigBanner(
-    message: MainViewMessageFor<
-      typeof MAIN_VIEW_COMMANDS.SHOW_AGENT_CONFIG_BANNER
-    >,
-  ): void {
-    this.agentConfigBanner.set({
-      visible: true,
-      agentName: message.agentName ?? '',
-      customDirSet: message.customDirSet ?? false,
-    });
-  }
-
-  private handleShowDependencyBanner(
-    message: MainViewMessageFor<
-      typeof MAIN_VIEW_COMMANDS.SHOW_DEPENDENCY_BANNER
-    >,
-  ): void {
-    this.dependencyBanner.set({
-      visible: true,
-      missingTools: message.missingTools ?? [],
-    });
-  }
-
-  private handleSetSelectedAgent(
-    message: MainViewMessageFor<typeof MAIN_VIEW_COMMANDS.SET_SELECTED_AGENT>,
-  ): void {
-    const sessionType = parseSessionType(message.sessionType ?? undefined);
-    if (sessionType) {
-      this.swapModeInstruction(this.sessionType.get(), sessionType);
-      this.sessionType.set(sessionType);
-    }
-    if (message.agentId) {
-      if (this.sessionType.get() === SESSION_TYPES.TOOL_USE) {
-        this.toolUseAgent.set(message.agentId);
-      } else {
-        this.workflowAgent.set(message.agentId);
-      }
-    }
-    this.refreshInstructionPlaceholder();
-    this.saveState();
-  }
-
-  private scheduleInstructionSave(): void {
-    if (this.instructionSaveTimer) {
-      window.clearTimeout(this.instructionSaveTimer);
-    }
-    this.instructionSaveTimer = window.setTimeout(() => {
-      this.saveState();
-      this.instructionSaveTimer = null;
-    }, 300);
-  }
-
-  private get primaryInputFile(): string {
-    return this.multiFiles.get().inputFiles[0] ?? '';
-  }
-
-  private isSelectedAgentOrchestrator(): boolean {
-    if (this.sessionType.get() !== SESSION_TYPES.TOOL_USE) return false;
-    const agentId = this.toolUseAgent.get();
-    const opt = this.toolUseAgentOptions.get().find((o) => o.value === agentId);
-    return opt?.isOrchestrator ?? false;
-  }
-
-  private refreshInstructionPlaceholder(): void {
-    const placeholderKey: keyof typeof ONBOARDING_PLACEHOLDERS =
-      this.isSelectedAgentOrchestrator()
-        ? 'orchestrator'
-        : this.sessionType.get();
-    const placeholders = ONBOARDING_PLACEHOLDERS[placeholderKey];
-    if (!placeholders.length) return;
-    const current = this.instructionPlaceholder.get();
-    const currentIndex = placeholders.indexOf(current);
-    if (!current || currentIndex === -1) {
-      this.instructionPlaceholder.set(placeholders[0]);
-    }
-  }
-
-  private executeAgent(): void {
-    postMessage(MAIN_VIEW_COMMANDS.EXECUTE, this.buildExecuteMessage());
-  }
-
-  private buildExecuteMessage(): MainViewExecuteMessage {
-    return buildMainViewExecuteMessage({
-      sessionType: this.sessionType.get(),
-      workflowAgent: this.workflowAgent.get(),
-      toolUseAgent: this.toolUseAgent.get(),
-      model: this.model.get(),
-      instruction: this.instruction.get(),
-      singleFiles: this.singleFiles.get(),
-      multiFiles: this.multiFiles.get(),
-      checkboxValues: this.checkboxValues.get(),
-    });
-  }
-
-  private handlePolishInstruction(): void {
-    const instructionText = this.instruction.get();
-    if (!instructionText.trim()) return;
-
-    const executionMessage = this.buildExecuteMessage();
-    const files = executionMessage.files ?? {};
-    this.isPolishing.set(true);
-    postMessage(MAIN_VIEW_COMMANDS.POLISH_INSTRUCTION_TEXT, {
-      text: instructionText,
-      agent: executionMessage.agent,
-      model: this.model.get(),
-      editedFile: files.editedFile,
-      baseFile: files.baseFile,
-      inputFiles: files.inputFiles,
-      inputFilesActive: files.inputFilesActive,
-      contextFiles: files.contextFiles,
-      contextFilesActive: files.contextFilesActive,
-      mediaFiles: files.mediaFiles,
-      mediaFilesActive: files.mediaFilesActive,
-      outputFiles: files.outputFiles,
-      outputFilesActive: files.outputFilesActive,
-    });
-  }
-
-  private handleRecordingToggle(): void {
-    postMessage(
-      this.isRecording.get()
-        ? MAIN_VIEW_COMMANDS.STOP_RECORDING
-        : MAIN_VIEW_COMMANDS.START_RECORDING,
-    );
-  }
-
-  private handleApiKeyBannerAction(action: 'set' | 'guide'): void {
-    const { provider } = this.apiKeyBanner.get();
-    if (action === 'set') {
-      const command = provider
-        ? MAIN_VIEW_COMMANDS.OPEN_SET_PROVIDER_API_KEY
-        : MAIN_VIEW_COMMANDS.OPEN_SET_API_KEY;
-      postMessage(command, provider ? { provider } : undefined);
-      return;
-    }
-    const command = provider
-      ? MAIN_VIEW_COMMANDS.OPEN_PROVIDER_API_KEY_URL
-      : MAIN_VIEW_COMMANDS.OPEN_API_KEY_GUIDE;
-    postMessage(command, provider ? { provider } : undefined);
-  }
-
-  private handleAgentConfigAction(action: 'edit' | 'dir' | 'docs'): void {
-    switch (action) {
-      case 'edit':
-        postMessage(MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS, {
-          sessionType: this.sessionType.get(),
-        });
-        break;
-      case 'dir':
-        postMessage(MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY, {
-          customDirSet: this.agentConfigBanner.get().customDirSet,
-        });
-        break;
-      case 'docs':
-        postMessage(MAIN_VIEW_COMMANDS.OPEN_AGENT_DOCS);
-        break;
-    }
-  }
-
-  private runLatexDiffsAction(action: LatexDiffsActionDetail['action']): void {
-    const sf = this.singleFiles.get();
-    switch (action) {
-      case 'latexdiff':
-        this.postActionPlan(
-          planLatexdiff({
-            inputFile: this.primaryInputFile,
-            baseFile: sf.baseFile,
-            editedFile: sf.editedFile,
-          }),
-        );
-        break;
-      case 'latexdiffvc':
-        this.postActionPlan(
-          planLatexdiffVC({
-            inputFile: this.primaryInputFile,
-            baseFile: sf.baseFile,
-            commitHash: this.commit.get(),
-          }),
-        );
-        break;
-      case 'packLatexdiffvc':
-        this.postActionPlan(
-          planLatexdiffVCPack(
-            {
-              inputFile: this.primaryInputFile,
-              baseFile: sf.baseFile,
-              commitHash: this.commit.get(),
-            },
-            'pack',
-          ),
-        );
-        break;
-      case 'cleanLatexdiffvc':
-        this.postActionPlan(
-          planLatexdiffVCPack(
-            {
-              inputFile: this.primaryInputFile,
-              baseFile: sf.baseFile,
-              commitHash: this.commit.get(),
-            },
-            'clean',
-          ),
-        );
-        break;
-      case 'merge':
-        this.postActionPlan(
-          planMerge({
-            primaryInput: this.primaryInputFile,
-            editedFile: sf.editedFile,
-          }),
-        );
-        break;
-      case 'compare':
-        this.postActionPlan(
-          planCompare(
-            { baseFile: sf.baseFile, editedFile: sf.editedFile },
-            MAIN_VIEW_COMMANDS.COMPARE,
-          ),
-        );
-        break;
-      case 'accept':
-        this.postActionPlan(
-          planCompare(
-            { baseFile: sf.baseFile, editedFile: sf.editedFile },
-            MAIN_VIEW_COMMANDS.ACCEPT_EDITED,
-          ),
-        );
-        break;
-    }
-  }
-
-  private shouldForceApiKeyBanner(): boolean {
-    if (this.apiKeyBanner.get().requiresKey) {
-      return true;
-    }
-    const option = this.getModelOptionsForSession(this.sessionType.get()).find(
-      (item) => item.value === this.model.get(),
-    );
-    return option?.requiresKey ?? false;
-  }
-
-  private getModelOptionsForSession(
-    sessionType: SessionType,
-  ): ModelOptionData[] {
-    if (sessionType === SESSION_TYPES.WORKFLOW) {
-      return this.workflowModelOptions.get() ?? this.modelOptions.get();
-    }
-    return this.toolUseModelOptions.get() ?? this.modelOptions.get();
-  }
-
-  private refreshModelSelectionForActiveSession(): void {
-    const options = this.getModelOptionsForSession(this.sessionType.get());
-    this.model.set(
-      this.validateSelection(
-        options,
-        this.model.get(),
-        true, // preferEnabled: skip disabled models
-      ),
-    );
-  }
-
-  private runPanelAction(action: ActionDetail['action']): void {
-    switch (action) {
-      case 'pack':
-      case 'clean': {
-        const isToolUse = this.sessionType.get() === SESSION_TYPES.TOOL_USE;
-        this.postActionPlan(
-          planPackClean(
-            {
-              primaryInput: this.primaryInputFile,
-              model: this.model.get(),
-              inputFiles: this.multiFiles.get().inputFiles,
-              agent: isToolUse
-                ? this.toolUseAgent.get()
-                : this.workflowAgent.get(),
-            },
-            action,
-          ),
-        );
-        break;
-      }
-      case 'polish':
-        this.handlePolishInstruction();
-        break;
-      case 'record':
-        this.handleRecordingToggle();
-        break;
-      case 'erase':
-        this.setInstruction('');
-        this.saveState();
-        break;
+    if (restored && message.executeImmediately) {
+      executeAgent();
     }
   }
 
@@ -1670,19 +445,6 @@ export class MainApp extends MainAppBase {
       openInEditor: true,
     });
   };
-
-  /** Check if a commit hash exists in the options array. */
-  private hasCommitValue(value: string): boolean {
-    if (!value) return false;
-    const commits = this.fileOptions.get().commit ?? [];
-    const entries = commits.some((commit) => commit.startsWith('HEAD'))
-      ? commits
-      : ['HEAD', ...commits];
-    return entries.some((commit) => {
-      const [hash] = commit.split(': ');
-      return hash === value;
-    });
-  }
 
   /** Launcher/Progress tabs plus header actions (hidden on the desktop host). */
   private renderViewHeader(): TemplateResult | typeof nothing {
@@ -1712,7 +474,7 @@ export class MainApp extends MainAppBase {
       `;
     }
 
-    const onboardingState = this.onboardingFunnelState.get();
+    const onboardingState = onboardingFunnelState$.get();
     if (onboardingState === 'pending') {
       return html`
         <div class="content-wrapper">
@@ -1744,7 +506,7 @@ export class MainApp extends MainAppBase {
       `;
     }
 
-    const isToolUse = this.sessionType.get() === SESSION_TYPES.TOOL_USE;
+    const isToolUse = sessionType$.get() === SESSION_TYPES.TOOL_USE;
     // Tool-use (interactive) agents read input/context via their own tools, so
     // only the Media group (pasted/added images the agent can view) is relevant
     // to them; workflow agents get the full set. Surfacing Media here lets an
@@ -1754,11 +516,11 @@ export class MainApp extends MainAppBase {
       ? FILE_SELECT_CONFIGS.filter((config) => config.type === 'media')
       : FILE_SELECT_CONFIGS;
 
-    const akb = this.apiKeyBanner.get();
-    const acb = this.agentConfigBanner.get();
-    const db = this.dependencyBanner.get();
-    const sf = this.singleFiles.get();
-    const fo = this.fileOptions.get();
+    const akb = apiKeyBanner$.get();
+    const acb = agentConfigBanner$.get();
+    const db = dependencyBanner$.get();
+    const sf = singleFiles$.get();
+    const fo = fileOptions$.get();
 
     return html`
       <div class="content-wrapper">
@@ -1778,12 +540,12 @@ export class MainApp extends MainAppBase {
           }
 
           <instruction-panel
-            .showSessionHint=${!this.sessionHintDismissed.get()}
+            .showSessionHint=${!sessionHintDismissed$.get()}
             @session-type-change=${this.onSessionTypeChange}
             @agent-change=${this.onAgentChange}
             @model-change=${this.onModelChange}
             @instruction-input=${this.onInstructionInput}
-            @instruction-paste=${this.saveState}
+            @instruction-paste=${this.onInstructionPaste}
             @panel-action=${this.onPanelAction}
             @execute=${this.onExecute}
             @agent-settings=${this.onAgentSettings}
@@ -1798,10 +560,9 @@ export class MainApp extends MainAppBase {
             .agentConfigBanner=${acb}
             .dependencyBanner=${db}
             .gettingStartedVisible=${
-              this.gettingStartedVisible.get() &&
-              !this.gettingStartedDismissed.get()
+              gettingStartedVisible$.get() && !gettingStartedDismissed$.get()
             }
-            .loginBannerVisible=${this.loginBannerVisible.get()}
+            .loginBannerVisible=${loginBannerVisible$.get()}
             @api-key-action=${this.onApiKeyAction}
             @agent-config-action=${this.onAgentConfigAction}
             @dependency-dismiss=${this.onDependencyDismiss}
@@ -1816,7 +577,7 @@ export class MainApp extends MainAppBase {
           <wa-divider></wa-divider>
           <wa-details
             class="file-selection-details"
-            ?open=${this.fileSelectionOpen.get()}
+            ?open=${fileSelectionOpen$.get()}
             @wa-show=${(event: Event) => {
               // Filter by event source: child wa-dropdown components
               // inside the panel also emit wa-show/wa-hide which bubble
@@ -1824,12 +585,12 @@ export class MainApp extends MainAppBase {
               // the Files panel re-flips fileSelectionOpen on the next
               // dropdown close (see webawesome#1540).
               if (event.target === event.currentTarget) {
-                this.fileSelectionOpen.set(true);
+                fileSelectionOpen$.set(true);
               }
             }}
             @wa-hide=${(event: Event) => {
               if (event.target === event.currentTarget) {
-                this.fileSelectionOpen.set(false);
+                fileSelectionOpen$.set(false);
               }
             }}
           >
@@ -1861,14 +622,14 @@ export class MainApp extends MainAppBase {
             ? nothing
             : html`
                 <latexdiffs-section
-                  .visible=${this.latexdiffsVisible.get()}
+                  .visible=${latexdiffsVisible$.get()}
                   .baseFile=${sf.baseFile}
                   .baseFileOptions=${fo.baseFile ?? []}
                   .editedFile=${sf.editedFile}
                   .editedFileOptions=${fo.editedFile ?? []}
-                  .commit=${this.commit.get()}
+                  .commit=${commit$.get()}
                   .commitOptions=${fo.commit ?? []}
-                  .isGitRepo=${this.isGitRepo.get()}
+                  .isGitRepo=${isGitRepo$.get()}
                   @latexdiffs-toggle=${this.onLatexDiffsToggle}
                   @latexdiffs-action=${this.onLatexDiffsAction}
                   @base-file-change=${this.onBaseFileChange}

--- a/packages/extension/src/webview/frontend/mainViewActions.ts
+++ b/packages/extension/src/webview/frontend/mainViewActions.ts
@@ -1,0 +1,542 @@
+/**
+ * User-action logic and shared mutators for the Main view.
+ *
+ * These functions operate on the module-scope signals in `mainViewState.ts`
+ * and persist through `persistence.ts`. They are shared by the backend
+ * message slices (`slices/`) and by `MainApp`'s DOM event handlers.
+ */
+
+// Local imports - shared IPC and helpers
+import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
+import { postMessage } from '@shared/hostBridge';
+import {
+  buildMainViewExecuteMessage,
+  planCompare,
+  planLatexdiff,
+  planLatexdiffVC,
+  planLatexdiffVCPack,
+  planMerge,
+  planPackClean,
+  type MainViewExecuteMessage,
+} from '@shared/mainView';
+import type {
+  ActionDetail,
+  LatexDiffsActionDetail,
+  MultiFiles,
+} from '@shared/schemas';
+
+// Local imports - main view
+import {
+  SESSION_TYPES,
+  parseSessionType,
+  type DocumentFileType,
+  type MultipleDocumentFileType,
+  type SessionType,
+} from './constants';
+import {
+  agentConfigBanner$,
+  apiKeyBanner$,
+  checkboxValues$,
+  commit$,
+  fileSelectionOpen$,
+  getModelOptionsForSession,
+  instruction$,
+  instructionPlaceholder$,
+  isPolishing$,
+  isRecording$,
+  model$,
+  multiFiles$,
+  outputFilesActive$,
+  primaryInputFile,
+  sessionType$,
+  singleFiles$,
+  toolUseAgent$,
+  toolUseAgentOptions$,
+  toolUseInstruction$,
+  workflowAgent$,
+  workflowInstruction$,
+} from './mainViewState';
+import { saveState } from './persistence';
+import { FILE_UPDATE_COMMANDS, ONBOARDING_PLACEHOLDERS } from './store';
+
+export type MainActionPlan =
+  | { readonly valid: false; readonly message: string }
+  | {
+      readonly valid: true;
+      readonly command: string;
+      readonly payload: Record<string, unknown>;
+      readonly infoText?: string;
+    };
+
+export function showInformation(text: string): void {
+  postMessage(MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE, {
+    text,
+  });
+}
+
+export function postActionPlan(plan: MainActionPlan): boolean {
+  if (!plan.valid) {
+    showInformation(plan.message);
+    return false;
+  }
+
+  postMessage(plan.command, plan.payload);
+  if (plan.infoText) {
+    showInformation(plan.infoText);
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Instruction / session-mode helpers
+// ---------------------------------------------------------------------------
+
+export function setInstruction(value: string): void {
+  instruction$.set(value);
+  if (sessionType$.get() === SESSION_TYPES.WORKFLOW) {
+    workflowInstruction$.set(value);
+  } else {
+    toolUseInstruction$.set(value);
+  }
+}
+
+/** Stash instruction for the mode being left, restore for the mode being entered. */
+export function swapModeInstruction(from: SessionType, to: SessionType): void {
+  if (from === to) return;
+  if (from === SESSION_TYPES.WORKFLOW) {
+    workflowInstruction$.set(instruction$.get());
+  } else {
+    toolUseInstruction$.set(instruction$.get());
+  }
+  instruction$.set(
+    to === SESSION_TYPES.WORKFLOW
+      ? workflowInstruction$.get()
+      : toolUseInstruction$.get(),
+  );
+}
+
+function isSelectedAgentOrchestrator(): boolean {
+  if (sessionType$.get() !== SESSION_TYPES.TOOL_USE) return false;
+  const agentId = toolUseAgent$.get();
+  const opt = toolUseAgentOptions$.get().find((o) => o.value === agentId);
+  return opt?.isOrchestrator ?? false;
+}
+
+export function refreshInstructionPlaceholder(): void {
+  const placeholderKey: keyof typeof ONBOARDING_PLACEHOLDERS =
+    isSelectedAgentOrchestrator() ? 'orchestrator' : sessionType$.get();
+  const placeholders = ONBOARDING_PLACEHOLDERS[placeholderKey];
+  if (!placeholders.length) return;
+  const current = instructionPlaceholder$.get();
+  const currentIndex = placeholders.indexOf(current);
+  if (!current || currentIndex === -1) {
+    instructionPlaceholder$.set(placeholders[0]);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Selection validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates that a selection exists in options.
+ * Returns current value if found, otherwise falls back to first available option.
+ */
+export function validateSelection<
+  T extends { value: string; disabled?: boolean },
+>(options: T[], currentValue: string, preferEnabled = false): string {
+  const current = options.find((opt) => opt.value === currentValue);
+  if (current && (!preferEnabled || !current.disabled)) {
+    return currentValue;
+  }
+
+  // Fallback: prefer enabled options (for models with missing API keys)
+  if (preferEnabled) {
+    const firstEnabled = options.find((opt) => !opt.disabled);
+    if (firstEnabled) return firstEnabled.value;
+  }
+  if (current) return currentValue;
+  return options[0]?.value ?? '';
+}
+
+export function refreshModelSelectionForActiveSession(): void {
+  const options = getModelOptionsForSession(sessionType$.get());
+  model$.set(
+    validateSelection(
+      options,
+      model$.get(),
+      true, // preferEnabled: skip disabled models
+    ),
+  );
+}
+
+export function enterToolUseSession(): void {
+  if (sessionType$.get() !== SESSION_TYPES.TOOL_USE) {
+    swapModeInstruction(sessionType$.get(), SESSION_TYPES.TOOL_USE);
+    sessionType$.set(SESSION_TYPES.TOOL_USE);
+    fileSelectionOpen$.set(false);
+    outputFilesActive$.set(false);
+    updateMultiFiles('outputFiles', []);
+    refreshModelSelectionForActiveSession();
+  }
+  refreshInstructionPlaceholder();
+  saveState();
+}
+
+// ---------------------------------------------------------------------------
+// File mutations
+// ---------------------------------------------------------------------------
+
+export function updateMultiFiles(
+  listId: keyof MultiFiles,
+  files: string[],
+): void {
+  multiFiles$.set({ ...multiFiles$.get(), [listId]: files });
+  saveState();
+
+  const fileType = listId.replace('Files', '') as MultipleDocumentFileType;
+  const command = FILE_UPDATE_COMMANDS[fileType];
+  if (command) {
+    postMessage(command, { fileType, files });
+  }
+}
+
+export function updateCheckboxValue(id: string, checked: boolean): void {
+  const cv = checkboxValues$.get();
+  if (!(id in cv)) return;
+  checkboxValues$.set({
+    ...cv,
+    [id]: checked,
+  });
+  saveState();
+}
+
+export function removeFile(listId: keyof MultiFiles, file: string): void {
+  const files = (multiFiles$.get()[listId] ?? []).filter(
+    (f: string) => f !== file,
+  );
+  if (files.length === 0) {
+    if (listId === 'outputFiles') {
+      outputFilesActive$.set(false);
+    }
+  }
+  updateMultiFiles(listId, files);
+}
+
+export function selectMultipleFiles(listId: string): void {
+  // Hint the OS dialog with the head of the multi-list (the "primary"
+  // file post-collapse) so it opens at the right folder.
+  const fileType = listId.replace('Files', '');
+  const mf = multiFiles$.get();
+  const listKey = listId as keyof MultiFiles;
+  const currentFile = (mf[listKey] ?? [])[0];
+  postMessage(MAIN_VIEW_COMMANDS.SELECT_MULTIPLE_FILES, {
+    fileType,
+    currentFile,
+  });
+}
+
+export function addOpenedFiles(type: DocumentFileType): void {
+  postMessage(MAIN_VIEW_COMMANDS.ADD_OPENED_FILES, {
+    fileType: type,
+  });
+}
+
+export function getCurrentFile(
+  type: DocumentFileType | 'base' | 'edited',
+): void {
+  const payload: Record<string, unknown> = { fileType: type };
+  const sf = singleFiles$.get();
+  if ((type === 'base' || type === 'edited') && sf.baseFile) {
+    payload.baseFile = sf.baseFile;
+  }
+  postMessage(MAIN_VIEW_COMMANDS.GET_CURRENT_FILE, payload);
+}
+
+// No-op for input/context/media so the LatexDiffsSection event signature
+// (DocumentFileType union) stays compatible — only base/edited can be cleared.
+export function emptyFile(type: DocumentFileType | 'base' | 'edited'): void {
+  if (type !== 'base' && type !== 'edited') return;
+  const sf = singleFiles$.get();
+  singleFiles$.set({
+    ...sf,
+    [type === 'base' ? 'baseFile' : 'editedFile']: '',
+  });
+  saveState();
+}
+
+export function emptyFiles(type: MultipleDocumentFileType): void {
+  const listId = `${type}Files`;
+  if (type === 'output') {
+    outputFilesActive$.set(false);
+  }
+  updateMultiFiles(listId as keyof MultiFiles, []);
+}
+
+export function refreshEditedFiles(): void {
+  postMessage(MAIN_VIEW_COMMANDS.REQUEST_EDITED_FILE, {
+    baseFile: singleFiles$.get().baseFile,
+    notifyWhenEmpty: true,
+  });
+}
+
+export function setBaseFile(value: string): void {
+  singleFiles$.set({ ...singleFiles$.get(), baseFile: value });
+  saveState();
+  postMessage(MAIN_VIEW_COMMANDS.REQUEST_EDITED_FILE, {
+    baseFile: value,
+  });
+}
+
+export function setEditedFile(value: string): void {
+  singleFiles$.set({
+    ...singleFiles$.get(),
+    editedFile: value,
+  });
+  saveState();
+}
+
+export function setCommit(value: string): void {
+  commit$.set(value);
+  saveState();
+}
+
+// ---------------------------------------------------------------------------
+// Session / agent / model changes (user-driven)
+// ---------------------------------------------------------------------------
+
+export function changeSessionType(value: string): void {
+  const parsed = parseSessionType(value) ?? SESSION_TYPES.WORKFLOW;
+  const prev = sessionType$.get();
+  if (parsed === prev) return;
+
+  swapModeInstruction(prev, parsed);
+  sessionType$.set(parsed);
+  refreshModelSelectionForActiveSession();
+  // Auto-open the Files <wa-details> when the user enters workflow mode,
+  // and auto-close when leaving. This is the one-shot behavior the bound
+  // `?open` template expression used to encode — but tracking it here
+  // means subsequent user collapses survive re-renders.
+  fileSelectionOpen$.set(parsed === SESSION_TYPES.WORKFLOW);
+  refreshInstructionPlaceholder();
+  if (parsed === SESSION_TYPES.TOOL_USE) {
+    outputFilesActive$.set(false);
+    updateMultiFiles('outputFiles', []);
+  }
+  saveState();
+}
+
+export function changeAgent(sessionType: SessionType, value: string): void {
+  if (sessionType === SESSION_TYPES.WORKFLOW) {
+    workflowAgent$.set(value);
+  } else {
+    toolUseAgent$.set(value);
+  }
+  swapModeInstruction(sessionType$.get(), sessionType);
+  sessionType$.set(sessionType);
+  refreshModelSelectionForActiveSession();
+  refreshInstructionPlaceholder();
+  saveState();
+  postMessage(MAIN_VIEW_COMMANDS.HIDE_AGENT_CONFIG_BANNER);
+}
+
+export function changeModel(value: string): void {
+  model$.set(value);
+  saveState();
+  postMessage(MAIN_VIEW_COMMANDS.MODEL_SELECTED, { model: value });
+}
+
+// ---------------------------------------------------------------------------
+// Execute / panel actions
+// ---------------------------------------------------------------------------
+
+export function buildExecuteMessage(): MainViewExecuteMessage {
+  return buildMainViewExecuteMessage({
+    sessionType: sessionType$.get(),
+    workflowAgent: workflowAgent$.get(),
+    toolUseAgent: toolUseAgent$.get(),
+    model: model$.get(),
+    instruction: instruction$.get(),
+    singleFiles: singleFiles$.get(),
+    multiFiles: multiFiles$.get(),
+    checkboxValues: checkboxValues$.get(),
+  });
+}
+
+export function executeAgent(): void {
+  postMessage(MAIN_VIEW_COMMANDS.EXECUTE, buildExecuteMessage());
+}
+
+function polishInstruction(): void {
+  const instructionText = instruction$.get();
+  if (!instructionText.trim()) return;
+
+  const executionMessage = buildExecuteMessage();
+  const files = executionMessage.files ?? {};
+  isPolishing$.set(true);
+  postMessage(MAIN_VIEW_COMMANDS.POLISH_INSTRUCTION_TEXT, {
+    text: instructionText,
+    agent: executionMessage.agent,
+    model: model$.get(),
+    editedFile: files.editedFile,
+    baseFile: files.baseFile,
+    inputFiles: files.inputFiles,
+    inputFilesActive: files.inputFilesActive,
+    contextFiles: files.contextFiles,
+    contextFilesActive: files.contextFilesActive,
+    mediaFiles: files.mediaFiles,
+    mediaFilesActive: files.mediaFilesActive,
+    outputFiles: files.outputFiles,
+    outputFilesActive: files.outputFilesActive,
+  });
+}
+
+function toggleRecording(): void {
+  postMessage(
+    isRecording$.get()
+      ? MAIN_VIEW_COMMANDS.STOP_RECORDING
+      : MAIN_VIEW_COMMANDS.START_RECORDING,
+  );
+}
+
+export function runPanelAction(action: ActionDetail['action']): void {
+  switch (action) {
+    case 'pack':
+    case 'clean': {
+      const isToolUse = sessionType$.get() === SESSION_TYPES.TOOL_USE;
+      postActionPlan(
+        planPackClean(
+          {
+            primaryInput: primaryInputFile(),
+            model: model$.get(),
+            inputFiles: multiFiles$.get().inputFiles,
+            agent: isToolUse ? toolUseAgent$.get() : workflowAgent$.get(),
+          },
+          action,
+        ),
+      );
+      break;
+    }
+    case 'polish':
+      polishInstruction();
+      break;
+    case 'record':
+      toggleRecording();
+      break;
+    case 'erase':
+      setInstruction('');
+      saveState();
+      break;
+  }
+}
+
+export function runLatexDiffsAction(
+  action: LatexDiffsActionDetail['action'],
+): void {
+  const sf = singleFiles$.get();
+  switch (action) {
+    case 'latexdiff':
+      postActionPlan(
+        planLatexdiff({
+          inputFile: primaryInputFile(),
+          baseFile: sf.baseFile,
+          editedFile: sf.editedFile,
+        }),
+      );
+      break;
+    case 'latexdiffvc':
+      postActionPlan(
+        planLatexdiffVC({
+          inputFile: primaryInputFile(),
+          baseFile: sf.baseFile,
+          commitHash: commit$.get(),
+        }),
+      );
+      break;
+    case 'packLatexdiffvc':
+      postActionPlan(
+        planLatexdiffVCPack(
+          {
+            inputFile: primaryInputFile(),
+            baseFile: sf.baseFile,
+            commitHash: commit$.get(),
+          },
+          'pack',
+        ),
+      );
+      break;
+    case 'cleanLatexdiffvc':
+      postActionPlan(
+        planLatexdiffVCPack(
+          {
+            inputFile: primaryInputFile(),
+            baseFile: sf.baseFile,
+            commitHash: commit$.get(),
+          },
+          'clean',
+        ),
+      );
+      break;
+    case 'merge':
+      postActionPlan(
+        planMerge({
+          primaryInput: primaryInputFile(),
+          editedFile: sf.editedFile,
+        }),
+      );
+      break;
+    case 'compare':
+      postActionPlan(
+        planCompare(
+          { baseFile: sf.baseFile, editedFile: sf.editedFile },
+          MAIN_VIEW_COMMANDS.COMPARE,
+        ),
+      );
+      break;
+    case 'accept':
+      postActionPlan(
+        planCompare(
+          { baseFile: sf.baseFile, editedFile: sf.editedFile },
+          MAIN_VIEW_COMMANDS.ACCEPT_EDITED,
+        ),
+      );
+      break;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Banner actions (user-driven)
+// ---------------------------------------------------------------------------
+
+export function runApiKeyBannerAction(action: 'set' | 'guide'): void {
+  const { provider } = apiKeyBanner$.get();
+  if (action === 'set') {
+    const command = provider
+      ? MAIN_VIEW_COMMANDS.OPEN_SET_PROVIDER_API_KEY
+      : MAIN_VIEW_COMMANDS.OPEN_SET_API_KEY;
+    postMessage(command, provider ? { provider } : undefined);
+    return;
+  }
+  const command = provider
+    ? MAIN_VIEW_COMMANDS.OPEN_PROVIDER_API_KEY_URL
+    : MAIN_VIEW_COMMANDS.OPEN_API_KEY_GUIDE;
+  postMessage(command, provider ? { provider } : undefined);
+}
+
+export function runAgentConfigAction(action: 'edit' | 'dir' | 'docs'): void {
+  switch (action) {
+    case 'edit':
+      postMessage(MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS, {
+        sessionType: sessionType$.get(),
+      });
+      break;
+    case 'dir':
+      postMessage(MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY, {
+        customDirSet: agentConfigBanner$.get().customDirSet,
+      });
+      break;
+    case 'docs':
+      postMessage(MAIN_VIEW_COMMANDS.OPEN_AGENT_DOCS);
+      break;
+  }
+}

--- a/packages/extension/src/webview/frontend/mainViewState.ts
+++ b/packages/extension/src/webview/frontend/mainViewState.ts
@@ -1,0 +1,242 @@
+/**
+ * Module-level reactive state for the Main view.
+ *
+ * Hoisted from `MainApp` private `signal(...)` fields (issue #7075), following
+ * the same module-scope slice-store shape as `progressView/frontend/
+ * progressState.ts`. Identity and reactivity are preserved: consumers still
+ * read plain signals and `Signal.Computed` derivations, and `MainApp` keeps
+ * its `@provide`/`@state` + `willUpdate()` context-sync idiom — only what
+ * feeds `fileStateContext$`/`sessionContext$` moved from `this.xxx` fields to
+ * these module-scope signals.
+ *
+ * Singleton scope: only one Main view per webview/page. If we ever need
+ * multiple independent main-view instances on the same page, this file must
+ * be promoted to a per-instance store.
+ */
+
+// Local imports - shared signals and schemas
+import { Signal, signal } from '@shared/signals';
+import type {
+  AgentConfigBannerState,
+  AgentOptionData,
+  ApiKeyBannerState,
+  CheckboxValues,
+  DependencyBannerState,
+  FileOptions,
+  ModelOptionData,
+  MultiFiles,
+  OnboardingFunnelState,
+  SingleFiles,
+} from '@shared/schemas';
+
+// Local imports - main view
+import { SESSION_TYPES, type SessionType } from './constants';
+import {
+  fileStateContext,
+  sessionContext,
+  type FileStateContextValue,
+  type SessionContextValue,
+} from './contexts/mainViewContexts';
+import {
+  DEFAULT_CHECKBOX_VALUES,
+  DEFAULT_FILE_OPTIONS,
+  DEFAULT_MULTI_FILES,
+  DEFAULT_SINGLE_FILES,
+  DEFAULT_STATE,
+  ONBOARDING_PLACEHOLDERS,
+} from './store';
+
+// Re-export the context objects so MainApp wires @provide from one place.
+export { fileStateContext, sessionContext };
+export type { FileStateContextValue, SessionContextValue };
+
+/** Onboarding funnel plus the pre-first-push sentinel. */
+export type WebviewOnboardingFunnelState = OnboardingFunnelState | 'pending';
+
+// ---------------------------------------------------------------------------
+// Session / agent / model / instruction state
+// ---------------------------------------------------------------------------
+
+export const sessionType$ = signal<SessionType>(DEFAULT_STATE.sessionType);
+export const workflowAgent$ = signal(DEFAULT_STATE.workflowAgent);
+export const toolUseAgent$ = signal(DEFAULT_STATE.toolUseAgent);
+export const model$ = signal(DEFAULT_STATE.model);
+export const commit$ = signal(DEFAULT_STATE.commit);
+export const instruction$ = signal(DEFAULT_STATE.instruction);
+export const workflowInstruction$ = signal(DEFAULT_STATE.workflowInstruction);
+export const toolUseInstruction$ = signal(DEFAULT_STATE.toolUseInstruction);
+export const instructionPlaceholder$ = signal(
+  ONBOARDING_PLACEHOLDERS[DEFAULT_STATE.sessionType][0],
+);
+
+// ---------------------------------------------------------------------------
+// Document / file state
+// ---------------------------------------------------------------------------
+
+export const singleFiles$ = signal<SingleFiles>({ ...DEFAULT_SINGLE_FILES });
+export const fileOptions$ = signal<FileOptions>({ ...DEFAULT_FILE_OPTIONS });
+export const multiFiles$ = signal<MultiFiles>({ ...DEFAULT_MULTI_FILES });
+export const outputFilesActive$ = signal(DEFAULT_STATE.outputFilesActive);
+export const checkboxValues$ = signal<CheckboxValues>({
+  ...DEFAULT_CHECKBOX_VALUES,
+});
+export const isGitRepo$ = signal(true);
+
+// ---------------------------------------------------------------------------
+// LaTeX-diffs / files-panel UI state
+// ---------------------------------------------------------------------------
+
+export const latexdiffsVisible$ = signal(DEFAULT_STATE.latexdiffsVisible);
+/**
+ * Tracks whether the workflow Files <wa-details> is open. Initialized to
+ * match the initial session type and updated imperatively from
+ * wa-show/wa-hide so user toggles survive across re-renders. Without this,
+ * binding `?open=${isWorkflow}` would force the section open on every render
+ * pass, defeating user collapses.
+ */
+export const fileSelectionOpen$ = signal(
+  DEFAULT_STATE.sessionType === SESSION_TYPES.WORKFLOW,
+);
+
+// ---------------------------------------------------------------------------
+// Model / agent catalog data
+// ---------------------------------------------------------------------------
+
+export const modelOptions$ = signal<ModelOptionData[]>([]);
+export const workflowModelOptions$ = signal<ModelOptionData[] | undefined>(
+  undefined,
+);
+export const toolUseModelOptions$ = signal<ModelOptionData[] | undefined>(
+  undefined,
+);
+export const workflowAgentOptions$ = signal<AgentOptionData[]>([]);
+export const toolUseAgentOptions$ = signal<AgentOptionData[]>([]);
+
+// ---------------------------------------------------------------------------
+// Chat / voice state
+// ---------------------------------------------------------------------------
+
+export const isRecording$ = signal(false);
+export const isPolishing$ = signal(false);
+
+// ---------------------------------------------------------------------------
+// Banners / onboarding state
+// ---------------------------------------------------------------------------
+
+export const apiKeyBanner$ = signal<ApiKeyBannerState>({ visible: false });
+export const agentConfigBanner$ = signal<AgentConfigBannerState>({
+  visible: false,
+});
+export const dependencyBanner$ = signal<DependencyBannerState>({
+  visible: false,
+});
+export const gettingStartedVisible$ = signal(false);
+// Session-only: the host re-sends SHOW_GETTING_STARTED_BANNER on file
+// refreshes, so dismissal is tracked separately and never persisted.
+export const gettingStartedDismissed$ = signal(false);
+export const sessionHintDismissed$ = signal(true);
+export const loginBannerVisible$ = signal(false);
+// Onboarding funnel (PRD: agent-native onboarding). The host owns the real
+// state; 'pending' only suppresses first-paint launcher/welcome flashes until
+// SET_ONBOARDING_FUNNEL arrives.
+export const onboardingFunnelState$ =
+  signal<WebviewOnboardingFunnelState>('pending');
+
+// ---------------------------------------------------------------------------
+// Host-pushed debug flag (mirrored from MainApp's @state field in willUpdate
+// so the module-scope sessionContext$ derivation can observe it).
+// ---------------------------------------------------------------------------
+
+export const debugMode$ = signal(false);
+
+// ---------------------------------------------------------------------------
+// Derived read helpers
+// ---------------------------------------------------------------------------
+
+export function getModelOptionsForSession(
+  sessionType: SessionType,
+): ModelOptionData[] {
+  if (sessionType === SESSION_TYPES.WORKFLOW) {
+    return workflowModelOptions$.get() ?? modelOptions$.get();
+  }
+  return toolUseModelOptions$.get() ?? modelOptions$.get();
+}
+
+export function primaryInputFile(): string {
+  return multiFiles$.get().inputFiles[0] ?? '';
+}
+
+// ---------------------------------------------------------------------------
+// Context derivations consumed by MainApp's @provide/@state fields
+// ---------------------------------------------------------------------------
+
+export const fileStateContext$ = new Signal.Computed(
+  (): FileStateContextValue => ({
+    sessionType: sessionType$.get(),
+    checkboxValues: checkboxValues$.get(),
+    singleFiles: singleFiles$.get(),
+    fileOptions: fileOptions$.get(),
+    multiFiles: multiFiles$.get(),
+    outputFilesActive: outputFilesActive$.get(),
+  }),
+);
+
+export const sessionContext$ = new Signal.Computed((): SessionContextValue => ({
+  sessionType: sessionType$.get(),
+  instruction: instruction$.get(),
+  placeholder: instructionPlaceholder$.get(),
+  workflowAgent: workflowAgent$.get(),
+  toolUseAgent: toolUseAgent$.get(),
+  model: model$.get(),
+  workflowAgentOptions: workflowAgentOptions$.get(),
+  toolUseAgentOptions: toolUseAgentOptions$.get(),
+  modelOptions: getModelOptionsForSession(sessionType$.get()),
+  isRecording: isRecording$.get(),
+  isPolishing: isPolishing$.get(),
+  debugMode: debugMode$.get(),
+}));
+
+/**
+ * Reset every writable signal to its initial value. Called from `MainApp`'s
+ * constructor on remount in the same JS context (tests, hot reload) so each
+ * mount starts from the same slate a fresh per-instance field set used to
+ * provide. Main-view state is singleton-scoped per the file header, so the
+ * reset is a per-mount slate, not multi-instance coordination.
+ */
+export function resetMainViewState(): void {
+  sessionType$.set(DEFAULT_STATE.sessionType);
+  workflowAgent$.set(DEFAULT_STATE.workflowAgent);
+  toolUseAgent$.set(DEFAULT_STATE.toolUseAgent);
+  model$.set(DEFAULT_STATE.model);
+  commit$.set(DEFAULT_STATE.commit);
+  instruction$.set(DEFAULT_STATE.instruction);
+  workflowInstruction$.set(DEFAULT_STATE.workflowInstruction);
+  toolUseInstruction$.set(DEFAULT_STATE.toolUseInstruction);
+  instructionPlaceholder$.set(
+    ONBOARDING_PLACEHOLDERS[DEFAULT_STATE.sessionType][0],
+  );
+  singleFiles$.set({ ...DEFAULT_SINGLE_FILES });
+  fileOptions$.set({ ...DEFAULT_FILE_OPTIONS });
+  multiFiles$.set({ ...DEFAULT_MULTI_FILES });
+  outputFilesActive$.set(DEFAULT_STATE.outputFilesActive);
+  checkboxValues$.set({ ...DEFAULT_CHECKBOX_VALUES });
+  isGitRepo$.set(true);
+  latexdiffsVisible$.set(DEFAULT_STATE.latexdiffsVisible);
+  fileSelectionOpen$.set(DEFAULT_STATE.sessionType === SESSION_TYPES.WORKFLOW);
+  modelOptions$.set([]);
+  workflowModelOptions$.set(undefined);
+  toolUseModelOptions$.set(undefined);
+  workflowAgentOptions$.set([]);
+  toolUseAgentOptions$.set([]);
+  isRecording$.set(false);
+  isPolishing$.set(false);
+  apiKeyBanner$.set({ visible: false });
+  agentConfigBanner$.set({ visible: false });
+  dependencyBanner$.set({ visible: false });
+  gettingStartedVisible$.set(false);
+  gettingStartedDismissed$.set(false);
+  sessionHintDismissed$.set(true);
+  loginBannerVisible$.set(false);
+  onboardingFunnelState$.set('pending');
+  debugMode$.set(false);
+}

--- a/packages/extension/src/webview/frontend/messageDispatcher.ts
+++ b/packages/extension/src/webview/frontend/messageDispatcher.ts
@@ -1,0 +1,28 @@
+/**
+ * Composed handler registry for MainView backend messages.
+ *
+ * Handlers are organized into domain-specific slices under ./slices/ (same
+ * shape as progressView/frontend/messageDispatcher.ts), keyed by
+ * MAIN_VIEW_COMMANDS. `MainApp.handleMessage` routes raw messages through
+ * `dispatchMainView(raw, mainViewMessageHandlers, onError)`.
+ */
+
+// Local imports - shared schemas
+import type { MainViewHandlerRegistry } from '@shared/schemas';
+
+// Slice imports
+import { bannerHandlers } from './slices/bannerSlice';
+import { catalogHandlers } from './slices/catalogSlice';
+import { chatHandlers } from './slices/chatSlice';
+import { documentHandlers } from './slices/documentSlice';
+import { onboardingHandlers } from './slices/onboardingSlice';
+import { sessionHandlers } from './slices/sessionSlice';
+
+export const mainViewMessageHandlers: MainViewHandlerRegistry = {
+  ...catalogHandlers,
+  ...sessionHandlers,
+  ...documentHandlers,
+  ...chatHandlers,
+  ...bannerHandlers,
+  ...onboardingHandlers,
+};

--- a/packages/extension/src/webview/frontend/persistence.ts
+++ b/packages/extension/src/webview/frontend/persistence.ts
@@ -1,0 +1,285 @@
+/**
+ * Persistence machinery for the Main view.
+ *
+ * Owns the single `PersistedState` instance (backed by the shared
+ * `webviewStorage` singleton) and both restore paths (issue #7075):
+ *
+ *   1. mount-time webview-storage restore (`restorePersistedState`), and
+ *   2. backend-pushed history-rerun/reset restore (`handleRestoreState`).
+ *
+ * Both paths force `outputFiles`/`outputFilesActive` back to empty/false and
+ * share `restorePerModeInstructions`'s legacy-migration precedence. Behavior
+ * is pinned by `src/test-kernel/webview/MainAppPersistenceRestore.vitest.mts`.
+ */
+
+// Local imports - shared state and schemas
+import { PersistedState } from '@shared/state';
+import {
+  MainViewPersistedStateSchema,
+  type MainViewPersistedState,
+} from '@shared/schemas';
+import type { MultiFiles } from '@shared/schemas';
+import type { StateRestoreMessage } from '@shared/schemas/commonViewMessages';
+
+// Local imports - main view
+import { MULTIPLE_DOCUMENT_FILE_TYPES, SESSION_TYPES } from './constants';
+import { SESSION_DEFAULTS } from './sessionDefaults';
+import {
+  checkboxValues$,
+  commit$,
+  fileSelectionOpen$,
+  instruction$,
+  latexdiffsVisible$,
+  model$,
+  multiFiles$,
+  outputFilesActive$,
+  sessionType$,
+  singleFiles$,
+  toolUseAgent$,
+  toolUseInstruction$,
+  workflowAgent$,
+  workflowInstruction$,
+} from './mainViewState';
+import { webviewStorage } from './webviewStorage';
+import type { ZodError } from 'zod';
+
+const stateManager = new PersistedState(
+  webviewStorage,
+  'mainViewState',
+  MainViewPersistedStateSchema,
+);
+
+/**
+ * Reentrancy guard around `saveState()`: while a backend-pushed restore is
+ * applying a snapshot, intermediate mutations must not write partially
+ * restored state back to storage. Do NOT "simplify away" without a regression
+ * test proving it safe (issue #7075) — the characterization suite asserts
+ * exactly one storage write per backend restore.
+ */
+let saveBlockCount = 0;
+let instructionSaveTimer: number | null = null;
+
+function blockSave(): void {
+  saveBlockCount += 1;
+}
+
+function unblockSave(): void {
+  if (saveBlockCount > 0) {
+    saveBlockCount -= 1;
+  }
+}
+
+export function saveState(): void {
+  if (saveBlockCount > 0) {
+    return;
+  }
+
+  const sf = singleFiles$.get();
+  const mf = multiFiles$.get();
+  const cv = checkboxValues$.get();
+
+  const persisted: MainViewPersistedState = {
+    sessionType: sessionType$.get(),
+    workflowAgent: workflowAgent$.get(),
+    toolUseAgent: toolUseAgent$.get(),
+    model: model$.get(),
+    commit: commit$.get(),
+    instruction: instruction$.get(),
+    workflowInstruction: workflowInstruction$.get(),
+    toolUseInstruction: toolUseInstruction$.get(),
+    editedFile: sf.editedFile,
+    baseFile: sf.baseFile,
+    inputFiles: mf.inputFiles,
+    contextFiles: mf.contextFiles,
+    mediaFiles: mf.mediaFiles,
+    outputFiles: [],
+    outputFilesActive: false,
+    latexdiffsVisible: latexdiffsVisible$.get(),
+    autoExtractFigure: cv.autoExtractFigure,
+    autoExtractTikzFigure: cv.autoExtractTikzFigure,
+    autoCompileInputPdf: cv.autoCompileInputPdf,
+    attachTeXCount: cv.attachTeXCount,
+  };
+
+  stateManager.setState(persisted);
+}
+
+export function restorePersistedState(): void {
+  // State is parsed through MainViewPersistedStateSchema which provides all defaults.
+  // No manual fallbacks needed - schema handles missing/invalid values.
+  const state = stateManager.getState();
+
+  sessionType$.set(state.sessionType);
+  fileSelectionOpen$.set(state.sessionType === SESSION_TYPES.WORKFLOW);
+  workflowAgent$.set(state.workflowAgent);
+  toolUseAgent$.set(state.toolUseAgent);
+  model$.set(state.model);
+  commit$.set(state.commit);
+
+  restorePerModeInstructions(state);
+  singleFiles$.set({
+    editedFile: state.editedFile,
+    baseFile: state.baseFile,
+  });
+  multiFiles$.set({
+    inputFiles: state.inputFiles,
+    contextFiles: state.contextFiles,
+    mediaFiles: state.mediaFiles,
+    outputFiles: [],
+  });
+  outputFilesActive$.set(false);
+  latexdiffsVisible$.set(state.latexdiffsVisible);
+  checkboxValues$.set({
+    autoExtractFigure: state.autoExtractFigure,
+    autoExtractTikzFigure: state.autoExtractTikzFigure,
+    autoCompileInputPdf: state.autoCompileInputPdf,
+    attachTeXCount: state.attachTeXCount,
+  });
+}
+
+/**
+ * Restore per-mode instructions from persisted state, migrating the legacy
+ * single `instruction` field for users who haven't saved per-mode fields yet.
+ */
+function restorePerModeInstructions(state: MainViewPersistedState): void {
+  const wf =
+    state.workflowInstruction ||
+    (state.sessionType === SESSION_TYPES.WORKFLOW ? state.instruction : '');
+  const tu =
+    state.toolUseInstruction ||
+    (state.sessionType !== SESSION_TYPES.WORKFLOW ? state.instruction : '');
+  workflowInstruction$.set(wf);
+  toolUseInstruction$.set(tu);
+  instruction$.set(state.sessionType === SESSION_TYPES.WORKFLOW ? wf : tu);
+}
+
+/**
+ * Apply a backend-pushed restore (history rerun or reset).
+ *
+ * Returns true only when a state snapshot was successfully applied — the
+ * caller uses this to honor `executeImmediately` (a reset or a failed parse
+ * must never trigger an execute).
+ */
+export function handleRestoreState(
+  message: StateRestoreMessage,
+  onSchemaError: (context: string, error: ZodError) => void,
+): boolean {
+  if (message.isResetOperation === true) {
+    clearForNewSession();
+    return false;
+  }
+  if (!message.state) {
+    return false;
+  }
+
+  const parsed = MainViewPersistedStateSchema.safeParse(message.state);
+  if (!parsed.success) {
+    onSchemaError('[MainApp] State restore validation failed.', parsed.error);
+    return false;
+  }
+  const state = parsed.data;
+  blockSave();
+  try {
+    sessionType$.set(state.sessionType);
+    workflowAgent$.set(state.workflowAgent);
+    toolUseAgent$.set(state.toolUseAgent);
+    model$.set(state.model);
+    commit$.set(state.commit);
+    restorePerModeInstructions(state);
+    singleFiles$.set({
+      editedFile: state.editedFile,
+      baseFile: state.baseFile,
+    });
+
+    checkboxValues$.set({
+      autoExtractFigure: state.autoExtractFigure,
+      autoExtractTikzFigure: state.autoExtractTikzFigure,
+      autoCompileInputPdf: state.autoCompileInputPdf,
+      attachTeXCount: state.attachTeXCount,
+    });
+    outputFilesActive$.set(false);
+    latexdiffsVisible$.set(state.latexdiffsVisible);
+
+    restoreFileArrays(state);
+  } finally {
+    unblockSave();
+  }
+  saveState();
+  return true;
+}
+
+function restoreFileArrays(state: MainViewPersistedState): void {
+  multiFiles$.set(
+    Object.fromEntries(
+      MULTIPLE_DOCUMENT_FILE_TYPES.map((type) => {
+        const key = `${type}Files` as keyof MultiFiles;
+        const files =
+          type === 'output' ? [] : state[key as keyof MainViewPersistedState];
+        return [key, Array.isArray(files) ? files : []];
+      }),
+    ) as MultiFiles,
+  );
+}
+
+function clearForNewSession(): void {
+  instruction$.set('');
+  workflowInstruction$.set('');
+  toolUseInstruction$.set('');
+  const defaults = SESSION_DEFAULTS[sessionType$.get()];
+  if (defaults.resetFiles) {
+    singleFiles$.set({
+      editedFile: '',
+      baseFile: '',
+    });
+    multiFiles$.set({
+      inputFiles: [],
+      contextFiles: [],
+      mediaFiles: [],
+      outputFiles: [],
+    });
+    if (defaults.checkboxOverrides) {
+      checkboxValues$.set({
+        ...checkboxValues$.get(),
+        ...defaults.checkboxOverrides,
+      });
+    }
+    if (defaults.outputFilesActive !== undefined) {
+      outputFilesActive$.set(false);
+    }
+  }
+  saveState();
+}
+
+/** Debounce instruction keystrokes so each one doesn't hit storage. */
+export function scheduleInstructionSave(): void {
+  if (instructionSaveTimer) {
+    window.clearTimeout(instructionSaveTimer);
+  }
+  instructionSaveTimer = window.setTimeout(() => {
+    saveState();
+    instructionSaveTimer = null;
+  }, 300);
+}
+
+/** Flush a pending debounced instruction save (on disconnect). */
+export function flushPendingInstructionSave(): void {
+  if (instructionSaveTimer) {
+    window.clearTimeout(instructionSaveTimer);
+    instructionSaveTimer = null;
+    saveState();
+  }
+}
+
+/**
+ * Reset the transient runtime (save-block counter, pending debounce timer)
+ * without touching stored state. Called from `MainApp`'s constructor on
+ * remount in the same JS context, matching the fresh-instance slate the old
+ * per-instance fields provided.
+ */
+export function resetPersistenceRuntime(): void {
+  saveBlockCount = 0;
+  if (instructionSaveTimer) {
+    window.clearTimeout(instructionSaveTimer);
+    instructionSaveTimer = null;
+  }
+}

--- a/packages/extension/src/webview/frontend/slices/bannerSlice.ts
+++ b/packages/extension/src/webview/frontend/slices/bannerSlice.ts
@@ -1,0 +1,72 @@
+/**
+ * Banner slice: API-key, agent-config, dependency, and login banner pushes.
+ */
+
+// Local imports - shared IPC and schemas
+import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
+import type { MainViewHandlerRegistry } from '@shared/schemas';
+
+// Local imports - main view
+import {
+  agentConfigBanner$,
+  apiKeyBanner$,
+  dependencyBanner$,
+  getModelOptionsForSession,
+  loginBannerVisible$,
+  model$,
+  sessionType$,
+} from '../mainViewState';
+
+function shouldForceApiKeyBanner(): boolean {
+  if (apiKeyBanner$.get().requiresKey) {
+    return true;
+  }
+  const option = getModelOptionsForSession(sessionType$.get()).find(
+    (item) => item.value === model$.get(),
+  );
+  return option?.requiresKey ?? false;
+}
+
+export const bannerHandlers: MainViewHandlerRegistry = {
+  [MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER]: (message) => {
+    apiKeyBanner$.set({
+      visible: true,
+      provider: message.provider ?? '',
+      requiresKey: message.requiresKey ?? false,
+    });
+  },
+  [MAIN_VIEW_COMMANDS.HIDE_API_KEY_BANNER]: () => {
+    if (shouldForceApiKeyBanner()) {
+      return;
+    }
+    apiKeyBanner$.set({ visible: false });
+  },
+
+  [MAIN_VIEW_COMMANDS.SHOW_AGENT_CONFIG_BANNER]: (message) => {
+    agentConfigBanner$.set({
+      visible: true,
+      agentName: message.agentName ?? '',
+      customDirSet: message.customDirSet ?? false,
+    });
+  },
+  [MAIN_VIEW_COMMANDS.HIDE_AGENT_CONFIG_BANNER]: () => {
+    agentConfigBanner$.set({ visible: false });
+  },
+
+  [MAIN_VIEW_COMMANDS.SHOW_DEPENDENCY_BANNER]: (message) => {
+    dependencyBanner$.set({
+      visible: true,
+      missingTools: message.missingTools ?? [],
+    });
+  },
+  [MAIN_VIEW_COMMANDS.HIDE_DEPENDENCY_BANNER]: () => {
+    dependencyBanner$.set({ visible: false });
+  },
+
+  [MAIN_VIEW_COMMANDS.SHOW_LOGIN_BANNER]: () => {
+    loginBannerVisible$.set(true);
+  },
+  [MAIN_VIEW_COMMANDS.HIDE_LOGIN_BANNER]: () => {
+    loginBannerVisible$.set(false);
+  },
+};

--- a/packages/extension/src/webview/frontend/slices/catalogSlice.ts
+++ b/packages/extension/src/webview/frontend/slices/catalogSlice.ts
@@ -1,0 +1,119 @@
+/**
+ * Catalog slice: model/agent option pushes from the host.
+ */
+
+// Local imports - shared IPC and schemas
+import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
+import type { AgentOptionData, MainViewHandlerRegistry } from '@shared/schemas';
+import { agentName } from '@shared/schemas/agent';
+import { PREFERRED_TOOL_USE_AGENTS } from '@shared/constants/agents';
+// Constants-only module: safe for the webview bundle (no platform imports).
+
+// Local imports - main view
+import { SESSION_TYPES } from '../constants';
+import {
+  modelOptions$,
+  toolUseAgent$,
+  toolUseAgentOptions$,
+  toolUseModelOptions$,
+  workflowAgent$,
+  workflowAgentOptions$,
+  workflowModelOptions$,
+} from '../mainViewState';
+import {
+  enterToolUseSession,
+  refreshModelSelectionForActiveSession,
+} from '../mainViewActions';
+
+/**
+ * Exact value match first, then plain-name match (source changes and
+ * plain-name defaults), then the caller's preferred fallback list. With no
+ * fallback list (workflow), an unresolvable agent keeps the stale value so
+ * the dropdown shows no selection and execution errors explicitly.
+ */
+function validateAgentSelection(
+  options: AgentOptionData[],
+  currentValue: string,
+  preferredFallback: readonly string[] = [],
+): string {
+  if (options.some((opt) => opt.value === currentValue)) {
+    return currentValue;
+  }
+  // Match by name: handles source changes, plain-name defaults, and remote
+  // rows whose value still carries legacy decorated storage names.
+  const name = agentName(currentValue);
+  const byName = options.find((opt) => agentName(opt.value) === name);
+  if (byName) return byName.value;
+  for (const preferred of preferredFallback) {
+    const match = options.find((opt) => agentName(opt.value) === preferred);
+    if (match) return match.value;
+  }
+  // No match — keep stale value so the UI shows no selection.
+  // Execution will error with "unknown agent" if the user proceeds.
+  return currentValue;
+}
+
+function findAgentSelection(
+  options: AgentOptionData[],
+  candidate: string,
+): string | undefined {
+  const exact = options.find((opt) => opt.value === candidate);
+  if (exact) return exact.value;
+  const name = agentName(candidate);
+  return options.find((opt) => agentName(opt.value) === name)?.value;
+}
+
+export const catalogHandlers: MainViewHandlerRegistry = {
+  [MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS]: (message) => {
+    const optionsDataByCategory = message.optionsDataByCategory;
+    const fallbackOptions =
+      message.optionsData ??
+      optionsDataByCategory?.workflow ??
+      optionsDataByCategory?.toolUse;
+    if (!fallbackOptions) return;
+
+    modelOptions$.set(fallbackOptions);
+    if (optionsDataByCategory) {
+      if (Object.hasOwn(optionsDataByCategory, SESSION_TYPES.WORKFLOW)) {
+        workflowModelOptions$.set(optionsDataByCategory.workflow);
+      }
+      if (Object.hasOwn(optionsDataByCategory, SESSION_TYPES.TOOL_USE)) {
+        toolUseModelOptions$.set(optionsDataByCategory.toolUse);
+      }
+    }
+    refreshModelSelectionForActiveSession();
+  },
+
+  [MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS]: (message) => {
+    const optionsData = message.optionsData ?? {};
+
+    if (optionsData.workflow) {
+      workflowAgentOptions$.set(optionsData.workflow);
+      workflowAgent$.set(
+        validateAgentSelection(optionsData.workflow, workflowAgent$.get()),
+      );
+    }
+
+    if (optionsData.toolUse) {
+      toolUseAgentOptions$.set(optionsData.toolUse);
+      const selectedToolUseAgent = message.selectedToolUseAgent
+        ? findAgentSelection(optionsData.toolUse, message.selectedToolUseAgent)
+        : undefined;
+      toolUseAgent$.set(
+        selectedToolUseAgent ??
+          validateAgentSelection(
+            optionsData.toolUse,
+            toolUseAgent$.get(),
+            // State 2 sanity (PRD: agent-native onboarding): a persisted agent
+            // that no longer resolves (e.g. BYOK user with the sign-in-only
+            // 'orchestrator' default) falls back along the preferred list
+            // instead of leaving the dropdown with no selection.
+            PREFERRED_TOOL_USE_AGENTS,
+          ),
+      );
+      if (selectedToolUseAgent) {
+        enterToolUseSession();
+      }
+    }
+  },
+};

--- a/packages/extension/src/webview/frontend/slices/chatSlice.ts
+++ b/packages/extension/src/webview/frontend/slices/chatSlice.ts
@@ -1,0 +1,54 @@
+/**
+ * Chat slice: instruction polish/transcription results and voice-recording
+ * lifecycle pushes.
+ */
+
+// Local imports - shared IPC and schemas
+import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
+import type { MainViewHandlerRegistry } from '@shared/schemas';
+
+// Local imports - main view
+import { instruction$, isPolishing$, isRecording$ } from '../mainViewState';
+import { setInstruction, showInformation } from '../mainViewActions';
+import { saveState } from '../persistence';
+
+export const chatHandlers: MainViewHandlerRegistry = {
+  [MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_POLISHED]: (message) => {
+    isPolishing$.set(false);
+    if (message.text.trim()) {
+      setInstruction(message.text);
+      showInformation('Instruction text has been polished!');
+      saveState();
+    }
+  },
+
+  [MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_POLISH_ERROR]: (message) => {
+    isPolishing$.set(false);
+    const errorText = message.error ?? '';
+    showInformation(`Error polishing text: ${errorText || 'Unknown error'}`);
+  },
+
+  [MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_TRANSCRIBED]: (message) => {
+    if (!message.text) {
+      isRecording$.set(false);
+      return;
+    }
+
+    const current = instruction$.get();
+    const updated = current ? `${current} ${message.text}` : message.text;
+    setInstruction(updated);
+    isRecording$.set(false);
+    showInformation('Instruction text transcribed!');
+    saveState();
+  },
+
+  [MAIN_VIEW_COMMANDS.RECORDING_STARTED]: () => {
+    isRecording$.set(true);
+  },
+  [MAIN_VIEW_COMMANDS.RECORDING_STOPPED]: () => {
+    isRecording$.set(false);
+  },
+  [MAIN_VIEW_COMMANDS.RECORDING_ERROR]: () => {
+    isRecording$.set(false);
+  },
+};

--- a/packages/extension/src/webview/frontend/slices/documentSlice.ts
+++ b/packages/extension/src/webview/frontend/slices/documentSlice.ts
@@ -1,0 +1,198 @@
+/**
+ * Document slice: host-pushed file lists, single-file selections, commits,
+ * and opened-file merges.
+ */
+
+// Local imports - shared IPC and schemas
+import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
+import type {
+  FileOptions,
+  MainViewHandlerRegistry,
+  MainViewMessage,
+  MultiFiles,
+} from '@shared/schemas';
+import { unique } from '@utils/core';
+
+// Local imports - main view
+import { DOCUMENT_FILE_TYPES, type DocumentFileType } from '../constants';
+import {
+  commit$,
+  fileOptions$,
+  isGitRepo$,
+  multiFiles$,
+  outputFilesActive$,
+  singleFiles$,
+} from '../mainViewState';
+import { showInformation, updateMultiFiles } from '../mainViewActions';
+import { saveState } from '../persistence';
+import { MULTI_FILE_COMMAND_TO_KEY } from '../store';
+
+// Helper type for extracting specific message type from union
+type MainViewMessageFor<C extends MainViewMessage['command']> = Extract<
+  MainViewMessage,
+  { command: C }
+>;
+
+type SetMultipleFilesMessage =
+  | MainViewMessageFor<typeof MAIN_VIEW_COMMANDS.SET_INPUT_FILES>
+  | MainViewMessageFor<typeof MAIN_VIEW_COMMANDS.SET_CONTEXT_FILES>
+  | MainViewMessageFor<typeof MAIN_VIEW_COMMANDS.SET_MEDIA_FILES>
+  | MainViewMessageFor<typeof MAIN_VIEW_COMMANDS.SET_OUTPUT_FILES>;
+
+function handleSetMultipleFiles(message: SetMultipleFilesMessage): void {
+  const files = message.files ?? [];
+  const listId = MULTI_FILE_COMMAND_TO_KEY[message.command] as keyof MultiFiles;
+  if (!listId) return;
+
+  multiFiles$.set({ ...multiFiles$.get(), [listId]: files });
+  if (listId === 'outputFiles') {
+    outputFilesActive$.set(false);
+  }
+  saveState();
+}
+
+/** Check if a commit hash exists in the options array. */
+function hasCommitValue(value: string): boolean {
+  if (!value) return false;
+  const commits = fileOptions$.get().commit ?? [];
+  const entries = commits.some((commit) => commit.startsWith('HEAD'))
+    ? commits
+    : ['HEAD', ...commits];
+  return entries.some((commit) => {
+    const [hash] = commit.split(': ');
+    return hash === value;
+  });
+}
+
+export const documentHandlers: MainViewHandlerRegistry = {
+  [MAIN_VIEW_COMMANDS.SET_EDITED_FILE]: (message) => {
+    const files = message.files ?? [];
+    fileOptions$.set({ ...fileOptions$.get(), editedFile: files });
+    const currentValue = singleFiles$.get().editedFile;
+    if (currentValue && !files.includes(currentValue)) {
+      singleFiles$.set({ ...singleFiles$.get(), editedFile: '' });
+    }
+    saveState();
+  },
+
+  [MAIN_VIEW_COMMANDS.SET_BASE_FILE]: (message) => {
+    const files = message.files ?? [];
+    fileOptions$.set({ ...fileOptions$.get(), baseFile: files });
+
+    if (
+      !message.preserveBaseFile &&
+      !files.includes(singleFiles$.get().baseFile)
+    ) {
+      singleFiles$.set({ ...singleFiles$.get(), baseFile: '' });
+    }
+
+    saveState();
+  },
+
+  [MAIN_VIEW_COMMANDS.EDITED_FILE_SELECTED]: (message) => {
+    singleFiles$.set({
+      ...singleFiles$.get(),
+      editedFile: message.filePath,
+    });
+    saveState();
+  },
+
+  [MAIN_VIEW_COMMANDS.SET_INPUT_FILES]: handleSetMultipleFiles,
+  [MAIN_VIEW_COMMANDS.SET_CONTEXT_FILES]: handleSetMultipleFiles,
+  [MAIN_VIEW_COMMANDS.SET_MEDIA_FILES]: handleSetMultipleFiles,
+  [MAIN_VIEW_COMMANDS.SET_OUTPUT_FILES]: handleSetMultipleFiles,
+
+  [MAIN_VIEW_COMMANDS.ADD_MEDIA_FILE]: (message) => {
+    const file = message.file;
+    const mf = multiFiles$.get();
+    const existing = mf.mediaFiles;
+    if (existing.includes(file)) return;
+    multiFiles$.set({
+      ...mf,
+      mediaFiles: [...existing, file],
+    });
+    saveState();
+  },
+
+  [MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS]: (message) => {
+    const commits = message.commits;
+    const gitRepo = message.isGitRepo ?? true;
+    isGitRepo$.set(gitRepo);
+
+    fileOptions$.set({
+      ...fileOptions$.get(),
+      commit: gitRepo ? commits : [],
+    });
+
+    const currentCommit = commit$.get();
+    if (!gitRepo) {
+      commit$.set('');
+    } else if (!currentCommit || !hasCommitValue(currentCommit)) {
+      commit$.set('HEAD');
+    }
+    saveState();
+  },
+
+  [MAIN_VIEW_COMMANDS.SET_CURRENT_FILE]: (message) => {
+    const { fileType, filePath } = message;
+    if (!filePath) return;
+
+    // Workflow categories (input/context/media): prepend the active editor's
+    // file to the multi-list head so it becomes the "primary" file.
+    if (DOCUMENT_FILE_TYPES.includes(fileType as DocumentFileType)) {
+      const listId = `${fileType}Files` as keyof MultiFiles;
+      const mf = multiFiles$.get();
+      const existing = mf[listId] ?? [];
+      const next = [filePath, ...existing.filter((f) => f !== filePath)];
+      updateMultiFiles(listId, next);
+      return;
+    }
+
+    // Base/edited single-slot fields go through fileOptions like before.
+    const key = `${fileType}File` as keyof FileOptions;
+    const sf = singleFiles$.get();
+    if (!(key in sf)) return;
+    const options = fileOptions$.get()[key] ?? [];
+    if (!options.includes(filePath)) {
+      showInformation(
+        `The current file is not in the ${fileType} file list: ${filePath}`,
+      );
+      return;
+    }
+    singleFiles$.set({ ...sf, [key]: filePath });
+    saveState();
+  },
+
+  [MAIN_VIEW_COMMANDS.SET_SELECTED_COMMIT]: (message) => {
+    const commitHash = message.commitHash;
+    const commitLabel = message.commitLabel ?? '';
+
+    if (!commitHash) return;
+    const fo = fileOptions$.get();
+    const options = fo.commit ?? [];
+    if (!options.some((option) => option.startsWith(commitHash))) {
+      fileOptions$.set({
+        ...fo,
+        commit: [...options, commitLabel || commitHash],
+      });
+    }
+    commit$.set(commitHash);
+    saveState();
+  },
+
+  [MAIN_VIEW_COMMANDS.SET_OPENED_FILES]: (message) => {
+    const fileType = message.fileType;
+    const normalizedType = fileType.endsWith('Files')
+      ? fileType
+      : `${fileType}Files`;
+    const listId = normalizedType as keyof MultiFiles;
+    const mf = multiFiles$.get();
+    if (!(listId in mf)) return;
+
+    const filesToAdd = message.files ?? [];
+    const existing = mf[listId] ?? [];
+    const merged = unique([...existing, ...filesToAdd]);
+    multiFiles$.set({ ...mf, [listId]: merged });
+    saveState();
+  },
+};

--- a/packages/extension/src/webview/frontend/slices/onboardingSlice.ts
+++ b/packages/extension/src/webview/frontend/slices/onboardingSlice.ts
@@ -1,0 +1,35 @@
+/**
+ * Onboarding slice: onboarding-funnel pushes plus the getting-started and
+ * orchestrator-hint banners that drive the onboarding surfaces.
+ */
+
+// Local imports - shared IPC and schemas
+import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
+import type { MainViewHandlerRegistry } from '@shared/schemas';
+
+// Local imports - main view
+import {
+  gettingStartedVisible$,
+  onboardingFunnelState$,
+  sessionHintDismissed$,
+} from '../mainViewState';
+
+export const onboardingHandlers: MainViewHandlerRegistry = {
+  [MAIN_VIEW_COMMANDS.SET_ONBOARDING_FUNNEL]: (message) => {
+    onboardingFunnelState$.set(message.state);
+  },
+
+  [MAIN_VIEW_COMMANDS.SHOW_GETTING_STARTED_BANNER]: () => {
+    gettingStartedVisible$.set(true);
+  },
+  [MAIN_VIEW_COMMANDS.HIDE_GETTING_STARTED_BANNER]: () => {
+    gettingStartedVisible$.set(false);
+  },
+
+  [MAIN_VIEW_COMMANDS.SHOW_ORCHESTRATOR_BANNER]: () => {
+    sessionHintDismissed$.set(false);
+  },
+  [MAIN_VIEW_COMMANDS.HIDE_ORCHESTRATOR_BANNER]: () => {
+    sessionHintDismissed$.set(true);
+  },
+};

--- a/packages/extension/src/webview/frontend/slices/sessionSlice.ts
+++ b/packages/extension/src/webview/frontend/slices/sessionSlice.ts
@@ -1,0 +1,35 @@
+/**
+ * Session slice: host-pushed agent/session selection.
+ */
+
+// Local imports - shared IPC and schemas
+import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
+import type { MainViewHandlerRegistry } from '@shared/schemas';
+
+// Local imports - main view
+import { SESSION_TYPES, parseSessionType } from '../constants';
+import { sessionType$, toolUseAgent$, workflowAgent$ } from '../mainViewState';
+import {
+  refreshInstructionPlaceholder,
+  swapModeInstruction,
+} from '../mainViewActions';
+import { saveState } from '../persistence';
+
+export const sessionHandlers: MainViewHandlerRegistry = {
+  [MAIN_VIEW_COMMANDS.SET_SELECTED_AGENT]: (message) => {
+    const sessionType = parseSessionType(message.sessionType ?? undefined);
+    if (sessionType) {
+      swapModeInstruction(sessionType$.get(), sessionType);
+      sessionType$.set(sessionType);
+    }
+    if (message.agentId) {
+      if (sessionType$.get() === SESSION_TYPES.TOOL_USE) {
+        toolUseAgent$.set(message.agentId);
+      } else {
+        workflowAgent$.set(message.agentId);
+      }
+    }
+    refreshInstructionPlaceholder();
+    saveState();
+  },
+};

--- a/packages/extension/src/webview/frontend/webviewStorage.ts
+++ b/packages/extension/src/webview/frontend/webviewStorage.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared webview storage singleton for the main view.
+ *
+ * All modules in the main view frontend MUST use this shared instance rather
+ * than calling `createWebviewStorage(hostBridge)` independently. Multiple
+ * independent instances each maintain their own cache, so writes from one
+ * instance can silently overwrite changes made by another.
+ */
+import { createWebviewStorage } from '@shared/state';
+import { hostBridge } from '@shared/hostBridge';
+
+export const webviewStorage = createWebviewStorage(hostBridge);

--- a/src/test-kernel/webview/MainAppPersistenceRestore.vitest.mts
+++ b/src/test-kernel/webview/MainAppPersistenceRestore.vitest.mts
@@ -1,0 +1,423 @@
+// Third-party imports
+import { beforeEach, describe, expect, it } from 'vitest';
+
+// Local imports - shared constants and types
+import { COMMON_COMMANDS, MAIN_VIEW_COMMANDS } from '@shared/ipc';
+import { HOST_BRIDGE_API_KEY } from '@shared/hostBridgeTypes';
+import type {
+  FileStateContextValue,
+  MainViewPersistedState,
+  SessionContextValue,
+} from '@shared/schemas';
+
+// Local imports - component type (type-only: the module loads inside the DOM harness)
+import type { MainApp } from '@webview/frontend/MainApp';
+
+// Local imports - test utilities
+import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
+
+/**
+ * Characterization tests for MainApp's persistence/restore machinery.
+ *
+ * These pin down the CURRENT behavior of the two independently-triggered
+ * restore paths (issue #7075):
+ *   1. mount-time webview-storage restore (`restorePersistedState`), and
+ *   2. backend-pushed history-rerun/reset restore (`handleRestoreState`),
+ * including the legacy single-`instruction` migration precedence, the forced
+ * `outputFiles`/`outputFilesActive` reset, and the save-reentrancy guard
+ * (exactly one storage write per backend restore).
+ *
+ * They observe only refactor-stable surfaces — the `@provide`/`@state` context
+ * values, host-bridge storage writes, and posted messages — so they must pass
+ * unchanged before AND after the slice-store migration.
+ */
+
+type PostedMessage = { command: string } & Record<string, unknown>;
+
+const posted: PostedMessage[] = [];
+const storageWrites: Array<Record<string, unknown>> = [];
+let webviewState: Record<string, unknown>;
+
+/**
+ * Legacy persisted blob: predates the per-mode instruction fields (only the
+ * single `instruction` field is present) and carries stale output-file state
+ * that both restore paths must force back to inactive/empty.
+ */
+const LEGACY_SEED = {
+  sessionType: 'workflow',
+  workflowAgent: 'correct',
+  toolUseAgent: 'orchestrator',
+  model: 'seed-model',
+  commit: 'HEAD',
+  instruction: 'legacy single-field instruction',
+  editedFile: 'main_polish.tex',
+  baseFile: 'main.tex',
+  inputFiles: ['main.tex', 'appendix.tex'],
+  contextFiles: ['refs.bib'],
+  mediaFiles: [],
+  outputFiles: ['stale-output.tex'],
+  outputFilesActive: true,
+  latexdiffsVisible: true,
+  autoExtractFigure: true,
+  autoExtractTikzFigure: false,
+  autoCompileInputPdf: true,
+  attachTeXCount: true,
+};
+
+// Install the host-bridge stub at module scope, BEFORE the DOM harness imports
+// the MainApp module — `hostBridge` resolves this global at module load.
+webviewState = { mainViewState: structuredClone(LEGACY_SEED) };
+(globalThis as Record<string, unknown>)[HOST_BRIDGE_API_KEY] = {
+  postMessage: (message: unknown) => {
+    posted.push(message as PostedMessage);
+  },
+  getState: () => webviewState,
+  setState: (state: unknown) => {
+    webviewState = state as Record<string, unknown>;
+    // The storage layer mutates and re-passes one cache object; deep-copy at
+    // record time so each entry is a faithful snapshot of that write.
+    storageWrites.push(structuredClone(webviewState));
+  },
+};
+
+function contextsOf(element: MainApp): {
+  fileState: FileStateContextValue;
+  session: SessionContextValue;
+} {
+  const internal = element as unknown as {
+    fileStateContextValue: FileStateContextValue;
+    sessionContextValue: SessionContextValue;
+  };
+  return {
+    fileState: internal.fileStateContextValue,
+    session: internal.sessionContextValue,
+  };
+}
+
+async function mountMainApp(): Promise<MainApp> {
+  const element = document.createElement('main-app') as MainApp;
+  document.body.append(element);
+  await element.updateComplete;
+  return element;
+}
+
+function dispatchHostMessage(data: Record<string, unknown>): void {
+  window.dispatchEvent(new window.MessageEvent('message', { data }));
+}
+
+function lastPersistedBlob(): MainViewPersistedState {
+  const write = storageWrites.at(-1);
+  expect(write, 'expected at least one storage write').toBeDefined();
+  return write!.mainViewState as MainViewPersistedState;
+}
+
+/** Minimal valid full-shape restore blob; spread overrides per scenario. */
+function restoreState(
+  overrides: Partial<MainViewPersistedState> & Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    sessionType: 'toolUse',
+    workflowAgent: 'correct',
+    toolUseAgent: 'orchestrator',
+    model: 'restored-model',
+    commit: 'abc1234',
+    instruction: '',
+    workflowInstruction: '',
+    toolUseInstruction: '',
+    editedFile: 'restored_edited.tex',
+    baseFile: 'restored.tex',
+    inputFiles: ['restored.tex'],
+    contextFiles: ['restored.bib'],
+    mediaFiles: ['figure.png'],
+    outputFiles: ['restored-output.tex'],
+    outputFilesActive: true,
+    latexdiffsVisible: false,
+    autoExtractFigure: false,
+    autoExtractTikzFigure: true,
+    autoCompileInputPdf: false,
+    attachTeXCount: false,
+    ...overrides,
+  };
+}
+
+describe('MainApp persistence and restore characterization', () => {
+  useLitComponentTestDom(() => import('@webview/frontend/MainApp'));
+
+  beforeEach(() => {
+    posted.length = 0;
+    storageWrites.length = 0;
+  });
+
+  // NOTE: this test must run first — it characterizes the mount-time restore
+  // against the pristine LEGACY_SEED, before other tests overwrite storage.
+  it('restores persisted state on mount, migrating the legacy instruction and forcing output files inactive', async () => {
+    const element = await mountMainApp();
+    const { fileState, session } = contextsOf(element);
+
+    // Session/agent/model fields restored verbatim.
+    expect(session.sessionType).toBe('workflow');
+    expect(session.workflowAgent).toBe('correct');
+    expect(session.toolUseAgent).toBe('orchestrator');
+    expect(session.model).toBe('seed-model');
+
+    // Legacy migration: active mode was workflow, so the single legacy
+    // `instruction` becomes the workflow instruction and stays active.
+    expect(session.instruction).toBe('legacy single-field instruction');
+
+    // File state restored — EXCEPT output files, which are forced inactive.
+    expect(fileState.singleFiles).toEqual({
+      editedFile: 'main_polish.tex',
+      baseFile: 'main.tex',
+    });
+    expect(fileState.multiFiles).toEqual({
+      inputFiles: ['main.tex', 'appendix.tex'],
+      contextFiles: ['refs.bib'],
+      mediaFiles: [],
+      outputFiles: [],
+    });
+    expect(fileState.outputFilesActive).toBe(false);
+    expect(fileState.checkboxValues).toEqual({
+      autoExtractFigure: true,
+      autoExtractTikzFigure: false,
+      autoCompileInputPdf: true,
+      attachTeXCount: true,
+    });
+
+    // Mount-time restore alone must not write back to storage.
+    expect(storageWrites).toHaveLength(0);
+
+    // A subsequent save persists the migrated per-mode instructions and the
+    // forced-empty output state (never the stale seed values).
+    dispatchHostMessage({
+      command: MAIN_VIEW_COMMANDS.EDITED_FILE_SELECTED,
+      filePath: 'other_polish.tex',
+    });
+    const blob = lastPersistedBlob();
+    expect(blob.instruction).toBe('legacy single-field instruction');
+    expect(blob.workflowInstruction).toBe('legacy single-field instruction');
+    expect(blob.toolUseInstruction).toBe('');
+    expect(blob.outputFiles).toEqual([]);
+    expect(blob.outputFilesActive).toBe(false);
+    expect(blob.latexdiffsVisible).toBe(true);
+    expect(blob.editedFile).toBe('other_polish.tex');
+  });
+
+  it('applies a backend-pushed restore with exactly one storage write and forced output reset', async () => {
+    const element = await mountMainApp();
+    posted.length = 0;
+    storageWrites.length = 0;
+
+    dispatchHostMessage({
+      command: COMMON_COMMANDS.STATE_RESTORE,
+      state: restoreState({
+        toolUseInstruction: 'restored tool-use instruction',
+        workflowInstruction: 'restored workflow instruction',
+      }),
+    });
+    await element.updateComplete;
+
+    // Reentrancy guard characterization: the whole restore produces exactly
+    // one storage write (the trailing save), never intermediate saves.
+    expect(storageWrites).toHaveLength(1);
+
+    const blob = lastPersistedBlob();
+    expect(blob.sessionType).toBe('toolUse');
+    expect(blob.model).toBe('restored-model');
+    expect(blob.commit).toBe('abc1234');
+    expect(blob.editedFile).toBe('restored_edited.tex');
+    expect(blob.baseFile).toBe('restored.tex');
+    expect(blob.inputFiles).toEqual(['restored.tex']);
+    expect(blob.contextFiles).toEqual(['restored.bib']);
+    expect(blob.mediaFiles).toEqual(['figure.png']);
+    // Restored output files are dropped, not re-persisted.
+    expect(blob.outputFiles).toEqual([]);
+    expect(blob.outputFilesActive).toBe(false);
+    expect(blob.instruction).toBe('restored tool-use instruction');
+    expect(blob.workflowInstruction).toBe('restored workflow instruction');
+    expect(blob.toolUseInstruction).toBe('restored tool-use instruction');
+
+    const { fileState, session } = contextsOf(element);
+    expect(session.sessionType).toBe('toolUse');
+    expect(session.instruction).toBe('restored tool-use instruction');
+    expect(fileState.multiFiles.outputFiles).toEqual([]);
+    expect(fileState.outputFilesActive).toBe(false);
+    expect(fileState.checkboxValues.autoExtractTikzFigure).toBe(true);
+
+    // No execute unless explicitly requested.
+    expect(posted.filter((m) => m.command === MAIN_VIEW_COMMANDS.EXECUTE))
+      .toHaveLength(0);
+  });
+
+  it('migrates the legacy instruction to the workflow slot when restoring a workflow session', async () => {
+    const element = await mountMainApp();
+    storageWrites.length = 0;
+
+    dispatchHostMessage({
+      command: COMMON_COMMANDS.STATE_RESTORE,
+      state: restoreState({
+        sessionType: 'workflow',
+        instruction: 'legacy only',
+        workflowInstruction: '',
+        toolUseInstruction: '',
+      }),
+    });
+    await element.updateComplete;
+
+    const blob = lastPersistedBlob();
+    expect(blob.workflowInstruction).toBe('legacy only');
+    expect(blob.toolUseInstruction).toBe('');
+    expect(blob.instruction).toBe('legacy only');
+    expect(contextsOf(element).session.instruction).toBe('legacy only');
+  });
+
+  it('migrates the legacy instruction to the tool-use slot when restoring a tool-use session', async () => {
+    const element = await mountMainApp();
+    storageWrites.length = 0;
+
+    dispatchHostMessage({
+      command: COMMON_COMMANDS.STATE_RESTORE,
+      state: restoreState({
+        sessionType: 'toolUse',
+        instruction: 'legacy only',
+        workflowInstruction: '',
+        toolUseInstruction: '',
+      }),
+    });
+    await element.updateComplete;
+
+    const blob = lastPersistedBlob();
+    expect(blob.workflowInstruction).toBe('');
+    expect(blob.toolUseInstruction).toBe('legacy only');
+    expect(blob.instruction).toBe('legacy only');
+    expect(contextsOf(element).session.instruction).toBe('legacy only');
+  });
+
+  it('prefers per-mode instructions over the legacy field when both are present', async () => {
+    const element = await mountMainApp();
+    storageWrites.length = 0;
+
+    dispatchHostMessage({
+      command: COMMON_COMMANDS.STATE_RESTORE,
+      state: restoreState({
+        sessionType: 'workflow',
+        instruction: 'legacy loser',
+        workflowInstruction: 'workflow winner',
+        toolUseInstruction: 'tool-use winner',
+      }),
+    });
+    await element.updateComplete;
+
+    const blob = lastPersistedBlob();
+    expect(blob.workflowInstruction).toBe('workflow winner');
+    expect(blob.toolUseInstruction).toBe('tool-use winner');
+    expect(blob.instruction).toBe('workflow winner');
+    expect(contextsOf(element).session.instruction).toBe('workflow winner');
+  });
+
+  it('executes immediately after a successful restore when requested', async () => {
+    const element = await mountMainApp();
+    posted.length = 0;
+
+    dispatchHostMessage({
+      command: COMMON_COMMANDS.STATE_RESTORE,
+      state: restoreState({ toolUseInstruction: 'run this' }),
+      executeImmediately: true,
+    });
+    await element.updateComplete;
+
+    const executes = posted.filter(
+      (m) => m.command === MAIN_VIEW_COMMANDS.EXECUTE,
+    );
+    expect(executes).toHaveLength(1);
+    expect(executes[0].instruction).toBe('run this');
+  });
+
+  it('reset operation in workflow mode clears instructions and files and applies checkbox overrides', async () => {
+    const element = await mountMainApp();
+
+    // Establish a workflow session with content to clear.
+    dispatchHostMessage({
+      command: COMMON_COMMANDS.STATE_RESTORE,
+      state: restoreState({
+        sessionType: 'workflow',
+        workflowInstruction: 'about to be cleared',
+        autoExtractFigure: true,
+        autoExtractTikzFigure: true,
+        autoCompileInputPdf: true,
+        attachTeXCount: true,
+      }),
+    });
+    await element.updateComplete;
+    storageWrites.length = 0;
+
+    dispatchHostMessage({
+      command: COMMON_COMMANDS.STATE_RESTORE,
+      isResetOperation: true,
+    });
+    await element.updateComplete;
+
+    expect(storageWrites).toHaveLength(1);
+    const blob = lastPersistedBlob();
+    expect(blob.instruction).toBe('');
+    expect(blob.workflowInstruction).toBe('');
+    expect(blob.toolUseInstruction).toBe('');
+    expect(blob.editedFile).toBe('');
+    expect(blob.baseFile).toBe('');
+    expect(blob.inputFiles).toEqual([]);
+    expect(blob.contextFiles).toEqual([]);
+    expect(blob.mediaFiles).toEqual([]);
+    expect(blob.outputFiles).toEqual([]);
+    expect(blob.outputFilesActive).toBe(false);
+    // Workflow reset overrides the auto-extract/compile toggles but leaves
+    // attachTeXCount as the user set it.
+    expect(blob.autoExtractFigure).toBe(false);
+    expect(blob.autoExtractTikzFigure).toBe(false);
+    expect(blob.autoCompileInputPdf).toBe(false);
+    expect(blob.attachTeXCount).toBe(true);
+
+    const { fileState, session } = contextsOf(element);
+    expect(session.instruction).toBe('');
+    expect(fileState.singleFiles).toEqual({ editedFile: '', baseFile: '' });
+    expect(fileState.multiFiles).toEqual({
+      inputFiles: [],
+      contextFiles: [],
+      mediaFiles: [],
+      outputFiles: [],
+    });
+  });
+
+  it('reset operation in tool-use mode clears instructions but keeps file selections', async () => {
+    const element = await mountMainApp();
+
+    dispatchHostMessage({
+      command: COMMON_COMMANDS.STATE_RESTORE,
+      state: restoreState({
+        sessionType: 'toolUse',
+        toolUseInstruction: 'about to be cleared',
+        mediaFiles: ['kept-figure.png'],
+        editedFile: 'kept_edited.tex',
+      }),
+    });
+    await element.updateComplete;
+    storageWrites.length = 0;
+
+    dispatchHostMessage({
+      command: COMMON_COMMANDS.STATE_RESTORE,
+      isResetOperation: true,
+    });
+    await element.updateComplete;
+
+    expect(storageWrites).toHaveLength(1);
+    const blob = lastPersistedBlob();
+    expect(blob.instruction).toBe('');
+    expect(blob.workflowInstruction).toBe('');
+    expect(blob.toolUseInstruction).toBe('');
+    // Tool-use reset keeps file selections (SESSION_DEFAULTS.toolUse.resetFiles=false).
+    expect(blob.mediaFiles).toEqual(['kept-figure.png']);
+    expect(blob.editedFile).toBe('kept_edited.tex');
+
+    const { fileState, session } = contextsOf(element);
+    expect(session.instruction).toBe('');
+    expect(fileState.multiFiles.mediaFiles).toEqual(['kept-figure.png']);
+  });
+});

--- a/src/test-kernel/webview/MainAppPersistenceRestore.vitest.mts
+++ b/src/test-kernel/webview/MainAppPersistenceRestore.vitest.mts
@@ -244,8 +244,9 @@ describe('MainApp persistence and restore characterization', () => {
     expect(fileState.checkboxValues.autoExtractTikzFigure).toBe(true);
 
     // No execute unless explicitly requested.
-    expect(posted.filter((m) => m.command === MAIN_VIEW_COMMANDS.EXECUTE))
-      .toHaveLength(0);
+    expect(
+      posted.filter((m) => m.command === MAIN_VIEW_COMMANDS.EXECUTE),
+    ).toHaveLength(0);
   });
 
   it('migrates the legacy instruction to the workflow slot when restoring a workflow session', async () => {


### PR DESCRIPTION
Pin down the two restore paths (mount-time webview-storage restore and
backend-pushed history-rerun/reset restore) ahead of the slice-store
migration (#7075): legacy single-instruction migration precedence, the
forced outputFiles/outputFilesActive reset, single-storage-write save
guard behavior, and session-type-dependent reset semantics. Observes
only refactor-stable surfaces (context values, storage writes, posted
messages) so the suite must pass unchanged before and after.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015nsrZupDTyrmU76CkFMu5S

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large structural refactor of launcher state, persistence, and execute/file flows; behavior is intended to be unchanged but regression risk is real without the new characterization suite and broad manual checks.
> 
> **Overview**
> **Refactors the main webview launcher** by pulling most logic out of `MainApp` into a slice-store layout (issue #7075), aligned with the progress view pattern.
> 
> Reactive state moves to **`mainViewState.ts`** (module-scope signals, computed `fileStateContext$` / `sessionContext$`, and `resetMainViewState()` on remount). User-driven behavior lives in **`mainViewActions.ts`**; host IPC is routed through **`messageDispatcher.ts`** and domain **`slices/`** (catalog, session, document, chat, banner, onboarding). **`persistence.ts`** centralizes mount-time and backend `STATE_RESTORE` flows, debounced instruction saves, and the save-reentrancy guard, using a shared **`webviewStorage`** singleton.
> 
> `MainApp` keeps Lit wiring (events, render, context sync in `willUpdate`, including mirroring `debugMode` into signals). **`MainAppPersistenceRestore.vitest.mts`** pins restore semantics (legacy instruction migration, forced empty output files, single write per backend restore, reset-by-session-type) so behavior should stay stable across the move.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02e69202ee0da4628d591f97cf5d3fe8ef7d9eb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->