### PR TITLE
Thread session param into wakeQueuedFollowUpStream call in inquiry continuation

### DIFF
--- a/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
@@ -14,7 +14,11 @@ import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import {
+  StreamStatusMachine,
+  StreamStatusService,
+} from '@agent/runtime/StreamStatusService';
+import { SessionHandle } from '@agent/runtime/SessionHandle';
 import {
   AgentExecutionHandle,
   executionRegistry,
@@ -374,6 +378,52 @@ describe('ToolUseFollowUp', () => {
       ]);
     } finally {
       executionRegistry.untrack(executionId);
+      ToolUseFollowUpQueue.release(parentStreamId);
+    }
+  });
+
+  it('routes the wake decision to an explicitly passed session instead of currentSession()', async () => {
+    // Regression for #7161: an explicit session param must decide
+    // active/resuming (and therefore wake/release) on its own state, not
+    // silently fall back to the process default session.
+    const parentStreamId = 'parent-stream-session-routing' as StreamTabId;
+
+    await initResumePlatform({ tryResumeStream: async () => false });
+
+    const result = { status: 'queued' as const, reason: 'waiting' as const };
+
+    const routedSession = new SessionHandle({
+      status: new StreamStatusMachine(),
+    });
+    seedStreamStatusForTest(
+      routedSession.status,
+      parentStreamId,
+      STREAM_STATUS.RUNNING,
+    );
+
+    try {
+      // The explicit session marks this stream RUNNING (active), so passing
+      // it must make the wake decision defer to it.
+      assert.deepEqual(
+        await wakeQueuedFollowUpStream(
+          parentStreamId,
+          result,
+          undefined,
+          routedSession,
+        ),
+        { kind: 'active_or_resuming' },
+      );
+
+      // Without an explicit session, the decision falls back to
+      // currentSession() (the process default), whose StreamStatusService
+      // has no state for this stream — proving the two sessions are not
+      // conflated and the routed session's state actually drove the result
+      // above.
+      assert.deepEqual(await wakeQueuedFollowUpStream(parentStreamId, result), {
+        kind: 'queued_resume_failed',
+      });
+    } finally {
+      clearStreamStatusForTest(routedSession.status, parentStreamId);
       ToolUseFollowUpQueue.release(parentStreamId);
     }
   });

--- a/src/test-kernel/tools/InquiryContinuationSession.vitest.ts
+++ b/src/test-kernel/tools/InquiryContinuationSession.vitest.ts
@@ -104,12 +104,43 @@ describe('external inquiry continuation session routing', () => {
       undefined,
       session,
     );
-    expect(wakeQueuedFollowUpStreamMock).toHaveBeenCalledWith(STREAM, {
-      status: 'sent',
-    });
+    // The wake/resume/release decision must route to the same session
+    // that owns this continuation (e.g. a desktop window), not fall back
+    // to currentSession() / the platform default.
+    expect(wakeQueuedFollowUpStreamMock).toHaveBeenCalledWith(
+      STREAM,
+      { status: 'sent' },
+      undefined,
+      session,
+    );
   });
 
-  it('delegates queued wake decisions to the follow-up owner', async () => {
+  it('delegates queued wake decisions to the follow-up owner, threading the session', async () => {
+    const session = { tag: 'desktop-session' } as unknown as SessionHandle;
+    sendFollowUpMock.mockResolvedValueOnce({
+      status: 'queued',
+      reason: 'waiting',
+    });
+    wakeQueuedFollowUpStreamMock.mockResolvedValueOnce({
+      kind: 'resumed' as const,
+    });
+
+    const outcome = await injectContinuationForAnsweredThread(
+      THREAD,
+      answeredManifest(),
+      session,
+    );
+
+    expect(outcome).toBe('resumed');
+    expect(wakeQueuedFollowUpStreamMock).toHaveBeenCalledWith(
+      STREAM,
+      { status: 'queued', reason: 'waiting' },
+      undefined,
+      session,
+    );
+  });
+
+  it('passes an undefined session through to the wake decision when none was provided', async () => {
     sendFollowUpMock.mockResolvedValueOnce({
       status: 'queued',
       reason: 'waiting',
@@ -124,10 +155,12 @@ describe('external inquiry continuation session routing', () => {
     );
 
     expect(outcome).toBe('resumed');
-    expect(wakeQueuedFollowUpStreamMock).toHaveBeenCalledWith(STREAM, {
-      status: 'queued',
-      reason: 'waiting',
-    });
+    expect(wakeQueuedFollowUpStreamMock).toHaveBeenCalledWith(
+      STREAM,
+      { status: 'queued', reason: 'waiting' },
+      undefined,
+      undefined,
+    );
   });
 
   it('archives inquiries when the follow-up owner drops a stale queue', async () => {

--- a/src/tools/inquiry/inquiryContinuation.ts
+++ b/src/tools/inquiry/inquiryContinuation.ts
@@ -164,7 +164,12 @@ async function deliverContinuation(params: {
   }
 
   const outcome = mapWakeResultToInquiryOutcome(
-    await wakeQueuedFollowUpStream(params.parentStreamId, result),
+    await wakeQueuedFollowUpStream(
+      params.parentStreamId,
+      result,
+      undefined,
+      params.session,
+    ),
   );
 
   await emitInquiryThreadUpdate(


### PR DESCRIPTION
Closes #7161

`deliverContinuation` (`src/tools/inquiry/inquiryContinuation.ts`) already threads an explicit `session?: SessionHandle` through to `sendFollowUp` and `emitInquiryThreadUpdate`, but the subsequent call to `wakeQueuedFollowUpStream(params.parentStreamId, result)` omitted it, so the wake/resume/release decision fell back to `currentSession()` / the platform default instead of routing to the specific session that owns this continuation (e.g. a desktop window).

`wakeQueuedFollowUpStream` (`src/agent/followUp/ToolUseFollowUp.ts`) already accepts an optional `session` parameter for exactly this purpose (added in #7158). This PR passes `params.session` through at the `inquiryContinuation.ts` call site.

## Changes

- `src/tools/inquiry/inquiryContinuation.ts`: pass `params.session` as the fourth argument to `wakeQueuedFollowUpStream`.
- `src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts`: new regression test proving `wakeQueuedFollowUpStream` routes its wake decision to an explicitly passed session (which reports the stream as active/resuming) rather than falling back to `currentSession()` (whose default `StreamStatusService` has no state for that stream) — the same stream/result pair yields `active_or_resuming` with the explicit session and `queued_resume_failed` without it.
- `src/test-kernel/tools/InquiryContinuationSession.vitest.ts`: updated/added assertions confirming the `inquiryContinuation.ts` call site actually forwards the session to the mocked `wakeQueuedFollowUpStream`, both when a session is provided and when it is not.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single call-site threading of an existing optional parameter, with regression tests only; no new wake policy logic.
> 
> **Overview**
> Fixes **#7161**: after an external inquiry answer is injected, **`deliverContinuation`** in `inquiryContinuation.ts` already forwarded `session` to `sendFollowUp` and UI events, but **`wakeQueuedFollowUpStream`** was called without it, so queued-stream wake/resume/release used the process default session instead of the window that owns the parent stream.
> 
> The call site now passes **`params.session`** as the fourth argument (matching the API added in #7158).
> 
> Tests add a **`ToolUseFollowUp`** regression that an explicit `SessionHandle` drives active/resuming vs default-session fallback, and tighten **`InquiryContinuationSession`** mocks to expect the session (or `undefined`) on the wake call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8909309179544f46cea6cfe5fa92a71658e3f52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->