### PR TITLE
fix(trace-viewer): make _IsExact catch added/removed optional fields

### DIFF
--- a/packages/trace-viewer/src/traceDataSchema.ts
+++ b/packages/trace-viewer/src/traceDataSchema.ts
@@ -93,13 +93,46 @@ export type TraceData = z.infer<typeof TraceDataSchema>;
  * `assembleTrace` produces — kept in sync with `TraceDocument` rather than a
  * hand-maintained duplicate, so a field added/renamed there surfaces here as
  * a type error instead of a silent validation gap.
+ *
+ * Uses the higher-order-function comparison form (as used by type-fest's
+ * `IsEqual`) rather than mutual `extends`: for object types, a plain mutual-
+ * `extends` check (`[A] extends [B] ? [B] extends [A] ? true : false : false`)
+ * treats `{a: string}` and `{a: string; b?: number}` as equal, because a
+ * value missing optional property `b` still satisfies both sides. Comparing
+ * the types as `G extends A` / `G extends B` conditional-type constructors
+ * instead is sensitive to that difference, so an added/removed optional
+ * field on either side of the mirror fails this check.
+ *
+ * Both sides are run through `_Simplify` first, recursively, for two reasons
+ * that are false-positive noise rather than real schema drift:
+ *  - `AgentConfig` and `ExecutionMeta` are derived via `.superRefine()` /
+ *    `.transform()` and end up as intersection types (e.g.
+ *    `Base & { outcome?: RunOutcome }`) rather than plain object types. The
+ *    HOF comparison treats an intersection and its structurally-identical
+ *    flattened object type as *different* conditional-type constructors.
+ *  - `TraceDocument` (an authored `interface`) declares its fields
+ *    `readonly`, while the corresponding zod-inferred types are mutable. The
+ *    HOF comparison is sensitive to that modifier even though it doesn't
+ *    reflect an actual shape difference for our purposes, so `_Simplify`
+ *    also strips `readonly` (`-readonly`) while preserving each key's
+ *    optional/required modifier — the thing we actually want it to catch.
+ * Arrays are passed through unsimplified (rather than mapped element-wise):
+ * recursing into their element type isn't needed for these three mirrors and
+ * empirically trips up the HOF check on unrelated, larger union element
+ * types (e.g. `StreamLogEntry`) without adding any real coverage here.
  */
 type _AssertTrue<T extends true> = T;
-type _IsExact<Source, Target> = [Source] extends [Target]
-  ? [Target] extends [Source]
+type _Simplify<T> = T extends readonly unknown[]
+  ? T
+  : T extends object
+    ? { -readonly [K in keyof T]: _Simplify<T[K]> }
+    : T;
+type _IsExact<A, B> =
+  (<G>() => G extends _Simplify<A> ? 1 : 2) extends <
+    G,
+  >() => G extends _Simplify<B> ? 1 : 2
     ? true
-    : false
-  : false;
+    : false;
 
 type _AssertTraceDataAcceptsTraceDocument = _AssertTrue<
   _IsExact<TraceDocument, TraceData>
@@ -109,6 +142,26 @@ type _AssertTraceAgentConfigAcceptsAgentConfig = _AssertTrue<
 >;
 type _AssertTraceExecutionMetaAcceptsExecutionMeta = _AssertTrue<
   _IsExact<ExecutionMeta, z.infer<typeof TraceExecutionMetaSchema>>
+>;
+
+/**
+ * Regression coverage for #7265: `_IsExact`'s previous mutual-`extends` form
+ * (`[A] extends [B] ? [B] extends [A] ? true : false : false`) considered
+ * `{a: string}` and `{a: string; b?: number}` equal in both directions — a
+ * value missing an optional property still structurally satisfies both
+ * sides — so it silently missed an added/removed optional field on either
+ * mirror. This checks the HOF form actually rejects both directions, and
+ * still accepts identical shapes (no false positive from the fix itself).
+ */
+type _AssertFalse<T extends false> = T;
+type _AssertCatchesAddedOptionalField = _AssertFalse<
+  _IsExact<{ a: string }, { a: string; b?: number }>
+>;
+type _AssertCatchesRemovedOptionalField = _AssertFalse<
+  _IsExact<{ a: string; b?: number }, { a: string }>
+>;
+type _AssertStillMatchesIdenticalOptionalShape = _AssertTrue<
+  _IsExact<{ a: string; b?: number }, { a: string; b?: number }>
 >;
 
 /**


### PR DESCRIPTION
Closes #7265

`_IsExact` in `packages/trace-viewer/src/traceDataSchema.ts` (from #7260) used a mutual-`extends` check to compare `AgentConfig`/`ExecutionMeta`/`TraceDocument` against their browser-safe schema mirrors. That technique treats `{a: string}` and `{a: string; b?: number}` as equal — a value missing an optional property still structurally satisfies both sides — so an optional field added to or removed from either side of a mirror would silently pass `tsc` instead of failing it, exactly the drift class #7251/#7260 were meant to catch.

Replaced it with the higher-order-function comparison form (`type-fest`'s `IsEqual` technique): comparing `A`/`B` as `<G>() => G extends A ? 1 : 2` conditional-type constructors instead of via mutual `extends`. That form is sensitive to added/removed optional fields.

Swapping it in verbatim as given regressed two of the three real assertions (`TraceDocument`/`TraceData` and `ExecutionMeta`) — not from real drift, but from two representation quirks the HOF form is sensitive to that mutual-`extends` wasn't:

- `AgentConfig` and `ExecutionMeta` are produced via `.superRefine()`/`.transform()` and come out as intersection types (e.g. `Base & { outcome?: RunOutcome }`) rather than plain object types.
- `TraceDocument`'s interface fields are declared `readonly`, while the corresponding zod-inferred mirrors are mutable.

`_IsExact` now runs both sides through a recursive `_Simplify` first (flattens intersections into a plain mapped type, strips `readonly` via `-readonly` while preserving each key's optional/required modifier, leaves array element types untouched since recursing into them isn't needed here and empirically trips up the HOF check on unrelated large union types like `StreamLogEntry`). This clears both false positives while still correctly failing `tsc` on a synthetic added optional field (verified manually against all three assertions, then reverted).

Added inline compile-time regression assertions (`_AssertCatchesAddedOptionalField`, `_AssertCatchesRemovedOptionalField`, `_AssertStillMatchesIdenticalOptionalShape`) that fail under the old mutual-`extends` form and pass under the new one, so a future regression back to mutual-`extends` fails `tsc`.

Left the file-private `_AssertTrue`/`_IsExact` pair in `src/tools/claudeAgentShared.ts` untouched — it's applied to a literal-string union, where the optional-field gap doesn't apply.

## Verification
- `pnpm --filter @texra/trace-viewer run typecheck` — clean
- `npm run typecheck` (full workspace) — clean
- `npx vitest run src/test-kernel/transcript/traceViewerSchema.vitest.ts` — 6/6 passing
- `eslint packages/trace-viewer/src/traceDataSchema.ts` — only a pre-existing `import/order` warning, unrelated to this change
- Manually confirmed a synthetic added optional field on `TraceAgentConfigSchema` fails `tsc` with the new `_IsExact`, and that the new regression assertions fail under the old mutual-`extends` form

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time-only changes in trace-viewer type assertions; no runtime or security impact.
> 
> **Overview**
> Fixes a gap in compile-time mirror checks between `TraceDocument` / agent types and `TraceDataSchema` in `traceDataSchema.ts`: **`_IsExact` no longer uses mutual `extends`**, which treated types with different optional keys as equal.
> 
> **`_IsExact`** now uses the higher-order conditional-type comparison (same idea as `type-fest` `IsEqual`), with both sides passed through **`_Simplify`** first to flatten Zod intersection outputs and strip `readonly` on `TraceDocument` fields so real drift still fails `tsc` without false positives on representation quirks.
> 
> Adds **`_AssertFalse` / `_AssertTrue` regression types** that prove added/removed optional properties are rejected and identical optional shapes still match, so reverting to mutual-`extends` breaks the build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c256e020b67447e4d8e19c23647f7308185c9cb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->