### PR TITLE
fix(output): wire OUTPUT_DOCUMENT_TAG into its call sites

### DIFF
--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -13,7 +13,10 @@ import { getExtractedDocOutputFileName } from '@agent/utils/outputFileUtils';
 import replacementEngine, { applyReplacements } from '@replacement/engine';
 import { FENCED_LATEX_BLOCK_REPLACEMENTS } from '@replacement/rulesRegex';
 import type { FileLocation, OutputFileInfo } from '@shared/schemas';
-import { OUTPUT_DOCUMENTS_TAG } from '@shared/constants/outputProtocol';
+import {
+  OUTPUT_DOCUMENT_TAG,
+  OUTPUT_DOCUMENTS_TAG,
+} from '@shared/constants/outputProtocol';
 import {
   AbsoluteFS,
   createExternalLocation,
@@ -247,7 +250,7 @@ export class XmlOutputManager {
     // similarity tiers below read the raw response instead.
     const cdataWrapped = addCdataToTagsMultiple(rawOutputContent, [
       thinkingTag,
-      'document',
+      OUTPUT_DOCUMENT_TAG,
     ]);
 
     let documents: Array<{ content: string; name: string }> | null = null;

--- a/src/utils/text/xmlExtraction.ts
+++ b/src/utils/text/xmlExtraction.ts
@@ -9,6 +9,7 @@
 
 // Local imports - utils
 import * as logger from '@logger/logUtils';
+import { OUTPUT_DOCUMENT_TAG } from '@shared/constants/outputProtocol';
 import { isObject } from '@utils/core';
 
 // Local imports
@@ -149,8 +150,8 @@ export function extractContentFromXMLbyTagMultiple(
 
   if (containerTag in root) {
     const container = root[containerTag];
-    if (isObject(container) && 'document' in container) {
-      const documents = container.document;
+    if (isObject(container) && OUTPUT_DOCUMENT_TAG in container) {
+      const documents = container[OUTPUT_DOCUMENT_TAG];
       if (Array.isArray(documents)) {
         return documents.map((doc) => {
           const entry = doc as Record<string, unknown>;


### PR DESCRIPTION
## Root cause

PR #7356 introduced `OUTPUT_DOCUMENT_TAG = 'document'` in `src/shared/constants/outputProtocol.ts` as the unified-output-protocol constant for the per-document child tag, but never wired it into any consumer. The literal `'document'` stayed hardcoded at the two places the constant was meant to replace. Three review passes on #7356 (two `claude[bot]` + the automated `github-actions[bot]` review) flagged this inline before merge and it went unaddressed.

## Fix

Replaced both hardcoded `'document'` literals with `OUTPUT_DOCUMENT_TAG`:

- `src/agent/output/XmlOutputManager.ts:250` — the `addCdataToTagsMultiple(rawOutputContent, [thinkingTag, 'document'])` call now reads `OUTPUT_DOCUMENT_TAG`.
- `src/utils/text/xmlExtraction.ts:152-153` — `extractContentFromXMLbyTagMultiple`'s `'document' in container` check and the paired `container.document` property access now both key off `OUTPUT_DOCUMENT_TAG` (switched to bracket-notation access so both stay tied to the same constant instead of drifting if the tag name ever changes).

Left the other `'document'`/`'documents'` occurrences in `XmlOutputManager.ts` (lines 101, 212, 306) untouched — those are the English singular/plural word passed to `formatResultCount(...)` for log messages, not the protocol tag, as called out in the issue.

No behavior change: `OUTPUT_DOCUMENT_TAG`'s value is exactly `'document'`, so this is a pure literal→constant swap.

## Verification

- `npx tsc --noEmit` — same pre-existing, unrelated errors (`@openrouter/sdk` module-resolution + `vscode-jsonrpc/node` type errors) present identically on the base commit before this change; no new errors introduced.
- `npx eslint src/agent/output/XmlOutputManager.ts src/utils/text/xmlExtraction.ts` — clean.
- `npx prettier --check src/agent/output/XmlOutputManager.ts src/utils/text/xmlExtraction.ts` — clean, no reformatting needed.
- `npx vitest run src/test-kernel/agent/output/XmlOutputManager.vitest.ts src/test-kernel/utils/text/xmlUtils.vitest.ts src/test-kernel/utils/text/ExtractDocumentsLegacyFallback.vitest.ts` — 91/91 passed. These suites already exercise the `<document name="...">` XML-parse, CDATA-wrap, and legacy-fallback extraction paths through both changed call sites, so no new regression test was needed.

Fixes #7364.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Literal-to-constant refactor only; tag value unchanged and existing tests cover both call sites.
> 
> **Overview**
> Replaces hardcoded `'document'` protocol tag literals with the shared **`OUTPUT_DOCUMENT_TAG`** constant so per-document XML handling stays aligned with the unified output protocol.
> 
> In **`XmlOutputManager`**, CDATA wrapping for the XML-parse tier now passes **`OUTPUT_DOCUMENT_TAG`** into **`addCdataToTagsMultiple`** alongside the thinking tag. In **`xmlExtraction`**, **`extractContentFromXMLbyTagMultiple`** uses the same constant for the container child check and document array access (bracket notation so both stay tied to one definition).
> 
> No runtime change: the constant is still `'document'`. Log strings that use the English word “document” for counts were left as-is.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f283784d28ce6ce02cdd257227c1cea8669c9052. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->