### PR TITLE
style(webview): group ZodError import

### DIFF
--- a/packages/extension/src/webview/frontend/persistence.ts
+++ b/packages/extension/src/webview/frontend/persistence.ts
@@ -12,6 +12,9 @@
  * is pinned by `src/test-kernel/webview/MainAppPersistenceRestore.vitest.mts`.
  */
 
+// Third-party imports
+import { type ZodError } from 'zod';
+
 // Local imports - shared state and schemas
 import { PersistedState } from '@shared/state';
 import {
@@ -41,7 +44,6 @@ import {
   workflowInstruction$,
 } from './mainViewState';
 import { webviewStorage } from './webviewStorage';
-import type { ZodError } from 'zod';
 
 const stateManager = new PersistedState(
   webviewStorage,


### PR DESCRIPTION
## Summary

Moves the `ZodError` type import in `packages/extension/src/webview/frontend/persistence.ts` into the file's third-party import section. The symbol remains type-only via `import { type ZodError } from 'zod'`, so this is an import-organization-only change.

Evidence re-verification found minor line drift: the issue cites `persistence.ts:40`, while current `main` has the misplaced import at line 44. The cited Copilot review comment still matches the live file.

## Issue acceptance gates

- Addresses #7130.
- Re-verified the cited import site and Copilot review comment before implementation.
- Moved the `ZodError` import into a third-party import block above local imports.
- Kept the touched file lint-clean; full repo lint remains at the existing warning baseline.

## Single source of truth

`packages/extension/src/webview/frontend/persistence.ts` now has a single import-group ordering for its dependencies: third-party imports first, followed by local shared state/schema imports and local main-view imports.

## Duplication and abstraction budget

No duplication removed and no abstraction added. This PR only corrects import grouping.

## Host impact

Extension: no behavior change; webview persistence imports are reorganized only.

Desktop: none.

CLI: none.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write packages/extension/src/webview/frontend/persistence.ts`
- `npx eslint packages/extension/src/webview/frontend/persistence.ts`
- `git diff --check`
- `npm run typecheck`
- `npm run lint` (passed with the repository's existing 15 warnings)
- `npm run compile:fast`
- `npm test`

Closes #7130

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-order-only change with no logic, API, or persistence behavior impact.
> 
> **Overview**
> Reorganizes imports in `persistence.ts` so **`ZodError`** from `zod` sits in a labeled **third-party** block at the top of the file, ahead of local `@shared` and main-view imports. The import stays **type-only** (`import { type ZodError } from 'zod'`); it is removed from its previous position after the `./mainViewState` import block.
> 
> No runtime or persistence behavior changes—only import ordering and grouping to match other webview frontend files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6f26175d9f7cf3a8ed35a8877d3b06bd20f468f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->