### PR TITLE
Centralize GitHub polling dedup resources

### DIFF
--- a/src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts
+++ b/src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts
@@ -5,7 +5,13 @@ import { afterEach, describe, expect, it, vi, type Mock } from 'vitest';
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 
 // Local imports - tools
-import type { GhCheckRun, GhPullRequest } from '@tools/github/prTypes';
+import type {
+  GhCheckRun,
+  GhIssueComment,
+  GhPullRequest,
+  GhReview,
+  GhReviewComment,
+} from '@tools/github/prTypes';
 
 // Local imports - test support
 import { mockGitHubClient } from '../support/githubClientMock';
@@ -19,9 +25,9 @@ interface CiStartedState {
     typeof noopAgentRuntimeHost
   >;
   initialized: boolean;
-  seenIssueCommentIds: Set<number>;
-  seenReviewCommentIds: Set<number>;
-  seenReviewIds: Set<number>;
+  issueComments: TestDedupedResource<GhIssueComment>;
+  reviewComments: TestDedupedResource<GhReviewComment>;
+  reviews: TestDedupedResource<GhReview>;
   lastFailedCheckKeys: Set<string>;
   lastAnnotationKeys: Set<string>;
   pendingAnnotationRuns: GhCheckRun[];
@@ -43,10 +49,6 @@ interface CiStartedState {
     pagesByPage: Map<number, GhCheckRun[]>;
     lastTotalCount: number;
   };
-  sinceCursors: {
-    issueComments?: string;
-    reviewComments?: string;
-  };
   lastSuccessAt: number;
   consecutiveFailures: number;
   skipPollUntilMs: number;
@@ -56,9 +58,23 @@ interface CiStartedSource {
   pollOne(key: string, state: CiStartedState): Promise<void>;
 }
 
+interface TestDedupedResource<T> {
+  sinceCursor: string | undefined;
+  seed(items: readonly T[]): void;
+  diff(items: readonly T[], emit: (item: T) => void): void;
+}
+
 const SHA = 'abcdef1234567890';
 const OLD_SHA = '1234567890abcdef';
 let emitCiStartedEvents = false;
+
+function testDedupedResource<T>(): TestDedupedResource<T> {
+  return {
+    sinceCursor: undefined,
+    seed: vi.fn(),
+    diff: vi.fn(),
+  };
+}
 
 function createState(
   events: string[],
@@ -71,9 +87,9 @@ function createState(
     listeners: new Set([listener]),
     runtimeHostByListener: new Map([[listener, noopAgentRuntimeHost]]),
     initialized: true,
-    seenIssueCommentIds: new Set(),
-    seenReviewCommentIds: new Set(),
-    seenReviewIds: new Set(),
+    issueComments: testDedupedResource(),
+    reviewComments: testDedupedResource(),
+    reviews: testDedupedResource(),
     lastFailedCheckKeys: new Set(),
     lastAnnotationKeys: new Set(),
     pendingAnnotationRuns: [],
@@ -85,7 +101,6 @@ function createState(
     merged: false,
     mergeableState: 'clean',
     etags: {},
-    sinceCursors: {},
     lastSuccessAt: Date.now(),
     consecutiveFailures: 0,
     skipPollUntilMs: 0,

--- a/src/test-kernel/tools/PollingSourceBase.vitest.ts
+++ b/src/test-kernel/tools/PollingSourceBase.vitest.ts
@@ -1,0 +1,132 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+import { z, type ZodType } from 'zod';
+
+// Local imports - tools
+import { getNewestTimestamp } from '@tools/github/formatUtils';
+import {
+  DedupedResource,
+  PollingSourceBase,
+  type BasePollSubscriptionState,
+} from '@tools/github/PollingSourceBase';
+import type { ConditionalResponse } from '@tools/github/githubClient';
+
+interface TestItem {
+  id: number;
+  created_at: string;
+  updated_at?: string | null;
+}
+
+class TestPollingSource extends PollingSourceBase<
+  string,
+  BasePollSubscriptionState
+> {
+  constructor() {
+    super({
+      name: 'TestPollingSource',
+      pollIntervalMs: 10_000,
+      maxConcurrent: 1,
+      backoffBaseMs: 1_000,
+      backoffMaxMs: 10_000,
+      maxFailureDurationMs: 60_000,
+    });
+  }
+
+  validate<T>(
+    res: ConditionalResponse<unknown>,
+    schema: ZodType<T>,
+  ): ConditionalResponse<T> | undefined {
+    return this.validateOrSkip(res, schema, 'bad payload');
+  }
+
+  setWarnForTest(warn: typeof this.logger.warn): void {
+    this.logger.warn = warn;
+  }
+
+  protected pollOne(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  protected formatErrorEvent(): string {
+    return 'subscription error';
+  }
+
+  protected emitKeysChangedEvent(): void {
+    // No-op: this test double doesn't need key-change events.
+  }
+}
+
+describe('DedupedResource', () => {
+  it('seeds seen ids, emits only newly seen items, advances cursor, and trims', () => {
+    const resource = new DedupedResource<TestItem>({
+      getId: (item) => item.id,
+      getCursor: getNewestTimestamp,
+      maxSeenIds: 3,
+      sinceCursor: '2026-07-04T00:00:00Z',
+    });
+
+    resource.seed([
+      { id: 1, created_at: '2026-07-04T00:00:01Z' },
+      { id: 2, created_at: '2026-07-04T00:00:02Z' },
+    ]);
+
+    expect([...resource.seenIds]).toEqual([1, 2]);
+    expect(resource.sinceCursor).toBe('2026-07-04T00:00:02Z');
+
+    const emitted: number[] = [];
+    resource.diff(
+      [
+        { id: 2, created_at: '2026-07-04T00:00:03Z' },
+        { id: 3, created_at: '2026-07-04T00:00:04Z' },
+        { id: 4, created_at: '2026-07-04T00:00:05Z' },
+      ],
+      (item) => emitted.push(item.id),
+    );
+
+    expect(emitted).toEqual([3, 4]);
+    expect(resource.sinceCursor).toBe('2026-07-04T00:00:05Z');
+    expect([...resource.seenIds]).toEqual([2, 3, 4]);
+  });
+
+  it('keeps an existing cursor when seeding an empty list', () => {
+    const resource = new DedupedResource<TestItem>({
+      getId: (item) => item.id,
+      getCursor: getNewestTimestamp,
+      maxSeenIds: 3,
+      sinceCursor: '2026-07-04T00:00:00Z',
+    });
+
+    resource.seed([]);
+
+    expect(resource.sinceCursor).toBe('2026-07-04T00:00:00Z');
+  });
+});
+
+describe('PollingSourceBase.validateOrSkip', () => {
+  it('returns parsed 200 responses and passes through 304 responses', () => {
+    const source = new TestPollingSource();
+    const schema = z.object({ id: z.number() });
+
+    expect(
+      source.validate({ status: 200, data: { id: 7 }, etag: 'etag' }, schema),
+    ).toEqual({ status: 200, data: { id: 7 }, etag: 'etag' });
+
+    expect(source.validate({ status: 304 }, schema)).toEqual({ status: 304 });
+  });
+
+  it('logs and skips malformed 200 responses without throwing', () => {
+    const source = new TestPollingSource();
+    const warn = vi.fn();
+    source.setWarnForTest(warn);
+
+    const result = source.validate(
+      { status: 200, data: { id: 'bad' }, etag: 'etag' },
+      z.object({ id: z.number() }),
+    );
+
+    expect(result).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith('bad payload', {
+      data: expect.any(z.ZodError),
+    });
+  });
+});

--- a/src/tools/github/IssuePollingSource.ts
+++ b/src/tools/github/IssuePollingSource.ts
@@ -23,9 +23,11 @@ import {
   formatIssueReopened,
   formatIssueSubscriptionError,
 } from './formatIssueEvent';
-import { getNewestTimestamp, trimSet, withSince } from './formatUtils';
+import { getNewestTimestamp, withSince } from './formatUtils';
 import { ghGet } from './githubClient';
 import {
+  DedupedResource,
+  DEFAULT_POLLING_BACKOFF_CONFIG,
   PollingSourceBase,
   type BasePollSubscriptionState,
 } from './PollingSourceBase';
@@ -57,9 +59,8 @@ interface SubscriptionState extends BasePollSubscriptionState {
   slug: string;
   initialized: boolean;
   state: 'open' | 'closed' | undefined;
-  seenCommentIds: Set<number>;
+  comments: DedupedResource<GhIssueComment>;
   etags: { issue?: string; comments?: string };
-  sinceCursor?: string;
 }
 
 function createInitialState(issue: IssueKey): SubscriptionState {
@@ -70,9 +71,12 @@ function createInitialState(issue: IssueKey): SubscriptionState {
     runtimeHostByListener: new Map(),
     initialized: false,
     state: undefined,
-    seenCommentIds: new Set(),
+    comments: new DedupedResource<GhIssueComment>({
+      getId: (comment: GhIssueComment) => comment.id,
+      getCursor: getNewestTimestamp,
+      maxSeenIds: MAX_SEEN_IDS,
+    }),
     etags: {},
-    sinceCursor: undefined,
     lastSuccessAt: Date.now(),
     consecutiveFailures: 0,
     skipPollUntilMs: 0,
@@ -85,9 +89,7 @@ class IssuePollingSource extends PollingSourceBase<string, SubscriptionState> {
       name: 'IssuePollingSource',
       pollIntervalMs: 30_000,
       maxConcurrent: 10,
-      backoffBaseMs: 60_000,
-      backoffMaxMs: 3_600_000,
-      maxFailureDurationMs: 24 * 3_600_000,
+      ...DEFAULT_POLLING_BACKOFF_CONFIG,
     });
   }
 
@@ -136,7 +138,7 @@ class IssuePollingSource extends PollingSourceBase<string, SubscriptionState> {
     const issuePath = `/repos/${issue.owner}/${issue.repo}/issues/${issue.issueNumber}`;
     const commentsUrl = withSince(
       `${issuePath}/comments?per_page=100`,
-      state.sinceCursor,
+      state.comments.sinceCursor,
     );
 
     // The two endpoints are independent — fetch in parallel.
@@ -151,8 +153,12 @@ class IssuePollingSource extends PollingSourceBase<string, SubscriptionState> {
       // the independent comments fetch below — a malformed issue payload must
       // not block comment delivery. Never throw: a throw would stall
       // lastSuccessAt and risk the 24 h detach of a live subscription.
-      const parsedIssue = GhIssueSchema.safeParse(issueRes.data);
-      if (parsedIssue.success) {
+      const parsedIssue = this.validateOrSkip(
+        issueRes,
+        GhIssueSchema,
+        `Skipping issue-state check for ${state.slug}#${issue.issueNumber}: malformed issue payload`,
+      );
+      if (parsedIssue?.status === 200) {
         const issueData = parsedIssue.data;
         state.etags.issue = issueRes.etag;
         const newState = issueData.state;
@@ -182,40 +188,30 @@ class IssuePollingSource extends PollingSourceBase<string, SubscriptionState> {
           );
         }
         state.state = newState;
-      } else {
-        this.logger.warn(
-          `Skipping issue-state check for ${state.slug}#${issue.issueNumber}: malformed issue payload`,
-          { data: parsedIssue.error },
-        );
       }
     }
 
     // Parse the comments array once; both the seeding and diff branches below
     // consume `comments`. Non-throwing: on a malformed payload, log + skip this
-    // tick. state.etags.comments and state.sinceCursor are advanced only inside
+    // tick. state.etags.comments and the comments cursor are advanced only inside
     // the guarded branches, so a skip re-fetches next tick (no If-None-Match)
     // and lastSuccessAt still advances → no 24 h detach. A bad single element
     // triggers a whole-array skip instead of a mid-loop TypeError throw.
     let comments: GhIssueComment[] | undefined;
     if (commentsRes.status === 200) {
-      const parsedComments = GhIssueCommentArraySchema.safeParse(
-        commentsRes.data,
+      const parsedComments = this.validateOrSkip(
+        commentsRes,
+        GhIssueCommentArraySchema,
+        `Skipping comments tick for ${state.slug}#${issue.issueNumber}: malformed comments payload`,
       );
-      if (!parsedComments.success) {
-        this.logger.warn(
-          `Skipping comments tick for ${state.slug}#${issue.issueNumber}: malformed comments payload`,
-          { data: parsedComments.error },
-        );
-        return;
-      }
+      if (!parsedComments) return;
       comments = parsedComments.data;
     }
 
     if (!state.initialized) {
       if (commentsRes.status === 200 && comments) {
         state.etags.comments = commentsRes.etag;
-        for (const c of comments) state.seenCommentIds.add(c.id);
-        state.sinceCursor = getNewestTimestamp(comments);
+        state.comments.seed(comments);
       }
       state.initialized = true;
       return;
@@ -223,14 +219,10 @@ class IssuePollingSource extends PollingSourceBase<string, SubscriptionState> {
 
     if (commentsRes.status === 200 && comments) {
       state.etags.comments = commentsRes.etag;
-      for (const c of comments) {
-        if (state.seenCommentIds.has(c.id)) continue;
-        state.seenCommentIds.add(c.id);
-        if (shouldDropBotEvent(c.user)) continue;
+      state.comments.diff(comments, (c) => {
+        if (shouldDropBotEvent(c.user)) return;
         this.emit(state, formatIssueComment(state.slug, issue.issueNumber, c));
-      }
-      state.sinceCursor = getNewestTimestamp(comments) ?? state.sinceCursor;
-      trimSet(state.seenCommentIds, MAX_SEEN_IDS);
+      });
     }
   }
 }

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -34,7 +34,7 @@ import {
   formatReviewComment,
   formatSubscriptionError,
 } from './formatPREvent';
-import { getNewestTimestamp, trimSet, withSince } from './formatUtils';
+import { getNewestTimestamp, withSince } from './formatUtils';
 import {
   ghGet,
   GitHubAuthError,
@@ -58,6 +58,8 @@ import {
   planAnnotationCandidates,
 } from './prCheckRunDomain';
 import {
+  DedupedResource,
+  DEFAULT_POLLING_BACKOFF_CONFIG,
   PollingSourceBase,
   type BasePollSubscriptionState,
 } from './PollingSourceBase';
@@ -95,9 +97,20 @@ function createInitialState(pr: PRKey): SubscriptionState {
     listeners: new Set(),
     runtimeHostByListener: new Map(),
     initialized: false,
-    seenIssueCommentIds: new Set(),
-    seenReviewCommentIds: new Set(),
-    seenReviewIds: new Set(),
+    issueComments: new DedupedResource<GhIssueComment>({
+      getId: (comment: GhIssueComment) => comment.id,
+      getCursor: getNewestTimestamp,
+      maxSeenIds: MAX_SEEN_IDS,
+    }),
+    reviewComments: new DedupedResource<GhReviewComment>({
+      getId: (comment: GhReviewComment) => comment.id,
+      getCursor: getNewestTimestamp,
+      maxSeenIds: MAX_SEEN_IDS,
+    }),
+    reviews: new DedupedResource<GhReview>({
+      getId: (review: GhReview) => review.id,
+      maxSeenIds: MAX_SEEN_IDS,
+    }),
     lastFailedCheckKeys: new Set(),
     lastAnnotationKeys: new Set(),
     pendingAnnotationRuns: [],
@@ -110,7 +123,6 @@ function createInitialState(pr: PRKey): SubscriptionState {
     merged: false,
     mergeableState: undefined,
     etags: {},
-    sinceCursors: {},
     lastSuccessAt: Date.now(),
     consecutiveFailures: 0,
     skipPollUntilMs: 0,
@@ -126,6 +138,10 @@ const MAX_SEEN_IDS = 1000;
 // lighting up a fleet of checks). Excess candidates stay in
 // `pendingAnnotationRuns` and are drained on subsequent ticks.
 const MAX_ANNOTATION_RUNS_PER_SUBSCRIPTION_TICK = 3;
+
+function isSubmittedReview(review: GhReview): boolean {
+  return review.state !== 'PENDING';
+}
 
 export interface PRKey {
   owner: string;
@@ -146,9 +162,9 @@ interface SubscriptionState extends BasePollSubscriptionState {
   slug: string;
   /** Initialized on first tick so we don't replay historical events. */
   initialized: boolean;
-  seenIssueCommentIds: Set<number>;
-  seenReviewCommentIds: Set<number>;
-  seenReviewIds: Set<number>;
+  issueComments: DedupedResource<GhIssueComment>;
+  reviewComments: DedupedResource<GhReviewComment>;
+  reviews: DedupedResource<GhReview>;
   lastFailedCheckKeys: Set<string>;
   /**
    * `${id}:${completed_at}` for runs observed (with annotations) on the most
@@ -195,14 +211,6 @@ interface SubscriptionState extends BasePollSubscriptionState {
    * it tells us how many pages to walk when page 1 returns 304.
    */
   checkRunsCache?: CheckRunsCache;
-  // ISO `since` cursors for server-side filtering on the comments endpoints.
-  // Advance to the newest seen item's timestamp so PRs with >100 comments
-  // still surface new activity (default sort is oldest-first; without
-  // `since` the recent items fall off the first page).
-  sinceCursors: {
-    issueComments?: string;
-    reviewComments?: string;
-  };
 }
 
 export class PRPollingSource extends PollingSourceBase<
@@ -216,9 +224,7 @@ export class PRPollingSource extends PollingSourceBase<
       name: 'PRPollingSource',
       pollIntervalMs: PR_POLL_INTERVAL_MS,
       maxConcurrent: MAX_CONCURRENT_PR_SUBSCRIPTIONS,
-      backoffBaseMs: 60_000,
-      backoffMaxMs: 3_600_000,
-      maxFailureDurationMs: 24 * 3_600_000,
+      ...DEFAULT_POLLING_BACKOFF_CONFIG,
     });
   }
 
@@ -324,14 +330,12 @@ export class PRPollingSource extends PollingSourceBase<
       // never trips. We skip BEFORE writing state.etags.pr, so the PR-detail
       // ETag is not advanced on a bad body — the next tick re-fetches the same
       // resource and re-validates (no strand).
-      const parsed = GhPullRequestSchema.safeParse(prRes.data);
-      if (!parsed.success) {
-        this.logger.warn(
-          `Skipping PR poll for ${prKeyToString(pr)}: malformed pull-request payload`,
-          { data: parsed.error },
-        );
-        return;
-      }
+      const parsed = this.validateOrSkip(
+        prRes,
+        GhPullRequestSchema,
+        `Skipping PR poll for ${prKeyToString(pr)}: malformed pull-request payload`,
+      );
+      if (!parsed) return;
       const prData = parsed.data;
       state.etags.pr = prRes.etag;
       const newHead = prData.head.sha;
@@ -420,11 +424,11 @@ export class PRPollingSource extends PollingSourceBase<
 
     const issueCommentsUrl = withSince(
       `${issuePath}/comments?per_page=100`,
-      state.sinceCursors.issueComments,
+      state.issueComments.sinceCursor,
     );
     const reviewCommentsUrl = withSince(
       `${prPath}/comments?per_page=100`,
-      state.sinceCursors.reviewComments,
+      state.reviewComments.sinceCursor,
     );
     const [commentsRes, reviewCommentsRes, reviewsRes, checksOutcome] =
       await Promise.all([
@@ -459,16 +463,11 @@ export class PRPollingSource extends PollingSourceBase<
     if (!state.initialized) {
       if (commentsRes.status === 200) {
         state.etags.issueComments = commentsRes.etag;
-        for (const c of commentsRes.data) state.seenIssueCommentIds.add(c.id);
-        state.sinceCursors.issueComments = getNewestTimestamp(commentsRes.data);
+        state.issueComments.seed(commentsRes.data);
       }
       if (reviewCommentsRes.status === 200) {
         state.etags.reviewComments = reviewCommentsRes.etag;
-        for (const c of reviewCommentsRes.data)
-          state.seenReviewCommentIds.add(c.id);
-        state.sinceCursors.reviewComments = getNewestTimestamp(
-          reviewCommentsRes.data,
-        );
+        state.reviewComments.seed(reviewCommentsRes.data);
       }
       if (reviewsRes.status === 200) {
         state.etags.reviews = reviewsRes.etag;
@@ -477,9 +476,7 @@ export class PRPollingSource extends PollingSourceBase<
         // when it transitions PENDING → APPROVED/CHANGES_REQUESTED/COMMENTED,
         // so if we seed the pending id here the actual submission will be
         // silently deduped later.
-        for (const r of reviewsRes.data) {
-          if (r.state !== 'PENDING') state.seenReviewIds.add(r.id);
-        }
+        state.reviews.seed(reviewsRes.data.filter(isSubmittedReview));
       }
       if (checksRes.status === 200) {
         // ETag/page caching is owned by `fetchAllCheckRuns` via
@@ -529,49 +526,30 @@ export class PRPollingSource extends PollingSourceBase<
     // Diff and emit.
     if (commentsRes.status === 200) {
       state.etags.issueComments = commentsRes.etag;
-      for (const c of commentsRes.data) {
-        if (!state.seenIssueCommentIds.has(c.id)) {
-          state.seenIssueCommentIds.add(c.id);
-          if (shouldDropBotEvent(c.user)) continue;
-          this.emit(state, formatIssueComment(state.slug, pr.pullNumber, c));
-        }
-      }
-      state.sinceCursors.issueComments =
-        getNewestTimestamp(commentsRes.data) ??
-        state.sinceCursors.issueComments;
-      trimSet(state.seenIssueCommentIds, MAX_SEEN_IDS);
+      state.issueComments.diff(commentsRes.data, (c) => {
+        if (shouldDropBotEvent(c.user)) return;
+        this.emit(state, formatIssueComment(state.slug, pr.pullNumber, c));
+      });
     }
 
     if (reviewCommentsRes.status === 200) {
       state.etags.reviewComments = reviewCommentsRes.etag;
-      for (const c of reviewCommentsRes.data) {
-        if (!state.seenReviewCommentIds.has(c.id)) {
-          state.seenReviewCommentIds.add(c.id);
-          if (shouldDropBotEvent(c.user)) continue;
-          this.emit(state, formatReviewComment(state.slug, pr.pullNumber, c));
-        }
-      }
-      state.sinceCursors.reviewComments =
-        getNewestTimestamp(reviewCommentsRes.data) ??
-        state.sinceCursors.reviewComments;
-      trimSet(state.seenReviewCommentIds, MAX_SEEN_IDS);
+      state.reviewComments.diff(reviewCommentsRes.data, (c) => {
+        if (shouldDropBotEvent(c.user)) return;
+        this.emit(state, formatReviewComment(state.slug, pr.pullNumber, c));
+      });
     }
 
     if (reviewsRes.status === 200) {
       state.etags.reviews = reviewsRes.etag;
-      for (const r of reviewsRes.data) {
-        // Same reasoning as the seeding branch: ignore PENDING drafts —
-        // they keep the same id when submitted, and emitting "reviewed"
-        // on a draft would both be misleading and prevent the real
-        // submission event from firing.
-        if (r.state === 'PENDING') continue;
-        if (!state.seenReviewIds.has(r.id)) {
-          state.seenReviewIds.add(r.id);
-          if (shouldDropBotEvent(r.user)) continue;
-          this.emit(state, formatReview(state.slug, pr.pullNumber, r));
-        }
-      }
-      trimSet(state.seenReviewIds, MAX_SEEN_IDS);
+      // Same reasoning as the seeding branch: ignore PENDING drafts — they
+      // keep the same id when submitted, and emitting "reviewed" on a draft
+      // would both be misleading and prevent the real submission event from
+      // firing.
+      state.reviews.diff(reviewsRes.data.filter(isSubmittedReview), (r) => {
+        if (shouldDropBotEvent(r.user)) return;
+        this.emit(state, formatReview(state.slug, pr.pullNumber, r));
+      });
     }
 
     if (checksRes.status === 200) {

--- a/src/tools/github/PollingSourceBase.ts
+++ b/src/tools/github/PollingSourceBase.ts
@@ -20,10 +20,13 @@ import { createChannelTrace } from '@logger';
 import { unique } from '@utils/core';
 
 import {
+  type ConditionalResponse,
   GitHubAuthError,
   GitHubPermanentError,
   GitHubRateLimitError,
 } from './githubClient';
+import { trimSet } from './formatUtils';
+import type { ZodType } from 'zod';
 
 import type { Disposable } from '@platform/interfaces/disposable';
 
@@ -45,6 +48,73 @@ export interface PollingSourceConfig {
   backoffBaseMs: number;
   backoffMaxMs: number;
   maxFailureDurationMs: number;
+}
+
+type SuccessfulConditionalResponse<T> = Extract<
+  ConditionalResponse<T>,
+  { status: 200 }
+>;
+
+export const DEFAULT_POLLING_BACKOFF_CONFIG = {
+  backoffBaseMs: 60_000,
+  backoffMaxMs: 3_600_000,
+  maxFailureDurationMs: 24 * 3_600_000,
+} satisfies Pick<
+  PollingSourceConfig,
+  'backoffBaseMs' | 'backoffMaxMs' | 'maxFailureDurationMs'
+>;
+
+interface DedupedResourceOptions<T, Id> {
+  getId(item: T): Id;
+  getCursor?(items: readonly T[]): string | undefined;
+  maxSeenIds: number;
+  sinceCursor?: string;
+}
+
+export class DedupedResource<T, Id = number> {
+  readonly seenIds: Set<Id>;
+  sinceCursor: string | undefined;
+
+  private readonly getId: (item: T) => Id;
+  private readonly getCursor:
+    ((items: readonly T[]) => string | undefined) | undefined;
+  private readonly maxSeenIds: number;
+
+  constructor(options: DedupedResourceOptions<T, Id>) {
+    this.getId = options.getId;
+    this.getCursor = options.getCursor;
+    this.maxSeenIds = options.maxSeenIds;
+    this.sinceCursor = options.sinceCursor;
+    this.seenIds = new Set();
+  }
+
+  seed(items: readonly T[]): void {
+    for (const item of items) {
+      this.seenIds.add(this.getId(item));
+    }
+    this.advanceCursor(items);
+    this.trim();
+  }
+
+  diff(items: readonly T[], emit: (item: T) => void): void {
+    for (const item of items) {
+      const id = this.getId(item);
+      if (this.seenIds.has(id)) continue;
+      this.seenIds.add(id);
+      emit(item);
+    }
+    this.advanceCursor(items);
+    this.trim();
+  }
+
+  private advanceCursor(items: readonly T[]): void {
+    const newest = this.getCursor?.(items);
+    if (newest) this.sinceCursor = newest;
+  }
+
+  private trim(): void {
+    trimSet(this.seenIds, this.maxSeenIds);
+  }
 }
 
 /**
@@ -166,6 +236,30 @@ export abstract class PollingSourceBase<
         this.logger.warn('Listener threw', { data: err });
       }
     }
+  }
+
+  protected validateOrSkip<T>(
+    res: SuccessfulConditionalResponse<unknown>,
+    schema: ZodType<T>,
+    label: string,
+  ): SuccessfulConditionalResponse<T> | undefined;
+  protected validateOrSkip<T>(
+    res: ConditionalResponse<unknown>,
+    schema: ZodType<T>,
+    label: string,
+  ): ConditionalResponse<T> | undefined;
+  protected validateOrSkip<T>(
+    res: ConditionalResponse<unknown>,
+    schema: ZodType<T>,
+    label: string,
+  ): ConditionalResponse<T> | undefined {
+    if (res.status === 304) return res;
+    const parsed = schema.safeParse(res.data);
+    if (!parsed.success) {
+      this.logger.warn(label, { data: parsed.error });
+      return undefined;
+    }
+    return { ...res, data: parsed.data };
   }
 
   /**

--- a/src/tools/github/RepoPollingSource.ts
+++ b/src/tools/github/RepoPollingSource.ts
@@ -48,9 +48,11 @@ import {
   formatRepoReviewComment,
   formatRepoSubscriptionError,
 } from './formatRepoEvent';
-import { getNewestTimestamp, trimSet } from './formatUtils';
+import { getNewestTimestamp } from './formatUtils';
 import { ghGet } from './githubClient';
 import {
+  DedupedResource,
+  DEFAULT_POLLING_BACKOFF_CONFIG,
   PollingSourceBase,
   type BasePollSubscriptionState,
 } from './PollingSourceBase';
@@ -83,7 +85,7 @@ const SEED_WINDOW_MS = 60_000;
 // least-recently-used PR on overflow; `.get()`/`.set()` both refresh recency,
 // so closed-and-forgotten PRs roll off before actively-touched ones.
 const MAX_PR_STATE_ENTRIES = 500;
-// Cap on the per-comment seen-id sets, mirroring PRPollingSource. Events
+// Cap on the per-comment dedup resources, mirroring PRPollingSource. Events
 // older than this fall out of the dedup window — but the `since` cursor
 // will normally have advanced past them by then anyway.
 const MAX_SEEN_IDS = 1000;
@@ -122,24 +124,15 @@ interface SubscriptionState extends BasePollSubscriptionState {
    */
   subscribedAt: string;
   /**
-   * ISO timestamps for `since=` filtering on the comments endpoints. Advanced
-   * to the newest seen item after each successful tick so we don't replay
-   * history. The pulls endpoint does NOT support `since` (only `state`,
-   * `head`, `base`, `sort`, `direction`, `per_page`, `page`), so we don't
-   * track a cursor for it.
+   * Per-comment-id dedup plus ISO `since=` cursors for the comments endpoints.
+   * The comments endpoints use `since` with `>=` semantics, so the newest item
+   * per batch reappears every tick; edited comments also resurface with a new
+   * `updated_at`. Without ID tracking the same comment fires "New comment"
+   * repeatedly. The pulls endpoint does NOT support `since`, so PR transitions
+   * are tracked by the per-PR maps below instead.
    */
-  since: {
-    issueComments: string;
-    reviewComments: string;
-  };
-  /**
-   * Per-comment-id dedup. The comments endpoints use `since` with `>=`
-   * semantics, so the newest item per batch reappears every tick; edited
-   * comments also resurface with a new `updated_at`. Without ID-tracking
-   * the same comment fires "New comment" repeatedly. Trimmed to MAX_SEEN_IDS.
-   */
-  seenIssueCommentIds: Set<number>;
-  seenReviewCommentIds: Set<number>;
+  issueComments: DedupedResource<GhIssueComment>;
+  reviewComments: DedupedResource<GhReviewComment>;
   /**
    * Per-PR last-known state, indexed by PR number. Lets us emit a single
    * "opened" / "closed" / "merged" event per transition rather than every
@@ -167,9 +160,7 @@ class RepoPollingSource extends PollingSourceBase<RepoKey, SubscriptionState> {
       name: 'RepoPollingSource',
       pollIntervalMs: 30_000,
       maxConcurrent: 3,
-      backoffBaseMs: 60_000,
-      backoffMaxMs: 3_600_000,
-      maxFailureDurationMs: 24 * 3_600_000,
+      ...DEFAULT_POLLING_BACKOFF_CONFIG,
     });
   }
 
@@ -212,8 +203,8 @@ class RepoPollingSource extends PollingSourceBase<RepoKey, SubscriptionState> {
     state: SubscriptionState,
   ): Promise<void> {
     const { owner, repo } = state;
-    const issuePath = `/repos/${owner}/${repo}/issues/comments?per_page=${PER_PAGE}&since=${encodeURIComponent(state.since.issueComments)}&sort=updated&direction=asc`;
-    const reviewPath = `/repos/${owner}/${repo}/pulls/comments?per_page=${PER_PAGE}&since=${encodeURIComponent(state.since.reviewComments)}&sort=updated&direction=asc`;
+    const issuePath = `/repos/${owner}/${repo}/issues/comments?per_page=${PER_PAGE}&since=${encodeURIComponent(state.issueComments.sinceCursor ?? '')}&sort=updated&direction=asc`;
+    const reviewPath = `/repos/${owner}/${repo}/pulls/comments?per_page=${PER_PAGE}&since=${encodeURIComponent(state.reviewComments.sinceCursor ?? '')}&sort=updated&direction=asc`;
     // The /pulls list endpoint does NOT support `since`; we get the top
     // 100 most-recently-updated PRs every tick. The `prStateByNumber`
     // transition tracker is what makes that safe.
@@ -229,41 +220,34 @@ class RepoPollingSource extends PollingSourceBase<RepoKey, SubscriptionState> {
     // this tick), NEVER throw: pollEntry() resets lastSuccessAt on a normal
     // return, but a throw routes to handleFailure, and a generic failure that
     // persists past maxFailureDurationMs (24 h) DETACHES the live subscription.
-    // Skipping is safe because nothing is mutated yet — the `since` cursors and
-    // prStateByNumber/prUpdatedAtByNumber maps are untouched, comment dedup is
-    // by seen-id Sets, and PR transitions compare prev-vs-next — so the same
-    // window is re-evaluated idempotently next tick.
+    // Skipping is safe because no parsed response has been committed yet: the
+    // DedupedResource instances and PR transition/probe maps are untouched, so
+    // the same window is re-evaluated idempotently next tick.
     if (issueRes.status === 200) {
-      const parsed = GhIssueCommentArraySchema.safeParse(issueRes.data);
-      if (!parsed.success) {
-        this.logger.warn(
-          `Skipping ${owner}/${repo} tick: issue-comments payload failed validation`,
-          { data: parsed.error },
-        );
-        return;
-      }
+      const parsed = this.validateOrSkip(
+        issueRes,
+        GhIssueCommentArraySchema,
+        `Skipping ${owner}/${repo} tick: issue-comments payload failed validation`,
+      );
+      if (!parsed) return;
       issueRes.data = parsed.data;
     }
     if (reviewRes.status === 200) {
-      const parsed = GhReviewCommentArraySchema.safeParse(reviewRes.data);
-      if (!parsed.success) {
-        this.logger.warn(
-          `Skipping ${owner}/${repo} tick: review-comments payload failed validation`,
-          { data: parsed.error },
-        );
-        return;
-      }
+      const parsed = this.validateOrSkip(
+        reviewRes,
+        GhReviewCommentArraySchema,
+        `Skipping ${owner}/${repo} tick: review-comments payload failed validation`,
+      );
+      if (!parsed) return;
       reviewRes.data = parsed.data;
     }
     if (pullsRes.status === 200) {
-      const parsed = GhPullsListEntryArraySchema.safeParse(pullsRes.data);
-      if (!parsed.success) {
-        this.logger.warn(
-          `Skipping ${owner}/${repo} tick: pulls-list payload failed validation`,
-          { data: parsed.error },
-        );
-        return;
-      }
+      const parsed = this.validateOrSkip(
+        pullsRes,
+        GhPullsListEntryArraySchema,
+        `Skipping ${owner}/${repo} tick: pulls-list payload failed validation`,
+      );
+      if (!parsed) return;
       pullsRes.data = parsed.data;
     }
 
@@ -281,14 +265,10 @@ class RepoPollingSource extends PollingSourceBase<RepoKey, SubscriptionState> {
         }
       }
       if (issueRes.status === 200) {
-        for (const c of issueRes.data) state.seenIssueCommentIds.add(c.id);
-        const newest = getNewestTimestamp(issueRes.data);
-        if (newest) state.since.issueComments = newest;
+        state.issueComments.seed(issueRes.data);
       }
       if (reviewRes.status === 200) {
-        for (const c of reviewRes.data) state.seenReviewCommentIds.add(c.id);
-        const newest = getNewestTimestamp(reviewRes.data);
-        if (newest) state.since.reviewComments = newest;
+        state.reviewComments.seed(reviewRes.data);
       }
       state.initialized = true;
       return;
@@ -324,31 +304,21 @@ class RepoPollingSource extends PollingSourceBase<RepoKey, SubscriptionState> {
     }
 
     if (issueRes.status === 200) {
-      for (const c of issueRes.data) {
-        if (state.seenIssueCommentIds.has(c.id)) continue;
-        state.seenIssueCommentIds.add(c.id);
+      state.issueComments.diff(issueRes.data, (c) => {
         const number = parseTargetNumberFromIssueUrl(c);
-        if (number === undefined) continue;
-        if (shouldDropBotEvent(c.user)) continue;
+        if (number === undefined) return;
+        if (shouldDropBotEvent(c.user)) return;
         this.emit(state, formatRepoIssueComment(state.slug, number, c));
-      }
-      trimSet(state.seenIssueCommentIds, MAX_SEEN_IDS);
-      const newest = getNewestTimestamp(issueRes.data);
-      if (newest) state.since.issueComments = newest;
+      });
     }
 
     if (reviewRes.status === 200) {
-      for (const c of reviewRes.data) {
-        if (state.seenReviewCommentIds.has(c.id)) continue;
-        state.seenReviewCommentIds.add(c.id);
+      state.reviewComments.diff(reviewRes.data, (c) => {
         const prNumber = parsePRNumberFromReviewCommentUrl(c.html_url);
-        if (prNumber === undefined) continue;
-        if (shouldDropBotEvent(c.user)) continue;
+        if (prNumber === undefined) return;
+        if (shouldDropBotEvent(c.user)) return;
         this.emit(state, formatRepoReviewComment(state.slug, prNumber, c));
-      }
-      trimSet(state.seenReviewCommentIds, MAX_SEEN_IDS);
-      const newest = getNewestTimestamp(reviewRes.data);
-      if (newest) state.since.reviewComments = newest;
+      });
     }
     // Bare APPROVED/DISMISSED reviews without comments aren't surfaced — they
     // live only on /pulls/{n}/reviews, which is per-PR. An orchestrator that
@@ -491,12 +461,18 @@ function createInitialState(owner: string, repo: string): SubscriptionState {
     runtimeHostByListener: new Map(),
     initialized: false,
     subscribedAt: new Date(now).toISOString(),
-    since: {
-      issueComments: seed,
-      reviewComments: seed,
-    },
-    seenIssueCommentIds: new Set(),
-    seenReviewCommentIds: new Set(),
+    issueComments: new DedupedResource<GhIssueComment>({
+      getId: (comment: GhIssueComment) => comment.id,
+      getCursor: getNewestTimestamp,
+      maxSeenIds: MAX_SEEN_IDS,
+      sinceCursor: seed,
+    }),
+    reviewComments: new DedupedResource<GhReviewComment>({
+      getId: (comment: GhReviewComment) => comment.id,
+      getCursor: getNewestTimestamp,
+      maxSeenIds: MAX_SEEN_IDS,
+      sinceCursor: seed,
+    }),
     prStateByNumber: new LRUCache({ max: MAX_PR_STATE_ENTRIES }),
     prUpdatedAtByNumber: new LRUCache({ max: MAX_PR_STATE_ENTRIES }),
     prMergeableByNumber: new LRUCache({ max: MAX_PR_STATE_ENTRIES }),


### PR DESCRIPTION
## Summary

Consolidates the repeated GitHub polling seed/diff bookkeeping into `DedupedResource<T>` on `PollingSourceBase`. Issue, repo, and PR pollers now keep per-resource seen-id sets and since cursors in that shared primitive, while endpoint-specific behavior stays local: PR/repo state transitions, ETag writes, bot filtering, PENDING-review handling, check-run handling, and repo mergeability probing are unchanged.

Also adds `PollingSourceBase.validateOrSkip()` for the existing non-throwing parse-or-skip boundaries and hoists the shared polling backoff defaults used by all three GitHub pollers.

## Issue acceptance gates

- Addresses #7069: adds `DedupedResource<T>` on `PollingSourceBase` owning seen IDs and optional since cursor with `seed()` / `diff()` operations.
- Refactors `IssuePollingSource`, `RepoPollingSource`, and `PRPollingSource` to use the resource primitive for comment/review seed/diff/trim bookkeeping.
- Keeps seed-only side effects explicit, including `RepoPollingSource` pre-seeding `prUpdatedAtByNumber` before returning from the first tick.
- Adds shared `validateOrSkip()` for the existing `safeParse`-or-warn blocks.
- Hoists the duplicated backoff defaults into `DEFAULT_POLLING_BACKOFF_CONFIG`.
- Re-verification drift was posted on #7069: current `PRPollingSource.ts` only has a local parse-or-skip block for the PR-detail response, so this PR does not introduce new PR subresource array validation behavior.

## Single source of truth

`src/tools/github/PollingSourceBase.ts` now owns the reusable polling dedup primitive (`DedupedResource<T>`), the non-throwing validation helper, and the shared default backoff settings.

## Duplication and abstraction budget

Removed the repeated seen-id/cursor/trim loops from the issue, repo, and PR pollers. The new abstraction owns one invariant: a resource marks newly seen IDs before the caller decides whether to emit, advances its cursor from the full response window, and trims its own ID set. It is not a pass-through layer; endpoint-specific decisions remain in the pollers.

This refactor is net-positive in lines because the added mass is the shared primitive plus focused regression tests for its seed/diff/cursor/validation behavior.

## Host impact

Extension: No user-facing behavior change expected; GitHub subscription follow-up messages keep the same event ordering and bot-filter behavior.

Desktop: No user-facing behavior change expected; desktop receives the same GitHub subscription events through the existing runtime host path.

CLI: No output contract change expected; the CLI headless run validation passed.

## Scheduled refactoring

None. No #6981 ledger row is needed because this PR does not introduce a new shim, projection, dual-write, alias, fallback, or migration path.

## Validation

- `corepack pnpm exec prettier --write src/tools/github/PollingSourceBase.ts src/tools/github/IssuePollingSource.ts src/tools/github/RepoPollingSource.ts src/tools/github/PRPollingSource.ts src/test-kernel/tools/PollingSourceBase.vitest.ts src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/tools/PollingSourceBase.vitest.ts src/test-kernel/tools/PRPollingSource.vitest.ts src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts src/test-kernel/tools/PRPollingSourceAnnotationPages.vitest.ts src/test-kernel/agent/followUp/GitHubSubscriptionProgressEvents.vitest.ts`
- `npm run typecheck`
- `git diff --check`
- `npm run lint` (passes with the existing 15 warnings)
- `npm run compile:fast`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `npm test`
- Post-review amend: `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/tools/PollingSourceBase.vitest.ts`, `npm run typecheck`, targeted `eslint` for `PollingSourceBase.ts` and `RepoPollingSource.ts`, `git diff --check`, and `npm test`

Closes #7069
