### PR TITLE
feat(cli): apply TUI work-plan run facts directly

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -63,7 +63,10 @@ import {
   type TuiSession,
 } from './tui/state/sessionRunState';
 import { createTuiHostInteractions } from './tui/state/subscribeApprovals';
-import { wrapRuntimeHost } from './tui/state/subscribeRuntimeHost';
+import {
+  attachTuiWorkPlanRunFactSubscription,
+  wrapRuntimeHost,
+} from './tui/state/subscribeRuntimeHost';
 import { notify } from './tui/notifications/terminalNotifier';
 import {
   appendLocalErrorTranscript,
@@ -238,6 +241,9 @@ export function createChatSessionController(
       defaultSession(),
       interactiveHost,
     );
+    const detachTuiWorkPlanRunFacts = attachTuiWorkPlanRunFactSubscription(
+      defaultSession().events,
+    );
     const detachLegacyProgressProjection = attachLegacyProgressEventProjection(
       defaultSession().events,
       interactiveHost,
@@ -247,6 +253,7 @@ export function createChatSessionController(
       approvalsUnavailable: approvalPromptsUnavailable(sessionContext),
       finalize: (): void => {
         detachResultToast();
+        detachTuiWorkPlanRunFacts();
         detachLegacyProgressProjection();
         detachHostInteractions();
         if (session.runtimeHost === interactiveHost) {

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -3,11 +3,17 @@
 // not handled here — `subscribeApprovals.ts` owns the typed-modal pipeline.
 
 import { defaultSession } from '@agent/runtime/SessionHandle';
+import { fromRunFactDomainKey } from '@agent/runtime/runFactEvents';
+import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 import type {
   ProgressEvent,
   ProgressEventPayloads,
 } from '@eventBus/ProgressEventBus';
+import {
+  UpdatePlanPayloadSchema,
+  UpdateTodosPayloadSchema,
+} from '@shared/schemas';
 import { diffActiveChildren } from '@shared/streams/childActivityReducer';
 import {
   reduceStreamMeta,
@@ -106,6 +112,45 @@ export function wrapRuntimeHost(
     return original(event, payload);
   };
   return { ...host, emit };
+}
+
+export function attachTuiWorkPlanRunFactSubscription(
+  events: SessionEventHub,
+): () => void {
+  return events.subscribe(
+    (sessionEvent) => {
+      if (sessionEvent.scope !== 'run') return;
+      const { event } = sessionEvent;
+      if (event.type !== 'domain') return;
+      const factName = fromRunFactDomainKey(event.key);
+
+      switch (factName) {
+        case 'updateTodos': {
+          const payload = UpdateTodosPayloadSchema.safeParse(event.data);
+          if (payload.success) {
+            patchStream(payload.data.streamId, (s) => ({
+              ...s,
+              todos: payload.data.todos,
+            }));
+          }
+          return;
+        }
+        case 'updatePlan': {
+          const payload = UpdatePlanPayloadSchema.safeParse(event.data);
+          if (payload.success) {
+            patchStream(payload.data.streamId, (s) => ({
+              ...s,
+              plan: payload.data.plan,
+            }));
+          }
+          return;
+        }
+        default:
+          return;
+      }
+    },
+    { scope: 'run', types: ['domain'] },
+  );
 }
 
 function applyToState<K extends ProgressEvent>(

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -13,6 +13,8 @@ import {
 } from '@transcript';
 import { clearAllStreamStatusesForTest } from '@test/helpers/streamStatusTestUtils';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import { SessionEventHub } from '@agent/runtime/SessionEventHub';
+import { toRunFactDomainKey } from '@agent/runtime/runFactEvents';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import {
   activeStreamId,
@@ -61,7 +63,10 @@ import {
 import { transcriptViewportKey } from '@cli/chat/tui/state/transcriptViewportMode';
 import { projectStreamTranscript } from '@cli/chat/tui/state/transcriptProjection';
 import { subscribeStreamStatus } from '@cli/chat/tui/state/subscribeStreamStatus';
-import { wrapRuntimeHost } from '@cli/chat/tui/state/subscribeRuntimeHost';
+import {
+  attachTuiWorkPlanRunFactSubscription,
+  wrapRuntimeHost,
+} from '@cli/chat/tui/state/subscribeRuntimeHost';
 import {
   COMPLETED_PROCESS_TAIL_LINES,
   buildCompletedProcessTranscript,
@@ -105,6 +110,7 @@ import {
   STREAM_PHASE,
   STREAM_STATUS,
   TODO_STATUS,
+  type Plan,
   type StorageKey,
   type StreamTabId,
   type TodoItem,
@@ -2605,6 +2611,76 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
       close: async () => {},
     } as unknown as CliRuntimeHost;
   }
+
+  it('applies direct runFact.updateTodos events without host emission', () => {
+    const hub = new SessionEventHub();
+    const hostEmit = vi.fn();
+    const wrapped = wrapRuntimeHost({
+      emit: hostEmit,
+      close: async () => {},
+    } as unknown as CliRuntimeHost);
+    const wrappedEmit = vi.spyOn(wrapped, 'emit');
+    const detach = attachTuiWorkPlanRunFactSubscription(hub);
+    const todos: TodoItem[] = [
+      {
+        content: 'State the compactness lemma',
+        status: TODO_STATUS.PENDING,
+        activeForm: 'Stating the compactness lemma',
+      },
+    ];
+
+    try {
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'domain',
+          key: toRunFactDomainKey('updateTodos'),
+          data: { streamId: root, todos },
+        },
+      });
+
+      expect(streams.get().get(root)?.todos).toEqual(todos);
+      expect(wrappedEmit).not.toHaveBeenCalled();
+      expect(hostEmit).not.toHaveBeenCalled();
+    } finally {
+      detach();
+      wrappedEmit.mockRestore();
+    }
+  });
+
+  it('applies direct runFact.updatePlan events without host emission', () => {
+    const hub = new SessionEventHub();
+    const hostEmit = vi.fn();
+    const wrapped = wrapRuntimeHost({
+      emit: hostEmit,
+      close: async () => {},
+    } as unknown as CliRuntimeHost);
+    const wrappedEmit = vi.spyOn(wrapped, 'emit');
+    const detach = attachTuiWorkPlanRunFactSubscription(hub);
+    const plan: Plan = {
+      objective: 'Prove the local estimate and record the stopping criterion.',
+    };
+
+    try {
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'domain',
+          key: toRunFactDomainKey('updatePlan'),
+          data: { streamId: root, plan },
+        },
+      });
+
+      expect(streams.get().get(root)?.plan).toEqual(plan);
+      expect(wrappedEmit).not.toHaveBeenCalled();
+      expect(hostEmit).not.toHaveBeenCalled();
+    } finally {
+      detach();
+      wrappedEmit.mockRestore();
+    }
+  });
 
   it('bridges only transitional metadata events to the snapshot store', () => {
     const snapshotStore = {


### PR DESCRIPTION
## Summary

This PR moves the chat TUI's live work-plan rendering for two replacement facts, `updateTodos` and `updatePlan`, onto the session event plane.

The legacy host-event cases remain in place. This is intentional: public CLI output and non-migrated consumers still depend on projected progress events, and these two facts are idempotent replacements, so duplicate direct-plus-legacy delivery does not accumulate state.

## Scope

- add a TUI session subscription for `runFact.updateTodos` and `runFact.updatePlan`;
- wire that subscription into `setupRunHost` next to the existing legacy projection;
- add tests proving direct session facts update TUI state without host emission.

## Non-goals

- no changes to `SessionRunFactProjector` or `LegacyProgressEventProjection`;
- no changes to public CLI NDJSON output;
- no migration of `goalPaused`, `updateStreamUsage`, or process events, since those append or accumulate and need separate duplication guards.

Part of #6968 and #6951.

## Validation

- `corepack pnpm exec prettier --check packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts packages/cli/src/chat/chatSessionController.ts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm exec eslint packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts packages/cli/src/chat/chatSessionController.ts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CLI state-sync change with schema validation; legacy progress paths remain, and duplicate idempotent updates should not corrupt todos/plan.
> 
> **Overview**
> The chat TUI now listens on **`SessionEventHub`** for run-scoped **`updateTodos`** and **`updatePlan`** domain facts and patches stream slices directly, instead of relying only on wrapped runtime host progress emissions for live plan/todo panels.
> 
> **`attachTuiWorkPlanRunFactSubscription`** validates payloads with **`UpdateTodosPayloadSchema`** / **`UpdatePlanPayloadSchema`** and updates **`todos`** / **`plan`** on the matching stream. **`setupRunHost`** registers this subscription next to the existing legacy progress projection and disposes it in **`finalize`**.
> 
> Legacy **`wrapRuntimeHost`** handlers for the same progress events are unchanged so other consumers can still use projected host events; duplicate delivery is acceptable because these facts replace state idempotently. New tests assert hub events update CLI state without calling host **`emit`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ac7ce2ec5ba52460e290cf6ea2dc0137bf79294. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->