### PR TITLE
fix(desktop): wire cancelForStream into stream teardown

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1087,6 +1087,11 @@ export class DesktopProgressBridge {
     // Releases approval state (pending approvals, bypass flags, coordinator
     // requests) and the follow-up queue for this stream.
     releaseStreamResources(streamId, this.session);
+    // releaseStreamResources only settles the legacy approval registries;
+    // DesktopHostInteractions keeps its own pendingRequests map (bash/plan/
+    // proposal/user-question) that only this cancels, so a pending approval
+    // wouldn't otherwise be settled and the awaiting tool call would hang.
+    this.session.interactions.cancelForStream(streamId, 'Stream deleted.');
 
     this.releaseApprovalsForStream(streamId);
     this.workflowFileActions.clearStreamBackups(streamId);
@@ -1112,6 +1117,12 @@ export class DesktopProgressBridge {
     for (const streamId of streamIds) {
       this.deletedStreams.add(streamId);
       releaseStreamResources(streamId, this.session);
+      // See the matching comment in deleteStream: DesktopHostInteractions'
+      // pendingRequests map is not covered by releaseStreamResources.
+      this.session.interactions.cancelForStream(
+        streamId,
+        'All streams deleted.',
+      );
     }
     // Catch pending approvals with no concrete stream context (undefined or
     // empty streamId) — the per-stream loop skips them because they do not

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -58,6 +58,10 @@ type TestableBridge = Bridge & {
         streamId: StreamTabId;
         operation: string;
       }) => Promise<unknown>;
+      requestBashApproval?: (request: {
+        command: string;
+        streamId?: StreamTabId;
+      }) => Promise<unknown>;
     };
   };
   handleProgressEvent(event: string, payload: unknown): void;
@@ -1922,6 +1926,62 @@ describe('DesktopProgressBridge', () => {
     }
   });
 
+  it('cancels a pending plan approval instead of hanging when its stream is deleted', async () => {
+    const messages: unknown[] = [];
+    const bridge = await createBridge(messages);
+
+    try {
+      bridge.handleProgressEvent('setActiveStream', {
+        streamId: 'plan-delete-stream',
+        agentCategory: AgentCategory.Workflow,
+      });
+
+      const result = bridge.runtimeHost.interactions?.requestPlanApproval?.({
+        approvalId: 'plan-cancel-on-delete',
+        streamId: 'plan-delete-stream' as StreamTabId,
+        plan: { objective: 'Check cancellation on stream delete.' },
+        goalEnabled: false,
+      });
+
+      await vi.waitFor(() => {
+        expect(
+          progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION),
+        ).toContainEqual(
+          expect.objectContaining({
+            action: 'show',
+            permission: expect.objectContaining({
+              kind: PERMISSION_KIND.PLAN_APPROVAL,
+              data: expect.objectContaining({
+                approvalId: 'plan-cancel-on-delete',
+              }),
+            }),
+          }),
+        );
+      });
+
+      await bridge.deleteStream('plan-delete-stream' as StreamTabId);
+
+      // Before the fix, this promise never settled: releaseStreamResources
+      // only cleared the legacy approval registries, not
+      // DesktopHostInteractions' own pendingRequests map.
+      await expect(result).resolves.toEqual({
+        action: 'reject',
+        feedback: 'Stream deleted.',
+      });
+      expect(
+        progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION),
+      ).toContainEqual(
+        expect.objectContaining({
+          action: 'resolve',
+          kind: PERMISSION_KIND.PLAN_APPROVAL,
+          id: 'plan-cancel-on-delete',
+        }),
+      );
+    } finally {
+      bridge.dispose();
+    }
+  });
+
   it('does not resume a stream deleted in this desktop session', async () => {
     const taskState = { agentConfig: SEARCH_TOOL_USE_AGENT_CONFIG };
     const retrieveSessionResumeData = vi.fn(async () => ({
@@ -2103,6 +2163,48 @@ describe('DesktopProgressBridge', () => {
         streamStates: {},
       });
       expect(cleanupAllRequests).toHaveBeenCalledOnce();
+    } finally {
+      bridge.dispose();
+    }
+  });
+
+  it('cancels a pending bash approval instead of hanging when all streams are deleted', async () => {
+    const messages: unknown[] = [];
+    const bridge = await createBridge(messages);
+
+    try {
+      bridge.handleProgressEvent('setActiveStream', {
+        streamId: 'bash-delete-all-stream',
+        agentCategory: AgentCategory.Workflow,
+      });
+
+      const result = bridge.runtimeHost.interactions?.requestBashApproval?.({
+        command: 'echo hi',
+        streamId: 'bash-delete-all-stream' as StreamTabId,
+      });
+
+      await vi.waitFor(() => {
+        expect(
+          progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION),
+        ).toContainEqual(
+          expect.objectContaining({
+            action: 'show',
+            permission: expect.objectContaining({
+              kind: PERMISSION_KIND.BASH,
+            }),
+          }),
+        );
+      });
+
+      await bridge.deleteAllStreams();
+
+      // Before the fix, this promise never settled: releaseStreamResources
+      // only cleared the legacy approval registries, not
+      // DesktopHostInteractions' own pendingRequests map.
+      await expect(result).resolves.toEqual({
+        accepted: false,
+        userMessage: 'All streams deleted.',
+      });
     } finally {
       bridge.dispose();
     }


### PR DESCRIPTION
Closes #7312

## What changed

`DesktopHostInteractions.cancelForStream` (`packages/desktop/src/main/desktopHostInteractions.ts`) was implemented but had zero callers anywhere in the codebase. Stream teardown (`deleteStream`, `deleteAllStreams` in `packages/desktop/src/main/desktopAgentExecution.ts`) only settled the legacy approval registries via `releaseStreamResources`/`cleanupApprovalsForStream` (`src/tools/approval/index.ts`), which have no knowledge of `DesktopHostInteractions`'s own `pendingRequests` map.

Net effect: deleting or bulk-deleting a desktop stream while a bash/plan/proposal/user-question approval was pending never resolved the underlying tool call's promise — it hung indefinitely.

This PR calls `session.interactions.cancelForStream(streamId, cause)` alongside the existing `releaseStreamResources` call in both `deleteStream` and `deleteAllStreams`, so any pending desktop host interaction for that stream is rejected (with a descriptive cause) instead of left dangling.

`stopStream` is intentionally left untouched: it doesn't currently call `releaseStreamResources`/`cleanupApprovalsForStream` either (a "stop" interrupts the execution but doesn't tear down approval state, mirroring the extension's `stopAgent`), so there's no analogous gap there today.

## Test plan

- [x] Added a regression test that requests a plan approval, deletes its stream, and asserts the pending promise now resolves with `{ action: 'reject', feedback: 'Stream deleted.' }` instead of hanging (confirmed it times out without the fix).
- [x] Added a regression test that requests a bash approval, calls `deleteAllStreams`, and asserts the pending promise resolves with `{ accepted: false, userMessage: 'All streams deleted.' }` instead of hanging (confirmed it times out without the fix).
- [x] `npx vitest run src/test-kernel/desktop/DesktopAgentExecution.vitest.mts` — 55 passed.
- [x] `npx eslint packages/desktop/src/main/desktopAgentExecution.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts` — clean.
- [x] `npm run typecheck` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nbVZZcHVNLBNZ2tESvR7v

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted teardown fix with regression tests; no auth or data-path changes, and behavior is limited to rejecting pending approvals when streams are removed.
> 
> **Overview**
> Deleting a desktop progress stream (or **delete all**) used to call `releaseStreamResources` but never `DesktopHostInteractions.cancelForStream`, so bash/plan/proposal/user-question approvals tracked in the host’s `pendingRequests` map could leave tool calls waiting forever.
> 
> **`deleteStream`** now calls `session.interactions.cancelForStream(streamId, 'Stream deleted.')` right after `releaseStreamResources`. **`deleteAllStreams`** does the same per stream with `'All streams deleted.'` Comments document why both paths are needed. **`stopStream`** is unchanged.
> 
> Regression tests cover plan approval on single-stream delete and bash approval on delete-all, asserting the pending promises resolve with reject/cancel payloads instead of hanging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5598c89b91603143343a2ca8c94a03bc43a1611. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->