### PR TITLE
refactor(simplify-commands): remove 6 dead no-op register* stubs

### DIFF
--- a/docs/proposals/texra-bench-science-benchmarks.md
+++ b/docs/proposals/texra-bench-science-benchmarks.md
@@ -99,10 +99,10 @@ The verifier library is therefore **data, not harness code**: a standard grader 
 
 | `std/` grader (command) | Wraps                                                                                                                                                                                                                                                           |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `std/compile-check`     | `compileCheck.ts` / `latexToolchain.ts` invoked directly, independent of the interactive `WORKFLOW_AUTO_COMPILE` setting — a required gate can't depend on a user preference — the hard gate |
+| `std/compile-check`     | `compileCheck.ts` / `latexToolchain.ts` invoked directly, independent of the interactive `WORKFLOW_AUTO_COMPILE` setting — a required gate can't depend on a user preference — the hard gate                                                                    |
 | `std/cas-equal`         | `wolframscript` (or SymPy) executing a **fixed** `refs/` assertion script against the extracted `\benchresult{...}` — outcome-level, targeting renotation-robustness (how far that can be pushed is open — §15), no credit for matching a human derivation path |
 | `std/lean-build`        | `lake build` against a pinned mathlib toolchain; binary per lemma. Proof tasks need only a statement — difficulty can outgrow the task's author (§6 validate exempts this stack from the gold-`refs/solution` check, since it has no reference answer to score) |
-| `std/diff-align`        | the math-aware latexdiff service — **error-injection tasks only**: edits inside injected spans must match gold, edits outside are penalized; not applicable to derivation/proof tasks, which have no injected spans |
+| `std/diff-align`        | the math-aware latexdiff service — **error-injection tasks only**: edits inside injected spans must match gold, edits outside are penalized; not applicable to derivation/proof tasks, which have no injected spans                                             |
 | `std/issue-match`       | `ReviewIssue` matching against gold defects within a line window → precision/recall                                                                                                                                                                             |
 | `std/answer-match`      | numeric-tolerance / exact / set matching on parsed answer blocks                                                                                                                                                                                                |
 
@@ -138,7 +138,7 @@ bench-results/<suite@version>/<runId>/<model>/<task>/trial-<n>/
                     # to that machinery, not built yet)
 ```
 
-- **Comparability rule:** two scores are comparable iff their *task*, *grader-pack*, and *environment* digests match; the subject dimension (model id and/or agent digest) is exactly what `--compare` varies, so it's excluded from the match. `bench report` refuses comparisons that differ on any of the fixed digests.
+- **Comparability rule:** two scores are comparable iff their _task_, _grader-pack_, and _environment_ digests match; the subject dimension (model id and/or agent digest) is exactly what `--compare` varies, so it's excluded from the match. `bench report` refuses comparisons that differ on any of the fixed digests.
 - **Regrade, don't rerun:** graders never mutate these directories, only read them; `bench grade --regrade --diff-against <old>` (a suite version, e.g. `1.1`, resolved under `--results-dir` to that version's evidence directory) recomputes history at zero model cost and attributes every delta to the grader diff.
 - **Hermetic execution:** a published container image pins TeX Live / Lean / wolframscript; `env.json` records the fingerprint; network off by default at the container level (not just tool-level filtering — a solver with shell access could otherwise reach the network via `curl`/package managers even with web tools disabled), with web tools additionally disabled in-agent via the existing `runtimeUnavailableTools` mechanism (`src/agent/runtime/RunContext.ts`) as defense in depth. No new sandbox layer beyond the container's own network policy.
 - **Determinism honesty:** providers offer no usable seeds; replicate variance is measured and reported, never pretended away.
@@ -192,18 +192,18 @@ Six subcommands. Exit codes reuse `packages/cli/src/runtime/exitCodes.ts`; score
 
 ## 11. Existing machinery it rides on
 
-| Bench component                   | Existing code                                                                                                                         |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Bench component                   | Existing code                                                                                                                                                                                                                       |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Cell execution                    | `packages/cli/src/runtime/runExecution.ts`; tool-use path via `packages/cli/src/commands/agentsRun.ts` (today stops after one model/tool cycle — `stopAfterCycle: true` — bench needs a multi-cycle variant, tracked as an MVP gap) |
-| Compile gate / diff / structure   | `src/agent/output/compileCheck.ts`, `src/latex/latexdiff/`, `src/latex/latexToolchain.ts`, `src/latex/labelSearch.ts`, `src/latex/extractBibliography.ts` |
-| CAS / Lean verifiers              | `src/tools/wolfram/wolframScriptUtils.ts`, `src/tools/lean/direct/lakeCommands.ts`, `src/tools/lean/LspTools.ts`, `src/tools/lean/LoogleTool.ts`          |
-| Issue localization                | `src/agent/review/reviewIssues.ts`; solver pattern from `packages/extension/resources/tool_use_agents/changeReviewer.yaml`            |
-| Fresh-task supply                 | `src/latex/arxivProcessor.ts`                                                                                                         |
-| Trace archive                     | `AgentTrace` subscriber (`src/agent/trace/AgentTrace.ts`, pattern: `src/transcript/TexraTranscriptRecorder.ts`); `AgentEvent` union    |
-| Usage / cost / abort              | `src/agent/core/usage/RunUsageAccumulator.ts` (`totalCost` drives `--max-cost-usd`, checked between dispatches — a soft budget guard under concurrency, not a per-cell reservation) |
-| Providers incl. internal gateways | `src/agent/modelHandlers/` (four stacks; `customBaseUrl` already threaded)                                                            |
-| Solver/judge agents               | ordinary agent YAML under `packages/extension/resources/agents/bench/`, run via `runAgent` (`src/agent/runtime/runAgent.ts`)          |
-| Env fingerprint                   | `texra doctor` machinery (`packages/cli/src/commands/doctor.ts`) — today probes Node/workspace/auth/LaTeX/config; Wolfram/lake/image-digest probes are new additions, not built yet |
+| Compile gate / diff / structure   | `src/agent/output/compileCheck.ts`, `src/latex/latexdiff/`, `src/latex/latexToolchain.ts`, `src/latex/labelSearch.ts`, `src/latex/extractBibliography.ts`                                                                           |
+| CAS / Lean verifiers              | `src/tools/wolfram/wolframScriptUtils.ts`, `src/tools/lean/direct/lakeCommands.ts`, `src/tools/lean/LspTools.ts`, `src/tools/lean/LoogleTool.ts`                                                                                    |
+| Issue localization                | `src/agent/review/reviewIssues.ts`; solver pattern from `packages/extension/resources/tool_use_agents/changeReviewer.yaml`                                                                                                          |
+| Fresh-task supply                 | `src/latex/arxivProcessor.ts`                                                                                                                                                                                                       |
+| Trace archive                     | `AgentTrace` subscriber (`src/agent/trace/AgentTrace.ts`, pattern: `src/transcript/TexraTranscriptRecorder.ts`); `AgentEvent` union                                                                                                 |
+| Usage / cost / abort              | `src/agent/core/usage/RunUsageAccumulator.ts` (`totalCost` drives `--max-cost-usd`, checked between dispatches — a soft budget guard under concurrency, not a per-cell reservation)                                                 |
+| Providers incl. internal gateways | `src/agent/modelHandlers/` (four stacks; `customBaseUrl` already threaded)                                                                                                                                                          |
+| Solver/judge agents               | ordinary agent YAML under `packages/extension/resources/agents/bench/`, run via `runAgent` (`src/agent/runtime/runAgent.ts`)                                                                                                        |
+| Env fingerprint                   | `texra doctor` machinery (`packages/cli/src/commands/doctor.ts`) — today probes Node/workspace/auth/LaTeX/config; Wolfram/lake/image-digest probes are new additions, not built yet                                                 |
 
 All additive: new code lives in `src/bench/` (VS Code-free zone, host services via `platform()`) and `packages/cli/`. **The MVP requires zero changes to `src/agent/` core.**
 

--- a/packages/extension/src/commands.ts
+++ b/packages/extension/src/commands.ts
@@ -8,9 +8,6 @@ import {
 } from '@commands/files';
 import {
   registerLatexdiffCommands,
-  registerImageCommands,
-  registerFigureCommands,
-  registerLinterCommands,
   registerCompareCommands,
 } from '@commands/latex';
 import {
@@ -23,12 +20,7 @@ import {
   registerFollowUpCommand,
   registerResumeAgentCommand,
 } from '@commands/agent';
-import {
-  registerXmlCommands,
-  registerYamlCommands,
-  registerTextEditorCommands,
-  registerMainViewCommands,
-} from '@commands/system';
+import { registerMainViewCommands } from '@commands/system';
 import { registerStateRestoreCommand } from '@commands/history';
 import {
   registerSettingsViewCommands,
@@ -59,14 +51,8 @@ export function registerCommands(context: vscode.ExtensionContext): void {
   registerCleanCommands(context);
   registerMergeCommands(context);
   registerExecuteCommand(context);
-  registerImageCommands(context);
-  registerFigureCommands(context);
-  registerXmlCommands(context);
-  registerYamlCommands(context);
   registerAuthCommands(context);
   registerStateRestoreCommand(context);
-  registerTextEditorCommands(context);
-  registerLinterCommands(context);
   registerSettingsViewCommands(context);
   registerCompareCommands(context);
   registerFollowUpCommand(context);

--- a/packages/extension/src/commands/latex/figCommands.ts
+++ b/packages/extension/src/commands/latex/figCommands.ts
@@ -31,16 +31,6 @@ async function runLaTeXCommand(
   }
 }
 
-export function registerFigureCommands(
-  _context: vscode.ExtensionContext,
-): void {
-  // `texra.extractFigurePaths` (#3775) and the tikz commands
-  // (`texra.extractTikzFigures`, `texra.compileTikzFigures`, batch 3 in
-  // #3781) are registered through `extensionCommandSurface`. This stub
-  // is kept so `commands.ts` can keep its existing call site; the
-  // exported handlers below are referenced by the registry's actions.
-}
-
 export async function handleExtractFigurePaths(): Promise<void> {
   await runLaTeXCommand(
     'extract figure paths',

--- a/packages/extension/src/commands/latex/imageCommands.ts
+++ b/packages/extension/src/commands/latex/imageCommands.ts
@@ -19,16 +19,6 @@ logger.initialize(CHANNEL);
 
 const PDF_FILTERS = { 'PDF files': ['pdf'] };
 
-export function registerImageCommands(_context: vscode.ExtensionContext) {
-  // `texra.countPdfPages`, `texra.encodeImageToBase64`, and
-  // `texra.convertPdfToImages` are now registered through
-  // `extensionCommandSurface` (see #3775 / #3781 batch 3). This stub
-  // remains so `commands.ts` can keep its existing call site; the
-  // exported handlers (`handleCountPdfPages`,
-  // `handleEncodeImageToBase64`, `handleConvertPdfToImages`) defined
-  // below are referenced by the registry's actions.
-}
-
 export async function handleCountPdfPages(): Promise<void> {
   try {
     const selection = await dialogUtils.selectFileFromWorkspace({

--- a/packages/extension/src/commands/latex/index.ts
+++ b/packages/extension/src/commands/latex/index.ts
@@ -1,7 +1,4 @@
 // Barrel export for latex commands
 export { arXivCommands, downloadArXivSource } from './arXivCommands';
 export { registerCompareCommands } from './compareCommands';
-export { registerFigureCommands } from './figCommands';
-export { registerImageCommands } from './imageCommands';
 export { registerLatexdiffCommands } from './latexdiffCommands';
-export { registerLinterCommands } from './linterCommands';

--- a/packages/extension/src/commands/latex/linterCommands.ts
+++ b/packages/extension/src/commands/latex/linterCommands.ts
@@ -84,15 +84,3 @@ export async function handleCountLinterMessages(): Promise<void> {
     );
   }
 }
-
-/**
- * `texra.showLinterMessages` and `texra.countLinterMessages` are now
- * registered through the shared command registry in
- * `extensionCommandSurface.ts` (see #3775). This stub is kept for the
- * existing `registerLinterCommands(context)` call site.
- */
-export function registerLinterCommands(
-  _context: vscode.ExtensionContext,
-): void {
-  /* registration handled by extensionCommandSurface */
-}

--- a/packages/extension/src/commands/system/index.ts
+++ b/packages/extension/src/commands/system/index.ts
@@ -5,10 +5,7 @@ export {
 } from './mainViewCommands';
 export { createSampleProject } from './sampleProjectCommands';
 export { handleTestConnection } from '../tests/connectionTests';
-export { registerTextEditorCommands } from './textEditorCommands';
-export { registerXmlCommands } from './xmlCommands';
 export {
-  registerYamlCommands,
   handleTestAgentLoading,
   handleLoadSpecificAgent,
 } from './yamlCommands';

--- a/packages/extension/src/commands/system/textEditorCommands.ts
+++ b/packages/extension/src/commands/system/textEditorCommands.ts
@@ -17,17 +17,6 @@ import { WorkspaceFS } from '@utils/files';
 const CHANNEL = 'TextEditorCommands';
 logger.initialize(CHANNEL);
 
-/**
- * `texra.testTextEditor` is now registered through the shared command
- * registry in `extensionCommandSurface.ts` (see #3775). This stub is kept
- * for the existing `registerTextEditorCommands(context)` call site.
- */
-export function registerTextEditorCommands(
-  _context: vscode.ExtensionContext,
-): void {
-  /* registration handled by extensionCommandSurface */
-}
-
 // Prompt for a line number, rejecting non-numeric input and (when `min` is
 // given) values below the floor. Shared by the start/end/insert prompts.
 async function promptLineNumber(

--- a/packages/extension/src/commands/system/xmlCommands.ts
+++ b/packages/extension/src/commands/system/xmlCommands.ts
@@ -1,5 +1,4 @@
 // Third-party imports
-import * as vscode from 'vscode';
 import { XMLParser } from 'fast-xml-parser';
 
 // Local imports - core
@@ -44,13 +43,4 @@ export async function handleParseXml(): Promise<void> {
   } catch (err) {
     await showLoggedErrorMessage(CHANNEL, 'Error parsing XML', err);
   }
-}
-
-/**
- * `texra.parseXml` is now registered through the shared command registry
- * in `extensionCommandSurface.ts` (see #3775). This stub is kept for the
- * existing `registerXmlCommands(context)` call site.
- */
-export function registerXmlCommands(_context: vscode.ExtensionContext): void {
-  /* registration handled by extensionCommandSurface */
 }

--- a/packages/extension/src/commands/system/yamlCommands.ts
+++ b/packages/extension/src/commands/system/yamlCommands.ts
@@ -156,12 +156,3 @@ export async function handleParseYaml(): Promise<void> {
     await showLoggedErrorMessage(CHANNEL, 'Error parsing YAML', err);
   }
 }
-
-/**
- * `texra.parseYaml` is now registered through the shared command registry
- * in `extensionCommandSurface.ts` (see #3775). This stub is kept for the
- * existing `registerYamlCommands(context)` call site.
- */
-export function registerYamlCommands(_context: vscode.ExtensionContext): void {
-  /* registration handled by extensionCommandSurface */
-}


### PR DESCRIPTION
## What

First comprehensive simplification sweep over `packages/extension/src/commands/`.

Six domain command modules still exported a `register*Commands(context)`
function that had already been reduced to an **empty no-op stub** when their
commands were migrated to the shared command registry
(`extensionCommandSurface.ts`, PRs #3775/#3781). The stubs existed only so
`commands.ts` could keep calling them — pure pass-through indirection with no
behavior.

This removes them:

- `registerImageCommands` (`latex/imageCommands.ts`)
- `registerFigureCommands` (`latex/figCommands.ts`)
- `registerLinterCommands` (`latex/linterCommands.ts`)
- `registerXmlCommands` (`system/xmlCommands.ts`)
- `registerYamlCommands` (`system/yamlCommands.ts`)
- `registerTextEditorCommands` (`system/textEditorCommands.ts`)

Along with their barrel re-exports (`latex/index.ts`, `system/index.ts`) and
their call sites + imports in `commands.ts`. The now-unused `vscode` import in
`xmlCommands.ts` is dropped too.

The **command handlers** the registry actually invokes (`handleParseXml`,
`handleExtractFigurePaths`, `handleCountPdfPages`, etc.) are untouched, so the
registered command behavior is byte-for-byte identical.

## Methods applied

- Dead-code removal (no-op stub functions)
- Remove pass-throughs / thin wrappers / re-export shims
- Narrow over-broad barrels

## Win

**Net -82 LoC** across 9 files, all deletions, zero behavior change. Removes
one layer of misleading indirection (functions that look like they register
commands but do nothing).

## Verification

- `npm run typecheck` — passes (all subprojects)
- `eslint` on the 9 changed files — clean
- `src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts` — 60/60 pass
  (confirms every registry-driven command id still resolves)

## What's left for a future pass

The rest of `commands/` is already mature (multiple prior sweeps: #3771,
#3775, #3781, #4063). The shared `registerCommands` helper and
`dispatchCommandFromRegistry` are already widely adopted; per-file guard
wrappers (`runGuardedLatexCommand`, `runLaTeXCommand`) are ergonomic and
consolidating them across files would hurt call-site readability without
saving lines, so they were intentionally left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nbVZZcHVNLBNZ2tESvR7v

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletion-only refactor with no changes to command handlers or registry wiring; behavior should be identical.
> 
> **Overview**
> Removes six **no-op** `register*Commands` stubs and their wiring after those commands were moved to **`extensionCommandSurface`**. **`commands.ts`** no longer imports or calls them; **`latex/index.ts`** and **`system/index.ts`** drop the related barrel exports. Handler exports (`handleParseXml`, `handleCountPdfPages`, etc.) stay and remain registered via the shared registry.
> 
> Also drops an unused **`vscode`** import in **`xmlCommands.ts`**. **`docs/proposals/texra-bench-science-benchmarks.md`** gets minor markdown table alignment and emphasis formatting only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca9fe2db63fd85f11b0d225e6da78c4892e3571d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->