### PR TITLE
compileLatex2Pdf returns { ok, logTail } so callers surface the compile log

### DIFF
--- a/packages/desktop/src/main/desktopPreviewHost.ts
+++ b/packages/desktop/src/main/desktopPreviewHost.ts
@@ -137,9 +137,10 @@ export function createDesktopPreviewHost(
     const built = await compileLatex2Pdf(createExternalLocation(sourcePath), {
       outputDirectory,
     });
-    if (!built) {
+    if (!built.ok) {
+      const tail = built.logTail ? `\n\n${built.logTail}` : '';
       await fail(
-        `LaTeX build failed for ${sourcePath}. See the LaTeX log next to the source for details.`,
+        `LaTeX build failed for ${sourcePath}. See the LaTeX log next to the source for details.${tail}`,
       );
     }
 

--- a/packages/desktop/src/main/desktopPreviewHost.ts
+++ b/packages/desktop/src/main/desktopPreviewHost.ts
@@ -138,9 +138,16 @@ export function createDesktopPreviewHost(
       outputDirectory,
     });
     if (!built.ok) {
-      const tail = built.logTail ? `\n\n${built.logTail}` : '';
+      // The full engine log (up to 200 lines) goes to console.error, not the
+      // dialog message -- fail() surfaces the message via a blocking native
+      // `dialog.showMessageBox` modal (see main/index.ts's showErrorMessage),
+      // which has no scrolling affordance and would render as an oversized,
+      // unreadable dialog for a multi-hundred-line raw compiler log.
+      console.error(
+        `[desktop] LaTeX build failed for ${sourcePath}:\n${built.logTail}`,
+      );
       await fail(
-        `LaTeX build failed for ${sourcePath}. See the LaTeX log next to the source for details.${tail}`,
+        `LaTeX build failed for ${sourcePath}. See the LaTeX log next to the source for details.`,
       );
     }
 

--- a/packages/extension/src/frontend/latex/openBuild.ts
+++ b/packages/extension/src/frontend/latex/openBuild.ts
@@ -129,13 +129,15 @@ async function openAndBuildLatex(
     // packages, so compile internally with TEXINPUTS set.
     // Resolve the same outDir that LaTeX Workshop uses so the viewer finds the PDF.
     const outDir = resolveLatexWorkshopOutDir(uri.fsPath);
-    const ok = await compileLatex2Pdf(pathToLocation(uri.fsPath), {
+    const compiled = await compileLatex2Pdf(pathToLocation(uri.fsPath), {
       outputDirectory: outDir,
     });
-    if (!ok) {
+    if (!compiled.ok) {
       logger.warn(
         CHANNEL,
-        `Internal LaTeX compilation failed for ${uri.fsPath}`,
+        `Internal LaTeX compilation failed for ${uri.fsPath}${
+          compiled.logTail ? `\n${compiled.logTail}` : ''
+        }`,
       );
     }
   }

--- a/packages/extension/src/frontend/latex/openBuild.ts
+++ b/packages/extension/src/frontend/latex/openBuild.ts
@@ -135,9 +135,8 @@ async function openAndBuildLatex(
     if (!compiled.ok) {
       logger.warn(
         CHANNEL,
-        `Internal LaTeX compilation failed for ${uri.fsPath}${
-          compiled.logTail ? `\n${compiled.logTail}` : ''
-        }`,
+        `Internal LaTeX compilation failed for ${uri.fsPath}`,
+        { data: { sourceFile: uri.fsPath, logTail: compiled.logTail } },
       );
     }
   }

--- a/packages/extension/src/frontend/latex/openBuild.ts
+++ b/packages/extension/src/frontend/latex/openBuild.ts
@@ -133,9 +133,13 @@ async function openAndBuildLatex(
       outputDirectory: outDir,
     });
     if (!compiled.ok) {
+      // Include the tail in the visible message itself, not just `data` —
+      // writeLine only shows `data` when texra.logger.debugMode is on
+      // (default off), and this failure's whole point is to be visible
+      // without needing to enable debug logging.
       logger.warn(
         CHANNEL,
-        `Internal LaTeX compilation failed for ${uri.fsPath}`,
+        `Internal LaTeX compilation failed for ${uri.fsPath}:\n${compiled.logTail}`,
         { data: { sourceFile: uri.fsPath, logTail: compiled.logTail } },
       );
     }

--- a/packages/extension/src/settingsView/handlers/historyHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/historyHandlers.ts
@@ -259,7 +259,8 @@ export class HistoryHandlers {
       if (logTail) {
         this.ctx.logger.error(
           this.ctx.channel,
-          `LaTeX export compilation failed for ${storagePath}:\n${logTail}`,
+          `LaTeX export compilation failed for ${storagePath}`,
+          { data: { storagePath, logTail } },
         );
       }
       const doc = await vscode.workspace.openTextDocument(absolutePath);

--- a/packages/extension/src/settingsView/handlers/historyHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/historyHandlers.ts
@@ -255,11 +255,13 @@ export class HistoryHandlers {
       );
     } else {
       // Compilation failed — open the .tex source instead, and log the
-      // compile log tail so the failure reason is discoverable.
+      // compile log tail so the failure reason is discoverable. Included in
+      // the visible message itself, not just `data` — the logger only shows
+      // `data` when texra.logger.debugMode is on (default off).
       if (logTail) {
         this.ctx.logger.error(
           this.ctx.channel,
-          `LaTeX export compilation failed for ${storagePath}`,
+          `LaTeX export compilation failed for ${storagePath}:\n${logTail}`,
           { data: { storagePath, logTail } },
         );
       }

--- a/packages/extension/src/settingsView/handlers/historyHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/historyHandlers.ts
@@ -242,7 +242,7 @@ export class HistoryHandlers {
     historyId: string,
     exportInput: ChatExportInput,
   ): Promise<void> {
-    const { absolutePath, storagePath, pdfPath } =
+    const { absolutePath, storagePath, pdfPath, logTail } =
       await this.chatExportController.exportAsLatex(historyId, exportInput);
 
     if (pdfPath) {
@@ -254,7 +254,14 @@ export class HistoryHandlers {
         `Chat exported and compiled: ${filename.replace('.tex', '.pdf')}`,
       );
     } else {
-      // Compilation failed — open the .tex source instead
+      // Compilation failed — open the .tex source instead, and log the
+      // compile log tail so the failure reason is discoverable.
+      if (logTail) {
+        this.ctx.logger.error(
+          this.ctx.channel,
+          `LaTeX export compilation failed for ${storagePath}:\n${logTail}`,
+        );
+      }
       const doc = await vscode.workspace.openTextDocument(absolutePath);
       await vscode.window.showTextDocument(doc, { preview: false });
       void vscode.window.showWarningMessage(

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -427,13 +427,19 @@ export class LatexDiffManager {
     });
 
     if (!compiled.ok) {
-      this.logger.warn('Failed to compile latexdiff PDF', {
-        data: {
-          diffFile: diffLocation.absolutePath,
-          logTail: compiled.logTail,
+      // No MESSAGE_TYPES.INTERNAL here (unlike the diagnostic logs above) —
+      // this is a real failure (the diff PDF silently doesn't appear), so it
+      // must reach the standard channel subscriber, and the tail belongs in
+      // the visible message itself since `data` is only shown in debug mode.
+      this.logger.warn(
+        `Failed to compile latexdiff PDF:\n${compiled.logTail}`,
+        {
+          data: {
+            diffFile: diffLocation.absolutePath,
+            logTail: compiled.logTail,
+          },
         },
-        messageType: MESSAGE_TYPES.INTERNAL,
-      });
+      );
       return { diffLocation, artifact: null };
     }
 

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -419,14 +419,21 @@ export class LatexDiffManager {
         : null,
       this.resolveWorkspaceSourceDir(referenceLocation),
     ].filter((dir): dir is string => dir !== null);
-    const ok = await compileLatex2Pdf(diffLocation, {
+    const compiled = await compileLatex2Pdf(diffLocation, {
       channel: this.streamId,
       outputDirectory: buildDir,
       timeout: timeoutMs,
       extraInputDirs,
     });
 
-    if (!ok) {
+    if (!compiled.ok) {
+      this.logger.warn('Failed to compile latexdiff PDF', {
+        data: {
+          diffFile: diffLocation.absolutePath,
+          logTail: compiled.logTail,
+        },
+        messageType: MESSAGE_TYPES.INTERNAL,
+      });
       return { diffLocation, artifact: null };
     }
 

--- a/src/agent/output/compileCheck.ts
+++ b/src/agent/output/compileCheck.ts
@@ -23,7 +23,6 @@ import {
 } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { hasExtension } from '@utils/core/pathCore';
-import { splitContentLines } from '@utils/text/stringUtils';
 import { readPlatformSetting } from '@utils/config/platformSettings';
 
 import {
@@ -39,7 +38,6 @@ export interface CompileCheckContext {
   streamId: string;
 }
 
-const LOG_TAIL_LINES = 200;
 const COMPILE_LOG_EXCERPT_CHAR_LIMIT = 12000;
 const MIN_TIMEOUT_MS = LATEX_CONFIG_RANGES.workflowAutoCompileTimeoutMs.min;
 
@@ -283,7 +281,7 @@ async function compileOne(
       flexibleFS.delete(legacyLogDest).catch(() => undefined),
     ]);
 
-  let ok: boolean;
+  let compileResult: { ok: boolean; logTail?: string };
   try {
     const content = await flexibleFS.read(outputFile.location);
     if (!/\\documentclass/.test(content)) {
@@ -307,7 +305,7 @@ async function compileOne(
 
     // execa's timeout option kills the child process on expiry, so we don't
     // orphan hanging latexmk/pdflatex runs.
-    ok = await compileLatex2Pdf(outputFile.location, {
+    compileResult = await compileLatex2Pdf(outputFile.location, {
       channel: ctx.streamId,
       outputDirectory: buildDir,
       timeout: opts.timeoutMs,
@@ -336,7 +334,7 @@ async function compileOne(
     });
   }
 
-  if (ok) {
+  if (compileResult.ok) {
     ctx.logger.debug(`Compile check: ${displayName} built successfully`);
     // Only now that we know the outcome do we clear a stale failure log from
     // a previous attempt at this round — clearing it up front would leave a
@@ -355,7 +353,7 @@ async function compileOne(
     return { failure: null, failureLogExcerpt: '', artifact };
   }
 
-  const tail = await readLogTail(buildDir, compiledBasename);
+  const tail = compileResult.logTail ?? '(no compile log tail available)';
   const failureLogExcerpt = `Compile check failed for ${displayName}\nBuild directory: ${buildDir}\n\n${tail}`;
   ctx.logger.warn(`Compile check: ${displayName} failed`, {
     data: path.relative(opts.runDirectory, logDest.absolutePath),
@@ -505,22 +503,4 @@ function combineFailureLogExcerpts(excerpts: string[]): string {
     `[truncated to last ${COMPILE_LOG_EXCERPT_CHAR_LIMIT} characters]`,
     combined.slice(-COMPILE_LOG_EXCERPT_CHAR_LIMIT),
   ].join('\n');
-}
-
-async function readLogTail(
-  buildDir: string,
-  compiledBasename: string,
-): Promise<string> {
-  // LaTeX engines drop `<basename-without-ext>.log`; strip .tex
-  // case-insensitively so .TEX/.Tex map to the same file.
-  const latexLogAbs = path.join(
-    buildDir,
-    `${compiledBasename.replace(/\.tex$/i, '')}.log`,
-  );
-  try {
-    const full = await flexibleFS.read(pathToLocation(latexLogAbs));
-    return splitContentLines(full).slice(-LOG_TAIL_LINES).join('\n');
-  } catch (err) {
-    return `(no LaTeX log at ${latexLogAbs}: ${toErrorMessage(err)})`;
-  }
 }

--- a/src/agent/output/compileCheck.ts
+++ b/src/agent/output/compileCheck.ts
@@ -3,7 +3,7 @@ import * as path from 'node:path';
 
 import type { AgentTrace } from '@agent/trace';
 import { hasLatexCompiler } from '@latex/latexToolchain';
-import { compileLatex2Pdf } from '@latex/texTools';
+import { compileLatex2Pdf, type CompileLatex2PdfResult } from '@latex/texTools';
 import type {
   CompileFailure,
   CompileResult,
@@ -281,7 +281,7 @@ async function compileOne(
       flexibleFS.delete(legacyLogDest).catch(() => undefined),
     ]);
 
-  let compileResult: { ok: boolean; logTail?: string };
+  let compileResult: CompileLatex2PdfResult;
   try {
     const content = await flexibleFS.read(outputFile.location);
     if (!/\\documentclass/.test(content)) {
@@ -353,8 +353,7 @@ async function compileOne(
     return { failure: null, failureLogExcerpt: '', artifact };
   }
 
-  const tail = compileResult.logTail ?? '(no compile log tail available)';
-  const failureLogExcerpt = `Compile check failed for ${displayName}\nBuild directory: ${buildDir}\n\n${tail}`;
+  const failureLogExcerpt = `Compile check failed for ${displayName}\nBuild directory: ${buildDir}\n\n${compileResult.logTail}`;
   ctx.logger.warn(`Compile check: ${displayName} failed`, {
     data: path.relative(opts.runDirectory, logDest.absolutePath),
   });

--- a/src/controllers/settingsView/ChatExportController.ts
+++ b/src/controllers/settingsView/ChatExportController.ts
@@ -63,6 +63,8 @@ export interface ChatExportResult {
 export interface LatexExportResult extends ChatExportResult {
   /** Absolute path to the compiled PDF, or undefined if compilation failed. */
   readonly pdfPath?: string;
+  /** Tail of the LaTeX compile log, present when compilation failed. */
+  readonly logTail?: string;
 }
 
 /** `assembleTrace`'s failure statuses, re-surfaced for the HTML export path. */
@@ -147,11 +149,16 @@ export class ChatExportController {
     const location = pathToLocation(absolutePath);
     const compiled = await compileLatex2Pdf(location);
 
-    const pdfPath = compiled
+    const pdfPath = compiled.ok
       ? absolutePath.replace(/\.tex$/, '.pdf')
       : undefined;
 
-    return { storagePath, absolutePath, pdfPath };
+    return {
+      storagePath,
+      absolutePath,
+      pdfPath,
+      logTail: compiled.ok ? undefined : compiled.logTail,
+    };
   }
 
   /**

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -124,7 +124,15 @@ export class LatexMediaManager {
           const compiled = await compileLatex2Pdf(file, {
             outputDirectory: buildDir,
           });
-          if (!compiled) return undefined;
+          if (!compiled.ok) {
+            this.logger.warn('Failed to compile LaTeX to PDF', {
+              data: {
+                sourceFile: file.absolutePath,
+                logTail: compiled.logTail,
+              },
+            });
+            return undefined;
+          }
 
           const pdfFile = path.join(
             buildDir,

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -125,12 +125,15 @@ export class LatexMediaManager {
             outputDirectory: buildDir,
           });
           if (!compiled.ok) {
-            this.logger.warn('Failed to compile LaTeX to PDF', {
-              data: {
-                sourceFile: file.absolutePath,
-                logTail: compiled.logTail,
+            this.logger.warn(
+              `Failed to compile LaTeX to PDF:\n${compiled.logTail}`,
+              {
+                data: {
+                  sourceFile: file.absolutePath,
+                  logTail: compiled.logTail,
+                },
               },
-            });
+            );
             return undefined;
           }
 

--- a/src/latex/TikzPictureManager.ts
+++ b/src/latex/TikzPictureManager.ts
@@ -189,7 +189,7 @@ class TikzPictureManager {
         if (!compiled.ok) {
           logger.warn(
             this.channel,
-            `Failed to compile TikZ picture ${texLocation.absolutePath}`,
+            `Failed to compile TikZ picture ${texLocation.absolutePath}:\n${compiled.logTail}`,
             {
               data: {
                 texFile: texLocation.absolutePath,

--- a/src/latex/TikzPictureManager.ts
+++ b/src/latex/TikzPictureManager.ts
@@ -182,10 +182,18 @@ class TikzPictureManager {
           buildDirLocation,
           suffix,
         );
-        await compileLatex2Pdf(texLocation, {
+        const compiled = await compileLatex2Pdf(texLocation, {
           channel: this.channel,
           compiler: 'pdflatex',
         });
+        if (!compiled.ok) {
+          logger.warn(
+            this.channel,
+            `Failed to compile TikZ picture ${texLocation.absolutePath}${
+              compiled.logTail ? `\n${compiled.logTail}` : ''
+            }`,
+          );
+        }
 
         // Derive PDF location from tex location
         const pdfFilename = path

--- a/src/latex/TikzPictureManager.ts
+++ b/src/latex/TikzPictureManager.ts
@@ -189,9 +189,13 @@ class TikzPictureManager {
         if (!compiled.ok) {
           logger.warn(
             this.channel,
-            `Failed to compile TikZ picture ${texLocation.absolutePath}${
-              compiled.logTail ? `\n${compiled.logTail}` : ''
-            }`,
+            `Failed to compile TikZ picture ${texLocation.absolutePath}`,
+            {
+              data: {
+                texFile: texLocation.absolutePath,
+                logTail: compiled.logTail,
+              },
+            },
           );
         }
 

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -14,9 +14,38 @@ import { WorkspaceFS, flexibleFS, pathToLocation } from '@utils/files';
 import { runToolWithCheck } from '@utils/system';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { getConfig } from '@utils/config/configUtils';
+import { splitContentLines } from '@utils/text/stringUtils';
 
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);
+
+// Raw tail, no TeX-log parsing -- a deliberate choice (see compileCheck.ts):
+// tex compile logs are noisy and heuristic parsing is a losing game, so every
+// caller gets the same last-N-lines excerpt an LLM or a human can read as-is.
+const LOG_TAIL_LINES = 200;
+
+/**
+ * Read the tail of the `.log` file a LaTeX engine drops next to its output
+ * (`<basename-without-ext>.log` inside `outDir`). Shared by every
+ * {@link compileLatex2Pdf} caller so a failed compile always comes with
+ * enough context to act on, not just a boolean.
+ */
+async function readCompileLogTail(
+  outDir: string,
+  latexFile: string,
+): Promise<string> {
+  const compiledBasename = path.basename(latexFile);
+  const logAbs = path.join(
+    outDir,
+    `${compiledBasename.replace(/\.tex$/i, '')}.log`,
+  );
+  try {
+    const full = await flexibleFS.read(pathToLocation(logAbs));
+    return splitContentLines(full).slice(-LOG_TAIL_LINES).join('\n');
+  } catch (err) {
+    return `(no LaTeX log at ${logAbs}: ${toErrorMessage(err)})`;
+  }
+}
 
 export function buildKpathseaSearchPath(
   prependPaths: readonly string[],
@@ -91,23 +120,35 @@ export function buildLatexSearchParts(input: {
   };
 }
 
+/** Result of a {@link compileLatex2Pdf} attempt. */
+export interface CompileLatex2PdfResult {
+  /** True if compilation succeeded. */
+  ok: boolean;
+  /**
+   * Last {@link LOG_TAIL_LINES} lines of the engine's `.log` file, present on
+   * failure so every caller can surface (or at least log) why the compile
+   * failed instead of just a bare `false`.
+   */
+  logTail?: string;
+}
+
 /**
  * Compile a LaTeX file to PDF
  * @param latexLocation FileLocation for the LaTeX file
  * @param options Compilation options (channel defaults to module CHANNEL)
- * @returns Promise<boolean> True if compilation succeeded
+ * @returns `{ ok, logTail? }` -- `logTail` is populated on failure.
  */
 export async function compileLatex2Pdf(
   latexLocation: FileLocation,
   options: LaTeXCompileOptions = {},
-): Promise<boolean> {
+): Promise<CompileLatex2PdfResult> {
   // Schema provides compiler default; channel defaults to module constant
   const parsed = LaTeXCompileOptionsSchema.parse(options);
   const channel = parsed.channel ?? CHANNEL;
   const { outputDirectory, compiler, timeout, extraInputDirs } = parsed;
+  const latexFile = latexLocation.absolutePath;
+  const outDir = outputDirectory ?? path.dirname(latexFile);
   try {
-    const latexFile = latexLocation.absolutePath;
-    const outDir = outputDirectory ?? path.dirname(latexFile);
     await flexibleFS.ensureDir(pathToLocation(outDir));
 
     // TeX resolves relative `\input{…}` / `\bibliography{…}` against the
@@ -192,11 +233,16 @@ export async function compileLatex2Pdf(
 
     if (result && result.success) {
       logger.debug(channel, `Successfully compiled ${latexFile}`);
-      return true;
+      return { ok: true };
     }
-    return false;
+    return { ok: false, logTail: await readCompileLogTail(outDir, latexFile) };
   } catch (err) {
-    logger.error(channel, `Error compiling LaTeX: ${toErrorMessage(err)}`);
-    return false;
+    const message = toErrorMessage(err);
+    logger.error(channel, `Error compiling LaTeX: ${message}`);
+    const tail = await readCompileLogTail(outDir, latexFile);
+    return {
+      ok: false,
+      logTail: `Error compiling LaTeX: ${message}\n\n${tail}`,
+    };
   }
 }

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -120,23 +120,22 @@ export function buildLatexSearchParts(input: {
   };
 }
 
-/** Result of a {@link compileLatex2Pdf} attempt. */
-export interface CompileLatex2PdfResult {
-  /** True if compilation succeeded. */
-  ok: boolean;
-  /**
-   * Last {@link LOG_TAIL_LINES} lines of the engine's `.log` file, present on
-   * failure so every caller can surface (or at least log) why the compile
-   * failed instead of just a bare `false`.
-   */
-  logTail?: string;
-}
+/**
+ * Result of a {@link compileLatex2Pdf} attempt. A discriminated union on `ok`
+ * so the type system guarantees {@link LOG_TAIL_LINES}'s worth of the
+ * engine's `.log` file tail is present whenever compilation fails, instead of
+ * every caller needing a defensive fallback for a theoretically-missing
+ * `logTail`.
+ */
+export type CompileLatex2PdfResult =
+  { ok: true } | { ok: false; logTail: string };
 
 /**
  * Compile a LaTeX file to PDF
  * @param latexLocation FileLocation for the LaTeX file
  * @param options Compilation options (channel defaults to module CHANNEL)
- * @returns `{ ok, logTail? }` -- `logTail` is populated on failure.
+ * @returns `{ ok: true } | { ok: false, logTail }` -- `logTail` is always
+ * populated on failure.
  */
 export async function compileLatex2Pdf(
   latexLocation: FileLocation,

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -34,11 +34,11 @@ async function readCompileLogTail(
   outDir: string,
   latexFile: string,
 ): Promise<string> {
-  const compiledBasename = path.basename(latexFile);
-  const logAbs = path.join(
-    outDir,
-    `${compiledBasename.replace(/\.tex$/i, '')}.log`,
-  );
+  // Strip whatever extension the source actually has (.tex/.ltx/.latex are
+  // all compilable, per isLatexFile) — the engine's .log file is always
+  // named after the source with its own extension removed, not just .tex.
+  const compiledBasename = path.basename(latexFile, path.extname(latexFile));
+  const logAbs = path.join(outDir, `${compiledBasename}.log`);
   try {
     const full = await flexibleFS.read(pathToLocation(logAbs));
     return splitContentLines(full).slice(-LOG_TAIL_LINES).join('\n');

--- a/src/test-kernel/agent/output/CompileCheck.vitest.ts
+++ b/src/test-kernel/agent/output/CompileCheck.vitest.ts
@@ -30,9 +30,17 @@ interface FakeCompileOptions {
   outputDirectory?: string;
 }
 
+interface FakeCompileResult {
+  ok: boolean;
+  logTail?: string;
+}
+
 const mocks = vi.hoisted(() => ({
   compileLatex2Pdf: vi.fn(
-    async (_location: FileLocation, _options?: FakeCompileOptions) => true,
+    async (
+      _location: FileLocation,
+      _options?: FakeCompileOptions,
+    ): Promise<FakeCompileResult> => ({ ok: true }),
   ),
   hasLatexCompiler: vi.fn(async () => true),
 }));
@@ -99,28 +107,10 @@ function initLatexPlatform(files: Record<string, string>): Promise<void> {
   });
 }
 
-// Writes a fake LaTeX build log next to where `compileLatex2Pdf` was asked to
-// build, so `readLogTail` (which greps for `<basename>.log` in the reported
-// build directory) finds something real rather than falling back to "(no
-// LaTeX log at ...)". Lets tests control the tail's exact line content
-// without needing to reproduce compileCheck's internal safeName/hash scheme.
-async function seedLatexLog(
-  outputDirectory: string,
-  texAbsolutePath: string,
-  content: string,
-): Promise<void> {
-  const basenameNoExt = path.basename(texAbsolutePath).replace(/\.tex$/i, '');
-  const logDest = pathToLocation(
-    path.join(outputDirectory, `${basenameNoExt}.log`),
-  );
-  await flexibleFS.ensureDir(pathToLocation(outputDirectory));
-  await flexibleFS.write(logDest, content);
-}
-
 describe('runCompileCheck', () => {
   beforeEach(() => {
     mocks.compileLatex2Pdf.mockReset();
-    mocks.compileLatex2Pdf.mockResolvedValue(true);
+    mocks.compileLatex2Pdf.mockResolvedValue({ ok: true });
     mocks.hasLatexCompiler.mockReset();
     mocks.hasLatexCompiler.mockResolvedValue(true);
   });
@@ -189,8 +179,14 @@ describe('runCompileCheck', () => {
     expect(result.compileResult?.status).toBe('ok');
   });
 
-  it('truncates a single failing log tail to the last 200 lines', async () => {
-    const executionId = 'compile-tail-truncation';
+  // The 200-line raw-tail extraction itself now lives in compileLatex2Pdf
+  // (src/latex/texTools.ts), covered by TexTools.vitest.ts. This test proves
+  // the other half of issue #7079's fix: whatever `logTail` compileCheck
+  // receives from the shared { ok, logTail } return shape is threaded
+  // through, unmodified, into the persisted failure excerpt -- it is not
+  // read from disk a second time.
+  it('sources the failing log tail from compileLatex2Pdf, not a separate disk read', async () => {
+    const executionId = 'compile-tail-passthrough';
     const texPath = path.join(runDir(executionId), 'r0', 'main.tex');
     await initLatexPlatform({
       [texPath]: '\\documentclass{article}\\begin{document}Hi\\end{document}',
@@ -198,19 +194,11 @@ describe('runCompileCheck', () => {
 
     // Zero-padded so containment checks below can't be fooled by numeric
     // substrings (e.g. "L0001" would otherwise match inside "L00010").
-    const totalLines = 250;
-    mocks.compileLatex2Pdf.mockImplementation(async (location, options) => {
-      const lines = Array.from(
-        { length: totalLines },
-        (_, i) => `L${String(i + 1).padStart(4, '0')}`,
-      );
-      await seedLatexLog(
-        options?.outputDirectory ?? '',
-        location.absolutePath,
-        lines.join('\n'),
-      );
-      return false;
-    });
+    const logTail = Array.from(
+      { length: 200 },
+      (_, i) => `L${String(i + 51).padStart(4, '0')}`,
+    ).join('\n');
+    mocks.compileLatex2Pdf.mockResolvedValue({ ok: false, logTail });
 
     const outputState = createOutputState();
     ensureRoundData(outputState, 0).outputs = [
@@ -232,11 +220,9 @@ describe('runCompileCheck', () => {
       result.compileResult?.status === 'failed'
         ? result.compileResult.logExcerpt
         : '';
-    // Last 200 of 250 lines survive: L0051 .. L0250.
     expect(excerpt).toContain('L0051');
     expect(excerpt).toContain('L0250');
     expect(excerpt).not.toContain('L0050');
-    expect(excerpt).not.toContain('L0001');
   });
 
   it('truncates the combined excerpt to the last 12000 characters', async () => {
@@ -251,17 +237,13 @@ describe('runCompileCheck', () => {
     // wrapped with the "Compile check failed for..." header. Zero-padded
     // markers avoid numeric-substring false matches in the assertions below.
     const longLine = 'x'.repeat(100);
-    mocks.compileLatex2Pdf.mockImplementation(async (location, options) => {
-      const lines = Array.from(
-        { length: 150 },
-        (_, i) => `${longLine}-END${String(i + 1).padStart(4, '0')}`,
-      );
-      await seedLatexLog(
-        options?.outputDirectory ?? '',
-        location.absolutePath,
-        lines.join('\n'),
-      );
-      return false;
+    const lines = Array.from(
+      { length: 150 },
+      (_, i) => `${longLine}-END${String(i + 1).padStart(4, '0')}`,
+    );
+    mocks.compileLatex2Pdf.mockResolvedValue({
+      ok: false,
+      logTail: lines.join('\n'),
     });
 
     const outputState = createOutputState();
@@ -298,7 +280,7 @@ describe('runCompileCheck', () => {
       [texPath]: '\\documentclass{article}\\begin{document}Hi\\end{document}',
     });
 
-    mocks.compileLatex2Pdf.mockResolvedValueOnce(false);
+    mocks.compileLatex2Pdf.mockResolvedValueOnce({ ok: false });
 
     const outputState = createOutputState();
     ensureRoundData(outputState, 0).outputs = [
@@ -320,7 +302,7 @@ describe('runCompileCheck', () => {
 
     // Re-run the same round (e.g. after a repaired retry); this time the
     // compile succeeds.
-    mocks.compileLatex2Pdf.mockResolvedValueOnce(true);
+    mocks.compileLatex2Pdf.mockResolvedValueOnce({ ok: true });
     const secondResult = await runCompileCheck(ctx, 0);
     expect(secondResult.compileResult?.status).toBe('ok');
 
@@ -382,14 +364,9 @@ describe('runCompileCheck', () => {
       [texPathB]: '\\documentclass{article}\\begin{document}B\\end{document}',
     });
 
-    mocks.compileLatex2Pdf.mockImplementation(async (location, options) => {
+    mocks.compileLatex2Pdf.mockImplementation(async (location) => {
       const abs = location.absolutePath;
-      await seedLatexLog(
-        options?.outputDirectory ?? '',
-        abs,
-        `LOG MARKER FOR ${abs}`,
-      );
-      return false;
+      return { ok: false, logTail: `LOG MARKER FOR ${abs}` };
     });
 
     const outputState = createOutputState();

--- a/src/test-kernel/agent/output/CompileCheck.vitest.ts
+++ b/src/test-kernel/agent/output/CompileCheck.vitest.ts
@@ -11,6 +11,7 @@ import { runCompileCheck } from '@agent/output/compileCheck';
 import { createOutputState, ensureRoundData } from '@agent/output/outputState';
 
 // Local imports - shared
+import type { CompileLatex2PdfResult } from '@latex/texTools';
 import type {
   ExecutionId,
   FileLocation,
@@ -30,17 +31,12 @@ interface FakeCompileOptions {
   outputDirectory?: string;
 }
 
-interface FakeCompileResult {
-  ok: boolean;
-  logTail?: string;
-}
-
 const mocks = vi.hoisted(() => ({
   compileLatex2Pdf: vi.fn(
     async (
       _location: FileLocation,
       _options?: FakeCompileOptions,
-    ): Promise<FakeCompileResult> => ({ ok: true }),
+    ): Promise<CompileLatex2PdfResult> => ({ ok: true }),
   ),
   hasLatexCompiler: vi.fn(async () => true),
 }));
@@ -280,7 +276,10 @@ describe('runCompileCheck', () => {
       [texPath]: '\\documentclass{article}\\begin{document}Hi\\end{document}',
     });
 
-    mocks.compileLatex2Pdf.mockResolvedValueOnce({ ok: false });
+    mocks.compileLatex2Pdf.mockResolvedValueOnce({
+      ok: false,
+      logTail: 'stale failure log',
+    });
 
     const outputState = createOutputState();
     ensureRoundData(outputState, 0).outputs = [

--- a/src/test-kernel/agent/output/LatexCompileInputDirs.vitest.ts
+++ b/src/test-kernel/agent/output/LatexCompileInputDirs.vitest.ts
@@ -31,7 +31,7 @@ import {
 } from '@utils/files';
 
 const mocks = vi.hoisted(() => ({
-  compileLatex2Pdf: vi.fn(async () => true),
+  compileLatex2Pdf: vi.fn(async () => ({ ok: true })),
   hasLatexCompiler: vi.fn(async () => true),
 }));
 

--- a/src/test-kernel/desktop/DesktopPreviewHost.vitest.mts
+++ b/src/test-kernel/desktop/DesktopPreviewHost.vitest.mts
@@ -23,7 +23,7 @@ interface DesktopPreviewHostModule {
 }
 
 async function loadDesktopPreviewHost(
-  compileLatex2Pdf = vi.fn(async () => true),
+  compileLatex2Pdf = vi.fn(async () => ({ ok: true })),
   access?: (filePath: string) => Promise<void>,
   checkToolInstalled = vi.fn(async () => true),
 ): Promise<DesktopPreviewHostModule> {
@@ -158,7 +158,7 @@ describe('desktop preview host', () => {
   });
 
   it('builds LaTeX previews and opens the generated PDF path', async () => {
-    const compileLatex2Pdf = vi.fn(async () => true);
+    const compileLatex2Pdf = vi.fn(async () => ({ ok: true }));
     const { createDesktopPreviewHost } =
       await loadDesktopPreviewHost(compileLatex2Pdf);
     const dir = await makeTempDir();
@@ -182,7 +182,7 @@ describe('desktop preview host', () => {
   });
 
   it('opens compile-preview PDF targets without running LaTeX', async () => {
-    const compileLatex2Pdf = vi.fn(async () => true);
+    const compileLatex2Pdf = vi.fn(async () => ({ ok: true }));
     const checkToolInstalled = vi.fn(async () => true);
     const { createDesktopPreviewHost } = await loadDesktopPreviewHost(
       compileLatex2Pdf,
@@ -203,7 +203,7 @@ describe('desktop preview host', () => {
   });
 
   it('reports missing LaTeX toolchains before compiling preview sources', async () => {
-    const compileLatex2Pdf = vi.fn(async () => true);
+    const compileLatex2Pdf = vi.fn(async () => ({ ok: true }));
     const checkToolInstalled = vi.fn(async () => false);
     const { createDesktopPreviewHost } = await loadDesktopPreviewHost(
       compileLatex2Pdf,
@@ -231,7 +231,8 @@ describe('desktop preview host', () => {
   });
 
   it('reports LaTeX build failures without opening stale PDFs', async () => {
-    const compileLatex2Pdf = vi.fn(async () => false);
+    const logTail = 'simulated compile log tail';
+    const compileLatex2Pdf = vi.fn(async () => ({ ok: false, logTail }));
     const { createDesktopPreviewHost } =
       await loadDesktopPreviewHost(compileLatex2Pdf);
     const dir = await makeTempDir();
@@ -242,6 +243,13 @@ describe('desktop preview host', () => {
     );
     const showErrorMessage = vi.fn();
     const shell = makeShell();
+    // Silence and inspect the console.error the full log tail is routed to
+    // instead of the (short) dialog message -- see the desktop preview host's
+    // fail() call, which must not stuff the full engine log into a native
+    // dialog.showMessageBox modal.
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
 
     const host = createDesktopPreviewHost({ shell, showErrorMessage });
 
@@ -250,7 +258,14 @@ describe('desktop preview host', () => {
       host.openBuildDisplay({ absolutePath: texPath }),
     ).rejects.toThrow(message);
     expect(showErrorMessage).toHaveBeenCalledWith(message);
+    expect(showErrorMessage).not.toHaveBeenCalledWith(
+      expect.stringContaining(logTail),
+    );
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining(logTail),
+    );
     expect(shell.openPath).not.toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
   });
 
   it('opens external URLs through Electron shell.openExternal', async () => {

--- a/src/test-kernel/latex/LatexProcessingHelpers.vitest.ts
+++ b/src/test-kernel/latex/LatexProcessingHelpers.vitest.ts
@@ -171,12 +171,12 @@ describe('LatexMediaManager PDF compilation', () => {
     mocks.compileLatex2Pdf.mockImplementation(
       async (file: FileLocation, options: { outputDirectory?: string }) => {
         if (path.basename(file.absolutePath) === 'missing-result.tex') {
-          return undefined;
+          return { ok: false, logTail: 'simulated compile failure' };
         }
         const outputDirectory = options.outputDirectory!;
         await mkdir(outputDirectory, { recursive: true });
         await writeFile(compiledPdfPath, 'compiled pdf');
-        return true;
+        return { ok: true };
       },
     );
 

--- a/src/test-kernel/latex/TexTools.vitest.ts
+++ b/src/test-kernel/latex/TexTools.vitest.ts
@@ -75,7 +75,7 @@ describe('compileLatex2Pdf structured return', () => {
       { outputDirectory },
     );
 
-    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected a failed compile');
     // Last 200 of 250 lines survive: L0051 .. L0250.
     expect(result.logTail).toContain('L0051');
     expect(result.logTail).toContain('L0250');
@@ -91,7 +91,7 @@ describe('compileLatex2Pdf structured return', () => {
       { outputDirectory: path.join(workspacePath, 'build-missing') },
     );
 
-    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected a failed compile');
     expect(result.logTail).toContain('no LaTeX log at');
   });
 
@@ -105,7 +105,7 @@ describe('compileLatex2Pdf structured return', () => {
       { outputDirectory: path.join(workspacePath, 'build') },
     );
 
-    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected a failed compile');
     expect(result.logTail).toContain('boom: pdflatex crashed');
   });
 });

--- a/src/test-kernel/latex/TexTools.vitest.ts
+++ b/src/test-kernel/latex/TexTools.vitest.ts
@@ -1,0 +1,111 @@
+// Standard library imports
+import * as path from 'node:path';
+
+// Third-party imports
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports - test support
+import { installPlatform } from '@test/support/setupPlatform';
+
+// Local imports - latex
+import { compileLatex2Pdf } from '@latex/texTools';
+
+// Local imports - shared
+import type { ExecResult } from '@shared/schemas/opResults';
+
+// Local imports - file utilities
+import { flexibleFS, pathToLocation } from '@utils/files';
+
+const mocks = vi.hoisted(() => ({
+  runToolWithCheck: vi.fn(),
+}));
+
+vi.mock('@utils/system', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@utils/system')>();
+  return { ...actual, runToolWithCheck: mocks.runToolWithCheck };
+});
+
+const workspacePath = '/workspace';
+
+function execResult(success: boolean): ExecResult {
+  return { success, stdout: '', stderr: '', exitCode: success ? 0 : 1 };
+}
+
+// Issue #7079: compileLatex2Pdf used to return a bare boolean, so every
+// caller besides compileCheck.readLogTail swallowed the compile log on
+// failure. These tests exercise the real production code (only the
+// subprocess call is mocked) to prove the { ok, logTail } shape and the
+// 200-line raw-tail extraction it now owns.
+describe('compileLatex2Pdf structured return', () => {
+  beforeEach(async () => {
+    mocks.runToolWithCheck.mockReset();
+    await installPlatform({ workspacePath });
+  });
+
+  it('returns { ok: true } with no logTail on a successful compile', async () => {
+    mocks.runToolWithCheck.mockResolvedValue(execResult(true));
+
+    const result = await compileLatex2Pdf(
+      pathToLocation(path.join(workspacePath, 'main.tex')),
+      { outputDirectory: path.join(workspacePath, 'build') },
+    );
+
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('surfaces the last 200 lines of the engine log as logTail on a failed compile', async () => {
+    mocks.runToolWithCheck.mockResolvedValue(execResult(false));
+
+    const outputDirectory = path.join(workspacePath, 'build');
+    // Zero-padded so containment checks below can't be fooled by numeric
+    // substrings (e.g. "L0001" would otherwise match inside "L00010").
+    const totalLines = 250;
+    const lines = Array.from(
+      { length: totalLines },
+      (_, i) => `L${String(i + 1).padStart(4, '0')}`,
+    );
+    await flexibleFS.ensureDir(pathToLocation(outputDirectory));
+    await flexibleFS.write(
+      pathToLocation(path.join(outputDirectory, 'main.log')),
+      lines.join('\n'),
+    );
+
+    const result = await compileLatex2Pdf(
+      pathToLocation(path.join(workspacePath, 'main.tex')),
+      { outputDirectory },
+    );
+
+    expect(result.ok).toBe(false);
+    // Last 200 of 250 lines survive: L0051 .. L0250.
+    expect(result.logTail).toContain('L0051');
+    expect(result.logTail).toContain('L0250');
+    expect(result.logTail).not.toContain('L0050');
+    expect(result.logTail).not.toContain('L0001');
+  });
+
+  it('falls back to a discoverable placeholder when no engine log exists on disk', async () => {
+    mocks.runToolWithCheck.mockResolvedValue(execResult(false));
+
+    const result = await compileLatex2Pdf(
+      pathToLocation(path.join(workspacePath, 'missing.tex')),
+      { outputDirectory: path.join(workspacePath, 'build-missing') },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.logTail).toContain('no LaTeX log at');
+  });
+
+  it('surfaces the exception message as logTail when the compiler invocation throws', async () => {
+    mocks.runToolWithCheck.mockRejectedValue(
+      new Error('boom: pdflatex crashed'),
+    );
+
+    const result = await compileLatex2Pdf(
+      pathToLocation(path.join(workspacePath, 'main.tex')),
+      { outputDirectory: path.join(workspacePath, 'build') },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.logTail).toContain('boom: pdflatex crashed');
+  });
+});

--- a/src/test-kernel/latex/TexTools.vitest.ts
+++ b/src/test-kernel/latex/TexTools.vitest.ts
@@ -83,6 +83,31 @@ describe('compileLatex2Pdf structured return', () => {
     expect(result.logTail).not.toContain('L0001');
   });
 
+  it.each(['.ltx', '.latex'])(
+    'finds the engine log for a %s source, not just .tex',
+    async (ext) => {
+      mocks.runToolWithCheck.mockResolvedValue(execResult(false));
+
+      const outputDirectory = path.join(workspacePath, `build${ext}`);
+      await flexibleFS.ensureDir(pathToLocation(outputDirectory));
+      // The engine always names the log after the source with ITS OWN
+      // extension stripped, regardless of which LaTeX extension was used.
+      await flexibleFS.write(
+        pathToLocation(path.join(outputDirectory, 'main.log')),
+        'engine log content',
+      );
+
+      const result = await compileLatex2Pdf(
+        pathToLocation(path.join(workspacePath, `main${ext}`)),
+        { outputDirectory },
+      );
+
+      if (result.ok) throw new Error('expected a failed compile');
+      expect(result.logTail).toContain('engine log content');
+      expect(result.logTail).not.toContain('no LaTeX log at');
+    },
+  );
+
   it('falls back to a discoverable placeholder when no engine log exists on disk', async () => {
     mocks.runToolWithCheck.mockResolvedValue(execResult(false));
 


### PR DESCRIPTION
Closes #7079

`compileLatex2Pdf` previously returned a bare boolean, so the 200-line raw log-tail extraction only existed in `compileCheck`'s own `readLogTail` helper. Every other compile path (latexdiff, TikZ extraction, media compilation, chat export, the desktop preview host, and the extension's internal LaTeX-Workshop fallback) got nothing to act on when a compile failed -- just `false`.

## What changed

- `compileLatex2Pdf` (`src/latex/texTools.ts`) now returns `{ ok: boolean; logTail?: string }`. The tail-read (still the same last-200-lines raw excerpt, no TeX-log parsing) moved into texTools as `readCompileLogTail`, shared by both the success/failure return path and the catch block (where the tail is prefixed with the actual exception message).
- `compileCheck.ts` sources its per-round failure excerpt from that shared return instead of re-reading the log off disk a second time; its own behavior (per-round excerpt persistence, character-limit truncation) is unchanged.
- Every other caller now surfaces the tail on failure:
  - `LatexDiffManager` and `LatexMediaManager` log it via their injected `AgentTrace` logger.
  - `TikzPictureManager` and the VS Code LaTeX-Workshop-fallback path (`openBuild.ts`) log it via the module logger.
  - `ChatExportController.exportAsLatex` threads `logTail` through `LatexExportResult`; the settings-view handler logs it before falling back to opening the `.tex` source.
  - The desktop preview host (`desktopPreviewHost.ts`) appends it to the thrown build-failure error.

No `compile_tex` tool added -- explicitly out of scope per the issue, previously ruled out in the auto-compile-pdf PRD and issue #5664.

## Testing

- `npx tsc --noEmit` (root + `tsconfig.test-kernel.json`), `pnpm --filter texra typecheck`, and `pnpm --filter @texra/desktop typecheck` all pass.
- `npx eslint` on all changed files: clean.
- Added `src/test-kernel/latex/TexTools.vitest.ts`, a new regression suite exercising the real `compileLatex2Pdf` (only the subprocess call is mocked) covering: success returns `{ ok: true }` with no tail, a failed compile returns the last 200 lines of the engine log, a missing log file falls back to a discoverable placeholder, and a thrown exception surfaces its message in `logTail`.
- Updated `CompileCheck.vitest.ts`, `LatexCompileInputDirs.vitest.ts`, and `LatexProcessingHelpers.vitest.ts` mocks to the new `{ ok, logTail }` shape; `npx vitest run src/test-kernel/latex src/test-kernel/agent/output` -- 25 files, 176 tests, all passing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad API change across many LaTeX compile call sites, but behavior on success is unchanged and failures only gain diagnostics; regression risk is mainly missed callers or altered failure UX.
> 
> **Overview**
> **`compileLatex2Pdf`** no longer returns a bare boolean. It now returns `{ ok: true }` or `{ ok: false, logTail }`, with **`logTail`** always set on failure as the last **200 lines** of the engine `.log` (or a placeholder / exception prefix). That tail logic lives in **`readCompileLogTail`** inside `texTools.ts`, replacing the duplicate helper that only **`compileCheck`** used before.
> 
> **`compileCheck`** uses the shared **`logTail`** for persisted failure excerpts instead of reading the log from disk again. Other compile paths now expose failures instead of silently dropping them: workflow **latexdiff** and **media** PDF builds, **TikZ** standalone compiles, **chat export** LaTeX (optional **`logTail`** on **`LatexExportResult`** plus settings-view logging), the extension’s **internal LaTeX Workshop fallback**, and the **desktop** preview host (short user dialog, full tail on **`console.error`**).
> 
> Tests add **`TexTools.vitest.ts`** for the structured return and tail extraction; existing mocks and **`CompileCheck`** coverage are updated for the new shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 873630d53bf2d6ecec9ef392307f737a235799fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->