### PR TITLE
refactor(latex): remove dead latexdiff-vc-multiple path + two micro-cleanups

### DIFF
--- a/docs/proposals/texra-bench-science-benchmarks.md
+++ b/docs/proposals/texra-bench-science-benchmarks.md
@@ -99,10 +99,10 @@ The verifier library is therefore **data, not harness code**: a standard grader 
 
 | `std/` grader (command) | Wraps                                                                                                                                                                                                                                                           |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `std/compile-check`     | `compileCheck.ts` / `latexToolchain.ts` invoked directly, independent of the interactive `WORKFLOW_AUTO_COMPILE` setting — a required gate can't depend on a user preference — the hard gate |
+| `std/compile-check`     | `compileCheck.ts` / `latexToolchain.ts` invoked directly, independent of the interactive `WORKFLOW_AUTO_COMPILE` setting — a required gate can't depend on a user preference — the hard gate                                                                    |
 | `std/cas-equal`         | `wolframscript` (or SymPy) executing a **fixed** `refs/` assertion script against the extracted `\benchresult{...}` — outcome-level, targeting renotation-robustness (how far that can be pushed is open — §15), no credit for matching a human derivation path |
 | `std/lean-build`        | `lake build` against a pinned mathlib toolchain; binary per lemma. Proof tasks need only a statement — difficulty can outgrow the task's author (§6 validate exempts this stack from the gold-`refs/solution` check, since it has no reference answer to score) |
-| `std/diff-align`        | the math-aware latexdiff service — **error-injection tasks only**: edits inside injected spans must match gold, edits outside are penalized; not applicable to derivation/proof tasks, which have no injected spans |
+| `std/diff-align`        | the math-aware latexdiff service — **error-injection tasks only**: edits inside injected spans must match gold, edits outside are penalized; not applicable to derivation/proof tasks, which have no injected spans                                             |
 | `std/issue-match`       | `ReviewIssue` matching against gold defects within a line window → precision/recall                                                                                                                                                                             |
 | `std/answer-match`      | numeric-tolerance / exact / set matching on parsed answer blocks                                                                                                                                                                                                |
 
@@ -138,7 +138,7 @@ bench-results/<suite@version>/<runId>/<model>/<task>/trial-<n>/
                     # to that machinery, not built yet)
 ```
 
-- **Comparability rule:** two scores are comparable iff their *task*, *grader-pack*, and *environment* digests match; the subject dimension (model id and/or agent digest) is exactly what `--compare` varies, so it's excluded from the match. `bench report` refuses comparisons that differ on any of the fixed digests.
+- **Comparability rule:** two scores are comparable iff their _task_, _grader-pack_, and _environment_ digests match; the subject dimension (model id and/or agent digest) is exactly what `--compare` varies, so it's excluded from the match. `bench report` refuses comparisons that differ on any of the fixed digests.
 - **Regrade, don't rerun:** graders never mutate these directories, only read them; `bench grade --regrade --diff-against <old>` (a suite version, e.g. `1.1`, resolved under `--results-dir` to that version's evidence directory) recomputes history at zero model cost and attributes every delta to the grader diff.
 - **Hermetic execution:** a published container image pins TeX Live / Lean / wolframscript; `env.json` records the fingerprint; network off by default at the container level (not just tool-level filtering — a solver with shell access could otherwise reach the network via `curl`/package managers even with web tools disabled), with web tools additionally disabled in-agent via the existing `runtimeUnavailableTools` mechanism (`src/agent/runtime/RunContext.ts`) as defense in depth. No new sandbox layer beyond the container's own network policy.
 - **Determinism honesty:** providers offer no usable seeds; replicate variance is measured and reported, never pretended away.
@@ -192,18 +192,18 @@ Six subcommands. Exit codes reuse `packages/cli/src/runtime/exitCodes.ts`; score
 
 ## 11. Existing machinery it rides on
 
-| Bench component                   | Existing code                                                                                                                         |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Bench component                   | Existing code                                                                                                                                                                                                                       |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Cell execution                    | `packages/cli/src/runtime/runExecution.ts`; tool-use path via `packages/cli/src/commands/agentsRun.ts` (today stops after one model/tool cycle — `stopAfterCycle: true` — bench needs a multi-cycle variant, tracked as an MVP gap) |
-| Compile gate / diff / structure   | `src/agent/output/compileCheck.ts`, `src/latex/latexdiff/`, `src/latex/latexToolchain.ts`, `src/latex/labelSearch.ts`, `src/latex/extractBibliography.ts` |
-| CAS / Lean verifiers              | `src/tools/wolfram/wolframScriptUtils.ts`, `src/tools/lean/direct/lakeCommands.ts`, `src/tools/lean/LspTools.ts`, `src/tools/lean/LoogleTool.ts`          |
-| Issue localization                | `src/agent/review/reviewIssues.ts`; solver pattern from `packages/extension/resources/tool_use_agents/changeReviewer.yaml`            |
-| Fresh-task supply                 | `src/latex/arxivProcessor.ts`                                                                                                         |
-| Trace archive                     | `AgentTrace` subscriber (`src/agent/trace/AgentTrace.ts`, pattern: `src/transcript/TexraTranscriptRecorder.ts`); `AgentEvent` union    |
-| Usage / cost / abort              | `src/agent/core/usage/RunUsageAccumulator.ts` (`totalCost` drives `--max-cost-usd`, checked between dispatches — a soft budget guard under concurrency, not a per-cell reservation) |
-| Providers incl. internal gateways | `src/agent/modelHandlers/` (four stacks; `customBaseUrl` already threaded)                                                            |
-| Solver/judge agents               | ordinary agent YAML under `packages/extension/resources/agents/bench/`, run via `runAgent` (`src/agent/runtime/runAgent.ts`)          |
-| Env fingerprint                   | `texra doctor` machinery (`packages/cli/src/commands/doctor.ts`) — today probes Node/workspace/auth/LaTeX/config; Wolfram/lake/image-digest probes are new additions, not built yet |
+| Compile gate / diff / structure   | `src/agent/output/compileCheck.ts`, `src/latex/latexdiff/`, `src/latex/latexToolchain.ts`, `src/latex/labelSearch.ts`, `src/latex/extractBibliography.ts`                                                                           |
+| CAS / Lean verifiers              | `src/tools/wolfram/wolframScriptUtils.ts`, `src/tools/lean/direct/lakeCommands.ts`, `src/tools/lean/LspTools.ts`, `src/tools/lean/LoogleTool.ts`                                                                                    |
+| Issue localization                | `src/agent/review/reviewIssues.ts`; solver pattern from `packages/extension/resources/tool_use_agents/changeReviewer.yaml`                                                                                                          |
+| Fresh-task supply                 | `src/latex/arxivProcessor.ts`                                                                                                                                                                                                       |
+| Trace archive                     | `AgentTrace` subscriber (`src/agent/trace/AgentTrace.ts`, pattern: `src/transcript/TexraTranscriptRecorder.ts`); `AgentEvent` union                                                                                                 |
+| Usage / cost / abort              | `src/agent/core/usage/RunUsageAccumulator.ts` (`totalCost` drives `--max-cost-usd`, checked between dispatches — a soft budget guard under concurrency, not a per-cell reservation)                                                 |
+| Providers incl. internal gateways | `src/agent/modelHandlers/` (four stacks; `customBaseUrl` already threaded)                                                                                                                                                          |
+| Solver/judge agents               | ordinary agent YAML under `packages/extension/resources/agents/bench/`, run via `runAgent` (`src/agent/runtime/runAgent.ts`)                                                                                                        |
+| Env fingerprint                   | `texra doctor` machinery (`packages/cli/src/commands/doctor.ts`) — today probes Node/workspace/auth/LaTeX/config; Wolfram/lake/image-digest probes are new additions, not built yet                                                 |
 
 All additive: new code lives in `src/bench/` (VS Code-free zone, host services via `platform()`) and `packages/cli/`. **The MVP requires zero changes to `src/agent/` core.**
 

--- a/src/latex/TikzPictureManager.ts
+++ b/src/latex/TikzPictureManager.ts
@@ -170,13 +170,11 @@ class TikzPictureManager {
     const compiledFiles: FileLocation[] = [];
 
     for (const [label, tikzpicturess] of labeledTikzPictures) {
-      const suffixes =
-        tikzpicturess.length > 1
-          ? tikzpicturess.map((_, i) => String.fromCharCode(97 + i))
-          : [undefined];
+      const hasMultiple = tikzpicturess.length > 1;
 
       for (const [i, tikzpictures] of tikzpicturess.entries()) {
-        const suffix = suffixes[i];
+        // Disambiguate multiple pictures under one label with a/b/c… suffixes.
+        const suffix = hasMultiple ? String.fromCharCode(97 + i) : undefined;
 
         const texLocation = await this.createStandalone(
           tikzpictures,

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -9,7 +9,6 @@ import type { FileLocation } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { flexibleFS, pathToLocation } from '@utils/files';
 import { executeCommand } from '@utils/system';
-import { toErrorMessage } from '@utils/errors/errorMessage';
 import { readPlatformSetting } from '@utils/config/platformSettings';
 import { runLatexFormatter } from './texFormatter';
 import { generateDiffFileName } from './latexdiff/diffFileNameManager';
@@ -27,18 +26,6 @@ export const LaTeXdiffResultSchema = z.object({
   message: z.string().optional(),
 });
 export type LaTeXdiffResult = z.infer<typeof LaTeXdiffResultSchema>;
-
-export const LaTeXdiffMultipleResultSchema = z.object({
-  success: z.boolean(),
-  results: z.object({
-    success: z.array(z.string()),
-    failed: z.array(z.string()),
-  }),
-  message: z.string().optional(),
-});
-export type LaTeXdiffMultipleResult = z.infer<
-  typeof LaTeXdiffMultipleResultSchema
->;
 
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);
@@ -229,73 +216,6 @@ export class LaTeXdiffService {
       };
     } catch (err) {
       return this.logDiffError('Error running LaTeX diff VC', err);
-    }
-  }
-
-  async runDiffVcMultiple(
-    inputLocations: FileLocation[],
-    commitHash: string,
-    mathMarkup?: MathMarkupOption,
-  ): Promise<LaTeXdiffMultipleResult> {
-    try {
-      if (inputLocations.length === 0) {
-        const message = 'No input files provided';
-        logger.warn(this.channel, message);
-        return {
-          success: false,
-          results: { success: [], failed: [] },
-          message,
-        };
-      }
-
-      const results = { success: [] as string[], failed: [] as string[] };
-
-      for (const inputLocation of inputLocations) {
-        const inputFile = inputLocation.absolutePath;
-        try {
-          const result = await this.runDiffVc(
-            inputLocation,
-            commitHash,
-            mathMarkup,
-          );
-          if (result.success) {
-            results.success.push(inputFile);
-          } else {
-            results.failed.push(inputFile);
-          }
-        } catch (err) {
-          logger.error(
-            this.channel,
-            `Error processing ${inputFile}: ${toErrorMessage(err)}`,
-          );
-          results.failed.push(inputFile);
-        }
-      }
-
-      const summaryParts = ['LaTeX diff operations completed:'];
-      if (results.success.length > 0) {
-        summaryParts.push(`Successful:\n${results.success.join('\n')}`);
-      }
-      if (results.failed.length > 0) {
-        summaryParts.push(`Failed:\n${results.failed.join('\n')}`);
-      }
-      const summary = summaryParts.join('\n');
-
-      logger.info(this.channel, summary);
-
-      return {
-        success: results.failed.length === 0,
-        results,
-        message: summary,
-      };
-    } catch (err) {
-      const message = formatError('Error in runDiffVcMultiple', err);
-      logger.error(this.channel, message);
-      return {
-        success: false,
-        results: { success: [], failed: [] },
-        message,
-      };
     }
   }
 

--- a/src/latex/latexdiff/diffFileNameManager.ts
+++ b/src/latex/latexdiff/diffFileNameManager.ts
@@ -70,6 +70,19 @@ export function generateDiffFileName(
 }
 
 /**
+ * Ordered from most specific to least so the VC/between-round hashes are
+ * recognized before the bare `_diff` suffix that they also end with.
+ */
+const GENERATED_LATEXDIFF_ARTIFACT_PATTERNS: {
+  kind: GeneratedLatexdiffArtifactKind;
+  regex: RegExp;
+}[] = [
+  { kind: 'versionControlDiff', regex: /^(.+)-diff[0-9a-f]{6,40}$/i },
+  { kind: 'betweenRoundDiff', regex: /^(.+)_diffr\d+r\d+$/i },
+  { kind: 'workspaceDiff', regex: /^(.+)_diff$/i },
+];
+
+/**
  * Recognize filenames TeXRA/latexdiff generates so source-editing commands can
  * avoid treating diff artifacts as editable paper sources.
  */
@@ -79,16 +92,7 @@ export function detectGeneratedLatexdiffArtifact(
   const parsed = path.parse(filePath);
   if (parsed.ext.toLowerCase() !== '.tex') return null;
 
-  const patterns: {
-    kind: GeneratedLatexdiffArtifactKind;
-    regex: RegExp;
-  }[] = [
-    { kind: 'versionControlDiff', regex: /^(.+)-diff[0-9a-f]{6,40}$/i },
-    { kind: 'betweenRoundDiff', regex: /^(.+)_diffr\d+r\d+$/i },
-    { kind: 'workspaceDiff', regex: /^(.+)_diff$/i },
-  ];
-
-  for (const pattern of patterns) {
+  for (const pattern of GENERATED_LATEXDIFF_ARTIFACT_PATTERNS) {
     const match = pattern.regex.exec(parsed.name);
     const sourceStem = match?.[1];
     if (!sourceStem) continue;


### PR DESCRIPTION
## Summary

A code-simplification pass over `src/latex/` (host-agnostic LaTeX processing: formatting, diff, TikZ, PDF, arXiv). This directory turned out to be **already very clean** from prior refactor work, so the real, verifiable win here is one dead-code removal plus two small clarity fixes. No behavior change.

## What changed

**1. Dead-code removal — `LaTeXdiffService.runDiffVcMultiple` (`src/latex/latexdiff.ts`)**
- The method had **no callers anywhere in the repo** (a repo-wide grep across `.ts/.tsx/.js/.mjs`, including tests, desktop, and CLI, found only its own definition and its own error-message string).
- It was the **sole consumer** of `LaTeXdiffMultipleResult` / `LaTeXdiffMultipleResultSchema` and of this file's `toErrorMessage` import, so those went too.
- Net: ~80 lines of unreachable code removed. (`runDiffVc`, the single-file VC path, is still live and untouched.)
- Methods applied from the sweep list: **dead-code removal**, **schema/type dedup cleanup** (the now-orphaned schema).

**2. `TikzPictureManager.compile` (`src/latex/TikzPictureManager.ts`)**
- Derive the `a/b/c…` disambiguation suffix inline from the loop index (`hasMultiple ? String.fromCharCode(97 + i) : undefined`) instead of pre-building a parallel `suffixes` array purely to index back into it.
- Methods applied: **declarative/simplification**, removing an intermediate data structure.

**3. `detectGeneratedLatexdiffArtifact` (`src/latex/latexdiff/diffFileNameManager.ts`)**
- Hoisted the three-entry generated-artifact regex table to a module-level constant, matching the module-scope regex-table convention already used across this directory (`latexParsingUtils.ts`, `diffFileProcessor.ts`, etc.). Avoids rebuilding three regexes on every call.
- Methods applied: **consolidate constants/tables**, hoist invariant.

## Verification
- `tsc --noEmit` (root) — clean
- `eslint` on the 3 changed files — clean
- `prettier --check` on the 3 changed files — clean
- `vitest run src/test-kernel/latex src/test-kernel/tools/latex TexcountTool ArxivDownloadTool` — **77 tests pass**

## Scope / what's left for a future pass

`src/latex/` is already well-refactored (module-scope regex tables, shared `latexParsingUtils` helpers, host-neutral ports, Zod-derived types per the schema-SSOT convention), so this PR is deliberately small rather than forced. Candidates deliberately **not** taken here (would be churn or need a design discussion, not mechanical simplification):

- **Between-round diff pairing duplication** in `latexdiff/diffOperations.ts` (`runLatexdiffFromMetadata` vs `runLatexdiffViaWorkspaceScan`) — structurally similar consecutive-pair loops, but they operate on different data shapes (`OutputFileInfo` with pre-built `FileLocation`s vs a `Map<round,string>` needing `toAbsolute`/`pathToLocation`). A shared `consecutivePairs` helper would be LoC-neutral and add indirection, so it was left alone.
- **Legacy/mid-era workspace-scan layouts** in `diffOperations.ts` / `outputDiscovery.ts` are intentionally retained backward-compat for existing user workspaces (documented in-code), not obsolete cruft — not removed.
- The result/option **Zod schemas** in `texcount.ts` and `latexdiff.ts` (`LaTeXdiffResultSchema`, `Texcount*Schema`) are never `.parse()`d and exist only to derive types, but the repo's active schema-SSOT convention wants schema→`z.infer`, so they were left as-is.
- Repeated `baseDir` resolution + figure-path normalization between `LatexMediaManager.extractFiguresFromFiles` and `mirrorFigureDependencies` — a real but subtle double-resolve; refactoring safely would touch a method called from multiple sites, so deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nbVZZcHVNLBNZ2tESvR7v

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal and refactors with no intended behavior change; live `runDiffVc` and artifact detection callers remain.
> 
> **Overview**
> Removes **~80 lines of unreachable LaTeXdiff code**: `LaTeXdiffService.runDiffVcMultiple`, its `LaTeXdiffMultipleResult` / Zod schema, and the file’s unused `toErrorMessage` import. The single-file **`runDiffVc`** path is unchanged.
> 
> **`TikzPictureManager.compile`** derives `a/b/c…` disambiguation suffixes inline from the loop index instead of building a parallel `suffixes` array.
> 
> **`detectGeneratedLatexdiffArtifact`** moves the three regex patterns to module-level `GENERATED_LATEXDIFF_ARTIFACT_PATTERNS` (with ordering documented) so they aren’t recreated on every call.
> 
> The **TeXRA Bench proposal** doc only gets markdown table alignment and italic emphasis tweaks—no design changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bfae497d26329ec21eee3283d279e54e0cf580a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->