### PR TITLE
fix(cli): cancel all pending interaction kinds when a stream stops

### DIFF
--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -247,6 +247,30 @@ export function clearApprovals(): void {
   }
 }
 
+/**
+ * Cancel every pending approval/human-input prompt whose payload belongs to
+ * `streamId`, regardless of kind. Used when a single stream is stopped —
+ * unlike {@link clearApprovals}, other streams' pending prompts are left
+ * untouched.
+ */
+export function clearApprovalsForStream(streamId: string): void {
+  let changed = false;
+  for (const item of [...pendingItems]) {
+    if (approvalPayloadStreamId(item.payload) !== streamId) continue;
+    if (!pendingItems.delete(item)) continue;
+    changed = true;
+    const advance = item.advance;
+    item.advance = undefined;
+    item.resolve(INTERRUPT);
+    if (currentItem === item) {
+      currentItem = undefined;
+      CURRENT.set(undefined);
+      advance?.();
+    }
+  }
+  if (changed) syncApprovalStatus();
+}
+
 export function clearRetryApprovalsForStream(streamId: string): void {
   let changed = false;
   for (const item of [...pendingItems]) {

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -65,6 +65,7 @@ import { patchSessionMeta } from './cliState/sessionSlice';
 import { setCliCodexSubscription } from './codexSubscription';
 import {
   approvalPayloadStreamId,
+  clearApprovalsForStream,
   clearRetryApprovalsForStream,
   enqueueApproval,
   onApprovalsCleared,
@@ -196,7 +197,7 @@ export function createTuiHostInteractions(
     resolve: () => false,
     cancelForStream(streamId) {
       cancelRetryRoute(retryRoutes, streamId);
-      clearRetryApprovalsForStream(streamId);
+      clearApprovalsForStream(streamId);
     },
     dispose() {
       invalidateRetryRoutes(retryRoutes, { cancel: true });

--- a/src/test-kernel/cli/ApprovalQueue.vitest.mts
+++ b/src/test-kernel/cli/ApprovalQueue.vitest.mts
@@ -10,6 +10,7 @@ import {
   approvalPayloadStreamId,
   approvalQueueStatus,
   clearApprovals,
+  clearApprovalsForStream,
   currentApproval,
   enqueueApproval,
   type ApprovalPayload,
@@ -27,6 +28,18 @@ function bashPayload(streamId: string): ApprovalPayload {
       command: 'echo ok',
     },
   };
+}
+
+function planPayload(streamId: string): ApprovalPayload {
+  return {
+    kind: 'plan',
+    payload: {
+      approvalId: `plan-${streamId}`,
+      plan: { objective: 'Do the thing.' },
+      streamId,
+      goalEnabled: false,
+    },
+  } as ApprovalPayload;
 }
 
 function externalInquiryPayload(streamId: string): ApprovalPayload {
@@ -159,6 +172,38 @@ describe('CLI approval queue', () => {
 
     currentApproval.get()?.decide({ accepted: true });
     await expect(nextResult).resolves.toEqual({ accepted: true });
+  });
+
+  it('cancels every pending kind for one stream without touching other streams', async () => {
+    const targetBash = bashPayload('stream-a');
+    const targetPlan = planPayload('stream-a');
+    const otherBash = bashPayload('stream-b');
+
+    const targetBashResult = enqueueApproval(targetBash);
+    const targetPlanResult = enqueueApproval(targetPlan);
+    const otherBashResult = enqueueApproval(otherBash);
+
+    await vi.waitFor(() => {
+      expect(currentApproval.get()?.payload).toBe(targetBash);
+    });
+    expect(approvalQueueStatus.get()).toEqual({ depth: 3, kind: 'approval' });
+
+    clearApprovalsForStream('stream-a');
+
+    const interrupted = {
+      accepted: false,
+      userMessage: 'Session interrupted.',
+    };
+    await expect(targetBashResult).resolves.toEqual(interrupted);
+    await expect(targetPlanResult).resolves.toEqual(interrupted);
+
+    await vi.waitFor(() => {
+      expect(currentApproval.get()?.payload).toBe(otherBash);
+    });
+    expect(approvalQueueStatus.get()).toEqual({ depth: 1, kind: 'approval' });
+
+    currentApproval.get()?.decide({ accepted: true });
+    await expect(otherBashResult).resolves.toEqual({ accepted: true });
   });
 
   it('notifies only when a TUI approval becomes the foreground modal', async () => {


### PR DESCRIPTION
## Summary

`createTuiHostInteractions().cancelForStream` (`packages/cli/src/chat/tui/state/subscribeApprovals.ts`) only cancelled retry routes for the stopped stream via `clearRetryApprovalsForStream`. Plan approval, agent proposal, bash approval, and user-question prompts queued for that stream were left pending indefinitely — the extension and desktop `HostInteractions` adapters already cancel every pending kind generically for a stream (since #7316 removed `BasePromiseCoordinator`), so the CLI was the one host still missing this.

Today this is masked because the CLI's only interrupt entry point (`interruptActiveRun`) always calls the global `clearApprovals()` first, which resolves every pending approval-queue item regardless of stream. A future per-stream-only stop path would leave these promises permanently stuck.

## Fix

- Added `clearApprovalsForStream(streamId)` to `packages/cli/src/chat/tui/state/approvalQueue.ts`, generalizing the existing `clearRetryApprovalsForStream` pattern to match any pending item by its payload's stream id (via the existing `approvalPayloadStreamId` helper), regardless of kind.
- Wired it into `cancelForStream` in `subscribeApprovals.ts`, alongside the existing `cancelRetryRoute` call (which separately settles the retry-only `activeRetryRoutes` tracking used by the direct `HostInteractions.requestRetry` path).
- Left `clearRetryApprovalsForStream` unchanged — it's still used elsewhere to clear a stale prior retry request for a stream before routing a new one, which is retry-specific behavior distinct from stream-stop cancellation.

## Verification

- `npm run typecheck` — clean
- `npx eslint` on changed files — clean
- `corepack pnpm exec vitest run src/test-kernel/cli/ApprovalQueue.vitest.mts src/test-kernel/cli/TuiApprovalRetry.vitest.mts src/test-kernel/cli/ApprovalAdapter.vitest.mts` — 41/41 passed
- Added a new test: "cancels every pending kind for one stream without touching other streams" (bash + plan on the target stream, bash on another stream; confirms only the target stream's prompts are interrupted and the other stream's queue is untouched)

Fixes #7306.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized approval-queue lifecycle change with tests; no auth or data-path changes, and behavior aligns other hosts’ per-stream cancel.
> 
> **Overview**
> When a single stream is stopped, the CLI TUI now clears **every** pending approval/human-input prompt tied to that stream (bash, plan, proposal, tool edit, user questions, etc.), not only retry prompts.
> 
> **`clearApprovalsForStream(streamId)`** in `approvalQueue.ts` walks the pending queue, matches items via `approvalPayloadStreamId`, resolves them with the standard interrupt decision, and advances the foreground modal if needed—without affecting other streams. **`createTuiHostInteractions().cancelForStream`** now calls this instead of **`clearRetryApprovalsForStream`** (retry-only clearing remains for replacing stale retry requests).
> 
> A vitest case confirms mixed kinds on one stream are interrupted while another stream’s queue keeps running.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cc9875a65dc2af127782750d1704b97cbf72539. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->