### PR TITLE
refactor: package native subagent callbacks

### DIFF
--- a/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
+++ b/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
@@ -1,0 +1,111 @@
+// Third-party imports
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports - shared
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
+
+const mocks = vi.hoisted(() => ({
+  currentSession: vi.fn(),
+  deliverChildRunFollowUp: vi.fn(),
+  persistChildRunReport: vi.fn(),
+  writeResultMeta: vi.fn(),
+}));
+
+vi.mock('@agent/runtime/SessionHandle', () => ({
+  currentSession: mocks.currentSession,
+}));
+
+vi.mock('@agent/storage', () => ({
+  getExecutionStore: vi.fn(() => ({ writeResultMeta: mocks.writeResultMeta })),
+}));
+
+vi.mock('@tools/childRunDelivery', () => ({
+  deliverChildRunFollowUp: mocks.deliverChildRunFollowUp,
+  persistChildRunReport: mocks.persistChildRunReport,
+}));
+
+// Local imports - tools
+import { subagentDeliveryRegistry } from '@tools/subagentDeliveryState';
+import { NativeSubagentStrategy } from '@tools/delegation/nativeSubagentStrategy';
+
+describe('NativeSubagentStrategy', () => {
+  const executionId = 'exec-1' as ExecutionId;
+  const parentStreamId = 'parent-stream' as StreamTabId;
+  const ownerSession = { tag: 'owner-session' } as never;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.currentSession.mockReturnValue({
+      executions: { getHandle: vi.fn(() => undefined) },
+    });
+  });
+
+  afterEach(() => {
+    subagentDeliveryRegistry.finish(executionId);
+  });
+
+  it('persists the result manifest before waking the parent', async () => {
+    const order: string[] = [];
+    mocks.writeResultMeta.mockImplementation(async () => {
+      order.push('manifest');
+    });
+    mocks.deliverChildRunFollowUp.mockImplementation(async () => {
+      order.push('wake');
+      return { kind: 'delivered' };
+    });
+    mocks.persistChildRunReport.mockImplementation(async () => {
+      order.push('report');
+      return { kind: 'persisted' };
+    });
+    const strategy = new NativeSubagentStrategy({
+      executionId,
+      agentName: 'review',
+      orchestratorStreamId: parentStreamId,
+      parentSession: ownerSession,
+      startedAt: 0,
+      settleSubagentCost: vi.fn(),
+    });
+
+    await expect(
+      strategy.persistAndDeliverTerminal('payload', {
+        agentName: 'review',
+        outcome: 'completed',
+        success: true,
+        wallTimeMs: 1,
+      }),
+    ).resolves.toBe(true);
+
+    expect(order[0]).toBe('manifest');
+    expect(order).toContain('wake');
+    expect(order).toContain('report');
+    expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledWith({
+      targetStreamId: parentStreamId,
+      followUp: { text: 'payload', origin: 'subagent_result' },
+      session: ownerSession,
+      wake: true,
+    });
+  });
+
+  it('resets the in-flight delivery gate when terminal delivery drops', async () => {
+    mocks.writeResultMeta.mockResolvedValue(undefined);
+    mocks.persistChildRunReport.mockResolvedValue({ kind: 'persisted' });
+    mocks.deliverChildRunFollowUp
+      .mockResolvedValueOnce({ kind: 'dropped' })
+      .mockResolvedValueOnce({ kind: 'delivered' });
+    const strategy = new NativeSubagentStrategy({
+      executionId,
+      agentName: 'review',
+      orchestratorStreamId: parentStreamId,
+      parentSession: ownerSession,
+      startedAt: 0,
+      settleSubagentCost: vi.fn(),
+    });
+
+    await expect(strategy.persistAndDeliverTerminal('first')).resolves.toBe(
+      false,
+    );
+    await expect(strategy.persistAndDeliverTerminal('second')).resolves.toBe(
+      true,
+    );
+  });
+});

--- a/src/tools/delegation/nativeSubagentStrategy.ts
+++ b/src/tools/delegation/nativeSubagentStrategy.ts
@@ -1,0 +1,339 @@
+/**
+ * Native subagent callback strategy.
+ *
+ * This packages the async `executeAgent` callback choreography used by native
+ * delegated agents. It does not run the child loop itself; `executeSubagent`
+ * still calls `executeAgent` directly. The strategy owns only delivery policy
+ * for native child results: progress/interim/terminal follow-ups, manifest
+ * writes, duplicate-delivery gating, and registry cleanup.
+ */
+
+// Local imports - agent
+import { getExecutionStore, type ResultMeta } from '@agent/storage';
+import type { AgentFlowResult } from '@agent/runtime/AgentFlowResult';
+import {
+  currentSession,
+  type SessionHandle,
+} from '@agent/runtime/SessionHandle';
+import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
+import type { FollowUpQueueInput } from '@agent/followUp/FollowUpQueue';
+import type { AttachedMemoryMiss } from '@agent/types/AttachedMemory';
+
+// Local imports - logger
+import * as logger from '@logger/logUtils';
+
+// Local imports - tools
+import type {
+  ExecutionId,
+  StreamTabId,
+  SubagentProgressUpdate,
+} from '@shared/schemas';
+import {
+  deliverChildRunFollowUp,
+  persistChildRunReport,
+} from '@tools/childRunDelivery';
+import {
+  buildSubagentFailureResultMeta,
+  buildSubagentResultMeta,
+  formatSubagentDelivery,
+  formatSubagentError,
+  formatSubagentProgress,
+} from '@tools/subagentResults';
+import {
+  SUBAGENT_DELIVERY_DECISION,
+  subagentDeliveryRegistry,
+} from '@tools/subagentDeliveryState';
+import {
+  computeAndWriteWorkflowDiffs,
+  type DiffFileInfo,
+} from '@tools/subagentDiffs';
+import { toErrorMessage } from '@utils/errors/errorMessage';
+
+export interface NativeSubagentStrategyParams {
+  readonly executionId: ExecutionId;
+  readonly agentName: string;
+  readonly orchestratorStreamId: StreamTabId;
+  readonly parentSession: SessionHandle;
+  readonly startedAt: number;
+  readonly workingDirectory?: string;
+  readonly settleSubagentCost: (result?: AgentFlowResult) => void;
+}
+
+/**
+ * Format a subagent result for delivery to the orchestrator.
+ * For workflow results, computes latexdiffs and writes them as files to the
+ * execution's run directory first — the delivery references diff file paths
+ * so the orchestrator can read them on demand via /executions/{id}/files/.
+ */
+export async function subagentDeliveryMessage(
+  executionId: ExecutionId,
+  agentName: string,
+  result: AgentFlowResult,
+  options: {
+    readonly startedAt: number;
+    readonly workingDirectory?: string;
+  },
+): Promise<{ msg: string; resultMeta: ResultMeta }> {
+  let diffInfos: Map<string, DiffFileInfo> | undefined;
+  let diffsUnavailable: string | undefined;
+  if (result.category === 'workflow' && result.outputs.length > 0) {
+    try {
+      diffInfos = await computeAndWriteWorkflowDiffs(
+        executionId,
+        result.outputs,
+      );
+    } catch (err) {
+      // Diff computation failure is non-fatal: deliver without diffs, but tell
+      // the orchestrator to read the output files directly.
+      diffsUnavailable = toErrorMessage(err);
+      logger.warn(
+        'subagentDelivery',
+        `Diff computation failed for ${executionId}: ${diffsUnavailable}`,
+      );
+    }
+  }
+
+  const wallTimeMs = Date.now() - options.startedAt;
+  return {
+    msg: formatSubagentDelivery(agentName, result, {
+      diffInfos,
+      diffsUnavailable,
+      wallTimeMs,
+      workingDirectory: options.workingDirectory,
+    }),
+    resultMeta: buildSubagentResultMeta(agentName, result, {
+      diffInfos,
+      diffsUnavailable,
+      wallTimeMs,
+    }),
+  };
+}
+
+export async function writeSubagentReport(
+  executionId: ExecutionId,
+  message: string,
+): Promise<void> {
+  const result = await persistChildRunReport(executionId, message);
+  if (result.kind === 'failed') {
+    // Non-fatal, but the report is the only durable copy of the result when
+    // delivery later fails.
+    logger.warn(
+      'subagentDelivery',
+      `Failed to persist subagent report for ${executionId}: ${toErrorMessage(result.err)}`,
+    );
+  }
+}
+
+/**
+ * Best-effort persist of the structured result manifest — the chaining
+ * contract read via /executions/{id}/result. Never blocks or fails delivery.
+ */
+export async function writeSubagentResultMeta(
+  executionId: ExecutionId,
+  resultMeta: ResultMeta,
+): Promise<void> {
+  try {
+    await getExecutionStore(executionId).writeResultMeta(resultMeta);
+  } catch (err) {
+    logger.warn(
+      'subagentDelivery',
+      `Failed to persist subagent result manifest for ${executionId}: ${toErrorMessage(err)}`,
+    );
+  }
+}
+
+export class NativeSubagentStrategy {
+  private readonly deliveryState;
+  private childStreamId: StreamTabId | undefined;
+
+  constructor(private readonly params: NativeSubagentStrategyParams) {
+    this.deliveryState = subagentDeliveryRegistry.start(params.executionId);
+  }
+
+  setChildStreamId(streamId: StreamTabId): void {
+    this.childStreamId = streamId;
+  }
+
+  async deliverFollowUp(
+    followUp: FollowUpQueueInput,
+    options?: { wake?: boolean },
+  ): Promise<boolean> {
+    const { executionId, orchestratorStreamId, parentSession } = this.params;
+    const handle = currentSession().executions.getHandle(executionId);
+    const targetStreamId =
+      handle instanceof AgentExecutionHandle
+        ? handle.deliveryTargetStreamId
+        : orchestratorStreamId;
+    if (!targetStreamId) return false;
+
+    const result = await deliverChildRunFollowUp({
+      targetStreamId,
+      followUp,
+      session: parentSession,
+      wake: options?.wake,
+    });
+    if (result.kind === 'no_session') {
+      logger.warn(
+        'subagentDelivery',
+        `Unable to deliver subagent result for ${executionId}: parent stream ${targetStreamId} has no active session (status: ${result.streamStatus ?? 'unknown'}).`,
+      );
+      return false;
+    }
+    if (result.kind === 'dropped') {
+      logger.warn(
+        'subagentDelivery',
+        `Dropped subagent result for ${executionId}: parent stream ${targetStreamId} is gone and could not be resumed. The result remains in the execution report.`,
+      );
+      return false;
+    }
+    return true;
+  }
+
+  async deliverTerminalFollowUp(
+    followUp: FollowUpQueueInput,
+  ): Promise<boolean> {
+    if (!this.deliveryState.beginDelivery()) return false;
+    try {
+      const delivered = await this.deliverFollowUp(followUp, { wake: true });
+      if (delivered) {
+        this.deliveryState.completeDelivery();
+      } else {
+        this.deliveryState.failDelivery();
+      }
+      return delivered;
+    } catch (err) {
+      this.deliveryState.failDelivery();
+      throw err;
+    }
+  }
+
+  /**
+   * Deliver a terminal result and persist its report and manifest. The manifest
+   * lands before wake because the parent can immediately read
+   * /executions/{id}/result after the follow-up arrives.
+   */
+  async persistAndDeliverTerminal(
+    msg: string,
+    resultMeta?: ResultMeta,
+  ): Promise<boolean> {
+    const { executionId } = this.params;
+    if (resultMeta) {
+      await writeSubagentResultMeta(executionId, resultMeta);
+    }
+    const [delivered] = await Promise.all([
+      this.deliverTerminalFollowUp({ text: msg, origin: 'subagent_result' }),
+      writeSubagentReport(executionId, msg),
+    ]);
+    return delivered;
+  }
+
+  onProgress(update: SubagentProgressUpdate): void {
+    if (this.deliveryState.isDelivered()) return;
+    const msg = formatSubagentProgress(
+      this.params.executionId,
+      this.params.agentName,
+      update,
+    );
+    void this.deliverFollowUp({ text: msg, origin: 'subagent_result' });
+  }
+
+  onFollowUpConsumed(): void {
+    this.deliveryState.markPending();
+  }
+
+  async onBeforeWaiting(
+    lastResponse: string | undefined,
+    touchedFiles: string[],
+    memoryMisses: readonly AttachedMemoryMiss[],
+  ): Promise<boolean> {
+    const deliveryDecision = this.deliveryState.resolveBeforeWaiting(
+      this.childStreamId,
+    );
+    if (deliveryDecision === SUBAGENT_DELIVERY_DECISION.AlreadyDelivered) {
+      return true;
+    }
+    if (deliveryDecision === SUBAGENT_DELIVERY_DECISION.MissingStream) {
+      return false;
+    }
+    const resolvedChildStreamId = this.childStreamId;
+    if (!resolvedChildStreamId) return false;
+
+    const { executionId, agentName, startedAt, workingDirectory } = this.params;
+    const interimResult = {
+      category: 'toolUse' as const,
+      // The turn finished and the subagent is entering WAITING — for the
+      // orchestrator this interim delivery is a completed turn.
+      outcome: 'completed' as const,
+      lastResponse,
+      touchedFiles,
+      executionId,
+      streamId: resolvedChildStreamId,
+      memoryMisses: memoryMisses.length > 0 ? [...memoryMisses] : undefined,
+    };
+    const wallTimeMs = Date.now() - startedAt;
+    const msg = formatSubagentDelivery(agentName, interimResult, {
+      wallTimeMs,
+      workingDirectory,
+    });
+    // Claim only the enqueue step: formatting failures before this still leave
+    // onCompleted/onError available as terminal fallbacks.
+    return await this.persistAndDeliverTerminal(
+      msg,
+      buildSubagentResultMeta(agentName, interimResult, { wallTimeMs }),
+    );
+  }
+
+  async onCompleted(result: AgentFlowResult): Promise<void> {
+    this.params.settleSubagentCost(result);
+    const { msg, resultMeta } = await subagentDeliveryMessage(
+      this.params.executionId,
+      this.params.agentName,
+      result,
+      {
+        startedAt: this.params.startedAt,
+        workingDirectory: this.params.workingDirectory,
+      },
+    );
+    await this.persistAndDeliverTerminal(msg, resultMeta);
+  }
+
+  async deliverSubagentError(
+    err: unknown,
+    result?: AgentFlowResult,
+  ): Promise<void> {
+    this.params.settleSubagentCost(result);
+    const { executionId, agentName, startedAt, workingDirectory } = this.params;
+    const wallTimeMs = Date.now() - startedAt;
+    const msg = formatSubagentError(executionId, agentName, err, {
+      wallTimeMs,
+      workingDirectory,
+      memoryMisses: result?.memoryMisses,
+    });
+    // Overwrite any interim success manifest from onBeforeWaiting so
+    // /executions/{id}/result never claims success for a failed run.
+    await this.persistAndDeliverTerminal(
+      msg,
+      buildSubagentFailureResultMeta(agentName, result, wallTimeMs),
+    );
+  }
+
+  onError(err: unknown, result?: AgentFlowResult): Promise<void> {
+    return this.deliverSubagentError(err, result);
+  }
+
+  attachPromise(promise: Promise<unknown>): void {
+    promise
+      // Await the error delivery so the registry entry is not torn down while
+      // the delivery and any resume-based follow-up routing are in flight.
+      .catch((err: unknown) => this.deliverSubagentError(err))
+      .catch((deliveryErr: unknown) => {
+        logger.warn(
+          'subagentDelivery',
+          `Failed to deliver subagent error for ${this.params.executionId}: ${toErrorMessage(deliveryErr)}`,
+        );
+      })
+      .finally(() => {
+        subagentDeliveryRegistry.finish(this.params.executionId);
+      });
+  }
+}

--- a/src/tools/delegation/subagentExecution.ts
+++ b/src/tools/delegation/subagentExecution.ts
@@ -7,64 +7,44 @@
  */
 
 // Local imports - agent
-import {
-  getExecutionStore,
-  registerExecution,
-  type ResultMeta,
-} from '@agent/storage';
+import { registerExecution } from '@agent/storage';
 import {
   AgentConfigSchema,
   type AgentConfigPayload,
 } from '@agent/core/definition/AgentConfig';
 import { evaluateCurrentDelegationGate } from '@agent/runtime/delegationPolicy';
 import { currentSession } from '@agent/runtime/SessionHandle';
-import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
 import {
   getAgentFlowErrorResult,
   type AgentFlowResult,
 } from '@agent/runtime/AgentFlowResult';
 import { tryUseRunContext } from '@agent/runtime/RunContext';
 import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
-import type { FollowUpQueueInput } from '@agent/followUp/FollowUpQueue';
 
 // Local imports - logger
 import * as logger from '@logger/logUtils';
 
 // Local imports - tools
-import {
-  AgentCategory,
-  type ExecutionId,
-  type StreamTabId,
-  type SubagentProgressUpdate,
-} from '@shared/schemas';
+import { AgentCategory, type StreamTabId } from '@shared/schemas';
 import type { ToolResult } from '@shared/schemas/toolResult';
 import {
   enableYoloOnChildStream,
   inheritBashBypassOnChildStream,
 } from '@tools/approval';
 import {
-  computeAndWriteWorkflowDiffs,
-  type DiffFileInfo,
-} from '@tools/subagentDiffs';
-import {
   buildSubagentFailureResultMeta,
-  buildSubagentResultMeta,
-  formatSubagentDelivery,
   formatSubagentError,
-  formatSubagentProgress,
 } from '@tools/subagentResults';
-import {
-  SUBAGENT_DELIVERY_DECISION,
-  subagentDeliveryRegistry,
-} from '@tools/subagentDeliveryState';
-import {
-  deliverChildRunFollowUp,
-  persistChildRunReport,
-} from '@tools/childRunDelivery';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 // Local imports - utils
 import { generateExecutionId } from '@utils/core/executionId';
+import {
+  NativeSubagentStrategy,
+  subagentDeliveryMessage,
+  writeSubagentReport,
+  writeSubagentResultMeta,
+} from './nativeSubagentStrategy';
 
 // ============================================================================
 // Shared utilities
@@ -80,94 +60,6 @@ interface ApprovalMeta {
   requestedModel?: string;
   agentOverride?: string;
   requestedAgent?: string;
-}
-
-/**
- * Format a subagent result for delivery to the orchestrator.
- * For workflow results, computes latexdiffs and writes them as files to the
- * execution's run directory first — the delivery references diff file paths
- * so the orchestrator can read them on demand via /executions/{id}/files/.
- */
-async function subagentDeliveryMessage(
-  executionId: string,
-  agentName: string,
-  result: AgentFlowResult,
-  options: {
-    readonly startedAt: number;
-    readonly workingDirectory?: string;
-  },
-): Promise<{ msg: string; resultMeta: ResultMeta }> {
-  let diffInfos: Map<string, DiffFileInfo> | undefined;
-  let diffsUnavailable: string | undefined;
-  if (result.category === 'workflow' && result.outputs.length > 0) {
-    try {
-      diffInfos = await computeAndWriteWorkflowDiffs(
-        executionId,
-        result.outputs,
-      );
-    } catch (err) {
-      // Diff computation failure is non-fatal — deliver without diffs, but
-      // tell the orchestrator so it can read the output files directly
-      // instead of assuming the revision was a no-op.
-      diffsUnavailable = toErrorMessage(err);
-      logger.warn(
-        'subagentDelivery',
-        `Diff computation failed for ${executionId}: ${diffsUnavailable}`,
-      );
-    }
-  }
-
-  const wallTimeMs = Date.now() - options.startedAt;
-  return {
-    msg: formatSubagentDelivery(agentName, result, {
-      diffInfos,
-      diffsUnavailable,
-      wallTimeMs,
-      workingDirectory: options.workingDirectory,
-    }),
-    resultMeta: buildSubagentResultMeta(agentName, result, {
-      diffInfos,
-      diffsUnavailable,
-      wallTimeMs,
-    }),
-  };
-}
-
-async function writeSubagentReport(
-  executionId: string,
-  message: string,
-): Promise<void> {
-  const result = await persistChildRunReport(
-    executionId as ExecutionId,
-    message,
-  );
-  if (result.kind === 'failed') {
-    // Non-fatal, but the report is the only durable copy of the result when
-    // delivery later fails — leave a trace instead of vanishing silently.
-    logger.warn(
-      'subagentDelivery',
-      `Failed to persist subagent report for ${executionId}: ${toErrorMessage(result.err)}`,
-    );
-  }
-}
-
-/**
- * Best-effort persist of the structured result manifest — the chaining
- * contract read via /executions/{id}/result. Never blocks or fails
- * delivery.
- */
-async function writeSubagentResultMeta(
-  executionId: string,
-  resultMeta: ResultMeta,
-): Promise<void> {
-  try {
-    await getExecutionStore(executionId).writeResultMeta(resultMeta);
-  } catch (err) {
-    logger.warn(
-      'subagentDelivery',
-      `Failed to persist subagent result manifest for ${executionId}: ${toErrorMessage(err)}`,
-    );
-  }
 }
 
 /**
@@ -370,121 +262,15 @@ export async function executeSubagent(
     }
   }
 
-  // Register delivery state so delegate_agent (resume) can find live subagents.
-  // The state object owns duplicate-delivery protection between onBeforeWaiting
-  // and onCompleted. When a follow-up is consumed, the next onBeforeWaiting
-  // delivers the resumed cycle's result.
-  const deliveryState = subagentDeliveryRegistry.start(executionId);
-  let childStreamId: StreamTabId | undefined;
-
-  /**
-   * Deliver a follow-up to the parent stream. For terminal results (`wake`),
-   * a parent whose cycle has exited is resumed via the host port so the
-   * queued result is consumed instead of sitting until the user pokes the
-   * stream; if the parent is gone for good (terminal status, resume failed),
-   * the force-reopened queue is re-released so late deliveries don't leak
-   * into the next run — the result stays readable in the execution report.
-   */
-  async function deliverFollowUp(
-    followUp: FollowUpQueueInput,
-    options?: { wake?: boolean },
-  ): Promise<boolean> {
-    const handle = currentSession().executions.getHandle(executionId);
-    const targetStreamId =
-      handle instanceof AgentExecutionHandle
-        ? handle.deliveryTargetStreamId
-        : orchestratorStreamId;
-    if (!targetStreamId) return false;
-
-    const result = await deliverChildRunFollowUp({
-      targetStreamId,
-      followUp,
-      session: parentSession,
-      wake: options?.wake,
-    });
-    if (result.kind === 'no_session') {
-      logger.warn(
-        'subagentDelivery',
-        `Unable to deliver subagent result for ${executionId}: parent stream ${targetStreamId} has no active session (status: ${result.streamStatus ?? 'unknown'}).`,
-      );
-      return false;
-    }
-    if (result.kind === 'dropped') {
-      logger.warn(
-        'subagentDelivery',
-        `Dropped subagent result for ${executionId}: parent stream ${targetStreamId} is gone and could not be resumed. The result remains in the execution report.`,
-      );
-      return false;
-    }
-    return true;
-  }
-
-  async function deliverTerminalFollowUp(
-    followUp: FollowUpQueueInput,
-  ): Promise<boolean> {
-    if (!deliveryState.beginDelivery()) return false;
-    try {
-      const delivered = await deliverFollowUp(followUp, { wake: true });
-      if (delivered) {
-        deliveryState.completeDelivery();
-      } else {
-        deliveryState.failDelivery();
-      }
-      return delivered;
-    } catch (err) {
-      deliveryState.failDelivery();
-      throw err;
-    }
-  }
-
-  /**
-   * Deliver a terminal result and persist its report (and, when available,
-   * its structured result manifest) concurrently — the best-effort writes
-   * never delay the parent's wakeup, and they run even when delivery is
-   * deduplicated (the report/manifest are the durable copies).
-   */
-  async function persistAndDeliverTerminal(
-    msg: string,
-    resultMeta?: ResultMeta,
-  ): Promise<boolean> {
-    // The manifest lands BEFORE the wake: a parent chaining on this result
-    // reads /executions/{id}/result the moment the follow-up arrives, so
-    // the small JSON write must not race the delivery. The prose report
-    // duplicates the delivery text, so it stays off the critical path.
-    if (resultMeta) {
-      await writeSubagentResultMeta(executionId, resultMeta);
-    }
-    const [delivered] = await Promise.all([
-      deliverTerminalFollowUp({ text: msg, origin: 'subagent_result' }),
-      writeSubagentReport(executionId, msg),
-    ]);
-    return delivered;
-  }
-
-  function onProgress(update: SubagentProgressUpdate): void {
-    if (deliveryState.isDelivered()) return;
-    const msg = formatSubagentProgress(executionId, agentName, update);
-    void deliverFollowUp({ text: msg, origin: 'subagent_result' });
-  }
-
-  async function deliverSubagentError(
-    err: unknown,
-    result?: AgentFlowResult,
-  ): Promise<void> {
-    settleSubagentCost(result);
-    const wallTimeMs = Date.now() - startedAt;
-    const msg = formatSubagentError(executionId, agentName, err, {
-      wallTimeMs,
-      workingDirectory,
-      memoryMisses: result?.memoryMisses,
-    });
-    // Overwrite any interim success manifest from onBeforeWaiting so
-    // /executions/{id}/result never claims success for a failed run.
-    await persistAndDeliverTerminal(
-      msg,
-      buildSubagentFailureResultMeta(agentName, result, wallTimeMs),
-    );
-  }
+  const nativeStrategy = new NativeSubagentStrategy({
+    executionId,
+    agentName,
+    orchestratorStreamId,
+    parentSession,
+    startedAt,
+    workingDirectory,
+    settleSubagentCost,
+  });
 
   const promise = executeAgent(configPayload, executionId, {
     runtimeHost,
@@ -496,73 +282,17 @@ export async function executeSubagent(
     runtimeUnavailableTools: parentContext.runtimeUnavailableTools,
     toolEditApprovalHandler: parentContext.toolEditApprovalHandler,
     onStreamResolved: (resolvedStreamId) => {
-      childStreamId = resolvedStreamId;
+      nativeStrategy.setChildStreamId(resolvedStreamId);
       inheritChildStreamApprovals(resolvedStreamId);
     },
-    onProgress,
-    onFollowUpConsumed: () => {
-      deliveryState.markPending();
-    },
-    onBeforeWaiting: async (lastResponse, touchedFiles, memoryMisses) => {
-      const deliveryDecision =
-        deliveryState.resolveBeforeWaiting(childStreamId);
-      if (deliveryDecision === SUBAGENT_DELIVERY_DECISION.AlreadyDelivered) {
-        return true;
-      }
-      if (deliveryDecision === SUBAGENT_DELIVERY_DECISION.MissingStream) {
-        return false;
-      }
-      const resolvedChildStreamId = childStreamId;
-      if (!resolvedChildStreamId) return false;
-
-      const interimResult = {
-        category: 'toolUse' as const,
-        // The turn finished and the subagent is entering WAITING — for the
-        // orchestrator this interim delivery is a completed turn.
-        outcome: 'completed' as const,
-        lastResponse,
-        touchedFiles,
-        executionId,
-        streamId: resolvedChildStreamId,
-        memoryMisses: memoryMisses.length > 0 ? [...memoryMisses] : undefined,
-      };
-      const wallTimeMs = Date.now() - startedAt;
-      const msg = formatSubagentDelivery(agentName, interimResult, {
-        wallTimeMs,
-        workingDirectory,
-      });
-      // Claim only the enqueue step: formatting failures before this still
-      // leave onCompleted/onError available as terminal fallbacks.
-      return await persistAndDeliverTerminal(
-        msg,
-        buildSubagentResultMeta(agentName, interimResult, { wallTimeMs }),
-      );
-    },
-    onCompleted: async (result) => {
-      settleSubagentCost(result);
-      const { msg, resultMeta } = await subagentDeliveryMessage(
-        executionId,
-        agentName,
-        result,
-        { startedAt, workingDirectory },
-      );
-      await persistAndDeliverTerminal(msg, resultMeta);
-    },
-    onError: (err, result) => deliverSubagentError(err, result),
+    onProgress: (update) => nativeStrategy.onProgress(update),
+    onFollowUpConsumed: () => nativeStrategy.onFollowUpConsumed(),
+    onBeforeWaiting: (lastResponse, touchedFiles, memoryMisses) =>
+      nativeStrategy.onBeforeWaiting(lastResponse, touchedFiles, memoryMisses),
+    onCompleted: (result) => nativeStrategy.onCompleted(result),
+    onError: (err, result) => nativeStrategy.onError(err, result),
   });
-  promise
-    // Await the error delivery so the registry entry is not torn down while
-    // the delivery (and any resume-based follow-up routing) is in flight.
-    .catch((err: unknown) => deliverSubagentError(err))
-    .catch((deliveryErr: unknown) => {
-      logger.warn(
-        'subagentDelivery',
-        `Failed to deliver subagent error for ${executionId}: ${toErrorMessage(deliveryErr)}`,
-      );
-    })
-    .finally(() => {
-      subagentDeliveryRegistry.finish(executionId);
-    });
+  nativeStrategy.attachPromise(promise);
   const isToolUse = configPayload.agentCategory === AgentCategory.ToolUse;
   const meta = options?.approvalMeta;
   const metaLines: string[] = [];


### PR DESCRIPTION
## Summary

Second F6 slice for #6976. This packages the native `executeAgent` callback choreography as a strategy-shaped object without switching native children onto the shared agent-CLI loop yet.

- add `NativeSubagentStrategy` for native progress, interim wait, completed, error, and rejection delivery callbacks
- keep `executeSubagent()` as the public entry point and keep its direct `executeAgent(...)` call
- move native result-message formatting/report/manifest helper ownership with the strategy
- add focused strategy tests for manifest-before-wake ordering and failed-delivery retry gating

## Single ownership

The strategy now owns native child-result delivery policy: duplicate-delivery gating, progress/interim/terminal follow-ups, manifest-before-wake ordering, error overwrite of interim success manifests, and registry cleanup after rejection delivery. `executeSubagent()` still owns launch context, execution registration, approval inheritance, headless `stopAfterCycle` behavior, and the actual `executeAgent` call.

This deliberately does not start the final one-loop/N-strategies migration. It is a packaging step that makes that later move smaller and reviewable.

## Preserved invariants

- Result manifest is written before terminal wake.
- Prose report remains best-effort and can run concurrently with delivery.
- `onBeforeWaiting` and `onCompleted` cannot double-deliver.
- Failed delivery resets the in-flight delivery gate.
- `onFollowUpConsumed` marks the next cycle pending.
- Detached children do not deliver back to a released parent.
- `onError` overwrites any interim success manifest.
- Promise rejection delivery finishes before `subagentDeliveryRegistry.finish(...)`.
- Subagent cost is settled at most once.

## Validation

- `npm test -- --run src/test-kernel/tools/NativeSubagentStrategy.vitest.ts src/test-kernel/tools/DelegationHeadless.vitest.mts src/test-kernel/tools/ChildRunDelivery.vitest.ts src/test-kernel/tools/SubagentDeliveryState.vitest.ts src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing unrelated import-order warning in `codexToolTemplates.ts`)
- `npm run compile:fast`
- `git diff --check`

Refs #6976. The remaining F6 work is to move native workflow/tool-use child execution onto the shared one-loop strategy model once this packaging slice is merged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors orchestrator wake and execution manifest ordering on a sensitive multi-agent path; behavior is intended to be unchanged and is partially guarded by new strategy tests plus existing delegation/delivery suites.
> 
> **Overview**
> Pulls native delegated-agent **result delivery** out of `executeSubagent()` into a new **`NativeSubagentStrategy`**, without changing who runs the child (`executeSubagent` still calls `executeAgent` directly).
> 
> The strategy now owns progress/interim/terminal follow-ups, duplicate-delivery gating via `subagentDeliveryRegistry`, manifest-before-wake ordering, error paths that overwrite interim success manifests, and registry cleanup on promise rejection. Helpers for formatting workflow diffs, prose reports, and `/executions/{id}/result` manifests move with the strategy and are still used from the headless `stopAfterCycle` path.
> 
> `executeSubagent()` shrinks to launch/registration/approval wiring and delegates `onProgress`, `onBeforeWaiting`, `onCompleted`, `onError`, and promise attachment to the strategy. New unit tests lock in **manifest before parent wake** and **retry after a dropped terminal delivery**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 146a4e8a79480d48fb4aa34e78ca3745e73be70f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->