### PR TITLE
Route formatChatAsHtml through chatExportFormatter's single surface

### DIFF
--- a/packages/cli/src/commands/history.ts
+++ b/packages/cli/src/commands/history.ts
@@ -2,11 +2,11 @@ import * as path from 'node:path';
 
 import { defineCommand } from 'citty';
 
-import { formatChatAsMarkdown } from '@agent/export/chatExportFormatter';
 import {
   DEFAULT_HTML_EXPORT_ASSETS_HREF,
   formatChatAsHtml,
-} from '@agent/export/htmlExport/htmlFormatter';
+  formatChatAsMarkdown,
+} from '@agent/export/chatExportFormatter';
 import { type ExecutionId } from '@shared/schemas';
 
 import { CliExitCode } from '../runtime/exitCodes';

--- a/src/agent/export/chatExportFormatter.ts
+++ b/src/agent/export/chatExportFormatter.ts
@@ -1,6 +1,6 @@
 /**
  * Template-driven formatters for exporting chat conversations
- * as Markdown or LaTeX documents.
+ * as Markdown, LaTeX, or HTML documents.
  *
  * Architecture (pandoc-style):
  *   raw messages → normalizeMessages() → ExportNode[] → FormatSpec → string
@@ -14,8 +14,9 @@
  * under the extension's `resources/`), so it is passed into `formatChatAsLatex`
  * rather than imported here.
  *
- * The implementation lives in `./chatExport/`; this file is the public entry
- * point so callers import a single stable surface.
+ * The implementation lives in `./chatExport/` (Markdown/LaTeX) and
+ * `./htmlExport/` (HTML); this file is the public entry point so callers
+ * import a single stable surface.
  */
 
 import type { ChatExportInput } from '@agent/export/schemas';
@@ -35,6 +36,11 @@ export {
   generateExportFilename,
   generateExportFolderName,
 } from './chatExport/filenames';
+export {
+  formatChatAsHtml,
+  DEFAULT_HTML_EXPORT_ASSETS_HREF,
+  type HtmlExportOptions,
+} from './htmlExport/htmlFormatter';
 
 export function formatChatAsMarkdown(input: ChatExportInput): string {
   return renderDocument(input, markdownSpec);

--- a/src/agent/export/htmlExport/htmlFormatter.ts
+++ b/src/agent/export/htmlExport/htmlFormatter.ts
@@ -28,13 +28,12 @@ import {
 import { renderTemplateToHtml } from '@shared/htmlExport/ssrRender';
 import { tryParseUrl } from '@utils/core';
 
-import {
-  extractMeta,
-  normalizeMessages,
-  type ChatExportInput,
-  type DocumentMeta,
-  type ExportNode,
-} from '../chatExportFormatter';
+// Imported from the underlying modules rather than `../chatExportFormatter`
+// (the documented single entry point) to avoid a circular dependency: that
+// barrel re-exports `formatChatAsHtml` from this file.
+import { extractMeta } from '../chatExport/formatSpec';
+import { normalizeConversationForExport as normalizeMessages } from '../normalizeConversation';
+import type { ChatExportInput, DocumentMeta, ExportNode } from '../schemas';
 
 let cachedProcessor: MarkdownProcessor | null = null;
 

--- a/src/controllers/settingsView/ChatExportController.ts
+++ b/src/controllers/settingsView/ChatExportController.ts
@@ -19,6 +19,7 @@ import { loadChatExportInput } from '@agent/export/loadChatExportInput';
 import {
   formatChatAsMarkdown,
   formatChatAsLatex,
+  formatChatAsHtml,
   generateExportFilename,
   generateExportFolderName,
   type ChatExportInput,
@@ -158,8 +159,6 @@ export class ChatExportController {
     exportInput: ChatExportInput,
     assetsSrc: string,
   ): Promise<HtmlExportResult> {
-    const { formatChatAsHtml } =
-      await import('@agent/export/htmlExport/htmlFormatter');
     const fsExtra = (await import('fs-extra')).default;
 
     const folderName = generateExportFolderName(exportInput);

--- a/src/test-kernel/commands/htmlFormatter.vitest.ts
+++ b/src/test-kernel/commands/htmlFormatter.vitest.ts
@@ -4,8 +4,10 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { formatChatAsHtml } from '@agent/export/htmlExport/htmlFormatter';
-import type { ChatExportInput } from '@agent/export/chatExportFormatter';
+import {
+  formatChatAsHtml,
+  type ChatExportInput,
+} from '@agent/export/chatExportFormatter';
 
 const fixture: ChatExportInput = {
   timestamp: '2026-05-23T10:00:00.000Z',


### PR DESCRIPTION
Closes #7127

`chatExportFormatter.ts` documents itself as the single public entry point for chat export, but the third renderer `formatChatAsHtml` was only reachable via a deep `@agent/export/htmlExport/htmlFormatter` import, bypassing that documented surface.

## Changes

- `chatExportFormatter.ts` now re-exports `formatChatAsHtml`, `DEFAULT_HTML_EXPORT_ASSETS_HREF`, and the `HtmlExportOptions` type alongside the existing `formatChatAsMarkdown`/`formatChatAsLatex` surface.
- `htmlFormatter.ts` now imports `ChatExportInput`/`DocumentMeta`/`ExportNode`/`normalizeMessages`/`extractMeta` from their underlying modules (`../schemas`, `../normalizeConversation`, `../chatExport/formatSpec`) instead of `../chatExportFormatter`, to avoid a circular import now that the barrel re-exports from this file.
- Repointed deep importers to the single surface: `packages/cli/src/commands/history.ts`, `src/controllers/settingsView/ChatExportController.ts` (also dropped its now-redundant dynamic `import('@agent/export/htmlExport/htmlFormatter')` since the static barrel import already pulls in the module), and `src/test-kernel/commands/htmlFormatter.vitest.ts`.

Rebased onto current `main`, which already includes #7170's `loadChatExportInput` extraction; this PR stays scoped to the `formatChatAsHtml` re-export surface and doesn't touch that loader.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npx vitest run src/test-kernel/commands/htmlFormatter.vitest.ts src/test-kernel/controllers/ChatExportController.vitest.ts src/test-kernel/cli/History.vitest.mts src/test-kernel/agent/export` (all pass)
- [x] `npx eslint` on all changed files (clean)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-path and re-export wiring only; HTML export behavior is unchanged.
> 
> **Overview**
> **`chatExportFormatter`** is now the documented single import surface for HTML export as well as Markdown/LaTeX: it re-exports **`formatChatAsHtml`**, **`DEFAULT_HTML_EXPORT_ASSETS_HREF`**, and **`HtmlExportOptions`**.
> 
> **`htmlFormatter.ts`** stops importing from the barrel and pulls **`extractMeta`**, normalization, and types from **`../chatExport/formatSpec`**, **`../normalizeConversation`**, and **`../schemas`** so the barrel can re-export HTML without a circular dependency.
> 
> Call sites that used **`@agent/export/htmlExport/htmlFormatter`** (**CLI `history`**, **`ChatExportController`**, **`htmlFormatter.vitest`**) now import from **`@agent/export/chatExportFormatter`**; the controller drops a redundant dynamic import because the static barrel import already loads the HTML module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 541a36003ad896cc45c1aaac753767cbea112e14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->