### PR TITLE
fix: clean up host interaction prompts

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1100,7 +1100,7 @@ export class DesktopProgressBridge {
     // empty streamId) — the per-stream loop skips them because they do not
     // equal any StreamTabId. Scope this to THIS window's runtime host so a
     // sibling window's streamless approval is not rejected.
-    cleanupUnscopedApprovals(this.runtimeHost);
+    cleanupUnscopedApprovals(this.runtimeHost, this.session);
     // Child/subagent coordinator requests may be session-owned without a local
     // desktop stream entry, so clear the owning window's coordinator bridge
     // after the visible per-stream sweep. This is session-scoped and does not

--- a/packages/desktop/src/main/desktopHostInteractions.ts
+++ b/packages/desktop/src/main/desktopHostInteractions.ts
@@ -216,6 +216,27 @@ class DesktopHostInteractions implements HostInteractions {
     }
   }
 
+  cancelUnscoped(cause?: string): void {
+    for (const [requestId, request] of [...this.pendingRequests.entries()]) {
+      if (request.streamId) continue;
+      this.resolve(requestId, {
+        kind: request.kind,
+        action: 'reject',
+        feedback: cause,
+      });
+    }
+  }
+
+  cancelAll(cause?: string): void {
+    for (const [requestId, request] of [...this.pendingRequests.entries()]) {
+      this.resolve(requestId, {
+        kind: request.kind,
+        action: 'reject',
+        feedback: cause,
+      });
+    }
+  }
+
   dispose(): void {
     for (const requestId of [...this.pendingRequests.keys()]) {
       this.resolve(requestId, {

--- a/packages/extension/src/progressView/extensionHostInteractions.ts
+++ b/packages/extension/src/progressView/extensionHostInteractions.ts
@@ -282,6 +282,22 @@ export function createExtensionHostInteractions(
       }
     },
 
+    cancelUnscoped(cause?: string): void {
+      void cause;
+      for (const pending of [...pendingRequests.values()]) {
+        if (!pending.streamId) {
+          releasePending(pending);
+        }
+      }
+    },
+
+    cancelAll(cause?: string): void {
+      void cause;
+      for (const pending of [...pendingRequests.values()]) {
+        releasePending(pending);
+      }
+    },
+
     dispose(): void {
       for (const pending of [...pendingRequests.values()]) {
         releasePending(pending);

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -124,6 +124,8 @@ export interface HostInteractions {
   pending(): readonly PendingHostInteraction[];
   resolve(requestId: string, result: HostInteractionResolution): boolean;
   cancelForStream(streamId: StreamTabId, cause?: string): void;
+  cancelUnscoped?(cause?: string): void;
+  cancelAll?(cause?: string): void;
   dispose?(): void;
 }
 
@@ -132,6 +134,8 @@ const noopHostInteractions: HostInteractions = {
   pending: () => [],
   resolve: () => false,
   cancelForStream: () => {},
+  cancelUnscoped: () => {},
+  cancelAll: () => {},
 };
 
 /**
@@ -220,6 +224,14 @@ export class SessionHostInteractions implements HostInteractions {
 
   cancelForStream(streamId: StreamTabId, cause?: string): void {
     this.active.cancelForStream(streamId, cause);
+  }
+
+  cancelUnscoped(cause?: string): void {
+    this.active.cancelUnscoped?.(cause);
+  }
+
+  cancelAll(cause?: string): void {
+    this.active.cancelAll?.(cause);
   }
 
   dispose(): void {

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
@@ -151,6 +151,32 @@ describe('createExtensionHostInteractions', () => {
     expect(interactions.pending()).toEqual([]);
   });
 
+  it('cancels streamless user questions during unscoped cleanup', async () => {
+    const handlers = createHandlers();
+    const interactions = createExtensionHostInteractions({
+      runtimeHost: createRuntimeHost(),
+      getApprovalHandlers: () => handlers,
+    });
+
+    const resultPromise = interactions.askUserQuestion?.({
+      requestId: 'question-a',
+      questions: [
+        {
+          question: 'Which normalization should be used?',
+          options: [{ label: 'Unit volume' }, { label: 'Unit mass' }],
+        },
+      ],
+      allowBypass: false,
+      streamId: '',
+    });
+
+    interactions.cancelUnscoped?.('No stream owns this question.');
+
+    await expect(resultPromise).resolves.toEqual({ submitted: false });
+    expect(handlers.userQuestion.resolve).toHaveBeenCalledWith('question-a');
+    expect(interactions.pending()).toEqual([]);
+  });
+
   it('delegates tool edit approval to the native VS Code port', async () => {
     const nativeResult = { accepted: true };
     mocks.nativeRequestApproval.mockResolvedValue(nativeResult);

--- a/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
+++ b/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
@@ -1,11 +1,12 @@
 // Third-party imports
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import {
   noopAgentRuntimeHost,
   type AgentRuntimeHost,
 } from '@agent/runtime/AgentRuntimeHost';
+import { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { StreamTabId } from '@shared/schemas';
 import {
   cleanupApprovalsForStream,
@@ -49,6 +50,15 @@ describe('approval cleanup scope (SDK Step 7d residue #5)', () => {
   it('scopes streamless cleanup to the owning runtime host', () => {
     const hostA = host();
     const hostB = host();
+    const session = new SessionHandle();
+    const cancelUnscoped = vi.fn();
+    const detach = session.useHostInteractions({
+      handleProgressEvent: () => false,
+      pending: () => [],
+      resolve: () => false,
+      cancelForStream: () => {},
+      cancelUnscoped,
+    });
     const settled = new Set<string>();
     const createPending = (id: string, runtimeHost: AgentRuntimeHost) => {
       let isSettled = false;
@@ -75,9 +85,12 @@ describe('approval cleanup scope (SDK Step 7d residue #5)', () => {
         createPending('bash-b', hostB),
       );
 
-      cleanupUnscopedApprovals(hostA);
+      cleanupUnscopedApprovals(hostA, session);
 
       expect(settled).toEqual(new Set(['tool-a', 'bash-a']));
+      expect(cancelUnscoped).toHaveBeenCalledWith(
+        'Streamless approval cleanup.',
+      );
 
       cleanupUnscopedApprovals();
 
@@ -89,6 +102,7 @@ describe('approval cleanup scope (SDK Step 7d residue #5)', () => {
       unregisterPendingApproval('tool-b');
       bashApprovalController.unregisterPending('bash-a');
       bashApprovalController.unregisterPending('bash-b');
+      detach();
     }
   });
 });

--- a/src/test-kernel/tools/ExternalInquiryAction.vitest.ts
+++ b/src/test-kernel/tools/ExternalInquiryAction.vitest.ts
@@ -1,0 +1,88 @@
+// Third-party imports
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports
+import type {
+  HostInteractionResolution,
+  HostInteractions,
+} from '@agent/runtime/HostInteractions';
+import { defaultSession } from '@agent/runtime/SessionHandle';
+import { handleExternalInquiryAction } from '@tools/inquiry/ExternalInquiryTool';
+
+const storageMocks = vi.hoisted(() => ({
+  ensureExternalInquiryThreadMirror: vi.fn(),
+  getOpenTurnDraft: vi.fn(),
+  getThreadSummary: vi.fn(),
+  listThreadsByStatus: vi.fn(),
+  manifestToTranscript: vi.fn(),
+  markDropped: vi.fn(),
+  readExternalInquiryThread: vi.fn(),
+  recordAnswerForOpenTurn: vi.fn(),
+  recordOpenQuestion: vi.fn(),
+}));
+
+const continuationMocks = vi.hoisted(() => ({
+  injectContinuationForAnsweredThread: vi.fn(),
+  injectContinuationForDroppedThread: vi.fn(),
+}));
+
+vi.mock('@tools/inquiry/externalInquiryStorage', () => storageMocks);
+
+vi.mock('@tools/inquiry/inquiryContinuation', () => continuationMocks);
+
+describe('handleExternalInquiryAction', () => {
+  let detach: (() => void) | undefined;
+  let resolve: ReturnType<
+    typeof vi.fn<
+      (requestId: string, result: HostInteractionResolution) => boolean
+    >
+  >;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storageMocks.recordAnswerForOpenTurn.mockResolvedValue(null);
+    storageMocks.markDropped.mockResolvedValue(null);
+    resolve = vi.fn<
+      (requestId: string, result: HostInteractionResolution) => boolean
+    >(() => true);
+    const interactions: HostInteractions = {
+      handleProgressEvent: () => false,
+      pending: () => [],
+      resolve,
+      cancelForStream: () => {},
+    };
+    detach = defaultSession().useHostInteractions(interactions);
+  });
+
+  afterEach(() => {
+    detach?.();
+    detach = undefined;
+  });
+
+  it('resolves extension submit actions through the default session', async () => {
+    await handleExternalInquiryAction({
+      action: 'submit',
+      threadId: 'thread-submit',
+      answer: 'A proof follows by compactness.',
+    });
+
+    expect(resolve).toHaveBeenCalledWith('thread-submit', {
+      kind: 'externalInquiry',
+      action: 'submit',
+    });
+  });
+
+  it('resolves extension drop actions through the default session', async () => {
+    await handleExternalInquiryAction({
+      action: 'drop',
+      threadId: 'thread-drop',
+      feedback: 'The question is no longer needed.',
+    });
+
+    expect(resolve).toHaveBeenCalledWith('thread-drop', {
+      kind: 'externalInquiry',
+      action: 'drop',
+      feedback: 'The question is no longer needed.',
+    });
+  });
+});

--- a/src/tools/approval/index.ts
+++ b/src/tools/approval/index.ts
@@ -71,9 +71,13 @@ export function releaseStreamResources(
  * pending with no UI prompt to answer. Multi-session hosts pass their own
  * `runtimeHost` so sibling windows' streamless approvals stay intact.
  */
-export function cleanupUnscopedApprovals(runtimeHost?: AgentRuntimeHost): void {
+export function cleanupUnscopedApprovals(
+  runtimeHost?: AgentRuntimeHost,
+  session: SessionHandle = defaultSession(),
+): void {
   toolEditApprovalController.rejectUnscopedPending(runtimeHost);
   bashApprovalController.rejectUnscopedPending(runtimeHost);
+  session.interactions.cancelUnscoped?.('Streamless approval cleanup.');
 }
 
 /**
@@ -96,6 +100,7 @@ export function cleanupAllApprovals(
   toolEditApprovalController.bypass.clearAll();
   bashApprovalController.bypass.clearAll();
   proposalApprovalState.clearAll();
+  session.interactions.cancelAll?.('All approvals cleared.');
   session.coordinators.cleanupAllRequests();
 }
 

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -18,7 +18,10 @@
 import { z } from 'zod';
 
 import { tryUseRunContext } from '@agent/runtime/RunContext';
-import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import {
+  defaultSession,
+  type SessionHandle,
+} from '@agent/runtime/SessionHandle';
 import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import { createChannelTrace } from '@logger';
 import {
@@ -149,6 +152,7 @@ export async function handleExternalInquiryAction(
   payload: InquiryActionMessage,
   options: { session?: SessionHandle } = {},
 ): Promise<void> {
+  const session = options.session ?? defaultSession();
   if (payload.action === 'submit') {
     const persisted = await recordAnswerForOpenTurn({
       threadId: payload.threadId,
@@ -159,7 +163,7 @@ export async function handleExternalInquiryAction(
     // this the request would replay on next webview load and the stream would
     // be reported as having pending permissions forever. Emit even for stale
     // submits so duplicate/delayed UI actions do not leave a leaked permission.
-    options.session?.interactions.resolve(payload.threadId, {
+    session.interactions.resolve(payload.threadId, {
       kind: 'externalInquiry',
       action: 'submit',
     });
@@ -188,7 +192,7 @@ export async function handleExternalInquiryAction(
     });
   }
   const droppedManifest = await markDropped({ threadId: payload.threadId });
-  options.session?.interactions.resolve(payload.threadId, {
+  session.interactions.resolve(payload.threadId, {
     kind: 'externalInquiry',
     action: 'drop',
     feedback: payload.feedback,


### PR DESCRIPTION
## Summary

This PR fixes two HostInteractions cleanup regressions left after the Stage 4 removal of legacy progress-event fallbacks.

- Adds session-owned cleanup hooks for pending host interactions with no stream scope, and wires them through extension and desktop host interaction implementations.
- Routes desktop delete-all cleanup through the window session so streamless `ask_user_question` prompts are rejected for the owning window without touching sibling windows.
- Restores default-session cleanup for extension external-inquiry submit/drop actions when the shared progress-view command handler omits an explicit session.

## Root Cause

PR #7316 moved `ask_user_question` and external inquiry cleanup from process-global fallback queues/events to session-owned `HostInteractions`. The per-stream cleanup path was updated, but the streamless cleanup path still only cleared the old tool-edit/bash controllers. Separately, `handleExternalInquiryAction` no longer used the default session when no session option was supplied, even though the extension command handler relies on that default.

## User Impact

Streamless user-question prompts are now declined during unscoped cleanup instead of remaining pending indefinitely. Extension external-inquiry cards are removed on submit/drop again, including stale submit/drop actions that should clear the panel state.

Fixes #7321.

## Validation

- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts src/test-kernel/tools/ApprovalCleanupScope.vitest.ts src/test-kernel/tools/ExternalInquiryAction.vitest.ts`
- `npm run compile:fast`
- `npm run lint` (passes with an existing unrelated import-order warning in `packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes approval and multi-window teardown paths where stuck or cross-window rejections are easy to get wrong; behavior is narrowly scoped to cleanup and inquiry resolution.
> 
> **Overview**
> Fixes **HostInteractions** cleanup gaps after session-owned prompts replaced legacy global queues: streamless **`ask_user_question`** (and similar) could stay pending when only tool/bash controllers were cleared.
> 
> Adds optional **`cancelUnscoped`** and **`cancelAll`** on **`HostInteractions`**, implemented on desktop and extension hosts. **`cleanupUnscopedApprovals`** and **`cleanupAllApprovals`** now invoke those session hooks alongside the existing global controllers. Desktop **delete all** passes the window **`session`** so streamless prompts are rejected for that window only, not sibling windows.
> 
> **`handleExternalInquiryAction`** again resolves submit/drop through **`defaultSession()`** when the caller omits an explicit session, so extension inquiry cards clear from pending permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f86d12a3f746161f5a30e5ba77627de60ec5b9d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->