### PR TITLE
fix: clear running stream badges

### DIFF
--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -711,6 +711,21 @@ export class ProgressEventHandler {
       if (activeStreamToSync !== undefined) {
         await this.syncFilterDrivenActiveStreamContent(activeStreamToSync);
       }
+    } else if (isNewRunningTransition) {
+      const statusesForRefresh = this.state.streamStatus.getAll();
+      statusesForRefresh.set(streamId, status);
+      const substatesForRefresh = this.state.streamStatus.getAllSubstates();
+      if (substate) {
+        substatesForRefresh.set(streamId, substate);
+      } else {
+        substatesForRefresh.delete(streamId);
+      }
+      this.webviewUpdater.updateStreamMetadata(
+        this.state,
+        streamId,
+        statusesForRefresh,
+        substatesForRefresh,
+      );
     } else {
       const lastTimestamp = this.state.streamLogs.getLastTimestamp(streamId);
       this.webviewUpdater.updateStreamStatus(

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -385,6 +385,66 @@ describe('ProgressBackend', () => {
     }
   });
 
+  it('clears stale per-run badges when an existing stream re-enters running', async () => {
+    const { backend, messages } = createRecordingBackend();
+    const stream = 'tool-stream' as StreamTabId;
+
+    try {
+      await backend.state.snapshots.load([]);
+      backend.state.streamLogs.ensureStream(stream);
+      backend.state.snapshots.setTaskState(
+        stream,
+        toolUseTaskState('search', 'deepseekproT'),
+        'abc123' as ExecutionId,
+      );
+      backend.state.updateStreamHints(stream, {
+        agentCategory: AgentCategory.ToolUse,
+      });
+      backend.state.getOrCreateStreamState(stream, AgentCategory.ToolUse);
+      backend.state.updateStreamState(stream, (prev) => ({
+        ...prev,
+        conversationProgress: { toolCallCount: 7 },
+        roundStage: { index: 2 },
+        finishedSubagentCount: 3,
+        finishedProcessCount: 2,
+      }));
+
+      await backend.eventHandler.setStreamStatus(
+        stream,
+        STREAM_PHASE.RUNNING,
+        STREAM_PHASE.COMPLETED,
+      );
+
+      expect(
+        messages.some(
+          (message) =>
+            message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_STATUS,
+        ),
+      ).toBe(false);
+
+      const patch = messages.find(
+        (message) =>
+          message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA &&
+          message.streamInfo.name === stream,
+      );
+      if (patch?.command !== PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA) {
+        throw new Error('Expected existing stream metadata patch');
+      }
+
+      expect(patch.streamState).toMatchObject({
+        kind: AgentCategory.ToolUse,
+        status: STREAM_PHASE.RUNNING,
+        conversationProgress: { toolCallCount: 0 },
+        finishedSubagentCount: 0,
+        finishedProcessCount: 0,
+      });
+      expect(Object.hasOwn(patch.streamState, 'roundStage')).toBe(true);
+      expect(patch.streamState.roundStage).toBeUndefined();
+    } finally {
+      backend.dispose();
+    }
+  });
+
   it('revalidates and syncs the active stream when status registration changes the filter', async () => {
     const { backend, messages } = createRecordingBackend();
 


### PR DESCRIPTION
## Summary

Routes existing-stream RUNNING transitions through the progress-view metadata patch path so the webview receives the backend-owned reset state when a stream starts another run. This clears stale round and tool-call badges immediately instead of waiting for a later progress event.

## Issue acceptance gates

Addresses #7178:

- Re-verified the backend reset path still clears `roundStage`, `conversationProgress.toolCallCount`, and finished child counters in `ProgressViewState.resetFinishedChildCounters()`.
- Re-verified the existing-stream status-only branch still omitted those reset fields.
- Existing streams that re-enter RUNNING now send `UPDATE_STREAM_METADATA`, carrying the reset metadata from the backend state.
- Added a regression that seeds stale round/tool-call/finished-child values, re-enters RUNNING, and asserts the outbound message is a metadata patch with explicit `roundStage` clear and zeroed counters.

## Single source of truth

`ProgressViewState` remains the owner of backend-owned stream metadata, and `WebviewUpdater.updateStreamMetadata()` is the single outbound path for metadata patches that must carry more than status/substate/timestamp.

## Duplication and abstraction budget

No new abstraction or pass-through layer was added. The change reuses the existing metadata patch contract rather than extending `UPDATE_STREAM_STATUS` with another partial metadata shape.

## Host impact

Extension: Existing stream tabs clear stale progress badges as soon as a new RUNNING transition starts.

Desktop: Same shared progress backend metadata patch applies to desktop progress views.

CLI: No CLI behavior or headless output changes.

## Scheduled refactoring

None. No shim, dual-write, alias, fallback, or migration path was introduced.

## Validation

- `corepack pnpm exec prettier --write src/shared/progressView/backend/events/ProgressEventHandler.ts src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `npm test -- --run src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `npm run typecheck`
- `npm test`
- `npm run lint` (passes with one pre-existing warning in `packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts`)
- `npm run compile:fast`
- `git diff --check`

Closes #7178

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to progress-view IPC when an existing stream starts a new run; no auth, data, or CLI impact.
> 
> **Overview**
> When an **existing** stream tab transitions to **RUNNING** again, the progress backend already resets per-run state (`roundStage`, tool-call counts, finished child counters) but the webview was still notified via **`UPDATE_STREAM_STATUS`**, which did not carry those cleared fields—so stale badges could linger until later progress events.
> 
> **`setStreamStatus`** now routes that case through **`updateStreamMetadata`** (same path as new streams), so the outbound patch includes the backend-owned reset **`streamState`** immediately.
> 
> A regression test seeds stale round/tool-call/finished-child values, re-enters RUNNING from COMPLETED, and asserts the message is a metadata patch with zeroed counters and an explicit **`roundStage`** clear (not a status-only update).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3493bb047f644b56682ef23b2c18d35e3bb6934. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->