### PR TITLE
docs(modelHandlers): document file-upload predicates as genuine per-provider behavior

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -168,6 +168,18 @@ export abstract class ModelHandler<
   /**
    * Whether the handler supports processing attachments in tool results.
    * Override in handlers that don't support attachments (e.g., DeepSeek).
+   *
+   * Not foldable into a single llm-zoo capability read (#7101 triage):
+   * `capabilities.supportsVision` looks like the natural candidate, but it
+   * doesn't line up — Grok, Kimi, and Qwen models all report
+   * `supportsVision: false` while still relying on this base default of
+   * `true` to include a text attachment summary in tool results (see
+   * `ModelHandlerOpenAI`/`ModelHandlerOpenRouterNative`), and DeepSeek's
+   * override below isn't gating on vision either — DeepSeek's tool-result
+   * format doesn't accommodate attachment content at all. Folding this into
+   * `supportsVision` would silently drop attachment summaries for every
+   * non-vision Grok/Kimi/Qwen model. Stays an overridable getter: genuinely
+   * per-provider behavior, not a foldable predicate.
    */
   protected get canProcessToolResultAttachments(): boolean {
     return true;
@@ -177,6 +189,18 @@ export abstract class ModelHandler<
    * Whether the handler can upload files to the provider's API for tool results.
    * Override in handlers that support provider-specific file upload APIs
    * (e.g., Anthropic Files API, OpenAI Files API).
+   *
+   * Not foldable into a single capability read (#7101 triage): Anthropic's
+   * override is an unconditional `true` — there's no llm-zoo or
+   * `ProviderCapabilityProfile` flag for "has a Files API," it's a
+   * provider-wide fact about the Anthropic SDK, not a per-model capability
+   * (it would coincidentally match `capabilities.supportsVision`, which is
+   * `true` for every current Anthropic model, but that conflates two
+   * unrelated capabilities and would break the moment they diverge).
+   * OpenAIResponse's override already reads the `ProviderCapabilityProfile`
+   * (`getActiveProviderCapabilities()?.openAIResponses`) with a fallback —
+   * that one's the "runtime combinator over profile data" bucket, not
+   * genuine per-provider behavior. Stays an overridable getter.
    */
   protected get supportsToolResultFileUpload(): boolean {
     return false;

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -244,7 +244,11 @@ export class ModelHandlerAnthropic extends ModelHandler<
   }
 
   /**
-   * Anthropic supports file uploads via their Files API.
+   * Anthropic supports file uploads via their Files API. Unconditionally
+   * true rather than a capability read: this is a provider-wide fact about
+   * the Anthropic SDK, not a per-model llm-zoo flag or `ProviderCapabilityProfile`
+   * entry (#7101 triage: see the base getter's doc comment for why this
+   * stays a per-provider override rather than folding into a capability read).
    */
   protected override get supportsToolResultFileUpload(): boolean {
     return true;

--- a/src/agent/modelHandlers/openai/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerDeepSeek.ts
@@ -33,7 +33,13 @@ export class ModelHandlerDeepSeek extends ReasoningModelHandlerOpenAI<DeepSeekTo
   // from ReasoningModelHandlerOpenAI.
 
   /**
-   * DeepSeek models don't support vision/attachments in tool results.
+   * DeepSeek's tool-result format doesn't accommodate attachment content, so
+   * attachment summaries are suppressed entirely. Not derived from
+   * `capabilities.supportsVision` — that flag is about image understanding
+   * in normal turns, not whether the tool-result format can carry an
+   * attachment summary; the two happen to both be false for DeepSeek today,
+   * but that's a coincidence, not a rule (#7101 triage: see the base
+   * getter's doc comment for why this stays a per-provider override).
    */
   protected override get canProcessToolResultAttachments(): boolean {
     return false;

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -292,7 +292,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   }
 
   /**
-   * OpenAI Response API supports file uploads.
+   * OpenAI Response API supports file uploads. Reads the ChatGPT-subscription
+   * profile when active (that backend disables tool-result file upload);
+   * otherwise defaults to true for the base Responses API (#7101 triage:
+   * runtime combinator over profile data, not a per-provider override).
    */
   protected override get supportsToolResultFileUpload(): boolean {
     return (


### PR DESCRIPTION
## Context

Part of #7101 (F4 follow-up: fold the remaining ~28 `ModelHandler` base predicates into capability-profile reads). Three clusters already merged (provider-identity getters, `supportsTokenCounting`, `supportsManualCompaction` docs). This slice picks up the next untouched cluster: the file-upload predicates.

**Note:** this PR intentionally avoids any `close #7101`/`fix #7101`-shaped substring — even negated — since GitHub's auto-close keyword matcher has already false-positive-closed this issue three times from sentences that merely mention `#7101` near "close." Using "Part of #7101" only.

## Predicates audited

- `protected get canProcessToolResultAttachments()` (`ModelHandler.ts:172`, base `true`, overridden by `ModelHandlerDeepSeek` → `false`)
- `protected get supportsToolResultFileUpload()` (`ModelHandler.ts:181` (post-edit), base `false`, overridden by `ModelHandlerAnthropic` → unconditional `true` and `ModelHandlerOpenAIResponse` → `ProviderCapabilityProfile` read with fallback)

## Root cause / findings

Both predicates were candidates for folding into a pure `this.capabilities` read, but neither actually reduces to one:

- **`canProcessToolResultAttachments`**: `capabilities.supportsVision` looks like the natural backing flag, but it doesn't line up. Grok (`grok43`, `grok3-`, `grok2`), Kimi (all active variants), and Qwen/DashScope models (`qwen3max`, `qwenplus`, `qwenturbo`) all report `supportsVision: false` in llm-zoo while still relying on this getter's base `true` default to include a text attachment summary in tool results (`ModelHandlerOpenAI`/`ModelHandlerOpenRouterNative` call sites just build a text summary, not an image block). Folding this into `supportsVision` would silently drop those summaries for every non-vision Grok/Kimi/Qwen model. DeepSeek's `false` override isn't gating on vision either — its tool-result format can't carry attachment content at all, coincidentally aligning with (but not derived from) its `supportsVision: false`.
- **`supportsToolResultFileUpload`**: Anthropic's override is an unconditional `true` — there's no llm-zoo capability flag or `ProviderCapabilityProfile` entry for "has a Files API"; it's a provider-wide fact about the Anthropic SDK. (It happens to match `supportsVision: true` for every current Anthropic model, but that conflates two unrelated capabilities and isn't a rule.) OpenAIResponse's override already reads `ProviderCapabilityProfile` (`getActiveProviderCapabilities()?.openAIResponses`) with a fallback to `true` — that one *is* the "runtime combinator over profile data" bucket the issue calls out, already correctly implemented.

## Fix

Doc-comment only — no runtime behavior change. Updated the base-getter JSDoc on both predicates in `ModelHandler.ts` to document the audit finding (why each doesn't fold), following the exact rubric used for `supportsManualCompaction` in the prior slice (PR #7369). Also updated the per-provider override doc comments (`ModelHandlerDeepSeek`, `ModelHandlerAnthropic`, `ModelHandlerOpenAIResponse`) to cross-reference the same reasoning.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint src/agent/modelHandlers/ModelHandler.ts src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts src/agent/modelHandlers/openai/modelHandlerDeepSeek.ts src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts` — clean
- `npx vitest run src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts src/test-kernel/agent/modelHandlers/ModelHandlerDeepSeek.vitest.ts src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts src/test-kernel/model/ProviderCapabilities.vitest.ts` — 78 passed (4 files)
- `npx prettier --check <changed files>` — all match

Part of #7101.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes with no execution path impact.
> 
> **Overview**
> **Documentation-only** follow-up to #7101 for the tool-result attachment cluster: `canProcessToolResultAttachments` and `supportsToolResultFileUpload`. **No runtime or behavior changes.**
> 
> Expanded JSDoc on the base getters in `ModelHandler.ts` records why these predicates **must stay overridable** instead of collapsing to a single `capabilities` / llm-zoo read. **`canProcessToolResultAttachments`** is not equivalent to `supportsVision` (e.g. Grok/Kimi/Qwen keep text attachment summaries with `supportsVision: false`; mapping to vision would drop those summaries). **`supportsToolResultFileUpload`** is split between provider-wide facts (Anthropic Files API), profile-driven reads (OpenAI Responses), and per-handler overrides (DeepSeek).
> 
> Matching notes were added on **`ModelHandlerDeepSeek`**, **`ModelHandlerAnthropic`**, and **`ModelHandlerOpenAIResponse`** overrides, cross-referencing the base rationale—same style as the earlier `supportsManualCompaction` documentation slice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5342a91931ff9ed0b643ee71dab35b1ece034130. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->