### PR TITLE
fix(latex): restore arxivProcessor default log channel to 'arxivProcessor' (Closes #7359)

### DIFF
--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -72,7 +72,12 @@ export function resolveArxivPaperDirectoryRelative(
 }
 
 class ArxivSourceProcessor {
-  constructor(private readonly channel: string = 'ArxivProcessor') {
+  // NOTE: The default channel string stays 'arxivProcessor' (lowercase) even
+  // though the exported singleton was renamed to PascalCase in #7347. It is used
+  // directly as the logger channel and prefixes every log line as
+  // `[arxivProcessor] ...`, so keep it stable for anything filtering on the
+  // channel name — a class-identifier rename must not change this value.
+  constructor(private readonly channel: string = 'arxivProcessor') {
     logger.initialize(this.channel);
   }
 

--- a/src/test-kernel/latex/ArxivProcessor.vitest.ts
+++ b/src/test-kernel/latex/ArxivProcessor.vitest.ts
@@ -43,6 +43,18 @@ describe('arXiv processor paths', () => {
   });
 });
 
+describe('arXiv processor logger channel', () => {
+  it('defaults the log channel to "arxivProcessor" (stable across the #7347 PascalCase rename)', () => {
+    // `channel` is private, but it is the exact value passed to
+    // logger.info(this.channel, ...) and rendered as the `[channel]` prefix on
+    // every log line this class emits. #7347 renamed the exported singleton to
+    // PascalCase and accidentally changed this string too; the channel value
+    // must stay lowercase so log filters keep matching `[arxivProcessor]`.
+    const channel = (ArxivProcessor as unknown as { channel: string }).channel;
+    expect(channel).toBe('arxivProcessor');
+  });
+});
+
 describe('arXiv source download filenames', () => {
   it('does not infer a missing header filename when it matches the base path', async () => {
     const dir = await makeTempDir();


### PR DESCRIPTION
## Root cause

#7347 (`refactor(naming): rename service-singleton exports to PascalCase`) was described as a pure identifier rename with no behavior change, but it also changed `ArxivSourceProcessor`'s default `channel` constructor param from the string `'arxivProcessor'` to `'ArxivProcessor'` (`src/latex/arxivProcessor.ts`).

`this.channel` is passed directly to the logger — `logger.info(this.channel, ...)` — and `logAt`/`writeLine` in `src/logger/logUtils.ts` prefix non-agent log lines with `` `[${channel}] ` ``. So every line this class emitted changed from `[arxivProcessor] ...` to `[ArxivProcessor] ...`, breaking log continuity for anything that greps/filters on the old channel name. A class-identifier rename should not have changed the channel string value. This was flagged twice in the #7347 review and never addressed before merge.

## Fix

- Restore the default `channel` string literal to `'arxivProcessor'` (only the string value — the class and exported `ArxivProcessor` singleton stay PascalCase, as #7347 intended). Added a short comment documenting why the channel string stays lowercase despite the PascalCase identifier.
- Verified this was the only genuine channel-*value* regression in #7347: `git show <7347> -- src/latex/ src/logger/` shows the other diffs (`FlexibleFS`, `LaTeXdiffService`) are identifier renames, and `CHANNEL = 'LaTeXCommands'` string was unchanged. Other latex classes default their channel to the `CHANNEL` const, not a PascalCased literal.
- Added a focused test asserting the exported `ArxivProcessor` singleton's default channel is `'arxivProcessor'`.

## Net diff (`git diff --stat origin/main`)

```
 src/latex/arxivProcessor.ts                    |  7 ++++++-
 src/test-kernel/latex/ArxivProcessor.vitest.ts | 12 ++++++++++++
 2 files changed, 18 insertions(+), 1 deletion(-)
```

## Test results

- `npx vitest run src/test-kernel/latex/ArxivProcessor.vitest.ts` — 3 passed (incl. new channel guard).
- `npx vitest run src/test-kernel/logger` — 5 passed.
- `npm run typecheck` — the 13 pre-existing errors are all in unrelated files (`src/agent/modelHandlers/openrouter/*`, `src/tools/lean/direct/jsonRpc.ts`, `ResponseUsage.ts`); none in the touched files.

Closes #7359

https://claude.ai/code/session_01PkkPA9A5vht7PmB9xxiqU3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single string default and documentation/test only; no download, extraction, or API behavior changes.
> 
> **Overview**
> Fixes a **logging regression** from #7347: the PascalCase rename accidentally changed `ArxivSourceProcessor`'s default `channel` constructor argument from `'arxivProcessor'` to `'ArxivProcessor'`, so log lines prefixed with `[channel]` no longer matched existing filters.
> 
> Restores the default channel string to **`'arxivProcessor'`** while keeping the class and `ArxivProcessor` export PascalCase. Adds a short comment explaining why the channel string stays lowercase, and a vitest that asserts the singleton's default channel remains `'arxivProcessor'`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68f3d15c2b263e0f8793530c0a1ad7df9796e787. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->