### PR TITLE
[codex] Share restart repair ownership

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -52,6 +52,7 @@ import { createChannelTrace } from '@logger';
 import type { MainViewExecuteMessage } from '@shared/mainView';
 import {
   STREAM_PHASE,
+  type EndGroupStatus,
   type AgentProposalPermission,
   type AgentCategoryFilter,
   type MainViewPersistedState,
@@ -68,6 +69,10 @@ import {
   createProgressBackendUiConfig,
   type ApprovalRequestHandlerSet,
 } from '@shared/progressView/backend/progressBackendUiConfig';
+import {
+  repairRestartedStreams,
+  RESTART_REPAIR_PHASES,
+} from '@shared/progressView/backend/restartRepair';
 import type { MementoStorage } from '@shared/progressView/backend/persistence/PersistentMapManager';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc/progressViewCommands';
 import { COMMON_COMMANDS } from '@shared/ipc/commonCommands';
@@ -111,11 +116,6 @@ const DESKTOP_UNAVAILABLE_TOOLS: readonly DesktopUnavailableTool[] = [
   'inline_comment',
   DIAGNOSTICS_ADD_RUNTIME_CAPABILITY,
 ];
-const RESTART_REPAIR_PHASES: ReadonlySet<StreamPhase> = new Set([
-  STREAM_PHASE.RUNNING,
-  STREAM_PHASE.WAITING,
-]);
-
 export interface DesktopAgentExecutionOptions {
   postToRenderer(message: unknown): boolean | void;
   opener?: Pick<ExternalOpener, 'openPath'> & {
@@ -749,73 +749,19 @@ export class DesktopProgressBridge {
     return { waitingStreams, activeExecutionIds, allExecutionIds };
   }
 
-  private resetRestartRepairStreamStatuses(
-    repairStreams: ReadonlySet<StreamTabId>,
-    waitingStreams: ReadonlySet<StreamTabId>,
-  ): StreamTabId[] {
-    const affectedStreams: StreamTabId[] = [];
-    const statusEmitOptions = {
-      runtimeHost: this.runtimeHost,
-      trace: this.logger,
-    };
-    for (const streamId of repairStreams) {
-      const currentStatus = this.session.status.get(streamId);
-      if (!currentStatus || !RESTART_REPAIR_PHASES.has(currentStatus)) {
-        continue;
-      }
-      if (waitingStreams.has(streamId)) {
-        this.session.status.transition(
-          streamId,
-          STREAM_PHASE.WAITING,
-          'restart-repair',
-          statusEmitOptions,
-        );
-        this.logger.debug(
-          `Stream ${streamId} restored to WAITING after reload`,
-        );
-        continue;
-      }
-      let markedFailed = this.session.status.transition(
-        streamId,
-        STREAM_PHASE.FAILED,
-        'restart-repair',
-        statusEmitOptions,
-      );
-      if (!markedFailed && currentStatus === STREAM_PHASE.WAITING) {
-        markedFailed =
-          this.session.status.transition(
-            streamId,
-            STREAM_PHASE.RUNNING,
-            'resume',
-            statusEmitOptions,
-          ) &&
-          this.session.status.transition(
-            streamId,
-            STREAM_PHASE.FAILED,
-            'lifecycle',
-            statusEmitOptions,
-          );
-      }
-      if (markedFailed) {
-        affectedStreams.push(streamId);
-        this.logger.debug(
-          `Stream ${streamId} set to FAILED during desktop restart recovery`,
-        );
-      } else {
-        this.logger.warn(
-          `Failed to repair stream ${streamId} during desktop restart recovery`,
-        );
-      }
-    }
-    return affectedStreams;
-  }
-
   private getRestartRepairStreamSet(
     executionIdMap: ReadonlyMap<StreamTabId, ExecutionId>,
     allExecutionIds: ReadonlyMap<StreamTabId, ExecutionId>,
     activeExecutionIds: ReadonlySet<string>,
+    waitingStreams: ReadonlySet<StreamTabId>,
   ): Set<StreamTabId> {
-    const repairStreams = new Set(executionIdMap.keys());
+    const repairStreams = new Set(waitingStreams);
+    for (const streamId of executionIdMap.keys()) {
+      const currentStatus = this.session.status.get(streamId);
+      if (currentStatus != null && RESTART_REPAIR_PHASES.has(currentStatus)) {
+        repairStreams.add(streamId);
+      }
+    }
     for (const [streamId, snapshot] of this.progressEvents.restoredStreams) {
       const executionId = snapshot.executionId ?? allExecutionIds.get(streamId);
       if (executionId && activeExecutionIds.has(executionId)) {
@@ -834,11 +780,14 @@ export class DesktopProgressBridge {
 
   private async closeRunningTaskGroupsForStreams(
     streamIds: readonly StreamTabId[],
+    status: EndGroupStatus,
+    now: number = Date.now(),
   ): Promise<StreamTabId[]> {
     if (streamIds.length === 0) return [];
     const closedGroups = await this.state.streamLogs.endRunningGroupsForStreams(
       streamIds,
-      Date.now(),
+      now,
+      status,
     );
     if (closedGroups.length > 0) {
       await this.state.streamLogs.save();
@@ -871,22 +820,26 @@ export class DesktopProgressBridge {
         repairExecutionIdMap,
         repairAllExecutionIds,
         repairActiveExecutionIds,
-      );
-      const affectedStreams = this.resetRestartRepairStreamStatuses(
-        repairStreams,
         waitingStreams,
       );
-      const closeGroupStreams = new Set([
-        ...affectedStreams,
-        ...waitingStreams,
-      ]);
-      const closedGroups = await this.closeRunningTaskGroupsForStreams([
-        ...closeGroupStreams,
-      ]);
+      const repairResult = await repairRestartedStreams({
+        streamStatus: this.session.status,
+        waitingStreams,
+        executionIds: repairAllExecutionIds,
+        repairStreams,
+        closeRunningGroups: (streamIds, status, now) =>
+          this.closeRunningTaskGroupsForStreams(streamIds, status, now),
+        statusEmitOptions: {
+          runtimeHost: this.runtimeHost,
+          trace: this.logger,
+        },
+        logger: this.logger,
+      });
       if (
-        waitingStreams.size > 0 ||
-        affectedStreams.length > 0 ||
-        closedGroups.length > 0 ||
+        repairResult.waitingStreams.length > 0 ||
+        repairResult.failedStreams.length > 0 ||
+        repairResult.closedWaitingGroups.length > 0 ||
+        repairResult.closedFailedGroups.length > 0 ||
         this.progressEvents.restoredStreams.size > 0
       ) {
         this.syncFullView();
@@ -901,11 +854,12 @@ export class DesktopProgressBridge {
       this.progressEvents.hydrateRestoredStreams();
       const { activeExecutionIds, allExecutionIds } =
         this.refreshActiveExecutionIds();
+      let repairExecutionIds = allExecutionIds;
       // The in-memory scan above only catches streams whose CURRENT status
       // already happens to be WAITING. It misses a stream that was RUNNING
       // at crash time but has a valid persisted flow record -- ground truth
       // that only detectWaitingStreams() (KV-store backed) can see. Without
-      // this, resetRestartRepairStreamStatuses would wrongly demote such a
+      // this, restart repair would wrongly demote such a
       // stream to FAILED instead of restoring it to WAITING.
       try {
         const executionIdMap = new Map(
@@ -921,6 +875,7 @@ export class DesktopProgressBridge {
         for (const streamId of persistedWaitingStreams) {
           waitingStreams.add(streamId);
         }
+        repairExecutionIds = postDetectAllExecutionIds;
         // The helper only race-guards its own (persisted-record) result.
         // waitingStreams also carries the pre-existing in-memory-scan
         // entries from above, which predate the KV read and so never got
@@ -961,37 +916,49 @@ export class DesktopProgressBridge {
           activeExecutionIds: postDetectErrorActiveExecutionIds,
           allExecutionIds: postDetectErrorAllExecutionIds,
         } = this.refreshActiveExecutionIds();
+        repairExecutionIds = postDetectErrorAllExecutionIds;
         for (const [streamId, executionId] of postDetectErrorAllExecutionIds) {
           if (postDetectErrorActiveExecutionIds.has(executionId)) {
             waitingStreams.delete(streamId);
           }
         }
       }
-      const affectedStreams = this.resetRestartRepairStreamStatuses(
-        new Set(this.progressEvents.restoredStreams.keys()),
-        waitingStreams,
-      );
-      const closeGroupStreams = new Set([
-        ...affectedStreams,
-        ...waitingStreams,
-      ]);
-      if (closeGroupStreams.size > 0) {
-        try {
-          await this.closeRunningTaskGroupsForStreams([...closeGroupStreams]);
-        } catch (groupError) {
-          this.logger.warn(
-            'Failed to close desktop stream groups after repair failure',
-            {
-              data:
-                groupError instanceof Error
-                  ? groupError
-                  : { error: groupError },
-            },
-          );
+      try {
+        const fallbackRepairStreams = new Set([
+          ...this.progressEvents.restoredStreams.keys(),
+          ...waitingStreams,
+        ]);
+        const repairResult = await repairRestartedStreams({
+          streamStatus: this.session.status,
+          waitingStreams,
+          executionIds: repairExecutionIds,
+          repairStreams: fallbackRepairStreams,
+          closeRunningGroups: (streamIds, status, now) =>
+            this.closeRunningTaskGroupsForStreams(streamIds, status, now),
+          statusEmitOptions: {
+            runtimeHost: this.runtimeHost,
+            trace: this.logger,
+          },
+          logger: this.logger,
+        });
+        if (
+          repairResult.waitingStreams.length > 0 ||
+          repairResult.failedStreams.length > 0 ||
+          repairResult.closedWaitingGroups.length > 0 ||
+          repairResult.closedFailedGroups.length > 0
+        ) {
+          this.syncFullView();
         }
-      }
-      if (affectedStreams.length > 0 || waitingStreams.size > 0) {
-        this.syncFullView();
+      } catch (repairError) {
+        this.logger.warn(
+          'Failed to apply desktop stream repair fallback writes',
+          {
+            data:
+              repairError instanceof Error
+                ? repairError
+                : { error: repairError },
+          },
+        );
       }
       this.logger.warn('Failed to repair desktop streams after restart', {
         data: error instanceof Error ? error : { error },

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -933,6 +933,7 @@ export class DesktopProgressBridge {
           waitingStreams,
           executionIds: repairExecutionIds,
           repairStreams: fallbackRepairStreams,
+          retryFailedStreams: true,
           closeRunningGroups: (streamIds, status, now) =>
             this.closeRunningTaskGroupsForStreams(streamIds, status, now),
           statusEmitOptions: {

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -39,6 +39,7 @@ import {
   createProgressBackendUiConfig,
   type ApprovalRequestHandlerSet,
 } from '@shared/progressView/backend/progressBackendUiConfig';
+import { repairRestartedStreams } from '@shared/progressView/backend/restartRepair';
 import { buildStreamInfo } from '@shared/progressView/backend/streamInfoUtils';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import { collectKnownSessionLinks } from '@tools/inquiry/externalInquiryResultFormatter';
@@ -455,10 +456,18 @@ export class ProgressViewProvider
   }
 
   public async cleanupTasksAfterRestart(): Promise<void> {
-    const waitingStreams = await detectWaitingStreams(
-      this.state.snapshots.getExecutionIdMap(),
-    );
-    await this.resetRunningStreamStatuses(waitingStreams);
+    const executionIds = this.state.snapshots.getExecutionIdMap();
+    const waitingStreams = await detectWaitingStreams(executionIds);
+    await repairRestartedStreams({
+      streamStatus: this.state.streamStatus,
+      waitingStreams,
+      executionIds,
+      repairStreams: executionIds.keys(),
+      closeRunningGroups: (streamIds, status, now) =>
+        this.state.endRunningTaskGroups(now, streamIds, status),
+      statusEmitOptions: { trace: this.logger },
+      logger: this.logger,
+    });
     this.syncFullView({ forceRebuild: true });
   }
 
@@ -471,26 +480,6 @@ export class ProgressViewProvider
       this._mainViewProvider?.getActiveMode() === 'progress' &&
       this._mainViewProvider.getWebviewView()?.visible === true
     );
-  }
-
-  private async resetRunningStreamStatuses(
-    waitingStreams: Set<StreamTabId>,
-  ): Promise<void> {
-    const affectedStreams =
-      this.eventHandler.resetRunningTasksToError(waitingStreams);
-
-    const streamsWithRunningGroups = await this.state.endRunningTaskGroups(
-      Date.now(),
-      affectedStreams,
-    );
-
-    for (const streamId of streamsWithRunningGroups) {
-      if (!affectedStreams.includes(streamId)) {
-        this.logger.debug(
-          `Stream ${streamId} had running groups but wasn't marked as affected`,
-        );
-      }
-    }
   }
 
   public async setActiveStream(streamId: StreamTabId): Promise<void> {

--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -769,38 +769,4 @@ export class ProgressEventHandler {
   getAllStreamSubstates(): Map<StreamTabId, StreamSubstate> {
     return this.state.streamStatus.getAllSubstates();
   }
-
-  resetRunningTasksToError(waitingStreams: Set<StreamTabId>): StreamTabId[] {
-    const affectedStreams: StreamTabId[] = [];
-
-    for (const [streamId, status] of this.state.streamStatus.entries()) {
-      if (status !== STREAM_PHASE.RUNNING) continue;
-
-      if (waitingStreams.has(streamId)) {
-        this.state.streamStatus.transition(
-          streamId,
-          STREAM_PHASE.WAITING,
-          'restart-repair',
-          { trace: this.logger },
-        );
-        this.logger.debug(
-          `Stream ${streamId} restored to WAITING after reload`,
-        );
-        continue;
-      }
-
-      this.state.streamStatus.transition(
-        streamId,
-        STREAM_PHASE.FAILED,
-        'restart-repair',
-        { trace: this.logger },
-      );
-      affectedStreams.push(streamId);
-      this.logger.debug(
-        `Stream ${streamId} set to ERROR during restart recovery`,
-      );
-    }
-
-    return affectedStreams;
-  }
 }

--- a/src/shared/progressView/backend/restartRepair.ts
+++ b/src/shared/progressView/backend/restartRepair.ts
@@ -32,6 +32,8 @@ export interface RestartRepairOptions {
     now: number,
   ): Promise<readonly StreamTabId[]>;
   repairStreams?: Iterable<StreamTabId>;
+  /** Retry terminal metadata after an earlier repair already moved a stream to FAILED. */
+  retryFailedStreams?: boolean;
   statusEmitOptions?: StreamStatusEmitOptions;
   writeTerminalStatus?: (
     executionId: ExecutionId,
@@ -178,7 +180,11 @@ export async function repairRestartedStreams(
       continue;
     }
 
-    if (currentStatus === STREAM_PHASE.FAILED && !isWaitingStream) {
+    if (
+      options.retryFailedStreams === true &&
+      currentStatus === STREAM_PHASE.FAILED &&
+      !isWaitingStream
+    ) {
       failedStreams.push(streamId);
       continue;
     }

--- a/src/shared/progressView/backend/restartRepair.ts
+++ b/src/shared/progressView/backend/restartRepair.ts
@@ -1,0 +1,264 @@
+import { writeTerminalStatus as defaultWriteTerminalStatus } from '@agent/storage/executionLifecycle';
+import type {
+  StreamStatusEmitOptions,
+  StreamStatusMachine,
+} from '@agent/runtime/StreamStatusService';
+import {
+  projectRunOutcome,
+  STREAM_TRANSITION_CAUSE,
+} from '@common/constants/streamStatus';
+import {
+  END_GROUP_STATUS,
+  RUN_OUTCOME,
+  STREAM_PHASE,
+  type EndGroupStatus,
+  type ExecutionId,
+  type StreamPhase,
+  type StreamTabId,
+} from '@shared/schemas';
+
+interface RestartRepairLogger {
+  debug(message: string): void;
+  warn(message: string, context?: { data?: unknown }): void;
+}
+
+export interface RestartRepairOptions {
+  streamStatus: StreamStatusMachine;
+  waitingStreams: ReadonlySet<StreamTabId>;
+  executionIds: ReadonlyMap<StreamTabId, ExecutionId>;
+  closeRunningGroups(
+    streamIds: readonly StreamTabId[],
+    status: EndGroupStatus,
+    now: number,
+  ): Promise<readonly StreamTabId[]>;
+  repairStreams?: Iterable<StreamTabId>;
+  statusEmitOptions?: StreamStatusEmitOptions;
+  writeTerminalStatus?: (
+    executionId: ExecutionId,
+    status: string,
+  ) => Promise<void>;
+  logger?: RestartRepairLogger;
+  now?: number;
+}
+
+export interface RestartRepairResult {
+  waitingStreams: StreamTabId[];
+  failedStreams: StreamTabId[];
+  closedWaitingGroups: StreamTabId[];
+  closedFailedGroups: StreamTabId[];
+  terminalStatusUpdated: ExecutionId[];
+}
+
+export const RESTART_REPAIR_PHASES: ReadonlySet<StreamPhase> = new Set([
+  STREAM_PHASE.RUNNING,
+  STREAM_PHASE.WAITING,
+]);
+
+function repairCandidates(
+  streamStatus: StreamStatusMachine,
+  repairStreams?: Iterable<StreamTabId>,
+): StreamTabId[] {
+  if (repairStreams) return [...repairStreams];
+  return [...streamStatus.entries()]
+    .filter(([, phase]) => phase === STREAM_PHASE.RUNNING)
+    .map(([streamId]) => streamId);
+}
+
+function transitionToFailedForRestart(
+  streamStatus: StreamStatusMachine,
+  streamId: StreamTabId,
+  currentStatus: StreamPhase | undefined,
+  statusEmitOptions: StreamStatusEmitOptions | undefined,
+): boolean {
+  if (
+    streamStatus.transition(
+      streamId,
+      STREAM_PHASE.FAILED,
+      STREAM_TRANSITION_CAUSE.RESTART_REPAIR,
+      statusEmitOptions,
+    )
+  ) {
+    return true;
+  }
+  if (currentStatus !== STREAM_PHASE.WAITING) return false;
+  return (
+    streamStatus.transition(
+      streamId,
+      STREAM_PHASE.RUNNING,
+      STREAM_TRANSITION_CAUSE.RESUME,
+      statusEmitOptions,
+    ) &&
+    streamStatus.transition(
+      streamId,
+      STREAM_PHASE.FAILED,
+      STREAM_TRANSITION_CAUSE.RESTART_REPAIR,
+      statusEmitOptions,
+    )
+  );
+}
+
+async function writeFailedTerminalStatuses(
+  streamIds: readonly StreamTabId[],
+  executionIds: ReadonlyMap<StreamTabId, ExecutionId>,
+  writeTerminalStatus: (
+    executionId: ExecutionId,
+    status: string,
+  ) => Promise<void>,
+  logger: RestartRepairLogger | undefined,
+): Promise<ExecutionId[]> {
+  const status = projectRunOutcome(RUN_OUTCOME.FAILED).executionStatus;
+  const writes = streamIds.flatMap((streamId) => {
+    const executionId = executionIds.get(streamId);
+    return executionId ? [{ streamId, executionId }] : [];
+  });
+  const results = await Promise.allSettled(
+    writes.map(({ executionId }) => writeTerminalStatus(executionId, status)),
+  );
+
+  const updated: ExecutionId[] = [];
+  for (const [index, result] of results.entries()) {
+    const { streamId, executionId } = writes[index];
+    if (result.status === 'fulfilled') {
+      updated.push(executionId);
+      continue;
+    }
+    logger?.warn('Failed to persist restart-repair terminal status', {
+      data: { streamId, executionId, error: result.reason },
+    });
+  }
+  return updated;
+}
+
+/**
+ * Shared restart repair owner for extension and desktop hosts.
+ *
+ * Hosts still supply host-specific facts (waiting detection, active-run race
+ * guards, restored desktop streams), but this function owns the writes that
+ * must stay consistent: stream status, transcript group closure, and terminal
+ * execution metadata for failed repairs.
+ */
+export async function repairRestartedStreams(
+  options: RestartRepairOptions,
+): Promise<RestartRepairResult> {
+  const waitingStreams: StreamTabId[] = [];
+  const failedStreams: StreamTabId[] = [];
+  const waitingGroupStreams: StreamTabId[] = [];
+  const orphanedGroupStreams: StreamTabId[] = [];
+
+  for (const streamId of repairCandidates(
+    options.streamStatus,
+    options.repairStreams,
+  )) {
+    const currentStatus = options.streamStatus.get(streamId);
+    const isWaitingStream = options.waitingStreams.has(streamId);
+
+    if (currentStatus == null) {
+      if (isWaitingStream) {
+        waitingGroupStreams.push(streamId);
+        if (
+          options.streamStatus.transition(
+            streamId,
+            STREAM_PHASE.WAITING,
+            STREAM_TRANSITION_CAUSE.RESTART_REPAIR,
+            options.statusEmitOptions,
+          )
+        ) {
+          waitingStreams.push(streamId);
+          options.logger?.debug(
+            `Stream ${streamId} restored to WAITING after restart`,
+          );
+        } else {
+          options.logger?.warn(
+            `Failed to repair stream ${streamId} to WAITING after restart`,
+          );
+        }
+      } else {
+        orphanedGroupStreams.push(streamId);
+      }
+      continue;
+    }
+
+    if (currentStatus === STREAM_PHASE.FAILED && !isWaitingStream) {
+      failedStreams.push(streamId);
+      continue;
+    }
+
+    if (!RESTART_REPAIR_PHASES.has(currentStatus)) {
+      if (isWaitingStream) {
+        waitingGroupStreams.push(streamId);
+      }
+      continue;
+    }
+
+    if (isWaitingStream) {
+      waitingGroupStreams.push(streamId);
+      if (
+        options.streamStatus.transition(
+          streamId,
+          STREAM_PHASE.WAITING,
+          STREAM_TRANSITION_CAUSE.RESTART_REPAIR,
+          options.statusEmitOptions,
+        )
+      ) {
+        waitingStreams.push(streamId);
+        options.logger?.debug(
+          `Stream ${streamId} restored to WAITING after restart`,
+        );
+      } else {
+        options.logger?.warn(
+          `Failed to repair stream ${streamId} to WAITING after restart`,
+        );
+      }
+      continue;
+    }
+
+    if (
+      transitionToFailedForRestart(
+        options.streamStatus,
+        streamId,
+        currentStatus,
+        options.statusEmitOptions,
+      )
+    ) {
+      failedStreams.push(streamId);
+      options.logger?.debug(
+        `Stream ${streamId} set to FAILED during restart repair`,
+      );
+    } else {
+      options.logger?.warn(`Failed to repair stream ${streamId} after restart`);
+    }
+  }
+
+  const now = options.now ?? Date.now();
+  const failedGroupStreams = [...failedStreams, ...orphanedGroupStreams];
+  const closedWaitingGroups =
+    waitingGroupStreams.length > 0
+      ? await options.closeRunningGroups(
+          waitingGroupStreams,
+          END_GROUP_STATUS.STOPPED,
+          now,
+        )
+      : [];
+  const closedFailedGroups =
+    failedGroupStreams.length > 0
+      ? await options.closeRunningGroups(
+          failedGroupStreams,
+          END_GROUP_STATUS.ERROR,
+          now,
+        )
+      : [];
+  const terminalStatusUpdated = await writeFailedTerminalStatuses(
+    failedStreams,
+    options.executionIds,
+    options.writeTerminalStatus ?? defaultWriteTerminalStatus,
+    options.logger,
+  );
+
+  return {
+    waitingStreams,
+    failedStreams,
+    closedWaitingGroups: [...closedWaitingGroups],
+    closedFailedGroups: [...closedFailedGroups],
+    terminalStatusUpdated,
+  };
+}

--- a/src/shared/progressView/backend/state/ProgressViewState.ts
+++ b/src/shared/progressView/backend/state/ProgressViewState.ts
@@ -17,6 +17,7 @@ import {
   LOG_LEVELS,
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
+  type EndGroupStatus,
   StreamTabInfoSchema,
   type ActiveChildInfo,
   type AgentCategoryFilter,
@@ -314,11 +315,11 @@ export class ProgressViewState {
   async endRunningTaskGroups(
     now: number = Date.now(),
     streamIds?: readonly StreamTabId[],
+    status?: EndGroupStatus,
   ): Promise<StreamTabId[]> {
-    const affectedFromLogs = await this.streamLogs.endRunningGroups(
-      now,
-      streamIds,
-    );
+    const affectedFromLogs = streamIds
+      ? await this.streamLogs.endRunningGroupsForStreams(streamIds, now, status)
+      : await this.streamLogs.endRunningGroups(now, [], status);
     if (affectedFromLogs.length > 0) {
       await this.streamLogs.save();
     }

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -16,11 +16,13 @@ import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import { DESKTOP_SHELL_COMMANDS } from '@desktop/desktopShellMessages';
 import {
   AgentCategory,
+  END_GROUP_STATUS,
   LOG_LEVELS,
   RUN_OUTCOME,
   STREAM_LOG_ENTRY_TYPES,
   STREAM_PHASE,
   STREAM_STATUS,
+  type EndGroupStatus,
   type RestoredStreamSnapshot,
   type RunOutcome,
   type StreamTabId,
@@ -904,6 +906,55 @@ describe('DesktopProgressBridge', () => {
     }
   });
 
+  it('closes fallback waiting groups from durable snapshots outside restored streams', async () => {
+    let finishDetection!: (value: Set<StreamTabId>) => void;
+    const detectionGate = new Promise<Set<StreamTabId>>((resolve) => {
+      finishDetection = resolve;
+    });
+    const detectWaitingStreams = vi.fn(async () => detectionGate);
+    const bridge = await createBridge([], {
+      configureProgressSnapshotStore: (store) => {
+        store.setTaskState(
+          'snapshot-waiting-stream',
+          TaskStateSchema.parse(workflowTaskState()),
+          'abc123',
+        );
+      },
+      detectWaitingStreams,
+      streamLogsLoadError: new Error('stream log store unavailable'),
+    });
+    const restartRepair = (
+      bridge as unknown as { restartRepair: Promise<void> }
+    ).restartRepair;
+    const streamLogs = bridge.streamLogs as typeof bridge.streamLogs & {
+      endRunningGroupsForStreams: (
+        streamIds: readonly StreamTabId[],
+        now?: number,
+        status?: EndGroupStatus,
+      ) => Promise<StreamTabId[]>;
+    };
+    const closeSpy = vi.spyOn(streamLogs, 'endRunningGroupsForStreams');
+
+    try {
+      await vi.waitFor(() => expect(detectWaitingStreams).toHaveBeenCalled());
+      finishDetection(new Set<StreamTabId>(['snapshot-waiting-stream']));
+      await restartRepair;
+
+      expect(bridgeStatus(bridge).get('snapshot-waiting-stream')).toBe(
+        STREAM_STATUS.WAITING,
+      );
+      expect(closeSpy).toHaveBeenCalledWith(
+        ['snapshot-waiting-stream'],
+        expect.any(Number),
+        END_GROUP_STATUS.STOPPED,
+      );
+    } finally {
+      finishDetection(new Set());
+      bridgeStatus(bridge).clearStream('snapshot-waiting-stream');
+      bridge.dispose();
+    }
+  });
+
   it('rechecks active executions after a failed persisted-record lookup in the fallback path', async () => {
     // Regression test for the "catch-within-catch" gap (issue #7160): the
     // fallback path's own recheck (see the regression test above) only ran
@@ -955,6 +1006,7 @@ describe('DesktopProgressBridge', () => {
       endRunningGroupsForStreams: (
         streamIds: readonly StreamTabId[],
         now?: number,
+        status?: EndGroupStatus,
       ) => Promise<StreamTabId[]>;
     };
     const closeSpy = vi.spyOn(streamLogs, 'endRunningGroupsForStreams');
@@ -1152,6 +1204,7 @@ describe('DesktopProgressBridge', () => {
       endRunningGroupsForStreams: (
         streamIds: readonly StreamTabId[],
         now?: number,
+        status?: EndGroupStatus,
       ) => Promise<StreamTabId[]>;
     };
     const closeSpy = vi.spyOn(streamLogs, 'endRunningGroupsForStreams');
@@ -1164,6 +1217,7 @@ describe('DesktopProgressBridge', () => {
         expect(closeSpy).toHaveBeenCalledWith(
           ['waiting-stream'],
           expect.any(Number),
+          END_GROUP_STATUS.STOPPED,
         );
       });
     } finally {
@@ -1192,6 +1246,7 @@ describe('DesktopProgressBridge', () => {
       endRunningGroupsForStreams: (
         streamIds: readonly StreamTabId[],
         now?: number,
+        status?: EndGroupStatus,
       ) => Promise<StreamTabId[]>;
     };
     const closeSpy = vi
@@ -1211,6 +1266,7 @@ describe('DesktopProgressBridge', () => {
         expect(closeSpy).toHaveBeenLastCalledWith(
           ['waiting-stream'],
           expect.any(Number),
+          END_GROUP_STATUS.STOPPED,
         );
       });
     } finally {

--- a/src/test-kernel/progressView/RestartRepair.vitest.ts
+++ b/src/test-kernel/progressView/RestartRepair.vitest.ts
@@ -278,6 +278,7 @@ describe('repairRestartedStreams', () => {
       waitingStreams: new Set(),
       executionIds: new Map([[streamId, executionId]]),
       repairStreams: [streamId],
+      retryFailedStreams: true,
       closeRunningGroups,
       writeTerminalStatus,
       now: 567,
@@ -297,6 +298,40 @@ describe('repairRestartedStreams', () => {
       executionId,
       EXECUTION_STATUS.ERROR,
     );
+  });
+
+  it('does not retry historical failed streams unless retry is requested', async () => {
+    const streamId = 'stream-historical-failed' as StreamTabId;
+    const executionId = 'execution-historical-failed' as ExecutionId;
+    const streamStatus = new StreamStatusMachine();
+    seedRunning(streamStatus, streamId);
+    streamStatus.transition(
+      streamId,
+      STREAM_PHASE.FAILED,
+      STREAM_TRANSITION_CAUSE.LIFECYCLE,
+    );
+    const closeRunningGroups = vi.fn(
+      async (streamIds: readonly StreamTabId[]) => [...streamIds],
+    );
+    const writeTerminalStatus = vi.fn(async () => undefined);
+
+    const result = await repairRestartedStreams({
+      streamStatus,
+      waitingStreams: new Set(),
+      executionIds: new Map([[streamId, executionId]]),
+      repairStreams: [streamId],
+      closeRunningGroups,
+      writeTerminalStatus,
+    });
+
+    expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
+    expect(result).toMatchObject({
+      failedStreams: [],
+      closedFailedGroups: [],
+      terminalStatusUpdated: [],
+    });
+    expect(closeRunningGroups).not.toHaveBeenCalled();
+    expect(writeTerminalStatus).not.toHaveBeenCalled();
   });
 
   it('can terminalize stale WAITING streams through the resume choreography', async () => {

--- a/src/test-kernel/progressView/RestartRepair.vitest.ts
+++ b/src/test-kernel/progressView/RestartRepair.vitest.ts
@@ -1,0 +1,345 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { setupPlatform } from '@test/support/setupPlatform';
+import { getExecutionStore } from '@agent/storage';
+import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
+import { STREAM_TRANSITION_CAUSE } from '@common/constants/streamStatus';
+import {
+  END_GROUP_STATUS,
+  EXECUTION_STATUS,
+  RUN_OUTCOME,
+  STREAM_PHASE,
+  type EndGroupStatus,
+  type ExecutionId,
+  type StreamTabId,
+} from '@shared/schemas';
+import { repairRestartedStreams } from '@shared/progressView/backend/restartRepair';
+
+setupPlatform({ workspacePath: '/workspace' });
+
+function seedRunning(
+  streamStatus: StreamStatusMachine,
+  streamId: StreamTabId,
+): void {
+  streamStatus.transition(
+    streamId,
+    STREAM_PHASE.RUNNING,
+    STREAM_TRANSITION_CAUSE.LIFECYCLE,
+  );
+}
+
+function seedWaiting(
+  streamStatus: StreamStatusMachine,
+  streamId: StreamTabId,
+): void {
+  seedRunning(streamStatus, streamId);
+  streamStatus.transition(
+    streamId,
+    STREAM_PHASE.WAITING,
+    STREAM_TRANSITION_CAUSE.WAIT,
+  );
+}
+
+describe('repairRestartedStreams', () => {
+  it('repairs resumable running streams to WAITING with neutral group closure', async () => {
+    const streamId = 'stream-waiting' as StreamTabId;
+    const executionId = 'execution-waiting' as ExecutionId;
+    const streamStatus = new StreamStatusMachine();
+    seedRunning(streamStatus, streamId);
+    const closeRunningGroups = vi.fn(
+      async (streamIds: readonly StreamTabId[], status: EndGroupStatus) =>
+        status === END_GROUP_STATUS.STOPPED ? [...streamIds] : [],
+    );
+    const writeTerminalStatus = vi.fn();
+
+    const result = await repairRestartedStreams({
+      streamStatus,
+      waitingStreams: new Set([streamId]),
+      executionIds: new Map([[streamId, executionId]]),
+      closeRunningGroups,
+      writeTerminalStatus,
+      now: 123,
+    });
+
+    expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.WAITING);
+    expect(result).toMatchObject({
+      waitingStreams: [streamId],
+      failedStreams: [],
+      closedWaitingGroups: [streamId],
+      closedFailedGroups: [],
+      terminalStatusUpdated: [],
+    });
+    expect(closeRunningGroups).toHaveBeenCalledWith(
+      [streamId],
+      END_GROUP_STATUS.STOPPED,
+      123,
+    );
+    expect(writeTerminalStatus).not.toHaveBeenCalled();
+  });
+
+  it('repairs resumable streams without an in-memory phase and closes their groups', async () => {
+    const streamId = 'stream-waiting-without-phase' as StreamTabId;
+    const executionId = 'execution-waiting-without-phase' as ExecutionId;
+    const streamStatus = new StreamStatusMachine();
+    const closeRunningGroups = vi.fn(
+      async (streamIds: readonly StreamTabId[], status: EndGroupStatus) =>
+        status === END_GROUP_STATUS.STOPPED ? [...streamIds] : [],
+    );
+    const writeTerminalStatus = vi.fn();
+
+    const result = await repairRestartedStreams({
+      streamStatus,
+      waitingStreams: new Set([streamId]),
+      executionIds: new Map([[streamId, executionId]]),
+      repairStreams: [streamId],
+      closeRunningGroups,
+      writeTerminalStatus,
+      now: 234,
+    });
+
+    expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.WAITING);
+    expect(result.closedWaitingGroups).toEqual([streamId]);
+    expect(closeRunningGroups).toHaveBeenCalledWith(
+      [streamId],
+      END_GROUP_STATUS.STOPPED,
+      234,
+    );
+    expect(writeTerminalStatus).not.toHaveBeenCalled();
+  });
+
+  it('closes non-waiting candidates without an in-memory phase without terminalizing them', async () => {
+    const streamId = 'stream-without-phase' as StreamTabId;
+    const executionId = 'execution-without-phase' as ExecutionId;
+    const streamStatus = new StreamStatusMachine();
+    const closeRunningGroups = vi.fn(
+      async (streamIds: readonly StreamTabId[], status: EndGroupStatus) =>
+        status === END_GROUP_STATUS.ERROR ? [...streamIds] : [],
+    );
+    const writeTerminalStatus = vi.fn(async () => undefined);
+
+    const result = await repairRestartedStreams({
+      streamStatus,
+      waitingStreams: new Set(),
+      executionIds: new Map([[streamId, executionId]]),
+      repairStreams: [streamId],
+      closeRunningGroups,
+      writeTerminalStatus,
+      now: 345,
+    });
+
+    expect(streamStatus.get(streamId)).toBeUndefined();
+    expect(result).toMatchObject({
+      waitingStreams: [],
+      failedStreams: [],
+      closedWaitingGroups: [],
+      closedFailedGroups: [streamId],
+      terminalStatusUpdated: [],
+    });
+    expect(closeRunningGroups).toHaveBeenCalledWith(
+      [streamId],
+      END_GROUP_STATUS.ERROR,
+      345,
+    );
+    expect(writeTerminalStatus).not.toHaveBeenCalled();
+  });
+
+  it('closes waiting groups even when the current phase is not repairable', async () => {
+    const streamId = 'stream-terminal-waiting' as StreamTabId;
+    const executionId = 'execution-terminal-waiting' as ExecutionId;
+    const streamStatus = new StreamStatusMachine();
+    seedRunning(streamStatus, streamId);
+    streamStatus.transition(
+      streamId,
+      STREAM_PHASE.CANCELLED,
+      STREAM_TRANSITION_CAUSE.LIFECYCLE,
+    );
+    const closeRunningGroups = vi.fn(
+      async (streamIds: readonly StreamTabId[], status: EndGroupStatus) =>
+        status === END_GROUP_STATUS.STOPPED ? [...streamIds] : [],
+    );
+    const writeTerminalStatus = vi.fn(async () => undefined);
+
+    const result = await repairRestartedStreams({
+      streamStatus,
+      waitingStreams: new Set([streamId]),
+      executionIds: new Map([[streamId, executionId]]),
+      repairStreams: [streamId],
+      closeRunningGroups,
+      writeTerminalStatus,
+      now: 456,
+    });
+
+    expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
+    expect(result).toMatchObject({
+      waitingStreams: [],
+      failedStreams: [],
+      closedWaitingGroups: [streamId],
+      closedFailedGroups: [],
+      terminalStatusUpdated: [],
+    });
+    expect(closeRunningGroups).toHaveBeenCalledWith(
+      [streamId],
+      END_GROUP_STATUS.STOPPED,
+      456,
+    );
+    expect(writeTerminalStatus).not.toHaveBeenCalled();
+  });
+
+  it('repairs non-resumable running streams to FAILED and writes terminal meta', async () => {
+    const streamId = 'stream-failed' as StreamTabId;
+    const executionId = 'execution-failed' as ExecutionId;
+    const streamStatus = new StreamStatusMachine();
+    seedRunning(streamStatus, streamId);
+    const closeRunningGroups = vi.fn(
+      async (streamIds: readonly StreamTabId[], status: EndGroupStatus) =>
+        status === END_GROUP_STATUS.ERROR ? [...streamIds] : [],
+    );
+    const writeTerminalStatus = vi.fn(async () => undefined);
+
+    const result = await repairRestartedStreams({
+      streamStatus,
+      waitingStreams: new Set(),
+      executionIds: new Map([[streamId, executionId]]),
+      closeRunningGroups,
+      writeTerminalStatus,
+      now: 456,
+    });
+
+    expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
+    expect(result).toMatchObject({
+      waitingStreams: [],
+      failedStreams: [streamId],
+      closedWaitingGroups: [],
+      closedFailedGroups: [streamId],
+      terminalStatusUpdated: [executionId],
+    });
+    expect(closeRunningGroups).toHaveBeenCalledWith(
+      [streamId],
+      END_GROUP_STATUS.ERROR,
+      456,
+    );
+    expect(writeTerminalStatus).toHaveBeenCalledWith(
+      executionId,
+      EXECUTION_STATUS.ERROR,
+    );
+  });
+
+  it('does not write failed terminal meta before failed groups close', async () => {
+    const streamId = 'stream-failed-close-error' as StreamTabId;
+    const executionId = 'execution-failed-close-error' as ExecutionId;
+    const streamStatus = new StreamStatusMachine();
+    seedRunning(streamStatus, streamId);
+    const writeTerminalStatus = vi.fn(async () => undefined);
+
+    await expect(
+      repairRestartedStreams({
+        streamStatus,
+        waitingStreams: new Set(),
+        executionIds: new Map([[streamId, executionId]]),
+        closeRunningGroups: async () => {
+          throw new Error('group close failed');
+        },
+        writeTerminalStatus,
+      }),
+    ).rejects.toThrow('group close failed');
+
+    expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
+    expect(writeTerminalStatus).not.toHaveBeenCalled();
+  });
+
+  it('writes failed terminal meta when retrying an already failed repair', async () => {
+    const streamId = 'stream-failed-retry' as StreamTabId;
+    const executionId = 'execution-failed-retry' as ExecutionId;
+    const streamStatus = new StreamStatusMachine();
+    seedRunning(streamStatus, streamId);
+    const writeTerminalStatus = vi.fn(async () => undefined);
+
+    await expect(
+      repairRestartedStreams({
+        streamStatus,
+        waitingStreams: new Set(),
+        executionIds: new Map([[streamId, executionId]]),
+        closeRunningGroups: async () => {
+          throw new Error('group close failed');
+        },
+        writeTerminalStatus,
+      }),
+    ).rejects.toThrow('group close failed');
+    expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
+    expect(writeTerminalStatus).not.toHaveBeenCalled();
+
+    const closeRunningGroups = vi.fn(
+      async (streamIds: readonly StreamTabId[], status: EndGroupStatus) =>
+        status === END_GROUP_STATUS.ERROR ? [...streamIds] : [],
+    );
+
+    const result = await repairRestartedStreams({
+      streamStatus,
+      waitingStreams: new Set(),
+      executionIds: new Map([[streamId, executionId]]),
+      repairStreams: [streamId],
+      closeRunningGroups,
+      writeTerminalStatus,
+      now: 567,
+    });
+
+    expect(result).toMatchObject({
+      failedStreams: [streamId],
+      closedFailedGroups: [streamId],
+      terminalStatusUpdated: [executionId],
+    });
+    expect(closeRunningGroups).toHaveBeenCalledWith(
+      [streamId],
+      END_GROUP_STATUS.ERROR,
+      567,
+    );
+    expect(writeTerminalStatus).toHaveBeenCalledWith(
+      executionId,
+      EXECUTION_STATUS.ERROR,
+    );
+  });
+
+  it('can terminalize stale WAITING streams through the resume choreography', async () => {
+    const streamId = 'stream-stale-waiting' as StreamTabId;
+    const executionId = 'execution-stale-waiting' as ExecutionId;
+    const streamStatus = new StreamStatusMachine();
+    seedWaiting(streamStatus, streamId);
+
+    await repairRestartedStreams({
+      streamStatus,
+      waitingStreams: new Set(),
+      executionIds: new Map([[streamId, executionId]]),
+      repairStreams: [streamId],
+      closeRunningGroups: async (streamIds) => [...streamIds],
+      writeTerminalStatus: vi.fn(async () => undefined),
+    });
+
+    expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
+  });
+
+  it('writes failed execution metadata through the default lifecycle hook', async () => {
+    const streamId = 'stream-real-meta' as StreamTabId;
+    const executionId = 'execution-real-meta' as ExecutionId;
+    const store = getExecutionStore(executionId);
+    await store.writeMeta({
+      timestamp: '2026-07-05T00:00:00.000Z',
+      description: 'keep this field',
+    });
+    const streamStatus = new StreamStatusMachine();
+    seedRunning(streamStatus, streamId);
+
+    const result = await repairRestartedStreams({
+      streamStatus,
+      waitingStreams: new Set(),
+      executionIds: new Map([[streamId, executionId]]),
+      closeRunningGroups: async () => [],
+    });
+
+    await expect(store.readMeta()).resolves.toMatchObject({
+      description: 'keep this field',
+      terminalStatus: EXECUTION_STATUS.ERROR,
+      outcome: RUN_OUTCOME.FAILED,
+    });
+    expect(result.terminalStatusUpdated).toEqual([executionId]);
+  });
+});

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -441,6 +441,43 @@ describe('StreamLogStore load', () => {
     expect(storage.fullLogReads()).toBe(1);
   });
 
+  it('does not load selected streams whose summaries have no running group', async () => {
+    const storage = mockStorage({
+      logs: {
+        alpha: [logEntry('alpha', 1, 100)],
+        beta: [runningGroupEntry('beta', 1, 110)],
+      },
+      summaries: {
+        alpha: {
+          firstTimestamp: 100,
+          lastTimestamp: 100,
+          hasRunningGroup: false,
+        },
+        beta: {
+          firstTimestamp: 110,
+          lastTimestamp: 110,
+          hasRunningGroup: true,
+        },
+      },
+    });
+
+    const store = new StreamLogStore();
+    await store.load();
+
+    const affected = await store.endRunningGroupsForStreams(
+      ['alpha', 'beta'],
+      300,
+    );
+    await store.flush();
+
+    expect(affected).toEqual(['beta']);
+    expect(storage.fullLogReads()).toBe(1);
+    expect(store.get('alpha')).toBeUndefined();
+    expect(store.get('beta')?.getRange(0).at(0)?.type).toBe(
+      STREAM_LOG_ENTRY_TYPES.GROUP_END,
+    );
+  });
+
   it('bounds stale running group rehydrates', async () => {
     const streamIds = Array.from(
       { length: 20 },

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -13,6 +13,7 @@ import {
   STREAM_LOG_SUMMARIES_DIR,
 } from '@transcript';
 import {
+  END_GROUP_STATUS,
   LOG_LEVELS,
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
@@ -406,6 +407,38 @@ describe('StreamLogStore load', () => {
     expect(
       storage.writes.get(storageFile(STREAM_LOG_SUMMARIES_DIR, 'beta')),
     ).toBeUndefined();
+  });
+
+  it('can close selected running groups with a neutral stopped status', async () => {
+    const storage = mockStorage({
+      logs: {
+        alpha: [runningGroupEntry('alpha', 1, 100)],
+      },
+      summaries: {
+        alpha: {
+          firstTimestamp: 100,
+          lastTimestamp: 100,
+          hasRunningGroup: true,
+        },
+      },
+    });
+
+    const store = new StreamLogStore();
+    await store.load();
+
+    const affected = await store.endRunningGroupsForStreams(
+      ['alpha'],
+      300,
+      END_GROUP_STATUS.STOPPED,
+    );
+    await store.flush();
+
+    expect(affected).toEqual(['alpha']);
+    expect(store.get('alpha')?.getRange(0).at(0)?.data).toEqual({
+      status: END_GROUP_STATUS.STOPPED,
+      endTime: 300,
+    });
+    expect(storage.fullLogReads()).toBe(1);
   });
 
   it('bounds stale running group rehydrates', async () => {

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -388,9 +388,15 @@ export class StreamLogStore {
     status: EndGroupStatus = END_GROUP_STATUS.ERROR,
   ): Promise<StreamTabId[]> {
     if (streamIds.length === 0) return [];
-    await pMap(streamIds, (id) => this.ensureLoaded(id), {
-      concurrency: STREAM_LOG_LOAD_CONCURRENCY,
-    });
+    const streamsToLoad = streamIds.filter(
+      (id) =>
+        !this.logs.has(id) && this.summaries.get(id)?.hasRunningGroup === true,
+    );
+    if (streamsToLoad.length > 0) {
+      await pMap(streamsToLoad, (id) => this.ensureLoaded(id), {
+        concurrency: STREAM_LOG_LOAD_CONCURRENCY,
+      });
+    }
 
     const affected = this.endRunningGroupsInLoadedLogs(
       now,

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -4,8 +4,10 @@ import { z } from 'zod';
 import { KVStore } from '@common/storage/KVStore';
 import * as log from '@logger/logUtils';
 import {
+  END_GROUP_STATUS,
   PersistedStreamLogEntrySchema,
   STREAM_LOG_ENTRY_TYPES,
+  type EndGroupStatus,
   type StreamLogEntry,
   type StreamTabId,
 } from '@shared/schemas';
@@ -357,6 +359,7 @@ export class StreamLogStore {
   async endRunningGroups(
     now: number = Date.now(),
     streamIds: readonly StreamTabId[] = [],
+    status: EndGroupStatus = END_GROUP_STATUS.ERROR,
   ): Promise<StreamTabId[]> {
     const streamsToLoad = new Set(streamIds);
     for (const [streamId, summary] of this.summaries) {
@@ -371,7 +374,7 @@ export class StreamLogStore {
       });
     }
 
-    const affected = this.endRunningGroupsInLoadedLogs(now);
+    const affected = this.endRunningGroupsInLoadedLogs(now, undefined, status);
     if (affected.length > 0) {
       void this.save();
     }
@@ -382,13 +385,18 @@ export class StreamLogStore {
   async endRunningGroupsForStreams(
     streamIds: readonly StreamTabId[],
     now: number = Date.now(),
+    status: EndGroupStatus = END_GROUP_STATUS.ERROR,
   ): Promise<StreamTabId[]> {
     if (streamIds.length === 0) return [];
     await pMap(streamIds, (id) => this.ensureLoaded(id), {
       concurrency: STREAM_LOG_LOAD_CONCURRENCY,
     });
 
-    const affected = this.endRunningGroupsInLoadedLogs(now, new Set(streamIds));
+    const affected = this.endRunningGroupsInLoadedLogs(
+      now,
+      new Set(streamIds),
+      status,
+    );
     if (affected.length > 0) {
       void this.save();
     }
@@ -399,6 +407,7 @@ export class StreamLogStore {
   private endRunningGroupsInLoadedLogs(
     now: number,
     streamIds?: ReadonlySet<StreamTabId>,
+    status: EndGroupStatus = END_GROUP_STATUS.ERROR,
   ): StreamTabId[] {
     const affected: StreamTabId[] = [];
     for (const [streamId, logInstance] of this.logs.entries()) {
@@ -410,7 +419,7 @@ export class StreamLogStore {
 
         updatedAny ||= !!logInstance.update(entry.id, {
           type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
-          data: { ...existingData, status: 'error', endTime: now },
+          data: { ...existingData, status, endTime: now },
         });
       }
 


### PR DESCRIPTION
## Summary

Moves restart repair status application into a shared backend helper used by both the extension progress view and desktop progress bridge. The helper applies the existing waiting-stream predicate supplied by each host, then performs the coupled writes in one place: stream status repair, transcript group closure, and failed execution terminal metadata.

## Issue acceptance gates

Addresses #7212.

- One shared module owns restart-repair classification application: `src/shared/progressView/backend/restartRepair.ts` now owns status rewrite, group closure status selection, and failed terminal-meta writes.
- Extension and desktop both call the shared repair helper.
- RUNNING plus persisted waiting flow repairs to WAITING and closes running transcript groups as `stopped`.
- RUNNING without waiting flow repairs to FAILED, closes running transcript groups as `error`, and writes failed execution terminal metadata.
- Desktop restored-stream hydration and active-execution race guards remain in `desktopAgentExecution.ts`; no HostInteractions/F2 rewiring is included.
- Focused tests cover the shared helper, selected transcript group closure, and desktop waiting repair behavior.

## Single source of truth

`repairRestartedStreams` is the single owner for restart-repair write sequencing across hosts.

## Duplication and abstraction budget

Removed duplicated extension and desktop status-reset logic. The new abstraction is not a pass-through layer: it owns the invariant that a restart repair must keep stream status, transcript group terminal state, and failed execution metadata consistent. This PR is line-positive because the added mass lives in the shared owner plus focused regression coverage.

No #6981 legacy-retirement ledger row is required: this change does not introduce a shim, projection, dual-write, alias, fallback, or migration path.

## Host impact

Extension: restart cleanup still uses the existing persisted waiting detection, but shared repair now also writes failed execution terminal metadata and closes WAITING repairs with neutral `stopped` groups.

Desktop: restart repair uses the same shared write owner while preserving restored-stream hydration and active-execution race guards.

CLI: no CLI/runtime byte-output behavior change.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write packages/desktop/src/main/desktopAgentExecution.ts packages/extension/src/progressView/ProgressViewProvider.ts src/shared/progressView/backend/events/ProgressEventHandler.ts src/shared/progressView/backend/state/ProgressViewState.ts src/shared/progressView/backend/restartRepair.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/progressView/RestartRepair.vitest.ts src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts src/transcript/StreamLogStore.ts`
- `npm test -- --run src/test-kernel/progressView/RestartRepair.vitest.ts src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/agent/runtime/StreamStatusService.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts`
- `npm run compile:fast`
- `npm test`
- `npm run typecheck`
- `npm run lint` (passes; reports one pre-existing unrelated import-order warning in `packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts`)
- `git diff --check`
- `git pull --rebase --autostash origin main`

Closes #7212

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches stream lifecycle, transcript persistence, and execution terminal metadata on every host restart; behavior is heavily tested but mistakes could mis-classify resumable vs failed runs.
> 
> **Overview**
> After a reload or crash, **extension and desktop** now run the same **`repairRestartedStreams`** path instead of separate status-reset logic. Hosts still detect waiting streams and desktop-specific race guards; the shared module owns **stream phase transitions**, **closing open transcript groups**, and **persisting failed execution terminal metadata**.
> 
> **Resumable** interrupted runs are restored to **WAITING** and running groups close as **`stopped`**. **Non-resumable** in-flight runs become **FAILED**, groups close as **`error`**, and execution store gets a failed terminal status. **`StreamLogStore`** accepts an **`EndGroupStatus`** on group closure and avoids loading streams that have no running group when closing selected streams.
> 
> Duplicated **`resetRunningTasksToError`** / desktop **`resetRestartRepairStreamStatuses`** are removed. Desktop’s degraded fallback calls the same helper with **`retryFailedStreams`** so terminal metadata can be retried after a partial failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9b1142a6c28e9feb5b605825ca4617efe06cc67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->