### PR TITLE
Fix stale sawSoleOutputChunkLabel surviving unresolved state transitions

### DIFF
--- a/src/agent/output/extraction/filenameHeaders.ts
+++ b/src/agent/output/extraction/filenameHeaders.ts
@@ -349,10 +349,10 @@ export function extractFilenameHeaderDocuments(
         pendingPrefacedMarkdownFence = fence;
       }
       ignoreProseUntilNextHeader = false;
-      // This fence failed the sole-output-chunk gate above (not LaTeX-ish),
-      // so it is prose/example content, not a continuation of the coalesced
-      // output — any pending "next chunk" label it followed no longer
-      // applies to whatever comes after it.
+      // This fence failed the sole-output-chunk gate above (whatever the
+      // reason), so it is prose/example content, not a continuation of the
+      // coalesced output — any pending "next chunk" label it followed no
+      // longer applies to whatever comes after it.
       sawSoleOutputChunkLabel = false;
       continue;
     }

--- a/src/agent/output/extraction/filenameHeaders.ts
+++ b/src/agent/output/extraction/filenameHeaders.ts
@@ -349,6 +349,11 @@ export function extractFilenameHeaderDocuments(
         pendingPrefacedMarkdownFence = fence;
       }
       ignoreProseUntilNextHeader = false;
+      // This fence failed the sole-output-chunk gate above (not LaTeX-ish),
+      // so it is prose/example content, not a continuation of the coalesced
+      // output — any pending "next chunk" label it followed no longer
+      // applies to whatever comes after it.
+      sawSoleOutputChunkLabel = false;
       continue;
     }
 
@@ -384,6 +389,7 @@ export function extractFilenameHeaderDocuments(
       pendingPrefacedMarkdownFence = null;
       ignoreProseUntilNextHeader = true;
       synthesizedSingleInputFromPrefix = false;
+      sawSoleOutputChunkLabel = false;
       continue;
     }
 
@@ -424,6 +430,7 @@ export function extractFilenameHeaderDocuments(
           preHeaderLines = [];
           ignoreProseUntilNextHeader = false;
           synthesizedSingleInputFromPrefix = true;
+          sawSoleOutputChunkLabel = false;
           continue;
         }
         preHeaderLines = [];

--- a/src/test-kernel/agent/output/extraction/filenameHeaders.vitest.ts
+++ b/src/test-kernel/agent/output/extraction/filenameHeaders.vitest.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractFilenameHeaderDocuments } from '@agent/output/extraction/filenameHeaders';
+
+/**
+ * Regression coverage for issue #6937: `sawSoleOutputChunkLabel` must be
+ * reset at *every* state transition that can leave `currentName` null again,
+ * not just the header-match branch. A stale `true` value lets a later,
+ * unrelated fence be misread as a continuation of the sole coalesced output
+ * and silently merged into it.
+ *
+ * All scenarios below use the single-output-file wiring
+ * (`synthesisName === coalesceRepeatedName`) that `XmlOutputManager` uses for
+ * agents like ocr / paper2slide that declare exactly one output file — see
+ * `src/agent/output/XmlOutputManager.ts` around the `soleExpectedFile` wiring.
+ */
+function extract(content: string) {
+  return extractFilenameHeaderDocuments(content, {
+    thinkingTag: 'scratchpad',
+    roundDir: '/round',
+    labelFiles: ['output.tex'],
+    synthesisName: 'output.tex',
+    coalesceRepeatedName: 'output.tex',
+    wrapperTag: 'documents',
+  });
+}
+
+describe('extractFilenameHeaderDocuments — sawSoleOutputChunkLabel resets', () => {
+  it('does not carry a stale sole-output-chunk label across an unrelated non-LaTeX aside fence', () => {
+    // 1. `% output.tex` establishes the sole coalesced output.
+    // 2. A bare label ("Continued.tex:") that doesn't name a known file sets
+    //    sawSoleOutputChunkLabel = true, signaling "the next fence may be a
+    //    continuation of the sole output".
+    // 3. A ```json aside appears next — it fails the isLatexMarkdownFence
+    //    gate, so it is prose/example content, not a continuation. Before the
+    //    fix, entering this branch left sawSoleOutputChunkLabel stale-true.
+    // 4. The aside's own (bare) closing fence is then evaluated fresh against
+    //    the sole-output-chunk gate: with the stale flag, it is
+    //    misinterpreted as *opening* a new coalesced chunk, silently
+    //    absorbing the unrelated text that follows into output.tex.
+    const content = [
+      '```',
+      '% output.tex',
+      '\\documentclass{article}',
+      '\\begin{document}',
+      'First chunk content.',
+      '\\end{document}',
+      '```',
+      '',
+      'Here is some unrelated commentary about the results.',
+      '',
+      'Continued.tex:',
+      '```json',
+      '{"key": "value"}',
+      '```',
+      'More unrelated text that should not be part of the doc.',
+      '```',
+      '\\section{Unrelated}',
+      'This should not be merged into output.tex.',
+      '```',
+    ].join('\n');
+
+    const documents = extract(content);
+
+    expect(documents).toEqual([
+      {
+        name: 'output.tex',
+        content: [
+          '\\documentclass{article}',
+          '\\begin{document}',
+          'First chunk content.',
+          '\\end{document}',
+        ].join('\n'),
+      },
+    ]);
+  });
+
+  it('resets the label across a synthesized single-output document and its auto-close', () => {
+    // Reproduces the full chain the issue describes: a prose segment leaves
+    // sawSoleOutputChunkLabel stale-true, then a *synthesized* (unlabeled
+    // LaTeX prefix) document is created and auto-closed while that flag is
+    // live, exercising both the synthesis branch (currentName =
+    // synthesisName) and its auto-close path. The whole call must still
+    // resolve to a single, correctly-assembled output.tex with no corrupted
+    // or duplicated documents.
+    const content = [
+      '```',
+      '\\section{Intro}',
+      '% output.tex',
+      '\\begin{document}',
+      'Doc1 body text.',
+      '\\end{document}',
+      '```',
+      'Some commentary before the aside.',
+      '```',
+      '\\section{Second}',
+      '',
+      '```',
+      'chunk content for coalescing',
+      '```',
+      'More commentary here.',
+      'Continued.tex:',
+      '% output.tex',
+      '\\begin{document}',
+      'Doc2 body text.',
+      '\\end{document}',
+      '```',
+    ].join('\n');
+
+    const documents = extract(content);
+
+    expect(documents).toEqual([
+      {
+        name: 'output.tex',
+        content: [
+          '\\section{Intro}',
+          '% output.tex',
+          '\\begin{document}',
+          'Doc1 body text.',
+          '\\end{document}',
+          '',
+          'chunk content for coalescing',
+          '',
+          '\\section{Second}',
+          '',
+          '% output.tex',
+          '\\begin{document}',
+          'Doc2 body text.',
+          '\\end{document}',
+        ].join('\n'),
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #6937

## Problem

`extractFilenameHeaderDocuments` (`src/agent/output/extraction/filenameHeaders.ts`) is a hand-rolled state machine tracking several mutable flags, including `sawSoleOutputChunkLabel`. That flag was reset to `false` when a header match occurred, but not in two other branches that also send `currentName` back to `null`:

- the prose-fence-prefix branch, when a fence appears that fails the `isLatexMarkdownFence` gate (i.e. it's an example/aside fence, not a continuation of the sole output)
- the single-input-synthesis branch (`currentName = synthesisName`), and its auto-close path

This is a live path in production: `synthesisName` and `coalesceRepeatedName` are simultaneously non-null whenever an agent declares exactly one output file (see `src/agent/output/XmlOutputManager.ts` around the `soleExpectedFile` wiring — e.g. the `ocr` and `paper2slide` agents). A stale `sawSoleOutputChunkLabel = true` set during one prose segment could survive through an unrelated fence or a synthesized document's full lifecycle and then wrongly trigger `pendingSoleOutputChunk` coalescing later, silently merging unrelated content into the output file.

## Fix

Reset `sawSoleOutputChunkLabel = false` in both identified branches (and the auto-close path), matching the existing reset in the header-match branch, so the flag can never carry a stale "next chunk" signal past a state transition that didn't actually confirm one.

## Tests

Added `src/test-kernel/agent/output/extraction/filenameHeaders.vitest.ts` with two regression tests:

1. A test that reproduces the prose-fence-prefix bug precisely: a bare label sets the flag, a `\`\`\`json` aside fence fails the LaTeX gate, and — pre-fix — the aside's own closing delimiter is misread as opening a new coalesced chunk, silently absorbing unrelated text into `output.tex`. This test fails on the pre-fix code and passes after the fix.
2. A test reproducing the full narrative from the issue (prose leaves the flag stale, then a synthesized single-output document is created and auto-closed) that locks in correct end-to-end output for that flow.

I verified test 1 fails against the original code and passes after the fix (confirmed by temporarily reverting the change and re-running). I was not able to construct an input where the synthesis/auto-close resets alone (independent of the prose-fence-prefix fix) change the output — reaching those branches with the flag genuinely stale always coincides with `mayStartAdjacentSoleOutputChunk` also being legitimately `true` right after a coalesced flush, which independently drives the same merge decision. Those two resets are still correct and match the codebase's existing invariant (every path that clears `currentName` should also clear this flag), and are exercised (for coverage) by test 2.

## Verification

- `npm run typecheck` — passes
- `npx eslint src/agent/output/extraction/filenameHeaders.ts src/test-kernel/agent/output/extraction/filenameHeaders.vitest.ts` — clean
- `npx prettier --check` on touched files — clean
- Targeted vitest run: `src/test-kernel/agent/output/extraction/filenameHeaders.vitest.ts` (new, 2/2 passing) and `src/test-kernel/agent/output/XmlOutputManager.vitest.ts` (existing, 74/74 passing — no regressions)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes output-parsing behavior for single-file agents; wrong merges corrupt generated artifacts, but scope is narrow and covered by new regression tests.
> 
> **Overview**
> Fixes **#6937** by clearing `sawSoleOutputChunkLabel` on additional paths in `extractFilenameHeaderDocuments` where the parser treats content as prose or finishes a synthesized single-output document, not only when a filename header matches.
> 
> For single-output agents (e.g. OCR / paper2slide via `XmlOutputManager`), a bare “continued” label could leave that flag true across a non-LaTeX aside fence or synthesis/auto-close. A later fence was then misclassified as another coalesced chunk and **unrelated text was merged into the sole output file**.
> 
> Adds `filenameHeaders.vitest.ts` with two regression tests for the aside-fence case and the full synthesis/auto-close flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e120bbc0d3005427a4e3fcda8c524dc21d939fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->