### PR TITLE
refactor: add cli host interactions port

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -62,7 +62,7 @@ import {
   publishChatTuiRootRunStartAvailability,
   type TuiSession,
 } from './tui/state/sessionRunState';
-import { installTuiApprovals } from './tui/state/subscribeApprovals';
+import { createTuiHostInteractions } from './tui/state/subscribeApprovals';
 import { wrapRuntimeHost } from './tui/state/subscribeRuntimeHost';
 import { notify } from './tui/notifications/terminalNotifier';
 import {
@@ -226,22 +226,32 @@ export function createChatSessionController(
   } => {
     const runtimeHost = createCliRuntimeHost(sessionContext);
     const wrapped = wrapRuntimeHost(runtimeHost, snapshotStore);
+    const detachHostInteractions = defaultSession().useHostInteractions(
+      createTuiHostInteractions(wrapped, sessionContext),
+    );
+    disposers.push(detachHostInteractions);
+    const interactiveHost: CliRuntimeHost = {
+      ...wrapped,
+      interactions: defaultSession().interactions,
+    };
     const detachResultToast = attachTerminalResultToast(
       defaultSession(),
-      wrapped,
+      interactiveHost,
     );
     const detachLegacyProgressProjection = attachLegacyProgressEventProjection(
       defaultSession().events,
-      wrapped,
+      interactiveHost,
     );
-    disposers.push(installTuiApprovals(wrapped, sessionContext));
     return {
-      wrapped,
+      wrapped: interactiveHost,
       approvalsUnavailable: approvalPromptsUnavailable(sessionContext),
       finalize: (): void => {
         detachResultToast();
         detachLegacyProgressProjection();
-        if (session.runtimeHost === wrapped) session.runtimeHost = undefined;
+        detachHostInteractions();
+        if (session.runtimeHost === interactiveHost) {
+          session.runtimeHost = undefined;
+        }
         markChatTuiRunCompleted(session);
         void runtimeHost.close();
       },

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -9,12 +9,22 @@
 // `never` auto-rejects with `denyMessage(...)`. Only `ask` (or interactive
 // non-print) reaches the queue.
 //
-// Tool-edit goes through the Platform approval port (installed per active CLI
-// session) because it returns a typed Promise<ToolEditApprovalResult>, not a
-// fire-and-forget event.
+// Tool-edit is part of this port because it returns a typed
+// Promise<ToolEditApprovalResult>, not a fire-and-forget event.
+
+import { nanoid } from 'nanoid';
 
 import { platform } from '@platform/platform';
 import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
+import type {
+  HostBashApprovalRequest,
+  HostBashApprovalResult,
+  HostInteractions,
+  HostRetryRequest,
+} from '@agent/runtime/HostInteractions';
+import type { PlanApprovalResult } from '@agent/runtime/PlanApprovalCoordinator';
+import type { ProposalResult } from '@agent/runtime/AgentProposalCoordinator';
+import type { RetryResult } from '@agent/runtime/RetryRequestCoordinator';
 import { setCliApiMode } from '@cli/runtime/apiAccessMode';
 import {
   approvalPromptAllowed,
@@ -31,7 +41,6 @@ import {
   isCliApprovalEvent,
   type CliApprovalEvent,
 } from '@cli/runtime/approvalEvents';
-import { setActiveCliToolEditApprovalHandler } from '@cli/runtime/initPlatform';
 import type { CliContext } from '@cli/runtime/cliContext';
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
@@ -122,59 +131,77 @@ async function maybeAutoSwitchRetry(
 }
 
 /**
- * Install the typed approval pipeline. Returns an `unbind` callback that
- * restores the original emit + clears the tool-edit handler.
+ * Create the typed approval pipeline for the active TUI session.
  */
-export function installTuiApprovals(
+export function createTuiHostInteractions(
   host: CliRuntimeHost,
   context: CliContext,
-): () => void {
-  const originalEmit = host.emit;
+): HostInteractions {
+  const retryRoutes = createRetryRouteState();
   const disposeApprovalClearListener = onApprovalsCleared(() => {
-    invalidateRetryRoutes({ cancel: true });
+    invalidateRetryRoutes(retryRoutes, { cancel: true });
   });
-  host.emit = ((event, payload) => {
-    // Approval events are intentionally NOT forwarded to originalEmit.
-    // The underlying `createCliRuntimeHost.emit` chains through
-    // `handleCliApprovalEvent`, which would re-handle the same approval
-    // via the legacy stderr prompt — racing the TUI modal for the same
-    // resolver. Non-approval events (status, usage, log) keep flowing
-    // through the original chain.
-    if (isCliApprovalEvent(event)) {
+
+  return {
+    async requestToolEditApproval(request) {
+      let decision: ApprovalDecision | undefined = immediateDecision(context);
+      if (!decision) {
+        decision = await enqueueTuiApproval(
+          { kind: 'toolEdit', request },
+          host,
+        );
+        markIfRejected(context, decision);
+      }
+      if (
+        decision.accepted &&
+        decision.bypass === 'toolEdit' &&
+        request.streamId
+      ) {
+        setToolEditApprovalSessionBypass(request.streamId, true, host);
+      }
+      return decision.accepted
+        ? { accepted: true, appliedContent: request.proposedContent }
+        : { accepted: false, userMessage: decision.userMessage };
+    },
+    requestBashApproval(request) {
+      return requestBashInteraction(request, context, host);
+    },
+    requestPlanApproval(request) {
+      return requestPlanInteraction(request, context, host);
+    },
+    requestAgentProposal(request) {
+      return requestProposalInteraction(request, context, host);
+    },
+    requestRetry(request) {
+      return requestRetryInteraction(request, context, host, retryRoutes);
+    },
+    askUserQuestion(request) {
+      return requestUserQuestionInteraction(request, context, host);
+    },
+    openExternalInquiry(request) {
+      return openExternalInquiryInteraction(request, context, host);
+    },
+    handleProgressEvent(event, payload) {
+      if (!isCliApprovalEvent(event)) return false;
       routeApproval(
         event,
         payload as ProgressEventPayloads[CliApprovalEvent],
         context,
         host,
+        retryRoutes,
       );
-      return;
-    }
-    originalEmit(event, payload);
-  }) as CliRuntimeHost['emit'];
-
-  setActiveCliToolEditApprovalHandler(async (request) => {
-    let decision: ApprovalDecision | undefined = immediateDecision(context);
-    if (!decision) {
-      decision = await enqueueTuiApproval({ kind: 'toolEdit', request }, host);
-      markIfRejected(context, decision);
-    }
-    if (
-      decision.accepted &&
-      decision.bypass === 'toolEdit' &&
-      request.streamId
-    ) {
-      setToolEditApprovalSessionBypass(request.streamId, true, host);
-    }
-    return decision.accepted
-      ? { accepted: true, appliedContent: request.proposedContent }
-      : { accepted: false, userMessage: decision.userMessage };
-  });
-
-  return () => {
-    invalidateRetryRoutes({ cancel: false });
-    disposeApprovalClearListener();
-    host.emit = originalEmit;
-    setActiveCliToolEditApprovalHandler(undefined);
+      return true;
+    },
+    pending: () => [],
+    resolve: () => false,
+    cancelForStream(streamId) {
+      cancelRetryRoute(retryRoutes, streamId);
+      clearRetryApprovalsForStream(streamId);
+    },
+    dispose() {
+      invalidateRetryRoutes(retryRoutes, { cancel: true });
+      disposeApprovalClearListener();
+    },
   };
 }
 
@@ -183,6 +210,7 @@ function routeApproval(
   payload: ProgressEventPayloads[CliApprovalEvent],
   context: CliContext,
   host: CliRuntimeHost,
+  retryRoutes: RetryRouteState,
 ): void {
   switch (event) {
     case 'showBashPermission':
@@ -226,6 +254,7 @@ function routeApproval(
         context,
         host,
         payload as ProgressEventPayloads['showRetryRequest'],
+        retryRoutes,
       );
       return;
     case 'showExternalInquiry':
@@ -254,14 +283,45 @@ function routeApproval(
  * Track the latest route per stream so a stale lookup cannot switch API mode
  * or trigger an older retry after a newer retry request replaced it.
  */
-const activeRetryRoutes = new Map<string, symbol>();
+interface ActiveRetryRoute {
+  readonly routeId: symbol;
+  readonly settle?: (result: RetryResult) => void;
+}
 
-function invalidateRetryRoutes(options: { cancel: boolean }): void {
-  const streamIds = [...activeRetryRoutes.keys()];
-  activeRetryRoutes.clear();
-  if (!options.cancel) return;
+interface RetryRouteState {
+  readonly activeRetryRoutes: Map<string, ActiveRetryRoute>;
+}
+
+function createRetryRouteState(): RetryRouteState {
+  return { activeRetryRoutes: new Map() };
+}
+
+function isActiveRetryRoute(
+  state: RetryRouteState,
+  streamId: string,
+  routeId: symbol,
+): boolean {
+  return state.activeRetryRoutes.get(streamId)?.routeId === routeId;
+}
+
+function cancelRetryRoute(state: RetryRouteState, streamId: string): void {
+  const route = state.activeRetryRoutes.get(streamId);
+  if (!route) return;
+  state.activeRetryRoutes.delete(streamId);
+  route.settle?.({ action: 'cancel' });
+}
+
+function invalidateRetryRoutes(
+  state: RetryRouteState,
+  options: { cancel: boolean },
+): void {
+  const streamIds = [...state.activeRetryRoutes.keys()];
   for (const streamId of streamIds) {
-    runCoordinatorBridge.cancelRetry(streamId);
+    if (options.cancel) {
+      cancelRetryRoute(state, streamId);
+    } else {
+      state.activeRetryRoutes.delete(streamId);
+    }
   }
 }
 
@@ -269,13 +329,15 @@ function routeRetry(
   context: CliContext,
   host: CliRuntimeHost,
   payload: ProgressEventPayloads['showRetryRequest'],
+  retryRoutes: RetryRouteState,
 ): void {
   const routeId = Symbol(payload.streamId);
-  activeRetryRoutes.set(payload.streamId, routeId);
+  retryRoutes.activeRetryRoutes.set(payload.streamId, { routeId });
   clearRetryApprovalsForStream(payload.streamId);
-  const isCurrent = () => activeRetryRoutes.get(payload.streamId) === routeId;
+  const isCurrent = () =>
+    isActiveRetryRoute(retryRoutes, payload.streamId, routeId);
   const finish = () => {
-    if (isCurrent()) activeRetryRoutes.delete(payload.streamId);
+    if (isCurrent()) retryRoutes.activeRetryRoutes.delete(payload.streamId);
   };
 
   routeWithPolicy(
@@ -364,6 +426,198 @@ function routeWithPolicy<K extends 'bash' | 'plan' | 'proposal' | 'retry', P>(
   })();
 }
 
+async function decideWithPolicy<
+  K extends 'bash' | 'plan' | 'proposal' | 'retry',
+  P,
+>(
+  context: CliContext,
+  host: CliRuntimeHost,
+  kind: K,
+  payload: P,
+  options: RouteWithPolicyOptions<P> = {},
+): Promise<ApprovalDecision> {
+  const policy =
+    kind === 'retry'
+      ? immediateDecisionForApproval(
+          'showRetryRequest',
+          payload as ProgressEventPayloads['showRetryRequest'],
+          context,
+        )
+      : immediateDecision(context);
+  if (policy) return policy;
+
+  let autoDecision: ApprovalDecision | undefined;
+  if (options.beforeQueue) {
+    try {
+      autoDecision = await options.beforeQueue(payload);
+    } catch {
+      autoDecision = undefined;
+    }
+    if (options.isCurrent && !options.isCurrent()) {
+      return { accepted: false, userMessage: 'Approval request was replaced.' };
+    }
+    if (autoDecision) return autoDecision;
+  }
+
+  try {
+    const queuePayload = { kind, payload } as Extract<
+      ApprovalPayload,
+      { kind: K }
+    >;
+    const decision = await enqueueTuiApproval(queuePayload, host);
+    if (options.isCurrent && !options.isCurrent()) {
+      return { accepted: false, userMessage: 'Approval request was replaced.' };
+    }
+    markIfRejected(context, decision);
+    return decision;
+  } catch {
+    const decision: ApprovalDecision = {
+      accepted: false,
+      userMessage: 'CLI approval prompt failed.',
+    };
+    markIfRejected(context, decision);
+    return decision;
+  }
+}
+
+async function requestBashInteraction(
+  request: HostBashApprovalRequest,
+  context: CliContext,
+  host: CliRuntimeHost,
+): Promise<HostBashApprovalResult> {
+  const payload: ProgressEventPayloads['showBashPermission'] = {
+    requestId: `bash-${nanoid()}`,
+    command: request.command,
+    ...(request.cwd ? { cwd: request.cwd } : {}),
+    allowBypass: true,
+    streamId: request.streamId ?? '',
+  };
+  const decision = await decideWithPolicy(context, host, 'bash', payload);
+  if (decision.accepted && decision.bypass === 'bash' && request.streamId) {
+    setBashApprovalSessionBypass(request.streamId, true, host);
+  }
+  return {
+    accepted: decision.accepted,
+    userMessage: feedbackOnReject(decision),
+  };
+}
+
+async function requestPlanInteraction(
+  request: ProgressEventPayloads['showPlanApproval'],
+  context: CliContext,
+  host: CliRuntimeHost,
+): Promise<PlanApprovalResult> {
+  const decision = await decideWithPolicy(context, host, 'plan', request);
+  const feedback = feedbackOnReject(decision);
+  return decision.accepted
+    ? { action: decision.planAction ?? 'approve' }
+    : { action: 'reject', ...(feedback ? { feedback } : {}) };
+}
+
+async function requestProposalInteraction(
+  request: ProgressEventPayloads['showAgentProposal'],
+  context: CliContext,
+  host: CliRuntimeHost,
+): Promise<ProposalResult> {
+  const decision = await decideWithPolicy(context, host, 'proposal', request);
+  const feedback = feedbackOnReject(decision);
+  return decision.accepted
+    ? { action: 'approve' }
+    : { action: 'reject', ...(feedback ? { feedback } : {}) };
+}
+
+async function requestRetryInteraction(
+  request: HostRetryRequest,
+  context: CliContext,
+  host: CliRuntimeHost,
+  retryRoutes: RetryRouteState,
+): Promise<RetryResult> {
+  cancelRetryRoute(retryRoutes, request.streamId);
+  const routeId = Symbol(request.streamId);
+  clearRetryApprovalsForStream(request.streamId);
+
+  return await new Promise<RetryResult>((resolve) => {
+    retryRoutes.activeRetryRoutes.set(request.streamId, {
+      routeId,
+      settle: resolve,
+    });
+    const isCurrent = () =>
+      isActiveRetryRoute(retryRoutes, request.streamId, routeId);
+    const finish = () => {
+      if (isCurrent()) retryRoutes.activeRetryRoutes.delete(request.streamId);
+    };
+
+    void (async () => {
+      const decision = await decideWithPolicy(context, host, 'retry', request, {
+        beforeQueue: maybeAutoSwitchRetry,
+        isCurrent,
+      });
+      if (!isCurrent()) return;
+      if (
+        decision.accepted &&
+        (decision.apiMode || decision.disableChatGptSubscription)
+      ) {
+        clearRetryApprovalsForStream(request.streamId);
+      }
+      if (!decision.accepted) {
+        resolve({ action: 'cancel' });
+        finish();
+        return;
+      }
+      try {
+        await applyRetrySideEffects(request, decision, { isCurrent });
+        if (!isCurrent()) return;
+        resolve({ action: 'retry', feedback: decision.userMessage });
+      } catch {
+        if (isCurrent()) resolve({ action: 'cancel' });
+      } finally {
+        finish();
+      }
+    })();
+  });
+}
+
+async function requestUserQuestionInteraction(
+  payload: ProgressEventPayloads['showUserQuestion'],
+  context: CliContext,
+  host: CliRuntimeHost,
+): Promise<{
+  submitted: boolean;
+  answers?: ApprovalDecision['userQuestionAnswers'];
+  feedback?: string;
+}> {
+  if (!approvalPromptAllowed(context)) {
+    return {
+      submitted: false,
+      feedback: humanInputDenialFeedback(
+        context,
+        'User question requires human input; yolo mode cannot synthesize an answer.',
+      ),
+    };
+  }
+
+  const decision = await enqueueTuiApproval(
+    { kind: 'userQuestion', payload },
+    host,
+  );
+  markIfRejected(context, decision);
+  return decision.accepted && decision.userQuestionAnswers
+    ? { submitted: true, answers: decision.userQuestionAnswers }
+    : {
+        submitted: false,
+        feedback: decision.userMessage || 'User question skipped by user.',
+      };
+}
+
+async function openExternalInquiryInteraction(
+  payload: ProgressEventPayloads['showExternalInquiry'],
+  context: CliContext,
+  host: CliRuntimeHost,
+): Promise<{ threadId: string }> {
+  handleExternalInquiry(payload, context, host);
+  return { threadId: payload.threadId };
+}
+
 export function enqueueTuiApproval(
   payload: ApprovalPayload,
   host: CliRuntimeHost,
@@ -440,6 +694,16 @@ async function applyRetryDecision(
   decision: ApprovalDecision,
   options: { isCurrent?: () => boolean } = {},
 ): Promise<void> {
+  await applyRetrySideEffects(payload, decision, options);
+  if (options.isCurrent?.() === false) return;
+  runCoordinatorBridge.triggerRetry(payload.streamId, decision.userMessage);
+}
+
+async function applyRetrySideEffects(
+  payload: Pick<ProgressEventPayloads['showRetryRequest'], 'streamId'>,
+  decision: ApprovalDecision,
+  options: { isCurrent?: () => boolean } = {},
+): Promise<void> {
   const isCurrent = () => options.isCurrent?.() ?? true;
   if (!isCurrent()) return;
   if (decision.apiMode) {
@@ -451,8 +715,6 @@ async function applyRetryDecision(
     await setCliCodexSubscription(false);
     if (!isCurrent()) return;
   }
-  if (!isCurrent()) return;
-  runCoordinatorBridge.triggerRetry(payload.streamId, decision.userMessage);
 }
 
 function handleExternalInquiry(

--- a/src/agent/runtime/AgentProposalCoordinator.ts
+++ b/src/agent/runtime/AgentProposalCoordinator.ts
@@ -53,6 +53,12 @@ export class AgentProposalCoordinator extends BasePromiseCoordinator<
     this.runtimeHost.emit('requestEnsureProgressView', {});
     this.runtimeHost.emit('setActiveStream', { streamId });
 
+    const interaction = this.runtimeHost.interactions?.requestAgentProposal?.(
+      { proposalId, streamId, ...proposal },
+      { timeoutMs },
+    );
+    if (interaction) return interaction;
+
     return this.waitForUserAction(
       proposalId,
       { proposalId, streamId, ...proposal },

--- a/src/agent/runtime/AgentRuntimeHost.ts
+++ b/src/agent/runtime/AgentRuntimeHost.ts
@@ -1,4 +1,5 @@
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import type { HostInteractions } from './HostInteractions';
 
 /**
  * The single progress sink the agent core emits through during a run. Hosts
@@ -26,6 +27,8 @@ import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
  * by tests and non-interactive paths.
  */
 export interface AgentRuntimeHost {
+  readonly interactions?: HostInteractions;
+
   emit<K extends keyof ProgressEventPayloads>(
     event: K,
     payload: ProgressEventPayloads[K],

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -1,0 +1,229 @@
+import type {
+  ProgressEvent,
+  ProgressEventPayloads,
+} from '@eventBus/ProgressEventBus';
+import type {
+  AgentProposal,
+  Plan,
+  ProviderErrorPartial,
+  StreamTabId,
+  UserQuestionAnswers,
+  ExternalInquiryPermission,
+  UserQuestionPermission,
+} from '@shared/schemas';
+import type {
+  ToolEditApprovalRequest,
+  ToolEditApprovalResult,
+} from '@platform/interfaces/toolEditApproval';
+import type { PlanApprovalResult } from './PlanApprovalCoordinator';
+import type { ProposalResult } from './AgentProposalCoordinator';
+import type { RetryResult } from './RetryRequestCoordinator';
+
+export interface HostInteractionOptions {
+  readonly timeoutMs?: number;
+}
+
+export interface HostPlanApprovalRequest {
+  readonly approvalId: string;
+  readonly streamId: StreamTabId;
+  readonly plan: Plan;
+  readonly goalEnabled: boolean;
+}
+
+export interface HostBashApprovalRequest {
+  readonly command: string;
+  readonly cwd?: string | null;
+  readonly streamId?: StreamTabId | null;
+}
+
+export interface HostBashApprovalResult {
+  readonly accepted: boolean;
+  readonly userMessage?: string;
+}
+
+export type HostAgentProposalRequest = AgentProposal & {
+  readonly proposalId: string;
+  readonly streamId: StreamTabId;
+};
+
+export interface HostRetryRequest {
+  readonly streamId: StreamTabId;
+  readonly operation: string;
+  readonly model?: string;
+  readonly errorMessage?: string;
+  readonly errorDetails?: ProviderErrorPartial;
+}
+
+export type HostUserQuestionRequest = UserQuestionPermission;
+
+export interface HostUserQuestionResult {
+  readonly submitted: boolean;
+  readonly answers?: UserQuestionAnswers;
+  readonly feedback?: string;
+}
+
+export type HostExternalInquiryRequest = ExternalInquiryPermission;
+
+export interface HostExternalInquiryHandle {
+  readonly threadId: string;
+}
+
+export interface PendingHostInteraction {
+  readonly id: string;
+  readonly kind: string;
+  readonly streamId?: StreamTabId;
+}
+
+export interface HostInteractionResolution {
+  readonly kind: string;
+  readonly action: string;
+  readonly feedback?: string;
+  readonly value?: unknown;
+}
+
+/**
+ * Session-owned host interaction surface.
+ *
+ * During the Stage 4 migration, hosts may still implement this port by handling
+ * the legacy progress-event request names internally. The important boundary is
+ * ownership: runtime code asks the session for an interaction, while host code
+ * owns display, replay, and first-wins resolution.
+ */
+export interface HostInteractions {
+  requestToolEditApproval?(
+    request: ToolEditApprovalRequest,
+    options?: HostInteractionOptions,
+  ): Promise<ToolEditApprovalResult> | undefined;
+  requestBashApproval?(
+    request: HostBashApprovalRequest,
+    options?: HostInteractionOptions,
+  ): Promise<HostBashApprovalResult> | undefined;
+  requestPlanApproval?(
+    request: HostPlanApprovalRequest,
+    options?: HostInteractionOptions,
+  ): Promise<PlanApprovalResult> | undefined;
+  requestAgentProposal?(
+    request: HostAgentProposalRequest,
+    options?: HostInteractionOptions,
+  ): Promise<ProposalResult> | undefined;
+  requestRetry?(
+    request: HostRetryRequest,
+    options?: HostInteractionOptions,
+  ): Promise<RetryResult> | undefined;
+  askUserQuestion?(
+    request: HostUserQuestionRequest,
+    options?: HostInteractionOptions,
+  ): Promise<HostUserQuestionResult> | undefined;
+  openExternalInquiry?(
+    request: HostExternalInquiryRequest,
+  ): Promise<HostExternalInquiryHandle> | undefined;
+  handleProgressEvent<K extends ProgressEvent>(
+    event: K,
+    payload: ProgressEventPayloads[K],
+  ): boolean;
+  pending(): readonly PendingHostInteraction[];
+  resolve(requestId: string, result: HostInteractionResolution): boolean;
+  cancelForStream(streamId: StreamTabId, cause?: string): void;
+  dispose?(): void;
+}
+
+const noopHostInteractions: HostInteractions = {
+  handleProgressEvent: () => false,
+  pending: () => [],
+  resolve: () => false,
+  cancelForStream: () => {},
+};
+
+/**
+ * Stable per-session slot. The `SessionHandle` exposes this object once, while
+ * each host installs the concrete implementation for the session lifetime it
+ * owns. Keeping the slot stable avoids passing a mutable host callback through
+ * every run-construction path during the staged migration.
+ */
+export class SessionHostInteractions implements HostInteractions {
+  private active: HostInteractions = noopHostInteractions;
+
+  use(interactions: HostInteractions): () => void {
+    const previous = this.active;
+    this.active = interactions;
+    let disposed = false;
+    return () => {
+      if (disposed) return;
+      disposed = true;
+      if (this.active === interactions) this.active = previous;
+      interactions.dispose?.();
+    };
+  }
+
+  handleProgressEvent<K extends ProgressEvent>(
+    event: K,
+    payload: ProgressEventPayloads[K],
+  ): boolean {
+    return this.active.handleProgressEvent(event, payload);
+  }
+
+  requestToolEditApproval(
+    request: ToolEditApprovalRequest,
+    options?: HostInteractionOptions,
+  ): Promise<ToolEditApprovalResult> | undefined {
+    return this.active.requestToolEditApproval?.(request, options);
+  }
+
+  requestBashApproval(
+    request: HostBashApprovalRequest,
+    options?: HostInteractionOptions,
+  ): Promise<HostBashApprovalResult> | undefined {
+    return this.active.requestBashApproval?.(request, options);
+  }
+
+  requestPlanApproval(
+    request: HostPlanApprovalRequest,
+    options?: HostInteractionOptions,
+  ): Promise<PlanApprovalResult> | undefined {
+    return this.active.requestPlanApproval?.(request, options);
+  }
+
+  requestAgentProposal(
+    request: HostAgentProposalRequest,
+    options?: HostInteractionOptions,
+  ): Promise<ProposalResult> | undefined {
+    return this.active.requestAgentProposal?.(request, options);
+  }
+
+  requestRetry(
+    request: HostRetryRequest,
+    options?: HostInteractionOptions,
+  ): Promise<RetryResult> | undefined {
+    return this.active.requestRetry?.(request, options);
+  }
+
+  askUserQuestion(
+    request: HostUserQuestionRequest,
+    options?: HostInteractionOptions,
+  ): Promise<HostUserQuestionResult> | undefined {
+    return this.active.askUserQuestion?.(request, options);
+  }
+
+  openExternalInquiry(
+    request: HostExternalInquiryRequest,
+  ): Promise<HostExternalInquiryHandle> | undefined {
+    return this.active.openExternalInquiry?.(request);
+  }
+
+  pending(): readonly PendingHostInteraction[] {
+    return this.active.pending();
+  }
+
+  resolve(requestId: string, result: HostInteractionResolution): boolean {
+    return this.active.resolve(requestId, result);
+  }
+
+  cancelForStream(streamId: StreamTabId, cause?: string): void {
+    this.active.cancelForStream(streamId, cause);
+  }
+
+  dispose(): void {
+    this.active.dispose?.();
+    this.active = noopHostInteractions;
+  }
+}

--- a/src/agent/runtime/PlanApprovalCoordinator.ts
+++ b/src/agent/runtime/PlanApprovalCoordinator.ts
@@ -64,6 +64,12 @@ export class PlanApprovalCoordinator extends BasePromiseCoordinator<
     this.runtimeHost.emit('requestEnsureProgressView', {});
     this.runtimeHost.emit('setActiveStream', { streamId });
 
+    const interaction = this.runtimeHost.interactions?.requestPlanApproval?.(
+      { approvalId, streamId, plan, goalEnabled },
+      { timeoutMs },
+    );
+    if (interaction) return interaction;
+
     return this.waitForUserAction(
       approvalId,
       { approvalId, streamId, plan, goalEnabled },

--- a/src/agent/runtime/RetryRequestCoordinator.ts
+++ b/src/agent/runtime/RetryRequestCoordinator.ts
@@ -71,6 +71,12 @@ export class RetryRequestCoordinatorImpl extends BasePromiseCoordinator<
       data: errorMessage ?? 'unknown error',
     });
 
+    const interaction = this.runtimeHost.interactions?.requestRetry?.(
+      { streamId, operation, model, errorMessage, errorDetails },
+      { timeoutMs },
+    );
+    if (interaction) return interaction;
+
     return this.waitForUserAction(
       streamId,
       { streamId, operation, model, errorMessage, errorDetails },

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -50,6 +50,10 @@ import {
   StreamStatusMachine,
   StreamStatusService,
 } from './StreamStatusService';
+import {
+  SessionHostInteractions,
+  type HostInteractions,
+} from './HostInteractions';
 import { SessionEventHub } from './SessionEventHub';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 
@@ -68,6 +72,7 @@ export type SessionHandleInit = Partial<
     | 'transcripts'
     | 'followUps'
     | 'flushers'
+    | 'interactions'
     | 'hostChannel'
   >
 >;
@@ -99,6 +104,8 @@ export class SessionHandle {
   readonly followUps: ToolUseFollowUpQueue;
   /** This session's trace-flush callbacks (drained on dispose / shutdown). */
   readonly flushers: Set<() => void>;
+  /** Session-scoped host interaction owner. */
+  readonly interactions: SessionHostInteractions;
   /**
    * Optional session-scoped emit surface for the non-run-scoped host-path
    * emissions (SDK Step 7d follow-on F-1). Unset ⇒ those stay on the bus.
@@ -135,11 +142,16 @@ export class SessionHandle {
     this.status = status;
     this.transcripts = transcripts;
     this.followUps = followUps;
+    this.interactions = init.interactions ?? new SessionHostInteractions();
     // A fresh session owns its own flusher set; the default session aliases the
     // process-module set so `createRunTrace`'s default writes still drain.
     this.flushers = init.flushers ?? new Set<() => void>();
     this.hostChannel = init.hostChannel;
     liveSessions.add(this);
+  }
+
+  useHostInteractions(interactions: HostInteractions): () => void {
+    return this.interactions.use(interactions);
   }
 
   /** Drain pending trace writes for this session's streams only. */
@@ -244,6 +256,7 @@ export class SessionHandle {
     this.subscriptions.dispose();
     this.executions.dispose();
     this.interrupts.retainOnly(new Set());
+    this.interactions.dispose();
     this.resultListeners.clear();
   }
 

--- a/src/test-kernel/agent/runtime/PromiseCoordinators.vitest.ts
+++ b/src/test-kernel/agent/runtime/PromiseCoordinators.vitest.ts
@@ -109,6 +109,40 @@ describe('promise coordinators', () => {
     );
   });
 
+  it('uses host interactions before the legacy show/resolve event pair', async () => {
+    const events: RecordedEvent[] = [];
+    const seenPlans: string[] = [];
+    const plan: Plan = { objective: 'Approve through HostInteractions' };
+    const host: AgentRuntimeHost = {
+      interactions: {
+        requestPlanApproval: async (request) => {
+          seenPlans.push(request.approvalId);
+          return { action: 'approve' };
+        },
+        handleProgressEvent: () => false,
+        pending: () => [],
+        resolve: () => false,
+        cancelForStream: () => {},
+      },
+      emit: (event, payload) => events.push({ event, payload }),
+    };
+    const coordinator = new PlanApprovalCoordinator(host);
+
+    assert.deepEqual(
+      await coordinator.waitForApproval('stream:interactions', {
+        approvalId: 'approval:interactions',
+        plan,
+      }),
+      { action: 'approve' },
+    );
+
+    assert.deepEqual(seenPlans, ['approval:interactions']);
+    assert.deepEqual(
+      events.map((entry) => entry.event),
+      ['requestEnsureProgressView', 'setActiveStream'],
+    );
+  });
+
   it('dismisses a replaced request through the coordinator host', async () => {
     const { events, host } = createRecordingHost();
     const coordinator = new PlanApprovalCoordinator(host);

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -94,11 +94,12 @@ vi.mock('@platform/platform', () => ({
   platform: () => ({ secrets: mocks.secrets }),
 }));
 
+import type { HostInteractions } from '@agent/runtime/HostInteractions';
 import {
   clearApprovals,
   currentApproval,
 } from '@cli/chat/tui/state/approvalQueue';
-import { installTuiApprovals } from '@cli/chat/tui/state/subscribeApprovals';
+import { createTuiHostInteractions } from '@cli/chat/tui/state/subscribeApprovals';
 import type { CliContext } from '@cli/runtime/cliContext';
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
@@ -121,6 +122,20 @@ function host(): CliRuntimeHost {
     emit: vi.fn(),
     close: vi.fn(async () => undefined),
   } as unknown as CliRuntimeHost;
+}
+
+function tui(): {
+  readonly runtimeHost: CliRuntimeHost;
+  readonly interactions: HostInteractions;
+  readonly dispose: () => void;
+} {
+  const runtimeHost = host();
+  const interactions = createTuiHostInteractions(runtimeHost, context());
+  return {
+    runtimeHost,
+    interactions,
+    dispose: () => interactions.dispose?.(),
+  };
 }
 
 function relayRetry(params: {
@@ -167,6 +182,17 @@ afterEach(() => {
 });
 
 describe('TUI retry approvals', () => {
+  it('does not mutate the runtime host emitter', () => {
+    const runtimeHost = host();
+    const originalEmit = runtimeHost.emit;
+    const interactions = createTuiHostInteractions(runtimeHost, context());
+    try {
+      expect(runtimeHost.emit).toBe(originalEmit);
+    } finally {
+      interactions.dispose?.();
+    }
+  });
+
   it('auto-switches provider-less relay retries when any personal key exists', async () => {
     const fallbackProvider =
       API_PROVIDERS.find((provider) => provider !== 'openai') ??
@@ -176,32 +202,35 @@ describe('TUI retry approvals', () => {
         provider === fallbackProvider ? 'sk-test' : undefined,
     );
 
-    const runtimeHost = host();
-    const unbind = installTuiApprovals(runtimeHost, context());
+    const { interactions, dispose } = tui();
     try {
-      runtimeHost.emit('showRetryRequest', relayRetry({ streamId: 's1' }));
+      const result = interactions.requestRetry?.(
+        relayRetry({ streamId: 's1' }),
+      );
 
       await vi.waitFor(() => {
         expect(mocks.setCliApiMode).toHaveBeenCalledWith('personal');
-        expect(mocks.triggerRetry).toHaveBeenCalledWith('s1', undefined);
+      });
+      await expect(result).resolves.toEqual({
+        action: 'retry',
+        feedback: undefined,
       });
       expect(currentApproval.get()).toBeUndefined();
       expect(mocks.lookupApiKey.mock.calls.map((call) => call[1])).toContain(
         fallbackProvider,
       );
     } finally {
-      unbind();
+      dispose();
     }
   });
 
   it('falls back to the retry modal when API key lookup fails', async () => {
     mocks.lookupApiKey.mockRejectedValue(new Error('keychain unavailable'));
 
-    const runtimeHost = host();
-    const unbind = installTuiApprovals(runtimeHost, context());
+    const { interactions, dispose } = tui();
     try {
       const retry = relayRetry({ streamId: 's2', provider: 'openai' });
-      runtimeHost.emit('showRetryRequest', retry);
+      void interactions.requestRetry?.(retry);
 
       await vi.waitFor(() => {
         expect(currentApproval.get()?.payload).toMatchObject({
@@ -211,21 +240,20 @@ describe('TUI retry approvals', () => {
       });
       expect(mocks.triggerRetry).not.toHaveBeenCalled();
     } finally {
-      unbind();
+      dispose();
     }
   });
 
   it('does not auto-switch when a retry provider is not an API provider', async () => {
     mocks.lookupApiKey.mockResolvedValue('sk-test');
 
-    const runtimeHost = host();
-    const unbind = installTuiApprovals(runtimeHost, context());
+    const { interactions, dispose } = tui();
     try {
       const retry = relayRetry({
         streamId: 'unknown-provider',
         provider: 'custom-provider',
       });
-      runtimeHost.emit('showRetryRequest', retry);
+      void interactions.requestRetry?.(retry);
 
       await vi.waitFor(() => {
         expect(currentApproval.get()?.payload).toMatchObject({
@@ -236,7 +264,7 @@ describe('TUI retry approvals', () => {
       expect(mocks.lookupApiKey).not.toHaveBeenCalled();
       expect(mocks.triggerRetry).not.toHaveBeenCalled();
     } finally {
-      unbind();
+      dispose();
     }
   });
 
@@ -246,10 +274,9 @@ describe('TUI retry approvals', () => {
         provider === 'openai' ? 'sk-openai' : undefined,
     );
 
-    const runtimeHost = host();
-    const unbind = installTuiApprovals(runtimeHost, context());
+    const { interactions, dispose } = tui();
     try {
-      runtimeHost.emit('showRetryRequest', {
+      const result = interactions.requestRetry?.({
         streamId: 'message-fallback',
         operation: 'model request',
         errorMessage: 'Monthly spending limit reached.',
@@ -263,14 +290,14 @@ describe('TUI retry approvals', () => {
 
       await vi.waitFor(() => {
         expect(mocks.setCliApiMode).toHaveBeenCalledWith('personal');
-        expect(mocks.triggerRetry).toHaveBeenCalledWith(
-          'message-fallback',
-          undefined,
-        );
+      });
+      await expect(result).resolves.toEqual({
+        action: 'retry',
+        feedback: undefined,
       });
       expect(currentApproval.get()).toBeUndefined();
     } finally {
-      unbind();
+      dispose();
     }
   });
 
@@ -280,22 +307,26 @@ describe('TUI retry approvals', () => {
         provider === 'openai' ? 'sk-openai' : undefined,
     );
 
-    const runtimeHost = host();
-    const unbind = installTuiApprovals(runtimeHost, context());
+    const { interactions, dispose } = tui();
     try {
-      runtimeHost.emit('showRetryRequest', chatGptSubscriptionRetry('s3'));
+      const result = interactions.requestRetry?.(
+        chatGptSubscriptionRetry('s3'),
+      );
 
       await vi.waitFor(() => {
         expect(mocks.setCliApiMode).toHaveBeenCalledWith('personal');
         expect(mocks.setCliCodexSubscription).toHaveBeenCalledWith(false);
-        expect(mocks.triggerRetry).toHaveBeenCalledWith('s3', undefined);
+      });
+      await expect(result).resolves.toEqual({
+        action: 'retry',
+        feedback: undefined,
       });
       expect(currentApproval.get()).toBeUndefined();
       expect(mocks.lookupApiKey.mock.calls.map((call) => call[1])).toEqual([
         'openai',
       ]);
     } finally {
-      unbind();
+      dispose();
     }
   });
 
@@ -308,15 +339,13 @@ describe('TUI retry approvals', () => {
         }),
     );
 
-    const runtimeHost = host();
-    const unbind = installTuiApprovals(runtimeHost, context());
+    const { interactions, dispose } = tui();
     try {
-      runtimeHost.emit(
-        'showRetryRequest',
+      const result = interactions.requestRetry?.(
         relayRetry({ streamId: 'interrupted', provider: 'openai' }),
       );
       clearApprovals();
-      expect(mocks.cancelRetry).toHaveBeenCalledWith('interrupted');
+      await expect(result).resolves.toEqual({ action: 'cancel' });
 
       resolveLookup?.('sk-after-interrupt');
       await Promise.resolve();
@@ -324,10 +353,10 @@ describe('TUI retry approvals', () => {
 
       expect(mocks.setCliApiMode).not.toHaveBeenCalled();
       expect(mocks.triggerRetry).not.toHaveBeenCalled();
-      expect(mocks.cancelRetry).toHaveBeenCalledTimes(1);
+      expect(mocks.cancelRetry).not.toHaveBeenCalled();
       expect(currentApproval.get()).toBeUndefined();
     } finally {
-      unbind();
+      dispose();
     }
   });
 
@@ -340,13 +369,12 @@ describe('TUI retry approvals', () => {
         }),
     );
 
-    const runtimeHost = host();
-    const unbind = installTuiApprovals(runtimeHost, context());
-    runtimeHost.emit(
-      'showRetryRequest',
+    const { interactions, dispose } = tui();
+    const result = interactions.requestRetry?.(
       relayRetry({ streamId: 'unbound', provider: 'openai' }),
     );
-    unbind();
+    dispose();
+    await expect(result).resolves.toEqual({ action: 'cancel' });
 
     resolveLookup?.('sk-after-unbind');
     await Promise.resolve();
@@ -361,11 +389,9 @@ describe('TUI retry approvals', () => {
   it('cancels an active retry modal when approvals are cleared', async () => {
     mocks.lookupApiKey.mockResolvedValue(undefined);
 
-    const runtimeHost = host();
-    const unbind = installTuiApprovals(runtimeHost, context());
+    const { interactions, dispose } = tui();
     try {
-      runtimeHost.emit(
-        'showRetryRequest',
+      const result = interactions.requestRetry?.(
         relayRetry({ streamId: 'modal-interrupt', provider: 'openai' }),
       );
 
@@ -377,10 +403,10 @@ describe('TUI retry approvals', () => {
       });
 
       clearApprovals();
-      expect(mocks.cancelRetry).toHaveBeenCalledWith('modal-interrupt');
+      await expect(result).resolves.toEqual({ action: 'cancel' });
       expect(currentApproval.get()).toBeUndefined();
     } finally {
-      unbind();
+      dispose();
     }
   });
 
@@ -395,19 +421,16 @@ describe('TUI retry approvals', () => {
       )
       .mockResolvedValueOnce(undefined);
 
-    const runtimeHost = host();
-    const unbind = installTuiApprovals(runtimeHost, context());
+    const { interactions, dispose } = tui();
     try {
-      runtimeHost.emit(
-        'showRetryRequest',
+      void interactions.requestRetry?.(
         relayRetry({
           streamId: 'same-stream',
           provider: 'openai',
           message: 'first retry',
         }),
       );
-      runtimeHost.emit(
-        'showRetryRequest',
+      void interactions.requestRetry?.(
         relayRetry({
           streamId: 'same-stream',
           provider: 'openai',
@@ -429,7 +452,7 @@ describe('TUI retry approvals', () => {
       expect(mocks.setCliApiMode).not.toHaveBeenCalled();
       expect(mocks.triggerRetry).not.toHaveBeenCalled();
     } finally {
-      unbind();
+      dispose();
     }
   });
 
@@ -438,11 +461,9 @@ describe('TUI retry approvals', () => {
       .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce('sk-new');
 
-    const runtimeHost = host();
-    const unbind = installTuiApprovals(runtimeHost, context());
+    const { interactions, dispose } = tui();
     try {
-      runtimeHost.emit(
-        'showRetryRequest',
+      void interactions.requestRetry?.(
         relayRetry({
           streamId: 'same-stream',
           provider: 'openai',
@@ -456,8 +477,7 @@ describe('TUI retry approvals', () => {
         });
       });
 
-      runtimeHost.emit(
-        'showRetryRequest',
+      const second = interactions.requestRetry?.(
         relayRetry({
           streamId: 'same-stream',
           provider: 'openai',
@@ -466,25 +486,23 @@ describe('TUI retry approvals', () => {
       );
 
       await vi.waitFor(() => {
-        expect(mocks.triggerRetry).toHaveBeenCalledWith(
-          'same-stream',
-          undefined,
-        );
         expect(currentApproval.get()).toBeUndefined();
       });
+      await expect(second).resolves.toEqual({
+        action: 'retry',
+        feedback: undefined,
+      });
     } finally {
-      unbind();
+      dispose();
     }
   });
 
   it('replaces an older retry modal when a newer retry also needs input', async () => {
     mocks.lookupApiKey.mockResolvedValue(undefined);
 
-    const runtimeHost = host();
-    const unbind = installTuiApprovals(runtimeHost, context());
+    const { interactions, dispose } = tui();
     try {
-      runtimeHost.emit(
-        'showRetryRequest',
+      void interactions.requestRetry?.(
         relayRetry({
           streamId: 'same-stream',
           provider: 'openai',
@@ -498,8 +516,7 @@ describe('TUI retry approvals', () => {
         });
       });
 
-      runtimeHost.emit(
-        'showRetryRequest',
+      void interactions.requestRetry?.(
         relayRetry({
           streamId: 'same-stream',
           provider: 'openai',
@@ -516,7 +533,7 @@ describe('TUI retry approvals', () => {
       expect(mocks.cancelRetry).not.toHaveBeenCalled();
       expect(mocks.triggerRetry).not.toHaveBeenCalled();
     } finally {
-      unbind();
+      dispose();
     }
   });
 
@@ -532,11 +549,9 @@ describe('TUI retry approvals', () => {
       )
       .mockResolvedValueOnce(undefined);
 
-    const runtimeHost = host();
-    const unbind = installTuiApprovals(runtimeHost, context());
+    const { interactions, dispose } = tui();
     try {
-      runtimeHost.emit(
-        'showRetryRequest',
+      void interactions.requestRetry?.(
         relayRetry({
           streamId: 'same-stream',
           provider: 'openai',
@@ -547,8 +562,7 @@ describe('TUI retry approvals', () => {
         expect(mocks.setCliApiMode).toHaveBeenCalledTimes(1);
       });
 
-      runtimeHost.emit(
-        'showRetryRequest',
+      const second = interactions.requestRetry?.(
         relayRetry({
           streamId: 'same-stream',
           provider: 'openai',
@@ -556,10 +570,11 @@ describe('TUI retry approvals', () => {
         }),
       );
       await vi.waitFor(() => {
-        expect(mocks.triggerRetry).toHaveBeenCalledWith(
-          'same-stream',
-          undefined,
-        );
+        expect(mocks.setCliApiMode).toHaveBeenCalledTimes(2);
+      });
+      await expect(second).resolves.toEqual({
+        action: 'retry',
+        feedback: undefined,
       });
 
       rejectFirstModeSwitch?.(new Error('stale mode switch failed'));
@@ -568,7 +583,7 @@ describe('TUI retry approvals', () => {
 
       expect(mocks.cancelRetry).not.toHaveBeenCalled();
     } finally {
-      unbind();
+      dispose();
     }
   });
 });

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -96,6 +96,13 @@ async function showApprovalPrompt(
 
   const requestId = `bash-${nanoid()}`;
 
+  const interaction = runtimeHost.interactions?.requestBashApproval?.({
+    command: request.command,
+    ...(request.cwd ? { cwd: request.cwd } : {}),
+    streamId,
+  });
+  if (interaction) return interaction;
+
   try {
     return await new Promise<BashApprovalResult>((resolve) => {
       let settled = false;

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -227,6 +227,14 @@ export async function requestToolEditApproval(
     return finalizeApprovalResult({ accepted: true }, preparedRequest);
   }
 
+  const hostInteraction =
+    context?.runtimeHost.interactions?.requestToolEditApproval?.(
+      preparedRequest,
+    );
+  if (hostInteraction) {
+    return finalizeApprovalResult(await hostInteraction, preparedRequest);
+  }
+
   const result = await toolEditApprovalController.enqueue(async () => {
     // Prefer the run's own approval channel (set by hosts that manage more
     // than one concurrent session per process, e.g. desktop's one window per

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -415,7 +415,13 @@ export class ExternalInquiryTool extends defineTool({
           draft: null,
           transcript: null,
         };
-    runtimeHost.emit('showExternalInquiry', permission);
+    const interaction =
+      runtimeHost.interactions?.openExternalInquiry?.(permission);
+    if (interaction) {
+      void interaction;
+    } else {
+      runtimeHost.emit('showExternalInquiry', permission);
+    }
 
     // Background Tasks panel: announce the open thread.
     const summary = await getThreadSummary(persisted.threadId);

--- a/src/tools/userQuestion/UserQuestionTool.ts
+++ b/src/tools/userQuestion/UserQuestionTool.ts
@@ -142,13 +142,26 @@ The tool returns a JSON object whose keys are the original question texts and wh
       data: input.questions[0]?.question.slice(0, 100) ?? '',
     });
 
+    const permission = {
+      requestId,
+      questions: input.questions,
+      context: input.context ?? undefined,
+      allowBypass: false,
+      streamId: streamId ?? '',
+    };
+    let usedInteraction = false;
     try {
-      const result = await awaitUserQuestionResponse({
-        requestId,
-        input,
-        runtimeHost,
-        streamId,
-      });
+      const interaction =
+        runtimeHost.interactions?.askUserQuestion?.(permission);
+      usedInteraction = interaction != null;
+      const result = interaction
+        ? await interaction
+        : await awaitUserQuestionResponse({
+            requestId,
+            input,
+            runtimeHost,
+            streamId,
+          });
 
       if (!result.submitted) {
         return {
@@ -174,7 +187,9 @@ The tool returns a JSON object whose keys are the original question texts and wh
       };
     } finally {
       pendingQuestions.delete(requestId);
-      runtimeHost.emit('resolveUserQuestion', { requestId });
+      if (!usedInteraction) {
+        runtimeHost.emit('resolveUserQuestion', { requestId });
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

This is the Stage 4 CLI-first slice for #6967.

- Adds a session-owned `HostInteractions` port and exposes it through `SessionHandle` and `AgentRuntimeHost` for the migration period.
- Routes the CLI TUI approval path through Promise-returning interaction methods instead of rewriting `host.emit` in `subscribeApprovals.ts`.
- Converts CLI TUI handling for tool edit, bash, plan approval, agent proposal, retry, user question, and external inquiry to the interaction path while retaining legacy event fallback for non-TUI CLI, desktop, and extension.
- Keeps retry policy ownership unchanged: the new port is the host prompt surface only; it preserves the existing CLI API-mode switch behavior and stale-route guards.

## Single Source Of Truth

`SessionHandle.interactions` is now the owner of the host interaction implementation for a session. The CLI TUI installs one concrete implementation for its active session and passes the stable session interaction object on the runtime host. The old `show*`/`resolve*` event names remain as compatibility fallback for hosts not yet ported; they are not deleted in this PR.

## Scheduled Refactoring

This PR intentionally leaves the legacy progress-event request/resolve names alive for desktop and extension. A #6981 ledger row is needed for this compatibility window: remove the fallback after the desktop and extension Stage 4 host implementations land and all runtime request sites resolve through `session.interactions`.

## Tests

- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/TuiApprovalRetry.vitest.mts src/test-kernel/cli/ApprovalQueue.vitest.mts src/test-kernel/cli/ApprovalAdapter.vitest.mts src/test-kernel/agent/runtime/PromiseCoordinators.vitest.ts`
- `npm run compile:fast`
- `npm run lint` (passes with the pre-existing `codexToolTemplates.ts` import-order warning)
- `npm test`
- `git diff --check`

Closes part of #6967.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes human-in-the-loop surfaces (approvals, retries, questions, inquiries) across CLI and agent runtime; mitigated by legacy event fallbacks and expanded tests, but behavior regressions in race/cancel paths are plausible until other hosts migrate.
> 
> **Overview**
> Introduces a **session-owned `HostInteractions` port** on `SessionHandle` (via `SessionHostInteractions` / `useHostInteractions`) and exposes the stable slot on `AgentRuntimeHost.interactions` for the Stage 4 migration.
> 
> **CLI TUI** no longer rewrites `host.emit` or registers a process-wide tool-edit handler: `createTuiHostInteractions` implements Promise-based prompts (tool edit, bash, plan, proposal, retry, user question, external inquiry) and is installed per run through `defaultSession().useHostInteractions`, with the runtime host carrying `defaultSession().interactions`.
> 
> **Runtime and tools** now **prefer the interaction port** when present—plan/agent-proposal/retry coordinators short-circuit before legacy `show*`/`resolve*` pairs; bash, tool-edit, user-question, and inquiry tools call the matching `request*` / `ask*` / `open*` methods and keep the old progress-event path as fallback for desktop/extension.
> 
> Retry handling on the TUI path is refactored to **per-session route state** and **`requestRetry` promises** (including cancel on dispose/clear), with tests asserting the host emitter is not mutated and coordinators skip legacy approval events when interactions are wired.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86ca9ba033ae4ea87d4d19d649924008e6390469. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->