### PR TITLE
docs(modelHandlers): triage supportsManualCompaction as a genuine per-provider predicate (#7101)

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -521,7 +521,16 @@ export abstract class ModelHandler<
     return this.capabilities.supportsReasoningEffort;
   }
 
-  /** Whether this handler supports manual context compaction. Override in subclasses. */
+  /**
+   * Whether this handler supports manual (user-requested) context compaction.
+   * Each override computes this differently — Anthropic combines llm-zoo
+   * model-family eligibility with tool-use mode, OpenAI-family handlers gate
+   * on tool-use mode alone, OpenAIResponse reads the ChatGPT-subscription
+   * profile with an OpenRouter-routing fallback, and GoogleInteractions is
+   * unconditionally true — so no single capability-profile read replaces the
+   * per-handler logic. Stays an overridable getter (#7101 triage: genuinely
+   * per-provider behavior, not a foldable predicate).
+   */
   get supportsManualCompaction(): boolean {
     return false;
   }

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -230,6 +230,13 @@ export class ModelHandlerAnthropic extends ModelHandler<
     return getAnthropicMaxPdfPages(this.getEffectiveContextWindow());
   }
 
+  /**
+   * Client-side compaction is available for tool-use sessions on models whose
+   * llm-zoo family is compaction-eligible. `isCompactionEligibleModel` is a
+   * `startsWith`-style model-family gate in `anthropicThinking.ts`; moving it
+   * to an llm-zoo capability flag is #7080's scope, not this predicate's own
+   * #7101 triage.
+   */
   override get supportsManualCompaction(): boolean {
     return (
       isCompactionEligibleModel(this.config.fullName) && this.isToolUseMode()

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -371,6 +371,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
   protected override backgroundModeSupported = true;
 
+  /**
+   * Reads the ChatGPT-subscription profile when active (that backend doesn't
+   * support manual compaction); otherwise falls back to whether this request
+   * is routed through OpenRouter, which implements its own compaction path via
+   * `ModelHandlerOpenRouterNative` instead.
+   */
   override get supportsManualCompaction(): boolean {
     return (
       this.getOpenAIResponseCapabilities()?.supportsManualCompaction ??

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -93,6 +93,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
   // ── Client-side compaction state ──────────────────────────────────────
   private lastKnownInputTokens = 0;
 
+  /** Client-side compaction is implemented for tool-use sessions regardless of the routed-through provider. */
   override get supportsManualCompaction(): boolean {
     return this.isToolUseMode();
   }


### PR DESCRIPTION
## Root cause / context

F4 (#6974/#7024) folded llm-zoo capability flags into `this.capabilities` reads. #7101 tracks folding the remaining ~28 `ModelHandler` base predicates into capability-profile reads, one cluster per PR. #7346 folded the six provider-identity getters; #7353 folded `supportsTokenCounting`. This PR triages the `supportsManualCompaction` cluster.

## Investigation

`supportsManualCompaction` has five overrides across the handler hierarchy, and none of them reduce to a single capability-profile read:

- **Anthropic**: `isCompactionEligibleModel(this.config.fullName) && this.isToolUseMode()` — combines a `startsWith`-style llm-zoo model-family gate (in `anthropicThinking.ts`) with tool-use mode. Moving that model-family gate to an llm-zoo flag is explicitly **#7080's** scope (a neighboring but distinct issue), not this predicate's own #7101 triage.
- **OpenAI (chat)** and **OpenRouterNative**: gate on tool-use mode alone.
- **OpenAIResponse**: reads the ChatGPT-subscription `ProviderCapabilityProfile` when active, falling back to an OpenRouter-routing check.
- **GoogleInteractions**: unconditionally `true` (documented reason: never reached through OpenRouter).

Each formula differs (model-family × mode, mode alone, profile × routing, constant) — there's no shared pure-data read to fold the base getter into without either losing per-handler logic or inventing a new capability-profile axis to hold a single boolean, which is exactly the premature-abstraction-for-under-3-shared-call-sites pattern this repo's own tech-debt audits flag as a net-LOC add rather than a savings.

## Fix

Per the issue's own triage rule ("...or add a doc comment marking it as a genuine per-provider combinator, mirroring the #7346/#7353 pattern exactly"), this predicate belongs in the **genuinely per-provider behavior** bucket the base class already named for `isAutoRetryManagedByProvider`/`isBackgroundModeActive`. This PR:

- Documents that conclusion on the base `supportsManualCompaction` getter.
- Adds the provider-specific rationale at each override site that lacked one (Anthropic, OpenAIResponse, OpenRouterNative). OpenAI (chat) and GoogleInteractions already had adequate doc comments, left untouched.

**No behavior change** — every override's returned value and all read call sites are untouched; this is a documentation-only change.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint <changed files>` — clean
- `npx vitest run src/test-kernel/modelHandlers src/test-kernel/agent/modelHandlers src/test-kernel/agent/modelHandlers/OpenAIResponseCompaction.vitest.ts src/test-kernel/model/ProviderCapabilities.vitest.ts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts` — 429 passed, 4 skipped
- `npx prettier --check <changed files>` — clean

## Scope note

#7101 is scoped as incremental (one predicate cluster per PR). The remaining clusters — file-upload (`canProcessToolResultAttachments`/`supportsToolResultFileUpload`) and pseudo-prefill (`shouldStorePseudoPrefillAsOutput`/`shouldPrependPrefillOnResumeWithoutAssistantPrefill`) — are left for follow-up PRs, so **this does not close #7101**.

Note on the commit/PR body wording: I deliberately avoided a `Fixes #7101`-shaped phrase anywhere in this PR. GitHub's closing-keyword matcher doesn't parse negation, and it has already false-positive-closed #7101 twice (after #7346 and #7353 merged) purely because their bodies contained a negated "...does not close #7101" sentence that still matched the keyword scanner. This PR references the issue as "Part of #7101" instead.

Claude-Session: https://claude.ai/code/session_01WPQvBwoRRof78oSE8VKTHD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes with no logic, API, or call-site modifications.
> 
> **Overview**
> **Documentation-only** follow-up to #7101: `supportsManualCompaction` stays an overridable getter rather than a single `this.capabilities` read, because each provider’s formula differs.
> 
> The base `ModelHandler` getter now explains that Anthropic, OpenAI-family, OpenAI Response, and Google Interactions each compute manual compaction eligibility differently, matching the “genuine per-provider behavior” bucket used for predicates like `isAutoRetryManagedByProvider`.
> 
> Provider-specific comments were added where they were missing: **Anthropic** (model-family gate × tool-use mode), **OpenAI Response** (ChatGPT subscription profile vs OpenRouter routing), and **OpenRouter native** (tool-use only). **No runtime or return-value changes** — only doc comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7250d5c0c18e5e999bc5eb734fd0f59271977f49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->