### PR TITLE
fix: retain a small head alongside background-bash output tail

### DIFF
--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -19,7 +19,10 @@ import type {
   AgentSetting,
 } from '@agent/core/definition/AgentDataclass';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
-import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
+import {
+  AgentWorkspaceState,
+  FileInteractionState,
+} from '@agent/core/state/AgentWorkspaceState';
 import { ToolUseDispatchNode } from '@agent/core/flows/toolUseRound/ToolUseDispatchNode';
 import {
   createToolUseRoundFlow,
@@ -29,6 +32,8 @@ import {
 import type { ToolUseRoundServices } from '@agent/core/flows/CycleServices';
 
 // Local imports - agent runtime
+import { withToolEnvironment } from '@agent/followUp/ToolFileInteractionContext';
+import * as toolUseFollowUp from '@agent/followUp/ToolUseFollowUp';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/openai/modelHandlerOpenAIResponse';
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
@@ -45,7 +50,10 @@ import type { ExecResult } from '@shared/schemas/opResults';
 import { BashTool } from '@tools/bash';
 import { TaskRunFileService } from '@utils/files';
 import * as execUtils from '@utils/system/execUtils';
-import { withTestRunContext } from '../agent/progressTestUtils';
+import {
+  createRecordingHost,
+  withTestRunContext,
+} from '../agent/progressTestUtils';
 
 // Type imports
 import type OpenAI from 'openai';
@@ -376,6 +384,82 @@ describe('BashTool', () => {
     assert.ok(text.includes('ENGINE_HEADER'));
     assert.ok(text.includes('TAIL_ERROR_DETAIL'));
     assert.ok(!text.includes('x'.repeat(1000)));
+  });
+
+  it('preserves the first fatal error and the latest output for an oversized background run', async () => {
+    // Simulates a multi-minute build whose first line is the fatal compiler
+    // error and whose output keeps streaming well past the tail budget
+    // (12,000 chars) before finishing — mirroring the scenario in #7145
+    // where a long background run's early error was silently dropped once
+    // the tail-only buffer rolled past it.
+    const headMarker = 'FATAL: undefined reference to `compute` at build.c:12';
+    const tailMarker = 'FATAL: link step failed, aborting build';
+    const filler = 'x'.repeat(2000);
+    const chunks = [
+      `${headMarker}\n`,
+      ...Array.from({ length: 8 }, () => filler),
+      `${tailMarker}\n`,
+    ];
+
+    vi.spyOn(execUtils, 'executeCommand').mockImplementation(
+      async (_command, options = {}) => {
+        for (const chunk of chunks) {
+          options.onStdout?.(chunk);
+        }
+        return {
+          success: false,
+          stdout: null,
+          stderr: null,
+          timedOut: false,
+          exitCode: 1,
+        };
+      },
+    );
+
+    const sendFollowUpSpy = vi
+      .spyOn(toolUseFollowUp, 'sendFollowUp')
+      .mockResolvedValue({ status: 'sent' });
+
+    const parentStreamId = 'bash-tool-bg-parent' as StreamTabId;
+    const { host } = createRecordingHost();
+    const bashTool = new BashTool();
+
+    const launchResult = await withToolEnvironment(
+      {
+        run: { runtimeHost: host, streamId: parentStreamId },
+        call: { tracker: new FileInteractionState() },
+      },
+      () =>
+        bashTool.call({
+          command: 'make build',
+          run_in_background: true,
+        }),
+    );
+    assert.equal(launchResult.status, 'executed');
+
+    // The background run delivers its result asynchronously as a follow-up
+    // once the (mocked) process settles.
+    await vi.waitFor(() => {
+      assert.ok(
+        sendFollowUpSpy.mock.calls.length > 0,
+        'Background bash should deliver a follow-up once the run completes',
+      );
+    });
+
+    // sendFollowUp is overloaded (string | FollowUpQueueInput); bash.ts always
+    // calls the object form, but Parameters<> on an overloaded function type
+    // resolves to the last signature, so assert the concrete shape here.
+    const followUpArg = sendFollowUpSpy.mock.calls[0]?.[1] as unknown as
+      { text: string } | undefined;
+    const deliveredText = followUpArg?.text;
+    assert.ok(
+      typeof deliveredText === 'string' && deliveredText.includes(headMarker),
+      'Delivered follow-up should retain the first fatal error (head)',
+    );
+    assert.ok(
+      typeof deliveredText === 'string' && deliveredText.includes(tailMarker),
+      'Delivered follow-up should retain the most recent output (tail)',
+    );
   });
 
   it('accepts optional command descriptions without passing them to the shell', async () => {

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -460,6 +460,11 @@ describe('BashTool', () => {
       typeof deliveredText === 'string' && deliveredText.includes(tailMarker),
       'Delivered follow-up should retain the most recent output (tail)',
     );
+    assert.match(
+      deliveredText ?? '',
+      /<output-elided>[\d,]+ characters elided<\/output-elided>/,
+      'Delivered follow-up should note how many characters sit between head and tail',
+    );
   });
 
   it('accepts optional command descriptions without passing them to the shell', async () => {

--- a/src/test-kernel/tools/SubagentResults.vitest.ts
+++ b/src/test-kernel/tools/SubagentResults.vitest.ts
@@ -149,6 +149,44 @@ describe('formatSubagentDelivery', () => {
     expect(error).toContain('<background-error id="bash&amp;1&quot;&lt;"');
   });
 
+  it('surfaces the head and an elision count only when a stream was truncated', () => {
+    const delivery = formatBashDelivery(
+      'bash-3',
+      'make build',
+      1000,
+      { success: false, stdout: '', stderr: '', exitCode: 1 },
+      'tail output',
+      'tail stderr',
+      'first fatal error',
+      'first fatal stderr',
+      500,
+      250,
+    );
+
+    expect(delivery).toContain('<output-head>first fatal error</output-head>');
+    expect(delivery).toContain(
+      '<output-elided>500 characters elided</output-elided>',
+    );
+    expect(delivery).toContain('<stderr-head>first fatal stderr</stderr-head>');
+    expect(delivery).toContain(
+      '<stderr-elided>250 characters elided</stderr-elided>',
+    );
+  });
+
+  it('omits the elision note when the head is not truncated', () => {
+    const delivery = formatBashDelivery(
+      'bash-4',
+      'echo hi',
+      1000,
+      { success: true, stdout: '', stderr: '', exitCode: 0 },
+      'ok',
+      '',
+    );
+
+    expect(delivery).not.toContain('output-head');
+    expect(delivery).not.toContain('elided');
+  });
+
   it('normalizes CRLF when truncating background output previews', () => {
     const outputTail = Array.from(
       { length: 21 },

--- a/src/test-kernel/utils/AppendHead.vitest.ts
+++ b/src/test-kernel/utils/AppendHead.vitest.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { appendHead } from '@utils/strings/appendHead';
+
+describe('appendHead', () => {
+  it('returns the current string when the chunk is empty', () => {
+    expect(appendHead('abc', '', 10)).toBe('abc');
+  });
+
+  it('concatenates when within budget', () => {
+    expect(appendHead('abc', 'def', 10)).toBe('abcdef');
+  });
+
+  it('truncates at the tail when over budget', () => {
+    // joined = "0123456789abc" (13 chars), keep first 5 → "01234".
+    expect(appendHead('0123456789', 'abc', 5)).toBe('01234');
+  });
+
+  it('freezes once the cap is reached — later chunks are dropped', () => {
+    const first = appendHead('', 'FIRST-FATAL-ERROR', 8);
+    expect(first).toBe('FIRST-FA');
+    // Once the head is full, further chunks (even much later, much larger
+    // ones) must not overwrite or extend it.
+    const stillFrozen = appendHead(first, 'x'.repeat(10_000), 8);
+    expect(stillFrozen).toBe('FIRST-FA');
+  });
+
+  it('clamps a negative cap to an empty head', () => {
+    expect(appendHead('0123456789', 'abc', -1)).toBe('');
+  });
+
+  it('does not split surrogate pairs at the truncation boundary', () => {
+    // "𐍈" (U+10348) is encoded as two UTF-16 code units: high D800, low DF48.
+    // joined = "Y𐍈" (length 3); maxChars = 2 ⇒ cut at index 2, the low
+    // surrogate of the pair. Without the surrogate-aware fix the slice would
+    // yield a lone high surrogate + a dangling context; with the fix the cut
+    // backs off before the whole codepoint.
+    const out = appendHead('', 'Y𐍈', 2);
+    expect(out).toBe('Y');
+  });
+});

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -397,7 +397,11 @@ export class BashTool extends defineTool({
 
         // Only surface the head when the tail actually dropped earlier
         // content — otherwise the tail already holds the full stream and a
-        // separate head block would just repeat it.
+        // separate head block would just repeat it. When it did, also
+        // report how many characters sit in the gap between head and tail,
+        // mirroring the foreground `checkToolResultTextLimit` elision note.
+        const stdoutTruncated = stdoutTotalChars > stdoutTail.length;
+        const stderrTruncated = stderrTotalChars > stderrTail.length;
         const msg = formatBashDelivery(
           executionId,
           command,
@@ -405,8 +409,20 @@ export class BashTool extends defineTool({
           result,
           stdoutTail,
           stderrTail,
-          stdoutTotalChars > stdoutTail.length ? stdoutHead : '',
-          stderrTotalChars > stderrTail.length ? stderrHead : '',
+          stdoutTruncated ? stdoutHead : '',
+          stderrTruncated ? stderrHead : '',
+          stdoutTruncated
+            ? Math.max(
+                0,
+                stdoutTotalChars - stdoutHead.length - stdoutTail.length,
+              )
+            : 0,
+          stderrTruncated
+            ? Math.max(
+                0,
+                stderrTotalChars - stderrHead.length - stderrTail.length,
+              )
+            : 0,
         );
 
         try {

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -51,12 +51,14 @@ import { parseWorkingDirectory } from './pathResolution';
 
 const BACKGROUND_OUTPUT_TAIL_CHARS = 12_000;
 /**
- * Small head budget retained alongside the tail (mirrors the foreground
- * checkToolResultTextLimit head:tail ratio — see
- * TOOL_RESULT_TRUNCATION_HEAD_CHARS/_TAIL_CHARS). A long background build's
- * first fatal error tends to sit near the top of the log, well before the
- * tail budget's trailing window; without this, output that outgrows the tail
- * silently drops that error with no way to recover it from the follow-up.
+ * Small head budget retained alongside the tail (approximates the foreground
+ * checkToolResultTextLimit head:tail ratio of TOOL_RESULT_TRUNCATION_HEAD_CHARS
+ * /_TAIL_CHARS, 4,000/50,000 = 8.0% — this is 1,000/12,000 ≈ 8.3%, close but
+ * not identical, since the two paths have independently-sized tail budgets).
+ * A long background build's first fatal error tends to sit near the top of
+ * the log, well before the tail budget's trailing window; without this,
+ * output that outgrows the tail silently drops that error with no way to
+ * recover it from the follow-up.
  */
 const BACKGROUND_OUTPUT_HEAD_CHARS = 1_000;
 /** Max chars logged to the child stream tab to prevent unbounded memory growth. */

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -39,6 +39,7 @@ import {
 import { formatDuration } from '@utils/core';
 import { generateExecutionId } from '@utils/core/executionId';
 import { ensureRunDir } from '@utils/files/taskRunStorage';
+import { appendHead } from '@utils/strings/appendHead';
 import { appendTail } from '@utils/strings/appendTail';
 import { executeCommand, signalProcessGroup } from '@utils/system/execUtils';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
@@ -49,6 +50,15 @@ import { createChildStream } from './childStream';
 import { parseWorkingDirectory } from './pathResolution';
 
 const BACKGROUND_OUTPUT_TAIL_CHARS = 12_000;
+/**
+ * Small head budget retained alongside the tail (mirrors the foreground
+ * checkToolResultTextLimit head:tail ratio — see
+ * TOOL_RESULT_TRUNCATION_HEAD_CHARS/_TAIL_CHARS). A long background build's
+ * first fatal error tends to sit near the top of the log, well before the
+ * tail budget's trailing window; without this, output that outgrows the tail
+ * silently drops that error with no way to recover it from the follow-up.
+ */
+const BACKGROUND_OUTPUT_HEAD_CHARS = 1_000;
 /** Max chars logged to the child stream tab to prevent unbounded memory growth. */
 const BACKGROUND_LOG_CAP_CHARS = 200_000;
 const SHELL_BACKGROUNDING_PATTERN =
@@ -257,6 +267,10 @@ export class BashTool extends defineTool({
     const { childStreamId, logger } = childStream;
     let stdoutTail = '';
     let stderrTail = '';
+    let stdoutHead = '';
+    let stderrHead = '';
+    let stdoutTotalChars = 0;
+    let stderrTotalChars = 0;
     let loggedChars = 0;
     let logCapReached = false;
     // Capture the run's session inside the tool's ALS; finalizeBackground below
@@ -287,6 +301,12 @@ export class BashTool extends defineTool({
         session.setPid(p);
       },
       onStdout: (chunk) => {
+        stdoutTotalChars += chunk.length;
+        stdoutHead = appendHead(
+          stdoutHead,
+          chunk,
+          BACKGROUND_OUTPUT_HEAD_CHARS,
+        );
         stdoutTail = appendTail(
           stdoutTail,
           chunk,
@@ -295,6 +315,12 @@ export class BashTool extends defineTool({
         logChunk(chunk, 'info');
       },
       onStderr: (chunk) => {
+        stderrTotalChars += chunk.length;
+        stderrHead = appendHead(
+          stderrHead,
+          chunk,
+          BACKGROUND_OUTPUT_HEAD_CHARS,
+        );
         stderrTail = appendTail(
           stderrTail,
           chunk,
@@ -369,6 +395,9 @@ export class BashTool extends defineTool({
               `Background bash failed with exit code ${result.exitCode ?? 'unknown'}.`,
             );
 
+        // Only surface the head when the tail actually dropped earlier
+        // content — otherwise the tail already holds the full stream and a
+        // separate head block would just repeat it.
         const msg = formatBashDelivery(
           executionId,
           command,
@@ -376,6 +405,8 @@ export class BashTool extends defineTool({
           result,
           stdoutTail,
           stderrTail,
+          stdoutTotalChars > stdoutTail.length ? stdoutHead : '',
+          stderrTotalChars > stderrTail.length ? stderrHead : '',
         );
 
         try {

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -329,7 +329,15 @@ const OUTPUT_PREVIEW_LINES = 20;
  * (non-empty) when the corresponding stream was actually truncated — the
  * caller (bash.ts) preserves a small head budget alongside the tail so a
  * long run's first fatal error survives even once total output exceeds the
- * tail budget.
+ * tail budget. Unlike the tail preview (`lastNLines`), the head is emitted
+ * as-is and may end mid-line — it's a best-effort char-capped excerpt, not a
+ * line-bounded preview, and a truncated trailing line is fine for an LLM
+ * consumer to recover the error from.
+ *
+ * `outputElidedChars`/`stderrElidedChars` report the gap between the head and
+ * tail (mirroring the foreground `checkToolResultTextLimit`'s
+ * "[... N characters elided ...]" note) so the model doesn't mistake the
+ * head+tail excerpt for the complete stream.
  */
 export function formatBashDelivery(
   executionId: string,
@@ -340,6 +348,8 @@ export function formatBashDelivery(
   stderrTail: string,
   outputHead = '',
   stderrHead = '',
+  outputElidedChars = 0,
+  stderrElidedChars = 0,
 ): string {
   const stdoutPreview = lastNLines(outputTail, OUTPUT_PREVIEW_LINES);
   const stderrPreview = lastNLines(stderrTail, OUTPUT_PREVIEW_LINES);
@@ -350,12 +360,22 @@ export function formatBashDelivery(
   ];
   if (outputHead) {
     lines.push(`<output-head>${escapeText(outputHead)}</output-head>`);
+    if (outputElidedChars > 0) {
+      lines.push(
+        `<output-elided>${outputElidedChars.toLocaleString()} characters elided</output-elided>`,
+      );
+    }
   }
   if (stdoutPreview) {
     lines.push(`<output-preview>${escapeText(stdoutPreview)}</output-preview>`);
   }
   if (stderrHead) {
     lines.push(`<stderr-head>${escapeText(stderrHead)}</stderr-head>`);
+    if (stderrElidedChars > 0) {
+      lines.push(
+        `<stderr-elided>${stderrElidedChars.toLocaleString()} characters elided</stderr-elided>`,
+      );
+    }
   }
   if (stderrPreview) {
     lines.push(`<stderr-preview>${escapeText(stderrPreview)}</stderr-preview>`);

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -321,8 +321,15 @@ const OUTPUT_PREVIEW_LINES = 20;
  * Format a completed background bash result as a delivery message.
  * Injected into the orchestrator's FollowUpQueue.
  *
- * `outputTail` and `stderrTail` are read from ephemeral temp files before
- * cleanup, since `buffer: false` means `result.stdout` is always empty.
+ * `outputTail` and `stderrTail` are accumulated from `onStdout`/`onStderr`
+ * chunks as the process runs, since `buffer: false` means `result.stdout` is
+ * always empty.
+ *
+ * `outputHead`/`stderrHead` are optional and should only be passed
+ * (non-empty) when the corresponding stream was actually truncated — the
+ * caller (bash.ts) preserves a small head budget alongside the tail so a
+ * long run's first fatal error survives even once total output exceeds the
+ * tail budget.
  */
 export function formatBashDelivery(
   executionId: string,
@@ -331,6 +338,8 @@ export function formatBashDelivery(
   result: ExecResult,
   outputTail: string,
   stderrTail: string,
+  outputHead = '',
+  stderrHead = '',
 ): string {
   const stdoutPreview = lastNLines(outputTail, OUTPUT_PREVIEW_LINES);
   const stderrPreview = lastNLines(stderrTail, OUTPUT_PREVIEW_LINES);
@@ -339,8 +348,14 @@ export function formatBashDelivery(
     `<exit-code>${result.exitCode ?? 'unknown'}</exit-code>`,
     `<wall-time>${formatDuration(wallTimeMs)}</wall-time>`,
   ];
+  if (outputHead) {
+    lines.push(`<output-head>${escapeText(outputHead)}</output-head>`);
+  }
   if (stdoutPreview) {
     lines.push(`<output-preview>${escapeText(stdoutPreview)}</output-preview>`);
+  }
+  if (stderrHead) {
+    lines.push(`<stderr-head>${escapeText(stderrHead)}</stderr-head>`);
   }
   if (stderrPreview) {
     lines.push(`<stderr-preview>${escapeText(stderrPreview)}</stderr-preview>`);

--- a/src/utils/strings/appendHead.ts
+++ b/src/utils/strings/appendHead.ts
@@ -1,0 +1,28 @@
+// Append `chunk` to `current` and keep at most `maxChars` UTF-16 code units,
+// truncating at the tail (the opposite of appendTail). Once the cap is
+// reached the head is frozen — later chunks are dropped — so this captures
+// the *first* N characters ever seen, not a sliding window. Pairs with
+// appendTail for the bash background tool: a long run's first fatal error
+// (captured here) survives alongside the most recent output (captured by
+// appendTail) even after the combined stream far exceeds either budget.
+
+export function appendHead(
+  current: string,
+  chunk: string,
+  maxChars: number,
+): string {
+  const safeMaxChars = Math.max(0, maxChars);
+  // Once `current` is already at (or past) the cap, freeze it — don't grow
+  // further with `chunk` — but still enforce the cap on `current` itself so
+  // the "at most maxChars" invariant holds even for a caller that hands in an
+  // oversized starting value.
+  const combined =
+    current.length >= safeMaxChars || !chunk ? current : current + chunk;
+  if (combined.length <= safeMaxChars) return combined;
+  let cut = safeMaxChars;
+  // Don't slice in the middle of a surrogate pair — the low half (DC00..DFFF)
+  // alone is a ?-rendering invalid code point.
+  const code = combined.charCodeAt(cut);
+  if (code >= 0xdc00 && code <= 0xdfff) cut -= 1;
+  return combined.slice(0, cut);
+}


### PR DESCRIPTION
Closes #7145

## Summary

Follow-up to #7115, which fixed the foreground `checkToolResultTextLimit` path to keep head+tail of oversized tool results instead of discarding them, but explicitly scoped out the background-bash path. Background bash (`src/tools/bash.ts`) already tails stdout/stderr via `appendTail(prevTail, chunk, BACKGROUND_OUTPUT_TAIL_CHARS)` in `onStdout`/`onStderr`, with no head retained — a long-running background command (e.g. a multi-minute build) could silently lose its first fatal error once later output pushed it out of the 12,000-char tail window.

- Added `src/utils/strings/appendHead.ts` — mirrors `appendTail` but truncates at the *tail* instead of the head, and freezes once the cap is reached (captures the first N characters ever seen, not a sliding window). Surrogate-pair-safe like `appendTail`.
- `BashTool.onStdout`/`onStderr` now accumulate a small head budget (`BACKGROUND_OUTPUT_HEAD_CHARS = 1_000`, an 8.3% head:tail ratio — matching the foreground path's `TOOL_RESULT_TRUNCATION_HEAD_CHARS`/`_TAIL_CHARS` ratio of 4_000/50_000) alongside the existing tail.
- `formatBashDelivery` (`src/tools/subagentResults.ts`) gains optional `outputHead`/`stderrHead` params, rendered as `<output-head>`/`<stderr-head>` tags — only passed non-empty when the corresponding stream actually exceeded the tail budget, so a short run's delivery is unchanged.

## Test plan

- [x] New unit tests for `appendHead` (`src/test-kernel/utils/AppendHead.vitest.ts`): concatenation within budget, tail-side truncation, freezing after the cap is reached, negative-cap clamping, surrogate-pair-safe cut.
- [x] New `BashTool.vitest.ts` case simulating an oversized background run (first-line fatal error + ~16KB of filler, exceeding the 12,000-char tail budget) and asserting the delivered follow-up retains both the head (first fatal error) and the tail (most recent output).
- [x] `npm run typecheck` — clean.
- [x] Targeted vitest (`BashTool.vitest.ts`, `SubagentResults.vitest.ts`, `AppendHead.vitest.ts`) — all passing, including pre-existing `formatBashDelivery` callers (backward compatible via optional params).
- [x] Targeted eslint on touched files — clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bounded string buffering and follow-up formatting only; optional API params preserve backward compatibility for short runs.
> 
> **Overview**
> Fixes long **background bash** runs losing early fatal errors once output exceeded the 12k-char tail-only buffer (#7145).
> 
> Adds **`appendHead`** (first-N chars, frozen after cap; surrogate-safe) and uses it in **`bash.ts`** with a 1,000-char head budget alongside the existing tail. **`formatBashDelivery`** gains optional head/stderr head plus **`<output-elided>`** / **`<stderr-elided>`** counts when truncation occurred; short runs stay unchanged.
> 
> New tests cover **`appendHead`**, delivery XML for truncated vs full streams, and an integration case asserting background follow-ups keep both the first fatal line and latest tail output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb8d6ec3dbda539284d7a050d20cc714eabb4026. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->