### PR TITLE
fix: route output-file side effects through run facts

### DIFF
--- a/packages/extension/src/frontend/events/runFactSubscriptions.ts
+++ b/packages/extension/src/frontend/events/runFactSubscriptions.ts
@@ -1,0 +1,28 @@
+// Local imports
+import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
+import { toRunFactDomainKey } from '@agent/runtime/runFactEvents';
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import { isObject } from '@utils/core';
+
+type AddOutputFilesPayload = ProgressEventPayloads['addOutputFiles'];
+
+function isAddOutputFilesPayload(data: unknown): data is AddOutputFilesPayload {
+  return isObject(data) && isObject(data.filesByRound);
+}
+
+export function subscribeAddOutputFilesRunFact(
+  events: SessionEventHub,
+  listener: (payload: AddOutputFilesPayload) => void,
+): () => void {
+  const key = toRunFactDomainKey('addOutputFiles');
+  return events.subscribe(
+    (sessionEvent) => {
+      if (sessionEvent.scope !== 'run') return;
+      const { event } = sessionEvent;
+      if (event.type !== 'domain' || event.key !== key) return;
+      if (!isAddOutputFilesPayload(event.data)) return;
+      listener(event.data);
+    },
+    { scope: 'run', types: ['domain'] },
+  );
+}

--- a/packages/extension/src/frontend/latex/inlineCriticism.ts
+++ b/packages/extension/src/frontend/latex/inlineCriticism.ts
@@ -5,8 +5,8 @@
  * Problems panel, like a linter.
  *
  * Two ingest paths:
- *   1. Bus event hook on `addOutputFiles` parses each output `.tex` file.
- *      Universal — any agent that writes the macro participates.
+ *   1. Session run facts keyed by `runFact.addOutputFiles` parse each output
+ *      `.tex` file. Universal — any agent that writes the macro participates.
  *   2. The `diagnostics` tool's `add` command routes through
  *      `pushManualCriticism` here for tool-use agents that want to flag issues
  *      without inserting the macro.
@@ -19,8 +19,11 @@
 import * as vscode from 'vscode';
 
 // Local imports
+import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import { globalSM, GlobalStateKey } from '@common/state';
-import { bus, type ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import { subscribeAddOutputFilesRunFact } from '@frontend/events/runFactSubscriptions';
 import { parseCriticismAnnotations } from '@latex/criticismParser';
 import * as logger from '@logger/logUtils';
 import type { OutputFileInfo } from '@shared/schemas';
@@ -36,8 +39,9 @@ const CODE_PARSED = 'criticize';
 const CODE_TOOL = 'criticize:tool';
 
 let collection: vscode.DiagnosticCollection | undefined;
-let busUnsubscribe: (() => void) | undefined;
+let runFactUnsubscribe: (() => void) | undefined;
 let extensionContext: vscode.ExtensionContext | undefined;
+let sessionEvents: SessionEventHub | undefined;
 
 /** Criticism severity (0–5) → VS Code DiagnosticSeverity. */
 function mapSeverity(severity: number): vscode.DiagnosticSeverity {
@@ -138,14 +142,17 @@ function enable(context: vscode.ExtensionContext): void {
   if (collection) return;
   collection = vscode.languages.createDiagnosticCollection(COLLECTION_NAME);
   context.subscriptions.push(collection);
-  busUnsubscribe = bus.on('addOutputFiles', handleAddOutputFiles);
+  runFactUnsubscribe = subscribeAddOutputFilesRunFact(
+    sessionEvents ?? defaultSession().events,
+    handleAddOutputFiles,
+  );
   logger.info(CHANNEL, 'Inline criticism diagnostics enabled');
 }
 
 function disable(): void {
-  if (busUnsubscribe) {
-    busUnsubscribe();
-    busUnsubscribe = undefined;
+  if (runFactUnsubscribe) {
+    runFactUnsubscribe();
+    runFactUnsubscribe = undefined;
   }
   if (collection) {
     collection.clear();
@@ -185,8 +192,10 @@ export function pushManualCriticism(entry: ManualCriticismEntry): boolean {
 
 export function registerInlineCriticism(
   context: vscode.ExtensionContext,
+  events: SessionEventHub = defaultSession().events,
 ): void {
   extensionContext = context;
+  sessionEvents = events;
   if (isInlineCriticismEnabled()) enable(context);
   context.subscriptions.push({ dispose: disable });
 }

--- a/packages/extension/src/frontend/ui/fileDecorations.ts
+++ b/packages/extension/src/frontend/ui/fileDecorations.ts
@@ -1,6 +1,9 @@
 import * as vscode from 'vscode';
 
+import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import { bus } from '@eventBus/ProgressEventBus';
+import { subscribeAddOutputFilesRunFact } from '@frontend/events/runFactSubscriptions';
 import type { OutputFileInfo } from '@shared/schemas/output';
 
 // Session-scoped: the touched set is not persisted across window reloads so
@@ -59,11 +62,12 @@ function collectWorkspacePaths(
 
 export function registerFileDecorations(
   context: vscode.ExtensionContext,
+  events: SessionEventHub = defaultSession().events,
 ): void {
   const provider = new TeXRAFileDecorationProvider();
 
-  const unsubscribeOutputFiles = bus.on(
-    'addOutputFiles',
+  const unsubscribeOutputFiles = subscribeAddOutputFilesRunFact(
+    events,
     ({ filesByRound }) => {
       const paths = new Set<string>();
       for (const roundFiles of Object.values(filesByRound)) {

--- a/src/test-kernel/frontend/OutputFileRunFactSubscriptions.vitest.ts
+++ b/src/test-kernel/frontend/OutputFileRunFactSubscriptions.vitest.ts
@@ -1,0 +1,285 @@
+import { join } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import type { OutputFileInfo, StreamTabId } from '@shared/schemas';
+import type * as VSCode from 'vscode';
+
+const mocks = vi.hoisted(() => ({
+  diagnosticCollections: [] as Array<{
+    readonly items: Map<string, unknown[]>;
+    clear: ReturnType<typeof vi.fn>;
+    dispose: ReturnType<typeof vi.fn>;
+  }>,
+  registeredProviders: [] as unknown[],
+  registerFileDecorationProvider: vi.fn((provider: unknown) => {
+    mocks.registeredProviders.push(provider);
+    return { dispose: vi.fn() };
+  }),
+  createDiagnosticCollection: vi.fn(() => {
+    const items = new Map<string, unknown[]>();
+    const collection = {
+      items,
+      get: (uri: { fsPath: string }) => items.get(uri.fsPath),
+      set: (uri: { fsPath: string }, diagnostics: unknown[]) => {
+        items.set(uri.fsPath, diagnostics);
+      },
+      delete: (uri: { fsPath: string }) => {
+        items.delete(uri.fsPath);
+      },
+      clear: vi.fn(() => items.clear()),
+      dispose: vi.fn(),
+    };
+    mocks.diagnosticCollections.push(collection);
+    return collection;
+  }),
+}));
+
+vi.mock('vscode', () => {
+  class Diagnostic {
+    source: string | undefined;
+    code: string | undefined;
+
+    constructor(
+      public range: unknown,
+      public message: string,
+      public severity: number,
+    ) {}
+  }
+
+  class EventEmitter<T> {
+    event = (_listener: (e: T) => unknown) => ({ dispose: vi.fn() });
+    fire(_data: T): void {}
+    dispose(): void {}
+  }
+
+  return {
+    Diagnostic,
+    DiagnosticSeverity: {
+      Error: 0,
+      Warning: 1,
+      Information: 2,
+      Hint: 3,
+    },
+    Disposable: class {
+      constructor(private readonly callOnDispose: () => unknown) {}
+      dispose(): void {
+        this.callOnDispose();
+      }
+    },
+    EventEmitter,
+    Range: class {
+      constructor(
+        public startLine: number,
+        public startCharacter: number,
+        public endLine: number,
+        public endCharacter: number,
+      ) {}
+    },
+    ThemeColor: class {
+      constructor(public id: string) {}
+    },
+    Uri: {
+      file: (absolutePath: string) => ({
+        scheme: 'file',
+        fsPath: absolutePath,
+        path: absolutePath,
+        toString: () => absolutePath,
+      }),
+    },
+    languages: {
+      createDiagnosticCollection: mocks.createDiagnosticCollection,
+    },
+    window: {
+      createOutputChannel: (_name: string) => ({
+        appendLine: (_text: string) => {},
+        append: (_text: string) => {},
+        show: () => {},
+        dispose: () => {},
+      }),
+      registerFileDecorationProvider: mocks.registerFileDecorationProvider,
+    },
+    workspace: {
+      getConfiguration: (_section?: string) => ({
+        get: <T>(_key: string, defaultValue?: T) => defaultValue,
+      }),
+      onDidChangeConfiguration: () => ({ dispose: () => {} }),
+    },
+  };
+});
+
+const { SessionEventHub } = await import('@agent/runtime/SessionEventHub');
+const { toRunFactDomainKey } = await import('@agent/runtime/runFactEvents');
+const { bus } = await import('@eventBus/ProgressEventBus');
+const { registerInlineCriticism, setInlineCriticismEnabled } =
+  await import('@frontend/latex/inlineCriticism');
+const { registerFileDecorations } =
+  await import('@frontend/ui/fileDecorations');
+const { AbsoluteFS } = await import('@utils/files');
+const vscode = await import('vscode');
+
+const streamId = 'stream:frontend-run-fact' as StreamTabId;
+
+function makeContext(): {
+  subscriptions: Array<{ dispose(): unknown }>;
+} {
+  return { subscriptions: [] };
+}
+
+function workspaceOutputFile(absolutePath: string): OutputFileInfo {
+  return {
+    source: absolutePath,
+    location: {
+      kind: 'workspace',
+      absolutePath,
+      relativePath: absolutePath.split('/').at(-1) ?? absolutePath,
+    },
+    lineage: null,
+    diff: null,
+    round: 1,
+  };
+}
+
+function addOutputFilesPayload(
+  absolutePath: string,
+): ProgressEventPayloads['addOutputFiles'] {
+  return {
+    streamId,
+    filesByRound: { 1: [workspaceOutputFile(absolutePath)] },
+  };
+}
+
+function emitAddOutputFilesRunFact(
+  hub: InstanceType<typeof SessionEventHub>,
+  payload: ProgressEventPayloads['addOutputFiles'],
+): void {
+  hub.emit({
+    scope: 'run',
+    streamId,
+    event: {
+      type: 'domain',
+      key: toRunFactDomainKey('addOutputFiles'),
+      data: payload,
+    },
+  });
+}
+
+function disposeContext(context: {
+  subscriptions: Array<{ dispose(): unknown }>;
+}) {
+  for (const subscription of context.subscriptions.toReversed()) {
+    subscription.dispose();
+  }
+}
+
+function drainBufferedAddOutputFilesBusEvents(): void {
+  const unsubscribe = bus.on('addOutputFiles', () => undefined);
+  unsubscribe();
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+): Promise<void> {
+  for (let i = 0; i < 20; i += 1) {
+    if (predicate()) return;
+    await sleep(10);
+  }
+  throw new Error(message);
+}
+
+describe('output-file run fact frontend subscriptions', () => {
+  let tempDir: string | undefined;
+
+  beforeEach(() => {
+    mocks.diagnosticCollections.length = 0;
+    mocks.registeredProviders.length = 0;
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    drainBufferedAddOutputFilesBusEvents();
+    if (tempDir) {
+      await AbsoluteFS.delete(tempDir, { recursive: true });
+      tempDir = undefined;
+    }
+  });
+
+  it('badges run-fact output files and keeps workspaceFilesWritten on the bus', () => {
+    const hub = new SessionEventHub();
+    const context = makeContext();
+    registerFileDecorations(context as unknown as VSCode.ExtensionContext, hub);
+    const provider = mocks.registeredProviders.at(-1) as {
+      provideFileDecoration(uri: { scheme: string; fsPath: string }): unknown;
+    };
+
+    const legacyPath = '/tmp/texra-legacy-output.tex';
+    bus.emit('addOutputFiles', addOutputFilesPayload(legacyPath));
+    expect(provider.provideFileDecoration(vscode.Uri.file(legacyPath))).toBe(
+      undefined,
+    );
+    drainBufferedAddOutputFilesBusEvents();
+
+    const runFactPath = '/tmp/texra-run-fact-output.tex';
+    emitAddOutputFilesRunFact(hub, addOutputFilesPayload(runFactPath));
+    expect(
+      provider.provideFileDecoration(vscode.Uri.file(runFactPath)),
+    ).toMatchObject({ badge: 'T', tooltip: 'Modified by TeXRA' });
+
+    const writtenPath = '/tmp/texra-workspace-written.tex';
+    bus.emit('workspaceFilesWritten', { absolutePaths: [writtenPath] });
+    expect(
+      provider.provideFileDecoration(vscode.Uri.file(writtenPath)),
+    ).toMatchObject({ badge: 'T', tooltip: 'Modified by TeXRA' });
+
+    disposeContext(context);
+  });
+
+  it('refreshes inline criticism only for live run facts while enabled', async () => {
+    tempDir = `/tmp/texra-inline-criticism-${Date.now()}`;
+    const outputPath = join(tempDir, 'out.tex');
+    await AbsoluteFS.createDir(tempDir);
+    await AbsoluteFS.write(
+      outputPath,
+      'before\n\\criticize{tighten this argument}{4}{5}\nafter\n',
+    );
+
+    const hub = new SessionEventHub();
+    const context = makeContext();
+    registerInlineCriticism(context as unknown as VSCode.ExtensionContext, hub);
+
+    emitAddOutputFilesRunFact(hub, addOutputFilesPayload(outputPath));
+    await setInlineCriticismEnabled(true);
+    expect(mocks.diagnosticCollections.at(-1)?.items.get(outputPath)).toBe(
+      undefined,
+    );
+
+    bus.emit('addOutputFiles', addOutputFilesPayload(outputPath));
+    await sleep(20);
+    expect(mocks.diagnosticCollections.at(-1)?.items.get(outputPath)).toBe(
+      undefined,
+    );
+    drainBufferedAddOutputFilesBusEvents();
+
+    emitAddOutputFilesRunFact(hub, addOutputFilesPayload(outputPath));
+    await waitFor(
+      () =>
+        (mocks.diagnosticCollections.at(-1)?.items.get(outputPath) ?? [])
+          .length > 0,
+      'inline criticism diagnostics were not refreshed',
+    );
+    expect(
+      mocks.diagnosticCollections.at(-1)?.items.get(outputPath),
+    ).toHaveLength(1);
+
+    await setInlineCriticismEnabled(false);
+    emitAddOutputFilesRunFact(hub, addOutputFilesPayload(outputPath));
+    expect(mocks.diagnosticCollections.at(-1)?.items.get(outputPath)).toBe(
+      undefined,
+    );
+
+    disposeContext(context);
+  });
+});


### PR DESCRIPTION
## Summary

Part of #6968 and #6951.

This PR moves the extension-only `addOutputFiles` side effects from the process progress bus to session-scoped run facts:

- `registerFileDecorations(...)` now receives workflow output-file badges from `runFact.addOutputFiles` on the active session event hub.
- `inlineCriticism` now parses newly produced `.tex` workflow outputs from `runFact.addOutputFiles` while the feature is enabled.
- `workspaceFilesWritten` remains on the bus because accepted/copied workspace writes are app-side side effects, not workflow output production facts.

A small extension helper, `subscribeAddOutputFilesRunFact(...)`, centralizes the typed subscription and ignores unrelated domain events or malformed payloads.

## Non-goals

This PR does not change `ProgressBackend`, `ProgressEventHandler`, `SessionRunFactProjector`, `LegacyProgressEventProjection`, CLI/TUI rendering, or the `ProgressEventPayloads` compatibility surface.

Final projector deletion is still blocked until the progress backend's own `addOutputFiles` projection and remaining CLI/TUI rendering compatibility paths are moved off the legacy rail.

## Validation

- `corepack pnpm exec prettier --write packages/extension/src/frontend/events/runFactSubscriptions.ts packages/extension/src/frontend/ui/fileDecorations.ts packages/extension/src/frontend/latex/inlineCriticism.ts src/test-kernel/frontend/OutputFileRunFactSubscriptions.vitest.ts`
- `git diff --check`
- `corepack pnpm exec eslint packages/extension/src/frontend/events/runFactSubscriptions.ts packages/extension/src/frontend/ui/fileDecorations.ts packages/extension/src/frontend/latex/inlineCriticism.ts src/test-kernel/frontend/OutputFileRunFactSubscriptions.vitest.ts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/frontend/OutputFileRunFactSubscriptions.vitest.ts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `corepack pnpm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> UI updates for workflow outputs depend on run-fact emission on the session hub; mis-wiring or gaps in projection could leave badges/diagnostics stale until the broader migration completes.
> 
> **Overview**
> Workflow **output file** side effects in the extension now listen on **session-scoped run facts** (`runFact.addOutputFiles`) instead of the progress bus `addOutputFiles` event.
> 
> A shared **`subscribeAddOutputFilesRunFact`** helper filters run-scoped domain events, validates payloads, and invokes listeners. **File decoration badges** and **inline criticism** (`.tex` parsing when enabled) use this path; both registrars accept an optional **`SessionEventHub`** (defaulting to the active session). **`workspaceFilesWritten`** is unchanged on the bus for accepted workspace writes.
> 
> New **Vitest** coverage asserts run-fact events drive badges and criticism while legacy bus `addOutputFiles` no longer does.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f1635581ced50536fdf675d1c6b9d90f264322d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->