### PR TITLE
refactor(modelHandlers): fold supportsTokenCounting into a capability-profile read

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -1500,10 +1500,16 @@ export abstract class ModelHandler<
 
   /**
    * Whether this handler supports native token counting via API.
-   * Override in subclasses that have token counting capability.
+   *
+   * Defaults to the llm-zoo `supportsTokenCounting` capability flag (#7101:
+   * pure-data predicate, read from the profile rather than overridden per
+   * handler). Override only when the effective value comes from somewhere
+   * other than `this.capabilities` — e.g. a provider-specific capabilities
+   * lookup, or a hardcoded value where the API is universally available
+   * regardless of the model's llm-zoo flag.
    */
   get supportsTokenCounting(): boolean {
-    return false;
+    return this.capabilities.supportsTokenCounting;
   }
 
   /**

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -259,11 +259,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
     return true;
   }
 
-  // supportsTokenCounting (Anthropic's countTokens endpoint for exact
-  // pre-flight counts) is now the base class's default: it reads the
-  // llm-zoo `supportsTokenCounting` capability flag directly, so this
-  // handler no longer needs to re-forward it (#7101).
-
   /**
    * Estimates token count using Anthropic's native countTokens API.
    *

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -259,13 +259,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
     return true;
   }
 
-  /**
-   * Whether this handler supports native token counting via API.
-   * Uses Anthropic's countTokens endpoint for exact pre-flight counts.
-   */
-  override get supportsTokenCounting(): boolean {
-    return this.capabilities.supportsTokenCounting;
-  }
+  // supportsTokenCounting (Anthropic's countTokens endpoint for exact
+  // pre-flight counts) is now the base class's default: it reads the
+  // llm-zoo `supportsTokenCounting` capability flag directly, so this
+  // handler no longer needs to re-forward it (#7101).
 
   /**
    * Estimates token count using Anthropic's native countTokens API.

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -184,13 +184,10 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     });
   }
 
-  /**
-   * Whether this handler supports native token counting.
-   * Uses Google's countTokens endpoint for exact pre-flight counts.
-   */
-  override get supportsTokenCounting(): boolean {
-    return this.capabilities.supportsTokenCounting;
-  }
+  // supportsTokenCounting (Google's countTokens endpoint for exact
+  // pre-flight counts) is now the base class's default: it reads the
+  // llm-zoo `supportsTokenCounting` capability flag directly, so this
+  // handler no longer needs to re-forward it (#7101).
 
   /**
    * Gemini carries thought signatures across parallel function calls, which must

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -184,11 +184,6 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     });
   }
 
-  // supportsTokenCounting (Google's countTokens endpoint for exact
-  // pre-flight counts) is now the base class's default: it reads the
-  // llm-zoo `supportsTokenCounting` capability flag directly, so this
-  // handler no longer needs to re-forward it (#7101).
-
   /**
    * Gemini carries thought signatures across parallel function calls, which must
    * be preserved by batching the results into a single follow-up message.

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -557,11 +557,6 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
     });
   }
 
-  // supportsTokenCounting (Google's countTokens endpoint for exact
-  // pre-flight counts) is now the base class's default: it reads the
-  // llm-zoo `supportsTokenCounting` capability flag directly, so this
-  // handler no longer needs to re-forward it (#7101).
-
   /**
    * The handler implements client-side compaction (see `compactConversation`),
    * so manual (user-requested) compaction is supported. Always true: the

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -557,9 +557,10 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
     });
   }
 
-  override get supportsTokenCounting(): boolean {
-    return this.capabilities.supportsTokenCounting;
-  }
+  // supportsTokenCounting (Google's countTokens endpoint for exact
+  // pre-flight counts) is now the base class's default: it reads the
+  // llm-zoo `supportsTokenCounting` capability flag directly, so this
+  // handler no longer needs to re-forward it (#7101).
 
   /**
    * The handler implements client-side compaction (see `compactConversation`),


### PR DESCRIPTION
## Root cause

#7101 tracks folding the ~28 individually-overridable `ModelHandler` base
predicates into capability-profile reads, triaged one bounded cluster per PR
(mirroring the just-merged #7346, which handled the provider-identity
cluster).

This PR handles the `supportsTokenCounting` cluster. `ModelHandlerAnthropic`,
`ModelHandlerGoogleGenAI`, and `ModelHandlerGoogleInteractions` each carried
an identical one-line override:

```ts
override get supportsTokenCounting(): boolean {
  return this.capabilities.supportsTokenCounting;
}
```

This did nothing but forward the llm-zoo `supportsTokenCounting` capability
flag the base class already has on `this.capabilities` — a pure-data
predicate per the #7101 triage. The base class's own getter hardcoded
`false` instead of reading it, so three handlers each had to re-declare the
same forwarding override just to unhardcode the default.

## Fix

- Base `ModelHandler.supportsTokenCounting` now defaults to
  `this.capabilities.supportsTokenCounting` (the profile read) instead of a
  hardcoded `false`.
- Deleted the three now-redundant overrides in `ModelHandlerAnthropic`,
  `ModelHandlerGoogleGenAI`, and `ModelHandlerGoogleInteractions`.
- Left `ModelHandlerKimi` (hardcoded `true`) and `ModelHandlerOpenAIResponse`
  (reads from `getOpenAIResponseCapabilities()`, a different source) alone —
  both compute the flag from something other than `this.capabilities`, so
  they're genuinely-per-provider overrides, not pure-data duplication.

**No behavior change.** Checked llm-zoo's published model data directly:
`supportsTokenCounting: true` is only set in `ANTHROPIC_DEFAULT_CAPABILITIES`;
every other provider (Google included) inherits `false` from
`DEFAULT_MODEL_CAPABILITIES` and never overrides it. So:
- Anthropic/Google: effective value unchanged (their overrides already just
  forwarded this same field).
- Every other provider without an override: effective value unchanged
  (`false`, same as the old hardcoded base default, since none of them set
  the flag to `true` in llm-zoo).

## Scope

Per the issue, this is intentionally one bounded cluster, not the whole
predicate census. Remaining clusters (`shouldUseServerSideKeys` combinators,
`supportsManualCompaction`, `supportsToolResultFileUpload`,
`canProcessToolResultAttachments`, etc.) are left for follow-up PRs — this
does not close #7101.

## Verification

```
npx tsc --noEmit
# clean

npx eslint src/agent/modelHandlers/ModelHandler.ts \
  src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts \
  src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts \
  src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
# clean

npx vitest run src/test-kernel/modelHandlers src/test-kernel/agent/modelHandlers
# Test Files  48 passed | 1 skipped (49)
# Tests  405 passed | 4 skipped (409)

npx vitest run src/test-kernel/model/ProviderCapabilities.vitest.ts \
  src/test-kernel/agent/modelHandlers/ModelHandlerDeepSeek.vitest.ts \
  src/test-kernel/agent/modelHandlers/ModelHandlerOpenRouterNative.vitest.ts \
  src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
# Test Files  4 passed (4)
# Tests  48 passed (48)

npx prettier --check <changed files>
# All matched files use Prettier code style!
```

Part of #7101.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of a predicate default with no intended behavior change; token preflight still gated by the same capability flag and existing handler-specific skips (e.g. Anthropic file sources).
> 
> **Overview**
> Part of **#7101**: the base `ModelHandler.supportsTokenCounting` getter now reads **`this.capabilities.supportsTokenCounting`** (llm-zoo profile) instead of always returning `false`, with docs on when subclasses should still override.
> 
> **Removed** three identical forwarding overrides in `ModelHandlerAnthropic`, `ModelHandlerGoogleGenAI`, and `ModelHandlerGoogleInteractions` that only duplicated that read. Handlers like Kimi and OpenAI Response that derive the flag from another source are unchanged.
> 
> **No intended runtime change** — providers that already forwarded the profile behave the same; others stay off unless llm-zoo sets the flag (e.g. Anthropic).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8640b49cd1746e93a2c6a6d64cdf069ab5050f92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->