### PR TITLE
refactor: add desktop host interactions port

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -96,6 +96,7 @@ import {
   createDesktopToolEditApprovalController,
   type DesktopToolEditApprovalController,
 } from './desktopToolEditApproval.js';
+import { createDesktopHostInteractions } from './desktopHostInteractions.js';
 import {
   DesktopProgressFileActions,
   type DesktopLatexdiffRunContext,
@@ -228,6 +229,8 @@ export class DesktopProgressBridge {
    * execution running anywhere" checks use `getAllActiveExecutionIds()`.
    */
   private readonly session: SessionHandle;
+  /** Detaches this window's concrete host interaction implementation. */
+  private readonly detachHostInteractions: () => void;
   /** Detaches the session→toast consumer; called on dispose. */
   private detachResultToast: (() => void) | undefined;
 
@@ -235,10 +238,21 @@ export class DesktopProgressBridge {
     private readonly postToRenderer: (message: unknown) => boolean | void,
     private readonly options: DesktopProgressBridgeOptions = {},
   ) {
-    this.runtimeHost = {
+    const hostChannel: AgentRuntimeHost = {
       emit: (event, payload) => this.handleProgressEvent(event, payload),
     };
-    this.session = new SessionHandle({ hostChannel: this.runtimeHost });
+    this.session = new SessionHandle({ hostChannel });
+    this.runtimeHost = {
+      ...hostChannel,
+      interactions: this.session.interactions,
+    };
+    this.detachHostInteractions = this.session.useHostInteractions(
+      createDesktopHostInteractions({
+        runtimeHost: this.runtimeHost,
+        getApprovalHandlers: () => this.approvalHandlers,
+        getToolEditApprovals: () => this.toolEditApprovals,
+      }),
+    );
     setProgressViewBridge({ isViewVisible: () => true });
     this.backend = new ProgressBackend({
       session: this.session,
@@ -454,7 +468,14 @@ export class DesktopProgressBridge {
         return true;
       },
       resolveProposal: (proposalId, result) => {
-        this.session.coordinators.resolveProposal(proposalId, result);
+        const resolved = this.session.interactions.resolve(proposalId, {
+          kind: 'proposal',
+          action: result.action,
+          value: result,
+        });
+        if (!resolved) {
+          this.session.coordinators.resolveProposal(proposalId, result);
+        }
       },
       onMissingProposal: (proposalId) => {
         this.logger.warn(
@@ -537,17 +558,46 @@ export class DesktopProgressBridge {
           });
         },
         handleBashApprovalAction: (message) =>
-          handleProgressViewBashApprovalAction(message),
-        handlePlanApprovalAction: (message) => {
-          this.session.coordinators.resolvePlanApproval(message.approvalId, {
+          this.session.interactions.resolve(message.requestId, {
+            kind: 'bash',
             action: message.action,
-            ...(message.action === 'reject' && {
-              feedback: message.feedback,
-            }),
-          });
+            feedback: message.feedback,
+          }) || handleProgressViewBashApprovalAction(message),
+        handlePlanApprovalAction: (message) => {
+          const resolved = this.session.interactions.resolve(
+            message.approvalId,
+            {
+              kind: 'plan',
+              action: message.action,
+              ...(message.action === 'reject' && {
+                feedback: message.feedback,
+              }),
+            },
+          );
+          if (!resolved) {
+            this.session.coordinators.resolvePlanApproval(message.approvalId, {
+              action: message.action,
+              ...(message.action === 'reject' && {
+                feedback: message.feedback,
+              }),
+            });
+          }
         },
-        handleUserQuestionAction: (message) =>
-          handleUserQuestionAction(message),
+        handleUserQuestionAction: (message) => {
+          const resolved = this.session.interactions.resolve(
+            message.requestId,
+            {
+              kind: 'userQuestion',
+              action: message.action,
+              value: message.answers,
+              feedback: message.feedback,
+            },
+          );
+          if (!resolved) {
+            return handleUserQuestionAction(message);
+          }
+          return undefined;
+        },
         handleAgentProposalAction: (message) =>
           this.agentProposalController.handleAction(message),
       },
@@ -653,6 +703,7 @@ export class DesktopProgressBridge {
 
   dispose(): void {
     this.detachResultToast?.();
+    this.detachHostInteractions();
     this.toolEditApprovals.dispose();
     this.unsubscribe();
     this.backend.dispose();

--- a/packages/desktop/src/main/desktopHostInteractions.ts
+++ b/packages/desktop/src/main/desktopHostInteractions.ts
@@ -1,0 +1,256 @@
+import { nanoid } from 'nanoid';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type {
+  HostBashApprovalRequest,
+  HostBashApprovalResult,
+  HostInteractionResolution,
+  HostInteractions,
+  HostPlanApprovalRequest,
+  HostRetryRequest,
+  HostUserQuestionResult,
+  PendingHostInteraction,
+} from '@agent/runtime/HostInteractions';
+import type { PlanApprovalResult } from '@agent/runtime/PlanApprovalCoordinator';
+import type { ProposalResult } from '@agent/runtime/AgentProposalCoordinator';
+import type { RetryResult } from '@agent/runtime/RetryRequestCoordinator';
+import type {
+  AgentProposalPermission,
+  StreamTabId,
+  UserQuestionAnswers,
+} from '@shared/schemas';
+import type { ApprovalRequestHandlerSet } from '@shared/progressView/backend/progressBackendUiConfig';
+import type {
+  ToolEditApprovalRequest,
+  ToolEditApprovalResult,
+} from '@platform/interfaces/toolEditApproval';
+
+import type { DesktopToolEditApprovalController } from './desktopToolEditApproval.js';
+
+type PendingDesktopInteraction =
+  | {
+      kind: 'bash';
+      streamId?: StreamTabId;
+      settle: (result: HostBashApprovalResult) => void;
+    }
+  | {
+      kind: 'plan';
+      streamId: StreamTabId;
+      settle: (result: PlanApprovalResult) => void;
+    }
+  | {
+      kind: 'proposal';
+      streamId: StreamTabId;
+      settle: (result: ProposalResult) => void;
+    }
+  | {
+      kind: 'userQuestion';
+      streamId?: StreamTabId;
+      settle: (result: HostUserQuestionResult) => void;
+    };
+
+export interface DesktopHostInteractionsOptions {
+  runtimeHost: AgentRuntimeHost;
+  getApprovalHandlers(): ApprovalRequestHandlerSet;
+  getToolEditApprovals(): DesktopToolEditApprovalController;
+}
+
+export function createDesktopHostInteractions(
+  options: DesktopHostInteractionsOptions,
+): HostInteractions {
+  return new DesktopHostInteractions(options);
+}
+
+class DesktopHostInteractions implements HostInteractions {
+  private readonly pendingRequests = new Map<
+    string,
+    PendingDesktopInteraction
+  >();
+
+  constructor(private readonly options: DesktopHostInteractionsOptions) {}
+
+  requestToolEditApproval(
+    request: ToolEditApprovalRequest,
+  ): Promise<ToolEditApprovalResult> {
+    return this.options.getToolEditApprovals().requestApproval(request);
+  }
+
+  requestBashApproval(
+    request: HostBashApprovalRequest,
+  ): Promise<HostBashApprovalResult> {
+    const requestId = `desktop-bash-${nanoid()}`;
+    const streamId = request.streamId ?? undefined;
+    const payload = {
+      requestId,
+      command: request.command,
+      ...(request.cwd ? { cwd: request.cwd } : {}),
+      allowBypass: true,
+      streamId: streamId ?? '',
+    };
+    return this.showPending(requestId, { kind: 'bash', streamId }, (settle) => {
+      this.activateStream(streamId);
+      this.options.getApprovalHandlers().bash.show(payload);
+      return settle;
+    });
+  }
+
+  requestPlanApproval(
+    request: HostPlanApprovalRequest,
+  ): Promise<PlanApprovalResult> {
+    return this.showPending(
+      request.approvalId,
+      { kind: 'plan', streamId: request.streamId },
+      (settle) => {
+        this.options.getApprovalHandlers().planApproval.show(request);
+        return settle;
+      },
+    );
+  }
+
+  requestAgentProposal(
+    request: AgentProposalPermission,
+  ): Promise<ProposalResult> {
+    return this.showPending(
+      request.proposalId,
+      { kind: 'proposal', streamId: request.streamId },
+      (settle) => {
+        this.options.getApprovalHandlers().agentProposal.show(request);
+        return settle;
+      },
+    );
+  }
+
+  requestRetry(_request: HostRetryRequest): Promise<RetryResult> {
+    return Promise.resolve({ action: 'cancel' });
+  }
+
+  askUserQuestion(
+    request: Parameters<NonNullable<HostInteractions['askUserQuestion']>>[0],
+  ): Promise<HostUserQuestionResult> {
+    const streamId = request.streamId || undefined;
+    return this.showPending(
+      request.requestId,
+      { kind: 'userQuestion', streamId },
+      (settle) => {
+        this.activateStream(streamId);
+        this.options.getApprovalHandlers().userQuestion.show(request);
+        return settle;
+      },
+    );
+  }
+
+  openExternalInquiry(
+    request: Parameters<
+      NonNullable<HostInteractions['openExternalInquiry']>
+    >[0],
+  ): Promise<{ threadId: string }> {
+    this.options.getApprovalHandlers().externalInquiry.show(request);
+    return Promise.resolve({ threadId: request.threadId });
+  }
+
+  handleProgressEvent(): boolean {
+    return false;
+  }
+
+  pending(): readonly PendingHostInteraction[] {
+    return [...this.pendingRequests.entries()].map(([id, request]) => ({
+      id,
+      kind: request.kind,
+      ...(request.streamId ? { streamId: request.streamId } : {}),
+    }));
+  }
+
+  resolve(requestId: string, result: HostInteractionResolution): boolean {
+    const request = this.pendingRequests.get(requestId);
+    if (!request) return false;
+    this.pendingRequests.delete(requestId);
+
+    switch (request.kind) {
+      case 'bash':
+        request.settle({
+          accepted: result.action === 'approve',
+          ...(result.feedback ? { userMessage: result.feedback } : {}),
+        });
+        this.options.getApprovalHandlers().bash.resolve(requestId);
+        return true;
+      case 'plan':
+        request.settle(
+          result.action === 'approve' || result.action === 'approve_and_goal'
+            ? { action: result.action }
+            : {
+                action: 'reject',
+                ...(result.feedback ? { feedback: result.feedback } : {}),
+              },
+        );
+        this.options.getApprovalHandlers().planApproval.resolve(requestId);
+        return true;
+      case 'proposal':
+        request.settle(toProposalResult(result));
+        this.options.getApprovalHandlers().agentProposal.resolve(requestId);
+        return true;
+      case 'userQuestion':
+        request.settle({
+          submitted: result.action === 'submit',
+          ...(result.value
+            ? { answers: result.value as UserQuestionAnswers }
+            : {}),
+          ...(result.feedback ? { feedback: result.feedback } : {}),
+        });
+        this.options.getApprovalHandlers().userQuestion.resolve(requestId);
+        return true;
+    }
+  }
+
+  cancelForStream(streamId: StreamTabId, cause?: string): void {
+    for (const [requestId, request] of [...this.pendingRequests.entries()]) {
+      if (request.streamId !== streamId) continue;
+      this.resolve(requestId, {
+        kind: request.kind,
+        action: 'reject',
+        feedback: cause,
+      });
+    }
+  }
+
+  dispose(): void {
+    for (const requestId of [...this.pendingRequests.keys()]) {
+      this.resolve(requestId, {
+        kind: 'dispose',
+        action: 'reject',
+        feedback: 'Desktop session disposed.',
+      });
+    }
+  }
+
+  private showPending<TResult, TEntry extends PendingDesktopInteraction>(
+    requestId: string,
+    entry: Omit<TEntry, 'settle'>,
+    show: (settle: TEntry['settle']) => TEntry['settle'],
+  ): Promise<TResult> {
+    return new Promise<TResult>((resolve) => {
+      const settle = show((result) => resolve(result as TResult));
+      this.pendingRequests.set(requestId, {
+        ...entry,
+        settle,
+      } as TEntry);
+    });
+  }
+
+  private activateStream(streamId: StreamTabId | undefined): void {
+    this.options.runtimeHost.emit('requestEnsureProgressView', {});
+    if (streamId)
+      this.options.runtimeHost.emit('setActiveStream', { streamId });
+  }
+}
+
+function toProposalResult(result: HostInteractionResolution): ProposalResult {
+  if (result.value && typeof result.value === 'object') {
+    const value = result.value as ProposalResult;
+    if ('action' in value) return value;
+  }
+  return result.action === 'approve' || result.action === 'setup'
+    ? { action: result.action }
+    : {
+        action: 'reject',
+        ...(result.feedback ? { feedback: result.feedback } : {}),
+      };
+}

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -32,6 +32,7 @@ import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc/progressViewCommands';
 import type { ProgressViewInboundHandlerRegistry } from '@shared/schemas/progressView';
 import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
 import { assertSupported } from '@shared/utils/dispatcher';
+import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import { DIAGNOSTICS_ADD_RUNTIME_CAPABILITY } from '@tools/diagnosticsRuntimeCapabilities';
 
 // Local imports - desktop test paths
@@ -44,6 +45,21 @@ type Bridge = {
 };
 
 type TestableBridge = Bridge & {
+  runtimeHost: {
+    interactions?: {
+      requestPlanApproval?: (request: {
+        approvalId: string;
+        streamId: StreamTabId;
+        plan: { objective: string };
+        goalEnabled: boolean;
+      }) => Promise<unknown>;
+      requestAgentProposal?: (request: unknown) => Promise<unknown>;
+      requestRetry?: (request: {
+        streamId: StreamTabId;
+        operation: string;
+      }) => Promise<unknown>;
+    };
+  };
   handleProgressEvent(event: string, payload: unknown): void;
   syncFullView(): void;
   tryResumeStream(streamId: StreamTabId): Promise<boolean>;
@@ -608,6 +624,165 @@ describe('DesktopProgressBridge', () => {
           }),
         );
       });
+    } finally {
+      bridge.dispose();
+    }
+  });
+
+  it('installs host interactions on the desktop runtime host', async () => {
+    const bridge = await createBridge([]);
+
+    try {
+      expect(bridge.runtimeHost.interactions).toMatchObject({
+        requestPlanApproval: expect.any(Function),
+        requestAgentProposal: expect.any(Function),
+        requestRetry: expect.any(Function),
+      });
+    } finally {
+      bridge.dispose();
+    }
+  });
+
+  it('resolves plan approvals through desktop host interactions', async () => {
+    const messages: unknown[] = [];
+    const bridge = await createBridge(messages);
+
+    try {
+      messages.length = 0;
+      const result = bridge.runtimeHost.interactions?.requestPlanApproval?.({
+        approvalId: 'plan-host-interaction',
+        streamId: 'stream-plan' as StreamTabId,
+        plan: { objective: 'Check the desktop host interaction port.' },
+        goalEnabled: false,
+      });
+
+      await vi.waitFor(() => {
+        expect(
+          progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION),
+        ).toContainEqual(
+          expect.objectContaining({
+            action: 'show',
+            permission: expect.objectContaining({
+              kind: PERMISSION_KIND.PLAN_APPROVAL,
+              data: expect.objectContaining({
+                approvalId: 'plan-host-interaction',
+              }),
+            }),
+          }),
+        );
+      });
+
+      const handlePlan = assertSupported(
+        bridge.progressViewInboundHandlers[
+          PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION
+        ],
+      );
+      await handlePlan({
+        command: PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION,
+        approvalId: 'plan-host-interaction',
+        action: 'approve',
+      });
+
+      await expect(result).resolves.toEqual({ action: 'approve' });
+      expect(
+        progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION),
+      ).toContainEqual(
+        expect.objectContaining({
+          action: 'resolve',
+          kind: PERMISSION_KIND.PLAN_APPROVAL,
+          id: 'plan-host-interaction',
+        }),
+      );
+    } finally {
+      bridge.dispose();
+    }
+  });
+
+  it('resolves agent proposals through desktop host interactions', async () => {
+    const messages: unknown[] = [];
+    const bridge = await createBridge(messages);
+
+    try {
+      messages.length = 0;
+      const result = bridge.runtimeHost.interactions?.requestAgentProposal?.({
+        proposalId: 'proposal-host-interaction',
+        streamId: 'stream-proposal',
+        agentCategory: AgentCategory.Workflow,
+        agent: 'proofreader',
+        model: 'gemini31p',
+        instruction: 'Check this draft.',
+        inputFiles: ['main.tex'],
+        contextFiles: [],
+        mediaFiles: [],
+        outputFiles: ['main.review.tex'],
+        useMultipleOutputs: false,
+        toolConfig: DEFAULT_TOOL_CONFIG,
+      });
+
+      await vi.waitFor(() => {
+        expect(
+          progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION),
+        ).toContainEqual(
+          expect.objectContaining({
+            action: 'show',
+            permission: expect.objectContaining({
+              kind: PERMISSION_KIND.PROPOSAL,
+              data: expect.objectContaining({
+                proposalId: 'proposal-host-interaction',
+              }),
+            }),
+          }),
+        );
+      });
+
+      const handleProposal = assertSupported(
+        bridge.progressViewInboundHandlers[
+          PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION
+        ],
+      );
+      await handleProposal({
+        command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
+        proposalId: 'proposal-host-interaction',
+        action: 'approve',
+      });
+
+      await expect(result).resolves.toEqual({ action: 'approve' });
+      expect(
+        progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION),
+      ).toContainEqual(
+        expect.objectContaining({
+          action: 'resolve',
+          kind: PERMISSION_KIND.PROPOSAL,
+          id: 'proposal-host-interaction',
+        }),
+      );
+    } finally {
+      bridge.dispose();
+    }
+  });
+
+  it('keeps desktop retry requests on the existing cancel path', async () => {
+    const messages: unknown[] = [];
+    const bridge = await createBridge(messages);
+
+    try {
+      messages.length = 0;
+      await expect(
+        bridge.runtimeHost.interactions?.requestRetry?.({
+          streamId: 'stream-retry' as StreamTabId,
+          operation: 'model request',
+        }),
+      ).resolves.toEqual({ action: 'cancel' });
+      expect(
+        progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION),
+      ).not.toContainEqual(
+        expect.objectContaining({
+          action: 'show',
+          permission: expect.objectContaining({
+            kind: PERMISSION_KIND.RETRY,
+          }),
+        }),
+      );
     } finally {
       bridge.dispose();
     }


### PR DESCRIPTION
## Summary

This is the desktop slice of Stage 4 for #6967. It ports the desktop runtime path to the session-scoped `HostInteractions` abstraction without changing renderer IPC shapes.

Changes:

- Add `createDesktopHostInteractions`, a desktop adapter around the existing progress approval handler set.
- Install `session.interactions` on the desktop `runtimeHost` used for agent execution.
- Resolve bash, plan approval, agent proposal, and user-question actions through the interaction port first, with the existing coordinator/action handlers retained as compatibility fallback.
- Delegate tool-edit approval to the existing desktop tool-edit approval controller.
- Keep desktop retry requests on the current immediate-cancel path, so no retry permission panel is introduced.

The legacy progress-event fallback remains intentionally present while the remaining Stage 4 host slice is completed. That temporary compatibility state is already recorded in the migration ledger by #7303; this PR shortens that window for the desktop host.

## Validation

- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts`
- `corepack pnpm exec eslint packages/desktop/src/main/desktopAgentExecution.ts packages/desktop/src/main/desktopHostInteractions.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `npm run compile:fast`
- `npm run lint` (passes with the pre-existing import-order warning in `packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts`)
- `npm test`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches interactive approval and proposal resolution paths for desktop runs; behavior should match prior flows but dual resolve/fallback logic adds regression surface until Stage 4 is complete.
> 
> **Overview**
> Desktop agent execution now wires the session-scoped **`HostInteractions`** port onto **`runtimeHost`**, matching the Stage 4 migration used elsewhere without changing renderer IPC.
> 
> A new **`createDesktopHostInteractions`** adapter tracks pending bash, plan, proposal, and user-question prompts via the existing progress approval handlers (and delegates tool-edit approval to the desktop controller). **`DesktopProgressBridge`** registers it with **`session.useHostInteractions`**, exposes **`session.interactions`** on the host, and tears it down on dispose.
> 
> Inbound approval actions now **`resolve` through the interaction port first**, with the previous coordinator/bash/user-question handlers kept as fallbacks. Agent proposal setup resolution uses the same pattern. **Retry** stays on the immediate **`{ action: 'cancel' }`** path—no retry permission UI on desktop.
> 
> Tests cover installation on the runtime host and end-to-end plan/proposal resolution plus the retry cancel behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31f2230912b3dd9dfa2ae18f3db914c8a4b344e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->