### PR TITLE
fix: move output-file run facts to progress backend

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1012,6 +1012,7 @@ export class DesktopProgressBridge {
     event: K,
     payload: ProgressEventPayloads[K],
   ): void {
+    if (event === 'addOutputFiles') return;
     this.backend.handleProgressEvent(event, payload);
     this.progressEvents.onProgressEvent(event, payload);
   }

--- a/packages/extension/src/progressView/progressBackendProcessBus.ts
+++ b/packages/extension/src/progressView/progressBackendProcessBus.ts
@@ -1,4 +1,8 @@
-import type { ProgressEventBusLike } from '@eventBus/ProgressEventBus';
+import type {
+  ProgressEvent,
+  ProgressEventBusLike,
+  ProgressEventPayloads,
+} from '@eventBus/ProgressEventBus';
 import type { ProgressBackend } from '@shared/progressView/backend/ProgressBackend';
 import type { ProgressEventSubscription } from '@shared/progressView/backend/events/ProgressEventHandler';
 
@@ -11,5 +15,22 @@ export function attachProgressBackendProcessBus(
   backend: Pick<ProgressBackend, 'eventHandler'>,
   bus: ProgressEventBusLike,
 ): ProgressEventSubscription {
-  return backend.eventHandler.setupEventListeners(bus);
+  const backendBus: ProgressEventBusLike = {
+    on<K extends ProgressEvent>(
+      event: K,
+      listener: (payload: ProgressEventPayloads[K]) => void,
+      options?: { signal?: AbortSignal },
+    ): () => void {
+      if (event === 'addOutputFiles') return () => {};
+      return bus.on(event, listener, options);
+    },
+    emit<K extends ProgressEvent>(
+      event: K,
+      payload: ProgressEventPayloads[K],
+    ): void {
+      bus.emit(event, payload);
+    },
+  };
+
+  return backend.eventHandler.setupEventListeners(backendBus);
 }

--- a/src/shared/progressView/backend/ProgressBackend.ts
+++ b/src/shared/progressView/backend/ProgressBackend.ts
@@ -2,6 +2,7 @@ import {
   defaultSession,
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
+import { toRunFactDomainKey } from '@agent/runtime/runFactEvents';
 import {
   type ProjectedProgressEvent,
   projectRunFactToProgressEvent,
@@ -24,7 +25,10 @@ import {
 } from '@shared/progressView/backend/events/ProgressEventHandler';
 import type { MementoStorage } from '@shared/progressView/backend/persistence/PersistentMapManager';
 import { ProgressViewState } from '@shared/progressView/backend/state/ProgressViewState';
+import { isObject } from '@utils/core';
 import type { StreamSnapshotStore } from '@transcript';
+
+const ADD_OUTPUT_FILES_DOMAIN_KEY = toRunFactDomainKey('addOutputFiles');
 
 export interface ProgressBackendServices {
   state: ProgressViewState;
@@ -153,8 +157,28 @@ export class ProgressBackend {
         types: ['stage.start', 'child.activity', 'process.output'],
       },
     );
+    const detachOutputFileRunFacts = this.session.events.subscribe(
+      (sessionEvent) => {
+        if (sessionEvent.scope !== 'run') return;
+        const { event } = sessionEvent;
+        if (
+          event.type !== 'domain' ||
+          event.key !== ADD_OUTPUT_FILES_DOMAIN_KEY ||
+          !isObject(event.data)
+        ) {
+          return;
+        }
+
+        const payload =
+          event.data as unknown as ProgressEventPayloads['addOutputFiles'];
+        this.eventHandler.handleAddOutputFiles(payload);
+        this.onSessionProgressEvent?.('addOutputFiles', payload);
+      },
+      { scope: 'run', types: ['domain'] },
+    );
     return {
       dispose: () => {
+        detachOutputFileRunFacts();
         detachRunFacts();
         detachSessionFacts();
         eventHandlerSubscription.dispose();

--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -226,15 +226,7 @@ export class ProgressEventHandler {
       addOutputFiles: {
         module: 'ProgressEvents',
         context: 'failed to handle addOutputFiles',
-        handle: ({ streamId, filesByRound }) => {
-          this.state.snapshots.addOutputFiles(streamId, filesByRound);
-          this.sendIfActive(streamId, () => {
-            const rounds = this.state.snapshots.getOutputFiles(streamId);
-            this.webviewUpdater.updateFiles(streamId, {
-              rounds: rounds.size ? mapToRecord(rounds) : undefined,
-            });
-          });
-        },
+        handle: (payload) => this.handleAddOutputFiles(payload),
       },
       updateMissingOutputs: {
         module: 'ProgressEvents',
@@ -479,6 +471,19 @@ export class ProgressEventHandler {
     withEventErrorHandling(registration.module, registration.context, () =>
       registration.handle(payload),
     );
+  }
+
+  handleAddOutputFiles({
+    streamId,
+    filesByRound,
+  }: ProgressEventPayloads['addOutputFiles']): void {
+    this.state.snapshots.addOutputFiles(streamId, filesByRound);
+    this.sendIfActive(streamId, () => {
+      const rounds = this.state.snapshots.getOutputFiles(streamId);
+      this.webviewUpdater.updateFiles(streamId, {
+        rounds: rounds.size ? mapToRecord(rounds) : undefined,
+      });
+    });
   }
 
   /** Send to webview only if streamId is the active stream. */

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -607,6 +607,44 @@ describe('DesktopProgressBridge', () => {
     }
   });
 
+  it('leaves output-file host events to the session run-fact path', async () => {
+    const messages: unknown[] = [];
+    const bridge = await createBridge(messages);
+    const streamId = 'desktop:output-files' as StreamTabId;
+    const initialFileUpdates = progressMessages(
+      messages,
+      PROGRESS_VIEW_COMMANDS.UPDATE_FILES,
+    ).length;
+
+    try {
+      bridge.handleProgressEvent('addOutputFiles', {
+        streamId,
+        filesByRound: {
+          1: [
+            {
+              source: 'paper.tex',
+              location: {
+                kind: 'workspace',
+                absolutePath: '/workspace/paper.tex',
+                relativePath: 'paper.tex',
+              },
+              round: 1,
+              lineage: null,
+              diff: null,
+            },
+          ],
+        },
+      });
+      await settleProgressEvents();
+
+      expect(
+        progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_FILES),
+      ).toHaveLength(initialFileUpdates);
+    } finally {
+      bridge.dispose();
+    }
+  });
+
   it('keeps desktop runtime host app events on the window-local bridge path', async () => {
     const messages: unknown[] = [];
     const showErrorMessage = vi.fn();

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -10,6 +10,7 @@ import { streamDataDir, StreamSnapshotStore } from '@transcript';
 // Local imports - agent
 import { getExecutionStore } from '@agent/storage';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
+import { toRunFactDomainKey } from '@agent/runtime/runFactEvents';
 import type { TaskState } from '@agent/core/state/TaskState';
 import {
   type ProgressEvent,
@@ -29,6 +30,8 @@ import {
   STREAM_LOG_ENTRY_TYPES,
   STREAM_PHASE,
   type ExecutionId,
+  type FileLocation,
+  type OutputFileInfo,
   type ProgressViewOutboundMessage,
   type StreamTabId,
 } from '@shared/schemas';
@@ -472,6 +475,66 @@ describe('ProgressBackend', () => {
 
     expect(applier).not.toHaveBeenCalled();
     expect(backend.state.activeStream).not.toBe(streamId);
+  });
+
+  it('applies session output-file run facts directly without duplicate legacy delivery', async () => {
+    const { backend, session } = createIsolatedRecordingBackend();
+    const subscription = backend.setupEventListeners();
+    const handleProgressEvent = vi.spyOn(
+      backend.eventHandler,
+      'handleProgressEvent',
+    );
+    const updateFiles = vi.spyOn(backend.webviewUpdater, 'updateFiles');
+    const streamId = 'session:output-files' as StreamTabId;
+    const location: FileLocation = {
+      kind: 'workspace',
+      absolutePath: '/workspace/paper.tex',
+      relativePath: 'paper.tex',
+    };
+    const outputFile: OutputFileInfo = {
+      source: 'paper.tex',
+      location,
+      round: 1,
+      lineage: null,
+      diff: null,
+    };
+
+    try {
+      await backend.state.snapshots.load([]);
+      backend.handleProgressEvent('setActiveStream', {
+        streamId,
+        agentCategory: AgentCategory.Workflow,
+      });
+      handleProgressEvent.mockClear();
+      updateFiles.mockClear();
+
+      session.events.emit({
+        scope: 'run',
+        streamId,
+        event: {
+          type: 'domain',
+          key: toRunFactDomainKey('addOutputFiles'),
+          data: {
+            streamId,
+            filesByRound: { 1: [outputFile] },
+          } satisfies ProgressEventPayloads['addOutputFiles'],
+        },
+      });
+
+      expect(handleProgressEvent).not.toHaveBeenCalled();
+      expect(updateFiles).toHaveBeenCalledTimes(1);
+      expect(updateFiles).toHaveBeenCalledWith(streamId, {
+        rounds: { 1: [outputFile] },
+      });
+      expect(backend.state.snapshots.getOutputFiles(streamId)).toEqual(
+        new Map([[1, [outputFile]]]),
+      );
+    } finally {
+      subscription.dispose();
+      await backend.state.clearAll();
+      backend.dispose();
+      session.dispose();
+    }
   });
 
   it('notifies host observers for session-originated progress events', async () => {

--- a/src/test-kernel/progressView/ProgressBackendProcessBus.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendProcessBus.vitest.ts
@@ -6,7 +6,11 @@ import type {
   ProgressEventPayloads,
 } from '@eventBus/ProgressEventBus';
 import { attachProgressBackendProcessBus } from '@progressView/progressBackendProcessBus';
-import { AgentCategory, type StreamTabId } from '@shared/schemas';
+import {
+  AgentCategory,
+  type OutputFileInfo,
+  type StreamTabId,
+} from '@shared/schemas';
 import {
   ProgressBackend,
   type ProgressBackendUiConfig,
@@ -124,6 +128,46 @@ describe('attachProgressBackendProcessBus', () => {
         agentCategory: AgentCategory.Workflow,
       });
       expect(backend.state.activeStream).toBe(first);
+    } finally {
+      busSubscription.dispose();
+      backendSubscription.dispose();
+      backend.dispose();
+    }
+  });
+
+  it('leaves addOutputFiles to the session run-fact path', () => {
+    const backend = new ProgressBackend({
+      storage: new MemoryMementoStorage(),
+      sendMessage: () => true,
+      hasTarget: () => true,
+      configureUi: () => createUiConfig(),
+    });
+    const processBus = new MemoryProgressBus();
+    const backendSubscription = backend.setupEventListeners();
+    const busSubscription = attachProgressBackendProcessBus(
+      backend,
+      processBus,
+    );
+    const streamId = 'extension:output-files' as StreamTabId;
+    const outputFile: OutputFileInfo = {
+      source: 'paper.tex',
+      location: {
+        kind: 'workspace',
+        absolutePath: '/workspace/paper.tex',
+        relativePath: 'paper.tex',
+      },
+      round: 1,
+      lineage: null,
+      diff: null,
+    };
+
+    try {
+      processBus.emit('addOutputFiles', {
+        streamId,
+        filesByRound: { 1: [outputFile] },
+      });
+
+      expect(backend.state.snapshots.getOutputFiles(streamId).size).toBe(0);
     } finally {
       busSubscription.dispose();
       backendSubscription.dispose();


### PR DESCRIPTION
## Summary

Part of #6968 and #6951.

This PR moves the progress backend's `addOutputFiles` state/UI projection to the session fact rail:

- `ProgressBackend.setupEventListeners()` now subscribes directly to session `runFact.addOutputFiles` domain facts.
- `ProgressEventHandler.handleAddOutputFiles(...)` owns the reused effect: update `StreamSnapshotStore`, then send `UPDATE_FILES` when the stream is active.
- The extension process-bus boundary ignores legacy `addOutputFiles` because the backend now receives that fact from the session.
- The desktop host-progress boundary ignores projected `addOutputFiles` for the same reason; desktop still receives one renderer update through the backend's session observer.

## Non-goals

This PR does not delete `SessionRunFactProjector` and does not suppress its global `addOutputFiles` projection. That is intentional: CLI NDJSON/public output still depends on the projected host event today.

This also does not change CLI/TUI rendering or `LegacyProgressEventProjection`. Those remain later Stage 5 gates.

## Validation

- `corepack pnpm exec prettier --write ...` on touched files
- `git diff --check`
- touched-file ESLint
- focused Vitest:
  - `src/test-kernel/progressView/ProgressBackend.vitest.ts`
  - `src/test-kernel/progressView/ProgressBackendProcessBus.vitest.ts`
  - `src/test-kernel/progressView/SessionRunFactProjectorEquivalence.vitest.ts`
  - `src/test-kernel/agent/runtime/SessionEventHub.vitest.ts`
  - `src/test-kernel/agent/output/OutputProgressEvents.vitest.ts`
  - `src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `corepack pnpm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how progress UI receives output-file updates across desktop and extension; incorrect fact subscription or boundary filtering could drop updates or still double-apply, though new tests target those paths.
> 
> **Overview**
> **`addOutputFiles` is wired through the session fact rail** so snapshots and `UPDATE_FILES` updates happen once from run domain facts, not from the legacy progress-event path.
> 
> `ProgressBackend.setupEventListeners()` subscribes to run-scoped `domain` facts keyed as `addOutputFiles`, validates payload shape, and calls `ProgressEventHandler.handleAddOutputFiles()` (extracted from the old inline registration). Host observers still get `onSessionProgressEvent('addOutputFiles', …)` for side effects such as the desktop progress bridge.
> 
> **Duplicate delivery is blocked at host boundaries:** the VS Code extension’s `attachProgressBackendProcessBus` adapter no-ops `on('addOutputFiles')`, and desktop `handleProgressEvent` returns early for `addOutputFiles` so projected host events do not re-enter the backend. Legacy global projection of `addOutputFiles` is intentionally left in place for CLI/NDJSON consumers.
> 
> Tests assert session facts update files without invoking `handleProgressEvent`, process-bus emits do not mutate snapshots, and desktop host `addOutputFiles` does not emit extra `UPDATE_FILES`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bb830417f91bc9b33b8a32185308465697492ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->