### PR TITLE
fix(transcript): keep completed-run todo reads consistent and fresh

### DIFF
--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -188,6 +188,12 @@ export interface ExecutionKVStore {
   readConfig(): Promise<AgentConfig | null>;
   readReport(): Promise<string | null>;
   readTodos(): Promise<TodoEntry[]>;
+  /**
+   * Last-modified time (ms since epoch) of the legacy `todos.json`, or
+   * `undefined` when it has never been written. Lets callers compare
+   * freshness against a durable sidecar written by a different store.
+   */
+  todosModifiedAt(): Promise<number | undefined>;
   readConversation(): Promise<unknown[] | null>;
   readWorkspaceFiles(): Promise<string[]>;
   readChildren(): Promise<ChildRecord[]>;
@@ -270,6 +276,10 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
 
   async readTodos(): Promise<TodoEntry[]> {
     return TodoArraySchema.parse(await this.read<unknown[]>(KEYS.TODOS));
+  }
+
+  async todosModifiedAt(): Promise<number | undefined> {
+    return this.modifiedAt(KEYS.TODOS);
   }
 
   async readConversation(): Promise<unknown[] | null> {

--- a/src/test-kernel/support/FakeExecutionKVStore.ts
+++ b/src/test-kernel/support/FakeExecutionKVStore.ts
@@ -19,6 +19,7 @@ export function createFakeKv(executionId = 'test-exec-0001'): ExecutionKVStore {
     readConfig: async () => null,
     readReport: async () => null,
     readTodos: async () => [],
+    todosModifiedAt: async () => undefined,
     readConversation: async () => null,
     readWorkspaceFiles: async () => [],
     readChildren: async () => [],

--- a/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
@@ -30,6 +30,7 @@ const mocks = vi.hoisted(() => ({
   readMeta: vi.fn(),
   readChildren: vi.fn(),
   readTodos: vi.fn(),
+  todosModifiedAt: vi.fn(),
   readReport: vi.fn(),
   readWorkspaceFiles: vi.fn(),
   listExecutions: vi.fn(),
@@ -45,6 +46,7 @@ vi.mock('@agent/storage', async () => {
       readMeta: mocks.readMeta,
       readChildren: mocks.readChildren,
       readTodos: mocks.readTodos,
+      todosModifiedAt: mocks.todosModifiedAt,
       readReport: mocks.readReport,
       readWorkspaceFiles: mocks.readWorkspaceFiles,
     })),
@@ -122,6 +124,7 @@ describe('ExecutionsTool', () => {
     mocks.readMeta.mockResolvedValue(null);
     mocks.readChildren.mockResolvedValue([]);
     mocks.readTodos.mockResolvedValue([]);
+    mocks.todosModifiedAt.mockResolvedValue(undefined);
     mocks.readReport.mockResolvedValue(null);
     mocks.readWorkspaceFiles.mockResolvedValue([]);
   });
@@ -314,6 +317,69 @@ describe('ExecutionsTool', () => {
 
       expect(result.output).toContain('Read the old KV todo');
       expect(mocks.readTodos).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // Regression for #7300: the advertised /executions/{id}/todos endpoint used
+  // to read legacy KV directly, so it could disagree with the completed
+  // summary above once a run's task list only lived in the sidecar.
+  it('agrees with the completed summary when reading /executions/{id}/todos', async () => {
+    await withTempStorage(async () => {
+      const executionId = 'abc123' as ExecutionId;
+      const streamId = `codex#${executionId}` as StreamTabId;
+      await writeSidecarTodos(streamId, executionId, [
+        {
+          content: 'Read the sidecar work plan',
+          status: 'in_progress',
+          activeForm: 'Reading the sidecar work plan',
+        },
+      ]);
+      mocks.readTodos.mockResolvedValue([
+        { content: 'Read the old KV todo', status: 'pending' },
+      ]);
+
+      const result = await new ExecutionsTool().call({
+        path: `/executions/${executionId}/todos`,
+      });
+
+      expect(result.output).toContain('Read the sidecar work plan');
+      expect(result.output).not.toContain('Read the old KV todo');
+      expect(mocks.readTodos).not.toHaveBeenCalled();
+    });
+  });
+
+  // Regression for #7301: a stale-but-present sidecar used to be treated as
+  // authoritative even when a final todo_write had already landed a fresher
+  // legacy write, hiding completed tasks as still pending.
+  it('prefers a fresher legacy KV write over a stale sidecar in the completed summary', async () => {
+    await withTempStorage(async () => {
+      const executionId = 'abc123' as ExecutionId;
+      const streamId = `codex#${executionId}` as StreamTabId;
+      await writeSidecarTodos(streamId, executionId, [
+        {
+          content: 'Stale sidecar todo',
+          status: 'pending',
+          activeForm: 'Doing the stale sidecar todo',
+        },
+      ]);
+      mocks.readMeta.mockResolvedValue({
+        timestamp: '2026-06-15T09:36:02.345Z',
+        category: 'toolUse',
+      });
+      mocks.readConfig.mockResolvedValue(config);
+      mocks.readTodos.mockResolvedValue([
+        { content: 'Fresher legacy todo', status: 'completed' },
+      ]);
+      // Simulate a final todo_write flushing to legacy KV after the sidecar's
+      // own asynchronous write already landed.
+      mocks.todosModifiedAt.mockResolvedValue(Date.now() + 60_000);
+
+      const result = await new ExecutionsTool().call({
+        path: `/executions/${executionId}`,
+      });
+
+      expect(result.output).toContain('Fresher legacy todo');
+      expect(result.output).not.toContain('Stale sidecar todo');
     });
   });
 

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -447,6 +447,7 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
       store.readChildren(),
       readCompletedRunTodos(executionId, {
         legacyFallback: () => store.readTodos(),
+        legacyModifiedAt: () => store.todosModifiedAt(),
       }),
       store.readReport(),
     ]);
@@ -669,8 +670,24 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
     };
   }
 
+  /**
+   * Same source of truth as `showSummary()`'s completed-run todos branch: a
+   * running execution's task list is read live from KV, but once the
+   * execution is finished this must route through `readCompletedRunTodos()`
+   * so this endpoint never disagrees with the summary about which tasks are
+   * still pending.
+   */
   private async showTodos(executionId: ExecutionId): Promise<ToolResult> {
-    const todos = await getExecutionStore(executionId).readTodos();
+    const handle = currentSession().executions.getHandle(executionId);
+    const store = getExecutionStore(executionId);
+    const todos = handle
+      ? await store.readTodos()
+      : (
+          await readCompletedRunTodos(executionId, {
+            legacyFallback: () => store.readTodos(),
+            legacyModifiedAt: () => store.todosModifiedAt(),
+          })
+        ).todos;
 
     if (todos.length === 0) {
       return {

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -1,4 +1,5 @@
 import type { TodoEntry } from '@agent/storage';
+import { isFileNotFoundError } from '@common/errors';
 import type { ExecutionId, StreamTabId, TodoItem } from '@shared/schemas';
 import { StorageFS } from '@utils/files';
 
@@ -17,6 +18,13 @@ export interface CompletedRunTodosReadResult {
 export interface CompletedRunTodosReaderOptions {
   readonly snapshotStore?: StreamSnapshotStore;
   readonly legacyFallback?: () => Promise<readonly TodoEntry[]>;
+  /**
+   * Last-modified time (ms since epoch) of the legacy `todos.json`, if it
+   * exists. Used to detect a final `todo_write` that landed after the
+   * sidecar's own (asynchronous) write flushed, so the fresher source wins
+   * regardless of which one happens to exist.
+   */
+  readonly legacyModifiedAt?: () => Promise<number | undefined>;
 }
 
 function todoItemToEntry(todo: TodoItem): TodoEntry {
@@ -30,6 +38,18 @@ function workPlanPath(streamId: StreamTabId): string {
   return `${streamDataDir(streamId)}/${STREAM_DATA_KEYS.WORK_PLAN}.json`;
 }
 
+/** Sidecar `workPlan.json` mtime (ms since epoch), or `undefined` if absent. */
+async function sidecarModifiedAt(
+  streamId: StreamTabId,
+): Promise<number | undefined> {
+  try {
+    return (await StorageFS.stat(workPlanPath(streamId))).mtime;
+  } catch (err) {
+    if (isFileNotFoundError(err)) return undefined;
+    throw err;
+  }
+}
+
 async function readLegacyTodos(
   fallback: (() => Promise<readonly TodoEntry[]>) | undefined,
 ): Promise<CompletedRunTodosReadResult> {
@@ -40,11 +60,25 @@ async function readLegacyTodos(
   };
 }
 
+async function readSidecarTodos(
+  snapshotStore: StreamSnapshotStore,
+  streamId: StreamTabId,
+): Promise<CompletedRunTodosReadResult> {
+  const snapshot = await snapshotStore.read(streamId);
+  return {
+    todos: snapshot.todos.map(todoItemToEntry),
+    source: 'streamData',
+    streamId,
+  };
+}
+
 /**
- * Read the archived task list for a completed run from the stream sidecar.
- *
- * `executions/{id}/todos.json` is still consulted only as a temporary legacy
- * fallback for runs recorded before durable work-plan sidecars existed.
+ * Read the archived task list for a completed run, preferring the durable
+ * stream sidecar (`streamData/{stream}/workPlan.json`) but falling back to
+ * `executions/{id}/todos.json` for runs recorded before sidecars existed —
+ * or when the legacy write is demonstrably fresher than the sidecar (a final
+ * `todo_write` can land before the snapshot store's asynchronous sidecar
+ * write has flushed).
  */
 export async function readCompletedRunTodos(
   executionId: ExecutionId,
@@ -55,18 +89,17 @@ export async function readCompletedRunTodos(
     snapshotStore,
   });
 
-  if (resolved) {
-    if (await StorageFS.exists(workPlanPath(resolved.streamId))) {
-      const snapshot = await snapshotStore.read(resolved.streamId);
-      return {
-        todos: snapshot.todos.map(todoItemToEntry),
-        source: 'streamData',
-        streamId: resolved.streamId,
-      };
-    }
+  if (!resolved) return readLegacyTodos(options.legacyFallback);
 
+  const sidecarMtime = await sidecarModifiedAt(resolved.streamId);
+  if (sidecarMtime === undefined) {
     return readLegacyTodos(options.legacyFallback);
   }
 
-  return readLegacyTodos(options.legacyFallback);
+  const legacyMtime = await options.legacyModifiedAt?.();
+  if (legacyMtime !== undefined && legacyMtime > sidecarMtime) {
+    return readLegacyTodos(options.legacyFallback);
+  }
+
+  return readSidecarTodos(snapshotStore, resolved.streamId);
 }


### PR DESCRIPTION
Closes #7300
Closes #7301

## What changed

- **#7300**: `showTodos()` (the advertised `/executions/{id}/todos` endpoint) read only the legacy `executions/{id}/todos.json` KV directly, so it could disagree with the completed `/executions/{id}` summary once a run's task list lived only in the `streamData/{stream}/workPlan.json` sidecar. It now checks for a live in-memory handle (matching `showSummary()`'s pattern) and otherwise routes through the same `readCompletedRunTodos()` reader the summary uses, so both endpoints always agree.

- **#7301**: `readCompletedRunTodos()` treated the mere existence of `workPlan.json` as authoritative once a completed run had a sidecar. If a final `todo_write` flushed to the legacy `executions/{id}/todos.json` before the snapshot store's asynchronous sidecar write landed, the stale sidecar won and the fresher legacy write was skipped — `/executions/{id}` could show tasks as still pending after the run had actually completed. Added a freshness check: a new `ExecutionKVStore.todosModifiedAt()` accessor exposes the legacy write's mtime (built on the existing `KVStore.modifiedAt()`), and `readCompletedRunTodos()` now compares it against the sidecar `workPlan.json`'s mtime, preferring whichever is newer.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx eslint` on all changed files — clean
- [x] `npx vitest run src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts` — 13/13 pass, including two new regression tests:
  - `agrees with the completed summary when reading /executions/{id}/todos` (#7300)
  - `prefers a fresher legacy KV write over a stale sidecar in the completed summary` (#7301)
- [x] Broader sweep: `npx vitest run src/test-kernel/tools src/test-kernel/agent/storage src/test-kernel/transcript` — 510/510 pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to read paths for completed-run todos in ExecutionsTool and transcript archive logic; no auth or write-path changes, with targeted regression tests.
> 
> **Overview**
> Aligns completed-run task list reads so the **`/executions/{id}/todos`** path and the completed **`/executions/{id}`** summary use the same logic, and picks the fresher source when legacy KV and stream sidecars disagree.
> 
> **`ExecutionsTool.showTodos()`** no longer always reads legacy `todos.json`. For runs still in memory it keeps live KV reads; for finished runs it routes through **`readCompletedRunTodos()`** with the same **`legacyModifiedAt`** hook as **`showSummary()`**.
> 
> **`readCompletedRunTodos()`** stops treating a present **`workPlan.json`** sidecar as automatically authoritative. It compares sidecar mtime to legacy **`todos.json`** via new **`ExecutionKVStore.todosModifiedAt()`**, preferring whichever is newer when a final **`todo_write`** lands in KV after an async sidecar write.
> 
> Regression tests cover sidecar-only todos on the todos endpoint (#7300) and fresher legacy KV over a stale sidecar in the summary (#7301).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d42dec52b45dc7063a538ffc171b7d80febbfb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->