### PR TITLE
fix(ci): remove duplicate declarations breaking verify-vsix-contents.mjs

### DIFF
--- a/scripts/verify-vsix-contents.mjs
+++ b/scripts/verify-vsix-contents.mjs
@@ -23,12 +23,6 @@ const snapshotPath = path.join(
   'extension-package-invariants.snapshot.json',
 );
 
-const CATALOG_DERIVED_CONTRIBUTES = [
-  'configuration',
-  'commands',
-  'keybindings',
-];
-
 function defaultVsixPath() {
   const packageJson = readJson(path.join(extensionDir, 'package.json'));
   return path.join(rootDir, 'releases', `texra-${packageJson.version}.vsix`);
@@ -118,14 +112,6 @@ function verifyManifest(vsixPath, snapshot, failures) {
     'VSIX extension/package.json no longer matches the extension manifest snapshot.',
     failures,
   );
-}
-
-function withoutCatalogDerivedContributes(packageJson) {
-  const { contributes } = packageJson;
-  if (!contributes || typeof contributes !== 'object') return packageJson;
-  const trimmedContributes = { ...contributes };
-  for (const key of CATALOG_DERIVED_CONTRIBUTES) delete trimmedContributes[key];
-  return { ...packageJson, contributes: trimmedContributes };
 }
 
 function verifyRequiredPaths(entries, snapshot, failures) {


### PR DESCRIPTION
## Summary

`scripts/verify-vsix-contents.mjs` currently has a `SyntaxError: Identifier 'CATALOG_DERIVED_CONTRIBUTES' has already been declared` / same for `withoutCatalogDerivedContributes` — **this breaks `check:vsix-contents` (part of the `validate (linux)` CI job) unconditionally on current `main`**, failing CI for every open/future PR regardless of what they touch. Found while investigating an unrelated PR's (#7347) CI failure and confirmed it reproduces on a clean `main` checkout, not just that PR's branch.

## Root cause

#7343 moved `CATALOG_DERIVED_CONTRIBUTES` and `withoutCatalogDerivedContributes` into the shared `scripts/extension-package-utils.mjs` and added the import to `verify-vsix-contents.mjs` — its own commit message states the goal was "single owner, no byte-duplicated copy" — but the diff never deleted the pre-existing local `const CATALOG_DERIVED_CONTRIBUTES = [...]` and local `function withoutCatalogDerivedContributes(...)` in `verify-vsix-contents.mjs`, leaving both the import and the old local declarations. That's a duplicate top-level identifier, which is a hard SyntaxError at module load — the script never even reaches its `main()` logic.

## Fix

Deleted the two now-redundant local declarations (both byte-identical to the imported versions in `extension-package-utils.mjs`), completing the move #7343 intended.

## Verification

- `node --check scripts/verify-vsix-contents.mjs` — clean (was a SyntaxError before)
- `node scripts/verify-vsix-contents.mjs` — now runs past module load to its normal "Missing VSIX artifact ... run npm run build:fast first" message, instead of crashing on import
- `npx eslint scripts/verify-vsix-contents.mjs` — same pre-existing `console`-undefined warnings as before my change (this file isn't part of the project's TS/lint graph for Node globals; unrelated to this fix, diff is deletion-only)
- `npx prettier --check` — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletion-only cleanup with no logic change; restores a CI script that was failing at parse time.
> 
> **Overview**
> **Fixes a hard module-load failure** in `scripts/verify-vsix-contents.mjs` that was breaking `check:vsix-contents` (and the `validate (linux)` CI job) on every branch.
> 
> After #7343 centralized `CATALOG_DERIVED_CONTRIBUTES` and `withoutCatalogDerivedContributes` in `scripts/extension-package-utils.mjs` and wired them in via import, the script still kept identical local `const` and `function` definitions. Node rejects duplicate top-level identifiers, so the verifier never ran.
> 
> This change **deletes only those two redundant local blocks**; behavior stays on the shared imports already used by `assertCatalogContributesShipped` and `verifyManifest`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d61865077bdfadaea4e714bebb3551153a4548f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->