### PR TITLE
[codex] docs: update VS Code minimum version docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ In the CLI, export the same variables in your shell and run with
 
 ## Requirements
 
-- **VS Code 1.105+** (also runs in Cursor, Windsurf, Antigravity), or
+- **VS Code 1.106+** (also runs in Cursor, Windsurf, Antigravity), or
   **Node.js >=22.9.0** for the CLI
 - **LaTeX distribution** (TeX Live, MiKTeX, or MacTeX)
 - **Perl** (for `latexindent` and `latexdiff`)

--- a/docs/.vitepress/components/InstallTroubleshootCards.vue
+++ b/docs/.vitepress/components/InstallTroubleshootCards.vue
@@ -19,7 +19,7 @@ const issues = [
     icon: 'plug',
     title: 'Extension not loading',
     checks: [
-      'VS Code is on 1.105 or newer',
+      'VS Code is on 1.106 or newer',
       'Output panel → "TeXRA" shows no errors',
       'Reinstall the extension',
     ],

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -11,7 +11,7 @@ This guide will walk you through the process of installing TeXRA and all its dep
 
 TeXRA is designed to work on all major operating systems with the following minimum requirements:
 
-- **Visual Studio Code**: Version 1.105 or newer (for the VS Code extension)
+- **Visual Studio Code**: Version 1.106 or newer (for the VS Code extension)
 - **Operating System**: Windows, macOS, or Linux
 - **Internet Connection**: Required for API access to language models
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -25,7 +25,7 @@ to confirm available models, and `texra tools status` to check tool availability
 **Solutions**:
 
 1. **Check VS Code compatibility**:
-   - Ensure you're running VS Code version 1.105 or newer
+   - Ensure you're running VS Code version 1.106 or newer
    - Update VS Code if needed
 
 2. **Verify installation**:


### PR DESCRIPTION
## Summary

Updates the public VS Code minimum-version docs from 1.105 to 1.106 so they match the extension engine floor introduced by #7254.

## Issue acceptance gates

Addresses #7258:
- Re-verified the cited stale references on latest `origin/main` at `README.md:121`, `docs/guide/installation.md:14`, and `docs/guide/troubleshooting.md:28`.
- Updated those public references to VS Code 1.106 or newer.
- Also updated the VitePress installation troubleshooting card text because re-verification found it mirrors the same public minimum-version guidance.
- Did not touch package manifests, code, historical changelog notes, PRDs, or files related to #7259/#7260/#7261.

## Single source of truth

`packages/extension/package.json` remains the source of truth for the extension `engines.vscode` floor (`^1.106.0`); these docs now match it.

## Duplication and abstraction budget

No abstraction added. This is a narrow text-only docs sync.

## Host impact

Extension: Users reading README or installation/troubleshooting docs now see the correct VS Code 1.106+ requirement.

Desktop: No runtime impact.

CLI: No runtime impact.

## Scheduled refactoring

None.

## Validation

- `git diff --check -- README.md docs/guide/installation.md docs/guide/troubleshooting.md docs/.vitepress/components/InstallTroubleshootCards.vue`
- `corepack pnpm exec prettier --check README.md docs/guide/installation.md docs/guide/troubleshooting.md docs/.vitepress/components/InstallTroubleshootCards.vue`
- `node docs/scripts/check-root-docs.mjs`

Closes #7258

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Text-only documentation sync with no runtime or packaging changes.
> 
> **Overview**
> **Aligns user-facing docs with the extension engine floor** (`^1.106.0` in `packages/extension/package.json`) by changing every stated minimum from **1.105** to **1.106**.
> 
> Updates appear in `README.md` (Requirements), `docs/guide/installation.md` (System Requirements), `docs/guide/troubleshooting.md` (Extension Not Loading), and the VitePress `InstallTroubleshootCards.vue` checklist that mirrors installation troubleshooting. No code, manifests, or changelog edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71bfabf6fbb63ba1d2f87a23da953792e72c97f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->