### PR TITLE
fix(progress-view): guard disposed backend from post-close progress events

### DIFF
--- a/src/shared/progressView/backend/ProgressBackend.ts
+++ b/src/shared/progressView/backend/ProgressBackend.ts
@@ -79,6 +79,7 @@ export class ProgressBackend {
   readonly eventHandler: ProgressEventHandler;
   private readonly session: SessionHandle;
   private readonly onSessionProgressEvent?: SessionProgressEventObserver;
+  private disposed = false;
 
   constructor(options: ProgressBackendOptions) {
     this.session = options.session ?? defaultSession();
@@ -172,10 +173,18 @@ export class ProgressBackend {
     event: K,
     payload: ProgressEventPayloads[K],
   ): void {
+    // A run may still hold the host-channel emit closure that routes here after
+    // this backend is disposed (e.g. a desktop window closed while the run keeps
+    // executing headless). Applying events to a disposed backend would mutate
+    // torn-down state and post messages to a closed window, so the direct
+    // applier no-ops once disposed. Before #7363 the bus-listener teardown made
+    // this path implicitly safe; the direct call needs an explicit guard.
+    if (this.disposed) return;
     this.eventHandler.handleProgressEvent(event, payload);
   }
 
   dispose(): void {
+    this.disposed = true;
     this.webviewBridge.dispose();
   }
 }

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -454,6 +454,26 @@ describe('ProgressBackend', () => {
     }
   });
 
+  it('no-ops the direct applier after dispose', () => {
+    const { backend } = createIsolatedRecordingBackend();
+    const applier = vi.spyOn(backend.eventHandler, 'handleProgressEvent');
+    const streamId = 'desktop-post-close-stream' as StreamTabId;
+
+    backend.dispose();
+
+    // A run that kept executing headless after a desktop window closed still
+    // holds the host-channel emit closure that routes to handleProgressEvent.
+    expect(() =>
+      backend.handleProgressEvent('setActiveStream', {
+        streamId,
+        agentCategory: AgentCategory.Workflow,
+      }),
+    ).not.toThrow();
+
+    expect(applier).not.toHaveBeenCalled();
+    expect(backend.state.activeStream).not.toBe(streamId);
+  });
+
   it('notifies host observers for session-originated progress events', async () => {
     const messages: ProgressViewOutboundMessage[] = [];
     const observed: Array<{


### PR DESCRIPTION
Closes #7368

## Root cause

Follow-up from #7363, which replaced `ProgressBackend`'s bus-based `emitEvent` with a direct call `this.eventHandler.handleProgressEvent(event, payload)`.

When a desktop window closes while a run continues headless, `DesktopProgressBridge.dispose()` disposes `backendSubscription` and then disposes the session with `keepActiveExecutions: true` — but the run still holds the `hostChannel.emit` closure that routes to `backend.handleProgressEvent` (`packages/desktop/src/main/desktopAgentExecution.ts:239-240, 1011-1016`). The direct call bypassed the now-disposed subscription and still applied events, mutating a disposed progress backend and posting messages to a closed renderer window. Before #7363, aborting the local bus listener made this path an implicit no-op.

Flagged by `chatgpt-codex-connector[bot]` (P2) during review of #7363; unaddressed at merge.

## Fix

Add an explicit disposed-state guard at the host-neutral applier boundary (`src/shared/progressView/backend/ProgressBackend.ts`):

- `dispose()` sets a `disposed` flag.
- `handleProgressEvent()` no-ops once `disposed` is true.

This restores the pre-#7363 safety. Both the desktop direct emit path and the session-fact projection (`handleProjectedProgressEvent`) funnel through this single applier, so one guard covers every route. Scoped strictly to the disposal-guard — no event-handler restructure, no `EventHandlerContext` change (left to sibling #7367).

## Diff

```
 src/shared/progressView/backend/ProgressBackend.ts   |  9 +++++++++
 src/test-kernel/progressView/ProgressBackend.vitest.ts | 20 ++++++++++++++++++++
 2 files changed, 29 insertions(+)
```

## Tests

- Added `no-ops the direct applier after dispose` to `ProgressBackend.vitest.ts`: after `dispose()`, `handleProgressEvent` does not throw, does not reach `eventHandler.handleProgressEvent`, and does not mutate state.
- `npx vitest run src/test-kernel/progressView/` — all pass (ProgressBackend suite 22/22).
- `npm run typecheck` — 0 new errors in changed files (the 13 pre-existing errors in openrouter/ResponseUsage/lean on origin/main are unaffected).

https://claude.ai/code/session_01PkkPA9A5vht7PmB9xxiqU3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, defensive lifecycle guard with a focused unit test; no change to normal event handling while the backend is active.
> 
> **Overview**
> **`ProgressBackend`** now tracks a **`disposed`** flag set in **`dispose()`** and returns early from **`handleProgressEvent()`** when disposed, so headless runs that still call the desktop **`hostChannel.emit`** closure after a window closes cannot mutate backend state or drive webview updates.
> 
> A regression test asserts that post-**`dispose()`** calls do not throw, do not reach **`eventHandler.handleProgressEvent`**, and leave state unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7adcccb132dbb91323a943662ee644ddd76d28c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->