### PR TITLE
Derive extension command registration from the shared catalog

### DIFF
--- a/packages/extension/src/commands/extensionCommandHandlers.ts
+++ b/packages/extension/src/commands/extensionCommandHandlers.ts
@@ -13,10 +13,7 @@ import {
   definedHandler,
   type CommandHandler,
 } from '@shared/commands/registry';
-import {
-  AgentCategorySchema,
-  type AgentCategory,
-} from '@shared/schemas/agent';
+import { AgentCategorySchema, type AgentCategory } from '@shared/schemas/agent';
 import { StreamTabIdSchema } from '@shared/schemas/identifiers';
 import {
   SETTINGS_TAB,
@@ -84,8 +81,7 @@ type HiddenExtensionRegistryCommandId =
   (typeof EXTENSION_HIDDEN_ALIASES)[number];
 
 export type ExtensionRegistryCommandId =
-  | ExtensionRegistryCatalogCommandId
-  | HiddenExtensionRegistryCommandId;
+  ExtensionRegistryCatalogCommandId | HiddenExtensionRegistryCommandId;
 
 /**
  * Runtime mirror of `ExtensionRegistryCatalogCommandId`, used by tests to

--- a/packages/extension/src/commands/extensionCommandHandlers.ts
+++ b/packages/extension/src/commands/extensionCommandHandlers.ts
@@ -3,11 +3,7 @@ import { z } from 'zod';
 
 // Local imports
 import { API_PROVIDERS, type ApiProvider } from '@model/apiProviders';
-import {
-  commandCatalog,
-  type CommandCatalogEntry,
-  type CommandId,
-} from '@shared/commands/catalog';
+import { commandCatalog } from '@shared/commands/catalog';
 import {
   awaitTrue,
   definedHandler,
@@ -64,10 +60,13 @@ const ShowProgressViewArgSchema = z.unknown();
  * constraint below is the compile-time signal that a handler still needs
  * to be authored (real per-command behavior can't be generated).
  */
-export type ExtensionRegistryCatalogCommandId = Extract<
+type ExtensionRegistryCatalogEntry = Extract<
   (typeof commandCatalog)[number],
   { extensionRegistry: true }
->['id'];
+>;
+
+export type ExtensionRegistryCatalogCommandId =
+  ExtensionRegistryCatalogEntry['id'];
 
 /**
  * Compatibility ids intentionally absent from the shared catalog — they
@@ -89,11 +88,13 @@ export type ExtensionRegistryCommandId =
  * register every catalog entry tagged `extensionRegistry: true` (and flag
  * strays that no longer belong).
  */
-export const EXTENSION_REGISTRY_CATALOG_COMMAND_IDS: readonly CommandId[] = (
-  commandCatalog as readonly CommandCatalogEntry[]
-)
-  .filter((entry) => entry.extensionRegistry === true)
-  .map((entry) => entry.id as CommandId);
+export const EXTENSION_REGISTRY_CATALOG_COMMAND_IDS: readonly ExtensionRegistryCatalogCommandId[] =
+  commandCatalog
+    .filter(
+      (entry): entry is ExtensionRegistryCatalogEntry =>
+        'extensionRegistry' in entry && entry.extensionRegistry === true,
+    )
+    .map((entry) => entry.id);
 
 /**
  * Capabilities the registry handlers need from the extension host. Mirrors

--- a/packages/extension/src/commands/extensionCommandHandlers.ts
+++ b/packages/extension/src/commands/extensionCommandHandlers.ts
@@ -1,0 +1,301 @@
+// Third-party imports
+import { z } from 'zod';
+
+// Local imports
+import { API_PROVIDERS, type ApiProvider } from '@model/apiProviders';
+import {
+  commandCatalog,
+  type CommandCatalogEntry,
+  type CommandId,
+} from '@shared/commands/catalog';
+import {
+  awaitTrue,
+  definedHandler,
+  type CommandHandler,
+} from '@shared/commands/registry';
+import {
+  AgentCategorySchema,
+  type AgentCategory,
+} from '@shared/schemas/agent';
+import { StreamTabIdSchema } from '@shared/schemas/identifiers';
+import {
+  SETTINGS_TAB,
+  type SettingsTab,
+} from '@shared/schemas/settingsViewMessages';
+
+/**
+ * This module is deliberately free of `vscode` imports (unlike
+ * `extensionCommandSurface.ts`, which wires the real actions against VS
+ * Code APIs) so it — and the catalog-derived types/handler map it
+ * exports — can be imported directly from Vitest suites without a
+ * `vscode` mock, the same way `packages/desktop/src/desktopCommandSurface.ts`
+ * is testable today.
+ */
+
+/**
+ * Optional `ApiProvider` argument for `texra.setApiKey`. The schema accepts
+ * `undefined` so the registry's `safeParse` succeeds when the command is
+ * invoked from the palette without arguments — the action then prompts the
+ * user via `showQuickPick`.
+ */
+const SetApiKeyArgSchema = z.enum(API_PROVIDERS).optional();
+
+/**
+ * Optional `AgentCategory` argument for `texra.createAgentWithAI`. The
+ * registry parses raw `unknown` and the action defaults to `workflow`
+ * when undefined (preserving the legacy `category ?? 'workflow'` shape).
+ */
+const CreateAgentWithAIArgSchema = AgentCategorySchema.optional();
+
+/**
+ * Optional `{ inPlace }` argument for `texra.showProgressView`. The
+ * legacy registration accepted any argument shape and only honoured the
+ * `inPlace` boolean — `z.unknown()` here preserves that best-effort
+ * semantics so callers passing `null`, booleans, or stringified flags
+ * still open the progress view (just without the in-place flag) instead
+ * of being rejected by the dispatcher as unhandled.
+ */
+const ShowProgressViewArgSchema = z.unknown();
+
+/**
+ * Catalog ids whose extension registration is driven by the shared
+ * `dispatchCommandFromRegistry` handler map below, derived from the
+ * `extensionRegistry: true` tag on `commandCatalog` entries
+ * (`src/shared/commands/catalog.ts`) rather than a hand-mirrored id list.
+ * Adding a new registry-driven command only requires tagging its catalog
+ * entry — `EXTENSION_COMMAND_HANDLERS` failing to `satisfy` its `Record<>`
+ * constraint below is the compile-time signal that a handler still needs
+ * to be authored (real per-command behavior can't be generated).
+ */
+export type ExtensionRegistryCatalogCommandId = Extract<
+  (typeof commandCatalog)[number],
+  { extensionRegistry: true }
+>['id'];
+
+/**
+ * Compatibility ids intentionally absent from the shared catalog — they
+ * don't appear in the command palette or `package.json` contributions —
+ * but must keep resolving for existing callers (e.g. stored keybindings,
+ * webview postMessage payloads).
+ */
+export const EXTENSION_HIDDEN_ALIASES = ['texra.showSettingsView'] as const;
+
+type HiddenExtensionRegistryCommandId =
+  (typeof EXTENSION_HIDDEN_ALIASES)[number];
+
+export type ExtensionRegistryCommandId =
+  | ExtensionRegistryCatalogCommandId
+  | HiddenExtensionRegistryCommandId;
+
+/**
+ * Runtime mirror of `ExtensionRegistryCatalogCommandId`, used by tests to
+ * assert `EXTENSION_COMMAND_HANDLERS` / `EXTENSION_PARAMETERIZED_HANDLERS`
+ * register every catalog entry tagged `extensionRegistry: true` (and flag
+ * strays that no longer belong).
+ */
+export const EXTENSION_REGISTRY_CATALOG_COMMAND_IDS: readonly CommandId[] = (
+  commandCatalog as readonly CommandCatalogEntry[]
+)
+  .filter((entry) => entry.extensionRegistry === true)
+  .map((entry) => entry.id as CommandId);
+
+/**
+ * Capabilities the registry handlers need from the extension host. Mirrors
+ * `DesktopCommandActions` in shape — both register parallel handler maps
+ * over the same `CommandId` union with their host-specific actions.
+ */
+export interface ExtensionCommandActions {
+  showSettings(
+    tabIndex?: SettingsTab,
+    agentSubTab?: AgentCategory,
+  ): Promise<void>;
+  resetMainView(): Promise<void>;
+  openWorkbenchSettings(): Thenable<unknown>;
+  cleanBuild(): Promise<void>;
+  cleanOutput(): Promise<void>;
+  indentTeX(): Promise<void>;
+  signIn(): Promise<boolean>;
+  signInChatGpt(): Promise<boolean>;
+  signOut(): Promise<void>;
+  viewProfile(): Promise<void>;
+  runSetupAssistant(): Promise<void>;
+  openGettingStarted(): Thenable<unknown>;
+  createSampleProject(): Promise<void>;
+  downloadArXivSource(): Promise<void>;
+  testConnection(): Promise<void>;
+  testAgentLoading(): Promise<void>;
+  loadSpecificAgent(): Promise<void>;
+  openProgressViewInTab(): Promise<void>;
+  openDoc(page: string): Promise<void>;
+  stopAgent(streamId: string): void;
+  compactResponse(streamId: string): Promise<void>;
+  parseXml(): Promise<void>;
+  parseYaml(): Promise<void>;
+  testTextEditor(): Promise<void>;
+  indentCurrentTeX(): Promise<void>;
+  applyReplacements(): Promise<void>;
+  fixCompilation(): Promise<void>;
+  getTeXCount(): Promise<void>;
+  countPdfPages(): Promise<void>;
+  showLinterMessages(): Promise<void>;
+  countLinterMessages(): Promise<void>;
+  extractFigurePaths(): Promise<void>;
+  // Batch 3 (#3781). The action functions return data (the underlying
+  // `string | string[] | undefined`) for direct callers, but the
+  // registry's typed return is `Promise<boolean>`, so the dispatcher
+  // wraps them with `awaitTrue(...)` and the resolved data is
+  // intentionally dropped. Palette / `executeCommand` callers don't
+  // consume the value today; if a future caller needs the original
+  // payload it must call the action helper directly instead of going
+  // through `vscode.commands.executeCommand`.
+  encodeImageToBase64(): Promise<string | undefined>;
+  convertPdfToImages(): Promise<string[] | string | undefined>;
+  extractTikzFigures(): Promise<void>;
+  compileTikzFigures(): Promise<void>;
+  cloneOverleafProject(): Promise<void>;
+  // Batch 4 (#3781).
+  removeApiKey(): Promise<void>;
+  showImportOptions(): Promise<void>;
+  toggleView(): Promise<void>;
+  showProgressView(inPlace: boolean): Promise<void>;
+  setApiKey(provider: ApiProvider | undefined): Promise<void>;
+  createAgentWithAI(category: AgentCategory): Promise<void>;
+  execute(input: unknown): Promise<void>;
+}
+
+export const EXTENSION_COMMAND_HANDLERS = {
+  'texra.showDashboard': (actions) => awaitTrue(actions.showSettings()),
+  'texra.showSettingsView': (actions) => awaitTrue(actions.showSettings()),
+  'texra.showMemory': (actions) =>
+    awaitTrue(actions.showSettings(SETTINGS_TAB.MEMORY)),
+  'texra.showAgentHistory': (actions) =>
+    awaitTrue(actions.showSettings(SETTINGS_TAB.HISTORY)),
+  'texra.showModels': (actions) =>
+    awaitTrue(actions.showSettings(SETTINGS_TAB.MODELS)),
+  'texra.showTools': (actions) =>
+    awaitTrue(actions.showSettings(SETTINGS_TAB.TOOLS)),
+  'texra.showMultiAgent': (actions) =>
+    awaitTrue(actions.showSettings(SETTINGS_TAB.MULTI_AGENT)),
+  'texra.showGitSettings': (actions) =>
+    awaitTrue(actions.showSettings(SETTINGS_TAB.GIT)),
+  'texra.openSettings': (actions) => awaitTrue(actions.openWorkbenchSettings()),
+  'texra.mainView.reset': (actions) => awaitTrue(actions.resetMainView()),
+  'texra.cleanOutput': (actions) => awaitTrue(actions.cleanOutput()),
+  'texra.cleanBuild': (actions) => awaitTrue(actions.cleanBuild()),
+  'texra.indentTeX': (actions) => awaitTrue(actions.indentTeX()),
+  'texra.auth.signIn': (actions) => awaitTrue(actions.signIn()),
+  'texra.auth.chatgpt.signIn': (actions) => awaitTrue(actions.signInChatGpt()),
+  'texra.auth.signOut': (actions) => awaitTrue(actions.signOut()),
+  'texra.auth.viewProfile': (actions) => awaitTrue(actions.viewProfile()),
+  'texra.runSetupAssistant': (actions) =>
+    awaitTrue(actions.runSetupAssistant()),
+  'texra.openGettingStarted': (actions) =>
+    awaitTrue(actions.openGettingStarted()),
+  'texra.createSampleProject': (actions) =>
+    awaitTrue(actions.createSampleProject()),
+  'texra.downloadArXivSource': (actions) =>
+    awaitTrue(actions.downloadArXivSource()),
+  'texra.testConnection': (actions) => awaitTrue(actions.testConnection()),
+  'texra.testAgentLoading': (actions) => awaitTrue(actions.testAgentLoading()),
+  'texra.loadSpecificAgent': (actions) =>
+    awaitTrue(actions.loadSpecificAgent()),
+  'texra.openProgressViewInTab': (actions) =>
+    awaitTrue(actions.openProgressViewInTab()),
+  'texra.openDoc': definedHandler(
+    z.string(),
+    (actions: ExtensionCommandActions, page) =>
+      awaitTrue(actions.openDoc(page)),
+  ),
+  'texra.stopAgent': definedHandler(
+    StreamTabIdSchema,
+    (actions: ExtensionCommandActions, streamId) => {
+      actions.stopAgent(streamId);
+      return true;
+    },
+  ),
+  'texra.compactResponse': definedHandler(
+    StreamTabIdSchema,
+    (actions: ExtensionCommandActions, streamId) =>
+      awaitTrue(actions.compactResponse(streamId)),
+  ),
+  'texra.parseXml': (actions) => awaitTrue(actions.parseXml()),
+  'texra.parseYaml': (actions) => awaitTrue(actions.parseYaml()),
+  'texra.testTextEditor': (actions) => awaitTrue(actions.testTextEditor()),
+  'texra.indentCurrentTeX': (actions) => awaitTrue(actions.indentCurrentTeX()),
+  'texra.applyReplacements': (actions) =>
+    awaitTrue(actions.applyReplacements()),
+  'texra.fixCompilation': (actions) => awaitTrue(actions.fixCompilation()),
+  'texra.getTeXCount': (actions) => awaitTrue(actions.getTeXCount()),
+  'texra.countPdfPages': (actions) => awaitTrue(actions.countPdfPages()),
+  'texra.showLinterMessages': (actions) =>
+    awaitTrue(actions.showLinterMessages()),
+  'texra.countLinterMessages': (actions) =>
+    awaitTrue(actions.countLinterMessages()),
+  'texra.extractFigurePaths': (actions) =>
+    awaitTrue(actions.extractFigurePaths()),
+  // Batch 3 (#3781) — image / PDF / TikZ / Overleaf entry points.
+  'texra.encodeImageToBase64': (actions) =>
+    awaitTrue(actions.encodeImageToBase64()),
+  'texra.convertPdfToImages': (actions) =>
+    awaitTrue(actions.convertPdfToImages()),
+  'texra.extractTikzFigures': (actions) =>
+    awaitTrue(actions.extractTikzFigures()),
+  'texra.compileTikzFigures': (actions) =>
+    awaitTrue(actions.compileTikzFigures()),
+  'texra.cloneOverleafProject': (actions) =>
+    awaitTrue(actions.cloneOverleafProject()),
+  // Batch 4 (#3781).
+  'texra.removeApiKey': (actions) => awaitTrue(actions.removeApiKey()),
+  'texra.showImportOptions': (actions) =>
+    awaitTrue(actions.showImportOptions()),
+  'texra.toggleView': (actions) => awaitTrue(actions.toggleView()),
+  'texra.showProgressView': definedHandler(
+    ShowProgressViewArgSchema,
+    (actions: ExtensionCommandActions, parsed) => {
+      const inPlace =
+        typeof parsed === 'object' &&
+        parsed !== null &&
+        (parsed as { inPlace?: unknown }).inPlace === true;
+      return awaitTrue(actions.showProgressView(inPlace));
+    },
+  ),
+  'texra.setApiKey': definedHandler(
+    SetApiKeyArgSchema,
+    (actions: ExtensionCommandActions, provider) =>
+      awaitTrue(actions.setApiKey(provider)),
+  ),
+  'texra.createAgentWithAI': definedHandler(
+    CreateAgentWithAIArgSchema,
+    (actions: ExtensionCommandActions, category) =>
+      awaitTrue(actions.createAgentWithAI(category ?? 'workflow')),
+  ),
+  'texra.execute': definedHandler(
+    z.unknown(),
+    (actions: ExtensionCommandActions, input) =>
+      awaitTrue(actions.execute(input)),
+  ),
+} as const satisfies Record<
+  Exclude<ExtensionRegistryCommandId, 'texra.showAgents'>,
+  // The typed handlers (`openDoc`, `stopAgent`, `compactResponse`) carry
+  // their own argument shapes via `definedHandler`. Matching the registry
+  // map's per-entry TArgs widening (`any`) keeps inference per entry
+  // without unifying every entry on `unknown`.
+  CommandHandler<ExtensionCommandActions, any>
+>;
+
+// `texra.showAgents` accepts an optional `AgentCategory` argument from
+// `executeCommand` callers, so it can't share the no-arg `CommandHandler`
+// signature. It's still routed through the same actions interface — the
+// only difference is that the VS Code registration forwards the argument.
+//
+// FOLLOW_UP: This bespoke parameterized map can be replaced with the
+// `definedHandler` typed-args helper in `@shared/commands/registry` once
+// the surrounding parameterized commands (pack/clean/compare/etc.) are
+// migrated through that path. Keeping it as-is for now to minimize churn.
+export const EXTENSION_PARAMETERIZED_HANDLERS = {
+  'texra.showAgents': (actions, subTab?: AgentCategory) =>
+    actions.showSettings(SETTINGS_TAB.AGENTS, subTab),
+} satisfies Record<
+  Extract<ExtensionRegistryCommandId, 'texra.showAgents'>,
+  (actions: ExtensionCommandActions, arg?: AgentCategory) => Promise<void>
+>;

--- a/packages/extension/src/commands/extensionCommandSurface.ts
+++ b/packages/extension/src/commands/extensionCommandSurface.ts
@@ -72,13 +72,6 @@ import {
   type ExtensionCommandActions,
 } from './extensionCommandHandlers';
 
-export type {
-  ExtensionCommandActions,
-  ExtensionRegistryCommandId,
-  ExtensionRegistryCatalogCommandId,
-} from './extensionCommandHandlers';
-export { EXTENSION_HIDDEN_ALIASES } from './extensionCommandHandlers';
-
 const RESET_CHANNEL = 'mainViewCommands';
 const CHATGPT_SIGN_IN_CHANNEL = 'ChatGptSubscription';
 

--- a/packages/extension/src/commands/extensionCommandSurface.ts
+++ b/packages/extension/src/commands/extensionCommandSurface.ts
@@ -1,6 +1,5 @@
 // Third-party imports
 import * as vscode from 'vscode';
-import { z } from 'zod';
 
 // Local imports
 import {
@@ -59,214 +58,29 @@ import { handleParseXml as sysParseXml } from '@commands/system/xmlCommands';
 import { handleParseYaml as sysParseYaml } from '@commands/system/yamlCommands';
 import { handleTestTextEditor as sysTestTextEditor } from '@commands/system/textEditorCommands';
 import { SIDEBAR_VIEWS, getActiveSidebarView } from '@common/webview';
-import { type ApiProvider, SecretManager } from '@frontend/secretManager';
 import { signInWithChatGptSubscription } from '@frontend/auth/codexSubscriptionSignIn';
 import { getMainWebview } from '@frontend/system/commandUtils';
 import { runCleanBuild, runCleanOutput } from '@housekeeping';
 import type { SettingsViewProvider } from '@settingsView/SettingsViewProvider';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
-import type { CommandId } from '@shared/commands/catalog';
-import {
-  awaitTrue,
-  definedHandler,
-  dispatchCommandFromRegistry,
-  type CommandHandler,
-} from '@shared/commands/registry';
-import { AgentCategorySchema, type AgentCategory } from '@shared/schemas/agent';
-import { StreamTabIdSchema } from '@shared/schemas/identifiers';
-import {
-  SETTINGS_TAB,
-  type SettingsTab,
-} from '@shared/schemas/settingsViewMessages';
+import { dispatchCommandFromRegistry } from '@shared/commands/registry';
+import type { AgentCategory } from '@shared/schemas/agent';
 import { SETTINGS_QUERY } from '@utils/config';
+import {
+  EXTENSION_COMMAND_HANDLERS,
+  EXTENSION_PARAMETERIZED_HANDLERS,
+  type ExtensionCommandActions,
+} from './extensionCommandHandlers';
 
-/**
- * Optional `ApiProvider` argument for `texra.setApiKey`. The schema accepts
- * `undefined` so the registry's `safeParse` succeeds when the command is
- * invoked from the palette without arguments — the action then prompts the
- * user via `showQuickPick`.
- */
-const SetApiKeyArgSchema = z.enum(SecretManager.API_PROVIDERS).optional();
-
-/**
- * Optional `AgentCategory` argument for `texra.createAgentWithAI`. The
- * registry parses raw `unknown` and the action defaults to `workflow`
- * when undefined (preserving the legacy `category ?? 'workflow'` shape).
- */
-const CreateAgentWithAIArgSchema = AgentCategorySchema.optional();
-
-/**
- * Optional `{ inPlace }` argument for `texra.showProgressView`. The
- * legacy registration accepted any argument shape and only honoured the
- * `inPlace` boolean — `z.unknown()` here preserves that best-effort
- * semantics so callers passing `null`, booleans, or stringified flags
- * still open the progress view (just without the in-place flag) instead
- * of being rejected by the dispatcher as unhandled.
- */
-const ShowProgressViewArgSchema = z.unknown();
+export type {
+  ExtensionCommandActions,
+  ExtensionRegistryCommandId,
+  ExtensionRegistryCatalogCommandId,
+} from './extensionCommandHandlers';
+export { EXTENSION_HIDDEN_ALIASES } from './extensionCommandHandlers';
 
 const RESET_CHANNEL = 'mainViewCommands';
 const CHATGPT_SIGN_IN_CHANNEL = 'ChatGptSubscription';
-
-/**
- * Subset of `CommandId` whose registration is now driven by the shared
- * `dispatchCommandFromRegistry` helper. Any new entry must also exist in
- * `commandCatalog` so the shared catalog stays the source of truth. Hidden
- * compatibility aliases are the exception: they stay callable by command id
- * but are intentionally absent from the public command catalog and manifest.
- *
- * The desktop registry (`packages/desktop/src/desktopCommandSurface.ts`)
- * dispatches the same IDs through the same helper — this is deliberate
- * so adding a new view-routing command is a single registry entry per
- * host, not a parallel `vscode.commands.registerCommand` call site.
- */
-type HiddenExtensionRegistryCommandId = 'texra.showSettingsView';
-
-export type ExtensionRegistryCommandId =
-  | Extract<
-      CommandId,
-      | 'texra.showDashboard'
-      | 'texra.showMemory'
-      | 'texra.showAgentHistory'
-      | 'texra.showModels'
-      | 'texra.showAgents'
-      | 'texra.showTools'
-      | 'texra.showMultiAgent'
-      | 'texra.showGitSettings'
-      | 'texra.openSettings'
-      | 'texra.mainView.reset'
-      | 'texra.cleanOutput'
-      | 'texra.cleanBuild'
-      | 'texra.indentTeX'
-      | 'texra.auth.signIn'
-      | 'texra.auth.chatgpt.signIn'
-      | 'texra.auth.signOut'
-      | 'texra.auth.viewProfile'
-      | 'texra.runSetupAssistant'
-      | 'texra.openGettingStarted'
-      | 'texra.createSampleProject'
-      | 'texra.downloadArXivSource'
-      | 'texra.testConnection'
-      | 'texra.testAgentLoading'
-      | 'texra.loadSpecificAgent'
-      | 'texra.openProgressViewInTab'
-      | 'texra.openDoc'
-      | 'texra.stopAgent'
-      | 'texra.compactResponse'
-      // Batch 2 (#3775) — no-arg host-context commands. These read from
-      // the active editor or fixed UI surfaces; their args are not
-      // serializable, so they ride the legacy no-arg handler shape.
-      | 'texra.parseXml'
-      | 'texra.parseYaml'
-      | 'texra.testTextEditor'
-      | 'texra.indentCurrentTeX'
-      | 'texra.applyReplacements'
-      | 'texra.fixCompilation'
-      | 'texra.getTeXCount'
-      | 'texra.countPdfPages'
-      | 'texra.showLinterMessages'
-      | 'texra.countLinterMessages'
-      | 'texra.extractFigurePaths'
-      // Batch 3 (#3781) — additional no-arg commands. Each handler runs
-      // its own user prompt internally (file picker, input box) so the
-      // VS Code call site doesn't pass arguments. The `cloneOverleafProject`
-      // entry needs `vscode.ExtensionContext` for `secrets` access; that's
-      // captured as a closure inside the action factory below.
-      | 'texra.encodeImageToBase64'
-      | 'texra.convertPdfToImages'
-      | 'texra.extractTikzFigures'
-      | 'texra.compileTikzFigures'
-      | 'texra.cloneOverleafProject'
-      // Batch 4 (#3781) — settings/api/agent surface follow-ups. The
-      // typed handlers carry a Zod schema for their argument so the dispatcher
-      // can parse the optional provider / category / inPlace / config flag
-      // before the handler runs. The remaining no-arg entries (toggleView,
-      // showImportOptions, removeApiKey) drive interactive UI flows internally.
-      | 'texra.removeApiKey'
-      | 'texra.showImportOptions'
-      | 'texra.toggleView'
-      | 'texra.showProgressView'
-      | 'texra.setApiKey'
-      | 'texra.createAgentWithAI'
-      | 'texra.execute'
-    >
-  | HiddenExtensionRegistryCommandId;
-
-/*
- * Duplicate-registration audit (#3787 follow-up):
- * Every command id in `EXTENSION_COMMAND_HANDLERS` +
- * `EXTENSION_PARAMETERIZED_HANDLERS` has been verified to have no stale
- * `vscode.commands.registerCommand(...)` call elsewhere. The remaining
- * legacy `registerCommand` call sites all register ids NOT present in
- * the registry — they're legitimate VS Code-only handlers (file ops, git,
- * latex tools, pack/clean variants). The shared `commandCatalog` remains
- * the authoritative list of registry entries; this map is the
- * authoritative registration mechanism for those entries.
- */
-
-/**
- * Capabilities the registry handlers need from the extension host. Mirrors
- * `DesktopCommandActions` in shape — both register parallel handler maps
- * over the same `CommandId` union with their host-specific actions.
- */
-export interface ExtensionCommandActions {
-  showSettings(
-    tabIndex?: SettingsTab,
-    agentSubTab?: AgentCategory,
-  ): Promise<void>;
-  resetMainView(): Promise<void>;
-  openWorkbenchSettings(): Thenable<unknown>;
-  cleanBuild(): Promise<void>;
-  cleanOutput(): Promise<void>;
-  indentTeX(): Promise<void>;
-  signIn(): Promise<boolean>;
-  signInChatGpt(): Promise<boolean>;
-  signOut(): Promise<void>;
-  viewProfile(): Promise<void>;
-  runSetupAssistant(): Promise<void>;
-  openGettingStarted(): Thenable<unknown>;
-  createSampleProject(): Promise<void>;
-  downloadArXivSource(): Promise<void>;
-  testConnection(): Promise<void>;
-  testAgentLoading(): Promise<void>;
-  loadSpecificAgent(): Promise<void>;
-  openProgressViewInTab(): Promise<void>;
-  openDoc(page: string): Promise<void>;
-  stopAgent(streamId: string): void;
-  compactResponse(streamId: string): Promise<void>;
-  parseXml(): Promise<void>;
-  parseYaml(): Promise<void>;
-  testTextEditor(): Promise<void>;
-  indentCurrentTeX(): Promise<void>;
-  applyReplacements(): Promise<void>;
-  fixCompilation(): Promise<void>;
-  getTeXCount(): Promise<void>;
-  countPdfPages(): Promise<void>;
-  showLinterMessages(): Promise<void>;
-  countLinterMessages(): Promise<void>;
-  extractFigurePaths(): Promise<void>;
-  // Batch 3 (#3781). The action functions return data (the underlying
-  // `string | string[] | undefined`) for direct callers, but the
-  // registry's typed return is `Promise<boolean>`, so the dispatcher
-  // wraps them with `awaitTrue(...)` and the resolved data is
-  // intentionally dropped. Palette / `executeCommand` callers don't
-  // consume the value today; if a future caller needs the original
-  // payload it must call the action helper directly instead of going
-  // through `vscode.commands.executeCommand`.
-  encodeImageToBase64(): Promise<string | undefined>;
-  convertPdfToImages(): Promise<string[] | string | undefined>;
-  extractTikzFigures(): Promise<void>;
-  compileTikzFigures(): Promise<void>;
-  cloneOverleafProject(): Promise<void>;
-  // Batch 4 (#3781).
-  removeApiKey(): Promise<void>;
-  showImportOptions(): Promise<void>;
-  toggleView(): Promise<void>;
-  showProgressView(inPlace: boolean): Promise<void>;
-  setApiKey(provider: ApiProvider | undefined): Promise<void>;
-  createAgentWithAI(category: AgentCategory): Promise<void>;
-  execute(input: unknown): Promise<void>;
-}
 
 export function createExtensionCommandActions(
   context: vscode.ExtensionContext,
@@ -356,142 +170,15 @@ export function createExtensionCommandActions(
   };
 }
 
-const EXTENSION_COMMAND_HANDLERS = {
-  'texra.showDashboard': (actions) => awaitTrue(actions.showSettings()),
-  'texra.showSettingsView': (actions) => awaitTrue(actions.showSettings()),
-  'texra.showMemory': (actions) =>
-    awaitTrue(actions.showSettings(SETTINGS_TAB.MEMORY)),
-  'texra.showAgentHistory': (actions) =>
-    awaitTrue(actions.showSettings(SETTINGS_TAB.HISTORY)),
-  'texra.showModels': (actions) =>
-    awaitTrue(actions.showSettings(SETTINGS_TAB.MODELS)),
-  'texra.showTools': (actions) =>
-    awaitTrue(actions.showSettings(SETTINGS_TAB.TOOLS)),
-  'texra.showMultiAgent': (actions) =>
-    awaitTrue(actions.showSettings(SETTINGS_TAB.MULTI_AGENT)),
-  'texra.showGitSettings': (actions) =>
-    awaitTrue(actions.showSettings(SETTINGS_TAB.GIT)),
-  'texra.openSettings': (actions) => awaitTrue(actions.openWorkbenchSettings()),
-  'texra.mainView.reset': (actions) => awaitTrue(actions.resetMainView()),
-  'texra.cleanOutput': (actions) => awaitTrue(actions.cleanOutput()),
-  'texra.cleanBuild': (actions) => awaitTrue(actions.cleanBuild()),
-  'texra.indentTeX': (actions) => awaitTrue(actions.indentTeX()),
-  'texra.auth.signIn': (actions) => awaitTrue(actions.signIn()),
-  'texra.auth.chatgpt.signIn': (actions) => awaitTrue(actions.signInChatGpt()),
-  'texra.auth.signOut': (actions) => awaitTrue(actions.signOut()),
-  'texra.auth.viewProfile': (actions) => awaitTrue(actions.viewProfile()),
-  'texra.runSetupAssistant': (actions) =>
-    awaitTrue(actions.runSetupAssistant()),
-  'texra.openGettingStarted': (actions) =>
-    awaitTrue(actions.openGettingStarted()),
-  'texra.createSampleProject': (actions) =>
-    awaitTrue(actions.createSampleProject()),
-  'texra.downloadArXivSource': (actions) =>
-    awaitTrue(actions.downloadArXivSource()),
-  'texra.testConnection': (actions) => awaitTrue(actions.testConnection()),
-  'texra.testAgentLoading': (actions) => awaitTrue(actions.testAgentLoading()),
-  'texra.loadSpecificAgent': (actions) =>
-    awaitTrue(actions.loadSpecificAgent()),
-  'texra.openProgressViewInTab': (actions) =>
-    awaitTrue(actions.openProgressViewInTab()),
-  'texra.openDoc': definedHandler(
-    z.string(),
-    (actions: ExtensionCommandActions, page) =>
-      awaitTrue(actions.openDoc(page)),
-  ),
-  'texra.stopAgent': definedHandler(
-    StreamTabIdSchema,
-    (actions: ExtensionCommandActions, streamId) => {
-      actions.stopAgent(streamId);
-      return true;
-    },
-  ),
-  'texra.compactResponse': definedHandler(
-    StreamTabIdSchema,
-    (actions: ExtensionCommandActions, streamId) =>
-      awaitTrue(actions.compactResponse(streamId)),
-  ),
-  'texra.parseXml': (actions) => awaitTrue(actions.parseXml()),
-  'texra.parseYaml': (actions) => awaitTrue(actions.parseYaml()),
-  'texra.testTextEditor': (actions) => awaitTrue(actions.testTextEditor()),
-  'texra.indentCurrentTeX': (actions) => awaitTrue(actions.indentCurrentTeX()),
-  'texra.applyReplacements': (actions) =>
-    awaitTrue(actions.applyReplacements()),
-  'texra.fixCompilation': (actions) => awaitTrue(actions.fixCompilation()),
-  'texra.getTeXCount': (actions) => awaitTrue(actions.getTeXCount()),
-  'texra.countPdfPages': (actions) => awaitTrue(actions.countPdfPages()),
-  'texra.showLinterMessages': (actions) =>
-    awaitTrue(actions.showLinterMessages()),
-  'texra.countLinterMessages': (actions) =>
-    awaitTrue(actions.countLinterMessages()),
-  'texra.extractFigurePaths': (actions) =>
-    awaitTrue(actions.extractFigurePaths()),
-  // Batch 3 (#3781) — image / PDF / TikZ / Overleaf entry points.
-  'texra.encodeImageToBase64': (actions) =>
-    awaitTrue(actions.encodeImageToBase64()),
-  'texra.convertPdfToImages': (actions) =>
-    awaitTrue(actions.convertPdfToImages()),
-  'texra.extractTikzFigures': (actions) =>
-    awaitTrue(actions.extractTikzFigures()),
-  'texra.compileTikzFigures': (actions) =>
-    awaitTrue(actions.compileTikzFigures()),
-  'texra.cloneOverleafProject': (actions) =>
-    awaitTrue(actions.cloneOverleafProject()),
-  // Batch 4 (#3781).
-  'texra.removeApiKey': (actions) => awaitTrue(actions.removeApiKey()),
-  'texra.showImportOptions': (actions) =>
-    awaitTrue(actions.showImportOptions()),
-  'texra.toggleView': (actions) => awaitTrue(actions.toggleView()),
-  'texra.showProgressView': definedHandler(
-    ShowProgressViewArgSchema,
-    (actions: ExtensionCommandActions, parsed) => {
-      const inPlace =
-        typeof parsed === 'object' &&
-        parsed !== null &&
-        (parsed as { inPlace?: unknown }).inPlace === true;
-      return awaitTrue(actions.showProgressView(inPlace));
-    },
-  ),
-  'texra.setApiKey': definedHandler(
-    SetApiKeyArgSchema,
-    (actions: ExtensionCommandActions, provider) =>
-      awaitTrue(actions.setApiKey(provider)),
-  ),
-  'texra.createAgentWithAI': definedHandler(
-    CreateAgentWithAIArgSchema,
-    (actions: ExtensionCommandActions, category) =>
-      awaitTrue(actions.createAgentWithAI(category ?? 'workflow')),
-  ),
-  'texra.execute': definedHandler(
-    z.unknown(),
-    (actions: ExtensionCommandActions, input) =>
-      awaitTrue(actions.execute(input)),
-  ),
-} as const satisfies Record<
-  Exclude<ExtensionRegistryCommandId, 'texra.showAgents'>,
-  // The typed handlers (`openDoc`, `stopAgent`, `compactResponse`) carry
-  // their own argument shapes via `definedHandler`. Matching the registry
-  // map's per-entry TArgs widening (`any`) keeps inference per entry
-  // without unifying every entry on `unknown`.
-  CommandHandler<ExtensionCommandActions, any>
->;
-
-// `texra.showAgents` accepts an optional `AgentCategory` argument from
-// `executeCommand` callers, so it can't share the no-arg `CommandHandler`
-// signature. It's still routed through the same actions interface — the
-// only difference is that the VS Code registration forwards the argument.
-//
-// FOLLOW_UP: This bespoke parameterized map can be replaced with the
-// `definedHandler` typed-args helper in `@shared/commands/registry` once
-// the surrounding parameterized commands (pack/clean/compare/etc.) are
-// migrated through that path. Keeping it as-is for now to minimize churn.
-const EXTENSION_PARAMETERIZED_HANDLERS = {
-  'texra.showAgents': (actions, subTab?: AgentCategory) =>
-    actions.showSettings(SETTINGS_TAB.AGENTS, subTab),
-} satisfies Record<
-  Extract<ExtensionRegistryCommandId, 'texra.showAgents'>,
-  (actions: ExtensionCommandActions, arg?: AgentCategory) => Promise<void>
->;
+/*
+ * Duplicate-registration audit (#3787 follow-up):
+ * Every command id in `EXTENSION_COMMAND_HANDLERS` +
+ * `EXTENSION_PARAMETERIZED_HANDLERS` has been verified to have no stale
+ * `vscode.commands.registerCommand(...)` call elsewhere. The remaining
+ * legacy `registerCommand` call sites all register ids NOT tagged
+ * `extensionRegistry` in `commandCatalog` — they're legitimate VS
+ * Code-only handlers (file ops, git, latex tools, pack/clean variants).
+ */
 
 /**
  * Register every command in the shared registry against `vscode.commands`,

--- a/src/shared/commands/catalog.ts
+++ b/src/shared/commands/catalog.ts
@@ -12,28 +12,43 @@ export interface CommandCatalogEntry {
   icon?: string;
   enablement?: string;
   keybinding?: CommandKeybinding;
+  /**
+   * Set on entries whose VS Code extension registration goes through the
+   * shared `dispatchCommandFromRegistry` handler map (see
+   * `packages/extension/src/commands/extensionCommandHandlers.ts`) rather
+   * than a bespoke `vscode.commands.registerCommand` call elsewhere.
+   * Untagged entries are still valid commands — they're registered
+   * directly by other command modules — this flag only marks membership
+   * in the shared-registry surface so it can be derived instead of hand-
+   * mirrored.
+   */
+  extensionRegistry?: true;
 }
 
 export const commandCatalog = [
   {
     id: 'texra.createSampleProject',
+    extensionRegistry: true,
     title: 'Create Sample Project',
     category: 'TeXRA',
   },
   {
     id: 'texra.runSetupAssistant',
+    extensionRegistry: true,
     title: 'Run Setup Assistant Agent (Setup Wizard)',
     category: 'TeXRA',
     icon: '$(rocket)',
   },
   {
     id: 'texra.openGettingStarted',
+    extensionRegistry: true,
     title: 'Open Getting Started Walkthrough',
     category: 'TeXRA',
     icon: '$(mortar-board)',
   },
   {
     id: 'texra.cleanOutput',
+    extensionRegistry: true,
     title: 'Clean All LLM Output Files (Workspace-wide)',
     shortTitle: 'Clean LLM Outputs',
     category: 'TeXRA',
@@ -46,6 +61,7 @@ export const commandCatalog = [
   },
   {
     id: 'texra.cleanBuild',
+    extensionRegistry: true,
     title: 'Clean All Build Files (Workspace-wide)',
     shortTitle: 'Clean Build Files',
     category: 'TeXRA',
@@ -58,6 +74,7 @@ export const commandCatalog = [
   },
   {
     id: 'texra.indentTeX',
+    extensionRegistry: true,
     title: 'Indent All LaTeX Files',
     category: 'TeXRA',
     icon: '$(indent)',
@@ -69,6 +86,7 @@ export const commandCatalog = [
   },
   {
     id: 'texra.cloneOverleafProject',
+    extensionRegistry: true,
     title: 'Clone Overleaf/ShareLaTeX Project',
     category: 'TeXRA',
     icon: '$(repo-clone)',
@@ -80,6 +98,7 @@ export const commandCatalog = [
   },
   {
     id: 'texra.indentCurrentTeX',
+    extensionRegistry: true,
     title: 'Indent Current TeX',
     category: 'TeXRA',
     icon: '$(indent)',
@@ -92,6 +111,7 @@ export const commandCatalog = [
   },
   {
     id: 'texra.applyReplacements',
+    extensionRegistry: true,
     title: 'Apply LaTeX Replacements to Current File',
     category: 'TeXRA',
     icon: '$(symbol-text)',
@@ -99,6 +119,7 @@ export const commandCatalog = [
   },
   {
     id: 'texra.fixCompilation',
+    extensionRegistry: true,
     title: 'Fix LaTeX Compilation Errors',
     category: 'TeXRA',
     icon: '$(wrench)',
@@ -106,6 +127,7 @@ export const commandCatalog = [
   },
   {
     id: 'texra.getTeXCount',
+    extensionRegistry: true,
     title: 'Count Words in Current TeX File',
     category: 'TeXRA',
     icon: '$(symbol-number)',
@@ -113,82 +135,98 @@ export const commandCatalog = [
   },
   {
     id: 'texra.countPdfPages',
+    extensionRegistry: true,
     title: 'Count PDF Pages',
     category: 'TeXRA',
   },
   {
     id: 'texra.encodeImageToBase64',
+    extensionRegistry: true,
     title: 'Encode Image to Base64',
     category: 'TeXRA',
   },
   {
     id: 'texra.convertPdfToImages',
+    extensionRegistry: true,
     title: 'Convert PDF to Images',
     category: 'TeXRA',
   },
   {
     id: 'texra.extractFigurePaths',
+    extensionRegistry: true,
     title: 'Extract Figure Paths from LaTeX',
     category: 'TeXRA',
   },
   {
     id: 'texra.extractTikzFigures',
+    extensionRegistry: true,
     title: 'Extract TikZ Figures from Current File',
     category: 'TeXRA',
   },
   {
     id: 'texra.compileTikzFigures',
+    extensionRegistry: true,
     title: 'Compile TikZ Figures from Current File',
     category: 'TeXRA',
   },
   {
     id: 'texra.testConnection',
+    extensionRegistry: true,
     title: 'Test API Connection',
     category: 'TeXRA',
   },
   {
     id: 'texra.testAgentLoading',
+    extensionRegistry: true,
     title: 'Test Agent Loading',
     category: 'TeXRA',
   },
   {
     id: 'texra.loadSpecificAgent',
+    extensionRegistry: true,
     title: 'Load Specific Agent',
     category: 'TeXRA',
   },
   {
     id: 'texra.downloadArXivSource',
+    extensionRegistry: true,
     title: 'Download arXiv Source',
     category: 'TeXRA',
   },
   {
     id: 'texra.showImportOptions',
+    extensionRegistry: true,
     title: 'Import or Create LaTeX Project',
     category: 'TeXRA',
     icon: '$(cloud-download)',
   },
   {
     id: 'texra.parseXml',
+    extensionRegistry: true,
     title: 'Parse XML Structure',
     category: 'TeXRA',
   },
   {
     id: 'texra.parseYaml',
+    extensionRegistry: true,
     title: 'Parse YAML Structure',
     category: 'TeXRA',
   },
   {
     id: 'texra.stopAgent',
+    extensionRegistry: true,
     title: 'Stop Agent',
     category: 'TeXRA',
   },
   {
     id: 'texra.compactResponse',
+    extensionRegistry: true,
     title: 'Compact Response',
     category: 'TeXRA',
   },
   {
     id: 'texra.execute',
+    extensionRegistry: true,
     title: 'Execute Agent',
     category: 'TeXRA',
     keybinding: {
@@ -213,67 +251,79 @@ export const commandCatalog = [
   },
   {
     id: 'texra.createAgentWithAI',
+    extensionRegistry: true,
     title: 'Create AI Agent',
     category: 'TeXRA',
     icon: '$(sparkle)',
   },
   {
     id: 'texra.setApiKey',
+    extensionRegistry: true,
     title: 'Set API Key',
     category: 'TeXRA',
   },
   {
     id: 'texra.removeApiKey',
+    extensionRegistry: true,
     title: 'Remove API Key',
     category: 'TeXRA',
   },
   {
     id: 'texra.auth.signIn',
+    extensionRegistry: true,
     title: 'Sign In',
     category: 'TeXRA',
     icon: '$(sign-in)',
   },
   {
     id: 'texra.auth.chatgpt.signIn',
+    extensionRegistry: true,
     title: 'Sign In with ChatGPT Subscription',
     category: 'TeXRA',
     icon: '$(comment-discussion)',
   },
   {
     id: 'texra.auth.signOut',
+    extensionRegistry: true,
     title: 'Sign Out',
     category: 'TeXRA',
     icon: '$(sign-out)',
   },
   {
     id: 'texra.auth.viewProfile',
+    extensionRegistry: true,
     title: 'View Profile',
     category: 'TeXRA',
     icon: '$(account)',
   },
   {
     id: 'texra.testTextEditor',
+    extensionRegistry: true,
     title: 'Test Text Editor Tool',
     category: 'TeXRA',
     icon: '$(edit)',
   },
   {
     id: 'texra.showLinterMessages',
+    extensionRegistry: true,
     title: 'Show Linter Messages',
     category: 'TeXRA',
   },
   {
     id: 'texra.countLinterMessages',
+    extensionRegistry: true,
     title: 'Count Linter Messages',
     category: 'TeXRA',
   },
   {
     id: 'texra.openDoc',
+    extensionRegistry: true,
     title: 'Open TeXRA Documentation',
     category: 'TeXRA',
   },
   {
     id: 'texra.mainView.reset',
+    extensionRegistry: true,
     title: 'New Session',
     shortTitle: 'New',
     category: 'TeXRA',
@@ -281,48 +331,56 @@ export const commandCatalog = [
   },
   {
     id: 'texra.showAgentHistory',
+    extensionRegistry: true,
     title: 'Show Agent Execution History',
     category: 'TeXRA',
     icon: '$(history)',
   },
   {
     id: 'texra.showMemory',
+    extensionRegistry: true,
     title: 'Show Memory',
     category: 'TeXRA',
     icon: '$(database)',
   },
   {
     id: 'texra.showModels',
+    extensionRegistry: true,
     title: 'Show Models',
     category: 'TeXRA',
     icon: '$(hubot)',
   },
   {
     id: 'texra.showAgents',
+    extensionRegistry: true,
     title: 'Show Agents',
     category: 'TeXRA',
     icon: '$(symbol-method)',
   },
   {
     id: 'texra.showTools',
+    extensionRegistry: true,
     title: 'Show Tool Dashboard',
     category: 'TeXRA',
     icon: '$(tools)',
   },
   {
     id: 'texra.showMultiAgent',
+    extensionRegistry: true,
     title: 'Show Multi-Agent Settings',
     category: 'TeXRA',
     icon: '$(organization)',
   },
   {
     id: 'texra.showGitSettings',
+    extensionRegistry: true,
     title: 'Show Git Settings',
     category: 'TeXRA',
     icon: '$(git-branch)',
   },
   {
     id: 'texra.openSettings',
+    extensionRegistry: true,
     title: 'Open TeXRA Settings',
     category: 'TeXRA',
     icon: '$(settings-gear)',
@@ -340,6 +398,7 @@ export const commandCatalog = [
   },
   {
     id: 'texra.showProgressView',
+    extensionRegistry: true,
     title: 'Show Progress',
     category: 'TeXRA',
     icon: '$(eye)',
@@ -351,6 +410,7 @@ export const commandCatalog = [
   },
   {
     id: 'texra.toggleView',
+    extensionRegistry: true,
     title: 'Toggle Launcher/Progress View',
     category: 'TeXRA',
     icon: '$(split-horizontal)',
@@ -362,6 +422,7 @@ export const commandCatalog = [
   },
   {
     id: 'texra.openProgressViewInTab',
+    extensionRegistry: true,
     title: 'Open Progress in Editor Tab',
     shortTitle: 'Open in Tab',
     category: 'TeXRA',
@@ -369,6 +430,7 @@ export const commandCatalog = [
   },
   {
     id: 'texra.showDashboard',
+    extensionRegistry: true,
     title: 'Show Settings Dashboard',
     shortTitle: 'Settings',
     category: 'TeXRA',

--- a/src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts
+++ b/src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts
@@ -106,9 +106,9 @@ describe('extension command registry — catalog-driven registration', () => {
   it.each(EXTENSION_HIDDEN_ALIASES)(
     'hidden alias %s is absent from the public catalog',
     (id) => {
-      expect(
-        commandCatalog.some((entry) => (entry.id as string) === id),
-      ).toBe(false);
+      expect(commandCatalog.some((entry) => (entry.id as string) === id)).toBe(
+        false,
+      );
     },
   );
 });
@@ -242,9 +242,7 @@ describe('extension command surface — newly migrated commands (#3771, #3775, #
       'stream-2',
     );
     await expect(Promise.resolve(result)).resolves.toBe(true);
-    expect(actions.compactResponse).toHaveBeenCalledExactlyOnceWith(
-      'stream-2',
-    );
+    expect(actions.compactResponse).toHaveBeenCalledExactlyOnceWith('stream-2');
   });
 
   it('texra.compactResponse rejects empty streamId', () => {

--- a/src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts
+++ b/src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts
@@ -1,164 +1,26 @@
 // Third-party imports
 import { describe, expect, it, vi } from 'vitest';
-import { z } from 'zod';
 
 // Local imports
-import type { ExtensionCommandActions } from '@commands/extensionCommandSurface';
 import {
-  awaitTrue,
-  definedHandler,
-  dispatchCommandFromRegistry,
-  type CommandHandler,
-} from '@shared/commands/registry';
-import { AgentCategorySchema } from '@shared/schemas/agent';
-import { StreamTabIdSchema } from '@shared/schemas/identifiers';
-
-// Re-implement the extension's no-arg handler map here in test form. We
-// can't import the real `extensionCommandSurface.ts` from a vitest run
-// because it transitively pulls in `vscode`. The point of this test is
-// not to re-test the dispatcher (covered in CommandRegistry.vitest.ts);
-// it's to lock in that each newly migrated id (#3771, #3775, #3781)
-// calls the right `actions.*` method, AND that async failures
-// propagate through the dispatcher (regression guard for #3782).
+  EXTENSION_COMMAND_HANDLERS,
+  EXTENSION_HIDDEN_ALIASES,
+  EXTENSION_PARAMETERIZED_HANDLERS,
+  EXTENSION_REGISTRY_CATALOG_COMMAND_IDS,
+  type ExtensionCommandActions,
+} from '@commands/extensionCommandHandlers';
+import {
+  commandCatalog,
+  type CommandCatalogEntry,
+} from '@shared/commands/catalog';
+import { dispatchCommandFromRegistry } from '@shared/commands/registry';
 import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
 
-const HANDLERS = {
-  'texra.showDashboard': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.showSettings()),
-  'texra.showSettingsView': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.showSettings()),
-  'texra.cleanOutput': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.cleanOutput()),
-  'texra.cleanBuild': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.cleanBuild()),
-  'texra.indentTeX': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.indentTeX()),
-  'texra.auth.signIn': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.signIn()),
-  'texra.auth.chatgpt.signIn': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.signInChatGpt()),
-  'texra.auth.signOut': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.signOut()),
-  'texra.auth.viewProfile': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.viewProfile()),
-  'texra.showMemory': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.showSettings(SETTINGS_TAB.MEMORY)),
-  'texra.runSetupAssistant': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.runSetupAssistant()),
-  'texra.openGettingStarted': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.openGettingStarted()),
-  'texra.createSampleProject': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.createSampleProject()),
-  'texra.downloadArXivSource': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.downloadArXivSource()),
-  'texra.testConnection': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.testConnection()),
-  'texra.testAgentLoading': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.testAgentLoading()),
-  'texra.loadSpecificAgent': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.loadSpecificAgent()),
-  'texra.openProgressViewInTab': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.openProgressViewInTab()),
-  'texra.openDoc': definedHandler(
-    z.string(),
-    (actions: ExtensionCommandActions, page) =>
-      awaitTrue(actions.openDoc(page)),
-  ),
-  'texra.stopAgent': definedHandler(
-    StreamTabIdSchema,
-    (actions: ExtensionCommandActions, streamId) => {
-      actions.stopAgent(streamId);
-      return true;
-    },
-  ),
-  'texra.compactResponse': definedHandler(
-    StreamTabIdSchema,
-    (actions: ExtensionCommandActions, streamId) =>
-      awaitTrue(actions.compactResponse(streamId)),
-  ),
-  // Batch 2 (#3775) — no-arg host-context commands.
-  'texra.parseXml': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.parseXml()),
-  'texra.parseYaml': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.parseYaml()),
-  'texra.testTextEditor': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.testTextEditor()),
-  'texra.indentCurrentTeX': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.indentCurrentTeX()),
-  'texra.applyReplacements': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.applyReplacements()),
-  'texra.fixCompilation': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.fixCompilation()),
-  'texra.getTeXCount': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.getTeXCount()),
-  'texra.countPdfPages': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.countPdfPages()),
-  'texra.showLinterMessages': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.showLinterMessages()),
-  'texra.countLinterMessages': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.countLinterMessages()),
-  'texra.extractFigurePaths': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.extractFigurePaths()),
-  // Batch 3 (#3781) — additional no-arg commands; same async pattern.
-  'texra.encodeImageToBase64': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.encodeImageToBase64()),
-  'texra.convertPdfToImages': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.convertPdfToImages()),
-  'texra.extractTikzFigures': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.extractTikzFigures()),
-  'texra.compileTikzFigures': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.compileTikzFigures()),
-  'texra.cloneOverleafProject': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.cloneOverleafProject()),
-  // Batch 4 (#3781) — settings/api/agent surface follow-ups. Mirrors the
-  // real `EXTENSION_COMMAND_HANDLERS` shape so each migrated id is
-  // exercised through the dispatcher without importing the host-coupled
-  // surface. The `ApiProvider` schema is duplicated locally because
-  // `SecretManager` carries a `vscode` import.
-  'texra.removeApiKey': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.removeApiKey()),
-  'texra.showImportOptions': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.showImportOptions()),
-  'texra.toggleView': (actions: ExtensionCommandActions) =>
-    awaitTrue(actions.toggleView()),
-  'texra.showProgressView': definedHandler(
-    z.object({ inPlace: z.boolean().optional() }).partial().optional(),
-    (actions: ExtensionCommandActions, parsed) =>
-      awaitTrue(actions.showProgressView(parsed?.inPlace === true)),
-  ),
-  'texra.setApiKey': definedHandler(
-    z
-      .enum([
-        'openai',
-        'anthropic',
-        'openRouter',
-        'google',
-        'xai',
-        'deepseek',
-        'moonshot',
-        'dashscope',
-        'minimax',
-        'glm',
-      ])
-      .optional(),
-    (actions: ExtensionCommandActions, provider) =>
-      awaitTrue(actions.setApiKey(provider)),
-  ),
-  'texra.createAgentWithAI': definedHandler(
-    AgentCategorySchema.optional(),
-    (actions: ExtensionCommandActions, category) =>
-      awaitTrue(actions.createAgentWithAI(category ?? 'workflow')),
-  ),
-  'texra.execute': definedHandler(
-    z.unknown(),
-    (actions: ExtensionCommandActions, input) =>
-      awaitTrue(actions.execute(input)),
-  ),
-  // The typed handlers carry their own argument shapes via
-  // `definedHandler`. Matching the registry map's per-entry TArgs widening
-  // (`any`) keeps inference per entry without unifying every entry on
-  // `unknown`.
-} satisfies Record<string, CommandHandler<ExtensionCommandActions, any>>;
+// `extensionCommandHandlers.ts` is deliberately free of `vscode` imports,
+// so — unlike `extensionCommandSurface.ts`, which wires the real actions
+// against VS Code APIs — the real handler map can be exercised here
+// directly. There is no hand-copied re-implementation to drift out of
+// sync with the production map.
 
 function makeActions(): ExtensionCommandActions {
   return {
@@ -199,7 +61,6 @@ function makeActions(): ExtensionCommandActions {
     extractTikzFigures: vi.fn().mockResolvedValue(undefined),
     compileTikzFigures: vi.fn().mockResolvedValue(undefined),
     cloneOverleafProject: vi.fn().mockResolvedValue(undefined),
-    // Batch 4 (#3781).
     removeApiKey: vi.fn().mockResolvedValue(undefined),
     showImportOptions: vi.fn().mockResolvedValue(undefined),
     toggleView: vi.fn().mockResolvedValue(undefined),
@@ -209,6 +70,48 @@ function makeActions(): ExtensionCommandActions {
     execute: vi.fn().mockResolvedValue(undefined),
   };
 }
+
+describe('extension command registry — catalog-driven registration', () => {
+  it('registers exactly the catalog ids tagged extensionRegistry, plus hidden aliases', () => {
+    const registered = [
+      ...Object.keys(EXTENSION_COMMAND_HANDLERS),
+      ...Object.keys(EXTENSION_PARAMETERIZED_HANDLERS),
+    ].sort();
+    const expected = [
+      ...EXTENSION_REGISTRY_CATALOG_COMMAND_IDS,
+      ...EXTENSION_HIDDEN_ALIASES,
+    ].sort();
+    expect(registered).toEqual(expected);
+  });
+
+  it('flags a catalog entry tagged extensionRegistry that has no handler', () => {
+    // Guards the assertion above against a false-positive pass: if a
+    // future catalog entry is tagged `extensionRegistry: true` without a
+    // matching handler, the id set comparison must fail rather than
+    // silently pass.
+    const taggedIds = new Set(
+      (commandCatalog as readonly CommandCatalogEntry[])
+        .filter((entry) => entry.extensionRegistry === true)
+        .map((entry) => entry.id),
+    );
+    const registeredIds = new Set([
+      ...Object.keys(EXTENSION_COMMAND_HANDLERS),
+      ...Object.keys(EXTENSION_PARAMETERIZED_HANDLERS),
+    ]);
+    for (const id of taggedIds) {
+      expect(registeredIds.has(id)).toBe(true);
+    }
+  });
+
+  it.each(EXTENSION_HIDDEN_ALIASES)(
+    'hidden alias %s is absent from the public catalog',
+    (id) => {
+      expect(
+        commandCatalog.some((entry) => (entry.id as string) === id),
+      ).toBe(false);
+    },
+  );
+});
 
 describe('extension command surface — newly migrated commands (#3771, #3775, #3781)', () => {
   it.each([
@@ -253,7 +156,11 @@ describe('extension command surface — newly migrated commands (#3771, #3775, #
     ['texra.toggleView', 'toggleView'],
   ] as const)('%s dispatches to actions.%s', async (id, actionKey) => {
     const actions = makeActions();
-    const result = dispatchCommandFromRegistry(id, HANDLERS, actions);
+    const result = dispatchCommandFromRegistry(
+      id,
+      EXTENSION_COMMAND_HANDLERS,
+      actions,
+    );
     // Async handlers return a promise; awaiting must resolve to `true`.
     await expect(Promise.resolve(result)).resolves.toBe(true);
     expect(actions[actionKey]).toHaveBeenCalledOnce();
@@ -263,7 +170,7 @@ describe('extension command surface — newly migrated commands (#3771, #3775, #
     const actions = makeActions();
     const result = dispatchCommandFromRegistry(
       'texra.showMemory',
-      HANDLERS,
+      EXTENSION_COMMAND_HANDLERS,
       actions,
     );
     await expect(Promise.resolve(result)).resolves.toBe(true);
@@ -272,11 +179,23 @@ describe('extension command surface — newly migrated commands (#3771, #3775, #
     );
   });
 
+  it('texra.showAgents (parameterized) passes the agents sub-tab', async () => {
+    const actions = makeActions();
+    await EXTENSION_PARAMETERIZED_HANDLERS['texra.showAgents'](
+      actions,
+      'toolUse',
+    );
+    expect(actions.showSettings).toHaveBeenCalledExactlyOnceWith(
+      SETTINGS_TAB.AGENTS,
+      'toolUse',
+    );
+  });
+
   it('texra.openDoc forwards parsed page argument', async () => {
     const actions = makeActions();
     const result = dispatchCommandFromRegistry(
       'texra.openDoc',
-      HANDLERS,
+      EXTENSION_COMMAND_HANDLERS,
       actions,
       undefined,
       'getting-started',
@@ -290,7 +209,7 @@ describe('extension command surface — newly migrated commands (#3771, #3775, #
     expect(
       dispatchCommandFromRegistry(
         'texra.openDoc',
-        HANDLERS,
+        EXTENSION_COMMAND_HANDLERS,
         actions,
         undefined,
         42,
@@ -304,7 +223,7 @@ describe('extension command surface — newly migrated commands (#3771, #3775, #
     expect(
       dispatchCommandFromRegistry(
         'texra.stopAgent',
-        HANDLERS,
+        EXTENSION_COMMAND_HANDLERS,
         actions,
         undefined,
         'stream-1',
@@ -317,13 +236,15 @@ describe('extension command surface — newly migrated commands (#3771, #3775, #
     const actions = makeActions();
     const result = dispatchCommandFromRegistry(
       'texra.compactResponse',
-      HANDLERS,
+      EXTENSION_COMMAND_HANDLERS,
       actions,
       undefined,
       'stream-2',
     );
     await expect(Promise.resolve(result)).resolves.toBe(true);
-    expect(actions.compactResponse).toHaveBeenCalledExactlyOnceWith('stream-2');
+    expect(actions.compactResponse).toHaveBeenCalledExactlyOnceWith(
+      'stream-2',
+    );
   });
 
   it('texra.compactResponse rejects empty streamId', () => {
@@ -331,7 +252,7 @@ describe('extension command surface — newly migrated commands (#3771, #3775, #
     expect(
       dispatchCommandFromRegistry(
         'texra.compactResponse',
-        HANDLERS,
+        EXTENSION_COMMAND_HANDLERS,
         actions,
         undefined,
         '',
@@ -345,7 +266,7 @@ describe('extension command surface — newly migrated commands (#3771, #3775, #
     const actions = makeActions();
     const result = dispatchCommandFromRegistry(
       'texra.showProgressView',
-      HANDLERS,
+      EXTENSION_COMMAND_HANDLERS,
       actions,
     );
     await expect(Promise.resolve(result)).resolves.toBe(true);
@@ -356,7 +277,7 @@ describe('extension command surface — newly migrated commands (#3771, #3775, #
     const actions = makeActions();
     const result = dispatchCommandFromRegistry(
       'texra.showProgressView',
-      HANDLERS,
+      EXTENSION_COMMAND_HANDLERS,
       actions,
       undefined,
       { inPlace: true },
@@ -369,7 +290,7 @@ describe('extension command surface — newly migrated commands (#3771, #3775, #
     const actions = makeActions();
     const result = dispatchCommandFromRegistry(
       'texra.setApiKey',
-      HANDLERS,
+      EXTENSION_COMMAND_HANDLERS,
       actions,
       undefined,
       'anthropic',
@@ -382,7 +303,7 @@ describe('extension command surface — newly migrated commands (#3771, #3775, #
     const actions = makeActions();
     const result = dispatchCommandFromRegistry(
       'texra.setApiKey',
-      HANDLERS,
+      EXTENSION_COMMAND_HANDLERS,
       actions,
     );
     await expect(Promise.resolve(result)).resolves.toBe(true);
@@ -394,7 +315,7 @@ describe('extension command surface — newly migrated commands (#3771, #3775, #
     expect(
       dispatchCommandFromRegistry(
         'texra.setApiKey',
-        HANDLERS,
+        EXTENSION_COMMAND_HANDLERS,
         actions,
         undefined,
         'not-a-provider',
@@ -407,7 +328,7 @@ describe('extension command surface — newly migrated commands (#3771, #3775, #
     const actions = makeActions();
     const result = dispatchCommandFromRegistry(
       'texra.createAgentWithAI',
-      HANDLERS,
+      EXTENSION_COMMAND_HANDLERS,
       actions,
     );
     await expect(Promise.resolve(result)).resolves.toBe(true);
@@ -420,7 +341,7 @@ describe('extension command surface — newly migrated commands (#3771, #3775, #
     const actions = makeActions();
     const result = dispatchCommandFromRegistry(
       'texra.createAgentWithAI',
-      HANDLERS,
+      EXTENSION_COMMAND_HANDLERS,
       actions,
       undefined,
       'toolUse',
@@ -436,7 +357,7 @@ describe('extension command surface — newly migrated commands (#3771, #3775, #
     const payload = { config: { name: 'test' } };
     const result = dispatchCommandFromRegistry(
       'texra.execute',
-      HANDLERS,
+      EXTENSION_COMMAND_HANDLERS,
       actions,
       undefined,
       payload,
@@ -464,7 +385,11 @@ describe('extension command surface — newly migrated commands (#3771, #3775, #
 
       (actions[actionKey] as any).mockRejectedValueOnce(failure);
 
-      const result = dispatchCommandFromRegistry(id, HANDLERS, actions);
+      const result = dispatchCommandFromRegistry(
+        id,
+        EXTENSION_COMMAND_HANDLERS,
+        actions,
+      );
       await expect(Promise.resolve(result)).rejects.toBe(failure);
     });
 
@@ -476,7 +401,7 @@ describe('extension command surface — newly migrated commands (#3771, #3775, #
 
       const result = dispatchCommandFromRegistry(
         'texra.compactResponse',
-        HANDLERS,
+        EXTENSION_COMMAND_HANDLERS,
         actions,
         undefined,
         'stream-3',


### PR DESCRIPTION
## Summary
- Tag `src/shared/commands/catalog.ts` entries with `extensionRegistry: true` for the ~50 commands whose VS Code registration goes through the shared `dispatchCommandFromRegistry` handler map, and derive `extensionCommandSurface.ts`'s id union from that tag via `Extract<>` instead of a hand-authored ~50-entry union list.
- Split the vscode-free handler map (`EXTENSION_COMMAND_HANDLERS`, `EXTENSION_PARAMETERIZED_HANDLERS`), the `ExtensionCommandActions` interface, and the catalog-derived types into a new `packages/extension/src/commands/extensionCommandHandlers.ts` (no `vscode` import) so it can be imported directly in Vitest without a `vscode` mock. `extensionCommandSurface.ts` now only holds the vscode-coupled action wiring and the registration loop.
- Kept an explicit hidden-alias list (`EXTENSION_HIDDEN_ALIASES = ['texra.showSettingsView']`) for the one compat id intentionally absent from the public catalog.
- Rewrote `src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts` to import the real handler map (previously it hand-copied ~35 entries because the real file transitively pulled in `vscode`), removing that second drift-prone copy, and added a completeness test asserting the registered id set exactly equals the catalog ids tagged `extensionRegistry` plus the hidden aliases, plus a hidden-alias regression test.

## Verification
- Diffed the registered command-id set before/after: 52 ids in both cases, 0 removed, 0 added (51 catalog-tagged ids + 1 hidden alias).
- npm run typecheck, npm run lint, and npm run compile:fast all pass with no new warnings/errors.
- Could not execute npm test / vitest directly in this sandboxed environment (the command required interactive approval that was not available); the completeness-test logic was independently verified by replicating its comparison in a standalone script against the real source files, confirming the two 52-id sets are equal.

Fixes https://github.com/LionSR/TeXRA/issues/7102

Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only: same 52 registered command ids with compile-time `satisfies Record<>` checks; runtime dispatch behavior is unchanged aside from test coverage.
> 
> **Overview**
> **Derives** which VS Code commands use the shared `dispatchCommandFromRegistry` path from `commandCatalog` via a new **`extensionRegistry: true`** flag (~51 entries), replacing a large hand-written `ExtensionRegistryCommandId` union.
> 
> **Splits** handler maps, Zod arg schemas, and `ExtensionCommandActions` into **`extensionCommandHandlers.ts`** (no `vscode` import) so Vitest can import the real `EXTENSION_COMMAND_HANDLERS` map; **`extensionCommandSurface.ts`** keeps only `createExtensionCommandActions` and `registerExtensionCommandRegistry`. The hidden compat id **`texra.showSettingsView`** stays on an explicit **`EXTENSION_HIDDEN_ALIASES`** list.
> 
> **Updates** `ExtensionCommandRegistry.vitest.ts` to drop the duplicated handler map and add tests that registered ids match catalog-tagged ids plus hidden aliases. `setApiKey` now uses **`API_PROVIDERS`** from `@model/apiProviders` instead of `SecretManager` in the handler module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43f769e972bd369a07b7d0c9e518531f04fa0739. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->