### PR TITLE
fix: synthesize cancelled tool_result for interrupted tool-use calls

### DIFF
--- a/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
@@ -53,14 +53,16 @@ const STREAMABLE_TOOLS = new Set(['bash']);
 const STREAM_BUFFER_MAX = 50_000;
 
 /**
- * Error message for a tool_result synthesized in place of a tool_use whose
- * call never executed (interrupted before dispatch, or aborted mid-flight).
- * Every persisted tool_use must have a paired tool_result — providers with
- * strict tool-call pairing requirements (e.g. Anthropic, and OpenAI's
- * response-chaining mode) reject follow-up requests otherwise.
+ * Error message for a tool_result synthesized in place of a tool_use with no
+ * recorded result: the call may have never started (interrupted before
+ * dispatch), or started and been aborted mid-flight (interrupted after the
+ * tool ran but before its result was accepted). Every persisted tool_use must
+ * have a paired tool_result — providers with strict tool-call pairing
+ * requirements (e.g. Anthropic, and OpenAI's response-chaining mode) reject
+ * follow-up requests otherwise.
  */
 const CANCELLED_CALL_ERROR =
-  'Tool call cancelled — the run was interrupted before this tool executed.';
+  'Tool call cancelled — the run was interrupted and no result was recorded for this call.';
 
 /**
  * Result of executing a single tool call, capturing everything needed
@@ -458,10 +460,19 @@ export class ToolUseDispatchNode<C> extends BatchNode<
   /** Process tool execution results and create follow-up messages. */
   async post(
     shared: ToolUseRoundShared,
-    toolCalls: SdkToolCall[],
+    dispatchedCalls: SdkToolCall[],
     execResults: (ToolExecutionResult | null)[],
   ): Promise<string | undefined> {
     const { workspace } = this.services;
+
+    // prep() returns [] when interruption is detected before any call is
+    // dispatched (or when there was nothing to dispatch this round). Fall
+    // back to shared.toolCalls — the full set the model requested — so an
+    // interruption caught this early still gets synthesized cancelled
+    // results instead of leaving those tool_use blocks unpaired in history.
+    const toolCalls = dispatchedCalls.length
+      ? dispatchedCalls
+      : (shared.toolCalls ?? []);
 
     if (!toolCalls.length) {
       return FlowTransition.COMPLETE;

--- a/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
@@ -53,6 +53,16 @@ const STREAMABLE_TOOLS = new Set(['bash']);
 const STREAM_BUFFER_MAX = 50_000;
 
 /**
+ * Error message for a tool_result synthesized in place of a tool_use whose
+ * call never executed (interrupted before dispatch, or aborted mid-flight).
+ * Every persisted tool_use must have a paired tool_result — providers with
+ * strict tool-call pairing requirements (e.g. Anthropic, and OpenAI's
+ * response-chaining mode) reject follow-up requests otherwise.
+ */
+const CANCELLED_CALL_ERROR =
+  'Tool call cancelled — the run was interrupted before this tool executed.';
+
+/**
  * Result of executing a single tool call, capturing everything needed
  * for logging and message creation.
  */
@@ -353,6 +363,33 @@ export class ToolUseDispatchNode<C> extends BatchNode<
     };
   }
 
+  /**
+   * Build a synthetic "cancelled" result for a tool_use that never executed
+   * (interrupted before dispatch, or aborted mid-flight and returned `null`
+   * from `exec()`). Mirrors the duplicate-call synthetic result shape so it
+   * flows through the same follow-up-message construction unchanged.
+   */
+  private buildCancelledResult(call: SdkToolCall): ToolExecutionResult {
+    const cancelledResult: ToolResult = {
+      status: 'error',
+      error: CANCELLED_CALL_ERROR,
+    };
+    return {
+      call,
+      result: cancelledResult,
+      parsedInput: call.input,
+      extracted: {
+        sanitizedResult: cancelledResult,
+        attachments: [],
+      },
+      editedFiles: [],
+      logRef: {
+        logId: undefined,
+        groupId: this.services.logger.activeStageId(),
+      },
+    };
+  }
+
   private async logAndProcessMediaFiles(
     execResult: ToolExecutionResult,
   ): Promise<void> {
@@ -421,30 +458,47 @@ export class ToolUseDispatchNode<C> extends BatchNode<
   /** Process tool execution results and create follow-up messages. */
   async post(
     shared: ToolUseRoundShared,
-    _toolCalls: SdkToolCall[],
+    toolCalls: SdkToolCall[],
     execResults: (ToolExecutionResult | null)[],
   ): Promise<string | undefined> {
     const { workspace } = this.services;
 
-    const completedResults = execResults.filter(
-      (r): r is ToolExecutionResult => r !== null,
-    );
-
-    if (completedResults.length < execResults.length) {
-      shared.shouldStop = true;
-    }
-    if (!completedResults.length) {
+    if (!toolCalls.length) {
       return FlowTransition.COMPLETE;
+    }
+
+    // Every tool_use the model requested must end up paired with a tool_result
+    // before persistence. A call that never executed — interrupted before
+    // dispatch, aborted mid-flight, or a duplicate whose primary never ran —
+    // shows up here as `null`; synthesize a "cancelled" result for it instead
+    // of silently dropping it, so the persisted turn always satisfies
+    // provider tool-call pairing invariants on resume.
+    let interrupted = false;
+    const allResults = toolCalls.map((call, index) => {
+      const execResult = execResults[index];
+      if (execResult) return execResult;
+      interrupted = true;
+      return this.buildCancelledResult(call);
+    });
+
+    if (interrupted) {
+      shared.shouldStop = true;
     }
 
     const assistantText = shared.text ?? '';
 
-    for (const execResult of completedResults) {
-      await this.logAndProcessMediaFiles(execResult);
+    // Only log results that actually ran (or were synthesized earlier for
+    // duplicate skips) — a mid-flight abort already finalizes its own card
+    // with a 'failed' status inside executeToolCall(), and a never-started
+    // call has no card to update.
+    for (const execResult of execResults) {
+      if (execResult) {
+        await this.logAndProcessMediaFiles(execResult);
+      }
     }
 
-    const extracted = completedResults.map((er) => er.extracted);
-    const calls = completedResults.map((er) => er.call);
+    const extracted = allResults.map((er) => er.extracted);
+    const calls = allResults.map((er) => er.call);
 
     // For handlers that carry provider-side reasoning across multiple parallel
     // calls, batch all tool calls into a single message to preserve thought
@@ -466,7 +520,7 @@ export class ToolUseDispatchNode<C> extends BatchNode<
         );
       shared.messages.push(...followUpMsgs);
     } else {
-      for (const [index, execResult] of completedResults.entries()) {
+      for (const [index, execResult] of allResults.entries()) {
         const { sanitizedResult, attachments } = extracted[index];
         const followUpMsgs = await modelHandler.createToolUseFollowUpMessages(
           this.services.client,

--- a/src/test-kernel/agent/followUp/ToolUseDispatchInterruption.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseDispatchInterruption.vitest.ts
@@ -1,0 +1,203 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports - agent core
+import { createRunTrace } from '@transcript';
+import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
+import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
+import type { ToolUseRoundServices } from '@agent/core/flows/CycleServices';
+import {
+  createToolUseRoundFlow,
+  type ToolUseRoundShared,
+} from '@agent/core/flows/ToolUseRoundFlow';
+import { MapToolRegistry } from '@agent/core/tools/ToolTypes';
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
+import { withTestRunContext } from '../progressTestUtils';
+
+/**
+ * Regression test for https://github.com/LionSR/TeXRA/issues/7163.
+ *
+ * When a tool-use round is interrupted mid-flight, `ToolUseDispatchNode` used
+ * to silently drop the tool_use blocks for calls that never executed —
+ * persisting an assistant turn with N tool_use blocks but fewer than N
+ * tool_result entries. Providers with strict tool-call pairing requirements
+ * (e.g. Anthropic, and OpenAI's response-chaining mode) reject a follow-up
+ * request whose history has an unpaired tool_use on resume.
+ *
+ * This test dispatches two tool calls in one round, interrupts the run
+ * between the first call finishing and the second call starting, and asserts
+ * the persisted messages contain a matching tool_use/tool_result pair for
+ * *both* calls — the second pair being a synthesized "cancelled" result.
+ */
+describe('ToolUseDispatchNode interruption', () => {
+  it('synthesizes a cancelled tool_result for a call skipped mid-round, keeping tool_use/tool_result counts paired', async () => {
+    let checkCount = 0;
+    const checkInterruption = vi.fn(() => {
+      checkCount += 1;
+      // Checks 1-4 (round prep, dispatch prep, call-a's pre-dispatch check,
+      // call-a's post-invoke check) report "not interrupted" so call-a runs
+      // to completion. From call-b's pre-dispatch check (5) onward,
+      // interruption is detected — call-b never executes.
+      return checkCount > 4;
+    });
+
+    const toolACall = vi.fn(async () => ({
+      status: 'executed' as const,
+      output: 'toolA done',
+    }));
+    const toolBCall = vi.fn(async () => ({
+      status: 'executed' as const,
+      output: 'toolB done',
+    }));
+
+    const createToolUseFollowUpMessages = vi.fn(
+      async (
+        _client: unknown,
+        call: { callId: string; name: string },
+        result: unknown,
+      ) =>
+        [
+          {
+            type: 'function_call',
+            call_id: call.callId,
+            name: call.name,
+            arguments: '{}',
+          },
+          {
+            type: 'function_call_output',
+            call_id: call.callId,
+            output: JSON.stringify(result),
+          },
+        ] as ProviderMessage[],
+    );
+
+    const createResponse = vi.fn(async () => ({
+      response: { id: 'round-1', toolCalls: true },
+    }));
+
+    const services = {
+      checkInterruption,
+      client: {},
+      config: { agent: 'test-agent', model: 'test-model' },
+      fileService: {
+        createLocation: (filePath: string) => ({ absolutePath: filePath }),
+      },
+      logger: createRunTrace('ToolUseDispatchInterruption').trace,
+      modelHandler: {
+        addMediaToUserMessage: vi.fn(async () => {}),
+        capabilities: { supportsVision: true },
+        createAssistantMessageFromResponse: vi.fn(
+          (_response: unknown, text: string) =>
+            ({ type: 'message', role: 'assistant', content: text }) as never,
+        ),
+        createResponse,
+        createToolUseFollowUpMessages,
+        createUserFollowUpMessages: vi.fn(),
+        extractAssistantContent: () => [],
+        extractResponse: (response: { toolCalls?: boolean }) => ({
+          text: '',
+          usage: null,
+          stopReason: response.toolCalls ? 'tool_calls' : 'stop',
+        }),
+        extractServerToolData: () => ({
+          contentBlocks: [],
+          webFetchResults: [],
+          webSearchResults: [],
+        }),
+        extractToolUse: (response: { toolCalls?: boolean }) =>
+          response.toolCalls
+            ? [
+                {
+                  callId: 'call-a',
+                  input: {},
+                  name: 'toolA',
+                  provider: 'test',
+                  raw: {},
+                },
+                {
+                  callId: 'call-b',
+                  input: {},
+                  name: 'toolB',
+                  provider: 'test',
+                  raw: {},
+                },
+              ]
+            : [],
+        getStreamingConfig: () => false,
+        isEndTurnStop: (stopReason: string) => stopReason === 'stop',
+        processThinkingBlock: () => null,
+        setOutputStreaming: vi.fn(),
+      },
+      prompt: { systemPrompt: '', userPrefix: '', userRequest: '' },
+      run: AgentRunStateSnapshotSchema.parse({}),
+      session: {
+        hasQueuedFollowUp: () => false,
+      },
+      setAbortController: () => {},
+      setting: {
+        temperature: 0,
+        tools: [{ name: 'toolA' }, { name: 'toolB' }],
+      },
+      streamStatus: new StreamStatusMachine(),
+      toolRegistry: new MapToolRegistry({
+        toolA: { call: toolACall, definition: { name: 'toolA' } } as never,
+        toolB: { call: toolBCall, definition: { name: 'toolB' } } as never,
+      }),
+      userVarChannels: { input: {}, transient: {} },
+      workspace: AgentWorkspaceState.create(),
+    } as unknown as ToolUseRoundServices;
+
+    const shared: ToolUseRoundShared = {
+      messages: [],
+      shouldStop: false,
+      endTurn: false,
+      response: undefined,
+      responseTimeMs: undefined,
+      stopReason: undefined,
+      lastError: undefined,
+      toolCalls: undefined,
+      text: undefined,
+      roundIndex: 0,
+      roundResponseTimeMs: 0,
+      roundNormalizedUsage: undefined,
+    };
+
+    await withTestRunContext(noopAgentRuntimeHost, 'test-stream', () =>
+      createToolUseRoundFlow().setServices(services).run(shared),
+    );
+
+    // Only one round was attempted — the loop stopped after interruption
+    // rather than calling the model again.
+    expect(createResponse).toHaveBeenCalledTimes(1);
+    expect(toolACall).toHaveBeenCalledTimes(1);
+    expect(toolBCall).not.toHaveBeenCalled();
+    expect(shared.shouldStop).toBe(true);
+
+    type FunctionCallMessage = { type: string; call_id: string };
+    const functionCalls = shared.messages.filter(
+      (m) => (m as FunctionCallMessage).type === 'function_call',
+    ) as unknown as FunctionCallMessage[];
+    const functionResults = shared.messages.filter(
+      (m) => (m as FunctionCallMessage).type === 'function_call_output',
+    ) as unknown as (FunctionCallMessage & { output: string })[];
+
+    // Both tool_use blocks the model requested must be paired with a
+    // tool_result, even though only one of them actually executed.
+    expect(functionCalls).toHaveLength(2);
+    expect(functionResults).toHaveLength(2);
+    expect(functionCalls.map((m) => m.call_id).sort()).toEqual([
+      'call-a',
+      'call-b',
+    ]);
+    expect(functionResults.map((m) => m.call_id).sort()).toEqual([
+      'call-a',
+      'call-b',
+    ]);
+
+    const cancelledResult = functionResults.find((m) => m.call_id === 'call-b');
+    expect(cancelledResult?.output).toContain('"status":"error"');
+    expect(cancelledResult?.output.toLowerCase()).toContain('cancelled');
+  });
+});

--- a/src/test-kernel/agent/followUp/ToolUseDispatchInterruption.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseDispatchInterruption.vitest.ts
@@ -200,4 +200,178 @@ describe('ToolUseDispatchNode interruption', () => {
     expect(cancelledResult?.output).toContain('"status":"error"');
     expect(cancelledResult?.output.toLowerCase()).toContain('cancelled');
   });
+
+  it('synthesizes cancelled tool_results for every requested call when interruption is detected in dispatch prep() before any call executes', async () => {
+    let checkCount = 0;
+    const checkInterruption = vi.fn(() => {
+      checkCount += 1;
+      // Check 1 is ToolUseRoundPrepNode's pre-model-call check (not
+      // interrupted, so the model call proceeds and returns two tool calls).
+      // Check 2 is ToolUseDispatchNode.prep()'s own check, which now reports
+      // interrupted — before either call is dispatched. `exec()` is never
+      // invoked for call-a or call-b in this scenario.
+      return checkCount > 1;
+    });
+
+    const toolACall = vi.fn(async () => ({
+      status: 'executed' as const,
+      output: 'toolA done',
+    }));
+    const toolBCall = vi.fn(async () => ({
+      status: 'executed' as const,
+      output: 'toolB done',
+    }));
+
+    const createToolUseFollowUpMessages = vi.fn(
+      async (
+        _client: unknown,
+        call: { callId: string; name: string },
+        result: unknown,
+      ) =>
+        [
+          {
+            type: 'function_call',
+            call_id: call.callId,
+            name: call.name,
+            arguments: '{}',
+          },
+          {
+            type: 'function_call_output',
+            call_id: call.callId,
+            output: JSON.stringify(result),
+          },
+        ] as ProviderMessage[],
+    );
+
+    const createResponse = vi.fn(async () => ({
+      response: { id: 'round-1', toolCalls: true },
+    }));
+
+    const services = {
+      checkInterruption,
+      client: {},
+      config: { agent: 'test-agent', model: 'test-model' },
+      fileService: {
+        createLocation: (filePath: string) => ({ absolutePath: filePath }),
+      },
+      logger: createRunTrace('ToolUseDispatchInterruption').trace,
+      modelHandler: {
+        addMediaToUserMessage: vi.fn(async () => {}),
+        capabilities: { supportsVision: true },
+        createAssistantMessageFromResponse: vi.fn(
+          (_response: unknown, text: string) =>
+            ({ type: 'message', role: 'assistant', content: text }) as never,
+        ),
+        createResponse,
+        createToolUseFollowUpMessages,
+        createUserFollowUpMessages: vi.fn(),
+        extractAssistantContent: () => [],
+        extractResponse: (response: { toolCalls?: boolean }) => ({
+          text: '',
+          usage: null,
+          stopReason: response.toolCalls ? 'tool_calls' : 'stop',
+        }),
+        extractServerToolData: () => ({
+          contentBlocks: [],
+          webFetchResults: [],
+          webSearchResults: [],
+        }),
+        extractToolUse: (response: { toolCalls?: boolean }) =>
+          response.toolCalls
+            ? [
+                {
+                  callId: 'call-a',
+                  input: {},
+                  name: 'toolA',
+                  provider: 'test',
+                  raw: {},
+                },
+                {
+                  callId: 'call-b',
+                  input: {},
+                  name: 'toolB',
+                  provider: 'test',
+                  raw: {},
+                },
+              ]
+            : [],
+        getStreamingConfig: () => false,
+        isEndTurnStop: (stopReason: string) => stopReason === 'stop',
+        processThinkingBlock: () => null,
+        setOutputStreaming: vi.fn(),
+      },
+      prompt: { systemPrompt: '', userPrefix: '', userRequest: '' },
+      run: AgentRunStateSnapshotSchema.parse({}),
+      session: {
+        hasQueuedFollowUp: () => false,
+      },
+      setAbortController: () => {},
+      setting: {
+        temperature: 0,
+        tools: [{ name: 'toolA' }, { name: 'toolB' }],
+      },
+      streamStatus: new StreamStatusMachine(),
+      toolRegistry: new MapToolRegistry({
+        toolA: { call: toolACall, definition: { name: 'toolA' } } as never,
+        toolB: { call: toolBCall, definition: { name: 'toolB' } } as never,
+      }),
+      userVarChannels: { input: {}, transient: {} },
+      workspace: AgentWorkspaceState.create(),
+    } as unknown as ToolUseRoundServices;
+
+    const shared: ToolUseRoundShared = {
+      messages: [],
+      shouldStop: false,
+      endTurn: false,
+      response: undefined,
+      responseTimeMs: undefined,
+      stopReason: undefined,
+      lastError: undefined,
+      toolCalls: undefined,
+      text: undefined,
+      roundIndex: 0,
+      roundResponseTimeMs: 0,
+      roundNormalizedUsage: undefined,
+    };
+
+    await withTestRunContext(noopAgentRuntimeHost, 'test-stream', () =>
+      createToolUseRoundFlow().setServices(services).run(shared),
+    );
+
+    // Only one round was attempted, and neither tool call ever executed —
+    // dispatch prep() caught the interruption before exec() ran for either.
+    expect(createResponse).toHaveBeenCalledTimes(1);
+    expect(toolACall).not.toHaveBeenCalled();
+    expect(toolBCall).not.toHaveBeenCalled();
+    expect(shared.shouldStop).toBe(true);
+    // The pending calls must be cleared, not left dangling on shared state.
+    expect(shared.toolCalls).toEqual([]);
+
+    type FunctionCallMessage = { type: string; call_id: string };
+    const functionCalls = shared.messages.filter(
+      (m) => (m as FunctionCallMessage).type === 'function_call',
+    ) as unknown as FunctionCallMessage[];
+    const functionResults = shared.messages.filter(
+      (m) => (m as FunctionCallMessage).type === 'function_call_output',
+    ) as unknown as (FunctionCallMessage & { output: string })[];
+
+    // Both tool_use blocks the model requested must still be paired with a
+    // tool_result, even though prep() never dispatched either of them.
+    expect(functionCalls).toHaveLength(2);
+    expect(functionResults).toHaveLength(2);
+    expect(functionCalls.map((m) => m.call_id).sort()).toEqual([
+      'call-a',
+      'call-b',
+    ]);
+    expect(functionResults.map((m) => m.call_id).sort()).toEqual([
+      'call-a',
+      'call-b',
+    ]);
+
+    for (const callId of ['call-a', 'call-b']) {
+      const cancelledResult = functionResults.find((m) => m.call_id === callId);
+      expect(cancelledResult?.output).toContain('"status":"error"');
+      expect(cancelledResult?.output.toLowerCase()).toContain('cancelled');
+    }
+  });
 });


### PR DESCRIPTION
Closes #7163

## Problem

When a tool-use round is interrupted mid-round, `ToolUseDispatchNode`
dropped `null` result slots for calls that never executed — including,
since the parallel-dispatch/duplicate-detection change, a duplicate
call whose primary never ran. Downstream persistence could then record
an assistant turn with N `tool_use` blocks but fewer than N
`tool_result` entries. Providers with strict tool-call pairing
requirements (Anthropic, and OpenAI's response-chaining mode, which
keeps the original response's function_call items server-side) can
reject the conversation on retry/resume.

## Fix

`ToolUseDispatchNode.post()` now walks the full set of originally
requested tool calls (not just the ones that produced a result) and
synthesizes a terminal "cancelled" `tool_result` (`status: 'error'`)
for any call whose `exec()` returned `null` — before building the
follow-up messages that get pushed into persisted conversation state.
This guarantees every persisted `tool_use` has a matching `tool_result`,
regardless of where in a multi-call round the interruption landed.

Also fixes a related gap: previously, when *every* call in a round was
interrupted, `post()` returned early without ever clearing
`shared.toolCalls`, leaving stale state. That path is now unified with
the general case.

Logging is unaffected: only calls that actually executed (or were
already synthesized as duplicate-skips) go through
`logAndProcessMediaFiles`, so a call that was aborted mid-flight (whose
card was already finalized as `'failed'` inside `executeToolCall`)
isn't logged twice, and a call that never started doesn't get a
spurious card.

## Test plan

- Added `src/test-kernel/agent/followUp/ToolUseDispatchInterruption.vitest.ts`:
  drives a real two-call tool-use round through `createToolUseRoundFlow`,
  interrupts between the first call completing and the second call
  starting, and asserts the persisted messages contain a matched
  `function_call`/`function_call_output` pair for *both* calls (the
  second being the synthesized cancellation) plus `shouldStop === true`.
  Verified this test fails against the pre-fix code (1 pair instead of 2)
  and passes with the fix.
- `npm run typecheck` — passes (root, test-kernel, extension, CLI).
- `npx eslint` on both touched files — clean.
- Targeted vitest run of `src/test-kernel/agent/followUp/` (16 files, 93
  tests) plus `BashTool.vitest.ts` and
  `GoogleInteractionsToolUse.vitest.ts` (which also exercise this flow) —
  all pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how interrupted tool rounds are persisted and resumed; incorrect pairing logic could still break provider APIs, but scope is narrow and covered by new regression tests.
> 
> **Overview**
> Fixes interrupted tool-use rounds leaving **unpaired `tool_use` blocks** in persisted history, which could break resume/retry on providers that require strict tool-call pairing (Anthropic, OpenAI response-chaining).
> 
> **`ToolUseDispatchNode.post()`** now walks every call the model requested for the round (including when `prep()` bailed out before dispatch and `dispatchedCalls` is empty, via `shared.toolCalls`). Any slot where `exec()` returned `null` gets a synthetic error **`tool_result`** (`buildCancelledResult` / `CANCELLED_CALL_ERROR`) instead of being dropped. Follow-up messages are built from that full paired set; **`shouldStop`** is set when any call was interrupted. Tool-use **logging** still runs only for real `execResults` (no duplicate cards for never-started or already-failed calls).
> 
> Adds **`ToolUseDispatchInterruption.vitest.ts`** regression coverage for interruption between two calls and interruption in dispatch `prep()` before any tool runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f526162f4c6322ccbd2e7ed227dd7cecf47c6ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->