### PR TITLE
fix(desktop): consult persisted flow records in restart-repair fallback path

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -844,10 +844,24 @@ export class DesktopProgressBridge {
             ([, executionId]) => !activeExecutionIds.has(executionId),
           ),
         );
-        const { waitingStreams: persistedWaitingStreams } =
-          await this.detectRaceGuardedWaitingStreams(executionIdMap);
+        const {
+          waitingStreams: persistedWaitingStreams,
+          activeExecutionIds: postDetectActiveExecutionIds,
+          allExecutionIds: postDetectAllExecutionIds,
+        } = await this.detectRaceGuardedWaitingStreams(executionIdMap);
         for (const streamId of persistedWaitingStreams) {
           waitingStreams.add(streamId);
+        }
+        // The helper only race-guards its own (persisted-record) result.
+        // waitingStreams also carries the pre-existing in-memory-scan
+        // entries from above, which predate the KV read and so never got
+        // checked against activity that happened during it -- recheck them
+        // here too, or an actively-resumed stream could still be handed to
+        // closeRunningTaskGroupsForStreams() below.
+        for (const [streamId, executionId] of postDetectAllExecutionIds) {
+          if (postDetectActiveExecutionIds.has(executionId)) {
+            waitingStreams.delete(streamId);
+          }
         }
       } catch (detectError) {
         // Keep going with whatever the in-memory scan already found -- a

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -815,7 +815,7 @@ export class DesktopProgressBridge {
       // at crash time but has a valid persisted flow record -- ground truth
       // that only detectWaitingStreams() (KV-store backed) can see. Without
       // this, resetRestartRepairStreamStatuses would wrongly demote such a
-      // stream to FAILED instead of restoring it to WAITING (#6938).
+      // stream to FAILED instead of restoring it to WAITING.
       try {
         const executionIdMap = new Map(
           [...allExecutionIds].filter(
@@ -824,6 +824,19 @@ export class DesktopProgressBridge {
         );
         const persistedWaitingStreams =
           await detectWaitingStreams(executionIdMap);
+        // Mirror the try path: a stream may have resumed and gone active
+        // while the KV read above was in flight, so re-fetch active
+        // execution ids and drop any stream that is active now before
+        // folding the persisted-record result into waitingStreams.
+        const {
+          activeExecutionIds: postDetectActiveExecutionIds,
+          allExecutionIds: postDetectAllExecutionIds,
+        } = this.refreshActiveExecutionIds();
+        for (const [streamId, executionId] of postDetectAllExecutionIds) {
+          if (postDetectActiveExecutionIds.has(executionId)) {
+            persistedWaitingStreams.delete(streamId);
+          }
+        }
         for (const streamId of persistedWaitingStreams) {
           waitingStreams.add(streamId);
         }

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -653,6 +653,33 @@ export class DesktopProgressBridge {
     return { activeExecutionIds, allExecutionIds };
   }
 
+  /**
+   * Consults detectWaitingStreams() (the KV-store-backed, ground-truth
+   * persisted flow record check) and then re-fetches active execution ids
+   * to drop any stream that became active while that await was in flight --
+   * a narrow but real race (another window, or a headless run, could resume
+   * the stream mid-lookup). Shared by both the primary try path and the
+   * degraded catch-fallback path in repairOrphanedStreamsAfterRestart so the
+   * two can no longer silently diverge on this check the way they once did.
+   */
+  private async detectRaceGuardedWaitingStreams(
+    executionIdMap: ReadonlyMap<StreamTabId, ExecutionId>,
+  ): Promise<{
+    waitingStreams: Set<StreamTabId>;
+    activeExecutionIds: Set<string>;
+    allExecutionIds: ReadonlyMap<StreamTabId, ExecutionId>;
+  }> {
+    const waitingStreams = await detectWaitingStreams(executionIdMap);
+    const { activeExecutionIds, allExecutionIds } =
+      this.refreshActiveExecutionIds();
+    for (const [streamId, executionId] of allExecutionIds) {
+      if (activeExecutionIds.has(executionId)) {
+        waitingStreams.delete(streamId);
+      }
+    }
+    return { waitingStreams, activeExecutionIds, allExecutionIds };
+  }
+
   private resetRestartRepairStreamStatuses(
     repairStreams: ReadonlySet<StreamTabId>,
     waitingStreams: ReadonlySet<StreamTabId>,
@@ -761,16 +788,11 @@ export class DesktopProgressBridge {
           ([, executionId]) => !activeExecutionIds.has(executionId),
         ),
       );
-      const waitingStreams = await detectWaitingStreams(executionIdMap);
       const {
+        waitingStreams,
         activeExecutionIds: repairActiveExecutionIds,
         allExecutionIds: repairAllExecutionIds,
-      } = this.refreshActiveExecutionIds();
-      for (const [streamId, executionId] of repairAllExecutionIds) {
-        if (repairActiveExecutionIds.has(executionId)) {
-          waitingStreams.delete(streamId);
-        }
-      }
+      } = await this.detectRaceGuardedWaitingStreams(executionIdMap);
       const repairExecutionIdMap = new Map(
         [...repairAllExecutionIds].filter(
           ([, executionId]) => !repairActiveExecutionIds.has(executionId),
@@ -822,21 +844,8 @@ export class DesktopProgressBridge {
             ([, executionId]) => !activeExecutionIds.has(executionId),
           ),
         );
-        const persistedWaitingStreams =
-          await detectWaitingStreams(executionIdMap);
-        // Mirror the try path: a stream may have resumed and gone active
-        // while the KV read above was in flight, so re-fetch active
-        // execution ids and drop any stream that is active now before
-        // folding the persisted-record result into waitingStreams.
-        const {
-          activeExecutionIds: postDetectActiveExecutionIds,
-          allExecutionIds: postDetectAllExecutionIds,
-        } = this.refreshActiveExecutionIds();
-        for (const [streamId, executionId] of postDetectAllExecutionIds) {
-          if (postDetectActiveExecutionIds.has(executionId)) {
-            persistedWaitingStreams.delete(streamId);
-          }
-        }
+        const { waitingStreams: persistedWaitingStreams } =
+          await this.detectRaceGuardedWaitingStreams(executionIdMap);
         for (const streamId of persistedWaitingStreams) {
           waitingStreams.add(streamId);
         }

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -808,7 +808,39 @@ export class DesktopProgressBridge {
         }
       }
       this.progressEvents.hydrateRestoredStreams();
-      this.refreshActiveExecutionIds();
+      const { activeExecutionIds, allExecutionIds } =
+        this.refreshActiveExecutionIds();
+      // The in-memory scan above only catches streams whose CURRENT status
+      // already happens to be WAITING. It misses a stream that was RUNNING
+      // at crash time but has a valid persisted flow record -- ground truth
+      // that only detectWaitingStreams() (KV-store backed) can see. Without
+      // this, resetRestartRepairStreamStatuses would wrongly demote such a
+      // stream to FAILED instead of restoring it to WAITING (#6938).
+      try {
+        const executionIdMap = new Map(
+          [...allExecutionIds].filter(
+            ([, executionId]) => !activeExecutionIds.has(executionId),
+          ),
+        );
+        const persistedWaitingStreams =
+          await detectWaitingStreams(executionIdMap);
+        for (const streamId of persistedWaitingStreams) {
+          waitingStreams.add(streamId);
+        }
+      } catch (detectError) {
+        // Keep going with whatever the in-memory scan already found -- a
+        // failure here must not block the rest of this already-degraded
+        // fallback path.
+        this.logger.warn(
+          'Failed to consult persisted flow records during desktop restart-repair fallback',
+          {
+            data:
+              detectError instanceof Error
+                ? detectError
+                : { error: detectError },
+          },
+        );
+      }
       const affectedStreams = this.resetRestartRepairStreamStatuses(
         new Set(this.progressEvents.restoredStreams.keys()),
         waitingStreams,

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -27,7 +27,10 @@ import { DIAGNOSTICS_ADD_RUNTIME_CAPABILITY } from '@tools/diagnosticsRuntimeCap
 
 // Local imports - desktop test paths
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
-import type { StreamSnapshotStore as ProgressSnapshotStore } from '@transcript';
+import {
+  STREAM_LOGS_DIR,
+  type StreamSnapshotStore as ProgressSnapshotStore,
+} from '@transcript';
 
 type Bridge = {
   openFileCompile(filePath: string): Promise<void>;
@@ -133,6 +136,8 @@ interface DesktopAgentExecutionModule {
 type CreateBridgeOptions = {
   kvStoreBacking?: Map<string, unknown>;
   kvRead?: (key: string) => Promise<unknown> | unknown;
+  /** Forces `state.streamLogs.load()` to reject, to exercise the restart-repair fallback (catch) path. */
+  streamLogsLoadError?: Error;
   retrieveSessionResumeData?: ReturnType<typeof vi.fn>;
   resumeToolUseFromSnapshot?: ReturnType<typeof vi.fn>;
   runAgent?: RunExecutionRequest;
@@ -255,6 +260,9 @@ async function createBridge(
       }
 
       async listKeys(): Promise<string[]> {
+        if (options.streamLogsLoadError && this.dir === STREAM_LOGS_DIR) {
+          throw options.streamLogsLoadError;
+        }
         if (!options.kvStoreBacking) return [];
         const prefix = `${this.dir}/`;
         return [...options.kvStoreBacking.keys()]
@@ -790,6 +798,11 @@ describe('DesktopProgressBridge', () => {
   });
 
   it('marks restored running streams as errored when startup repair fails', async () => {
+    // The catch-fallback path also consults detectWaitingStreams() (see the
+    // regression test below), so when the persisted-record lookup itself is
+    // completely unavailable, it is invoked once from the primary try path
+    // and once again from the fallback -- both fail here, so there really is
+    // no way to know the stream is resumable and it correctly lands in FAILED.
     const detectWaitingStreams = vi.fn(async () => {
       throw new Error('flow store unavailable');
     });
@@ -806,13 +819,53 @@ describe('DesktopProgressBridge', () => {
 
     try {
       await vi.waitFor(() => {
-        expect(detectWaitingStreams).toHaveBeenCalledOnce();
+        expect(detectWaitingStreams).toHaveBeenCalledTimes(2);
         expect(bridgeStatus(bridge).get('broken-stream')).toBe(
           STREAM_PHASE.FAILED,
         );
       });
     } finally {
       bridgeStatus(bridge).clearStream('broken-stream');
+      bridge.dispose();
+    }
+  });
+
+  it('restores a RUNNING stream with a persisted flow record to WAITING when streamLogs.load() throws', async () => {
+    // Regression test for #6938: the catch-fallback path used to only
+    // consider streams whose CURRENT in-memory status was already WAITING,
+    // missing a stream that was RUNNING at crash time but still has a valid
+    // persisted flow record -- wrongly demoting it to FAILED instead of
+    // WAITING. The fallback must now consult detectWaitingStreams() (ground
+    // truth from the persisted KV record) just like the primary try path.
+    const detectWaitingStreams = vi.fn(
+      async (executionIds: ReadonlyMap<StreamTabId, string>) =>
+        new Set<StreamTabId>(
+          [...executionIds.keys()].filter(
+            (streamId) => streamId === 'resumable-stream',
+          ),
+        ),
+    );
+    const bridge = await createBridge([], {
+      detectWaitingStreams,
+      streamLogsLoadError: new Error('stream log store unavailable'),
+      streamSnapshotStore: createStreamSnapshotStore([
+        restoredSnapshot({
+          streamId: 'resumable-stream',
+          executionId: 'abc123',
+          lastKnownStatus: STREAM_STATUS.RUNNING,
+        }),
+      ]),
+    });
+
+    try {
+      await vi.waitFor(() => {
+        expect(detectWaitingStreams).toHaveBeenCalledOnce();
+        expect(bridgeStatus(bridge).get('resumable-stream')).toBe(
+          STREAM_STATUS.WAITING,
+        );
+      });
+    } finally {
+      bridgeStatus(bridge).clearStream('resumable-stream');
       bridge.dispose();
     }
   });

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -831,7 +831,7 @@ describe('DesktopProgressBridge', () => {
   });
 
   it('restores a RUNNING stream with a persisted flow record to WAITING when streamLogs.load() throws', async () => {
-    // Regression test for #6938: the catch-fallback path used to only
+    // Regression test: the catch-fallback path used to only
     // consider streams whose CURRENT in-memory status was already WAITING,
     // missing a stream that was RUNNING at crash time but still has a valid
     // persisted flow record -- wrongly demoting it to FAILED instead of


### PR DESCRIPTION
Closes #6938

## Problem

`repairOrphanedStreamsAfterRestart` (`packages/desktop/src/main/desktopAgentExecution.ts`) has a primary try path and a catch-fallback path (reached e.g. when `streamLogs.load()` throws). Both run the same repair sequence, but they computed their `waitingStreams` input differently:

- **try path**: uses `detectWaitingStreams()` (`src/agent/storage/detectWaitingStreams.ts`), which checks ground-truth persisted flow records in the KV store.
- **catch path**: only captured streams whose *current in-memory* status already equaled `WAITING` -- never consulting the persisted flow record.

Since `resetRestartRepairStreamStatuses` demotes any repair-eligible stream (RUNNING or WAITING) that is *not* in `waitingStreams` to `FAILED`, a stream that was genuinely `RUNNING` at crash time with a valid persisted flow record would, if the catch branch was hit, get wrongly marked `FAILED` instead of `WAITING` -- losing real resumability.

## Fix

The catch-fallback path now also calls `detectWaitingStreams()` against the non-active execution-id map (mirroring what the try path already does), folding any persisted-record streams into `waitingStreams` before repair runs. The call is wrapped in its own `try`/`catch` so a failure there (e.g. the KV store is also unavailable) can't break the rest of the already-degraded fallback -- it just logs and falls back to whatever the in-memory scan found, same as before.

## Tests

- Added a regression test that forces `streamLogs.load()` to throw (via a new `streamLogsLoadError` test-harness option) and asserts a `RUNNING` stream with a persisted flow record ends up `WAITING`, not `FAILED`.
- Updated the existing "marks restored running streams as errored when startup repair fails" test: since the fallback now also calls `detectWaitingStreams()`, that call happens twice when it always throws (once from the try path, once from the fallback) instead of once; the final state is unchanged (still correctly `FAILED` when persisted-record lookup is completely unavailable).

## Verification

- `npm run typecheck` (root + test-kernel + extension + CLI): clean.
- `packages/desktop` package typecheck (`tsc --noEmit -p tsconfig.main.json`, and the full `npm run typecheck` in `packages/desktop`): clean. (Root tsconfig excludes `packages/desktop`, so this is checked separately.)
- Targeted `vitest run src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`: 46/46 passed.
- `eslint` on both touched files: 0 errors (1 pre-existing import-order warning, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches desktop startup recovery and stream status transitions (WAITING vs FAILED), which affects resumability after crash/restart; scope is localized and covered by targeted vitest regressions.
> 
> **Overview**
> **Fixes a divergence between the primary and fallback paths in desktop restart stream repair** (`repairOrphanedStreamsAfterRestart`). When `streamLogs.load()` throws, the catch branch no longer builds `waitingStreams` only from streams already in-memory `WAITING`; it also consults **`detectWaitingStreams()`** (persisted KV flow records), matching the try path.
> 
> A new **`detectRaceGuardedWaitingStreams`** helper centralizes that lookup plus a post-await refresh of active execution ids so streams that resume mid-check are excluded—shared by try and catch so the two paths cannot drift again.
> 
> The fallback wraps the persisted lookup in its own try/catch (warn and continue on KV failure) and re-race-guards in-memory `WAITING` entries collected before the KV read. Tests add **`streamLogsLoadError`** harness support and a regression asserting a **RUNNING** restored stream with a flow record becomes **WAITING** when load fails; the “flow store unavailable” case now expects **`detectWaitingStreams`** twice (try + fallback).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9456a1e3b225a76462dab68a577e550a803fba0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->