### PR TITLE
fix(agent): report zero-output-across-retries runs as FAILED, not COMPLETED

### DIFF
--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -152,10 +152,23 @@ function toProposalResult(decision: ApprovalDecision): ProposalResult {
     : { action: 'reject', feedback: decision.userMessage };
 }
 
-function toRetryResult(decision: ApprovalDecision): RetryResult {
-  return decision.accepted
-    ? { action: 'retry', feedback: decision.userMessage }
-    : { action: 'cancel' };
+function toRetryResult(
+  decision: ApprovalDecision,
+  humanInputAvailable: boolean,
+): RetryResult {
+  if (decision.accepted) {
+    return { action: 'retry', feedback: decision.userMessage };
+  }
+  // A non-accepted retry with no human available is a policy/headless
+  // auto-denial (e.g. `--approval-policy never --no-input`), not a user
+  // cancel — surface it as a distinct `deny` so a run that produces zero
+  // output across all retries reports FAILED, not COMPLETED. See #7331.
+  return humanInputAvailable
+    ? { action: 'cancel' }
+    : {
+        action: 'deny',
+        ...(decision.userMessage ? { reason: decision.userMessage } : {}),
+      };
 }
 
 async function askHeadlessUserQuestion(
@@ -261,7 +274,7 @@ export function createHeadlessCliHostInteractions(
         hooks,
         { writeRejectionToStderr: true },
       );
-      return toRetryResult(decision);
+      return toRetryResult(decision, approvalPromptAllowed(context));
     },
     askUserQuestion(request) {
       return askHeadlessUserQuestion(request, context, hooks);

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -284,6 +284,25 @@ export abstract class RetryableInvocationNode<
       return { shouldRetry: true, userCancelled: false };
     }
 
+    if (result.action === 'deny') {
+      // Policy/headless auto-denial: no human was available to approve the
+      // retry (e.g. `--approval-policy never --no-input`). This is a failure,
+      // not a user cancel — leaving `userCancelled` false routes it to the
+      // `failed` fallback so a zero-output run reports FAILED (surfacing the
+      // underlying error), not COMPLETED. Resume to RUNNING first because a
+      // WAITING stream can't terminalize directly: the propagating failure is
+      // written as the terminal outcome by the run lifecycle. See #7331.
+      logProgressStatus(
+        logger,
+        result.reason ?? 'Retry denied (no human input available)',
+      );
+      streamStatus.transition(streamId, STREAM_PHASE.RUNNING, 'resume', {
+        runtimeHost,
+        trace: logger,
+      });
+      return { shouldRetry: false, userCancelled: false };
+    }
+
     const message =
       result.action === 'timeout'
         ? 'Retry timed out (no response)'

--- a/src/agent/runtime/RetryRequestCoordinator.ts
+++ b/src/agent/runtime/RetryRequestCoordinator.ts
@@ -9,7 +9,12 @@ import type { ProviderErrorPartial } from '@shared/schemas';
 export type RetryResult =
   | { action: 'retry'; feedback?: string }
   | { action: 'cancel' }
-  | { action: 'timeout' };
+  | { action: 'timeout' }
+  // Policy/headless auto-denial: the retry could not be approved because no
+  // human input was available (e.g. `--approval-policy never --no-input`).
+  // Distinct from a user `cancel` so retry-exhaustion with no human lands in
+  // the `failed` fallback (→ RUN_OUTCOME.FAILED) instead of `cancelled`. See #7331.
+  | { action: 'deny'; reason?: string };
 
 export interface RetryRequestOptions {
   /** Name of the operation that failed (e.g. "Model invocation"). */

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -276,4 +276,41 @@ describe('RetryState', () => {
       }
     },
   );
+
+  it('classifies a policy/headless retry denial as failed, not cancelled (#7331)', async () => {
+    const streamId = 'retry-state-deny' as StreamTabId;
+    const { node, streamStatus, waitForRetry } = createRetryNode(streamId);
+
+    waitForRetry.mockResolvedValueOnce({
+      action: 'deny',
+      reason: 'Denied by CLI approval policy.',
+    });
+    const error = new Error('stream dropped before first token');
+
+    try {
+      seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.RUNNING);
+
+      const shouldRetry = await withRetryRunContext(
+        streamId,
+        waitForRetry,
+        () => node.retryPrompt(undefined, error),
+      );
+
+      // A denial does not retry and — crucially — is NOT a user cancel, so the
+      // stream resumes to RUNNING to let the failure terminalize (a WAITING
+      // stream can't be written to a terminal outcome directly).
+      expect(shouldRetry).toBe(false);
+      expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.RUNNING);
+
+      // The fallback classifies this as `failed` (→ RUN_OUTCOME.FAILED),
+      // surfacing the underlying error — rather than `cancelled`, which would
+      // let a zero-output run report COMPLETED.
+      expect(node.fallbackFor(error)).toMatchObject({
+        kind: 'failed',
+        message: 'stream dropped before first token',
+      });
+    } finally {
+      clearStreamStatusForTest(streamStatus, streamId);
+    }
+  });
 });

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.mts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.mts
@@ -26,7 +26,12 @@ import {
 } from '@cli/runtime/approvalAdapter';
 import type { CliContext } from '@cli/runtime/cliContext';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
-import { AgentCategory, DEFAULT_TOOL_CONFIG } from '@shared/schemas';
+import {
+  AgentCategory,
+  DEFAULT_TOOL_CONFIG,
+  type StreamTabId,
+} from '@shared/schemas';
+import type { HostRetryRequest } from '@agent/runtime/HostInteractions';
 import { requestToolEditApproval } from '@tools/approval/toolEditApproval';
 
 function context(overrides: Partial<CliContext> = {}): CliContext {
@@ -236,6 +241,35 @@ describe('approval prompt hooks', () => {
       threadId: 'ei_aabbccdd0011',
       feedback: expect.stringContaining('non-TUI CLI runs'),
     });
+  });
+});
+
+describe('requestRetry classification (#7331)', () => {
+  const retryRequest: HostRetryRequest = {
+    streamId: 'root@deepseekT#abc' as StreamTabId,
+    operation: 'Model invocation',
+    errorMessage: 'stream dropped before first token',
+  };
+
+  it('denies (not cancels) a retry when no human input is available', async () => {
+    const result = await createHeadlessCliHostInteractions(
+      context({ approvalPolicy: 'never', mode: 'headless' }),
+    ).requestRetry?.(retryRequest);
+
+    // A policy/headless auto-denial is a distinct failure, not a user cancel,
+    // so a zero-output run reports FAILED rather than COMPLETED.
+    expect(result).toEqual({
+      action: 'deny',
+      reason: 'Denied by CLI approval policy.',
+    });
+  });
+
+  it('cancels a retry the interactive user explicitly rejects', async () => {
+    const result = await createHeadlessCliHostInteractions(
+      context({ approvalPrompt: async () => 'n not now' }),
+    ).requestRetry?.(retryRequest);
+
+    expect(result).toEqual({ action: 'cancel' });
   });
 });
 


### PR DESCRIPTION
Closes #7331

## Root cause

Follow-up from #7022. When the relay's 390s upstream timeout fires on a slow-to-first-token request under headless `texra run --print --output-format ndjson --approval-policy never --no-input`, the model invocation is retried; if every retry also yields zero output, the run terminated with `outcome: "completed"` and exit code 0 — a silent failure headless callers couldn't distinguish from a genuine empty-but-successful response.

The defect is a misclassification several layers upstream of the reporting code, exactly as diagnosed in the issue:

1. `packages/cli/src/runtime/approvalAdapter.ts` `toRetryResult` collapsed **every** non-accepted retry decision to `{ action: 'cancel' }` — no distinction between a real user cancel and a policy auto-denial when no human is available.
2. `src/agent/core/flows/RetryState.ts` `handleManualRetryPrompt` mapped any non-`retry` result to `userCancelled: true`.
3. `getFallbackResult` checked `_userCancelled` first and returned `{ kind: 'cancelled' }`, never reaching the `{ kind: 'failed', ... }` branch.
4. The `cancelled` classification leaves `shared.lastError` unset, so `deriveRunOutcome({ failed: false, cancelled: false })` in the round loop resolves to `RUN_OUTCOME.COMPLETED`.

## Fix

Add a distinct `{ action: 'deny'; reason? }` variant to `RetryResult`, separate from a user `cancel`:

- The headless CLI adapter emits `deny` when `approvalPromptAllowed(context)` is false (policy/headless auto-denial, no human available); interactive user rejections still map to `cancel`.
- `RetryState` handles `deny` by resuming the stream to RUNNING (a WAITING stream can't terminalize directly) and returning `userCancelled: false`, so the exhausted retry routes into the existing `failed` fallback. `handleInvocationResult` then sets `shared.lastError`, `deriveRunOutcome` returns `RUN_OUTCOME.FAILED`, and the run lifecycle surfaces the underlying stream-drop/timeout error in the terminal `result` record.

Scoped to the "no output produced because no human could approve a retry" case — runs that legitimately produce output (short or empty) never hit the retry prompt, and interactive/other-host retry denials are unchanged (they don't produce `deny`).

## Net diff (`git diff --stat origin/main`)

```
 packages/cli/src/runtime/approvalAdapter.ts        | 20 ++++++++---
 src/agent/core/flows/RetryState.ts                 | 19 +++++++++++
 src/agent/runtime/RetryRequestCoordinator.ts       |  7 +++-
 src/test-kernel/agent/runtime/RetryState.vitest.ts | 35 +++++++++++++++++++
 src/test-kernel/cli/ApprovalAdapter.vitest.mts     | 40 +++++++++++++++++++++-
 5 files changed, 113 insertions(+), 8 deletions(-)
```

## Tests

- `RetryState.vitest.ts`: new case asserts a policy/headless retry denial resumes to RUNNING and classifies the fallback as `{ kind: 'failed' }` (not `cancelled`) with the underlying error message.
- `ApprovalAdapter.vitest.mts`: new cases assert `requestRetry` returns `{ action: 'deny' }` in headless/never mode and `{ action: 'cancel' }` for an interactive user rejection.

Gates: `tsc --noEmit` (root + test-kernel + CLI) clean; both vitest suites pass (33 tests).

https://claude.ai/code/session_01PkkPA9A5vht7PmB9xxiqU3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how headless CLI runs classify terminal outcomes when retries are policy-denied; scoped and covered by tests but affects run lifecycle reporting that callers rely on.
> 
> **Overview**
> Fixes **#7331**: headless runs that exhaust retries with **no output** were ending as **completed** (exit 0) because policy-blocked retries were treated like **user cancels**.
> 
> Introduces a **`deny`** `RetryResult` for policy/headless auto-denial when no human can approve a retry (`--approval-policy never --no-input`). The CLI **`toRetryResult`** maps non-accepted retries to **`deny`** when `approvalPromptAllowed` is false, and **`cancel`** when the user rejects interactively.
> 
> **`RetryState.handleManualRetryPrompt`** handles **`deny`** by resuming the stream to **RUNNING** (without setting `userCancelled`), so retry exhaustion uses the existing **`failed`** fallback and **`RUN_OUTCOME.FAILED`** with the underlying error instead of **`cancelled`** → completed.
> 
> Tests cover CLI **`requestRetry`** classification and **`RetryState`** fallback behavior for **`deny`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d183d3a943810f77be68c656fb4ae8c7470c1ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->