### PR TITLE
refactor(modelHandlers): streaming-catch template method across 5 provider handlers

### DIFF
--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -24,7 +24,7 @@ import type { MediaEntry } from '@agent/utils/mediaTypes';
 // Local imports - common
 import {
   attachStreamDiagnostics,
-  annotateStreamFailure,
+  handleStreamingFailure,
   trackStreamConnect,
   takeTail,
   isUserAbort,
@@ -664,69 +664,77 @@ export class ModelHandlerAnthropic extends ModelHandler<
         // Store thinking blocks for API conversation continuation
         this.processThinkingBlock(response);
       } catch (streamError) {
-        tagAnthropicSdkError(streamError, this.config.provider);
+        return handleStreamingFailure(streamError, {
+          // No finalizeOnError hook: Anthropic finalizes the stream handler
+          // unconditionally in the `finally` block below (it also needs to
+          // run on the success path), not as a catch-only step.
+          partialTail: () =>
+            extractPartialTextTail(
+              stream.currentMessage,
+              PARTIAL_TEXT_TAIL_MAX,
+            ),
+          retryEligible: (tail) => connect.isConnected() || tail.length > 0,
+          decorateError: (err, partialText) => {
+            tagAnthropicSdkError(err, this.config.provider);
 
-        const diagnostics = streamHandler.getDiagnostics();
-        const partialText = extractPartialTextTail(
-          stream.currentMessage,
-          PARTIAL_TEXT_TAIL_MAX,
-        );
-        const requestId = stream.request_id;
+            const diagnostics = streamHandler.getDiagnostics();
+            const requestId = stream.request_id;
 
-        // Wrap only non-APIError, non-abort stream failures that happened
-        // before message_start. APIError subclasses carry status/headers/
-        // requestID/type needed for retry classification; aborts are
-        // identified through the metadata tag attached above (isUserAbort),
-        // which wrapping would hide. Gate on diagnostics.messageStartReceived
-        // (tracked from the actual message_start SSE event) rather than
-        // stream.currentMessage, which the SDK does not keep populated once
-        // finalMessage() has settled — using it here previously mislabeled
-        // post-message_start failures (e.g. the message_stop guard above) as
-        // "closed before message_start", clobbering the more accurate error.
-        const isAbort = isUserAbort(streamError);
-        let enrichedError: unknown = streamError;
-        if (
-          !diagnostics.messageStartReceived &&
-          streamError instanceof Error &&
-          !(streamError instanceof AnthropicAPIError) &&
-          !isAbort
-        ) {
-          enrichedError = new Error(
-            `Stream closed before message_start after ${diagnostics.elapsedSecs}s ` +
-              `(${diagnostics.eventsProcessed} events). ` +
-              `Likely connection dropped before the API responded.`,
-            { cause: streamError },
-          );
-        }
+            // Wrap only non-APIError, non-abort stream failures that
+            // happened before message_start. APIError subclasses carry
+            // status/headers/requestID/type needed for retry classification;
+            // aborts are identified through the metadata tag attached above
+            // (isUserAbort), which wrapping would hide. Gate on
+            // diagnostics.messageStartReceived (tracked from the actual
+            // message_start SSE event) rather than stream.currentMessage,
+            // which the SDK does not keep populated once finalMessage() has
+            // settled — using it here previously mislabeled post-
+            // message_start failures (e.g. the message_stop guard above) as
+            // "closed before message_start", clobbering the more accurate
+            // error.
+            const isAbort = isUserAbort(err);
+            let enrichedError: unknown = err;
+            if (
+              !diagnostics.messageStartReceived &&
+              err instanceof Error &&
+              !(err instanceof AnthropicAPIError) &&
+              !isAbort
+            ) {
+              enrichedError = new Error(
+                `Stream closed before message_start after ${diagnostics.elapsedSecs}s ` +
+                  `(${diagnostics.eventsProcessed} events). ` +
+                  `Likely connection dropped before the API responded.`,
+                { cause: err },
+              );
+            }
 
-        // detectRequestId() reads .request_id off the thrown error, so set it
-        // on whichever object we're throwing (the wrapper or the original).
-        if (requestId && enrichedError instanceof Error) {
-          (enrichedError as ErrorWithRequestId).request_id = requestId;
-        }
+            // detectRequestId() reads .request_id off the thrown error, so
+            // set it on whichever object we're throwing (the wrapper or the
+            // original).
+            if (requestId && enrichedError instanceof Error) {
+              (enrichedError as ErrorWithRequestId).request_id = requestId;
+            }
 
-        const logMessage = `Stream ${isAbort ? 'aborted' : 'failed'}`;
-        const logData = {
-          data: {
-            isUsingRelay: this.shouldUseServerSideKeys(),
-            baseUrl: this.getBaseUrl() ?? 'default',
-            model: this.config.fullName,
-            streamDiagnostics: diagnostics,
-            partialTextLength: partialText.length,
-            error: enrichedError,
+            const logMessage = `Stream ${isAbort ? 'aborted' : 'failed'}`;
+            const logData = {
+              data: {
+                isUsingRelay: this.shouldUseServerSideKeys(),
+                baseUrl: this.getBaseUrl() ?? 'default',
+                model: this.config.fullName,
+                streamDiagnostics: diagnostics,
+                partialTextLength: partialText.length,
+                error: enrichedError,
+              },
+            };
+            // The retry node owns user-facing failure reporting. Keep stream
+            // diagnostics available without showing a second visible failure
+            // row.
+            this.logger.debug(logMessage, logData);
+
+            attachStreamDiagnostics(enrichedError, diagnostics);
+            return enrichedError;
           },
-        };
-        // The retry node owns user-facing failure reporting. Keep stream
-        // diagnostics available without showing a second visible failure row.
-        this.logger.debug(logMessage, logData);
-
-        attachStreamDiagnostics(enrichedError, diagnostics);
-        annotateStreamFailure(
-          enrichedError,
-          partialText,
-          connect.isConnected() || partialText.length > 0,
-        );
-        throw enrichedError;
+        });
       } finally {
         // Always finalize stream handler to prevent memory leaks on error
         streamHandler.finalize();

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -26,7 +26,8 @@ import type { MediaEntry } from '@agent/utils/mediaTypes';
 import { K_SLICE } from '@agent/core/constants';
 import {
   getSdkErrorMessage,
-  annotateStreamFailure,
+  consumeStreamChunks,
+  handleStreamingFailure,
   takeTail,
   PARTIAL_TEXT_TAIL_MAX,
 } from '@common/errors/sdkErrorUtils';
@@ -362,13 +363,15 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         // the first thought/text part — the phase signal for this API.
         thinking = this.createThinkingStream();
         output = this.createOutputStream();
+        const thinkingStream = thinking;
+        const outputStream = output;
 
         let baseResponse: GenerateContentResponse | undefined;
         let latestCandidate: Candidate | undefined;
         const aggregatedParts: Part[] = [];
         let usageFromChunks: GenerateContentResponseUsageMetadata | undefined;
 
-        for await (const chunk of stream) {
+        await consumeStreamChunks(stream, (chunk) => {
           baseResponse ??= chunk;
           const candidate = chunk.candidates?.[0];
           if (candidate) {
@@ -377,7 +380,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
             aggregatedParts.push(...parts);
             for (const part of parts) {
               if (part.thought && isTextPart(part)) {
-                thinking.append(part.text);
+                thinkingStream.append(part.text);
               }
             }
           }
@@ -387,7 +390,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
             : '';
           if (chunkText) {
             aggregatedText += chunkText;
-            output.append(chunkText);
+            outputStream.append(chunkText);
           }
 
           if (chunk.usageMetadata) {
@@ -411,7 +414,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
               baseResponse.responseId = chunk.responseId;
             }
           }
-        }
+        });
 
         if (!baseResponse) {
           throw new Error('Stream produced no response');
@@ -469,61 +472,70 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       const response = await chat.sendMessage(sendParams);
       return { response };
     } catch (error) {
-      // Finalize the progress streams on error so the view does not hang in a
-      // loading state. Undefined on the non-streaming path; `finalize` is
-      // idempotent so a re-finalize after the success path is a no-op. No
-      // explicit final text so any chunks already streamed are preserved
-      // (passing `''` would overwrite the visible partial output).
-      thinking?.finalize(undefined);
-      output?.finalize();
-      // Error logging follows "log at the boundary" principle - Node's retryPrompt
-      // or execFallback will log the error once. We only add debug diagnostics here
-      // for specific error types that need additional context.
-      if (
-        error instanceof Error &&
-        error.message?.includes('request.contents[0].parts')
-      ) {
-        this.logger.debug(
-          'Potential issue with sendMessage parameter structure. Check conversion.',
-        );
-      }
-      if (error instanceof Error && error.message?.includes('SAFETY')) {
-        // SDK errors may include response metadata at runtime
-        const errorWithResponse = error as Error & {
-          response?: { promptFeedback?: unknown };
-        };
-        const promptFeedback = errorWithResponse.response?.promptFeedback;
-        const blockReason =
-          promptFeedback &&
-          typeof promptFeedback === 'object' &&
-          'blockReason' in promptFeedback
-            ? String((promptFeedback as { blockReason?: unknown }).blockReason)
-            : undefined;
-        const safetyDetail =
-          blockReason ??
-          (promptFeedback === undefined
-            ? undefined
-            : JSON.stringify(promptFeedback));
-        this.logger.warn(
-          `Content blocked by safety filter${safetyDetail ? `: ${safetyDetail}` : ''}.`,
-          {
-            data: promptFeedback,
-          },
-        );
-      }
-      // If the stream produced any text before failing, attach a tail to the
-      // error so the retry UI can show progress and future continuation logic
-      // can reference it. Google's SDK has no currentMessage accessor, so we
-      // rely on the manually accumulated buffer above.
-      // Google's SDK never reaches the SDK-retry boundary here, so this catch
-      // does not opt into flow-level auto-retry (retryEligible = false); it only
-      // lifts any accumulated tail onto the error for the retry UI.
-      annotateStreamFailure(
-        error,
-        aggregatedText ? takeTail(aggregatedText, PARTIAL_TEXT_TAIL_MAX) : '',
-        false,
-      );
-      throw error;
+      return handleStreamingFailure(error, {
+        // Finalize the progress streams on error so the view does not hang in
+        // a loading state. Undefined on the non-streaming path; `finalize` is
+        // idempotent so a re-finalize after the success path is a no-op. No
+        // explicit final text so any chunks already streamed are preserved
+        // (passing `''` would overwrite the visible partial output).
+        finalizeOnError: () => {
+          thinking?.finalize(undefined);
+          output?.finalize();
+        },
+        // If the stream produced any text before failing, attach a tail to
+        // the error so the retry UI can show progress and future
+        // continuation logic can reference it. Google's SDK has no
+        // currentMessage accessor, so we rely on the manually accumulated
+        // buffer above.
+        partialTail: () =>
+          aggregatedText ? takeTail(aggregatedText, PARTIAL_TEXT_TAIL_MAX) : '',
+        // Google's SDK never reaches the SDK-retry boundary here, so this
+        // catch does not opt into flow-level auto-retry — always false,
+        // unlike every other provider's `connected || tail` formula. It only
+        // lifts any accumulated tail onto the error for the retry UI.
+        retryEligible: () => false,
+        decorateError: (err) => {
+          // Error logging follows "log at the boundary" principle - Node's
+          // retryPrompt or execFallback will log the error once. We only add
+          // debug diagnostics here for specific error types that need
+          // additional context.
+          if (
+            err instanceof Error &&
+            err.message?.includes('request.contents[0].parts')
+          ) {
+            this.logger.debug(
+              'Potential issue with sendMessage parameter structure. Check conversion.',
+            );
+          }
+          if (err instanceof Error && err.message?.includes('SAFETY')) {
+            // SDK errors may include response metadata at runtime
+            const errorWithResponse = err as Error & {
+              response?: { promptFeedback?: unknown };
+            };
+            const promptFeedback = errorWithResponse.response?.promptFeedback;
+            const blockReason =
+              promptFeedback &&
+              typeof promptFeedback === 'object' &&
+              'blockReason' in promptFeedback
+                ? String(
+                    (promptFeedback as { blockReason?: unknown }).blockReason,
+                  )
+                : undefined;
+            const safetyDetail =
+              blockReason ??
+              (promptFeedback === undefined
+                ? undefined
+                : JSON.stringify(promptFeedback));
+            this.logger.warn(
+              `Content blocked by safety filter${safetyDetail ? `: ${safetyDetail}` : ''}.`,
+              {
+                data: promptFeedback,
+              },
+            );
+          }
+          return err;
+        },
+      });
     }
   }
 

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -18,7 +18,7 @@ import {
   buildErrorLogData,
   getSdkErrorMessage,
   isMissingFinishReasonError,
-  annotateStreamFailure,
+  handleStreamingFailure,
   trackStreamConnect,
   isUserAbort,
   PARTIAL_TEXT_TAIL_MAX,
@@ -432,39 +432,43 @@ export class ModelHandlerOpenAI<
       this.finalizeStreams(thinking, output, finalResponse);
       return finalResponse;
     } catch (streamError) {
-      // Finalize the progress streams on error so the progress view does not
-      // hang in a loading state (parity with the OpenRouter streaming path).
-      // No explicit final text so any chunks already streamed are preserved
-      // (passing `''` would overwrite the visible partial output). `finalize`
-      // is idempotent, so this is safe even if a partial finalize already ran.
-      thinking.finalize(undefined);
-      output.finalize();
-      // Tag at the boundary so abort identity survives wrapping and
-      // minification (mirrors the Anthropic stream catch).
-      tagOpenAISdkError(streamError, this.config.provider);
-      // On mid-stream failure, lift the partial content the SDK already
-      // accumulated (currentChatCompletionSnapshot) onto the error so the
-      // retry UI can show it and future continuation logic can reference
-      // the tail. Aborts are control flow; log at debug, skip warn.
-      const partialText = extractOpenAIPartialTail(
-        stream.currentChatCompletionSnapshot,
-        PARTIAL_TEXT_TAIL_MAX,
-      );
-      annotateStreamFailure(
-        streamError,
-        partialText,
-        connect.isConnected() || partialText.length > 0,
-      );
-      const isAbort = isUserAbort(streamError);
-      if (!isAbort) {
-        this.logger.warn('Stream failed', {
-          data: {
-            ...buildErrorLogData(streamError, { model: this.config.fullName }),
-            partialTextLength: partialText.length,
-          },
-        });
-      }
-      throw streamError;
+      return handleStreamingFailure(streamError, {
+        // Finalize the progress streams on error so the progress view does
+        // not hang in a loading state (parity with the OpenRouter streaming
+        // path). No explicit final text so any chunks already streamed are
+        // preserved (passing `''` would overwrite the visible partial
+        // output). `finalize` is idempotent, so this is safe even if a
+        // partial finalize already ran.
+        finalizeOnError: () => {
+          thinking.finalize(undefined);
+          output.finalize();
+        },
+        // On mid-stream failure, lift the partial content the SDK already
+        // accumulated (currentChatCompletionSnapshot) onto the error so the
+        // retry UI can show it and future continuation logic can reference
+        // the tail.
+        partialTail: () =>
+          extractOpenAIPartialTail(
+            stream.currentChatCompletionSnapshot,
+            PARTIAL_TEXT_TAIL_MAX,
+          ),
+        retryEligible: (tail) => connect.isConnected() || tail.length > 0,
+        decorateError: (err, tail) => {
+          // Tag at the boundary so abort identity survives wrapping and
+          // minification (mirrors the Anthropic stream catch).
+          tagOpenAISdkError(err, this.config.provider);
+          // Aborts are control flow; log at debug, skip warn.
+          if (!isUserAbort(err)) {
+            this.logger.warn('Stream failed', {
+              data: {
+                ...buildErrorLogData(err, { model: this.config.fullName }),
+                partialTextLength: tail.length,
+              },
+            });
+          }
+          return err;
+        },
+      });
     } finally {
       cleanup();
     }

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -22,7 +22,8 @@ import {
   isContextWindowError,
   isPreviousResponseIdError,
   isUserAbort,
-  annotateStreamFailure,
+  consumeStreamChunks,
+  handleStreamingFailure,
   attachFlowAutoRetryRequired,
   trackStreamConnect,
   type StreamConnectTracker,
@@ -1889,6 +1890,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       // Processor handles interleaved thinking and web search
       // GPT can: think → web_search → think more → web_search → text
       processor = this.createStreamProcessor();
+      const streamProcessor = processor;
 
       const retrieveAfterUnhandledStreamEvent = async (
         streamError: unknown,
@@ -1947,18 +1949,18 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
       let response: Response | undefined;
       try {
-        for await (const event of stream) {
+        await consumeStreamChunks(stream, (event) => {
           streamEventObserved = true;
           if (event.type === 'response.created') {
             responseId = event.response.id;
           }
-          processor.process(event);
+          streamProcessor.process(event);
           if (event.type === 'response.output_text.delta') {
             streamedText += event.delta;
           } else if (event.type === 'response.output_item.done') {
             streamedItems.push(event.item);
           }
-        }
+        });
       } catch (streamError) {
         response = await retrieveAfterUnhandledStreamEvent(streamError);
       }
@@ -2000,19 +2002,24 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       );
       return { response, updatedMessages: ctx.compactedMessages };
     } catch (error) {
-      // Finalize the progress streams on error so the view does not hang in a
-      // loading state (no-op if the stream never opened or already finalized).
-      processor?.abort();
-      // Attach a capped tail of any streamed text before it propagates so the
-      // retry UI receives the same structured error shape downstream.
-      annotateStreamFailure(
-        error,
-        streamedText ? takeTail(streamedText, PARTIAL_TEXT_TAIL_MAX) : '',
-        (connect?.isConnected() ?? false) ||
+      return handleStreamingFailure(error, {
+        // Finalize the progress streams on error so the view does not hang
+        // in a loading state (no-op if the stream never opened or already
+        // finalized). Note: this only runs when `recover` above (the
+        // `retrieveAfterUnhandledStreamEvent` polling fallback attempted at
+        // both the event-loop catch and the `finalResponse()` catch) was
+        // either unavailable or itself failed — a successful recovery
+        // returns a valid `response` and never reaches this catch.
+        finalizeOnError: () => processor?.abort(),
+        // Attach a capped tail of any streamed text before it propagates so
+        // the retry UI receives the same structured error shape downstream.
+        partialTail: () =>
+          streamedText ? takeTail(streamedText, PARTIAL_TEXT_TAIL_MAX) : '',
+        retryEligible: () =>
+          (connect?.isConnected() ?? false) ||
           streamEventObserved ||
           streamedText.length > 0,
-      );
-      throw error;
+      });
     } finally {
       connect?.cleanup();
     }

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -14,8 +14,9 @@ import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import type { MediaEntry } from '@agent/utils/mediaTypes';
 import { K_SLICE } from '@agent/core/constants';
 import {
-  annotateStreamFailure,
+  consumeStreamChunks,
   detectStatusCode,
+  handleStreamingFailure,
   takeTail,
   PARTIAL_TEXT_TAIL_MAX,
 } from '@common/errors/sdkErrorUtils';
@@ -244,13 +245,15 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
         // starts fire (if ever) at the first reasoning/content delta.
         thinking = this.createThinkingStream();
         output = this.createOutputStream();
+        const thinkingStream = thinking;
+        const outputStream = output;
 
-        for await (const chunk of stream) {
+        await consumeStreamChunks(stream, (chunk) => {
           const { contentDelta, reasoningDelta } =
             aggregator.consumeChunk(chunk);
-          if (reasoningDelta) thinking.append(reasoningDelta);
-          if (contentDelta) output.append(contentDelta);
-        }
+          if (reasoningDelta) thinkingStream.append(reasoningDelta);
+          if (contentDelta) outputStream.append(contentDelta);
+        });
 
         const response = aggregator.buildResponse();
         const finalReasoning = this.processThinkingBlock(response);
@@ -267,24 +270,21 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
         }
         return { response, updatedMessages };
       } catch (err) {
-        // Ensure progress streams are finalized on error to prevent
-        // the progress view from being stuck in a loading state. No explicit
-        // final text so any chunks already streamed are preserved (passing `''`
-        // would overwrite the visible partial output).
-        thinking?.finalize(undefined);
-        output?.finalize();
-        // Lift the accumulated partial text onto the error so the retry UI
-        // can show the tail (parity with the other streaming providers).
-        const partialTail = takeTail(
-          aggregator.partialContent,
-          PARTIAL_TEXT_TAIL_MAX,
-        );
-        annotateStreamFailure(
-          err,
-          partialTail,
-          streamConnected || partialTail.length > 0,
-        );
-        throw err;
+        return handleStreamingFailure(err, {
+          // Ensure progress streams are finalized on error to prevent the
+          // progress view from being stuck in a loading state. No explicit
+          // final text so any chunks already streamed are preserved (passing
+          // `''` would overwrite the visible partial output).
+          finalizeOnError: () => {
+            thinking?.finalize(undefined);
+            output?.finalize();
+          },
+          // Lift the accumulated partial text onto the error so the retry UI
+          // can show the tail (parity with the other streaming providers).
+          partialTail: () =>
+            takeTail(aggregator.partialContent, PARTIAL_TEXT_TAIL_MAX),
+          retryEligible: (tail) => streamConnected || tail.length > 0,
+        });
       }
     }
 

--- a/src/common/errors/sdkError/streamFailure.ts
+++ b/src/common/errors/sdkError/streamFailure.ts
@@ -83,3 +83,87 @@ export function annotateStreamFailure(
     attachFlowAutoRetryRequired(err);
   }
 }
+
+/**
+ * Drives an async-iterable provider stream, invoking `consume` once per chunk.
+ * A named extraction of the `for await (const chunk of stream) { ... }` loop
+ * every iterate-based streaming handler (OpenRouter, GoogleGenAI, and the
+ * event loop inside OpenAI Responses) previously hand-wrote inline. Handlers
+ * whose SDK drives consumption through its own event emitter instead of a
+ * plain async iterable (Anthropic's `attachToStream`, OpenAI chat completions'
+ * `stream.on('chunk', ...)`) do not use this — their "consume" hook is the
+ * listener they register directly with the SDK.
+ */
+export async function consumeStreamChunks<TChunk>(
+  stream: AsyncIterable<TChunk>,
+  consume: (chunk: TChunk) => void,
+): Promise<void> {
+  for await (const chunk of stream) {
+    consume(chunk);
+  }
+}
+
+/**
+ * Hooks for {@link handleStreamingFailure}, the shared tail of the mid-stream
+ * failure skeleton every provider handler's streaming catch block runs:
+ * finalize the in-flight progress streams, compute the partial-output tail,
+ * optionally enrich/tag/log the error, then annotate it and rethrow.
+ *
+ * Each hook is a thin accessor over state the handler already computed in its
+ * own catch block (stream diagnostics, aggregator buffers, connect trackers)
+ * — this function does not own stream consumption or recovery. Two carve-outs
+ * this deliberately does NOT try to unify (see callers for the exact
+ * preserved behavior):
+ *  - OpenAI Responses' `recover` path (polling fallback after an unhandled
+ *    SSE event) is attempted at two points *inside* the handler's own try
+ *    block, before this function's catch-tail ever runs; it only fires here
+ *    if recovery itself also failed.
+ *  - Each handler's `retryEligible` formula is preserved verbatim (they
+ *    differ three ways today: `connected||tail`, `connected||observed||tail`,
+ *    and GoogleGenAI's hardcoded `false`) — this function does not compute or
+ *    default the formula, only applies whatever the handler decided.
+ */
+export interface StreamingFailureHooks {
+  /**
+   * Finalizes in-flight progress streams so the progress view does not hang
+   * in a loading state (expected to be idempotent). Omit when the handler
+   * already finalizes unconditionally in a `finally` block (Anthropic).
+   */
+  finalizeOnError?: () => void;
+  /** Extracts the capped partial-output tail to attach to the error. */
+  partialTail: () => string;
+  /**
+   * Per-handler retry-eligibility formula, given the already-computed tail.
+   * Preserve each handler's exact current formula — do not unify.
+   */
+  retryEligible: (partialTail: string) => boolean;
+  /**
+   * Optional provider-specific error enrichment (tagging, wrapping, debug/warn
+   * logging) run after the tail is computed and before `annotateStreamFailure`.
+   * Returns the error to annotate and rethrow (the same reference if no
+   * wrapping is needed).
+   */
+  decorateError?: (err: unknown, partialTail: string) => unknown;
+}
+
+/**
+ * Runs the shared mid-stream failure skeleton: finalize → tail → decorate →
+ * annotate → rethrow. Call this as the last step of a provider handler's
+ * streaming catch block, in place of the previously hand-duplicated sequence.
+ */
+export function handleStreamingFailure(
+  err: unknown,
+  hooks: StreamingFailureHooks,
+): never {
+  hooks.finalizeOnError?.();
+  const partialTail = hooks.partialTail();
+  const decorated = hooks.decorateError
+    ? hooks.decorateError(err, partialTail)
+    : err;
+  annotateStreamFailure(
+    decorated,
+    partialTail,
+    hooks.retryEligible(partialTail),
+  );
+  throw decorated;
+}

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -25,7 +25,10 @@ export {
 export {
   type ConnectTrackableStream,
   type StreamConnectTracker,
+  type StreamingFailureHooks,
   annotateStreamFailure,
+  consumeStreamChunks,
+  handleStreamingFailure,
   trackStreamConnect,
 } from './sdkError/streamFailure';
 

--- a/src/test-kernel/agent/modelHandlers/GoogleGenAIStreamRetryEligibility.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleGenAIStreamRetryEligibility.vitest.ts
@@ -1,0 +1,136 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+import { createPartFromText, type Content } from '@google/genai';
+import {
+  DEFAULT_MODEL_CAPABILITIES,
+  ModelProvider,
+  type ModelConfig,
+} from 'llm-zoo';
+
+// Local imports - agent
+import type { AgentTrace } from '@agent/trace';
+import { ModelHandlerGoogleGenAI } from '@agent/modelHandlers/google/modelHandlerGoogleGenAI';
+
+// Local imports - common errors
+import {
+  detectPartialText,
+  requiresFlowAutoRetry,
+} from '@common/errors/sdkErrorUtils';
+
+function createConfig(): ModelConfig {
+  return {
+    name: 'test-google-model',
+    label: 'Test Google Model',
+    fullName: 'google/test',
+    shortName: 'google/test',
+    provider: ModelProvider.GOOGLE,
+    maxOutputTokens: 1024,
+    inputPrice: 0,
+    outputPrice: 0,
+    contextWindow: 4096,
+    capabilities: {
+      ...DEFAULT_MODEL_CAPABILITIES,
+      supportsTokenCounting: false,
+    },
+    openRouterOnly: false,
+  };
+}
+
+function createLoggerStub(): AgentTrace {
+  return {
+    debug: () => undefined,
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    openStream: () => ({
+      id: 'stream-1',
+      append: () => undefined,
+      finalize: (text?: string) => text ?? '',
+    }),
+  } as unknown as AgentTrace;
+}
+
+class StreamingGoogleHandler extends ModelHandlerGoogleGenAI {
+  override getStreamingConfig(): boolean {
+    return true;
+  }
+}
+
+function createStreamingHandler(): ModelHandlerGoogleGenAI {
+  const handler = new StreamingGoogleHandler(createConfig());
+  handler.setLogger(createLoggerStub());
+  handler.setOutputStreaming(true);
+  return handler;
+}
+
+/**
+ * A stream that yields one chunk of visible text, then throws mid-stream —
+ * simulating a dropped connection *after* content has already been produced.
+ * `streamConnected`-style formulas elsewhere (`connected || tail.length > 0`)
+ * would mark this retry-eligible; GoogleGenAI must not.
+ */
+function createFakeClientWithMidStreamFailure(
+  visibleText: string,
+  failure: Error,
+): any {
+  return {
+    chats: {
+      create: () => ({
+        sendMessageStream: async () =>
+          (async function* () {
+            const chunk: any = {
+              candidates: [
+                {
+                  content: {
+                    role: 'model',
+                    parts: [createPartFromText(visibleText)],
+                  },
+                },
+              ],
+            };
+            yield chunk;
+            throw failure;
+          })(),
+        sendMessage: async () => {
+          throw new Error(
+            'sendMessage should not be called when streaming is enabled',
+          );
+        },
+      }),
+    },
+    models: {},
+  };
+}
+
+describe('ModelHandlerGoogleGenAI streaming retry eligibility', () => {
+  it('never marks a mid-stream failure flow-auto-retry-eligible, even with a partial tail', async () => {
+    const handler = createStreamingHandler();
+    const failure = new Error('relay connection dropped mid-stream');
+
+    const messages: Content[] = [
+      { role: 'user', parts: [createPartFromText('Hi there')] },
+    ];
+
+    let caught: unknown;
+    try {
+      await handler.createResponse({
+        client: createFakeClientWithMidStreamFailure(
+          'partial text before the drop',
+          failure,
+        ),
+        messages,
+        temperature: 0,
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBe(failure);
+    // The tail must still be attached for the retry UI...
+    expect(detectPartialText(failure)).toBe('partial text before the drop');
+    // ...but GoogleGenAI's SDK never reaches the SDK-retry boundary, so this
+    // must stay false regardless of tail/connection state. A template that
+    // hardcoded `connected || tail.length > 0` would regress this to `true`.
+    expect(requiresFlowAutoRetry(failure)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #7083

## What changed

Extracts the duplicated mid-stream failure skeleton — finalize progress streams → compute partial tail → decorate/tag/log → `annotateStreamFailure` → rethrow — from the five streaming model handlers (anthropic, openai, openaiResponse, googleGenAI, openRouterNative) into two shared helpers in `src/common/errors/sdkError/streamFailure.ts`, alongside the existing `annotateStreamFailure`/`trackStreamConnect` extraction precedent:

- **`consumeStreamChunks(stream, consume)`** — a named extraction of the `for await (const chunk of stream) { ... }` loop used by the three iterate-based handlers (OpenRouter, GoogleGenAI, and OpenAI Responses' inner event loop). Anthropic and OpenAI chat-completions consume via SDK event listeners (`stream.on(...)`) instead of a manual loop, so they don't use this utility — their "consume" hook stays their own listener registration.
- **`handleStreamingFailure(err, hooks)`** — the shared catch-block tail, with hooks for:
  - `finalizeOnError?` — finalizes in-flight progress streams (optional: Anthropic finalizes unconditionally in a `finally` instead, so it omits this hook)
  - `partialTail` — extracts the capped partial-output tail
  - `retryEligible(tail)` — the per-handler retry-eligibility formula
  - `decorateError?(err, tail)` — optional provider-specific tagging/wrapping/logging before annotate

## The 5-hook design and how each quirk was preserved

The issue's "~5 hooks" (consume, partialTail, retryEligible, decorateError, recover) map onto this shape as follows:

- **`consume`** → `consumeStreamChunks`, a real shared loop utility (not just a documented convention) for the 3 handlers that iterate manually.
- **`partialTail` / `retryEligible` / `decorateError`** → hooks on `handleStreamingFailure`, exactly as named.
- **`recover`** → deliberately **not** threaded through the shared function. OpenAI Responses' `retrieveAfterUnhandledStreamEvent` polling fallback is invoked at its original two call sites *inside* the handler's own try block (once after the event-loop catch, once after the `finalResponse()` catch) — completely unchanged code. `handleStreamingFailure` only fires if recovery itself also fails, which matches the issue's note that "recover() must wrap the consume loop AND finalize, not just the outer catch."
- **GoogleGenAI's `retryEligible = false`** stays hardcoded as `retryEligible: () => false` (its SDK never reaches the SDK-retry boundary) — never computed via a shared `connected || tail` formula. Pinned by a new regression test, `GoogleGenAIStreamRetryEligibility.vitest.ts`, which drives a real mid-stream failure through `createResponse` and asserts `requiresFlowAutoRetry(err) === false` even with a non-empty tail. I verified the test actually catches a regression by temporarily hardcoding the formula to `true` and confirming the test fails, then reverted.
- **Each handler's exact `retryEligible` formula is preserved verbatim**: OpenRouter/OpenAI `connected || tail.length > 0`, OpenAI Responses `connected || observed || tail.length > 0`, GoogleGenAI `false`, Anthropic `connected || tail.length > 0`.
- **Anthropic landed last** (after the other 4 proved the template shape) and keeps every divergence: the finally-based `streamHandler.finalize()` (not routed through `finalizeOnError`, since it also needs to run on the success path), the pre-`message_start` wrapper-error enrichment, `request_id` attachment, `attachStreamDiagnostics`, and debug-level logging — all now living inside its `decorateError` hook, in the same relative order as before.

## Verification (zero behavior change)

- `npm run typecheck` (root `tsc --noEmit`, `tsconfig.test-kernel.json`, and each workspace package's typecheck) — clean.
- `npx eslint` on all changed files — clean.
- `npx prettier --check` — clean (applied `--write` once during the refactor).
- Full `vitest run` — **4925 tests passed** (4 pre-existing skips), including the identity- and log-sensitive `AnthropicStreamFailureLogging.vitest.ts` (`.rejects.toBe(providerError)`, exact `logger.debug` call shape) and `OpenAIResponseErrors.vitest.ts` / `OpenAIResponseBackgroundAbort.vitest.ts` suites, all passing unchanged.
- New `GoogleGenAIStreamRetryEligibility.vitest.ts` added and confirmed to fail under a deliberately-broken formula before reverting.

Migration order followed the issue's plan: openRouterNative → openai → googleGenAI → openaiResponse → anthropic (each verified individually via typecheck + that handler's test suite before moving on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shared error/retry annotation path for all major streaming providers; behavior is intended to be identical but regressions would affect retry UI and auto-retry eligibility.
> 
> **Overview**
> Pulls the repeated **finalize → partial tail → decorate → annotate → rethrow** path out of Anthropic, OpenAI chat, OpenAI Responses, Google GenAI, and OpenRouter streaming catches into **`handleStreamingFailure(err, hooks)`** in `src/common/errors/sdkError/streamFailure.ts`, re-exported from `sdkErrorUtils`.
> 
> Adds **`consumeStreamChunks`** for handlers that manually `for await` over streams (Google GenAI, OpenRouter native, OpenAI Responses event loop). Anthropic and OpenAI chat still consume via SDK listeners and only adopt the shared failure tail.
> 
> Each handler keeps its own behavior via hooks: optional **`finalizeOnError`**, **`partialTail`**, **`retryEligible`** (including Google’s hardcoded **`false`**), and **`decorateError`** (Anthropic pre-`message_start` wrapping, diagnostics, logging). OpenAI Responses’ in-handler **`recover`** polling is unchanged; the shared helper runs only when that path fails.
> 
> New **`GoogleGenAIStreamRetryEligibility.vitest.ts`** asserts partial text is still attached but flow auto-retry stays off after a mid-stream failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f733204201e8856a37578d4a4c6b3e5f4647f9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->