### PR TITLE
fix(tools): await ExternalInquiryTool's HostInteractions promise

### DIFF
--- a/src/test-kernel/tools/ExternalInquiryHostInteractionRejection.vitest.ts
+++ b/src/test-kernel/tools/ExternalInquiryHostInteractionRejection.vitest.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { setupPlatform } from '@test/support/setupPlatform';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
+import type { StreamTabId } from '@shared/schemas';
+import { ExternalInquiryTool } from '@tools/inquiry/ExternalInquiryTool';
+
+const STREAM = 'stream:inquiry-host-interaction' as StreamTabId;
+
+function createRuntimeHostWithRejectingInteraction(
+  reason: Error,
+): AgentRuntimeHost {
+  return {
+    emit: () => {},
+    interactions: {
+      handleProgressEvent: () => false,
+      pending: () => [],
+      resolve: () => false,
+      cancelForStream: () => {},
+      openExternalInquiry: () => Promise.reject(reason),
+    },
+  };
+}
+
+describe('ExternalInquiryTool host interaction dispatch', () => {
+  // Tool writes a new thread manifest to storage; keep state isolated.
+  setupPlatform();
+
+  it('surfaces a rejected openExternalInquiry() as a tool error instead of an unhandled rejection', async () => {
+    const runtimeHost = createRuntimeHostWithRejectingInteraction(
+      new Error('external inquiry panel unavailable'),
+    );
+
+    const result = await withRunContext(
+      createRunContext({ runtimeHost, streamId: STREAM }),
+      () =>
+        new ExternalInquiryTool().call({
+          command: 'ask',
+          question: 'Does a synchronous panel failure surface as a tool error?',
+        }),
+    );
+
+    // Before the fix, `void interaction` dropped the rejection: the promise
+    // was never awaited or attached to a .catch(), so the tool call proceeded
+    // to `status: 'executed'` and the rejection surfaced later as a process
+    // level unhandled rejection instead of a tool error result.
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('external inquiry panel unavailable');
+  });
+});

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -423,7 +423,7 @@ export class ExternalInquiryTool extends defineTool({
     if (!interaction) {
       throw new Error('HostInteractions.openExternalInquiry is required');
     }
-    void interaction;
+    await interaction;
 
     // Background Tasks panel: announce the open thread.
     const summary = await getThreadSummary(persisted.threadId);


### PR DESCRIPTION
Closes #7305

## What changed

`ExternalInquiryTool.executeAsk()` called `runtimeHost.interactions?.openExternalInquiry?.(permission)` and discarded the returned promise via `void interaction;` — the only one of the seven `HostInteractions` methods introduced in #7303 that didn't `await` its result. If the host's panel throws synchronously or the returned promise rejects (e.g. desktop's window is unavailable), the rejection became an unhandled promise rejection instead of surfacing through `BaseTool.call()`'s existing try/catch.

Fixed by awaiting the promise, matching the pattern used by `requestBashApproval`, `requestPlanApproval`, `requestAgentProposal`, `requestRetry`, `askUserQuestion`, and `requestToolEditApproval`.

## Test plan

- Added `src/test-kernel/tools/ExternalInquiryHostInteractionRejection.vitest.ts`, which mocks a rejecting `openExternalInquiry` and asserts the tool call resolves to `status: 'error'`. Verified this test fails against the pre-fix code (`status: 'executed'` plus a real "Unhandled Rejection" reported by vitest — reproducing the exact bug) and passes after the fix.
- `npx vitest run` on the touched inquiry test files (28 tests, all passing).
- `npx tsc --noEmit` (root) and `npx tsc --noEmit -p tsconfig.test-kernel.json` — clean.
- `npx eslint` on both changed files — clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line behavioral fix aligned with existing host-interaction patterns; only affects error handling when opening the inquiry panel fails.
> 
> **Overview**
> **`ExternalInquiryTool`** no longer discards the promise from **`openExternalInquiry`** with `void interaction`; it **`await`s** that promise so synchronous throws and rejections (e.g. inquiry panel unavailable) propagate through **`BaseTool.call()`** as a normal tool error instead of an unhandled rejection while the call still reported **`executed`**.
> 
> A kernel test mocks a rejecting host interaction and asserts **`status: 'error'`** with the rejection message, matching the other **`HostInteractions`** methods that already await their results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0715bd4b3082c876cbfd41231e7c695e591ec4f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->