### PR TITLE
fix: version execution resume records

### DIFF
--- a/docs/proposals/texra-bench-science-benchmarks.md
+++ b/docs/proposals/texra-bench-science-benchmarks.md
@@ -99,10 +99,10 @@ The verifier library is therefore **data, not harness code**: a standard grader 
 
 | `std/` grader (command) | Wraps                                                                                                                                                                                                                                                           |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `std/compile-check`     | `compileCheck.ts` / `latexToolchain.ts` invoked directly, independent of the interactive `WORKFLOW_AUTO_COMPILE` setting — a required gate can't depend on a user preference — the hard gate |
+| `std/compile-check`     | `compileCheck.ts` / `latexToolchain.ts` invoked directly, independent of the interactive `WORKFLOW_AUTO_COMPILE` setting — a required gate can't depend on a user preference — the hard gate                                                                    |
 | `std/cas-equal`         | `wolframscript` (or SymPy) executing a **fixed** `refs/` assertion script against the extracted `\benchresult{...}` — outcome-level, targeting renotation-robustness (how far that can be pushed is open — §15), no credit for matching a human derivation path |
 | `std/lean-build`        | `lake build` against a pinned mathlib toolchain; binary per lemma. Proof tasks need only a statement — difficulty can outgrow the task's author (§6 validate exempts this stack from the gold-`refs/solution` check, since it has no reference answer to score) |
-| `std/diff-align`        | the math-aware latexdiff service — **error-injection tasks only**: edits inside injected spans must match gold, edits outside are penalized; not applicable to derivation/proof tasks, which have no injected spans |
+| `std/diff-align`        | the math-aware latexdiff service — **error-injection tasks only**: edits inside injected spans must match gold, edits outside are penalized; not applicable to derivation/proof tasks, which have no injected spans                                             |
 | `std/issue-match`       | `ReviewIssue` matching against gold defects within a line window → precision/recall                                                                                                                                                                             |
 | `std/answer-match`      | numeric-tolerance / exact / set matching on parsed answer blocks                                                                                                                                                                                                |
 
@@ -138,7 +138,7 @@ bench-results/<suite@version>/<runId>/<model>/<task>/trial-<n>/
                     # to that machinery, not built yet)
 ```
 
-- **Comparability rule:** two scores are comparable iff their *task*, *grader-pack*, and *environment* digests match; the subject dimension (model id and/or agent digest) is exactly what `--compare` varies, so it's excluded from the match. `bench report` refuses comparisons that differ on any of the fixed digests.
+- **Comparability rule:** two scores are comparable iff their _task_, _grader-pack_, and _environment_ digests match; the subject dimension (model id and/or agent digest) is exactly what `--compare` varies, so it's excluded from the match. `bench report` refuses comparisons that differ on any of the fixed digests.
 - **Regrade, don't rerun:** graders never mutate these directories, only read them; `bench grade --regrade --diff-against <old>` (a suite version, e.g. `1.1`, resolved under `--results-dir` to that version's evidence directory) recomputes history at zero model cost and attributes every delta to the grader diff.
 - **Hermetic execution:** a published container image pins TeX Live / Lean / wolframscript; `env.json` records the fingerprint; network off by default at the container level (not just tool-level filtering — a solver with shell access could otherwise reach the network via `curl`/package managers even with web tools disabled), with web tools additionally disabled in-agent via the existing `runtimeUnavailableTools` mechanism (`src/agent/runtime/RunContext.ts`) as defense in depth. No new sandbox layer beyond the container's own network policy.
 - **Determinism honesty:** providers offer no usable seeds; replicate variance is measured and reported, never pretended away.
@@ -192,18 +192,18 @@ Six subcommands. Exit codes reuse `packages/cli/src/runtime/exitCodes.ts`; score
 
 ## 11. Existing machinery it rides on
 
-| Bench component                   | Existing code                                                                                                                         |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Bench component                   | Existing code                                                                                                                                                                                                                       |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Cell execution                    | `packages/cli/src/runtime/runExecution.ts`; tool-use path via `packages/cli/src/commands/agentsRun.ts` (today stops after one model/tool cycle — `stopAfterCycle: true` — bench needs a multi-cycle variant, tracked as an MVP gap) |
-| Compile gate / diff / structure   | `src/agent/output/compileCheck.ts`, `src/latex/latexdiff/`, `src/latex/latexToolchain.ts`, `src/latex/labelSearch.ts`, `src/latex/extractBibliography.ts` |
-| CAS / Lean verifiers              | `src/tools/wolfram/wolframScriptUtils.ts`, `src/tools/lean/direct/lakeCommands.ts`, `src/tools/lean/LspTools.ts`, `src/tools/lean/LoogleTool.ts`          |
-| Issue localization                | `src/agent/review/reviewIssues.ts`; solver pattern from `packages/extension/resources/tool_use_agents/changeReviewer.yaml`            |
-| Fresh-task supply                 | `src/latex/arxivProcessor.ts`                                                                                                         |
-| Trace archive                     | `AgentTrace` subscriber (`src/agent/trace/AgentTrace.ts`, pattern: `src/transcript/TexraTranscriptRecorder.ts`); `AgentEvent` union    |
-| Usage / cost / abort              | `src/agent/core/usage/RunUsageAccumulator.ts` (`totalCost` drives `--max-cost-usd`, checked between dispatches — a soft budget guard under concurrency, not a per-cell reservation) |
-| Providers incl. internal gateways | `src/agent/modelHandlers/` (four stacks; `customBaseUrl` already threaded)                                                            |
-| Solver/judge agents               | ordinary agent YAML under `packages/extension/resources/agents/bench/`, run via `runAgent` (`src/agent/runtime/runAgent.ts`)          |
-| Env fingerprint                   | `texra doctor` machinery (`packages/cli/src/commands/doctor.ts`) — today probes Node/workspace/auth/LaTeX/config; Wolfram/lake/image-digest probes are new additions, not built yet |
+| Compile gate / diff / structure   | `src/agent/output/compileCheck.ts`, `src/latex/latexdiff/`, `src/latex/latexToolchain.ts`, `src/latex/labelSearch.ts`, `src/latex/extractBibliography.ts`                                                                           |
+| CAS / Lean verifiers              | `src/tools/wolfram/wolframScriptUtils.ts`, `src/tools/lean/direct/lakeCommands.ts`, `src/tools/lean/LspTools.ts`, `src/tools/lean/LoogleTool.ts`                                                                                    |
+| Issue localization                | `src/agent/review/reviewIssues.ts`; solver pattern from `packages/extension/resources/tool_use_agents/changeReviewer.yaml`                                                                                                          |
+| Fresh-task supply                 | `src/latex/arxivProcessor.ts`                                                                                                                                                                                                       |
+| Trace archive                     | `AgentTrace` subscriber (`src/agent/trace/AgentTrace.ts`, pattern: `src/transcript/TexraTranscriptRecorder.ts`); `AgentEvent` union                                                                                                 |
+| Usage / cost / abort              | `src/agent/core/usage/RunUsageAccumulator.ts` (`totalCost` drives `--max-cost-usd`, checked between dispatches — a soft budget guard under concurrency, not a per-cell reservation)                                                 |
+| Providers incl. internal gateways | `src/agent/modelHandlers/` (four stacks; `customBaseUrl` already threaded)                                                                                                                                                          |
+| Solver/judge agents               | ordinary agent YAML under `packages/extension/resources/agents/bench/`, run via `runAgent` (`src/agent/runtime/runAgent.ts`)                                                                                                        |
+| Env fingerprint                   | `texra doctor` machinery (`packages/cli/src/commands/doctor.ts`) — today probes Node/workspace/auth/LaTeX/config; Wolfram/lake/image-digest probes are new additions, not built yet                                                 |
 
 All additive: new code lives in `src/bench/` (VS Code-free zone, host services via `platform()`) and `packages/cli/`. **The MVP requires zero changes to `src/agent/` core.**
 

--- a/docs/proposals/texra-bench-science-benchmarks.md
+++ b/docs/proposals/texra-bench-science-benchmarks.md
@@ -99,10 +99,10 @@ The verifier library is therefore **data, not harness code**: a standard grader 
 
 | `std/` grader (command) | Wraps                                                                                                                                                                                                                                                           |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `std/compile-check`     | `compileCheck.ts` / `latexToolchain.ts` invoked directly, independent of the interactive `WORKFLOW_AUTO_COMPILE` setting — a required gate can't depend on a user preference — the hard gate                                                                    |
+| `std/compile-check`     | `compileCheck.ts` / `latexToolchain.ts` invoked directly, independent of the interactive `WORKFLOW_AUTO_COMPILE` setting — a required gate can't depend on a user preference — the hard gate |
 | `std/cas-equal`         | `wolframscript` (or SymPy) executing a **fixed** `refs/` assertion script against the extracted `\benchresult{...}` — outcome-level, targeting renotation-robustness (how far that can be pushed is open — §15), no credit for matching a human derivation path |
 | `std/lean-build`        | `lake build` against a pinned mathlib toolchain; binary per lemma. Proof tasks need only a statement — difficulty can outgrow the task's author (§6 validate exempts this stack from the gold-`refs/solution` check, since it has no reference answer to score) |
-| `std/diff-align`        | the math-aware latexdiff service — **error-injection tasks only**: edits inside injected spans must match gold, edits outside are penalized; not applicable to derivation/proof tasks, which have no injected spans                                             |
+| `std/diff-align`        | the math-aware latexdiff service — **error-injection tasks only**: edits inside injected spans must match gold, edits outside are penalized; not applicable to derivation/proof tasks, which have no injected spans |
 | `std/issue-match`       | `ReviewIssue` matching against gold defects within a line window → precision/recall                                                                                                                                                                             |
 | `std/answer-match`      | numeric-tolerance / exact / set matching on parsed answer blocks                                                                                                                                                                                                |
 
@@ -138,7 +138,7 @@ bench-results/<suite@version>/<runId>/<model>/<task>/trial-<n>/
                     # to that machinery, not built yet)
 ```
 
-- **Comparability rule:** two scores are comparable iff their _task_, _grader-pack_, and _environment_ digests match; the subject dimension (model id and/or agent digest) is exactly what `--compare` varies, so it's excluded from the match. `bench report` refuses comparisons that differ on any of the fixed digests.
+- **Comparability rule:** two scores are comparable iff their *task*, *grader-pack*, and *environment* digests match; the subject dimension (model id and/or agent digest) is exactly what `--compare` varies, so it's excluded from the match. `bench report` refuses comparisons that differ on any of the fixed digests.
 - **Regrade, don't rerun:** graders never mutate these directories, only read them; `bench grade --regrade --diff-against <old>` (a suite version, e.g. `1.1`, resolved under `--results-dir` to that version's evidence directory) recomputes history at zero model cost and attributes every delta to the grader diff.
 - **Hermetic execution:** a published container image pins TeX Live / Lean / wolframscript; `env.json` records the fingerprint; network off by default at the container level (not just tool-level filtering — a solver with shell access could otherwise reach the network via `curl`/package managers even with web tools disabled), with web tools additionally disabled in-agent via the existing `runtimeUnavailableTools` mechanism (`src/agent/runtime/RunContext.ts`) as defense in depth. No new sandbox layer beyond the container's own network policy.
 - **Determinism honesty:** providers offer no usable seeds; replicate variance is measured and reported, never pretended away.
@@ -192,18 +192,18 @@ Six subcommands. Exit codes reuse `packages/cli/src/runtime/exitCodes.ts`; score
 
 ## 11. Existing machinery it rides on
 
-| Bench component                   | Existing code                                                                                                                                                                                                                       |
-| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Bench component                   | Existing code                                                                                                                         |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | Cell execution                    | `packages/cli/src/runtime/runExecution.ts`; tool-use path via `packages/cli/src/commands/agentsRun.ts` (today stops after one model/tool cycle — `stopAfterCycle: true` — bench needs a multi-cycle variant, tracked as an MVP gap) |
-| Compile gate / diff / structure   | `src/agent/output/compileCheck.ts`, `src/latex/latexdiff/`, `src/latex/latexToolchain.ts`, `src/latex/labelSearch.ts`, `src/latex/extractBibliography.ts`                                                                           |
-| CAS / Lean verifiers              | `src/tools/wolfram/wolframScriptUtils.ts`, `src/tools/lean/direct/lakeCommands.ts`, `src/tools/lean/LspTools.ts`, `src/tools/lean/LoogleTool.ts`                                                                                    |
-| Issue localization                | `src/agent/review/reviewIssues.ts`; solver pattern from `packages/extension/resources/tool_use_agents/changeReviewer.yaml`                                                                                                          |
-| Fresh-task supply                 | `src/latex/arxivProcessor.ts`                                                                                                                                                                                                       |
-| Trace archive                     | `AgentTrace` subscriber (`src/agent/trace/AgentTrace.ts`, pattern: `src/transcript/TexraTranscriptRecorder.ts`); `AgentEvent` union                                                                                                 |
-| Usage / cost / abort              | `src/agent/core/usage/RunUsageAccumulator.ts` (`totalCost` drives `--max-cost-usd`, checked between dispatches — a soft budget guard under concurrency, not a per-cell reservation)                                                 |
-| Providers incl. internal gateways | `src/agent/modelHandlers/` (four stacks; `customBaseUrl` already threaded)                                                                                                                                                          |
-| Solver/judge agents               | ordinary agent YAML under `packages/extension/resources/agents/bench/`, run via `runAgent` (`src/agent/runtime/runAgent.ts`)                                                                                                        |
-| Env fingerprint                   | `texra doctor` machinery (`packages/cli/src/commands/doctor.ts`) — today probes Node/workspace/auth/LaTeX/config; Wolfram/lake/image-digest probes are new additions, not built yet                                                 |
+| Compile gate / diff / structure   | `src/agent/output/compileCheck.ts`, `src/latex/latexdiff/`, `src/latex/latexToolchain.ts`, `src/latex/labelSearch.ts`, `src/latex/extractBibliography.ts` |
+| CAS / Lean verifiers              | `src/tools/wolfram/wolframScriptUtils.ts`, `src/tools/lean/direct/lakeCommands.ts`, `src/tools/lean/LspTools.ts`, `src/tools/lean/LoogleTool.ts`          |
+| Issue localization                | `src/agent/review/reviewIssues.ts`; solver pattern from `packages/extension/resources/tool_use_agents/changeReviewer.yaml`            |
+| Fresh-task supply                 | `src/latex/arxivProcessor.ts`                                                                                                         |
+| Trace archive                     | `AgentTrace` subscriber (`src/agent/trace/AgentTrace.ts`, pattern: `src/transcript/TexraTranscriptRecorder.ts`); `AgentEvent` union    |
+| Usage / cost / abort              | `src/agent/core/usage/RunUsageAccumulator.ts` (`totalCost` drives `--max-cost-usd`, checked between dispatches — a soft budget guard under concurrency, not a per-cell reservation) |
+| Providers incl. internal gateways | `src/agent/modelHandlers/` (four stacks; `customBaseUrl` already threaded)                                                            |
+| Solver/judge agents               | ordinary agent YAML under `packages/extension/resources/agents/bench/`, run via `runAgent` (`src/agent/runtime/runAgent.ts`)          |
+| Env fingerprint                   | `texra doctor` machinery (`packages/cli/src/commands/doctor.ts`) — today probes Node/workspace/auth/LaTeX/config; Wolfram/lake/image-digest probes are new additions, not built yet |
 
 All additive: new code lives in `src/bench/` (VS Code-free zone, host services via `platform()`) and `packages/cli/`. **The MVP requires zero changes to `src/agent/` core.**
 

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -15,6 +15,7 @@ import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
   PersistedFlow,
   flowKey,
+  stampFlowRecordSchemaVersion,
   type FlowRecord,
 } from '@agent/node/persistedFlow';
 import type { AgentToolUseSetting } from '@agent/core/definition/AgentDataclass';
@@ -365,7 +366,10 @@ export async function runToolUseFlow<C = unknown>(
             logger.debug('Migrated legacy shared state to flat format');
           }
           flowRecord.shared = migratedData;
-          await kv.write(flowKey(executionId), flowRecord);
+          await kv.write(
+            flowKey(executionId),
+            stampFlowRecordSchemaVersion(flowRecord),
+          );
         }
       }
     }

--- a/src/agent/node/persistedFlow.ts
+++ b/src/agent/node/persistedFlow.ts
@@ -16,16 +16,24 @@ export function flowKey(runId: string): string {
 const CHANNEL = 'PersistedFlow';
 logger.initialize(CHANNEL);
 
+export const FLOW_RECORD_SCHEMA_VERSION = 1;
+
 interface NodeRecord {
   action?: string;
 }
 
 export interface FlowRecord {
+  schemaVersion?: number;
   flowName: string;
   params: Record<string, unknown>;
   shared: unknown;
   createdAt: string;
   nodes: NodeRecord[];
+}
+
+export function stampFlowRecordSchemaVersion<T extends FlowRecord>(flow: T): T {
+  flow.schemaVersion = FLOW_RECORD_SCHEMA_VERSION;
+  return flow;
 }
 
 /**
@@ -180,7 +188,7 @@ export class PersistedFlow<
     this.cachedRecord = null;
     flow.nodes.push({ action });
     flow.shared = this.serializeShared(shared);
-    await this.kv.write(key, flow);
+    await this.kv.write(key, stampFlowRecordSchemaVersion(flow));
     this.cachedRecord = flow;
     await this.fireProjection(shared);
 
@@ -231,7 +239,7 @@ export class PersistedFlow<
     this.cachedRecord = null;
     mutate?.(flow);
     flow.shared = this.serializeShared(shared);
-    await this.kv.write(key, flow);
+    await this.kv.write(key, stampFlowRecordSchemaVersion(flow));
     this.cachedRecord = flow;
     await this.fireProjection(shared);
   }
@@ -245,6 +253,7 @@ export class PersistedFlow<
     }
 
     const record: FlowRecord = {
+      schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
       flowName: 'texra',
       params: this._params as Record<string, unknown>,
       shared: this.serializeShared(shared),

--- a/src/agent/runtime/SessionResumeRetrieval.ts
+++ b/src/agent/runtime/SessionResumeRetrieval.ts
@@ -18,7 +18,10 @@ import {
 } from '@agent/core/definition/AgentConfig';
 import { flowKey, type FlowRecord } from '@agent/node/persistedFlow';
 import { ProviderMessageSchema } from '@agent/modelHandlers/types/ProviderMessage';
-import { StateSlicesSchema } from '@agent/implementations/flows/tooluse/nodes/types';
+import {
+  migrateSharedState,
+  StateSlicesSchema,
+} from '@agent/implementations/flows/tooluse/nodes/types';
 import {
   TOOL_USE_SNAPSHOT_VERSION,
   ToolUseSessionSnapshotSchema,
@@ -56,40 +59,15 @@ type WorkflowResumeData = z.infer<typeof WorkflowResumeDataSchema>;
 
 export type SessionResumeData = ToolUseResumeData | WorkflowResumeData;
 
-/** Fields shared by both `messages` (current) and `conversation` (legacy) branches. */
-const SharedToolUseFields = z.object({
+const CurrentToolUseFlowRecordStateSchema = z.looseObject({
+  messages: z.array(ProviderMessageSchema),
   modelHandlerCompatibilityKey: ModelHandlerCompatibilityKeySchema.nullish(),
   stateSlices: StateSlicesSchema,
 });
 
-/** Core fields schema — accepts `messages` (current) or `conversation` (legacy), normalizing to `messages`. */
-const ToolUseStateFieldsSchema = z
-  .union([
-    SharedToolUseFields.extend({ messages: z.array(ProviderMessageSchema) }),
-    SharedToolUseFields.extend({
-      conversation: z.array(ProviderMessageSchema),
-    }),
-  ])
-  .transform((data) => ({
-    messages: 'messages' in data ? data.messages : data.conversation,
-    modelHandlerCompatibilityKey:
-      data.modelHandlerCompatibilityKey ?? undefined,
-    stateSlices: data.stateSlices,
-  }));
-
-/**
- * Schema that accepts both flat and legacy formats, normalizing to flat.
- * - Flat format: { messages, stateSlices, ... }
- * - Legacy format: { state: { messages, stateSlices, ... } }
- */
-const ToolUseFlowRecordStateSchema = z
-  .union([
-    ToolUseStateFieldsSchema,
-    z.object({ state: ToolUseStateFieldsSchema }),
-  ])
-  .transform((data) => ('state' in data ? data.state : data));
-
-type NormalizedToolUseState = z.infer<typeof ToolUseFlowRecordStateSchema>;
+type NormalizedToolUseState = z.infer<
+  typeof CurrentToolUseFlowRecordStateSchema
+>;
 
 /**
  * Minimal schema for validating workflow flow record exists and has resumable state.
@@ -168,9 +146,16 @@ async function retrieveToolUseResumeData(
       return null;
     }
 
-    // Parse shared state, supporting both flat and legacy formats
-    const parseResult = ToolUseFlowRecordStateSchema.safeParse(
-      flowRecord.shared,
+    const migrationResult = migrateSharedState(flowRecord.shared);
+    if (migrationResult === null) {
+      logger.warn(
+        `Invalid flow record structure for execution: ${executionId}`,
+      );
+      return null;
+    }
+
+    const parseResult = CurrentToolUseFlowRecordStateSchema.safeParse(
+      migrationResult.data,
     );
     if (!parseResult.success) {
       logger.warn(

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -15,6 +15,7 @@ import {
   AgentConfigSchema,
 } from '@agent/core/definition/AgentConfig';
 import { KVStore } from '@common/storage/KVStore';
+import * as logger from '@logger/logUtils';
 import {
   ExecutionIdSchema,
   RunOutcomeSchema,
@@ -28,6 +29,7 @@ import {
   OutputFileSummarySchema,
 } from '@shared/schemas/output';
 import { byString, filterNotNull } from '@utils/core';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 
 // ============================================================================
 // Key constants (implementation detail — not exported)
@@ -44,12 +46,16 @@ const KEYS = {
   child: (id: string) => `child-${id}`,
 } as const;
 
+const CHANNEL = 'ExecutionKVStore';
+export const EXECUTION_META_SCHEMA_VERSION = 1;
+
 // ============================================================================
 // Domain types — Zod schemas as source of truth
 // ============================================================================
 
 /** Execution metadata stored alongside config at launch time. */
 const ExecutionMetaBaseSchema = z.object({
+  schemaVersion: z.literal(EXECUTION_META_SCHEMA_VERSION).prefault(1),
   timestamp: z.string(),
   parentExecutionId: ExecutionIdSchema.optional(),
   /** Persisted when execution reaches a terminal state (success or error). */
@@ -79,6 +85,7 @@ const ExecutionMetaSchema = ExecutionMetaBaseSchema.transform(
   },
 );
 export type ExecutionMeta = z.infer<typeof ExecutionMetaSchema>;
+export type ExecutionMetaInput = z.input<typeof ExecutionMetaSchema>;
 
 /** Shape of a persisted todo item from tool-use flow state. */
 const TodoEntrySchema = z.object({
@@ -187,7 +194,7 @@ export interface ExecutionKVStore {
   readResultMeta(): Promise<ResultMeta | null>;
 
   // -- Typed writers --------------------------------------------------------
-  writeMeta(meta: ExecutionMeta): Promise<void>;
+  writeMeta(meta: ExecutionMetaInput): Promise<void>;
   writeConfig(config: AgentConfig): Promise<void>;
   writeReport(report: string): Promise<void>;
   writeTodos(todos: TodoEntry[]): Promise<void>;
@@ -229,14 +236,28 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
   private async readValidated<T>(
     key: string,
     schema: z.ZodType<T>,
+    options: { warnOnFailure?: boolean } = {},
   ): Promise<T | null> {
     const raw = await this.read(key);
-    if (!raw) return null;
-    return schema.nullable().catch(null).parse(raw);
+    if (raw == null) return null;
+    const result = schema.nullable().safeParse(raw);
+    if (result.success) return result.data;
+    if (options.warnOnFailure) {
+      logger.warn(
+        CHANNEL,
+        `Failed to parse execution ${this.executionId} ${key}.json: ${toErrorMessage(
+          result.error,
+        )}`,
+        { data: result.error },
+      );
+    }
+    return null;
   }
 
   async readMeta(): Promise<ExecutionMeta | null> {
-    return this.readValidated(KEYS.META, ExecutionMetaSchema);
+    return this.readValidated(KEYS.META, ExecutionMetaSchema, {
+      warnOnFailure: true,
+    });
   }
 
   async readConfig(): Promise<AgentConfig | null> {
@@ -284,8 +305,8 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
 
   // -- Typed writers --------------------------------------------------------
 
-  async writeMeta(meta: ExecutionMeta): Promise<void> {
-    await this.write(KEYS.META, meta);
+  async writeMeta(meta: ExecutionMetaInput): Promise<void> {
+    await this.write(KEYS.META, ExecutionMetaSchema.parse(meta));
   }
 
   async writeConfig(config: AgentConfig): Promise<void> {

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -15,7 +15,11 @@ import * as logger from '@logger/logUtils';
 import type { ExecutionId } from '@shared/schemas';
 import { WorkspaceFS } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
-import { type ExecutionMeta, getExecutionStore } from './ExecutionKVStore';
+import {
+  type ExecutionMeta,
+  type ExecutionMetaInput,
+  getExecutionStore,
+} from './ExecutionKVStore';
 import { invalidateListingCache } from './executionListing';
 
 /**
@@ -105,7 +109,7 @@ export async function registerExecution(
   const timestamp = new Date().toISOString();
   const store = getExecutionStore(executionId);
 
-  const meta: ExecutionMeta = { timestamp, parentExecutionId };
+  const meta: ExecutionMetaInput = { timestamp, parentExecutionId };
   if (category) meta.category = category;
   if (delegationDepth !== undefined) meta.delegationDepth = delegationDepth;
   const persistedConfig = normalizeWriterCategory(

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -5,8 +5,10 @@
  */
 
 export {
+  EXECUTION_META_SCHEMA_VERSION,
   type ExecutionKVStore,
   type ExecutionMeta,
+  type ExecutionMetaInput,
   type TodoEntry,
   type ChildRecord,
   type ResultMeta,

--- a/src/test-kernel/agent/PersistedFlow.vitest.ts
+++ b/src/test-kernel/agent/PersistedFlow.vitest.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { setupPlatform } from '@test/support/setupPlatform';
+import { getExecutionStore } from '@agent/storage';
+import { BaseNode } from '@agent/node';
+import {
+  FLOW_RECORD_SCHEMA_VERSION,
+  flowKey,
+  PersistedFlow,
+  type FlowRecord,
+} from '@agent/node/persistedFlow';
+import type { ExecutionId } from '@shared/schemas';
+
+setupPlatform({ workspacePath: '/workspace' });
+
+class CompleteNode extends BaseNode<{ count: number }> {
+  async post(shared: { count: number }): Promise<string> {
+    shared.count += 1;
+    return 'complete';
+  }
+}
+
+describe('PersistedFlow', () => {
+  it('writes the current schema version into new flow records', async () => {
+    const executionId = 'abc126' as ExecutionId;
+    const store = getExecutionStore(executionId);
+    const flow = new PersistedFlow(new CompleteNode(), store, executionId);
+
+    await flow.run({ count: 0 });
+
+    await expect(
+      store.read<FlowRecord>(flowKey(executionId)),
+    ).resolves.toMatchObject({
+      schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
+      nodes: [{ action: 'complete' }],
+    });
+  });
+});

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -112,6 +112,51 @@ describe('retrieveSessionResumeData', () => {
     );
   });
 
+  it('normalizes legacy nested conversation shared state for tool-use resume', async () => {
+    const executionId = 'abc128' as ExecutionId;
+    const streamId = 'chat@gpt54#abc128' as StreamTabId;
+    await getExecutionStore(executionId).write(flowKey(executionId), {
+      flowName: 'texra',
+      params: {},
+      shared: {
+        state: {
+          conversation: [
+            {
+              role: 'user',
+              content: 'Continue the legacy conversation.',
+            },
+          ],
+          shouldSkipCycle: false,
+          stateSlices: {
+            runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
+            workspaceSnapshot: AgentWorkspaceState.create().toSnapshot(),
+            userChannels: {
+              input: Object.freeze({ MODEL: 'gpt54' }),
+              transient: {},
+            },
+          },
+        },
+      },
+      createdAt: new Date().toISOString(),
+      nodes: [],
+    });
+
+    const resume = await retrieveSessionResumeData(
+      streamId,
+      executionId,
+      agentConfigToTaskState(CONFIG),
+    );
+
+    expect(resume?.type).toBe('toolUse');
+    if (resume?.type !== 'toolUse') return;
+    expect(resume.snapshot.messages).toEqual([
+      {
+        role: 'user',
+        content: 'Continue the legacy conversation.',
+      },
+    ]);
+  });
+
   it('infers the legacy Google GenAI handler for old workflow transcripts', async () => {
     const executionId = 'abc125' as ExecutionId;
     const streamId = 'workflow@gemini35f#abc125' as StreamTabId;

--- a/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
@@ -1,7 +1,12 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { setupPlatform } from '@test/support/setupPlatform';
-import { clearStoreCache, getExecutionStore } from '@agent/storage';
+import {
+  clearStoreCache,
+  EXECUTION_META_SCHEMA_VERSION,
+  getExecutionStore,
+} from '@agent/storage';
+import * as logger from '@logger/logUtils';
 import {
   EXECUTION_STATUS,
   RUN_OUTCOME,
@@ -13,6 +18,10 @@ setupPlatform({ workspacePath: '/workspace' });
 
 beforeEach(() => {
   clearStoreCache();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 describe('ExecutionKVStore meta read shims', () => {
@@ -30,6 +39,7 @@ describe('ExecutionKVStore meta read shims', () => {
       });
 
       await expect(getExecutionStore(id).readMeta()).resolves.toMatchObject({
+        schemaVersion: EXECUTION_META_SCHEMA_VERSION,
         terminalStatus,
         outcome,
       });
@@ -46,8 +56,36 @@ describe('ExecutionKVStore meta read shims', () => {
       });
 
       await expect(getExecutionStore(id).readMeta()).resolves.toMatchObject({
+        schemaVersion: EXECUTION_META_SCHEMA_VERSION,
         outcome,
       });
     },
   );
+
+  it('writes the current schema version for execution meta', async () => {
+    const id = 'versioned-meta' as ExecutionId;
+
+    await getExecutionStore(id).writeMeta({
+      timestamp: '2026-07-04T00:00:00.000Z',
+    });
+
+    await expect(getExecutionStore(id).read('meta')).resolves.toMatchObject({
+      schemaVersion: EXECUTION_META_SCHEMA_VERSION,
+      timestamp: '2026-07-04T00:00:00.000Z',
+    });
+  });
+
+  it('warns when execution meta is malformed instead of silently dropping it', async () => {
+    const id = 'bad-meta' as ExecutionId;
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    await getExecutionStore(id).write('meta', { timestamp: 123 });
+
+    await expect(getExecutionStore(id).readMeta()).resolves.toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      'ExecutionKVStore',
+      expect.stringContaining(`Failed to parse execution ${id} meta.json`),
+      { data: expect.any(Error) },
+    );
+  });
 });

--- a/src/test-kernel/cli/HistoryStatus.vitest.ts
+++ b/src/test-kernel/cli/HistoryStatus.vitest.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import { setupPlatform } from '@test/support/setupPlatform';
-import { registerExecution, getExecutionStore } from '@agent/storage';
+import {
+  EXECUTION_META_SCHEMA_VERSION,
+  registerExecution,
+  getExecutionStore,
+} from '@agent/storage';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { flowKey } from '@agent/node/persistedFlow';
@@ -116,6 +120,7 @@ describe('CLI history status formatting', () => {
       id: 'abc123' as ExecutionId,
       status: CLI_HISTORY_RESUMABLE_STATUS,
       meta: {
+        schemaVersion: EXECUTION_META_SCHEMA_VERSION,
         timestamp: '2026-06-03T05:03:06.717Z',
         category: 'toolUse',
         delegationDepth: 0,


### PR DESCRIPTION
## Summary

Adds current schema versions to newly written execution metadata and flow records, makes malformed execution metadata reads warn instead of silently degrading, and collapses tool-use resume onto the existing shared-state migration helper.

## Issue acceptance gates

Addresses #7209:

- Re-verified current evidence for unversioned `ExecutionMeta`, unversioned `FlowRecord`, silent `readValidated()` drops, and duplicated tool-use legacy shared-state migration.
- Existing unversioned `meta.json` and `flow_*.json` records still load.
- New `writeMeta()` and `PersistedFlow` writes include schema versions.
- Malformed execution meta reads now warn and return `null` instead of silently degrading.
- Tool-use flow startup and resume now share `migrateSharedState()` for legacy shared-state normalization.
- Focused storage/runtime tests cover legacy-read and new-write behavior.

This PR intentionally does not change completed-run archival ownership, `conversation.json` / `todos.json` deletion, or `deriveResumability()` semantics; those remain blocked on #6966 maintainer decisions.

## Single source of truth

`ExecutionKVStore` owns execution meta parsing/writing and its schema version. `PersistedFlow` owns flow-record version stamping. `migrateSharedState()` is now the single implementation of tool-use legacy shared-state normalization.

## Duplication and abstraction budget

Removed the duplicate legacy tool-use shared-state migration schema from `SessionResumeRetrieval`. No pass-through layer or factory was added; the new stamping helper owns only the invariant that flow records written through migration/update paths carry the current schema version.

The auto-format workflow also normalized existing Markdown table/emphasis formatting in `docs/proposals/texra-bench-science-benchmarks.md`; that is mechanical formatter output only and fixes the branch rewrite loop that was causing action-required CI runs.

## Host impact

Extension: malformed execution metadata becomes diagnosable in logs; existing resume behavior is otherwise preserved.

Desktop: same shared storage/runtime behavior; existing unversioned records remain readable.

CLI: history/resume metadata reads now warn on malformed meta instead of silently dropping it; headless output shape is unchanged.

## Scheduled refactoring

Existing #6981 ledger rows already cover the retained legacy flow-shape migration arms and pre-KV/index migration paths; no new shim row is introduced.

## Validation

- `corepack pnpm exec prettier --write src/agent/storage/ExecutionKVStore.ts src/agent/storage/index.ts src/agent/storage/executionLifecycle.ts src/agent/node/persistedFlow.ts src/agent/implementations/flows/tooluse/runToolUseFlow.ts src/agent/runtime/SessionResumeRetrieval.ts src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts src/test-kernel/agent/PersistedFlow.vitest.ts src/test-kernel/agent/SessionResumeRetrieval.vitest.ts src/test-kernel/cli/HistoryStatus.vitest.ts`
- `npm test -- --run src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts src/test-kernel/agent/PersistedFlow.vitest.ts src/test-kernel/agent/SessionResumeRetrieval.vitest.ts src/test-kernel/cli/HistoryStatus.vitest.ts`
- `npm run typecheck`
- `npm test`
- `git diff --check`
- `npm run lint` (passes with the pre-existing unrelated warning in `packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts`)
- `npm run compile:fast`
- GitHub PR checks on `f9a7192d`: `validate`, `validate (linux)`, `webview smoke (macOS)`, `review`, `claude-review-anthropic`, `claude-review-deepseek`, `Cursor Bugbot`, `label`; `docs build` and `format` skipped by workflow conditions.

Closes #7209
