### PR TITLE
refactor: share child-run delivery mechanics

### DIFF
--- a/src/test-kernel/progressView/ProcessOutputState.vitest.ts
+++ b/src/test-kernel/progressView/ProcessOutputState.vitest.ts
@@ -377,6 +377,7 @@ describe('process output frontend state', () => {
         streamInfo: {
           name: streamId,
           label: 'stream-a',
+          kind: 'agent',
           agentCategory: AgentCategory.Workflow,
           creationTimestamp: 1,
         },

--- a/src/test-kernel/tools/ChildRunDelivery.vitest.ts
+++ b/src/test-kernel/tools/ChildRunDelivery.vitest.ts
@@ -1,0 +1,130 @@
+// Third-party imports
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports - shared
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
+
+const mocks = vi.hoisted(() => ({
+  writeReport: vi.fn(),
+  sendFollowUp: vi.fn(),
+  wakeOrReleaseQueuedStream: vi.fn(),
+}));
+
+vi.mock('@agent/storage', () => ({
+  getExecutionStore: vi.fn(() => ({ writeReport: mocks.writeReport })),
+}));
+
+vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
+  sendFollowUp: mocks.sendFollowUp,
+  wakeOrReleaseQueuedStream: mocks.wakeOrReleaseQueuedStream,
+}));
+
+// Local imports - tools
+import {
+  deliverChildRunFollowUp,
+  persistChildRunReport,
+} from '@tools/childRunDelivery';
+
+describe('child run delivery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('persists reports through the execution store', async () => {
+    mocks.writeReport.mockResolvedValue(undefined);
+
+    await expect(
+      persistChildRunReport('exec-1' as ExecutionId, 'payload'),
+    ).resolves.toEqual({ kind: 'persisted' });
+
+    expect(mocks.writeReport).toHaveBeenCalledWith('payload');
+  });
+
+  it('returns the storage error when report persistence fails', async () => {
+    const err = new Error('disk full');
+    mocks.writeReport.mockRejectedValue(err);
+
+    await expect(
+      persistChildRunReport('exec-1' as ExecutionId, 'payload'),
+    ).resolves.toEqual({ kind: 'failed', err });
+  });
+
+  it('delivers a follow-up with the explicit owner session', async () => {
+    const session = { tag: 'owner-session' };
+    mocks.sendFollowUp.mockResolvedValue({ status: 'sent' });
+
+    await expect(
+      deliverChildRunFollowUp({
+        targetStreamId: 'parent' as StreamTabId,
+        followUp: { text: 'done', origin: 'subagent_result' },
+        session: session as never,
+      }),
+    ).resolves.toEqual({ kind: 'delivered' });
+
+    expect(mocks.sendFollowUp).toHaveBeenCalledWith(
+      'parent',
+      { text: 'done', origin: 'subagent_result' },
+      undefined,
+      undefined,
+      session,
+    );
+    expect(mocks.wakeOrReleaseQueuedStream).not.toHaveBeenCalled();
+  });
+
+  it('wakes or releases force-opened parent queues with the same session', async () => {
+    const session = { tag: 'owner-session' };
+    const sendResult = { status: 'queued', reason: 'children_running' };
+    mocks.sendFollowUp.mockResolvedValue(sendResult);
+    mocks.wakeOrReleaseQueuedStream.mockResolvedValue(true);
+
+    await expect(
+      deliverChildRunFollowUp({
+        targetStreamId: 'parent' as StreamTabId,
+        followUp: { text: 'done', origin: 'subagent_result' },
+        session: session as never,
+        wake: true,
+      }),
+    ).resolves.toEqual({ kind: 'delivered' });
+
+    expect(mocks.wakeOrReleaseQueuedStream).toHaveBeenCalledWith(
+      'parent',
+      sendResult,
+      session,
+    );
+  });
+
+  it('classifies missing and dropped parent streams', async () => {
+    const session = { tag: 'owner-session' };
+    mocks.sendFollowUp.mockResolvedValueOnce({
+      status: 'no_session',
+      streamStatus: 'completed',
+    });
+
+    await expect(
+      deliverChildRunFollowUp({
+        targetStreamId: 'parent' as StreamTabId,
+        followUp: { text: 'done', origin: 'subagent_result' },
+        session: session as never,
+        wake: true,
+      }),
+    ).resolves.toEqual({
+      kind: 'no_session',
+      streamStatus: 'completed',
+    });
+
+    mocks.sendFollowUp.mockResolvedValueOnce({
+      status: 'queued',
+      reason: 'children_running',
+    });
+    mocks.wakeOrReleaseQueuedStream.mockResolvedValueOnce(false);
+
+    await expect(
+      deliverChildRunFollowUp({
+        targetStreamId: 'parent' as StreamTabId,
+        followUp: { text: 'done', origin: 'subagent_result' },
+        session: session as never,
+        wake: true,
+      }),
+    ).resolves.toEqual({ kind: 'dropped' });
+  });
+});

--- a/src/tools/agentCliSessionLoop.ts
+++ b/src/tools/agentCliSessionLoop.ts
@@ -9,17 +9,13 @@
 //
 // Host-agnostic, VS Code-free.
 
-import { getExecutionStore, writeTerminalStatus } from '@agent/storage';
+import { writeTerminalStatus } from '@agent/storage';
 import type { AgentTrace } from '@agent/trace';
 import { type IInterruptible } from '@agent/runtime/InterruptRegistry';
 import {
   currentSession,
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
-import {
-  sendFollowUp,
-  wakeOrReleaseQueuedStream,
-} from '@agent/followUp/ToolUseFollowUp';
 import type { FollowUpQueue } from '@agent/followUp/FollowUpQueue';
 import {
   deriveRunOutcome,
@@ -31,6 +27,10 @@ import { STREAM_STATUS } from '@shared/schemas';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { isCleanInterruption, logTurnSummary } from './agentCliShared';
+import {
+  deliverChildRunFollowUp,
+  persistChildRunReport,
+} from './childRunDelivery';
 import type { ChildStream } from './childStream';
 
 /** Minimal token usage shape consumed by the loop's turn summary. */
@@ -189,11 +189,10 @@ async function persistReportBestEffort(
   msg: string,
   logger: AgentTrace,
 ): Promise<void> {
-  try {
-    await getExecutionStore(executionId).writeReport(msg);
-  } catch (storageErr) {
+  const result = await persistChildRunReport(executionId, msg);
+  if (result.kind === 'failed') {
     logger.warn(`Failed to persist report for ${executionId}`, {
-      data: storageErr,
+      data: result.err,
     });
   }
 }
@@ -277,17 +276,13 @@ export function runAgentCliSession<TTurn>(
             ? strategy.formatDelivery(turn, prompt, wallTimeMs)
             : strategy.formatError(turn, prompt, err);
         await persistReportBestEffort(executionId, msg, logger);
-        const delivery = await sendFollowUp(
-          parentStreamId,
-          {
-            text: msg,
-            origin: 'subagent_result',
-          },
-          undefined,
-          undefined,
-          runSession,
-        );
-        if (delivery.status === 'no_session') {
+        const delivery = await deliverChildRunFollowUp({
+          targetStreamId: parentStreamId,
+          followUp: { text: msg, origin: 'subagent_result' },
+          session: runSession,
+          wake: true,
+        });
+        if (delivery.kind === 'no_session') {
           logger.warn(
             'Turn result not delivered: parent stream has no active session. The result remains in the execution report.',
             {
@@ -298,13 +293,7 @@ export function runAgentCliSession<TTurn>(
               },
             },
           );
-        } else if (
-          !(await wakeOrReleaseQueuedStream(
-            parentStreamId,
-            delivery,
-            runSession,
-          ))
-        ) {
+        } else if (delivery.kind === 'dropped') {
           logger.warn(
             'Turn result dropped: parent stream is gone and could not be resumed. The result remains in the execution report.',
             { data: { executionId, parentStreamId } },

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -29,6 +29,7 @@ import { ensureRunDir } from '@utils/files/taskRunStorage';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
 import { createChildStream, type ChildStream } from './childStream';
+import { formatDeliveryEnvelope } from './deliveryEnvelope';
 
 /** Maximum prompt length echoed back in a delivery/error XML element. */
 const DELIVERY_PROMPT_MAX = 200;
@@ -62,11 +63,7 @@ export function formatAgentCliDelivery(params: AgentCliDeliveryParams): string {
   const { tag, executionId, prompt, wallTimeMs, usage, extraLines } = params;
   const durationSec = (wallTimeMs / 1000).toFixed(1);
   const response = params.response || '(no response)';
-  const idAttr = params.idAttr?.value
-    ? ` ${params.idAttr.name}="${escapeAttr(params.idAttr.value)}"`
-    : '';
   const lines = [
-    `<${tag} id="${escapeAttr(executionId)}" prompt="${escapeAttr(prompt.slice(0, DELIVERY_PROMPT_MAX))}"${idAttr}>`,
     `<wall-time>${durationSec}s</wall-time>`,
     `<response>${escapeText(response)}</response>`,
   ];
@@ -74,8 +71,18 @@ export function formatAgentCliDelivery(params: AgentCliDeliveryParams): string {
     lines.push(`<usage input="${usage.input}" output="${usage.output}" />`);
   }
   if (extraLines) lines.push(...extraLines);
-  lines.push(`</${tag}>`);
-  return lines.join('\n');
+  return formatDeliveryEnvelope({
+    tag,
+    attributes: [
+      { name: 'id', value: executionId },
+      { name: 'prompt', value: prompt.slice(0, DELIVERY_PROMPT_MAX) },
+      {
+        name: params.idAttr?.name ?? '',
+        value: params.idAttr?.value || null,
+      },
+    ].filter((attr) => attr.name !== ''),
+    bodyLines: lines,
+  });
 }
 
 /**
@@ -88,11 +95,14 @@ export function formatAgentCliError(
   prompt: string,
   err: unknown,
 ): string {
-  return [
-    `<${tag} id="${escapeAttr(executionId)}" prompt="${escapeAttr(prompt.slice(0, DELIVERY_PROMPT_MAX))}">`,
-    `<message>${escapeText(toErrorMessage(err))}</message>`,
-    `</${tag}>`,
-  ].join('\n');
+  return formatDeliveryEnvelope({
+    tag,
+    attributes: [
+      { name: 'id', value: executionId },
+      { name: 'prompt', value: prompt.slice(0, DELIVERY_PROMPT_MAX) },
+    ],
+    bodyLines: [`<message>${escapeText(toErrorMessage(err))}</message>`],
+  });
 }
 
 /**

--- a/src/tools/childRunDelivery.ts
+++ b/src/tools/childRunDelivery.ts
@@ -1,0 +1,67 @@
+/**
+ * Shared mechanics for delivering child-run results to an owning parent stream.
+ *
+ * Callers own their result format, duplicate-delivery policy, and warning text.
+ * This module owns only the common boundary actions: best-effort report writes,
+ * follow-up enqueue, and optional wake-or-release of a force-opened queue.
+ */
+
+// Local imports - agent
+import { getExecutionStore } from '@agent/storage';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import {
+  sendFollowUp,
+  wakeOrReleaseQueuedStream,
+} from '@agent/followUp/ToolUseFollowUp';
+import type { FollowUpQueueInput } from '@agent/followUp/FollowUpQueue';
+
+// Local imports - shared
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
+
+export type ChildRunDeliveryResult =
+  | { kind: 'delivered' }
+  | { kind: 'no_session'; streamStatus: string | undefined }
+  | { kind: 'dropped' };
+
+export type ChildRunReportResult =
+  { kind: 'persisted' } | { kind: 'failed'; err: unknown };
+
+export async function persistChildRunReport(
+  executionId: ExecutionId,
+  message: string,
+): Promise<ChildRunReportResult> {
+  try {
+    await getExecutionStore(executionId).writeReport(message);
+    return { kind: 'persisted' };
+  } catch (err) {
+    return { kind: 'failed', err };
+  }
+}
+
+export async function deliverChildRunFollowUp(params: {
+  readonly targetStreamId: StreamTabId;
+  readonly followUp: FollowUpQueueInput;
+  readonly session: SessionHandle;
+  readonly wake?: boolean;
+}): Promise<ChildRunDeliveryResult> {
+  const result = await sendFollowUp(
+    params.targetStreamId,
+    params.followUp,
+    undefined,
+    undefined,
+    params.session,
+  );
+  if (result.status === 'no_session') {
+    return { kind: 'no_session', streamStatus: result.streamStatus };
+  }
+  if (!params.wake) {
+    return { kind: 'delivered' };
+  }
+  return (await wakeOrReleaseQueuedStream(
+    params.targetStreamId,
+    result,
+    params.session,
+  ))
+    ? { kind: 'delivered' }
+    : { kind: 'dropped' };
+}

--- a/src/tools/delegation/subagentExecution.ts
+++ b/src/tools/delegation/subagentExecution.ts
@@ -25,10 +25,6 @@ import {
 } from '@agent/runtime/AgentFlowResult';
 import { tryUseRunContext } from '@agent/runtime/RunContext';
 import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
-import {
-  sendFollowUp,
-  wakeOrReleaseQueuedStream,
-} from '@agent/followUp/ToolUseFollowUp';
 import type { FollowUpQueueInput } from '@agent/followUp/FollowUpQueue';
 
 // Local imports - logger
@@ -37,6 +33,7 @@ import * as logger from '@logger/logUtils';
 // Local imports - tools
 import {
   AgentCategory,
+  type ExecutionId,
   type StreamTabId,
   type SubagentProgressUpdate,
 } from '@shared/schemas';
@@ -60,6 +57,10 @@ import {
   SUBAGENT_DELIVERY_DECISION,
   subagentDeliveryRegistry,
 } from '@tools/subagentDeliveryState';
+import {
+  deliverChildRunFollowUp,
+  persistChildRunReport,
+} from '@tools/childRunDelivery';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 // Local imports - utils
@@ -136,14 +137,16 @@ async function writeSubagentReport(
   executionId: string,
   message: string,
 ): Promise<void> {
-  try {
-    await getExecutionStore(executionId).writeReport(message);
-  } catch (err) {
+  const result = await persistChildRunReport(
+    executionId as ExecutionId,
+    message,
+  );
+  if (result.kind === 'failed') {
     // Non-fatal, but the report is the only durable copy of the result when
     // delivery later fails — leave a trace instead of vanishing silently.
     logger.warn(
       'subagentDelivery',
-      `Failed to persist subagent report for ${executionId}: ${toErrorMessage(err)}`,
+      `Failed to persist subagent report for ${executionId}: ${toErrorMessage(result.err)}`,
     );
   }
 }
@@ -393,24 +396,20 @@ export async function executeSubagent(
         : orchestratorStreamId;
     if (!targetStreamId) return false;
 
-    const result = await sendFollowUp(
+    const result = await deliverChildRunFollowUp({
       targetStreamId,
       followUp,
-      undefined,
-      undefined,
-      parentSession,
-    );
-    if (result.status === 'no_session') {
+      session: parentSession,
+      wake: options?.wake,
+    });
+    if (result.kind === 'no_session') {
       logger.warn(
         'subagentDelivery',
         `Unable to deliver subagent result for ${executionId}: parent stream ${targetStreamId} has no active session (status: ${result.streamStatus ?? 'unknown'}).`,
       );
       return false;
     }
-    if (
-      options?.wake &&
-      !(await wakeOrReleaseQueuedStream(targetStreamId, result))
-    ) {
+    if (result.kind === 'dropped') {
       logger.warn(
         'subagentDelivery',
         `Dropped subagent result for ${executionId}: parent stream ${targetStreamId} is gone and could not be resumed. The result remains in the execution report.`,

--- a/src/tools/deliveryEnvelope.ts
+++ b/src/tools/deliveryEnvelope.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared XML envelope formatting for child-run deliveries.
+ *
+ * The child drivers decide what facts belong in the payload. This helper owns
+ * the repetitive boundary mechanics: ordered attributes, XML escaping, and
+ * opening/closing tags.
+ */
+
+// Local imports
+import { escapeAttr } from '@shared/utils/xmlEscape';
+
+export interface DeliveryEnvelopeAttribute {
+  readonly name: string;
+  readonly value: string | number | boolean | null | undefined;
+}
+
+export interface DeliveryEnvelopeParams {
+  readonly tag: string;
+  readonly attributes: readonly DeliveryEnvelopeAttribute[];
+  readonly bodyLines: readonly string[];
+}
+
+export function formatDeliveryEnvelope(params: DeliveryEnvelopeParams): string {
+  const attrs = params.attributes
+    .filter((attr) => attr.value !== null && attr.value !== undefined)
+    .map((attr) => `${attr.name}="${escapeAttr(String(attr.value))}"`)
+    .join(' ');
+  const open = attrs ? `<${params.tag} ${attrs}>` : `<${params.tag}>`;
+  return [open, ...params.bodyLines, `</${params.tag}>`].join('\n');
+}

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -26,6 +26,7 @@ import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
 import { formatDuration } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { splitContentLines } from '@utils/text/stringUtils';
+import { formatDeliveryEnvelope } from './deliveryEnvelope';
 import type { DiffFileInfo } from './subagentDiffs';
 
 // ============================================================================
@@ -155,7 +156,6 @@ export function formatSubagentDelivery(
   },
 ): string {
   const lines = [
-    `<subagent-result id="${escapeAttr(result.executionId)}" agent="${escapeAttr(agentName)}" category="${escapeAttr(result.category)}" status="${escapeAttr(result.outcome)}">`,
     ...formatDeliveryPreamble({
       wallTimeMs: options?.wallTimeMs,
       workingDirectory: options?.workingDirectory,
@@ -194,8 +194,16 @@ export function formatSubagentDelivery(
     }
   }
 
-  lines.push('</subagent-result>');
-  return lines.join('\n');
+  return formatDeliveryEnvelope({
+    tag: 'subagent-result',
+    attributes: [
+      { name: 'id', value: result.executionId },
+      { name: 'agent', value: agentName },
+      { name: 'category', value: result.category },
+      { name: 'status', value: result.outcome },
+    ],
+    bodyLines: lines,
+  });
 }
 
 /**
@@ -213,18 +221,22 @@ export function formatSubagentError(
 ): string {
   const formatted = normalizeProviderError(err);
   const lines = [
-    `<subagent-error id="${escapeAttr(executionId)}" agent="${escapeAttr(agentName)}" retryable="${formatted.userRetryable ? 'true' : 'false'}">`,
     ...formatDeliveryPreamble({
       wallTimeMs: options?.wallTimeMs,
       workingDirectory: options?.workingDirectory,
       memoryMisses: options?.memoryMisses,
     }),
   ];
-  lines.push(
-    `<message>${escapeText(formatted.message)}</message>`,
-    '</subagent-error>',
-  );
-  return lines.join('\n');
+  lines.push(`<message>${escapeText(formatted.message)}</message>`);
+  return formatDeliveryEnvelope({
+    tag: 'subagent-error',
+    attributes: [
+      { name: 'id', value: executionId },
+      { name: 'agent', value: agentName },
+      { name: 'retryable', value: formatted.userRetryable },
+    ],
+    bodyLines: lines,
+  });
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

First F6 slice for #6976. This extracts the common child-run delivery mechanics without changing the child-run loop semantics.

- add `childRunDelivery` for best-effort report persistence and explicit-session follow-up wake/release
- route both the agent-CLI session loop and native delegation delivery through that helper
- add a small XML envelope helper used by agent-CLI and native subagent result/error formatting
- fix a stale progress-view test fixture by adding the required `streamInfo.kind` discriminator

## Single ownership

The new helper owns only the boundary mechanics shared by child-run drivers: writing the report, enqueueing the parent follow-up, and optionally waking or releasing the queued parent stream with the same explicit session. Native delegation still owns duplicate-delivery policy, result manifest writes, interim `onBeforeWaiting` delivery, and resume registry state. The agent-CLI loop still owns turn execution, interruption, outcome derivation, and terminal status.

This deliberately does not start #6967/#6979 HostInteractions work and does not touch the #6966/#7246 persistence-policy decisions.

## Validation

- `npm test -- --run src/test-kernel/tools/ChildRunDelivery.vitest.ts src/test-kernel/tools/SubagentDeliveryState.vitest.ts src/test-kernel/tools/AgentCliShared.vitest.ts src/test-kernel/tools/SubagentResults.vitest.ts src/test-kernel/tools/DelegationHeadless.vitest.mts src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts`
- `npm test -- --run src/test-kernel/tools/ChildRunDelivery.vitest.ts src/test-kernel/tools/SubagentDeliveryState.vitest.ts src/test-kernel/tools/AgentCliShared.vitest.ts src/test-kernel/tools/SubagentResults.vitest.ts src/test-kernel/tools/ToolStatusFormatting.vitest.ts src/test-kernel/tools/SubagentResultMeta.vitest.ts src/test-kernel/tools/DelegationHeadless.vitest.mts src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/progressView/ProcessOutputState.vitest.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing unrelated import-order warning in `codexToolTemplates.ts`)
- `npm run compile:fast`
- `git diff --check`

Refs #6976. Follow-up work remains to migrate the native execution driver itself into the shared session-loop strategy model.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches parent follow-up delivery for agent-CLI and subagent paths; behavior is intended to be equivalent but misclassified delivery could drop or fail to wake queued parent streams.
> 
> **Overview**
> Extracts shared **child-run boundary** behavior into `childRunDelivery` (`persistChildRunReport`, `deliverChildRunFollowUp`) and routes the **agent-CLI session loop** and **native subagent delegation** through it instead of inlining `sendFollowUp` / `wakeOrReleaseQueuedStream` / execution-store writes.
> 
> Delivery outcomes are normalized to `delivered` / `no_session` / `dropped`; callers still own duplicate-delivery policy, manifests, and warning text. **`formatDeliveryEnvelope`** centralizes XML root tags and escaping for agent-CLI and subagent result/error payloads.
> 
> Adds **`ChildRunDelivery.vitest.ts`** and fixes a progress-view test fixture by setting **`streamInfo.kind: 'agent'`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c2ad96b510ba783c500414d7641325516e738b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

