### PR TITLE
fix: isolate orphan sweep failures

### DIFF
--- a/src/shared/progressView/backend/state/SessionStores.ts
+++ b/src/shared/progressView/backend/state/SessionStores.ts
@@ -1,11 +1,16 @@
 // Local imports - agent
 import { deleteExecution as deleteStoredExecution } from '@agent/storage/executionListing';
 
+// Local imports - logger
+import * as logger from '@logger/logUtils';
+
 // Local imports - shared
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
 // Local imports - transcript
 import type { StreamLogStore, StreamSnapshotStore } from '@transcript';
+
+const CHANNEL = 'SessionStores';
 
 export interface SessionStoresOptions {
   streamLogs: StreamLogStore;
@@ -69,19 +74,29 @@ export class SessionStores {
     const orphanedStreams = persistedStreams.filter(
       (stream) => !liveStreams.has(stream),
     );
+    const sweptStreams: StreamTabId[] = [];
     const executionIds = new Set<ExecutionId>();
 
     await Promise.all(
       orphanedStreams.map(async (stream) => {
-        const executionId =
-          await this.snapshots.readPersistedExecutionId(stream);
-        if (executionId) executionIds.add(executionId);
-        await this.snapshots.deleteStream(stream);
+        try {
+          const executionId =
+            await this.snapshots.readPersistedExecutionId(stream);
+          await this.snapshots.deleteStream(stream);
+          sweptStreams.push(stream);
+          if (executionId) executionIds.add(executionId);
+        } catch (error) {
+          logger.warn(
+            CHANNEL,
+            `Skipping orphaned stream cleanup for ${stream}; startup will continue.`,
+            { data: error },
+          );
+        }
       }),
     );
     await this.deleteExecutionIds(executionIds);
 
-    return { streams: orphanedStreams, executionIds: [...executionIds] };
+    return { streams: sweptStreams, executionIds: [...executionIds] };
   }
 
   private async deleteExecutionIds(

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -10,6 +10,9 @@ import { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { TaskState } from '@agent/core/state/TaskState';
 import { bus } from '@eventBus/ProgressEventBus';
 
+// Local imports - logger
+import * as logger from '@logger/logUtils';
+
 // Local imports - shared
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import {
@@ -574,6 +577,68 @@ describe('ProgressBackend', () => {
       );
     } finally {
       await getExecutionStore(historyExecution).clear();
+      await backend.state.clearAll();
+      backend.dispose();
+      session.dispose();
+    }
+  });
+
+  it('continues sweeping streamData orphans when one orphan cleanup fails', async () => {
+    const failingStream = 'tool@deepseek#d6966d' as StreamTabId;
+    const sweptStream = 'tool@deepseek#e6966e' as StreamTabId;
+    const failingExecution = 'd6966d' as ExecutionId;
+    const sweptExecution = 'e6966e' as ExecutionId;
+    const seed = new StreamSnapshotStore();
+    await seed.load([failingStream, sweptStream]);
+    seed.setTaskState(
+      failingStream,
+      toolUseTaskState('search', 'deepseekproT'),
+      failingExecution,
+    );
+    seed.setTaskState(
+      sweptStream,
+      toolUseTaskState('search', 'deepseekproT'),
+      sweptExecution,
+    );
+    await writeExecutionConfig(failingExecution);
+    await writeExecutionConfig(sweptExecution);
+    await seed.flush();
+
+    const { backend, session } = createIsolatedRecordingBackend();
+    const originalDeleteStream = backend.state.snapshots.deleteStream.bind(
+      backend.state.snapshots,
+    );
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const deleteSpy = vi
+      .spyOn(backend.state.snapshots, 'deleteStream')
+      .mockImplementation(async (stream) => {
+        if (stream === failingStream) {
+          throw new Error('locked stream sidecar');
+        }
+        await originalDeleteStream(stream);
+      });
+
+    try {
+      await expect(backend.state.load()).resolves.toBeUndefined();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        'SessionStores',
+        `Skipping orphaned stream cleanup for ${failingStream}; startup will continue.`,
+        { data: expect.any(Error) },
+      );
+      expect(await StorageFS.exists(streamDataDir(failingStream))).toBe(true);
+      expect(await StorageFS.exists(`executions/${failingExecution}`)).toBe(
+        true,
+      );
+      expect(await StorageFS.exists(streamDataDir(sweptStream))).toBe(false);
+      expect(await StorageFS.exists(`executions/${sweptExecution}`)).toBe(
+        false,
+      );
+    } finally {
+      deleteSpy.mockRestore();
+      warnSpy.mockRestore();
+      await getExecutionStore(failingExecution).clear();
+      await getExecutionStore(sweptExecution).clear();
       await backend.state.clearAll();
       backend.dispose();
       session.dispose();

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -12,7 +12,7 @@ import {
   WorkspaceStorageProvider,
 } from '@platform/defaults/workspaceStorage';
 import { createFakePlatform } from '@test/support/FakePlatform';
-import { setupPlatform } from '@test/support/setupPlatform';
+import { installPlatform, setupPlatform } from '@test/support/setupPlatform';
 import { StreamSnapshotStore, streamDataDir } from '@transcript';
 import { getExecutionStore } from '@agent/storage';
 import { TaskStateSchema, type TaskState } from '@agent/core/state/TaskState';


### PR DESCRIPTION
## Summary

Makes `SessionStores.sweepOrphanedStreams()` isolate per-orphan cleanup failures so one unreadable or locked `streamData/{id}` sidecar cannot reject `ProgressViewState.load()` and block progress-view startup.

## Issue acceptance gates

Addresses #7194:

- Re-verified `sweepOrphanedStreams()` still used a bare `Promise.all` over orphan cleanup work.
- Re-verified `ProgressViewState.load()` still awaited the sweep during startup.
- Wraps each orphan cleanup body in per-item try/catch with a warning and continues sweeping other orphans.
- Adds a regression where one orphan delete throws, another orphan is still cleaned up, and `ProgressViewState.load()` resolves.

## Single source of truth

`SessionStores` remains the lifecycle owner for the durable stream footprint across stream logs, streamData sidecars, and referenced execution directories.

## Duplication and abstraction budget

No new abstraction or pass-through layer was added. The change keeps the best-effort housekeeping policy inside the existing lifecycle owner instead of spreading startup error handling into `ProgressViewState.load()`.

## Host impact

Extension: Progress view startup continues if one orphaned stream sidecar cannot be cleaned up.

Desktop: Same shared backend startup sweep hardening applies to desktop progress views.

CLI: No CLI behavior or headless output changes.

## Scheduled refactoring

None. No shim, dual-write, alias, fallback, or migration path was introduced.

## Validation

- `corepack pnpm exec prettier --write src/shared/progressView/backend/state/SessionStores.ts src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `npm test -- --run src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `npm run typecheck`
- `npm test`
- `npm run lint` (passes with one pre-existing warning in `packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts`)
- `npm run compile:fast`
- `git diff --check`

Closes #7194

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Best-effort housekeeping only; failures are logged and skipped without changing live-stream behavior or auth/data paths.
> 
> **Overview**
> **Orphan stream cleanup no longer blocks progress-view startup** when a single `streamData` sidecar cannot be read or deleted.
> 
> `SessionStores.sweepOrphanedStreams()` now wraps each orphan’s cleanup in its own try/catch, logs a `SessionStores` warning, and keeps sweeping the rest. The sweep result lists only streams that were actually removed, and execution dirs are deleted only for those successes—so `ProgressViewState.load()` can finish even if one orphan is locked or corrupt.
> 
> A **ProgressBackend** regression test simulates one failing `deleteStream` and asserts `load()` resolves, the warning is emitted, and the other orphan (and its execution dir) is still cleaned up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d02f1b215bb667c1e8fcd55165d9acc8b82fc3a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->