### PR TITLE
fix(test-kernel): import installPlatform in StreamSnapshotStore.vitest.ts

### DIFF
--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -12,7 +12,7 @@ import {
   WorkspaceStorageProvider,
 } from '@platform/defaults/workspaceStorage';
 import { createFakePlatform } from '@test/support/FakePlatform';
-import { setupPlatform } from '@test/support/setupPlatform';
+import { installPlatform, setupPlatform } from '@test/support/setupPlatform';
 import { StreamSnapshotStore, streamDataDir } from '@transcript';
 import { getExecutionStore } from '@agent/storage';
 import { TaskStateSchema, type TaskState } from '@agent/core/state/TaskState';


### PR DESCRIPTION
## Summary

`main` is currently failing typecheck: #7189 migrated `StreamSnapshotStore.vitest.ts`'s ad hoc per-test platform installs to the new `installPlatform()` helper from `@test/support/setupPlatform`, but only added `setupPlatform` to the import — `installPlatform` itself was never imported, even though it's called at 4 call sites (lines 396, 415, 443, 470).

## Fix

Add `installPlatform` to the existing import from `@test/support/setupPlatform`.

## Verification

- `tsc --noEmit -p tsconfig.test-kernel.json` — clean (previously reported 4 errors on this file)
- `vitest run src/test-kernel/transcript/StreamSnapshotStore.vitest.ts` — 21/21 passing

This is blocking CI on every other open PR (validate/validate-linux fail repo-wide until this lands), so flagging as urgent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only import fix with no runtime or production behavior changes.
> 
> **Overview**
> Restores a missing import so `StreamSnapshotStore.vitest.ts` typechecks again after the migration to `installPlatform()` from `@test/support/setupPlatform`.
> 
> The file already calls **`installPlatform`** in several tests but only imported **`setupPlatform`**; this adds **`installPlatform`** to that same import line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35be14c7b36a3d63292e14ec58c5da651c64910f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->