### PR TITLE
fix(webview): rename tool-use follow-up panel label to "Follow-up chat"

### DIFF
--- a/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
@@ -140,10 +140,10 @@ export class WorkflowToolUseFollowupSection extends LitElement {
     return html`
       <wa-details
         class="panel-collapsible"
-        summary="Tool-use follow-up"
+        summary="Follow-up chat"
         @wa-show=${this.handleShow}
         role="region"
-        aria-label="Workflow tool-use follow-up"
+        aria-label="Follow-up chat"
       >
         <div class="followup__body">
           <div class="followup__description">


### PR DESCRIPTION
## Summary

Renames the tool-use follow-up panel's visible label from "Tool-use follow-up" to "Follow-up chat", and updates the `aria-label` to match so the accessible name stays consistent with what's shown on screen.

No behavior change, no other files reference the old label text (checked `src/agent/followUp/ToolUseFollowUp.ts` and `streamContexts.ts` -- both use "tool-use follow-up" only as internal terminology in doc comments, not user-facing text).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only label change in the progress webview with no behavior or API impact.
> 
> **Overview**
> Renames the workflow progress view collapsible panel’s visible title and region **`aria-label`** from **"Tool-use follow-up"** to **"Follow-up chat"** in `WorkflowToolUseFollowupSection`, so screen readers hear the same name users see.
> 
> No logic, events, or copy inside the panel body change; other controls still use their existing follow-up-specific labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51406a528bcfa05cb6e2b75a1213520a60939bbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->