### PR TITLE
Move TeXRA view container to secondary sidebar without bumping engines

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1401,7 +1401,7 @@
       }
     ],
     "viewsContainers": {
-      "activitybar": [
+      "secondarySidebar": [
         {
           "id": "texra",
           "title": "TeXRA",

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -1753,7 +1753,7 @@
         ]
       },
       "viewsContainers": {
-        "activitybar": [
+        "secondarySidebar": [
           {
             "icon": "resources/logo-128x128.svg",
             "id": "texra",


### PR DESCRIPTION
## Summary

Moves the TeXRA view container contribution from `viewsContainers.activitybar` to `viewsContainers.secondarySidebar` while keeping the VS Code engine range unchanged.

This update also syncs `scripts/extension-package-invariants.snapshot.json` so the package invariant CI check matches the manifest.

## Issue acceptance gates

Existing PR #7134 does not reference a tracking issue in its body. This update addresses the failing CI gate by making `npm run check:extension-package-invariants` pass again.

## Single source of truth

`packages/extension/package.json` remains the manifest source of truth; `scripts/extension-package-invariants.snapshot.json` is the generated invariant snapshot used by CI to detect accidental package drift.

## Duplication and abstraction budget

No abstraction was added. The snapshot duplication is intentional CI guard data and now matches the manifest.

## Host impact

Extension: TeXRA contributes its view container under the secondary sidebar manifest key.

Desktop: no impact.

CLI: no impact.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm run check:extension-package-invariants`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; pre-existing warnings on this older branch)
- `npm test`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only UI placement change with no extension logic touched; main risk is users on hosts without `secondarySidebar` seeing a different default location than intended.
> 
> **Overview**
> Moves the TeXRA **view container** from the primary activity bar (`viewsContainers.activitybar`) to the **secondary sidebar** (`viewsContainers.secondarySidebar`), so the main webview opens on the right alongside other agent-style panels on VS Code 1.106+.
> 
> **`engines.vscode` stays at `^1.105.0`** on purpose: older or forked hosts that do not understand `secondarySidebar` are expected to ignore the new key and still surface the view (e.g. under Explorer) instead of blocking installs via a higher engine gate.
> 
> The extension manifest invariant snapshot is updated to match so CI keeps tracking the contributed sidebar location.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e1239b2458f35c207782bd09248514db0049386. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->