### PR TITLE
Add createFlushableDebounce helper, migrate 4 hand-rolled debounce sites

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -20,6 +20,7 @@ import {
   hasIncompleteEmbeddedSubagentFollowup,
   summarizeFollowupMessage,
 } from '@shared/subagentFollowup';
+import { createFlushableDebounce } from '@utils/core';
 import { normalizeKnownHtmlForCliMarkdown } from '../render/htmlMarkdownNormalize';
 import {
   isRenderableTranscriptEntry,
@@ -337,26 +338,32 @@ function sortTranscriptCandidatesIfNeeded(
 export function subscribeStreamLog(): () => void {
   const store = getDefaultStreamLogStore();
   const pendingStreams = new Set<StreamTabId>();
-  let timer: ReturnType<typeof setTimeout> | undefined;
 
   // One trailing timer shared by every stream: during a multi-subagent burst
   // the root and each child emit within the same window, and per-stream
   // timers would fire staggered — one sync→render pass per stream. A shared
-  // flush coalesces them into a single pass; syncStreamLog reads the full
-  // log at flush time, so batching loses nothing.
+  // batch window coalesces them into a single pass; syncStreamLog reads the
+  // full log when it fires, so batching loses nothing.
+  const syncDebounce = createFlushableDebounce(() => {
+    const streamIds = [...pendingStreams];
+    pendingStreams.clear();
+    for (const id of streamIds) syncStreamLog(id);
+  }, STREAM_SYNC_THROTTLE_MS);
+
   const dispose = store.onChange((streamId) => {
     pendingStreams.add(streamId);
-    timer ??= setTimeout(() => {
-      timer = undefined;
-      const streamIds = [...pendingStreams];
-      pendingStreams.clear();
-      for (const id of streamIds) syncStreamLog(id);
-    }, STREAM_SYNC_THROTTLE_MS);
+    // Only start the window on its first tick — later ticks in the same
+    // window join the batch without resetting the countdown (`pending`
+    // guard), unlike a classic debounce that would restart on every call.
+    if (!syncDebounce.pending) syncDebounce.schedule();
   });
 
   return () => {
     dispose();
-    if (timer !== undefined) clearTimeout(timer);
+    // Cancel, not flush: the caller is tearing down (process exit or
+    // unmount), so a final render of whatever was still pending isn't
+    // needed and would race an already-torn-down UI.
+    syncDebounce.cancel();
     pendingStreams.clear();
   };
 }

--- a/packages/desktop/src/main/desktopStreamSnapshot.ts
+++ b/packages/desktop/src/main/desktopStreamSnapshot.ts
@@ -31,6 +31,7 @@ import {
   type StreamPhase,
   type StreamTabId,
 } from '@shared/schemas';
+import { createFlushableDebounce } from '@utils/core';
 
 const STREAMS_KEY = 'restoredStreams';
 export const DESKTOP_STREAM_SNAPSHOT_WRITE_DEBOUNCE_MS = 100;
@@ -86,7 +87,6 @@ export async function openDesktopStreamSnapshotStore(
   const live = new Map<StreamTabId, RestoredStreamSnapshot>(
     parseHydrated(raw, log).map((s) => [s.streamId, s]),
   );
-  let pendingDebounce: ReturnType<typeof setTimeout> | undefined;
   let pendingUpsertWaiters: Array<{
     resolve(): void;
     reject(error: unknown): void;
@@ -122,11 +122,19 @@ export async function openDesktopStreamSnapshotStore(
     return write;
   }
 
+  // The debounce batches successive `upsert()` writes; `persistPendingUpserts`
+  // (used both when it fires and on immediate/flush paths) is the actual work,
+  // so this site only needs the timer's schedule/cancel/pending primitives —
+  // its own `flush()` isn't used since the awaited write chain below is what
+  // callers actually need to observe completion.
+  const writeDebounce = createFlushableDebounce(() => {
+    void persistPendingUpserts().catch(() => {
+      // Individual upsert promises receive the rejection through their waiters.
+    });
+  }, DESKTOP_STREAM_SNAPSHOT_WRITE_DEBOUNCE_MS);
+
   function clearPendingDebounce(): typeof pendingUpsertWaiters {
-    if (pendingDebounce) {
-      clearTimeout(pendingDebounce);
-      pendingDebounce = undefined;
-    }
+    writeDebounce.cancel();
     const waiters = pendingUpsertWaiters;
     pendingUpsertWaiters = [];
     return waiters;
@@ -141,13 +149,7 @@ export async function openDesktopStreamSnapshotStore(
     const promise = new Promise<void>((resolve, reject) => {
       pendingUpsertWaiters.push({ resolve, reject });
     });
-    if (pendingDebounce) clearTimeout(pendingDebounce);
-    pendingDebounce = setTimeout(() => {
-      pendingDebounce = undefined;
-      void persistPendingUpserts().catch(() => {
-        // Individual upsert promises receive the rejection through their waiters.
-      });
-    }, DESKTOP_STREAM_SNAPSHOT_WRITE_DEBOUNCE_MS);
+    writeDebounce.schedule();
     return promise;
   }
 
@@ -161,7 +163,7 @@ export async function openDesktopStreamSnapshotStore(
       const generationBeforeFlush = writeGeneration;
       await persistPendingUpserts();
       if (
-        pendingDebounce === undefined &&
+        !writeDebounce.pending &&
         pendingUpsertWaiters.length === 0 &&
         writeGeneration === generationBeforeFlush
       ) {

--- a/packages/extension/src/frontend/review/agentReviewCommitWatcher.ts
+++ b/packages/extension/src/frontend/review/agentReviewCommitWatcher.ts
@@ -17,6 +17,7 @@ import * as vscode from 'vscode';
 // Local imports
 import { getGitAPI, type GitRepository } from '@frontend/git/gitExtensionTypes';
 import * as logger from '@logger/logUtils';
+import { createFlushableDebounce } from '@utils/core';
 import { WorkspaceFS } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { getConfig } from '@utils/config/configUtils';
@@ -49,9 +50,32 @@ function watchRepository(
 
   let lastName = repository.state.HEAD?.name;
   let lastCommit = repository.state.HEAD?.commit;
-  let debounce: NodeJS.Timeout | undefined;
   /** Oldest un-reviewed base while commits coalesce in the debounce window. */
   let pendingBaseRef: string | undefined;
+  /** Branch name at the moment the pending review was (re)scheduled. */
+  let pendingBranchName: string | undefined;
+
+  // Fixed callback: reads the mutable pending* state above at fire time
+  // rather than threading per-call args through the timer, so `schedule()`
+  // rescheduling from a later commit picks up the latest branch name.
+  const reviewDebounce = createFlushableDebounce(() => {
+    const baseRef = pendingBaseRef;
+    const name = pendingBranchName;
+    pendingBaseRef = undefined;
+    pendingBranchName = undefined;
+    if (!baseRef) return;
+    // Re-check at fire time: the user may have disabled run-on-commit
+    // during the debounce window, and a review costs a model session.
+    if (!getConfig<boolean>('agentReview.runOnCommit', false)) return;
+    logger.info(
+      CHANNEL,
+      `Commit detected on ${name ?? 'HEAD'}; starting agent review`,
+    );
+    void AgentReviewService.runReview('commit', {
+      baseRef,
+      baseDescription: `previous commit on ${name ?? 'HEAD'}`,
+    });
+  }, COMMIT_DEBOUNCE_MS);
 
   const subscription = repository.state.onDidChange(() => {
     const head = repository.state.HEAD;
@@ -64,9 +88,9 @@ function watchRepository(
       // checkout also invalidates the reviewed change set, so stale results
       // are cleared — except on the initial state population (lastName
       // undefined), which is not a user checkout.
-      if (debounce) clearTimeout(debounce);
-      debounce = undefined;
+      reviewDebounce.cancel();
       pendingBaseRef = undefined;
+      pendingBranchName = undefined;
       if (lastName !== undefined) {
         AgentReviewService.clear();
       }
@@ -88,35 +112,24 @@ function watchRepository(
     if (!hadCommit) return;
     if (!getConfig<boolean>('agentReview.runOnCommit', false)) return;
 
-    if (debounce) clearTimeout(debounce);
     // Rapid commits (amend, rebase replays) coalesce into one review; keep
     // the OLDEST pending base so the combined run still covers every commit
     // since the last completed review.
     pendingBaseRef ??= previousCommit;
-    const baseRef = pendingBaseRef;
-    if (!baseRef) return;
-    debounce = setTimeout(() => {
-      debounce = undefined;
-      pendingBaseRef = undefined;
-      // Re-check at fire time: the user may have disabled run-on-commit
-      // during the debounce window, and a review costs a model session.
-      if (!getConfig<boolean>('agentReview.runOnCommit', false)) return;
-      logger.info(
-        CHANNEL,
-        `Commit detected on ${name ?? 'HEAD'}; starting agent review`,
-      );
-      void AgentReviewService.runReview('commit', {
-        baseRef,
-        baseDescription: `previous commit on ${name ?? 'HEAD'}`,
-      });
-    }, COMMIT_DEBOUNCE_MS);
+    if (!pendingBaseRef) return;
+    pendingBranchName = name;
+    reviewDebounce.schedule();
   });
 
   context.subscriptions.push({
     dispose: () => {
       subscription.dispose();
-      if (debounce) clearTimeout(debounce);
+      // Intentionally cancel (not flush): a review still pending at dispose
+      // (extension deactivation, workspace close) must not kick off a fresh
+      // model session during teardown.
+      reviewDebounce.cancel();
       pendingBaseRef = undefined;
+      pendingBranchName = undefined;
       watchedRoots.delete(repoRoot);
     },
   });

--- a/packages/extension/src/webview/frontend/persistence.ts
+++ b/packages/extension/src/webview/frontend/persistence.ts
@@ -23,6 +23,7 @@ import {
 } from '@shared/schemas';
 import type { MultiFiles } from '@shared/schemas';
 import type { StateRestoreMessage } from '@shared/schemas/commonViewMessages';
+import { createFlushableDebounce } from '@utils/core';
 
 // Local imports - main view
 import { MULTIPLE_DOCUMENT_FILE_TYPES, SESSION_TYPES } from './constants';
@@ -60,7 +61,6 @@ const stateManager = new PersistedState(
  * exactly one storage write per backend restore.
  */
 let saveBlockCount = 0;
-let instructionSaveTimer: number | null = null;
 
 function blockSave(): void {
   saveBlockCount += 1;
@@ -254,24 +254,22 @@ function clearForNewSession(): void {
   saveState();
 }
 
+const INSTRUCTION_SAVE_DEBOUNCE_MS = 300;
+
+/** Debounces `saveState()` calls triggered by instruction keystrokes. */
+const instructionSaveDebounce = createFlushableDebounce(
+  saveState,
+  INSTRUCTION_SAVE_DEBOUNCE_MS,
+);
+
 /** Debounce instruction keystrokes so each one doesn't hit storage. */
 export function scheduleInstructionSave(): void {
-  if (instructionSaveTimer) {
-    window.clearTimeout(instructionSaveTimer);
-  }
-  instructionSaveTimer = window.setTimeout(() => {
-    saveState();
-    instructionSaveTimer = null;
-  }, 300);
+  instructionSaveDebounce.schedule();
 }
 
 /** Flush a pending debounced instruction save (on disconnect). */
 export function flushPendingInstructionSave(): void {
-  if (instructionSaveTimer) {
-    window.clearTimeout(instructionSaveTimer);
-    instructionSaveTimer = null;
-    saveState();
-  }
+  instructionSaveDebounce.flush();
 }
 
 /**
@@ -282,9 +280,6 @@ export function flushPendingInstructionSave(): void {
  */
 export function resetPersistenceRuntime(): void {
   saveBlockCount = 0;
-  if (instructionSaveTimer) {
-    window.clearTimeout(instructionSaveTimer);
-    instructionSaveTimer = null;
-  }
+  instructionSaveDebounce.cancel();
   stateManager.reload();
 }

--- a/src/test-kernel/cli/SubscribeStreamLogDispose.vitest.mts
+++ b/src/test-kernel/cli/SubscribeStreamLogDispose.vitest.mts
@@ -1,0 +1,115 @@
+// Regression coverage for subscribeStreamLog's shared createFlushableDebounce
+// migration: the "only start the batch window on its first tick" coalescing
+// behavior, and dispose() cancelling (not flushing) a still-pending batch.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  getDefaultStreamLogStore,
+  setDefaultStreamLogStore,
+  StreamLogStore,
+} from '@transcript';
+import { subscribeStreamLog } from '@cli/chat/tui/state/subscribeStreamLog';
+import { streams } from '@cli/chat/tui/state/cliState/streamsSlice';
+import { resetCliState } from '@cli/chat/tui/state/cliState/reset';
+import {
+  LOG_LEVELS,
+  MESSAGE_TYPES,
+  STREAM_LOG_ENTRY_TYPES,
+  type StreamTabId,
+} from '@shared/schemas';
+
+const streamA = 'stream-a' as StreamTabId;
+const streamB = 'stream-b' as StreamTabId;
+
+function appendUserMessage(
+  store: StreamLogStore,
+  streamId: StreamTabId,
+  id: string,
+  text: string,
+): void {
+  store.append(streamId, {
+    id,
+    type: STREAM_LOG_ENTRY_TYPES.LOG,
+    level: LOG_LEVELS.INFO,
+    timestamp: Date.now(),
+    messageType: MESSAGE_TYPES.USER_MESSAGE,
+    text,
+  });
+}
+
+describe('subscribeStreamLog batching and dispose', () => {
+  let previousStore: StreamLogStore;
+
+  beforeEach(() => {
+    previousStore = getDefaultStreamLogStore();
+    setDefaultStreamLogStore(new StreamLogStore());
+    resetCliState();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    setDefaultStreamLogStore(previousStore);
+  });
+
+  it('coalesces multiple store changes within the batch window into a single sync pass', () => {
+    const dispose = subscribeStreamLog();
+    const store = getDefaultStreamLogStore();
+
+    appendUserMessage(store, streamA, 'a-1', 'hello');
+    // A second change arriving inside the window must NOT restart the timer:
+    // if it did, the deadline would move to 5+16=21ms and the assertion
+    // below (at the *original* 16ms deadline) would see nothing synced yet.
+    vi.advanceTimersByTime(5);
+    appendUserMessage(store, streamB, 'b-1', 'world');
+    vi.advanceTimersByTime(11);
+
+    expect(
+      streams
+        .get()
+        .get(streamA)
+        ?.entries.map((e) => e.text),
+    ).toEqual(['hello']);
+    expect(
+      streams
+        .get()
+        .get(streamB)
+        ?.entries.map((e) => e.text),
+    ).toEqual(['world']);
+
+    dispose();
+  });
+
+  it('dispose cancels a pending batch instead of flushing it', () => {
+    const dispose = subscribeStreamLog();
+    const store = getDefaultStreamLogStore();
+
+    appendUserMessage(store, streamA, 'a-1', 'hello');
+    // Dispose before the batch window elapses: the pending sync must be
+    // dropped, not run early — the entry never reaches the transcript slice.
+    dispose();
+    vi.advanceTimersByTime(1000);
+
+    expect(streams.get().get(streamA)).toBeUndefined();
+  });
+
+  it('a later subscribeStreamLog call still batches normally after a prior dispose', () => {
+    const firstDispose = subscribeStreamLog();
+    firstDispose();
+
+    const secondDispose = subscribeStreamLog();
+    const store = getDefaultStreamLogStore();
+    appendUserMessage(store, streamA, 'a-1', 'hello again');
+    vi.advanceTimersByTime(16);
+
+    expect(
+      streams
+        .get()
+        .get(streamA)
+        ?.entries.map((e) => e.text),
+    ).toEqual(['hello again']);
+
+    secondDispose();
+  });
+});

--- a/src/test-kernel/utils/Async.vitest.ts
+++ b/src/test-kernel/utils/Async.vitest.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { delay } from '@utils/core/async';
+import { createFlushableDebounce, delay } from '@utils/core/async';
 
 describe('async utilities', () => {
   it('resolves after the requested delay', async () => {
@@ -24,5 +24,113 @@ describe('async utilities', () => {
     controller.abort();
 
     await expect(promise).rejects.toMatchObject({ name: 'AbortError' });
+  });
+});
+
+describe('createFlushableDebounce', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('invokes the callback once after the wait elapses', () => {
+    const callback = vi.fn();
+    const batcher = createFlushableDebounce(callback, 100);
+
+    batcher.schedule();
+    expect(callback).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(99);
+    expect(callback).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(callback).toHaveBeenCalledOnce();
+    expect(batcher.pending).toBe(false);
+  });
+
+  it('restarts the timer on every schedule() call, like a classic trailing debounce', () => {
+    const callback = vi.fn();
+    const batcher = createFlushableDebounce(callback, 100);
+
+    batcher.schedule();
+    vi.advanceTimersByTime(60);
+    batcher.schedule(); // resets the 100ms window
+    vi.advanceTimersByTime(60);
+    expect(callback).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(40);
+    expect(callback).toHaveBeenCalledOnce();
+  });
+
+  it('flush() runs the callback synchronously and clears the pending timer', () => {
+    const callback = vi.fn();
+    const batcher = createFlushableDebounce(callback, 100);
+
+    batcher.schedule();
+    batcher.flush();
+
+    expect(callback).toHaveBeenCalledOnce();
+    expect(batcher.pending).toBe(false);
+
+    // The timer was cleared by flush(), so letting it "expire" must not
+    // invoke the callback a second time.
+    vi.advanceTimersByTime(100);
+    expect(callback).toHaveBeenCalledOnce();
+  });
+
+  it('flush() is a no-op when nothing is pending', () => {
+    const callback = vi.fn();
+    const batcher = createFlushableDebounce(callback, 100);
+
+    batcher.flush();
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('cancel() drops the pending call without invoking the callback', () => {
+    const callback = vi.fn();
+    const batcher = createFlushableDebounce(callback, 100);
+
+    batcher.schedule();
+    batcher.cancel();
+    expect(batcher.pending).toBe(false);
+
+    vi.advanceTimersByTime(1000);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('cancel() is a no-op when nothing is pending', () => {
+    const callback = vi.fn();
+    const batcher = createFlushableDebounce(callback, 100);
+
+    expect(() => batcher.cancel()).not.toThrow();
+    expect(batcher.pending).toBe(false);
+  });
+
+  it('pending reflects schedule/fire/flush/cancel transitions', () => {
+    const batcher = createFlushableDebounce(vi.fn(), 50);
+
+    expect(batcher.pending).toBe(false);
+    batcher.schedule();
+    expect(batcher.pending).toBe(true);
+    vi.advanceTimersByTime(50);
+    expect(batcher.pending).toBe(false);
+
+    batcher.schedule();
+    batcher.cancel();
+    expect(batcher.pending).toBe(false);
+  });
+
+  it('schedule() after flush() starts a fresh window (flush fully resets state)', () => {
+    const callback = vi.fn();
+    const batcher = createFlushableDebounce(callback, 100);
+
+    batcher.schedule();
+    batcher.flush();
+    expect(callback).toHaveBeenCalledOnce();
+
+    batcher.schedule();
+    vi.advanceTimersByTime(100);
+    expect(callback).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/test-kernel/webview/MainAppPersistenceRestore.vitest.mts
+++ b/src/test-kernel/webview/MainAppPersistenceRestore.vitest.mts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - shared constants and types
 import { COMMON_COMMANDS, MAIN_VIEW_COMMANDS } from '@shared/ipc';
@@ -153,6 +153,18 @@ function restoreState(
 
 describe('MainApp persistence and restore characterization', () => {
   useLitComponentTestDom(() => import('@webview/frontend/MainApp'));
+
+  // Dynamically re-imported (module-cache hit) AFTER useLitComponentTestDom's
+  // beforeAll has installed the DOM globals and imported MainApp — a static
+  // top-level import here would evaluate persistence.ts's `webviewStorage`
+  // singleton before the HOST_BRIDGE_API_KEY mock above is wired up.
+  let persistence: typeof import('@webview/frontend/persistence');
+  let setInstruction: typeof import('@webview/frontend/mainViewActions').setInstruction;
+
+  beforeAll(async () => {
+    persistence = await import('@webview/frontend/persistence');
+    ({ setInstruction } = await import('@webview/frontend/mainViewActions'));
+  });
 
   beforeEach(() => {
     seedWebviewState();
@@ -430,5 +442,82 @@ describe('MainApp persistence and restore characterization', () => {
     const { fileState, session } = contextsOf(element);
     expect(session.instruction).toBe('');
     expect(fileState.multiFiles.mediaFiles).toEqual(['kept-figure.png']);
+  });
+
+  describe('instruction-save debounce (createFlushableDebounce migration)', () => {
+    it('coalesces rapid instruction keystrokes into a single storage write after 300ms', async () => {
+      const element = await mountMainApp();
+      storageWrites.length = 0;
+
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+      try {
+        setInstruction('h');
+        persistence.scheduleInstructionSave();
+        vi.advanceTimersByTime(200);
+        // A second keystroke inside the window restarts the 300ms wait — a
+        // naive one-shot timer (or a non-restarting batcher) would let the
+        // first write land at the 300ms mark below instead of waiting for
+        // this call's own full window.
+        setInstruction('hello');
+        persistence.scheduleInstructionSave();
+        vi.advanceTimersByTime(299);
+        expect(storageWrites).toHaveLength(0);
+
+        vi.advanceTimersByTime(1);
+        expect(storageWrites).toHaveLength(1);
+        expect(lastPersistedBlob().instruction).toBe('hello');
+      } finally {
+        vi.useRealTimers();
+      }
+
+      element.remove();
+    });
+
+    it('flushPendingInstructionSave (called on disconnect) synchronously persists a pending debounced save', async () => {
+      const element = await mountMainApp();
+      storageWrites.length = 0;
+
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+      try {
+        setInstruction('unsaved when disconnected');
+        persistence.scheduleInstructionSave();
+        expect(storageWrites).toHaveLength(0);
+
+        // disconnectedCallback -> flushPendingInstructionSave(): the pending
+        // debounced save must run synchronously, not be dropped on teardown.
+        element.remove();
+        expect(storageWrites).toHaveLength(1);
+        expect(lastPersistedBlob().instruction).toBe(
+          'unsaved when disconnected',
+        );
+
+        // flush() must clear the timer — letting it "expire" afterward must
+        // not produce a second write.
+        vi.advanceTimersByTime(1000);
+        expect(storageWrites).toHaveLength(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('resetPersistenceRuntime cancels a pending debounced save instead of flushing it', async () => {
+      const element = await mountMainApp();
+      storageWrites.length = 0;
+
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+      try {
+        setInstruction('discarded by reset, not persisted');
+        persistence.scheduleInstructionSave();
+
+        persistence.resetPersistenceRuntime();
+
+        vi.advanceTimersByTime(1000);
+        expect(storageWrites).toHaveLength(0);
+      } finally {
+        vi.useRealTimers();
+      }
+
+      element.remove();
+    });
   });
 });

--- a/src/utils/core/async.ts
+++ b/src/utils/core/async.ts
@@ -3,3 +3,71 @@ export { debounce } from 'perfect-debounce';
 
 // AbortSignal-aware sleep shared by extension, CLI, and webview code.
 export { default as delay } from 'delay';
+
+/**
+ * A trailing-edge timer batcher with a synchronous flush escape hatch —
+ * perfect-debounce's `debounce()` only exposes `cancel()` (discard the
+ * pending call), with no way to force the trailing call to run early. Several
+ * hand-rolled `setTimeout`/`clearTimeout` sites need exactly that: run the
+ * pending work synchronously right now (typically just before teardown/
+ * dispose), instead of either waiting out the timer or dropping the work.
+ *
+ * `schedule()` always (re)starts the timer, matching a classic trailing
+ * debounce. A call site that instead wants "start once, coalesce further
+ * calls until it fires" (a throttle-style batching window) can guard with
+ * `pending`: `if (!batcher.pending) batcher.schedule();`.
+ *
+ * The callback is fixed at creation and takes no arguments — call sites that
+ * need per-invocation data close over their own mutable state (as the
+ * original hand-rolled versions already did) and read it when the callback
+ * fires, rather than threading arguments through the timer.
+ */
+export interface FlushableDebounce {
+  /** (Re)start the timer; invokes the callback after `waitMs` of inactivity. */
+  schedule(): void;
+  /**
+   * If a call is pending, invoke the callback synchronously right now and
+   * clear the timer. No-op when nothing is pending.
+   */
+  flush(): void;
+  /** Clear the pending timer without invoking the callback. No-op when nothing is pending. */
+  cancel(): void;
+  /** True while a call is scheduled and hasn't fired, flushed, or been cancelled yet. */
+  readonly pending: boolean;
+}
+
+export function createFlushableDebounce(
+  callback: () => void,
+  waitMs: number,
+): FlushableDebounce {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  function cancel(): void {
+    if (timer === undefined) return;
+    clearTimeout(timer);
+    timer = undefined;
+  }
+
+  function schedule(): void {
+    if (timer !== undefined) clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = undefined;
+      callback();
+    }, waitMs);
+  }
+
+  function flush(): void {
+    if (timer === undefined) return;
+    cancel();
+    callback();
+  }
+
+  return {
+    schedule,
+    flush,
+    cancel,
+    get pending() {
+      return timer !== undefined;
+    },
+  };
+}

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -26,7 +26,12 @@ export {
   unique,
   assertNever,
 } from './typeGuards';
-export { debounce, delay } from './async';
+export {
+  debounce,
+  delay,
+  createFlushableDebounce,
+  type FlushableDebounce,
+} from './async';
 export { byName, byString, toNewestFirstByTimestamp } from './comparators';
 export { clamp, clampIndex, clampOptional, roundTo } from './math';
 export { tryParseUrl } from './urlCore';


### PR DESCRIPTION
Closes #7283

## What changed

perfect-debounce's `debounce()` only exposes `cancel()` (discard the pending call) — there's no way to force the trailing call to run synchronously right now. Four call sites had each hand-rolled their own `setTimeout`/`clearTimeout` bookkeeping to get exactly that capability (flagged as a follow-up in #7270's consolidation audit).

Adds `createFlushableDebounce()` (`src/utils/core/async.ts`, re-exported from `@utils/core`) with `schedule()` / `flush()` / `cancel()` / `pending`, and migrates all four sites named in the issue:

- **`packages/extension/src/webview/frontend/persistence.ts`** — `flushPendingInstructionSave()` (called on webview disconnect) now calls `.flush()`; `resetPersistenceRuntime()` calls `.cancel()`, preserving the original no-save-on-reset behavior.
- **`packages/desktop/src/main/desktopStreamSnapshot.ts`** — the write-batching timer moves onto the shared helper (`schedule`/`cancel`/`pending`); the existing async `flush()`/`flushPendingWrites()` layering is unchanged since it has to await the write chain, not just fire the callback.
- **`packages/extension/src/frontend/review/agentReviewCommitWatcher.ts`** — the per-repo debounce becomes a single fixed callback that reads mutable `pendingBaseRef`/`pendingBranchName` state at fire time, instead of a fresh closure captured on every reschedule. Dispose still `.cancel()`s, not flushes — a review pending at extension deactivation/workspace close must not kick off a fresh model session during teardown.
- **`packages/cli/src/chat/tui/state/subscribeStreamLog.ts`** — the "start once, coalesce further changes until it fires" batching window (not a classic reset-per-call debounce) is preserved via the `pending` guard at the call site (`if (!syncDebounce.pending) syncDebounce.schedule();`). Dispose `.cancel()`s, matching the original drop-on-teardown behavior.

Each site keeps its own pre-existing flush-vs-cancel choice on dispose — the issue explicitly warned these differ per site, so this migration preserves rather than unifies them. Only `persistence.ts` actually exercises `.flush()`; the other three only needed `schedule()`/`cancel()`/`pending()`.

## Test coverage

- New generic unit tests for `createFlushableDebounce` (schedule/flush/cancel/pending transitions, restart-on-reschedule, flush-then-reschedule) in `src/test-kernel/utils/Async.vitest.ts`.
- New tests for `persistence.ts`'s debounce/flush/reset paths in `src/test-kernel/webview/MainAppPersistenceRestore.vitest.mts` — this file had zero coverage of `scheduleInstructionSave`/`flushPendingInstructionSave`/`resetPersistenceRuntime` before this PR.
- New `src/test-kernel/cli/SubscribeStreamLogDispose.vitest.mts` covering the batch-window coalescing behavior and cancel-on-dispose (previously untested).
- `desktopStreamSnapshot.ts`'s existing flush tests (`src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts`) already cover that site's write batching in depth and pass unchanged against the migrated implementation.
- `agentReviewCommitWatcher.ts` has no existing test infrastructure (no repo code exercises the VS Code git-extension API surface in tests today), and its dispose path doesn't flush (matches pre-existing behavior) — no new "flush-on-dispose" coverage was needed there since that behavior doesn't exist at that site; the refactor was verified by direct code-level equivalence review instead.

## Verification

- `npx tsc --noEmit` (root, test-kernel, `packages/desktop` main, `packages/cli`) — clean.
- `npx eslint` on all changed files — clean.
- Targeted vitest runs: all of `src/test-kernel/utils`, `src/test-kernel/webview`, `src/test-kernel/desktop`, `src/test-kernel/frontend`, `src/test-kernel/transcript`, and the full `src/test-kernel/cli` suite — all pass (635 + 1562 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor across TUI, webview, desktop, and extension timers; risk is mainly subtle timing/regression in debounce coalescing, mitigated by targeted tests.
> 
> **Overview**
> Introduces **`createFlushableDebounce`** in `@utils/core` (`schedule` / `flush` / `cancel` / `pending`) so call sites can run pending trailing work synchronously on teardown—something `perfect-debounce`’s `debounce()` doesn’t support.
> 
> **Four hand-rolled `setTimeout` implementations** are replaced while keeping each site’s existing semantics: webview **instruction saves** use classic trailing debounce with **flush on disconnect** and **cancel on `resetPersistenceRuntime`**; desktop **stream snapshot** upserts still batch writes and use **`pending`** in the flush loop; the git **commit review watcher** uses a fixed callback over mutable `pendingBaseRef` / `pendingBranchName` and **cancel on dispose**; CLI **`subscribeStreamLog`** keeps throttle-style coalescing via **`if (!pending) schedule()`** and **cancel on dispose**.
> 
> Adds unit tests for the helper, CLI subscribe/dispose batching, and webview debounce/flush/reset paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f1268e8893fc30d72cc4862eca78b1eae2f49b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->