### PR TITLE
refactor(latex): dedupe baseDir resolution in LatexMediaManager

### DIFF
--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -61,6 +61,7 @@ export class LatexMediaManager {
   private async mirrorFigureDependencies(
     latexFile: FileLocation,
     figures: string[],
+    baseDir?: string,
   ): Promise<void> {
     if (!this.fileService?.hasRunDirectory() || figures.length === 0) {
       return;
@@ -69,14 +70,17 @@ export class LatexMediaManager {
     // Resolve against the workspace directory so figure paths from a
     // run-storage symlink map back to real workspace files (otherwise
     // mirrorWorkspaceFile would classify them as external and skip).
-    const baseDir = await resolveLatexDir(latexFile.absolutePath);
+    // Callers that already resolved this for their own purposes (e.g.
+    // extractFiguresFromFiles) pass it in to avoid a redundant async lookup.
+    const resolvedBaseDir =
+      baseDir ?? (await resolveLatexDir(latexFile.absolutePath));
     const absolutePaths = new Set<string>();
     for (const relative of figures) {
       const trimmed = relative?.trim();
       if (!trimmed) {
         continue;
       }
-      absolutePaths.add(path.normalize(path.join(baseDir, trimmed)));
+      absolutePaths.add(path.normalize(path.join(resolvedBaseDir, trimmed)));
     }
 
     if (absolutePaths.size === 0) {
@@ -440,7 +444,7 @@ export class LatexMediaManager {
       }
 
       workspaceState.media.addMediaFiles(fileLocations);
-      mirrorTasks.push(this.mirrorFigureDependencies(file, figures));
+      mirrorTasks.push(this.mirrorFigureDependencies(file, figures, baseDir));
     }
 
     if (mirrorTasks.length > 0) {

--- a/src/test-kernel/latex/LatexProcessingHelpers.vitest.ts
+++ b/src/test-kernel/latex/LatexProcessingHelpers.vitest.ts
@@ -1,5 +1,13 @@
 // Standard library imports
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readlink,
+  realpath,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
@@ -7,7 +15,9 @@ import * as path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - platform
+import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 
 // Local imports - test support
 import { installPlatform as installFakePlatform } from '@test/support/setupPlatform';
@@ -17,19 +27,40 @@ import type { AgentTrace } from '@agent/trace';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 
 // Local imports - latex
-import { LatexMediaManager } from '@latex/LatexMediaManager';
+import {
+  LatexMediaManager,
+  type MediaWorkspaceState,
+} from '@latex/LatexMediaManager';
 import { DiffFileProcessor } from '@latex/latexdiff/diffFileProcessor';
 import type { FileLocation } from '@shared/schemas';
 import type { ToolConfig } from '@shared/schemas/toolConfig';
-import { createExternalLocation } from '@utils/files';
+import {
+  createExternalLocation,
+  createWorkspaceLocation,
+  getRunDir,
+  TaskRunFileService,
+} from '@utils/files';
 
 const mocks = vi.hoisted(() => ({
   compileLatex2Pdf: vi.fn(),
+  resolveLatexDir: vi.fn(),
 }));
 
 vi.mock('@latex/texTools', () => ({
   compileLatex2Pdf: mocks.compileLatex2Pdf,
 }));
+
+// Spy on resolveLatexDir while preserving its real behavior, so tests can
+// assert *how many times* the (async) baseDir resolution runs per file
+// without changing what it resolves to. This is the regression guard for
+// issue #7228: extractFiguresFromFiles and mirrorFigureDependencies used to
+// each independently resolve the same baseDir.
+vi.mock('@latex/latexParsingUtils', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@latex/latexParsingUtils')>();
+  mocks.resolveLatexDir.mockImplementation(actual.resolveLatexDir);
+  return { ...actual, resolveLatexDir: mocks.resolveLatexDir };
+});
 
 type DiffFileProcessorInternals = {
   processLineByLine(content: string): string;
@@ -162,5 +193,134 @@ describe('LatexMediaManager PDF compilation', () => {
     expect(workspaceState.media.files.map((file) => file.absolutePath)).toEqual(
       [compiledPdfPath],
     );
+  });
+});
+
+type LatexMediaManagerFigureInternals = {
+  extractFiguresFromFiles(
+    files: FileLocation[],
+    workspaceState: MediaWorkspaceState,
+  ): Promise<void>;
+  mirrorFiguresForFiles(files: FileLocation[]): Promise<void>;
+};
+
+describe('LatexMediaManager figure baseDir resolution (issue #7228)', () => {
+  function installRunStoragePlatform(
+    workspaceDir: string,
+    storageRoot: string,
+  ): Promise<void> {
+    return installFakePlatform(
+      { workspacePath: workspaceDir },
+      {
+        fs: nodeFilesystem,
+        workspace: createNodeWorkspace(() => workspaceDir),
+        storage: new WorkspaceStorageProvider(storageRoot, workspaceDir),
+      },
+    );
+  }
+
+  async function writeFixture(): Promise<{
+    workspaceDir: string;
+    storageRoot: string;
+    texPath: string;
+    figurePath: string;
+  }> {
+    // Canonicalize up front: on macOS os.tmpdir() lives under a /tmp -> /private/tmp
+    // symlink, and resolveLatexDir follows real paths. Without this, the
+    // workspace root and the realpath'd baseDir it computes would disagree,
+    // and mirrorWorkspaceFile would (correctly, but confusingly for this test)
+    // classify the figure as external and skip mirroring it.
+    const tempDir = await realpath(await makeTempDir());
+    const workspaceDir = path.join(tempDir, 'workspace');
+    const storageRoot = path.join(tempDir, 'storage');
+    const figureDir = path.join(workspaceDir, 'figures');
+    const texPath = path.join(workspaceDir, 'main.tex');
+    const figurePath = path.join(figureDir, 'plot.png');
+
+    await mkdir(figureDir, { recursive: true });
+    await writeFile(
+      texPath,
+      [
+        '\\documentclass{article}',
+        '\\begin{document}',
+        '\\includegraphics{figures/plot.png}',
+        '\\end{document}',
+        '',
+      ].join('\n'),
+    );
+    await writeFile(figurePath, 'fake-png-bytes');
+
+    await installRunStoragePlatform(workspaceDir, storageRoot);
+    return { workspaceDir, storageRoot, texPath, figurePath };
+  }
+
+  /** Resolve the symlink `mirrorWorkspaceFile` creates in run storage and
+   * assert it points back at the real workspace figure. */
+  async function expectFigureMirrored(
+    executionId: string,
+    figurePath: string,
+  ): Promise<void> {
+    const mirroredPath = path.join(getRunDir(executionId), 'figures/plot.png');
+    const stats = await lstat(mirroredPath);
+    expect(stats.isSymbolicLink()).toBe(true);
+    const target = await readlink(mirroredPath);
+    expect(
+      await realpath(path.resolve(path.dirname(mirroredPath), target)),
+    ).toBe(await realpath(figurePath));
+  }
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    await Promise.all(
+      tempDirs
+        .splice(0)
+        .map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it('extractFiguresFromFiles reuses its resolved baseDir instead of re-resolving it in mirrorFigureDependencies', async () => {
+    const executionId = 'extract-basedir-dedup';
+    const { texPath, figurePath } = await writeFixture();
+
+    const workspaceState = AgentWorkspaceState.create();
+    const manager = new LatexMediaManager(
+      logger,
+      new TaskRunFileService(executionId),
+    ) as unknown as LatexMediaManagerFigureInternals;
+    await manager.extractFiguresFromFiles(
+      [createWorkspaceLocation(texPath, 'main.tex')],
+      workspaceState,
+    );
+
+    // Before the fix this was 3: once inside extractFigurePathsFromLatex,
+    // once in extractFiguresFromFiles, and once more (redundantly) in
+    // mirrorFigureDependencies. The mirror call now reuses the baseDir
+    // extractFiguresFromFiles already resolved.
+    expect(mocks.resolveLatexDir).toHaveBeenCalledTimes(2);
+
+    expect(workspaceState.media.files.map((f) => f.absolutePath)).toEqual([
+      figurePath,
+    ]);
+    await expectFigureMirrored(executionId, figurePath);
+  });
+
+  it('mirrorFiguresForFiles (no precomputed baseDir) still resolves and mirrors the correct path', async () => {
+    const executionId = 'mirror-basedir-fallback';
+    const { texPath, figurePath } = await writeFixture();
+
+    const manager = new LatexMediaManager(
+      logger,
+      new TaskRunFileService(executionId),
+    ) as unknown as LatexMediaManagerFigureInternals;
+    await manager.mirrorFiguresForFiles([
+      createWorkspaceLocation(texPath, 'main.tex'),
+    ]);
+
+    // Unchanged by the fix: mirrorFiguresForFiles has no precomputed baseDir,
+    // so mirrorFigureDependencies still resolves it itself (once inside
+    // extractFigurePathsFromLatex, once as the fallback resolution).
+    expect(mocks.resolveLatexDir).toHaveBeenCalledTimes(2);
+
+    await expectFigureMirrored(executionId, figurePath);
   });
 });


### PR DESCRIPTION
Closes #7228

## What changed

`mirrorFigureDependencies` now accepts an optional `baseDir` parameter. `extractFiguresFromFiles` already resolves `baseDir` via `resolveLatexDir(file.absolutePath)` for building `fileLocations`; it now passes that same value into `mirrorFigureDependencies` instead of letting it independently re-resolve the same async lookup.

The other call site, `mirrorFiguresForFiles`, doesn't have a precomputed `baseDir`, so `mirrorFigureDependencies` falls back to resolving it internally (`baseDir ?? (await resolveLatexDir(latexFile.absolutePath))`) — unchanged behavior there.

No behavior change: `resolveLatexDir` is deterministic per absolute path, this just removes the redundant async resolution on the `extractFiguresFromFiles` path.

## Test plan

- Added a regression test (`LatexProcessingHelpers.vitest.ts`) that spies on `resolveLatexDir` (via `vi.mock` with the real implementation preserved) and asserts:
  - `extractFiguresFromFiles` now resolves `baseDir` only twice per file (previously three times: once in `extractFigurePathsFromLatex`, once in `extractFiguresFromFiles`, once more redundantly in `mirrorFigureDependencies`).
  - `mirrorFiguresForFiles` still resolves twice (unchanged — no precomputed `baseDir` at that call site).
  - Both call sites still mirror the figure to the correct absolute path in run storage (verified via the real symlink `mirrorWorkspaceFile` creates).
- Verified the test fails (catches the regression) when the fix's call-site change is manually reverted, then confirmed it passes again with the fix restored.
- `npx tsc --noEmit` and `npx tsc --noEmit -p tsconfig.test-kernel.json`: clean (one pre-existing unrelated failure in `standaloneTraceHtml.vitest.ts`, confirmed present on `origin/main` before this change).
- `npx eslint` on both touched files: clean.
- `npx vitest run src/test-kernel/latex`: all 63 tests pass (14 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nbVZZcHVNLBNZ2tESvR7v

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor with no API surface change beyond a private method parameter; risk is limited to figure path resolution/mirroring, covered by new regression tests.
> 
> **Overview**
> **`mirrorFigureDependencies`** now takes an optional `baseDir`. On the figure-extraction path, **`extractFiguresFromFiles`** passes the `resolveLatexDir` result it already computed for media paths, so mirroring no longer runs the same async lookup a third time per `.tex` file.
> 
> **`mirrorFiguresForFiles`** is unchanged: it still omits `baseDir`, so **`mirrorFigureDependencies`** falls back to `resolveLatexDir` internally.
> 
> Regression tests in **`LatexProcessingHelpers.vitest.ts`** spy on **`resolveLatexDir`** (real implementation preserved) and assert call counts (2 vs the old 3 on extract) plus that figures still symlink into run storage correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3a8be4e015e837f93a969ddbae5e1e2284cc71b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->