### PR TITLE
refactor: simplify data-structure designs flagged by complexity audit

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -784,7 +784,7 @@ function makeRetryApprovalPayload(): RetryPermission {
     operation: 'Tool-use call',
     errorMessage: 'HTTP 429 Too Many Requests',
     errorDetails: {
-      isCredentialExhausted: true,
+      exhaustionReason: 'relay-limit',
       isRelayError: true,
       statusCode: 429,
     },
@@ -996,6 +996,7 @@ if (SHOW_CHILDREN) {
   const startedAt = Date.now() - 74_000;
   const nestedStartedAt = startedAt + 24_000;
   const nestedStrategyChild = {
+    kind: 'subagent' as const,
     executionId: 'harness-nested-local-checker',
     agentName: 'localChecker',
     childStreamId: 'harness-nested-local-checker-stream',
@@ -1003,6 +1004,7 @@ if (SHOW_CHILDREN) {
     startedAt: nestedStartedAt,
   };
   const nestedStrategyProcess = {
+    kind: 'process' as const,
     executionId: 'harness-nested-proof-audit',
     agentName: 'proof audit',
     toolName: 'bash',
@@ -1011,6 +1013,7 @@ if (SHOW_CHILDREN) {
   };
   const childStreams = [
     {
+      kind: 'subagent' as const,
       executionId: 'harness-child-strategy',
       agentName: 'strategy',
       childStreamId: 'harness-child-strategy-stream',
@@ -1018,6 +1021,7 @@ if (SHOW_CHILDREN) {
       startedAt,
     },
     {
+      kind: 'subagent' as const,
       executionId: 'harness-child-lean',
       agentName: 'leanSolver',
       childStreamId: 'harness-child-lean-stream',
@@ -1025,6 +1029,7 @@ if (SHOW_CHILDREN) {
       elapsed: '2m 3s',
     },
     {
+      kind: 'subagent' as const,
       executionId: 'harness-child-review',
       agentName: 'reviewer',
       childStreamId: 'harness-child-review-stream',
@@ -1052,6 +1057,7 @@ if (SHOW_CHILDREN) {
     childStreams,
     activeProcesses: [
       {
+        kind: 'process' as const,
         executionId: 'harness-process-latexmk',
         agentName: 'latex build',
         toolName: 'bash',

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -4,6 +4,7 @@ import { MODEL_CONFIGS } from 'llm-zoo';
 import { useEffect, useState } from 'react';
 import stringWidth from 'string-width';
 
+import { computeUtilizationPercent } from '@agent/modelHandlers/support/contextUtilization';
 import { isCodexSubscriptionActive } from '@auth/codex';
 import { shortCliApiMode } from '@cli/runtime/apiAccessMode';
 import {
@@ -157,7 +158,10 @@ function formatUsage(
   }
 
   const ratio = used / contextWindow;
-  const percent = Math.max(1, Math.round(ratio * 100));
+  const percent = Math.max(
+    1,
+    Math.round(computeUtilizationPercent(used, contextWindow)),
+  );
   let color: StatusBarColor;
   if (ratio >= 0.9) color = 'red';
   else if (ratio >= 0.6) color = 'yellow';

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -7,6 +7,7 @@ import {
   STREAM_STATUS,
   type ActiveChildInfo,
   type StreamTabId,
+  type SubagentChildInfo,
 } from '@shared/schemas';
 import { formatStreamStatusLabel } from '@shared/streams/streamStatusDisplay';
 import { formatCompactDuration } from '@utils/core';
@@ -132,12 +133,10 @@ export function childElapsed(
 }
 
 function streamDescription(
-  child: Pick<ActiveChildInfo, 'childStreamId'>,
+  child: SubagentChildInfo,
   streamsById: ReadonlyMap<StreamTabId, Pick<StreamSlice, 'description'>>,
 ): string | undefined {
-  return child.childStreamId
-    ? streamsById.get(child.childStreamId)?.description
-    : undefined;
+  return streamsById.get(child.childStreamId)?.description;
 }
 
 const TASK_DETAIL_TRANSCRIPT_COLUMNS = 120;
@@ -153,10 +152,9 @@ function streamEntryTailLines(entry: ConversationEntry): readonly string[] {
 }
 
 function streamTranscriptLines(
-  child: Pick<ActiveChildInfo, 'childStreamId'>,
+  child: SubagentChildInfo,
   streamsById: ReadonlyMap<StreamTabId, Pick<StreamSlice, 'entries'>>,
 ): readonly string[] {
-  if (!child.childStreamId) return [];
   const stream = streamsById.get(child.childStreamId);
   if (!stream) return [];
   return stream.entries.flatMap((entry) =>
@@ -164,50 +162,58 @@ function streamTranscriptLines(
   );
 }
 
-function buildSubagentItem(
+/**
+ * Build a picker/detail row for either a subagent or a process badge. The two
+ * kinds share the same `ChildControlItem` output shape and most of the
+ * derivation logic (label, elapsed, status), so they're built by one function
+ * switching on `child.kind` — the two remaining differences are genuine, not
+ * artifacts of a shared-but-undiscriminated input type: a subagent's tail
+ * comes from its own stream's transcript (looked up by `childStreamId`),
+ * while a process's tail comes from its captured stdout/stderr, and only
+ * subagents can be individually non-killable (already-detached rows).
+ */
+function buildChildControlItem(
   child: ActiveChildInfo,
-  streamsById: ReadonlyMap<
-    StreamTabId,
-    Pick<StreamSlice, 'description' | 'entries'>
-  >,
-  nowMs?: number,
-  killable = true,
+  ctx: {
+    readonly streamsById: ReadonlyMap<
+      StreamTabId,
+      Pick<StreamSlice, 'description' | 'entries'>
+    >;
+    readonly processOutput: ReadonlyMap<string, ProcessOutputTail>;
+    readonly killable: boolean;
+    readonly nowMs?: number;
+  },
 ): ChildControlItem {
   const label = childExecutionLabel(child);
-  const command = streamDescription(child, streamsById) ?? label;
-  const elapsed = childElapsed(child, nowMs);
+  const elapsed = childElapsed(child, ctx.nowMs);
   const statusLabel = childStatusDescription(child.status);
-  return {
-    executionId: child.executionId,
-    childStreamId: child.childStreamId,
-    kind: 'subagent',
-    label,
-    command,
-    description: compactParts([statusLabel, elapsed ?? undefined]),
-    statusLabel,
-    elapsed,
-    killable,
-    tailLines: streamTranscriptLines(child, streamsById),
-  };
-}
 
-function buildProcessItem(
-  child: ActiveChildInfo,
-  tail: ProcessOutputTail | undefined,
-  nowMs?: number,
-): ChildControlItem {
-  const tailLines = processTailLines(tail);
-  const lastLine = tailLines.at(-1);
-  const label = childExecutionLabel(child);
-  const elapsed = childElapsed(child, nowMs);
-  const statusLabel = childStatusDescription(child.status);
+  if (child.kind === 'subagent') {
+    return {
+      executionId: child.executionId,
+      childStreamId: child.childStreamId,
+      kind: 'subagent',
+      label,
+      command: streamDescription(child, ctx.streamsById) ?? label,
+      description: compactParts([statusLabel, elapsed ?? undefined]),
+      statusLabel,
+      elapsed,
+      killable: ctx.killable,
+      tailLines: streamTranscriptLines(child, ctx.streamsById),
+    };
+  }
+
+  const tailLines = processTailLines(ctx.processOutput.get(child.executionId));
   return {
     executionId: child.executionId,
-    childStreamId: child.childStreamId,
     kind: 'process',
     label,
     command: label,
-    description: compactParts([statusLabel, elapsed ?? undefined, lastLine]),
+    description: compactParts([
+      statusLabel,
+      elapsed ?? undefined,
+      tailLines.at(-1),
+    ]),
     statusLabel,
     elapsed,
     killable: true,
@@ -252,12 +258,12 @@ export function buildChildControlItems(
 ): readonly ChildControlItem[] {
   const activeKeys = new Set(slice.activeSubagents.map(childExecutionKey));
   const subagentItems = visibleSubagentRows(slice).map((child) =>
-    buildSubagentItem(
-      child,
+    buildChildControlItem(child, {
       streamsById,
+      processOutput: slice.processOutput,
       nowMs,
-      activeKeys.has(childExecutionKey(child)),
-    ),
+      killable: activeKeys.has(childExecutionKey(child)),
+    }),
   );
   if (mode === 'subagents') {
     return subagentItems;
@@ -266,11 +272,12 @@ export function buildChildControlItems(
   return [
     ...subagentItems,
     ...slice.activeProcesses.map((child) =>
-      buildProcessItem(
-        child,
-        slice.processOutput.get(child.executionId),
+      buildChildControlItem(child, {
+        streamsById,
+        processOutput: slice.processOutput,
         nowMs,
-      ),
+        killable: true,
+      }),
     ),
   ];
 }

--- a/packages/cli/src/chat/tui/state/childExecutions.ts
+++ b/packages/cli/src/chat/tui/state/childExecutions.ts
@@ -1,15 +1,15 @@
 // Local imports - shared schemas
 import type { ActiveChildInfo } from '@shared/schemas';
 
-export function childExecutionKey(
-  child: Pick<ActiveChildInfo, 'childStreamId' | 'executionId'>,
-): string {
-  return child.childStreamId ?? child.executionId;
+export function childExecutionKey(child: ActiveChildInfo): string {
+  return child.kind === 'subagent' ? child.childStreamId : child.executionId;
 }
 
-export function childExecutionLabel(
-  child: Pick<ActiveChildInfo, 'agentName' | 'toolName' | 'executionId'>,
-): string {
+export function childExecutionLabel(child: ActiveChildInfo): string {
+  // The agent name is always set by the runtime (for both kinds), so it's the
+  // label; toolName/executionId are just defensive fallbacks for a malformed
+  // entry. `kind` isn't needed here — it's `childExecutionKey` that actually
+  // discriminates (only subagents have a stream tab to key by).
   return child.agentName || child.toolName || child.executionId;
 }
 

--- a/packages/cli/src/chat/tui/state/cliState/parentStreamSlice.ts
+++ b/packages/cli/src/chat/tui/state/cliState/parentStreamSlice.ts
@@ -59,7 +59,8 @@ export function registerChildStreams(
 ): void {
   commitParentStreamEdges(
     children.map((child) => ({
-      childStreamId: child.childStreamId,
+      childStreamId:
+        child.kind === 'subagent' ? child.childStreamId : undefined,
       parentStreamId,
     })),
   );

--- a/packages/cli/src/chat/tui/state/cliState/streamsSlice.ts
+++ b/packages/cli/src/chat/tui/state/cliState/streamsSlice.ts
@@ -60,7 +60,11 @@ function updateChildStatusReferences(
 ): readonly ActiveChildInfo[] {
   let out: ActiveChildInfo[] | undefined;
   children.forEach((child, index) => {
-    if (child.childStreamId !== childStreamId || child.status === status) {
+    if (
+      child.kind !== 'subagent' ||
+      child.childStreamId !== childStreamId ||
+      child.status === status
+    ) {
       return;
     }
     out ??= [...children];
@@ -147,7 +151,9 @@ function removeChildStreamReference(
   children: readonly ActiveChildInfo[],
   streamId: StreamTabId,
 ): readonly ActiveChildInfo[] {
-  const next = children.filter((child) => child.childStreamId !== streamId);
+  const next = children.filter(
+    (child) => child.kind !== 'subagent' || child.childStreamId !== streamId,
+  );
   return next.length === children.length ? children : next;
 }
 

--- a/packages/cli/src/chat/tui/state/focusCycle.ts
+++ b/packages/cli/src/chat/tui/state/focusCycle.ts
@@ -30,7 +30,7 @@ function orderedDescendantsFromSlice(
     ...visibleSubagentRows(slice),
     ...slice.activeProcesses,
   ]) {
-    if (child.childStreamId) out.push(child.childStreamId);
+    if (child.kind === 'subagent') out.push(child.childStreamId);
   }
   return unique(out);
 }

--- a/packages/cli/src/chat/tui/state/resumeHint.ts
+++ b/packages/cli/src/chat/tui/state/resumeHint.ts
@@ -136,7 +136,7 @@ export function collectResumeTargets({
 
   for (const slice of streams.values()) {
     for (const child of slice.childStreams) {
-      if (!child.childStreamId || seen.has(child.executionId)) continue;
+      if (child.kind !== 'subagent' || seen.has(child.executionId)) continue;
       const childSlice = streams.get(child.childStreamId);
       if (childSlice?.category !== AgentCategory.ToolUse) continue;
       seen.add(child.executionId);

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -41,6 +41,7 @@ import {
   isApiProvider,
   type ApiProvider,
 } from '@model/apiProviders';
+import { isUpstreamCreditDepletedError } from '@shared/schemas';
 import {
   handleProgressViewBashApprovalAction,
   setBashApprovalSessionBypass,
@@ -90,7 +91,7 @@ async function maybeAutoSwitchRetry(
   // Upstream credit depletion means the stored direct key IS the broken
   // credential — the user must provide a changed key, so we cannot
   // auto-switch to the stored value.
-  if (details?.isUpstreamCreditDepleted) return undefined;
+  if (isUpstreamCreditDepletedError(details)) return undefined;
 
   // ChatGPT-subscription exhaustion -> the user needs an OpenAI key.
   // Relay exhaustion -> use the provider from error details when known;

--- a/packages/cli/src/runtime/approval/approvalPolicy.ts
+++ b/packages/cli/src/runtime/approval/approvalPolicy.ts
@@ -2,6 +2,7 @@ import { isRelayMonthlyLimitMessage } from '@common/errors/sdkErrorUtils';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import {
   isChatGptSubscriptionLimitError,
+  isCredentialExhausted,
   type ApprovalDecision as SharedApprovalDecision,
 } from '@shared/schemas';
 
@@ -57,7 +58,7 @@ export function isCliApiSwitchableRetry(
   if (!details) return false;
   if (isChatGptSubscriptionLimitError(details)) return true;
   return (
-    details.isCredentialExhausted === true &&
+    isCredentialExhausted(details) &&
     (details.isRelayError === true ||
       isRelayMonthlyLimitMessage(payload.errorMessage))
   );
@@ -167,7 +168,7 @@ function isUnretryableRetryRequest(
   const details = (payload as ProgressEventPayloads['showRetryRequest'])
     .errorDetails;
   if (!details) return false;
-  if (details.isCredentialExhausted) return true;
+  if (isCredentialExhausted(details)) return true;
   if (details.statusCode === 401 || details.statusCode === 403) return true;
   return false;
 }

--- a/packages/cli/src/runtime/history/conversationFormat.ts
+++ b/packages/cli/src/runtime/history/conversationFormat.ts
@@ -1,3 +1,10 @@
+import {
+  formatConversationContent,
+  hasProviderReasoningBlock,
+  stringifyConversationValue,
+  HIDDEN_PROVIDER_REASONING_MARKER,
+  type ConversationFormatOptions,
+} from '@agent/storage/conversationFormat';
 import { isObject } from '@utils/core/typeGuards';
 
 import type {
@@ -7,11 +14,28 @@ import type {
 
 const CONVERSATION_PREVIEW_MESSAGE_LIMIT = 3;
 const CONVERSATION_PREVIEW_CONTENT_LIMIT = 4000;
-const HIDDEN_PROVIDER_REASONING_MARKER = '[provider reasoning hidden]';
 
 interface ConversationMessageFormatOptions {
   readonly includeToolUseMarkers?: boolean;
   readonly contentLimit?: number;
+}
+
+/**
+ * The shared formatter never truncates tool_use/tool_result blocks or shows
+ * their input/args for the CLI (unlike the ExecutionsTool endpoint, which
+ * truncates both) — the CLI truncates once, at the whole-message level, in
+ * {@link toConversationPreviewMessage}. Provider-reasoning (`thinking`)
+ * blocks are always hidden here (surfaced instead via
+ * {@link HIDDEN_PROVIDER_REASONING_MARKER} when they're the only content).
+ */
+function toBlockFormatOptions(
+  options: ConversationMessageFormatOptions,
+): ConversationFormatOptions {
+  return {
+    includeToolUseMarkers: options.includeToolUseMarkers,
+    includeToolUseInput: false,
+    hideProviderReasoning: true,
+  };
 }
 
 export function createConversationPreview(
@@ -83,10 +107,11 @@ function formatConversationMessage(
   raw: Record<string, unknown>,
   options: ConversationMessageFormatOptions,
 ): string {
+  const blockOptions = toBlockFormatOptions(options);
   const role = typeof raw.role === 'string' ? raw.role : '';
   const parts = [
-    formatConversationMessageContent(raw.content, options),
-    formatConversationMessageContent(raw.parts, options),
+    formatConversationContent(raw.content, blockOptions),
+    formatConversationContent(raw.parts, blockOptions),
     ...(options.includeToolUseMarkers === true
       ? formatTopLevelToolCalls(raw.tool_calls)
       : []),
@@ -139,91 +164,14 @@ function formatConversationMessages(
   return lines.join('\n');
 }
 
-function formatConversationMessageContent(
-  content: unknown,
-  options: ConversationMessageFormatOptions,
-): string {
-  if (content == null) return '';
-  if (typeof content === 'string') return content;
-  if (Array.isArray(content)) {
-    return content
-      .map((block) => formatConversationContentBlock(block, options))
-      .join('\n')
-      .trim();
-  }
-  return formatJsonish(content);
-}
-
-function formatConversationContentBlock(
-  block: unknown,
-  options: ConversationMessageFormatOptions,
-): string {
-  if (typeof block === 'string') return block;
-  if (!isObject(block)) return formatJsonish(block);
-  if (typeof block.text === 'string') return block.text;
-
-  if (isObject(block.functionCall)) {
-    if (options.includeToolUseMarkers !== true) return '';
-    const name =
-      typeof block.functionCall.name === 'string'
-        ? block.functionCall.name
-        : 'unknown';
-    return `[tool_use: ${name}]`;
-  }
-
-  if (isObject(block.functionResponse)) {
-    return `[tool_result: ${formatGoogleFunctionResponse(block.functionResponse, options)}]`;
-  }
-
-  switch (block.type) {
-    case 'thinking':
-    case 'redacted_thinking':
-      return '';
-    case 'tool_use':
-      if (options.includeToolUseMarkers !== true) return '';
-      return `[tool_use: ${String(block.name ?? 'unknown')}]`;
-    case 'tool_result':
-      return `[tool_result: ${formatConversationMessageContent(block.content, options)}]`;
-    default:
-      return formatJsonish(block);
-  }
-}
-
-function hasProviderReasoningBlock(content: unknown): boolean {
-  if (Array.isArray(content)) return content.some(isProviderReasoningBlock);
-  return isProviderReasoningBlock(content);
-}
-
-function isProviderReasoningBlock(block: unknown): boolean {
-  return (
-    isObject(block) &&
-    (block.type === 'thinking' || block.type === 'redacted_thinking')
-  );
-}
-
-function formatGoogleFunctionResponse(
-  functionResponse: Record<string, unknown>,
-  options: ConversationMessageFormatOptions,
-): string {
-  const response = isObject(functionResponse.response)
-    ? functionResponse.response
-    : undefined;
-  if (response && Object.hasOwn(response, 'result')) {
-    return formatConversationMessageContent(response.result, options);
-  }
-  if (response !== undefined) {
-    return formatConversationMessageContent(response, options);
-  }
-  return formatJsonish(functionResponse);
-}
-
 function formatTopLevelToolCalls(toolCalls: unknown): string[] {
   if (!Array.isArray(toolCalls)) return [];
   return toolCalls.map(formatTopLevelToolCall);
 }
 
 function formatTopLevelToolCall(toolCall: unknown): string {
-  if (!isObject(toolCall)) return `[tool_use: ${formatJsonish(toolCall)}]`;
+  if (!isObject(toolCall))
+    return `[tool_use: ${stringifyConversationValue(toolCall)}]`;
   const nestedFunction = isObject(toolCall.function)
     ? toolCall.function
     : undefined;
@@ -232,12 +180,4 @@ function formatTopLevelToolCall(toolCall: unknown): string {
       (value): value is string => typeof value === 'string',
     ) ?? 'unknown';
   return `[tool_use: ${name}]`;
-}
-
-function formatJsonish(value: unknown): string {
-  try {
-    return JSON.stringify(value) ?? '';
-  } catch {
-    return String(value);
-  }
 }

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -40,6 +40,7 @@ import {
   wakeQueuedFollowUpStream,
 } from '@agent/followUp/ToolUseFollowUp';
 import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
+import type { StreamPhaseState } from '@agent/runtime/StreamStatusService';
 import {
   getFileListConfig,
   loadFileListSettings,
@@ -58,8 +59,6 @@ import {
   type MainViewPersistedState,
   type ProgressViewOutboundMessage,
   type ExecutionId,
-  type StreamPhase,
-  type StreamSubstate,
   type StreamTabId,
 } from '@shared/schemas';
 import type { ProgressViewInboundHandlerRegistry } from '@shared/schemas/progressView';
@@ -990,20 +989,14 @@ export class DesktopProgressBridge {
     this.progressEvents.onProgressEvent(event, payload);
   }
 
-  private streamStatusSnapshot(): Map<StreamTabId, StreamPhase> {
-    return this.session.status.getAll();
-  }
-
-  private streamSubstateSnapshot(): Map<StreamTabId, StreamSubstate> {
-    return this.session.status.getAllSubstates();
+  private streamStateSnapshot(): Map<StreamTabId, StreamPhaseState> {
+    return this.session.status.getAllStreamStates();
   }
 
   private updateStreamMetadata(): StreamTabId | '' {
     return this.backend.webviewUpdater.sendStreamMetadata(
       this.state,
-      this.streamStatusSnapshot(),
-      undefined,
-      this.streamSubstateSnapshot(),
+      this.streamStateSnapshot(),
     );
   }
 

--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -76,7 +76,11 @@ function toStreamPaletteEntry(stream: StreamTabInfo): CommandPaletteEntry {
   return {
     id: buildSwitchStreamCommandId(stream.name),
     label: `Switch to ${stream.label || stream.name}`,
-    meta: stream.description || stream.agent || stream.modelLabel || 'Stream',
+    meta:
+      stream.description ||
+      stream.agent ||
+      (stream.kind === 'agent' ? stream.modelLabel : undefined) ||
+      'Stream',
     category: 'Streams',
     enabled: true,
   };

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -298,9 +298,8 @@ export class ProgressViewProvider
 
     const activeStream = this.webviewUpdater.sendStreamMetadata(
       this.state,
-      this.eventHandler.getAllStreamStatuses(),
+      this.eventHandler.getAllStreamStates(),
       theme,
-      this.eventHandler.getAllStreamSubstates(),
     );
 
     // Skip content sync when streams exist but filter excludes all of them

--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -421,9 +421,11 @@ export class BackgroundTasksPanel extends LitElement {
   ): TemplateResult {
     const icon = getTaskIcon(child);
     const entry = this.processOutputs.get(child.executionId);
-    const isClickable = Boolean(child.childStreamId);
-    const description = child.childStreamId
-      ? this.streamById.get(child.childStreamId)?.description
+    const childStreamId =
+      child.kind === 'subagent' ? child.childStreamId : undefined;
+    const isClickable = childStreamId !== undefined;
+    const description = childStreamId
+      ? this.streamById.get(childStreamId)?.description
       : undefined;
     const waiting = isWaiting(child);
 
@@ -450,7 +452,7 @@ export class BackgroundTasksPanel extends LitElement {
             tabindex=${isClickable ? '0' : '-1'}
             @click=${
               isClickable
-                ? () => this.navigateToStream(child.childStreamId!)
+                ? () => this.navigateToStream(childStreamId!)
                 : nothing
             }
             @keydown=${
@@ -458,7 +460,7 @@ export class BackgroundTasksPanel extends LitElement {
                 ? (e: KeyboardEvent) => {
                     if (e.key === 'Enter' || e.key === ' ') {
                       e.preventDefault();
-                      this.navigateToStream(child.childStreamId!);
+                      this.navigateToStream(childStreamId!);
                     }
                   }
                 : nothing
@@ -528,8 +530,7 @@ export class BackgroundTasksPanel extends LitElement {
 function isAgentTool(child: ActiveChildInfo): boolean {
   // Explicit tool name match, or subagent with no tool name (delegation/workflow)
   return (
-    child.toolName === 'codex' ||
-    (!child.toolName && Boolean(child.childStreamId))
+    child.toolName === 'codex' || (!child.toolName && child.kind === 'subagent')
   );
 }
 
@@ -539,7 +540,7 @@ function getTaskIcon(child: ActiveChildInfo): string {
   if (isAgentTool(child)) return 'robot';
   // Subagents (delegation, workflow) default to server-process;
   // processes without a toolName fall back to terminal.
-  return child.childStreamId ? 'server-process' : 'terminal';
+  return child.kind === 'subagent' ? 'server-process' : 'terminal';
 }
 
 /** Check if a child is in a waiting/idle state rather than actively processing. */

--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -444,7 +444,8 @@ export class FileList extends LitElement {
       this.getCompactDisplayPath(location);
     const { dir, basename } = parsePath(displayPath);
     const tooltipPath = this.getDisplayPath(location);
-    const effectiveBase = getEffectiveDiffBase(file.lineage)?.absolutePath ?? '';
+    const effectiveBase =
+      getEffectiveDiffBase(file.lineage)?.absolutePath ?? '';
     const diffBase = file.lineage?.diffBase?.absolutePath;
 
     const filePath = location.absolutePath;

--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -18,6 +18,7 @@ import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 
 // Local imports
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import { getEffectiveDiffBase } from '@shared/schemas';
 import type { CompileFailure, OutputFileInfo } from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { isKnownUnsupported } from '@shared/utils/dispatcher';
@@ -443,10 +444,7 @@ export class FileList extends LitElement {
       this.getCompactDisplayPath(location);
     const { dir, basename } = parsePath(displayPath);
     const tooltipPath = this.getDisplayPath(location);
-    const effectiveBase =
-      file.lineage?.diffBase?.absolutePath ??
-      file.lineage?.original?.absolutePath ??
-      '';
+    const effectiveBase = getEffectiveDiffBase(file.lineage)?.absolutePath ?? '';
     const diffBase = file.lineage?.diffBase?.absolutePath;
 
     const filePath = location.absolutePath;

--- a/packages/extension/src/progressView/frontend/components/ProcessStreamContent.ts
+++ b/packages/extension/src/progressView/frontend/components/ProcessStreamContent.ts
@@ -33,7 +33,10 @@ export class ProcessStreamContent extends LitElement {
 
     // Bash streams register as tool-use kind, so renderStreamHeader reflects
     // their active YOLO / Super YOLO state from the shared tool-use fields.
-    const command = streamInfo.command ?? streamInfo.description ?? '';
+    const command =
+      (streamInfo.kind === 'process' ? streamInfo.command : undefined) ??
+      streamInfo.description ??
+      '';
 
     return html`
       ${renderStreamHeader(

--- a/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
@@ -18,7 +18,10 @@ import {
 } from '@shared/styles';
 
 // Local imports - shared schemas
-import type { ProviderErrorPartial } from '@shared/schemas';
+import {
+  isCredentialExhausted,
+  type ProviderErrorPartial,
+} from '@shared/schemas';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 import { renderDotMeta, type MetaPart } from '@shared/wa/metaStrip';
 
@@ -45,7 +48,7 @@ export class RetryRequestPanel extends BaseRequestPanel<'retry'> {
         this.emitAction('retry');
         return true;
       case 'k':
-        if (data.errorDetails?.isCredentialExhausted) {
+        if (isCredentialExhausted(data.errorDetails)) {
           this.emitAction('useOwnApiKey');
           return true;
         }
@@ -61,8 +64,7 @@ export class RetryRequestPanel extends BaseRequestPanel<'retry'> {
   override render(): TemplateResult {
     const data = this.permission.data;
     const isRelay = data.errorDetails?.isRelayError === true;
-    const isCredentialExhausted =
-      data.errorDetails?.isCredentialExhausted === true;
+    const credentialExhausted = isCredentialExhausted(data.errorDetails);
     const userRetryable = data.errorDetails?.userRetryable !== false;
     const metaParts: MetaPart[] = [
       ...(data.model ? [`Model: ${data.model}`] : []),
@@ -109,7 +111,7 @@ export class RetryRequestPanel extends BaseRequestPanel<'retry'> {
           }
         </div>
         <div class="retry-request__actions">
-          ${when(isCredentialExhausted, () =>
+          ${when(credentialExhausted, () =>
             renderLabeledActionButton({
               icon: 'key',
               text: 'Use your own API key',

--- a/packages/extension/src/progressView/frontend/components/StreamConversation.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamConversation.ts
@@ -8,7 +8,6 @@ import { customElement, property, state } from 'lit/decorators.js';
 // Local imports - shared
 import type { InquiryThreadUpdatedEvent } from '@shared/schemas';
 import { SignalWatcher } from '@shared/signals';
-import { isProcessAgent } from '@shared/streams/agentKind';
 
 // Local imports - progress view
 import {
@@ -119,7 +118,7 @@ export class StreamConversation extends SignalWatcher(LitElement) {
     // Process agents (e.g. bash) proxy raw stdout/stderr — render them with
     // a dedicated terminal-style container, not the LLM workflow/tool-use
     // chrome.
-    if (isProcessAgent(streamInfo.agent)) {
+    if (streamInfo.kind === 'process') {
       return html`<process-stream-content></process-stream-content>`;
     }
 

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -63,10 +63,14 @@ function buildTooltip(
   lastTimestamp: number | undefined,
   statusLabel: string,
 ): string {
+  const modelDisplay =
+    info.kind === 'agent' && info.model
+      ? (info.modelLabel ?? info.model)
+      : undefined;
   const mainLine = [
     info.label,
     `Status: ${statusLabel}`,
-    info.model && `Model: ${info.modelLabel ?? info.model}`,
+    modelDisplay && `Model: ${modelDisplay}`,
     info.inputFile && `Input: ${info.inputFile}`,
   ]
     .filter(Boolean)
@@ -227,7 +231,11 @@ export class StreamTab extends LitElement {
                         : nothing
                     }
                     <span class="model"
-                      >${stream.modelLabel ?? stream.model ?? ''}</span
+                      >${
+                        stream.kind === 'agent'
+                          ? (stream.modelLabel ?? stream.model ?? '')
+                          : ''
+                      }</span
                     >
                     <wa-icon
                       library=${TEXRA_ICON_LIBRARY}

--- a/packages/extension/src/progressView/frontend/components/WorkflowStreamContent.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowStreamContent.ts
@@ -74,7 +74,7 @@ export class WorkflowStreamContent extends BaseStreamContent {
         .status=${state.status}
         .hasOutputFiles=${hasOutputFiles(state.files)}
         .options=${this.streamContext.followupOptions}
-        .streamModel=${streamInfo.model ?? null}
+        .streamModel=${streamInfo.kind === 'agent' ? (streamInfo.model ?? null) : null}
         .unsupportedCommands=${this.streamContext.unsupportedCommands}
       ></workflow-tool-use-followup-section>
     `;

--- a/packages/extension/src/progressView/frontend/eventHandlers.ts
+++ b/packages/extension/src/progressView/frontend/eventHandlers.ts
@@ -5,6 +5,7 @@ import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import { postMessage } from '@shared/hostBridge';
 import {
   isChatGptSubscriptionLimitError,
+  isUpstreamCreditDepletedError,
   type GettingStartedActionDetail,
   type StreamTabId,
 } from '@shared/schemas';
@@ -342,10 +343,11 @@ export function handlePermissionAction(
           provider: chatgptSubscription
             ? 'openai'
             : permission.data.errorDetails?.provider,
-          upstreamCreditDepleted:
-            permission.data.errorDetails?.isUpstreamCreditDepleted === true
-              ? true
-              : undefined,
+          upstreamCreditDepleted: isUpstreamCreditDepletedError(
+            permission.data.errorDetails,
+          )
+            ? true
+            : undefined,
           viaRelay:
             permission.data.errorDetails?.isRelayError === true
               ? true

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/contextManagementFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/contextManagementFormatters.ts
@@ -82,11 +82,7 @@ function buildContextManagementItems(data: ContextManagementData): {
   const items: StatItem[] = [];
 
   // For max_tokens_reduced, show the reduction
-  if (
-    action === 'max_tokens_reduced' &&
-    data.originalMaxTokens !== undefined &&
-    data.reducedMaxTokens !== undefined
-  ) {
+  if (action === 'max_tokens_reduced') {
     items.push({
       icon: 'arrow-down',
       label: 'Max tokens reduced',
@@ -95,7 +91,7 @@ function buildContextManagementItems(data: ContextManagementData): {
   }
 
   // For clearing actions, show tokens freed
-  if (TOKENS_FREED_ACTIONS.has(action) && data.tokensAfter !== undefined) {
+  if (action !== 'max_tokens_reduced' && TOKENS_FREED_ACTIONS.has(action)) {
     const tokensFreed = data.tokensBefore - data.tokensAfter;
     if (tokensFreed > 0) {
       items.push({
@@ -108,7 +104,7 @@ function buildContextManagementItems(data: ContextManagementData): {
 
   // Show context utilization
   const utilizationDisplay =
-    data.utilizationAfter !== undefined
+    action !== 'max_tokens_reduced'
       ? `${data.utilizationBefore.toFixed(1)}% → ${data.utilizationAfter.toFixed(1)}%`
       : `${data.utilizationBefore.toFixed(1)}%`;
   items.push({
@@ -147,7 +143,6 @@ export function formatContextManagementTemplate(
   // Hide max_tokens_reduced events when the reduced value is still comfortable
   if (
     parsed.data.action === 'max_tokens_reduced' &&
-    parsed.data.reducedMaxTokens !== undefined &&
     parsed.data.reducedMaxTokens >= MAX_TOKENS_REDUCED_DISPLAY_THRESHOLD
   ) {
     return null;

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/contextManagementFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/contextManagementFormatters.ts
@@ -90,7 +90,13 @@ function buildContextManagementItems(data: ContextManagementData): {
     });
   }
 
-  // For clearing actions, show tokens freed
+  // For clearing actions, show tokens freed.
+  // The `action !== 'max_tokens_reduced'` check looks redundant next to
+  // `TOKENS_FREED_ACTIONS.has(action)` (which already excludes that action
+  // at runtime), but it is what lets TypeScript narrow `data` to the
+  // tokens-freed branch of the discriminated union below — dropping it is a
+  // compile error (`tokensAfter` doesn't exist on the max_tokens_reduced
+  // variant), so keep both checks.
   if (action !== 'max_tokens_reduced' && TOKENS_FREED_ACTIONS.has(action)) {
     const tokensFreed = data.tokensBefore - data.tokensAfter;
     if (tokensFreed > 0) {

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -24,7 +24,6 @@ import {
   type StreamTabInfo,
   type TaskGroup,
 } from '@shared/schemas';
-import { isProcessAgent } from '@shared/streams/agentKind';
 import { toNewestFirstByTimestamp } from '@utils/core';
 
 import { setsEqual } from './utils';
@@ -315,7 +314,7 @@ export const logContext$ = new Signal.Computed((): StreamLogContextValue => {
     streamStatus: activeStreamState$.get()?.status ?? null,
     // Process agents emit raw stdout/stderr; render them terminal-style
     // (monospace, no timestamps, tight spacing) rather than logger entries.
-    terminalMode: isProcessAgent(activeStreamInfo.agent),
+    terminalMode: activeStreamInfo.kind === 'process',
   };
 });
 

--- a/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
@@ -62,6 +62,7 @@ const SAMPLE_FILES: Record<string, OutputFileInfo[]> = {
 
 const SAMPLE_STREAMS: StreamTabInfo[] = [
   {
+    kind: 'agent',
     name: ACTIVE_STREAM_ID,
     label: 'manuscript_revised.tex - polish workflow',
     modelLabel: 'Opus 4.7',
@@ -72,6 +73,7 @@ const SAMPLE_STREAMS: StreamTabInfo[] = [
     executionId: 'abc123',
   },
   {
+    kind: 'agent',
     name: 'figures',
     label: 'figures.tex - tikz tighten',
     modelLabel: 'Sonnet 4.5',
@@ -82,6 +84,7 @@ const SAMPLE_STREAMS: StreamTabInfo[] = [
     executionId: 'abc124',
   },
   {
+    kind: 'agent',
     name: 'review',
     label: 'reviewer-response - draft',
     modelLabel: 'Opus 4.7',
@@ -92,6 +95,7 @@ const SAMPLE_STREAMS: StreamTabInfo[] = [
     executionId: 'abc125',
   },
   {
+    kind: 'agent',
     name: 'bib',
     label: 'bibliography sync',
     modelLabel: 'Sonnet 4.5',

--- a/packages/trace-viewer/src/replayTrace.ts
+++ b/packages/trace-viewer/src/replayTrace.ts
@@ -7,9 +7,11 @@ import {
   StreamStatusSchema,
   streamStatusToLifecycleStatus,
   type StreamLifecycleStatus,
+  type StreamTabInfo,
 } from '@shared/schemas';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc/progressViewCommands';
 import type { ProgressViewOutboundMessage } from '@shared/schemas/progressView';
+import { isProcessAgent } from '@shared/streams/agentKind';
 import { isObject } from '@utils/core';
 import type { TraceDocument } from '@transcript';
 
@@ -69,22 +71,29 @@ export function replayTrace(
   ctx: MessageHandlerContext,
 ): void {
   const { snapshot } = trace;
+  const streamTabBase = {
+    name: trace.streamId,
+    label: trace.config.agent,
+    agent: trace.config.agent,
+    agentCategory: trace.config.agentCategory,
+    // Empty-entries traces have nothing to derive a creation time from;
+    // fall back to "now" rather than the Unix epoch, which would render
+    // as a misleadingly specific (and wrong) 1970 date.
+    creationTimestamp: trace.entries[0]?.timestamp ?? Date.now(),
+    executionId: trace.executionId,
+    description: trace.meta?.description,
+  };
+  // A replayed process-agent trace (e.g. bash) must keep kind: 'process' so
+  // the progress UI picks the terminal-style renderer instead of tool-use
+  // chrome — matches the live classification in buildStreamTabInfo.
+  const streamTabInfo: StreamTabInfo = isProcessAgent(trace.config.agent)
+    ? { ...streamTabBase, kind: 'process', command: trace.config.instruction }
+    : { ...streamTabBase, kind: 'agent', model: trace.config.model };
   const updateStreams: UpdateStreamsMessage = {
     command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
     streams: [
       {
-        kind: 'agent',
-        name: trace.streamId,
-        label: trace.config.agent,
-        model: trace.config.model,
-        agent: trace.config.agent,
-        agentCategory: trace.config.agentCategory,
-        // Empty-entries traces have nothing to derive a creation time from;
-        // fall back to "now" rather than the Unix epoch, which would render
-        // as a misleadingly specific (and wrong) 1970 date.
-        creationTimestamp: trace.entries[0]?.timestamp ?? Date.now(),
-        executionId: trace.executionId,
-        description: trace.meta?.description,
+        ...streamTabInfo,
       },
     ],
     activeStream: trace.streamId,

--- a/packages/trace-viewer/src/replayTrace.ts
+++ b/packages/trace-viewer/src/replayTrace.ts
@@ -10,8 +10,8 @@ import {
 } from '@shared/schemas';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc/progressViewCommands';
 import type { ProgressViewOutboundMessage } from '@shared/schemas/progressView';
-import type { TraceDocument } from '@transcript';
 import { isObject } from '@utils/core';
+import type { TraceDocument } from '@transcript';
 
 type UpdateStreamsMessage = Extract<
   ProgressViewOutboundMessage,
@@ -73,6 +73,7 @@ export function replayTrace(
     command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
     streams: [
       {
+        kind: 'agent',
         name: trace.streamId,
         label: trace.config.agent,
         model: trace.config.model,

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -10,6 +10,7 @@ import { SupabaseClient } from '@auth/SupabaseClient';
 import { normalizeProviderError } from '@common/errors';
 import { isUserAbort } from '@common/errors/sdkErrorUtils';
 import {
+  isCredentialExhausted,
   STREAM_PHASE,
   toRetryErrorInfo,
   type RetryErrorInfo,
@@ -200,7 +201,7 @@ export abstract class RetryableInvocationNode<
     if (isUserAbort(error)) return false;
 
     const formatted = normalizeProviderError(error);
-    if (formatted.isCredentialExhausted) return false;
+    if (isCredentialExhausted(formatted)) return false;
     if (!formatted.userRetryable) return false;
     const code = formatted.statusCode;
     return code !== StatusCodes.UNAUTHORIZED && code !== StatusCodes.FORBIDDEN;

--- a/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
@@ -698,9 +698,11 @@ export class ToolUseDispatchNode<C> extends BatchNode<
     if (shouldBatch) {
       const followUpMsgs =
         await modelHandler.createBatchedToolUseFollowUpMessages!(
-          calls,
-          extracted.map((e) => e.sanitizedResult),
-          extracted.map((e) => e.attachments),
+          calls.map((call, index) => ({
+            call,
+            result: extracted[index].sanitizedResult,
+            attachments: extracted[index].attachments,
+          })),
           workspace,
           assistantText || undefined,
         );

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -1009,37 +1009,26 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
    * in each "step" has a thought_signature. If calls are split into separate
    * model messages, each becomes a new step requiring its own signature.
    *
-   * @param calls - Array of tool calls (should preserve original order from model response)
-   * @param results - Array of sanitized results (same order as calls)
-   * @param attachmentsPerCall - Array of attachment arrays (same order as calls)
+   * @param entries - One entry per tool call, in original model-response order,
+   *   each bundling its own call/result/attachments (structurally aligned).
    * @param workspaceState - Workspace state to reset after consumption
    * @param text - Optional text to include before function calls
    */
   async createBatchedToolUseFollowUpMessages(
-    calls: GoogleToolCall[],
-    results: ToolResult[],
-    attachmentsPerCall: ToolFileAttachment[][],
+    entries: Array<{
+      call: GoogleToolCall;
+      result: ToolResult;
+      attachments: ToolFileAttachment[];
+    }>,
     workspaceState?: AgentWorkspaceState,
     text?: string,
   ): Promise<Content[]> {
-    if (calls.length === 0) {
+    if (entries.length === 0) {
       return [];
     }
 
-    if (calls.length !== results.length) {
-      throw new Error(
-        `Mismatched calls and results: ${calls.length} calls, ${results.length} results`,
-      );
-    }
-
-    if (calls.length !== attachmentsPerCall.length) {
-      throw new Error(
-        `Mismatched calls and attachments: ${calls.length} calls, ${attachmentsPerCall.length} attachment arrays`,
-      );
-    }
-
     // Validate all calls have IDs
-    for (const [index, call] of calls.entries()) {
+    for (const [index, { call }] of entries.entries()) {
       if (!call.callId) {
         throw new Error(
           `Function call at index ${index} (${call.name ?? 'unknown'}) is missing callId`,
@@ -1050,13 +1039,13 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     // Build all function call parts (preserving thought signature on first call)
     const callParts: Part[] = [
       ...(text ? [createPartFromText(text)] : []),
-      ...calls.map((call) => this.buildFunctionCallPart(call)),
+      ...entries.map(({ call }) => this.buildFunctionCallPart(call)),
     ];
 
     // Build all function response parts in parallel
     const responseParts = await Promise.all(
-      calls.map((call, i) =>
-        this.buildFunctionResponsePart(call, results[i], attachmentsPerCall[i]),
+      entries.map(({ call, result, attachments }) =>
+        this.buildFunctionResponsePart(call, result, attachments),
       ),
     );
 

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -1146,24 +1146,16 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
    * batched path, re-expressed as Interactions `Step[]` (spec §6.1).
    */
   async createBatchedToolUseFollowUpMessages(
-    calls: GoogleToolCall[],
-    results: ToolResult[],
-    attachmentsPerCall: ToolFileAttachment[][],
+    entries: Array<{
+      call: GoogleToolCall;
+      result: ToolResult;
+      attachments: ToolFileAttachment[];
+    }>,
     workspaceState?: AgentWorkspaceState,
     text?: string,
   ): Promise<Step[]> {
-    if (calls.length === 0) return [];
-    if (calls.length !== results.length) {
-      throw new Error(
-        `Mismatched calls and results: ${calls.length} calls, ${results.length} results`,
-      );
-    }
-    if (calls.length !== attachmentsPerCall.length) {
-      throw new Error(
-        `Mismatched calls and attachments: ${calls.length} calls, ${attachmentsPerCall.length} attachment arrays`,
-      );
-    }
-    for (const [index, call] of calls.entries()) {
+    if (entries.length === 0) return [];
+    for (const [index, { call }] of entries.entries()) {
       if (!call.callId) {
         throw new Error(
           `Function call at index ${index} (${call.name ?? 'unknown'}) is missing callId`,
@@ -1172,13 +1164,13 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
     }
 
     const assistantSteps = this.buildAssistantTurnSteps(
-      calls,
+      entries.map((e) => e.call),
       workspaceState,
       text,
     );
     const resultSteps = await Promise.all(
-      calls.map((call, i) =>
-        this.buildFunctionResultStep(call, results[i], attachmentsPerCall[i]),
+      entries.map(({ call, result, attachments }) =>
+        this.buildFunctionResultStep(call, result, attachments),
       ),
     );
 

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -43,7 +43,6 @@ import { tagOpenAISdkError } from './openAISdkError';
 import { computeOpenAIPrice, normalizeOpenAIUsage } from './openAIUsage';
 import { OPENAI_CHAT_FINISH } from '../types/StopReasonTypes';
 import {
-  checkBatchedToolCalls,
   insertMediaIntoChatUserMessage,
   normalizeOpenAIMessageContent,
   prependTextToChatUserMessage,
@@ -1327,17 +1326,21 @@ export class ModelHandlerOpenAI<
    * subsequent calls, causing the API to reject the request.
    */
   async createBatchedToolUseFollowUpMessages(
-    calls: TCall[],
-    results: ToolResult[],
-    _attachmentsPerCall: ToolFileAttachment[][],
+    entries: Array<{
+      call: TCall;
+      result: ToolResult;
+      attachments: ToolFileAttachment[];
+    }>,
     workspaceState?: AgentWorkspaceState,
     text?: string,
   ): Promise<ChatCompletionMessageParam[]> {
-    if (!checkBatchedToolCalls(calls.length, results.length)) {
+    if (entries.length === 0) {
       return [];
     }
 
-    const toolCalls = calls.map((call) => this.normalizeToolCall(call.raw));
+    const toolCalls = entries.map(({ call }) =>
+      this.normalizeToolCall(call.raw),
+    );
     const callMsg = this.buildAssistantMessageWithToolCalls(
       toolCalls,
       workspaceState,
@@ -1347,7 +1350,7 @@ export class ModelHandlerOpenAI<
     const toolResultMessages = toolCalls.map((call, i) => ({
       role: 'tool' as const,
       tool_call_id: call.id,
-      content: formatToolResultAsText(results[i]),
+      content: formatToolResultAsText(entries[i].result),
     }));
 
     return [callMsg, ...toolResultMessages];

--- a/src/agent/modelHandlers/openai/openAIMessageUtils.ts
+++ b/src/agent/modelHandlers/openai/openAIMessageUtils.ts
@@ -188,30 +188,6 @@ export function normalizeOpenAIMessageContent<T extends MessageLike>(
 type ChatContentPart = { type: string };
 
 /**
- * Check a batched tool-use follow-up before building provider messages.
- *
- * Shared by the chat-shaped handlers (OpenAI, OpenRouter), whose batched
- * follow-up requires exactly one result per call. Throws on a count mismatch
- * (a programmer error that would otherwise produce a malformed request) and
- * returns `false` when there is nothing to send so the caller can early-return.
- * Named `check*` rather than `assert*` because it also encodes the empty-guard
- * result rather than only throwing.
- *
- * @returns `true` when there is at least one call to process, `false` when empty.
- */
-export function checkBatchedToolCalls(
-  callCount: number,
-  resultCount: number,
-): boolean {
-  if (callCount !== resultCount) {
-    throw new Error(
-      `Batched tool calls mismatch: ${callCount} calls vs ${resultCount} results`,
-    );
-  }
-  return callCount > 0;
-}
-
-/**
  * Prepend `text` to the last user message in a chat-shaped conversation.
  *
  * Chat providers (OpenAI, OpenRouter) model user content as either a plain

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -39,7 +39,6 @@ import { tagOpenRouterSdkError } from './openRouterSdkError';
 import { OPENAI_CHAT_FINISH } from '../types/StopReasonTypes';
 import { toOpenAITools } from '../toolConversion';
 import {
-  checkBatchedToolCalls,
   insertMediaIntoChatUserMessage,
   prependTextToChatUserMessage,
 } from '../openai/openAIMessageUtils';
@@ -688,26 +687,28 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
   }
 
   async createBatchedToolUseFollowUpMessages(
-    calls: OpenRouterToolCall[],
-    results: ToolResult[],
-    _attachmentsPerCall: ToolFileAttachment[][],
+    entries: Array<{
+      call: OpenRouterToolCall;
+      result: ToolResult;
+      attachments: ToolFileAttachment[];
+    }>,
     _workspaceState?: AgentWorkspaceState,
     text?: string,
   ): Promise<ChatMessages[]> {
-    if (!checkBatchedToolCalls(calls.length, results.length)) return [];
+    if (entries.length === 0) return [];
 
     const callMsg: ChatMessages = {
       role: 'assistant',
-      toolCalls: calls.map((c) => c.raw),
+      toolCalls: entries.map(({ call }) => call.raw),
       ...(text ? { content: text } : {}),
     } as ChatMessages;
 
-    const resultMsgs: ChatMessages[] = calls.map(
-      (call, i) =>
+    const resultMsgs: ChatMessages[] = entries.map(
+      ({ call, result }) =>
         ({
           role: 'tool',
           toolCallId: call.callId,
-          content: formatToolResultAsText(results[i]),
+          content: formatToolResultAsText(result),
         }) as ChatMessages,
     );
 

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -110,16 +110,18 @@ export type IModelHandler<
    * - All function calls go in ONE model message (first call has thoughtSignature)
    * - All function responses go in ONE user message
    *
-   * @param calls - Array of tool calls (preserving original order from model response)
-   * @param results - Array of tool result payloads (same order as calls)
-   * @param attachmentsPerCall - Array of attachment arrays (same order as calls)
+   * @param entries - One entry per tool call, in original model-response order.
+   *   Each entry bundles the call with its own result and attachments, so
+   *   alignment is structural rather than three positionally-zipped arrays.
    * @param workspaceState - Optional workspace state for reasoning blocks
    * @param text - Optional text to include before function calls
    */
   createBatchedToolUseFollowUpMessages?(
-    calls: T[],
-    results: ToolResult[],
-    attachmentsPerCall: ToolFileAttachment[][],
+    entries: Array<{
+      call: T;
+      result: ToolResult;
+      attachments: ToolFileAttachment[];
+    }>,
     workspaceState?: AgentWorkspaceState,
     text?: string,
   ): Promise<M[]>;

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -336,17 +336,33 @@ export async function runFlowWithLifecycle(
     // Abort still carries the SDK message for event consumers; the toast mapper
     // intentionally suppresses user-facing notifications for aborts.
     if (!resultEmitted) {
+      const message = kind === 'unexpected' ? errorMsg : sdkMsg;
+      // `abort`/`disk-full` route through `formatProviderHttpError`'s
+      // `terminalError()` branch, which never populates the provider/relay/
+      // credential fields — narrow to the fields it actually sets so
+      // `ResultEvent.error`'s per-kind union stays honest (see events.ts).
+      const error: NonNullable<ResultEvent['error']> =
+        kind === 'abort' || kind === 'disk-full'
+          ? {
+              kind,
+              message,
+              userRetryable: providerErrorInfo.userRetryable,
+              isRelayError: providerErrorInfo.isRelayError,
+              streamDiagnostics: providerErrorInfo.streamDiagnostics,
+              partialText: providerErrorInfo.partialText,
+            }
+          : {
+              kind,
+              message,
+              ...providerErrorInfo,
+            };
       handle.settleResult(
         emitRunResult(
           ctx,
           category,
           toResultOutcome(outcome),
           options?.isSubagent ?? false,
-          {
-            kind,
-            message: kind === 'unexpected' ? errorMsg : sdkMsg,
-            ...providerErrorInfo,
-          },
+          error,
         ),
       );
     }

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -35,7 +35,7 @@ type WaitingTransitionCause = Extract<
   'wait' | 'restart-repair'
 >;
 
-interface StreamPhaseState {
+export interface StreamPhaseState {
   readonly phase: StreamPhase;
   readonly substate?: StreamSubstate;
 }
@@ -219,26 +219,39 @@ export class StreamStatusMachine {
     return this.getAll().entries();
   }
 
-  getAll(): Map<StreamTabId, StreamPhase> {
-    const values = new Map<StreamTabId, StreamPhase>();
+  /**
+   * Combined per-stream phase + substate, merging in in-flight reservations
+   * exactly once. `getAll()` and `getAllSubstates()` are thin projections of
+   * this so the two views can never diverge on which streams they cover.
+   */
+  getAllStreamStates(): Map<StreamTabId, StreamPhaseState> {
+    const values = new Map<StreamTabId, StreamPhaseState>();
     for (const [stream, state] of this.phases) {
-      values.set(stream, state.phase);
+      values.set(stream, state);
     }
     for (const stream of this.reservations) {
-      values.set(stream, STREAM_PHASE.RUNNING);
+      values.set(stream, {
+        phase: STREAM_PHASE.RUNNING,
+        substate: STREAM_SUBSTATE.STARTING,
+      });
+    }
+    return values;
+  }
+
+  getAll(): Map<StreamTabId, StreamPhase> {
+    const values = new Map<StreamTabId, StreamPhase>();
+    for (const [stream, state] of this.getAllStreamStates()) {
+      values.set(stream, state.phase);
     }
     return values;
   }
 
   getAllSubstates(): Map<StreamTabId, StreamSubstate> {
     const values = new Map<StreamTabId, StreamSubstate>();
-    for (const [stream, state] of this.phases) {
+    for (const [stream, state] of this.getAllStreamStates()) {
       if (state.substate) {
         values.set(stream, state.substate);
       }
-    }
-    for (const stream of this.reservations) {
-      values.set(stream, STREAM_SUBSTATE.STARTING);
     }
     return values;
   }

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -786,19 +786,18 @@ export class ExecutionRegistry {
       const { status, elapsed } = this.getStatus(handle);
       const summaryStatus =
         status === STREAM_PHASE.CANCELLED ? STREAM_STATUS.STOPPED : status;
-      const info: ActiveChildInfo = {
+      const base = {
         executionId: handle.executionId,
         agentName: handle.agentName,
         status: summaryStatus,
         startedAt: handle.startedAt,
         elapsed: elapsed ?? null,
+        ...(handle.toolName ? { toolName: handle.toolName } : {}),
       };
-      if (handle instanceof AgentExecutionHandle) {
-        info.childStreamId = handle.childStreamId;
-        if (handle.toolName) info.toolName = handle.toolName;
-      } else if (handle instanceof ProcessExecutionHandle && handle.toolName) {
-        info.toolName = handle.toolName;
-      }
+      const info: ActiveChildInfo =
+        handle instanceof AgentExecutionHandle
+          ? { ...base, kind: 'subagent', childStreamId: handle.childStreamId }
+          : { ...base, kind: 'process' };
       result.push(info);
     }
     return result;

--- a/src/agent/storage/conversationFormat.ts
+++ b/src/agent/storage/conversationFormat.ts
@@ -1,0 +1,220 @@
+/**
+ * Shared formatters for rendering a stored execution conversation
+ * (`ExecutionKVStore.readConversation()`) as text.
+ *
+ * A stored conversation is `unknown[]` — whichever model handler produced it
+ * (Anthropic, OpenAI, Google, OpenRouter) writes its own provider-native
+ * message shape, so `content` blocks show up as Anthropic-style
+ * `{type: 'text'|'tool_use'|'tool_result'}`, Google's discriminator-less
+ * `{text}`/`{functionCall}`/`{functionResponse}` parts, or OpenAI's top-level
+ * `tool_calls`. This module recognizes those shapes once, instead of every
+ * caller re-parsing them with its own drifted truncation rules.
+ *
+ * Used by:
+ *  - `ExecutionsTool`'s `/executions/{id}/conversation` endpoint
+ *    (`src/tools/executions/conversationFormat.ts`)
+ *  - the CLI's `texra history` / resume previews
+ *    (`packages/cli/src/runtime/history/conversationFormat.ts`)
+ *
+ * Callers keep their own message-level composition (XML-ish `<message>`
+ * blocks for the tools endpoint; a structured preview/transcript shape plus
+ * whole-message truncation for the CLI) — only the per-content-block
+ * recognition and truncation below is shared.
+ */
+import { isObject } from '@utils/core/typeGuards';
+
+const DEFAULT_TRUNCATION_MARKER = '...';
+
+export const HIDDEN_PROVIDER_REASONING_MARKER = '[provider reasoning hidden]';
+
+export interface ConversationFormatOptions {
+  /** Truncate string/JSON-ish top-level message content at this many chars. Omit for no limit. */
+  readonly textLimit?: number;
+  /** Truncate tool_use/tool_result (and Google functionCall/functionResponse) block text at this many chars. Omit for no limit. */
+  readonly toolBlockLimit?: number;
+  /** Suffix appended to a truncated value. Defaults to `'...'`. */
+  readonly truncationMarker?: string;
+  /** Render a `[tool_use: ...]` marker for tool-call blocks. Defaults to `true`. */
+  readonly includeToolUseMarkers?: boolean;
+  /** Include the call's input/args in the tool_use marker (`name(json)` vs bare `name`). Defaults to `true`. */
+  readonly includeToolUseInput?: boolean;
+  /** Render `thinking`/`redacted_thinking` blocks as `''` instead of their JSON form. Defaults to `false`. */
+  readonly hideProviderReasoning?: boolean;
+}
+
+function asText(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+/** `JSON.stringify` returns `undefined` for undefined/symbol/function values; fall back to `''` so truncation never sees a non-string. */
+export function stringifyConversationValue(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? '';
+  } catch {
+    return String(value);
+  }
+}
+
+// Deliberately ASCII-only (`...`, code-unit slicing) rather than
+// `truncateWithEllipsis`'s Unicode `…` + grapheme-aware cut — this output
+// feeds plain-text conversation views (the ExecutionsTool endpoint, the CLI
+// transcript) that must stay pure ASCII.
+function truncate(
+  str: string,
+  maxLen: number | undefined,
+  marker: string,
+): string {
+  if (maxLen === undefined || str.length <= maxLen) return str;
+  return `${str.slice(0, Math.max(maxLen - marker.length, 0))}${marker}`;
+}
+
+export function hasProviderReasoningBlock(content: unknown): boolean {
+  if (Array.isArray(content)) return content.some(isProviderReasoningBlock);
+  return isProviderReasoningBlock(content);
+}
+
+function isProviderReasoningBlock(block: unknown): boolean {
+  return (
+    isObject(block) &&
+    (block.type === 'thinking' || block.type === 'redacted_thinking')
+  );
+}
+
+function extractGoogleFunctionResponseContent(
+  functionResponse: Record<string, unknown>,
+): unknown {
+  const response = isObject(functionResponse.response)
+    ? functionResponse.response
+    : undefined;
+  if (response && Object.hasOwn(response, 'result')) return response.result;
+  if (response !== undefined) return response;
+  return functionResponse;
+}
+
+function formatToolUseMarker(
+  name: string,
+  input: unknown,
+  options: ConversationFormatOptions,
+): string {
+  if (options.includeToolUseMarkers === false) return '';
+  if (options.includeToolUseInput === false) return `[tool_use: ${name}]`;
+  const marker = options.truncationMarker ?? DEFAULT_TRUNCATION_MARKER;
+  const inputJson = truncate(
+    stringifyConversationValue(input ?? {}),
+    options.toolBlockLimit,
+    marker,
+  );
+  return `[tool_use: ${name}(${inputJson})]`;
+}
+
+function formatToolResultMarker(
+  content: unknown,
+  options: ConversationFormatOptions,
+): string {
+  const marker = options.truncationMarker ?? DEFAULT_TRUNCATION_MARKER;
+  const inner = Array.isArray(content)
+    ? content
+        .map((block) => formatConversationBlock(block, options))
+        .join('\n')
+        .trim()
+    : typeof content === 'string'
+      ? content
+      : stringifyConversationValue(content);
+  return `[tool_result: ${truncate(inner, options.toolBlockLimit, marker)}]`;
+}
+
+/**
+ * Render a single content-block (an element of a message's `content`/`parts`
+ * array) to text. Handles Anthropic's `{type: ...}` discriminated blocks,
+ * Google's discriminator-less `{text}`/`{functionCall}`/`{functionResponse}`
+ * parts, and falls back to a JSON dump for unrecognized shapes.
+ */
+export function formatConversationBlock(
+  block: unknown,
+  options: ConversationFormatOptions = {},
+): string {
+  const marker = options.truncationMarker ?? DEFAULT_TRUNCATION_MARKER;
+  if (typeof block === 'string') return block;
+  if (!isObject(block)) {
+    return truncate(
+      stringifyConversationValue(block),
+      options.toolBlockLimit,
+      marker,
+    );
+  }
+  // Google's `parts` entries have no `type` discriminator at all — a plain
+  // `text` field is the only signal, so check it before the `type` switch.
+  if (typeof block.text === 'string') return block.text;
+
+  if (isObject(block.functionCall)) {
+    return formatToolUseMarker(
+      asText(block.functionCall.name) || 'unknown',
+      block.functionCall.args,
+      options,
+    );
+  }
+  if (isObject(block.functionResponse)) {
+    return formatToolResultMarker(
+      extractGoogleFunctionResponseContent(block.functionResponse),
+      options,
+    );
+  }
+
+  switch (block.type) {
+    case 'text':
+      // A recognized text block whose `text` failed the duck-type check
+      // above (missing/non-string) — render empty, not its JSON form.
+      return asText(block.text);
+    case 'thinking':
+    case 'redacted_thinking':
+      return options.hideProviderReasoning
+        ? ''
+        : truncate(
+            stringifyConversationValue(block),
+            options.toolBlockLimit,
+            marker,
+          );
+    case 'tool_use':
+      return formatToolUseMarker(
+        asText(block.name) || 'unknown',
+        block.input,
+        options,
+      );
+    case 'tool_result':
+      return formatToolResultMarker(block.content, options);
+    default:
+      return truncate(
+        stringifyConversationValue(block),
+        options.toolBlockLimit,
+        marker,
+      );
+  }
+}
+
+/**
+ * Render a message's `content` (or Google's `parts`) field to text: a string
+ * passes through (truncated at `textLimit`), an array joins each block's
+ * rendering, and any other JSON-ish value is stringified (also truncated at
+ * `textLimit`).
+ */
+export function formatConversationContent(
+  content: unknown,
+  options: ConversationFormatOptions = {},
+): string {
+  const marker = options.truncationMarker ?? DEFAULT_TRUNCATION_MARKER;
+  if (content == null) return '';
+  if (typeof content === 'string') {
+    return truncate(content, options.textLimit, marker);
+  }
+  if (Array.isArray(content)) {
+    return content
+      .map((block) => formatConversationBlock(block, options))
+      .join('\n')
+      .trim();
+  }
+  return truncate(
+    stringifyConversationValue(content),
+    options.textLimit,
+    marker,
+  );
+}

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -37,3 +37,11 @@ export {
   type ResumabilityCause,
   type ResumabilityDecision,
 } from './resumability';
+export {
+  HIDDEN_PROVIDER_REASONING_MARKER,
+  type ConversationFormatOptions,
+  formatConversationBlock,
+  formatConversationContent,
+  hasProviderReasoningBlock,
+  stringifyConversationValue,
+} from './conversationFormat';

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -294,7 +294,10 @@ export interface ResultEvent extends StageStamp {
         readonly kind: Extract<AgentErrorKind, 'abort' | 'disk-full'>;
       })
     | (ResultEventProviderError & {
-        readonly kind: Extract<AgentErrorKind, 'missing-api-key' | 'unexpected'>;
+        readonly kind: Extract<
+          AgentErrorKind,
+          'missing-api-key' | 'unexpected'
+        >;
       });
   readonly usage?: RunUsageTotals;
 }

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -233,17 +233,53 @@ export interface DomainEvent extends StageStamp {
 }
 
 /**
+ * Fields `formatProviderHttpError`'s `terminalError()` branch actually sets
+ * for `abort` / `disk-full` (see `src/common/errors/sdkError/
+ * providerErrorFormat.ts`): it deliberately opts out of provider/relay/
+ * credential classification, so `statusCode`/`provider`/`requestId`/
+ * `exhaustionReason` are never populated for these kinds.
+ */
+type ResultEventLocalError = Readonly<{
+  message?: string;
+  userRetryable?: RetryErrorInfo['userRetryable'];
+  isRelayError?: RetryErrorInfo['isRelayError'];
+  streamDiagnostics?: RetryErrorInfo['streamDiagnostics'];
+  partialText?: RetryErrorInfo['partialText'];
+}>;
+
+/**
+ * Fields available for `missing-api-key` / `unexpected`, which fall through
+ * `formatProviderHttpError` to the general SDK/provider-error classification
+ * path and so may populate the full `RetryErrorInfo` shape (minus `message`,
+ * carried separately, and `rawErrorBody`, stripped as bulky by
+ * `toRetryErrorInfo` at the emission boundary).
+ */
+type ResultEventProviderError = ResultEventLocalError &
+  Readonly<
+    Partial<
+      Omit<
+        RetryErrorInfo,
+        | 'message'
+        | 'userRetryable'
+        | 'isRelayError'
+        | 'streamDiagnostics'
+        | 'partialText'
+      >
+    >
+  >;
+
+/**
  * Terminal run outcome as data — emitted exactly once at the run-lifecycle
  * boundary (`runFlowWithLifecycle`), never from flows or the bus. `cancelled`
  * is a sibling of `failed` (a user interrupt is not a failure). `error.kind` is
- * the classified terminal-error discriminant; the rest of `error` is the
- * `RetryErrorInfo` normalized at the same boundary (statusCode, provider,
- * isCredentialExhausted, partialText, …). `normalizeProviderError` always
- * returns a structured shape, so baseline fields like `userRetryable`/
- * `isRelayError` are present for every kind, including `missing-api-key` and
- * `disk-full` — only genuine SDK/provider failures also populate `statusCode`/
- * `provider`/`requestId`/`partialText`. `usage` is the run totals (present
- * once at least one round recorded usage, including on failures).
+ * the classified terminal-error discriminant, and it also selects which
+ * `RetryErrorInfo` fields are ever populated: `abort`/`disk-full` are always
+ * local, non-provider failures (`ResultEventLocalError`), while
+ * `missing-api-key`/`unexpected` go through the general provider/SDK
+ * classification and may carry the fuller shape (`ResultEventProviderError`) —
+ * see `formatProviderHttpError` in `src/common/errors/sdkError/
+ * providerErrorFormat.ts`. `usage` is the run totals (present once at least
+ * one round recorded usage, including on failures).
  */
 export interface ResultEvent extends StageStamp {
   readonly type: 'result';
@@ -253,10 +289,13 @@ export interface ResultEvent extends StageStamp {
   readonly agentName: string;
   readonly category: 'toolUse' | 'workflow';
   readonly isSubagent: boolean;
-  readonly error?: Readonly<Partial<Omit<RetryErrorInfo, 'message'>>> & {
-    readonly kind: AgentErrorKind;
-    readonly message?: string;
-  };
+  readonly error?:
+    | (ResultEventLocalError & {
+        readonly kind: Extract<AgentErrorKind, 'abort' | 'disk-full'>;
+      })
+    | (ResultEventProviderError & {
+        readonly kind: Extract<AgentErrorKind, 'missing-api-key' | 'unexpected'>;
+      });
   readonly usage?: RunUsageTotals;
 }
 

--- a/src/common/errors/sdkError/providerErrorFormat.ts
+++ b/src/common/errors/sdkError/providerErrorFormat.ts
@@ -3,6 +3,7 @@ import {
   type ErrorLogData,
   type ExhaustionReason,
   type ProviderError,
+  normalizeLegacyProviderErrorFields,
 } from '@shared/schemas';
 import {
   extractErrorMessage,
@@ -277,10 +278,18 @@ function detectCachedProviderError(err: unknown): ProviderError | undefined {
 export function normalizeProviderError(err: unknown): ProviderError {
   const cached = detectCachedProviderError(err);
   if (cached) {
-    // Migrate an explicitly-attached ProviderError from a deeper cause onto the
-    // wrapper so later reads skip the chain walk.
-    providerErrorMetadata.attach(err, cached);
-    return cached;
+    // A cached error may have been attached before the legacy retryable/
+    // exhaustion-flag migration ran (e.g. a resumed flow's raw persisted
+    // `lastError`, which bypasses the schema-level migration on the resume
+    // path) — run the same migration fresh errors get so callers never read
+    // legacy field names off a cached value.
+    const normalized = normalizeLegacyProviderErrorFields(
+      cached,
+    ) as ProviderError;
+    // Migrate the normalized error from a deeper cause onto the wrapper so
+    // later reads skip both the chain walk and this normalization.
+    providerErrorMetadata.attach(err, normalized);
+    return normalized;
   }
 
   // Compute fresh but DO NOT cache the result: a caller may format an error for

--- a/src/common/errors/sdkError/providerErrorFormat.ts
+++ b/src/common/errors/sdkError/providerErrorFormat.ts
@@ -1,6 +1,7 @@
 import {
   type ErrorContext,
   type ErrorLogData,
+  type ExhaustionReason,
   type ProviderError,
 } from '@shared/schemas';
 import {
@@ -166,11 +167,18 @@ export function formatProviderHttpError(err: unknown): ProviderError {
   const chatgptSubscriptionMessage = chatgptSubscriptionLimit
     ? describeChatGptSubscriptionLimit(chatgptSubscriptionLimit)
     : undefined;
-  const isCredentialExhausted =
-    isRelayMonthlyLimitBody(rawErrorBody) ||
-    isRelayMonthlyLimitByMessage ||
-    isUpstreamCreditDepleted ||
-    isChatGptSubscriptionLimited;
+  // Priority mirrors the pre-refactor OR order: ChatGPT-subscription and
+  // upstream-credit are independently detected first; relay monthly limit
+  // (by body or message) is the remaining exhaustion condition.
+  const exhaustionReason: ExhaustionReason | undefined =
+    isChatGptSubscriptionLimited
+      ? 'chatgpt-subscription'
+      : isUpstreamCreditDepleted
+        ? 'upstream-credit'
+        : isRelayMonthlyLimitBody(rawErrorBody) || isRelayMonthlyLimitByMessage
+          ? 'relay-limit'
+          : undefined;
+  const isCredentialExhausted = exhaustionReason !== undefined;
 
   // Terminal failures (user abort, local disk-full): never retryable and never
   // a relay/credential affordance. Carries diagnostics but deliberately opts
@@ -204,9 +212,7 @@ export function formatProviderHttpError(err: unknown): ProviderError {
   // for these fields so adding a future flag touches one place, not two.
   const classification = {
     isRelayError: isRelay,
-    isCredentialExhausted: isCredentialExhausted || undefined,
-    isUpstreamCreditDepleted: isUpstreamCreditDepleted || undefined,
-    isChatGptSubscriptionLimited: isChatGptSubscriptionLimited || undefined,
+    exhaustionReason,
     rawErrorBody,
     streamDiagnostics,
     partialText,

--- a/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
+++ b/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
@@ -52,7 +52,6 @@ export interface ProgressWorkflowFileActionsControllerDeps {
 
 type ModelOutputBackup = {
   content: string;
-  streamId: StreamTabId;
 };
 
 export class ProgressWorkflowFileActionsController {
@@ -164,7 +163,7 @@ export class ProgressWorkflowFileActionsController {
     ) {
       const fileName = path.basename(file);
       await this.deps.sendFollowUp(
-        backup.streamId,
+        activeStream,
         `[System: User modified the model's suggested output for "${fileName}" before accepting. The accepted version differs from the original model output.]`,
       );
     }

--- a/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
+++ b/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
@@ -234,7 +234,7 @@ export class ProgressWorkflowFileActionsController {
     try {
       const content = await this.deps.host.readFile(file);
       const streamBackups = this.modelOutputBackups.get(streamId) ?? new Map();
-      streamBackups.set(file, { content, streamId });
+      streamBackups.set(file, { content });
       this.modelOutputBackups.set(streamId, streamBackups);
     } catch {
       // Best-effort: backup only informs the accepted-edit follow-up.

--- a/src/latex/latexdiff/diffOperations.ts
+++ b/src/latex/latexdiff/diffOperations.ts
@@ -15,7 +15,7 @@ import {
 } from '@agent/output/workflowOutputLayout';
 import type { MathMarkupOption } from '@latex/latexdiff/mathMarkup';
 import * as logger from '@logger/logUtils';
-import { RoundKeySchema } from '@shared/schemas';
+import { getEffectiveDiffBase, RoundKeySchema } from '@shared/schemas';
 import type { OutputFileInfo } from '@shared/schemas';
 import {
   WorkspaceFS,
@@ -116,10 +116,7 @@ export async function runLatexdiffFromMetadata(params: {
 
   for (const [round, infos] of rounds.entries()) {
     for (const info of infos) {
-      // Prefer the immutable pre-run snapshot (diffBase): lineage.original now
-      // points at the live workspace file, which for in-place rewrites is the
-      // post-run file itself, so latexdiff would compare it against itself.
-      const base = info.lineage?.diffBase ?? info.lineage?.original ?? null;
+      const base = getEffectiveDiffBase(info.lineage);
       const description = `${getFileLabel(info)} (r${round})`;
 
       if (!base) {

--- a/src/shared/agent/terminalResultPresentation.ts
+++ b/src/shared/agent/terminalResultPresentation.ts
@@ -38,8 +38,12 @@ export function terminalResultToast(
   event: ResultEvent,
 ): TerminalResultToast | null {
   if (event.isSubagent || !event.error) return null;
+  // Bind to a local so the switch below narrows this value's per-kind shape
+  // (ResultEvent.error is now a union keyed on `kind`) rather than the
+  // `event.error` property-access chain, which narrows less reliably.
+  const error = event.error;
 
-  switch (event.error.kind) {
+  switch (error.kind) {
     case 'missing-api-key':
       return {
         type: 'instruction',
@@ -56,22 +60,25 @@ export function terminalResultToast(
     case 'disk-full':
       return {
         type: 'error',
-        payload: { message: event.error.message ?? 'Disk full.' },
+        payload: { message: error.message ?? 'Disk full.' },
       };
     case 'unexpected':
       return {
         type: 'error',
         payload: {
-          message: event.error.message ?? 'Unexpected error executing agent.',
+          message: error.message ?? 'Unexpected error executing agent.',
         },
       };
     case 'abort':
       // User-initiated cancellation: no toast (matches the prior lifecycle).
       return null;
     default: {
-      // Exhaustiveness guard: a new AgentErrorKind must take an explicit stance
-      // here rather than silently falling through to no-toast.
-      const _exhaustive: never = event.error.kind;
+      // Exhaustiveness guard: a new AgentErrorKind must take an explicit
+      // stance here rather than silently falling through to no-toast.
+      // Assert on the whole narrowed union (not `error.kind`) — now that
+      // `error` itself is a discriminated union, property access on an
+      // already-`never`-narrowed object does not type-check.
+      const _exhaustive: never = error;
       void _exhaustive;
       return null;
     }

--- a/src/shared/progressView/backend/WebviewUpdater.ts
+++ b/src/shared/progressView/backend/WebviewUpdater.ts
@@ -1,3 +1,4 @@
+import type { StreamPhaseState } from '@agent/runtime/StreamStatusService';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import type {
   AgentCategoryFilter,
@@ -109,8 +110,7 @@ export class WebviewUpdater {
   updateStreamMetadata(
     state: ProgressViewState,
     streamId: StreamTabId,
-    statuses?: Map<string, StreamPhase>,
-    substates?: Map<string, StreamSubstate>,
+    streamStates?: Map<StreamTabId, StreamPhaseState>,
     options?: {
       activeStream?: ActiveStreamId;
       agentFilter?: AgentCategoryFilter;
@@ -122,8 +122,7 @@ export class WebviewUpdater {
     const streamState = this.buildStreamMetadataForStream(
       state,
       streamInfo,
-      statuses,
-      substates,
+      streamStates,
     );
 
     this.sendMessage({
@@ -409,9 +408,8 @@ export class WebviewUpdater {
    */
   sendStreamMetadata(
     state: ProgressViewState,
-    statuses?: Map<string, StreamPhase>,
+    streamStates?: Map<StreamTabId, StreamPhaseState>,
     theme?: 'dark' | 'light',
-    substates?: Map<string, StreamSubstate>,
   ): ActiveStreamId {
     // Send every stream so streamById stays comprehensive for consumers like
     // BackgroundTasksPanel that need to render cross-filter subagent children
@@ -459,8 +457,7 @@ export class WebviewUpdater {
       const metadata = this.buildStreamMetadataForStream(
         state,
         streamInfo,
-        statuses,
-        substates,
+        streamStates,
       );
       streamMetadata[streamInfo.name] = metadata;
     }
@@ -482,14 +479,14 @@ export class WebviewUpdater {
   private buildStreamMetadataForStream(
     state: ProgressViewState,
     streamInfo: StreamTabInfo,
-    statuses?: Map<string, StreamPhase>,
-    substates?: Map<string, StreamSubstate>,
+    streamStates?: Map<StreamTabId, StreamPhaseState>,
   ): StreamMetadata {
     const current = state.getStreamState(streamInfo.name);
+    const streamState = streamStates?.get(streamInfo.name);
     return buildStreamMetadata({
       kind: streamInfo.agentCategory,
-      status: statuses?.get(streamInfo.name),
-      substate: substates?.get(streamInfo.name),
+      status: streamState?.phase,
+      substate: streamState?.substate,
       lastTimestamp: state.streamLogs.getLastTimestamp(streamInfo.name),
       conversationProgress: current?.conversationProgress,
       roundStage: current?.roundStage,

--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -1,5 +1,6 @@
 import type { AgentTrace } from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import type { StreamPhaseState } from '@agent/runtime/StreamStatusService';
 import { isInFlightStatus } from '@common/constants/streamStatus';
 import type {
   ProgressEventBusLike,
@@ -366,8 +367,7 @@ export class ProgressEventHandler {
       this.webviewUpdater.updateStreamMetadata(
         this.state,
         streamId,
-        this.state.streamStatus.getAll(),
-        this.state.streamStatus.getAllSubstates(),
+        this.state.streamStatus.getAllStreamStates(),
         {
           activeStream: shouldSwitch ? this.state.activeStream : undefined,
           agentFilter: filterChanged
@@ -408,8 +408,7 @@ export class ProgressEventHandler {
       this.webviewUpdater.updateStreamMetadata(
         this.state,
         streamId,
-        this.state.streamStatus.getAll(),
-        this.state.streamStatus.getAllSubstates(),
+        this.state.streamStatus.getAllStreamStates(),
         {
           agentFilter: isActiveStream
             ? this.state.agentCategoryFilter
@@ -690,19 +689,10 @@ export class ProgressEventHandler {
         }
         activeStream = nextActiveStream;
       }
-      const statusesForRefresh = this.state.streamStatus.getAll();
-      statusesForRefresh.set(streamId, status);
-      const substatesForRefresh = this.state.streamStatus.getAllSubstates();
-      if (substate) {
-        substatesForRefresh.set(streamId, substate);
-      } else {
-        substatesForRefresh.delete(streamId);
-      }
       this.webviewUpdater.updateStreamMetadata(
         this.state,
         streamId,
-        statusesForRefresh,
-        substatesForRefresh,
+        this.buildStreamStatesForRefresh(streamId, status, substate),
         {
           activeStream,
           agentFilter: this.state.agentCategoryFilter,
@@ -712,19 +702,10 @@ export class ProgressEventHandler {
         await this.syncFilterDrivenActiveStreamContent(activeStreamToSync);
       }
     } else if (isNewRunningTransition) {
-      const statusesForRefresh = this.state.streamStatus.getAll();
-      statusesForRefresh.set(streamId, status);
-      const substatesForRefresh = this.state.streamStatus.getAllSubstates();
-      if (substate) {
-        substatesForRefresh.set(streamId, substate);
-      } else {
-        substatesForRefresh.delete(streamId);
-      }
       this.webviewUpdater.updateStreamMetadata(
         this.state,
         streamId,
-        statusesForRefresh,
-        substatesForRefresh,
+        this.buildStreamStatesForRefresh(streamId, status, substate),
       );
     } else {
       const lastTimestamp = this.state.streamLogs.getLastTimestamp(streamId);
@@ -762,11 +743,26 @@ export class ProgressEventHandler {
     );
   }
 
-  getAllStreamStatuses(): Map<StreamTabId, StreamPhase> {
-    return this.state.streamStatus.getAll();
+  getAllStreamStates(): Map<StreamTabId, StreamPhaseState> {
+    return this.state.streamStatus.getAllStreamStates();
   }
 
-  getAllStreamSubstates(): Map<StreamTabId, StreamSubstate> {
-    return this.state.streamStatus.getAllSubstates();
+  /**
+   * Snapshot the status machine and splice in `streamId`'s about-to-be-applied
+   * status/substate, which hasn't been written to the machine yet when this
+   * is called during `setStreamStatus`. Combined into one map so the phase
+   * and substate views can't diverge on which streams they cover.
+   */
+  private buildStreamStatesForRefresh(
+    streamId: StreamTabId,
+    status: StreamPhase,
+    substate?: StreamSubstate,
+  ): Map<StreamTabId, StreamPhaseState> {
+    const statesForRefresh = this.state.streamStatus.getAllStreamStates();
+    statesForRefresh.set(
+      streamId,
+      substate ? { phase: status, substate } : { phase: status },
+    );
+    return statesForRefresh;
   }
 }

--- a/src/shared/progressView/backend/state/ProgressViewState.ts
+++ b/src/shared/progressView/backend/state/ProgressViewState.ts
@@ -19,7 +19,7 @@ import {
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
   type EndGroupStatus,
-  StreamTabInfoSchema,
+  StreamTabInfoBaseSchema,
   type ActiveChildInfo,
   type AgentCategoryFilter,
   type ConversationProgress,
@@ -42,7 +42,7 @@ import { SessionStores } from './SessionStores';
 const LEGACY_INSTRUCTION_BACKFILL_CONCURRENCY = 8;
 
 /** Ephemeral stream metadata hints, displayed before TaskState is fully populated. */
-export const StreamHintsSchema = StreamTabInfoSchema.pick({
+export const StreamHintsSchema = StreamTabInfoBaseSchema.pick({
   agent: true,
   agentCategory: true,
   inputFile: true,

--- a/src/shared/progressView/backend/streamTabInfo.ts
+++ b/src/shared/progressView/backend/streamTabInfo.ts
@@ -85,14 +85,9 @@ export function buildStreamTabInfo(inputs: StreamTabInfoInputs): StreamTabInfo {
       ? { workingDirectory: config.workingDirectory }
       : undefined);
 
-  return {
+  const base = {
     name: streamId,
     label,
-    model: processAgent ? undefined : config?.model,
-    modelLabel:
-      !processAgent && config?.model
-        ? (MODEL_CONFIGS[config.model]?.label ?? config.model)
-        : undefined,
     agent: resolvedAgent,
     agentCategory: category,
     isRemote,
@@ -101,7 +96,17 @@ export function buildStreamTabInfo(inputs: StreamTabInfoInputs): StreamTabInfo {
     executionId: inputs.executionId,
     parentStreamId: inputs.parentStreamId,
     description: inputs.description,
-    command,
     worktree,
   };
+
+  return processAgent
+    ? { ...base, kind: 'process', command }
+    : {
+        ...base,
+        kind: 'agent',
+        model: config?.model,
+        modelLabel: config?.model
+          ? (MODEL_CONFIGS[config.model]?.label ?? config.model)
+          : undefined,
+      };
 }

--- a/src/shared/schemas/contextManagement.ts
+++ b/src/shared/schemas/contextManagement.ts
@@ -28,12 +28,7 @@ const MaxTokensReducedDataSchema = ContextManagementDataBaseSchema.extend({
 });
 
 const TokensFreedDataSchema = ContextManagementDataBaseSchema.extend({
-  action: z.enum([
-    'compaction',
-    'clear_tool_uses',
-    'clear_thinking',
-    'truncation',
-  ]),
+  action: ContextManagementAction.exclude(['max_tokens_reduced']),
   tokensAfter: TokenCountSchema,
   utilizationAfter: z.number().nonnegative(),
 });

--- a/src/shared/schemas/contextManagement.ts
+++ b/src/shared/schemas/contextManagement.ts
@@ -33,10 +33,36 @@ const TokensFreedDataSchema = ContextManagementDataBaseSchema.extend({
   utilizationAfter: z.number().nonnegative(),
 });
 
-export const ContextManagementDataSchema = z.discriminatedUnion('action', [
-  MaxTokensReducedDataSchema,
-  TokensFreedDataSchema,
-]);
+/**
+ * Persisted stream-log entries predate this discriminated union, when
+ * `tokensAfter`/`utilizationAfter` were merely `.optional()` on every action.
+ * Default them from the before-values on read so an older log entry that
+ * omitted them still parses (reporting no measured change) instead of
+ * silently vanishing from the progress view.
+ */
+function fillLegacyTokensFreedFields(raw: unknown): unknown {
+  if (
+    typeof raw !== 'object' ||
+    raw === null ||
+    (raw as { action?: unknown }).action === 'max_tokens_reduced'
+  ) {
+    return raw;
+  }
+  const data = raw as Record<string, unknown>;
+  return {
+    ...data,
+    tokensAfter: data.tokensAfter ?? data.tokensBefore,
+    utilizationAfter: data.utilizationAfter ?? data.utilizationBefore,
+  };
+}
+
+export const ContextManagementDataSchema = z.preprocess(
+  fillLegacyTokensFreedFields,
+  z.discriminatedUnion('action', [
+    MaxTokensReducedDataSchema,
+    TokensFreedDataSchema,
+  ]),
+);
 
 export type ContextManagementData = z.infer<typeof ContextManagementDataSchema>;
 

--- a/src/shared/schemas/contextManagement.ts
+++ b/src/shared/schemas/contextManagement.ts
@@ -13,18 +13,35 @@ export type ContextManagementAction = z.infer<typeof ContextManagementAction>;
 
 const PositiveTokenCountSchema = z.int().positive();
 
-export const ContextManagementDataSchema = z.object({
-  action: ContextManagementAction,
+const ContextManagementDataBaseSchema = z.object({
   tokensBefore: TokenCountSchema,
-  tokensAfter: TokenCountSchema.optional(),
   contextWindow: PositiveTokenCountSchema,
   utilizationBefore: z.number().nonnegative(),
-  utilizationAfter: z.number().nonnegative().optional(),
   details: z.string().optional(),
   summary: z.string().optional(),
-  originalMaxTokens: PositiveTokenCountSchema.optional(),
-  reducedMaxTokens: PositiveTokenCountSchema.optional(),
 });
+
+const MaxTokensReducedDataSchema = ContextManagementDataBaseSchema.extend({
+  action: z.literal('max_tokens_reduced'),
+  originalMaxTokens: PositiveTokenCountSchema,
+  reducedMaxTokens: PositiveTokenCountSchema,
+});
+
+const TokensFreedDataSchema = ContextManagementDataBaseSchema.extend({
+  action: z.enum([
+    'compaction',
+    'clear_tool_uses',
+    'clear_thinking',
+    'truncation',
+  ]),
+  tokensAfter: TokenCountSchema,
+  utilizationAfter: z.number().nonnegative(),
+});
+
+export const ContextManagementDataSchema = z.discriminatedUnion('action', [
+  MaxTokensReducedDataSchema,
+  TokensFreedDataSchema,
+]);
 
 export type ContextManagementData = z.infer<typeof ContextManagementDataSchema>;
 

--- a/src/shared/schemas/errors.ts
+++ b/src/shared/schemas/errors.ts
@@ -37,6 +37,69 @@ function normalizeProviderErrorRetryFlag(value: unknown): unknown {
   };
 }
 
+/** Reason a credential/quota is exhausted, requiring the user to switch
+ *  credentials before any retry can succeed. The three reasons are mutually
+ *  exclusive — a single error is classified as exactly one — which is why
+ *  this is a discriminant rather than independent booleans (see
+ *  `isCredentialExhausted` below for the pre-refactor combined check). */
+export const ExhaustionReasonSchema = z.enum([
+  /** Relay monthly spending limit reached; the stored personal key is fine. */
+  'relay-limit',
+  /** The upstream provider account itself is out of credit/quota — the key
+   *  the user has IS the broken one, so a new key is required. */
+  'upstream-credit',
+  /** A ChatGPT-subscription (Codex) request was rejected because the plan's
+   *  usage quota is exhausted; accepting the switch disables the "prefer
+   *  ChatGPT subscription" preference rather than disabling relay. */
+  'chatgpt-subscription',
+]);
+export type ExhaustionReason = z.infer<typeof ExhaustionReasonSchema>;
+
+/** Migrates the pre-refactor independent `isCredentialExhausted` /
+ *  `isUpstreamCreditDepleted` / `isChatGptSubscriptionLimited` booleans (still
+ *  present in error data persisted to disk by older TeXRA versions — stream
+ *  logs are unversioned JSON reparsed on later loads) into `exhaustionReason`.
+ *  Priority mirrors the original derivation order in `formatProviderHttpError`:
+ *  ChatGPT-subscription and upstream-credit were independently detected and
+ *  OR'd into `isCredentialExhausted` alongside the relay-limit condition, so a
+ *  legacy record with only `isCredentialExhausted: true` set reconstructs as
+ *  `'relay-limit'`. */
+function normalizeLegacyExhaustionFlags(value: unknown): unknown {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return value;
+  }
+  const data = value as Record<string, unknown>;
+  if ('exhaustionReason' in data) {
+    return value;
+  }
+  const hasLegacyFlags =
+    'isCredentialExhausted' in data ||
+    'isUpstreamCreditDepleted' in data ||
+    'isChatGptSubscriptionLimited' in data;
+  if (!hasLegacyFlags) {
+    return value;
+  }
+  const {
+    isCredentialExhausted,
+    isUpstreamCreditDepleted,
+    isChatGptSubscriptionLimited,
+    ...rest
+  } = data;
+  const exhaustionReason: ExhaustionReason | undefined =
+    isChatGptSubscriptionLimited === true
+      ? 'chatgpt-subscription'
+      : isUpstreamCreditDepleted === true
+        ? 'upstream-credit'
+        : isCredentialExhausted === true
+          ? 'relay-limit'
+          : undefined;
+  return exhaustionReason === undefined ? rest : { ...rest, exhaustionReason };
+}
+
+function normalizeLegacyProviderErrorFields(value: unknown): unknown {
+  return normalizeLegacyExhaustionFlags(normalizeProviderErrorRetryFlag(value));
+}
+
 /** Core error details from a provider/SDK */
 const ProviderErrorObjectSchema = z.object({
   message: z.string(),
@@ -51,26 +114,17 @@ const ProviderErrorObjectSchema = z.object({
    *  before any retry makes sense). */
   userRetryable: z.boolean(),
   /** True when the error is known to come from the relay. Omitted when the
-   *  retry-state path cannot determine the relay verdict. */
+   *  retry-state path cannot determine the relay verdict. Independent of
+   *  `exhaustionReason` — a relay error can be a transient 5xx with no
+   *  exhaustion, and an exhaustion can be direct-to-provider (upstream credit
+   *  depletion) with no relay involved. */
   isRelayError: z.boolean().optional(),
-  /** True when the credential (relay monthly limit OR upstream provider
-   *  account) has been exhausted. Auto-retry is skipped for these errors
-   *  and the retry panel offers a "Use your own API key" button. */
-  isCredentialExhausted: z.boolean().optional(),
-  /** True when the upstream provider account itself is out of credit
-   *  (Anthropic 400 "credit balance is too low"). Distinguishes the
-   *  "the key I have IS the broken one" case from relay monthly limit,
-   *  where the stored personal key is fine. The auto-resume handler
-   *  uses this to require a new key rather than reusing the depleted
-   *  stored credential. */
-  isUpstreamCreditDepleted: z.boolean().optional(),
-  /** True when a ChatGPT-subscription (Codex) request was rejected because the
-   *  plan's usage quota is exhausted. Like the relay monthly limit it is a
-   *  credential exhaustion (auto-retry suppressed, "Use your own API key"
-   *  offered), but accepting that switch disables the "prefer ChatGPT
-   *  subscription" preference and retries through the OpenAI API key rather
-   *  than disabling relay. */
-  isChatGptSubscriptionLimited: z.boolean().optional(),
+  /** Reason the credential/quota is exhausted (relay monthly limit, upstream
+   *  provider credit depletion, or ChatGPT-subscription usage limit). Auto-
+   *  retry is skipped and the retry panel offers a "Use your own API key"
+   *  button for any of these. Use the `isCredentialExhausted` helper below
+   *  for the pre-refactor combined boolean check. */
+  exhaustionReason: ExhaustionReasonSchema.optional(),
   requestId: z.string().optional(),
   rawErrorBody: z.unknown().optional(),
   streamDiagnostics: StreamDiagnosticsSchema.optional(),
@@ -82,7 +136,7 @@ const ProviderErrorObjectSchema = z.object({
   partialText: z.string().optional(),
 });
 const ProviderErrorSchema = z.preprocess(
-  normalizeProviderErrorRetryFlag,
+  normalizeLegacyProviderErrorFields,
   ProviderErrorObjectSchema,
 );
 export type ProviderError = z.infer<typeof ProviderErrorSchema>;
@@ -96,7 +150,7 @@ export type ErrorContext = z.infer<typeof ErrorContextSchema>;
 
 /** Complete error log data - combines provider error with context */
 export const ErrorLogDataSchema = z.preprocess(
-  normalizeProviderErrorRetryFlag,
+  normalizeLegacyProviderErrorFields,
   ProviderErrorObjectSchema.extend(ErrorContextSchema.shape).extend({
     rawMessage: z.string().optional(),
   }),
@@ -105,7 +159,7 @@ export type ErrorLogData = z.infer<typeof ErrorLogDataSchema>;
 
 /** Provider error with all fields optional for event transport */
 export const ProviderErrorPartialSchema = z.preprocess(
-  normalizeProviderErrorRetryFlag,
+  normalizeLegacyProviderErrorFields,
   ProviderErrorObjectSchema.partial(),
 );
 export type ProviderErrorPartial = z.infer<typeof ProviderErrorPartialSchema>;
@@ -114,13 +168,34 @@ export type ProviderErrorPartial = z.infer<typeof ProviderErrorPartialSchema>;
  *  usage-limit rejection". Both hosts (VS Code progress view, CLI approval
  *  policy) branch on this to switch the retry from the relay/personal-key path
  *  to disabling the subscription preference. Accepts any error shape carrying
- *  the flag (full `ProviderError`, `ProviderErrorPartial`, or `RetryErrorInfo`)
+ *  the field (full `ProviderError`, `ProviderErrorPartial`, or `RetryErrorInfo`)
  *  so the predicate stays the one place that owns the verdict. */
 export function isChatGptSubscriptionLimitError(
-  errorDetails:
-    Pick<ProviderError, 'isChatGptSubscriptionLimited'> | undefined | null,
+  errorDetails: Pick<ProviderError, 'exhaustionReason'> | undefined | null,
 ): boolean {
-  return errorDetails?.isChatGptSubscriptionLimited === true;
+  return errorDetails?.exhaustionReason === 'chatgpt-subscription';
+}
+
+/** Single source of truth for "the upstream provider account itself is out of
+ *  credit/quota" — the key the user has IS the broken one, so the auto-resume
+ *  handler must require a new key rather than reusing the depleted stored
+ *  credential (unlike relay-limit exhaustion, where the stored personal key
+ *  is fine). */
+export function isUpstreamCreditDepletedError(
+  errorDetails: Pick<ProviderError, 'exhaustionReason'> | undefined | null,
+): boolean {
+  return errorDetails?.exhaustionReason === 'upstream-credit';
+}
+
+/** Single source of truth for "auto-retry should be skipped because the
+ *  credential/quota is exhausted" — the combined check the pre-refactor
+ *  `isCredentialExhausted` boolean used to store directly. Kept as a derived
+ *  predicate (not a stored field) so the three exhaustion reasons can't drift
+ *  out of sync with it. */
+export function isCredentialExhausted(
+  errorDetails: Pick<ProviderError, 'exhaustionReason'> | undefined | null,
+): boolean {
+  return errorDetails?.exhaustionReason !== undefined;
 }
 
 /**
@@ -135,7 +210,7 @@ export function isChatGptSubscriptionLimitError(
  * error fields are added.
  */
 export const RetryErrorInfoSchema = z.preprocess(
-  normalizeProviderErrorRetryFlag,
+  normalizeLegacyProviderErrorFields,
   ProviderErrorObjectSchema.omit({ rawErrorBody: true }),
 );
 export type RetryErrorInfo = z.infer<typeof RetryErrorInfoSchema>;

--- a/src/shared/schemas/errors.ts
+++ b/src/shared/schemas/errors.ts
@@ -31,9 +31,14 @@ function normalizeProviderErrorRetryFlag(value: unknown): unknown {
   if ('userRetryable' in data || typeof data.retryable !== 'boolean') {
     return value;
   }
+  // Drop the legacy key rather than merely adding `userRetryable` alongside
+  // it: callers that use this migration directly (not just as a
+  // z.preprocess step ahead of an object schema that would otherwise strip
+  // it) must not see a stale `retryable` field on the result.
+  const { retryable, ...rest } = data;
   return {
-    ...data,
-    userRetryable: data.retryable,
+    ...rest,
+    userRetryable: retryable,
   };
 }
 
@@ -96,7 +101,16 @@ function normalizeLegacyExhaustionFlags(value: unknown): unknown {
   return exhaustionReason === undefined ? rest : { ...rest, exhaustionReason };
 }
 
-function normalizeLegacyProviderErrorFields(value: unknown): unknown {
+/**
+ * Migrates the legacy `retryable`/exhaustion-boolean fields on a raw provider
+ * error value into the canonical `userRetryable`/`exhaustionReason` shape.
+ * Used both as the `z.preprocess` step for schemas below and directly by
+ * `normalizeProviderError` (`@common/errors/sdkError/providerErrorFormat`) so
+ * a cached `ProviderError` — attached before this migration ran, e.g. from a
+ * resumed flow's raw persisted state — is normalized the same way a freshly
+ * formatted error is, instead of being returned with legacy fields intact.
+ */
+export function normalizeLegacyProviderErrorFields(value: unknown): unknown {
   return normalizeLegacyExhaustionFlags(normalizeProviderErrorRetryFlag(value));
 }
 

--- a/src/shared/schemas/output.ts
+++ b/src/shared/schemas/output.ts
@@ -52,6 +52,18 @@ export const FileLineageSchema = z.strictObject({
   diffBase: FileLocationSchema.nullable(),
   diffFile: FileLocationSchema.nullable(),
 });
+export type FileLineage = z.infer<typeof FileLineageSchema>;
+
+/**
+ * The file location a diff should render against: the explicit `diffBase`
+ * when the file was rewritten in place (so a diff against the current path
+ * would show no change), falling back to `original`.
+ */
+export function getEffectiveDiffBase(
+  lineage: FileLineage | null | undefined,
+): FileLocation | null {
+  return lineage?.diffBase ?? lineage?.original ?? null;
+}
 
 export const OutputFileInfoSchema = OutputFileSchema.extend({
   round: z.number().prefault(() => 0),
@@ -167,10 +179,7 @@ export const OutputFileSummaryFromInfoSchema = OutputFileInfoSchema.transform(
     relativePath: displayPath(output.location),
     absolutePath: output.location.absolutePath,
     location: output.location.kind,
-    originalPath:
-      output.lineage?.diffBase?.absolutePath ??
-      output.lineage?.original?.absolutePath ??
-      null,
+    originalPath: getEffectiveDiffBase(output.lineage)?.absolutePath ?? null,
     added: output.diff?.added ?? null,
     removed: output.diff?.removed ?? null,
   }),

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -288,11 +288,18 @@ export const WorktreeInfoSchema = z.object({
 });
 export type WorktreeInfo = z.infer<typeof WorktreeInfoSchema>;
 
-export const StreamTabInfoSchema = z.object({
+/**
+ * Fields shared by every stream tab regardless of what's running underneath
+ * it — split out (rather than folded into the discriminated union below) so
+ * consumers that only need the common metadata (e.g. `StreamHintsSchema` in
+ * `ProgressViewState.ts`) can `.pick()` from a plain object schema; Zod's
+ * discriminated unions don't support `.pick()`/`.partial()` directly.
+ */
+export const StreamTabInfoBaseSchema = z.object({
   name: z.string(),
   label: z.string(),
-  model: z.string().optional(),
-  modelLabel: z.string().optional(),
+  /** Name of the agent/tool that launched the stream (e.g. "bash",
+   * "paper-polish"). Present for both agent and process streams. */
   agent: z.string().optional(),
   agentCategory: AgentCategorySchema,
   isRemote: z.boolean().optional(),
@@ -302,11 +309,28 @@ export const StreamTabInfoSchema = z.object({
   parentStreamId: StreamTabIdSchema.optional(),
   /** AI-generated summary of what this session aims to accomplish. */
   description: z.string().optional(),
-  /** Full, untruncated command that spawned a process-agent stream (e.g. bash).
-   * Set only for process streams; used by the process stream view. */
-  command: z.string().optional(),
   /** Git worktree / PR context for streams whose agents operate in a
    * worktree other than the workspace root. Surfaced as a chip on the tab. */
   worktree: WorktreeInfoSchema.optional(),
 });
+
+/**
+ * Discriminated on `kind`: a stream tab is either a live LLM-driven "agent"
+ * run (carries `model`/`modelLabel`) or a raw OS "process" stream such as the
+ * `bash` tool (carries `command`, no meaningful model). Renderers switch on
+ * `kind` instead of probing which of `model`/`command` happens to be set.
+ */
+export const StreamTabInfoSchema = z.discriminatedUnion('kind', [
+  StreamTabInfoBaseSchema.extend({
+    kind: z.literal('agent'),
+    model: z.string().optional(),
+    modelLabel: z.string().optional(),
+  }),
+  StreamTabInfoBaseSchema.extend({
+    kind: z.literal('process'),
+    /** Full, untruncated command that spawned this stream; used by the
+     * process stream view. */
+    command: z.string().optional(),
+  }),
+]);
 export type StreamTabInfo = z.infer<typeof StreamTabInfoSchema>;

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -18,24 +18,42 @@ import { TodoItemSchema } from './todo';
 import { ContextStateDataSchema } from './contextManagement';
 import { RunUsageMapSchema, TokenUsageStatsSchema } from './usage';
 
-// Active Child Info (shared shape for subagent and process badges)
+// Active Child Info — discriminated by `kind` rather than by which array the
+// entry came from (`activeSubagents` vs `activeProcesses`) or by guessing from
+// which optional field happens to be set. Only `childStreamId` is genuinely
+// exclusive to one kind (only subagents own a stream tab); `toolName` can
+// appear on either kind — e.g. a subagent launched via a specific CLI tool
+// (`options.toolName` in `createChildStream`), or a background process running
+// a named tool (`bash`, `codex`) — so it stays a shared, optional field.
 
-export const ActiveChildInfoSchema = z.object({
+const ActiveChildInfoBaseSchema = z.object({
   executionId: z.string(),
   agentName: z.string(),
-  /** Stream tab ID for subagents (they have their own tab). Absent for processes. */
-  childStreamId: z.string().optional(),
   /** Current execution status (e.g. "running", "waiting"). Defaults to "running". */
   status: z.string().optional(),
   /** Epoch milliseconds when the child execution began. */
   startedAt: z.int().positive().optional(),
   /** Formatted elapsed time (e.g. "1m 23s"). */
   elapsed: z.string().nullish(),
-  /** Tool name that spawned this process (e.g. "bash", "codex"). Absent for subagents. */
+  /** Tool that spawned this child (e.g. "bash", "codex"). Used for icon/label
+   *  selection in the UI; may be set on either kind. */
   toolName: z.string().optional(),
 });
 
+export const ActiveChildInfoSchema = z.discriminatedUnion('kind', [
+  ActiveChildInfoBaseSchema.extend({
+    kind: z.literal('subagent'),
+    /** Stream tab ID — subagents own their own tab. */
+    childStreamId: z.string(),
+  }),
+  ActiveChildInfoBaseSchema.extend({
+    kind: z.literal('process'),
+  }),
+]);
+
 export type ActiveChildInfo = z.infer<typeof ActiveChildInfoSchema>;
+export type SubagentChildInfo = Extract<ActiveChildInfo, { kind: 'subagent' }>;
+export type ProcessChildInfo = Extract<ActiveChildInfo, { kind: 'process' }>;
 
 // Round Stage (ephemeral round label from typed stage.start metadata)
 

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -40,16 +40,42 @@ const ActiveChildInfoBaseSchema = z.object({
   toolName: z.string().optional(),
 });
 
-export const ActiveChildInfoSchema = z.discriminatedUnion('kind', [
-  ActiveChildInfoBaseSchema.extend({
-    kind: z.literal('subagent'),
-    /** Stream tab ID — subagents own their own tab. */
-    childStreamId: z.string(),
-  }),
-  ActiveChildInfoBaseSchema.extend({
-    kind: z.literal('process'),
-  }),
-]);
+/**
+ * Persisted/replayed ActiveChildInfo entries predate the `kind` discriminant,
+ * when subagent vs. process was inferred from array membership
+ * (`activeSubagents` vs. `activeProcesses`) or from whether `childStreamId`
+ * happened to be set. `childStreamId` was — and still is — exclusive to
+ * subagents, so backfill `kind` from that same signal on read, matching the
+ * legacy inference, instead of failing to parse.
+ */
+function fillLegacyActiveChildKind(raw: unknown): unknown {
+  if (
+    typeof raw !== 'object' ||
+    raw === null ||
+    (raw as { kind?: unknown }).kind !== undefined
+  ) {
+    return raw;
+  }
+  const data = raw as Record<string, unknown>;
+  return {
+    ...data,
+    kind: typeof data.childStreamId === 'string' ? 'subagent' : 'process',
+  };
+}
+
+export const ActiveChildInfoSchema = z.preprocess(
+  fillLegacyActiveChildKind,
+  z.discriminatedUnion('kind', [
+    ActiveChildInfoBaseSchema.extend({
+      kind: z.literal('subagent'),
+      /** Stream tab ID — subagents own their own tab. */
+      childStreamId: z.string(),
+    }),
+    ActiveChildInfoBaseSchema.extend({
+      kind: z.literal('process'),
+    }),
+  ]),
+);
 
 export type ActiveChildInfo = z.infer<typeof ActiveChildInfoSchema>;
 export type SubagentChildInfo = Extract<ActiveChildInfo, { kind: 'subagent' }>;

--- a/src/test-kernel/agent/index/StreamTabInfo.vitest.ts
+++ b/src/test-kernel/agent/index/StreamTabInfo.vitest.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 
 import { AgentCategory } from '@shared/schemas';
 import { buildStreamTabInfo } from '@shared/progressView/backend/streamTabInfo';
-import { isProcessAgent } from '@shared/streams/agentKind';
 
 describe('buildStreamTabInfo', () => {
   it('classifies stream-id-derived bash child streams as process agents', () => {
@@ -16,7 +15,6 @@ describe('buildStreamTabInfo', () => {
 
     expect(info.label).toBe('bash');
     expect(info.agent).toBe('bash');
-    expect(isProcessAgent(info.agent)).toBe(true);
-    expect(info.model).toBeUndefined();
+    expect(info.kind).toBe('process');
   });
 });

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsToolUse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsToolUse.vitest.ts
@@ -330,9 +330,11 @@ describe('ModelHandlerGoogleInteractions tool use', () => {
     ];
 
     const followUp = await handler.createBatchedToolUseFollowUpMessages!(
-      calls,
-      results,
-      [[], []],
+      calls.map((call, index) => ({
+        call,
+        result: results[index],
+        attachments: [],
+      })),
       workspace,
       'thinking done',
     );

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerDeepSeek.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerDeepSeek.vitest.ts
@@ -299,25 +299,28 @@ describe('ModelHandlerDeepSeek tool conversion', () => {
     const messages = await handler.createBatchedToolUseFollowUpMessages(
       [
         {
-          raw: {
-            id: 'call_1',
-            type: 'function',
-            function: { name: 'first_tool', arguments: '{}' },
+          call: {
+            raw: {
+              id: 'call_1',
+              type: 'function',
+              function: { name: 'first_tool', arguments: '{}' },
+            },
           },
+          result: { status: 'executed', output: 'first result' },
+          attachments: [],
         },
         {
-          raw: {
-            id: 'call_2',
-            type: 'function',
-            function: { name: 'second_tool', arguments: '{}' },
+          call: {
+            raw: {
+              id: 'call_2',
+              type: 'function',
+              function: { name: 'second_tool', arguments: '{}' },
+            },
           },
+          result: { status: 'executed', output: 'second result' },
+          attachments: [],
         },
       ] as any,
-      [
-        { status: 'executed', output: 'first result' },
-        { status: 'executed', output: 'second result' },
-      ],
-      [[], []],
       workspace as any,
       '',
     );
@@ -357,15 +360,17 @@ describe('ModelHandlerDeepSeek tool conversion', () => {
     const messages = await handler.createBatchedToolUseFollowUpMessages(
       [
         {
-          raw: {
-            id: 'call_1',
-            type: 'function',
-            function: { name: 'some_tool', arguments: '{}' },
+          call: {
+            raw: {
+              id: 'call_1',
+              type: 'function',
+              function: { name: 'some_tool', arguments: '{}' },
+            },
           },
+          result: { status: 'executed', output: 'result' },
+          attachments: [],
         },
       ] as any,
-      [{ status: 'executed', output: 'result' }],
-      [[]],
       workspace as any,
       '',
     );

--- a/src/test-kernel/agent/modelHandlers/OpenAIMessageUtils.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIMessageUtils.vitest.ts
@@ -4,7 +4,6 @@ import { describe, it } from 'vitest';
 
 // Local imports - agent
 import {
-  checkBatchedToolCalls,
   insertMediaIntoChatUserMessage,
   normalizeOpenAIMessageContent,
   prependTextToChatUserMessage,
@@ -197,28 +196,6 @@ describe('normalizeOpenAIMessageContent', () => {
     assert.equal(normalized.length, 3);
     assert.equal(normalized[1].tool_call_id, 'call_1');
     assert.equal(normalized[2].tool_call_id, 'call_2');
-  });
-});
-
-describe('checkBatchedToolCalls', () => {
-  it('throws on a call/result count mismatch', () => {
-    assert.throws(
-      () => checkBatchedToolCalls(2, 1),
-      /Batched tool calls mismatch: 2 calls vs 1 results/,
-    );
-  });
-
-  it('returns false when there is nothing to send', () => {
-    assert.equal(checkBatchedToolCalls(0, 0), false);
-  });
-
-  it('returns true when counts match and are non-empty', () => {
-    assert.equal(checkBatchedToolCalls(3, 3), true);
-  });
-
-  it('reports the mismatch before the empty check', () => {
-    // A zero call count with a non-zero result count is still a mismatch.
-    assert.throws(() => checkBatchedToolCalls(0, 2), /0 calls vs 2 results/);
   });
 });
 

--- a/src/test-kernel/agent/modelHandlers/OpenAIResponseErrors.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIResponseErrors.vitest.ts
@@ -32,8 +32,7 @@ describe('OpenAI Responses error normalization', () => {
     const providerError = normalizeOpenAIResponseError(error, 'openai');
 
     expect(providerError.provider).toBe('openai');
-    expect(providerError.isCredentialExhausted).toBe(true);
-    expect(providerError.isUpstreamCreditDepleted).toBe(true);
+    expect(providerError.exhaustionReason).toBe('upstream-credit');
     expect(providerError.userRetryable).toBe(true);
   });
 

--- a/src/test-kernel/agent/runtime/LegacyProgressEventProjection.vitest.ts
+++ b/src/test-kernel/agent/runtime/LegacyProgressEventProjection.vitest.ts
@@ -20,6 +20,7 @@ describe('LegacyProgressEventProjection', () => {
     const childStreamId = 'stream:child' as StreamTabId;
     const executionId = 'exec:process-output' as ExecutionId;
     const child: ActiveChildInfo = {
+      kind: 'subagent',
       executionId: 'exec:child' as ExecutionId,
       childStreamId,
       agentName: 'orchestrator',
@@ -28,6 +29,7 @@ describe('LegacyProgressEventProjection', () => {
       elapsed: null,
     };
     const process: ActiveChildInfo = {
+      kind: 'process',
       executionId,
       agentName: 'bash',
       status: 'running',

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.mts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.mts
@@ -59,7 +59,7 @@ const credentialExhaustedRetry: ProgressEventPayloads['showRetryRequest'] = {
   operation: 'Tool-use call',
   errorMessage: 'HTTP 429 Too Many Requests',
   errorDetails: {
-    isCredentialExhausted: true,
+    exhaustionReason: 'relay-limit',
     isRelayError: true,
     statusCode: 429,
   },
@@ -526,7 +526,7 @@ describe('formatRetryRequestMessage', () => {
       errorMessage:
         'HTTP 429 Too Many Requests – 429 Monthly spending limit reached ($300).',
       errorDetails: {
-        isCredentialExhausted: true,
+        exhaustionReason: 'relay-limit',
         isRelayError: false,
         statusCode: 429,
       },

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -113,22 +113,27 @@ function slice(
 describe('CLI child execution controls', () => {
   it('maps Alt-number focus jumps to visible descendant streams', () => {
     const root = slice({
+      // Only subagents own a stream tab, so both live-only ("agent-1", still in
+      // activeSubagents but not yet retained in childStreams) and
+      // retained ("agent-2") subagent rows are valid focus-jump targets —
+      // background processes never are.
       activeSubagents: [
         {
+          kind: 'subagent',
           executionId: 'agent-1',
           agentName: 'critic',
           childStreamId: 'child-a',
         },
-      ],
-      activeProcesses: [
         {
-          executionId: 'proc-1',
+          kind: 'subagent',
+          executionId: 'agent-3',
           agentName: 'bash',
           childStreamId: 'child-b',
         },
       ],
       childStreams: [
         {
+          kind: 'subagent',
           executionId: 'agent-2',
           agentName: 'critic',
           childStreamId: 'child-c',
@@ -171,6 +176,7 @@ describe('CLI child execution controls', () => {
     const root = slice({
       activeSubagents: [
         {
+          kind: 'subagent',
           executionId: 'agent-1',
           agentName: 'critic',
           childStreamId: 'child-a',
@@ -178,6 +184,7 @@ describe('CLI child execution controls', () => {
       ],
       childStreams: [
         {
+          kind: 'subagent',
           executionId: 'agent-2',
           agentName: 'reviewer',
           childStreamId: 'child-b',
@@ -219,6 +226,7 @@ describe('CLI child execution controls', () => {
     const state = slice({
       activeSubagents: [
         {
+          kind: 'subagent',
           executionId: 'agent-1',
           agentName: 'critic',
           childStreamId: 'child-a',
@@ -228,6 +236,7 @@ describe('CLI child execution controls', () => {
       ],
       childStreams: [
         {
+          kind: 'subagent',
           executionId: 'agent-2',
           agentName: 'reviewer',
           childStreamId: 'child-b',
@@ -237,6 +246,7 @@ describe('CLI child execution controls', () => {
       ],
       activeProcesses: [
         {
+          kind: 'process',
           executionId: 'proc-1',
           agentName: 'latexmk',
           status: 'running',
@@ -302,6 +312,7 @@ describe('CLI child execution controls', () => {
     const state = slice({
       activeSubagents: [
         {
+          kind: 'subagent',
           executionId: 'agent-1',
           agentName: 'critic',
           childStreamId: 'child-a',
@@ -312,6 +323,7 @@ describe('CLI child execution controls', () => {
       ],
       activeProcesses: [
         {
+          kind: 'process',
           executionId: 'proc-1',
           agentName: 'latexmk',
           status: 'waiting',
@@ -343,6 +355,7 @@ describe('CLI child execution controls', () => {
     const state = slice({
       activeSubagents: [
         {
+          kind: 'subagent',
           executionId: 'agent-1',
           agentName: 'review',
           childStreamId: 'child-a',
@@ -352,6 +365,7 @@ describe('CLI child execution controls', () => {
       ],
       activeProcesses: [
         {
+          kind: 'process',
           executionId: 'proc-1',
           agentName: 'bash',
           status: STREAM_STATUS.WAITING,
@@ -388,12 +402,16 @@ describe('CLI child execution controls', () => {
     const state = slice({
       activeSubagents: [
         {
+          kind: 'subagent',
+          childStreamId: 'agent-2-stream',
           executionId: 'agent-2',
           agentName: 'critic',
           status: 'running',
           startedAt: 2_000,
         },
         {
+          kind: 'subagent',
+          childStreamId: 'agent-1-stream',
           executionId: 'agent-1',
           agentName: 'reviewer',
           status: 'initializing',
@@ -402,6 +420,7 @@ describe('CLI child execution controls', () => {
       ],
       activeProcesses: [
         {
+          kind: 'process',
           executionId: 'proc-1',
           agentName: 'latexmk',
           status: 'waiting',
@@ -419,6 +438,8 @@ describe('CLI child execution controls', () => {
         slice({
           activeSubagents: [
             {
+              kind: 'subagent',
+              childStreamId: 'agent-1-stream',
               executionId: 'agent-1',
               agentName: 'critic',
               status: 'completed',
@@ -435,6 +456,7 @@ describe('CLI child execution controls', () => {
     const state = slice({
       activeSubagents: [
         {
+          kind: 'subagent',
           executionId: 'agent-1',
           agentName: 'bash',
           childStreamId: 'child-a',
@@ -473,6 +495,7 @@ describe('CLI child execution controls', () => {
     const state = slice({
       activeSubagents: [
         {
+          kind: 'subagent',
           executionId: 'agent-1',
           agentName: 'bash',
           childStreamId: 'child-a',
@@ -535,6 +558,7 @@ describe('CLI child execution controls', () => {
     const state = slice({
       activeSubagents: [
         {
+          kind: 'subagent',
           executionId: 'agent-2',
           agentName: 'polisher',
           childStreamId: 'child-b',
@@ -543,12 +567,14 @@ describe('CLI child execution controls', () => {
       ],
       childStreams: [
         {
+          kind: 'subagent',
           executionId: 'agent-1',
           agentName: 'critic',
           childStreamId: 'child-a',
           status: 'completed',
         },
         {
+          kind: 'subagent',
           executionId: 'agent-2',
           agentName: 'polisher',
           childStreamId: 'child-b',
@@ -581,6 +607,7 @@ describe('CLI child execution controls', () => {
     const state = slice({
       activeSubagents: [
         {
+          kind: 'subagent',
           executionId: 'agent-2',
           agentName: 'polisher',
           childStreamId: 'child-b',
@@ -589,12 +616,14 @@ describe('CLI child execution controls', () => {
       ],
       childStreams: [
         {
+          kind: 'subagent',
           executionId: 'agent-1',
           agentName: 'critic',
           childStreamId: 'child-a',
           status: 'completed',
         },
         {
+          kind: 'subagent',
           executionId: 'agent-2',
           agentName: 'polisher',
           childStreamId: 'child-b',
@@ -605,11 +634,13 @@ describe('CLI child execution controls', () => {
 
     expect(visibleSubagentRows(state)).toMatchObject([
       {
+        kind: 'subagent',
         executionId: 'agent-1',
         childStreamId: 'child-a',
         status: 'completed',
       },
       {
+        kind: 'subagent',
         executionId: 'agent-2',
         childStreamId: 'child-b',
         status: 'running',
@@ -622,6 +653,7 @@ describe('CLI child execution controls', () => {
     const state = slice({
       activeSubagents: [
         {
+          kind: 'subagent',
           executionId: 'agent-2',
           agentName: 'polisher',
           childStreamId: 'child-b',
@@ -630,12 +662,14 @@ describe('CLI child execution controls', () => {
       ],
       childStreams: [
         {
+          kind: 'subagent',
           executionId: 'agent-1',
           agentName: 'critic',
           childStreamId: 'child-a',
           status: 'stopped',
         },
         {
+          kind: 'subagent',
           executionId: 'agent-2',
           agentName: 'polisher',
           childStreamId: 'child-b',
@@ -646,6 +680,7 @@ describe('CLI child execution controls', () => {
 
     expect(buildChildControlItems(state, 'tasks')).toMatchObject([
       {
+        kind: 'subagent',
         executionId: 'agent-1',
         childStreamId: 'child-a',
         label: 'critic',
@@ -653,6 +688,7 @@ describe('CLI child execution controls', () => {
         killable: false,
       },
       {
+        kind: 'subagent',
         executionId: 'agent-2',
         childStreamId: 'child-b',
         label: 'polisher',
@@ -666,6 +702,7 @@ describe('CLI child execution controls', () => {
     const state = slice({
       childStreams: [
         {
+          kind: 'subagent',
           executionId: 'agent-1',
           agentName: 'critic',
           childStreamId: 'child-a',
@@ -682,6 +719,7 @@ describe('CLI child execution controls', () => {
       streamId: 'main',
       activeSubagents: [
         {
+          kind: 'subagent',
           executionId: 'agent-1',
           agentName: 'review',
           childStreamId: 'review-stream',
@@ -718,6 +756,7 @@ describe('CLI child execution controls', () => {
       streamId: 'main',
       activeSubagents: [
         {
+          kind: 'subagent',
           executionId: 'agent-1',
           agentName: 'review',
           childStreamId: 'review-stream',
@@ -753,6 +792,7 @@ describe('CLI child execution controls', () => {
       streamId: 'main',
       activeSubagents: [
         {
+          kind: 'subagent',
           executionId: 'agent-1',
           agentName: 'review',
           childStreamId: 'review-stream',
@@ -792,6 +832,7 @@ describe('CLI child execution controls', () => {
       streamId: 'review-stream',
       activeSubagents: [
         {
+          kind: 'subagent',
           executionId: 'agent-2',
           agentName: 'detail-review',
           childStreamId: 'detail-stream',
@@ -840,6 +881,7 @@ describe('CLI child execution controls', () => {
       streamId: 'main',
       activeSubagents: [
         {
+          kind: 'subagent',
           executionId: 'agent-1',
           agentName: 'review',
           childStreamId: 'review-stream',
@@ -889,6 +931,7 @@ describe('CLI child execution controls', () => {
             streamId: 'main',
             activeSubagents: [
               {
+                kind: 'subagent',
                 executionId: 'agent-1',
                 agentName: 'review',
                 childStreamId: 'review-stream',
@@ -927,6 +970,7 @@ describe('CLI child execution controls', () => {
             streamId: 'main',
             childStreams: [
               {
+                kind: 'subagent',
                 executionId: 'agent-1',
                 agentName: 'review',
                 childStreamId: 'review-stream',
@@ -959,6 +1003,7 @@ describe('CLI child execution controls', () => {
       streamId: 'review-stream',
       activeProcesses: [
         {
+          kind: 'process',
           executionId: 'proc-1',
           agentName: 'latexmk',
           status: 'running',
@@ -976,6 +1021,7 @@ describe('CLI child execution controls', () => {
             streamId: 'main',
             activeSubagents: [
               {
+                kind: 'subagent',
                 executionId: 'agent-1',
                 agentName: 'review',
                 childStreamId: 'review-stream',

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -909,6 +909,7 @@ describe('CLI conversation transcript splitting', () => {
           model: 'deepseekT',
           activeSubagents: [
             {
+              kind: 'subagent',
               executionId: 'ei_search',
               agentName: 'search',
               childStreamId: CHILD,

--- a/src/test-kernel/cli/ResumeHint.vitest.mts
+++ b/src/test-kernel/cli/ResumeHint.vitest.mts
@@ -16,6 +16,7 @@ import {
   AgentCategory,
   type ActiveChildInfo,
   type StreamTabId,
+  type SubagentChildInfo,
 } from '@shared/schemas';
 
 function makeSlice(
@@ -46,9 +47,12 @@ function makeSlice(
 }
 
 function child(
-  over: Partial<ActiveChildInfo> & { executionId: string },
+  over: Partial<SubagentChildInfo> & {
+    executionId: string;
+    childStreamId: StreamTabId;
+  },
 ): ActiveChildInfo {
-  return { agentName: 'agent', ...over };
+  return { kind: 'subagent', agentName: 'agent', ...over };
 }
 
 function streamsOf(

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -812,6 +812,7 @@ describe('CLI run progress renderer', () => {
         parentStreamId: 'parent-stream',
         children: [
           {
+            kind: 'subagent',
             executionId: 'child-execution',
             childStreamId: 'child-stream',
             agentName: 'review',
@@ -835,6 +836,7 @@ describe('CLI run progress renderer', () => {
           parentStreamId: 'parent-stream',
           children: [
             {
+              kind: 'subagent',
               executionId: 'child-execution',
               childStreamId: 'child-stream',
               agentName: 'review',

--- a/src/test-kernel/cli/StreamTabsStrip.vitest.mts
+++ b/src/test-kernel/cli/StreamTabsStrip.vitest.mts
@@ -36,6 +36,7 @@ function child(init: {
   readonly status?: string;
 }): ActiveChildInfo {
   return {
+    kind: 'subagent',
     executionId: init.executionId,
     agentName: init.agentName ?? '',
     childStreamId: init.childStreamId,

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -32,12 +32,32 @@ describe('CLI SubagentList display model', () => {
 
   it('uses a compact child row budget instead of clipping nested sections', () => {
     const subagents: ActiveChildInfo[] = [
-      { executionId: 'strategy', agentName: 'strategy' },
-      { executionId: 'lean', agentName: 'leanSolver' },
-      { executionId: 'review', agentName: 'reviewer' },
+      {
+        kind: 'subagent',
+        executionId: 'strategy',
+        agentName: 'strategy',
+        childStreamId: 'strategy-stream',
+      },
+      {
+        kind: 'subagent',
+        executionId: 'lean',
+        agentName: 'leanSolver',
+        childStreamId: 'lean-stream',
+      },
+      {
+        kind: 'subagent',
+        executionId: 'review',
+        agentName: 'reviewer',
+        childStreamId: 'review-stream',
+      },
     ];
     const activeProcesses: ActiveChildInfo[] = [
-      { executionId: 'latexmk', agentName: 'latex build', toolName: 'bash' },
+      {
+        kind: 'process',
+        executionId: 'latexmk',
+        agentName: 'latex build',
+        toolName: 'bash',
+      },
     ];
 
     const display = compactRows({
@@ -55,11 +75,23 @@ describe('CLI SubagentList display model', () => {
 
   it('reserves a single overflowing row for the overflow summary', () => {
     const display = compactRows({
-      activeProcesses: [{ executionId: 'latexmk', agentName: 'latex build' }],
+      activeProcesses: [
+        { kind: 'process', executionId: 'latexmk', agentName: 'latex build' },
+      ],
       maxRows: 1,
       subagents: [
-        { executionId: 'strategy', agentName: 'strategy' },
-        { executionId: 'lean', agentName: 'leanSolver' },
+        {
+          kind: 'subagent',
+          executionId: 'strategy',
+          agentName: 'strategy',
+          childStreamId: 'strategy-stream',
+        },
+        {
+          kind: 'subagent',
+          executionId: 'lean',
+          agentName: 'leanSolver',
+          childStreamId: 'lean-stream',
+        },
       ],
     });
 
@@ -69,11 +101,21 @@ describe('CLI SubagentList display model', () => {
 
   it('keeps exact-fit compact rows without adding an overflow summary', () => {
     const subagents: ActiveChildInfo[] = [
-      { executionId: 'strategy', agentName: 'strategy' },
-      { executionId: 'lean', agentName: 'leanSolver' },
+      {
+        kind: 'subagent',
+        executionId: 'strategy',
+        agentName: 'strategy',
+        childStreamId: 'strategy-stream',
+      },
+      {
+        kind: 'subagent',
+        executionId: 'lean',
+        agentName: 'leanSolver',
+        childStreamId: 'lean-stream',
+      },
     ];
     const activeProcesses: ActiveChildInfo[] = [
-      { executionId: 'latexmk', agentName: 'latex build' },
+      { kind: 'process', executionId: 'latexmk', agentName: 'latex build' },
     ];
 
     const display = compactRows({
@@ -94,6 +136,7 @@ describe('CLI SubagentList display model', () => {
     expect(
       compactChildRowText({
         child: {
+          kind: 'process',
           executionId: 'latexmk',
           agentName: 'latex build',
           status: 'running',
@@ -115,6 +158,7 @@ describe('CLI SubagentList display model', () => {
     expect(
       compactChildRowText({
         child: {
+          kind: 'process',
           executionId: 'review',
           agentName: 'review',
           status: STREAM_STATUS.WAITING,

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -38,14 +38,13 @@ vi.mock('@cli/runtime/approvalAdapter', () => {
   interface RetryPayloadForMock {
     errorMessage?: string;
     errorDetails?: {
-      isCredentialExhausted?: boolean;
+      exhaustionReason?: 'relay-limit' | 'upstream-credit' | 'chatgpt-subscription';
       isRelayError?: boolean;
-      isChatGptSubscriptionLimited?: boolean;
     };
   }
 
   const isChatGptSubscriptionRetry = (payload: RetryPayloadForMock) =>
-    payload.errorDetails?.isChatGptSubscriptionLimited === true;
+    payload.errorDetails?.exhaustionReason === 'chatgpt-subscription';
   const isRelayMonthlyLimitMessage = (message?: string) =>
     message?.toLowerCase().includes('monthly spending limit') === true;
 
@@ -74,7 +73,7 @@ vi.mock('@cli/runtime/approvalAdapter', () => {
     },
     isCliApiSwitchableRetry: (payload: RetryPayloadForMock) =>
       isChatGptSubscriptionRetry(payload) ||
-      (payload.errorDetails?.isCredentialExhausted === true &&
+      (payload.errorDetails?.exhaustionReason !== undefined &&
         (payload.errorDetails?.isRelayError === true ||
           isRelayMonthlyLimitMessage(payload.errorMessage))),
     isCliChatGptSubscriptionRetry: isChatGptSubscriptionRetry,
@@ -134,7 +133,7 @@ function relayRetry(params: {
     errorMessage: params.message ?? 'Relay monthly limit reached.',
     errorDetails: {
       message: params.message ?? 'Relay monthly limit reached.',
-      isCredentialExhausted: true,
+      exhaustionReason: 'relay-limit',
       isRelayError: true,
       ...(params.provider ? { provider: params.provider } : {}),
     },
@@ -150,8 +149,7 @@ function chatGptSubscriptionRetry(
     errorMessage: 'ChatGPT subscription usage limit reached.',
     errorDetails: {
       message: 'ChatGPT subscription usage limit reached.',
-      isCredentialExhausted: true,
-      isChatGptSubscriptionLimited: true,
+      exhaustionReason: 'chatgpt-subscription',
       provider: 'openai',
     },
   } as ProgressEventPayloads['showRetryRequest'];
@@ -256,7 +254,7 @@ describe('TUI retry approvals', () => {
         errorMessage: 'Monthly spending limit reached.',
         errorDetails: {
           message: 'Monthly spending limit reached.',
-          isCredentialExhausted: true,
+          exhaustionReason: 'relay-limit',
           isRelayError: false,
           provider: 'openai',
         },

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -38,7 +38,8 @@ vi.mock('@cli/runtime/approvalAdapter', () => {
   interface RetryPayloadForMock {
     errorMessage?: string;
     errorDetails?: {
-      exhaustionReason?: 'relay-limit' | 'upstream-credit' | 'chatgpt-subscription';
+      exhaustionReason?:
+        'relay-limit' | 'upstream-credit' | 'chatgpt-subscription';
       isRelayError?: boolean;
     };
   }

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -162,6 +162,7 @@ describe('cliState Phase 4 fields', () => {
       ...s,
       childStreams: [
         {
+          kind: 'subagent',
           executionId: 'history-1',
           agentName: 'critic',
           childStreamId: child1,
@@ -170,17 +171,20 @@ describe('cliState Phase 4 fields', () => {
       ],
       activeSubagents: [
         {
+          kind: 'subagent',
           executionId: 'agent-1',
           agentName: 'critic',
           childStreamId: child1,
           status: STREAM_STATUS.RUNNING,
         },
       ],
+      // Processes never own a stream tab, so an unrelated background process
+      // must be untouched by removing child1's stream below.
       activeProcesses: [
         {
+          kind: 'process',
           executionId: 'process-1',
           agentName: 'bash',
-          childStreamId: child1,
           status: STREAM_STATUS.RUNNING,
         },
       ],
@@ -200,9 +204,13 @@ describe('cliState Phase 4 fields', () => {
     if (!parent) throw new Error('missing parent stream');
     expect(parent.childStreams).toEqual([]);
     expect(parent.activeSubagents).toEqual([]);
-    expect(parent.activeProcesses).toEqual([]);
+    // Unaffected: process-1 never referenced child1's stream.
+    expect(parent.activeProcesses).toMatchObject([
+      { executionId: 'process-1' },
+    ]);
     expect(visibleSubagentRows(parent)).toEqual([]);
-    expect(hasChildControlItems(parent, 'tasks')).toBe(false);
+    // Still true: the untouched process-1 counts as a task-mode item.
+    expect(hasChildControlItems(parent, 'tasks')).toBe(true);
     expect(hasChildControlItems(parent, 'subagents')).toBe(false);
     expect(nextFocusForward()).toBeUndefined();
   });
@@ -218,6 +226,7 @@ describe('cliState Phase 4 fields', () => {
         ...s,
         activeSubagents: [
           {
+            kind: 'subagent',
             executionId: 'agent-1',
             agentName: 'codex',
             childStreamId: child1,
@@ -226,6 +235,7 @@ describe('cliState Phase 4 fields', () => {
         ],
         childStreams: [
           {
+            kind: 'subagent',
             executionId: 'agent-1',
             agentName: 'codex',
             childStreamId: child1,
@@ -249,6 +259,7 @@ describe('cliState Phase 4 fields', () => {
       expect(parent?.childStreams[0]?.status).toBe(STREAM_PHASE.FAILED);
       expect(visibleSubagentRows(parent!)).toMatchObject([
         {
+          kind: 'subagent',
           executionId: 'agent-1',
           childStreamId: child1,
           status: STREAM_PHASE.FAILED,
@@ -284,6 +295,7 @@ describe('cliState Phase 4 fields', () => {
       parentStreamId: root,
       children: [
         {
+          kind: 'subagent',
           executionId: 'agent-1',
           agentName: 'critic',
           childStreamId: child1,
@@ -1431,6 +1443,7 @@ describe('CLI TUI row allocation', () => {
       ...s,
       childStreams: [
         {
+          kind: 'subagent',
           executionId: 'child-exec-1',
           agentName: 'critic',
           childStreamId: child1,
@@ -1454,6 +1467,7 @@ describe('CLI TUI row allocation', () => {
       ...s,
       childStreams: [
         {
+          kind: 'subagent',
           executionId: 'child-exec-1',
           agentName: 'critic',
           childStreamId: child1,
@@ -1569,6 +1583,7 @@ describe('CLI TUI row allocation', () => {
       ...s,
       childStreams: [
         {
+          kind: 'subagent',
           executionId: 'child-exec-1',
           agentName: 'critic',
           childStreamId: child1,
@@ -1614,6 +1629,7 @@ describe('CLI TUI row allocation', () => {
       ...s,
       childStreams: [
         {
+          kind: 'subagent',
           executionId: 'child-exec-1',
           agentName: 'critic',
           childStreamId: child1,
@@ -2728,13 +2744,14 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
       parentStreamId: root,
       processes: [
         {
+          kind: 'process',
           executionId: 'exec-a',
           agentName: 'latexmk',
           toolName: 'bash',
           status: 'exit 1',
           elapsed: '2s',
         },
-        { executionId: 'exec-b', agentName: 'bash' },
+        { kind: 'process', executionId: 'exec-b', agentName: 'bash' },
       ],
     });
     wrapped.emit('updateProcessOutput', {
@@ -2755,7 +2772,9 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
     // active-processes update, after a durable transcript entry is added.
     wrapped.emit('updateActiveProcesses', {
       parentStreamId: root,
-      processes: [{ executionId: 'exec-b', agentName: 'bash' }],
+      processes: [
+        { kind: 'process', executionId: 'exec-b', agentName: 'bash' },
+      ],
     });
     const slice = streams.get().get(root);
     const out = streams.get().get(root)?.processOutput;
@@ -2796,6 +2815,7 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
   it('formats completed-process transcript rows for terminal rendering', () => {
     const process = buildCompletedProcessTranscript(
       {
+        kind: 'process',
         executionId: 'exec-a',
         agentName: 'latexmk',
         status: 'exit 2',
@@ -2829,6 +2849,7 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
   it('does not keep a stale running status after a process leaves the active list', () => {
     const process = buildCompletedProcessTranscript(
       {
+        kind: 'process',
         executionId: 'exec-a',
         agentName: 'bash',
         status: 'running',
@@ -2850,11 +2871,21 @@ describe('focusCycle', () => {
     patchStream(child2, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
     patchStream(root, (s) => ({
       ...s,
+      // Only subagents own a stream tab, so both live siblings are modeled as
+      // subagents here — a background process is never itself a focus target.
       activeSubagents: [
-        { executionId: 'e1', agentName: 'a', childStreamId: child1 },
-      ],
-      activeProcesses: [
-        { executionId: 'e2', agentName: 'b', childStreamId: child2 },
+        {
+          kind: 'subagent',
+          executionId: 'e1',
+          agentName: 'a',
+          childStreamId: child1,
+        },
+        {
+          kind: 'subagent',
+          executionId: 'e2',
+          agentName: 'b',
+          childStreamId: child2,
+        },
       ],
     }));
     // root → first descendant.

--- a/src/test-kernel/common/ChatGptSubscriptionDetection.vitest.ts
+++ b/src/test-kernel/common/ChatGptSubscriptionDetection.vitest.ts
@@ -60,11 +60,9 @@ describe('formatProviderHttpError for ChatGPT subscription limits', () => {
 
     const providerError = formatProviderHttpError(error);
 
-    expect(providerError.isChatGptSubscriptionLimited).toBe(true);
-    expect(providerError.isCredentialExhausted).toBe(true);
+    expect(providerError.exhaustionReason).toBe('chatgpt-subscription');
     // The stored OpenAI key is NOT the broken credential, so no key change is
-    // forced (that flag is reserved for upstream credit depletion).
-    expect(providerError.isUpstreamCreditDepleted).toBeUndefined();
+    // forced (that reason is reserved for upstream credit depletion).
     expect(providerError.userRetryable).toBe(true);
     expect(providerError.message).toContain('ChatGPT subscription usage limit');
   });

--- a/src/test-kernel/common/SdkErrorUtils.vitest.mts
+++ b/src/test-kernel/common/SdkErrorUtils.vitest.mts
@@ -283,7 +283,7 @@ describe('formatProviderHttpError', () => {
 
     expect(formatted.statusCode).toBe(429);
     expect(formatted.isRelayError).toBe(true);
-    expect(formatted.isCredentialExhausted).toBe(true);
+    expect(formatted.exhaustionReason).toBe('relay-limit');
     expect(formatted.userRetryable).toBe(true);
   });
 
@@ -335,8 +335,7 @@ describe('formatProviderHttpError', () => {
     const formatted = formatProviderHttpError(error);
 
     expect(formatted.provider).toBe('openai');
-    expect(formatted.isCredentialExhausted).toBe(true);
-    expect(formatted.isUpstreamCreditDepleted).toBe(true);
+    expect(formatted.exhaustionReason).toBe('upstream-credit');
     expect(formatted.userRetryable).toBe(true);
   });
 
@@ -355,8 +354,7 @@ describe('formatProviderHttpError', () => {
     const formatted = formatProviderHttpError(error);
 
     expect(formatted.provider).toBe('openai');
-    expect(formatted.isCredentialExhausted).toBe(true);
-    expect(formatted.isUpstreamCreditDepleted).toBe(true);
+    expect(formatted.exhaustionReason).toBe('upstream-credit');
     expect(formatted.userRetryable).toBe(true);
   });
 
@@ -376,8 +374,7 @@ describe('formatProviderHttpError', () => {
 
     expect(formatted.provider).toBe('openai');
     expect(formatted.statusCode).toBeUndefined();
-    expect(formatted.isCredentialExhausted).toBe(true);
-    expect(formatted.isUpstreamCreditDepleted).toBe(true);
+    expect(formatted.exhaustionReason).toBe('upstream-credit');
     expect(formatted.userRetryable).toBe(true);
   });
 
@@ -396,7 +393,7 @@ describe('formatProviderHttpError', () => {
 
     expect(formatted.provider).toBe('openai');
     expect(formatted.statusCode).toBeUndefined();
-    expect(formatted.isCredentialExhausted).toBeUndefined();
+    expect(formatted.exhaustionReason).toBeUndefined();
     expect(formatted.userRetryable).toBe(true);
   });
 
@@ -532,6 +529,43 @@ describe('provider error schemas', () => {
     expect('retryable' in errorLog).toBe(false);
     expect(retryInfo.userRetryable).toBe(true);
   });
+
+  it('migrates legacy exhaustion booleans persisted by older TeXRA versions', () => {
+    // Stream logs are unversioned JSON reparsed on later loads (see
+    // StreamLogStore) — a record written before the exhaustionReason
+    // refactor still carries the independent boolean flags.
+    const chatgptLegacy = ErrorLogDataSchema.parse({
+      message: 'legacy chatgpt-subscription record',
+      userRetryable: true,
+      isCredentialExhausted: true,
+      isChatGptSubscriptionLimited: true,
+    });
+    expect(chatgptLegacy.exhaustionReason).toBe('chatgpt-subscription');
+    expect('isCredentialExhausted' in chatgptLegacy).toBe(false);
+    expect('isChatGptSubscriptionLimited' in chatgptLegacy).toBe(false);
+
+    const upstreamLegacy = RetryErrorInfoSchema.parse({
+      message: 'legacy upstream-credit record',
+      userRetryable: true,
+      isCredentialExhausted: true,
+      isUpstreamCreditDepleted: true,
+    });
+    expect(upstreamLegacy.exhaustionReason).toBe('upstream-credit');
+
+    const relayLimitLegacy = RetryErrorInfoSchema.parse({
+      message: 'legacy relay-limit record',
+      userRetryable: true,
+      isCredentialExhausted: true,
+    });
+    expect(relayLimitLegacy.exhaustionReason).toBe('relay-limit');
+
+    const noExhaustionLegacy = RetryErrorInfoSchema.parse({
+      message: 'legacy non-exhausted record',
+      userRetryable: true,
+      isCredentialExhausted: false,
+    });
+    expect(noExhaustionLegacy.exhaustionReason).toBeUndefined();
+  });
 });
 
 describe('toRetryErrorInfo / toProviderErrorFromRetry round-trip', () => {
@@ -542,8 +576,7 @@ describe('toRetryErrorInfo / toProviderErrorFromRetry round-trip', () => {
     statusCode: 429,
     statusText: 'Too Many Requests',
     provider: 'anthropic',
-    isCredentialExhausted: true,
-    isUpstreamCreditDepleted: undefined,
+    exhaustionReason: 'relay-limit',
     requestId: 'req_abc123',
     streamDiagnostics: {
       thinkingChars: 100,
@@ -570,7 +603,7 @@ describe('toRetryErrorInfo / toProviderErrorFromRetry round-trip', () => {
     expect(reconstructed.statusCode).toBe(429);
     expect(reconstructed.provider).toBe('anthropic');
     expect(reconstructed.isRelayError).toBe(true);
-    expect(reconstructed.isCredentialExhausted).toBe(true);
+    expect(reconstructed.exhaustionReason).toBe('relay-limit');
     expect(reconstructed.requestId).toBe('req_abc123');
     expect(reconstructed.userRetryable).toBe(true);
   });
@@ -646,7 +679,6 @@ describe('toRetryErrorInfo / toProviderErrorFromRetry round-trip', () => {
       statusText: 'Too Many Requests',
       provider: 'openai',
       isRelayError: false,
-      isCredentialExhausted: undefined,
       requestId: 'req_tooluse_123',
     };
 

--- a/src/test-kernel/common/SdkErrorUtils.vitest.mts
+++ b/src/test-kernel/common/SdkErrorUtils.vitest.mts
@@ -767,4 +767,28 @@ describe('attachProviderError end-to-end', () => {
     expect(logData.operation).toBe('execute orchestrator');
     expect(normalizeProviderError(wrapper)).toBe(reconstructed);
   });
+
+  it('migrates legacy fields on a cached ProviderError instead of returning them unchanged', () => {
+    // Simulates a cached error attached before the retryable/exhaustion-flag
+    // migration ran — e.g. a resumed tool-use flow's raw persisted
+    // `lastError`, which bypasses the schema-level migration on that resume
+    // path (migrateSharedState casts the persisted shape directly).
+    const legacyCached = {
+      message: 'legacy relay-limit record',
+      retryable: true,
+      isCredentialExhausted: true,
+    } as unknown as ProviderError;
+
+    const err = new Error(legacyCached.message);
+    attachProviderError(err, legacyCached);
+
+    const recovered = normalizeProviderError(err);
+
+    expect(recovered.userRetryable).toBe(true);
+    expect(recovered.exhaustionReason).toBe('relay-limit');
+    expect('retryable' in recovered).toBe(false);
+    expect('isCredentialExhausted' in recovered).toBe(false);
+    // Downstream credential-exhaustion checks must see the migrated reason.
+    expect(recovered.exhaustionReason !== undefined).toBe(true);
+  });
 });

--- a/src/test-kernel/progressView/ProcessOutputState.vitest.ts
+++ b/src/test-kernel/progressView/ProcessOutputState.vitest.ts
@@ -70,6 +70,7 @@ function createProcessState(streamId: StreamTabId): ProgressState {
     createStreamState(AgentCategory.Workflow, {
       activeProcesses: [
         {
+          kind: 'process',
           executionId: 'active-process',
           agentName: 'bash',
           status: STREAM_STATUS.RUNNING,
@@ -102,6 +103,7 @@ function registerWorkflowStream(
   streamId: StreamTabId,
 ): void {
   state.streamById.set(streamId, {
+    kind: 'agent',
     name: streamId,
     label: 'stream-a',
     agentCategory: AgentCategory.Workflow,
@@ -117,6 +119,7 @@ describe('process output frontend state', () => {
     state.activeStreamId = streamId;
     state.streamFilter = 'workflow';
     state.streamById.set(siblingId, {
+      kind: 'agent',
       name: siblingId,
       label: 'old sibling',
       agentCategory: AgentCategory.ToolUse,
@@ -130,6 +133,8 @@ describe('process output frontend state', () => {
         status: STREAM_PHASE.RUNNING,
         activeSubagents: [
           {
+            kind: 'subagent',
+            childStreamId: 'old-child-stream',
             executionId: 'old-child',
             agentName: 'old child',
           },
@@ -143,6 +148,7 @@ describe('process output frontend state', () => {
       {
         command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA,
         streamInfo: {
+          kind: 'agent',
           name: siblingId,
           label: 'search',
           agent: 'search',
@@ -162,6 +168,7 @@ describe('process output frontend state', () => {
           finishedSubagentCount: 1,
           activeProcesses: [
             {
+              kind: 'process',
               executionId: 'process-a',
               agentName: 'bash',
             },
@@ -189,6 +196,7 @@ describe('process output frontend state', () => {
       finishedSubagentCount: 1,
       activeProcesses: [
         {
+          kind: 'process',
           executionId: 'process-a',
           agentName: 'bash',
         },
@@ -239,6 +247,7 @@ describe('process output frontend state', () => {
         finishedSubagentCount: 0,
         activeProcesses: [
           {
+            kind: 'process',
             executionId: 'active-process',
             agentName: 'bash',
             status: STREAM_STATUS.RUNNING,
@@ -317,6 +326,7 @@ describe('process output frontend state', () => {
         command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
         streams: [
           {
+            kind: 'agent',
             name: streamId,
             label: 'stream-a',
             agentCategory: AgentCategory.Workflow,
@@ -383,12 +393,14 @@ describe('process output frontend state', () => {
     const child = 'stream-child' as StreamTabId;
     const state = createInitialState();
     state.streamById.set(parent, {
+      kind: 'agent',
       name: parent,
       label: 'parent',
       agentCategory: AgentCategory.Workflow,
       creationTimestamp: 1,
     });
     state.streamById.set(child, {
+      kind: 'agent',
       name: child,
       label: 'child',
       agentCategory: AgentCategory.ToolUse,

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -217,9 +217,7 @@ describe('ProgressBackend', () => {
 
     backend.webviewUpdater.sendStreamMetadata(
       backend.state,
-      backend.eventHandler.getAllStreamStatuses(),
-      undefined,
-      backend.eventHandler.getAllStreamSubstates(),
+      backend.eventHandler.getAllStreamStates(),
     );
 
     expect(
@@ -329,9 +327,7 @@ describe('ProgressBackend', () => {
 
       backend.webviewUpdater.sendStreamMetadata(
         backend.state,
-        backend.eventHandler.getAllStreamStatuses(),
-        undefined,
-        backend.eventHandler.getAllStreamSubstates(),
+        backend.eventHandler.getAllStreamStates(),
       );
       const fullSync = messages.find(
         (message) => message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,

--- a/src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts
@@ -54,6 +54,7 @@ const stream = 'stream:shared-snapshot' as StreamTabId;
 const parentStream = 'stream:parent' as StreamTabId;
 const runId = 'run-1' as StorageKey;
 const activeSubagent: ActiveChildInfo = {
+  kind: 'subagent',
   executionId: 'child-1',
   agentName: 'search',
   childStreamId: 'stream:child',

--- a/src/test-kernel/progressView/RetryRequestPanel.vitest.mts
+++ b/src/test-kernel/progressView/RetryRequestPanel.vitest.mts
@@ -23,7 +23,7 @@ function createRetryPermission(): RetryRequestPanel['permission'] {
       model: 'test-model',
       errorMessage: 'Relay quota exhausted',
       errorDetails: {
-        isCredentialExhausted: true,
+        exhaustionReason: 'relay-limit',
         isRelayError: true,
         userRetryable: true,
       },

--- a/src/test-kernel/progressView/StreamTree.vitest.ts
+++ b/src/test-kernel/progressView/StreamTree.vitest.ts
@@ -17,6 +17,7 @@ import {
 
 function stream(name: string, parentStreamId?: string): StreamTabInfo {
   return {
+    kind: 'agent',
     name,
     label: name,
     agentCategory: AgentCategory.ToolUse,

--- a/src/test-kernel/progressView/streamInfoUtils.vitest.ts
+++ b/src/test-kernel/progressView/streamInfoUtils.vitest.ts
@@ -10,6 +10,7 @@ import { compareByNewestCreationTime } from '@shared/progressView/backend/stream
 
 function streamInfo(name: string, creationTimestamp: number): StreamTabInfo {
   return {
+    kind: 'agent',
     name,
     label: name,
     agentCategory: 'workflow',

--- a/src/test-kernel/schemas/SchemaMigrations.vitest.ts
+++ b/src/test-kernel/schemas/SchemaMigrations.vitest.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { RunUsageAccumulatorJSONSchema } from '@agent/core/usage/RunUsageAccumulator';
 import {
+  ActiveChildInfoSchema,
   ContextManagementDataSchema,
   OutputXmlSummarySchema,
 } from '@shared/schemas';
@@ -159,5 +160,39 @@ describe('ContextManagementDataSchema — legacy missing tokensAfter/utilization
         action: 'max_tokens_reduced',
       }),
     ).toThrow();
+  });
+});
+
+describe('ActiveChildInfoSchema — legacy missing kind discriminant', () => {
+  const legacyBase = {
+    executionId: 'exec-1',
+    agentName: 'review',
+  };
+
+  it('infers kind: subagent from a legacy entry that has childStreamId', () => {
+    const result = ActiveChildInfoSchema.parse({
+      ...legacyBase,
+      childStreamId: 'stream-1',
+    });
+
+    expect(result).toMatchObject({
+      kind: 'subagent',
+      childStreamId: 'stream-1',
+    });
+  });
+
+  it('infers kind: process from a legacy entry without childStreamId', () => {
+    const result = ActiveChildInfoSchema.parse({ ...legacyBase });
+
+    expect(result).toMatchObject({ kind: 'process' });
+  });
+
+  it('passes an already-migrated entry through unchanged', () => {
+    const result = ActiveChildInfoSchema.parse({
+      ...legacyBase,
+      kind: 'process',
+    });
+
+    expect(result).toMatchObject({ kind: 'process' });
   });
 });

--- a/src/test-kernel/schemas/SchemaMigrations.vitest.ts
+++ b/src/test-kernel/schemas/SchemaMigrations.vitest.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import { RunUsageAccumulatorJSONSchema } from '@agent/core/usage/RunUsageAccumulator';
-import { ContextManagementDataSchema, OutputXmlSummarySchema } from '@shared/schemas';
+import {
+  ContextManagementDataSchema,
+  OutputXmlSummarySchema,
+} from '@shared/schemas';
 
 // Minimal NormalizedUsage fixture: all required fields, no optionals.
 const usageFixture = {

--- a/src/test-kernel/schemas/SchemaMigrations.vitest.ts
+++ b/src/test-kernel/schemas/SchemaMigrations.vitest.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { RunUsageAccumulatorJSONSchema } from '@agent/core/usage/RunUsageAccumulator';
-import { OutputXmlSummarySchema } from '@shared/schemas';
+import { ContextManagementDataSchema, OutputXmlSummarySchema } from '@shared/schemas';
 
 // Minimal NormalizedUsage fixture: all required fields, no optionals.
 const usageFixture = {
@@ -115,5 +115,46 @@ describe('OutputXmlSummarySchema — tagContents legacy string coercion', () => 
     });
 
     expect(result.tagContents['broken']).toEqual([]);
+  });
+});
+
+describe('ContextManagementDataSchema — legacy missing tokensAfter/utilizationAfter', () => {
+  const legacyBase = {
+    tokensBefore: 1000,
+    contextWindow: 200_000,
+    utilizationBefore: 5,
+  };
+
+  it('defaults tokensAfter/utilizationAfter from the before-values on a pre-union entry', () => {
+    const result = ContextManagementDataSchema.parse({
+      ...legacyBase,
+      action: 'clear_tool_uses',
+    });
+
+    expect(result).toMatchObject({
+      action: 'clear_tool_uses',
+      tokensAfter: 1000,
+      utilizationAfter: 5,
+    });
+  });
+
+  it('passes an already-populated tokens-freed entry through unchanged', () => {
+    const result = ContextManagementDataSchema.parse({
+      ...legacyBase,
+      action: 'compaction',
+      tokensAfter: 400,
+      utilizationAfter: 2,
+    });
+
+    expect(result).toMatchObject({ tokensAfter: 400, utilizationAfter: 2 });
+  });
+
+  it('still requires originalMaxTokens/reducedMaxTokens for max_tokens_reduced', () => {
+    expect(() =>
+      ContextManagementDataSchema.parse({
+        ...legacyBase,
+        action: 'max_tokens_reduced',
+      }),
+    ).toThrow();
   });
 });

--- a/src/test-kernel/shared/StreamMetaReducer.vitest.ts
+++ b/src/test-kernel/shared/StreamMetaReducer.vitest.ts
@@ -89,6 +89,7 @@ describe('reduceStreamMeta', () => {
 
   describe('activeProcesses', () => {
     const active: ActiveChildInfo = {
+      kind: 'process',
       executionId: 'active',
       agentName: 'bash',
     };

--- a/src/test-kernel/shared/StreamMetadata.vitest.ts
+++ b/src/test-kernel/shared/StreamMetadata.vitest.ts
@@ -27,6 +27,7 @@ describe('buildStreamMetadata', () => {
 
   it('preserves supplied status, progress, child badges, and timestamps', () => {
     const child: ActiveChildInfo = {
+      kind: 'process',
       executionId: 'agent-1',
       agentName: 'review',
       status: STREAM_STATUS.RUNNING,

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -30,6 +30,7 @@ import { type StreamTabId, type ExecutionId } from '@shared/schemas';
 import { BASH_TOOL_DEFAULT_TIMEOUT_MS } from '@shared/constants/toolDefaults';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { formatBashDelivery, formatBashError } from '@tools/subagentResults';
+import { requireRunStream } from '@tools/contextHelpers';
 import {
   buildBashApprovalRejectedResult,
   requestBashApproval,
@@ -162,12 +163,16 @@ export class BashTool extends defineTool({
     const timeoutMs = input.timeout ?? BASH_TOOL_DEFAULT_TIMEOUT_MS;
 
     if (input.run_in_background) {
+      const { streamId, runtimeHost } = requireRunStream(
+        'bash run_in_background',
+        runContext,
+      );
       return this.executeBackground(
         input.command,
         timeoutMs,
-        runContext?.streamId,
+        streamId,
         runContext?.executionId,
-        runContext?.runtimeHost,
+        runtimeHost,
         cwd,
       );
     }
@@ -226,17 +231,11 @@ export class BashTool extends defineTool({
   private async executeBackground(
     command: string,
     timeoutMs: number,
-    parentStreamId: StreamTabId | undefined,
+    parentStreamId: StreamTabId,
     parentExecutionId: ExecutionId | undefined,
-    runtimeHost: AgentRuntimeHost | undefined,
+    runtimeHost: AgentRuntimeHost,
     cwd?: string,
   ): Promise<ToolResult> {
-    if (!parentStreamId || !runtimeHost) {
-      throw new ToolError(
-        'Background execution requires a parent stream runtime context.',
-      );
-    }
-
     const executionId = generateExecutionId();
 
     await ensureRunDir(executionId);

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -34,7 +34,8 @@ import {
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { StreamTabId, ExecutionId, ToolUseLog } from '@shared/schemas';
 import { MESSAGE_TYPES } from '@shared/schemas';
-import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
+import { type ToolResult } from '@shared/schemas/toolResult';
+import { requireRunStream } from '@tools/contextHelpers';
 import { parseWorkingDirectory } from '@tools/pathResolution';
 import { isNonEmptyString } from '@utils/core';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
@@ -509,15 +510,19 @@ export class ClaudeAgentTool extends defineTool({
             },
           });
         }
+        const { streamId, runtimeHost } = requireRunStream(
+          CLAUDE_AGENT_NAME,
+          runContext,
+        );
         return launchClaudeAgentSession(
           input,
           permissionMode,
           model,
           effort,
-          runContext?.streamId,
+          streamId,
           runContext?.executionId,
           runContext?.workingDirectory,
-          runContext?.runtimeHost,
+          runtimeHost,
         );
       },
     );
@@ -529,17 +534,11 @@ async function launchClaudeAgentSession(
   permissionMode: ClaudeAgentPermissionMode,
   model: string,
   effort: ClaudeAgentEffort,
-  parentStreamId: StreamTabId | undefined,
+  parentStreamId: StreamTabId,
   parentExecutionId: ExecutionId | undefined,
   parentWorkingDirectory: string | undefined,
-  runtimeHost: AgentRuntimeHost | undefined,
+  runtimeHost: AgentRuntimeHost,
 ): Promise<ToolResult> {
-  if (!parentStreamId || !runtimeHost) {
-    throw new ToolError(
-      'Claude Code CLI requires a parent stream runtime context — it must be called from an active tool-use agent.',
-    );
-  }
-
   const config = await getClaudeAgentConfig();
   const workingDir = parseWorkingDirectory(parentWorkingDirectory);
   const workspace = config.buildClaudeAgentWorkspaceOptions(workingDir);

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -493,10 +493,7 @@ export class CodexTool extends defineTool({
         }
         // Fall through when the thread's in-memory loop is gone (extension
         // reload, crash): createCodexThread resumes via the SDK from disk.
-        const { streamId, runtimeHost } = requireRunStream(
-          'codex',
-          runContext,
-        );
+        const { streamId, runtimeHost } = requireRunStream('codex', runContext);
         return launchCodexSession(
           input,
           streamId,

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -40,6 +40,7 @@ import type {
 import { MESSAGE_TYPES } from '@shared/schemas';
 import { CodexSandboxModeSchema } from '@shared/schemas/agentCliSettings';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
+import { requireRunStream } from '@tools/contextHelpers';
 import { parseWorkingDirectory } from '@tools/pathResolution';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
@@ -492,12 +493,16 @@ export class CodexTool extends defineTool({
         }
         // Fall through when the thread's in-memory loop is gone (extension
         // reload, crash): createCodexThread resumes via the SDK from disk.
+        const { streamId, runtimeHost } = requireRunStream(
+          'codex',
+          runContext,
+        );
         return launchCodexSession(
           input,
-          runContext?.streamId,
+          streamId,
           runContext?.executionId,
           runContext?.workingDirectory,
-          runContext?.runtimeHost,
+          runtimeHost,
         );
       },
     );
@@ -506,17 +511,11 @@ export class CodexTool extends defineTool({
 
 async function launchCodexSession(
   input: CodexInput,
-  parentStreamId: StreamTabId | undefined,
+  parentStreamId: StreamTabId,
   parentExecutionId: ExecutionId | undefined,
   parentWorkingDirectory: string | undefined,
-  runtimeHost: AgentRuntimeHost | undefined,
+  runtimeHost: AgentRuntimeHost,
 ): Promise<ToolResult> {
-  if (!parentStreamId || !runtimeHost) {
-    throw new ToolError(
-      'Codex requires a parent stream runtime context — it must be called from an active tool-use agent.',
-    );
-  }
-
   const workingDir = parseWorkingDirectory(parentWorkingDirectory);
   const thread = await createCodexThread(input, workingDir);
   const config = (await getCodexConfig()).buildCodexConfig(input.prompt);

--- a/src/tools/contextHelpers.ts
+++ b/src/tools/contextHelpers.ts
@@ -28,16 +28,34 @@ export function requireRuntimeHost(
 }
 
 /**
+ * Return the active stream id, throwing a ToolError if none is active. Use
+ * from tools that address a stream (e.g. a goal keyed by stream id) but,
+ * unlike {@link requireRunStream}, don't need the runtime host to do so.
+ */
+export function requireStreamId(
+  toolName: string,
+  context: RunContext | undefined = tryUseRunContext(),
+): StreamTabId {
+  const streamId = context?.streamId;
+  if (!streamId) {
+    throw new ToolError(`${toolName} requires an active stream context.`);
+  }
+  return streamId;
+}
+
+/**
  * Return the active stream id and runtime host together, throwing a
  * ToolError if either is missing. Use from tools that need both a stream
  * to address (e.g. subscribe/approval) and a host to emit on.
  */
-export function requireRunStream(toolName: string): {
+export function requireRunStream(
+  toolName: string,
+  context: RunContext | undefined = tryUseRunContext(),
+): {
   streamId: StreamTabId;
   runtimeHost: AgentRuntimeHost;
   context: RunContext;
 } {
-  const context = tryUseRunContext();
   if (!context?.streamId || !context.runtimeHost) {
     throw new ToolError(
       `${toolName} must be called from within an agent stream.`,

--- a/src/tools/executions/conversationFormat.ts
+++ b/src/tools/executions/conversationFormat.ts
@@ -1,80 +1,28 @@
 /**
- * Pure formatters for rendering a stored execution conversation as text.
+ * Message-level formatter for rendering a stored execution conversation as
+ * text, built on the shared per-content-block formatter in
+ * `@agent/storage/conversationFormat` (the same block recognition and
+ * truncation the CLI's `texra history` conversation previews use).
  * Used by ExecutionsTool's /conversation endpoint; kept free of I/O so the
  * tool class stays focused on path routing and storage access.
  */
+import {
+  formatConversationContent,
+  type ConversationFormatOptions,
+} from '@agent/storage/conversationFormat';
 
-// Deliberately ASCII-only (`...`, code-unit slicing) rather than
-// `truncateWithEllipsis`'s Unicode `…` + grapheme-aware cut — this output
-// feeds the ExecutionsTool's plain-text conversation view, which must stay
-// pure ASCII.
-function truncate(str: string, maxLen: number): string {
-  return str.length > maxLen ? `${str.slice(0, maxLen - 3)}...` : str;
-}
-
-/**
- * The recognized content-block shapes within a stored conversation. Stored
- * blocks are untrusted JSON, so each variant only declares the fields this
- * formatter reads; unknown shapes fall through to the JSON default.
- */
-type ConversationBlock =
-  | { type: 'text'; text?: unknown }
-  | { type: 'tool_use'; name?: unknown; input?: unknown }
-  | { type: 'tool_result'; content?: unknown };
-
-/** Narrows an arbitrary stored block to a recognized variant by its `type` tag. */
-function asConversationBlock(block: unknown): ConversationBlock | undefined {
-  if (typeof block !== 'object' || block === null) return undefined;
-  const type = (block as { type?: unknown }).type;
-  if (type === 'text' || type === 'tool_use' || type === 'tool_result') {
-    return block as ConversationBlock;
-  }
-  return undefined;
-}
+const CONVERSATION_FORMAT_OPTIONS: ConversationFormatOptions = {
+  textLimit: 500,
+  toolBlockLimit: 100,
+};
 
 function asText(value: unknown): string {
   return typeof value === 'string' ? value : '';
 }
 
-function formatBlock(block: unknown): string {
-  if (typeof block === 'string') {
-    return block;
-  }
-  const typed = asConversationBlock(block);
-  switch (typed?.type) {
-    case 'text':
-      return asText(typed.text);
-    case 'tool_use':
-      return `[tool_use: ${asText(typed.name)}(${truncate(JSON.stringify(typed.input ?? {}) ?? '', 100)})]`;
-    case 'tool_result': {
-      const output =
-        typeof typed.content === 'string'
-          ? typed.content
-          : (JSON.stringify(typed.content) ?? '');
-      return `[tool_result: ${truncate(output, 100)}]`;
-    }
-    default:
-      // `JSON.stringify` returns undefined for undefined/symbol/function
-      // blocks; fall back to '' so truncate never sees a non-string (matches
-      // the tool_result and message-content paths above).
-      return truncate(JSON.stringify(block) ?? '', 100);
-  }
-}
-
 interface ConversationMessage {
   role?: unknown;
   content?: unknown;
-}
-
-function formatMessageContent(content: unknown): string {
-  if (content == null) return '';
-  if (typeof content === 'string') {
-    return truncate(content, 500);
-  }
-  if (Array.isArray(content)) {
-    return content.map((block) => formatBlock(block)).join('\n');
-  }
-  return truncate(JSON.stringify(content) ?? '', 500);
 }
 
 /** Render a stored conversation as numbered <message> blocks. */
@@ -84,7 +32,10 @@ export function formatConversation(conversation: readonly unknown[]): string {
     // Coerce a missing, non-string, or empty role to "unknown": stored roles
     // are untrusted, and an empty label would render a meaningless role="".
     const role = asText(m.role) || 'unknown';
-    const content = formatMessageContent(m.content);
+    const content = formatConversationContent(
+      m.content,
+      CONVERSATION_FORMAT_OPTIONS,
+    );
     return `<message index="${i + 1}" role="${role}">\n${content}\n</message>`;
   });
 

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -33,8 +33,9 @@ import {
   isGoalInFlight,
   type Goal,
 } from '@shared/schemas/goal';
-import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
+import { type ToolResult } from '@shared/schemas/toolResult';
 import { proposalApprovalState } from '@tools/approval';
+import { requireStreamId } from '@tools/contextHelpers';
 import {
   GoalStore,
   isGoalEnabled,
@@ -109,27 +110,18 @@ Best practices:
 }) {
   protected async execute(input: PlanToolInput): Promise<ToolResult> {
     const contexts = getCurrentToolContexts();
-    const streamId = contexts?.runContext?.streamId;
 
     switch (input.command) {
       case 'update':
         return this.executeUpdate({ objective: input.objective }, contexts);
       case 'pause':
-        if (!streamId) {
-          throw new ToolError('plan(pause) requires an active stream context.');
-        }
         return this.executePause(
-          streamId,
+          requireStreamId('plan(pause)', contexts?.runContext),
           requireNonEmptyString(input.reason, 'reason'),
         );
       case 'complete':
-        if (!streamId) {
-          throw new ToolError(
-            'plan(complete) requires an active stream context.',
-          );
-        }
         return this.executeComplete(
-          streamId,
+          requireStreamId('plan(complete)', contexts?.runContext),
           requireNonEmptyString(input.reason, 'reason'),
         );
     }

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -128,6 +128,18 @@ function descriptorFromConfig(
   });
 }
 
+/**
+ * A stream's executionId, preferring the canonical `runDescriptor.executionId`
+ * over the legacy top-level `executionId` field written before descriptors
+ * existed. Both fields are set together on new writes (see `setTaskState`),
+ * so this only matters for meta read from older on-disk data.
+ */
+function executionIdFromMeta(
+  meta: StreamTabMeta | undefined,
+): ExecutionId | undefined {
+  return meta?.runDescriptor?.executionId ?? meta?.executionId;
+}
+
 export class StreamSnapshotStore {
   // -- In-memory accumulators (one entry per stream that has emitted) --------
   private readonly outputFiles = new Map<
@@ -351,6 +363,29 @@ export class StreamSnapshotStore {
     return inner;
   }
 
+  /**
+   * Shared round→value patch application for the round-keyed accumulators
+   * (missing outputs, compile failures). `normalize` returns `null` to delete
+   * a round's entry (e.g. once its failure list empties out) or the value to
+   * store otherwise.
+   */
+  private applyRoundKeyedPatch<V>(
+    map: Map<StreamTabId, Map<number, V>>,
+    stream: StreamTabId,
+    filesByRound: Record<string, unknown>,
+    normalize: (raw: unknown) => V | null,
+  ): Map<number, V> {
+    const rounds = this.getOrCreate(map, stream);
+    for (const [round, raw] of Object.entries(filesByRound)) {
+      const key = RoundKeySchema.safeParse(round);
+      if (!key.success) continue;
+      const value = normalize(raw);
+      if (value === null) rounds.delete(key.data);
+      else rounds.set(key.data, value);
+    }
+    return rounds;
+  }
+
   private parseOutputFilesPatch(
     filesByRound: RoundIndexed<OutputFileInfo>,
   ): OutputFilesPatch {
@@ -460,11 +495,12 @@ export class StreamSnapshotStore {
     filesByRound: RoundIndexed<string>,
   ): void {
     this.mutate(stream, () => {
-      const rounds = this.getOrCreate(this.missingOutputs, stream);
-      for (const [round, files] of Object.entries(filesByRound)) {
-        const key = RoundKeySchema.safeParse(round);
-        if (key.success) rounds.set(key.data, files);
-      }
+      const rounds = this.applyRoundKeyedPatch<string[]>(
+        this.missingOutputs,
+        stream,
+        filesByRound,
+        (raw) => raw as string[],
+      );
       this.write(stream, STREAM_DATA_KEYS.MISSING_OUTPUTS, mapToRecord(rounds));
     });
   }
@@ -474,16 +510,17 @@ export class StreamSnapshotStore {
     filesByRound: RoundIndexed<CompileFailure>,
   ): void {
     this.mutate(stream, () => {
-      const rounds = this.getOrCreate(this.compileFailures, stream);
-      for (const [round, failures] of Object.entries(filesByRound)) {
-        const key = RoundKeySchema.safeParse(round);
-        if (!key.success) continue;
-        const normalized = CompileFailureSchema.array().parse(
-          Array.isArray(failures) ? failures : [],
-        );
-        if (normalized.length === 0) rounds.delete(key.data);
-        else rounds.set(key.data, normalized);
-      }
+      const rounds = this.applyRoundKeyedPatch<CompileFailure[]>(
+        this.compileFailures,
+        stream,
+        filesByRound,
+        (raw) => {
+          const normalized = CompileFailureSchema.array().parse(
+            Array.isArray(raw) ? raw : [],
+          );
+          return normalized.length === 0 ? null : normalized;
+        },
+      );
       this.write(
         stream,
         STREAM_DATA_KEYS.COMPILE_FAILURES,
@@ -785,7 +822,7 @@ export class StreamSnapshotStore {
     stream: StreamTabId,
   ): Promise<ExecutionId | undefined> {
     const meta = (await readStreamData(this.kv(stream))).meta;
-    return meta?.runDescriptor?.executionId ?? meta?.executionId;
+    return executionIdFromMeta(meta);
   }
 
   /**
@@ -1065,7 +1102,7 @@ export class StreamSnapshotStore {
     stream: StreamTabId,
     meta: StreamTabMeta,
   ): Promise<HydratedRunState> {
-    const executionId = meta.runDescriptor?.executionId ?? meta.executionId;
+    const executionId = executionIdFromMeta(meta);
     let descriptor = meta.runDescriptor;
     if (meta.runDescriptor) {
       descriptor = meta.runDescriptor;
@@ -1151,7 +1188,7 @@ export class StreamSnapshotStore {
         : undefined;
     const runConfig =
       latestRunConfigOverlay ?? runConfigOverlay ?? hydrated.config;
-    const executionId = meta?.runDescriptor?.executionId ?? meta?.executionId;
+    const executionId = executionIdFromMeta(meta);
     const runDescriptor =
       latestRunDescriptorOverlay ??
       runDescriptorOverlay ??

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -22,6 +22,7 @@ import type {
   AgentTraceSubscriber,
   LogEvent,
 } from '@agent/trace';
+import { computeUtilizationPercent } from '@agent/modelHandlers/support/contextUtilization';
 import { isDebugModeEnabled } from '@logger/logUtils';
 import {
   END_GROUP_STATUS,
@@ -289,8 +290,10 @@ export function attachTranscriptRecorder(
         return;
 
       case 'context.state': {
-        const utilizationPercent =
-          (event.inputTokens / event.contextWindow) * 100;
+        const utilizationPercent = computeUtilizationPercent(
+          event.inputTokens,
+          event.contextWindow,
+        );
         appendLog({
           groupId: event.stageId,
           messageType: MESSAGE_TYPES.CONTEXT_STATE,


### PR DESCRIPTION
## Summary

Follows up on a codebase-wide audit of data-structure complexity (nested maps, kitchen-sink optional schemas, duplicated transforms, scattered fallback logic). Addresses all 14 confirmed findings, grouped by severity:

**High**
- `StreamSnapshotStore`: extract shared `applyRoundKeyedPatch` for the round-keyed accumulators (missing outputs / compile failures); dedupe the `executionId` legacy-fallback derivation into one `executionIdFromMeta` helper (was repeated 3x in the same file)
- `bash`/`codex`/`claudeAgent`/`plan` tools now route through the existing `requireRunStream`/`requireStreamId` helpers instead of each hand-rolling its own missing-context guard with divergent behavior (throw vs. warn-and-degrade vs. silently pass `undefined`)
- `ProviderErrorObjectSchema`: replace 3 independent exhaustion booleans (`isCredentialExhausted`, `isUpstreamCreditDepleted`, `isChatGptSubscriptionLimited`) with one `exhaustionReason` discriminant, with a legacy on-disk migration for old trace/transcript data
- `StreamStatusService`/`WebviewUpdater`: single `getAllStreamStates()` map instead of two independently-rebuilt phase/substate maps that could silently diverge in stream coverage
- `IModelHandler.createBatchedToolUseFollowUpMessages`: one array of `{call, result, attachments}` records instead of three positionally-zipped parallel arrays — removes the runtime "mismatched length" guards this fragility required

**Medium/Low**
- Unified the stored-conversation formatter shared by `ExecutionsTool` and the CLI `history` command into `src/agent/storage/conversationFormat.ts`
- Dropped the redundant `streamId` echoed into `ModelOutputBackup` values (the map key, already in scope, is now used directly)
- `ContextManagementDataSchema`, `ActiveChildInfoSchema`, `StreamTabInfoSchema`: converted to Zod discriminated unions instead of always-optional "kitchen sink" bags
- `getEffectiveDiffBase`: one helper for the `diffBase ?? original` fallback, reused by `output.ts`, latexdiff, and the progress-view file list (previously duplicated 3x with the same rationale comment)
- Narrowed `ResultEvent.error` per `AgentErrorKind` instead of `Partial<...>` of the full provider-error shape
- Use the existing `computeUtilizationPercent` helper in the transcript recorder and CLI status bar instead of re-deriving the formula inline

One finding (agentCategory fallback sites) was investigated and found to have no further applicable call sites beyond the two already using the canonical helper — no change was needed there.

## Issue acceptance gates

Internal code-review follow-up (not tied to a filed issue): implement the confirmed findings from a data-structure complexity audit of this repo. All 14 confirmed findings are addressed; each is verified by grep/type-check, not just described.

## Single source of truth

- `executionIdFromMeta()` (`StreamSnapshotStore.ts`) is now the one place that resolves a stream's execution id from meta.
- `requireRunStream()`/`requireStreamId()` (`contextHelpers.ts`) are the one place tools assert an active run context.
- `getAllStreamStates()` (`StreamStatusService.ts`) is the one accessor for combined phase+substate state.
- `getEffectiveDiffBase()` (`output.ts`) is the one place that resolves a file's diff base.
- `computeUtilizationPercent()` (`contextUtilization.ts`) is the one formula for context-window utilization.

## Duplication and abstraction budget

Removed: 3x `executionId` fallback, 3x `diffBase ?? original` fallback, 2 independently-rebuilt phase/substate maps, 3 positional-array parameters, 2 parsed-conversation formatters, duplicated tool-context guard logic across 4 tool files, duplicated builder functions (`buildSubagentItem`/`buildProcessItem` → one `buildChildControlItem`). No new abstraction layers were introduced beyond the discriminated-union schema shapes themselves and the small helpers named above, each of which owns exactly one invariant (e.g. `requireStreamId` owns "no runtime host required," distinct from `requireRunStream`, which does require one).

## Host impact

Extension: progress-view frontend components (`StreamTabs`, `StreamConversation`, `ProcessStreamContent`, `WorkflowStreamContent`, `FileList`, `BackgroundTasksPanel`, `RetryRequestPanel`) updated to narrow on the new `kind` discriminants and `exhaustionReason`.

Desktop: `desktopAgentExecution.ts` and `desktopCommandPalette.ts` updated for the unified stream-state accessor and `kind` discriminant.

CLI: `StatusBar.tsx`, `childControls.ts`/`childExecutions.ts`, `cliState` slices, `subscribeApprovals.ts`, `approvalPolicy.ts`, and the CLI conversation-history formatter updated for the same schema/helper changes.

## Scheduled refactoring

None — all confirmed findings from the audit are addressed in this PR.

## Validation

- `npm run typecheck` (root, test-kernel, extension, cli, trace-viewer projects) — clean, 0 errors.
- `npm run lint` — 0 errors (2 pre-existing, unrelated warnings left untouched; auto-fixed the import-order warnings introduced by this change).
- `npx vitest run` across `src/test-kernel/{agent,progressView,common,cli}` and `src/tools` — 2845 passed, 6 skipped, 0 failed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WXiz3MetAcTLcMS2RPG9VB)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide cross-host refactor touching retry/credential classification and persisted JSON migrations; behavior is heavily test-covered but regressions could affect approvals, stream tabs, and auto-retry.
> 
> **Overview**
> Follow-up to a data-structure complexity audit: **tightens schemas and removes duplicated logic** across agent runtime, progress UI, and CLI.
> 
> **Provider / retry errors** replace three independent exhaustion booleans with a single **`exhaustionReason`** (`relay-limit`, `upstream-credit`, `chatgpt-subscription`), plus **`normalizeLegacyProviderErrorFields`** on read for old persisted logs and cached errors. Call sites use **`isCredentialExhausted`**, **`isUpstreamCreditDepletedError`**, and related helpers instead of raw flags.
> 
> **Stream and child metadata** use Zod discriminated unions: **`StreamTabInfo`** (`kind: 'agent' | 'process'`), **`ActiveChildInfo`** (`subagent` vs `process`, with legacy `kind` backfill from `childStreamId`), and **`ContextManagementData`** (action-specific fields). Progress hosts switch rendering on **`kind`** rather than guessing from optional `model`/`command`.
> 
> **Stream status** exposes **`getAllStreamStates()`** (phase + substate together); **`WebviewUpdater`** / desktop / extension take one map so phase and substate coverage cannot diverge.
> 
> **Model handlers** change batched parallel tool follow-ups to one **`entries: { call, result, attachments }[]`** API (dropping positional zip + **`checkBatchedToolCalls`**).
> 
> **Shared helpers**: stored-conversation text formatting moves to **`@agent/storage/conversationFormat`** (CLI history delegates); **`getEffectiveDiffBase`** centralizes diff-base resolution; CLI status bar uses **`computeUtilizationPercent`**. **`ResultEvent.error`** is narrowed by **`AgentErrorKind`** so abort/disk-full payloads do not claim full provider-error fields.
> 
> CLI child pickers merge **`buildSubagentItem` / `buildProcessItem`** into **`buildChildControlItem`** keyed on **`child.kind`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d239f4386641cc097f23ff335f8b4ce0612853ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->