### PR TITLE
refactor: bind native subagent delivery to run handles

### DIFF
--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -145,6 +145,7 @@ export type AgentRunHandle = Pick<
   | 'runtimeHost'
   | 'trace'
   | 'result'
+  | 'deliveryTargetStreamId'
 >;
 
 /**

--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -174,6 +174,7 @@ describe('headless delegation', () => {
       expect.objectContaining({
         isSubagent: true,
         parentStreamId: 'parent-stream',
+        session: expect.any(Object),
         stopAfterCycle: true,
       }),
     );
@@ -388,10 +389,15 @@ describe('headless delegation', () => {
     expect(result.output).toContain(
       "Subagent 'review' launched. Result will be delivered automatically",
     );
-    expect(mocks.executeAgent).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.any(String),
-      expect.not.objectContaining({ stopAfterCycle: true }),
+    const executeOptions = mocks.executeAgent.mock.calls.at(-1)?.[2];
+    expect(executeOptions).toEqual(
+      expect.objectContaining({
+        onRun: expect.any(Function),
+        session: expect.any(Object),
+      }),
+    );
+    expect(executeOptions).not.toEqual(
+      expect.objectContaining({ stopAfterCycle: true }),
     );
   });
 

--- a/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
+++ b/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
@@ -1,18 +1,16 @@
 // Third-party imports
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+// Local imports - agent
+import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
+
 // Local imports - shared
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
 const mocks = vi.hoisted(() => ({
-  currentSession: vi.fn(),
   deliverChildRunFollowUp: vi.fn(),
   persistChildRunReport: vi.fn(),
   writeResultMeta: vi.fn(),
-}));
-
-vi.mock('@agent/runtime/SessionHandle', () => ({
-  currentSession: mocks.currentSession,
 }));
 
 vi.mock('@agent/storage', () => ({
@@ -24,7 +22,6 @@ vi.mock('@tools/childRunDelivery', () => ({
   persistChildRunReport: mocks.persistChildRunReport,
 }));
 
-// Local imports - tools
 import { subagentDeliveryRegistry } from '@tools/subagentDeliveryState';
 import { NativeSubagentStrategy } from '@tools/delegation/nativeSubagentStrategy';
 
@@ -35,9 +32,6 @@ describe('NativeSubagentStrategy', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.currentSession.mockReturnValue({
-      executions: { getHandle: vi.fn(() => undefined) },
-    });
   });
 
   afterEach(() => {
@@ -84,6 +78,76 @@ describe('NativeSubagentStrategy', () => {
       session: ownerSession,
       wake: true,
     });
+  });
+
+  it('uses the captured run handle delivery target', async () => {
+    const handleParent = 'handle-parent' as StreamTabId;
+    const childStream = 'child-stream' as StreamTabId;
+    mocks.persistChildRunReport.mockResolvedValue({ kind: 'persisted' });
+    mocks.deliverChildRunFollowUp.mockResolvedValue({ kind: 'delivered' });
+    const strategy = new NativeSubagentStrategy({
+      executionId,
+      agentName: 'review',
+      orchestratorStreamId: parentStreamId,
+      parentSession: ownerSession,
+      startedAt: 0,
+      settleSubagentCost: vi.fn(),
+    });
+    strategy.setRunHandle(
+      new AgentExecutionHandle(
+        executionId,
+        handleParent,
+        childStream,
+        'review',
+        'toolUse',
+        {} as never,
+      ),
+    );
+
+    await expect(strategy.persistAndDeliverTerminal('payload')).resolves.toBe(
+      true,
+    );
+
+    expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledWith({
+      targetStreamId: handleParent,
+      followUp: { text: 'payload', origin: 'subagent_result' },
+      session: ownerSession,
+      wake: true,
+    });
+  });
+
+  it('suppresses delivery after the captured run handle is detached', async () => {
+    const handleParent = 'handle-parent' as StreamTabId;
+    const childStream = 'child-stream' as StreamTabId;
+    mocks.persistChildRunReport.mockResolvedValue({ kind: 'persisted' });
+    const strategy = new NativeSubagentStrategy({
+      executionId,
+      agentName: 'review',
+      orchestratorStreamId: parentStreamId,
+      parentSession: ownerSession,
+      startedAt: 0,
+      settleSubagentCost: vi.fn(),
+    });
+    const handle = new AgentExecutionHandle(
+      executionId,
+      handleParent,
+      childStream,
+      'review',
+      'toolUse',
+      {} as never,
+    );
+    strategy.setRunHandle(handle);
+    handle.detach();
+
+    await expect(strategy.persistAndDeliverTerminal('payload')).resolves.toBe(
+      false,
+    );
+
+    expect(mocks.deliverChildRunFollowUp).not.toHaveBeenCalled();
+    expect(mocks.persistChildRunReport).toHaveBeenCalledWith(
+      executionId,
+      'payload',
+    );
   });
 
   it('resets the in-flight delivery gate when terminal delivery drops', async () => {

--- a/src/tools/delegation/nativeSubagentStrategy.ts
+++ b/src/tools/delegation/nativeSubagentStrategy.ts
@@ -11,11 +11,8 @@
 // Local imports - agent
 import { getExecutionStore, type ResultMeta } from '@agent/storage';
 import type { AgentFlowResult } from '@agent/runtime/AgentFlowResult';
-import {
-  currentSession,
-  type SessionHandle,
-} from '@agent/runtime/SessionHandle';
-import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import type { AgentRunHandle } from '@agent/runtime/executionRegistry';
 import type { FollowUpQueueInput } from '@agent/followUp/FollowUpQueue';
 import type { AttachedMemoryMiss } from '@agent/types/AttachedMemory';
 
@@ -145,6 +142,7 @@ export async function writeSubagentResultMeta(
 export class NativeSubagentStrategy {
   private readonly deliveryState;
   private childStreamId: StreamTabId | undefined;
+  private runHandle: AgentRunHandle | undefined;
 
   constructor(private readonly params: NativeSubagentStrategyParams) {
     this.deliveryState = subagentDeliveryRegistry.start(params.executionId);
@@ -154,16 +152,19 @@ export class NativeSubagentStrategy {
     this.childStreamId = streamId;
   }
 
+  setRunHandle(handle: AgentRunHandle): void {
+    this.runHandle = handle;
+    this.childStreamId = handle.childStreamId;
+  }
+
   async deliverFollowUp(
     followUp: FollowUpQueueInput,
     options?: { wake?: boolean },
   ): Promise<boolean> {
     const { executionId, orchestratorStreamId, parentSession } = this.params;
-    const handle = currentSession().executions.getHandle(executionId);
-    const targetStreamId =
-      handle instanceof AgentExecutionHandle
-        ? handle.deliveryTargetStreamId
-        : orchestratorStreamId;
+    const targetStreamId = this.runHandle
+      ? this.runHandle.deliveryTargetStreamId
+      : orchestratorStreamId;
     if (!targetStreamId) return false;
 
     const result = await deliverChildRunFollowUp({

--- a/src/tools/delegation/subagentExecution.ts
+++ b/src/tools/delegation/subagentExecution.ts
@@ -215,6 +215,7 @@ export async function executeSubagent(
       let subagentError: unknown;
       const result = await executeAgent(configPayload, executionId, {
         runtimeHost,
+        session: parentSession,
         isSubagent: true,
         enforceCategory: true,
         parentStreamId: orchestratorStreamId,
@@ -274,6 +275,7 @@ export async function executeSubagent(
 
   const promise = executeAgent(configPayload, executionId, {
     runtimeHost,
+    session: parentSession,
     isSubagent: true,
     enforceCategory: true,
     parentStreamId: orchestratorStreamId,
@@ -291,6 +293,7 @@ export async function executeSubagent(
       nativeStrategy.onBeforeWaiting(lastResponse, touchedFiles, memoryMisses),
     onCompleted: (result) => nativeStrategy.onCompleted(result),
     onError: (err, result) => nativeStrategy.onError(err, result),
+    onRun: (handle) => nativeStrategy.setRunHandle(handle),
   });
   nativeStrategy.attachPromise(promise);
   const isToolUse = configPayload.agentCategory === AgentCategory.ToolUse;


### PR DESCRIPTION
## Summary

This is the third partial F6 slice for #6976. Native delegated agents now bind delivery to the live runtime run handle instead of recovering parent/child ownership through a session-global lookup.

Changes:
- expose `deliveryTargetStreamId` through `AgentRunHandle`
- pass the owning `SessionHandle` into both native `executeAgent` launch branches
- capture the live run handle with `onRun` in the async native delegation path
- route native follow-up delivery from the captured handle, preserving the pre-handle fallback only before the lifecycle handle exists
- preserve detached-child behavior: once the handle has no delivery target, the result is persisted but not delivered to the old parent

This does not close #6976. Native delegation still calls `executeAgent` directly; the remaining work is the full one-loop/N-strategies migration.

## Invariants preserved

- no result XML or storage format changes
- result manifest still writes before parent wake
- report persistence remains best-effort
- no change to subagent cost roll-up
- no change to early tool-use delivery before `WAITING`
- no deletion of the synchronous `stopAfterCycle` path

## Validation

- `npm test -- --run src/test-kernel/tools/NativeSubagentStrategy.vitest.ts src/test-kernel/tools/DelegationHeadless.vitest.mts`
- `npm test -- --run src/test-kernel/tools/NativeSubagentStrategy.vitest.ts src/test-kernel/tools/DelegationHeadless.vitest.mts src/test-kernel/tools/ChildRunDelivery.vitest.ts src/test-kernel/tools/SubagentDeliveryState.vitest.ts src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts`
- `npm run typecheck`
- `npm run lint` (passes with the pre-existing unrelated `codexToolTemplates.ts` import-order warning)
- `npm run compile:fast`
- `git diff --check`

No #6981 ledger row is needed: this introduces no shim, dual-write, projection, persisted fallback, or compatibility path.

Refs #6976
Refs #6953

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestrator wake routing for async native subagents; behavior is covered by new strategy and headless delegation tests, but wrong handle binding could mis-deliver or drop results.
> 
> **Overview**
> Native delegated subagents now route parent follow-ups from a **captured runtime run handle** instead of looking up the execution in the current session.
> 
> **`AgentRunHandle`** exposes **`deliveryTargetStreamId`** (including after **`detach()`**, when delivery is intentionally suppressed). **`NativeSubagentStrategy`** stores the handle via **`setRunHandle`** / async **`onRun`**, uses that target for **`deliverFollowUp`**, and only falls back to **`orchestratorStreamId`** before a handle exists. **`executeSubagent`** passes the owning **`SessionHandle`** into both sync and async **`executeAgent`** launches and wires **`onRun`** on the async path.
> 
> Tests cover handle-based delivery, detached-handle suppression (persist without wake), and updated delegation launch expectations (**`session`**, **`onRun`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b84f07c2abecd78744613045987724abc790f1f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->