### PR TITLE
docs: remove stale prefills references

### DIFF
--- a/docs/.vitepress/components/AgentYamlHero.vue
+++ b/docs/.vitepress/components/AgentYamlHero.vue
@@ -5,7 +5,7 @@
 // right of each key explaining its role. Standalone (no MockupFrame) — just the
 // focused code card. Keys use --mk-syn-keyword, template vars are --mk-accent
 // chips, values are plain mono text. Mirrors the prose of the YAML-structure
-// section (agentCategory / prefills / systemPrompt / userPrefix / userRequest).
+// section (agentCategory / systemPrompt / userPrefix / userRequest).
 //
 // The root carries `.mockup` so the shared `--mk-*` colour + dimensional tokens
 // resolve here and the card flips cleanly between the docs light / dark themes.
@@ -30,13 +30,6 @@ import MockCard from './MockCard.vue';
           ><span class="kw">agentCategory</span>: workflow</code
         >
         <span class="yh-note">workflow vs toolUse</span>
-      </div>
-      <div class="yh-line indent">
-        <code class="yh-code"
-          ><span class="kw">prefills</span>:
-          <span class="tag">&lt;scratchpad&gt;</span></code
-        >
-        <span class="yh-note">starts every response</span>
       </div>
       <div class="yh-line indent">
         <code class="yh-code"

--- a/docs/guide/agent-architecture.md
+++ b/docs/guide/agent-architecture.md
@@ -33,7 +33,6 @@ These `.yaml` files have two main parts (and thankfully, YAML is usually less pr
 
 1.  **`settings`**: Define general operational parameters. For example:
     - `agentCategory`: Is it a `workflow` agent (structured Chain-of-Thought reasoning with XML-wrapped output) or a `toolUse` agent (interactive conversation that can call tools like file editing, web search, etc.)?
-    - `prefills`: Text the agent should automatically start its response with (e.g., `<scratchpad>`).
     - _(Other settings control output format, inheritance, etc. See [Configuration](./configuration.md) and [Custom Agents](./custom-agents.md) for full details)._
 2.  **`prompts`**: Contain text templates that TeXRA fills with your specific context (input files, instructions) to guide the LLM at different stages:
     - `systemPrompt`: Sets the overall role and high-level instructions for the LLM.

--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -73,10 +73,6 @@ settings:
   # Output Handling
   documentTag: documents # The main XML tag wrapping the agent's final output (defaults to `documents`).
   endTag: '</documents>' # The closing tag that signals the agent has finished its main output.
-  prefills:
-    - "<documents>\n" # List of strings the AI should start its response(s) with.
-      # Item [0] is for Round 0, Item [1] is for Round 1 (reflection).
-      # Crucial for models needing specific start formats (e.g., XML tags).
 
   # File Handling (Optional - Advanced)
   # requiredFiles:

--- a/packages/extension/resources/docs/agent-creation/workflow_schema.md
+++ b/packages/extension/resources/docs/agent-creation/workflow_schema.md
@@ -39,9 +39,6 @@ prompts:
 
 - `userRequest` MUST have the same number of entries as `rounds`. Round 1
   → one entry; round 2 → two entries.
-- Do NOT emit `prefills`. The field is deprecated --- reasoning models
-  ignore it at runtime, and other models do fine when the userRequest
-  spells out the expected `<documents>...</documents>` wrapper.
 - Always include `{{ INSTRUCTION }}` somewhere so user instructions pass
   through.
 - System prompts should use LaTeX formatting (`\begin{itemize}`,


### PR DESCRIPTION
## Summary

Removes the stale `prefills` setting from published agent docs now that PR #7114 removed the field from runtime schemas and agent plumbing. The public guide no longer lists `prefills`, the custom-agent YAML example no longer teaches it, and the YAML hero mock card no longer shows it as a working setting.

I also removed the optional stale "Do NOT emit `prefills`" reminder from the packaged workflow-agent creation docs, since the field is gone and no longer needs a generation warning.

## Issue acceptance gates

- Addresses #7118.
- Re-verified every cited doc site before implementation.
- Removed the published `prefills` setting reference from `docs/guide/agent-architecture.md`.
- Removed the worked `prefills:` YAML example and surrounding stale prose from `docs/guide/custom-agents.md`.
- Removed the `prefills` mock line and top-file comment reference from `docs/.vitepress/components/AgentYamlHero.vue`.
- Removed the optional stale workflow-schema reminder in `packages/extension/resources/docs/agent-creation/workflow_schema.md`.
- Verified the affected files have no remaining `prefills`, `starts every response`, or `specific start formats` matches.

## Single source of truth

The current agent schema/runtime remains the source of truth: `prefills` is not a supported agent setting. The published docs now describe prompt/output structure through `documentTag`, `endTag`, and `userRequest` rather than a removed field.

## Duplication and abstraction budget

Removed stale duplicate documentation for a setting that runtime now strips as legacy. No abstraction added; this PR is net-negative in lines.

## Host impact

Extension: no runtime change; packaged agent-creation docs no longer mention `prefills`.

Desktop: none.

CLI: none.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write docs/guide/agent-architecture.md docs/guide/custom-agents.md docs/.vitepress/components/AgentYamlHero.vue packages/extension/resources/docs/agent-creation/workflow_schema.md`
- `rg -n 'prefills|starts every response|specific start formats' docs/guide/agent-architecture.md docs/guide/custom-agents.md docs/.vitepress/components/AgentYamlHero.vue packages/extension/resources/docs/agent-creation/workflow_schema.md` (no matches)
- `git diff --check`
- `npm run typecheck`
- `npm run lint` (passed with the repository's existing 15 warnings)
- `npm run compile:fast`
- `npm test`
- `npm ci --legacy-peer-deps` in `docs/`
- `npm run docs:build` in `docs/` (passed; VitePress emitted the existing large-chunk warning)

Closes #7118

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime, auth, or data-path changes.
> 
> **Overview**
> Aligns published agent documentation with runtime after **`prefills`** was removed from schemas and plumbing.
> 
> The **agent architecture** guide no longer lists `prefills` under `settings`. The **custom agents** YAML example drops the `prefills:` block and related comments. The **AgentYamlHero** mock card and its header comment no longer show `prefills` as a working setting. Packaged **workflow agent creation** docs drop the “do not emit `prefills`” critical rule, since the field is gone.
> 
> Docs now steer authors toward **`documentTag`**, **`endTag`**, and **`userRequest`** (including scratchpad / XML wrapper guidance) for output shape instead of a removed setting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fbf2e618897b24ce6d39d3d5a30f064d505f44e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->