### PR TITLE
fix(latex): route workspaceFilesWritten through emitRuntimeEvent

### DIFF
--- a/packages/extension/src/commands/latex/compareCommands.ts
+++ b/packages/extension/src/commands/latex/compareCommands.ts
@@ -6,9 +6,9 @@ import * as vscode from 'vscode';
 
 // Local imports
 import { legacyWorkflowOutputStem } from '@agent/output/workflowOutputLayout';
+import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import { showQuickPick } from '@commands/_shared/quickInputUtils';
 import { registerCommands } from '@commands/_shared/registerCommands';
-import { bus } from '@eventBus/ProgressEventBus';
 import {
   showLoggedErrorMessage,
   showLoggedMessage,
@@ -239,7 +239,9 @@ async function handleAcceptEdited(
           return answer === 'Yes';
         },
         emitWritten: (absolutePath) =>
-          bus.emit('workspaceFilesWritten', { absolutePaths: [absolutePath] }),
+          emitRuntimeEvent('workspaceFilesWritten', {
+            absolutePaths: [absolutePath],
+          }),
         showInfo: (message) => {
           vscode.window.showInformationMessage(message);
           logger.info(CHANNEL, message);
@@ -263,7 +265,7 @@ async function handleAcceptEdited(
     await flexibleFS.write(targetLocation, editedContent);
 
     if (targetLocation.kind === 'workspace') {
-      bus.emit('workspaceFilesWritten', {
+      emitRuntimeEvent('workspaceFilesWritten', {
         absolutePaths: [targetLocation.absolutePath],
       });
     }


### PR DESCRIPTION
## Summary

A scheduled codebase audit for confusing/overlapped responsibilities found that `packages/extension/src/commands/latex/compareCommands.ts` fired the `workspaceFilesWritten` progress event via a raw `bus.emit(...)` call, while every sibling file in `packages/extension/src/commands/` (`followUpCommand.ts`, `streamEventUtils.ts`) and the desktop host's equivalent accept-file flow (`packages/desktop/src/main/desktopProgressFileActions.ts`) already route the same class of event through `emitRuntimeEvent(...)`. This PR brings the two call sites in `compareCommands.ts` in line with that convention.

## Issue acceptance gates

- Both `workspaceFilesWritten` emissions in `handleAcceptEdited` (the no-`copyMeta` replace path and the `copyMeta` replace-or-copy path) now go through `emitRuntimeEvent`, matching the pattern used elsewhere in the same command directory. ✅
- No behavior change: `emitRuntimeEvent` resolves to `bus.emit` in this call path today (the extension runs single-session, and this is a UI command outside any run's `RunContext`), so this is a pure consistency fix, not a functional change. ✅

## Single source of truth

`src/agent/runtime/emitRuntimeEvent.ts` remains the single emit path for run/host progress events — this PR removes the one remaining direct `bus.emit` call for `workspaceFilesWritten` in `packages/extension/src/commands/`, so all command-layer callers of this event now go through it.

## Duplication and abstraction budget

Removed duplication: two different emit conventions (`bus.emit` vs. `emitRuntimeEvent`) existed for the same event across sibling files in the same directory. No new abstraction was added — this reuses the existing `emitRuntimeEvent` helper.

## Host impact

Extension: `compareCommands.ts`'s two `workspaceFilesWritten` emit sites now call `emitRuntimeEvent` instead of `bus.emit` directly; behavior is unchanged (falls back to `bus.emit` since there's no active run context), but the path is now session-aware-ready if this command is ever wired to a non-default session.

Desktop: No change — already used `runtimeHost.emit` directly via its own host object.

CLI: No change — unaffected code path.

## Scheduled refactoring

None. This was a self-contained consistency fix identified during a broader audit; no further action items were surfaced as more significant.

## Validation

- `npm run typecheck` — passes clean (no errors).
- `npx eslint packages/extension/src/commands/latex/compareCommands.ts` — no findings.
- `npx vitest run src/test-kernel/agent/runtime/EmitRuntimeEvent.vitest.ts src/test-kernel/progressView/ProgressBackend.vitest.ts` — 18/18 passed.
- No dedicated unit test exists for `compareCommands.ts`'s accept-file flow; the change is a mechanical routing swap verified by the above type/lint/test checks and by reading `emitRuntimeEvent`'s fallback logic, which confirms identical runtime behavior for this call site.


---
_Generated by [Claude Code](https://claude.ai/code/session_0148ymqNn23DitqUH2QUnWK2)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical routing swap for progress events with no intended behavior change in the extension UI command path.
> 
> **Overview**
> **Accept-edited** flows in `compareCommands.ts` no longer call `ProgressEventBus` directly; both `workspaceFilesWritten` notifications (simple replace via `emitWritten`, and workspace writes after replace-or-copy) now go through **`emitRuntimeEvent`**, matching other commands in the same layer.
> 
> The **`bus`** import is removed in favor of **`emitRuntimeEvent`**. Payload shape is unchanged (`absolutePaths`); this is an emit-path alignment, not a new feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67e7b2d23e1c3ba2cc4e84ee50585155538f7a41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->