### PR TITLE
refactor(modelHandlers): dedupe chat user-message helpers across OpenAI/OpenRouter

### DIFF
--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -41,7 +41,7 @@ import { tagOpenAISdkError } from './openAISdkError';
 import { computeOpenAIPrice, normalizeOpenAIUsage } from './openAIUsage';
 import { OPENAI_CHAT_FINISH } from '../types/StopReasonTypes';
 import {
-  assertBatchedToolCalls,
+  checkBatchedToolCalls,
   insertMediaIntoChatUserMessage,
   normalizeOpenAIMessageContent,
   prependTextToChatUserMessage,
@@ -1317,7 +1317,7 @@ export class ModelHandlerOpenAI<
     workspaceState?: AgentWorkspaceState,
     text?: string,
   ): Promise<ChatCompletionMessageParam[]> {
-    if (!assertBatchedToolCalls(calls.length, results.length)) {
+    if (!checkBatchedToolCalls(calls.length, results.length)) {
       return [];
     }
 
@@ -1365,7 +1365,7 @@ export class ModelHandlerOpenAI<
 
     try {
       const formattedMedia = await this.createMediaMessage(mediaFiles);
-      insertMediaIntoChatUserMessage(messages, formattedMedia);
+      insertMediaIntoChatUserMessage(lastUserMsg, formattedMedia);
     } catch (err) {
       logSdkError(
         this.logger,

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -40,7 +40,12 @@ import { tagOpenAISdkError } from './openAISdkError';
 // Local file imports
 import { computeOpenAIPrice, normalizeOpenAIUsage } from './openAIUsage';
 import { OPENAI_CHAT_FINISH } from '../types/StopReasonTypes';
-import { normalizeOpenAIMessageContent } from './openAIMessageUtils';
+import {
+  assertBatchedToolCalls,
+  insertMediaIntoChatUserMessage,
+  normalizeOpenAIMessageContent,
+  prependTextToChatUserMessage,
+} from './openAIMessageUtils';
 import {
   extractOpenAIPartialTail,
   extractReasoningDelta as extractReasoningDeltaFromChunk,
@@ -1312,13 +1317,7 @@ export class ModelHandlerOpenAI<
     workspaceState?: AgentWorkspaceState,
     text?: string,
   ): Promise<ChatCompletionMessageParam[]> {
-    if (calls.length !== results.length) {
-      throw new Error(
-        `Batched tool calls mismatch: ${calls.length} calls vs ${results.length} results`,
-      );
-    }
-
-    if (calls.length === 0) {
+    if (!assertBatchedToolCalls(calls.length, results.length)) {
       return [];
     }
 
@@ -1349,21 +1348,7 @@ export class ModelHandlerOpenAI<
     messages: ChatCompletionMessageParam[],
     text: string,
   ): void {
-    if (!text.trim()) return;
-
-    const lastUserMsg = messages.findLast((m) => m.role === 'user');
-    if (!lastUserMsg || !('content' in lastUserMsg)) return;
-
-    if (typeof lastUserMsg.content === 'string') {
-      lastUserMsg.content = text + lastUserMsg.content;
-    } else if (Array.isArray(lastUserMsg.content)) {
-      const firstTextPart = lastUserMsg.content.find((p) => p.type === 'text');
-      if (firstTextPart && 'text' in firstTextPart) {
-        firstTextPart.text = text + firstTextPart.text;
-      } else {
-        lastUserMsg.content.unshift({ type: 'text', text });
-      }
-    }
+    prependTextToChatUserMessage(messages, text);
   }
 
   /**
@@ -1380,17 +1365,7 @@ export class ModelHandlerOpenAI<
 
     try {
       const formattedMedia = await this.createMediaMessage(mediaFiles);
-      if (typeof lastUserMsg.content === 'string') {
-        lastUserMsg.content = [
-          ...formattedMedia,
-          {
-            type: 'text',
-            text: lastUserMsg.content,
-          } as ChatCompletionContentPart,
-        ];
-      } else if (Array.isArray(lastUserMsg.content)) {
-        lastUserMsg.content.unshift(...formattedMedia);
-      }
+      insertMediaIntoChatUserMessage(messages, formattedMedia);
     } catch (err) {
       logSdkError(
         this.logger,

--- a/src/agent/modelHandlers/openai/openAIMessageUtils.ts
+++ b/src/agent/modelHandlers/openai/openAIMessageUtils.ts
@@ -184,17 +184,22 @@ export function normalizeOpenAIMessageContent<T extends MessageLike>(
   return working;
 }
 
+/** Minimal structural view of a chat content part (text or media). */
+type ChatContentPart = { type: string };
+
 /**
- * Validate a batched tool-use follow-up before building provider messages.
+ * Check a batched tool-use follow-up before building provider messages.
  *
  * Shared by the chat-shaped handlers (OpenAI, OpenRouter), whose batched
  * follow-up requires exactly one result per call. Throws on a count mismatch
  * (a programmer error that would otherwise produce a malformed request) and
  * returns `false` when there is nothing to send so the caller can early-return.
+ * Named `check*` rather than `assert*` because it also encodes the empty-guard
+ * result rather than only throwing.
  *
  * @returns `true` when there is at least one call to process, `false` when empty.
  */
-export function assertBatchedToolCalls(
+export function checkBatchedToolCalls(
   callCount: number,
   resultCount: number,
 ): boolean {
@@ -227,8 +232,8 @@ export function prependTextToChatUserMessage<T extends MessageLike>(
   if (typeof content === 'string') {
     lastUserMsg.content = text + content;
   } else if (Array.isArray(content)) {
-    const firstTextPart = content.find((p) => p.type === 'text');
-    if (firstTextPart && 'text' in firstTextPart) {
+    const firstTextPart = content.find(isTextContentItem);
+    if (firstTextPart) {
       firstTextPart.text = text + firstTextPart.text;
     } else {
       content.unshift({ type: 'text', text });
@@ -237,23 +242,24 @@ export function prependTextToChatUserMessage<T extends MessageLike>(
 }
 
 /**
- * Insert already-formatted media parts at the front of the last user message.
+ * Insert already-formatted media parts at the front of a user message.
  *
- * The caller owns provider-specific media formatting (and the decision to skip
- * work when vision is unsupported or no user message exists); this shares only
- * the string-vs-array insertion so OpenAI and OpenRouter don't diverge. A
- * string body is promoted to a parts array with the media ahead of the text.
+ * Operates on the specific message the caller already located and validated —
+ * NOT a re-scan of the array — so media lands on that message even if the
+ * conversation gained another user turn while async media formatting was in
+ * flight. The caller owns provider-specific media formatting and the decision
+ * to skip work when vision is unsupported or no user message exists; this
+ * shares only the string-vs-array insertion so OpenAI and OpenRouter don't
+ * diverge. A string body is promoted to a parts array with the media ahead of
+ * the text.
  */
-export function insertMediaIntoChatUserMessage<T extends MessageLike>(
-  messages: T[],
-  formattedMedia: readonly unknown[],
+export function insertMediaIntoChatUserMessage(
+  message: MessageLike,
+  formattedMedia: readonly ChatContentPart[],
 ): void {
-  const lastUserMsg = messages.findLast((m) => m.role === 'user');
-  if (!lastUserMsg || !('content' in lastUserMsg)) return;
-
-  const content = lastUserMsg.content;
+  const content = message.content;
   if (typeof content === 'string') {
-    lastUserMsg.content = [...formattedMedia, { type: 'text', text: content }];
+    message.content = [...formattedMedia, { type: 'text', text: content }];
   } else if (Array.isArray(content)) {
     content.unshift(...formattedMedia);
   }

--- a/src/agent/modelHandlers/openai/openAIMessageUtils.ts
+++ b/src/agent/modelHandlers/openai/openAIMessageUtils.ts
@@ -183,3 +183,78 @@ export function normalizeOpenAIMessageContent<T extends MessageLike>(
 
   return working;
 }
+
+/**
+ * Validate a batched tool-use follow-up before building provider messages.
+ *
+ * Shared by the chat-shaped handlers (OpenAI, OpenRouter), whose batched
+ * follow-up requires exactly one result per call. Throws on a count mismatch
+ * (a programmer error that would otherwise produce a malformed request) and
+ * returns `false` when there is nothing to send so the caller can early-return.
+ *
+ * @returns `true` when there is at least one call to process, `false` when empty.
+ */
+export function assertBatchedToolCalls(
+  callCount: number,
+  resultCount: number,
+): boolean {
+  if (callCount !== resultCount) {
+    throw new Error(
+      `Batched tool calls mismatch: ${callCount} calls vs ${resultCount} results`,
+    );
+  }
+  return callCount > 0;
+}
+
+/**
+ * Prepend `text` to the last user message in a chat-shaped conversation.
+ *
+ * Chat providers (OpenAI, OpenRouter) model user content as either a plain
+ * string or an array of typed parts; this mutates whichever shape is present
+ * in place — merging into the first existing text part, or unshifting a new
+ * one. A blank `text` or the absence of a user message is a no-op.
+ */
+export function prependTextToChatUserMessage<T extends MessageLike>(
+  messages: T[],
+  text: string,
+): void {
+  if (!text.trim()) return;
+
+  const lastUserMsg = messages.findLast((m) => m.role === 'user');
+  if (!lastUserMsg || !('content' in lastUserMsg)) return;
+
+  const content = lastUserMsg.content;
+  if (typeof content === 'string') {
+    lastUserMsg.content = text + content;
+  } else if (Array.isArray(content)) {
+    const firstTextPart = content.find((p) => p.type === 'text');
+    if (firstTextPart && 'text' in firstTextPart) {
+      firstTextPart.text = text + firstTextPart.text;
+    } else {
+      content.unshift({ type: 'text', text });
+    }
+  }
+}
+
+/**
+ * Insert already-formatted media parts at the front of the last user message.
+ *
+ * The caller owns provider-specific media formatting (and the decision to skip
+ * work when vision is unsupported or no user message exists); this shares only
+ * the string-vs-array insertion so OpenAI and OpenRouter don't diverge. A
+ * string body is promoted to a parts array with the media ahead of the text.
+ */
+export function insertMediaIntoChatUserMessage<T extends MessageLike>(
+  messages: T[],
+  formattedMedia: readonly unknown[],
+): void {
+  const lastUserMsg = messages.findLast((m) => m.role === 'user');
+  if (!lastUserMsg || !('content' in lastUserMsg)) return;
+
+  const content = lastUserMsg.content;
+  if (typeof content === 'string') {
+    lastUserMsg.content = [...formattedMedia, { type: 'text', text: content }];
+  } else if (Array.isArray(content)) {
+    content.unshift(...formattedMedia);
+  }
+}

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -38,7 +38,7 @@ import { tagOpenRouterSdkError } from './openRouterSdkError';
 import { OPENAI_CHAT_FINISH } from '../types/StopReasonTypes';
 import { toOpenAITools } from '../toolConversion';
 import {
-  assertBatchedToolCalls,
+  checkBatchedToolCalls,
   insertMediaIntoChatUserMessage,
   prependTextToChatUserMessage,
 } from '../openai/openAIMessageUtils';
@@ -697,7 +697,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     _workspaceState?: AgentWorkspaceState,
     text?: string,
   ): Promise<ChatMessages[]> {
-    if (!assertBatchedToolCalls(calls.length, results.length)) return [];
+    if (!checkBatchedToolCalls(calls.length, results.length)) return [];
 
     const callMsg: ChatMessages = {
       role: 'assistant',
@@ -827,7 +827,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
 
     try {
       const formattedMedia = await this.createMediaMessage(mediaFiles);
-      insertMediaIntoChatUserMessage(messages, formattedMedia);
+      insertMediaIntoChatUserMessage(lastUserMsg, formattedMedia);
     } catch (err) {
       logSdkError(this.logger, 'Error adding media to user message', err, {
         operation: 'add media to user message',

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -38,6 +38,11 @@ import { tagOpenRouterSdkError } from './openRouterSdkError';
 import { OPENAI_CHAT_FINISH } from '../types/StopReasonTypes';
 import { toOpenAITools } from '../toolConversion';
 import {
+  assertBatchedToolCalls,
+  insertMediaIntoChatUserMessage,
+  prependTextToChatUserMessage,
+} from '../openai/openAIMessageUtils';
+import {
   formatAttachmentSummary,
   formatToolResultAsText,
 } from '../utils/toolAttachmentUtils';
@@ -692,12 +697,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     _workspaceState?: AgentWorkspaceState,
     text?: string,
   ): Promise<ChatMessages[]> {
-    if (calls.length !== results.length) {
-      throw new Error(
-        `Batched tool calls mismatch: ${calls.length} calls vs ${results.length} results`,
-      );
-    }
-    if (calls.length === 0) return [];
+    if (!assertBatchedToolCalls(calls.length, results.length)) return [];
 
     const callMsg: ChatMessages = {
       role: 'assistant',
@@ -814,26 +814,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
   // ---------------------------------------------------------------------------
 
   prependTextToUserMessage(messages: ChatMessages[], text: string): void {
-    if (!text.trim()) return;
-    const lastUserMsg = messages.findLast((m) => m.role === 'user');
-    if (!lastUserMsg || !('content' in lastUserMsg)) return;
-
-    if (typeof lastUserMsg.content === 'string') {
-      (lastUserMsg as ChatUserMessage).content = text + lastUserMsg.content;
-    } else if (Array.isArray(lastUserMsg.content)) {
-      const firstTextPart = (lastUserMsg.content as ChatContentItems[]).find(
-        (p) => p.type === 'text',
-      );
-      if (firstTextPart && 'text' in firstTextPart) {
-        const part = firstTextPart as ChatContentText;
-        part.text = text + part.text;
-      } else {
-        (lastUserMsg.content as ChatContentItems[]).unshift({
-          type: 'text',
-          text,
-        });
-      }
-    }
+    prependTextToChatUserMessage(messages, text);
   }
 
   async addMediaToUserMessage(
@@ -846,14 +827,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
 
     try {
       const formattedMedia = await this.createMediaMessage(mediaFiles);
-      if (typeof lastUserMsg.content === 'string') {
-        (lastUserMsg as ChatUserMessage).content = [
-          ...formattedMedia,
-          { type: 'text', text: lastUserMsg.content },
-        ];
-      } else if (Array.isArray(lastUserMsg.content)) {
-        (lastUserMsg.content as ChatContentItems[]).unshift(...formattedMedia);
-      }
+      insertMediaIntoChatUserMessage(messages, formattedMedia);
     } catch (err) {
       logSdkError(this.logger, 'Error adding media to user message', err, {
         operation: 'add media to user message',

--- a/src/test-kernel/agent/modelHandlers/OpenAIMessageUtils.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIMessageUtils.vitest.ts
@@ -3,7 +3,12 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'vitest';
 
 // Local imports - agent
-import { normalizeOpenAIMessageContent } from '@agent/modelHandlers/openai/openAIMessageUtils';
+import {
+  assertBatchedToolCalls,
+  insertMediaIntoChatUserMessage,
+  normalizeOpenAIMessageContent,
+  prependTextToChatUserMessage,
+} from '@agent/modelHandlers/openai/openAIMessageUtils';
 
 describe('normalizeOpenAIMessageContent', () => {
   it('merges consecutive roles when requested', () => {
@@ -192,5 +197,118 @@ describe('normalizeOpenAIMessageContent', () => {
     assert.equal(normalized.length, 3);
     assert.equal(normalized[1].tool_call_id, 'call_1');
     assert.equal(normalized[2].tool_call_id, 'call_2');
+  });
+});
+
+describe('assertBatchedToolCalls', () => {
+  it('throws on a call/result count mismatch', () => {
+    assert.throws(
+      () => assertBatchedToolCalls(2, 1),
+      /Batched tool calls mismatch: 2 calls vs 1 results/,
+    );
+  });
+
+  it('returns false when there is nothing to send', () => {
+    assert.equal(assertBatchedToolCalls(0, 0), false);
+  });
+
+  it('returns true when counts match and are non-empty', () => {
+    assert.equal(assertBatchedToolCalls(3, 3), true);
+  });
+
+  it('reports the mismatch before the empty check', () => {
+    // A zero call count with a non-zero result count is still a mismatch.
+    assert.throws(() => assertBatchedToolCalls(0, 2), /0 calls vs 2 results/);
+  });
+});
+
+describe('prependTextToChatUserMessage', () => {
+  it('prepends to a string user content in place', () => {
+    const messages = [
+      { role: 'assistant', content: 'hi' },
+      { role: 'user', content: 'question' },
+    ];
+    prependTextToChatUserMessage(messages, 'PREFIX: ');
+    assert.equal(messages[1].content, 'PREFIX: question');
+  });
+
+  it('merges into the first text part of an array content', () => {
+    const messages = [
+      {
+        role: 'user',
+        content: [
+          { type: 'image_url', image_url: { url: 'data:...' } },
+          { type: 'text', text: 'body' },
+        ],
+      },
+    ];
+    prependTextToChatUserMessage(messages, 'PRE ');
+    const parts = messages[0].content as Array<{ type: string; text?: string }>;
+    assert.equal(parts[1].text, 'PRE body');
+    assert.equal(parts.length, 2, 'no new part added when a text part exists');
+  });
+
+  it('unshifts a text part when the array has none', () => {
+    const messages = [
+      {
+        role: 'user',
+        content: [{ type: 'image_url', image_url: { url: 'data:...' } }],
+      },
+    ];
+    prependTextToChatUserMessage(messages, 'PRE');
+    const parts = messages[0].content as Array<{ type: string; text?: string }>;
+    assert.equal(parts.length, 2);
+    assert.deepEqual(parts[0], { type: 'text', text: 'PRE' });
+  });
+
+  it('targets the last user message and ignores later assistant turns', () => {
+    const messages = [
+      { role: 'user', content: 'first' },
+      { role: 'assistant', content: 'reply' },
+      { role: 'user', content: 'second' },
+    ];
+    prependTextToChatUserMessage(messages, 'X');
+    assert.equal(messages[0].content, 'first');
+    assert.equal(messages[2].content, 'Xsecond');
+  });
+
+  it('is a no-op for blank text or when no user message exists', () => {
+    const blank = [{ role: 'user', content: 'unchanged' }];
+    prependTextToChatUserMessage(blank, '   ');
+    assert.equal(blank[0].content, 'unchanged');
+
+    const noUser = [{ role: 'assistant', content: 'only' }];
+    prependTextToChatUserMessage(noUser, 'X');
+    assert.equal(noUser[0].content, 'only');
+  });
+});
+
+describe('insertMediaIntoChatUserMessage', () => {
+  const media = [{ type: 'image_url', image_url: { url: 'data:media' } }];
+
+  it('promotes a string body to an array with media ahead of the text', () => {
+    const messages = [{ role: 'user', content: 'describe this' }];
+    insertMediaIntoChatUserMessage(messages, media);
+    assert.deepEqual(messages[0].content, [
+      ...media,
+      { type: 'text', text: 'describe this' },
+    ]);
+  });
+
+  it('unshifts media in front of existing array parts', () => {
+    const messages = [
+      { role: 'user', content: [{ type: 'text', text: 'body' }] },
+    ];
+    insertMediaIntoChatUserMessage(messages, media);
+    const parts = messages[0].content as Array<{ type: string }>;
+    assert.equal(parts.length, 2);
+    assert.equal(parts[0].type, 'image_url');
+    assert.equal(parts[1].type, 'text');
+  });
+
+  it('is a no-op when no user message exists', () => {
+    const messages = [{ role: 'assistant', content: 'only' }];
+    insertMediaIntoChatUserMessage(messages, media);
+    assert.equal(messages[0].content, 'only');
   });
 });

--- a/src/test-kernel/agent/modelHandlers/OpenAIMessageUtils.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIMessageUtils.vitest.ts
@@ -4,7 +4,7 @@ import { describe, it } from 'vitest';
 
 // Local imports - agent
 import {
-  assertBatchedToolCalls,
+  checkBatchedToolCalls,
   insertMediaIntoChatUserMessage,
   normalizeOpenAIMessageContent,
   prependTextToChatUserMessage,
@@ -200,25 +200,25 @@ describe('normalizeOpenAIMessageContent', () => {
   });
 });
 
-describe('assertBatchedToolCalls', () => {
+describe('checkBatchedToolCalls', () => {
   it('throws on a call/result count mismatch', () => {
     assert.throws(
-      () => assertBatchedToolCalls(2, 1),
+      () => checkBatchedToolCalls(2, 1),
       /Batched tool calls mismatch: 2 calls vs 1 results/,
     );
   });
 
   it('returns false when there is nothing to send', () => {
-    assert.equal(assertBatchedToolCalls(0, 0), false);
+    assert.equal(checkBatchedToolCalls(0, 0), false);
   });
 
   it('returns true when counts match and are non-empty', () => {
-    assert.equal(assertBatchedToolCalls(3, 3), true);
+    assert.equal(checkBatchedToolCalls(3, 3), true);
   });
 
   it('reports the mismatch before the empty check', () => {
     // A zero call count with a non-zero result count is still a mismatch.
-    assert.throws(() => assertBatchedToolCalls(0, 2), /0 calls vs 2 results/);
+    assert.throws(() => checkBatchedToolCalls(0, 2), /0 calls vs 2 results/);
   });
 });
 
@@ -287,28 +287,38 @@ describe('insertMediaIntoChatUserMessage', () => {
   const media = [{ type: 'image_url', image_url: { url: 'data:media' } }];
 
   it('promotes a string body to an array with media ahead of the text', () => {
-    const messages = [{ role: 'user', content: 'describe this' }];
-    insertMediaIntoChatUserMessage(messages, media);
-    assert.deepEqual(messages[0].content, [
+    const message = { role: 'user', content: 'describe this' };
+    insertMediaIntoChatUserMessage(message, media);
+    assert.deepEqual(message.content, [
       ...media,
       { type: 'text', text: 'describe this' },
     ]);
   });
 
   it('unshifts media in front of existing array parts', () => {
-    const messages = [
-      { role: 'user', content: [{ type: 'text', text: 'body' }] },
-    ];
-    insertMediaIntoChatUserMessage(messages, media);
-    const parts = messages[0].content as Array<{ type: string }>;
+    const message = { role: 'user', content: [{ type: 'text', text: 'body' }] };
+    insertMediaIntoChatUserMessage(message, media);
+    const parts = message.content as Array<{ type: string }>;
     assert.equal(parts.length, 2);
     assert.equal(parts[0].type, 'image_url');
     assert.equal(parts[1].type, 'text');
   });
 
-  it('is a no-op when no user message exists', () => {
-    const messages = [{ role: 'assistant', content: 'only' }];
-    insertMediaIntoChatUserMessage(messages, media);
-    assert.equal(messages[0].content, 'only');
+  it('targets the captured message, not a later user turn', () => {
+    // Regression guard: media must land on the message the caller located and
+    // validated before the async formatting await, even if the conversation
+    // gained another user turn meanwhile.
+    const captured = { role: 'user', content: 'original' };
+    const conversation = [captured, { role: 'user', content: 'newer turn' }];
+    insertMediaIntoChatUserMessage(captured, media);
+    assert.ok(
+      Array.isArray(captured.content),
+      'media should land on the captured message',
+    );
+    assert.equal(
+      conversation[1].content,
+      'newer turn',
+      'a later user turn must be untouched',
+    );
   });
 });


### PR DESCRIPTION
OpenRouter extends ModelHandler directly rather than ModelHandlerOpenAI, so it
carried byte-identical copies of the chat-shaped user-message plumbing. Extract
the shared logic into openAIMessageUtils.ts (the existing generic MessageLike
home) as three helpers, keeping a single source of truth:

- assertBatchedToolCalls: the count-mismatch throw + empty early-return guard
- prependTextToChatUserMessage: prepend text to the last user message
- insertMediaIntoChatUserMessage: insert formatted media ahead of user content

Both handlers now delegate. Behavior is preserved: the batch guard keeps the
same message and check order; addMedia keeps its per-instance vision/user-message
pre-check to skip async media formatting. The Google handlers are intentionally
untouched — their batch guard uses a different message and an extra
attachments check, so folding them in would change behavior.

Adds unit coverage for all three helpers.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016D97suwS5AkAVSdjKm3Fnc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with preserved behavior and new unit tests; no auth or API contract changes beyond deduplication.
> 
> **Overview**
> Pulls duplicated **chat-shaped** message plumbing out of `ModelHandlerOpenAI` and `ModelHandlerOpenRouterNative` into `openAIMessageUtils.ts`, so OpenAI and OpenRouter share one implementation.
> 
> **`checkBatchedToolCalls`** centralizes the batched tool-use guard (count mismatch throw, empty early return). **`prependTextToChatUserMessage`** and **`insertMediaIntoChatUserMessage`** own in-place edits to the last user message (string vs parts array). Handlers still do vision checks and locate the user message before async media formatting; **`insertMediaIntoChatUserMessage`** takes that specific message so media does not jump to a newer user turn after the await.
> 
> Adds Vitest coverage for all three helpers. Google handlers are unchanged (different batch/attachment rules).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 127d9e08af5cbd29883289a5e006d0237de2bfd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->