### PR TITLE
refactor(simplify-tools): dedup rate-limit + delegation-description helpers

### DIFF
--- a/docs/proposals/texra-bench-science-benchmarks.md
+++ b/docs/proposals/texra-bench-science-benchmarks.md
@@ -99,10 +99,10 @@ The verifier library is therefore **data, not harness code**: a standard grader 
 
 | `std/` grader (command) | Wraps                                                                                                                                                                                                                                                           |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `std/compile-check`     | `compileCheck.ts` / `latexToolchain.ts` invoked directly, independent of the interactive `WORKFLOW_AUTO_COMPILE` setting — a required gate can't depend on a user preference — the hard gate |
+| `std/compile-check`     | `compileCheck.ts` / `latexToolchain.ts` invoked directly, independent of the interactive `WORKFLOW_AUTO_COMPILE` setting — a required gate can't depend on a user preference — the hard gate                                                                    |
 | `std/cas-equal`         | `wolframscript` (or SymPy) executing a **fixed** `refs/` assertion script against the extracted `\benchresult{...}` — outcome-level, targeting renotation-robustness (how far that can be pushed is open — §15), no credit for matching a human derivation path |
 | `std/lean-build`        | `lake build` against a pinned mathlib toolchain; binary per lemma. Proof tasks need only a statement — difficulty can outgrow the task's author (§6 validate exempts this stack from the gold-`refs/solution` check, since it has no reference answer to score) |
-| `std/diff-align`        | the math-aware latexdiff service — **error-injection tasks only**: edits inside injected spans must match gold, edits outside are penalized; not applicable to derivation/proof tasks, which have no injected spans |
+| `std/diff-align`        | the math-aware latexdiff service — **error-injection tasks only**: edits inside injected spans must match gold, edits outside are penalized; not applicable to derivation/proof tasks, which have no injected spans                                             |
 | `std/issue-match`       | `ReviewIssue` matching against gold defects within a line window → precision/recall                                                                                                                                                                             |
 | `std/answer-match`      | numeric-tolerance / exact / set matching on parsed answer blocks                                                                                                                                                                                                |
 
@@ -138,7 +138,7 @@ bench-results/<suite@version>/<runId>/<model>/<task>/trial-<n>/
                     # to that machinery, not built yet)
 ```
 
-- **Comparability rule:** two scores are comparable iff their *task*, *grader-pack*, and *environment* digests match; the subject dimension (model id and/or agent digest) is exactly what `--compare` varies, so it's excluded from the match. `bench report` refuses comparisons that differ on any of the fixed digests.
+- **Comparability rule:** two scores are comparable iff their _task_, _grader-pack_, and _environment_ digests match; the subject dimension (model id and/or agent digest) is exactly what `--compare` varies, so it's excluded from the match. `bench report` refuses comparisons that differ on any of the fixed digests.
 - **Regrade, don't rerun:** graders never mutate these directories, only read them; `bench grade --regrade --diff-against <old>` (a suite version, e.g. `1.1`, resolved under `--results-dir` to that version's evidence directory) recomputes history at zero model cost and attributes every delta to the grader diff.
 - **Hermetic execution:** a published container image pins TeX Live / Lean / wolframscript; `env.json` records the fingerprint; network off by default at the container level (not just tool-level filtering — a solver with shell access could otherwise reach the network via `curl`/package managers even with web tools disabled), with web tools additionally disabled in-agent via the existing `runtimeUnavailableTools` mechanism (`src/agent/runtime/RunContext.ts`) as defense in depth. No new sandbox layer beyond the container's own network policy.
 - **Determinism honesty:** providers offer no usable seeds; replicate variance is measured and reported, never pretended away.
@@ -192,18 +192,18 @@ Six subcommands. Exit codes reuse `packages/cli/src/runtime/exitCodes.ts`; score
 
 ## 11. Existing machinery it rides on
 
-| Bench component                   | Existing code                                                                                                                         |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Bench component                   | Existing code                                                                                                                                                                                                                       |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Cell execution                    | `packages/cli/src/runtime/runExecution.ts`; tool-use path via `packages/cli/src/commands/agentsRun.ts` (today stops after one model/tool cycle — `stopAfterCycle: true` — bench needs a multi-cycle variant, tracked as an MVP gap) |
-| Compile gate / diff / structure   | `src/agent/output/compileCheck.ts`, `src/latex/latexdiff/`, `src/latex/latexToolchain.ts`, `src/latex/labelSearch.ts`, `src/latex/extractBibliography.ts` |
-| CAS / Lean verifiers              | `src/tools/wolfram/wolframScriptUtils.ts`, `src/tools/lean/direct/lakeCommands.ts`, `src/tools/lean/LspTools.ts`, `src/tools/lean/LoogleTool.ts`          |
-| Issue localization                | `src/agent/review/reviewIssues.ts`; solver pattern from `packages/extension/resources/tool_use_agents/changeReviewer.yaml`            |
-| Fresh-task supply                 | `src/latex/arxivProcessor.ts`                                                                                                         |
-| Trace archive                     | `AgentTrace` subscriber (`src/agent/trace/AgentTrace.ts`, pattern: `src/transcript/TexraTranscriptRecorder.ts`); `AgentEvent` union    |
-| Usage / cost / abort              | `src/agent/core/usage/RunUsageAccumulator.ts` (`totalCost` drives `--max-cost-usd`, checked between dispatches — a soft budget guard under concurrency, not a per-cell reservation) |
-| Providers incl. internal gateways | `src/agent/modelHandlers/` (four stacks; `customBaseUrl` already threaded)                                                            |
-| Solver/judge agents               | ordinary agent YAML under `packages/extension/resources/agents/bench/`, run via `runAgent` (`src/agent/runtime/runAgent.ts`)          |
-| Env fingerprint                   | `texra doctor` machinery (`packages/cli/src/commands/doctor.ts`) — today probes Node/workspace/auth/LaTeX/config; Wolfram/lake/image-digest probes are new additions, not built yet |
+| Compile gate / diff / structure   | `src/agent/output/compileCheck.ts`, `src/latex/latexdiff/`, `src/latex/latexToolchain.ts`, `src/latex/labelSearch.ts`, `src/latex/extractBibliography.ts`                                                                           |
+| CAS / Lean verifiers              | `src/tools/wolfram/wolframScriptUtils.ts`, `src/tools/lean/direct/lakeCommands.ts`, `src/tools/lean/LspTools.ts`, `src/tools/lean/LoogleTool.ts`                                                                                    |
+| Issue localization                | `src/agent/review/reviewIssues.ts`; solver pattern from `packages/extension/resources/tool_use_agents/changeReviewer.yaml`                                                                                                          |
+| Fresh-task supply                 | `src/latex/arxivProcessor.ts`                                                                                                                                                                                                       |
+| Trace archive                     | `AgentTrace` subscriber (`src/agent/trace/AgentTrace.ts`, pattern: `src/transcript/TexraTranscriptRecorder.ts`); `AgentEvent` union                                                                                                 |
+| Usage / cost / abort              | `src/agent/core/usage/RunUsageAccumulator.ts` (`totalCost` drives `--max-cost-usd`, checked between dispatches — a soft budget guard under concurrency, not a per-cell reservation)                                                 |
+| Providers incl. internal gateways | `src/agent/modelHandlers/` (four stacks; `customBaseUrl` already threaded)                                                                                                                                                          |
+| Solver/judge agents               | ordinary agent YAML under `packages/extension/resources/agents/bench/`, run via `runAgent` (`src/agent/runtime/runAgent.ts`)                                                                                                        |
+| Env fingerprint                   | `texra doctor` machinery (`packages/cli/src/commands/doctor.ts`) — today probes Node/workspace/auth/LaTeX/config; Wolfram/lake/image-digest probes are new additions, not built yet                                                 |
 
 All additive: new code lives in `src/bench/` (VS Code-free zone, host services via `platform()`) and `packages/cli/`. **The MVP requires zero changes to `src/agent/` core.**
 

--- a/src/test-kernel/tools/DelegationDescriptionBlock.vitest.mts
+++ b/src/test-kernel/tools/DelegationDescriptionBlock.vitest.mts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ToolDefinition } from '@model';
+import { replaceDelegationDescriptionBlock } from '@tools/delegationDescriptionBlock';
+
+const LINE = /^Anchor:.*$/m;
+
+describe('replaceDelegationDescriptionBlock', () => {
+  it('leaves non-delegation tools untouched (same reference)', () => {
+    const tool: ToolDefinition = {
+      name: 'read_file',
+      description: 'Anchor: x',
+    };
+    expect(
+      replaceDelegationDescriptionBlock(tool, LINE, 'Anchor: y', {
+        appendIfMissing: true,
+      }),
+    ).toBe(tool);
+  });
+
+  it('leaves a delegation tool without a description untouched', () => {
+    const tool: ToolDefinition = { name: 'delegate_agent' };
+    expect(
+      replaceDelegationDescriptionBlock(tool, LINE, 'Anchor: y', {
+        appendIfMissing: true,
+      }),
+    ).toBe(tool);
+  });
+
+  it('replaces the matched block in place', () => {
+    const tool: ToolDefinition = {
+      name: 'delegate_agent',
+      description: 'Intro.\nAnchor: old\nOutro.',
+    };
+    expect(
+      replaceDelegationDescriptionBlock(tool, LINE, 'Anchor: new', {
+        appendIfMissing: true,
+      }).description,
+    ).toBe('Intro.\nAnchor: new\nOutro.');
+  });
+
+  it('keeps a $ in the replacement literal', () => {
+    const tool: ToolDefinition = {
+      name: 'delegate_agent',
+      description: 'Anchor: old',
+    };
+    expect(
+      replaceDelegationDescriptionBlock(tool, LINE, 'Anchor: $P=NP$', {
+        appendIfMissing: true,
+      }).description,
+    ).toBe('Anchor: $P=NP$');
+  });
+
+  it('appends the block when missing and appendIfMissing is true', () => {
+    const tool: ToolDefinition = {
+      name: 'delegate_agent',
+      description: 'Intro only.',
+    };
+    expect(
+      replaceDelegationDescriptionBlock(tool, LINE, 'Anchor: added', {
+        appendIfMissing: true,
+      }).description,
+    ).toBe('Intro only.\n\nAnchor: added');
+  });
+
+  it('leaves the description unchanged when missing and append is off', () => {
+    const tool: ToolDefinition = {
+      name: 'delegate_agent',
+      description: 'Intro only.',
+    };
+    const result = replaceDelegationDescriptionBlock(
+      tool,
+      LINE,
+      'Anchor: added',
+      { appendIfMissing: false },
+    );
+    expect(result.description).toBe('Intro only.');
+  });
+
+  it('never evaluates the replacement thunk when the tool is skipped', () => {
+    const thunk = vi.fn(() => 'Anchor: computed');
+
+    // Replace-only, anchor absent → thunk must not run (mirrors the worktree
+    // annotation reading its config setting only when the line is present).
+    replaceDelegationDescriptionBlock(
+      { name: 'delegate_agent', description: 'Intro only.' },
+      LINE,
+      thunk,
+      { appendIfMissing: false },
+    );
+    // Non-delegation tool → thunk must not run.
+    replaceDelegationDescriptionBlock(
+      { name: 'read_file', description: 'Anchor: x' },
+      LINE,
+      thunk,
+      { appendIfMissing: true },
+    );
+    expect(thunk).not.toHaveBeenCalled();
+
+    // Anchor present → thunk runs exactly once.
+    const out = replaceDelegationDescriptionBlock(
+      { name: 'delegate_agent', description: 'Anchor: x' },
+      LINE,
+      thunk,
+      { appendIfMissing: false },
+    );
+    expect(thunk).toHaveBeenCalledTimes(1);
+    expect(out.description).toBe('Anchor: computed');
+  });
+});

--- a/src/tools/arxiv/ArxivMetadataTool.ts
+++ b/src/tools/arxiv/ArxivMetadataTool.ts
@@ -2,10 +2,8 @@
 import { z } from 'zod';
 
 // Local imports - latex
-import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
 import { arxivProcessor } from '@latex/arxivProcessor';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
-import { abandonOnAbort } from '@tools/cancellation';
 import {
   type ArxivPaperMetadata,
   createArxivClient,
@@ -13,7 +11,7 @@ import {
   normaliseArxivIdentifier,
 } from '@tools/latex/arxivShared';
 import { ARXIV_CONSTANTS } from '@tools/citation/constants';
-import { waitForRateLimit } from '@tools/citation/rateLimiter';
+import { rateLimitedRequest } from '@tools/citation/rateLimiter';
 import { defineTool } from '@tools/core/define';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -51,15 +49,12 @@ export class ArxivMetadataTool extends defineTool({
 
     let entries;
     try {
-      // Respect arXiv API rate limits
-      await waitForRateLimit('arxiv', ARXIV_CONSTANTS.RATE_LIMIT_DELAY_MS);
-      // Use arxiv-client's ids() method for direct ID lookup. The client
-      // has no AbortSignal hook, so a cancelled batch abandons the
-      // in-flight lookup instead of waiting it out.
-      entries = await abandonOnAbort(
-        createArxivClient().ids([requestId]).execute(),
-        getCurrentToolCallContext()?.signal,
+      // Use arxiv-client's ids() method for direct ID lookup.
+      entries = await rateLimitedRequest(
+        'arxiv',
+        ARXIV_CONSTANTS.RATE_LIMIT_DELAY_MS,
         'arXiv metadata lookup',
+        () => createArxivClient().ids([requestId]).execute(),
       );
     } catch (error) {
       throw new ToolError(

--- a/src/tools/arxiv/ArxivSearchTool.ts
+++ b/src/tools/arxiv/ArxivSearchTool.ts
@@ -10,13 +10,11 @@ import {
 import { z } from 'zod';
 
 // Local imports
-import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
 import { warn } from '@logger/logUtils';
 import type { ToolResult } from '@shared/schemas/toolResult';
-import { abandonOnAbort } from '@tools/cancellation';
 import { requireNonEmptyString, wrapApiCall } from '@tools/utils';
 import { ARXIV_CONSTANTS } from '@tools/citation/constants';
-import { waitForRateLimit } from '@tools/citation/rateLimiter';
+import { rateLimitedRequest } from '@tools/citation/rateLimiter';
 import { defineTool } from '@tools/core/define';
 import {
   type ArxivSearchResult,
@@ -133,16 +131,16 @@ export class ArxivSearchTool extends defineTool({
       client = client.sortOrder(input.sortOrder);
     }
 
-    const entries = await wrapApiCall(async () => {
-      await waitForRateLimit('arxiv', ARXIV_CONSTANTS.RATE_LIMIT_DELAY_MS);
-      // The arXiv client has no AbortSignal hook, so a cancelled batch
-      // abandons the in-flight search instead of waiting it out.
-      return abandonOnAbort(
-        client.execute(),
-        getCurrentToolCallContext()?.signal,
-        'arXiv search',
-      );
-    }, 'Failed to query arXiv API');
+    const entries = await wrapApiCall(
+      () =>
+        rateLimitedRequest(
+          'arxiv',
+          ARXIV_CONSTANTS.RATE_LIMIT_DELAY_MS,
+          'arXiv search',
+          () => client.execute(),
+        ),
+      'Failed to query arXiv API',
+    );
 
     const results: ArxivSearchResult[] = entries.map((entry) => {
       const base = extractBasePaperMetadata(entry);

--- a/src/tools/citation/CrossrefDoiTool.ts
+++ b/src/tools/citation/CrossrefDoiTool.ts
@@ -3,15 +3,13 @@ import { type Work } from '@jamesgopsill/crossref-client';
 import { z } from 'zod';
 
 // Local imports
-import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
-import { abandonOnAbort } from '@tools/cancellation';
 import { requireNonEmptyString, wrapApiCall } from '@tools/utils';
 import { defineTool } from '@tools/core/define';
 
 // Local file imports
 import { CROSSREF_CONSTANTS, crossrefClient } from './constants';
-import { waitForRateLimit } from './rateLimiter';
+import { rateLimitedRequest } from './rateLimiter';
 
 const CrossrefDoiInputSchema = z.strictObject({
   doi: z.string().describe('DOI to look up, with or without a DOI URL prefix.'),
@@ -28,19 +26,16 @@ export class CrossrefDoiTool extends defineTool({
   protected async execute(input: CrossrefDoiInput): Promise<ToolResult> {
     const trimmedDoi = requireNonEmptyString(input.doi, 'DOI');
 
-    const response = await wrapApiCall(async () => {
-      await waitForRateLimit(
-        'crossref',
-        CROSSREF_CONSTANTS.RATE_LIMIT_DELAY_MS,
-      );
-      // The Crossref client has no AbortSignal hook, so a cancelled batch
-      // abandons the in-flight lookup instead of waiting it out.
-      return abandonOnAbort(
-        crossrefClient.work(trimmedDoi),
-        getCurrentToolCallContext()?.signal,
-        'Crossref DOI lookup',
-      );
-    }, 'Crossref lookup failed');
+    const response = await wrapApiCall(
+      () =>
+        rateLimitedRequest(
+          'crossref',
+          CROSSREF_CONSTANTS.RATE_LIMIT_DELAY_MS,
+          'Crossref DOI lookup',
+          () => crossrefClient.work(trimmedDoi),
+        ),
+      'Crossref lookup failed',
+    );
 
     if (!response.ok || !response.content?.message) {
       throw new ToolError('Crossref response did not include metadata.');

--- a/src/tools/citation/CrossrefSearchTool.ts
+++ b/src/tools/citation/CrossrefSearchTool.ts
@@ -7,16 +7,14 @@ import {
 import { z } from 'zod';
 
 // Local imports
-import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
-import { abandonOnAbort } from '@tools/cancellation';
 import { requireNonEmptyString, wrapApiCall } from '@tools/utils';
 import { defineTool } from '@tools/core/define';
 import { pluralize } from '@utils/text/stringUtils';
 
 // Local file imports
 import { CROSSREF_CONSTANTS, crossrefClient } from './constants';
-import { waitForRateLimit } from './rateLimiter';
+import { rateLimitedRequest } from './rateLimiter';
 
 const CrossrefSearchInputSchema = z.strictObject({
   query: z.string().describe('Bibliographic search query for Crossref works.'),
@@ -72,19 +70,16 @@ export class CrossrefSearchTool extends defineTool({
       ...(input.filter && { filter: input.filter }),
     };
 
-    const response = await wrapApiCall(async () => {
-      await waitForRateLimit(
-        'crossref',
-        CROSSREF_CONSTANTS.RATE_LIMIT_DELAY_MS,
-      );
-      // The Crossref client has no AbortSignal hook, so a cancelled batch
-      // abandons the in-flight search instead of waiting it out.
-      return abandonOnAbort(
-        crossrefClient.works(options),
-        getCurrentToolCallContext()?.signal,
-        'Crossref search',
-      );
-    }, 'Crossref search failed');
+    const response = await wrapApiCall(
+      () =>
+        rateLimitedRequest(
+          'crossref',
+          CROSSREF_CONSTANTS.RATE_LIMIT_DELAY_MS,
+          'Crossref search',
+          () => crossrefClient.works(options),
+        ),
+      'Crossref search failed',
+    );
 
     if (!response.ok || !response.content?.message) {
       throw new ToolError('Crossref search did not return any items.');

--- a/src/tools/citation/rateLimiter.ts
+++ b/src/tools/citation/rateLimiter.ts
@@ -35,3 +35,22 @@ export async function waitForRateLimit(
   }
   await abandonOnAbort(limiter.wait(), signal, 'before contacting the API');
 }
+
+/**
+ * Run a rate-limited, cancellable request against an external metadata API.
+ *
+ * Combines the throttle wait ({@link waitForRateLimit}) with cancellation
+ * ({@link abandonOnAbort}) against the current tool call's signal — the exact
+ * pattern every arXiv/Crossref lookup repeats. These clients expose no
+ * AbortSignal hook, so on cancellation the in-flight request is *abandoned*:
+ * only safe for the idempotent, read-only lookups these tools perform.
+ */
+export async function rateLimitedRequest<T>(
+  apiName: string,
+  minDelayMs: number,
+  label: string,
+  request: () => Promise<T>,
+): Promise<T> {
+  await waitForRateLimit(apiName, minDelayMs);
+  return abandonOnAbort(request(), getCurrentToolCallContext()?.signal, label);
+}

--- a/src/tools/delegationAgentAvailability.ts
+++ b/src/tools/delegationAgentAvailability.ts
@@ -19,7 +19,7 @@
 import { getVisibleAgents } from '@agent/index/agentRegistry';
 import type { ToolDefinition } from '@model';
 import type { AgentCategory } from '@shared/schemas/agent';
-import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
+import { replaceDelegationDescriptionBlock } from '@tools/delegationDescriptionBlock';
 
 /** Matches the "Available agents:" header plus its contiguous (non-blank) list
  * lines, stopping at the first blank line or end of string. Anchored to a line
@@ -69,20 +69,19 @@ export function visibleDelegationAgentsBlock(category: AgentCategory): string {
 
 /**
  * Replace the "Available agents:" block in a delegation tool's description with
- * the supplied block. Non-delegation tools and tools without a description are
- * returned untouched. The block is injected via a replacer function so a `$` in
- * an agent description (e.g. inline LaTeX math) is never read as a replacement
- * pattern.
+ * the supplied block, appending it when the description has no such block yet.
+ * A `$` in an agent description (e.g. inline LaTeX math) stays literal.
  */
 export function withDelegationAgentAvailability(
   tool: ToolDefinition,
   agentsBlock: string,
 ): ToolDefinition {
-  if (!DELEGATION_TOOLS.has(tool.name) || !tool.description) return tool;
-
-  const description = AVAILABLE_AGENTS_BLOCK.test(tool.description)
-    ? tool.description.replace(AVAILABLE_AGENTS_BLOCK, () => agentsBlock)
-    : `${tool.description}\n\n${agentsBlock}`;
-
-  return { ...tool, description };
+  return replaceDelegationDescriptionBlock(
+    tool,
+    AVAILABLE_AGENTS_BLOCK,
+    agentsBlock,
+    {
+      appendIfMissing: true,
+    },
+  );
 }

--- a/src/tools/delegationDescriptionBlock.ts
+++ b/src/tools/delegationDescriptionBlock.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared mechanics for the per-run "Available agents / models / worktree"
+ * annotations injected into delegation tool descriptions.
+ *
+ * Each availability module (agents, models, worktree) owns its own anchor
+ * pattern and copy; they all share the same injection contract: only touch
+ * delegation tools that have a description, replace the matched block in place
+ * (via a replacer function so a `$` in the replacement is never read as a
+ * pattern token), and — for annotations that must default onto a description
+ * with no anchor — append the block instead.
+ */
+
+// Type imports
+import type { ToolDefinition } from '@model';
+
+// Local imports
+import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
+
+/**
+ * Replace `pattern`'s match in a delegation tool's description with
+ * `replacement`, returning a new definition. Non-delegation tools and tools
+ * without a description are returned untouched.
+ *
+ * When the pattern does not match:
+ *   - `appendIfMissing: true` appends the block as a trailing paragraph.
+ *   - `appendIfMissing: false` leaves the description unchanged (replace-only,
+ *     for annotations that must never be added where the anchor is absent).
+ *
+ * `replacement` may be a thunk so the caller can defer any config/registry read
+ * until the tool is confirmed to need the block (matched, or appended).
+ */
+export function replaceDelegationDescriptionBlock(
+  tool: ToolDefinition,
+  pattern: RegExp,
+  replacement: string | (() => string),
+  { appendIfMissing }: { appendIfMissing: boolean },
+): ToolDefinition {
+  if (!DELEGATION_TOOLS.has(tool.name) || !tool.description) return tool;
+
+  const matched = pattern.test(tool.description);
+  if (!matched && !appendIfMissing) return tool;
+
+  const text = typeof replacement === 'function' ? replacement() : replacement;
+  const description = matched
+    ? tool.description.replace(pattern, () => text)
+    : `${tool.description}\n\n${text}`;
+  return { ...tool, description };
+}

--- a/src/tools/delegationModelAvailability.ts
+++ b/src/tools/delegationModelAvailability.ts
@@ -1,7 +1,7 @@
 import type { ToolDefinition } from '@model';
 import { decideRunModel } from '@model/runModelDecision';
 import type { ModelOptionData } from '@shared/schemas';
-import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
+import { replaceDelegationDescriptionBlock } from '@tools/delegationDescriptionBlock';
 
 const AVAILABLE_MODELS_LINE = /^Available models:.*$/m;
 
@@ -76,12 +76,10 @@ export function withDelegationModelAvailability(
   tool: ToolDefinition,
   modelNames: readonly string[] | null,
 ): ToolDefinition {
-  if (!DELEGATION_TOOLS.has(tool.name) || !tool.description) return tool;
-
-  const availableModelsLine = formatAvailableModelsLine(modelNames);
-  const description = AVAILABLE_MODELS_LINE.test(tool.description)
-    ? tool.description.replace(AVAILABLE_MODELS_LINE, availableModelsLine)
-    : `${tool.description}\n\n${availableModelsLine}`;
-
-  return { ...tool, description };
+  return replaceDelegationDescriptionBlock(
+    tool,
+    AVAILABLE_MODELS_LINE,
+    () => formatAvailableModelsLine(modelNames),
+    { appendIfMissing: true },
+  );
 }

--- a/src/tools/delegationWorktreeAvailability.ts
+++ b/src/tools/delegationWorktreeAvailability.ts
@@ -15,7 +15,7 @@
  */
 
 import type { ToolDefinition } from '@model';
-import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
+import { replaceDelegationDescriptionBlock } from '@tools/delegationDescriptionBlock';
 import { isWorktreeSupportEnabled } from '@tools/worktreeConfig';
 
 /** The single "Git worktree support:" line, anchored to a line start. */
@@ -36,14 +36,16 @@ const WORKTREE_DISABLED_LINE =
 export function withDelegationWorktreeAvailability(
   tool: ToolDefinition,
 ): ToolDefinition {
-  if (!DELEGATION_TOOLS.has(tool.name) || !tool.description) return tool;
-  if (!WORKTREE_LINE.test(tool.description)) return tool;
-
-  const line = isWorktreeSupportEnabled()
-    ? WORKTREE_ENABLED_LINE
-    : WORKTREE_DISABLED_LINE;
-  return {
-    ...tool,
-    description: tool.description.replace(WORKTREE_LINE, () => line),
-  };
+  // Replace-only: a tool with no "Git worktree support:" line takes no
+  // `working_directory`, so the line must never be appended. The setting is
+  // read lazily, only when the anchor is present.
+  return replaceDelegationDescriptionBlock(
+    tool,
+    WORKTREE_LINE,
+    () =>
+      isWorktreeSupportEnabled()
+        ? WORKTREE_ENABLED_LINE
+        : WORKTREE_DISABLED_LINE,
+    { appendIfMissing: false },
+  );
 }


### PR DESCRIPTION
## What

First comprehensive simplifier pass over `src/tools/`. Two host-agnostic **dedup / single-source-of-truth** consolidations that collapse repeated boilerplate into single, tested helpers. This is a behavior-preserving refactor.

### 1. `rateLimitedRequest()` — shared rate-limit + abort for metadata tools

The arXiv and Crossref tools each repeated the same tricky sequence: `waitForRateLimit(api, delay)`, then `abandonOnAbort(request(), getCurrentToolCallContext()?.signal, label)`. Getting this right matters (both the throttle wait *and* the request must observe the current tool call's abort signal), so it now lives in one place in `citation/rateLimiter.ts`.

Applied to `CrossrefDoiTool`, `CrossrefSearchTool`, `ArxivSearchTool`, `ArxivMetadataTool`. Each drops three imports (`waitForRateLimit`, `abandonOnAbort`, `getCurrentToolCallContext`) for one. `ArxivMetadataTool` keeps its `try/catch` so the `"Failed to query arXiv API:"` re-wrap is preserved exactly.

### 2. `replaceDelegationDescriptionBlock()` — shared delegation-description injection

The three delegation-availability annotators (`delegationAgentAvailability`, `delegationModelAvailability`, `delegationWorktreeAvailability`) each re-implemented the same injection contract:

- guard on `DELEGATION_TOOLS.has(name)` + a non-empty description,
- replace the anchor block in place via a **replacer function** (so a `$` in the text stays literal),
- **append** when the anchor is missing (agents/models) or **leave untouched** (worktree, replace-only).

That contract now has one home; each annotator keeps only its own anchor pattern and copy. The `replacement` argument accepts a thunk, so the worktree annotator still reads its config setting **lazily** — only when the anchor is present — matching prior behavior exactly.

Public function signatures are unchanged, so the caller in `src/agent/runtime/agentToolResolution.ts` (out of scope) needs no edits.

## Methods applied

- **dedup duplicated logic into shared helpers** (both changes)
- **reduce change-amplification** — a delegation-tool guard change is now one edit, not three
- **schema/contract SSOT** — the description-injection contract is documented once
- **test coverage** — added regression coverage for the previously-untested worktree replace-only + lazy-read path

## Honest scope note

This is a **dedup / change-amplification** win, not a raw-LoC deletion: production code is roughly flat (~+1 net across the 8 modified files) plus a 48-line shared helper. The value is fewer copies of error-prone logic (4× rate-limit, 3× delegation guard) and new coverage, not fewer lines. I did **not** chase knip's "unused export" list — most entries are co-located Zod schemas / barrel type surface whose bulk removal is risky in a behavior-preserving pass.

## Left for a future pass

- **agentCli dual system** (`claudeAgent.ts` / `codex.ts` + `*Shared`/`*Config`/`*Import` modules) — already shares a well-factored `agentCliShared.ts`; further convergence is architectural and risky.
- **github polling sources** (`PollingSourceBase` + `RepoPollingSource` + `PRPollingSource`) — large and complex; treat as its own scoped effort.
- **command-dispatch tools** (`MemoryTool`, `PlanTool`, `ExecutionsTool`) — branchy `requireField` switch ladders that could be data-driven, but large surface + behavior risk.

## Verification

- `npm run typecheck` — passes (all workspace projects)
- `eslint` on all changed files — clean
- vitest: `ArxivSearchTool`, `DelegationModelAvailability`, `DelegationAgentAvailability`, `DelegationWorktreeAvailability`, `ToolConversion`, and the new `DelegationDescriptionBlock` suites — **44 tests pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nbVZZcHVNLBNZ2tESvR7v

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor with targeted tests; external tool behavior and delegation annotator semantics are intended to stay the same.
> 
> **Overview**
> Introduces two shared helpers in `src/tools/` and routes existing call sites through them without changing public APIs.
> 
> **`rateLimitedRequest`** in `citation/rateLimiter.ts` centralizes the throttle wait plus `abandonOnAbort` against the current tool-call signal. **ArXiv** and **Crossref** metadata/search tools drop repeated boilerplate and call this helper instead (error wrapping in `ArxivMetadataTool` is unchanged).
> 
> **`replaceDelegationDescriptionBlock`** owns the delegation-tool description injection contract (delegation-tool guard, replacer-safe `$` handling, append vs replace-only). **Agent, model, and worktree** availability modules keep their anchor patterns and copy but delegate to this helper; worktree still uses replace-only with a lazy thunk for config reads.
> 
> Adds **`DelegationDescriptionBlock.vitest.mts`** for the new helper. The TeXRA bench proposal doc only gets table alignment and light typography tweaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bd99a6d96e9c1e7111e92a86c03dbafb9c7f74a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->