### PR TITLE
fix(progress-view): guard addOutputFiles session-fact subscriber after dispose (Closes #7381)

### DIFF
--- a/src/shared/progressView/backend/ProgressBackend.ts
+++ b/src/shared/progressView/backend/ProgressBackend.ts
@@ -171,7 +171,12 @@ export class ProgressBackend {
 
         const payload =
           event.data as unknown as ProgressEventPayloads['addOutputFiles'];
-        this.eventHandler.handleAddOutputFiles(payload);
+        // Route through handleProgressEvent (not eventHandler.handleAddOutputFiles
+        // directly) so this session-fact subscriber honors the `disposed` guard —
+        // a run may still deliver this fact after the backend is torn down (a
+        // desktop window closed mid-run) — and gets the same withEventErrorHandling
+        // wrapper as every other registered handler.
+        this.handleProgressEvent('addOutputFiles', payload);
         this.onSessionProgressEvent?.('addOutputFiles', payload);
       },
       { scope: 'run', types: ['domain'] },

--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -473,7 +473,10 @@ export class ProgressEventHandler {
     );
   }
 
-  handleAddOutputFiles({
+  // Its only caller is the addOutputFiles registration reached via
+  // handleProgressEvent (ProgressBackend now routes the session-fact subscriber
+  // through that guarded path too), so it stays private.
+  private handleAddOutputFiles({
     streamId,
     filesByRound,
   }: ProgressEventPayloads['addOutputFiles']): void {

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -477,7 +477,7 @@ describe('ProgressBackend', () => {
     expect(backend.state.activeStream).not.toBe(streamId);
   });
 
-  it('applies session output-file run facts directly without duplicate legacy delivery', async () => {
+  it('applies session output-file run facts through the guarded handler without duplicate legacy delivery', async () => {
     const { backend, session } = createIsolatedRecordingBackend();
     const subscription = backend.setupEventListeners();
     const handleProgressEvent = vi.spyOn(
@@ -521,7 +521,13 @@ describe('ProgressBackend', () => {
         },
       });
 
-      expect(handleProgressEvent).not.toHaveBeenCalled();
+      // Routed through the guarded backend.handleProgressEvent → eventHandler
+      // path exactly once (not double-delivered via the legacy bus projection).
+      expect(handleProgressEvent).toHaveBeenCalledTimes(1);
+      expect(handleProgressEvent).toHaveBeenCalledWith('addOutputFiles', {
+        streamId,
+        filesByRound: { 1: [outputFile] },
+      });
       expect(updateFiles).toHaveBeenCalledTimes(1);
       expect(updateFiles).toHaveBeenCalledWith(streamId, {
         rounds: { 1: [outputFile] },
@@ -533,6 +539,61 @@ describe('ProgressBackend', () => {
       subscription.dispose();
       await backend.state.clearAll();
       backend.dispose();
+      session.dispose();
+    }
+  });
+
+  it('no-ops the session output-file run fact after dispose', async () => {
+    const { backend, session } = createIsolatedRecordingBackend();
+    const subscription = backend.setupEventListeners();
+    const updateFiles = vi.spyOn(backend.webviewUpdater, 'updateFiles');
+    const streamId = 'session:disposed-output-files' as StreamTabId;
+    const outputFile: OutputFileInfo = {
+      source: 'paper.tex',
+      location: {
+        kind: 'workspace',
+        absolutePath: '/workspace/paper.tex',
+        relativePath: 'paper.tex',
+      },
+      round: 1,
+      lineage: null,
+      diff: null,
+    };
+
+    try {
+      await backend.state.snapshots.load([]);
+      backend.handleProgressEvent('setActiveStream', {
+        streamId,
+        agentCategory: AgentCategory.Workflow,
+      });
+      updateFiles.mockClear();
+
+      // A run that kept executing headless after a desktop window closed can
+      // still deliver an addOutputFiles run fact to the now-disposed backend
+      // through its still-attached session-fact subscriber. It must no-op via
+      // the shared `disposed` guard instead of mutating torn-down state.
+      backend.dispose();
+
+      session.events.emit({
+        scope: 'run',
+        streamId,
+        event: {
+          type: 'domain',
+          key: toRunFactDomainKey('addOutputFiles'),
+          data: {
+            streamId,
+            filesByRound: { 1: [outputFile] },
+          } satisfies ProgressEventPayloads['addOutputFiles'],
+        },
+      });
+
+      expect(updateFiles).not.toHaveBeenCalled();
+      expect(backend.state.snapshots.getOutputFiles(streamId)).toEqual(
+        new Map(),
+      );
+    } finally {
+      subscription.dispose();
+      await backend.state.clearAll();
       session.dispose();
     }
   });


### PR DESCRIPTION
Closes #7381.

## Root cause

#7378 added a direct session-fact subscription (`detachOutputFileRunFacts` in `ProgressBackend.setupEventListeners()`) that called `this.eventHandler.handleAddOutputFiles(payload)` **directly**, bypassing the `if (this.disposed) return;` guard on `ProgressBackend.handleProgressEvent()` (added in #7363, hardened in #7372).

A run can keep executing headless after its desktop window closes; the `setupEventListeners` subscriber stays attached (`dispose()` only flips `this.disposed` and tears down the webview bridge — it does not detach the subscription). So an `addOutputFiles` run fact delivered after `backend.dispose()` still mutated the torn-down snapshot store and called `webviewUpdater.updateFiles` on a closed window. The direct call also skipped the `withEventErrorHandling` wrapper every registered handler gets, so failures surfaced as a generic `SessionEventHub` warning instead of the scoped `'failed to handle addOutputFiles'` log entry.

## Fix

- `src/shared/progressView/backend/ProgressBackend.ts`: the `detachOutputFileRunFacts` subscriber now calls `this.handleProgressEvent('addOutputFiles', payload)` instead of `this.eventHandler.handleAddOutputFiles(payload)`. This restores **both** the `disposed` guard and the `withEventErrorHandling` wrapper in one change. `this.onSessionProgressEvent?.(...)` forwarding is unchanged (it mirrors the existing `handleProjectedProgressEvent` path, and the desktop bridge already guards its own side per #7379).
- `src/shared/progressView/backend/events/ProgressEventHandler.ts`: `handleAddOutputFiles` is now reached only via its registration (`handleProgressEvent` → `withEventErrorHandling`), so it folds back to `private` (issue Details bullet 2).

## Maintainer note — guard centralization (suggestion, not implemented here)

This is the **third** disposed-guard bypass fixed in this class — after #7372 (the `handleProgressEvent` guard itself) and #7379 (the desktop progress-event bridge). Each new direct delivery path has had to re-remember the guard. A follow-up could centralize the `disposed` check at the `eventHandler` boundary (or a single choke point every subscriber must route through) so future direct subscribers can't reintroduce this bug class. Left out of scope here to keep this fix minimal.

## Tests

Extended `src/test-kernel/progressView/ProgressBackend.vitest.ts`:

- Updated *"applies session output-file run facts through the guarded handler without duplicate legacy delivery"* — now asserts the fact routes through `eventHandler.handleProgressEvent('addOutputFiles', …)` exactly once (`updateFiles` still called once, no duplicate legacy delivery).
- New *"no-ops the session output-file run fact after dispose"* — emits an `addOutputFiles` run fact after `backend.dispose()` and asserts no `updateFiles` call and no snapshot mutation, mirroring the existing `handleProgressEvent`-after-dispose coverage.

## Verification

- `npx vitest run src/test-kernel/progressView/ProgressBackend.vitest.ts` → **24 passed** (was 23; +1 new test)
- `npx vitest run src/test-kernel/progressView/ src/test-kernel/frontend/OutputFileRunFactSubscriptions.vitest.ts` → **159 passed (33 files)**
- Root typecheck (`npm run typecheck`) → **0 errors**
- Test-kernel typecheck (`npx tsc --noEmit -p tsconfig.test-kernel.json`) → **0 errors** (0 in changed files)

## Net diff (`git diff --stat origin/main`)

```
 src/shared/progressView/backend/ProgressBackend.ts |  7 ++-
 .../backend/events/ProgressEventHandler.ts         |  5 +-
 .../progressView/ProgressBackend.vitest.ts         | 65 +++++++++++++++++++++-
 3 files changed, 73 insertions(+), 4 deletions(-)
```

Production change is a few lines (mostly comment) and reduces public surface; no new abstraction/port/facade (code-review checklist §13 OK).

https://claude.ai/code/session_01PkkPA9A5vht7PmB9xxiqU3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small routing change in progress-view event handling with targeted tests; no auth, security, or broad API surface changes.
> 
> **Overview**
> Fixes a path where **`addOutputFiles` run facts** from the session-fact subscriber could still update snapshots and the webview after **`ProgressBackend.dispose()`** (e.g. headless run after a desktop window closes).
> 
> The **`detachOutputFileRunFacts`** subscriber now calls **`this.handleProgressEvent('addOutputFiles', payload)`** instead of **`eventHandler.handleAddOutputFiles`**, so delivery respects the existing **`disposed`** guard and **`withEventErrorHandling`** like other progress events. **`handleAddOutputFiles`** on **`ProgressEventHandler`** is **`private`** again.
> 
> Tests assert guarded routing (single **`handleProgressEvent`** call) and a new case that post-dispose facts do not call **`updateFiles`** or mutate snapshots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cee20f486b25757014582183457aff1b34fc7bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->