### PR TITLE
refactor: extract app signals from progress bus

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -666,8 +666,7 @@ function createWindow(options: {
     refreshToolAvailability: async () => {
       const { refreshToolAvailability } =
         await import('@tools/toolAvailability');
-      const execution = await getAgentExecution();
-      await refreshToolAvailability(execution.progress.runtimeHost);
+      await refreshToolAvailability();
     },
     runInstallCommand: async (command) => {
       await runSetupCommand(command);

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -45,6 +45,7 @@ import { createSampleProjectWithoutWorkspace } from '@commands/system/sampleProj
 import { openGettingStarted } from '@commands/system/walkthroughCommands';
 import { SIDEBAR_VIEWS, setActiveSidebarView } from '@common/webview';
 import { globalSM, initializeStateManagers, workspaceSM } from '@common/state';
+import { appSignals } from '@eventBus/AppSignals';
 import { bus } from '@eventBus/ProgressEventBus';
 import { SecretManager } from '@frontend/secretManager';
 import {
@@ -619,26 +620,24 @@ export async function activate(context: vscode.ExtensionContext) {
       if (e.key !== SecretManager.GITHUB_TOKEN_KEY) return;
       // Re-probe so any subscribed UI (Tools tab) reflects the new token
       // presence; getGitHubToken() now reads SecretStorage live (no cache).
-      void refreshToolAvailability(extensionAgentRuntimeHost).catch(
-        logRefreshFailure('secret change'),
-      );
+      void refreshToolAvailability().catch(logRefreshFailure('secret change'));
     }),
     // Lean/LaTeX extension installed or removed → re-probe so the Tools tab
     // reflects the new state without the user clicking Re-check.
     vscode.extensions.onDidChange(() => {
-      void refreshToolAvailability(extensionAgentRuntimeHost).catch(
+      void refreshToolAvailability().catch(
         logRefreshFailure('extension change'),
       );
     }),
     // Workspace folders opened/closed can flip `isGitRepository`, which
     // gates the GitHub PR subscription tool group.
     vscode.workspace.onDidChangeWorkspaceFolders(() => {
-      void refreshToolAvailability(extensionAgentRuntimeHost).catch(
+      void refreshToolAvailability().catch(
         logRefreshFailure('workspace folder change'),
       );
     }),
   );
-  const disposeGitHubAuthListener = bus.on(
+  const disposeGitHubAuthListener = appSignals.on(
     'githubTokenInvalid',
     ({ message }) => {
       logger.error('extension', `GitHub token rejected: ${message}`);

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -30,13 +30,12 @@ import { AUTH_COMMANDS } from '@auth/constants';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { BaseViewMessageHandler } from '@common/webview';
 import { WorkspaceStateKey, globalSM, workspaceSM } from '@common/state';
-import { bus } from '@eventBus/ProgressEventBus';
+import { appSignals } from '@eventBus/AppSignals';
 import { SecretManager, type ApiProvider } from '@frontend/secretManager';
 import {
   showLoggedErrorMessage,
   showLoggedInfoMessage,
 } from '@frontend/ui/errorHandlingUtils';
-import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { selectAgentInMainView } from '@frontend/agents/remoteAgentUtils';
 import {
   applyGitAuthorConfig,
@@ -209,18 +208,18 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
     this.handlerRegistry = this.createHandlerRegistry();
 
-    // Lifetime == extension; bus is process-global so no dispose needed.
+    // Lifetime == extension; appSignals is process-global so no dispose needed.
     const refreshSubscriptions = () =>
       void this.withActiveWebview((w) =>
         this.githubHandlers.sendPRSubscriptions(w),
       );
-    bus.on('prSubscriptionsChanged', refreshSubscriptions);
-    bus.on('prSubscriptionBindingsChanged', refreshSubscriptions);
-    bus.on('repoSubscriptionsChanged', refreshSubscriptions);
-    bus.on('repoSubscriptionBindingsChanged', refreshSubscriptions);
-    bus.on('issueSubscriptionsChanged', refreshSubscriptions);
-    bus.on('issueSubscriptionBindingsChanged', refreshSubscriptions);
-    bus.on('toolAvailabilityChanged', () => {
+    appSignals.on('prSubscriptionsChanged', refreshSubscriptions);
+    appSignals.on('prSubscriptionBindingsChanged', refreshSubscriptions);
+    appSignals.on('repoSubscriptionsChanged', refreshSubscriptions);
+    appSignals.on('repoSubscriptionBindingsChanged', refreshSubscriptions);
+    appSignals.on('issueSubscriptionsChanged', refreshSubscriptions);
+    appSignals.on('issueSubscriptionBindingsChanged', refreshSubscriptions);
+    appSignals.on('toolAvailabilityChanged', () => {
       void this.withActiveWebview((w) =>
         this.sendToolDashboardData(w, { skipChecks: true }),
       );
@@ -462,8 +461,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         openToolInstallUrl: (data) => this.openExternalUrl(data.url),
         installToolExtension: (data) =>
           this.latexHandlers.installExtension(data.extensionId),
-        recheckToolStatus: () =>
-          refreshToolAvailability(extensionAgentRuntimeHost),
+        recheckToolStatus: () => refreshToolAvailability(),
         toggleTool: async (data) => {
           await setToolEnabled(data.toolId, data.enabled);
           refreshDisabledToolCache();

--- a/scripts/verify-vsix-contents.mjs
+++ b/scripts/verify-vsix-contents.mjs
@@ -21,6 +21,12 @@ const snapshotPath = path.join(
   'extension-package-invariants.snapshot.json',
 );
 
+const CATALOG_DERIVED_CONTRIBUTES = [
+  'configuration',
+  'commands',
+  'keybindings',
+];
+
 function defaultVsixPath() {
   const packageJson = readJson(path.join(extensionDir, 'package.json'));
   return path.join(rootDir, 'releases', `texra-${packageJson.version}.vsix`);
@@ -72,7 +78,7 @@ function verifyManifest(vsixPath, snapshot, failures) {
   const manifestBytes = readVsixEntry(vsixPath, 'extension/package.json');
   const manifest = JSON.parse(manifestBytes.toString('utf8'));
   const manifestSnapshot = extensionManifestSnapshot(
-    manifest,
+    withoutCatalogDerivedContributes(manifest),
     Object.keys(snapshot.manifest),
   );
 
@@ -83,6 +89,14 @@ function verifyManifest(vsixPath, snapshot, failures) {
     'VSIX extension/package.json no longer matches the extension manifest snapshot.',
     failures,
   );
+}
+
+function withoutCatalogDerivedContributes(packageJson) {
+  const { contributes } = packageJson;
+  if (!contributes || typeof contributes !== 'object') return packageJson;
+  const trimmedContributes = { ...contributes };
+  for (const key of CATALOG_DERIVED_CONTRIBUTES) delete trimmedContributes[key];
+  return { ...packageJson, contributes: trimmedContributes };
 }
 
 function verifyRequiredPaths(entries, snapshot, failures) {

--- a/src/agent/runtime/AgentRuntimeHost.ts
+++ b/src/agent/runtime/AgentRuntimeHost.ts
@@ -20,8 +20,7 @@ import type { HostInteractions } from './HostInteractions';
  * - **Frontend-bound, ignorable** (the `── Frontend-bound events ──` group in
  *   {@link ProgressEventPayloads}: `requestOpenFile`, `requestShowInstruction`,
  *   `showAgentConfigBanner`, `requestShowError`, `requestEnsureProgressView`,
- *   plus the `*SubscriptionsChanged` / `toolAvailabilityChanged` UI-refresh
- *   signals): pure host-UI requests with no effect on the agent loop.
+ *   pure host-UI requests with no effect on the agent loop.
  *
  * {@link noopAgentRuntimeHost} (drop everything) is a valid host — it is used
  * by tests and non-interactive paths.

--- a/src/eventBus/AppSignals.ts
+++ b/src/eventBus/AppSignals.ts
@@ -1,0 +1,65 @@
+import { EventEmitter } from 'node:events';
+
+export interface AppSignalPayloads {
+  /**
+   * GitHub rejected the configured token. Frontends can surface the failure
+   * and direct the user to token settings.
+   */
+  githubTokenInvalid: { message: string };
+
+  /** Active PR-activity subscription keys changed. */
+  prSubscriptionsChanged: { keys: readonly string[] };
+  /** Active PR-activity owners changed. */
+  prSubscriptionBindingsChanged: undefined;
+  /** Active repo-activity subscription keys changed. */
+  repoSubscriptionsChanged: { keys: readonly string[] };
+  /** Active repo-activity owners changed. */
+  repoSubscriptionBindingsChanged: undefined;
+  /** Active issue-activity subscription keys changed. */
+  issueSubscriptionsChanged: { keys: readonly string[] };
+  /** Active issue-activity owners changed. */
+  issueSubscriptionBindingsChanged: undefined;
+
+  /**
+   * External tool availability was re-probed. Frontends refresh their
+   * dashboards from the updated cache.
+   */
+  toolAvailabilityChanged: undefined;
+}
+
+export type AppSignal = keyof AppSignalPayloads;
+
+export interface AppSignalsLike {
+  on<K extends AppSignal>(
+    event: K,
+    listener: (payload: AppSignalPayloads[K]) => void,
+    options?: { signal?: AbortSignal },
+  ): () => void;
+
+  emit<K extends AppSignal>(event: K, payload: AppSignalPayloads[K]): void;
+}
+
+class AppSignals implements AppSignalsLike {
+  private readonly emitter = new EventEmitter();
+
+  on<K extends AppSignal>(
+    event: K,
+    listener: (payload: AppSignalPayloads[K]) => void,
+    options?: { signal?: AbortSignal },
+  ): () => void {
+    if (options?.signal?.aborted) return () => {};
+
+    this.emitter.on(event, listener);
+    const cleanup = (): void => {
+      this.emitter.off(event, listener);
+    };
+    options?.signal?.addEventListener('abort', cleanup, { once: true });
+    return cleanup;
+  }
+
+  emit<K extends AppSignal>(event: K, payload: AppSignalPayloads[K]): void {
+    this.emitter.emit(event, payload);
+  }
+}
+
+export const appSignals = new AppSignals();

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -219,32 +219,6 @@ export interface ProgressEventPayloads {
   extensionDeactivating: undefined;
 
   /**
-   * Emitted when PR-activity polling is rejected by GitHub (401/403 auth).
-   * The frontend shows a toast prompting the user to replace the token.
-   */
-  githubTokenInvalid: { message: string };
-
-  /** Active PR-activity subscription keys changed; frontends refresh their list. */
-  prSubscriptionsChanged: { keys: readonly string[] };
-  /** Active PR-activity owners changed; frontends refresh owner metadata. */
-  prSubscriptionBindingsChanged: undefined;
-  /** Active repo-activity subscription keys changed. */
-  repoSubscriptionsChanged: { keys: readonly string[] };
-  /** Active repo-activity owners changed. */
-  repoSubscriptionBindingsChanged: undefined;
-  /** Active issue-activity subscription keys changed. */
-  issueSubscriptionsChanged: { keys: readonly string[] };
-  /** Active issue-activity owners changed. */
-  issueSubscriptionBindingsChanged: undefined;
-
-  /**
-   * External tool availability was re-probed. Frontends (Tools tab) refresh
-   * their dashboard from the updated cache. Emitted by
-   * {@link refreshToolAvailability}.
-   */
-  toolAvailabilityChanged: undefined;
-
-  /**
    * One or more files were written directly to the workspace (e.g. via
    * accept_run_files). Listened by fileDecorations to badge the files.
    */

--- a/src/test-kernel/agent/followUp/GitHubSubscriptionProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/GitHubSubscriptionProgressEvents.vitest.ts
@@ -14,14 +14,14 @@ import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
 
+// Local imports - event bus
+import { appSignals, type AppSignalPayloads } from '@eventBus/AppSignals';
+
 // Local imports - shared schemas
 import type { StreamTabId } from '@shared/schemas';
 
 // Local imports - tools
-import {
-  emitGitHubSubscriptionChanged,
-  emitGitHubSubscriptionChangedToHosts,
-} from '@tools/github/subscriptionEventEmitter';
+import { emitGitHubSubscriptionChanged } from '@tools/github/subscriptionEventEmitter';
 import { GitHubAuthError } from '@tools/github/githubClient';
 import {
   PollingSourceBase,
@@ -31,6 +31,19 @@ import { StreamSubscriptionRegistry } from '@tools/github/StreamSubscriptionRegi
 
 // Local imports - test
 import { createRecordingHost } from '../progressTestUtils';
+
+function recordAppSignal<K extends keyof AppSignalPayloads>(
+  event: K,
+): {
+  readonly events: { event: K; payload: AppSignalPayloads[K] }[];
+  readonly dispose: () => void;
+} {
+  const events: { event: K; payload: AppSignalPayloads[K] }[] = [];
+  const dispose = appSignals.on(event, (payload) => {
+    events.push({ event, payload });
+  });
+  return { events, dispose };
+}
 
 class TestPollingSource extends PollingSourceBase<
   string,
@@ -116,57 +129,68 @@ class RegistryTestSource {
   }
 }
 
-describe('GitHub subscription progress events', () => {
+describe('GitHub subscription app signals and follow-ups', () => {
   beforeEach(() => {
     sendFollowUpMock.mockReset();
     sendFollowUpMock.mockResolvedValue({ status: 'sent' as const });
   });
 
-  it('publishes binding changes through the explicit runtime host', () => {
-    const host = createRecordingHost();
+  it('publishes binding changes through app signals', () => {
+    const signal = recordAppSignal('repoSubscriptionBindingsChanged');
 
-    emitGitHubSubscriptionChanged(
-      host.host,
-      'repoSubscriptionBindingsChanged',
-      undefined,
-    );
+    try {
+      emitGitHubSubscriptionChanged(
+        'repoSubscriptionBindingsChanged',
+        undefined,
+      );
 
-    expect(host.events).toEqual([
-      { event: 'repoSubscriptionBindingsChanged', payload: undefined },
-    ]);
+      expect(signal.events).toEqual([
+        { event: 'repoSubscriptionBindingsChanged', payload: undefined },
+      ]);
+    } finally {
+      signal.dispose();
+    }
   });
 
-  it('deduplicates multiple bindings that share a runtime host', () => {
-    const host = createRecordingHost();
+  it('publishes issue binding changes without a runtime host', () => {
+    const signal = recordAppSignal('issueSubscriptionBindingsChanged');
 
-    emitGitHubSubscriptionChangedToHosts(
-      [host.host, host.host],
-      'issueSubscriptionBindingsChanged',
-      undefined,
-    );
+    try {
+      emitGitHubSubscriptionChanged(
+        'issueSubscriptionBindingsChanged',
+        undefined,
+      );
 
-    expect(host.events).toEqual([
-      { event: 'issueSubscriptionBindingsChanged', payload: undefined },
-    ]);
+      expect(signal.events).toEqual([
+        { event: 'issueSubscriptionBindingsChanged', payload: undefined },
+      ]);
+    } finally {
+      signal.dispose();
+    }
   });
 
-  it('reports token invalid events through the subscription runtime host', () => {
+  it('reports token invalid events through app signals', () => {
     const host = createRecordingHost();
+    const signal = recordAppSignal('githubTokenInvalid');
     const listener = () => {};
     const state: BasePollSubscriptionState = {
       listeners: new Set([listener]),
-      runtimeHostByListener: new Map([[listener, host.host]]),
       lastSuccessAt: Date.now(),
       consecutiveFailures: 0,
       skipPollUntilMs: 0,
     };
 
-    new TestPollingSource().failWithAuthError(state);
+    try {
+      new TestPollingSource().failWithAuthError(state);
 
-    expect(host.events).toContainEqual({
-      event: 'githubTokenInvalid',
-      payload: { message: 'bad token' },
-    });
+      expect(signal.events).toContainEqual({
+        event: 'githubTokenInvalid',
+        payload: { message: 'bad token' },
+      });
+      expect(host.events).toEqual([]);
+    } finally {
+      signal.dispose();
+    }
   });
 
   it('tracks transient backoff independently per subscription', () => {
@@ -175,7 +199,6 @@ describe('GitHub subscription progress events', () => {
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5);
     const createState = (): BasePollSubscriptionState => ({
       listeners: new Set(),
-      runtimeHostByListener: new Map(),
       lastSuccessAt: now,
       consecutiveFailures: 0,
       skipPollUntilMs: 0,
@@ -199,6 +222,7 @@ describe('GitHub subscription progress events', () => {
 
   it('emits one binding change when unsubscribe disposes synchronously', () => {
     const host = createRecordingHost();
+    const signal = recordAppSignal('repoSubscriptionBindingsChanged');
     const source = new RegistryTestSource();
     const registry = new StreamSubscriptionRegistry<string, string>({
       name: 'test subscriptions',
@@ -207,16 +231,21 @@ describe('GitHub subscription progress events', () => {
       bindingsChangedEvent: 'repoSubscriptionBindingsChanged',
     });
 
-    registry.bind('stream-a' as StreamTabId, 'owner/repo', host.host);
-    host.events.length = 0;
+    try {
+      registry.bind('stream-a' as StreamTabId, 'owner/repo', host.host);
+      host.events.length = 0;
 
-    expect(
-      registry.unbind('stream-a' as StreamTabId, 'owner/repo', host.host),
-    ).toBe(true);
+      expect(
+        registry.unbind('stream-a' as StreamTabId, 'owner/repo', host.host),
+      ).toBe(true);
 
-    expect(host.events).toEqual([
-      { event: 'repoSubscriptionBindingsChanged', payload: undefined },
-    ]);
+      expect(signal.events).toEqual([
+        { event: 'repoSubscriptionBindingsChanged', payload: undefined },
+      ]);
+      expect(host.events).toEqual([]);
+    } finally {
+      signal.dispose();
+    }
   });
 
   it('passes the bind-time session to detached subscription follow-ups', () => {

--- a/src/test-kernel/tools/ToolAvailabilityAppSignals.vitest.ts
+++ b/src/test-kernel/tools/ToolAvailabilityAppSignals.vitest.ts
@@ -1,0 +1,37 @@
+// Third-party imports
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+afterEach(() => {
+  vi.doUnmock('@tools/externalToolDefs');
+  vi.resetModules();
+});
+
+describe('tool availability app signals', () => {
+  it('emits toolAvailabilityChanged after a refresh', async () => {
+    vi.doMock('@tools/externalToolDefs', () => ({
+      EXTERNAL_TOOL_DEFS: [
+        {
+          id: 'test-tool',
+          tools: [],
+          name: 'Test tool',
+          category: 'ai-agents',
+          check: vi.fn(async () => true),
+        },
+      ],
+    }));
+    const { appSignals } = await import('@eventBus/AppSignals');
+    const { refreshToolAvailability } = await import('@tools/toolAvailability');
+    const events: undefined[] = [];
+    const dispose = appSignals.on('toolAvailabilityChanged', (payload) => {
+      events.push(payload);
+    });
+
+    try {
+      await refreshToolAvailability();
+
+      expect(events).toEqual([undefined]);
+    } finally {
+      dispose();
+    }
+  });
+});

--- a/src/tools/github/IssuePollingSource.ts
+++ b/src/tools/github/IssuePollingSource.ts
@@ -31,7 +31,7 @@ import {
   PollingSourceBase,
   type BasePollSubscriptionState,
 } from './PollingSourceBase';
-import { emitGitHubSubscriptionChangedToHosts } from './subscriptionEventEmitter';
+import { emitGitHubSubscriptionChanged } from './subscriptionEventEmitter';
 import {
   GhIssueCommentArraySchema,
   GhIssueSchema,
@@ -68,7 +68,6 @@ function createInitialState(issue: IssueKey): SubscriptionState {
     issue,
     slug: `${issue.owner}/${issue.repo}`,
     listeners: new Set(),
-    runtimeHostByListener: new Map(),
     initialized: false,
     state: undefined,
     comments: new DedupedResource<GhIssueComment>({
@@ -107,15 +106,8 @@ class IssuePollingSource extends PollingSourceBase<string, SubscriptionState> {
     );
   }
 
-  protected emitKeysChangedEvent(
-    keys: readonly string[],
-    runtimeHosts: readonly AgentRuntimeHost[],
-  ): void {
-    emitGitHubSubscriptionChangedToHosts(
-      runtimeHosts,
-      'issueSubscriptionsChanged',
-      { keys },
-    );
+  protected emitKeysChangedEvent(keys: readonly string[]): void {
+    emitGitHubSubscriptionChanged('issueSubscriptionsChanged', { keys });
   }
 
   protected formatErrorEvent(

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -77,7 +77,7 @@ import {
   type GhReview,
   type GhReviewComment,
 } from './prTypes';
-import { emitGitHubSubscriptionChangedToHosts } from './subscriptionEventEmitter';
+import { emitGitHubSubscriptionChanged } from './subscriptionEventEmitter';
 import type { Disposable } from '@platform/interfaces/disposable';
 
 export const GITHUB_PR_POLLING_EMIT_CI_STARTED_CONFIG_KEY =
@@ -95,7 +95,6 @@ function createInitialState(pr: PRKey): SubscriptionState {
     pr,
     slug: `${pr.owner}/${pr.repo}`,
     listeners: new Set(),
-    runtimeHostByListener: new Map(),
     initialized: false,
     issueComments: new DedupedResource<GhIssueComment>({
       getId: (comment: GhIssueComment) => comment.id,
@@ -272,10 +271,9 @@ export class PRPollingSource extends PollingSourceBase<
   updateSubscription(
     input: PRSubscribeInput,
     onEvent: (text: string) => void,
-    runtimeHost: AgentRuntimeHost,
+    _runtimeHost: AgentRuntimeHost,
   ): void {
     const key = prKeyToString(input);
-    this.updateListenerRuntimeHost(key, onEvent, runtimeHost);
     this.setListenerAnnotationLevel(key, onEvent, input);
   }
 
@@ -293,17 +291,8 @@ export class PRPollingSource extends PollingSourceBase<
     );
   }
 
-  protected emitKeysChangedEvent(
-    keys: readonly string[],
-    runtimeHosts: readonly AgentRuntimeHost[],
-  ): void {
-    emitGitHubSubscriptionChangedToHosts(
-      runtimeHosts,
-      'prSubscriptionsChanged',
-      {
-        keys,
-      },
-    );
+  protected emitKeysChangedEvent(keys: readonly string[]): void {
+    emitGitHubSubscriptionChanged('prSubscriptionsChanged', { keys });
   }
 
   protected formatErrorEvent(

--- a/src/tools/github/PollingSourceBase.ts
+++ b/src/tools/github/PollingSourceBase.ts
@@ -15,9 +15,8 @@ import pMap from 'p-map';
 
 import type { AgentTrace } from '@agent/trace';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import { appSignals } from '@eventBus/AppSignals';
 import { createChannelTrace } from '@logger';
-import { unique } from '@utils/core';
 
 import {
   type ConditionalResponse,
@@ -32,7 +31,6 @@ import type { Disposable } from '@platform/interfaces/disposable';
 
 export interface BasePollSubscriptionState {
   listeners: Set<(text: string) => void>;
-  runtimeHostByListener: Map<(text: string) => void, AgentRuntimeHost>;
   /** Most recent successful poll. The 24 h detach gate compares against this. */
   lastSuccessAt: number;
   consecutiveFailures: number;
@@ -151,10 +149,7 @@ export abstract class PollingSourceBase<
   protected abstract formatErrorEvent(key: K, state: S, detail: string): string;
 
   /** Subclass: publish the externally visible subscription-changed event. */
-  protected abstract emitKeysChangedEvent(
-    keys: readonly K[],
-    runtimeHosts: readonly AgentRuntimeHost[],
-  ): void;
+  protected abstract emitKeysChangedEvent(keys: readonly K[]): void;
 
   activeKeys(): readonly K[] {
     return [...this.subscriptions.keys()];
@@ -162,16 +157,6 @@ export abstract class PollingSourceBase<
 
   protected getSubscriptionState(key: K): S | undefined {
     return this.subscriptions.get(key);
-  }
-
-  updateListenerRuntimeHost(
-    key: K,
-    onEvent: (text: string) => void,
-    runtimeHost: AgentRuntimeHost,
-  ): void {
-    this.subscriptions
-      .get(key)
-      ?.runtimeHostByListener.set(onEvent, runtimeHost);
   }
 
   has(key: K): boolean {
@@ -188,10 +173,9 @@ export abstract class PollingSourceBase<
   }
 
   disposeAll(): void {
-    const runtimeHosts = this.activeRuntimeHosts();
     this.subscriptions.clear();
     this.stopTimer();
-    this.notifyKeysChanged(runtimeHosts);
+    this.notifyKeysChanged();
   }
 
   /**
@@ -203,7 +187,7 @@ export abstract class PollingSourceBase<
     key: K,
     initState: () => S,
     onEvent: (text: string) => void,
-    runtimeHost: AgentRuntimeHost,
+    _runtimeHost: AgentRuntimeHost,
   ): Disposable {
     let state = this.subscriptions.get(key);
     let created = false;
@@ -219,8 +203,7 @@ export abstract class PollingSourceBase<
       created = true;
     }
     state.listeners.add(onEvent);
-    state.runtimeHostByListener.set(onEvent, runtimeHost);
-    if (created) this.notifyKeysChanged([runtimeHost]);
+    if (created) this.notifyKeysChanged();
     this.ensureTimer();
     return {
       dispose: () => this.removeListener(key, onEvent),
@@ -270,9 +253,8 @@ export abstract class PollingSourceBase<
   protected detach(key: K): void {
     const state = this.subscriptions.get(key);
     if (!state) return;
-    const runtimeHosts = this.hostsForState(state);
     this.subscriptions.delete(key);
-    this.notifyKeysChanged(runtimeHosts);
+    this.notifyKeysChanged();
   }
 
   /** Emit a formatted halted-subscription error, then detach the key. */
@@ -284,18 +266,16 @@ export abstract class PollingSourceBase<
   private removeListener(key: K, onEvent: (text: string) => void): void {
     const state = this.subscriptions.get(key);
     if (!state) return;
-    const runtimeHost = state.runtimeHostByListener.get(onEvent);
     state.listeners.delete(onEvent);
-    state.runtimeHostByListener.delete(onEvent);
     if (state.listeners.size === 0) {
       this.subscriptions.delete(key);
       this.logger.info(`Unsubscribed from ${key}`);
-      this.notifyKeysChanged(runtimeHost ? [runtimeHost] : []);
+      this.notifyKeysChanged();
     }
     if (this.subscriptions.size === 0) this.stopTimer();
   }
 
-  private notifyKeysChanged(runtimeHosts = this.activeRuntimeHosts()): void {
+  private notifyKeysChanged(): void {
     const keys = [...this.subscriptions.keys()];
     for (const listener of this.keysChangedListeners) {
       try {
@@ -304,29 +284,7 @@ export abstract class PollingSourceBase<
         this.logger.warn('Keys-changed listener threw', { data: err });
       }
     }
-    this.emitKeysChangedEvent(keys, unique(runtimeHosts));
-  }
-
-  private activeRuntimeHosts(): AgentRuntimeHost[] {
-    const runtimeHosts: AgentRuntimeHost[] = [];
-    for (const state of this.subscriptions.values()) {
-      runtimeHosts.push(...this.hostsForState(state));
-    }
-    return unique(runtimeHosts);
-  }
-
-  private hostsForState(state: S): AgentRuntimeHost[] {
-    return unique(state.runtimeHostByListener.values());
-  }
-
-  private emitToStateHosts<EventKey extends keyof ProgressEventPayloads>(
-    state: S,
-    event: EventKey,
-    payload: ProgressEventPayloads[EventKey],
-  ): void {
-    for (const runtimeHost of this.hostsForState(state)) {
-      runtimeHost.emit(event, payload);
-    }
+    this.emitKeysChangedEvent(keys);
   }
 
   private ensureTimer(): void {
@@ -395,9 +353,7 @@ export abstract class PollingSourceBase<
         data: err,
       });
       this.emit(state, this.formatErrorEvent(key, state, err.message));
-      this.emitToStateHosts(state, 'githubTokenInvalid', {
-        message: err.message,
-      });
+      appSignals.emit('githubTokenInvalid', { message: err.message });
       this.detach(key);
       return;
     }

--- a/src/tools/github/RepoPollingSource.ts
+++ b/src/tools/github/RepoPollingSource.ts
@@ -67,7 +67,7 @@ import {
   type GhPullsListEntry,
   type GhReviewComment,
 } from './prTypes';
-import { emitGitHubSubscriptionChangedToHosts } from './subscriptionEventEmitter';
+import { emitGitHubSubscriptionChanged } from './subscriptionEventEmitter';
 
 import type { Disposable } from '@platform/interfaces/disposable';
 
@@ -179,15 +179,8 @@ class RepoPollingSource extends PollingSourceBase<RepoKey, SubscriptionState> {
     );
   }
 
-  protected emitKeysChangedEvent(
-    keys: readonly RepoKey[],
-    runtimeHosts: readonly AgentRuntimeHost[],
-  ): void {
-    emitGitHubSubscriptionChangedToHosts(
-      runtimeHosts,
-      'repoSubscriptionsChanged',
-      { keys },
-    );
+  protected emitKeysChangedEvent(keys: readonly RepoKey[]): void {
+    emitGitHubSubscriptionChanged('repoSubscriptionsChanged', { keys });
   }
 
   protected formatErrorEvent(
@@ -458,7 +451,6 @@ function createInitialState(owner: string, repo: string): SubscriptionState {
     repo,
     slug: repoKeyOf(owner, repo),
     listeners: new Set(),
-    runtimeHostByListener: new Map(),
     initialized: false,
     subscribedAt: new Date(now).toISOString(),
     issueComments: new DedupedResource<GhIssueComment>({

--- a/src/tools/github/StreamSubscriptionRegistry.ts
+++ b/src/tools/github/StreamSubscriptionRegistry.ts
@@ -23,7 +23,7 @@ import {
 import { createChannelTrace } from '@logger';
 import type { StreamTabId } from '@shared/schemas';
 
-import { emitGitHubSubscriptionChangedToHosts } from './subscriptionEventEmitter';
+import { emitGitHubSubscriptionChanged } from './subscriptionEventEmitter';
 
 import type { Disposable } from '@platform/interfaces/disposable';
 
@@ -67,7 +67,6 @@ export interface StreamSubscriptionRegistryOptions<K extends string, Input> {
 interface BoundSubscription {
   disposable: Disposable;
   onEvent: (text: string) => void;
-  runtimeHost: AgentRuntimeHost;
   /**
    * Session captured at bind() time (inside the run's AsyncLocalStorage).
    * onEvent fires later from a detached polling timer where the ALS is empty, so
@@ -113,7 +112,6 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
     }
     const existing = bound.get(key);
     if (existing) {
-      existing.runtimeHost = runtimeHost;
       existing.session = session;
       this.opts.source.updateSubscription?.(
         input,
@@ -128,7 +126,6 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
     const subscription: BoundSubscription = {
       disposable: { dispose: () => {} },
       onEvent: () => {},
-      runtimeHost,
       session,
     };
     subscription.onEvent = (text: string) => {
@@ -172,7 +169,7 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
     }
     subscription.disposable = disposable;
     this.logger.info(`Bound subscription ${key} → stream ${streamId}`);
-    if (!keyIsNew) this.emitBindingsChanged([runtimeHost]);
+    if (!keyIsNew) this.emitBindingsChanged();
     return true;
   }
 
@@ -180,7 +177,7 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
   unbind(
     streamId: StreamTabId,
     input: Input,
-    runtimeHost: AgentRuntimeHost,
+    _runtimeHost: AgentRuntimeHost,
   ): boolean {
     const key = this.opts.keyOf(input);
     const bound = this.perStream.get(streamId);
@@ -188,7 +185,7 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
     if (!bound || !binding) return false;
     this.removeBoundKey(streamId, bound, key);
     this.disposeSafe(binding.disposable, 'explicit unsubscribe');
-    this.emitBindingsChanged([runtimeHost]);
+    this.emitBindingsChanged();
     return true;
   }
 
@@ -197,22 +194,19 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
    * bindings removed. Lets the settings UI cancel a subscription globally
    * without needing to know which stream owns it.
    */
-  unbindAll(key: string, runtimeHost: AgentRuntimeHost): number {
+  unbindAll(key: string, _runtimeHost: AgentRuntimeHost): number {
     const removedBindings: BoundSubscription[] = [];
-    const runtimeHosts: AgentRuntimeHost[] = [];
     for (const [streamId, bound] of [...this.perStream]) {
       const binding = bound.get(key as K);
       if (!binding) continue;
       removedBindings.push(binding);
-      runtimeHosts.push(binding.runtimeHost);
       this.removeBoundKey(streamId, bound, key as K);
     }
     if (removedBindings.length > 0) {
       for (const binding of removedBindings) {
         this.disposeSafe(binding.disposable, 'unbindAll');
       }
-      runtimeHosts.push(runtimeHost);
-      this.emitBindingsChanged(runtimeHosts);
+      this.emitBindingsChanged();
     }
     return removedBindings.length;
   }
@@ -255,31 +249,27 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
     queue.onRelease((streamId) => {
       const bound = this.perStream.get(streamId);
       if (!bound) return;
-      const runtimeHosts = [...bound.values()].map(
-        (binding) => binding.runtimeHost,
-      );
       this.perStream.delete(streamId);
       for (const binding of bound.values()) {
         this.disposeSafe(binding.disposable, 'release');
       }
-      this.emitBindingsChanged(runtimeHosts);
+      this.emitBindingsChanged();
     });
   }
 
   private pruneMissingSourceKeys(keys: readonly K[]): void {
     const active = new Set<string>(keys);
-    const runtimeHosts: AgentRuntimeHost[] = [];
+    let removed = false;
     for (const [streamId, bound] of [...this.perStream]) {
       for (const key of [...bound.keys()]) {
         if (!active.has(key)) {
-          const binding = bound.get(key);
-          if (binding) runtimeHosts.push(binding.runtimeHost);
           bound.delete(key);
+          removed = true;
         }
       }
       if (bound.size === 0) this.perStream.delete(streamId);
     }
-    if (runtimeHosts.length > 0) this.emitBindingsChanged(runtimeHosts);
+    if (removed) this.emitBindingsChanged();
   }
 
   private removeBoundKey(
@@ -299,11 +289,7 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
     }
   }
 
-  private emitBindingsChanged(runtimeHosts: Iterable<AgentRuntimeHost>): void {
-    emitGitHubSubscriptionChangedToHosts(
-      runtimeHosts,
-      this.opts.bindingsChangedEvent,
-      undefined,
-    );
+  private emitBindingsChanged(): void {
+    emitGitHubSubscriptionChanged(this.opts.bindingsChangedEvent, undefined);
   }
 }

--- a/src/tools/github/subscriptionBindings.ts
+++ b/src/tools/github/subscriptionBindings.ts
@@ -83,12 +83,6 @@ const repoSubscriptions = new StreamSubscriptionRegistry<
         listener,
         runtimeHost,
       ),
-    updateSubscription: (input, listener, runtimeHost) =>
-      repoPollingSource.updateListenerRuntimeHost(
-        repoKeyOf(input.owner, input.repo),
-        listener,
-        runtimeHost,
-      ),
   },
   keyOf: (input) => repoKeyOf(input.owner, input.repo),
   bindingsChangedEvent: 'repoSubscriptionBindingsChanged',
@@ -133,12 +127,6 @@ const issueSubscriptions = new StreamSubscriptionRegistry<string, IssueKey>({
     onKeysChanged: (listener) => issuePollingSource.onKeysChanged(listener),
     subscribe: (input, listener, runtimeHost) =>
       issuePollingSource.subscribe(input, listener, runtimeHost),
-    updateSubscription: (input, listener, runtimeHost) =>
-      issuePollingSource.updateListenerRuntimeHost(
-        issueKeyToString(input),
-        listener,
-        runtimeHost,
-      ),
   },
   keyOf: issueKeyToString,
   bindingsChangedEvent: 'issueSubscriptionBindingsChanged',

--- a/src/tools/github/subscriptionEventEmitter.ts
+++ b/src/tools/github/subscriptionEventEmitter.ts
@@ -1,5 +1,4 @@
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import { appSignals, type AppSignalPayloads } from '@eventBus/AppSignals';
 
 export type GitHubSubscriptionChangedEvent =
   | 'prSubscriptionsChanged'
@@ -11,22 +10,6 @@ export type GitHubSubscriptionChangedEvent =
 
 export function emitGitHubSubscriptionChanged<
   K extends GitHubSubscriptionChangedEvent,
->(
-  runtimeHost: AgentRuntimeHost,
-  event: K,
-  payload: ProgressEventPayloads[K],
-): void {
-  runtimeHost.emit(event, payload);
-}
-
-export function emitGitHubSubscriptionChangedToHosts<
-  K extends GitHubSubscriptionChangedEvent,
->(
-  runtimeHosts: Iterable<AgentRuntimeHost>,
-  event: K,
-  payload: ProgressEventPayloads[K],
-): void {
-  for (const runtimeHost of new Set(runtimeHosts)) {
-    emitGitHubSubscriptionChanged(runtimeHost, event, payload);
-  }
+>(event: K, payload: AppSignalPayloads[K]): void {
+  appSignals.emit(event, payload);
 }

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -13,7 +13,7 @@
  */
 
 // Local imports
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { appSignals } from '@eventBus/AppSignals';
 import type { RegisteredToolName } from '@tools/registry';
 import { EXTERNAL_TOOL_DEFS } from '@tools/externalToolDefs';
 import { getDisabledToolIds } from '@utils/config/constants';
@@ -187,11 +187,9 @@ export function getLastCheckResults(): ExternalToolCheckResult[] | null {
  * `runExternalToolChecks`, so the dashboard-load probe and a refresh-triggered
  * probe can't race.
  */
-export async function refreshToolAvailability(
-  runtimeHost: AgentRuntimeHost,
-): Promise<void> {
+export async function refreshToolAvailability(): Promise<void> {
   await runExternalToolChecks();
-  runtimeHost.emit('toolAvailabilityChanged', undefined);
+  appSignals.emit('toolAvailabilityChanged', undefined);
 }
 
 /**


### PR DESCRIPTION
Part of #6968. This Stage 5 slice moves the low-risk process refresh signals off `ProgressEventBus` and onto an explicit `AppSignals` emitter.

## Changes

- Add `src/eventBus/AppSignals.ts` for process-level UI refresh signals without the progress bus replay buffer.
- Move `githubTokenInvalid`, GitHub subscription/key binding churn, and `toolAvailabilityChanged` to `appSignals`.
- Remove those keys from `ProgressEventPayloads` and from the `AgentRuntimeHost` documentation.
- Make `refreshToolAvailability()` host-free, so desktop and extension no longer manufacture a runtime host to refresh process-level tool state.
- Keep `requestShowError`, `requestEnsureProgressView`, `workspaceFilesWritten`, and run/session projection events on their existing host/session paths.
- Align the VSIX content verifier with the package-invariants snapshot by omitting catalog-derived `contributes` sections in both comparisons.

## Verification

- `corepack pnpm exec vitest run src/test-kernel/agent/followUp/GitHubSubscriptionProgressEvents.vitest.ts src/test-kernel/tools/ToolAvailabilityAppSignals.vitest.ts src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `corepack pnpm run compile:fast`
- `corepack pnpm run lint` (0 errors; two pre-existing import-order warnings outside this change)
- `corepack pnpm run check:extension-package-invariants`
- `corepack pnpm run build:fast && corepack pnpm run check:vsix-contents`
- `git diff --check`

## Grep evidence

- `ProgressEventBus.ts` has no remaining `githubTokenInvalid`, GitHub subscription churn, or `toolAvailabilityChanged` keys.
- `bus.emit` / `bus.on` has no remaining call sites for the migrated signal names.
