### PR TITLE
fix(output): wire xmlExtraction fallback regexes to OUTPUT_DOCUMENT_TAG

### DIFF
--- a/src/utils/text/xmlExtraction.ts
+++ b/src/utils/text/xmlExtraction.ts
@@ -29,7 +29,9 @@ logger.initialize(CHANNEL);
  * is case-insensitive as a safety net but counter should reflect
  * what primary path can extract.
  */
-export const DOCUMENT_NAME_REGEX = /<document[^>]*name="([^"]*)"[^>]*>/;
+export const DOCUMENT_NAME_REGEX = new RegExp(
+  `<${OUTPUT_DOCUMENT_TAG}[^>]*name="([^"]*)"[^>]*>`,
+);
 
 /**
  * Get a string representation of an object's structure without its values.
@@ -102,8 +104,10 @@ export function extractMultipleTextFromTag(
     content: string,
   ): Array<{ content: string; name: string }> => {
     // Full extraction pattern - case-sensitive to match CDATA wrapping behavior
-    const documentRegex =
-      /<document[^>]*name="([^"]*)"[^>]*>(.*?)<\/document>/gs;
+    const documentRegex = new RegExp(
+      `<${OUTPUT_DOCUMENT_TAG}[^>]*name="([^"]*)"[^>]*>(.*?)<\/${OUTPUT_DOCUMENT_TAG}>`,
+      'gs',
+    );
 
     return [...content.matchAll(documentRegex)].map((match) => ({
       name: match[1] || 'unnamed',


### PR DESCRIPTION
## Root cause

Follow-up from #7365 (which wired `OUTPUT_DOCUMENT_TAG` into `XmlOutputManager.ts`'s `addCdataToTagsMultiple` call and `xmlExtraction.ts`'s container-property check). Two module-level regex-based fallback extractors in `src/utils/text/xmlExtraction.ts` still hardcoded the literal `'document'` directly in a regex literal instead of reading the shared constant:

- `DOCUMENT_NAME_REGEX` (line ~32)
- the `documentRegex` built inside `extractMultipleTextFromTag` (lines ~105-106)

If `OUTPUT_DOCUMENT_TAG` were ever renamed, these two regexes would silently keep matching the old tag name while the two call sites fixed in #7365 correctly followed the constant — exactly the drift `src/shared/constants/outputProtocol.ts` was introduced to prevent.

## Fix

Rebuilt both regexes with `new RegExp(...)` interpolating `OUTPUT_DOCUMENT_TAG`, preserving:
- the existing capture groups
- the `'gs'` flags on `documentRegex`
- case-sensitivity (no `i` flag, matching the comment noting this is intentional to mirror the primary XMLParser extraction path)

`DOCUMENT_NAME_REGEX` is exported and consumed elsewhere (`src/utils/text/xmlUtils.ts` re-export, `src/agent/output/XmlOutputManager.ts`'s `DOCUMENT_NAME_REGEX_GLOBAL = new RegExp(DOCUMENT_NAME_REGEX.source, 'g')`); both only read `.source`/use it as a `RegExp` value, so building it via `new RegExp(...)` at module load instead of a literal is a no-op change for those call sites. No behavior change is expected: `OUTPUT_DOCUMENT_TAG` is currently `'document'`, identical to the previous hardcoded literal.

This is the minimal fix scoped to the issue — no other refactoring.

## Verification

- `npx tsc --noEmit` — clean for the changed file (23 pre-existing unrelated errors in `@openrouter/sdk` / `vscode-jsonrpc` modules exist identically before and after this change, confirmed via `git stash`)
- `npx eslint src/utils/text/xmlExtraction.ts` — clean
- `npx prettier --check src/utils/text/xmlExtraction.ts` — passes, no reformatting needed
- `npx vitest run src/test-kernel/utils/text/ExtractDocumentsLegacyFallback.vitest.ts src/test-kernel/utils/text/xmlUtils.vitest.ts src/test-kernel/agent/output/XmlOutputManager.vitest.ts src/test-kernel/agent/output/CompileFailureRoundContext.vitest.ts` — 3 test files / 95 tests passed (21 + 74; `CompileFailureRoundContext.vitest.ts` had 0 tests relevant to this path but was included as a broader output-module sanity check)

Fixes #7370.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical constant wiring in fallback regex builders; OUTPUT_DOCUMENT_TAG is unchanged so extraction behavior is identical.
> 
> **Overview**
> Completes the **OUTPUT_DOCUMENT_TAG** centralization started in #7365 by replacing two hardcoded `'document'` regex literals in `xmlExtraction.ts` with `new RegExp(...)` patterns that interpolate **`OUTPUT_DOCUMENT_TAG`**.
> 
> **`DOCUMENT_NAME_REGEX`** and the **`documentRegex`** inside **`extractMultipleTextFromTag`** now track the shared constant, so a future tag rename would not leave these fallbacks matching the old name while the primary XML path uses the constant. Capture groups, **`gs`** flags, and case-sensitivity are unchanged; consumers that read **`DOCUMENT_NAME_REGEX.source`** (e.g. **`XmlOutputManager`**) behave the same because the tag value is still **`'document'`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c41fea1f10b3b27d6fe6eba46e61079014806bd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->