### PR TITLE
[codex] Fix standalone trace meta fixture

### DIFF
--- a/src/test-kernel/transcript/standaloneTraceHtml.vitest.ts
+++ b/src/test-kernel/transcript/standaloneTraceHtml.vitest.ts
@@ -76,6 +76,7 @@ describe('injectStandaloneTrace', () => {
   it('escapes a literal </script> inside trace data instead of truncating the page', () => {
     const t = trace({
       meta: {
+        schemaVersion: 1,
         timestamp: '2026-01-01T00:00:00.000Z',
         description: '</script><img src=x onerror=alert(1)>',
       },


### PR DESCRIPTION
## Summary

Adds the missing `schemaVersion: 1` field to the standalone trace HTML test fixture's `ExecutionMeta` override so current `main` typechecks again.

## Single source of truth

`ExecutionMeta` keeps `schemaVersion` as a required schema field; this PR updates the fixture to follow that schema instead of widening the type or adding a fallback.

## Duplication and abstraction budget

No duplication or abstraction changes. This is a one-line fixture correction for the current main CI failure.

## Host impact

- Extension: none.
- Desktop: none.
- CLI: none.

## Checks run

- `npm test -- --run src/test-kernel/transcript/standaloneTraceHtml.vitest.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing unrelated import-order warning in `packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts`)
- `npm run compile:fast`
- `npm test`
- `git diff --check`

Closes #7235

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test fixture-only change with no production, extension, desktop, or CLI impact.
> 
> **Overview**
> Fixes a **typecheck/CI failure** on `main` by aligning the `injectStandaloneTrace` XSS regression test with the current **`ExecutionMeta`** schema.
> 
> The test that embeds a malicious `</script>` payload in trace `meta` now includes the required **`schemaVersion: 1`** on the `meta` override. No runtime or production code changes—fixture-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1240a8991ad78dd4ee32e4afcbf7d46dbfefb381. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->