### PR TITLE
refactor: persist CLI snapshots from session facts

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -24,6 +24,7 @@ import { getVisibleAgents, loadAgents } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { detachSubagentsOnStop } from '@agent/runtime/detachSubagentsOnStop';
 import { executionRegistry } from '@agent/runtime/executionRegistry';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import { sendFollowUp } from '@agent/followUp/ToolUseFollowUp';
 import {
   type CliContext,
@@ -404,6 +405,12 @@ export async function runChat(
   // shared, host-agnostic snapshot store so a `texra resume` restores the full
   // display — the same streamData/{id}/* files the extension/desktop read.
   const snapshotStore = new StreamSnapshotStore();
+  let detachSnapshotEvents: (() => void) | undefined =
+    snapshotStore.attachSessionEvents(defaultSession().events);
+  const detachSnapshotPersistence = (): void => {
+    detachSnapshotEvents?.();
+    detachSnapshotEvents = undefined;
+  };
 
   const disposers: Array<() => void> = [];
   // Ink registers one stdout "resize" listener per mounted useWindowSize()
@@ -810,6 +817,7 @@ export async function runChat(
   // loaded, so this can neither hang nor affect headless paths.
   const drainPersistence = async (): Promise<void> => {
     flushPendingRunTraces();
+    detachSnapshotPersistence();
     await Promise.all([
       getDefaultStreamLogStore().flush(),
       snapshotStore.flush(),

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -94,7 +94,15 @@ export function wrapRuntimeHost(
   const original = host.emit;
   const emit: Emit = (event, payload) => {
     applyToState(event, payload);
-    snapshotStore?.handleProgressEvent(event, payload);
+    switch (event) {
+      case 'setTaskState':
+      case 'updateStreamDescription':
+      case 'setParentStream':
+        snapshotStore?.handleProgressEvent(event, payload);
+        break;
+      default:
+        break;
+    }
     return original(event, payload);
   };
   return { ...host, emit };

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -66,7 +66,7 @@ type ExecuteAgentResultForCategory<C extends AgentCategory | undefined> =
     ? Extract<ExecuteAgentResult, { category: C }>
     : ExecuteAgentResult;
 
-function persistCliProgressEvents(
+function persistCliMetadataProgressEvents(
   host: CliRuntimeHost,
   snapshotStore: StreamSnapshotStore,
 ): CliRuntimeHost {
@@ -74,7 +74,17 @@ function persistCliProgressEvents(
     event: K,
     payload: ProgressEventPayloads[K],
   ): void => {
-    snapshotStore.handleProgressEvent(event, payload);
+    // Durable run facts enter StreamSnapshotStore from SessionEventHub. Keep
+    // only the legacy metadata events here until they move to typed run facts.
+    switch (event) {
+      case 'setTaskState':
+      case 'updateStreamDescription':
+      case 'setParentStream':
+        snapshotStore.handleProgressEvent(event, payload);
+        break;
+      default:
+        break;
+    }
     host.emit(event, payload);
   };
   return { ...host, emit };
@@ -181,7 +191,13 @@ export async function executeCliRequest(
 ): Promise<{ result: ExecuteAgentResult; terminalStatus: ExecutionStatus }> {
   const baseRuntimeHost = createCliRuntimeHost(runContext);
   const snapshotStore = new StreamSnapshotStore();
-  const runtimeHost = persistCliProgressEvents(baseRuntimeHost, snapshotStore);
+  const detachSnapshotEvents = snapshotStore.attachSessionEvents(
+    defaultSession().events,
+  );
+  const runtimeHost = persistCliMetadataProgressEvents(
+    baseRuntimeHost,
+    snapshotStore,
+  );
   const detachHostInteractions = defaultSession().useHostInteractions(
     createHeadlessCliHostInteractions(runContext, {
       beforePrompt: () => runtimeHost.prepareInteractivePrompt?.(),
@@ -265,7 +281,11 @@ export async function executeCliRequest(
     detachHostInteractions();
     uninstallApprovalHandlers();
     try {
-      flushPendingRunTraces();
+      try {
+        flushPendingRunTraces();
+      } finally {
+        detachSnapshotEvents();
+      }
       await Promise.all([streamLogStore.flush(), snapshotStore.flush()]);
     } finally {
       await interactionHost.close();

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -14,6 +14,7 @@ import type { CliContext } from '@cli/runtime/cliContext';
 import type { executeCliRequest } from '@cli/runtime/runExecution';
 import {
   EXECUTION_STATUS,
+  type StorageKey,
   type StreamTabId,
   type TodoItem,
 } from '@shared/schemas';
@@ -271,10 +272,11 @@ describe('executeCliRequest', () => {
     );
   });
 
-  it('persists headless stream sidecars emitted through the runtime host', async () => {
+  it('persists headless stream sidecars from session events without double-counting legacy host usage', async () => {
     await installStoragePlatform();
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
     const request = baseRequest();
+    const streamId = 'stream-1' as StreamTabId;
     const todo: TodoItem = {
       content: 'Write the introduction',
       status: 'in_progress',
@@ -282,25 +284,63 @@ describe('executeCliRequest', () => {
     };
 
     mocks.runAgent.mockImplementationOnce(async (_request, options) => {
+      const { defaultSession } = await import('@agent/runtime/SessionHandle');
+      const { toRunFactDomainKey } =
+        await import('@agent/runtime/runFactEvents');
+      defaultSession().events.emit({
+        scope: 'run',
+        streamId,
+        event: {
+          type: 'domain',
+          key: toRunFactDomainKey('updateTodos'),
+          data: {
+            streamId,
+            todos: [todo],
+          },
+        },
+      });
+      defaultSession().events.emit({
+        scope: 'run',
+        streamId,
+        event: {
+          type: 'usage',
+          stats: { inputTokens: 100, outputTokens: 20, cost: 0.5 },
+          data: {
+            streamId,
+            storageKey: 'run-1' as StorageKey,
+            usage: { inputTokens: 100, outputTokens: 20, cost: 0.5 },
+          },
+        },
+      });
+      // This is the legacy projected event still visible on the public host
+      // channel. It must not be persisted a second time by the CLI bridge.
+      options.runtimeHost.emit('updateStreamUsage', {
+        streamId,
+        storageKey: 'run-1' as StorageKey,
+        usage: { inputTokens: 100, outputTokens: 20, cost: 0.5 },
+      });
       options.runtimeHost.emit('updateTodos', {
-        streamId: 'stream-1',
+        streamId,
         todos: [todo],
       });
       return {
         category: 'toolUse',
         executionId: 'exec-1',
         status: 'completed',
-        streamId: 'stream-1',
+        streamId,
       };
     });
 
     await executeCliRequest(request, cliContext());
 
     const { StreamSnapshotStore } = await import('@transcript');
-    const snapshot = await new StreamSnapshotStore().read(
-      'stream-1' as StreamTabId,
-    );
+    const snapshot = await new StreamSnapshotStore().read(streamId);
     expect(snapshot.todos).toEqual([todo]);
+    expect(snapshot.runUsage['run-1']).toMatchObject({
+      inputTokens: 100,
+      outputTokens: 20,
+      cost: 0.5,
+    });
   });
 
   it('loads the stream log store before the run and flushes it after, in order', async () => {
@@ -358,6 +398,8 @@ describe('executeCliRequest', () => {
       return {
         ...actual,
         StreamSnapshotStore: class {
+          attachSessionEvents = vi.fn(() => vi.fn());
+
           handleProgressEvent = vi.fn();
 
           flush = vi.fn(async () => {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -2606,16 +2606,30 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
     } as unknown as CliRuntimeHost;
   }
 
-  it('feeds runtime events to the snapshot store directly', () => {
+  it('bridges only transitional metadata events to the snapshot store', () => {
     const snapshotStore = {
       handleProgressEvent: vi.fn(),
     } as unknown as StreamSnapshotStore;
     const wrapped = wrapRuntimeHost(makeHost(), snapshotStore);
 
-    wrapped.emit('updateTodos', { streamId: root, todos: [] });
+    const todos: TodoItem[] = [
+      {
+        content: 'Write the introduction',
+        status: TODO_STATUS.IN_PROGRESS,
+        activeForm: 'Writing the introduction',
+      },
+    ];
+    wrapped.emit('updateTodos', { streamId: root, todos });
+    expect(streams.get().get(root)?.todos).toEqual(todos);
+    expect(snapshotStore.handleProgressEvent).not.toHaveBeenCalled();
+
+    wrapped.emit('updateStreamDescription', {
+      streamId: root,
+      description: 'search / kimi26T',
+    });
     expect(snapshotStore.handleProgressEvent).toHaveBeenCalledWith(
-      'updateTodos',
-      { streamId: root, todos: [] },
+      'updateStreamDescription',
+      { streamId: root, description: 'search / kimi26T' },
     );
   });
 

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -15,8 +15,11 @@ import { createFakePlatform } from '@test/support/FakePlatform';
 import { installPlatform, setupPlatform } from '@test/support/setupPlatform';
 import { StreamSnapshotStore, streamDataDir } from '@transcript';
 import { getExecutionStore } from '@agent/storage';
+import { SessionEventHub } from '@agent/runtime/SessionEventHub';
+import { toRunFactDomainKey } from '@agent/runtime/runFactEvents';
 import { TaskStateSchema, type TaskState } from '@agent/core/state/TaskState';
 import type {
+  CompileFailure,
   ExecutionId,
   OutputFileInfo,
   Plan,
@@ -84,6 +87,24 @@ function outputFile(relativePath: string, round: number): OutputFileInfo {
     round,
     lineage: null,
     diff: null,
+  };
+}
+
+function compileFailure(relativePath: string, round: number): CompileFailure {
+  return {
+    round,
+    displayName: relativePath,
+    output: {
+      kind: 'workspace',
+      absolutePath: `/workspace/${relativePath}.pdf`,
+      relativePath: `${relativePath}.pdf`,
+    },
+    log: {
+      kind: 'workspace',
+      absolutePath: `/workspace/${relativePath}.log`,
+      relativePath: `${relativePath}.log`,
+    },
+    logRelativePath: `${relativePath}.log`,
   };
 }
 
@@ -155,6 +176,102 @@ describe('StreamSnapshotStore', () => {
     expect(await StorageFS.exists(path.join(dir, 'usageStats.json'))).toBe(
       true,
     );
+  });
+
+  it('persists durable run facts directly from session events and ignores goalPaused', async () => {
+    const events = new SessionEventHub();
+    const writer = new StreamSnapshotStore();
+    const detach = writer.attachSessionEvents(events);
+    const output = outputFile('paper.tex', 1);
+    const failure = compileFailure('paper.tex', 1);
+
+    events.emit({
+      scope: 'run',
+      streamId: STREAM,
+      event: {
+        type: 'domain',
+        key: toRunFactDomainKey('updateTodos'),
+        data: { streamId: STREAM, todos: [TODO] },
+      },
+    });
+    events.emit({
+      scope: 'run',
+      streamId: STREAM,
+      event: {
+        type: 'domain',
+        key: toRunFactDomainKey('updatePlan'),
+        data: { streamId: STREAM, plan: PLAN },
+      },
+    });
+    events.emit({
+      scope: 'run',
+      streamId: STREAM,
+      event: {
+        type: 'domain',
+        key: toRunFactDomainKey('addOutputFiles'),
+        data: { streamId: STREAM, filesByRound: { 1: [output] } },
+      },
+    });
+    events.emit({
+      scope: 'run',
+      streamId: STREAM,
+      event: {
+        type: 'domain',
+        key: toRunFactDomainKey('updateMissingOutputs'),
+        data: { streamId: STREAM, filesByRound: { 1: ['paper.pdf'] } },
+      },
+    });
+    events.emit({
+      scope: 'run',
+      streamId: STREAM,
+      event: {
+        type: 'domain',
+        key: toRunFactDomainKey('updateCompileFailures'),
+        data: { streamId: STREAM, filesByRound: { 1: [failure] } },
+      },
+    });
+    events.emit({
+      scope: 'run',
+      streamId: STREAM,
+      event: {
+        type: 'usage',
+        stats: { inputTokens: 100, outputTokens: 20, cost: 0.5 },
+        data: {
+          streamId: STREAM,
+          storageKey: RUN,
+          usage: usage(100, 20, 0.5),
+        },
+      },
+    });
+    events.emit({
+      scope: 'run',
+      streamId: OTHER_STREAM,
+      event: {
+        type: 'domain',
+        key: toRunFactDomainKey('goalPaused'),
+        data: { streamId: OTHER_STREAM },
+      },
+    });
+
+    detach();
+    await writer.flush();
+
+    const snap = await new StreamSnapshotStore().read(STREAM);
+    expect(snap.todos).toEqual([TODO]);
+    expect(snap.plan).toEqual(PLAN);
+    expect(snap.outputFilesByRound).toEqual({ '1': [output] });
+    expect(snap.missingOutputsByRound).toEqual({ '1': ['paper.pdf'] });
+    expect(snap.compileFailuresByRound).toEqual({ '1': [failure] });
+    expect(snap.runUsage[RUN]).toMatchObject({
+      inputTokens: 100,
+      outputTokens: 20,
+      cost: 0.5,
+    });
+
+    const goalPausedOnly = await new StreamSnapshotStore().read(OTHER_STREAM);
+    expect(goalPausedOnly.todos).toEqual([]);
+    expect(goalPausedOnly.plan).toBeNull();
+    expect(goalPausedOnly.runUsage).toEqual({});
   });
 
   it('returns an empty (valid) snapshot for a stream with no sidecar', async () => {

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -24,6 +24,8 @@ import { getExecutionStore } from '@agent/storage';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { TaskStateSchema, type TaskState } from '@agent/core/state/TaskState';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
+import { fromRunFactDomainKey } from '@agent/runtime/runFactEvents';
+import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import { isFileNotFoundError } from '@common/errors';
 import { KVStore } from '@common/storage/KVStore';
 import type {
@@ -40,8 +42,11 @@ import {
   RUN_DESCRIPTOR_SCHEMA_VERSION,
   planSummaryLine,
   RoundKeySchema,
+  StreamTabIdSchema,
   sumUsageStats,
   TokenUsageStatsParsingSchema,
+  UpdatePlanPayloadSchema,
+  UpdateTodosPayloadSchema,
   buildRunDescriptor,
   type CompileFailure,
   type ExecutionId,
@@ -82,6 +87,24 @@ const CHANNEL = 'StreamSnapshotStore';
 /** Bounded fan-out for seeding many streams' sidecars (mirrors the retired
  *  managers' `pMap` hydration so startup doesn't open a file handle per tab). */
 const SEED_IO_CONCURRENCY = 8;
+
+const AddOutputFilesRunFactSchema = z.looseObject({
+  streamId: StreamTabIdSchema,
+  filesByRound: z.record(z.string(), OutputFileInfoListSchema),
+});
+const UpdateMissingOutputsRunFactSchema = z.looseObject({
+  streamId: StreamTabIdSchema,
+  filesByRound: z.record(z.string(), z.array(z.string())),
+});
+const UpdateCompileFailuresRunFactSchema = z.looseObject({
+  streamId: StreamTabIdSchema,
+  filesByRound: z.record(z.string(), z.array(CompileFailureSchema)),
+});
+const UsageRunEventDataSchema = z.looseObject({
+  streamId: StreamTabIdSchema,
+  storageKey: z.string().min(1),
+  usage: TokenUsageStatsParsingSchema,
+});
 
 type OutputFilesPatch = Map<number, OutputFileInfo[] | null>;
 type UsageUpdateResult =
@@ -284,6 +307,93 @@ export class StreamSnapshotStore {
       default:
         return;
     }
+  }
+
+  /**
+   * Persist already-migrated durable run facts directly from the session event
+   * plane. The legacy progress-event entry point remains for extension/desktop
+   * consumers and for CLI metadata that has not moved to run-scoped facts.
+   */
+  attachSessionEvents(events: SessionEventHub): () => void {
+    return events.subscribe(
+      (sessionEvent) => {
+        if (sessionEvent.scope !== 'run') return;
+        const { event } = sessionEvent;
+
+        if (event.type === 'usage') {
+          this.handleSessionUsageEvent(event.data);
+          return;
+        }
+
+        if (event.type !== 'domain') return;
+        const factName = fromRunFactDomainKey(event.key);
+        if (!factName || factName === 'goalPaused') return;
+
+        switch (factName) {
+          case 'updateTodos': {
+            const payload = UpdateTodosPayloadSchema.safeParse(event.data);
+            if (payload.success) {
+              this.setTodos(payload.data.streamId, payload.data.todos);
+            }
+            return;
+          }
+          case 'updatePlan': {
+            const payload = UpdatePlanPayloadSchema.safeParse(event.data);
+            if (payload.success) {
+              this.setPlan(payload.data.streamId, payload.data.plan);
+            }
+            return;
+          }
+          case 'addOutputFiles': {
+            const payload = AddOutputFilesRunFactSchema.safeParse(event.data);
+            if (payload.success) {
+              this.addOutputFiles(
+                payload.data.streamId,
+                payload.data.filesByRound,
+              );
+            }
+            return;
+          }
+          case 'updateMissingOutputs': {
+            const payload = UpdateMissingOutputsRunFactSchema.safeParse(
+              event.data,
+            );
+            if (payload.success) {
+              this.updateMissingOutputs(
+                payload.data.streamId,
+                payload.data.filesByRound,
+              );
+            }
+            return;
+          }
+          case 'updateCompileFailures': {
+            const payload = UpdateCompileFailuresRunFactSchema.safeParse(
+              event.data,
+            );
+            if (payload.success) {
+              this.updateCompileFailures(
+                payload.data.streamId,
+                payload.data.filesByRound,
+              );
+            }
+            return;
+          }
+          default:
+            return;
+        }
+      },
+      { scope: 'run', types: ['domain', 'usage'] },
+    );
+  }
+
+  private handleSessionUsageEvent(data: unknown): void {
+    const payload = UsageRunEventDataSchema.safeParse(data);
+    if (!payload.success) return;
+    void this.addUsage(
+      payload.data.streamId,
+      payload.data.storageKey as StorageKey,
+      payload.data.usage,
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary

Part of #6968 and #6951.

This PR moves CLI snapshot persistence for already-migrated durable run facts away from bus-shaped progress events and onto the session-scoped runtime event stream.

Concretely:

- `StreamSnapshotStore.attachSessionEvents(...)` now persists durable run facts from `SessionEventHub`:
  - `runFact.updateTodos`
  - `runFact.updatePlan`
  - `runFact.addOutputFiles`
  - `runFact.updateMissingOutputs`
  - `runFact.updateCompileFailures`
  - compatible `usage` events carrying `streamId`, `storageKey`, and `usage`
- Headless CLI execution and the chat TUI attach the snapshot store directly to `defaultSession().events`.
- CLI runtime-host bridges now persist only metadata events that are not session facts yet:
  - `setTaskState`
  - `updateStreamDescription`
  - `setParentStream`
- The TUI still applies progress events to live UI state; it just stops using that bus-shaped path as the persistence owner for durable run facts.

## Non-goals

This does not delete the progress projectors or the remaining `ProgressEventPayloads` compatibility surface. Those still have work to do for extension and desktop consumers, public CLI/TUI rendering, and remaining metadata events.

This also intentionally avoids changing CLI public output semantics.

## Evidence of the migration boundary

- `persistCliProgressEvents` is gone; the remaining CLI helper is `persistCliMetadataProgressEvents`.
- CLI calls to `snapshotStore.handleProgressEvent(...)` are now limited to metadata persistence.
- Durable CLI snapshot data enters the store through `StreamSnapshotStore.attachSessionEvents(...)`.
- Legacy projectors remain attached, so this PR is a gate before deletion rather than the deletion itself.

## Validation

- `corepack pnpm exec prettier --write src/transcript/StreamSnapshotStore.ts packages/cli/src/runtime/runExecution.ts packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts packages/cli/src/chat/tui/runChatTui.tsx src/test-kernel/transcript/StreamSnapshotStore.vitest.ts src/test-kernel/cli/RunExecution.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `git diff --check`
- `corepack pnpm exec eslint src/transcript/StreamSnapshotStore.ts packages/cli/src/runtime/runExecution.ts packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts packages/cli/src/chat/tui/runChatTui.tsx src/test-kernel/transcript/StreamSnapshotStore.vitest.ts src/test-kernel/cli/RunExecution.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm exec vitest run src/test-kernel/transcript/StreamSnapshotStore.vitest.ts src/test-kernel/cli/RunExecution.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `corepack pnpm run compile:fast`
- `corepack pnpm run lint` completed with two existing import-order warnings outside this PR's files.
- `corepack pnpm test` passed: 619 files, 4954 tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how resume/`texra resume` sidecars are populated; incorrect filtering could drop data or duplicate usage, though tests and the narrow metadata bridge reduce that risk.
> 
> **Overview**
> CLI **stream sidecar persistence** (todos, plan, outputs, usage, etc.) now comes from **`SessionEventHub` run-scoped facts** via `StreamSnapshotStore.attachSessionEvents`, instead of mirroring every progress event on the runtime host.
> 
> Headless execution and the chat TUI **subscribe** `defaultSession().events` and **detach** before flush on exit. The CLI host wrappers (`persistCliMetadataProgressEvents`, `wrapRuntimeHost`) only call `handleProgressEvent` for **metadata not yet on session facts**: `setTaskState`, `updateStreamDescription`, and `setParentStream`. Live TUI state still updates from progress events (e.g. `updateTodos`); those events are no longer the persistence source for durable run data, which avoids **double-writing** when legacy projectors still emit bus-shaped usage/todo events.
> 
> Tests cover session-event persistence, `goalPaused` ignored for snapshots, and headless usage not duplicated from host `updateStreamUsage`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee64925db01b2a75fe9b0dd621eead6ed3110f4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->