### PR TITLE
fix(security): sanitize URL schemes in trace-viewer/progress-view web-tool link rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ### Shared (all surfaces)
 
+#### Bug Fixes
+
+- **Web search/fetch links now block dangerous URL schemes** — a link
+  surfaced from a web search result or fetched page can no longer use a
+  `javascript:`/`data:`/`vbscript:`/`file:` URL to become a live,
+  script-executing link; only `http:`, `https:`, and `mailto:` links render
+  as clickable, in both the Progress View and exported HTML chats.
+
 #### Improvements
 
 - **Read-only tool calls in one model response now run in parallel** —

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters.ts
@@ -17,10 +17,10 @@ import {
   buildDetailsSummary,
   SPINNER_ICON_NAME,
 } from '@progressView/frontend/formatters/htmlBuilders';
-import type {
-  WebSearchPayload,
-  WebFetchPayload,
-  LogMessageData,
+import {
+  WebSearchPayloadSchema,
+  WebFetchPayloadSchema,
+  type LogMessageData,
 } from '@shared/schemas';
 import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
 import { tryParseUrl } from '@utils/core';
@@ -66,7 +66,11 @@ export function formatWebSearchTemplate(
   const { data } = message;
   if (!data || typeof data !== 'object') return null;
 
-  const { query, results, provider, status } = data as WebSearchPayload;
+  // Parsed (not merely cast) so `WebSearchResultItemSchema` actually
+  // sanitizes each result's `url` — a `javascript:`/`data:` scheme from a
+  // web_search tool result must never reach the `<a href>` below.
+  const { query, results, provider, status } =
+    WebSearchPayloadSchema.parse(data);
   const resultCount = Array.isArray(results) ? results.length : 0;
   const providerKey = typeof provider === 'string' ? provider : 'web';
   const statusKey = typeof status === 'string' ? status : '';
@@ -83,9 +87,13 @@ export function formatWebSearchTemplate(
   const sections: TemplateResult[] = [];
 
   if (resultCount > 0) {
+    // `r.url` is already schema-sanitized (`WebSearchResultItemSchema`) to
+    // either a safe URL or `undefined` — never render an `<a>` without a
+    // real href (an empty/missing href is not itself dangerous, but a
+    // result with no safe URL should read as inert text, not a dead link).
     // prettier-ignore
     const resultItems = (results ?? []).map(
-      (r) => html`<li class="detail-item"><wa-icon library=${TEXRA_ICON_LIBRARY} name="link" aria-hidden="true"></wa-icon> <a href=${r.url ?? ''} class="web-search-link" target="_blank" rel="noopener noreferrer">${r.title ?? r.domain ?? r.url}</a>${r.domain ? html` <span class="file-source">(${r.domain})</span>` : ''}</li>`,
+      (r) => html`<li class="detail-item"><wa-icon library=${TEXRA_ICON_LIBRARY} name="link" aria-hidden="true"></wa-icon> ${r.url ? html`<a href=${r.url} class="web-search-link" target="_blank" rel="noopener noreferrer">${r.title ?? r.domain ?? r.url}</a>` : html`<span class="web-search-link">${r.title ?? r.domain ?? ''}</span>`}${r.domain ? html` <span class="file-source">(${r.domain})</span>` : ''}</li>`,
     );
     // prettier-ignore
     const resultsTemplate = html`<span class="file-list-summary">Results (${resultCount})</span><ul class="detail-list">${resultItems}</ul>`;
@@ -134,7 +142,10 @@ export function formatWebFetchTemplate(
   const { data } = message;
   if (!data || typeof data !== 'object') return null;
 
-  const { url, title, status, errorCode } = data as WebFetchPayload;
+  // Parsed (not merely cast) so `WebFetchPayloadSchema` actually sanitizes
+  // `url` — a `javascript:`/`data:` scheme from a web_fetch tool result must
+  // never reach the `<a href>` below.
+  const { url, title, status, errorCode } = WebFetchPayloadSchema.parse(data);
   const statusKey = typeof status === 'string' ? status : '';
   const isFailed = statusKey === 'failed';
 

--- a/src/shared/schemas/progressView/data.ts
+++ b/src/shared/schemas/progressView/data.ts
@@ -5,6 +5,8 @@
  */
 import { z } from 'zod';
 
+import { tryParseUrl } from '@utils/core';
+
 import { AgentCategorySchema } from '../agent';
 import { StreamTabIdSchema } from '../identifiers';
 
@@ -81,8 +83,56 @@ const NormalizedToolUseSchema = z.object({
 });
 export type NormalizedToolUse = z.infer<typeof NormalizedToolUseSchema>;
 
+// ============================================================
+// URL Sanitization
+// ============================================================
+
+/**
+ * Schemes a tool-controlled URL may use when rendered as a live `href`.
+ * Mirrors the retired `SAFE_URL_SCHEMES` from the hand-written HTML chat
+ * exporter's `safeUrl()` helper (deleted with `formatChatAsHtml` in #7137;
+ * see git history) — `web_search`/`web_fetch` results carry LLM/tool
+ * output verbatim, so a `javascript:`/`data:`/`vbscript:`/`file:` URL must
+ * never reach an anchor's `href`, where it becomes a live, script-executing
+ * link. Sanitizing here (schema level) covers both the live Progress View
+ * webview and exported standalone HTML — the export has no CSP and is
+ * opened with full privileges via `file://` or `vscode.env.openExternal` —
+ * since both render through this shared schema.
+ */
+const SAFE_URL_SCHEMES = new Set(['http:', 'https:', 'mailto:']);
+
+/**
+ * Returns `raw` unchanged if it's safe to render as an `href`, or
+ * `undefined` if it isn't, so callers can omit the link (or fall back to
+ * plain text) instead of rendering a live anchor. Behavior matches the
+ * retired `safeUrl()` exactly:
+ * - trims surrounding whitespace
+ * - empty string → unsafe (nothing to link to)
+ * - anchor-only (`#foo`) → safe as-is, no scheme to abuse
+ * - root-relative (`/foo`, but NOT protocol-relative `//foo`) → safe as-is
+ * - everything else must parse as an absolute URL (via the `URL` global,
+ *   so protocol-relative `//foo` fails here too) with an allow-listed
+ *   scheme
+ */
+function sanitizeUrl(raw: string): string | undefined {
+  const trimmed = raw.trim();
+  if (trimmed === '') return undefined;
+  if (trimmed.startsWith('#')) return trimmed;
+  if (trimmed.startsWith('/') && !trimmed.startsWith('//')) return trimmed;
+  const url = tryParseUrl(trimmed);
+  if (!url) return undefined;
+  return SAFE_URL_SCHEMES.has(url.protocol) ? trimmed : undefined;
+}
+
+/**
+ * A URL field that sanitizes on parse. An unsafe scheme collapses to
+ * `undefined` rather than failing the parse, so one malicious field in an
+ * otherwise-valid tool payload doesn't reject the whole message.
+ */
+const SafeUrlSchema = z.string().transform(sanitizeUrl);
+
 export const WebSearchResultItemSchema = z.object({
-  url: z.string().optional(),
+  url: SafeUrlSchema.optional(),
   title: z.string().optional(),
   domain: z.string().optional(),
 });
@@ -96,7 +146,7 @@ export const WebSearchPayloadSchema = z.object({
 export type WebSearchPayload = z.infer<typeof WebSearchPayloadSchema>;
 
 export const WebFetchPayloadSchema = z.object({
-  url: z.string().optional(),
+  url: SafeUrlSchema.optional(),
   title: z.string().optional(),
   provider: z.string().optional(),
   status: z.string().optional(),

--- a/src/test-kernel/progressView/WebFormattersUrlSanitization.vitest.mts
+++ b/src/test-kernel/progressView/WebFormattersUrlSanitization.vitest.mts
@@ -1,0 +1,142 @@
+/**
+ * Regression coverage for issue #7230 at the *rendering* layer: even with
+ * schema-level sanitization (`WebUrlSanitization.vitest.ts`), the formatters
+ * that bind `href` from web_search/web_fetch tool payloads
+ * (`webFormatters.ts`) must never emit a live anchor for a dangerous scheme,
+ * and must still render legitimate links normally.
+ */
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - shared schemas
+import { LOG_LEVELS, type LogMessageData } from '@shared/schemas';
+
+// Local imports - test utilities
+import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
+
+useLitComponentTestDom(
+  () =>
+    import('@progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters'),
+);
+
+function webSearchMessage(url: string): LogMessageData {
+  return {
+    id: 'web-search-1',
+    text: '',
+    level: LOG_LEVELS.INFO,
+    timestamp: 1,
+    messageType: 'webSearch',
+    data: {
+      query: 'test query',
+      provider: 'anthropic',
+      status: 'completed',
+      results: [{ url, title: 'Click me', domain: 'example.com' }],
+    },
+  };
+}
+
+function webFetchMessage(url: string): LogMessageData {
+  return {
+    id: 'web-fetch-1',
+    text: '',
+    level: LOG_LEVELS.INFO,
+    timestamp: 1,
+    messageType: 'webFetch',
+    data: {
+      url,
+      title: 'Fetched page',
+      status: 'completed',
+    },
+  };
+}
+
+const DANGEROUS_URLS = [
+  'javascript:alert(1)',
+  'data:text/html,<script>alert(1)</script>',
+  'vbscript:msgbox(1)',
+  'file:///etc/passwd',
+];
+
+describe('web-search/web-fetch formatters: URL scheme sanitization', () => {
+  describe('web_search results', () => {
+    it.each(DANGEROUS_URLS)(
+      'never renders %s as a clickable href',
+      async (url) => {
+        const { formatWebSearchTemplate } =
+          await import('@progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters');
+        const { render } = await import('lit');
+
+        const container = document.createElement('div');
+        render(formatWebSearchTemplate(webSearchMessage(url)), container);
+
+        // The single result carries only a dangerous URL, so it must render
+        // as inert text — no anchor at all, not merely an anchor with a
+        // neutralized href.
+        expect(container.querySelectorAll('a').length).toBe(0);
+        // The result should still be visible (as inert text), just not linked.
+        expect(container.textContent).toContain('Click me');
+      },
+    );
+
+    it('renders a legitimate https URL as a real clickable href', async () => {
+      const { formatWebSearchTemplate } =
+        await import('@progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters');
+      const { render } = await import('lit');
+      const url = 'https://example.com/article?id=42';
+
+      const container = document.createElement('div');
+      render(formatWebSearchTemplate(webSearchMessage(url)), container);
+
+      const anchor = container.querySelector('a.web-search-link');
+      expect(anchor).not.toBeNull();
+      expect(anchor?.getAttribute('href')).toBe(url);
+      expect(anchor?.textContent).toContain('Click me');
+    });
+
+    it('renders a mailto URL as a real clickable href', async () => {
+      const { formatWebSearchTemplate } =
+        await import('@progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters');
+      const { render } = await import('lit');
+      const url = 'mailto:someone@example.com';
+
+      const container = document.createElement('div');
+      render(formatWebSearchTemplate(webSearchMessage(url)), container);
+
+      const anchor = container.querySelector('a.web-search-link');
+      expect(anchor?.getAttribute('href')).toBe(url);
+    });
+  });
+
+  describe('web_fetch payloads', () => {
+    it.each(DANGEROUS_URLS)(
+      'never renders %s as a clickable href',
+      async (url) => {
+        const { formatWebFetchTemplate } =
+          await import('@progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters');
+        const { render } = await import('lit');
+
+        const container = document.createElement('div');
+        render(formatWebFetchTemplate(webFetchMessage(url)), container);
+
+        // The "URL:" section is only rendered when a safe URL survives
+        // sanitization, so a dangerous URL must produce no anchor at all.
+        expect(container.querySelectorAll('a').length).toBe(0);
+      },
+    );
+
+    it('renders a legitimate https URL as a real clickable href', async () => {
+      const { formatWebFetchTemplate } =
+        await import('@progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters');
+      const { render } = await import('lit');
+      const url = 'https://example.com/doc.pdf';
+
+      const container = document.createElement('div');
+      render(formatWebFetchTemplate(webFetchMessage(url)), container);
+
+      const anchor = container.querySelector('a.web-search-link');
+      expect(anchor).not.toBeNull();
+      expect(anchor?.getAttribute('href')).toBe(url);
+      expect(anchor?.textContent).toBe(url);
+    });
+  });
+});

--- a/src/test-kernel/schemas/WebUrlSanitization.vitest.ts
+++ b/src/test-kernel/schemas/WebUrlSanitization.vitest.ts
@@ -1,0 +1,111 @@
+/**
+ * Regression coverage for issue #7230: `web_search`/`web_fetch` `url` fields
+ * are LLM/tool-controlled and must never carry a dangerous scheme through to
+ * a rendered `<a href>` — in the live Progress View webview OR the exported
+ * standalone HTML (which has no CSP). The sanitization lives at the schema
+ * level (`WebSearchResultItemSchema` / `WebFetchPayloadSchema` in
+ * `src/shared/schemas/progressView/data.ts`) so both render paths, which
+ * share the same formatters, are protected by one fix.
+ *
+ * Expected behavior mirrors the retired hand-written HTML exporter's
+ * `safeUrl()` (deleted with `formatChatAsHtml` in #7137 — see
+ * `git log -p -S SAFE_URL_SCHEMES`): only `http:`/`https:`/`mailto:` survive
+ * scheme validation; anchor-only (`#foo`) and root-relative (`/foo`, not
+ * `//foo`) URLs pass through unchecked since there's no scheme to abuse;
+ * everything else (empty, unparseable, protocol-relative, dangerous scheme)
+ * collapses to `undefined`.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { WebFetchPayloadSchema, WebSearchPayloadSchema } from '@shared/schemas';
+
+function parseSearchUrl(url: string): string | undefined {
+  return WebSearchPayloadSchema.parse({
+    results: [{ url, title: 'result' }],
+  }).results?.[0]?.url;
+}
+
+function parseFetchUrl(url: string): string | undefined {
+  return WebFetchPayloadSchema.parse({ url }).url;
+}
+
+describe('web tool URL sanitization (issue #7230)', () => {
+  describe('dangerous schemes are stripped', () => {
+    const dangerous = [
+      'javascript:alert(1)',
+      'javascript:alert(document.cookie)',
+      'JavaScript:alert(1)', // scheme match must not be case-sensitive-bypassable
+      'data:text/html,<script>alert(1)</script>',
+      'data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==',
+      'vbscript:msgbox(1)',
+      'file:///etc/passwd',
+      '  javascript:alert(1)', // leading whitespace shouldn't bypass the scheme check
+      'javascript:alert(1)  ', // trailing whitespace likewise
+    ];
+
+    it.each(dangerous)('strips %s from web_search results', (url) => {
+      expect(parseSearchUrl(url)).toBeUndefined();
+    });
+
+    it.each(dangerous)('strips %s from web_fetch payloads', (url) => {
+      expect(parseFetchUrl(url)).toBeUndefined();
+    });
+  });
+
+  it('strips protocol-relative URLs (no scheme to validate against)', () => {
+    expect(parseSearchUrl('//evil.example.com/path')).toBeUndefined();
+    expect(parseFetchUrl('//evil.example.com/path')).toBeUndefined();
+  });
+
+  it('strips the empty string', () => {
+    expect(parseSearchUrl('')).toBeUndefined();
+    expect(parseFetchUrl('')).toBeUndefined();
+  });
+
+  it('strips whitespace-only URLs', () => {
+    expect(parseSearchUrl('   ')).toBeUndefined();
+  });
+
+  describe('legitimate URLs still render', () => {
+    const safe = [
+      'http://example.com',
+      'https://example.com/path?query=1#frag',
+      'mailto:someone@example.com',
+      'https://sub.example.co.uk:8443/a/b?c=d&e=f',
+      '  https://example.com/padded  ', // whitespace-padded but otherwise safe
+    ];
+
+    it.each(safe)('keeps %s as a live href for web_search', (url) => {
+      expect(parseSearchUrl(url)).toBe(url.trim());
+    });
+
+    it.each(safe)('keeps %s as a live href for web_fetch', (url) => {
+      expect(parseFetchUrl(url)).toBe(url.trim());
+    });
+  });
+
+  it('keeps anchor-only fragments as-is', () => {
+    expect(parseSearchUrl('#section-2')).toBe('#section-2');
+  });
+
+  it('keeps root-relative paths as-is', () => {
+    expect(parseSearchUrl('/local/path')).toBe('/local/path');
+  });
+
+  it('sanitizes each item independently in a mixed results list', () => {
+    const parsed = WebSearchPayloadSchema.parse({
+      results: [
+        { url: 'javascript:alert(1)', title: 'evil' },
+        { url: 'https://example.com', title: 'safe' },
+      ],
+    });
+
+    expect(parsed.results?.[0]?.url).toBeUndefined();
+    expect(parsed.results?.[1]?.url).toBe('https://example.com');
+  });
+
+  it('leaves a missing url as undefined without throwing', () => {
+    expect(WebSearchPayloadSchema.parse({}).results).toBeUndefined();
+    expect(WebFetchPayloadSchema.parse({}).url).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #7230

## What changed

Retiring the hand-written HTML chat exporter (#7202/#7137) deleted its `safeUrl()` helper and `SAFE_URL_SCHEMES` allowlist (`http:`/`https:`/`mailto:`) with no replacement. The new shared render path binds `href=${url}` directly from `web_search`/`web_fetch` tool payloads with no scheme check, so a `javascript:`/`data:` URL surfacing in a tool result becomes a live, script-executing link — in both the live Progress View webview and the exported standalone HTML (no CSP, opened via `file://` or `vscode.env.openExternal`).

Fixed at the schema level, per the issue's own recommendation, so one fix protects both surfaces (the live webview and the trace-viewer-based HTML export both render through the same Progress View formatters):

- `src/shared/schemas/progressView/data.ts`: `WebSearchResultItemSchema.url` and `WebFetchPayloadSchema.url` now run through a `SafeUrlSchema` transform (`sanitizeUrl`) that reproduces the retired `safeUrl()` exactly — trims whitespace, allows anchor-only (`#foo`) and root-relative (`/foo`, not `//foo`) URLs through unchecked, and otherwise requires the URL to parse (via the `URL` global — so protocol-relative `//foo` is rejected too, matching the old exporter's own regression test) with an allow-listed scheme. Unsafe values collapse to `undefined` instead of failing the whole parse.
- `packages/extension/.../webFormatters.ts`: switched from a raw `data as WebSearchPayload` / `data as WebFetchPayload` type assertion (which never actually validated anything at runtime) to a real `WebSearchPayloadSchema.parse(data)` / `WebFetchPayloadSchema.parse(data)`, so the sanitizing transform actually runs — defense in depth, since the schema alone was previously unreachable from this render path. Also adjusted the web-search result template to render inert `<span>` text instead of an `<a href="">` when no safe URL survives (previously `r.url ?? ''` could leave a dangling empty-href anchor).
- Grepped `packages/extension/src/progressView/frontend/formatters/` and the wider webview/settingsView tree for other `href=` bindings from LLM/tool-controlled fields: the only two sites are the ones this PR fixes (lines ~88/~154 of `webFormatters.ts`, both now sanitized). The other `href=` bindings found (`ExternalInquiryPanel.ts`, `ApiAccessSection.ts`) are hardcoded internal marketing/support URLs, not tool-controlled. The markdown-rendering `unsafeHTML` sites (`bannerFormatters.ts`, `htmlBuilders.ts`) go through the existing markdown-it pipeline, which has its own link-scheme validation — out of scope for this issue.

## Verification against the retired `safeUrl()`

Recovered the deleted implementation via `git log -p -S SAFE_URL_SCHEMES` (from `a30d56f36`, the commit that removed `src/agent/export/htmlExport/htmlFormatter.ts`) and matched its edge cases exactly in the new `sanitizeUrl()`:

- empty string → rejected (no scheme to abuse)
- `#foo` → passed through as-is
- `/foo` (root-relative, not `//foo`) → passed through as-is
- `//evil.example.com` (protocol-relative) → rejected — confirmed against the old exporter's own `"strips protocol-relative URLs from tool-provided links"` test, which exists because `tryParseUrl` (`new URL(...)`, no base) throws on a schemeless/protocol-relative string
- anything else must parse as an absolute `URL` with scheme in `{http:, https:, mailto:}`; whitespace is trimmed first, so leading/trailing padding around an otherwise-safe or otherwise-dangerous URL doesn't change the verdict

## Testing

- `src/test-kernel/schemas/WebUrlSanitization.vitest.ts` (new): schema-level coverage — `javascript:`, `data:` (raw and base64), `vbscript:`, `file:`, mixed-case `JavaScript:`, whitespace-padded dangerous URLs, protocol-relative, empty/whitespace-only all sanitize to `undefined`; `http:`/`https:`/`mailto:` (including whitespace-padded and query/fragment/port variants), anchor-only, and root-relative URLs all pass through unchanged (trimmed); mixed valid/invalid results lists sanitize independently; missing `url` doesn't throw.
- `src/test-kernel/progressView/WebFormattersUrlSanitization.vitest.mts` (new): formatter-level coverage using the existing `useLitComponentTestDom` harness — renders `formatWebSearchTemplate`/`formatWebFetchTemplate` into a real DOM and asserts a dangerous-scheme URL produces **zero** `<a>` elements (not merely a neutralized `href`), while a legitimate `https:`/`mailto:` URL still renders as a real clickable anchor with the exact expected `href`.
- `npx tsc --noEmit` (root) and `pnpm --filter texra typecheck` (extension package): clean. `npm run typecheck`'s one failure (`standaloneTraceHtml.vitest.ts` missing `schemaVersion`) is pre-existing on `origin/main`, unrelated to this change (confirmed via `git stash` + re-run).
- `eslint` on all changed/new files: clean.
- Full `src/test-kernel/progressView` + `src/test-kernel/schemas` + the export-controller/trace-html suites: 40 files / 208 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-sensitive rendering of LLM-controlled URLs in privileged webviews/exports; behavior is narrowly scoped with tests mirroring the old safeUrl() rules.
> 
> **Overview**
> **Blocks script-executing links** from `web_search` / `web_fetch` tool output in the Progress View and exported HTML chats (#7230).
> 
> Shared Progress View schemas now run tool-controlled `url` fields through `SafeUrlSchema`, restoring the retired HTML exporter’s `safeUrl()` rules: only `http:`, `https:`, and `mailto:` become live `href`s; `javascript:`, `data:`, `vbscript:`, `file:`, protocol-relative, and empty values collapse to `undefined` without failing the whole payload.
> 
> `webFormatters.ts` **parses** payloads with `WebSearchPayloadSchema` / `WebFetchPayloadSchema` (instead of type assertions) so sanitization actually runs at render time, and web-search results without a safe URL show **inert text** instead of a dead `<a href="">`.
> 
> Regression tests cover schema parsing and Lit formatter DOM output; the changelog documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17a27d27af5fd53a60d92989e3942a6c740e57ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->