### PR TITLE
refactor: remove GitHub subscription runtime host plumbing

### DIFF
--- a/packages/extension/src/settingsView/handlers/githubSubscriptionHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/githubSubscriptionHandlers.ts
@@ -12,7 +12,6 @@ import {
   showLoggedErrorMessage,
   showLoggedMessage,
 } from '@frontend/ui/errorHandlingUtils';
-import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import {
   getProgressStreamLabel,
   revealProgressStream,
@@ -130,11 +129,11 @@ export class GitHubSubscriptionHandlers {
     const k = data.key;
     let removed: number;
     if (k.includes('/pulls/')) {
-      removed = unbindAllForPR(k, extensionAgentRuntimeHost);
+      removed = unbindAllForPR(k);
     } else if (k.includes('/issues/')) {
-      removed = unbindAllForIssue(k, extensionAgentRuntimeHost);
+      removed = unbindAllForIssue(k);
     } else {
-      removed = unbindAllForRepo(k, extensionAgentRuntimeHost);
+      removed = unbindAllForRepo(k);
     }
     if (removed === 0) {
       void vscode.window.showInformationMessage(

--- a/scripts/verify-vsix-contents.mjs
+++ b/scripts/verify-vsix-contents.mjs
@@ -23,12 +23,6 @@ const snapshotPath = path.join(
   'extension-package-invariants.snapshot.json',
 );
 
-const CATALOG_DERIVED_CONTRIBUTES = [
-  'configuration',
-  'commands',
-  'keybindings',
-];
-
 function defaultVsixPath() {
   const packageJson = readJson(path.join(extensionDir, 'package.json'));
   return path.join(rootDir, 'releases', `texra-${packageJson.version}.vsix`);
@@ -118,14 +112,6 @@ function verifyManifest(vsixPath, snapshot, failures) {
     'VSIX extension/package.json no longer matches the extension manifest snapshot.',
     failures,
   );
-}
-
-function withoutCatalogDerivedContributes(packageJson) {
-  const { contributes } = packageJson;
-  if (!contributes || typeof contributes !== 'object') return packageJson;
-  const trimmedContributes = { ...contributes };
-  for (const key of CATALOG_DERIVED_CONTRIBUTES) delete trimmedContributes[key];
-  return { ...packageJson, contributes: trimmedContributes };
 }
 
 function verifyRequiredPaths(entries, snapshot, failures) {

--- a/src/test-kernel/agent/followUp/GitHubSubscriptionProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/GitHubSubscriptionProgressEvents.vitest.ts
@@ -9,8 +9,6 @@ vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
   sendFollowUp: sendFollowUpMock,
 }));
 
-// Local imports - agent runtime
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
 
@@ -104,9 +102,7 @@ class RegistryTestSource {
   subscribe(
     input: string,
     onEvent: (text: string) => void,
-    runtimeHost: AgentRuntimeHost,
   ): { dispose(): void } {
-    void runtimeHost;
     this.keys.add(input);
     this.onEventByKey.set(input, onEvent);
     this.emitKeysChanged();
@@ -232,12 +228,12 @@ describe('GitHub subscription app signals and follow-ups', () => {
     });
 
     try {
-      registry.bind('stream-a' as StreamTabId, 'owner/repo', host.host);
+      registry.bind('stream-a' as StreamTabId, 'owner/repo');
       host.events.length = 0;
 
-      expect(
-        registry.unbind('stream-a' as StreamTabId, 'owner/repo', host.host),
-      ).toBe(true);
+      expect(registry.unbind('stream-a' as StreamTabId, 'owner/repo')).toBe(
+        true,
+      );
 
       expect(signal.events).toEqual([
         { event: 'repoSubscriptionBindingsChanged', payload: undefined },
@@ -268,7 +264,7 @@ describe('GitHub subscription app signals and follow-ups', () => {
           streamId,
           session,
         }),
-        () => registry.bind(streamId, 'owner/repo', host.host),
+        () => registry.bind(streamId, 'owner/repo'),
       );
 
       source.emit('owner/repo', 'new github event');
@@ -305,7 +301,7 @@ describe('GitHub subscription app signals and follow-ups', () => {
 
     try {
       process.once('unhandledRejection', unhandledRejection);
-      registry.bind(streamId, 'owner/repo', host.host);
+      registry.bind(streamId, 'owner/repo');
 
       source.emit('owner/repo', 'new github event');
       await new Promise((resolve) => setImmediate(resolve));

--- a/src/test-kernel/tools/PRPollingSource.vitest.ts
+++ b/src/test-kernel/tools/PRPollingSource.vitest.ts
@@ -1,9 +1,6 @@
 // Third-party imports
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Local imports - agent
-import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-
 // Local imports - tools
 import {
   DEFAULT_CHECK_ANNOTATION_LEVEL,
@@ -25,10 +22,6 @@ interface AnnotationDrainState {
   pr: { owner: string; repo: string; pullNumber: number };
   slug: string;
   listeners: Set<(text: string) => void>;
-  runtimeHostByListener: Map<
-    (text: string) => void,
-    typeof noopAgentRuntimeHost
-  >;
   annotationLevelByListener: Map<
     (text: string) => void,
     GitHubCheckAnnotationLevel
@@ -53,12 +46,10 @@ interface AnnotationDrainSource {
   subscribe(
     input: PRSubscribeInput,
     onEvent: (text: string) => void,
-    runtimeHost: typeof noopAgentRuntimeHost,
   ): { dispose(): void };
   updateSubscription(
     input: PRSubscribeInput,
     onEvent: (text: string) => void,
-    runtimeHost: typeof noopAgentRuntimeHost,
   ): void;
   getSubscriptionState(key: string): AnnotationDrainState | undefined;
   has(key: string): boolean;
@@ -94,7 +85,6 @@ function createDrainState(runs: GhCheckRun[]): AnnotationDrainState {
     pr: { owner: 'owner', repo: 'repo', pullNumber: 7 },
     slug: 'owner/repo',
     listeners: new Set(),
-    runtimeHostByListener: new Map(),
     annotationLevelByListener: new Map(),
     currentShaState: { pendingAnnotationRuns: runs },
     lastSuccessAt: Date.now(),
@@ -222,7 +212,7 @@ describe('PRPollingSource annotation drain', () => {
     const source = new PRPollingSource() as unknown as AnnotationDrainSource;
     const pr = { owner: 'owner', repo: 'repo', pullNumber: 7 };
     const listener = vi.fn();
-    const disposable = source.subscribe(pr, listener, noopAgentRuntimeHost);
+    const disposable = source.subscribe(pr, listener);
     const key = prKeyToString(pr);
     const state = source.getSubscriptionState(key);
     expect(state).toBeTruthy();
@@ -239,7 +229,6 @@ describe('PRPollingSource annotation drain', () => {
     source.updateSubscription(
       { ...pr, minAnnotationLevel: 'warning' },
       listener,
-      noopAgentRuntimeHost,
     );
     state.currentShaState = { pendingAnnotationRuns: [createCheckRun(14)] };
 

--- a/src/test-kernel/tools/PRPollingSourceAnnotationPages.vitest.ts
+++ b/src/test-kernel/tools/PRPollingSourceAnnotationPages.vitest.ts
@@ -1,9 +1,6 @@
 // Third-party imports
 import { afterEach, describe, expect, it, vi, type Mock } from 'vitest';
 
-// Local imports - agent
-import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-
 // Local imports - tools
 import type { GhCheckAnnotation, GhCheckRun } from '@tools/github/prTypes';
 
@@ -27,10 +24,6 @@ interface AnnotationDrainState {
   pr: { owner: string; repo: string; pullNumber: number };
   slug: string;
   listeners: Set<(text: string) => void>;
-  runtimeHostByListener: Map<
-    (text: string) => void,
-    typeof noopAgentRuntimeHost
-  >;
   annotationLevelByListener: Map<(text: string) => void, 'failure'>;
   currentShaState: CurrentShaState | undefined;
   lastSuccessAt: number;
@@ -100,7 +93,6 @@ function drainState(runs: GhCheckRun[]): AnnotationDrainState {
     pr: { owner: 'owner', repo: 'repo', pullNumber: 7 },
     slug: 'owner/repo',
     listeners: new Set(),
-    runtimeHostByListener: new Map(),
     annotationLevelByListener: new Map(),
     currentShaState: { pendingAnnotationRuns: runs },
     lastSuccessAt: Date.now(),

--- a/src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts
+++ b/src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts
@@ -1,9 +1,6 @@
 // Third-party imports
 import { afterEach, describe, expect, it, vi, type Mock } from 'vitest';
 
-// Local imports - agent
-import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-
 // Local imports - tools
 import type {
   GhCheckRun,
@@ -33,10 +30,6 @@ interface CiStartedState {
   pr: { owner: string; repo: string; pullNumber: number };
   slug: string;
   listeners: Set<(text: string) => void>;
-  runtimeHostByListener: Map<
-    (text: string) => void,
-    typeof noopAgentRuntimeHost
-  >;
   initialized: boolean;
   issueComments: TestDedupedResource<GhIssueComment>;
   reviewComments: TestDedupedResource<GhReviewComment>;
@@ -105,7 +98,6 @@ function createState(
     pr: { owner: 'owner', repo: 'repo', pullNumber: 7 },
     slug: 'owner/repo',
     listeners: new Set([listener]),
-    runtimeHostByListener: new Map([[listener, noopAgentRuntimeHost]]),
     initialized: true,
     issueComments: testDedupedResource(),
     reviewComments: testDedupedResource(),

--- a/src/tools/github/IssuePollingSource.ts
+++ b/src/tools/github/IssuePollingSource.ts
@@ -14,8 +14,6 @@
  * file only owns the per-issue endpoint set and the dedup state.
  */
 
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-
 import { shouldDropBotEvent } from './botFilter';
 import {
   formatIssueClosed,
@@ -92,18 +90,9 @@ class IssuePollingSource extends PollingSourceBase<string, SubscriptionState> {
     });
   }
 
-  subscribe(
-    issue: IssueKey,
-    onEvent: (text: string) => void,
-    runtimeHost: AgentRuntimeHost,
-  ): Disposable {
+  subscribe(issue: IssueKey, onEvent: (text: string) => void): Disposable {
     const key = issueKeyToString(issue);
-    return this.register(
-      key,
-      () => createInitialState(issue),
-      onEvent,
-      runtimeHost,
-    );
+    return this.register(key, () => createInitialState(issue), onEvent);
   }
 
   protected emitKeysChangedEvent(keys: readonly string[]): void {

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -11,7 +11,6 @@
  * layer above.
  */
 
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { getConfig } from '@utils/config';
 import { shouldDropBotEvent } from './botFilter';
 import {
@@ -248,14 +247,12 @@ export class PRPollingSource extends PollingSourceBase<
   subscribe(
     input: PRSubscribeInput,
     onEvent: (text: string) => void,
-    runtimeHost: AgentRuntimeHost,
   ): Disposable {
     const key = prKeyToString(input);
     const disposable = this.register(
       key,
       () => createInitialState(input),
       onEvent,
-      runtimeHost,
     );
     this.setListenerAnnotationLevel(key, onEvent, input);
     return {
@@ -271,7 +268,6 @@ export class PRPollingSource extends PollingSourceBase<
   updateSubscription(
     input: PRSubscribeInput,
     onEvent: (text: string) => void,
-    _runtimeHost: AgentRuntimeHost,
   ): void {
     const key = prKeyToString(input);
     this.setListenerAnnotationLevel(key, onEvent, input);

--- a/src/tools/github/PollingSourceBase.ts
+++ b/src/tools/github/PollingSourceBase.ts
@@ -14,7 +14,6 @@
 import pMap from 'p-map';
 
 import type { AgentTrace } from '@agent/trace';
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { appSignals } from '@eventBus/AppSignals';
 import { createChannelTrace } from '@logger';
 
@@ -187,7 +186,6 @@ export abstract class PollingSourceBase<
     key: K,
     initState: () => S,
     onEvent: (text: string) => void,
-    _runtimeHost: AgentRuntimeHost,
   ): Disposable {
     let state = this.subscriptions.get(key);
     let created = false;

--- a/src/tools/github/RepoPollingSource.ts
+++ b/src/tools/github/RepoPollingSource.ts
@@ -36,8 +36,6 @@
 
 import { LRUCache } from 'lru-cache';
 
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-
 import { shouldDropBotEvent } from './botFilter';
 import {
   formatRepoIssueComment,
@@ -168,15 +166,9 @@ class RepoPollingSource extends PollingSourceBase<RepoKey, SubscriptionState> {
     owner: string,
     repo: string,
     onEvent: (text: string) => void,
-    runtimeHost: AgentRuntimeHost,
   ): Disposable {
     const key = repoKeyOf(owner, repo);
-    return this.register(
-      key,
-      () => createInitialState(owner, repo),
-      onEvent,
-      runtimeHost,
-    );
+    return this.register(key, () => createInitialState(owner, repo), onEvent);
   }
 
   protected emitKeysChangedEvent(keys: readonly RepoKey[]): void {

--- a/src/tools/github/StreamSubscriptionRegistry.ts
+++ b/src/tools/github/StreamSubscriptionRegistry.ts
@@ -14,7 +14,6 @@
 import type { AgentTrace } from '@agent/trace';
 import { sendFollowUp } from '@agent/followUp/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import {
   currentSession,
@@ -34,16 +33,8 @@ export interface SubscriptionBinding<K extends string> {
 
 interface PollingSourceLike<K extends string, Input> {
   has(key: K): boolean;
-  subscribe(
-    input: Input,
-    onEvent: (text: string) => void,
-    runtimeHost: AgentRuntimeHost,
-  ): Disposable;
-  updateSubscription?(
-    input: Input,
-    onEvent: (text: string) => void,
-    runtimeHost: AgentRuntimeHost,
-  ): void;
+  subscribe(input: Input, onEvent: (text: string) => void): Disposable;
+  updateSubscription?(input: Input, onEvent: (text: string) => void): void;
   activeKeys(): readonly K[];
   onKeysChanged(listener: (keys: readonly K[]) => void): Disposable;
 }
@@ -94,11 +85,7 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
   }
 
   /** Returns true if a new subscription was created, false if it already existed. */
-  bind(
-    streamId: StreamTabId,
-    input: Input,
-    runtimeHost: AgentRuntimeHost,
-  ): boolean {
+  bind(streamId: StreamTabId, input: Input): boolean {
     const key = this.opts.keyOf(input);
     // Capture the session HERE: bind() runs inside the run's AsyncLocalStorage
     // (the github tool's execute()), but onEvent fires later from a detached
@@ -113,11 +100,7 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
     const existing = bound.get(key);
     if (existing) {
       existing.session = session;
-      this.opts.source.updateSubscription?.(
-        input,
-        existing.onEvent,
-        runtimeHost,
-      );
+      this.opts.source.updateSubscription?.(input, existing.onEvent);
       return false;
     }
     // Set a sentinel before subscribe() so list() returns correct owner
@@ -158,11 +141,7 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
     const keyIsNew = !this.opts.source.has(key);
     let disposable: Disposable;
     try {
-      disposable = this.opts.source.subscribe(
-        input,
-        subscription.onEvent,
-        runtimeHost,
-      );
+      disposable = this.opts.source.subscribe(input, subscription.onEvent);
     } catch (err) {
       this.removeBoundKey(streamId, bound, key);
       throw err;
@@ -174,11 +153,7 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
   }
 
   /** Returns true if a subscription existed and was removed. */
-  unbind(
-    streamId: StreamTabId,
-    input: Input,
-    _runtimeHost: AgentRuntimeHost,
-  ): boolean {
+  unbind(streamId: StreamTabId, input: Input): boolean {
     const key = this.opts.keyOf(input);
     const bound = this.perStream.get(streamId);
     const binding = bound?.get(key);
@@ -194,7 +169,7 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
    * bindings removed. Lets the settings UI cancel a subscription globally
    * without needing to know which stream owns it.
    */
-  unbindAll(key: string, _runtimeHost: AgentRuntimeHost): number {
+  unbindAll(key: string): number {
     const removedBindings: BoundSubscription[] = [];
     for (const [streamId, bound] of [...this.perStream]) {
       const binding = bound.get(key as K);

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -158,12 +158,12 @@ async function execSubscribe(
   input: GitHubSubscriptionInput,
 ): Promise<ToolResult> {
   await requireToken();
-  const { streamId, runtimeHost } = requireRunStream('github_subscription');
+  const { streamId } = requireRunStream('github_subscription');
   const target = requirePath(input);
   const minAnnotationLevel =
     input.min_annotation_level ?? DEFAULT_CHECK_ANNOTATION_LEVEL;
   if (target.kind === 'repo') {
-    const created = bindRepoSubscription(streamId, target, runtimeHost);
+    const created = bindRepoSubscription(streamId, target);
     const slug = `${target.owner}/${target.repo}`;
     return {
       status: 'executed',
@@ -176,14 +176,10 @@ async function execSubscribe(
     };
   }
   if (target.kind === 'pr') {
-    const created = bindPRSubscription(
-      streamId,
-      {
-        ...target,
-        minAnnotationLevel,
-      },
-      runtimeHost,
-    );
+    const created = bindPRSubscription(streamId, {
+      ...target,
+      minAnnotationLevel,
+    });
     const slug = `${target.owner}/${target.repo}/pulls/${target.pullNumber}`;
     const annotationLevelDescription =
       ANNOTATION_LEVEL_DESCRIPTIONS[minAnnotationLevel];
@@ -217,16 +213,12 @@ async function execSubscribe(
       (await resolveIssueIsPR(target.owner, target.repo, target.issueNumber)));
 
   if (isPR) {
-    const created = bindPRSubscription(
-      streamId,
-      {
-        owner: target.owner,
-        repo: target.repo,
-        pullNumber: target.issueNumber,
-        minAnnotationLevel,
-      },
-      runtimeHost,
-    );
+    const created = bindPRSubscription(streamId, {
+      owner: target.owner,
+      repo: target.repo,
+      pullNumber: target.issueNumber,
+      minAnnotationLevel,
+    });
     const wasIssuePath = !knownPR;
     const annotationLevelDescription =
       ANNOTATION_LEVEL_DESCRIPTIONS[minAnnotationLevel];
@@ -242,7 +234,7 @@ async function execSubscribe(
         : `Already subscribed to ${prSlug}. Inline check annotation filter is now ${annotationLevelDescription}.`,
     };
   }
-  const created = bindIssueSubscription(streamId, target, runtimeHost);
+  const created = bindIssueSubscription(streamId, target);
   return {
     status: 'executed',
     summary: created
@@ -275,10 +267,10 @@ async function resolveIssueIsPR(
 }
 
 function execUnsubscribe(input: GitHubSubscriptionInput): ToolResult {
-  const { streamId, runtimeHost } = requireRunStream('github_subscription');
+  const { streamId } = requireRunStream('github_subscription');
   const target = requirePath(input);
   if (target.kind === 'repo') {
-    const removed = unbindRepoSubscription(streamId, target, runtimeHost);
+    const removed = unbindRepoSubscription(streamId, target);
     const slug = `${target.owner}/${target.repo}`;
     return {
       status: 'executed',
@@ -288,7 +280,7 @@ function execUnsubscribe(input: GitHubSubscriptionInput): ToolResult {
     };
   }
   if (target.kind === 'pr') {
-    const removed = unbindPRSubscription(streamId, target, runtimeHost);
+    const removed = unbindPRSubscription(streamId, target);
     const slug = `${target.owner}/${target.repo}/pulls/${target.pullNumber}`;
     return {
       status: 'executed',
@@ -299,16 +291,12 @@ function execUnsubscribe(input: GitHubSubscriptionInput): ToolResult {
   }
   // Symmetric to subscribe: a /issues/N path may have been re-routed to a
   // PR subscription. Try both — whichever owns it wins.
-  const issueRemoved = unbindIssueSubscription(streamId, target, runtimeHost);
-  const prRemoved = unbindPRSubscription(
-    streamId,
-    {
-      owner: target.owner,
-      repo: target.repo,
-      pullNumber: target.issueNumber,
-    },
-    runtimeHost,
-  );
+  const issueRemoved = unbindIssueSubscription(streamId, target);
+  const prRemoved = unbindPRSubscription(streamId, {
+    owner: target.owner,
+    repo: target.repo,
+    pullNumber: target.issueNumber,
+  });
   const slug = `${target.owner}/${target.repo}/issues/${target.issueNumber}`;
   return {
     status: 'executed',

--- a/src/tools/github/subscriptionBindings.ts
+++ b/src/tools/github/subscriptionBindings.ts
@@ -1,4 +1,3 @@
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { StreamTabId } from '@shared/schemas';
 
 import {
@@ -42,24 +41,19 @@ export function listPRSubscriptionBindings(
 export function bindPRSubscription(
   streamId: StreamTabId,
   pr: PRSubscribeInput,
-  runtimeHost: AgentRuntimeHost,
 ): boolean {
-  return prSubscriptions.bind(streamId, pr, runtimeHost);
+  return prSubscriptions.bind(streamId, pr);
 }
 
 export function unbindPRSubscription(
   streamId: StreamTabId,
   pr: PRSubscribeInput,
-  runtimeHost: AgentRuntimeHost,
 ): boolean {
-  return prSubscriptions.unbind(streamId, pr, runtimeHost);
+  return prSubscriptions.unbind(streamId, pr);
 }
 
-export function unbindAllForPR(
-  key: string,
-  runtimeHost: AgentRuntimeHost,
-): number {
-  return prSubscriptions.unbindAll(key, runtimeHost);
+export function unbindAllForPR(key: string): number {
+  return prSubscriptions.unbindAll(key);
 }
 
 export interface RepoBindInput {
@@ -76,13 +70,8 @@ const repoSubscriptions = new StreamSubscriptionRegistry<
     has: (key) => repoPollingSource.has(key),
     activeKeys: () => repoPollingSource.activeKeys(),
     onKeysChanged: (listener) => repoPollingSource.onKeysChanged(listener),
-    subscribe: (input, listener, runtimeHost) =>
-      repoPollingSource.subscribe(
-        input.owner,
-        input.repo,
-        listener,
-        runtimeHost,
-      ),
+    subscribe: (input, listener) =>
+      repoPollingSource.subscribe(input.owner, input.repo, listener),
   },
   keyOf: (input) => repoKeyOf(input.owner, input.repo),
   bindingsChangedEvent: 'repoSubscriptionBindingsChanged',
@@ -99,24 +88,19 @@ export function listRepoSubscriptionBindings(
 export function bindRepoSubscription(
   streamId: StreamTabId,
   input: RepoBindInput,
-  runtimeHost: AgentRuntimeHost,
 ): boolean {
-  return repoSubscriptions.bind(streamId, input, runtimeHost);
+  return repoSubscriptions.bind(streamId, input);
 }
 
 export function unbindRepoSubscription(
   streamId: StreamTabId,
   input: RepoBindInput,
-  runtimeHost: AgentRuntimeHost,
 ): boolean {
-  return repoSubscriptions.unbind(streamId, input, runtimeHost);
+  return repoSubscriptions.unbind(streamId, input);
 }
 
-export function unbindAllForRepo(
-  key: string,
-  runtimeHost: AgentRuntimeHost,
-): number {
-  return repoSubscriptions.unbindAll(key, runtimeHost);
+export function unbindAllForRepo(key: string): number {
+  return repoSubscriptions.unbindAll(key);
 }
 
 const issueSubscriptions = new StreamSubscriptionRegistry<string, IssueKey>({
@@ -125,8 +109,8 @@ const issueSubscriptions = new StreamSubscriptionRegistry<string, IssueKey>({
     has: (key) => issuePollingSource.has(key),
     activeKeys: () => issuePollingSource.activeKeys(),
     onKeysChanged: (listener) => issuePollingSource.onKeysChanged(listener),
-    subscribe: (input, listener, runtimeHost) =>
-      issuePollingSource.subscribe(input, listener, runtimeHost),
+    subscribe: (input, listener) =>
+      issuePollingSource.subscribe(input, listener),
   },
   keyOf: issueKeyToString,
   bindingsChangedEvent: 'issueSubscriptionBindingsChanged',
@@ -143,22 +127,17 @@ export function listIssueSubscriptionBindings(
 export function bindIssueSubscription(
   streamId: StreamTabId,
   issue: IssueKey,
-  runtimeHost: AgentRuntimeHost,
 ): boolean {
-  return issueSubscriptions.bind(streamId, issue, runtimeHost);
+  return issueSubscriptions.bind(streamId, issue);
 }
 
 export function unbindIssueSubscription(
   streamId: StreamTabId,
   issue: IssueKey,
-  runtimeHost: AgentRuntimeHost,
 ): boolean {
-  return issueSubscriptions.unbind(streamId, issue, runtimeHost);
+  return issueSubscriptions.unbind(streamId, issue);
 }
 
-export function unbindAllForIssue(
-  key: string,
-  runtimeHost: AgentRuntimeHost,
-): number {
-  return issueSubscriptions.unbindAll(key, runtimeHost);
+export function unbindAllForIssue(key: string): number {
+  return issueSubscriptions.unbindAll(key);
 }


### PR DESCRIPTION
## Summary

- Remove the unused `AgentRuntimeHost` parameter from GitHub polling-source registration and stream subscription binding APIs.
- Update the GitHub subscription tool and settings unsubscribe handlers to bind and unbind by stream/session state alone.
- Remove stale test-only `runtimeHostByListener` state from PR polling harnesses.

The semantic dependency that remains is the bind-time `SessionHandle` captured by `StreamSubscriptionRegistry`; detached poller callbacks still pass that session to `sendFollowUp` so follow-ups are delivered to the correct runtime session.

Fixes part of #6968.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/agent/followUp/GitHubSubscriptionProgressEvents.vitest.ts src/test-kernel/tools/PRPollingSource.vitest.ts src/test-kernel/tools/PRPollingSourceAnnotationPages.vitest.ts src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `corepack pnpm exec eslint packages/extension/src/settingsView/handlers/githubSubscriptionHandlers.ts src/test-kernel/agent/followUp/GitHubSubscriptionProgressEvents.vitest.ts src/test-kernel/tools/PRPollingSource.vitest.ts src/test-kernel/tools/PRPollingSourceAnnotationPages.vitest.ts src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts src/tools/github/IssuePollingSource.ts src/tools/github/PRPollingSource.ts src/tools/github/PollingSourceBase.ts src/tools/github/RepoPollingSource.ts src/tools/github/StreamSubscriptionRegistry.ts src/tools/github/githubSubscriptionTool.ts src/tools/github/subscriptionBindings.ts`
- `corepack pnpm run compile:fast`
- `corepack pnpm run lint` (0 errors; two pre-existing import-order warnings outside this change)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> API-only cleanup with no new auth or data paths; follow-ups still use bind-time session capture, covered by existing tests.
> 
> **Overview**
> Removes the unused **`AgentRuntimeHost`** argument from GitHub polling sources, **`StreamSubscriptionRegistry`**, **`subscriptionBindings`**, the **`github_subscription`** tool, and settings **unsubscribe** handlers. Subscribe/bind/unbind now take stream (and input) only; callers no longer pass **`extensionAgentRuntimeHost`**.
> 
> **Follow-up delivery is unchanged in intent:** **`StreamSubscriptionRegistry`** still captures **`SessionHandle`** at bind time (inside run context) and passes it to **`sendFollowUp`** when poller callbacks fire off the timer. Tests drop **`runtimeHostByListener`** / **`noopAgentRuntimeHost`** and assert bind-time session routing.
> 
> The VSIX verify script drops duplicated catalog-contribute helpers in favor of shared **`extension-package-utils.mjs`** (per repo snapshot; not part of the subscription behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e94478f1d033f76961042665b85ad6760e4c4692. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->