### PR TITLE
docs: codify abstraction-cost loop guardrails from the 2026-07 calibration

### DIFF
--- a/.claude/skills/code-review/references/review-checklist.md
+++ b/.claude/skills/code-review/references/review-checklist.md
@@ -105,6 +105,16 @@ Full pattern list with examples in `AGENTS.md` → "ES2023+ Patterns". Greps for
 - **`new Promise((resolve) => setTimeout(resolve, ms))`** in Node-only code → `setTimeout` from `node:timers/promises`.
 - **Don't flag** the legitimate index loops: token consumers that advance `i` by variable strides, queue/BFS loops that append mid-iteration, and `charCodeAt(i)` hash loops (code-point iteration would change persisted hash output).
 
+## 13. Abstraction-cost guardrails (2026-07 calibration)
+
+Standing rules from the 2026-07 tech-debt re-calibration, which found that a run of "reduction" PRs quietly re-accumulated abstraction cost: 22 PRs pitched as reductions netted **+5,046 production LoC**, with 18 of 22 net-positive — the "Refactor-LOC lesson" at scale. Evidence base: [`docs/proposals/tech-debt-audit-2026-07.md`](../../../../docs/proposals/tech-debt-audit-2026-07.md). Apply these whenever a PR adds a port/facade/projector/strategy/template-method, or is titled `refactor:` / `simplify:` / `consolidate` / `dedupe` / `extract`:
+
+- **Build implies delete in the same PR.** A new port/facade/projector/strategy/template-method merges only if it deletes the path it replaces in that same PR. Deferral is allowed only with a ledger row **and** a concrete removal-trigger issue that is a merge-blocker for the next stage.
+- **No leapfrogging a migration.** A staged migration may not merge stage N+1 scaffolding while stage N's deletion issue is still open.
+- **Net-positive-LOC "reductions" need a reason.** Reject a PR titled `refactor:`/`simplify:`/`consolidate`/`dedupe`/`extract` that grows LoC unless it (a) deletes an old path, (b) collapses to a genuine ≥2-caller helper, or (c) trades LoC for a `CLAUDE.md`-mandated type-safety win (e.g. a discriminated union with `assertNever`). The PR body must state the actual `git diff --stat origin/main` net LoC and justify any positive number.
+- **No trivial-identity or single-caller extractions.** Grep the caller count before approving any new shared helper — one caller is not DRY. Extends `CLAUDE.md` → "Discouraged Factory Patterns".
+- **Don't reward activity.** A program/migration that opens more follow-up issues than it retires pauses further building until its tail closes.
+
 ## Final pass
 
 - Cut findings not tied to a real `path:line` in the diff.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,8 @@ const options: Options = { ... };
 - Create class instances or complex objects
 - Need to capture closures with initialization context
 
+At review time this extends into the **Abstraction-cost guardrails** (code-review checklist § 13): grep the caller count before approving any new shared helper (single-caller extractions are banned), and hold new ports/facades/template-methods to build-implies-delete-in-the-same-PR with net-LOC accounting.
+
 ### Render-Time Workarounds (Anti-pattern)
 
 Never compensate for data model problems at render time. Renderers should only transform and display.


### PR DESCRIPTION
## What

Codifies the "loop guardrails" from the 2026-07 tech-debt re-calibration as durable review rules, so the continuous refactor loop stops re-accumulating abstraction cost. **Docs/process only — no product code changes.**

## Why

The re-calibration found that a run of PRs pitched as reductions quietly re-accumulated abstraction cost: 22 "reduction" PRs netted **+5,046 production LoC**, with 18 of 22 net-positive — the documented "Refactor-LOC lesson" at scale. That course-correction lived only as tacit judgment; this turns it into standing review rules the code-review skill enforces on every refactor/consolidate PR.

## What changed

- **`.claude/skills/code-review/references/review-checklist.md`** — new tight section **§ 13 "Abstraction-cost guardrails (2026-07 calibration)"** (placed before "Final pass", no renumbering of existing sections). Six rules: build-implies-delete-in-the-same-PR, no migration-stage leapfrogging, net-positive-LOC "reductions" need a stated `git diff --stat origin/main` justification, the ban on trivial-identity/single-caller extractions (extends "Discouraged Factory Patterns"), don't-reward-activity (issues-opened vs -retired), and the evidence-base link to `docs/proposals/tech-debt-audit-2026-07.md`.
- **`CLAUDE.md`** — one-line pointer at the end of "Discouraged Factory Patterns" into the new checklist § 13, keeping the review rules single-homed in the checklist and cross-referencing the existing anti-patterns rather than restating them.

## Net diff (`git diff --stat origin/main`)

```
 .claude/skills/code-review/references/review-checklist.md | 10 ++++++++++
 CLAUDE.md                                                 |  2 ++
 2 files changed, 12 insertions(+)
```

Additive only; no existing content restructured; no new root-level docs file (respects the `docs-root-boundary` gate).

https://claude.ai/code/session_01PkkPA9A5vht7PmB9xxiqU3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and review-process changes only; no runtime, auth, or product behavior is modified.
> 
> **Overview**
> Turns the **2026-07 tech-debt re-calibration** findings into standing **code-review rules** so refactor/consolidate PRs are checked for net abstraction cost, not just intent.
> 
> **`review-checklist.md`** gains **§ 13 Abstraction-cost guardrails**: new ports/facades must **delete replaced code in the same PR**; no **leapfrogging** staged migrations; **`refactor:`/`simplify:` PRs that grow LoC** must cite `git diff --stat origin/main` and justify growth; **single-caller extractions** are rejected; migrations that **open more issues than they close** pause further building. Links evidence to `docs/proposals/tech-debt-audit-2026-07.md`.
> 
> **`CLAUDE.md`** adds one line under **Discouraged Factory Patterns** pointing reviewers at § 13 (caller-count grep, build-implies-delete, net-LOC), keeping rules single-homed in the checklist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e40e1866c126116d53ceff9448c32e85050a321. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->