### PR TITLE
fix(trace-viewer): exclude tool-use round endings from the legacy status scan

### DIFF
--- a/packages/trace-viewer/src/replayTrace.ts
+++ b/packages/trace-viewer/src/replayTrace.ts
@@ -29,6 +29,19 @@ type SyncStreamContentMessage = Extract<
 >;
 
 /**
+ * Stage kinds nested under the root "Run:" stage (see `StageOptions.kind` in
+ * `@agent/trace`). A tool-use round (and any other non-root stage of these
+ * kinds) is opened without an ambient parent — `runFlowWithLifecycle` never
+ * wraps flow execution in the root stage's `within(...)` — so its `GROUP_END`
+ * row gets `groupId === undefined` just like the root run stage's own. Only
+ * the root stage's row is tagged `kind: 'run'` (or has no `kind` at all, for
+ * traces recorded before stage kinds existed); anything tagged with one of
+ * these kinds is a nested stage that happens to share the root's "no parent"
+ * shape and must be excluded from the reverse scan below.
+ */
+const NESTED_STAGE_KINDS = new Set(['round', 'phase', 'session']);
+
+/**
  * Maps the persisted-history `ExecutionStatus` onto the `StreamLifecycleStatus`
  * vocabulary `StreamMetadataSchema.status` renders. `executionStatusToRunOutcome`
  * is the sanctioned inverse of `runOutcomeToExecutionStatus` — its `RunOutcome`
@@ -51,6 +64,12 @@ function toStreamLifecycleStatus(trace: TraceDocument): StreamLifecycleStatus {
     if (entry.type !== STREAM_LOG_ENTRY_TYPES.GROUP_END) continue;
     if (entry.groupId !== undefined) continue;
     if (!isObject(entry.data)) continue;
+    if (
+      typeof entry.data.kind === 'string' &&
+      NESTED_STAGE_KINDS.has(entry.data.kind)
+    ) {
+      continue;
+    }
     const status = StreamStatusSchema.safeParse(entry.data.status);
     if (status.success) return streamStatusToLifecycleStatus(status.data);
   }

--- a/packages/trace-viewer/src/replayTrace.ts
+++ b/packages/trace-viewer/src/replayTrace.ts
@@ -42,6 +42,42 @@ type SyncStreamContentMessage = Extract<
 const NESTED_STAGE_KINDS = new Set(['round', 'phase', 'session']);
 
 /**
+ * Identifies the root run stage's entry id by structural position, for
+ * archived traces where `data.kind` isn't available to check — recorded
+ * before `TexraTranscriptRecorder` started re-attaching `kind` across the
+ * stage.end merge, or even before per-stage `kind` existed at all. The stage
+ * label (`entry.text`) isn't a safe fallback either: it's arbitrary
+ * human-authored text with no enforced format guarantee across every past
+ * recorder revision (see the "Legacy run" fixture in
+ * `replayTrace.vitest.ts`'s issue #7188 case).
+ *
+ * What *is* guaranteed for every historical trace: each stage occupies
+ * exactly one entry for its whole lifetime — `stage.end` mutates that same
+ * entry in place (`StreamLogStore.update` / `StreamLog.update`) rather than
+ * appending a new one — so a stage's position in `trace.entries` is fixed at
+ * `stage.start` time and never moves. `beginRunStage` opens the root run
+ * stage before any flow (and therefore any tool-use round, which shares the
+ * root's "no parent" `groupId === undefined` shape) ever starts, so among
+ * every top-level stage entry the root's is always the earliest by seqNo.
+ * Any later entry sharing that "no parent" shape is a nested round/phase/
+ * session stage that started after the root, never the root itself.
+ */
+function findRootStageId(
+  entries: TraceDocument['entries'],
+): string | undefined {
+  for (const entry of entries) {
+    if (entry.groupId !== undefined) continue;
+    if (
+      entry.type === STREAM_LOG_ENTRY_TYPES.GROUP_START ||
+      entry.type === STREAM_LOG_ENTRY_TYPES.GROUP_END
+    ) {
+      return entry.id;
+    }
+  }
+  return undefined;
+}
+
+/**
  * Maps the persisted-history `ExecutionStatus` onto the `StreamLifecycleStatus`
  * vocabulary `StreamMetadataSchema.status` renders. `executionStatusToRunOutcome`
  * is the sanctioned inverse of `runOutcomeToExecutionStatus` — its `RunOutcome`
@@ -60,14 +96,21 @@ function toStreamLifecycleStatus(trace: TraceDocument): StreamLifecycleStatus {
     const outcome = executionStatusToRunOutcome(trace.terminalStatus);
     if (outcome) return outcome;
   }
+  const rootStageId = findRootStageId(trace.entries);
   for (const entry of trace.entries.toReversed()) {
     if (entry.type !== STREAM_LOG_ENTRY_TYPES.GROUP_END) continue;
     if (entry.groupId !== undefined) continue;
     if (!isObject(entry.data)) continue;
-    if (
-      typeof entry.data.kind === 'string' &&
-      NESTED_STAGE_KINDS.has(entry.data.kind)
-    ) {
+    const kind =
+      typeof entry.data.kind === 'string' ? entry.data.kind : undefined;
+    if (kind !== undefined) {
+      if (NESTED_STAGE_KINDS.has(kind)) continue;
+    } else if (entry.id !== rootStageId) {
+      // No `data.kind` to check — this entry predates kind-tagging
+      // altogether. Fall back to the structural ordering invariant: only
+      // the entry at the root stage's fixed position (the first top-level
+      // stage entry in the trace) can be the run's own GROUP_END; anything
+      // else sharing the "no parent" shape is a nested round/phase/session.
       continue;
     }
     const status = StreamStatusSchema.safeParse(entry.data.status);

--- a/src/test-kernel/traceViewer/replayTrace.vitest.ts
+++ b/src/test-kernel/traceViewer/replayTrace.vitest.ts
@@ -260,6 +260,68 @@ describe('replayTrace legacy-status fallback (issue #7188)', () => {
     expect(replayed?.status).toBe(STREAM_STATUS.READY);
   });
 
+  it('ignores a cleanly-closed tool-use round with no data.kind at all — archived before the stage.end kind fix (issue #7291)', () => {
+    // Traces archived before TexraTranscriptRecorder started re-attaching
+    // `kind` to `stage.end` (this same effort, #7267) have GROUP_END rows
+    // with NO `data.kind` whatsoever: `store.update` replaces `data`
+    // wholesale, so the round's `kind: 'round'` tag from stage.start never
+    // made it onto its GROUP_END row. `data.kind` alone can't tell this
+    // legacy round's end apart from the legacy root run's end (crash
+    // mid-run) — the fallback must key on entry ordering instead (see
+    // `findRootStageId`): the root run's stage entry is always the first
+    // top-level ("no parent") stage entry in the trace, since the round
+    // only starts after the root run stage has already opened. Labels are
+    // deliberately non-canonical ("Legacy run" / "Round 0", not "Run: ...")
+    // to prove the fallback doesn't key on label text either.
+    const { ctx, getState } = createContext(createInitialState());
+    const trace: TraceDocument = {
+      ...legacyTrace(undefined),
+      config: AgentConfigSchema.parse({
+        agent: 'correct',
+        model: 'gemini35f',
+        agentCategory: AgentCategory.ToolUse,
+      }),
+      entries: [
+        {
+          seqNo: 1,
+          id: 'root-run',
+          type: STREAM_LOG_ENTRY_TYPES.GROUP_START,
+          level: LOG_LEVELS.INFO,
+          timestamp: 100,
+          messageType: MESSAGE_TYPES.DEFAULT,
+          text: 'Legacy run',
+          // Legacy trace predates stage kinds entirely, so even the
+          // GROUP_START row carries no `kind`.
+          data: { status: 'running' },
+          // No matching GROUP_END: the root run stage never closed (crash
+          // mid-run), so this entry stays a GROUP_START forever.
+        },
+        {
+          seqNo: 2,
+          id: 'r0',
+          type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
+          level: LOG_LEVELS.INFO,
+          timestamp: 120,
+          // No groupId — rounds have no ambient parent, so this is
+          // indistinguishable from a root stage by groupId alone.
+          messageType: MESSAGE_TYPES.DEFAULT,
+          text: 'Round 0',
+          // No `kind` — the legacy shape this fix must handle: the round
+          // closed cleanly before TexraTranscriptRecorder preserved `kind`
+          // across the stage.end merge, so this row has only its entry
+          // position (second top-level stage entry, opened after root) to
+          // distinguish it from root.
+          data: { status: 'stopped', endTime: 120 },
+        },
+      ],
+    };
+
+    replayTrace(trace, ctx);
+
+    const replayed = getState().streamStates.get(trace.streamId);
+    expect(replayed?.status).toBe(STREAM_STATUS.READY);
+  });
+
   it('derives "failed" from snapshot.status "error" instead of defaulting to ready', () => {
     const { ctx, getState } = createContext(createInitialState());
     const trace = legacyTrace('error');

--- a/src/test-kernel/traceViewer/replayTrace.vitest.ts
+++ b/src/test-kernel/traceViewer/replayTrace.vitest.ts
@@ -211,6 +211,55 @@ describe('replayTrace legacy-status fallback (issue #7188)', () => {
     expect(replayed?.status).toBe(STREAM_STATUS.READY);
   });
 
+  it('ignores a cleanly-closed tool-use round when the root run stage never closed (issue #7267)', () => {
+    // Tool-use rounds (ToolUseCycleNode) are opened without an ambient
+    // parent stage — runFlowWithLifecycle never wraps flow execution in the
+    // root "Run:" stage's `within(...)` — so a round's GROUP_END row carries
+    // `groupId: undefined`, the same "no parent" shape as the root run
+    // stage's own GROUP_END. Only `data.kind` (preserved through the
+    // stage.end merge by TexraTranscriptRecorder) tells them apart.
+    const { ctx, getState } = createContext(createInitialState());
+    const trace: TraceDocument = {
+      ...legacyTrace(undefined),
+      config: AgentConfigSchema.parse({
+        agent: 'correct',
+        model: 'gemini35f',
+        agentCategory: AgentCategory.ToolUse,
+      }),
+      entries: [
+        {
+          seqNo: 1,
+          id: 'root-run',
+          type: STREAM_LOG_ENTRY_TYPES.GROUP_START,
+          level: LOG_LEVELS.INFO,
+          timestamp: 100,
+          messageType: MESSAGE_TYPES.DEFAULT,
+          text: 'Run: correct',
+          data: { status: 'running', kind: 'run' },
+          // No matching GROUP_END: the root run stage never closed (crash
+          // mid-run), so this entry stays a GROUP_START forever.
+        },
+        {
+          seqNo: 2,
+          id: 'r0',
+          type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
+          level: LOG_LEVELS.INFO,
+          timestamp: 120,
+          // No groupId — the bug: rounds have no ambient parent, so this is
+          // indistinguishable from a root stage by groupId alone.
+          messageType: MESSAGE_TYPES.DEFAULT,
+          text: 'r0',
+          data: { status: 'stopped', endTime: 120, kind: 'round' },
+        },
+      ],
+    };
+
+    replayTrace(trace, ctx);
+
+    const replayed = getState().streamStates.get(trace.streamId);
+    expect(replayed?.status).toBe(STREAM_STATUS.READY);
+  });
+
   it('derives "failed" from snapshot.status "error" instead of defaulting to ready', () => {
     const { ctx, getState } = createContext(createInitialState());
     const trace = legacyTrace('error');

--- a/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
+++ b/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { attachTranscriptRecorder } from '@transcript/TexraTranscriptRecorder';
+import { StreamLogStore } from '@transcript/StreamLogStore';
+import { TraceEmitter } from '@agent/trace';
+import { STREAM_LOG_ENTRY_TYPES, type StreamTabId } from '@shared/schemas';
+import { isObject } from '@utils/core';
+
+describe('attachTranscriptRecorder stage kind (issue #7267)', () => {
+  it("preserves a round stage's kind onto its persisted GROUP_END row", () => {
+    const trace = new TraceEmitter();
+    const store = new StreamLogStore();
+    const streamId = 'stream:kind-preserved' as StreamTabId;
+    store.ensureStream(streamId);
+    attachTranscriptRecorder(trace, streamId, store);
+
+    const round = trace.openStage('r0', { kind: 'round', index: 0 });
+    round.end();
+
+    const entries = store.get(streamId)?.getRange(0) ?? [];
+    const roundEntry = entries.find((e) => e.id === round.id);
+
+    expect(roundEntry?.type).toBe(STREAM_LOG_ENTRY_TYPES.GROUP_END);
+    expect(isObject(roundEntry?.data) && roundEntry.data.kind).toBe('round');
+  });
+
+  it("preserves the root run stage's kind onto its persisted GROUP_END row", () => {
+    const trace = new TraceEmitter();
+    const store = new StreamLogStore();
+    const streamId = 'stream:run-kind-preserved' as StreamTabId;
+    store.ensureStream(streamId);
+    attachTranscriptRecorder(trace, streamId, store);
+
+    const runStage = trace.openStage('Run: agent', { kind: 'run' });
+    runStage.end();
+
+    const entries = store.get(streamId)?.getRange(0) ?? [];
+    const runEntry = entries.find((e) => e.id === runStage.id);
+
+    expect(runEntry?.type).toBe(STREAM_LOG_ENTRY_TYPES.GROUP_END);
+    expect(isObject(runEntry?.data) && runEntry.data.kind).toBe('run');
+  });
+});

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -107,6 +107,13 @@ export function attachTranscriptRecorder(
   store: StreamLogStore,
 ): TranscriptRecorderHandle {
   const streams = new Map<string, StreamSinkState>();
+  // stage.start's `kind` lives only on that event — `store.update` at
+  // stage.end replaces `data` wholesale (see StreamLog.update), so without
+  // this the persisted GROUP_END row would forget whether the stage was the
+  // root "Run:" stage or a nested round/phase/session. Replayed legacy traces
+  // rely on that distinction to tell a root run's terminal status apart from
+  // a round's (see toStreamLifecycleStatus in packages/trace-viewer).
+  const stageKinds = new Map<string, 'run' | 'round' | 'phase' | 'session'>();
 
   const flushStream = (state: StreamSinkState, id: string): void => {
     if (state.updateTimer) {
@@ -206,6 +213,7 @@ export function attachTranscriptRecorder(
         return;
 
       case 'stage.start':
+        if (event.kind) stageKinds.set(event.id, event.kind);
         store.append(streamId, {
           id: event.id,
           type: STREAM_LOG_ENTRY_TYPES.GROUP_START,
@@ -224,15 +232,19 @@ export function attachTranscriptRecorder(
         });
         return;
 
-      case 'stage.end':
+      case 'stage.end': {
+        const kind = stageKinds.get(event.id);
+        stageKinds.delete(event.id);
         store.update(streamId, event.id, {
           type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
           data: {
             status: event.status ?? END_GROUP_STATUS.STOPPED,
             endTime: Date.now(),
+            ...(kind ? { kind } : {}),
           },
         });
         return;
+      }
 
       case 'tool.start':
         // event.logId is the canonical id — SDK consumers correlate


### PR DESCRIPTION
Closes #7267

## What changed

`toStreamLifecycleStatus()`'s reverse scan (added in #7264) narrowed to
`GROUP_END` rows where `groupId === undefined`, to stop a nested
stage's terminal status from being mistaken for the root run's. But
tool-use rounds (`ToolUseCycleNode.ts`) open their stage without an
ambient parent -- `runFlowWithLifecycle` never wraps flow execution in
the root "Run:" stage's `within(...)` (confirmed: it calls
`runner(handle)` directly) -- so a round's `GROUP_END` row also gets
`groupId === undefined`, indistinguishable from the root run stage's
own.

For a legacy tool-use trace where the root `Run:` stage never closed
(crash mid-run) but the last round closed cleanly, the scan matched the
round's `GROUP_END` and reported the run as completed/stopped instead
of falling back to `snapshot.status`/`READY` -- the exact failure mode
#7261/#7264 set out to fix.

## Why this fix (not re-parenting tool-use rounds)

The issue offered two options: give rounds a real parent, or mark the
root stage so the scan can tell them apart by `kind`. Re-parenting tool-
use rounds under "Run:" would also change live rendering: the progress
view's group tree treats a stage with no resolvable parent as a root
(flat container, no header), and workflow rounds are already correctly
parented this way. Tool-use rounds are currently rendered flat/un-nested
(`TaskGroupList.ts`'s `checkForCompletedRuns` explicitly skips its round-
complete-sound logic for tool-use), so giving them a real parent would
visibly nest every tool-use round under a collapsible "Run:" header in
the live UI -- well beyond a trace-viewer/legacy-scan fix.

Instead:
- `TexraTranscriptRecorder.ts`: preserve each stage's `kind` across the
  `stage.end` merge (`store.update` replaces `data` wholesale, so `kind`
  was being dropped from `GROUP_END` rows even though `stage.start`
  already carried it).
- `replayTrace.ts`: the reverse scan now also skips `GROUP_END` rows
  tagged `round`/`phase`/`session`, keeping only the root run stage's
  row (`kind: 'run'`, or no `kind` at all for traces predating stage
  kinds -- `kind: 'round'`/`kind: 'run'` were both added in the same
  commit, #7164, so any trace with a round tag also has the run tag).

This is additive metadata only; it doesn't touch live progress-view
rendering or grouping behavior.

## Testing

- Added a regression test in `replayTrace.vitest.ts` reproducing the
  exact scenario from the issue (root run stage never closes, last
  tool-use round closes cleanly with `groupId: undefined`) -- verified
  it fails without the fix (`completed` instead of `ready`) and passes
  with it.
- Added `TexraTranscriptRecorder.vitest.ts` verifying `kind` survives
  the `stage.end` merge for both round and run stages.
- `npm run typecheck` (full workspace) passes.
- `npx eslint` on changed files: clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to legacy trace replay status derivation and transcript metadata on stage end; no live UI grouping or auth changes.
> 
> **Overview**
> Fixes incorrect **completed** lifecycle status when replaying legacy tool-use traces where the root run never closed but a tool-use round’s top-level `GROUP_END` did.
> 
> **`TexraTranscriptRecorder`** now remembers each stage’s `kind` from `stage.start` and writes it onto the in-place `GROUP_END` update, because `store.update` replaces `data` wholesale and was dropping `kind`.
> 
> **`toStreamLifecycleStatus` in `replayTrace.ts`** skips top-level `GROUP_END` rows tagged `round` / `phase` / `session` (same `groupId === undefined` shape as the root run). For traces with no `data.kind`, **`findRootStageId`** picks the first top-level stage entry so only the root run’s own `GROUP_END` can drive status.
> 
> Regression tests cover kind-tagged rounds (#7267), pre-kind archives (#7291), and recorder kind preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 575d00530f82c32091bc7731a187af3ebd9aa79f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->