### PR TITLE
fix(extension): require VS Code 1.106 for secondary sidebar

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -5,7 +5,7 @@
   "version": "0.39.3",
   "publisher": "texra-ai",
   "engines": {
-    "vscode": "^1.105.0"
+    "vscode": "^1.106.0"
   },
   "categories": [
     "Programming Languages",

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -5,7 +5,7 @@
     "description": "TeXRA: Your 24/7 AI Theorist.",
     "publisher": "texra-ai",
     "engines": {
-      "vscode": "^1.105.0"
+      "vscode": "^1.106.0"
     },
     "categories": [
       "Programming Languages",


### PR DESCRIPTION
## Source of truth

`packages/extension/package.json` is the single source of truth for the extension's supported VS Code host version. Since the manifest now contributes the TeXRA container through `viewsContainers.secondarySidebar`, the advertised engine floor must be the first VS Code version that supports that contribution point: `^1.106.0`.

## Duplication and abstraction budget

No new abstraction, shim, fallback, projection, dual-write, alias, or migration path is introduced. This removes the contradictory compatibility claim where the manifest advertised `^1.105.0` while relying on a `secondarySidebar` contribution that the PRD documents as a 1.106+ surface. The generated extension package invariant snapshot is updated to match the manifest.

## Host impact

- Extension: VS Code 1.105.x is no longer advertised as supported for this extension package, so hosts that cannot render `secondarySidebar` will reject the package instead of silently dropping the TeXRA container.
- Desktop: no impact; desktop does not consume the VS Code extension manifest to place its UI.
- CLI: no impact.

## Checks

- `npm run sync:extension-package-invariants`
- `corepack pnpm exec prettier --write packages/extension/package.json scripts/extension-package-invariants.snapshot.json`
- `npm run check:extension-package-invariants`
- `git diff --check`
- `npm run typecheck`
- `npm test`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing unrelated import-order warning in `packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts`)

Closes #7249

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only compatibility alignment with no runtime logic changes; main user impact is dropping install on VS Code 1.105.x.
> 
> **Overview**
> Raises the extension’s advertised **minimum VS Code version** from `^1.105.0` to `^1.106.0` in `packages/extension/package.json`, matching the manifest’s `viewsContainers.secondarySidebar` contribution (that surface is 1.106+).
> 
> The generated **`scripts/extension-package-invariants.snapshot.json`** is updated so CI still reflects the manifest. **VS Code 1.105.x** will no longer be offered as supported; hosts below 1.106 should refuse or block install instead of loading the extension and dropping the TeXRA sidebar container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3db16f354feb49e88648ff58b0988c4f78bfc7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->