### PR TITLE
fix: harden stream snapshot run hydration

### DIFF
--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -2,14 +2,18 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { MemoryStateStore } from '@platform/defaults/memoryState';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
-import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
+import {
+  resolveRunStoragePath,
+  WorkspaceStorageProvider,
+} from '@platform/defaults/workspaceStorage';
 import { createFakePlatform } from '@test/support/FakePlatform';
 import { StreamSnapshotStore, streamDataDir } from '@transcript';
+import { getExecutionStore } from '@agent/storage';
 import { TaskStateSchema, type TaskState } from '@agent/core/state/TaskState';
 import type {
   ExecutionId,
@@ -20,6 +24,7 @@ import type {
   TodoItem,
   TokenUsageStats,
 } from '@shared/schemas';
+import { RUN_DESCRIPTOR_SCHEMA_VERSION } from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas/agent';
 import { StorageFS } from '@utils/files';
 
@@ -83,8 +88,19 @@ function outputFile(relativePath: string, round: number): OutputFileInfo {
   };
 }
 
+function toolUseTaskState(agent = 'search', model = 'deepseekproT'): TaskState {
+  return TaskStateSchema.parse({
+    agentConfig: {
+      agent,
+      model,
+      agentCategory: AgentCategory.ToolUse,
+    },
+  });
+}
+
 describe('StreamSnapshotStore', () => {
   afterEach(async () => {
+    vi.restoreAllMocks();
     await Promise.all(
       tempDirs
         .splice(0)
@@ -383,6 +399,132 @@ describe('StreamSnapshotStore', () => {
     expect(raw).toMatchObject({
       [RUN]: { inputTokens: 100, outputTokens: 20, cost: 0.5 },
       [RUN_2]: { inputTokens: 50, outputTokens: 10, cost: 0.25 },
+    });
+  });
+
+  it('forces the current meta schema version over stale cached meta', async () => {
+    await installPlatform();
+    const store = new StreamSnapshotStore();
+    await store.load([]);
+
+    const internals = store as unknown as {
+      meta: Map<StreamTabId, { schemaVersion: number; description?: string }>;
+    };
+    internals.meta.set(STREAM, { schemaVersion: 0 });
+
+    store.setDescription(STREAM, 'Updated session');
+    await store.flush();
+
+    expect(internals.meta.get(STREAM)).toMatchObject({
+      schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+      description: 'Updated session',
+    });
+  });
+
+  it('preserves legacy meta taskState when unrelated meta patches are written', async () => {
+    await installPlatform();
+    const dir = streamDataDir(STREAM);
+    const taskState = toolUseTaskState('legacy-search');
+    await StorageFS.ensureDir(dir);
+    await StorageFS.write(
+      path.join(dir, 'meta.json'),
+      JSON.stringify({
+        schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+        taskState,
+      }),
+    );
+
+    const store = new StreamSnapshotStore();
+    await store.load([STREAM]);
+    store.setDescription(STREAM, 'Prior session');
+    await store.flush();
+
+    const raw = (await StorageFS.readJson(path.join(dir, 'meta.json'))) as {
+      schemaVersion?: unknown;
+      taskState?: unknown;
+      description?: unknown;
+    };
+    expect(raw.schemaVersion).toBe(RUN_DESCRIPTOR_SCHEMA_VERSION);
+    expect(raw.taskState).toEqual(taskState);
+    expect(raw.description).toBe('Prior session');
+  });
+
+  it('falls back to legacy taskState when an execution config is unreadable', async () => {
+    await installPlatform();
+    const dir = streamDataDir(STREAM);
+    const executionId = 'abc123' as ExecutionId;
+    const taskState = toolUseTaskState('legacy-search');
+    await StorageFS.ensureDir(dir);
+    await StorageFS.write(
+      path.join(dir, 'meta.json'),
+      JSON.stringify({
+        schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+        executionId,
+        taskState,
+      }),
+    );
+    await StorageFS.ensureDir(resolveRunStoragePath(executionId));
+    await StorageFS.write(
+      path.join(resolveRunStoragePath(executionId), 'config.json'),
+      '{',
+    );
+
+    const store = new StreamSnapshotStore();
+    await expect(store.load([STREAM])).resolves.toBeUndefined();
+
+    expect(store.getTaskState(STREAM)).toEqual(taskState);
+    expect(store.getExecutionId(STREAM)).toBe(executionId);
+  });
+
+  it('keeps a runtime run-config update that arrives during async hydration', async () => {
+    await installPlatform();
+    const dir = streamDataDir(STREAM);
+    const oldExecutionId = 'abc123' as ExecutionId;
+    const newExecutionId = 'def456' as ExecutionId;
+    const oldTaskState = toolUseTaskState('old-search');
+    const newTaskState = toolUseTaskState('new-search');
+    await StorageFS.ensureDir(dir);
+    await StorageFS.write(
+      path.join(dir, 'meta.json'),
+      JSON.stringify({
+        schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+        executionId: oldExecutionId,
+      }),
+    );
+    await getExecutionStore(oldExecutionId).writeConfig(
+      oldTaskState.agentConfig,
+    );
+
+    const store = new StreamSnapshotStore();
+    const originalRead = StorageFS.read.bind(StorageFS);
+    const configPath = path.join(
+      resolveRunStoragePath(oldExecutionId),
+      'config.json',
+    );
+    let injectedRuntimeUpdate = false;
+    vi.spyOn(StorageFS, 'read').mockImplementation(async (target: string) => {
+      const raw = await originalRead(target);
+      if (!injectedRuntimeUpdate && target === configPath) {
+        injectedRuntimeUpdate = true;
+        store.setTaskState(STREAM, newTaskState, newExecutionId);
+      }
+      return raw;
+    });
+
+    await store.load([STREAM]);
+    expect(injectedRuntimeUpdate).toBe(true);
+    expect(store.getTaskState(STREAM)).toEqual(newTaskState);
+    expect(store.getExecutionId(STREAM)).toBe(newExecutionId);
+
+    await store.flush();
+    const raw = (await StorageFS.readJson(path.join(dir, 'meta.json'))) as {
+      executionId?: unknown;
+      runDescriptor?: { executionId?: unknown; agent?: unknown };
+    };
+    expect(raw.executionId).toBe(newExecutionId);
+    expect(raw.runDescriptor).toMatchObject({
+      executionId: newExecutionId,
+      agent: 'new-search',
     });
   });
 

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -84,6 +84,10 @@ const SEED_IO_CONCURRENCY = 8;
 type OutputFilesPatch = Map<number, OutputFileInfo[] | null>;
 type UsageUpdateResult =
   TokenUsageStats | undefined | Promise<TokenUsageStats | undefined>;
+interface HydratedRunState {
+  config?: AgentConfig;
+  descriptor?: RunDescriptor;
+}
 
 /**
  * Match criteria for {@link StreamSnapshotStore.findWorkflowStreamsMatching}.
@@ -669,9 +673,9 @@ export class StreamSnapshotStore {
     patch: Partial<StreamTabMeta>,
   ): StreamTabMeta {
     const next: StreamTabMeta = {
-      schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
       ...(this.meta.get(stream) ?? {}),
       ...patch,
+      schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
     };
     this.meta.set(stream, next);
     return next;
@@ -687,6 +691,8 @@ export class StreamSnapshotStore {
       ...(next.runDescriptor !== undefined && {
         runDescriptor: next.runDescriptor,
       }),
+      ...(next.taskState !== undefined &&
+        next.runDescriptor === undefined && { taskState: next.taskState }),
       ...(next.parentStreamId !== undefined && {
         parentStreamId: next.parentStreamId,
       }),
@@ -1039,35 +1045,41 @@ export class StreamSnapshotStore {
   private async hydrateRunStateFromMeta(
     stream: StreamTabId,
     meta: StreamTabMeta,
-  ): Promise<void> {
+  ): Promise<HydratedRunState> {
     const executionId = meta.runDescriptor?.executionId ?? meta.executionId;
+    let descriptor = meta.runDescriptor;
     if (meta.runDescriptor) {
-      this.runDescriptors.set(stream, meta.runDescriptor);
+      descriptor = meta.runDescriptor;
     }
 
     if (executionId) {
-      const config = await getExecutionStore(executionId).readConfig();
-      if (config) {
-        this.runConfigs.set(stream, config);
-        this.runDescriptors.set(
-          stream,
-          meta.runDescriptor ??
-            descriptorFromConfig(stream, executionId, config),
+      let config: AgentConfig | null = null;
+      try {
+        config = await getExecutionStore(executionId).readConfig();
+      } catch (error) {
+        logger.warn(
+          CHANNEL,
+          `Could not read execution config for stream ${stream}; falling back to legacy taskState.`,
+          { data: { stream, executionId, error } },
         );
-        return;
+      }
+      if (config) {
+        return {
+          config,
+          descriptor:
+            descriptor ?? descriptorFromConfig(stream, executionId, config),
+        };
       }
     }
 
     const legacyTaskState = this.parseLegacyTaskState(stream, meta);
-    if (!legacyTaskState) return;
+    if (!legacyTaskState) return { descriptor };
     const config = legacyTaskState.agentConfig;
-    this.runConfigs.set(stream, config);
     if (executionId) {
-      this.runDescriptors.set(
-        stream,
-        descriptorFromConfig(stream, executionId, config),
-      );
+      descriptor =
+        descriptor ?? descriptorFromConfig(stream, executionId, config);
     }
+    return { config, descriptor };
   }
 
   /** Seed the in-memory accumulators for one stream + migrate legacy once. */
@@ -1095,24 +1107,42 @@ export class StreamSnapshotStore {
     this.workPlan.set(stream, data.workPlan);
     this.runDescriptors.delete(stream);
     this.runConfigs.delete(stream);
-    const meta = metaOverlay
+    let meta = metaOverlay
       ? { ...(data.meta ?? {}), ...metaOverlay }
       : data.meta;
+    let hydrated: HydratedRunState = {};
     if (meta) {
       this.meta.set(stream, meta);
-      await this.hydrateRunStateFromMeta(stream, meta);
+      hydrated = await this.hydrateRunStateFromMeta(stream, meta);
     } else {
       this.meta.delete(stream);
     }
-    if (runConfigOverlay) {
-      this.runConfigs.set(stream, runConfigOverlay);
-      const executionId = meta?.runDescriptor?.executionId ?? meta?.executionId;
-      const descriptor =
-        runDescriptorOverlay ??
-        (executionId
-          ? descriptorFromConfig(stream, executionId, runConfigOverlay)
-          : undefined);
-      if (descriptor) this.runDescriptors.set(stream, descriptor);
+    const latestMetaOverlay = this.metaOverlays.has(stream)
+      ? this.meta.get(stream)
+      : undefined;
+    if (latestMetaOverlay) {
+      meta = { ...(data.meta ?? {}), ...latestMetaOverlay };
+      this.meta.set(stream, meta);
+    }
+    const latestRunConfigOverlay =
+      latestMetaOverlay !== undefined ? this.runConfigs.get(stream) : undefined;
+    const latestRunDescriptorOverlay =
+      latestMetaOverlay !== undefined
+        ? this.runDescriptors.get(stream)
+        : undefined;
+    const runConfig =
+      latestRunConfigOverlay ?? runConfigOverlay ?? hydrated.config;
+    const executionId = meta?.runDescriptor?.executionId ?? meta?.executionId;
+    const runDescriptor =
+      latestRunDescriptorOverlay ??
+      runDescriptorOverlay ??
+      hydrated.descriptor ??
+      (runConfig && executionId
+        ? descriptorFromConfig(stream, executionId, runConfig)
+        : undefined);
+    if (runConfig) this.runConfigs.set(stream, runConfig);
+    if (runDescriptor) {
+      this.runDescriptors.set(stream, runDescriptor);
     }
     this.metaOverlays.delete(stream);
     if (outputFileOverlay) {


### PR DESCRIPTION
## Summary

Hardens StreamSnapshotStore run metadata hydration so persisted stream meta cannot regress the RunDescriptor schema version, legacy taskState fallback survives unrelated meta writes until the stream migrates, unreadable execution config files do not abort a load batch, and runtime config updates that arrive during async hydration are not overwritten by stale disk data.

## Issue acceptance gates

Addresses #7177:

- Forces `meta.json` schemaVersion to `RUN_DESCRIPTOR_SCHEMA_VERSION` after merging cached meta and patches.
- Preserves legacy `meta.taskState` on unrelated meta writes while the stream has not migrated to RunDescriptor-backed metadata.
- Catches per-stream execution config read failures and falls back to legacy taskState when available.
- Re-merges the newest run-config/run-descriptor overlay after async hydration so in-flight runtime updates win over stale disk reads.
- Adds focused regressions for all four cases in `StreamSnapshotStore.vitest.ts`.

## Single source of truth

`StreamSnapshotStore` remains the single owner for streamData meta persistence and run-state hydration from `executions/{id}/config.json`; this PR keeps the legacy taskState path as a bounded read/write fallback only for pre-RunDescriptor metadata.

## Duplication and abstraction budget

No new pass-through layer or projector was added. The helper introduced here is a local return shape for hydrated run state so `applyStreamData()` can merge disk state and newer runtime overlays exactly once. This refactor is net-positive in lines because it adds four regression tests covering the review-reported corruption and race cases.

## Host impact

Extension: Progress view resume/follow-up hydration survives corrupt execution config and keeps newer in-memory run config during startup races.

Desktop: Same shared snapshot hydration hardening applies to desktop progress backends.

CLI: Same shared snapshot hydration hardening applies to CLI progress/resume reads; no headless output contract changes.

## Scheduled refactoring

None for this PR. No new shim, dual-write, alias, or migration path was introduced; the existing legacy taskState retirement remains governed by the architecture program / #6981.

## Validation

- `corepack pnpm exec prettier --write src/transcript/StreamSnapshotStore.ts src/test-kernel/transcript/StreamSnapshotStore.vitest.ts`
- `npm test -- --run src/test-kernel/transcript/StreamSnapshotStore.vitest.ts`
- `npm run typecheck`
- `npm test`
- `npm run lint` (passes with one pre-existing warning in `packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts`)
- `npm run compile:fast`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `git diff --check`

Closes #7177

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared resume/hydration paths used by extension, desktop, and CLI; behavior is tightened with fallbacks and tests, but incorrect merge logic could still mis-associate execution ids or run config at startup.
> 
> **Overview**
> Hardens **`StreamSnapshotStore`** so stream `meta.json` and run config stay consistent across resume, corrupt disk, and startup races.
> 
> **Meta persistence:** `patchMetaMemory` now applies **`RUN_DESCRIPTOR_SCHEMA_VERSION` after** merging patches so stale in-memory schema versions cannot win. **`writeMeta`** keeps legacy **`taskState`** on disk when the stream has not migrated to **`runDescriptor`** yet, so unrelated updates (e.g. description) do not drop the fallback.
> 
> **Hydration:** `hydrateRunStateFromMeta` returns a local **`HydratedRunState`** instead of mutating maps directly; execution **`config.json`** read failures are caught and logged, with fallback to legacy **`taskState`** when present. **`applyStreamData`** re-reads the latest meta/run overlays after async hydration so in-flight **`setTaskState`** updates are not overwritten by stale disk reads.
> 
> **Tests:** Four regressions in **`StreamSnapshotStore.vitest.ts`** cover schema version forcing, legacy **`taskState`** retention, corrupt execution config, and the hydration race (with **`vi.spyOn`** on **`StorageFS.read`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e9bcb8952f375bd61471dbe2e26584053bf86ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->