### PR TITLE
fix: clean execution dirs with stream deletes

### DIFF
--- a/src/shared/progressView/backend/state/ProgressViewState.ts
+++ b/src/shared/progressView/backend/state/ProgressViewState.ts
@@ -37,6 +37,7 @@ import {
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { clamp } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
+import { SessionStores } from './SessionStores';
 
 /** Ephemeral stream metadata hints, displayed before TaskState is fully populated. */
 export const StreamHintsSchema = StreamTabInfoSchema.pick({
@@ -125,6 +126,8 @@ export class ProgressViewState {
   /** Single owner of all per-stream sidecar state (output files, usage, todos,
    * plan, taskState/executionId/parent/description + meta queries). */
   readonly snapshots: StreamSnapshotStore;
+  /** Atomic lifecycle owner across streamLogs, streamData, and executions. */
+  readonly stores: SessionStores;
 
   // -- Preferences ------------------------------------------------------------
   private _prefs!: PersistedState<ProgressViewPrefs>;
@@ -155,6 +158,10 @@ export class ProgressViewState {
     this.streamLogs = session.transcripts;
     this.followUps = session.followUps;
     this.snapshots = snapshots;
+    this.stores = new SessionStores({
+      streamLogs: this.streamLogs,
+      snapshots: this.snapshots,
+    });
   }
 
   /** Drop interruptible handles whose stream sidecar was removed. */
@@ -326,12 +333,7 @@ export class ProgressViewState {
     this._sessionState.delete(stream);
     this._streamStates.delete(stream);
 
-    // Delete from disk: stream log file + stream data directory (the snapshot
-    // store owns streamData/ — it evicts its own memory + removes the dir).
-    await Promise.all([
-      this.streamLogs.delete(stream),
-      this.snapshots.deleteStream(stream),
-    ]);
+    await this.stores.deleteStream(stream);
 
     // Update active stream *after* deletion so keys() no longer includes it.
     if (this._prefs.get('activeStream') === stream) {
@@ -353,8 +355,7 @@ export class ProgressViewState {
     this._streamStates.clear();
     this._prefs.reset();
 
-    // Delete from disk (snapshot store owns streamData/, evicts its own memory)
-    await Promise.all([this.streamLogs.clear(), this.snapshots.deleteAll()]);
+    await this.stores.deleteAll();
 
     this.pruneInterruptHandles();
   }
@@ -367,6 +368,14 @@ export class ProgressViewState {
 
     const streamIds = this.streamLogs.keys();
     this.logger.info(`[Persistence] Discovered ${streamIds.length} stream(s)`);
+
+    const sweep = await this.stores.sweepOrphanedStreams(new Set(streamIds));
+    if (sweep.streams.length > 0) {
+      this.logger.info(
+        `[Persistence] Removed ${sweep.streams.length} orphaned stream sidecar(s) and ${sweep.executionIds.length} execution dir(s)`,
+        { data: sweep },
+      );
+    }
 
     await this.snapshots.load(streamIds);
 

--- a/src/shared/progressView/backend/state/SessionStores.ts
+++ b/src/shared/progressView/backend/state/SessionStores.ts
@@ -1,0 +1,96 @@
+// Local imports - agent
+import { deleteExecution as deleteStoredExecution } from '@agent/storage/executionListing';
+
+// Local imports - shared
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
+
+// Local imports - transcript
+import type { StreamLogStore, StreamSnapshotStore } from '@transcript';
+
+export interface SessionStoresOptions {
+  streamLogs: StreamLogStore;
+  snapshots: StreamSnapshotStore;
+  deleteExecution?: (executionId: ExecutionId) => Promise<boolean>;
+}
+
+/**
+ * Owns the durable footprint for a progress stream.
+ *
+ * `StreamLogStore` and `StreamSnapshotStore` keep separate on-disk formats;
+ * this class owns the lifecycle invariant across those formats plus the
+ * execution directory they reference.
+ */
+export class SessionStores {
+  private readonly streamLogs: StreamLogStore;
+  private readonly snapshots: StreamSnapshotStore;
+  private readonly deleteExecution: (
+    executionId: ExecutionId,
+  ) => Promise<boolean>;
+
+  constructor(options: SessionStoresOptions) {
+    this.streamLogs = options.streamLogs;
+    this.snapshots = options.snapshots;
+    this.deleteExecution = options.deleteExecution ?? deleteStoredExecution;
+  }
+
+  async deleteStream(stream: StreamTabId): Promise<void> {
+    const executionId =
+      this.snapshots.getExecutionId(stream) ??
+      (await this.snapshots.readPersistedExecutionId(stream));
+
+    await Promise.all([
+      this.streamLogs.delete(stream),
+      this.snapshots.deleteStream(stream),
+      this.deleteExecutionIds(executionId ? [executionId] : []),
+    ]);
+  }
+
+  async deleteAll(): Promise<void> {
+    const persistedStreams = await this.snapshots.listPersistedStreams();
+    const executionIds = new Set<ExecutionId>(
+      this.snapshots.getExecutionIdMap().values(),
+    );
+    for (const stream of persistedStreams) {
+      const executionId = await this.snapshots.readPersistedExecutionId(stream);
+      if (executionId) executionIds.add(executionId);
+    }
+
+    await Promise.all([
+      this.streamLogs.clear(),
+      this.snapshots.deleteAll(),
+      this.deleteExecutionIds(executionIds),
+    ]);
+  }
+
+  async sweepOrphanedStreams(
+    liveStreams: ReadonlySet<StreamTabId>,
+  ): Promise<{ streams: StreamTabId[]; executionIds: ExecutionId[] }> {
+    const persistedStreams = await this.snapshots.listPersistedStreams();
+    const orphanedStreams = persistedStreams.filter(
+      (stream) => !liveStreams.has(stream),
+    );
+    const executionIds = new Set<ExecutionId>();
+
+    await Promise.all(
+      orphanedStreams.map(async (stream) => {
+        const executionId =
+          await this.snapshots.readPersistedExecutionId(stream);
+        if (executionId) executionIds.add(executionId);
+        await this.snapshots.deleteStream(stream);
+      }),
+    );
+    await this.deleteExecutionIds(executionIds);
+
+    return { streams: orphanedStreams, executionIds: [...executionIds] };
+  }
+
+  private async deleteExecutionIds(
+    executionIds: Iterable<ExecutionId>,
+  ): Promise<void> {
+    await Promise.all(
+      [...new Set(executionIds)].map((executionId) =>
+        this.deleteExecution(executionId),
+      ),
+    );
+  }
+}

--- a/src/test-kernel/controllers/ProgressStreamLifecycleController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressStreamLifecycleController.vitest.ts
@@ -4,6 +4,12 @@ import { describe, it } from 'vitest';
 
 // Standard library imports
 
+// Local imports - shared
+import type { StreamTabId } from '@shared/schemas';
+
+// Local imports - tools
+import { GoalStore } from '@tools/goal';
+
 // Local imports - test support
 import { createProgressStreamLifecycleHarness } from '../support/ProgressControllerHarnesses';
 
@@ -35,6 +41,21 @@ describe('ProgressStreamLifecycleController', () => {
     assert.deepEqual(recorder.calls.get('clearBackups'), ['stream-b']);
     assert.deepEqual(recorder.calls.get('clearWebview'), ['stream-b']);
     assert.deepEqual(recorder.calls.get('deleteWebview'), ['stream-b']);
+  });
+
+  it('forgets the stream goal when deleting a stream', async () => {
+    const stream = 'stream-a' as StreamTabId;
+    await GoalStore.forget(stream);
+    await GoalStore.start(stream, 'finish the cleanup');
+    const { controller } = createProgressStreamLifecycleHarness();
+
+    try {
+      await controller.deleteStream(stream);
+
+      assert.equal(GoalStore.getForStream(stream), null);
+    } finally {
+      await GoalStore.forget(stream);
+    }
   });
 
   it('deletes active finished streams and activates the next visible stream', async () => {

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -216,6 +216,11 @@ async function createBridge(
   options: CreateBridgeOptions = {},
 ): Promise<TestableBridge> {
   vi.resetModules();
+  const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
+    import('@platform/platform'),
+    import('@test/support/FakePlatform'),
+  ]);
+  initPlatform(createFakePlatform());
   vi.doMock('@agent/runtime/ProgressViewBridge', () => ({
     setProgressViewBridge: vi.fn(),
   }));
@@ -390,6 +395,11 @@ async function createExecution(options: {
   onRunCompleted?: () => void;
 }): Promise<DesktopExecution> {
   vi.resetModules();
+  const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
+    import('@platform/platform'),
+    import('@test/support/FakePlatform'),
+  ]);
+  initPlatform(createFakePlatform());
   vi.doMock('@agent/runtime/ProgressViewBridge', () => ({
     setProgressViewBridge: vi.fn(),
   }));
@@ -1713,6 +1723,28 @@ describe('DesktopProgressBridge', () => {
       await expect(bridge.tryResumeStream('stream-1')).resolves.toBe(false);
       expect(retrieveSessionResumeData).not.toHaveBeenCalled();
     } finally {
+      bridge.dispose();
+    }
+  });
+
+  it('forgets desktop goal records when deleting a stream', async () => {
+    const stream = 'goal-stream' as StreamTabId;
+    const bridge = await createBridge([]);
+    const { GoalStore: bridgeGoalStore } = await import('@tools/goal');
+    await bridgeGoalStore.forget(stream);
+    await bridgeGoalStore.start(stream, 'finish the cleanup');
+
+    try {
+      bridge.handleProgressEvent('setActiveStream', {
+        streamId: stream,
+        agentCategory: AgentCategory.Workflow,
+      });
+
+      await bridge.deleteStream(stream);
+
+      expect(bridgeGoalStore.getForStream(stream)).toBeNull();
+    } finally {
+      await bridgeGoalStore.forget(stream);
       bridge.dispose();
     }
   });

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -1,7 +1,12 @@
 // Third-party imports
 import { describe, expect, it, vi } from 'vitest';
 
+// Local imports - transcript
+import { streamDataDir, StreamSnapshotStore } from '@transcript';
+
 // Local imports - agent
+import { getExecutionStore } from '@agent/storage';
+import { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { TaskState } from '@agent/core/state/TaskState';
 import { bus } from '@eventBus/ProgressEventBus';
 
@@ -10,7 +15,9 @@ import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   AgentCategory,
   STREAM_PHASE,
+  type ExecutionId,
   type ProgressViewOutboundMessage,
+  type StreamTabId,
 } from '@shared/schemas';
 import {
   ProgressBackend,
@@ -18,6 +25,7 @@ import {
   type ProgressBackendUiConfig,
 } from '@shared/progressView/backend/ProgressBackend';
 import type { MementoStorage } from '@shared/progressView/backend/persistence/PersistentMapManager';
+import { StorageFS } from '@utils/files';
 
 class MemoryMementoStorage implements MementoStorage {
   private readonly values = new Map<string, unknown>();
@@ -86,6 +94,33 @@ function createRecordingBackend(): {
     configureUi: () => createUiConfig(),
   });
   return { backend, messages };
+}
+
+function createIsolatedRecordingBackend(): {
+  backend: ProgressBackend;
+  messages: ProgressViewOutboundMessage[];
+  session: SessionHandle;
+} {
+  const messages: ProgressViewOutboundMessage[] = [];
+  const session = new SessionHandle();
+  const backend = new ProgressBackend({
+    storage: new MemoryMementoStorage(),
+    snapshots: new StreamSnapshotStore(),
+    session,
+    sendMessage: (message) => {
+      messages.push(message);
+      return true;
+    },
+    hasTarget: () => true,
+    configureUi: () => createUiConfig(),
+  });
+  return { backend, messages, session };
+}
+
+async function writeExecutionConfig(executionId: ExecutionId): Promise<void> {
+  await getExecutionStore(executionId).writeConfig(
+    toolUseTaskState('search', 'deepseekproT').agentConfig,
+  );
 }
 
 describe('ProgressBackend', () => {
@@ -410,6 +445,78 @@ describe('ProgressBackend', () => {
       });
     } finally {
       backend.dispose();
+    }
+  });
+
+  it('deletes the execution directory named by stream metadata when a stream is cleared', async () => {
+    const { backend, session } = createIsolatedRecordingBackend();
+    const stream = 'tool@deepseek#a6966a' as StreamTabId;
+    const executionId = 'a6966a' as ExecutionId;
+
+    try {
+      await backend.state.snapshots.load([stream]);
+      backend.state.streamLogs.ensureStream(stream);
+      backend.state.snapshots.setTaskState(
+        stream,
+        toolUseTaskState('search', 'deepseekproT'),
+        executionId,
+      );
+      await writeExecutionConfig(executionId);
+      await backend.state.flush();
+
+      expect(await StorageFS.exists(`executions/${executionId}`)).toBe(true);
+      expect(await StorageFS.exists(streamDataDir(stream))).toBe(true);
+
+      await backend.state.clearStream(stream);
+
+      expect(await StorageFS.exists(`executions/${executionId}`)).toBe(false);
+      expect(await StorageFS.exists(streamDataDir(stream))).toBe(false);
+    } finally {
+      await backend.state.clearAll();
+      backend.dispose();
+      session.dispose();
+    }
+  });
+
+  it('sweeps streamData orphans without deleting standalone execution history', async () => {
+    const orphanStream = 'tool@deepseek#b6966b' as StreamTabId;
+    const orphanExecution = 'b6966b' as ExecutionId;
+    const historyExecution = 'c6966c' as ExecutionId;
+    const seed = new StreamSnapshotStore();
+    await seed.load([orphanStream]);
+    seed.setTaskState(
+      orphanStream,
+      toolUseTaskState('search', 'deepseekproT'),
+      orphanExecution,
+    );
+    await writeExecutionConfig(orphanExecution);
+    await writeExecutionConfig(historyExecution);
+    await seed.flush();
+
+    const { backend, session } = createIsolatedRecordingBackend();
+    try {
+      expect(await StorageFS.exists(streamDataDir(orphanStream))).toBe(true);
+      expect(await StorageFS.exists(`executions/${orphanExecution}`)).toBe(
+        true,
+      );
+      expect(await StorageFS.exists(`executions/${historyExecution}`)).toBe(
+        true,
+      );
+
+      await backend.state.load();
+
+      expect(await StorageFS.exists(streamDataDir(orphanStream))).toBe(false);
+      expect(await StorageFS.exists(`executions/${orphanExecution}`)).toBe(
+        false,
+      );
+      expect(await StorageFS.exists(`executions/${historyExecution}`)).toBe(
+        true,
+      );
+    } finally {
+      await getExecutionStore(historyExecution).clear();
+      await backend.state.clearAll();
+      backend.dispose();
+      session.dispose();
     }
   });
 });

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -24,6 +24,7 @@ import { getExecutionStore } from '@agent/storage';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { TaskStateSchema, type TaskState } from '@agent/core/state/TaskState';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
+import { isFileNotFoundError } from '@common/errors';
 import { KVStore } from '@common/storage/KVStore';
 import type {
   ProgressEvent,
@@ -59,7 +60,10 @@ import {
 import { getCleanAgentName } from '@shared/schemas/agent';
 
 import { mapToRecord } from '@shared/progressView/backend/persistence/serializationUtils';
+import { StorageFS } from '@utils/files';
+import { isDirectory } from '@utils/files/fsEntryType';
 import {
+  decodeStreamId,
   STREAM_DATA_DIR,
   STREAM_DATA_KEYS,
   streamDataDir,
@@ -170,6 +174,15 @@ export class StreamSnapshotStore {
       this.kvCache.set(streamId, store);
     }
     return store;
+  }
+
+  private async readPersistedStreamDirs(): Promise<[string, number][]> {
+    try {
+      return await StorageFS.readDir(STREAM_DATA_DIR);
+    } catch (error) {
+      if (isFileNotFoundError(error)) return [];
+      throw error;
+    }
   }
 
   private streamVersion(stream: StreamTabId): number {
@@ -748,6 +761,23 @@ export class StreamSnapshotStore {
     // executionId is validated to a real ExecutionId at the single disk-read
     // entry (`readMeta`), so no cast/re-validation is needed here.
     return this.meta.get(stream)?.executionId;
+  }
+
+  /** Streams with persisted sidecars under `streamData/`. */
+  async listPersistedStreams(): Promise<StreamTabId[]> {
+    const entries = await this.readPersistedStreamDirs();
+    return entries
+      .filter(([, type]) => isDirectory(type))
+      .map(([encoded]) => decodeStreamId(encoded))
+      .filter((stream): stream is StreamTabId => stream !== undefined);
+  }
+
+  /** Execution id recorded in a stream sidecar, without seeding memory. */
+  async readPersistedExecutionId(
+    stream: StreamTabId,
+  ): Promise<ExecutionId | undefined> {
+    const meta = (await readStreamData(this.kv(stream))).meta;
+    return meta?.runDescriptor?.executionId ?? meta?.executionId;
   }
 
   getParentStreamId(stream: StreamTabId): StreamTabId | undefined {

--- a/src/transcript/streamDataPaths.ts
+++ b/src/transcript/streamDataPaths.ts
@@ -50,6 +50,15 @@ export function encodeStreamId(id: string): string {
   return encodeURIComponent(id);
 }
 
+/** Decode a persisted stream directory name. Invalid legacy names are skipped. */
+export function decodeStreamId(encoded: string): string | undefined {
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    return undefined;
+  }
+}
+
 /** Build the relative directory path for a stream's sidecar data: `streamData/{encoded}`. */
 export function streamDataDir(streamId: string): string {
   return path.join(STREAM_DATA_DIR, encodeStreamId(streamId));


### PR DESCRIPTION
## Summary

Implements the first #6966 Stage 3c split: progress stream deletion now owns the full durable footprint for a stream. `ProgressViewState` delegates stream deletion, delete-all, and startup orphan cleanup to `SessionStores`, which deletes the stream log, `streamData/{id}`, and the referenced `executions/{id}` directory together.

The orphan sweep is intentionally conservative: it only deletes execution directories named by orphaned `streamData` sidecars whose stream log is gone, and it leaves standalone execution history untouched.

## Issue acceptance gates

Refs #6966, task bullet 1 only. #6966 explicitly says to split PRs by the six task bullets, so this PR does not auto-close the full issue.

Satisfied in this split:

- Deleting a tab removes stream logs, streamData, and the execution directory named by stream metadata.
- Startup orphan sweep is covered by test and preserves standalone execution history.
- Goal entries remain forgotten on extension and desktop delete paths; regression tests cover the existing behavior.

Remaining #6966 gates are intentionally left for later splits: KV projection deletion, `deriveResumability`, shared restart repair / #6938 verification, versioned loud reads, and write hygiene.

## Single source of truth

`src/shared/progressView/backend/state/SessionStores.ts` now owns the lifecycle invariant across `StreamLogStore`, `StreamSnapshotStore`, and `executions/{id}` for progress stream cleanup. The on-disk formats remain separate, as required by audit A6.

## Duplication and abstraction budget

This removes ad hoc lifecycle ownership from `ProgressViewState.clearStream()` / `clearAll()` without collapsing the storage formats. The new abstraction is not a pass-through layer: it owns the cross-store invariant that stream logs, streamData sidecars, and referenced execution directories are deleted atomically. The PR is net-positive in lines because the added mass is in that small lifecycle owner plus regression coverage for extension, desktop, and orphan preservation.

## Host impact

Extension: tab deletion and delete-all now delete the referenced execution directory through the shared progress state. Existing goal cleanup remains covered by regression test.

Desktop: desktop progress deletion uses the same shared progress state cleanup; the desktop goal-forget path is covered by regression test. Test harnesses now reinitialize the fake platform after module resets because delete-all reaches shared storage.

CLI: no output or resume behavior change. Standalone execution history remains intact, and CLI headless validation passed.

## Scheduled refactoring

Remaining #6966 task bullets stay on #6966. No legacy retirement ledger row is needed in this split because it introduces no shim, projection, dual-write, alias, fallback, or migration path.

## Validation

Initial validation before the latest rebase:

- `corepack pnpm exec prettier --write src/test-kernel/controllers/ProgressStreamLifecycleController.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/transcript/streamDataPaths.ts src/transcript/StreamSnapshotStore.ts src/shared/progressView/backend/state/SessionStores.ts src/shared/progressView/backend/state/ProgressViewState.ts src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `npm test -- --run src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/controllers/ProgressStreamLifecycleController.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `npm run typecheck`
- `npm test`
- `npm run lint` (passes with one pre-existing unrelated import-order warning in `packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts`)
- `npm run compile:fast`
- `npm test -- --run src/test-kernel/progressView/SessionRunFactProjectorEquivalence.vitest.ts`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `git diff --check`

Post-rebase refresh after `origin/main` moved:

- `git pull --ff-only`
- `git rebase origin/main`
- `npm run typecheck`
- `npm test -- --run src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/controllers/ProgressStreamLifecycleController.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `git diff --check origin/main..HEAD`

Refs #6966
