### PR TITLE
ci(release): gate extension publish on catalog drift (Closes #7348)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,16 @@ jobs:
       - name: Type check
         run: pnpm run typecheck
 
+      # Fail the release before building/publishing if the code-generated
+      # `contributes.*` subtrees in package.json have drifted from the settings
+      # and command catalogs. `check:vsix-contents` (below) only asserts these
+      # subtrees are present and non-empty before trimming them from its
+      # manifest snapshot; it does not compare their contents. Without this
+      # gate a release cut from a commit whose catalog drift bypassed PR CI
+      # could publish a stale VS Code manifest.
+      - name: Check package contributes catalog
+        run: pnpm run check:package-contributes
+
       - name: Build extension VSIX
         run: pnpm --filter texra build:fast
 


### PR DESCRIPTION
## The gap

Fast-follow from #7343. The `publish-extension` job in `.github/workflows/release.yml` ran typecheck, built the VSIX, and then ran **only** `check:vsix-contents`. That check (repaired in #7343) asserts the three code-generated `contributes.*` subtrees — `configuration`, `commands`, `keybindings` — are *present and non-empty* before trimming them from its manifest snapshot comparison, but it does **not** compare their *contents* against the generated catalog.

Consequence: a release cut from a commit where a catalog subtree is present-but-stale (or missing individual generated entries) still passed the publish job and could publish a bad VS Code manifest. Normal PR CI catches this via the catalog codegen/`--check`, so the exposure was limited to a release cut from a commit whose drift bypassed PR CI — the P2 Codex flagged on #7343.

## The fix (issue option b)

Add the existing, already-tested `check:package-contributes` npm script as a step in the publish job, positioned **after `Type check` and before `Build extension VSIX`** so catalog drift fails the release *before* anything is built or published:

```yaml
      - name: Check package contributes catalog
        run: pnpm run check:package-contributes
```

Chose option (b) over option (a) — importing the catalog codegen comparison into `verify-vsix-contents.mjs` — deliberately: `check:vsix-contents` was just repaired by #7343 and sits on the release-critical path, so keeping new drift logic out of that script avoids adding regression risk to it. Option (b) reuses the same `--check` codegen that PR CI already relies on, with zero new logic.

## Verified

- `check:package-contributes` = `npm run compile:tsc-out && node scripts/sync-package-contributes.mjs --check` (confirmed name/definition in `package.json`, defined by #7338).
- Runs standalone green on a clean tree: `npm run check:package-contributes` → exit `0` (`package.json contributes.* is in sync with the catalogs`); `CI=true pnpm run check:package-contributes` → exit `0` (the `CI=true` env, always set by GitHub Actions, is required to bypass pnpm's no-TTY deps-status purge; without it pnpm aborts headlessly).
- YAML parses; step lands at position 7 of 12: `… | Type check | Check package contributes catalog | Build extension VSIX | Check VSIX contents | … | Publish to …`.
- Rebased onto current `origin/main` (which already contains #7343) so the diff is exactly the addition.

## Net diff

```
 .github/workflows/release.yml | 10 ++++++++++
 1 file changed, 10 insertions(+)
```

Closes #7348

https://claude.ai/code/session_01PkkPA9A5vht7PmB9xxiqU3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release workflow-only change; reuses an existing npm check with no runtime or publish logic changes.
> 
> **Overview**
> **Release publish** now fails early if code-generated `contributes.*` in the extension `package.json` is out of sync with the settings/command catalogs.
> 
> The `publish-extension` job runs `pnpm run check:package-contributes` **after typecheck and before building the VSIX**, so a release cannot build or publish when catalog drift slipped past PR CI. This complements `check:vsix-contents`, which only checks that those subtrees exist and are non-empty—not that their contents match the catalogs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edc040f073e9ee7193daefbaf36d296ec6f88049. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->