### PR TITLE
fix(progress-view): guard desktop progress-event bridge after dispose (Closes #7377)

### DIFF
--- a/packages/desktop/src/main/desktopProgressEventBridge.ts
+++ b/packages/desktop/src/main/desktopProgressEventBridge.ts
@@ -124,6 +124,9 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
   /** Streams that became live in this bridge and must not be restored as ghosts. */
   private readonly liveStreams = new Set<StreamTabId>();
 
+  /** True once `dispose()` has torn down this bridge. */
+  private disposed = false;
+
   private readonly unsubscribe: () => void;
 
   constructor(private readonly opts: DesktopProgressEventBridgeOptions) {
@@ -208,6 +211,14 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
     event: K,
     payload: ProgressEventPayloads[K],
   ): void {
+    // A headless run may still hold the owning bridge's `hostChannel.emit`
+    // closure that routes here after the desktop window closed and this bridge
+    // was disposed. Applying events post-dispose would repopulate the ghost /
+    // live stream maps that `dispose()` just cleared, re-persist snapshots, and
+    // route/show-error into a closed renderer. Mirror the ProgressBackend guard
+    // from #7372 (its sibling caller reached from the same fan-out point) so
+    // this second route also no-ops once disposed.
+    if (this.disposed) return;
     switch (event) {
       case 'setActiveStream': {
         const data = payload as ProgressEventPayloads['setActiveStream'];
@@ -384,6 +395,7 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
   // ── Dispose ──────────────────────────────────────────────────────────────
 
   dispose(): void {
+    this.disposed = true;
     this.unsubscribe();
     this.restoredStreams.clear();
     this.restoredDisplaySent.clear();

--- a/src/test-kernel/desktop/desktopProgressEventBridge.vitest.ts
+++ b/src/test-kernel/desktop/desktopProgressEventBridge.vitest.ts
@@ -1,0 +1,65 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'vitest';
+
+import type { AgentTrace } from '@agent/trace';
+import type { ProgressViewState } from '@shared/progressView/backend/state/ProgressViewState';
+import {
+  createDesktopProgressEventBridge,
+  type DesktopProgressEventBridgeOptions,
+} from '@desktop/main/desktopProgressEventBridge';
+
+/**
+ * Regression test for #7377: a headless run can keep the owning bridge's
+ * `hostChannel.emit` closure after the desktop window closed and the bridge was
+ * disposed. Events delivered through that second route (the one #7372 left
+ * unguarded) must no-op — they must not re-route the renderer, re-show root
+ * errors, or otherwise touch torn-down state.
+ */
+function makeBridge() {
+  const calls = { showError: [] as string[], routeToProgress: 0 };
+  const options: DesktopProgressEventBridgeOptions = {
+    // Only the requestShowError / requestEnsureProgressView paths are exercised;
+    // neither dereferences `state`, and with no snapshot store constructor-time
+    // hydration is a no-op, so a cast placeholder is sufficient here.
+    state: {} as ProgressViewState,
+    streamStatus: { get: () => undefined, transition: () => undefined },
+    streamSnapshotStore: undefined,
+    sendMessage: () => undefined,
+    logger: { warn: () => undefined } as unknown as AgentTrace,
+    getActiveStream: () => '',
+    routeToProgress: () => {
+      calls.routeToProgress += 1;
+    },
+    onGoalStateChanged: () => undefined,
+    onShowError: (message) => {
+      calls.showError.push(message);
+    },
+  };
+  return { bridge: createDesktopProgressEventBridge(options), calls };
+}
+
+describe('DesktopProgressEventBridge dispose guard (#7377)', () => {
+  it('routes events before dispose', () => {
+    const { bridge, calls } = makeBridge();
+
+    bridge.onProgressEvent('requestShowError', { message: 'boom' });
+    bridge.onProgressEvent('requestEnsureProgressView', {});
+
+    assert.deepEqual(calls.showError, ['boom']);
+    assert.equal(calls.routeToProgress, 1);
+  });
+
+  it('no-ops progress events delivered after dispose', () => {
+    const { bridge, calls } = makeBridge();
+
+    bridge.dispose();
+
+    assert.doesNotThrow(() => {
+      bridge.onProgressEvent('requestShowError', { message: 'after-dispose' });
+      bridge.onProgressEvent('requestEnsureProgressView', {});
+    });
+
+    assert.deepEqual(calls.showError, []);
+    assert.equal(calls.routeToProgress, 0);
+  });
+});

--- a/src/test-kernel/desktop/desktopProgressEventBridge.vitest.ts
+++ b/src/test-kernel/desktop/desktopProgressEventBridge.vitest.ts
@@ -22,7 +22,7 @@ function makeBridge() {
     // neither dereferences `state`, and with no snapshot store constructor-time
     // hydration is a no-op, so a cast placeholder is sufficient here.
     state: {} as ProgressViewState,
-    streamStatus: { get: () => undefined, transition: () => undefined },
+    streamStatus: { get: () => undefined, transition: () => false },
     streamSnapshotStore: undefined,
     sendMessage: () => undefined,
     logger: { warn: () => undefined } as unknown as AgentTrace,


### PR DESCRIPTION
## Root cause

Follow-up to #7372, which added a `disposed` guard to `ProgressBackend.handleProgressEvent`. That PR's "one guard covers every route" framing overstated the fix: `DesktopProgressBridge.handleProgressEvent` (`packages/desktop/src/main/desktopAgentExecution.ts:1011-1017`) fans out to **two** callers —

```ts
this.backend.handleProgressEvent(event, payload); // guarded by #7372
this.progressEvents.onProgressEvent(event, payload); // NOT guarded
```

`DesktopProgressEventBridgeImpl` (`packages/desktop/src/main/desktopProgressEventBridge.ts`) had no disposed-state guard of its own. A headless run that still holds the owning bridge's `hostChannel.emit` closure after the desktop window closes (`session.dispose({ keepActiveExecutions: true })`) can therefore still reach `onProgressEvent` post-dispose — re-populating the ghost/live stream maps that `dispose()` just cleared, re-persisting snapshots, and routing / showing root errors into a closed renderer. Flagged by `chatgpt-codex-connector[bot]` and `claude[bot]` during review of #7372 (https://github.com/LionSR/TeXRA/pull/7372#discussion_r3533059897) and left unaddressed at merge.

## Fix

Add a self-owned `disposed` flag to `DesktopProgressEventBridgeImpl`: set it at the top of `dispose()` and early-return at the top of `onProgressEvent`, mirroring the minimal #7372 pattern in `ProgressBackend`.

Placing the guard at the bridge entry point (rather than at each downstream side effect) makes it a single SSOT check that covers **both** routes reaching `onProgressEvent`: the direct `hostChannel.emit` path (`desktopAgentExecution.ts:1016`) and the session-fact projection path (`desktopAgentExecution.ts:267`, via `ProgressBackend.onSessionProgressEvent`). The already-guarded `ProgressBackend.ts` is left untouched. No new abstraction (§13) — a private flag + guard + comment.

The constructor's `requestShowError` / `requestEnsureProgressView` bus subscriptions were already safe (torn down by `this.unsubscribe()` in `dispose()`); the leak was solely the direct-call route into `onProgressEvent`.

## Net diff (`git diff --stat origin/main`)

```
 packages/desktop/src/main/desktopProgressEventBridge.ts | 12 ++++
 src/test-kernel/desktop/desktopProgressEventBridge.vitest.ts | 65 +++++++++++++
 2 files changed, 77 insertions(+)
```

## Tests

- Added `src/test-kernel/desktop/desktopProgressEventBridge.vitest.ts` — asserts events route before `dispose()` and that `onProgressEvent` no-ops (no `onShowError`, no `routeToProgress`, no throw) after `dispose()`. **Passes (2/2).**
- `npm run typecheck`: 0 errors in changed files. Pre-existing openrouter/ModelHandler/lean errors on origin/main are unrelated.
- Broader `src/test-kernel/desktop/` + `src/test-kernel/progressView/`: the `progressView`/`ProgressBackend` suites pass. The three `Desktop*.vitest.mts` files fail to **load** on this worktree only, due to missing node_modules packages (`fix-path`, `vscode-jsonrpc/node`) — an environment gap, not a logic failure; all 63 failures trace to those two import errors at module load.

https://claude.ai/code/session_01PkkPA9A5vht7PmB9xxiqU3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow lifecycle guard on an already-disposed code path; behavior unchanged while the bridge is active, with regression tests covering the fix.
> 
> **Overview**
> Follow-up to **#7372**: `ProgressBackend` already no-ops progress events after dispose, but `DesktopProgressEventBridgeImpl.onProgressEvent` did not. Headless runs can still invoke the bridge via a stale `hostChannel.emit` closure after the window closes and `dispose()` clears ghost/live stream state, which could repersist snapshots and call `routeToProgress` / `onShowError` on a torn-down renderer.
> 
> **`DesktopProgressEventBridgeImpl`** now keeps a private `disposed` flag, sets it at the start of `dispose()`, and returns immediately at the top of `onProgressEvent` when disposed—same pattern as the backend guard.
> 
> Adds **`desktopProgressEventBridge.vitest.ts`** regression tests: events still route before dispose; after dispose, `requestShowError` and `requestEnsureProgressView` no-op without touching callbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2c11534056a4363c313dcd86f3cc321da6ae65c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->