### PR TITLE
fix(cli): persist streamLogs for headless CLI runs

### DIFF
--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -1,6 +1,10 @@
 import { SHUTDOWN_PHASE } from '@platform/interfaces/lifecycle';
 import { tryPlatform } from '@platform/platform';
-import { StreamSnapshotStore } from '@transcript';
+import {
+  flushPendingRunTraces,
+  getDefaultStreamLogStore,
+  StreamSnapshotStore,
+} from '@transcript';
 import { writeTerminalStatus } from '@agent/storage';
 import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
@@ -210,6 +214,20 @@ export async function executeCliRequest(
       ],
     });
 
+  // Headless runs append to StreamLogStore the same as the interactive TUI
+  // (via createRunTrace's transcript recorder), but StreamLogStore.save()/
+  // flush() silently no-op until .load() has run once — without this, every
+  // headless run's streamLogs are appended in memory and then lost entirely
+  // when the process exits. Mirrors runChatTui.tsx's best-effort load. Done
+  // last (right before the run starts) so it can't delay the synchronous
+  // shutdown-hook registration above.
+  const streamLogStore = getDefaultStreamLogStore();
+  try {
+    await streamLogStore.load();
+  } catch {
+    // Persistence stays disabled; the run still executes in-memory as before.
+  }
+
   let result: ExecuteAgentResult;
   try {
     result = await (options.wrap ? options.wrap(invoke) : invoke());
@@ -228,7 +246,8 @@ export async function executeCliRequest(
     detachResultToast();
     uninstallApprovalHandlers();
     try {
-      await snapshotStore.flush();
+      flushPendingRunTraces();
+      await Promise.all([streamLogStore.flush(), snapshotStore.flush()]);
     } finally {
       await runtimeHost.close();
     }

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -134,6 +134,7 @@ describe('executeCliRequest', () => {
   beforeEach(stubRunExecutionDeps);
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await Promise.all(
       tempDirs
         .splice(0)
@@ -292,6 +293,53 @@ describe('executeCliRequest', () => {
       'stream-1' as StreamTabId,
     );
     expect(snapshot.todos).toEqual([todo]);
+  });
+
+  it('loads the stream log store before the run and flushes it after, in order', async () => {
+    const { executeCliRequest } = await import('@cli/runtime/runExecution');
+    const { getDefaultStreamLogStore } = await import('@transcript');
+    const request = baseRequest();
+    const store = getDefaultStreamLogStore();
+    const callOrder: string[] = [];
+    vi.spyOn(store, 'load').mockImplementation(async () => {
+      callOrder.push('load');
+    });
+    vi.spyOn(store, 'flush').mockImplementation(async () => {
+      callOrder.push('flush');
+    });
+    mocks.runAgent.mockImplementationOnce(async () => {
+      callOrder.push('runAgent');
+      return {
+        category: 'toolUse',
+        executionId: 'exec-1',
+        status: 'completed',
+        streamId: 'stream-1',
+      };
+    });
+
+    await executeCliRequest(request, cliContext());
+
+    // The bug this test guards: StreamLogStore.save()/flush() silently no-op
+    // until .load() has run once, so headless runs lost their whole
+    // streamLogs timeline. `load` must precede the run, `flush` must follow it.
+    expect(callOrder).toEqual(['load', 'runAgent', 'flush']);
+  });
+
+  it('flushes the stream log store even when the run throws', async () => {
+    const { executeCliRequest } = await import('@cli/runtime/runExecution');
+    const { getDefaultStreamLogStore } = await import('@transcript');
+    const request = baseRequest();
+    const store = getDefaultStreamLogStore();
+    const loadSpy = vi.spyOn(store, 'load').mockResolvedValue(undefined);
+    const flushSpy = vi.spyOn(store, 'flush').mockResolvedValue(undefined);
+    mocks.runAgent.mockRejectedValueOnce(new Error('boom'));
+
+    await expect(
+      executeCliRequest(request, cliContext()),
+    ).rejects.toThrow('boom');
+
+    expect(loadSpy).toHaveBeenCalledTimes(1);
+    expect(flushSpy).toHaveBeenCalledTimes(1);
   });
 
   it('closes the runtime host when sidecar flush fails', async () => {

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -334,9 +334,9 @@ describe('executeCliRequest', () => {
     const flushSpy = vi.spyOn(store, 'flush').mockResolvedValue(undefined);
     mocks.runAgent.mockRejectedValueOnce(new Error('boom'));
 
-    await expect(
-      executeCliRequest(request, cliContext()),
-    ).rejects.toThrow('boom');
+    await expect(executeCliRequest(request, cliContext())).rejects.toThrow(
+      'boom',
+    );
 
     expect(loadSpy).toHaveBeenCalledTimes(1);
     expect(flushSpy).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
- Headless CLI runs (`texra run`, `agents run`, `multi-agent run`) never called `StreamLogStore.load()`, so `save()`/`flush()` silently no-op for the whole run — every headless execution's `streamLogs` timeline (thinking blocks, tool calls with I/O, round structure) was appended in memory and then lost entirely on process exit.
- `executeCliRequest` now loads the store before the run and flushes it (alongside `flushPendingRunTraces()` + the snapshot store) on exit, mirroring the interactive TUI path already used in `runChatTui.tsx`.
- The `.load()` call is placed immediately before `invoke()` (not earlier) so it can't delay the synchronous shutdown-hook registration a few lines above — an earlier draft placed it right after runtime-host setup and broke the existing "marks owned executions interrupted during platform shutdown" test.

Fixes #7057. This is the prerequisite for #7058 (faithful trace-viewer export), which needs a real `streamLogs` timeline to render for headless runs.

## Test plan
- [x] Extended `src/test-kernel/cli/RunExecution.vitest.mts` with two tests: load happens before the run and flush happens after (in order), and flush still happens when the run throws.
- [x] Full existing `RunExecution.vitest.mts` suite passes (17/17).
- [x] `src/test-kernel/cli` + `src/test-kernel/transcript` suites pass (128 files, 1574 tests).
- [x] `CI=true npm run typecheck` clean across all 5 workspace projects.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to headless CLI teardown/persistence; mirrors an existing TUI pattern with graceful load failure handling.
> 
> **Overview**
> Headless CLI execution (`texra run`, `agents run`, etc.) was dropping the full **streamLogs** timeline on exit because **`StreamLogStore.save()`/`flush()` no-op until `load()` has run once** — the interactive TUI already loads the store; headless did not.
> 
> **`executeCliRequest`** now **best-effort `load()`s** the default stream log store **immediately before** `invoke()` (after shutdown-hook registration), and on teardown **`flushPendingRunTraces()`** plus **`streamLogStore.flush()`** run **in parallel** with the existing snapshot flush. Failed loads keep in-memory-only behavior.
> 
> Tests assert **load → run → flush** ordering and that **flush still runs when the run throws**; **`vi.restoreAllMocks()`** was added in **`afterEach`** so store spies do not leak across cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c77b5c7a15095fe17e84ddc285d925a6c70a9e96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->