### PR TITLE
fix(progress): clear queued progress on run restart

### DIFF
--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -101,6 +101,7 @@ export class ProgressEventHandler {
     this.state.clearStreamHints(streamId);
     this.state.getOrCreateStreamState(streamId, category);
     this.state.resetFinishedChildCounters(streamId);
+    this.pendingProgressUpdates.delete(streamId);
     this.state.pruneInterruptHandles();
 
     if (this.state.activeStream === streamId) {

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -454,6 +454,66 @@ describe('ProgressBackend', () => {
     }
   });
 
+  it('drops buffered conversation progress when an existing stream re-enters running', async () => {
+    vi.useFakeTimers();
+    const { backend, messages } = createRecordingBackend();
+    const subscription = backend.setupEventListeners(bus);
+    const stream = 'tool-stream' as StreamTabId;
+
+    try {
+      await backend.state.snapshots.load([]);
+      backend.state.streamLogs.ensureStream(stream);
+      backend.state.activeStream = stream;
+      backend.state.snapshots.setTaskState(
+        stream,
+        toolUseTaskState('search', 'deepseekproT'),
+        'abc123' as ExecutionId,
+      );
+      backend.state.updateStreamHints(stream, {
+        agentCategory: AgentCategory.ToolUse,
+      });
+      backend.state.getOrCreateStreamState(stream, AgentCategory.ToolUse);
+
+      bus.emit('updateConversationProgress', {
+        streamId: stream,
+        progress: { toolCallCount: 7 },
+      });
+
+      await backend.eventHandler.setStreamStatus(
+        stream,
+        STREAM_PHASE.RUNNING,
+        STREAM_PHASE.COMPLETED,
+      );
+
+      await vi.advanceTimersByTimeAsync(501);
+
+      const patch = messages.find(
+        (message) =>
+          message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA &&
+          message.streamInfo.name === stream,
+      );
+      expect(patch).toMatchObject({
+        command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA,
+        streamState: {
+          conversationProgress: { toolCallCount: 0 },
+        },
+      });
+      expect(
+        messages.some(
+          (message) =>
+            message.command ===
+              PROGRESS_VIEW_COMMANDS.UPDATE_CONVERSATION_PROGRESS &&
+            message.stream === stream &&
+            message.progress.toolCallCount === 7,
+        ),
+      ).toBe(false);
+    } finally {
+      subscription.dispose();
+      backend.dispose();
+      vi.useRealTimers();
+    }
+  });
+
   it('revalidates and syncs the active stream when status registration changes the filter', async () => {
     const { backend, messages } = createRecordingBackend();
 


### PR DESCRIPTION
## Summary

Clears any buffered conversation-progress update for a stream when that existing stream re-enters RUNNING. This keeps the delayed progress throttle from resurrecting stale tool-call badges after the RUNNING metadata reset has already zeroed the per-run counters.

## Root Cause

The existing-stream RUNNING path reset `ProgressViewState` and patched metadata, but `ProgressEventHandler` still retained a pending `updateConversationProgress` entry for the same stream. If the throttle fired after the reset, the stale buffered `toolCallCount` could be sent back to the active stream.

## Validation

- `npm test -- --run src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `npm run typecheck`
- `npm run lint` (0 errors; existing unrelated import-order warning in `codexToolTemplates.ts`)
- `npm run compile:fast`
- `git diff --check`

Closes #7201

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line guard on an existing lifecycle path in progress UI state; behavior is covered by a new regression test.
> 
> **Overview**
> When an **existing stream re-enters `RUNNING`**, the handler now **drops that stream’s entry from `pendingProgressUpdates`** as part of the running transition, alongside the existing per-run state reset.
> 
> **Why:** Conversation progress is **throttled** (~500ms) into a per-stream buffer before the webview is updated. After a restart, metadata already **zeros** counters like `toolCallCount`, but a **stale buffered update** could still flush afterward and bring back old badge counts.
> 
> A **vitest** case covers emitting progress, transitioning back to `RUNNING`, advancing the throttle timer, and asserting **no** `UPDATE_CONVERSATION_PROGRESS` with the old count is sent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 579062e2209d09a7cea658533168f33a426d0d3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->