### PR TITLE
refactor: add extension host interactions port

### DIFF
--- a/packages/extension/src/frontend/agentRuntime/extensionAgentRuntimeHost.ts
+++ b/packages/extension/src/frontend/agentRuntime/extensionAgentRuntimeHost.ts
@@ -1,6 +1,8 @@
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import { bus } from '@eventBus/ProgressEventBus';
 
 export const extensionAgentRuntimeHost: AgentRuntimeHost = {
+  interactions: defaultSession().interactions,
   emit: (event, payload) => bus.emit(event, payload),
 };

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -16,6 +16,7 @@ import { ProgressWorkflowActionsController } from '@controllers/progressView/Pro
 import { ProgressWorkflowFileActionsController } from '@controllers/progressView/ProgressWorkflowFileActionsController';
 import { getAgent } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import type { HostInteractions } from '@agent/runtime/HostInteractions';
 import type { RunCoordinatorBridge } from '@agent/runtime/runCoordinators';
 import {
   validateExecutionRequest,
@@ -101,6 +102,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     context: vscode.ExtensionContext,
     private readonly host: PromptHost,
     private readonly coordinators: ProgressViewCoordinatorBridge,
+    private readonly interactions: HostInteractions,
   ) {
     super('ProgressView', { trackActiveView: true });
 
@@ -263,11 +265,11 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
             return true;
           },
           handleBashApprovalAction: (message) =>
-            handleProgressViewBashApprovalAction(message),
+            this.handleBashApprovalAction(message),
           handlePlanApprovalAction: (message) =>
             this.handlePlanApprovalAction(message),
           handleUserQuestionAction: (message) =>
-            handleUserQuestionAction(message),
+            this.handleUserQuestionAction(message),
           handleAgentProposalAction: (message) =>
             this.agentProposalController.handleAction(message),
         },
@@ -294,7 +296,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       [PROGRESS_VIEW_COMMANDS.RETRY_STREAM_REQUEST]: (data) =>
         this.handleRetryStreamRequest(data),
       [PROGRESS_VIEW_COMMANDS.CANCEL_RETRY_REQUEST]: (data) => {
-        this.coordinators.cancelRetry(data.stream);
+        this.handleCancelRetryRequest(data);
       },
       [PROGRESS_VIEW_COMMANDS.USE_OWN_API_KEY]: (data) =>
         this.handleUseOwnApiKey(data),
@@ -588,7 +590,14 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         );
       },
       resolveProposal: (proposalId, result) => {
-        this.coordinators.resolveProposal(proposalId, result);
+        const resolved = this.interactions.resolve(proposalId, {
+          kind: 'proposal',
+          action: result.action,
+          value: result,
+        });
+        if (!resolved) {
+          this.coordinators.resolveProposal(proposalId, result);
+        }
       },
       onMissingProposal: (proposalId) => {
         this.logger.warn(
@@ -685,12 +694,66 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   private async handleRetryStreamRequest(
     data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.RETRY_STREAM_REQUEST>,
   ): Promise<void> {
+    if (
+      this.interactions.resolve(data.stream, {
+        kind: 'retry',
+        action: 'retry',
+        feedback: data.feedback,
+      })
+    ) {
+      return;
+    }
     const success = this.coordinators.triggerRetry(data.stream, data.feedback);
     if (!success) {
       await this.host.info(
         'No retryable request is available for this stream yet.',
       );
     }
+  }
+
+  private handleCancelRetryRequest(
+    data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.CANCEL_RETRY_REQUEST>,
+  ): void {
+    if (
+      this.interactions.resolve(data.stream, {
+        kind: 'retry',
+        action: 'cancel',
+      })
+    ) {
+      return;
+    }
+    this.coordinators.cancelRetry(data.stream);
+  }
+
+  private handleBashApprovalAction(
+    data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION>,
+  ): Promise<void> | void {
+    if (
+      this.interactions.resolve(data.requestId, {
+        kind: 'bash',
+        action: data.action,
+        feedback: data.feedback,
+      })
+    ) {
+      return;
+    }
+    return handleProgressViewBashApprovalAction(data);
+  }
+
+  private handleUserQuestionAction(
+    data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.USER_QUESTION_ACTION>,
+  ): Promise<void> | void {
+    if (
+      this.interactions.resolve(data.requestId, {
+        kind: 'userQuestion',
+        action: data.action,
+        value: data.answers,
+        feedback: data.feedback,
+      })
+    ) {
+      return;
+    }
+    return handleUserQuestionAction(data);
   }
 
   private async handleUseOwnApiKey(
@@ -792,6 +855,15 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION>,
   ): void {
     const { approvalId, action } = data;
+    if (
+      this.interactions.resolve(approvalId, {
+        kind: 'plan',
+        action,
+        feedback: data.feedback,
+      })
+    ) {
+      return;
+    }
     switch (action) {
       case 'approve':
         this.coordinators.resolvePlanApproval(approvalId, {

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -18,6 +18,7 @@ import {
 } from '@common/webview';
 import { workspaceSM } from '@common/state';
 import { bus } from '@eventBus/ProgressEventBus';
+import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { VscodePromptHost } from '@frontend/hosts/VscodePromptHost';
 import { createChannelTrace } from '@logger';
 import {
@@ -52,6 +53,7 @@ import {
 } from '@tools/inquiry/externalInquiryStorage';
 
 import { ProgressViewMessageHandler } from './ProgressViewMessageHandler';
+import { createExtensionHostInteractions } from './extensionHostInteractions';
 
 import type { MainViewProvider } from '../MainViewProvider';
 
@@ -96,6 +98,7 @@ export class ProgressViewProvider
 
   private _sidebarWebviewGetter?: () => vscode.Webview | undefined;
   private _mainViewProvider?: MainViewProvider;
+  private readonly detachHostInteractions: () => void;
 
   private approvalHandlers!: ApprovalRequestHandlerSet;
 
@@ -166,7 +169,15 @@ export class ProgressViewProvider
       context,
       new VscodePromptHost(),
       defaultSession().coordinators,
+      defaultSession().interactions,
     );
+    this.detachHostInteractions = defaultSession().useHostInteractions(
+      createExtensionHostInteractions({
+        runtimeHost: extensionAgentRuntimeHost,
+        getApprovalHandlers: () => this.approvalHandlers,
+      }),
+    );
+    this._disposables.push({ dispose: this.detachHostInteractions });
 
     ProgressViewProvider._instance = this;
     setProgressViewBridge(this);

--- a/packages/extension/src/progressView/extensionHostInteractions.ts
+++ b/packages/extension/src/progressView/extensionHostInteractions.ts
@@ -1,0 +1,307 @@
+import { nanoid } from 'nanoid';
+
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type {
+  HostBashApprovalRequest,
+  HostBashApprovalResult,
+  HostInteractionResolution,
+  HostInteractions,
+  HostPlanApprovalRequest,
+  HostRetryRequest,
+  HostUserQuestionResult,
+  PendingHostInteraction,
+} from '@agent/runtime/HostInteractions';
+import type { PlanApprovalResult } from '@agent/runtime/PlanApprovalCoordinator';
+import type { ProposalResult } from '@agent/runtime/AgentProposalCoordinator';
+import type { RetryResult } from '@agent/runtime/RetryRequestCoordinator';
+import { nativeRequestApproval } from '@frontend/approval/nativeToolEditApproval';
+import type {
+  AgentProposalPermission,
+  StreamTabId,
+  UserQuestionAnswers,
+} from '@shared/schemas';
+import type { ApprovalRequestHandlerSet } from '@shared/progressView/backend/progressBackendUiConfig';
+import type {
+  ToolEditApprovalRequest,
+  ToolEditApprovalResult,
+} from '@platform/interfaces/toolEditApproval';
+
+export interface ExtensionHostInteractionsOptions {
+  runtimeHost: AgentRuntimeHost;
+  getApprovalHandlers(): ApprovalRequestHandlerSet;
+}
+
+type PendingKind = 'bash' | 'plan' | 'proposal' | 'retry' | 'userQuestion';
+
+interface PendingExtensionInteraction<T> extends PendingHostInteraction {
+  readonly kind: PendingKind;
+  readonly settle: (value: T) => void;
+}
+
+type PendingExtensionInteractionValue =
+  | HostBashApprovalResult
+  | PlanApprovalResult
+  | ProposalResult
+  | RetryResult
+  | HostUserQuestionResult;
+
+export function createExtensionHostInteractions(
+  options: ExtensionHostInteractionsOptions,
+): HostInteractions {
+  const pendingRequests = new Map<
+    string,
+    PendingExtensionInteraction<PendingExtensionInteractionValue>
+  >();
+
+  const handlers = () => options.getApprovalHandlers();
+
+  const activateStream = (streamId?: StreamTabId | null) => {
+    options.runtimeHost.emit('requestEnsureProgressView', {});
+    if (streamId) {
+      options.runtimeHost.emit('setActiveStream', { streamId });
+    }
+  };
+
+  const showPending = <T extends PendingExtensionInteractionValue>(
+    pending: Omit<PendingExtensionInteraction<T>, 'settle'>,
+    show: () => void,
+  ): Promise<T> => {
+    return new Promise<T>((resolve) => {
+      pendingRequests.set(pending.id, {
+        ...pending,
+        settle: resolve as (value: PendingExtensionInteractionValue) => void,
+      });
+      show();
+    });
+  };
+
+  const resolvePending = <T extends PendingExtensionInteractionValue>(
+    requestId: string,
+    expectedKind: PendingKind,
+    value: T,
+    resolveUi: () => void,
+  ): boolean => {
+    const pending = pendingRequests.get(requestId);
+    if (!pending || pending.kind !== expectedKind) return false;
+    pendingRequests.delete(requestId);
+    pending.settle(value);
+    resolveUi();
+    return true;
+  };
+
+  const releasePending = (
+    pending: PendingExtensionInteraction<PendingExtensionInteractionValue>,
+  ): void => {
+    pendingRequests.delete(pending.id);
+    switch (pending.kind) {
+      case 'bash':
+        handlers().bash.resolve(pending.id);
+        pending.settle({ accepted: false });
+        break;
+      case 'plan':
+        handlers().planApproval.resolve(pending.id);
+        pending.settle({ action: 'reject' });
+        break;
+      case 'proposal':
+        handlers().agentProposal.resolve(pending.id);
+        pending.settle({ action: 'reject' });
+        break;
+      case 'retry':
+        handlers().retry.resolve(pending.id);
+        pending.settle({ action: 'cancel' });
+        break;
+      case 'userQuestion':
+        handlers().userQuestion.resolve(pending.id);
+        pending.settle({ submitted: false });
+        break;
+    }
+  };
+
+  return {
+    requestToolEditApproval(
+      request: ToolEditApprovalRequest,
+    ): Promise<ToolEditApprovalResult> {
+      return nativeRequestApproval(request);
+    },
+
+    requestBashApproval(
+      request: HostBashApprovalRequest,
+    ): Promise<HostBashApprovalResult> {
+      const requestId = `bash-${nanoid()}`;
+      const streamId = request.streamId ?? '';
+      activateStream(request.streamId);
+      return showPending<HostBashApprovalResult>(
+        { id: requestId, kind: 'bash', streamId },
+        () =>
+          handlers().bash.show({
+            requestId,
+            command: request.command,
+            ...(request.cwd ? { cwd: request.cwd } : {}),
+            allowBypass: true,
+            streamId,
+          }),
+      );
+    },
+
+    requestPlanApproval(
+      request: HostPlanApprovalRequest,
+    ): Promise<PlanApprovalResult> {
+      activateStream(request.streamId);
+      return showPending<PlanApprovalResult>(
+        {
+          id: request.approvalId,
+          kind: 'plan',
+          streamId: request.streamId,
+        },
+        () => handlers().planApproval.show(request),
+      );
+    },
+
+    requestAgentProposal(
+      request: AgentProposalPermission,
+    ): Promise<ProposalResult> {
+      activateStream(request.streamId);
+      return showPending<ProposalResult>(
+        {
+          id: request.proposalId,
+          kind: 'proposal',
+          streamId: request.streamId,
+        },
+        () => handlers().agentProposal.show(request),
+      );
+    },
+
+    requestRetry(request: HostRetryRequest): Promise<RetryResult> {
+      activateStream(request.streamId);
+      return showPending<RetryResult>(
+        {
+          id: request.streamId,
+          kind: 'retry',
+          streamId: request.streamId,
+        },
+        () => handlers().retry.show(request),
+      );
+    },
+
+    askUserQuestion(
+      request: Parameters<NonNullable<HostInteractions['askUserQuestion']>>[0],
+    ): Promise<HostUserQuestionResult> {
+      activateStream(request.streamId || undefined);
+      return showPending<HostUserQuestionResult>(
+        {
+          id: request.requestId,
+          kind: 'userQuestion',
+          streamId: request.streamId,
+        },
+        () => handlers().userQuestion.show(request),
+      );
+    },
+
+    async openExternalInquiry(request) {
+      activateStream(request.streamId || undefined);
+      handlers().externalInquiry.show(request);
+      return { threadId: request.threadId };
+    },
+
+    handleProgressEvent: () => false,
+
+    pending(): readonly PendingHostInteraction[] {
+      return [...pendingRequests.values()].map(({ id, kind, streamId }) => ({
+        id,
+        kind,
+        streamId,
+      }));
+    },
+
+    resolve(requestId: string, result: HostInteractionResolution): boolean {
+      switch (result.kind) {
+        case 'bash':
+          return resolvePending<HostBashApprovalResult>(
+            requestId,
+            'bash',
+            {
+              accepted: result.action === 'approve',
+              userMessage:
+                result.action === 'reject'
+                  ? result.feedback?.trim()
+                  : undefined,
+            },
+            () => handlers().bash.resolve(requestId),
+          );
+        case 'plan':
+          return resolvePending<PlanApprovalResult>(
+            requestId,
+            'plan',
+            toPlanApprovalResult(result),
+            () => handlers().planApproval.resolve(requestId),
+          );
+        case 'proposal':
+          return resolvePending<ProposalResult>(
+            requestId,
+            'proposal',
+            toProposalResult(result),
+            () => handlers().agentProposal.resolve(requestId),
+          );
+        case 'retry':
+          return resolvePending<RetryResult>(
+            requestId,
+            'retry',
+            result.action === 'retry'
+              ? { action: 'retry', feedback: result.feedback }
+              : { action: 'cancel' },
+            () => handlers().retry.resolve(requestId),
+          );
+        case 'userQuestion':
+          return resolvePending<HostUserQuestionResult>(
+            requestId,
+            'userQuestion',
+            {
+              submitted: result.action === 'submit',
+              answers:
+                result.action === 'submit'
+                  ? (result.value as UserQuestionAnswers | undefined)
+                  : undefined,
+              feedback:
+                result.action === 'submit' ? undefined : result.feedback,
+            },
+            () => handlers().userQuestion.resolve(requestId),
+          );
+        default:
+          return false;
+      }
+    },
+
+    cancelForStream(streamId: StreamTabId): void {
+      for (const pending of [...pendingRequests.values()]) {
+        if (pending.streamId === streamId) {
+          releasePending(pending);
+        }
+      }
+    },
+
+    dispose(): void {
+      for (const pending of [...pendingRequests.values()]) {
+        releasePending(pending);
+      }
+    },
+  };
+}
+
+function toPlanApprovalResult(
+  result: HostInteractionResolution,
+): PlanApprovalResult {
+  if (result.action === 'approve') return { action: 'approve' };
+  if (result.action === 'approve_and_goal')
+    return { action: 'approve_and_goal' };
+  return { action: 'reject', feedback: result.feedback };
+}
+
+function toProposalResult(result: HostInteractionResolution): ProposalResult {
+  const value = result.value as ProposalResult | undefined;
+  if (value?.action === 'approve') return value;
+  if (value?.action === 'setup') return value;
+  if (value?.action === 'reject') return value;
+  if (result.action === 'setup') return { action: 'setup' };
+  if (result.action === 'approve') return { action: 'approve' };
+  return { action: 'reject', feedback: result.feedback };
+}

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createExtensionHostInteractions } from '@progressView/extensionHostInteractions';
+import type { StreamTabId } from '@shared/schemas';
+import type { ApprovalRequestHandlerSet } from '@shared/progressView/backend/progressBackendUiConfig';
+
+const mocks = vi.hoisted(() => ({
+  nativeRequestApproval: vi.fn(),
+}));
+
+vi.mock('@frontend/approval/nativeToolEditApproval', () => ({
+  nativeRequestApproval: mocks.nativeRequestApproval,
+}));
+
+interface RecordingApprovalHandler<T extends { streamId: string }> {
+  readonly show: ReturnType<typeof vi.fn>;
+  readonly resolve: ReturnType<typeof vi.fn>;
+  readonly replay: ReturnType<typeof vi.fn>;
+  readonly get: ReturnType<typeof vi.fn>;
+  readonly hasPendingForStream: ReturnType<typeof vi.fn>;
+  readonly releaseForStream: ReturnType<typeof vi.fn>;
+  readonly clear: ReturnType<typeof vi.fn>;
+  readonly pendingSize: number;
+}
+
+function handler<
+  T extends { streamId: string },
+>(): RecordingApprovalHandler<T> {
+  return {
+    show: vi.fn(),
+    resolve: vi.fn(),
+    replay: vi.fn(),
+    get: vi.fn(),
+    hasPendingForStream: vi.fn(() => false),
+    releaseForStream: vi.fn(),
+    clear: vi.fn(),
+    pendingSize: 0,
+  };
+}
+
+function createHandlers(): ApprovalRequestHandlerSet {
+  return {
+    toolEdit: handler(),
+    bash: handler(),
+    retry: handler(),
+    agentProposal: handler(),
+    planApproval: handler(),
+    externalInquiry: handler(),
+    userQuestion: handler(),
+  } as unknown as ApprovalRequestHandlerSet;
+}
+
+function createRuntimeHost() {
+  return { emit: vi.fn() };
+}
+
+describe('createExtensionHostInteractions', () => {
+  it('shows and resolves plan approvals through existing handlers', async () => {
+    const runtimeHost = createRuntimeHost();
+    const handlers = createHandlers();
+    const interactions = createExtensionHostInteractions({
+      runtimeHost,
+      getApprovalHandlers: () => handlers,
+    });
+
+    const resultPromise = interactions.requestPlanApproval?.({
+      approvalId: 'plan-a',
+      streamId: 'stream-a' as StreamTabId,
+      goalEnabled: true,
+      plan: { objective: 'Prove the compactness lemma.' },
+    });
+
+    expect(resultPromise).toBeDefined();
+    expect(runtimeHost.emit).toHaveBeenCalledWith(
+      'requestEnsureProgressView',
+      {},
+    );
+    expect(runtimeHost.emit).toHaveBeenCalledWith('setActiveStream', {
+      streamId: 'stream-a',
+    });
+    expect(handlers.planApproval.show).toHaveBeenCalledWith({
+      approvalId: 'plan-a',
+      streamId: 'stream-a',
+      goalEnabled: true,
+      plan: { objective: 'Prove the compactness lemma.' },
+    });
+    expect(interactions.pending()).toEqual([
+      { id: 'plan-a', kind: 'plan', streamId: 'stream-a' },
+    ]);
+
+    expect(
+      interactions.resolve('plan-a', {
+        kind: 'plan',
+        action: 'approve_and_goal',
+      }),
+    ).toBe(true);
+
+    await expect(resultPromise).resolves.toEqual({
+      action: 'approve_and_goal',
+    });
+    expect(handlers.planApproval.resolve).toHaveBeenCalledWith('plan-a');
+    expect(interactions.pending()).toEqual([]);
+  });
+
+  it('cancels pending retry requests for a removed stream', async () => {
+    const runtimeHost = createRuntimeHost();
+    const handlers = createHandlers();
+    const interactions = createExtensionHostInteractions({
+      runtimeHost,
+      getApprovalHandlers: () => handlers,
+    });
+
+    const resultPromise = interactions.requestRetry?.({
+      streamId: 'stream-a' as StreamTabId,
+      operation: 'Model invocation',
+    });
+
+    interactions.cancelForStream('stream-a' as StreamTabId);
+
+    await expect(resultPromise).resolves.toEqual({ action: 'cancel' });
+    expect(handlers.retry.resolve).toHaveBeenCalledWith('stream-a');
+  });
+
+  it('shows external inquiries without waiting for a user decision', async () => {
+    const runtimeHost = createRuntimeHost();
+    const handlers = createHandlers();
+    const interactions = createExtensionHostInteractions({
+      runtimeHost,
+      getApprovalHandlers: () => handlers,
+    });
+
+    await expect(
+      interactions.openExternalInquiry?.({
+        requestId: 'thread-a',
+        threadId: 'thread-a',
+        question: 'Which convention should be used?',
+        allowBypass: false,
+        streamId: 'stream-a' as StreamTabId,
+        mode: 'new',
+      }),
+    ).resolves.toEqual({ threadId: 'thread-a' });
+
+    expect(handlers.externalInquiry.show).toHaveBeenCalledWith({
+      requestId: 'thread-a',
+      threadId: 'thread-a',
+      question: 'Which convention should be used?',
+      allowBypass: false,
+      streamId: 'stream-a',
+      mode: 'new',
+    });
+    expect(interactions.pending()).toEqual([]);
+  });
+
+  it('delegates tool edit approval to the native VS Code port', async () => {
+    const nativeResult = { accepted: true };
+    mocks.nativeRequestApproval.mockResolvedValue(nativeResult);
+    const interactions = createExtensionHostInteractions({
+      runtimeHost: createRuntimeHost(),
+      getApprovalHandlers: createHandlers,
+    });
+    const request = {
+      path: 'paper.tex',
+      originalContent: 'A',
+      proposedContent: 'B',
+      sourceTool: 'edit',
+      streamId: 'stream-a' as StreamTabId,
+    };
+
+    await expect(interactions.requestToolEditApproval?.(request)).resolves.toBe(
+      nativeResult,
+    );
+    expect(mocks.nativeRequestApproval).toHaveBeenCalledWith(request);
+  });
+});

--- a/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
+++ b/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - agent runtime
 import type { RunCoordinatorBridge } from '@agent/runtime/runCoordinators';
+import type { HostInteractions } from '@agent/runtime/HostInteractions';
 
 // Local imports - progress view
 import { ProgressViewMessageHandler } from '@progressView/ProgressViewMessageHandler';
@@ -63,13 +64,32 @@ function createCoordinatorBridge(
   };
 }
 
+function createHostInteractions(
+  overrides: Partial<HostInteractions> = {},
+): HostInteractions {
+  return {
+    handleProgressEvent: vi.fn(() => false),
+    pending: vi.fn(() => []),
+    resolve: vi.fn(() => false),
+    cancelForStream: vi.fn(),
+    ...overrides,
+  };
+}
+
 function createMessageHandler(
   provider: ProgressViewProvider,
   context: vscode.ExtensionContext,
   host = new FakePromptHost(),
   coordinators = createCoordinatorBridge(),
+  interactions = createHostInteractions(),
 ): ProgressViewMessageHandler {
-  return new ProgressViewMessageHandler(provider, context, host, coordinators);
+  return new ProgressViewMessageHandler(
+    provider,
+    context,
+    host,
+    coordinators,
+    interactions,
+  );
 }
 
 function createCoordinatorHandler(
@@ -268,6 +288,48 @@ describe('progress-view onboarding refresh wiring', () => {
     expect(coordinators.cancelRetry).toHaveBeenCalledWith('stream-a');
   });
 
+  it('resolves retry requests through host interactions before coordinators', async () => {
+    const interactions = createHostInteractions({
+      resolve: vi.fn(() => true),
+    });
+    const coordinators = createCoordinatorBridge();
+    const directHandler = createMessageHandler(
+      createProgressViewProvider(),
+      createExtensionContext(),
+      new FakePromptHost(),
+      coordinators,
+      interactions,
+    );
+
+    await directHandler.handleMessage(
+      {
+        command: PROGRESS_VIEW_COMMANDS.RETRY_STREAM_REQUEST,
+        stream: 'stream-a',
+        feedback: 'try the other branch',
+      },
+      createWebviewView(),
+    );
+    await directHandler.handleMessage(
+      {
+        command: PROGRESS_VIEW_COMMANDS.CANCEL_RETRY_REQUEST,
+        stream: 'stream-a',
+      },
+      createWebviewView(),
+    );
+
+    expect(interactions.resolve).toHaveBeenCalledWith('stream-a', {
+      kind: 'retry',
+      action: 'retry',
+      feedback: 'try the other branch',
+    });
+    expect(interactions.resolve).toHaveBeenCalledWith('stream-a', {
+      kind: 'retry',
+      action: 'cancel',
+    });
+    expect(coordinators.triggerRetry).not.toHaveBeenCalled();
+    expect(coordinators.cancelRetry).not.toHaveBeenCalled();
+  });
+
   it('reports missing retry requests from the injected coordinators', async () => {
     const context = createExtensionContext();
     const provider = createProgressViewProvider();
@@ -317,6 +379,42 @@ describe('progress-view onboarding refresh wiring', () => {
     });
   });
 
+  it('resolves agent proposal actions through host interactions before coordinators', async () => {
+    const interactions = createHostInteractions({
+      resolve: vi.fn(() => true),
+    });
+    const coordinators = createCoordinatorBridge();
+    const handler = createMessageHandler(
+      createProgressViewProvider(),
+      createExtensionContext(),
+      new FakePromptHost(),
+      coordinators,
+      interactions,
+    );
+
+    await handler.handleMessage(
+      {
+        command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
+        proposalId: 'proposal-a',
+        action: 'approve',
+        model: 'gemini31p',
+        agent: 'critic',
+      },
+      createWebviewView(),
+    );
+
+    expect(interactions.resolve).toHaveBeenCalledWith('proposal-a', {
+      kind: 'proposal',
+      action: 'approve',
+      value: {
+        action: 'approve',
+        model: 'gemini31p',
+        agent: 'critic',
+      },
+    });
+    expect(coordinators.resolveProposal).not.toHaveBeenCalled();
+  });
+
   it('routes plan approval actions through the injected coordinators', async () => {
     const { coordinators, handler } = createCoordinatorHandler();
 
@@ -334,6 +432,37 @@ describe('progress-view onboarding refresh wiring', () => {
       action: 'reject',
       feedback: 'state the invariant first',
     });
+  });
+
+  it('resolves plan approvals through host interactions before coordinators', async () => {
+    const interactions = createHostInteractions({
+      resolve: vi.fn(() => true),
+    });
+    const coordinators = createCoordinatorBridge();
+    const handler = createMessageHandler(
+      createProgressViewProvider(),
+      createExtensionContext(),
+      new FakePromptHost(),
+      coordinators,
+      interactions,
+    );
+
+    await handler.handleMessage(
+      {
+        command: PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION,
+        approvalId: 'plan-a',
+        action: 'reject',
+        feedback: 'state the invariant first',
+      },
+      createWebviewView(),
+    );
+
+    expect(interactions.resolve).toHaveBeenCalledWith('plan-a', {
+      kind: 'plan',
+      action: 'reject',
+      feedback: 'state the invariant first',
+    });
+    expect(coordinators.resolvePlanApproval).not.toHaveBeenCalled();
   });
 
   it('delegates onboarding refresh through the main view provider', async () => {


### PR DESCRIPTION
## Summary

This is the extension slice of Stage 4 for #6967. It ports the VS Code extension runtime path to the session-scoped `HostInteractions` abstraction after the CLI and desktop slices have already landed.

Changes:

- Install `defaultSession().interactions` on `extensionAgentRuntimeHost`.
- Add `createExtensionHostInteractions`, an extension adapter over the existing progress-view approval handler set.
- Install the adapter from `ProgressViewProvider` for the provider lifetime.
- Resolve retry, bash approval, plan approval, agent proposal, and user-question actions through the interaction port first, while preserving the existing coordinator/module fallback paths.
- Delegate tool-edit approval to the existing VS Code native diff approval port.
- Keep external inquiry non-blocking and show-only.
- Preserve renderer IPC/message shapes.

This completes the three host ports needed before the Stage 4 zero-grep cleanup. The remaining work after this PR is to remove the temporary legacy progress-event/coordinator fallback once the zero-grep gate confirms there are no runtime callers left on the old path.

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `corepack pnpm exec eslint packages/extension/src/frontend/agentRuntime/extensionAgentRuntimeHost.ts packages/extension/src/progressView/extensionHostInteractions.ts packages/extension/src/progressView/ProgressViewProvider.ts packages/extension/src/progressView/ProgressViewMessageHandler.ts src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts`
- `npm run compile:fast`
- `npm run lint` (passes with the pre-existing import-order warning in `packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts`)
- `npm test`
- `git diff --check`

The focused progress-view tests emit the existing repeated-listener warning from constructing many progress handlers in one process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches approval/retry/plan/proposal/user-question resolution paths with a dual fallback to legacy coordinators; behavior should match today but mistakes could leave prompts stuck or skip retries.
> 
> **Overview**
> The VS Code extension now routes agent runtime user prompts through the session-scoped **`HostInteractions`** port (Stage 4), matching CLI/desktop.
> 
> **`extensionAgentRuntimeHost`** exposes `defaultSession().interactions`. **`ProgressViewProvider`** registers **`createExtensionHostInteractions`** for the provider lifetime via `useHostInteractions`, wiring the existing progress-view approval handler set (show/replay/resolve UI) into promise-based request APIs for bash, plan, proposal, retry, and user questions; tool edits still go through native VS Code diff approval; external inquiry stays show-only and non-blocking.
> 
> **`ProgressViewMessageHandler`** takes `HostInteractions` and tries `interactions.resolve` first for retry, bash, plan, proposal, and user-question IPC actions, falling back to coordinators/legacy handlers when nothing is pending.
> 
> New vitest coverage exercises the adapter and the interactions-first routing in the message handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1df7d16ca0b2175b5acb525e35d4a3a10ca82fc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->