### PR TITLE
fix(progress): use null sentinel for round stage reset

### DIFF
--- a/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
@@ -19,7 +19,10 @@ import { firstStreamId, type ProgressState, type StreamState } from '../store';
 import { unsupportedProgressCommands$ } from '../progressState';
 import { clearResolvedProposalIds } from './permissionSlice';
 import { pendingDescriptions, takePendingDescription } from './streamMetaSlice';
-import { mergeBackendOwnedState } from './streamStateMerge';
+import {
+  mergeBackendOwnedState,
+  metadataToStreamStatePartial,
+} from './streamStateMerge';
 import { clearCopyContentStore } from '../formatters/copyContentStore';
 import { clearProposalInputStore } from '../formatters/proposalInputStore';
 import {
@@ -51,7 +54,10 @@ function updateStreamInfo(
         stream.name,
         existing
           ? mergeBackendOwnedState(existing, metadata)
-          : createStreamState(stream.agentCategory, metadata),
+          : createStreamState(
+              stream.agentCategory,
+              metadataToStreamStatePartial(metadata),
+            ),
       );
     } else if (!existing) {
       mergedStates.set(stream.name, createStreamState(stream.agentCategory));

--- a/packages/extension/src/progressView/frontend/slices/streamMetaSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamMetaSlice.ts
@@ -23,7 +23,10 @@ import {
   isToolUseState,
   type ProcessOutputMap,
 } from '../store';
-import { mergeBackendOwnedState } from './streamStateMerge';
+import {
+  mergeBackendOwnedState,
+  metadataToStreamStatePartial,
+} from './streamStateMerge';
 import type { HandlerRegistry } from '../messageHandlerTypes';
 
 /**
@@ -87,7 +90,10 @@ export const streamMetaHandlers: HandlerRegistry = {
       const existingState = prev.streamStates.get(name);
       const mergedState = existingState
         ? mergeBackendOwnedState(existingState, data.streamState)
-        : createStreamState(data.streamState.kind, data.streamState);
+        : createStreamState(
+            data.streamState.kind,
+            metadataToStreamStatePartial(data.streamState),
+          );
 
       return create(prev, (draft) => {
         if (

--- a/packages/extension/src/progressView/frontend/slices/streamStateMerge.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamStateMerge.ts
@@ -1,8 +1,21 @@
 import { create } from 'mutative';
 
-import { createStreamState, type StreamMetadata } from '@shared/schemas';
+import {
+  createStreamState,
+  type StreamMetadata,
+  type StreamState,
+} from '@shared/schemas';
 
-import type { StreamState } from '../store';
+export function metadataToStreamStatePartial(
+  metadata: StreamMetadata,
+): Partial<StreamState> {
+  return {
+    ...metadata,
+    ...(Object.hasOwn(metadata, 'roundStage') && {
+      roundStage: metadata.roundStage ?? undefined,
+    }),
+  } as Partial<StreamState>;
+}
 
 export function mergeBackendOwnedState(
   existing: StreamState,
@@ -12,7 +25,7 @@ export function mergeBackendOwnedState(
     // Kind changed: create fresh state with new-kind defaults, overlay metadata,
     // and preserve frontend-owned taskGroups.
     return createStreamState(metadata.kind, {
-      ...metadata,
+      ...metadataToStreamStatePartial(metadata),
       taskGroups: existing.taskGroups,
     });
   }
@@ -22,7 +35,7 @@ export function mergeBackendOwnedState(
   // above already ensures matches `existing.kind`) so a new field added to
   // that schema is picked up here without also updating this call site.
   return create(existing, (draft) => {
-    Object.assign(draft, metadata);
+    Object.assign(draft, metadataToStreamStatePartial(metadata));
     if (!Object.hasOwn(metadata, 'substate')) {
       delete draft.substate;
     }

--- a/packages/extension/src/progressView/frontend/slices/syncSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/syncSlice.ts
@@ -103,7 +103,7 @@ export const syncHandlers: HandlerRegistry = {
             draft.conversationProgress = data.conversationProgress;
           }
           if ('roundStage' in data) {
-            draft.roundStage = data.roundStage;
+            draft.roundStage = data.roundStage ?? undefined;
           }
           if (data.badges) {
             draft.activeSubagents = data.badges.activeSubagents;

--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -581,7 +581,7 @@ export class ProgressEventHandler {
       queuedFollowUps,
       agentCategory,
       conversationProgress,
-      roundStage,
+      roundStage: includeActiveState ? (roundStage ?? null) : undefined,
       badges,
       parentStreamId,
       ...streamControls,

--- a/src/shared/schemas/progressView/outbound.ts
+++ b/src/shared/schemas/progressView/outbound.ts
@@ -303,7 +303,7 @@ export const SyncStreamContentMessageSchema = z.object({
   agentCategory: z.string().optional(),
   // Tab-switch state (R2: replaces separate syncActiveStreamState messages)
   conversationProgress: ConversationProgressSchema.optional(),
-  roundStage: RoundStageSchema.optional(),
+  roundStage: RoundStageSchema.nullable().optional(),
   badges: z
     .object({
       activeSubagents: z.array(ActiveChildInfoSchema),

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -81,7 +81,11 @@ const BackendOwnedFieldsSchema = z.object({
   finishedProcessCount: z.number().prefault(DEFAULT_FINISHED_CHILD_COUNT),
 });
 
-export const StreamMetadataSchema = BackendOwnedFieldsSchema.extend({
+const BackendOwnedMetadataFieldsSchema = BackendOwnedFieldsSchema.extend({
+  roundStage: RoundStageSchema.nullable().optional(),
+});
+
+export const StreamMetadataSchema = BackendOwnedMetadataFieldsSchema.extend({
   kind: AgentCategorySchema,
 });
 

--- a/src/shared/streams/streamMetadata.ts
+++ b/src/shared/streams/streamMetadata.ts
@@ -21,7 +21,7 @@ export interface StreamMetadataInputs {
   substate?: StreamSubstate;
   lastTimestamp?: number;
   conversationProgress?: ConversationProgress;
-  roundStage?: RoundStage;
+  roundStage?: RoundStage | null;
   activeSubagents?: ActiveChildInfo[];
   finishedSubagentCount?: number;
   activeProcesses?: ActiveChildInfo[];
@@ -39,7 +39,7 @@ export function buildStreamMetadata(
     conversationProgress: inputs.conversationProgress ?? {
       ...DEFAULT_CONVERSATION_PROGRESS,
     },
-    roundStage: inputs.roundStage,
+    roundStage: inputs.roundStage ?? null,
     activeSubagents: inputs.activeSubagents ?? [],
     finishedSubagentCount:
       inputs.finishedSubagentCount ?? DEFAULT_FINISHED_CHILD_COUNT,

--- a/src/test-kernel/progressView/ProcessOutputState.vitest.ts
+++ b/src/test-kernel/progressView/ProcessOutputState.vitest.ts
@@ -349,6 +349,47 @@ describe('process output frontend state', () => {
     expect(getState().streamStates.get(streamId)?.substate).toBeUndefined();
   });
 
+  it('clears round stage from a transport-safe metadata patch', () => {
+    const streamId = 'stream-a' as StreamTabId;
+    const state = createInitialState();
+    registerWorkflowStream(state, streamId);
+    state.streamStates.set(
+      streamId,
+      createStreamState(AgentCategory.Workflow, {
+        roundStage: { index: 2 },
+      } satisfies Partial<StreamState>),
+    );
+    const { ctx, getState } = createContext(state);
+
+    const message = JSON.parse(
+      JSON.stringify({
+        command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA,
+        streamInfo: {
+          name: streamId,
+          label: 'stream-a',
+          agentCategory: AgentCategory.Workflow,
+          creationTimestamp: 1,
+        },
+        streamState: {
+          kind: AgentCategory.Workflow,
+          status: STREAM_PHASE.RUNNING,
+          conversationProgress: {
+            toolCallCount: 0,
+          },
+          roundStage: null,
+          activeSubagents: [],
+          finishedSubagentCount: 0,
+          activeProcesses: [],
+          finishedProcessCount: 0,
+        },
+      } satisfies ProgressViewOutboundMessage),
+    ) as ProgressViewOutboundMessage;
+
+    dispatch(streamMetaHandlers, message, ctx);
+
+    expect(getState().streamStates.get(streamId)?.roundStage).toBeUndefined();
+  });
+
   it('clears round stage when synced content explicitly clears it', () => {
     const streamId = 'stream-a' as StreamTabId;
     const state = createInitialState();
@@ -361,19 +402,19 @@ describe('process output frontend state', () => {
     );
     const { ctx, getState } = createContext(state);
 
-    dispatch(
-      syncHandlers,
-      {
+    const message = JSON.parse(
+      JSON.stringify({
         command: PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT,
         stream: streamId,
         action: 'render',
         todos: [],
         plan: null,
         queuedFollowUps: [],
-        roundStage: undefined,
-      } as ProgressViewOutboundMessage,
-      ctx,
-    );
+        roundStage: null,
+      } satisfies ProgressViewOutboundMessage),
+    ) as ProgressViewOutboundMessage;
+
+    dispatch(syncHandlers, message, ctx);
 
     expect(getState().streamStates.get(streamId)?.roundStage).toBeUndefined();
   });

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -444,11 +444,13 @@ describe('ProgressBackend', () => {
         kind: AgentCategory.ToolUse,
         status: STREAM_PHASE.RUNNING,
         conversationProgress: { toolCallCount: 0 },
+        roundStage: null,
         finishedSubagentCount: 0,
         finishedProcessCount: 0,
       });
-      expect(Object.hasOwn(patch.streamState, 'roundStage')).toBe(true);
-      expect(patch.streamState.roundStage).toBeUndefined();
+      expect(
+        JSON.parse(JSON.stringify(patch)).streamState.roundStage,
+      ).toBeNull();
     } finally {
       backend.dispose();
     }

--- a/src/test-kernel/shared/StreamMetadata.vitest.ts
+++ b/src/test-kernel/shared/StreamMetadata.vitest.ts
@@ -16,6 +16,7 @@ describe('buildStreamMetadata', () => {
       kind: AgentCategory.Workflow,
       status: STREAM_STATUS.READY,
       conversationProgress: { toolCallCount: 0 },
+      roundStage: null,
       activeSubagents: [],
       finishedSubagentCount: 0,
       activeProcesses: [],


### PR DESCRIPTION
## Summary

Changes the progress-view outbound metadata contract to use `roundStage: null` as the transport-safe clear sentinel. The frontend still stores `roundStage` as `RoundStage | undefined`; `null` is normalized at the metadata and sync-content merge boundaries.

## Root Cause

#7196 reset stale round badges by sending an own `roundStage: undefined` field. That works for in-memory objects, but VS Code webview messages are JSON-serializable and JSON drops `undefined` object fields, so the clear signal could disappear before the frontend reducer saw it.

## What Changed

- Allows nullable `roundStage` only in outbound metadata/sync payloads.
- Emits `roundStage: null` from the backend metadata builder when no round is active.
- Normalizes nullable metadata before `createStreamState()` and `mergeBackendOwnedState()`.
- Normalizes sync-content `roundStage: null` to frontend `undefined`.
- Adds JSON-round-trip regressions for metadata patches and sync-content payloads.

## Validation

- `npm test -- --run src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/progressView/ProcessOutputState.vitest.ts src/test-kernel/shared/StreamMetadata.vitest.ts`
- `npm run typecheck`
- `npm run lint` (0 errors; existing unrelated import-order warning in `codexToolTemplates.ts`)
- `npm run compile:fast`
- `git diff --check`

Closes #7200

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow progress-view UI sync contract change with normalization at merge boundaries and JSON round-trip tests; no auth, data, or payment paths.
> 
> **Overview**
> Fixes **stale round badges** when clearing `roundStage` across the VS Code webview: JSON drops `undefined` fields, so an explicit clear never reached the frontend reducers.
> 
> Outbound **metadata and `SYNC_STREAM_CONTENT`** now allow `roundStage: null` as the transport sentinel. The backend (`buildStreamMetadata`, `syncStreamContent`) emits `null` when no round is active or when resetting on re-enter RUNNING. Frontend state still uses `RoundStage | undefined`; **`metadataToStreamStatePartial`** and **`syncSlice`** map `null` → `undefined` at merge boundaries. Stream lifecycle/meta slices route metadata through that helper instead of spreading raw metadata into `createStreamState` / `mergeBackendOwnedState`.
> 
> Tests assert JSON round-trip for metadata patches and sync payloads so the clear signal survives serialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec32ea4d9652f6bc2dbd6647bbd72fb8bdfd9a85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->