### PR TITLE
feat(cli): apply TUI goal-paused facts directly

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -42,6 +42,10 @@ type Emit = <K extends ProgressEvent>(
 ) => void;
 
 type UpdateStreamUsagePayload = ProgressEventPayloads['updateStreamUsage'];
+type GoalPausedPayload = ProgressEventPayloads['goalPaused'];
+
+const GOAL_PAUSED_TRANSCRIPT_NOTICE =
+  'Goal paused after a failed cycle. Review the error before starting a new goal.';
 
 function usageEchoKey(payload: UpdateStreamUsagePayload): string {
   const parsedUsage = ExtendedTokenUsageStatsSchema.safeParse(payload.usage);
@@ -67,10 +71,7 @@ function usageEchoKey(payload: UpdateStreamUsagePayload): string {
   });
 }
 
-function consumeUsageEchoCount(
-  counts: Map<string, number>,
-  key: string,
-): boolean {
+function consumeEchoCount(counts: Map<string, number>, key: string): boolean {
   const count = counts.get(key);
   if (!count) return false;
   if (count === 1) {
@@ -81,21 +82,26 @@ function consumeUsageEchoCount(
   return true;
 }
 
-class UsageEchoGuard {
+class EchoGuard<T> {
   private readonly directAppliedCounts = new Map<string, number>();
   private readonly legacyAppliedCounts = new Map<string, number>();
 
-  applyDirect(payload: UpdateStreamUsagePayload): void {
-    const key = usageEchoKey(payload);
-    if (consumeUsageEchoCount(this.legacyAppliedCounts, key)) return;
-    applyUsageUpdate(payload);
+  constructor(
+    private readonly keyFor: (payload: T) => string,
+    private readonly apply: (payload: T) => void,
+  ) {}
+
+  applyDirect(payload: T): void {
+    const key = this.keyFor(payload);
+    if (consumeEchoCount(this.legacyAppliedCounts, key)) return;
+    this.apply(payload);
     this.rememberForThisTurn(this.directAppliedCounts, key);
   }
 
-  applyLegacy(payload: UpdateStreamUsagePayload): void {
-    const key = usageEchoKey(payload);
-    if (consumeUsageEchoCount(this.directAppliedCounts, key)) return;
-    applyUsageUpdate(payload);
+  applyLegacy(payload: T): void {
+    const key = this.keyFor(payload);
+    if (consumeEchoCount(this.directAppliedCounts, key)) return;
+    this.apply(payload);
     this.rememberForThisTurn(this.legacyAppliedCounts, key);
   }
 
@@ -107,12 +113,29 @@ class UsageEchoGuard {
   private rememberForThisTurn(counts: Map<string, number>, key: string): void {
     counts.set(key, (counts.get(key) ?? 0) + 1);
     queueMicrotask(() => {
-      consumeUsageEchoCount(counts, key);
+      consumeEchoCount(counts, key);
     });
   }
 }
 
+type UsageEchoGuard = EchoGuard<UpdateStreamUsagePayload>;
 let activeUsageEchoGuard: UsageEchoGuard | undefined;
+
+function goalPausedEchoKey(payload: GoalPausedPayload): string {
+  return payload.streamId;
+}
+
+type GoalPausedNoticeEchoGuard = EchoGuard<GoalPausedPayload>;
+let activeGoalPausedNoticeEchoGuard: GoalPausedNoticeEchoGuard | undefined;
+
+function appendGoalPausedTranscriptNotice(payload: GoalPausedPayload): void {
+  // Without a transcript line, an auto-paused goal is indistinguishable
+  // from a hang: the agent simply stops mid-objective.
+  appendLocalAssistantTranscript(
+    GOAL_PAUSED_TRANSCRIPT_NOTICE,
+    payload.streamId,
+  );
+}
 
 function toUpdateStreamUsagePayload(
   data: unknown,
@@ -223,8 +246,13 @@ export function wrapRuntimeHost(
 export function attachTuiRunFactSubscription(
   events: SessionEventHub,
 ): () => void {
-  const usageEchoGuard = new UsageEchoGuard();
+  const usageEchoGuard = new EchoGuard(usageEchoKey, applyUsageUpdate);
+  const goalPausedNoticeEchoGuard = new EchoGuard(
+    goalPausedEchoKey,
+    appendGoalPausedTranscriptNotice,
+  );
   activeUsageEchoGuard = usageEchoGuard;
+  activeGoalPausedNoticeEchoGuard = goalPausedNoticeEchoGuard;
   const detach = events.subscribe(
     (sessionEvent) => {
       if (sessionEvent.scope !== 'run') return;
@@ -264,6 +292,14 @@ export function attachTuiRunFactSubscription(
           }
           return;
         }
+        case 'goalPaused': {
+          if (isObject(event.data) && typeof event.data.streamId === 'string') {
+            goalPausedNoticeEchoGuard.applyDirect({
+              streamId: event.data.streamId as GoalPausedPayload['streamId'],
+            });
+          }
+          return;
+        }
         default:
           return;
       }
@@ -273,8 +309,12 @@ export function attachTuiRunFactSubscription(
   return () => {
     detach();
     usageEchoGuard.clear();
+    goalPausedNoticeEchoGuard.clear();
     if (activeUsageEchoGuard === usageEchoGuard) {
       activeUsageEchoGuard = undefined;
+    }
+    if (activeGoalPausedNoticeEchoGuard === goalPausedNoticeEchoGuard) {
+      activeGoalPausedNoticeEchoGuard = undefined;
     }
   };
 }
@@ -460,13 +500,12 @@ function applyToState<K extends ProgressEvent>(
       return;
     }
     case 'goalPaused': {
-      // Without a transcript line, an auto-paused goal is indistinguishable
-      // from a hang: the agent simply stops mid-objective.
       const p = payload as ProgressEventPayloads['goalPaused'];
-      appendLocalAssistantTranscript(
-        'Goal paused after a failed cycle. Review the error before starting a new goal.',
-        p.streamId,
-      );
+      if (activeGoalPausedNoticeEchoGuard) {
+        activeGoalPausedNoticeEchoGuard.applyLegacy(p);
+      } else {
+        appendGoalPausedTranscriptNotice(p);
+      }
       return;
     }
     case 'followUpSent': {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -121,6 +121,8 @@ import { stripOrchestratorFollowup } from '@shared/subagentFollowup';
 const root = 'root' as StreamTabId;
 const child1 = 'child-1' as StreamTabId;
 const child2 = 'child-2' as StreamTabId;
+const GOAL_PAUSED_TRANSCRIPT_NOTICE =
+  'Goal paused after a failed cycle. Review the error before starting a new goal.';
 
 afterEach(() => {
   clearAllStreamStatusesForTest(StreamStatusService);
@@ -2683,6 +2685,41 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
     }
   });
 
+  it('applies direct runFact.goalPaused events without host emission', () => {
+    const hub = new SessionEventHub();
+    const hostEmit = vi.fn();
+    const wrapped = wrapRuntimeHost({
+      emit: hostEmit,
+      close: async () => {},
+    } as unknown as CliRuntimeHost);
+    const wrappedEmit = vi.spyOn(wrapped, 'emit');
+    const detach = attachTuiRunFactSubscription(hub);
+
+    try {
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'domain',
+          key: toRunFactDomainKey('goalPaused'),
+          data: { streamId: root },
+        },
+      });
+
+      expect(
+        streams
+          .get()
+          .get(root)
+          ?.entries.map((entry) => entry.text),
+      ).toEqual([GOAL_PAUSED_TRANSCRIPT_NOTICE]);
+      expect(wrappedEmit).not.toHaveBeenCalled();
+      expect(hostEmit).not.toHaveBeenCalled();
+    } finally {
+      detach();
+      wrappedEmit.mockRestore();
+    }
+  });
+
   it('applies direct usage events without host emission', () => {
     const hub = new SessionEventHub();
     const hostEmit = vi.fn();
@@ -2837,6 +2874,80 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
         reasoningTokens: 7,
       });
       expect(hostEmit).toHaveBeenCalledWith('updateStreamUsage', payload);
+    } finally {
+      detachTui();
+      detachProjector();
+    }
+  });
+
+  it('does not duplicate the goalPaused notice when the TUI subscriber is first', () => {
+    const hub = new SessionEventHub();
+    const hostEmit = vi.fn();
+    const wrapped = wrapRuntimeHost({
+      emit: hostEmit,
+      close: async () => {},
+    } as unknown as CliRuntimeHost);
+    const detachTui = attachTuiRunFactSubscription(hub);
+    const detachProjector = attachSessionRunFactProjector(hub, wrapped, root);
+    const payload = { streamId: root };
+
+    try {
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'domain',
+          key: toRunFactDomainKey('goalPaused'),
+          data: payload,
+        },
+      });
+
+      expect(
+        streams
+          .get()
+          .get(root)
+          ?.entries.filter(
+            (entry) => entry.text === GOAL_PAUSED_TRANSCRIPT_NOTICE,
+          ),
+      ).toHaveLength(1);
+      expect(hostEmit).toHaveBeenCalledWith('goalPaused', payload);
+    } finally {
+      detachProjector();
+      detachTui();
+    }
+  });
+
+  it('does not duplicate the goalPaused notice when the projector is first', () => {
+    const hub = new SessionEventHub();
+    const hostEmit = vi.fn();
+    const wrapped = wrapRuntimeHost({
+      emit: hostEmit,
+      close: async () => {},
+    } as unknown as CliRuntimeHost);
+    const detachProjector = attachSessionRunFactProjector(hub, wrapped, root);
+    const detachTui = attachTuiRunFactSubscription(hub);
+    const payload = { streamId: root };
+
+    try {
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'domain',
+          key: toRunFactDomainKey('goalPaused'),
+          data: payload,
+        },
+      });
+
+      expect(
+        streams
+          .get()
+          .get(root)
+          ?.entries.filter(
+            (entry) => entry.text === GOAL_PAUSED_TRANSCRIPT_NOTICE,
+          ),
+      ).toHaveLength(1);
+      expect(hostEmit).toHaveBeenCalledWith('goalPaused', payload);
     } finally {
       detachTui();
       detachProjector();


### PR DESCRIPTION
## Summary

- route chat TUI `runFact.goalPaused` session facts directly through the TUI session subscription
- preserve `SessionRunFactProjector` and the legacy `goalPaused` host-event case for public CLI and non-migrated compatibility
- add a goal-paused-specific transcript echo guard so direct plus projected delivery appends the pause notice exactly once in either subscription order

## Non-goals

- no deletion of `SessionRunFactProjector`, `LegacyProgressEventProjection`, or progress-bus keys
- no global idempotence for `appendLocalAssistantTranscript`; repeated local assistant messages outside this goal-paused echo path remain allowed

## Validation

- `corepack pnpm exec prettier --check packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm exec eslint packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/TuiStateAndFocus.vitest.mts` (116 tests)
- `corepack pnpm run typecheck`
- `git diff --check`

Part of #6968 / #6951.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI TUI transcript/event wiring only; behavior is constrained to deduping the goal-paused notice and mirrors the existing usage echo pattern.
> 
> **Overview**
> Routes **`goalPaused`** run facts through **`attachTuiRunFactSubscription`** so the chat TUI can append the pause notice from session domain events without relying on host emission for that path. The legacy **`goalPaused`** progress handler and **`SessionRunFactProjector`** stay in place for compatibility; **`applyToState`** now funnels that path through an echo guard instead of always calling **`appendLocalAssistantTranscript`** inline.
> 
> Generalizes **`UsageEchoGuard`** to a generic **`EchoGuard<T>`** (shared by stream usage and goal-paused notices) so direct subscription and projected/legacy delivery dedupe on **`streamId`** and the pause message appears **once** regardless of subscriber order. Adds vitest coverage for direct application and non-duplication when TUI vs projector attaches first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87b0a470e9bc909e2cc6d5015184f7e2a8caf5cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->