### PR TITLE
fix: misc small cleanups (typecheck, Codex reasoning effort, UI labels/alignment)

### DIFF
--- a/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
@@ -140,10 +140,10 @@ export class WorkflowToolUseFollowupSection extends LitElement {
     return html`
       <wa-details
         class="panel-collapsible"
-        summary="Tool-use follow-up"
+        summary="Follow-up chat"
         @wa-show=${this.handleShow}
         role="region"
-        aria-label="Workflow tool-use follow-up"
+        aria-label="Follow-up chat"
       >
         <div class="followup__body">
           <div class="followup__description">

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.styles.ts
@@ -82,6 +82,11 @@ export const modelSelectionListStyles: CSSResult = css`
   .provider-group-toggle::part(base) {
     display: flex;
     align-items: center;
+    /* wa-button's own .button part defaults to justify-content: center
+     * (a centered label suits a typical button) -- override it here since
+     * this button's content is a left-aligned row (chevron, name, count),
+     * matching the API Configuration provider rows above it. */
+    justify-content: flex-start;
     width: 100%;
     padding: var(--wa-space-xs);
     background: none;

--- a/src/agent/modelHandlers/openai/modelHandlerCodex.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerCodex.ts
@@ -105,6 +105,10 @@ export const CODEX_DEFAULT_INSTRUCTIONS = 'You are a helpful assistant.';
  *  - guarantee a non-empty top-level `instructions`, hoisting system/developer
  *    items out of `input` into `instructions` (matching Zed/Codex), deduping
  *    text already present, with {@link CODEX_DEFAULT_INSTRUCTIONS} as fallback.
+ *  - clamp `reasoning.effort` above `medium` down to `medium`: with no
+ *    background mode (see above), a `high`/`xhigh` reasoning turn runs fully
+ *    synchronously over this connection and risks the client timing out
+ *    before the backend responds.
  */
 export function rewriteCodexRequestBody(
   body: Record<string, unknown>,
@@ -116,6 +120,16 @@ export function rewriteCodexRequestBody(
   delete rewritten.max_output_tokens;
   delete rewritten.background;
   rewritten.store = false;
+
+  const reasoning = rewritten.reasoning;
+  if (
+    reasoning &&
+    typeof reasoning === 'object' &&
+    'effort' in reasoning &&
+    (reasoning.effort === 'high' || reasoning.effort === 'xhigh')
+  ) {
+    rewritten.reasoning = { ...reasoning, effort: 'medium' };
+  }
 
   const instructions: string[] = [];
   if (

--- a/src/test-kernel/agent/modelHandlers/CodexRequestRewrite.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/CodexRequestRewrite.vitest.ts
@@ -150,6 +150,28 @@ describe('rewriteCodexRequestBody', () => {
     rewriteCodexRequestBody(body);
     expect(body).toEqual(snapshot);
   });
+
+  it.each(['high', 'xhigh'])(
+    'clamps %s reasoning effort down to medium (no background mode to absorb a long synchronous turn)',
+    (effort) => {
+      const out = rewriteCodexRequestBody({
+        input: [{ role: 'user', content: 'hi' }],
+        reasoning: { effort },
+      });
+      expect(out.reasoning).toEqual({ effort: 'medium' });
+    },
+  );
+
+  it.each(['low', 'medium'])(
+    'leaves %s reasoning effort unchanged',
+    (effort) => {
+      const out = rewriteCodexRequestBody({
+        input: [{ role: 'user', content: 'hi' }],
+        reasoning: { effort },
+      });
+      expect(out.reasoning).toEqual({ effort });
+    },
+  );
 });
 
 describe('isGenerationRequest', () => {

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -12,7 +12,7 @@ import {
   WorkspaceStorageProvider,
 } from '@platform/defaults/workspaceStorage';
 import { createFakePlatform } from '@test/support/FakePlatform';
-import { setupPlatform } from '@test/support/setupPlatform';
+import { installPlatform, setupPlatform } from '@test/support/setupPlatform';
 import { StreamSnapshotStore, streamDataDir } from '@transcript';
 import { getExecutionStore } from '@agent/storage';
 import { TaskStateSchema, type TaskState } from '@agent/core/state/TaskState';


### PR DESCRIPTION
Consolidates 4 small, independent fixes from #7204, #7198, #7206, #7207 into one PR:

1. **fix(test-kernel):** import `installPlatform` in `StreamSnapshotStore.vitest.ts` — #7189 left 4 call sites referencing an unimported name, breaking `main`'s typecheck repo-wide.
2. **fix(webview):** rename the tool-use follow-up panel label to "Follow-up chat", aria-label to match.
3. **fix(modelHandlers):** clamp `reasoning.effort` to `medium` on the Codex (ChatGPT subscription) path — no background mode means a high/xhigh turn risks a client timeout.
4. **fix(settingsView):** left-align the provider group rows in Model Selection (`wa-button`'s default `justify-content: center` was leaking through).

Each commit is independently verified (typecheck + targeted tests, see the individual PRs). Closing #7204/#7198/#7206/#7207 in favor of this one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized changes; the Codex clamp only affects subscription wire requests and reduces timeout risk rather than widening capability.
> 
> **Overview**
> Bundles four independent fixes: **test import**, **progress UI copy**, **Codex request shaping**, and **settings layout**.
> 
> Adds the missing `installPlatform` import in `StreamSnapshotStore.vitest.ts` so existing `installPlatform()` call sites typecheck again.
> 
> Renames the workflow tool-use follow-up collapsible to **"Follow-up chat"** (summary and `aria-label`).
> 
> On the ChatGPT subscription Codex path, `rewriteCodexRequestBody` now **downgrades `reasoning.effort` from `high`/`xhigh` to `medium`**, because without background mode those turns run synchronously and can time out; `low`/`medium` are unchanged. Vitest fixtures cover the clamp.
> 
> In Model Selection, provider group toggle buttons get **`justify-content: flex-start`** on the `wa-button` part so chevron/name/count align left like the API Configuration rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cb246718b82631351a313d84b38809fb792b9b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->