### PR TITLE
docs(modelFactory): drop stale "additive sibling" framing in shouldUseGoogleInteractionsAPI

### DIFF
--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -180,14 +180,16 @@ function modelRequiresInteractionsAPI(config: ModelConfig): boolean {
 /**
  * Check if the Google Interactions API should be used for this config.
  *
- * Additive sibling to the chat/`generateContent` Google route, gated behind
- * `texra.model.useGoogleInteractionsAPI` (default on). OpenRouter can NOT proxy
- * Interactions, so an active OpenRouter proxy always returns false — the chat
- * handler (or OpenRouter) remains the fallback. This is a PURE predicate (never
- * throws): the unsupported Interactions-only + OpenRouter combination is failed
- * loudly at handler creation (`assertGoogleInteractionsRoutable`), not here, so
- * key-derivation callers (history restore, `modelSwitchDisabledReason`) stay
- * exception-free — matching `requiresOpenAIResponsesAPI`'s contract.
+ * Routes to the default, actively-developed Interactions handler unless
+ * `texra.model.useGoogleInteractionsAPI` (default on) is off; the chat/
+ * `generateContent` GenAI handler is the feature-frozen fallback (#7097).
+ * OpenRouter can NOT proxy Interactions, so an active OpenRouter proxy always
+ * returns false — the GenAI handler (or OpenRouter) remains the fallback in
+ * that case too. This is a PURE predicate (never throws): the unsupported
+ * Interactions-only + OpenRouter combination is failed loudly at handler
+ * creation (`assertGoogleInteractionsRoutable`), not here, so key-derivation
+ * callers (history restore, `modelSwitchDisabledReason`) stay exception-free —
+ * matching `requiresOpenAIResponsesAPI`'s contract.
  */
 export function shouldUseGoogleInteractionsAPI(
   config: ModelConfig,


### PR DESCRIPTION
## Root cause

PR #7329 recorded the #7097 decision — `ModelHandlerGoogleInteractions` is now the default, actively-developed Google route, and `ModelHandlerGoogleGenAI` is a feature-frozen stateless fallback no longer tracked for behavioral parity — in `src/agent/modelHandlers/README.md` and both handler class docstrings. It missed a third location: `shouldUseGoogleInteractionsAPI`'s docstring in `src/agent/runtime/ModelFactory.ts` still opened with "Additive sibling to the chat/`generateContent` Google route," which now contradicts the docs that PR just aligned.

## Fix

Doc-only change. Reworded the docstring to say Interactions is the default/actively-developed route and GenAI is the feature-frozen fallback (#7097), matching the framing already used in the README and the two handler class docstrings. No behavior change — `shouldUseGoogleInteractionsAPI`'s logic is untouched.

## Verification

- `npx tsc --noEmit` — pre-existing unrelated errors only (identical error set with/without this change: `@openrouter/sdk` module-resolution errors and `src/tools/lean/direct/jsonRpc.ts` implicit-any errors; confirmed via `git stash`/`git stash pop` diff). No errors touch `ModelFactory.ts`.
- `npx eslint src/agent/runtime/ModelFactory.ts` — clean.
- `npx vitest run src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts` — 36/36 passed.
- `npx prettier --check src/agent/runtime/ModelFactory.ts` — passed, no reformatting needed.

Fixes #7332.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change; routing predicate and handler selection are unchanged.
> 
> **Overview**
> Updates the **`shouldUseGoogleInteractionsAPI`** docstring in `ModelFactory.ts` so it matches the post-#7097 story already used elsewhere: **Google Interactions** is the default, actively developed route; **GenAI** (`generateContent`) is the feature-frozen fallback when `texra.model.useGoogleInteractionsAPI` is off.
> 
> Removes the outdated “additive sibling to the chat/`generateContent` route” wording. **No code or routing logic changes** — only documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e97067433b5a371cd2af16257478a10286bbc1ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->