### PR TITLE
Grant one bounded compile-repair round on a final-round compile failure

### DIFF
--- a/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
@@ -51,6 +51,13 @@ export const ReflectionFlowStateSchema = z.object({
 
   /** One-shot repair context injected into the next round's user request. */
   compileFailureContext: z.string().optional(),
+
+  /**
+   * Set once a compile-repair round has been granted, so a compile failure
+   * on that repair round (or a resumed run) can't grant a second one.
+   * Bounds the repair round to exactly one per run.
+   */
+  compileRepairRoundGranted: z.boolean().optional(),
 });
 
 export type ReflectionFlowState = z.infer<typeof ReflectionFlowStateSchema>;

--- a/src/agent/implementations/flows/reflection/roundStageTotal.ts
+++ b/src/agent/implementations/flows/reflection/roundStageTotal.ts
@@ -1,0 +1,12 @@
+/**
+ * Widen a round stage's `total` for a granted compile-repair round (#7077):
+ * that round opens with `roundIndex === totalRounds` (one past the
+ * configured last round), so without this the progress badge would render
+ * an over-total "Round 3 of 2".
+ */
+export function computeRoundStageTotal(
+  totalRounds: number,
+  roundIndex: number,
+): number {
+  return Math.max(totalRounds, roundIndex + 1);
+}

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -55,6 +55,7 @@ import {
   ReflectionFlowStateSchema,
   type ReflectionFlowShared,
 } from './ReflectionFlowState';
+import { computeRoundStageTotal } from './roundStageTotal';
 import type {
   ReflectionServices,
   WorkflowOutputPolicy,
@@ -271,11 +272,7 @@ export async function runReflectionFlow<C = unknown>(
             parent: parent ?? undefined,
             kind: 'round',
             index: roundIndex,
-            // Widen the stage's total for a granted compile-repair round
-            // (#7077): that round opens with roundIndex === totalRounds
-            // (one past the configured last round), so without this the
-            // progress badge would render an over-total "Round 3 of 2".
-            total: Math.max(shared.totalRounds, roundIndex + 1),
+            total: computeRoundStageTotal(shared.totalRounds, roundIndex),
           }),
         resetForNextRound: (s) => {
           s.workspaceSnapshot = AgentWorkspaceState.emptySnapshot();

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -247,6 +247,18 @@ export async function runReflectionFlow<C = unknown>(
     mediaNode.next(responseCycleNode);
     responseCycleNode.next(outputNode);
 
+    const workflowOutputPolicy: WorkflowOutputPolicy =
+      input.workflowOutputPolicy ?? {
+        shouldAutoOpenPdfOrLog: () =>
+          readPlatformSetting<boolean>(
+            WorkspaceStateKey.WORKFLOW_AUTO_OPEN_PDF,
+          ),
+        shouldRejectOnCompileFailure: () =>
+          readPlatformSetting<boolean>(
+            WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE,
+          ),
+      };
+
     const pf = new RoundPersistedFlow<
       ReflectionFlowShared,
       Record<string, unknown>,
@@ -265,6 +277,25 @@ export async function runReflectionFlow<C = unknown>(
           s.workspaceSnapshot = AgentWorkspaceState.emptySnapshot();
         },
         checkInterruption,
+        // Bounded compile-repair round (#7077): a compile failure on what
+        // would otherwise be the final round gets exactly one extra round
+        // so the model sees the failure context via PrepareContextNode
+        // instead of the run silently ending on a broken output. Gated on
+        // the same setting that produced compileFailureContext in the
+        // first place, and on the one-shot `compileRepairRoundGranted`
+        // flag so a repair round that itself fails to compile doesn't
+        // chain a second one — even across resume.
+        grantExtraRound: (s) => {
+          if (
+            !s.compileFailureContext ||
+            s.compileRepairRoundGranted ||
+            !workflowOutputPolicy.shouldRejectOnCompileFailure()
+          ) {
+            return false;
+          }
+          s.compileRepairRoundGranted = true;
+          return true;
+        },
       },
     });
 
@@ -278,16 +309,7 @@ export async function runReflectionFlow<C = unknown>(
       promptBuilder,
       fileService,
       getOutputFileLocation,
-      workflowOutputPolicy: input.workflowOutputPolicy ?? {
-        shouldAutoOpenPdfOrLog: () =>
-          readPlatformSetting<boolean>(
-            WorkspaceStateKey.WORKFLOW_AUTO_OPEN_PDF,
-          ),
-        shouldRejectOnCompileFailure: () =>
-          readPlatformSetting<boolean>(
-            WorkspaceStateKey.WORKFLOW_REJECT_ON_COMPILE_FAILURE,
-          ),
-      },
+      workflowOutputPolicy,
       baseFiles,
     };
     pf.setServices(services);

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -271,7 +271,11 @@ export async function runReflectionFlow<C = unknown>(
             parent: parent ?? undefined,
             kind: 'round',
             index: roundIndex,
-            total: shared.totalRounds,
+            // Widen the stage's total for a granted compile-repair round
+            // (#7077): that round opens with roundIndex === totalRounds
+            // (one past the configured last round), so without this the
+            // progress badge would render an over-total "Round 3 of 2".
+            total: Math.max(shared.totalRounds, roundIndex + 1),
           }),
         resetForNextRound: (s) => {
           s.workspaceSnapshot = AgentWorkspaceState.emptySnapshot();

--- a/src/agent/node/roundPersistedFlow.ts
+++ b/src/agent/node/roundPersistedFlow.ts
@@ -73,6 +73,17 @@ export interface RoundCallbacks<S extends RoundAwareState> {
 
   /** Reset workspace state for a new round. */
   resetForNextRound?: (shared: S) => void;
+
+  /**
+   * Called only when the round loop would otherwise stop because
+   * `currentRound + 1 >= totalRounds`. Return true to run exactly one more
+   * round beyond the configured total (e.g. a compile-repair round). The
+   * callback owns recording that the extra round was granted (a persisted
+   * boolean on shared state) so it isn't asked again once it has said yes
+   * — this is what keeps the extra round bounded to exactly one per run,
+   * including across resume.
+   */
+  grantExtraRound?: (shared: S) => boolean;
 }
 
 // ============================================================================
@@ -186,12 +197,17 @@ export class RoundPersistedFlow<
    * This is the SINGLE SOURCE OF TRUTH for the continue/finalize decision.
    */
   private shouldContinueNextRound(shared: S): boolean {
-    return (
-      !shared.lastError &&
-      !this.callbacks.checkInterruption?.() &&
-      shared.continueRounds &&
-      shared.currentRound + 1 < shared.totalRounds
-    );
+    if (
+      shared.lastError ||
+      this.callbacks.checkInterruption?.() ||
+      !shared.continueRounds
+    ) {
+      return false;
+    }
+    if (shared.currentRound + 1 < shared.totalRounds) return true;
+    // Otherwise this would be the last round. Give the caller one chance to
+    // grant a bounded extra round (e.g. a compile-repair round) instead.
+    return this.callbacks.grantExtraRound?.(shared) ?? false;
   }
 
   /** Derive the canonical RunOutcome from shared state after the round loop exits. */

--- a/src/test-kernel/agent/RoundPersistedFlowCompileRepair.vitest.ts
+++ b/src/test-kernel/agent/RoundPersistedFlowCompileRepair.vitest.ts
@@ -1,0 +1,184 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - node/flow primitives under test
+import { BaseNode } from '@agent/node';
+import {
+  RoundPersistedFlow,
+  type RoundAwareState,
+} from '@agent/node/roundPersistedFlow';
+import type { ExecutionKVStore } from '@agent/storage/ExecutionKVStore';
+
+/**
+ * Regression coverage for #7077: a compile failure on what would have been
+ * the final round must get exactly one extra ("repair") round carrying the
+ * failure context — gated on the reject-on-compile-failure setting, and
+ * never granted twice even if the repair round itself fails again.
+ *
+ * These tests exercise `RoundPersistedFlow`'s round-continuation decision
+ * directly (the single source of truth the fix touches), using a minimal
+ * fake node and an in-memory KV store instead of standing up the full
+ * reflection flow (model handler, prompt builder, LaTeX compile, etc).
+ */
+
+/** Minimal in-memory stand-in for ExecutionKVStore; only read/write/getExecutionId are exercised by PersistedFlow. */
+function createFakeKv(): ExecutionKVStore {
+  const store = new Map<string, unknown>();
+  return {
+    read: async <T>(key: string) => store.get(key) as T | undefined,
+    write: async <T>(key: string, value: T) => {
+      store.set(key, value);
+    },
+    delete: async (key: string) => {
+      store.delete(key);
+    },
+    exists: async (key: string) => store.has(key),
+    listKeys: async () => [...store.keys()],
+    clear: async () => store.clear(),
+    getExecutionId: () => 'test-exec-0001',
+    readMeta: async () => null,
+    readConfig: async () => null,
+    readReport: async () => null,
+    readTodos: async () => [],
+    readConversation: async () => null,
+    readWorkspaceFiles: async () => [],
+    readChildren: async () => [],
+    readResultMeta: async () => null,
+    writeMeta: async () => {},
+    writeConfig: async () => {},
+    writeReport: async () => {},
+    writeTodos: async () => {},
+    writeConversation: async () => {},
+    writeWorkspaceFiles: async () => {},
+    writeChild: async () => {},
+    writeResultMeta: async () => {},
+  } as unknown as ExecutionKVStore;
+}
+
+interface FakeShared extends RoundAwareState {
+  /** Round indices actually executed, in order. */
+  roundsRun: number[];
+  /** compileFailureContext observed by each executed round, if any. */
+  contextSeenByRound: Record<number, string | undefined>;
+  /** Round indices that should simulate a compile failure. */
+  failingRounds: number[];
+  /** Mirrors OutputNode's one-shot repair context (set on failure, consumed next round). */
+  compileFailureContext?: string;
+  /** Mirrors the persisted "already granted a repair round" flag. */
+  compileRepairRoundGranted?: boolean;
+  /** Mirrors the rejectOnCompileFailure setting. */
+  rejectOnCompileFailureEnabled: boolean;
+}
+
+/**
+ * A single node standing in for the whole reflection round (PrepareContext +
+ * ... + OutputNode): it records the round it ran in, captures whatever
+ * compileFailureContext it saw (mimicking PrepareContextNode consuming it),
+ * then mimics OutputNode by setting a fresh compileFailureContext if this
+ * round is scripted to fail compilation.
+ */
+class FakeRoundNode extends BaseNode<FakeShared> {
+  async post(shared: FakeShared): Promise<undefined> {
+    shared.roundsRun.push(shared.currentRound);
+    shared.contextSeenByRound[shared.currentRound] =
+      shared.compileFailureContext;
+    delete shared.compileFailureContext;
+
+    if (shared.failingRounds.includes(shared.currentRound)) {
+      shared.compileFailureContext = `compile failed on round ${shared.currentRound}`;
+    }
+    return undefined;
+  }
+}
+
+function makeFlow(kv: ExecutionKVStore) {
+  const node = new FakeRoundNode();
+  return new RoundPersistedFlow<FakeShared>(node, kv, {
+    callbacks: {
+      grantExtraRound: (s) => {
+        if (
+          !s.compileFailureContext ||
+          s.compileRepairRoundGranted ||
+          !s.rejectOnCompileFailureEnabled
+        ) {
+          return false;
+        }
+        s.compileRepairRoundGranted = true;
+        return true;
+      },
+    },
+  });
+}
+
+function initialShared(overrides: Partial<FakeShared>): FakeShared {
+  return {
+    currentRound: 0,
+    totalRounds: 2,
+    continueRounds: true,
+    roundsRun: [],
+    contextSeenByRound: {},
+    failingRounds: [],
+    rejectOnCompileFailureEnabled: true,
+    ...overrides,
+  };
+}
+
+describe('RoundPersistedFlow bounded compile-repair round (#7077)', () => {
+  it('grants exactly one extra round when the final configured round fails to compile', async () => {
+    const kv = createFakeKv();
+    const flow = makeFlow(kv);
+    // totalRounds: 2 (rounds 0 and 1 configured); round 1 (the last one) fails.
+    const shared = initialShared({ totalRounds: 2, failingRounds: [1] });
+
+    await flow.run(shared);
+    const finalShared = (await flow.getShared())!;
+
+    // Round 0, round 1 (configured, fails), and a granted repair round 2.
+    expect(finalShared.roundsRun).toEqual([0, 1, 2]);
+    // The repair round (2) received the failure context from round 1.
+    expect(finalShared.contextSeenByRound[2]).toBe('compile failed on round 1');
+    expect(finalShared.compileRepairRoundGranted).toBe(true);
+  });
+
+  it('does not grant an extra round when a clean final round has no failure context', async () => {
+    const kv = createFakeKv();
+    const flow = makeFlow(kv);
+    const shared = initialShared({ totalRounds: 2, failingRounds: [] });
+
+    await flow.run(shared);
+    const finalShared = (await flow.getShared())!;
+
+    expect(finalShared.roundsRun).toEqual([0, 1]);
+    expect(finalShared.compileRepairRoundGranted).toBeUndefined();
+  });
+
+  it('does not grant an extra round when rejectOnCompileFailure is off', async () => {
+    const kv = createFakeKv();
+    const flow = makeFlow(kv);
+    const shared = initialShared({
+      totalRounds: 2,
+      failingRounds: [1],
+      rejectOnCompileFailureEnabled: false,
+    });
+
+    await flow.run(shared);
+    const finalShared = (await flow.getShared())!;
+
+    expect(finalShared.roundsRun).toEqual([0, 1]);
+    expect(finalShared.compileRepairRoundGranted).toBeUndefined();
+  });
+
+  it('does not chain a second repair round when the repair round itself fails again', async () => {
+    const kv = createFakeKv();
+    const flow = makeFlow(kv);
+    // Both the configured final round (1) and the granted repair round (2) fail.
+    const shared = initialShared({ totalRounds: 2, failingRounds: [1, 2] });
+
+    await flow.run(shared);
+    const finalShared = (await flow.getShared())!;
+
+    // Exactly one repair round (2) — no round 3, even though round 2 also failed.
+    expect(finalShared.roundsRun).toEqual([0, 1, 2]);
+    expect(finalShared.compileRepairRoundGranted).toBe(true);
+  });
+});

--- a/src/test-kernel/agent/RoundPersistedFlowCompileRepair.vitest.ts
+++ b/src/test-kernel/agent/RoundPersistedFlowCompileRepair.vitest.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from 'vitest';
 
 // Local imports - node/flow primitives under test
+import { createFakeKv } from '@test/support/FakeExecutionKVStore';
 import { BaseNode } from '@agent/node';
 import {
   RoundPersistedFlow,
@@ -20,40 +21,6 @@ import type { ExecutionKVStore } from '@agent/storage/ExecutionKVStore';
  * fake node and an in-memory KV store instead of standing up the full
  * reflection flow (model handler, prompt builder, LaTeX compile, etc).
  */
-
-/** Minimal in-memory stand-in for ExecutionKVStore; only read/write/getExecutionId are exercised by PersistedFlow. */
-function createFakeKv(): ExecutionKVStore {
-  const store = new Map<string, unknown>();
-  return {
-    read: async <T>(key: string) => store.get(key) as T | undefined,
-    write: async <T>(key: string, value: T) => {
-      store.set(key, value);
-    },
-    delete: async (key: string) => {
-      store.delete(key);
-    },
-    exists: async (key: string) => store.has(key),
-    listKeys: async () => [...store.keys()],
-    clear: async () => store.clear(),
-    getExecutionId: () => 'test-exec-0001',
-    readMeta: async () => null,
-    readConfig: async () => null,
-    readReport: async () => null,
-    readTodos: async () => [],
-    readConversation: async () => null,
-    readWorkspaceFiles: async () => [],
-    readChildren: async () => [],
-    readResultMeta: async () => null,
-    writeMeta: async () => {},
-    writeConfig: async () => {},
-    writeReport: async () => {},
-    writeTodos: async () => {},
-    writeConversation: async () => {},
-    writeWorkspaceFiles: async () => {},
-    writeChild: async () => {},
-    writeResultMeta: async () => {},
-  } as unknown as ExecutionKVStore;
-}
 
 interface FakeShared extends RoundAwareState {
   /** Round indices actually executed, in order. */

--- a/src/test-kernel/progressView/RepairRoundBadge.vitest.ts
+++ b/src/test-kernel/progressView/RepairRoundBadge.vitest.ts
@@ -3,11 +3,13 @@ import { JSDOM } from 'jsdom';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 // Local imports - node/flow primitives under test
+import { createFakeKv } from '@test/support/FakeExecutionKVStore';
 import { BaseNode } from '@agent/node';
 import {
   RoundPersistedFlow,
   type RoundAwareState,
 } from '@agent/node/roundPersistedFlow';
+import { computeRoundStageTotal } from '@agent/implementations/flows/reflection/roundStageTotal';
 import type { ExecutionKVStore } from '@agent/storage/ExecutionKVStore';
 import type { RoundStage } from '@shared/schemas';
 
@@ -16,49 +18,17 @@ import type { RoundStage } from '@shared/schemas';
  * bounded compile-repair round): when the repair round is granted,
  * `currentRound` becomes `totalRounds` (one index past the configured last
  * round). `runReflectionFlow.ts`'s `createRoundStage` callback widens the
- * stage's `total` for that round (`Math.max(shared.totalRounds,
- * roundIndex + 1)`) so the webview progress badge never displays an
- * over-total round count like "Round 3 of 2".
+ * stage's `total` for that round via the exported `computeRoundStageTotal`
+ * so the webview progress badge never displays an over-total round count
+ * like "Round 3 of 2".
  *
- * These tests mirror that exact widening formula against `RoundPersistedFlow`
- * (the same mechanics `RoundPersistedFlowCompileRepair.vitest.ts` exercises)
- * to confirm the repair round really is opened with the widened total, then
- * feed the resulting stage through the actual webview badge formatters to
- * confirm the rendered badge stays sensible rather than over-total.
+ * These tests exercise the REAL `computeRoundStageTotal` (not a local copy
+ * of its formula) against `RoundPersistedFlow` (the same mechanics
+ * `RoundPersistedFlowCompileRepair.vitest.ts` exercises) to confirm the
+ * repair round really is opened with the widened total, then feed the
+ * resulting stage through the actual webview badge formatters to confirm
+ * the rendered badge stays sensible rather than over-total.
  */
-
-function createFakeKv(): ExecutionKVStore {
-  const store = new Map<string, unknown>();
-  return {
-    read: async <T>(key: string) => store.get(key) as T | undefined,
-    write: async <T>(key: string, value: T) => {
-      store.set(key, value);
-    },
-    delete: async (key: string) => {
-      store.delete(key);
-    },
-    exists: async (key: string) => store.has(key),
-    listKeys: async () => [...store.keys()],
-    clear: async () => store.clear(),
-    getExecutionId: () => 'test-exec-repair-badge',
-    readMeta: async () => null,
-    readConfig: async () => null,
-    readReport: async () => null,
-    readTodos: async () => [],
-    readConversation: async () => null,
-    readWorkspaceFiles: async () => [],
-    readChildren: async () => [],
-    readResultMeta: async () => null,
-    writeMeta: async () => {},
-    writeConfig: async () => {},
-    writeReport: async () => {},
-    writeTodos: async () => {},
-    writeConversation: async () => {},
-    writeWorkspaceFiles: async () => {},
-    writeChild: async () => {},
-    writeResultMeta: async () => {},
-  } as unknown as ExecutionKVStore;
-}
 
 interface FakeShared extends RoundAwareState {
   failingRounds: number[];
@@ -86,10 +56,11 @@ function makeFlowWithStageCapture(
   const node = new FakeRoundNode();
   return new RoundPersistedFlow<FakeShared>(node, kv, {
     callbacks: {
-      // Mirrors runReflectionFlow.ts's createRoundStage callback exactly,
-      // including the fix's widened total.
+      // Mirrors runReflectionFlow.ts's createRoundStage callback, using the
+      // SAME exported computeRoundStageTotal (not a local reimplementation)
+      // so this test actually fails if the real widening logic regresses.
       createRoundStage: (roundIndex, _parent, shared) => {
-        const total = Math.max(shared.totalRounds, roundIndex + 1);
+        const total = computeRoundStageTotal(shared.totalRounds, roundIndex);
         capturedStages.push({ index: roundIndex, total });
         return {
           id: `r${roundIndex}`,

--- a/src/test-kernel/progressView/RepairRoundBadge.vitest.ts
+++ b/src/test-kernel/progressView/RepairRoundBadge.vitest.ts
@@ -1,0 +1,183 @@
+// Third-party imports
+import { JSDOM } from 'jsdom';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+// Local imports - node/flow primitives under test
+import { BaseNode } from '@agent/node';
+import {
+  RoundPersistedFlow,
+  type RoundAwareState,
+} from '@agent/node/roundPersistedFlow';
+import type { ExecutionKVStore } from '@agent/storage/ExecutionKVStore';
+import type { RoundStage } from '@shared/schemas';
+
+/**
+ * Regression coverage for the reviewer finding on PR #7290 (issue #7077's
+ * bounded compile-repair round): when the repair round is granted,
+ * `currentRound` becomes `totalRounds` (one index past the configured last
+ * round). `runReflectionFlow.ts`'s `createRoundStage` callback widens the
+ * stage's `total` for that round (`Math.max(shared.totalRounds,
+ * roundIndex + 1)`) so the webview progress badge never displays an
+ * over-total round count like "Round 3 of 2".
+ *
+ * These tests mirror that exact widening formula against `RoundPersistedFlow`
+ * (the same mechanics `RoundPersistedFlowCompileRepair.vitest.ts` exercises)
+ * to confirm the repair round really is opened with the widened total, then
+ * feed the resulting stage through the actual webview badge formatters to
+ * confirm the rendered badge stays sensible rather than over-total.
+ */
+
+function createFakeKv(): ExecutionKVStore {
+  const store = new Map<string, unknown>();
+  return {
+    read: async <T>(key: string) => store.get(key) as T | undefined,
+    write: async <T>(key: string, value: T) => {
+      store.set(key, value);
+    },
+    delete: async (key: string) => {
+      store.delete(key);
+    },
+    exists: async (key: string) => store.has(key),
+    listKeys: async () => [...store.keys()],
+    clear: async () => store.clear(),
+    getExecutionId: () => 'test-exec-repair-badge',
+    readMeta: async () => null,
+    readConfig: async () => null,
+    readReport: async () => null,
+    readTodos: async () => [],
+    readConversation: async () => null,
+    readWorkspaceFiles: async () => [],
+    readChildren: async () => [],
+    readResultMeta: async () => null,
+    writeMeta: async () => {},
+    writeConfig: async () => {},
+    writeReport: async () => {},
+    writeTodos: async () => {},
+    writeConversation: async () => {},
+    writeWorkspaceFiles: async () => {},
+    writeChild: async () => {},
+    writeResultMeta: async () => {},
+  } as unknown as ExecutionKVStore;
+}
+
+interface FakeShared extends RoundAwareState {
+  failingRounds: number[];
+  compileFailureContext?: string;
+  compileRepairRoundGranted?: boolean;
+}
+
+class FakeRoundNode extends BaseNode<FakeShared> {
+  async post(shared: FakeShared): Promise<undefined> {
+    delete shared.compileFailureContext;
+    if (shared.failingRounds.includes(shared.currentRound)) {
+      shared.compileFailureContext = `compile failed on round ${shared.currentRound}`;
+    }
+    return undefined;
+  }
+}
+
+/** Stages opened via `createRoundStage`, captured in call order. */
+type CapturedStage = { index: number; total: number | undefined };
+
+function makeFlowWithStageCapture(
+  kv: ExecutionKVStore,
+  capturedStages: CapturedStage[],
+) {
+  const node = new FakeRoundNode();
+  return new RoundPersistedFlow<FakeShared>(node, kv, {
+    callbacks: {
+      // Mirrors runReflectionFlow.ts's createRoundStage callback exactly,
+      // including the fix's widened total.
+      createRoundStage: (roundIndex, _parent, shared) => {
+        const total = Math.max(shared.totalRounds, roundIndex + 1);
+        capturedStages.push({ index: roundIndex, total });
+        return {
+          id: `r${roundIndex}`,
+          end: () => {},
+          within: (fn) => Promise.resolve(fn()),
+          run: (fn) => Promise.resolve(fn()),
+          child: () => {
+            throw new Error('not used in this test');
+          },
+        };
+      },
+      grantExtraRound: (s) => {
+        if (!s.compileFailureContext || s.compileRepairRoundGranted) {
+          return false;
+        }
+        s.compileRepairRoundGranted = true;
+        return true;
+      },
+    },
+  });
+}
+
+describe('repair-round progress badge (PR #7290 follow-up)', () => {
+  it('widens the stage total for the granted repair round instead of leaving it stuck at the configured total', async () => {
+    const kv = createFakeKv();
+    const capturedStages: CapturedStage[] = [];
+    const flow = makeFlowWithStageCapture(kv, capturedStages);
+    const shared: FakeShared = {
+      currentRound: 0,
+      totalRounds: 2,
+      continueRounds: true,
+      failingRounds: [1],
+    };
+
+    await flow.run(shared);
+
+    // Round 0, round 1 (configured, fails), and a granted repair round 2.
+    expect(capturedStages).toEqual([
+      { index: 0, total: 2 },
+      { index: 1, total: 2 },
+      // Without the fix this would be `{ index: 2, total: 2 }` — the repair
+      // round opening with index === total.
+      { index: 2, total: 3 },
+    ]);
+  });
+
+  describe('badge formatters given the repair round stage', () => {
+    let dom: JSDOM;
+
+    beforeAll(async () => {
+      dom = new JSDOM('<!doctype html><html><body></body></html>');
+      Object.assign(globalThis, {
+        window: dom.window,
+        document: dom.window.document,
+        Node: dom.window.Node,
+        Element: dom.window.Element,
+        DocumentFragment: dom.window.DocumentFragment,
+      });
+    });
+
+    afterAll(() => {
+      dom.window.close();
+    });
+
+    it('renders a sensible, non-over-total badge for the widened repair-round stage', async () => {
+      const { renderProgressBadgeContent, getProgressBadgeTitle } =
+        await import('@progressView/frontend/formatters/progressBadgeFormatter');
+      const { render } = await import('lit');
+
+      // The repair round as opened by the fixed createRoundStage callback:
+      // index 2 (0-based, the round past the configured totalRounds: 2),
+      // total widened to 3 via Math.max(totalRounds, roundIndex + 1).
+      const repairRoundStage: RoundStage = { index: 2, total: 3 };
+
+      const container = document.createElement('div');
+      render(
+        renderProgressBadgeContent(undefined, repairRoundStage),
+        container,
+      );
+      expect(container.textContent).toBe('r3/3');
+      expect(container.textContent).not.toBe('r3/2');
+
+      expect(getProgressBadgeTitle(undefined, repairRoundStage)).toBe(
+        'Round 3 of 3',
+      );
+      expect(getProgressBadgeTitle(undefined, repairRoundStage)).not.toBe(
+        'Round 3 of 2',
+      );
+    });
+  });
+});

--- a/src/test-kernel/support/FakeExecutionKVStore.ts
+++ b/src/test-kernel/support/FakeExecutionKVStore.ts
@@ -1,0 +1,35 @@
+import type { ExecutionKVStore } from '@agent/storage/ExecutionKVStore';
+
+/** Minimal in-memory stand-in for ExecutionKVStore; only read/write/getExecutionId are exercised by PersistedFlow. */
+export function createFakeKv(executionId = 'test-exec-0001'): ExecutionKVStore {
+  const store = new Map<string, unknown>();
+  return {
+    read: async <T>(key: string) => store.get(key) as T | undefined,
+    write: async <T>(key: string, value: T) => {
+      store.set(key, value);
+    },
+    delete: async (key: string) => {
+      store.delete(key);
+    },
+    exists: async (key: string) => store.has(key),
+    listKeys: async () => [...store.keys()],
+    clear: async () => store.clear(),
+    getExecutionId: () => executionId,
+    readMeta: async () => null,
+    readConfig: async () => null,
+    readReport: async () => null,
+    readTodos: async () => [],
+    readConversation: async () => null,
+    readWorkspaceFiles: async () => [],
+    readChildren: async () => [],
+    readResultMeta: async () => null,
+    writeMeta: async () => {},
+    writeConfig: async () => {},
+    writeReport: async () => {},
+    writeTodos: async () => {},
+    writeConversation: async () => {},
+    writeWorkspaceFiles: async () => {},
+    writeChild: async () => {},
+    writeResultMeta: async () => {},
+  } as unknown as ExecutionKVStore;
+}


### PR DESCRIPTION
Closes #7077

## What changed

`RoundPersistedFlow.shouldContinueNextRound` stopped strictly at
`currentRound + 1 < totalRounds`. A compile failure on the final configured
round stored `shared.compileFailureContext` (`OutputNode.post`) and
auto-opened the log, but the run then exited — `PrepareContextNode` only
injects that context into a round that actually runs, so the model never
saw the failure.

- `RoundCallbacks` gains an optional `grantExtraRound(shared)` hook, invoked
  only when the round loop is otherwise about to stop
  (`currentRound + 1 >= totalRounds`). Returning `true` runs exactly one
  more round.
- `runReflectionFlow` wires `grantExtraRound` to grant one extra round when
  `compileFailureContext` is set, `rejectOnCompileFailure` is on, and no
  repair round has been granted yet for this run.
- A new persisted boolean, `compileRepairRoundGranted` (`ReflectionFlowState`),
  records that the grant happened so it can't happen twice — including
  across a resume that lands mid-repair-round, since the resume path
  re-syncs `totalRounds` from config but this boolean travels with the same
  snapshot.

The extra round is an ordinary reflection round; it reaches the model
through the existing `PrepareContextNode` wiring with no changes needed
there. No new setting, no new node type, no `maxCompileRepairRounds` knob —
per the issue's own proposed fix and no-spare-width guidance.

The issue's two adjacent naming/tracking notes (the "reject" setting doesn't
actually reject the round's output; a PRD checkbox references a nonexistent
constant) are left untouched — the issue calls them out as optional/
maintainer's-call and explicitly says not to let them block this fix.

## Testing

- `src/test-kernel/agent/RoundPersistedFlowCompileRepair.vitest.ts` (new):
  exercises `RoundPersistedFlow`'s round-continuation decision directly with
  a minimal fake node + in-memory KV store, covering:
  - a compile failure on the final configured round gets exactly one extra
    round, which receives the failure context;
  - a clean final round grants no extra round;
  - `rejectOnCompileFailure` off grants no extra round even on failure;
  - a repair round that itself fails again does not chain a second repair
    round.
- `npx tsc --noEmit` and `npx tsc --noEmit -p tsconfig.test-kernel.json` — clean.
- `npx eslint` on all touched files — clean.
- Full `src/test-kernel/agent` suite (147 files, 1050 tests) — passing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core round-continuation logic in `RoundPersistedFlow` and reflection run lifecycle (extra model round, persisted state), but behavior is tightly gated and covered by targeted tests.
> 
> **Overview**
> When the **last configured reflection round** fails LaTeX compile, the run used to store `compileFailureContext` and stop, so the model never got a follow-up round to fix it.
> 
> **Round loop:** `RoundPersistedFlow` now consults an optional `grantExtraRound` hook when `currentRound + 1 >= totalRounds` would end the run. The reflection flow grants **at most one** extra round when `compileFailureContext` is set, `rejectOnCompileFailure` is on, and persisted `compileRepairRoundGranted` is not already set (including after resume).
> 
> **UI:** Round stage `total` uses `computeRoundStageTotal` so a repair round past the configured count shows e.g. **Round 3 of 3** instead of **Round 3 of 2**.
> 
> Regression tests cover the grant logic, no double repair, setting gating, and badge formatting; a shared `createFakeKv` supports flow unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6350e2f5a124d683c96fe0f432626df689eddcc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->