### PR TITLE
fix(trace-viewer): ignore nested legacy group endings

### DIFF
--- a/packages/trace-viewer/src/replayTrace.ts
+++ b/packages/trace-viewer/src/replayTrace.ts
@@ -47,6 +47,7 @@ function toStreamLifecycleStatus(trace: TraceDocument): StreamLifecycleStatus {
   }
   for (const entry of trace.entries.toReversed()) {
     if (entry.type !== STREAM_LOG_ENTRY_TYPES.GROUP_END) continue;
+    if (entry.groupId !== undefined) continue;
     if (!isObject(entry.data)) continue;
     const status = StreamStatusSchema.safeParse(entry.data.status);
     if (status.success) return streamStatusToLifecycleStatus(status.data);

--- a/src/test-kernel/traceViewer/replayTrace.vitest.ts
+++ b/src/test-kernel/traceViewer/replayTrace.vitest.ts
@@ -165,6 +165,52 @@ describe('replayTrace legacy-status fallback (issue #7188)', () => {
     expect(replayed?.status).toBe('failed');
   });
 
+  it('ignores nested group-end status when the root run stage never closed', () => {
+    const { ctx, getState } = createContext(createInitialState());
+    const trace: TraceDocument = {
+      ...legacyTrace(undefined),
+      entries: [
+        {
+          seqNo: 1,
+          id: 'root-run',
+          type: STREAM_LOG_ENTRY_TYPES.GROUP_START,
+          level: LOG_LEVELS.INFO,
+          timestamp: 100,
+          messageType: MESSAGE_TYPES.DEFAULT,
+          text: 'Run',
+          data: { status: 'running' },
+        },
+        {
+          seqNo: 2,
+          id: 'inner-round',
+          type: STREAM_LOG_ENTRY_TYPES.GROUP_START,
+          level: LOG_LEVELS.INFO,
+          timestamp: 110,
+          groupId: 'root-run',
+          messageType: MESSAGE_TYPES.DEFAULT,
+          text: 'Round',
+          data: { status: 'running' },
+        },
+        {
+          seqNo: 3,
+          id: 'inner-round',
+          type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
+          level: LOG_LEVELS.INFO,
+          timestamp: 120,
+          groupId: 'root-run',
+          messageType: MESSAGE_TYPES.DEFAULT,
+          text: 'Round',
+          data: { status: 'stopped', endTime: 120 },
+        },
+      ],
+    };
+
+    replayTrace(trace, ctx);
+
+    const replayed = getState().streamStates.get(trace.streamId);
+    expect(replayed?.status).toBe(STREAM_STATUS.READY);
+  });
+
   it('derives "failed" from snapshot.status "error" instead of defaulting to ready', () => {
     const { ctx, getState } = createContext(createInitialState());
     const trace = legacyTrace('error');


### PR DESCRIPTION
## Summary

Scopes trace-viewer's legacy terminal-status scan to the root run stage by ignoring nested `GROUP_END` rows with a `groupId`. Legacy traces that crashed before the root run closed now fall back to snapshot/ready instead of treating an inner stopped round as a completed run.

## Issue acceptance gates

Addresses #7261:
- Re-verified `toStreamLifecycleStatus()` still scanned any `GROUP_END` after #7256.
- Restricts the reverse scan to root `GROUP_END` entries where `groupId === undefined`.
- Adds regression coverage for a legacy trace with a completed nested stage and no root terminal group-end.

## Single source of truth

`packages/trace-viewer/src/replayTrace.ts` remains the trace-viewer replay status projector; root-run terminal rows are now the only transcript-derived source for legacy terminal status.

## Duplication and abstraction budget

No abstraction added. This is a one-line narrowing of the existing scan plus focused regression coverage.

## Host impact

Extension: Exported trace-viewer no longer shows crash-mid-run legacy traces as completed because an inner stage stopped cleanly.

Desktop: Same trace-viewer replay behavior when opening exported traces.

CLI: Same behavior for `texra history --export html` trace-viewer outputs; no headless byte-format change except replay interpretation in the viewer.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write packages/trace-viewer/src/replayTrace.ts src/test-kernel/traceViewer/replayTrace.vitest.ts`
- `corepack pnpm exec vitest run src/test-kernel/traceViewer/replayTrace.vitest.ts`
- `git diff --check`
- `npm run typecheck`
- `npm test`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing warning in `packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts`)

Closes #7261

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-condition change to offline trace replay status projection with focused regression coverage; no auth, persistence, or live-run path changes.
> 
> **Overview**
> Fixes incorrect **completed/stopped** display for legacy traces that never recorded `terminalStatus` and crashed before the root run stage closed.
> 
> `toStreamLifecycleStatus()` in `replayTrace.ts` still walks transcript entries in reverse for a terminal `GROUP_END`, but it **skips nested** endings where `groupId` is set. Only the root run’s `GROUP_END` (`groupId === undefined`) can set lifecycle status from transcript data; otherwise behavior falls through to snapshot status or `READY`.
> 
> Adds a regression test: open root run, nested round ends with `stopped`, root never closes → replayed stream status stays **`READY`** instead of inheriting the inner stage’s stopped state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b4198027aa646ab0b45c5e68753d8844ad83e97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->