### PR TITLE
fix(cli): point trace export message to saved trace

### DIFF
--- a/packages/cli/src/commands/history.ts
+++ b/packages/cli/src/commands/history.ts
@@ -170,9 +170,10 @@ export async function runHistoryExport(
       );
       return CliExitCode.Usage;
     }
+    const traceFile = path.join(destDir, 'trace.json');
     writeTextStderr(
-      `Wrote trace JSON for ${id} to stdout. Save the output to a file, ` +
-        `then open ${destDir}/index.html?trace=<your-filename>.`,
+      `Wrote trace JSON for ${id} to stdout. Save the output to ` +
+        `${traceFile}, then open ${destDir}/index.html?trace=trace.json.`,
     );
     return CliExitCode.Success;
   }

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -1360,8 +1360,9 @@ describe('CLI history runtime', () => {
                   '<relative-path-to-the-redirected-file>',
                 );
                 expect(stderr).toContain(
-                  `Wrote trace JSON for a1 to stdout. Save the output to a ` +
-                    `file, then open ${destDir}/index.html?trace=<your-filename>.`,
+                  `Wrote trace JSON for a1 to stdout. Save the output to ` +
+                    `${path.join(destDir, 'trace.json')}, then open ` +
+                    `${destDir}/index.html?trace=trace.json.`,
                 );
               },
             );


### PR DESCRIPTION
## Source of truth

`packages/cli/src/commands/history.ts` owns the human stderr instruction for `texra history show --export html --assets-dir`. The message now names the actual file location the trace-viewer URL resolves against: `${assetsDir}/trace.json` with `?trace=trace.json`.

## Duplication and abstraction budget

No new abstraction, fallback, projection, alias, dual-write, shim, or migration path is introduced. This is a wording correction plus the existing CLI history test assertion.

## Host impact

- Extension: no impact.
- Desktop: no impact.
- CLI: shared-assets HTML export instructions now tell users to redirect stdout into the staged assets directory so the printed trace-viewer URL can fetch the JSON file successfully. The JSON bytes and exit-code behavior are unchanged.

## Checks

- `corepack pnpm exec prettier --write packages/cli/src/commands/history.ts src/test-kernel/cli/History.vitest.mts`
- `corepack pnpm exec vitest run src/test-kernel/cli/History.vitest.mts`
- `git diff --check`
- `npm run typecheck`
- `npm test`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing unrelated import-order warning in `packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts`)

Closes #7247

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing stderr text and test expectations only; export output and exit codes are unchanged.
> 
> **Overview**
> For **`texra history show --export html --assets-dir`**, the stderr help text no longer uses vague “save to a file” / `<your-filename>` wording. It now tells users to redirect stdout to **`trace.json`** inside the staged assets directory and open **`index.html?trace=trace.json`**, matching what the trace viewer actually loads.
> 
> The CLI history test assertion was updated to expect the concrete path and query string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcb2837fd6d4f986ca0e18d5ee4c9b03c0450799. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->