### PR TITLE
fix(cli): correct exit code and message wording in history --export --assets-dir

### DIFF
--- a/packages/cli/src/commands/history.ts
+++ b/packages/cli/src/commands/history.ts
@@ -111,7 +111,7 @@ async function runHistoryShow(
  * stdout, to be redirected next to (or referenced by) that shared bundle's
  * `index.html?trace=<path>`.
  */
-async function runHistoryExport(
+export async function runHistoryExport(
   context: CliContext,
   id: ExecutionId,
   format: 'html' | 'md',
@@ -167,11 +167,13 @@ async function runHistoryExport(
           'install, so nothing was staged into --assets-dir. Rebuild the ' +
           'CLI (`npm run texra-local:build`) so packages/trace-viewer builds.',
       );
+      writeRawStdout(JSON.stringify(trace));
+      return CliExitCode.Usage;
     }
     writeRawStdout(JSON.stringify(trace));
     writeTextStderr(
-      `Wrote trace data for ${id}. View it via <redirected-path> next to ` +
-        `${destDir}, e.g. ${destDir}/index.html?trace=<relative-path-to-the-redirected-file>.`,
+      `Wrote trace JSON for ${id} to stdout. Save the output to a file, ` +
+        `then open ${destDir}/index.html?trace=<your-filename>.`,
     );
     return CliExitCode.Success;
   }

--- a/packages/cli/src/commands/history.ts
+++ b/packages/cli/src/commands/history.ts
@@ -161,16 +161,15 @@ export async function runHistoryExport(
       resourcesPath: context.resourcesPath,
       destDir,
     });
+    writeRawStdout(JSON.stringify(trace));
     if (staged === 'missing') {
       writeTextStderr(
         'Note: the bundled trace-viewer assets were not found in this CLI ' +
           'install, so nothing was staged into --assets-dir. Rebuild the ' +
           'CLI (`npm run texra-local:build`) so packages/trace-viewer builds.',
       );
-      writeRawStdout(JSON.stringify(trace));
       return CliExitCode.Usage;
     }
-    writeRawStdout(JSON.stringify(trace));
     writeTextStderr(
       `Wrote trace JSON for ${id} to stdout. Save the output to a file, ` +
         `then open ${destDir}/index.html?trace=<your-filename>.`,

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
   deleteAllExecutions: vi.fn(),
   readCliToolUseResumeData: vi.fn(),
   readCliToolUseResumeDataForListing: vi.fn(),
+  assembleTrace: vi.fn(),
 }));
 
 vi.mock('@agent/storage', async () => {
@@ -54,8 +55,27 @@ vi.mock('@cli/runtime/toolUseResumeData', () => ({
   readCliToolUseResumeDataForListing: mocks.readCliToolUseResumeDataForListing,
 }));
 
+vi.mock('@transcript', async () => {
+  const actual =
+    await vi.importActual<typeof import('@transcript')>('@transcript');
+  return {
+    ...actual,
+    assembleTrace: mocks.assembleTrace,
+  };
+});
+
+// `runHistoryExport` calls this unconditionally; the real implementation
+// bootstraps platform agent directories keyed by `resourcesPath`, which is
+// unrelated to (and heavier than) what these tests exercise.
+vi.mock('@cli/runtime/initPlatform', () => ({
+  initLocalCliPlatform: vi.fn(),
+}));
+
 // Imported after vi.mock so the mocked dependencies are in place.
-import { parseHistoryListLimit } from '@cli/commands/history';
+import { parseHistoryListLimit, runHistoryExport } from '@cli/commands/history';
+import type { CliContext } from '@cli/runtime/cliContext';
+import { CliExitCode } from '@cli/runtime/exitCodes';
+import type { TraceDocument } from '@transcript';
 import {
   cliHistoryNdjsonRecords,
   deleteCliHistory,
@@ -1220,6 +1240,124 @@ describe('CLI history runtime', () => {
           ).resolves.toBeNull();
         },
       );
+    });
+
+    describe('runHistoryExport --assets-dir', () => {
+      // Capture every byte written so we can assert on exit code + wording
+      // without the real bytes leaking to the test runner's own stdout/stderr.
+      let stdout = '';
+      let stderr = '';
+      let stdoutSpy: ReturnType<typeof vi.spyOn>;
+      let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+      const trace = {
+        executionId: 'a1',
+        streamId: 'a1',
+        config,
+        meta: null,
+        entries: [],
+        snapshot: { todos: [], plan: null, usage: null },
+        terminalStatus: null,
+      } as unknown as TraceDocument;
+
+      function makeContext(resourcesPath: string): CliContext {
+        return {
+          cwd: '/workspace',
+          mode: 'headless',
+          outputFormat: 'text',
+          approvalPolicy: 'never',
+          colorEnabled: false,
+          version: '0.0.0',
+          resourcesPath,
+        };
+      }
+
+      beforeEach(() => {
+        stdout = '';
+        stderr = '';
+        mocks.assembleTrace.mockResolvedValue({ status: 'ok', trace });
+        stdoutSpy = vi
+          .spyOn(process.stdout, 'write')
+          .mockImplementation((chunk: unknown) => {
+            stdout += String(chunk);
+            return true;
+          }) as unknown as ReturnType<typeof vi.spyOn>;
+        stderrSpy = vi
+          .spyOn(process.stderr, 'write')
+          .mockImplementation((chunk: unknown) => {
+            stderr += String(chunk);
+            return true;
+          }) as unknown as ReturnType<typeof vi.spyOn>;
+      });
+
+      afterEach(() => {
+        stdoutSpy.mockRestore();
+        stderrSpy.mockRestore();
+      });
+
+      it('returns a non-zero exit code (but still writes the trace JSON) when the bundled assets are missing', async () => {
+        await withTempDir(
+          'texra-history-export-missing-src-',
+          async (resourcesPath) => {
+            await withTempDir(
+              'texra-history-export-missing-dest-',
+              async (cwd) => {
+                const destDir = path.join(cwd, 'shared-assets');
+                const exitCode = await runHistoryExport(
+                  makeContext(resourcesPath),
+                  'a1' as ExecutionId,
+                  'html',
+                  { assetsDir: destDir },
+                );
+
+                expect(exitCode).toBe(CliExitCode.Usage);
+                expect(stdout).toBe(JSON.stringify(trace));
+                expect(stderr).toContain('were not found in this CLI install');
+              },
+            );
+          },
+        );
+      });
+
+      it('returns success and writes a concrete (non-placeholder) instruction when assets stage correctly', async () => {
+        await withTempDir(
+          'texra-history-export-staged-src-',
+          async (resourcesPath) => {
+            const traceViewerDir = path.join(resourcesPath, 'traceViewer');
+            await mkdir(traceViewerDir, { recursive: true });
+            await writeFile(
+              path.join(traceViewerDir, 'index.html'),
+              '<html></html>',
+            );
+
+            await withTempDir(
+              'texra-history-export-staged-dest-',
+              async (cwd) => {
+                const destDir = path.join(cwd, 'shared-assets');
+                const exitCode = await runHistoryExport(
+                  makeContext(resourcesPath),
+                  'a1' as ExecutionId,
+                  'html',
+                  { assetsDir: destDir },
+                );
+
+                expect(exitCode).toBe(CliExitCode.Success);
+                expect(stdout).toBe(JSON.stringify(trace));
+                // Must not contain the old literal placeholder tokens, which
+                // read like an unresolved template rather than instructions.
+                expect(stderr).not.toContain('<redirected-path>');
+                expect(stderr).not.toContain(
+                  '<relative-path-to-the-redirected-file>',
+                );
+                expect(stderr).toContain(
+                  `Wrote trace JSON for a1 to stdout. Save the output to a ` +
+                    `file, then open ${destDir}/index.html?trace=<your-filename>.`,
+                );
+              },
+            );
+          },
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
Closes #7231
Closes #7232

## What changed

In `runHistoryExport`'s `--assets-dir` branch (`packages/cli/src/commands/history.ts`):

- **#7231**: when `stageCliHistoryTraceViewerAssets` reports `'missing'` (the bundled trace-viewer assets aren't present in this CLI install, so nothing was staged), the command now returns `CliExitCode.Usage` instead of unconditionally `CliExitCode.Success`. The trace JSON is still written to stdout in this case, since that's still useful for scripting — but the exit code now reflects that no viewable `index.html` exists at `--assets-dir`.
- **#7232**: the success-path stderr message no longer prints the literal placeholder tokens `<redirected-path>` / `<relative-path-to-the-redirected-file>` verbatim (which read like an unresolved template). It now reads as a concrete instruction: `Wrote trace JSON for ${id} to stdout. Save the output to a file, then open ${destDir}/index.html?trace=<your-filename>.`

## Verification

- `npx tsc -p tsconfig.json --noEmit` — clean.
- `npx vitest run src/test-kernel/cli/History.vitest.mts` — 47/47 passing, including two new regression tests covering the `'missing'` exit-code/stdout behavior and the reworded success message (asserting the old placeholder tokens are gone).
- `npx vitest run src/test-kernel/cli/` — 125 files / 1557 tests passing.
- `npx eslint packages/cli/src/commands/history.ts src/test-kernel/cli/History.vitest.mts` — clean.
- `npx prettier --check` on both changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only export messaging and exit-code behavior with regression tests; no auth, data, or core runtime changes.
> 
> **Overview**
> Fixes **`texra history show --export html --assets-dir`** so scripts and humans get honest feedback when shared trace-viewer assets are missing or when export succeeds.
> 
> When bundled trace-viewer files cannot be staged, the command still writes trace JSON to stdout (for piping) but now exits with **`CliExitCode.Usage`** instead of success, since there is no viewable `index.html` at `--assets-dir`. The success-path stderr text no longer prints unresolved-looking placeholders (`<redirected-path>`); it tells users to save stdout to a file and open `index.html?trace=<your-filename>`.
> 
> **`runHistoryExport`** is exported for direct testing; Vitest adds regression coverage for the missing-assets exit code and the reworded success message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e47611ad8b9b8bede7dd36c8b0cc8a80e3a2880a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->