### PR TITLE
fix(agent-runtime): don't block the parent while resuming a suspended child

### DIFF
--- a/src/test-kernel/tools/DelegationTools.vitest.ts
+++ b/src/test-kernel/tools/DelegationTools.vitest.ts
@@ -1,17 +1,67 @@
 // Third-party imports
 import * as assert from 'node:assert';
-import { describe, it, afterEach } from 'vitest';
+import { describe, it, afterEach, beforeEach, vi } from 'vitest';
 
 // Node.js built-in imports
 
 // Platform imports
 import { FileType, type FileStat } from '@platform/interfaces/filesystem';
 
+const mocks = vi.hoisted(() => ({
+  tryUseRunContext: vi.fn(),
+  currentSession: vi.fn(),
+  sendFollowUp: vi.fn(),
+  wakeQueuedFollowUpStream: vi.fn(),
+  depthGateError: vi.fn(() => null),
+  getNativeSubagentStrategy: vi.fn(),
+}));
+
+vi.mock('@agent/runtime/RunContext', () => ({
+  tryUseRunContext: mocks.tryUseRunContext,
+}));
+
+vi.mock('@agent/runtime/SessionHandle', () => ({
+  currentSession: mocks.currentSession,
+}));
+
+vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
+  sendFollowUp: mocks.sendFollowUp,
+  wakeQueuedFollowUpStream: mocks.wakeQueuedFollowUpStream,
+}));
+
+vi.mock('@tools/delegation/subagentExecution', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('@tools/delegation/subagentExecution')
+    >();
+  return { ...actual, depthGateError: mocks.depthGateError };
+});
+
+vi.mock('@tools/delegation/nativeSubagentStrategy', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('@tools/delegation/nativeSubagentStrategy')
+    >();
+  return {
+    ...actual,
+    getNativeSubagentStrategy: mocks.getNativeSubagentStrategy,
+  };
+});
+
+// Local imports - agent
+import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
+import type { FollowUpWakeResult } from '@agent/followUp/ToolUseFollowUp';
+
+// Local imports - shared
+import { AgentCategory, type StreamTabId } from '@shared/schemas';
+
 // Local imports - tools
 import {
+  DelegateAgentTool,
   rejectOversizedBibAttachments,
   type WorkflowAgentInput,
 } from '@tools/DelegationTools';
+import { subagentDeliveryRegistry } from '@tools/subagentDeliveryState';
 import { WorkspaceFS } from '@utils/files';
 
 const BASE_INPUT: WorkflowAgentInput = {
@@ -107,5 +157,114 @@ describe('DelegationTools', () => {
 
     assert.strictEqual(result, null);
     assert.strictEqual(statCalled, false);
+  });
+});
+
+// Races the tool call's promise against a short timer so a regression that
+// re-introduces blocking (awaiting the resumed child's full turn) fails fast
+// instead of hanging until the child eventually resolves.
+async function raceAgainstBlockingResume<T>(
+  promise: Promise<T>,
+): Promise<{ settled: true; value: T } | { settled: false }> {
+  const TIMEOUT = Symbol('timeout');
+  const outcome = await Promise.race([
+    promise.then((value) => ({ settled: true as const, value })),
+    new Promise<typeof TIMEOUT>((resolve) =>
+      setTimeout(() => resolve(TIMEOUT), 50),
+    ),
+  ]);
+  return outcome === TIMEOUT ? { settled: false } : outcome;
+}
+
+describe('DelegateAgentTool resume (issue #7289)', () => {
+  const executionId = 'exec-resume-issue-7289';
+  const parentStreamId = 'parent-stream' as StreamTabId;
+  const childStreamId = 'child-stream' as StreamTabId;
+
+  function makeHandle(): AgentExecutionHandle {
+    return new AgentExecutionHandle(
+      executionId,
+      parentStreamId,
+      childStreamId,
+      'review',
+      AgentCategory.ToolUse,
+      { emit: vi.fn() } as never,
+    );
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.depthGateError.mockReturnValue(null);
+    mocks.tryUseRunContext.mockReturnValue({
+      delegationDepth: 0,
+      streamId: parentStreamId,
+    } as never);
+    mocks.currentSession.mockReturnValue({
+      executions: { getHandle: () => makeHandle() },
+    } as never);
+    mocks.sendFollowUp.mockResolvedValue({
+      status: 'queued',
+      reason: 'waiting',
+    });
+    subagentDeliveryRegistry.start(executionId);
+  });
+
+  afterEach(() => {
+    subagentDeliveryRegistry.finish(executionId);
+  });
+
+  it('returns once the follow-up is queued, without waiting for a resumed native subagent to reach its next boundary', async () => {
+    let resolveWake: ((value: FollowUpWakeResult) => void) | undefined;
+    const wakeQueuedFollowUp = vi.fn(
+      () =>
+        new Promise<FollowUpWakeResult>((resolve) => {
+          resolveWake = resolve;
+        }),
+    );
+    mocks.getNativeSubagentStrategy.mockReturnValue({ wakeQueuedFollowUp });
+
+    const tool = new DelegateAgentTool();
+    const outcome = await raceAgainstBlockingResume(
+      tool.call({ execution_id: executionId, instruction: 'Keep going.' }),
+    );
+
+    assert.strictEqual(
+      outcome.settled,
+      true,
+      'delegate_agent resume blocked the parent tool call for the full child turn',
+    );
+    if (outcome.settled) {
+      assert.strictEqual(outcome.value.status, 'executed');
+    }
+    assert.strictEqual(wakeQueuedFollowUp.mock.calls.length, 1);
+
+    // Settle the still-pending wake so it doesn't leak into later tests.
+    resolveWake?.({ kind: 'resumed' });
+  });
+
+  it('returns once the follow-up is queued, without waiting for the host resume port when no native strategy is registered', async () => {
+    mocks.getNativeSubagentStrategy.mockReturnValue(undefined);
+    let resolveWake: ((value: FollowUpWakeResult) => void) | undefined;
+    mocks.wakeQueuedFollowUpStream.mockReturnValue(
+      new Promise<FollowUpWakeResult>((resolve) => {
+        resolveWake = resolve;
+      }),
+    );
+
+    const tool = new DelegateAgentTool();
+    const outcome = await raceAgainstBlockingResume(
+      tool.call({ execution_id: executionId, instruction: 'Keep going.' }),
+    );
+
+    assert.strictEqual(
+      outcome.settled,
+      true,
+      'delegate_agent resume blocked the parent tool call on the host resume port',
+    );
+    if (outcome.settled) {
+      assert.strictEqual(outcome.value.status, 'executed');
+    }
+
+    resolveWake?.({ kind: 'resumed' });
   });
 });

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -20,6 +20,9 @@ import {
   wakeQueuedFollowUpStream,
 } from '@agent/followUp/ToolUseFollowUp';
 
+// Local imports - logger
+import * as logger from '@logger/logUtils';
+
 // Local imports - tools
 import {
   AgentCategory,
@@ -37,6 +40,7 @@ import { defineTool } from '@tools/core/define';
 
 // Local imports - utils
 import { WorkspaceFS } from '@utils/files';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 import { isNonEmptyString } from '@utils/text/stringUtils';
 
 // Local imports - delegation
@@ -58,6 +62,9 @@ import { getNativeSubagentStrategy } from './delegation/nativeSubagentStrategy';
 
 export { rejectOversizedBibAttachments } from './delegation/inputFields';
 export type { WorkflowAgentInput };
+
+const LOG_CHANNEL = 'delegation';
+logger.initialize(LOG_CHANNEL);
 
 // ============================================================================
 // delegate_workflow tool - for document processing agents
@@ -303,21 +310,34 @@ Git worktree support: resolved from the active workspace at runtime.`,
       deliveryState.markPending();
     }
 
+    // Dispatch the wake without awaiting it: waking a WAITING subagent resumes
+    // its run all the way to the next WAITING/terminal boundary, which can be
+    // an entire child turn. This tool call only hands the follow-up off — the
+    // result (or the wake's own failure) arrives asynchronously via the
+    // follow-up queue, same as the original delegation's async-arrival
+    // contract. Awaiting it here would stall this tool call, and the parent
+    // orchestrator's whole turn with it, for as long as the child keeps
+    // running (see #7289). Neither branch's return value is otherwise
+    // consulted below, so nothing here depends on it settling first.
     const nativeStrategy = getNativeSubagentStrategy(executionId);
-    if (nativeStrategy) {
-      await nativeStrategy.wakeQueuedFollowUp(result, {
-        approvalPromptsUnavailable: parentContext?.approvalPromptsUnavailable,
-        runtimeUnavailableTools: parentContext?.runtimeUnavailableTools,
-        toolEditApprovalHandler: parentContext?.toolEditApprovalHandler,
-      });
-    } else {
-      await wakeQueuedFollowUpStream(
-        handle.childStreamId,
-        result,
-        undefined,
-        session,
+    const wake = nativeStrategy
+      ? nativeStrategy.wakeQueuedFollowUp(result, {
+          approvalPromptsUnavailable: parentContext?.approvalPromptsUnavailable,
+          runtimeUnavailableTools: parentContext?.runtimeUnavailableTools,
+          toolEditApprovalHandler: parentContext?.toolEditApprovalHandler,
+        })
+      : wakeQueuedFollowUpStream(
+          handle.childStreamId,
+          result,
+          undefined,
+          session,
+        );
+    wake.catch((err: unknown) => {
+      logger.warn(
+        LOG_CHANNEL,
+        `Failed to wake resumed subagent '${executionId}': ${toErrorMessage(err)}`,
       );
-    }
+    });
 
     switch (result.status) {
       case 'sent':


### PR DESCRIPTION
Closes #7289

## What changed

`delegate_agent`'s resume path (`src/tools/DelegationTools.ts`) `await`ed
the wake of a WAITING native subagent — via
`nativeStrategy.wakeQueuedFollowUp(...)` or the fallback
`wakeQueuedFollowUpStream(...)` — which drives the resumed run all the
way to its next `WAITING`/terminal boundary. That meant the parent
orchestrator's `delegate_agent` tool call stalled for the entire
resumed child turn, contradicting the delegation contract used
everywhere else: results arrive asynchronously via the follow-up
queue, not by blocking the tool call.

Neither branch's return value (`FollowUpWakeResult`) was consulted
after the `await` — the response text is built purely from
`sendFollowUp`'s earlier, fast result — so the fix simply stops
awaiting the wake. It's still dispatched synchronously (so the
in-flight bookkeeping the wake path relies on, e.g. transitioning the
stream to `RESUMING`, still happens before the tool call returns), but
the tool call no longer blocks on the resumed run reaching its next
boundary. A `.catch()` logs any wake failure instead of letting it
become an unhandled rejection, since the tool call itself is no longer
around to observe it.

This mirrors how the *original* delegation already works: `executeSubagent`
hands the launched run's promise to `NativeSubagentStrategy.attachPromise`
(fire-and-forget) instead of awaiting it, and delivers the result later
via the follow-up queue.

## Regression coverage

Added two tests in `src/test-kernel/tools/DelegationTools.vitest.ts`
(native-subagent path and the host-resume-port fallback) that give the
tool call's wake dispatch a promise which never resolves during the
test, then race the tool call against a short timer. Verified both
tests fail against the pre-fix code (the tool call never returns
inside the race window) and pass with the fix.

## Verification

- `npx tsc -p . --noEmit` — clean
- `npx vitest run src/test-kernel/tools/DelegationTools.vitest.ts src/test-kernel/tools/NativeSubagentStrategy.vitest.ts` — 11/11 passing
- `npx eslint src/tools/DelegationTools.ts src/test-kernel/tools/DelegationTools.vitest.ts` — clean
- Confirmed the new tests fail against the pre-fix code (temporarily stashed the fix) and pass with it restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orchestration timing for subagent resume; behavior change is intentional and aligned with async delegation, with targeted regression tests.
> 
> **Overview**
> Fixes **#7289** by changing `delegate_agent`’s resume path so it no longer **awaits** waking a queued follow-up on a WAITING subagent.
> 
> After `sendFollowUp` queues or sends the instruction, the tool still **starts** the wake (`nativeStrategy.wakeQueuedFollowUp` or `wakeQueuedFollowUpStream`) but returns immediately with the usual `executed` result built from `sendFollowUp` alone. Wake failures are logged on the `delegation` channel via `.catch()` instead of blocking the parent turn or becoming unhandled rejections.
> 
> Regression tests in `DelegationTools.vitest.ts` mock follow-up/wake dependencies and race the tool call against a 50ms timer when the wake promise never resolves, covering both the native subagent strategy and the host resume-port fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21e77c30ee18ee870c16c10ea69f099fec5f8e55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->