### PR TITLE
test(webview): isolate MainApp restore suite state

### DIFF
--- a/packages/extension/src/webview/frontend/persistence.ts
+++ b/packages/extension/src/webview/frontend/persistence.ts
@@ -272,9 +272,9 @@ export function flushPendingInstructionSave(): void {
 
 /**
  * Reset the transient runtime (save-block counter, pending debounce timer)
- * without touching stored state. Called from `MainApp`'s constructor on
- * remount in the same JS context, matching the fresh-instance slate the old
- * per-instance fields provided.
+ * and reload the cached persisted state from storage. Called from `MainApp`'s
+ * constructor on remount in the same JS context, matching the fresh-instance
+ * slate the old per-instance fields provided.
  */
 export function resetPersistenceRuntime(): void {
   saveBlockCount = 0;
@@ -282,4 +282,5 @@ export function resetPersistenceRuntime(): void {
     window.clearTimeout(instructionSaveTimer);
     instructionSaveTimer = null;
   }
+  stateManager.reload();
 }

--- a/src/shared/state/PersistedState.ts
+++ b/src/shared/state/PersistedState.ts
@@ -151,6 +151,11 @@ export class PersistedState<T extends Record<string, unknown>> {
     this.storage.set(this.key, this.state);
   }
 
+  /** Reload current state from the backing storage. */
+  reload(): void {
+    this.state = this.load();
+  }
+
   /** Partial update (merge) */
   update(partial: Partial<T>): void {
     this.setState({ ...this.state, ...partial });

--- a/src/test-kernel/webview/MainAppPersistenceRestore.vitest.mts
+++ b/src/test-kernel/webview/MainAppPersistenceRestore.vitest.mts
@@ -64,9 +64,20 @@ const LEGACY_SEED = {
   attachTeXCount: true,
 };
 
+function seedWebviewState(state: Record<string, unknown> = LEGACY_SEED): void {
+  if (!webviewState) {
+    webviewState = { mainViewState: structuredClone(state) };
+    return;
+  }
+  for (const key of Object.keys(webviewState)) {
+    delete webviewState[key];
+  }
+  webviewState.mainViewState = structuredClone(state);
+}
+
 // Install the host-bridge stub at module scope, BEFORE the DOM harness imports
 // the MainApp module — `hostBridge` resolves this global at module load.
-webviewState = { mainViewState: structuredClone(LEGACY_SEED) };
+seedWebviewState();
 (globalThis as Record<string, unknown>)[HOST_BRIDGE_API_KEY] = {
   postMessage: (message: unknown) => {
     posted.push(message as PostedMessage);
@@ -144,12 +155,11 @@ describe('MainApp persistence and restore characterization', () => {
   useLitComponentTestDom(() => import('@webview/frontend/MainApp'));
 
   beforeEach(() => {
+    seedWebviewState();
     posted.length = 0;
     storageWrites.length = 0;
   });
 
-  // NOTE: this test must run first — it characterizes the mount-time restore
-  // against the pristine LEGACY_SEED, before other tests overwrite storage.
   it('restores persisted state on mount, migrating the legacy instruction and forcing output files inactive', async () => {
     const element = await mountMainApp();
     const { fileState, session } = contextsOf(element);


### PR DESCRIPTION
## Summary

Makes `MainAppPersistenceRestore.vitest.mts` independent of test execution order. The suite now reseeds the host-bridge state before each test and removes the ordering comment that required the mount-time restore test to run first.

While validating with `--sequence.shuffle`, the first fix exposed the actual remount cache owner: `PersistedState` keeps an internal state snapshot. `resetPersistenceRuntime()` now reloads that cached state from storage on `MainApp` remount, which matches the constructor's existing fresh-slate intent.

## Issue acceptance gates

- [x] Re-verified the cited file on current `origin/main`: `beforeEach` still only reset `posted`/`storageWrites`, and the first test still carried the "must run first" comment.
- [x] `webviewState` is reset before each test.
- [x] The mount-time restore test no longer relies on module-load-time initialization or file-order execution.
- [x] The suite passes with Vitest shuffled ordering.

## Single source of truth

`src/shared/state/PersistedState.ts` remains the owner of the in-memory persisted-state cache. `resetPersistenceRuntime()` in `packages/extension/src/webview/frontend/persistence.ts` is the MainApp remount coordinator that now reloads that cache from the backing webview storage.

## Duplication and abstraction budget

Removed the test-order dependency instead of duplicating setup across individual tests. Added one `PersistedState.reload()` method so remount code can refresh the existing cache through the state abstraction rather than reaching into private fields.

This refactor is not net-negative in lines; the added mass is the explicit per-test seed helper plus the small cache reload method needed to make shuffled-order execution deterministic.

## Host impact

Extension: no user-visible behavior change; MainApp remounts in the same JS context now reload the persisted-state cache from webview storage before restoring.

Desktop: none.

CLI: none.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write src/shared/state/PersistedState.ts packages/extension/src/webview/frontend/persistence.ts src/test-kernel/webview/MainAppPersistenceRestore.vitest.mts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/webview/MainAppPersistenceRestore.vitest.mts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/webview/MainAppPersistenceRestore.vitest.mts --sequence.shuffle`
- `git diff --check`
- `npm run typecheck`
- `npm run lint` (passes with the repo's existing 15 warnings)
- `npm run compile:fast`
- `npm test`

Closes #7129

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small extension webview change aligned with existing remount intent; no auth or backend impact, covered by characterization tests including shuffled runs.
> 
> **Overview**
> Makes **MainApp persistence restore tests** order-independent by reseeding host-bridge `webviewState` in `beforeEach` via `seedWebviewState()`, and drops the comment that required the mount-restore test to run first.
> 
> Fixes remount behavior when **MainApp** is constructed again in the same JS context: `resetPersistenceRuntime()` now calls **`PersistedState.reload()`**, which re-reads `mainViewState` from webview storage so the in-memory cache does not keep a stale snapshot from the previous mount.
> 
> Adds **`reload()`** on `PersistedState` as the single abstraction for refreshing the internal cache from backing storage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f369ce794cf29cc8ceeecfd85a2af099240cda0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->