### PR TITLE
[codex] Route inquiry wake through owning session

### DIFF
--- a/src/test-kernel/agent/runtime/SessionScope.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionScope.vitest.ts
@@ -24,7 +24,10 @@ import {
   getAllActiveExecutionIds,
 } from '@agent/runtime/SessionHandle';
 import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
-import { sendFollowUp } from '@agent/followUp/ToolUseFollowUp';
+import {
+  sendFollowUp,
+  wakeQueuedFollowUpStream,
+} from '@agent/followUp/ToolUseFollowUp';
 import { MESSAGE_TYPES, type Plan, type StreamTabId } from '@shared/schemas';
 import { cleanupAllApprovals } from '@tools/approval';
 
@@ -279,6 +282,51 @@ describe('sendFollowUp host-path session routing (SDK Step 7d PR 4)', () => {
         status: 'no_session',
         streamStatus: undefined,
       });
+    } finally {
+      windowSession.followUps.release(parentStream);
+      windowSession.dispose();
+    }
+  });
+
+  it('uses the passed session for queued wake release decisions', async () => {
+    const windowSession = new SessionHandle();
+    const { host } = createRecordingHost();
+    const parentStream = 'stream:fu-wake-parent' as StreamTabId;
+
+    try {
+      windowSession.executions.track(
+        new AgentExecutionHandle(
+          'exec:fu-wake-child',
+          parentStream,
+          'stream:fu-wake-child' as StreamTabId,
+          'orchestrator',
+          'toolUse',
+          host,
+          createCoordinators(host),
+        ),
+      );
+
+      const result = await sendFollowUp(
+        parentStream,
+        'continue',
+        undefined,
+        undefined,
+        windowSession,
+      );
+      expect(result).toEqual({ status: 'queued', reason: 'children_running' });
+      expect(windowSession.followUps.getAll(parentStream)).toEqual([
+        'continue',
+      ]);
+
+      await expect(
+        wakeQueuedFollowUpStream(
+          parentStream,
+          result,
+          { tryResumeStream: async () => false },
+          windowSession,
+        ),
+      ).resolves.toEqual({ kind: 'dropped' });
+      expect(windowSession.followUps.getAll(parentStream)).toEqual([]);
     } finally {
       windowSession.followUps.release(parentStream);
       windowSession.dispose();

--- a/src/test-kernel/tools/InquiryContinuationSession.vitest.ts
+++ b/src/test-kernel/tools/InquiryContinuationSession.vitest.ts
@@ -87,7 +87,7 @@ describe('external inquiry continuation session routing', () => {
     readExternalInquiryThreadMock.mockClear();
   });
 
-  it('passes the host-provided session through to sendFollowUp', async () => {
+  it('passes the host-provided session through to follow-up send and wake', async () => {
     const session = { tag: 'desktop-session' } as unknown as SessionHandle;
 
     const outcome: InjectionOutcome = await injectContinuationForAnsweredThread(
@@ -104,9 +104,14 @@ describe('external inquiry continuation session routing', () => {
       undefined,
       session,
     );
-    expect(wakeQueuedFollowUpStreamMock).toHaveBeenCalledWith(STREAM, {
-      status: 'sent',
-    });
+    expect(wakeQueuedFollowUpStreamMock).toHaveBeenCalledWith(
+      STREAM,
+      {
+        status: 'sent',
+      },
+      undefined,
+      session,
+    );
   });
 
   it('delegates queued wake decisions to the follow-up owner', async () => {
@@ -124,10 +129,15 @@ describe('external inquiry continuation session routing', () => {
     );
 
     expect(outcome).toBe('resumed');
-    expect(wakeQueuedFollowUpStreamMock).toHaveBeenCalledWith(STREAM, {
-      status: 'queued',
-      reason: 'waiting',
-    });
+    expect(wakeQueuedFollowUpStreamMock).toHaveBeenCalledWith(
+      STREAM,
+      {
+        status: 'queued',
+        reason: 'waiting',
+      },
+      undefined,
+      undefined,
+    );
   });
 
   it('archives inquiries when the follow-up owner drops a stale queue', async () => {

--- a/src/tools/inquiry/inquiryContinuation.ts
+++ b/src/tools/inquiry/inquiryContinuation.ts
@@ -164,7 +164,12 @@ async function deliverContinuation(params: {
   }
 
   const outcome = mapWakeResultToInquiryOutcome(
-    await wakeQueuedFollowUpStream(params.parentStreamId, result),
+    await wakeQueuedFollowUpStream(
+      params.parentStreamId,
+      result,
+      undefined,
+      params.session,
+    ),
   );
 
   await emitInquiryThreadUpdate(


### PR DESCRIPTION
## Summary

Fixes the Stage 3a follow-up in #7161. Inquiry continuations already queued follow-ups through the caller-provided `SessionHandle`; this change passes the same owning session into `wakeQueuedFollowUpStream` so queued wake/resume/release decisions stay on the desktop window session that owns the stream.

## Issue acceptance gates

- Re-verified the cited `deliverContinuation` path in `src/tools/inquiry/inquiryContinuation.ts`: `sendFollowUp` received `params.session`, while `wakeQueuedFollowUpStream` did not.
- The wake call now forwards `params.session` as the session owner.
- Added a boundary regression proving inquiry continuations pass the host session through both send and wake.
- Added a session-scoped integration regression proving a queued `children_running` follow-up is released from the passed non-default session, not the process default.

## Single source of truth

The `SessionHandle` supplied to inquiry continuation remains the single owner for follow-up queue and stream-status wake decisions.

## Duplication and abstraction budget

No new abstraction, shim, or pass-through layer. This removes a fallback to `currentSession()` from the inquiry continuation wake path.

The PR is net-positive because the added lines are regression coverage for the desktop multi-session queue/wake behavior.

## Host impact

Extension: unchanged default-session behavior.

Desktop: inquiry answers/drops for a WAITING stream wake or release against the owning BrowserWindow session instead of the process default.

CLI: unchanged; default-session behavior remains intact.

## Scheduled refactoring

None. No shim, dual-write, alias, or migration path was introduced.

## Validation

- `corepack pnpm exec prettier --write src/tools/inquiry/inquiryContinuation.ts src/test-kernel/tools/InquiryContinuationSession.vitest.ts src/test-kernel/agent/runtime/SessionScope.vitest.ts`
- `npm test -- --run src/test-kernel/tools/InquiryContinuationSession.vitest.ts src/test-kernel/agent/runtime/SessionScope.vitest.ts src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts`
- `npm run typecheck`
- `npm test` (584 passed, 1 skipped; 4579 passed, 4 skipped)
- `npm run lint` (passes with one unrelated import-order warning in `packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts`)
- `npm run compile:fast`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `git diff --check origin/main..HEAD`

Closes #7161

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow routing fix with regression tests; default-session callers unchanged when session is omitted.
> 
> **Overview**
> Inquiry continuations already queued follow-ups via the caller’s `SessionHandle`; **`wakeQueuedFollowUpStream` now receives the same session** in `deliverContinuation`, so queued wake/resume/release (e.g. `children_running` drops) use the desktop window session that owns the stream instead of falling back to the process default.
> 
> Tests were tightened to assert the session is forwarded on both **send** and **wake**, plus a **session-scoped** regression that a queued follow-up is released from the passed non-default session when wake returns `dropped`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78c8064c4931175ced9e0b58fe962c53ce2b018d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->