### PR TITLE
fix(modelHandlers): gate appendEndTagIfNeeded to stop-configured models

### DIFF
--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -279,6 +279,18 @@ export class ModelHandlerOpenAI<
     return summaryParams;
   }
 
+  /**
+   * Whether this request configures the agent's end tag as an API-level `stop`
+   * sequence (see `buildChatBaseParams`). o-series and Grok reasoning models
+   * never do, so a natural `STOP` finish from them does not imply the provider
+   * stripped the end tag. Single source of truth gating both the `stop` config
+   * and `extractResponse`'s `appendEndTagIfNeeded` restoration, so the two
+   * can't drift apart.
+   */
+  protected get configuresEndTagStopSequence(): boolean {
+    return !this.isOReasoningModel && !this.isGrokReasoningModel;
+  }
+
   protected buildChatBaseParams(
     messages: ChatCompletionMessageParam[],
     temperature?: number,
@@ -296,7 +308,7 @@ export class ModelHandlerOpenAI<
         : { max_tokens: effectiveMaxTokens }),
     };
 
-    if (!this.isOReasoningModel && !this.isGrokReasoningModel) {
+    if (this.configuresEndTagStopSequence) {
       if (endTag) {
         baseParams.stop = [endTag];
       }
@@ -941,11 +953,16 @@ export class ModelHandlerOpenAI<
           completion_tokens: 0,
         };
 
-        // Add end tag if response was stopped and tag isn't present
+        // Only restore the end tag when it was configured as an API-level
+        // stop sequence (see `configuresEndTagStopSequence`). o-series/Grok
+        // reasoning models never set `stop`, so a natural STOP there doesn't
+        // imply the provider stripped the tag — forging it could mask
+        // incomplete output as complete.
         newResponse = this.appendEndTagIfNeeded(
           newResponse,
           endTag,
-          stopReason === OPENAI_CHAT_FINISH.STOP,
+          stopReason === OPENAI_CHAT_FINISH.STOP &&
+            this.configuresEndTagStopSequence,
         );
         newResponse = replacementEngine.applyAll(newResponse);
 
@@ -987,11 +1004,16 @@ export class ModelHandlerOpenAI<
       this.logger.error('content is empty');
     }
 
-    // Add end tag if response was stopped and tag isn't present
+    // Only restore the end tag when it was configured as an API-level stop
+    // sequence (see `configuresEndTagStopSequence`). o-series/Grok reasoning
+    // models never set `stop`, so a natural STOP there doesn't imply the
+    // provider stripped the tag — forging it could mask incomplete output as
+    // complete.
     newResponse = this.appendEndTagIfNeeded(
       newResponse,
       endTag,
-      stopReason === OPENAI_CHAT_FINISH.STOP,
+      stopReason === OPENAI_CHAT_FINISH.STOP &&
+        this.configuresEndTagStopSequence,
     );
     newResponse = replacementEngine.applyAll(newResponse);
 

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIEndTag.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIEndTag.vitest.ts
@@ -1,0 +1,114 @@
+// Third-party imports
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'vitest';
+import {
+  DEFAULT_MODEL_CAPABILITIES,
+  type ModelConfig,
+  ModelProvider,
+} from 'llm-zoo';
+
+// Local imports - agent
+import type { AgentTrace } from '@agent/trace';
+import { ModelHandlerOpenAI } from '@agent/modelHandlers/openai/modelHandlerOpenAI';
+import { ModelHandlerXAI } from '@agent/modelHandlers/openai/modelHandlerXAI';
+
+const END_TAG = '</document>';
+
+function createLoggerStub(): AgentTrace {
+  const noop = () => {
+    /* no-op for tests */
+  };
+  return {
+    streamId: 'test-channel',
+    debug: noop,
+    info: noop,
+    warn: noop,
+    error: noop,
+  } as unknown as AgentTrace;
+}
+
+function buildConfig(
+  provider: ModelProvider,
+  overrides: Partial<ModelConfig> = {},
+): ModelConfig {
+  return {
+    name: 'test-model',
+    fullName: 'test-model',
+    shortName: 'test-model',
+    provider,
+    maxOutputTokens: 1024,
+    inputPrice: 0,
+    outputPrice: 0,
+    contextWindow: 200000,
+    capabilities: {
+      ...DEFAULT_MODEL_CAPABILITIES,
+      supportsVision: false,
+      ...(overrides.capabilities ?? {}),
+    },
+    openRouterOnly: false,
+    ...overrides,
+    label: overrides.label ?? 'Test Model',
+  };
+}
+
+/** A `stop`-configured completion whose text is missing its closing end tag. */
+function completionWithoutEndTag() {
+  return {
+    id: 'test-completion',
+    choices: [
+      {
+        index: 0,
+        message: { role: 'assistant', content: 'the document body' },
+        finish_reason: 'stop',
+      },
+    ],
+    usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+  } as any;
+}
+
+describe('ModelHandlerOpenAI.extractResponse end-tag restoration', () => {
+  it('restores the end tag for a non-reasoning model that configures a stop sequence', () => {
+    // A plain OpenAI chat model sets `stop: [endTag]`, so the SDK strips the
+    // matched tag from the completion — extractResponse must put it back.
+    const handler = new ModelHandlerOpenAI(
+      buildConfig(ModelProvider.OPENAI, {
+        capabilities: { supportsReasoning: false },
+      }),
+    );
+    handler.setLogger(createLoggerStub());
+
+    const result = handler.extractResponse(completionWithoutEndTag(), END_TAG);
+
+    assert.equal(result.text, `the document body\n${END_TAG}`);
+  });
+
+  it('does not forge an end tag for an o-series reasoning model (no stop configured)', () => {
+    // o-series reasoning models never configure `stop`, so a natural STOP does
+    // not imply the provider stripped the tag — forging it could mask
+    // genuinely incomplete output as complete.
+    const handler = new ModelHandlerOpenAI(
+      buildConfig(ModelProvider.OPENAI, {
+        capabilities: { supportsReasoning: true },
+      }),
+    );
+    handler.setLogger(createLoggerStub());
+
+    const result = handler.extractResponse(completionWithoutEndTag(), END_TAG);
+
+    assert.equal(result.text, 'the document body');
+  });
+
+  it('does not forge an end tag for a Grok reasoning model (no stop configured)', () => {
+    // ModelHandlerXAI inherits the gated behavior via super.extractResponse().
+    const handler = new ModelHandlerXAI(
+      buildConfig(ModelProvider.XAI, {
+        capabilities: { supportsReasoning: true },
+      }),
+    );
+    handler.setLogger(createLoggerStub());
+
+    const result = handler.extractResponse(completionWithoutEndTag(), END_TAG);
+
+    assert.equal(result.text, 'the document body');
+  });
+});

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIEndTag.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIEndTag.vitest.ts
@@ -3,6 +3,7 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'vitest';
 import {
   DEFAULT_MODEL_CAPABILITIES,
+  type ModelCapabilities,
   type ModelConfig,
   ModelProvider,
 } from 'llm-zoo';
@@ -29,8 +30,11 @@ function createLoggerStub(): AgentTrace {
 
 function buildConfig(
   provider: ModelProvider,
-  overrides: Partial<ModelConfig> = {},
+  overrides: Partial<Omit<ModelConfig, 'capabilities'>> & {
+    capabilities?: Partial<ModelCapabilities>;
+  } = {},
 ): ModelConfig {
+  const { capabilities: capabilityOverrides, label, ...rest } = overrides;
   return {
     name: 'test-model',
     fullName: 'test-model',
@@ -40,14 +44,14 @@ function buildConfig(
     inputPrice: 0,
     outputPrice: 0,
     contextWindow: 200000,
+    openRouterOnly: false,
+    ...rest,
     capabilities: {
       ...DEFAULT_MODEL_CAPABILITIES,
       supportsVision: false,
-      ...(overrides.capabilities ?? {}),
+      ...(capabilityOverrides ?? {}),
     },
-    openRouterOnly: false,
-    ...overrides,
-    label: overrides.label ?? 'Test Model',
+    label: label ?? 'Test Model',
   };
 }
 


### PR DESCRIPTION
## Root cause

Follow-up to #7345 (root issue #7095), which stopped forging the agent's closing end tag on the **Responses API** because that API has no `stop` parameter — a `completed` status never implies the provider stripped the tag.

`src/agent/modelHandlers/openai/modelHandlerOpenAI.ts` had the **same latent bug** for o-series and Grok reasoning models. `buildChatBaseParams` only configures the end tag as an API-level stop sequence when it is *not* a reasoning model:

```ts
if (!this.isOReasoningModel && !this.isGrokReasoningModel) {
  if (endTag) baseParams.stop = [endTag];
  ...
}
```

…but `extractResponse`'s two `appendEndTagIfNeeded` call sites used `stopReason === OPENAI_CHAT_FINISH.STOP` **alone** as the "natural stop" predicate, with no reasoning/Grok exception. For o-series/Grok reasoning models the request never set `stop`, so a natural `STOP` there does **not** mean the provider stripped anything — forging the tag can mask genuinely incomplete output as complete, the exact failure mode #7345 fixed on the Responses path. `ModelHandlerXAI.extractResponse` inherited this via `super.extractResponse()`.

Flagged by two reviews on #7345 (the repo `review` agent and the Claude code-review pass).

## Fix

Introduce a single `configuresEndTagStopSequence` getter as the **one source of truth** for "the end tag was configured as an API-level `stop` sequence" (`!isOReasoningModel && !isGrokReasoningModel`). It now gates **both**:

- the `stop` config in `buildChatBaseParams`, and
- the "natural stop" predicate passed to `appendEndTagIfNeeded` at both `extractResponse` call sites,

so the request config and the tag-restoration can't drift apart. Mirrors #7345's approach (restore the tag only where a configured stop sequence backs the predicate).

## Tests

New `ModelHandlerOpenAIEndTag.vitest.ts` regression test, analogous to #7345's:

- non-reasoning OpenAI model (stop configured) → missing end tag is restored;
- o-series reasoning model (no stop) → tag not forged;
- Grok reasoning model via `ModelHandlerXAI` (no stop) → tag not forged.

Results:
- `npm run typecheck`: 0 errors in the changed files (13 pre-existing errors elsewhere — `openrouter/*`, `ResponseUsage.ts`, `lean/jsonRpc.ts` — verified identical on `origin/main`, unrelated to this change).
- `npx vitest run src/test-kernel/agent/modelHandlers/`: 386 passed | 4 skipped (incl. the 3 new tests).

## Net diff

`git diff --stat origin/main`: 2 files, +141 / −5.

Closes #7360.

https://claude.ai/code/session_01PkkPA9A5vht7PmB9xxiqU3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow behavior change in response post-processing for reasoning models; aligns restoration with request config and adds targeted tests.
> 
> **Overview**
> Fixes a chat-completions bug where **`extractResponse`** could **append the agent end tag** on any `finish_reason: stop`, even for **o-series and Grok reasoning** models that **never send `stop: [endTag]`** in the request. That could treat truncated output as complete (same class of issue as #7345 on the Responses API).
> 
> Adds **`configuresEndTagStopSequence`** as the single gate for both **`buildChatBaseParams`** (`stop` + temperature) and **`appendEndTagIfNeeded`** in **`extractResponse`** (both code paths). **`ModelHandlerXAI`** picks this up via the base class.
> 
> New **`ModelHandlerOpenAIEndTag.vitest.ts`** covers: restore tag when stop is configured; no forge for o-series or Grok reasoning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4137de1f040c89c5215a4e945eab00d6703c978. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->