### PR TITLE
fix(modelHandlers): drop stop-reason keyword sniffing; stop forging end tags on Responses API

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -718,10 +718,16 @@ export abstract class ModelHandler<
   }
 
   /**
-   * Append the agent's end tag to a natural-stop response when the model did
-   * not already emit it. Shared by the provider handlers that use an
-   * `includes` presence check; each caller supplies its own "natural stop"
-   * predicate because provider stop-reason vocabularies differ.
+   * Restore the agent's end tag when the provider's API stripped it.
+   *
+   * Providers that accept the end tag as an API-level stop sequence
+   * (Anthropic `stop_sequences`, OpenAI/OpenRouter `stop`) omit the matched
+   * stop text from the returned completion by contract — this puts it back
+   * so downstream continuation/extraction logic sees the tag it was told to
+   * watch for. Only call this from a caller whose "natural stop" predicate is
+   * backed by that same configured stop sequence; each caller supplies its
+   * own predicate because provider stop-reason vocabularies differ. Logs
+   * when it actually fires, so there's data on how often it's needed.
    */
   protected appendEndTagIfNeeded(
     text: string,
@@ -729,6 +735,10 @@ export abstract class ModelHandler<
     isNaturalStop: boolean,
   ): string {
     if (isNaturalStop && endTag && !text.includes(endTag)) {
+      this.logger.debug(
+        'appendEndTagIfNeeded: restoring end tag stripped by provider stop sequence',
+        { data: { endTag } },
+      );
       return `${text}\n${endTag}`;
     }
     return text;

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -2215,11 +2215,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         ? OPENAI_CHAT_FINISH.STOP
         : OPENAI_CHAT_FINISH.LENGTH;
 
-    newResponse = this.appendEndTagIfNeeded(
-      newResponse,
-      endTag,
-      stopReason === OPENAI_CHAT_FINISH.STOP,
-    );
+    // Unlike Chat Completions/Anthropic, the Responses API has no `stop`
+    // parameter — this handler never configures the end tag as an API-level
+    // stop sequence, so a "completed" status never implies the provider
+    // stripped it. Forging the tag here would be pure speculation that could
+    // mask genuinely incomplete output as done; the extraction layer already
+    // tolerates a missing end tag.
     newResponse = replacementEngine.applyAll(newResponse);
 
     return { text: newResponse, usage, stopReason };

--- a/src/agent/modelHandlers/utils/stopReasonUtils.ts
+++ b/src/agent/modelHandlers/utils/stopReasonUtils.ts
@@ -19,30 +19,16 @@ const TOKEN_LIMIT_STOP_REASONS: readonly ProviderStopReason[] = [
   GOOGLE_FINISH.MAX_TOKENS,
 ];
 
-/** Keywords for fallback string matching */
-const TOKEN_LIMIT_KEYWORDS = [
-  'max_token',
-  'max-token',
-  'token limit',
-  'token_limit',
-  'length',
-];
-
 /**
  * Determines whether a provider stop reason represents a token limit hit.
  *
- * This consolidates provider-specific enums with best-effort string matching so
- * call sites can share the same continuation heuristics.
+ * Every supported SDK reports a clean enum stop reason for this condition, so
+ * this is a direct membership check against the known enum values — no
+ * best-effort string matching.
  */
 export function isTokenLimitStopReason(
   reason: ProviderStopReason | undefined,
 ): boolean {
   if (!reason) return false;
-
-  if (TOKEN_LIMIT_STOP_REASONS.includes(reason)) {
-    return true;
-  }
-
-  const normalized = String(reason).toLowerCase();
-  return TOKEN_LIMIT_KEYWORDS.some((keyword) => normalized.includes(keyword));
+  return TOKEN_LIMIT_STOP_REASONS.includes(reason);
 }

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
@@ -957,6 +957,30 @@ describe('ModelHandlerOpenAIResponse.extractResponse', () => {
 
     assert.equal(result.text, 'fallback text');
   });
+
+  it('does not forge a missing end tag onto a completed response', () => {
+    // The Responses API has no `stop` parameter, so a "completed" status
+    // never implies the provider stripped the end tag from the output.
+    // Forging it here would mask genuinely incomplete output as done.
+    const handler = createHandler();
+    const result = handler.extractResponse(
+      {
+        id: 'resp-no-end-tag',
+        status: 'completed',
+        output_text: 'the document body without a closing tag',
+        usage: {
+          input_tokens: 1,
+          output_tokens: 2,
+          total_tokens: 3,
+          input_tokens_details: { cached_tokens: 0 },
+          output_tokens_details: { reasoning_tokens: 0 },
+        },
+      } as any,
+      '</documents>',
+    );
+
+    assert.equal(result.text, 'the document body without a closing tag');
+  });
 });
 
 describe('ModelHandlerOpenAIResponse.extractAssistantText', () => {

--- a/src/test-kernel/agent/modelHandlers/stopReasonUtils.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/stopReasonUtils.vitest.ts
@@ -21,15 +21,17 @@ describe('isTokenLimitStopReason', () => {
     assert.equal(isTokenLimitStopReason(GOOGLE_FINISH.MAX_TOKENS), true);
   });
 
-  it('detects keyword-based token limit strings', () => {
-    assert.equal(isTokenLimitStopReason('max_tokens'), true);
-    assert.equal(isTokenLimitStopReason('Token limit reached'), true);
-    assert.equal(isTokenLimitStopReason('length'), true);
-  });
-
   it('ignores unrelated stop reasons', () => {
     assert.equal(isTokenLimitStopReason(undefined), false);
     assert.equal(isTokenLimitStopReason('stop'), false);
     assert.equal(isTokenLimitStopReason('function_call'), false);
+  });
+
+  it('no longer matches near-miss strings via substring fallback', () => {
+    // These used to match the deleted keyword-based fallback ladder; only
+    // exact enum values should match now.
+    assert.equal(isTokenLimitStopReason('max-token'), false);
+    assert.equal(isTokenLimitStopReason('Token limit reached'), false);
+    assert.equal(isTokenLimitStopReason('token_limit'), false);
   });
 });


### PR DESCRIPTION
## Root cause

Two F3-era residues (#7095, items 1 and 2 — item 3 was already done on `origin/main`, see below):

1. **`stopReasonUtils.ts` keyword fallback.** `isTokenLimitStopReason` fell back to substring matching (`'max_token'`, `'length'`, …) after the provider-enum check. Every supported SDK (OpenAI, Anthropic, Google, MCP) already reports a clean enum stop reason, so the fallback was dead weight that could also mis-classify an unrelated string that happens to contain "length".

2. **`appendEndTagIfNeeded` (`ModelHandler.ts`).** This restores the agent's closing tag when a provider's API strips it. I verified — via the vendored SDK type declarations, not assumption — that **three of its four call sites are load-bearing, not speculative**:
   - Anthropic sets `stop_sequences: [endTag]`; the SDK's own doc comment says a stop-sequence match yields `stop_reason: "stop_sequence"` with the matched text excluded from the response.
   - OpenAI Chat Completions sets `baseParams.stop = [endTag]`; the SDK doc comment states verbatim: "the returned text will not contain the stop sequence."
   - OpenRouter Native does the same (`request.stop = [endTag]`).

   `appendEndTagIfNeeded` is exactly restoring that stripped text, and it's load-bearing: `ModelHandlerAnthropic.shouldContinue` treats `stop_reason === 'stop_sequence' && !hasEndTag` as "should continue". If I'd gated the shared helper to fire only on token-limit stops (a literal reading of the issue text), every well-formed Anthropic/OpenAI/OpenRouter response terminated via the configured stop sequence would lose its closing tag and get treated as needing another continuation turn — reintroducing, for the wrong reason, exactly the "looks incomplete" failure mode the issue is warning about, while doing nothing to fix the real problem.

   The one caller **without** that backing is `ModelHandlerOpenAIResponse`: the Responses API has no `stop` parameter at all (confirmed absent from the OpenAI SDK's request types), so a `status === 'completed'` there never implies the provider stripped anything. That call was pure speculation — "the model probably meant to close its tag" — with no API contract behind it, and is the genuine instance of "silently forging the tag can mask truncated output as complete" the issue describes.

## Fix

- `stopReasonUtils.ts`: deleted the substring/keyword ladder; `isTokenLimitStopReason` is now a direct enum membership check.
- `ModelHandler.ts`: `appendEndTagIfNeeded` now logs (`debug`) whenever it actually appends a tag, so there's telemetry on how often the remaining, justified call sites (Anthropic/OpenAI-chat/OpenRouter-native) actually need it — data for a future full retirement.
- `modelHandlerOpenAIResponse.ts`: deleted the unjustified `appendEndTagIfNeeded` call; added a regression test (`does not forge a missing end tag onto a completed response`) locking in that a `status: 'completed'` response with no closing tag is returned as-is.
- Updated `stopReasonUtils.vitest.ts` to drop the now-invalid "keyword fallback" test and assert the near-miss strings it used to match no longer do.

Item 3 (collapsing `WithPrefill`/`WithoutPrefill` method pairs) was already done on `origin/main` — `addContinueMessage`/`updateMessageContent` already branch internally on `capabilities.supportsAssistantPrefill` (confirmed via `grep -rn "WithPrefill\|WithoutPrefill"` returning nothing) — so this PR only covers items 1 and 2.

## Verification

- `npx tsc --noEmit` — clean.
- `npx eslint` on all changed files — clean.
- `npx prettier --check` on all changed files — clean (no rewrite needed).
- `npx vitest run src/test-kernel/agent/modelHandlers/ModelHandlerContinuationContract.vitest.ts src/test-kernel/agent/modelHandlers/stopReasonUtils.vitest.ts src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts` — 4 files, 67 tests, all pass (continuation contract still green across every provider).
- `npx vitest run src/test-kernel/agent/modelHandlers/` — 46 passed, 1 pre-existing skip, 383 tests pass.
- `npx vitest run src/test-kernel/agent/` (full agent suite, since `ModelHandler.ts` is shared) — 148 passed, 1 pre-existing skip, 1057 tests pass.

Fixes #7095.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent continuation heuristics (token-limit detection and Responses end-tag handling); behavior shifts are intentional but affect when multi-turn generation continues vs stops.
> 
> **Overview**
> Tightens **continuation/stop-reason** handling and **end-tag restoration** so incomplete output is not mistaken for a finished turn.
> 
> **`isTokenLimitStopReason`** now only recognizes known provider enum values; the old substring/keyword ladder (`length`, `max_token`, etc.) is removed so unrelated stop strings are not treated as truncation.
> 
> **OpenAI Responses** `extractResponse` no longer calls **`appendEndTagIfNeeded`**: that API has no `stop` sequence for the agent end tag, so a `completed` response does not mean the provider stripped the tag—appending it could mark truncated text as done. Anthropic, Chat Completions, and OpenRouter paths that configure the end tag as a stop sequence still use the shared helper.
> 
> **`appendEndTagIfNeeded`** is documented as restoring tags omitted by stop-sequence APIs and emits **debug** logs when it actually appends, for telemetry on the remaining justified call sites.
> 
> Regression tests cover Responses extraction without forged tags and near-miss strings that no longer count as token-limit stops.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da2588c829d102a7e569c4bdb9e1729063119ff2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->