### PR TITLE
Add PgUp/PgDn and g/G scrolling to ChildControlPicker's TaskDetailView

### DIFF
--- a/docs/proposals/texra-bench-science-benchmarks.md
+++ b/docs/proposals/texra-bench-science-benchmarks.md
@@ -99,10 +99,10 @@ The verifier library is therefore **data, not harness code**: a standard grader 
 
 | `std/` grader (command) | Wraps                                                                                                                                                                                                                                                           |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `std/compile-check`     | `compileCheck.ts` / `latexToolchain.ts` invoked directly, independent of the interactive `WORKFLOW_AUTO_COMPILE` setting — a required gate can't depend on a user preference — the hard gate |
+| `std/compile-check`     | `compileCheck.ts` / `latexToolchain.ts` invoked directly, independent of the interactive `WORKFLOW_AUTO_COMPILE` setting — a required gate can't depend on a user preference — the hard gate                                                                    |
 | `std/cas-equal`         | `wolframscript` (or SymPy) executing a **fixed** `refs/` assertion script against the extracted `\benchresult{...}` — outcome-level, targeting renotation-robustness (how far that can be pushed is open — §15), no credit for matching a human derivation path |
 | `std/lean-build`        | `lake build` against a pinned mathlib toolchain; binary per lemma. Proof tasks need only a statement — difficulty can outgrow the task's author (§6 validate exempts this stack from the gold-`refs/solution` check, since it has no reference answer to score) |
-| `std/diff-align`        | the math-aware latexdiff service — **error-injection tasks only**: edits inside injected spans must match gold, edits outside are penalized; not applicable to derivation/proof tasks, which have no injected spans |
+| `std/diff-align`        | the math-aware latexdiff service — **error-injection tasks only**: edits inside injected spans must match gold, edits outside are penalized; not applicable to derivation/proof tasks, which have no injected spans                                             |
 | `std/issue-match`       | `ReviewIssue` matching against gold defects within a line window → precision/recall                                                                                                                                                                             |
 | `std/answer-match`      | numeric-tolerance / exact / set matching on parsed answer blocks                                                                                                                                                                                                |
 
@@ -138,7 +138,7 @@ bench-results/<suite@version>/<runId>/<model>/<task>/trial-<n>/
                     # to that machinery, not built yet)
 ```
 
-- **Comparability rule:** two scores are comparable iff their *task*, *grader-pack*, and *environment* digests match; the subject dimension (model id and/or agent digest) is exactly what `--compare` varies, so it's excluded from the match. `bench report` refuses comparisons that differ on any of the fixed digests.
+- **Comparability rule:** two scores are comparable iff their _task_, _grader-pack_, and _environment_ digests match; the subject dimension (model id and/or agent digest) is exactly what `--compare` varies, so it's excluded from the match. `bench report` refuses comparisons that differ on any of the fixed digests.
 - **Regrade, don't rerun:** graders never mutate these directories, only read them; `bench grade --regrade --diff-against <old>` (a suite version, e.g. `1.1`, resolved under `--results-dir` to that version's evidence directory) recomputes history at zero model cost and attributes every delta to the grader diff.
 - **Hermetic execution:** a published container image pins TeX Live / Lean / wolframscript; `env.json` records the fingerprint; network off by default at the container level (not just tool-level filtering — a solver with shell access could otherwise reach the network via `curl`/package managers even with web tools disabled), with web tools additionally disabled in-agent via the existing `runtimeUnavailableTools` mechanism (`src/agent/runtime/RunContext.ts`) as defense in depth. No new sandbox layer beyond the container's own network policy.
 - **Determinism honesty:** providers offer no usable seeds; replicate variance is measured and reported, never pretended away.
@@ -192,18 +192,18 @@ Six subcommands. Exit codes reuse `packages/cli/src/runtime/exitCodes.ts`; score
 
 ## 11. Existing machinery it rides on
 
-| Bench component                   | Existing code                                                                                                                         |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Bench component                   | Existing code                                                                                                                                                                                                                       |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Cell execution                    | `packages/cli/src/runtime/runExecution.ts`; tool-use path via `packages/cli/src/commands/agentsRun.ts` (today stops after one model/tool cycle — `stopAfterCycle: true` — bench needs a multi-cycle variant, tracked as an MVP gap) |
-| Compile gate / diff / structure   | `src/agent/output/compileCheck.ts`, `src/latex/latexdiff/`, `src/latex/latexToolchain.ts`, `src/latex/labelSearch.ts`, `src/latex/extractBibliography.ts` |
-| CAS / Lean verifiers              | `src/tools/wolfram/wolframScriptUtils.ts`, `src/tools/lean/direct/lakeCommands.ts`, `src/tools/lean/LspTools.ts`, `src/tools/lean/LoogleTool.ts`          |
-| Issue localization                | `src/agent/review/reviewIssues.ts`; solver pattern from `packages/extension/resources/tool_use_agents/changeReviewer.yaml`            |
-| Fresh-task supply                 | `src/latex/arxivProcessor.ts`                                                                                                         |
-| Trace archive                     | `AgentTrace` subscriber (`src/agent/trace/AgentTrace.ts`, pattern: `src/transcript/TexraTranscriptRecorder.ts`); `AgentEvent` union    |
-| Usage / cost / abort              | `src/agent/core/usage/RunUsageAccumulator.ts` (`totalCost` drives `--max-cost-usd`, checked between dispatches — a soft budget guard under concurrency, not a per-cell reservation) |
-| Providers incl. internal gateways | `src/agent/modelHandlers/` (four stacks; `customBaseUrl` already threaded)                                                            |
-| Solver/judge agents               | ordinary agent YAML under `packages/extension/resources/agents/bench/`, run via `runAgent` (`src/agent/runtime/runAgent.ts`)          |
-| Env fingerprint                   | `texra doctor` machinery (`packages/cli/src/commands/doctor.ts`) — today probes Node/workspace/auth/LaTeX/config; Wolfram/lake/image-digest probes are new additions, not built yet |
+| Compile gate / diff / structure   | `src/agent/output/compileCheck.ts`, `src/latex/latexdiff/`, `src/latex/latexToolchain.ts`, `src/latex/labelSearch.ts`, `src/latex/extractBibliography.ts`                                                                           |
+| CAS / Lean verifiers              | `src/tools/wolfram/wolframScriptUtils.ts`, `src/tools/lean/direct/lakeCommands.ts`, `src/tools/lean/LspTools.ts`, `src/tools/lean/LoogleTool.ts`                                                                                    |
+| Issue localization                | `src/agent/review/reviewIssues.ts`; solver pattern from `packages/extension/resources/tool_use_agents/changeReviewer.yaml`                                                                                                          |
+| Fresh-task supply                 | `src/latex/arxivProcessor.ts`                                                                                                                                                                                                       |
+| Trace archive                     | `AgentTrace` subscriber (`src/agent/trace/AgentTrace.ts`, pattern: `src/transcript/TexraTranscriptRecorder.ts`); `AgentEvent` union                                                                                                 |
+| Usage / cost / abort              | `src/agent/core/usage/RunUsageAccumulator.ts` (`totalCost` drives `--max-cost-usd`, checked between dispatches — a soft budget guard under concurrency, not a per-cell reservation)                                                 |
+| Providers incl. internal gateways | `src/agent/modelHandlers/` (four stacks; `customBaseUrl` already threaded)                                                                                                                                                          |
+| Solver/judge agents               | ordinary agent YAML under `packages/extension/resources/agents/bench/`, run via `runAgent` (`src/agent/runtime/runAgent.ts`)                                                                                                        |
+| Env fingerprint                   | `texra doctor` machinery (`packages/cli/src/commands/doctor.ts`) — today probes Node/workspace/auth/LaTeX/config; Wolfram/lake/image-digest probes are new additions, not built yet                                                 |
 
 All additive: new code lives in `src/bench/` (VS Code-free zone, host services via `platform()`) and `packages/cli/`. **The MVP requires zero changes to `src/agent/` core.**
 

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -23,6 +23,9 @@ import {
 } from '../state/childControls';
 import { useLiveNowMs } from '../state/useLiveNowMs';
 import {
+  jumpTaskDetailScrollState,
+  moveTaskDetailScrollState,
+  pageTaskDetailScrollState,
   syncTaskDetailScrollState,
   taskDetailFollowTailScrollOffsetForColumns,
   taskDetailInitialScrollOffset,
@@ -30,7 +33,6 @@ import {
   taskDetailScrollContextKey,
   taskDetailVisibleOutputRowsFromOffsetForColumns,
   taskDetailVisibleScrollOffset,
-  moveTaskDetailScrollState,
   type TaskDetailScrollContext,
   type TaskDetailScrollState,
 } from '../state/taskDetailScroll';
@@ -593,6 +595,52 @@ function TaskDetailView({
           current,
           maxOffset,
           'down',
+          followOffset,
+          scrollContext,
+        ),
+      );
+    }
+    if (key.pageUp) {
+      setScrollState((current) =>
+        pageTaskDetailScrollState(
+          current,
+          maxOffset,
+          'up',
+          visibleLineCount,
+          followOffset,
+          scrollContext,
+        ),
+      );
+    }
+    if (key.pageDown) {
+      setScrollState((current) =>
+        pageTaskDetailScrollState(
+          current,
+          maxOffset,
+          'down',
+          visibleLineCount,
+          followOffset,
+          scrollContext,
+        ),
+      );
+    }
+    if (input === 'g') {
+      setScrollState((current) =>
+        jumpTaskDetailScrollState(
+          current,
+          maxOffset,
+          'top',
+          followOffset,
+          scrollContext,
+        ),
+      );
+    }
+    if (input === 'G') {
+      setScrollState((current) =>
+        jumpTaskDetailScrollState(
+          current,
+          maxOffset,
+          'bottom',
           followOffset,
           scrollContext,
         ),

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -66,6 +66,12 @@ const ULTRA_COMPACT_TASK_DETAIL_MAX_ROWS = 4;
 const NARROW_TASK_DETAIL_HINT_MAX_COLUMNS = 56;
 const PICKER_HORIZONTAL_CHROME_COLUMNS = 4;
 const MIN_COLUMNS_FOR_KILL_HINT = 44;
+// PgUp/PgDn and g/G are the least essential task-detail hints — they
+// duplicate `TranscriptViewer`'s paging bindings but the arrow-key scroll
+// hint above already covers the same affordance more compactly. Only surface
+// them once there's room for the full hint row (scroll + page + top/bottom +
+// focus stream + kill + back) without crowding out the higher-priority ones.
+const MIN_COLUMNS_FOR_PAGE_JUMP_HINTS = 84;
 
 export function pickerTitle(mode: ChildControlMode): string {
   return CHILD_CONTROL_MODE_COPY[mode].title;
@@ -205,6 +211,14 @@ export function taskDetailKeyHintsForColumns({
     availableColumns <= NARROW_TASK_DETAIL_HINT_MAX_COLUMNS;
   const hints: KeyHint[] = [];
   if (showScrollHint) hints.push({ key: '↑/↓', action: 'scroll' });
+  if (
+    showScrollHint &&
+    (availableColumns === undefined ||
+      availableColumns >= MIN_COLUMNS_FOR_PAGE_JUMP_HINTS)
+  ) {
+    hints.push({ key: 'PgUp/PgDn', action: 'page' });
+    hints.push({ key: 'g/G', action: 'top/bottom' });
+  }
   if (canFocusStream) {
     hints.push({ key: 'f', action: narrow ? 'focus' : 'focus stream' });
   }

--- a/packages/cli/src/chat/tui/state/taskDetailScroll.ts
+++ b/packages/cli/src/chat/tui/state/taskDetailScroll.ts
@@ -277,6 +277,32 @@ function taskDetailScrollOffsetFollowsTail(
   return offset === Math.min(followOffset, maxOffset);
 }
 
+function taskDetailScrollStateAtOffset(
+  state: TaskDetailScrollState,
+  maxOffset: number,
+  nextOffset: number,
+  followOffset = maxOffset,
+  context?: TaskDetailScrollContext,
+): TaskDetailScrollState {
+  const clampedOffset = clamp(nextOffset, 0, maxOffset);
+  const followsTail = taskDetailScrollOffsetFollowsTail(
+    clampedOffset,
+    maxOffset,
+    followOffset,
+  );
+  const anchor = followsTail
+    ? undefined
+    : context
+      ? taskDetailScrollAnchorFromOffset(context, clampedOffset)
+      : state.anchor;
+  return {
+    executionId: state.executionId,
+    followsTail,
+    offset: clampedOffset,
+    ...(anchor ? { anchor } : {}),
+  };
+}
+
 export function moveTaskDetailScrollState(
   state: TaskDetailScrollState,
   maxOffset: number,
@@ -290,24 +316,57 @@ export function moveTaskDetailScrollState(
     followOffset,
     context,
   );
-  const nextOffset =
-    direction === 'up'
-      ? Math.max(0, offset - 1)
-      : Math.min(maxOffset, offset + 1);
-  const followsTail = taskDetailScrollOffsetFollowsTail(
+  const nextOffset = direction === 'up' ? offset - 1 : offset + 1;
+  return taskDetailScrollStateAtOffset(
+    state,
+    maxOffset,
     nextOffset,
+    followOffset,
+    context,
+  );
+}
+
+/** PgUp/PgDn: move by a page (the visible row budget) instead of a single
+ *  row. Mirrors `moveTaskDetailScrollState`, just with a configurable step. */
+export function pageTaskDetailScrollState(
+  state: TaskDetailScrollState,
+  maxOffset: number,
+  direction: 'down' | 'up',
+  pageSize: number,
+  followOffset = maxOffset,
+  context?: TaskDetailScrollContext,
+): TaskDetailScrollState {
+  const offset = taskDetailVisibleScrollOffset(
+    state,
     maxOffset,
     followOffset,
+    context,
   );
-  const anchor = followsTail
-    ? undefined
-    : context
-      ? taskDetailScrollAnchorFromOffset(context, nextOffset)
-      : state.anchor;
-  return {
-    executionId: state.executionId,
-    followsTail,
-    offset: nextOffset,
-    ...(anchor ? { anchor } : {}),
-  };
+  const step = Math.max(1, pageSize);
+  const nextOffset = direction === 'up' ? offset - step : offset + step;
+  return taskDetailScrollStateAtOffset(
+    state,
+    maxOffset,
+    nextOffset,
+    followOffset,
+    context,
+  );
+}
+
+/** g/G: jump straight to the top or back to the tail. */
+export function jumpTaskDetailScrollState(
+  state: TaskDetailScrollState,
+  maxOffset: number,
+  target: 'bottom' | 'top',
+  followOffset = maxOffset,
+  context?: TaskDetailScrollContext,
+): TaskDetailScrollState {
+  const nextOffset = target === 'top' ? 0 : followOffset;
+  return taskDetailScrollStateAtOffset(
+    state,
+    maxOffset,
+    nextOffset,
+    followOffset,
+    context,
+  );
 }

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -17,7 +17,9 @@ import {
   taskDetailKeyHintsForColumns,
 } from '@cli/chat/tui/modals/ChildControlPicker';
 import {
+  jumpTaskDetailScrollState,
   moveTaskDetailScrollState,
+  pageTaskDetailScrollState,
   syncTaskDetailScrollState,
   taskDetailFollowTailScrollOffsetForColumns,
   taskDetailInitialScrollOffset,
@@ -1484,6 +1486,184 @@ describe('CLI child execution controls', () => {
       followsTail: true,
       offset: 9,
     });
+  });
+
+  it('pages task detail scroll by the visible row budget (PgUp/PgDn)', () => {
+    const tailing = { executionId: 'task-1', followsTail: true, offset: 9 };
+    expect(pageTaskDetailScrollState(tailing, 9, 'up', 3)).toEqual({
+      executionId: 'task-1',
+      followsTail: false,
+      offset: 6,
+    });
+    expect(
+      pageTaskDetailScrollState(
+        { executionId: 'task-1', followsTail: false, offset: 6 },
+        9,
+        'up',
+        3,
+      ),
+    ).toEqual({
+      executionId: 'task-1',
+      followsTail: false,
+      offset: 3,
+    });
+    expect(
+      pageTaskDetailScrollState(
+        { executionId: 'task-1', followsTail: false, offset: 3 },
+        9,
+        'down',
+        3,
+      ),
+    ).toEqual({
+      executionId: 'task-1',
+      followsTail: false,
+      offset: 6,
+    });
+
+    // Clamps at the boundaries instead of overshooting.
+    const top = { executionId: 'task-1', followsTail: false, offset: 1 };
+    expect(pageTaskDetailScrollState(top, 9, 'up', 3)).toEqual({
+      executionId: 'task-1',
+      followsTail: false,
+      offset: 0,
+    });
+    expect(
+      pageTaskDetailScrollState(
+        { executionId: 'task-1', followsTail: false, offset: 8 },
+        9,
+        'down',
+        3,
+        9,
+      ),
+    ).toEqual({
+      executionId: 'task-1',
+      followsTail: true,
+      offset: 9,
+    });
+
+    // A page landing exactly on the follow offset re-arms tail-following.
+    expect(
+      pageTaskDetailScrollState(
+        { executionId: 'task-1', followsTail: false, offset: 3 },
+        9,
+        'down',
+        3,
+        6,
+      ),
+    ).toEqual({
+      executionId: 'task-1',
+      followsTail: true,
+      offset: 6,
+    });
+
+    // A zero/negative page size still advances by at least one row.
+    expect(pageTaskDetailScrollState(tailing, 9, 'up', 0)).toEqual({
+      executionId: 'task-1',
+      followsTail: false,
+      offset: 8,
+    });
+  });
+
+  it('jumps task detail scroll to the top and back to the tail (g/G)', () => {
+    const manual = { executionId: 'task-1', followsTail: false, offset: 4 };
+    expect(jumpTaskDetailScrollState(manual, 9, 'top')).toEqual({
+      executionId: 'task-1',
+      followsTail: false,
+      offset: 0,
+    });
+    expect(jumpTaskDetailScrollState(manual, 9, 'bottom')).toEqual({
+      executionId: 'task-1',
+      followsTail: true,
+      offset: 9,
+    });
+    expect(jumpTaskDetailScrollState(manual, 9, 'bottom', 4)).toEqual({
+      executionId: 'task-1',
+      followsTail: true,
+      offset: 4,
+    });
+
+    const tailing = { executionId: 'task-1', followsTail: true, offset: 9 };
+    expect(jumpTaskDetailScrollState(tailing, 9, 'top')).toEqual({
+      executionId: 'task-1',
+      followsTail: false,
+      offset: 0,
+    });
+  });
+
+  it('anchors a PgUp jump when earlier output rewraps, like manual scrolling', () => {
+    const availableColumns = 20;
+    const visibleRowBudget = 1;
+    const beforeLines = ['intro', 'target marker', 'after'];
+    const beforeContext = {
+      availableColumns,
+      compact: true,
+      tailLines: beforeLines,
+    };
+    const beforeMaxOffset = taskDetailInitialScrollOffset(
+      taskDetailScrollableOutputRowCountForColumns(beforeContext),
+      visibleRowBudget,
+    );
+    const beforeFollowOffset = taskDetailFollowTailScrollOffsetForColumns({
+      ...beforeContext,
+      visibleRowBudget,
+    });
+
+    const paged = pageTaskDetailScrollState(
+      { executionId: 'task-1', followsTail: true, offset: beforeFollowOffset },
+      beforeMaxOffset,
+      'up',
+      1,
+      beforeFollowOffset,
+      beforeContext,
+    );
+
+    expect(paged).toEqual({
+      anchor: { lineIndex: 1, wrappedRowOffset: 0 },
+      executionId: 'task-1',
+      followsTail: false,
+      offset: 1,
+    });
+
+    const afterLines = [
+      'intro expanded before anchor '.repeat(2),
+      'target marker',
+      'after',
+    ];
+    const afterContext = {
+      availableColumns,
+      compact: true,
+      tailLines: afterLines,
+    };
+    const afterMaxOffset = taskDetailInitialScrollOffset(
+      taskDetailScrollableOutputRowCountForColumns(afterContext),
+      visibleRowBudget,
+    );
+    const afterFollowOffset = taskDetailFollowTailScrollOffsetForColumns({
+      ...afterContext,
+      visibleRowBudget,
+    });
+    const synced = syncTaskDetailScrollState(
+      paged,
+      'task-1',
+      afterMaxOffset,
+      afterFollowOffset,
+      afterContext,
+    );
+    const visibleOffset = taskDetailVisibleScrollOffset(
+      synced,
+      afterMaxOffset,
+      afterFollowOffset,
+      afterContext,
+    );
+
+    expect(visibleOffset).toBeGreaterThan(paged.offset);
+    expect(
+      taskDetailVisibleOutputRowsFromOffsetForColumns({
+        ...afterContext,
+        offset: visibleOffset,
+        visibleRowBudget,
+      }),
+    ).toEqual(['target marker']);
   });
 
   it('keeps the highlighted picker item inside the visible window', () => {

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -1116,6 +1116,57 @@ describe('CLI child execution controls', () => {
     ]);
   });
 
+  it('surfaces PgUp/PgDn and g/G hints once the terminal is wide enough', () => {
+    expect(
+      taskDetailKeyHintsForColumns({
+        availableColumns: 60,
+        canFocusStream: true,
+        canKill: true,
+        showScrollHint: true,
+      }),
+    ).not.toContainEqual({ key: 'PgUp/PgDn', action: 'page' });
+    expect(
+      taskDetailKeyHintsForColumns({
+        availableColumns: 84,
+        canFocusStream: true,
+        canKill: true,
+        showScrollHint: true,
+      }),
+    ).toEqual([
+      { key: '↑/↓', action: 'scroll' },
+      { key: 'PgUp/PgDn', action: 'page' },
+      { key: 'g/G', action: 'top/bottom' },
+      { key: 'f', action: 'focus stream' },
+      { key: 'k', action: 'kill' },
+      { key: 'Esc', action: 'back' },
+    ]);
+    expect(
+      taskDetailKeyHintsForColumns({
+        availableColumns: undefined,
+        canFocusStream: true,
+        canKill: true,
+        showScrollHint: true,
+      }),
+    ).toEqual([
+      { key: '↑/↓', action: 'scroll' },
+      { key: 'PgUp/PgDn', action: 'page' },
+      { key: 'g/G', action: 'top/bottom' },
+      { key: 'f', action: 'focus stream' },
+      { key: 'k', action: 'kill' },
+      { key: 'Esc', action: 'back' },
+    ]);
+    // No content to page/jump through: the paging hints stay hidden even
+    // when there's plenty of width, same as the arrow-key scroll hint.
+    expect(
+      taskDetailKeyHintsForColumns({
+        availableColumns: 84,
+        canFocusStream: true,
+        canKill: true,
+        showScrollHint: false,
+      }),
+    ).not.toContainEqual({ key: 'PgUp/PgDn', action: 'page' });
+  });
+
   it('budgets compact task detail output by wrapped terminal rows', () => {
     expect(taskDetailWrappedRowCount('abcd', 4)).toBe(1);
     expect(taskDetailWrappedRowCount('abcde', 4)).toBe(2);


### PR DESCRIPTION
Closes #7193

TaskDetailView (the inline task-detail scroll surface in ChildControlPicker) only supported single-line up/down scrolling. TranscriptViewer already has PgUp/PgDn page scrolling and g/G jump-to-top/bottom bindings; this brings TaskDetailView to parity.

What changed:
- `state/taskDetailScroll.ts`: factored `moveTaskDetailScrollState`'s offset-to-state logic into a shared `taskDetailScrollStateAtOffset` helper, then added `pageTaskDetailScrollState` (PgUp/PgDn, steps by the visible row budget) and `jumpTaskDetailScrollState` (g/G, jumps to offset 0 or back to the tail). All three transitions go through the same helper, so they preserve the existing anchor-based reflow behavior (`TaskDetailScrollAnchor`) that keeps a manually-scrolled position stable across resize/rewrap.
- `modals/ChildControlPicker.tsx`: wired `key.pageUp`/`key.pageDown` and `input === 'g'`/`'G'` in `TaskDetailView`'s `useInput` handler through the new primitives, mirroring `TranscriptViewer.tsx`'s key handling.
- Added regression tests in `ChildControls.vitest.mts` covering paging, jumping, boundary clamping, and the anchor-preserving resize path for the new bindings (mirrors the existing `moveTaskDetailScrollState` anchor test).

Verification: `npx vitest run src/test-kernel/cli` (125 files / 1555 tests pass), `tsc --noEmit -p packages/cli/tsconfig.json`, `tsc --noEmit -p tsconfig.test-kernel.json`, and `eslint` on the changed files all pass clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI TUI scroll behavior and tests only; no runtime, auth, or data-path changes.
> 
> **Overview**
> **Task detail scrolling** in `ChildControlPicker`'s `TaskDetailView` gains **PgUp/PgDn** (page by visible row budget) and **g/G** (jump to top or tail), bringing it in line with `TranscriptViewer` beyond single-line ↑/↓.
> 
> In `taskDetailScroll.ts`, offset updates are centralized in `taskDetailScrollStateAtOffset`; new **`pageTaskDetailScrollState`** and **`jumpTaskDetailScrollState`** use the same path as line moves so **anchor-based reflow** behavior stays intact. `TaskDetailView` wires the new keys in `useInput`, and **key hints** show PgUp/PgDn and g/G only when the terminal is wide enough (≥84 columns) and scrolling applies.
> 
> `ChildControls.vitest.mts` adds coverage for paging, jumping, boundary clamping, tail-follow re-arming, and anchor stability on rewrap. The bench proposal doc diff is **table/typography formatting only** (no design change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78a361c2f5773445db151a1bd3ce22afcfb16b3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->