### PR TITLE
Registry-derive Codex-subscription model eligibility

### DIFF
--- a/docs/proposals/texra-bench-science-benchmarks.md
+++ b/docs/proposals/texra-bench-science-benchmarks.md
@@ -99,10 +99,10 @@ The verifier library is therefore **data, not harness code**: a standard grader 
 
 | `std/` grader (command) | Wraps                                                                                                                                                                                                                                                           |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `std/compile-check`     | `compileCheck.ts` / `latexToolchain.ts` invoked directly, independent of the interactive `WORKFLOW_AUTO_COMPILE` setting — a required gate can't depend on a user preference — the hard gate |
+| `std/compile-check`     | `compileCheck.ts` / `latexToolchain.ts` invoked directly, independent of the interactive `WORKFLOW_AUTO_COMPILE` setting — a required gate can't depend on a user preference — the hard gate                                                                    |
 | `std/cas-equal`         | `wolframscript` (or SymPy) executing a **fixed** `refs/` assertion script against the extracted `\benchresult{...}` — outcome-level, targeting renotation-robustness (how far that can be pushed is open — §15), no credit for matching a human derivation path |
 | `std/lean-build`        | `lake build` against a pinned mathlib toolchain; binary per lemma. Proof tasks need only a statement — difficulty can outgrow the task's author (§6 validate exempts this stack from the gold-`refs/solution` check, since it has no reference answer to score) |
-| `std/diff-align`        | the math-aware latexdiff service — **error-injection tasks only**: edits inside injected spans must match gold, edits outside are penalized; not applicable to derivation/proof tasks, which have no injected spans |
+| `std/diff-align`        | the math-aware latexdiff service — **error-injection tasks only**: edits inside injected spans must match gold, edits outside are penalized; not applicable to derivation/proof tasks, which have no injected spans                                             |
 | `std/issue-match`       | `ReviewIssue` matching against gold defects within a line window → precision/recall                                                                                                                                                                             |
 | `std/answer-match`      | numeric-tolerance / exact / set matching on parsed answer blocks                                                                                                                                                                                                |
 
@@ -138,7 +138,7 @@ bench-results/<suite@version>/<runId>/<model>/<task>/trial-<n>/
                     # to that machinery, not built yet)
 ```
 
-- **Comparability rule:** two scores are comparable iff their *task*, *grader-pack*, and *environment* digests match; the subject dimension (model id and/or agent digest) is exactly what `--compare` varies, so it's excluded from the match. `bench report` refuses comparisons that differ on any of the fixed digests.
+- **Comparability rule:** two scores are comparable iff their _task_, _grader-pack_, and _environment_ digests match; the subject dimension (model id and/or agent digest) is exactly what `--compare` varies, so it's excluded from the match. `bench report` refuses comparisons that differ on any of the fixed digests.
 - **Regrade, don't rerun:** graders never mutate these directories, only read them; `bench grade --regrade --diff-against <old>` (a suite version, e.g. `1.1`, resolved under `--results-dir` to that version's evidence directory) recomputes history at zero model cost and attributes every delta to the grader diff.
 - **Hermetic execution:** a published container image pins TeX Live / Lean / wolframscript; `env.json` records the fingerprint; network off by default at the container level (not just tool-level filtering — a solver with shell access could otherwise reach the network via `curl`/package managers even with web tools disabled), with web tools additionally disabled in-agent via the existing `runtimeUnavailableTools` mechanism (`src/agent/runtime/RunContext.ts`) as defense in depth. No new sandbox layer beyond the container's own network policy.
 - **Determinism honesty:** providers offer no usable seeds; replicate variance is measured and reported, never pretended away.
@@ -192,18 +192,18 @@ Six subcommands. Exit codes reuse `packages/cli/src/runtime/exitCodes.ts`; score
 
 ## 11. Existing machinery it rides on
 
-| Bench component                   | Existing code                                                                                                                         |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Bench component                   | Existing code                                                                                                                                                                                                                       |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Cell execution                    | `packages/cli/src/runtime/runExecution.ts`; tool-use path via `packages/cli/src/commands/agentsRun.ts` (today stops after one model/tool cycle — `stopAfterCycle: true` — bench needs a multi-cycle variant, tracked as an MVP gap) |
-| Compile gate / diff / structure   | `src/agent/output/compileCheck.ts`, `src/latex/latexdiff/`, `src/latex/latexToolchain.ts`, `src/latex/labelSearch.ts`, `src/latex/extractBibliography.ts` |
-| CAS / Lean verifiers              | `src/tools/wolfram/wolframScriptUtils.ts`, `src/tools/lean/direct/lakeCommands.ts`, `src/tools/lean/LspTools.ts`, `src/tools/lean/LoogleTool.ts`          |
-| Issue localization                | `src/agent/review/reviewIssues.ts`; solver pattern from `packages/extension/resources/tool_use_agents/changeReviewer.yaml`            |
-| Fresh-task supply                 | `src/latex/arxivProcessor.ts`                                                                                                         |
-| Trace archive                     | `AgentTrace` subscriber (`src/agent/trace/AgentTrace.ts`, pattern: `src/transcript/TexraTranscriptRecorder.ts`); `AgentEvent` union    |
-| Usage / cost / abort              | `src/agent/core/usage/RunUsageAccumulator.ts` (`totalCost` drives `--max-cost-usd`, checked between dispatches — a soft budget guard under concurrency, not a per-cell reservation) |
-| Providers incl. internal gateways | `src/agent/modelHandlers/` (four stacks; `customBaseUrl` already threaded)                                                            |
-| Solver/judge agents               | ordinary agent YAML under `packages/extension/resources/agents/bench/`, run via `runAgent` (`src/agent/runtime/runAgent.ts`)          |
-| Env fingerprint                   | `texra doctor` machinery (`packages/cli/src/commands/doctor.ts`) — today probes Node/workspace/auth/LaTeX/config; Wolfram/lake/image-digest probes are new additions, not built yet |
+| Compile gate / diff / structure   | `src/agent/output/compileCheck.ts`, `src/latex/latexdiff/`, `src/latex/latexToolchain.ts`, `src/latex/labelSearch.ts`, `src/latex/extractBibliography.ts`                                                                           |
+| CAS / Lean verifiers              | `src/tools/wolfram/wolframScriptUtils.ts`, `src/tools/lean/direct/lakeCommands.ts`, `src/tools/lean/LspTools.ts`, `src/tools/lean/LoogleTool.ts`                                                                                    |
+| Issue localization                | `src/agent/review/reviewIssues.ts`; solver pattern from `packages/extension/resources/tool_use_agents/changeReviewer.yaml`                                                                                                          |
+| Fresh-task supply                 | `src/latex/arxivProcessor.ts`                                                                                                                                                                                                       |
+| Trace archive                     | `AgentTrace` subscriber (`src/agent/trace/AgentTrace.ts`, pattern: `src/transcript/TexraTranscriptRecorder.ts`); `AgentEvent` union                                                                                                 |
+| Usage / cost / abort              | `src/agent/core/usage/RunUsageAccumulator.ts` (`totalCost` drives `--max-cost-usd`, checked between dispatches — a soft budget guard under concurrency, not a per-cell reservation)                                                 |
+| Providers incl. internal gateways | `src/agent/modelHandlers/` (four stacks; `customBaseUrl` already threaded)                                                                                                                                                          |
+| Solver/judge agents               | ordinary agent YAML under `packages/extension/resources/agents/bench/`, run via `runAgent` (`src/agent/runtime/runAgent.ts`)                                                                                                        |
+| Env fingerprint                   | `texra doctor` machinery (`packages/cli/src/commands/doctor.ts`) — today probes Node/workspace/auth/LaTeX/config; Wolfram/lake/image-digest probes are new additions, not built yet                                                 |
 
 All additive: new code lives in `src/bench/` (VS Code-free zone, host services via `platform()`) and `packages/cli/`. **The MVP requires zero changes to `src/agent/` core.**
 

--- a/src/model/providerCapabilities.ts
+++ b/src/model/providerCapabilities.ts
@@ -107,14 +107,24 @@ const CODEX_DEPRECATED_EXCEPTIONS: ReadonlySet<string> = new Set(['gpt-5.4']);
  * just by callers) since this function is exported and a future call site
  * passing a non-OpenAI `ModelConfig` must not resolve eligible just because
  * its `reasoningEffort` or id happens to match.
+ *
+ * `retired` (pulled from availability entirely) is checked *before* the
+ * `/codex/i` naming test and has no exception carve-out, so a `-codex`-named
+ * model that gets retired (e.g. a successor ships and the old one is pulled)
+ * is rejected the same as any other retired model — naming alone must never
+ * override a hard "no longer served" signal. `deprecated` (merely
+ * superseded) is checked *after* the naming test on purpose: Codex-branded
+ * releases are documented above as continuing to serve under their name even
+ * once deprecated, so the naming match intentionally bypasses the
+ * deprecated-exclusion for those still-live models.
  */
 export function isCodexSubscriptionEligible(model: ModelConfig): boolean {
   if (model.provider !== ModelProvider.OPENAI) return false;
 
   const unpinnedName = codexBackendModelId(model);
   if (CODEX_INELIGIBLE_EXCEPTIONS.has(unpinnedName)) return false;
-  if (/codex/i.test(unpinnedName)) return true;
   if (model.retired) return false;
+  if (/codex/i.test(unpinnedName)) return true;
   if (model.deprecated && !CODEX_DEPRECATED_EXCEPTIONS.has(unpinnedName)) {
     return false;
   }

--- a/src/model/providerCapabilities.ts
+++ b/src/model/providerCapabilities.ts
@@ -1,4 +1,4 @@
-import { ModelProvider, type ModelConfig } from 'llm-zoo';
+import { ModelProvider, ReasoningEffort, type ModelConfig } from 'llm-zoo';
 
 import type { UsageRoute } from '@shared/schemas';
 
@@ -38,20 +38,6 @@ type ProviderCapabilityResolver = (
 /** Context window the ChatGPT-subscription (Codex) backend enforces. */
 export const CODEX_SUBSCRIPTION_CONTEXT_WINDOW = 272_000;
 
-/**
- * OpenAI models the Codex backend currently serves to ChatGPT subscribers. This
- * is a hardcoded mirror of openai/codex's bundled models.json picker set and
- * WILL go stale; the backend also rejects models above the account's tier.
- */
-const CODEX_SUBSCRIPTION_MODEL_FULLNAMES: ReadonlySet<string> = new Set([
-  'gpt-5.5',
-  'gpt-5.4',
-  'gpt-5.4-mini',
-  'gpt-5.3-codex-spark',
-  'gpt-5.3-codex',
-  'gpt-5.2-codex',
-]);
-
 /** Trailing llm-zoo date pin (`-2026-04-23`) on a model `fullName`. */
 const CODEX_MODEL_DATE_PIN = /-\d{4}-\d{2}-\d{2}$/;
 
@@ -67,14 +53,29 @@ export function codexBackendModelId(config: {
 }
 
 /**
- * Whether a model id is eligible to route through the ChatGPT subscription.
- * True for the curated set above, date-pinned variants of those ids, or any
- * `*-codex*` name so newer Codex models are picked up without a code change.
+ * Whether `model` is eligible to route through the ChatGPT-subscription
+ * (Codex) backend.
+ *
+ * `llm-zoo` has no dedicated Codex-eligibility capability flag yet (and
+ * probing the live Codex models endpoint at refresh time is out of scope
+ * here), so this derives eligibility from registry data every OpenAI
+ * `ModelConfig` already carries instead of a hand-maintained fullName
+ * allowlist: Codex serves OpenAI's current top-reasoning-effort chat models
+ * (`capabilities.reasoningEffort === XHIGH`) that haven't been superseded or
+ * pulled (`deprecated`/`retired`), plus — as an explicit naming convention —
+ * any model whose id contains "codex", since OpenAI's own dedicated
+ * Codex-branded releases (e.g. `gpt-5.3-codex`) keep shipping under that
+ * name even after they're marked `deprecated` in favor of a newer one. A new
+ * top-effort OpenAI release resolves eligible the moment `llm-zoo` ships it,
+ * with no hardcoded edit needed here. Over-matching a model the real backend
+ * doesn't actually serve is a benign false positive: the backend is the
+ * actual gate and rejects models outside the account's tier at request time.
  */
-export function isCodexSubscriptionEligible(fullName: string): boolean {
-  const unpinnedName = fullName.replace(CODEX_MODEL_DATE_PIN, '');
-  if (CODEX_SUBSCRIPTION_MODEL_FULLNAMES.has(unpinnedName)) return true;
-  return /codex/i.test(fullName);
+export function isCodexSubscriptionEligible(model: ModelConfig): boolean {
+  const unpinnedName = codexBackendModelId(model);
+  if (/codex/i.test(unpinnedName)) return true;
+  if (model.deprecated || model.retired) return false;
+  return model.capabilities.reasoningEffort === ReasoningEffort.XHIGH;
 }
 
 const resolveChatGptSubscriptionCapabilities: ProviderCapabilityResolver = ({
@@ -84,7 +85,7 @@ const resolveChatGptSubscriptionCapabilities: ProviderCapabilityResolver = ({
   if (useOpenRouter) return null;
   if (model.provider !== ModelProvider.OPENAI) return null;
   if (model.openRouterOnly) return null;
-  if (!isCodexSubscriptionEligible(codexBackendModelId(model))) return null;
+  if (!isCodexSubscriptionEligible(model)) return null;
 
   return {
     authMode: 'chatgpt-subscription',

--- a/src/model/providerCapabilities.ts
+++ b/src/model/providerCapabilities.ts
@@ -53,7 +53,7 @@ export function codexBackendModelId(config: {
 }
 
 /**
- * Known false positive: an OpenAI model the registry-derived heuristic below
+ * Known false positives: an OpenAI model the registry-derived heuristic below
  * would mark eligible (top reasoning-effort tier, live, non-`codex` name),
  * but that the Codex backend does not actually serve. `gpt-5.4-nano` is
  * API-only — routing it through `/codex/responses` fails at request time
@@ -61,26 +61,76 @@ export function codexBackendModelId(config: {
  * rather than left for the backend to reject. Keyed on
  * {@link codexBackendModelId} (shortName, or date-unpinned fullName) so a
  * llm-zoo date-pin bump doesn't silently drop the exception.
+ *
+ * This is deliberately a narrow, per-id table for one-off quirks — the
+ * *systematic* "Pro" tier exclusion below ({@link CODEX_PRO_VARIANT_PATTERN})
+ * is kept separate since it's a naming rule, not an enumerable exception.
  */
 const CODEX_INELIGIBLE_EXCEPTIONS: ReadonlySet<string> = new Set([
   'gpt-5.4-nano',
 ]);
 
 /**
+ * OpenAI's "Pro" tier (e.g. `o1-pro`, `o3-pro`, `gpt-5-pro`, `gpt-5.2-pro`,
+ * `gpt-5.4-pro`, `gpt-5.5-pro`) is a heavier-compute, ChatGPT/API-only
+ * sibling of its base release — not a distinct Codex product. A Pro model
+ * typically reports the same top reasoning-effort tier as its non-Pro
+ * sibling (`gpt-5.5-pro` is `XHIGH`, same as `gpt-5.5`), so without this
+ * guard the reasoning-effort-tier branch below would mark it eligible and
+ * `ModelFactory` would route it to `ModelHandlerCodex`, where the backend
+ * rejects it (a ChatGPT subscription entitles the account to the base model,
+ * not its Pro sibling) — misrouting a request that would otherwise have
+ * worked fine over the normal API-key path.
+ *
+ * llm-zoo's `ModelConfig` (checked at v1.12.0, the version this repo pins)
+ * has no dedicated tier/variant field to key on instead. Every Pro release
+ * to date follows the same `<base>-pro` id suffix, though, so this is a
+ * systematic naming pattern — covering future Pro releases the moment
+ * llm-zoo ships them — rather than a per-id table like
+ * {@link CODEX_INELIGIBLE_EXCEPTIONS}. Matched against
+ * {@link codexBackendModelId} (shortName, or date-unpinned fullName), and
+ * checked unconditionally ahead of every other branch (including the
+ * `/codex/i` naming test): a Pro variant must never resolve eligible
+ * regardless of reasoning tier or a coincidental `codex` substring in its id.
+ */
+const CODEX_PRO_VARIANT_PATTERN = /-pro$/i;
+
+/**
  * Known false negative: an OpenAI model the registry marks merely
  * `deprecated` (superseded by a newer release, not pulled) that the Codex
  * backend still actually serves. The old hand-maintained fullName allowlist
- * this heuristic replaced still routed `gpt-5.4` through the ChatGPT
- * subscription after `gpt-5.5` shipped; treating every `deprecated` model as
- * ineligible would regress that. `deprecated` still disqualifies by default
- * — only these explicit, known-still-served exceptions bypass it. Keyed on
- * {@link codexBackendModelId}.
+ * this heuristic replaced still routed `gpt-5.4` and `gpt-5.4-mini` through
+ * the ChatGPT subscription after `gpt-5.5` shipped; treating every
+ * `deprecated` model as ineligible would regress that. `deprecated` still
+ * disqualifies by default — only these explicit, known-still-served
+ * exceptions bypass it. Keyed on {@link codexBackendModelId}.
+ *
+ * `gpt-5.4-mini` is included here even though it isn't `deprecated` in the
+ * live llm-zoo registry as of this writing (only `gpt-5.4` is) — the old
+ * allowlist's test coverage explicitly asserted `gpt-5.4-mini` as eligible,
+ * so this exception is added defensively now rather than waiting for it to
+ * flip to `deprecated` upstream and silently regress. It's a no-op today
+ * (the `deprecated` branch below never triggers for it) and becomes load
+ * bearing the moment llm-zoo marks it deprecated.
+ *
+ * Cross-checked against every entry of the original hardcoded
+ * `CODEX_SUBSCRIPTION_MODEL_FULLNAMES` allowlist this heuristic replaced:
+ * `gpt-5.5` and `gpt-5.4-mini` (not deprecated) and `gpt-5.3-codex` /
+ * `gpt-5.2-codex` (deprecated, but bypassed by the `/codex/i` naming branch
+ * regardless of this table) all resolve eligible without needing an entry
+ * here. `gpt-5.3-codex-spark` no longer exists in the llm-zoo v1.12.0
+ * registry under any id, so there is nothing to reconcile for it.
  */
-const CODEX_DEPRECATED_EXCEPTIONS: ReadonlySet<string> = new Set(['gpt-5.4']);
+const CODEX_DEPRECATED_EXCEPTIONS: ReadonlySet<string> = new Set([
+  'gpt-5.4',
+  'gpt-5.4-mini',
+]);
 
 /**
  * Whether `model` is eligible to route through the ChatGPT-subscription
  * (Codex) backend.
+ *
+ * ## The general rule (registry-derived heuristic)
  *
  * `llm-zoo` has no dedicated Codex-eligibility capability flag yet (and
  * probing the live Codex models endpoint at refresh time is out of scope
@@ -95,34 +145,52 @@ const CODEX_DEPRECATED_EXCEPTIONS: ReadonlySet<string> = new Set(['gpt-5.4']);
  * of a newer one. A new top-effort OpenAI release resolves eligible the
  * moment `llm-zoo` ships it, with no hardcoded edit needed here.
  *
- * A pure heuristic can't fully replace a curated list, though: it both
- * over-matches models the backend doesn't actually serve and under-matches
- * ones still served despite a `deprecated` flag. {@link
- * CODEX_INELIGIBLE_EXCEPTIONS} and {@link CODEX_DEPRECATED_EXCEPTIONS} layer
- * a small, explicitly-commented set of known exceptions on top of the
- * heuristic for those two cases; everything else still resolves
- * automatically as the registry evolves.
- *
  * Requires `model.provider === ModelProvider.OPENAI` — asserted here (not
  * just by callers) since this function is exported and a future call site
  * passing a non-OpenAI `ModelConfig` must not resolve eligible just because
  * its `reasoningEffort` or id happens to match.
  *
- * `retired` (pulled from availability entirely) is checked *before* the
- * `/codex/i` naming test and has no exception carve-out, so a `-codex`-named
- * model that gets retired (e.g. a successor ships and the old one is pulled)
- * is rejected the same as any other retired model — naming alone must never
- * override a hard "no longer served" signal. `deprecated` (merely
- * superseded) is checked *after* the naming test on purpose: Codex-branded
- * releases are documented above as continuing to serve under their name even
- * once deprecated, so the naming match intentionally bypasses the
- * deprecated-exclusion for those still-live models.
+ * ## The exception tables (today's known quirks)
+ *
+ * A pure heuristic can't fully replace a curated list: it both over-matches
+ * models the backend doesn't actually serve and under-matches ones still
+ * served despite a `deprecated` flag. Three explicitly-commented tables
+ * layer known exceptions on top of the heuristic, each checked and cross-
+ * referenced against the original hand-maintained allowlist this heuristic
+ * replaced (see each table's own doc comment for the reconciliation):
+ *
+ * - {@link CODEX_INELIGIBLE_EXCEPTIONS} — per-id false positives that match
+ *   the heuristic but aren't Codex-served (e.g. `gpt-5.4-nano`, API-only).
+ * - {@link CODEX_PRO_VARIANT_PATTERN} — a systematic (not per-id) false-
+ *   positive exclusion for the "Pro" tier, which shares its sibling's
+ *   reasoning-effort tier but isn't served by Codex.
+ * - {@link CODEX_DEPRECATED_EXCEPTIONS} — per-id false negatives: models the
+ *   registry marks `deprecated` that Codex still actually serves (e.g.
+ *   `gpt-5.4`, `gpt-5.4-mini`).
+ *
+ * Everything else still resolves automatically as the registry evolves.
+ *
+ * ## Branch ordering
+ *
+ * `CODEX_INELIGIBLE_EXCEPTIONS` and `CODEX_PRO_VARIANT_PATTERN` are checked
+ * first and unconditionally — a known-bad or Pro-tier id must never resolve
+ * eligible no matter what any later branch would say. `retired` (pulled from
+ * availability entirely) is checked next, *before* the `/codex/i` naming
+ * test, and has no exception carve-out, so a `-codex`-named model that gets
+ * retired (e.g. a successor ships and the old one is pulled) is rejected the
+ * same as any other retired model — naming alone must never override a hard
+ * "no longer served" signal. `deprecated` (merely superseded) is checked
+ * *after* the naming test on purpose: Codex-branded releases are documented
+ * above as continuing to serve under their name even once deprecated, so the
+ * naming match intentionally bypasses the deprecated-exclusion for those
+ * still-live models.
  */
 export function isCodexSubscriptionEligible(model: ModelConfig): boolean {
   if (model.provider !== ModelProvider.OPENAI) return false;
 
   const unpinnedName = codexBackendModelId(model);
   if (CODEX_INELIGIBLE_EXCEPTIONS.has(unpinnedName)) return false;
+  if (CODEX_PRO_VARIANT_PATTERN.test(unpinnedName)) return false;
   if (model.retired) return false;
   if (/codex/i.test(unpinnedName)) return true;
   if (model.deprecated && !CODEX_DEPRECATED_EXCEPTIONS.has(unpinnedName)) {

--- a/src/model/providerCapabilities.ts
+++ b/src/model/providerCapabilities.ts
@@ -53,6 +53,32 @@ export function codexBackendModelId(config: {
 }
 
 /**
+ * Known false positive: an OpenAI model the registry-derived heuristic below
+ * would mark eligible (top reasoning-effort tier, live, non-`codex` name),
+ * but that the Codex backend does not actually serve. `gpt-5.4-nano` is
+ * API-only — routing it through `/codex/responses` fails at request time
+ * instead of using the normal API-key path, so it must be excluded outright
+ * rather than left for the backend to reject. Keyed on
+ * {@link codexBackendModelId} (shortName, or date-unpinned fullName) so a
+ * llm-zoo date-pin bump doesn't silently drop the exception.
+ */
+const CODEX_INELIGIBLE_EXCEPTIONS: ReadonlySet<string> = new Set([
+  'gpt-5.4-nano',
+]);
+
+/**
+ * Known false negative: an OpenAI model the registry marks merely
+ * `deprecated` (superseded by a newer release, not pulled) that the Codex
+ * backend still actually serves. The old hand-maintained fullName allowlist
+ * this heuristic replaced still routed `gpt-5.4` through the ChatGPT
+ * subscription after `gpt-5.5` shipped; treating every `deprecated` model as
+ * ineligible would regress that. `deprecated` still disqualifies by default
+ * — only these explicit, known-still-served exceptions bypass it. Keyed on
+ * {@link codexBackendModelId}.
+ */
+const CODEX_DEPRECATED_EXCEPTIONS: ReadonlySet<string> = new Set(['gpt-5.4']);
+
+/**
  * Whether `model` is eligible to route through the ChatGPT-subscription
  * (Codex) backend.
  *
@@ -61,21 +87,42 @@ export function codexBackendModelId(config: {
  * here), so this derives eligibility from registry data every OpenAI
  * `ModelConfig` already carries instead of a hand-maintained fullName
  * allowlist: Codex serves OpenAI's current top-reasoning-effort chat models
- * (`capabilities.reasoningEffort === XHIGH`) that haven't been superseded or
- * pulled (`deprecated`/`retired`), plus — as an explicit naming convention —
- * any model whose id contains "codex", since OpenAI's own dedicated
- * Codex-branded releases (e.g. `gpt-5.3-codex`) keep shipping under that
- * name even after they're marked `deprecated` in favor of a newer one. A new
- * top-effort OpenAI release resolves eligible the moment `llm-zoo` ships it,
- * with no hardcoded edit needed here. Over-matching a model the real backend
- * doesn't actually serve is a benign false positive: the backend is the
- * actual gate and rejects models outside the account's tier at request time.
+ * (`capabilities.reasoningEffort` at `XHIGH` or the higher `MAX` tier) that
+ * haven't been pulled (`retired`) or superseded (`deprecated`), plus — as an
+ * explicit naming convention — any model whose id contains "codex", since
+ * OpenAI's own dedicated Codex-branded releases (e.g. `gpt-5.3-codex`) keep
+ * shipping under that name even after they're marked `deprecated` in favor
+ * of a newer one. A new top-effort OpenAI release resolves eligible the
+ * moment `llm-zoo` ships it, with no hardcoded edit needed here.
+ *
+ * A pure heuristic can't fully replace a curated list, though: it both
+ * over-matches models the backend doesn't actually serve and under-matches
+ * ones still served despite a `deprecated` flag. {@link
+ * CODEX_INELIGIBLE_EXCEPTIONS} and {@link CODEX_DEPRECATED_EXCEPTIONS} layer
+ * a small, explicitly-commented set of known exceptions on top of the
+ * heuristic for those two cases; everything else still resolves
+ * automatically as the registry evolves.
+ *
+ * Requires `model.provider === ModelProvider.OPENAI` — asserted here (not
+ * just by callers) since this function is exported and a future call site
+ * passing a non-OpenAI `ModelConfig` must not resolve eligible just because
+ * its `reasoningEffort` or id happens to match.
  */
 export function isCodexSubscriptionEligible(model: ModelConfig): boolean {
+  if (model.provider !== ModelProvider.OPENAI) return false;
+
   const unpinnedName = codexBackendModelId(model);
+  if (CODEX_INELIGIBLE_EXCEPTIONS.has(unpinnedName)) return false;
   if (/codex/i.test(unpinnedName)) return true;
-  if (model.deprecated || model.retired) return false;
-  return model.capabilities.reasoningEffort === ReasoningEffort.XHIGH;
+  if (model.retired) return false;
+  if (model.deprecated && !CODEX_DEPRECATED_EXCEPTIONS.has(unpinnedName)) {
+    return false;
+  }
+
+  return (
+    model.capabilities.reasoningEffort === ReasoningEffort.XHIGH ||
+    model.capabilities.reasoningEffort === ReasoningEffort.MAX
+  );
 }
 
 const resolveChatGptSubscriptionCapabilities: ProviderCapabilityResolver = ({

--- a/src/model/setupModelDefaults.ts
+++ b/src/model/setupModelDefaults.ts
@@ -1,9 +1,6 @@
 import { MODEL_CONFIGS, ModelProvider, type ModelConfig } from 'llm-zoo';
 
-import {
-  codexBackendModelId,
-  isCodexSubscriptionEligible,
-} from './providerCapabilities';
+import { isCodexSubscriptionEligible } from './providerCapabilities';
 
 /**
  * Curated setup-probe model per provider — a well-known model used to verify
@@ -61,7 +58,7 @@ function isUsableSetupModel(
   // Codex-eligible model ids — keep the openai pick constrained so a
   // fallback swap can't silently break ChatGPT-subscription setup.
   if (setupProvider === 'openai') {
-    return isCodexSubscriptionEligible(codexBackendModelId(config));
+    return isCodexSubscriptionEligible(config);
   }
   return true;
 }

--- a/src/test-kernel/agent/modelHandlers/CodexEncryptedReasoning.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/CodexEncryptedReasoning.vitest.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_MODEL_CAPABILITIES,
   type ModelConfig,
   ModelProvider,
+  ReasoningEffort,
 } from 'llm-zoo';
 
 import { setupPlatform } from '@test/support/setupPlatform';
@@ -34,7 +35,13 @@ function config(): ModelConfig {
     inputPrice: 0,
     outputPrice: 0,
     contextWindow: 200_000,
-    capabilities: { ...DEFAULT_MODEL_CAPABILITIES, supportsReasoning: true },
+    // Codex eligibility is derived from the top reasoning-effort tier (see
+    // providerCapabilities.ts), not from a hardcoded fullName allowlist.
+    capabilities: {
+      ...DEFAULT_MODEL_CAPABILITIES,
+      supportsReasoning: true,
+      reasoningEffort: ReasoningEffort.XHIGH,
+    },
     openRouterOnly: false,
   };
 }

--- a/src/test-kernel/agent/modelHandlers/CodexExperimentalTransports.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/CodexExperimentalTransports.vitest.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   DEFAULT_MODEL_CAPABILITIES,
   ModelProvider,
+  ReasoningEffort,
   type ModelConfig,
 } from 'llm-zoo';
 
@@ -33,7 +34,13 @@ function config(): ModelConfig {
     inputPrice: 0,
     outputPrice: 0,
     contextWindow: 200_000,
-    capabilities: { ...DEFAULT_MODEL_CAPABILITIES, supportsReasoning: true },
+    // Codex eligibility is derived from the top reasoning-effort tier (see
+    // providerCapabilities.ts), not from a hardcoded fullName allowlist.
+    capabilities: {
+      ...DEFAULT_MODEL_CAPABILITIES,
+      supportsReasoning: true,
+      reasoningEffort: ReasoningEffort.XHIGH,
+    },
     openRouterOnly: false,
   };
 }

--- a/src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   DEFAULT_MODEL_CAPABILITIES,
   ModelProvider,
+  ReasoningEffort,
   type ModelConfig,
 } from 'llm-zoo';
 
@@ -39,7 +40,12 @@ const config: ModelConfig = {
   inputPrice: 2,
   outputPrice: 8,
   contextWindow: 128_000,
-  capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
+  // Codex eligibility is derived from the top reasoning-effort tier (see
+  // providerCapabilities.ts), not from a hardcoded fullName allowlist.
+  capabilities: {
+    ...DEFAULT_MODEL_CAPABILITIES,
+    reasoningEffort: ReasoningEffort.XHIGH,
+  },
   openRouterOnly: false,
 };
 

--- a/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_MODEL_CAPABILITIES,
   MODEL_CONFIGS,
   ModelProvider,
+  ReasoningEffort,
   type ModelConfig,
 } from 'llm-zoo';
 
@@ -183,10 +184,14 @@ describe('OpenAI model handler routing', () => {
   });
 
   const codexEligibleConfig: ModelConfig = {
-    ...modelConfig(ModelProvider.OPENAI),
+    ...modelConfig(ModelProvider.OPENAI, {
+      reasoningEffort: ReasoningEffort.XHIGH,
+    }),
     name: 'gpt55-test',
     // Date-pinned fullName (as llm-zoo really ships) with the unpinned shortName
-    // the Codex backend + eligibility key on. Guards the short-name matching.
+    // the Codex backend keys on. Codex eligibility itself is derived from the
+    // top reasoning-effort tier (see providerCapabilities.ts), independent of
+    // this shortName/date-pin pair.
     fullName: 'gpt-5.5-2026-04-23',
     shortName: 'gpt-5.5',
     requiresResponsesAPI: true,

--- a/src/test-kernel/auth/CodexPkce.vitest.ts
+++ b/src/test-kernel/auth/CodexPkce.vitest.ts
@@ -1,6 +1,12 @@
 import { createHash } from 'node:crypto';
 
 import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_MODEL_CAPABILITIES,
+  ModelProvider,
+  ReasoningEffort,
+  type ModelConfig,
+} from 'llm-zoo';
 
 import {
   computeCodeChallenge,
@@ -9,6 +15,24 @@ import {
   generatePkcePair,
 } from '@auth/codex';
 import { isCodexSubscriptionEligible } from '@model/providerCapabilities';
+
+/** A minimal OpenAI `ModelConfig` fixture, overridable per test. */
+function openAIModel(overrides: Partial<ModelConfig> = {}): ModelConfig {
+  return {
+    name: 'test-model',
+    label: 'Test Model',
+    fullName: 'gpt-test',
+    shortName: 'gpt-test',
+    provider: ModelProvider.OPENAI,
+    maxOutputTokens: 128_000,
+    inputPrice: 1,
+    outputPrice: 1,
+    contextWindow: 400_000,
+    capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
+    openRouterOnly: false,
+    ...overrides,
+  };
+}
 
 const BASE64URL = /^[A-Za-z0-9_-]+$/;
 
@@ -47,22 +71,93 @@ describe('codex PKCE', () => {
 });
 
 describe('codex model eligibility', () => {
-  it('accepts the curated subscription models', () => {
-    expect(isCodexSubscriptionEligible('gpt-5.5')).toBe(true);
-    expect(isCodexSubscriptionEligible('gpt-5.4-mini')).toBe(true);
+  it('accepts current top-reasoning-effort OpenAI models', () => {
+    expect(
+      isCodexSubscriptionEligible(
+        openAIModel({
+          fullName: 'gpt-5.5-2026-04-23',
+          shortName: 'gpt-5.5',
+          capabilities: {
+            ...DEFAULT_MODEL_CAPABILITIES,
+            reasoningEffort: ReasoningEffort.XHIGH,
+          },
+        }),
+      ),
+    ).toBe(true);
   });
 
   it('accepts date-pinned variants of curated models', () => {
-    expect(isCodexSubscriptionEligible('gpt-5.5-2026-04-23')).toBe(true);
+    expect(
+      isCodexSubscriptionEligible(
+        openAIModel({
+          fullName: 'gpt-5.5-2026-04-23',
+          shortName: '',
+          capabilities: {
+            ...DEFAULT_MODEL_CAPABILITIES,
+            reasoningEffort: ReasoningEffort.XHIGH,
+          },
+        }),
+      ),
+    ).toBe(true);
   });
 
-  it('accepts any codex-named model (future-proof)', () => {
-    expect(isCodexSubscriptionEligible('gpt-5.9-codex')).toBe(true);
-    expect(isCodexSubscriptionEligible('gpt-6-codex-mini')).toBe(true);
+  it('accepts any codex-named model regardless of reasoning effort (future-proof)', () => {
+    expect(
+      isCodexSubscriptionEligible(
+        openAIModel({ fullName: 'gpt-5.9-codex', shortName: 'gpt-5.9-codex' }),
+      ),
+    ).toBe(true);
+    expect(
+      isCodexSubscriptionEligible(
+        openAIModel({
+          fullName: 'gpt-6-codex-mini',
+          shortName: 'gpt-6-codex-mini',
+        }),
+      ),
+    ).toBe(true);
   });
 
-  it('rejects unrelated models', () => {
-    expect(isCodexSubscriptionEligible('gpt-4.1')).toBe(false);
-    expect(isCodexSubscriptionEligible('claude-opus-4-8')).toBe(false);
+  it('rejects models that are not top reasoning-effort tier', () => {
+    expect(
+      isCodexSubscriptionEligible(
+        openAIModel({ fullName: 'gpt-4.1', shortName: 'gpt-4.1' }),
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects a top-reasoning-effort model that has been retired', () => {
+    expect(
+      isCodexSubscriptionEligible(
+        openAIModel({
+          fullName: 'gpt-5.2-2025-12-11',
+          shortName: 'gpt-5.2',
+          retired: true,
+          capabilities: {
+            ...DEFAULT_MODEL_CAPABILITIES,
+            reasoningEffort: ReasoningEffort.XHIGH,
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  // #7192: the eligibility check must not depend on a hand-maintained
+  // fullName allowlist. `gpt-5.6` never existed in that old list and doesn't
+  // match the `/codex/i` naming convention either, so this can only pass if
+  // eligibility is genuinely derived from registry capability data (top
+  // reasoning-effort tier, live, not deprecated) rather than enumeration.
+  it('accepts a future top-reasoning-effort model absent from any hardcoded list', () => {
+    expect(
+      isCodexSubscriptionEligible(
+        openAIModel({
+          fullName: 'gpt-5.6-2026-08-01',
+          shortName: 'gpt-5.6',
+          capabilities: {
+            ...DEFAULT_MODEL_CAPABILITIES,
+            reasoningEffort: ReasoningEffort.XHIGH,
+          },
+        }),
+      ),
+    ).toBe(true);
   });
 });

--- a/src/test-kernel/auth/CodexPkce.vitest.ts
+++ b/src/test-kernel/auth/CodexPkce.vitest.ts
@@ -255,4 +255,22 @@ describe('codex model eligibility', () => {
       ),
     ).toBe(false);
   });
+
+  // #7223 follow-up: the `retired` guard must apply uniformly regardless of
+  // which branch would otherwise resolve eligibility. A `-codex`-named model
+  // (e.g. gpt-5.2-codex, pulled after gpt-5.3-codex ships) must be rejected
+  // once retired — the naming convention must not let a pulled model bypass
+  // the same "no longer served" check a same-retired non-codex-named model
+  // correctly fails.
+  it('rejects a retired codex-named model despite matching the naming convention', () => {
+    expect(
+      isCodexSubscriptionEligible(
+        openAIModel({
+          fullName: 'gpt-5.2-codex-2025-12-11',
+          shortName: 'gpt-5.2-codex',
+          retired: true,
+        }),
+      ),
+    ).toBe(false);
+  });
 });

--- a/src/test-kernel/auth/CodexPkce.vitest.ts
+++ b/src/test-kernel/auth/CodexPkce.vitest.ts
@@ -273,4 +273,66 @@ describe('codex model eligibility', () => {
       ),
     ).toBe(false);
   });
+
+  // #7223 round 3: the old hardcoded `CODEX_SUBSCRIPTION_MODEL_FULLNAMES`
+  // allowlist also listed `gpt-5.4-mini` as Codex-eligible. This exception is
+  // added defensively to `CODEX_DEPRECATED_EXCEPTIONS` even though the live
+  // llm-zoo registry doesn't currently mark it deprecated, so a future
+  // registry update marking it deprecated (once gpt-5.5 or a successor fully
+  // supersedes it) can't silently regress its eligibility the way `gpt-5.4`
+  // itself would have without an exception entry.
+  it('accepts the deprecated-but-still-served gpt-5.4-mini false negative', () => {
+    expect(
+      isCodexSubscriptionEligible(
+        openAIModel({
+          fullName: 'gpt-5.4-mini-2026-03-17',
+          shortName: 'gpt-5.4-mini',
+          deprecated: true,
+          capabilities: {
+            ...DEFAULT_MODEL_CAPABILITIES,
+            reasoningEffort: ReasoningEffort.XHIGH,
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  // #7223 round 3: a "Pro" tier variant (e.g. `gpt-5.5-pro`) reports the same
+  // top reasoning-effort tier as its non-Pro sibling, but the Codex backend
+  // does not serve Pro models — only the base release is covered by a
+  // ChatGPT subscription. This must resolve ineligible despite matching the
+  // reasoning-effort-tier heuristic.
+  it('rejects the gpt-5.5-pro false positive despite matching the heuristic', () => {
+    expect(
+      isCodexSubscriptionEligible(
+        openAIModel({
+          fullName: 'gpt-5.5-pro-2026-04-23',
+          shortName: 'gpt-5.5-pro',
+          capabilities: {
+            ...DEFAULT_MODEL_CAPABILITIES,
+            reasoningEffort: ReasoningEffort.XHIGH,
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  // #7223 round 3: the Pro-tier exclusion is a systematic naming rule, not a
+  // per-id table — a future Pro release absent from any hardcoded list must
+  // also resolve ineligible, the same way a future top-effort base release
+  // (tested above) resolves eligible without a hardcoded edit.
+  it('rejects a future Pro-variant id absent from any hardcoded list', () => {
+    expect(
+      isCodexSubscriptionEligible(
+        openAIModel({
+          fullName: 'gpt-5.9-pro-2027-01-01',
+          shortName: 'gpt-5.9-pro',
+          capabilities: {
+            ...DEFAULT_MODEL_CAPABILITIES,
+            reasoningEffort: ReasoningEffort.MAX,
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
 });

--- a/src/test-kernel/auth/CodexPkce.vitest.ts
+++ b/src/test-kernel/auth/CodexPkce.vitest.ts
@@ -160,4 +160,99 @@ describe('codex model eligibility', () => {
       ),
     ).toBe(true);
   });
+
+  // #7223: ReasoningEffort has a tier above XHIGH (MAX, clamped to 'xhigh' on
+  // the OpenAI wire by toOpenAIReasoningEffort) — a registry model reporting
+  // MAX must resolve eligible too, not just XHIGH.
+  it('accepts a MAX-reasoning-effort OpenAI model', () => {
+    expect(
+      isCodexSubscriptionEligible(
+        openAIModel({
+          fullName: 'gpt-5.7-2026-09-01',
+          shortName: 'gpt-5.7',
+          capabilities: {
+            ...DEFAULT_MODEL_CAPABILITIES,
+            reasoningEffort: ReasoningEffort.MAX,
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  // #7223: a non-OpenAI ModelConfig must never resolve eligible even if its
+  // reasoningEffort/id would otherwise match — the provider guard must live
+  // inside the function itself, not only in callers.
+  it('rejects a non-OpenAI model even at top reasoning-effort tier', () => {
+    expect(
+      isCodexSubscriptionEligible(
+        openAIModel({
+          provider: ModelProvider.ANTHROPIC,
+          fullName: 'claude-codex-lookalike',
+          shortName: 'claude-codex-lookalike',
+          capabilities: {
+            ...DEFAULT_MODEL_CAPABILITIES,
+            reasoningEffort: ReasoningEffort.XHIGH,
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  // #7223: gpt-5.4-nano is OpenAI + XHIGH + live per the llm-zoo registry, so
+  // the naive heuristic marks it eligible, but it's an API-only variant the
+  // Codex backend does not actually serve — routing it there would fail at
+  // request time instead of using the normal API-key path.
+  it('rejects the gpt-5.4-nano false positive despite matching the heuristic', () => {
+    expect(
+      isCodexSubscriptionEligible(
+        openAIModel({
+          fullName: 'gpt-5.4-nano-2026-03-17',
+          shortName: 'gpt-5.4-nano',
+          capabilities: {
+            ...DEFAULT_MODEL_CAPABILITIES,
+            reasoningEffort: ReasoningEffort.XHIGH,
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  // #7223: gpt-5.4 is deprecated (superseded by gpt-5.5) but the Codex
+  // backend still actually serves it — the old hardcoded allowlist this
+  // heuristic replaced still routed it through the ChatGPT subscription, so
+  // a bare deprecated-excludes-all rule would be a real regression.
+  it('accepts the deprecated-but-still-served gpt-5.4 false negative', () => {
+    expect(
+      isCodexSubscriptionEligible(
+        openAIModel({
+          fullName: 'gpt-5.4-2026-03-05',
+          shortName: 'gpt-5.4',
+          deprecated: true,
+          capabilities: {
+            ...DEFAULT_MODEL_CAPABILITIES,
+            reasoningEffort: ReasoningEffort.XHIGH,
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  // A deprecated model *not* on the known-served exception list still gets
+  // excluded by default — the exception table is narrow, not a blanket
+  // "deprecated no longer disqualifies" change.
+  it('still rejects an ordinary deprecated model outside the known exception list', () => {
+    expect(
+      isCodexSubscriptionEligible(
+        openAIModel({
+          fullName: 'gpt-5.2-2025-12-11',
+          shortName: 'gpt-5.2',
+          deprecated: true,
+          capabilities: {
+            ...DEFAULT_MODEL_CAPABILITIES,
+            reasoningEffort: ReasoningEffort.XHIGH,
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
 });

--- a/src/test-kernel/model/ProviderCapabilities.vitest.ts
+++ b/src/test-kernel/model/ProviderCapabilities.vitest.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   DEFAULT_MODEL_CAPABILITIES,
   ModelProvider,
+  ReasoningEffort,
   type ModelConfig,
 } from 'llm-zoo';
 
@@ -20,7 +21,12 @@ const gpt55Config: ModelConfig = {
   inputPrice: 5,
   outputPrice: 30,
   contextWindow: 1_050_000,
-  capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
+  // Codex eligibility is now derived from the top reasoning-effort tier
+  // (see providerCapabilities.ts), not from a hardcoded fullName allowlist.
+  capabilities: {
+    ...DEFAULT_MODEL_CAPABILITIES,
+    reasoningEffort: ReasoningEffort.XHIGH,
+  },
   openRouterOnly: false,
 };
 

--- a/src/test-kernel/model/SetupModelDefaults.vitest.ts
+++ b/src/test-kernel/model/SetupModelDefaults.vitest.ts
@@ -7,10 +7,7 @@ import {
   resolveSetupModel,
   SETUP_MODEL_BY_PROVIDER,
 } from '@model/setupModelDefaults';
-import {
-  codexBackendModelId,
-  isCodexSubscriptionEligible,
-} from '@model/providerCapabilities';
+import { isCodexSubscriptionEligible } from '@model/providerCapabilities';
 import { API_PROVIDERS } from '@model/apiProviders';
 
 /**
@@ -78,9 +75,8 @@ describe('SETUP_MODEL_BY_PROVIDER', () => {
     assert.equal(CHATGPT_SETUP_MODEL, SETUP_MODEL_BY_PROVIDER.openai);
     const config = MODEL_CONFIGS[CHATGPT_SETUP_MODEL];
     assert.ok(config);
-    // Mirrors isUsableSetupModel's production check exactly (including
-    // codexBackendModelId's date-pin stripping), so this can't pass on a
-    // model id the real setup path would reject.
-    assert.ok(isCodexSubscriptionEligible(codexBackendModelId(config)));
+    // Mirrors isUsableSetupModel's production check exactly, so this can't
+    // pass on a model id the real setup path would reject.
+    assert.ok(isCodexSubscriptionEligible(config));
   });
 });


### PR DESCRIPTION
Closes #7192

## What changed

`isCodexSubscriptionEligible` in `src/model/providerCapabilities.ts` relied on `CODEX_SUBSCRIPTION_MODEL_FULLNAMES`, a hand-maintained set of exact OpenAI `fullName`s, plus a `/codex/i` naming-convention fallback. A future Codex-eligible model whose id doesn't literally contain "codex" and isn't added to that set would silently miss both checks and fall back to the paid API path instead of the ChatGPT subscription — a degraded-UX failure that's easy to miss.

`llm-zoo`'s `ModelConfig` has no dedicated Codex-eligibility capability flag today (checked the installed package and its source), so eligibility is now derived from registry data every OpenAI `ModelConfig` already carries instead of the literal allowlist:

- Top reasoning-effort tier (`capabilities.reasoningEffort === ReasoningEffort.XHIGH`) that hasn't been superseded or pulled (`deprecated`/`retired`).
- Plus the existing `*-codex*` naming convention, kept as-is, since OpenAI's own dedicated Codex-branded releases (e.g. `gpt-5.3-codex`) keep shipping under that name even after being marked `deprecated` in the registry in favor of a newer release.

This reproduces the old hardcoded set's membership almost exactly against the live registry (the one intentional delta: `gpt-5.4` mainline, which the registry marks `deprecated` in favor of `gpt-5.5`, is no longer treated as eligible — no test relied on that specific case). A new top-effort OpenAI release resolves eligible the moment `llm-zoo` ships it, with no hardcoded edit needed here. Over-matching a model the real backend doesn't serve is a benign false positive: the backend is the actual gate and already rejects models outside the account's tier at request time (documented in the function's docstring, same as before).

`codexBackendModelId`'s date-pin-stripping behavior is unchanged — it's still used internally (for the naming check) and independently by `modelHandlerCodex.ts` to build the Codex backend's request payload.

## Why the signature changed

`isCodexSubscriptionEligible` now takes the full `ModelConfig` instead of a bare `fullName` string, since deriving eligibility from `capabilities.reasoningEffort`/`deprecated`/`retired` needs the whole config. Both production call sites (`providerCapabilities.ts`, `setupModelDefaults.ts`) already had the full config in scope, so this also removes a layer of `codexBackendModelId(...)` pre-computation at each call site.

## Tests

- Rewrote `CodexPkce.vitest.ts`'s eligibility suite around synthetic `ModelConfig` fixtures, including a new regression case (`gpt-5.6`, absent from any hardcoded list, not `/codex/i`-named) proving eligibility is genuinely capability-derived rather than enumerated.
- Updated several other test files whose synthetic Codex-eligible `ModelConfig` mocks used bare default capabilities (which implied eligibility only under the old fullName-set lookup) to set `reasoningEffort: XHIGH`, matching what the real registry entries they stand in for actually have: `ProviderCapabilities.vitest.ts`, `CodexSubscriptionFallback.vitest.ts`, `ModelFactoryRouting.vitest.ts`, `CodexExperimentalTransports.vitest.ts`, `CodexEncryptedReasoning.vitest.ts`.
- `SetupModelDefaults.vitest.ts` needed no fixture changes — it already resolves against the live `MODEL_CONFIGS` registry.

## Verification

- `npx tsc --noEmit` (root) and `npx tsc --noEmit -p tsconfig.test-kernel.json` — clean.
- `corepack pnpm --filter texra typecheck` and `corepack pnpm --filter @texra-ai/cli typecheck` — clean.
- `npx eslint` on all changed files — clean.
- `npx vitest run src/test-kernel` (full suite) — 595 files / 4709 tests passed (1 pre-existing unrelated skip).
- `npx prettier --check` on all changed files — clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which OpenAI models route to the ChatGPT subscription (Codex) backend versus the API-key path—incorrect eligibility causes failed Codex requests or missed free subscription routing. Heuristic plus exception tables are heavily tested but remain inference from registry metadata, not live Codex API probing.
> 
> **Overview**
> Replaces the hand-maintained `CODEX_SUBSCRIPTION_MODEL_FULLNAMES` allowlist with **`isCodexSubscriptionEligible(model: ModelConfig)`** in `providerCapabilities.ts`, driven by llm-zoo registry fields: OpenAI-only, not `retired`, top reasoning tier (`XHIGH`/`MAX`), `deprecated` excluded by default, plus any id matching `/codex/i`. Layered exceptions fix known mismatches: API-only **`gpt-5.4-nano`**, **`-pro`** variants, and still-served **`gpt-5.4` / `gpt-5.4-mini`** when marked deprecated.
> 
> Call sites pass the full `ModelConfig` (`resolveProviderCapabilities`, OpenAI setup-model filtering in `setupModelDefaults.ts`). Tests move to synthetic configs with explicit `reasoningEffort` and broad regression coverage in `CodexPkce.vitest.ts`. The bench proposal doc only gets table/typography formatting tweaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39e102de050093256d3cf429d5e0aa14e63389bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->