### PR TITLE
fix(agent-runtime): fix dispose/interrupt ordering for WAITING native subagents

### DIFF
--- a/src/agent/implementations/flows/tooluse/ToolUseServices.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseServices.ts
@@ -15,6 +15,10 @@ export type ToolUseBeforeWaitingCallback = (
   lastResponse: string | undefined,
   touchedFiles: string[],
   memoryMisses: readonly AttachedMemoryMiss[],
+  /** Run cost accumulated so far, when available — lets a native subagent
+   *  strategy settle the parent's usage totals if this suspended turn is
+   *  later abandoned instead of resumed to completion. */
+  totalCostUsd?: number,
 ) => boolean | void | Promise<boolean | void>;
 
 export interface ToolUseServices<C = unknown> extends BaseFlowContextInit<C> {

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -25,6 +25,9 @@ interface WaitPrepResult {
   previouslyDeliveredToOrchestrator: boolean;
   /** Set after the current cycle has been delivered to an orchestrator. */
   deliveredToOrchestrator?: boolean;
+  /** Run cost accumulated so far — forwarded to `onBeforeWaiting` so a
+   *  suspended-then-abandoned native subagent can still settle its cost. */
+  totalCostUsd?: number;
 }
 
 export class ToolUseWaitNode<C> extends Node<
@@ -48,6 +51,8 @@ export class ToolUseWaitNode<C> extends Node<
             modelHandler.extractAssistantText(m),
           )
         : undefined,
+      totalCostUsd:
+        shared.stateSlices?.runStateSnapshot.usageAccumulator.totals.totalCost,
     };
   }
 
@@ -94,6 +99,7 @@ export class ToolUseWaitNode<C> extends Node<
         prepRes.lastResponse,
         prepRes.touchedFiles,
         this.services.attachedMemoryMisses ?? [],
+        prepRes.totalCostUsd,
       );
       prepRes.deliveredToOrchestrator =
         onBeforeWaiting !== undefined && delivered !== false;

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -94,7 +94,17 @@ export class ToolUseWaitNode<C> extends Node<
         await setGoalSessionBashAutoApproval(streamId, false, runtimeHost);
         emitRunFact(this.services.logger, 'goalPaused', { streamId });
       }
-    } else if (!prepRes.previouslyDeliveredToOrchestrator) {
+    } else {
+      // Always call `onBeforeWaiting`, even when an earlier cycle already
+      // delivered this subagent's result. `NativeSubagentStrategy.onBeforeWaiting`
+      // re-registers this turn's `abandon()` cleanup on the current
+      // `runHandle` on every genuinely-suspending call — initial launch and
+      // every resume alike (see its doc comment) — and is otherwise a no-op
+      // "already delivered" short-circuit. Skipping the call here (as a
+      // `previouslyDeliveredToOrchestrator` fast path once did) would leave a
+      // turn that resumes already-delivered and suspends again with no
+      // cleanup registered on its handle, so a later stop/kill of that
+      // suspension would bypass the strategy's own teardown.
       const delivered = await onBeforeWaiting?.(
         prepRes.lastResponse,
         prepRes.touchedFiles,
@@ -102,9 +112,8 @@ export class ToolUseWaitNode<C> extends Node<
         prepRes.totalCostUsd,
       );
       prepRes.deliveredToOrchestrator =
-        onBeforeWaiting !== undefined && delivered !== false;
-    } else {
-      prepRes.deliveredToOrchestrator = true;
+        prepRes.previouslyDeliveredToOrchestrator ||
+        (onBeforeWaiting !== undefined && delivered !== false);
     }
 
     const shouldSuspendNativeSubagent =

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -463,7 +463,17 @@ export async function runToolUseFlow<C = unknown>(
       }
     }
 
-    sessionLifecycle.dispose();
+    // WAITING outcome: leave the follow-up queue live, matching the flow
+    // record preserved above. A delegate_agent follow-up can race into it via
+    // sendFollowUp's 'active' branch between the WAITING transition inside
+    // ToolUseWaitNode and this teardown — the tool-use flow context detaches
+    // above, but the stream doesn't leave WAITING until resume, so the same
+    // live queue instance is what a genuine kill (see ExecutionRegistry.
+    // terminate's waiting-cleanup path) or resume drains instead of a
+    // `dispose()` here silently discarding it.
+    if (outcome !== STREAM_PHASE.WAITING) {
+      sessionLifecycle.dispose();
+    }
     runSession.coordinators.cleanupRequestsForStream(streamId);
     runSession.interrupts.unregister(streamId);
     for (const handler of switchedHandlers) {

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -236,9 +236,23 @@ export async function runFlowWithLifecycle(
         void getExecutionStore(ctx.executionId)
           .delete(flowKey(ctx.executionId))
           .catch(() => {});
+        // The kill path never resumes this run, so the per-suspension parent
+        // stage opened by beginRunStage would otherwise dangle open forever.
+        endParentStageSafely(
+          ctx,
+          agentIdentifier,
+          legacyEndGroupStatusForOutcome(RUN_OUTCOME.CANCELLED),
+        );
       });
       return result;
     }
+    // The wait node may have pre-registered a suspension cleanup (via
+    // onBeforeWaiting) on a turn that then continued past the wait instead of
+    // suspending. This run is terminating normally, so drop any stale
+    // registration before teardown unregisters the interrupt — otherwise
+    // ExecutionRegistry.terminate() could mistake this handle for a suspended
+    // one in the window between interrupt-unregister and untrack.
+    handle.clearWaitingCleanup();
     // The flow's outcome is the canonical terminal fact; everything below is
     // one row of the projection table. No other layer may re-derive these.
     const projection = projectRunOutcome(result.outcome);
@@ -314,6 +328,9 @@ export async function runFlowWithLifecycle(
     logger.debug(`Task completed with outcome: ${result.outcome}`);
     return result;
   } catch (err) {
+    // Same stale-registration guard as the success arm: an errored run is
+    // not suspended, so no waiting-cleanup may survive into teardown.
+    handle.clearWaitingCleanup();
     const kind = classifyAgentError(err);
     const outcome = AGENT_ERROR_OUTCOME[kind];
     const projection = projectRunOutcome(outcome);

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -3,8 +3,9 @@ import {
   setFirstRunDone,
 } from '@controllers/onboarding/onboardingFunnel';
 import { platform } from '@platform/platform';
-import { writeTerminalStatus } from '@agent/storage';
+import { getExecutionStore, writeTerminalStatus } from '@agent/storage';
 import { logSdkError, type ResultEvent } from '@agent/trace';
+import { flowKey } from '@agent/node/persistedFlow';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 import {
@@ -224,6 +225,18 @@ export async function runFlowWithLifecycle(
     const result = await runner(handle);
     if (isWaitingFlowResult(result)) {
       logger.debug(`Task suspended with outcome: ${result.outcome}`);
+      // The handle stays tracked (correct for resume) but the live tool-use
+      // session and its interrupt registration are already gone by the time
+      // this returns (runToolUseFlow's finally). Register a fallback so a
+      // stop/kill during the suspended window still tears this down instead
+      // of ExecutionRegistry.terminate() finding no interruptible context and
+      // no-oping — see AgentRunLifecycle/ExecutionRegistry issue #7287.
+      handle.registerWaitingCleanup(() => {
+        ctx.session.followUps.release(streamId);
+        void getExecutionStore(ctx.executionId)
+          .delete(flowKey(ctx.executionId))
+          .catch(() => {});
+      });
       return result;
     }
     // The flow's outcome is the canonical terminal fact; everything below is

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -64,6 +64,7 @@ export class AgentExecutionHandle implements ExecutionHandle {
   private _parentStreamId: StreamTabId;
   private _deliveryTargetStreamId: StreamTabId | undefined;
   private toolUseFlowContext?: LiveToolUseFlowContext;
+  private waitingCleanups?: Set<() => void>;
 
   /** Stable tool name for UI identification (e.g. "bash", "codex"). */
   toolName?: string;
@@ -132,6 +133,33 @@ export class AgentExecutionHandle implements ExecutionHandle {
   getToolUseFlow(): LiveToolUseFlowContext | undefined {
     return this.toolUseFlowContext;
   }
+
+  /**
+   * Register a teardown callback for when this handle is torn down while
+   * suspended at WAITING — the live tool-use session and interrupt
+   * registration are already gone by then (`runToolUseFlow`'s `finally`
+   * unregisters them unconditionally on return, while the handle itself stays
+   * tracked so a later resume can find it). `ExecutionRegistry.terminate()`
+   * runs these instead of the (now absent) live interrupt when a stop/kill
+   * targets a suspended subagent. Multiple independent owners (the run
+   * lifecycle, a native subagent delivery strategy) may each register their
+   * own teardown.
+   */
+  registerWaitingCleanup(cleanup: () => void): void {
+    (this.waitingCleanups ??= new Set()).add(cleanup);
+  }
+
+  /**
+   * Run and clear every registered waiting-cleanup callback.
+   * Returns whether any callback was registered (and thus ran).
+   */
+  runWaitingCleanup(): boolean {
+    const cleanups = this.waitingCleanups;
+    if (!cleanups || cleanups.size === 0) return false;
+    this.waitingCleanups = undefined;
+    for (const cleanup of cleanups) cleanup();
+    return true;
+  }
 }
 
 export type AgentRunHandle = Pick<
@@ -146,6 +174,7 @@ export type AgentRunHandle = Pick<
   | 'trace'
   | 'result'
   | 'deliveryTargetStreamId'
+  | 'registerWaitingCleanup'
 >;
 
 /**

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -150,6 +150,18 @@ export class AgentExecutionHandle implements ExecutionHandle {
   }
 
   /**
+   * Drop every registered waiting-cleanup without running it. The run
+   * lifecycle calls this on every non-WAITING terminal path: owners may
+   * pre-register from `onBeforeWaiting` before the suspension is confirmed,
+   * and a flow that continues past the wait (queued follow-up) or errors out
+   * must not leave a stale cleanup that `ExecutionRegistry.terminate()` could
+   * mistake for a suspended handle during normal teardown.
+   */
+  clearWaitingCleanup(): void {
+    this.waitingCleanups = undefined;
+  }
+
+  /**
    * Run and clear every registered waiting-cleanup callback.
    * Returns whether any callback was registered (and thus ran).
    */

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -33,7 +33,7 @@ import {
   StreamLogStore,
   unregisterFlushers,
 } from '@transcript';
-import type { AgentTrace, ResultEvent } from '@agent/trace';
+import type { AgentEvent, AgentTrace, ResultEvent } from '@agent/trace';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import { createChannelTrace } from '@logger';
 import type { StreamTabId } from '@shared/schemas';
@@ -132,7 +132,12 @@ export class SessionHandle {
     const executions =
       init.executions ??
       new ExecutionRegistry({ interrupts, streamStatus: status, events });
-    executions.attachSessionEvents(events);
+    // Re-attaching on every `SessionHandle` construction — including for the
+    // shared/default-session `ExecutionRegistry` singleton, which predates any
+    // session — rebinds `publishResult` to *this* session's listeners.
+    executions.attachSessionEvents(events, (event, streamId) =>
+      this.publishRunEvent(streamId, event),
+    );
     const coordinators =
       init.coordinators ?? new RunCoordinatorBridge(executions);
 
@@ -189,21 +194,35 @@ export class SessionHandle {
    * run bundles into its trace teardown.
    */
   attachRunTrace(trace: AgentTrace, streamId: StreamTabId): () => void {
-    return trace.subscribe((event) => {
-      this.events.emit({ scope: 'run', streamId, event });
-      if (event.type !== 'result') return;
-      // Guard each listener so one throwing consumer can't starve the rest:
-      // the whole fan-out is a single trace subscriber, so without this a throw
-      // would skip the remaining listeners (TraceEmitter only guards at the
-      // subscriber boundary, not between listeners).
-      for (const listener of this.resultListeners) {
-        try {
-          listener(event);
-        } catch (err) {
-          logger.warn('onResult listener threw', { data: err });
-        }
+    return trace.subscribe((event) => this.publishRunEvent(streamId, event));
+  }
+
+  /**
+   * Forward one run-scoped event to this session's event bus and, for
+   * terminal `result` events, to `onResult` listeners. Shared by
+   * `attachRunTrace` (the live per-run trace subscription above) and by
+   * `ExecutionRegistry`'s injected `publishResult` callback (see
+   * `attachSessionEvents`), which needs the identical forwarding for a
+   * terminal event synthesized *after* the originating run's own trace has
+   * already been disposed — killing a native subagent suspended at WAITING
+   * (`terminateWaitingHandle`) settles `handle.result` and the run's own
+   * (already-torn-down) trace, but has no other way to reach this session's
+   * `onResult` subscribers.
+   */
+  publishRunEvent(streamId: StreamTabId, event: AgentEvent): void {
+    this.events.emit({ scope: 'run', streamId, event });
+    if (event.type !== 'result') return;
+    // Guard each listener so one throwing consumer can't starve the rest:
+    // the whole fan-out is a single trace subscriber, so without this a throw
+    // would skip the remaining listeners (TraceEmitter only guards at the
+    // subscriber boundary, not between listeners).
+    for (const listener of this.resultListeners) {
+      try {
+        listener(event);
+      } catch (err) {
+        logger.warn('onResult listener threw', { data: err });
       }
-    });
+    }
   }
 
   /**

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -861,10 +861,13 @@ export class ExecutionRegistry {
    * between its own interrupt-unregister and untrack during normal teardown.
    *
    * This path bypasses `runFlowWithLifecycle`'s own terminal handling (the
-   * flow never resumes to produce one), so it settles `handle.result` and
-   * persists the terminal status itself — otherwise a consumer awaiting
-   * `handle.result` (F-2) would hang forever and the execution's history
-   * would keep a non-terminal status.
+   * flow never resumes to produce one), so it emits the terminal `result` on
+   * the run trace, settles `handle.result`, and persists the terminal status
+   * itself — otherwise trace subscribers would miss the stop, a consumer
+   * awaiting `handle.result` (F-2) would hang forever, and the execution's
+   * history would keep a non-terminal status. Unlike `emitRunResult`, no
+   * usage totals ride the event: the flow is suspended, so there is no live
+   * usage monitor to read.
    */
   private terminateWaitingHandle(handle: AgentExecutionHandle): boolean {
     if (!handle.runWaitingCleanup()) return false;
@@ -877,6 +880,7 @@ export class ExecutionRegistry {
       category: handle.category,
       isSubagent: handle.isChildExecution,
     };
+    handle.trace?.emit(cancelledResult);
     handle.settleResult(cancelledResult);
     void writeTerminalStatus(
       handle.executionId,

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -5,6 +5,8 @@
  * notification, and subagent lineage tracking in a single module.
  */
 
+import { writeTerminalStatus } from '@agent/storage';
+import type { ResultEvent } from '@agent/trace';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
   StreamStatusService,
@@ -17,8 +19,10 @@ import {
 import {
   isInFlightStatus,
   isLiveElapsedStatus,
+  projectRunOutcome,
 } from '@common/constants/streamStatus';
 import {
+  RUN_OUTCOME,
   STREAM_PHASE,
   STREAM_STATUS,
   STREAM_SUBSTATE,
@@ -855,9 +859,29 @@ export class ExecutionRegistry {
    * interrupt context. Returns false (no-op) when the handle never registered
    * a waiting-cleanup — i.e. it isn't actually suspended, just momentarily
    * between its own interrupt-unregister and untrack during normal teardown.
+   *
+   * This path bypasses `runFlowWithLifecycle`'s own terminal handling (the
+   * flow never resumes to produce one), so it settles `handle.result` and
+   * persists the terminal status itself — otherwise a consumer awaiting
+   * `handle.result` (F-2) would hang forever and the execution's history
+   * would keep a non-terminal status.
    */
   private terminateWaitingHandle(handle: AgentExecutionHandle): boolean {
     if (!handle.runWaitingCleanup()) return false;
+    const cancelledResult: ResultEvent = {
+      type: 'result',
+      outcome: RUN_OUTCOME.CANCELLED,
+      executionId: handle.executionId,
+      streamId: handle.childStreamId,
+      agentName: handle.agentName,
+      category: handle.category,
+      isSubagent: handle.isChildExecution,
+    };
+    handle.settleResult(cancelledResult);
+    void writeTerminalStatus(
+      handle.executionId,
+      projectRunOutcome(RUN_OUTCOME.CANCELLED).executionStatus,
+    ).catch(() => {});
     this.untrackHandle(handle);
     this.streamStatus.transition(
       handle.childStreamId,

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -144,6 +144,15 @@ export class ExecutionRegistry {
   private readonly streamStatus: StreamStatusMachine;
   private readonly interrupts: InterruptRegistry;
   private events: SessionEventHub | undefined;
+  /**
+   * Publishes a synthesized terminal `result` event to the owning session's
+   * `onResult` channel — the same forwarding `SessionHandle.attachRunTrace`
+   * does for a live run's own trace, injected here because
+   * `terminateWaitingHandle` produces its `result` event *after* the
+   * suspended run's own trace has already been disposed (see there).
+   */
+  private publishResult:
+    ((event: ResultEvent, streamId: StreamTabId) => void) | undefined;
   // Persistent listeners stay attached across notifications (unlike one-shot
   // waiters in `changeCallbacks`). Used by the executions subscribe action.
   private readonly persistentListeners = new Map<
@@ -156,16 +165,21 @@ export class ExecutionRegistry {
     processOutput = new ProcessOutputPoller(),
     streamStatus = StreamStatusService,
     events,
+    publishResult,
   }: {
     readonly interrupts?: InterruptRegistry;
     readonly processOutput?: ProcessOutputPoller;
     readonly streamStatus?: StreamStatusMachine;
     readonly events?: SessionEventHub;
+    readonly publishResult?: (
+      event: ResultEvent,
+      streamId: StreamTabId,
+    ) => void;
   } = {}) {
     this.interrupts = interrupts;
     this.processOutput = processOutput;
     this.streamStatus = streamStatus;
-    if (events) this.attachSessionEvents(events);
+    if (events) this.attachSessionEvents(events, publishResult);
     // Notify waiters and refresh UI badges when stream status changes
     // (e.g. RUNNING → WAITING). Without this, waitForChange only resolves
     // on progress/kill/untrack, and the background-tasks panel shows stale badges.
@@ -190,8 +204,12 @@ export class ExecutionRegistry {
     );
   }
 
-  attachSessionEvents(events: SessionEventHub): void {
+  attachSessionEvents(
+    events: SessionEventHub,
+    publishResult?: (event: ResultEvent, streamId: StreamTabId) => void,
+  ): void {
     this.events = events;
+    if (publishResult) this.publishResult = publishResult;
     this.processOutput.setOutputEmitter((payload) => {
       events.emit({
         scope: 'run',
@@ -861,13 +879,22 @@ export class ExecutionRegistry {
    * between its own interrupt-unregister and untrack during normal teardown.
    *
    * This path bypasses `runFlowWithLifecycle`'s own terminal handling (the
-   * flow never resumes to produce one), so it emits the terminal `result` on
-   * the run trace, settles `handle.result`, and persists the terminal status
-   * itself — otherwise trace subscribers would miss the stop, a consumer
-   * awaiting `handle.result` (F-2) would hang forever, and the execution's
-   * history would keep a non-terminal status. Unlike `emitRunResult`, no
-   * usage totals ride the event: the flow is suspended, so there is no live
-   * usage monitor to read.
+   * flow never resumes to produce one), so it publishes the terminal
+   * `result`, settles `handle.result`, and persists the terminal status
+   * itself — otherwise trace/session subscribers would miss the stop, a
+   * consumer awaiting `handle.result` (F-2) would hang forever, and the
+   * execution's history would keep a non-terminal status. Unlike
+   * `emitRunResult`, no usage totals ride the event: the flow is suspended,
+   * so there is no live usage monitor to read.
+   *
+   * `handle.trace` belongs to the turn that suspended this handle at WAITING,
+   * and `runFlowWithLifecycle`'s own `finally` already disposed it (channel +
+   * transcript + session bridge) the moment that turn returned — emitting on
+   * it is a harmless best effort, not the real fix. `publishResult` (wired
+   * from `SessionHandle.publishRunEvent`) reaches this session's
+   * `onResult`/event-bus subscribers directly instead, so a user-initiated
+   * stop of a suspended native subagent still surfaces a terminal event even
+   * though the turn's own trace is already gone.
    */
   private terminateWaitingHandle(handle: AgentExecutionHandle): boolean {
     if (!handle.runWaitingCleanup()) return false;
@@ -881,6 +908,7 @@ export class ExecutionRegistry {
       isSubagent: handle.isChildExecution,
     };
     handle.trace?.emit(cancelledResult);
+    this.publishResult?.(cancelledResult, handle.childStreamId);
     handle.settleResult(cancelledResult);
     void writeTerminalStatus(
       handle.executionId,

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -822,18 +822,25 @@ export class ExecutionRegistry {
         this.interruptActiveChildren(handle.childStreamId, visited, options);
       }
       const interruptible = this.interrupts.get(handle.childStreamId);
-      if (!interruptible) return false;
-      interruptible.interrupt();
-      this.streamStatus.transition(
-        handle.childStreamId,
-        STREAM_PHASE.CANCELLED,
-        'user-stop',
-        {
-          runtimeHost: handle.runtimeHost,
-          trace: handle.trace,
-        },
-      );
-      return true;
+      if (interruptible) {
+        interruptible.interrupt();
+        this.streamStatus.transition(
+          handle.childStreamId,
+          STREAM_PHASE.CANCELLED,
+          'user-stop',
+          {
+            runtimeHost: handle.runtimeHost,
+            trace: handle.trace,
+          },
+        );
+        return true;
+      }
+      // No live interrupt context: a native subagent suspended at WAITING has
+      // already had its tool-use session disposed and interrupt unregistered
+      // (runToolUseFlow's finally), while the handle stays tracked for resume
+      // (runFlowWithLifecycle). Run its registered waiting-cleanup instead of
+      // silently no-oping the kill.
+      return this.terminateWaitingHandle(handle);
     }
 
     if (handle instanceof ProcessExecutionHandle) {
@@ -841,6 +848,27 @@ export class ExecutionRegistry {
     }
 
     return false;
+  }
+
+  /**
+   * Tear down an `AgentExecutionHandle` suspended at WAITING with no live
+   * interrupt context. Returns false (no-op) when the handle never registered
+   * a waiting-cleanup — i.e. it isn't actually suspended, just momentarily
+   * between its own interrupt-unregister and untrack during normal teardown.
+   */
+  private terminateWaitingHandle(handle: AgentExecutionHandle): boolean {
+    if (!handle.runWaitingCleanup()) return false;
+    this.untrackHandle(handle);
+    this.streamStatus.transition(
+      handle.childStreamId,
+      STREAM_PHASE.CANCELLED,
+      'user-stop',
+      {
+        runtimeHost: handle.runtimeHost,
+        trace: handle.trace,
+      },
+    );
+    return true;
   }
 
   private interruptRegisteredStream(

--- a/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
@@ -189,7 +189,7 @@ describe('ToolUseFollowUp', () => {
       );
       assert.equal(resumedSessionLifecycle.hasQueuedFollowUp(), true);
     } finally {
-      executionRegistry.untrack(executionId);
+      SharedExecutionRegistry.untrack(executionId);
       sessionLifecycle.dispose();
     }
   });

--- a/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
@@ -31,6 +31,7 @@ import {
   wakeOrReleaseQueuedStream,
 } from '@agent/followUp/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
+import { ToolUseSessionLifecycle } from '@agent/implementations/flows/tooluse/ToolUseSessionLifecycle';
 import type { FollowUpQueueInput } from '@agent/followUp/FollowUpQueue';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
@@ -145,6 +146,52 @@ describe('ToolUseFollowUp', () => {
     assert.deepEqual(calls, [
       { text: 'subagent result', origin: 'subagent_result' },
     ]);
+  });
+
+  it('does not drop a follow-up that races into the live queue before a WAITING teardown (issue #7286)', async () => {
+    // Regression: runToolUseFlow's finally called sessionLifecycle.dispose()
+    // unconditionally, even on the WAITING branch. While the tool-use flow
+    // context is still attached (teardownSetup/detach runs earlier in that
+    // same finally, but after a follow-up can land here), a delegate_agent
+    // follow-up can reach the live queue via sendFollowUp's 'active' branch
+    // -- dispose() then released that same queue, silently discarding the
+    // item before the native wake path (which only handles 'queued' results)
+    // ever saw it. Fixed by skipping dispose() when the outcome is WAITING.
+    const waitingStreamId = 'stream-waiting-race-follow-up' as StreamTabId;
+    const sessionLifecycle = new ToolUseSessionLifecycle(
+      waitingStreamId,
+      ToolUseFollowUpQueue.defaultInstance(),
+    );
+    const executionId = trackToolUseFlow(waitingStreamId, (followUp) =>
+      sessionLifecycle.appendFollowUp(followUp),
+    );
+
+    try {
+      // Simulate the race: a delegate_agent follow-up lands in the live
+      // session while the tool-use flow context is still attached.
+      const result = await sendFollowUp(waitingStreamId, 'keep going');
+      assert.deepEqual(result, { status: 'sent' });
+      assert.equal(sessionLifecycle.hasQueuedFollowUp(), true);
+
+      // runToolUseFlow's finally, on the WAITING branch, now skips
+      // sessionLifecycle.dispose() -- the follow-up survives instead of
+      // being dropped when the queue would otherwise have been released.
+      assert.deepEqual(ToolUseFollowUpQueue.getAll(waitingStreamId), [
+        'keep going',
+      ]);
+
+      // A subsequent resume constructs a new ToolUseSessionLifecycle for the
+      // same stream; since the queue was never released, acquire() hands
+      // back the same live instance with the raced-in follow-up intact.
+      const resumedSessionLifecycle = new ToolUseSessionLifecycle(
+        waitingStreamId,
+        ToolUseFollowUpQueue.defaultInstance(),
+      );
+      assert.equal(resumedSessionLifecycle.hasQueuedFollowUp(), true);
+    } finally {
+      executionRegistry.untrack(executionId);
+      sessionLifecycle.dispose();
+    }
   });
 
   it('reports unknown streams as no session', async () => {

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -154,7 +154,11 @@ describe('ToolUseWaitNode', () => {
       },
     );
 
-    expect(onBeforeWaiting).toHaveBeenCalledOnce();
+    // Called on both turns: `onBeforeWaiting` fires on every genuine-suspend
+    // attempt regardless of prior delivery (see the dedicated abandon-hook
+    // regression test below) — the second call's `mockResolvedValueOnce(true)`
+    // exercises that.
+    expect(onBeforeWaiting).toHaveBeenCalledTimes(2);
     expect(secondTransition).toBe(FlowTransition.WAITING);
     expect(shared.deliveredToOrchestrator).toBe(true);
   });
@@ -202,10 +206,58 @@ describe('ToolUseWaitNode', () => {
       },
     );
 
-    expect(onBeforeWaiting).not.toHaveBeenCalled();
+    // `onBeforeWaiting` is now called even on an already-delivered turn (see
+    // "still calls onBeforeWaiting ... suspends again" below): it is
+    // idempotent (NativeSubagentStrategy short-circuits redelivery via its
+    // own delivery-state) and registering the strategy's abandon() cleanup on
+    // *this* turn's runHandle must not depend on whether delivery is a no-op.
+    expect(onBeforeWaiting).toHaveBeenCalledOnce();
     expect(onFollowUpConsumed).toHaveBeenCalledOnce();
     expect(transition).toBe(FlowTransition.CONTINUE);
     expect(shared.deliveredToOrchestrator).toBeUndefined();
+  });
+
+  it('still calls onBeforeWaiting (registering waiting-cleanup) when an already-delivered turn suspends again (Bugbot: skipped wait omits abandon hook)', async () => {
+    // Regression: previously, `previouslyDeliveredToOrchestrator` skipped
+    // `onBeforeWaiting` entirely, so a native subagent that resumes
+    // already-delivered and then suspends at WAITING again never registered
+    // this turn's `abandon()` cleanup on its `runHandle` — a later stop/kill
+    // of that second suspension fell through to bare untrack side effects
+    // instead of the strategy's own teardown. `onBeforeWaiting` must fire
+    // (and thus its cleanup-registration side effect run) on every turn that
+    // reaches a genuine WAITING suspend, regardless of prior delivery.
+    const shared: ToolUseRunShared = {
+      deliveredToOrchestrator: true,
+      messages: [],
+      shouldSkipCycle: false,
+      stateSlices: null,
+    };
+    const onBeforeWaiting = vi.fn(async () => true);
+    const runtimeHost = { emit: vi.fn() };
+
+    const services = {
+      checkInterruption: () => false,
+      isSubagent: true,
+      logger: { emit: vi.fn(), error: vi.fn(), info: vi.fn() },
+      modelHandler: { extractAssistantText: () => undefined },
+      onBeforeWaiting,
+      runtimeHost,
+      session: {
+        hasQueuedFollowUp: () => false,
+        waitForFollowUp: vi.fn(),
+      },
+      streamStatus: new StreamStatusMachine(),
+      streamId: 'test-stream',
+    } as unknown as ToolUseServices;
+
+    const node = new ToolUseWaitNode().setServices(services);
+    const prep = await node.prep(shared);
+    const exec = await withTestRunContext(runtimeHost, 'test-stream', () =>
+      node.exec(prep),
+    );
+
+    expect(onBeforeWaiting).toHaveBeenCalledOnce();
+    expect(exec.kind).toBe('waiting');
   });
 
   it('preserves delivered state when interruption is already set before waiting', async () => {

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -78,7 +78,12 @@ describe('ToolUseWaitNode', () => {
     );
 
     expect(onBeforeWaiting).toHaveBeenCalledOnce();
-    expect(onBeforeWaiting).toHaveBeenCalledWith(undefined, [], memoryMisses);
+    expect(onBeforeWaiting).toHaveBeenCalledWith(
+      undefined,
+      [],
+      memoryMisses,
+      undefined,
+    );
     expect(transition).toBe(FlowTransition.WAITING);
     expect(shared.deliveredToOrchestrator).toBe(true);
   });

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -474,28 +474,29 @@ describe('runFlowWithLifecycle', () => {
       );
 
       expect(result.outcome).toBe(STREAM_PHASE.WAITING);
-      expect(executionRegistry.getHandle(executionId)).toBeDefined();
+      expect(SharedExecutionRegistry.getHandle(executionId)).toBeDefined();
       expect(followUpsRelease).not.toHaveBeenCalled();
       expect(storageMocks.deleteFlowRecord).not.toHaveBeenCalled();
 
-      // runToolUseFlow's finally has already disposed the live session and
-      // unregistered this stream's interrupt by the time a native subagent
-      // suspends at WAITING (not reproduced by this fake runner, but true in
-      // production — see runToolUseFlow.ts). Before the fix,
-      // executionRegistry.kill() found no interruptible context for a
-      // suspended handle and silently no-opped, leaving the handle stuck
-      // registered forever. It must now fall back to the waiting-cleanup
-      // registered above and actually tear the execution down.
-      expect(executionRegistry.kill(executionId)).toBe(true);
+      // runToolUseFlow's finally unregisters this stream's interrupt but
+      // (post #7286) preserves the follow-up queue for WAITING — it does not
+      // dispose the session — by the time a native subagent suspends at
+      // WAITING (not reproduced by this fake runner, but true in production —
+      // see runToolUseFlow.ts). Before the fix, SharedExecutionRegistry.kill()
+      // found no interruptible context for a suspended handle and silently
+      // no-opped, leaving the handle stuck registered forever. It must now
+      // fall back to the waiting-cleanup registered above and actually tear
+      // the execution down.
+      expect(SharedExecutionRegistry.kill(executionId)).toBe(true);
 
-      expect(executionRegistry.getHandle(executionId)).toBeUndefined();
+      expect(SharedExecutionRegistry.getHandle(executionId)).toBeUndefined();
       expect(StreamStatusService.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
       expect(followUpsRelease).toHaveBeenCalledWith(streamId);
       expect(storageMocks.deleteFlowRecord).toHaveBeenCalledWith(
         `flow_${executionId}`,
       );
     } finally {
-      executionRegistry.untrack(executionId);
+      SharedExecutionRegistry.untrack(executionId);
       clearStreamStatusForTest(StreamStatusService, streamId);
     }
   });

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -21,7 +21,10 @@ import {
   StreamStatusMachine,
   StreamStatusService,
 } from '@agent/runtime/StreamStatusService';
-import { SharedExecutionRegistry } from '@agent/runtime/executionRegistry';
+import {
+  SharedExecutionRegistry,
+  type AgentExecutionHandle,
+} from '@agent/runtime/executionRegistry';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { runFlowWithLifecycle } from '@agent/runtime/AgentRunLifecycle';
 import { AgentFlowError } from '@agent/runtime/AgentFlowResult';
@@ -454,11 +457,50 @@ describe('runFlowWithLifecycle', () => {
     }
   });
 
+  it('clears a pre-registered waiting-cleanup when the run completes without suspending', async () => {
+    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+      'lifecycle-stale-waiting-cleanup',
+    );
+    const staleCleanup = vi.fn();
+    let captured: AgentExecutionHandle | undefined;
+
+    try {
+      // Simulate onBeforeWaiting pre-registering on a turn that then
+      // continues past the wait (queued follow-up) and completes normally.
+      const result = await runFlowWithLifecycle(
+        ctx,
+        async () => ({
+          category: 'toolUse',
+          outcome: RUN_OUTCOME.COMPLETED,
+          executionId,
+          streamId,
+        }),
+        {
+          isSubagent: true,
+          onRun: (handle) => {
+            captured = handle as AgentExecutionHandle;
+            handle.registerWaitingCleanup(staleCleanup);
+          },
+        },
+      );
+
+      expect(result.outcome).toBe(RUN_OUTCOME.COMPLETED);
+      // The stale registration must be gone: nothing ran it, and a
+      // terminate() racing into the teardown window must not find it.
+      expect(staleCleanup).not.toHaveBeenCalled();
+      expect(captured?.runWaitingCleanup()).toBe(false);
+    } finally {
+      SharedExecutionRegistry.untrack(executionId);
+      clearStreamStatusForTest(streamStatus, streamId);
+    }
+  });
+
   it('lets a stop/kill tear down a subagent suspended at WAITING (issue #7287)', async () => {
     const { executionId, streamId, ctx } = lifecycleFixture(
       'lifecycle-subagent-waiting-kill',
     );
     const followUpsRelease = vi.spyOn(ctx.session.followUps, 'release');
+    const parentStageEnd = vi.spyOn(ctx.parentStage, 'end');
     storageMocks.deleteFlowRecord.mockClear();
 
     try {
@@ -510,6 +552,9 @@ describe('runFlowWithLifecycle', () => {
       expect(storageMocks.deleteFlowRecord).toHaveBeenCalledWith(
         `flow_${executionId}`,
       );
+      // The kill path never resumes, so the per-suspension parent stage must
+      // be closed here rather than dangling open forever.
+      expect(parentStageEnd).toHaveBeenCalled();
     } finally {
       SharedExecutionRegistry.untrack(executionId);
       clearStreamStatusForTest(StreamStatusService, streamId);

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -47,10 +47,12 @@ import { createRecordingHost } from '../progressTestUtils';
 
 const storageMocks = vi.hoisted(() => ({
   writeTerminalStatus: vi.fn().mockResolvedValue(undefined),
+  deleteFlowRecord: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('@agent/storage', () => ({
   writeTerminalStatus: storageMocks.writeTerminalStatus,
+  getExecutionStore: () => ({ delete: storageMocks.deleteFlowRecord }),
 }));
 
 async function initLifecycleTestPlatform(firstRunDone: boolean) {
@@ -449,6 +451,52 @@ describe('runFlowWithLifecycle', () => {
     } finally {
       SharedExecutionRegistry.untrack(executionId);
       clearStreamStatusForTest(streamStatus, streamId);
+    }
+  });
+
+  it('lets a stop/kill tear down a subagent suspended at WAITING (issue #7287)', async () => {
+    const { executionId, streamId, ctx } = lifecycleFixture(
+      'lifecycle-subagent-waiting-kill',
+    );
+    const followUpsRelease = vi.spyOn(ctx.session.followUps, 'release');
+    storageMocks.deleteFlowRecord.mockClear();
+
+    try {
+      const result = await runFlowWithLifecycle(
+        ctx,
+        async () => ({
+          category: 'toolUse',
+          outcome: STREAM_PHASE.WAITING,
+          executionId,
+          streamId,
+        }),
+        { isSubagent: true },
+      );
+
+      expect(result.outcome).toBe(STREAM_PHASE.WAITING);
+      expect(executionRegistry.getHandle(executionId)).toBeDefined();
+      expect(followUpsRelease).not.toHaveBeenCalled();
+      expect(storageMocks.deleteFlowRecord).not.toHaveBeenCalled();
+
+      // runToolUseFlow's finally has already disposed the live session and
+      // unregistered this stream's interrupt by the time a native subagent
+      // suspends at WAITING (not reproduced by this fake runner, but true in
+      // production — see runToolUseFlow.ts). Before the fix,
+      // executionRegistry.kill() found no interruptible context for a
+      // suspended handle and silently no-opped, leaving the handle stuck
+      // registered forever. It must now fall back to the waiting-cleanup
+      // registered above and actually tear the execution down.
+      expect(executionRegistry.kill(executionId)).toBe(true);
+
+      expect(executionRegistry.getHandle(executionId)).toBeUndefined();
+      expect(StreamStatusService.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
+      expect(followUpsRelease).toHaveBeenCalledWith(streamId);
+      expect(storageMocks.deleteFlowRecord).toHaveBeenCalledWith(
+        `flow_${executionId}`,
+      );
+    } finally {
+      executionRegistry.untrack(executionId);
+      clearStreamStatusForTest(StreamStatusService, streamId);
     }
   });
 

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -477,6 +477,9 @@ describe('runFlowWithLifecycle', () => {
       expect(SharedExecutionRegistry.getHandle(executionId)).toBeDefined();
       expect(followUpsRelease).not.toHaveBeenCalled();
       expect(storageMocks.deleteFlowRecord).not.toHaveBeenCalled();
+      // The fixture's ctx.logger is noopTrace, and the run handle carries it
+      // as its trace channel.
+      const traceEmit = vi.spyOn(noopTrace, 'emit');
 
       // runToolUseFlow's finally unregisters this stream's interrupt but
       // (post #7286) preserves the follow-up queue for WAITING — it does not
@@ -488,6 +491,18 @@ describe('runFlowWithLifecycle', () => {
       // fall back to the waiting-cleanup registered above and actually tear
       // the execution down.
       expect(SharedExecutionRegistry.kill(executionId)).toBe(true);
+
+      // The bypassed runFlowWithLifecycle can't emit the terminal result, so
+      // terminateWaitingHandle must — trace subscribers would otherwise miss
+      // the stop entirely.
+      expect(traceEmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'result',
+          outcome: 'cancelled',
+          executionId,
+        }),
+      );
+      traceEmit.mockRestore();
 
       expect(SharedExecutionRegistry.getHandle(executionId)).toBeUndefined();
       expect(StreamStatusService.get(streamId)).toBe(STREAM_PHASE.CANCELLED);

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -70,6 +70,77 @@ describe('executionRegistry', () => {
     }
   });
 
+  it('falls back to a registered waiting-cleanup when a suspended handle has no live interrupt (issue #7287)', () => {
+    // Regression: a native subagent suspended at WAITING has already had its
+    // live interrupt unregistered (runToolUseFlow's finally), while the
+    // handle stays tracked for resume. Before the fix, terminate() found no
+    // interruptible context and silently no-opped, leaving the handle stuck
+    // registered forever with no way to tear it down from a stop/kill.
+    const explicit = createRecordingHost();
+    const interrupts = new InterruptRegistry();
+    const streamStatus = new StreamStatusMachine();
+    const registry = new ExecutionRegistry({ interrupts, streamStatus });
+    const executionId = 'exec-waiting-cleanup-kill-test';
+    const parentStreamId = 'parent-waiting-cleanup-kill-test' as StreamTabId;
+    const childStreamId = 'child-waiting-cleanup-kill-test' as StreamTabId;
+    const cleanup = vi.fn();
+
+    try {
+      const handle = new AgentExecutionHandle(
+        executionId,
+        parentStreamId,
+        childStreamId,
+        'test-subagent',
+        'toolUse',
+        explicit.host,
+      );
+      registry.track(handle);
+      handle.registerWaitingCleanup(cleanup);
+      // No interrupts.register() for childStreamId: mirrors a suspended
+      // subagent whose live tool-use session has already been disposed.
+
+      expect(registry.kill(executionId)).toBe(true);
+
+      expect(cleanup).toHaveBeenCalledOnce();
+      expect(streamStatus.get(childStreamId)).toBe(STREAM_PHASE.CANCELLED);
+      expect(registry.getHandle(executionId)).toBeUndefined();
+    } finally {
+      registry.dispose();
+    }
+  });
+
+  it('reports a failed kill for a tracked handle with neither an interrupt nor a waiting-cleanup', () => {
+    // Guards the fallback above: a handle that never registered a
+    // waiting-cleanup (i.e. was never confirmed suspended at WAITING) must
+    // still no-op exactly like before the fix — otherwise the fallback could
+    // spuriously tear down a handle mid-completion, in the narrow window
+    // between its own interrupt unregister and its own untrack.
+    const streamStatus = new StreamStatusMachine();
+    const registry = new ExecutionRegistry({ streamStatus });
+    const executionId = 'exec-no-cleanup-kill-test';
+    const parentStreamId = 'parent-no-cleanup-kill-test' as StreamTabId;
+    const childStreamId = 'child-no-cleanup-kill-test' as StreamTabId;
+
+    try {
+      const handle = new AgentExecutionHandle(
+        executionId,
+        parentStreamId,
+        childStreamId,
+        'test-subagent',
+        'toolUse',
+        createRecordingHost().host,
+      );
+      registry.track(handle);
+
+      expect(registry.kill(executionId)).toBe(false);
+
+      expect(streamStatus.get(childStreamId)).toBeUndefined();
+      expect(registry.getHandle(executionId)).toBe(handle);
+    } finally {
+      registry.dispose();
+    }
+  });
+
   it('owns visible stream stop policy for root and children', () => {
     const explicit = createRecordingHost();
     const interrupts = new InterruptRegistry();

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import { seedStreamStatusForTest } from '@test/helpers/streamStatusTestUtils';
+import type { AgentTrace } from '@agent/trace';
 import {
   AgentExecutionHandle,
   ExecutionRegistry,
@@ -11,8 +12,14 @@ import {
 } from '@agent/runtime/executionRegistry';
 import { InterruptRegistry } from '@agent/runtime/InterruptRegistry';
 import { ProcessOutputPoller } from '@agent/runtime/ProcessOutputPoller';
+import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
-import { STREAM_PHASE, STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+import {
+  RUN_OUTCOME,
+  STREAM_PHASE,
+  STREAM_STATUS,
+  type StreamTabId,
+} from '@shared/schemas';
 
 import { createRecordingHost } from '../progressTestUtils';
 
@@ -104,6 +111,75 @@ describe('executionRegistry', () => {
       expect(cleanup).toHaveBeenCalledOnce();
       expect(streamStatus.get(childStreamId)).toBe(STREAM_PHASE.CANCELLED);
       expect(registry.getHandle(executionId)).toBeUndefined();
+    } finally {
+      registry.dispose();
+    }
+  });
+
+  it('publishes the cancelled terminal result when killing a suspended WAITING handle (Bugbot: waiting kill omits trace result)', async () => {
+    // Regression: terminateWaitingHandle settles handle.result and the run's
+    // own (already-disposed, per runFlowWithLifecycle's finally) trace, but
+    // previously never told the owning session about the terminal event —
+    // trace/session-result-stream subscribers (session.onResult et al.) would
+    // silently miss a user-initiated stop of a suspended native subagent even
+    // though handle.result itself resolved correctly. `publishResult` is the
+    // callback SessionHandle injects (see SessionHandle.publishRunEvent) so
+    // this path can reach those subscribers directly, since the turn's own
+    // trace subscriptions are already torn down by the time a kill runs.
+    const streamStatus = new StreamStatusMachine();
+    const publishResult = vi.fn();
+    const registry = new ExecutionRegistry({
+      streamStatus,
+      events: new SessionEventHub(),
+      publishResult,
+    });
+    const executionId = 'exec-waiting-kill-publish-result-test';
+    const parentStreamId =
+      'parent-waiting-kill-publish-result-test' as StreamTabId;
+    const childStreamId =
+      'child-waiting-kill-publish-result-test' as StreamTabId;
+    const trace: AgentTrace = { emit: vi.fn() } as unknown as AgentTrace;
+
+    try {
+      const handle = new AgentExecutionHandle(
+        executionId,
+        parentStreamId,
+        childStreamId,
+        'test-subagent',
+        'toolUse',
+        createRecordingHost().host,
+        undefined,
+        trace,
+      );
+      registry.track(handle);
+      handle.registerWaitingCleanup(() => {});
+
+      expect(registry.kill(executionId)).toBe(true);
+
+      expect(publishResult).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          type: 'result',
+          outcome: RUN_OUTCOME.CANCELLED,
+          executionId,
+          streamId: childStreamId,
+        }),
+        childStreamId,
+      );
+      // The (already-disposed-in-production) trace still gets a best-effort
+      // emit — harmless when there are no subscribers left, but exercised
+      // here to confirm the call site didn't drop it. (A second, unrelated
+      // `trace.emit` call comes from the streamStatus transition below.)
+      expect(trace.emit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'result',
+          outcome: RUN_OUTCOME.CANCELLED,
+        }),
+      );
+      await expect(handle.result).resolves.toMatchObject({
+        type: 'result',
+        outcome: RUN_OUTCOME.CANCELLED,
+        executionId,
+      });
     } finally {
       registry.dispose();
     }

--- a/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
+++ b/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
@@ -369,8 +369,11 @@ describe('NativeSubagentStrategy', () => {
     // strategy's private finish() for it. Without a waiting-cleanup hook,
     // killing the suspended child left `activeNativeSubagents` (and the
     // delivery registry) pointing at a gone execution forever.
+    mocks.persistChildRunReport.mockResolvedValue({ kind: 'persisted' });
+    mocks.deliverChildRunFollowUp.mockResolvedValue({ kind: 'delivered' });
     const handleParent = 'handle-parent-waiting' as StreamTabId;
     const childStream = 'child-stream-waiting' as StreamTabId;
+    const settleSubagentCost = vi.fn();
     const strategy = new NativeSubagentStrategy({
       executionId,
       agentName: 'review',
@@ -378,7 +381,7 @@ describe('NativeSubagentStrategy', () => {
       parentSession: ownerSession,
       runtimeHost: { emit: vi.fn() },
       startedAt: 0,
-      settleSubagentCost: vi.fn(),
+      settleSubagentCost,
     });
     const handle = new AgentExecutionHandle(
       executionId,
@@ -389,8 +392,14 @@ describe('NativeSubagentStrategy', () => {
       {} as never,
     );
     strategy.setRunHandle(handle);
+    strategy.setChildStreamId(childStream);
     expect(getNativeSubagentStrategy(executionId)).toBe(strategy);
 
+    // Production calls `onBeforeWaiting` (from inside the flow) before the
+    // top-level promise ever resolves — that's what registers the
+    // waiting-cleanup on the *current* `runHandle` (see `resumeStream`'s
+    // analogous second-suspension test below for the resumed case).
+    await strategy.onBeforeWaiting('done for now', [], [], 0.02);
     strategy.attachPromise(
       Promise.resolve({
         category: 'toolUse',
@@ -407,6 +416,82 @@ describe('NativeSubagentStrategy', () => {
 
     // Simulate ExecutionRegistry.terminate()'s waiting-cleanup fallback.
     expect(handle.runWaitingCleanup()).toBe(true);
+
+    expect(getNativeSubagentStrategy(executionId)).toBeUndefined();
+    expect(
+      SharedSubagentDeliveryRegistry.getActive(executionId),
+    ).toBeUndefined();
+    // abandon() settles the cost snapshot captured by the last onBeforeWaiting.
+    expect(settleSubagentCost).toHaveBeenCalledWith(
+      expect.objectContaining({ totalCostUsd: 0.02 }),
+    );
+  });
+
+  it('registers a waiting-cleanup on the resumed handle when a resumed subagent suspends at WAITING a second time (issue #7286/#7287)', async () => {
+    // Regression: `resumeStream()` replaces `runHandle` with a new handle for
+    // the resumed turn. Before the fix, the strategy's WAITING-cleanup was
+    // only ever attached to the *initial* launch promise (`attachPromise`),
+    // so stopping the child during a second (or later) suspended turn ran no
+    // strategy teardown at all — the fallback below would have found nothing
+    // registered on the new handle and returned `false`.
+    const childStream = 'child-stream-resume-waiting' as StreamTabId;
+    const runtimeHost = { emit: vi.fn() };
+    const config = { agentCategory: 'toolUse' };
+    const snapshot = {
+      agentConfig: config,
+      executionId,
+      messages: [],
+      streamId: childStream,
+    };
+    mocks.readConfig.mockResolvedValue(config);
+    mocks.retrieveSessionResumeData.mockResolvedValue({
+      type: 'toolUse',
+      snapshot,
+    });
+    mocks.persistChildRunReport.mockResolvedValue({ kind: 'persisted' });
+    mocks.deliverChildRunFollowUp.mockResolvedValue({ kind: 'delivered' });
+
+    const strategy = new NativeSubagentStrategy({
+      executionId,
+      agentName: 'review',
+      orchestratorStreamId: parentStreamId,
+      parentSession: ownerSession,
+      runtimeHost,
+      startedAt: 0,
+      settleSubagentCost: vi.fn(),
+    });
+    strategy.setChildStreamId(childStream);
+
+    const resumedHandle = new AgentExecutionHandle(
+      executionId,
+      parentStreamId,
+      childStream,
+      'review',
+      'toolUse',
+      {} as never,
+    );
+    // Simulate the resumed run's own lifecycle: it hands the strategy a
+    // brand-new handle (`onRun`), processes the queued follow-up, and then
+    // suspends at WAITING again (`onBeforeWaiting`) before resolving.
+    mocks.resumeQueuedToolUseSnapshot.mockImplementation(
+      async (_streamId, _snapshot, _host, options) => {
+        options.onRun(resumedHandle);
+        await options.onBeforeWaiting('resumed then waited again', [], []);
+        return true;
+      },
+    );
+
+    await expect(
+      strategy.wakeQueuedFollowUp({ status: 'queued', reason: 'waiting' }, {}),
+    ).resolves.toEqual({ kind: 'resumed' });
+
+    // The strategy is still tracked — this second suspension hasn't been
+    // torn down yet, only observed.
+    expect(getNativeSubagentStrategy(executionId)).toBe(strategy);
+
+    // The core fix: the *new* (resumed) handle — not the original launch
+    // handle — has its own waiting-cleanup registered.
+    expect(resumedHandle.runWaitingCleanup()).toBe(true);
 
     expect(getNativeSubagentStrategy(executionId)).toBeUndefined();
     expect(

--- a/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
+++ b/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
@@ -5,7 +5,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
 
 // Local imports - shared
-import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import {
+  STREAM_PHASE,
+  type ExecutionId,
+  type StreamTabId,
+} from '@shared/schemas';
 
 const mocks = vi.hoisted(() => ({
   deliverChildRunFollowUp: vi.fn(),
@@ -353,6 +357,57 @@ describe('NativeSubagentStrategy', () => {
     // Despite the throw, `finish()` must still run (moved into `finally`) so
     // a later `delegate_agent` call doesn't find stale delivery state for a
     // run that has already exited its lifecycle.
+    expect(getNativeSubagentStrategy(executionId)).toBeUndefined();
+    expect(
+      SharedSubagentDeliveryRegistry.getActive(executionId),
+    ).toBeUndefined();
+  });
+
+  it('registers a waiting-cleanup that abandons the strategy once the run confirms WAITING (issue #7287)', async () => {
+    // Regression: a WAITING subagent's promise never resolves again (no
+    // resume through attachPromise), so nothing else ever calls this
+    // strategy's private finish() for it. Without a waiting-cleanup hook,
+    // killing the suspended child left `activeNativeSubagents` (and the
+    // delivery registry) pointing at a gone execution forever.
+    const handleParent = 'handle-parent-waiting' as StreamTabId;
+    const childStream = 'child-stream-waiting' as StreamTabId;
+    const strategy = new NativeSubagentStrategy({
+      executionId,
+      agentName: 'review',
+      orchestratorStreamId: parentStreamId,
+      parentSession: ownerSession,
+      runtimeHost: { emit: vi.fn() },
+      startedAt: 0,
+      settleSubagentCost: vi.fn(),
+    });
+    const handle = new AgentExecutionHandle(
+      executionId,
+      handleParent,
+      childStream,
+      'review',
+      'toolUse',
+      {} as never,
+    );
+    strategy.setRunHandle(handle);
+    expect(getNativeSubagentStrategy(executionId)).toBe(strategy);
+
+    strategy.attachPromise(
+      Promise.resolve({
+        category: 'toolUse',
+        outcome: STREAM_PHASE.WAITING,
+        executionId,
+        streamId: childStream,
+      }),
+    );
+    // Let attachPromise's .then()/.finally() chain settle.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Suspended, not finished: the strategy stays registered for a resume.
+    expect(getNativeSubagentStrategy(executionId)).toBe(strategy);
+
+    // Simulate ExecutionRegistry.terminate()'s waiting-cleanup fallback.
+    expect(handle.runWaitingCleanup()).toBe(true);
+
     expect(getNativeSubagentStrategy(executionId)).toBeUndefined();
     expect(
       SharedSubagentDeliveryRegistry.getActive(executionId),

--- a/src/tools/delegation/nativeSubagentStrategy.ts
+++ b/src/tools/delegation/nativeSubagentStrategy.ts
@@ -394,14 +394,17 @@ export class NativeSubagentStrategy {
     if (totalCostUsd !== undefined) {
       this.lastKnownCostUsd = totalCostUsd;
     }
-    // `onBeforeWaiting` fires immediately before every genuine WAITING
-    // suspension of a native subagent — the initial launch and every later
-    // resume alike, each with its own `runHandle` (see `setRunHandle` /
-    // `resumeStream`). Registering here, rather than only once on the
-    // initial launch promise, is what makes a stop/kill during a *second*
-    // (or later) suspended turn still run this strategy's own teardown
-    // instead of leaving `activeNativeSubagents`/the delivery registry
-    // pointing at a removed execution (see `abandon()`).
+    // `onBeforeWaiting` fires before every *potential* WAITING suspension of
+    // a native subagent — the initial launch and every later resume alike,
+    // each with its own `runHandle` (see `setRunHandle` / `resumeStream`).
+    // The flow may still continue past the wait (a follow-up raced into the
+    // queue), in which case the run lifecycle clears this pre-registration on
+    // its terminal path (`clearWaitingCleanup`), so a non-suspended run never
+    // carries a stale abandon into teardown. Registering here, rather than
+    // only once on the initial launch promise, is what makes a stop/kill
+    // during a *second* (or later) suspended turn still run this strategy's
+    // own teardown instead of leaving `activeNativeSubagents`/the delivery
+    // registry pointing at a removed execution (see `abandon()`).
     this.runHandle?.registerWaitingCleanup(() => this.abandon());
 
     const deliveryDecision = this.deliveryState.resolveBeforeWaiting(

--- a/src/tools/delegation/nativeSubagentStrategy.ts
+++ b/src/tools/delegation/nativeSubagentStrategy.ts
@@ -31,10 +31,11 @@ import type { AttachedMemoryMiss } from '@agent/types/AttachedMemory';
 import * as logger from '@logger/logUtils';
 
 // Local imports - tools
-import type {
-  ExecutionId,
-  StreamTabId,
-  SubagentProgressUpdate,
+import {
+  RUN_OUTCOME,
+  type ExecutionId,
+  type StreamTabId,
+  type SubagentProgressUpdate,
 } from '@shared/schemas';
 import {
   deliverChildRunFollowUp,
@@ -171,6 +172,12 @@ export class NativeSubagentStrategy {
   private childStreamId: StreamTabId | undefined;
   private runHandle: AgentRunHandle | undefined;
   private readonly detachAbandonListener: () => void;
+  /**
+   * Most recent run-cost snapshot observed while suspending at WAITING. Used
+   * by `abandon()` to roll a suspended-then-stopped subagent's spend into the
+   * parent's usage totals, since that path never reaches `onCompleted`/`onError`.
+   */
+  private lastKnownCostUsd: number | undefined;
 
   constructor(private readonly params: NativeSubagentStrategyParams) {
     this.deliveryState = SharedSubagentDeliveryRegistry.start(
@@ -334,8 +341,18 @@ export class NativeSubagentStrategy {
         allowWaitingResult: true,
         onProgress: (update) => this.onProgress(update),
         onFollowUpConsumed: () => this.onFollowUpConsumed(),
-        onBeforeWaiting: (lastResponse, touchedFiles, memoryMisses) =>
-          this.onBeforeWaiting(lastResponse, touchedFiles, memoryMisses),
+        onBeforeWaiting: (
+          lastResponse,
+          touchedFiles,
+          memoryMisses,
+          totalCostUsd,
+        ) =>
+          this.onBeforeWaiting(
+            lastResponse,
+            touchedFiles,
+            memoryMisses,
+            totalCostUsd,
+          ),
         // `finish()` runs in `finally` in each hook below: `resumeQueuedToolUseSnapshot`
         // and `runFlowWithLifecycle` only log and swallow a throw from these
         // callbacks (they never propagate it back here), so a `this.finish()`
@@ -372,7 +389,21 @@ export class NativeSubagentStrategy {
     lastResponse: string | undefined,
     touchedFiles: string[],
     memoryMisses: readonly AttachedMemoryMiss[],
+    totalCostUsd?: number,
   ): Promise<boolean> {
+    if (totalCostUsd !== undefined) {
+      this.lastKnownCostUsd = totalCostUsd;
+    }
+    // `onBeforeWaiting` fires immediately before every genuine WAITING
+    // suspension of a native subagent — the initial launch and every later
+    // resume alike, each with its own `runHandle` (see `setRunHandle` /
+    // `resumeStream`). Registering here, rather than only once on the
+    // initial launch promise, is what makes a stop/kill during a *second*
+    // (or later) suspended turn still run this strategy's own teardown
+    // instead of leaving `activeNativeSubagents`/the delivery registry
+    // pointing at a removed execution (see `abandon()`).
+    this.runHandle?.registerWaitingCleanup(() => this.abandon());
+
     const deliveryDecision = this.deliveryState.resolveBeforeWaiting(
       this.childStreamId,
     );
@@ -456,12 +487,24 @@ export class NativeSubagentStrategy {
 
   /**
    * Tear down this strategy's tracking state without delivering anything.
-   * Registered as a WAITING-suspend cleanup (see `attachPromise`) so a
-   * stop/kill of a suspended child — which never resolves this strategy's
-   * own promise again — doesn't leave `activeNativeSubagents`/the delivery
-   * registry pointing at a gone execution.
+   * Registered as a WAITING-suspend cleanup on every turn's `runHandle` (see
+   * `onBeforeWaiting`) — initial launch and every later resume alike — so a
+   * stop/kill of a suspended child, on any turn, doesn't leave
+   * `activeNativeSubagents`/the delivery registry pointing at a gone
+   * execution. Also settles the parent's usage totals with the most recent
+   * cost snapshot observed before suspending, since this path never reaches
+   * `onCompleted`/`onError`.
    */
   abandon(): void {
+    if (this.lastKnownCostUsd !== undefined) {
+      this.params.settleSubagentCost({
+        category: 'toolUse',
+        outcome: RUN_OUTCOME.CANCELLED,
+        executionId: this.params.executionId,
+        streamId: this.childStreamId ?? this.params.orchestratorStreamId,
+        totalCostUsd: this.lastKnownCostUsd,
+      });
+    }
     this.finish();
   }
 
@@ -470,11 +513,14 @@ export class NativeSubagentStrategy {
     promise
       .then((result: unknown) => {
         if (isWaitingFlowResult(result as AgentRuntimeFlowResult)) {
-          suspended = true;
           // Only reachable once the flow genuinely suspended (not a
-          // near-miss cycle that kept running in-process), so this can't
-          // race with the strategy's own normal completion teardown below.
-          this.runHandle?.registerWaitingCleanup(() => this.abandon());
+          // near-miss cycle that kept running in-process). The abandon
+          // cleanup itself is registered from `onBeforeWaiting`, which fires
+          // immediately before this on every suspending turn (initial launch
+          // and each resume) — this flag only needs to know a suspend
+          // happened so `.finally()` below skips the normal-completion
+          // teardown.
+          suspended = true;
         }
       })
       // Await the error delivery so the registry entry is not torn down while

--- a/src/tools/delegation/nativeSubagentStrategy.ts
+++ b/src/tools/delegation/nativeSubagentStrategy.ts
@@ -454,12 +454,27 @@ export class NativeSubagentStrategy {
     activeNativeSubagents.delete(this.params.executionId);
   }
 
+  /**
+   * Tear down this strategy's tracking state without delivering anything.
+   * Registered as a WAITING-suspend cleanup (see `attachPromise`) so a
+   * stop/kill of a suspended child — which never resolves this strategy's
+   * own promise again — doesn't leave `activeNativeSubagents`/the delivery
+   * registry pointing at a gone execution.
+   */
+  abandon(): void {
+    this.finish();
+  }
+
   attachPromise(promise: Promise<unknown>): void {
     let suspended = false;
     promise
       .then((result: unknown) => {
         if (isWaitingFlowResult(result as AgentRuntimeFlowResult)) {
           suspended = true;
+          // Only reachable once the flow genuinely suspended (not a
+          // near-miss cycle that kept running in-process), so this can't
+          // race with the strategy's own normal completion teardown below.
+          this.runHandle?.registerWaitingCleanup(() => this.abandon());
         }
       })
       // Await the error delivery so the registry entry is not torn down while

--- a/src/tools/delegation/subagentExecution.ts
+++ b/src/tools/delegation/subagentExecution.ts
@@ -291,8 +291,13 @@ export async function executeSubagent(
     },
     onProgress: (update) => nativeStrategy.onProgress(update),
     onFollowUpConsumed: () => nativeStrategy.onFollowUpConsumed(),
-    onBeforeWaiting: (lastResponse, touchedFiles, memoryMisses) =>
-      nativeStrategy.onBeforeWaiting(lastResponse, touchedFiles, memoryMisses),
+    onBeforeWaiting: (lastResponse, touchedFiles, memoryMisses, totalCostUsd) =>
+      nativeStrategy.onBeforeWaiting(
+        lastResponse,
+        touchedFiles,
+        memoryMisses,
+        totalCostUsd,
+      ),
     onCompleted: (result) => nativeStrategy.onCompleted(result),
     onError: (err, result) => nativeStrategy.onError(err, result),
     onRun: (handle) => nativeStrategy.setRunHandle(handle),


### PR DESCRIPTION
## Summary

Both issues are about the same `finally` block in `runToolUseFlow.ts`: it treats a native subagent's WAITING suspend exactly like a terminal outcome, even though the `AgentExecutionHandle` deliberately stays tracked afterward for a later resume (`runFlowWithLifecycle`'s `isWaitingFlowResult` branch returns early without untracking).

- **#7286**: The `finally` block unconditionally called `sessionLifecycle.dispose()`, even on the `outcome === STREAM_PHASE.WAITING` branch. While the child stream is WAITING, a `delegate_agent` follow-up can land in the live in-memory session queue via `sendFollowUp` (`'active'` branch → `'sent'`) in the window between the WAITING transition and this teardown — `dispose()` then released that same queue, silently dropping the follow-up before the native wake path (which only handles `'queued'` results) ever consumed it.
- **#7287**: By the time a native subagent suspends at WAITING, `runToolUseFlow`'s `finally` has already disposed the live session and unregistered its interrupt handler. If the user then stops/kills that WAITING child, `ExecutionRegistry.terminate()` finds no interruptible context, so the kill either fails or only marks the stream cancelled while the handle/delivery state stay stuck.

## What changed

- `runToolUseFlow.ts`: skip `sessionLifecycle.dispose()` on the WAITING outcome, mirroring the flow-record preservation already done there. The follow-up queue stays live so a raced-in follow-up survives, and the same `ToolUseFollowUpQueue.acquire()` round-trip a resume already does hands it back intact.
- `ExecutionHandle.ts`: `AgentExecutionHandle` gets `registerWaitingCleanup`/`runWaitingCleanup` — a teardown slot distinct from the disposed live tool-use session, for a handle suspended at WAITING. `AgentRunHandle` exposes `registerWaitingCleanup` too.
- `executionRegistry.ts`: `terminate()` falls back to `runWaitingCleanup()` when no live interrupt is registered for a tracked `AgentExecutionHandle` — untracking it and transitioning its stream to CANCELLED instead of silently no-oping the kill.
- `AgentRunLifecycle.ts`: once a run is confirmed WAITING, registers the core waiting-cleanup (release the follow-up queue, best-effort delete the persisted flow record).
- `nativeSubagentStrategy.ts`: `NativeSubagentStrategy` registers its own waiting-cleanup (a new public `abandon()`) once its promise confirms WAITING, so a killed suspended child also clears `activeNativeSubagents`/the delivery registry instead of leaving a stale entry.

Design note: the waiting-cleanup registration is gated strictly on a *confirmed* WAITING outcome (never at run start), so a normal completing/failing run can't spuriously trip the new `terminate()` fallback during its own narrow interrupt-unregister → untrack window.

## Test plan

- [x] `npm run typecheck` — clean across the workspace.
- [x] `npx eslint` on all changed files — clean.
- [x] Targeted vitest suites, all passing:
  - `ToolUseFollowUp.vitest.ts` — new regression proving a follow-up that races into the live queue during the WAITING window survives (#7286), plus all existing cases.
  - `ExecutionRegistry.vitest.ts` — new regression: `terminate()` now tears down a suspended-at-WAITING handle via its registered waiting-cleanup, and a guard test confirming a handle with *no* waiting-cleanup still no-ops exactly as before (no new race for normal completion) (#7287).
  - `AgentRunLifecycle.vitest.ts` — new end-to-end regression: after a run returns WAITING, `executionRegistry.kill()` now untracks the handle, transitions the stream to CANCELLED, releases the follow-up queue, and deletes the persisted flow record.
  - `NativeSubagentStrategy.vitest.ts` — new regression: `abandon()` fires via the registered waiting-cleanup once the strategy's promise confirms WAITING, clearing `activeNativeSubagents`/the delivery registry.
- [x] Full `npx vitest run` — 4938 passed, 4 skipped (pre-existing), 0 failed.

Closes #7286
Closes #7287

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nbVZZcHVNLBNZ2tESvR7v

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches execution lifecycle, terminate/kill, and follow-up queue ownership—critical for subagent suspend/resume/stop, with broad regression tests but non-trivial race windows.
> 
> **Overview**
> Fixes **native subagent WAITING** handling where `runToolUseFlow`'s `finally` treated suspend like a full exit: it could **dispose the follow-up queue** (dropping delegate follow-ups that landed before teardown) and leave **no interrupt path** when the user stops a suspended child.
> 
> **Teardown:** On `STREAM_PHASE.WAITING`, the tool-use flow **keeps the follow-up queue live** (skips `sessionLifecycle.dispose()`), matching preserved flow records.
> 
> **Suspended kill:** `AgentExecutionHandle` adds **waiting-cleanup** slots; `runFlowWithLifecycle` registers lifecycle teardown on confirmed WAITING; `ExecutionRegistry.terminate()` runs those when the live interrupt is already gone, emitting a **cancelled `result`**, settling `handle.result`, persisting terminal status, and untracking. **`SessionHandle.publishRunEvent`** is injected so `onResult` still fires after the run trace is disposed.
> 
> **Native subagent:** `ToolUseWaitNode` always invokes **`onBeforeWaiting`** (including re-suspend after prior delivery) and passes **`totalCostUsd`**; `NativeSubagentStrategy` registers **`abandon()`** per turn so kill clears delivery registry state and rolls up cost. Stale cleanups are **cleared** on normal completion/error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5efe05ed47b6f7a7950616152e726ebb15b6918b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->