### PR TITLE
fix(trace-viewer): reject incompatible snapshot versions

### DIFF
--- a/packages/trace-viewer/src/traceDataSchema.ts
+++ b/packages/trace-viewer/src/traceDataSchema.ts
@@ -26,11 +26,20 @@ import {
   ExecutionStatusSchema,
   RunOutcomeSchema,
 } from '@shared/schemas/stream';
-import { StreamSnapshotSchema } from '@shared/schemas/streamSnapshot';
+import {
+  STREAM_SNAPSHOT_SCHEMA_VERSION,
+  StreamSnapshotSchema,
+} from '@shared/schemas/streamSnapshot';
 import { ToolConfigSchema } from '@shared/schemas/toolConfig';
 import type { TraceDocument } from '@transcript/traceAssembler';
 
 const TRACE_EXECUTION_META_SCHEMA_VERSION = 1;
+
+const TraceStreamSnapshotSchema = StreamSnapshotSchema.extend({
+  schemaVersion: z
+    .literal(STREAM_SNAPSHOT_SCHEMA_VERSION)
+    .prefault(STREAM_SNAPSHOT_SCHEMA_VERSION),
+});
 
 const TraceAgentConfigSchema = NullableFileFieldsSchema.extend({
   agent: z.string(),
@@ -73,7 +82,7 @@ export const TraceDataSchema = z.object({
   config: TraceAgentConfigSchema,
   meta: TraceExecutionMetaSchema.nullable(),
   entries: z.array(StreamLogEntrySchema),
-  snapshot: StreamSnapshotSchema,
+  snapshot: TraceStreamSnapshotSchema,
   terminalStatus: ExecutionStatusSchema.nullable(),
 });
 

--- a/src/test-kernel/transcript/traceViewerSchema.vitest.ts
+++ b/src/test-kernel/transcript/traceViewerSchema.vitest.ts
@@ -151,6 +151,30 @@ describe('trace-viewer TraceDataSchema', () => {
     );
   });
 
+  it('rejects a trace snapshot stamped with an incompatible schema version', () => {
+    const incompatible = {
+      executionId: 'abcdef',
+      streamId: 'stream-1',
+      config: config(),
+      meta: null,
+      entries: [],
+      snapshot: {
+        schemaVersion: 999,
+        streamId: 'stream-1',
+        outputFilesByRound: {},
+        missingOutputsByRound: {},
+        compileFailuresByRound: {},
+      },
+      terminalStatus: null,
+    };
+
+    const result = TraceDataSchema.safeParse(incompatible);
+    expect(result.success).toBe(false);
+    expect(() => parseTraceData(incompatible)).toThrowError(
+      /incompatible TeXRA version/,
+    );
+  });
+
   it('rejects a trace whose entries are not an array of StreamLogEntry', () => {
     const malformed = {
       executionId: 'abcdef',


### PR DESCRIPTION
## Source of truth

`TraceDataSchema` in `packages/trace-viewer/src/traceDataSchema.ts` is the external-boundary validator for trace files loaded by trace-viewer. It now owns a trace-viewer-specific snapshot schema that keeps the shared `StreamSnapshotSchema` shape but rejects incompatible `snapshot.schemaVersion` values instead of inheriting the persistence reader's lenient `.catch()` behavior.

## Duplication and abstraction budget

No new pass-through layer is introduced. The only duplication is the intentional boundary-specific override of one field (`schemaVersion`) while reusing the shared snapshot schema for the rest of the shape. This keeps local-disk snapshot hydration tolerant while making exported trace-file validation loud at the browser boundary.

## Host impact

- Extension: exported trace-viewer HTML now rejects traces stamped with an incompatible snapshot schema instead of replaying them after silent coercion.
- Desktop: same behavior for any desktop surface that opens trace-viewer exports.
- CLI: `texra history --export html` / trace-viewer exports get the stricter validation in the generated viewer; CLI runtime behavior is otherwise unchanged.

## Checks

- `corepack pnpm exec prettier --write packages/trace-viewer/src/traceDataSchema.ts src/test-kernel/transcript/traceViewerSchema.vitest.ts`
- `corepack pnpm exec vitest run src/test-kernel/transcript/traceViewerSchema.vitest.ts`
- `corepack pnpm --filter @texra/trace-viewer run typecheck`
- `corepack pnpm --filter @texra/trace-viewer run build`
- `git diff --check`
- `npm run typecheck`
- `npm test`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing unrelated import-order warning in `packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts`)

Closes #7252

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows validation at the trace-viewer export boundary only; runtime persistence and assembly paths are unchanged aside from stricter rejection of incompatible exported traces.
> 
> **Overview**
> Trace-viewer validation now uses **`TraceStreamSnapshotSchema`**, which extends the shared snapshot shape but requires **`snapshot.schemaVersion`** to match the current **`STREAM_SNAPSHOT_SCHEMA_VERSION`** via a strict literal (with prefault for missing values), instead of inheriting the shared schema’s **`.catch()`** coercion that could silently accept mismatched exports.
> 
> **`TraceDataSchema.snapshot`** is wired to this boundary-specific schema so exported HTML/`trace.json` loads fail loudly through **`parseTraceData`** when the snapshot was stamped by an incompatible TeXRA build, while local persistence readers can stay lenient.
> 
> A vitest case asserts traces with **`schemaVersion: 999`** are rejected and surface the existing **incompatible TeXRA version** error message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eb0dddd6abe92530bc6ee9cf8b61a8ea94b5f36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->