### PR TITLE
Recheck active streams when restart-repair's fallback detection fails

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -879,6 +879,27 @@ export class DesktopProgressBridge {
                 : { error: detectError },
           },
         );
+        // detectRaceGuardedWaitingStreams() throwing only means the
+        // KV-store-backed lookup itself failed -- it does not mean no time
+        // passed. A stream could still have become active elsewhere while
+        // that (failed) await was in flight, so re-fetch active execution
+        // ids here too and recheck waitingStreams against them, or an
+        // actively-resumed stream could be handed to
+        // closeRunningTaskGroupsForStreams() below just because detection
+        // happened to fail. This mirrors the recheck the success branch
+        // above performs with its own (persisted-record) result, and also
+        // re-runs forgetActiveRestoredStreams() so a now-active stream is
+        // dropped from repairStreams entirely rather than being marked
+        // FAILED.
+        const {
+          activeExecutionIds: postDetectErrorActiveExecutionIds,
+          allExecutionIds: postDetectErrorAllExecutionIds,
+        } = this.refreshActiveExecutionIds();
+        for (const [streamId, executionId] of postDetectErrorAllExecutionIds) {
+          if (postDetectErrorActiveExecutionIds.has(executionId)) {
+            waitingStreams.delete(streamId);
+          }
+        }
       }
       const affectedStreams = this.resetRestartRepairStreamStatuses(
         new Set(this.progressEvents.restoredStreams.keys()),

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -887,6 +887,80 @@ describe('DesktopProgressBridge', () => {
     }
   });
 
+  it('rechecks active executions after a failed persisted-record lookup in the fallback path', async () => {
+    // Regression test for the "catch-within-catch" gap (issue #7160): the
+    // fallback path's own recheck (see the regression test above) only ran
+    // when detectRaceGuardedWaitingStreams() *resolved*. If
+    // detectWaitingStreams() itself throws on the fallback's second consult,
+    // the catch(detectError) block used to just log a warning and continue
+    // with the pre-existing in-memory waitingStreams -- even if the stream
+    // became active elsewhere while that failed lookup was in flight. It
+    // must still recheck against fresh active execution ids so an
+    // actively-resumed stream isn't handed to
+    // closeRunningTaskGroupsForStreams() below.
+    let activeExecutionIds: readonly string[] = [];
+    let detectCallCount = 0;
+    let rejectSecondDetect!: (error: Error) => void;
+    const secondDetectGate = new Promise<Set<StreamTabId>>((_, reject) => {
+      rejectSecondDetect = reject;
+    });
+    const detectWaitingStreams = vi.fn(async (): Promise<Set<StreamTabId>> => {
+      detectCallCount += 1;
+      if (detectCallCount === 1) {
+        // The primary try path's own consult -- fails immediately so the
+        // repair falls into the degraded catch-fallback path.
+        throw new Error('primary detect failed');
+      }
+      // The fallback's consult -- stays pending until the test simulates
+      // the race, then rejects (below).
+      return secondDetectGate;
+    });
+    const bridge = await createBridge([], {
+      activeExecutionIds: () => activeExecutionIds,
+      detectWaitingStreams,
+      streamSnapshotStore: createStreamSnapshotStore([
+        restoredSnapshot({
+          streamId: 'race-stream',
+          executionId: 'abc123',
+          lastKnownStatus: STREAM_PHASE.WAITING,
+        }),
+      ]),
+    });
+    // repairOrphanedStreamsAfterRestart() never emits an UPDATE_STREAMS sync
+    // in the fixed (fully-forgotten) outcome under test, so there is no
+    // message to poll for -- await the repair's own settle signal instead,
+    // which resolves only after its try/catch body (including any awaited
+    // closeRunningTaskGroupsForStreams call) has fully run.
+    const restartRepair = (
+      bridge as unknown as { restartRepair: Promise<void> }
+    ).restartRepair;
+    const streamLogs = bridge.streamLogs as typeof bridge.streamLogs & {
+      endRunningGroupsForStreams: (
+        streamIds: readonly StreamTabId[],
+        now?: number,
+      ) => Promise<StreamTabId[]>;
+    };
+    const closeSpy = vi.spyOn(streamLogs, 'endRunningGroupsForStreams');
+
+    try {
+      await vi.waitFor(() =>
+        expect(detectWaitingStreams).toHaveBeenCalledTimes(2),
+      );
+      // Simulate the race: another window (or a headless run) resumes the
+      // stream while the fallback's persisted-record lookup is in flight,
+      // and that lookup then fails.
+      activeExecutionIds = ['abc123'];
+      rejectSecondDetect(new Error('fallback detect failed'));
+      await restartRepair;
+
+      expect(closeSpy).not.toHaveBeenCalled();
+    } finally {
+      rejectSecondDetect(new Error('cleanup'));
+      bridgeStatus(bridge).clearStream('race-stream');
+      bridge.dispose();
+    }
+  });
+
   it('marks restored waiting streams as failed when no waiting session remains', async () => {
     const detectWaitingStreams = vi.fn(async () => new Set<StreamTabId>());
     const bridge = await createBridge([], {


### PR DESCRIPTION
Closes #7160

Follow-up to #7149 (merged). `repairOrphanedStreamsAfterRestart`'s catch-fallback path in `packages/desktop/src/main/desktopAgentExecution.ts` already rechecks active execution ids after a successful `detectRaceGuardedWaitingStreams()` call in the fallback, dropping any stream that became active while the KV read was in flight. That recheck only ran on the success path: if the fallback's own `detectRaceGuardedWaitingStreams()` call itself threw, the `catch (detectError)` block just logged a warning and continued with whatever `waitingStreams` the earlier in-memory scan had found, without rechecking for streams that became active in the meantime.

## Fix

Apply the same race-guard recheck in the `detectError` catch path: re-fetch active execution ids via the existing `refreshActiveExecutionIds()` helper (which also re-runs `forgetActiveRestoredStreams`, so a now-active stream is dropped from `repairStreams` entirely rather than being marked FAILED or handed to `closeRunningTaskGroupsForStreams()`), then prune `waitingStreams` against the fresh ids -- mirroring the recheck the success branch already performs with its own (persisted-record) result.

## Test

Added a regression test (`rechecks active executions after a failed persisted-record lookup in the fallback path`) that:
- forces the primary path's `detectWaitingStreams()` call to fail (entering the catch-fallback),
- forces the fallback's own `detectWaitingStreams()` call to stay pending and then reject (the "catch-within-catch" case),
- simulates the race by marking the stream's execution id active while that second, failing lookup is in flight,
- asserts `closeRunningTaskGroupsForStreams` is never called for the now-active stream.

Verified the test fails (catches `endRunningGroupsForStreams` being called with the stream) when the fix is reverted, and passes with it applied.

## Verification
- `npm run typecheck` -- clean
- `npx vitest run src/test-kernel/desktop/DesktopAgentExecution.vitest.mts` -- 47/47 passed
- `npx eslint packages/desktop/src/main/desktopAgentExecution.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts` -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches desktop startup stream recovery and cross-window execution races; incorrect pruning could leave orphan groups or skip needed cleanup, but the change mirrors an existing success-path guard and is covered by a targeted regression test.
> 
> **Overview**
> **Desktop restart-repair** now applies the same **active-execution race guard** when the degraded fallback’s KV `detectWaitingStreams` lookup **throws**, not only when it succeeds.
> 
> In `repairOrphanedStreamsAfterRestart`’s inner `catch (detectError)`, after logging, the code calls `refreshActiveExecutionIds()` and removes any `waitingStreams` entry whose execution id is active—so a stream resumed elsewhere during the failed lookup is not passed to `closeRunningTaskGroupsForStreams()` or wrongly repaired as failed.
> 
> Adds a **regression test** for the “catch-within-catch” case: primary detect fails, fallback detect rejects while the execution becomes active, asserting `endRunningGroupsForStreams` is never called.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c013c90ebd74d268a3da41c6fda865f94b9a07e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->