### PR TITLE
Gate agents/git/latex tab commands on the registry, not desktopHost

### DIFF
--- a/docs/proposals/texra-bench-science-benchmarks.md
+++ b/docs/proposals/texra-bench-science-benchmarks.md
@@ -99,10 +99,10 @@ The verifier library is therefore **data, not harness code**: a standard grader 
 
 | `std/` grader (command) | Wraps                                                                                                                                                                                                                                                           |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `std/compile-check`     | `compileCheck.ts` / `latexToolchain.ts` invoked directly, independent of the interactive `WORKFLOW_AUTO_COMPILE` setting — a required gate can't depend on a user preference — the hard gate |
+| `std/compile-check`     | `compileCheck.ts` / `latexToolchain.ts` invoked directly, independent of the interactive `WORKFLOW_AUTO_COMPILE` setting — a required gate can't depend on a user preference — the hard gate                                                                    |
 | `std/cas-equal`         | `wolframscript` (or SymPy) executing a **fixed** `refs/` assertion script against the extracted `\benchresult{...}` — outcome-level, targeting renotation-robustness (how far that can be pushed is open — §15), no credit for matching a human derivation path |
 | `std/lean-build`        | `lake build` against a pinned mathlib toolchain; binary per lemma. Proof tasks need only a statement — difficulty can outgrow the task's author (§6 validate exempts this stack from the gold-`refs/solution` check, since it has no reference answer to score) |
-| `std/diff-align`        | the math-aware latexdiff service — **error-injection tasks only**: edits inside injected spans must match gold, edits outside are penalized; not applicable to derivation/proof tasks, which have no injected spans |
+| `std/diff-align`        | the math-aware latexdiff service — **error-injection tasks only**: edits inside injected spans must match gold, edits outside are penalized; not applicable to derivation/proof tasks, which have no injected spans                                             |
 | `std/issue-match`       | `ReviewIssue` matching against gold defects within a line window → precision/recall                                                                                                                                                                             |
 | `std/answer-match`      | numeric-tolerance / exact / set matching on parsed answer blocks                                                                                                                                                                                                |
 
@@ -138,7 +138,7 @@ bench-results/<suite@version>/<runId>/<model>/<task>/trial-<n>/
                     # to that machinery, not built yet)
 ```
 
-- **Comparability rule:** two scores are comparable iff their *task*, *grader-pack*, and *environment* digests match; the subject dimension (model id and/or agent digest) is exactly what `--compare` varies, so it's excluded from the match. `bench report` refuses comparisons that differ on any of the fixed digests.
+- **Comparability rule:** two scores are comparable iff their _task_, _grader-pack_, and _environment_ digests match; the subject dimension (model id and/or agent digest) is exactly what `--compare` varies, so it's excluded from the match. `bench report` refuses comparisons that differ on any of the fixed digests.
 - **Regrade, don't rerun:** graders never mutate these directories, only read them; `bench grade --regrade --diff-against <old>` (a suite version, e.g. `1.1`, resolved under `--results-dir` to that version's evidence directory) recomputes history at zero model cost and attributes every delta to the grader diff.
 - **Hermetic execution:** a published container image pins TeX Live / Lean / wolframscript; `env.json` records the fingerprint; network off by default at the container level (not just tool-level filtering — a solver with shell access could otherwise reach the network via `curl`/package managers even with web tools disabled), with web tools additionally disabled in-agent via the existing `runtimeUnavailableTools` mechanism (`src/agent/runtime/RunContext.ts`) as defense in depth. No new sandbox layer beyond the container's own network policy.
 - **Determinism honesty:** providers offer no usable seeds; replicate variance is measured and reported, never pretended away.
@@ -192,18 +192,18 @@ Six subcommands. Exit codes reuse `packages/cli/src/runtime/exitCodes.ts`; score
 
 ## 11. Existing machinery it rides on
 
-| Bench component                   | Existing code                                                                                                                         |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Bench component                   | Existing code                                                                                                                                                                                                                       |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Cell execution                    | `packages/cli/src/runtime/runExecution.ts`; tool-use path via `packages/cli/src/commands/agentsRun.ts` (today stops after one model/tool cycle — `stopAfterCycle: true` — bench needs a multi-cycle variant, tracked as an MVP gap) |
-| Compile gate / diff / structure   | `src/agent/output/compileCheck.ts`, `src/latex/latexdiff/`, `src/latex/latexToolchain.ts`, `src/latex/labelSearch.ts`, `src/latex/extractBibliography.ts` |
-| CAS / Lean verifiers              | `src/tools/wolfram/wolframScriptUtils.ts`, `src/tools/lean/direct/lakeCommands.ts`, `src/tools/lean/LspTools.ts`, `src/tools/lean/LoogleTool.ts`          |
-| Issue localization                | `src/agent/review/reviewIssues.ts`; solver pattern from `packages/extension/resources/tool_use_agents/changeReviewer.yaml`            |
-| Fresh-task supply                 | `src/latex/arxivProcessor.ts`                                                                                                         |
-| Trace archive                     | `AgentTrace` subscriber (`src/agent/trace/AgentTrace.ts`, pattern: `src/transcript/TexraTranscriptRecorder.ts`); `AgentEvent` union    |
-| Usage / cost / abort              | `src/agent/core/usage/RunUsageAccumulator.ts` (`totalCost` drives `--max-cost-usd`, checked between dispatches — a soft budget guard under concurrency, not a per-cell reservation) |
-| Providers incl. internal gateways | `src/agent/modelHandlers/` (four stacks; `customBaseUrl` already threaded)                                                            |
-| Solver/judge agents               | ordinary agent YAML under `packages/extension/resources/agents/bench/`, run via `runAgent` (`src/agent/runtime/runAgent.ts`)          |
-| Env fingerprint                   | `texra doctor` machinery (`packages/cli/src/commands/doctor.ts`) — today probes Node/workspace/auth/LaTeX/config; Wolfram/lake/image-digest probes are new additions, not built yet |
+| Compile gate / diff / structure   | `src/agent/output/compileCheck.ts`, `src/latex/latexdiff/`, `src/latex/latexToolchain.ts`, `src/latex/labelSearch.ts`, `src/latex/extractBibliography.ts`                                                                           |
+| CAS / Lean verifiers              | `src/tools/wolfram/wolframScriptUtils.ts`, `src/tools/lean/direct/lakeCommands.ts`, `src/tools/lean/LspTools.ts`, `src/tools/lean/LoogleTool.ts`                                                                                    |
+| Issue localization                | `src/agent/review/reviewIssues.ts`; solver pattern from `packages/extension/resources/tool_use_agents/changeReviewer.yaml`                                                                                                          |
+| Fresh-task supply                 | `src/latex/arxivProcessor.ts`                                                                                                                                                                                                       |
+| Trace archive                     | `AgentTrace` subscriber (`src/agent/trace/AgentTrace.ts`, pattern: `src/transcript/TexraTranscriptRecorder.ts`); `AgentEvent` union                                                                                                 |
+| Usage / cost / abort              | `src/agent/core/usage/RunUsageAccumulator.ts` (`totalCost` drives `--max-cost-usd`, checked between dispatches — a soft budget guard under concurrency, not a per-cell reservation)                                                 |
+| Providers incl. internal gateways | `src/agent/modelHandlers/` (four stacks; `customBaseUrl` already threaded)                                                                                                                                                          |
+| Solver/judge agents               | ordinary agent YAML under `packages/extension/resources/agents/bench/`, run via `runAgent` (`src/agent/runtime/runAgent.ts`)                                                                                                        |
+| Env fingerprint                   | `texra doctor` machinery (`packages/cli/src/commands/doctor.ts`) — today probes Node/workspace/auth/LaTeX/config; Wolfram/lake/image-digest probes are new additions, not built yet                                                 |
 
 All additive: new code lives in `src/bench/` (VS Code-free zone, host services via `platform()`) and `packages/cli/`. **The MVP requires zero changes to `src/agent/` core.**
 

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -834,7 +834,7 @@ export class SettingsApp extends SettingsAppBase {
               .customAgentDirIsDefault=${customAgentDirIsDefault.get()}
               .initialSubTab=${agentSubTab.get()}
               .userTier=${tier.get()}
-              .desktopHost=${desktopHost}
+              .unsupportedCommands=${unsupportedCommands.get()}
               @agent-open-yaml=${this.handleOpenAgentYaml}
               @agent-enabled-set=${this.handleSetAgentEnabled}
               @agent-all-enabled-set=${this.handleSetAllAgentsEnabled}
@@ -934,7 +934,7 @@ export class SettingsApp extends SettingsAppBase {
               .authorName=${gitAuthorName.get()}
               .authorEmail=${gitAuthorEmail.get()}
               .toggleDisabled=${!gitSettingsLoaded.get()}
-              .desktopHost=${desktopHost}
+              .unsupportedCommands=${unsupportedCommands.get()}
               @git-mark-commits-toggle=${this.handleGitMarkCommitsToggle}
               @git-author-name-change=${this.handleGitAuthorNameChange}
               @git-author-email-change=${this.handleGitAuthorEmailChange}
@@ -958,6 +958,10 @@ export class SettingsApp extends SettingsAppBase {
               .configLoaded=${latexConfigValuesLoaded.get()}
               .inlineCriticismEnabled=${inlineCriticismEnabled.get()}
               .desktopHost=${desktopHost}
+              .inlineCriticismSupported=${!isKnownUnsupported(
+                unsupportedCommands.get(),
+                SETTINGS_VIEW_COMMANDS.GET_INLINE_CRITICISM_ENABLED,
+              )}
               @latex-apply-settings=${this.handleApplyLatexSettings}
               @latex-install-workshop=${this.handleInstallLatexWorkshop}
               @latex-run-install-command=${this.handleRunInstallCommand}

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -15,6 +15,7 @@ import { classMap } from 'lit/directives/class-map.js';
 
 // Local imports - shared styles
 import { commonViewStyles, designTokens } from '@shared/styles';
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 
@@ -26,6 +27,7 @@ import {
   type AgentSourceType,
 } from '@shared/schemas/agent';
 import type { AgentSelectionItem } from '@shared/schemas/settingsViewMessages';
+import { isKnownUnsupported } from '@shared/utils/dispatcher';
 import { AgentSelectionEvents } from './events';
 import { agentSelectionPanelStyles } from './AgentSelectionPanel.styles';
 
@@ -60,7 +62,16 @@ export class AgentSelectionPanel extends LitElement {
   @property({ attribute: false }) agents: AgentSelectionItem[] = [];
   @property({ attribute: false }) category: AgentCategory = 'workflow';
   @property({ attribute: false }) userTier = 'free';
-  @property({ type: Boolean, attribute: 'desktop-host' }) desktopHost = false;
+
+  /**
+   * Commands the active host's registry declares `unsupported(...)`, sent
+   * once at webview-ready (see `unsupportedCommands` in
+   * `@shared/utils/dispatcher`). `null` before that broadcast arrives —
+   * checked via `isKnownUnsupported`, which treats "not yet known" as
+   * unsupported so a control never flashes visible then hidden.
+   */
+  @property({ attribute: false })
+  unsupportedCommands: ReadonlySet<string> | null = null;
 
   @state() private selectedKey: string | null = null;
 
@@ -445,7 +456,10 @@ export class AgentSelectionPanel extends LitElement {
             agent.source === AGENT_SOURCE.REMOTE &&
             this.userTier === 'Ultra' &&
             !agent.hasPath &&
-            !this.desktopHost
+            !isKnownUnsupported(
+              this.unsupportedCommands,
+              SETTINGS_VIEW_COMMANDS.VIEW_REMOTE_AGENT_PROMPT,
+            )
               ? html`
                   ${renderLabeledActionButton({
                     icon: 'file-lines',
@@ -473,7 +487,11 @@ export class AgentSelectionPanel extends LitElement {
               : nothing
           }
           ${
-            builtIn && !this.desktopHost
+            builtIn &&
+            !isKnownUnsupported(
+              this.unsupportedCommands,
+              SETTINGS_VIEW_COMMANDS.CUSTOMIZE_AGENT,
+            )
               ? html`
                   ${renderLabeledActionButton({
                     icon: 'pencil',
@@ -490,7 +508,11 @@ export class AgentSelectionPanel extends LitElement {
               : nothing
           }
           ${
-            isCustom && !this.desktopHost
+            isCustom &&
+            !isKnownUnsupported(
+              this.unsupportedCommands,
+              SETTINGS_VIEW_COMMANDS.DELETE_CUSTOM_AGENT,
+            )
               ? html`
                   ${renderLabeledActionButton({
                     icon: 'trash',

--- a/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AgentsTab.ts
@@ -21,8 +21,10 @@ import {
 } from '@shared/styles';
 
 // Local imports - shared schemas
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import type { AgentCategory } from '@shared/schemas/agent';
 import type { AgentSelectionItem } from '@shared/schemas/settingsViewMessages';
+import { isKnownUnsupported } from '@shared/utils/dispatcher';
 import type { WaTabShowEvent } from '@shared/wa/tabs';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { AgentSelectionEvents } from '../components/profile/events';
@@ -152,7 +154,16 @@ export class AgentsTab extends LitElement {
   @property({ attribute: false }) customAgentDirIsDefault = true;
   @property({ attribute: false }) initialSubTab?: AgentCategory;
   @property({ attribute: false }) userTier = 'free';
-  @property({ type: Boolean, attribute: 'desktop-host' }) desktopHost = false;
+
+  /**
+   * Commands the active host's registry declares `unsupported(...)`, sent
+   * once at webview-ready (see `unsupportedCommands` in
+   * `@shared/utils/dispatcher`). `null` before that broadcast arrives —
+   * checked via `isKnownUnsupported`, which treats "not yet known" as
+   * unsupported so a control never flashes visible then hidden.
+   */
+  @property({ attribute: false })
+  unsupportedCommands: ReadonlySet<string> | null = null;
 
   @state() private activeSubTab: AgentCategory = 'workflow';
 
@@ -241,7 +252,10 @@ export class AgentsTab extends LitElement {
               ${waIcon('save', { slot: 'start' })} Save Team
             </wa-button>
             ${
-              this.desktopHost
+              isKnownUnsupported(
+                this.unsupportedCommands,
+                SETTINGS_VIEW_COMMANDS.CREATE_AGENT,
+              )
                 ? nothing
                 : html`
                     <wa-button
@@ -326,7 +340,7 @@ export class AgentsTab extends LitElement {
           .agents=${activeAgents}
           .category=${this.activeSubTab}
           .userTier=${this.userTier}
-          .desktopHost=${this.desktopHost}
+          .unsupportedCommands=${this.unsupportedCommands}
         ></agent-selection-panel>
       </div>
     `;

--- a/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
@@ -6,6 +6,7 @@ import { customElement, property } from 'lit/decorators.js';
 
 // Local imports - shared styles
 import { commonViewStyles, designTokens } from '@shared/styles';
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   renderSetStatusIcon,
   statusCheckIconStyles,
@@ -23,6 +24,7 @@ import type { PRSubscriptionEntry } from '@shared/schemas/settingsViewMessages';
 
 // Local imports - shared utils
 import { createEvent } from '@shared/utils/events';
+import { isKnownUnsupported } from '@shared/utils/dispatcher';
 
 // Local imports - shared constants
 import {
@@ -182,7 +184,16 @@ export class GitTab extends LitElement {
     'none';
   @property({ attribute: false })
   prSubscriptions: readonly PRSubscriptionEntry[] = [];
-  @property({ type: Boolean, attribute: 'desktop-host' }) desktopHost = false;
+
+  /**
+   * Commands the active host's registry declares `unsupported(...)`, sent
+   * once at webview-ready (see `unsupportedCommands` in
+   * `@shared/utils/dispatcher`). `null` before that broadcast arrives —
+   * checked via `isKnownUnsupported`, which treats "not yet known" as
+   * unsupported so a control never flashes visible then hidden.
+   */
+  @property({ attribute: false })
+  unsupportedCommands: ReadonlySet<string> | null = null;
 
   private handleMarkCommitsToggle(event: Event): void {
     const target = event.target as WaSwitch | null;
@@ -247,7 +258,10 @@ export class GitTab extends LitElement {
     return html`
       <div class="git-container">
         ${
-          this.desktopHost
+          isKnownUnsupported(
+            this.unsupportedCommands,
+            SETTINGS_VIEW_COMMANDS.GET_GITHUB_TOKEN_STATUS,
+          )
             ? nothing
             : html`
                 <div class="setting-block">
@@ -328,7 +342,10 @@ export class GitTab extends LitElement {
               `
         }
         ${
-          !this.desktopHost && this.prSubscriptions.length > 0
+          !isKnownUnsupported(
+            this.unsupportedCommands,
+            SETTINGS_VIEW_COMMANDS.GET_PR_SUBSCRIPTIONS,
+          ) && this.prSubscriptions.length > 0
             ? html`
                 <div class="setting-block">
                   <p class="section-title">Active GitHub subscriptions</p>

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -233,6 +233,16 @@ export class LaTeXTab extends LitElement {
   @property({ type: Boolean }) inlineCriticismEnabled = false;
   @property({ type: Boolean, attribute: 'desktop-host' }) desktopHost = false;
 
+  /**
+   * Whether the active host's registry supports the inline-criticism
+   * commands (`GET_INLINE_CRITICISM_ENABLED`) — derived via
+   * `isKnownUnsupported` in `SettingsApp`, not the raw `desktopHost` flag,
+   * since this is command availability rather than host-specific UI
+   * (unlike the VS Code settings.json sections below, which genuinely don't
+   * exist on desktop and stay gated on `desktopHost`).
+   */
+  @property({ type: Boolean }) inlineCriticismSupported = false;
+
   private handleApply(field?: SettingInfo['key'], reset = false): void {
     this.dispatchEvent(createEvent('latex-apply-settings', { field, reset }));
   }
@@ -534,7 +544,11 @@ export class LaTeXTab extends LitElement {
                 )}
               `
         }
-        ${this.desktopHost ? nothing : this.renderInlineCriticismSetting()}
+        ${
+          this.inlineCriticismSupported
+            ? this.renderInlineCriticismSetting()
+            : nothing
+        }
         ${this.renderCompileDiffSettings()}
       </div>
     `;


### PR DESCRIPTION
Closes #7183

Follow-up from #7159, which scoped out `SettingsApp`'s `agents-tab`/`git-tab`/`latex-tab` children as needing to touch each component's own internals.

## What changed

`AgentsTab`, `AgentSelectionPanel` (its child), `GitTab`, and `LaTeXTab` decided several controls' visibility from the raw `desktopHost` boolean prop, even though what they were actually gating is command availability — the same fact the registry's `unsupported(...)` markers already encode. Threaded `unsupportedCommands` (the same `ReadonlySet<string> | null` used by `HistoryTab`/`HistoryItemElement`) into each component instead, and gate with `isKnownUnsupported()` against the concrete command each control fires:

- `AgentsTab`: "New Agent" / "From Template" buttons → `CREATE_AGENT`
- `AgentSelectionPanel`: "Customize" → `CUSTOMIZE_AGENT`, "Delete" → `DELETE_CUSTOM_AGENT`, "View Prompt" → `VIEW_REMOTE_AGENT_PROMPT`
- `GitTab`: GitHub token section → `GET_GITHUB_TOKEN_STATUS`, PR subscriptions section → `GET_PR_SUBSCRIPTIONS`
- `LaTeXTab`: inline-criticism setting (the issue's cited example) → `GET_INLINE_CRITICISM_ENABLED`, via a narrower `inlineCriticismSupported` boolean computed in `SettingsApp` (mirroring the existing `showDesktopCrashReporting` pattern on the tools tab)

`LaTeXTab` keeps its `desktopHost` prop for the sections it also gates that are *not* command availability: the VS Code-terminal wording in the package-manager hint, filtering the LaTeX Workshop dependency card, and hiding the "Apply All" button / "Recommended Settings" section for `settings.json`-backed values. Those genuinely don't exist on desktop (no VS Code settings.json, no extension host) — `applyLatexSettings`/`installLatexWorkshop`/`getLatexSettingsStatus` all have real (if reduced) handlers on desktop rather than being marked `unsupported`, so gating them on the registry would be wrong.

Verified each command constant against both hosts' registries: `createAgent`/`customizeAgent`/`deleteCustomAgent`/`viewRemoteAgentPrompt`/`getGitHubTokenStatus`/`getInlineCriticismEnabled` are real handlers on the VS Code extension host and `unsupported(...)` on desktop — same runtime behavior as before, now derived from one source of truth instead of two parallel conventions.

Includes one unrelated commit (`chore: reformat texra-bench-science-benchmarks.md with prettier`) fixing pre-existing formatting drift the repo's whole-tree pre-commit format hook forced before it would let the feature commit through.

## Verification
- `npm run typecheck` — clean (root, test-kernel, CLI, trace-viewer)
- `eslint` — clean on all 5 touched files (fixed two import-order warnings)
- `prettier --check` — clean
- Targeted vitest: `stateSettings.vitest.ts`, `desktopSettingsIpc.vitest.ts`, `DesktopSettingsIpc.vitest.mts` — 59 passing (confirms the desktop registry's `unsupported(...)` markers for the commands this PR now gates on haven't moved)

No new test infra exists for these Lit settingsView components (no vitest coverage of their render output anywhere in the repo today), so this is a same-behavior refactor verified by inspection against both hosts' registries rather than new component tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Same-behavior refactor aligned with existing registry tests; no auth or data-path changes, only UI visibility wiring in the settings webview.
> 
> **Overview**
> Settings webview **Agents**, **Git**, and **LaTeX** tabs no longer hide controls with the **`desktopHost`** flag. They take **`unsupportedCommands`** and use **`isKnownUnsupported()`** against the IPC command each control would invoke, matching **History** / **Tools** and the host registry as the single source of truth.
> 
> **Agents** (`AgentsTab`, `AgentSelectionPanel`): create/customize/delete/view-remote-prompt buttons gate on **`CREATE_AGENT`**, **`CUSTOMIZE_AGENT`**, **`DELETE_CUSTOM_AGENT`**, **`VIEW_REMOTE_AGENT_PROMPT`**. **`SettingsApp`** passes **`unsupportedCommands`** instead of **`desktopHost`** into those components.
> 
> **Git** (`GitTab`): GitHub token and PR subscription sections gate on **`GET_GITHUB_TOKEN_STATUS`** and **`GET_PR_SUBSCRIPTIONS`**.
> 
> **LaTeX** (`LaTeXTab`): inline criticism uses **`inlineCriticismSupported`** from **`SettingsApp`** (derived from **`GET_INLINE_CRITICISM_ENABLED`**). **`desktopHost`** remains only for VS Code–specific UI (recommended **`settings.json`** blocks, LaTeX Workshop card, terminal copy).
> 
> Unrelated: Prettier-only alignment in **`docs/proposals/texra-bench-science-benchmarks.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e057119a26bdcc8992f51cb6aefec81993e8f1f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->