### PR TITLE
refactor(agent/modelHandlers): dedupe Google streamed tool-argument parsing

### DIFF
--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -17,6 +17,7 @@ import { logProgressStatus, logSdkError } from '@agent/trace';
 import { hasEndTag } from '@agent/core/definition/AgentDataclass';
 import type { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
+import { parseToolArgumentsAsObject } from '@agent/modelHandlers/utils/parseArguments';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import type { MediaEntry } from '@agent/utils/mediaTypes';
 import { K_SLICE } from '@agent/core/constants';
@@ -27,7 +28,6 @@ import {
   takeTail,
   PARTIAL_TEXT_TAIL_MAX,
 } from '@common/errors/sdkErrorUtils';
-import { safeParseJson } from '@common/parsing/safeParseJson';
 import type { ToolDefinition } from '@model';
 import replacementEngine from '@replacement/engine';
 
@@ -39,7 +39,7 @@ import type {
 } from '@shared/schemas/toolResult';
 
 // Local imports - utils
-import { filterNotNull, isNonEmptyString, isObject } from '@utils/core';
+import { filterNotNull, isNonEmptyString } from '@utils/core';
 import { getShortDisplayPath } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
 import { joinNonEmpty, pluralize } from '@utils/text/stringUtils';
@@ -1882,7 +1882,10 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
           case 'step.stop': {
             const slot = pending.get(event.index);
             if (slot && slot.type === 'function_call' && slot.argsBuffer) {
-              slot.args = this.parseArguments(slot.argsBuffer);
+              slot.args = parseToolArgumentsAsObject(
+                slot.argsBuffer,
+                this.logger,
+              );
             }
             break;
           }
@@ -2027,7 +2030,9 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
           type: 'function_call',
           id: slot.callId ?? nanoid(),
           name: slot.callName ?? '',
-          arguments: slot.args ?? this.parseArguments(slot.argsBuffer),
+          arguments:
+            slot.args ??
+            parseToolArgumentsAsObject(slot.argsBuffer, this.logger),
         } satisfies FunctionCallStep);
       } else if (slot.text) {
         steps.push({
@@ -2037,18 +2042,6 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
       }
     }
     return steps;
-  }
-
-  private parseArguments(buffer: string): Record<string, unknown> {
-    if (!buffer) return {};
-    const parsed = safeParseJson(buffer);
-    if (parsed.isErr()) {
-      this.logger.warn('Failed to parse streamed tool arguments.', {
-        data: parsed.error,
-      });
-      return {};
-    }
-    return isObject(parsed.value) ? parsed.value : {};
   }
 
   // ===========================================================================

--- a/src/agent/modelHandlers/utils/parseArguments.ts
+++ b/src/agent/modelHandlers/utils/parseArguments.ts
@@ -2,21 +2,29 @@ import type { AgentTrace } from '@agent/trace';
 import { safeParseJson } from '@common/parsing/safeParseJson';
 import { isObject } from '@utils/core';
 
+const DEFAULT_PARSE_FAILURE_MESSAGE =
+  'Tool call arguments could not be parsed as JSON; using raw string.';
+
 /**
  * Safely parse tool call arguments from raw string to object.
  * Returns the original value if not a string, or if JSON parsing fails.
+ *
+ * `warnMessage` lets callers whose fallback behavior differs from "use the
+ * raw string" (e.g. {@link parseToolArgumentsAsObject}, which discards the
+ * raw string and falls back to `{}`) log an accurate description instead.
  */
-export function parseToolArguments(raw: unknown, logger: AgentTrace): unknown {
+export function parseToolArguments(
+  raw: unknown,
+  logger: AgentTrace,
+  warnMessage = DEFAULT_PARSE_FAILURE_MESSAGE,
+): unknown {
   if (typeof raw !== 'string') {
     return raw;
   }
 
   const parsed = safeParseJson(raw);
   if (parsed.isErr()) {
-    logger.warn(
-      'Tool call arguments could not be parsed as JSON; using raw string.',
-      { data: parsed.error },
-    );
+    logger.warn(warnMessage, { data: parsed.error });
     return raw;
   }
   return parsed.value;
@@ -32,6 +40,10 @@ export function parseToolArgumentsAsObject(
   logger: AgentTrace,
 ): Record<string, unknown> {
   if (!raw) return {};
-  const parsed = parseToolArguments(raw, logger);
+  const parsed = parseToolArguments(
+    raw,
+    logger,
+    'Failed to parse streamed tool arguments.',
+  );
   return isObject(parsed) ? parsed : {};
 }

--- a/src/agent/modelHandlers/utils/parseArguments.ts
+++ b/src/agent/modelHandlers/utils/parseArguments.ts
@@ -1,5 +1,6 @@
 import type { AgentTrace } from '@agent/trace';
 import { safeParseJson } from '@common/parsing/safeParseJson';
+import { isObject } from '@utils/core';
 
 /**
  * Safely parse tool call arguments from raw string to object.
@@ -19,4 +20,18 @@ export function parseToolArguments(raw: unknown, logger: AgentTrace): unknown {
     return raw;
   }
   return parsed.value;
+}
+
+/**
+ * Same as {@link parseToolArguments}, but always returns a plain object —
+ * for handlers (e.g. streamed argument buffers) whose tool-call arguments
+ * must be a Record rather than a possibly-raw string.
+ */
+export function parseToolArgumentsAsObject(
+  raw: string,
+  logger: AgentTrace,
+): Record<string, unknown> {
+  if (!raw) return {};
+  const parsed = parseToolArguments(raw, logger);
+  return isObject(parsed) ? parsed : {};
 }


### PR DESCRIPTION
## Summary

Requested audit: scan the codebase for duplicate logic and custom implementations of things native/stdlib methods or existing shared utilities already provide, then consolidate what's safe to consolidate.

Two independent scans (custom-vs-native, duplicate-logic) came back with the overall finding that **this codebase is unusually well-consolidated already** — debounce/throttle, deep-equal, UUID generation, path joining, retry/backoff, concurrency limiting, and event emitters all already route through shared utils or native APIs with no reimplementations found. Error handling, file-existence checks, CLI arg parsing, and test fixtures are similarly centralized.

Two flagged "duplicate truncate" call sites turned out to be **false positives on inspection** — see below. One real, small duplication was found and fixed.

## What changed

`src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts` had a private `parseArguments()` that re-implemented the exact `safeParseJson` → warn-on-error → fallback shape already shared by the OpenAI, OpenAI-Response, and OpenRouter handlers via `parseToolArguments()` (`src/agent/modelHandlers/utils/parseArguments.ts`). The only difference was that Google's variant always needed to return a plain object (streamed argument buffers), not a possibly-raw string.

Added `parseToolArgumentsAsObject()` next to the existing `parseToolArguments()` as a thin object-coercing wrapper, and switched the Google handler's two call sites to use it, deleting the private duplicate. This also dropped now-unused `safeParseJson`/`isObject` imports from that file.

## Issue acceptance gates

- All 4 model-provider handlers (Anthropic path unaffected/no duplicate found there, OpenAI, OpenAI-Response, OpenRouter, Google) now share one parse-tool-arguments code path instead of Google carrying its own copy.

## Single source of truth

`src/agent/modelHandlers/utils/parseArguments.ts` is now the single owner of "parse streamed/raw tool-call arguments from JSON, warning and falling back on parse failure" for every model handler.

## Duplication and abstraction budget

Removed: one duplicated parse/warn/fallback method (Google handler, ~11 lines) in favor of a shared helper already used by 3 other handlers. No new abstraction beyond a single additional exported function in the existing shared module — not a new file, not a new layer.

Considered and **deliberately not touched** (to avoid churn / because they weren't real duplication on closer inspection):
- `src/tools/executions/conversationFormat.ts`'s local `truncate()` looked like a duplicate of `truncateWithEllipsis` (`src/utils/text/stringUtils.ts`), but it's intentionally ASCII-only (`...` not the Unicode `…`) and is guarded by an explicit test (`ExecutionsConversationFormat.vitest.ts`: "preserves ASCII truncation for conversation output" / `expect(output).not.toContain('…')`). Swapping it would be a behavior change, not a consolidation.
- `packages/cli/src/runtime/history/conversationFormat.ts`'s truncation returns a `truncated` boolean and appends a distinct `\n...[truncated]` marker — a different contract than ellipsis-style display truncation, not a genuine duplicate.
- A few `schema.safeParse(x).success` one-line type guards (`src/shared/schemas/agent.ts`, `toolAttachmentUtils.ts`, `stream.ts`) and two `safeParse` + manual branch call sites (`modelHandlerKimi.ts`, `RemoteAgentLoader.ts`) are idiomatic single-value Zod usage; wrapping 3-5 one-liners in a new generic helper would be premature abstraction per this repo's stated anti-pattern guidance, not a real win.

## Host impact

Extension: no behavior change (Google model handler is host-agnostic core).

Desktop: no behavior change.

CLI: no behavior change.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — clean.
- `npx eslint` on both changed files — clean.
- `npx vitest run src/test-kernel/agent/modelHandlers/` — 360 passed, 4 skipped (0 failures).
- `npm test` (full suite) — 4519 passed, 1 pre-existing unrelated failure (`execUtils.vitest.ts` process-group-abort timing test, unrelated file, not touched by this PR) confirmed environmental/flaky in this sandbox.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LPMqCCVoPPxJh4SPjNkH2j)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only consolidation of existing parse/warn/fallback behavior; no new API surface beyond the shared helper and unchanged runtime fallbacks for streamed tool arguments.
> 
> **Overview**
> Removes duplicated JSON parsing for streamed Google Interactions tool calls by routing both `step.stop` and `finalizeSteps` through a new shared **`parseToolArgumentsAsObject`** helper in `parseArguments.ts`, deleting the Google handler’s private **`parseArguments`** method.
> 
> **`parseToolArguments`** now accepts an optional **`warnMessage`** so callers that fall back to `{}` instead of a raw string can log the same accurate warning text the Google path used before. **`parseToolArgumentsAsObject`** wraps that logic and always returns a **`Record<string, unknown>`** (empty buffer → `{}`, parse failure or non-object → `{}`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d472b3eccf81d6fbb24e4d0b5f6a36413bcdef62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->