### PR TITLE
docs(webview): remove stale issue tags

### DIFF
--- a/packages/extension/src/webview/frontend/mainViewState.ts
+++ b/packages/extension/src/webview/frontend/mainViewState.ts
@@ -1,13 +1,13 @@
 /**
  * Module-level reactive state for the Main view.
  *
- * Hoisted from `MainApp` private `signal(...)` fields (issue #7075), following
- * the same module-scope slice-store shape as `progressView/frontend/
- * progressState.ts`. Identity and reactivity are preserved: consumers still
- * read plain signals and `Signal.Computed` derivations, and `MainApp` keeps
- * its `@provide`/`@state` + `willUpdate()` context-sync idiom — only what
- * feeds `fileStateContext$`/`sessionContext$` moved from `this.xxx` fields to
- * these module-scope signals.
+ * Hoisted from `MainApp` private `signal(...)` fields, following the same
+ * module-scope slice-store shape as `progressView/frontend/progressState.ts`.
+ * Identity and reactivity are preserved: consumers still read plain signals
+ * and `Signal.Computed` derivations, and `MainApp` keeps its
+ * `@provide`/`@state` + `willUpdate()` context-sync idiom — only what feeds
+ * `fileStateContext$`/`sessionContext$` moved from `this.xxx` fields to these
+ * module-scope signals.
  *
  * Singleton scope: only one Main view per webview/page. If we ever need
  * multiple independent main-view instances on the same page, this file must

--- a/packages/extension/src/webview/frontend/persistence.ts
+++ b/packages/extension/src/webview/frontend/persistence.ts
@@ -2,7 +2,7 @@
  * Persistence machinery for the Main view.
  *
  * Owns the single `PersistedState` instance (backed by the shared
- * `webviewStorage` singleton) and both restore paths (issue #7075):
+ * `webviewStorage` singleton) and both restore paths:
  *
  *   1. mount-time webview-storage restore (`restorePersistedState`), and
  *   2. backend-pushed history-rerun/reset restore (`handleRestoreState`).
@@ -55,7 +55,7 @@ const stateManager = new PersistedState(
  * Reentrancy guard around `saveState()`: while a backend-pushed restore is
  * applying a snapshot, intermediate mutations must not write partially
  * restored state back to storage. Do NOT "simplify away" without a regression
- * test proving it safe (issue #7075) — the characterization suite asserts
+ * test proving it safe — the characterization suite asserts
  * exactly one storage write per backend restore.
  */
 let saveBlockCount = 0;

--- a/src/test-kernel/webview/MainAppPersistenceRestore.vitest.mts
+++ b/src/test-kernel/webview/MainAppPersistenceRestore.vitest.mts
@@ -20,7 +20,7 @@ import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
  * Characterization tests for MainApp's persistence/restore machinery.
  *
  * These pin down the CURRENT behavior of the two independently-triggered
- * restore paths (issue #7075):
+ * restore paths:
  *   1. mount-time webview-storage restore (`restorePersistedState`), and
  *   2. backend-pushed history-rerun/reset restore (`handleRestoreState`),
  * including the legacy single-`instruction` migration precedence, the forced


### PR DESCRIPTION
## Summary

Removes the `(issue #7075)` process tags from MainApp persistence source comments while preserving the substantive rationale in each comment. This keeps the comments focused on durable behavior and invariants instead of issue-number history.

Evidence re-verification found the cited tags still present after #7141. The only drift was in `persistence.ts`: the second cited site moved from line 56 to line 58 after #7141 added the third-party import block.

## Issue acceptance gates

- Addresses #7131.
- Re-verified the four cited comment sites and the claude review comment before implementation.
- Removed only `(issue #7075)` references from the cited source comments.
- Preserved the comments' substantive rationale, including the reentrancy-guard warning.
- Verified `rg -n --fixed-strings "(issue #7075)" packages/extension/src/webview/frontend/mainViewState.ts packages/extension/src/webview/frontend/persistence.ts src/test-kernel/webview/MainAppPersistenceRestore.vitest.mts` returns no matches.

## Single source of truth

There is no source-level issue-number marker after this change; the issue/PR history remains the durable process record, while the source comments state only the behavioral rationale.

## Duplication and abstraction budget

No duplication removed and no abstraction added. This is a comment-only cleanup and is net-zero in lines.

## Host impact

Extension: no behavior change; source comments only.

Desktop: none.

CLI: none.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write packages/extension/src/webview/frontend/mainViewState.ts packages/extension/src/webview/frontend/persistence.ts src/test-kernel/webview/MainAppPersistenceRestore.vitest.mts`
- `rg -n --fixed-strings "(issue #7075)" packages/extension/src/webview/frontend/mainViewState.ts packages/extension/src/webview/frontend/persistence.ts src/test-kernel/webview/MainAppPersistenceRestore.vitest.mts` (no matches)
- `git diff --check`
- `npm run typecheck`
- `npm run lint` (passed with the repository's existing 15 warnings)
- `npm run compile:fast`
- `npm test`

Closes #7131

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime or test logic changes—only comment text and line wrapping.
> 
> **Overview**
> Removes **`(issue #7075)`** process tags from comments in **`mainViewState.ts`**, **`persistence.ts`**, and **`MainAppPersistenceRestore.vitest.mts`**, leaving the behavioral rationale (slice-store hoisting, restore paths, reentrancy guard, characterization tests) unchanged.
> 
> In **`mainViewState.ts`**, the file-header comment is reflowed across lines only; wording is the same aside from dropping the issue reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87660bd74248745c69e41c9d7b11b666ad08221f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->