### PR TITLE
Dedupe tool-kind display classification between CLI and progress view

### DIFF
--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -5,6 +5,7 @@ import { Box, Text, useWindowSize } from 'ink';
 
 // Local imports - shared schemas and utilities
 import { TOOL_USE_STATUS, type NormalizedToolUse } from '@shared/schemas';
+import { toolDisplayKind } from '@tools/toolKind';
 import { isObject } from '@utils/core';
 import {
   collapseWhitespace,
@@ -148,9 +149,13 @@ function statusColor(toolUse: NormalizedToolUse): 'green' | 'red' | undefined {
 
 function isEditLikeTool(toolName: string): boolean {
   const name = lastSegmentToolName(toolName).toLowerCase();
+  if (toolDisplayKind(name) === 'edit') return true;
+  // Beyond TeXRA's own tool registry: a delegated Claude Code sub-agent
+  // reports its own built-in tool names (`edit`, `multiedit`) verbatim, and
+  // some provider tool-use variants carry a `str_replace`/`text_editor`
+  // substring instead of one of the exact names classified above.
   return (
     name === 'edit' ||
-    name === 'edit_file' ||
     name === 'multiedit' ||
     name.includes('str_replace') ||
     name.includes('text_editor')
@@ -527,7 +532,10 @@ export function UniversalToolRow({
 }
 
 function isBashTool(toolUse: NormalizedToolUse): boolean {
-  return lastSegmentToolName(toolUse.toolName).toLowerCase() === 'bash';
+  return (
+    toolDisplayKind(lastSegmentToolName(toolUse.toolName).toLowerCase()) ===
+    'bash'
+  );
 }
 
 function isMcpTool(toolUse: NormalizedToolUse): boolean {

--- a/packages/extension/src/progressView/frontend/formatters/constants.ts
+++ b/packages/extension/src/progressView/frontend/formatters/constants.ts
@@ -48,26 +48,12 @@ export const TIME_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
 // ============================================================================
 // Tool Categories for Specialized Formatting
 // ============================================================================
-
-/**
- * Tools that show old/new diff display for their input.
- * Output is human-readable status, NOT code (don't syntax highlight output).
- */
-export const TOOLS_WITH_DIFF_INPUT = new Set([
-  'edit_file',
-  'str_replace_editor',
-  'str_replace_based_edit_tool',
-]);
-
-/**
- * Tools that read files and should show file link instead of content.
- */
-export const TOOLS_WITH_FILE_LINK = new Set(['read_file']);
-
-/**
- * Tools that write files and should show file link + syntax-highlighted content.
- */
-export const TOOLS_WITH_FILE_CONTENT = new Set(['write_file']);
+//
+// The edit/read/write display-kind classification (which tools show an
+// old/new diff, a file link, or a file link + content) lives in
+// `@tools/toolKind` — the single source of truth shared with the CLI chat
+// TUI's `toolRenderers.tsx` (see issue #7120). Use `toolDisplayKind()` from
+// that module instead of adding tool-name lists here.
 
 /**
  * Tools whose input AND output are code that benefits from syntax highlighting.

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -16,6 +16,7 @@ import type { LogMessageData } from '@shared/schemas';
 import { normalizeToolUseData } from '@shared/toolUse';
 import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
 import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+import { toolDisplayKind } from '@tools/toolKind';
 import { isObject } from '@utils/core';
 import { truncateSummary } from '@utils/text/stringUtils';
 
@@ -39,12 +40,7 @@ import {
 } from '../htmlBuilders';
 import { registerProposalInput } from '../proposalInputStore';
 import { stringifyWithLanguage } from '../parseUtils';
-import {
-  TOOLS_WITH_FILE_LINK,
-  TOOLS_WITH_FILE_CONTENT,
-  TOOL_LABEL_MAP,
-  TRIVIAL_WRITE_OUTPUT,
-} from '../constants';
+import { TOOL_LABEL_MAP, TRIVIAL_WRITE_OUTPUT } from '../constants';
 
 import {
   buildBannerContent,
@@ -135,13 +131,13 @@ export function formatToolUseTemplate(
   });
 
   // Show output if present
-  const isWriteTool = TOOLS_WITH_FILE_CONTENT.has(toolName);
+  const isWriteTool = toolDisplayKind(toolName) === 'write';
   const isTrivialWriteOutput =
     isWriteTool && outputText.trim() === TRIVIAL_WRITE_OUTPUT;
   if (
     outputText &&
     !toolName.startsWith('mcp:') &&
-    !TOOLS_WITH_FILE_LINK.has(toolName) &&
+    toolDisplayKind(toolName) !== 'read' &&
     !isTrivialWriteOutput
   ) {
     sections.push(

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
@@ -29,9 +29,6 @@ import {
   extractCodeOnlyInput,
 } from '@progressView/frontend/formatters/parseUtils';
 import {
-  TOOLS_WITH_DIFF_INPUT,
-  TOOLS_WITH_FILE_LINK,
-  TOOLS_WITH_FILE_CONTENT,
   TOOL_CODE_LANGUAGES,
   getLanguageFromPath,
 } from '@progressView/frontend/formatters/constants';
@@ -42,6 +39,7 @@ import {
 } from '@shared/schemas/codex';
 import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
 import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+import { toolDisplayKind } from '@tools/toolKind';
 import type { ExecutionsToolInput } from '@tools/ExecutionsTool';
 import type { EditInput } from '@tools/EditTool';
 import type { TextEditorInput } from '@tools/TextEditorTool';
@@ -469,17 +467,17 @@ const TOOL_SECTION_BUILDERS: Array<{
 }> = [
   {
     match: (ctx) =>
-      TOOLS_WITH_DIFF_INPUT.has(ctx.toolName) && isObject(ctx.input),
+      toolDisplayKind(ctx.toolName) === 'edit' && isObject(ctx.input),
     build: buildEditDiffInputSections,
   },
   {
     match: (ctx) =>
-      TOOLS_WITH_FILE_LINK.has(ctx.toolName) && Boolean(ctx.filePath),
+      toolDisplayKind(ctx.toolName) === 'read' && Boolean(ctx.filePath),
     build: buildFileLinkSections,
   },
   {
     match: (ctx) =>
-      TOOLS_WITH_FILE_CONTENT.has(ctx.toolName) && Boolean(ctx.filePath),
+      toolDisplayKind(ctx.toolName) === 'write' && Boolean(ctx.filePath),
     build: buildFileContentSections,
   },
   {

--- a/src/tools/toolKind.ts
+++ b/src/tools/toolKind.ts
@@ -51,7 +51,13 @@ export const TOOL_DISPLAY_KIND: Partial<
 };
 
 /** Look up a tool's display kind by its exact (canonical or native) name.
- *  Returns `undefined` for tools that use the generic display treatment. */
+ *  Returns `undefined` for tools that use the generic display treatment.
+ *  Guarded with `Object.hasOwn` so an arbitrary tool name (e.g. `toString`,
+ *  `__proto__`) can't resolve to an inherited `Object.prototype` member
+ *  instead of a real entry. */
 export function toolDisplayKind(toolName: string): ToolDisplayKind | undefined {
-  return TOOL_DISPLAY_KIND[toolName as KnownToolName];
+  const key = toolName as KnownToolName;
+  return Object.hasOwn(TOOL_DISPLAY_KIND, key)
+    ? TOOL_DISPLAY_KIND[key]
+    : undefined;
 }

--- a/src/tools/toolKind.ts
+++ b/src/tools/toolKind.ts
@@ -1,0 +1,57 @@
+// Local imports - registry (type-only: keeps this module free of the
+// registry's concrete tool-class dependencies so it stays cheap to bundle
+// into either frontend).
+import type { RegisteredToolName } from './registry';
+
+/**
+ * Structural "kind" of a tool's UI treatment, shared by every host that
+ * renders individual tool calls: the CLI chat TUI
+ * (`packages/cli/src/chat/tui/panes/toolRenderers.tsx`) and the VS Code
+ * progress view
+ * (`packages/extension/src/progressView/frontend/formatters/`).
+ *
+ * Both hosts used to hardcode their own tool-name lists for this and had
+ * quietly drifted apart — neither referenced the actual tool registry, and
+ * each recognized tool names the other didn't (issue #7120). This module is
+ * the single source of truth: a tool-name -> kind lookup co-located with
+ * `./registry.ts`, the canonical tool factory, so a renamed or removed
+ * registered tool is caught here at compile time.
+ */
+export type ToolDisplayKind = 'edit' | 'read' | 'write' | 'bash';
+
+/**
+ * Non-registered tool names that still need a display kind:
+ *  - `str_replace_based_edit_tool` is Anthropic's native tool-use name for
+ *    the text-editor tool (see `TextEditorTool.ts`'s `API_TYPE_TO_NAME`) and
+ *    surfaces verbatim in some tool-use entries instead of our canonical
+ *    `str_replace_editor`.
+ */
+type KnownToolName = RegisteredToolName | 'str_replace_based_edit_tool';
+
+/**
+ * Tool name -> display kind, for the tools whose display treatment isn't the
+ * generic fallback (a labeled input/output block):
+ *  - `edit`: shows an old/new diff instead of the raw input.
+ *  - `read`: shows a file link instead of the raw input/output.
+ *  - `write`: shows a file link plus syntax-highlighted content.
+ *  - `bash`: shows a shell-style command/output block.
+ */
+export const TOOL_DISPLAY_KIND: Partial<
+  Record<KnownToolName, ToolDisplayKind>
+> = {
+  edit_file: 'edit',
+  str_replace_editor: 'edit',
+  str_replace_based_edit_tool: 'edit',
+
+  read_file: 'read',
+
+  write_file: 'write',
+
+  bash: 'bash',
+};
+
+/** Look up a tool's display kind by its exact (canonical or native) name.
+ *  Returns `undefined` for tools that use the generic display treatment. */
+export function toolDisplayKind(toolName: string): ToolDisplayKind | undefined {
+  return TOOL_DISPLAY_KIND[toolName as KnownToolName];
+}


### PR DESCRIPTION
Closes #7120

## Problem

Tool-kind display classification (which tools show a diff, a file link, a file link + content, or shell-style output) was duplicated with drifting heuristics between `packages/cli/src/chat/tui/panes/toolRenderers.tsx` and `packages/extension/src/progressView/frontend/formatters/constants.ts`. Neither referenced the actual tool registry (`src/tools/registry.ts`), both hardcoded their own tool-name lists, and each already recognized tool names the other didn't (e.g. the CLI's `isEditLikeTool` matched `multiedit`/bare `edit`/`text_editor`-substring names that the extension's `TOOLS_WITH_DIFF_INPUT` set didn't).

## Fix

Added `src/tools/toolKind.ts` as the single source of truth: a `toolName -> ToolDisplayKind` (`'edit' | 'read' | 'write' | 'bash'`) lookup co-located with the tool registry. Its map is typed against `RegisteredToolName` (from `registry.ts`), so a renamed or removed registered tool is caught at compile time. It's a VS Code-free, type-only-import module (no runtime dependency on the concrete tool classes), safe to bundle into either frontend.

Migrated both hosts to consume it:
- `toolRenderers.tsx`: `isEditLikeTool`/`isBashTool` now check `toolDisplayKind()` first for the registry-derived names, keeping only the CLI-specific fallback for delegated Claude-Code-sub-agent tool names (`edit`, `multiedit`) and provider-variant substrings (`str_replace`/`text_editor`) that aren't part of TeXRA's own tool registry.
- `constants.ts` / `toolFormatters.ts` / `toolSections.ts`: removed the local `TOOLS_WITH_DIFF_INPUT` / `TOOLS_WITH_FILE_LINK` / `TOOLS_WITH_FILE_CONTENT` sets; call sites now call `toolDisplayKind(toolName) === 'edit' | 'read' | 'write'` directly.

Left untouched (extension-only presentation detail, not part of the CLI/extension duplication): `TOOL_ICON_MAP`, `TOOL_LABEL_MAP`, `TOOL_OUTPUT_LANGUAGES`, `TOOL_CODE_LANGUAGES`.

## Verification

Wrote a standalone script reproducing the OLD and NEW classification logic for both hosts (edit/read/write for the extension, edit/bash for the CLI) and diffed them across every registered tool name (`src/tools/registry.ts`) plus every known legacy/alias name (`str_replace_based_edit_tool`, `multiedit`, `edit`, `ls`, `execute`, `run`, `propose_workflow`, `propose_agent`, `codex_*`, etc.) — zero classification changes for either host.

- `npm run typecheck`: passes
- Targeted vitest (`ToolRenderers.vitest.mts`, `ToolUseRowPatch.vitest.mts`, `ToolUseFormatter.vitest.mts`): 19/19 passing
- `eslint` on touched files: clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-layer refactor with behavior preserved per PR verification; no auth, data, or execution-path changes.
> 
> **Overview**
> Introduces **`src/tools/toolKind.ts`** as the shared **`toolName → ToolDisplayKind`** (`edit` | `read` | `write` | `bash`) lookup, typed against **`RegisteredToolName`** so registry renames surface at compile time.
> 
> The **CLI TUI** (`toolRenderers.tsx`) now uses **`toolDisplayKind()`** for edit-like and bash detection; delegated sub-agent names (`edit`, `multiedit`) and **`str_replace` / `text_editor`** substring heuristics remain CLI-only fallbacks.
> 
> The **VS Code progress view** drops local **`TOOLS_WITH_*`** sets in **`constants.ts`** and routes **`toolFormatters.ts`** / **`toolSections.ts`** through the same helper for diff, file-link, write, and read output rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fddfc59dcfa38237135c0b806e28c4fc01ef396b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->