### PR TITLE
fix(progress): guard output-file session facts after dispose

### DIFF
--- a/src/shared/progressView/backend/ProgressBackend.ts
+++ b/src/shared/progressView/backend/ProgressBackend.ts
@@ -171,7 +171,7 @@ export class ProgressBackend {
 
         const payload =
           event.data as unknown as ProgressEventPayloads['addOutputFiles'];
-        this.eventHandler.handleAddOutputFiles(payload);
+        this.handleProgressEvent('addOutputFiles', payload);
         this.onSessionProgressEvent?.('addOutputFiles', payload);
       },
       { scope: 'run', types: ['domain'] },

--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -473,7 +473,7 @@ export class ProgressEventHandler {
     );
   }
 
-  handleAddOutputFiles({
+  private handleAddOutputFiles({
     streamId,
     filesByRound,
   }: ProgressEventPayloads['addOutputFiles']): void {

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -477,7 +477,7 @@ describe('ProgressBackend', () => {
     expect(backend.state.activeStream).not.toBe(streamId);
   });
 
-  it('applies session output-file run facts directly without duplicate legacy delivery', async () => {
+  it('applies session output-file run facts through the guarded applier', async () => {
     const { backend, session } = createIsolatedRecordingBackend();
     const subscription = backend.setupEventListeners();
     const handleProgressEvent = vi.spyOn(
@@ -521,13 +521,75 @@ describe('ProgressBackend', () => {
         },
       });
 
-      expect(handleProgressEvent).not.toHaveBeenCalled();
+      expect(handleProgressEvent).toHaveBeenCalledTimes(1);
+      expect(handleProgressEvent).toHaveBeenCalledWith('addOutputFiles', {
+        streamId,
+        filesByRound: { 1: [outputFile] },
+      });
       expect(updateFiles).toHaveBeenCalledTimes(1);
       expect(updateFiles).toHaveBeenCalledWith(streamId, {
         rounds: { 1: [outputFile] },
       });
       expect(backend.state.snapshots.getOutputFiles(streamId)).toEqual(
         new Map([[1, [outputFile]]]),
+      );
+    } finally {
+      subscription.dispose();
+      await backend.state.clearAll();
+      backend.dispose();
+      session.dispose();
+    }
+  });
+
+  it('no-ops session output-file run facts after dispose', async () => {
+    const { backend, session } = createIsolatedRecordingBackend();
+    const subscription = backend.setupEventListeners();
+    const handleProgressEvent = vi.spyOn(
+      backend.eventHandler,
+      'handleProgressEvent',
+    );
+    const updateFiles = vi.spyOn(backend.webviewUpdater, 'updateFiles');
+    const streamId = 'session:output-files-after-dispose' as StreamTabId;
+    const location: FileLocation = {
+      kind: 'workspace',
+      absolutePath: '/workspace/paper.tex',
+      relativePath: 'paper.tex',
+    };
+    const outputFile: OutputFileInfo = {
+      source: 'paper.tex',
+      location,
+      round: 1,
+      lineage: null,
+      diff: null,
+    };
+
+    try {
+      await backend.state.snapshots.load([]);
+      backend.handleProgressEvent('setActiveStream', {
+        streamId,
+        agentCategory: AgentCategory.Workflow,
+      });
+      handleProgressEvent.mockClear();
+      updateFiles.mockClear();
+      backend.dispose();
+
+      session.events.emit({
+        scope: 'run',
+        streamId,
+        event: {
+          type: 'domain',
+          key: toRunFactDomainKey('addOutputFiles'),
+          data: {
+            streamId,
+            filesByRound: { 1: [outputFile] },
+          } satisfies ProgressEventPayloads['addOutputFiles'],
+        },
+      });
+
+      expect(handleProgressEvent).not.toHaveBeenCalled();
+      expect(updateFiles).not.toHaveBeenCalled();
+      expect(backend.state.snapshots.getOutputFiles(streamId)).toEqual(
+        new Map(),
       );
     } finally {
       subscription.dispose();


### PR DESCRIPTION
## Summary

Fixes #7381.

The direct `runFact.addOutputFiles` subscriber now routes through `ProgressBackend.handleProgressEvent('addOutputFiles', payload)` instead of calling the event handler directly. This restores the disposed-backend guard added in #7363 and the scoped `withEventErrorHandling` wrapper for the `addOutputFiles` handler.

## Details

- routes direct output-file session facts through the guarded progress-event applier;
- folds `ProgressEventHandler.handleAddOutputFiles` back to a private helper;
- adds a regression test that emits `runFact.addOutputFiles` after `backend.dispose()` and verifies that snapshots and `updateFiles` are not mutated.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec prettier --check src/shared/progressView/backend/ProgressBackend.ts src/shared/progressView/backend/events/ProgressEventHandler.ts src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `corepack pnpm exec eslint src/shared/progressView/backend/ProgressBackend.ts src/shared/progressView/backend/events/ProgressEventHandler.ts src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `corepack pnpm exec tsc --noEmit --pretty false`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow routing fix in progress event handling with regression tests; no auth, security, or data-model changes beyond avoiding post-dispose UI/state updates.
> 
> **Overview**
> Fixes a regression where **session `addOutputFiles` run facts** bypassed `ProgressBackend.handleProgressEvent` and could still update snapshots and the webview after the backend was disposed (e.g. window closed while a run continues).
> 
> The output-file subscriber now calls **`handleProgressEvent('addOutputFiles', payload)`** so the same **disposed-backend no-op** and **`withEventErrorHandling`** path as other progress events apply. **`ProgressEventHandler.handleAddOutputFiles`** is private again (only used via the event registration map).
> 
> Tests now assert session output-file facts go through the guarded applier, plus a new case that emits **`addOutputFiles` after `dispose()`** and expects no handler, **`updateFiles`**, or snapshot mutation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39ef623968e9060878db4fc8f3a9aa153b70bb71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->