### PR TITLE
refactor: route desktop progress events directly

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -47,7 +47,7 @@ import {
   type ListableFileType,
 } from '@common/files/fileListingRules';
 import { listWorkspaceFiles } from '@common/files/workspaceFileListing';
-import { bus, type ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import type { DiffViewHost, ExternalOpener } from '@hosts/uiHosts';
 import { createChannelTrace } from '@logger';
 import type { MainViewExecuteMessage } from '@shared/mainView';
@@ -327,7 +327,7 @@ export class DesktopProgressBridge {
         void this.options.showErrorMessage?.(message);
       },
     });
-    const backendSubscription = this.backend.setupEventListeners(bus);
+    const backendSubscription = this.backend.setupEventListeners();
     this.restartRepair = this.repairOrphanedStreamsAfterRestart();
     // Onboarding funnel (PRD: agent-native onboarding): a completed run ends
     // State 1. `AgentRunLifecycle` persists `firstRunDone` BEFORE it emits the
@@ -1012,7 +1012,7 @@ export class DesktopProgressBridge {
     event: K,
     payload: ProgressEventPayloads[K],
   ): void {
-    bus.emit(event, payload);
+    this.backend.handleProgressEvent(event, payload);
     this.progressEvents.onProgressEvent(event, payload);
   }
 

--- a/packages/desktop/src/main/desktopProgressEventBridge.ts
+++ b/packages/desktop/src/main/desktopProgressEventBridge.ts
@@ -82,9 +82,8 @@ export interface DesktopProgressEventBridge {
    * Handle a progress event emitted through the runtime host.
    *
    * Applies the desktop-specific rail update (persist snapshot, remove ghost,
-   * route-to-progress). Ordinary runtime-host events are also published to the
-   * process bus by the owning bridge; session-projected facts call this through
-   * a window-local path instead.
+   * route-to-progress, show root errors) for events delivered through the
+   * owning window's runtime host or session projection path.
    */
   onProgressEvent<K extends keyof ProgressEventPayloads>(
     event: K,
@@ -259,6 +258,14 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
           status: goal?.status,
           objective: goal?.objective,
         });
+        return;
+      }
+      case 'requestEnsureProgressView':
+        this.opts.routeToProgress();
+        return;
+      case 'requestShowError': {
+        const data = payload as ProgressEventPayloads['requestShowError'];
+        this.opts.onShowError(data.message);
         return;
       }
       default:

--- a/src/shared/progressView/backend/ProgressBackend.ts
+++ b/src/shared/progressView/backend/ProgressBackend.ts
@@ -167,8 +167,10 @@ export class ProgressBackend {
     await this.state.load();
   }
 
-  setupEventListeners(bus: ProgressEventBusLike): ProgressEventSubscription {
-    const busSubscription = this.eventHandler.setupEventListeners(bus);
+  setupEventListeners(bus?: ProgressEventBusLike): ProgressEventSubscription {
+    const busSubscription = bus
+      ? this.eventHandler.setupEventListeners(bus)
+      : undefined;
     const localSubscription = this.eventHandler.setupEventListeners(
       this.localEvents,
     );
@@ -200,7 +202,7 @@ export class ProgressBackend {
         detachRunFacts();
         detachSessionFacts();
         localSubscription.dispose();
-        busSubscription.dispose();
+        busSubscription?.dispose();
       },
     };
   }

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -156,6 +156,7 @@ interface DesktopAgentExecutionModule {
     options?: {
       streamSnapshotStore?: TestDesktopStreamSnapshotStore;
       progressSnapshotStore?: ProgressSnapshotStore;
+      showErrorMessage?: (message: string) => Promise<void> | void;
     },
   ) => Bridge;
   createDesktopAgentExecution(options: {
@@ -181,6 +182,7 @@ type CreateBridgeOptions = {
   configureProgressSnapshotStore?: (store: ProgressSnapshotStore) => void;
   detectWaitingStreams?: ReturnType<typeof vi.fn>;
   activeExecutionIds?: readonly string[] | (() => readonly string[]);
+  showErrorMessage?: (message: string) => Promise<void> | void;
 };
 
 type TestDesktopStreamSnapshotStore = {
@@ -399,6 +401,7 @@ async function createBridge(
   return new DesktopProgressBridge((message) => messages.push(message), {
     streamSnapshotStore: options.streamSnapshotStore,
     progressSnapshotStore,
+    showErrorMessage: options.showErrorMessage,
   }) as TestableBridge;
 }
 
@@ -572,23 +575,55 @@ describe('DesktopProgressBridge', () => {
     vi.restoreAllMocks();
   });
 
-  it('mirrors runtime events to the shared progress bus', async () => {
+  it('routes runtime events to the desktop backend without the shared progress bus', async () => {
     const messages: unknown[] = [];
     const bridge = await createBridge(messages);
     const { bus } = await import('@eventBus/ProgressEventBus');
     const seen: unknown[] = [];
-    const off = bus.on('updateTodos', (payload) => {
+    const off = bus.on('setActiveStream', (payload) => {
       seen.push(payload);
     });
 
     try {
-      bridge.handleProgressEvent('updateTodos', {
+      bridge.handleProgressEvent('setActiveStream', {
         streamId: 'parent',
-        todos: [],
+        agentCategory: AgentCategory.Workflow,
       });
-      expect(seen).toEqual([{ streamId: 'parent', todos: [] }]);
+      await settleProgressEvents();
+      bridge.syncFullView();
+
+      expect(seen).toEqual([]);
+      expect(
+        progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS).at(
+          -1,
+        ),
+      ).toMatchObject({
+        activeStream: 'parent',
+        streams: [expect.objectContaining({ name: 'parent' })],
+      });
     } finally {
       off();
+      bridge.dispose();
+    }
+  });
+
+  it('keeps desktop runtime host app events on the window-local bridge path', async () => {
+    const messages: unknown[] = [];
+    const showErrorMessage = vi.fn();
+    const bridge = await createBridge(messages, { showErrorMessage });
+
+    try {
+      bridge.handleProgressEvent('requestEnsureProgressView', {});
+      bridge.handleProgressEvent('requestShowError', {
+        message: 'Root run failed',
+      });
+
+      expect(messages).toContainEqual({
+        command: DESKTOP_SHELL_COMMANDS.SET_ROUTE,
+        route: 'progress',
+      });
+      expect(showErrorMessage).toHaveBeenCalledWith('Root run failed');
+    } finally {
       bridge.dispose();
     }
   });

--- a/src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts
@@ -517,6 +517,34 @@ describe('DesktopProgressEventBridge', () => {
         bridge.dispose();
       }
     });
+
+    it('routes window-local ensure-progress requests from runtime-host events', () => {
+      const routeToProgress = vi.fn();
+      const bridge = createBridge({ routeToProgress });
+
+      try {
+        bridge.onProgressEvent('requestEnsureProgressView', {});
+
+        expect(routeToProgress).toHaveBeenCalledTimes(1);
+      } finally {
+        bridge.dispose();
+      }
+    });
+
+    it('routes window-local error requests from runtime-host events', () => {
+      const onShowError = vi.fn();
+      const bridge = createBridge({ onShowError });
+
+      try {
+        bridge.onProgressEvent('requestShowError', {
+          message: 'Root run failed',
+        });
+
+        expect(onShowError).toHaveBeenCalledWith('Root run failed');
+      } finally {
+        bridge.dispose();
+      }
+    });
   });
 
   // ── Process-bus events ──────────────────────────────────────────────────

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -201,6 +201,25 @@ describe('ProgressBackend', () => {
     backend.dispose();
   });
 
+  it('handles local progress events without an external process bus', () => {
+    const { backend } = createIsolatedRecordingBackend();
+    const subscription = backend.setupEventListeners();
+    const streamId = 'desktop-local-stream' as StreamTabId;
+
+    try {
+      backend.handleProgressEvent('setActiveStream', {
+        streamId,
+        agentCategory: AgentCategory.Workflow,
+      });
+
+      expect(backend.state.activeStream).toBe(streamId);
+      expect(backend.state.streamLogs.has(streamId)).toBe(true);
+    } finally {
+      subscription.dispose();
+      backend.dispose();
+    }
+  });
+
   it('uses the injected target predicate before sending messages', () => {
     const sent = vi.fn(() => true);
     let hasTarget = false;


### PR DESCRIPTION
## Summary

This PR switches the desktop progress runtime path from process-wide `ProgressEventBus` fan-out to direct delivery into the desktop progress backend.

The shared `ProgressBackend` can now be attached without an external process bus. It still subscribes to its local event bus and session-fact projections, while extension callers may continue to pass the existing bus until that boundary is moved in a later Stage 5 slice.

## Why

The desktop shell has a window-local progress backend. Emitting every desktop runtime progress event onto the process-wide bus makes that backend depend on global fan-out, which is the wrong ownership boundary for the session-scoped runtime architecture. Direct delivery keeps desktop progress state local to the owning bridge, while preserving snapshot persistence and desktop app events through `createDesktopProgressEventBridge`.

## Changes

- Made `ProgressBackend.setupEventListeners` accept no external bus.
- Changed `DesktopProgressBridge` to call `backend.setupEventListeners()` without `ProgressEventBus`.
- Routed desktop runtime progress events directly through `backend.handleProgressEvent(...)` and then the desktop snapshot/event bridge.
- Preserved window-local handling for `requestEnsureProgressView` and `requestShowError` on the direct runtime-host path.
- Replaced the old desktop bus-mirroring test with an invariant that desktop events do not re-emit on the shared bus but still update local progress state.
- Added shared-backend, desktop bridge, and desktop entry tests for local progress/app-event handling without external process-bus fan-out.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts src/test-kernel/progressView/SessionRunFactProjectorEquivalence.vitest.ts src/test-kernel/progressView/LegacyProgressEventProjection.vitest.ts src/test-kernel/agent/runtime/EmitRuntimeEvent.vitest.ts`
- `corepack pnpm exec vitest run src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `corepack pnpm exec prettier --write packages/desktop/src/main/desktopAgentExecution.ts packages/desktop/src/main/desktopProgressEventBridge.ts src/shared/progressView/backend/ProgressBackend.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `corepack pnpm exec eslint packages/desktop/src/main/desktopAgentExecution.ts packages/desktop/src/main/desktopProgressEventBridge.ts src/shared/progressView/backend/ProgressBackend.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `git diff --check`
- `corepack pnpm run compile:fast`
- `corepack pnpm run lint` (0 errors; the two existing unrelated import-order warnings remain)
- `corepack pnpm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This changes how desktop progress events are wired (routing, UI navigation, and error surfacing) across the runtime host and bridge; behavior is covered by new/updated tests but touches core progress update paths.
> 
> **Overview**
> **Desktop progress no longer fans runtime events through the process-wide `ProgressEventBus`.** The owning bridge calls `ProgressBackend.handleProgressEvent` directly, and `setupEventListeners()` runs without attaching the shared bus (extension callers can still pass it).
> 
> `ProgressBackend.setupEventListeners` now treats an external bus as optional; session/run fact subscriptions and the internal local event bus remain the path that updates progress state when no process bus is wired.
> 
> `DesktopProgressEventBridge` handles **`requestEnsureProgressView`** and **`requestShowError`** on the window-local `onProgressEvent` path (route to progress, show root errors), while it still listens on the process bus for those two events when they are emitted without an active runtime host.
> 
> Tests assert desktop events do not re-emit on the shared bus but still update local UI state, and cover the new bridge routing for ensure-progress and show-error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f7a530595ba00e95f154c5c99280df1dd548c60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->