### PR TITLE
perf: debounce desktop stream snapshot writes

### DIFF
--- a/packages/desktop/src/main/desktopStreamSnapshot.ts
+++ b/packages/desktop/src/main/desktopStreamSnapshot.ts
@@ -33,6 +33,7 @@ import {
 } from '@shared/schemas';
 
 const STREAMS_KEY = 'restoredStreams';
+export const DESKTOP_STREAM_SNAPSHOT_WRITE_DEBOUNCE_MS = 100;
 const RESTART_REPAIR_PHASES: ReadonlySet<StreamPhase> = new Set([
   STREAM_PHASE.RUNNING,
   STREAM_PHASE.WAITING,
@@ -54,6 +55,8 @@ export interface DesktopStreamSnapshotStore {
   remove(streamId: StreamTabId): Promise<void>;
   /** Replace the entire snapshot list. */
   replaceAll(snapshots: RestoredStreamSnapshot[]): Promise<void>;
+  /** Persist any pending debounced snapshot update. */
+  flush(): Promise<void>;
   /** Current in-memory snapshot list (post-hydrate). */
   getAll(): RestoredStreamSnapshot[];
 }
@@ -77,19 +80,82 @@ export async function openDesktopStreamSnapshotStore(
   const raw = store.get<unknown>(STREAMS_KEY);
 
   // Live in-memory list keyed by streamId, seeded from the persisted file.
-  // We always rewrite the whole `streams` array on every change — the rail
-  // rarely has more than a dozen entries, so the cost is trivial and the
-  // code stays simple (no merge bugs vs. partial updates).
+  // We still rewrite the whole `streams` array, but frequent status/activity
+  // upserts share one debounced write. Destructive edits stay immediate so
+  // callers can rely on durability when remove()/replaceAll() resolve.
   const live = new Map<StreamTabId, RestoredStreamSnapshot>(
     parseHydrated(raw, log).map((s) => [s.streamId, s]),
   );
+  let pendingDebounce: ReturnType<typeof setTimeout> | undefined;
+  let pendingUpsertWaiters: Array<{
+    resolve(): void;
+    reject(error: unknown): void;
+  }> = [];
+  let writeChain = Promise.resolve();
 
-  async function persist(): Promise<void> {
-    const file: RestoredStreamsFile = {
+  function currentFile(): RestoredStreamsFile {
+    return {
       version: 1,
       streams: [...live.values()],
     };
-    await store.set(STREAMS_KEY, file);
+  }
+
+  async function persist(): Promise<void> {
+    await store.set(STREAMS_KEY, currentFile());
+  }
+
+  function enqueuePersist(
+    waiters: typeof pendingUpsertWaiters = [],
+  ): Promise<void> {
+    const write = writeChain.then(persist, persist);
+    writeChain = write.catch(() => {});
+    void write.then(
+      () => {
+        for (const waiter of waiters) waiter.resolve();
+      },
+      (error: unknown) => {
+        for (const waiter of waiters) waiter.reject(error);
+      },
+    );
+    return write;
+  }
+
+  function clearPendingDebounce(): typeof pendingUpsertWaiters {
+    if (pendingDebounce) {
+      clearTimeout(pendingDebounce);
+      pendingDebounce = undefined;
+    }
+    const waiters = pendingUpsertWaiters;
+    pendingUpsertWaiters = [];
+    return waiters;
+  }
+
+  function persistPendingUpserts(): Promise<void> {
+    const waiters = clearPendingDebounce();
+    return waiters.length > 0 ? enqueuePersist(waiters) : writeChain;
+  }
+
+  function schedulePersist(): Promise<void> {
+    const promise = new Promise<void>((resolve, reject) => {
+      pendingUpsertWaiters.push({ resolve, reject });
+    });
+    if (pendingDebounce) clearTimeout(pendingDebounce);
+    pendingDebounce = setTimeout(() => {
+      pendingDebounce = undefined;
+      void persistPendingUpserts().catch(() => {
+        // Individual upsert promises receive the rejection through their waiters.
+      });
+    }, DESKTOP_STREAM_SNAPSHOT_WRITE_DEBOUNCE_MS);
+    return promise;
+  }
+
+  async function persistImmediately(): Promise<void> {
+    const waiters = clearPendingDebounce();
+    await enqueuePersist(waiters);
+  }
+
+  async function flushPendingWrites(): Promise<void> {
+    await persistPendingUpserts();
   }
 
   return {
@@ -104,18 +170,21 @@ export async function openDesktopStreamSnapshotStore(
     },
     async upsert(snapshot) {
       live.set(snapshot.streamId, snapshot);
-      await persist();
+      await schedulePersist();
     },
     async remove(streamId) {
       if (!live.delete(streamId)) return;
-      await persist();
+      await persistImmediately();
     },
     async replaceAll(snapshots) {
       live.clear();
       for (const snapshot of snapshots) {
         live.set(snapshot.streamId, snapshot);
       }
-      await persist();
+      await persistImmediately();
+    },
+    async flush() {
+      await flushPendingWrites();
     },
     getAll() {
       return [...live.values()];

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -955,8 +955,12 @@ if (protocolLifecycle.shouldContinue) {
       // so we treat it as "no snapshot available" and continue.
       let streamSnapshotStore: DesktopStreamSnapshotStore | undefined;
       try {
-        streamSnapshotStore = await openDesktopStreamSnapshotStore(
+        const openedStreamSnapshotStore = await openDesktopStreamSnapshotStore(
           join(app.getPath('userData'), 'streams.json'),
+        );
+        streamSnapshotStore = openedStreamSnapshotStore;
+        lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () =>
+          openedStreamSnapshotStore.flush(),
         );
       } catch (error) {
         console.warn('Failed to open desktop stream snapshot store', error);

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -172,6 +172,7 @@ type TestDesktopStreamSnapshotStore = {
   upsert(snapshot: RestoredStreamSnapshot): Promise<void>;
   remove(streamId: StreamTabId): Promise<void>;
   replaceAll(snapshots: RestoredStreamSnapshot[]): Promise<void>;
+  flush(): Promise<void>;
   getAll(): RestoredStreamSnapshot[];
 };
 
@@ -494,6 +495,7 @@ function createStreamSnapshotStore(
       live.clear();
       for (const snapshot of snapshots) live.set(snapshot.streamId, snapshot);
     }),
+    flush: vi.fn(async () => {}),
     getAll: () => [...live.values()],
   };
 }

--- a/src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts
@@ -56,6 +56,7 @@ function createSnapshotStore(
     upsert: vi.fn(async () => {}),
     remove: vi.fn(async () => {}),
     replaceAll: vi.fn(async () => {}),
+    flush: vi.fn(async () => {}),
     getAll: vi.fn(() => []),
     ...overrides,
   };

--- a/src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts
+++ b/src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 // Third-party imports
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - shared schemas
 import {
@@ -15,6 +15,17 @@ import {
 
 // Local imports - desktop test paths
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
+
+const writeFileAtomicMock = vi.hoisted(() =>
+  vi.fn(async (filePath: string, data: string) => {
+    const { writeFile: writeFileImpl } = await import('node:fs/promises');
+    await writeFileImpl(filePath, data);
+  }),
+);
+
+vi.mock('write-file-atomic', () => ({
+  default: writeFileAtomicMock,
+}));
 
 type Snapshot = {
   streamId: string;
@@ -37,10 +48,12 @@ type Store = {
   upsert(snapshot: Snapshot): Promise<void>;
   remove(id: string): Promise<void>;
   replaceAll(snapshots: Snapshot[]): Promise<void>;
+  flush(): Promise<void>;
   getAll(): Snapshot[];
 };
 
 interface Module {
+  DESKTOP_STREAM_SNAPSHOT_WRITE_DEBOUNCE_MS: number;
   openDesktopStreamSnapshotStore(
     filePath: string,
     options?: { log?: { warn(...args: unknown[]): void } },
@@ -73,13 +86,18 @@ function makeSnapshot(overrides: Partial<Snapshot> = {}): Snapshot {
 
 describe('DesktopStreamSnapshot', () => {
   let tempDir: string | undefined;
+  let debounceMs: number;
   let openDesktopStreamSnapshotStore: Module['openDesktopStreamSnapshotStore'];
 
   beforeEach(async () => {
-    ({ openDesktopStreamSnapshotStore } = await loadModule());
+    const module = await loadModule();
+    debounceMs = module.DESKTOP_STREAM_SNAPSHOT_WRITE_DEBOUNCE_MS;
+    openDesktopStreamSnapshotStore = module.openDesktopStreamSnapshotStore;
+    writeFileAtomicMock.mockClear();
   });
 
   afterEach(async () => {
+    vi.useRealTimers();
     if (tempDir == null) return;
     await rm(tempDir, { recursive: true, force: true });
     tempDir = undefined;
@@ -88,6 +106,13 @@ describe('DesktopStreamSnapshot', () => {
   async function tempFilePath(): Promise<string> {
     tempDir = await mkdtemp(join(tmpdir(), 'texra-stream-snapshot-'));
     return join(tempDir, 'streams.json');
+  }
+
+  async function readPersistedSnapshots(filePath: string): Promise<Snapshot[]> {
+    const raw = JSON.parse(await readFile(filePath, 'utf8')) as {
+      restoredStreams: { streams: Snapshot[] };
+    };
+    return raw.restoredStreams.streams;
   }
 
   it('starts empty when the file does not exist', async () => {
@@ -190,6 +215,54 @@ describe('DesktopStreamSnapshot', () => {
     expect(store.getAll()[0]?.description).toBe('second');
   });
 
+  it('coalesces rapid upserts into one debounced write', async () => {
+    vi.useFakeTimers();
+    const filePath = await tempFilePath();
+    const store = await openDesktopStreamSnapshotStore(filePath);
+
+    const first = store.upsert(makeSnapshot({ description: 'first' }));
+    const second = store.upsert(
+      makeSnapshot({
+        streamId: 'toolUseAgent@2',
+        agentCategory: 'toolUse',
+        description: 'second',
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(debounceMs - 1);
+    expect(writeFileAtomicMock).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await Promise.all([first, second]);
+
+    expect(writeFileAtomicMock).toHaveBeenCalledTimes(1);
+    expect(await readPersistedSnapshots(filePath)).toEqual([
+      expect.objectContaining({
+        streamId: 'workflowAgent@1',
+        description: 'first',
+      }),
+      expect.objectContaining({
+        streamId: 'toolUseAgent@2',
+        description: 'second',
+      }),
+    ]);
+  });
+
+  it('flush persists a pending debounced upsert immediately', async () => {
+    vi.useFakeTimers();
+    const filePath = await tempFilePath();
+    const store = await openDesktopStreamSnapshotStore(filePath);
+
+    const pending = store.upsert(makeSnapshot({ description: 'pending' }));
+    await store.flush();
+    await pending;
+
+    expect(writeFileAtomicMock).toHaveBeenCalledTimes(1);
+    expect(await readPersistedSnapshots(filePath)).toEqual([
+      expect.objectContaining({ description: 'pending' }),
+    ]);
+  });
+
   it('remove drops a snapshot and persists the removal', async () => {
     const filePath = await tempFilePath();
 
@@ -201,6 +274,23 @@ describe('DesktopStreamSnapshot', () => {
 
     const reopened = await openDesktopStreamSnapshotStore(filePath);
     expect(reopened.hydrated).toEqual([]);
+  });
+
+  it('remove persists immediately when a debounced upsert is pending', async () => {
+    vi.useFakeTimers();
+    const filePath = await tempFilePath();
+    const store = await openDesktopStreamSnapshotStore(filePath);
+
+    const pending = store.upsert(makeSnapshot());
+    await store.remove('workflowAgent@1');
+    await pending;
+
+    expect(store.getAll()).toEqual([]);
+    expect(writeFileAtomicMock).toHaveBeenCalledTimes(1);
+    expect(await readPersistedSnapshots(filePath)).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(debounceMs);
+    expect(writeFileAtomicMock).toHaveBeenCalledTimes(1);
   });
 
   it('remove is a no-op when the id is unknown', async () => {
@@ -217,6 +307,27 @@ describe('DesktopStreamSnapshot', () => {
 
     const reopened = await openDesktopStreamSnapshotStore(filePath);
     expect(reopened.hydrated).toEqual([]);
+  });
+
+  it('replaceAll persists immediately when a debounced upsert is pending', async () => {
+    vi.useFakeTimers();
+    const filePath = await tempFilePath();
+    const store = await openDesktopStreamSnapshotStore(filePath);
+    const replacement = makeSnapshot({
+      streamId: 'replacement@1',
+      description: 'replacement',
+    });
+
+    const pending = store.upsert(makeSnapshot({ description: 'pending' }));
+    await store.replaceAll([replacement]);
+    await pending;
+
+    expect(store.getAll()).toEqual([replacement]);
+    expect(writeFileAtomicMock).toHaveBeenCalledTimes(1);
+    expect(await readPersistedSnapshots(filePath)).toEqual([replacement]);
+
+    await vi.advanceTimersByTimeAsync(debounceMs);
+    expect(writeFileAtomicMock).toHaveBeenCalledTimes(1);
   });
 
   it('discards a malformed snapshot file without throwing', async () => {


### PR DESCRIPTION
## Summary

Debounces desktop `streams.json` persistence for frequent status/activity `upsert()` calls while keeping the existing file schema and store ownership intact. Destructive `remove()` and `replaceAll()` operations still persist immediately, and desktop shutdown now flushes any pending debounced snapshot write.

## Issue acceptance gates

Addresses #7211.

- Rapid `upsert()` calls coalesce into one persisted `streams.json` write after the debounce window.
- `remove()` and `replaceAll()` still resolve only after their final state is durable.
- Desktop shutdown drains pending debounced stream snapshot writes through `LifecycleHost`.
- Malformed-file tolerance and restored-stream normalization remain unchanged.
- No schema/format migration, alias, fallback, projection, or dual-write was introduced, so no #6981 ledger row is needed.

Evidence recheck: the cited `DesktopStreamSnapshotStore`, `DesktopProgressEventBridge.persistStreamSnapshot()`, and `JsonStore.set()` sites still match the issue on current `origin/main` before this patch.

## Single source of truth

`DesktopStreamSnapshotStore` remains the single owner of desktop restored stream snapshot persistence and now owns the debounce/drain policy for that file.

## Duplication and abstraction budget

No pass-through layer was added. The change avoids pushing debounce policy into `JsonStore` or the progress bridge, so the host-specific write hygiene stays beside the one `streams.json` owner. Added mass is mainly acceptance coverage plus a small in-store queue/timer needed to preserve durable destructive writes.

## Host impact

Extension: No behavior change.

Desktop: Frequent restored-stream status/activity updates coalesce into fewer full-file writes; destructive edits and shutdown durability are preserved.

CLI: No behavior change.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write packages/desktop/src/main/desktopStreamSnapshot.ts packages/desktop/src/main/index.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts`
- `npm test -- --run src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `git diff --check`
- `npm run typecheck`
- `npm run lint` (passes with existing import-order warning in `packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts`)
- `npm run compile:fast`
- `npm test`
- Re-ran `npm run typecheck`, `npm run lint`, `npm run compile:fast`, and `npm test` after rebasing onto current `origin/main`.

Closes #7211

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persistence timing for cross-launch stream rail data—shutdown flush and immediate destructive writes mitigate data loss, but a crash within the debounce window could still lose the latest upsert until the next write.
> 
> **Overview**
> **Debounces** frequent `upsert()` persistence for desktop restored-stream snapshots in `streams.json` (100ms window) so rapid status/activity updates coalesce into fewer full-file writes, while keeping the same schema and store ownership.
> 
> `remove()` and `replaceAll()` still **flush immediately** (they cancel any pending debounced write and persist), so callers keep the same durability guarantees when those APIs resolve. A new **`flush()`** on `DesktopStreamSnapshotStore` drains pending debounced writes; desktop startup wires it into **`LifecycleHost` shutdown** (`SHUTDOWN_PHASE.ON`) so quit does not drop the last coalesced snapshot.
> 
> Tests cover coalescing, `flush`, and immediate persistence when destructive ops race a pending upsert; test doubles gain `flush()` stubs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a365228762583a2a41b6cdc32697226590f816ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->