### PR TITLE
fix: harden compileCheck against silent-success misreporting

### DIFF
--- a/src/agent/output/compileCheck.ts
+++ b/src/agent/output/compileCheck.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import * as path from 'node:path';
 
 import type { AgentTrace } from '@agent/trace';
@@ -7,6 +8,8 @@ import { compileLatex2Pdf } from '@latex/texTools';
 import type {
   CompileFailure,
   CompileResult,
+  ExecutionId,
+  FileLocation,
   OutputFileInfo,
 } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
@@ -150,9 +153,25 @@ export async function runCompileCheck(
       }
       if (result.artifact) artifacts.push(result.artifact);
     } catch (err) {
-      ctx.logger.warn(
-        `Compile check: ${displayName} skipped: ${toErrorMessage(err)}`,
-        { data: err },
+      // compileOne handles its own read/compile exceptions internally and
+      // reports them as failures, never as skips — this catch is only a
+      // last-resort backstop for a bug in that handling itself. It must still
+      // never let an errored check masquerade as a successful round, so it
+      // records a failure (with no on-disk log, since we can't trust the
+      // paths that failed to compute) rather than swallowing the error.
+      const message = toErrorMessage(err);
+      ctx.logger.warn(`Compile check: ${displayName} errored: ${message}`, {
+        data: err,
+      });
+      failures.push({
+        round: currentRound,
+        displayName,
+        output: outputFile.location,
+        log: outputFile.location,
+        logRelativePath: '(no log available)',
+      });
+      failureLogExcerpts.push(
+        `Compile check errored for ${displayName}\n\n${message}`,
       );
     }
   }
@@ -179,6 +198,11 @@ interface PerFileOptions {
   timeoutMs: number;
 }
 
+// Short hex digest length appended to safeName below — enough to make
+// collisions between distinct paths astronomically unlikely while keeping
+// log filenames legible.
+const PATH_HASH_LENGTH = 8;
+
 async function compileOne(
   ctx: CompileCheckContext,
   outputFile: OutputFileInfo,
@@ -202,7 +226,16 @@ async function compileOne(
   const pathForSafeName = comparablePath.startsWith(roundPrefix)
     ? comparablePath.slice(roundPrefix.length)
     : comparablePath;
-  const safeName = pathForSafeName.replaceAll(/[^a-zA-Z0-9._-]/g, '_');
+  // Sanitizing to a filesystem-safe name is lossy: two distinct paths that
+  // differ only in characters outside [a-zA-Z0-9._-] (e.g. "a:b.tex" and
+  // "a_b.tex") both collapse to the same string, so a second file's log
+  // write/delete would clobber the first's. Suffix with a short hash of the
+  // untruncated path so every output gets its own collision-free log slot.
+  const pathHash = createHash('sha1')
+    .update(pathForSafeName)
+    .digest('hex')
+    .slice(0, PATH_HASH_LENGTH);
+  const safeName = `${pathForSafeName.replaceAll(/[^a-zA-Z0-9._-]/g, '_')}_${pathHash}`;
   const buildDir = path.join(
     opts.compileRoot,
     'build',
@@ -216,66 +249,143 @@ async function compileOne(
     'compile',
     `r${currentRound}_${safeName}.log`,
   );
+  const executionId = ctx.fileService.metadata.executionId;
 
-  // Clear any stale log from a previous round so "no log = success" holds.
-  await flexibleFS.delete(logDest).catch(() => undefined);
+  let ok: boolean;
+  try {
+    const content = await flexibleFS.read(outputFile.location);
+    if (!/\\documentclass/.test(content)) {
+      ctx.logger.debug(
+        `Compile check: ${displayName} has no \\documentclass, skipping`,
+      );
+      // Only clear a stale log now that we know this file needs no compile
+      // check — deleting it up front (before we know the outcome) would let a
+      // mid-check crash erase evidence of a real prior failure.
+      await flexibleFS.delete(logDest).catch(() => undefined);
+      return { failure: null, failureLogExcerpt: '', artifact: null };
+    }
 
-  const content = await flexibleFS.read(outputFile.location);
-  if (!/\\documentclass/.test(content)) {
-    ctx.logger.debug(
-      `Compile check: ${displayName} has no \\documentclass, skipping`,
+    // The output compiles from `buildDir`, not its original workspace folder.
+    // For extracted outputs, the run-storage basename can be generic while
+    // outputFile.source carries the real workspace path.
+    const extraInputDirs = resolveWorkspaceSourceDir(
+      outputFile,
+      pathForSafeName,
     );
-    return { failure: null, failureLogExcerpt: '', artifact: null };
+
+    // execa's timeout option kills the child process on expiry, so we don't
+    // orphan hanging latexmk/pdflatex runs.
+    ok = await compileLatex2Pdf(outputFile.location, {
+      channel: ctx.streamId,
+      outputDirectory: buildDir,
+      timeout: opts.timeoutMs,
+      extraInputDirs,
+    });
+  } catch (err) {
+    // A per-file exception here (fs read error, compiler crash, etc.) means
+    // we could not determine whether this output compiles — that must never
+    // be reported as success. Record it as a failure with a synthetic
+    // excerpt, persisted to the same discoverable compile/*.log slot a real
+    // compile failure would use.
+    const message = toErrorMessage(err);
+    ctx.logger.warn(`Compile check: ${displayName} errored: ${message}`, {
+      data: err,
+    });
+    return writeCompileFailure({
+      ctx,
+      opts,
+      displayName,
+      currentRound,
+      outputFile,
+      logDest,
+      logRelativePath,
+      executionId,
+      failureLogExcerpt: `Compile check errored for ${displayName}\n\n${message}`,
+    });
   }
-
-  // The output compiles from `buildDir`, not its original workspace folder.
-  // For extracted outputs, the run-storage basename can be generic while
-  // outputFile.source carries the real workspace path.
-  const extraInputDirs = resolveWorkspaceSourceDir(outputFile, pathForSafeName);
-
-  // execa's timeout option kills the child process on expiry, so we don't
-  // orphan hanging latexmk/pdflatex runs.
-  const ok = await compileLatex2Pdf(outputFile.location, {
-    channel: ctx.streamId,
-    outputDirectory: buildDir,
-    timeout: opts.timeoutMs,
-    extraInputDirs,
-  });
 
   if (ok) {
     ctx.logger.debug(`Compile check: ${displayName} built successfully`);
-    const executionId = ctx.fileService.metadata.executionId;
-    const compiledPdfPath = path.join(
+    // Only now that we know the outcome do we clear a stale failure log from
+    // a previous attempt at this round — clearing it up front would leave a
+    // crash mid-check masquerading as success.
+    await flexibleFS.delete(logDest).catch(() => undefined);
+    const artifact = await tryPublishArtifact({
+      ctx,
+      opts,
+      displayName,
+      currentRound,
+      outputFile,
+      compiledBasename,
       buildDir,
-      `${compiledBasename.replace(/\.tex$/i, '')}.pdf`,
-    );
-    const artifact = executionId
-      ? await publishCompiledPdfArtifact({
-          runDirectory: opts.runDirectory,
-          executionId,
-          round: currentRound,
-          displayName,
-          source: outputFile.location,
-          compiledPdfPath,
-        })
-      : null;
-
-    if (artifact) {
-      ctx.logger.debug(`Compile check: ${displayName} PDF persisted`, {
-        data: artifact.latestPdf.relativePath,
-      });
-    }
+      executionId,
+    });
     return { failure: null, failureLogExcerpt: '', artifact };
   }
 
   const tail = await readLogTail(buildDir, compiledBasename);
   const failureLogExcerpt = `Compile check failed for ${displayName}\nBuild directory: ${buildDir}\n\n${tail}`;
-  await flexibleFS.ensureDir(pathToLocation(opts.compileRoot));
-  await flexibleFS.write(logDest, `${failureLogExcerpt}\n`);
   ctx.logger.warn(`Compile check: ${displayName} failed`, {
     data: path.relative(opts.runDirectory, logDest.absolutePath),
   });
-  const executionId = ctx.fileService.metadata.executionId;
+  return writeCompileFailure({
+    ctx,
+    opts,
+    displayName,
+    currentRound,
+    outputFile,
+    logDest,
+    logRelativePath,
+    executionId,
+    failureLogExcerpt,
+  });
+}
+
+interface WriteCompileFailureArgs {
+  ctx: CompileCheckContext;
+  opts: PerFileOptions;
+  displayName: string;
+  currentRound: number;
+  outputFile: OutputFileInfo;
+  logDest: FileLocation;
+  logRelativePath: string;
+  executionId: ExecutionId | undefined;
+  failureLogExcerpt: string;
+}
+
+/**
+ * Persist a failure's log excerpt to its collision-free `compile/*.log` slot
+ * and build the corresponding {@link CompileFailure} record. Never throws:
+ * persistence errors are logged and swallowed so a failure is always counted
+ * even when the log itself couldn't be written to disk.
+ */
+async function writeCompileFailure(args: WriteCompileFailureArgs): Promise<{
+  failure: CompileFailure;
+  failureLogExcerpt: string;
+  artifact: null;
+}> {
+  const {
+    ctx,
+    opts,
+    displayName,
+    currentRound,
+    outputFile,
+    logDest,
+    logRelativePath,
+    executionId,
+    failureLogExcerpt,
+  } = args;
+
+  try {
+    await flexibleFS.ensureDir(pathToLocation(opts.compileRoot));
+    await flexibleFS.write(logDest, `${failureLogExcerpt}\n`);
+  } catch (writeErr) {
+    ctx.logger.warn(
+      `Compile check: failed to persist log for ${displayName}: ${toErrorMessage(writeErr)}`,
+      { data: writeErr },
+    );
+  }
+
   const logLocation = executionId
     ? createRunStorageLocation(
         logDest.absolutePath,
@@ -294,6 +404,65 @@ async function compileOne(
     failureLogExcerpt,
     artifact: null,
   };
+}
+
+interface TryPublishArtifactArgs {
+  ctx: CompileCheckContext;
+  opts: PerFileOptions;
+  displayName: string;
+  currentRound: number;
+  outputFile: OutputFileInfo;
+  compiledBasename: string;
+  buildDir: string;
+  executionId: ExecutionId | undefined;
+}
+
+/**
+ * Publish the compiled PDF as a best-effort side effect of a successful
+ * compile. A failure here (e.g. copying the PDF into run storage) must not
+ * turn a document that genuinely compiled into a reported compile failure.
+ */
+async function tryPublishArtifact(
+  args: TryPublishArtifactArgs,
+): Promise<CompiledPdfArtifact | null> {
+  const {
+    ctx,
+    opts,
+    displayName,
+    currentRound,
+    outputFile,
+    compiledBasename,
+    buildDir,
+    executionId,
+  } = args;
+  if (!executionId) return null;
+
+  const compiledPdfPath = path.join(
+    buildDir,
+    `${compiledBasename.replace(/\.tex$/i, '')}.pdf`,
+  );
+  try {
+    const artifact = await publishCompiledPdfArtifact({
+      runDirectory: opts.runDirectory,
+      executionId,
+      round: currentRound,
+      displayName,
+      source: outputFile.location,
+      compiledPdfPath,
+    });
+    if (artifact) {
+      ctx.logger.debug(`Compile check: ${displayName} PDF persisted`, {
+        data: artifact.latestPdf.relativePath,
+      });
+    }
+    return artifact;
+  } catch (err) {
+    ctx.logger.warn(
+      `Compile check: ${displayName} PDF publish failed: ${toErrorMessage(err)}`,
+      { data: err },
+    );
+    return null;
+  }
 }
 
 function combineFailureLogExcerpts(excerpts: string[]): string {

--- a/src/agent/output/compileCheck.ts
+++ b/src/agent/output/compileCheck.ts
@@ -163,12 +163,23 @@ export async function runCompileCheck(
       ctx.logger.warn(`Compile check: ${displayName} errored: ${message}`, {
         data: err,
       });
+      // logRelativePath must stay a real, resolvable path: downstream
+      // consumers build a `/files/${logRelativePath}` deep link and an "open
+      // compile log" action around `log.absolutePath` — a placeholder string
+      // here would silently break both. Fall back to the output file's own
+      // comparable path (still useful context, even though it isn't a log).
+      let fallbackRelativePath: string;
+      try {
+        fallbackRelativePath = getComparablePath(outputFile.location);
+      } catch {
+        fallbackRelativePath = outputFile.location.absolutePath;
+      }
       failures.push({
         round: currentRound,
         displayName,
         output: outputFile.location,
         log: outputFile.location,
-        logRelativePath: '(no log available)',
+        logRelativePath: fallbackRelativePath,
       });
       failureLogExcerpts.push(
         `Compile check errored for ${displayName}\n\n${message}`,
@@ -203,6 +214,13 @@ interface PerFileOptions {
 // log filenames legible.
 const PATH_HASH_LENGTH = 8;
 
+// Cap on the sanitized stem portion of safeName (before the hash suffix).
+// Most filesystems reject a single path component over ~255 bytes; a deeply
+// nested or very long output path plus the round prefix, hash, and `.log`
+// extension could otherwise exceed that. The hash is derived from the full,
+// untruncated path, so truncating the stem never reintroduces collisions.
+const MAX_SANITIZED_STEM_LENGTH = 200;
+
 async function compileOne(
   ctx: CompileCheckContext,
   outputFile: OutputFileInfo,
@@ -236,7 +254,8 @@ async function compileOne(
     .update(pathForSafeName)
     .digest('hex')
     .slice(0, PATH_HASH_LENGTH);
-  const safeName = `${legacySafeName}_${pathHash}`;
+  const sanitizedStem = legacySafeName.slice(0, MAX_SANITIZED_STEM_LENGTH);
+  const safeName = `${sanitizedStem}_${pathHash}`;
   const buildDir = path.join(
     opts.compileRoot,
     'build',

--- a/src/agent/output/compileCheck.ts
+++ b/src/agent/output/compileCheck.ts
@@ -231,11 +231,12 @@ async function compileOne(
   // "a_b.tex") both collapse to the same string, so a second file's log
   // write/delete would clobber the first's. Suffix with a short hash of the
   // untruncated path so every output gets its own collision-free log slot.
+  const legacySafeName = pathForSafeName.replaceAll(/[^a-zA-Z0-9._-]/g, '_');
   const pathHash = createHash('sha1')
     .update(pathForSafeName)
     .digest('hex')
     .slice(0, PATH_HASH_LENGTH);
-  const safeName = `${pathForSafeName.replaceAll(/[^a-zA-Z0-9._-]/g, '_')}_${pathHash}`;
+  const safeName = `${legacySafeName}_${pathHash}`;
   const buildDir = path.join(
     opts.compileRoot,
     'build',
@@ -249,7 +250,19 @@ async function compileOne(
     'compile',
     `r${currentRound}_${safeName}.log`,
   );
+  // Pre-fix builds wrote to this un-hashed name. A run resumed under this
+  // fix must still clean it up on success, or a leftover legacy log from
+  // before the upgrade would keep reading as a failure forever.
+  const legacyLogDest = pathToLocation(
+    path.join(opts.compileRoot, `r${currentRound}_${legacySafeName}.log`),
+  );
   const executionId = ctx.fileService.metadata.executionId;
+
+  const clearStaleLogs = (): Promise<void[]> =>
+    Promise.all([
+      flexibleFS.delete(logDest).catch(() => undefined),
+      flexibleFS.delete(legacyLogDest).catch(() => undefined),
+    ]);
 
   let ok: boolean;
   try {
@@ -261,7 +274,7 @@ async function compileOne(
       // Only clear a stale log now that we know this file needs no compile
       // check — deleting it up front (before we know the outcome) would let a
       // mid-check crash erase evidence of a real prior failure.
-      await flexibleFS.delete(logDest).catch(() => undefined);
+      await clearStaleLogs();
       return { failure: null, failureLogExcerpt: '', artifact: null };
     }
 
@@ -309,7 +322,7 @@ async function compileOne(
     // Only now that we know the outcome do we clear a stale failure log from
     // a previous attempt at this round — clearing it up front would leave a
     // crash mid-check masquerading as success.
-    await flexibleFS.delete(logDest).catch(() => undefined);
+    await clearStaleLogs();
     const artifact = await tryPublishArtifact({
       ctx,
       opts,

--- a/src/test-kernel/agent/output/CompileCheck.vitest.ts
+++ b/src/test-kernel/agent/output/CompileCheck.vitest.ts
@@ -334,6 +334,44 @@ describe('runCompileCheck', () => {
     await expect(flexibleFS.read(logLocation)).rejects.toThrow();
   });
 
+  it('clears a pre-hash-suffix legacy log left over from before this fix', async () => {
+    // Before the collision-free hash suffix, the log for "main.tex" at round 0
+    // would have been written to "r0_main.tex.log" (no hash). A run resumed
+    // under the fixed code must still clean that legacy name up on success,
+    // not just the new hashed name it now writes to.
+    const executionId = 'compile-legacy-log';
+    const texPath = path.join(runDir(executionId), 'r0', 'main.tex');
+    const legacyLogPath = path.join(
+      runDir(executionId),
+      'compile',
+      'r0_main.tex.log',
+    );
+    await initLatexPlatform({
+      [texPath]: '\\documentclass{article}\\begin{document}Hi\\end{document}',
+      [legacyLogPath]: 'Compile check failed for main.tex (pre-upgrade)\n',
+    });
+
+    const outputState = createOutputState();
+    ensureRoundData(outputState, 0).outputs = [
+      outputFile(executionId, path.join('r0', 'main.tex'), 'main.tex', 0),
+    ];
+
+    const result = await runCompileCheck(
+      {
+        fileService: new TaskRunFileService(executionId),
+        outputState,
+        logger: logger(),
+        streamId: 'compile-stream',
+      },
+      0,
+    );
+
+    expect(result.compileResult?.status).toBe('ok');
+    await expect(
+      flexibleFS.read(pathToLocation(legacyLogPath)),
+    ).rejects.toThrow();
+  });
+
   it('gives colliding-after-sanitization paths distinct, non-clobbering log slots', async () => {
     const executionId = 'compile-collision';
     // Both sanitize (non [a-zA-Z0-9._-] -> "_") to the same "dir_a_b.tex":

--- a/src/test-kernel/agent/output/CompileCheck.vitest.ts
+++ b/src/test-kernel/agent/output/CompileCheck.vitest.ts
@@ -1,0 +1,391 @@
+// Standard library imports
+import * as path from 'node:path';
+
+// Third-party imports
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports - agent
+import type { AgentTrace } from '@agent/trace';
+import { runCompileCheck } from '@agent/output/compileCheck';
+import { createOutputState, ensureRoundData } from '@agent/output/outputState';
+
+// Local imports - shared
+import type {
+  ExecutionId,
+  FileLocation,
+  OutputFileInfo,
+} from '@shared/schemas';
+import { WorkspaceStateKey } from '@shared/state/stateKeys';
+
+// Local imports - file utilities
+import {
+  TaskRunFileService,
+  createRunStorageLocation,
+  flexibleFS,
+  pathToLocation,
+} from '@utils/files';
+
+interface FakeCompileOptions {
+  outputDirectory?: string;
+}
+
+const mocks = vi.hoisted(() => ({
+  compileLatex2Pdf: vi.fn(
+    async (_location: FileLocation, _options?: FakeCompileOptions) => true,
+  ),
+  hasLatexCompiler: vi.fn(async () => true),
+}));
+
+vi.mock('@latex/texTools', () => ({
+  compileLatex2Pdf: mocks.compileLatex2Pdf,
+}));
+
+vi.mock('@latex/latexToolchain', () => ({
+  hasLatexCompiler: mocks.hasLatexCompiler,
+}));
+
+const storagePath = '/storage';
+const workspacePath = '/workspace';
+
+function runDir(executionId: ExecutionId): string {
+  return path.join(storagePath, 'executions', executionId);
+}
+
+function runStorageFile(
+  executionId: ExecutionId,
+  relativePath: string,
+): FileLocation {
+  return createRunStorageLocation(
+    path.join(runDir(executionId), relativePath),
+    relativePath,
+    executionId,
+  );
+}
+
+function outputFile(
+  executionId: ExecutionId,
+  relativePath: string,
+  source: string,
+  round: number,
+): OutputFileInfo {
+  return {
+    source,
+    round,
+    location: runStorageFile(executionId, relativePath),
+    lineage: null,
+    diff: null,
+  };
+}
+
+function logger(): AgentTrace {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  } as unknown as AgentTrace;
+}
+
+async function initLatexPlatform(files: Record<string, string>): Promise<void> {
+  const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
+    import('@platform/platform'),
+    import('@test/support/FakePlatform'),
+  ]);
+  initPlatform(
+    createFakePlatform({
+      files,
+      storagePath,
+      workspacePath,
+      workspaceState: {
+        [WorkspaceStateKey.WORKFLOW_AUTO_COMPILE]: true,
+        [WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS]: 30_000,
+      },
+    }),
+  );
+}
+
+// Writes a fake LaTeX build log next to where `compileLatex2Pdf` was asked to
+// build, so `readLogTail` (which greps for `<basename>.log` in the reported
+// build directory) finds something real rather than falling back to "(no
+// LaTeX log at ...)". Lets tests control the tail's exact line content
+// without needing to reproduce compileCheck's internal safeName/hash scheme.
+async function seedLatexLog(
+  outputDirectory: string,
+  texAbsolutePath: string,
+  content: string,
+): Promise<void> {
+  const basenameNoExt = path.basename(texAbsolutePath).replace(/\.tex$/i, '');
+  const logDest = pathToLocation(
+    path.join(outputDirectory, `${basenameNoExt}.log`),
+  );
+  await flexibleFS.ensureDir(pathToLocation(outputDirectory));
+  await flexibleFS.write(logDest, content);
+}
+
+describe('runCompileCheck', () => {
+  beforeEach(() => {
+    mocks.compileLatex2Pdf.mockReset();
+    mocks.compileLatex2Pdf.mockResolvedValue(true);
+    mocks.hasLatexCompiler.mockReset();
+    mocks.hasLatexCompiler.mockResolvedValue(true);
+  });
+
+  it('counts a per-file exception as a failure, never a silent skip', async () => {
+    const executionId = 'compile-exception';
+    // No file is seeded at the tex path, so flexibleFS.read throws ENOENT
+    // before compileLatex2Pdf is ever invoked.
+    await initLatexPlatform({});
+
+    const outputState = createOutputState();
+    ensureRoundData(outputState, 0).outputs = [
+      outputFile(executionId, path.join('r0', 'main.tex'), 'main.tex', 0),
+    ];
+
+    const result = await runCompileCheck(
+      {
+        fileService: new TaskRunFileService(executionId),
+        outputState,
+        logger: logger(),
+        streamId: 'compile-stream',
+      },
+      0,
+    );
+
+    expect(mocks.compileLatex2Pdf).not.toHaveBeenCalled();
+    expect(result.compileResult?.status).toBe('failed');
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0].displayName).toBe('main.tex');
+    if (result.compileResult?.status === 'failed') {
+      expect(result.compileResult.logExcerpt).toContain(
+        'Compile check errored for main.tex',
+      );
+    }
+
+    // The synthetic excerpt is persisted like a real failure so it stays
+    // discoverable on disk, not just in-memory.
+    const persisted = await flexibleFS.read(result.failures[0].log);
+    expect(persisted).toContain('Compile check errored for main.tex');
+  });
+
+  it('treats a fragment with no \\documentclass as a graceful skip, not a failure', async () => {
+    const executionId = 'compile-fragment';
+    const texPath = path.join(runDir(executionId), 'r0', 'chunk.tex');
+    await initLatexPlatform({
+      [texPath]: '\\section{Included fragment}\n',
+    });
+
+    const outputState = createOutputState();
+    ensureRoundData(outputState, 0).outputs = [
+      outputFile(executionId, path.join('r0', 'chunk.tex'), 'chunk.tex', 0),
+    ];
+
+    const result = await runCompileCheck(
+      {
+        fileService: new TaskRunFileService(executionId),
+        outputState,
+        logger: logger(),
+        streamId: 'compile-stream',
+      },
+      0,
+    );
+
+    expect(mocks.compileLatex2Pdf).not.toHaveBeenCalled();
+    expect(result.failures).toHaveLength(0);
+    expect(result.compileResult?.status).toBe('ok');
+  });
+
+  it('truncates a single failing log tail to the last 200 lines', async () => {
+    const executionId = 'compile-tail-truncation';
+    const texPath = path.join(runDir(executionId), 'r0', 'main.tex');
+    await initLatexPlatform({
+      [texPath]: '\\documentclass{article}\\begin{document}Hi\\end{document}',
+    });
+
+    // Zero-padded so containment checks below can't be fooled by numeric
+    // substrings (e.g. "L0001" would otherwise match inside "L00010").
+    const totalLines = 250;
+    mocks.compileLatex2Pdf.mockImplementation(async (location, options) => {
+      const lines = Array.from(
+        { length: totalLines },
+        (_, i) => `L${String(i + 1).padStart(4, '0')}`,
+      );
+      await seedLatexLog(
+        options?.outputDirectory ?? '',
+        location.absolutePath,
+        lines.join('\n'),
+      );
+      return false;
+    });
+
+    const outputState = createOutputState();
+    ensureRoundData(outputState, 0).outputs = [
+      outputFile(executionId, path.join('r0', 'main.tex'), 'main.tex', 0),
+    ];
+
+    const result = await runCompileCheck(
+      {
+        fileService: new TaskRunFileService(executionId),
+        outputState,
+        logger: logger(),
+        streamId: 'compile-stream',
+      },
+      0,
+    );
+
+    expect(result.compileResult?.status).toBe('failed');
+    const excerpt =
+      result.compileResult?.status === 'failed'
+        ? result.compileResult.logExcerpt
+        : '';
+    // Last 200 of 250 lines survive: L0051 .. L0250.
+    expect(excerpt).toContain('L0051');
+    expect(excerpt).toContain('L0250');
+    expect(excerpt).not.toContain('L0050');
+    expect(excerpt).not.toContain('L0001');
+  });
+
+  it('truncates the combined excerpt to the last 12000 characters', async () => {
+    const executionId = 'compile-char-truncation';
+    const texPath = path.join(runDir(executionId), 'r0', 'main.tex');
+    await initLatexPlatform({
+      [texPath]: '\\documentclass{article}\\begin{document}Hi\\end{document}',
+    });
+
+    // 150 lines * 101 chars (100 + newline) stays under the 200-line cap but
+    // comfortably exceeds the 12000-character combined-excerpt limit once
+    // wrapped with the "Compile check failed for..." header. Zero-padded
+    // markers avoid numeric-substring false matches in the assertions below.
+    const longLine = 'x'.repeat(100);
+    mocks.compileLatex2Pdf.mockImplementation(async (location, options) => {
+      const lines = Array.from(
+        { length: 150 },
+        (_, i) => `${longLine}-END${String(i + 1).padStart(4, '0')}`,
+      );
+      await seedLatexLog(
+        options?.outputDirectory ?? '',
+        location.absolutePath,
+        lines.join('\n'),
+      );
+      return false;
+    });
+
+    const outputState = createOutputState();
+    ensureRoundData(outputState, 0).outputs = [
+      outputFile(executionId, path.join('r0', 'main.tex'), 'main.tex', 0),
+    ];
+
+    const result = await runCompileCheck(
+      {
+        fileService: new TaskRunFileService(executionId),
+        outputState,
+        logger: logger(),
+        streamId: 'compile-stream',
+      },
+      0,
+    );
+
+    expect(result.compileResult?.status).toBe('failed');
+    const excerpt =
+      result.compileResult?.status === 'failed'
+        ? result.compileResult.logExcerpt
+        : '';
+    expect(excerpt.startsWith('[truncated to last 12000 characters]')).toBe(
+      true,
+    );
+    expect(excerpt).toContain('END0150');
+    expect(excerpt).not.toContain('END0001');
+  });
+
+  it('clears a stale failure log once a later attempt at the same round succeeds', async () => {
+    const executionId = 'compile-stale-log';
+    const texPath = path.join(runDir(executionId), 'r0', 'main.tex');
+    await initLatexPlatform({
+      [texPath]: '\\documentclass{article}\\begin{document}Hi\\end{document}',
+    });
+
+    mocks.compileLatex2Pdf.mockResolvedValueOnce(false);
+
+    const outputState = createOutputState();
+    ensureRoundData(outputState, 0).outputs = [
+      outputFile(executionId, path.join('r0', 'main.tex'), 'main.tex', 0),
+    ];
+    const ctx = {
+      fileService: new TaskRunFileService(executionId),
+      outputState,
+      logger: logger(),
+      streamId: 'compile-stream',
+    };
+
+    const firstResult = await runCompileCheck(ctx, 0);
+    expect(firstResult.compileResult?.status).toBe('failed');
+    const logLocation = firstResult.failures[0].log;
+    await expect(flexibleFS.read(logLocation)).resolves.toContain(
+      'Compile check failed for main.tex',
+    );
+
+    // Re-run the same round (e.g. after a repaired retry); this time the
+    // compile succeeds.
+    mocks.compileLatex2Pdf.mockResolvedValueOnce(true);
+    const secondResult = await runCompileCheck(ctx, 0);
+    expect(secondResult.compileResult?.status).toBe('ok');
+
+    // The stale failure log from the first attempt must be gone -- otherwise
+    // "no compile/*.log = success" would still find leftover failure evidence.
+    await expect(flexibleFS.read(logLocation)).rejects.toThrow();
+  });
+
+  it('gives colliding-after-sanitization paths distinct, non-clobbering log slots', async () => {
+    const executionId = 'compile-collision';
+    // Both sanitize (non [a-zA-Z0-9._-] -> "_") to the same "dir_a_b.tex":
+    // "dir/a:b.tex" (":" -> "_") and "dir/a_b.tex" ("/" -> "_", "_" already
+    // allowed). Without a disambiguating hash, the second file's log write
+    // would silently replace the first's.
+    const pathA = path.join('r0', 'dir', 'a:b.tex');
+    const pathB = path.join('r0', 'dir', 'a_b.tex');
+    const texPathA = path.join(runDir(executionId), pathA);
+    const texPathB = path.join(runDir(executionId), pathB);
+    await initLatexPlatform({
+      [texPathA]: '\\documentclass{article}\\begin{document}A\\end{document}',
+      [texPathB]: '\\documentclass{article}\\begin{document}B\\end{document}',
+    });
+
+    mocks.compileLatex2Pdf.mockImplementation(async (location, options) => {
+      const abs = location.absolutePath;
+      await seedLatexLog(
+        options?.outputDirectory ?? '',
+        abs,
+        `LOG MARKER FOR ${abs}`,
+      );
+      return false;
+    });
+
+    const outputState = createOutputState();
+    ensureRoundData(outputState, 0).outputs = [
+      outputFile(executionId, pathA, 'a:b.tex', 0),
+      outputFile(executionId, pathB, 'a_b.tex', 0),
+    ];
+
+    const result = await runCompileCheck(
+      {
+        fileService: new TaskRunFileService(executionId),
+        outputState,
+        logger: logger(),
+        streamId: 'compile-stream',
+      },
+      0,
+    );
+
+    expect(result.failures).toHaveLength(2);
+    const [failureA, failureB] = result.failures;
+    // Distinct log slots despite the identical sanitized basename.
+    expect(failureA.logRelativePath).not.toBe(failureB.logRelativePath);
+    expect(failureA.log.absolutePath).not.toBe(failureB.log.absolutePath);
+
+    const persistedA = await flexibleFS.read(failureA.log);
+    const persistedB = await flexibleFS.read(failureB.log);
+    expect(persistedA).toContain(`LOG MARKER FOR ${texPathA}`);
+    expect(persistedA).not.toContain(texPathB);
+    expect(persistedB).toContain(`LOG MARKER FOR ${texPathB}`);
+    expect(persistedB).not.toContain(texPathA);
+  });
+});

--- a/src/test-kernel/agent/output/CompileCheck.vitest.ts
+++ b/src/test-kernel/agent/output/CompileCheck.vitest.ts
@@ -426,4 +426,53 @@ describe('runCompileCheck', () => {
     expect(persistedB).toContain(`LOG MARKER FOR ${texPathB}`);
     expect(persistedB).not.toContain(texPathA);
   });
+
+  it('records a resolvable log path through the outer backstop when compileOne throws before its own try/catch', async () => {
+    // Simulates a bug in compileOne's own pre-compile bookkeeping (path/hash
+    // computation), which runs before compileOne's internal try/catch and so
+    // can only be caught by runCompileCheck's outer per-file backstop.
+    const executionId = 'compile-outer-backstop';
+    const texPath = path.join(runDir(executionId), 'r0', 'main.tex');
+    await initLatexPlatform({
+      [texPath]: '\\documentclass{article}\\begin{document}Hi\\end{document}',
+    });
+
+    const filesModule = await import('@utils/files');
+    const comparablePathSpy = vi
+      .spyOn(filesModule, 'getComparablePath')
+      .mockImplementationOnce(() => {
+        throw new Error('simulated bookkeeping bug');
+      });
+
+    try {
+      const outputState = createOutputState();
+      const relativePath = path.join('r0', 'main.tex');
+      ensureRoundData(outputState, 0).outputs = [
+        outputFile(executionId, relativePath, 'main.tex', 0),
+      ];
+
+      const result = await runCompileCheck(
+        {
+          fileService: new TaskRunFileService(executionId),
+          outputState,
+          logger: logger(),
+          streamId: 'compile-stream',
+        },
+        0,
+      );
+
+      expect(mocks.compileLatex2Pdf).not.toHaveBeenCalled();
+      expect(result.compileResult?.status).toBe('failed');
+      expect(result.failures).toHaveLength(1);
+      // The second (uninstrumented) call to getComparablePath, made from the
+      // backstop itself, resolves normally -- so the failure gets a real,
+      // resolvable path instead of a broken placeholder string.
+      expect(result.failures[0].logRelativePath).toBe(relativePath);
+      expect(result.failures[0].log).toEqual(
+        outputFile(executionId, relativePath, 'main.tex', 0).location,
+      );
+    } finally {
+      comparablePathSpy.mockRestore();
+    }
+  });
 });


### PR DESCRIPTION
Closes #7078

## Summary

`runCompileCheck` had three robustness gaps that could let a broken or errored compile check silently report a successful round:

1. **Per-file exceptions were treated as skips.** An fs read error, a compiler crash, or any other exception from `compileOne` was caught, logged as a warning, and otherwise ignored — the overall round status was derived solely from `failures.length`, so an errored check contributed nothing and the round could still come back `status: 'ok'`. Exceptions are now recorded as `CompileFailure` entries with a synthetic excerpt (`Compile check errored for <name>\n\n<message>`), persisted to the same discoverable `compile/*.log` slot a real compile failure would use. A defensive outer backstop in the loop still records a failure (without attempting disk I/O) even in the unlikely case an exception escapes that inner handling.

2. **`safeName` sanitization could collapse two distinct paths into one log slot.** Two output paths differing only in characters outside `[a-zA-Z0-9._-]` (e.g. `dir/a:b.tex` and `dir/a_b.tex`) both sanitized to the same string, so the second `compileOne` call's write/delete would clobber the first's log — silently erasing evidence of a real failure. `safeName` is now suffixed with a short hash (first 8 hex chars of a SHA-1 of the untruncated path) so every output gets its own collision-free build/log slot.

3. **The stale-log delete happened before the compile outcome was known.** The old code deleted any previous log immediately, then only wrote a new one on failure. A crash between those two steps (e.g. the process dying mid-compile) would erase a real prior failure's log, and a later read of "no `compile/*.log` = success" would misread it as success. The delete is now deferred until the outcome is actually known — cleared only on success or on a fragment-skip (no `\documentclass`), never before compiling.

## Tests

Added `src/test-kernel/agent/output/CompileCheck.vitest.ts` with a fake `compileLatex2Pdf`/`hasLatexCompiler`, covering:
- a per-file exception counts as a failure (not a skip), with the synthetic excerpt persisted to disk
- a fragment with no `\documentclass` is still a graceful skip, not a failure
- a single failing log's tail is truncated to the last 200 lines
- the combined excerpt across failures is truncated to the last 12000 characters
- a stale failure log is cleared once a later attempt at the same round succeeds
- two paths that collide after sanitization get distinct, non-clobbering log slots

Existing `CompileFailureRoundContext.vitest.ts`, `OutputProgressEvents.vitest.ts`, and `LatexCompileInputDirs.vitest.ts` still pass unchanged.

## Verification
- `npx tsc --noEmit` (root project) — clean
- `npx tsc --noEmit -p tsconfig.test-kernel.json` — clean
- `npx tsc --noEmit -p packages/extension/tsconfig.json` and `-p packages/cli/tsconfig.json` — clean (unaffected by this change, checked directly since `npm run typecheck`'s `pnpm --filter` step is unreliable under concurrent sibling-worktree installs sharing this machine's symlinked `node_modules`)
- `npx vitest run` on the new test file plus the three pre-existing compileCheck-adjacent suites — all pass
- `eslint` on both touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how compile round success/failure is derived and where `compile/*.log` files are written or removed, which directly affects workflow retry/UI signals; scope is localized to `compileCheck` with broad new tests.
> 
> **Overview**
> Hardens **workflow auto-compile verification** so errored or ambiguous checks can’t leave a round reporting `status: 'ok'` when something actually went wrong.
> 
> **Per-file errors are failures, not silent skips.** Read/compile exceptions inside `compileOne` now produce a `CompileFailure` with a synthetic excerpt, written through shared `writeCompileFailure` into the usual `compile/*.log` slot. The outer per-file `catch` in `runCompileCheck` still records a failure (with a resolvable fallback path for UI deep links) if bookkeeping throws before that inner handling.
> 
> **Compile log paths are collision-free and legacy-safe.** `safeName` gains a short SHA-1 suffix (with stem length capped) so distinct paths that sanitize the same way no longer clobber each other’s logs. Stale logs are deleted only after a known outcome (success or no-`\documentclass` skip), and pre-hash **legacy** log filenames are cleared on success so resumed runs don’t stay failed forever.
> 
> **PDF publish is isolated from compile success.** Successful compiles call `tryPublishArtifact`, which swallows publish/copy errors so a good build isn’t flipped to failed.
> 
> Adds **`CompileCheck.vitest.ts`** covering exceptions-as-failures, fragment skips, log truncation, stale/legacy log cleanup, path-collision disambiguation, and the outer backstop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f01cfa7f82902f574e084822a3ad2d06cd524f1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->