### PR TITLE
refactor(agent): make documentTag/endTag unified-output-protocol constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ All notable changes to this project will be documented in this file.
 - **Faster subagent result delivery** — the orchestrator wakes as soon as a
   subagent finishes instead of waiting for report persistence, and
   consecutive maintenance follow-ups batch into a single turn.
+- **`settings.documentTag`/`endTag` are no longer configurable in custom
+  agents** — every agent now emits the standard unified output container,
+  matching what every bundled agent already used. Custom agent YAMLs that
+  still set a bespoke `documentTag`/`endTag` keep loading; the fields are
+  dropped with a console warning rather than kept as a live setting.
 - **Subagent runs record a structured result manifest** — outputs, line-diff
   references, outcome, and cost are readable as JSON via the executions tool
   (`/executions/{id}/result`), so follow-on agents can chain on data instead

--- a/docs/proposals/unified-output-protocol.md
+++ b/docs/proposals/unified-output-protocol.md
@@ -1,9 +1,12 @@
 # Unified Output Protocol
 
-> **Status:** Partially landed proposal (2026-07-04 status sweep). Bundled agents
-> and templates have converged on the `<documents><document ...>` protocol, but
-> the schema/registry deletion plan is not complete: configurable
-> `documentTag`/`endTag` still exist for compatibility.
+> **Status:** Partially landed proposal (2026-07-07 status sweep). Bundled agents
+> and templates have converged on the `<documents><document ...>` protocol, and
+> `documentTag`/`endTag` are now fixed protocol constants
+> (`@shared/constants/outputProtocol`) rather than per-agent settings — old
+> YAML that still sets them is ignored with a warning (#7094). The rest of the
+> schema/registry deletion plan (`isMultipleOutput`, `MULTIPLE_SUFFIX`,
+> `groupByBaseName`, the paired-YAML/`_multiple` fork) is not complete.
 
 ## Problem
 

--- a/packages/extension/resources/agents/correct.yaml
+++ b/packages/extension/resources/agents/correct.yaml
@@ -3,8 +3,6 @@ description: Fixes typos, grammar, and LaTeX formatting without changing your wr
 
 settings:
   agentCategory: workflow
-  documentTag: documents
-  endTag: </documents>
   rounds: 1
 
 prompts:

--- a/packages/extension/resources/agents/merge.yaml
+++ b/packages/extension/resources/agents/merge.yaml
@@ -3,8 +3,6 @@ description: Merges partial edits back into the full original document.
 
 settings:
   agentCategory: workflow
-  documentTag: documents
-  endTag: </documents>
   rounds: 1
 
 prompts:

--- a/packages/extension/resources/agents/ocr.yaml
+++ b/packages/extension/resources/agents/ocr.yaml
@@ -3,8 +3,6 @@ description: Converts handwritten mathematical content from images into LaTeX.
 
 settings:
   agentCategory: workflow
-  documentTag: documents
-  endTag: </documents>
   defaultOutputFiles:
     - ocr_result.tex
 

--- a/packages/extension/resources/agents/polish.yaml
+++ b/packages/extension/resources/agents/polish.yaml
@@ -3,8 +3,6 @@ description: Rewrites and restructures text to improve clarity, flow, and readab
 
 settings:
   agentCategory: workflow
-  documentTag: documents
-  endTag: </documents>
 
 prompts:
   systemPrompt: |

--- a/packages/extension/resources/agents/transcribe_audio.yaml
+++ b/packages/extension/resources/agents/transcribe_audio.yaml
@@ -3,8 +3,6 @@ description: Transcribes audio with speaker identification and LaTeX math format
 
 settings:
   agentCategory: workflow
-  documentTag: documents
-  endTag: </documents>
   defaultOutputFiles:
     - transcript.tex
 

--- a/packages/extension/resources/agents/write/paper2poster.yaml
+++ b/packages/extension/resources/agents/write/paper2poster.yaml
@@ -3,8 +3,6 @@ description: Converts a research paper into a LaTeX conference poster using a pr
 
 settings:
   agentCategory: workflow
-  documentTag: documents
-  endTag: </documents>
   isRewrite: False
   defaultOutputFiles:
     - poster.tex

--- a/packages/extension/resources/agents/write/paper2slide.yaml
+++ b/packages/extension/resources/agents/write/paper2slide.yaml
@@ -3,8 +3,6 @@ description: Converts a research paper into a LaTeX Beamer slide deck using a pr
 
 settings:
   agentCategory: workflow
-  documentTag: documents
-  endTag: </documents>
   defaultOutputFiles:
     - slides.tex
   requiredFilesInternal:

--- a/packages/extension/resources/docs/agent-creation/execution_and_testing.md
+++ b/packages/extension/resources/docs/agent-creation/execution_and_testing.md
@@ -13,8 +13,8 @@ flow shapes:
 
 - **Workflow flow** for `agentCategory: workflow`. Fixed rounds, each round
   consumes `userRequest[i]`. Operates on `inputFiles` (or the active editor
-  selection). Emits LaTeX output files per `documentTag` /
-  `defaultOutputFiles`.
+  selection). Emits LaTeX output files from the unified `<documents>`
+  container / `defaultOutputFiles`.
 - **Tool-use flow** for `agentCategory: toolUse`. Multi-step loop invoking
   declared tools. May WAIT for interim follow-ups, spawn subagents via
   `delegate_workflow` / `delegate_agent`, and resume.

--- a/packages/extension/resources/docs/agent-creation/workflow_schema.md
+++ b/packages/extension/resources/docs/agent-creation/workflow_schema.md
@@ -16,8 +16,6 @@ settings:
   isRewrite: true # true = editing existing docs, false = creating new
   rounds: 2 # 1 or 2 (default 2)
   temperature: 0.1 # 0.1 for editing, 0.5-0.8 for creative tasks
-  documentTag: documents
-  endTag: '</documents>'
 
 prompts:
   systemPrompt: |
@@ -81,8 +79,8 @@ for model-specific instructions.
 All workflow agents use the same unified output protocol regardless of whether
 they produce one file or many. No separate `_multiple` variant is needed.
 
-- Use `documentTag: documents` (the default). Omit it unless you need a custom
-  tag for a legacy single-output agent.
+- The `<documents><document name="...">` container is fixed protocol, not a
+  setting — every agent emits it; there is nothing to configure.
 - For editing agents, iterate over `INPUT_FILES` to emit one
   `<document name="filename.tex">` block per selected input file inside
   `<documents>`.
@@ -115,8 +113,6 @@ description: Improves writing quality and clarity based on your instructions.
 
 settings:
   agentCategory: workflow
-  documentTag: documents
-  endTag: '</documents>'
 
 prompts:
   systemPrompt: |

--- a/packages/extension/resources/templates/agentCreatorWorkflow.yaml
+++ b/packages/extension/resources/templates/agentCreatorWorkflow.yaml
@@ -14,13 +14,14 @@ prompts:
     You are an expert on the TeXRA codebase, a VS Code extension that runs YAML-defined AI agents.
     When generating workflow agent YAML definitions, follow the schema below exactly.
     Workflow agents process LaTeX documents in fixed rounds (default 2), producing output
-    wrapped in a documentTag. Modern thinking-capable models reason natively before
-    producing the final output --- do not add scratchpad scaffolding by default.
+    wrapped in the standard <documents><document name="..."> container. Modern
+    thinking-capable models reason natively before producing the final output ---
+    do not add scratchpad scaffolding by default.
 
     CRITICAL RULES:
     - agentCategory MUST be "workflow" (not "toolUse"). Workflow agents do NOT call tools.
-    - documentTag SHOULD be "documents" for new workflow agents.
-    - endTag MUST match documentTag as a closing XML tag (e.g. "</documents>").
+    - The output container (<documents><document name="...">) is fixed
+      protocol, not a per-agent setting — do not add settings for it.
     - Infer appropriate settings from the agent's description:
       - isRewrite: true when the agent edits/revises/corrects existing documents, false when it creates new content.
       - temperature: low (0.1) for editing/correction tasks, higher (0.5-0.8) for creative/generation tasks.
@@ -52,8 +53,6 @@ prompts:
     description: <one-line description>
     settings:
       agentCategory: workflow
-      documentTag: documents
-      endTag: </documents>
       isRewrite: <true if editing existing docs, false if creating new>
       temperature: <0.1 for precise editing, 0.5-0.8 for creative>
     prompts:
@@ -80,8 +79,6 @@ prompts:
     description: Improves writing quality and clarity based on your specific instructions.
     settings:
       agentCategory: workflow
-      documentTag: documents
-      endTag: </documents>
     prompts:
       systemPrompt: |
         You are a professional scientist. Your task is to improve a LaTeX research paper
@@ -115,7 +112,8 @@ prompts:
           Output the further enhanced content as <documents>{% for output in INPUT_FILES %}<document name="{{ output }}">...</document>{% endfor %}</documents>.
 
     IMPORTANT REMINDERS:
-    - The documentTag in prompts must match the settings.documentTag.
+    - Wrap the final output in <documents><document name="..."> exactly as shown
+      above — this container is fixed protocol, not a setting to configure.
     - userRequest must be an array with exactly as many entries as rounds (1 or 2).
     - Include {{ INSTRUCTION }} somewhere in the prompts so the user's instructions are passed through.
     - Write prompt text in LaTeX style (\begin{itemize}, \textbf{}, etc.), not markdown.

--- a/packages/extension/resources/templates/agentTemplate-workflowSingle.yaml
+++ b/packages/extension/resources/templates/agentTemplate-workflowSingle.yaml
@@ -8,8 +8,6 @@ settings:
   agentCategory: workflow
   temperature: 0.1
   isRewrite: true
-  documentTag: documents
-  endTag: </documents>
 
 # --- Agent Prompts ---
 prompts:
@@ -20,7 +18,7 @@ prompts:
     AI agents using YAML files. TeXRA loads selected documents and exposes them
     as variables, so prompts can reference data like {{ INPUT_CONTENT }} or
     {{ ALL_INPUTS }}. Each agent runs one or more rounds and produces its
-    final output wrapped in the configured documentTag.
+    final output wrapped in the standard <documents> container.
 
     Variable Retrieval (VR) exposes runtime data as variables in these prompts:
       - {{ INPUT_FILE }} / {{ INPUT_CONTENT }}: main file path and text

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/dataFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/dataFormatters.ts
@@ -19,6 +19,7 @@ import {
   type ExtendedTokenUsageStats,
   type LogMessageData,
 } from '@shared/schemas';
+import { OUTPUT_DOCUMENTS_TAG } from '@shared/constants/outputProtocol';
 import { getBasename } from '@shared/utils/path';
 import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
 import { formatCompactTokenCount } from '@utils/core';
@@ -60,10 +61,10 @@ export function formatFileListTemplate(
 }
 
 /** Render XML link template. */
-function renderXmlLink(xmlFile: string, documentTag: string | null) {
+function renderXmlLink(xmlFile: string) {
   const xmlFileName = getBasename(xmlFile);
   // prettier-ignore
-  return html`<div class="xml-link-container"><wa-icon library=${TEXRA_ICON_LIBRARY} name="file-code" aria-hidden="true"></wa-icon> <span>Open XML to check tag consistency:</span> <span class="file-link clickable-link" data-file=${xmlFile} role="button" tabindex="0">${xmlFileName}</span>${documentTag ? html` <span class="document-tag">(Expected &lt;${documentTag}&gt; block)</span>` : ''}</div>`;
+  return html`<div class="xml-link-container"><wa-icon library=${TEXRA_ICON_LIBRARY} name="file-code" aria-hidden="true"></wa-icon> <span>Open XML to check tag consistency:</span> <span class="file-link clickable-link" data-file=${xmlFile} role="button" tabindex="0">${xmlFileName}</span> <span class="document-tag">(Expected &lt;${OUTPUT_DOCUMENTS_TAG}&gt; block)</span></div>`;
 }
 
 /** Format missing outputs entry as TemplateResult. */
@@ -78,12 +79,12 @@ export function formatMissingOutputsTemplate(
     return null;
   }
 
-  const { missing, xmlFile, documentTag } = parseResult.data;
+  const { missing, xmlFile } = parseResult.data;
   const shouldOpen = options?.defaultOpen ?? false;
 
   // Special case: only XML link, no missing files
   if (missing.length === 0 && xmlFile) {
-    return renderXmlLink(xmlFile, documentTag);
+    return renderXmlLink(xmlFile);
   }
 
   // prettier-ignore
@@ -97,7 +98,7 @@ export function formatMissingOutputsTemplate(
     iconName: 'warning',
     label: `Missing outputs (${missing.length})`,
     labelClass: 'summary-text',
-  })}<ul class="file-list-content" data-log-id=${ifDefined(id)}>${listItems}</ul>${xmlFile ? renderXmlLink(xmlFile, documentTag) : ''}</details>`;
+  })}<ul class="file-list-content" data-log-id=${ifDefined(id)}>${listItems}</ul>${xmlFile ? renderXmlLink(xmlFile) : ''}</details>`;
 }
 
 // =============================================================================

--- a/src/agent/core/definition/AgentDataclass.ts
+++ b/src/agent/core/definition/AgentDataclass.ts
@@ -6,17 +6,11 @@ import {
   AgentCategorySchema,
   AgentNameSchema,
 } from '@shared/schemas/agent';
-import { isNonEmptyString } from '@utils/core';
+import { OUTPUT_END_TAG } from '@shared/constants/outputProtocol';
 
 export { AgentCategory };
 
 export const AgentSettingBaseSchema = z.strictObject({
-  documentTag: z
-    .string()
-    .trim()
-    .min(1, 'documentTag cannot be empty')
-    .prefault('documents'),
-  endTag: z.string().prefault('</documents>'),
   temperature: z.number().min(0).max(1).prefault(1.0),
   requiredFiles: z.record(z.string(), z.string()).prefault({}),
   requiredFilesInternal: z.record(z.string(), z.string()).prefault({}),
@@ -52,7 +46,15 @@ export const AgentToolUseSettingSchema = AgentSettingBaseSchema.extend({
     .prefault(AgentCategory.ToolUse),
 });
 
-/** Drop obsolete settings accepted only for legacy YAML and persisted state. */
+/**
+ * Drop obsolete settings accepted only for legacy YAML and persisted state.
+ * `documentTag`/`endTag` used to configure the per-agent output container;
+ * every bundled and custom agent has converged on the fixed
+ * `<documents><document name="..."></documents>` protocol (see
+ * `@shared/constants/outputProtocol`), so the fields are ignored — with a
+ * warning, since a custom agent that relied on a bespoke tag silently gets
+ * the standard container instead.
+ */
 function stripLegacySettingFields(input: unknown): unknown {
   if (typeof input !== 'object' || input === null || Array.isArray(input)) {
     return input;
@@ -60,38 +62,25 @@ function stripLegacySettingFields(input: unknown): unknown {
   const {
     outputExt: _outputExt,
     prefills: _prefills,
+    documentTag,
+    endTag,
     ...rest
   } = input as Record<string, unknown>;
+  if (documentTag !== undefined || endTag !== undefined) {
+    // console.warn, not the structured trace logger: this module is a leaf
+    // schema (`core/definition`, dependency-free by design — see
+    // src/agent/core/README.md) and must not pull in the logger's transitive
+    // `@shared/schemas` barrel just for one deprecation notice. Same pattern
+    // as `src/shared/schemas/streamData.ts`'s `warnDroppedItem`.
+    console.warn(
+      '[AgentDataclass] settings.documentTag/endTag are no longer configurable — every agent emits the fixed <documents><document name="..."> container. Ignoring the value from this agent definition.',
+    );
+  }
   return rest;
 }
 
-/**
- * Derive endTag from documentTag when none is set. `fallbackTag` supplies the
- * tag when documentTag is absent/blank; `null` leaves the input unchanged.
- */
-function deriveEndTagFrom(input: unknown, fallbackTag: string | null): unknown {
-  if (typeof input !== 'object' || input === null) return input;
-  const obj = input as Record<string, unknown>;
-  if (obj.endTag !== undefined) return obj;
-  const docTag = isNonEmptyString(obj.documentTag)
-    ? obj.documentTag.trim()
-    : fallbackTag;
-  if (docTag === null) return input;
-  return { ...obj, endTag: `</${docTag}>` };
-}
-
-/** Derive endTag from documentTag when endTag is not explicitly set. */
-function deriveEndTag(input: unknown): unknown {
-  return deriveEndTagFrom(input, 'documents');
-}
-
-/** Preserve partial child blocks: derive only from explicitly written documentTag. */
-function deriveExplicitEndTag(input: unknown): unknown {
-  return deriveEndTagFrom(input, null);
-}
-
 export const AgentSettingSchema = z.preprocess(
-  (input) => deriveEndTag(stripLegacySettingFields(input)),
+  stripLegacySettingFields,
   z.discriminatedUnion('agentCategory', [
     AgentWorkflowSettingSchema,
     AgentToolUseSettingSchema,
@@ -116,12 +105,6 @@ export type AgentToolUseSetting = Extract<
 /** Partial settings as they appear in YAML before inheritance and defaults. */
 const RawAgentSettingInputSchema = z.strictObject({
   agentCategory: AgentCategorySchema.optional(),
-  documentTag: z
-    .string()
-    .trim()
-    .min(1, 'documentTag cannot be empty')
-    .optional(),
-  endTag: z.string().optional(),
   temperature: z.number().min(0).max(1).optional(),
   requiredFiles: z.record(z.string(), z.string()).optional(),
   requiredFilesInternal: z.record(z.string(), z.string()).optional(),
@@ -146,18 +129,15 @@ const RawAgentSettingInputSchema = z.strictObject({
  * defaults, so inherited child blocks only override fields the author wrote.
  */
 export const AgentSettingInputSchema = z.preprocess(
-  (input) => deriveExplicitEndTag(stripLegacySettingFields(input)),
+  stripLegacySettingFields,
   RawAgentSettingInputSchema,
 );
 
 export type AgentSettingInput = z.infer<typeof AgentSettingInputSchema>;
 
-export function hasEndTag(
-  settings: AgentSetting,
-  fileContent: string,
-): boolean {
-  const endTag = settings.endTag;
-  return endTag !== '' && fileContent.includes(endTag);
+/** Whether `fileContent` already contains the protocol's closing tag. */
+export function hasEndTag(fileContent: string): boolean {
+  return fileContent.includes(OUTPUT_END_TAG);
 }
 
 export const AgentPromptSchema = z.strictObject({

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -22,6 +22,7 @@ import { isTokenLimitStopReason } from '@agent/modelHandlers/utils/stopReasonUti
 import { K_SLICE } from '@agent/core/constants';
 import type { ToolDefinition } from '@model';
 import { MESSAGE_TYPES, AgentFileLocationSchema } from '@shared/schemas';
+import { OUTPUT_END_TAG } from '@shared/constants/outputProtocol';
 import { isApprovalGatedToolName } from '@tools/approvalGatedTools';
 import { AbsoluteFS, flexibleFS } from '@utils/files';
 import { getSystemPromptWithRules } from '@utils/prompt';
@@ -273,7 +274,7 @@ class ResponseProcessNode<C> extends BaseNode<
       } = extractModelResponse(
         prepRes.responseObject,
         prepRes.responseTimeMs,
-        this.services.setting.endTag,
+        OUTPUT_END_TAG,
         this.services,
         { normalizeNullUsage: true },
       );
@@ -605,7 +606,7 @@ export function createResponseCycleFlow<C>(): Flow<
     streaming: false,
     backgroundModeAware: true,
     getSystemPrompt: (shared) => shared.systemPrompt,
-    getEndTag: (services) => services.setting.endTag,
+    getEndTag: () => OUTPUT_END_TAG,
     getTools: responseCycleToolsForModel,
     storeResponse: (shared, response) => {
       shared.responseObject = response;

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -116,11 +116,7 @@ export class OutputNode<C = unknown> extends Node<
       logger.debug(`Processing output for round ${currentRound}`);
 
       await tryOperation(
-        () =>
-          xmlManager.ensureCorrectXmlStructure(
-            outputLocation,
-            setting.documentTag,
-          ),
+        () => xmlManager.ensureCorrectXmlStructure(outputLocation),
         this.recoverWarn('XML structure'),
       );
 

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -115,7 +115,7 @@ export async function runReflectionFlow<C = unknown>(
   });
 
   const outputState = createOutputState();
-  const xmlManager = new XmlOutputManager(setting, config, logger, fileService);
+  const xmlManager = new XmlOutputManager(config, logger, fileService);
   const diffManager = new LatexDiffManager(
     setting,
     () => getOutputFilesByRound(outputState),

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -49,9 +49,10 @@ import { isGpt5ModelName } from '@model/modelNames';
 
 // Local imports - logger
 import { MESSAGE_TYPES } from '@shared/schemas';
+import type { FileLocation } from '@shared/schemas';
+import { OUTPUT_END_TAG } from '@shared/constants/outputProtocol';
 
 // Local imports - tools
-import type { FileLocation } from '@shared/schemas';
 import type {
   ToolFileAttachment,
   ToolResult,
@@ -666,9 +667,7 @@ export abstract class ModelHandler<
 
     // Detect stop markers in model output
     const endTurn = END_TURN_REASONS.includes(stopReason ?? '');
-    const encounterDocumentTag = newResponse.includes(
-      `</${agentSetting.documentTag}>`,
-    );
+    const encounterDocumentTag = newResponse.includes(OUTPUT_END_TAG);
 
     if (maxOutputTokensExceeded) {
       this.logger.warn('Output tokens exceed input token multiplier', {
@@ -732,11 +731,10 @@ export abstract class ModelHandler<
    */
   protected createContinuationPrompt(
     workspaceState: AgentWorkspaceState,
-    agentSetting: AgentSetting,
+    _agentSetting: AgentSetting,
   ): string {
     const prefillTokens = workspaceState.assembly.lastResponse.slice(-K_SLICE);
-    const endTag = agentSetting.endTag;
-    return `Your response got cut off, because you only have limited response space. Continue responding exactly from where you left off until the very end, marked by ${endTag}. Avoid repeating yourself and avoid starting over. Start your response at the next token after: "${prefillTokens}"`;
+    return `Your response got cut off, because you only have limited response space. Continue responding exactly from where you left off until the very end, marked by ${OUTPUT_END_TAG}. Avoid repeating yourself and avoid starting over. Start your response at the next token after: "${prefillTokens}"`;
   }
 
   /** Creates and configures a client instance for the specific model provider. */
@@ -1055,7 +1053,7 @@ export abstract class ModelHandler<
 
     messages.push(this.createAssistantMessageForPrefillText(fileContent));
 
-    if (hasEndTag(agentSetting, fileContent)) {
+    if (hasEndTag(fileContent)) {
       this.logger.debug(
         'End tag detected - skipping model call (response already added above)',
       );
@@ -1148,15 +1146,15 @@ export abstract class ModelHandler<
   shouldContinue(
     stopReason: ProviderStopReason,
     newResponse: string,
-    agentSetting: AgentSetting,
+    _agentSetting: AgentSetting,
   ): boolean {
-    const hasResponseEndTag = hasEndTag(agentSetting, newResponse);
+    const hasResponseEndTag = hasEndTag(newResponse);
     const shouldContinue =
       isTokenLimitStopReason(stopReason) && !hasResponseEndTag;
 
     this.logger.debug(
       shouldContinue
-        ? `Should continue: token limit reached and end tag '${agentSetting.endTag}' is missing.`
+        ? `Should continue: token limit reached and end tag '${OUTPUT_END_TAG}' is missing.`
         : `Should not continue: StopReason='${stopReason}', HasEndTag='${hasResponseEndTag}'.`,
     );
     return shouldContinue;

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -1167,7 +1167,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
   shouldContinue(
     stopReason: ProviderStopReason,
     newResponse: string,
-    agentSetting: AgentSetting,
+    _agentSetting: AgentSetting,
   ): boolean {
     // DEBUG: Log the stop reason to help diagnose continuation issues
     this.logger.debug(
@@ -1186,7 +1186,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const shouldContinue =
       (stopReason === ANTHROPIC_STOP.MAX_TOKENS ||
         stopReason === ANTHROPIC_STOP.STOP_SEQUENCE) &&
-      !hasEndTag(agentSetting, newResponse);
+      !hasEndTag(newResponse);
 
     if (!shouldContinue && stopReason === ANTHROPIC_STOP.STOP_SEQUENCE) {
       this.logger.debug('Response complete (end tag found)');

--- a/src/agent/output/OutputFileProcessor.ts
+++ b/src/agent/output/OutputFileProcessor.ts
@@ -1,5 +1,4 @@
 import { logMissingOutputs, type AgentTrace } from '@agent/trace';
-import type { AgentWorkflowSetting } from '@agent/core/definition/AgentDataclass';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { emitRunFact } from '@agent/runtime/runFactEvents';
 import {
@@ -7,6 +6,7 @@ import {
   type OutputFileInfo,
   type RoundOutput,
 } from '@shared/schemas';
+import { OUTPUT_DOCUMENTS_TAG } from '@shared/constants/outputProtocol';
 import { normalizeFilePath } from '@shared/utils/path';
 import { flexibleFS, replaceInputCommands } from '@utils/files';
 import {
@@ -18,7 +18,6 @@ import { tryOperation } from './outputOperations';
 import type { XmlOutputManager } from './XmlOutputManager';
 
 export interface ProcessingContext {
-  agentSetting: AgentWorkflowSetting;
   baseFiles: FileLocation[];
   streamId: string;
   runtimeHost: AgentRuntimeHost;
@@ -48,7 +47,6 @@ export class OutputFileProcessor {
         const processedPairs =
           await this.ctx.xmlManager.splitScratchpadMultipleOutputXml(
             outputLocation,
-            this.ctx.agentSetting.documentTag,
             currRound,
             'scratchpad',
             this.similarityBaseFiles(currRound),
@@ -140,16 +138,15 @@ export class OutputFileProcessor {
     // Distinguish a genuinely empty turn from a non-empty response that simply
     // could not be parsed: if the model returned content but nothing extracted,
     // it almost always means it did not wrap each file in
-    // `<documentTag name="…">`. Surface that as a warning so the round is not a
+    // `<document name="…">`. Surface that as a warning so the round is not a
     // silent "success" that writes no files; the raw response is kept for recovery.
     const rawText = await flexibleFS.read(outputLocation).catch(() => '');
     if (rawText.trim().length > 0) {
       this.ctx.logger.warn(
-        `The model returned output but no files could be extracted from it — it likely did not wrap each document in <${this.ctx.agentSetting.documentTag}>. The raw response was kept at ${outputLocation.absolutePath} for recovery.`,
+        `The model returned output but no files could be extracted from it — it likely did not wrap each document in <${OUTPUT_DOCUMENTS_TAG}>. The raw response was kept at ${outputLocation.absolutePath} for recovery.`,
         {
           data: {
             round: currRound,
-            documentTag: this.ctx.agentSetting.documentTag,
             rawResponsePath: outputLocation.absolutePath,
           },
         },
@@ -158,7 +155,6 @@ export class OutputFileProcessor {
     logMissingOutputs(this.ctx.logger, {
       missing: [] as string[],
       xmlFile: outputLocation.absolutePath,
-      documentTag: this.ctx.agentSetting.documentTag,
     });
     emitRunFact(this.ctx.logger, 'updateMissingOutputs', {
       streamId: this.ctx.streamId,
@@ -200,32 +196,31 @@ export class OutputFileProcessor {
         const rawContent = await flexibleFS.read(rawOutput);
         const tagContents: Record<string, string[]> = {};
         const documents: string[] = [];
-        const documentTag = this.ctx.agentSetting.documentTag;
 
         const documentEntries = extractMultipleTextFromTag(
           rawContent,
-          documentTag,
+          OUTPUT_DOCUMENTS_TAG,
         );
         if (documentEntries.length > 0) {
-          tagContents[documentTag] = documentEntries.map((e) =>
+          tagContents[OUTPUT_DOCUMENTS_TAG] = documentEntries.map((e) =>
             e.content.trim(),
           );
 
           for (const entry of documentEntries) {
             const nameAttr = entry.name ? ` name="${entry.name}"` : '';
             documents.push(
-              `<${documentTag}${nameAttr}>${entry.content.trim()}</${documentTag}>`,
+              `<${OUTPUT_DOCUMENTS_TAG}${nameAttr}>${entry.content.trim()}</${OUTPUT_DOCUMENTS_TAG}>`,
             );
           }
         } else {
           const singleDocument = extractTextFromTag(
             rawContent,
-            documentTag,
+            OUTPUT_DOCUMENTS_TAG,
           ).trim();
           if (singleDocument) {
-            tagContents[documentTag] = [singleDocument];
+            tagContents[OUTPUT_DOCUMENTS_TAG] = [singleDocument];
             documents.push(
-              `<${documentTag}>${singleDocument}</${documentTag}>`,
+              `<${OUTPUT_DOCUMENTS_TAG}>${singleDocument}</${OUTPUT_DOCUMENTS_TAG}>`,
             );
           }
         }

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -9,11 +9,11 @@ import {
   type AgentTrace,
 } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
-import { AgentSetting } from '@agent/core/definition/AgentDataclass';
 import { getExtractedDocOutputFileName } from '@agent/utils/outputFileUtils';
 import replacementEngine, { applyReplacements } from '@replacement/engine';
 import { FENCED_LATEX_BLOCK_REPLACEMENTS } from '@replacement/rulesRegex';
 import type { FileLocation, OutputFileInfo } from '@shared/schemas';
+import { OUTPUT_DOCUMENTS_TAG } from '@shared/constants/outputProtocol';
 import {
   AbsoluteFS,
   createExternalLocation,
@@ -71,7 +71,6 @@ const EXTRACTION_METHOD_MESSAGES: Record<string, string> = {
 
 export class XmlOutputManager {
   constructor(
-    private readonly agentSetting: AgentSetting,
     private readonly agentConfig: AgentConfig,
     private readonly logger: AgentTrace,
     private readonly fileService: TaskRunFileService,
@@ -86,24 +85,27 @@ export class XmlOutputManager {
 
   private extractMultipleDocumentsByRegex(
     outputContent: string,
-    documentTag: string,
     preferredName?: string,
   ): Array<{ content: string; name: string }> | null {
-    const result = extractDocuments(outputContent, documentTag, preferredName);
+    const result = extractDocuments(
+      outputContent,
+      OUTPUT_DOCUMENTS_TAG,
+      preferredName,
+    );
 
     if (result.documents) {
       const suffix =
         EXTRACTION_METHOD_MESSAGES[result.method] ?? 'using fallback method';
       logInternal(
         this.logger,
-        `Recovered ${documentTag} ${suffix} (${formatResultCount(result.documents.length, 'document')})`,
+        `Recovered ${OUTPUT_DOCUMENTS_TAG} ${suffix} (${formatResultCount(result.documents.length, 'document')})`,
       );
       return result.documents;
     }
 
     debugInternal(
       this.logger,
-      `No ${documentTag} found in output file using fallback method`,
+      `No ${OUTPUT_DOCUMENTS_TAG} found in output file using fallback method`,
     );
     return null;
   }
@@ -130,7 +132,6 @@ export class XmlOutputManager {
     logMissingOutputs(this.logger, {
       missing,
       xmlFile: outputLocation.absolutePath,
-      documentTag: this.agentSetting.documentTag,
     });
   }
 
@@ -150,7 +151,6 @@ export class XmlOutputManager {
     logMissingOutputs(this.logger, {
       missing,
       xmlFile: outputLocation.absolutePath,
-      documentTag: this.agentSetting.documentTag,
     });
   }
 
@@ -208,7 +208,7 @@ export class XmlOutputManager {
 
     logInternal(
       this.logger,
-      `Recovered ${this.agentSetting.documentTag} by matching unlabeled fenced ` +
+      `Recovered ${OUTPUT_DOCUMENTS_TAG} by matching unlabeled fenced ` +
         `blocks against the original input files (${formatResultCount(documents.length, 'document')})`,
     );
 
@@ -222,7 +222,6 @@ export class XmlOutputManager {
       logMissingOutputs(this.logger, {
         missing: unmatchedFiles,
         xmlFile: outputLocation.absolutePath,
-        documentTag: this.agentSetting.documentTag,
       });
     }
     if (documents.length < blocks.length) {
@@ -236,7 +235,6 @@ export class XmlOutputManager {
 
   async splitScratchpadMultipleOutputXml(
     outputLocation: FileLocation,
-    documentTag: string,
     round: number,
     thinkingTag: string = 'scratchpad',
     baseFiles: readonly FileLocation[] = [],
@@ -257,11 +255,14 @@ export class XmlOutputManager {
     try {
       const parser = new XMLParser(XML_PARSER_OPTIONS);
       const root = parser.parse(cdataWrapped);
-      documents = extractContentFromXMLbyTagMultiple(root, documentTag);
+      documents = extractContentFromXMLbyTagMultiple(
+        root,
+        OUTPUT_DOCUMENTS_TAG,
+      );
       if (!documents) {
         debugInternal(
           this.logger,
-          `No ${documentTag} found in parsed XML, attempting fallback extraction...`,
+          `No ${OUTPUT_DOCUMENTS_TAG} found in parsed XML, attempting fallback extraction...`,
         );
       }
     } catch (err) {
@@ -272,10 +273,7 @@ export class XmlOutputManager {
     }
 
     if (!documents) {
-      documents = this.extractMultipleDocumentsByRegex(
-        cdataWrapped,
-        documentTag,
-      );
+      documents = this.extractMultipleDocumentsByRegex(cdataWrapped);
     }
 
     // The files this agent is expected to write: the declared outputFiles
@@ -300,12 +298,12 @@ export class XmlOutputManager {
         synthesisName: soleExpectedFile,
         coalesceRepeatedName:
           this.agentConfig.outputFiles.length === 1 ? soleExpectedFile : null,
-        wrapperTag: documentTag,
+        wrapperTag: OUTPUT_DOCUMENTS_TAG,
       });
       if (documents) {
         logInternal(
           this.logger,
-          `Recovered ${this.agentSetting.documentTag} from filename headers (${formatResultCount(documents.length, 'document')})`,
+          `Recovered ${OUTPUT_DOCUMENTS_TAG} from filename headers (${formatResultCount(documents.length, 'document')})`,
         );
         if (expectedFiles.length > 1) {
           this.warnMissingExpectedFiles(
@@ -338,7 +336,7 @@ export class XmlOutputManager {
         ];
         logInternal(
           this.logger,
-          `Recovered ${this.agentSetting.documentTag} by concatenating ` +
+          `Recovered ${OUTPUT_DOCUMENTS_TAG} by concatenating ` +
             `unlabeled fenced blocks under ${soleExpectedFile} (${formatResultCount(fencedBlocks.length, 'block')})`,
         );
       }
@@ -357,7 +355,6 @@ export class XmlOutputManager {
       // workspace location instead of collapsing to the round root.
       documents = this.extractMultipleDocumentsByRegex(
         cdataWrapped,
-        documentTag,
         soleExpectedFile,
       );
     }
@@ -448,18 +445,15 @@ export class XmlOutputManager {
     return outputFiles;
   }
 
-  async ensureCorrectXmlStructure(
-    fileLocation: FileLocation,
-    documentTag: string,
-  ): Promise<void> {
+  async ensureCorrectXmlStructure(fileLocation: FileLocation): Promise<void> {
     this.logger.debug(
       `Ensuring correct XML structure: ${fileLocation.absolutePath}`,
     );
     const originalContent = await AbsoluteFS.read(fileLocation.absolutePath);
     let content = await this.processXmlContent(originalContent);
 
-    const closeTag = `</${documentTag}>`;
-    const openTag = `<${documentTag}>`;
+    const closeTag = `</${OUTPUT_DOCUMENTS_TAG}>`;
+    const openTag = `<${OUTPUT_DOCUMENTS_TAG}>`;
     const hasOpenTag = content.includes(openTag);
     const hasCloseTag = content.includes(closeTag);
 

--- a/src/agent/output/outputFileExtraction.ts
+++ b/src/agent/output/outputFileExtraction.ts
@@ -72,7 +72,6 @@ export async function extractFilesFromXml(
       const rawLocation = data.rawOutput;
 
       const processingContext: ProcessingContext = {
-        agentSetting: deps.setting,
         baseFiles: deps.baseFiles,
         streamId: deps.streamId,
         runtimeHost: deps.runtimeHost,

--- a/src/agent/output/outputValidation.ts
+++ b/src/agent/output/outputValidation.ts
@@ -71,7 +71,6 @@ export async function checkExpectedOutputs(
         logMissingOutputs(deps.logger, {
           missing,
           xmlFile: xmlExists ? outputLocation.absolutePath : null,
-          documentTag: deps.setting.documentTag,
         });
         deps.logger.debug(`Missing expected outputs for round ${currRound}`, {
           data: missing,

--- a/src/shared/constants/outputProtocol.ts
+++ b/src/shared/constants/outputProtocol.ts
@@ -1,0 +1,20 @@
+/**
+ * Unified output protocol tag names
+ * (`docs/proposals/unified-output-protocol.md`).
+ *
+ * Every bundled and custom agent converged on one output container —
+ * `<documents><document name="...">...</document></documents>` — so these
+ * are fixed protocol constants, not per-agent configuration. They used to be
+ * threaded through as `settings.documentTag` / `settings.endTag`; that
+ * configurability is gone (see `AgentDataclass.ts`'s legacy-field strip), and
+ * every consumer reads these constants directly instead.
+ */
+
+/** Outer container tag wrapping every document the model emits. */
+export const OUTPUT_DOCUMENTS_TAG = 'documents';
+
+/** Per-document child tag inside the container, carrying a `name` attribute. */
+export const OUTPUT_DOCUMENT_TAG = 'document';
+
+/** Closing tag that marks a complete response. */
+export const OUTPUT_END_TAG = `</${OUTPUT_DOCUMENTS_TAG}>`;

--- a/src/shared/schemas/progressView/data.ts
+++ b/src/shared/schemas/progressView/data.ts
@@ -37,7 +37,6 @@ export const StreamScopedBaseSchema = z.object({ stream: StreamTabIdSchema });
 export const MissingOutputsPayloadSchema = z.object({
   missing: z.array(z.string()).prefault([]),
   xmlFile: z.string().nullable().prefault(null),
-  documentTag: z.string().nullable().prefault(null),
 });
 
 export const TOOL_USE_STATUS = {

--- a/src/test-kernel/agent/AgentSettingSchema.vitest.ts
+++ b/src/test-kernel/agent/AgentSettingSchema.vitest.ts
@@ -19,23 +19,16 @@ describe('AgentSettingSchema', () => {
     expect(Object.hasOwn(setting, 'outputExt')).toBe(false);
   });
 
-  it('trims documentTag before deriving endTag', () => {
+  it('ignores legacy documentTag/endTag without exposing them in settings', () => {
     const setting = AgentSettingSchema.parse({
       agentCategory: AgentCategory.Workflow,
-      documentTag: '  latex_document  ',
+      documentTag: 'latex_document',
+      endTag: '</latex_document>',
     });
 
-    expect(setting.documentTag).toBe('latex_document');
-    expect(setting.endTag).toBe('</latex_document>');
-  });
-
-  it('rejects blank documentTag values', () => {
-    expect(() =>
-      AgentSettingSchema.parse({
-        agentCategory: AgentCategory.Workflow,
-        documentTag: '   ',
-      }),
-    ).toThrow('documentTag cannot be empty');
+    expect(setting.agentCategory).toBe(AgentCategory.Workflow);
+    expect(Object.hasOwn(setting, 'documentTag')).toBe(false);
+    expect(Object.hasOwn(setting, 'endTag')).toBe(false);
   });
 });
 

--- a/src/test-kernel/agent/modelHandlers/EmptyPrefill.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/EmptyPrefill.vitest.ts
@@ -70,8 +70,6 @@ function buildConfig(
 function createAgentSetting() {
   return AgentSettingSchema.parse({
     agentCategory: AgentCategory.Workflow,
-    documentTag: 'documents',
-    endTag: '</documents>',
   });
 }
 

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsMessages.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsMessages.vitest.ts
@@ -358,13 +358,16 @@ describe('ModelHandlerGoogleInteractions message construction', () => {
       steps: [
         {
           type: 'model_output',
-          content: [{ type: 'text', text: 'body</doc>' }],
+          content: [{ type: 'text', text: 'body</documents>' }],
         },
       ],
     } as never;
 
-    const { stopReason, text } = handler.extractResponse(response, '</doc>');
-    const setting = { documentTag: 'doc', endTag: '</doc>' } as never;
+    const { stopReason, text } = handler.extractResponse(
+      response,
+      '</documents>',
+    );
+    const setting = {} as never;
     const round = { continuationCount: 0 } as never;
     const global = {
       usageAccumulator: {

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -1292,12 +1292,10 @@ async function withTempOutputPath(
   }
 }
 
-/** Build the workflow AgentSetting shared by the latex_document prefill tests. */
-function createLatexAgentSetting(): AgentSetting {
+/** Build the workflow AgentSetting shared by the prefill tests. */
+function createPrefillAgentSetting(): AgentSetting {
   return AgentSettingSchema.parse({
     agentCategory: AgentCategory.Workflow,
-    documentTag: 'latex_document',
-    endTag: '</latex_document>',
   });
 }
 
@@ -1309,7 +1307,7 @@ describe('ModelHandlerAnthropic output prefill initialization', () => {
       });
       stubHandlerForTest(handler);
 
-      const agentSetting = createLatexAgentSetting();
+      const agentSetting = createPrefillAgentSetting();
       const messages: MessageParam[] = [
         {
           role: 'user',
@@ -1346,7 +1344,7 @@ describe('ModelHandlerAnthropic output prefill initialization', () => {
       });
       stubHandlerForTest(handler);
 
-      const agentSetting = createLatexAgentSetting();
+      const agentSetting = createPrefillAgentSetting();
       const userMessage: MessageParam = {
         role: 'user',
         content: [{ type: 'text', text: 'revise the document' }],
@@ -1379,7 +1377,7 @@ describe('ModelHandlerAnthropic output prefill initialization', () => {
       });
       stubHandlerForTest(handler);
 
-      const agentSetting = createLatexAgentSetting();
+      const agentSetting = createPrefillAgentSetting();
       const userText = 'revise the document';
       const messages: MessageParam[] = [
         {

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerContinuationContract.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerContinuationContract.vitest.ts
@@ -75,8 +75,6 @@ function buildConfig(
 
 const agentSetting = AgentSettingSchema.parse({
   agentCategory: AgentCategory.Workflow,
-  documentTag: 'documents',
-  endTag: '</documents>',
 });
 
 function createWorkspaceState(): AgentWorkspaceState {

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
@@ -998,8 +998,6 @@ describe('ModelHandlerOpenAIResponse.initializeOutputAndPrefill', () => {
       const handler = createHandler();
       const agentSetting = AgentSettingSchema.parse({
         agentCategory: AgentCategory.Workflow,
-        documentTag: 'documents',
-        endTag: '</documents>',
       });
       const userMessage: ResponseInputItem = {
         type: 'message',

--- a/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
@@ -3,7 +3,6 @@ import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import { noopTrace, TraceEmitter, type AgentTrace } from '@agent/trace';
-import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { OutputNode } from '@agent/implementations/flows/reflection/nodes/OutputNode';
 import type { ReflectionFlowShared } from '@agent/implementations/flows/reflection/ReflectionFlowState';
 import type { ReflectionServices } from '@agent/implementations/flows/reflection/ReflectionServices';
@@ -90,11 +89,6 @@ const defaultWorkflowOutputPolicy = {
   shouldAutoOpenPdfOrLog: () => true,
   shouldRejectOnCompileFailure: () => true,
 };
-
-const workflowAgentSetting = {
-  agentCategory: AgentCategory.Workflow,
-  documentTag: 'documents',
-} as ProcessingContext['agentSetting'];
 
 function createRoundDataStore() {
   const roundData = new Map<number, RoundOutput>();
@@ -363,7 +357,6 @@ describe('output progress events', () => {
       },
     } as unknown as XmlOutputManager;
     const context: ProcessingContext = {
-      agentSetting: workflowAgentSetting,
       baseFiles: [],
       streamId: 'stream:processor',
       runtimeHost: host,
@@ -404,7 +397,6 @@ describe('output progress events', () => {
       splitScratchpadMultipleOutputXml: async () => [],
     } as unknown as XmlOutputManager;
     const context: ProcessingContext = {
-      agentSetting: workflowAgentSetting,
       baseFiles: [],
       streamId: 'stream:processor',
       runtimeHost: host,
@@ -458,7 +450,6 @@ describe('output progress events', () => {
         splitScratchpadMultipleOutputXml: async () => [],
       } as unknown as XmlOutputManager;
       const context: ProcessingContext = {
-        agentSetting: workflowAgentSetting,
         baseFiles: [],
         streamId: 'stream:processor',
         runtimeHost: host,

--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { installPlatform } from '@test/support/setupPlatform';
 import type { AgentTrace } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
-import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { assignByContentSimilarity } from '@agent/output/extraction/contentSimilarity';
 import { OutputFileProcessor } from '@agent/output/OutputFileProcessor';
 import { XmlOutputManager } from '@agent/output/XmlOutputManager';
@@ -27,28 +26,7 @@ function initFakePlatform(files: Record<string, string> = {}) {
   return installPlatform({ files, workspacePath: '/workspace' });
 }
 
-function createWorkflowAgentSetting(
-  documentTag: string,
-  overrides: { rounds?: number; defaultOutputFiles?: string[] } = {},
-) {
-  return {
-    agentCategory: AgentCategory.Workflow,
-    documentTag,
-    endTag: '</documents>',
-    temperature: 0,
-    requiredFiles: {},
-    requiredFilesInternal: {},
-    defaultOutputFiles: [],
-    filePatternsContain: [],
-    tools: [],
-    isRewrite: true,
-    rounds: 1,
-    ...overrides,
-  };
-}
-
 function createXmlManager(
-  documentTag = 'document',
   inputFiles: string[] = ['paper.tex'],
   options: {
     outputFiles?: string[];
@@ -56,7 +34,6 @@ function createXmlManager(
   } = {},
 ): XmlOutputManager {
   return new XmlOutputManager(
-    createWorkflowAgentSetting(documentTag),
     {
       inputFiles,
       outputFiles: options.outputFiles ?? [],
@@ -76,7 +53,6 @@ function splitDocuments(
 ): ReturnType<XmlOutputManager['splitScratchpadMultipleOutputXml']> {
   return manager.splitScratchpadMultipleOutputXml(
     createExternalLocation('/tmp/run/output.xml'),
-    'documents',
     0,
   );
 }
@@ -151,7 +127,7 @@ describe('XmlOutputManager', () => {
         'Appendix text.',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
 
     const outputs = await splitDocuments(manager);
 
@@ -180,7 +156,7 @@ describe('XmlOutputManager', () => {
         '```',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
 
     const outputs = await splitDocuments(manager);
 
@@ -209,7 +185,7 @@ describe('XmlOutputManager', () => {
         '```',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
 
     const outputs = await splitDocuments(manager);
 
@@ -238,7 +214,7 @@ describe('XmlOutputManager', () => {
         '```',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
 
     const outputs = await splitDocuments(manager);
 
@@ -267,7 +243,7 @@ describe('XmlOutputManager', () => {
         '\\end{document}',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
 
     const outputs = await splitDocuments(manager);
 
@@ -299,7 +275,7 @@ describe('XmlOutputManager', () => {
         '</document>',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
 
     const outputs = await splitDocuments(manager);
 
@@ -327,7 +303,7 @@ describe('XmlOutputManager', () => {
         '\\end{document}',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
 
     const outputs = await splitDocuments(manager);
 
@@ -354,7 +330,7 @@ describe('XmlOutputManager', () => {
         'Appendix text.',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
 
     const outputs = await splitDocuments(manager);
 
@@ -380,7 +356,7 @@ describe('XmlOutputManager', () => {
         'Part text.',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
 
     const outputs = await splitDocuments(manager);
 
@@ -406,7 +382,7 @@ describe('XmlOutputManager', () => {
         'Generated text.',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
 
     const outputs = await splitDocuments(manager);
 
@@ -427,7 +403,7 @@ describe('XmlOutputManager', () => {
       '/tmp/run/output.xml',
       ['% sections\\intro.tex', 'Intro text.'].join('\n'),
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
 
     const outputs = await splitDocuments(manager);
 
@@ -453,7 +429,7 @@ describe('XmlOutputManager', () => {
         'Appendix text.',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
 
     const outputs = await splitDocuments(manager);
 
@@ -490,7 +466,7 @@ describe('XmlOutputManager', () => {
         'Appendix text.',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
 
     const outputs = await splitDocuments(manager);
 
@@ -528,7 +504,7 @@ describe('XmlOutputManager', () => {
         'Appendix text.',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
 
     const outputs = await splitDocuments(manager);
 
@@ -563,7 +539,7 @@ describe('XmlOutputManager', () => {
         '\\end{document}',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
 
     const outputs = await splitDocuments(manager);
 
@@ -592,7 +568,7 @@ describe('XmlOutputManager', () => {
         'Still the same fragment.',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
 
     const outputs = await splitDocuments(manager);
 
@@ -620,7 +596,7 @@ describe('XmlOutputManager', () => {
         '\n',
       ),
     );
-    const manager = createXmlManager('documents', ['main.tex', 'appendix.tex']);
+    const manager = createXmlManager(['main.tex', 'appendix.tex']);
 
     const outputs = await splitDocuments(manager);
 
@@ -640,7 +616,7 @@ describe('XmlOutputManager', () => {
         '\\section{Intro}',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
 
     const outputs = await splitDocuments(manager);
 
@@ -669,7 +645,7 @@ describe('XmlOutputManager', () => {
         '\\end{document}',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
 
     const outputs = await splitDocuments(manager);
 
@@ -706,7 +682,7 @@ describe('XmlOutputManager', () => {
         'Appendix text.',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
 
     const outputs = await splitDocuments(manager);
 
@@ -742,7 +718,7 @@ describe('XmlOutputManager', () => {
         'Done.',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
 
     const outputs = await splitDocuments(manager);
 
@@ -764,7 +740,7 @@ describe('XmlOutputManager', () => {
         '```',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
 
     const outputs = await splitDocuments(manager);
 
@@ -789,7 +765,7 @@ describe('XmlOutputManager', () => {
         '```',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
 
     const outputs = await splitDocuments(manager);
 
@@ -816,7 +792,7 @@ describe('XmlOutputManager', () => {
         'Done.',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
 
     const outputs = await splitDocuments(manager);
 
@@ -847,7 +823,7 @@ describe('XmlOutputManager', () => {
         'Appendix text.',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
 
     const outputs = await splitDocuments(manager);
 
@@ -875,7 +851,7 @@ describe('XmlOutputManager', () => {
         'Actual output.',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
 
     const outputs = await splitDocuments(manager);
 
@@ -891,7 +867,7 @@ describe('XmlOutputManager', () => {
       '/tmp/run/output.xml',
       ['% chunk.tex', 'First.', '% chunk.tex', 'Second.'].join('\n'),
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
 
     const outputs = await splitDocuments(manager);
 
@@ -919,7 +895,7 @@ describe('XmlOutputManager', () => {
         'Second duplicate.',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
 
     const outputs = await splitDocuments(manager);
 
@@ -944,7 +920,7 @@ describe('XmlOutputManager', () => {
       '/tmp/run/output.xml',
       ['% chunk.tex', '% chunk.tex', 'Actual content.'].join('\n'),
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
 
     const outputs = await splitDocuments(manager);
 
@@ -964,7 +940,7 @@ describe('XmlOutputManager', () => {
         'Equivalent safe path.',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
 
     const outputs = await splitDocuments(manager);
 
@@ -990,7 +966,7 @@ describe('XmlOutputManager', () => {
         'Explicit extracted fallback.',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
 
     const outputs = await splitDocuments(manager);
 
@@ -1017,7 +993,7 @@ describe('XmlOutputManager', () => {
 Appendix.
 </document></documents>`,
     );
-    const manager = createXmlManager('documents');
+    const manager = createXmlManager();
     let roundOutputs: OutputFileInfo[] = [];
     const roundData: RoundOutput = {
       round: 0,
@@ -1032,7 +1008,6 @@ Appendix.
       },
     };
     const processor = new OutputFileProcessor({
-      agentSetting: createWorkflowAgentSetting('documents'),
       baseFiles: [],
       streamId: 'stream',
       runtimeHost: { emit: vi.fn() } as unknown as AgentRuntimeHost,
@@ -1079,7 +1054,7 @@ Appendix.
         '```',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents', [
+    const manager = createXmlManager([
       'Draft/LeanMPSPaper/Draft3.tex',
       'Draft/LeanMPSPaper/endmatter.tex',
     ]);
@@ -1105,9 +1080,7 @@ Appendix.
       '/tmp/run/output.xml',
       ['Draft3.tex:', '```latex', 'Recovered by basename.', '```'].join('\n'),
     );
-    const manager = createXmlManager('documents', [
-      'Draft/LeanMPSPaper/Draft3.tex',
-    ]);
+    const manager = createXmlManager(['Draft/LeanMPSPaper/Draft3.tex']);
 
     const outputs = await splitDocuments(manager);
 
@@ -1131,7 +1104,7 @@ Appendix.
         '```',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents', [
+    const manager = createXmlManager([
       'Draft/LeanMPSPaper/Draft3.tex',
       'Draft/LeanMPSPaper/endmatter.tex',
     ]);
@@ -1156,7 +1129,7 @@ Appendix.
         'Final text.',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents', ['paper.tex']);
+    const manager = createXmlManager(['paper.tex']);
 
     const outputs = await splitDocuments(manager);
 
@@ -1183,10 +1156,7 @@ Appendix.
         '```',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents', [
-      '_macros.tex',
-      '_helpers.tex',
-    ]);
+    const manager = createXmlManager(['_macros.tex', '_helpers.tex']);
 
     const outputs = await splitDocuments(manager);
 
@@ -1210,7 +1180,7 @@ Appendix.
         'Appendix content.',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents', ['main.tex', 'appendix.tex']);
+    const manager = createXmlManager(['main.tex', 'appendix.tex']);
 
     const outputs = await splitDocuments(manager);
 
@@ -1242,7 +1212,7 @@ Appendix.
         '```',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents', ['main.tex']);
+    const manager = createXmlManager(['main.tex']);
 
     const outputs = await splitDocuments(manager);
 
@@ -1268,7 +1238,7 @@ Appendix.
         '```',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents', ['main.tex']);
+    const manager = createXmlManager(['main.tex']);
 
     const outputs = await splitDocuments(manager);
 
@@ -1292,7 +1262,7 @@ Appendix.
         '```',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents', ['main.tex', 'appendix.tex']);
+    const manager = createXmlManager(['main.tex', 'appendix.tex']);
 
     const outputs = await splitDocuments(manager);
 
@@ -1319,7 +1289,7 @@ Appendix.
         'Real body.',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents', ['main.tex']);
+    const manager = createXmlManager(['main.tex']);
 
     const outputs = await splitDocuments(manager);
 
@@ -1342,7 +1312,7 @@ Appendix.
         '```',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents', ['main.tex', 'appendix.tex']);
+    const manager = createXmlManager(['main.tex', 'appendix.tex']);
 
     const outputs = await splitDocuments(manager);
 
@@ -1369,7 +1339,7 @@ Appendix.
         '```',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents', ['main.tex']);
+    const manager = createXmlManager(['main.tex']);
 
     const outputs = await splitDocuments(manager);
 
@@ -1392,7 +1362,7 @@ Appendix.
         '```',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents', ['main.tex']);
+    const manager = createXmlManager(['main.tex']);
 
     const outputs = await splitDocuments(manager);
 
@@ -1409,7 +1379,7 @@ Appendix.
         '\n',
       ),
     );
-    const manager = createXmlManager('documents', ['main.tex']);
+    const manager = createXmlManager(['main.tex']);
 
     const outputs = await splitDocuments(manager);
 
@@ -1431,7 +1401,7 @@ Appendix.
         '```',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents', ['main.tex']);
+    const manager = createXmlManager(['main.tex']);
 
     const outputs = await splitDocuments(manager);
 
@@ -1441,23 +1411,16 @@ Appendix.
     );
   });
 
-  it('strips the configured outer wrapper before filename-label recovery', async () => {
+  it('strips the outer <documents> wrapper before filename-label recovery', async () => {
     await AbsoluteFS.write(
       '/tmp/run/output.xml',
-      [
-        '<latex_documents>',
-        'main.tex:',
-        'Recovered body.',
-        '</latex_documents>',
-      ].join('\n'),
+      ['<documents>', 'main.tex:', 'Recovered body.', '</documents>'].join(
+        '\n',
+      ),
     );
-    const manager = createXmlManager('latex_documents', ['main.tex']);
+    const manager = createXmlManager(['main.tex']);
 
-    const outputs = await manager.splitScratchpadMultipleOutputXml(
-      createExternalLocation('/tmp/run/output.xml'),
-      'latex_documents',
-      0,
-    );
+    const outputs = await splitDocuments(manager);
 
     expect(outputs.map((output) => output.source)).toEqual(['main.tex']);
     await expect(AbsoluteFS.read('/tmp/run/main.tex')).resolves.toBe(
@@ -1470,7 +1433,7 @@ Appendix.
       '/tmp/run/output.xml',
       ['\\section{Intro}', 'Text.', 'paper.tex:', 'More text.'].join('\n'),
     );
-    const manager = createXmlManager('documents', ['paper.tex']);
+    const manager = createXmlManager(['paper.tex']);
 
     const outputs = await splitDocuments(manager);
 
@@ -1496,7 +1459,7 @@ Appendix.
         '\\end{document}',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents', ['main.tex', 'body.tex']);
+    const manager = createXmlManager(['main.tex', 'body.tex']);
 
     const outputs = await splitDocuments(manager);
 
@@ -1543,14 +1506,10 @@ Appendix.
       ].join('\n'),
     );
 
-    const manager = createXmlManager('documents', [
-      'appendices.tex',
-      'cost_section.tex',
-    ]);
+    const manager = createXmlManager(['appendices.tex', 'cost_section.tex']);
 
     const outputs = await manager.splitScratchpadMultipleOutputXml(
       createExternalLocation('/tmp/run/output.xml'),
-      'documents',
       0,
       'scratchpad',
       [
@@ -1579,9 +1538,6 @@ Appendix.
     inputFiles: string[] = ['page1.png', 'page2.png'],
   ): XmlOutputManager {
     return new XmlOutputManager(
-      createWorkflowAgentSetting('documents', {
-        defaultOutputFiles: ['ocr_result.tex'],
-      }),
       {
         inputFiles,
         outputFiles: ['ocr_result.tex'],
@@ -1609,7 +1565,6 @@ Appendix.
     const outputs =
       await createSingleArtifactManager().splitScratchpadMultipleOutputXml(
         createExternalLocation('/tmp/run/output.xml'),
-        'documents',
         0,
         'scratchpad',
         [createExternalLocation('/tmp/run/ocr_result.tex')],
@@ -1634,7 +1589,6 @@ Appendix.
     const outputs =
       await createSingleArtifactManager().splitScratchpadMultipleOutputXml(
         createExternalLocation('/tmp/run/output.xml'),
-        'documents',
         0,
         'scratchpad',
         [createExternalLocation('/tmp/run/ocr_result.tex')],
@@ -1658,7 +1612,6 @@ Appendix.
       'paper.tex',
     ]).splitScratchpadMultipleOutputXml(
       createExternalLocation('/tmp/run/output.xml'),
-      'documents',
       0,
       'scratchpad',
       [createExternalLocation('/tmp/run/ocr_result.tex')],
@@ -1679,7 +1632,6 @@ Appendix.
     const outputs =
       await createSingleArtifactManager().splitScratchpadMultipleOutputXml(
         createExternalLocation('/tmp/run/output.xml'),
-        'documents',
         0,
         'scratchpad',
         [createExternalLocation('/tmp/run/ocr_result.tex')],
@@ -1710,7 +1662,6 @@ Appendix.
     const outputs =
       await createSingleArtifactManager().splitScratchpadMultipleOutputXml(
         createExternalLocation('/tmp/run/output.xml'),
-        'documents',
         0,
         'scratchpad',
         [createExternalLocation('/tmp/run/ocr_result.tex')],
@@ -1744,7 +1695,6 @@ Appendix.
     const outputs =
       await createSingleArtifactManager().splitScratchpadMultipleOutputXml(
         createExternalLocation('/tmp/run/output.xml'),
-        'documents',
         0,
         'scratchpad',
         [createExternalLocation('/tmp/run/ocr_result.tex')],
@@ -1775,7 +1725,6 @@ Appendix.
     const outputs =
       await createSingleArtifactManager().splitScratchpadMultipleOutputXml(
         createExternalLocation('/tmp/run/output.xml'),
-        'documents',
         0,
         'scratchpad',
         [createExternalLocation('/tmp/run/ocr_result.tex')],
@@ -1801,7 +1750,7 @@ Appendix.
         '```',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents', ['paper.tex']);
+    const manager = createXmlManager(['paper.tex']);
 
     const outputs = await splitDocuments(manager);
 
@@ -1830,7 +1779,6 @@ Appendix.
     const outputs =
       await createSingleArtifactManager().splitScratchpadMultipleOutputXml(
         createExternalLocation('/tmp/run/output.xml'),
-        'documents',
         0,
         'scratchpad',
         [createExternalLocation('/tmp/run/ocr_result.tex')],
@@ -1855,11 +1803,10 @@ Appendix.
         '```',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents', ['a.tex', 'b.tex']);
+    const manager = createXmlManager(['a.tex', 'b.tex']);
 
     const outputs = await manager.splitScratchpadMultipleOutputXml(
       createExternalLocation('/tmp/run/output.xml'),
-      'documents',
       0,
       'scratchpad',
       [
@@ -1902,11 +1849,10 @@ Appendix.
         '```',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents', ['cost.tex', 'arch.tex']);
+    const manager = createXmlManager(['cost.tex', 'arch.tex']);
 
     const outputs = await manager.splitScratchpadMultipleOutputXml(
       createExternalLocation('/tmp/run/output.xml'),
-      'documents',
       0,
       'scratchpad',
       [
@@ -1958,10 +1904,7 @@ Appendix.
       ].join('\n'),
     );
 
-    const manager = createXmlManager('documents', [
-      'appendices.tex',
-      'cost_section.tex',
-    ]);
+    const manager = createXmlManager(['appendices.tex', 'cost_section.tex']);
     const roundDataByRound = new Map<number, RoundOutput>();
     const ensureRound = (round: number): RoundOutput => {
       const existing = roundDataByRound.get(round);
@@ -1999,7 +1942,6 @@ Appendix.
     ];
     let roundOutputs: OutputFileInfo[] = [];
     const processor = new OutputFileProcessor({
-      agentSetting: createWorkflowAgentSetting('documents', { rounds: 2 }),
       baseFiles: [
         createExternalLocation('/tmp/run/appendices.tex'),
         createExternalLocation('/tmp/run/cost_section.tex'),
@@ -2050,11 +1992,10 @@ Appendix.
         '```',
       ].join('\n'),
     );
-    const manager = createXmlManager('documents', ['cost.tex', 'arch.tex']);
+    const manager = createXmlManager(['cost.tex', 'arch.tex']);
 
     const outputs = await manager.splitScratchpadMultipleOutputXml(
       createExternalLocation('/tmp/run/output.xml'),
-      'documents',
       0,
       'scratchpad',
       [
@@ -2085,11 +2026,7 @@ Appendix.
         '```',
       ].join('\n'),
     );
-    const manager = createXmlManager(
-      'documents',
-      ['main.tex', 'appendix.tex'],
-      { logger },
-    );
+    const manager = createXmlManager(['main.tex', 'appendix.tex'], { logger });
 
     const outputs = await splitDocuments(manager);
 
@@ -2114,13 +2051,12 @@ Appendix.
       '/tmp/run/output.xml',
       ['```latex', 'Unclosed revised content.'].join('\n'),
     );
-    const manager = createXmlManager('documents', ['a.tex', 'b.tex'], {
+    const manager = createXmlManager(['a.tex', 'b.tex'], {
       logger,
     });
 
     const outputs = await manager.splitScratchpadMultipleOutputXml(
       createExternalLocation('/tmp/run/output.xml'),
-      'documents',
       0,
       'scratchpad',
       [

--- a/src/test-kernel/agent/utils/userVars.vitest.ts
+++ b/src/test-kernel/agent/utils/userVars.vitest.ts
@@ -28,11 +28,9 @@ setupPlatform({}, { config: fakeConfig });
 
 const baseSetting: AgentSetting = {
   agentCategory: AgentCategory.Workflow,
-  documentTag: 'documents',
   temperature: 1,
   isRewrite: true,
   rounds: 1,
-  endTag: '</documents>',
   requiredFiles: {},
   requiredFilesInternal: {},
   defaultOutputFiles: [],

--- a/src/test-kernel/modelHandlers/ModelHandlerGoogle.vitest.ts
+++ b/src/test-kernel/modelHandlers/ModelHandlerGoogle.vitest.ts
@@ -34,10 +34,9 @@ function createGoogleHandler(): ModelHandlerGoogleGenAI {
 describe('ModelHandlerGoogleGenAI.shouldContinue', () => {
   const handler = createGoogleHandler();
 
-  const agentSetting = {
-    endTag: '</doc>',
-    documentTag: 'doc',
-  } as AgentSetting;
+  // The end tag is now a fixed protocol constant (`</documents>`), not a
+  // per-agent setting; `agentSetting` is unused by the base `shouldContinue`.
+  const agentSetting = {} as AgentSetting;
 
   it('continues when FinishReason.MAX_TOKENS is returned without the end tag', () => {
     const shouldContinue = handler.shouldContinue(
@@ -52,7 +51,7 @@ describe('ModelHandlerGoogleGenAI.shouldContinue', () => {
   it('stops when the end tag is present even if FinishReason.MAX_TOKENS was returned', () => {
     const shouldContinue = handler.shouldContinue(
       FinishReason.MAX_TOKENS,
-      'partial output</doc>',
+      'partial output</documents>',
       agentSetting,
     );
 

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -158,9 +158,7 @@ function roundServices(opts: {
     config: testModelConfig as any,
     setting: {
       agentCategory: AgentCategory.ToolUse,
-      documentTag: 'doc',
       temperature: 0,
-      endTag: '</doc>',
       requiredFiles: {},
       requiredFilesInternal: {},
       defaultOutputFiles: [],

--- a/src/utils/text/xmlExtraction.ts
+++ b/src/utils/text/xmlExtraction.ts
@@ -55,10 +55,10 @@ function getObjectStructure(obj: unknown): string {
  */
 export function extractTextFromTag(
   inputContent: string,
-  documentTag: string,
+  tagName: string,
 ): string {
   // Find all matches and get the last one using matchAll
-  const regex = new RegExp(`<${documentTag}>(.*?)<\/${documentTag}>`, 'gs');
+  const regex = new RegExp(`<${tagName}>(.*?)<\/${tagName}>`, 'gs');
   const matches = [...inputContent.matchAll(regex)];
   const lastContent = matches.at(-1)?.[1] ?? '';
 
@@ -137,7 +137,7 @@ export function extractMultipleTextFromTag(
  */
 export function extractContentFromXMLbyTagMultiple(
   root: Record<string, unknown>,
-  documentTag: string,
+  containerTag: string,
 ): Array<{ content: string; name: string }> | null {
   if (!isObject(root)) {
     logger.error(
@@ -147,8 +147,8 @@ export function extractContentFromXMLbyTagMultiple(
     return null;
   }
 
-  if (documentTag in root) {
-    const container = root[documentTag];
+  if (containerTag in root) {
+    const container = root[containerTag];
     if (isObject(container) && 'document' in container) {
       const documents = container.document;
       if (Array.isArray(documents)) {
@@ -169,7 +169,7 @@ export function extractContentFromXMLbyTagMultiple(
 
   logger.error(
     CHANNEL,
-    `No ${documentTag} or document elements found in output file. Structure: ${getObjectStructure(root)}`,
+    `No ${containerTag} or document elements found in output file. Structure: ${getObjectStructure(root)}`,
   );
   return null;
 }
@@ -207,15 +207,15 @@ export interface MultipleExtractionResult {
  * Tries in order: simple tag -> markdown block -> latex document
  *
  * @param outputContent The raw output content to extract from
- * @param documentTag The XML tag to look for
+ * @param tagName The XML tag to look for
  * @returns Extraction result with content and method used
  */
 function extractDocument(
   outputContent: string,
-  documentTag: string,
+  tagName: string,
 ): ExtractionResult {
   // Try simple tag extraction
-  const fallbackContent = extractTextFromTag(outputContent, documentTag);
+  const fallbackContent = extractTextFromTag(outputContent, tagName);
   if (fallbackContent) {
     return { content: fallbackContent, method: 'simple' };
   }
@@ -247,17 +247,17 @@ function extractDocument(
  * unambiguous destination.
  *
  * @param outputContent The raw output content to extract from
- * @param documentTag The container tag to look for documents within
+ * @param containerTag The container tag to look for documents within
  * @param preferredName Recovery hint — when set, treat single-doc legacy
  *   shapes as a one-document result named after the hint
  * @returns Extraction result with documents array and method used
  */
 export function extractDocuments(
   outputContent: string,
-  documentTag: string,
+  containerTag: string,
   preferredName?: string,
 ): MultipleExtractionResult {
-  const documents = extractMultipleTextFromTag(outputContent, documentTag);
+  const documents = extractMultipleTextFromTag(outputContent, containerTag);
   if (documents && documents.length > 0) {
     return { documents, method: 'simple' };
   }


### PR DESCRIPTION
## Root cause

`docs/proposals/unified-output-protocol.md` is marked partially landed: bundled agents and templates converged on the `<documents><document name="...">` container, but the schema/registry deletion step never completed — `settings.documentTag`/`settings.endTag` stayed configurable in the schema even though every bundled agent (and every consumer) already used the same fixed value. The protocol was fixed in practice but configurable in type, so `XmlOutputManager`, `OutputFileProcessor`, `ModelHandler`, and the progress-view formatter all threaded the tag through as runtime data pulled from settings instead of reading a constant.

## Fix

- Add `OUTPUT_DOCUMENTS_TAG` / `OUTPUT_DOCUMENT_TAG` / `OUTPUT_END_TAG` in a new `src/shared/constants/outputProtocol.ts`, and read them everywhere the tag was previously sourced from `agentSetting.documentTag`/`.endTag` or threaded as a parameter.
- Drop `documentTag`/`endTag` from `AgentSettingBaseSchema` and `RawAgentSettingInputSchema`. `stripLegacySettingFields` (the existing home for `outputExt`/`prefills` legacy stripping) now also ignores `documentTag`/`endTag` with a `console.warn` — not the structured trace logger, since that would drag `core/definition` (a dependency-free leaf schema module per `src/agent/core/README.md`) into the logger's `@shared/schemas` barrel just for one deprecation notice (same pattern as `src/shared/schemas/streamData.ts`'s `warnDroppedItem`). Old custom-agent YAML that still sets these fields keeps loading instead of failing validation.
- Simplify `XmlOutputManager` (drop the `documentTag` constructor param and the two methods' `documentTag` parameters; the constructor's `agentSetting` field became fully unused once the tag reads moved to the constant, so it's gone too — one production call site plus tests updated) and `OutputFileProcessor` (`ProcessingContext.agentSetting` was only ever read for `.documentTag`; also gone).
- `ModelHandler.hasEndTag` drops its `settings` parameter (fixed constant now, not a setting).
- Drop the now-dead `documentTag` field from `MissingOutputsPayloadSchema`; the progress-view formatter renders the fixed tag directly instead of threading it through log data.
- Sweep the 7 bundled agent YAMLs, the 2 agent-creation templates, and the 2 packaged agent-creation docs for the now-invalid `documentTag: documents` / `endTag: </documents>` settings and stale prose (all bundled agents already set the values that match the new constants, so this is a no-op for their behavior).

## Acceptance check

```
grep -rn "documentTag" src packages
```
now hits only `src/shared/constants/outputProtocol.ts` (doc comment), `src/agent/core/definition/AgentDataclass.ts` (the tolerant-strip shim + its doc comment), and `src/test-kernel/agent/AgentSettingSchema.vitest.ts` (the regression test for that shim — it necessarily has to name the field to test that it's stripped).

## Scope note

`docs/proposals/unified-output-protocol.md`'s bigger fork-removal plan (`isMultipleOutput`, `MULTIPLE_SUFFIX`, `groupByBaseName`, paired `_multiple` YAMLs, remote-storage cleanup) is untouched — that's a separate, much larger effort the issue explicitly doesn't ask for. I bumped the doc's status header to note this sub-step landed. I also left `reference-agents/*.yaml` (top-level, not under `src`/`packages`) and historical/frozen docs (`docs/prds/*`, `docs/supabase/MIGRATION_UNIFY_MULTIPLE.md`, `docs/proposals/google-interactions-*-spec.md`) alone — they're outside the acceptance grep's `src packages` scope and are either point-in-time records or a separately-maintained example set (several already carry other unrelated stale fields like `outputExt`, suggesting they're not kept in lockstep with `packages/extension/resources`). I couldn't check the live Supabase `remote_agents` table for a non-default `documentTag` from this sandbox (no production DB access); the tolerant ignore-with-warning parse is the safety net if one exists.

## Verification

- `npx tsc --noEmit` and `npx tsc --noEmit -p tsconfig.test-kernel.json` — diffed byte-for-byte against origin/main in this same sandbox; identical pre-existing environment-only errors (missing `@openrouter/sdk`/`vscode-jsonrpc`/`citty`/`ink`/`react`/`electron` type declarations under this worktree's partial `node_modules`), zero new errors, none in changed files.
- `npx eslint <changed .ts/.tsx files>` — clean (one import-order warning auto-fixed).
- `npx prettier --check <changed files>` — clean (two files needed `--write`, both markdown line-wrap only).
- `npx vitest run src/test-kernel/agent/` — 148 files, 1055 passed, 4 skipped (one fewer test than baseline: two `AgentSettingSchema.vitest.ts` cases collapsed into one covering the tolerant-strip behavior).
- `npx vitest run src/test-kernel/tools/BashTool.vitest.ts src/test-kernel/modelHandlers/ModelHandlerGoogle.vitest.ts` — 14 passed.
- Full `npm test` — 75 pre-existing environment-only failures (same file set, same count, confirmed identical against origin/main in this sandbox — missing `packages/cli`/`packages/desktop` deps), zero new failures; 3825 passed vs. baseline 3826 (same one-test consolidation as above).

https://claude.ai/code/session_01WPQvBwoRRof78oSE8VKTHD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core output parsing and model continuation/stop logic; legacy custom agents with non-standard tags will behave differently without failing load, which could surprise users until they fix YAML.
> 
> **Overview**
> **Locks workflow output to the unified `<documents><document name="...">` container** by introducing `@shared/constants/outputProtocol` and routing extraction, continuation, prefill, and progress-view messaging through those constants instead of `settings.documentTag` / `settings.endTag`.
> 
> **Schema and wiring cleanup:** `documentTag`/`endTag` are removed from agent settings Zod schemas; `endTag` derivation helpers are deleted; `hasEndTag` no longer takes settings. `XmlOutputManager` and `OutputFileProcessor` drop settings/parameters that only existed to pass the tag. `MissingOutputsPayloadSchema` no longer carries `documentTag`.
> 
> **Backward compatibility:** YAML that still sets `documentTag`/`endTag` loads with fields stripped and a `console.warn` (custom agents that relied on bespoke tags now get the standard container silently). Bundled agent YAMLs, templates, and agent-creation docs are swept to remove the obsolete settings and update prose.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff59f5067b42eb9c07123d8569bd7463f354ebb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->