### PR TITLE
fix: add required schemaVersion to standaloneTraceHtml test meta override

### DIFF
--- a/src/test-kernel/transcript/standaloneTraceHtml.vitest.ts
+++ b/src/test-kernel/transcript/standaloneTraceHtml.vitest.ts
@@ -76,6 +76,7 @@ describe('injectStandaloneTrace', () => {
   it('escapes a literal </script> inside trace data instead of truncating the page', () => {
     const t = trace({
       meta: {
+        schemaVersion: 1,
         timestamp: '2026-01-01T00:00:00.000Z',
         description: '</script><img src=x onerror=alert(1)>',
       },


### PR DESCRIPTION
Main's typecheck is currently broken, blocking CI on every open PR:

```
src/test-kernel/transcript/standaloneTraceHtml.vitest.ts(78,7): error TS2322:
Property 'schemaVersion' is missing in type '{ timestamp: string; description: string; }'
```

`#7210` made `TraceDocument`'s `meta.schemaVersion` a required field, but a test added by `#7202` still overrides `meta` with a partial object that predates that requirement. Adding `schemaVersion: 1` to the override fixes it.

Verified: `tsc --noEmit`, `tsc --noEmit -p tsconfig.test-kernel.json`, and the affected vitest file all pass locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only type fix with no production code paths touched.
> 
> **Overview**
> Restores **TypeScript compliance** for the standalone trace HTML vitest that checks `</script>` escaping in embedded trace JSON.
> 
> The XSS-focused case still overrides `meta` with `timestamp` and a malicious `description`, but now includes **`schemaVersion: 1`** so the object satisfies `TraceDocument` after `meta.schemaVersion` became required. **No runtime or production behavior changes**—only the test fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c0cd4e4b4815cfc104c46bdb82d870049bc8901. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->