### PR TITLE
refactor: suspend native subagents at waiting

### DIFF
--- a/src/agent/core/flows/FlowTransitions.ts
+++ b/src/agent/core/flows/FlowTransitions.ts
@@ -3,6 +3,7 @@ export const FlowTransition = {
   COMPLETE: 'complete',
   CONTINUE: 'continue',
   FINALIZE: 'finalize',
+  WAITING: 'waiting',
 } as const;
 
 export type FlowTransition =

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -89,7 +89,7 @@ export class ToolUseWaitNode<C> extends Node<
         await setGoalSessionBashAutoApproval(streamId, false, runtimeHost);
         emitRunFact(this.services.logger, 'goalPaused', { streamId });
       }
-    } else {
+    } else if (!prepRes.previouslyDeliveredToOrchestrator) {
       const delivered = await onBeforeWaiting?.(
         prepRes.lastResponse,
         prepRes.touchedFiles,
@@ -97,6 +97,21 @@ export class ToolUseWaitNode<C> extends Node<
       );
       prepRes.deliveredToOrchestrator =
         onBeforeWaiting !== undefined && delivered !== false;
+    } else {
+      prepRes.deliveredToOrchestrator = true;
+    }
+
+    const shouldSuspendNativeSubagent =
+      isSubagent === true &&
+      onBeforeWaiting !== undefined &&
+      prepRes.deliveredToOrchestrator === true &&
+      !this.services.stopAfterCycle;
+    if (shouldSuspendNativeSubagent && !session.hasQueuedFollowUp()) {
+      streamStatus.transitionToWaiting(streamId, 'wait', {
+        runtimeHost,
+        trace: this.services.logger,
+      });
+      return { kind: 'waiting' };
     }
 
     if (this.services.stopAfterCycle) {
@@ -153,6 +168,13 @@ export class ToolUseWaitNode<C> extends Node<
   ): Promise<string | undefined> {
     const { onFollowUpConsumed, logger, streamStatus } = this.services;
     const { streamId, runtimeHost } = useLaunchRunContext();
+
+    if (execRes.kind === 'waiting') {
+      if (prepRes.deliveredToOrchestrator) {
+        shared.deliveredToOrchestrator = true;
+      }
+      return FlowTransition.WAITING;
+    }
 
     if (execRes.kind === 'stop') {
       if (prepRes.deliveredToOrchestrator) {

--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -61,7 +61,8 @@ export type WaitExecResult =
        */
       synthetic?: boolean;
     }
-  | { kind: 'stop' };
+  | { kind: 'stop' }
+  | { kind: 'waiting' };
 
 /**
  * Prepared shared state needed to run one tool-use cycle: produced by

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -30,6 +30,7 @@ import { deriveRunOutcome } from '@common/constants/streamStatus';
 import { attachProviderError } from '@common/errors/sdkErrorUtils';
 import {
   RUN_OUTCOME,
+  STREAM_PHASE,
   toProviderErrorFromRetry,
   type RunOutcome,
 } from '@shared/schemas';
@@ -84,7 +85,7 @@ export interface RunToolUseFlowInput<
 }
 
 export interface RunToolUseFlowResult {
-  outcome: RunOutcome;
+  outcome: RunOutcome | typeof STREAM_PHASE.WAITING;
   lastResponse?: string;
   /** Workspace-relative paths of files edited by tool calls during this session. */
   touchedFiles?: string[];
@@ -303,7 +304,7 @@ export async function runToolUseFlow<C = unknown>(
     switchModel,
   };
 
-  let outcome: RunOutcome = RUN_OUTCOME.CANCELLED;
+  let outcome: RunToolUseFlowResult['outcome'] = RUN_OUTCOME.CANCELLED;
   let lastResponse: string | undefined;
   let touchedFiles: string[] | undefined;
   let totalCostUsd: number | undefined;
@@ -380,6 +381,7 @@ export async function runToolUseFlow<C = unknown>(
     prepareNode.next(cycleNode);
     cycleNode.next(waitNode);
     waitNode.on(FlowTransition.CONTINUE, cycleNode);
+    waitNode.on(FlowTransition.WAITING, waitNode);
     const pf: ToolUsePersistedFlow<C> = new PersistedFlow(prepareNode, kv);
     activePersistedFlow = pf;
     pf.setServices(services);
@@ -392,7 +394,7 @@ export async function runToolUseFlow<C = unknown>(
         await store.writeWorkspaceFiles(currentTouchedFiles);
       }
     });
-    await pf.run(shared);
+    const finalAction = await pf.run(shared);
     // Re-read shared from the flow record — PersistedFlow deep-clones the
     // initial shared via structuredClone, so nodes mutate the clone, not the
     // original object.  Without this, reads of lastError, messages, etc. below
@@ -412,15 +414,24 @@ export async function runToolUseFlow<C = unknown>(
       ? extractedTouchedFiles
       : undefined;
 
-    const isInterrupted = input.checkInterruption();
-    const interruptedAfterDeliveredSubagentResult =
-      input.isSubagent &&
-      shared.deliveredToOrchestrator === true &&
-      isInterrupted;
-    outcome = deriveRunOutcome({
-      failed: Boolean(shared.lastError),
-      cancelled: isInterrupted && !interruptedAfterDeliveredSubagentResult,
-    });
+    if (
+      finalAction === FlowTransition.WAITING &&
+      input.isSubagent === true &&
+      input.onBeforeWaiting !== undefined &&
+      shared.deliveredToOrchestrator === true
+    ) {
+      outcome = STREAM_PHASE.WAITING;
+    } else {
+      const isInterrupted = input.checkInterruption();
+      const interruptedAfterDeliveredSubagentResult =
+        input.isSubagent &&
+        shared.deliveredToOrchestrator === true &&
+        isInterrupted;
+      outcome = deriveRunOutcome({
+        failed: Boolean(shared.lastError),
+        cancelled: isInterrupted && !interruptedAfterDeliveredSubagentResult,
+      });
+    }
     if (shared.lastError) {
       // Re-throw so runFlowWithLifecycle logs the error and shows
       // the user notification, while preserving terminal run accounting.
@@ -440,7 +451,9 @@ export async function runToolUseFlow<C = unknown>(
     activePersistedFlow = undefined;
     teardownSetup?.();
     teardownSetup = undefined;
-    if (shared.userCancelledRetry) {
+    if (outcome === STREAM_PHASE.WAITING) {
+      logger.debug('Flow record preserved for native subagent WAITING');
+    } else if (shared.userCancelledRetry) {
       logger.debug('Flow record preserved for resume after retry cancellation');
     } else {
       try {

--- a/src/agent/node/persistedFlow.ts
+++ b/src/agent/node/persistedFlow.ts
@@ -3,6 +3,7 @@
 
 import type { ExecutionKVStore } from '@agent/storage/ExecutionKVStore';
 
+import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import * as logger from '@logger/logUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -57,6 +58,8 @@ export function stampFlowRecordSchemaVersion<T extends FlowRecord>(flow: T): T {
 export interface StepResult<S> {
   /** Whether there are more nodes to execute */
   hasMore: boolean;
+  /** Whether this step persisted a non-terminal wait at the current node. */
+  waiting?: boolean;
   /** The action returned by the node (for routing) */
   action: string | undefined;
   /** The shared state after node execution (mutated in-place) */
@@ -150,10 +153,13 @@ export class PersistedFlow<
 
   async run(shared: S): Promise<Action | undefined> {
     await this.ensureRecord(shared);
-    while ((await this.stepWithResult()).hasMore) {
+    let step = await this.stepWithResult();
+    while (step.hasMore) {
       // step loop
+      step = await this.stepWithResult();
     }
-    return (this.cachedRecord?.cursor?.lastAction ??
+    return (step.action ??
+      this.cachedRecord?.cursor?.lastAction ??
       this.cachedRecord?.nodes.at(-1)?.action) as Action | undefined;
   }
 
@@ -197,7 +203,8 @@ export class PersistedFlow<
     cursor.setParams(params);
     cursor.setServices(this._services);
     const action = await cursor._run(shared);
-    const next = cursor.getNextNode(action);
+    const waiting = action === FlowTransition.WAITING;
+    const next = waiting ? cursor : cursor.getNextNode(action);
     const cursorId = this.idForNode(cursor);
     const nextNodeId = next ? this.idForNode(next) : null;
 
@@ -215,7 +222,8 @@ export class PersistedFlow<
     await this.fireProjection(shared);
 
     return {
-      hasMore: true,
+      hasMore: !waiting,
+      ...(waiting ? { waiting } : {}),
       action,
       shared,
     };

--- a/src/agent/runtime/AgentFlowResult.ts
+++ b/src/agent/runtime/AgentFlowResult.ts
@@ -4,6 +4,7 @@ import { AttachedMemoryMissSchema } from '@agent/types/AttachedMemory';
 import {
   ExecutionIdSchema,
   RunOutcomeSchema,
+  STREAM_PHASE,
   StreamTabIdSchema,
   type ExecutionId,
   type RunOutcome,
@@ -51,6 +52,32 @@ export const AgentFlowResultSchema = z.discriminatedUnion('category', [
 ]);
 
 export type AgentFlowResult = z.infer<typeof AgentFlowResultSchema>;
+
+export const WaitingToolUseFlowResultSchema = AgentFlowMetaSchema.extend({
+  category: z.literal('toolUse'),
+  outcome: z.literal(STREAM_PHASE.WAITING),
+  lastResponse: z.string().optional(),
+  /** Workspace-relative paths of files edited by tool calls during this session. */
+  touchedFiles: z.array(z.string()).optional(),
+});
+
+export type WaitingToolUseFlowResult = z.infer<
+  typeof WaitingToolUseFlowResultSchema
+>;
+
+/** Runtime flow results include the non-terminal WAITING state. */
+export type AgentRuntimeFlowResult = AgentFlowResult | WaitingToolUseFlowResult;
+
+export function isWaitingFlowResult(
+  result: AgentRuntimeFlowResult | unknown,
+): result is WaitingToolUseFlowResult {
+  if (!result || typeof result !== 'object') return false;
+  const candidate = result as { category?: unknown; outcome?: unknown };
+  return (
+    candidate.category === 'toolUse' &&
+    candidate.outcome === STREAM_PHASE.WAITING
+  );
+}
 
 export class AgentFlowError extends Error {
   constructor(

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -34,6 +34,8 @@ import { AgentExecutionHandle, type AgentRunHandle } from './executionRegistry';
 import {
   getAgentFlowErrorResult,
   buildTerminalFlowResult,
+  isWaitingFlowResult,
+  type AgentRuntimeFlowResult,
   type AgentFlowResult,
 } from './AgentFlowResult';
 import type { AgentLaunchContext } from './AgentLaunchContext';
@@ -169,9 +171,9 @@ function emitRunStart(ctx: AgentLaunchContext): void {
  */
 export async function runFlowWithLifecycle(
   ctx: AgentLaunchContext,
-  runner: (handle: AgentExecutionHandle) => Promise<AgentFlowResult>,
+  runner: (handle: AgentExecutionHandle) => Promise<AgentRuntimeFlowResult>,
   options?: RunFlowLifecycleOptions,
-): Promise<AgentFlowResult> {
+): Promise<AgentRuntimeFlowResult> {
   const { streamId, session } = ctx;
   const agentIdentifier = ctx.config.agent;
   const category =
@@ -220,6 +222,10 @@ export async function runFlowWithLifecycle(
     // set stream status themselves.
     transitionRunStart(ctx);
     const result = await runner(handle);
+    if (isWaitingFlowResult(result)) {
+      logger.debug(`Task suspended with outcome: ${result.outcome}`);
+      return result;
+    }
     // The flow's outcome is the canonical terminal fact; everything below is
     // one row of the projection table. No other layer may re-derive these.
     const projection = projectRunOutcome(result.outcome);

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -49,6 +49,9 @@ import { runFlowWithLifecycle } from './AgentRunLifecycle';
 import {
   AgentFlowError,
   buildOptionalFlowResultFields,
+  isWaitingFlowResult,
+  type AgentRuntimeFlowResult,
+  type WaitingToolUseFlowResult,
   type AgentFlowResult,
 } from './AgentFlowResult';
 import { createInterruptCallbacks } from './InterruptManager';
@@ -87,7 +90,7 @@ function buildToolUseFlowResult(
   executionId: ExecutionId,
   streamId: StreamTabId,
   memoryMisses: AgentFlowResult['memoryMisses'],
-): AgentFlowResult {
+): AgentRuntimeFlowResult {
   return {
     category: 'toolUse',
     outcome: result.outcome,
@@ -124,7 +127,7 @@ async function runToolUseAgent(
     ExecuteAgentOptions,
     'isSubagent' | 'onBeforeWaiting' | 'onFollowUpConsumed' | 'onProgress'
   >,
-): Promise<AgentFlowResult> {
+): Promise<AgentRuntimeFlowResult> {
   const { streamId } = ctx;
   const onRoundFinalized = createUsageRecordingCallback(ctx);
   try {
@@ -175,16 +178,14 @@ async function runToolUseAgent(
   } catch (err) {
     const failedResult = getToolUseFlowErrorResult(err);
     if (!failedResult) throw err;
-    throw new AgentFlowError(
-      getSdkErrorMessage(err),
-      buildToolUseFlowResult(
-        failedResult,
-        ctx.executionId,
-        streamId,
-        ctx.attachedMemoryMisses,
-      ),
-      { cause: err },
+    const result = buildToolUseFlowResult(
+      failedResult,
+      ctx.executionId,
+      streamId,
+      ctx.attachedMemoryMisses,
     );
+    if (isWaitingFlowResult(result)) throw err;
+    throw new AgentFlowError(getSdkErrorMessage(err), result, { cause: err });
   }
 }
 
@@ -270,6 +271,12 @@ export interface ExecuteAgentOptions {
   onProgress?: (update: SubagentProgressUpdate) => void;
   /** Stop a tool-use execution after one model/tool cycle instead of waiting for follow-up input. */
   stopAfterCycle?: boolean;
+  /**
+   * Allow the promise to resolve with the non-terminal WAITING result. This is
+   * reserved for native subagent drivers that keep the execution handle and
+   * delivery state alive across conversational turns.
+   */
+  allowWaitingResult?: boolean;
   /** Hide tools whose approval prompts cannot be answered in this host mode. */
   approvalPromptsUnavailable?: boolean;
   /** Hide tools unavailable because the current host/runtime cannot support them. */
@@ -293,6 +300,17 @@ export interface ExecuteAgentOptions {
   onRun?: (handle: AgentRunHandle) => void | Promise<void>;
 }
 
+export function executeAgent(
+  configPayload: AgentConfigPayload,
+  executionId: ExecutionId | undefined,
+  options: ExecuteAgentOptions & { allowWaitingResult: true },
+): Promise<AgentFlowResult | WaitingToolUseFlowResult>;
+export function executeAgent(
+  configPayload: AgentConfigPayload,
+  executionId: ExecutionId | undefined,
+  options: ExecuteAgentOptions & { allowWaitingResult?: false | undefined },
+): Promise<AgentFlowResult>;
+
 /**
  * Low-level execution runner for an already-registered execution. Fresh
  * launches should use `runAgent()` or call `registerExecution()` first so the
@@ -303,7 +321,7 @@ export async function executeAgent(
   configPayload: AgentConfigPayload,
   executionId: ExecutionId | undefined,
   options: ExecuteAgentOptions,
-): Promise<AgentFlowResult> {
+): Promise<AgentRuntimeFlowResult> {
   if (options == null || options.runtimeHost == null) {
     throw new Error('executeAgent requires an explicit runtimeHost');
   }
@@ -340,7 +358,7 @@ export async function executeAgent(
       config,
       ctx.runtimeHost,
     ).catch(() => {});
-    return runFlowWithLifecycle(
+    const result = await runFlowWithLifecycle(
       ctx,
       async (handle) => {
         // Pre-execution UI setup (RUNNING is set by runFlowWithLifecycle)
@@ -375,6 +393,12 @@ export async function executeAgent(
         onRun: options.onRun,
       },
     );
+    if (isWaitingFlowResult(result) && options.allowWaitingResult !== true) {
+      throw new Error(
+        'executeAgent received a non-terminal WAITING result without allowWaitingResult.',
+      );
+    }
+    return result;
   });
 }
 
@@ -388,6 +412,16 @@ export interface ResumeToolUseFromSnapshotOptions {
   /** Per-run override for the host's tool-edit approval UI — see `ExecuteAgentOptions.toolEditApprovalHandler`. */
   readonly toolEditApprovalHandler?: ToolEditApprovalPort;
   readonly onRun?: (handle: AgentRunHandle) => void | Promise<void>;
+  readonly onBeforeWaiting?: ToolUseBeforeWaitingCallback;
+  readonly onFollowUpConsumed?: () => void;
+  readonly onProgress?: (update: SubagentProgressUpdate) => void;
+  readonly onCompleted?: (result: AgentFlowResult) => void | Promise<void>;
+  readonly onError?: (
+    error: unknown,
+    result: AgentFlowResult,
+  ) => void | Promise<void>;
+  readonly parentStreamId?: StreamTabId;
+  readonly allowWaitingResult?: boolean;
   readonly setupSession?: (session: IToolUseSession) => void;
 }
 
@@ -395,7 +429,7 @@ export async function resumeToolUseFromSnapshot(
   snapshot: ToolUseSessionSnapshot,
   runtimeHost: AgentRuntimeHost,
   options: ResumeToolUseFromSnapshotOptions = {},
-): Promise<void> {
+): Promise<AgentRuntimeFlowResult> {
   const modelHandlerCompatibilityKey =
     snapshot.modelHandlerCompatibilityKey ??
     inferPersistedModelHandlerCompatibilityKey(
@@ -426,7 +460,7 @@ export async function resumeToolUseFromSnapshot(
   ctx.toolEditApprovalHandler = options.toolEditApprovalHandler;
   const { setting, streamId } = ctx;
 
-  await withExecutionRunContext(ctx, async () => {
+  return withExecutionRunContext(ctx, async () => {
     if (setting.agentCategory !== AgentCategory.ToolUse) {
       throw new AgentError(
         'Attempted to resume a non tool-use agent with resumeToolUseFromSnapshot.',
@@ -434,7 +468,7 @@ export async function resumeToolUseFromSnapshot(
     }
 
     const isSubagent = (ctx.delegation?.delegationDepth ?? 0) > 0;
-    await runFlowWithLifecycle(
+    const result = await runFlowWithLifecycle(
       ctx,
       async (handle) => {
         const result = await runToolUseFlow(
@@ -449,10 +483,14 @@ export async function resumeToolUseFromSnapshot(
             // would drop subagent-specific instructions (e.g. the shared
             // /memories protocol) that the fresh run had included.
             isSubagent,
-            onFollowUpConsumed: () =>
+            onBeforeWaiting: options.onBeforeWaiting,
+            onProgress: options.onProgress,
+            onFollowUpConsumed: () => {
               emitRuntimeEvent('updateQueuedFollowUps', {
                 streamId: ctx.streamId,
-              }),
+              });
+              options.onFollowUpConsumed?.();
+            },
           },
           undefined,
           (flowContext) => {
@@ -468,7 +506,19 @@ export async function resumeToolUseFromSnapshot(
           ctx.attachedMemoryMisses,
         );
       },
-      { isSubagent, onRun: options.onRun },
+      {
+        isSubagent,
+        parentStreamId: options.parentStreamId,
+        onCompleted: options.onCompleted,
+        onError: options.onError,
+        onRun: options.onRun,
+      },
     );
+    if (isWaitingFlowResult(result) && options.allowWaitingResult !== true) {
+      throw new Error(
+        'resumeToolUseFromSnapshot received a non-terminal WAITING result without allowWaitingResult.',
+      );
+    }
+    return result;
   });
 }

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -1,8 +1,12 @@
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
+import type { ToolUseBeforeWaitingCallback } from '@agent/implementations/flows/tooluse/ToolUseServices';
 import type { FollowUpQueueInput } from '@agent/followUp/FollowUpQueue';
+import type { AgentFlowResult } from '@agent/runtime/AgentFlowResult';
+import type { AgentRunHandle } from '@agent/runtime/executionRegistry';
 import {
   STREAM_PHASE,
   STREAM_SUBSTATE,
+  type SubagentProgressUpdate,
   type StreamTabId,
 } from '@shared/schemas';
 import { resumeToolUseFromSnapshot } from './executeAgent';
@@ -17,8 +21,23 @@ export interface ResumeQueuedToolUseOptions {
   readonly session?: SessionHandle;
   /** Tools hidden because the current host/runtime cannot support them. */
   readonly runtimeUnavailableTools?: readonly string[];
+  /** Hide tools whose approval prompts cannot be answered in this host mode. */
+  readonly approvalPromptsUnavailable?: boolean;
   /** Per-run override for the host's tool-edit approval UI — see `ExecuteAgentOptions.toolEditApprovalHandler`. */
   readonly toolEditApprovalHandler?: ToolEditApprovalPort;
+  /** Parent stream used when a native subagent resumes under its orchestrator. */
+  readonly parentStreamId?: StreamTabId;
+  /** Allow native subagent resume to halt at WAITING instead of terminalizing. */
+  readonly allowWaitingResult?: boolean;
+  readonly onBeforeWaiting?: ToolUseBeforeWaitingCallback;
+  readonly onFollowUpConsumed?: () => void;
+  readonly onProgress?: (update: SubagentProgressUpdate) => void;
+  readonly onCompleted?: (result: AgentFlowResult) => void | Promise<void>;
+  readonly onRunError?: (
+    error: unknown,
+    result: AgentFlowResult,
+  ) => void | Promise<void>;
+  readonly onRun?: (handle: AgentRunHandle) => void | Promise<void>;
   /**
    * Follow-ups to replay ahead of any items already queued for the stream
    * (e.g. an explicit follow-up typed alongside a manual resume). Seeded before
@@ -73,8 +92,17 @@ export async function resumeQueuedToolUseSnapshot(
 
     await resumeToolUseFromSnapshot(snapshot, runtimeHost, {
       session: options.session,
+      approvalPromptsUnavailable: options.approvalPromptsUnavailable,
       runtimeUnavailableTools: options.runtimeUnavailableTools,
       toolEditApprovalHandler: options.toolEditApprovalHandler,
+      parentStreamId: options.parentStreamId,
+      allowWaitingResult: options.allowWaitingResult,
+      onBeforeWaiting: options.onBeforeWaiting,
+      onFollowUpConsumed: options.onFollowUpConsumed,
+      onProgress: options.onProgress,
+      onCompleted: options.onCompleted,
+      onError: options.onRunError,
+      onRun: options.onRun,
       setupSession: (session) => {
         for (const item of followUps) {
           session.appendFollowUp(item);

--- a/src/test-kernel/agent/PersistedFlow.vitest.ts
+++ b/src/test-kernel/agent/PersistedFlow.vitest.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { getExecutionStore } from '@agent/storage';
 import { BaseNode } from '@agent/node';
+import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import {
   FLOW_RECORD_SCHEMA_VERSION,
   flowKey,
@@ -24,6 +25,13 @@ class ContinueOnceNode extends BaseNode<{ count: number; continue: boolean }> {
   async post(shared: { count: number; continue: boolean }): Promise<string> {
     shared.count += 1;
     return shared.continue ? 'again' : 'complete';
+  }
+}
+
+class SuspendNode extends BaseNode<{ count: number }> {
+  async post(shared: { count: number }): Promise<string> {
+    shared.count += 1;
+    return FlowTransition.WAITING;
   }
 }
 
@@ -101,6 +109,38 @@ describe('PersistedFlow', () => {
         { action: 'again' },
         { action: 'complete', nodeId: 'start/again' },
       ],
+    });
+  });
+
+  it('persists WAITING without advancing the replay cursor', async () => {
+    const executionId = 'abc129' as ExecutionId;
+    const store = getExecutionStore(executionId);
+    const flow = new PersistedFlow(new SuspendNode(), store, executionId);
+
+    await expect(flow.run({ count: 0 })).resolves.toBe(FlowTransition.WAITING);
+
+    await expect(
+      store.read<FlowRecord>(flowKey(executionId)),
+    ).resolves.toMatchObject({
+      shared: { count: 1 },
+      cursor: {
+        nextNodeId: 'start',
+        lastAction: FlowTransition.WAITING,
+      },
+      nodes: [{ action: FlowTransition.WAITING, nodeId: 'start' }],
+    });
+
+    await expect(flow.run({ count: 999 })).resolves.toBe(
+      FlowTransition.WAITING,
+    );
+    await expect(
+      store.read<FlowRecord>(flowKey(executionId)),
+    ).resolves.toMatchObject({
+      shared: { count: 2 },
+      cursor: {
+        nextNodeId: 'start',
+        lastAction: FlowTransition.WAITING,
+      },
     });
   });
 });

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -33,7 +33,7 @@ import { GoalStore } from '@tools/goal';
 import { withTestRunContext } from '../progressTestUtils';
 
 describe('ToolUseWaitNode', () => {
-  it('marks a delivered subagent cycle before stopping on interruption', async () => {
+  it('marks a delivered native subagent cycle before suspending at WAITING', async () => {
     const shared: ToolUseRunShared = {
       messages: [],
       shouldSkipCycle: false,
@@ -79,7 +79,7 @@ describe('ToolUseWaitNode', () => {
 
     expect(onBeforeWaiting).toHaveBeenCalledOnce();
     expect(onBeforeWaiting).toHaveBeenCalledWith(undefined, [], memoryMisses);
-    expect(transition).toBe(FlowTransition.COMPLETE);
+    expect(transition).toBe(FlowTransition.WAITING);
     expect(shared.deliveredToOrchestrator).toBe(true);
   });
 
@@ -149,9 +149,58 @@ describe('ToolUseWaitNode', () => {
       },
     );
 
-    expect(onBeforeWaiting).toHaveBeenCalledTimes(2);
-    expect(secondTransition).toBe(FlowTransition.COMPLETE);
+    expect(onBeforeWaiting).toHaveBeenCalledOnce();
+    expect(secondTransition).toBe(FlowTransition.WAITING);
     expect(shared.deliveredToOrchestrator).toBe(true);
+  });
+
+  it('does not redeliver an already delivered wait when replay consumes follow-up', async () => {
+    const shared: ToolUseRunShared = {
+      deliveredToOrchestrator: true,
+      messages: [],
+      shouldSkipCycle: false,
+      stateSlices: null,
+    };
+    const onBeforeWaiting = vi.fn(async () => true);
+    const onFollowUpConsumed = vi.fn();
+    const runtimeHost = { emit: vi.fn() };
+
+    const services = {
+      checkInterruption: () => false,
+      isSubagent: true,
+      logger: { emit: vi.fn(), error: vi.fn(), info: vi.fn() },
+      modelHandler: {
+        createUserFollowUpMessages: vi.fn(async () => []),
+        extractAssistantText: () => undefined,
+      },
+      onBeforeWaiting,
+      onFollowUpConsumed,
+      runtimeHost,
+      session: {
+        hasQueuedFollowUp: () => true,
+        waitForFollowUp: async () => ({
+          items: [{ text: 'continue the proof', origin: 'user' }],
+        }),
+      },
+      streamStatus: new StreamStatusMachine(),
+      streamId: 'test-stream',
+    } as unknown as ToolUseServices;
+
+    const node = new ToolUseWaitNode().setServices(services);
+    const prep = await node.prep(shared);
+    const transition = await withTestRunContext(
+      runtimeHost,
+      'test-stream',
+      async () => {
+        const exec = await node.exec(prep);
+        return node.post(shared, prep, exec);
+      },
+    );
+
+    expect(onBeforeWaiting).not.toHaveBeenCalled();
+    expect(onFollowUpConsumed).toHaveBeenCalledOnce();
+    expect(transition).toBe(FlowTransition.CONTINUE);
+    expect(shared.deliveredToOrchestrator).toBeUndefined();
   });
 
   it('preserves delivered state when interruption is already set before waiting', async () => {

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -414,6 +414,44 @@ describe('runFlowWithLifecycle', () => {
     }
   });
 
+  it('keeps native subagent WAITING results registered and nonterminal', async () => {
+    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+      'lifecycle-subagent-waiting',
+    );
+    const onCompleted = vi.fn();
+    const onError = vi.fn();
+    storageMocks.writeTerminalStatus.mockClear();
+
+    try {
+      const result = await runFlowWithLifecycle(
+        ctx,
+        async () => {
+          expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.RUNNING);
+          expect(
+            streamStatus.transition(streamId, STREAM_PHASE.WAITING, 'wait'),
+          ).toBe(true);
+          return {
+            category: 'toolUse',
+            outcome: STREAM_PHASE.WAITING,
+            executionId,
+            streamId,
+          };
+        },
+        { isSubagent: true, onCompleted, onError },
+      );
+
+      expect(result.outcome).toBe(STREAM_PHASE.WAITING);
+      expect(storageMocks.writeTerminalStatus).not.toHaveBeenCalled();
+      expect(onCompleted).not.toHaveBeenCalled();
+      expect(onError).not.toHaveBeenCalled();
+      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.WAITING);
+      expect(executionRegistry.getHandle(executionId)).toBeDefined();
+    } finally {
+      executionRegistry.untrack(executionId);
+      clearStreamStatusForTest(streamStatus, streamId);
+    }
+  });
+
   // The canonical outcome is decided once and projected three ways. This
   // matrix pins the projections for every terminal path — in particular that
   // a user stop (the no-throw `cancelled` exit, the dominant stop path)

--- a/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
+++ b/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
@@ -10,11 +10,25 @@ import type { ExecutionId, StreamTabId } from '@shared/schemas';
 const mocks = vi.hoisted(() => ({
   deliverChildRunFollowUp: vi.fn(),
   persistChildRunReport: vi.fn(),
+  readConfig: vi.fn(),
+  resumeQueuedToolUseSnapshot: vi.fn(),
+  retrieveSessionResumeData: vi.fn(),
   writeResultMeta: vi.fn(),
 }));
 
 vi.mock('@agent/storage', () => ({
-  getExecutionStore: vi.fn(() => ({ writeResultMeta: mocks.writeResultMeta })),
+  getExecutionStore: vi.fn(() => ({
+    readConfig: mocks.readConfig,
+    writeResultMeta: mocks.writeResultMeta,
+  })),
+}));
+
+vi.mock('@agent/runtime/SessionResumeRetrieval', () => ({
+  retrieveSessionResumeData: mocks.retrieveSessionResumeData,
+}));
+
+vi.mock('@agent/runtime/resumeQueuedToolUse', () => ({
+  resumeQueuedToolUseSnapshot: mocks.resumeQueuedToolUseSnapshot,
 }));
 
 vi.mock('@tools/childRunDelivery', () => ({
@@ -56,6 +70,7 @@ describe('NativeSubagentStrategy', () => {
       agentName: 'review',
       orchestratorStreamId: parentStreamId,
       parentSession: ownerSession,
+      runtimeHost: { emit: vi.fn() },
       startedAt: 0,
       settleSubagentCost: vi.fn(),
     });
@@ -90,6 +105,7 @@ describe('NativeSubagentStrategy', () => {
       agentName: 'review',
       orchestratorStreamId: parentStreamId,
       parentSession: ownerSession,
+      runtimeHost: { emit: vi.fn() },
       startedAt: 0,
       settleSubagentCost: vi.fn(),
     });
@@ -125,6 +141,7 @@ describe('NativeSubagentStrategy', () => {
       agentName: 'review',
       orchestratorStreamId: parentStreamId,
       parentSession: ownerSession,
+      runtimeHost: { emit: vi.fn() },
       startedAt: 0,
       settleSubagentCost: vi.fn(),
     });
@@ -161,6 +178,7 @@ describe('NativeSubagentStrategy', () => {
       agentName: 'review',
       orchestratorStreamId: parentStreamId,
       parentSession: ownerSession,
+      runtimeHost: { emit: vi.fn() },
       startedAt: 0,
       settleSubagentCost: vi.fn(),
     });
@@ -170,6 +188,69 @@ describe('NativeSubagentStrategy', () => {
     );
     await expect(strategy.persistAndDeliverTerminal('second')).resolves.toBe(
       true,
+    );
+  });
+
+  it('resumes queued follow-ups with native delivery callbacks', async () => {
+    const childStream = 'child-stream' as StreamTabId;
+    const runtimeHost = { emit: vi.fn() };
+    const config = { agentCategory: 'toolUse' };
+    const snapshot = {
+      agentConfig: config,
+      executionId,
+      messages: [],
+      streamId: childStream,
+    };
+    mocks.readConfig.mockResolvedValue(config);
+    mocks.retrieveSessionResumeData.mockResolvedValue({
+      type: 'toolUse',
+      snapshot,
+    });
+    mocks.resumeQueuedToolUseSnapshot.mockResolvedValue(true);
+
+    const strategy = new NativeSubagentStrategy({
+      executionId,
+      agentName: 'review',
+      orchestratorStreamId: parentStreamId,
+      parentSession: ownerSession,
+      runtimeHost,
+      startedAt: 0,
+      settleSubagentCost: vi.fn(),
+    });
+    strategy.setChildStreamId(childStream);
+
+    await expect(
+      strategy.wakeQueuedFollowUp(
+        { status: 'queued', reason: 'waiting' },
+        {
+          approvalPromptsUnavailable: true,
+          runtimeUnavailableTools: ['edit_file'],
+        },
+      ),
+    ).resolves.toEqual({ kind: 'resumed' });
+
+    expect(mocks.retrieveSessionResumeData).toHaveBeenCalledWith(
+      childStream,
+      executionId,
+      config,
+    );
+    expect(mocks.resumeQueuedToolUseSnapshot).toHaveBeenCalledWith(
+      childStream,
+      snapshot,
+      runtimeHost,
+      expect.objectContaining({
+        allowWaitingResult: true,
+        approvalPromptsUnavailable: true,
+        parentStreamId,
+        runtimeUnavailableTools: ['edit_file'],
+        session: ownerSession,
+        onBeforeWaiting: expect.any(Function),
+        onCompleted: expect.any(Function),
+        onFollowUpConsumed: expect.any(Function),
+        onProgress: expect.any(Function),
+        onRun: expect.any(Function),
+        onRunError: expect.any(Function),
+      }),
     );
   });
 });

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -15,7 +15,10 @@ import { z } from 'zod';
 import { currentSession } from '@agent/runtime/SessionHandle';
 import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
 import { tryUseRunContext } from '@agent/runtime/RunContext';
-import { sendFollowUp } from '@agent/followUp/ToolUseFollowUp';
+import {
+  sendFollowUp,
+  wakeQueuedFollowUpStream,
+} from '@agent/followUp/ToolUseFollowUp';
 
 // Local imports - tools
 import {
@@ -51,6 +54,7 @@ import {
   WorkflowAgentInputSchema,
   type WorkflowAgentInput,
 } from './delegation/inputFields';
+import { getNativeSubagentStrategy } from './delegation/nativeSubagentStrategy';
 
 export { rejectOversizedBibAttachments } from './delegation/inputFields';
 export type { WorkflowAgentInput };
@@ -256,7 +260,8 @@ Git worktree support: resolved from the active workspace at runtime.`,
     const gated = depthGateError(parentDelegationDepth);
     if (gated) return gated;
 
-    const handle = currentSession().executions.getHandle(executionId);
+    const session = currentSession();
+    const handle = session.executions.getHandle(executionId);
     if (!(handle instanceof AgentExecutionHandle)) {
       throw new Error(
         `Execution '${executionId}' not found or not an agent execution. Use the executions tool to check status.`,
@@ -294,10 +299,28 @@ Git worktree support: resolved from the active workspace at runtime.`,
 
     const framedInstruction = formatFollowUpInstruction(instruction);
     const result = await sendFollowUp(handle.childStreamId, framedInstruction);
+    if (result.status !== 'no_session') {
+      deliveryState.markPending();
+    }
+
+    const nativeStrategy = getNativeSubagentStrategy(executionId);
+    if (nativeStrategy) {
+      await nativeStrategy.wakeQueuedFollowUp(result, {
+        approvalPromptsUnavailable: parentContext?.approvalPromptsUnavailable,
+        runtimeUnavailableTools: parentContext?.runtimeUnavailableTools,
+        toolEditApprovalHandler: parentContext?.toolEditApprovalHandler,
+      });
+    } else {
+      await wakeQueuedFollowUpStream(
+        handle.childStreamId,
+        result,
+        undefined,
+        session,
+      );
+    }
 
     switch (result.status) {
       case 'sent':
-        deliveryState.markPending();
         return {
           status: 'executed',
           summary: `Follow-up sent to '${handle.agentName}'`,
@@ -307,7 +330,6 @@ Git worktree support: resolved from the active workspace at runtime.`,
           ].join('\n'),
         };
       case 'queued':
-        deliveryState.markPending();
         return {
           status: 'executed',
           summary: `Follow-up queued for '${handle.agentName}'`,

--- a/src/tools/delegation/nativeSubagentStrategy.ts
+++ b/src/tools/delegation/nativeSubagentStrategy.ts
@@ -2,18 +2,29 @@
  * Native subagent callback strategy.
  *
  * This packages the async `executeAgent` callback choreography used by native
- * delegated agents. It does not run the child loop itself; `executeSubagent`
- * still calls `executeAgent` directly. The strategy owns only delivery policy
- * for native child results: progress/interim/terminal follow-ups, manifest
- * writes, duplicate-delivery gating, and registry cleanup.
+ * delegated agents. The strategy owns child result delivery across WAITING
+ * turns: progress/interim/terminal follow-ups, manifest writes, duplicate
+ * delivery gating, WAITING resume, and registry cleanup.
  */
 
 // Local imports - agent
 import { getExecutionStore, type ResultMeta } from '@agent/storage';
-import type { AgentFlowResult } from '@agent/runtime/AgentFlowResult';
+import {
+  isWaitingFlowResult,
+  type AgentFlowResult,
+  type AgentRuntimeFlowResult,
+} from '@agent/runtime/AgentFlowResult';
+import { retrieveSessionResumeData } from '@agent/runtime/SessionResumeRetrieval';
+import { resumeQueuedToolUseSnapshot } from '@agent/runtime/resumeQueuedToolUse';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { AgentRunHandle } from '@agent/runtime/executionRegistry';
 import type { FollowUpQueueInput } from '@agent/followUp/FollowUpQueue';
+import {
+  wakeQueuedFollowUpStream,
+  type FollowUpWakeResult,
+  type SendFollowUpResult,
+} from '@agent/followUp/ToolUseFollowUp';
 import type { AttachedMemoryMiss } from '@agent/types/AttachedMemory';
 
 // Local imports - logger
@@ -45,15 +56,31 @@ import {
   type DiffFileInfo,
 } from '@tools/subagentDiffs';
 import { toErrorMessage } from '@utils/errors/errorMessage';
+import type { ToolEditApprovalPort } from '@platform/interfaces/toolEditApproval';
 
 export interface NativeSubagentStrategyParams {
   readonly executionId: ExecutionId;
   readonly agentName: string;
   readonly orchestratorStreamId: StreamTabId;
   readonly parentSession: SessionHandle;
+  readonly runtimeHost: AgentRuntimeHost;
   readonly startedAt: number;
   readonly workingDirectory?: string;
   readonly settleSubagentCost: (result?: AgentFlowResult) => void;
+}
+
+export interface NativeSubagentResumeOptions {
+  readonly approvalPromptsUnavailable?: boolean;
+  readonly runtimeUnavailableTools?: readonly string[];
+  readonly toolEditApprovalHandler?: ToolEditApprovalPort;
+}
+
+const activeNativeSubagents = new Map<string, NativeSubagentStrategy>();
+
+export function getNativeSubagentStrategy(
+  executionId: string,
+): NativeSubagentStrategy | undefined {
+  return activeNativeSubagents.get(executionId);
 }
 
 /**
@@ -146,6 +173,7 @@ export class NativeSubagentStrategy {
 
   constructor(private readonly params: NativeSubagentStrategyParams) {
     this.deliveryState = subagentDeliveryRegistry.start(params.executionId);
+    activeNativeSubagents.set(params.executionId, this);
   }
 
   setChildStreamId(streamId: StreamTabId): void {
@@ -242,6 +270,71 @@ export class NativeSubagentStrategy {
     this.deliveryState.markPending();
   }
 
+  async wakeQueuedFollowUp(
+    result: SendFollowUpResult,
+    options: NativeSubagentResumeOptions,
+  ): Promise<FollowUpWakeResult> {
+    const streamId = this.childStreamId;
+    if (!streamId) return { kind: 'queued_resume_failed' };
+    return wakeQueuedFollowUpStream(
+      streamId,
+      result,
+      {
+        tryResumeStream: (id) => this.resumeStream(id, options),
+      },
+      this.params.parentSession,
+    );
+  }
+
+  private async resumeStream(
+    streamId: StreamTabId,
+    options: NativeSubagentResumeOptions,
+  ): Promise<boolean> {
+    if (streamId !== this.childStreamId) return false;
+    const config = await getExecutionStore(
+      this.params.executionId,
+    ).readConfig();
+    if (!config) return false;
+
+    const resume = await retrieveSessionResumeData(
+      streamId,
+      this.params.executionId,
+      config,
+    );
+    if (!resume || resume.type !== 'toolUse') return false;
+
+    return await resumeQueuedToolUseSnapshot(
+      streamId,
+      resume.snapshot,
+      this.params.runtimeHost,
+      {
+        session: this.params.parentSession,
+        approvalPromptsUnavailable: options.approvalPromptsUnavailable,
+        runtimeUnavailableTools: options.runtimeUnavailableTools,
+        toolEditApprovalHandler: options.toolEditApprovalHandler,
+        parentStreamId: this.params.orchestratorStreamId,
+        allowWaitingResult: true,
+        onProgress: (update) => this.onProgress(update),
+        onFollowUpConsumed: () => this.onFollowUpConsumed(),
+        onBeforeWaiting: (lastResponse, touchedFiles, memoryMisses) =>
+          this.onBeforeWaiting(lastResponse, touchedFiles, memoryMisses),
+        onCompleted: async (result) => {
+          await this.onCompleted(result);
+          this.finish();
+        },
+        onRunError: async (err, result) => {
+          await this.onError(err, result);
+          this.finish();
+        },
+        onError: async (err) => {
+          await this.deliverSubagentError(err);
+          this.finish();
+        },
+        onRun: (handle) => this.setRunHandle(handle),
+      },
+    );
+  }
+
   async onBeforeWaiting(
     lastResponse: string | undefined,
     touchedFiles: string[],
@@ -322,8 +415,19 @@ export class NativeSubagentStrategy {
     return this.deliverSubagentError(err, result);
   }
 
+  private finish(): void {
+    subagentDeliveryRegistry.finish(this.params.executionId);
+    activeNativeSubagents.delete(this.params.executionId);
+  }
+
   attachPromise(promise: Promise<unknown>): void {
+    let suspended = false;
     promise
+      .then((result: unknown) => {
+        if (isWaitingFlowResult(result as AgentRuntimeFlowResult)) {
+          suspended = true;
+        }
+      })
       // Await the error delivery so the registry entry is not torn down while
       // the delivery and any resume-based follow-up routing are in flight.
       .catch((err: unknown) => this.deliverSubagentError(err))
@@ -334,7 +438,9 @@ export class NativeSubagentStrategy {
         );
       })
       .finally(() => {
-        subagentDeliveryRegistry.finish(this.params.executionId);
+        if (!suspended) {
+          this.finish();
+        }
       });
   }
 }

--- a/src/tools/delegation/subagentExecution.ts
+++ b/src/tools/delegation/subagentExecution.ts
@@ -268,6 +268,7 @@ export async function executeSubagent(
     agentName,
     orchestratorStreamId,
     parentSession,
+    runtimeHost,
     startedAt,
     workingDirectory,
     settleSubagentCost,
@@ -283,6 +284,7 @@ export async function executeSubagent(
     approvalPromptsUnavailable: parentContext.approvalPromptsUnavailable,
     runtimeUnavailableTools: parentContext.runtimeUnavailableTools,
     toolEditApprovalHandler: parentContext.toolEditApprovalHandler,
+    allowWaitingResult: true,
     onStreamResolved: (resolvedStreamId) => {
       nativeStrategy.setChildStreamId(resolvedStreamId);
       inheritChildStreamApprovals(resolvedStreamId);


### PR DESCRIPTION
## Summary

- add a non-terminal `WAITING` flow transition and keep the persisted-flow cursor on the wait node
- let native tool-use subagents deliver an interim result, halt at `WAITING`, and remain registered instead of terminalizing
- wake `delegate_agent execution_id=...` follow-ups through the native delivery strategy so resumed child turns still report back to the orchestrator

This is a #6976 vertical slice for the native subagent wait boundary. It does not delete the older bus/projector surface by itself.

## Validation

- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/agent/PersistedFlow.vitest.ts src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts src/test-kernel/tools/NativeSubagentStrategy.vitest.ts src/test-kernel/tools/DelegationHeadless.vitest.mts`
- `corepack pnpm exec eslint <changed files>`
- `npm run compile:fast`
- `git diff --check`
- `npm run lint` (passes with the existing unrelated `codexToolTemplates.ts` import-order warning)
- `npm test`

Refs #6976

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core agent lifecycle, persisted flow replay, and subagent delegation/resume wiring; regressions could strand runs, duplicate deliveries, or leave executions untracked.
> 
> **Overview**
> Introduces a **non-terminal `WAITING` flow transition** so tool-use runs can pause mid-graph without terminalizing. **`PersistedFlow`** keeps the replay cursor on the wait node, preserves the KV flow record on suspend, and **`ToolUseWaitNode`** can return `waiting` after a native subagent delivers an interim result to the orchestrator (without blocking on follow-up or re-delivering on replay).
> 
> **`runFlowWithLifecycle`** treats `STREAM_PHASE.WAITING` as a suspend: no terminal status write, execution handle stays registered. Callers need **`allowWaitingResult`** on `executeAgent` / resume paths or they get an explicit error.
> 
> **`NativeSubagentStrategy`** owns multi-turn delivery: registry lookup, **`wakeQueuedFollowUp`** → snapshot resume with native callbacks, and deferred registry cleanup until true completion. **`delegate_agent`** resume routes queued follow-ups through that strategy instead of only the generic wake path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf9a72e461b57c55ce025f60a63bf18178c79418. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->