### PR TITLE
Registry-derive DEFAULT_MODELS and MODEL_LIST_VERSION

### DIFF
--- a/docs/proposals/texra-bench-science-benchmarks.md
+++ b/docs/proposals/texra-bench-science-benchmarks.md
@@ -99,10 +99,10 @@ The verifier library is therefore **data, not harness code**: a standard grader 
 
 | `std/` grader (command) | Wraps                                                                                                                                                                                                                                                           |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `std/compile-check`     | `compileCheck.ts` / `latexToolchain.ts` invoked directly, independent of the interactive `WORKFLOW_AUTO_COMPILE` setting — a required gate can't depend on a user preference — the hard gate |
+| `std/compile-check`     | `compileCheck.ts` / `latexToolchain.ts` invoked directly, independent of the interactive `WORKFLOW_AUTO_COMPILE` setting — a required gate can't depend on a user preference — the hard gate                                                                    |
 | `std/cas-equal`         | `wolframscript` (or SymPy) executing a **fixed** `refs/` assertion script against the extracted `\benchresult{...}` — outcome-level, targeting renotation-robustness (how far that can be pushed is open — §15), no credit for matching a human derivation path |
 | `std/lean-build`        | `lake build` against a pinned mathlib toolchain; binary per lemma. Proof tasks need only a statement — difficulty can outgrow the task's author (§6 validate exempts this stack from the gold-`refs/solution` check, since it has no reference answer to score) |
-| `std/diff-align`        | the math-aware latexdiff service — **error-injection tasks only**: edits inside injected spans must match gold, edits outside are penalized; not applicable to derivation/proof tasks, which have no injected spans |
+| `std/diff-align`        | the math-aware latexdiff service — **error-injection tasks only**: edits inside injected spans must match gold, edits outside are penalized; not applicable to derivation/proof tasks, which have no injected spans                                             |
 | `std/issue-match`       | `ReviewIssue` matching against gold defects within a line window → precision/recall                                                                                                                                                                             |
 | `std/answer-match`      | numeric-tolerance / exact / set matching on parsed answer blocks                                                                                                                                                                                                |
 
@@ -138,7 +138,7 @@ bench-results/<suite@version>/<runId>/<model>/<task>/trial-<n>/
                     # to that machinery, not built yet)
 ```
 
-- **Comparability rule:** two scores are comparable iff their *task*, *grader-pack*, and *environment* digests match; the subject dimension (model id and/or agent digest) is exactly what `--compare` varies, so it's excluded from the match. `bench report` refuses comparisons that differ on any of the fixed digests.
+- **Comparability rule:** two scores are comparable iff their _task_, _grader-pack_, and _environment_ digests match; the subject dimension (model id and/or agent digest) is exactly what `--compare` varies, so it's excluded from the match. `bench report` refuses comparisons that differ on any of the fixed digests.
 - **Regrade, don't rerun:** graders never mutate these directories, only read them; `bench grade --regrade --diff-against <old>` (a suite version, e.g. `1.1`, resolved under `--results-dir` to that version's evidence directory) recomputes history at zero model cost and attributes every delta to the grader diff.
 - **Hermetic execution:** a published container image pins TeX Live / Lean / wolframscript; `env.json` records the fingerprint; network off by default at the container level (not just tool-level filtering — a solver with shell access could otherwise reach the network via `curl`/package managers even with web tools disabled), with web tools additionally disabled in-agent via the existing `runtimeUnavailableTools` mechanism (`src/agent/runtime/RunContext.ts`) as defense in depth. No new sandbox layer beyond the container's own network policy.
 - **Determinism honesty:** providers offer no usable seeds; replicate variance is measured and reported, never pretended away.
@@ -192,18 +192,18 @@ Six subcommands. Exit codes reuse `packages/cli/src/runtime/exitCodes.ts`; score
 
 ## 11. Existing machinery it rides on
 
-| Bench component                   | Existing code                                                                                                                         |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Bench component                   | Existing code                                                                                                                                                                                                                       |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Cell execution                    | `packages/cli/src/runtime/runExecution.ts`; tool-use path via `packages/cli/src/commands/agentsRun.ts` (today stops after one model/tool cycle — `stopAfterCycle: true` — bench needs a multi-cycle variant, tracked as an MVP gap) |
-| Compile gate / diff / structure   | `src/agent/output/compileCheck.ts`, `src/latex/latexdiff/`, `src/latex/latexToolchain.ts`, `src/latex/labelSearch.ts`, `src/latex/extractBibliography.ts` |
-| CAS / Lean verifiers              | `src/tools/wolfram/wolframScriptUtils.ts`, `src/tools/lean/direct/lakeCommands.ts`, `src/tools/lean/LspTools.ts`, `src/tools/lean/LoogleTool.ts`          |
-| Issue localization                | `src/agent/review/reviewIssues.ts`; solver pattern from `packages/extension/resources/tool_use_agents/changeReviewer.yaml`            |
-| Fresh-task supply                 | `src/latex/arxivProcessor.ts`                                                                                                         |
-| Trace archive                     | `AgentTrace` subscriber (`src/agent/trace/AgentTrace.ts`, pattern: `src/transcript/TexraTranscriptRecorder.ts`); `AgentEvent` union    |
-| Usage / cost / abort              | `src/agent/core/usage/RunUsageAccumulator.ts` (`totalCost` drives `--max-cost-usd`, checked between dispatches — a soft budget guard under concurrency, not a per-cell reservation) |
-| Providers incl. internal gateways | `src/agent/modelHandlers/` (four stacks; `customBaseUrl` already threaded)                                                            |
-| Solver/judge agents               | ordinary agent YAML under `packages/extension/resources/agents/bench/`, run via `runAgent` (`src/agent/runtime/runAgent.ts`)          |
-| Env fingerprint                   | `texra doctor` machinery (`packages/cli/src/commands/doctor.ts`) — today probes Node/workspace/auth/LaTeX/config; Wolfram/lake/image-digest probes are new additions, not built yet |
+| Compile gate / diff / structure   | `src/agent/output/compileCheck.ts`, `src/latex/latexdiff/`, `src/latex/latexToolchain.ts`, `src/latex/labelSearch.ts`, `src/latex/extractBibliography.ts`                                                                           |
+| CAS / Lean verifiers              | `src/tools/wolfram/wolframScriptUtils.ts`, `src/tools/lean/direct/lakeCommands.ts`, `src/tools/lean/LspTools.ts`, `src/tools/lean/LoogleTool.ts`                                                                                    |
+| Issue localization                | `src/agent/review/reviewIssues.ts`; solver pattern from `packages/extension/resources/tool_use_agents/changeReviewer.yaml`                                                                                                          |
+| Fresh-task supply                 | `src/latex/arxivProcessor.ts`                                                                                                                                                                                                       |
+| Trace archive                     | `AgentTrace` subscriber (`src/agent/trace/AgentTrace.ts`, pattern: `src/transcript/TexraTranscriptRecorder.ts`); `AgentEvent` union                                                                                                 |
+| Usage / cost / abort              | `src/agent/core/usage/RunUsageAccumulator.ts` (`totalCost` drives `--max-cost-usd`, checked between dispatches — a soft budget guard under concurrency, not a per-cell reservation)                                                 |
+| Providers incl. internal gateways | `src/agent/modelHandlers/` (four stacks; `customBaseUrl` already threaded)                                                                                                                                                          |
+| Solver/judge agents               | ordinary agent YAML under `packages/extension/resources/agents/bench/`, run via `runAgent` (`src/agent/runtime/runAgent.ts`)                                                                                                        |
+| Env fingerprint                   | `texra doctor` machinery (`packages/cli/src/commands/doctor.ts`) — today probes Node/workspace/auth/LaTeX/config; Wolfram/lake/image-digest probes are new additions, not built yet                                                 |
 
 All additive: new code lives in `src/bench/` (VS Code-free zone, host services via `platform()`) and `packages/cli/`. **The MVP requires zero changes to `src/agent/` core.**
 

--- a/src/model/modelListRefresh.ts
+++ b/src/model/modelListRefresh.ts
@@ -64,24 +64,30 @@ function reconcileEnabledModels(
   }
 
   // Retired models are hard unavailable even for users with included relay
-  // access. Strip them whenever this refresh version is crossed. (Version 21
-  // was the last hand-bumped MODEL_LIST_VERSION before #7191 switched to a
-  // hash-derived value, which always lands above this range -- see
-  // MODEL_LIST_HASH_BASE in modelOptionsBasic.ts -- so this sweep still fires
-  // exactly once for every pre-#7191 install.)
-  if ((previousVersion ?? 0) < 21) {
-    for (const model of currentModels) {
-      if (isRetiredModel(model)) strippedSet.add(model);
-    }
+  // access. This sweep runs on every reconciliation, unconditionally --
+  // deliberately *not* gated behind a version threshold like the two sweeps
+  // above. `reconcileEnabledModels` only ever runs when MODEL_LIST_VERSION
+  // has changed (see `refreshModelListStateIfNeeded`), and since #7191 that
+  // version is a hash of the resolved default set: it changes again every
+  // time a future pick quietly retires, at which point the user's persisted
+  // version is already a hash-derived value from a prior run, permanently
+  // past any legacy "< N" gate. Freezing this sweep behind such a gate (it
+  // used to read `previousVersion < 21`, the last hand-bumped version before
+  // #7191) would mean it fires exactly once during the pre-#7191 migration
+  // and then never again -- silently leaving future retired defaults stuck in
+  // an existing user's enabled-models list. Running it unconditionally keeps
+  // it correct across both versioning schemes, at negligible cost (the set of
+  // currently-enabled models is small).
+  for (const model of currentModels) {
+    if (isRetiredModel(model)) strippedSet.add(model);
   }
 
   const kept = currentModels.filter((model) => !strippedSet.has(model));
-  const added = DEFAULT_MODELS.filter(
-    (model) =>
-      !kept.includes(model) &&
-      !isDeprecatedModel(model) &&
-      !isRetiredModel(model),
-  );
+  // DEFAULT_MODELS is already resolved against the live registry --
+  // resolveDefaultModels (modelOptionsBasic.ts) drops retired/deprecated
+  // picks before this module ever sees them -- so the only remaining check
+  // here is "not already present".
+  const added = DEFAULT_MODELS.filter((model) => !kept.includes(model));
 
   return {
     models: [...kept, ...added],

--- a/src/model/modelListRefresh.ts
+++ b/src/model/modelListRefresh.ts
@@ -48,11 +48,15 @@ function reconcileEnabledModels(
   // Generic deprecated-model sweep for users upgrading past version 16: remove
   // models the registry now marks as deprecated so normal dropdowns stay
   // current. Introduced at version 15 (sonnet/opus tiers) and re-bumped to 16
-  // when opus47/opus47T were deprecated in favor of opus48/opus48T. Bump the
-  // guard to the current MODEL_LIST_VERSION whenever the registry deprecates
-  // more defaults. Version 18 leads DEFAULT_MODELS with gemini35f and version
-  // 19 adds fable5; both only add or reorder models (no removals), so the
-  // deprecated-model sweep intentionally remains guarded at version 16.
+  // when opus47/opus47T were deprecated in favor of opus48/opus48T. Version
+  // 18 leads DEFAULT_MODELS with gemini35f and version 19 adds fable5; both
+  // only add or reorder models (no removals), so the deprecated-model sweep
+  // intentionally remains guarded at version 16. These thresholds are frozen
+  // historical facts about specific past migrations, not tied to the current
+  // value of MODEL_LIST_VERSION: since #7191, that value is a hash of the
+  // resolved default set rather than a hand-bumped integer, so it no longer
+  // makes sense to "bump the guard to the current version" -- a future
+  // one-time sweep would add its own new numeric threshold here instead.
   if ((previousVersion ?? 0) < 16) {
     for (const model of currentModels) {
       if (isDeprecatedModel(model)) strippedSet.add(model);
@@ -60,7 +64,11 @@ function reconcileEnabledModels(
   }
 
   // Retired models are hard unavailable even for users with included relay
-  // access. Strip them whenever this refresh version is crossed.
+  // access. Strip them whenever this refresh version is crossed. (Version 21
+  // was the last hand-bumped MODEL_LIST_VERSION before #7191 switched to a
+  // hash-derived value, which always lands above this range -- see
+  // MODEL_LIST_HASH_BASE in modelOptionsBasic.ts -- so this sweep still fires
+  // exactly once for every pre-#7191 install.)
   if ((previousVersion ?? 0) < 21) {
     for (const model of currentModels) {
       if (isRetiredModel(model)) strippedSet.add(model);

--- a/src/model/modelOptionsBasic.ts
+++ b/src/model/modelOptionsBasic.ts
@@ -29,10 +29,11 @@ export function isRetiredModel(model: string): boolean {
  * table is hand-maintained. What IS derived from the registry, so this table
  * going stale can never silently ship a dead default, is {@link
  * DEFAULT_MODELS} below: it drops any pick the live registry has since
- * retired. {@link MODEL_LIST_VERSION} then hashes that resolved (post-filter)
- * set, so either this table changing or a pick quietly retiring underneath it
- * changes the reconciliation trigger automatically -- no maintainer has to
- * remember to hand-bump a version constant.
+ * retired or deprecated. {@link MODEL_LIST_VERSION} then hashes that resolved
+ * (post-filter) set, so either this table changing or a pick quietly
+ * retiring/deprecating underneath it changes the reconciliation trigger
+ * automatically -- no maintainer has to remember to hand-bump a version
+ * constant.
  */
 const PREFERRED_DEFAULT_MODELS: readonly string[] = [
   'gemini35f',
@@ -48,19 +49,27 @@ const PREFERRED_DEFAULT_MODELS: readonly string[] = [
 
 /**
  * Resolve a preferred model list against the live registry, dropping any pick
- * the registry marks retired. Exported (separately from {@link
- * DEFAULT_MODELS}) so tests can exercise the resolution mechanism itself
- * against a known-retired registry entry, without depending on {@link
- * PREFERRED_DEFAULT_MODELS} happening to contain one today.
+ * the registry marks retired or deprecated -- matching the stricter filter
+ * `reconcileEnabledModels` (`modelListRefresh.ts`) already applies before
+ * granting a default to an *existing* user, so a first-time user (or any
+ * direct `DEFAULT_MODELS` consumer, e.g. `SettingsModelSelectionController`)
+ * can't be handed a stale default an existing user would never receive.
+ * Exported (separately from {@link DEFAULT_MODELS}) so tests can exercise the
+ * resolution mechanism itself against known-retired/deprecated registry
+ * entries, without depending on {@link PREFERRED_DEFAULT_MODELS} happening to
+ * contain one today.
  */
 export function resolveDefaultModels(preferred: readonly string[]): string[] {
-  return preferred.filter((model) => !isRetiredModel(model));
+  return preferred.filter(
+    (model) => !isRetiredModel(model) && !isDeprecatedModel(model),
+  );
 }
 
 /**
  * Models that should be present in every user's model list, resolved against
- * the live registry: a preferred pick the registry now marks retired is
- * dropped rather than dangling in the default list with no way back out.
+ * the live registry: a preferred pick the registry now marks retired or
+ * deprecated is dropped rather than dangling in the default list with no way
+ * back out.
  */
 export const DEFAULT_MODELS: string[] = resolveDefaultModels(
   PREFERRED_DEFAULT_MODELS,
@@ -93,7 +102,7 @@ function fnv1aHash(input: string): number {
  * registry-derived set does, rather than only asserting today's value.
  */
 export function computeModelListVersion(models: readonly string[]): number {
-  return MODEL_LIST_HASH_BASE + fnv1aHash([...models].sort().join(','));
+  return MODEL_LIST_HASH_BASE + fnv1aHash(models.toSorted().join(','));
 }
 
 /**

--- a/src/model/modelOptionsBasic.ts
+++ b/src/model/modelOptionsBasic.ts
@@ -10,8 +10,31 @@ import {
   isFastFirstResponseModel,
 } from '@shared/constants/fastModels';
 
-/** Models that should be present in every user's model list. */
-export const DEFAULT_MODELS = [
+/** Return whether the registry marks a model as deprecated. */
+export function isDeprecatedModel(model: string): boolean {
+  return MODEL_CONFIGS[model]?.deprecated ?? false;
+}
+
+/** Return whether the registry marks a model as no longer served. */
+export function isRetiredModel(model: string): boolean {
+  return MODEL_CONFIGS[model]?.retired ?? false;
+}
+
+/**
+ * Curated pick of models that should be present in every user's model list --
+ * a *preference*, not the source of truth for whether each pick is still
+ * servable. `llm-zoo`'s `ModelConfig` has no "featured"/"default" capability
+ * flag to derive this set from directly, so -- the same way
+ * `setupModelDefaults.ts` curates one setup-probe model per provider -- this
+ * table is hand-maintained. What IS derived from the registry, so this table
+ * going stale can never silently ship a dead default, is {@link
+ * DEFAULT_MODELS} below: it drops any pick the live registry has since
+ * retired. {@link MODEL_LIST_VERSION} then hashes that resolved (post-filter)
+ * set, so either this table changing or a pick quietly retiring underneath it
+ * changes the reconciliation trigger automatically -- no maintainer has to
+ * remember to hand-bump a version constant.
+ */
+const PREFERRED_DEFAULT_MODELS: readonly string[] = [
   'gemini35f',
   'gemini31p',
   'sonnet46T',
@@ -23,21 +46,70 @@ export const DEFAULT_MODELS = [
   'kimi26T',
 ];
 
-/** Increment when the persisted model list needs reconciliation. */
-export const MODEL_LIST_VERSION = 21;
+/**
+ * Resolve a preferred model list against the live registry, dropping any pick
+ * the registry marks retired. Exported (separately from {@link
+ * DEFAULT_MODELS}) so tests can exercise the resolution mechanism itself
+ * against a known-retired registry entry, without depending on {@link
+ * PREFERRED_DEFAULT_MODELS} happening to contain one today.
+ */
+export function resolveDefaultModels(preferred: readonly string[]): string[] {
+  return preferred.filter((model) => !isRetiredModel(model));
+}
+
+/**
+ * Models that should be present in every user's model list, resolved against
+ * the live registry: a preferred pick the registry now marks retired is
+ * dropped rather than dangling in the default list with no way back out.
+ */
+export const DEFAULT_MODELS: string[] = resolveDefaultModels(
+  PREFERRED_DEFAULT_MODELS,
+);
+
+/**
+ * Baseline added to the {@link MODEL_LIST_VERSION} hash so it can never
+ * collide with the hand-bumped integers (1-21) this file used before it
+ * switched to a registry-derived trigger -- `reconcileEnabledModels`'s
+ * one-time migration gates read a user's previously *persisted* version
+ * number, which for every existing install is still one of those small
+ * integers, so the new value must land clear of that range.
+ */
+const MODEL_LIST_HASH_BASE = 1000;
+
+/** Deterministic 32-bit FNV-1a hash of `input`, as a non-negative integer. */
+function fnv1aHash(input: string): number {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+/**
+ * Compute the reconciliation trigger for a resolved default-model set: a hash
+ * of `models` sorted so only membership, not order, affects the result.
+ * Exported so tests can confirm the trigger actually changes when the
+ * registry-derived set does, rather than only asserting today's value.
+ */
+export function computeModelListVersion(models: readonly string[]): number {
+  return MODEL_LIST_HASH_BASE + fnv1aHash([...models].sort().join(','));
+}
+
+/**
+ * Reconciliation trigger for the persisted enabled-models list
+ * (`modelListRefresh.ts`). Derived from a hash of the resolved {@link
+ * DEFAULT_MODELS} set instead of a hand-bumped integer, so a registry change
+ * that alters what resolves (a curated pick retiring and dropping out, or a
+ * maintainer editing {@link PREFERRED_DEFAULT_MODELS}) is detected
+ * automatically on the next launch rather than relying on someone
+ * remembering to bump this value.
+ */
+export const MODEL_LIST_VERSION: number =
+  computeModelListVersion(DEFAULT_MODELS);
 
 const MILLION = 1_000_000;
 const THOUSAND = 1_000;
-
-/** Return whether the registry marks a model as deprecated. */
-export function isDeprecatedModel(model: string): boolean {
-  return MODEL_CONFIGS[model]?.deprecated ?? false;
-}
-
-/** Return whether the registry marks a model as no longer served. */
-export function isRetiredModel(model: string): boolean {
-  return MODEL_CONFIGS[model]?.retired ?? false;
-}
 
 /** Format context window number for display. */
 function formatContext(context: number | undefined): string | undefined {

--- a/src/model/modelOptionsBasic.ts
+++ b/src/model/modelOptionsBasic.ts
@@ -29,13 +29,20 @@ export function isRetiredModel(model: string): boolean {
  * table is hand-maintained. What IS derived from the registry, so this table
  * going stale can never silently ship a dead default, is {@link
  * DEFAULT_MODELS} below: it drops any pick the live registry has since
- * retired or deprecated. {@link MODEL_LIST_VERSION} then hashes that resolved
- * (post-filter) set, so either this table changing or a pick quietly
- * retiring/deprecating underneath it changes the reconciliation trigger
- * automatically -- no maintainer has to remember to hand-bump a version
- * constant.
+ * retired or deprecated. {@link MODEL_LIST_VERSION} hashes this table paired
+ * with each pick's *live status* -- not the resolved post-filter set -- so
+ * either this table changing, or a pick's status quietly transitioning
+ * underneath it (active to deprecated, deprecated to retired, or back),
+ * changes the reconciliation trigger automatically. Hashing status alongside
+ * id matters specifically for the deprecated-to-retired case: a pick already
+ * excluded from the resolved set for being deprecated stays excluded once
+ * it's retired too, so hashing only the resolved set would never notice that
+ * transition -- yet `reconcileEnabledModels`'s unconditional retired-model
+ * sweep needs exactly that trigger to strip the now-unservable model from
+ * existing users. No maintainer has to remember to hand-bump a version
+ * constant either way.
  */
-const PREFERRED_DEFAULT_MODELS: readonly string[] = [
+export const PREFERRED_DEFAULT_MODELS: readonly string[] = [
   'gemini35f',
   'gemini31p',
   'sonnet46T',
@@ -85,7 +92,12 @@ export const DEFAULT_MODELS: string[] = resolveDefaultModels(
  */
 const MODEL_LIST_HASH_BASE = 1000;
 
-/** Deterministic 32-bit FNV-1a hash of `input`, as a non-negative integer. */
+/**
+ * Deterministic 32-bit FNV-1a hash of `input`, as a non-negative integer.
+ * Operates on UTF-16 code units (`charCodeAt`), not raw bytes -- byte-
+ * equivalent to canonical FNV-1a for the ASCII-only inputs this module hashes
+ * (model ids), but not a general byte-level implementation.
+ */
 function fnv1aHash(input: string): number {
   let hash = 0x811c9dc5;
   for (let index = 0; index < input.length; index += 1) {
@@ -96,26 +108,54 @@ function fnv1aHash(input: string): number {
 }
 
 /**
- * Compute the reconciliation trigger for a resolved default-model set: a hash
- * of `models` sorted so only membership, not order, affects the result.
- * Exported so tests can confirm the trigger actually changes when the
- * registry-derived set does, rather than only asserting today's value.
+ * Live registry status of a model. Distinguishes "deprecated" (still
+ * servable, discouraged) from "retired" (hard unavailable) so {@link
+ * computeModelListVersion} can detect a transition between them even though
+ * {@link resolveDefaultModels} filters both out of the resolved set the same
+ * way.
  */
-export function computeModelListVersion(models: readonly string[]): number {
-  return MODEL_LIST_HASH_BASE + fnv1aHash(models.toSorted().join(','));
+type ModelStatus = 'active' | 'deprecated' | 'retired';
+
+function modelStatus(model: string): ModelStatus {
+  if (isRetiredModel(model)) return 'retired';
+  if (isDeprecatedModel(model)) return 'deprecated';
+  return 'active';
+}
+
+/**
+ * Compute the reconciliation trigger for a preferred-model list: a hash of
+ * each pick's id *and* live registry status, sorted so only membership (not
+ * order) affects the result. Hashing status alongside id -- rather than
+ * hashing only the resolved (post-filter) set -- matters because two picks
+ * that both filter out of that set, e.g. one deprecated and one retired,
+ * must still produce different hashes: a deprecated pick transitioning to
+ * retired needs to change the hash so `reconcileEnabledModels` re-runs and
+ * its unconditional retired-model sweep can strip the now-unservable model
+ * from existing users. Exported so tests can confirm the trigger actually
+ * changes when the registry-derived status does, rather than only asserting
+ * today's value.
+ */
+export function computeModelListVersion(preferred: readonly string[]): number {
+  const entries = preferred
+    .toSorted()
+    .map((model) => `${model}:${modelStatus(model)}`);
+  return MODEL_LIST_HASH_BASE + fnv1aHash(entries.join(','));
 }
 
 /**
  * Reconciliation trigger for the persisted enabled-models list
- * (`modelListRefresh.ts`). Derived from a hash of the resolved {@link
- * DEFAULT_MODELS} set instead of a hand-bumped integer, so a registry change
- * that alters what resolves (a curated pick retiring and dropping out, or a
- * maintainer editing {@link PREFERRED_DEFAULT_MODELS}) is detected
- * automatically on the next launch rather than relying on someone
+ * (`modelListRefresh.ts`). Derived from a hash of {@link
+ * PREFERRED_DEFAULT_MODELS} paired with each pick's live registry status,
+ * instead of a hand-bumped integer, so a registry change that alters what
+ * resolves -- a curated pick's status transitioning (including between two
+ * statuses that both drop it from {@link DEFAULT_MODELS}, like deprecated to
+ * retired), or a maintainer editing {@link PREFERRED_DEFAULT_MODELS} -- is
+ * detected automatically on the next launch rather than relying on someone
  * remembering to bump this value.
  */
-export const MODEL_LIST_VERSION: number =
-  computeModelListVersion(DEFAULT_MODELS);
+export const MODEL_LIST_VERSION: number = computeModelListVersion(
+  PREFERRED_DEFAULT_MODELS,
+);
 
 const MILLION = 1_000_000;
 const THOUSAND = 1_000;

--- a/src/test-kernel/model/ModelListRefresh.vitest.ts
+++ b/src/test-kernel/model/ModelListRefresh.vitest.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { MODEL_CONFIGS } from 'llm-zoo';
+
+import { refreshModelListStateIfNeeded } from '@model/modelListRefresh';
+import { GlobalStateKey } from '@shared/state/stateKeys';
+
+import type { StateStore } from '@platform/interfaces/state';
+
+function fakeStateStore(initial: Record<string, unknown> = {}): StateStore {
+  const store = new Map<string, unknown>(Object.entries(initial));
+  return {
+    get<T>(key: string, defaultValue?: T): T {
+      return (store.has(key) ? store.get(key) : defaultValue) as T;
+    },
+    async update(key: string, value: unknown): Promise<void> {
+      store.set(key, value);
+    },
+  };
+}
+
+/**
+ * #7216 review: the retired-model sweep in `reconcileEnabledModels` used to
+ * be gated behind `previousVersion < 21`, a threshold frozen from the
+ * hand-bumped MODEL_LIST_VERSION scheme this file used before #7191. Since
+ * #7191, MODEL_LIST_VERSION is a registry-derived hash that always lands
+ * above 21 (see `MODEL_LIST_HASH_BASE` in modelOptionsBasic.ts) -- so once a
+ * user's persisted version is itself hash-derived, that legacy gate could
+ * never fire again, silently leaving a newly-retired model stuck in an
+ * existing user's enabled-models list forever. The sweep must keep firing on
+ * every reconciliation regardless of which versioning scheme produced
+ * `previousVersion`.
+ */
+describe('refreshModelListStateIfNeeded', () => {
+  it('strips a retired model even when previousVersion is already a hash-derived value past the legacy migration threshold', async () => {
+    expect(MODEL_CONFIGS.grok4?.retired).toBe(true);
+
+    const state = fakeStateStore({
+      // Simulates a user who already reconciled once under the hash-based
+      // scheme (any value > 21, e.g. MODEL_LIST_HASH_BASE + some hash).
+      [GlobalStateKey.MODEL_LIST_VERSION]: 5000,
+      [GlobalStateKey.ENABLED_MODELS]: ['opus48T', 'grok4'],
+    });
+
+    const result = await refreshModelListStateIfNeeded(state);
+
+    expect(result.skipped).toBe(false);
+    expect(result.removed).toContain('grok4');
+    expect(
+      state.get<string[]>(GlobalStateKey.ENABLED_MODELS, []),
+    ).not.toContain('grok4');
+  });
+});

--- a/src/test-kernel/model/ModelOptionsBasic.vitest.ts
+++ b/src/test-kernel/model/ModelOptionsBasic.vitest.ts
@@ -3,7 +3,13 @@ import { describe, expect, it } from 'vitest';
 import { MODEL_CONFIGS } from 'llm-zoo';
 
 // Local imports - model
-import { DEFAULT_MODELS, isRetiredModel } from '@model/modelOptionsBasic';
+import {
+  computeModelListVersion,
+  DEFAULT_MODELS,
+  isRetiredModel,
+  MODEL_LIST_VERSION,
+  resolveDefaultModels,
+} from '@model/modelOptionsBasic';
 import { DEFAULT_HELPER_MODEL } from '@shared/constants/providers';
 
 describe('default helper model', () => {
@@ -54,5 +60,54 @@ describe('default model list', () => {
 
   it('does not include retired models', () => {
     expect(DEFAULT_MODELS.filter(isRetiredModel)).toEqual([]);
+  });
+});
+
+/**
+ * #7191: DEFAULT_MODELS was a hand-maintained literal array and
+ * MODEL_LIST_VERSION a hand-bumped integer -- a model retiring underneath the
+ * literal list left it dangling with no automatic removal, and a maintainer
+ * had to remember to bump the version whenever the resolved defaults changed.
+ * `resolveDefaultModels` and `computeModelListVersion` make both derive from
+ * the live registry instead. These tests exercise the mechanism directly
+ * against real registry data (grok4, retired live in the registry today, same
+ * as SetupModelDefaults.vitest.ts's #7081 regression) rather than only
+ * asserting today's already-passing DEFAULT_MODELS snapshot.
+ */
+describe('resolveDefaultModels', () => {
+  it('drops a preferred pick the live registry marks retired', () => {
+    expect(MODEL_CONFIGS.grok4?.retired).toBe(true);
+    const resolved = resolveDefaultModels(['opus48T', 'grok4']);
+    expect(resolved).toEqual(['opus48T']);
+  });
+
+  it('keeps every preferred pick when none are retired', () => {
+    const preferred = ['opus48T', 'gemini31p'];
+    expect(resolveDefaultModels(preferred)).toEqual(preferred);
+  });
+});
+
+describe('computeModelListVersion', () => {
+  it('changes when the resolved default set changes', () => {
+    const before = computeModelListVersion(['opus48T', 'gemini31p']);
+    const afterAdd = computeModelListVersion(['opus48T', 'gemini31p', 'gpt55']);
+    const afterRemove = computeModelListVersion(['opus48T']);
+
+    expect(afterAdd).not.toBe(before);
+    expect(afterRemove).not.toBe(before);
+  });
+
+  it('is order-independent (only set membership drives reconciliation)', () => {
+    expect(computeModelListVersion(['opus48T', 'gemini31p'])).toBe(
+      computeModelListVersion(['gemini31p', 'opus48T']),
+    );
+  });
+
+  it('is a pure function of the resolved set, wired to MODEL_LIST_VERSION', () => {
+    expect(MODEL_LIST_VERSION).toBe(computeModelListVersion(DEFAULT_MODELS));
+  });
+
+  it('never lands in the pre-#7191 hand-bumped range (1-21), so every existing install reconciles exactly once on upgrade', () => {
+    expect(MODEL_LIST_VERSION).toBeGreaterThan(21);
   });
 });

--- a/src/test-kernel/model/ModelOptionsBasic.vitest.ts
+++ b/src/test-kernel/model/ModelOptionsBasic.vitest.ts
@@ -6,6 +6,7 @@ import { MODEL_CONFIGS } from 'llm-zoo';
 import {
   computeModelListVersion,
   DEFAULT_MODELS,
+  isDeprecatedModel,
   isRetiredModel,
   MODEL_LIST_VERSION,
   resolveDefaultModels,
@@ -61,6 +62,10 @@ describe('default model list', () => {
   it('does not include retired models', () => {
     expect(DEFAULT_MODELS.filter(isRetiredModel)).toEqual([]);
   });
+
+  it('does not include deprecated models', () => {
+    expect(DEFAULT_MODELS.filter(isDeprecatedModel)).toEqual([]);
+  });
 });
 
 /**
@@ -81,7 +86,13 @@ describe('resolveDefaultModels', () => {
     expect(resolved).toEqual(['opus48T']);
   });
 
-  it('keeps every preferred pick when none are retired', () => {
+  it('drops a preferred pick the live registry marks deprecated', () => {
+    expect(MODEL_CONFIGS.gpt54?.deprecated).toBe(true);
+    const resolved = resolveDefaultModels(['opus48T', 'gpt54']);
+    expect(resolved).toEqual(['opus48T']);
+  });
+
+  it('keeps every preferred pick when none are retired or deprecated', () => {
     const preferred = ['opus48T', 'gemini31p'];
     expect(resolveDefaultModels(preferred)).toEqual(preferred);
   });

--- a/src/test-kernel/model/ModelOptionsBasic.vitest.ts
+++ b/src/test-kernel/model/ModelOptionsBasic.vitest.ts
@@ -9,6 +9,7 @@ import {
   isDeprecatedModel,
   isRetiredModel,
   MODEL_LIST_VERSION,
+  PREFERRED_DEFAULT_MODELS,
   resolveDefaultModels,
 } from '@model/modelOptionsBasic';
 import { DEFAULT_HELPER_MODEL } from '@shared/constants/providers';
@@ -114,11 +115,32 @@ describe('computeModelListVersion', () => {
     );
   });
 
-  it('is a pure function of the resolved set, wired to MODEL_LIST_VERSION', () => {
-    expect(MODEL_LIST_VERSION).toBe(computeModelListVersion(DEFAULT_MODELS));
+  it('is a pure function of the preferred (unfiltered) list, wired to MODEL_LIST_VERSION', () => {
+    expect(MODEL_LIST_VERSION).toBe(
+      computeModelListVersion(PREFERRED_DEFAULT_MODELS),
+    );
   });
 
   it('never lands in the pre-#7191 hand-bumped range (1-21), so every existing install reconciles exactly once on upgrade', () => {
     expect(MODEL_LIST_VERSION).toBeGreaterThan(21);
+  });
+
+  /**
+   * #7216 review: hashing the *resolved* (post-filter) set made the trigger
+   * blind to a status transition between two states that both filter out of
+   * that set -- most importantly deprecated -> retired. A preferred pick that
+   * is merely deprecated is still nominally servable; once the registry marks
+   * it retired, `reconcileEnabledModels`'s unconditional retired-model sweep
+   * needs to strip it from existing users, which only happens if the version
+   * hash actually changes. `gpt54` (deprecated) and `grok4` (retired) both
+   * resolve to the same empty set, so a hash of `resolveDefaultModels(...)`
+   * output would have collapsed them to the same version.
+   */
+  it('distinguishes a deprecated preferred pick from a retired one, even though both resolve to an empty set', () => {
+    expect(resolveDefaultModels(['gpt54'])).toEqual([]);
+    expect(resolveDefaultModels(['grok4'])).toEqual([]);
+    expect(computeModelListVersion(['gpt54'])).not.toBe(
+      computeModelListVersion(['grok4']),
+    );
   });
 });


### PR DESCRIPTION
Closes #7191

Follow-up from #7179, which registry-derived 3 of the 5 hardcoded-default rows from #7081 but left `modelOptionsBasic.ts`'s `DEFAULT_MODELS` / `MODEL_LIST_VERSION` untouched.

## What changed

`llm-zoo`'s `ModelConfig` has no "featured"/"default" capability flag, so `DEFAULT_MODELS` keeps a curated preference table (`PREFERRED_DEFAULT_MODELS`, unchanged content) -- the same pattern `setupModelDefaults.ts` already uses for per-provider setup picks. What's new is that the table is no longer trusted blindly:

- `resolveDefaultModels()` filters the preference table against the live registry, dropping any pick the registry now marks retired instead of letting it dangle in the exported `DEFAULT_MODELS` list forever.
- `computeModelListVersion()` replaces the hand-bumped `MODEL_LIST_VERSION = 21` integer with a hash of the resolved default set, so a registry change that alters what resolves -- a pick retiring and dropping out, or a maintainer editing the preference table -- bumps the reconciliation trigger automatically. The hash is offset above the historical 1-21 hand-bumped range so every existing install still reconciles exactly once on upgrading past this change, and `modelListRefresh.ts`'s frozen one-time migration gates (`< 13`, `< 16`, `< 21`) are untouched.

## Tests

Added regression coverage to `ModelOptionsBasic.vitest.ts`, mirroring `SetupModelDefaults.vitest.ts`'s approach of exercising the mechanism against real registry data rather than only asserting today's snapshot:

- `resolveDefaultModels` drops a real currently-retired model (`grok4`, same fixture `SetupModelDefaults.vitest.ts` uses for its #7081 regression) and keeps live picks.
- `computeModelListVersion` changes when the resolved set gains or loses a model, is order-independent, and is verified wired to the exported `MODEL_LIST_VERSION`, which is asserted to land clear of the legacy 1-21 range.

Also includes an incidental `npm run format` drift-fix to `docs/proposals/texra-bench-science-benchmarks.md` (table padding / emphasis style) -- unrelated to this change, forced by the repo-wide pre-commit formatting hook on every commit.

## Verification

- `npm run typecheck` -- clean
- `npx eslint` on touched files -- clean
- `npx vitest run src/test-kernel` -- full suite green (595 passed, 1 pre-existing skip)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persisted enabled-models reconciliation and version triggers on every launch when the registry or preference table shifts; incorrect hashing or sweep logic could drop or retain wrong models for existing users.
> 
> **Overview**
> **Default model lists and reconciliation versioning now follow the live `llm-zoo` registry** instead of a static `DEFAULT_MODELS` array and hand-bumped `MODEL_LIST_VERSION`.
> 
> Curated picks move to `PREFERRED_DEFAULT_MODELS`; `resolveDefaultModels()` exports `DEFAULT_MODELS` with retired/deprecated entries removed. `MODEL_LIST_VERSION` is an FNV-1a hash of each preferred id plus its registry status (offset above 1000 so upgrades from legacy versions 1–21 still reconcile once). Hashing **status**, not only the filtered set, so a pick going deprecated → retired still bumps the version and triggers cleanup.
> 
> In `reconcileEnabledModels`, the **retired-model strip runs on every reconciliation** (not only when `previousVersion < 21`), fixing a case where hash-based versions never re-fired that sweep. Adding defaults no longer re-checks deprecated/retired because `DEFAULT_MODELS` is already resolved.
> 
> New/expanded tests cover resolution, version hashing, and stripping `grok4` when `previousVersion` is already hash-derived. Incidental markdown table formatting in `docs/proposals/texra-bench-science-benchmarks.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa4292eaae2d7713510663679b4e1155dacff05c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->