### PR TITLE
fix: honor cli tui interaction timeouts

### DIFF
--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -248,24 +248,31 @@ export function clearApprovals(): void {
 }
 
 export function clearRetryApprovalsForStream(streamId: string): void {
-  let changed = false;
+  clearApprovalsWhere(
+    (payload) =>
+      payload.kind === 'retry' && payload.payload.streamId === streamId,
+    INTERRUPT,
+  );
+}
+
+export function clearApprovalsWhere(
+  predicate: (payload: ApprovalPayload) => boolean,
+  decision: ApprovalDecision = INTERRUPT,
+): number {
+  let cleared = 0;
   for (const item of [...pendingItems]) {
-    if (
-      item.payload.kind !== 'retry' ||
-      item.payload.payload.streamId !== streamId
-    ) {
-      continue;
-    }
+    if (!predicate(item.payload)) continue;
     if (!pendingItems.delete(item)) continue;
-    changed = true;
+    cleared += 1;
     const advance = item.advance;
     item.advance = undefined;
-    item.resolve(INTERRUPT);
+    item.resolve(decision);
     if (currentItem === item) {
       currentItem = undefined;
       CURRENT.set(undefined);
       advance?.();
     }
   }
-  if (changed) syncApprovalStatus();
+  if (cleared > 0) syncApprovalStatus();
+  return cleared;
 }

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -18,6 +18,7 @@ import { platform } from '@platform/platform';
 import type {
   HostBashApprovalRequest,
   HostBashApprovalResult,
+  HostInteractionOptions,
   HostInteractions,
   HostRetryRequest,
 } from '@agent/runtime/HostInteractions';
@@ -55,6 +56,7 @@ import { patchSessionMeta } from './cliState/sessionSlice';
 import { setCliCodexSubscription } from './codexSubscription';
 import {
   approvalPayloadStreamId,
+  clearApprovalsWhere,
   clearRetryApprovalsForStream,
   enqueueApproval,
   onApprovalsCleared,
@@ -156,14 +158,46 @@ export function createTuiHostInteractions(
     requestBashApproval(request) {
       return requestBashInteraction(request, context, host);
     },
-    requestPlanApproval(request) {
-      return requestPlanInteraction(request, context, host);
+    requestPlanApproval(request, options) {
+      return withInteractionTimeout(
+        requestPlanInteraction(request, context, host),
+        options,
+        { action: 'timeout' },
+        () =>
+          clearApprovalsWhere(
+            (payload) =>
+              payload.kind === 'plan' &&
+              payload.payload.approvalId === request.approvalId,
+            NEUTRAL_TIMEOUT_DECISION,
+          ),
+      );
     },
-    requestAgentProposal(request) {
-      return requestProposalInteraction(request, context, host);
+    requestAgentProposal(request, options) {
+      return withInteractionTimeout(
+        requestProposalInteraction(request, context, host),
+        options,
+        { action: 'timeout' },
+        () =>
+          clearApprovalsWhere(
+            (payload) =>
+              payload.kind === 'proposal' &&
+              payload.payload.proposalId === request.proposalId,
+            NEUTRAL_TIMEOUT_DECISION,
+          ),
+      );
     },
-    requestRetry(request) {
-      return requestRetryInteraction(request, context, host, retryRoutes);
+    requestRetry(request, options) {
+      return withInteractionTimeout(
+        requestRetryInteraction(request, context, host, retryRoutes),
+        options,
+        { action: 'timeout' },
+        () => {
+          settleRetryRoute(retryRoutes, request.streamId, {
+            action: 'timeout',
+          });
+          clearRetryApprovalsForStream(request.streamId);
+        },
+      );
     },
     askUserQuestion(request) {
       return requestUserQuestionInteraction(request, context, host);
@@ -199,6 +233,53 @@ interface RetryRouteState {
   readonly activeRetryRoutes: Map<string, ActiveRetryRoute>;
 }
 
+const NEUTRAL_TIMEOUT_DECISION: ApprovalDecision = {
+  accepted: true,
+  userMessage: 'Approval request timed out.',
+};
+
+function validTimeoutMs(timeoutMs: number | undefined): number | undefined {
+  if (timeoutMs == null || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return undefined;
+  }
+  return Math.floor(timeoutMs);
+}
+
+function withInteractionTimeout<T>(
+  promise: Promise<T>,
+  options: HostInteractionOptions | undefined,
+  timeoutResult: T,
+  onTimeout: () => void,
+): Promise<T> {
+  const timeoutMs = validTimeoutMs(options?.timeoutMs);
+  if (timeoutMs == null) return promise;
+
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      onTimeout();
+      resolve(timeoutResult);
+    }, timeoutMs);
+
+    promise.then(
+      (result) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(result);
+      },
+      (error: unknown) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
 function createRetryRouteState(): RetryRouteState {
   return { activeRetryRoutes: new Map() };
 }
@@ -212,10 +293,18 @@ function isActiveRetryRoute(
 }
 
 function cancelRetryRoute(state: RetryRouteState, streamId: string): void {
+  settleRetryRoute(state, streamId, { action: 'cancel' });
+}
+
+function settleRetryRoute(
+  state: RetryRouteState,
+  streamId: string,
+  result: RetryResult,
+): void {
   const route = state.activeRetryRoutes.get(streamId);
   if (!route) return;
   state.activeRetryRoutes.delete(streamId);
-  route.settle?.({ action: 'cancel' });
+  route.settle?.(result);
 }
 
 function invalidateRetryRoutes(

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   secrets: {},
   setCliApiMode: vi.fn(async () => undefined),
   setCliCodexSubscription: vi.fn(async () => undefined),
+  markApprovalDenied: vi.fn(),
   triggerRetry: vi.fn(),
   cancelRetry: vi.fn(),
 }));
@@ -77,7 +78,7 @@ vi.mock('@cli/runtime/approvalAdapter', () => {
         (payload.errorDetails?.isRelayError === true ||
           isRelayMonthlyLimitMessage(payload.errorMessage))),
     isCliChatGptSubscriptionRetry: isChatGptSubscriptionRetry,
-    markApprovalDenied: vi.fn(),
+    markApprovalDenied: mocks.markApprovalDenied,
   };
 });
 
@@ -103,6 +104,7 @@ import type { CliContext } from '@cli/runtime/cliContext';
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import { API_PROVIDERS, type ApiProvider } from '@model/apiProviders';
+import { AgentCategory } from '@shared/schemas';
 
 function context(): CliContext {
   return {
@@ -176,6 +178,7 @@ afterEach(() => {
   mocks.notify.mockReset();
   mocks.setCliApiMode.mockClear();
   mocks.setCliCodexSubscription.mockClear();
+  mocks.markApprovalDenied.mockClear();
   mocks.triggerRetry.mockClear();
   mocks.cancelRetry.mockClear();
 });
@@ -403,6 +406,90 @@ describe('TUI retry approvals', () => {
 
       clearApprovals();
       await expect(result).resolves.toEqual({ action: 'cancel' });
+      expect(currentApproval.get()).toBeUndefined();
+    } finally {
+      dispose();
+    }
+  });
+
+  it('times out an active plan approval modal', async () => {
+    const { interactions, dispose } = tui();
+    try {
+      const result = interactions.requestPlanApproval?.(
+        {
+          approvalId: 'plan-timeout',
+          streamId: 'plan-stream',
+          goalEnabled: false,
+          plan: { objective: 'Check the timeout path.' },
+        },
+        { timeoutMs: 10 },
+      );
+
+      await vi.waitFor(() => {
+        expect(currentApproval.get()?.payload).toMatchObject({
+          kind: 'plan',
+          payload: { approvalId: 'plan-timeout' },
+        });
+      });
+      await expect(result).resolves.toEqual({ action: 'timeout' });
+      await Promise.resolve();
+      expect(mocks.markApprovalDenied).not.toHaveBeenCalled();
+      expect(currentApproval.get()).toBeUndefined();
+    } finally {
+      dispose();
+    }
+  });
+
+  it('times out an active proposal approval modal', async () => {
+    const { interactions, dispose } = tui();
+    try {
+      const result = interactions.requestAgentProposal?.(
+        {
+          proposalId: 'proposal-timeout',
+          streamId: 'proposal-stream',
+          agent: 'reviewer',
+          model: 'gpt-test',
+          instruction: 'Review this argument.',
+          memories: [],
+          agentCategory: AgentCategory.ToolUse,
+        },
+        { timeoutMs: 10 },
+      );
+
+      await vi.waitFor(() => {
+        expect(currentApproval.get()?.payload).toMatchObject({
+          kind: 'proposal',
+          payload: { proposalId: 'proposal-timeout' },
+        });
+      });
+      await expect(result).resolves.toEqual({ action: 'timeout' });
+      await Promise.resolve();
+      expect(mocks.markApprovalDenied).not.toHaveBeenCalled();
+      expect(currentApproval.get()).toBeUndefined();
+    } finally {
+      dispose();
+    }
+  });
+
+  it('times out an active retry modal', async () => {
+    mocks.lookupApiKey.mockResolvedValue(undefined);
+
+    const { interactions, dispose } = tui();
+    try {
+      const result = interactions.requestRetry?.(
+        relayRetry({ streamId: 'retry-timeout', provider: 'openai' }),
+        { timeoutMs: 100 },
+      );
+
+      await vi.waitFor(() => {
+        expect(currentApproval.get()?.payload).toMatchObject({
+          kind: 'retry',
+          payload: { streamId: 'retry-timeout' },
+        });
+      });
+      await expect(result).resolves.toEqual({ action: 'timeout' });
+      await Promise.resolve();
+      expect(mocks.markApprovalDenied).not.toHaveBeenCalled();
       expect(currentApproval.get()).toBeUndefined();
     } finally {
       dispose();


### PR DESCRIPTION
## Summary

This PR closes the remaining CLI timeout item from #7304 after the Stage 4 HostInteractions cleanup.

The CLI TUI `HostInteractions` adapter now honors `HostInteractionOptions.timeoutMs` for plan approvals, agent proposals, and retry prompts. When the timeout fires, the adapter removes the corresponding pending approval from the TUI queue and resolves the host interaction with the existing `timeout` result shape instead of leaving a visible modal or queue entry behind.

## Root Cause

Stage 4 threaded `timeoutMs` from the runtime coordinators into `HostInteractions`, but the CLI TUI implementation ignored that option for plan, proposal, and retry requests. The runtime could therefore request a bounded wait while the TUI still waited indefinitely.

## Verification

- `corepack pnpm exec vitest run src/test-kernel/cli/TuiApprovalRetry.vitest.mts`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `corepack pnpm exec eslint packages/cli/src/chat/tui/state/approvalQueue.ts packages/cli/src/chat/tui/state/subscribeApprovals.ts src/test-kernel/cli/TuiApprovalRetry.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `git diff --check`

Refs #7304.
Refs #6967.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how plan, proposal, and retry prompts end when the user does not respond, which affects coordinator/runtime flow; logic is localized to the TUI approval adapter with new tests.
> 
> **Overview**
> The CLI TUI **`HostInteractions`** adapter now respects **`HostInteractionOptions.timeoutMs`** for plan approvals, agent proposals, and retry prompts—behavior the runtime already passed through after Stage 4 but the TUI ignored.
> 
> **`withInteractionTimeout`** wraps those three request paths: when the timer fires, the matching pending approval is removed via new **`clearApprovalsWhere`** (refactored from stream-specific retry clearing), the modal/queue slot is released, and the host promise resolves with **`{ action: 'timeout' }`**. Retry routing uses **`settleRetryRoute`** so timeouts settle active retry routes the same way cancellation does.
> 
> Vitest coverage adds plan, proposal, and retry timeout cases and asserts timeouts do not call **`markApprovalDenied`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b9bca0baec306cdbecf2ae6721302cafb949e61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->