### PR TITLE
Add module-map README to src/agent/runtime

### DIFF
--- a/src/agent/runtime/README.md
+++ b/src/agent/runtime/README.md
@@ -1,0 +1,47 @@
+# Agent runtime modules
+
+`agent/runtime` is the host-agnostic execution layer that sits on top of
+`agent/core`'s domain model: it launches, tracks, resumes, and reports on
+agent runs. Unlike `core` (recently split into `definition/state/usage/tools/flows/`,
+see `src/agent/core/README.md`), this directory stays a flat list of ~50
+files — see [Why this stays flat](#why-this-stays-flat) — so this README is
+the module map that directory would otherwise provide: it documents the
+logical groupings by concern so the shape is visible without opening every
+file.
+
+| Group                                           | Concern                                                          | Files                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| ----------------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Launch & configuration**                      | Resolve what a run should do before it starts                    | `AgentLaunchContext`, `agentLoad` (resolve + load agent YAML), `agentToolResolution` (effective tool list pipeline), `delegationPolicy` (nested-delegation depth), `toolInjection` (conditional tool auto-injection registry), `selectAutoOpenFinalOutput` (post-run auto-open policy)                                                                                                                                                                                                                                          |
+| **Run orchestration & resume**                  | Entry points that start or resume a run, and their result shapes | `runAgent` (top-level entry: assigns `executionId`, registers, runs), `executeAgent` (lower-level execution + tool-use resume), `AgentRunLifecycle` (completion side effects, error classification), `AgentFlowResult` (`WorkflowFlowResult`/`ToolUseFlowResult` schemas), `resolveAndResumeStream` (cross-host resume skeleton), `resumeQueuedToolUse`, `resumeToolUseSnapshot`, `SessionResumeRetrieval` (persisted resume data), `followUpResumeDetection`                                                                   |
+| **Execution registry & live handles**           | Track, interrupt, and tear down in-flight executions             | `ExecutionHandle` (polymorphic handle types), `executionRegistry` (registration, lookup, subagent lineage), `ExecutionSubscriptionBinder` (stream ↔ execution-status subscriptions), `InterruptRegistry`, `InterruptManager`, `ProcessOutputPoller` (spawned-process stdout/stderr), `agentShutdown` (host teardown), `detachSubagentsOnStop` (detach-vs-cascade policy)                                                                                                                                                        |
+| **Session, event hub & emission**               | The per-session event contract and its single emit path to hosts | `AgentRuntimeHost` (the progress-sink interface every host implements), `SessionHandle` (one composition record per session), `SessionEventHub` (typed session facts), `SessionRunFactProjector`, `LegacyProgressEventProjection` (facts → legacy host events), `emitRuntimeEvent` (single emit path, SDK Step 7d F-1), `runFactEvents` (run-fact domain event names), `conversationProgressHub`, `StreamStatusService` (stream status state machine), `streamTab` (stream tab id), `terminalResultToast`, `ProgressViewBridge` |
+| **Run context & user-interaction coordinators** | Ambient per-run context and promise-based user-approval gates    | `RunContext` (`AsyncLocalStorage`-based ambient context), `runCoordinators` (accessors over `RunContext` + `executionRegistry`), `BasePromiseCoordinator` (generic promise-keyed-by-id base), `AgentProposalCoordinator`, `PlanApprovalCoordinator`, `RetryRequestCoordinator`                                                                                                                                                                                                                                                  |
+| **Model resolution**                            | Turn a model name/config into a handler instance                 | `ModelFactory` (provider handler factory), `modelHandlerCompatibilityKey`, `modelHandlerCompatibilityInference`, `internalValidationOverride` (CI-only stub swap), `helperModel`, `helperModelName`, `helperModelPreference` (the "fix LaTeX" flag), `textConnection` (direct-client helper-model connection for LaTeX commands)                                                                                                                                                                                                |
+| **Content helpers**                             | One-shot content generation built on the helper model            | `sessionDescription` (AI session summary), `polishModel` (polish prompt template), `textEnhancement` (polish orchestration), `mediaVisionWarning` (vision-support warning for attached media)                                                                                                                                                                                                                                                                                                                                   |
+
+## Why this stays flat
+
+`core`'s split works because each module's files are addressed through the
+module path (`@agent/core/<module>/<File>`), so moving a file only means
+updating the few imports that reference it. `runtime` files are the opposite:
+~180 files across `src/` and `packages/*` import a specific
+`@agent/runtime/<File>` path directly (there is no barrel — see
+[Importing](#importing)), so physically moving any of these files into
+subdirectories means rewriting every one of those call sites. That's
+mechanical churn disproportionate to a documentation change, not a "natural"
+low-risk split — hence a README module map instead of a directory split. If a
+future refactor touches a whole group's call sites anyway, revisit turning
+that group into a real subdirectory.
+
+## Importing
+
+Import each file directly by its `@agent/runtime/<File>` path, e.g.:
+
+```ts
+import { runAgent } from '@agent/runtime/runAgent';
+import { executionRegistry } from '@agent/runtime/executionRegistry';
+```
+
+There is intentionally no `@agent/runtime` barrel, matching `core`'s
+no-barrel convention — import from the specific file so dependency edges stay
+explicit and no re-export shim needs to be maintained.


### PR DESCRIPTION
Closes #7122

`src/agent/runtime/` has grown to 53 flat `.ts` files with no README or sub-grouping, unlike its sibling `src/agent/core/` (recently split into `definition/state/usage/tools/flows/` with an explicit module-map README, `src/agent/core/README.md`).

This adds `src/agent/runtime/README.md`, documenting the directory's existing file groupings by concern in the same table style as `core`'s README:

- **Launch & configuration** — resolving what a run should do before it starts (`AgentLaunchContext`, `agentLoad`, `agentToolResolution`, `delegationPolicy`, `toolInjection`, `selectAutoOpenFinalOutput`)
- **Run orchestration & resume** — entry points and their result types (`runAgent`, `executeAgent`, `AgentRunLifecycle`, `AgentFlowResult`, `resolveAndResumeStream`, `resumeQueuedToolUse`, `resumeToolUseSnapshot`, `SessionResumeRetrieval`, `followUpResumeDetection`)
- **Execution registry & live handles** — tracking/interrupting/tearing down live executions (`ExecutionHandle`, `executionRegistry`, `ExecutionSubscriptionBinder`, `InterruptRegistry`, `InterruptManager`, `ProcessOutputPoller`, `agentShutdown`, `detachSubagentsOnStop`)
- **Session, event hub & emission** — the per-session event contract and single emit path (`AgentRuntimeHost`, `SessionHandle`, `SessionEventHub`, `SessionRunFactProjector`, `LegacyProgressEventProjection`, `emitRuntimeEvent`, `runFactEvents`, `conversationProgressHub`, `StreamStatusService`, `streamTab`, `terminalResultToast`, `ProgressViewBridge`)
- **Run context & user-interaction coordinators** — ambient run context plus promise-based approval gates (`RunContext`, `runCoordinators`, `BasePromiseCoordinator`, `AgentProposalCoordinator`, `PlanApprovalCoordinator`, `RetryRequestCoordinator`)
- **Model resolution** — provider handler factory and helper-model resolution (`ModelFactory`, `modelHandlerCompatibilityKey`, `modelHandlerCompatibilityInference`, `internalValidationOverride`, `helperModel`, `helperModelName`, `helperModelPreference`, `textConnection`)
- **Content helpers** — one-shot content generation on the helper model (`sessionDescription`, `polishModel`, `textEnhancement`, `mediaVisionWarning`)

I checked whether an actual directory split (mirroring `core/`) was warranted per the issue's "low-risk" carve-out, and decided against it: ~180 files across `src/` and `packages/*` import an exact `@agent/runtime/<File>` path directly (there's no barrel), so physically moving any of these files means rewriting every one of those call sites — that's mechanical churn disproportionate to a docs change, not the "so natural / low-risk" case the issue allows for. The README explains this decision under "Why this stays flat" so it isn't re-litigated later without cause.

Documentation only — no file moves, no behavior changes.

## Verification
- `npx tsc --noEmit` (root) — clean
- `npx tsc --noEmit -p tsconfig.test-kernel.json` — clean
- `pnpm --filter texra typecheck` / `pnpm --filter @texra-ai/cli typecheck` — clean
- Cross-checked every one of the 53 `src/agent/runtime/*.ts` basenames appears in the README table (script-verified, zero missing)
- `npm run format` (prettier) applied to the new file via the pre-commit hook

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, import paths, or behavior changes.
> 
> **Overview**
> Adds **`src/agent/runtime/README.md`**, mirroring the module-map style of `src/agent/core/README.md`, so the ~50 flat runtime files are grouped by concern (launch, orchestration/resume, execution registry, session/events, coordinators, model resolution, content helpers) without opening each file.
> 
> Documents why the directory stays flat (~180 direct `@agent/runtime/<File>` imports, no barrel) and how to import (`@agent/runtime/<File>`, no barrel re-exports). **No code moves or behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3f9c2296866998e057a0e1042cc8f8c04dfc9f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->