### PR TITLE
refactor(simplify-desktop): extract shared wa-dialog overlay factory

### DIFF
--- a/docs/proposals/texra-bench-science-benchmarks.md
+++ b/docs/proposals/texra-bench-science-benchmarks.md
@@ -99,10 +99,10 @@ The verifier library is therefore **data, not harness code**: a standard grader 
 
 | `std/` grader (command) | Wraps                                                                                                                                                                                                                                                           |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `std/compile-check`     | `compileCheck.ts` / `latexToolchain.ts` invoked directly, independent of the interactive `WORKFLOW_AUTO_COMPILE` setting — a required gate can't depend on a user preference — the hard gate |
+| `std/compile-check`     | `compileCheck.ts` / `latexToolchain.ts` invoked directly, independent of the interactive `WORKFLOW_AUTO_COMPILE` setting — a required gate can't depend on a user preference — the hard gate                                                                    |
 | `std/cas-equal`         | `wolframscript` (or SymPy) executing a **fixed** `refs/` assertion script against the extracted `\benchresult{...}` — outcome-level, targeting renotation-robustness (how far that can be pushed is open — §15), no credit for matching a human derivation path |
 | `std/lean-build`        | `lake build` against a pinned mathlib toolchain; binary per lemma. Proof tasks need only a statement — difficulty can outgrow the task's author (§6 validate exempts this stack from the gold-`refs/solution` check, since it has no reference answer to score) |
-| `std/diff-align`        | the math-aware latexdiff service — **error-injection tasks only**: edits inside injected spans must match gold, edits outside are penalized; not applicable to derivation/proof tasks, which have no injected spans |
+| `std/diff-align`        | the math-aware latexdiff service — **error-injection tasks only**: edits inside injected spans must match gold, edits outside are penalized; not applicable to derivation/proof tasks, which have no injected spans                                             |
 | `std/issue-match`       | `ReviewIssue` matching against gold defects within a line window → precision/recall                                                                                                                                                                             |
 | `std/answer-match`      | numeric-tolerance / exact / set matching on parsed answer blocks                                                                                                                                                                                                |
 
@@ -138,7 +138,7 @@ bench-results/<suite@version>/<runId>/<model>/<task>/trial-<n>/
                     # to that machinery, not built yet)
 ```
 
-- **Comparability rule:** two scores are comparable iff their *task*, *grader-pack*, and *environment* digests match; the subject dimension (model id and/or agent digest) is exactly what `--compare` varies, so it's excluded from the match. `bench report` refuses comparisons that differ on any of the fixed digests.
+- **Comparability rule:** two scores are comparable iff their _task_, _grader-pack_, and _environment_ digests match; the subject dimension (model id and/or agent digest) is exactly what `--compare` varies, so it's excluded from the match. `bench report` refuses comparisons that differ on any of the fixed digests.
 - **Regrade, don't rerun:** graders never mutate these directories, only read them; `bench grade --regrade --diff-against <old>` (a suite version, e.g. `1.1`, resolved under `--results-dir` to that version's evidence directory) recomputes history at zero model cost and attributes every delta to the grader diff.
 - **Hermetic execution:** a published container image pins TeX Live / Lean / wolframscript; `env.json` records the fingerprint; network off by default at the container level (not just tool-level filtering — a solver with shell access could otherwise reach the network via `curl`/package managers even with web tools disabled), with web tools additionally disabled in-agent via the existing `runtimeUnavailableTools` mechanism (`src/agent/runtime/RunContext.ts`) as defense in depth. No new sandbox layer beyond the container's own network policy.
 - **Determinism honesty:** providers offer no usable seeds; replicate variance is measured and reported, never pretended away.
@@ -192,18 +192,18 @@ Six subcommands. Exit codes reuse `packages/cli/src/runtime/exitCodes.ts`; score
 
 ## 11. Existing machinery it rides on
 
-| Bench component                   | Existing code                                                                                                                         |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Bench component                   | Existing code                                                                                                                                                                                                                       |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Cell execution                    | `packages/cli/src/runtime/runExecution.ts`; tool-use path via `packages/cli/src/commands/agentsRun.ts` (today stops after one model/tool cycle — `stopAfterCycle: true` — bench needs a multi-cycle variant, tracked as an MVP gap) |
-| Compile gate / diff / structure   | `src/agent/output/compileCheck.ts`, `src/latex/latexdiff/`, `src/latex/latexToolchain.ts`, `src/latex/labelSearch.ts`, `src/latex/extractBibliography.ts` |
-| CAS / Lean verifiers              | `src/tools/wolfram/wolframScriptUtils.ts`, `src/tools/lean/direct/lakeCommands.ts`, `src/tools/lean/LspTools.ts`, `src/tools/lean/LoogleTool.ts`          |
-| Issue localization                | `src/agent/review/reviewIssues.ts`; solver pattern from `packages/extension/resources/tool_use_agents/changeReviewer.yaml`            |
-| Fresh-task supply                 | `src/latex/arxivProcessor.ts`                                                                                                         |
-| Trace archive                     | `AgentTrace` subscriber (`src/agent/trace/AgentTrace.ts`, pattern: `src/transcript/TexraTranscriptRecorder.ts`); `AgentEvent` union    |
-| Usage / cost / abort              | `src/agent/core/usage/RunUsageAccumulator.ts` (`totalCost` drives `--max-cost-usd`, checked between dispatches — a soft budget guard under concurrency, not a per-cell reservation) |
-| Providers incl. internal gateways | `src/agent/modelHandlers/` (four stacks; `customBaseUrl` already threaded)                                                            |
-| Solver/judge agents               | ordinary agent YAML under `packages/extension/resources/agents/bench/`, run via `runAgent` (`src/agent/runtime/runAgent.ts`)          |
-| Env fingerprint                   | `texra doctor` machinery (`packages/cli/src/commands/doctor.ts`) — today probes Node/workspace/auth/LaTeX/config; Wolfram/lake/image-digest probes are new additions, not built yet |
+| Compile gate / diff / structure   | `src/agent/output/compileCheck.ts`, `src/latex/latexdiff/`, `src/latex/latexToolchain.ts`, `src/latex/labelSearch.ts`, `src/latex/extractBibliography.ts`                                                                           |
+| CAS / Lean verifiers              | `src/tools/wolfram/wolframScriptUtils.ts`, `src/tools/lean/direct/lakeCommands.ts`, `src/tools/lean/LspTools.ts`, `src/tools/lean/LoogleTool.ts`                                                                                    |
+| Issue localization                | `src/agent/review/reviewIssues.ts`; solver pattern from `packages/extension/resources/tool_use_agents/changeReviewer.yaml`                                                                                                          |
+| Fresh-task supply                 | `src/latex/arxivProcessor.ts`                                                                                                                                                                                                       |
+| Trace archive                     | `AgentTrace` subscriber (`src/agent/trace/AgentTrace.ts`, pattern: `src/transcript/TexraTranscriptRecorder.ts`); `AgentEvent` union                                                                                                 |
+| Usage / cost / abort              | `src/agent/core/usage/RunUsageAccumulator.ts` (`totalCost` drives `--max-cost-usd`, checked between dispatches — a soft budget guard under concurrency, not a per-cell reservation)                                                 |
+| Providers incl. internal gateways | `src/agent/modelHandlers/` (four stacks; `customBaseUrl` already threaded)                                                                                                                                                          |
+| Solver/judge agents               | ordinary agent YAML under `packages/extension/resources/agents/bench/`, run via `runAgent` (`src/agent/runtime/runAgent.ts`)                                                                                                        |
+| Env fingerprint                   | `texra doctor` machinery (`packages/cli/src/commands/doctor.ts`) — today probes Node/workspace/auth/LaTeX/config; Wolfram/lake/image-digest probes are new additions, not built yet                                                 |
 
 All additive: new code lives in `src/bench/` (VS Code-free zone, host services via `platform()`) and `packages/cli/`. **The MVP requires zero changes to `src/agent/` core.**
 

--- a/packages/desktop/src/desktopPdfMessages.ts
+++ b/packages/desktop/src/desktopPdfMessages.ts
@@ -10,10 +10,10 @@ import { z } from 'zod';
 // `wa-dialog` overlay — Electron's bundled Chromium renders PDFs
 // natively, no extra dependency required.
 //
-// This is the second overlay pattern (settings is the first; diff is
-// the prior). Once a third overlay arrives we should extract a shared
-// `createOverlay()` factory; today the duplication is small enough
-// that a shared abstraction would obscure rather than help.
+// This is the third overlay pattern (settings, then diff). All three now
+// share the wa-dialog shell via `createOverlayDialog` in
+// `renderer/overlayDialog.ts`; each overlay owns only its content element
+// and behavior.
 //
 // `desktop:showPdf` carries:
 //   - `title`: shown in the dialog header (e.g. "paper.pdf")

--- a/packages/desktop/src/renderer/diffOverlay.ts
+++ b/packages/desktop/src/renderer/diffOverlay.ts
@@ -2,7 +2,7 @@ import {
   DESKTOP_THEME_KIND,
   type DesktopThemeKind,
 } from '@shared/constants/desktopTheme';
-import { createDialogCloseButton } from './dialogCloseButton';
+import { createOverlayDialog } from './overlayDialog';
 import type { DesktopShowDiffMessage } from '../desktopDiffMessages';
 import type WaDialog from '@awesome.me/webawesome/dist/components/dialog/dialog.js';
 
@@ -28,26 +28,6 @@ export function createDiffOverlay(appRoot: HTMLElement): DiffOverlayController {
 
   function ensure(): WaDialog {
     if (dialog) return dialog;
-    const d = document.createElement('wa-dialog') as WaDialog;
-    d.classList.add('desktop-diff-overlay');
-    d.withoutHeader = true;
-    d.lightDismiss = false;
-    d.setAttribute('aria-label', 'Compare files');
-
-    const body = document.createElement('section');
-    body.classList.add('desktop-diff-body');
-
-    const header = document.createElement('header');
-    header.classList.add('desktop-diff-header');
-    const t = document.createElement('h2');
-    t.classList.add('desktop-diff-title');
-    t.textContent = 'Compare';
-    titleEl = t;
-    const s = document.createElement('p');
-    s.classList.add('desktop-diff-subtitle');
-    subtitleEl = s;
-    header.append(t, s);
-
     // Lazily create the <texra-diff-view> on first show (Monaco is heavy
     // to import; defer until actually needed). The element is reused
     // across re-opens — Lit's @property setter handles content swaps.
@@ -56,21 +36,18 @@ export function createDiffOverlay(appRoot: HTMLElement): DiffOverlayController {
     view.hostTheme = currentTheme;
     viewEl = view;
 
-    body.append(header, view);
-    d.append(body);
-
-    const close = createDialogCloseButton(
-      'desktop-diff-close',
-      'Close diff',
-      () => {
-        d.open = false;
-      },
-    );
-    d.append(close);
-
-    appRoot.append(d);
-    dialog = d;
-    return d;
+    const shell = createOverlayDialog({
+      appRoot,
+      prefix: 'desktop-diff',
+      ariaLabel: 'Compare files',
+      closeLabel: 'Close diff',
+      title: 'Compare',
+      content: view,
+    });
+    titleEl = shell.titleEl ?? null;
+    subtitleEl = shell.subtitleEl ?? null;
+    dialog = shell.dialog;
+    return dialog;
   }
 
   function open(payload: DesktopShowDiffMessage): void {

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -94,7 +94,7 @@ import { getRendererPlatform } from './rendererPlatform';
 import { createPdfOverlay } from './pdfOverlay';
 import { createDiffOverlay } from './diffOverlay';
 import { createLogsDrawer } from './logsDrawer';
-import { createDialogCloseButton } from './dialogCloseButton';
+import { createOverlayDialog } from './overlayDialog';
 import type WaDialog from '@awesome.me/webawesome/dist/components/dialog/dialog.js';
 
 const root = document.querySelector<HTMLElement>('#app');
@@ -507,26 +507,18 @@ let settingsDialog: WaDialog | null = null;
 
 function ensureSettingsDialog(): WaDialog {
   if (settingsDialog) return settingsDialog;
-  const dialog = document.createElement('wa-dialog') as WaDialog;
-  dialog.classList.add('desktop-settings-overlay');
-  dialog.withoutHeader = true;
-  dialog.lightDismiss = false;
-  dialog.setAttribute('aria-label', 'Settings');
-  dialog.setAttribute('data-route-button', 'settings');
-  // Settings-app fills the dialog body. We append it directly so subsequent
-  // re-opens reuse the same instance (preserving tab selection and state).
-  dialog.append(settingsView);
-  const close = createDialogCloseButton(
-    'desktop-settings-close',
-    'Close settings',
-    () => {
-      dialog.open = false;
-    },
-  );
-  dialog.append(close);
-  appRoot.append(dialog);
-  settingsDialog = dialog;
-  return dialog;
+  // Settings-app fills the dialog body. We pass it as the shell content (no
+  // titled header) so subsequent re-opens reuse the same instance, preserving
+  // tab selection and state.
+  settingsDialog = createOverlayDialog({
+    appRoot,
+    prefix: 'desktop-settings',
+    ariaLabel: 'Settings',
+    closeLabel: 'Close settings',
+    content: settingsView,
+    attributes: { 'data-route-button': 'settings' },
+  }).dialog;
+  return settingsDialog;
 }
 
 function openSettingsOverlay(): void {

--- a/packages/desktop/src/renderer/overlayDialog.ts
+++ b/packages/desktop/src/renderer/overlayDialog.ts
@@ -1,0 +1,76 @@
+import { createDialogCloseButton } from './dialogCloseButton';
+import type WaDialog from '@awesome.me/webawesome/dist/components/dialog/dialog.js';
+
+/**
+ * Shared scaffolding for the desktop's imperative `wa-dialog` overlays
+ * (settings, diff, PDF). Each overlay used to hand-build the same shell —
+ * `withoutHeader` / `lightDismiss` / `aria-label`, an optional titled header,
+ * an absolutely-positioned close button, and the `appRoot.append`. Centralizing
+ * it keeps overlays owning only their content and behavior, and stops the
+ * near-identical shells (and their `desktop-*` class families) from drifting.
+ */
+export interface OverlayDialogOptions {
+  appRoot: HTMLElement;
+  /**
+   * CSS class family. Derives `${prefix}-overlay` and `${prefix}-close`, plus
+   * `${prefix}-body` / `-header` / `-title` / `-subtitle` when `title` is set.
+   */
+  prefix: string;
+  ariaLabel: string;
+  closeLabel: string;
+  /** The overlay's content element (iframe, diff view, settings-app). */
+  content: HTMLElement;
+  /** When set, wraps `content` in a titled `<section>` header shell. */
+  title?: string;
+  /** Extra attributes to set on the dialog (e.g. `data-route-button`). */
+  attributes?: Record<string, string>;
+}
+
+export interface OverlayDialogHandle {
+  dialog: WaDialog;
+  /** Present only when `title` was supplied (the diff/PDF header overlays). */
+  titleEl?: HTMLElement;
+  subtitleEl?: HTMLElement;
+}
+
+/** Build a closed wa-dialog shell with shared chrome and append it to `appRoot`. */
+export function createOverlayDialog(
+  options: OverlayDialogOptions,
+): OverlayDialogHandle {
+  const { prefix } = options;
+  const dialog = document.createElement('wa-dialog') as WaDialog;
+  dialog.classList.add(`${prefix}-overlay`);
+  dialog.withoutHeader = true;
+  dialog.lightDismiss = false;
+  dialog.setAttribute('aria-label', options.ariaLabel);
+  for (const [name, value] of Object.entries(options.attributes ?? {})) {
+    dialog.setAttribute(name, value);
+  }
+
+  let titleEl: HTMLElement | undefined;
+  let subtitleEl: HTMLElement | undefined;
+  if (options.title == null) {
+    dialog.append(options.content);
+  } else {
+    const body = document.createElement('section');
+    body.classList.add(`${prefix}-body`);
+    const header = document.createElement('header');
+    header.classList.add(`${prefix}-header`);
+    titleEl = document.createElement('h2');
+    titleEl.classList.add(`${prefix}-title`);
+    titleEl.textContent = options.title;
+    subtitleEl = document.createElement('p');
+    subtitleEl.classList.add(`${prefix}-subtitle`);
+    header.append(titleEl, subtitleEl);
+    body.append(header, options.content);
+    dialog.append(body);
+  }
+
+  dialog.append(
+    createDialogCloseButton(`${prefix}-close`, options.closeLabel, () => {
+      dialog.open = false;
+    }),
+  );
+  options.appRoot.append(dialog);
+  return { dialog, titleEl, subtitleEl };
+}

--- a/packages/desktop/src/renderer/pdfOverlay.ts
+++ b/packages/desktop/src/renderer/pdfOverlay.ts
@@ -2,7 +2,7 @@ import {
   isSafeAbsolutePdfPath,
   type DesktopShowPdfMessage,
 } from '../desktopPdfMessages';
-import { createDialogCloseButton } from './dialogCloseButton';
+import { createOverlayDialog } from './overlayDialog';
 import type WaDialog from '@awesome.me/webawesome/dist/components/dialog/dialog.js';
 
 /**
@@ -46,26 +46,6 @@ export function createPdfOverlay(appRoot: HTMLElement): PdfOverlayController {
 
   function ensure(): WaDialog {
     if (dialog) return dialog;
-    const d = document.createElement('wa-dialog') as WaDialog;
-    d.classList.add('desktop-pdf-overlay');
-    d.withoutHeader = true;
-    d.lightDismiss = false;
-    d.setAttribute('aria-label', 'PDF preview');
-
-    const body = document.createElement('section');
-    body.classList.add('desktop-pdf-body');
-
-    const header = document.createElement('header');
-    header.classList.add('desktop-pdf-header');
-    const t = document.createElement('h2');
-    t.classList.add('desktop-pdf-title');
-    t.textContent = 'Preview';
-    titleEl = t;
-    const s = document.createElement('p');
-    s.classList.add('desktop-pdf-subtitle');
-    subtitleEl = s;
-    header.append(t, s);
-
     // Use an `<iframe>` (not `<webview>`) — `<webview>` requires
     // `webviewTag: true` in webPreferences which we don't enable.
     // Electron's main BrowserWindow renders PDFs in iframes via the
@@ -78,17 +58,17 @@ export function createPdfOverlay(appRoot: HTMLElement): PdfOverlayController {
     frame.setAttribute('sandbox', 'allow-same-origin');
     frameEl = frame;
 
-    body.append(header, frame);
-    d.append(body);
-
-    const close = createDialogCloseButton(
-      'desktop-pdf-close',
-      'Close PDF preview',
-      () => {
-        d.open = false;
-      },
-    );
-    d.append(close);
+    const shell = createOverlayDialog({
+      appRoot,
+      prefix: 'desktop-pdf',
+      ariaLabel: 'PDF preview',
+      closeLabel: 'Close PDF preview',
+      title: 'Preview',
+      content: frame,
+    });
+    titleEl = shell.titleEl ?? null;
+    subtitleEl = shell.subtitleEl ?? null;
+    const d = shell.dialog;
 
     // `wa-hide` fires for every close (close button, Escape, close()); open()
     // sets wantOpen back to true. wa-after-hide runs after the hide animation
@@ -108,7 +88,6 @@ export function createPdfOverlay(appRoot: HTMLElement): PdfOverlayController {
       if (frameEl) frameEl.removeAttribute('src');
     });
 
-    appRoot.append(d);
     dialog = d;
     return d;
   }

--- a/packages/desktop/src/renderer/pdfOverlay.ts
+++ b/packages/desktop/src/renderer/pdfOverlay.ts
@@ -70,6 +70,14 @@ export function createPdfOverlay(appRoot: HTMLElement): PdfOverlayController {
     subtitleEl = shell.subtitleEl ?? null;
     const d = shell.dialog;
 
+    // `createOverlayDialog` already appended `d` to `appRoot` above, before
+    // these listeners are registered. That's safe: `wa-dialog.open` defaults
+    // to false and nothing before this point sets it, so `wa-hide`/
+    // `wa-after-hide` (only dispatched from `requestClose()`, which requires
+    // the dialog to already be showModal'd) cannot fire until `open()` below
+    // sets `d.open = true`, which happens after this listener registration
+    // has already returned.
+    //
     // `wa-hide` fires for every close (close button, Escape, close()); open()
     // sets wantOpen back to true. wa-after-hide runs after the hide animation
     // — by which point a reopen during the animation has set a new src and


### PR DESCRIPTION
## What & why

`packages/desktop/src` is already heavily refactored (dispatcher/`createCommandHandler` abstractions, data-driven command tables, discriminated-union IPC, documented slice-refactors). A thorough sweep for the usual targets (duplicated IPC wiring, thin pass-through adapters, dead code, over-broad barrels) turned up **no** meaningful dead code (knip's flags are test-only / re-export false positives) and no thin wrappers to flatten.

The one genuine, self-flagged duplication was the renderer's three imperative overlays. `desktopPdfMessages.ts` literally left a TODO:

> This is the second overlay pattern (settings is the first; diff is the prior). **Once a third overlay arrives we should extract a shared `createOverlay()` factory**; today the duplication is small enough that a shared abstraction would obscure rather than help.

The third overlay has arrived. Settings, diff, and PDF each hand-built the same `wa-dialog` shell — `withoutHeader` / `lightDismiss` / `aria-label`, a titled header, an absolutely-positioned close button, and the `appRoot.append` — before adding their own content, with the `desktop-*` class families copy-pasted per overlay.

## Change

- Add `renderer/overlayDialog.ts` with a single **prefix-driven** `createOverlayDialog`. One `prefix` derives the whole `desktop-*` class family (`-overlay`, `-close`, and — when a `title` is given — `-body`/`-header`/`-title`/`-subtitle`). It returns the dialog plus the title/subtitle nodes for later updates.
- `diffOverlay.ts`, `pdfOverlay.ts`, and the settings dialog in `main.ts` now build only their content element (diff view / iframe / settings-app) and their own behavior (PDF's reopen dance, diff's theme). The close button now has a single home (was previously imported straight into each overlay).
- Update the stale `desktopPdfMessages.ts` comment to point at the new factory.

**No behavior change**: DOM structure, class names, close wiring, `aria-label`s, and content-before-close append order are all preserved exactly. The prefix-derived class strings match the previous literals one-for-one.

## Methods applied

`dedup duplicated logic into shared helpers` + `flatten` (removes the triplicated shell construction and the drift risk between three near-identical overlays; discharges a documented TODO).

## LoC / honesty note

The three overlay bodies collectively shrink by ~52 lines; the new fully-typed + documented factory module is ~76 lines, so raw total LoC is roughly **neutral (~+24)** — a typed shared factory's fixed overhead (imports, two interfaces, doc) is about equal to the boilerplate it removes. The value here is dedup + drift-prevention + a cheap path for future overlays, not deletion. Flagging this transparently rather than dressing it as a LoC win.

## What's left for a future pass

The package is otherwise already clean. Candidates that were considered and **deliberately not** touched:
- `desktopAgentExecution.ts` / `desktopProgressEventBridge.ts` restart-repair machinery — off-limits (adjacent to in-flight PRs #7210/#7221) and correctly a documented slice-refactor.
- The `main.ts` `window.addEventListener('message')` schema ladder and the `error instanceof Error ? error : { error }` log-shaping micro-pattern (9 sites) — real but ~LoC-neutral; not worth churn.

## Verification

- `npm run typecheck` — pass
- `eslint` on all changed files — clean
- `vitest` desktop suites (`DesktopPdfMessages`, `DesktopDiffMessages`, `DesktopThemeTokens`, `DesktopRendererPlatform`) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nbVZZcHVNLBNZ2tESvR7v

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor preserves documented DOM structure, classes, and close wiring; risk is limited to subtle overlay lifecycle edge cases (e.g. PDF hide listeners), mitigated by unchanged behavior intent and existing desktop tests.
> 
> **Overview**
> Introduces **`createOverlayDialog`** in `packages/desktop/src/renderer/overlayDialog.ts` so settings, diff, and PDF overlays no longer each hand-build the same `wa-dialog` shell (`withoutHeader`, `lightDismiss`, `aria-label`, optional titled header, close button, `appRoot` append). A single **`prefix`** drives the existing `desktop-*` class names; callers pass only their content element and keep overlay-specific behavior (PDF reopen/`wa-after-hide`, diff theme, settings tab state).
> 
> **`diffOverlay.ts`**, **`pdfOverlay.ts`**, and the settings path in **`main.ts`** now call the factory instead of duplicating DOM construction; **`desktopPdfMessages.ts`** comments are updated to note all three overlays share the factory.
> 
> The TeXRA Bench proposal doc change is **markdown-only** (table column alignment and `_task_` emphasis)—no design or behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92c4bb6eee905f864c24adefde356c61e21a3eae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->