### PR TITLE
fix(settingsView): left-align provider group rows in Model Selection

### DIFF
--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.styles.ts
@@ -82,6 +82,11 @@ export const modelSelectionListStyles: CSSResult = css`
   .provider-group-toggle::part(base) {
     display: flex;
     align-items: center;
+    /* wa-button's own .button part defaults to justify-content: center
+     * (a centered label suits a typical button) -- override it here since
+     * this button's content is a left-aligned row (chevron, name, count),
+     * matching the API Configuration provider rows above it. */
+    justify-content: flex-start;
     width: 100%;
     padding: var(--wa-space-xs);
     background: none;


### PR DESCRIPTION
## Problem

In the settings Dashboard, the provider group header rows under **Model Selection** ("OpenAI 2/4 enabled ✓", "Anthropic 4/9 enabled ✓", etc.) render with their chevron/name/count content horizontally centered, unlike the equivalent provider rows in **API Configuration** just above, which are flush left.

## Root cause

`.provider-group-toggle` wraps a `<wa-button>`. Web Awesome's own `.button` part defaults to `justify-content: center` (sensible for a typical centered-label button). The `.provider-group-toggle::part(base)` override in `ModelSelectionList.styles.ts` sets `display: flex; align-items: center; width: 100%` but never touches `justify-content`, so the component's centering default leaks through.

## Fix

Add `justify-content: flex-start` to `.provider-group-toggle::part(base)`.

## Verification

- `tsc --noEmit -p packages/extension/tsconfig.json` — clean
- `eslint` on the touched file — clean
- `ModelSelectionProviderKeys.vitest.ts` — 2/2 passing (no test asserts computed styles, so this is a visual-only fix; screenshot below)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CSS-only layout fix on settings UI; no logic, auth, or data changes.
> 
> **Overview**
> **Model Selection** provider group header rows (chevron, name, enabled count) were horizontally centered because `wa-button`’s shadow `.button` part defaults to `justify-content: center`, and the existing `::part(base)` override never changed that.
> 
> This adds **`justify-content: flex-start`** on `.provider-group-toggle::part(base)` in `ModelSelectionList.styles.ts` so those rows align left like **API Configuration** provider rows above.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d79d7defd403d98f9cfc38efe156197d5932465. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->