### PR TITLE
[codex] Route goal state consumers through sessions

### DIFF
--- a/packages/desktop/src/main/desktopProgressEventBridge.ts
+++ b/packages/desktop/src/main/desktopProgressEventBridge.ts
@@ -139,15 +139,9 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
     this.hydrateRestoredStreams();
 
     // These events can be emitted on the process bus without an active desktop
-    // runtime host. Keep them subscribed here so all desktop windows see goal
-    // badge, progress-routing, and root-error updates.
-    const unsubscribeGoal = bus.on('goalStateChanged', ({ streamId }) => {
-      const goal = GoalStore.getForStream(streamId);
-      opts.onGoalStateChanged(streamId, isGoalInFlight(goal), {
-        status: goal?.status,
-        objective: goal?.objective,
-      });
-    });
+    // runtime host. Keep them subscribed here so all desktop windows see
+    // progress-routing and root-error updates. Goal state is session-scoped and
+    // reaches this bridge through `onProgressEvent`.
     const unsubscribeEnsureProgress = bus.on(
       'requestEnsureProgressView',
       () => {
@@ -158,7 +152,6 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
       opts.onShowError(message);
     });
     this.unsubscribe = () => {
-      unsubscribeGoal();
       unsubscribeEnsureProgress();
       unsubscribeShowError();
     };

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -17,6 +17,7 @@ import { ProgressWorkflowFileActionsController } from '@controllers/progressView
 import { getAgent } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { HostInteractions } from '@agent/runtime/HostInteractions';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import type { RunCoordinatorBridge } from '@agent/runtime/runCoordinators';
 import {
   validateExecutionRequest,
@@ -45,7 +46,7 @@ import {
   type ProgressViewInboundMessage,
 } from '@shared/schemas/progressView';
 import { unsupportedCommands } from '@shared/utils/dispatcher';
-import { GoalStore } from '@tools/goal';
+import { GoalStore, subscribeGoalStateChanges } from '@tools/goal';
 import {
   createExternalLocation,
   flexibleFS,
@@ -130,14 +131,17 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     });
     context.subscriptions.push({ dispose: unsubscribeRemoveStream });
 
-    const unsubscribeGoal = bus.on('goalStateChanged', ({ streamId }) => {
-      const goal = GoalStore.getForStream(streamId);
-      this.provider.webviewUpdater.updateGoalActive(
-        streamId,
-        isGoalInFlight(goal),
-        { status: goal?.status, objective: goal?.objective },
-      );
-    });
+    const unsubscribeGoal = subscribeGoalStateChanges(
+      defaultSession(),
+      ({ streamId }) => {
+        const goal = GoalStore.getForStream(streamId);
+        this.provider.webviewUpdater.updateGoalActive(
+          streamId,
+          isGoalInFlight(goal),
+          { status: goal?.status, objective: goal?.objective },
+        );
+      },
+    );
     context.subscriptions.push({ dispose: unsubscribeGoal });
   }
 

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -113,11 +113,6 @@ export class ProgressViewProvider
       getStreamControls: getProgressStreamControls,
       getUnsupportedCommands: () =>
         this.messageHandler.getUnsupportedCommands(),
-      onSessionProgressEvent: (event, payload) => {
-        if (event === 'goalStateChanged') {
-          bus.emit(event, payload);
-        }
-      },
       configureUi: ({ webviewUpdater: u }) => {
         const canSend = () => this.canSendToWebview();
         this.approvalHandlers = buildApprovalRequestHandlerSet({

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -25,6 +25,7 @@ import {
   buildModelSelectionMessage,
   createModelSelectionController,
 } from '@controllers/settingsView/SettingsModelSelectionControllerFactory';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import { AUTH_COMMANDS } from '@auth/constants';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { BaseViewMessageHandler } from '@common/webview';
@@ -78,7 +79,7 @@ import {
   PROVIDER_URLS,
   PROVIDER_VSCODE_SETTINGS,
 } from '@shared/constants/providers';
-import { GoalStore } from '@tools/goal';
+import { GoalStore, subscribeGoalStateChanges } from '@tools/goal';
 import {
   getLastCheckResults,
   refreshToolAvailability,
@@ -224,9 +225,10 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         this.sendToolDashboardData(w, { skipChecks: true }),
       );
     });
-    bus.on('goalStateChanged', () => {
+    const unsubscribeGoals = subscribeGoalStateChanges(defaultSession(), () => {
       void this.withActiveWebview((w) => this.sendGoalList(w));
     });
+    context.subscriptions.push({ dispose: unsubscribeGoals });
   }
 
   private createHandlerRegistry(): SettingsViewInboundHandlerRegistry {

--- a/src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts
@@ -4,9 +4,9 @@
  * Covers ghost-stream hydration, snapshot persistence, restored-display
  * sending, progress-event handling, and stream-lifecycle callbacks.
  *
- * Event-bus wiring (goalStateChanged, requestEnsureProgressView,
- * requestShowError) is tested indirectly through the bridge's public
- * API and the callbacks it invokes.
+ * Event-bus wiring (requestEnsureProgressView, requestShowError) and
+ * session-progress handling are tested indirectly through the bridge's
+ * public API and the callbacks it invokes.
  */
 
 // Third-party imports
@@ -499,12 +499,30 @@ describe('DesktopProgressEventBridge', () => {
         bridge.dispose();
       }
     });
+
+    it('updates goal badge state from the session progress path', () => {
+      const onGoalStateChanged = vi.fn();
+      const bridge = createBridge({ onGoalStateChanged });
+
+      try {
+        bridge.onProgressEvent('goalStateChanged', {
+          streamId: 'goal-stream',
+        });
+
+        expect(onGoalStateChanged).toHaveBeenCalledWith('goal-stream', false, {
+          status: undefined,
+          objective: undefined,
+        });
+      } finally {
+        bridge.dispose();
+      }
+    });
   });
 
   // ── Process-bus events ──────────────────────────────────────────────────
 
   describe('process-bus events', () => {
-    it('subscribes to desktop-wide goal, routing, and root-error events', () => {
+    it('subscribes to desktop-wide routing and root-error events only', () => {
       const routeToProgress = vi.fn();
       const onGoalStateChanged = vi.fn();
       const onShowError = vi.fn();
@@ -515,23 +533,17 @@ describe('DesktopProgressEventBridge', () => {
       });
 
       try {
-        mockBusHandlers.get('goalStateChanged')?.({
-          streamId: 'goal-stream',
-        });
         mockBusHandlers.get('requestEnsureProgressView')?.({});
         mockBusHandlers.get('requestShowError')?.({
           message: 'Root run failed',
         });
 
-        expect(onGoalStateChanged).toHaveBeenCalledWith('goal-stream', false, {
-          status: undefined,
-          objective: undefined,
-        });
+        expect(mockBusHandlers.has('goalStateChanged')).toBe(false);
+        expect(onGoalStateChanged).not.toHaveBeenCalled();
         expect(routeToProgress).toHaveBeenCalledTimes(1);
         expect(onShowError).toHaveBeenCalledWith('Root run failed');
 
         bridge.dispose();
-        expect(mockBusHandlers.has('goalStateChanged')).toBe(false);
         expect(mockBusHandlers.has('requestEnsureProgressView')).toBe(false);
         expect(mockBusHandlers.has('requestShowError')).toBe(false);
       } finally {

--- a/src/test-kernel/tools/GoalStateSubscription.vitest.ts
+++ b/src/test-kernel/tools/GoalStateSubscription.vitest.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { SessionHandle } from '@agent/runtime/SessionHandle';
+import type { StreamTabId } from '@shared/schemas';
+import { subscribeGoalStateChanges } from '@tools/goal';
+
+describe('subscribeGoalStateChanges', () => {
+  it('delivers only goal changes from the supplied session', () => {
+    const sessionA = new SessionHandle();
+    const sessionB = new SessionHandle();
+    const seen: unknown[] = [];
+    const detach = subscribeGoalStateChanges(sessionA, (change) => {
+      seen.push(change);
+    });
+
+    try {
+      sessionB.events.emit({
+        scope: 'session',
+        event: {
+          type: 'goalStateChanged',
+          payload: { streamId: 'other-session' as StreamTabId },
+        },
+      });
+      sessionA.events.emit({
+        scope: 'session',
+        event: {
+          type: 'setActiveStream',
+          payload: { streamId: 'same-session' as StreamTabId },
+        },
+      });
+      sessionA.events.emit({
+        scope: 'session',
+        event: {
+          type: 'goalStateChanged',
+          payload: { streamId: 'same-session' as StreamTabId },
+        },
+      });
+
+      expect(seen).toEqual([{ streamId: 'same-session' }]);
+    } finally {
+      detach();
+      sessionA.dispose();
+      sessionB.dispose();
+    }
+  });
+});

--- a/src/tools/goal/goalStore.ts
+++ b/src/tools/goal/goalStore.ts
@@ -31,6 +31,12 @@ const LEGACY_INDEX_KEY = 'odysseys:index';
 // without calling `forget()` leave dangling entries until next manual cleanup.
 const indexMutex = new Mutex();
 
+export interface GoalStateChange {
+  readonly streamId: StreamTabId;
+}
+
+export type GoalStateChangeListener = (change: GoalStateChange) => void;
+
 function streamKey(streamId: StreamTabId): string {
   return `${STREAM_KEY_PREFIX}${streamId}`;
 }
@@ -189,6 +195,28 @@ function requireNonEmpty(value: string, label: string): string {
     throw new Error(`${label} must not be empty or whitespace-only.`);
   }
   return trimmed;
+}
+
+/**
+ * Subscribe to goal mutations in one explicitly-owned session.
+ * Goal state is session-scoped: consumers must pass the session they render,
+ * rather than listening on a process-wide compatibility event.
+ */
+export function subscribeGoalStateChanges(
+  session: Pick<SessionHandle, 'events'>,
+  listener: GoalStateChangeListener,
+): () => void {
+  return session.events.subscribe(
+    (sessionEvent) => {
+      if (
+        sessionEvent.scope === 'session' &&
+        sessionEvent.event.type === 'goalStateChanged'
+      ) {
+        listener(sessionEvent.event.payload);
+      }
+    },
+    { scope: 'session' },
+  );
 }
 
 export const GoalStore = {

--- a/src/tools/goal/index.ts
+++ b/src/tools/goal/index.ts
@@ -1,3 +1,8 @@
 export { isGoalEnabled } from './goalFeatureFlag';
-export { GoalStore } from './goalStore';
+export {
+  GoalStore,
+  subscribeGoalStateChanges,
+  type GoalStateChange,
+  type GoalStateChangeListener,
+} from './goalStore';
 export { setGoalSessionBashAutoApproval } from './goalAutoApproval';


### PR DESCRIPTION
## Summary

This PR removes the remaining `goalStateChanged` ProgressEventBus compatibility path from the extension progress/settings consumers and the desktop progress bridge.

Goal state remains a session fact. The extension progress badge and settings goal list now subscribe through a goal-specific helper that requires an explicit session. The desktop bridge no longer listens for goal changes on the process bus; its goal badge refresh continues through the window-local session progress path.

## Details

- Added `subscribeGoalStateChanges(session, listener)` in the goal module as a small session-scoped goal signal surface.
- Switched extension progress and settings consumers from `bus.on('goalStateChanged')` to `subscribeGoalStateChanges(defaultSession(), ...)`.
- Removed the extension `ProgressBackend` compatibility re-emission of session-projected `goalStateChanged` back onto the process bus.
- Removed the desktop bridge process-bus `goalStateChanged` subscription while preserving `requestEnsureProgressView` and `requestShowError` process-bus handling.
- Added tests for session isolation in the goal subscription helper and for desktop goal badge updates through the session progress path.

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/tools/GoalStateSubscription.vitest.ts src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- `npm run lint` (passes with one unrelated warning in `packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts`)
- `npm run typecheck`
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cross-host event routing for goal UI refresh; behavior should match for the default session, but incorrect session wiring could drop badge or settings list updates in multi-session setups.
> 
> **Overview**
> Removes the process-wide **`goalStateChanged`** ProgressEventBus compatibility path for goal UI consumers and routes them through an explicit **session** instead.
> 
> Adds **`subscribeGoalStateChanges(session, listener)`** in the goal module so callers subscribe to session events rather than the global bus. Extension **progress** (goal badge) and **settings** (goal list) now use **`subscribeGoalStateChanges(defaultSession(), …)`** with proper disposal on extension subscriptions. **`ProgressBackend`** no longer re-emits session-projected **`goalStateChanged`** onto the process bus from **`ProgressViewProvider`**.
> 
> On **desktop**, **`DesktopProgressEventBridge`** stops listening for goals on the process bus; goal badge refresh still runs when **`goalStateChanged`** arrives via the window-local **`onProgressEvent`** path. Process-bus wiring for **`requestEnsureProgressView`** and **`requestShowError`** is unchanged.
> 
> Tests cover session isolation for the new helper and desktop goal badge updates through the session progress path (not the bus).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81a377e2aa605baa8249e7ac479607c738d8fad7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->