### PR TITLE
fix(trace-viewer): use real TraceDocument type and fix legacy-trace status fallback

### DIFF
--- a/packages/trace-viewer/src/main.ts
+++ b/packages/trace-viewer/src/main.ts
@@ -18,7 +18,8 @@ import {
   handleToolbarCommand,
 } from '@progressView/frontend/eventHandlers';
 
-import { replayTrace, type ReplayableTrace } from './replayTrace';
+import { replayTrace } from './replayTrace';
+import type { TraceDocument } from '@transcript';
 
 const root = document.querySelector<HTMLElement>('#app');
 if (root == null) throw new Error('Trace viewer root (#app) not found.');
@@ -52,8 +53,8 @@ conversationView.addEventListener(
  * traces that shouldn't duplicate the bundle per page). Both paths feed the
  * exact same `replayTrace`.
  */
-async function loadTrace(): Promise<ReplayableTrace> {
-  const inline = (window as { __TEXRA_TRACE__?: ReplayableTrace })
+async function loadTrace(): Promise<TraceDocument> {
+  const inline = (window as { __TEXRA_TRACE__?: TraceDocument })
     .__TEXRA_TRACE__;
   if (inline) return inline;
 

--- a/packages/trace-viewer/src/replayTrace.ts
+++ b/packages/trace-viewer/src/replayTrace.ts
@@ -3,40 +3,12 @@ import type { MessageHandlerContext } from '@progressView/frontend/messageHandle
 import {
   executionStatusToRunOutcome,
   STREAM_STATUS,
-  type AgentCategory,
-  type ExecutionId,
-  type ExecutionStatus,
+  streamStatusToLifecycleStatus,
   type StreamLifecycleStatus,
-  type StreamLogEntry,
-  type StreamSnapshot,
-  type StreamTabId,
 } from '@shared/schemas';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc/progressViewCommands';
 import type { ProgressViewOutboundMessage } from '@shared/schemas/progressView';
-
-/**
- * Structurally matches `TraceDocument` from `@transcript/traceAssembler` —
- * kept as a local shape here rather than importing that type directly so
- * this package doesn't depend on an in-flight sibling PR merging first. The
- * two should be interchangeable field-for-field. `snapshot` reuses the real
- * `StreamSnapshot` shared type directly (not a hand-rolled subset) since it's
- * a stable, already-merged schema — narrowing it locally previously dropped
- * the workflow output-file/compile-failure fields silently.
- */
-export interface ReplayableTrace {
-  readonly executionId: ExecutionId;
-  readonly streamId: StreamTabId;
-  readonly config: {
-    readonly agent: string;
-    readonly model: string;
-    readonly agentCategory: AgentCategory;
-  };
-  readonly meta: { readonly description?: string } | null;
-  readonly entries: StreamLogEntry[];
-  readonly snapshot: StreamSnapshot;
-  /** `null` when the execution predates outcome tracking or never reached a terminal state. */
-  readonly terminalStatus: ExecutionStatus | null;
-}
+import type { TraceDocument } from '@transcript';
 
 type UpdateStreamsMessage = Extract<
   ProgressViewOutboundMessage,
@@ -57,14 +29,23 @@ type SyncStreamContentMessage = Extract<
  * is the sanctioned inverse of `runOutcomeToExecutionStatus` — its `RunOutcome`
  * result (`completed`/`cancelled`/`failed`) is structurally identical to
  * `StreamPhase`'s values, so it's already a valid `StreamLifecycleStatus`.
- * `null` (predates outcome tracking) defaults to `READY`, same as an
+ *
+ * `terminalStatus` is `null` for traces that predate outcome tracking (or
+ * never reached a terminal state) — for those legacy traces, fall back to
+ * deriving status from the snapshot's own recorded `status` instead of
+ * unconditionally reporting `READY`, so an archived failed/stopped run
+ * doesn't render as if it finished cleanly. Only when the snapshot itself
+ * has no recorded status either does this default to `READY`, same as an
  * unqualified successful finish.
  */
-function toStreamLifecycleStatus(
-  terminalStatus: ExecutionStatus | null,
-): StreamLifecycleStatus {
-  const outcome = executionStatusToRunOutcome(terminalStatus ?? undefined);
-  return outcome ?? STREAM_STATUS.READY;
+function toStreamLifecycleStatus(trace: TraceDocument): StreamLifecycleStatus {
+  if (trace.terminalStatus !== null) {
+    const outcome = executionStatusToRunOutcome(trace.terminalStatus);
+    if (outcome) return outcome;
+  }
+  return trace.snapshot.status
+    ? streamStatusToLifecycleStatus(trace.snapshot.status)
+    : STREAM_STATUS.READY;
 }
 
 /**
@@ -75,7 +56,7 @@ function toStreamLifecycleStatus(
  * `logSlice.ts`'s `if (!streamState) return`).
  */
 export function replayTrace(
-  trace: ReplayableTrace,
+  trace: TraceDocument,
   ctx: MessageHandlerContext,
 ): void {
   const { snapshot } = trace;
@@ -100,7 +81,7 @@ export function replayTrace(
     agentFilter: 'all',
     streamStates: {
       [trace.streamId]: {
-        status: toStreamLifecycleStatus(trace.terminalStatus),
+        status: toStreamLifecycleStatus(trace),
         kind: trace.config.agentCategory,
         conversationProgress: snapshot.conversationProgress,
         // Liveness is never restored as live (matches the existing

--- a/src/test-kernel/traceViewer/replayTrace.vitest.ts
+++ b/src/test-kernel/traceViewer/replayTrace.vitest.ts
@@ -1,0 +1,114 @@
+import { create } from 'mutative';
+import { describe, expect, it } from 'vitest';
+
+import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
+import type { MessageHandlerContext } from '@progressView/frontend/messageHandlerTypes';
+import {
+  createInitialState,
+  type ProgressState,
+} from '@progressView/frontend/store';
+import {
+  AgentCategory,
+  STREAM_STATUS,
+  StreamSnapshotSchema,
+  type ExecutionId,
+  type StreamTabId,
+} from '@shared/schemas';
+// Relative import: `packages/trace-viewer` is a separate workspace package
+// with no path alias into the root vitest config, but this suite exercises
+// the real replay pipeline (`@progressView/frontend`'s dispatcher + slices),
+// so a plain relative import is the simplest way to reach it.
+import { replayTrace } from '../../../packages/trace-viewer/src/replayTrace';
+import type { TraceDocument } from '@transcript';
+
+function createContext(initialState: ProgressState): {
+  ctx: MessageHandlerContext;
+  getState: () => ProgressState;
+} {
+  let state = initialState;
+  const ctx: MessageHandlerContext = {
+    getState: () => state,
+    setState: (updater) => {
+      state = updater(state);
+    },
+    setStreamState: (streamId, updater) => {
+      const current = state.streamStates.get(streamId);
+      if (!current) return;
+      const updated = updater(current);
+      if (updated === current) return;
+      state = create(state, (draft) => {
+        draft.streamStates.set(streamId, updated);
+      });
+    },
+    setStreamLogs: () => {},
+    savePrefs: () => {},
+    getPermissions: () => [],
+    setPermissions: () => {},
+    setPlacement: () => {},
+  };
+  return { ctx, getState: () => state };
+}
+
+function legacyTrace(
+  snapshotStatus: 'error' | 'stopped' | undefined,
+): TraceDocument {
+  const streamId = 'stream:legacy-trace' as StreamTabId;
+  return {
+    executionId: 'abc123' as ExecutionId,
+    streamId,
+    config: AgentConfigSchema.parse({
+      agent: 'correct',
+      model: 'gemini35f',
+      agentCategory: AgentCategory.Workflow,
+    }),
+    // Legacy meta: no description, nothing replayTrace needs beyond the
+    // optional `description` read.
+    meta: null,
+    entries: [],
+    snapshot: StreamSnapshotSchema.parse({
+      streamId,
+      status: snapshotStatus,
+    }),
+    // The bug under test: `null` is what real traces recorded before outcome
+    // tracking (or that never reached a terminal state) persist here.
+    terminalStatus: null,
+  };
+}
+
+describe('replayTrace legacy-status fallback (issue #7188)', () => {
+  it('derives "failed" from snapshot.status "error" instead of defaulting to ready', () => {
+    const { ctx, getState } = createContext(createInitialState());
+    const trace = legacyTrace('error');
+
+    replayTrace(trace, ctx);
+
+    const replayed = getState().streamStates.get(trace.streamId);
+    expect(replayed?.status).not.toBe(STREAM_STATUS.READY);
+    expect(replayed?.status).toBe('failed');
+  });
+
+  it('derives a non-ready status from snapshot.status "stopped" instead of defaulting to ready', () => {
+    const { ctx, getState } = createContext(createInitialState());
+    const trace = legacyTrace('stopped');
+
+    replayTrace(trace, ctx);
+
+    const replayed = getState().streamStates.get(trace.streamId);
+    // STOPPED folds into the canonical COMPLETED phase (the same collapse
+    // `streamStatusToLifecycleStatus` performs everywhere else in the app) —
+    // the point of this regression is that it must not silently become
+    // READY, not that the literal legacy string survives.
+    expect(replayed?.status).not.toBe(STREAM_STATUS.READY);
+    expect(replayed?.status).toBe('completed');
+  });
+
+  it('still reports READY when neither terminalStatus nor snapshot.status is set', () => {
+    const { ctx, getState } = createContext(createInitialState());
+    const trace = legacyTrace(undefined);
+
+    replayTrace(trace, ctx);
+
+    const replayed = getState().streamStates.get(trace.streamId);
+    expect(replayed?.status).toBe(STREAM_STATUS.READY);
+  });
+});


### PR DESCRIPTION
Closes #7186
Closes #7188

## What changed

**#7186** — `packages/trace-viewer/src/replayTrace.ts` no longer keeps a local `ReplayableTrace` interface that structurally duplicated `TraceDocument`. It now imports the real `TraceDocument` type directly from `@transcript` (the sibling PR that defined it has since merged). `replayTrace()` and `packages/trace-viewer/src/main.ts`'s `loadTrace()` are updated to use `TraceDocument` throughout. No `as`/`unknown` casts were needed or added — the real type's field shapes (`config: AgentConfig`, `meta: ExecutionMeta | null`) are supersets of what the local duplicate declared, so every existing field access (`trace.config.agent/model/agentCategory`, `trace.meta?.description`) still type-checks as-is.

**#7188** — `toStreamLifecycleStatus()` previously fell back to `STREAM_STATUS.READY` whenever `terminalStatus` was `null` (legacy traces recorded before outcome tracking, or that never reached a terminal state), even when the trace's own `snapshot.status` recorded that the run had actually failed or was stopped. It now falls back to deriving the status from `trace.snapshot.status` (via the existing sanctioned `streamStatusToLifecycleStatus` conversion, the same one `streamRestoration.ts` uses for legacy-status restoration) instead of unconditionally reporting READY. Only when the snapshot itself carries no status either does it default to READY, matching the prior behavior for genuinely-unknown traces.

## Regression coverage

Added `src/test-kernel/traceViewer/replayTrace.vitest.ts`, exercising `replayTrace()` end-to-end through the real `dispatchMessage` pipeline:
- `terminalStatus: null` + `snapshot.status: 'error'` → replays as `'failed'`, not `'ready'`.
- `terminalStatus: null` + `snapshot.status: 'stopped'` → replays as `'completed'` (STOPPED folds into the canonical COMPLETED phase, same as everywhere else in the app), not `'ready'`.
- `terminalStatus: null` + no `snapshot.status` → still replays as `'ready'` (unchanged behavior for genuinely-unknown traces).

## Test plan

- [x] `npx tsc --noEmit -p packages/trace-viewer/tsconfig.json` — clean.
- [x] `npx tsc --noEmit -p tsconfig.test-kernel.json` — clean (one pre-existing, unrelated failure in `standaloneTraceHtml.vitest.ts` confirmed present on `origin/main` before this change).
- [x] `npx tsc --noEmit -p tsconfig.json` — clean.
- [x] `npx eslint` on all three changed files — clean.
- [x] New regression suite passes (3/3); broader `src/test-kernel/transcript`, `src/test-kernel/progressView`, `src/test-kernel/traceViewer` suites pass (33 files / 167 tests).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018nbVZZcHVNLBNZ2tESvR7v

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to trace-viewer replay and display status mapping; behavior change only affects how archived legacy traces render, with new regression tests.
> 
> **Overview**
> Trace viewer replay now uses the shared **`TraceDocument`** type from `@transcript` instead of a local **`ReplayableTrace`** duplicate; **`loadTrace`** and **`replayTrace`** are typed against that type end-to-end.
> 
> **`toStreamLifecycleStatus`** no longer treats **`terminalStatus: null`** as always **READY**. When outcome tracking is missing, it derives lifecycle status from **`trace.snapshot.status`** via **`streamStatusToLifecycleStatus`**, so failed/stopped legacy runs do not look like a clean finish; **READY** is only used when neither terminal nor snapshot status is set.
> 
> Adds **`replayTrace.vitest.ts`** regression tests through the real progress-view dispatcher for error → failed, stopped → completed, and the unchanged unknown → ready path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adf8e39276f2a5fbcf3103516943167628a05d70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->