### PR TITLE
fix(progress-view): route addOutputFiles session facts through the disposed guard

### DIFF
--- a/src/shared/progressView/backend/ProgressBackend.ts
+++ b/src/shared/progressView/backend/ProgressBackend.ts
@@ -171,7 +171,7 @@ export class ProgressBackend {
 
         const payload =
           event.data as unknown as ProgressEventPayloads['addOutputFiles'];
-        this.eventHandler.handleAddOutputFiles(payload);
+        this.handleProgressEvent('addOutputFiles', payload);
         this.onSessionProgressEvent?.('addOutputFiles', payload);
       },
       { scope: 'run', types: ['domain'] },

--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -473,7 +473,7 @@ export class ProgressEventHandler {
     );
   }
 
-  handleAddOutputFiles({
+  private handleAddOutputFiles({
     streamId,
     filesByRound,
   }: ProgressEventPayloads['addOutputFiles']): void {

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -477,7 +477,7 @@ describe('ProgressBackend', () => {
     expect(backend.state.activeStream).not.toBe(streamId);
   });
 
-  it('applies session output-file run facts directly without duplicate legacy delivery', async () => {
+  it('routes session output-file run facts through the guarded handler exactly once', async () => {
     const { backend, session } = createIsolatedRecordingBackend();
     const subscription = backend.setupEventListeners();
     const handleProgressEvent = vi.spyOn(
@@ -521,7 +521,14 @@ describe('ProgressBackend', () => {
         },
       });
 
-      expect(handleProgressEvent).not.toHaveBeenCalled();
+      // Goes through handleProgressEvent (restoring the disposed guard and
+      // withEventErrorHandling wrapper — see issue #7381) exactly once, not
+      // the direct eventHandler.handleAddOutputFiles bypass.
+      expect(handleProgressEvent).toHaveBeenCalledTimes(1);
+      expect(handleProgressEvent).toHaveBeenCalledWith('addOutputFiles', {
+        streamId,
+        filesByRound: { 1: [outputFile] },
+      });
       expect(updateFiles).toHaveBeenCalledTimes(1);
       expect(updateFiles).toHaveBeenCalledWith(streamId, {
         rounds: { 1: [outputFile] },
@@ -533,6 +540,60 @@ describe('ProgressBackend', () => {
       subscription.dispose();
       await backend.state.clearAll();
       backend.dispose();
+      session.dispose();
+    }
+  });
+
+  it('drops output-file run facts delivered after dispose without mutating state', async () => {
+    const { backend, session } = createIsolatedRecordingBackend();
+    const subscription = backend.setupEventListeners();
+    const updateFiles = vi.spyOn(backend.webviewUpdater, 'updateFiles');
+    const streamId = 'session:output-files-post-dispose' as StreamTabId;
+    const location: FileLocation = {
+      kind: 'workspace',
+      absolutePath: '/workspace/paper.tex',
+      relativePath: 'paper.tex',
+    };
+    const outputFile: OutputFileInfo = {
+      source: 'paper.tex',
+      location,
+      round: 1,
+      lineage: null,
+      diff: null,
+    };
+
+    try {
+      await backend.state.snapshots.load([]);
+      backend.handleProgressEvent('setActiveStream', {
+        streamId,
+        agentCategory: AgentCategory.Workflow,
+      });
+
+      // A run may still hold the session-event delivery path after
+      // backend.dispose() (e.g. a desktop window closed while the run keeps
+      // executing headless). The disposed backend must not mutate its
+      // torn-down snapshot store or push a stale webview update.
+      backend.dispose();
+
+      expect(() =>
+        session.events.emit({
+          scope: 'run',
+          streamId,
+          event: {
+            type: 'domain',
+            key: toRunFactDomainKey('addOutputFiles'),
+            data: {
+              streamId,
+              filesByRound: { 1: [outputFile] },
+            } satisfies ProgressEventPayloads['addOutputFiles'],
+          },
+        }),
+      ).not.toThrow();
+
+      expect(updateFiles).not.toHaveBeenCalled();
+      expect(backend.state.snapshots.getOutputFiles(streamId).size).toBe(0);
+    } finally {
+      subscription.dispose();
       session.dispose();
     }
   });


### PR DESCRIPTION
## Root cause

#7378 added a direct session-fact subscriber for `addOutputFiles` in
`ProgressBackend.setupEventListeners()` (`detachOutputFileRunFacts`) that
called `this.eventHandler.handleAddOutputFiles(payload)` directly instead of
routing through `this.handleProgressEvent('addOutputFiles', payload)`.

`handleProgressEvent()` no-ops once `this.disposed` is true — a guard added in
#7363 specifically because a run may still hold a delivery path that reaches
the backend after it's disposed (e.g. a desktop window closed while its run
keeps executing headless). The new subscriber bypassed that guard entirely,
so a run-fact delivered after `backend.dispose()` still mutated the
(torn-down) snapshot store and called `webviewUpdater.updateFiles`. The same
direct call also skipped the `withEventErrorHandling` wrapper every other
registered handler gets, so failures inside `handleAddOutputFiles` would
surface as a generic `SessionEventHub` warning instead of the scoped
`'failed to handle addOutputFiles'` log entry.

Flagged by Cursor Bugbot (Medium Severity) and independently reiterated
across three automated review passes on #7378's commit; none were addressed
before merge.

## Fix

- `ProgressBackend.setupEventListeners()`: the `addOutputFiles` session-fact
  subscriber now calls `this.handleProgressEvent('addOutputFiles', payload)`
  instead of `this.eventHandler.handleAddOutputFiles(payload)` directly. This
  restores both the `disposed` guard and the `withEventErrorHandling` wrapper
  in one change — no new abstraction, just routing through the existing
  guarded entry point every other handler already uses.
- `ProgressEventHandler.handleAddOutputFiles` is folded back to `private`:
  with the direct external call removed, its only remaining caller is the
  class's own event-registration table (`createEventRegistrations()`), so the
  public surface it briefly needed is gone.

## Tests

- Updated `applies session output-file run facts directly without duplicate
  legacy delivery` (renamed to `routes session output-file run facts through
  the guarded handler exactly once`) to assert the call now flows through
  `eventHandler.handleProgressEvent` exactly once, instead of asserting it was
  never called (which was actually the bug).
- Added `drops output-file run facts delivered after dispose without mutating
  state`: emits an `addOutputFiles` session run-fact after `backend.dispose()`
  and asserts no snapshot mutation and no `webviewUpdater.updateFiles` call
  occurs — mirroring the existing disposed-guard coverage added in #7372 for
  the legacy direct-applier path.

## Verification

- `npx tsc --noEmit` — clean (only pre-existing, unrelated `@openrouter/sdk`
  / `vscode-jsonrpc` module-resolution errors present identically on
  `origin/main`; none in the touched files).
- `npx eslint src/shared/progressView/backend/ProgressBackend.ts src/shared/progressView/backend/events/ProgressEventHandler.ts src/test-kernel/progressView/ProgressBackend.vitest.ts` — clean.
- `npx prettier --check <changed files>` — all matched files already use
  Prettier style.
- `npx vitest run src/test-kernel/progressView/ProgressBackend.vitest.ts` —
  24 passed (24), including the 2 new/updated tests.
- `npx vitest run src/test-kernel/progressView/` — 32 files / 157 tests
  passed.

Fixes #7381.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small routing fix in progress-view event handling with focused regression tests; no auth, data, or API surface changes beyond restoring existing guards.
> 
> **Overview**
> Session **addOutputFiles** run facts no longer call `ProgressEventHandler.handleAddOutputFiles` directly from `ProgressBackend.setupEventListeners()`. They go through **`ProgressBackend.handleProgressEvent('addOutputFiles', …)`** like other progress events, so the **`disposed` no-op** and **`withEventErrorHandling`** wrapper apply again after a window/backend teardown while a run keeps emitting.
> 
> `handleAddOutputFiles` is **`private`** again because nothing outside the event registration table needs it.
> 
> Tests now expect a single guarded `handleProgressEvent` call for output-file facts, and add coverage that facts emitted **after `dispose()`** do not touch snapshots or call **`updateFiles`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7e8283ef94dba138314df50589ff3f3f50c1256. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->