### PR TITLE
fix(trace-viewer): derive legacy status from log entries

### DIFF
--- a/packages/trace-viewer/src/replayTrace.ts
+++ b/packages/trace-viewer/src/replayTrace.ts
@@ -3,12 +3,15 @@ import type { MessageHandlerContext } from '@progressView/frontend/messageHandle
 import {
   executionStatusToRunOutcome,
   STREAM_STATUS,
+  STREAM_LOG_ENTRY_TYPES,
+  StreamStatusSchema,
   streamStatusToLifecycleStatus,
   type StreamLifecycleStatus,
 } from '@shared/schemas';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc/progressViewCommands';
 import type { ProgressViewOutboundMessage } from '@shared/schemas/progressView';
 import type { TraceDocument } from '@transcript';
+import { isObject } from '@utils/core';
 
 type UpdateStreamsMessage = Extract<
   ProgressViewOutboundMessage,
@@ -31,17 +34,22 @@ type SyncStreamContentMessage = Extract<
  * `StreamPhase`'s values, so it's already a valid `StreamLifecycleStatus`.
  *
  * `terminalStatus` is `null` for traces that predate outcome tracking (or
- * never reached a terminal state) — for those legacy traces, fall back to
- * deriving status from the snapshot's own recorded `status` instead of
- * unconditionally reporting `READY`, so an archived failed/stopped run
- * doesn't render as if it finished cleanly. Only when the snapshot itself
- * has no recorded status either does this default to `READY`, same as an
- * unqualified successful finish.
+ * never reached a terminal state). For those legacy traces, derive status from
+ * the persisted transcript's last terminal group row before falling back to the
+ * older snapshot-status escape hatch. Only when neither source records a
+ * terminal status does this default to `READY`, same as an unqualified
+ * successful finish.
  */
 function toStreamLifecycleStatus(trace: TraceDocument): StreamLifecycleStatus {
   if (trace.terminalStatus !== null) {
     const outcome = executionStatusToRunOutcome(trace.terminalStatus);
     if (outcome) return outcome;
+  }
+  for (const entry of trace.entries.toReversed()) {
+    if (entry.type !== STREAM_LOG_ENTRY_TYPES.GROUP_END) continue;
+    if (!isObject(entry.data)) continue;
+    const status = StreamStatusSchema.safeParse(entry.data.status);
+    if (status.success) return streamStatusToLifecycleStatus(status.data);
   }
   return trace.snapshot.status
     ? streamStatusToLifecycleStatus(trace.snapshot.status)

--- a/src/test-kernel/traceViewer/replayTrace.vitest.ts
+++ b/src/test-kernel/traceViewer/replayTrace.vitest.ts
@@ -1,15 +1,31 @@
-import { create } from 'mutative';
-import { describe, expect, it } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
+import { create } from 'mutative';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { MemoryStateStore } from '@platform/defaults/memoryState';
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
+import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
+import { createFakePlatform } from '@test/support/FakePlatform';
+import { setupPlatform } from '@test/support/setupPlatform';
+import { assembleTrace, StreamLogStore } from '@transcript';
+import { getExecutionStore } from '@agent/storage';
+import { getStreamTabId } from '@agent/runtime/streamTab';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
-import type { MessageHandlerContext } from '@progressView/frontend/messageHandlerTypes';
 import {
   createInitialState,
   type ProgressState,
 } from '@progressView/frontend/store';
+import type { MessageHandlerContext } from '@progressView/frontend/messageHandlerTypes';
 import {
   AgentCategory,
+  LOG_LEVELS,
+  MESSAGE_TYPES,
   STREAM_STATUS,
+  STREAM_LOG_ENTRY_TYPES,
   StreamSnapshotSchema,
   type ExecutionId,
   type StreamTabId,
@@ -19,7 +35,27 @@ import {
 // the real replay pipeline (`@progressView/frontend`'s dispatcher + slices),
 // so a plain relative import is the simplest way to reach it.
 import { replayTrace } from '../../../packages/trace-viewer/src/replayTrace';
+import type { Platform } from '@platform/platform';
 import type { TraceDocument } from '@transcript';
+
+const tempDirs: string[] = [];
+
+async function buildStoragePlatform(): Promise<Platform> {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'texra-replay-trace-'));
+  tempDirs.push(tempDir);
+  const workspaceDir = path.join(tempDir, 'workspace');
+  const storageRoot = path.join(tempDir, 'storage');
+  return createFakePlatform(
+    { workspacePath: workspaceDir },
+    {
+      fs: nodeFilesystem,
+      workspace: createNodeWorkspace(() => workspaceDir),
+      storage: new WorkspaceStorageProvider(storageRoot, workspaceDir),
+      globalState: new MemoryStateStore(),
+      workspaceState: new MemoryStateStore(),
+    },
+  );
+}
 
 function createContext(initialState: ProgressState): {
   ctx: MessageHandlerContext;
@@ -49,6 +85,14 @@ function createContext(initialState: ProgressState): {
   return { ctx, getState: () => state };
 }
 
+setupPlatform(buildStoragePlatform);
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
 function legacyTrace(
   snapshotStatus: 'error' | 'stopped' | undefined,
 ): TraceDocument {
@@ -76,6 +120,51 @@ function legacyTrace(
 }
 
 describe('replayTrace legacy-status fallback (issue #7188)', () => {
+  it('derives failed status from a real exported legacy trace without snapshot.status', async () => {
+    const executionId = 'abc124' as ExecutionId;
+    const config = AgentConfigSchema.parse({
+      agent: 'correct',
+      model: 'gemini35f',
+      agentCategory: AgentCategory.Workflow,
+    });
+    await getExecutionStore(executionId).writeConfig(config);
+    await getExecutionStore(executionId).writeMeta({
+      timestamp: '2026-07-06T00:00:00.000Z',
+    });
+
+    const streamId = getStreamTabId(config.agent, config.model, {
+      executionId,
+    });
+    const store = new StreamLogStore();
+    await store.load();
+    store.append(streamId, {
+      id: 'terminal-stage',
+      type: STREAM_LOG_ENTRY_TYPES.GROUP_START,
+      level: LOG_LEVELS.INFO,
+      timestamp: 100,
+      messageType: MESSAGE_TYPES.DEFAULT,
+      text: 'Legacy run',
+      data: { status: 'running' },
+    });
+    store.update(streamId, 'terminal-stage', {
+      type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
+      data: { status: 'error', endTime: 200 },
+    });
+    await store.flush();
+
+    const result = await assembleTrace(executionId);
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    expect(result.trace.terminalStatus).toBeNull();
+    expect(result.trace.snapshot.status).toBeUndefined();
+
+    const { ctx, getState } = createContext(createInitialState());
+    replayTrace(result.trace, ctx);
+
+    const replayed = getState().streamStates.get(result.trace.streamId);
+    expect(replayed?.status).toBe('failed');
+  });
+
   it('derives "failed" from snapshot.status "error" instead of defaulting to ready', () => {
     const { ctx, getState } = createContext(createInitialState());
     const trace = legacyTrace('error');


### PR DESCRIPTION
## Source of truth

For legacy exported traces with `terminalStatus: null`, the persisted transcript entries are the source of truth for whether an archived run ended with a failure/stop. `replayTrace` now reads the latest terminal `group-end` row from `trace.entries` before falling back to the older snapshot-status escape hatch.

## Duplication and abstraction budget

No new persistence field, shim, projection, fallback writer, or migration path is introduced. This deliberately does not persist liveness/status into `StreamSnapshotStore`, whose schema documents that live status is not durable. The compatibility fallback remains read-only for any existing hand-authored trace that already carries `snapshot.status`.

## Host impact

- Extension: trace-viewer HTML exports replay legacy failed/stopped traces using persisted log data instead of rendering them as ready.
- Desktop: same replay correction for desktop-opened trace-viewer exports.
- CLI: `texra history --export html` exports get the corrected replay behavior; CLI runtime byte output is otherwise unchanged.

## Checks

- `corepack pnpm exec prettier --write packages/trace-viewer/src/replayTrace.ts src/test-kernel/traceViewer/replayTrace.vitest.ts`
- `corepack pnpm exec vitest run src/test-kernel/traceViewer/replayTrace.vitest.ts src/test-kernel/transcript/traceAssembler.vitest.ts`
- `git diff --check`
- `npm run typecheck`
- `npm test`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing unrelated import-order warning in `packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts`)

Closes #7248

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only replay fallback for legacy trace display; no auth, persistence schema, or live-run behavior changes.
> 
> **Overview**
> For legacy traces with **`terminalStatus: null`**, **`replayTrace`** now infers stream lifecycle status by walking **`trace.entries`** in reverse and using the latest terminal **`group-end`** row’s **`status`** (via **`StreamStatusSchema`** / **`streamStatusToLifecycleStatus`**) before the existing **`snapshot.status`** fallback and the **`READY`** default.
> 
> This fixes archived HTML trace replay where failed runs had no durable snapshot status but still recorded failure in the transcript log.
> 
> Tests add a storage-backed integration case that builds a trace through **`assembleTrace`** with only log-derived terminal **`error`**, plus platform temp-dir setup for that path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e66d00c79ca9ae23cd3eaac861efc1a4bffd96c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->