### PR TITLE
Fix ProgressBoardLayoutMock design-gallery harness to set unsupportedCommands

### DIFF
--- a/docs/proposals/texra-bench-science-benchmarks.md
+++ b/docs/proposals/texra-bench-science-benchmarks.md
@@ -99,10 +99,10 @@ The verifier library is therefore **data, not harness code**: a standard grader 
 
 | `std/` grader (command) | Wraps                                                                                                                                                                                                                                                           |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `std/compile-check`     | `compileCheck.ts` / `latexToolchain.ts` invoked directly, independent of the interactive `WORKFLOW_AUTO_COMPILE` setting — a required gate can't depend on a user preference — the hard gate |
+| `std/compile-check`     | `compileCheck.ts` / `latexToolchain.ts` invoked directly, independent of the interactive `WORKFLOW_AUTO_COMPILE` setting — a required gate can't depend on a user preference — the hard gate                                                                    |
 | `std/cas-equal`         | `wolframscript` (or SymPy) executing a **fixed** `refs/` assertion script against the extracted `\benchresult{...}` — outcome-level, targeting renotation-robustness (how far that can be pushed is open — §15), no credit for matching a human derivation path |
 | `std/lean-build`        | `lake build` against a pinned mathlib toolchain; binary per lemma. Proof tasks need only a statement — difficulty can outgrow the task's author (§6 validate exempts this stack from the gold-`refs/solution` check, since it has no reference answer to score) |
-| `std/diff-align`        | the math-aware latexdiff service — **error-injection tasks only**: edits inside injected spans must match gold, edits outside are penalized; not applicable to derivation/proof tasks, which have no injected spans |
+| `std/diff-align`        | the math-aware latexdiff service — **error-injection tasks only**: edits inside injected spans must match gold, edits outside are penalized; not applicable to derivation/proof tasks, which have no injected spans                                             |
 | `std/issue-match`       | `ReviewIssue` matching against gold defects within a line window → precision/recall                                                                                                                                                                             |
 | `std/answer-match`      | numeric-tolerance / exact / set matching on parsed answer blocks                                                                                                                                                                                                |
 
@@ -138,7 +138,7 @@ bench-results/<suite@version>/<runId>/<model>/<task>/trial-<n>/
                     # to that machinery, not built yet)
 ```
 
-- **Comparability rule:** two scores are comparable iff their *task*, *grader-pack*, and *environment* digests match; the subject dimension (model id and/or agent digest) is exactly what `--compare` varies, so it's excluded from the match. `bench report` refuses comparisons that differ on any of the fixed digests.
+- **Comparability rule:** two scores are comparable iff their _task_, _grader-pack_, and _environment_ digests match; the subject dimension (model id and/or agent digest) is exactly what `--compare` varies, so it's excluded from the match. `bench report` refuses comparisons that differ on any of the fixed digests.
 - **Regrade, don't rerun:** graders never mutate these directories, only read them; `bench grade --regrade --diff-against <old>` (a suite version, e.g. `1.1`, resolved under `--results-dir` to that version's evidence directory) recomputes history at zero model cost and attributes every delta to the grader diff.
 - **Hermetic execution:** a published container image pins TeX Live / Lean / wolframscript; `env.json` records the fingerprint; network off by default at the container level (not just tool-level filtering — a solver with shell access could otherwise reach the network via `curl`/package managers even with web tools disabled), with web tools additionally disabled in-agent via the existing `runtimeUnavailableTools` mechanism (`src/agent/runtime/RunContext.ts`) as defense in depth. No new sandbox layer beyond the container's own network policy.
 - **Determinism honesty:** providers offer no usable seeds; replicate variance is measured and reported, never pretended away.
@@ -192,18 +192,18 @@ Six subcommands. Exit codes reuse `packages/cli/src/runtime/exitCodes.ts`; score
 
 ## 11. Existing machinery it rides on
 
-| Bench component                   | Existing code                                                                                                                         |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Bench component                   | Existing code                                                                                                                                                                                                                       |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Cell execution                    | `packages/cli/src/runtime/runExecution.ts`; tool-use path via `packages/cli/src/commands/agentsRun.ts` (today stops after one model/tool cycle — `stopAfterCycle: true` — bench needs a multi-cycle variant, tracked as an MVP gap) |
-| Compile gate / diff / structure   | `src/agent/output/compileCheck.ts`, `src/latex/latexdiff/`, `src/latex/latexToolchain.ts`, `src/latex/labelSearch.ts`, `src/latex/extractBibliography.ts` |
-| CAS / Lean verifiers              | `src/tools/wolfram/wolframScriptUtils.ts`, `src/tools/lean/direct/lakeCommands.ts`, `src/tools/lean/LspTools.ts`, `src/tools/lean/LoogleTool.ts`          |
-| Issue localization                | `src/agent/review/reviewIssues.ts`; solver pattern from `packages/extension/resources/tool_use_agents/changeReviewer.yaml`            |
-| Fresh-task supply                 | `src/latex/arxivProcessor.ts`                                                                                                         |
-| Trace archive                     | `AgentTrace` subscriber (`src/agent/trace/AgentTrace.ts`, pattern: `src/transcript/TexraTranscriptRecorder.ts`); `AgentEvent` union    |
-| Usage / cost / abort              | `src/agent/core/usage/RunUsageAccumulator.ts` (`totalCost` drives `--max-cost-usd`, checked between dispatches — a soft budget guard under concurrency, not a per-cell reservation) |
-| Providers incl. internal gateways | `src/agent/modelHandlers/` (four stacks; `customBaseUrl` already threaded)                                                            |
-| Solver/judge agents               | ordinary agent YAML under `packages/extension/resources/agents/bench/`, run via `runAgent` (`src/agent/runtime/runAgent.ts`)          |
-| Env fingerprint                   | `texra doctor` machinery (`packages/cli/src/commands/doctor.ts`) — today probes Node/workspace/auth/LaTeX/config; Wolfram/lake/image-digest probes are new additions, not built yet |
+| Compile gate / diff / structure   | `src/agent/output/compileCheck.ts`, `src/latex/latexdiff/`, `src/latex/latexToolchain.ts`, `src/latex/labelSearch.ts`, `src/latex/extractBibliography.ts`                                                                           |
+| CAS / Lean verifiers              | `src/tools/wolfram/wolframScriptUtils.ts`, `src/tools/lean/direct/lakeCommands.ts`, `src/tools/lean/LspTools.ts`, `src/tools/lean/LoogleTool.ts`                                                                                    |
+| Issue localization                | `src/agent/review/reviewIssues.ts`; solver pattern from `packages/extension/resources/tool_use_agents/changeReviewer.yaml`                                                                                                          |
+| Fresh-task supply                 | `src/latex/arxivProcessor.ts`                                                                                                                                                                                                       |
+| Trace archive                     | `AgentTrace` subscriber (`src/agent/trace/AgentTrace.ts`, pattern: `src/transcript/TexraTranscriptRecorder.ts`); `AgentEvent` union                                                                                                 |
+| Usage / cost / abort              | `src/agent/core/usage/RunUsageAccumulator.ts` (`totalCost` drives `--max-cost-usd`, checked between dispatches — a soft budget guard under concurrency, not a per-cell reservation)                                                 |
+| Providers incl. internal gateways | `src/agent/modelHandlers/` (four stacks; `customBaseUrl` already threaded)                                                                                                                                                          |
+| Solver/judge agents               | ordinary agent YAML under `packages/extension/resources/agents/bench/`, run via `runAgent` (`src/agent/runtime/runAgent.ts`)                                                                                                        |
+| Env fingerprint                   | `texra doctor` machinery (`packages/cli/src/commands/doctor.ts`) — today probes Node/workspace/auth/LaTeX/config; Wolfram/lake/image-digest probes are new additions, not built yet                                                 |
 
 All additive: new code lives in `src/bench/` (VS Code-free zone, host services via `platform()`) and `packages/cli/`. **The MVP requires zero changes to `src/agent/` core.**
 

--- a/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
@@ -27,6 +27,13 @@ import { designTokens, commonViewStyles } from '@shared/styles';
 const ACTIVE_STREAM_ID = 'polish';
 const BASE_TIME = Date.parse('2026-05-28T16:00:00Z');
 
+// The design gallery has no host registry broadcasting capabilities, so
+// `unsupportedCommands` would otherwise stay `null`, which `isKnownUnsupported`
+// treats as "unsupported" and hides every gated toolbar/file-list control
+// (Restore, Diff, Pack, Clean, Run latexFixer, etc.). An empty set says every
+// command is supported, so this static mock renders the full designed layout.
+const NO_UNSUPPORTED_COMMANDS: ReadonlySet<string> = new Set();
+
 /** Realistic OutputFileInfo fixture for the production <file-list>. */
 function mockFile(
   relative: string,
@@ -296,6 +303,7 @@ export class ProgressBoardLayoutMock extends LitElement {
             .progress=${{ toolCallCount: 4 }}
             .roundStage=${{ index: 1, total: 2 }}
             .yoloActive=${true}
+            .unsupportedCommands=${NO_UNSUPPORTED_COMMANDS}
           ></stream-header>
           <div class="log-body">
             <task-group-list
@@ -311,6 +319,7 @@ export class ProgressBoardLayoutMock extends LitElement {
               .filesByRound=${SAMPLE_FILES}
               .failuresByRound=${{}}
               .showRoundHeaders=${false}
+              .unsupportedCommands=${NO_UNSUPPORTED_COMMANDS}
             ></file-list>
           </div>
         </div>


### PR DESCRIPTION
Closes #7184

## What changed

`ProgressBoardLayoutMock.ts` (the design-gallery dev harness) never set `.unsupportedCommands` on its `<stream-header>`/`<file-list>` elements. `isKnownUnsupported` treats a `null` set as "unsupported" (the right default for the real progress view before the host's one-shot capability broadcast lands), so every gated toolbar/file-list control (Restore, Diff, Pack, Clean, Run latexFixer, etc.) rendered hidden in the gallery instead of showing the intended layout.

Passed an explicit empty `Set()` on both elements, since the static mock has no host registry to broadcast a real one and every command should read as supported so the gallery renders as designed.

## Why

Follow-up from #7159 / umbrella #7182, as filed in #7184. Dev-tool only, not shipped-app-facing.

## Note

This branch also carries an unrelated one-line-per-row `chore` commit fixing pre-existing prettier drift in `docs/proposals/texra-bench-science-benchmarks.md` (table column widths / emphasis style). That file was already out of sync with the repo's pinned prettier version on `main`, and the local `npm-format` pre-commit hook reformats it on every commit attempt in this repo, so it had to land before this branch's own commit could go through cleanly.

## Verification

- `npx tsc --noEmit` in `packages/extension` — clean
- `npx eslint packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts` — clean
- `npx prettier --check` on the touched file — clean
- No existing vitest coverage targets this dev-only design-gallery mock; the change is a prop-wiring fix with no new branching logic to unit test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only mock and documentation formatting; no shipped progress view behavior change.
> 
> **Overview**
> **Design gallery:** `ProgressBoardLayoutMock` now passes an empty `unsupportedCommands` set into `<stream-header>` and `<file-list>`. Without it, `isKnownUnsupported` treats `null` as unsupported and hides gated actions (Restore, Diff, Pack, Clean, Run latexFixer, etc.); the static mock has no host capability broadcast, so the empty set marks every command supported for the intended full layout preview.
> 
> **Docs (incidental):** `docs/proposals/texra-bench-science-benchmarks.md` gets prettier-driven table column alignment and `_` emphasis instead of `*` on one comparability bullet—no proposal substance change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae2e711b04075756d3e281cf5af12e717cc4f2ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->