### PR TITLE
fix(trace-viewer): enforce schema mirror type assertions

### DIFF
--- a/packages/trace-viewer/src/traceDataSchema.ts
+++ b/packages/trace-viewer/src/traceDataSchema.ts
@@ -94,13 +94,22 @@ export type TraceData = z.infer<typeof TraceDataSchema>;
  * hand-maintained duplicate, so a field added/renamed there surfaces here as
  * a type error instead of a silent validation gap.
  */
-type _AssertTraceDataAcceptsTraceDocument = TraceDocument extends TraceData
-  ? true
-  : never;
-type _AssertTraceAgentConfigAcceptsAgentConfig =
-  AgentConfig extends z.infer<typeof TraceAgentConfigSchema> ? true : never;
-type _AssertTraceExecutionMetaAcceptsExecutionMeta =
-  ExecutionMeta extends z.infer<typeof TraceExecutionMetaSchema> ? true : never;
+type _AssertTrue<T extends true> = T;
+type _IsExact<Source, Target> = [Source] extends [Target]
+  ? [Target] extends [Source]
+    ? true
+    : false
+  : false;
+
+type _AssertTraceDataAcceptsTraceDocument = _AssertTrue<
+  _IsExact<TraceDocument, TraceData>
+>;
+type _AssertTraceAgentConfigAcceptsAgentConfig = _AssertTrue<
+  _IsExact<AgentConfig, z.infer<typeof TraceAgentConfigSchema>>
+>;
+type _AssertTraceExecutionMetaAcceptsExecutionMeta = _AssertTrue<
+  _IsExact<ExecutionMeta, z.infer<typeof TraceExecutionMetaSchema>>
+>;
 
 /**
  * Parses raw trace data (from `fetch()` or `window.__TEXRA_TRACE__`) against


### PR DESCRIPTION
## Summary

Replaces trace-viewer's inert schema mirror type aliases with constrained exact assertions, so drift between `TraceDocument`/`AgentConfig`/`ExecutionMeta` and the browser-safe trace-viewer schemas fails `tsc` instead of compiling as `never`.

## Issue acceptance gates

Addresses #7251:
- Re-verified the cited assertions in `packages/trace-viewer/src/traceDataSchema.ts`; #7255 shifted the lines but did not fix the inert `? true : never` pattern.
- Applies the fix to all three aliases: trace data, agent config, and execution meta.
- Uses bidirectional exact checks so added or renamed source fields are caught, not just one-way assignability failures.

## Single source of truth

`packages/trace-viewer/src/traceDataSchema.ts` remains the browser-safe runtime schema mirror; its local `_AssertTrue<_IsExact<...>>` helpers now enforce the mirror contract at compile time.

## Duplication and abstraction budget

No runtime abstraction or pass-through layer was added. This keeps the existing mirror but makes its stated compile-time guard real.

## Host impact

Extension: No runtime behavior change; trace-viewer validation mirror drift now fails during typecheck.

Desktop: No runtime behavior change.

CLI: No runtime behavior change.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write packages/trace-viewer/src/traceDataSchema.ts`
- `corepack pnpm --filter @texra/trace-viewer run typecheck`
- `corepack pnpm exec vitest run src/test-kernel/transcript/traceViewerSchema.vitest.ts`
- `git diff --check`
- `npm run typecheck`
- `npm test`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing warning in `packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts`)

Closes #7251

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time-only change in trace-viewer; no runtime behavior or validation logic changes.
> 
> **Overview**
> Strengthens **compile-time** guards in `traceDataSchema.ts` so the browser-safe Zod mirrors stay aligned with `TraceDocument`, `AgentConfig`, and `ExecutionMeta`.
> 
> Previously, assertions used one-way `extends` checks with `? true : never`, which did not reliably fail `tsc` when shapes drifted. They now use `_AssertTrue` + `_IsExact` for **bidirectional** equality on all three pairs, so added or renamed fields on either side surface as type errors instead of silent gaps at runtime validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e71639b6fbbd415edb0c111b10c8603478b2525. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->