### PR TITLE
Remove deprecated `prefills` agent field and reflection-flow plumbing

### DIFF
--- a/packages/extension/resources/templates/agentCreatorWorkflow.yaml
+++ b/packages/extension/resources/templates/agentCreatorWorkflow.yaml
@@ -26,9 +26,6 @@ prompts:
       - temperature: low (0.1) for editing/correction tasks, higher (0.5-0.8) for creative/generation tasks.
       - rounds: 1 for simple single-pass tasks, 2 for tasks that benefit from reflection.
     - userRequest is an array with exactly as many entries as rounds (1 or 2).
-    - Do NOT emit `prefills`. The field is deprecated --- reasoning models
-      ignore it at runtime, and other models do fine when the userRequest
-      spells out the expected `<documents>...</documents>` wrapper.
     - Fields with defaults can be omitted if the default value is acceptable.
     Respond only with the YAML wrapped in <yaml> tags.
 
@@ -120,7 +117,6 @@ prompts:
     IMPORTANT REMINDERS:
     - The documentTag in prompts must match the settings.documentTag.
     - userRequest must be an array with exactly as many entries as rounds (1 or 2).
-    - Do NOT emit `prefills` --- the field is deprecated and reasoning models ignore it.
     - Include {{ INSTRUCTION }} somewhere in the prompts so the user's instructions are passed through.
     - Write prompt text in LaTeX style (\begin{itemize}, \textbf{}, etc.), not markdown.
 

--- a/packages/extension/resources/templates/agentTemplate-workflowSingle.yaml
+++ b/packages/extension/resources/templates/agentTemplate-workflowSingle.yaml
@@ -10,10 +10,6 @@ settings:
   isRewrite: true
   documentTag: documents
   endTag: </documents>
-  # `prefills` is deprecated and almost never needed. Reasoning-capable
-  # models ignore it at runtime, and other models do fine when the
-  # userRequest spells out the expected `<documents>...</documents>`
-  # wrapper. Omit it.
 
 # --- Agent Prompts ---
 prompts:

--- a/packages/extension/resources/tool_use_agents/creator.yaml
+++ b/packages/extension/resources/tool_use_agents/creator.yaml
@@ -133,8 +133,7 @@ prompts:
     - Keep prompts focused. Write precisely what the agent needs for its
       specific purpose — do not pad with boilerplate.
     - For workflow agents, `userRequest` must have the same number of
-      entries as `rounds`. Do NOT emit `prefills` --- the field is
-      deprecated and ignored by reasoning models.
+      entries as `rounds`.
     - For tool-use agents, `userRequest` must be a single string that
       contains {% raw %}`{{ INSTRUCTION }}`{% endraw %}.
     - Agents can inherit from existing agents via `inherits: parent_name`.

--- a/reference-agents/criticize.yaml
+++ b/reference-agents/criticize.yaml
@@ -6,9 +6,6 @@ settings:
   documentTag: documents
   endTag: </documents>
   outputExt: tex
-  prefills:
-    - <scratchpad>
-    - <scratchpad>
 
 prompts:
   systemPrompt: |

--- a/reference-agents/devise.yaml
+++ b/reference-agents/devise.yaml
@@ -6,9 +6,6 @@ settings:
   documentTag: documents
   endTag: </documents>
   outputExt: tex
-  prefills:
-    - <scratchpad>
-    - <scratchpad>
 
 prompts:
   systemPrompt: |

--- a/reference-agents/elevate.yaml
+++ b/reference-agents/elevate.yaml
@@ -6,9 +6,6 @@ settings:
   documentTag: documents
   endTag: </documents>
   outputExt: tex
-  prefills:
-    - <scratchpad>
-    - <scratchpad>
 
 prompts:
   systemPrompt: |

--- a/reference-agents/enhance.yaml
+++ b/reference-agents/enhance.yaml
@@ -7,9 +7,6 @@ settings:
   documentTag: documents
   endTag: </documents>
   outputExt: tex
-  prefills:
-    - <scratchpad>
-    - <scratchpad>
 
 prompts:
   systemPrompt: |

--- a/reference-agents/humanize.yaml
+++ b/reference-agents/humanize.yaml
@@ -6,9 +6,6 @@ settings:
   documentTag: documents
   endTag: </documents>
   outputExt: tex
-  prefills:
-    - <scratchpad>
-    - <scratchpad>
 
 prompts:
   systemPrompt: |

--- a/reference-agents/logic.yaml
+++ b/reference-agents/logic.yaml
@@ -6,9 +6,6 @@ settings:
   documentTag: documents
   endTag: </documents>
   outputExt: tex
-  prefills:
-    - <scratchpad>
-    - <scratchpad>
 
 prompts:
   systemPrompt: |

--- a/reference-agents/notation.yaml
+++ b/reference-agents/notation.yaml
@@ -6,9 +6,6 @@ settings:
   documentTag: documents
   endTag: </documents>
   outputExt: tex
-  prefills:
-    - <scratchpad>
-    - <scratchpad>
 
 prompts:
   systemPrompt: |

--- a/reference-agents/verifyFix.yaml
+++ b/reference-agents/verifyFix.yaml
@@ -7,10 +7,6 @@ settings:
   documentTag: documents
   endTag: </documents>
   outputExt: tex
-  prefills:
-    - <scratchpad>
-    - <scratchpad>
-    - <scratchpad>
 
 prompts:
   systemPrompt: |

--- a/src/agent/core/definition/AgentDataclass.ts
+++ b/src/agent/core/definition/AgentDataclass.ts
@@ -44,7 +44,6 @@ export const AgentWorkflowSettingSchema = AgentSettingBaseSchema.extend({
     .prefault(AgentCategory.Workflow),
   isRewrite: z.boolean().prefault(true),
   rounds: z.int().positive().prefault(2),
-  prefills: z.array(z.string()).prefault([]),
 });
 
 export const AgentToolUseSettingSchema = AgentSettingBaseSchema.extend({
@@ -58,7 +57,11 @@ function stripLegacySettingFields(input: unknown): unknown {
   if (typeof input !== 'object' || input === null || Array.isArray(input)) {
     return input;
   }
-  const { outputExt: _outputExt, ...rest } = input as Record<string, unknown>;
+  const {
+    outputExt: _outputExt,
+    prefills: _prefills,
+    ...rest
+  } = input as Record<string, unknown>;
   return rest;
 }
 
@@ -136,7 +139,6 @@ const RawAgentSettingInputSchema = z.strictObject({
   internal: z.boolean().optional(),
   isRewrite: z.boolean().optional(),
   rounds: z.int().positive().optional(),
-  prefills: z.array(z.string()).optional(),
 });
 
 /**

--- a/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
@@ -18,7 +18,6 @@ import {
 
 const RoundContextSchema = z.object({
   messages: z.array(ProviderMessageSchema),
-  prefill: z.string(),
   stateRoundSnapshot: ConversationRoundStateSnapshotSchema,
 });
 

--- a/src/agent/implementations/flows/reflection/nodes/PrepareContextNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/PrepareContextNode.ts
@@ -62,16 +62,6 @@ export class PrepareContextNode<C = unknown> extends Node<
       );
     }
 
-    // Reasoning models produce their own preamble through extended thinking,
-    // so any configured prefill would force an unnecessary surface-level
-    // continuation. Skip it for those models regardless of YAML configuration.
-    let prefill = '';
-    if (modelHandler.capabilities.supportsReasoning) {
-      logger.debug('Reasoning-capable model detected; skipping prefill');
-    } else {
-      prefill = await promptBuilder.buildPrefill(currentRound);
-    }
-
     logger.debug('Prepared round context', {
       data: {
         round: isFirstRound ? 'first' : currentRound,
@@ -81,7 +71,6 @@ export class PrepareContextNode<C = unknown> extends Node<
 
     return {
       messages,
-      prefill,
       stateRoundSnapshot: stateRound,
     };
   }

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -73,17 +73,17 @@ export class ResponseCycleNode<C = unknown> extends Node<
     const { shared } = prepRes;
     const context = shared.context!; // Validated in prep()
 
-    const [prefillEndsTurn, initializedMessages] =
+    const [outputAlreadyComplete, initializedMessages] =
       await this.services.modelHandler.initializeOutputAndPrefill(
         this.services.config,
         this.services.setting,
         context.messages,
         prepRes.workspace,
         prepRes.outputLocation,
-        context.prefill,
+        '',
       );
 
-    if (prefillEndsTurn) {
+    if (outputAlreadyComplete) {
       return { outcome: 'completed', endTurn: true };
     }
 

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -132,7 +132,6 @@ export async function runReflectionFlow<C = unknown>(
 
   const promptBuilder = new PromptBuilder(
     prompt,
-    setting,
     userVarChannels.transient,
     logger,
   );

--- a/src/test-kernel/agent/ReflectionOutputLocation.vitest.ts
+++ b/src/test-kernel/agent/ReflectionOutputLocation.vitest.ts
@@ -23,7 +23,6 @@ function reflectionShared(): ReflectionFlowShared {
     workspaceSnapshot: AgentWorkspaceState.emptySnapshot(),
     context: {
       messages: [],
-      prefill: '',
       stateRoundSnapshot: ConversationRoundStateSnapshotSchema.parse({
         roundIndex: 1,
       }),

--- a/src/test-kernel/agent/ResponseCycleCancellation.vitest.ts
+++ b/src/test-kernel/agent/ResponseCycleCancellation.vitest.ts
@@ -50,7 +50,6 @@ function reflectionShared(): ReflectionFlowShared {
     workspaceSnapshot: AgentWorkspaceState.emptySnapshot(),
     context: {
       messages: [],
-      prefill: '',
       stateRoundSnapshot: ConversationRoundStateSnapshotSchema.parse({
         roundIndex: 0,
       }),

--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -46,7 +46,6 @@ function createWorkflowAgentSetting(
     tools: [],
     isRewrite: true,
     rounds: 1,
-    prefills: [],
     ...overrides,
   };
 }

--- a/src/test-kernel/agent/utils/promptBuilder.vitest.ts
+++ b/src/test-kernel/agent/utils/promptBuilder.vitest.ts
@@ -2,33 +2,11 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'vitest';
 
-// Standard library imports
-
-// Local imports - prompt utilities
-import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 // Type imports
-import type {
-  AgentPrompt,
-  AgentWorkflowSetting,
-} from '@agent/core/definition/AgentDataclass';
+import type { AgentPrompt } from '@agent/core/definition/AgentDataclass';
 import { PromptBuilder } from '@utils/prompt';
 
 describe('PromptBuilder', () => {
-  const baseSetting: AgentWorkflowSetting = {
-    agentCategory: AgentCategory.Workflow,
-    documentTag: 'documents',
-    endTag: '</documents>',
-    temperature: 1,
-    isRewrite: true,
-    rounds: 2,
-    prefills: [],
-    defaultOutputFiles: [],
-    requiredFiles: {},
-    requiredFilesInternal: {},
-    filePatternsContain: [],
-    tools: [],
-  };
-
   it('uses array-based userRequest entries for reflections', async () => {
     const prompt: AgentPrompt = {
       systemPrompt: 'system',
@@ -36,7 +14,7 @@ describe('PromptBuilder', () => {
       userRequest: ['initial {{ value }}', 'reflect {{ value }}'],
     } as AgentPrompt;
 
-    const builder = new PromptBuilder(prompt, baseSetting, { value: 'test' });
+    const builder = new PromptBuilder(prompt, { value: 'test' });
     const initial = await builder.buildInitialPrompts();
     assert.equal(initial.userRequest, 'initial test');
 
@@ -54,7 +32,7 @@ describe('PromptBuilder', () => {
       userRequest: 'initial only',
     } as AgentPrompt;
 
-    const builder = new PromptBuilder(prompt, baseSetting, {});
+    const builder = new PromptBuilder(prompt, {});
     const initial = await builder.buildInitialPrompts();
     assert.equal(initial.userRequest, 'initial only');
 

--- a/src/test-kernel/agent/utils/userVars.vitest.ts
+++ b/src/test-kernel/agent/utils/userVars.vitest.ts
@@ -37,7 +37,6 @@ const baseSetting: AgentSetting = {
   temperature: 1,
   isRewrite: true,
   rounds: 1,
-  prefills: [],
   endTag: '</documents>',
   requiredFiles: {},
   requiredFilesInternal: {},

--- a/src/utils/prompt/PromptBuilder.ts
+++ b/src/utils/prompt/PromptBuilder.ts
@@ -1,17 +1,12 @@
 // Local imports - agent
 import type { AgentTrace } from '@agent/trace/AgentTrace';
-import type {
-  AgentPrompt,
-  AgentWorkflowSetting,
-} from '@agent/core/definition/AgentDataclass';
+import type { AgentPrompt } from '@agent/core/definition/AgentDataclass';
 import { ensureArray } from '@utils/core';
 import { loadTexraRules } from '@utils/files/rulesUtils';
 import { buildWorkspaceInfoBlock } from '@utils/system/workspaceInfo';
 
 // Local imports - utilities
 import { renderPrompt } from './promptUtils';
-
-type PromptBuilderSetting = Pick<AgentWorkflowSetting, 'prefills'>;
 
 /** Instructions appended to tool-use agent prompts */
 const TOOL_USE_INSTRUCTIONS = `<tool_use_instructions>
@@ -117,16 +112,14 @@ export async function getSystemPromptWithRules(
  *
  * @example
  * ```ts
- * const builder = new PromptBuilder(prompt, setting, vars, logger);
+ * const builder = new PromptBuilder(prompt, vars, logger);
  * const initial = await builder.buildInitialPrompts();
  * const firstRoundRequest = await builder.buildUserRequest(1);
- * const prefill = await builder.buildPrefill(0);
  * ```
  */
 export class PromptBuilder {
   constructor(
     private readonly agentPrompt: AgentPrompt,
-    private readonly agentSetting: PromptBuilderSetting,
     private readonly userVars: Record<string, unknown>,
     private readonly logger?: AgentTrace,
   ) {}
@@ -167,30 +160,6 @@ export class PromptBuilder {
     }
 
     return renderPrompt(template, this.userVars);
-  }
-
-  /**
-   * Return the prefill value that should seed the assistant response.
-   *
-   * @param currRound Zero-based conversation round index
-   * @remarks Reuses the first configured prefill when subsequent rounds omit a value.
-   */
-  public async buildPrefill(currRound: number): Promise<string> {
-    const prefills = this.agentSetting.prefills;
-    if (!prefills || prefills.length === 0) {
-      return '';
-    }
-
-    const normalizedRound = Math.max(0, currRound);
-    if (normalizedRound < prefills.length) {
-      return prefills[normalizedRound] ?? '';
-    }
-
-    this.logger?.debug(
-      `No prefill configured for round ${currRound}. Reusing first prefill.`,
-    );
-
-    return prefills[0] ?? '';
   }
 
   private getRoundTemplate(currRound: number): string | undefined {
@@ -235,12 +204,7 @@ export async function buildInitialToolUsePrompts(
     nestedDelegationBlocked?: boolean;
   },
 ): Promise<InitialPrompts & { instructionSuffix: string }> {
-  const builder = new PromptBuilder(
-    agentPrompt,
-    { prefills: [] },
-    userVars,
-    logger,
-  );
+  const builder = new PromptBuilder(agentPrompt, userVars, logger);
   const initial = await builder.buildInitialPrompts();
 
   const memoryEnabled = options?.resolvedToolNames?.includes('memory') ?? false;


### PR DESCRIPTION
## Summary
- Removes the deprecated `prefills` agent field (model-weakness scaffolding already declared dead in the agent-creator prompts) and its reflection-flow plumbing.
- Schema now tolerates `prefills` in old/custom YAMLs via a back-compat strip (field is silently ignored, not an error).
- Deletes `PromptBuilder.buildPrefill`, the `ReflectionFlowState.prefill` slot, and the prefill computation in `PrepareContextNode`; `ResponseCycleNode` now passes a literal empty string to `ModelHandler.initializeOutputAndPrefill`.
- Strips `prefills:` from the 8 reference-agent YAMLs and removes stale "Do NOT emit prefills" guidance from the agent-creator prompts/templates.
- Leaves the `ModelHandler` base continuation/re-prefill machinery (max-tokens recovery) untouched, per the issue's scope guard.

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` (full vitest suite: 578 files / 4511 tests passed)
- [x] `grep -rn "prefills"` has no hits outside the back-compat strip, an unrelated test description, a CLI false positive, and `docs/`

Closes #7093.

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core workflow agent settings and reflection round initialization; legacy YAML is tolerated but agents that still depended on prefills for non-reasoning models will behave differently.
> 
> **Overview**
> Removes the deprecated **`prefills`** workflow setting and the reflection-flow code that applied per-round assistant continuations (e.g. `<scratchpad>` seeds). Workflow rounds no longer read YAML prefills or call **`PromptBuilder.buildPrefill`**; **`ResponseCycleNode`** always passes an empty string into **`initializeOutputAndPrefill`** (the model handler’s continuation/max-tokens path is unchanged).
> 
> **`AgentDataclass`** drops `prefills` from the workflow schema and strips it in **`stripLegacySettingFields`** so old YAML still loads without error. Eight reference agents lose `prefills:` blocks; agent-creator templates and **`creator.yaml`** no longer tell authors to avoid emitting prefills. Tests and **`ReflectionFlowState`** are updated to match the slimmer round context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e33a78795bdca84c70ee34114766436d9ebbc5ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->