### PR TITLE
refactor(storage): collapse storage layout aliases

### DIFF
--- a/packages/cli/src/runtime/memory.ts
+++ b/packages/cli/src/runtime/memory.ts
@@ -81,7 +81,7 @@ export function cliMemoryStoragePathFromInput(inputPath: string): string {
       `Invalid memory path "${trimmed}". Memory paths must be relative to ${MEMORY_DISPLAY_ROOT}.`,
     );
   }
-  if (trimmed.startsWith('memories/')) {
+  if (trimmed.startsWith(`${resolveMemoryStoragePath()}/`)) {
     return resolveMemoryStoragePath(trimmed);
   }
   return displayToStoragePath(`${MEMORY_DISPLAY_ROOT}/${trimmed}`);

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -83,7 +83,6 @@ import {
 } from '@shared/settingsView/handlers/agentSelectionHandlers';
 import { buildChatGptAuthStatusMessage } from '@shared/settingsView/handlers/chatGptHandlers';
 import type { ExternalToolCheckResult } from '@tools/toolAvailability';
-import { MEMORY_STORAGE_ROOT } from '@tools/memory/constants';
 import { StorageFS } from '@utils/files';
 import {
   applyGitAuthorSettings,
@@ -476,8 +475,8 @@ export function createDesktopSettingsIpc(
   }
 
   async function openMemoryFolder(): Promise<void> {
-    await StorageFS.ensureDir(MEMORY_STORAGE_ROOT);
-    await options.openPath?.(StorageFS.fullPath(MEMORY_STORAGE_ROOT));
+    await StorageFS.ensureDir(resolveMemoryStoragePath());
+    await options.openPath?.(StorageFS.fullPath(resolveMemoryStoragePath()));
   }
 
   async function postHistoryData(): Promise<void> {

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -8,6 +8,7 @@ import dotenv from 'dotenv';
 // Local imports - core
 import { initPlatform, platform } from '@platform/platform';
 import { createLifecycleHost } from '@platform/defaults/lifecycleHost';
+import { RUNS_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import {
   SHUTDOWN_PHASE,
   type LifecycleHost,
@@ -115,7 +116,6 @@ import { setLeanLanguageServices } from '@tools/lean/leanLanguageServices';
 import { setOpenBuildDisplay } from '@tools/approval/latexPreview';
 import { StorageFS } from '@utils/files';
 import { getConfig } from '@utils/config';
-import { TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
 
 // Local imports - components
 import { ProgressViewProvider } from './progressView/ProgressViewProvider';
@@ -288,7 +288,7 @@ export async function activate(context: vscode.ExtensionContext) {
     bus.emit('extensionDeactivating', undefined),
   );
   lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => disposeDiffRefresh());
-  await StorageFS.ensureDir(TASK_RUNS_DIR);
+  await StorageFS.ensureDir(RUNS_STORAGE_DIR);
   FileLister.initialize(context);
   initializeServerSideKeyAccess(
     {

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -80,7 +80,6 @@ import {
   refreshToolAvailability,
   refreshDisabledToolCache,
 } from '@tools/toolAvailability';
-import { MEMORY_STORAGE_ROOT } from '@tools/memory/constants';
 import { StorageFS } from '@utils/files';
 import { hasExtension } from '@utils/core/pathCore';
 import {
@@ -780,8 +779,8 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
   private async handleOpenMemoryFolder(): Promise<void> {
     try {
-      await StorageFS.ensureDir(MEMORY_STORAGE_ROOT);
-      const absolutePath = StorageFS.fullPath(MEMORY_STORAGE_ROOT);
+      await StorageFS.ensureDir(resolveMemoryStoragePath());
+      const absolutePath = StorageFS.fullPath(resolveMemoryStoragePath());
       await safeExecuteCommand(
         'revealFileInOS',
         [vscode.Uri.file(absolutePath)],

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -6,11 +6,10 @@
  * and generic read/write for arbitrary keys.
  */
 
-import * as path from 'node:path';
-
 import { LRUCache } from 'lru-cache';
 import { z } from 'zod';
 
+import { resolveRunStoragePath } from '@platform/defaults/workspaceStorage';
 import {
   type AgentConfig,
   AgentConfigSchema,
@@ -29,7 +28,6 @@ import {
   OutputFileSummarySchema,
 } from '@shared/schemas/output';
 import { byString, filterNotNull } from '@utils/core';
-import { TASK_RUNS_DIR } from '@utils/files';
 
 // ============================================================================
 // Key constants (implementation detail — not exported)
@@ -173,7 +171,7 @@ export interface ExecutionKVStore {
  */
 class StorageFSKVStore extends KVStore implements ExecutionKVStore {
   constructor(private readonly executionId: ExecutionId) {
-    super(path.join(TASK_RUNS_DIR, executionId));
+    super(resolveRunStoragePath(executionId));
   }
 
   async clear(): Promise<void> {

--- a/src/agent/storage/executionListing.ts
+++ b/src/agent/storage/executionListing.ts
@@ -11,6 +11,7 @@
 
 import pMap from 'p-map';
 
+import { RUNS_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import { platform } from '@platform/platform';
 import {
   type AgentConfig,
@@ -20,14 +21,14 @@ import { isFileNotFoundError } from '@common/errors';
 import { toErrorMessage } from '@common/errors/errorMessage';
 import * as logger from '@logger/logUtils';
 import type { ExecutionId } from '@shared/schemas';
-import { StorageFS, WorkspaceFS, TASK_RUNS_DIR } from '@utils/files';
+import { StorageFS, WorkspaceFS } from '@utils/files';
 import { filterNotNull, toNewestFirstByTimestamp } from '@utils/core';
 import { isDirectory } from '@utils/files/fsEntryType';
 
 import { type ExecutionMeta, getExecutionStore } from './ExecutionKVStore';
 
 const CHANNEL = 'ExecutionListing';
-const INDEX_PATH = `${TASK_RUNS_DIR}/index.json`;
+const INDEX_PATH = `${RUNS_STORAGE_DIR}/index.json`;
 const LEGACY_HISTORY_KEY = 'texra.agentHistory';
 const EXECUTION_ID_PATTERN = /^[0-9a-f][-0-9a-f]*$/i;
 const EXECUTION_STORAGE_CONCURRENCY = 32;
@@ -117,7 +118,7 @@ export async function listExecutions(): Promise<ExecutionListingEntry[]> {
     migrated = true;
   }
 
-  const entries = await readDirOrEmpty(TASK_RUNS_DIR);
+  const entries = await readDirOrEmpty(RUNS_STORAGE_DIR);
   const executionDirs = listExecutionDirs(entries);
 
   // Read meta + config with bounded concurrency. Large histories should not
@@ -176,7 +177,7 @@ export async function listExecutions(): Promise<ExecutionListingEntry[]> {
 export async function deleteExecution(
   executionId: ExecutionId,
 ): Promise<boolean> {
-  const existed = await StorageFS.exists(`${TASK_RUNS_DIR}/${executionId}`);
+  const existed = await StorageFS.exists(`${RUNS_STORAGE_DIR}/${executionId}`);
   if (!existed) return false;
   try {
     await getExecutionStore(executionId).clear();
@@ -196,7 +197,7 @@ export async function deleteExecution(
 export async function deleteAllExecutions(
   exclude?: ReadonlySet<string>,
 ): Promise<ExecutionId[]> {
-  const entries = await readDirOrEmpty(TASK_RUNS_DIR);
+  const entries = await readDirOrEmpty(RUNS_STORAGE_DIR);
   const executionDirs = listExecutionDirs(entries, exclude);
 
   try {

--- a/src/agent/utils/debugMessageSaver.ts
+++ b/src/agent/utils/debugMessageSaver.ts
@@ -1,10 +1,11 @@
 import * as path from 'node:path';
 
+import { RUNS_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import type { AgentTrace } from '@agent/trace';
 import type { ExecutionId } from '@shared/schemas';
 import { WorkspaceFS, StorageFS } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
-import { ensureRunDir, TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
+import { ensureRunDir } from '@utils/files/taskRunStorage';
 
 export interface DebugContext {
   logger: AgentTrace;
@@ -57,7 +58,7 @@ export async function maybeSaveDebugObject({
   try {
     // Use appropriate file system based on whether we have an execution context
     const filePath = executionId
-      ? path.join(TASK_RUNS_DIR, executionId, debugFileName)
+      ? path.join(RUNS_STORAGE_DIR, executionId, debugFileName)
       : debugFileName;
     const fs = executionId ? StorageFS : WorkspaceFS;
 

--- a/src/platform/defaults/workspaceStorage.ts
+++ b/src/platform/defaults/workspaceStorage.ts
@@ -6,7 +6,7 @@ import { basename, isAbsolute, join, normalize, relative } from 'node:path';
 // Local imports - platform
 import type { StorageProvider } from '../interfaces/storage';
 
-export const STORAGE_LAYOUT = {
+const STORAGE_LAYOUT = {
   global: 'global-storage',
   workspace: 'workspace-storage',
   memory: 'memories',
@@ -65,7 +65,9 @@ export function resolveWorkspaceStoragePath(
   );
 }
 
-export function resolveMemoryStoragePath(storagePath: string): string {
+export function resolveMemoryStoragePath(
+  storagePath: string = MEMORY_STORAGE_DIR,
+): string {
   const normalized = normalize(storagePath);
   const memoryRelative = relative(MEMORY_STORAGE_DIR, normalized);
   if (memoryRelative.startsWith('..') || isAbsolute(memoryRelative)) {

--- a/src/test-kernel/agent/utils/debugMessageSaver.vitest.ts
+++ b/src/test-kernel/agent/utils/debugMessageSaver.vitest.ts
@@ -8,10 +8,10 @@ import { describe, it, beforeAll, beforeEach, afterEach } from 'vitest';
 // Local imports - agent
 // Internal imports
 import { createFakePlatform } from '@test/support/FakePlatform';
+import { RUNS_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
 import type { ExecutionId } from '@shared/schemas';
 import { WorkspaceFS, StorageFS } from '@utils/files';
-import { TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
 
 beforeAll(async () => {
   // getConfig reads through the platform config provider; enable the
@@ -106,8 +106,8 @@ describe('maybeSaveDebugObject', () => {
       },
     });
 
-    const expectedDir = path.join(TASK_RUNS_DIR, executionId);
-    assert.deepEqual(ensured, [TASK_RUNS_DIR, expectedDir]);
+    const expectedDir = path.join(RUNS_STORAGE_DIR, executionId);
+    assert.deepEqual(ensured, [RUNS_STORAGE_DIR, expectedDir]);
 
     assert.equal(storageWrites.length, 1);
     const expectedRelativePath = path.join(expectedDir, 'response.json');

--- a/src/test-kernel/settings/MemoryFileSystemConcurrency.vitest.ts
+++ b/src/test-kernel/settings/MemoryFileSystemConcurrency.vitest.ts
@@ -8,10 +8,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Platform imports
 import { FileType, type FileStat } from '@platform/interfaces/filesystem';
+import { MEMORY_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 
 // Local imports - settings memory
 import { walkMemoryDirectory } from '@tools/memory/memoryFileSystem';
-import { MEMORY_STORAGE_ROOT } from '@tools/memory/constants';
 import { StorageFS } from '@utils/files';
 import { delay } from '@utils/core/async';
 
@@ -57,15 +57,15 @@ describe('memory filesystem listing', () => {
 
   it('bounds metadata reads while walking large memory directories', async () => {
     vi.spyOn(StorageFS, 'readDir').mockImplementation(async (target) => {
-      if (target === MEMORY_STORAGE_ROOT) {
+      if (target === MEMORY_STORAGE_DIR) {
         return [
           ['alpha', FileType.Directory],
           ['beta', FileType.Directory],
         ];
       }
       if (
-        target === path.join(MEMORY_STORAGE_ROOT, 'alpha') ||
-        target === path.join(MEMORY_STORAGE_ROOT, 'beta')
+        target === path.join(MEMORY_STORAGE_DIR, 'alpha') ||
+        target === path.join(MEMORY_STORAGE_DIR, 'beta')
       ) {
         return memoryFiles();
       }
@@ -90,7 +90,7 @@ describe('memory filesystem listing', () => {
       readStreamFromText(TEST_FRONTMATTER),
     );
 
-    const items = await walkMemoryDirectory(MEMORY_STORAGE_ROOT);
+    const items = await walkMemoryDirectory(MEMORY_STORAGE_DIR);
 
     expect(items).toHaveLength(FILE_COUNT_PER_DIRECTORY * 2);
     expect(maxActiveMetadataReads).toBeGreaterThan(1);

--- a/src/tools/inquiry/externalInquiryStorage.ts
+++ b/src/tools/inquiry/externalInquiryStorage.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import { Mutex } from 'async-mutex';
 import { z } from 'zod';
 
+import { RUNS_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import { createChannelTrace } from '@logger';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import {
@@ -270,12 +271,13 @@ export async function ensureExternalInquiryThreadMirror(params: {
   executionId: ExecutionId;
   threadId: ExternalInquiryThreadId;
 }): Promise<ExternalInquiryThreadMirrorPaths> {
+  const threadStoragePath = `${RUNS_STORAGE_DIR}/${params.executionId}/${EXEC_DIR}/${params.threadId}`;
   await copyGlobalDirectoryToExecution(
     threadDir(params.threadId),
-    path.join('executions', params.executionId, EXEC_DIR, params.threadId),
+    threadStoragePath,
   );
 
-  const threadPath = `/executions/${params.executionId}/${EXEC_DIR}/${params.threadId}`;
+  const threadPath = `/${threadStoragePath}`;
   return {
     executionId: params.executionId,
     threadPath,

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import { z } from 'zod';
 
 // Local imports
+import { MEMORY_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import { tryUseRunContext } from '@agent/runtime/RunContext';
 import { debug } from '@logger/logUtils';
 import { formatRelativeTime } from '@shared/utils/string';
@@ -33,7 +34,6 @@ import { countOccurrences, requireField } from '../utils';
 
 // Local imports - shared memory constants and utilities
 import {
-  MEMORY_STORAGE_ROOT,
   MAX_VIEW_LINES,
   MAX_PINNED_MEMORIES,
   DIRECTORY_LISTING_DEPTH,
@@ -250,7 +250,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
     // Handle non-existent root directory gracefully - return empty listing
     // instead of error (consistent with MemoryViewMessageHandler behavior)
     if (!exists) {
-      if (resolvedPath === MEMORY_STORAGE_ROOT) {
+      if (resolvedPath === MEMORY_STORAGE_DIR) {
         return {
           status: 'executed',
           summary: 'Viewed empty memory directory',
@@ -317,7 +317,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
       throw new ToolError(`File ${inputPath} already exists.`);
     }
 
-    await StorageFS.ensureDir(MEMORY_STORAGE_ROOT);
+    await StorageFS.ensureDir(MEMORY_STORAGE_DIR);
     await StorageFS.ensureDir(path.dirname(resolvedPath));
     await this.writeMemoryFile(resolvedPath, fileText);
     recordToolFileRead(inputPath);

--- a/src/tools/memory/constants.ts
+++ b/src/tools/memory/constants.ts
@@ -1,8 +1,4 @@
-import { MEMORY_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
-
 export const MEMORY_DISPLAY_ROOT = '/memories';
-
-export const MEMORY_STORAGE_ROOT = MEMORY_STORAGE_DIR;
 
 export const MAX_VIEW_LINES = 999_999;
 

--- a/src/tools/memory/memoryFileSystem.ts
+++ b/src/tools/memory/memoryFileSystem.ts
@@ -9,9 +9,9 @@ import * as path from 'node:path';
 
 import pMap from 'p-map';
 
+import { MEMORY_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import type { MemoryPreview, MemoryViewItem } from '@shared/schemas';
 import {
-  MEMORY_STORAGE_ROOT,
   MAX_PREVIEW_LINES,
   MAX_PREVIEW_CHARS,
   shouldSkipEntry,
@@ -114,7 +114,7 @@ export async function loadMemoryPreview(
 /**
  * Walks the memory directory and collects all memory items.
  * @param storagePath - Current directory path to walk
- * @param relativeRoot - Path relative to MEMORY_STORAGE_ROOT for display
+ * @param relativeRoot - Path relative to MEMORY_STORAGE_DIR for display
  * @returns Array of memory items found in the directory
  */
 export async function walkMemoryDirectory(
@@ -146,7 +146,7 @@ export async function walkMemoryDirectory(
         const nextRelative = directory.relativeRoot
           ? path.join(directory.relativeRoot, name)
           : name;
-        const nextStoragePath = path.join(MEMORY_STORAGE_ROOT, nextRelative);
+        const nextStoragePath = path.join(MEMORY_STORAGE_DIR, nextRelative);
 
         if (isDirectory(type)) {
           return {
@@ -193,12 +193,12 @@ export async function walkMemoryDirectory(
  * @returns Array of memory items, newest first
  */
 export async function loadMemoryItems(): Promise<MemoryViewItem[]> {
-  const exists = await StorageFS.exists(MEMORY_STORAGE_ROOT);
+  const exists = await StorageFS.exists(MEMORY_STORAGE_DIR);
   if (!exists) {
     return [];
   }
 
-  const items = await walkMemoryDirectory(MEMORY_STORAGE_ROOT);
+  const items = await walkMemoryDirectory(MEMORY_STORAGE_DIR);
   return items.toSorted(
     (a, b) =>
       (b.pinned ? 1 : 0) - (a.pinned ? 1 : 0) || b.mtime.localeCompare(a.mtime),

--- a/src/tools/memory/memoryMeta.ts
+++ b/src/tools/memory/memoryMeta.ts
@@ -11,10 +11,11 @@ import * as path from 'node:path';
 import * as yaml from 'yaml';
 import { z } from 'zod';
 
+import { MEMORY_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import { StorageFS } from '@utils/files';
 import { isDirectory } from '@utils/files/fsEntryType';
 
-import { MEMORY_STORAGE_ROOT, shouldSkipEntry } from './constants';
+import { shouldSkipEntry } from './constants';
 
 /**
  * Attribution metadata schema. Source of truth for the {@link MemoryFileMeta}
@@ -154,14 +155,14 @@ export function setPinnedMeta(
 }
 
 /**
- * Count pinned memory files under MEMORY_STORAGE_ROOT.
+ * Count pinned memory files under MEMORY_STORAGE_DIR.
  * Short-circuits once `limit` is reached to avoid unnecessary reads.
  * Returns 0 if the storage root does not exist.
  */
 export async function countPinnedMemories(limit?: number): Promise<number> {
-  const exists = await StorageFS.exists(MEMORY_STORAGE_ROOT);
+  const exists = await StorageFS.exists(MEMORY_STORAGE_DIR);
   if (!exists) return 0;
-  return countPinnedInDir(MEMORY_STORAGE_ROOT, limit ?? Infinity);
+  return countPinnedInDir(MEMORY_STORAGE_DIR, limit ?? Infinity);
 }
 
 async function countPinnedInDir(

--- a/src/tools/memory/memoryUtils.ts
+++ b/src/tools/memory/memoryUtils.ts
@@ -1,8 +1,9 @@
 import * as path from 'node:path';
 
+import { MEMORY_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import { normalizeFilePath } from '@shared/utils/path';
 
-import { MEMORY_DISPLAY_ROOT, MEMORY_STORAGE_ROOT } from './constants';
+import { MEMORY_DISPLAY_ROOT } from './constants';
 
 export function relativeToDisplayPath(relativePath: string): string {
   if (!relativePath) {
@@ -12,7 +13,7 @@ export function relativeToDisplayPath(relativePath: string): string {
 }
 
 export function toDisplayPath(storagePath: string): string {
-  const relative = path.relative(MEMORY_STORAGE_ROOT, storagePath);
+  const relative = path.relative(MEMORY_STORAGE_DIR, storagePath);
   return relativeToDisplayPath(relative);
 }
 
@@ -44,13 +45,13 @@ export function displayToStoragePath(displayPath: string): string {
     displayPath === MEMORY_DISPLAY_ROOT
       ? ''
       : displayPath.slice(`${MEMORY_DISPLAY_ROOT}/`.length);
-  const resolved = path.resolve(MEMORY_STORAGE_ROOT, suffix);
-  const base = path.resolve(MEMORY_STORAGE_ROOT);
+  const resolved = path.resolve(MEMORY_STORAGE_DIR, suffix);
+  const base = path.resolve(MEMORY_STORAGE_DIR);
   const relative = path.relative(base, resolved);
   if (relative.startsWith('..') || path.isAbsolute(relative)) {
     throw new Error(`Invalid memory path: ${displayPath}`);
   }
   return relative
-    ? path.join(MEMORY_STORAGE_ROOT, relative)
-    : MEMORY_STORAGE_ROOT;
+    ? path.join(MEMORY_STORAGE_DIR, relative)
+    : MEMORY_STORAGE_DIR;
 }

--- a/src/utils/files/runStorageFs.ts
+++ b/src/utils/files/runStorageFs.ts
@@ -3,7 +3,6 @@ import * as path from 'node:path';
 import { promises as fs } from 'node:fs';
 
 import {
-  LEGACY_RUNS_STORAGE_DIR,
   resolveExistingRunStoragePath,
   resolveRunOriginalSnapshotPath,
   resolveRunStoragePath,
@@ -18,10 +17,6 @@ import { createRunStorageLocation } from './fileLocation';
 import { StorageFS } from './storageFS';
 
 export const CHANNEL = 'taskRunStorage';
-
-export const TASK_RUNS_DIR = RUNS_STORAGE_DIR;
-
-export const LEGACY_RUNS_DIR = LEGACY_RUNS_STORAGE_DIR;
 
 export function getRunDir(id: ExecutionId): string {
   return StorageFS.fullPath(resolveRunStoragePath(id));
@@ -51,7 +46,7 @@ export async function findRunDir(id: ExecutionId): Promise<string | undefined> {
 }
 
 export async function ensureRunDir(id: ExecutionId): Promise<void> {
-  await StorageFS.ensureDir(TASK_RUNS_DIR);
+  await StorageFS.ensureDir(RUNS_STORAGE_DIR);
   await StorageFS.ensureDir(resolveRunStoragePath(id));
 }
 

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -40,11 +40,9 @@ export {
   ensureRunDir,
   getOriginalSnapshotPath,
   getRunDir,
-  LEGACY_RUNS_DIR,
   findRunDir,
   findExistingRunStoragePath,
   runStorageLocationFromAbsolutePath,
-  TASK_RUNS_DIR,
 } from './runStorageFs';
 
 logger.initialize(CHANNEL);


### PR DESCRIPTION
## Summary

Collapses the remaining storage-layout vocabulary aliases left after #6998. `TASK_RUNS_DIR`, `LEGACY_RUNS_DIR`, and `MEMORY_STORAGE_ROOT` are removed, `STORAGE_LAYOUT` is no longer exported, and the remaining production consumers now route through the canonical layout surface in `src/platform/defaults/workspaceStorage.ts`.

The re-verification pass found drift from the issue body: #7038 and #7039 were already closed, `resolveMemoryStorageRelativePath` is already gone, the invalid memory-path message already preserves the original display path, and `taskRunStorage.ts` already routes original snapshots through `getOriginalSnapshotPath`. This PR therefore scopes to the remaining live #7042 residues. Refs #7038 and #7039.

## Issue acceptance gates

- [x] One exported name per storage directory: production grep for `TASK_RUNS_DIR`, `MEMORY_STORAGE_ROOT`, `LEGACY_RUNS_DIR`, and exported `STORAGE_LAYOUT` is zero.
- [x] Raw storage bypass sites removed: `externalInquiryStorage.ts` now builds mirrored execution paths from `RUNS_STORAGE_DIR`, and CLI memory path handling derives `memories/` from `resolveMemoryStoragePath()`.
- [x] As-touched execution and memory consumers now use `RUNS_STORAGE_DIR`, `MEMORY_STORAGE_DIR`, or layout resolvers directly.
- [x] Net LoC negative: 18 files changed, 55 insertions and 62 deletions.
- [x] No behavior change intended.

## Single source of truth

`src/platform/defaults/workspaceStorage.ts` owns the storage directory vocabulary and path resolvers. It remains the only production source for the persisted `executions`, legacy `taskRuns`, and `memories` directory names.

## Duplication and abstraction budget

Removed three pass-through aliases and one unused exported layout object. No new pass-through layer was added; the only API broadening is allowing `resolveMemoryStoragePath()` with no argument to return the canonical memory root, matching the existing root-call behavior of `resolveRunStoragePath()`.

This refactor is net-negative in lines, so no added-mass justification is needed.

## Host impact

Extension: no behavior change; activation and settings memory-folder handling use canonical storage layout names.

Desktop: no behavior change; settings memory-folder handling uses the canonical memory resolver.

CLI: no behavior change; memory storage-path input now checks against the canonical memory root instead of a raw `memories/` literal. `validate:run` passed, covering `texra run`, `--print`, and `--output-format json` headless contracts.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write $(git diff --name-only)`
- `git diff --check`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/platform/WorkspaceStorage.vitest.ts src/test-kernel/cli/CliMemory.vitest.mts src/test-kernel/tools/InquiryStorage.vitest.ts src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts src/test-kernel/agent/DeleteExecution.vitest.mts src/test-kernel/agent/utils/debugMessageSaver.vitest.ts src/test-kernel/settings/MemoryFileSystemConcurrency.vitest.ts`
- `npm run typecheck`
- `npm run lint` (passes with the repo's existing 15 warnings)
- `npm run check:cli-architecture`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `npm run compile:fast`
- `npm test`

Closes #7042

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical import and alias removal with no intended behavior change; paths still resolve to the same `executions` and `memories` directories.
> 
> **Overview**
> **Collapses leftover storage vocabulary** so `workspaceStorage.ts` is the single source for persisted directory names (`executions`, `memories`, legacy `taskRuns`).
> 
> Removes **`TASK_RUNS_DIR`**, **`LEGACY_RUNS_DIR`**, **`MEMORY_STORAGE_ROOT`**, and the exported **`STORAGE_LAYOUT`** object. Call sites now use **`RUNS_STORAGE_DIR`**, **`MEMORY_STORAGE_DIR`**, **`resolveRunStoragePath`**, and **`resolveMemoryStoragePath()`** (optional no-arg default returns the memory root, mirroring run storage).
> 
> **Host and tool touchpoints:** extension activation ensures **`RUNS_STORAGE_DIR`**; desktop/extension settings open the memory folder via **`resolveMemoryStoragePath()`**; CLI memory input accepts storage-style prefixes derived from that resolver instead of a hardcoded `memories/` string; **`externalInquiryStorage`** builds execution mirror paths from **`RUNS_STORAGE_DIR`**; memory tools and filesystem utilities reference **`MEMORY_STORAGE_DIR`** directly rather than a constants re-export.
> 
> **Net refactor only** — same on-disk layout and behavior; tests updated to match canonical names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efc4481d54ce3aaa200ce06bee47b283e90d508b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->