### PR TITLE
[codex] record architecture checkpoint a

### DIFF
--- a/docs/proposals/agent-sdk-readiness-checkpoint-2026-07-05.md
+++ b/docs/proposals/agent-sdk-readiness-checkpoint-2026-07-05.md
@@ -116,15 +116,14 @@ sweep.
 
 ### Core / runtime
 
-1. **`StreamStatusMachine as StreamStatusRegistry` test-only alias** _(LOW)_.
-   `src/agent/runtime/StreamStatusService.ts:303` re-exports the same-file class
-   under a legacy name consumed **only** by ~10 test-kernel vitest files; no
-   production code uses `StreamStatusRegistry`. Per CLAUDE.md ("update tests to use
-   the underlying type directly rather than through wrappers") the alias can be
-   dropped once the tests are repointed to `StreamStatusMachine`. Not a pure
-   deletion — it touches the test suite, so reviewed-train. (Distinct from the
-   `StreamStatusRegistry.onDidChange` module-subscription item already tracked in
-   the detailed audit §; that references the pre-rename name.)
+1. **`StreamStatusMachine as StreamStatusRegistry` test-only alias** _(LOW;
+   resolved by Checkpoint A, 2026-07-05)_. This checkpoint originally found
+   `src/agent/runtime/StreamStatusService.ts:303` re-exporting the same-file
+   class under a legacy name consumed **only** by test-kernel vitest files; no
+   production code used `StreamStatusRegistry`. Checkpoint A repointed the tests
+   to `StreamStatusMachine` and deleted the alias. (Distinct from the
+   `StreamStatusRegistry.onDidChange` module-subscription item already tracked
+   in the detailed audit §; that references the pre-rename name.)
 
 2. **`executionRegistry.ts` handle re-export facade** _(LOW — arguable, keep)_.
    `executionRegistry.ts:41-50` surfaces `ExecutionHandle` / `AgentExecutionHandle`
@@ -252,11 +251,11 @@ typecheck + lint + routing test green), a pure-deletion the 07-03 fan-out missed
 in the same class as that pass's `PersistedFlow.attach`/`getRunId` deletion.
 Everything else the fresh audit surfaced is reviewed-train (port narrowing incl.
 the `*WithPrefill` collapse and the auto-retry-ownership merge, the
-`StreamStatusRegistry` alias drop, the `formatChatAsHtml` / `@logger` surface
-coherence, the strategic Google-handler consolidation) — fold these into the
-canonical plan's surface / multi-tenant track through the reviewed PR train. Do
-not re-open the adjudicated traps, and do not sweep the reviewed-train items
-unattended.
+`formatChatAsHtml` / `@logger` surface coherence, the strategic Google-handler
+consolidation). The `StreamStatusRegistry` alias drop has since landed through
+Checkpoint A. Fold the remaining items into the canonical plan's surface /
+multi-tenant track through the reviewed PR train. Do not re-open the adjudicated
+traps, and do not sweep the remaining reviewed-train items unattended.
 
 ## Verified (this checkpoint)
 
@@ -276,12 +275,13 @@ unattended.
 - Change verified green: `npm run typecheck` **exit 0** (all four projects);
   `eslint` on the three changed files clean; `npx vitest run
 ModelFactoryRouting.vitest.ts` — **36 passed**.
-- New candidates verified in-tree: `StreamStatusMachine as StreamStatusRegistry`
-  (`StreamStatusService.ts:303`, test-only importers); `*WithPrefill`/`*WithoutPrefill`
-  pairs (`IModelHandler.ts:289-331`, sole caller `ResponseCycleFlow.ts:418/582`);
-  auto-retry pair (`IModelHandler.ts:226/233`, caller `ModelInvocationNode.ts:81`);
-  `formatChatAsHtml` deep-imported around `chatExportFormatter.ts`; `@logger`
-  barrel 25 importers vs ~70 `logUtils` / deep `redaction` imports.
+- New candidates verified in-tree at checkpoint time: the now-resolved
+  `StreamStatusMachine as StreamStatusRegistry` alias; `*WithPrefill` /
+  `*WithoutPrefill` pairs (`IModelHandler.ts:289-331`, sole caller
+  `ResponseCycleFlow.ts:418/582`); auto-retry pair (`IModelHandler.ts:226/233`,
+  caller `ModelInvocationNode.ts:81`); `formatChatAsHtml` deep-imported around
+  `chatExportFormatter.ts`; `@logger` barrel 25 importers vs ~70 `logUtils` /
+  deep `redaction` imports.
 - PR-train non-interference confirmed: `git diff --stat` since the last-known
 spine over `ModelFactory.ts` / `IModelHandler.ts` / `src/logger` /
 then-current `packages/core/src/index.ts` / `src/agent/trace` shows only the #7073

--- a/docs/proposals/architecture-checkpoints-2026.md
+++ b/docs/proposals/architecture-checkpoints-2026.md
@@ -1,0 +1,151 @@
+# Architecture Checkpoints (2026)
+
+> **Status:** Running checkpoint record for the 2026-07 architecture and
+> foundation debt program. Checkpoints append sections here; they do not create
+> one-off checkpoint files.
+
+Sources of truth for the current program:
+
+- [`tech-debt-audit-2026-07.md`](./tech-debt-audit-2026-07.md)
+- [`session-scoped-runtime-architecture.md`](./session-scoped-runtime-architecture.md)
+- GitHub trackers #6951, #6953, and #6981.
+
+## 2026-07-05 - Checkpoint A after stages 0-2
+
+**Verdict:** Stage 3 remains a correctness track, not pre-payment. The
+maintainer pre-flight answer recorded on #6978 is to "do the wisest thing" for
+desktop; this checkpoint interprets that as multi-window desktop being
+supported/intended unless current code proves it mechanically impossible.
+Current code supports the go decision: each desktop progress bridge constructs a
+fresh `SessionHandle` for its BrowserWindow
+(`packages/desktop/src/main/desktopAgentExecution.ts:232`), while
+cross-window active-execution aggregation is explicit
+(`src/agent/runtime/SessionHandle.ts:254`).
+
+Stages 3a, 3b, and 3c should proceed in parallel after #6978 lands. Stage 4 and
+F2 stay coupled behind Checkpoint B (#6979). Foundation Checkpoint C (#6980) is
+absorbed by this pass and should close when #6978 lands.
+
+### Re-verified Evidence
+
+- **L1 still live:** `createRunTrace` still defaults to the process default
+  stream-log store (`src/transcript/runTrace.ts:32`), and every
+  `ProgressViewState` constructor still installs its store as that default
+  (`src/shared/progressView/backend/state/ProgressViewState.ts:155`). The
+  default getter/setter live at `src/transcript/StreamLogStore.ts:824`.
+- **L2 still live:** each desktop backend subscribes to the process bus
+  (`packages/desktop/src/main/desktopAgentExecution.ts:299`), and desktop
+  runtime events still hit `bus.emit` before the per-window bridge
+  (`packages/desktop/src/main/desktopAgentExecution.ts:851`).
+- **L3 drifted but still live:** `StreamStatusService` is now the process
+  default `StreamStatusMachine`, not the old registry alias
+  (`src/agent/runtime/StreamStatusService.ts:303`). Delete-all still clears a
+  window's status view through its backend state
+  (`src/shared/progressView/backend/state/ProgressViewState.ts:343`).
+- **Child-stream activation ordering is no longer active evidence:** #6993
+  fixed the ordering. Child streams now attach session trace/projector
+  subscribers before activation (`src/tools/childStream.ts:83`) and assert that
+  before emitting `setActiveStream` / `setTaskState`
+  (`src/tools/childStream.ts:98`).
+- **Stage 3a remains scoped to the remaining registry/process-output bus facts:**
+  child parent/status facts are still emitted from
+  `src/agent/runtime/executionRegistry.ts:203` and `:678`; process output still
+  emits `updateProcessOutput` at `src/agent/runtime/ProcessOutputPoller.ts:88`
+  and `:216`.
+- **Stage 3b citation drift:** `handleSetTaskState` still carries run-start
+  side effects, but the old O(N) metadata rebuild has already been narrowed to
+  a single-stream metadata patch (`src/shared/progressView/backend/events/ProgressEventHandler.ts:373`).
+  The remaining work is moving hint clear, stream-state ensure, finished-child
+  reset, interrupt prune, and the single-stream patch onto the `-> running`
+  transition.
+- **Round encoding still has three surfaces:** reflection stages still use
+  `r<N>` labels (`src/agent/implementations/flows/reflection/runReflectionFlow.ts:262`),
+  `ExecutionProgress` is produced in `src/agent/runtime/executeAgent.ts:103`,
+  and the round/turn half of `conversationProgress` is emitted from
+  `src/agent/runtime/executeAgent.ts:126` / `:171` and projected by
+  `src/agent/runtime/conversationProgressHub.ts:31`.
+- **Stage 3c citation drift:** `detectWaitingStreams` moved to
+  `src/agent/storage/detectWaitingStreams.ts:59`; desktop restart repair lives
+  at `packages/desktop/src/main/desktopAgentExecution.ts:753` with the catch
+  fallback at `:803`; `ExecutionKVStore`'s warn-vs-null read policy lives at
+  `src/agent/storage/ExecutionKVStore.ts:192`.
+- **Tab deletion scope corrected:** `ProgressViewState.clearStream` still
+  deletes stream logs and stream data but not `executions/{id}`
+  (`src/shared/progressView/backend/state/ProgressViewState.ts:322`). Goal
+  entries are now explicitly forgotten by the extension and desktop delete
+  paths, so Stage 3c should keep that as regression coverage rather than cite it
+  as an open leak.
+
+### Simplification And Ledger
+
+- The now test-only `StreamStatusRegistry` compatibility alias was deleted in
+  this checkpoint. Tests now import `StreamStatusMachine` directly, and
+  `rg StreamStatusRegistry src packages` is empty.
+- Stage 2.5 already removed the `clearRunningSubstate` second write path; the
+  only production `phases.set` writer in the status machine is the transition
+  path (`src/agent/runtime/StreamStatusService.ts:135`).
+- The Stage 1 `SessionRunFactProjector` remains live migration scaffolding:
+  launch still attaches it (`src/agent/runtime/AgentLaunchContext.ts:343`), and
+  Stage 5 owns its deletion with the bus keys.
+- #7042's storage-layout alias hop has fired and was executed. The old
+  production names `TASK_RUNS_DIR`, `MEMORY_STORAGE_ROOT`, and
+  `LEGACY_RUNS_DIR` grep to zero; canonical exports are
+  `RUNS_STORAGE_DIR` / `MEMORY_STORAGE_DIR`
+  (`src/platform/defaults/workspaceStorage.ts:18`), with the legacy run fallback
+  still explicit (`src/platform/defaults/workspaceStorage.ts:85`).
+- The #7043 `src/shared/toolUse.ts:85` legacy `isError` sniff is already in
+  #6981 with an age-based D3 trigger. It stays until pre-F5 persisted
+  tool-use logs are outside support.
+- No Stage 0 tier-3/tier-4 shim trigger has fired. Those rows remain active
+  until Stage 5 and the age windows named in #6981.
+
+Temporary hop deleted since Stage 0: the F9 storage-layout alias/bypass hop
+from #7042, plus the Stage 2 `StreamStatusRegistry` alias in this PR. The answer
+is not "none."
+
+### Census
+
+Counts are from current `main` at `509fdbe6c` plus the alias deletion in this
+checkpoint where noted.
+
+- Pass-through methods: baseline 33 / 10 files; current 35 / 10 files. Raw
+  count is +2. Inspected hits are boundary/adaptor wrappers or scheduled owners
+  (`InterruptRegistry`, progress backend, host secrets/storage). No extra
+  deletion is safe inside #6978; Stage 3 PRs must be net-negative on this meter.
+- Identity wrappers: baseline 9; current 13 by the strict named-function meter.
+  Raw count is +4. The excess is mostly named dependency or UI helper
+  boundaries; do not churn in this checkpoint.
+- Re-export-only barrels: baseline 23; current 49 by a repo-wide `index.ts`
+  export-only scan. The wider scan includes host/frontend package barrels absent
+  from the original targeted meter. No new barrels in Stage 3; delete touched
+  empty or compatibility barrels only.
+- `ensureRoundData` refs: baseline 14; current 14 non-test refs.
+  Non-increasing. Stage 3b remains responsible for collapsing this toward the
+  round owner.
+- `syncStream*` refs: baseline ~100; current 50 non-test refs for
+  `syncStreamLog`, `syncFullView`, `syncStreamContent`, and `syncStream`.
+  Decreased. Stage 3a/3c should keep this non-increasing while transferring
+  ownership, not wrapping it.
+
+The raw width meters are warnings, not permission to add more width. For the
+next three stage PRs, the acceptance bar is: no new pass-through layers, no new
+barrels, and a stated count delta for any touched meter.
+
+### Remaining Order
+
+1. Stage 3a (#6964): session facts, child/process arms, session-owned
+   transcripts/follow-ups. Use the corrected child-stream and follow-up citations
+   above; do not re-litigate #6993's ordering fix.
+2. Stage 3b (#6965): `RunDescriptor`, config persistence, and typed round
+   stages. Treat the metadata-patch O(N) claim as stale; the side effect is now a
+   per-stream patch.
+3. Stage 3c (#6966): persistence facade, atomic delete, orphan sweep,
+   `deriveResumability`, and shared restart repair. Split by task bullets if the
+   PR gets too large.
+4. Checkpoint B (#6979): mandatory before Stage 4. It owns the Stage 4 + F2
+   combined plan for `desktopAgentExecution.ts` and the two message handlers.
+5. Stage 4 (#6967), then Stage 5 (#6968). F6 (#6976) waits until Stages 3a-3c
+   have landed. F2 (#6972) waits for Checkpoint B's combined plan.
+
+Next periodic checkpoint trigger: #6979 after Stages 3a-3c land, or
+2026-07-12 if Stage 3 is still open and more hardening merges have accumulated.

--- a/docs/proposals/session-scoped-runtime-architecture.md
+++ b/docs/proposals/session-scoped-runtime-architecture.md
@@ -1,7 +1,7 @@
 # Session-scoped runtime architecture: facts, interactions, and status ownership
 
-> **Status:** Partially landed proposal (Stages 0-2; status refreshed
-> 2026-07-04). Companion to the diagnosis in
+> **Status:** Partially landed proposal (Stages 0-2 plus Checkpoint A; status
+> refreshed 2026-07-05). Companion to the diagnosis in
 > `tech-debt-audit-2026-07.md` (Part B1/B5 + appendix); this document is the
 > target design. It covers the event/logger chain, the
 > approval/interaction RPC machinery, stream status, and the execution registries
@@ -772,11 +772,11 @@ ordering they force:
   trace→bus and others still emit directly, relative order between two
   related facts can invert. Stages therefore migrate whole fact _clusters_
   (e.g. status+result together), never half of a causally-linked pair.
-- **Multi-window desktop reality check.** L1–L3's "live bug" severity
-  assumes >1 `DesktopAgentExecution` per process actually ships. The
-  per-window session comments say yes, but verify before paying stages 3–5;
-  if single-window, those stages are pre-payment for a planned feature and
-  should be re-prioritized honestly.
+- **Multi-window desktop reality check.** Checkpoint A recorded the maintainer
+  pre-flight answer on 2026-07-05: for desktop, do the wisest thing. The
+  checkpoint treats multi-window desktop as supported/intended unless current
+  code proves it mechanically impossible, so L1–L3 remain correctness work for
+  stages 3–5 rather than pre-payment.
 - **Collision with the active PR train.** This branch was force-updated
   mid-audit by concurrent maintainer work; the program only works as small,
   independently shippable PRs per stage — a long-lived refactor branch

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -300,6 +300,4 @@ export class StreamStatusMachine {
   }
 }
 
-export { StreamStatusMachine as StreamStatusRegistry };
-
 export const StreamStatusService = new StreamStatusMachine();

--- a/src/test-kernel/agent/followUp/ToolUseRoundFollowUpMedia.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseRoundFollowUpMedia.vitest.ts
@@ -13,7 +13,7 @@ import {
 import { MapToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
+import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import { withTestRunContext } from '../progressTestUtils';
 
 describe('ToolUseRoundFlow queued follow-ups', () => {
@@ -59,7 +59,7 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
       },
       setAbortController: () => {},
       setting: { temperature: 0, tools: [] },
-      streamStatus: new StreamStatusRegistry(),
+      streamStatus: new StreamStatusMachine(),
       toolRegistry: new MapToolRegistry({}),
       userVarChannels: { input: {}, transient: {} },
       workspace: AgentWorkspaceState.create(),
@@ -203,7 +203,7 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
       },
       setAbortController: () => {},
       setting: { temperature: 0, tools: [{ name: 'again' }] },
-      streamStatus: new StreamStatusRegistry(),
+      streamStatus: new StreamStatusMachine(),
       toolRegistry: new MapToolRegistry({
         again: {
           call: vi.fn(async () => ({

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -16,7 +16,7 @@ import {
 } from '@agent/implementations/flows/tooluse/nodes/types';
 import type { ToolUseServices } from '@agent/implementations/flows/tooluse/ToolUseServices';
 import {
-  StreamStatusRegistry,
+  StreamStatusMachine,
   StreamStatusService,
 } from '@agent/runtime/StreamStatusService';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
@@ -61,7 +61,7 @@ describe('ToolUseWaitNode', () => {
           return null;
         },
       },
-      streamStatus: new StreamStatusRegistry(),
+      streamStatus: new StreamStatusMachine(),
       streamId: 'test-stream',
     } as unknown as ToolUseServices;
 
@@ -121,7 +121,7 @@ describe('ToolUseWaitNode', () => {
           return null;
         },
       },
-      streamStatus: new StreamStatusRegistry(),
+      streamStatus: new StreamStatusMachine(),
       streamId: 'test-stream',
     } as unknown as ToolUseServices;
 
@@ -175,7 +175,7 @@ describe('ToolUseWaitNode', () => {
         hasQueuedFollowUp: () => false,
         waitForFollowUp: vi.fn(),
       },
-      streamStatus: new StreamStatusRegistry(),
+      streamStatus: new StreamStatusMachine(),
       streamId: 'test-stream',
     } as unknown as ToolUseServices;
 
@@ -221,7 +221,7 @@ describe('ToolUseWaitNode', () => {
         createUserFollowUpMessages: vi.fn(async () => []),
       },
       runtimeHost,
-      streamStatus: new StreamStatusRegistry(),
+      streamStatus: new StreamStatusMachine(),
       streamId: 'test-stream',
     } as unknown as ToolUseServices;
 
@@ -295,7 +295,7 @@ describe('ToolUseWaitNode', () => {
       },
       stopAfterCycle: true,
       streamId,
-      streamStatus: new StreamStatusRegistry(),
+      streamStatus: new StreamStatusMachine(),
     } as unknown as ToolUseServices;
     const node = new ToolUseWaitNode().setServices(services);
 
@@ -352,7 +352,7 @@ describe('ToolUseWaitNode', () => {
     );
     const onFollowUpConsumed = vi.fn();
     const waitForFollowUp = vi.fn();
-    const streamStatus = new StreamStatusRegistry();
+    const streamStatus = new StreamStatusMachine();
     const runtimeHost = { emit: vi.fn() };
     const services = {
       checkInterruption: () => false,
@@ -454,7 +454,7 @@ describe('ToolUseWaitNode', () => {
         waitForFollowUp,
       },
       streamId,
-      streamStatus: new StreamStatusRegistry(),
+      streamStatus: new StreamStatusMachine(),
     } as unknown as ToolUseServices;
     const node = new ToolUseWaitNode().setServices(services);
 
@@ -522,7 +522,7 @@ describe('ToolUseWaitNode', () => {
         waitForFollowUp,
       },
       streamId,
-      streamStatus: new StreamStatusRegistry(),
+      streamStatus: new StreamStatusMachine(),
     } as unknown as ToolUseServices;
     const node = new ToolUseWaitNode().setServices(services);
 
@@ -567,7 +567,7 @@ describe('ToolUseWaitNode', () => {
         waitForFollowUp,
       },
       streamId,
-      streamStatus: new StreamStatusRegistry(),
+      streamStatus: new StreamStatusMachine(),
     } as unknown as ToolUseServices;
     const node = new ToolUseWaitNode().setServices(services);
 
@@ -591,7 +591,7 @@ describe('ToolUseWaitNode', () => {
 
   it('updates the injected stream status owner while waiting and resuming', async () => {
     const streamId = 'wait-node-owner' as StreamTabId;
-    const streamStatus = new StreamStatusRegistry();
+    const streamStatus = new StreamStatusMachine();
     const shared: ToolUseRunShared = {
       messages: [],
       shouldSkipCycle: false,
@@ -648,7 +648,7 @@ describe('ToolUseWaitNode', () => {
 
   it('repairs retry-cancelled parent cycles to waiting before blocking', async () => {
     const streamId = 'wait-node-retry-cancelled-wait' as StreamTabId;
-    const streamStatus = new StreamStatusRegistry();
+    const streamStatus = new StreamStatusMachine();
     const runtimeHost = { emit: vi.fn() };
     const waitForFollowUp = vi.fn(async () => null);
     const services = {
@@ -716,7 +716,7 @@ describe('ToolUseWaitNode', () => {
     );
     const info = vi.fn();
     const runtimeHost = { emit: vi.fn() };
-    const streamStatus = new StreamStatusRegistry();
+    const streamStatus = new StreamStatusMachine();
     const services = {
       checkInterruption: () => false,
       logger: { emit: vi.fn(), error: vi.fn(), info },

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -16,7 +16,7 @@ import {
 } from '@agent/core/definition/AgentDataclass';
 import { AgentProposalCoordinator } from '@agent/runtime/AgentProposalCoordinator';
 import {
-  StreamStatusRegistry,
+  StreamStatusMachine,
   StreamStatusService,
 } from '@agent/runtime/StreamStatusService';
 import { executionRegistry } from '@agent/runtime/executionRegistry';
@@ -72,7 +72,7 @@ function createLifecycleContext({
 }: {
   executionId: ExecutionId;
   streamId: StreamTabId;
-  streamStatus: StreamStatusRegistry;
+  streamStatus: StreamStatusMachine;
   agent?: string;
 }): {
   ctx: AgentLaunchContext;
@@ -155,13 +155,13 @@ function lifecycleFixture(
 ): {
   executionId: ExecutionId;
   streamId: StreamTabId;
-  streamStatus: StreamStatusRegistry;
+  streamStatus: StreamStatusMachine;
   ctx: AgentLaunchContext;
   explicit: ReturnType<typeof createRecordingHost>;
 } {
   const executionId = `execution-${slug}` as ExecutionId;
   const streamId = `stream-${slug}` as StreamTabId;
-  const streamStatus = new StreamStatusRegistry();
+  const streamStatus = new StreamStatusMachine();
   const { ctx, explicit } = createLifecycleContext({
     executionId,
     streamId,

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -11,7 +11,7 @@ import {
 } from '@agent/runtime/executionRegistry';
 import { InterruptRegistry } from '@agent/runtime/InterruptRegistry';
 import { ProcessOutputPoller } from '@agent/runtime/ProcessOutputPoller';
-import { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
+import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import { STREAM_PHASE, STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 
 import { createRecordingHost } from '../progressTestUtils';
@@ -41,7 +41,7 @@ describe('executionRegistry', () => {
   it('uses its interrupt registry when terminating agent handles', () => {
     const explicit = createRecordingHost();
     const interrupts = new InterruptRegistry();
-    const streamStatus = new StreamStatusRegistry();
+    const streamStatus = new StreamStatusMachine();
     const registry = new ExecutionRegistry({ interrupts, streamStatus });
     const executionId = 'exec-injected-interrupt-test';
     const parentStreamId = 'parent-injected-interrupt-test' as StreamTabId;
@@ -73,7 +73,7 @@ describe('executionRegistry', () => {
   it('owns visible stream stop policy for root and children', () => {
     const explicit = createRecordingHost();
     const interrupts = new InterruptRegistry();
-    const streamStatus = new StreamStatusRegistry();
+    const streamStatus = new StreamStatusMachine();
     const registry = new ExecutionRegistry({ interrupts, streamStatus });
     const rootStreamId = 'root-stop-policy-test' as StreamTabId;
     const childStreamId = 'child-stop-policy-test' as StreamTabId;
@@ -137,7 +137,7 @@ describe('executionRegistry', () => {
   it('interrupts grandchildren when killing a subagent chain', () => {
     const explicit = createRecordingHost();
     const interrupts = new InterruptRegistry();
-    const streamStatus = new StreamStatusRegistry();
+    const streamStatus = new StreamStatusMachine();
     const registry = new ExecutionRegistry({ interrupts, streamStatus });
     const rootStreamId = 'root-cascade-test' as StreamTabId;
     const childStreamId = 'child-cascade-test' as StreamTabId;
@@ -187,7 +187,7 @@ describe('executionRegistry', () => {
   it('detaches descendants when killing with detached subagents', () => {
     const explicit = createRecordingHost();
     const interrupts = new InterruptRegistry();
-    const streamStatus = new StreamStatusRegistry();
+    const streamStatus = new StreamStatusMachine();
     const registry = new ExecutionRegistry({ interrupts, streamStatus });
     const rootStreamId = 'root-detach-kill-test' as StreamTabId;
     const childStreamId = 'child-detach-kill-test' as StreamTabId;
@@ -251,7 +251,7 @@ describe('executionRegistry', () => {
   it('detaches children when stopping a stream with detached subagents', () => {
     const explicit = createRecordingHost();
     const interrupts = new InterruptRegistry();
-    const streamStatus = new StreamStatusRegistry();
+    const streamStatus = new StreamStatusMachine();
     const registry = new ExecutionRegistry({ interrupts, streamStatus });
     const rootStreamId = 'root-detach-stop-policy-test' as StreamTabId;
     const childStreamId = 'child-detach-stop-policy-test' as StreamTabId;
@@ -342,7 +342,7 @@ describe('executionRegistry', () => {
   it('stops a registered stream before its execution handle is tracked', () => {
     const explicit = createRecordingHost();
     const interrupts = new InterruptRegistry();
-    const streamStatus = new StreamStatusRegistry();
+    const streamStatus = new StreamStatusMachine();
     const registry = new ExecutionRegistry({ interrupts, streamStatus });
     const streamId = 'untracked-stop-policy-test' as StreamTabId;
     const interrupt = vi.fn();
@@ -372,7 +372,7 @@ describe('executionRegistry', () => {
 
   it('marks an ownerless stream stopped when a host can publish status', () => {
     const explicit = createRecordingHost();
-    const streamStatus = new StreamStatusRegistry();
+    const streamStatus = new StreamStatusMachine();
     const registry = new ExecutionRegistry({ streamStatus });
     const streamId = 'ownerless-stop-policy-test' as StreamTabId;
 
@@ -396,7 +396,7 @@ describe('executionRegistry', () => {
   });
 
   it('reports no target when no execution, interrupt, or host owns the stream', () => {
-    const streamStatus = new StreamStatusRegistry();
+    const streamStatus = new StreamStatusMachine();
     const registry = new ExecutionRegistry({ streamStatus });
     const streamId = 'missing-stop-target-test' as StreamTabId;
 
@@ -414,7 +414,7 @@ describe('executionRegistry', () => {
 
   it('reports agent status from its stream-status owner', () => {
     const explicit = createRecordingHost();
-    const streamStatus = new StreamStatusRegistry();
+    const streamStatus = new StreamStatusMachine();
     const registry = new ExecutionRegistry({ streamStatus });
     const parentStreamId = 'parent-owned-status-test' as StreamTabId;
     const childStreamId = 'child-owned-status-test' as StreamTabId;
@@ -450,7 +450,7 @@ describe('executionRegistry', () => {
 
   it('publishes initial status when tracking an agent execution', () => {
     const explicit = createRecordingHost();
-    const streamStatus = new StreamStatusRegistry();
+    const streamStatus = new StreamStatusMachine();
     const registry = new ExecutionRegistry({ streamStatus });
     const parentStreamId = 'parent-track-agent-status-test' as StreamTabId;
     const childStreamId = 'child-track-agent-status-test' as StreamTabId;
@@ -483,7 +483,7 @@ describe('executionRegistry', () => {
 
   it('updates live agent status without reviving stopped or stale handles', () => {
     const explicit = createRecordingHost();
-    const streamStatus = new StreamStatusRegistry();
+    const streamStatus = new StreamStatusMachine();
     const registry = new ExecutionRegistry({ streamStatus });
     const parentStreamId = 'parent-update-agent-status-test' as StreamTabId;
     const childStreamId = 'child-update-agent-status-test' as StreamTabId;
@@ -538,7 +538,7 @@ describe('executionRegistry', () => {
 
   it('finishes agent executions without overwriting explicit stops', () => {
     const explicit = createRecordingHost();
-    const streamStatus = new StreamStatusRegistry();
+    const streamStatus = new StreamStatusMachine();
     const registry = new ExecutionRegistry({ streamStatus });
     const parentStreamId = 'parent-finish-agent-status-test' as StreamTabId;
     const childStreamId = 'child-finish-agent-status-test' as StreamTabId;
@@ -573,7 +573,7 @@ describe('executionRegistry', () => {
 
   it('finishes waiting agent executions through a lifecycle terminal phase', () => {
     const explicit = createRecordingHost();
-    const streamStatus = new StreamStatusRegistry();
+    const streamStatus = new StreamStatusMachine();
     const registry = new ExecutionRegistry({ streamStatus });
     const parentStreamId = 'parent-finish-waiting-agent-test' as StreamTabId;
     const childStreamId = 'child-finish-waiting-agent-test' as StreamTabId;
@@ -619,7 +619,7 @@ describe('executionRegistry', () => {
 
   it('can finish an agent execution from its handle after untracking', () => {
     const explicit = createRecordingHost();
-    const streamStatus = new StreamStatusRegistry();
+    const streamStatus = new StreamStatusMachine();
     const registry = new ExecutionRegistry({ streamStatus });
     const parentStreamId = 'parent-finish-untracked-agent-test' as StreamTabId;
     const childStreamId = 'child-finish-untracked-agent-test' as StreamTabId;
@@ -840,7 +840,7 @@ describe('executionRegistry', () => {
 
   it('owns tool-use follow-up admission from status, context, and children', () => {
     const explicit = createRecordingHost();
-    const streamStatus = new StreamStatusRegistry();
+    const streamStatus = new StreamStatusMachine();
     const registry = new ExecutionRegistry({ streamStatus });
     const activeStreamId = 'stream-follow-up-active-test' as StreamTabId;
     const resumingStreamId = 'stream-follow-up-resuming-test' as StreamTabId;
@@ -980,7 +980,7 @@ describe('executionRegistry', () => {
 
   it('detaches its stream-status listener when disposed', () => {
     const explicit = createRecordingHost();
-    const streamStatus = new StreamStatusRegistry();
+    const streamStatus = new StreamStatusMachine();
     const registry = new ExecutionRegistry({ streamStatus });
     const executionId = 'exec-dispose-runtime-host-test';
     const parentStreamId = 'parent-dispose-runtime-host-test' as StreamTabId;

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -22,7 +22,7 @@ import {
 } from '@agent/runtime/RunContext';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
 import {
-  StreamStatusRegistry,
+  StreamStatusMachine,
   StreamStatusService,
 } from '@agent/runtime/StreamStatusService';
 import {
@@ -40,7 +40,7 @@ import {
 interface TestRetryServices {
   streamId: StreamTabId;
   runtimeHost: AgentRuntimeHost;
-  streamStatus: StreamStatusRegistry;
+  streamStatus: StreamStatusMachine;
   logger: AgentTrace;
   setAbortController: (ac: AbortController | null) => void;
 }
@@ -65,7 +65,7 @@ class ExposedRetryNode extends RetryableInvocationNode<
 
 interface RetryNodeKit {
   node: ExposedRetryNode;
-  streamStatus: StreamStatusRegistry;
+  streamStatus: StreamStatusMachine;
   waitForRetry: Mock<
     (
       streamId: string,
@@ -75,7 +75,7 @@ interface RetryNodeKit {
 }
 
 function createRetryNode(streamId: StreamTabId): RetryNodeKit {
-  const streamStatus = new StreamStatusRegistry();
+  const streamStatus = new StreamStatusMachine();
   const waitForRetry = vi.fn<RetryNodeKit['waitForRetry']>();
   const node = new ExposedRetryNode().setServices({
     streamId,

--- a/src/test-kernel/agent/runtime/SessionIsolation.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionIsolation.vitest.ts
@@ -21,7 +21,7 @@ import {
   defaultSession,
 } from '@agent/runtime/SessionHandle';
 import { runFlowWithLifecycle } from '@agent/runtime/AgentRunLifecycle';
-import { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
+import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import type { AgentLaunchContext } from '@agent/runtime/AgentLaunchContext';
 import type { IInterruptible } from '@agent/runtime/InterruptRegistry';
 import { UsageMonitor } from '@agent/utils/UsageMonitor';
@@ -58,7 +58,7 @@ async function initTestPlatform() {
 function createLifecycleContext(
   executionId: ExecutionId,
   streamId: StreamTabId,
-  streamStatus: StreamStatusRegistry,
+  streamStatus: StreamStatusMachine,
   session: SessionHandle,
 ): AgentLaunchContext {
   const explicit = createRecordingHost();
@@ -170,7 +170,7 @@ describe('session isolation (SDK Step 7d PR 2)', () => {
     await initTestPlatform();
     const executionId = 'execution:iso-track' as ExecutionId;
     const streamId = 'stream:iso-track' as StreamTabId;
-    const streamStatus = new StreamStatusRegistry();
+    const streamStatus = new StreamStatusMachine();
     const sessionB = new SessionHandle();
     const ctx = createLifecycleContext(
       executionId,

--- a/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
@@ -18,7 +18,7 @@ import { RetryRequestCoordinatorImpl } from '@agent/runtime/RetryRequestCoordina
 import { runFlowWithLifecycle } from '@agent/runtime/AgentRunLifecycle';
 import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
 import type { AgentRunHandle } from '@agent/runtime/executionRegistry';
-import { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
+import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import type { AgentLaunchContext } from '@agent/runtime/AgentLaunchContext';
 import { UsageMonitor } from '@agent/utils/UsageMonitor';
 import {
@@ -45,13 +45,13 @@ let counter = 0;
 
 function createCtx(overrides?: { logger?: TraceEmitter }): {
   ctx: AgentLaunchContext;
-  streamStatus: StreamStatusRegistry;
+  streamStatus: StreamStatusMachine;
 } {
   const explicit = createRecordingHost();
   const n = counter++;
   const executionId = `exec:result-${n}` as ExecutionId;
   const streamId = `stream:result-${n}` as StreamTabId;
-  const streamStatus = new StreamStatusRegistry();
+  const streamStatus = new StreamStatusMachine();
   const config = AgentConfigSchema.parse({
     agent: 'assistant',
     model: 'test-model',
@@ -125,7 +125,7 @@ function setupResultCase(): {
   logger: TraceEmitter;
   results: ResultEvent[];
   ctx: AgentLaunchContext;
-  streamStatus: StreamStatusRegistry;
+  streamStatus: StreamStatusMachine;
 } {
   const logger = new TraceEmitter();
   const results = collectResults(logger);

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -31,7 +31,7 @@ import type { ToolUseRoundServices } from '@agent/core/flows/CycleServices';
 // Local imports - agent runtime
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/openai/modelHandlerOpenAIResponse';
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { StreamStatusRegistry } from '@agent/runtime/StreamStatusService';
+import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 // Type imports
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import type { SdkToolCall } from '@agent/modelHandlers/types/IModelHandler';
@@ -166,7 +166,7 @@ function roundServices(opts: {
     } satisfies AgentPrompt,
     userVarChannels: { input: {}, transient: {} },
     logger: opts.logger,
-    streamStatus: new StreamStatusRegistry(),
+    streamStatus: new StreamStatusMachine(),
     client: {} as OpenAI,
     fileService: new TaskRunFileService('deadbeef'),
     toolRegistry: opts.toolRegistry,


### PR DESCRIPTION
## Summary

Records Checkpoint A for the 2026-07 session-scoped runtime architecture program after stages 0-2, including the refreshed Stage 3 go/no-go evidence, the desktop pre-flight decision, corrected citations for stages 3a/3b/3c, and the current census/ledger state.

This also retires the now test-only `StreamStatusRegistry` compatibility alias so tests import the `StreamStatusMachine` name directly.

## Issue acceptance gates

- #6978: re-verified the cited L1-L3 evidence after stages 0-2 and recorded citation drift in the running checkpoint record.
- #6978: recorded the desktop pre-flight answer and Stage 3 sequencing decision.
- #6978: audited temporary shims/aliases/projections against #6981 and retired the `StreamStatusRegistry` alias row.
- #6978: refreshed the Stage 3 issue specs and parent tracker status in GitHub before implementation.
- #6978: updated proposal status so completed checkpoint work is no longer described as purely future/open.

## Single source of truth

`docs/proposals/architecture-checkpoints-2026.md` is now the running checkpoint record for architecture checkpoints. `StreamStatusMachine` is the single status-machine type name; the old `StreamStatusRegistry` compatibility alias is gone.

## Duplication and abstraction budget

Removed the `StreamStatusRegistry` alias and updated the tests that still imported it. No new shim, projection, fallback, pass-through layer, or barrel was added. This PR is net-positive in lines because the added mass is the checkpoint evidence record required by #6978, not new runtime surface area.

## Host impact

Extension: no runtime behavior change; the checkpoint records the remaining extension/process default facts and updates test imports.

Desktop: no runtime behavior change; the maintainer pre-flight answer is recorded and Stage 3 proceeds treating multi-window desktop as supported/intended unless current code proves otherwise.

CLI: no runtime behavior change.

## Scheduled refactoring

#6981 was updated before this PR to mark the `StreamStatusRegistry` alias retired by Checkpoint A while keeping the `StatusEvent` to `updateStreamStatus` projection scheduled for Stage 5. Stage 3a (#6964), Stage 3b (#6965), and Stage 3c (#6966) are unblocked after this lands; Checkpoint B (#6979) remains mandatory before Stage 4/F2.

## Validation

- `corepack pnpm exec prettier --write` on touched files
- `npx vitest run src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/agent/runtime/RetryState.vitest.ts src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts src/test-kernel/agent/runtime/SessionIsolation.vitest.ts src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts src/test-kernel/agent/followUp/ToolUseRoundFollowUpMedia.vitest.ts src/test-kernel/tools/BashTool.vitest.ts`
- `npm run typecheck`
- `npm run lint` (passed with existing warnings outside this PR's files)
- `npm run compile:fast`
- `npm test` (passed; emitted existing environment warnings about metadata disk full and missing localStorage file)
- `git diff --check`
- `rg -n "StreamStatusRegistry" src packages --glob '!**/node_modules/**'`

Closes #6978

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-heavy PR with a test-only import rename; no production runtime logic changes.
> 
> **Overview**
> **Checkpoint A (2026-07-05)** is recorded in a new running doc, `architecture-checkpoints-2026.md`, and related proposals are updated so stages 0–2 are closed and Stage 3 can proceed.
> 
> The checkpoint **re-verifies** L1–L3 session/global leak evidence, notes citation drift for 3a/3b/3c (e.g. child-stream ordering fixed in #6993, metadata patch no longer O(N)), and records the desktop pre-flight: multi-window desktop stays **supported/intended** unless code proves otherwise. It also captures simplification ledger items (F9 storage aliases retired, census meters) and the remaining order: parallel 3a/3b/3c, then Checkpoint B before Stage 4/F2.
> 
> **Code change:** the test-only `StreamStatusMachine as StreamStatusRegistry` re-export is **removed** from `StreamStatusService.ts`; test-kernel vitests now construct/import **`StreamStatusMachine`** directly. Production behavior is unchanged (`StreamStatusService` remains the process default machine).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40cd1deb2038407dd383fd9f6ad58cf05c6f9001. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->