### PR TITLE
fix(security): reject root-relative URLs in web tool result sanitization

### DIFF
--- a/src/shared/schemas/progressView/data.ts
+++ b/src/shared/schemas/progressView/data.ts
@@ -102,23 +102,17 @@ export type NormalizedToolUse = z.infer<typeof NormalizedToolUseSchema>;
 const SAFE_URL_SCHEMES = new Set(['http:', 'https:', 'mailto:']);
 
 /**
- * Returns `raw` unchanged if it's safe to render as an `href`, or
- * `undefined` if it isn't, so callers can omit the link (or fall back to
- * plain text) instead of rendering a live anchor. Behavior matches the
- * retired `safeUrl()` exactly:
- * - trims surrounding whitespace
- * - empty string → unsafe (nothing to link to)
- * - anchor-only (`#foo`) → safe as-is, no scheme to abuse
- * - root-relative (`/foo`, but NOT protocol-relative `//foo`) → safe as-is
- * - everything else must parse as an absolute URL (via the `URL` global,
- *   so protocol-relative `//foo` fails here too) with an allow-listed
- *   scheme
+ * Returns `raw` unchanged if it's safe to render as an `href`, or `undefined`
+ * otherwise. Root-relative paths are rejected, not treated as safe-as-is like
+ * an anchor fragment: unlike a browser resolving against the current page's
+ * origin, the standalone HTML export opens via `file://` with no origin,
+ * where a tool-controlled `/etc/passwd` would resolve against the filesystem
+ * root (issue #7230 follow-up).
  */
 function sanitizeUrl(raw: string): string | undefined {
   const trimmed = raw.trim();
   if (trimmed === '') return undefined;
   if (trimmed.startsWith('#')) return trimmed;
-  if (trimmed.startsWith('/') && !trimmed.startsWith('//')) return trimmed;
   const url = tryParseUrl(trimmed);
   if (!url) return undefined;
   return SAFE_URL_SCHEMES.has(url.protocol) ? trimmed : undefined;

--- a/src/test-kernel/schemas/WebUrlSanitization.vitest.ts
+++ b/src/test-kernel/schemas/WebUrlSanitization.vitest.ts
@@ -7,13 +7,15 @@
  * `src/shared/schemas/progressView/data.ts`) so both render paths, which
  * share the same formatters, are protected by one fix.
  *
- * Expected behavior mirrors the retired hand-written HTML exporter's
- * `safeUrl()` (deleted with `formatChatAsHtml` in #7137 — see
- * `git log -p -S SAFE_URL_SCHEMES`): only `http:`/`https:`/`mailto:` survive
- * scheme validation; anchor-only (`#foo`) and root-relative (`/foo`, not
- * `//foo`) URLs pass through unchecked since there's no scheme to abuse;
- * everything else (empty, unparseable, protocol-relative, dangerous scheme)
- * collapses to `undefined`.
+ * Only `http:`/`https:`/`mailto:` survive scheme validation; anchor-only
+ * (`#foo`) URLs pass through unchecked since there's no scheme to abuse;
+ * everything else (empty, unparseable, protocol-relative, root-relative,
+ * dangerous scheme) collapses to `undefined`. Root-relative (`/foo`) is
+ * rejected rather than passed through as safe-as-is (a follow-up to the
+ * original #7230 fix): the standalone HTML export opens via `file://` with
+ * no origin, so a tool-controlled `/etc/passwd` would resolve against the
+ * filesystem root instead of a web origin, becoming a live link to a local
+ * file.
  */
 import { describe, expect, it } from 'vitest';
 
@@ -88,8 +90,24 @@ describe('web tool URL sanitization (issue #7230)', () => {
     expect(parseSearchUrl('#section-2')).toBe('#section-2');
   });
 
-  it('keeps root-relative paths as-is', () => {
-    expect(parseSearchUrl('/local/path')).toBe('/local/path');
+  describe('root-relative paths are rejected (issue #7230 follow-up)', () => {
+    // A standalone HTML export opens via `file://` with no origin, so a
+    // root-relative URL resolves against the filesystem root rather than a
+    // web origin — a tool-controlled `/etc/passwd` must not become a live
+    // link to a local file.
+    const rootRelative = [
+      '/etc/passwd',
+      '/Users/alice/.ssh/id_rsa',
+      '/local/path',
+    ];
+
+    it.each(rootRelative)('strips %s from web_search results', (url) => {
+      expect(parseSearchUrl(url)).toBeUndefined();
+    });
+
+    it.each(rootRelative)('strips %s from web_fetch payloads', (url) => {
+      expect(parseFetchUrl(url)).toBeUndefined();
+    });
   });
 
   it('sanitizes each item independently in a mixed results list', () => {


### PR DESCRIPTION
## Summary

Follow-up to #7236 / issue #7230. A fresh P1 review on #7236 (after it merged) found a real gap in that fix: `sanitizeUrl()` in `src/shared/schemas/progressView/data.ts` treated a root-relative URL (starts with `/` but not `//`) as always safe, mirroring how a browser resolves it against the *current page's* origin.

But when a trace/chat is exported to standalone HTML (`ChatExportController.exportAsHtml`) and opened via `file://`, a root-relative URL resolves against the *filesystem root*, not a web origin. A tool-controlled `web_search`/`web_fetch` result URL like `/etc/passwd` or `/Users/alice/.ssh/id_rsa` would become a clickable link that opens/exposes a local file when the exported HTML is viewed — defeating part of the original fix.

- Removed the root-relative early-return branch in `sanitizeUrl()`. `web_search`/`web_fetch` results are virtually always absolute URLs, so there's no legitimate need to pass root-relative paths through as safe; only absolute `http:`/`https:`/`mailto:` and anchor-only `#...` fragments are treated as safe now.
- Trimmed the `sanitizeUrl()` docstring per CLAUDE.md's comment guidance — it previously restated the code line-by-line; it now explains only the non-obvious part (why root-relative is rejected).
- Added regression tests proving `/etc/passwd`, `/Users/alice/.ssh/id_rsa`, and `/local/path` are rejected (render as plain text, not a live link) for both `web_search` and `web_fetch` payloads, while confirming absolute `http`/`https`/`mailto` URLs and anchor-only fragments still work.

## Test plan
- [x] `npx vitest run src/test-kernel/schemas/WebUrlSanitization.vitest.ts` — 40/40 pass, including new root-relative rejection cases
- [x] `npx vitest run src/test-kernel/controllers/ChatExportControllerHtml.vitest.ts src/test-kernel/schemas` — 86/86 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/shared/schemas/progressView/data.ts src/test-kernel/schemas/WebUrlSanitization.vitest.ts` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nbVZZcHVNLBNZ2tESvR7v

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted hardening of existing schema sanitization with regression tests; behavior tightens only for root-relative URLs that were incorrectly treated as safe.
> 
> **Overview**
> **Closes a gap in Progress View / HTML export link sanitization** where root-relative paths (e.g. `/etc/passwd`) were treated as safe `href` values.
> 
> `sanitizeUrl()` in `data.ts` no longer passes through paths that start with `/` (unless protocol-relative `//`). Only anchor fragments (`#...`) and absolute URLs with allow-listed schemes (`http:`, `https:`, `mailto:`) remain linkable; other values collapse to `undefined` so `web_search` / `web_fetch` results render as plain text instead of anchors.
> 
> Regression tests in `WebUrlSanitization.vitest.ts` now expect root-relative URLs to be stripped for both payload types, with comments/docs updated to explain **`file://` export has no web origin**, so root-relative links would resolve on the local filesystem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98252468cf0d4d35a67171c276f5e2c265b90c29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->