### PR TITLE
fix(transcript): resolve the right persisted stream, bound the resolver's read cost

### DIFF
--- a/src/test-kernel/transcript/executionStreamResolver.vitest.ts
+++ b/src/test-kernel/transcript/executionStreamResolver.vitest.ts
@@ -1,0 +1,208 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { MemoryStateStore } from '@platform/defaults/memoryState';
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
+import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
+import { createFakePlatform } from '@test/support/FakePlatform';
+import { setupPlatform } from '@test/support/setupPlatform';
+import {
+  resolvePersistedStreamIdForExecution,
+  StreamLogStore,
+  StreamSnapshotStore,
+} from '@transcript';
+import { TaskStateSchema, type TaskState } from '@agent/core/state/TaskState';
+import {
+  LOG_LEVELS,
+  MESSAGE_TYPES,
+  STREAM_LOG_ENTRY_TYPES,
+  type ExecutionId,
+  type StreamTabId,
+  type TodoItem,
+} from '@shared/schemas';
+import { AgentCategory } from '@shared/schemas/agent';
+import type { Platform } from '@platform/platform';
+
+const tempDirs: string[] = [];
+
+async function buildResolverPlatform(): Promise<Platform> {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'texra-resolver-'));
+  tempDirs.push(tempDir);
+  const workspaceDir = path.join(tempDir, 'workspace');
+  const storageRoot = path.join(tempDir, 'storage');
+  return createFakePlatform(
+    { workspacePath: workspaceDir },
+    {
+      fs: nodeFilesystem,
+      workspace: createNodeWorkspace(() => workspaceDir),
+      storage: new WorkspaceStorageProvider(storageRoot, workspaceDir),
+      globalState: new MemoryStateStore(),
+      workspaceState: new MemoryStateStore(),
+    },
+  );
+}
+
+function taskState(agent: string, model = 'deepseekproT'): TaskState {
+  return TaskStateSchema.parse({
+    agentConfig: { agent, model, agentCategory: AgentCategory.ToolUse },
+  });
+}
+
+const TODO: TodoItem = {
+  content: 'Fix the bug',
+  status: 'pending',
+  activeForm: 'Fixing the bug',
+};
+
+describe('resolvePersistedStreamIdForExecution', () => {
+  setupPlatform(buildResolverPlatform);
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await Promise.all(
+      tempDirs
+        .splice(0)
+        .map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it('resolves the sole meta-matched stream without needing a data-presence check', async () => {
+    const executionId = 'abc111' as ExecutionId;
+    const streamId = 'orchestrator@deepseekproT#abc111' as StreamTabId;
+
+    const store = new StreamSnapshotStore();
+    store.setTaskState(streamId, taskState('orchestrator'), executionId);
+    await store.flush();
+
+    const resolved = await resolvePersistedStreamIdForExecution(executionId, {
+      snapshotStore: new StreamSnapshotStore(),
+    });
+
+    expect(resolved).toEqual({ streamId, source: 'streamDataMeta' });
+  });
+
+  it(
+    'prefers the meta-matched candidate with a real workPlan.json over a bare ' +
+      'meta-only match sharing the same executionId (#7298)',
+    async () => {
+      const executionId = 'abc222' as ExecutionId;
+      // A parent orchestrator tab and a child bash-tool stream both record the
+      // same executionId in their sidecar meta.json, but only the child ever
+      // durably persisted todos — mirrors the resolver picking the parent (no
+      // streamLogs/workPlan) and callers like the completed-run todo reader
+      // silently reading nothing.
+      // Named so the no-data candidate sorts alphabetically FIRST in the
+      // persisted-stream directory listing — this is what makes the test
+      // actually exercise the "first meta match wins" bug rather than
+      // accidentally passing because the real-data stream happened to be
+      // read first.
+      const parentStream = 'aOrchestrator@deepseekproT#abc222' as StreamTabId;
+      const childStream = 'zBashTool@tool#abc222' as StreamTabId;
+
+      const store = new StreamSnapshotStore();
+      store.setTaskState(parentStream, taskState('orchestrator'), executionId);
+      store.setTaskState(childStream, taskState('bash'), executionId);
+      store.handleProgressEvent('updateTodos', {
+        streamId: childStream,
+        todos: [TODO],
+      });
+      await store.flush();
+
+      const resolved = await resolvePersistedStreamIdForExecution(executionId, {
+        snapshotStore: new StreamSnapshotStore(),
+      });
+
+      expect(resolved).toEqual({
+        streamId: childStream,
+        source: 'streamDataMeta',
+      });
+    },
+  );
+
+  it(
+    'prefers the meta-matched candidate with real streamLogs over a bare ' +
+      'meta-only match, using an already-loaded StreamLogStore (#7298)',
+    async () => {
+      const executionId = 'abc333' as ExecutionId;
+      // Same alphabetical-ordering reasoning as the workPlan test above.
+      const parentStream = 'aOrchestrator@deepseekproT#abc333' as StreamTabId;
+      const childStream = 'zBashTool@tool#abc333' as StreamTabId;
+
+      const snapshotWriter = new StreamSnapshotStore();
+      snapshotWriter.setTaskState(
+        parentStream,
+        taskState('orchestrator'),
+        executionId,
+      );
+      snapshotWriter.setTaskState(childStream, taskState('bash'), executionId);
+      await snapshotWriter.flush();
+
+      const logStore = new StreamLogStore();
+      await logStore.load();
+      logStore.append(childStream, {
+        id: 'entry-1',
+        type: STREAM_LOG_ENTRY_TYPES.LOG,
+        level: LOG_LEVELS.INFO,
+        timestamp: 100,
+        messageType: MESSAGE_TYPES.DEFAULT,
+        text: 'child stream output',
+      });
+      await logStore.flush();
+
+      const resolved = await resolvePersistedStreamIdForExecution(executionId, {
+        snapshotStore: new StreamSnapshotStore(),
+        streamLogStore: logStore,
+      });
+
+      expect(resolved).toEqual({
+        streamId: childStream,
+        source: 'streamDataMeta',
+      });
+    },
+  );
+
+  it(
+    'bounds the concurrent meta-file reads instead of fanning out over every ' +
+      'persisted stream at once (#7299)',
+    async () => {
+      const streamCount = 20;
+      const seedStore = new StreamSnapshotStore();
+      for (let i = 0; i < streamCount; i++) {
+        const idHex = i.toString(16).padStart(2, '0');
+        seedStore.setTaskState(
+          `agent${i}@model#abcd${idHex}` as StreamTabId,
+          taskState('agent'),
+          `abcd${idHex}` as ExecutionId,
+        );
+      }
+      await seedStore.flush();
+
+      const resolveStore = new StreamSnapshotStore();
+      let inFlight = 0;
+      let maxInFlight = 0;
+      vi.spyOn(resolveStore, 'readPersistedExecutionId').mockImplementation(
+        async () => {
+          inFlight++;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          inFlight--;
+          return undefined;
+        },
+      );
+
+      await resolvePersistedStreamIdForExecution('abcdff' as ExecutionId, {
+        snapshotStore: resolveStore,
+      });
+
+      // Matches the resolver's META_SCAN_CONCURRENCY bound: with 20 candidates
+      // and an unbounded fan-out every read would start at once (maxInFlight
+      // would hit 20); bounded, it never exceeds the worker-pool size.
+      expect(maxInFlight).toBeGreaterThan(1);
+      expect(maxInFlight).toBeLessThanOrEqual(8);
+    },
+  );
+});

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -73,6 +73,7 @@ import {
   assembleSnapshot,
   EMPTY_WORK_PLAN,
   readLegacyInstruction as readLegacyInstructionFromDisk,
+  readMeta,
   readStreamData,
   type StreamData,
 } from './streamSnapshotRead';
@@ -817,12 +818,29 @@ export class StreamSnapshotStore {
       .filter((stream): stream is StreamTabId => stream !== undefined);
   }
 
-  /** Execution id recorded in a stream sidecar, without seeding memory. */
+  /**
+   * Execution id recorded in a stream sidecar's `meta.json`, without seeding
+   * memory or reading the stream's other sidecar files. Callers that scan
+   * every persisted stream (the `executionStreamResolver` meta-match, bulk
+   * admin sweeps in `SessionStores`) only ever need this one field, so this
+   * reads just `meta.json` rather than the full 6-file `readStreamData()`.
+   */
   async readPersistedExecutionId(
     stream: StreamTabId,
   ): Promise<ExecutionId | undefined> {
-    const meta = (await readStreamData(this.kv(stream))).meta;
-    return executionIdFromMeta(meta);
+    return executionIdFromMeta(await readMeta(this.kv(stream)));
+  }
+
+  /**
+   * Whether a stream has a persisted `workPlan.json` sidecar — an existence
+   * check only (a single stat via `KVStore.exists`), not a read. Used by the
+   * resolver to disambiguate between multiple persisted streams that share an
+   * `executionId` (e.g. a parent orchestrator tab and a child stream): the
+   * candidate that actually holds durable todo/plan data is preferred over a
+   * bare `meta.json`-only match.
+   */
+  async hasPersistedWorkPlan(stream: StreamTabId): Promise<boolean> {
+    return this.kv(stream).exists(STREAM_DATA_KEYS.WORK_PLAN);
   }
 
   /**

--- a/src/transcript/executionStreamResolver.ts
+++ b/src/transcript/executionStreamResolver.ts
@@ -1,3 +1,5 @@
+import pMap from 'p-map';
+
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
 import { StreamSnapshotStore } from './StreamSnapshotStore';
@@ -13,8 +15,22 @@ export interface PersistedStreamIdResolution {
 
 export interface PersistedStreamIdResolverOptions {
   readonly snapshotStore?: StreamSnapshotStore;
-  readonly streamLogStore?: Pick<StreamLogStore, 'keys'>;
+  readonly streamLogStore?: Pick<StreamLogStore, 'keys' | 'has'>;
   readonly fallbackStreamId?: StreamTabId;
+}
+
+/**
+ * Bounded fan-out for the per-execution meta scan. This resolver now runs on
+ * hot paths (every completed `/executions/{id}` summary, every
+ * `assembleTrace()` call) instead of the rare bulk-admin sweeps it was
+ * originally built for, so an unbounded `Promise.all` over every persisted
+ * stream risks file-descriptor pressure in a workspace with a large history.
+ */
+const META_SCAN_CONCURRENCY = 8;
+
+interface MetaMatchCandidate {
+  readonly streamId: StreamTabId;
+  readonly executionId: ExecutionId | undefined;
 }
 
 function findSuffixMatch(
@@ -23,6 +39,54 @@ function findSuffixMatch(
 ): StreamTabId | undefined {
   const suffix = `#${executionId}`;
   return streams.find((id) => id.endsWith(suffix));
+}
+
+/**
+ * Whether a meta-matched candidate actually holds durable data for this
+ * execution, as opposed to a bare `meta.json` record. Checked cheaply: an
+ * already-loaded `StreamLogStore.has()` lookup is O(1) in-memory, and
+ * `hasPersistedWorkPlan()` is a single stat, so this never re-reads the full
+ * per-stream sidecar set.
+ */
+async function hasRealPersistedData(
+  snapshotStore: StreamSnapshotStore,
+  streamId: StreamTabId,
+  streamLogStore: Pick<StreamLogStore, 'keys' | 'has'> | undefined,
+): Promise<boolean> {
+  if (streamLogStore?.has(streamId)) return true;
+  return snapshotStore.hasPersistedWorkPlan(streamId);
+}
+
+/**
+ * Disambiguate multiple persisted streams whose sidecar `meta.json` all
+ * reference the same `executionId` (e.g. a parent orchestrator tab and a
+ * `bash@tool#executionId` child stream). Prefers the first candidate that
+ * actually has `streamLogs`/`workPlan.json` data; a bare metadata match is a
+ * last resort so the resolver still returns *something* rather than nothing.
+ */
+async function pickBestMetaMatch(
+  candidates: readonly MetaMatchCandidate[],
+  snapshotStore: StreamSnapshotStore,
+  streamLogStore: Pick<StreamLogStore, 'keys' | 'has'> | undefined,
+): Promise<StreamTabId> {
+  if (candidates.length === 1) return candidates[0].streamId;
+
+  const withData = await pMap(
+    candidates,
+    async (candidate) => ({
+      candidate,
+      hasData: await hasRealPersistedData(
+        snapshotStore,
+        candidate.streamId,
+        streamLogStore,
+      ),
+    }),
+    { concurrency: META_SCAN_CONCURRENCY },
+  );
+  return (
+    withData.find((entry) => entry.hasData)?.candidate.streamId ??
+    candidates[0].streamId
+  );
 }
 
 /**
@@ -39,16 +103,24 @@ export async function resolvePersistedStreamIdForExecution(
   const snapshotStore = options.snapshotStore ?? new StreamSnapshotStore();
   const persistedStreams = await snapshotStore.listPersistedStreams();
 
-  const matchedByMeta = (
-    await Promise.all(
-      persistedStreams.map(async (streamId) => ({
+  const metaCandidates = (
+    await pMap(
+      persistedStreams,
+      async (streamId): Promise<MetaMatchCandidate> => ({
         streamId,
         executionId: await snapshotStore.readPersistedExecutionId(streamId),
-      })),
+      }),
+      { concurrency: META_SCAN_CONCURRENCY },
     )
-  ).find((candidate) => candidate.executionId === executionId);
-  if (matchedByMeta) {
-    return { streamId: matchedByMeta.streamId, source: 'streamDataMeta' };
+  ).filter((candidate) => candidate.executionId === executionId);
+
+  if (metaCandidates.length > 0) {
+    const streamId = await pickBestMetaMatch(
+      metaCandidates,
+      snapshotStore,
+      options.streamLogStore,
+    );
+    return { streamId, source: 'streamDataMeta' };
   }
 
   const matchedSidecar = findSuffixMatch(persistedStreams, executionId);


### PR DESCRIPTION
## Summary

`resolvePersistedStreamIdForExecution()` matched on sidecar `meta.json`
`executionId` and returned the *first* stream it found. When several
persisted streams share an `executionId` (e.g. a parent orchestrator tab
and a child stream like `bash@tool#executionId`), the resolver could pick
whichever one the directory scan happened to read first — regardless of
which one actually held `streamLogs`/`workPlan.json`. Trace assembly could
then report `streamLogs_missing` for a run that has logs, and the
completed-run todo reader could silently read from the wrong sidecar.

The same scan also fanned out `readPersistedExecutionId()` over *every*
persisted stream in one unbounded `Promise.all`, and that method read all
6 sidecar files (`readStreamData()`) just to get `.meta` — fine for the
rare bulk-admin sweeps it was originally built for, expensive now that it
runs on every completed `/executions/{id}` summary and every
`assembleTrace()` call.

- `readPersistedExecutionId()` now reads only `meta.json` (reusing the
  already-exported `readMeta()`) instead of the full 6-file
  `readStreamData()`.
- The meta scan runs through a concurrency-bounded `pMap` (8-wide, matching
  the pattern already used elsewhere in this store) instead of an unbounded
  `Promise.all`.
- When more than one persisted stream matches an `executionId`, the
  resolver disambiguates with a cheap existence check — an already-loaded
  `StreamLogStore.has()` (O(1), used by `assembleTrace`) or a single stat
  via the new `hasPersistedWorkPlan()` (used by the completed-run todo
  reader) — before falling back to the first match.

- Closes #7298
- Closes #7299

## Test plan

- [x] `npx tsc --noEmit` across all workspace packages (`npm run typecheck`)
- [x] `npx eslint` on all changed files (clean)
- [x] New regression suite `src/test-kernel/transcript/executionStreamResolver.vitest.ts` (this resolver previously had no dedicated tests):
  - resolves the sole meta match without a data-presence check
  - prefers the candidate with a real `workPlan.json` over a bare meta-only match sharing the same `executionId` (#7298) — named so the no-data candidate sorts first in the directory listing, so the test actually catches the "first match wins" bug rather than passing by directory-order coincidence
  - prefers the candidate with real `streamLogs` (via an already-loaded `StreamLogStore`) the same way (#7298)
  - bounds concurrent meta-file reads to the resolver's worker-pool size instead of firing 20-at-once for 20 candidates (#7299) — confirmed this test fails against the pre-fix code (maxInFlight hits 20)
- [x] Full `src/test-kernel/transcript/` suite (66 tests) and the `ExecutionsTool` suites that exercise `readCompletedRunTodos` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nbVZZcHVNLBNZ2tESvR7v

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path transcript resolution used by execution summaries and trace assembly; behavior shifts when multiple streams share an executionId, though tests target the prior wrong-stream cases.
> 
> **Overview**
> Fixes **`resolvePersistedStreamIdForExecution()`** so completed-run summaries, trace assembly, and todo reads hit the stream that actually has transcript data, without scanning every sidecar file at once.
> 
> When several persisted streams share the same **`executionId`** (parent orchestrator vs child tool stream), resolution no longer stops at the first **`meta.json`** match from directory order. It collects all meta matches, then prefers a candidate with **`streamLogs`** (via an optional loaded **`StreamLogStore.has()`**) or a persisted **`workPlan.json`** (**`hasPersistedWorkPlan()`** stat); a bare meta-only stream is only a fallback.
> 
> The meta scan is **8-wide `pMap`** instead of unbounded **`Promise.all`**, and **`readPersistedExecutionId()`** reads only **`meta.json`** via **`readMeta()`** instead of the full **`readStreamData()`** set. A new **`executionStreamResolver.vitest.ts`** suite covers sole-match behavior, disambiguation (#7298), and concurrency bounds (#7299).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 133d4f295ab9d3bb39f9d135c97b50b83c9a9aca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->