### PR TITLE
fix(cli): reconcile history export not-found semantics, extract shared loader

### DIFF
--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -11,6 +11,7 @@ import {
   type ResultMeta,
 } from '@agent/storage';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import { loadChatExportInput } from '@agent/export/loadChatExportInput';
 import type { ChatExportInput } from '@agent/export/schemas';
 import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
 import {
@@ -213,8 +214,10 @@ export type CliHistoryExportInputResult =
 /**
  * Load a stored execution's config + conversation as the format-agnostic
  * {@link ChatExportInput} the html/markdown export formatters consume.
- * Mirrors the extension's `ChatExportController.buildExportInput` so the CLI
- * and extension render the same conversation identically.
+ * Thin CLI-specific wrapper around the shared {@link loadChatExportInput}
+ * loader, which also backs the extension's
+ * `ChatExportController.buildExportInput` — so the CLI and extension render
+ * the same conversation identically.
  *
  * Distinguishes "this execution id has no stored data at all" (`not_found`
  * — the same case `history show` reports as not found) from "this execution
@@ -222,42 +225,15 @@ export type CliHistoryExportInputResult =
  * would still display it, just without a conversation to render). Reporting
  * both as "not found" would mislead a caller whose id is valid but whose
  * execution simply never produced a conversation.
- *
- * `store.readConfig()` already validates against `AgentConfigSchema`
- * internally and falls back to `null` on a schema mismatch (see
- * `ExecutionKVStore.readValidated`), so `config` here is never a raw,
- * unvalidated value — no redundant re-parse (and no risk of it throwing on a
- * corrupt record) is needed.
  */
 export async function readCliHistoryExportInput(
   id: ExecutionId,
 ): Promise<CliHistoryExportInputResult> {
-  const store = getExecutionStore(id);
-  const [config, conversation, meta] = await Promise.all([
-    store.readConfig(),
-    store.readConversation(),
-    store.readMeta(),
-  ]);
+  const { meta, config, conversation, exportInput } =
+    await loadChatExportInput(id);
+  if (exportInput) return { status: 'ok', exportInput };
   if (!meta && !config && !conversation) return { status: 'not_found' };
-  if (!config || !conversation) return { status: 'incomplete' };
-
-  return {
-    status: 'ok',
-    exportInput: {
-      timestamp: meta?.timestamp ?? new Date().toISOString(),
-      description: meta?.description,
-      config: {
-        agent: config.agent,
-        model: config.model,
-        instruction: config.instruction,
-        inputFiles: config.inputFiles,
-        mediaFiles: config.mediaFiles,
-        contextFiles: config.contextFiles,
-        outputFiles: config.outputFiles,
-      },
-      messages: conversation,
-    },
-  };
+  return { status: 'incomplete' };
 }
 
 /**

--- a/src/agent/export/loadChatExportInput.ts
+++ b/src/agent/export/loadChatExportInput.ts
@@ -1,0 +1,95 @@
+/**
+ * Host-neutral loader for a stored execution's chat export input.
+ *
+ * Both the CLI (`texra history show <id> --export`) and the extension's
+ * Settings "Export chat" action need to read the same execution-store triple
+ * (config, conversation, meta) and assemble the same format-agnostic
+ * {@link ChatExportInput} the html/markdown/LaTeX formatters consume, so the
+ * two hosts render a stored conversation identically. This module is the
+ * single place that does that read + assemble; each host wraps it with its
+ * own status vocabulary (see `readCliHistoryExportInput` in
+ * `packages/cli/src/runtime/history.ts` and
+ * `ChatExportController.buildExportInput` in
+ * `src/controllers/settingsView/ChatExportController.ts`).
+ *
+ * `store.readConfig()` already validates against `AgentConfigSchema`
+ * internally and falls back to `null` on a schema mismatch (see
+ * `ExecutionKVStore.readValidated`), so `config` here is never a raw,
+ * unvalidated value — no redundant re-parse (and no risk of it throwing on a
+ * corrupt record) is needed.
+ */
+
+import { getExecutionStore, type ExecutionMeta } from '@agent/storage';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import type { ChatExportInput } from '@agent/export/schemas';
+import type { ExecutionId } from '@shared/schemas';
+
+/**
+ * Facts read from the execution store, plus the assembled
+ * {@link ChatExportInput} when both `config` and a non-empty `conversation`
+ * are present. `exportInput` is `null` whenever there is nothing (or not
+ * enough) to export; callers distinguish "nothing at all" from "something is
+ * missing" using `meta`/`config`/`conversation` themselves.
+ */
+export interface ChatExportLoadResult {
+  readonly meta: ExecutionMeta | null;
+  readonly config: AgentConfig | null;
+  /** Normalized: `null` when absent *or* empty — an empty array never counts
+   *  as "a conversation is present" (see module doc). */
+  readonly conversation: readonly unknown[] | null;
+  readonly exportInput: ChatExportInput | null;
+}
+
+/**
+ * A stored conversation is only "present" when it has at least one message.
+ * A stored-but-empty array must be treated the same as absent so that
+ * every existence check downstream (this module's `exportInput`, and each
+ * host's own not-found/incomplete classification) agrees with
+ * `readCliHistoryDetails`, which builds no preview from an empty array
+ * either. Without this, a plain truthiness check (`!conversation`) would
+ * treat `[]` as "present" — `![]` is `false` in JS — and misreport an
+ * execution `history show` already treats as not found.
+ */
+function hasConversationMessages(
+  conversation: readonly unknown[] | null,
+): conversation is readonly unknown[] {
+  return Array.isArray(conversation) && conversation.length > 0;
+}
+
+export async function loadChatExportInput(
+  id: ExecutionId,
+): Promise<ChatExportLoadResult> {
+  const store = getExecutionStore(id);
+  const [config, rawConversation, meta] = await Promise.all([
+    store.readConfig(),
+    store.readConversation(),
+    store.readMeta(),
+  ]);
+  const conversation = hasConversationMessages(rawConversation)
+    ? rawConversation
+    : null;
+
+  if (!config || !conversation) {
+    return { meta, config, conversation, exportInput: null };
+  }
+
+  return {
+    meta,
+    config,
+    conversation,
+    exportInput: {
+      timestamp: meta?.timestamp ?? new Date().toISOString(),
+      description: meta?.description,
+      config: {
+        agent: config.agent,
+        model: config.model,
+        instruction: config.instruction,
+        inputFiles: config.inputFiles,
+        mediaFiles: config.mediaFiles,
+        contextFiles: config.contextFiles,
+        outputFiles: config.outputFiles,
+      },
+      messages: conversation,
+    },
+  };
+}

--- a/src/agent/export/loadChatExportInput.ts
+++ b/src/agent/export/loadChatExportInput.ts
@@ -13,10 +13,10 @@
  * `src/controllers/settingsView/ChatExportController.ts`).
  *
  * `store.readConfig()` already validates against `AgentConfigSchema`
- * internally and falls back to `null` on a schema mismatch (see
- * `ExecutionKVStore.readValidated`), so `config` here is never a raw,
- * unvalidated value — no redundant re-parse (and no risk of it throwing on a
- * corrupt record) is needed.
+ * internally and falls back to `null` on a schema mismatch (see the private
+ * `readValidated` helper on `StorageFSKVStore` in `ExecutionKVStore.ts`), so
+ * `config` here is never a raw, unvalidated value — no redundant re-parse
+ * (and no risk of it throwing on a corrupt record) is needed.
  */
 
 import { getExecutionStore, type ExecutionMeta } from '@agent/storage';
@@ -42,13 +42,16 @@ export interface ChatExportLoadResult {
 
 /**
  * A stored conversation is only "present" when it has at least one message.
- * A stored-but-empty array must be treated the same as absent so that
- * every existence check downstream (this module's `exportInput`, and each
- * host's own not-found/incomplete classification) agrees with
- * `readCliHistoryDetails`, which builds no preview from an empty array
- * either. Without this, a plain truthiness check (`!conversation`) would
- * treat `[]` as "present" — `![]` is `false` in JS — and misreport an
- * execution `history show` already treats as not found.
+ * `ExecutionKVStore.readConversation()` already normalizes an empty stored
+ * array to `null` at the store layer, so this check is defensive rather than
+ * the primary fix — but it keeps the "non-empty array only" contract
+ * explicit for this module's callers (and for tests, which mock the store
+ * directly and can return `[]` without going through that normalization).
+ * Without it, a plain truthiness check (`!conversation`) would treat `[]` as
+ * "present" — `![]` is `false` in JS — and every existence check downstream
+ * (this module's `exportInput`, and each host's own not-found/incomplete
+ * classification) would disagree with `readCliHistoryDetails`, which builds
+ * no preview from an empty array either.
  */
 function hasConversationMessages(
   conversation: readonly unknown[] | null,

--- a/src/controllers/settingsView/ChatExportController.ts
+++ b/src/controllers/settingsView/ChatExportController.ts
@@ -13,8 +13,7 @@
  */
 
 // Local imports - agent
-import { getExecutionStore } from '@agent/storage';
-import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
+import { loadChatExportInput } from '@agent/export/loadChatExportInput';
 
 // Local imports - host-neutral chat-export formatters
 import {
@@ -85,39 +84,23 @@ export class ChatExportController {
    *
    * Returns a discriminated status so the caller can show the right error
    * message for each missing piece without coupling to storage details.
+   * Thin wrapper around the shared {@link loadChatExportInput} loader, which
+   * also backs the CLI's `readCliHistoryExportInput` — so both hosts read,
+   * validate, and assemble export input identically (including treating a
+   * stored-but-empty conversation array as absent, not present).
    */
   async buildExportInput(historyId: string): Promise<ExportInputResult> {
-    const store = getExecutionStore(historyId as ExecutionId);
-    const [rawConfig, conversation, meta] = await Promise.all([
-      store.readConfig(),
-      store.readConversation(),
-      store.readMeta(),
-    ]);
+    const { config, exportInput } = await loadChatExportInput(
+      historyId as ExecutionId,
+    );
 
-    if (!rawConfig) {
+    if (!config) {
       return { status: 'config_missing' };
     }
 
-    if (!conversation) {
+    if (!exportInput) {
       return { status: 'conversation_missing' };
     }
-
-    const config = AgentConfigSchema.parse(rawConfig);
-
-    const exportInput: ChatExportInput = {
-      timestamp: meta?.timestamp ?? new Date().toISOString(),
-      description: meta?.description,
-      config: {
-        agent: config.agent,
-        model: config.model,
-        instruction: config.instruction,
-        inputFiles: config.inputFiles,
-        mediaFiles: config.mediaFiles,
-        contextFiles: config.contextFiles,
-        outputFiles: config.outputFiles,
-      },
-      messages: conversation,
-    };
 
     return { status: 'ok', exportInput };
   }

--- a/src/test-kernel/agent/export/loadChatExportInput.vitest.ts
+++ b/src/test-kernel/agent/export/loadChatExportInput.vitest.ts
@@ -1,0 +1,128 @@
+/* eslint-disable import/order -- Vitest mocks must be declared before importing the module under test. */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import type { ExecutionId } from '@shared/schemas';
+import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
+
+const mocks = vi.hoisted(() => ({
+  readConfig: vi.fn(),
+  readConversation: vi.fn(),
+  readMeta: vi.fn(),
+}));
+
+vi.mock('@agent/storage', () => ({
+  getExecutionStore: vi.fn(() => ({
+    readConfig: mocks.readConfig,
+    readConversation: mocks.readConversation,
+    readMeta: mocks.readMeta,
+  })),
+}));
+
+// Imported after vi.mock so the mocked dependency is in place.
+import { loadChatExportInput } from '@agent/export/loadChatExportInput';
+
+const config = {
+  agent: 'correct',
+  model: 'deepseekT',
+  instruction: 'Polish the introduction.',
+  agentCategory: 'workflow',
+  inputFiles: ['chapters/intro.tex'],
+  outputFiles: ['chapters/intro.tex'],
+  contextFiles: [],
+  mediaFiles: [],
+  editedFile: null,
+  editedFiles: [],
+  memories: [],
+  toolConfig: DEFAULT_TOOL_CONFIG,
+} as AgentConfig;
+
+describe('loadChatExportInput (shared CLI/extension chat-export loader)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.readConfig.mockResolvedValue(null);
+    mocks.readConversation.mockResolvedValue(null);
+    mocks.readMeta.mockResolvedValue(null);
+  });
+
+  it('assembles a ChatExportInput when config and a non-empty conversation are both present', async () => {
+    mocks.readConfig.mockResolvedValue(config);
+    mocks.readConversation.mockResolvedValue([
+      { role: 'user', content: 'Polish the lemma.' },
+      { role: 'assistant', content: 'Done.' },
+    ]);
+    mocks.readMeta.mockResolvedValue({
+      timestamp: '2026-05-18T08:00:00.000Z',
+      description: 'Polish pass',
+    });
+
+    const result = await loadChatExportInput('a1' as ExecutionId);
+
+    expect(result.exportInput).toEqual({
+      timestamp: '2026-05-18T08:00:00.000Z',
+      description: 'Polish pass',
+      config: {
+        agent: 'correct',
+        model: 'deepseekT',
+        instruction: 'Polish the introduction.',
+        inputFiles: ['chapters/intro.tex'],
+        mediaFiles: [],
+        contextFiles: [],
+        outputFiles: ['chapters/intro.tex'],
+      },
+      messages: [
+        { role: 'user', content: 'Polish the lemma.' },
+        { role: 'assistant', content: 'Done.' },
+      ],
+    });
+    expect(result.conversation).toEqual([
+      { role: 'user', content: 'Polish the lemma.' },
+      { role: 'assistant', content: 'Done.' },
+    ]);
+  });
+
+  it('returns a null exportInput when nothing is stored at all', async () => {
+    const result = await loadChatExportInput('missing' as ExecutionId);
+
+    expect(result).toEqual({
+      meta: null,
+      config: null,
+      conversation: null,
+      exportInput: null,
+    });
+  });
+
+  it('normalizes a stored-but-empty conversation array to null, matching "no conversation"', async () => {
+    // An empty array is truthy in JS (`![]` is `false`) — a naive presence
+    // check on the raw store value would treat it as "a conversation is
+    // present". Every caller (CLI not_found/incomplete, extension
+    // config_missing/conversation_missing) needs `conversation`/`exportInput`
+    // to already reflect "absent" for this case, not just falsy-vs-array.
+    mocks.readConversation.mockResolvedValue([]);
+
+    const result = await loadChatExportInput('missing' as ExecutionId);
+
+    expect(result.conversation).toBeNull();
+    expect(result.exportInput).toBeNull();
+  });
+
+  it('reports a null exportInput when config is present but the conversation is empty', async () => {
+    mocks.readConfig.mockResolvedValue(config);
+    mocks.readConversation.mockResolvedValue([]);
+
+    const result = await loadChatExportInput('a1' as ExecutionId);
+
+    expect(result.config).toEqual(config);
+    expect(result.conversation).toBeNull();
+    expect(result.exportInput).toBeNull();
+  });
+
+  it('reports a null exportInput when conversation is present but config is missing', async () => {
+    mocks.readConversation.mockResolvedValue([{ role: 'user', content: 'hi' }]);
+
+    const result = await loadChatExportInput('a1' as ExecutionId);
+
+    expect(result.config).toBeNull();
+    expect(result.exportInput).toBeNull();
+  });
+});

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -1102,6 +1102,32 @@ describe('CLI history runtime', () => {
       ).resolves.toEqual({ status: 'incomplete' });
     });
 
+    it('reports "not_found" (not "incomplete") when the stored conversation is an empty array', async () => {
+      // A stored-but-empty conversation array is truthy (`![]` is `false`),
+      // so a naive `!conversation` check would treat it as "present" and
+      // report 'incomplete' here — while `history show` builds no preview
+      // from an empty array and, with config/meta also absent, reports the
+      // same id as not found. The two commands must agree.
+      mocks.readConfig.mockResolvedValue(null);
+      mocks.readConversation.mockResolvedValue([]);
+      mocks.readMeta.mockResolvedValue(null);
+
+      await expect(
+        readCliHistoryExportInput('missing' as ExecutionId),
+      ).resolves.toEqual({ status: 'not_found' });
+      await expect(
+        readCliHistoryDetails('missing' as ExecutionId),
+      ).resolves.toBeNull();
+    });
+
+    it('still reports "incomplete" when config exists but the stored conversation is only an empty array', async () => {
+      mocks.readConversation.mockResolvedValue([]);
+
+      await expect(
+        readCliHistoryExportInput('a1' as ExecutionId),
+      ).resolves.toEqual({ status: 'incomplete' });
+    });
+
     it('stages the bundled HTML export assets into the destination directory', async () => {
       await withTempDir('texra-history-export-src-', async (resourcesPath) => {
         await withTempDir('texra-history-export-dest-', async (cwd) => {

--- a/src/test-kernel/controllers/ChatExportController.vitest.ts
+++ b/src/test-kernel/controllers/ChatExportController.vitest.ts
@@ -1,0 +1,109 @@
+/* eslint-disable import/order -- Vitest mocks must be declared before importing the module under test. */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
+
+const mocks = vi.hoisted(() => ({
+  readConfig: vi.fn(),
+  readConversation: vi.fn(),
+  readMeta: vi.fn(),
+}));
+
+vi.mock('@agent/storage', () => ({
+  getExecutionStore: vi.fn(() => ({
+    readConfig: mocks.readConfig,
+    readConversation: mocks.readConversation,
+    readMeta: mocks.readMeta,
+  })),
+}));
+
+// Imported after vi.mock so the mocked dependency is in place.
+import { ChatExportController } from '@controllers/settingsView/ChatExportController';
+
+const config = {
+  agent: 'correct',
+  model: 'deepseekT',
+  instruction: 'Polish the introduction.',
+  agentCategory: 'workflow',
+  inputFiles: ['chapters/intro.tex'],
+  outputFiles: ['chapters/intro.tex'],
+  contextFiles: [],
+  mediaFiles: [],
+  editedFile: null,
+  editedFiles: [],
+  memories: [],
+  toolConfig: DEFAULT_TOOL_CONFIG,
+} as AgentConfig;
+
+describe('ChatExportController.buildExportInput', () => {
+  const controller = new ChatExportController({ latexPreamble: '' });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.readConfig.mockResolvedValue(null);
+    mocks.readConversation.mockResolvedValue(null);
+    mocks.readMeta.mockResolvedValue(null);
+  });
+
+  it('builds export input from the stored config, conversation, and meta', async () => {
+    mocks.readConfig.mockResolvedValue(config);
+    mocks.readConversation.mockResolvedValue([
+      { role: 'user', content: 'Polish the lemma.' },
+      { role: 'assistant', content: 'Done.' },
+    ]);
+    mocks.readMeta.mockResolvedValue({
+      timestamp: '2026-05-18T08:00:00.000Z',
+      description: 'Polish pass',
+    });
+
+    const result = await controller.buildExportInput('a1');
+
+    expect(result).toEqual({
+      status: 'ok',
+      exportInput: {
+        timestamp: '2026-05-18T08:00:00.000Z',
+        description: 'Polish pass',
+        config: {
+          agent: 'correct',
+          model: 'deepseekT',
+          instruction: 'Polish the introduction.',
+          inputFiles: ['chapters/intro.tex'],
+          mediaFiles: [],
+          contextFiles: [],
+          outputFiles: ['chapters/intro.tex'],
+        },
+        messages: [
+          { role: 'user', content: 'Polish the lemma.' },
+          { role: 'assistant', content: 'Done.' },
+        ],
+      },
+    });
+  });
+
+  it('reports "config_missing" when nothing is stored at all', async () => {
+    await expect(controller.buildExportInput('missing')).resolves.toEqual({
+      status: 'config_missing',
+    });
+  });
+
+  it('reports "conversation_missing" when config exists but conversation does not', async () => {
+    mocks.readConfig.mockResolvedValue(config);
+
+    await expect(controller.buildExportInput('a1')).resolves.toEqual({
+      status: 'conversation_missing',
+    });
+  });
+
+  it('reports "conversation_missing" (not "ok") when the stored conversation is only an empty array', async () => {
+    // A stored-but-empty conversation array is truthy — this must not be
+    // mistaken for "a conversation is present" (matches the CLI's
+    // not_found/incomplete reconciliation for the same underlying case).
+    mocks.readConfig.mockResolvedValue(config);
+    mocks.readConversation.mockResolvedValue([]);
+
+    await expect(controller.buildExportInput('a1')).resolves.toEqual({
+      status: 'conversation_missing',
+    });
+  });
+});


### PR DESCRIPTION
Closes #7156, closes #7157

## What changed

**#7156** — `readCliHistoryExportInput` treated a stored empty conversation array (`[]`) as *present*, because `![]` is `false` in JS:

```ts
if (!meta && !config && !conversation) return { status: 'not_found' };
if (!config || !conversation) return { status: 'incomplete' };
```

So `(config: null, conversation: [], meta: null)` reported `'incomplete'` ("exists, nothing to export yet"). But `readCliHistoryDetails` (backing plain `history show`) builds no preview from an empty array, and with config/meta also null, reports the *same* execution id as not found. `history show <id>` and `history show <id> --export html` disagreed about existence for the same id.

**#7157** — `readCliHistoryExportInput` deliberately mirrored `ChatExportController.buildExportInput`: both read config/conversation/meta from the execution store and build a `ChatExportInput`, so the CLI and extension render conversations identically. That mirroring was duplicated read/validate/assemble logic across two call sites.

## Fix

Extracted a shared, host-neutral `loadChatExportInput` helper (`src/agent/export/loadChatExportInput.ts`) that does the store reads, normalizes a stored-but-empty conversation array to `null` (matching "no conversation" semantically instead of by truthiness), and assembles the `ChatExportInput` when both config and a non-empty conversation are present.

Both callers are now thin, host-specific wrappers:
- `readCliHistoryExportInput` (CLI) derives `not_found` / `incomplete` / `ok` from the loader's facts.
- `ChatExportController.buildExportInput` (extension) derives `config_missing` / `conversation_missing` / `ok`, and also drops a redundant `AgentConfigSchema.parse()` re-parse of a value that `store.readConfig()` already validates.

Both hosts get the corrected empty-array semantics for free, and `history show <id>` / `history show <id> --export html` now agree on existence for the same id.

## Tests

- `src/test-kernel/cli/History.vitest.mts` — added coverage for the empty-array reconciliation (`not_found` when nothing else exists, `incomplete` when config exists) and confirmed `readCliHistoryDetails` agrees.
- `src/test-kernel/agent/export/loadChatExportInput.vitest.ts` — new, direct coverage of the shared loader (assemble, nothing stored, empty-array normalization, config-only, conversation-only).
- `src/test-kernel/controllers/ChatExportController.vitest.ts` — new, covers the extension wrapper's status derivation including the empty-array case.

## Verification

- `npm run typecheck` — clean
- Targeted vitest files (`History.vitest.mts`, `loadChatExportInput.vitest.ts`, `ChatExportController.vitest.ts`, plus pre-existing `chatExportFormatter.vitest.ts` / `HistoryHandlers.vitest.ts` as a smoke check) — all pass
- `eslint` on touched files — clean (no errors, no warnings)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor plus edge-case semantics for export/history only; no auth, payments, or core agent runtime changes.
> 
> **Overview**
> Introduces shared **`loadChatExportInput`** so CLI history export and the extension Settings chat export read the same execution-store data and build identical **`ChatExportInput`** payloads. **`readCliHistoryExportInput`** and **`ChatExportController.buildExportInput`** are now thin wrappers that map loader results to host-specific statuses; the extension no longer re-parses config with **`AgentConfigSchema`**.
> 
> **Empty conversation fix:** stored **`[]`** is normalized to “no conversation” (not truthy-present), so **`history show`** and **`history show --export`** agree on **not_found** vs **incomplete** for the same execution id. Tests cover the shared loader, CLI export semantics, and the extension wrapper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 654ed491f55454175d356714e5f85d3bf6ef86a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->