### PR TITLE
refactor: add persisted flow replay cursor

### DIFF
--- a/src/agent/node/index.ts
+++ b/src/agent/node/index.ts
@@ -97,6 +97,10 @@ class BaseNode<
     }
     return next;
   }
+  /** Successor table used by persisted flows to build graph-local replay cursors. */
+  successorEntries(): readonly [Action, BaseNode][] {
+    return [...this._successors.entries()];
+  }
   clone(): this {
     const clonedNode = Object.create(Object.getPrototypeOf(this));
     Object.assign(clonedNode, this);

--- a/src/agent/node/persistedFlow.ts
+++ b/src/agent/node/persistedFlow.ts
@@ -16,10 +16,19 @@ export function flowKey(runId: string): string {
 const CHANNEL = 'PersistedFlow';
 logger.initialize(CHANNEL);
 
-export const FLOW_RECORD_SCHEMA_VERSION = 1;
+export const FLOW_RECORD_SCHEMA_VERSION = 2;
+const START_NODE_ID = 'start';
 
 interface NodeRecord {
   action?: string;
+  nodeId?: string;
+}
+
+export interface FlowCursor {
+  /** The next graph-local node path, or null when the flow has reached a terminal edge. */
+  nextNodeId: string | null;
+  /** Last action emitted by the previous node, for diagnostics and legacy parity. */
+  lastAction?: string;
 }
 
 export interface FlowRecord {
@@ -28,6 +37,11 @@ export interface FlowRecord {
   params: Record<string, unknown>;
   shared: unknown;
   createdAt: string;
+  /**
+   * Authoritative replay cursor. `nodes[]` is now only an audit log: it can be
+   * capped or moved later without changing resume semantics.
+   */
+  cursor?: FlowCursor;
   nodes: NodeRecord[];
 }
 
@@ -83,6 +97,8 @@ export class PersistedFlow<
    * stepWithResult that immediately follows the previous step's write).
    */
   private cachedRecord: FlowRecord | null = null;
+  private nodeIds: Map<BaseNode, string> | null = null;
+  private nodesById: Map<string, BaseNode> | null = null;
 
   /**
    * Optional write-through projection callback.
@@ -137,7 +153,8 @@ export class PersistedFlow<
     while ((await this.stepWithResult()).hasMore) {
       // step loop
     }
-    return this.cachedRecord?.nodes.at(-1)?.action as Action | undefined;
+    return (this.cachedRecord?.cursor?.lastAction ??
+      this.cachedRecord?.nodes.at(-1)?.action) as Action | undefined;
   }
 
   /**
@@ -158,16 +175,14 @@ export class PersistedFlow<
       throw new Error('Invalid or corrupted flow record');
     }
 
-    let cursor: BaseNode | undefined = this.start;
-    for (const n of flow.nodes)
-      cursor = cursor?.getNextNode(n.action as Action);
+    const cursor = this.resolveCursor(flow);
 
     // No more nodes to execute
     if (!cursor) {
       this.cachedRecord = flow;
       return {
         hasMore: false,
-        action: flow.nodes.at(-1)?.action,
+        action: flow.cursor?.lastAction ?? flow.nodes.at(-1)?.action,
         shared: flow.shared as S,
       };
     }
@@ -182,11 +197,18 @@ export class PersistedFlow<
     cursor.setParams(params);
     cursor.setServices(this._services);
     const action = await cursor._run(shared);
+    const next = cursor.getNextNode(action);
+    const cursorId = this.idForNode(cursor);
+    const nextNodeId = next ? this.idForNode(next) : null;
 
     // Invalidate cache before mutation: if kv.write fails, the next read
     // falls through to KVStore which has the correct pre-mutation state.
     this.cachedRecord = null;
-    flow.nodes.push({ action });
+    flow.nodes.push({ action, nodeId: cursorId });
+    flow.cursor = {
+      nextNodeId,
+      ...(action !== undefined ? { lastAction: action } : {}),
+    };
     flow.shared = this.serializeShared(shared);
     await this.kv.write(key, stampFlowRecordSchemaVersion(flow));
     this.cachedRecord = flow;
@@ -219,7 +241,81 @@ export class PersistedFlow<
   protected async resetNodeHistory(shared: S): Promise<void> {
     await this.commitShared(shared, (flow) => {
       flow.nodes = [];
+      flow.cursor = { nextNodeId: this.idForNode(this.start) };
     });
+  }
+
+  private resolveCursor(flow: FlowRecord): BaseNode | undefined {
+    if (flow.cursor) {
+      if (flow.cursor.nextNodeId === null) return undefined;
+      const byId = this.nodeIndex().byId;
+      const cursor = byId.get(flow.cursor.nextNodeId);
+      if (!cursor) {
+        throw new Error(
+          `Invalid persisted flow cursor: ${flow.cursor.nextNodeId}`,
+        );
+      }
+      return cursor;
+    }
+
+    return this.replayLegacyNodePath(flow.nodes);
+  }
+
+  private replayLegacyNodePath(
+    nodes: readonly NodeRecord[],
+  ): BaseNode | undefined {
+    let cursor: BaseNode | undefined = this.start;
+    for (const n of nodes) {
+      cursor = cursor?.getNextNode(n.action as Action);
+    }
+    return cursor;
+  }
+
+  private idForNode(node: BaseNode): string {
+    const id = this.nodeIndex().ids.get(node);
+    if (!id) {
+      throw new Error('Persisted flow graph contains an unindexed node');
+    }
+    return id;
+  }
+
+  private nodeIndex(): {
+    readonly ids: Map<BaseNode, string>;
+    readonly byId: Map<string, BaseNode>;
+  } {
+    if (this.nodeIds && this.nodesById) {
+      return { ids: this.nodeIds, byId: this.nodesById };
+    }
+
+    const ids = new Map<BaseNode, string>();
+    const byId = new Map<string, BaseNode>();
+    const queue: Array<{ node: BaseNode; id: string }> = [
+      { node: this.start, id: START_NODE_ID },
+    ];
+
+    for (let index = 0; index < queue.length; index += 1) {
+      const item = queue[index];
+      if (!item) continue;
+      const { node, id } = item;
+      if (ids.has(node)) continue;
+
+      ids.set(node, id);
+      byId.set(id, node);
+      for (const [action, successor] of node
+        .successorEntries()
+        .toSorted(([left], [right]) => left.localeCompare(right))) {
+        if (!ids.has(successor)) {
+          queue.push({
+            node: successor,
+            id: `${id}/${encodeURIComponent(action)}`,
+          });
+        }
+      }
+    }
+
+    this.nodeIds = ids;
+    this.nodesById = byId;
+    return { ids, byId };
   }
 
   /**
@@ -258,6 +354,7 @@ export class PersistedFlow<
       params: this._params as Record<string, unknown>,
       shared: this.serializeShared(shared),
       createdAt: new Date().toISOString(),
+      cursor: { nextNodeId: this.idForNode(this.start) },
       nodes: [],
     };
     await this.kv.write(key, record);

--- a/src/test-kernel/agent/PersistedFlow.vitest.ts
+++ b/src/test-kernel/agent/PersistedFlow.vitest.ts
@@ -20,6 +20,13 @@ class CompleteNode extends BaseNode<{ count: number }> {
   }
 }
 
+class ContinueOnceNode extends BaseNode<{ count: number; continue: boolean }> {
+  async post(shared: { count: number; continue: boolean }): Promise<string> {
+    shared.count += 1;
+    return shared.continue ? 'again' : 'complete';
+  }
+}
+
 describe('PersistedFlow', () => {
   it('writes the current schema version into new flow records', async () => {
     const executionId = 'abc126' as ExecutionId;
@@ -32,7 +39,68 @@ describe('PersistedFlow', () => {
       store.read<FlowRecord>(flowKey(executionId)),
     ).resolves.toMatchObject({
       schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
+      cursor: { nextNodeId: null, lastAction: 'complete' },
       nodes: [{ action: 'complete' }],
+    });
+  });
+
+  it('replays from the cursor rather than the audit node log', async () => {
+    const executionId = 'abc127' as ExecutionId;
+    const store = getExecutionStore(executionId);
+    const first = new ContinueOnceNode();
+    const second = new CompleteNode();
+    first.on('again', second);
+    const flow = new PersistedFlow(first, store, executionId);
+
+    await store.write(flowKey(executionId), {
+      schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
+      flowName: 'texra',
+      params: {},
+      shared: { count: 0, continue: false },
+      createdAt: new Date().toISOString(),
+      cursor: { nextNodeId: 'start/again', lastAction: 'again' },
+      nodes: [],
+    } satisfies FlowRecord);
+
+    await flow.run({ count: 999, continue: true });
+
+    await expect(
+      store.read<FlowRecord>(flowKey(executionId)),
+    ).resolves.toMatchObject({
+      shared: { count: 1, continue: false },
+      cursor: { nextNodeId: null, lastAction: 'complete' },
+      nodes: [{ action: 'complete', nodeId: 'start/again' }],
+    });
+  });
+
+  it('migrates legacy node-path records to cursor replay on the next step', async () => {
+    const executionId = 'abc128' as ExecutionId;
+    const store = getExecutionStore(executionId);
+    const first = new ContinueOnceNode();
+    const second = new CompleteNode();
+    first.on('again', second);
+    const flow = new PersistedFlow(first, store, executionId);
+
+    await store.write(flowKey(executionId), {
+      schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
+      flowName: 'texra',
+      params: {},
+      shared: { count: 1, continue: false },
+      createdAt: new Date().toISOString(),
+      nodes: [{ action: 'again' }],
+    } satisfies FlowRecord);
+
+    await flow.run({ count: 999, continue: true });
+
+    await expect(
+      store.read<FlowRecord>(flowKey(executionId)),
+    ).resolves.toMatchObject({
+      shared: { count: 2, continue: false },
+      cursor: { nextNodeId: null, lastAction: 'complete' },
+      nodes: [
+        { action: 'again' },
+        { action: 'complete', nodeId: 'start/again' },
+      ],
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add a versioned `FlowRecord.cursor` that stores the next node to execute, making it the authoritative replay state for `PersistedFlow`.
- Keep `nodes[]` as an audit log rather than the replay source, while preserving cursor-less v1 records through the existing node-path replay on their next step.
- Add regression coverage showing cursor replay works even when `nodes[]` is empty, and legacy node-path records migrate to cursor replay after one step.

## Why this is the right next slice

This implements the replay-policy half of #7246 without touching completed-run display/archive ownership. It also removes a concrete blocker for #6976: a future native tool-use WAITING suspension boundary can preserve flow state without depending on an unbounded `nodes[]` replay path.

## Single Source Of Truth

`FlowRecord.cursor.nextNodeId` is now the replay fact. `nodes[]` is no longer consulted for records that carry a cursor; it remains only an append-only audit log and a v1 compatibility source for records written before this PR.

## Scheduled Refactoring

A #6981 ledger row will be added for the cursor-less v1 flow-record replay compatibility path introduced here. Removal trigger: D3 age-based expiry per persisted-run retention, after schema-v2 cursor records have aged past the supported retention window.

## Validation

- `npm test -- --run src/test-kernel/agent/PersistedFlow.vitest.ts src/test-kernel/agent/storage/Resumability.vitest.ts src/test-kernel/agent/SessionResumeRetrieval.vitest.ts src/test-kernel/tools/ExecutionsToolResumability.vitest.ts`
- `npm test -- --run src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (passes with the existing unrelated `codexToolTemplates.ts` warning)
- `npm test`
- `git diff --check`

Part of #7246. Prepares #6976.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core agent execution resume semantics and persisted record shape (v2); incorrect cursor or node indexing could mis-route resumed runs, though legacy replay and new tests mitigate regressions.
> 
> **Overview**
> **Persisted flow resume** no longer derives the next node by replaying the full `nodes[]` action history. New and updated records use **schema v2** with an authoritative **`FlowRecord.cursor`** (`nextNodeId`, optional `lastAction`); `nodes[]` is append-only audit data (with optional `nodeId` per step).
> 
> **`PersistedFlow`** builds stable graph-local node IDs (from `start` plus encoded action paths via new **`BaseNode.successorEntries()`**), resolves the executable node from `cursor` when present, and falls back to **legacy node-path replay** only for cursor-less records. Each step updates the cursor after execution; **`resetNodeHistory`** clears the audit log and resets the cursor to the start node. **`run()`** / terminal steps prefer **`cursor.lastAction`** over the last audit entry.
> 
> **Tests** cover cursor-based resume with an empty `nodes[]`, legacy records migrating to cursor replay on the next step, and new records stamping v2 cursor state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf9f080bf09e68838bac2cb96c9b75eb7ef14b80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->