### PR TITLE
fix(ci): trim catalog-derived contributes in verify-vsix-contents to match shrunk snapshot

### DIFF
--- a/scripts/extension-package-utils.mjs
+++ b/scripts/extension-package-utils.mjs
@@ -66,3 +66,25 @@ export function extensionManifestSnapshot(packageJson, manifestKeys) {
     manifestKeys.map((key) => [key, stable(packageJson[key])]),
   );
 }
+
+// Catalog-derived `contributes` subtrees. These are code-generated from the
+// settings/command catalogs by scripts/sync-package-contributes.mjs and
+// diff-checked by the catalog vitest suites, so snapshotting them would just
+// duplicate that guard with ~35 KB of committed generated JSON. They are
+// omitted from the manifest snapshot (verify-extension-package-invariants.mjs)
+// and from the built-VSIX manifest comparison (verify-vsix-contents.mjs); the
+// remaining non-catalog contributes (menus, views, walkthroughs, …) and
+// manifest keys stay guarded.
+const CATALOG_DERIVED_CONTRIBUTES = [
+  'configuration',
+  'commands',
+  'keybindings',
+];
+
+export function withoutCatalogDerivedContributes(packageJson) {
+  const { contributes } = packageJson;
+  if (!contributes || typeof contributes !== 'object') return packageJson;
+  const trimmedContributes = { ...contributes };
+  for (const key of CATALOG_DERIVED_CONTRIBUTES) delete trimmedContributes[key];
+  return { ...packageJson, contributes: trimmedContributes };
+}

--- a/scripts/extension-package-utils.mjs
+++ b/scripts/extension-package-utils.mjs
@@ -75,7 +75,7 @@ export function extensionManifestSnapshot(packageJson, manifestKeys) {
 // and from the built-VSIX manifest comparison (verify-vsix-contents.mjs); the
 // remaining non-catalog contributes (menus, views, walkthroughs, …) and
 // manifest keys stay guarded.
-const CATALOG_DERIVED_CONTRIBUTES = [
+export const CATALOG_DERIVED_CONTRIBUTES = [
   'configuration',
   'commands',
   'keybindings',

--- a/scripts/verify-extension-package-invariants.mjs
+++ b/scripts/verify-extension-package-invariants.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 import {
   extensionManifestSnapshot,
   readJson,
+  withoutCatalogDerivedContributes,
 } from './extension-package-utils.mjs';
 
 const rootDir = path.resolve(
@@ -59,18 +60,6 @@ const REQUIRED_PACKAGED_PATHS = [
 // in the source tree, but verify-vsix-contents.mjs still checks the built
 // VSIX includes them.
 const BUILD_TIME_PACKAGED_PATHS = new Set(['readme.md', 'changelog.md']);
-
-// Catalog-derived `contributes` subtrees. These are code-generated from the
-// settings/command catalogs by scripts/sync-package-contributes.mjs and
-// diff-checked by the catalog vitest suites, so snapshotting them here would
-// just duplicate that guard with ~35 KB of committed generated JSON. They are
-// omitted from the manifest snapshot; the remaining non-catalog contributes
-// (menus, views, walkthroughs, …) and manifest keys stay guarded.
-const CATALOG_DERIVED_CONTRIBUTES = [
-  'configuration',
-  'commands',
-  'keybindings',
-];
 
 const REQUIRED_VSCODEIGNORE_LINES = [
   'src/**',
@@ -142,14 +131,6 @@ function hasFiles(relativeDir) {
     if (entry.isDirectory() && hasFiles(child)) return true;
   }
   return false;
-}
-
-function withoutCatalogDerivedContributes(packageJson) {
-  const { contributes } = packageJson;
-  if (!contributes || typeof contributes !== 'object') return packageJson;
-  const trimmedContributes = { ...contributes };
-  for (const key of CATALOG_DERIVED_CONTRIBUTES) delete trimmedContributes[key];
-  return { ...packageJson, contributes: trimmedContributes };
 }
 
 function buildSnapshot() {

--- a/scripts/verify-vsix-contents.mjs
+++ b/scripts/verify-vsix-contents.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'node:url';
 import {
   extensionManifestSnapshot,
   readJson,
+  withoutCatalogDerivedContributes,
 } from './extension-package-utils.mjs';
 
 const rootDir = path.resolve(
@@ -71,8 +72,12 @@ function assertEntryExists(entries, entryPath, failures) {
 function verifyManifest(vsixPath, snapshot, failures) {
   const manifestBytes = readVsixEntry(vsixPath, 'extension/package.json');
   const manifest = JSON.parse(manifestBytes.toString('utf8'));
+  // The built VSIX ships the full contributes (catalog-derived subtrees
+  // included); the committed snapshot omits them, so trim the same subtrees
+  // here before comparing. This only affects the comparison, not the shipped
+  // package.json.
   const manifestSnapshot = extensionManifestSnapshot(
-    manifest,
+    withoutCatalogDerivedContributes(manifest),
     Object.keys(snapshot.manifest),
   );
 

--- a/scripts/verify-vsix-contents.mjs
+++ b/scripts/verify-vsix-contents.mjs
@@ -6,6 +6,7 @@ import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
 import {
+  CATALOG_DERIVED_CONTRIBUTES,
   extensionManifestSnapshot,
   readJson,
   withoutCatalogDerivedContributes,
@@ -69,9 +70,32 @@ function assertEntryExists(entries, entryPath, failures) {
   assert(entries.has(entryPath), `VSIX is missing ${entryPath}`, failures);
 }
 
+function assertCatalogContributesShipped(manifest, failures) {
+  // Release guard: withoutCatalogDerivedContributes() below deletes these
+  // catalog-derived subtrees before the snapshot comparison, so a build that
+  // shipped them missing or empty would still pass the comparison. release.yml's
+  // publish job runs only this script (not the catalog vitests), so assert the
+  // shipped subtrees are present and non-empty here before trimming them.
+  const contributes = manifest.contributes;
+  for (const key of CATALOG_DERIVED_CONTRIBUTES) {
+    const value = contributes?.[key];
+    const nonEmpty = Array.isArray(value)
+      ? value.length > 0
+      : Boolean(value) &&
+        typeof value === 'object' &&
+        Object.keys(value).length > 0;
+    assert(
+      nonEmpty,
+      `VSIX extension/package.json is missing a non-empty contributes.${key}; the release would ship without it.`,
+      failures,
+    );
+  }
+}
+
 function verifyManifest(vsixPath, snapshot, failures) {
   const manifestBytes = readVsixEntry(vsixPath, 'extension/package.json');
   const manifest = JSON.parse(manifestBytes.toString('utf8'));
+  assertCatalogContributesShipped(manifest, failures);
   // The built VSIX ships the full contributes (catalog-derived subtrees
   // included); the committed snapshot omits them, so trim the same subtrees
   // here before comparing. This only affects the comparison, not the shipped


### PR DESCRIPTION
Closes #7342

## Root cause

Follow-up to #7338, which code-generated `contributes.configuration/commands/keybindings` from the settings/command catalogs and dropped those three subtrees from the committed `scripts/extension-package-invariants.snapshot.json` (70,509 → ~30,323 bytes) via `withoutCatalogDerivedContributes()` in `verify-extension-package-invariants.mjs`.

`scripts/verify-vsix-contents.mjs` was not updated to match. Its `verifyManifest()` still compared the **full** manifest read back out of the built VSIX's `extension/package.json` (which legitimately still contains all three catalog-derived subtrees — they are real, required VS Code contributions) against `snapshot.manifest`, which no longer has them. The two can never match again, so `check:vsix-contents` fails unconditionally. That check runs in both `.github/workflows/ci.yml` and `.github/workflows/release.yml`, so it breaks CI and the release pipeline — a P0.

## Fix

Exactly the issue's "Fix direction", scope-limited:

- Moved `CATALOG_DERIVED_CONTRIBUTES` and `withoutCatalogDerivedContributes()` from `verify-extension-package-invariants.mjs` into the already-shared `scripts/extension-package-utils.mjs`. Both scripts now import the one owner — no byte-duplicated copy (code-review §13 single-owner rule). The constant stays module-local (nothing imports it); only the function is exported.
- In `verify-vsix-contents.mjs` `verifyManifest()`, applied `withoutCatalogDerivedContributes()` to the VSIX-extracted `manifest` before building `extensionManifestSnapshot(...)`, so both sides omit the same three subtrees.
- The shipped `package.json` is untouched — those contributions stay in the built VSIX; only the snapshot **comparison** is trimmed.

## Net diff (`git diff --stat origin/main`)

```
 scripts/extension-package-utils.mjs             | 22 ++++++++++++++++++++++
 scripts/verify-extension-package-invariants.mjs | 21 +--------------------
 scripts/verify-vsix-contents.mjs                |  7 ++++++-
 3 files changed, 29 insertions(+), 21 deletions(-)
```

## What I ran

- `node scripts/verify-extension-package-invariants.mjs` → "Extension package invariants are in sync" (exit 0), zero snapshot diff after the helper move.
- Exercised `verifyManifest()`'s exact logic against the real source `packages/extension/package.json` (the source that gets packaged into the VSIX's `extension/package.json`, which retains full `contributes`): the **trimmed** comparison matches `snapshot.manifest` (true), while the **old untrimmed** comparison does not (false) — reproducing the bug and confirming the fix.
- `prettier --write` on all three scripts → unchanged (already formatted). `scripts/` is outside the `npm run lint` scope (`src`, `packages/*/src` only), so the repo lint gate does not cover these files.

## Not run

- Full `check:vsix-contents` against a real built VSIX — no VSIX artifact is present and building one (`npm run build:fast`) would churn against the many concurrent agents in this shared checkout. The equivalence proof above uses the same source `package.json` that vsce copies into the VSIX, so it faithfully exercises the `verifyManifest` code path; final confirmation should come from CI's `check:vsix-contents` step on this PR.

https://claude.ai/code/session_01PkkPA9A5vht7PmB9xxiqU3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/release verification script changes only; no runtime extension behavior or packaged manifest content is altered beyond stricter release guards.
> 
> **Overview**
> Fixes **unconditional `check:vsix-contents` failures** after the extension invariant snapshot stopped including catalog-generated `contributes.configuration`, `commands`, and `keybindings`.
> 
> **`CATALOG_DERIVED_CONTRIBUTES`** and **`withoutCatalogDerivedContributes()`** move into **`extension-package-utils.mjs`** so both verify scripts share one definition. **`verify-vsix-contents.mjs`** trims the VSIX `package.json` the same way before comparing to the committed snapshot; the built VSIX still ships full contributes.
> 
> Adds **`assertCatalogContributesShipped`** so release runs that only execute this script still fail if those three subtrees are missing or empty—since trimming would otherwise hide that regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1049b6cd8fbf59d09c57d2a2e4fee0badf9f616f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->