### PR TITLE
fix(cli): use execution-specific trace export names

### DIFF
--- a/packages/cli/src/commands/history.ts
+++ b/packages/cli/src/commands/history.ts
@@ -170,10 +170,11 @@ export async function runHistoryExport(
       );
       return CliExitCode.Usage;
     }
-    const traceFile = path.join(destDir, 'trace.json');
+    const traceFileName = `${id}.json`;
+    const traceFile = path.join(destDir, traceFileName);
     writeTextStderr(
       `Wrote trace JSON for ${id} to stdout. Save the output to ` +
-        `${traceFile}, then open ${destDir}/index.html?trace=trace.json.`,
+        `${traceFile}, then open ${destDir}/index.html?trace=${traceFileName}.`,
     );
     return CliExitCode.Success;
   }

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -1260,15 +1260,19 @@ describe('CLI history runtime', () => {
       let stdoutSpy: ReturnType<typeof vi.spyOn>;
       let stderrSpy: ReturnType<typeof vi.spyOn>;
 
-      const trace = {
-        executionId: 'a1',
-        streamId: 'a1',
-        config,
-        meta: null,
-        entries: [],
-        snapshot: { todos: [], plan: null, usage: null },
-        terminalStatus: null,
-      } as unknown as TraceDocument;
+      function makeTrace(executionId: string): TraceDocument {
+        return {
+          executionId,
+          streamId: executionId,
+          config,
+          meta: null,
+          entries: [],
+          snapshot: { todos: [], plan: null, usage: null },
+          terminalStatus: null,
+        } as unknown as TraceDocument;
+      }
+
+      const trace = makeTrace('a1');
 
       function makeContext(resourcesPath: string): CliContext {
         return {
@@ -1361,9 +1365,63 @@ describe('CLI history runtime', () => {
                 );
                 expect(stderr).toContain(
                   `Wrote trace JSON for a1 to stdout. Save the output to ` +
-                    `${path.join(destDir, 'trace.json')}, then open ` +
-                    `${destDir}/index.html?trace=trace.json.`,
+                    `${path.join(destDir, 'a1.json')}, then open ` +
+                    `${destDir}/index.html?trace=a1.json.`,
                 );
+              },
+            );
+          },
+        );
+      });
+
+      it('uses execution-specific trace filenames for repeat exports into the same assets directory', async () => {
+        await withTempDir(
+          'texra-history-export-repeat-src-',
+          async (resourcesPath) => {
+            const traceViewerDir = path.join(resourcesPath, 'traceViewer');
+            await mkdir(traceViewerDir, { recursive: true });
+            await writeFile(
+              path.join(traceViewerDir, 'index.html'),
+              '<html></html>',
+            );
+
+            await withTempDir(
+              'texra-history-export-repeat-dest-',
+              async (cwd) => {
+                const destDir = path.join(cwd, 'shared-assets');
+                const firstTrace = makeTrace('abc123');
+                const secondTrace = makeTrace('def456');
+                mocks.assembleTrace
+                  .mockResolvedValueOnce({ status: 'ok', trace: firstTrace })
+                  .mockResolvedValueOnce({ status: 'ok', trace: secondTrace });
+
+                const firstExit = await runHistoryExport(
+                  makeContext(resourcesPath),
+                  'abc123' as ExecutionId,
+                  'html',
+                  { assetsDir: destDir },
+                );
+                const secondExit = await runHistoryExport(
+                  makeContext(resourcesPath),
+                  'def456' as ExecutionId,
+                  'html',
+                  { assetsDir: destDir },
+                );
+
+                expect(firstExit).toBe(CliExitCode.Success);
+                expect(secondExit).toBe(CliExitCode.Success);
+                expect(stdout).toBe(
+                  JSON.stringify(firstTrace) + JSON.stringify(secondTrace),
+                );
+                expect(stderr).toContain(
+                  `${path.join(destDir, 'abc123.json')}, then open ` +
+                    `${destDir}/index.html?trace=abc123.json.`,
+                );
+                expect(stderr).toContain(
+                  `${path.join(destDir, 'def456.json')}, then open ` +
+                    `${destDir}/index.html?trace=def456.json.`,
+                );
+                expect(stderr).not.toContain('trace=trace.json');
               },
             );
           },


### PR DESCRIPTION
## Summary

Updates `texra history show --export html --assets-dir` instructions so each trace JSON filename and `trace=` URL are derived from the execution id instead of the shared literal `trace.json`.

## Issue acceptance gates

Addresses #7262:
- Re-verified the `--assets-dir` shared-assets contract in `packages/cli/src/commands/history.ts` and the hardcoded `trace.json` instruction path on current main.
- Changed the printed save path to `<assets-dir>/<execution-id>.json`.
- Changed the printed viewer URL to `index.html?trace=<execution-id>.json`.
- Added regression coverage for repeat exports into the same assets directory so old links keep pointing at execution-specific trace JSON files.

## Single source of truth

`runHistoryExport` now derives the shared-assets trace filename directly from the execution id it is exporting.

## Duplication and abstraction budget

No abstraction added. This removes the duplicated implicit filename decision by using the existing execution id as the one naming source.

## Host impact

Extension: No impact.

Desktop: No impact.

CLI: `history show --export html --assets-dir` now prints per-execution trace filenames, preventing repeated shared-assets exports from reusing `trace.json` in the suggested redirect target.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write packages/cli/src/commands/history.ts src/test-kernel/cli/History.vitest.mts`
- `corepack pnpm exec vitest run src/test-kernel/cli/History.vitest.mts`
- `npm run typecheck`
- `npm run lint` (passes with existing unrelated import-order warning in `packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts`)
- `npm run compile:fast`
- `npm test`
- `git diff --check`

Closes #7262

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only change to printed export instructions; no runtime export or storage behavior beyond filename guidance in user-facing text.
> 
> **Overview**
> **`texra history show --export html --assets-dir`** no longer suggests a shared **`trace.json`** filename for every export. **`runHistoryExport`** derives the trace file name from the execution id (`<id>.json`) and updates the stderr instructions for where to save stdout and how to open **`index.html?trace=<id>.json`**.
> 
> Tests were adjusted for the new messaging and a regression case was added: two exports into the same **`--assets-dir`** must each print distinct save paths and viewer query strings, with no **`trace=trace.json`** wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 614b212703e8a06eb49571155fb2e0dad94738f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->