### PR TITLE
refactor: collapse duplicated SessionFact switch, inline trivial stream wrapper

### DIFF
--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -26,7 +26,6 @@ import type { MediaEntry } from '@agent/utils/mediaTypes';
 import { K_SLICE } from '@agent/core/constants';
 import {
   getSdkErrorMessage,
-  consumeStreamChunks,
   handleStreamingFailure,
   takeTail,
   PARTIAL_TEXT_TAIL_MAX,
@@ -377,7 +376,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         const aggregatedParts: Part[] = [];
         let usageFromChunks: GenerateContentResponseUsageMetadata | undefined;
 
-        await consumeStreamChunks(stream, (chunk) => {
+        for await (const chunk of stream) {
           baseResponse ??= chunk;
           const candidate = chunk.candidates?.[0];
           if (candidate) {
@@ -420,7 +419,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
               baseResponse.responseId = chunk.responseId;
             }
           }
-        });
+        }
 
         if (!baseResponse) {
           throw new Error('Stream produced no response');

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -22,7 +22,6 @@ import {
   isContextWindowError,
   isPreviousResponseIdError,
   isUserAbort,
-  consumeStreamChunks,
   handleStreamingFailure,
   attachFlowAutoRetryRequired,
   trackStreamConnect,
@@ -1949,7 +1948,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
       let response: Response | undefined;
       try {
-        await consumeStreamChunks(stream, (event) => {
+        for await (const event of stream) {
           streamEventObserved = true;
           if (event.type === 'response.created') {
             responseId = event.response.id;
@@ -1960,7 +1959,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           } else if (event.type === 'response.output_item.done') {
             streamedItems.push(event.item);
           }
-        });
+        }
       } catch (streamError) {
         response = await retrieveAfterUnhandledStreamEvent(streamError);
       }

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -14,7 +14,6 @@ import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import type { MediaEntry } from '@agent/utils/mediaTypes';
 import { K_SLICE } from '@agent/core/constants';
 import {
-  consumeStreamChunks,
   detectStatusCode,
   handleStreamingFailure,
   takeTail,
@@ -248,12 +247,12 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
         const thinkingStream = thinking;
         const outputStream = output;
 
-        await consumeStreamChunks(stream, (chunk) => {
+        for await (const chunk of stream) {
           const { contentDelta, reasoningDelta } =
             aggregator.consumeChunk(chunk);
           if (reasoningDelta) thinkingStream.append(reasoningDelta);
           if (contentDelta) outputStream.append(contentDelta);
-        });
+        }
 
         const response = aggregator.buildResponse();
         const finalReasoning = this.processThinkingBlock(response);

--- a/src/agent/runtime/LegacyProgressEventProjection.ts
+++ b/src/agent/runtime/LegacyProgressEventProjection.ts
@@ -2,30 +2,10 @@ import type { AgentEvent } from '@agent/trace';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { StreamTabId } from '@shared/schemas';
 
-import type { SessionEventHub, SessionFact } from './SessionEventHub';
-
-function emitLegacySessionFact(
-  runtimeHost: AgentRuntimeHost,
-  fact: SessionFact,
-): void {
-  switch (fact.type) {
-    case 'goalStateChanged':
-      runtimeHost.emit('goalStateChanged', fact.payload);
-      return;
-    case 'inquiryThreadUpdated':
-      runtimeHost.emit('inquiryThreadUpdated', fact.payload);
-      return;
-    case 'clearMissingOutputs':
-      runtimeHost.emit('clearMissingOutputs', fact.payload);
-      return;
-    case 'updateQueuedFollowUps':
-      runtimeHost.emit('updateQueuedFollowUps', fact.payload);
-      return;
-    case 'setActiveStream':
-      runtimeHost.emit('setActiveStream', fact.payload);
-      return;
-  }
-}
+import {
+  emitLegacySessionFactOnHost,
+  type SessionEventHub,
+} from './SessionEventHub';
 
 function emitLegacyRunEvent(
   runtimeHost: AgentRuntimeHost,
@@ -92,7 +72,7 @@ export function attachLegacyProgressEventProjection(
   const detachSessionFacts = events.subscribe(
     (sessionEvent) => {
       if (sessionEvent.scope === 'session') {
-        emitLegacySessionFact(runtimeHost, sessionEvent.event);
+        emitLegacySessionFactOnHost(runtimeHost, sessionEvent.event);
       }
     },
     { scope: 'session' },

--- a/src/agent/runtime/SessionEventHub.ts
+++ b/src/agent/runtime/SessionEventHub.ts
@@ -4,6 +4,9 @@ import type { AgentEvent } from '@agent/trace';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import { createChannelTrace } from '@logger';
 import type { StreamTabId } from '@shared/schemas';
+import { assertNever } from '@utils/core';
+
+import type { AgentRuntimeHost } from './AgentRuntimeHost';
 
 const logger = createChannelTrace('SessionEventHub');
 
@@ -32,6 +35,37 @@ export type SessionFact =
 export type SessionEvent =
   | { scope: 'run'; streamId: StreamTabId; event: AgentEvent }
   | { scope: 'session'; event: SessionFact };
+
+/**
+ * Re-emit a {@link SessionFact} on the legacy per-host progress-event
+ * surface. Shared by `emitRuntimeEvent`'s host-channel path and
+ * `LegacyProgressEventProjection`'s hub-subscription path — both project the
+ * same fact vocabulary onto the same host events.
+ */
+export function emitLegacySessionFactOnHost(
+  host: AgentRuntimeHost,
+  fact: SessionFact,
+): void {
+  switch (fact.type) {
+    case 'goalStateChanged':
+      host.emit('goalStateChanged', fact.payload);
+      return;
+    case 'inquiryThreadUpdated':
+      host.emit('inquiryThreadUpdated', fact.payload);
+      return;
+    case 'clearMissingOutputs':
+      host.emit('clearMissingOutputs', fact.payload);
+      return;
+    case 'updateQueuedFollowUps':
+      host.emit('updateQueuedFollowUps', fact.payload);
+      return;
+    case 'setActiveStream':
+      host.emit('setActiveStream', fact.payload);
+      return;
+    default:
+      assertNever(fact, 'Unhandled SessionFact type');
+  }
+}
 
 export interface SessionEventSubscriptionFilter {
   readonly scope?: SessionEvent['scope'];

--- a/src/agent/runtime/emitRuntimeEvent.ts
+++ b/src/agent/runtime/emitRuntimeEvent.ts
@@ -22,28 +22,10 @@ import { bus, type ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
 import { tryUseRunContext } from './RunContext';
 import { defaultSession, type SessionHandle } from './SessionHandle';
-import type { AgentRuntimeHost } from './AgentRuntimeHost';
-import type { SessionFact } from './SessionEventHub';
-
-function emitLegacyHostFact(host: AgentRuntimeHost, fact: SessionFact): void {
-  switch (fact.type) {
-    case 'goalStateChanged':
-      host.emit('goalStateChanged', fact.payload);
-      return;
-    case 'inquiryThreadUpdated':
-      host.emit('inquiryThreadUpdated', fact.payload);
-      return;
-    case 'clearMissingOutputs':
-      host.emit('clearMissingOutputs', fact.payload);
-      return;
-    case 'updateQueuedFollowUps':
-      host.emit('updateQueuedFollowUps', fact.payload);
-      return;
-    case 'setActiveStream':
-      host.emit('setActiveStream', fact.payload);
-      return;
-  }
-}
+import {
+  emitLegacySessionFactOnHost,
+  type SessionFact,
+} from './SessionEventHub';
 
 function emitSessionFact(fact: SessionFact, session?: SessionHandle): void {
   const owner = session ?? tryUseRunContext()?.session;
@@ -52,7 +34,7 @@ function emitSessionFact(fact: SessionFact, session?: SessionHandle): void {
     return;
   }
   if (owner?.hostChannel) {
-    emitLegacyHostFact(owner.hostChannel, fact);
+    emitLegacySessionFactOnHost(owner.hostChannel, fact);
     return;
   }
   defaultSession().events.emit({ scope: 'session', event: fact });

--- a/src/common/errors/sdkError/streamFailure.ts
+++ b/src/common/errors/sdkError/streamFailure.ts
@@ -85,25 +85,6 @@ export function annotateStreamFailure(
 }
 
 /**
- * Drives an async-iterable provider stream, invoking `consume` once per chunk.
- * A named extraction of the `for await (const chunk of stream) { ... }` loop
- * every iterate-based streaming handler (OpenRouter, GoogleGenAI, and the
- * event loop inside OpenAI Responses) previously hand-wrote inline. Handlers
- * whose SDK drives consumption through its own event emitter instead of a
- * plain async iterable (Anthropic's `attachToStream`, OpenAI chat completions'
- * `stream.on('chunk', ...)`) do not use this — their "consume" hook is the
- * listener they register directly with the SDK.
- */
-export async function consumeStreamChunks<TChunk>(
-  stream: AsyncIterable<TChunk>,
-  consume: (chunk: TChunk) => void,
-): Promise<void> {
-  for await (const chunk of stream) {
-    consume(chunk);
-  }
-}
-
-/**
  * Hooks for {@link handleStreamingFailure}, the shared tail of the mid-stream
  * failure skeleton every provider handler's streaming catch block runs:
  * finalize the in-flight progress streams, compute the partial-output tail,

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -27,7 +27,6 @@ export {
   type StreamConnectTracker,
   type StreamingFailureHooks,
   annotateStreamFailure,
-  consumeStreamChunks,
   handleStreamingFailure,
   trackStreamConnect,
 } from './sdkError/streamFailure';


### PR DESCRIPTION
## Summary

Two verified "do-now" items from the 2026-07-06 abstraction-cost calibration audit (posted to #6951 and cross-checked against a deeper follow-up workflow pass recorded in the same audit trail) — small, net-negative-LOC, mechanical cleanups, not new abstraction:

1. **Collapse duplicated `SessionFact` switch.** `emitRuntimeEvent.ts` and `LegacyProgressEventProjection.ts` each hand-rolled a byte-identical 5-case switch projecting `SessionFact` onto legacy host events (`goalStateChanged`, `inquiryThreadUpdated`, `clearMissingOutputs`, `updateQueuedFollowUps`, `setActiveStream`). Collapsed into one `assertNever`-guarded `emitLegacySessionFactOnHost` in `SessionEventHub.ts`, which already owns the `SessionFact` type — single owner, no new indirection (confirmed no import cycle: `AgentRuntimeHost.ts` doesn't import `SessionEventHub.ts`).
2. **Inline a trivial stream wrapper.** `consumeStreamChunks` was a bare `for await (const chunk of stream) { consume(chunk) }` wrapper — verified via its introducing commit that it never carried any shared error-handling/retry/logging logic (that stays in `handleStreamingFailure`, untouched). Inlined back into its 3 call sites (openai/google/openrouter streaming handlers) and deleted, along with its barrel re-export.

## Verification

- Re-checked both against fresh HEAD before touching anything — a third candidate from the same audit ("delete inert `HostInteractionOptions.timeoutMs`") turned out to be **stale** (a concurrent PR, #7325, gave it a real caller in the interim) and was correctly skipped, not applied blindly.
- Ran `/simplify`: 4 parallel review agents (reuse, simplification, efficiency, altitude) — all returned zero findings.
- `npx tsc --noEmit` — clean
- `npx eslint` on all 8 changed files — clean
- `corepack pnpm exec vitest run` across all affected suites (model handlers for openai/google/openrouter streaming + runtime SessionEventHub/emitRuntimeEvent/LegacyProgressEventProjection + common StreamFailure) — 14 files / 76 tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only deduplication and inlining across runtime event projection and streaming loops; mid-stream failure handling is unchanged.
> 
> **Overview**
> This PR is a small mechanical cleanup with no intended behavior change.
> 
> **Session runtime events:** The identical five-case switch that mapped `SessionFact` types onto legacy `AgentRuntimeHost` events lived in both `emitRuntimeEvent.ts` (host-channel fallback) and `LegacyProgressEventProjection.ts` (hub subscription). That logic now lives in **`emitLegacySessionFactOnHost`** in `SessionEventHub.ts`, next to the `SessionFact` type, with an **`assertNever`** default so new fact types fail at compile/runtime instead of silently falling through.
> 
> **Model streaming:** **`consumeStreamChunks`** was only a `for await` + callback wrapper with no shared error handling (that remains in `handleStreamingFailure`). Google GenAI, OpenAI Responses, and OpenRouter native handlers now iterate streams inline; the helper and its `sdkErrorUtils` re-export are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 859b2229cc8f0f1fa4d380241af437e181c18cbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->