### PR TITLE
feat(runtime): land session fact channel stage 3a

### DIFF
--- a/docs/proposals/architecture-checkpoints-2026.md
+++ b/docs/proposals/architecture-checkpoints-2026.md
@@ -133,9 +133,10 @@ barrels, and a stated count delta for any touched meter.
 
 ### Remaining Order
 
-1. Stage 3a (#6964): session facts, child/process arms, session-owned
-   transcripts/follow-ups. Use the corrected child-stream and follow-up citations
-   above; do not re-litigate #6993's ordering fix.
+1. Stage 3a (#6964): completed by the Stage 3a PR. It lands session facts,
+   child/process arms, and session-owned transcripts/follow-ups. The corrected
+   child-stream and follow-up citations above were the implementation evidence;
+   do not re-litigate #6993's ordering fix.
 2. Stage 3b (#6965): `RunDescriptor`, config persistence, and typed round
    stages. Treat the metadata-patch O(N) claim as stale; the side effect is now a
    per-stream patch.

--- a/docs/proposals/session-scoped-runtime-architecture.md
+++ b/docs/proposals/session-scoped-runtime-architecture.md
@@ -1,7 +1,7 @@
 # Session-scoped runtime architecture: facts, interactions, and status ownership
 
-> **Status:** Partially landed proposal (Stages 0-2 plus Checkpoint A; status
-> refreshed 2026-07-05). Companion to the diagnosis in
+> **Status:** Partially landed proposal (Stages 0-3a plus Checkpoint A; status
+> refreshed by #6964 on 2026-07-05). Companion to the diagnosis in
 > `tech-debt-audit-2026-07.md` (Part B1/B5 + appendix); this document is the
 > target design. It covers the event/logger chain, the
 > approval/interaction RPC machinery, stream status, and the execution registries
@@ -18,10 +18,12 @@ The evidence, condensed (file:line references in the audit appendix):
 
 **Genuine cross-session leaks (live bugs in multi-window desktop):**
 
-- L1. `getDefaultStreamLogStore()` is process-global and last-writer-wins
+- L1. Pre-Stage 3a evidence: `getDefaultStreamLogStore()` was process-global and last-writer-wins
   (`ProgressViewState.ts:153` calls `setDefaultStreamLogStore(this.streamLogs)`
-  per window; `runTrace.ts:34` defaults to it). A run's transcript appends to
-  whichever window's store was constructed last.
+  per window; `runTrace.ts:34` defaults to it). A run's transcript appended to
+  whichever window's store was constructed last. Stage 3a (#6964) moves run
+  traces and progress backends onto `session.transcripts`; the default getter
+  remains only as the single-session compatibility path.
 - L2. Desktop re-emits every progress event onto the shared process `bus`
   (`desktopAgentExecution.ts:811`) and every window's backend subscribes to
   that same bus (`:295`). Window A's run events mutate window B's
@@ -51,16 +53,19 @@ The evidence, condensed (file:line references in the audit appendix):
 - The bus's 1000-event pre-subscription buffer exists only because the sink
   subscribes lazily to a process-global emitter; it is a symptom, not a
   feature.
-- Session invariants enforced by comments, not types: the per-session
-  subscription binder reads the process-static streamId-keyed
+- Pre-Stage 3a session invariants were enforced by comments, not types: the
+  per-session subscription binder read the process-static streamId-keyed
   `ToolUseFollowUpQueue` (`SessionHandle.ts:99-104`); `handles`
-  (executionId-keyed) and `InterruptRegistry` (streamTabId-keyed) must be
-  populated in tandem or a stream is discoverable but uninterruptible.
+  (executionId-keyed) and `InterruptRegistry` (streamTabId-keyed) had to be
+  populated in tandem or a stream was discoverable but uninterruptible. Stage 3a
+  moves the binder and tool-use flows onto `session.followUps`; interrupt
+  ownership remains a later stage concern.
 
 **What is already right (build on it, don't replace it):**
 
 - `SessionHandle` is a real composition root (owns per-session
-  interrupts/executions/coordinators/subscriptions) with the
+  interrupts/executions/coordinators/subscriptions plus the Stage 3a
+  events/transcripts/follow-up owners) with the
   `defaultSession()` aliasing strategy proven by the 7d migration.
 - The 12-variant `AgentEvent` trace is a clean one-way fact stream with
   per-run subscribers; `conversationProgressHub` proves the trace→bus
@@ -289,7 +294,9 @@ stop/kill. Changes:
   comment. Same move for `session.transcripts` (per-session `StreamLogStore`;
   the `StreamSnapshotStore` sidecars stay a separate format per audit A6 and
   get the same session scoping): `createRunTrace` takes the store from the
-  launching session, deleting `getDefaultStreamLogStore` and fixing L1.
+  launching session, removing the last-writer-wins path and fixing L1. The
+  default store/queue accessors remain as scheduled single-session
+  compatibility shims until D1.
 - The two read-only methods (`requestManualCompaction`,
   follow-up-target queries where still needed externally) are exposed via
   narrow `Pick<>` interfaces, the pattern the repo already uses twice.
@@ -821,15 +828,16 @@ deleted.
    `restart-repair`/`clear` causes; add the `status` trace arm and make
    `updateStreamStatus` a projection. RunTable stop path switches from
    writing to requesting `cancelled`.
-3. **Session facts + registry facts + run structure.** `SessionFact` channel
-   for the non-run emitters; `child.activity`/`process.output` arms;
-   `session.transcripts` and `session.followUps` instances (fixes L1;
-   deletes the static queue and the binder invariant comment). Also here:
-   the `run.start` `RunDescriptor` arm (retiring `setTaskState` and moving
-   its run-start piggy-backs onto the `→ running` transition from stage 2)
-   and typed round stages (`kind`/`index`/`total`), deleting the
-   `ExecutionProgress` round counters and the round half of
-   `conversationProgress`. The persistence facade lands here too:
+3. **Session facts + registry facts + run structure.** Stage 3a (#6964) lands
+   the `SessionFact` channel for the non-run emitters,
+   `child.activity`/`process.output` arms, and `session.transcripts` /
+   `session.followUps` instances (fixes L1 and deletes the binder invariant
+   comment). Remaining Stage 3 work keeps the same track: the `run.start`
+   `RunDescriptor` arm (retiring `setTaskState` and moving its run-start
+   piggy-backs onto the `→ running` transition from stage 2) and typed round
+   stages (`kind`/`index`/`total`), deleting the `ExecutionProgress` round
+   counters and the round half of `conversationProgress`. The persistence
+   facade lands here too:
    `session.stores` atomic delete + orphan sweep, the single
    `deriveResumability` and shared `repairAfterRestart` primitives (repair
    uses stage 2's `restart-repair` cause), and deletion of the

--- a/docs/proposals/tech-debt-audit-2026-07.md
+++ b/docs/proposals/tech-debt-audit-2026-07.md
@@ -425,14 +425,13 @@ Two independent delivery systems, meeting only at two bridges:
 
 ### Execution cluster as it actually runs
 
-- **Ownership map:** `SessionHandle` (289 lines) composes per-session
-  `InterruptRegistry`, `ExecutionRegistry`, `RunCoordinatorBridge`,
-  `ExecutionSubscriptionBinder` in forced dependency order
-  (`SessionHandle.ts:86-118`); `defaultSession()` aliases the process
-  singletons so unmigrated call sites stay byte-identical. Deliberately NOT
-  session-owned: `StreamStatusService` (shared instance injected into every
-  session), static `ToolUseFollowUpQueue`, `subagentDeliveryRegistry`
-  (explicit rationale comment), `toolInjectionRegistry`.
+- **Ownership map:** `SessionHandle` composes per-session `InterruptRegistry`,
+  `ExecutionRegistry`, `RunCoordinatorBridge`, `ExecutionSubscriptionBinder`,
+  event hub, transcript store, and follow-up queue in forced dependency order;
+  `defaultSession()` aliases the process singletons/default store/default queue
+  so unmigrated call sites stay byte-identical. Deliberately NOT session-owned:
+  `subagentDeliveryRegistry` (explicit rationale comment),
+  `toolInjectionRegistry`.
 - **Lifecycle single-writer (landed):** `runFlowWithLifecycle` is the sole
   owner of RUNNING and of the terminal transition; `RunOutcome` is projected
   through the declarative `RUN_OUTCOME_PROJECTION` table to

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -21,6 +21,7 @@ import {
   executeAgent,
   resumeToolUseFromSnapshot,
 } from '@agent/runtime/executeAgent';
+import { attachLegacyProgressEventProjection } from '@agent/runtime/LegacyProgressEventProjection';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
 import { type CliContext } from '@cli/runtime/cliContext';
@@ -227,12 +228,17 @@ export function createChatSessionController(
       defaultSession(),
       wrapped,
     );
+    const detachLegacyProgressProjection = attachLegacyProgressEventProjection(
+      defaultSession().events,
+      wrapped,
+    );
     disposers.push(installTuiApprovals(wrapped, sessionContext));
     return {
       wrapped,
       approvalsUnavailable: approvalPromptsUnavailable(sessionContext),
       finalize: (): void => {
         detachResultToast();
+        detachLegacyProgressProjection();
         if (session.runtimeHost === wrapped) session.runtimeHost = undefined;
         markChatTuiRunCompleted(session);
         void runtimeHost.close();

--- a/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
+++ b/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
@@ -1,6 +1,6 @@
 import { executionRegistry } from '@agent/runtime/executionRegistry';
 import { notifyFollowUpSent } from '@agent/followUp/ToolUseFollowUp';
-import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import { isCodexSubscriptionActive } from '@auth/codex';
 import { formatCliApiMode } from '@cli/runtime/apiAccessMode';
 import { formatCliApprovalPolicy } from '@cli/runtime/approvalPolicyText';
@@ -177,7 +177,7 @@ export async function handleTuiSlashCommand(
           queuedFollowUpMessages:
             activeStreamId === undefined
               ? []
-              : ToolUseFollowUpQueue.getAll(activeStreamId),
+              : defaultSession().followUps.getAll(activeStreamId),
         }),
       );
       return true;

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -2,7 +2,7 @@
 // still flowing through the original emitter. Approvals are intentionally
 // not handled here — `subscribeApprovals.ts` owns the typed-modal pipeline.
 
-import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 import type {
   ProgressEvent,
@@ -46,7 +46,7 @@ function sameQueuedFollowUps(
 function refreshQueuedFollowUps(
   streamId: ProgressEventPayloads['updateQueuedFollowUps']['streamId'],
 ): void {
-  const messages = ToolUseFollowUpQueue.getAll(streamId);
+  const messages = defaultSession().followUps.getAll(streamId);
   patchStream(streamId, (s) => {
     if (
       s.queuedFollowUps === messages.length &&

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -13,6 +13,7 @@ import {
   type ValidatedExecutionRequest,
 } from '@agent/core/state/executionRequests';
 import { runAgent } from '@agent/runtime/runAgent';
+import { attachLegacyProgressEventProjection } from '@agent/runtime/LegacyProgressEventProjection';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
 import type {
@@ -185,6 +186,10 @@ export async function executeCliRequest(
     defaultSession(),
     runtimeHost,
   );
+  const detachLegacyProgressProjection = attachLegacyProgressEventProjection(
+    defaultSession().events,
+    runtimeHost,
+  );
   const uninstallApprovalHandlers = installCliApprovalHandlers(runContext, {
     beforePrompt: () => runtimeHost.prepareInteractivePrompt?.(),
   });
@@ -244,6 +249,7 @@ export async function executeCliRequest(
       await writeTerminalStatus(ownedExecutionId, EXECUTION_STATUS.INTERRUPTED);
     }
     detachResultToast();
+    detachLegacyProgressProjection();
     uninstallApprovalHandlers();
     try {
       flushPendingRunTraces();

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -28,6 +28,7 @@ import {
 } from '@agent/runtime/resolveAndResumeStream';
 import type { ModelHandlerCompatibilityKey } from '@agent/runtime/modelHandlerCompatibilityKey';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import { resumeToolUseSnapshot } from '@agent/runtime/resumeToolUseSnapshot';
 import { selectAutoOpenFinalOutput } from '@agent/runtime/selectAutoOpenFinalOutput';
 import {
@@ -296,7 +297,6 @@ export class DesktopProgressBridge {
     });
     this.state = this.backend.state;
     this.streamLogs = this.state.streamLogs;
-    const backendSubscription = this.backend.setupEventListeners(bus);
     // Compose the extracted progress-event bridge for ghost-stream hydration,
     // stream-snapshot persistence, restored-display sending, and progress-event
     // → rail-update translation.  See #6329.
@@ -318,6 +318,9 @@ export class DesktopProgressBridge {
       onShowError: (message) => {
         void this.options.showErrorMessage?.(message);
       },
+    });
+    const backendSubscription = this.backend.setupEventListeners(bus, {
+      emit: (event, payload) => this.handleSessionProgressEvent(event, payload),
     });
     this.restartRepair = this.repairOrphanedStreamsAfterRestart();
     // Onboarding funnel (PRD: agent-native onboarding): a completed run ends
@@ -924,6 +927,14 @@ export class DesktopProgressBridge {
     this.progressEvents.onProgressEvent(event, payload);
   }
 
+  private handleSessionProgressEvent<K extends keyof ProgressEventPayloads>(
+    event: K,
+    payload: ProgressEventPayloads[K],
+  ): void {
+    this.backend.handleProgressEvent(event, payload);
+    this.progressEvents.onProgressEvent(event, payload);
+  }
+
   private streamStatusSnapshot(): Map<StreamTabId, StreamPhase> {
     return this.session.status.getAll();
   }
@@ -980,7 +991,7 @@ export class DesktopProgressBridge {
 
     this.releaseApprovalsForStream(streamId);
     this.workflowFileActions.clearStreamBackups(streamId);
-    await GoalStore.forget(streamId);
+    await GoalStore.forget(streamId, this.session);
     await this.state.clearStream(streamId);
     this.send({
       command: PROGRESS_VIEW_COMMANDS.DELETE_STREAM,
@@ -1013,7 +1024,7 @@ export class DesktopProgressBridge {
     // after the visible per-stream sweep. This is session-scoped and does not
     // touch sibling windows.
     this.session.coordinators.cleanupAllRequests();
-    await GoalStore.forgetMany([...streamIds]);
+    await GoalStore.forgetMany([...streamIds], this.session);
     // Drop persisted ghosts too: a "delete all" should leave nothing
     // for the next launch to hydrate, otherwise users would see the
     // ghosts come back zombie-style after relaunch.
@@ -1262,13 +1273,18 @@ export class DesktopProgressBridge {
       this.session,
     );
     if (result.status === 'sent' || result.status === 'queued') {
-      this.runtimeHost.emit('updateQueuedFollowUps', { streamId });
-      const wake = await wakeQueuedFollowUpStream(streamId, result, {
-        tryResumeStream: (id) => this.tryResumeStream(id),
-        isResumeInFlight: (id) => this.isResumeInFlight(id),
-      });
+      emitRuntimeEvent('updateQueuedFollowUps', { streamId }, this.session);
+      const wake = await wakeQueuedFollowUpStream(
+        streamId,
+        result,
+        {
+          tryResumeStream: (id) => this.tryResumeStream(id),
+          isResumeInFlight: (id) => this.isResumeInFlight(id),
+        },
+        this.session,
+      );
       if (wake.kind === 'dropped') {
-        this.runtimeHost.emit('updateQueuedFollowUps', { streamId });
+        emitRuntimeEvent('updateQueuedFollowUps', { streamId }, this.session);
         await this.options.showInfoMessage?.(
           'Message dropped because no session was available to receive it. Start a new agent task to continue.',
         );

--- a/packages/desktop/src/main/desktopProgressEventBridge.ts
+++ b/packages/desktop/src/main/desktopProgressEventBridge.ts
@@ -81,9 +81,10 @@ export interface DesktopProgressEventBridge {
   /**
    * Handle a progress event emitted through the runtime host.
    *
-   * The owning bridge MUST still call `bus.emit(event, payload)` itself —
-   * this method only applies the desktop-specific rail update (persist
-   * snapshot, remove ghost, route-to-progress).
+   * Applies the desktop-specific rail update (persist snapshot, remove ghost,
+   * route-to-progress). Ordinary runtime-host events are also published to the
+   * process bus by the owning bridge; session-projected facts call this through
+   * a window-local path instead.
    */
   onProgressEvent<K extends keyof ProgressEventPayloads>(
     event: K,
@@ -256,6 +257,15 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
       case 'setParentStream': {
         const data = payload as ProgressEventPayloads['setParentStream'];
         this.persistStreamSnapshot(data.childStreamId);
+        return;
+      }
+      case 'goalStateChanged': {
+        const data = payload as ProgressEventPayloads['goalStateChanged'];
+        const goal = GoalStore.getForStream(data.streamId);
+        this.opts.onGoalStateChanged(data.streamId, isGoalInFlight(goal), {
+          status: goal?.status,
+          objective: goal?.objective,
+        });
         return;
       }
       default:

--- a/packages/extension/src/commands/agent/followUpCommand.ts
+++ b/packages/extension/src/commands/agent/followUpCommand.ts
@@ -2,6 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - agent
+import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import { shouldProbePersistedFlowForFollowUp } from '@agent/runtime/followUpResumeDetection';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
@@ -71,15 +72,13 @@ async function handleFollowUpResult(
 ): Promise<void> {
   switch (result.status) {
     case 'sent':
-      extensionAgentRuntimeHost.emit('updateQueuedFollowUps', { streamId });
+      emitRuntimeEvent('updateQueuedFollowUps', { streamId });
       break;
     case 'queued':
-      extensionAgentRuntimeHost.emit('updateQueuedFollowUps', { streamId });
+      emitRuntimeEvent('updateQueuedFollowUps', { streamId });
       switch ((await wakeQueuedFollowUpStream(streamId, result)).kind) {
         case 'dropped':
-          extensionAgentRuntimeHost.emit('updateQueuedFollowUps', {
-            streamId,
-          });
+          emitRuntimeEvent('updateQueuedFollowUps', { streamId });
           await vscode.window.showWarningMessage(
             'Message dropped — no session available to receive it. Start a new agent task to continue.',
           );

--- a/packages/extension/src/commands/housekeeping/streamEventUtils.ts
+++ b/packages/extension/src/commands/housekeeping/streamEventUtils.ts
@@ -1,4 +1,4 @@
-import { bus } from '@eventBus/ProgressEventBus';
+import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 
 /**
  * How to identify the workflow tab(s) whose missing-outputs marker should be
@@ -23,8 +23,12 @@ export function emitClearMissingOutputs(
   options: ClearMissingOutputsOptions,
 ): void {
   if (options.streamIdOverride !== undefined) {
-    bus.emit('clearMissingOutputs', { streamId: options.streamIdOverride });
+    emitRuntimeEvent('clearMissingOutputs', {
+      streamId: options.streamIdOverride,
+    });
     return;
   }
-  bus.emit('clearMissingOutputs', { streamConfig: options.streamConfig });
+  emitRuntimeEvent('clearMissingOutputs', {
+    streamConfig: options.streamConfig,
+  });
 }

--- a/packages/extension/src/progressView/managers/ProgressStreamLifecycleHost.ts
+++ b/packages/extension/src/progressView/managers/ProgressStreamLifecycleHost.ts
@@ -2,7 +2,6 @@ import * as vscode from 'vscode';
 
 import type { RunCoordinatorBridge } from '@agent/runtime/runCoordinators';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
-import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import { isInFlightStatus } from '@common/constants/streamStatus';
 import type { StreamTabId } from '@shared/schemas';
 import { buildStreamInfos } from '@shared/progressView/backend/streamInfoUtils';
@@ -54,11 +53,11 @@ export class ProgressStreamLifecycleHost implements ProgressStreamLifecycleHostP
 
   cleanupDeletedStreams(streams: StreamTabId[]): void {
     // Process-wide approval reset for the single-session extension host.
-    // ToolUseFollowUpQueue has no bulk-release method, so queues are released
-    // per stream after the approval sweep.
+    // Queues are session-owned, so they are released per stream after the
+    // approval sweep through the same helper used by single-stream deletes.
     cleanupAllApprovals();
     for (const stream of streams) {
-      ToolUseFollowUpQueue.release(stream);
+      releaseStreamResources(stream);
     }
     this.backupCleaner.clearAllBackups();
     this.provider.webviewBridge.clearAll();

--- a/src/agent/followUp/ToolUseFollowUp.ts
+++ b/src/agent/followUp/ToolUseFollowUp.ts
@@ -16,11 +16,9 @@ import {
   currentSession,
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { createChannelTrace } from '@logger';
 import type { StreamTabId } from '@shared/schemas';
-import { ToolUseFollowUpQueue } from './ToolUseFollowUpQueueManager';
 import type { FollowUpQueueInput } from './FollowUpQueue';
 
 /**
@@ -66,6 +64,7 @@ export async function wakeQueuedFollowUpStream(
   streamId: StreamTabId,
   result: SendFollowUpResult,
   resumePort?: FollowUpResumePort,
+  session?: SessionHandle,
 ): Promise<FollowUpWakeResult> {
   if (
     result.status !== 'queued' ||
@@ -95,13 +94,14 @@ export async function wakeQueuedFollowUpStream(
   if (port.isResumeInFlight?.(streamId) === true) {
     return { kind: 'resume_in_flight' };
   }
-  if (StreamStatusService.isActiveOrResuming(streamId)) {
+  const ownerSession = session ?? currentSession();
+  if (ownerSession.status.isActiveOrResuming(streamId)) {
     return { kind: 'active_or_resuming' };
   }
   if (result.reason !== 'children_running') {
     return { kind: 'queued_resume_failed' };
   }
-  ToolUseFollowUpQueue.release(streamId);
+  ownerSession.followUps.release(streamId);
   return { kind: 'dropped' };
 }
 
@@ -112,8 +112,12 @@ export async function wakeQueuedFollowUpStream(
 export async function wakeOrReleaseQueuedStream(
   streamId: StreamTabId,
   result: SendFollowUpResult,
+  session?: SessionHandle,
 ): Promise<boolean> {
-  return (await wakeQueuedFollowUpStream(streamId, result)).kind !== 'dropped';
+  return (
+    (await wakeQueuedFollowUpStream(streamId, result, undefined, session))
+      .kind !== 'dropped'
+  );
 }
 
 const logger = createChannelTrace('ToolUseFollowUp');
@@ -187,9 +191,8 @@ export async function sendFollowUp(
   displayText?: string,
   session?: SessionHandle,
 ): Promise<SendFollowUpResult> {
-  const target = (
-    session ?? currentSession()
-  ).executions.getToolUseFollowUpTarget(streamId);
+  const ownerSession = session ?? currentSession();
+  const target = ownerSession.executions.getToolUseFollowUpTarget(streamId);
   const item =
     typeof followUp === 'string'
       ? { text: followUp, mediaFiles, displayText }
@@ -204,7 +207,7 @@ export async function sendFollowUp(
   if (target.kind === 'queue') {
     // children_running reopens a queue sealed by session disposal; callers
     // must auto-resume the parent or release again to avoid stale delivery.
-    ToolUseFollowUpQueue.enqueue(streamId, item, {
+    ownerSession.followUps.enqueue(streamId, item, {
       createIfMissing: true,
       force: target.reason === 'children_running',
     });

--- a/src/agent/followUp/ToolUseFollowUpQueueManager.ts
+++ b/src/agent/followUp/ToolUseFollowUpQueueManager.ts
@@ -1,10 +1,3 @@
-/**
- * Static manager for follow-up queues indexed by stream ID.
- *
- * Provides queue acquisition, release, and coordination for routing
- * follow-ups to active/resuming sessions.
- */
-
 import { createChannelTrace } from '@logger';
 import type { StreamTabId } from '@shared/schemas';
 import {
@@ -16,15 +9,19 @@ import {
 const logger = createChannelTrace('ToolUseFollowUpQueue');
 
 /**
- * Static manager for follow-up queues indexed by stream ID.
+ * Follow-up queue owner indexed by stream ID.
+ *
+ * Fresh instances are session-owned. Static methods proxy to the process
+ * default instance so unmigrated default-session callers stay byte-identical.
  */
 export class ToolUseFollowUpQueue {
-  private static readonly queues = new Map<StreamTabId, FollowUpQueue>();
+  private static readonly defaultQueue = new ToolUseFollowUpQueue();
+  private readonly queues = new Map<StreamTabId, FollowUpQueue>();
   /** Streams whose queues were explicitly released (orchestrator disposed). */
-  private static readonly released = new Set<StreamTabId>();
+  private readonly released = new Set<StreamTabId>();
   static readonly RELEASED_CAP = 500;
   /** Observers notified whenever a stream's queue is released. */
-  private static readonly releaseObservers = new Set<
+  private readonly releaseObservers = new Set<
     (streamId: StreamTabId) => void
   >();
 
@@ -34,14 +31,14 @@ export class ToolUseFollowUpQueue {
    * polling) to tear down stream-scoped subscriptions when the owning stream
    * goes away.
    */
-  static onRelease(observer: (streamId: StreamTabId) => void): () => void {
+  onRelease(observer: (streamId: StreamTabId) => void): () => void {
     this.releaseObservers.add(observer);
     return () => {
       this.releaseObservers.delete(observer);
     };
   }
 
-  static acquire(streamId: StreamTabId): FollowUpQueue {
+  acquire(streamId: StreamTabId): FollowUpQueue {
     this.released.delete(streamId);
     const existing = this.queues.get(streamId);
     if (existing) return existing;
@@ -50,7 +47,7 @@ export class ToolUseFollowUpQueue {
     return queue;
   }
 
-  static release(streamId: StreamTabId): void {
+  release(streamId: StreamTabId): void {
     const queue = this.queues.get(streamId);
     if (queue) {
       queue.dispose();
@@ -81,7 +78,7 @@ export class ToolUseFollowUpQueue {
    * responsible for ensuring a consumer will drain it, or releasing again on
    * failure).
    */
-  static enqueue(
+  enqueue(
     streamId: StreamTabId,
     followUp: FollowUpQueueInput,
     options?: { createIfMissing?: boolean; force?: boolean },
@@ -105,27 +102,63 @@ export class ToolUseFollowUpQueue {
     return true;
   }
 
-  static drain(streamId: StreamTabId): string[] {
+  drain(streamId: StreamTabId): string[] {
     return this.queues.get(streamId)?.drain() ?? [];
   }
 
   /** Drain queued follow-ups with their media file paths (resume replay). */
-  static drainItems(streamId: StreamTabId): DrainedFollowUpItem[] {
+  drainItems(streamId: StreamTabId): DrainedFollowUpItem[] {
     return this.queues.get(streamId)?.drainItems() ?? [];
   }
 
   /** Get all queued follow-up messages for a stream without consuming them. */
-  static getAll(streamId: StreamTabId): string[] {
+  getAll(streamId: StreamTabId): string[] {
     return this.queues.get(streamId)?.getAll() ?? [];
   }
 
-  private static rememberReleased(streamId: StreamTabId): void {
+  private rememberReleased(streamId: StreamTabId): void {
     this.released.delete(streamId);
     this.released.add(streamId);
-    while (this.released.size > this.RELEASED_CAP) {
+    while (this.released.size > ToolUseFollowUpQueue.RELEASED_CAP) {
       const oldest = this.released.values().next().value;
       if (oldest === undefined) return;
       this.released.delete(oldest);
     }
+  }
+
+  static onRelease(observer: (streamId: StreamTabId) => void): () => void {
+    return this.defaultQueue.onRelease(observer);
+  }
+
+  static acquire(streamId: StreamTabId): FollowUpQueue {
+    return this.defaultQueue.acquire(streamId);
+  }
+
+  static release(streamId: StreamTabId): void {
+    this.defaultQueue.release(streamId);
+  }
+
+  static enqueue(
+    streamId: StreamTabId,
+    followUp: FollowUpQueueInput,
+    options?: { createIfMissing?: boolean; force?: boolean },
+  ): boolean {
+    return this.defaultQueue.enqueue(streamId, followUp, options);
+  }
+
+  static drain(streamId: StreamTabId): string[] {
+    return this.defaultQueue.drain(streamId);
+  }
+
+  static drainItems(streamId: StreamTabId): DrainedFollowUpItem[] {
+    return this.defaultQueue.drainItems(streamId);
+  }
+
+  static getAll(streamId: StreamTabId): string[] {
+    return this.defaultQueue.getAll(streamId);
+  }
+
+  static defaultInstance(): ToolUseFollowUpQueue {
+    return this.defaultQueue;
   }
 }

--- a/src/agent/implementations/flows/tooluse/ToolUseSessionLifecycle.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseSessionLifecycle.ts
@@ -7,10 +7,13 @@ import type { IToolUseSession } from '@agent/core/flows/IToolUseSession';
 import type { StreamTabId } from '@shared/schemas';
 
 export class ToolUseSessionLifecycle implements IToolUseSession {
-  private readonly followUps = ToolUseFollowUpQueue.acquire(this.streamTabId);
+  private readonly followUps = this.queue.acquire(this.streamTabId);
   private syntheticFollowUpPending = false;
 
-  constructor(private readonly streamTabId: StreamTabId) {}
+  constructor(
+    private readonly streamTabId: StreamTabId,
+    private readonly queue: ToolUseFollowUpQueue,
+  ) {}
 
   appendFollowUp(followUp: FollowUpQueueInput): void {
     this.followUps.enqueue(followUp);
@@ -42,6 +45,6 @@ export class ToolUseSessionLifecycle implements IToolUseSession {
   }
 
   dispose(): void {
-    ToolUseFollowUpQueue.release(this.streamTabId);
+    this.queue.release(this.streamTabId);
   }
 }

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -150,7 +150,10 @@ export async function runToolUseFlow<C = unknown>(
   // closure below fires from the host thread outside the ALS, so it must use
   // this captured handle, not a fresh currentSession() lookup.
   const runSession = currentSession();
-  const sessionLifecycle = new ToolUseSessionLifecycle(streamId);
+  const sessionLifecycle = new ToolUseSessionLifecycle(
+    streamId,
+    runSession.followUps,
+  );
   const registry = toolRegistry ?? getDefaultToolRegistry();
   const delegationDepth = input.delegation?.delegationDepth ?? 0;
   const delegationGate = evaluateCurrentDelegationGate(delegationDepth);

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -336,7 +336,11 @@ async function assembleAgentLaunchContext(
   // runs outside any ALS, so it resolves to the process default. Either way the
   // child is tracked in the same session as its launcher.
   const session = input.session ?? currentSession();
-  const rawRunTrace = createRunTrace(streamId, undefined, session.flushers);
+  const rawRunTrace = createRunTrace(
+    streamId,
+    session.transcripts,
+    session.flushers,
+  );
   const detachSessionTrace = session.attachRunTrace(
     rawRunTrace.trace,
     streamId,

--- a/src/agent/runtime/ExecutionSubscriptionBinder.ts
+++ b/src/agent/runtime/ExecutionSubscriptionBinder.ts
@@ -17,6 +17,7 @@ import {
   type ExecutionProgress,
   type ExecutionRegistry,
 } from '@agent/runtime/executionRegistry';
+import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { sendFollowUp } from '@agent/followUp/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
@@ -177,9 +178,11 @@ class ExecutionSubscription implements Disposable {
     )
       .then((result) => {
         if (result.status === 'sent' || result.status === 'queued') {
-          this.runtimeHost.emit('updateQueuedFollowUps', {
-            streamId: this.streamId,
-          });
+          emitRuntimeEvent(
+            'updateQueuedFollowUps',
+            { streamId: this.streamId },
+            this.session,
+          );
         }
       })
       .catch((err: unknown) => {

--- a/src/agent/runtime/LegacyProgressEventProjection.ts
+++ b/src/agent/runtime/LegacyProgressEventProjection.ts
@@ -1,0 +1,99 @@
+import type { AgentEvent } from '@agent/trace';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+
+import type { SessionEventHub, SessionFact } from './SessionEventHub';
+
+function emitLegacySessionFact(
+  runtimeHost: AgentRuntimeHost,
+  fact: SessionFact,
+): void {
+  switch (fact.type) {
+    case 'goalStateChanged':
+      runtimeHost.emit('goalStateChanged', fact.payload);
+      return;
+    case 'inquiryThreadUpdated':
+      runtimeHost.emit('inquiryThreadUpdated', fact.payload);
+      return;
+    case 'clearMissingOutputs':
+      runtimeHost.emit('clearMissingOutputs', fact.payload);
+      return;
+    case 'updateQueuedFollowUps':
+      runtimeHost.emit('updateQueuedFollowUps', fact.payload);
+      return;
+    case 'setActiveStream':
+      runtimeHost.emit('setActiveStream', fact.payload);
+      return;
+  }
+}
+
+function emitLegacyRunEvent(
+  runtimeHost: AgentRuntimeHost,
+  event: AgentEvent,
+): void {
+  if (event.type === 'child.activity') {
+    if (event.kind === 'subagents') {
+      runtimeHost.emit('updateActiveSubagents', {
+        parentStreamId: event.parentStreamId,
+        children: [...event.children],
+      });
+      return;
+    }
+    if (event.kind === 'processes') {
+      runtimeHost.emit('updateActiveProcesses', {
+        parentStreamId: event.parentStreamId,
+        processes: [...event.processes],
+      });
+      return;
+    }
+    runtimeHost.emit('setParentStream', {
+      childStreamId: event.childStreamId,
+      parentStreamId: event.parentStreamId,
+    });
+    return;
+  }
+
+  if (event.type === 'process.output') {
+    runtimeHost.emit('updateProcessOutput', {
+      parentStreamId: event.parentStreamId,
+      executionId: event.executionId,
+      stdout: event.stdout,
+      stderr: event.stderr,
+    });
+  }
+}
+
+/**
+ * Temporary Stage 3a bridge from the new session-owned fact plane to the old
+ * ProgressEventPayloads surface. It is intentionally finite and one-way:
+ * SessionEventHub remains the source of truth for the migrated facts, while
+ * legacy hosts keep their byte-identical payload names until their consumers
+ * move to the session plane.
+ */
+export function attachLegacyProgressEventProjection(
+  events: SessionEventHub,
+  runtimeHost: AgentRuntimeHost,
+): () => void {
+  const detachSessionFacts = events.subscribe(
+    (sessionEvent) => {
+      if (sessionEvent.scope === 'session') {
+        emitLegacySessionFact(runtimeHost, sessionEvent.event);
+      }
+    },
+    { scope: 'session' },
+  );
+  const detachRunFacts = events.subscribe(
+    (sessionEvent) => {
+      if (sessionEvent.scope !== 'run') return;
+      emitLegacyRunEvent(runtimeHost, sessionEvent.event);
+    },
+    {
+      scope: 'run',
+      types: ['child.activity', 'process.output'],
+    },
+  );
+
+  return () => {
+    detachRunFacts();
+    detachSessionFacts();
+  };
+}

--- a/src/agent/runtime/ProcessOutputPoller.ts
+++ b/src/agent/runtime/ProcessOutputPoller.ts
@@ -4,9 +4,9 @@ import pMap from 'p-map';
 
 import { platform } from '@platform/platform';
 import * as logger from '@logger/logUtils';
-import type { StreamTabId } from '@shared/schemas';
-import { toErrorMessage } from '@utils/errors/errorMessage';
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { delay } from '@utils/core/async';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 import type { ProcessExecutionHandle } from './ExecutionHandle';
@@ -15,6 +15,15 @@ interface ProcessOutputSource {
   handle: ProcessExecutionHandle;
   runtimeHost: AgentRuntimeHost;
 }
+
+export interface ProcessOutputPayload {
+  readonly parentStreamId: StreamTabId;
+  readonly executionId: ExecutionId;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+type ProcessOutputEmitter = (payload: ProcessOutputPayload) => void;
 
 /** Interval at which temp files are read and pushed to the progress UI. */
 const OUTPUT_POLL_INTERVAL_MS = 500;
@@ -42,6 +51,15 @@ export class ProcessOutputPoller {
   private readonly processOutputs = new Map<string, ProcessOutputSource>();
   private readonly readingInProgress = new Map<string, Promise<void>>();
   private loopController: AbortController | null = null;
+  private emitOutput: ProcessOutputEmitter | undefined;
+
+  constructor(emitOutput?: ProcessOutputEmitter) {
+    this.emitOutput = emitOutput;
+  }
+
+  setOutputEmitter(emitOutput: ProcessOutputEmitter): void {
+    this.emitOutput = emitOutput;
+  }
 
   register(
     handle: ProcessExecutionHandle,
@@ -85,7 +103,7 @@ export class ProcessOutputPoller {
       state.stdout.decoder = new StringDecoder('utf8');
       state.stderr.decoder = new StringDecoder('utf8');
       if (outTail || errTail) {
-        runtimeHost.emit('updateProcessOutput', {
+        this.emitProcessOutput(runtimeHost, {
           parentStreamId: handle.parentStreamId,
           executionId: handle.executionId,
           stdout: outTail,
@@ -213,7 +231,7 @@ export class ProcessOutputPoller {
         ]);
         if (!outText && !errText) return;
 
-        runtimeHost.emit('updateProcessOutput', {
+        this.emitProcessOutput(runtimeHost, {
           parentStreamId,
           executionId,
           stdout: outText,
@@ -239,6 +257,17 @@ export class ProcessOutputPoller {
         this.readingInProgress.delete(executionId);
       }
     }
+  }
+
+  private emitProcessOutput(
+    runtimeHost: AgentRuntimeHost,
+    payload: ProcessOutputPayload,
+  ): void {
+    if (this.emitOutput) {
+      this.emitOutput(payload);
+      return;
+    }
+    runtimeHost.emit('updateProcessOutput', payload);
   }
 }
 

--- a/src/agent/runtime/SessionEventHub.ts
+++ b/src/agent/runtime/SessionEventHub.ts
@@ -1,12 +1,33 @@
 import process from 'node:process';
 
 import type { AgentEvent } from '@agent/trace';
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import { createChannelTrace } from '@logger';
 import type { StreamTabId } from '@shared/schemas';
 
 const logger = createChannelTrace('SessionEventHub');
 
-export type SessionFact = never;
+export type SessionFact =
+  | {
+      readonly type: 'goalStateChanged';
+      readonly payload: ProgressEventPayloads['goalStateChanged'];
+    }
+  | {
+      readonly type: 'inquiryThreadUpdated';
+      readonly payload: ProgressEventPayloads['inquiryThreadUpdated'];
+    }
+  | {
+      readonly type: 'clearMissingOutputs';
+      readonly payload: ProgressEventPayloads['clearMissingOutputs'];
+    }
+  | {
+      readonly type: 'updateQueuedFollowUps';
+      readonly payload: ProgressEventPayloads['updateQueuedFollowUps'];
+    }
+  | {
+      readonly type: 'setActiveStream';
+      readonly payload: ProgressEventPayloads['setActiveStream'];
+    };
 
 export type SessionEvent =
   | { scope: 'run'; streamId: StreamTabId; event: AgentEvent }

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -27,7 +27,12 @@
  * session is justified only as the ownership container.
  */
 
-import { getActiveFlushers, unregisterFlushers } from '@transcript';
+import {
+  getActiveFlushers,
+  getDefaultStreamLogStore,
+  StreamLogStore,
+  unregisterFlushers,
+} from '@transcript';
 import type { AgentTrace, ResultEvent } from '@agent/trace';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import { createChannelTrace } from '@logger';
@@ -60,6 +65,8 @@ export type SessionHandleInit = Partial<
     | 'subscriptions'
     | 'events'
     | 'status'
+    | 'transcripts'
+    | 'followUps'
     | 'flushers'
     | 'hostChannel'
   >
@@ -86,6 +93,10 @@ export class SessionHandle {
   readonly events: SessionEventHub;
   /** Session-scoped status plane; wraps shared status data during migration. */
   readonly status: StreamStatusMachine;
+  /** Session-owned transcript store for run traces launched in this session. */
+  readonly transcripts: StreamLogStore;
+  /** Session-owned follow-up queue owner. */
+  readonly followUps: ToolUseFollowUpQueue;
   /** This session's trace-flush callbacks (drained on dispose / shutdown). */
   readonly flushers: Set<() => void>;
   /**
@@ -99,31 +110,31 @@ export class SessionHandle {
     // member fall back to a neighboring module singleton (silent-state-split).
     const interrupts = init.interrupts ?? new InterruptRegistry();
     const status = init.status ?? new StreamStatusMachine();
+    const events = init.events ?? new SessionEventHub();
+    const transcripts = init.transcripts ?? new StreamLogStore();
+    const followUps = init.followUps ?? new ToolUseFollowUpQueue();
     const executions =
       init.executions ??
-      new ExecutionRegistry({ interrupts, streamStatus: status });
+      new ExecutionRegistry({ interrupts, streamStatus: status, events });
+    executions.attachSessionEvents(events);
     const coordinators =
       init.coordinators ?? new RunCoordinatorBridge(executions);
 
     this.interrupts = interrupts;
     this.executions = executions;
     this.coordinators = coordinators;
-    // INVARIANT (SDK Step 7d residue #9): this per-session binder reads the
-    // process-global, streamId-keyed `ToolUseFollowUpQueue` as its release
-    // source. That is coherent ONLY while the queue stays keyed by the globally-
-    // unique streamId — a session's release then touches only its own streams.
-    // If the queue is ever re-keyed (e.g. by sessionId+streamId), per-session
-    // cleanup silently breaks; the queue must move onto the session at that point.
     const subscriptions =
       init.subscriptions ??
       new ExecutionSubscriptionBinder({
         registry: executions,
-        releaseSource: ToolUseFollowUpQueue,
+        releaseSource: followUps,
         session: this,
       });
     this.subscriptions = subscriptions;
-    this.events = init.events ?? new SessionEventHub();
+    this.events = events;
     this.status = status;
+    this.transcripts = transcripts;
+    this.followUps = followUps;
     // A fresh session owns its own flusher set; the default session aliases the
     // process-module set so `createRunTrace`'s default writes still drain.
     this.flushers = init.flushers ?? new Set<() => void>();
@@ -287,6 +298,8 @@ export function defaultSession(): SessionHandle {
     coordinators: runCoordinatorBridge,
     subscriptions: executionSubscriptionBinder,
     status: StreamStatusService,
+    transcripts: getDefaultStreamLogStore(),
+    followUps: ToolUseFollowUpQueue.defaultInstance(),
     flushers: getActiveFlushers(),
   }));
 }

--- a/src/agent/runtime/emitRuntimeEvent.ts
+++ b/src/agent/runtime/emitRuntimeEvent.ts
@@ -4,11 +4,13 @@
  * Replaces scattered `bus.emit(...)` in `src/tools` so one fact has one emit
  * path and one name, resolving the target in priority order:
  *
- * 1. a host-path caller's `session.hostChannel` (set only by hosts that own a
+ * 1. migrated Stage 3a facts go to the owning `SessionEventHub` and are
+ *    projected to the legacy host surface by `LegacyProgressEventProjection`;
+ * 2. a host-path caller's `session.hostChannel` (set only by hosts that own a
  *    non-default session, e.g. a desktop window) — when present;
- * 2. otherwise the active run's `runtimeHost`, resolved from the ambient
+ * 3. otherwise the active run's `runtimeHost`, resolved from the ambient
  *    {@link RunContext} (the in-run case — tools firing inside a run's ALS);
- * 3. otherwise the process {@link bus} — the single-session fallback that keeps
+ * 4. otherwise the process {@link bus} — the single-session fallback that keeps
  *    the extension byte-identical (its run `runtimeHost.emit` is `bus.emit`
  *    anyway) and host-path callers that pass no session unchanged.
  *
@@ -19,13 +21,96 @@
 import { bus, type ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
 import { tryUseRunContext } from './RunContext';
-import type { SessionHandle } from './SessionHandle';
+import { defaultSession, type SessionHandle } from './SessionHandle';
+import type { AgentRuntimeHost } from './AgentRuntimeHost';
+import type { SessionFact } from './SessionEventHub';
+
+function emitLegacyHostFact(host: AgentRuntimeHost, fact: SessionFact): void {
+  switch (fact.type) {
+    case 'goalStateChanged':
+      host.emit('goalStateChanged', fact.payload);
+      return;
+    case 'inquiryThreadUpdated':
+      host.emit('inquiryThreadUpdated', fact.payload);
+      return;
+    case 'clearMissingOutputs':
+      host.emit('clearMissingOutputs', fact.payload);
+      return;
+    case 'updateQueuedFollowUps':
+      host.emit('updateQueuedFollowUps', fact.payload);
+      return;
+    case 'setActiveStream':
+      host.emit('setActiveStream', fact.payload);
+      return;
+  }
+}
+
+function emitSessionFact(fact: SessionFact, session?: SessionHandle): void {
+  const owner = session ?? tryUseRunContext()?.session;
+  if (owner?.events) {
+    owner.events.emit({ scope: 'session', event: fact });
+    return;
+  }
+  if (owner?.hostChannel) {
+    emitLegacyHostFact(owner.hostChannel, fact);
+    return;
+  }
+  defaultSession().events.emit({ scope: 'session', event: fact });
+}
 
 export function emitRuntimeEvent<K extends keyof ProgressEventPayloads>(
   event: K,
   payload: ProgressEventPayloads[K],
   session?: SessionHandle,
 ): void {
+  switch (event) {
+    case 'goalStateChanged':
+      emitSessionFact(
+        {
+          type: 'goalStateChanged',
+          payload: payload as ProgressEventPayloads['goalStateChanged'],
+        },
+        session,
+      );
+      return;
+    case 'inquiryThreadUpdated':
+      emitSessionFact(
+        {
+          type: 'inquiryThreadUpdated',
+          payload: payload as ProgressEventPayloads['inquiryThreadUpdated'],
+        },
+        session,
+      );
+      return;
+    case 'clearMissingOutputs':
+      emitSessionFact(
+        {
+          type: 'clearMissingOutputs',
+          payload: payload as ProgressEventPayloads['clearMissingOutputs'],
+        },
+        session,
+      );
+      return;
+    case 'updateQueuedFollowUps':
+      emitSessionFact(
+        {
+          type: 'updateQueuedFollowUps',
+          payload: payload as ProgressEventPayloads['updateQueuedFollowUps'],
+        },
+        session,
+      );
+      return;
+    case 'setActiveStream':
+      emitSessionFact(
+        {
+          type: 'setActiveStream',
+          payload: payload as ProgressEventPayloads['setActiveStream'],
+        },
+        session,
+      );
+      return;
+  }
+
   const host = session?.hostChannel ?? tryUseRunContext()?.runtimeHost;
   if (host) host.emit(event, payload);
   else bus.emit(event, payload);

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -7,6 +7,7 @@ import {
   runToolUseFlow,
   type RunToolUseFlowResult,
 } from '@agent/implementations/flows/tooluse/runToolUseFlow';
+import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import type { IToolUseSession } from '@agent/core/flows/IToolUseSession';
 import type { ToolUseBeforeWaitingCallback } from '@agent/implementations/flows/tooluse/ToolUseServices';
 import {
@@ -180,7 +181,7 @@ async function runToolUseAgent(
           options.onProgress?.(update);
         },
         onFollowUpConsumed: () => {
-          ctx.runtimeHost.emit('updateQueuedFollowUps', {
+          emitRuntimeEvent('updateQueuedFollowUps', {
             streamId: ctx.streamId,
           });
           options.onFollowUpConsumed?.();
@@ -492,7 +493,7 @@ export async function resumeToolUseFromSnapshot(
             // /memories protocol) that the fresh run had included.
             isSubagent,
             onFollowUpConsumed: () =>
-              ctx.runtimeHost.emit('updateQueuedFollowUps', {
+              emitRuntimeEvent('updateQueuedFollowUps', {
                 streamId: ctx.streamId,
               }),
           },

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -37,6 +37,7 @@ import {
   isChildExecution,
 } from './ExecutionHandle';
 import { ProcessOutputPoller } from './ProcessOutputPoller';
+import type { SessionEventHub } from './SessionEventHub';
 
 export type { ExecutionHandle } from './ExecutionHandle';
 export {
@@ -140,6 +141,7 @@ export class ExecutionRegistry {
   private readonly processOutput: ProcessOutputPoller;
   private readonly streamStatus: StreamStatusMachine;
   private readonly interrupts: InterruptRegistry;
+  private events: SessionEventHub | undefined;
   // Persistent listeners stay attached across notifications (unlike one-shot
   // waiters in `changeCallbacks`). Used by the executions subscribe action.
   private readonly persistentListeners = new Map<
@@ -151,14 +153,17 @@ export class ExecutionRegistry {
     interrupts = interruptRegistry,
     processOutput = new ProcessOutputPoller(),
     streamStatus = StreamStatusService,
+    events,
   }: {
     readonly interrupts?: InterruptRegistry;
     readonly processOutput?: ProcessOutputPoller;
     readonly streamStatus?: StreamStatusMachine;
+    readonly events?: SessionEventHub;
   } = {}) {
     this.interrupts = interrupts;
     this.processOutput = processOutput;
     this.streamStatus = streamStatus;
+    if (events) this.attachSessionEvents(events);
     // Notify waiters and refresh UI badges when stream status changes
     // (e.g. RUNNING → WAITING). Without this, waitForChange only resolves
     // on progress/kill/untrack, and the background-tasks panel shows stale badges.
@@ -183,6 +188,23 @@ export class ExecutionRegistry {
     );
   }
 
+  attachSessionEvents(events: SessionEventHub): void {
+    this.events = events;
+    this.processOutput.setOutputEmitter((payload) => {
+      events.emit({
+        scope: 'run',
+        streamId: payload.parentStreamId,
+        event: {
+          type: 'process.output',
+          parentStreamId: payload.parentStreamId,
+          executionId: payload.executionId,
+          stdout: payload.stdout,
+          stderr: payload.stderr,
+        },
+      });
+    });
+  }
+
   dispose(): void {
     this.disposeStatusListener();
     const executionIds = [...this.handles.keys()];
@@ -203,7 +225,8 @@ export class ExecutionRegistry {
     if (handle instanceof AgentExecutionHandle) {
       if (handle.isChildExecution) {
         this.emitActiveSubagentsUpdate(handle.parentStreamId, runtimeHost);
-        runtimeHost.emit('setParentStream', {
+        this.emitParentStreamUpdate(runtimeHost, {
+          parentScopeStreamId: handle.parentStreamId,
           childStreamId: handle.childStreamId,
           parentStreamId: handle.parentStreamId,
         });
@@ -570,7 +593,8 @@ export class ExecutionRegistry {
       if (!isChildExecution(handle, parentStreamId)) continue;
       if (handle instanceof AgentExecutionHandle) {
         handle.detach();
-        runtimeHost.emit('setParentStream', {
+        this.emitParentStreamUpdate(runtimeHost, {
+          parentScopeStreamId: parentStreamId,
           childStreamId: handle.childStreamId,
           parentStreamId: null,
         });
@@ -679,9 +703,26 @@ export class ExecutionRegistry {
     parentStreamId: StreamTabId,
     runtimeHost: AgentRuntimeHost,
   ): void {
+    const children = this.collectChildSummary(
+      parentStreamId,
+      AgentExecutionHandle,
+    );
+    if (this.events) {
+      this.events.emit({
+        scope: 'run',
+        streamId: parentStreamId,
+        event: {
+          type: 'child.activity',
+          kind: 'subagents',
+          parentStreamId,
+          children,
+        },
+      });
+      return;
+    }
     runtimeHost.emit('updateActiveSubagents', {
       parentStreamId,
-      children: this.collectChildSummary(parentStreamId, AgentExecutionHandle),
+      children,
     });
   }
 
@@ -689,12 +730,53 @@ export class ExecutionRegistry {
     parentStreamId: StreamTabId,
     runtimeHost: AgentRuntimeHost,
   ): void {
+    const processes = this.collectChildSummary(
+      parentStreamId,
+      ProcessExecutionHandle,
+    );
+    if (this.events) {
+      this.events.emit({
+        scope: 'run',
+        streamId: parentStreamId,
+        event: {
+          type: 'child.activity',
+          kind: 'processes',
+          parentStreamId,
+          processes,
+        },
+      });
+      return;
+    }
     runtimeHost.emit('updateActiveProcesses', {
       parentStreamId,
-      processes: this.collectChildSummary(
-        parentStreamId,
-        ProcessExecutionHandle,
-      ),
+      processes,
+    });
+  }
+
+  private emitParentStreamUpdate(
+    runtimeHost: AgentRuntimeHost,
+    payload: {
+      readonly parentScopeStreamId: StreamTabId;
+      readonly childStreamId: StreamTabId;
+      readonly parentStreamId: StreamTabId | null;
+    },
+  ): void {
+    if (this.events) {
+      this.events.emit({
+        scope: 'run',
+        streamId: payload.parentScopeStreamId,
+        event: {
+          type: 'child.activity',
+          kind: 'parent',
+          childStreamId: payload.childStreamId,
+          parentStreamId: payload.parentStreamId,
+        },
+      });
+      return;
+    }
+    runtimeHost.emit('setParentStream', {
+      childStreamId: payload.childStreamId,
+      parentStreamId: payload.parentStreamId,
     });
   }
 

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -1,17 +1,16 @@
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
 import type { FollowUpQueueInput } from '@agent/followUp/FollowUpQueue';
-import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import {
   STREAM_PHASE,
   STREAM_SUBSTATE,
   type StreamTabId,
 } from '@shared/schemas';
 import { resumeToolUseFromSnapshot } from './executeAgent';
-import { StreamStatusService } from './StreamStatusService';
+import { emitRuntimeEvent } from './emitRuntimeEvent';
+import { defaultSession, type SessionHandle } from './SessionHandle';
 import type { ToolEditApprovalPort } from '@platform/interfaces/toolEditApproval';
 
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
-import type { SessionHandle } from './SessionHandle';
 
 export interface ResumeQueuedToolUseOptions {
   /** Session owning this run's coordination state. Defaults to the process session. */
@@ -55,9 +54,11 @@ export async function resumeQueuedToolUseSnapshot(
   runtimeHost: AgentRuntimeHost,
   options: ResumeQueuedToolUseOptions,
 ): Promise<boolean> {
-  const streamStatus = options.session?.status ?? StreamStatusService;
+  const session = options.session ?? defaultSession();
+  const streamStatus = session.status;
+  const followUpsQueue = session.followUps;
 
-  ToolUseFollowUpQueue.acquire(streamId);
+  followUpsQueue.acquire(streamId);
   streamStatus.transition(streamId, STREAM_PHASE.RUNNING, 'resume', {
     runtimeHost,
     substate: STREAM_SUBSTATE.RESUMING,
@@ -67,8 +68,8 @@ export async function resumeQueuedToolUseSnapshot(
   let followUps: readonly FollowUpQueueInput[] = seed;
   let resumeError: { error: unknown } | undefined;
   try {
-    followUps = [...seed, ...ToolUseFollowUpQueue.drainItems(streamId)];
-    runtimeHost.emit('updateQueuedFollowUps', { streamId });
+    followUps = [...seed, ...followUpsQueue.drainItems(streamId)];
+    emitRuntimeEvent('updateQueuedFollowUps', { streamId }, session);
 
     await resumeToolUseFromSnapshot(snapshot, runtimeHost, {
       session: options.session,
@@ -85,10 +86,10 @@ export async function resumeQueuedToolUseSnapshot(
     // Re-enqueue the drained follow-ups (explicit seed first) so a later
     // resume replays them instead of dropping them.
     for (const item of followUps) {
-      ToolUseFollowUpQueue.enqueue(streamId, item, { force: true });
+      followUpsQueue.enqueue(streamId, item, { force: true });
     }
     if (followUps.length > 0) {
-      runtimeHost.emit('updateQueuedFollowUps', { streamId });
+      emitRuntimeEvent('updateQueuedFollowUps', { streamId }, session);
     }
   } finally {
     // Only the early-failure path leaves the stream RESUMING (a started run

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -12,7 +12,9 @@ import type { RunUsageTotals } from '@agent/core/usage/RunUsageAccumulator';
 import type { AgentErrorKind } from '@common/errors';
 import type { StreamTransitionCause } from '@common/constants/streamStatus';
 import type {
+  ActiveChildInfo,
   EndGroupStatus,
+  ExecutionId,
   RetryErrorInfo,
   RunOutcome,
   StreamPhase,
@@ -133,6 +135,36 @@ export interface StatusEvent extends StageStamp {
   readonly substate?: StreamSubstate;
 }
 
+/** Session-owned child/process activity for a parent run stream. */
+export type ChildActivityEvent =
+  | (StageStamp & {
+      readonly type: 'child.activity';
+      readonly kind: 'subagents';
+      readonly parentStreamId: StreamTabId;
+      readonly children: readonly ActiveChildInfo[];
+    })
+  | (StageStamp & {
+      readonly type: 'child.activity';
+      readonly kind: 'processes';
+      readonly parentStreamId: StreamTabId;
+      readonly processes: readonly ActiveChildInfo[];
+    })
+  | (StageStamp & {
+      readonly type: 'child.activity';
+      readonly kind: 'parent';
+      readonly childStreamId: StreamTabId;
+      readonly parentStreamId: StreamTabId | null;
+    });
+
+/** Incremental output from a child process owned by a parent run stream. */
+export interface ProcessOutputEvent extends StageStamp {
+  readonly type: 'process.output';
+  readonly parentStreamId: StreamTabId;
+  readonly executionId: ExecutionId;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
 /** Context window utilisation snapshot. */
 export interface ContextStateEvent extends StageStamp {
   readonly type: 'context.state';
@@ -218,6 +250,8 @@ export type AgentEvent =
   | ToolEndEvent
   | UsageEvent
   | StatusEvent
+  | ChildActivityEvent
+  | ProcessOutputEvent
   | ContextStateEvent
   | StreamStartEvent
   | StreamChunkEvent

--- a/src/shared/progressView/backend/ProgressBackend.ts
+++ b/src/shared/progressView/backend/ProgressBackend.ts
@@ -1,5 +1,14 @@
-import type { SessionHandle } from '@agent/runtime/SessionHandle';
-import type { ProgressEventBusLike } from '@eventBus/ProgressEventBus';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { attachLegacyProgressEventProjection } from '@agent/runtime/LegacyProgressEventProjection';
+import {
+  defaultSession,
+  type SessionHandle,
+} from '@agent/runtime/SessionHandle';
+import type {
+  ProgressEvent,
+  ProgressEventBusLike,
+  ProgressEventPayloads,
+} from '@eventBus/ProgressEventBus';
 import {
   WebviewBridge,
   type ProgressViewMessageSender,
@@ -37,6 +46,45 @@ export interface ProgressBackendOptions {
   session?: SessionHandle;
 }
 
+class LocalProgressEventBus implements ProgressEventBusLike {
+  private readonly listeners = new Map<
+    ProgressEvent,
+    Set<(payload: ProgressEventPayloads[ProgressEvent]) => void>
+  >();
+
+  on<K extends ProgressEvent>(
+    event: K,
+    listener: (payload: ProgressEventPayloads[K]) => void,
+    options?: { signal?: AbortSignal },
+  ): () => void {
+    if (options?.signal?.aborted) return () => {};
+    let listeners = this.listeners.get(event);
+    if (!listeners) {
+      listeners = new Set();
+      this.listeners.set(event, listeners);
+    }
+    listeners.add(
+      listener as (payload: ProgressEventPayloads[ProgressEvent]) => void,
+    );
+    const cleanup = (): void => {
+      listeners?.delete(
+        listener as (payload: ProgressEventPayloads[ProgressEvent]) => void,
+      );
+    };
+    options?.signal?.addEventListener('abort', cleanup, { once: true });
+    return cleanup;
+  }
+
+  emit<K extends ProgressEvent>(
+    event: K,
+    payload: ProgressEventPayloads[K],
+  ): void {
+    for (const listener of this.listeners.get(event) ?? []) {
+      listener(payload);
+    }
+  }
+}
+
 /**
  * Host-neutral progress-view backend composition.
  *
@@ -49,12 +97,15 @@ export class ProgressBackend {
   readonly webviewUpdater: WebviewUpdater;
   readonly webviewBridge: WebviewBridge;
   readonly eventHandler: ProgressEventHandler;
+  private readonly session: SessionHandle;
+  private readonly localEvents = new LocalProgressEventBus();
 
   constructor(options: ProgressBackendOptions) {
+    this.session = options.session ?? defaultSession();
     this.state = new ProgressViewState(
       options.storage,
       options.snapshots,
-      options.session,
+      this.session,
     );
     this.webviewUpdater = new WebviewUpdater((message) => {
       // View refreshes are best-effort; a closed transport must not take down
@@ -88,8 +139,32 @@ export class ProgressBackend {
     await this.state.load();
   }
 
-  setupEventListeners(bus: ProgressEventBusLike): ProgressEventSubscription {
-    return this.eventHandler.setupEventListeners(bus);
+  setupEventListeners(
+    bus: ProgressEventBusLike,
+    sessionProjectionTarget: AgentRuntimeHost = bus,
+  ): ProgressEventSubscription {
+    const busSubscription = this.eventHandler.setupEventListeners(bus);
+    const localSubscription = this.eventHandler.setupEventListeners(
+      this.localEvents,
+    );
+    const detachProjection = attachLegacyProgressEventProjection(
+      this.session.events,
+      sessionProjectionTarget,
+    );
+    return {
+      dispose: () => {
+        detachProjection();
+        localSubscription.dispose();
+        busSubscription.dispose();
+      },
+    };
+  }
+
+  handleProgressEvent<K extends ProgressEvent>(
+    event: K,
+    payload: ProgressEventPayloads[K],
+  ): void {
+    this.localEvents.emit(event, payload);
   }
 
   dispose(): void {

--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -1,6 +1,5 @@
 import type { AgentTrace } from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import { isInFlightStatus } from '@common/constants/streamStatus';
 import type {
   ProgressEventBusLike,
@@ -243,7 +242,7 @@ export class ProgressEventHandler {
         // Follow-up events
         updateQueuedFollowUps: (ctx, { streamId }) => {
           this.sendIfActive(streamId, () => {
-            const messages = ToolUseFollowUpQueue.getAll(streamId);
+            const messages = ctx.state.followUps.getAll(streamId);
             ctx.webviewUpdater.updateQueuedFollowUps(streamId, messages);
           });
         },
@@ -521,7 +520,7 @@ export class ProgressEventHandler {
 
     const extras = this.buildStreamSyncExtras(stream);
     const { todos, plan } = this.state.snapshots.getWorkPlan(stream);
-    const queuedFollowUps = ToolUseFollowUpQueue.getAll(stream);
+    const queuedFollowUps = this.state.followUps.getAll(stream);
     const agentCategory = this.getStreamCategory(stream);
 
     // Optionally include active-stream state (replaces syncActiveStreamState).

--- a/src/shared/progressView/backend/state/ProgressViewState.ts
+++ b/src/shared/progressView/backend/state/ProgressViewState.ts
@@ -1,12 +1,9 @@
 import { z } from 'zod';
 
-import {
-  setDefaultStreamLogStore,
-  StreamLogStore,
-  StreamSnapshotStore,
-} from '@transcript';
+import { StreamSnapshotStore, type StreamLogStore } from '@transcript';
 import type { AgentTrace } from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import type { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import {
   defaultSession,
@@ -135,6 +132,7 @@ export class ProgressViewState {
   private _sessionState = new Map<StreamTabId, StreamSessionState>();
 
   readonly streamStatus: StreamStatusMachine;
+  readonly followUps: ToolUseFollowUpQueue;
 
   private readonly logger: AgentTrace;
   private readonly session: SessionHandle;
@@ -152,8 +150,8 @@ export class ProgressViewState {
       WorkspaceStateKey.PROGRESS_VIEW_PREFS,
       ProgressViewPrefsSchema,
     );
-    this.streamLogs = new StreamLogStore();
-    setDefaultStreamLogStore(this.streamLogs);
+    this.streamLogs = session.transcripts;
+    this.followUps = session.followUps;
     this.snapshots = snapshots;
   }
 

--- a/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
@@ -9,6 +9,7 @@ import {
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { attachLegacyProgressEventProjection } from '@agent/runtime/LegacyProgressEventProjection';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
@@ -58,6 +59,18 @@ function startCodexChild(
     config,
     toolName: 'codex',
   });
+}
+
+function withLegacyProjection<T>(host: AgentRuntimeHost, run: () => T): T {
+  const detach = attachLegacyProgressEventProjection(
+    defaultSession().events,
+    host,
+  );
+  try {
+    return run();
+  } finally {
+    detach();
+  }
 }
 
 describe('child stream progress events', () => {
@@ -128,19 +141,23 @@ describe('child stream progress events', () => {
   it('publishes child stream lifecycle events through the explicit runtime host', () => {
     const active = createRecordingHost();
 
-    const childStream = createChildStream(executionId, parentStreamId, {
-      runtimeHost: active.host,
-      streamPrefix: 'bash',
-      streamCategory: AgentCategory.ToolUse,
-      agentName: 'test-agent',
-      description: 'Run a background bash command',
-      config,
-      toolName: 'bash',
-    });
+    const childStream = withLegacyProjection(active.host, () =>
+      createChildStream(executionId, parentStreamId, {
+        runtimeHost: active.host,
+        streamPrefix: 'bash',
+        streamCategory: AgentCategory.ToolUse,
+        agentName: 'test-agent',
+        description: 'Run a background bash command',
+        config,
+        toolName: 'bash',
+      }),
+    );
 
     expect(childStream.childStreamId).toBe(childStreamId);
 
-    childStream.finalize({ autoClose: true });
+    withLegacyProjection(active.host, () =>
+      childStream.finalize({ autoClose: true }),
+    );
 
     const { events } = active;
     expect(events.map((entry) => entry.event)).toEqual([
@@ -216,10 +233,12 @@ describe('child stream progress events', () => {
   it('publishes child loop status changes through the child stream owner', async () => {
     const active = createRecordingHost();
 
-    const childStream = startCodexChild(
-      loopExecutionId,
-      active.host,
-      'Run a long-lived Codex child loop',
+    const childStream = withLegacyProjection(active.host, () =>
+      startCodexChild(
+        loopExecutionId,
+        active.host,
+        'Run a long-lived Codex child loop',
+      ),
     );
     const handle =
       defaultSession().executions.getAgentHandleByStream(loopChildStreamId);
@@ -229,7 +248,9 @@ describe('child stream progress events', () => {
     childStream.waitForInput();
     childStream.beginTurn();
     childStream.failTurn();
-    childStream.finalize({ status: STREAM_STATUS.ERROR });
+    withLegacyProjection(active.host, () =>
+      childStream.finalize({ status: STREAM_STATUS.ERROR }),
+    );
 
     const statusEvents = active.events.filter(
       (entry) => entry.event === 'updateStreamStatus',

--- a/src/test-kernel/agent/followUp/FollowUpQueue.vitest.ts
+++ b/src/test-kernel/agent/followUp/FollowUpQueue.vitest.ts
@@ -8,6 +8,10 @@ import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManage
 import type { StreamTabId } from '@shared/schemas';
 
 describe('FollowUpQueue', () => {
+  function createLifecycle(streamId: StreamTabId): ToolUseSessionLifecycle {
+    return new ToolUseSessionLifecycle(streamId, new ToolUseFollowUpQueue());
+  }
+
   it('batches visible follow-ups for normal user input', async () => {
     const queue = new FollowUpQueue();
 
@@ -110,9 +114,7 @@ describe('FollowUpQueue', () => {
   });
 
   it('coalesces duplicate synthetic session follow-ups', async () => {
-    const session = new ToolUseSessionLifecycle(
-      'stream:synthetic-coalesce' as StreamTabId,
-    );
+    const session = createLifecycle('stream:synthetic-coalesce' as StreamTabId);
 
     try {
       session.appendSyntheticFollowUp('compact now');
@@ -129,7 +131,7 @@ describe('FollowUpQueue', () => {
   });
 
   it('allows synthetic session follow-ups after an interrupt clears the queue', async () => {
-    const session = new ToolUseSessionLifecycle(
+    const session = createLifecycle(
       'stream:synthetic-interrupt' as StreamTabId,
     );
 
@@ -148,9 +150,7 @@ describe('FollowUpQueue', () => {
   });
 
   it('attaches media to a session follow-up', async () => {
-    const session = new ToolUseSessionLifecycle(
-      'stream:media-followup' as StreamTabId,
-    );
+    const session = createLifecycle('stream:media-followup' as StreamTabId);
 
     try {
       session.appendFollowUp({

--- a/src/test-kernel/agent/followUp/GitHubSubscriptionProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/GitHubSubscriptionProgressEvents.vitest.ts
@@ -12,7 +12,7 @@ vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
 // Local imports - agent runtime
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
-import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import { SessionHandle } from '@agent/runtime/SessionHandle';
 
 // Local imports - shared schemas
 import type { StreamTabId } from '@shared/schemas';
@@ -223,7 +223,7 @@ describe('GitHub subscription progress events', () => {
     const streamId = 'stream-a' as StreamTabId;
     const host = createRecordingHost();
     const source = new RegistryTestSource();
-    const session = { tag: 'window-session' } as unknown as SessionHandle;
+    const session = new SessionHandle();
     const registry = new StreamSubscriptionRegistry<string, string>({
       name: 'test subscriptions',
       source,
@@ -232,24 +232,28 @@ describe('GitHub subscription progress events', () => {
     });
     sendFollowUpMock.mockClear();
 
-    withRunContext(
-      createRunContext({
-        runtimeHost: host.host,
+    try {
+      withRunContext(
+        createRunContext({
+          runtimeHost: host.host,
+          streamId,
+          session,
+        }),
+        () => registry.bind(streamId, 'owner/repo', host.host),
+      );
+
+      source.emit('owner/repo', 'new github event');
+
+      expect(sendFollowUpMock).toHaveBeenCalledWith(
         streamId,
+        'new github event',
+        undefined,
+        undefined,
         session,
-      }),
-      () => registry.bind(streamId, 'owner/repo', host.host),
-    );
-
-    source.emit('owner/repo', 'new github event');
-
-    expect(sendFollowUpMock).toHaveBeenCalledWith(
-      streamId,
-      'new github event',
-      undefined,
-      undefined,
-      session,
-    );
+      );
+    } finally {
+      session.dispose();
+    }
   });
 
   it('warns instead of leaking an unhandled rejection when delivery fails', async () => {

--- a/src/test-kernel/agent/runtime/EmitRuntimeEvent.vitest.ts
+++ b/src/test-kernel/agent/runtime/EmitRuntimeEvent.vitest.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 // Local imports - runtime
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
-import { SessionHandle } from '@agent/runtime/SessionHandle';
+import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
 import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import { bus } from '@eventBus/ProgressEventBus';
 import type { StreamTabId } from '@shared/schemas';
@@ -13,27 +13,42 @@ import { createRecordingHost } from '../progressTestUtils';
 const streamId = (s: string): StreamTabId => s as StreamTabId;
 
 describe('emitRuntimeEvent (SDK Step 7d F-1 — one emit path)', () => {
-  it('falls back to the process bus with no session and no run context', () => {
+  it('routes migrated facts to the default session instead of the process bus', () => {
+    const sessionSeen: unknown[] = [];
     const seen: unknown[] = [];
+    const detachSession = defaultSession().events.subscribe(
+      (event) => sessionSeen.push(event),
+      { scope: 'session' },
+    );
     const off = bus.on('goalStateChanged', (p) => seen.push(p));
     try {
       emitRuntimeEvent('goalStateChanged', { streamId: streamId('s:bus') });
-      expect(seen).toEqual([{ streamId: 's:bus' }]);
+      expect(sessionSeen).toEqual([
+        {
+          scope: 'session',
+          event: {
+            type: 'goalStateChanged',
+            payload: { streamId: 's:bus' },
+          },
+        },
+      ]);
+      expect(seen).toEqual([]);
     } finally {
+      detachSession();
       off();
     }
   });
 
-  it("emits through the active run's runtimeHost when inside a run context", () => {
+  it("keeps non-migrated events on the active run's runtimeHost", () => {
     const run = createRecordingHost();
     const busSeen: unknown[] = [];
-    const off = bus.on('goalStateChanged', (p) => busSeen.push(p));
+    const off = bus.on('requestShowError', (p) => busSeen.push(p));
     try {
       withRunContext(createRunContext({ runtimeHost: run.host }), () => {
-        emitRuntimeEvent('goalStateChanged', { streamId: streamId('s:run') });
+        emitRuntimeEvent('requestShowError', { message: 'run error' });
       });
       expect(run.events).toEqual([
-        { event: 'goalStateChanged', payload: { streamId: 's:run' } },
+        { event: 'requestShowError', payload: { message: 'run error' } },
       ]);
       // Not double-emitted onto the bus.
       expect(busSeen).toEqual([]);
@@ -42,10 +57,15 @@ describe('emitRuntimeEvent (SDK Step 7d F-1 — one emit path)', () => {
     }
   });
 
-  it('prefers an explicit session hostChannel over the run context and bus', () => {
+  it('prefers an explicit session event hub over the run context and bus for migrated facts', () => {
     const channel = createRecordingHost();
     const run = createRecordingHost();
     const session = new SessionHandle({ hostChannel: channel.host });
+    const sessionSeen: unknown[] = [];
+    const detachSession = session.events.subscribe(
+      (event) => sessionSeen.push(event),
+      { scope: 'session' },
+    );
     const busSeen: unknown[] = [];
     const off = bus.on('goalStateChanged', (p) => busSeen.push(p));
     try {
@@ -56,12 +76,20 @@ describe('emitRuntimeEvent (SDK Step 7d F-1 — one emit path)', () => {
           session,
         );
       });
-      expect(channel.events).toEqual([
-        { event: 'goalStateChanged', payload: { streamId: 's:chan' } },
+      expect(sessionSeen).toEqual([
+        {
+          scope: 'session',
+          event: {
+            type: 'goalStateChanged',
+            payload: { streamId: 's:chan' },
+          },
+        },
       ]);
+      expect(channel.events).toEqual([]);
       expect(run.events).toEqual([]);
       expect(busSeen).toEqual([]);
     } finally {
+      detachSession();
       off();
       session.dispose();
     }

--- a/src/test-kernel/agent/runtime/LegacyProgressEventProjection.vitest.ts
+++ b/src/test-kernel/agent/runtime/LegacyProgressEventProjection.vitest.ts
@@ -1,0 +1,116 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - runtime
+import { attachLegacyProgressEventProjection } from '@agent/runtime/LegacyProgressEventProjection';
+import { SessionEventHub } from '@agent/runtime/SessionEventHub';
+import type {
+  ActiveChildInfo,
+  ExecutionId,
+  StreamTabId,
+} from '@shared/schemas';
+
+import { createRecordingHost } from '../progressTestUtils';
+
+describe('LegacyProgressEventProjection', () => {
+  it('maps Stage 3a session and child/process facts onto legacy progress events', () => {
+    const hub = new SessionEventHub();
+    const host = createRecordingHost();
+    const parentStreamId = 'stream:parent' as StreamTabId;
+    const childStreamId = 'stream:child' as StreamTabId;
+    const executionId = 'exec:process-output' as ExecutionId;
+    const child: ActiveChildInfo = {
+      executionId: 'exec:child' as ExecutionId,
+      childStreamId,
+      agentName: 'orchestrator',
+      status: 'running',
+      startedAt: 1,
+      elapsed: null,
+    };
+    const process: ActiveChildInfo = {
+      executionId,
+      agentName: 'bash',
+      status: 'running',
+      startedAt: 2,
+      elapsed: '1s',
+      toolName: 'bash',
+    };
+
+    const detach = attachLegacyProgressEventProjection(hub, host.host);
+    try {
+      hub.emit({
+        scope: 'session',
+        event: {
+          type: 'updateQueuedFollowUps',
+          payload: { streamId: parentStreamId },
+        },
+      });
+      hub.emit({
+        scope: 'run',
+        streamId: parentStreamId,
+        event: {
+          type: 'child.activity',
+          kind: 'subagents',
+          parentStreamId,
+          children: [child],
+        },
+      });
+      hub.emit({
+        scope: 'run',
+        streamId: parentStreamId,
+        event: {
+          type: 'child.activity',
+          kind: 'processes',
+          parentStreamId,
+          processes: [process],
+        },
+      });
+      hub.emit({
+        scope: 'run',
+        streamId: parentStreamId,
+        event: {
+          type: 'child.activity',
+          kind: 'parent',
+          childStreamId,
+          parentStreamId,
+        },
+      });
+      hub.emit({
+        scope: 'run',
+        streamId: parentStreamId,
+        event: {
+          type: 'process.output',
+          parentStreamId,
+          executionId,
+          stdout: 'hello',
+          stderr: '',
+        },
+      });
+
+      expect(host.events).toEqual([
+        {
+          event: 'updateQueuedFollowUps',
+          payload: { streamId: parentStreamId },
+        },
+        {
+          event: 'updateActiveSubagents',
+          payload: { parentStreamId, children: [child] },
+        },
+        {
+          event: 'updateActiveProcesses',
+          payload: { parentStreamId, processes: [process] },
+        },
+        {
+          event: 'setParentStream',
+          payload: { childStreamId, parentStreamId },
+        },
+        {
+          event: 'updateProcessOutput',
+          payload: { parentStreamId, executionId, stdout: 'hello', stderr: '' },
+        },
+      ]);
+    } finally {
+      detach();
+    }
+  });
+});

--- a/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
@@ -2,8 +2,9 @@
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - runtime
-import { getActiveFlushers } from '@transcript';
+import { getActiveFlushers, getDefaultStreamLogStore } from '@transcript';
 import type { AgentTrace } from '@agent/trace';
+import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { AgentProposalCoordinator } from '@agent/runtime/AgentProposalCoordinator';
 import { PlanApprovalCoordinator } from '@agent/runtime/PlanApprovalCoordinator';
@@ -72,6 +73,10 @@ describe('SessionHandle', () => {
     expect(defaultSession().subscriptions).toBe(executionSubscriptionBinder);
     expect(defaultSession().status).toBe(StreamStatusService);
     expect(defaultSession().events).toBeDefined();
+    expect(defaultSession().transcripts).toBe(getDefaultStreamLogStore());
+    expect(defaultSession().followUps).toBe(
+      ToolUseFollowUpQueue.defaultInstance(),
+    );
     expect(defaultSession().flushers).toBe(getActiveFlushers());
     expect(defaultSession().hostChannel).toBeUndefined();
   });
@@ -85,6 +90,8 @@ describe('SessionHandle', () => {
       expect(fresh.subscriptions).not.toBe(executionSubscriptionBinder);
       expect(fresh.status).not.toBe(StreamStatusService);
       expect(fresh.events).not.toBe(defaultSession().events);
+      expect(fresh.transcripts).not.toBe(defaultSession().transcripts);
+      expect(fresh.followUps).not.toBe(defaultSession().followUps);
       expect(fresh.flushers).not.toBe(getActiveFlushers());
       expect(fresh.hostChannel).toBeUndefined();
     } finally {

--- a/src/test-kernel/agent/runtime/SessionScope.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionScope.vitest.ts
@@ -25,8 +25,7 @@ import {
 } from '@agent/runtime/SessionHandle';
 import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
 import { sendFollowUp } from '@agent/followUp/ToolUseFollowUp';
-import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
-import { type Plan, type StreamTabId } from '@shared/schemas';
+import { MESSAGE_TYPES, type Plan, type StreamTabId } from '@shared/schemas';
 import { cleanupAllApprovals } from '@tools/approval';
 
 import { createRecordingHost } from '../progressTestUtils';
@@ -142,6 +141,61 @@ describe('session-scoped trace flushers (SDK Step 7d PR 3)', () => {
   });
 });
 
+describe('session-owned transcripts and follow-up queues (Stage 3a)', () => {
+  it("writes run trace entries to the launching session's transcript store only", () => {
+    const launching = new SessionHandle();
+    const sibling = new SessionHandle();
+    const streamId = 'stream:session-transcript-owner' as StreamTabId;
+
+    try {
+      const handle = createRunTrace(
+        streamId,
+        launching.transcripts,
+        launching.flushers,
+      );
+      try {
+        const output = handle.trace.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
+        output.append('owned by launching session');
+
+        expect(
+          launching.transcripts
+            .get(streamId)
+            ?.getRange(0)
+            .map((entry) => entry.text),
+        ).toEqual(['owned by launching session']);
+        expect(sibling.transcripts.get(streamId)).toBeUndefined();
+        expect(getDefaultStreamLogStore().get(streamId)).toBeUndefined();
+      } finally {
+        handle.dispose();
+      }
+    } finally {
+      launching.dispose();
+      sibling.dispose();
+    }
+  });
+
+  it('keeps same-stream follow-up queues isolated by session', () => {
+    const a = new SessionHandle();
+    const b = new SessionHandle();
+    const streamId = 'stream:session-followups' as StreamTabId;
+
+    try {
+      a.followUps.acquire(streamId);
+      b.followUps.acquire(streamId);
+      a.followUps.enqueue(streamId, { text: 'from a' });
+      b.followUps.enqueue(streamId, { text: 'from b' });
+
+      a.followUps.release(streamId);
+
+      expect(a.followUps.getAll(streamId)).toEqual([]);
+      expect(b.followUps.getAll(streamId)).toEqual(['from b']);
+    } finally {
+      a.dispose();
+      b.dispose();
+    }
+  });
+});
+
 describe('cleanupAllApprovals scope (SDK Step 7d PR 3)', () => {
   it("clears only the given session's coordinator requests", async () => {
     const a = new SessionHandle();
@@ -226,7 +280,7 @@ describe('sendFollowUp host-path session routing (SDK Step 7d PR 4)', () => {
         streamStatus: undefined,
       });
     } finally {
-      ToolUseFollowUpQueue.release(parentStream);
+      windowSession.followUps.release(parentStream);
       windowSession.dispose();
     }
   });

--- a/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
+++ b/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
@@ -11,7 +11,8 @@ import {
   seedStreamStatusForTest,
 } from '@test/helpers/streamStatusTestUtils';
 import { resumeToolUseSnapshot } from '@agent/runtime/resumeToolUseSnapshot';
-import { SessionHandle } from '@agent/runtime/SessionHandle';
+import { attachLegacyProgressEventProjection } from '@agent/runtime/LegacyProgressEventProjection';
+import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
@@ -19,6 +20,7 @@ import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 
 const STREAM = 'stream:tooluse-resume' as StreamTabId;
 const runtimeHost = { emit: vi.fn() };
+let detachLegacyProjection: (() => void) | undefined;
 
 function snapshot(): ToolUseSessionSnapshot {
   return { streamId: STREAM } as ToolUseSessionSnapshot;
@@ -41,9 +43,15 @@ describe('resumeToolUseSnapshot', () => {
     resumeToolUseFromSnapshotMock.mockReset();
     resumeToolUseFromSnapshotMock.mockResolvedValue(undefined);
     runtimeHost.emit.mockReset();
+    detachLegacyProjection = attachLegacyProgressEventProjection(
+      defaultSession().events,
+      runtimeHost,
+    );
   });
 
   afterEach(() => {
+    detachLegacyProjection?.();
+    detachLegacyProjection = undefined;
     ToolUseFollowUpQueue.release(STREAM);
     clearStreamStatusForTest(StreamStatusService, STREAM);
   });
@@ -135,6 +143,35 @@ describe('resumeToolUseSnapshot', () => {
       expect(session.status.get(STREAM)).toBe(STREAM_STATUS.WAITING);
       expect(StreamStatusService.get(STREAM)).toBeUndefined();
     } finally {
+      session.status.clearStream(STREAM);
+      session.dispose();
+    }
+  });
+
+  it('preserves failed resume follow-ups in the supplied session queue only', async () => {
+    const failure = new Error('session queue resume failed');
+    resumeToolUseFromSnapshotMock.mockRejectedValue(failure);
+    const session = new SessionHandle();
+
+    try {
+      session.followUps.enqueue(
+        STREAM,
+        { text: 'session queued' },
+        { force: true },
+      );
+
+      await expect(
+        resumeToolUseSnapshot(snapshot(), {
+          runtimeHost,
+          session,
+          reportFailure: vi.fn(),
+        }),
+      ).resolves.toBe(false);
+
+      expect(session.followUps.getAll(STREAM)).toEqual(['session queued']);
+      expect(ToolUseFollowUpQueue.getAll(STREAM)).toEqual([]);
+    } finally {
+      session.followUps.release(STREAM);
       session.status.clearStream(STREAM);
       session.dispose();
     }

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -1,6 +1,12 @@
 // Third-party imports
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+// Local imports - transcript
+import {
+  STREAM_LOGS_DIR,
+  type StreamSnapshotStore as ProgressSnapshotStore,
+} from '@transcript';
+
 // Local imports - agent state
 import { seedStreamStatusForTest } from '@test/helpers/streamStatusTestUtils';
 import { TaskStateSchema } from '@agent/core/state/TaskState';
@@ -27,10 +33,6 @@ import { DIAGNOSTICS_ADD_RUNTIME_CAPABILITY } from '@tools/diagnosticsRuntimeCap
 
 // Local imports - desktop test paths
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
-import {
-  STREAM_LOGS_DIR,
-  type StreamSnapshotStore as ProgressSnapshotStore,
-} from '@transcript';
 
 type Bridge = {
   openFileCompile(filePath: string): Promise<void>;
@@ -77,6 +79,15 @@ type BridgeWithSession = TestableBridge & {
       cleanupAllRequests(): void;
     };
     status: StreamStatusMachine;
+    followUps: {
+      enqueue(
+        streamId: StreamTabId,
+        followUp: { text: string },
+        options?: { force?: boolean },
+      ): boolean;
+      getAll(streamId: StreamTabId): string[];
+      release(streamId: StreamTabId): void;
+    };
   };
 };
 
@@ -84,6 +95,12 @@ function bridgeStatus(
   bridge: TestableBridge,
 ): BridgeWithSession['session']['status'] {
   return (bridge as BridgeWithSession).session.status;
+}
+
+function bridgeFollowUps(
+  bridge: TestableBridge,
+): BridgeWithSession['session']['followUps'] {
+  return (bridge as BridgeWithSession).session.followUps;
 }
 
 type DesktopExecution = {
@@ -2178,8 +2195,6 @@ describe('DesktopProgressBridge', () => {
       retrieveSessionResumeData,
       resumeToolUseFromSnapshot,
     });
-    const { ToolUseFollowUpQueue } =
-      await import('@agent/followUp/ToolUseFollowUpQueueManager');
     const taskState = { agentConfig: SEARCH_TOOL_USE_AGENT_CONFIG };
 
     try {
@@ -2188,7 +2203,7 @@ describe('DesktopProgressBridge', () => {
         executionId: 'exec-1',
         taskState,
       });
-      ToolUseFollowUpQueue.enqueue(
+      bridgeFollowUps(bridge).enqueue(
         'stream-1',
         { text: 'queued follow-up' },
         { force: true },
@@ -2230,7 +2245,7 @@ describe('DesktopProgressBridge', () => {
         origin: 'user',
       });
     } finally {
-      ToolUseFollowUpQueue.release('stream-1');
+      bridgeFollowUps(bridge).release('stream-1');
       bridgeStatus(bridge).clearStream('stream-1');
       bridge.dispose();
     }
@@ -2252,8 +2267,6 @@ describe('DesktopProgressBridge', () => {
       retrieveSessionResumeData,
       resumeToolUseFromSnapshot,
     });
-    const { ToolUseFollowUpQueue } =
-      await import('@agent/followUp/ToolUseFollowUpQueueManager');
 
     try {
       bridge.handleProgressEvent('setTaskState', {
@@ -2261,19 +2274,19 @@ describe('DesktopProgressBridge', () => {
         executionId: 'exec-1',
         taskState: { agentConfig: SEARCH_TOOL_USE_AGENT_CONFIG },
       });
-      ToolUseFollowUpQueue.enqueue(
+      bridgeFollowUps(bridge).enqueue(
         'stream-1',
         { text: 'queued follow-up' },
         { force: true },
       );
 
       await expect(bridge.tryResumeStream('stream-1')).resolves.toBe(false);
-      expect(ToolUseFollowUpQueue.getAll('stream-1')).toEqual([
+      expect(bridgeFollowUps(bridge).getAll('stream-1')).toEqual([
         'queued follow-up',
       ]);
       expect(bridgeStatus(bridge).get('stream-1')).toBe(STREAM_STATUS.WAITING);
     } finally {
-      ToolUseFollowUpQueue.release('stream-1');
+      bridgeFollowUps(bridge).release('stream-1');
       bridgeStatus(bridge).clearStream('stream-1');
       bridge.dispose();
     }

--- a/src/tools/agentCliSessionLoop.ts
+++ b/src/tools/agentCliSessionLoop.ts
@@ -20,7 +20,6 @@ import {
   sendFollowUp,
   wakeOrReleaseQueuedStream,
 } from '@agent/followUp/ToolUseFollowUp';
-import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import type { FollowUpQueue } from '@agent/followUp/FollowUpQueue';
 import {
   deriveRunOutcome,
@@ -44,7 +43,7 @@ type TurnUsage = { input_tokens?: number; output_tokens?: number };
  * Does NOT implement the session duck-type (no `session.appendFollowUp`), so
  * flow-only commands such as context compaction ignore it. Follow-ups route
  * through the WAITING state queue path: `sendFollowUp()` → stream is WAITING →
- * `ToolUseFollowUpQueue.enqueue()`.
+ * `session.followUps.enqueue()`.
  */
 class AgentCliSession implements IInterruptible {
   private interrupted = false;
@@ -217,7 +216,7 @@ export function runAgentCliSession<TTurn>(
   // unregisters against the same handle the registration used.
   const runSession = currentSession();
   const session = new AgentCliSession();
-  const queue = ToolUseFollowUpQueue.acquire(childStreamId);
+  const queue = runSession.followUps.acquire(childStreamId);
   session.setQueue(queue);
   runSession.interrupts.register(childStreamId, session);
 
@@ -300,7 +299,11 @@ export function runAgentCliSession<TTurn>(
             },
           );
         } else if (
-          !(await wakeOrReleaseQueuedStream(parentStreamId, delivery))
+          !(await wakeOrReleaseQueuedStream(
+            parentStreamId,
+            delivery,
+            runSession,
+          ))
         ) {
           logger.warn(
             'Turn result dropped: parent stream is gone and could not be resumed. The result remains in the execution report.',
@@ -330,7 +333,7 @@ export function runAgentCliSession<TTurn>(
       const projection = projectRunOutcome(outcome);
       sessionStage.end(legacyEndGroupStatusForOutcome(outcome));
       runSession.interrupts.unregister(childStreamId);
-      ToolUseFollowUpQueue.release(childStreamId);
+      runSession.followUps.release(childStreamId);
       strategy.onSessionCleanup?.();
       // Persist terminal status before childStream.finalize() untracks and
       // notifies waiters.

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -6,8 +6,8 @@ import { type AgentTrace } from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { currentSession } from '@agent/runtime/SessionHandle';
 import { getCurrentToolContexts } from '@agent/followUp/ToolFileInteractionContext';
-import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import type { RunContext } from '@agent/runtime/RunContext';
 import { isAbortError } from '@common/errors';
 import type {
@@ -192,7 +192,9 @@ export function resumeAgentCliSession(
     );
   }
 
-  ToolUseFollowUpQueue.acquire(stored.childStreamId).enqueue({ text: prompt });
+  currentSession().followUps.acquire(stored.childStreamId).enqueue({
+    text: prompt,
+  });
 
   const preview = truncateWithEllipsis(prompt, 60);
   return {

--- a/src/tools/approval/index.ts
+++ b/src/tools/approval/index.ts
@@ -12,7 +12,6 @@ import {
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import type { StreamTabId } from '@shared/schemas';
 import {
   _rejectAllPendingUserQuestions,
@@ -50,7 +49,7 @@ export function cleanupApprovalsForStream(
  * (pending approvals, bypass flags, coordinator requests) AND the follow-up
  * queue. These two always need to be cleared together when a stream is
  * removed, so this is the single function hosts should call instead of
- * combining {@link cleanupApprovalsForStream} + `ToolUseFollowUpQueue.release`
+ * combining {@link cleanupApprovalsForStream} + `session.followUps.release`
  * manually.
  *
  * Host-specific teardown (webview state, backup files, goal store, etc.)
@@ -61,7 +60,7 @@ export function releaseStreamResources(
   session: SessionHandle = defaultSession(),
 ): void {
   cleanupApprovalsForStream(streamId, session);
-  ToolUseFollowUpQueue.release(streamId);
+  session.followUps.release(streamId);
 }
 
 /**

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -81,7 +81,11 @@ export function createChildStream(
   // Capture the run's session at creation (inside the parent run's ALS); the
   // status-update and finalize closures below fire later, possibly outside it.
   const session = currentSession();
-  const runTrace = createRunTrace(childStreamId, undefined, session.flushers);
+  const runTrace = createRunTrace(
+    childStreamId,
+    session.transcripts,
+    session.flushers,
+  );
   const detachSessionTrace = session.attachRunTrace(
     runTrace.trace,
     childStreamId,

--- a/src/tools/github/StreamSubscriptionRegistry.ts
+++ b/src/tools/github/StreamSubscriptionRegistry.ts
@@ -15,6 +15,7 @@ import type { AgentTrace } from '@agent/trace';
 import { sendFollowUp } from '@agent/followUp/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import {
   currentSession,
   type SessionHandle,
@@ -84,7 +85,8 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
     StreamTabId,
     Map<K, BoundSubscription>
   >();
-  private hooksRegistered = false;
+  private sourceHooksRegistered = false;
+  private readonly hookedReleaseQueues = new WeakSet<ToolUseFollowUpQueue>();
 
   constructor(
     private readonly opts: StreamSubscriptionRegistryOptions<K, Input>,
@@ -98,12 +100,12 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
     input: Input,
     runtimeHost: AgentRuntimeHost,
   ): boolean {
-    this.ensureHooks();
     const key = this.opts.keyOf(input);
     // Capture the session HERE: bind() runs inside the run's AsyncLocalStorage
     // (the github tool's execute()), but onEvent fires later from a detached
     // polling timer where the ALS is empty.
     const session = currentSession();
+    this.ensureHooks(session);
     let bound = this.perStream.get(streamId);
     if (!bound) {
       bound = new Map();
@@ -139,9 +141,11 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
       )
         .then((result) => {
           if (result.status === 'sent' || result.status === 'queued') {
-            subscription.runtimeHost.emit('updateQueuedFollowUps', {
-              streamId,
-            });
+            emitRuntimeEvent(
+              'updateQueuedFollowUps',
+              { streamId },
+              subscription.session,
+            );
           }
         })
         .catch((err: unknown) => {
@@ -233,9 +237,22 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
     }));
   }
 
-  private ensureHooks(): void {
-    if (this.hooksRegistered) return;
-    ToolUseFollowUpQueue.onRelease((streamId) => {
+  private ensureHooks(session: SessionHandle): void {
+    this.ensureReleaseHook(session.followUps);
+    if (this.sourceHooksRegistered) return;
+    // The polling source can detach subscriptions unilaterally (PR closed,
+    // auth failure, 24 h unreachable). Listen to the source directly; the
+    // progress event is for UI refresh, not for internal bookkeeping.
+    this.opts.source.onKeysChanged((keys) => {
+      this.pruneMissingSourceKeys(keys);
+    });
+    this.sourceHooksRegistered = true;
+  }
+
+  private ensureReleaseHook(queue: ToolUseFollowUpQueue): void {
+    if (this.hookedReleaseQueues.has(queue)) return;
+    this.hookedReleaseQueues.add(queue);
+    queue.onRelease((streamId) => {
       const bound = this.perStream.get(streamId);
       if (!bound) return;
       const runtimeHosts = [...bound.values()].map(
@@ -247,13 +264,6 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
       }
       this.emitBindingsChanged(runtimeHosts);
     });
-    // The polling source can detach subscriptions unilaterally (PR closed,
-    // auth failure, 24 h unreachable). Listen to the source directly; the
-    // progress event is for UI refresh, not for internal bookkeeping.
-    this.opts.source.onKeysChanged((keys) => {
-      this.pruneMissingSourceKeys(keys);
-    });
-    this.hooksRegistered = true;
   }
 
   private pruneMissingSourceKeys(keys: readonly K[]): void {

--- a/src/tools/goal/goalStore.ts
+++ b/src/tools/goal/goalStore.ts
@@ -3,6 +3,7 @@ import { Mutex } from 'async-mutex';
 
 import { platform, tryWorkspaceState } from '@platform/platform';
 import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import {
   type ExecutionId,
   StreamTabIdSchema,
@@ -278,7 +279,7 @@ export const GoalStore = {
   /** Drop the record (used on complete, abandon, or conversation delete).
    *  Bootstrap-tolerant — cleanup paths shouldn't fail loudly if state isn't
    *  wired yet. */
-  async forget(streamId: StreamTabId): Promise<void> {
+  async forget(streamId: StreamTabId, session?: SessionHandle): Promise<void> {
     const state = tryWorkspaceState();
     if (!state) return;
     // Gate on raw key presence, not parse success — an unparseable or
@@ -295,9 +296,9 @@ export const GoalStore = {
       state.update(legacyStreamKey(streamId), undefined),
       removeFromIndex(streamId),
     ]);
-    // Dual-context: PlanTool forgets in-run (→ run host via ALS); the
-    // progress-view lifecycle controller forgets host-path (→ bus fallback).
-    emitRuntimeEvent('goalStateChanged', { streamId });
+    // Dual-context: PlanTool forgets in-run (→ run session via ALS); hosts
+    // pass their owning session for non-default windows.
+    emitRuntimeEvent('goalStateChanged', { streamId }, session);
   },
 
   /**
@@ -306,7 +307,10 @@ export const GoalStore = {
    * — independent keys — but the index update is a single read-filter-
    * write so concurrent `forget()` calls don't race on it.
    */
-  async forgetMany(streamIds: readonly StreamTabId[]): Promise<void> {
+  async forgetMany(
+    streamIds: readonly StreamTabId[],
+    session?: SessionHandle,
+  ): Promise<void> {
     const state = tryWorkspaceState();
     if (!state) return;
     // Same raw-presence gate as `forget` so unparseable blobs are cleaned.
@@ -323,7 +327,7 @@ export const GoalStore = {
       mutateIndex((index) => index.filter((id) => !dropped.has(id))),
     ]);
     for (const id of toRemove)
-      emitRuntimeEvent('goalStateChanged', { streamId: id });
+      emitRuntimeEvent('goalStateChanged', { streamId: id }, session);
   },
 
   /**
@@ -333,6 +337,7 @@ export const GoalStore = {
    */
   async forgetByExecutionIds(
     executionIds: readonly ExecutionId[],
+    session?: SessionHandle,
   ): Promise<void> {
     if (executionIds.length === 0) return;
     // Stream ids include the execution id as a final `#${executionId}` suffix.
@@ -342,6 +347,6 @@ export const GoalStore = {
     const streamIds = readIndex().filter((streamId) =>
       suffixes.some((suffix) => streamId.endsWith(suffix)),
     );
-    await GoalStore.forgetMany(streamIds);
+    await GoalStore.forgetMany(streamIds, session);
   },
 };

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -318,7 +318,13 @@ export class ExternalInquiryTool extends defineTool({
     switch (input.command) {
       case 'ask': {
         const runtimeHost = requireRuntimeHost('inquiry', context);
-        return this.executeAsk({ input, streamId, runtimeHost, executionId });
+        return this.executeAsk({
+          input,
+          streamId,
+          runtimeHost,
+          executionId,
+          session: context?.session,
+        });
       }
       case 'read':
         return this.executeRead({ input, executionId });
@@ -332,8 +338,9 @@ export class ExternalInquiryTool extends defineTool({
     streamId: StreamTabId | undefined;
     runtimeHost: ReturnType<typeof requireRuntimeHost>;
     executionId?: string;
+    session?: SessionHandle;
   }): Promise<ToolResult> {
-    const { input, streamId, runtimeHost, executionId } = args;
+    const { input, streamId, runtimeHost, executionId, session } = args;
     if (!streamId) {
       throw new ToolError(
         'inquiry { command: "ask" } requires an active stream context.',
@@ -404,7 +411,7 @@ export class ExternalInquiryTool extends defineTool({
     // Background Tasks panel: announce the open thread.
     const summary = await getThreadSummary(persisted.threadId);
     if (summary) {
-      runtimeHost.emit('inquiryThreadUpdated', summary);
+      emitRuntimeEvent('inquiryThreadUpdated', summary, session);
     }
 
     const message =

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -388,6 +388,12 @@ export function attachTranscriptRecorder(
         // adds no row here (keeps transcript output unchanged).
         return;
 
+      case 'child.activity':
+      case 'process.output':
+        // Stage 3a child/process facts replace legacy progress events for UI
+        // badges and process panes; they were not transcript rows before.
+        return;
+
       default: {
         // Exhaustiveness check: adding a new event arm forces an error here.
         const _exhaustive: never = event;


### PR DESCRIPTION
## Summary

Lands #6964 Stage 3a: migrated the named non-run facts to `SessionEventHub`, added `child.activity` and `process.output` run facts, and moved run transcripts/follow-up queues onto `SessionHandle`. Existing extension/desktop/CLI consumers keep the legacy `ProgressEventPayloads` names through a finite compatibility bridge while downstream hosts migrate.

## Issue acceptance gates

- #6964: `emitRuntimeEvent` no longer sends migrated fact keys to the process bus when a real session is available; they enter `SessionEventHub` first.
- #6964: `child.activity` subsumes active subagent/process/parent-stream updates, and `process.output` subsumes process output events at the session hub boundary.
- #6964: `session.transcripts` owns run traces launched from that session; `session.followUps` owns queueing/release for tool-use follow-ups.
- #6964: multi-session tests cover transcript isolation and same-stream follow-up queue isolation.
- #6964: queued follow-up resume tests cover default-session compatibility and fresh-session queue preservation across failed resume.
- #6964: projector/bridge equivalence tests cover the Stage 3a legacy host payload names.
- #6964: `ensureStream` / `syncStream*` call-site counts are non-increasing; no call sites changed in the diff.

## Single source of truth

`SessionHandle.events` is now the source of truth for the migrated Stage 3a facts, and `SessionHandle.transcripts` / `SessionHandle.followUps` own per-session transcript and follow-up state.

## Duplication and abstraction budget

Removed direct producer emits for the migrated follow-up, missing-output, goal, inquiry, child-activity, and process-output facts. Added one finite legacy compatibility bridge, `LegacyProgressEventProjection`, solely to preserve the old host payload contract until consumers leave `ProgressEventPayloads`; it has no independent state and is ledgered for deletion.

This refactor is not net-negative in lines because the added mass is concentrated in explicit session ownership and regression tests for host parity/session isolation.

## Host impact

Extension: byte-identical host payload names via `defaultSession()` and the legacy projection; command-path `clearMissingOutputs` / follow-up refreshes now enter the session hub first.

Desktop: per-window backend handles projected session facts locally instead of rebroadcasting them onto the process bus; follow-up queues and goal cleanup use the window session.

CLI: headless and TUI runtime hosts attach the legacy projection so `texra run`, `--print`, and JSON event names remain compatible while runtime producers use session facts.

## Scheduled refactoring

#6981: Stage 3a rows added for `LegacyProgressEventProjection` removal at Stage 5 (#6968), and for static/default follow-up/transcript compatibility cleanup in D1 (#6982).

## Validation

- `corepack pnpm exec prettier --write` on touched files
- `npm run typecheck`
- `npm run lint` (passes with existing repo warnings only)
- `npm run compile:fast`
- `npm test`
- Focused: `corepack pnpm exec vitest run src/test-kernel/agent/runtime/EmitRuntimeEvent.vitest.ts src/test-kernel/agent/runtime/LegacyProgressEventProjection.vitest.ts src/test-kernel/agent/runtime/SessionHandle.vitest.ts src/test-kernel/agent/runtime/SessionScope.vitest.ts src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts src/test-kernel/agent/followUp/FollowUpQueue.vitest.ts src/test-kernel/progressView/SessionRunFactProjectorEquivalence.vitest.ts src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/cli/RunExecution.vitest.mts src/test-kernel/cli/SessionStatus.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`

Closes #6964

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core runtime event routing, multi-window desktop isolation, and follow-up/resume paths; behavior is heavily tested but regressions could affect cross-window leaks or queued follow-up delivery.
> 
> **Overview**
> **Stage 3a** lands session-scoped ownership for the facts and state that previously leaked across windows via process globals.
> 
> **Session-owned state:** `SessionHandle` now owns `transcripts` (`StreamLogStore`) and `followUps` (`ToolUseFollowUpQueue` instances). Run traces and tool-use queues route through the launching session instead of a last-writer-wins default store or static queue. `defaultSession()` still aliases the legacy default store/queue for unmigrated callers.
> 
> **Session fact plane:** `SessionEventHub` gains real `SessionFact` types (goal, inquiry, queued follow-ups, missing outputs, active stream) plus run facts `child.activity` and `process.output`. `emitRuntimeEvent` sends those keys to the hub first; `ExecutionRegistry` and `ProcessOutputPoller` publish child/process updates through the hub when a session is wired.
> 
> **Legacy compatibility:** `LegacyProgressEventProjection` maps hub facts back to existing `ProgressEventPayloads` names on the runtime host. CLI, extension, and desktop attach it so consumers stay byte-identical while producers migrate. Desktop routes projected session facts through a **window-local** progress path (`handleSessionProgressEvent` / local bus) instead of rebroadcasting them on the process bus.
> 
> **Call-site migration:** Follow-up send/wake/resume, stream delete cleanup, GitHub subscriptions, goal forget, and progress UI read from `session.followUps` / `session.transcripts` and pass `session` into `emitRuntimeEvent` where hosts are per-window. `ToolUseFollowUpQueue` static methods proxy to a default instance for compatibility.
> 
> Docs mark Stage 3a complete in the architecture checkpoint and audit proposals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32dc8e69376d73f76516a38b4abc84162e1a2fdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

