### PR TITLE
refactor(modelHandlers): delete single-use provider-identity predicates on ModelHandler base

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -191,7 +191,7 @@ export abstract class ModelHandler<
     this.logger = createChannelTrace('Agent');
     this.mediaProcessor = new MediaAttachmentProcessor(this.logger, {
       getCapabilities: () => this.capabilities,
-      isOpenAIProvider: () => this.isOpenai,
+      isOpenAIProvider: () => this.config.provider === ModelProvider.OPENAI,
     });
   }
 
@@ -488,42 +488,19 @@ export abstract class ModelHandler<
     });
   }
 
-  /** Checks if the model is from Anthropic provider. */
-  get isAnthropic(): boolean {
-    return this.config.provider === ModelProvider.ANTHROPIC;
-  }
-
-  /** Checks if the model is from OpenAI provider. */
-  get isOpenai(): boolean {
-    return this.config.provider === ModelProvider.OPENAI;
-  }
-
-  /** Checks if the model is from Google provider. */
-  get isGoogle(): boolean {
-    return this.config.provider === ModelProvider.GOOGLE;
-  }
-
-  // The DeepSeek/Kimi/MiniMax provider checks below are intentionally
-  // `protected`: their only reader is `ModelHandlerOpenRouterNative` (a
-  // subclass), which maps them to capability getters for the providers it
-  // proxies. Keeping them off the public `IModelHandler` port avoids leaking
-  // provider identity into the SDK surface (the behavioral gates were already
-  // converted to capability flags — see the SDK-readiness audit §7/§12).
-
-  /** Checks if the model is from DeepSeek provider. */
-  protected get isDeepSeek(): boolean {
-    return this.config.provider === ModelProvider.DEEPSEEK;
-  }
-
-  /** Checks if the model is from Moonshot/Kimi provider. */
-  protected get isKimi(): boolean {
-    return this.config.provider === ModelProvider.MOONSHOT;
-  }
-
-  /** Checks if the model is from MiniMax provider. */
-  protected get isMiniMax(): boolean {
-    return this.config.provider === ModelProvider.MINIMAX;
-  }
+  // Provider-identity getters (isAnthropic/isOpenai/isGoogle/isDeepSeek/
+  // isKimi/isMiniMax) were removed (#7101): each had exactly one or two call
+  // sites, all of which already had `this.config` (or, for the
+  // `ModelHandlerOpenRouterNative` combinators below, `this.config.provider`)
+  // in scope. `config.provider` — already part of the `IModelHandler` port —
+  // *is* the canonical profile read; a same-shaped getter wrapping it added
+  // no capability-profile value, just base-class surface. Callers now compare
+  // `config.provider` against `ModelProvider` directly. The remaining base
+  // predicates below fall into the other two buckets from the #7101 triage:
+  // runtime combinators over profile data (`shouldUseServerSideKeys`,
+  // `getEffectiveReasoningEffort`) and genuinely per-provider behavior that
+  // stays an overridable method/getter (`supportsManualCompaction`,
+  // `isAutoRetryManagedByProvider`, `isBackgroundModeActive`, etc.).
 
   /**
    * Whether parallel tool calls in a single turn must be batched into one
@@ -580,6 +557,10 @@ export abstract class ModelHandler<
     return getProviderStreaming(this.config.provider);
   }
 
+  /** Runtime combinator (provider identity × reasoning capability), read by
+   * multiple call sites in `openai/` — kept as a named getter rather than
+   * inlined at each one (#7101 triage: DRY combinator, not per-provider
+   * override). */
   get isOReasoningModel(): boolean {
     return (
       this.config.provider === ModelProvider.OPENAI &&
@@ -587,6 +568,8 @@ export abstract class ModelHandler<
     );
   }
 
+  /** Runtime combinator (provider identity × reasoning capability); see
+   * {@link isOReasoningModel}. */
   get isGrokReasoningModel(): boolean {
     return (
       this.config.provider === ModelProvider.XAI &&

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -104,7 +104,13 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
    * mirroring the Google/DeepSeek/Kimi/MiniMax direct-handler overrides.
    */
   override get requiresBatchedParallelToolResults(): boolean {
-    return this.isGoogle || this.isDeepSeek || this.isKimi || this.isMiniMax;
+    const { provider } = this.config;
+    return (
+      provider === ModelProvider.GOOGLE ||
+      provider === ModelProvider.DEEPSEEK ||
+      provider === ModelProvider.MOONSHOT ||
+      provider === ModelProvider.MINIMAX
+    );
   }
 
   /**
@@ -114,7 +120,8 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
   override get supportsReasoningLevelOverride(): boolean {
     return (
       this.capabilities.supportsReasoningEffort ||
-      (this.isDeepSeek && this.capabilities.supportsReasoning)
+      (this.config.provider === ModelProvider.DEEPSEEK &&
+        this.capabilities.supportsReasoning)
     );
   }
 

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -63,9 +63,6 @@ export type IModelHandler<
   ModelHandler<M, U, T, C, Resp>,
   | 'config'
   | 'capabilities'
-  | 'isOpenai'
-  | 'isAnthropic'
-  | 'isGoogle'
   | 'getStreamingConfig'
   | 'setOutputStreaming'
   | 'isBackgroundModeActive'

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 
 import { ZodError } from 'zod';
-import { MODEL_CONFIGS } from 'llm-zoo';
+import { MODEL_CONFIGS, ModelProvider } from 'llm-zoo';
 
 import { createRunTrace, type RunTrace } from '@transcript';
 import {
@@ -423,9 +423,9 @@ async function assembleAgentLaunchContext(
       prompt,
       agentPath,
       {
-        isOpenai: modelHandler.isOpenai,
-        isAnthropic: modelHandler.isAnthropic,
-        isGoogle: modelHandler.isGoogle,
+        isOpenai: modelHandler.config.provider === ModelProvider.OPENAI,
+        isAnthropic: modelHandler.config.provider === ModelProvider.ANTHROPIC,
+        isGoogle: modelHandler.config.provider === ModelProvider.GOOGLE,
       },
       agentLogger,
     );


### PR DESCRIPTION
## Root cause

#7101 (F4 follow-up) verified ~15 predicate getters still live on the
`ModelHandler` base class, individually overridable and auditable per new
provider. This PR handles one self-contained cluster from that census: the
six provider-identity getters `isAnthropic`/`isOpenai`/`isGoogle`/`isDeepSeek`/
`isKimi`/`isMiniMax`.

Each of these six getters had only **one or two call sites** in the entire
codebase, and every call site already had `this.config` (or, in one case,
`this.config.provider`) in scope. `config.provider` is already the canonical
profile read — `config` is itself part of the `IModelHandler` port — so a
same-shaped getter wrapping `config.provider === ModelProvider.X` added
base-class surface without adding any capability-profile value over the field
it wrapped. Per the #7101 triage rubric ("pure identity/static-support flags →
delete the method, inline the profile read"), these are the cleanest, lowest-
risk slice to fold first.

## Fix

- Deleted `isAnthropic`, `isOpenai`, `isGoogle` (public getters) and
  `isDeepSeek`, `isKimi`, `isMiniMax` (protected getters) from
  `ModelHandler.ts`.
- Inlined `this.config.provider === ModelProvider.X` at each of the four call
  sites: `ModelHandler`'s own `mediaProcessor` wiring,
  `ModelHandlerOpenRouterNative`'s `requiresBatchedParallelToolResults` /
  `supportsReasoningLevelOverride` combinators, and `AgentLaunchContext`'s
  `providerFlags` construction (which feeds `IS_OPENAI_MODEL` /
  `IS_ANTHROPIC_MODEL` / `IS_GOOGLE_MODEL` user vars).
- Dropped the now-stale `isOpenai` / `isAnthropic` / `isGoogle` entries from
  the `IModelHandler` `Pick<>` port (mechanically derived from the base
  class, so removing the base members required removing them here too).
- Documented `isOReasoningModel` / `isGrokReasoningModel` as DRY runtime
  combinators (provider × capability, read by multiple call sites) so they're
  explicitly classified as a different triage bucket from the deleted
  identity getters — satisfying the "remaining ones documented as combinator
  or behavioral" acceptance bullet for this slice.
- No behavior change: same provider comparisons, same call sites, just
  inlined instead of routed through a same-shaped getter.

This is an incremental slice, not the full #7101 census (the issue itself
calls out picking one cluster per PR). Remaining clusters — the runtime
combinators (`shouldUseServerSideKeys(+Sync)`), the abstract/overridable
behavioral predicates (`supportsManualCompaction`,
`supportsToolResultFileUpload`, `requiresBatchedParallelToolResults`'s base
default, etc.) — are left for follow-up PRs, so this PR does not close #7101.

## Verification

- `npx tsc --noEmit` — clean (matches pre-existing baseline; verified via
  `git stash` diff that remaining errors are unrelated `@openrouter/sdk`
  module-resolution / pre-existing `src/tools/lean` issues, identical before
  and after this change).
- `npx tsc --noEmit -p tsconfig.test-kernel.json` — clean.
- `corepack pnpm --filter texra typecheck` and
  `corepack pnpm --filter @texra-ai/cli typecheck` — clean.
- `npx eslint` on all four changed files — clean, no warnings.
- `npx prettier --check` on all four changed files — clean.
- `npx vitest run` on the most relevant suites — all pass:
  - `ModelFactoryRouting.vitest.ts`, `ModelHandlerOpenRouterNative.vitest.ts`,
    `ModelHandlerDeepSeek.vitest.ts`, `ModelHandlerReasoningCap.vitest.ts`,
    `AgentLaunchContext.vitest.ts`, `userVars.vitest.ts`,
    `UserVarsMissingFiles.vitest.mts` — 73/73 passed.
  - Full `src/test-kernel/agent/modelHandlers` +
    `src/test-kernel/modelHandlers` — 405/409 passed (4 pre-existing skips).
  - Full `src/test-kernel/agent` — 1056/1060 passed (4 pre-existing skips).

https://claude.ai/code/session_01WPQvBwoRRof78oSE8VKTHD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with equivalent provider checks; no auth, data, or API behavior changes beyond the documented #7101 surface reduction.
> 
> **Overview**
> Removes six **provider-identity getters** (`isAnthropic`, `isOpenai`, `isGoogle`, and protected `isDeepSeek` / `isKimi` / `isMiniMax`) from `ModelHandler` as part of #7101. Call sites now compare **`modelHandler.config.provider`** to **`ModelProvider`** directly.
> 
> **`IModelHandler`** no longer exposes `isOpenai`, `isAnthropic`, or `isGoogle` on its `Pick<>` port. **`AgentLaunchContext`** builds user-var provider flags the same way. **`ModelHandlerOpenRouterNative`** uses explicit provider checks for batched parallel tool results and DeepSeek reasoning override. **`MediaAttachmentProcessor`** wiring uses `config.provider === ModelProvider.OPENAI` instead of `isOpenai`.
> 
> **`isOReasoningModel`** / **`isGrokReasoningModel`** stay as documented runtime combinators (provider × capability). No intended behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c2894c34f2ad890836a523dc15cf9affd9f2eeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->