### PR TITLE
refactor: move progress bus to extension boundary

### DIFF
--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -54,6 +54,7 @@ import {
 
 import { ProgressViewMessageHandler } from './ProgressViewMessageHandler';
 import { createExtensionHostInteractions } from './extensionHostInteractions';
+import { attachProgressBackendProcessBus } from './progressBackendProcessBus';
 
 import type { MainViewProvider } from '../MainViewProvider';
 
@@ -197,7 +198,10 @@ export class ProgressViewProvider
 
   public async initialize(): Promise<void> {
     await this.backend.load();
-    this._disposables.push(this.backend.setupEventListeners(bus));
+    this._disposables.push(
+      this.backend.setupEventListeners(),
+      attachProgressBackendProcessBus(this.backend, bus),
+    );
     this.logger.debug('ProgressViewProvider initialized');
   }
 

--- a/packages/extension/src/progressView/progressBackendProcessBus.ts
+++ b/packages/extension/src/progressView/progressBackendProcessBus.ts
@@ -1,0 +1,15 @@
+import type { ProgressEventBusLike } from '@eventBus/ProgressEventBus';
+import type { ProgressBackend } from '@shared/progressView/backend/ProgressBackend';
+import type { ProgressEventSubscription } from '@shared/progressView/backend/events/ProgressEventHandler';
+
+/**
+ * Attach the VS Code extension's legacy process bus to the shared progress
+ * backend. This is an extension boundary adapter: the backend itself remains
+ * local/session-scoped.
+ */
+export function attachProgressBackendProcessBus(
+  backend: Pick<ProgressBackend, 'eventHandler'>,
+  bus: ProgressEventBusLike,
+): ProgressEventSubscription {
+  return backend.eventHandler.setupEventListeners(bus);
+}

--- a/src/shared/progressView/backend/ProgressBackend.ts
+++ b/src/shared/progressView/backend/ProgressBackend.ts
@@ -9,7 +9,6 @@ import {
 } from '@agent/runtime/sessionProgressEventProjection';
 import type {
   ProgressEvent,
-  ProgressEventBusLike,
   ProgressEventPayloads,
 } from '@eventBus/ProgressEventBus';
 import {
@@ -66,7 +65,7 @@ type SessionProgressEventObserver = <K extends ProgressEvent>(
   payload: ProgressEventPayloads[K],
 ) => void;
 
-class LocalProgressEventBus implements ProgressEventBusLike {
+class LocalProgressEventBus {
   private readonly listeners = new Map<
     ProgressEvent,
     Set<(payload: ProgressEventPayloads[ProgressEvent]) => void>
@@ -109,7 +108,7 @@ class LocalProgressEventBus implements ProgressEventBusLike {
  * Host-neutral progress-view backend composition.
  *
  * Hosts provide only storage, transport, and UI callbacks. The state manager,
- * message builders, log bridge, and event bus subscriber are constructed as one
+ * message builders, log bridge, and local/session event handler are constructed as one
  * graph so extension and desktop can converge on the same backend boundary.
  */
 export class ProgressBackend {
@@ -167,10 +166,7 @@ export class ProgressBackend {
     await this.state.load();
   }
 
-  setupEventListeners(bus?: ProgressEventBusLike): ProgressEventSubscription {
-    const busSubscription = bus
-      ? this.eventHandler.setupEventListeners(bus)
-      : undefined;
+  setupEventListeners(): ProgressEventSubscription {
     const localSubscription = this.eventHandler.setupEventListeners(
       this.localEvents,
     );
@@ -202,7 +198,6 @@ export class ProgressBackend {
         detachRunFacts();
         detachSessionFacts();
         localSubscription.dispose();
-        busSubscription?.dispose();
       },
     };
   }

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -12,9 +12,7 @@ import { getExecutionStore } from '@agent/storage';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { TaskState } from '@agent/core/state/TaskState';
 import {
-  bus,
   type ProgressEvent,
-  type ProgressEventBusLike,
   type ProgressEventPayloads,
 } from '@eventBus/ProgressEventBus';
 
@@ -57,45 +55,6 @@ class MemoryMementoStorage implements MementoStorage {
       return;
     }
     this.values.set(key, value);
-  }
-}
-
-class MemoryProgressBus implements ProgressEventBusLike {
-  private readonly listeners = new Map<
-    ProgressEvent,
-    Set<(payload: ProgressEventPayloads[ProgressEvent]) => void>
-  >();
-
-  on<K extends ProgressEvent>(
-    event: K,
-    listener: (payload: ProgressEventPayloads[K]) => void,
-    options?: { signal?: AbortSignal },
-  ): () => void {
-    if (options?.signal?.aborted) return () => {};
-    let listeners = this.listeners.get(event);
-    if (!listeners) {
-      listeners = new Set();
-      this.listeners.set(event, listeners);
-    }
-    listeners.add(
-      listener as (payload: ProgressEventPayloads[ProgressEvent]) => void,
-    );
-    const cleanup = (): void => {
-      listeners?.delete(
-        listener as (payload: ProgressEventPayloads[ProgressEvent]) => void,
-      );
-    };
-    options?.signal?.addEventListener('abort', cleanup, { once: true });
-    return cleanup;
-  }
-
-  emit<K extends ProgressEvent>(
-    event: K,
-    payload: ProgressEventPayloads[K],
-  ): void {
-    for (const listener of this.listeners.get(event) ?? []) {
-      listener(payload);
-    }
   }
 }
 
@@ -310,14 +269,14 @@ describe('ProgressBackend', () => {
 
   it('patches one stream for subagent registration and run-start metadata', async () => {
     const { backend, messages } = createRecordingBackend();
-    const subscription = backend.setupEventListeners(bus);
+    const subscription = backend.setupEventListeners();
 
     try {
       for (let i = 0; i < 20; i += 1) {
         backend.state.streamLogs.ensureStream(`history-${i}`);
       }
 
-      bus.emit('setActiveStream', {
+      backend.handleProgressEvent('setActiveStream', {
         streamId: 'root',
         agentCategory: AgentCategory.Workflow,
       });
@@ -331,7 +290,7 @@ describe('ProgressBackend', () => {
       );
       messages.length = 0;
 
-      bus.emit('setActiveStream', {
+      backend.handleProgressEvent('setActiveStream', {
         streamId: 'child',
         agentCategory: AgentCategory.ToolUse,
         suppressViewSwitch: true,
@@ -354,7 +313,7 @@ describe('ProgressBackend', () => {
       ).toBe(false);
       messages.length = 0;
 
-      bus.emit('setTaskState', {
+      backend.handleProgressEvent('setTaskState', {
         streamId: 'child',
         executionId: 'c41111',
         taskState: toolUseTaskState('search', 'deepseekproT'),
@@ -415,11 +374,10 @@ describe('ProgressBackend', () => {
   });
 
   it('scopes direct session events to each backend session', async () => {
-    const sharedBus = new MemoryProgressBus();
     const first = createIsolatedRecordingBackend();
     const second = createIsolatedRecordingBackend();
-    const firstSubscription = first.backend.setupEventListeners(sharedBus);
-    const secondSubscription = second.backend.setupEventListeners(sharedBus);
+    const firstSubscription = first.backend.setupEventListeners();
+    const secondSubscription = second.backend.setupEventListeners();
     const firstStream = 'session:first' as StreamTabId;
     const secondStream = 'session:second' as StreamTabId;
 
@@ -488,7 +446,7 @@ describe('ProgressBackend', () => {
         observed.push({ event, payload });
       },
     });
-    const subscription = backend.setupEventListeners(new MemoryProgressBus());
+    const subscription = backend.setupEventListeners();
     const streamId = 'session:observer' as StreamTabId;
 
     try {
@@ -513,12 +471,8 @@ describe('ProgressBackend', () => {
   it('handles direct session events with the backend effects of the legacy projection', async () => {
     const direct = createIsolatedRecordingBackend();
     const legacyEquivalent = createIsolatedRecordingBackend();
-    const directSubscription = direct.backend.setupEventListeners(
-      new MemoryProgressBus(),
-    );
-    const legacySubscription = legacyEquivalent.backend.setupEventListeners(
-      new MemoryProgressBus(),
-    );
+    const directSubscription = direct.backend.setupEventListeners();
+    const legacySubscription = legacyEquivalent.backend.setupEventListeners();
     const parentStreamId = 'session:parent' as StreamTabId;
     const childStreamId = 'session:child' as StreamTabId;
     const executionId = 'exec:direct-session' as ExecutionId;
@@ -820,7 +774,7 @@ describe('ProgressBackend', () => {
   it('drops buffered conversation progress when an existing stream re-enters running', async () => {
     vi.useFakeTimers();
     const { backend, messages } = createRecordingBackend();
-    const subscription = backend.setupEventListeners(bus);
+    const subscription = backend.setupEventListeners();
     const stream = 'tool-stream' as StreamTabId;
 
     try {
@@ -837,7 +791,7 @@ describe('ProgressBackend', () => {
       });
       backend.state.getOrCreateStreamState(stream, AgentCategory.ToolUse);
 
-      bus.emit('updateConversationProgress', {
+      backend.handleProgressEvent('updateConversationProgress', {
         streamId: stream,
         progress: { toolCallCount: 7 },
       });

--- a/src/test-kernel/progressView/ProgressBackendProcessBus.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendProcessBus.vitest.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type {
+  ProgressEvent,
+  ProgressEventBusLike,
+  ProgressEventPayloads,
+} from '@eventBus/ProgressEventBus';
+import { attachProgressBackendProcessBus } from '@progressView/progressBackendProcessBus';
+import { AgentCategory, type StreamTabId } from '@shared/schemas';
+import {
+  ProgressBackend,
+  type ProgressBackendUiConfig,
+} from '@shared/progressView/backend/ProgressBackend';
+import type { MementoStorage } from '@shared/progressView/backend/persistence/PersistentMapManager';
+
+class MemoryMementoStorage implements MementoStorage {
+  private readonly values = new Map<string, unknown>();
+
+  get<T>(key: string): T | undefined;
+  get<T>(key: string, defaultValue: T): T;
+  get<T>(key: string, defaultValue?: T): T | undefined {
+    return this.values.has(key) ? (this.values.get(key) as T) : defaultValue;
+  }
+
+  async update<T>(key: string, value: T | undefined): Promise<void> {
+    if (value === undefined) {
+      this.values.delete(key);
+      return;
+    }
+    this.values.set(key, value);
+  }
+}
+
+class MemoryProgressBus implements ProgressEventBusLike {
+  private readonly listeners = new Map<
+    ProgressEvent,
+    Set<(payload: ProgressEventPayloads[ProgressEvent]) => void>
+  >();
+
+  on<K extends ProgressEvent>(
+    event: K,
+    listener: (payload: ProgressEventPayloads[K]) => void,
+    options?: { signal?: AbortSignal },
+  ): () => void {
+    if (options?.signal?.aborted) return () => {};
+    let listeners = this.listeners.get(event);
+    if (!listeners) {
+      listeners = new Set();
+      this.listeners.set(event, listeners);
+    }
+    listeners.add(
+      listener as (payload: ProgressEventPayloads[ProgressEvent]) => void,
+    );
+    const cleanup = (): void => {
+      listeners?.delete(
+        listener as (payload: ProgressEventPayloads[ProgressEvent]) => void,
+      );
+    };
+    options?.signal?.addEventListener('abort', cleanup, { once: true });
+    return cleanup;
+  }
+
+  emit<K extends ProgressEvent>(
+    event: K,
+    payload: ProgressEventPayloads[K],
+  ): void {
+    for (const listener of this.listeners.get(event) ?? []) {
+      listener(payload);
+    }
+  }
+}
+
+function createUiConfig(): ProgressBackendUiConfig {
+  return {
+    callbacks: {
+      showRetryRequest: vi.fn(),
+      resolveRetryRequest: vi.fn(),
+      showToolEditPermission: vi.fn(),
+      resolveToolEditPermission: vi.fn(),
+      updateToolEditApprovalBypassState: vi.fn(),
+      updateSuperYoloBypassState: vi.fn(),
+      showBashPermission: vi.fn(),
+      resolveBashPermission: vi.fn(),
+      showAgentProposal: vi.fn(),
+      resolveAgentProposal: vi.fn(),
+      showPlanApproval: vi.fn(),
+      resolvePlanApproval: vi.fn(),
+      showExternalInquiry: vi.fn(),
+      resolveExternalInquiry: vi.fn(),
+      showUserQuestion: vi.fn(),
+      resolveUserQuestion: vi.fn(),
+    },
+    hasPendingPermissions: vi.fn(() => false),
+  };
+}
+
+describe('attachProgressBackendProcessBus', () => {
+  it('adapts extension process-bus events into the backend and detaches cleanly', () => {
+    const backend = new ProgressBackend({
+      storage: new MemoryMementoStorage(),
+      sendMessage: () => true,
+      hasTarget: () => true,
+      configureUi: () => createUiConfig(),
+    });
+    const processBus = new MemoryProgressBus();
+    const backendSubscription = backend.setupEventListeners();
+    const busSubscription = attachProgressBackendProcessBus(
+      backend,
+      processBus,
+    );
+    const first = 'extension:first' as StreamTabId;
+    const second = 'extension:second' as StreamTabId;
+
+    try {
+      processBus.emit('setActiveStream', {
+        streamId: first,
+        agentCategory: AgentCategory.Workflow,
+      });
+      expect(backend.state.activeStream).toBe(first);
+
+      busSubscription.dispose();
+      processBus.emit('setActiveStream', {
+        streamId: second,
+        agentCategory: AgentCategory.Workflow,
+      });
+      expect(backend.state.activeStream).toBe(first);
+    } finally {
+      busSubscription.dispose();
+      backendSubscription.dispose();
+      backend.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

This PR moves the remaining progress-backend process-bus attachment out of the shared `ProgressBackend` and into the VS Code extension boundary.

`ProgressBackend` now installs only its local event bus and session-fact subscriptions. The extension keeps legacy `ProgressEventBus` compatibility by explicitly attaching the process bus through an extension-local adapter.

## Why

After PR #7354, desktop no longer needs process-wide bus fan-out for progress-backend delivery. The next ownership step is to make the shared backend local/session-scoped and leave the process bus as a host-specific source of progress events for the extension only.

This is not the final bus/projector deletion. It is a boundary cleanup that makes the remaining extension compatibility path explicit and testable.

## Changes

- Removed the external bus parameter from `ProgressBackend.setupEventListeners()`.
- Added `attachProgressBackendProcessBus` under the extension progress-view boundary.
- Updated `ProgressViewProvider.initialize()` to attach local/session backend listeners and the extension process-bus adapter separately.
- Converted `ProgressBackend` tests from `bus.emit(...)` to `backend.handleProgressEvent(...)` where they are testing shared-backend behavior.
- Added a focused extension-boundary test proving process-bus events still reach the backend through the adapter and detach cleanly.

## Validation

- `corepack pnpm install`
- `corepack pnpm exec prettier --write packages/extension/src/progressView/ProgressViewProvider.ts packages/extension/src/progressView/progressBackendProcessBus.ts src/shared/progressView/backend/ProgressBackend.ts src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/progressView/ProgressBackendProcessBus.vitest.ts`
- `corepack pnpm exec eslint packages/extension/src/progressView/ProgressViewProvider.ts packages/extension/src/progressView/progressBackendProcessBus.ts src/shared/progressView/backend/ProgressBackend.ts src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/progressView/ProgressBackendProcessBus.vitest.ts`
- `corepack pnpm exec vitest run src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/progressView/ProgressBackendProcessBus.vitest.ts src/test-kernel/progressView/SessionRunFactProjectorEquivalence.vitest.ts src/test-kernel/progressView/LegacyProgressEventProjection.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `git diff --check`
- `corepack pnpm run compile:fast`
- `corepack pnpm run lint` (0 errors; the two existing unrelated import-order warnings remain)
- `corepack pnpm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of event wiring with explicit extension adapter and test coverage; desktop already used bus-less setup and behavior should be unchanged when the adapter is attached.
> 
> **Overview**
> **Shared `ProgressBackend` is now local/session-scoped only.** `setupEventListeners()` no longer accepts an external `ProgressEventBusLike`; it wires the internal local bus and session/run fact subscriptions. Legacy process-wide progress events are not part of the shared backend API anymore.
> 
> **The VS Code extension keeps compatibility explicitly.** `ProgressViewProvider.initialize()` registers backend listeners and, separately, `attachProgressBackendProcessBus(this.backend, bus)`, which forwards the extension’s legacy `ProgressEventBus` into `eventHandler.setupEventListeners(bus)`.
> 
> **Tests follow the new boundary.** Shared `ProgressBackend` tests drive behavior via `backend.handleProgressEvent(...)` instead of emitting on a shared bus; a focused test asserts process-bus events reach the backend through the adapter and stop after `dispose()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c6542d20e82d78e366ff414f2584a972f04127b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->