### PR TITLE
refactor(naming): rename runtime-scope singleton exports to PascalCase

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -16,7 +16,7 @@ import {
 } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { detachSubagentsOnStop } from '@agent/runtime/detachSubagentsOnStop';
-import { executionRegistry } from '@agent/runtime/executionRegistry';
+import { SharedExecutionRegistry } from '@agent/runtime/executionRegistry';
 import {
   executeAgent,
   resumeToolUseFromSnapshot,
@@ -196,7 +196,7 @@ export function createChatSessionController(
   const interruptActiveRun = (): void => {
     clearApprovals();
     if (!session.streamId) return;
-    executionRegistry.stopAgentStream(session.streamId, {
+    SharedExecutionRegistry.stopAgentStream(session.streamId, {
       detachActiveChildren: detachSubagentsOnStop(),
       runtimeHost: session.runtimeHost,
     });

--- a/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
+++ b/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
@@ -1,4 +1,4 @@
-import { executionRegistry } from '@agent/runtime/executionRegistry';
+import { SharedExecutionRegistry } from '@agent/runtime/executionRegistry';
 import { notifyFollowUpSent } from '@agent/followUp/ToolUseFollowUp';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { isCodexSubscriptionActive } from '@auth/codex';
@@ -215,7 +215,7 @@ export async function handleTuiSlashCommand(
       requestCliCompaction({
         streamId: activeStreamIdSignal.get(),
         requestManualCompaction: (streamId) =>
-          executionRegistry.requestManualCompaction(streamId),
+          SharedExecutionRegistry.requestManualCompaction(streamId),
         notifyFollowUpSent,
         appendTranscript: appendLocalAssistantTranscript,
       });

--- a/packages/cli/src/chat/tui/commands/handlers/agentModelCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/agentModelCommands.ts
@@ -1,6 +1,6 @@
 import { getAgent } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import { executionRegistry } from '@agent/runtime/executionRegistry';
+import { SharedExecutionRegistry } from '@agent/runtime/executionRegistry';
 import { assertCliAgentLaunch } from '@cli/runtime/agents';
 import { CliUsageError } from '@cli/runtime/cliContext';
 import { setCliHelperModel } from '@cli/runtime/initPlatform';
@@ -105,7 +105,7 @@ export async function applyCliModelSelection(
   }
 
   const activeFlow = context.session.streamId
-    ? executionRegistry.getToolUseFlowContext(context.session.streamId)
+    ? SharedExecutionRegistry.getToolUseFlowContext(context.session.streamId)
     : undefined;
   if (!activeFlow) {
     appendLocalAssistantTranscript(

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -23,7 +23,7 @@ import { getFirstRunDone } from '@controllers/onboarding/onboardingFunnel';
 import { getVisibleAgents, loadAgents } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { detachSubagentsOnStop } from '@agent/runtime/detachSubagentsOnStop';
-import { executionRegistry } from '@agent/runtime/executionRegistry';
+import { SharedExecutionRegistry } from '@agent/runtime/executionRegistry';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { sendFollowUp } from '@agent/followUp/ToolUseFollowUp';
 import {
@@ -444,7 +444,7 @@ export async function runChat(
   const hasActiveToolUseFlow = (): boolean =>
     Boolean(
       session.streamId &&
-      executionRegistry.getToolUseFlowContext(session.streamId),
+      SharedExecutionRegistry.getToolUseFlowContext(session.streamId),
     );
   const canSelectCurrentModel = (): boolean =>
     chatTuiCanSelectModel({
@@ -460,7 +460,7 @@ export async function runChat(
       return undefined;
     }
     const activeFlow = session.streamId
-      ? executionRegistry.getToolUseFlowContext(session.streamId)
+      ? SharedExecutionRegistry.getToolUseFlowContext(session.streamId)
       : undefined;
     return activeFlow?.modelSwitchDisabledReason(candidateModel);
   };
@@ -733,7 +733,7 @@ export async function runChat(
       onSuspend={() => handleSigtstp()}
       onKillExecution={(executionId) => {
         clearApprovals();
-        executionRegistry.kill(executionId, {
+        SharedExecutionRegistry.kill(executionId, {
           detachActiveChildren: detachSubagentsOnStop(),
         });
       }}

--- a/packages/desktop/src/main/desktopProgressEventBridge.ts
+++ b/packages/desktop/src/main/desktopProgressEventBridge.ts
@@ -12,7 +12,10 @@
 
 import type { AgentTrace } from '@agent/trace';
 import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
-import { bus, type ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import {
+  ProgressEventBus,
+  type ProgressEventPayloads,
+} from '@eventBus/ProgressEventBus';
 import {
   STREAM_PHASE,
   type ProgressViewOutboundMessage,
@@ -141,15 +144,18 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
     // runtime host. Keep them subscribed here so all desktop windows see
     // progress-routing and root-error updates. Goal state is session-scoped and
     // reaches this bridge through `onProgressEvent`.
-    const unsubscribeEnsureProgress = bus.on(
+    const unsubscribeEnsureProgress = ProgressEventBus.on(
       'requestEnsureProgressView',
       () => {
         opts.routeToProgress();
       },
     );
-    const unsubscribeShowError = bus.on('requestShowError', ({ message }) => {
-      opts.onShowError(message);
-    });
+    const unsubscribeShowError = ProgressEventBus.on(
+      'requestShowError',
+      ({ message }) => {
+        opts.onShowError(message);
+      },
+    );
     this.unsubscribe = () => {
       unsubscribeEnsureProgress();
       unsubscribeShowError();

--- a/packages/extension/src/commands/agent/agentCommands.ts
+++ b/packages/extension/src/commands/agent/agentCommands.ts
@@ -3,20 +3,20 @@ import * as vscode from 'vscode';
 
 // Local imports - agent
 import { detachSubagentsOnStop } from '@agent/runtime/detachSubagentsOnStop';
-import { executionRegistry } from '@agent/runtime/executionRegistry';
+import { SharedExecutionRegistry } from '@agent/runtime/executionRegistry';
 import { notifyFollowUpSent } from '@agent/followUp/ToolUseFollowUp';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import type { StreamTabId } from '@shared/schemas';
 
 export function stopAgent(streamId: StreamTabId): void {
-  executionRegistry.stopAgentStream(streamId, {
+  SharedExecutionRegistry.stopAgentStream(streamId, {
     detachActiveChildren: detachSubagentsOnStop(),
     runtimeHost: extensionAgentRuntimeHost,
   });
 }
 
 export async function compactResponse(streamId: StreamTabId): Promise<void> {
-  const result = executionRegistry.requestManualCompaction(streamId);
+  const result = SharedExecutionRegistry.requestManualCompaction(streamId);
   switch (result.kind) {
     case 'no_active_tool_use':
       await vscode.window.showInformationMessage(

--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -8,7 +8,7 @@ import { loadAgents } from '@agent/index';
 import { registerExecution } from '@agent/storage';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { executeAgent } from '@agent/runtime/executeAgent';
-import { executionRegistry } from '@agent/runtime/executionRegistry';
+import { SharedExecutionRegistry } from '@agent/runtime/executionRegistry';
 import { isCodexSubscriptionActive } from '@auth/codex';
 import { AUTH_COMMANDS } from '@auth/constants';
 import { getServerSideKeyService } from '@auth/serverKeys';
@@ -229,9 +229,9 @@ export async function launchSetupAssistant(): Promise<SetupAssistantLaunchResult
     // installs and config writes. The launcher's manual Execute path is
     // deliberately not gated — an explicit user action wins.
     if (
-      executionRegistry
-        .getAgentHandles()
-        .some((handle) => agentName(handle.agentName) === SETUP_AGENT_NAME)
+      SharedExecutionRegistry.getAgentHandles().some(
+        (handle) => agentName(handle.agentName) === SETUP_AGENT_NAME,
+      )
     ) {
       void vscode.window.showInformationMessage(
         'The setup assistant is already running — follow it in the Progress view.',

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -46,7 +46,7 @@ import { openGettingStarted } from '@commands/system/walkthroughCommands';
 import { SIDEBAR_VIEWS, setActiveSidebarView } from '@common/webview';
 import { globalSM, initializeStateManagers, workspaceSM } from '@common/state';
 import { appSignals } from '@eventBus/AppSignals';
-import { bus } from '@eventBus/ProgressEventBus';
+import { ProgressEventBus } from '@eventBus/ProgressEventBus';
 import { SecretManager } from '@frontend/secretManager';
 import {
   copyDefaultAgents,
@@ -291,7 +291,7 @@ export async function activate(context: vscode.ExtensionContext) {
     SharedIssuePollingSource.disposeAll(),
   );
   lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () =>
-    bus.emit('extensionDeactivating', undefined),
+    ProgressEventBus.emit('extensionDeactivating', undefined),
   );
   lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => disposeDiffRefresh());
   await StorageFS.ensureDir(RUNS_STORAGE_DIR);
@@ -730,7 +730,7 @@ export async function activate(context: vscode.ExtensionContext) {
     }
   };
 
-  const disposeStreamStatusListener = bus.on(
+  const disposeStreamStatusListener = ProgressEventBus.on(
     'updateStreamStatus',
     ({
       streamId,
@@ -744,7 +744,7 @@ export async function activate(context: vscode.ExtensionContext) {
       updateStatusBarText();
     },
   );
-  const disposeUsageListener = bus.on(
+  const disposeUsageListener = ProgressEventBus.on(
     'updateStreamUsage',
     ({ streamId, usage }: { streamId: string; usage: TokenUsageStats }) => {
       // UsageMonitor emits per-round deltas; the tracker accumulates them.

--- a/packages/extension/src/frontend/agentRuntime/extensionAgentRuntimeHost.ts
+++ b/packages/extension/src/frontend/agentRuntime/extensionAgentRuntimeHost.ts
@@ -1,8 +1,8 @@
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { defaultSession } from '@agent/runtime/SessionHandle';
-import { bus } from '@eventBus/ProgressEventBus';
+import { ProgressEventBus } from '@eventBus/ProgressEventBus';
 
 export const extensionAgentRuntimeHost: AgentRuntimeHost = {
   interactions: defaultSession().interactions,
-  emit: (event, payload) => bus.emit(event, payload),
+  emit: (event, payload) => ProgressEventBus.emit(event, payload),
 };

--- a/packages/extension/src/frontend/events/agentEventListeners.ts
+++ b/packages/extension/src/frontend/events/agentEventListeners.ts
@@ -11,7 +11,10 @@ import * as vscode from 'vscode';
 import { getProgressViewBridge } from '@agent/runtime/ProgressViewBridge';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
-import { bus, INSTRUCTION_ACTION } from '@eventBus/ProgressEventBus';
+import {
+  ProgressEventBus,
+  INSTRUCTION_ACTION,
+} from '@eventBus/ProgressEventBus';
 import type {
   InstructionAction,
   ProgressEventPayloads,
@@ -139,15 +142,17 @@ export function registerAgentEventListeners(): vscode.Disposable {
   const controller = new AbortController();
   const { signal } = controller;
 
-  bus.on('requestOpenFile', handleRequestOpenFile, { signal });
-  bus.on('requestShowInstruction', handleRequestShowInstruction, { signal });
-  bus.on(
+  ProgressEventBus.on('requestOpenFile', handleRequestOpenFile, { signal });
+  ProgressEventBus.on('requestShowInstruction', handleRequestShowInstruction, {
+    signal,
+  });
+  ProgressEventBus.on(
     'showAgentConfigBanner',
     (payload) => void handleShowAgentConfigBanner(payload),
     { signal },
   );
-  bus.on('requestShowError', handleRequestShowError, { signal });
-  bus.on(
+  ProgressEventBus.on('requestShowError', handleRequestShowError, { signal });
+  ProgressEventBus.on(
     'requestEnsureProgressView',
     (payload) => void handleRequestEnsureProgressView(payload),
     { signal },
@@ -155,8 +160,9 @@ export function registerAgentEventListeners(): vscode.Disposable {
 
   // Terminal-error toasts now come from the run's `result` event (the lifecycle
   // no longer emits them directly). The same shared helper every host uses
-  // re-emits `requestShow*` through `extensionAgentRuntimeHost` (= `bus.emit`),
-  // reaching the `bus.on` handlers registered above exactly once.
+  // re-emits `requestShow*` through `extensionAgentRuntimeHost` (=
+  // `ProgressEventBus.emit`), reaching the `ProgressEventBus.on` handlers
+  // registered above exactly once.
   const detachResult = attachTerminalResultToast(
     defaultSession(),
     extensionAgentRuntimeHost,

--- a/packages/extension/src/frontend/ui/fileDecorations.ts
+++ b/packages/extension/src/frontend/ui/fileDecorations.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 
 import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import { defaultSession } from '@agent/runtime/SessionHandle';
-import { bus } from '@eventBus/ProgressEventBus';
+import { ProgressEventBus } from '@eventBus/ProgressEventBus';
 import { subscribeAddOutputFilesRunFact } from '@frontend/events/runFactSubscriptions';
 import type { OutputFileInfo } from '@shared/schemas/output';
 
@@ -81,7 +81,7 @@ export function registerFileDecorations(
     },
   );
 
-  const unsubscribeWritten = bus.on(
+  const unsubscribeWritten = ProgressEventBus.on(
     'workspaceFilesWritten',
     ({ absolutePaths }) => {
       provider.markTouched(absolutePaths);

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -27,7 +27,7 @@ import { getServerSideKeyService } from '@auth/serverKeys';
 import { setPreferCodexSubscription } from '@auth/codex';
 import { apiKeyCommands } from '@commands/api/apiKeyCommands';
 import { BaseViewMessageHandler } from '@common/webview';
-import { bus } from '@eventBus/ProgressEventBus';
+import { ProgressEventBus } from '@eventBus/ProgressEventBus';
 import { SecretManager } from '@frontend/secretManager';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { loadOptions } from '@frontend/agents/optionsLoader';
@@ -125,10 +125,13 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     this.followUpPolishController = new ProgressFollowUpPolishController();
     this.handlerRegistry = this.createHandlerRegistry();
 
-    const unsubscribeRemoveStream = bus.on('removeStream', ({ streamId }) => {
-      void this.streamLifecycleController.deleteStream(streamId);
-      void GoalStore.forget(streamId);
-    });
+    const unsubscribeRemoveStream = ProgressEventBus.on(
+      'removeStream',
+      ({ streamId }) => {
+        void this.streamLifecycleController.deleteStream(streamId);
+        void GoalStore.forget(streamId);
+      },
+    );
     context.subscriptions.push({ dispose: unsubscribeRemoveStream });
 
     const unsubscribeGoal = subscribeGoalStateChanges(

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -17,7 +17,7 @@ import {
   setActiveSidebarView,
 } from '@common/webview';
 import { workspaceSM } from '@common/state';
-import { bus } from '@eventBus/ProgressEventBus';
+import { ProgressEventBus } from '@eventBus/ProgressEventBus';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { VscodePromptHost } from '@frontend/hosts/VscodePromptHost';
 import { createChannelTrace } from '@logger';
@@ -200,7 +200,7 @@ export class ProgressViewProvider
     await this.backend.load();
     this._disposables.push(
       this.backend.setupEventListeners(),
-      attachProgressBackendProcessBus(this.backend, bus),
+      attachProgressBackendProcessBus(this.backend, ProgressEventBus),
     );
     this.logger.debug('ProgressViewProvider initialized');
   }

--- a/packages/extension/src/settingsView/handlers/historyHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/historyHandlers.ts
@@ -27,7 +27,7 @@ import {
   AgentConfigSchema,
   type AgentConfig,
 } from '@agent/core/definition/AgentConfig';
-import { executionRegistry } from '@agent/runtime/executionRegistry';
+import { SharedExecutionRegistry } from '@agent/runtime/executionRegistry';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 import { runExecuteCommand } from '@commands/agent/executeCommand';
 import {
@@ -99,7 +99,7 @@ export class HistoryHandlers {
     data: SettingsMessageFor<typeof SETTINGS_VIEW_CMD.DELETE_AGENT>,
   ): Promise<void> {
     try {
-      const activeIds = executionRegistry.getActiveIds();
+      const activeIds = SharedExecutionRegistry.getActiveIds();
       if (activeIds.includes(data.historyId)) {
         await vscode.window.showWarningMessage(
           'Cannot delete a running execution',
@@ -125,7 +125,9 @@ export class HistoryHandlers {
 
   async handleClearHistory(): Promise<void> {
     try {
-      await deleteAllExecutions(new Set(executionRegistry.getActiveIds()));
+      await deleteAllExecutions(
+        new Set(SharedExecutionRegistry.getActiveIds()),
+      );
       await vscode.window.showInformationMessage('Agent history cleared');
       await this.ctx.withActiveWebview(async (w) => {
         await w.postMessage({

--- a/src/agent/features/registerGoal.ts
+++ b/src/agent/features/registerGoal.ts
@@ -1,4 +1,4 @@
-import { toolInjectionRegistry } from '@agent/runtime/toolInjection';
+import { SharedToolInjectionRegistry } from '@agent/runtime/toolInjection';
 import { isGoalEnabled } from '@tools/goal';
 
 /**
@@ -14,7 +14,7 @@ import { isGoalEnabled } from '@tools/goal';
  * idle-continuation registry — goal was its only consumer.
  */
 export function registerGoalFeature(): void {
-  toolInjectionRegistry.register({
+  SharedToolInjectionRegistry.register({
     toolName: 'plan',
     shouldInject: () => isGoalEnabled(),
   });

--- a/src/agent/features/registerMemory.ts
+++ b/src/agent/features/registerMemory.ts
@@ -1,9 +1,9 @@
 import { platform } from '@platform/platform';
-import { toolInjectionRegistry } from '@agent/runtime/toolInjection';
+import { SharedToolInjectionRegistry } from '@agent/runtime/toolInjection';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 
 export function registerMemoryFeature(): void {
-  toolInjectionRegistry.register({
+  SharedToolInjectionRegistry.register({
     toolName: 'memory',
     shouldInject: () =>
       platform().globalState.get<boolean>(GlobalStateKey.MEMORY_ENABLED, true),

--- a/src/agent/runtime/ExecutionSubscriptionBinder.ts
+++ b/src/agent/runtime/ExecutionSubscriptionBinder.ts
@@ -12,7 +12,7 @@
  */
 
 import {
-  executionRegistry,
+  SharedExecutionRegistry,
   type ExecutionHandle,
   type ExecutionRegistry,
 } from '@agent/runtime/executionRegistry';
@@ -188,7 +188,7 @@ export class ExecutionSubscriptionBinder {
   private releaseHook: (() => void) | undefined;
 
   constructor(options: ExecutionSubscriptionBinderOptions = {}) {
-    this.registry = options.registry ?? executionRegistry;
+    this.registry = options.registry ?? SharedExecutionRegistry;
     this.releaseSource = options.releaseSource ?? ToolUseFollowUpQueue;
     this.logger = options.logger ?? logger;
     this.session = options.session;
@@ -292,4 +292,5 @@ export class ExecutionSubscriptionBinder {
   }
 }
 
-export const executionSubscriptionBinder = new ExecutionSubscriptionBinder();
+export const SharedExecutionSubscriptionBinder =
+  new ExecutionSubscriptionBinder();

--- a/src/agent/runtime/InterruptRegistry.ts
+++ b/src/agent/runtime/InterruptRegistry.ts
@@ -31,4 +31,4 @@ export class InterruptRegistry {
   }
 }
 
-export const interruptRegistry = new InterruptRegistry();
+export const SharedInterruptRegistry = new InterruptRegistry();

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -39,12 +39,21 @@ import { createChannelTrace } from '@logger';
 import type { StreamTabId } from '@shared/schemas';
 
 import { tryUseRunContext } from './RunContext';
-import { ExecutionRegistry, executionRegistry } from './executionRegistry';
-import { InterruptRegistry, interruptRegistry } from './InterruptRegistry';
-import { RunCoordinatorBridge, runCoordinatorBridge } from './runCoordinators';
+import {
+  ExecutionRegistry,
+  SharedExecutionRegistry,
+} from './executionRegistry';
+import {
+  InterruptRegistry,
+  SharedInterruptRegistry,
+} from './InterruptRegistry';
+import {
+  RunCoordinatorBridge,
+  SharedRunCoordinatorBridge,
+} from './runCoordinators';
 import {
   ExecutionSubscriptionBinder,
-  executionSubscriptionBinder,
+  SharedExecutionSubscriptionBinder,
 } from './ExecutionSubscriptionBinder';
 import {
   StreamStatusMachine,
@@ -295,21 +304,21 @@ let cachedDefaultSession: SessionHandle | undefined;
  * The process-default session. Its members ARE the existing exported singletons
  * — identity is the behavior-neutral compatibility mechanism for the 7d train:
  * unmigrated call sites keep hitting the same objects, and per-call-site
- * migration is `runCoordinatorBridge.x(...)` → `session.coordinators.x(...)`
+ * migration is `SharedRunCoordinatorBridge.x(...)` → `session.coordinators.x(...)`
  * against the identical instance.
  *
  * Constructed lazily on first use rather than at module evaluation: many
  * run-scoped modules import `currentSession`, which pulls this module into
  * their import cycle, and an eager construction here would read the
- * `executionSubscriptionBinder` singleton before its own module finished
+ * `SharedExecutionSubscriptionBinder` singleton before its own module finished
  * initializing (TDZ). Deferring to first call sidesteps that entirely.
  */
 export function defaultSession(): SessionHandle {
   return (cachedDefaultSession ??= new SessionHandle({
-    interrupts: interruptRegistry,
-    executions: executionRegistry,
-    coordinators: runCoordinatorBridge,
-    subscriptions: executionSubscriptionBinder,
+    interrupts: SharedInterruptRegistry,
+    executions: SharedExecutionRegistry,
+    coordinators: SharedRunCoordinatorBridge,
+    subscriptions: SharedExecutionSubscriptionBinder,
     status: StreamStatusService,
     transcripts: getDefaultStreamLogStore(),
     followUps: ToolUseFollowUpQueue.defaultInstance(),

--- a/src/agent/runtime/agentShutdown.ts
+++ b/src/agent/runtime/agentShutdown.ts
@@ -3,11 +3,11 @@ import {
   type LifecycleHost,
 } from '@platform/interfaces/lifecycle';
 import {
-  claudeAgentSessions,
+  ClaudeAgentSessions,
   CodexThreads,
 } from '@tools/agentCliSessionStores';
 
-import { executionRegistry } from './executionRegistry';
+import { SharedExecutionRegistry } from './executionRegistry';
 
 /**
  * Stops agent-spawned child processes and CLI-backed agent sessions before
@@ -16,7 +16,7 @@ import { executionRegistry } from './executionRegistry';
  */
 export function registerAgentShutdownHandlers(lifecycle: LifecycleHost): void {
   lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
-    executionRegistry.killBackgroundProcesses(),
+    SharedExecutionRegistry.killBackgroundProcesses(),
   );
   // Interrupt CLI-backed sessions so their streams don't reload in a stale
   // WAITING state.
@@ -24,6 +24,6 @@ export function registerAgentShutdownHandlers(lifecycle: LifecycleHost): void {
     CodexThreads.interruptAll(),
   );
   lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
-    claudeAgentSessions.interruptAll(),
+    ClaudeAgentSessions.interruptAll(),
   );
 }

--- a/src/agent/runtime/agentToolResolution.ts
+++ b/src/agent/runtime/agentToolResolution.ts
@@ -54,7 +54,7 @@ import { withDelegationWorktreeAvailability } from '@tools/delegationWorktreeAva
 import { isApprovalGatedToolName } from '@tools/approvalGatedTools';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import {
-  toolInjectionRegistry,
+  SharedToolInjectionRegistry,
   type ToolInjectionRegistry,
 } from './toolInjection';
 
@@ -136,7 +136,7 @@ export async function resolveAgentTools({
   delegationBlocked,
   approvalPromptsUnavailable,
   runtimeUnavailableTools,
-  toolInjections = toolInjectionRegistry,
+  toolInjections = SharedToolInjectionRegistry,
 }: ResolveAgentToolsInput): Promise<ResolvedAgentTools> {
   const effectiveRegistry = registry ?? getDefaultToolRegistry();
   const disabled = getDisabledToolNames();

--- a/src/agent/runtime/emitRuntimeEvent.ts
+++ b/src/agent/runtime/emitRuntimeEvent.ts
@@ -1,8 +1,8 @@
 /**
  * Single emit path for run/host progress events (SDK Step 7d follow-on F-1).
  *
- * Replaces scattered `bus.emit(...)` in `src/tools` so one fact has one emit
- * path and one name, resolving the target in priority order:
+ * Replaces scattered `ProgressEventBus.emit(...)` in `src/tools` so one fact
+ * has one emit path and one name, resolving the target in priority order:
  *
  * 1. migrated Stage 3a facts go to the owning `SessionEventHub` and are
  *    projected to the legacy host surface by `LegacyProgressEventProjection`;
@@ -10,15 +10,19 @@
  *    non-default session, e.g. a desktop window) — when present;
  * 3. otherwise the active run's `runtimeHost`, resolved from the ambient
  *    {@link RunContext} (the in-run case — tools firing inside a run's ALS);
- * 4. otherwise the process {@link bus} — the single-session fallback that keeps
- *    the extension byte-identical (its run `runtimeHost.emit` is `bus.emit`
- *    anyway) and host-path callers that pass no session unchanged.
+ * 4. otherwise the process {@link ProgressEventBus} — the single-session
+ *    fallback that keeps the extension byte-identical (its run
+ *    `runtimeHost.emit` is `ProgressEventBus.emit` anyway) and host-path
+ *    callers that pass no session unchanged.
  *
  * In-run callers pass no `session` (the ALS supplies the run host). Host-path
  * callers — reachable outside any run ALS — MUST pass their owning `session`,
  * or the event resolves to the bus and a non-default session never sees it.
  */
-import { bus, type ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import {
+  ProgressEventBus,
+  type ProgressEventPayloads,
+} from '@eventBus/ProgressEventBus';
 
 import { tryUseRunContext } from './RunContext';
 import { defaultSession, type SessionHandle } from './SessionHandle';
@@ -95,5 +99,5 @@ export function emitRuntimeEvent<K extends keyof ProgressEventPayloads>(
 
   const host = session?.hostChannel ?? tryUseRunContext()?.runtimeHost;
   if (host) host.emit(event, payload);
-  else bus.emit(event, payload);
+  else ProgressEventBus.emit(event, payload);
 }

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -292,7 +292,7 @@ export interface ExecuteAgentOptions {
   toolEditApprovalHandler?: ToolEditApprovalPort;
   /** Resume using this persisted provider-message format instead of today's default route. */
   modelHandlerCompatibilityKey?: ModelHandlerCompatibilityKey | null;
-  /** Fires after flow completes but before executionRegistry.untrack, so follow-ups are enqueued before waiters resolve. */
+  /** Fires after flow completes but before SharedExecutionRegistry.untrack, so follow-ups are enqueued before waiters resolve. */
   onCompleted?: (result: AgentFlowResult) => void | Promise<void>;
   /** Fires when a subagent fails and should report the failure to its orchestrator. */
   onError?: (error: unknown, result: AgentFlowResult) => void | Promise<void>;

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -11,7 +11,7 @@ import {
   type StreamStatusMachine,
 } from '@agent/runtime/StreamStatusService';
 import {
-  interruptRegistry,
+  SharedInterruptRegistry,
   type InterruptRegistry,
 } from '@agent/runtime/InterruptRegistry';
 import {
@@ -148,7 +148,7 @@ export class ExecutionRegistry {
   >();
 
   constructor({
-    interrupts = interruptRegistry,
+    interrupts = SharedInterruptRegistry,
     processOutput = new ProcessOutputPoller(),
     streamStatus = StreamStatusService,
     events,
@@ -906,4 +906,4 @@ export class ExecutionRegistry {
   }
 }
 
-export const executionRegistry = new ExecutionRegistry();
+export const SharedExecutionRegistry = new ExecutionRegistry();

--- a/src/agent/runtime/runCoordinators.ts
+++ b/src/agent/runtime/runCoordinators.ts
@@ -1,5 +1,8 @@
 import { useRunContext, type RunCoordinators } from './RunContext';
-import { executionRegistry, type ExecutionRegistry } from './executionRegistry';
+import {
+  SharedExecutionRegistry,
+  type ExecutionRegistry,
+} from './executionRegistry';
 import type {
   ProposalRequestOptions,
   ProposalResult,
@@ -39,7 +42,7 @@ export class RunCoordinatorBridge {
     private readonly registry: Pick<
       ExecutionRegistry,
       'getAgentHandleByStream' | 'getAgentHandles'
-    > = executionRegistry,
+    > = SharedExecutionRegistry,
   ) {}
 
   async waitForPlanApproval(
@@ -201,4 +204,4 @@ function matchingRequests(
   );
 }
 
-export const runCoordinatorBridge = new RunCoordinatorBridge();
+export const SharedRunCoordinatorBridge = new RunCoordinatorBridge();

--- a/src/agent/runtime/terminalResultToast.ts
+++ b/src/agent/runtime/terminalResultToast.ts
@@ -9,8 +9,9 @@
  * CLI/extension pass the process {@link defaultSession}. A helper that
  * hard-coded the default would route desktop to the wrong session and never see
  * its results. Every host presents through its `runtimeHost` — including the
- * extension, whose `extensionAgentRuntimeHost.emit` is `bus.emit`, so the
- * `requestShow*` events reach the same `bus.on` handlers exactly once.
+ * extension, whose `extensionAgentRuntimeHost.emit` is `ProgressEventBus.emit`,
+ * so the `requestShow*` events reach the same `ProgressEventBus.on` handlers
+ * exactly once.
  */
 import { terminalResultToast } from '@shared/agent/terminalResultPresentation';
 

--- a/src/agent/runtime/toolInjection.ts
+++ b/src/agent/runtime/toolInjection.ts
@@ -31,4 +31,4 @@ export class ToolInjectionRegistry {
   }
 }
 
-export const toolInjectionRegistry = new ToolInjectionRegistry();
+export const SharedToolInjectionRegistry = new ToolInjectionRegistry();

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -285,7 +285,7 @@ export interface ProgressEventBusLike {
   ): void;
 }
 
-class ProgressEventBus implements ProgressEventBusLike {
+class ProgressEventBusImpl implements ProgressEventBusLike {
   private emitter = new EventEmitter();
   private buffer: {
     event: ProgressEvent;
@@ -333,4 +333,4 @@ class ProgressEventBus implements ProgressEventBusLike {
   }
 }
 
-export const bus = new ProgressEventBus();
+export const ProgressEventBus = new ProgressEventBusImpl();

--- a/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
@@ -22,7 +22,7 @@ import {
 import { SessionHandle } from '@agent/runtime/SessionHandle';
 import {
   AgentExecutionHandle,
-  executionRegistry,
+  SharedExecutionRegistry,
   type LiveToolUseFlowContext,
 } from '@agent/runtime/executionRegistry';
 import {
@@ -56,7 +56,7 @@ function trackChildHandle(
     'toolUse',
     noopAgentRuntimeHost,
   );
-  executionRegistry.track(handle);
+  SharedExecutionRegistry.track(handle);
 }
 
 describe('ToolUseFollowUp', () => {
@@ -86,8 +86,8 @@ describe('ToolUseFollowUp', () => {
   };
 
   afterEach(() => {
-    for (const executionId of executionRegistry.getActiveIds()) {
-      executionRegistry.untrack(executionId);
+    for (const executionId of SharedExecutionRegistry.getActiveIds()) {
+      SharedExecutionRegistry.untrack(executionId);
     }
     ToolUseFollowUpQueue.release(streamId);
   });
@@ -113,7 +113,7 @@ describe('ToolUseFollowUp', () => {
       modelSwitchDisabledReason: () => undefined,
       switchModel: async () => {},
     });
-    executionRegistry.track(handle);
+    SharedExecutionRegistry.track(handle);
     return executionId;
   }
 
@@ -179,7 +179,7 @@ describe('ToolUseFollowUp', () => {
         'hello while running',
       ]);
     } finally {
-      executionRegistry.untrack(executionId);
+      SharedExecutionRegistry.untrack(executionId);
       ToolUseFollowUpQueue.release(parentStreamId);
     }
   });
@@ -205,7 +205,7 @@ describe('ToolUseFollowUp', () => {
         'after release',
       ]);
     } finally {
-      executionRegistry.untrack(executionId);
+      SharedExecutionRegistry.untrack(executionId);
       ToolUseFollowUpQueue.release(parentStreamId);
     }
   });
@@ -238,7 +238,7 @@ describe('ToolUseFollowUp', () => {
         },
       ]);
     } finally {
-      executionRegistry.untrack(executionId);
+      SharedExecutionRegistry.untrack(executionId);
       ToolUseFollowUpQueue.release(parentStreamId);
     }
   });
@@ -286,7 +286,7 @@ describe('ToolUseFollowUp', () => {
         'result two',
       ]);
     } finally {
-      executionRegistry.untrack(executionId);
+      SharedExecutionRegistry.untrack(executionId);
       ToolUseFollowUpQueue.release(parentStreamId);
     }
   });
@@ -312,7 +312,7 @@ describe('ToolUseFollowUp', () => {
       });
       assert.deepEqual(ToolUseFollowUpQueue.getAll(parentStreamId), []);
     } finally {
-      executionRegistry.untrack(executionId);
+      SharedExecutionRegistry.untrack(executionId);
       ToolUseFollowUpQueue.release(parentStreamId);
     }
   });
@@ -377,7 +377,7 @@ describe('ToolUseFollowUp', () => {
         'late result',
       ]);
     } finally {
-      executionRegistry.untrack(executionId);
+      SharedExecutionRegistry.untrack(executionId);
       ToolUseFollowUpQueue.release(parentStreamId);
     }
   });

--- a/src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts
@@ -12,7 +12,7 @@ import {
 } from '@agent/runtime/AgentRuntimeHost';
 import {
   AgentExecutionHandle,
-  executionRegistry,
+  SharedExecutionRegistry,
   type LiveToolUseFlowContext,
 } from '@agent/runtime/executionRegistry';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
@@ -31,7 +31,7 @@ describe('tool-use follow-up progress events', () => {
     unsubscribeFollowUpObserver?.();
     unsubscribeFollowUpObserver = undefined;
     for (const executionId of trackedExecutionIds) {
-      executionRegistry.untrack(executionId);
+      SharedExecutionRegistry.untrack(executionId);
     }
     trackedExecutionIds.clear();
     clearAllStreamStatusesForTest(StreamStatusService);
@@ -64,7 +64,7 @@ describe('tool-use follow-up progress events', () => {
       modelSwitchDisabledReason: () => undefined,
       switchModel: async () => {},
     });
-    executionRegistry.track(handle);
+    SharedExecutionRegistry.track(handle);
     trackedExecutionIds.add(executionId);
   }
 
@@ -172,7 +172,7 @@ describe('tool-use follow-up progress events', () => {
       parentStreamId,
       STREAM_STATUS.STOPPED,
     );
-    executionRegistry.track(handle);
+    SharedExecutionRegistry.track(handle);
 
     try {
       const result = await sendFollowUp(parentStreamId, 'continue child');
@@ -185,7 +185,7 @@ describe('tool-use follow-up progress events', () => {
         'continue child',
       ]);
     } finally {
-      executionRegistry.untrack(executionId);
+      SharedExecutionRegistry.untrack(executionId);
       ToolUseFollowUpQueue.release(parentStreamId);
     }
   });

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -21,7 +21,7 @@ import {
   StreamStatusMachine,
   StreamStatusService,
 } from '@agent/runtime/StreamStatusService';
-import { executionRegistry } from '@agent/runtime/executionRegistry';
+import { SharedExecutionRegistry } from '@agent/runtime/executionRegistry';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { runFlowWithLifecycle } from '@agent/runtime/AgentRunLifecycle';
 import { AgentFlowError } from '@agent/runtime/AgentFlowResult';
@@ -392,7 +392,7 @@ describe('runFlowWithLifecycle', () => {
       'lifecycle-subagent-error-registered',
     );
     const onError = vi.fn(() => {
-      expect(executionRegistry.getHandle(executionId)).toBeDefined();
+      expect(SharedExecutionRegistry.getHandle(executionId)).toBeDefined();
     });
 
     try {
@@ -407,9 +407,9 @@ describe('runFlowWithLifecycle', () => {
       expect(result.outcome).toBe(RUN_OUTCOME.FAILED);
       expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
       expect(onError).toHaveBeenCalledOnce();
-      expect(executionRegistry.getHandle(executionId)).toBeUndefined();
+      expect(SharedExecutionRegistry.getHandle(executionId)).toBeUndefined();
     } finally {
-      executionRegistry.untrack(executionId);
+      SharedExecutionRegistry.untrack(executionId);
       clearStreamStatusForTest(streamStatus, streamId);
     }
   });
@@ -445,9 +445,9 @@ describe('runFlowWithLifecycle', () => {
       expect(onCompleted).not.toHaveBeenCalled();
       expect(onError).not.toHaveBeenCalled();
       expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.WAITING);
-      expect(executionRegistry.getHandle(executionId)).toBeDefined();
+      expect(SharedExecutionRegistry.getHandle(executionId)).toBeDefined();
     } finally {
-      executionRegistry.untrack(executionId);
+      SharedExecutionRegistry.untrack(executionId);
       clearStreamStatusForTest(streamStatus, streamId);
     }
   });
@@ -606,7 +606,7 @@ describe('runFlowWithLifecycle', () => {
         carriedResult,
       );
     } finally {
-      executionRegistry.untrack(executionId);
+      SharedExecutionRegistry.untrack(executionId);
       clearStreamStatusForTest(streamStatus, streamId);
     }
   });

--- a/src/test-kernel/agent/runtime/EmitRuntimeEvent.vitest.ts
+++ b/src/test-kernel/agent/runtime/EmitRuntimeEvent.vitest.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
 import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
-import { bus } from '@eventBus/ProgressEventBus';
+import { ProgressEventBus } from '@eventBus/ProgressEventBus';
 import type { StreamTabId } from '@shared/schemas';
 
 import { createRecordingHost } from '../progressTestUtils';
@@ -20,7 +20,7 @@ describe('emitRuntimeEvent (SDK Step 7d F-1 — one emit path)', () => {
       (event) => sessionSeen.push(event),
       { scope: 'session' },
     );
-    const off = bus.on('goalStateChanged', (p) => seen.push(p));
+    const off = ProgressEventBus.on('goalStateChanged', (p) => seen.push(p));
     try {
       emitRuntimeEvent('goalStateChanged', { streamId: streamId('s:bus') });
       expect(sessionSeen).toEqual([
@@ -42,7 +42,7 @@ describe('emitRuntimeEvent (SDK Step 7d F-1 — one emit path)', () => {
   it("keeps non-migrated events on the active run's runtimeHost", () => {
     const run = createRecordingHost();
     const busSeen: unknown[] = [];
-    const off = bus.on('requestShowError', (p) => busSeen.push(p));
+    const off = ProgressEventBus.on('requestShowError', (p) => busSeen.push(p));
     try {
       withRunContext(createRunContext({ runtimeHost: run.host }), () => {
         emitRuntimeEvent('requestShowError', { message: 'run error' });
@@ -67,7 +67,7 @@ describe('emitRuntimeEvent (SDK Step 7d F-1 — one emit path)', () => {
       { scope: 'session' },
     );
     const busSeen: unknown[] = [];
-    const off = bus.on('goalStateChanged', (p) => busSeen.push(p));
+    const off = ProgressEventBus.on('goalStateChanged', (p) => busSeen.push(p));
     try {
       withRunContext(createRunContext({ runtimeHost: run.host }), () => {
         emitRuntimeEvent(

--- a/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
@@ -21,11 +21,11 @@ import {
 } from '@agent/runtime/SessionHandle';
 import {
   AgentExecutionHandle,
-  executionRegistry,
+  SharedExecutionRegistry,
 } from '@agent/runtime/executionRegistry';
-import { interruptRegistry } from '@agent/runtime/InterruptRegistry';
-import { runCoordinatorBridge } from '@agent/runtime/runCoordinators';
-import { executionSubscriptionBinder } from '@agent/runtime/ExecutionSubscriptionBinder';
+import { SharedInterruptRegistry } from '@agent/runtime/InterruptRegistry';
+import { SharedRunCoordinatorBridge } from '@agent/runtime/runCoordinators';
+import { SharedExecutionSubscriptionBinder } from '@agent/runtime/ExecutionSubscriptionBinder';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { type Plan, type StreamTabId } from '@shared/schemas';
 
@@ -67,10 +67,12 @@ function trackAgent(
 
 describe('SessionHandle', () => {
   it('defaultSession wraps the process singletons by identity', () => {
-    expect(defaultSession().interrupts).toBe(interruptRegistry);
-    expect(defaultSession().executions).toBe(executionRegistry);
-    expect(defaultSession().coordinators).toBe(runCoordinatorBridge);
-    expect(defaultSession().subscriptions).toBe(executionSubscriptionBinder);
+    expect(defaultSession().interrupts).toBe(SharedInterruptRegistry);
+    expect(defaultSession().executions).toBe(SharedExecutionRegistry);
+    expect(defaultSession().coordinators).toBe(SharedRunCoordinatorBridge);
+    expect(defaultSession().subscriptions).toBe(
+      SharedExecutionSubscriptionBinder,
+    );
     expect(defaultSession().status).toBe(StreamStatusService);
     expect(defaultSession().events).toBeDefined();
     expect(defaultSession().transcripts).toBe(getDefaultStreamLogStore());
@@ -84,10 +86,10 @@ describe('SessionHandle', () => {
   it('a fresh session shares no member with the module singletons', () => {
     const fresh = new SessionHandle();
     try {
-      expect(fresh.interrupts).not.toBe(interruptRegistry);
-      expect(fresh.executions).not.toBe(executionRegistry);
-      expect(fresh.coordinators).not.toBe(runCoordinatorBridge);
-      expect(fresh.subscriptions).not.toBe(executionSubscriptionBinder);
+      expect(fresh.interrupts).not.toBe(SharedInterruptRegistry);
+      expect(fresh.executions).not.toBe(SharedExecutionRegistry);
+      expect(fresh.coordinators).not.toBe(SharedRunCoordinatorBridge);
+      expect(fresh.subscriptions).not.toBe(SharedExecutionSubscriptionBinder);
       expect(fresh.status).not.toBe(StreamStatusService);
       expect(fresh.events).not.toBe(defaultSession().events);
       expect(fresh.transcripts).not.toBe(defaultSession().transcripts);
@@ -104,8 +106,8 @@ describe('SessionHandle', () => {
     const session = new SessionHandle({ hostChannel: host });
     try {
       expect(session.hostChannel).toBe(host);
-      expect(session.executions).not.toBe(executionRegistry);
-      expect(session.interrupts).not.toBe(interruptRegistry);
+      expect(session.executions).not.toBe(SharedExecutionRegistry);
+      expect(session.interrupts).not.toBe(SharedInterruptRegistry);
     } finally {
       session.dispose();
     }

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -29,7 +29,7 @@ vi.mock('@cli/chat/tui/state/codexSubscription', () => ({
 }));
 
 vi.mock('@agent/runtime/runCoordinators', () => ({
-  runCoordinatorBridge: {
+  SharedRunCoordinatorBridge: {
     triggerRetry: mocks.triggerRetry,
     cancelRetry: mocks.cancelRetry,
   },

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -14,7 +14,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@agent/runtime/executionRegistry', () => ({
-  executionRegistry: {
+  SharedExecutionRegistry: {
     stopAgentStream: mocks.stopAgentStream,
   },
 }));

--- a/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
+++ b/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
@@ -37,7 +37,7 @@ vi.mock('@frontend/secretManager', () => ({
 }));
 
 vi.mock('@agent/runtime/executionRegistry', () => ({
-  executionRegistry: {
+  SharedExecutionRegistry: {
     getAgentHandles: () => agentHandles(),
   },
 }));

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -578,9 +578,9 @@ describe('DesktopProgressBridge', () => {
   it('routes runtime events to the desktop backend without the shared progress bus', async () => {
     const messages: unknown[] = [];
     const bridge = await createBridge(messages);
-    const { bus } = await import('@eventBus/ProgressEventBus');
+    const { ProgressEventBus } = await import('@eventBus/ProgressEventBus');
     const seen: unknown[] = [];
-    const off = bus.on('setActiveStream', (payload) => {
+    const off = ProgressEventBus.on('setActiveStream', (payload) => {
       seen.push(payload);
     });
 

--- a/src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts
@@ -133,7 +133,7 @@ async function loadBridgeModule(): Promise<
     },
   }));
   vi.doMock('@eventBus/ProgressEventBus', () => ({
-    bus: {
+    ProgressEventBus: {
       on: vi.fn((event: string, handler: MockBusHandler) => {
         mockBusHandlers.set(event, handler);
         return () => {

--- a/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
+++ b/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
@@ -163,7 +163,7 @@ async function loadApprovalModules(workspacePath = '/workspace') {
   );
 
   const [
-    { bus },
+    { ProgressEventBus: bus },
     { requestToolEditApproval },
     { cleanupApprovalsForStream },
     desktopModule,

--- a/src/test-kernel/frontend/OutputFileRunFactSubscriptions.vitest.ts
+++ b/src/test-kernel/frontend/OutputFileRunFactSubscriptions.vitest.ts
@@ -112,7 +112,7 @@ vi.mock('vscode', () => {
 
 const { SessionEventHub } = await import('@agent/runtime/SessionEventHub');
 const { toRunFactDomainKey } = await import('@agent/runtime/runFactEvents');
-const { bus } = await import('@eventBus/ProgressEventBus');
+const { ProgressEventBus } = await import('@eventBus/ProgressEventBus');
 const { registerInlineCriticism, setInlineCriticismEnabled } =
   await import('@frontend/latex/inlineCriticism');
 const { registerFileDecorations } =
@@ -175,7 +175,7 @@ function disposeContext(context: {
 }
 
 function drainBufferedAddOutputFilesBusEvents(): void {
-  const unsubscribe = bus.on('addOutputFiles', () => undefined);
+  const unsubscribe = ProgressEventBus.on('addOutputFiles', () => undefined);
   unsubscribe();
 }
 
@@ -216,7 +216,7 @@ describe('output-file run fact frontend subscriptions', () => {
     };
 
     const legacyPath = '/tmp/texra-legacy-output.tex';
-    bus.emit('addOutputFiles', addOutputFilesPayload(legacyPath));
+    ProgressEventBus.emit('addOutputFiles', addOutputFilesPayload(legacyPath));
     expect(provider.provideFileDecoration(vscode.Uri.file(legacyPath))).toBe(
       undefined,
     );
@@ -229,7 +229,9 @@ describe('output-file run fact frontend subscriptions', () => {
     ).toMatchObject({ badge: 'T', tooltip: 'Modified by TeXRA' });
 
     const writtenPath = '/tmp/texra-workspace-written.tex';
-    bus.emit('workspaceFilesWritten', { absolutePaths: [writtenPath] });
+    ProgressEventBus.emit('workspaceFilesWritten', {
+      absolutePaths: [writtenPath],
+    });
     expect(
       provider.provideFileDecoration(vscode.Uri.file(writtenPath)),
     ).toMatchObject({ badge: 'T', tooltip: 'Modified by TeXRA' });
@@ -256,7 +258,7 @@ describe('output-file run fact frontend subscriptions', () => {
       undefined,
     );
 
-    bus.emit('addOutputFiles', addOutputFilesPayload(outputPath));
+    ProgressEventBus.emit('addOutputFiles', addOutputFilesPayload(outputPath));
     await sleep(20);
     expect(mocks.diagnosticCollections.at(-1)?.items.get(outputPath)).toBe(
       undefined,

--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -7,7 +7,7 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { AgentProposalCoordinator } from '@agent/runtime/AgentProposalCoordinator';
 import {
   AgentExecutionHandle,
-  executionRegistry,
+  SharedExecutionRegistry,
 } from '@agent/runtime/executionRegistry';
 import { AgentFlowError } from '@agent/runtime/AgentFlowResult';
 import type { HostInteractions } from '@agent/runtime/HostInteractions';
@@ -153,8 +153,8 @@ describe('headless delegation', () => {
   });
 
   afterEach(() => {
-    for (const executionId of executionRegistry.getActiveIds()) {
-      executionRegistry.untrack(executionId);
+    for (const executionId of SharedExecutionRegistry.getActiveIds()) {
+      SharedExecutionRegistry.untrack(executionId);
     }
     ToolUseFollowUpQueue.release('parent-stream' as StreamTabId);
     ToolUseFollowUpQueue.release('child-stream' as StreamTabId);
@@ -602,7 +602,7 @@ describe('headless delegation', () => {
 
     mocks.executeAgent.mockImplementationOnce(
       async (_config, executionId: string, options) => {
-        executionRegistry.track(
+        SharedExecutionRegistry.track(
           new AgentExecutionHandle(
             executionId,
             parentStreamId,
@@ -628,7 +628,7 @@ describe('headless delegation', () => {
       () => callDelegateReview(),
     );
 
-    executionRegistry.detachActiveChildren(parentStreamId, host);
+    SharedExecutionRegistry.detachActiveChildren(parentStreamId, host);
 
     expect(onBeforeWaiting).toBeDefined();
     const delivered = await onBeforeWaiting!('The proof is correct.', [], []);

--- a/src/test-kernel/tools/InquiryContinuationSession.vitest.ts
+++ b/src/test-kernel/tools/InquiryContinuationSession.vitest.ts
@@ -20,7 +20,7 @@ vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
 }));
 
 vi.mock('@eventBus/ProgressEventBus', () => ({
-  bus: { emit: vi.fn() },
+  ProgressEventBus: { emit: vi.fn() },
 }));
 
 vi.mock('@platform/platform', () => ({

--- a/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
+++ b/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
@@ -36,7 +36,7 @@ vi.mock('@tools/childRunDelivery', () => ({
   persistChildRunReport: mocks.persistChildRunReport,
 }));
 
-import { subagentDeliveryRegistry } from '@tools/subagentDeliveryState';
+import { SharedSubagentDeliveryRegistry } from '@tools/subagentDeliveryState';
 import { NativeSubagentStrategy } from '@tools/delegation/nativeSubagentStrategy';
 
 describe('NativeSubagentStrategy', () => {
@@ -49,7 +49,7 @@ describe('NativeSubagentStrategy', () => {
   });
 
   afterEach(() => {
-    subagentDeliveryRegistry.finish(executionId);
+    SharedSubagentDeliveryRegistry.finish(executionId);
   });
 
   it('persists the result manifest before waking the parent', async () => {

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -31,7 +31,7 @@ import {
 } from '@shared/schemas';
 import type { ToolResult } from '@shared/schemas/toolResult';
 import { formatFollowUpInstruction } from '@tools/subagentResults';
-import { subagentDeliveryRegistry } from '@tools/subagentDeliveryState';
+import { SharedSubagentDeliveryRegistry } from '@tools/subagentDeliveryState';
 import { requireRunStream } from '@tools/contextHelpers';
 import { defineTool } from '@tools/core/define';
 
@@ -290,7 +290,7 @@ Git worktree support: resolved from the active workspace at runtime.`,
       );
     }
 
-    const deliveryState = subagentDeliveryRegistry.getActive(executionId);
+    const deliveryState = SharedSubagentDeliveryRegistry.getActive(executionId);
     if (!deliveryState) {
       throw new Error(
         `Execution '${executionId}' is no longer tracked for delivery. It may have already completed.`,

--- a/src/tools/agentCliSessionStores.ts
+++ b/src/tools/agentCliSessionStores.ts
@@ -32,7 +32,7 @@ export const CodexThreads = new AgentCliSessionRegistry<ActiveCodexThread>(
   'codex_thread_id',
 );
 
-export const claudeAgentSessions =
+export const ClaudeAgentSessions =
   new AgentCliSessionRegistry<ActiveClaudeAgentSession>(
     'claude_agent_session_id',
   );

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -47,7 +47,7 @@ import {
   findClaudeBinaryPath,
 } from './claudeAgentImport';
 import { type ChildStream } from './childStream';
-import { claudeAgentSessions } from './agentCliSessionStores';
+import { ClaudeAgentSessions } from './agentCliSessionStores';
 import {
   publishAgentCliStreamUsage,
   formatAgentCliDelivery,
@@ -424,8 +424,8 @@ function startClaudeAgentLoop(params: {
       if (turn.errorMessage) log.error(turn.errorMessage);
     },
     onTurnSuccess: (turn, session) => {
-      if (turn.sessionId && !claudeAgentSessions.isActive(turn.sessionId)) {
-        claudeAgentSessions.register(turn.sessionId, {
+      if (turn.sessionId && !ClaudeAgentSessions.isActive(turn.sessionId)) {
+        ClaudeAgentSessions.register(turn.sessionId, {
           childStreamId,
           parentStreamId,
           executionId,
@@ -459,7 +459,7 @@ function startClaudeAgentLoop(params: {
         err ?? turn?.errorMessage ?? turn?.finalResponse,
       ),
     onSessionCleanup: () => {
-      claudeAgentSessions.releaseMany(storedSessionIds);
+      ClaudeAgentSessions.releaseMany(storedSessionIds);
     },
   };
 
@@ -498,7 +498,7 @@ export class ClaudeAgentTool extends defineTool({
       `[${CLAUDE_AGENT_NAME} ${permissionMode}] ${input.prompt}`,
       (runContext) => {
         if (input.session_id) {
-          return resumeAgentCliSession(claudeAgentSessions, {
+          return resumeAgentCliSession(ClaudeAgentSessions, {
             id: input.session_id,
             prompt: input.prompt,
             callerStreamId: runContext?.streamId,

--- a/src/tools/delegation/nativeSubagentStrategy.ts
+++ b/src/tools/delegation/nativeSubagentStrategy.ts
@@ -49,7 +49,7 @@ import {
 } from '@tools/subagentResults';
 import {
   SUBAGENT_DELIVERY_DECISION,
-  subagentDeliveryRegistry,
+  SharedSubagentDeliveryRegistry,
 } from '@tools/subagentDeliveryState';
 import {
   computeAndWriteWorkflowDiffs,
@@ -172,7 +172,9 @@ export class NativeSubagentStrategy {
   private runHandle: AgentRunHandle | undefined;
 
   constructor(private readonly params: NativeSubagentStrategyParams) {
-    this.deliveryState = subagentDeliveryRegistry.start(params.executionId);
+    this.deliveryState = SharedSubagentDeliveryRegistry.start(
+      params.executionId,
+    );
     activeNativeSubagents.set(params.executionId, this);
   }
 
@@ -416,7 +418,7 @@ export class NativeSubagentStrategy {
   }
 
   private finish(): void {
-    subagentDeliveryRegistry.finish(this.params.executionId);
+    SharedSubagentDeliveryRegistry.finish(this.params.executionId);
     activeNativeSubagents.delete(this.params.executionId);
   }
 

--- a/src/tools/subagentDeliveryState.ts
+++ b/src/tools/subagentDeliveryState.ts
@@ -91,4 +91,4 @@ export type SubagentDeliveryDecision =
  * onto `SessionHandle`: a per-session split would be net-add with zero isolation
  * gain. Revisit only if a cross-session `clearAll`-style sweep is ever added.
  */
-export const subagentDeliveryRegistry = new SubagentDeliveryRegistry();
+export const SharedSubagentDeliveryRegistry = new SubagentDeliveryRegistry();


### PR DESCRIPTION
## Root cause

#7347 renamed most camelCase class-instance service-singleton exports to
PascalCase per AGENTS.md, but deliberately excluded `src/agent/runtime/`
and `src/tools/subagentDeliveryState.ts` because that area saw active
native-subagent churn on the day the original audit (#6866) landed, and
`subagentDeliveryRegistry` had just been touched by #7317. That PR's own
scope note asked for a human/maintainer decision on reopening #6866 or
filing a fresh issue "once things settle" — #7358 is that follow-up.
Reviewers on #7347 also flagged a same-file sibling that fell inside the
PR's stated scope but was missed: `claudeAgentSessions` in
`src/tools/agentCliSessionStores.ts`, the same `AgentCliSessionRegistry`
singleton shape as the already-renamed `CodexThreads` in that file.

## What changed

Pure rename of 8 export identifiers — no behavior change. All import
sites found via whole-word grep and updated, including `vi.mock()`
factories and JSDoc/comment references to the old identifiers (so mocks
and docs don't go stale):

| Old export | New export | File | Notes |
|---|---|---|---|
| `executionRegistry` | `SharedExecutionRegistry` | `src/agent/runtime/executionRegistry.ts` | class `ExecutionRegistry` kept as-is — constructed/typed directly in `SessionHandle.ts`, `runCoordinators.ts`, and several vitest suites |
| `interruptRegistry` | `SharedInterruptRegistry` | `src/agent/runtime/InterruptRegistry.ts` | class `InterruptRegistry` kept as-is — constructed directly in `agentCliSessionRegistry.ts` and tests |
| `toolInjectionRegistry` | `SharedToolInjectionRegistry` | `src/agent/runtime/toolInjection.ts` | class `ToolInjectionRegistry` kept as-is — constructed directly in tests |
| `executionSubscriptionBinder` | `SharedExecutionSubscriptionBinder` | `src/agent/runtime/ExecutionSubscriptionBinder.ts` | class kept as-is — constructed directly in `SessionHandle.ts` and tests |
| `runCoordinatorBridge` | `SharedRunCoordinatorBridge` | `src/agent/runtime/runCoordinators.ts` | class kept as-is — constructed directly in `SessionHandle.ts` and tests, typed in `ProgressViewMessageHandler.ts`/`ProgressStreamLifecycleHost.ts` |
| `subagentDeliveryRegistry` | `SharedSubagentDeliveryRegistry` | `src/tools/subagentDeliveryState.ts` | class kept as-is — constructed directly in its own vitest suite |
| `claudeAgentSessions` | `ClaudeAgentSessions` | `src/tools/agentCliSessionStores.ts` | no collision (missed sibling of `CodexThreads`) |
| `bus` | `ProgressEventBus` | `src/eventBus/ProgressEventBus.ts` | local class `ProgressEventBus` → `ProgressEventBusImpl` (same-file collision; class isn't referenced anywhere else, same treatment as `FlexibleFS`/`TikzPictureManager` in #7347) |

Collision handling follows #7347's own precedent: when the local class
is constructed or typed at other call sites, keep the class name as-is
and prefix the singleton export with `Shared*` (matches
`SharedAnnotationFetchBudget`/`SharedPRPollingSource` etc.); when the
class isn't referenced anywhere outside its own file, rename the local
class to `*Impl` and give the singleton the clean name instead (matches
`FlexibleFS`/`TikzPictureManager`).

## Verification

- `npx tsc --noEmit`: clean relative to the origin/main baseline — same
  13 pre-existing `@openrouter/sdk` / `vscode-jsonrpc/node` errors before
  and after (confirmed via `git stash`)
- `npx eslint <48 changed files>`: clean
- `npx prettier --check <48 changed files>`: clean (8 files needed
  `--write` after longer identifiers pushed lines over the width limit)
- `npx vitest run` across 29 test files covering every renamed singleton
  (ExecutionRegistry, InterruptRegistry, ToolInjectionRegistry,
  ExecutionSubscriptionBinder(Session), runCoordinators, SubagentDeliveryState,
  AgentCliSessionRegistry, ClaudeAgentConfig/ProgressEvents, ToolUseFollowUp(ProgressEvents),
  ToolUseToolResolution, AgentRunLifecycle, SessionHandle/Isolation/ResultEvent,
  EmitRuntimeEvent, ProgressBackend(ProcessBus), HistoryHandlers,
  DesktopProgressEventBridge, terminalResultPresentation, TuiApprovalRetry,
  DelegationHeadless, SetupAssistantRouting, InquiryContinuationSession,
  NativeSubagentStrategy, ExecutionsToolWorkspaceFiles, DelegationTools):
  **229/229 passed**
- Two desktop vitest files (`DesktopToolEditApproval.vitest.mts`,
  `DesktopAgentExecution.vitest.mts`) fail in this worktree on an
  unrelated pre-existing environment issue (`Cannot find package
  'vscode-jsonrpc/node'`) — confirmed identical failure count (61/61) on
  `git stash` before this change, so it's not something this diff
  introduced. Their `bus` → `ProgressEventBus` mock/destructure updates
  were still made and match the pattern used everywhere else.

Fixes #7358.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Identifier-only refactor across many files; no logic, API shape, or session wiring changes beyond import/export names.
> 
> **Overview**
> Renames process-wide singleton exports to match AGENTS.md PascalCase naming, with **no runtime behavior changes**. Call sites across CLI, extension, desktop, agent runtime, tools, and tests now import the new identifiers.
> 
> **Agent runtime & tools:** `executionRegistry`, `interruptRegistry`, `runCoordinatorBridge`, `executionSubscriptionBinder`, and `toolInjectionRegistry` become `Shared*` exports (e.g. `SharedExecutionRegistry`) where the underlying class name stays in use for typing and construction. `subagentDeliveryRegistry` → `SharedSubagentDeliveryRegistry`; `claudeAgentSessions` → `ClaudeAgentSessions` (aligned with `CodexThreads`).
> 
> **Progress events:** The global `bus` export is renamed to `ProgressEventBus`; the in-file implementation class is renamed to `ProgressEventBusImpl` to avoid a name collision. Extension/desktop hosts, `emitRuntimeEvent`, and all `on`/`emit` subscribers follow the new name.
> 
> **Compatibility:** `defaultSession()` still wires the same singleton instances by identity; comments and mocks were updated so docs and tests reference the new names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d5e7c5b604596eee6d40bb7e3384326710b32dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->