### PR TITLE
feat(cli): apply TUI usage facts directly

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -64,7 +64,7 @@ import {
 } from './tui/state/sessionRunState';
 import { createTuiHostInteractions } from './tui/state/subscribeApprovals';
 import {
-  attachTuiWorkPlanRunFactSubscription,
+  attachTuiRunFactSubscription,
   wrapRuntimeHost,
 } from './tui/state/subscribeRuntimeHost';
 import { notify } from './tui/notifications/terminalNotifier';
@@ -241,7 +241,7 @@ export function createChatSessionController(
       defaultSession(),
       interactiveHost,
     );
-    const detachTuiWorkPlanRunFacts = attachTuiWorkPlanRunFactSubscription(
+    const detachTuiRunFacts = attachTuiRunFactSubscription(
       defaultSession().events,
     );
     const detachLegacyProgressProjection = attachLegacyProgressEventProjection(
@@ -253,7 +253,7 @@ export function createChatSessionController(
       approvalsUnavailable: approvalPromptsUnavailable(sessionContext),
       finalize: (): void => {
         detachResultToast();
-        detachTuiWorkPlanRunFacts();
+        detachTuiRunFacts();
         detachLegacyProgressProjection();
         detachHostInteractions();
         if (session.runtimeHost === interactiveHost) {

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -11,6 +11,7 @@ import type {
   ProgressEventPayloads,
 } from '@eventBus/ProgressEventBus';
 import {
+  ExtendedTokenUsageStatsSchema,
   UpdatePlanPayloadSchema,
   UpdateTodosPayloadSchema,
 } from '@shared/schemas';
@@ -19,6 +20,7 @@ import {
   reduceStreamMeta,
   type StreamMetaCommand,
 } from '@shared/streams/streamMetaReducer';
+import { isObject } from '@utils/core';
 
 import { activeStreamId } from './cliState/focusSlice';
 import {
@@ -38,6 +40,110 @@ type Emit = <K extends ProgressEvent>(
   event: K,
   payload: ProgressEventPayloads[K],
 ) => void;
+
+type UpdateStreamUsagePayload = ProgressEventPayloads['updateStreamUsage'];
+
+function usageEchoKey(payload: UpdateStreamUsagePayload): string {
+  const parsedUsage = ExtendedTokenUsageStatsSchema.safeParse(payload.usage);
+  const usage = parsedUsage.success ? parsedUsage.data : payload.usage;
+  const extendedUsage = parsedUsage.success ? parsedUsage.data : undefined;
+  return JSON.stringify({
+    streamId: payload.streamId,
+    storageKey: payload.storageKey,
+    executionId: payload.executionId ?? null,
+    usage: {
+      inputTokens: usage.inputTokens,
+      outputTokens: usage.outputTokens,
+      cost: usage.cost,
+      cacheReadInputTokens: usage.cacheReadInputTokens ?? null,
+      cacheMissInputTokens: usage.cacheMissInputTokens ?? null,
+      cacheCreationInputTokens: usage.cacheCreationInputTokens ?? null,
+      elapsedTime: extendedUsage?.elapsedTime ?? null,
+      percentageCached: extendedUsage?.percentageCached ?? null,
+      reasoningTokens: extendedUsage?.reasoningTokens ?? null,
+      toolUseTokens: extendedUsage?.toolUseTokens ?? null,
+      usageRoute: usage.usageRoute ?? null,
+    },
+  });
+}
+
+function consumeUsageEchoCount(
+  counts: Map<string, number>,
+  key: string,
+): boolean {
+  const count = counts.get(key);
+  if (!count) return false;
+  if (count === 1) {
+    counts.delete(key);
+  } else {
+    counts.set(key, count - 1);
+  }
+  return true;
+}
+
+class UsageEchoGuard {
+  private readonly directAppliedCounts = new Map<string, number>();
+  private readonly legacyAppliedCounts = new Map<string, number>();
+
+  applyDirect(payload: UpdateStreamUsagePayload): void {
+    const key = usageEchoKey(payload);
+    if (consumeUsageEchoCount(this.legacyAppliedCounts, key)) return;
+    applyUsageUpdate(payload);
+    this.rememberForThisTurn(this.directAppliedCounts, key);
+  }
+
+  applyLegacy(payload: UpdateStreamUsagePayload): void {
+    const key = usageEchoKey(payload);
+    if (consumeUsageEchoCount(this.directAppliedCounts, key)) return;
+    applyUsageUpdate(payload);
+    this.rememberForThisTurn(this.legacyAppliedCounts, key);
+  }
+
+  clear(): void {
+    this.directAppliedCounts.clear();
+    this.legacyAppliedCounts.clear();
+  }
+
+  private rememberForThisTurn(counts: Map<string, number>, key: string): void {
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+    queueMicrotask(() => {
+      consumeUsageEchoCount(counts, key);
+    });
+  }
+}
+
+let activeUsageEchoGuard: UsageEchoGuard | undefined;
+
+function toUpdateStreamUsagePayload(
+  data: unknown,
+  fallbackStreamId: string,
+): UpdateStreamUsagePayload | undefined {
+  if (!isObject(data)) return undefined;
+  const storageKey = typeof data.storageKey === 'string' ? data.storageKey : '';
+  if (!storageKey) return undefined;
+  const usage = ExtendedTokenUsageStatsSchema.safeParse(data.usage);
+  if (!usage.success) return undefined;
+  const streamId =
+    typeof data.streamId === 'string' ? data.streamId : fallbackStreamId;
+  const executionId =
+    typeof data.executionId === 'string' ? data.executionId : undefined;
+  return {
+    streamId: streamId as UpdateStreamUsagePayload['streamId'],
+    storageKey: storageKey as UpdateStreamUsagePayload['storageKey'],
+    ...(executionId ? { executionId } : {}),
+    usage: usage.data,
+  };
+}
+
+function applyUsageUpdate(payload: UpdateStreamUsagePayload): void {
+  patchStream(payload.streamId, (s) => ({
+    ...s,
+    usage: payload.usage,
+    cumulativeUsage: sumResumeUsageStats(
+      s.cumulativeUsage ? [s.cumulativeUsage, payload.usage] : [payload.usage],
+    ),
+  }));
+}
 
 function sameQueuedFollowUps(
   left: readonly string[],
@@ -114,13 +220,26 @@ export function wrapRuntimeHost(
   return { ...host, emit };
 }
 
-export function attachTuiWorkPlanRunFactSubscription(
+export function attachTuiRunFactSubscription(
   events: SessionEventHub,
 ): () => void {
-  return events.subscribe(
+  const usageEchoGuard = new UsageEchoGuard();
+  activeUsageEchoGuard = usageEchoGuard;
+  const detach = events.subscribe(
     (sessionEvent) => {
       if (sessionEvent.scope !== 'run') return;
       const { event } = sessionEvent;
+      if (event.type === 'usage') {
+        const payload = toUpdateStreamUsagePayload(
+          event.data,
+          sessionEvent.streamId,
+        );
+        if (payload) {
+          usageEchoGuard.applyDirect(payload);
+        }
+        return;
+      }
+
       if (event.type !== 'domain') return;
       const factName = fromRunFactDomainKey(event.key);
 
@@ -149,8 +268,15 @@ export function attachTuiWorkPlanRunFactSubscription(
           return;
       }
     },
-    { scope: 'run', types: ['domain'] },
+    { scope: 'run', types: ['domain', 'usage'] },
   );
+  return () => {
+    detach();
+    usageEchoGuard.clear();
+    if (activeUsageEchoGuard === usageEchoGuard) {
+      activeUsageEchoGuard = undefined;
+    }
+  };
 }
 
 function applyToState<K extends ProgressEvent>(
@@ -206,13 +332,11 @@ function applyToState<K extends ProgressEvent>(
       return;
     case 'updateStreamUsage': {
       const p = payload as ProgressEventPayloads['updateStreamUsage'];
-      patchStream(p.streamId, (s) => ({
-        ...s,
-        usage: p.usage,
-        cumulativeUsage: sumResumeUsageStats(
-          s.cumulativeUsage ? [s.cumulativeUsage, p.usage] : [p.usage],
-        ),
-      }));
+      if (activeUsageEchoGuard) {
+        activeUsageEchoGuard.applyLegacy(p);
+      } else {
+        applyUsageUpdate(p);
+      }
       return;
     }
     case 'updateConversationProgress': {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -14,6 +14,7 @@ import {
 import { clearAllStreamStatusesForTest } from '@test/helpers/streamStatusTestUtils';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
+import { attachSessionRunFactProjector } from '@agent/runtime/SessionRunFactProjector';
 import { toRunFactDomainKey } from '@agent/runtime/runFactEvents';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import {
@@ -64,7 +65,7 @@ import { transcriptViewportKey } from '@cli/chat/tui/state/transcriptViewportMod
 import { projectStreamTranscript } from '@cli/chat/tui/state/transcriptProjection';
 import { subscribeStreamStatus } from '@cli/chat/tui/state/subscribeStreamStatus';
 import {
-  attachTuiWorkPlanRunFactSubscription,
+  attachTuiRunFactSubscription,
   wrapRuntimeHost,
 } from '@cli/chat/tui/state/subscribeRuntimeHost';
 import {
@@ -2620,7 +2621,7 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
       close: async () => {},
     } as unknown as CliRuntimeHost);
     const wrappedEmit = vi.spyOn(wrapped, 'emit');
-    const detach = attachTuiWorkPlanRunFactSubscription(hub);
+    const detach = attachTuiRunFactSubscription(hub);
     const todos: TodoItem[] = [
       {
         content: 'State the compactness lemma',
@@ -2657,7 +2658,7 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
       close: async () => {},
     } as unknown as CliRuntimeHost);
     const wrappedEmit = vi.spyOn(wrapped, 'emit');
-    const detach = attachTuiWorkPlanRunFactSubscription(hub);
+    const detach = attachTuiRunFactSubscription(hub);
     const plan: Plan = {
       objective: 'Prove the local estimate and record the stopping criterion.',
     };
@@ -2679,6 +2680,166 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
     } finally {
       detach();
       wrappedEmit.mockRestore();
+    }
+  });
+
+  it('applies direct usage events without host emission', () => {
+    const hub = new SessionEventHub();
+    const hostEmit = vi.fn();
+    const wrapped = wrapRuntimeHost({
+      emit: hostEmit,
+      close: async () => {},
+    } as unknown as CliRuntimeHost);
+    const wrappedEmit = vi.spyOn(wrapped, 'emit');
+    const detach = attachTuiRunFactSubscription(hub);
+    const storageKey = 'root-direct-run' as StorageKey;
+    const usage = {
+      inputTokens: 100,
+      outputTokens: 20,
+      cost: 1,
+      cacheReadInputTokens: 30,
+      elapsedTime: 1.5,
+      percentageCached: 25,
+      reasoningTokens: 7,
+    };
+
+    try {
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'usage',
+          stats: usage,
+          data: {
+            streamId: root,
+            storageKey,
+            executionId: 'exec-direct',
+            usage,
+          },
+        },
+      });
+
+      expect(streams.get().get(root)?.usage).toEqual(usage);
+      expect(streams.get().get(root)?.cumulativeUsage).toEqual({
+        inputTokens: 100,
+        outputTokens: 20,
+        cost: 1,
+        cacheReadInputTokens: 30,
+        cacheMissInputTokens: 0,
+        cacheCreationInputTokens: 0,
+        reasoningTokens: 7,
+      });
+      expect(wrappedEmit).not.toHaveBeenCalled();
+      expect(hostEmit).not.toHaveBeenCalled();
+    } finally {
+      detach();
+      wrappedEmit.mockRestore();
+    }
+  });
+
+  it('does not double-count projected usage when the TUI subscriber is first', () => {
+    const hub = new SessionEventHub();
+    const hostEmit = vi.fn();
+    const wrapped = wrapRuntimeHost({
+      emit: hostEmit,
+      close: async () => {},
+    } as unknown as CliRuntimeHost);
+    const detachTui = attachTuiRunFactSubscription(hub);
+    const detachProjector = attachSessionRunFactProjector(hub, wrapped, root);
+    const storageKey = 'root-echo-run' as StorageKey;
+    const payload = {
+      streamId: root,
+      storageKey,
+      executionId: 'exec-echo',
+      usage: {
+        inputTokens: 100,
+        outputTokens: 20,
+        cost: 1,
+        cacheReadInputTokens: 30,
+        elapsedTime: 1.5,
+        percentageCached: 25,
+        reasoningTokens: 7,
+      },
+    };
+
+    try {
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'usage',
+          stats: payload.usage,
+          data: payload,
+        },
+      });
+
+      expect(streams.get().get(root)?.usage).toEqual(payload.usage);
+      expect(streams.get().get(root)?.cumulativeUsage).toEqual({
+        inputTokens: 100,
+        outputTokens: 20,
+        cost: 1,
+        cacheReadInputTokens: 30,
+        cacheMissInputTokens: 0,
+        cacheCreationInputTokens: 0,
+        reasoningTokens: 7,
+      });
+      expect(hostEmit).toHaveBeenCalledWith('updateStreamUsage', payload);
+    } finally {
+      detachProjector();
+      detachTui();
+    }
+  });
+
+  it('does not double-count projected usage when the projector is first', () => {
+    const hub = new SessionEventHub();
+    const hostEmit = vi.fn();
+    const wrapped = wrapRuntimeHost({
+      emit: hostEmit,
+      close: async () => {},
+    } as unknown as CliRuntimeHost);
+    const detachProjector = attachSessionRunFactProjector(hub, wrapped, root);
+    const detachTui = attachTuiRunFactSubscription(hub);
+    const storageKey = 'root-projector-first-run' as StorageKey;
+    const payload = {
+      streamId: root,
+      storageKey,
+      executionId: 'exec-projector-first',
+      usage: {
+        inputTokens: 100,
+        outputTokens: 20,
+        cost: 1,
+        cacheReadInputTokens: 30,
+        elapsedTime: 1.5,
+        percentageCached: 25,
+        reasoningTokens: 7,
+      },
+    };
+
+    try {
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'usage',
+          stats: payload.usage,
+          data: payload,
+        },
+      });
+
+      expect(streams.get().get(root)?.usage).toEqual(payload.usage);
+      expect(streams.get().get(root)?.cumulativeUsage).toEqual({
+        inputTokens: 100,
+        outputTokens: 20,
+        cost: 1,
+        cacheReadInputTokens: 30,
+        cacheMissInputTokens: 0,
+        cacheCreationInputTokens: 0,
+        reasoningTokens: 7,
+      });
+      expect(hostEmit).toHaveBeenCalledWith('updateStreamUsage', payload);
+    } finally {
+      detachTui();
+      detachProjector();
     }
   });
 


### PR DESCRIPTION
Part of #6968.

## Summary

This Stage 5 slice moves the chat TUI live usage display to the session event rail for run-scoped `usage` events. It keeps the legacy host-event path intact for public CLI output and non-migrated consumers.

## Design

- `attachTuiRunFactSubscription(...)` now consumes both domain run facts and run-scoped `usage` events from `SessionEventHub`.
- Direct usage events update the TUI's latest and cumulative usage state without calling the runtime host emitter.
- A turn-scoped two-way echo guard pairs direct usage delivery with the matching projected `updateStreamUsage` host event in either subscription order, so the TUI does not double-count additive usage while `SessionRunFactProjector` remains attached.
- Direct usage parsing accepts the extended usage payloads emitted by normal runs, including elapsed/cache/reasoning fields.
- `SessionRunFactProjector` is deliberately unchanged. CLI NDJSON/public output still depends on projected host events until the final projector deletion gate.

## Validation

- `corepack pnpm exec prettier --check packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts packages/cli/src/chat/chatSessionController.ts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm exec eslint packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts packages/cli/src/chat/chatSessionController.ts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/TuiStateAndFocus.vitest.mts` — 113 tests
- `corepack pnpm run typecheck`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the TUI accumulates token usage during the session-event migration; incorrect echo handling could skew displayed costs, though guards and equivalence tests mitigate that.
> 
> **Overview**
> Moves **live token usage** in the chat TUI onto run-scoped `usage` events from `SessionEventHub`, alongside the existing direct handling of plan/todo run facts. **`attachTuiRunFactSubscription`** (renamed from the work-plan-only helper) now patches stream `usage` and `cumulativeUsage` from those events **without** going through the runtime host emitter.
> 
> A **`UsageEchoGuard`** dedupes the same usage update when `SessionRunFactProjector` still projects it as **`updateStreamUsage`**: direct hub events apply first and the matching legacy host event is skipped so cumulative totals are not applied twice. The legacy **`updateStreamUsage`** path in **`wrapRuntimeHost`** stays for NDJSON and other consumers.
> 
> Tests cover direct usage application and echo behavior regardless of subscriber vs projector attach order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b48b71940bfc6659327799e7cb444fc9d462c8bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->