### PR TITLE
refactor: route progress backend through session events

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -263,6 +263,9 @@ export class DesktopProgressBridge {
       getStreamControls: getProgressStreamControls,
       getUnsupportedCommands: () =>
         unsupportedCommands(this.progressViewInboundHandlers),
+      onSessionProgressEvent: (event, payload) => {
+        this.progressEvents.onProgressEvent(event, payload);
+      },
       configureUi: ({ webviewUpdater }) => {
         // The desktop renderer is always attached (no sidebar/editor re-target),
         // so every show/resolve reaches the webview.
@@ -324,9 +327,7 @@ export class DesktopProgressBridge {
         void this.options.showErrorMessage?.(message);
       },
     });
-    const backendSubscription = this.backend.setupEventListeners(bus, {
-      emit: (event, payload) => this.handleSessionProgressEvent(event, payload),
-    });
+    const backendSubscription = this.backend.setupEventListeners(bus);
     this.restartRepair = this.repairOrphanedStreamsAfterRestart();
     // Onboarding funnel (PRD: agent-native onboarding): a completed run ends
     // State 1. `AgentRunLifecycle` persists `firstRunDone` BEFORE it emits the
@@ -1012,14 +1013,6 @@ export class DesktopProgressBridge {
     payload: ProgressEventPayloads[K],
   ): void {
     bus.emit(event, payload);
-    this.progressEvents.onProgressEvent(event, payload);
-  }
-
-  private handleSessionProgressEvent<K extends keyof ProgressEventPayloads>(
-    event: K,
-    payload: ProgressEventPayloads[K],
-  ): void {
-    this.backend.handleProgressEvent(event, payload);
     this.progressEvents.onProgressEvent(event, payload);
   }
 

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -113,6 +113,11 @@ export class ProgressViewProvider
       getStreamControls: getProgressStreamControls,
       getUnsupportedCommands: () =>
         this.messageHandler.getUnsupportedCommands(),
+      onSessionProgressEvent: (event, payload) => {
+        if (event === 'goalStateChanged') {
+          bus.emit(event, payload);
+        }
+      },
       configureUi: ({ webviewUpdater: u }) => {
         const canSend = () => this.canSendToWebview();
         this.approvalHandlers = buildApprovalRequestHandlerSet({

--- a/src/agent/runtime/LegacyProgressEventProjection.ts
+++ b/src/agent/runtime/LegacyProgressEventProjection.ts
@@ -1,62 +1,13 @@
-import type { AgentEvent } from '@agent/trace';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import type { StreamTabId } from '@shared/schemas';
 
+import {
+  emitProjectedProgressEvent,
+  projectRunFactToProgressEvent,
+} from './sessionProgressEventProjection';
 import {
   emitLegacySessionFactOnHost,
   type SessionEventHub,
 } from './SessionEventHub';
-
-function emitLegacyRunEvent(
-  runtimeHost: AgentRuntimeHost,
-  streamId: StreamTabId,
-  event: AgentEvent,
-): void {
-  if (event.type === 'stage.start') {
-    if (event.kind !== 'round') return;
-    runtimeHost.emit('updateRoundStage', {
-      streamId,
-      roundStage: {
-        index: event.index ?? 0,
-        ...(event.total !== undefined && event.total > 0
-          ? { total: event.total }
-          : {}),
-      },
-    });
-    return;
-  }
-
-  if (event.type === 'child.activity') {
-    if (event.kind === 'subagents') {
-      runtimeHost.emit('updateActiveSubagents', {
-        parentStreamId: event.parentStreamId,
-        children: [...event.children],
-      });
-      return;
-    }
-    if (event.kind === 'processes') {
-      runtimeHost.emit('updateActiveProcesses', {
-        parentStreamId: event.parentStreamId,
-        processes: [...event.processes],
-      });
-      return;
-    }
-    runtimeHost.emit('setParentStream', {
-      childStreamId: event.childStreamId,
-      parentStreamId: event.parentStreamId,
-    });
-    return;
-  }
-
-  if (event.type === 'process.output') {
-    runtimeHost.emit('updateProcessOutput', {
-      parentStreamId: event.parentStreamId,
-      executionId: event.executionId,
-      stdout: event.stdout,
-      stderr: event.stderr,
-    });
-  }
-}
 
 /**
  * Temporary Stage 3a bridge from the new session-owned fact plane to the old
@@ -80,11 +31,12 @@ export function attachLegacyProgressEventProjection(
   const detachRunFacts = events.subscribe(
     (sessionEvent) => {
       if (sessionEvent.scope !== 'run') return;
-      emitLegacyRunEvent(
-        runtimeHost,
+      const projected = projectRunFactToProgressEvent(
         sessionEvent.streamId,
         sessionEvent.event,
       );
+      if (!projected) return;
+      emitProjectedProgressEvent(runtimeHost, projected);
     },
     {
       scope: 'run',

--- a/src/agent/runtime/SessionEventHub.ts
+++ b/src/agent/runtime/SessionEventHub.ts
@@ -4,8 +4,11 @@ import type { AgentEvent } from '@agent/trace';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import { createChannelTrace } from '@logger';
 import type { StreamTabId } from '@shared/schemas';
-import { assertNever } from '@utils/core';
 
+import {
+  emitProjectedProgressEvent,
+  projectSessionFactToProgressEvent,
+} from './sessionProgressEventProjection';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 
 const logger = createChannelTrace('SessionEventHub');
@@ -46,25 +49,7 @@ export function emitLegacySessionFactOnHost(
   host: AgentRuntimeHost,
   fact: SessionFact,
 ): void {
-  switch (fact.type) {
-    case 'goalStateChanged':
-      host.emit('goalStateChanged', fact.payload);
-      return;
-    case 'inquiryThreadUpdated':
-      host.emit('inquiryThreadUpdated', fact.payload);
-      return;
-    case 'clearMissingOutputs':
-      host.emit('clearMissingOutputs', fact.payload);
-      return;
-    case 'updateQueuedFollowUps':
-      host.emit('updateQueuedFollowUps', fact.payload);
-      return;
-    case 'setActiveStream':
-      host.emit('setActiveStream', fact.payload);
-      return;
-    default:
-      assertNever(fact, 'Unhandled SessionFact type');
-  }
+  emitProjectedProgressEvent(host, projectSessionFactToProgressEvent(fact));
 }
 
 export interface SessionEventSubscriptionFilter {

--- a/src/agent/runtime/sessionProgressEventProjection.ts
+++ b/src/agent/runtime/sessionProgressEventProjection.ts
@@ -1,0 +1,103 @@
+import type { AgentEvent } from '@agent/trace';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type {
+  ProgressEvent,
+  ProgressEventPayloads,
+} from '@eventBus/ProgressEventBus';
+import type { StreamTabId } from '@shared/schemas';
+
+import type { SessionFact } from './SessionEventHub';
+
+export type ProjectedProgressEvent = {
+  [K in ProgressEvent]: {
+    readonly event: K;
+    readonly payload: ProgressEventPayloads[K];
+  };
+}[ProgressEvent];
+
+export function emitProjectedProgressEvent(
+  runtimeHost: AgentRuntimeHost,
+  projected: ProjectedProgressEvent,
+): void {
+  runtimeHost.emit(projected.event, projected.payload);
+}
+
+export function projectSessionFactToProgressEvent(
+  fact: SessionFact,
+): ProjectedProgressEvent {
+  switch (fact.type) {
+    case 'goalStateChanged':
+      return { event: 'goalStateChanged', payload: fact.payload };
+    case 'inquiryThreadUpdated':
+      return { event: 'inquiryThreadUpdated', payload: fact.payload };
+    case 'clearMissingOutputs':
+      return { event: 'clearMissingOutputs', payload: fact.payload };
+    case 'updateQueuedFollowUps':
+      return { event: 'updateQueuedFollowUps', payload: fact.payload };
+    case 'setActiveStream':
+      return { event: 'setActiveStream', payload: fact.payload };
+  }
+}
+
+export function projectRunFactToProgressEvent(
+  streamId: StreamTabId,
+  event: AgentEvent,
+): ProjectedProgressEvent | undefined {
+  if (event.type === 'stage.start') {
+    if (event.kind !== 'round') return undefined;
+    return {
+      event: 'updateRoundStage',
+      payload: {
+        streamId,
+        roundStage: {
+          index: event.index ?? 0,
+          ...(event.total !== undefined && event.total > 0
+            ? { total: event.total }
+            : {}),
+        },
+      },
+    };
+  }
+
+  if (event.type === 'child.activity') {
+    if (event.kind === 'subagents') {
+      return {
+        event: 'updateActiveSubagents',
+        payload: {
+          parentStreamId: event.parentStreamId,
+          children: [...event.children],
+        },
+      };
+    }
+    if (event.kind === 'processes') {
+      return {
+        event: 'updateActiveProcesses',
+        payload: {
+          parentStreamId: event.parentStreamId,
+          processes: [...event.processes],
+        },
+      };
+    }
+    return {
+      event: 'setParentStream',
+      payload: {
+        childStreamId: event.childStreamId,
+        parentStreamId: event.parentStreamId,
+      },
+    };
+  }
+
+  if (event.type === 'process.output') {
+    return {
+      event: 'updateProcessOutput',
+      payload: {
+        parentStreamId: event.parentStreamId,
+        executionId: event.executionId,
+        stdout: event.stdout,
+        stderr: event.stderr,
+      },
+    };
+  }
+
+  return undefined;
+}

--- a/src/shared/progressView/backend/ProgressBackend.ts
+++ b/src/shared/progressView/backend/ProgressBackend.ts
@@ -1,9 +1,12 @@
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { attachLegacyProgressEventProjection } from '@agent/runtime/LegacyProgressEventProjection';
 import {
   defaultSession,
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
+import {
+  type ProjectedProgressEvent,
+  projectRunFactToProgressEvent,
+  projectSessionFactToProgressEvent,
+} from '@agent/runtime/sessionProgressEventProjection';
 import type {
   ProgressEvent,
   ProgressEventBusLike,
@@ -51,7 +54,17 @@ export interface ProgressBackendOptions {
    * projection of the registry.
    */
   getUnsupportedCommands?: () => readonly string[];
+  /** Host-local side effects for session-originated progress events. */
+  onSessionProgressEvent?<K extends ProgressEvent>(
+    event: K,
+    payload: ProgressEventPayloads[K],
+  ): void;
 }
+
+type SessionProgressEventObserver = <K extends ProgressEvent>(
+  event: K,
+  payload: ProgressEventPayloads[K],
+) => void;
 
 class LocalProgressEventBus implements ProgressEventBusLike {
   private readonly listeners = new Map<
@@ -106,9 +119,11 @@ export class ProgressBackend {
   readonly eventHandler: ProgressEventHandler;
   private readonly session: SessionHandle;
   private readonly localEvents = new LocalProgressEventBus();
+  private readonly onSessionProgressEvent?: SessionProgressEventObserver;
 
   constructor(options: ProgressBackendOptions) {
     this.session = options.session ?? defaultSession();
+    this.onSessionProgressEvent = options.onSessionProgressEvent;
     this.state = new ProgressViewState(
       options.storage,
       options.snapshots,
@@ -152,25 +167,49 @@ export class ProgressBackend {
     await this.state.load();
   }
 
-  setupEventListeners(
-    bus: ProgressEventBusLike,
-    sessionProjectionTarget: AgentRuntimeHost = bus,
-  ): ProgressEventSubscription {
+  setupEventListeners(bus: ProgressEventBusLike): ProgressEventSubscription {
     const busSubscription = this.eventHandler.setupEventListeners(bus);
     const localSubscription = this.eventHandler.setupEventListeners(
       this.localEvents,
     );
-    const detachProjection = attachLegacyProgressEventProjection(
-      this.session.events,
-      sessionProjectionTarget,
+    const detachSessionFacts = this.session.events.subscribe(
+      (sessionEvent) => {
+        if (sessionEvent.scope !== 'session') return;
+        this.handleProjectedProgressEvent(
+          projectSessionFactToProgressEvent(sessionEvent.event),
+        );
+      },
+      { scope: 'session' },
+    );
+    const detachRunFacts = this.session.events.subscribe(
+      (sessionEvent) => {
+        if (sessionEvent.scope !== 'run') return;
+        const projected = projectRunFactToProgressEvent(
+          sessionEvent.streamId,
+          sessionEvent.event,
+        );
+        if (projected) this.handleProjectedProgressEvent(projected);
+      },
+      {
+        scope: 'run',
+        types: ['stage.start', 'child.activity', 'process.output'],
+      },
     );
     return {
       dispose: () => {
-        detachProjection();
+        detachRunFacts();
+        detachSessionFacts();
         localSubscription.dispose();
         busSubscription.dispose();
       },
     };
+  }
+
+  private handleProjectedProgressEvent(
+    projected: ProjectedProgressEvent,
+  ): void {
+    this.handleProgressEvent(projected.event, projected.payload);
+    this.onSessionProgressEvent?.(projected.event, projected.payload);
   }
 
   handleProgressEvent<K extends ProgressEvent>(

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -11,7 +11,12 @@ import { streamDataDir, StreamSnapshotStore } from '@transcript';
 import { getExecutionStore } from '@agent/storage';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { TaskState } from '@agent/core/state/TaskState';
-import { bus } from '@eventBus/ProgressEventBus';
+import {
+  bus,
+  type ProgressEvent,
+  type ProgressEventBusLike,
+  type ProgressEventPayloads,
+} from '@eventBus/ProgressEventBus';
 
 // Local imports - logger
 import * as logger from '@logger/logUtils';
@@ -20,6 +25,7 @@ import * as logger from '@logger/logUtils';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   AgentCategory,
+  type ActiveChildInfo,
   LOG_LEVELS,
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
@@ -51,6 +57,45 @@ class MemoryMementoStorage implements MementoStorage {
       return;
     }
     this.values.set(key, value);
+  }
+}
+
+class MemoryProgressBus implements ProgressEventBusLike {
+  private readonly listeners = new Map<
+    ProgressEvent,
+    Set<(payload: ProgressEventPayloads[ProgressEvent]) => void>
+  >();
+
+  on<K extends ProgressEvent>(
+    event: K,
+    listener: (payload: ProgressEventPayloads[K]) => void,
+    options?: { signal?: AbortSignal },
+  ): () => void {
+    if (options?.signal?.aborted) return () => {};
+    let listeners = this.listeners.get(event);
+    if (!listeners) {
+      listeners = new Set();
+      this.listeners.set(event, listeners);
+    }
+    listeners.add(
+      listener as (payload: ProgressEventPayloads[ProgressEvent]) => void,
+    );
+    const cleanup = (): void => {
+      listeners?.delete(
+        listener as (payload: ProgressEventPayloads[ProgressEvent]) => void,
+      );
+    };
+    options?.signal?.addEventListener('abort', cleanup, { once: true });
+    return cleanup;
+  }
+
+  emit<K extends ProgressEvent>(
+    event: K,
+    payload: ProgressEventPayloads[K],
+  ): void {
+    for (const listener of this.listeners.get(event) ?? []) {
+      listener(payload);
+    }
   }
 }
 
@@ -347,6 +392,307 @@ describe('ProgressBackend', () => {
     } finally {
       subscription.dispose();
       backend.dispose();
+    }
+  });
+
+  it('scopes direct session events to each backend session', async () => {
+    const sharedBus = new MemoryProgressBus();
+    const first = createIsolatedRecordingBackend();
+    const second = createIsolatedRecordingBackend();
+    const firstSubscription = first.backend.setupEventListeners(sharedBus);
+    const secondSubscription = second.backend.setupEventListeners(sharedBus);
+    const firstStream = 'session:first' as StreamTabId;
+    const secondStream = 'session:second' as StreamTabId;
+
+    try {
+      first.session.events.emit({
+        scope: 'session',
+        event: {
+          type: 'setActiveStream',
+          payload: {
+            streamId: firstStream,
+            agentCategory: AgentCategory.Workflow,
+          },
+        },
+      });
+
+      await vi.waitFor(() =>
+        expect(first.backend.state.activeStream).toBe(firstStream),
+      );
+      expect(second.backend.state.activeStream).not.toBe(firstStream);
+      expect(JSON.stringify(second.messages)).not.toContain(firstStream);
+
+      second.session.events.emit({
+        scope: 'session',
+        event: {
+          type: 'setActiveStream',
+          payload: {
+            streamId: secondStream,
+            agentCategory: AgentCategory.ToolUse,
+          },
+        },
+      });
+
+      await vi.waitFor(() =>
+        expect(second.backend.state.activeStream).toBe(secondStream),
+      );
+      expect(first.backend.state.activeStream).toBe(firstStream);
+      expect(JSON.stringify(first.messages)).not.toContain(secondStream);
+    } finally {
+      firstSubscription.dispose();
+      secondSubscription.dispose();
+      first.backend.dispose();
+      second.backend.dispose();
+      first.session.dispose();
+      second.session.dispose();
+    }
+  });
+
+  it('notifies host observers for session-originated progress events', async () => {
+    const messages: ProgressViewOutboundMessage[] = [];
+    const observed: Array<{
+      event: ProgressEvent;
+      payload: ProgressEventPayloads[ProgressEvent];
+    }> = [];
+    const session = new SessionHandle();
+    const backend = new ProgressBackend({
+      storage: new MemoryMementoStorage(),
+      snapshots: new StreamSnapshotStore(),
+      session,
+      sendMessage: (message) => {
+        messages.push(message);
+        return true;
+      },
+      hasTarget: () => true,
+      configureUi: () => createUiConfig(),
+      onSessionProgressEvent: (event, payload) => {
+        observed.push({ event, payload });
+      },
+    });
+    const subscription = backend.setupEventListeners(new MemoryProgressBus());
+    const streamId = 'session:observer' as StreamTabId;
+
+    try {
+      session.events.emit({
+        scope: 'session',
+        event: {
+          type: 'goalStateChanged',
+          payload: { streamId },
+        },
+      });
+
+      expect(observed).toEqual([
+        { event: 'goalStateChanged', payload: { streamId } },
+      ]);
+    } finally {
+      subscription.dispose();
+      backend.dispose();
+      session.dispose();
+    }
+  });
+
+  it('handles direct session events with the backend effects of the legacy projection', async () => {
+    const direct = createIsolatedRecordingBackend();
+    const legacyEquivalent = createIsolatedRecordingBackend();
+    const directSubscription = direct.backend.setupEventListeners(
+      new MemoryProgressBus(),
+    );
+    const legacySubscription = legacyEquivalent.backend.setupEventListeners(
+      new MemoryProgressBus(),
+    );
+    const parentStreamId = 'session:parent' as StreamTabId;
+    const childStreamId = 'session:child' as StreamTabId;
+    const executionId = 'exec:direct-session' as ExecutionId;
+    const child: ActiveChildInfo = {
+      kind: 'subagent',
+      executionId: 'exec:child' as ExecutionId,
+      childStreamId,
+      agentName: 'orchestrator',
+      status: 'running',
+      startedAt: 1,
+      elapsed: null,
+    };
+    const process: ActiveChildInfo = {
+      kind: 'process',
+      executionId,
+      agentName: 'bash',
+      status: 'running',
+      startedAt: 2,
+      elapsed: '1s',
+      toolName: 'bash',
+    };
+    const inquiryThread = {
+      threadId: 'ei_123456789abc',
+      parentStreamId,
+      status: 'open',
+      lastQuestionPreview: 'Can you check this estimate?',
+      lastActivityIso: '2026-07-06T12:00:00.000Z',
+      turnCount: 1,
+      resumeOutcome: null,
+    } satisfies ProgressEventPayloads['inquiryThreadUpdated'];
+
+    try {
+      for (const target of [direct, legacyEquivalent]) {
+        await target.backend.state.snapshots.load([]);
+        target.backend.handleProgressEvent('setActiveStream', {
+          streamId: parentStreamId,
+          agentCategory: AgentCategory.ToolUse,
+        });
+        target.session.followUps.enqueue(
+          parentStreamId,
+          { text: 'continue with the local calculation' },
+          { force: true },
+        );
+        target.backend.handleProgressEvent('updateMissingOutputs', {
+          streamId: parentStreamId,
+          filesByRound: { 0: ['missing-output.tex'] },
+        });
+      }
+      await vi.waitFor(() =>
+        expect(direct.backend.state.activeStream).toBe(parentStreamId),
+      );
+      await vi.waitFor(() =>
+        expect(legacyEquivalent.backend.state.activeStream).toBe(
+          parentStreamId,
+        ),
+      );
+      direct.messages.length = 0;
+      legacyEquivalent.messages.length = 0;
+
+      direct.session.events.emit({
+        scope: 'run',
+        streamId: parentStreamId,
+        event: {
+          type: 'stage.start',
+          id: 'round-2',
+          label: 'round 2',
+          kind: 'round',
+          index: 2,
+          total: 4,
+        },
+      });
+      legacyEquivalent.backend.handleProgressEvent('updateRoundStage', {
+        streamId: parentStreamId,
+        roundStage: { index: 2, total: 4 },
+      });
+
+      direct.session.events.emit({
+        scope: 'run',
+        streamId: parentStreamId,
+        event: {
+          type: 'child.activity',
+          kind: 'subagents',
+          parentStreamId,
+          children: [child],
+        },
+      });
+      legacyEquivalent.backend.handleProgressEvent('updateActiveSubagents', {
+        parentStreamId,
+        children: [child],
+      });
+
+      direct.session.events.emit({
+        scope: 'run',
+        streamId: parentStreamId,
+        event: {
+          type: 'child.activity',
+          kind: 'processes',
+          parentStreamId,
+          processes: [process],
+        },
+      });
+      legacyEquivalent.backend.handleProgressEvent('updateActiveProcesses', {
+        parentStreamId,
+        processes: [process],
+      });
+
+      direct.session.events.emit({
+        scope: 'run',
+        streamId: parentStreamId,
+        event: {
+          type: 'child.activity',
+          kind: 'parent',
+          childStreamId,
+          parentStreamId,
+        },
+      });
+      legacyEquivalent.backend.handleProgressEvent('setParentStream', {
+        childStreamId,
+        parentStreamId,
+      });
+
+      direct.session.events.emit({
+        scope: 'run',
+        streamId: parentStreamId,
+        event: {
+          type: 'process.output',
+          parentStreamId,
+          executionId,
+          stdout: 'hello',
+          stderr: '',
+        },
+      });
+      legacyEquivalent.backend.handleProgressEvent('updateProcessOutput', {
+        parentStreamId,
+        executionId,
+        stdout: 'hello',
+        stderr: '',
+      });
+
+      direct.session.events.emit({
+        scope: 'session',
+        event: {
+          type: 'updateQueuedFollowUps',
+          payload: { streamId: parentStreamId },
+        },
+      });
+      legacyEquivalent.backend.handleProgressEvent('updateQueuedFollowUps', {
+        streamId: parentStreamId,
+      });
+
+      direct.session.events.emit({
+        scope: 'session',
+        event: {
+          type: 'clearMissingOutputs',
+          payload: { streamId: parentStreamId },
+        },
+      });
+      legacyEquivalent.backend.handleProgressEvent('clearMissingOutputs', {
+        streamId: parentStreamId,
+      });
+
+      direct.session.events.emit({
+        scope: 'session',
+        event: {
+          type: 'inquiryThreadUpdated',
+          payload: inquiryThread,
+        },
+      });
+      legacyEquivalent.backend.handleProgressEvent(
+        'inquiryThreadUpdated',
+        inquiryThread,
+      );
+
+      expect(direct.backend.eventHandler.getAllStreamStates()).toEqual(
+        legacyEquivalent.backend.eventHandler.getAllStreamStates(),
+      );
+      expect(
+        direct.backend.state.snapshots.getMissingOutputs(parentStreamId),
+      ).toEqual(
+        legacyEquivalent.backend.state.snapshots.getMissingOutputs(
+          parentStreamId,
+        ),
+      );
+      expect(direct.messages).toEqual(legacyEquivalent.messages);
+    } finally {
+      directSubscription.dispose();
+      legacySubscription.dispose();
+      await direct.backend.state.clearAll();
+      await legacyEquivalent.backend.state.clearAll();
+      direct.backend.dispose();
+      legacyEquivalent.backend.dispose();
+      direct.session.dispose();
+      legacyEquivalent.session.dispose();
     }
   });
 


### PR DESCRIPTION
## Summary

This is the first Stage 5 slice for #6968. It removes the shared progress backend's dependency on `attachLegacyProgressEventProjection` and makes each `ProgressBackend` subscribe directly to its owning `SessionHandle.events` for the session facts and run facts that had previously been projected through the legacy host bridge.

What changes:

- `ProgressBackend.setupEventListeners(...)` now subscribes to the backend's own session event hub and maps the migrated session/run facts into the existing local progress-event handler path.
- Desktop no longer passes a legacy projection target into `ProgressBackend`; instead it registers an explicit `onSessionProgressEvent` observer for desktop-only side effects such as restored-stream/snapshot handling.
- Added progress-backend tests for two fresh-session backends with no cross-talk, and for direct session events matching the backend effects of the old projected payloads.

This intentionally does not delete `LegacyProgressEventProjection`, `SessionRunFactProjector`, `ProgressEventBus`, CLI projections, AppSignals, or broad bus keys. Those remain later Stage 5 slices.

## Single Ownership / Layer Budget

This PR deletes one dependency edge from the progress backend:

`session.events -> LegacyProgressEventProjection -> host/local event bus -> ProgressBackend`

becomes:

`session.events -> ProgressBackend -> local backend event handling`

Desktop still has a host-local observer because its progress bridge owns desktop-only persistence and restored-stream side effects. That observer is explicit on the backend options rather than encoded as a legacy runtime-host projection target.

## Verification

- `corepack pnpm exec vitest run src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/agent/runtime/LegacyProgressEventProjection.vitest.ts`
- `corepack pnpm exec vitest run src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/agent/runtime/LegacyProgressEventProjection.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `corepack pnpm exec eslint src/shared/progressView/backend/ProgressBackend.ts packages/desktop/src/main/desktopAgentExecution.ts src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `npm run compile:fast`
- `npm run lint` (passes with the existing unrelated import-order warning in `packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts`)
- `git diff --check`

Refs #6968.
Refs #6951.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the progress event pipeline shared by desktop and extension; behavior is guarded by new parity tests but regressions in stream UI or bus fan-out are possible.
> 
> **Overview**
> **ProgressBackend** no longer wires **`attachLegacyProgressEventProjection`** through a runtime-host projection target. Each backend now subscribes to its owning **`SessionHandle.events`**, maps session and run facts through shared **`sessionProgressEventProjection`** helpers, and feeds the existing local progress-event handler path.
> 
> A new **`sessionProgressEventProjection`** module holds **`projectSessionFactToProgressEvent`**, **`projectRunFactToProgressEvent`**, and **`emitProjectedProgressEvent`**. **`LegacyProgressEventProjection`** and **`emitLegacySessionFactOnHost`** delegate to it so legacy bridges stay aligned without duplicating mapping logic.
> 
> Hosts pass optional **`onSessionProgressEvent`** for side effects: desktop forwards all session-originated events to **`DesktopProgressEventBridge`**; the extension re-emits **`goalStateChanged`** onto the global bus. Desktop drops the separate **`handleSessionProgressEvent`** / backend projection emit path.
> 
> Tests add coverage for per-session isolation (no cross-talk on a shared bus), the observer hook, and parity between direct session emits and the old projected progress payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db7ef91b58ad585834c5aaf20dc3dae59aff8dbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->