### PR TITLE
Derive hardcoded model defaults from the live registry

### DIFF
--- a/src/agent/modelHandlers/openai/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerKimi.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { MODEL_CONFIGS, ModelProvider } from 'llm-zoo';
 
 // Local imports - agent
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
@@ -8,13 +9,67 @@ import { ReasoningModelHandlerOpenAI } from './reasoningModelHandlerOpenAI';
 // Type imports
 import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
 
-function isKimiK25(fullName: string): boolean {
-  return fullName.startsWith('kimi-k2.5');
+/**
+ * Moonshot API `fullName`s shared by more than one TeXRA registry entry — a
+ * reasoning and a non-reasoning variant of the same Kimi model family (e.g.
+ * `kimi25`/`kimi25T` both wire to `kimi-k2.5`) distinguished only by TeXRA's
+ * `supportsReasoning` capability. Moonshot's API can't see that distinction
+ * and defaults these wire names to thinking-enabled, so the non-reasoning
+ * registry entry must explicitly send `thinking: { type: 'disabled' }`.
+ *
+ * Computed from the live registry rather than a pinned fullName literal, so
+ * a Kimi model added later that reuses this shared-fullName pattern (as
+ * `kimi26`/`kimi26T` already do) is disambiguated automatically — no new
+ * exact-name check to remember.
+ */
+const AMBIGUOUS_THINKING_DEFAULT_FULLNAMES: ReadonlySet<string> = (() => {
+  const supportsReasoningByFullName = new Map<string, boolean>();
+  const ambiguous = new Set<string>();
+  for (const config of Object.values(MODEL_CONFIGS)) {
+    if (config.provider !== ModelProvider.MOONSHOT) continue;
+    const seen = supportsReasoningByFullName.get(config.fullName);
+    if (seen !== undefined && seen !== config.capabilities.supportsReasoning) {
+      ambiguous.add(config.fullName);
+    }
+    supportsReasoningByFullName.set(
+      config.fullName,
+      config.capabilities.supportsReasoning,
+    );
+  }
+  return ambiguous;
+})();
+
+interface FixedTemperatureRule {
+  /** Resolve the temperature Moonshot requires for this model family. */
+  readonly temperature: (supportsReasoning: boolean) => number;
+  /** Whether compaction-summary calls must also drop `thinking` entirely. */
+  readonly disableThinkingInCompactionSummary?: boolean;
 }
 
-function isKimiK27Code(fullName: string): boolean {
-  return fullName === 'kimi-k2.7-code';
-}
+/**
+ * Fixed sampling temperature required by specific Moonshot API `fullName`s.
+ * Moonshot's API pins (or silently degrades) sampling for these families
+ * regardless of the caller-requested temperature; fullNames not listed here
+ * pass the requested temperature through unchanged. This is genuine
+ * per-model API knowledge that has no equivalent llm-zoo capability flag
+ * today, so it stays a small explicit table rather than a derived rule —
+ * adding a new fixed-temperature model is one new entry here, not a new
+ * `fullName === '...'` branch scattered through the handler body.
+ */
+const FIXED_TEMPERATURE_BY_FULLNAME: ReadonlyMap<string, FixedTemperatureRule> =
+  new Map<string, FixedTemperatureRule>([
+    [
+      'kimi-k2.5',
+      {
+        temperature: (supportsReasoning: boolean) =>
+          supportsReasoning ? 1 : 0.6,
+      },
+    ],
+    [
+      'kimi-k2.7-code',
+      { temperature: () => 1, disableThinkingInCompactionSummary: true },
+    ],
+  ]);
 
 /** Response from Kimi's token estimation API */
 const KimiTokenEstimateResponseSchema = z.object({
@@ -25,9 +80,12 @@ const KimiTokenEstimateResponseSchema = z.object({
  * Handler for Moonshot Kimi models using OpenAI-compatible API.
  * Kimi K2 Thinking models return reasoning_content automatically when streaming.
  *
- * Kimi K2.5 has thinking enabled by default on the Moonshot API.
- * For non-thinking variants (supportsReasoning: false), we must explicitly
- * send `thinking: { type: 'disabled' }` to turn off thinking mode.
+ * Some Kimi model families share one Moonshot API fullName between a
+ * reasoning and non-reasoning registry entry and default to thinking
+ * enabled on the wire; see {@link AMBIGUOUS_THINKING_DEFAULT_FULLNAMES} for
+ * how the non-reasoning entry gets it explicitly disabled, and
+ * {@link FIXED_TEMPERATURE_BY_FULLNAME} for families requiring a pinned
+ * sampling temperature.
  *
  * Supports thinking mode with tool calls. When thinking mode is enabled:
  * - The model outputs reasoning_content along with tool_calls
@@ -46,10 +104,11 @@ export class ModelHandlerKimi extends ReasoningModelHandlerOpenAI {
 
   protected override getThinkingParameter():
     { type: 'enabled' | 'disabled' } | undefined {
-    // Kimi K2.5 has thinking enabled by default on the Moonshot API.
-    // Explicitly disable it for non-thinking variants.
+    // See AMBIGUOUS_THINKING_DEFAULT_FULLNAMES: these wire names default to
+    // thinking-enabled on the Moonshot API, so the non-reasoning registry
+    // entry must explicitly turn it off.
     if (
-      this.config.fullName === 'kimi-k2.5' &&
+      AMBIGUOUS_THINKING_DEFAULT_FULLNAMES.has(this.config.fullName) &&
       !this.capabilities.supportsReasoning
     ) {
       return { type: 'disabled' };
@@ -64,16 +123,12 @@ export class ModelHandlerKimi extends ReasoningModelHandlerOpenAI {
     endTag?: string,
     tools?: ToolDefinition[],
   ) {
-    // Kimi K2.5 requires fixed temperature values:
-    // - thinking mode (supportsReasoning: true): temperature=1.0
-    // - non-thinking mode (supportsReasoning: false): temperature=0.6
-    // Kimi K2.7 Code requires temperature=1.0 for both catalog entries.
-    let temperature = _temperature;
-    if (isKimiK25(this.config.fullName)) {
-      temperature = this.capabilities.supportsReasoning ? 1 : 0.6;
-    } else if (isKimiK27Code(this.config.fullName)) {
-      temperature = 1;
-    }
+    const fixedTemperature = FIXED_TEMPERATURE_BY_FULLNAME.get(
+      this.config.fullName,
+    );
+    const temperature = fixedTemperature
+      ? fixedTemperature.temperature(this.capabilities.supportsReasoning)
+      : _temperature;
     return super.buildChatBaseParams(
       messages,
       temperature,
@@ -87,8 +142,13 @@ export class ModelHandlerKimi extends ReasoningModelHandlerOpenAI {
     conversationMessages: ChatCompletionMessageParam[],
   ) {
     const params = super.buildCompactionSummaryParams(conversationMessages);
-    if (isKimiK27Code(this.config.fullName)) {
-      params.temperature = 1;
+    const fixedTemperature = FIXED_TEMPERATURE_BY_FULLNAME.get(
+      this.config.fullName,
+    );
+    if (fixedTemperature?.disableThinkingInCompactionSummary) {
+      params.temperature = fixedTemperature.temperature(
+        this.capabilities.supportsReasoning,
+      );
       delete params.thinking;
     }
     return params;

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -1,5 +1,6 @@
 // Third-party imports
 import OpenAI from 'openai';
+import { ModelProvider } from 'llm-zoo';
 
 // Local imports - core utilities
 import { isAssistantMessage } from 'openai/lib/chatCompletionUtils';
@@ -99,6 +100,15 @@ type ChatCompletionSummaryParams = ChatCompletionCreateParamsNonStreaming & {
   thinking?: { type: 'enabled' | 'disabled' };
 };
 
+/**
+ * DeepSeek's official (non-OpenRouter) chat API caps `max_tokens` well below
+ * what its newer, larger-output model families allow. Used only as the
+ * threshold below which a registry entry is still bound by that legacy
+ * ceiling (see the `buildChatBaseParams` override below) — the value that
+ * gets sent is always the model's own `config.maxOutputTokens`, never this
+ * constant, so the registry entry stays the single source of truth for how
+ * many tokens a given model actually supports.
+ */
 const DEEPSEEK_OFFICIAL_API_MAX_TOKENS = 8192;
 
 // COMPACTION_SYSTEM_PROMPT imported from contextManagementConstants
@@ -324,13 +334,18 @@ export class ModelHandlerOpenAI<
     }
 
     if (
-      this.config.fullName === 'deepseek-chat' &&
-      !this.capabilities.supportsReasoning
+      this.config.provider === ModelProvider.DEEPSEEK &&
+      !this.capabilities.supportsReasoning &&
+      this.config.maxOutputTokens <= DEEPSEEK_OFFICIAL_API_MAX_TOKENS
     ) {
+      // Tool-use mode otherwise reduces max_tokens (getEffectiveMaxOutputTokens)
+      // to leave headroom for context growth; a model already capped at or
+      // below the official API's legacy ceiling has no headroom to spare, so
+      // use its own declared max_tokens unreduced.
       this.logger.debug(
-        `Setting max_tokens to ${DEEPSEEK_OFFICIAL_API_MAX_TOKENS} for DeepSeek-chat models from the official api`,
+        `Setting max_tokens to ${this.config.maxOutputTokens} for DeepSeek chat models capped at the official API's max_tokens ceiling`,
       );
-      baseParams.max_tokens = DEEPSEEK_OFFICIAL_API_MAX_TOKENS;
+      baseParams.max_tokens = this.config.maxOutputTokens;
     }
 
     return baseParams;

--- a/src/model/setupModelDefaults.ts
+++ b/src/model/setupModelDefaults.ts
@@ -1,9 +1,23 @@
+import { MODEL_CONFIGS, ModelProvider, type ModelConfig } from 'llm-zoo';
+
+import {
+  codexBackendModelId,
+  isCodexSubscriptionEligible,
+} from './providerCapabilities';
+
 /**
- * Provider-specific models the setup assistant can use when that provider is
- * the only known usable credential. Kept with model metadata so hosts do not
- * each define their own setup routing truth.
+ * Curated setup-probe model per provider — a well-known model used to verify
+ * a provider's credential during onboarding. This table is a *preference*,
+ * not the source of truth for whether that model is still servable: a
+ * provider can retire the pinned model at any time (this has already
+ * happened live for `xai: 'grok4'`), which would otherwise make the setup
+ * assistant silently probe a dead model forever. `resolveSetupModel` below
+ * validates each preference against the live `MODEL_CONFIGS` registry and
+ * substitutes a still-usable model for that provider when the pin has gone
+ * stale, so {@link SETUP_MODEL_BY_PROVIDER} always resolves to a servable
+ * model without needing this table hand-updated on every retirement.
  */
-export const SETUP_MODEL_BY_PROVIDER: Readonly<Record<string, string>> = {
+const PREFERRED_SETUP_MODEL_BY_PROVIDER: Readonly<Record<string, string>> = {
   anthropic: 'opus48T',
   openai: 'gpt55',
   google: 'gemini31p',
@@ -15,6 +29,85 @@ export const SETUP_MODEL_BY_PROVIDER: Readonly<Record<string, string>> = {
   minimax: 'minimax01',
   glm: 'glm5',
 };
+
+/**
+ * The llm-zoo `ModelProvider` each setup-provider key's fallback pool is
+ * drawn from. `openRouter` has no direct llm-zoo provider of its own — its
+ * preferred pick routes an Anthropic model through OpenRouter, so it falls
+ * back within Anthropic's live models too.
+ */
+const FALLBACK_MODEL_PROVIDER: Readonly<Record<string, ModelProvider>> = {
+  anthropic: ModelProvider.ANTHROPIC,
+  openai: ModelProvider.OPENAI,
+  google: ModelProvider.GOOGLE,
+  deepseek: ModelProvider.DEEPSEEK,
+  openRouter: ModelProvider.ANTHROPIC,
+  xai: ModelProvider.XAI,
+  moonshot: ModelProvider.MOONSHOT,
+  dashscope: ModelProvider.DASHSCOPE,
+  minimax: ModelProvider.MINIMAX,
+  glm: ModelProvider.GLM,
+};
+
+/** Whether `config` is safe to hand to the setup assistant for `setupProvider`. */
+function isUsableSetupModel(
+  config: ModelConfig | undefined,
+  setupProvider: string,
+): config is ModelConfig {
+  if (!config || config.retired) return false;
+  // A direct-API setup probe needs a model reachable outside OpenRouter.
+  if (config.openRouterOnly) return false;
+  // CHATGPT_SETUP_MODEL feeds isCodexSubscriptionActive, which only accepts
+  // Codex-eligible model ids — keep the openai pick constrained so a
+  // fallback swap can't silently break ChatGPT-subscription setup.
+  if (setupProvider === 'openai') {
+    return isCodexSubscriptionEligible(codexBackendModelId(config));
+  }
+  return true;
+}
+
+/** Newest still-usable model for `setupProvider`, preferring a non-deprecated one. */
+function fallbackSetupModel(setupProvider: string): string | undefined {
+  const modelProvider = FALLBACK_MODEL_PROVIDER[setupProvider];
+  if (!modelProvider) return undefined;
+
+  const candidates = Object.values(MODEL_CONFIGS).filter(
+    (config) =>
+      config.provider === modelProvider &&
+      isUsableSetupModel(config, setupProvider),
+  );
+  const preferNonDeprecated = candidates.find((config) => !config.deprecated);
+  return (preferNonDeprecated ?? candidates[0])?.name;
+}
+
+/**
+ * Resolve the model the setup assistant should probe for `setupProvider`:
+ * the curated preference above when it is still live, otherwise the newest
+ * usable model this provider currently has in the registry.
+ */
+export function resolveSetupModel(setupProvider: string): string {
+  const preferred = PREFERRED_SETUP_MODEL_BY_PROVIDER[setupProvider];
+  if (isUsableSetupModel(MODEL_CONFIGS[preferred], setupProvider)) {
+    return preferred;
+  }
+  return fallbackSetupModel(setupProvider) ?? preferred;
+}
+
+/**
+ * Provider-specific models the setup assistant can use when that provider is
+ * the only known usable credential. Kept with model metadata so hosts do not
+ * each define their own setup routing truth. Resolved once at module load —
+ * `MODEL_CONFIGS` is static per process — via {@link resolveSetupModel}, so a
+ * provider's curated pick going stale (retired or OpenRouter-only) degrades
+ * to a live fallback instead of hard-failing the setup probe.
+ */
+export const SETUP_MODEL_BY_PROVIDER: Readonly<Record<string, string>> =
+  Object.fromEntries(
+    Object.keys(PREFERRED_SETUP_MODEL_BY_PROVIDER).map((provider) => [
+      provider,
+      resolveSetupModel(provider),
+    ]),
+  );
 
 /** Codex-eligible setup model used to prove ChatGPT subscription access. */
 export const CHATGPT_SETUP_MODEL = SETUP_MODEL_BY_PROVIDER.openai;

--- a/src/model/setupModelDefaults.ts
+++ b/src/model/setupModelDefaults.ts
@@ -66,7 +66,11 @@ function isUsableSetupModel(
   return true;
 }
 
-/** Newest still-usable model for `setupProvider`, preferring a non-deprecated one. */
+/**
+ * A still-usable model for `setupProvider`, preferring a non-deprecated one.
+ * `MODEL_CONFIGS` iteration order is llm-zoo's own (not a recency contract),
+ * so this is "some live model," not necessarily the newest release.
+ */
 function fallbackSetupModel(setupProvider: string): string | undefined {
   const modelProvider = FALLBACK_MODEL_PROVIDER[setupProvider];
   if (!modelProvider) return undefined;
@@ -81,12 +85,17 @@ function fallbackSetupModel(setupProvider: string): string | undefined {
 }
 
 /**
- * Resolve the model the setup assistant should probe for `setupProvider`:
- * the curated preference above when it is still live, otherwise the newest
- * usable model this provider currently has in the registry.
+ * Resolve `setupProvider`'s `preferred` pick if it is still live, otherwise a
+ * usable fallback model this provider currently has in the registry. Takes
+ * `preferred` as a parameter (rather than looking it up) so callers that
+ * already know it holds a real value — like {@link SETUP_MODEL_BY_PROVIDER}
+ * below, iterating its own preference table — get back a plain `string`
+ * with no unresolved-provider case to handle.
  */
-export function resolveSetupModel(setupProvider: string): string {
-  const preferred = PREFERRED_SETUP_MODEL_BY_PROVIDER[setupProvider];
+function resolveWithPreferred(
+  setupProvider: string,
+  preferred: string,
+): string {
   if (isUsableSetupModel(MODEL_CONFIGS[preferred], setupProvider)) {
     return preferred;
   }
@@ -94,19 +103,36 @@ export function resolveSetupModel(setupProvider: string): string {
 }
 
 /**
+ * Resolve the model the setup assistant should probe for `setupProvider`:
+ * the curated preference above when it is still live, otherwise a usable
+ * model this provider currently has in the registry. Returns `undefined`
+ * for a `setupProvider` outside {@link PREFERRED_SETUP_MODEL_BY_PROVIDER} —
+ * callers that already hold a known provider key get a plain `string` from
+ * {@link SETUP_MODEL_BY_PROVIDER} instead.
+ */
+export function resolveSetupModel(setupProvider: string): string | undefined {
+  const preferred = PREFERRED_SETUP_MODEL_BY_PROVIDER[setupProvider];
+  return preferred === undefined
+    ? undefined
+    : resolveWithPreferred(setupProvider, preferred);
+}
+
+/**
  * Provider-specific models the setup assistant can use when that provider is
  * the only known usable credential. Kept with model metadata so hosts do not
  * each define their own setup routing truth. Resolved once at module load —
- * `MODEL_CONFIGS` is static per process — via {@link resolveSetupModel}, so a
- * provider's curated pick going stale (retired or OpenRouter-only) degrades
+ * `MODEL_CONFIGS` is static per process — via {@link resolveWithPreferred}, so
+ * a provider's curated pick going stale (retired or OpenRouter-only) degrades
  * to a live fallback instead of hard-failing the setup probe.
  */
 export const SETUP_MODEL_BY_PROVIDER: Readonly<Record<string, string>> =
   Object.fromEntries(
-    Object.keys(PREFERRED_SETUP_MODEL_BY_PROVIDER).map((provider) => [
-      provider,
-      resolveSetupModel(provider),
-    ]),
+    Object.entries(PREFERRED_SETUP_MODEL_BY_PROVIDER).map(
+      ([provider, preferred]) => [
+        provider,
+        resolveWithPreferred(provider, preferred),
+      ],
+    ),
   );
 
 /** Codex-eligible setup model used to prove ChatGPT subscription access. */

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerDeepSeek.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerDeepSeek.vitest.ts
@@ -14,6 +14,7 @@ import {
 
 // Local imports - agent
 import type { AgentTrace } from '@agent/trace';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { ModelHandlerDeepSeek } from '@agent/modelHandlers/openai/modelHandlerDeepSeek';
 
 // Type imports
@@ -473,5 +474,86 @@ describe('ModelHandlerDeepSeek tool conversion', () => {
     const capturedParams = getParams();
     assert.equal(capturedParams.tools[0].function.name, 'delegate_workflow');
     assert.equal(capturedParams.tools[0].function.strict, undefined);
+  });
+});
+
+describe('ModelHandlerOpenAI DeepSeek official max_tokens ceiling (#7081)', () => {
+  // Tool-use mode reduces max_tokens to 70% of the registry budget
+  // (getEffectiveMaxOutputTokens); running these in tool-use mode makes
+  // "override applied" vs. "override skipped" produce different numbers
+  // instead of a coincidental match.
+  it('bypasses the tool-use reduction for a low-budget non-reasoning DeepSeek entry, regardless of fullName', async () => {
+    // Registry-derived: gated on provider + capability + the config's own
+    // maxOutputTokens, not on the literal fullName 'deepseek-chat' — so a
+    // differently named low-budget entry is still capped correctly.
+    const handler = new ModelHandlerDeepSeek(
+      buildConfig({
+        fullName: 'deepseek-legacy-chat',
+        maxOutputTokens: 8192,
+        capabilities: {
+          ...DEFAULT_MODEL_CAPABILITIES,
+          supportsReasoning: false,
+        },
+      }),
+    );
+    handler.setAgentCategory(AgentCategory.ToolUse);
+    stubHandlerForTest(handler);
+    const { client, getParams } = createCapturingClient();
+
+    await handler.createResponse({
+      client,
+      messages: [{ role: 'user', content: 'hi' }],
+      temperature: 0,
+    });
+
+    assert.equal(getParams().max_tokens, 8192);
+  });
+
+  it('keeps the tool-use reduction for a current large-output non-reasoning DeepSeek entry', async () => {
+    const handler = new ModelHandlerDeepSeek(
+      buildConfig({
+        fullName: 'deepseek-v4-flash',
+        maxOutputTokens: 393216,
+        capabilities: {
+          ...DEFAULT_MODEL_CAPABILITIES,
+          supportsReasoning: false,
+        },
+      }),
+    );
+    handler.setAgentCategory(AgentCategory.ToolUse);
+    stubHandlerForTest(handler);
+    const { client, getParams } = createCapturingClient();
+
+    await handler.createResponse({
+      client,
+      messages: [{ role: 'user', content: 'hi' }],
+      temperature: 0,
+    });
+
+    assert.equal(getParams().max_tokens, Math.floor(393216 * 0.7));
+  });
+
+  it('keeps the tool-use reduction for a reasoning DeepSeek entry even at a low registry budget', async () => {
+    const handler = new ModelHandlerDeepSeek(
+      buildConfig({
+        fullName: 'deepseek-legacy-reasoner',
+        maxOutputTokens: 8192,
+        capabilities: {
+          ...DEFAULT_MODEL_CAPABILITIES,
+          supportsReasoning: true,
+        },
+      }),
+    );
+    handler.setAgentCategory(AgentCategory.ToolUse);
+    stubHandlerForTest(handler);
+    const { client, getParams } = createCapturingClient();
+
+    await handler.createResponse({
+      client,
+      messages: [{ role: 'user', content: 'think' }],
+      temperature: 0,
+    });
+
+    assert.equal(getParams().max_tokens, Math.floor(8192 * 0.7));
   });
 });

--- a/src/test-kernel/agent/modelHandlers/OpenAICompatibleProviderParams.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAICompatibleProviderParams.vitest.ts
@@ -153,6 +153,115 @@ describe('OpenAI-compatible provider request params', () => {
     assert.equal(createCalls[0].thinking, undefined);
   });
 
+  it('pins Kimi K2.5 non-reasoning chat requests to temperature 0.6 and disables thinking (#7081)', async () => {
+    const handler = new ModelHandlerKimi(
+      buildConfig(ModelProvider.MOONSHOT, {
+        name: 'kimi25',
+        fullName: 'kimi-k2.5',
+        capabilities: {
+          ...DEFAULT_MODEL_CAPABILITIES,
+          supportsReasoning: false,
+        },
+      }),
+    );
+    handler.setLogger(createLoggerStub() as AgentTrace);
+    (handler as any).getStreamingConfig = () => false;
+    (handler as any).estimateTokenCount = async () => 100;
+
+    const { client, createCalls } = createClientStub();
+    await handler.createResponse({
+      client: client as any,
+      messages: [{ role: 'user', content: 'hi' }],
+      temperature: 0,
+    });
+
+    assert.equal(createCalls[0].temperature, 0.6);
+    assert.deepEqual(createCalls[0].thinking, { type: 'disabled' });
+  });
+
+  it('pins Kimi K2.5 thinking chat requests to temperature 1 and leaves the API default (#7081)', async () => {
+    const handler = new ModelHandlerKimi(
+      buildConfig(ModelProvider.MOONSHOT, {
+        name: 'kimi25T',
+        fullName: 'kimi-k2.5',
+        capabilities: {
+          ...DEFAULT_MODEL_CAPABILITIES,
+          supportsReasoning: true,
+        },
+      }),
+    );
+    handler.setLogger(createLoggerStub() as AgentTrace);
+    (handler as any).getStreamingConfig = () => false;
+    (handler as any).estimateTokenCount = async () => 100;
+
+    const { client, createCalls } = createClientStub();
+    await handler.createResponse({
+      client: client as any,
+      messages: [{ role: 'user', content: 'think' }],
+      temperature: 0,
+    });
+
+    assert.equal(createCalls[0].temperature, 1);
+    assert.equal(createCalls[0].thinking, undefined);
+  });
+
+  it('disables thinking for the Kimi K2.6 non-reasoning entry sharing a fullName with its thinking sibling (#7081)', async () => {
+    // kimi26 and kimi26T both resolve to fullName 'kimi-k2.6' in the live
+    // registry — the same shared-fullName ambiguity as K2.5 — but before
+    // this fix only 'kimi-k2.5' was hardcoded here, so this non-reasoning
+    // entry silently kept thinking on at the Moonshot API default.
+    const handler = new ModelHandlerKimi(
+      buildConfig(ModelProvider.MOONSHOT, {
+        name: 'kimi26',
+        fullName: 'kimi-k2.6',
+        capabilities: {
+          ...DEFAULT_MODEL_CAPABILITIES,
+          supportsReasoning: false,
+        },
+      }),
+    );
+    handler.setLogger(createLoggerStub() as AgentTrace);
+    (handler as any).getStreamingConfig = () => false;
+    (handler as any).estimateTokenCount = async () => 100;
+
+    const { client, createCalls } = createClientStub();
+    await handler.createResponse({
+      client: client as any,
+      messages: [{ role: 'user', content: 'hi' }],
+      temperature: 0,
+    });
+
+    assert.deepEqual(createCalls[0].thinking, { type: 'disabled' });
+    // K2.6 has no fixed-temperature requirement, so the caller's temperature
+    // passes through unchanged.
+    assert.equal(createCalls[0].temperature, 0);
+  });
+
+  it('leaves Kimi K2.6 thinking requests on the API default (#7081)', async () => {
+    const handler = new ModelHandlerKimi(
+      buildConfig(ModelProvider.MOONSHOT, {
+        name: 'kimi26T',
+        fullName: 'kimi-k2.6',
+        capabilities: {
+          ...DEFAULT_MODEL_CAPABILITIES,
+          supportsReasoning: true,
+        },
+      }),
+    );
+    handler.setLogger(createLoggerStub() as AgentTrace);
+    (handler as any).getStreamingConfig = () => false;
+    (handler as any).estimateTokenCount = async () => 100;
+
+    const { client, createCalls } = createClientStub();
+    await handler.createResponse({
+      client: client as any,
+      messages: [{ role: 'user', content: 'think' }],
+      temperature: 0,
+    });
+
+    assert.equal(createCalls[0].thinking, undefined);
+  });
+
   it('maps GLM low reasoning effort to the provider minimum', async () => {
     const handler = new ModelHandlerGLM(
       buildConfig(ModelProvider.GLM, {

--- a/src/test-kernel/model/SetupModelDefaults.vitest.ts
+++ b/src/test-kernel/model/SetupModelDefaults.vitest.ts
@@ -1,0 +1,79 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'vitest';
+import { MODEL_CONFIGS } from 'llm-zoo';
+
+import {
+  CHATGPT_SETUP_MODEL,
+  resolveSetupModel,
+  SETUP_MODEL_BY_PROVIDER,
+} from '@model/setupModelDefaults';
+import { isCodexSubscriptionEligible } from '@model/providerCapabilities';
+import { API_PROVIDERS } from '@model/apiProviders';
+
+/**
+ * #7081: setup-probe models were 10 hardcoded per-provider literals — when
+ * one retires (as `grok4` has, live in the registry today), the setup
+ * assistant probes a dead model and a valid key's verification fails.
+ * `resolveSetupModel` validates every pick against the live registry and
+ * swaps to a still-active model when needed; these tests guard that no
+ * provider's resolved model is ever retired or OpenRouter-only, regardless
+ * of what happens to the curated preference table over time.
+ */
+describe('SETUP_MODEL_BY_PROVIDER', () => {
+  it('never resolves a provider to a retired or OpenRouter-only model', () => {
+    for (const [provider, model] of Object.entries(SETUP_MODEL_BY_PROVIDER)) {
+      const config = MODEL_CONFIGS[model];
+      assert.ok(config, `${provider} resolved to unknown model "${model}"`);
+      assert.equal(
+        config.retired ?? false,
+        false,
+        `${provider} resolved to retired model "${model}"`,
+      );
+      assert.equal(
+        config.openRouterOnly ?? false,
+        false,
+        `${provider} resolved to an OpenRouter-only model "${model}"`,
+      );
+    }
+  });
+
+  it('covers every non-OpenRouter direct-key API provider', () => {
+    for (const provider of API_PROVIDERS) {
+      if (provider === 'openRouter') continue;
+      assert.ok(
+        SETUP_MODEL_BY_PROVIDER[provider],
+        `missing setup model for provider "${provider}"`,
+      );
+    }
+  });
+
+  it('falls back off a retired preferred pick to a live model for the same provider (xai/grok4)', () => {
+    // grok4 is retired in the live registry as of this fix — the concrete
+    // failure mode #7081 reported, exercised against real data rather than
+    // a mock.
+    assert.equal(MODEL_CONFIGS.grok4?.retired, true);
+    const resolved = resolveSetupModel('xai');
+    assert.notEqual(resolved, 'grok4');
+    assert.equal(MODEL_CONFIGS[resolved]?.retired ?? false, false);
+    assert.equal(MODEL_CONFIGS[resolved]?.provider, 'xai');
+  });
+
+  it('keeps the preferred pick when it is still live (anthropic/opus48T)', () => {
+    assert.equal(MODEL_CONFIGS.opus48T?.retired ?? false, false);
+    assert.equal(resolveSetupModel('anthropic'), 'opus48T');
+  });
+
+  it('returns the original preference unresolved for an unknown setup provider', () => {
+    // No fallback pool exists for a provider key we don't recognize; resolve
+    // degrades to the (possibly undefined) preferred literal rather than
+    // throwing.
+    assert.equal(resolveSetupModel('does-not-exist'), undefined);
+  });
+
+  it('keeps CHATGPT_SETUP_MODEL Codex-eligible', () => {
+    assert.equal(CHATGPT_SETUP_MODEL, SETUP_MODEL_BY_PROVIDER.openai);
+    const config = MODEL_CONFIGS[CHATGPT_SETUP_MODEL];
+    assert.ok(config);
+    assert.ok(isCodexSubscriptionEligible(config.shortName || config.fullName));
+  });
+});

--- a/src/test-kernel/model/SetupModelDefaults.vitest.ts
+++ b/src/test-kernel/model/SetupModelDefaults.vitest.ts
@@ -7,7 +7,10 @@ import {
   resolveSetupModel,
   SETUP_MODEL_BY_PROVIDER,
 } from '@model/setupModelDefaults';
-import { isCodexSubscriptionEligible } from '@model/providerCapabilities';
+import {
+  codexBackendModelId,
+  isCodexSubscriptionEligible,
+} from '@model/providerCapabilities';
 import { API_PROVIDERS } from '@model/apiProviders';
 
 /**
@@ -53,6 +56,7 @@ describe('SETUP_MODEL_BY_PROVIDER', () => {
     // a mock.
     assert.equal(MODEL_CONFIGS.grok4?.retired, true);
     const resolved = resolveSetupModel('xai');
+    assert.ok(resolved, 'xai has a known preference, so this always resolves');
     assert.notEqual(resolved, 'grok4');
     assert.equal(MODEL_CONFIGS[resolved]?.retired ?? false, false);
     assert.equal(MODEL_CONFIGS[resolved]?.provider, 'xai');
@@ -74,6 +78,9 @@ describe('SETUP_MODEL_BY_PROVIDER', () => {
     assert.equal(CHATGPT_SETUP_MODEL, SETUP_MODEL_BY_PROVIDER.openai);
     const config = MODEL_CONFIGS[CHATGPT_SETUP_MODEL];
     assert.ok(config);
-    assert.ok(isCodexSubscriptionEligible(config.shortName || config.fullName));
+    // Mirrors isUsableSetupModel's production check exactly (including
+    // codexBackendModelId's date-pin stripping), so this can't pass on a
+    // model id the real setup path would reject.
+    assert.ok(isCodexSubscriptionEligible(codexBackendModelId(config)));
   });
 });


### PR DESCRIPTION
Closes #7081

Three hard-failure-mode hardcoded model defaults, all fixed by deriving from the live `llm-zoo` `MODEL_CONFIGS` registry instead of a pinned literal:

1. **`src/model/setupModelDefaults.ts`** — 10 hardcoded per-provider setup models. The curated preference table stays (llm-zoo has no "flagship" capability flag to derive it from), but each pick is now validated against `MODEL_CONFIGS` at module load and swapped for a still-usable model of the same provider when the preferred pick has been retired or is OpenRouter-only. Concretely: `xai: 'grok4'` is *already retired* in the live registry today, so before this fix the setup assistant would silently probe a dead model whenever xai was the only usable credential.

2. **`src/agent/modelHandlers/openai/modelHandlerKimi.ts`** — exact-fullName gates (`isKimiK25`, `isKimiK27Code`, and an inline `fullName === 'kimi-k2.5'` check) for fixed-temperature and thinking-disable behavior. Replaced with:
   - A thinking-disable set computed from the registry itself: any Moonshot `fullName` shared by both a `supportsReasoning: true` and `supportsReasoning: false` registry entry needs the non-reasoning entry to explicitly disable thinking (Moonshot's API can't otherwise tell the two apart and defaults to thinking-on). This also fixes `kimi26`/`kimi26T`, which share the same ambiguous-fullName pattern as `kimi25`/`kimi25T` but weren't covered by the old hardcoded check.
   - A small explicit fixed-temperature table (genuine per-model API knowledge with no llm-zoo capability-flag equivalent), so adding a new fixed-temperature Kimi model is one new table entry instead of a new string-equality branch.

3. **`src/agent/modelHandlers/openai/modelHandlerOpenAI.ts`** — the DeepSeek official-API `max_tokens` override matched the exact fullName `'deepseek-chat'`, which no longer exists as a live (non-retired) registry entry. Now gates on `provider === DEEPSEEK && !supportsReasoning && maxOutputTokens <= DEEPSEEK_OFFICIAL_API_MAX_TOKENS`, so any current or future small-output non-reasoning DeepSeek model gets the correct cap automatically.

`llm-zoo` is consumed as an external published npm package (not a workspace member of this repo), so it can't be patched directly — capability flags that would ideally live upstream (`fixedTemperature`, `thinkingDefaultOn`) are instead expressed as small local lookup tables/derivations keyed off registry data already available on `ModelConfig` (`provider`, `capabilities.supportsReasoning`, `maxOutputTokens`, `retired`, `openRouterOnly`), which is the closest available mechanism per `src/model/providerCapabilities.ts`'s existing local-capability-resolver pattern.

## Testing
- New `src/test-kernel/model/SetupModelDefaults.vitest.ts`: no provider resolves to a retired/OpenRouter-only model, covers all direct-key providers, and exercises the real `xai/grok4` retirement as a concrete regression case.
- Extended `OpenAICompatibleProviderParams.vitest.ts` with Kimi K2.5/K2.6 reasoning and non-reasoning cases.
- Extended `ModelHandlerDeepSeek.vitest.ts` with registry-derived max_tokens cases (low-budget non-reasoning override applies regardless of fullName; large-output and reasoning entries are unaffected).
- `npm run typecheck` (root, test-kernel, extension, CLI) passes.
- Targeted `eslint` over all changed files passes.
- All touched vitest suites (`src/test-kernel/model`, `src/test-kernel/agent/modelHandlers`, `src/test-kernel/controllers/SetupLaunch.vitest.ts`) pass, including pre-existing tests (no behavior change for currently-live models beyond the intended kimi-k2.6 fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential setup model selection and live LLM request parameters (thinking, temperature, max_tokens); behavior is mostly equivalence for current models plus targeted fixes (xai setup, Kimi K2.6), but wrong fallback or gating logic could break onboarding or API calls.
> 
> **Overview**
> Replaces **pinned model literals** with **registry-driven rules** so onboarding and API calls stay correct when `llm-zoo` entries retire or rename.
> 
> **Setup onboarding** (`setupModelDefaults.ts`): curated per-provider probe models are still preferences, but `SETUP_MODEL_BY_PROVIDER` is resolved at module load via `resolveSetupModel`, which rejects retired/OpenRouter-only picks and substitutes another usable model for that provider (e.g. **xai** no longer stuck on retired `grok4`). OpenAI probes remain **Codex-eligible**.
> 
> **Kimi / Moonshot** (`modelHandlerKimi.ts`): thinking-off for non-reasoning variants is derived from Moonshot `fullName`s that map to **both** reasoning and non-reasoning registry entries (covers **K2.6** as well as K2.5). Fixed temperatures and compaction-summary behavior move into a small **`FIXED_TEMPERATURE_BY_FULLNAME`** table instead of scattered `fullName ===` branches.
> 
> **DeepSeek official API** (`modelHandlerOpenAI.ts`): the legacy `max_tokens` bypass applies to **DeepSeek, non-reasoning, `maxOutputTokens` ≤ 8192** (any `fullName`), sending **`config.maxOutputTokens`** unreduced in tool-use mode—not only the old `deepseek-chat` name.
> 
> New/extended vitest coverage for setup resolution, Kimi K2.5/K2.6 params, and DeepSeek `max_tokens` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac053eaef61e9cb6ec72d8622946124eda2a2b15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->