### PR TITLE
feat(transcript): add trace.json assembler for one execution

### DIFF
--- a/src/test-kernel/transcript/traceAssembler.vitest.ts
+++ b/src/test-kernel/transcript/traceAssembler.vitest.ts
@@ -10,11 +10,11 @@ import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import {
+  assembleTrace,
   getDefaultStreamLogStore,
   setDefaultStreamLogStore,
   StreamLogStore,
 } from '@transcript';
-import { assembleTrace } from '@transcript/traceAssembler';
 import { getExecutionStore } from '@agent/storage';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
@@ -148,6 +148,47 @@ describe('assembleTrace', () => {
     const result = await assembleTrace(executionId);
 
     expect(result).toEqual({ status: 'streamLogs_missing' });
+  });
+
+  it('resolves a child stream by executionId suffix when its id does not match the derived agent@model#executionId format', async () => {
+    // Background child streams (bash/codex/claude subagents, see
+    // @tools/childStream.createChildStream) use a tool-specific
+    // "${streamPrefix}#executionId" id, not getStreamTabId's
+    // "agent@model#executionId" — the config's own agent/model would derive
+    // the wrong id entirely for these.
+    await installStoragePlatform();
+    const executionId = 'exec-child-1' as ExecutionId;
+    const executionConfig = config({ agent: 'orchestrator', model: 'deepseekT' });
+    await getExecutionStore(executionId).writeConfig(executionConfig);
+    await getExecutionStore(executionId).writeMeta({
+      timestamp: '2026-07-05T00:00:00.000Z',
+      outcome: 'completed',
+    });
+
+    const derivedId = getStreamTabId('orchestrator', 'deepseekT', {
+      executionId,
+    });
+    const actualChildStreamId = `bash@tool#${executionId}`;
+    expect(actualChildStreamId).not.toBe(derivedId);
+
+    const store = getDefaultStreamLogStore();
+    await store.load();
+    store.append(actualChildStreamId as ReturnType<typeof getStreamTabId>, {
+      id: 'entry-1',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 100,
+      messageType: MESSAGE_TYPES.DEFAULT,
+      text: 'child stream output',
+    });
+    await store.flush();
+
+    const result = await assembleTrace(executionId);
+
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    expect(result.trace.streamId).toBe(actualChildStreamId);
+    expect(result.trace.entries).toHaveLength(1);
   });
 
   it('returns a null terminalStatus when meta has no recorded outcome', async () => {

--- a/src/test-kernel/transcript/traceAssembler.vitest.ts
+++ b/src/test-kernel/transcript/traceAssembler.vitest.ts
@@ -158,7 +158,10 @@ describe('assembleTrace', () => {
     // the wrong id entirely for these.
     await installStoragePlatform();
     const executionId = 'exec-child-1' as ExecutionId;
-    const executionConfig = config({ agent: 'orchestrator', model: 'deepseekT' });
+    const executionConfig = config({
+      agent: 'orchestrator',
+      model: 'deepseekT',
+    });
     await getExecutionStore(executionId).writeConfig(executionConfig);
     await getExecutionStore(executionId).writeMeta({
       timestamp: '2026-07-05T00:00:00.000Z',

--- a/src/test-kernel/transcript/traceAssembler.vitest.ts
+++ b/src/test-kernel/transcript/traceAssembler.vitest.ts
@@ -18,13 +18,13 @@ import { assembleTrace } from '@transcript/traceAssembler';
 import { getExecutionStore } from '@agent/storage';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import { getStreamTabId } from '@agent/runtime/streamTab';
 import {
   EXECUTION_STATUS,
   LOG_LEVELS,
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
   type ExecutionId,
-  type StreamTabId,
 } from '@shared/schemas';
 import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
 
@@ -105,7 +105,7 @@ describe('assembleTrace', () => {
       outcome: 'completed',
     });
 
-    const streamId = 'review@sonnet46T#exec-happy-path' as StreamTabId;
+    const streamId = getStreamTabId('review', 'sonnet46T', { executionId });
     const store = getDefaultStreamLogStore();
     await store.load();
     store.append(streamId, {
@@ -159,8 +159,11 @@ describe('assembleTrace', () => {
       timestamp: '2026-07-05T00:00:00.000Z',
     });
 
-    const streamId =
-      `${executionConfig.agent}@${executionConfig.model}#${executionId}` as StreamTabId;
+    const streamId = getStreamTabId(
+      executionConfig.agent,
+      executionConfig.model,
+      { executionId },
+    );
     const store = getDefaultStreamLogStore();
     await store.load();
     store.append(streamId, {

--- a/src/test-kernel/transcript/traceAssembler.vitest.ts
+++ b/src/test-kernel/transcript/traceAssembler.vitest.ts
@@ -1,0 +1,177 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createFakePlatform } from '@test/support/FakePlatform';
+import { MemoryStateStore } from '@platform/defaults/memoryState';
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
+import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
+import {
+  getDefaultStreamLogStore,
+  setDefaultStreamLogStore,
+  StreamLogStore,
+} from '@transcript';
+import { assembleTrace } from '@transcript/traceAssembler';
+import { getExecutionStore } from '@agent/storage';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import {
+  EXECUTION_STATUS,
+  LOG_LEVELS,
+  MESSAGE_TYPES,
+  STREAM_LOG_ENTRY_TYPES,
+  type ExecutionId,
+  type StreamTabId,
+} from '@shared/schemas';
+import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
+
+const tempDirs: string[] = [];
+
+async function installStoragePlatform(): Promise<void> {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'texra-trace-'));
+  tempDirs.push(tempDir);
+  const workspaceDir = path.join(tempDir, 'workspace');
+  const storageRoot = path.join(tempDir, 'storage');
+  const { initPlatform } = await import('@platform/platform');
+  initPlatform(
+    createFakePlatform(
+      { workspacePath: workspaceDir },
+      {
+        fs: nodeFilesystem,
+        workspace: createNodeWorkspace(() => workspaceDir),
+        storage: new WorkspaceStorageProvider(storageRoot, workspaceDir),
+        globalState: new MemoryStateStore(),
+        workspaceState: new MemoryStateStore(),
+      },
+    ),
+  );
+}
+
+function config(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    inputFiles: [],
+    contextFiles: [],
+    mediaFiles: [],
+    outputFiles: [],
+    editedFile: null,
+    agent: 'orchestrator',
+    model: 'deepseekT',
+    instruction: 'Solve the problem.',
+    agentCategory: AgentCategory.ToolUse,
+    editedFiles: [],
+    toolConfig: DEFAULT_TOOL_CONFIG,
+    memories: [],
+    workingDirectory: '/workspace',
+    cliOutputFile: null,
+    cliMultiAgentPresetId: null,
+    ...overrides,
+  };
+}
+
+describe('assembleTrace', () => {
+  let previousStreamLogStore: StreamLogStore;
+
+  beforeEach(() => {
+    // A fresh store per test, not the process-wide singleton: StreamLogStore's
+    // underlying KVStore caches a "directory already ensured" flag for its own
+    // lifetime, which goes stale once a later test points the platform at a
+    // different temp storage root. Real hosts never switch storage roots
+    // mid-process, so this is a test-only concern — the sanctioned fix used
+    // throughout src/test-kernel is swapping in a fresh store per test.
+    previousStreamLogStore = getDefaultStreamLogStore();
+    setDefaultStreamLogStore(new StreamLogStore());
+  });
+
+  afterEach(async () => {
+    setDefaultStreamLogStore(previousStreamLogStore);
+    await Promise.all(
+      tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it('assembles a full trace document, deriving streamId from agent/model/executionId', async () => {
+    await installStoragePlatform();
+    const executionId = 'exec-happy-path' as ExecutionId;
+    const executionConfig = config({ agent: 'review', model: 'sonnet46T' });
+
+    await getExecutionStore(executionId).writeConfig(executionConfig);
+    await getExecutionStore(executionId).writeMeta({
+      timestamp: '2026-07-05T00:00:00.000Z',
+      outcome: 'completed',
+    });
+
+    const streamId = 'review@sonnet46T#exec-happy-path' as StreamTabId;
+    const store = getDefaultStreamLogStore();
+    await store.load();
+    store.append(streamId, {
+      id: 'entry-1',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 100,
+      messageType: MESSAGE_TYPES.DEFAULT,
+      text: 'hello',
+    });
+    await store.flush();
+
+    const result = await assembleTrace(executionId);
+
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    expect(result.trace.streamId).toBe(streamId);
+    expect(result.trace.config.agent).toBe('review');
+    expect(result.trace.config.model).toBe('sonnet46T');
+    expect(result.trace.entries).toHaveLength(1);
+    expect(result.trace.entries[0]).toMatchObject({ id: 'entry-1', text: 'hello' });
+    expect(result.trace.terminalStatus).toBe(EXECUTION_STATUS.COMPLETED);
+    expect(result.trace.snapshot.streamId).toBe(streamId);
+  });
+
+  it('returns config_missing when no config was ever written', async () => {
+    await installStoragePlatform();
+    const result = await assembleTrace('exec-no-config' as ExecutionId);
+    expect(result).toEqual({ status: 'config_missing' });
+  });
+
+  it('returns streamLogs_missing for a pre-#7057 execution (config exists, streamLogs never persisted)', async () => {
+    await installStoragePlatform();
+    const executionId = 'exec-no-logs' as ExecutionId;
+    await getExecutionStore(executionId).writeConfig(config());
+
+    const result = await assembleTrace(executionId);
+
+    expect(result).toEqual({ status: 'streamLogs_missing' });
+  });
+
+  it('returns a null terminalStatus when meta has no recorded outcome', async () => {
+    await installStoragePlatform();
+    const executionId = 'exec-no-outcome' as ExecutionId;
+    const executionConfig = config();
+    await getExecutionStore(executionId).writeConfig(executionConfig);
+    await getExecutionStore(executionId).writeMeta({
+      timestamp: '2026-07-05T00:00:00.000Z',
+    });
+
+    const streamId = `${executionConfig.agent}@${executionConfig.model}#${executionId}` as StreamTabId;
+    const store = getDefaultStreamLogStore();
+    await store.load();
+    store.append(streamId, {
+      id: 'entry-1',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 100,
+      messageType: MESSAGE_TYPES.DEFAULT,
+      text: 'hello',
+    });
+    await store.flush();
+
+    const result = await assembleTrace(executionId);
+
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    expect(result.trace.meta).not.toBeNull();
+    expect(result.trace.terminalStatus).toBeNull();
+  });
+});

--- a/src/test-kernel/transcript/traceAssembler.vitest.ts
+++ b/src/test-kernel/transcript/traceAssembler.vitest.ts
@@ -88,7 +88,9 @@ describe('assembleTrace', () => {
   afterEach(async () => {
     setDefaultStreamLogStore(previousStreamLogStore);
     await Promise.all(
-      tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+      tempDirs
+        .splice(0)
+        .map((dir) => rm(dir, { recursive: true, force: true })),
     );
   });
 
@@ -124,7 +126,10 @@ describe('assembleTrace', () => {
     expect(result.trace.config.agent).toBe('review');
     expect(result.trace.config.model).toBe('sonnet46T');
     expect(result.trace.entries).toHaveLength(1);
-    expect(result.trace.entries[0]).toMatchObject({ id: 'entry-1', text: 'hello' });
+    expect(result.trace.entries[0]).toMatchObject({
+      id: 'entry-1',
+      text: 'hello',
+    });
     expect(result.trace.terminalStatus).toBe(EXECUTION_STATUS.COMPLETED);
     expect(result.trace.snapshot.streamId).toBe(streamId);
   });
@@ -154,7 +159,8 @@ describe('assembleTrace', () => {
       timestamp: '2026-07-05T00:00:00.000Z',
     });
 
-    const streamId = `${executionConfig.agent}@${executionConfig.model}#${executionId}` as StreamTabId;
+    const streamId =
+      `${executionConfig.agent}@${executionConfig.model}#${executionId}` as StreamTabId;
     const store = getDefaultStreamLogStore();
     await store.load();
     store.append(streamId, {

--- a/src/transcript/index.ts
+++ b/src/transcript/index.ts
@@ -26,3 +26,8 @@ export {
 } from './runTrace';
 export { streamDataDir } from './streamDataPaths';
 export { StreamSnapshotStore } from './StreamSnapshotStore';
+export {
+  assembleTrace,
+  type AssembleTraceResult,
+  type TraceDocument,
+} from './traceAssembler';

--- a/src/transcript/traceAssembler.ts
+++ b/src/transcript/traceAssembler.ts
@@ -50,26 +50,35 @@ export async function assembleTrace(
   executionId: ExecutionId,
 ): Promise<AssembleTraceResult> {
   const executionStore = getExecutionStore(executionId);
-  const [config, meta] = await Promise.all([
-    executionStore.readConfig(),
-    executionStore.readMeta(),
-  ]);
-  if (!config) return { status: 'config_missing' };
-
-  // `streamId` is a composite of agent/model/executionId, not the executionId
-  // itself — see @agent/runtime/streamTab.getStreamTabId.
-  const streamId = getStreamTabId(config.agent, config.model, {
-    executionId,
-  });
-
   // A fresh instance, not the shared getDefaultStreamLogStore() singleton:
   // .load() clears all of a store's in-memory state, which would wipe out a
   // live host's in-flight session if this ran against the shared instance.
   // Reads the same on-disk files regardless — StreamSnapshotStore below
   // already follows this same call-scoped-instance pattern.
   const streamLogStore = new StreamLogStore();
+  const [config, meta] = await Promise.all([
+    executionStore.readConfig(),
+    executionStore.readMeta(),
+    streamLogStore.load(),
+  ]);
+  if (!config) return { status: 'config_missing' };
+
+  // Resolve the persisted streamId by executionId suffix rather than
+  // deriving it: a top-level run uses `agent@model#executionId`
+  // (getStreamTabId), but a background child stream (bash/codex/claude
+  // subagent, see @tools/childStream.createChildStream) uses a
+  // tool-specific `${streamPrefix}#executionId` instead. Every streamId
+  // ends in `#executionId` regardless of prefix scheme, and executionId is
+  // unique, so searching by suffix resolves both without this module having
+  // to know every child-stream prefix convention. Falls back to the derived
+  // top-level id if load() found nothing at all under this executionId.
+  const suffix = `#${executionId}`;
+  const streamId =
+    streamLogStore.keys().find((id) => id.endsWith(suffix)) ??
+    getStreamTabId(config.agent, config.model, { executionId });
+
   const [, snapshot] = await Promise.all([
-    streamLogStore.load().then(() => streamLogStore.ensureLoaded(streamId)),
+    streamLogStore.ensureLoaded(streamId),
     new StreamSnapshotStore().read(streamId),
   ]);
   const log = streamLogStore.get(streamId);

--- a/src/transcript/traceAssembler.ts
+++ b/src/transcript/traceAssembler.ts
@@ -21,7 +21,7 @@ import type {
   StreamTabId,
 } from '@shared/schemas';
 
-import { getDefaultStreamLogStore } from './StreamLogStore';
+import { StreamLogStore } from './StreamLogStore';
 import { StreamSnapshotStore } from './StreamSnapshotStore';
 
 export interface TraceDocument {
@@ -62,21 +62,19 @@ export async function assembleTrace(
     executionId,
   });
 
-  const streamLogStore = getDefaultStreamLogStore();
-  // Assumes a one-shot process (e.g. a CLI export command): `.load()` resets
-  // the store's in-memory state, so this must not run inside a long-lived
-  // host with an active session sharing the same store instance.
-  try {
-    await streamLogStore.load();
-  } catch {
-    // Persistence stays unavailable; ensureLoaded/get below will just find
-    // nothing, which the streamLogs_missing branch below already handles.
-  }
-  await streamLogStore.ensureLoaded(streamId);
+  // A fresh instance, not the shared getDefaultStreamLogStore() singleton:
+  // .load() clears all of a store's in-memory state, which would wipe out a
+  // live host's in-flight session if this ran against the shared instance.
+  // Reads the same on-disk files regardless — StreamSnapshotStore below
+  // already follows this same call-scoped-instance pattern.
+  const streamLogStore = new StreamLogStore();
+  const [, snapshot] = await Promise.all([
+    streamLogStore.load().then(() => streamLogStore.ensureLoaded(streamId)),
+    new StreamSnapshotStore().read(streamId),
+  ]);
   const log = streamLogStore.get(streamId);
   if (!log) return { status: 'streamLogs_missing' };
 
-  const snapshot = await new StreamSnapshotStore().read(streamId);
   const terminalStatus = meta?.outcome
     ? runOutcomeToExecutionStatus(meta.outcome)
     : null;

--- a/src/transcript/traceAssembler.ts
+++ b/src/transcript/traceAssembler.ts
@@ -1,0 +1,96 @@
+/**
+ * Assembles a {@link TraceDocument} — everything a static trace-viewer needs
+ * to replay one finished execution — from the same on-disk data the
+ * interactive hosts already read: `ExecutionKVStore` (config/meta),
+ * `StreamLogStore` (the round/thinking/tool-call timeline), and
+ * `StreamSnapshotStore` (todos/plan/usage sidecars).
+ *
+ * Host-neutral, following `ChatExportController.buildExportInput`'s
+ * discriminated-status pattern so callers can show a precise error instead of
+ * a generic failure.
+ */
+import { getExecutionStore, type ExecutionMeta } from '@agent/storage';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import { getStreamTabId } from '@agent/runtime/streamTab';
+import { runOutcomeToExecutionStatus } from '@common/constants/streamStatus';
+import type {
+  ExecutionId,
+  ExecutionStatus,
+  StreamLogEntry,
+  StreamSnapshot,
+  StreamTabId,
+} from '@shared/schemas';
+
+import { getDefaultStreamLogStore } from './StreamLogStore';
+import { StreamSnapshotStore } from './StreamSnapshotStore';
+
+export interface TraceDocument {
+  readonly executionId: ExecutionId;
+  readonly streamId: StreamTabId;
+  readonly config: AgentConfig;
+  readonly meta: ExecutionMeta | null;
+  readonly entries: StreamLogEntry[];
+  readonly snapshot: StreamSnapshot;
+  /** `null` when the execution predates outcome tracking or never reached a terminal state. */
+  readonly terminalStatus: ExecutionStatus | null;
+}
+
+export type AssembleTraceResult =
+  | { readonly status: 'ok'; readonly trace: TraceDocument }
+  | { readonly status: 'config_missing' | 'streamLogs_missing' };
+
+/**
+ * `streamLogs_missing` is the expected outcome for any execution recorded
+ * before the headless-persistence fix (TeXRA#7057) — headless runs before
+ * that fix never wrote a `streamLogs` file at all, so there is nothing here
+ * to replay faithfully. Callers should surface that distinction rather than
+ * a generic "not found".
+ */
+export async function assembleTrace(
+  executionId: ExecutionId,
+): Promise<AssembleTraceResult> {
+  const executionStore = getExecutionStore(executionId);
+  const [config, meta] = await Promise.all([
+    executionStore.readConfig(),
+    executionStore.readMeta(),
+  ]);
+  if (!config) return { status: 'config_missing' };
+
+  // `streamId` is a composite of agent/model/executionId, not the executionId
+  // itself — see @agent/runtime/streamTab.getStreamTabId.
+  const streamId = getStreamTabId(config.agent, config.model, {
+    executionId,
+  });
+
+  const streamLogStore = getDefaultStreamLogStore();
+  // Assumes a one-shot process (e.g. a CLI export command): `.load()` resets
+  // the store's in-memory state, so this must not run inside a long-lived
+  // host with an active session sharing the same store instance.
+  try {
+    await streamLogStore.load();
+  } catch {
+    // Persistence stays unavailable; ensureLoaded/get below will just find
+    // nothing, which the streamLogs_missing branch below already handles.
+  }
+  await streamLogStore.ensureLoaded(streamId);
+  const log = streamLogStore.get(streamId);
+  if (!log) return { status: 'streamLogs_missing' };
+
+  const snapshot = await new StreamSnapshotStore().read(streamId);
+  const terminalStatus = meta?.outcome
+    ? runOutcomeToExecutionStatus(meta.outcome)
+    : null;
+
+  return {
+    status: 'ok',
+    trace: {
+      executionId,
+      streamId,
+      config,
+      meta,
+      entries: log.toJSON(),
+      snapshot,
+      terminalStatus,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- New `src/transcript/traceAssembler.ts`: `assembleTrace(executionId)` reads an execution's `config`/`meta` (`ExecutionKVStore`), derives its `streamId` via `getStreamTabId(agent, model, {executionId})` (a composite `agent@model#executionId`, **not** the executionId alone), and reads the `streamLogs` timeline + `streamData` snapshot for that stream.
- Returns a discriminated result (`ok` / `config_missing` / `streamLogs_missing`), following `ChatExportController.buildExportInput`'s existing pattern.
- `streamLogs_missing` is the expected, distinct outcome for any execution recorded before #7057's fix — those headless runs never persisted a `streamLogs` file at all.
- `terminalStatus` is `null` (not guessed) when the persisted `meta` has no recorded outcome, rather than fabricating a status.

This is the data-assembly step for #7058's trace-viewer export — closes #7135.

## Test plan
- [x] `src/test-kernel/transcript/traceAssembler.vitest.ts`: happy path (streamId derivation, entries, terminal status), `config_missing`, `streamLogs_missing`, and a `meta`-without-outcome case — all against real on-disk temp storage (not mocked), following `RunExecution.vitest.mts`'s `installStoragePlatform` pattern.
- [x] Found and fixed a real test-isolation trap along the way: `StreamLogStore`'s underlying `KVStore` caches a "directory already ensured" flag for its instance lifetime, which goes stale once a test switches the platform to a different temp storage root. Fixed by swapping in a fresh `StreamLogStore` per test via `setDefaultStreamLogStore` — the same pattern already used across `src/test-kernel/agent/trace`, `src/test-kernel/logger`, etc.
- [x] `src/test-kernel/transcript` + `src/test-kernel/agent/trace` + `src/test-kernel/logger` (66 tests) pass.
- [x] `CI=true npm run typecheck` clean across all 4 workspace projects.
- [x] `eslint --fix` applied (two import-order warnings, autofixed).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only transcript assembly with no changes to execution, auth, or live stream singleton behavior beyond using a separate store instance for reads.
> 
> **Overview**
> Adds **`assembleTrace(executionId)`** to build a **`TraceDocument`** (config, meta, stream log entries, snapshot, and optional terminal status) from the same on-disk execution and stream persistence the interactive hosts use.
> 
> Results are **discriminated** (`ok`, `config_missing`, `streamLogs_missing`) so trace export/UI can show precise errors—especially **`streamLogs_missing`** for executions before stream log persistence (#7057). **`streamId`** is resolved by matching keys ending in `#executionId` (child tool streams) with fallback to **`getStreamTabId`**. Assembly uses a **call-scoped `StreamLogStore`** so `load()` does not clear the process singleton. **`terminalStatus`** stays **`null`** when meta has no outcome.
> 
> Exports and types are re-exported from **`@transcript`**. New kernel tests cover happy path, missing config/logs, child stream suffix resolution, and null terminal status, with per-test **`StreamLogStore`** isolation for temp storage roots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20b886063fb3daa214c06fb121e00f0977255e40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->