### PR TITLE
fix(export): escape Markdown emphasis/code-span/heading chars in chat export titles

### DIFF
--- a/src/agent/export/chatExport/markdownSpec.ts
+++ b/src/agent/export/chatExport/markdownSpec.ts
@@ -60,7 +60,10 @@ const ATTACHMENT_LABELS: Record<string, string> = {
   document: 'Document attachment',
 };
 
-const MARKDOWN_TEXT_ESCAPE_RE = /[\\[\]()<>!]/g;
+// Backtick/*/_/# added on top of the link-syntax-breaking set: a
+// tool-controlled title containing them can trigger incidental code-span,
+// emphasis, or heading formatting even though it can't inject a live link.
+const MARKDOWN_TEXT_ESCAPE_RE = /[\\[\]()<>!`*_#]/g;
 // No `[`/`]` here (unlike MARKDOWN_TEXT_ESCAPE_RE above): CommonMark's
 // bare-form link destination grammar restricts only unescaped/unbalanced
 // parentheses, ASCII space, and control characters — square brackets have

--- a/src/test-kernel/commands/history/chatExportFormatter.vitest.ts
+++ b/src/test-kernel/commands/history/chatExportFormatter.vitest.ts
@@ -215,6 +215,36 @@ describe('formatChatAsMarkdown', () => {
     assert.doesNotMatch(markdown, /\]\(javascript:/);
   });
 
+  it('escapes emphasis/code-span/heading characters in web tool titles', () => {
+    const title = '`rm -rf /` *bold* _italic_ # Heading';
+    const markdown = formatChatAsMarkdown({
+      timestamp: '2026-01-01T00:00:00.000Z',
+      config: {},
+      messages: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'web_search_tool_result',
+              content: [
+                {
+                  type: 'web_search_result',
+                  title,
+                  url: 'https://example.com',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    assert.ok(
+      markdown.includes('\\`rm -rf /\\` \\*bold\\* \\_italic\\_ \\# Heading'),
+      `expected escaped title, got: ${markdown}`,
+    );
+  });
+
   it('preserves IPv6 host brackets in Markdown link destinations', () => {
     const url = 'http://[::1]:8080/path';
     const markdown = formatChatAsMarkdown({

--- a/src/test-kernel/commands/history/chatExportFormatter.vitest.ts
+++ b/src/test-kernel/commands/history/chatExportFormatter.vitest.ts
@@ -245,6 +245,36 @@ describe('formatChatAsMarkdown', () => {
     );
   });
 
+  it('escapes emphasis/code-span/heading characters in web-fetch titles too', () => {
+    // Same escapeMarkdownText call as the web_search case above, but through
+    // the web_fetch **Title:** container (markdownSpec.ts's second call site).
+    const title = '`rm -rf /` *bold* _italic_ # Heading';
+    const markdown = formatChatAsMarkdown({
+      timestamp: '2026-01-01T00:00:00.000Z',
+      config: {},
+      messages: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'web_fetch_tool_result',
+              url: 'https://example.com',
+              title,
+              page_content: 'body',
+            },
+          ],
+        },
+      ],
+    });
+
+    assert.ok(
+      markdown.includes(
+        '**Title:** \\`rm -rf /\\` \\*bold\\* \\_italic\\_ \\# Heading',
+      ),
+      `expected escaped title, got: ${markdown}`,
+    );
+  });
+
   it('preserves IPv6 host brackets in Markdown link destinations', () => {
     const url = 'http://[::1]:8080/path';
     const markdown = formatChatAsMarkdown({


### PR DESCRIPTION
Closes #7296

Follow-up from #7259. `escapeMarkdownText` escaped the link-syntax-breaking set (`\[]()<>!`) for web-search/web-fetch titles, but not backtick, `*`, `_`, or `#`. A tool-controlled title containing those characters could still trigger incidental code-span, emphasis, or heading formatting in the exported Markdown document.

Not a security issue (no live-link injection possible through this gap) — flagged as out of scope for #7259 by two independent review rounds and left for this follow-up.

Extended `MARKDOWN_TEXT_ESCAPE_RE` to also neutralize backtick/`*`/`_`/`#`, and added regression coverage for a title containing all of them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Export-only text escaping with no auth, data, or URL-sanitizer changes; behavior is covered by new unit tests.
> 
> **Overview**
> Extends **`escapeMarkdownText`** in chat Markdown export so web search/fetch **titles** also escape backticks, `*`, `_`, and `#`, not only the link-breaking character set from #7259. Tool-controlled titles with those characters could otherwise render as code spans, emphasis, or headings in exported Markdown (formatting only—not live-link injection).
> 
> Adds regression tests for the same malicious-looking title on **web_search** link lines and **web_fetch** `**Title:**` lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cec13dabadb619fe9a71dbc813f921ee918e28d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->