### PR TITLE
fix(modelHandlers): clamp reasoning effort to medium on the Codex subscription path

### DIFF
--- a/src/agent/modelHandlers/openai/modelHandlerCodex.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerCodex.ts
@@ -105,6 +105,10 @@ export const CODEX_DEFAULT_INSTRUCTIONS = 'You are a helpful assistant.';
  *  - guarantee a non-empty top-level `instructions`, hoisting system/developer
  *    items out of `input` into `instructions` (matching Zed/Codex), deduping
  *    text already present, with {@link CODEX_DEFAULT_INSTRUCTIONS} as fallback.
+ *  - clamp `reasoning.effort` above `medium` down to `medium`: with no
+ *    background mode (see above), a `high`/`xhigh` reasoning turn runs fully
+ *    synchronously over this connection and risks the client timing out
+ *    before the backend responds.
  */
 export function rewriteCodexRequestBody(
   body: Record<string, unknown>,
@@ -116,6 +120,16 @@ export function rewriteCodexRequestBody(
   delete rewritten.max_output_tokens;
   delete rewritten.background;
   rewritten.store = false;
+
+  const reasoning = rewritten.reasoning;
+  if (
+    reasoning &&
+    typeof reasoning === 'object' &&
+    'effort' in reasoning &&
+    (reasoning.effort === 'high' || reasoning.effort === 'xhigh')
+  ) {
+    rewritten.reasoning = { ...reasoning, effort: 'medium' };
+  }
 
   const instructions: string[] = [];
   if (

--- a/src/test-kernel/agent/modelHandlers/CodexRequestRewrite.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/CodexRequestRewrite.vitest.ts
@@ -150,6 +150,28 @@ describe('rewriteCodexRequestBody', () => {
     rewriteCodexRequestBody(body);
     expect(body).toEqual(snapshot);
   });
+
+  it.each(['high', 'xhigh'])(
+    'clamps %s reasoning effort down to medium (no background mode to absorb a long synchronous turn)',
+    (effort) => {
+      const out = rewriteCodexRequestBody({
+        input: [{ role: 'user', content: 'hi' }],
+        reasoning: { effort },
+      });
+      expect(out.reasoning).toEqual({ effort: 'medium' });
+    },
+  );
+
+  it.each(['low', 'medium'])(
+    'leaves %s reasoning effort unchanged',
+    (effort) => {
+      const out = rewriteCodexRequestBody({
+        input: [{ role: 'user', content: 'hi' }],
+        reasoning: { effort },
+      });
+      expect(out.reasoning).toEqual({ effort });
+    },
+  );
 });
 
 describe('isGenerationRequest', () => {


### PR DESCRIPTION
## Summary

The ChatGPT-subscription (Codex) backend used by `modelHandlerCodex.ts` has no background mode at all (see the existing `background`-stripping comment in `rewriteCodexRequestBody`). Without it, a `high`/`xhigh` reasoning-effort turn has to run fully synchronously over the connection, which risks the client timing out before the backend finishes responding.

## Fix

In `rewriteCodexRequestBody`, clamp `reasoning.effort` down to `medium` when it's `high` or `xhigh`. `low`/`medium` pass through unchanged — this only caps the ceiling, it doesn't override an already-conservative user selection. Only affects requests routed through the ChatGPT-subscription (Codex) path; API-key requests to `gpt-5.5` are untouched.

## Verification

- `tsc --noEmit` (root) and `-p tsconfig.test-kernel.json` — both clean
- `eslint` on both touched files — clean
- New `CodexRequestRewrite.vitest.ts` cases: `high`/`xhigh` clamp to `medium`, `low`/`medium` pass through unchanged — 15/15 tests passing (11 existing + 4 new)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Subscription-only request shaping with explicit tests; no auth or API-key path changes, only a ceiling on reasoning effort for Codex.
> 
> **Overview**
> On the **ChatGPT subscription (Codex)** path, `rewriteCodexRequestBody` now **caps** `reasoning.effort` at **`medium`** when the outgoing request would use **`high`** or **`xhigh`**. **`low`** and **`medium`** are unchanged.
> 
> Codex has **no background mode**, so those higher effort levels would run as a **long synchronous** turn on the same connection and can **time out** before a response. The same rewrite already applies on **HTTP** (`codexFetch`) and **WebSocket** (`prepareWireParams`); API-key OpenAI routes are unaffected.
> 
> Tests in `CodexRequestRewrite.vitest.ts` lock in clamping for `high`/`xhigh` and pass-through for `low`/`medium`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7a12721818a3893901ce5280aa9397fd307e4fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->