### PR TITLE
refactor: consolidate duplicated fetch/retry, error-outcome, and truncation logic

### DIFF
--- a/packages/cli/src/chat/tui/panes/EntryErrorBoundary.tsx
+++ b/packages/cli/src/chat/tui/panes/EntryErrorBoundary.tsx
@@ -16,6 +16,7 @@ import { Component, type ReactNode } from 'react';
 
 import * as logUtils from '@logger/logUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
+import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
 import { WARNING } from '../ui/glyphs';
 
@@ -41,7 +42,7 @@ export function formatRenderError(error: unknown): string {
   // The marker is a single line: collapse whitespace and cap length so a long
   // or multi-line message can't reflow the transcript.
   const oneLine = message.replaceAll(/\s+/g, ' ').trim();
-  return oneLine.length > 120 ? `${oneLine.slice(0, 119)}…` : oneLine;
+  return truncateWithEllipsis(oneLine, 120);
 }
 
 export class EntryErrorBoundary extends Component<

--- a/packages/desktop/src/main/desktopGitHost.ts
+++ b/packages/desktop/src/main/desktopGitHost.ts
@@ -24,6 +24,8 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 
+import { clamp } from '@utils/core';
+
 const execFileAsync = promisify(execFile);
 
 /**
@@ -182,6 +184,5 @@ function clampCommitLimit(value: number): number {
   if (!Number.isFinite(value)) return DEFAULT_COMMIT_LIMIT;
   const rounded = Math.floor(value);
   if (rounded <= 0) return DEFAULT_COMMIT_LIMIT;
-  if (rounded > MAX_COMMIT_LIMIT) return MAX_COMMIT_LIMIT;
-  return rounded;
+  return clamp(rounded, 1, MAX_COMMIT_LIMIT);
 }

--- a/packages/extension/src/progressView/frontend/components/QueuedFollowUps.ts
+++ b/packages/extension/src/progressView/frontend/components/QueuedFollowUps.ts
@@ -10,6 +10,7 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 // Local imports - shared styles
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
 // Local imports - progress view constants
 import { ELEMENT_IDS } from '../constants';
@@ -99,7 +100,7 @@ export class QueuedFollowUps extends LitElement {
       return { display: message, full: undefined };
     }
     return {
-      display: message.slice(0, MAX_MESSAGE_LENGTH) + '...',
+      display: truncateWithEllipsis(message, MAX_MESSAGE_LENGTH),
       full: message,
     };
   }

--- a/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
@@ -21,6 +21,7 @@ import {
 import type { ProviderErrorPartial } from '@shared/schemas';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 import { renderDotMeta, type MetaPart } from '@shared/wa/metaStrip';
+import { tailWithEllipsis } from '@utils/text/stringUtils';
 
 // Local imports - base class
 import { BaseRequestPanel } from './BaseRequestPanel';
@@ -175,9 +176,7 @@ export class RetryRequestPanel extends BaseRequestPanel<'retry'> {
     if (partialText) {
       const maxTailChars = 1024;
       const isTruncated = partialText.length > maxTailChars;
-      const tail = isTruncated
-        ? '…' + partialText.slice(-maxTailChars)
-        : partialText;
+      const tail = tailWithEllipsis(partialText, maxTailChars);
       const header = isTruncated
         ? `--- Partial Output (last ${maxTailChars} of ${partialText.length} chars) ---`
         : `--- Partial Output (${partialText.length} chars) ---`;

--- a/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
@@ -24,7 +24,7 @@ import {
 } from '@shared/schemas';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 import { renderDotMeta, type MetaPart } from '@shared/wa/metaStrip';
-import { tailWithEllipsis } from '@utils/text/stringUtils';
+import { tailWithEllipsis, toGraphemes } from '@utils/text/stringUtils';
 
 // Local imports - base class
 import { BaseRequestPanel } from './BaseRequestPanel';
@@ -177,13 +177,18 @@ export class RetryRequestPanel extends BaseRequestPanel<'retry'> {
     const partialText = details.partialText;
     if (partialText) {
       const maxTailChars = 1024;
-      const isTruncated = partialText.length > maxTailChars;
+      // tailWithEllipsis counts grapheme clusters, not UTF-16 code units —
+      // match it here so `isTruncated` and the header's totals agree with
+      // what it actually slices (a naive .length comparison can disagree
+      // with grapheme count for multi-codepoint characters like emoji).
+      const totalChars = toGraphemes(partialText).length;
+      const isTruncated = totalChars > maxTailChars;
       // tailWithEllipsis's budget covers its own leading "…", so pass one
       // more than the content characters we actually want displayed.
       const tail = tailWithEllipsis(partialText, maxTailChars + 1);
       const header = isTruncated
-        ? `--- Partial Output (last ${maxTailChars} of ${partialText.length} chars) ---`
-        : `--- Partial Output (${partialText.length} chars) ---`;
+        ? `--- Partial Output (last ${maxTailChars} of ${totalChars} chars) ---`
+        : `--- Partial Output (${totalChars} chars) ---`;
       lines.push(header, tail);
     }
 

--- a/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
@@ -177,15 +177,17 @@ export class RetryRequestPanel extends BaseRequestPanel<'retry'> {
     const partialText = details.partialText;
     if (partialText) {
       const maxTailChars = 1024;
-      // tailWithEllipsis counts grapheme clusters, not UTF-16 code units —
-      // match it here so `isTruncated` and the header's totals agree with
-      // what it actually slices (a naive .length comparison can disagree
-      // with grapheme count for multi-codepoint characters like emoji).
-      const totalChars = toGraphemes(partialText).length;
-      const isTruncated = totalChars > maxTailChars;
       // tailWithEllipsis's budget covers its own leading "…", so pass one
       // more than the content characters we actually want displayed.
       const tail = tailWithEllipsis(partialText, maxTailChars + 1);
+      // Derive truncation from what tailWithEllipsis actually did (it
+      // returns the input unchanged when nothing needs cutting) rather than
+      // a separately-computed length comparison — two independent
+      // decisions about the same cutoff disagreed by one grapheme exactly
+      // at the boundary (partialText.length === maxTailChars + 1), where
+      // this said "truncated" but tailWithEllipsis returned the text whole.
+      const isTruncated = tail !== partialText;
+      const totalChars = toGraphemes(partialText).length;
       const header = isTruncated
         ? `--- Partial Output (last ${maxTailChars} of ${totalChars} chars) ---`
         : `--- Partial Output (${totalChars} chars) ---`;

--- a/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
@@ -178,7 +178,9 @@ export class RetryRequestPanel extends BaseRequestPanel<'retry'> {
     if (partialText) {
       const maxTailChars = 1024;
       const isTruncated = partialText.length > maxTailChars;
-      const tail = tailWithEllipsis(partialText, maxTailChars);
+      // tailWithEllipsis's budget covers its own leading "…", so pass one
+      // more than the content characters we actually want displayed.
+      const tail = tailWithEllipsis(partialText, maxTailChars + 1);
       const header = isTruncated
         ? `--- Partial Output (last ${maxTailChars} of ${partialText.length} chars) ---`
         : `--- Partial Output (${partialText.length} chars) ---`;

--- a/packages/extension/src/progressView/frontend/components/UserMessage.ts
+++ b/packages/extension/src/progressView/frontend/components/UserMessage.ts
@@ -24,7 +24,7 @@ import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
 
 // Local imports - formatter helpers
 import { processMarkdownContent } from '../formatters/markdownRenderer';
-import { formatTimestamp } from '../formatters/timestampUtils';
+import { formatDisplayTimestamp } from '../formatters/timestampUtils';
 
 const STRUCTURED_DELIVERY_TAGS = [
   'background-result',
@@ -215,7 +215,7 @@ export class UserMessage extends LitElement {
   }
 
   override render(): TemplateResult {
-    const { timeDisplay, tooltipTimestamp } = formatTimestamp(
+    const { timeDisplay, tooltipTimestamp } = formatDisplayTimestamp(
       new Date(this.timestamp),
     );
     const copyState = this.copyController.state;

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/bannerFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/bannerFormatters.ts
@@ -18,7 +18,7 @@ import {
 } from '../litTemplates';
 
 // Local imports - formatter helpers
-import { formatTimestamp } from '../timestampUtils';
+import { formatDisplayTimestamp } from '../timestampUtils';
 import { processMarkdownContent } from '../markdownRenderer';
 import { buildDetailsSummary } from '../htmlBuilders';
 
@@ -58,7 +58,7 @@ export function formatBannerContentTemplate(
   if (!trimmedContent) return null;
 
   const config = BANNER_CONFIG[messageType ?? ''] ?? BANNER_CONFIG.thinking;
-  const { fullTimestamp } = formatTimestamp(new Date(timestamp));
+  const { fullTimestamp } = formatDisplayTimestamp(new Date(timestamp));
   const markdownHtml = processMarkdownContent(trimmedContent);
   const shouldOpen = options?.defaultOpen ?? false;
   // prettier-ignore
@@ -85,7 +85,7 @@ export function formatModelResponseTemplate(
   const trimmedContent = (text ?? '').trim();
   if (!trimmedContent) return null;
 
-  const { fullTimestamp, timeDisplay, tooltipTimestamp } = formatTimestamp(
+  const { fullTimestamp, timeDisplay, tooltipTimestamp } = formatDisplayTimestamp(
     new Date(timestamp),
   );
   const markdownHtml = processMarkdownContent(trimmedContent);

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/bannerFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/bannerFormatters.ts
@@ -85,9 +85,8 @@ export function formatModelResponseTemplate(
   const trimmedContent = (text ?? '').trim();
   if (!trimmedContent) return null;
 
-  const { fullTimestamp, timeDisplay, tooltipTimestamp } = formatDisplayTimestamp(
-    new Date(timestamp),
-  );
+  const { fullTimestamp, timeDisplay, tooltipTimestamp } =
+    formatDisplayTimestamp(new Date(timestamp));
   const markdownHtml = processMarkdownContent(trimmedContent);
   // Model response defaults to open (was hardcoded open before)
   const shouldOpen = options?.defaultOpen ?? true;

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
@@ -31,7 +31,7 @@ import {
 
 // Local imports - formatter helpers
 import { stringifyWithLanguage } from '../parseUtils';
-import { formatTimestamp } from '../timestampUtils';
+import { formatDisplayTimestamp } from '../timestampUtils';
 import { ICON_BY_LEVEL } from '../constants';
 import { registerCopyContent } from '../copyContentStore';
 
@@ -49,7 +49,7 @@ export function formatProgressStatusTemplate(
   message: LogMessageData,
 ): FormatResult {
   const { level = 'info', id, groupId, timestamp, text, data } = message;
-  const { fullTimestamp, timeDisplay, tooltipTimestamp } = formatTimestamp(
+  const { fullTimestamp, timeDisplay, tooltipTimestamp } = formatDisplayTimestamp(
     new Date(timestamp),
   );
 
@@ -93,7 +93,7 @@ const ERROR_DETAIL_FIELDS = [
 /** Format error message as TemplateResult. */
 export function formatErrorTemplate(message: LogMessageData): FormatResult {
   const { id, groupId, timestamp, text, data } = message;
-  const { fullTimestamp, timeDisplay, tooltipTimestamp } = formatTimestamp(
+  const { fullTimestamp, timeDisplay, tooltipTimestamp } = formatDisplayTimestamp(
     new Date(timestamp),
   );
 
@@ -162,7 +162,7 @@ export function formatDefaultLogMessageTemplate(
     className: `log-level-icon log-level-icon--${level}`,
     label: level === 'error' || level === 'warn' ? level : undefined,
   });
-  const { fullTimestamp, timeDisplay, tooltipTimestamp } = formatTimestamp(
+  const { fullTimestamp, timeDisplay, tooltipTimestamp } = formatDisplayTimestamp(
     new Date(timestamp),
   );
 

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
@@ -49,9 +49,8 @@ export function formatProgressStatusTemplate(
   message: LogMessageData,
 ): FormatResult {
   const { level = 'info', id, groupId, timestamp, text, data } = message;
-  const { fullTimestamp, timeDisplay, tooltipTimestamp } = formatDisplayTimestamp(
-    new Date(timestamp),
-  );
+  const { fullTimestamp, timeDisplay, tooltipTimestamp } =
+    formatDisplayTimestamp(new Date(timestamp));
 
   const summaryText = (text ?? '').trim() || 'Status update';
   const detailText = stringifyWithLanguage(data).text;
@@ -93,9 +92,8 @@ const ERROR_DETAIL_FIELDS = [
 /** Format error message as TemplateResult. */
 export function formatErrorTemplate(message: LogMessageData): FormatResult {
   const { id, groupId, timestamp, text, data } = message;
-  const { fullTimestamp, timeDisplay, tooltipTimestamp } = formatDisplayTimestamp(
-    new Date(timestamp),
-  );
+  const { fullTimestamp, timeDisplay, tooltipTimestamp } =
+    formatDisplayTimestamp(new Date(timestamp));
 
   // Parse error data with schema - use empty object if invalid
   const parseResult = ErrorLogDataSchema.safeParse(data);
@@ -162,9 +160,8 @@ export function formatDefaultLogMessageTemplate(
     className: `log-level-icon log-level-icon--${level}`,
     label: level === 'error' || level === 'warn' ? level : undefined,
   });
-  const { fullTimestamp, timeDisplay, tooltipTimestamp } = formatDisplayTimestamp(
-    new Date(timestamp),
-  );
+  const { fullTimestamp, timeDisplay, tooltipTimestamp } =
+    formatDisplayTimestamp(new Date(timestamp));
 
   const timestampContent = verbose
     ? html`${levelIcon} [${timeDisplay}]`

--- a/packages/extension/src/progressView/frontend/formatters/timestampUtils.ts
+++ b/packages/extension/src/progressView/frontend/formatters/timestampUtils.ts
@@ -25,7 +25,7 @@ function getDateTimeFormatter(): Intl.DateTimeFormat {
 }
 
 /** Format a timestamp for display. */
-export function formatTimestamp(date: Date): {
+export function formatDisplayTimestamp(date: Date): {
   fullTimestamp: string;
   timeDisplay: string;
   tooltipTimestamp: string;

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -13,9 +13,8 @@ import type {
 } from '@agent/core/state/AgentState';
 import { bestConnectionMethod } from '@agent/runtime/textConnection';
 import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
-import { normalizeProviderError } from '@common/errors';
+import { buildFailedRetryInfo } from '@common/errors';
 import type { AgentFileLocation, RetryErrorInfo } from '@shared/schemas';
-import { toRetryErrorInfo } from '@shared/schemas';
 import { ensureError } from '@utils/errors/errorMessage';
 
 import type { ReflectionFlowShared } from '../ReflectionFlowState';
@@ -140,12 +139,10 @@ export class ResponseCycleNode<C = unknown> extends Node<
     } catch (error) {
       recordRound(prepRes.run, prepRes.round);
       await this.services.onRoundFinalized(prepRes.run);
-      const formatted = normalizeProviderError(error);
       return {
         outcome: 'failed',
         error: ensureError(error),
-        userRetryable: formatted.userRetryable,
-        lastError: toRetryErrorInfo(formatted),
+        ...buildFailedRetryInfo(error),
       };
     }
   }
@@ -154,13 +151,7 @@ export class ResponseCycleNode<C = unknown> extends Node<
     _prepRes: CyclePrepInput,
     error: Error,
   ): Promise<CycleOutcome> {
-    const formatted = normalizeProviderError(error);
-    return {
-      outcome: 'failed',
-      error,
-      userRetryable: formatted.userRetryable,
-      lastError: toRetryErrorInfo(formatted),
-    };
+    return { outcome: 'failed', error, ...buildFailedRetryInfo(error) };
   }
 
   async post(

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -10,8 +10,8 @@ import {
 import { withModelClient } from '@agent/core/flows/CycleServices';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
-import { normalizeProviderError } from '@common/errors';
-import { MESSAGE_TYPES, toRetryErrorInfo } from '@shared/schemas';
+import { buildFailedRetryInfo } from '@common/errors';
+import { MESSAGE_TYPES } from '@shared/schemas';
 import type { RetryErrorInfo } from '@shared/schemas';
 
 import {
@@ -146,12 +146,10 @@ export class ToolUseCycleNode<C> extends Node<
     _prepRes: CyclePrepResult,
     error: Error,
   ): Promise<ToolUseCycleOutcome> {
-    const formatted = normalizeProviderError(error);
     return {
       outcome: 'failed',
       message: error.message,
-      userRetryable: formatted.userRetryable,
-      lastError: toRetryErrorInfo(formatted),
+      ...buildFailedRetryInfo(error),
     };
   }
 

--- a/src/common/errors/index.ts
+++ b/src/common/errors/index.ts
@@ -25,6 +25,10 @@ export {
 // across the codebase (model handlers, runtime, UI layers).
 // normalizeProviderError is the single public normalization entry; the
 // non-caching formatProviderHttpError stays internal to sdkErrorUtils.
-export { getSdkErrorMessage, normalizeProviderError } from './sdkErrorUtils';
+export {
+  getSdkErrorMessage,
+  normalizeProviderError,
+  buildFailedRetryInfo,
+} from './sdkErrorUtils';
 
 export { AgentError } from './agentErrors';

--- a/src/common/errors/sdkError/providerErrorFormat.ts
+++ b/src/common/errors/sdkError/providerErrorFormat.ts
@@ -2,6 +2,8 @@ import {
   type ErrorContext,
   type ErrorLogData,
   type ProviderError,
+  type RetryErrorInfo,
+  toRetryErrorInfo,
 } from '@shared/schemas';
 import {
   extractErrorMessage,
@@ -288,6 +290,19 @@ export function normalizeProviderError(err: unknown): ProviderError {
 
 export function getSdkErrorMessage(err: unknown): string {
   return normalizeProviderError(err).message;
+}
+
+/** Normalize an error into the `{ userRetryable, lastError }` pair every
+ *  `execFallback`/failed-outcome branch attaches to its result. */
+export function buildFailedRetryInfo(err: unknown): {
+  userRetryable: boolean;
+  lastError: RetryErrorInfo;
+} {
+  const formatted = normalizeProviderError(err);
+  return {
+    userRetryable: formatted.userRetryable,
+    lastError: toRetryErrorInfo(formatted),
+  };
 }
 
 /** Builds consistent error data for logging with MESSAGE_TYPES.ERROR. */

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -45,6 +45,7 @@ export {
   normalizeProviderError,
   getSdkErrorMessage,
   buildErrorLogData,
+  buildFailedRetryInfo,
 } from './sdkError/providerErrorFormat';
 
 export { isRelayMonthlyLimitMessage } from './sdkError/relayDetection';

--- a/src/test-kernel/progressView/RetryRequestPanel.vitest.mts
+++ b/src/test-kernel/progressView/RetryRequestPanel.vitest.mts
@@ -4,6 +4,9 @@ import { describe, expect, it } from 'vitest';
 // Local imports - progress view component types
 import type { RetryRequestPanel } from '@progressView/frontend/components/RetryRequestPanel';
 
+// Local imports - shared schemas
+import type { ProviderErrorPartial } from '@shared/schemas';
+
 // Local imports - shared constants
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 
@@ -54,5 +57,26 @@ describe('retry-request-panel', () => {
     expect(buttons.map((button) => button.getAttribute('data-action'))).toEqual(
       ['useOwnApiKey', 'retry', 'cancel'],
     );
+  });
+
+  it('shows exactly the claimed number of tail characters for truncated partial output', async () => {
+    const element = await mountPanel();
+    // `formatRetryDetails` is private; TS-private is not runtime-enforced, and
+    // this pure-string-formatting logic doesn't need a full render to verify.
+    const formatRetryDetails: (details: ProviderErrorPartial) => string | null =
+      (element as unknown as Record<string, unknown>)[
+        'formatRetryDetails'
+      ] as never;
+
+    const text = formatRetryDetails.call(element, {
+      isRelayError: false,
+      userRetryable: true,
+      partialText: 'x'.repeat(2000),
+    });
+
+    expect(text).toContain('--- Partial Output (last 1024 of 2000 chars) ---');
+    const tail = (text ?? '').split('\n').at(-1) ?? '';
+    // "…" plus exactly 1024 content characters, not 1023.
+    expect(tail.replace(/^…/, '')).toHaveLength(1024);
   });
 });

--- a/src/test-kernel/progressView/RetryRequestPanel.vitest.mts
+++ b/src/test-kernel/progressView/RetryRequestPanel.vitest.mts
@@ -79,4 +79,24 @@ describe('retry-request-panel', () => {
     // "…" plus exactly 1024 content characters, not 1023.
     expect(tail.replace(/^…/, '')).toHaveLength(1024);
   });
+
+  it('reports and truncates by grapheme count, not UTF-16 code-unit length', async () => {
+    const element = await mountPanel();
+    const formatRetryDetails: (details: ProviderErrorPartial) => string | null =
+      (element as unknown as Record<string, unknown>)[
+        'formatRetryDetails'
+      ] as never;
+
+    // Each 😀 is a surrogate pair (2 UTF-16 units, 1 grapheme). 600 of them
+    // is 1200 code units but only 600 graphemes — under the 1024 threshold,
+    // so this must NOT be reported or truncated as if it were over it.
+    const text = formatRetryDetails.call(element, {
+      isRelayError: false,
+      userRetryable: true,
+      partialText: '😀'.repeat(600),
+    });
+
+    expect(text).toContain('--- Partial Output (600 chars) ---');
+    expect(text).not.toContain('last 1024');
+  });
 });

--- a/src/test-kernel/progressView/RetryRequestPanel.vitest.mts
+++ b/src/test-kernel/progressView/RetryRequestPanel.vitest.mts
@@ -44,6 +44,18 @@ async function mountPanel(): Promise<RetryRequestPanel> {
   return element;
 }
 
+// `formatRetryDetails` is private; TS-private is not runtime-enforced, and
+// this pure-string-formatting logic doesn't need a full render to verify.
+function formatRetryDetails(
+  element: RetryRequestPanel,
+  details: ProviderErrorPartial,
+): string | null {
+  const format: (details: ProviderErrorPartial) => string | null = (
+    element as unknown as Record<string, unknown>
+  )['formatRetryDetails'] as never;
+  return format.call(element, details);
+}
+
 describe('retry-request-panel', () => {
   it('marks retry action buttons with action ids for shared sizing styles', async () => {
     const element = await mountPanel();
@@ -61,14 +73,8 @@ describe('retry-request-panel', () => {
 
   it('shows exactly the claimed number of tail characters for truncated partial output', async () => {
     const element = await mountPanel();
-    // `formatRetryDetails` is private; TS-private is not runtime-enforced, and
-    // this pure-string-formatting logic doesn't need a full render to verify.
-    const formatRetryDetails: (details: ProviderErrorPartial) => string | null =
-      (element as unknown as Record<string, unknown>)[
-        'formatRetryDetails'
-      ] as never;
 
-    const text = formatRetryDetails.call(element, {
+    const text = formatRetryDetails(element, {
       isRelayError: false,
       userRetryable: true,
       partialText: 'x'.repeat(2000),
@@ -82,15 +88,11 @@ describe('retry-request-panel', () => {
 
   it('reports and truncates by grapheme count, not UTF-16 code-unit length', async () => {
     const element = await mountPanel();
-    const formatRetryDetails: (details: ProviderErrorPartial) => string | null =
-      (element as unknown as Record<string, unknown>)[
-        'formatRetryDetails'
-      ] as never;
 
     // Each 😀 is a surrogate pair (2 UTF-16 units, 1 grapheme). 600 of them
     // is 1200 code units but only 600 graphemes — under the 1024 threshold,
     // so this must NOT be reported or truncated as if it were over it.
-    const text = formatRetryDetails.call(element, {
+    const text = formatRetryDetails(element, {
       isRelayError: false,
       userRetryable: true,
       partialText: '😀'.repeat(600),
@@ -98,5 +100,37 @@ describe('retry-request-panel', () => {
 
     expect(text).toContain('--- Partial Output (600 chars) ---');
     expect(text).not.toContain('last 1024');
+  });
+
+  it('agrees on truncation at the exact boundary (maxTailChars + 1 total chars)', async () => {
+    const element = await mountPanel();
+
+    // At exactly 1025 chars, tailWithEllipsis(text, 1025) returns the text
+    // unchanged (1025 <= its own budget of 1025) — the header must not
+    // claim truncation when nothing was actually cut.
+    const text = formatRetryDetails(element, {
+      isRelayError: false,
+      userRetryable: true,
+      partialText: 'x'.repeat(1025),
+    });
+
+    expect(text).toContain('--- Partial Output (1025 chars) ---');
+    expect(text).not.toContain('last 1024');
+    expect((text ?? '').split('\n').at(-1)).toBe('x'.repeat(1025));
+  });
+
+  it('truncates one char past the boundary (maxTailChars + 2 total chars)', async () => {
+    const element = await mountPanel();
+
+    const text = formatRetryDetails(element, {
+      isRelayError: false,
+      userRetryable: true,
+      partialText: 'x'.repeat(1026),
+    });
+
+    expect(text).toContain('--- Partial Output (last 1024 of 1026 chars) ---');
+    const tail = (text ?? '').split('\n').at(-1) ?? '';
+    expect(tail.startsWith('…')).toBe(true);
+    expect(tail.replace(/^…/, '')).toHaveLength(1024);
   });
 });

--- a/src/tools/lean/LoogleTool.ts
+++ b/src/tools/lean/LoogleTool.ts
@@ -5,7 +5,7 @@
  */
 
 import ky from 'ky';
-import pRetry, { AbortError } from 'p-retry';
+import { AbortError } from 'p-retry';
 import { z } from 'zod';
 
 import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
@@ -13,12 +13,13 @@ import * as logger from '@logger/logUtils';
 import { ToolResult } from '@shared/schemas/toolResult';
 import {
   isTimeoutError,
-  isTransientHttpError,
+  joinAbortSignal,
+  retryTransientFetch,
   unwrapAbortError,
 } from '@tools/timeouts';
 import { defineTool } from '@tools/core/define';
 import { ensureArray } from '@utils/core';
-import { ensureError, toErrorMessage } from '@utils/errors/errorMessage';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 
 const LOOGLE_TIMEOUT_MS = 10_000; // 10 s
 const LOOGLE_CHANNEL = 'lean_loogle';
@@ -147,26 +148,17 @@ Useful for finding the right lemma when you know roughly what type it should hav
     // Cancellation for the owning agent run — parallel batches must be able
     // to abort in-flight Loogle requests and their retry backoff.
     const cancelSignal = getCurrentToolCallContext()?.signal;
-    return pRetry(
+    return retryTransientFetch(
       async () => {
-        let raw: unknown;
-        try {
-          const timeoutSignal = AbortSignal.timeout(LOOGLE_TIMEOUT_MS);
-          raw = await ky
-            .get(LOOGLE_API_URL, {
-              searchParams: { q: query },
-              headers: { 'User-Agent': 'TeXRA-VSCode-Extension' },
-              timeout: false,
-              signal: cancelSignal
-                ? AbortSignal.any([cancelSignal, timeoutSignal])
-                : timeoutSignal,
-              retry: 0,
-            })
-            .json<unknown>();
-        } catch (error: unknown) {
-          if (isTransientHttpError(error)) throw error;
-          throw new AbortError(ensureError(error));
-        }
+        const raw = await ky
+          .get(LOOGLE_API_URL, {
+            searchParams: { q: query },
+            headers: { 'User-Agent': 'TeXRA-VSCode-Extension' },
+            timeout: false,
+            signal: joinAbortSignal(LOOGLE_TIMEOUT_MS, cancelSignal),
+            retry: 0,
+          })
+          .json<unknown>();
         // Validate the body at the boundary. A malformed shape is not transient,
         // so abort retries and let executeSingle surface it as a tool error.
         const parsed = LoogleResponseSchema.safeParse(raw);
@@ -182,9 +174,7 @@ Useful for finding the right lemma when you know roughly what type it should hav
       {
         retries: LOOGLE_RETRIES,
         minTimeout: 1000,
-        signal: cancelSignal,
-        // Jitter the backoff so batched queries don't retry in lockstep.
-        randomize: true,
+        cancelSignal,
         onFailedAttempt: ({ error, retriesLeft }) => {
           logger.debug(
             LOOGLE_CHANNEL,

--- a/src/tools/timeouts.ts
+++ b/src/tools/timeouts.ts
@@ -95,8 +95,10 @@ export function joinAbortSignal(
 /**
  * Run `fetchOnce` under p-retry, retrying only transient failures (timeout,
  * network error, 429, 5xx) with jittered backoff — the pattern every
- * network-boundary tool (web fetch/search, Loogle, Zotero) repeats: classify
- * the error, retry if transient, otherwise abort immediately.
+ * network-boundary tool (web fetch/search, Loogle) repeats: classify the
+ * error, retry if transient, otherwise abort immediately. Zotero's
+ * `bbtClient.ts` shares only this module's abort-signal join, not the retry
+ * classification — it has no retry loop of its own.
  *
  * `fetchOnce` may itself throw an {@link AbortError} (e.g. a response-shape
  * or size-limit check) to abort retries without going through the

--- a/src/tools/timeouts.ts
+++ b/src/tools/timeouts.ts
@@ -8,7 +8,9 @@
 
 import isNetworkError from 'is-network-error';
 import { HTTPError, TimeoutError } from 'ky';
-import { AbortError } from 'p-retry';
+import pRetry, { AbortError, type Options as PRetryOptions } from 'p-retry';
+
+import { ensureError } from '@utils/errors/errorMessage';
 
 /**
  * Unwrap a p-retry {@link AbortError} to the original error it carried.
@@ -70,4 +72,63 @@ export function isTransientHttpError(error: unknown): boolean {
   // matches only the known fetch/undici network-failure messages, so genuine
   // bugs in the wrapped call surface instead of being masked as transient.
   return isNetworkError(error);
+}
+
+/**
+ * Join a per-call timeout with the run's cancellation signal (if any).
+ *
+ * `AbortSignal.timeout` covers both connection and body read; a client's own
+ * `timeout` option (e.g. ky's) only clears once headers arrive. The run's
+ * cancellation signal joins in so an interrupted run aborts in-flight
+ * requests instead of waiting out the timeout.
+ */
+export function joinAbortSignal(
+  timeoutMs: number,
+  cancelSignal?: AbortSignal,
+): AbortSignal {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  return cancelSignal
+    ? AbortSignal.any([cancelSignal, timeoutSignal])
+    : timeoutSignal;
+}
+
+/**
+ * Run `fetchOnce` under p-retry, retrying only transient failures (timeout,
+ * network error, 429, 5xx) with jittered backoff — the pattern every
+ * network-boundary tool (web fetch/search, Loogle, Zotero) repeats: classify
+ * the error, retry if transient, otherwise abort immediately.
+ *
+ * `fetchOnce` may itself throw an {@link AbortError} (e.g. a response-shape
+ * or size-limit check) to abort retries without going through the
+ * transient-error classification; that error passes through unwrapped.
+ */
+export async function retryTransientFetch<T>(
+  fetchOnce: () => Promise<T>,
+  options: {
+    retries: number;
+    minTimeout: number;
+    cancelSignal?: AbortSignal;
+    onFailedAttempt?: PRetryOptions['onFailedAttempt'];
+  },
+): Promise<T> {
+  return pRetry(
+    async () => {
+      try {
+        return await fetchOnce();
+      } catch (error: unknown) {
+        if (error instanceof AbortError || isTransientHttpError(error)) {
+          throw error;
+        }
+        throw new AbortError(ensureError(error));
+      }
+    },
+    {
+      retries: options.retries,
+      minTimeout: options.minTimeout,
+      randomize: true,
+      // Stop retrying (and skip inter-retry delays) once the run is cancelled.
+      signal: options.cancelSignal,
+      onFailedAttempt: options.onFailedAttempt,
+    },
+  );
 }

--- a/src/tools/web/WebFetchTool.ts
+++ b/src/tools/web/WebFetchTool.ts
@@ -3,7 +3,7 @@ import { isIP } from 'node:net';
 
 // Third-party imports
 import ky, { HTTPError } from 'ky';
-import pRetry, { AbortError } from 'p-retry';
+import { AbortError } from 'p-retry';
 import TurndownService from 'turndown';
 import { z } from 'zod';
 
@@ -12,11 +12,12 @@ import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionCo
 import { ToolError, ToolResult } from '@shared/schemas/toolResult';
 import {
   isTimeoutError,
-  isTransientHttpError,
+  joinAbortSignal,
+  retryTransientFetch,
   unwrapAbortError,
 } from '@tools/timeouts';
 import { defineTool } from '@tools/core/define';
-import { ensureError, toErrorMessage } from '@utils/errors/errorMessage';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 
 const WEB_FETCH_TIMEOUT_MS = 30_000; // 30 s
 const WEB_FETCH_RETRIES = 2;
@@ -140,25 +141,13 @@ export class WebFetchTool extends defineTool({
     let contentType: string;
 
     try {
-      ({ rawBody, contentType } = await pRetry(
+      ({ rawBody, contentType } = await retryTransientFetch(
         async (): Promise<{ rawBody: string; contentType: string }> => {
-          let response: Response;
-          try {
-            // AbortSignal.timeout covers both connection and body read;
-            // ky's own timeout only clears once headers arrive. The run's
-            // cancellation signal joins in so interrupts abort the fetch.
-            const timeoutSignal = AbortSignal.timeout(WEB_FETCH_TIMEOUT_MS);
-            response = await ky.get(url, {
-              timeout: false,
-              signal: cancelSignal
-                ? AbortSignal.any([cancelSignal, timeoutSignal])
-                : timeoutSignal,
-              retry: 0,
-            });
-          } catch (error: unknown) {
-            if (isTransientHttpError(error)) throw error;
-            throw new AbortError(ensureError(error));
-          }
+          const response = await ky.get(url, {
+            timeout: false,
+            signal: joinAbortSignal(WEB_FETCH_TIMEOUT_MS, cancelSignal),
+            retry: 0,
+          });
 
           const lengthHeader = response.headers.get('content-length');
           if (lengthHeader && Number(lengthHeader) > MAX_CONTENT_BYTES) {
@@ -171,14 +160,7 @@ export class WebFetchTool extends defineTool({
           const text = await readBodyWithLimit(response, MAX_CONTENT_BYTES);
           return { rawBody: text, contentType: ct };
         },
-        {
-          retries: WEB_FETCH_RETRIES,
-          minTimeout: 500,
-          randomize: true,
-          // Stop retrying (and skip inter-retry delays) once the run is
-          // cancelled.
-          signal: cancelSignal,
-        },
+        { retries: WEB_FETCH_RETRIES, minTimeout: 500, cancelSignal },
       ));
     } catch (error) {
       // Defensive: ensure the specific type checks below see the real error

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -1,6 +1,5 @@
 // Third-party imports
 import ky, { HTTPError } from 'ky';
-import pRetry, { AbortError } from 'p-retry';
 import { z } from 'zod';
 
 // Internal imports
@@ -8,11 +7,12 @@ import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionCo
 import { ToolError, ToolResult } from '@shared/schemas/toolResult';
 import {
   isTimeoutError,
-  isTransientHttpError,
+  joinAbortSignal,
+  retryTransientFetch,
   unwrapAbortError,
 } from '@tools/timeouts';
 import { defineTool } from '@tools/core/define';
-import { ensureError, toErrorMessage } from '@utils/errors/errorMessage';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 
 const DDG_TIMEOUT_MS = 15_000; // 15 s
 const DDG_RETRIES = 2;
@@ -66,37 +66,22 @@ export class WebSearchTool extends defineTool({
 
     let data: DuckDuckGoResponse;
     try {
-      data = await pRetry(
+      data = await retryTransientFetch(
         async () => {
-          try {
-            const timeoutSignal = AbortSignal.timeout(DDG_TIMEOUT_MS);
-            const response = await ky.get('https://api.duckduckgo.com/', {
-              searchParams: {
-                q: query,
-                format: 'json',
-                no_redirect: 1,
-                no_html: 1,
-              },
-              timeout: false,
-              signal: cancelSignal
-                ? AbortSignal.any([cancelSignal, timeoutSignal])
-                : timeoutSignal,
-              retry: 0,
-            });
-            return (await response.json()) as DuckDuckGoResponse;
-          } catch (error: unknown) {
-            if (isTransientHttpError(error)) throw error;
-            throw new AbortError(ensureError(error));
-          }
+          const response = await ky.get('https://api.duckduckgo.com/', {
+            searchParams: {
+              q: query,
+              format: 'json',
+              no_redirect: 1,
+              no_html: 1,
+            },
+            timeout: false,
+            signal: joinAbortSignal(DDG_TIMEOUT_MS, cancelSignal),
+            retry: 0,
+          });
+          return (await response.json()) as DuckDuckGoResponse;
         },
-        {
-          retries: DDG_RETRIES,
-          minTimeout: 500,
-          randomize: true,
-          // Stop retrying (and skip inter-retry delays) once the run is
-          // cancelled.
-          signal: cancelSignal,
-        },
+        { retries: DDG_RETRIES, minTimeout: 500, cancelSignal },
       );
     } catch (error) {
       // Defensive: ensure the specific type checks below see the real error

--- a/src/tools/zotero/bbtClient.ts
+++ b/src/tools/zotero/bbtClient.ts
@@ -15,7 +15,7 @@ import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionCo
 
 // Local imports - core
 import { ToolError } from '@shared/schemas/toolResult';
-import { isTimeoutError } from '@tools/timeouts';
+import { isTimeoutError, joinAbortSignal } from '@tools/timeouts';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { getConfig } from '@utils/config/configUtils';
 
@@ -207,16 +207,13 @@ export async function callBetterBibTeX<T>(
   // Cancellation for the owning agent run — a cancelled parallel batch must
   // abort a hung Zotero request instead of waiting out its timeout.
   const cancelSignal = getCurrentToolCallContext()?.signal;
-  const timeoutSignal = AbortSignal.timeout(timeout);
   let raw: unknown;
   try {
     raw = await ky
       .post(url, {
         json: { jsonrpc: '2.0', method, params, id: 1 },
         timeout: false,
-        signal: cancelSignal
-          ? AbortSignal.any([cancelSignal, timeoutSignal])
-          : timeoutSignal,
+        signal: joinAbortSignal(timeout, cancelSignal),
         retry: 0,
       })
       .json<unknown>();

--- a/src/utils/text/stringUtils.ts
+++ b/src/utils/text/stringUtils.ts
@@ -8,7 +8,7 @@ const graphemeSegmenter = new Intl.Segmenter(undefined, {
 });
 
 /** Split a string into its grapheme clusters for length-accurate slicing. */
-function toGraphemes(text: string): string[] {
+export function toGraphemes(text: string): string[] {
   return [...graphemeSegmenter.segment(text)].map((s) => s.segment);
 }
 


### PR DESCRIPTION
## Summary

Requested audit: scan the codebase for duplicate logic and custom implementations that should use native methods or shared utilities instead. Three parallel research passes covered (1) native-method replacement opportunities, (2) duplication across model handlers/agent flows/tools, and (3) duplication across the CLI TUI and webview frontends. The codebase turned out to already be well-factored in most areas (UUID gen, deep-clone, sleep/delay, retry, clamp, array dedupe, SDK error normalization, token-usage extraction, tool input validation all have a single shared implementation already). This PR implements the genuine, verifiable duplication that survived that audit.

## Issue acceptance gates

Ad-hoc consolidation audit (not tied to a filed issue). Gates: (1) identify duplicate/custom logic with file:line evidence, (2) consolidate the highest-confidence, lowest-risk findings, (3) leave higher-risk findings documented rather than force a refactor without adequate test coverage.

## Single source of truth

- `src/tools/timeouts.ts` now owns the "join a per-call timeout with the run's cancel signal" (`joinAbortSignal`) and "retry only transient fetch failures" (`retryTransientFetch`) logic for every network-boundary tool.
- `src/common/errors` (`buildFailedRetryInfo`) now owns "turn a caught provider error into `{ userRetryable, lastError }`" for PocketFlow cycle-node failure outcomes.
- `truncateWithEllipsis`/`tailWithEllipsis` (`@utils/text/stringUtils`, pre-existing) are now the single ellipsis-truncation implementation across the progress view and CLI TUI.
- `clamp` (`@utils/core`, pre-existing) is now used by `desktopGitHost`'s commit-limit bound check instead of a hand-rolled equivalent.

## Duplication and abstraction budget

Removed:
- ~90 lines of identical `AbortSignal.timeout` + `AbortSignal.any` + `p-retry` + transient-error-classification boilerplate duplicated across `WebFetchTool`, `WebSearchTool`, `LoogleTool`, and `bbtClient` → replaced with two small helpers in `src/tools/timeouts.ts` (already the shared home for this module's timeout/error predicates).
- Repeated `normalizeProviderError(error)` + `toRetryErrorInfo(formatted)` pairing in `ResponseCycleNode`/`ToolUseCycleNode`'s `execFallback`/catch paths → `buildFailedRetryInfo(error)`.
- Three hand-rolled ellipsis-truncation call sites (`QueuedFollowUps`, `EntryErrorBoundary`, `RetryRequestPanel`) → existing `truncateWithEllipsis`/`tailWithEllipsis` (also fixes non-grapheme-aware truncation that could split a surrogate pair or emoji).
- Hand-rolled bound-checking in `desktopGitHost.clampCommitLimit` → existing `clamp`.
- A same-name, different-signature `formatTimestamp` in the progress view (renamed to `formatDisplayTimestamp`) that collided with `@utils/text/stringUtils`'s `formatTimestamp` — no functional bug today (both were reached only via explicit relative imports), but it was a maintenance hazard the audit flagged.

No new abstraction layers were added beyond the two functions above, both used at 3+ call sites.

**Explicitly not implemented** (documented for a future PR, flagged as higher-risk):
- A shared `createFlushableDebounce()`/timer-batcher helper for 4 hand-rolled debounce/throttle sites (`webview/frontend/persistence.ts`, `frontend/review/agentReviewCommitWatcher.ts`, `desktop/main/desktopStreamSnapshot.ts`, `cli/chat/tui/state/subscribeStreamLog.ts`) — each needs a synchronous "flush before dispose" the existing shared `debounce()` (perfect-debounce) doesn't expose, so this needs careful per-site verification rather than a mechanical swap.
- Unifying three duration-formatting implementations (`formatCompactDuration`, `formatRelativeTime`, `runProgressRenderer.formatElapsed`) — each has a deliberate, documented rounding/floor difference; flagged for awareness, not a bug.

## Host impact

Extension: `desktopGitHost` clamp fix is desktop-only; progress-view truncation/timestamp-naming changes affect the extension's progress webview.

Desktop: commit-limit clamping in `desktopGitHost.ts`.

CLI: `EntryErrorBoundary` truncation fix; `WebFetchTool`/`WebSearchTool`/`LoogleTool`/`bbtClient` are host-agnostic core tools shared by all three hosts.

## Scheduled refactoring

None filed; the two "not implemented" items above are called out for a future pass if desired.

## Validation

- `npm run typecheck` — passes (root, extension, CLI, trace-viewer).
- `npm run lint` — passes (0 errors; 1 pre-existing unrelated warning).
- `npm test` — 4834 passed, 7 skipped, 1 failed. The one failure (`execUtils.vitest.ts > aborts shell command process groups including children`) is in a file untouched by this PR and is a process-group/signal-handling test that appears to be flaky in this sandboxed CI environment, not a regression from these changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_013zSon4eiUk9j5GbmDzYo4g)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes span agent retry metadata, multiple host-facing network tools (with a narrow WebFetch body-stream retry-classification shift), and progress/CLI display logic; behavior is mostly equivalent but not purely mechanical everywhere.
> 
> **Overview**
> This PR replaces repeated **network-tool** boilerplate with shared helpers in `src/tools/timeouts.ts`: **`joinAbortSignal`** (timeout + run cancel) and **`retryTransientFetch`** (p-retry with transient-only classification). **`WebFetchTool`**, **`WebSearchTool`**, and **`LoogleTool`** now call those helpers; **`bbtClient`** only adopts **`joinAbortSignal`**.
> 
> **Provider failure outcomes** in **`ResponseCycleNode`** and **`ToolUseCycleNode`** use new **`buildFailedRetryInfo`** from `@common/errors` instead of duplicating **`normalizeProviderError`** + **`toRetryErrorInfo`**.
> 
> **UI truncation** moves to **`truncateWithEllipsis`** / **`tailWithEllipsis`** / **`toGraphemes`** in the CLI error boundary, queued follow-ups, and **`RetryRequestPanel`** partial-output display (grapheme-aware counts and header/truncation alignment at the 1024-char boundary). The progress view renames **`formatTimestamp`** → **`formatDisplayTimestamp`** to avoid clashing with **`@utils/text/stringUtils`**. Desktop **`clampCommitLimit`** uses shared **`clamp`**.
> 
> New **`RetryRequestPanel`** tests cover partial-output formatting. Note: **`WebFetchTool`**’s full fetch callback (including body read) now runs inside **`retryTransientFetch`**, so non-transient errors during streaming follow the shared classification instead of p-retry’s default behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 212f35c5e084edaf32c78b03965e109bb8a7ee14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Behavior note (added post-review)

`retryTransientFetch`'s try/catch now wraps `WebFetchTool`'s entire fetch callback, including the `readBodyWithLimit` body-streaming call — previously only the `ky.get()` call was inside a retry boundary there. A non-abort, non-transient error during body streaming (e.g. a stray `TypeError`) is now classified by `isTransientHttpError` like any other error instead of falling through to p-retry's default retry-everything behavior. This is a real (if narrow) behavior change from the "purely mechanical" framing above — flagged by review as arguably a correctness improvement (matches `timeouts.ts`'s existing "bugs in the wrapped call surface instead of being masked as transient" intent), not requested as a code change.
