### PR TITLE
fix: migrate legacy global-scope bash-approval override on activation

### DIFF
--- a/docs/proposals/texra-bench-science-benchmarks.md
+++ b/docs/proposals/texra-bench-science-benchmarks.md
@@ -99,10 +99,10 @@ The verifier library is therefore **data, not harness code**: a standard grader 
 
 | `std/` grader (command) | Wraps                                                                                                                                                                                                                                                           |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `std/compile-check`     | `compileCheck.ts` / `latexToolchain.ts` invoked directly, independent of the interactive `WORKFLOW_AUTO_COMPILE` setting — a required gate can't depend on a user preference — the hard gate |
+| `std/compile-check`     | `compileCheck.ts` / `latexToolchain.ts` invoked directly, independent of the interactive `WORKFLOW_AUTO_COMPILE` setting — a required gate can't depend on a user preference — the hard gate                                                                    |
 | `std/cas-equal`         | `wolframscript` (or SymPy) executing a **fixed** `refs/` assertion script against the extracted `\benchresult{...}` — outcome-level, targeting renotation-robustness (how far that can be pushed is open — §15), no credit for matching a human derivation path |
 | `std/lean-build`        | `lake build` against a pinned mathlib toolchain; binary per lemma. Proof tasks need only a statement — difficulty can outgrow the task's author (§6 validate exempts this stack from the gold-`refs/solution` check, since it has no reference answer to score) |
-| `std/diff-align`        | the math-aware latexdiff service — **error-injection tasks only**: edits inside injected spans must match gold, edits outside are penalized; not applicable to derivation/proof tasks, which have no injected spans |
+| `std/diff-align`        | the math-aware latexdiff service — **error-injection tasks only**: edits inside injected spans must match gold, edits outside are penalized; not applicable to derivation/proof tasks, which have no injected spans                                             |
 | `std/issue-match`       | `ReviewIssue` matching against gold defects within a line window → precision/recall                                                                                                                                                                             |
 | `std/answer-match`      | numeric-tolerance / exact / set matching on parsed answer blocks                                                                                                                                                                                                |
 
@@ -138,7 +138,7 @@ bench-results/<suite@version>/<runId>/<model>/<task>/trial-<n>/
                     # to that machinery, not built yet)
 ```
 
-- **Comparability rule:** two scores are comparable iff their *task*, *grader-pack*, and *environment* digests match; the subject dimension (model id and/or agent digest) is exactly what `--compare` varies, so it's excluded from the match. `bench report` refuses comparisons that differ on any of the fixed digests.
+- **Comparability rule:** two scores are comparable iff their _task_, _grader-pack_, and _environment_ digests match; the subject dimension (model id and/or agent digest) is exactly what `--compare` varies, so it's excluded from the match. `bench report` refuses comparisons that differ on any of the fixed digests.
 - **Regrade, don't rerun:** graders never mutate these directories, only read them; `bench grade --regrade --diff-against <old>` (a suite version, e.g. `1.1`, resolved under `--results-dir` to that version's evidence directory) recomputes history at zero model cost and attributes every delta to the grader diff.
 - **Hermetic execution:** a published container image pins TeX Live / Lean / wolframscript; `env.json` records the fingerprint; network off by default at the container level (not just tool-level filtering — a solver with shell access could otherwise reach the network via `curl`/package managers even with web tools disabled), with web tools additionally disabled in-agent via the existing `runtimeUnavailableTools` mechanism (`src/agent/runtime/RunContext.ts`) as defense in depth. No new sandbox layer beyond the container's own network policy.
 - **Determinism honesty:** providers offer no usable seeds; replicate variance is measured and reported, never pretended away.
@@ -192,18 +192,18 @@ Six subcommands. Exit codes reuse `packages/cli/src/runtime/exitCodes.ts`; score
 
 ## 11. Existing machinery it rides on
 
-| Bench component                   | Existing code                                                                                                                         |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Bench component                   | Existing code                                                                                                                                                                                                                       |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Cell execution                    | `packages/cli/src/runtime/runExecution.ts`; tool-use path via `packages/cli/src/commands/agentsRun.ts` (today stops after one model/tool cycle — `stopAfterCycle: true` — bench needs a multi-cycle variant, tracked as an MVP gap) |
-| Compile gate / diff / structure   | `src/agent/output/compileCheck.ts`, `src/latex/latexdiff/`, `src/latex/latexToolchain.ts`, `src/latex/labelSearch.ts`, `src/latex/extractBibliography.ts` |
-| CAS / Lean verifiers              | `src/tools/wolfram/wolframScriptUtils.ts`, `src/tools/lean/direct/lakeCommands.ts`, `src/tools/lean/LspTools.ts`, `src/tools/lean/LoogleTool.ts`          |
-| Issue localization                | `src/agent/review/reviewIssues.ts`; solver pattern from `packages/extension/resources/tool_use_agents/changeReviewer.yaml`            |
-| Fresh-task supply                 | `src/latex/arxivProcessor.ts`                                                                                                         |
-| Trace archive                     | `AgentTrace` subscriber (`src/agent/trace/AgentTrace.ts`, pattern: `src/transcript/TexraTranscriptRecorder.ts`); `AgentEvent` union    |
-| Usage / cost / abort              | `src/agent/core/usage/RunUsageAccumulator.ts` (`totalCost` drives `--max-cost-usd`, checked between dispatches — a soft budget guard under concurrency, not a per-cell reservation) |
-| Providers incl. internal gateways | `src/agent/modelHandlers/` (four stacks; `customBaseUrl` already threaded)                                                            |
-| Solver/judge agents               | ordinary agent YAML under `packages/extension/resources/agents/bench/`, run via `runAgent` (`src/agent/runtime/runAgent.ts`)          |
-| Env fingerprint                   | `texra doctor` machinery (`packages/cli/src/commands/doctor.ts`) — today probes Node/workspace/auth/LaTeX/config; Wolfram/lake/image-digest probes are new additions, not built yet |
+| Compile gate / diff / structure   | `src/agent/output/compileCheck.ts`, `src/latex/latexdiff/`, `src/latex/latexToolchain.ts`, `src/latex/labelSearch.ts`, `src/latex/extractBibliography.ts`                                                                           |
+| CAS / Lean verifiers              | `src/tools/wolfram/wolframScriptUtils.ts`, `src/tools/lean/direct/lakeCommands.ts`, `src/tools/lean/LspTools.ts`, `src/tools/lean/LoogleTool.ts`                                                                                    |
+| Issue localization                | `src/agent/review/reviewIssues.ts`; solver pattern from `packages/extension/resources/tool_use_agents/changeReviewer.yaml`                                                                                                          |
+| Fresh-task supply                 | `src/latex/arxivProcessor.ts`                                                                                                                                                                                                       |
+| Trace archive                     | `AgentTrace` subscriber (`src/agent/trace/AgentTrace.ts`, pattern: `src/transcript/TexraTranscriptRecorder.ts`); `AgentEvent` union                                                                                                 |
+| Usage / cost / abort              | `src/agent/core/usage/RunUsageAccumulator.ts` (`totalCost` drives `--max-cost-usd`, checked between dispatches — a soft budget guard under concurrency, not a per-cell reservation)                                                 |
+| Providers incl. internal gateways | `src/agent/modelHandlers/` (four stacks; `customBaseUrl` already threaded)                                                                                                                                                          |
+| Solver/judge agents               | ordinary agent YAML under `packages/extension/resources/agents/bench/`, run via `runAgent` (`src/agent/runtime/runAgent.ts`)                                                                                                        |
+| Env fingerprint                   | `texra doctor` machinery (`packages/cli/src/commands/doctor.ts`) — today probes Node/workspace/auth/LaTeX/config; Wolfram/lake/image-digest probes are new additions, not built yet                                                 |
 
 All additive: new code lives in `src/bench/` (VS Code-free zone, host services via `platform()`) and `packages/cli/`. **The MVP requires zero changes to `src/agent/` core.**
 

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -101,6 +101,7 @@ import {
   type StreamLifecycleStatus,
   type TokenUsageStats,
 } from '@shared/schemas';
+import { migrateLegacyGlobalBashApprovalOverride } from '@shared/settingsView/handlers/approvalHandlers';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { setOpenPdfOpener } from '@tools/OpenPdfTool';
 import { refreshToolAvailability } from '@tools/toolAvailability';
@@ -354,6 +355,14 @@ export async function activate(context: vscode.ExtensionContext) {
     // config to TeXRA workspace storage. Safe to run on every activation —
     // a key already in workspaceSM is left untouched.
     migrateLatexConfigToStorage(),
+    // One-shot per-workspace migration of a legacy global-scope bash-approval
+    // override left over from before #7148 unified the write scope to
+    // workspace (issue #7169). Safe to run on every activation — the
+    // workspace-scoped marker makes it a no-op after the first run.
+    migrateLegacyGlobalBashApprovalOverride({
+      workspaceState: workspaceSM,
+      config: platform().config,
+    }),
     (async () => {
       await copyDefaultAgents(context);
       await registerAgentDirectoryRoots(context);

--- a/src/shared/settingsView/handlers/approvalHandlers.ts
+++ b/src/shared/settingsView/handlers/approvalHandlers.ts
@@ -124,8 +124,15 @@ export async function setBashApprovalEnabled(
  *
  * Gated by a per-workspace marker so it runs at most once per workspace,
  * and never overwrites a workspace that already has its own explicit
- * override (e.g. set via the post-#7148 UI) -- this only ever acts on a
- * value the user never got a chance to set at the new, correct scope.
+ * override at either the `workspace` or resource-scoped `workspaceFolder`
+ * level (`texra.toolUse.requireBashApproval` is declared `resource`-scoped,
+ * so post-#7148 UI writes commonly land as `workspaceFolderValue`) -- this
+ * only ever acts on a value the user never got a chance to set at the new,
+ * correct scope. The one-shot marker is only ever set once the legacy
+ * global value has been dealt with for real: either there was none to begin
+ * with, or clearing it actually succeeded. If the clear throws, the marker
+ * is left unset so a later activation gets another chance to retry it,
+ * rather than permanently stranding the stale global bypass.
  */
 export async function migrateLegacyGlobalBashApprovalOverride(
   ports: Pick<ApprovalHandlerPorts, 'workspaceState' | 'config'>,
@@ -149,7 +156,17 @@ export async function migrateLegacyGlobalBashApprovalOverride(
   const legacyGlobalValue = inspection?.globalValue;
 
   if (legacyGlobalValue !== undefined) {
-    if (inspection?.workspaceValue === undefined) {
+    // `texra.toolUse.requireBashApproval` is `resource`-scoped, so an
+    // existing explicit override for this workspace can land in either
+    // `workspaceValue` (the pre-#7148 write path) or `workspaceFolderValue`
+    // (post-#7148 UI writes, which target the open folder). Treat either as
+    // "this workspace already made its own choice" and never overwrite it
+    // with the legacy global value.
+    const hasExplicitWorkspaceOverride =
+      inspection?.workspaceValue !== undefined ||
+      inspection?.workspaceFolderValue !== undefined;
+
+    if (!hasExplicitWorkspaceOverride) {
       try {
         await config.update(
           BASH_APPROVAL_CONFIG_KEY,
@@ -177,10 +194,16 @@ export async function migrateLegacyGlobalBashApprovalOverride(
     try {
       await config.update(BASH_APPROVAL_CONFIG_KEY, undefined, 'global');
     } catch (err) {
+      // Clearing the stale global value failed -- leave the one-shot marker
+      // unset so a later activation retries the clear instead of
+      // permanently giving up on it. Otherwise the uncleared global `false`
+      // would keep silently bypassing approval for every other,
+      // not-yet-migrated workspace with no way to ever fix it.
       logger.warn(
         CHANNEL,
         `Failed to clear legacy global ${BASH_APPROVAL_CONFIG_KEY} override: ${toErrorMessage(err)}`,
       );
+      return;
     }
   }
 

--- a/src/shared/settingsView/handlers/approvalHandlers.ts
+++ b/src/shared/settingsView/handlers/approvalHandlers.ts
@@ -6,6 +6,7 @@
  * state shape — the only host-specific dependency is the bash-approval flag,
  * which lives in `ConfigProvider` rather than workspace state.
  */
+import * as logger from '@logger/logUtils';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc/settingsViewCommands';
 import type { UpdateApprovalSettingsMessage } from '@shared/schemas/settingsViewMessages';
@@ -25,7 +26,10 @@ import {
   parseCodexSandboxMode,
 } from '@shared/schemas/agentCliSettings';
 import type { SettingsStatePorts } from '@shared/settingsView/types';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 import type { ConfigProvider, ConfigTarget } from '@platform/interfaces/config';
+
+const CHANNEL = 'approvalHandlers';
 
 export interface ApprovalHandlerPorts extends SettingsStatePorts {
   readonly config: ConfigProvider;
@@ -93,6 +97,104 @@ export async function setBashApprovalEnabled(
   target: ConfigTarget,
 ): Promise<void> {
   await ports.config.update(BASH_APPROVAL_CONFIG_KEY, enabled, target);
+}
+
+/**
+ * One-shot per-workspace migration for the legacy global-scope bash-approval
+ * override (issue #7169, follow-up to #7148 / #7085).
+ *
+ * Before #7148, the extension host wrote `BASH_APPROVAL_CONFIG_KEY` to the
+ * *global* config target. `ConfigProvider.get` resolves workspace -> global,
+ * so a user who disabled bash approval before that fix still has a global
+ * `false` silently bypassing approval in every workspace with no
+ * workspace-level override -- with no visible signal that a stale global
+ * override is still in effect for a security-adjacent setting.
+ *
+ * This copies a pre-existing legacy global override into the *current*
+ * workspace's config (mirroring `migrateLatexConfigToStorage`'s one-shot
+ * pattern) so the effective value is preserved and now shows up in the
+ * Settings UI as an explicit, correctable workspace-level toggle, then
+ * clears the global value so it stops silently governing every other
+ * workspace. Because the legacy value was a single global scalar, only the
+ * first workspace to run this migration after upgrading inherits it; any
+ * workspace opened afterward falls back to the safe default (approval
+ * enabled) rather than continuing to silently inherit a stale bypass --
+ * the deliberate trade-off for a security-adjacent setting that can't be
+ * losslessly fanned out to every workspace that might have relied on it.
+ *
+ * Gated by a per-workspace marker so it runs at most once per workspace,
+ * and never overwrites a workspace that already has its own explicit
+ * override (e.g. set via the post-#7148 UI) -- this only ever acts on a
+ * value the user never got a chance to set at the new, correct scope.
+ */
+export async function migrateLegacyGlobalBashApprovalOverride(
+  ports: Pick<ApprovalHandlerPorts, 'workspaceState' | 'config'>,
+): Promise<void> {
+  const { workspaceState, config } = ports;
+
+  // One-shot gate, same rationale as LATEX_SETTINGS_MIGRATED: once this
+  // workspace has been migrated, never run again, so a user who later
+  // re-enables the global setting for some other reason doesn't get it
+  // silently re-imported and re-cleared here.
+  if (
+    workspaceState.get<boolean>(
+      WorkspaceStateKey.BASH_APPROVAL_GLOBAL_MIGRATED,
+      false,
+    )
+  ) {
+    return;
+  }
+
+  const inspection = config.inspect<boolean>(BASH_APPROVAL_CONFIG_KEY);
+  const legacyGlobalValue = inspection?.globalValue;
+
+  if (legacyGlobalValue !== undefined) {
+    if (inspection?.workspaceValue === undefined) {
+      try {
+        await config.update(
+          BASH_APPROVAL_CONFIG_KEY,
+          legacyGlobalValue,
+          BASH_APPROVAL_CONFIG_TARGET,
+        );
+        logger.info(
+          CHANNEL,
+          `Migrated legacy global ${BASH_APPROVAL_CONFIG_KEY} override (${String(legacyGlobalValue)}) to workspace scope`,
+        );
+      } catch (err) {
+        // Can't safely persist to workspace scope right now (e.g. no
+        // workspace folder open yet -- VS Code throws on a Workspace-target
+        // write with none open). Leave the global override and the marker
+        // untouched so a later activation gets another chance to migrate it
+        // instead of silently dropping it here.
+        logger.warn(
+          CHANNEL,
+          `Deferring legacy global bash-approval migration: ${toErrorMessage(err)}`,
+        );
+        return;
+      }
+    }
+
+    try {
+      await config.update(BASH_APPROVAL_CONFIG_KEY, undefined, 'global');
+    } catch (err) {
+      logger.warn(
+        CHANNEL,
+        `Failed to clear legacy global ${BASH_APPROVAL_CONFIG_KEY} override: ${toErrorMessage(err)}`,
+      );
+    }
+  }
+
+  try {
+    await workspaceState.update(
+      WorkspaceStateKey.BASH_APPROVAL_GLOBAL_MIGRATED,
+      true,
+    );
+  } catch (err) {
+    logger.warn(
+      CHANNEL,
+      `Failed to set BASH_APPROVAL_GLOBAL_MIGRATED marker: ${toErrorMessage(err)}`,
+    );
+  }
 }
 
 export async function setWorkspaceAgentSetting(

--- a/src/shared/state/stateKeys.ts
+++ b/src/shared/state/stateKeys.ts
@@ -64,6 +64,13 @@ export enum WorkspaceStateKey {
    * key absent) so reset-to-default isn't silently undone on next start.
    */
   LATEX_SETTINGS_MIGRATED = 'texra.latexSettingsMigrated',
+  /**
+   * One-shot per-workspace marker for the legacy global-scope bash-approval
+   * override migration. Set after
+   * `migrateLegacyGlobalBashApprovalOverride()` runs for this workspace;
+   * subsequent activations skip it. See issue #7169.
+   */
+  BASH_APPROVAL_GLOBAL_MIGRATED = 'texra.bashApprovalGlobalMigrated',
 }
 
 export enum GlobalStateKey {

--- a/src/test-kernel/settings/BashApprovalGlobalMigration.vitest.ts
+++ b/src/test-kernel/settings/BashApprovalGlobalMigration.vitest.ts
@@ -36,6 +36,7 @@ class MemoryStateStore implements StateStore {
  */
 class FakeConfigProvider implements ConfigProvider {
   private readonly workspaceValues = new Map<string, unknown>();
+  private readonly workspaceFolderValues = new Map<string, unknown>();
   private readonly globalValues = new Map<string, unknown>();
   readonly updateCalls: Array<{
     key: string;
@@ -43,7 +44,18 @@ class FakeConfigProvider implements ConfigProvider {
     target: ConfigTarget;
   }> = [];
 
+  /**
+   * When set, `update()` calls targeting this scope throw instead of
+   * applying -- simulates a persistence failure (e.g. VS Code rejecting the
+   * write) so tests can assert on partial-migration recovery behavior.
+   */
+  failUpdatesForTarget?: ConfigTarget;
+
   get<T>(key: string, defaultValue?: T): T {
+    // Mirrors VS Code's own resolution order: resource (folder) scope wins
+    // over workspace scope, which wins over global scope.
+    if (this.workspaceFolderValues.has(key))
+      return this.workspaceFolderValues.get(key) as T;
     if (this.workspaceValues.has(key))
       return this.workspaceValues.get(key) as T;
     if (this.globalValues.has(key)) return this.globalValues.get(key) as T;
@@ -55,6 +67,9 @@ class FakeConfigProvider implements ConfigProvider {
     value: T,
     target: ConfigTarget = 'workspace',
   ): Promise<void> {
+    if (target === this.failUpdatesForTarget) {
+      throw new Error(`simulated ${target}-scope update failure for ${key}`);
+    }
     this.updateCalls.push({ key, value, target });
     const store =
       target === 'global' ? this.globalValues : this.workspaceValues;
@@ -73,12 +88,19 @@ class FakeConfigProvider implements ConfigProvider {
       workspaceValue: this.workspaceValues.has(key)
         ? (this.workspaceValues.get(key) as T)
         : undefined,
+      workspaceFolderValue: this.workspaceFolderValues.has(key)
+        ? (this.workspaceFolderValues.get(key) as T)
+        : undefined,
       effectiveValue: this.get<T>(key),
     };
   }
 
   isExplicitlySet(key: string): boolean {
-    return this.workspaceValues.has(key) || this.globalValues.has(key);
+    return (
+      this.workspaceValues.has(key) ||
+      this.workspaceFolderValues.has(key) ||
+      this.globalValues.has(key)
+    );
   }
 
   watch(): { dispose(): void } {
@@ -88,6 +110,17 @@ class FakeConfigProvider implements ConfigProvider {
   /** Seeds a legacy global value directly, without going through `update()`. */
   seedGlobal(key: string, value: unknown): void {
     this.globalValues.set(key, value);
+  }
+
+  /**
+   * Seeds a resource-scoped `workspaceFolderValue` directly. Real writes
+   * to `'workspace'` target (`ConfigTarget` has no folder-scope option) land
+   * in `workspaceValue`, but `texra.toolUse.requireBashApproval` is declared
+   * `resource`-scoped, so post-#7148 UI writes commonly resolve as
+   * `workspaceFolderValue` instead -- this seeds that shape directly.
+   */
+  seedWorkspaceFolder(key: string, value: unknown): void {
+    this.workspaceFolderValues.set(key, value);
   }
 }
 
@@ -175,5 +208,69 @@ describe('migrateLegacyGlobalBashApprovalOverride', () => {
     const inspection = config.inspect<boolean>(BASH_APPROVAL_CONFIG_KEY);
     expect(inspection?.workspaceValue).toBe(true);
     expect(inspection?.globalValue).toBeUndefined();
+  });
+
+  it('respects a resource-scoped workspaceFolderValue override and does not overwrite it, but still clears the stale global value', async () => {
+    // `texra.toolUse.requireBashApproval` is declared `resource`-scoped, so
+    // post-#7148 UI writes commonly resolve as `workspaceFolderValue` rather
+    // than `workspaceValue` -- the migration must treat that the same as an
+    // explicit workspace override, not just copy the stale global `false`
+    // over the top of it (issue #7169 bugbot follow-up).
+    const config = new FakeConfigProvider();
+    config.seedGlobal(BASH_APPROVAL_CONFIG_KEY, false);
+    config.seedWorkspaceFolder(BASH_APPROVAL_CONFIG_KEY, true);
+    const workspaceState = new MemoryStateStore();
+
+    await migrateLegacyGlobalBashApprovalOverride({ workspaceState, config });
+
+    const inspection = config.inspect<boolean>(BASH_APPROVAL_CONFIG_KEY);
+    // The folder-level override is left untouched...
+    expect(inspection?.workspaceFolderValue).toBe(true);
+    expect(inspection?.workspaceValue).toBeUndefined();
+    // ...and no copy was made into workspace scope...
+    expect(
+      config.updateCalls.some(
+        (call) => call.target === BASH_APPROVAL_CONFIG_TARGET,
+      ),
+    ).toBe(false);
+    // ...but the stale global value is still cleared, since it no longer
+    // needs to govern anything.
+    expect(inspection?.globalValue).toBeUndefined();
+    expect(
+      workspaceState.get<boolean>(
+        WorkspaceStateKey.BASH_APPROVAL_GLOBAL_MIGRATED,
+        false,
+      ),
+    ).toBe(true);
+  });
+
+  it('leaves the one-shot marker unset when clearing the legacy global value fails, so a later activation retries the clear', async () => {
+    // If `config.update(..., 'global')` throws (e.g. a transient VS Code
+    // config-write failure), the marker must NOT be set -- otherwise this
+    // workspace's migration is treated as "done" forever, and the stale
+    // global `false` is left to silently keep bypassing approval in every
+    // other, not-yet-migrated workspace with no way to ever retry the clear
+    // (issue #7169 bugbot + claude-review follow-up).
+    const config = new FakeConfigProvider();
+    config.seedGlobal(BASH_APPROVAL_CONFIG_KEY, false);
+    config.failUpdatesForTarget = 'global';
+    const workspaceState = new MemoryStateStore();
+
+    await migrateLegacyGlobalBashApprovalOverride({ workspaceState, config });
+
+    const inspection = config.inspect<boolean>(BASH_APPROVAL_CONFIG_KEY);
+    // The workspace-scoped copy still succeeded (that update targets
+    // 'workspace', not 'global', so it isn't the one that fails here)...
+    expect(inspection?.workspaceValue).toBe(false);
+    // ...but the global value is still there because the clear failed...
+    expect(inspection?.globalValue).toBe(false);
+    // ...so the one-shot marker must stay unset, giving a later activation
+    // another chance to retry the clear.
+    expect(
+      workspaceState.get<boolean>(
+        WorkspaceStateKey.BASH_APPROVAL_GLOBAL_MIGRATED,
+        false,
+      ),
+    ).toBe(false);
   });
 });

--- a/src/test-kernel/settings/BashApprovalGlobalMigration.vitest.ts
+++ b/src/test-kernel/settings/BashApprovalGlobalMigration.vitest.ts
@@ -1,0 +1,179 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+import { BASH_APPROVAL_CONFIG_KEY } from '@shared/schemas/agentCliSettings';
+import {
+  BASH_APPROVAL_CONFIG_TARGET,
+  migrateLegacyGlobalBashApprovalOverride,
+} from '@shared/settingsView/handlers/approvalHandlers';
+import { WorkspaceStateKey } from '@shared/state/stateKeys';
+import type {
+  ConfigInspection,
+  ConfigProvider,
+  ConfigTarget,
+} from '@platform/interfaces/config';
+import type { StateStore } from '@platform/interfaces/state';
+
+class MemoryStateStore implements StateStore {
+  private readonly values = new Map<string, unknown>();
+
+  get<T>(key: string, defaultValue?: T): T {
+    return (this.values.has(key) ? this.values.get(key) : defaultValue) as T;
+  }
+
+  async update(key: string, value: unknown): Promise<void> {
+    this.values.set(key, value);
+  }
+}
+
+/**
+ * Minimal in-memory `ConfigProvider` with real workspace -> global fallback
+ * semantics, mirroring `VscodeConfigProvider`/`JsonConfigProvider`. Needed
+ * here (rather than the no-op `RecordingConfigProvider` used by
+ * `BashApprovalConfigTarget.vitest.ts`) because the migration reads
+ * `inspect()` to distinguish "no override anywhere" from "explicit
+ * workspace override" from "legacy global override only".
+ */
+class FakeConfigProvider implements ConfigProvider {
+  private readonly workspaceValues = new Map<string, unknown>();
+  private readonly globalValues = new Map<string, unknown>();
+  readonly updateCalls: Array<{
+    key: string;
+    value: unknown;
+    target: ConfigTarget;
+  }> = [];
+
+  get<T>(key: string, defaultValue?: T): T {
+    if (this.workspaceValues.has(key))
+      return this.workspaceValues.get(key) as T;
+    if (this.globalValues.has(key)) return this.globalValues.get(key) as T;
+    return defaultValue as T;
+  }
+
+  async update<T>(
+    key: string,
+    value: T,
+    target: ConfigTarget = 'workspace',
+  ): Promise<void> {
+    this.updateCalls.push({ key, value, target });
+    const store =
+      target === 'global' ? this.globalValues : this.workspaceValues;
+    if (value === undefined) {
+      store.delete(key);
+    } else {
+      store.set(key, value);
+    }
+  }
+
+  inspect<T = unknown>(key: string): ConfigInspection<T> | undefined {
+    return {
+      globalValue: this.globalValues.has(key)
+        ? (this.globalValues.get(key) as T)
+        : undefined,
+      workspaceValue: this.workspaceValues.has(key)
+        ? (this.workspaceValues.get(key) as T)
+        : undefined,
+      effectiveValue: this.get<T>(key),
+    };
+  }
+
+  isExplicitlySet(key: string): boolean {
+    return this.workspaceValues.has(key) || this.globalValues.has(key);
+  }
+
+  watch(): { dispose(): void } {
+    return { dispose: () => undefined };
+  }
+
+  /** Seeds a legacy global value directly, without going through `update()`. */
+  seedGlobal(key: string, value: unknown): void {
+    this.globalValues.set(key, value);
+  }
+}
+
+describe('migrateLegacyGlobalBashApprovalOverride', () => {
+  it('migrates a pre-existing legacy global override to workspace scope and clears it globally', async () => {
+    // Simulates a user who disabled bash approval before #7148, when the
+    // extension still wrote it to the global scope (issue #7085 / #7169).
+    const config = new FakeConfigProvider();
+    config.seedGlobal(BASH_APPROVAL_CONFIG_KEY, false);
+    const workspaceState = new MemoryStateStore();
+
+    await migrateLegacyGlobalBashApprovalOverride({ workspaceState, config });
+
+    const inspection = config.inspect<boolean>(BASH_APPROVAL_CONFIG_KEY);
+    // Effective behavior is preserved for this workspace...
+    expect(inspection?.workspaceValue).toBe(false);
+    expect(config.get<boolean>(BASH_APPROVAL_CONFIG_KEY, true)).toBe(false);
+    // ...but now as a visible, correctable workspace-scoped override rather
+    // than a silent global bypass, and the legacy global value is gone.
+    expect(inspection?.globalValue).toBeUndefined();
+    expect(
+      config.updateCalls.some(
+        (call) =>
+          call.key === BASH_APPROVAL_CONFIG_KEY &&
+          call.target === BASH_APPROVAL_CONFIG_TARGET &&
+          call.value === false,
+      ),
+    ).toBe(true);
+    // One-shot marker set so this workspace's migration never re-runs.
+    expect(
+      workspaceState.get<boolean>(
+        WorkspaceStateKey.BASH_APPROVAL_GLOBAL_MIGRATED,
+        false,
+      ),
+    ).toBe(true);
+  });
+
+  it('is a no-op when no legacy global override exists', async () => {
+    const config = new FakeConfigProvider();
+    const workspaceState = new MemoryStateStore();
+
+    await migrateLegacyGlobalBashApprovalOverride({ workspaceState, config });
+
+    expect(config.updateCalls).toHaveLength(0);
+    const inspection = config.inspect<boolean>(BASH_APPROVAL_CONFIG_KEY);
+    expect(inspection?.workspaceValue).toBeUndefined();
+    expect(inspection?.globalValue).toBeUndefined();
+    // Still marks the workspace as migrated, so a later manual edit of the
+    // (now cleared) global setting can't retroactively trigger a migration.
+    expect(
+      workspaceState.get<boolean>(
+        WorkspaceStateKey.BASH_APPROVAL_GLOBAL_MIGRATED,
+        false,
+      ),
+    ).toBe(true);
+  });
+
+  it('never re-runs once the per-workspace marker is already set', async () => {
+    const config = new FakeConfigProvider();
+    config.seedGlobal(BASH_APPROVAL_CONFIG_KEY, false);
+    const workspaceState = new MemoryStateStore();
+    await workspaceState.update(
+      WorkspaceStateKey.BASH_APPROVAL_GLOBAL_MIGRATED,
+      true,
+    );
+
+    await migrateLegacyGlobalBashApprovalOverride({ workspaceState, config });
+
+    expect(config.updateCalls).toHaveLength(0);
+    expect(config.inspect<boolean>(BASH_APPROVAL_CONFIG_KEY)?.globalValue).toBe(
+      false,
+    );
+  });
+
+  it("does not overwrite a workspace's own explicit override, but still clears the stale global value", async () => {
+    const config = new FakeConfigProvider();
+    config.seedGlobal(BASH_APPROVAL_CONFIG_KEY, false);
+    // This workspace already has its own explicit value -- e.g. set via the
+    // post-#7148 settings UI in an earlier session.
+    await config.update(BASH_APPROVAL_CONFIG_KEY, true, 'workspace');
+    const workspaceState = new MemoryStateStore();
+
+    await migrateLegacyGlobalBashApprovalOverride({ workspaceState, config });
+
+    const inspection = config.inspect<boolean>(BASH_APPROVAL_CONFIG_KEY);
+    expect(inspection?.workspaceValue).toBe(true);
+    expect(inspection?.globalValue).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #7169

Follow-up to #7148 / #7085: that PR fixed the *write* side (both hosts now write `texra.toolUse.requireBashApproval` to the workspace config scope), but left the *read* side unaddressed for users who already had a value from before the fix. `ConfigProvider.get` resolves workspace -> global, so a user who disabled bash approval before #7148 still has a global `false` silently bypassing approval in every workspace with no workspace-level override -- a security-adjacent bypass with no visible signal in the UI.

## What changed

Added `migrateLegacyGlobalBashApprovalOverride` (`src/shared/settingsView/handlers/approvalHandlers.ts`), a one-shot per-workspace migration mirroring `migrateLatexConfigToStorage`'s pattern, wired into the extension's activation (`packages/extension/src/extension.ts`, alongside the existing LaTeX migration call):

- Gated by a new `WorkspaceStateKey.BASH_APPROVAL_GLOBAL_MIGRATED` marker so it runs at most once per workspace.
- If a legacy global override exists and this workspace has no explicit workspace-level value yet, it copies the global value into workspace scope (`BASH_APPROVAL_CONFIG_TARGET`) -- so the effective behavior is preserved and now shows up as a visible, correctable toggle in the settings UI, rather than a silent global bypass.
- Clears the legacy global value afterward so it can no longer silently govern other, not-yet-opened workspaces. Because the legacy value was a single global scalar, only the first workspace to run the migration after upgrading inherits it; any other workspace falls back to the safe default (approval enabled) rather than continuing to silently inherit a stale bypass -- the deliberate trade-off for a security-adjacent setting that can't be losslessly fanned out.
- Never overwrites a workspace that already has its own explicit override (e.g. set via the post-#7148 UI).
- If persisting to workspace scope fails (e.g. no workspace folder open), it defers -- leaves the global value and the marker untouched so a later activation gets another chance, instead of silently dropping the value.

Only the VS Code extension needed this: per #7148's diff, desktop already defaulted to `'workspace'` at its call site pre-fix (only the extension hardcoded `'global'`), so desktop's config store was never affected by this scope-mismatch bug.

## Testing

- Added `src/test-kernel/settings/BashApprovalGlobalMigration.vitest.ts`: legacy global value present -> migrated to workspace + cleared globally; no legacy value -> no-op (marker still set); marker already set -> never re-runs; workspace already has its own explicit override -> left untouched (global still cleared).
- `npm run typecheck` passes.
- `npx eslint` clean on all changed files.
- Existing `BashApprovalConfigTarget.vitest.ts` and `DesktopSettingsIpc.vitest.mts` suites still pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-adjacent bash-approval config with deliberate trade-offs (first workspace inherits the legacy global value; others may revert to default after global clear), but behavior is guarded by inspect-based overrides and retry-safe marker logic.
> 
> **Overview**
> Adds a **one-shot per-workspace migration** for users who still have `texra.toolUse.requireBashApproval` stored at **global** scope from before #7148. On extension activation (alongside the LaTeX config migration), `migrateLegacyGlobalBashApprovalOverride` copies that legacy value into **workspace** scope when this folder has no explicit override, then **clears the global** entry so it stops silently affecting other workspaces.
> 
> The migration is gated by `WorkspaceStateKey.BASH_APPROVAL_GLOBAL_MIGRATED`, skips workspaces that already set `workspaceValue` or resource-scoped `workspaceFolderValue`, and **does not set the marker** if workspace copy or global clear fails so a later activation can retry. Only the VS Code extension runs it; desktop is unchanged per the PR rationale.
> 
> Also adds `BashApprovalGlobalMigration.vitest.ts` for the migration paths and minor **table/formatting** edits in `docs/proposals/texra-bench-science-benchmarks.md` (unrelated to the fix).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdc8b9e0d3974d50331d6d329f8caa2d0ace70a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->