### PR TITLE
fix: isolate orphan execution cleanup failures

### DIFF
--- a/src/shared/progressView/backend/state/SessionStores.ts
+++ b/src/shared/progressView/backend/state/SessionStores.ts
@@ -76,6 +76,7 @@ export class SessionStores {
     );
     const sweptStreams: StreamTabId[] = [];
     const executionIds = new Set<ExecutionId>();
+    const sweptExecutionIds: ExecutionId[] = [];
 
     await Promise.all(
       orphanedStreams.map(async (stream) => {
@@ -94,9 +95,22 @@ export class SessionStores {
         }
       }),
     );
-    await this.deleteExecutionIds(executionIds);
+    await Promise.all(
+      [...executionIds].map(async (executionId) => {
+        try {
+          const deleted = await this.deleteExecution(executionId);
+          if (deleted) sweptExecutionIds.push(executionId);
+        } catch (error) {
+          logger.warn(
+            CHANNEL,
+            `Skipping orphaned execution cleanup for ${executionId}; startup will continue.`,
+            { data: error },
+          );
+        }
+      }),
+    );
 
-    return { streams: sweptStreams, executionIds: [...executionIds] };
+    return { streams: sweptStreams, executionIds: sweptExecutionIds };
   }
 
   private async deleteExecutionIds(

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -644,4 +644,69 @@ describe('ProgressBackend', () => {
       session.dispose();
     }
   });
+
+  it('continues sweeping streamData orphans when one execution cleanup fails', async () => {
+    const failingStream = 'tool@deepseek#f6966f' as StreamTabId;
+    const sweptStream = 'tool@deepseek#a6966a' as StreamTabId;
+    const failingExecution = 'f6966f' as ExecutionId;
+    const sweptExecution = 'a6966a' as ExecutionId;
+    const seed = new StreamSnapshotStore();
+    await seed.load([failingStream, sweptStream]);
+    seed.setTaskState(
+      failingStream,
+      toolUseTaskState('search', 'deepseekproT'),
+      failingExecution,
+    );
+    seed.setTaskState(
+      sweptStream,
+      toolUseTaskState('search', 'deepseekproT'),
+      sweptExecution,
+    );
+    await writeExecutionConfig(failingExecution);
+    await writeExecutionConfig(sweptExecution);
+    await seed.flush();
+
+    const { backend, session } = createIsolatedRecordingBackend();
+    const stores = backend.state.stores as unknown as {
+      deleteExecution(executionId: ExecutionId): Promise<boolean>;
+    };
+    const originalDeleteExecution = stores.deleteExecution.bind(
+      backend.state.stores,
+    );
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const deleteExecutionSpy = vi
+      .spyOn(stores, 'deleteExecution')
+      .mockImplementation(async (executionId) => {
+        if (executionId === failingExecution) {
+          throw new Error('locked execution dir');
+        }
+        return originalDeleteExecution(executionId);
+      });
+
+    try {
+      await expect(backend.state.load()).resolves.toBeUndefined();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        'SessionStores',
+        `Skipping orphaned execution cleanup for ${failingExecution}; startup will continue.`,
+        { data: expect.any(Error) },
+      );
+      expect(await StorageFS.exists(streamDataDir(failingStream))).toBe(false);
+      expect(await StorageFS.exists(`executions/${failingExecution}`)).toBe(
+        true,
+      );
+      expect(await StorageFS.exists(streamDataDir(sweptStream))).toBe(false);
+      expect(await StorageFS.exists(`executions/${sweptExecution}`)).toBe(
+        false,
+      );
+    } finally {
+      deleteExecutionSpy.mockRestore();
+      warnSpy.mockRestore();
+      await getExecutionStore(failingExecution).clear();
+      await getExecutionStore(sweptExecution).clear();
+      await backend.state.clearAll();
+      backend.dispose();
+      session.dispose();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

`SessionStores.sweepOrphanedStreams()` now treats orphan execution-directory deletion as best-effort startup housekeeping. A failure deleting one execution directory logs a warning and does not reject progress-view state loading or stop other execution cleanup.

## Issue acceptance gates

Addresses #7203:

- Re-verified the current `sweepOrphanedStreams()` evidence: per-stream cleanup was isolated, but execution deletion still happened outside that isolated path.
- Execution-directory delete failures during orphan sweep now warn and continue.
- Added a regression test where one execution delete throws and `ProgressViewState.load()` still resolves while the other orphan execution is cleaned up.

## Single source of truth

`SessionStores` remains the lifecycle owner for progress stream durable footprint cleanup across `streamLogs`, `streamData`, and `executions/{id}`.

## Duplication and abstraction budget

No abstraction was added. The sweep-specific best-effort deletion stays inline in `sweepOrphanedStreams()` so strict tab-delete/delete-all semantics remain unchanged.

## Host impact

Extension: progress-view startup is no longer blocked by one orphan execution-directory delete failure.

Desktop: same shared backend behavior when the desktop progress state loads.

CLI: no CLI behavior change.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write src/shared/progressView/backend/state/SessionStores.ts src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `npm test -- --run src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `npm run typecheck`
- `npm test`
- `git diff --check`
- `npm run lint` (passes with the pre-existing unrelated warning in `packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts`)
- `npm run compile:fast`

Closes #7203

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Startup housekeeping only; explicit tab delete and delete-all still use strict `deleteExecutionIds()` behavior unchanged.
> 
> **Overview**
> **Orphan execution directory deletion during progress-view startup** is now best-effort, matching how per-stream orphan cleanup already behaved.
> 
> In `SessionStores.sweepOrphanedStreams()`, execution deletes no longer go through `deleteExecutionIds()` in one batch. Each ID is deleted in its own try/catch: failures log `Skipping orphaned execution cleanup for …` and do not reject state load or block other deletes. The returned `executionIds` list now reflects only executions that were actually removed, not every ID collected from swept streams.
> 
> A regression test asserts that when one `deleteExecution` throws, `ProgressViewState.load()` still resolves, the other orphan stream and execution are cleaned up, and the locked execution directory is left on disk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 318c0a09981fbd3eb24bd3aa27da2994be4b5403. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->