### PR TITLE
fix(trace-viewer): validate loaded trace data against a schema before replay

### DIFF
--- a/packages/trace-viewer/src/main.ts
+++ b/packages/trace-viewer/src/main.ts
@@ -19,6 +19,7 @@ import {
 } from '@progressView/frontend/eventHandlers';
 
 import { replayTrace } from './replayTrace';
+import { parseTraceData } from './traceDataSchema';
 import type { TraceDocument } from '@transcript';
 
 const root = document.querySelector<HTMLElement>('#app');
@@ -50,19 +51,21 @@ conversationView.addEventListener(
  * sidecar JSON — `fetch()` of a local file fails entirely under `file://`,
  * regardless of bundling), or a fetched `trace.json` next to the page (the
  * default when served over http/https, e.g. a static site hosting many
- * traces that shouldn't duplicate the bundle per page). Both paths feed the
- * exact same `replayTrace`.
+ * traces that shouldn't duplicate the bundle per page). Both paths are
+ * externally-authored (exported by whatever TeXRA version produced them), so
+ * both get validated through the same `parseTraceData` boundary before
+ * feeding the exact same `replayTrace` — a stale/malformed trace file throws
+ * a clear error here instead of failing deep inside `dispatchMessage`.
  */
 async function loadTrace(): Promise<TraceDocument> {
-  const inline = (window as { __TEXRA_TRACE__?: TraceDocument })
-    .__TEXRA_TRACE__;
-  if (inline) return inline;
+  const inline = (window as { __TEXRA_TRACE__?: unknown }).__TEXRA_TRACE__;
+  if (inline) return parseTraceData(inline);
 
   const params = new URLSearchParams(window.location.search);
   const file = params.get('trace') ?? 'trace.json';
   const res = await fetch(file);
   if (!res.ok) throw new Error(`Failed to fetch ${file}: ${res.status}`);
-  return res.json();
+  return parseTraceData(await res.json());
 }
 
 loadTrace()

--- a/packages/trace-viewer/src/traceDataSchema.ts
+++ b/packages/trace-viewer/src/traceDataSchema.ts
@@ -1,0 +1,67 @@
+/**
+ * Runtime validation for trace data loaded by `main.ts`'s `loadTrace()` —
+ * either fetched (`trace.json`) or inlined (`window.__TEXRA_TRACE__`).
+ *
+ * This is the trace-viewer's external boundary: the data was authored by
+ * whatever TeXRA version produced the export (CLI, extension, or desktop),
+ * and `main.ts` has no static guarantee it matches this build's expected
+ * shape. Mirrors `TraceDocument` (`@transcript/traceAssembler`) field-for-
+ * field, reusing the same shared schemas that already define its parts
+ * (`StreamSnapshotSchema`, `StreamLogEntrySchema`, `AgentConfigSchema`,
+ * `ExecutionMetaSchema`, …) rather than re-deriving them, so this schema
+ * tracks the real document shape instead of drifting from it.
+ */
+import { z } from 'zod';
+
+import { ExecutionMetaSchema } from '@agent/storage';
+import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
+import {
+  ExecutionIdSchema,
+  ExecutionStatusSchema,
+  StreamLogEntrySchema,
+  StreamSnapshotSchema,
+  StreamTabIdSchema,
+} from '@shared/schemas';
+import type { TraceDocument } from '@transcript/traceAssembler';
+
+export const TraceDataSchema = z.object({
+  executionId: ExecutionIdSchema,
+  streamId: StreamTabIdSchema,
+  config: AgentConfigSchema,
+  meta: ExecutionMetaSchema.nullable(),
+  entries: z.array(StreamLogEntrySchema),
+  snapshot: StreamSnapshotSchema,
+  terminalStatus: ExecutionStatusSchema.nullable(),
+});
+
+export type TraceData = z.infer<typeof TraceDataSchema>;
+
+/**
+ * Compile-time check that this schema's inferred shape actually accepts what
+ * `assembleTrace` produces — kept in sync with `TraceDocument` rather than a
+ * hand-maintained duplicate, so a field added/renamed there surfaces here as
+ * a type error instead of a silent validation gap.
+ */
+type _AssertTraceDataAcceptsTraceDocument = TraceDocument extends TraceData
+  ? true
+  : never;
+
+/**
+ * Parses raw trace data (from `fetch()` or `window.__TEXRA_TRACE__`) against
+ * {@link TraceDataSchema}. Throws a descriptive error identifying the trace
+ * file as malformed/incompatible rather than letting an arbitrary shape flow
+ * into `replayTrace()` → `dispatchMessage()`, which assumes the shape is
+ * already correct and would otherwise fail with a cryptic error deep inside
+ * a handler.
+ */
+export function parseTraceData(raw: unknown): TraceData {
+  const result = TraceDataSchema.safeParse(raw);
+  if (!result.success) {
+    throw new Error(
+      'Trace data does not match the expected schema — this trace file may ' +
+        'have been exported by an incompatible TeXRA version:\n' +
+        z.prettifyError(result.error),
+    );
+  }
+  return result.data;
+}

--- a/packages/trace-viewer/src/traceDataSchema.ts
+++ b/packages/trace-viewer/src/traceDataSchema.ts
@@ -6,29 +6,72 @@
  * whatever TeXRA version produced the export (CLI, extension, or desktop),
  * and `main.ts` has no static guarantee it matches this build's expected
  * shape. Mirrors `TraceDocument` (`@transcript/traceAssembler`) field-for-
- * field, reusing the same shared schemas that already define its parts
- * (`StreamSnapshotSchema`, `StreamLogEntrySchema`, `AgentConfigSchema`,
- * `ExecutionMetaSchema`, …) rather than re-deriving them, so this schema
- * tracks the real document shape instead of drifting from it.
+ * field while keeping runtime imports browser-safe. `@agent/*` schemas pull
+ * extension/runtime dependencies into the trace-viewer bundle, so the agent
+ * config and execution meta shapes are mirrored here with type-only
+ * compatibility assertions against their source types.
  */
 import { z } from 'zod';
 
-import { ExecutionMetaSchema } from '@agent/storage';
-import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import type { ExecutionMeta } from '@agent/storage';
+import { AgentCategorySchema, AgentSourceSchema } from '@shared/schemas/agent';
 import {
   ExecutionIdSchema,
-  ExecutionStatusSchema,
-  StreamLogEntrySchema,
-  StreamSnapshotSchema,
   StreamTabIdSchema,
-} from '@shared/schemas';
+} from '@shared/schemas/identifiers';
+import { NullableFileFieldsSchema } from '@shared/schemas/fileFields';
+import { StreamLogEntrySchema } from '@shared/schemas/log';
+import {
+  ExecutionStatusSchema,
+  RunOutcomeSchema,
+} from '@shared/schemas/stream';
+import { StreamSnapshotSchema } from '@shared/schemas/streamSnapshot';
+import { ToolConfigSchema } from '@shared/schemas/toolConfig';
 import type { TraceDocument } from '@transcript/traceAssembler';
+
+const TRACE_EXECUTION_META_SCHEMA_VERSION = 1;
+
+const TraceAgentConfigSchema = NullableFileFieldsSchema.extend({
+  agent: z.string(),
+  agentSource: AgentSourceSchema.nullish(),
+  model: z.string(),
+  instruction: z.string(),
+  displayInstruction: z.string().nullish(),
+  agentCategory: AgentCategorySchema,
+  editedFiles: z.array(z.string()),
+  toolConfig: ToolConfigSchema,
+  memories: z.array(z.string()),
+  workingDirectory: z.string().nullish(),
+  cliOutputFile: z.string().nullish(),
+  cliMultiAgentPresetId: z.string().nullish(),
+}).superRefine((config, ctx) => {
+  if (config.outputFiles.length > config.inputFiles.length) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['outputFiles'],
+      message:
+        'Number of output files must not be greater than the number of input files.',
+    });
+  }
+});
+
+const TraceExecutionMetaSchema = z.object({
+  schemaVersion: z.literal(TRACE_EXECUTION_META_SCHEMA_VERSION).prefault(1),
+  timestamp: z.string(),
+  parentExecutionId: ExecutionIdSchema.optional(),
+  terminalStatus: z.string().optional(),
+  outcome: RunOutcomeSchema.optional(),
+  category: z.string().optional(),
+  description: z.string().optional(),
+  delegationDepth: z.int().nonnegative().optional(),
+});
 
 export const TraceDataSchema = z.object({
   executionId: ExecutionIdSchema,
   streamId: StreamTabIdSchema,
-  config: AgentConfigSchema,
-  meta: ExecutionMetaSchema.nullable(),
+  config: TraceAgentConfigSchema,
+  meta: TraceExecutionMetaSchema.nullable(),
   entries: z.array(StreamLogEntrySchema),
   snapshot: StreamSnapshotSchema,
   terminalStatus: ExecutionStatusSchema.nullable(),
@@ -45,6 +88,10 @@ export type TraceData = z.infer<typeof TraceDataSchema>;
 type _AssertTraceDataAcceptsTraceDocument = TraceDocument extends TraceData
   ? true
   : never;
+type _AssertTraceAgentConfigAcceptsAgentConfig =
+  AgentConfig extends z.infer<typeof TraceAgentConfigSchema> ? true : never;
+type _AssertTraceExecutionMetaAcceptsExecutionMeta =
+  ExecutionMeta extends z.infer<typeof TraceExecutionMetaSchema> ? true : never;
 
 /**
  * Parses raw trace data (from `fetch()` or `window.__TEXRA_TRACE__`) against

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -9,6 +9,7 @@ export {
   type ExecutionKVStore,
   type ExecutionMeta,
   type ExecutionMetaInput,
+  ExecutionMetaSchema,
   type TodoEntry,
   type ChildRecord,
   type ResultMeta,

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -9,7 +9,6 @@ export {
   type ExecutionKVStore,
   type ExecutionMeta,
   type ExecutionMetaInput,
-  ExecutionMetaSchema,
   type TodoEntry,
   type ChildRecord,
   type ResultMeta,

--- a/src/test-kernel/transcript/traceViewerSchema.vitest.ts
+++ b/src/test-kernel/transcript/traceViewerSchema.vitest.ts
@@ -1,0 +1,174 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createFakePlatform } from '@test/support/FakePlatform';
+import { setupPlatform } from '@test/support/setupPlatform';
+import { MemoryStateStore } from '@platform/defaults/memoryState';
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
+import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
+import {
+  assembleTrace,
+  getDefaultStreamLogStore,
+  setDefaultStreamLogStore,
+  StreamLogStore,
+} from '@transcript';
+import { getExecutionStore } from '@agent/storage';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import { getStreamTabId } from '@agent/runtime/streamTab';
+import {
+  EXECUTION_STATUS,
+  LOG_LEVELS,
+  MESSAGE_TYPES,
+  STREAM_LOG_ENTRY_TYPES,
+  type ExecutionId,
+} from '@shared/schemas';
+import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
+import {
+  parseTraceData,
+  TraceDataSchema,
+} from '../../../packages/trace-viewer/src/traceDataSchema';
+import type { Platform } from '@platform/platform';
+
+const tempDirs: string[] = [];
+
+async function buildStoragePlatform(): Promise<Platform> {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'texra-trace-viewer-'));
+  tempDirs.push(tempDir);
+  const workspaceDir = path.join(tempDir, 'workspace');
+  const storageRoot = path.join(tempDir, 'storage');
+  return createFakePlatform(
+    { workspacePath: workspaceDir },
+    {
+      fs: nodeFilesystem,
+      workspace: createNodeWorkspace(() => workspaceDir),
+      storage: new WorkspaceStorageProvider(storageRoot, workspaceDir),
+      globalState: new MemoryStateStore(),
+      workspaceState: new MemoryStateStore(),
+    },
+  );
+}
+
+function config(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    inputFiles: [],
+    contextFiles: [],
+    mediaFiles: [],
+    outputFiles: [],
+    editedFile: null,
+    agent: 'orchestrator',
+    model: 'deepseekT',
+    instruction: 'Solve the problem.',
+    agentCategory: AgentCategory.ToolUse,
+    editedFiles: [],
+    toolConfig: DEFAULT_TOOL_CONFIG,
+    memories: [],
+    workingDirectory: '/workspace',
+    cliOutputFile: null,
+    cliMultiAgentPresetId: null,
+    ...overrides,
+  };
+}
+
+describe('trace-viewer TraceDataSchema', () => {
+  let previousStreamLogStore: StreamLogStore;
+
+  setupPlatform(buildStoragePlatform);
+
+  beforeEach(() => {
+    previousStreamLogStore = getDefaultStreamLogStore();
+    setDefaultStreamLogStore(new StreamLogStore());
+  });
+
+  afterEach(async () => {
+    setDefaultStreamLogStore(previousStreamLogStore);
+    await Promise.all(
+      tempDirs
+        .splice(0)
+        .map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it('accepts a real trace document produced by assembleTrace', async () => {
+    const executionId = 'abc12345' as ExecutionId;
+    const executionConfig = config({ agent: 'review', model: 'sonnet46T' });
+
+    await getExecutionStore(executionId).writeConfig(executionConfig);
+    await getExecutionStore(executionId).writeMeta({
+      timestamp: '2026-07-05T00:00:00.000Z',
+      outcome: 'completed',
+    });
+
+    const streamId = getStreamTabId('review', 'sonnet46T', { executionId });
+    const store = getDefaultStreamLogStore();
+    await store.load();
+    store.append(streamId, {
+      id: 'entry-1',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 100,
+      messageType: MESSAGE_TYPES.DEFAULT,
+      text: 'hello',
+    });
+    await store.flush();
+
+    const result = await assembleTrace(executionId);
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+
+    const parsed = TraceDataSchema.safeParse(result.trace);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.executionId).toBe(executionId);
+    expect(parsed.data.streamId).toBe(streamId);
+    expect(parsed.data.terminalStatus).toBe(EXECUTION_STATUS.COMPLETED);
+    expect(parsed.data.entries).toHaveLength(1);
+
+    // parseTraceData must accept the same real document without throwing.
+    expect(() => parseTraceData(result.trace)).not.toThrow();
+  });
+
+  it('rejects a trace missing required top-level fields', () => {
+    const malformed = {
+      executionId: 'abcdef',
+      streamId: 'stream-1',
+      // config, meta, entries, snapshot, terminalStatus all missing.
+    };
+
+    const result = TraceDataSchema.safeParse(malformed);
+    expect(result.success).toBe(false);
+  });
+
+  it('throws a clear, identifying error via parseTraceData for a malformed trace', () => {
+    const malformed = { totally: 'not a trace' };
+
+    expect(() => parseTraceData(malformed)).toThrowError(
+      /does not match the expected schema/,
+    );
+  });
+
+  it('rejects a trace whose entries are not an array of StreamLogEntry', () => {
+    const malformed = {
+      executionId: 'abcdef',
+      streamId: 'stream-1',
+      config: config(),
+      meta: null,
+      entries: [{ notAStreamLogEntry: true }],
+      snapshot: { streamId: 'stream-1' },
+      terminalStatus: null,
+    };
+
+    const result = TraceDataSchema.safeParse(malformed);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a null/undefined/primitive trace payload', () => {
+    expect(TraceDataSchema.safeParse(null).success).toBe(false);
+    expect(TraceDataSchema.safeParse(undefined).success).toBe(false);
+    expect(TraceDataSchema.safeParse('trace').success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds runtime validation at the trace-viewer load boundary for fetched `trace.json` and inline `window.__TEXRA_TRACE__` data before replay.

The CI fix keeps that schema browser-safe: `packages/trace-viewer/src/traceDataSchema.ts` reuses shared browser-safe schemas and mirrors the agent config / execution meta shapes with type-only compatibility assertions, instead of importing `@agent/*` runtime modules into the Vite browser bundle.

## Issue acceptance gates

#7187: loaded trace data is schema-validated before `replayTrace()`; malformed or incompatible traces throw a clear trace-shape error through the existing trace-viewer error path.

## Single source of truth

`packages/trace-viewer/src/traceDataSchema.ts` is the trace-viewer validation boundary for externally loaded trace payloads. `TraceDocument` remains the source type for the replay document shape, enforced through compile-time compatibility assertions.

## Duplication and abstraction budget

No pass-through layer was added. The trace-viewer keeps a small browser-safe mirror for `AgentConfig` and `ExecutionMeta` because importing the source `@agent/*` schemas pulls Node-only dependencies into the browser build; type-only assertions keep the mirror honest.

## Host impact

Extension: trace-viewer assets build again, and malformed trace JSON is rejected before replay.

Desktop: no runtime behavior change.

CLI: exported trace-viewer HTML validates inline trace data before replay; CLI command output contracts are unchanged.

## Scheduled refactoring

None. No legacy-retirement ledger row is needed because this PR adds no shim, fallback, dual-write, alias, or migration path.

## Validation

- `corepack pnpm exec prettier --write packages/trace-viewer/src/traceDataSchema.ts src/agent/storage/ExecutionKVStore.ts src/agent/storage/index.ts src/test-kernel/transcript/traceViewerSchema.vitest.ts packages/trace-viewer/src/main.ts`
- `corepack pnpm --filter @texra/trace-viewer run typecheck`
- `corepack pnpm --filter @texra/trace-viewer run build`
- `corepack pnpm exec vitest run src/test-kernel/transcript/traceViewerSchema.vitest.ts`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing unrelated import-order warning in `packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts`)
- `npm test`
- `git diff --check`

Closes #7187

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to trace-viewer load path and reject bad input earlier; no auth, persistence, or live execution behavior changes.
> 
> **Overview**
> Adds a **browser-safe Zod validation boundary** at trace load time so inline `window.__TEXRA_TRACE__` and fetched `trace.json` are checked before `replayTrace()`.
> 
> `loadTrace()` in `main.ts` now passes raw payloads through `parseTraceData()` instead of trusting JSON shape; failures surface as a clear “incompatible/malformed trace” error rather than breaking deep in message dispatch. The new `traceDataSchema.ts` mirrors `TraceDocument` using shared `@shared/schemas` plus local mirrors for agent config and execution meta (avoiding `@agent/*` runtime imports in the Vite bundle), with compile-time assertions that exported traces still align with `assembleTrace` output.
> 
> Vitest coverage confirms real `assembleTrace` documents pass validation and common malformed payloads are rejected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfbcf6033b41f48f39c38e32e982ba619028856b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->