### PR TITLE
refactor: read completed-run todos from sidecars

### DIFF
--- a/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
@@ -5,15 +5,23 @@ import * as path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
-import { setupPlatform } from '@test/support/setupPlatform';
+import { installPlatform, setupPlatform } from '@test/support/setupPlatform';
 import { seedStreamStatusForTest } from '@test/helpers/streamStatusTestUtils';
+import { StreamSnapshotStore, streamDataDir } from '@transcript';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
-import { STREAM_PHASE, type StreamTabId } from '@shared/schemas';
+import {
+  RUN_DESCRIPTOR_SCHEMA_VERSION,
+  STREAM_PHASE,
+  type ExecutionId,
+  type StreamTabId,
+  type TodoItem,
+} from '@shared/schemas';
 import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
 import { ExecutionsTool } from '@tools/ExecutionsTool';
+import { StorageFS } from '@utils/files';
 
 import { createRecordingHost } from '../agent/progressTestUtils';
 
@@ -69,6 +77,40 @@ async function withTempWorkspace(
   } finally {
     await rm(workspace, { recursive: true, force: true });
   }
+}
+
+/** Installs a real filesystem-backed storage root for sidecar persistence tests. */
+async function withTempStorage(run: () => Promise<void>): Promise<void> {
+  const root = await mkdtemp(path.join(tmpdir(), 'texra-exec-storage-'));
+  try {
+    await installPlatform(
+      {
+        workspacePath: path.join(root, 'workspace'),
+        storagePath: path.join(root, 'storage'),
+      },
+      { fs: nodeFilesystem },
+    );
+    await run();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+async function writeSidecarTodos(
+  streamId: StreamTabId,
+  executionId: ExecutionId,
+  todos: TodoItem[],
+): Promise<void> {
+  const snapshots = new StreamSnapshotStore();
+  snapshots.setTodos(streamId, todos);
+  await snapshots.flush();
+  await StorageFS.write(
+    path.join(streamDataDir(streamId), 'meta.json'),
+    JSON.stringify({
+      schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+      executionId,
+    }),
+  );
 }
 
 describe('ExecutionsTool', () => {
@@ -223,6 +265,56 @@ describe('ExecutionsTool', () => {
     expect(reportResult.output).toBe(
       '<subagent-result>full report</subagent-result>',
     );
+  });
+
+  it('reads completed summary todos from stream sidecars before legacy KV todos', async () => {
+    await withTempStorage(async () => {
+      const executionId = 'abc123' as ExecutionId;
+      const streamId = `codex#${executionId}` as StreamTabId;
+      await writeSidecarTodos(streamId, executionId, [
+        {
+          content: 'Read the sidecar work plan',
+          status: 'in_progress',
+          activeForm: 'Reading the sidecar work plan',
+        },
+      ]);
+      mocks.readMeta.mockResolvedValue({
+        timestamp: '2026-06-15T09:36:02.345Z',
+        category: 'toolUse',
+      });
+      mocks.readConfig.mockResolvedValue(config);
+      mocks.readTodos.mockResolvedValue([
+        { content: 'Read the old KV todo', status: 'pending' },
+      ]);
+
+      const result = await new ExecutionsTool().call({
+        path: `/executions/${executionId}`,
+      });
+
+      expect(result.output).toContain('Read the sidecar work plan');
+      expect(result.output).not.toContain('Read the old KV todo');
+      expect(mocks.readTodos).not.toHaveBeenCalled();
+    });
+  });
+
+  it('falls back to legacy KV todos when completed summary sidecars are absent', async () => {
+    await withTempStorage(async () => {
+      mocks.readMeta.mockResolvedValue({
+        timestamp: '2026-06-15T09:36:02.345Z',
+        category: 'toolUse',
+      });
+      mocks.readConfig.mockResolvedValue(config);
+      mocks.readTodos.mockResolvedValue([
+        { content: 'Read the old KV todo', status: 'pending' },
+      ]);
+
+      const result = await new ExecutionsTool().call({
+        path: '/executions/abc123',
+      });
+
+      expect(result.output).toContain('Read the old KV todo');
+      expect(mocks.readTodos).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('lists and reads persisted workspace files for tool-use executions', async () => {

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -9,6 +9,7 @@
 import { z } from 'zod';
 
 import { platform } from '@platform/platform';
+import { readCompletedRunTodos } from '@transcript';
 
 // Local imports - agent
 import {
@@ -440,11 +441,13 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
 
     // Completed execution: full KV fetch
     const store = getExecutionStore(executionId);
-    const [meta, config, children, todos, report] = await Promise.all([
+    const [meta, config, children, todosResult, report] = await Promise.all([
       store.readMeta(),
       store.readConfig(),
       store.readChildren(),
-      store.readTodos(),
+      readCompletedRunTodos(executionId, {
+        legacyFallback: () => store.readTodos(),
+      }),
       store.readReport(),
     ]);
 
@@ -477,7 +480,7 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
       executionId,
       category,
       children,
-      todos,
+      todosResult.todos,
       report,
       {
         suppressReport: false,

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -1,0 +1,72 @@
+import type { TodoEntry } from '@agent/storage';
+import type { ExecutionId, StreamTabId, TodoItem } from '@shared/schemas';
+import { StorageFS } from '@utils/files';
+
+import { resolvePersistedStreamIdForExecution } from './executionStreamResolver';
+import { STREAM_DATA_KEYS, streamDataDir } from './streamDataPaths';
+import { StreamSnapshotStore } from './StreamSnapshotStore';
+
+export type CompletedRunTodosSource = 'streamData' | 'legacyKV' | 'none';
+
+export interface CompletedRunTodosReadResult {
+  readonly todos: TodoEntry[];
+  readonly source: CompletedRunTodosSource;
+  readonly streamId?: StreamTabId;
+}
+
+export interface CompletedRunTodosReaderOptions {
+  readonly snapshotStore?: StreamSnapshotStore;
+  readonly legacyFallback?: () => Promise<readonly TodoEntry[]>;
+}
+
+function todoItemToEntry(todo: TodoItem): TodoEntry {
+  return {
+    content: todo.content,
+    status: todo.status,
+  };
+}
+
+function workPlanPath(streamId: StreamTabId): string {
+  return `${streamDataDir(streamId)}/${STREAM_DATA_KEYS.WORK_PLAN}.json`;
+}
+
+async function readLegacyTodos(
+  fallback: (() => Promise<readonly TodoEntry[]>) | undefined,
+): Promise<CompletedRunTodosReadResult> {
+  if (!fallback) return { todos: [], source: 'none' };
+  return {
+    todos: [...(await fallback())],
+    source: 'legacyKV',
+  };
+}
+
+/**
+ * Read the archived task list for a completed run from the stream sidecar.
+ *
+ * `executions/{id}/todos.json` is still consulted only as a temporary legacy
+ * fallback for runs recorded before durable work-plan sidecars existed.
+ */
+export async function readCompletedRunTodos(
+  executionId: ExecutionId,
+  options: CompletedRunTodosReaderOptions = {},
+): Promise<CompletedRunTodosReadResult> {
+  const snapshotStore = options.snapshotStore ?? new StreamSnapshotStore();
+  const resolved = await resolvePersistedStreamIdForExecution(executionId, {
+    snapshotStore,
+  });
+
+  if (resolved) {
+    if (await StorageFS.exists(workPlanPath(resolved.streamId))) {
+      const snapshot = await snapshotStore.read(resolved.streamId);
+      return {
+        todos: snapshot.todos.map(todoItemToEntry),
+        source: 'streamData',
+        streamId: resolved.streamId,
+      };
+    }
+
+    return readLegacyTodos(options.legacyFallback);
+  }
+
+  return readLegacyTodos(options.legacyFallback);
+}

--- a/src/transcript/executionStreamResolver.ts
+++ b/src/transcript/executionStreamResolver.ts
@@ -1,0 +1,69 @@
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
+
+import { StreamSnapshotStore } from './StreamSnapshotStore';
+import type { StreamLogStore } from './StreamLogStore';
+
+export type PersistedStreamIdResolutionSource =
+  'streamDataMeta' | 'streamDataSuffix' | 'streamLogsSuffix' | 'fallback';
+
+export interface PersistedStreamIdResolution {
+  readonly streamId: StreamTabId;
+  readonly source: PersistedStreamIdResolutionSource;
+}
+
+export interface PersistedStreamIdResolverOptions {
+  readonly snapshotStore?: StreamSnapshotStore;
+  readonly streamLogStore?: Pick<StreamLogStore, 'keys'>;
+  readonly fallbackStreamId?: StreamTabId;
+}
+
+function findSuffixMatch(
+  streams: readonly StreamTabId[],
+  executionId: ExecutionId,
+): StreamTabId | undefined {
+  const suffix = `#${executionId}`;
+  return streams.find((id) => id.endsWith(suffix));
+}
+
+/**
+ * Resolve an execution id to the stream id used by transcript sidecars.
+ *
+ * The sidecar metadata is canonical. The suffix checks preserve compatibility
+ * with older records and child-stream prefixes that cannot be derived from the
+ * top-level agent/model pair.
+ */
+export async function resolvePersistedStreamIdForExecution(
+  executionId: ExecutionId,
+  options: PersistedStreamIdResolverOptions = {},
+): Promise<PersistedStreamIdResolution | null> {
+  const snapshotStore = options.snapshotStore ?? new StreamSnapshotStore();
+  const persistedStreams = await snapshotStore.listPersistedStreams();
+
+  const matchedByMeta = (
+    await Promise.all(
+      persistedStreams.map(async (streamId) => ({
+        streamId,
+        executionId: await snapshotStore.readPersistedExecutionId(streamId),
+      })),
+    )
+  ).find((candidate) => candidate.executionId === executionId);
+  if (matchedByMeta) {
+    return { streamId: matchedByMeta.streamId, source: 'streamDataMeta' };
+  }
+
+  const matchedSidecar = findSuffixMatch(persistedStreams, executionId);
+  if (matchedSidecar) {
+    return { streamId: matchedSidecar, source: 'streamDataSuffix' };
+  }
+
+  const matchedLog = options.streamLogStore
+    ? findSuffixMatch(options.streamLogStore.keys(), executionId)
+    : undefined;
+  if (matchedLog) {
+    return { streamId: matchedLog, source: 'streamLogsSuffix' };
+  }
+
+  return options.fallbackStreamId
+    ? { streamId: options.fallbackStreamId, source: 'fallback' }
+    : null;
+}

--- a/src/transcript/index.ts
+++ b/src/transcript/index.ts
@@ -31,4 +31,14 @@ export {
   type AssembleTraceResult,
   type TraceDocument,
 } from './traceAssembler';
+export {
+  readCompletedRunTodos,
+  type CompletedRunTodosReadResult,
+  type CompletedRunTodosSource,
+} from './completedRunArchive';
+export {
+  resolvePersistedStreamIdForExecution,
+  type PersistedStreamIdResolution,
+  type PersistedStreamIdResolutionSource,
+} from './executionStreamResolver';
 export { injectStandaloneTrace } from './standaloneTraceHtml';

--- a/src/transcript/traceAssembler.ts
+++ b/src/transcript/traceAssembler.ts
@@ -23,6 +23,7 @@ import type {
 
 import { StreamLogStore } from './StreamLogStore';
 import { StreamSnapshotStore } from './StreamSnapshotStore';
+import { resolvePersistedStreamIdForExecution } from './executionStreamResolver';
 
 export interface TraceDocument {
   readonly executionId: ExecutionId;
@@ -63,19 +64,15 @@ export async function assembleTrace(
   ]);
   if (!config) return { status: 'config_missing' };
 
-  // Resolve the persisted streamId by executionId suffix rather than
-  // deriving it: a top-level run uses `agent@model#executionId`
-  // (getStreamTabId), but a background child stream (bash/codex/claude
-  // subagent, see @tools/childStream.createChildStream) uses a
-  // tool-specific `${streamPrefix}#executionId` instead. Every streamId
-  // ends in `#executionId` regardless of prefix scheme, and executionId is
-  // unique, so searching by suffix resolves both without this module having
-  // to know every child-stream prefix convention. Falls back to the derived
-  // top-level id if load() found nothing at all under this executionId.
-  const suffix = `#${executionId}`;
   const streamId =
-    streamLogStore.keys().find((id) => id.endsWith(suffix)) ??
-    getStreamTabId(config.agent, config.model, { executionId });
+    (
+      await resolvePersistedStreamIdForExecution(executionId, {
+        streamLogStore,
+        fallbackStreamId: getStreamTabId(config.agent, config.model, {
+          executionId,
+        }),
+      })
+    )?.streamId ?? getStreamTabId(config.agent, config.model, { executionId });
 
   const [, snapshot] = await Promise.all([
     streamLogStore.ensureLoaded(streamId),


### PR DESCRIPTION
## Summary

- Add a host-neutral transcript resolver from execution id to persisted stream id, using streamData metadata first and suffix fallbacks for older child-stream records.
- Add a completed-run todo reader that prefers durable `streamData/{stream}/workPlan.json` todos and falls back to legacy `executions/{id}/todos.json` only for older runs without a work-plan sidecar.
- Route completed `/executions/{id}` summaries through that reader and share the resolver with trace assembly.

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts src/test-kernel/transcript/traceAssembler.vitest.ts`
- `corepack pnpm exec eslint src/transcript/completedRunArchive.ts src/transcript/executionStreamResolver.ts src/transcript/traceAssembler.ts src/transcript/index.ts src/tools/ExecutionsTool.ts src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- `npm run compile:fast`
- `corepack pnpm exec prettier --check src/transcript/completedRunArchive.ts src/transcript/executionStreamResolver.ts src/transcript/traceAssembler.ts src/transcript/index.ts src/tools/ExecutionsTool.ts src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts`
- `npm run lint` (passes with the pre-existing import-order warning in `packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts`)
- `git diff --check`
- `npm test`

## Scheduled Refactoring

The temporary completed-run todo fallback to `executions/{id}/todos.json` is tracked in #6981 with a D3 removal trigger. The fallback is used only when a run has no durable `streamData/{stream}/workPlan.json` sidecar.

Closes part of #7246. Advances #6966 and #6951.