### PR TITLE
fix: drain desktop snapshot flushes

### DIFF
--- a/packages/desktop/src/main/desktopStreamSnapshot.ts
+++ b/packages/desktop/src/main/desktopStreamSnapshot.ts
@@ -92,6 +92,7 @@ export async function openDesktopStreamSnapshotStore(
     reject(error: unknown): void;
   }> = [];
   let writeChain = Promise.resolve();
+  let writeGeneration = 0;
 
   function currentFile(): RestoredStreamsFile {
     return {
@@ -107,6 +108,7 @@ export async function openDesktopStreamSnapshotStore(
   function enqueuePersist(
     waiters: typeof pendingUpsertWaiters = [],
   ): Promise<void> {
+    writeGeneration += 1;
     const write = writeChain.then(persist, persist);
     writeChain = write.catch(() => {});
     void write.then(
@@ -155,7 +157,17 @@ export async function openDesktopStreamSnapshotStore(
   }
 
   async function flushPendingWrites(): Promise<void> {
-    await persistPendingUpserts();
+    for (;;) {
+      const generationBeforeFlush = writeGeneration;
+      await persistPendingUpserts();
+      if (
+        pendingDebounce === undefined &&
+        pendingUpsertWaiters.length === 0 &&
+        writeGeneration === generationBeforeFlush
+      ) {
+        return;
+      }
+    }
   }
 
   return {

--- a/src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts
+++ b/src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts
@@ -115,6 +115,17 @@ describe('DesktopStreamSnapshot', () => {
     return raw.restoredStreams.streams;
   }
 
+  function deferred(): {
+    promise: Promise<void>;
+    resolve(): void;
+  } {
+    let resolve!: () => void;
+    const promise = new Promise<void>((settle) => {
+      resolve = settle;
+    });
+    return { promise, resolve };
+  }
+
   it('starts empty when the file does not exist', async () => {
     const store = await openDesktopStreamSnapshotStore(await tempFilePath());
 
@@ -261,6 +272,55 @@ describe('DesktopStreamSnapshot', () => {
     expect(await readPersistedSnapshots(filePath)).toEqual([
       expect.objectContaining({ description: 'pending' }),
     ]);
+  });
+
+  it('flush drains upserts scheduled while a write is in flight', async () => {
+    vi.useFakeTimers();
+    const filePath = await tempFilePath();
+    const store = await openDesktopStreamSnapshotStore(filePath);
+    const firstWriteStarted = deferred();
+    const releaseFirstWrite = deferred();
+    writeFileAtomicMock.mockImplementationOnce(async (target, data) => {
+      firstWriteStarted.resolve();
+      await releaseFirstWrite.promise;
+      await writeFile(target, data);
+    });
+
+    const first = store.upsert(makeSnapshot({ description: 'first' }));
+    const flush = store.flush();
+    await firstWriteStarted.promise;
+    const second = store.upsert(
+      makeSnapshot({
+        streamId: 'toolUseAgent@2',
+        agentCategory: 'toolUse',
+        description: 'second',
+      }),
+    );
+    let secondSettled = false;
+    void second.then(() => {
+      secondSettled = true;
+    });
+
+    releaseFirstWrite.resolve();
+    await flush;
+    await Promise.resolve();
+
+    expect(secondSettled).toBe(true);
+    await Promise.all([first, second]);
+    expect(writeFileAtomicMock).toHaveBeenCalledTimes(2);
+    expect(await readPersistedSnapshots(filePath)).toEqual([
+      expect.objectContaining({
+        streamId: 'workflowAgent@1',
+        description: 'first',
+      }),
+      expect.objectContaining({
+        streamId: 'toolUseAgent@2',
+        description: 'second',
+      }),
+    ]);
+
+    await vi.advanceTimersByTimeAsync(debounceMs);
+    expect(writeFileAtomicMock).toHaveBeenCalledTimes(2);
   });
 
   it('remove drops a snapshot and persists the removal', async () => {


### PR DESCRIPTION
## Summary

Makes desktop stream snapshot shutdown flushes drain until the snapshot store is quiescent. If a final `upsert()` arrives while an older write is still in flight, `flush()` now observes the new write generation and waits for the follow-up write before resolving.

## Issue acceptance gates

Addresses #7242:

- Reverified the cited debounce and shutdown flush sites on current `main` before implementation.
- `DesktopStreamSnapshotStore.flush()` loops until no debounce is pending, no upsert waiters remain, and no write was enqueued while the prior drain was awaiting.
- Added a regression test that blocks the first write, schedules a second upsert while flush is in flight, and asserts the second snapshot is persisted before `flush()` resolves.

## Single source of truth

`packages/desktop/src/main/desktopStreamSnapshot.ts` remains the owner of desktop stream snapshot write ordering and flush durability.

## Duplication and abstraction budget

No new abstraction or pass-through layer. The change extends the existing debounced write-chain with a write generation counter so `flush()` can detect work scheduled during an awaited write.

No shim, projection, dual-write, alias, fallback, or migration path is introduced, so no #6981 ledger row is required.

## Host impact

Extension: none.

Desktop: shutdown snapshot flush waits for mid-flush stream upserts before the lifecycle handler resolves, preventing the final snapshot update from being dropped during quit.

CLI: none.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write packages/desktop/src/main/desktopStreamSnapshot.ts src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts`
- `npm test -- --run src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts`
- `npm run typecheck`
- `npm run lint` (passes with existing unrelated import-order warning in `packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts`)
- `npm run compile:fast`
- `git diff --check`
- `npm test`

Closes #7242

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to desktop snapshot write ordering and shutdown flush behavior; no auth, security, or cross-host API changes.
> 
> **Overview**
> **Desktop stream snapshot `flush()`** now loops until the store is fully quiescent instead of doing a single drain pass. A **`writeGeneration`** counter increments on each enqueued persist; **`flushPendingWrites`** repeats until there is no pending debounce, no upsert waiters, and no new write was scheduled while the previous drain was awaiting.
> 
> This closes a shutdown race where a final **`upsert()`** during an in-flight write could resolve **`flush()`** before that snapshot was persisted (e.g. app quit on macOS).
> 
> A regression test blocks the first atomic write, schedules a second upsert mid-flush, and asserts both snapshots are on disk before **`flush()`** resolves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce3d5b150faaf45d909f3d03ebbeb20b73446edf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->