### PR TITLE
refactor(naming): rename service-singleton exports to PascalCase

### DIFF
--- a/packages/extension/src/commands/latex/arXivCommands.ts
+++ b/packages/extension/src/commands/latex/arXivCommands.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 // Local imports
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import {
-  arxivProcessor,
+  ArxivProcessor,
   type ArxivDownloadDestination,
 } from '@latex/arxivProcessor';
 import * as logger from '@logger/logUtils';
@@ -23,14 +23,14 @@ export async function downloadArXivSource(): Promise<void> {
     const arxivId = await vscode.window.showInputBox({
       placeHolder: 'e.g., 2404.12175 or https://arxiv.org/abs/2404.12175',
       prompt: 'Enter arXiv ID or URL',
-      validateInput: arxivProcessor.validateId.bind(arxivProcessor),
+      validateInput: ArxivProcessor.validateId.bind(ArxivProcessor),
     });
 
     if (!arxivId) {
       return;
     }
 
-    const paperId = arxivProcessor.getPaperDirName(arxivId);
+    const paperId = ArxivProcessor.getPaperDirName(arxivId);
 
     const destinationPick = await vscode.window.showQuickPick(
       [
@@ -75,7 +75,7 @@ export async function downloadArXivSource(): Promise<void> {
           logger.info(CHANNEL, 'User cancelled the download');
         });
 
-        const downloadResult = await arxivProcessor.downloadSource(arxivId, {
+        const downloadResult = await ArxivProcessor.downloadSource(arxivId, {
           progressCallback: (message, increment) =>
             progress.report({ message, increment }),
           autoIndent,

--- a/packages/extension/src/commands/latex/compareCommands.ts
+++ b/packages/extension/src/commands/latex/compareCommands.ts
@@ -24,7 +24,7 @@ import {
 import * as logger from '@logger/logUtils';
 import type { FileLocation } from '@shared/schemas';
 import { DIFF_REGISTRATION_DELAY_MS } from '@shared/constants/latex';
-import { flexibleFS } from '@utils/files';
+import { FlexibleFS } from '@utils/files';
 
 /** Run agent/model/round used to build the legacy postfixed copy name. */
 type AcceptCopyMeta = { agent: string; model: string; round: number };
@@ -50,7 +50,7 @@ async function validateFilesExist(
   baseLocation: FileLocation,
   editedLocation: FileLocation,
 ): Promise<boolean> {
-  if (!(await flexibleFS.exists(baseLocation))) {
+  if (!(await FlexibleFS.exists(baseLocation))) {
     void showLoggedMessage(
       CHANNEL,
       `Base file not found: ${baseLocation.absolutePath}`,
@@ -58,7 +58,7 @@ async function validateFilesExist(
     return false;
   }
 
-  if (!(await flexibleFS.exists(editedLocation))) {
+  if (!(await FlexibleFS.exists(editedLocation))) {
     void showLoggedMessage(
       CHANNEL,
       `Edited file not found: ${editedLocation.absolutePath}`,
@@ -226,9 +226,9 @@ async function handleAcceptEdited(
     // No run metadata: single-confirm replace flow shared with the desktop host.
     if (!copyMeta) {
       return await acceptEditedFileReplace(fileToUseLocation, editedLocation, {
-        exists: (location) => flexibleFS.exists(location),
-        readFile: (location) => flexibleFS.read(location),
-        writeFile: (location, content) => flexibleFS.write(location, content),
+        exists: (location) => FlexibleFS.exists(location),
+        readFile: (location) => FlexibleFS.read(location),
+        writeFile: (location, content) => FlexibleFS.write(location, content),
         confirm: async (message) => {
           const answer = await vscode.window.showWarningMessage(
             message,
@@ -259,10 +259,10 @@ async function handleAcceptEdited(
     if (!resolved) return false;
 
     const { targetLocation, targetFileName } = resolved;
-    const targetExisted = await flexibleFS.exists(targetLocation);
+    const targetExisted = await FlexibleFS.exists(targetLocation);
 
-    const editedContent = await flexibleFS.read(editedLocation);
-    await flexibleFS.write(targetLocation, editedContent);
+    const editedContent = await FlexibleFS.read(editedLocation);
+    await FlexibleFS.write(targetLocation, editedContent);
 
     if (targetLocation.kind === 'workspace') {
       emitRuntimeEvent('workspaceFilesWritten', {

--- a/packages/extension/src/commands/latex/figCommands.ts
+++ b/packages/extension/src/commands/latex/figCommands.ts
@@ -11,7 +11,7 @@ import {
 } from '@frontend/ui/errorHandlingUtils';
 import { withLaTeXGuard } from '@frontend/editor/activeFileGuards';
 import { extractFigurePathsFromLatex } from '@latex/extractFigure';
-import { tikzPictureManager } from '@latex/TikzPictureManager';
+import { TikzPictureManager } from '@latex/TikzPictureManager';
 import * as logger from '@logger/logUtils';
 import { pathToLocation } from '@utils/files';
 import { pluralize } from '@utils/text/stringUtils';
@@ -76,7 +76,7 @@ export async function handleExtractTikzFigures(): Promise<void> {
         `Processing LaTeX file for TikZ figures: ${filePath}`,
       );
 
-      const labeledTikzPictures = await tikzPictureManager.extract(
+      const labeledTikzPictures = await TikzPictureManager.extract(
         pathToLocation(filePath),
       );
 
@@ -129,7 +129,7 @@ export async function handleCompileTikzFigures(): Promise<void> {
             message: 'Extracting and compiling TikZ pictures...',
           });
 
-          const compiledFiles = await tikzPictureManager.compile(
+          const compiledFiles = await TikzPictureManager.compile(
             pathToLocation(filePath),
           );
 

--- a/packages/extension/src/commands/latex/latexdiffCommands.ts
+++ b/packages/extension/src/commands/latex/latexdiffCommands.ts
@@ -30,13 +30,13 @@ import {
   describeMathMarkupOption,
   type MathMarkupOption,
 } from '@latex/latexdiff/mathMarkup';
-import { CHANNEL, service } from '@latex/latexdiff/service';
+import { CHANNEL, LaTeXdiffService } from '@latex/latexdiff/service';
 import { runLatexdiffForExecution } from '@latex/latexdiff/runLatexdiff';
 import type { RunLatexdiffCommandConfig } from '@latex/latexdiff/types';
 import * as logger from '@logger/logUtils';
 import type { FileLocation } from '@shared/schemas';
 import { LATEX_CONFIG_DEFAULTS } from '@shared/constants/latex';
-import { flexibleFS, pathToLocation } from '@utils/files';
+import { FlexibleFS, pathToLocation } from '@utils/files';
 import { checkToolInstalled } from '@utils/system';
 
 import { getLatexdiffPackNotifications } from './latexHousekeepingNotifications';
@@ -114,7 +114,7 @@ async function openLatexdiffResult(
 
   const diffLocation = pathToLocation(diffFilePath);
 
-  if (!(await flexibleFS.exists(diffLocation))) {
+  if (!(await FlexibleFS.exists(diffLocation))) {
     await showLoggedMessage(
       CHANNEL,
       `Diff file could not be found. Expected path: ${diffFilePath}`,
@@ -225,7 +225,7 @@ async function handleLatexdiff(
   await withLatexdiffTool('latexdiff', 'Error creating LaTeX diff', () => {
     const fileToUseLocation = pathToLocation(fileToUse);
     return runDiffAndOpen(fileToUseLocation, 'latexdiff', (mathMarkup) =>
-      service.runDiff(
+      LaTeXdiffService.runDiff(
         fileToUseLocation,
         pathToLocation(editedFile),
         '_diff',
@@ -245,7 +245,7 @@ async function handleLatexdiffvc(
   await withLatexdiffTool('latexdiff-vc', 'Error creating LaTeX diff', () => {
     const fileToUseLocation = pathToLocation(fileToUse);
     return runDiffAndOpen(fileToUseLocation, 'latexdiff-vc', (mathMarkup) =>
-      service.runDiffVc(fileToUseLocation, commitHash, mathMarkup),
+      LaTeXdiffService.runDiffVc(fileToUseLocation, commitHash, mathMarkup),
     );
   });
 }

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -107,9 +107,9 @@ import { setOpenPdfOpener } from '@tools/OpenPdfTool';
 import { refreshToolAvailability } from '@tools/toolAvailability';
 import { setSetupPlatform } from '@tools/setup';
 import {
-  prPollingSource,
-  repoPollingSource,
-  issuePollingSource,
+  SharedPRPollingSource,
+  SharedRepoPollingSource,
+  SharedIssuePollingSource,
 } from '@tools/github';
 import { setInlineCommentProvider } from '@tools/comment/InlineCommentTool';
 import { setLeanLanguageServices } from '@tools/lean/leanLanguageServices';
@@ -280,10 +280,14 @@ export async function activate(context: vscode.ExtensionContext) {
     progressViewProviderInstance?.flushState(),
   );
   lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => clearStoreCache());
-  lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => prPollingSource.disposeAll());
-  lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => repoPollingSource.disposeAll());
   lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () =>
-    issuePollingSource.disposeAll(),
+    SharedPRPollingSource.disposeAll(),
+  );
+  lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () =>
+    SharedRepoPollingSource.disposeAll(),
+  );
+  lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () =>
+    SharedIssuePollingSource.disposeAll(),
   );
   lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () =>
     bus.emit('extensionDeactivating', undefined),

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -49,7 +49,7 @@ import { unsupportedCommands } from '@shared/utils/dispatcher';
 import { GoalStore, subscribeGoalStateChanges } from '@tools/goal';
 import {
   createExternalLocation,
-  flexibleFS,
+  FlexibleFS,
   pathToLocation,
   WorkspaceFS,
 } from '@utils/files';
@@ -551,7 +551,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
             )) ?? false
           );
         },
-        readFile: (file) => flexibleFS.read(createExternalLocation(file)),
+        readFile: (file) => FlexibleFS.read(createExternalLocation(file)),
         showInfo: async (message) => {
           await this.host.info(message);
         },

--- a/packages/extension/src/settingsView/handlers/githubSubscriptionHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/githubSubscriptionHandlers.ts
@@ -23,12 +23,12 @@ import {
   type SettingsMessageFor,
 } from '@shared/schemas/settingsViewMessages';
 import {
-  issuePollingSource,
+  SharedIssuePollingSource,
   listIssueSubscriptionBindings,
   listPRSubscriptionBindings,
   listRepoSubscriptionBindings,
-  prPollingSource,
-  repoPollingSource,
+  SharedPRPollingSource,
+  SharedRepoPollingSource,
   unbindAllForIssue,
   unbindAllForPR,
   unbindAllForRepo,
@@ -107,15 +107,15 @@ export class GitHubSubscriptionHandlers {
     await webview.postMessage({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_PR_SUBSCRIPTIONS,
       subscriptions: [
-        ...listPRSubscriptionBindings(prPollingSource.activeKeys()).map(
+        ...listPRSubscriptionBindings(SharedPRPollingSource.activeKeys()).map(
           toEntry,
         ),
-        ...listRepoSubscriptionBindings(repoPollingSource.activeKeys()).map(
-          toEntry,
-        ),
-        ...listIssueSubscriptionBindings(issuePollingSource.activeKeys()).map(
-          toEntry,
-        ),
+        ...listRepoSubscriptionBindings(
+          SharedRepoPollingSource.activeKeys(),
+        ).map(toEntry),
+        ...listIssueSubscriptionBindings(
+          SharedIssuePollingSource.activeKeys(),
+        ).map(toEntry),
       ],
     });
   }

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -23,7 +23,7 @@ import { K_SLICE } from '@agent/core/constants';
 import type { ToolDefinition } from '@model';
 import { MESSAGE_TYPES, AgentFileLocationSchema } from '@shared/schemas';
 import { isApprovalGatedToolName } from '@tools/approvalGatedTools';
-import { AbsoluteFS, flexibleFS } from '@utils/files';
+import { AbsoluteFS, FlexibleFS } from '@utils/files';
 import { getSystemPromptWithRules } from '@utils/prompt';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { extractScratchpad } from '@utils/text/xmlUtils';
@@ -111,7 +111,7 @@ class ResponsePrepNode<C> extends BaseNode<
   async prep(shared: ResponseCycleShared): Promise<ResponsePrepResult> {
     const { prompt, userVarChannels, checkInterruption } = this.services;
     const interrupted = checkInterruption();
-    const exists = await flexibleFS.exists(shared.outputLocation!);
+    const exists = await FlexibleFS.exists(shared.outputLocation!);
     const systemPrompt = interrupted
       ? undefined
       : await getSystemPromptWithRules(prompt.systemPrompt, {
@@ -393,7 +393,7 @@ class ResponseProcessNode<C> extends BaseNode<
       logger.debug(
         `Appending to existing file: ${outputLocation.absolutePath}`,
       );
-      await flexibleFS.appendFile(
+      await FlexibleFS.appendFile(
         outputLocation,
         connector + result.processedResponse,
       );

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -36,7 +36,7 @@ import {
   type FileLocation,
   type RoundOutput,
 } from '@shared/schemas';
-import { flexibleFS } from '@utils/files';
+import { FlexibleFS } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import type { ReflectionFlowShared } from '../ReflectionFlowState';
@@ -376,7 +376,7 @@ export class OutputNode<C = unknown> extends Node<
     const { logger } = this.services;
 
     const existingBase = await Promise.all(
-      baseFiles.map((base) => flexibleFS.exists(base)),
+      baseFiles.map((base) => FlexibleFS.exists(base)),
     );
     if (!existingBase.some(Boolean)) {
       logger.debug('No base files found for latexdiff');

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -57,7 +57,7 @@ import type {
   ToolResult,
 } from '@shared/schemas/toolResult';
 
-import { AbsoluteFS, flexibleFS } from '@utils/files';
+import { AbsoluteFS, FlexibleFS } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
 import {
   getProviderStreaming,
@@ -1025,7 +1025,7 @@ export abstract class ModelHandler<
     outputLocation: FileLocation,
     prefill: string,
   ): Promise<[boolean, M[]]> {
-    if (!(await flexibleFS.existsAndNonTrivial(outputLocation))) {
+    if (!(await FlexibleFS.existsAndNonTrivial(outputLocation))) {
       if (this.capabilities.supportsAssistantPrefill) {
         if (prefill.length === 0) {
           this.logger.debug(
@@ -1037,7 +1037,7 @@ export abstract class ModelHandler<
         this.logger.debug('Adding prefill message', { data: prefill });
         workspaceState.assembly.accumulatedOutput = `${prefill}\n`;
         await AbsoluteFS.ensureDir(dirname(outputLocation.absolutePath));
-        await flexibleFS.write(
+        await FlexibleFS.write(
           outputLocation,
           workspaceState.assembly.accumulatedOutput,
         );
@@ -1089,7 +1089,7 @@ export abstract class ModelHandler<
       !fileContent.includes(prefill)
     ) {
       workspaceState.assembly.accumulatedOutput = prefill + fileContent;
-      await flexibleFS.write(
+      await FlexibleFS.write(
         outputLocation,
         workspaceState.assembly.accumulatedOutput,
       );

--- a/src/agent/modelHandlers/utils/fileContentUtils.ts
+++ b/src/agent/modelHandlers/utils/fileContentUtils.ts
@@ -12,7 +12,7 @@ import replacementEngine from '@replacement/engine';
 
 // Local imports - files
 import type { FileLocation } from '@shared/schemas';
-import { flexibleFS } from '@utils/files';
+import { FlexibleFS } from '@utils/files';
 
 // Local imports - xml
 import { extractScratchpad } from '@utils/text/xmlUtils';
@@ -53,7 +53,7 @@ export async function prepareExistingOutputContent(
   logger: AgentTrace,
 ): Promise<PreparedFileContent> {
   // Read and clean the file content
-  let content = await flexibleFS.read(outputLocation);
+  let content = await FlexibleFS.read(outputLocation);
   content = replacementEngine.applyAll(content);
 
   // Extract any existing scratchpad content and log it
@@ -61,7 +61,7 @@ export async function prepareExistingOutputContent(
   if (scratchpad) logger.domain({ key: 'scratchpad', text: scratchpad });
 
   // Write cleaned content back to file
-  await flexibleFS.write(outputLocation, content);
+  await FlexibleFS.write(outputLocation, content);
 
   // Update workspace state - critical for multi-round agents on resume
   // so that subsequent rounds have correct context

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -20,7 +20,7 @@ import {
   createExternalLocation,
   createRunStorageLocation,
   createWorkspaceLocation,
-  flexibleFS,
+  FlexibleFS,
   TaskRunFileService,
   WorkspaceFS,
 } from '@utils/files';
@@ -125,7 +125,7 @@ export class LatexDiffManager {
   private async ensureWorkspaceDependency(
     targetLocation: FileLocation | null | undefined,
   ): Promise<void> {
-    if (!targetLocation || !(await flexibleFS.exists(targetLocation))) {
+    if (!targetLocation || !(await FlexibleFS.exists(targetLocation))) {
       return;
     }
 

--- a/src/agent/output/OutputFileProcessor.ts
+++ b/src/agent/output/OutputFileProcessor.ts
@@ -8,7 +8,7 @@ import {
   type RoundOutput,
 } from '@shared/schemas';
 import { normalizeFilePath } from '@shared/utils/path';
-import { flexibleFS, replaceInputCommands } from '@utils/files';
+import { FlexibleFS, replaceInputCommands } from '@utils/files';
 import {
   extractMultipleTextFromTag,
   extractTextFromTag,
@@ -142,7 +142,7 @@ export class OutputFileProcessor {
     // it almost always means it did not wrap each file in
     // `<documentTag name="…">`. Surface that as a warning so the round is not a
     // silent "success" that writes no files; the raw response is kept for recovery.
-    const rawText = await flexibleFS.read(outputLocation).catch(() => '');
+    const rawText = await FlexibleFS.read(outputLocation).catch(() => '');
     if (rawText.trim().length > 0) {
       this.ctx.logger.warn(
         `The model returned output but no files could be extracted from it — it likely did not wrap each document in <${this.ctx.agentSetting.documentTag}>. The raw response was kept at ${outputLocation.absolutePath} for recovery.`,
@@ -197,7 +197,7 @@ export class OutputFileProcessor {
 
     await tryOperation(
       async () => {
-        const rawContent = await flexibleFS.read(rawOutput);
+        const rawContent = await FlexibleFS.read(rawOutput);
         const tagContents: Record<string, string[]> = {};
         const documents: string[] = [];
         const documentTag = this.ctx.agentSetting.documentTag;

--- a/src/agent/output/compileCheck.ts
+++ b/src/agent/output/compileCheck.ts
@@ -15,7 +15,7 @@ import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { LATEX_CONFIG_RANGES } from '@shared/constants/latex';
 import {
   createRunStorageLocation,
-  flexibleFS,
+  FlexibleFS,
   getComparablePath,
   pathToLocation,
   WorkspaceFS,
@@ -277,13 +277,13 @@ async function compileOne(
 
   const clearStaleLogs = (): Promise<void[]> =>
     Promise.all([
-      flexibleFS.delete(logDest).catch(() => undefined),
-      flexibleFS.delete(legacyLogDest).catch(() => undefined),
+      FlexibleFS.delete(logDest).catch(() => undefined),
+      FlexibleFS.delete(legacyLogDest).catch(() => undefined),
     ]);
 
   let compileResult: CompileLatex2PdfResult;
   try {
-    const content = await flexibleFS.read(outputFile.location);
+    const content = await FlexibleFS.read(outputFile.location);
     if (!/\\documentclass/.test(content)) {
       ctx.logger.debug(
         `Compile check: ${displayName} has no \\documentclass, skipping`,
@@ -406,8 +406,8 @@ async function writeCompileFailure(args: WriteCompileFailureArgs): Promise<{
   } = args;
 
   try {
-    await flexibleFS.ensureDir(pathToLocation(opts.compileRoot));
-    await flexibleFS.write(logDest, `${failureLogExcerpt}\n`);
+    await FlexibleFS.ensureDir(pathToLocation(opts.compileRoot));
+    await FlexibleFS.write(logDest, `${failureLogExcerpt}\n`);
   } catch (writeErr) {
     ctx.logger.warn(
       `Compile check: failed to persist log for ${displayName}: ${toErrorMessage(writeErr)}`,

--- a/src/agent/output/diffComputation.ts
+++ b/src/agent/output/diffComputation.ts
@@ -11,7 +11,7 @@ import type { DiffStats } from '@shared/schemas/lineChanges';
 import {
   AbsoluteFS,
   createWorkspaceLocation,
-  flexibleFS,
+  FlexibleFS,
   getComparablePath,
   WorkspaceFS,
 } from '@utils/files';
@@ -37,14 +37,14 @@ async function computeDiffStats(
 ): Promise<DiffStats> {
   try {
     if (!baseLocation) {
-      const outContent = await flexibleFS.read(outputLocation);
+      const outContent = await FlexibleFS.read(outputLocation);
       const added = countLines(outContent);
       return { added };
     }
 
     const [baseContent, outContent] = await Promise.all([
-      flexibleFS.read(baseLocation),
-      flexibleFS.read(outputLocation),
+      FlexibleFS.read(baseLocation),
+      FlexibleFS.read(outputLocation),
     ]);
 
     // Preserve diff-match-patch's omitted-argument default: checkLines=true.

--- a/src/agent/output/outputValidation.ts
+++ b/src/agent/output/outputValidation.ts
@@ -11,7 +11,7 @@ import {
   type StageHandle,
 } from '@agent/trace';
 import type { FileLocation, StorageKey } from '@shared/schemas';
-import { flexibleFS } from '@utils/files';
+import { FlexibleFS } from '@utils/files';
 
 import {
   getStorageKey,
@@ -61,11 +61,11 @@ export async function checkExpectedOutputs(
 
       const checks = expected.map(async (file) => ({
         file,
-        exists: await flexibleFS.exists(deps.fileService.createLocation(file)),
+        exists: await FlexibleFS.exists(deps.fileService.createLocation(file)),
       }));
       const results = await Promise.all(checks);
       const missing = results.filter((r) => !r.exists).map((r) => r.file);
-      const xmlExists = await flexibleFS.exists(outputLocation);
+      const xmlExists = await FlexibleFS.exists(outputLocation);
 
       if (missing.length > 0) {
         logMissingOutputs(deps.logger, {

--- a/src/agent/runtime/agentShutdown.ts
+++ b/src/agent/runtime/agentShutdown.ts
@@ -4,7 +4,7 @@ import {
 } from '@platform/interfaces/lifecycle';
 import {
   claudeAgentSessions,
-  codexThreads,
+  CodexThreads,
 } from '@tools/agentCliSessionStores';
 
 import { executionRegistry } from './executionRegistry';
@@ -21,7 +21,7 @@ export function registerAgentShutdownHandlers(lifecycle: LifecycleHost): void {
   // Interrupt CLI-backed sessions so their streams don't reload in a stale
   // WAITING state.
   lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
-    codexThreads.interruptAll(),
+    CodexThreads.interruptAll(),
   );
   lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
     claudeAgentSessions.interruptAll(),

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -7,7 +7,7 @@ import type { AgentTrace } from '@agent/trace/AgentTrace';
 
 import type { FileLocation } from '@shared/schemas';
 import { ToolConfig } from '@shared/schemas/toolConfig';
-import { TaskRunFileService, flexibleFS, pathToLocation } from '@utils/files';
+import { TaskRunFileService, FlexibleFS, pathToLocation } from '@utils/files';
 import { filterNotNullish } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { isFile } from '@utils/files/fsEntryType';
@@ -17,7 +17,7 @@ import { getExtensionLowercase, hasExtension } from '@utils/core/pathCore';
 import { extractLatexFileDependencies } from './extractFileDependencies';
 import { extractFigurePathsFromLatex } from './extractFigure';
 import { resolveLatexDir, stripLatexComments } from './latexParsingUtils';
-import { tikzPictureManager } from './TikzPictureManager';
+import { TikzPictureManager } from './TikzPictureManager';
 import { compileLatex2Pdf } from './texTools';
 
 /** LaTeX project siblings that should always ride alongside the main file. */
@@ -120,7 +120,7 @@ export class LatexMediaManager {
       async (file): Promise<FileLocation | undefined> => {
         try {
           const buildDir = path.join(path.dirname(file.absolutePath), 'build');
-          await flexibleFS.ensureDir(pathToLocation(buildDir));
+          await FlexibleFS.ensureDir(pathToLocation(buildDir));
           const compiled = await compileLatex2Pdf(file, {
             outputDirectory: buildDir,
           });
@@ -142,11 +142,11 @@ export class LatexMediaManager {
             path.basename(file.absolutePath).replace(/\.tex$/, '.pdf'),
           );
           const pdfLocation = pathToLocation(pdfFile);
-          if (!(await flexibleFS.exists(pdfLocation))) return undefined;
+          if (!(await FlexibleFS.exists(pdfLocation))) return undefined;
 
           // Stat failures are noisier than other compile failures because an
           // existing-but-unreadable PDF likely indicates a permissions/IO bug.
-          const stats = await flexibleFS.stat(pdfLocation).catch((err) => {
+          const stats = await FlexibleFS.stat(pdfLocation).catch((err) => {
             this.logger.error(
               `Failed to stat compiled PDF ${pdfLocation.absolutePath}: ${toErrorMessage(err)}`,
               { data: { path: pdfLocation.absolutePath, error: err } },
@@ -288,7 +288,7 @@ export class LatexMediaManager {
 
     try {
       const realPath = await platform().fs.realPath(latexFile.absolutePath);
-      const content = await flexibleFS.read(latexFile);
+      const content = await FlexibleFS.read(latexFile);
       const uncommented = stripLatexComments(content);
       const baseDir = path.dirname(realPath);
 
@@ -298,7 +298,7 @@ export class LatexMediaManager {
           if (!name) continue;
           const candidate = path.join(baseDir, `${name}.sty`);
           if (
-            await flexibleFS.exists({
+            await FlexibleFS.exists({
               kind: 'external',
               absolutePath: candidate,
             })
@@ -442,7 +442,7 @@ export class LatexMediaManager {
 
       const existenceChecks = await pMap(
         fileLocations,
-        async (loc) => ({ loc, exists: await flexibleFS.exists(loc) }),
+        async (loc) => ({ loc, exists: await FlexibleFS.exists(loc) }),
         { concurrency: LATEX_CONCURRENCY, stopOnError: false },
       );
 
@@ -472,10 +472,10 @@ export class LatexMediaManager {
       files,
       async (file): Promise<FileLocation[]> => {
         try {
-          return await tikzPictureManager.compile(file);
+          return await TikzPictureManager.compile(file);
         } catch {
           // Silent skip: TikZ compilation failures are reported by the
-          // tikzPictureManager itself; pMap with stopOnError: false must
+          // TikzPictureManager itself; pMap with stopOnError: false must
           // continue past individual failures.
           return [];
         }
@@ -529,7 +529,7 @@ export class LatexMediaManager {
 
     const existingFilesInfo = await pMap(
       files,
-      async (file) => ({ file, exists: await flexibleFS.exists(file) }),
+      async (file) => ({ file, exists: await FlexibleFS.exists(file) }),
       { concurrency: LATEX_CONCURRENCY, stopOnError: false },
     );
     const existingFiles = existingFilesInfo

--- a/src/latex/TikzPictureManager.ts
+++ b/src/latex/TikzPictureManager.ts
@@ -5,7 +5,7 @@ import * as path from 'node:path';
 import * as logger from '@logger/logUtils';
 import type { FileLocation } from '@shared/schemas';
 import { renderPrompt } from '@utils/prompt';
-import { flexibleFS, TaskRunFileService, pathToLocation } from '@utils/files';
+import { FlexibleFS, TaskRunFileService, pathToLocation } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
 
 // Local imports - latex utils
@@ -22,7 +22,7 @@ function runStoragePath(loc: FileLocation): string {
   return loc.kind !== 'external' ? loc.relativePath : loc.absolutePath;
 }
 
-class TikzPictureManager {
+class TikzPictureManagerImpl {
   constructor(
     private readonly channel: string = CHANNEL,
     private readonly fileService?: TaskRunFileService,
@@ -70,7 +70,7 @@ class TikzPictureManager {
    * @returns Array of [label, tikzpictures] tuples
    */
   async extract(latexFile: FileLocation): Promise<[string, string[]][]> {
-    const content = await flexibleFS.read(latexFile);
+    const content = await FlexibleFS.read(latexFile);
 
     // Match each figure block first, then inspect labels inside the block. This
     // prevents an unlabeled figure from consuming a later figure's label.
@@ -131,7 +131,7 @@ class TikzPictureManager {
       path.join(buildDirLocation.absolutePath, filename),
     );
 
-    await flexibleFS.write(texLocation, standaloneContent);
+    await FlexibleFS.write(texLocation, standaloneContent);
     logger.debug(
       this.channel,
       `Created standalone LaTeX file: ${texLocation.absolutePath}`,
@@ -155,7 +155,7 @@ class TikzPictureManager {
       path.join(path.dirname(latexFile.absolutePath), 'build', inputName),
     );
 
-    await flexibleFS.ensureDir(buildDirLocation);
+    await FlexibleFS.ensureDir(buildDirLocation);
 
     logger.debug(
       this.channel,
@@ -211,7 +211,7 @@ class TikzPictureManager {
           path.join(path.dirname(texLocation.absolutePath), pdfFilename),
         );
 
-        if (await flexibleFS.exists(pdfLocation)) {
+        if (await FlexibleFS.exists(pdfLocation)) {
           compiledFiles.push(pdfLocation);
           logger.debug(
             this.channel,
@@ -225,4 +225,4 @@ class TikzPictureManager {
   }
 }
 
-export const tikzPictureManager = new TikzPictureManager();
+export const TikzPictureManager = new TikzPictureManagerImpl();

--- a/src/latex/acceptedFileTarget.ts
+++ b/src/latex/acceptedFileTarget.ts
@@ -92,7 +92,7 @@ export function buildAcceptSuccessMessage(
 
 /**
  * Host capabilities the accept-edited replace flow reaches through, so the
- * host-neutral orchestration can run on both the VS Code command (flexibleFS,
+ * host-neutral orchestration can run on both the VS Code command (FlexibleFS,
  * warning dialog, ProgressEventBus) and the desktop bridge (node fs, runtime
  * host emit) without each side re-implementing the confirm / write / emit /
  * success sequence.

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -72,7 +72,7 @@ export function resolveArxivPaperDirectoryRelative(
 }
 
 class ArxivSourceProcessor {
-  constructor(private readonly channel: string = 'arxivProcessor') {
+  constructor(private readonly channel: string = 'ArxivProcessor') {
     logger.initialize(this.channel);
   }
 
@@ -487,4 +487,4 @@ class ArxivSourceProcessor {
   }
 }
 
-export const arxivProcessor = new ArxivSourceProcessor();
+export const ArxivProcessor = new ArxivSourceProcessor();

--- a/src/latex/extractFigure.ts
+++ b/src/latex/extractFigure.ts
@@ -2,7 +2,7 @@
 import * as path from 'node:path';
 
 import type { FileLocation } from '@shared/schemas';
-import { flexibleFS } from '@utils/files';
+import { FlexibleFS } from '@utils/files';
 import { joinLatexPath } from '@utils/core/pathCore';
 
 import {
@@ -81,7 +81,7 @@ export async function extractFigurePathsFromLatex(
     /\\begin\{overpic\}(?:\[.*?\])?\{(.+?)\}/g,
   ];
 
-  const content = await flexibleFS.read(latexFileLocation);
+  const content = await FlexibleFS.read(latexFileLocation);
 
   // Pre-process content to remove commented-out text (including inline
   // comments and escaped `\%`, unlike a naive whole-line strip).

--- a/src/latex/extractFileDependencies.ts
+++ b/src/latex/extractFileDependencies.ts
@@ -12,7 +12,7 @@ import pMap from 'p-map';
 
 // Local imports
 import type { FileLocation } from '@shared/schemas';
-import { flexibleFS } from '@utils/files';
+import { FlexibleFS } from '@utils/files';
 import { ensureExtension, joinLatexPath } from '@utils/core/pathCore';
 
 // Local file imports
@@ -66,7 +66,7 @@ export async function extractLatexFileDependencies(
   // Follow symlinks so run-storage paths resolve against the workspace
   const latexDir = await resolveLatexDir(latexFileLocation.absolutePath);
 
-  const content = await flexibleFS.read(latexFileLocation);
+  const content = await FlexibleFS.read(latexFileLocation);
   const uncommented = stripLatexComments(content);
 
   const texInputPaths = [INPUT_PATTERN, INCLUDE_PATTERN].flatMap((pattern) =>

--- a/src/latex/latexParsingUtils.ts
+++ b/src/latex/latexParsingUtils.ts
@@ -10,7 +10,7 @@ import * as path from 'node:path';
 
 import { platform } from '@platform/platform';
 import * as logger from '@logger/logUtils';
-import { flexibleFS } from '@utils/files';
+import { FlexibleFS } from '@utils/files';
 import { ensureExtension, joinLatexPath } from '@utils/core/pathCore';
 
 /** Strips everything after an unescaped % on each line. */
@@ -50,13 +50,13 @@ export async function resolveLatexDir(absolutePath: string): Promise<string> {
 
 /**
  * Return `absolutePath` if it exists on disk, otherwise null. Centralizes
- * the `flexibleFS.exists({ kind: 'external', ... })` boilerplate used by
+ * the `FlexibleFS.exists({ kind: 'external', ... })` boilerplate used by
  * the various LaTeX dependency resolvers.
  */
 export async function existingExternalPath(
   absolutePath: string,
 ): Promise<string | null> {
-  if (await flexibleFS.exists({ kind: 'external', absolutePath })) {
+  if (await FlexibleFS.exists({ kind: 'external', absolutePath })) {
     return absolutePath;
   }
   return null;

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -7,7 +7,7 @@ import { formatError } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import type { FileLocation } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
-import { flexibleFS, pathToLocation } from '@utils/files';
+import { FlexibleFS, pathToLocation } from '@utils/files';
 import { executeCommand } from '@utils/system';
 import { readPlatformSetting } from '@utils/config/platformSettings';
 import { runLatexFormatter } from './texFormatter';
@@ -79,8 +79,8 @@ export class LaTeXdiffService {
   ): Promise<string[] | null> {
     try {
       return await Promise.all([
-        flexibleFS.read(inputLocation),
-        flexibleFS.read(editedLocation),
+        FlexibleFS.read(inputLocation),
+        FlexibleFS.read(editedLocation),
       ]);
     } catch {
       return null;
@@ -146,9 +146,9 @@ export class LaTeXdiffService {
       }
 
       // Write and process output
-      await flexibleFS.ensureDir(pathToLocation(outputDirectory));
+      await FlexibleFS.ensureDir(pathToLocation(outputDirectory));
       const outputLocation = pathToLocation(outputPath);
-      await flexibleFS.write(outputLocation, result.stdout);
+      await FlexibleFS.write(outputLocation, result.stdout);
       await this.fileProcessor.processDiffFile(outputLocation, editedLocation);
 
       logger.debug(
@@ -287,7 +287,7 @@ export class LaTeXdiffService {
   private async validateDocumentStructure(
     file: FileLocation,
   ): Promise<boolean> {
-    return hasDocumentEnvironment(await flexibleFS.read(file));
+    return hasDocumentEnvironment(await FlexibleFS.read(file));
   }
 
   private async bothFilesExist(
@@ -295,8 +295,8 @@ export class LaTeXdiffService {
     second: FileLocation,
   ): Promise<boolean> {
     const [firstExists, secondExists] = await Promise.all([
-      flexibleFS.exists(first),
-      flexibleFS.exists(second),
+      FlexibleFS.exists(first),
+      FlexibleFS.exists(second),
     ]);
     return firstExists && secondExists;
   }

--- a/src/latex/latexdiff/diffFileProcessor.ts
+++ b/src/latex/latexdiff/diffFileProcessor.ts
@@ -1,6 +1,6 @@
 import replacementEngine from '@replacement/engine';
 import type { FileLocation } from '@shared/schemas';
-import { flexibleFS } from '@utils/files';
+import { FlexibleFS } from '@utils/files';
 
 /** LaTeX starred math environments that need label removal during diff processing. */
 const STAR_ENVIRONMENTS = [
@@ -58,9 +58,9 @@ export class DiffFileProcessor {
     diffFileLocation: FileLocation,
     editedFileLocation?: FileLocation,
   ): Promise<void> {
-    const content = await flexibleFS.read(diffFileLocation);
+    const content = await FlexibleFS.read(diffFileLocation);
     const editedContent = editedFileLocation
-      ? await flexibleFS.read(editedFileLocation)
+      ? await FlexibleFS.read(editedFileLocation)
       : undefined;
     let processedContent = this.restoreFlattenedBibliography(
       content,
@@ -72,7 +72,7 @@ export class DiffFileProcessor {
     for (const [pattern, replacement] of DOCUMENT_END_FIXES) {
       processedContent = processedContent.replace(pattern, replacement);
     }
-    await flexibleFS.write(diffFileLocation, processedContent);
+    await FlexibleFS.write(diffFileLocation, processedContent);
   }
 
   private restoreFlattenedBibliography(

--- a/src/latex/latexdiff/diffOperations.ts
+++ b/src/latex/latexdiff/diffOperations.ts
@@ -19,14 +19,14 @@ import { getEffectiveDiffBase, RoundKeySchema } from '@shared/schemas';
 import type { OutputFileInfo } from '@shared/schemas';
 import {
   WorkspaceFS,
-  flexibleFS,
+  FlexibleFS,
   getComparablePath,
   pathToLocation,
 } from '@utils/files';
 import { hasExtension } from '@utils/core/pathCore';
 import { isDirectory, isFile, isSymlink } from '@utils/files/fsEntryType';
 
-import { CHANNEL, service } from './service';
+import { CHANNEL, LaTeXdiffService } from './service';
 import type {
   DiffOperation,
   DiffProgressReporter,
@@ -53,8 +53,8 @@ export async function executeDiffOperations(
       message: `Running ${operation.type} diff for ${operation.description}`,
     });
 
-    const baseExists = await flexibleFS.exists(operation.base);
-    const revisedExists = await flexibleFS.exists(operation.revised);
+    const baseExists = await FlexibleFS.exists(operation.base);
+    const revisedExists = await FlexibleFS.exists(operation.revised);
 
     if (!baseExists || !revisedExists) {
       results.push({
@@ -72,14 +72,14 @@ export async function executeDiffOperations(
 
     const diffResult =
       operation.type === 'round'
-        ? await service.runDiffForRound(
+        ? await LaTeXdiffService.runDiffForRound(
             operation.base,
             operation.revised,
             operation.round,
             mathMarkup,
             { cwd: operation.cwd },
           )
-        : await service.runDiffBetweenRounds(
+        : await LaTeXdiffService.runDiffBetweenRounds(
             operation.base,
             operation.revised,
             mathMarkup,

--- a/src/latex/latexdiff/service.ts
+++ b/src/latex/latexdiff/service.ts
@@ -6,11 +6,11 @@
  * thunk, so the value is never frozen at construction time.
  */
 
-import { LaTeXdiffService } from '@latex/latexdiff';
+import { LaTeXdiffService as LaTeXdiffServiceImpl } from '@latex/latexdiff';
 import * as logger from '@logger/logUtils';
 
 export const CHANNEL = 'LaTeXCommands';
 
 logger.initialize(CHANNEL);
 
-export const service = new LaTeXdiffService(CHANNEL);
+export const LaTeXdiffService = new LaTeXdiffServiceImpl(CHANNEL);

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -10,7 +10,7 @@ import * as logger from '@logger/logUtils';
 
 // Local imports - utils
 import type { FileLocation } from '@shared/schemas';
-import { WorkspaceFS, flexibleFS, pathToLocation } from '@utils/files';
+import { WorkspaceFS, FlexibleFS, pathToLocation } from '@utils/files';
 import { runToolWithCheck } from '@utils/system';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { getConfig } from '@utils/config/configUtils';
@@ -40,7 +40,7 @@ async function readCompileLogTail(
   const compiledBasename = path.basename(latexFile, path.extname(latexFile));
   const logAbs = path.join(outDir, `${compiledBasename}.log`);
   try {
-    const full = await flexibleFS.read(pathToLocation(logAbs));
+    const full = await FlexibleFS.read(pathToLocation(logAbs));
     return splitContentLines(full).slice(-LOG_TAIL_LINES).join('\n');
   } catch (err) {
     return `(no LaTeX log at ${logAbs}: ${toErrorMessage(err)})`;
@@ -148,7 +148,7 @@ export async function compileLatex2Pdf(
   const latexFile = latexLocation.absolutePath;
   const outDir = outputDirectory ?? path.dirname(latexFile);
   try {
-    await flexibleFS.ensureDir(pathToLocation(outDir));
+    await FlexibleFS.ensureDir(pathToLocation(outDir));
 
     // TeX resolves relative `\input{…}` / `\bibliography{…}` against the
     // compiler's cwd and TEXINPUTS, not the main file's location. When a

--- a/src/latex/texcount.ts
+++ b/src/latex/texcount.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 // Local imports - log
 import * as logger from '@logger/logUtils';
 import type { FileLocation } from '@shared/schemas';
-import { flexibleFS, pathToLocation } from '@utils/files';
+import { FlexibleFS, pathToLocation } from '@utils/files';
 import { runToolWithCheck } from '@utils/system';
 import { filterNotNull, ensureArray } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -21,7 +21,7 @@ async function hasChinesePackages(
   fileLocation: FileLocation,
 ): Promise<boolean> {
   try {
-    const content = await flexibleFS.read(fileLocation);
+    const content = await FlexibleFS.read(fileLocation);
     const chinesePackages = [
       'xeCJK',
       'ctexart',
@@ -71,7 +71,7 @@ async function validateTexFile(
   channel: string,
 ): Promise<ValidationResult> {
   const filePath = fileLocation.absolutePath;
-  if (!(await flexibleFS.exists(fileLocation))) {
+  if (!(await FlexibleFS.exists(fileLocation))) {
     const reason = `File ${filePath} does not exist.`;
     logger.warn(channel, reason);
     return { valid: false, reason };

--- a/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
@@ -13,7 +13,7 @@ import {
   type ToolEditApprovalRequest,
   type ToolEditApprovalResult,
 } from '@tools/approval';
-import { AbsoluteFS, flexibleFS, StorageFS, WorkspaceFS } from '@utils/files';
+import { AbsoluteFS, FlexibleFS, StorageFS, WorkspaceFS } from '@utils/files';
 import { createRecordingHost } from '../progressTestUtils';
 
 let testApprovalHandler:
@@ -69,7 +69,7 @@ describe('accept_run_files progress events', () => {
   let originalAbsoluteIsFile: typeof AbsoluteFS.isFile;
   let originalAbsoluteIsSymbolicLink: typeof AbsoluteFS.isSymbolicLink;
   let originalAbsoluteRead: typeof AbsoluteFS.read;
-  let originalFlexibleRead: typeof flexibleFS.read;
+  let originalFlexibleRead: typeof FlexibleFS.read;
 
   beforeEach(async () => {
     originalStorageExists = StorageFS.exists;
@@ -82,7 +82,7 @@ describe('accept_run_files progress events', () => {
     originalAbsoluteIsFile = AbsoluteFS.isFile;
     originalAbsoluteIsSymbolicLink = AbsoluteFS.isSymbolicLink;
     originalAbsoluteRead = AbsoluteFS.read;
-    originalFlexibleRead = flexibleFS.read;
+    originalFlexibleRead = FlexibleFS.read;
     AbsoluteFS.isSymbolicLink = async () => false;
     testApprovalHandler = undefined;
     await installTestPlatform();
@@ -109,7 +109,7 @@ describe('accept_run_files progress events', () => {
     AbsoluteFS.isFile = originalAbsoluteIsFile;
     AbsoluteFS.isSymbolicLink = originalAbsoluteIsSymbolicLink;
     AbsoluteFS.read = originalAbsoluteRead;
-    flexibleFS.read = originalFlexibleRead;
+    FlexibleFS.read = originalFlexibleRead;
     testApprovalHandler = undefined;
     cleanupAllApprovals();
   });
@@ -125,7 +125,7 @@ describe('accept_run_files progress events', () => {
     WorkspaceFS.read = async () => '';
     WorkspaceFS.write = async () => undefined;
     WorkspaceFS.delete = async () => undefined;
-    flexibleFS.read = async () => 'accepted content';
+    FlexibleFS.read = async () => 'accepted content';
 
     testApprovalHandler = async () => ({ accepted: true });
 
@@ -175,7 +175,7 @@ describe('accept_run_files progress events', () => {
     AbsoluteFS.isFile = async (target) =>
       target === `${storagePath}/executions/${executionId}/original/draft.tex`;
     AbsoluteFS.read = async () => 'old content';
-    flexibleFS.read = async () => 'new content';
+    FlexibleFS.read = async () => 'new content';
     testApprovalHandler = async (request) => {
       approvalOriginal = request.originalContent;
       approvalProposed = request.proposedContent;
@@ -210,7 +210,7 @@ describe('accept_run_files progress events', () => {
     };
     WorkspaceFS.delete = async () => undefined;
     AbsoluteFS.isFile = async () => false;
-    flexibleFS.read = async () => 'same content';
+    FlexibleFS.read = async () => 'same content';
     testApprovalHandler = async () => {
       approvals++;
       return { accepted: true };

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
@@ -34,7 +34,7 @@ import { BackgroundPoller } from '@agent/modelHandlers/support/BackgroundPoller'
 import { pathToLocation } from '@utils/files';
 import type { ResponseInputItem } from 'openai/resources/responses/responses';
 
-// pathToLocation and flexibleFS resolve through platform services, so this
+// pathToLocation and FlexibleFS resolve through platform services, so this
 // suite needs the real node fs rather than the in-memory default.
 setupPlatform({}, { fs: nodeFilesystem });
 

--- a/src/test-kernel/agent/output/CompileCheck.vitest.ts
+++ b/src/test-kernel/agent/output/CompileCheck.vitest.ts
@@ -23,7 +23,7 @@ import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import {
   TaskRunFileService,
   createRunStorageLocation,
-  flexibleFS,
+  FlexibleFS,
   pathToLocation,
 } from '@utils/files';
 
@@ -113,7 +113,7 @@ describe('runCompileCheck', () => {
 
   it('counts a per-file exception as a failure, never a silent skip', async () => {
     const executionId = 'compile-exception';
-    // No file is seeded at the tex path, so flexibleFS.read throws ENOENT
+    // No file is seeded at the tex path, so FlexibleFS.read throws ENOENT
     // before compileLatex2Pdf is ever invoked.
     await initLatexPlatform({});
 
@@ -144,7 +144,7 @@ describe('runCompileCheck', () => {
 
     // The synthetic excerpt is persisted like a real failure so it stays
     // discoverable on disk, not just in-memory.
-    const persisted = await flexibleFS.read(result.failures[0].log);
+    const persisted = await FlexibleFS.read(result.failures[0].log);
     expect(persisted).toContain('Compile check errored for main.tex');
   });
 
@@ -295,7 +295,7 @@ describe('runCompileCheck', () => {
     const firstResult = await runCompileCheck(ctx, 0);
     expect(firstResult.compileResult?.status).toBe('failed');
     const logLocation = firstResult.failures[0].log;
-    await expect(flexibleFS.read(logLocation)).resolves.toContain(
+    await expect(FlexibleFS.read(logLocation)).resolves.toContain(
       'Compile check failed for main.tex',
     );
 
@@ -307,7 +307,7 @@ describe('runCompileCheck', () => {
 
     // The stale failure log from the first attempt must be gone -- otherwise
     // "no compile/*.log = success" would still find leftover failure evidence.
-    await expect(flexibleFS.read(logLocation)).rejects.toThrow();
+    await expect(FlexibleFS.read(logLocation)).rejects.toThrow();
   });
 
   it('clears a pre-hash-suffix legacy log left over from before this fix', async () => {
@@ -344,7 +344,7 @@ describe('runCompileCheck', () => {
 
     expect(result.compileResult?.status).toBe('ok');
     await expect(
-      flexibleFS.read(pathToLocation(legacyLogPath)),
+      FlexibleFS.read(pathToLocation(legacyLogPath)),
     ).rejects.toThrow();
   });
 
@@ -390,8 +390,8 @@ describe('runCompileCheck', () => {
     expect(failureA.logRelativePath).not.toBe(failureB.logRelativePath);
     expect(failureA.log.absolutePath).not.toBe(failureB.log.absolutePath);
 
-    const persistedA = await flexibleFS.read(failureA.log);
-    const persistedB = await flexibleFS.read(failureB.log);
+    const persistedA = await FlexibleFS.read(failureA.log);
+    const persistedB = await FlexibleFS.read(failureB.log);
     expect(persistedA).toContain(`LOG MARKER FOR ${texPathA}`);
     expect(persistedA).not.toContain(texPathB);
     expect(persistedB).toContain(`LOG MARKER FOR ${texPathB}`);

--- a/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
@@ -26,7 +26,7 @@ import type {
   RoundOutput,
   StreamTabId,
 } from '@shared/schemas';
-import { flexibleFS } from '@utils/files';
+import { FlexibleFS } from '@utils/files';
 import { createRecordingHost, withTestRunContext } from '../progressTestUtils';
 
 function createLocation(path: string): FileLocation {
@@ -442,7 +442,7 @@ describe('output progress events', () => {
     // silently with only the raw output. It must now surface a warning. Stub
     // the read so the model output is treated as non-empty.
     const readSpy = vi
-      .spyOn(flexibleFS, 'read')
+      .spyOn(FlexibleFS, 'read')
       .mockResolvedValue('% chunk.tex\n\\section{Untagged content}\n');
     const projected = createProjectedRuntime('stream:processor');
     const { events, host, logger } = projected;

--- a/src/test-kernel/latex/ArxivProcessor.vitest.ts
+++ b/src/test-kernel/latex/ArxivProcessor.vitest.ts
@@ -5,7 +5,7 @@ import * as path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
-  arxivProcessor,
+  ArxivProcessor,
   resolveArxivPaperDirectoryRelative,
 } from '@latex/arxivProcessor';
 
@@ -59,7 +59,7 @@ describe('arXiv source download filenames', () => {
     );
     vi.stubGlobal('fetch', fetchMock);
 
-    const downloadedPath = await arxivProcessor.downloadFile(
+    const downloadedPath = await ArxivProcessor.downloadFile(
       'https://arxiv.org/src/2404.12175',
       destBasePath,
       5000,

--- a/src/test-kernel/latex/TexTools.vitest.ts
+++ b/src/test-kernel/latex/TexTools.vitest.ts
@@ -14,7 +14,7 @@ import { compileLatex2Pdf } from '@latex/texTools';
 import type { ExecResult } from '@shared/schemas/opResults';
 
 // Local imports - file utilities
-import { flexibleFS, pathToLocation } from '@utils/files';
+import { FlexibleFS, pathToLocation } from '@utils/files';
 
 const mocks = vi.hoisted(() => ({
   runToolWithCheck: vi.fn(),
@@ -64,8 +64,8 @@ describe('compileLatex2Pdf structured return', () => {
       { length: totalLines },
       (_, i) => `L${String(i + 1).padStart(4, '0')}`,
     );
-    await flexibleFS.ensureDir(pathToLocation(outputDirectory));
-    await flexibleFS.write(
+    await FlexibleFS.ensureDir(pathToLocation(outputDirectory));
+    await FlexibleFS.write(
       pathToLocation(path.join(outputDirectory, 'main.log')),
       lines.join('\n'),
     );
@@ -89,10 +89,10 @@ describe('compileLatex2Pdf structured return', () => {
       mocks.runToolWithCheck.mockResolvedValue(execResult(false));
 
       const outputDirectory = path.join(workspacePath, `build${ext}`);
-      await flexibleFS.ensureDir(pathToLocation(outputDirectory));
+      await FlexibleFS.ensureDir(pathToLocation(outputDirectory));
       // The engine always names the log after the source with ITS OWN
       // extension stripped, regardless of which LaTeX extension was used.
-      await flexibleFS.write(
+      await FlexibleFS.write(
         pathToLocation(path.join(outputDirectory, 'main.log')),
         'engine log content',
       );

--- a/src/test-kernel/latex/TikzPictureManager.vitest.ts
+++ b/src/test-kernel/latex/TikzPictureManager.vitest.ts
@@ -6,7 +6,7 @@ import { describe, it } from 'vitest';
 import { installPlatform as installFakePlatform } from '@test/support/setupPlatform';
 
 // Local imports - latex
-import { tikzPictureManager } from '@latex/TikzPictureManager';
+import { TikzPictureManager } from '@latex/TikzPictureManager';
 
 // Local imports - utils
 import { pathToLocation } from '@utils/files';
@@ -30,7 +30,7 @@ describe('TikzPictureManager', () => {
 `,
     });
 
-    const result = await tikzPictureManager.extract(
+    const result = await TikzPictureManager.extract(
       pathToLocation('paper.tex'),
     );
 
@@ -64,7 +64,7 @@ describe('TikzPictureManager', () => {
 `,
     });
 
-    const result = await tikzPictureManager.extract(
+    const result = await TikzPictureManager.extract(
       pathToLocation('paper.tex'),
     );
 

--- a/src/test-kernel/tools/ArxivDownloadTool.vitest.ts
+++ b/src/test-kernel/tools/ArxivDownloadTool.vitest.ts
@@ -29,9 +29,9 @@ declare module '@latex/arxivProcessor' {
 }
 
 // Mutable references for stubbing
-const processor = arxivModule.arxivProcessor as {
-  validateId: typeof arxivModule.arxivProcessor.validateId;
-  downloadSource: typeof arxivModule.arxivProcessor.downloadSource;
+const processor = arxivModule.ArxivProcessor as {
+  validateId: typeof arxivModule.ArxivProcessor.validateId;
+  downloadSource: typeof arxivModule.ArxivProcessor.downloadSource;
 };
 const wsFS = WorkspaceFS as unknown as {
   relativePath: typeof WorkspaceFS.relativePath;

--- a/src/test-kernel/tools/latex/ExtractTikzFiguresTool.vitest.ts
+++ b/src/test-kernel/tools/latex/ExtractTikzFiguresTool.vitest.ts
@@ -6,7 +6,7 @@ import { describe, it, afterEach, vi } from 'vitest';
 import { installPlatform as installFakePlatform } from '@test/support/setupPlatform';
 
 // Local imports - tools
-import { tikzPictureManager } from '@latex/TikzPictureManager';
+import { TikzPictureManager } from '@latex/TikzPictureManager';
 import { ExtractTikzFiguresTool } from '@tools/latex';
 import { pathToLocation } from '@utils/files';
 
@@ -24,10 +24,10 @@ describe('ExtractTikzFiguresTool', () => {
       '/workspace/slides.tex': '\\documentclass{beamer}',
       '/workspace/build/slides/fig_a.pdf': '%PDF',
     });
-    vi.spyOn(tikzPictureManager, 'extract').mockResolvedValue([
+    vi.spyOn(TikzPictureManager, 'extract').mockResolvedValue([
       ['fig:a', ['\\begin{tikzpicture}\\end{tikzpicture}']],
     ]);
-    vi.spyOn(tikzPictureManager, 'compile').mockResolvedValue([
+    vi.spyOn(TikzPictureManager, 'compile').mockResolvedValue([
       pathToLocation('build/slides/fig_a.pdf'),
     ]);
 
@@ -51,7 +51,7 @@ describe('ExtractTikzFiguresTool', () => {
     await installPlatform({
       '/workspace/draft.tex': '\\documentclass{article}',
     });
-    vi.spyOn(tikzPictureManager, 'extract').mockResolvedValue([
+    vi.spyOn(TikzPictureManager, 'extract').mockResolvedValue([
       ['fig:b', ['\\begin{tikzpicture}\\end{tikzpicture}']],
     ]);
 

--- a/src/test-kernel/utils/files/flexibleFS.vitest.ts
+++ b/src/test-kernel/utils/files/flexibleFS.vitest.ts
@@ -3,12 +3,12 @@ import * as assert from 'node:assert';
 import { describe, it } from 'vitest';
 
 // Internal imports
-import { flexibleFS } from '@utils/files/flexibleFS';
+import { FlexibleFS } from '@utils/files/flexibleFS';
 import { pathToLocation } from '@utils/files/taskRunStorage';
 import { AbsoluteFS } from '@utils/files/absoluteFS';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 
-describe('flexibleFS.write', () => {
+describe('FlexibleFS.write', () => {
   it('retries the write after clearing symlink loops', async () => {
     const originalWrite = AbsoluteFS.write;
     const originalDelete = AbsoluteFS.delete;
@@ -46,7 +46,7 @@ describe('flexibleFS.write', () => {
 
       const location = pathToLocation('file.tex');
       const expectedPath = WorkspaceFS.toAbsolute('file.tex');
-      await flexibleFS.write(location, 'content');
+      await FlexibleFS.write(location, 'content');
 
       assert.deepEqual(writes, [expectedPath, expectedPath]);
       assert.strictEqual(deleteTarget, expectedPath);

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -45,7 +45,7 @@ import {
   AbsoluteFS,
   StorageFS,
   WorkspaceFS,
-  flexibleFS,
+  FlexibleFS,
   createRunStorageLocation,
   createWorkspaceLocation,
 } from '@utils/files';
@@ -171,7 +171,7 @@ Optional:
           );
         }
 
-        const rawContent = await flexibleFS.read(sourceLocation);
+        const rawContent = await FlexibleFS.read(sourceLocation);
         const { content: proposedContent, count: strippedCount } =
           strip_criticize
             ? stripCriticizeAnnotations(rawContent)

--- a/src/tools/agentCliSessionStores.ts
+++ b/src/tools/agentCliSessionStores.ts
@@ -28,7 +28,7 @@ export interface ActiveClaudeAgentSession {
   additionalDirectories?: string[];
 }
 
-export const codexThreads = new AgentCliSessionRegistry<ActiveCodexThread>(
+export const CodexThreads = new AgentCliSessionRegistry<ActiveCodexThread>(
   'codex_thread_id',
 );
 

--- a/src/tools/arxiv/ArxivDownloadTool.ts
+++ b/src/tools/arxiv/ArxivDownloadTool.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod';
 
 // Local imports - tools
-import { arxivProcessor } from '@latex/arxivProcessor';
+import { ArxivProcessor } from '@latex/arxivProcessor';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { formatToolOutput } from '@tools/formatting';
 import { getGitignoreMatcher } from '@tools/gitignore';
@@ -65,14 +65,14 @@ export class ArxivDownloadTool extends defineTool({
 }) {
   protected async execute(input: ArxivDownloadInput): Promise<ToolResult> {
     const arxivId = input.id.trim();
-    const validationError = arxivProcessor.validateId(arxivId);
+    const validationError = ArxivProcessor.validateId(arxivId);
     if (validationError) {
       throw new ToolError(validationError);
     }
 
     let downloadResult: { path: string; alreadyExisted: boolean };
     try {
-      downloadResult = await arxivProcessor.downloadSource(arxivId, {
+      downloadResult = await ArxivProcessor.downloadSource(arxivId, {
         autoIndent: input.autoIndent,
         destination: input.destination,
       });

--- a/src/tools/arxiv/ArxivMetadataTool.ts
+++ b/src/tools/arxiv/ArxivMetadataTool.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod';
 
 // Local imports - latex
-import { arxivProcessor } from '@latex/arxivProcessor';
+import { ArxivProcessor } from '@latex/arxivProcessor';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import {
   type ArxivPaperMetadata,
@@ -40,7 +40,7 @@ export class ArxivMetadataTool extends defineTool({
 }) {
   protected async execute(input: ArxivMetadataInput): Promise<ToolResult> {
     const rawId = input.id.trim();
-    const validationError = arxivProcessor.validateId(rawId);
+    const validationError = ArxivProcessor.validateId(rawId);
     if (validationError) {
       throw new ToolError(validationError);
     }

--- a/src/tools/citation/CrossrefDoiTool.ts
+++ b/src/tools/citation/CrossrefDoiTool.ts
@@ -8,7 +8,7 @@ import { requireNonEmptyString, wrapApiCall } from '@tools/utils';
 import { defineTool } from '@tools/core/define';
 
 // Local file imports
-import { CROSSREF_CONSTANTS, crossrefClient } from './constants';
+import { CROSSREF_CONSTANTS, CrossrefClient } from './constants';
 import { rateLimitedRequest } from './rateLimiter';
 
 const CrossrefDoiInputSchema = z.strictObject({
@@ -32,7 +32,7 @@ export class CrossrefDoiTool extends defineTool({
           'crossref',
           CROSSREF_CONSTANTS.RATE_LIMIT_DELAY_MS,
           'Crossref DOI lookup',
-          () => crossrefClient.work(trimmedDoi),
+          () => CrossrefClient.work(trimmedDoi),
         ),
       'Crossref lookup failed',
     );

--- a/src/tools/citation/CrossrefSearchTool.ts
+++ b/src/tools/citation/CrossrefSearchTool.ts
@@ -13,7 +13,7 @@ import { defineTool } from '@tools/core/define';
 import { pluralize } from '@utils/text/stringUtils';
 
 // Local file imports
-import { CROSSREF_CONSTANTS, crossrefClient } from './constants';
+import { CROSSREF_CONSTANTS, CrossrefClient } from './constants';
 import { rateLimitedRequest } from './rateLimiter';
 
 const CrossrefSearchInputSchema = z.strictObject({
@@ -76,7 +76,7 @@ export class CrossrefSearchTool extends defineTool({
           'crossref',
           CROSSREF_CONSTANTS.RATE_LIMIT_DELAY_MS,
           'Crossref search',
-          () => crossrefClient.works(options),
+          () => CrossrefClient.works(options),
         ),
       'Crossref search failed',
     );

--- a/src/tools/citation/constants.ts
+++ b/src/tools/citation/constants.ts
@@ -2,10 +2,10 @@
  * Constants for academic metadata API tools (arXiv, Crossref).
  */
 
-import { CrossrefClient } from '@jamesgopsill/crossref-client';
+import { CrossrefClient as CrossrefApiClient } from '@jamesgopsill/crossref-client';
 
 /** Shared Crossref client instance — use this instead of creating new ones. */
-export const crossrefClient = new CrossrefClient();
+export const CrossrefClient = new CrossrefApiClient();
 
 // arXiv API constants
 export const ARXIV_CONSTANTS = {

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -49,7 +49,7 @@ import { defineTool } from './core/define';
 import { buildAgentWorkspaceOptions } from './agentWorkspaceOptions';
 import { importCodexClass, findCodexBinaryPath } from './codexImport';
 import { type ChildStream } from './childStream';
-import { codexThreads } from './agentCliSessionStores';
+import { CodexThreads } from './agentCliSessionStores';
 import {
   publishAgentCliStreamUsage,
   formatAgentCliDelivery,
@@ -369,8 +369,8 @@ function startCodexLoop(params: {
   // bypass the in-memory guard and start a concurrent loop.
   const registerThread = (session: SessionHandle): void => {
     const threadId = thread.id;
-    if (threadId && !codexThreads.isActive(threadId)) {
-      codexThreads.register(threadId, {
+    if (threadId && !CodexThreads.isActive(threadId)) {
+      CodexThreads.register(threadId, {
         thread,
         childStreamId,
         parentStreamId,
@@ -409,7 +409,7 @@ function startCodexLoop(params: {
       formatAgentCliError('codex-error', executionId, prompt, err),
     onSessionCleanup: () => {
       const threadId = thread.id;
-      if (threadId) codexThreads.release(threadId);
+      if (threadId) CodexThreads.release(threadId);
     },
   };
 
@@ -478,8 +478,8 @@ export class CodexTool extends defineTool({
     return withAgentCliApproval(
       `[codex ${input.sandbox_mode}] ${input.prompt}`,
       (runContext) => {
-        if (input.thread_id && codexThreads.isActive(input.thread_id)) {
-          return resumeAgentCliSession(codexThreads, {
+        if (input.thread_id && CodexThreads.isActive(input.thread_id)) {
+          return resumeAgentCliSession(CodexThreads, {
             id: input.thread_id,
             prompt: input.prompt,
             callerStreamId: runContext?.streamId,

--- a/src/tools/github/IssuePollingSource.ts
+++ b/src/tools/github/IssuePollingSource.ts
@@ -227,4 +227,4 @@ class IssuePollingSource extends PollingSourceBase<string, SubscriptionState> {
   }
 }
 
-export const issuePollingSource = new IssuePollingSource();
+export const SharedIssuePollingSource = new IssuePollingSource();

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -42,7 +42,7 @@ import {
   GitHubRateLimitError,
 } from './githubClient';
 import {
-  annotationFetchBudget,
+  SharedAnnotationFetchBudget,
   AnnotationFetchBudgetExhaustedError,
 } from './annotationFetchBudget';
 import {
@@ -243,7 +243,7 @@ export class PRPollingSource extends PollingSourceBase<
     remainingFetches?: number,
     nowMs?: number,
   ): void {
-    annotationFetchBudget.resetForTests(remainingFetches, nowMs);
+    SharedAnnotationFetchBudget.resetForTests(remainingFetches, nowMs);
   }
 
   subscribe(
@@ -878,11 +878,11 @@ export class PRPollingSource extends PollingSourceBase<
       repo,
       checkRunId,
       this.logger,
-      annotationFetchBudget,
+      SharedAnnotationFetchBudget,
       now,
     );
   }
 }
 
 /** Process-wide singleton. */
-export const prPollingSource = new PRPollingSource();
+export const SharedPRPollingSource = new PRPollingSource();

--- a/src/tools/github/RepoPollingSource.ts
+++ b/src/tools/github/RepoPollingSource.ts
@@ -546,4 +546,4 @@ function parsePRNumberFromReviewCommentUrl(url: string): number | undefined {
 }
 
 /** Process-wide singleton. */
-export const repoPollingSource = new RepoPollingSource();
+export const SharedRepoPollingSource = new RepoPollingSource();

--- a/src/tools/github/annotationFetchBudget.ts
+++ b/src/tools/github/annotationFetchBudget.ts
@@ -7,7 +7,7 @@
  * PR subscriptions in the process to a token bucket that continuously
  * refills, independent of the poll interval.
  *
- * A single shared singleton (`annotationFetchBudget`) is the authority; the
+ * A single shared singleton (`SharedAnnotationFetchBudget`) is the authority; the
  * infrastructure `fetchAnnotations` claims against it and `PRPollingSource`
  * exposes a test-only reset that targets the same instance.
  *
@@ -85,7 +85,7 @@ export class AnnotationFetchBudget {
 }
 
 /** Process-wide singleton shared by every PR subscription. */
-export const annotationFetchBudget = new AnnotationFetchBudget(
+export const SharedAnnotationFetchBudget = new AnnotationFetchBudget(
   MAX_PROCESS_ANNOTATION_REQUESTS_PER_WINDOW,
   ANNOTATION_FETCH_BUDGET_WINDOW_MS,
 );

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -45,9 +45,9 @@ import {
   unbindPRSubscription,
   unbindRepoSubscription,
 } from './subscriptionBindings';
-import { issuePollingSource } from './IssuePollingSource';
-import { prPollingSource } from './PRPollingSource';
-import { repoPollingSource } from './RepoPollingSource';
+import { SharedIssuePollingSource } from './IssuePollingSource';
+import { SharedPRPollingSource } from './PRPollingSource';
+import { SharedRepoPollingSource } from './RepoPollingSource';
 import type { GhIssue, GhPullRequest } from './prTypes';
 
 const GitHubSubscriptionInputSchema = z.strictObject({
@@ -209,8 +209,8 @@ async function execSubscribe(
   // own /issues/N → /pull/N redirect behavior on github.com.
   const issueSlug = `${target.owner}/${target.repo}/issues/${target.issueNumber}`;
   const prSlug = `${target.owner}/${target.repo}/pulls/${target.issueNumber}`;
-  const knownPR = prPollingSource.has(prSlug);
-  const knownIssue = !knownPR && issuePollingSource.has(issueSlug);
+  const knownPR = SharedPRPollingSource.has(prSlug);
+  const knownIssue = !knownPR && SharedIssuePollingSource.has(issueSlug);
   const isPR =
     knownPR ||
     (!knownIssue &&
@@ -321,14 +321,16 @@ function execUnsubscribe(input: GitHubSubscriptionInput): ToolResult {
 
 function execList(): ToolResult {
   const { streamId } = requireRunStream('github_subscription');
-  const prKeys = listPRSubscriptionBindings(prPollingSource.activeKeys())
+  const prKeys = listPRSubscriptionBindings(SharedPRPollingSource.activeKeys())
     .filter((b) => b.streamIds.includes(streamId))
     .map((b) => b.key);
-  const repoKeys = listRepoSubscriptionBindings(repoPollingSource.activeKeys())
+  const repoKeys = listRepoSubscriptionBindings(
+    SharedRepoPollingSource.activeKeys(),
+  )
     .filter((b) => b.streamIds.includes(streamId))
     .map((b) => b.key);
   const issueKeys = listIssueSubscriptionBindings(
-    issuePollingSource.activeKeys(),
+    SharedIssuePollingSource.activeKeys(),
   )
     .filter((b) => b.streamIds.includes(streamId))
     .map((b) => b.key);

--- a/src/tools/github/index.ts
+++ b/src/tools/github/index.ts
@@ -1,7 +1,7 @@
 export { GitHubSubscriptionTool } from './githubSubscriptionTool';
-export { prPollingSource } from './PRPollingSource';
-export { repoPollingSource } from './RepoPollingSource';
-export { issuePollingSource } from './IssuePollingSource';
+export { SharedPRPollingSource } from './PRPollingSource';
+export { SharedRepoPollingSource } from './RepoPollingSource';
+export { SharedIssuePollingSource } from './IssuePollingSource';
 export type { RepoKey } from './RepoPollingSource';
 export {
   listIssueSubscriptionBindings,

--- a/src/tools/github/subscriptionBindings.ts
+++ b/src/tools/github/subscriptionBindings.ts
@@ -3,17 +3,17 @@ import type { StreamTabId } from '@shared/schemas';
 
 import {
   issueKeyToString,
-  issuePollingSource,
+  SharedIssuePollingSource,
   type IssueKey,
 } from './IssuePollingSource';
 import {
   prKeyToString,
-  prPollingSource,
+  SharedPRPollingSource,
   type PRSubscribeInput,
 } from './PRPollingSource';
 import {
   repoKeyOf,
-  repoPollingSource,
+  SharedRepoPollingSource,
   type RepoKey,
 } from './RepoPollingSource';
 import {
@@ -26,7 +26,7 @@ const prSubscriptions = new StreamSubscriptionRegistry<
   PRSubscribeInput
 >({
   name: 'PRStreamSubscriptionRegistry',
-  source: prPollingSource,
+  source: SharedPRPollingSource,
   keyOf: prKeyToString,
   bindingsChangedEvent: 'prSubscriptionBindingsChanged',
 });
@@ -34,7 +34,7 @@ const prSubscriptions = new StreamSubscriptionRegistry<
 export type PRSubscriptionBinding = SubscriptionBinding<string>;
 
 export function listPRSubscriptionBindings(
-  keys: readonly string[] = prPollingSource.activeKeys(),
+  keys: readonly string[] = SharedPRPollingSource.activeKeys(),
 ): PRSubscriptionBinding[] {
   return prSubscriptions.list(keys);
 }
@@ -73,18 +73,19 @@ const repoSubscriptions = new StreamSubscriptionRegistry<
 >({
   name: 'RepoStreamSubscriptionRegistry',
   source: {
-    has: (key) => repoPollingSource.has(key),
-    activeKeys: () => repoPollingSource.activeKeys(),
-    onKeysChanged: (listener) => repoPollingSource.onKeysChanged(listener),
+    has: (key) => SharedRepoPollingSource.has(key),
+    activeKeys: () => SharedRepoPollingSource.activeKeys(),
+    onKeysChanged: (listener) =>
+      SharedRepoPollingSource.onKeysChanged(listener),
     subscribe: (input, listener, runtimeHost) =>
-      repoPollingSource.subscribe(
+      SharedRepoPollingSource.subscribe(
         input.owner,
         input.repo,
         listener,
         runtimeHost,
       ),
     updateSubscription: (input, listener, runtimeHost) =>
-      repoPollingSource.updateListenerRuntimeHost(
+      SharedRepoPollingSource.updateListenerRuntimeHost(
         repoKeyOf(input.owner, input.repo),
         listener,
         runtimeHost,
@@ -97,7 +98,7 @@ const repoSubscriptions = new StreamSubscriptionRegistry<
 export type RepoSubscriptionBinding = SubscriptionBinding<RepoKey>;
 
 export function listRepoSubscriptionBindings(
-  keys: readonly RepoKey[] = repoPollingSource.activeKeys(),
+  keys: readonly RepoKey[] = SharedRepoPollingSource.activeKeys(),
 ): RepoSubscriptionBinding[] {
   return repoSubscriptions.list(keys);
 }
@@ -128,13 +129,14 @@ export function unbindAllForRepo(
 const issueSubscriptions = new StreamSubscriptionRegistry<string, IssueKey>({
   name: 'IssueStreamSubscriptionRegistry',
   source: {
-    has: (key) => issuePollingSource.has(key),
-    activeKeys: () => issuePollingSource.activeKeys(),
-    onKeysChanged: (listener) => issuePollingSource.onKeysChanged(listener),
+    has: (key) => SharedIssuePollingSource.has(key),
+    activeKeys: () => SharedIssuePollingSource.activeKeys(),
+    onKeysChanged: (listener) =>
+      SharedIssuePollingSource.onKeysChanged(listener),
     subscribe: (input, listener, runtimeHost) =>
-      issuePollingSource.subscribe(input, listener, runtimeHost),
+      SharedIssuePollingSource.subscribe(input, listener, runtimeHost),
     updateSubscription: (input, listener, runtimeHost) =>
-      issuePollingSource.updateListenerRuntimeHost(
+      SharedIssuePollingSource.updateListenerRuntimeHost(
         issueKeyToString(input),
         listener,
         runtimeHost,
@@ -147,7 +149,7 @@ const issueSubscriptions = new StreamSubscriptionRegistry<string, IssueKey>({
 export type IssueSubscriptionBinding = SubscriptionBinding<string>;
 
 export function listIssueSubscriptionBindings(
-  keys: readonly string[] = issuePollingSource.activeKeys(),
+  keys: readonly string[] = SharedIssuePollingSource.activeKeys(),
 ): IssueSubscriptionBinding[] {
   return issueSubscriptions.list(keys);
 }

--- a/src/tools/latex/ExtractTikzFiguresTool.ts
+++ b/src/tools/latex/ExtractTikzFiguresTool.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod';
 
 // Local imports - tools
-import { tikzPictureManager } from '@latex/TikzPictureManager';
+import { TikzPictureManager } from '@latex/TikzPictureManager';
 import {
   type ToolFileAttachment,
   type ToolResult,
@@ -43,7 +43,7 @@ export class ExtractTikzFiguresTool extends defineTool({
   }: ExtractTikzInput): Promise<ToolResult> {
     const { path, display } = await resolveLatexFileOrThrow(texPath);
 
-    const tikzFigures = await tikzPictureManager.extract(
+    const tikzFigures = await TikzPictureManager.extract(
       pathToLocation(path.absolute),
     );
     if (tikzFigures.length === 0) {
@@ -68,7 +68,7 @@ export class ExtractTikzFiguresTool extends defineTool({
 
     let attachments: ToolFileAttachment[] | undefined;
     if (compile) {
-      const compiledPaths = await tikzPictureManager.compile(
+      const compiledPaths = await TikzPictureManager.compile(
         pathToLocation(path.absolute),
       );
       if (compiledPaths.length > 0) {

--- a/src/tools/zotero/ZoteroAddTool.ts
+++ b/src/tools/zotero/ZoteroAddTool.ts
@@ -27,7 +27,7 @@ import pTimeout from 'p-timeout';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { isTimeoutError } from '@tools/timeouts';
 import { waitForRateLimit } from '@tools/citation/rateLimiter';
-import { CROSSREF_CONSTANTS, crossrefClient } from '@tools/citation/constants';
+import { CROSSREF_CONSTANTS, CrossrefClient } from '@tools/citation/constants';
 import { defineTool } from '@tools/core/define';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { pluralize } from '@utils/text/stringUtils';
@@ -235,7 +235,7 @@ async function resolveDOI(
     await waitForRateLimit('crossref', CROSSREF_CONSTANTS.RATE_LIMIT_DELAY_MS);
 
     // The CrossrefClient has no timeout support, so we race against one.
-    const response = await pTimeout(crossrefClient.work(doi), {
+    const response = await pTimeout(CrossrefClient.work(doi), {
       milliseconds: CROSSREF_RESOLVE_TIMEOUT_MS,
       message: 'Crossref lookup timed out',
     });

--- a/src/utils/files/fileMappingUtils.ts
+++ b/src/utils/files/fileMappingUtils.ts
@@ -12,7 +12,7 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import { normalizeLatexPath, getPathSegments } from '@utils/core/pathCore';
 
 // Local file imports
-import { flexibleFS } from './flexibleFS';
+import { FlexibleFS } from './flexibleFS';
 import { getComparablePath } from './taskRunStorage';
 
 /**
@@ -167,7 +167,7 @@ export async function replaceInputCommands(
     const outputPath = getComparablePath(outputLocation);
 
     try {
-      const content = await flexibleFS.read(outputLocation);
+      const content = await FlexibleFS.read(outputLocation);
       const newContent = content.replaceAll(
         /\\input{([^}]+)}/g,
         (match, rawPath) => {
@@ -188,7 +188,7 @@ export async function replaceInputCommands(
       );
 
       if (newContent !== content) {
-        await flexibleFS.write(outputLocation, newContent);
+        await FlexibleFS.write(outputLocation, newContent);
         logger?.debug(`Updated input commands in ${outputPath}`);
       }
     } catch (err) {

--- a/src/utils/files/flexibleFS.ts
+++ b/src/utils/files/flexibleFS.ts
@@ -12,7 +12,7 @@ logger.initialize(CHANNEL);
  * Filesystem operations for FileLocation objects.
  * All paths must be FileLocation - use pathToLocation() to convert strings.
  */
-class FlexibleFS {
+class FlexibleFSImpl {
   exists(target: FileLocation): Promise<boolean> {
     return AbsoluteFS.exists(target.absolutePath);
   }
@@ -97,4 +97,4 @@ class FlexibleFS {
   }
 }
 
-export const flexibleFS = new FlexibleFS();
+export const FlexibleFS = new FlexibleFSImpl();


### PR DESCRIPTION
## Root cause

AGENTS.md (lines 89-91) mandates PascalCase for class-instance service
singletons (e.g. `StreamStatusService`, `ModelRegistry`) and camelCase
for simple command/function namespaces. Only 3 singleton exports
(`StreamStatusService`, `BinaryResolver`, `UsageLogService`) followed
this; #6866 found ~18 more still using camelCase.

## Scope of this PR

Per the issue's own suggestion, this PR covers the singletons **outside**
`src/agent/runtime/` and `src/tools/subagentDeliveryState.ts`, leaving
those for a follow-up: `subagentDeliveryRegistry` in particular was just
touched by merged PR #7317, and that whole area saw active native-subagent
churn on the day this audit landed. A human/maintainer should decide
whether to reopen #6866 for that remainder or file a fresh issue once
things settle (`executionRegistry`, `bus`, `interruptRegistry`,
`toolInjectionRegistry`, `executionSubscriptionBinder`,
`runCoordinatorBridge`, `subagentDeliveryRegistry`).

## What changed

Pure rename of the export identifier — no behavior change. Classes and
file paths are unchanged except where a same-file/same-import identifier
collision forced a secondary rename (documented per-file below):

| Old export | New export | File | Notes |
|---|---|---|---|
| `arxivProcessor` | `ArxivProcessor` | `src/latex/arxivProcessor.ts` | class stays `ArxivSourceProcessor`, no collision |
| `flexibleFS` | `FlexibleFS` | `src/utils/files/flexibleFS.ts` | local class `FlexibleFS` → `FlexibleFSImpl` (same-file collision; class isn't referenced elsewhere) |
| `crossrefClient` | `CrossrefClient` | `src/tools/citation/constants.ts` | aliased the `@jamesgopsill/crossref-client` import to `CrossrefApiClient` (that package already exports a class named `CrossrefClient`) |
| `tikzPictureManager` | `TikzPictureManager` | `src/latex/TikzPictureManager.ts` | local class → `TikzPictureManagerImpl` (same reasoning as FlexibleFS) |
| `service` | `LaTeXdiffService` | `src/latex/latexdiff/service.ts` | aliased the `@latex/latexdiff` class import to `LaTeXdiffServiceImpl` to avoid colliding with the new export name |
| `annotationFetchBudget` | `SharedAnnotationFetchBudget` | `src/tools/github/annotationFetchBudget.ts` | kept the `AnnotationFetchBudget` **class** name as-is — it's constructed directly in `checkRunsClient.ts` (param type) and in tests, so `Shared` prefix avoids the collision without touching those call sites |
| `codexThreads` | `CodexThreads` | `src/tools/agentCliSessionStores.ts` | no collision |
| `prPollingSource` | `SharedPRPollingSource` | `src/tools/github/PRPollingSource.ts` | kept the exported `PRPollingSource` **class** as-is — vitest suites construct it directly (`new PRPollingSource()`, `PRPollingSource.resetAnnotationFetchBudgetForTests(...)`) |
| `issuePollingSource` | `SharedIssuePollingSource` | `src/tools/github/IssuePollingSource.ts` | `Shared` prefix kept for family consistency with PR/Repo |
| `repoPollingSource` | `SharedRepoPollingSource` | `src/tools/github/RepoPollingSource.ts` | same |

All import sites were found via a whole-word grep sweep and updated; a
couple of `perl -pi` passes initially corrupted module-path strings that
happened to contain the renamed identifier as a substring (e.g.
`from './service'` → `from './LaTeXdiffService'`, `@latex/ArxivProcessor`
instead of `@latex/arxivProcessor`) — these were caught by `tsc --noEmit`
and fixed; the diff no longer touches any file path/module specifier.

Did not add the optional ESLint naming-convention rule from the issue's
action checklist — flagging class-instance-singleton camelCase
automatically needs a rule that can tell "single-purpose class instance"
apart from ordinary object exports, which isn't a stock
`@typescript-eslint/naming-convention` selector; a bespoke rule felt like
scope creep for a mechanical-rename PR and is better proposed alongside
the runtime-scope follow-up once the naming set is final.

## Verification

- `npx tsc --noEmit`: clean relative to the origin/main baseline (only
  pre-existing `@openrouter/sdk` / `vscode-jsonrpc` module-resolution
  errors remain — confirmed identical error set via `git stash`)
- `npx eslint <changed files>`: clean
- `npx prettier --check <changed files>`: clean (4 files needed
  `--write` after longer identifiers pushed some lines over the width
  limit)
- `npx vitest run` across the 24 test files covering every renamed
  singleton (Arxiv, FlexibleFS, TikzPictureManager, AnnotationFetchBudget,
  PRPollingSource\*, GitHubSubscriptionTool/ProgressEvents, latexdiff,
  AcceptRunFiles, CompileCheck, OutputProgressEvents,
  ModelHandlerOpenAIResponse, TexTools, codexConfig/codexImport):
  **120/120 passed**
- Full `npx vitest run`: the same 75 files / 90 tests fail before and
  after this change, all due to missing packages in this worktree
  (`citty`, `fix-path`, `vscode-jsonrpc/node`) — unrelated to this diff

Fixes #6866.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical export/import renames with no behavioral changes; collision fixes are local to implementation class names and import aliases.
> 
> **Overview**
> Aligns **class-instance singleton** exports with AGENTS.md: **PascalCase** for shared services (and `Shared*` where the export name would collide with an existing class).
> 
> **Renamed exports** (import sites only; no logic changes): `flexibleFS` → `FlexibleFS`, `arxivProcessor` → `ArxivProcessor`, `tikzPictureManager` → `TikzPictureManager`, `crossrefClient` → `CrossrefClient`, latexdiff `service` → `LaTeXdiffService`, `codexThreads` → `CodexThreads`, GitHub `prPollingSource` / `repoPollingSource` / `issuePollingSource` → `SharedPRPollingSource` / `SharedRepoPollingSource` / `SharedIssuePollingSource`, and `annotationFetchBudget` → `SharedAnnotationFetchBudget`.
> 
> Where the new export name matched a local class in the same file, implementations were renamed (`FlexibleFSImpl`, `TikzPictureManagerImpl`) or third-party imports were aliased (`CrossrefApiClient`, `LaTeXdiffServiceImpl`) so types and module paths stay stable.
> 
> Call sites span the VS Code extension, agent output/compile paths, LaTeX tooling, GitHub subscription/shutdown wiring, and vitest suites—**identifier-only** updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6843086c6a4cb31a25674f09a975791abb3838a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->