### PR TITLE
docs: fix stale AGENTS.md common/state/ path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ aliases until a future SDK surface is enforced with a build and import-boundary 
   - `frontend/latex/` - LaTeX build integration, linting
   - `frontend/media/` - Image and audio handling
 - `src/common/` holds backend-only helpers (errors, state, files, base webview classes). Import them through the `@common/*` alias for clarity.
-  - `common/state/` - State managers including `pendingStateManager`
+  - `packages/extension/src/common/state/` - State managers including `pendingStateManager`
   - `common/webview/` - Base classes (`BaseViewContentProvider`, `BaseViewMessageHandler`), webview HTML builder (`buildWebviewHtml`), command constants
 - `src/utils/` is reserved for utilities used by both the extension host and webviews. If a helper is specific to one side, place it under `frontend/` or `common/` instead of `utils/`.
   - `utils/core/` - Async, type-guard, math, comparator, and URL primitives (`debounce`, `delay`, `filterNotNull`, `clamp`, `byName`, `tryParseUrl`); re-exports string primitives from `utils/text/stringUtils` for browser-safe barrel access

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,9 +82,10 @@ aliases until a future SDK surface is enforced with a build and import-boundary 
   - `frontend/files/` - File lister and discovery utilities
   - `frontend/latex/` - LaTeX build integration, linting
   - `frontend/media/` - Image and audio handling
-- `src/common/` holds backend-only helpers (errors, state, files, base webview classes). Import them through the `@common/*` alias for clarity.
+- `src/common/` holds backend-only helpers (errors, files, parsing, storage, constants). Import them through the `@common/*` alias for clarity.
+- `packages/extension/src/common/` holds extension-only helpers (state managers, webview base classes):
   - `packages/extension/src/common/state/` - State managers including `pendingStateManager`
-  - `common/webview/` - Base classes (`BaseViewContentProvider`, `BaseViewMessageHandler`), webview HTML builder (`buildWebviewHtml`), command constants
+  - `packages/extension/src/common/webview/` - Base classes (`BaseViewContentProvider`, `BaseViewMessageHandler`), webview HTML builder (`buildWebviewHtml`), command constants
 - `src/utils/` is reserved for utilities used by both the extension host and webviews. If a helper is specific to one side, place it under `frontend/` or `common/` instead of `utils/`.
   - `utils/core/` - Async, type-guard, math, comparator, and URL primitives (`debounce`, `delay`, `filterNotNull`, `clamp`, `byName`, `tryParseUrl`); re-exports string primitives from `utils/text/stringUtils` for browser-safe barrel access
   - `utils/files/` - Filesystem utilities, rules, and vars


### PR DESCRIPTION
Closes #7124

AGENTS.md's directory-organization section described `common/state/` as a subdirectory of repo-root `src/common/`, but that directory does not exist there — only `constants/`, `errors/`, `files/`, `parsing/`, `storage/`, and `schemas.ts` live under repo-root `src/common/`.

The actual state managers (`stateManager.ts`, `pendingStateManager.ts`, `worktreeMemento.ts`, barrel `index.ts`) live at `packages/extension/src/common/state/`. This PR updates the bullet to reflect that path, mirroring the equivalent fix already applied to CLAUDE.md by #6893.

Docs-only change; `npm run typecheck` passes and there's no runtime surface to test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no code, build, or runtime behavior changes.
> 
> **Overview**
> **AGENTS.md**’s directory-organization section no longer lists `common/state/` and `common/webview/` under repo-root `src/common/`.
> 
> It now documents repo-root **`src/common/`** as backend-only helpers (errors, files, parsing, storage, constants) and **`packages/extension/src/common/`** as extension-only code, with **`state/`** (including `pendingStateManager`) and **`webview/`** base classes under that package path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7ca332cc095b677acc87ef8f0da82e2ec2a98f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->