### PR TITLE
Standardize test-suite platform bootstraps on setupPlatform/installPlatform

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -62,6 +62,10 @@ const COMPOSITION_ROOT_FILES = new Set([
   path.join(__dirname, 'packages/extension/src/extension.ts'),
   path.join(__dirname, 'packages/desktop/src/main/platform/index.ts'),
   path.join(__dirname, 'packages/cli/src/runtime/initPlatform.ts'),
+  // The test suite's composition root: the sole place vitest suites swap the
+  // fake platform, replacing the per-suite `await import('@platform/platform')`
+  // dance every suite used to hand-roll to dodge this same rule.
+  path.join(__dirname, 'src/test-kernel/support/setupPlatform.ts'),
 ]);
 
 const extensionPackageDir = path.join(__dirname, 'packages', 'extension');

--- a/src/test-kernel/agent/GoalContinuation.vitest.ts
+++ b/src/test-kernel/agent/GoalContinuation.vitest.ts
@@ -2,10 +2,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports
-import {
-  FakeConfigProvider,
-  createFakePlatform,
-} from '@test/support/FakePlatform';
+import { FakeConfigProvider } from '@test/support/FakePlatform';
+import { installPlatform as installFakePlatform } from '@test/support/setupPlatform';
+import { platform, type Platform } from '@platform/platform';
 import { maybeBuildGoalContinuation } from '@agent/goal';
 import type { StreamTabId } from '@shared/schemas';
 import {
@@ -13,7 +12,6 @@ import {
   GOAL_FEATURE_FLAG_KEY,
 } from '@shared/schemas/goal';
 import { GoalStore, isGoalEnabled } from '@tools/goal';
-import type { Platform } from '@platform/platform';
 
 const STREAM_ID = 'stream:goal-cont' as StreamTabId;
 // Pre-rename canonical key, still honored read-only for back-compat.
@@ -26,10 +24,8 @@ async function installPlatform(flagOn: boolean): Promise<Platform> {
 async function installPlatformWithConfig(
   config: Record<string, unknown>,
 ): Promise<Platform> {
-  const { initPlatform } = await import('@platform/platform');
-  const platform = createFakePlatform({ config });
-  initPlatform(platform);
-  return platform;
+  await installFakePlatform({ config });
+  return platform();
 }
 
 describe('isGoalEnabled', () => {

--- a/src/test-kernel/agent/RegisterExecutionWorkspaceDirectory.vitest.ts
+++ b/src/test-kernel/agent/RegisterExecutionWorkspaceDirectory.vitest.ts
@@ -20,6 +20,7 @@ vi.mock('@agent/storage/executionListing', () => ({
 }));
 
 import { registerExecution } from '@agent/storage/executionLifecycle';
+import { setupPlatform } from '@test/support/setupPlatform';
 
 const baseConfig = {
   agent: 'chat',
@@ -37,10 +38,9 @@ const baseConfig = {
 } as AgentConfig;
 
 describe('registerExecution', () => {
-  beforeEach(async () => {
-    const { initPlatform } = await import('@platform/platform');
-    const { createFakePlatform } = await import('@test/support/FakePlatform');
-    initPlatform(createFakePlatform({ workspacePath: '/workspace/root' }));
+  setupPlatform({ workspacePath: '/workspace/root' });
+
+  beforeEach(() => {
     vi.clearAllMocks();
     mocks.getExecutionStore.mockReturnValue({
       writeConfig: mocks.writeConfig,

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -1,6 +1,6 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { setupPlatform } from '@test/support/setupPlatform';
 import { getExecutionStore } from '@agent/storage';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
@@ -35,12 +35,9 @@ const GOOGLE_WORKFLOW_CONFIG: AgentConfig = {
   agentCategory: AgentCategory.Workflow,
 };
 
-beforeEach(async () => {
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(createFakePlatform({ workspacePath: '/workspace' }));
-});
-
 describe('retrieveSessionResumeData', () => {
+  setupPlatform({ workspacePath: '/workspace' });
+
   it('uses the persisted current model while preserving the original stream id', async () => {
     const executionId = 'abc123' as ExecutionId;
     const streamId = 'chat@gpt54#abc123' as StreamTabId;

--- a/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 // Local imports
+import { installPlatform } from '@test/support/setupPlatform';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { withToolFileInteractionContext } from '@agent/followUp/ToolFileInteractionContext';
@@ -19,28 +20,22 @@ let testApprovalHandler:
   | ((request: ToolEditApprovalRequest) => Promise<ToolEditApprovalResult>)
   | undefined;
 
-async function installTestPlatform(): Promise<void> {
-  const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
-    import('@platform/platform'),
-    import('@test/support/FakePlatform'),
-  ]);
-  initPlatform(
-    createFakePlatform(
-      {
-        workspacePath,
-        storagePath,
-        globalStoragePath: '/global/.texra/storage',
+function installTestPlatform(): Promise<void> {
+  return installPlatform(
+    {
+      workspacePath,
+      storagePath,
+      globalStoragePath: '/global/.texra/storage',
+    },
+    {
+      toolEditApproval: (request) => {
+        const handler = testApprovalHandler;
+        if (!handler) {
+          throw new Error('No test handler. Set `testApprovalHandler`.');
+        }
+        return handler(request);
       },
-      {
-        toolEditApproval: (request) => {
-          const handler = testApprovalHandler;
-          if (!handler) {
-            throw new Error('No test handler. Set `testApprovalHandler`.');
-          }
-          return handler(request);
-        },
-      },
-    ),
+    },
   );
 }
 

--- a/src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 // Local imports
 import { waitForRecordedEvent } from '@test/support/asyncTestUtils';
+import { installPlatform } from '@test/support/setupPlatform';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { withToolFileInteractionContext } from '@agent/followUp/ToolFileInteractionContext';
@@ -34,26 +35,20 @@ let testApprovalHandler:
   | ((request: ToolEditApprovalRequest) => Promise<ToolEditApprovalResult>)
   | undefined;
 
-async function installTestPlatform(): Promise<void> {
-  const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
-    import('@platform/platform'),
-    import('@test/support/FakePlatform'),
-  ]);
-  initPlatform(
-    createFakePlatform(
-      {},
-      {
-        toolEditApproval: (request) => {
-          const handler = testApprovalHandler;
-          if (!handler) {
-            throw new Error(
-              'No test approval handler. Set `testApprovalHandler` first.',
-            );
-          }
-          return handler(request);
-        },
+function installTestPlatform(): Promise<void> {
+  return installPlatform(
+    {},
+    {
+      toolEditApproval: (request) => {
+        const handler = testApprovalHandler;
+        if (!handler) {
+          throw new Error(
+            'No test approval handler. Set `testApprovalHandler` first.',
+          );
+        }
+        return handler(request);
       },
-    ),
+    },
   );
 }
 

--- a/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
@@ -6,6 +6,7 @@ import { describe, it, afterEach } from 'vitest';
 
 // Local imports - agent
 import { createFakePlatform } from '@test/support/FakePlatform';
+import { installPlatform } from '@test/support/setupPlatform';
 import {
   clearStreamStatusForTest,
   seedStreamStatusForTest,
@@ -38,9 +39,8 @@ type ResumeHost = NonNullable<
   NonNullable<Parameters<typeof createFakePlatform>[1]>['agentResume']
 >;
 
-async function initResumePlatform(agentResume: ResumeHost): Promise<void> {
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(createFakePlatform({}, { agentResume }));
+function initResumePlatform(agentResume: ResumeHost): Promise<void> {
+  return installPlatform({}, { agentResume });
 }
 
 function trackChildHandle(

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -2,7 +2,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { installPlatform } from '@test/support/setupPlatform';
 import {
   clearStreamStatusForTest,
   seedStreamStatusForTest,
@@ -260,8 +260,7 @@ describe('ToolUseWaitNode', () => {
 
   it('pauses the goal after a failed parent cycle', async () => {
     const streamId = 'wait-node-error-goal' as StreamTabId;
-    const { initPlatform } = await import('@platform/platform');
-    initPlatform(createFakePlatform({}));
+    await installPlatform();
 
     await GoalStore.start(streamId, 'finish the refactor');
 
@@ -334,8 +333,7 @@ describe('ToolUseWaitNode', () => {
 
   it('injects an active goal continuation before the blocking wait', async () => {
     const streamId = 'wait-node-active-goal' as StreamTabId;
-    const { initPlatform } = await import('@platform/platform');
-    initPlatform(createFakePlatform({}));
+    await installPlatform();
 
     await GoalStore.start(streamId, 'Finish the autonomous proof audit.');
 
@@ -419,8 +417,7 @@ describe('ToolUseWaitNode', () => {
 
   it('keeps injecting active goal continuations across a long run', async () => {
     const streamId = 'wait-node-long-goal' as StreamTabId;
-    const { initPlatform } = await import('@platform/platform');
-    initPlatform(createFakePlatform({}));
+    await installPlatform();
 
     await GoalStore.start(
       streamId,
@@ -502,8 +499,7 @@ describe('ToolUseWaitNode', () => {
 
   it('lets queued user follow-up win over an active goal continuation', async () => {
     const streamId = 'wait-node-goal-user-queued' as StreamTabId;
-    const { initPlatform } = await import('@platform/platform');
-    initPlatform(createFakePlatform({}));
+    await installPlatform();
 
     await GoalStore.start(streamId, 'Keep going autonomously.');
 
@@ -549,8 +545,7 @@ describe('ToolUseWaitNode', () => {
 
   it('does not let a subagent drive the parent goal continuation loop', async () => {
     const streamId = 'wait-node-goal-subagent' as StreamTabId;
-    const { initPlatform } = await import('@platform/platform');
-    initPlatform(createFakePlatform({}));
+    await installPlatform();
 
     await GoalStore.start(streamId, 'Parent-owned objective.');
 

--- a/src/test-kernel/agent/modelHandlers/CodexEncryptedReasoning.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/CodexEncryptedReasoning.vitest.ts
@@ -1,10 +1,11 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
   DEFAULT_MODEL_CAPABILITIES,
   type ModelConfig,
   ModelProvider,
 } from 'llm-zoo';
 
+import { setupPlatform } from '@test/support/setupPlatform';
 import type { AgentTrace } from '@agent/trace';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/openai/modelHandlerOpenAIResponse';
 import { ModelHandlerCodex } from '@agent/modelHandlers/openai/modelHandlerCodex';
@@ -75,16 +76,8 @@ function encryptedBlobs(blocks: ReadonlyArray<{ type?: string }>): string[] {
 describe('extractServerToolData reasoning preservation by store mode', () => {
   // The store:false (encrypted-reasoning) path is gated on the subscription
   // being active; turning it off drops the Codex handler to base behavior.
-  beforeEach(async () => {
-    const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
-      import('@platform/platform'),
-      import('@test/support/FakePlatform'),
-    ]);
-    initPlatform(
-      createFakePlatform({
-        config: { 'texra.chatgptCodex.preferSubscription': true },
-      }),
-    );
+  setupPlatform({
+    config: { 'texra.chatgptCodex.preferSubscription': true },
   });
 
   it('skips reasoning items that carry no encrypted_content (would be rejected empty)', () => {

--- a/src/test-kernel/agent/modelHandlers/CodexExperimentalTransports.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/CodexExperimentalTransports.vitest.ts
@@ -5,6 +5,7 @@ import {
   type ModelConfig,
 } from 'llm-zoo';
 
+import { installPlatform } from '@test/support/setupPlatform';
 import { ModelHandlerCodex } from '@agent/modelHandlers/openai/modelHandlerCodex';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { resetCodexCoordinator } from '@auth/codex';
@@ -37,26 +38,20 @@ function config(): ModelConfig {
   };
 }
 
-async function initPlatformWith(opts: {
+function initPlatformWith(opts: {
   config?: Record<string, unknown>;
   globalState?: Record<string, unknown>;
 }): Promise<void> {
-  const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
-    import('@platform/platform'),
-    import('@test/support/FakePlatform'),
-  ]);
-  initPlatform(
-    createFakePlatform({
-      config: {
-        'texra.chatgptCodex.preferSubscription': true,
-        // These tests exercise the subscription's transport mechanics with a
-        // workflow handler, so keep the "tool-use only" restriction off.
-        'texra.chatgptCodex.subscriptionToolUseOnly': false,
-        ...opts.config,
-      },
-      globalState: opts.globalState,
-    }),
-  );
+  return installPlatform({
+    config: {
+      'texra.chatgptCodex.preferSubscription': true,
+      // These tests exercise the subscription's transport mechanics with a
+      // workflow handler, so keep the "tool-use only" restriction off.
+      'texra.chatgptCodex.subscriptionToolUseOnly': false,
+      ...opts.config,
+    },
+    globalState: opts.globalState,
+  });
 }
 
 function workflowHandler(): ModelHandlerCodex {

--- a/src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts
@@ -5,6 +5,7 @@ import {
   type ModelConfig,
 } from 'llm-zoo';
 
+import { installPlatform } from '@test/support/setupPlatform';
 import { ModelHandlerCodex } from '@agent/modelHandlers/openai/modelHandlerCodex';
 import {
   CODEX_BACKEND_BASE_URL,
@@ -17,23 +18,15 @@ import { AgentCategory } from '@shared/schemas/agent';
 
 import type { ResponseUsage } from 'openai/resources/responses/responses';
 
-// Dynamic import keeps `initPlatform` out of the static import graph (it is
-// restricted to composition roots); the routing tests use the same pattern.
-async function initFakePlatformWithSubscription(
+function initFakePlatformWithSubscription(
   extraConfig: Record<string, unknown> = {},
 ): Promise<void> {
-  const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
-    import('@platform/platform'),
-    import('@test/support/FakePlatform'),
-  ]);
-  initPlatform(
-    createFakePlatform({
-      config: {
-        'texra.chatgptCodex.preferSubscription': true,
-        ...extraConfig,
-      },
-    }),
-  );
+  return installPlatform({
+    config: {
+      'texra.chatgptCodex.preferSubscription': true,
+      ...extraConfig,
+    },
+  });
 }
 
 const config: ModelConfig = {

--- a/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
@@ -10,6 +10,7 @@ import {
   type ModelConfig,
 } from 'llm-zoo';
 
+import { installPlatform } from '@test/support/setupPlatform';
 import { ModelHandlerOpenRouterNative } from '@agent/modelHandlers/openrouter/modelHandlerOpenRouterNative';
 import { ModelHandlerOpenAI } from '@agent/modelHandlers/openai/modelHandlerOpenAI';
 import { ModelHandlerGoogleGenAI } from '@agent/modelHandlers/google/modelHandlerGoogleGenAI';
@@ -31,6 +32,7 @@ import {
   type CodexSession,
 } from '@auth/codex';
 import { shouldRouteModelThroughOpenRouter } from '@model/openRouterRouting';
+import type { FakePlatformOptions } from '@test/support/FakePlatform';
 
 function modelConfig(
   provider: ModelProvider,
@@ -51,19 +53,11 @@ function modelConfig(
   };
 }
 
-// initPlatform is restricted to composition roots, so import it dynamically.
-// The dynamic import also re-resolves @platform/platform after this file's
-// vi.resetModules() calls, keeping it on the instance the factory reads.
-async function initFakePlatform(
-  options?: Parameters<
-    typeof import('@test/support/FakePlatform').createFakePlatform
-  >[0],
-): Promise<void> {
-  const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
-    import('@platform/platform'),
-    import('@test/support/FakePlatform'),
-  ]);
-  initPlatform(createFakePlatform(options));
+// installPlatform dynamically imports @platform/platform at call time, so
+// this also re-resolves it after this file's vi.resetModules() calls,
+// keeping it on the instance the factory reads.
+function initFakePlatform(options?: FakePlatformOptions): Promise<void> {
+  return installPlatform(options);
 }
 
 describe('OpenAI model handler routing', () => {

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -5,7 +5,7 @@ import { strict as assert } from 'node:assert';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { afterEach, beforeAll, describe, it, vi } from 'vitest';
+import { afterEach, describe, it, vi } from 'vitest';
 
 // Third-party imports
 import { APIUserAbortError as AnthropicUserAbortError } from '@anthropic-ai/sdk';
@@ -14,7 +14,7 @@ import { APIUserAbortError as AnthropicUserAbortError } from '@anthropic-ai/sdk'
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 
 // Local imports - test support
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { setupPlatform } from '@test/support/setupPlatform';
 
 // Local imports - agent
 import {
@@ -56,12 +56,9 @@ import type {
   ToolUseBlock,
 } from '@anthropic-ai/sdk/resources/messages';
 
-// Vitest isolates files, so this suite installs its own platform. Real node
-// fs is required because the prefill tests write and read files in os.tmpdir().
-beforeAll(async () => {
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(createFakePlatform({}, { fs: nodeFilesystem }));
-});
+// Real node fs is required because the prefill tests write and read files in
+// os.tmpdir().
+setupPlatform({}, { fs: nodeFilesystem });
 
 afterEach(() => {
   vi.restoreAllMocks();

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerApiKey.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerApiKey.vitest.ts
@@ -8,6 +8,7 @@ import {
 } from 'llm-zoo';
 
 // Local imports - handler under test
+import { installPlatform } from '@test/support/setupPlatform';
 import { ModelHandlerOpenRouterNative } from '@agent/modelHandlers/openrouter/modelHandlerOpenRouterNative';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import * as serverKeysModule from '@auth/serverKeys';
@@ -65,11 +66,7 @@ function stubServerSideKeyService(
 async function initFakePlatform(
   secrets: Record<string, string> = {},
 ): Promise<void> {
-  const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
-    import('@platform/platform'),
-    import('@test/support/FakePlatform'),
-  ]);
-  initPlatform(createFakePlatform({ secrets }));
+  await installPlatform({ secrets });
   invalidateApiKeyCache();
 }
 

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerGoogleGenAI.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerGoogleGenAI.vitest.ts
@@ -1,6 +1,6 @@
 // Third-party imports
 import { strict as assert } from 'node:assert';
-import { beforeAll, describe, it } from 'vitest';
+import { describe, it } from 'vitest';
 
 // Standard library imports
 
@@ -10,9 +10,6 @@ import {
   createPartFromText,
   createPartFromUri,
 } from '@google/genai';
-
-// Local imports - test support
-import { createFakePlatform } from '@test/support/FakePlatform';
 
 // Local imports - agent
 import {
@@ -41,13 +38,6 @@ import type {
   FunctionCall,
   Content,
 } from '@google/genai';
-
-// Vitest isolates files, so this suite installs its own platform
-// (pathToLocation resolves through platform workspace services).
-beforeAll(async () => {
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(createFakePlatform());
-});
 
 interface LoggerStub extends Partial<AgentTrace> {
   streamId: string;

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
@@ -3,7 +3,7 @@ import { strict as assert } from 'node:assert';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { beforeAll, describe, it } from 'vitest';
+import { describe, it } from 'vitest';
 
 // Third-party imports
 import {
@@ -17,7 +17,7 @@ import { OpenAIError } from 'openai';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 
 // Local imports - test support
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { setupPlatform } from '@test/support/setupPlatform';
 
 // Local imports - agent
 import type { AgentTrace } from '@agent/trace';
@@ -34,12 +34,9 @@ import { BackgroundPoller } from '@agent/modelHandlers/support/BackgroundPoller'
 import { pathToLocation } from '@utils/files';
 import type { ResponseInputItem } from 'openai/resources/responses/responses';
 
-// Vitest isolates files, so this suite installs its own platform
-// (pathToLocation and flexibleFS resolve through platform services).
-beforeAll(async () => {
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(createFakePlatform({}, { fs: nodeFilesystem }));
-});
+// pathToLocation and flexibleFS resolve through platform services, so this
+// suite needs the real node fs rather than the in-memory default.
+setupPlatform({}, { fs: nodeFilesystem });
 
 type LoggerStub = Partial<AgentTrace> & {
   streamId: string;

--- a/src/test-kernel/agent/modelHandlers/support/MediaAttachmentProcessor.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/support/MediaAttachmentProcessor.vitest.ts
@@ -15,7 +15,7 @@ import { PDFDocument, StandardFonts } from '@cantoo/pdf-lib';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 
 // Local imports - test support
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { setupPlatform } from '@test/support/setupPlatform';
 
 // Local imports - agent
 import { DEFAULT_MODEL_CAPABILITIES, type ModelCapabilities } from 'llm-zoo';
@@ -79,12 +79,10 @@ describe('MediaAttachmentProcessor', () => {
   const originalExists = absoluteFsAny.exists;
   const originalStat = absoluteFsAny.stat;
 
-  beforeAll(async () => {
-    // Vitest isolates files, so this suite installs its own platform.
-    // Real node fs is required because fixtures live in os.tmpdir().
-    const { initPlatform } = await import('@platform/platform');
-    initPlatform(createFakePlatform({}, { fs: nodeFilesystem }));
+  // Real node fs is required because fixtures live in os.tmpdir().
+  setupPlatform({}, { fs: nodeFilesystem });
 
+  beforeAll(() => {
     absoluteFsAny.exists = async (filePath: string) => {
       if (!path.isAbsolute(filePath)) {
         throw new Error(`Expected absolute path, received ${filePath}`);

--- a/src/test-kernel/agent/output/CompileCheck.vitest.ts
+++ b/src/test-kernel/agent/output/CompileCheck.vitest.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - agent
+import { installPlatform } from '@test/support/setupPlatform';
 import type { AgentTrace } from '@agent/trace';
 import { runCompileCheck } from '@agent/output/compileCheck';
 import { createOutputState, ensureRoundData } from '@agent/output/outputState';
@@ -86,22 +87,16 @@ function logger(): AgentTrace {
   } as unknown as AgentTrace;
 }
 
-async function initLatexPlatform(files: Record<string, string>): Promise<void> {
-  const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
-    import('@platform/platform'),
-    import('@test/support/FakePlatform'),
-  ]);
-  initPlatform(
-    createFakePlatform({
-      files,
-      storagePath,
-      workspacePath,
-      workspaceState: {
-        [WorkspaceStateKey.WORKFLOW_AUTO_COMPILE]: true,
-        [WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS]: 30_000,
-      },
-    }),
-  );
+function initLatexPlatform(files: Record<string, string>): Promise<void> {
+  return installPlatform({
+    files,
+    storagePath,
+    workspacePath,
+    workspaceState: {
+      [WorkspaceStateKey.WORKFLOW_AUTO_COMPILE]: true,
+      [WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS]: 30_000,
+    },
+  });
 }
 
 // Writes a fake LaTeX build log next to where `compileLatex2Pdf` was asked to

--- a/src/test-kernel/agent/output/CompiledPdfArtifacts.vitest.ts
+++ b/src/test-kernel/agent/output/CompiledPdfArtifacts.vitest.ts
@@ -7,6 +7,10 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 // Local imports - agent output
+
+// Local imports - platform
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { setupPlatform } from '@test/support/setupPlatform';
 import { publishCompiledPdfArtifact } from '@agent/output/compiledPdfArtifacts';
 
 // Local imports - file utilities
@@ -27,15 +31,7 @@ function readOutput(
 describe('compiled PDF artifacts', () => {
   const tempDirs: string[] = [];
 
-  beforeEach(async () => {
-    const [{ initPlatform }, { nodeFilesystem }, { createFakePlatform }] =
-      await Promise.all([
-        import('@platform/platform'),
-        import('@platform/defaults/nodeFilesystem'),
-        import('@test/support/FakePlatform'),
-      ]);
-    initPlatform(createFakePlatform({}, { fs: nodeFilesystem }));
-  });
+  setupPlatform({}, { fs: nodeFilesystem });
 
   async function makeTempDir(): Promise<string> {
     const dir = await mkdtemp(path.join(os.tmpdir(), 'texra-pdf-artifact-'));

--- a/src/test-kernel/agent/output/LatexCompileInputDirs.vitest.ts
+++ b/src/test-kernel/agent/output/LatexCompileInputDirs.vitest.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - agent
+import { installPlatform } from '@test/support/setupPlatform';
 import type { AgentTrace } from '@agent/trace';
 import {
   AgentCategory,
@@ -84,22 +85,16 @@ function logger(): AgentTrace {
   } as unknown as AgentTrace;
 }
 
-async function initLatexPlatform(files: Record<string, string>): Promise<void> {
-  const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
-    import('@platform/platform'),
-    import('@test/support/FakePlatform'),
-  ]);
-  initPlatform(
-    createFakePlatform({
-      files,
-      storagePath,
-      workspacePath,
-      workspaceState: {
-        [WorkspaceStateKey.WORKFLOW_AUTO_COMPILE]: true,
-        [WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS]: 30_000,
-      },
-    }),
-  );
+function initLatexPlatform(files: Record<string, string>): Promise<void> {
+  return installPlatform({
+    files,
+    storagePath,
+    workspacePath,
+    workspaceState: {
+      [WorkspaceStateKey.WORKFLOW_AUTO_COMPILE]: true,
+      [WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS]: 30_000,
+    },
+  });
 }
 
 describe('workflow LaTeX compile input directories', () => {

--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { installPlatform } from '@test/support/setupPlatform';
 import type { AgentTrace } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
@@ -22,12 +23,8 @@ vi.mock('@latex/texFormatter', () => ({
   runLatexFormatter: formatterMocks.runLatexFormatter,
 }));
 
-async function initFakePlatform(files: Record<string, string> = {}) {
-  const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
-    import('@platform/platform'),
-    import('@test/support/FakePlatform'),
-  ]);
-  initPlatform(createFakePlatform({ files, workspacePath: '/workspace' }));
+function initFakePlatform(files: Record<string, string> = {}) {
+  return installPlatform({ files, workspacePath: '/workspace' });
 }
 
 function createWorkflowAgentSetting(

--- a/src/test-kernel/agent/review/AgentReviewDiff.vitest.ts
+++ b/src/test-kernel/agent/review/AgentReviewDiff.vitest.ts
@@ -4,11 +4,11 @@ import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 
 // Third-party imports
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 // Local imports
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { setupPlatform } from '@test/support/setupPlatform';
 import {
   buildUntrackedFileDiff,
   collectReviewDiff,
@@ -17,15 +17,7 @@ import {
 } from '@agent/review/reviewDiff';
 import { executeCommand } from '@utils/system/execUtils';
 
-beforeAll(async () => {
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(
-    createFakePlatform(
-      { workspacePath: process.cwd() },
-      { fs: nodeFilesystem },
-    ),
-  );
-});
+setupPlatform({ workspacePath: process.cwd() }, { fs: nodeFilesystem });
 
 describe('isPathInChangeSet', () => {
   it('matches exact files and paths under changed directories', () => {

--- a/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
@@ -1,8 +1,7 @@
 // Third-party imports
-import { beforeAll, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 // Local imports
-import { createFakePlatform } from '@test/support/FakePlatform';
 import { noopTrace } from '@agent/trace';
 import {
   getAgentPath,
@@ -15,13 +14,6 @@ import { useRunContext } from '@agent/runtime/RunContext';
 import { createRecordingHost } from '../progressTestUtils';
 
 describe('AgentLaunchContext', () => {
-  // Launch resolution consults visibility state (getVisibleAgent), so a platform
-  // must be present even for the missing-agent path.
-  beforeAll(async () => {
-    const { initPlatform } = await import('@platform/platform');
-    initPlatform(createFakePlatform({}));
-  });
-
   it('publishes missing-agent banners through the explicit runtime host', async () => {
     const explicit = createRecordingHost();
 

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -7,6 +7,8 @@ import {
   clearStreamStatusForTest,
   seedStreamStatusForTest,
 } from '@test/helpers/streamStatusTestUtils';
+import { platform } from '@platform/platform';
+import { installPlatform } from '@test/support/setupPlatform';
 import { noopTrace } from '@agent/trace';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import {
@@ -52,17 +54,12 @@ vi.mock('@agent/storage', () => ({
 }));
 
 async function initLifecycleTestPlatform(firstRunDone: boolean) {
-  const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
-    import('@platform/platform'),
-    import('@test/support/FakePlatform'),
-  ]);
-  const fake = createFakePlatform({
+  await installPlatform({
     globalState: {
       [GlobalStateKey.ONBOARDING_FIRST_RUN_DONE]: firstRunDone,
     },
   });
-  initPlatform(fake);
-  return fake;
+  return platform();
 }
 
 function createLifecycleContext({

--- a/src/test-kernel/agent/runtime/ProcessOutputPoller.vitest.ts
+++ b/src/test-kernel/agent/runtime/ProcessOutputPoller.vitest.ts
@@ -7,6 +7,8 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - runtime
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { setupPlatform } from '@test/support/setupPlatform';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { ProcessExecutionHandle } from '@agent/runtime/ExecutionHandle';
 import { ProcessOutputPoller } from '@agent/runtime/ProcessOutputPoller';
@@ -86,15 +88,10 @@ afterEach(async () => {
 });
 
 describe('ProcessOutputPoller', () => {
-  beforeEach(async () => {
+  setupPlatform({}, { fs: nodeFilesystem });
+
+  beforeEach(() => {
     poller = new ProcessOutputPoller();
-    const [{ initPlatform }, { nodeFilesystem }, { createFakePlatform }] =
-      await Promise.all([
-        import('@platform/platform'),
-        import('@platform/defaults/nodeFilesystem'),
-        import('@test/support/FakePlatform'),
-      ]);
-    initPlatform(createFakePlatform({}, { fs: nodeFilesystem }));
   });
 
   it('flushes only new process output bytes', async () => {

--- a/src/test-kernel/agent/runtime/SessionIsolation.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionIsolation.vitest.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - runtime
 import { clearStreamStatusForTest } from '@test/helpers/streamStatusTestUtils';
+import { installPlatform } from '@test/support/setupPlatform';
 import { noopTrace } from '@agent/trace';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import {
@@ -43,16 +44,10 @@ vi.mock('@agent/storage', () => ({
   writeTerminalStatus: storageMocks.writeTerminalStatus,
 }));
 
-async function initTestPlatform() {
-  const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
-    import('@platform/platform'),
-    import('@test/support/FakePlatform'),
-  ]);
-  initPlatform(
-    createFakePlatform({
-      globalState: { [GlobalStateKey.ONBOARDING_FIRST_RUN_DONE]: true },
-    }),
-  );
+function initTestPlatform(): Promise<void> {
+  return installPlatform({
+    globalState: { [GlobalStateKey.ONBOARDING_FIRST_RUN_DONE]: true },
+  });
 }
 
 function createLifecycleContext(

--- a/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
@@ -1,9 +1,10 @@
 // Third-party imports
 import { ModelProvider } from 'llm-zoo';
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import { clearStreamStatusForTest } from '@test/helpers/streamStatusTestUtils';
+import { setupPlatform } from '@test/support/setupPlatform';
 import { TraceEmitter, type ResultEvent } from '@agent/trace';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import {
@@ -134,16 +135,8 @@ function setupResultCase(): {
 }
 
 describe('terminal result event (SDK Step 7d PR 6)', () => {
-  beforeAll(async () => {
-    const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
-      import('@platform/platform'),
-      import('@test/support/FakePlatform'),
-    ]);
-    initPlatform(
-      createFakePlatform({
-        globalState: { [GlobalStateKey.ONBOARDING_FIRST_RUN_DONE]: true },
-      }),
-    );
+  setupPlatform({
+    globalState: { [GlobalStateKey.ONBOARDING_FIRST_RUN_DONE]: true },
   });
 
   it('emits exactly one completed result on a successful run', async () => {

--- a/src/test-kernel/agent/runtime/UsageMonitorLastTotals.vitest.ts
+++ b/src/test-kernel/agent/runtime/UsageMonitorLastTotals.vitest.ts
@@ -1,6 +1,6 @@
 // Third-party imports
 import { ModelProvider } from 'llm-zoo';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 // Local imports
 import { TraceEmitter } from '@agent/trace';
@@ -60,14 +60,6 @@ function createMonitorWithEvents() {
 }
 
 describe('UsageMonitor.lastTotals (SDK Step 7d PR 5)', () => {
-  beforeAll(async () => {
-    const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
-      import('@platform/platform'),
-      import('@test/support/FakePlatform'),
-    ]);
-    initPlatform(createFakePlatform());
-  });
-
   it('is undefined before any round and caches the totals after recordUsage', async () => {
     const { dispose, monitor } = createMonitorWithEvents();
     try {

--- a/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { setupPlatform } from '@test/support/setupPlatform';
 import { clearStoreCache, getExecutionStore } from '@agent/storage';
 import {
   EXECUTION_STATUS,
@@ -9,9 +9,9 @@ import {
   type RunOutcome,
 } from '@shared/schemas';
 
-beforeEach(async () => {
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(createFakePlatform({ workspacePath: '/workspace' }));
+setupPlatform({ workspacePath: '/workspace' });
+
+beforeEach(() => {
   clearStoreCache();
 });
 

--- a/src/test-kernel/agent/utils/debugMessageSaver.vitest.ts
+++ b/src/test-kernel/agent/utils/debugMessageSaver.vitest.ts
@@ -1,27 +1,22 @@
 // Third-party imports
 import { strict as assert } from 'node:assert';
 import * as path from 'node:path';
-import { describe, it, beforeAll, beforeEach, afterEach } from 'vitest';
+import { describe, it, beforeEach, afterEach } from 'vitest';
 
 // Standard library imports
 
 // Local imports - agent
 // Internal imports
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { setupPlatform } from '@test/support/setupPlatform';
 import { RUNS_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
 import type { ExecutionId } from '@shared/schemas';
 import { WorkspaceFS, StorageFS } from '@utils/files';
 
-beforeAll(async () => {
-  // getConfig reads through the platform config provider; enable the
-  // debug-object saving flag there instead of patching the ESM export.
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(
-    createFakePlatform({
-      config: { 'texra.debug.saveDebugObjects': true },
-    }),
-  );
+// getConfig reads through the platform config provider; enable the
+// debug-object saving flag there instead of patching the ESM export.
+setupPlatform({
+  config: { 'texra.debug.saveDebugObjects': true },
 });
 
 describe('maybeSaveDebugObject', () => {

--- a/src/test-kernel/agent/utils/userVars.vitest.ts
+++ b/src/test-kernel/agent/utils/userVars.vitest.ts
@@ -1,14 +1,12 @@
 // Third-party imports
 import { strict as assert } from 'node:assert';
-import { beforeAll, describe, it } from 'vitest';
+import { describe, it } from 'vitest';
 
 // Standard library imports
 
 // Local imports - agent components
-import {
-  createFakePlatform,
-  FakeConfigProvider,
-} from '@test/support/FakePlatform';
+import { FakeConfigProvider } from '@test/support/FakePlatform';
+import { setupPlatform } from '@test/support/setupPlatform';
 import {
   AgentConfigSchema,
   type AgentConfig,
@@ -26,10 +24,7 @@ import { buildUserVars, getToolFlags } from '@agent/utils/userVars';
 // via this provider instead of patching the ESM export.
 const fakeConfig = new FakeConfigProvider();
 
-beforeAll(async () => {
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(createFakePlatform({}, { config: fakeConfig }));
-});
+setupPlatform({}, { config: fakeConfig });
 
 const baseSetting: AgentSetting = {
   agentCategory: AgentCategory.Workflow,

--- a/src/test-kernel/auth/CodexPreference.vitest.ts
+++ b/src/test-kernel/auth/CodexPreference.vitest.ts
@@ -2,9 +2,10 @@
 import { describe, expect, it } from 'vitest';
 
 // Local imports - test support
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { installPlatform } from '@test/support/setupPlatform';
 
 // Local imports - auth
+import { platform } from '@platform/platform';
 import {
   CODEX_PREFER_SUBSCRIPTION_KEY,
   isPreferCodexSubscription,
@@ -18,13 +19,6 @@ import type {
   ConfigTarget,
 } from '@platform/interfaces/config';
 import type { Disposable } from '@platform/interfaces/disposable';
-
-async function initTestPlatform(
-  platform: ReturnType<typeof createFakePlatform>,
-): Promise<void> {
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(platform);
-}
 
 class FolderOverrideConfigProvider implements ConfigProvider {
   private readonly globalValues = new Map<string, unknown>();
@@ -76,17 +70,16 @@ class FolderOverrideConfigProvider implements ConfigProvider {
 
 describe('Codex subscription preference', () => {
   it('writes workspace preference when workspace config already controls it', async () => {
-    const platform = createFakePlatform({
+    await installPlatform({
       config: { [CODEX_PREFER_SUBSCRIPTION_KEY]: false },
     });
-    await initTestPlatform(platform);
 
     const update = await setPreferCodexSubscription(true);
 
     expect(update).toEqual({ effective: true, target: 'workspace' });
     expect(isPreferCodexSubscription()).toBe(true);
     expect(
-      platform.config.inspect(CODEX_PREFER_SUBSCRIPTION_KEY),
+      platform().config.inspect(CODEX_PREFER_SUBSCRIPTION_KEY),
     ).toMatchObject({
       workspaceValue: true,
       effectiveValue: true,
@@ -95,7 +88,7 @@ describe('Codex subscription preference', () => {
 
   it('does not treat folder overrides as writable workspace config', async () => {
     const config = new FolderOverrideConfigProvider(false);
-    await initTestPlatform(createFakePlatform({}, { config }));
+    await installPlatform({}, { config });
 
     const update = await setPreferCodexSubscription(true);
 

--- a/src/test-kernel/cli/HistoryStatus.vitest.ts
+++ b/src/test-kernel/cli/HistoryStatus.vitest.ts
@@ -1,6 +1,6 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { setupPlatform } from '@test/support/setupPlatform';
 import { registerExecution, getExecutionStore } from '@agent/storage';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
@@ -34,10 +34,7 @@ const TOOL_USE_CONFIG: AgentConfig = {
   cliMultiAgentPresetId: null,
 };
 
-beforeEach(async () => {
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(createFakePlatform({ workspacePath: '/workspace' }));
-});
+setupPlatform({ workspacePath: '/workspace' });
 
 describe('CLI history status formatting', () => {
   it('keeps failed terminal statuses authoritative', () => {

--- a/src/test-kernel/controllers/ProgressWorkflowFileActionsHostFlows.vitest.ts
+++ b/src/test-kernel/controllers/ProgressWorkflowFileActionsHostFlows.vitest.ts
@@ -1,6 +1,6 @@
 // Third-party imports
 import { strict as assert } from 'node:assert';
-import { beforeAll, describe, it } from 'vitest';
+import { describe, it } from 'vitest';
 
 // Standard library imports
 
@@ -9,16 +9,6 @@ import {
   ProgressWorkflowFileActionsController,
   type ProgressWorkflowFileActionsControllerDeps,
 } from '@controllers/progressView/ProgressWorkflowFileActionsController';
-
-// Local imports - test support
-import { createFakePlatform } from '@test/support/FakePlatform';
-
-beforeAll(async () => {
-  // openTaskStorage resolves the run-storage path through the platform
-  // before handing it to the host opener.
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(createFakePlatform());
-});
 
 type LogEntry = { message: string; error: unknown };
 

--- a/src/test-kernel/desktop/desktopSettingsIpc.vitest.ts
+++ b/src/test-kernel/desktop/desktopSettingsIpc.vitest.ts
@@ -4,7 +4,7 @@ import { setImmediate } from 'node:timers/promises';
 import { afterEach, describe, it, vi } from 'vitest';
 
 // Local imports - tests
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { installPlatform } from '@test/support/setupPlatform';
 
 // Local imports - auth
 import * as serverKeysModule from '@auth/serverKeys';
@@ -69,12 +69,9 @@ async function createSettingsIpc(options: {
   infos: string[];
   onApiKeyChanged?: () => Promise<void>;
 }) {
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(
-    createFakePlatform(
-      { workspacePath: '/workspace' },
-      { secrets: options.secrets },
-    ),
+  await installPlatform(
+    { workspacePath: '/workspace' },
+    { secrets: options.secrets },
   );
   vi.spyOn(serverKeysModule, 'getServerSideKeyService').mockReturnValue({
     canUseServerSideKeys: async () => false,

--- a/src/test-kernel/latex/LatexProcessingHelpers.vitest.ts
+++ b/src/test-kernel/latex/LatexProcessingHelpers.vitest.ts
@@ -10,7 +10,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 
 // Local imports - test support
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { installPlatform as installFakePlatform } from '@test/support/setupPlatform';
 
 // Local imports - agent
 import type { AgentTrace } from '@agent/trace';
@@ -58,10 +58,10 @@ async function makeTempDir(): Promise<string> {
   return tempDir;
 }
 
-async function installPlatform(workspaceDir: string): Promise<void> {
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(
-    createFakePlatform({ workspacePath: workspaceDir }, { fs: nodeFilesystem }),
+function installPlatform(workspaceDir: string): Promise<void> {
+  return installFakePlatform(
+    { workspacePath: workspaceDir },
+    { fs: nodeFilesystem },
   );
 }
 

--- a/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
+++ b/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
@@ -8,7 +8,7 @@ import { MemoryStateStore } from '@platform/defaults/memoryState';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { installPlatform } from '@test/support/setupPlatform';
 import {
   createExternalLocation,
   createWorkspaceLocation,
@@ -37,24 +37,21 @@ describe('LaTeXdiffService shadow output', () => {
     return tempDir;
   }
 
-  async function installNodeBackedPlatform(
+  function installNodeBackedPlatform(
     workspaceDir: string,
     storageRoot: string,
   ): Promise<void> {
-    const { initPlatform } = await import('@platform/platform');
-    initPlatform(
-      createFakePlatform(
-        {
-          workspacePath: workspaceDir,
-        },
-        {
-          fs: nodeFilesystem,
-          workspace: createNodeWorkspace(() => workspaceDir),
-          storage: new WorkspaceStorageProvider(storageRoot, workspaceDir),
-          globalState: new MemoryStateStore(),
-          workspaceState: new MemoryStateStore(),
-        },
-      ),
+    return installPlatform(
+      {
+        workspacePath: workspaceDir,
+      },
+      {
+        fs: nodeFilesystem,
+        workspace: createNodeWorkspace(() => workspaceDir),
+        storage: new WorkspaceStorageProvider(storageRoot, workspaceDir),
+        globalState: new MemoryStateStore(),
+        workspaceState: new MemoryStateStore(),
+      },
     );
   }
 

--- a/src/test-kernel/latex/TikzPictureManager.vitest.ts
+++ b/src/test-kernel/latex/TikzPictureManager.vitest.ts
@@ -3,7 +3,7 @@ import * as assert from 'node:assert';
 import { describe, it } from 'vitest';
 
 // Local imports - tests
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { installPlatform as installFakePlatform } from '@test/support/setupPlatform';
 
 // Local imports - latex
 import { tikzPictureManager } from '@latex/TikzPictureManager';
@@ -11,9 +11,8 @@ import { tikzPictureManager } from '@latex/TikzPictureManager';
 // Local imports - utils
 import { pathToLocation } from '@utils/files';
 
-async function installPlatform(files: Record<string, string>) {
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(createFakePlatform({ workspacePath: '/workspace', files }));
+function installPlatform(files: Record<string, string>) {
+  return installFakePlatform({ workspacePath: '/workspace', files });
 }
 
 describe('TikzPictureManager', () => {

--- a/src/test-kernel/model/ComputeModelOptions.vitest.ts
+++ b/src/test-kernel/model/ComputeModelOptions.vitest.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { installPlatform, setupPlatform } from '@test/support/setupPlatform';
 import {
   ServerSideKeyService,
   setServerSideKeyService,
@@ -84,38 +84,32 @@ function codexSession(): CodexSession {
   };
 }
 
-async function initSubscriptionPlatform(
+function initSubscriptionPlatform(
   secrets: Record<string, string> = {},
 ): Promise<void> {
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(
-    createFakePlatform({
-      config: {
-        'texra.chatgptCodex.preferSubscription': true,
-        'texra.chatgptCodex.subscriptionToolUseOnly': true,
-      },
-      globalState: { [GlobalStateKey.ENABLED_MODELS]: ['gpt55'] },
-      secrets,
-    }),
-  );
+  return installPlatform({
+    config: {
+      'texra.chatgptCodex.preferSubscription': true,
+      'texra.chatgptCodex.subscriptionToolUseOnly': true,
+    },
+    globalState: { [GlobalStateKey.ENABLED_MODELS]: ['gpt55'] },
+    secrets,
+  });
 }
 
 describe('computeModelOptionsData relay quota state', () => {
-  beforeEach(async () => {
+  setupPlatform({
+    globalState: { [GlobalStateKey.ENABLED_MODELS]: ['gpt55'] },
+    secrets: {
+      [apiKeySecretName('openai')]: 'sk-openai',
+      [apiKeySecretName('deepseek')]: 'sk-deepseek',
+    },
+  });
+
+  beforeEach(() => {
     invalidateApiKeyCache();
     invalidateModelOptionsCache();
     resetCodexCoordinator();
-
-    const { initPlatform } = await import('@platform/platform');
-    initPlatform(
-      createFakePlatform({
-        globalState: { [GlobalStateKey.ENABLED_MODELS]: ['gpt55'] },
-        secrets: {
-          [apiKeySecretName('openai')]: 'sk-openai',
-          [apiKeySecretName('deepseek')]: 'sk-deepseek',
-        },
-      }),
-    );
   });
 
   it('shows relay quota exhaustion while included access remains selected', async () => {
@@ -223,18 +217,15 @@ describe('computeModelOptionsData relay quota state', () => {
   });
 
   it('shows subscription access before relay state when ChatGPT subscription is preferred and signed in', async () => {
-    const { initPlatform } = await import('@platform/platform');
-    initPlatform(
-      createFakePlatform({
-        config: {
-          'texra.chatgptCodex.preferSubscription': true,
-        },
-        globalState: { [GlobalStateKey.ENABLED_MODELS]: ['gpt55'] },
-        secrets: {
-          [CODEX_SESSION_SECRET_KEY]: JSON.stringify(codexSession()),
-        },
-      }),
-    );
+    await installPlatform({
+      config: {
+        'texra.chatgptCodex.preferSubscription': true,
+      },
+      globalState: { [GlobalStateKey.ENABLED_MODELS]: ['gpt55'] },
+      secrets: {
+        [CODEX_SESSION_SECRET_KEY]: JSON.stringify(codexSession()),
+      },
+    });
     const access = createModelOptionsAccess({
       useIncludedAccess: true,
       canUseServerSideKeys: true,

--- a/src/test-kernel/support/setupFakePlatform.ts
+++ b/src/test-kernel/support/setupFakePlatform.ts
@@ -1,7 +1,5 @@
-const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
-  import('@platform/platform'),
-  import('./FakePlatform'),
-]);
-initPlatform(createFakePlatform());
+import { installPlatform } from './setupPlatform';
+
+await installPlatform();
 
 export {};

--- a/src/test-kernel/support/setupPlatform.ts
+++ b/src/test-kernel/support/setupPlatform.ts
@@ -1,0 +1,62 @@
+/**
+ * Standardized per-suite fake platform override.
+ *
+ * `vitest.config.mjs` installs a default `createFakePlatform()` before every
+ * test file (see `setupFakePlatform.ts`), so most suites need nothing else.
+ * Suites that need custom options/overrides (a seeded workspace, a real
+ * `nodeFilesystem`, stubbed secrets, etc.) should call `setupPlatform(...)`
+ * once — at module scope or inside a `describe` — instead of hand-wiring
+ * `initPlatform(createFakePlatform(...))` in a `beforeAll`/`beforeEach`. It
+ * installs the requested platform before each test in the current suite and
+ * restores the suite-default fake platform afterward, so overrides never
+ * leak into later tests in the same file.
+ */
+import { afterEach, beforeEach } from 'vitest';
+
+import { createFakePlatform, type FakePlatformOptions } from './FakePlatform';
+import type { Platform } from '@platform/platform';
+
+type PlatformBuilder = () => Platform | Promise<Platform>;
+
+/**
+ * Installs a fake platform right now. `initPlatform` is restricted to
+ * composition roots by lint, so this is the one place test helpers reach for
+ * it dynamically — suites needing an ad hoc, one-off platform install
+ * (rather than the standard per-test `setupPlatform` wiring below) should
+ * call this instead of hand-rolling the dynamic import.
+ */
+export async function installPlatform(
+  options: FakePlatformOptions = {},
+  overrides: Partial<Platform> = {},
+): Promise<void> {
+  const { initPlatform } = await import('@platform/platform');
+  initPlatform(createFakePlatform(options, overrides));
+}
+
+/**
+ * Installs a fake platform for every test in the current suite.
+ *
+ * Pass `FakePlatformOptions`/`Partial<Platform>` overrides for the common
+ * case — a fresh `createFakePlatform(options, overrides)` is built for every
+ * test. Pass a builder function instead when the platform must be computed
+ * per test (a real `nodeFilesystem`, a per-test temp dir, captured state from
+ * an earlier step, etc.).
+ */
+export function setupPlatform(
+  optionsOrBuilder: FakePlatformOptions | PlatformBuilder = {},
+  overrides: Partial<Platform> = {},
+): void {
+  const buildPlatform: PlatformBuilder =
+    typeof optionsOrBuilder === 'function'
+      ? optionsOrBuilder
+      : () => createFakePlatform(optionsOrBuilder, overrides);
+
+  beforeEach(async () => {
+    const { initPlatform } = await import('@platform/platform');
+    initPlatform(await buildPlatform());
+  });
+
+  afterEach(async () => {
+    await installPlatform();
+  });
+}

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -1,9 +1,9 @@
 // Third-party imports
 import { strict as assert } from 'node:assert';
-import { describe, it, beforeAll, afterEach, vi } from 'vitest';
+import { describe, it, afterEach, vi } from 'vitest';
 
 // Local imports - tests
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { setupPlatform } from '@test/support/setupPlatform';
 
 // Local imports - agent core
 import {
@@ -195,15 +195,10 @@ function freshRoundShared(messages: ProviderMessage[]): ToolUseRoundShared {
 }
 
 describe('BashTool', () => {
-  beforeAll(async () => {
-    const { initPlatform } = await import('@platform/platform');
-    initPlatform(
-      createFakePlatform({
-        workspacePath: '/workspace',
-        // Unit tests exercise the tool directly — no approval host is wired.
-        config: { 'texra.toolUse.requireBashApproval': false },
-      }),
-    );
+  setupPlatform({
+    workspacePath: '/workspace',
+    // Unit tests exercise the tool directly — no approval host is wired.
+    config: { 'texra.toolUse.requireBashApproval': false },
   });
 
   afterEach(() => {

--- a/src/test-kernel/tools/ConcurrentToolEditApprovalHandlers.vitest.ts
+++ b/src/test-kernel/tools/ConcurrentToolEditApprovalHandlers.vitest.ts
@@ -3,7 +3,7 @@ import * as assert from 'node:assert';
 import { describe, it, beforeEach, afterEach } from 'vitest';
 
 // Local imports - tests
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { setupPlatform } from '@test/support/setupPlatform';
 
 // Local imports - agent types
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
@@ -28,21 +28,19 @@ import {
  * stole the first window's in-flight prompt.
  */
 describe('Concurrent per-run tool edit approval handlers', () => {
-  beforeEach(async () => {
-    const { initPlatform } = await import('@platform/platform');
-    initPlatform(
-      createFakePlatform(
-        { workspacePath: '/workspace', config: {}, files: {} },
-        {
-          toolEditApproval: () => {
-            throw new Error(
-              'platform().toolEditApproval should not be reached when the ' +
-                'RunContext supplies its own toolEditApprovalHandler',
-            );
-          },
-        },
-      ),
-    );
+  setupPlatform(
+    { workspacePath: '/workspace', config: {}, files: {} },
+    {
+      toolEditApproval: () => {
+        throw new Error(
+          'platform().toolEditApproval should not be reached when the ' +
+            'RunContext supplies its own toolEditApprovalHandler',
+        );
+      },
+    },
+  );
+
+  beforeEach(() => {
     cleanupAllApprovals();
   });
 

--- a/src/test-kernel/tools/DiagnosticsTool.vitest.ts
+++ b/src/test-kernel/tools/DiagnosticsTool.vitest.ts
@@ -3,15 +3,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { DiagnosticsTool } from '@tools/DiagnosticsTool';
 import type { GenericDiagnostic } from '@utils/diagnostics/diagnosticFormatting';
-import { createFakePlatform } from '../support/FakePlatform';
+import { installPlatform } from '../support/setupPlatform';
 import type { AddCriticismSink } from '@platform/interfaces/criticism';
-
-async function installPlatform(
-  overrides: Parameters<typeof createFakePlatform>[1] = {},
-): Promise<void> {
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(createFakePlatform({}, overrides));
-}
 
 afterEach(async () => {
   await installPlatform();
@@ -20,13 +13,13 @@ afterEach(async () => {
 function installLinter(
   linter: (path: string) => Promise<GenericDiagnostic[]>,
 ): Promise<void> {
-  return installPlatform({ linter });
+  return installPlatform({}, { linter });
 }
 
 function installAddCriticismSink(
   addCriticismSink: AddCriticismSink,
 ): Promise<void> {
-  return installPlatform({ addCriticismSink });
+  return installPlatform({}, { addCriticismSink });
 }
 
 function worktreeContext() {

--- a/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
@@ -4,6 +4,8 @@ import * as path from 'node:path';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { setupPlatform } from '@test/support/setupPlatform';
 import { seedStreamStatusForTest } from '@test/helpers/streamStatusTestUtils';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
@@ -70,14 +72,9 @@ async function withTempWorkspace(
 }
 
 describe('ExecutionsTool', () => {
-  beforeEach(async () => {
-    const [{ initPlatform }, { nodeFilesystem }, { createFakePlatform }] =
-      await Promise.all([
-        import('@platform/platform'),
-        import('@platform/defaults/nodeFilesystem'),
-        import('@test/support/FakePlatform'),
-      ]);
-    initPlatform(createFakePlatform({}, { fs: nodeFilesystem }));
+  setupPlatform({}, { fs: nodeFilesystem });
+
+  beforeEach(() => {
     vi.clearAllMocks();
     mocks.listExecutions.mockResolvedValue([]);
     mocks.readMeta.mockResolvedValue(null);

--- a/src/test-kernel/tools/GitHubAuth.vitest.ts
+++ b/src/test-kernel/tools/GitHubAuth.vitest.ts
@@ -1,6 +1,8 @@
 // Third-party imports
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { installPlatform } from '@test/support/setupPlatform';
+
 const originalGitHubToken = process.env.GITHUB_TOKEN;
 const originalGhToken = process.env.GH_TOKEN;
 
@@ -63,20 +65,13 @@ describe('getGitHubToken', () => {
     process.env.GITHUB_TOKEN = 'github-env-token';
     process.env.GH_TOKEN = 'gh-env-token';
 
-    const [{ initPlatform }, { createFakePlatform }, githubAuth] =
-      await Promise.all([
-        import('@platform/platform'),
-        import('@test/support/FakePlatform'),
-        import('@tools/github/githubAuth'),
-      ]);
+    const githubAuth = await import('@tools/github/githubAuth');
 
-    initPlatform(
-      createFakePlatform({
-        secrets: {
-          [githubAuth.GITHUB_TOKEN_STORAGE_KEY]: 'gh-secret-token',
-        },
-      }),
-    );
+    await installPlatform({
+      secrets: {
+        [githubAuth.GITHUB_TOKEN_STORAGE_KEY]: 'gh-secret-token',
+      },
+    });
 
     await expect(githubAuth.getGitHubToken()).resolves.toBe('gh-secret-token');
   });
@@ -84,20 +79,13 @@ describe('getGitHubToken', () => {
   it('ignores blank platform secrets before using environment fallbacks', async () => {
     process.env.GH_TOKEN = 'gh-env-token';
 
-    const [{ initPlatform }, { createFakePlatform }, githubAuth] =
-      await Promise.all([
-        import('@platform/platform'),
-        import('@test/support/FakePlatform'),
-        import('@tools/github/githubAuth'),
-      ]);
+    const githubAuth = await import('@tools/github/githubAuth');
 
-    initPlatform(
-      createFakePlatform({
-        secrets: {
-          [githubAuth.GITHUB_TOKEN_STORAGE_KEY]: '   ',
-        },
-      }),
-    );
+    await installPlatform({
+      secrets: {
+        [githubAuth.GITHUB_TOKEN_STORAGE_KEY]: '   ',
+      },
+    });
 
     await expect(githubAuth.getGitHubToken()).resolves.toBe('gh-env-token');
   });

--- a/src/test-kernel/tools/GoalForget.vitest.ts
+++ b/src/test-kernel/tools/GoalForget.vitest.ts
@@ -1,6 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { setupPlatform } from '@test/support/setupPlatform';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { GoalStore } from '@tools/goal';
 
@@ -8,10 +8,7 @@ const STREAM_A = 'stream:forget-a' as StreamTabId;
 const STREAM_B = 'stream:forget-b' as StreamTabId;
 
 describe('GoalStore.forget (abandon-on-delete contract)', () => {
-  beforeEach(async () => {
-    const { initPlatform } = await import('@platform/platform');
-    initPlatform(createFakePlatform({}));
-  });
+  setupPlatform();
 
   afterEach(async () => {
     await GoalStore.forget(STREAM_A);

--- a/src/test-kernel/tools/GoalLegacyMigration.vitest.ts
+++ b/src/test-kernel/tools/GoalLegacyMigration.vitest.ts
@@ -1,17 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
 import { platform } from '@platform/platform';
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { installPlatform } from '@test/support/setupPlatform';
 import type { StreamTabId } from '@shared/schemas';
 import { GoalStore } from '@tools/goal';
 
 const STREAM_ID = 'stream:legacy-goal' as StreamTabId;
 const NOW = '2026-06-09T00:00:00.000Z';
-
-async function installPlatform(workspaceState: Record<string, unknown>) {
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(createFakePlatform({ workspaceState }));
-}
 
 function legacyOdyssey(status: 'active' | 'paused' | 'complete' | 'abandoned') {
   return {
@@ -32,8 +27,10 @@ function legacyOdyssey(status: 'active' | 'paused' | 'complete' | 'abandoned') {
 describe('GoalStore legacy Odyssey migration', () => {
   it('reads active legacy Odyssey records as live goals', async () => {
     await installPlatform({
-      [`odysseys:byStream:${STREAM_ID}`]: legacyOdyssey('active'),
-      'odysseys:index': [STREAM_ID],
+      workspaceState: {
+        [`odysseys:byStream:${STREAM_ID}`]: legacyOdyssey('active'),
+        'odysseys:index': [STREAM_ID],
+      },
     });
 
     const goal = GoalStore.getForStream(STREAM_ID);
@@ -49,8 +46,10 @@ describe('GoalStore legacy Odyssey migration', () => {
 
   it('drops terminal legacy Odyssey records from the live goal surface', async () => {
     await installPlatform({
-      [`odysseys:byStream:${STREAM_ID}`]: legacyOdyssey('complete'),
-      'odysseys:index': [STREAM_ID],
+      workspaceState: {
+        [`odysseys:byStream:${STREAM_ID}`]: legacyOdyssey('complete'),
+        'odysseys:index': [STREAM_ID],
+      },
     });
 
     expect(GoalStore.getForStream(STREAM_ID)).toBeNull();

--- a/src/test-kernel/tools/GoalStoreConcurrency.vitest.ts
+++ b/src/test-kernel/tools/GoalStoreConcurrency.vitest.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { installPlatform } from '@test/support/setupPlatform';
 import type { StreamTabId } from '@shared/schemas';
 import { GoalStore } from '@tools/goal';
 import type { StateStore } from '@platform/interfaces/state';
@@ -70,9 +70,8 @@ class BlockingFirstIndexWriteState implements StateStore {
 
 describe('GoalStore index concurrency', () => {
   it('keeps both entries when concurrent start() calls overlap during the index write', async () => {
-    const { initPlatform } = await import('@platform/platform');
     const state = new BlockingFirstIndexWriteState();
-    initPlatform(createFakePlatform({}, { workspaceState: state }));
+    await installPlatform({}, { workspaceState: state });
 
     const firstStart = GoalStore.start(STREAM_A, 'objective a');
     await state.waitForBlockedIndexWrite();

--- a/src/test-kernel/tools/InquiryReadBoundary.vitest.ts
+++ b/src/test-kernel/tools/InquiryReadBoundary.vitest.ts
@@ -16,6 +16,7 @@ vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
   wakeQueuedFollowUpStream: wakeQueuedFollowUpStreamMock,
 }));
 
+import { setupPlatform } from '@test/support/setupPlatform';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import {
   type ExternalInquiryPermission,
@@ -24,8 +25,6 @@ import {
 } from '@shared/schemas';
 import { ExternalInquiryTool } from '@tools/inquiry/ExternalInquiryTool';
 import { injectContinuationForAnsweredThread } from '@tools/inquiry/inquiryContinuation';
-
-import { createFakePlatform } from '../support/FakePlatform';
 
 const THREAD = 'ei_aabbccdd0011' as ExternalInquiryThreadId;
 const OPEN_THREAD = 'ei_aabbccdd0022' as ExternalInquiryThreadId;
@@ -139,9 +138,12 @@ function createProgressProviderShell(): {
 }
 
 describe('external inquiry read boundary', () => {
-  beforeEach(async () => {
-    const { initPlatform } = await import('@platform/platform');
-    initPlatform(createFakePlatform());
+  // Tests seed threads against a fresh platform: state must not leak between
+  // tests in this file, so this installs (and resets) per test rather than
+  // once for the whole file.
+  setupPlatform();
+
+  beforeEach(() => {
     sendFollowUpMock.mockClear();
     wakeQueuedFollowUpStreamMock.mockClear();
   });

--- a/src/test-kernel/tools/InquiryStorage.vitest.ts
+++ b/src/test-kernel/tools/InquiryStorage.vitest.ts
@@ -3,9 +3,9 @@
  * dropped path, follow-up turn semantics, legacy manifest migration,
  * and listing filters.
  */
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { setupPlatform } from '@test/support/setupPlatform';
 import {
   ExternalInquiryPermissionSchema,
   type StreamTabId,
@@ -28,10 +28,10 @@ const STREAM_A = 'stream:a' as StreamTabId;
 const STREAM_B = 'stream:b' as StreamTabId;
 
 describe('InquiryStorage', () => {
-  beforeEach(async () => {
-    const { initPlatform } = await import('@platform/platform');
-    initPlatform(createFakePlatform());
-  });
+  // Each test seeds threads against a fresh platform: state must not leak
+  // between tests in this file, so this installs (and resets) per test
+  // rather than once for the whole file.
+  setupPlatform();
 
   it('opens, answers, and resolves a thread end-to-end', async () => {
     const opened = await recordOpenQuestion({

--- a/src/test-kernel/tools/OpenPdfTool.vitest.ts
+++ b/src/test-kernel/tools/OpenPdfTool.vitest.ts
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - tests
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { setupPlatform } from '@test/support/setupPlatform';
 
 // Local imports - runtime
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
@@ -16,20 +16,19 @@ import {
 } from '@tools/OpenPdfTool';
 
 describe('OpenPdfTool', () => {
-  beforeEach(async () => {
-    await installPlatform(
-      createFakePlatform({
-        workspacePath: '/workspace',
-        storagePath: '/storage',
-        files: {
-          '/workspace/paper.pdf': '%PDF-1.4\n',
-          '/workspace/figures/result.pdf': '%PDF-1.4\n',
-          '/run/paper.pdf': '%PDF-1.4\n',
-          '/storage/executions/run-1/output.pdf': '%PDF-1.4\n',
-          '/workspace/paper.tex': '\\documentclass{article}',
-        },
-      }),
-    );
+  setupPlatform({
+    workspacePath: '/workspace',
+    storagePath: '/storage',
+    files: {
+      '/workspace/paper.pdf': '%PDF-1.4\n',
+      '/workspace/figures/result.pdf': '%PDF-1.4\n',
+      '/run/paper.pdf': '%PDF-1.4\n',
+      '/storage/executions/run-1/output.pdf': '%PDF-1.4\n',
+      '/workspace/paper.tex': '\\documentclass{article}',
+    },
+  });
+
+  beforeEach(() => {
     setOpenPdfOpener(undefined);
   });
 
@@ -160,13 +159,6 @@ describe('OpenPdfTool', () => {
     expect(openPdf).not.toHaveBeenCalled();
   });
 });
-
-async function installPlatform(
-  platform: ReturnType<typeof createFakePlatform>,
-) {
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(platform);
-}
 
 function createRuntimeHost(): AgentRuntimeHost {
   return { emit: vi.fn() };

--- a/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
+++ b/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
@@ -2,10 +2,9 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 // Local imports
-import {
-  FakeConfigProvider,
-  createFakePlatform,
-} from '@test/support/FakePlatform';
+import { FakeConfigProvider } from '@test/support/FakePlatform';
+import { installPlatform as installFakePlatform } from '@test/support/setupPlatform';
+import { platform, type Platform } from '@platform/platform';
 import {
   FileInteractionState,
   WorkPlanState,
@@ -27,8 +26,6 @@ import {
   type RecordedProgressEvent,
 } from '../agent/progressTestUtils';
 
-import type { Platform } from '@platform/platform';
-
 const plan: Plan = {
   objective: [
     'Refactor the plan state boundary.',
@@ -47,12 +44,8 @@ const followUpPlan: Plan = {
 };
 
 async function installPlatform(flagOn: boolean): Promise<Platform> {
-  const { initPlatform } = await import('@platform/platform');
-  const platform = createFakePlatform({
-    config: { [GOAL_FEATURE_FLAG_KEY]: flagOn },
-  });
-  initPlatform(platform);
-  return platform;
+  await installFakePlatform({ config: { [GOAL_FEATURE_FLAG_KEY]: flagOn } });
+  return platform();
 }
 
 function startPlanUpdate(streamId: StreamTabId, objective: string) {

--- a/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
+++ b/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
@@ -3,7 +3,7 @@ import * as assert from 'node:assert';
 import { describe, it, beforeEach, afterEach } from 'vitest';
 
 // Local imports - tests
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { installPlatform as installFakePlatform } from '@test/support/setupPlatform';
 
 // Local imports - agent types
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
@@ -36,23 +36,20 @@ async function installPlatform(
   config: Record<string, unknown> = {},
   files: Record<string, string | Uint8Array> = {},
 ) {
-  const { initPlatform } = await import('@platform/platform');
   testApprovalHandler = undefined;
-  initPlatform(
-    createFakePlatform(
-      { workspacePath: '/workspace', config, files },
-      {
-        toolEditApproval: (request) => {
-          const handler = testApprovalHandler;
-          if (!handler) {
-            throw new Error(
-              'No test approval handler configured. Set `testApprovalHandler` first.',
-            );
-          }
-          return handler(request);
-        },
+  await installFakePlatform(
+    { workspacePath: '/workspace', config, files },
+    {
+      toolEditApproval: (request) => {
+        const handler = testApprovalHandler;
+        if (!handler) {
+          throw new Error(
+            'No test approval handler configured. Set `testApprovalHandler` first.',
+          );
+        }
+        return handler(request);
       },
-    ),
+    },
   );
 }
 

--- a/src/test-kernel/tools/codexImport.vitest.ts
+++ b/src/test-kernel/tools/codexImport.vitest.ts
@@ -5,13 +5,13 @@ import * as assert from 'node:assert';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { describe, it, beforeAll, afterEach } from 'vitest';
+import { describe, it, afterEach } from 'vitest';
 
 // Local imports - platform
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 
 // Local imports - tests
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { setupPlatform } from '@test/support/setupPlatform';
 
 // Local imports - tools
 import { findCodexBinaryInElectronResources } from '@tools/codexImport';
@@ -55,11 +55,8 @@ const PLATFORM_PACKAGES: Record<
 describe('findCodexBinaryInElectronResources', () => {
   let tempDir: string | undefined;
 
-  beforeAll(async () => {
-    // pathExists() probes the real filesystem through platform().fs.
-    const { initPlatform } = await import('@platform/platform');
-    initPlatform(createFakePlatform({}, { fs: nodeFilesystem }));
-  });
+  // pathExists() probes the real filesystem through platform().fs.
+  setupPlatform({}, { fs: nodeFilesystem });
 
   afterEach(() => {
     if (tempDir != null) {

--- a/src/test-kernel/tools/externalToolDefs.vitest.ts
+++ b/src/test-kernel/tools/externalToolDefs.vitest.ts
@@ -5,7 +5,7 @@ import * as assert from 'node:assert';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - platform/test support/tools
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { installPlatform } from '@test/support/setupPlatform';
 import { findExternalToolDef } from '@tools/externalToolDefs';
 import { BinaryResolver } from '@utils/system/binaryResolver';
 
@@ -45,20 +45,14 @@ describe('external tool definitions', () => {
   it('detects the current TeXRA CLI process through the host checker', async () => {
     const texraCli = findExternalToolDef('texra-cli');
     assert.ok(texraCli, 'TeXRA CLI tool definition should exist');
-    // Dynamic import: the no-platform-init-outside-composition-root lint rule
-    // reserves static initPlatform imports for composition roots.
-    const { initPlatform, tryPlatform } = await import('@platform/platform');
-    const previousPlatform = tryPlatform();
-    initPlatform(
-      createFakePlatform(
-        {},
-        {
-          toolAvailability: {
-            isVscodeExtensionInstalled: () => false,
-            isTexraCliEntrypoint: () => true,
-          },
+    await installPlatform(
+      {},
+      {
+        toolAvailability: {
+          isVscodeExtensionInstalled: () => false,
+          isTexraCliEntrypoint: () => true,
         },
-      ),
+      },
     );
 
     try {
@@ -71,7 +65,7 @@ describe('external tool definitions', () => {
         'Detected; integration coming soon',
       );
     } finally {
-      initPlatform(previousPlatform ?? createFakePlatform());
+      await installPlatform();
     }
   });
 
@@ -81,20 +75,14 @@ describe('external tool definitions', () => {
     const findPath = vi
       .spyOn(BinaryResolver, 'findPath')
       .mockReturnValue('/usr/local/bin/lake');
-    // Dynamic import: the no-platform-init-outside-composition-root lint rule
-    // reserves static initPlatform imports for composition roots.
-    const { initPlatform, tryPlatform } = await import('@platform/platform');
-    const previousPlatform = tryPlatform();
-    initPlatform(
-      createFakePlatform(
-        {},
-        {
-          toolAvailability: {
-            isVscodeExtensionInstalled: () => false,
-            isTexraCliEntrypoint: () => false,
-          },
+    await installPlatform(
+      {},
+      {
+        toolAvailability: {
+          isVscodeExtensionInstalled: () => false,
+          isTexraCliEntrypoint: () => false,
         },
-      ),
+      },
     );
 
     try {
@@ -116,7 +104,7 @@ describe('external tool definitions', () => {
       });
       await expect(lean.check(missingProbeResult)).resolves.toBe(false);
     } finally {
-      initPlatform(previousPlatform ?? createFakePlatform());
+      await installPlatform();
     }
   });
 });

--- a/src/test-kernel/tools/latex/ExtractBibliographyTool.vitest.ts
+++ b/src/test-kernel/tools/latex/ExtractBibliographyTool.vitest.ts
@@ -3,15 +3,14 @@ import * as assert from 'node:assert';
 import { describe, it, afterEach, vi } from 'vitest';
 
 // Local imports - tests
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { installPlatform as installFakePlatform } from '@test/support/setupPlatform';
 
 // Local imports - tools
 import * as bibliographyModule from '@latex/extractBibliography';
 import { ExtractBibliographyTool } from '@tools/latex';
 
-async function installPlatform(files: Record<string, string>) {
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(createFakePlatform({ workspacePath: '/workspace', files }));
+function installPlatform(files: Record<string, string>) {
+  return installFakePlatform({ workspacePath: '/workspace', files });
 }
 
 describe('ExtractBibliographyTool', () => {

--- a/src/test-kernel/tools/latex/ExtractFiguresTool.vitest.ts
+++ b/src/test-kernel/tools/latex/ExtractFiguresTool.vitest.ts
@@ -3,15 +3,14 @@ import * as assert from 'node:assert';
 import { describe, it, afterEach, vi } from 'vitest';
 
 // Local imports - tests
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { installPlatform as installFakePlatform } from '@test/support/setupPlatform';
 
 // Local imports - tools
 import * as figureModule from '@latex/extractFigure';
 import { ExtractLatexFiguresTool } from '@tools/latex';
 
-async function installPlatform(files: Record<string, string>) {
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(createFakePlatform({ workspacePath: '/workspace', files }));
+function installPlatform(files: Record<string, string>) {
+  return installFakePlatform({ workspacePath: '/workspace', files });
 }
 
 describe('ExtractLatexFiguresTool', () => {

--- a/src/test-kernel/tools/latex/ExtractTikzFiguresTool.vitest.ts
+++ b/src/test-kernel/tools/latex/ExtractTikzFiguresTool.vitest.ts
@@ -3,16 +3,15 @@ import * as assert from 'node:assert';
 import { describe, it, afterEach, vi } from 'vitest';
 
 // Local imports - tests
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { installPlatform as installFakePlatform } from '@test/support/setupPlatform';
 
 // Local imports - tools
 import { tikzPictureManager } from '@latex/TikzPictureManager';
 import { ExtractTikzFiguresTool } from '@tools/latex';
 import { pathToLocation } from '@utils/files';
 
-async function installPlatform(files: Record<string, string>) {
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(createFakePlatform({ workspacePath: '/workspace', files }));
+function installPlatform(files: Record<string, string>) {
+  return installFakePlatform({ workspacePath: '/workspace', files });
 }
 
 describe('ExtractTikzFiguresTool', () => {

--- a/src/test-kernel/tools/setup/SendToTerminalTool.vitest.ts
+++ b/src/test-kernel/tools/setup/SendToTerminalTool.vitest.ts
@@ -5,6 +5,7 @@ import { strict as assert } from 'node:assert';
 import { describe, it, beforeAll } from 'vitest';
 
 // Local imports
+import { installPlatform } from '@test/support/setupPlatform';
 import { BASH_APPROVAL_CONFIG_KEY } from '@shared/schemas/agentCliSettings';
 import { SendToTerminalTool } from '@tools/setup/SendToTerminalTool';
 import {
@@ -14,7 +15,7 @@ import {
 } from '@tools/setup/platform';
 
 import { createFakeSetupPlatform } from './fixtures';
-import type { Platform } from '@platform/platform';
+import type { ConfigProvider } from '@platform/interfaces/config';
 
 /**
  * `requestBashApproval` reads `texra.toolUse.requireBashApproval` via
@@ -24,30 +25,20 @@ import type { Platform } from '@platform/platform';
  * callback that never arrives. Stub the platform's config so the
  * approval flag resolves to `false`.
  *
- * `initPlatform` mutates module-scope state and the platform stays
- * registered for the rest of this file's worker process (vitest isolates
- * suites per file); we don't reset it in an `afterAll` hook because there
- * is no public reset API. That's fine here: the stub returns
- * `defaultValue` verbatim for every key except `BASH_APPROVAL_CONFIG_KEY`,
- * so behaviour stays identical to "no platform registered" unless a test
- * also checks the approval flag.
- *
- * Dynamic import: the no-platform-init-outside-composition-root lint rule
- * reserves static initPlatform imports for composition roots.
+ * The stub returns `defaultValue` verbatim for every key except
+ * `BASH_APPROVAL_CONFIG_KEY`, so behaviour stays identical to "no platform
+ * registered" unless a test also checks the approval flag.
  */
 async function installApprovalSkippingPlatform(): Promise<void> {
-  const { initPlatform } = await import('@platform/platform');
-  const stub: Partial<Platform> = {
-    config: {
-      get: <T>(key: string, defaultValue?: T): T =>
-        key === BASH_APPROVAL_CONFIG_KEY ? (false as T) : (defaultValue as T),
-      update: async () => {},
-      inspect: () => undefined,
-      isExplicitlySet: () => false,
-      watch: () => ({ dispose: () => {} }),
-    },
+  const stubConfig: ConfigProvider = {
+    get: <T>(key: string, defaultValue?: T): T =>
+      key === BASH_APPROVAL_CONFIG_KEY ? (false as T) : (defaultValue as T),
+    update: async () => {},
+    inspect: () => undefined,
+    isExplicitlySet: () => false,
+    watch: () => ({ dispose: () => {} }),
   };
-  initPlatform(stub as Platform);
+  await installPlatform({}, { config: stubConfig });
 }
 
 interface RunRecord {

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -9,6 +9,7 @@ import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import { createFakePlatform } from '@test/support/FakePlatform';
+import { setupPlatform } from '@test/support/setupPlatform';
 import { StreamSnapshotStore, streamDataDir } from '@transcript';
 import { TaskStateSchema, type TaskState } from '@agent/core/state/TaskState';
 import type {
@@ -22,26 +23,24 @@ import type {
 } from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas/agent';
 import { StorageFS } from '@utils/files';
+import type { Platform } from '@platform/platform';
 
 const tempDirs: string[] = [];
 
-async function installPlatform(): Promise<void> {
+async function buildSnapshotPlatform(): Promise<Platform> {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), 'texra-snapshot-'));
   tempDirs.push(tempDir);
   const workspaceDir = path.join(tempDir, 'workspace');
   const storageRoot = path.join(tempDir, 'storage');
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(
-    createFakePlatform(
-      { workspacePath: workspaceDir },
-      {
-        fs: nodeFilesystem,
-        workspace: createNodeWorkspace(() => workspaceDir),
-        storage: new WorkspaceStorageProvider(storageRoot, workspaceDir),
-        globalState: new MemoryStateStore(),
-        workspaceState: new MemoryStateStore(),
-      },
-    ),
+  return createFakePlatform(
+    { workspacePath: workspaceDir },
+    {
+      fs: nodeFilesystem,
+      workspace: createNodeWorkspace(() => workspaceDir),
+      storage: new WorkspaceStorageProvider(storageRoot, workspaceDir),
+      globalState: new MemoryStateStore(),
+      workspaceState: new MemoryStateStore(),
+    },
   );
 }
 
@@ -84,6 +83,8 @@ function outputFile(relativePath: string, round: number): OutputFileInfo {
 }
 
 describe('StreamSnapshotStore', () => {
+  setupPlatform(buildSnapshotPlatform);
+
   afterEach(async () => {
     await Promise.all(
       tempDirs
@@ -93,8 +94,6 @@ describe('StreamSnapshotStore', () => {
   });
 
   it('persists todos/plan/usage from progress events and reassembles them on a fresh store', async () => {
-    await installPlatform();
-
     const writer = new StreamSnapshotStore();
 
     writer.handleProgressEvent('updateTodos', {
@@ -143,7 +142,6 @@ describe('StreamSnapshotStore', () => {
   });
 
   it('returns an empty (valid) snapshot for a stream with no sidecar', async () => {
-    await installPlatform();
     const snap = await new StreamSnapshotStore().read(STREAM);
     expect(snap.streamId).toBe(STREAM);
     expect(snap.todos).toEqual([]);
@@ -152,7 +150,6 @@ describe('StreamSnapshotStore', () => {
   });
 
   it('migrates the legacy nested {runId:{round}} shape to flat ONCE at the load entry', async () => {
-    await installPlatform();
     const dir = streamDataDir(STREAM);
     await StorageFS.ensureDir(dir);
     await StorageFS.write(
@@ -177,7 +174,6 @@ describe('StreamSnapshotStore', () => {
   });
 
   it('seeds existing disk data before an unloaded progress mutation, so it is not erased', async () => {
-    await installPlatform();
     const dir = streamDataDir(STREAM);
     await StorageFS.ensureDir(dir);
     // A prior session persisted usage for run-1.
@@ -204,7 +200,6 @@ describe('StreamSnapshotStore', () => {
   });
 
   it('resolves pre-seed usage after merging existing disk usage', async () => {
-    await installPlatform();
     const dir = streamDataDir(STREAM);
     await StorageFS.ensureDir(dir);
     await StorageFS.write(
@@ -234,7 +229,6 @@ describe('StreamSnapshotStore', () => {
   });
 
   it('returns pre-seed usage only after a partial preload baseline is merged', async () => {
-    await installPlatform();
     const dir = streamDataDir(OTHER_STREAM);
     await StorageFS.ensureDir(dir);
     await StorageFS.write(
@@ -266,7 +260,6 @@ describe('StreamSnapshotStore', () => {
   });
 
   it('includes the disk baseline in a pre-seed usage result for the same run', async () => {
-    await installPlatform();
     const dir = streamDataDir(OTHER_STREAM);
     await StorageFS.ensureDir(dir);
     await StorageFS.write(
@@ -297,7 +290,6 @@ describe('StreamSnapshotStore', () => {
   });
 
   it('returns output files immediately for streams outside a partial preload without erasing disk outputs', async () => {
-    await installPlatform();
     const dir = streamDataDir(OTHER_STREAM);
     await StorageFS.ensureDir(dir);
     const prior = outputFile('prior.tex', 0);
@@ -322,7 +314,6 @@ describe('StreamSnapshotStore', () => {
   });
 
   it('keeps output overlays when flattening legacy output files after preload', async () => {
-    await installPlatform();
     const dir = streamDataDir(OTHER_STREAM);
     await StorageFS.ensureDir(dir);
     const prior = outputFile('prior.tex', 0);
@@ -347,7 +338,6 @@ describe('StreamSnapshotStore', () => {
   });
 
   it('makes task state readable immediately while preserving later seeded sidecars', async () => {
-    await installPlatform();
     const dir = streamDataDir(STREAM);
     await StorageFS.ensureDir(dir);
     await StorageFS.write(
@@ -387,7 +377,6 @@ describe('StreamSnapshotStore', () => {
   });
 
   it('load refreshes already-seeded streams from disk instead of keeping stale memory', async () => {
-    await installPlatform();
     const dir = streamDataDir(STREAM);
     await StorageFS.ensureDir(dir);
     await StorageFS.write(
@@ -417,7 +406,6 @@ describe('StreamSnapshotStore', () => {
   });
 
   it('treats streams created after load as new so direct mutators stay synchronous', async () => {
-    await installPlatform();
     const store = new StreamSnapshotStore();
     await store.load([]);
 
@@ -433,7 +421,6 @@ describe('StreamSnapshotStore', () => {
   });
 
   it('deleteStream cancels queued writes before removing the sidecar directory', async () => {
-    await installPlatform();
     const dir = streamDataDir(STREAM);
     const store = new StreamSnapshotStore();
     await store.load([]);
@@ -445,14 +432,12 @@ describe('StreamSnapshotStore', () => {
   });
 
   it('returns a frozen shared empty work plan default', async () => {
-    await installPlatform();
     const empty = new StreamSnapshotStore().getWorkPlan(STREAM);
     expect(Object.isFrozen(empty)).toBe(true);
     expect(Object.isFrozen(empty.todos)).toBe(true);
   });
 
   it('degrades gracefully when workPlan.json is valid JSON but the wrong shape', async () => {
-    await installPlatform();
     const dir = streamDataDir(STREAM);
     await StorageFS.ensureDir(dir);
     // Corrupt-but-parseable payload must NOT throw and abort read()/resume.
@@ -466,7 +451,6 @@ describe('StreamSnapshotStore', () => {
   });
 
   it('ignores a workPlan.json stamped with a newer schemaVersion (forward-compat gate)', async () => {
-    await installPlatform();
     const dir = streamDataDir(STREAM);
     await StorageFS.ensureDir(dir);
     // A file from a FUTURE schema must be read as empty, not have its unknown
@@ -486,7 +470,6 @@ describe('StreamSnapshotStore', () => {
   });
 
   it('drops a malformed executionId at the read entry without aborting the snapshot', async () => {
-    await installPlatform();
     const dir = streamDataDir(STREAM);
     await StorageFS.ensureDir(dir);
     // A legacy/corrupt executionId would trip the strict ExecutionIdSchema in

--- a/src/test-kernel/transcript/traceAssembler.vitest.ts
+++ b/src/test-kernel/transcript/traceAssembler.vitest.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { createFakePlatform } from '@test/support/FakePlatform';
+import { setupPlatform } from '@test/support/setupPlatform';
 import { MemoryStateStore } from '@platform/defaults/memoryState';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
@@ -27,26 +28,24 @@ import {
   type ExecutionId,
 } from '@shared/schemas';
 import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
+import type { Platform } from '@platform/platform';
 
 const tempDirs: string[] = [];
 
-async function installStoragePlatform(): Promise<void> {
+async function buildStoragePlatform(): Promise<Platform> {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), 'texra-trace-'));
   tempDirs.push(tempDir);
   const workspaceDir = path.join(tempDir, 'workspace');
   const storageRoot = path.join(tempDir, 'storage');
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(
-    createFakePlatform(
-      { workspacePath: workspaceDir },
-      {
-        fs: nodeFilesystem,
-        workspace: createNodeWorkspace(() => workspaceDir),
-        storage: new WorkspaceStorageProvider(storageRoot, workspaceDir),
-        globalState: new MemoryStateStore(),
-        workspaceState: new MemoryStateStore(),
-      },
-    ),
+  return createFakePlatform(
+    { workspacePath: workspaceDir },
+    {
+      fs: nodeFilesystem,
+      workspace: createNodeWorkspace(() => workspaceDir),
+      storage: new WorkspaceStorageProvider(storageRoot, workspaceDir),
+      globalState: new MemoryStateStore(),
+      workspaceState: new MemoryStateStore(),
+    },
   );
 }
 
@@ -74,6 +73,8 @@ function config(overrides: Partial<AgentConfig> = {}): AgentConfig {
 describe('assembleTrace', () => {
   let previousStreamLogStore: StreamLogStore;
 
+  setupPlatform(buildStoragePlatform);
+
   beforeEach(() => {
     // A fresh store per test, not the process-wide singleton: StreamLogStore's
     // underlying KVStore caches a "directory already ensured" flag for its own
@@ -95,7 +96,6 @@ describe('assembleTrace', () => {
   });
 
   it('assembles a full trace document, deriving streamId from agent/model/executionId', async () => {
-    await installStoragePlatform();
     const executionId = 'exec-happy-path' as ExecutionId;
     const executionConfig = config({ agent: 'review', model: 'sonnet46T' });
 
@@ -135,13 +135,11 @@ describe('assembleTrace', () => {
   });
 
   it('returns config_missing when no config was ever written', async () => {
-    await installStoragePlatform();
     const result = await assembleTrace('exec-no-config' as ExecutionId);
     expect(result).toEqual({ status: 'config_missing' });
   });
 
   it('returns streamLogs_missing for a pre-#7057 execution (config exists, streamLogs never persisted)', async () => {
-    await installStoragePlatform();
     const executionId = 'exec-no-logs' as ExecutionId;
     await getExecutionStore(executionId).writeConfig(config());
 
@@ -156,7 +154,6 @@ describe('assembleTrace', () => {
     // "${streamPrefix}#executionId" id, not getStreamTabId's
     // "agent@model#executionId" — the config's own agent/model would derive
     // the wrong id entirely for these.
-    await installStoragePlatform();
     const executionId = 'exec-child-1' as ExecutionId;
     const executionConfig = config({
       agent: 'orchestrator',
@@ -195,7 +192,6 @@ describe('assembleTrace', () => {
   });
 
   it('returns a null terminalStatus when meta has no recorded outcome', async () => {
-    await installStoragePlatform();
     const executionId = 'exec-no-outcome' as ExecutionId;
     const executionConfig = config();
     await getExecutionStore(executionId).writeConfig(executionConfig);

--- a/src/test-kernel/utils/ExecUtils.vitest.ts
+++ b/src/test-kernel/utils/ExecUtils.vitest.ts
@@ -2,51 +2,28 @@ import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { createFakePlatform } from '@test/support/FakePlatform';
+import { setupPlatform } from '@test/support/setupPlatform';
 import { executeCommandSync } from '@utils/system/execUtils';
-
-async function initDefaultFakePlatform(): Promise<void> {
-  const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
-    import('@platform/platform'),
-    import('@test/support/FakePlatform'),
-  ]);
-  initPlatform(createFakePlatform());
-}
-
-async function initNodeBackedPlatform(options: {
-  storagePath: string;
-  globalStoragePath: string;
-}): Promise<void> {
-  const [{ initPlatform }, { nodeFilesystem }, { createFakePlatform }] =
-    await Promise.all([
-      import('@platform/platform'),
-      import('@platform/defaults/nodeFilesystem'),
-      import('@test/support/FakePlatform'),
-    ]);
-  initPlatform(
-    createFakePlatform(
-      {
-        workspacePath: process.cwd(),
-        storagePath: options.storagePath,
-        globalStoragePath: options.globalStoragePath,
-      },
-      { fs: nodeFilesystem },
-    ),
-  );
-}
 
 describe('executeCommandSync', () => {
   let platformStorageRoot = '';
 
-  beforeEach(async () => {
+  setupPlatform(async () => {
     platformStorageRoot = await fs.mkdtemp(
       path.join(os.tmpdir(), 'texra-exec-utils-'),
     );
-    await initNodeBackedPlatform({
-      storagePath: path.join(platformStorageRoot, 'storage'),
-      globalStoragePath: path.join(platformStorageRoot, 'global-storage'),
-    });
+    return createFakePlatform(
+      {
+        workspacePath: process.cwd(),
+        storagePath: path.join(platformStorageRoot, 'storage'),
+        globalStoragePath: path.join(platformStorageRoot, 'global-storage'),
+      },
+      { fs: nodeFilesystem },
+    );
   });
 
   afterEach(async () => {
@@ -54,7 +31,6 @@ describe('executeCommandSync', () => {
       await fs.rm(platformStorageRoot, { recursive: true, force: true });
       platformStorageRoot = '';
     }
-    await initDefaultFakePlatform();
   });
 
   it('returns normalized stdout for successful commands', () => {

--- a/src/test-kernel/utils/RoundDirOwnership.vitest.ts
+++ b/src/test-kernel/utils/RoundDirOwnership.vitest.ts
@@ -18,7 +18,7 @@ import { MemoryStateStore } from '@platform/defaults/memoryState';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { installPlatform as installFakePlatform } from '@test/support/setupPlatform';
 import {
   AbsoluteFS,
   createWorkspaceLocation,
@@ -35,22 +35,19 @@ async function makeTempDir(prefix: string): Promise<string> {
   return dir;
 }
 
-async function installPlatform(
+function installPlatform(
   workspaceDir: string,
   storageRoot: string,
 ): Promise<void> {
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(
-    createFakePlatform(
-      { workspacePath: workspaceDir },
-      {
-        fs: nodeFilesystem,
-        workspace: createNodeWorkspace(() => workspaceDir),
-        storage: new WorkspaceStorageProvider(storageRoot, workspaceDir),
-        globalState: new MemoryStateStore(),
-        workspaceState: new MemoryStateStore(),
-      },
-    ),
+  return installFakePlatform(
+    { workspacePath: workspaceDir },
+    {
+      fs: nodeFilesystem,
+      workspace: createNodeWorkspace(() => workspaceDir),
+      storage: new WorkspaceStorageProvider(storageRoot, workspaceDir),
+      globalState: new MemoryStateStore(),
+      workspaceState: new MemoryStateStore(),
+    },
   );
 }
 

--- a/src/test-kernel/utils/TextDiffCallers.vitest.ts
+++ b/src/test-kernel/utils/TextDiffCallers.vitest.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 // Local imports - tests
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { installPlatform } from '@test/support/setupPlatform';
 
 // Local imports - agent output
 import { computeOutputDiffStats } from '@agent/output/diffComputation';
@@ -33,17 +33,14 @@ import {
 } from '@utils/files';
 import { getRunDir } from '@utils/files/taskRunStorage';
 
-async function installFakePlatform(
+function installFakePlatform(
   files: Record<string, string> = {},
 ): Promise<void> {
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(
-    createFakePlatform({
-      files,
-      storagePath: '/workspace/.texra/storage',
-      workspacePath: '/workspace',
-    }),
-  );
+  return installPlatform({
+    files,
+    storagePath: '/workspace/.texra/storage',
+    workspacePath: '/workspace',
+  });
 }
 
 describe('shared text-diff caller fixtures', () => {

--- a/src/test-kernel/utils/config/PlatformSettings.vitest.ts
+++ b/src/test-kernel/utils/config/PlatformSettings.vitest.ts
@@ -2,17 +2,16 @@
 import { describe, expect, it } from 'vitest';
 
 // Local imports
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { installPlatform } from '@test/support/setupPlatform';
 import { LATEX_CONFIG_DEFAULTS } from '@shared/constants/latex';
 import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 import { readPlatformSetting } from '@utils/config/platformSettings';
 
-async function initWith(options: {
+function initWith(options: {
   workspaceState?: Record<string, unknown>;
   globalState?: Record<string, unknown>;
 }): Promise<void> {
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(createFakePlatform(options));
+  return installPlatform(options);
 }
 
 describe('readPlatformSetting', () => {

--- a/src/test-kernel/utils/files/RelativeFSJson.vitest.ts
+++ b/src/test-kernel/utils/files/RelativeFSJson.vitest.ts
@@ -8,8 +8,11 @@ import { promises as fs } from 'node:fs';
 import { describe, it, beforeAll, afterAll, beforeEach } from 'vitest';
 import { z } from 'zod';
 
+// Local imports - platform
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+
 // Local imports - test support
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { setupPlatform } from '@test/support/setupPlatform';
 
 // Local imports - utils
 import { RelativeFS } from '@utils/files/relativeFS';
@@ -23,15 +26,11 @@ class TestRelativeFS extends RelativeFS {
 }
 
 describe('RelativeFS JSON helpers', () => {
-  beforeAll(async () => {
-    // RelativeFS goes through the platform filesystem; back it with the real
-    // node filesystem since this suite writes to a real temp directory.
-    const [{ initPlatform }, { nodeFilesystem }] = await Promise.all([
-      import('@platform/platform'),
-      import('@platform/defaults/nodeFilesystem'),
-    ]);
-    initPlatform(createFakePlatform({}, { fs: nodeFilesystem }));
+  // RelativeFS goes through the platform filesystem; back it with the real
+  // node filesystem since this suite writes to a real temp directory.
+  setupPlatform({}, { fs: nodeFilesystem });
 
+  beforeAll(async () => {
     await fs
       .rm(BASE_DIR, { recursive: true, force: true })
       .catch(() => undefined);

--- a/src/test-kernel/utils/files/WorkspaceFS.vitest.ts
+++ b/src/test-kernel/utils/files/WorkspaceFS.vitest.ts
@@ -1,19 +1,9 @@
 // Third-party imports
 import * as assert from 'node:assert';
-import { beforeAll, describe, it } from 'vitest';
-
-// Third-party imports
-
-// Local imports - test support
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { describe, it } from 'vitest';
 
 // Local imports - utils
 import { WorkspaceFS } from '@utils/files/workspaceFS';
-
-beforeAll(async () => {
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(createFakePlatform());
-});
 
 describe('WorkspaceFS Test Suite', () => {
   it('delete should be idempotent - not throw when file does not exist', async () => {

--- a/src/test-kernel/utils/files/flexibleFS.vitest.ts
+++ b/src/test-kernel/utils/files/flexibleFS.vitest.ts
@@ -1,21 +1,12 @@
 // Third-party imports
 import * as assert from 'node:assert';
-import { beforeAll, describe, it } from 'vitest';
-
-// Node.js built-in imports
+import { describe, it } from 'vitest';
 
 // Internal imports
-import { createFakePlatform } from '@test/support/FakePlatform';
 import { flexibleFS } from '@utils/files/flexibleFS';
 import { pathToLocation } from '@utils/files/taskRunStorage';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
-
-beforeAll(async () => {
-  // pathToLocation resolves paths against the platform workspace.
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(createFakePlatform());
-});
 
 describe('flexibleFS.write', () => {
   it('retries the write after clearing symlink loops', async () => {

--- a/src/test-kernel/utils/files/pathUtils.vitest.ts
+++ b/src/test-kernel/utils/files/pathUtils.vitest.ts
@@ -1,24 +1,13 @@
 // Third-party imports
-
-// Third-party imports
 import * as assert from 'node:assert';
 import * as path from 'node:path';
-import { beforeAll, describe, it } from 'vitest';
+import { describe, it } from 'vitest';
 
 // Local imports - common
-
-// Local imports - test support
-import { createFakePlatform } from '@test/support/FakePlatform';
 import { isTexFile } from '@common/files/fileTypeUtils';
 
 // Local imports - utils
 import { WorkspaceFS } from '@utils/files';
-
-beforeAll(async () => {
-  // WorkspaceFS resolves relative paths against the platform workspace.
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(createFakePlatform());
-});
 
 describe('pathUtils Test Suite', () => {
   describe('isTexFile', () => {

--- a/src/test-kernel/utils/system/execUtils.vitest.ts
+++ b/src/test-kernel/utils/system/execUtils.vitest.ts
@@ -6,22 +6,19 @@ import { join } from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
 
 // Third-party imports
-import { afterEach, beforeAll, describe, it } from 'vitest';
+import { afterEach, describe, it } from 'vitest';
 
 // Local imports - test support
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { setupPlatform } from '@test/support/setupPlatform';
 
 // Local imports - utils
 import { executeCommand } from '@utils/system/execUtils';
 
 const tempDirs: string[] = [];
 
-beforeAll(async () => {
-  // executeCommand resolves its cwd from the workspace; point the fake
-  // platform at a directory that exists on disk so spawning succeeds.
-  const { initPlatform } = await import('@platform/platform');
-  initPlatform(createFakePlatform({ workspacePath: process.cwd() }));
-});
+// executeCommand resolves its cwd from the workspace; point the fake
+// platform at a directory that exists on disk so spawning succeeds.
+setupPlatform({ workspacePath: process.cwd() });
 
 afterEach(() => {
   for (const dir of tempDirs.splice(0)) {


### PR DESCRIPTION
Closes #7104

## Summary

F1 (#6971, PR #7010) landed the global vitest bootstrap (`vitest.config.mjs`'s `setupFiles: ['src/test-kernel/support/setupFakePlatform.ts']`) that installs a default `createFakePlatform()` before every suite, but the per-suite bootstraps it was meant to subsume were still hand-rolled across 68 test files:

- ~10 sites were **pure redundancy**: a `beforeAll`/module-scope `initPlatform(createFakePlatform())` with no other customization, installing exactly what the global default already installs once per file. Deleted outright.
- The remaining ~58 sites pass custom `FakePlatformOptions`/`Partial<Platform>` overrides (real node fs, seeded workspace files, stubbed secrets, custom config, etc.), each via its own hand-rolled `await import('@platform/platform')` dance to dodge the `no-platform-init-outside-composition-root` lint rule.

## What changed

- Added `src/test-kernel/support/setupPlatform.ts` as the single override helper:
  - `setupPlatform(options?, overrides?)` — registers suite-level `beforeEach`/`afterEach` to install a fake platform and restore the default afterward. Also accepts a builder function for suites that must compute the platform per test (temp dirs, captured state, etc).
  - `installPlatform(options?, overrides?)` — installs a fake platform immediately, for per-test/mid-test swaps that don't fit the whole-suite pattern.
- `setupFakePlatform.ts` (the global `setupFiles` entry) now delegates to `installPlatform()`.
- Registered `setupPlatform.ts` as an additional composition root in `no-platform-init-outside-composition-root` (`eslint.config.mjs`) so it's the one place that imports `initPlatform` statically — every suite's `await import('@platform/platform')` workaround is gone.
- Migrated all 68 files mechanically, directory by directory, re-running the affected suites after each batch.

## Notable catch

Two files (`tools/InquiryStorage.vitest.ts`, `tools/InquiryReadBoundary.vitest.ts`) looked like pure-redundancy candidates at a glance, but their bootstrap ran in `beforeEach` (per-test reset), not `beforeAll` (once per file) — deleting them outright leaked inquiry-thread state across tests within the file and broke two assertions. Caught by running the full suite after each directory; kept as `setupPlatform()` calls instead.

## Verification

- `npm run typecheck` — clean
- Full vitest suite (`npx vitest run`) — 588 files / 4601+ tests passing, 0 regressions
- `eslint` (including `--fix` for import-order) — 0 errors
- `prettier --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nbVZZcHVNLBNZ2tESvR7v

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no production runtime changes; risk is limited to test isolation regressions, which the PR description reports were caught and fixed during migration.
> 
> **Overview**
> Introduces **`src/test-kernel/support/setupPlatform.ts`** as the test suite’s composition root for swapping the fake platform: **`installPlatform`** for immediate/ad hoc installs and **`setupPlatform`** for per-test install plus restore so overrides don’t leak across tests.
> 
> **`eslint.config.mjs`** whitelists that file for `initPlatform`, replacing the per-suite dynamic `import('@platform/platform')` pattern. The global vitest bootstrap **`setupFakePlatform.ts`** now calls **`installPlatform()`**.
> 
> Across **~68** `src/test-kernel` vitest files, hand-rolled `initPlatform(createFakePlatform(...))` in `beforeAll`/`beforeEach` is replaced with **`setupPlatform`** or **`installPlatform`**; redundant default-only bootstraps are removed. Suites that needed **per-test** platform resets (e.g. inquiry storage) keep **`setupPlatform()`** instead of relying on file-level defaults only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3ba7203300e6a1e2d68d1bdf6e24a1b8dc10fbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->