### PR TITLE
refactor(cli): adopt @texra/core in the two canonical run entry points

### DIFF
--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -1,16 +1,16 @@
+import {
+  AgentCategory,
+  defaultSession,
+  runAgent,
+  tryPlatform,
+  validateExecutionRequest,
+  type AgentConfigPayload,
+  type ValidatedExecutionRequest,
+} from '@texra/core';
 import { SHUTDOWN_PHASE } from '@platform/interfaces/lifecycle';
-import { tryPlatform } from '@platform/platform';
 import { StreamSnapshotStore } from '@transcript';
 import { writeTerminalStatus } from '@agent/storage';
-import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import {
-  validateExecutionRequest,
-  type ValidatedExecutionRequest,
-} from '@agent/core/state/executionRequests';
-import { runAgent } from '@agent/runtime/runAgent';
-import { defaultSession } from '@agent/runtime/SessionHandle';
 import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
-import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
 import type {
   ProgressEvent,
   ProgressEventPayloads,

--- a/packages/cli/src/runtime/terminalStatus.ts
+++ b/packages/cli/src/runtime/terminalStatus.ts
@@ -1,5 +1,4 @@
-import { getExecutionStore } from '@agent/storage';
-import { runAgent } from '@agent/runtime/runAgent';
+import { getExecutionStore, runAgent } from '@texra/core';
 
 import {
   legacyEndGroupStatusForOutcome,


### PR DESCRIPTION
## Summary

A codebase-wide audit for overlapping/confusing responsibilities turned up `packages/core` (`@texra/core`) as the most significant issue: it is documented as "the curated public surface of the TeXRA agent core... a host should prefer over deep `@agent/*`/`@platform` imports," and both `packages/desktop` and `packages/cli` declare it as a workspace dependency — but **zero files anywhere in the repo actually imported it**. Every host still used deep `@agent/*`/`@platform` imports exclusively. The package was only exercised by its own isolated `tsc --noEmit` in CI, so its curated re-exports could silently drift out of sync with the internal APIs they wrap without any real caller ever noticing.

This PR gives `@texra/core` its first two real consumers in the CLI (the only host where the dependency was already declared and every needed symbol was cleanly covered by the curated surface, so no `package.json`/lockfile changes were needed):

- `packages/cli/src/runtime/runExecution.ts` — the shared headless execution skeleton behind `run`, `agents run`, and `multi-agent run` — now imports `validateExecutionRequest`, `runAgent`, `defaultSession`, `AgentCategory`, and the `AgentConfigPayload`/`ValidatedExecutionRequest` types from `@texra/core`.
- `packages/cli/src/runtime/terminalStatus.ts` now imports `getExecutionStore` and `runAgent` from `@texra/core`.

Symbols not re-exported by the curated surface (`writeTerminalStatus`, `attachTerminalResultToast`, etc.) are left as deep imports, per `@texra/core`'s own documented "adopted incrementally, not migrated in bulk" policy — this is a small, deliberate first step, not a bulk migration.

## Issue acceptance gates

- [x] Identify and document overlapping/confusing-responsibility issues across the codebase (see audit findings below).
- [x] Refactor the most significant issue: `@texra/core` had no real consumers despite being the designated consolidation point for host↔core access.

## Single source of truth

`@texra/core`'s `src/index.ts` remains the single curated entry point for host↔core access; this PR does not change what it owns, only proves that a host can actually depend on it end-to-end (dependency declaration → import → typecheck → CLI architecture gate all pass).

## Duplication and abstraction budget

No duplication removed or added — this is a pure import-path substitution over existing re-exported bindings (same singletons/functions, just reached through the curated barrel instead of deep paths). No new abstraction introduced.

## Host impact

Extension: none (not touched in this PR; the extension does not yet declare `@texra/core` as a dependency — a follow-up would need a `package.json`/lockfile change first).

Desktop: none (not touched in this PR; the desktop's `desktopAgentExecution.ts` intentionally lazy-loads `runAgent` via a dynamic `import('@agent/runtime/runAgent')` to avoid pulling in the full curated surface at module load — worth a closer look before switching it, so left out of this scoped PR).

CLI: `runExecution.ts` and `terminalStatus.ts` now resolve `validateExecutionRequest`, `runAgent`, `defaultSession`, `AgentCategory`, and `getExecutionStore` through `@texra/core` instead of deep `@agent/*`/`@platform` imports. No behavior change — verified via typecheck and the CLI's host-import architecture gate.

## Scheduled refactoring

None filed. Worth a follow-up issue to evaluate migrating the extension (after adding the `@texra/core` dependency) and the desktop's non-lazy call sites, plus documenting `packages/core`'s "incremental adoption" intent more prominently so it doesn't silently regress to zero real consumers again.

## Validation

- `corepack pnpm --filter @texra-ai/cli typecheck` — pass
- `node packages/cli/scripts/check-host-imports.mjs` (the CLI's `check:architecture` gate) — pass
- `npx eslint packages/cli/src/runtime/runExecution.ts packages/cli/src/runtime/terminalStatus.ts` — no errors/warnings after fixing one `import/order` warning
- Not run: full monorepo `npm run typecheck` / `npm test` (only two CLI-internal files changed, both fully covered by the CLI-scoped checks above)

---

### Other overlap issues found during the audit (not addressed in this PR)

1. Tool-kind display classification is duplicated with drifting heuristics between `packages/cli/src/chat/tui/panes/toolRenderers.tsx` and `packages/extension/src/progressView/frontend/formatters/constants.ts` — neither references the actual tool registry (`src/tools/registry.ts`), and each already knows about tools the other doesn't.
2. `src/agent/runtime/` has grown to 52 flat files with no README/sub-grouping, unlike its sibling `src/agent/core/` (which was recently split into `definition/`/`state/`/`usage/`/`tools/`/`flows/` with an explicit module-map README specifically to solve this kind of navigability problem).
3. `CLAUDE.md`/`AGENTS.md` describe repo-root `src/common/state/`, which doesn't exist — the actual state managers live only in `packages/extension/src/common/state/`, a different directory in a different package.


---
_Generated by [Claude Code](https://claude.ai/code/session_015HX1zwjyDUteUm9RoKstRU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-path-only refactor over existing re-exports; no logic, API, or security changes.
> 
> **Overview**
> The CLI’s shared headless execution path (`runExecution.ts`) and terminal-status helpers (`terminalStatus.ts`) now pull **`validateExecutionRequest`**, **`runAgent`**, **`defaultSession`**, **`AgentCategory`**, **`tryPlatform`**, **`getExecutionStore`**, and related types from **`@texra/core`** instead of deep **`@agent/*`** / **`@platform`** paths.
> 
> This is the package’s first real in-repo consumers beyond its own typecheck—same symbols and behavior, only the import surface changes. Symbols not on the curated barrel (e.g. **`writeTerminalStatus`**, **`attachTerminalResultToast`**) stay on deep imports per incremental adoption.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dc930f4d998f2a3be3d73b95200214354fdeeb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->