### PR TITLE
refactor: centralize storage resumability

### DIFF
--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 import {
   deleteAllExecutions,
   deleteExecution,
+  deriveResumability,
   getExecutionStore,
   listExecutions,
   type ExecutionListingEntry,
@@ -14,11 +15,7 @@ import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { loadChatExportInput } from '@agent/export/loadChatExportInput';
 import type { ChatExportInput } from '@agent/export/schemas';
 import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
-import {
-  EXECUTION_STATUS,
-  ExecutionIdSchema,
-  type ExecutionId,
-} from '@shared/schemas';
+import { ExecutionIdSchema, type ExecutionId } from '@shared/schemas';
 import { GoalStore } from '@tools/goal';
 
 import { readCliToolUseResumeDataForListing } from './toolUseResumeData';
@@ -143,6 +140,7 @@ export async function readCliHistoryDetails(
     conversation,
     persistedWorkspaceFilePaths,
     generatedFiles,
+    resumability,
   ] = await Promise.all([
     store.readMeta(),
     store.readConfig(),
@@ -151,10 +149,12 @@ export async function readCliHistoryDetails(
     store.readConversation(),
     store.readWorkspaceFiles(),
     listGeneratedFiles(id),
+    deriveResumability(id),
   ]);
-  const resumeData = config
-    ? await readCliToolUseResumeDataForListing(id, config)
-    : undefined;
+  const resumeData =
+    resumability.resumable && config
+      ? await readCliToolUseResumeDataForListing(id, config)
+      : null;
   const conversationPreview = createConversationPreview(conversation);
   const fullConversation = options.includeFullConversation
     ? createConversationTranscript(conversation)
@@ -179,7 +179,7 @@ export async function readCliHistoryDetails(
     id,
     status: resolveCliHistoryStatus({
       terminalStatus: meta?.terminalStatus,
-      hasFlowRecord: !!resumeData,
+      resumable: resumeData !== null,
     }),
     meta,
     config,
@@ -190,7 +190,7 @@ export async function readCliHistoryDetails(
       ? { conversation: fullConversation }
       : {}),
     files,
-    hasFlowRecord: !!resumeData,
+    hasFlowRecord: resumeData !== null,
     currentModel: resumeData?.snapshot.agentConfig.model,
   };
 }
@@ -396,23 +396,14 @@ export function cliHistoryNdjsonRecords(
 
 export function resolveCliHistoryStatus(input: {
   readonly terminalStatus?: string;
-  readonly hasFlowRecord?: boolean;
+  readonly resumable: boolean;
 }): string {
   // An absent terminal status means the run never reached its terminal write
   // (crash, kill, old build) — never report that as 'completed'.
-  if (input.hasFlowRecord && terminalStatusAllowsResume(input.terminalStatus)) {
+  if (input.resumable) {
     return CLI_HISTORY_RESUMABLE_STATUS;
   }
   return input.terminalStatus ?? 'unknown';
-}
-
-function terminalStatusAllowsResume(
-  terminalStatus: string | undefined,
-): boolean {
-  return (
-    terminalStatus === undefined ||
-    terminalStatus === EXECUTION_STATUS.INTERRUPTED
-  );
 }
 
 export function formatCliHistoryDetailsText(
@@ -475,10 +466,9 @@ async function toCliHistoryEntry(
   entry: ExecutionListingEntry,
 ): Promise<CliHistoryEntry> {
   const inputBasename = firstInputBasename(entry.agentConfig);
-  // Cancelled sessions persist 'interrupted' and may keep a resumable flow
-  // record — check it for those too, not only for missing terminal statuses.
+  const resumability = await deriveResumability(entry.id);
   const resumeData =
-    terminalStatusAllowsResume(entry.terminalStatus) && entry.agentConfig
+    resumability.resumable && entry.agentConfig
       ? await readCliToolUseResumeDataForListing(entry.id, entry.agentConfig)
       : null;
   return {
@@ -488,7 +478,7 @@ async function toCliHistoryEntry(
     model: resumeData?.snapshot.agentConfig.model ?? entry.model,
     status: resolveCliHistoryStatus({
       terminalStatus: entry.terminalStatus,
-      hasFlowRecord: !!resumeData,
+      resumable: resumeData !== null,
     }),
     inputBasename,
     category: entry.category,

--- a/packages/extension/src/commands/agent/followUpCommand.ts
+++ b/packages/extension/src/commands/agent/followUpCommand.ts
@@ -2,15 +2,15 @@
 import * as vscode from 'vscode';
 
 // Local imports - agent
-import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
-import { shouldProbePersistedFlowForFollowUp } from '@agent/runtime/followUpResumeDetection';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import { deriveResumability } from '@agent/storage';
 import {
   sendFollowUp,
   wakeQueuedFollowUpStream,
   type SendFollowUpResult,
 } from '@agent/followUp/ToolUseFollowUp';
-import { hasPersistedFlowRecord } from '@agent/storage/detectWaitingStreams';
+import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
+import { shouldProbePersistedFlowForFollowUp } from '@agent/runtime/followUpResumeDetection';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { registerCommands } from '@commands/_shared/registerCommands';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { createChannelTrace } from '@logger';
@@ -46,8 +46,8 @@ async function lazyDetectWaitingStatus(
 
   inFlightDetections.add(streamId);
   try {
-    const hasFlow = await hasPersistedFlowRecord(executionId);
-    if (hasFlow) {
+    const resumability = await deriveResumability(executionId);
+    if (resumability.resumable) {
       const repaired = StreamStatusService.transitionToWaiting(
         streamId,
         'restart-repair',

--- a/src/agent/runtime/SessionResumeRetrieval.ts
+++ b/src/agent/runtime/SessionResumeRetrieval.ts
@@ -11,12 +11,15 @@
 
 import { z } from 'zod';
 
-import { getExecutionStore } from '@agent/storage';
+import {
+  deriveResumability,
+  RESUMABILITY_CAUSE,
+  type ResumabilityDecision,
+} from '@agent/storage';
 import {
   AgentConfigSchema,
   type AgentConfig,
 } from '@agent/core/definition/AgentConfig';
-import { flowKey, type FlowRecord } from '@agent/node/persistedFlow';
 import { ProviderMessageSchema } from '@agent/modelHandlers/types/ProviderMessage';
 import {
   migrateSharedState,
@@ -69,6 +72,20 @@ type NormalizedToolUseState = z.infer<
   typeof CurrentToolUseFlowRecordStateSchema
 >;
 
+function throwIfResumeStorageUnreadable(
+  resumability: ResumabilityDecision,
+): void {
+  if (resumability.resumable) return;
+  if (
+    resumability.cause !== RESUMABILITY_CAUSE.UNREADABLE_FLOW &&
+    resumability.cause !== RESUMABILITY_CAUSE.UNREADABLE_META &&
+    resumability.cause !== RESUMABILITY_CAUSE.INVALID_META
+  ) {
+    return;
+  }
+  throw new Error(`Unable to read resume storage: ${resumability.cause}`);
+}
+
 /**
  * Minimal schema for validating workflow flow record exists and has resumable state.
  * Full validation happens when the flow actually resumes.
@@ -114,24 +131,6 @@ export async function retrieveSessionResumeData(
   return null;
 }
 
-/** Read a flow record from the execution store. Returns null if absent or invalid. */
-async function readFlowRecord(
-  executionId: ExecutionId,
-  agentType: 'tool-use' | 'workflow',
-): Promise<FlowRecord | null> {
-  const kv = getExecutionStore(executionId);
-  const flowRecord = await kv.read<FlowRecord>(flowKey(executionId));
-
-  if (!flowRecord?.shared) {
-    logger.warn('No flow record found for execution', {
-      data: { agentType, executionId },
-    });
-    return null;
-  }
-
-  return flowRecord;
-}
-
 /**
  * Retrieve resume data for a tool-use session.
  */
@@ -141,10 +140,19 @@ async function retrieveToolUseResumeData(
   agentConfig: AgentConfig,
 ): Promise<ToolUseResumeData | null> {
   try {
-    const flowRecord = await readFlowRecord(executionId, 'tool-use');
-    if (!flowRecord) {
+    const resumability = await deriveResumability(executionId);
+    if (!resumability.resumable) {
+      throwIfResumeStorageUnreadable(resumability);
+      logger.warn('Execution is not resumable', {
+        data: {
+          agentType: 'tool-use',
+          executionId,
+          cause: resumability.cause,
+        },
+      });
       return null;
     }
+    const { flowRecord } = resumability;
 
     const migrationResult = migrateSharedState(flowRecord.shared);
     if (migrationResult === null) {
@@ -223,10 +231,19 @@ async function retrieveWorkflowResumeData(
   agentConfig: AgentConfig,
 ): Promise<WorkflowResumeData | null> {
   try {
-    const flowRecord = await readFlowRecord(executionId, 'workflow');
-    if (!flowRecord) {
+    const resumability = await deriveResumability(executionId);
+    if (!resumability.resumable) {
+      throwIfResumeStorageUnreadable(resumability);
+      logger.warn('Execution is not resumable', {
+        data: {
+          agentType: 'workflow',
+          executionId,
+          cause: resumability.cause,
+        },
+      });
       return null;
     }
+    const { flowRecord } = resumability;
 
     // Minimal validation - just verify essential fields exist.
     // Full state validation happens when the flow actually resumes.

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -75,7 +75,7 @@ const ExecutionMetaBaseSchema = z.object({
   delegationDepth: z.int().nonnegative().optional(),
 });
 
-const ExecutionMetaSchema = ExecutionMetaBaseSchema.transform(
+export const ExecutionMetaSchema = ExecutionMetaBaseSchema.transform(
   (
     meta,
   ): z.infer<typeof ExecutionMetaBaseSchema> & { outcome?: RunOutcome } => {

--- a/src/agent/storage/detectWaitingStreams.ts
+++ b/src/agent/storage/detectWaitingStreams.ts
@@ -5,46 +5,9 @@
  * mid-session. These streams can be resumed when the user sends a follow-up.
  */
 
-import { flowKey, type FlowRecord } from '@agent/node/persistedFlow';
-import * as logger from '@logger/logUtils';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { filterNotNull } from '@utils/core';
-import { toErrorMessage } from '@utils/errors/errorMessage';
-import { getExecutionStore } from './ExecutionKVStore';
-
-/**
- * Check if a single stream has a valid, resumable flow record.
- *
- * Used for lazy detection when a user sends a follow-up to a stream
- * that wasn't detected at startup (or when startup detection is skipped).
- *
- * Note: We read and validate the record rather than just checking existence,
- * because a corrupted/truncated record (e.g., from a crash during write)
- * would cause resume to fail, leaving the stream stuck in WAITING state.
- *
- * @returns true if a valid flow record exists (session can be resumed)
- */
-export async function hasPersistedFlowRecord(
-  executionId: ExecutionId,
-): Promise<boolean> {
-  try {
-    const kv = getExecutionStore(executionId);
-    const flowRecord = await kv.read<FlowRecord>(flowKey(executionId));
-    // Use truthy check to match resume logic in SessionResumeRetrieval.ts
-    // This rejects null, undefined, and empty objects consistently
-    return !!flowRecord?.shared;
-  } catch (err) {
-    // A corrupted/unreadable record means the stream isn't resumable; treat as
-    // no record, but log so silent KV-read failures are diagnosable.
-    logger.debug(
-      'DetectWaitingStreams',
-      `Failed to read persisted flow record for ${executionId}: ${toErrorMessage(
-        err,
-      )}`,
-    );
-    return false;
-  }
-}
+import { deriveResumability } from './resumability';
 
 /**
  * Detect streams that have persisted flow state and should be marked as WAITING.
@@ -60,7 +23,7 @@ export async function detectWaitingStreams(
   executionIdMap: ReadonlyMap<StreamTabId, ExecutionId>,
 ): Promise<Set<StreamTabId>> {
   const checks = Array.from(executionIdMap, async ([streamId, executionId]) =>
-    (await hasPersistedFlowRecord(executionId)) ? streamId : null,
+    (await deriveResumability(executionId)).resumable ? streamId : null,
   );
   const results = await Promise.all(checks);
   return new Set(results.filter(filterNotNull));

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -31,3 +31,9 @@ export {
   deleteExecution,
   deleteAllExecutions,
 } from './executionListing';
+export {
+  RESUMABILITY_CAUSE,
+  deriveResumability,
+  type ResumabilityCause,
+  type ResumabilityDecision,
+} from './resumability';

--- a/src/agent/storage/resumability.ts
+++ b/src/agent/storage/resumability.ts
@@ -1,0 +1,187 @@
+import { z } from 'zod';
+
+import { flowKey } from '@agent/node/persistedFlow';
+import type { FlowRecord } from '@agent/node/persistedFlow';
+import * as logger from '@logger/logUtils';
+import {
+  EXECUTION_STATUS,
+  RUN_OUTCOME,
+  type ExecutionId,
+  type RunOutcome,
+} from '@shared/schemas';
+import { toErrorMessage } from '@utils/errors/errorMessage';
+
+import {
+  ExecutionMetaSchema,
+  getExecutionStore,
+  type ExecutionMeta,
+} from './ExecutionKVStore';
+
+const CHANNEL = 'Resumability';
+
+const ResumableFlowRecordSchema = z.looseObject({
+  flowName: z.string(),
+  params: z.record(z.string(), z.unknown()),
+  shared: z.record(z.string(), z.unknown()),
+  createdAt: z.string(),
+  nodes: z.array(z.looseObject({ action: z.string().optional() })),
+});
+
+export const RESUMABILITY_CAUSE = {
+  INTERRUPTED_WITH_FLOW: 'interrupted-with-flow',
+  MISSING_TERMINAL_WITH_FLOW: 'missing-terminal-with-flow',
+  TERMINAL_COMPLETED: 'terminal-completed',
+  TERMINAL_FAILED: 'terminal-failed',
+  TERMINAL_STATUS: 'terminal-status',
+  MISSING_FLOW: 'missing-flow',
+  INVALID_FLOW: 'invalid-flow',
+  INVALID_META: 'invalid-meta',
+  UNREADABLE_FLOW: 'unreadable-flow',
+  UNREADABLE_META: 'unreadable-meta',
+} as const;
+
+export type ResumabilityCause =
+  (typeof RESUMABILITY_CAUSE)[keyof typeof RESUMABILITY_CAUSE];
+type ResumableCause =
+  | typeof RESUMABILITY_CAUSE.INTERRUPTED_WITH_FLOW
+  | typeof RESUMABILITY_CAUSE.MISSING_TERMINAL_WITH_FLOW;
+type NonResumableCause = Exclude<ResumabilityCause, ResumableCause>;
+
+export type ResumabilityDecision =
+  | {
+      readonly resumable: true;
+      readonly cause: ResumableCause;
+      readonly flowRecord: FlowRecord;
+      readonly terminalStatus?: string;
+      readonly outcome?: RunOutcome;
+    }
+  | {
+      readonly resumable: false;
+      readonly cause: NonResumableCause;
+      readonly terminalStatus?: string;
+      readonly outcome?: RunOutcome;
+    };
+
+function terminalBlockCause(
+  meta: ExecutionMeta | null,
+): NonResumableCause | undefined {
+  if (!meta) return undefined;
+  if (meta.outcome === RUN_OUTCOME.COMPLETED) {
+    return RESUMABILITY_CAUSE.TERMINAL_COMPLETED;
+  }
+  if (meta.outcome === RUN_OUTCOME.FAILED) {
+    return RESUMABILITY_CAUSE.TERMINAL_FAILED;
+  }
+  if (
+    meta.outcome === RUN_OUTCOME.CANCELLED ||
+    meta.terminalStatus === undefined ||
+    meta.terminalStatus === EXECUTION_STATUS.INTERRUPTED
+  ) {
+    return undefined;
+  }
+  return RESUMABILITY_CAUSE.TERMINAL_STATUS;
+}
+
+/**
+ * Single storage-owned resumability decision.
+ *
+ * Terminal metadata is authoritative for completed/failed runs so stale flow
+ * files cannot resurrect old executions. Cancelled or crash-interrupted runs
+ * require a valid flow record before they are resumable.
+ */
+export async function deriveResumability(
+  executionId: ExecutionId,
+): Promise<ResumabilityDecision> {
+  const store = getExecutionStore(executionId);
+  let meta: ExecutionMeta | null;
+  try {
+    const rawMeta = await store.read('meta');
+    if (rawMeta == null) {
+      meta = null;
+    } else {
+      const metaResult = ExecutionMetaSchema.safeParse(rawMeta);
+      if (!metaResult.success) {
+        logger.debug(
+          CHANNEL,
+          `Invalid execution metadata for ${executionId}: ${toErrorMessage(
+            metaResult.error,
+          )}`,
+          { data: metaResult.error },
+        );
+        return {
+          resumable: false,
+          cause: RESUMABILITY_CAUSE.INVALID_META,
+        };
+      }
+      meta = metaResult.data;
+    }
+  } catch (error) {
+    logger.debug(
+      CHANNEL,
+      `Failed to read execution metadata for ${executionId}: ${toErrorMessage(
+        error,
+      )}`,
+    );
+    return {
+      resumable: false,
+      cause: RESUMABILITY_CAUSE.UNREADABLE_META,
+    };
+  }
+
+  const terminalCause = terminalBlockCause(meta);
+  if (terminalCause !== undefined) {
+    return {
+      resumable: false,
+      cause: terminalCause,
+      terminalStatus: meta?.terminalStatus,
+      outcome: meta?.outcome,
+    };
+  }
+
+  let rawFlowRecord: unknown;
+  try {
+    rawFlowRecord = await store.read(flowKey(executionId));
+  } catch (error) {
+    logger.debug(
+      CHANNEL,
+      `Failed to read flow record for ${executionId}: ${toErrorMessage(error)}`,
+    );
+    return {
+      resumable: false,
+      cause: RESUMABILITY_CAUSE.UNREADABLE_FLOW,
+      terminalStatus: meta?.terminalStatus,
+      outcome: meta?.outcome,
+    };
+  }
+
+  if (rawFlowRecord == null) {
+    return {
+      resumable: false,
+      cause: RESUMABILITY_CAUSE.MISSING_FLOW,
+      terminalStatus: meta?.terminalStatus,
+      outcome: meta?.outcome,
+    };
+  }
+
+  const flowResult = ResumableFlowRecordSchema.safeParse(rawFlowRecord);
+  if (!flowResult.success) {
+    return {
+      resumable: false,
+      cause: RESUMABILITY_CAUSE.INVALID_FLOW,
+      terminalStatus: meta?.terminalStatus,
+      outcome: meta?.outcome,
+    };
+  }
+
+  return {
+    resumable: true,
+    cause:
+      meta?.outcome === RUN_OUTCOME.CANCELLED ||
+      meta?.terminalStatus === EXECUTION_STATUS.INTERRUPTED
+        ? RESUMABILITY_CAUSE.INTERRUPTED_WITH_FLOW
+        : RESUMABILITY_CAUSE.MISSING_TERMINAL_WITH_FLOW,
+    flowRecord: flowResult.data as FlowRecord,
+    terminalStatus: meta?.terminalStatus,
+    outcome: meta?.outcome,
+  };
+}

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { setupPlatform } from '@test/support/setupPlatform';
 import { getExecutionStore } from '@agent/storage';
@@ -155,6 +155,89 @@ describe('retrieveSessionResumeData', () => {
         content: 'Continue the legacy conversation.',
       },
     ]);
+  });
+
+  it('throws when resumable tool-use storage cannot be read', async () => {
+    const executionId = 'abc129' as ExecutionId;
+    const streamId = 'chat@gpt54#abc129' as StreamTabId;
+    const store = getExecutionStore(executionId);
+    await store.write(flowKey(executionId), {
+      flowName: 'texra',
+      params: {},
+      shared: {
+        messages: [],
+        shouldSkipCycle: false,
+        stateSlices: {
+          runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
+          workspaceSnapshot: AgentWorkspaceState.create().toSnapshot(),
+          userChannels: {
+            input: Object.freeze({ MODEL: 'gpt54' }),
+            transient: {},
+          },
+        },
+      },
+      createdAt: new Date().toISOString(),
+      nodes: [],
+    });
+    const originalRead = store.read.bind(store);
+    const readSpy = vi.spyOn(store, 'read').mockImplementation(async (key) => {
+      if (key === flowKey(executionId)) {
+        throw new Error('KV timeout');
+      }
+      return originalRead(key);
+    });
+
+    try {
+      await expect(
+        retrieveSessionResumeData(
+          streamId,
+          executionId,
+          agentConfigToTaskState(CONFIG),
+        ),
+      ).rejects.toThrow(
+        `Failed to retrieve tool-use resume data for stream: ${streamId}`,
+      );
+    } finally {
+      readSpy.mockRestore();
+    }
+  });
+
+  it('throws when tool-use metadata is invalid even if the flow record is valid', async () => {
+    const executionId = 'abc130' as ExecutionId;
+    const streamId = 'chat@gpt54#abc130' as StreamTabId;
+    const store = getExecutionStore(executionId);
+    await store.write('meta', {
+      schemaVersion: 999,
+      timestamp: '2026-07-05T00:00:00.000Z',
+    });
+    await store.write(flowKey(executionId), {
+      flowName: 'texra',
+      params: {},
+      shared: {
+        messages: [],
+        shouldSkipCycle: false,
+        stateSlices: {
+          runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
+          workspaceSnapshot: AgentWorkspaceState.create().toSnapshot(),
+          userChannels: {
+            input: Object.freeze({ MODEL: 'gpt54' }),
+            transient: {},
+          },
+        },
+      },
+      createdAt: new Date().toISOString(),
+      nodes: [],
+    });
+
+    await expect(
+      retrieveSessionResumeData(
+        streamId,
+        executionId,
+        agentConfigToTaskState(CONFIG),
+      ),
+    ).rejects.toThrow(
+      `Failed to retrieve tool-use resume data for stream: ${streamId}`,
+    );
   });
 
   it('infers the legacy Google GenAI handler for old workflow transcripts', async () => {

--- a/src/test-kernel/agent/storage/Resumability.vitest.ts
+++ b/src/test-kernel/agent/storage/Resumability.vitest.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { setupPlatform } from '@test/support/setupPlatform';
+import {
+  clearStoreCache,
+  deriveResumability,
+  EXECUTION_META_SCHEMA_VERSION,
+  getExecutionStore,
+  RESUMABILITY_CAUSE,
+} from '@agent/storage';
+import { flowKey, type FlowRecord } from '@agent/node/persistedFlow';
+import { EXECUTION_STATUS, type ExecutionId } from '@shared/schemas';
+
+const BASE_FLOW_RECORD: FlowRecord = {
+  flowName: 'texra',
+  params: {},
+  shared: { messages: [] },
+  createdAt: '2026-07-05T00:00:00.000Z',
+  nodes: [],
+};
+
+describe('deriveResumability', () => {
+  setupPlatform({ workspacePath: '/workspace' });
+
+  beforeEach(() => {
+    clearStoreCache();
+    vi.restoreAllMocks();
+  });
+
+  async function writeFlow(executionId: ExecutionId): Promise<void> {
+    await getExecutionStore(executionId).write(
+      flowKey(executionId),
+      BASE_FLOW_RECORD,
+    );
+  }
+
+  async function writeTerminalStatus(
+    executionId: ExecutionId,
+    terminalStatus: string,
+  ): Promise<void> {
+    await getExecutionStore(executionId).writeMeta({
+      schemaVersion: EXECUTION_META_SCHEMA_VERSION,
+      timestamp: '2026-07-05T00:00:00.000Z',
+      terminalStatus,
+    });
+  }
+
+  it('does not let a stale flow record make completed executions resumable', async () => {
+    const executionId = 'completed-with-flow' as ExecutionId;
+    await writeTerminalStatus(executionId, EXECUTION_STATUS.COMPLETED);
+    await writeFlow(executionId);
+
+    await expect(deriveResumability(executionId)).resolves.toMatchObject({
+      resumable: false,
+      cause: RESUMABILITY_CAUSE.TERMINAL_COMPLETED,
+      terminalStatus: EXECUTION_STATUS.COMPLETED,
+    });
+  });
+
+  it('does not let a stale flow record make failed executions resumable', async () => {
+    const executionId = 'failed-with-flow' as ExecutionId;
+    await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);
+    await writeFlow(executionId);
+
+    await expect(deriveResumability(executionId)).resolves.toMatchObject({
+      resumable: false,
+      cause: RESUMABILITY_CAUSE.TERMINAL_FAILED,
+      terminalStatus: EXECUTION_STATUS.ERROR,
+    });
+  });
+
+  it('marks interrupted executions with a valid flow record as resumable', async () => {
+    const executionId = 'interrupted-with-flow' as ExecutionId;
+    await writeTerminalStatus(executionId, EXECUTION_STATUS.INTERRUPTED);
+    await writeFlow(executionId);
+
+    await expect(deriveResumability(executionId)).resolves.toMatchObject({
+      resumable: true,
+      cause: RESUMABILITY_CAUSE.INTERRUPTED_WITH_FLOW,
+      terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+      flowRecord: BASE_FLOW_RECORD,
+    });
+  });
+
+  it('marks missing-terminal executions with a valid flow record as resumable', async () => {
+    const executionId = 'crash-with-flow' as ExecutionId;
+    await writeFlow(executionId);
+
+    await expect(deriveResumability(executionId)).resolves.toMatchObject({
+      resumable: true,
+      cause: RESUMABILITY_CAUSE.MISSING_TERMINAL_WITH_FLOW,
+      flowRecord: BASE_FLOW_RECORD,
+    });
+  });
+
+  it('reports missing flow records as not resumable', async () => {
+    const executionId = 'missing-flow' as ExecutionId;
+
+    await expect(deriveResumability(executionId)).resolves.toEqual({
+      resumable: false,
+      cause: RESUMABILITY_CAUSE.MISSING_FLOW,
+    });
+  });
+
+  it('reports invalid flow records as not resumable', async () => {
+    const executionId = 'invalid-flow' as ExecutionId;
+    await getExecutionStore(executionId).write(flowKey(executionId), {
+      ...BASE_FLOW_RECORD,
+      shared: null,
+    });
+
+    await expect(deriveResumability(executionId)).resolves.toEqual({
+      resumable: false,
+      cause: RESUMABILITY_CAUSE.INVALID_FLOW,
+    });
+  });
+
+  it('reports invalid metadata as not resumable even with a valid flow record', async () => {
+    const executionId = 'invalid-meta-with-flow' as ExecutionId;
+    const store = getExecutionStore(executionId);
+    await store.write('meta', {
+      schemaVersion: 999,
+      timestamp: '2026-07-05T00:00:00.000Z',
+    });
+    await writeFlow(executionId);
+
+    await expect(deriveResumability(executionId)).resolves.toMatchObject({
+      resumable: false,
+      cause: RESUMABILITY_CAUSE.INVALID_META,
+    });
+  });
+
+  it('reports unreadable flow records as not resumable', async () => {
+    const executionId = 'unreadable-flow' as ExecutionId;
+    const store = getExecutionStore(executionId);
+    await writeFlow(executionId);
+    const originalRead = store.read.bind(store);
+    vi.spyOn(store, 'read').mockImplementation(async (key) => {
+      if (key === flowKey(executionId)) {
+        throw new Error('disk offline');
+      }
+      return originalRead(key);
+    });
+
+    await expect(deriveResumability(executionId)).resolves.toMatchObject({
+      resumable: false,
+      cause: RESUMABILITY_CAUSE.UNREADABLE_FLOW,
+    });
+  });
+});

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   readResultMeta: vi.fn(),
   readReport: vi.fn(),
   exists: vi.fn(),
+  deriveResumability: vi.fn(),
   listExecutions: vi.fn(),
   deleteExecution: vi.fn(),
   deleteAllExecutions: vi.fn(),
@@ -39,6 +40,7 @@ vi.mock('@agent/storage', async () => {
       readReport: mocks.readReport,
       exists: mocks.exists,
     })),
+    deriveResumability: mocks.deriveResumability,
     listExecutions: mocks.listExecutions,
     deleteExecution: mocks.deleteExecution,
     deleteAllExecutions: mocks.deleteAllExecutions,
@@ -118,6 +120,10 @@ describe('CLI history runtime', () => {
     mocks.readResultMeta.mockResolvedValue(null);
     mocks.readReport.mockResolvedValue(null);
     mocks.exists.mockResolvedValue(false);
+    mocks.deriveResumability.mockResolvedValue({
+      resumable: false,
+      cause: 'missing-flow',
+    });
     mocks.readCliToolUseResumeData.mockResolvedValue(null);
     mocks.readCliToolUseResumeDataForListing.mockResolvedValue(null);
   });
@@ -301,6 +307,10 @@ describe('CLI history runtime', () => {
       agentCategory: 'toolUse',
     } as AgentConfig;
     mocks.readConfig.mockResolvedValue(toolUseConfig);
+    mocks.deriveResumability.mockResolvedValue({
+      resumable: true,
+      cause: 'interrupted-with-flow',
+    });
     mocks.readCliToolUseResumeDataForListing.mockResolvedValue({
       streamId: 'chat@gpt54#a1',
       config: toolUseConfig,

--- a/src/test-kernel/cli/HistoryStatus.vitest.ts
+++ b/src/test-kernel/cli/HistoryStatus.vitest.ts
@@ -37,6 +37,12 @@ const TOOL_USE_CONFIG: AgentConfig = {
   cliOutputFile: null,
   cliMultiAgentPresetId: null,
 };
+const WORKFLOW_CONFIG: AgentConfig = {
+  ...TOOL_USE_CONFIG,
+  agent: 'correct',
+  agentCategory: AgentCategory.Workflow,
+  instruction: 'Continue the workflow.',
+};
 
 setupPlatform({ workspacePath: '/workspace' });
 
@@ -45,7 +51,7 @@ describe('CLI history status formatting', () => {
     expect(
       resolveCliHistoryStatus({
         terminalStatus: EXECUTION_STATUS.ERROR,
-        hasFlowRecord: true,
+        resumable: false,
       }),
     ).toBe(EXECUTION_STATUS.ERROR);
   });
@@ -54,7 +60,7 @@ describe('CLI history status formatting', () => {
     expect(
       resolveCliHistoryStatus({
         terminalStatus: EXECUTION_STATUS.INTERRUPTED,
-        hasFlowRecord: true,
+        resumable: true,
       }),
     ).toBe(CLI_HISTORY_RESUMABLE_STATUS);
 
@@ -64,7 +70,7 @@ describe('CLI history status formatting', () => {
           id: 'stopped-with-flow',
           status: resolveCliHistoryStatus({
             terminalStatus: EXECUTION_STATUS.INTERRUPTED,
-            hasFlowRecord: true,
+            resumable: true,
           }),
         },
       ]),
@@ -77,13 +83,13 @@ describe('CLI history status formatting', () => {
     expect(
       resolveCliHistoryStatus({
         terminalStatus: '',
-        hasFlowRecord: true,
+        resumable: false,
       }),
     ).toBe('');
   });
 
   it('marks flow records without terminal status as resumable', () => {
-    expect(resolveCliHistoryStatus({ hasFlowRecord: true })).toBe(
+    expect(resolveCliHistoryStatus({ resumable: true })).toBe(
       CLI_HISTORY_RESUMABLE_STATUS,
     );
   });
@@ -112,7 +118,7 @@ describe('CLI history status formatting', () => {
   it('reports legacy terminal-status-free entries as unknown when no flow remains', () => {
     // A missing terminal status means the terminal write never happened
     // (crash, kill, old build) — reporting 'completed' would mask crashes.
-    expect(resolveCliHistoryStatus({ hasFlowRecord: false })).toBe('unknown');
+    expect(resolveCliHistoryStatus({ resumable: false })).toBe('unknown');
   });
 
   it('prints resumable details instead of inventing completed status', () => {
@@ -155,6 +161,30 @@ describe('CLI history status formatting', () => {
     expect(details?.hasFlowRecord).toBe(false);
     // Absent terminal status without a valid flow record is reported as
     // 'unknown', never invented as completed (crash-masking guard).
+    expect(details?.status).toBe('unknown');
+    expect(formatCliHistoryDetailsText(details!)).not.toContain(
+      'Resumable flow record: present',
+    );
+  });
+
+  it('does not mark non-tool-use flow records as CLI-resumable', async () => {
+    const id = 'workflow-with-flow' as ExecutionId;
+    await registerExecution(id, WORKFLOW_CONFIG, 'correct', undefined);
+    await getExecutionStore(id).write(flowKey(id), {
+      flowName: 'test',
+      params: {},
+      shared: {
+        currentRound: 1,
+        totalRounds: 2,
+        conversation: [],
+      },
+      createdAt: new Date().toISOString(),
+      nodes: [],
+    });
+
+    const details = await readCliHistoryDetails(id);
+
+    expect(details?.hasFlowRecord).toBe(false);
     expect(details?.status).toBe('unknown');
     expect(formatCliHistoryDetailsText(details!)).not.toContain(
       'Resumable flow record: present',

--- a/src/test-kernel/tools/ExecutionsToolResumability.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolResumability.vitest.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { setupPlatform } from '@test/support/setupPlatform';
+import { clearStoreCache, getExecutionStore } from '@agent/storage';
+import { flowKey, type FlowRecord } from '@agent/node/persistedFlow';
+import type { ExecutionId } from '@shared/schemas';
+import { ExecutionsTool } from '@tools/ExecutionsTool';
+
+const BASE_FLOW_RECORD: FlowRecord = {
+  flowName: 'texra',
+  params: {},
+  shared: { messages: [] },
+  createdAt: '2026-07-05T00:00:00.000Z',
+  nodes: [],
+};
+
+describe('ExecutionsTool resumability fallback', () => {
+  setupPlatform({ workspacePath: '/workspace' });
+
+  beforeEach(() => {
+    clearStoreCache();
+  });
+
+  it('does not label metadata-free resumable flow records as completed', async () => {
+    const executionId = 'abc123abc123' as ExecutionId;
+    await getExecutionStore(executionId).write(
+      flowKey(executionId),
+      BASE_FLOW_RECORD,
+    );
+
+    const result = await new ExecutionsTool().call({
+      path: `/executions/${executionId}`,
+    });
+
+    expect(result.status).toBe('executed');
+    expect(result.output).toContain('Status: resumable');
+    expect(result.output).not.toContain('Status: completed');
+  });
+
+  it('does not treat invalid metadata-free flow records as found', async () => {
+    const executionId = 'abc123abc124' as ExecutionId;
+    await getExecutionStore(executionId).write(flowKey(executionId), {
+      ...BASE_FLOW_RECORD,
+      shared: null,
+    });
+
+    const result = await new ExecutionsTool().call({
+      path: `/executions/${executionId}`,
+    });
+
+    expect(result.status).toBe('error');
+    expect(result.error).toContain(`Execution not found: ${executionId}`);
+  });
+
+  it('does not treat invalid metadata-free flow records as conversations', async () => {
+    const executionId = 'abc123abc125' as ExecutionId;
+    await getExecutionStore(executionId).write(flowKey(executionId), {
+      ...BASE_FLOW_RECORD,
+      shared: null,
+    });
+
+    const result = await new ExecutionsTool().call({
+      path: `/executions/${executionId}/conversation`,
+    });
+
+    expect(result.status).toBe('error');
+    expect(result.error).toContain(`Execution not found: ${executionId}`);
+  });
+});

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -12,6 +12,7 @@ import { platform } from '@platform/platform';
 
 // Local imports - agent
 import {
+  deriveResumability,
   getExecutionStore,
   listExecutionWorkspaceFiles,
   type ChildRecord,
@@ -20,7 +21,6 @@ import {
   resolveExecutionWorkspaceFilePath,
 } from '@agent/storage';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
-import { flowKey } from '@agent/node/persistedFlow';
 import { tryUseRunContext } from '@agent/runtime/RunContext';
 import { detachSubagentsOnStop } from '@agent/runtime/detachSubagentsOnStop';
 import {
@@ -449,13 +449,13 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
     ]);
 
     if (!meta && !config) {
-      const hasFlow = await store.exists(flowKey(executionId));
-      if (!hasFlow) {
+      const resumability = await deriveResumability(executionId);
+      if (!resumability.resumable) {
         throw new ToolError(`Execution not found: ${executionId}`);
       }
       return {
         status: 'executed',
-        output: `Execution: ${executionId}\nStatus: completed\n(No metadata available - use /executions/${executionId}/conversation to view messages)`,
+        output: `Execution: ${executionId}\nStatus: resumable\n(No metadata available - use /executions/${executionId}/conversation to view messages)`,
       };
     }
 
@@ -751,11 +751,11 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
     const conversation = await store.readConversation();
 
     if (!conversation) {
-      // readConversation already checked the flow blob; use lightweight
-      // exists checks to distinguish "no execution" from "no messages yet"
-      const exists =
-        (await store.exists('meta')) ||
-        (await store.exists(flowKey(executionId)));
+      // Match the top-level execution lookup: a flow-only record is found only
+      // when the shared storage decision says it is resumable.
+      const meta = await store.readMeta();
+      const resumability = await deriveResumability(executionId);
+      const exists = meta !== null || resumability.resumable;
       if (!exists) {
         throw new ToolError(`Execution not found: ${executionId}`);
       }


### PR DESCRIPTION
## Summary

Centralizes execution-storage resumability in `deriveResumability()` so terminal metadata, metadata validity, and flow-record validity are evaluated in one place. Updates restart repair, extension follow-up checks, session resume retrieval, CLI history, and `/executions` fallbacks to consume that decision instead of local flow-existence predicates.

## Issue acceptance gates

Addresses #7243:

- Reverified cited evidence on current `main` before implementation.
- Completed/error terminal metadata blocks stale flow records from becoming resumable.
- Interrupted/cancelled or terminal-status-free executions require a valid flow record before they are resumable.
- Missing, unreadable, or invalid flow records are not resumable and report explicit causes.
- Invalid metadata is not treated as missing-terminal resumability; active resume surfaces it as a load failure.
- CLI history/list/details only show `resumable` when the CLI tool-use resume path can assemble a usable snapshot.
- `/executions` no longer labels metadata-free flow records as completed and rejects invalid flow-only records consistently.

## Single source of truth

`src/agent/storage/resumability.ts` now owns the storage-level resumability decision and its cause model.

## Duplication and abstraction budget

Removed local “flow record exists means resumable” checks from restart repair, follow-up availability, session resume retrieval, CLI history status, and `/executions` fallbacks. The added module is not a pass-through layer: it owns the invariant that terminal metadata and validated flow storage must agree before a run is resumable. This PR is net-positive in lines because the added mass is concentrated in the shared decision helper and regression tests covering the former duplicated predicates.

No shim, projection, dual-write, alias, fallback, or migration path is introduced, so no #6981 ledger row is required.

## Host impact

Extension: lazy follow-up availability and session resume retrieval now use the shared storage decision; stale completed/error flow records cannot reopen follow-up paths.

Desktop: restart repair via `detectWaitingStreams()` uses the same decision, so completed/error or invalid flow storage repairs to non-resumable instead of WAITING.

CLI: history list/details only print `resumable` after a CLI tool-use resume snapshot can be assembled; active resume still reports load failures for unreadable or invalid resume storage instead of silently degrading to no snapshot.

## Scheduled refactoring

None for this PR. The remaining Stage 3c deletion of `conversation.json` / `todos.json` projections remains blocked on the completed-run archival/display ownership question documented on #6966.

## Validation

- `corepack pnpm exec prettier --write` on touched files
- `npm test -- --run src/test-kernel/agent/storage/Resumability.vitest.ts src/test-kernel/agent/SessionResumeRetrieval.vitest.ts src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts src/test-kernel/cli/HistoryStatus.vitest.ts src/test-kernel/cli/History.vitest.mts src/test-kernel/cli/SessionResumeResolution.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/progressView/RestartRepair.vitest.ts src/test-kernel/tools/ExecutionsToolResumability.vitest.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing unrelated import-order warning in `packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts`)
- `npm run compile:fast`
- `git diff --check`
- `npm test`

Closes #7243

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared resume/restart semantics across extension, desktop repair, CLI history, and session auto-resume; behavior is heavily regression-tested but mistakes could mis-label runs or block follow-ups.
> 
> **Overview**
> Introduces **`deriveResumability(executionId)`** in `@agent/storage` as the single place that decides whether an execution can resume, with explicit **causes** (e.g. stale flow on completed/failed runs, missing/invalid/unreadable flow or meta).
> 
> **Call sites** stop using local “flow record exists” checks: extension lazy follow-up / `detectWaitingStreams`, **`SessionResumeRetrieval`**, CLI history list/details, and **`ExecutionsTool`** fallbacks now consume the shared decision. Completed or failed **terminal metadata wins** over leftover flow files so finished runs cannot reopen as WAITING or `resumable`.
> 
> CLI history only shows **`resumable`** when storage says resumable **and** the CLI tool-use resume path can build a snapshot (`readCliToolUseResumeDataForListing`); workflow-only flow records are not CLI-resumable. **`resolveCliHistoryStatus`** takes a `resumable` flag instead of inferring from interrupted terminal status alone. Resume retrieval **throws** on unreadable or invalid meta/flow storage instead of silently treating it as “no session.” Metadata-free flow-only executions in `/executions` report **`Status: resumable`**, not completed, and invalid flow-only records are **not found**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e8e41e86c220a79fcb90c22517353d0e8950f2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->