### PR TITLE
feat(cli): apply TUI process facts directly

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -2,7 +2,9 @@
 // still flowing through the original emitter. Approvals are intentionally
 // not handled here — `subscribeApprovals.ts` owns the typed-modal pipeline.
 
+import type { AgentEvent } from '@agent/trace';
 import { defaultSession } from '@agent/runtime/SessionHandle';
+import { projectRunFactToProgressEvent } from '@agent/runtime/sessionProgressEventProjection';
 import { fromRunFactDomainKey } from '@agent/runtime/runFactEvents';
 import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
@@ -14,6 +16,7 @@ import {
   ExtendedTokenUsageStatsSchema,
   UpdatePlanPayloadSchema,
   UpdateTodosPayloadSchema,
+  type ActiveChildInfo,
 } from '@shared/schemas';
 import { diffActiveChildren } from '@shared/streams/childActivityReducer';
 import {
@@ -43,6 +46,9 @@ type Emit = <K extends ProgressEvent>(
 
 type UpdateStreamUsagePayload = ProgressEventPayloads['updateStreamUsage'];
 type GoalPausedPayload = ProgressEventPayloads['goalPaused'];
+type UpdateActiveProcessesPayload =
+  ProgressEventPayloads['updateActiveProcesses'];
+type UpdateProcessOutputPayload = ProgressEventPayloads['updateProcessOutput'];
 
 const GOAL_PAUSED_TRANSCRIPT_NOTICE =
   'Goal paused after a failed cycle. Review the error before starting a new goal.';
@@ -125,8 +131,37 @@ function goalPausedEchoKey(payload: GoalPausedPayload): string {
   return payload.streamId;
 }
 
+function processOutputEchoKey(payload: UpdateProcessOutputPayload): string {
+  return JSON.stringify({
+    parentStreamId: payload.parentStreamId,
+    executionId: payload.executionId,
+    stdout: payload.stdout,
+    stderr: payload.stderr,
+  });
+}
+
+function activeProcessesEchoKey(payload: UpdateActiveProcessesPayload): string {
+  return JSON.stringify({
+    parentStreamId: payload.parentStreamId,
+    processes: payload.processes.map((process) => ({
+      kind: process.kind,
+      executionId: process.executionId,
+      agentName: process.agentName,
+      status: process.status ?? null,
+      startedAt: process.startedAt ?? null,
+      elapsed: process.elapsed ?? null,
+      toolName: process.toolName ?? null,
+      childStreamId: process.kind === 'subagent' ? process.childStreamId : null,
+    })),
+  });
+}
+
 type GoalPausedNoticeEchoGuard = EchoGuard<GoalPausedPayload>;
 let activeGoalPausedNoticeEchoGuard: GoalPausedNoticeEchoGuard | undefined;
+type ActiveProcessesEchoGuard = EchoGuard<UpdateActiveProcessesPayload>;
+let activeProcessesEchoGuard: ActiveProcessesEchoGuard | undefined;
+type ProcessOutputEchoGuard = EchoGuard<UpdateProcessOutputPayload>;
+let activeProcessOutputEchoGuard: ProcessOutputEchoGuard | undefined;
 
 function appendGoalPausedTranscriptNotice(payload: GoalPausedPayload): void {
   // Without a transcript line, an auto-paused goal is indistinguishable
@@ -176,6 +211,127 @@ function sameQueuedFollowUps(
     left.length === right.length &&
     left.every((item, index) => item === right[index])
   );
+}
+
+function applyRoundStage(
+  payload: ProgressEventPayloads['updateRoundStage'],
+): void {
+  patchStream(payload.streamId, (s) => {
+    if (
+      s.roundStage?.index === payload.roundStage.index &&
+      s.roundStage?.total === payload.roundStage.total
+    ) {
+      return s;
+    }
+    return {
+      ...s,
+      roundStage: payload.roundStage,
+    };
+  });
+}
+
+function sameActiveChildren(
+  left: readonly ActiveChildInfo[],
+  right: readonly ActiveChildInfo[],
+): boolean {
+  return (
+    left.length === right.length && left.every((item, i) => item === right[i])
+  );
+}
+
+function applyActiveSubagents(
+  payload: ProgressEventPayloads['updateActiveSubagents'],
+): void {
+  registerChildStreams(payload.parentStreamId, payload.children);
+  patchStream(payload.parentStreamId, (s) => {
+    const childStreams = mergeChildStreams(s.childStreams, payload.children);
+    if (
+      sameActiveChildren(s.activeSubagents, payload.children) &&
+      sameActiveChildren(s.childStreams, childStreams)
+    ) {
+      return s;
+    }
+    return {
+      ...s,
+      activeSubagents: payload.children,
+      childStreams,
+    };
+  });
+}
+
+function applyActiveProcesses(payload: UpdateActiveProcessesPayload): void {
+  // The shared reducer drops tails for executions that left the active
+  // list; the CLI also persists a bounded transcript for each finished
+  // process before its tail is pruned (a CLI-only side effect).
+  patchStream(payload.parentStreamId, (s) => {
+    const vanishedIds = diffActiveChildren(
+      s.activeProcesses,
+      payload.processes,
+    );
+    const entries = appendCompletedProcessEntries(
+      payload.parentStreamId,
+      s,
+      vanishedIds,
+    );
+    const meta = applyStreamMeta(s, {
+      kind: 'activeProcesses',
+      processes: payload.processes,
+    });
+    return {
+      ...s,
+      activeProcesses: meta.activeProcesses,
+      entries,
+      processOutput: meta.processOutput,
+    };
+  });
+}
+
+function applyProcessOutput(payload: UpdateProcessOutputPayload): void {
+  patchStream(payload.parentStreamId, (s) => ({
+    ...s,
+    processOutput: applyStreamMeta(s, {
+      kind: 'processOutput',
+      executionId: payload.executionId,
+      stdout: payload.stdout,
+      stderr: payload.stderr,
+    }).processOutput,
+  }));
+}
+
+function applyParentStream(
+  payload: ProgressEventPayloads['setParentStream'],
+): void {
+  setParentStream(payload.childStreamId, payload.parentStreamId);
+}
+
+function applyDirectTuiRunEvent(
+  event: AgentEvent,
+  fallbackStreamId: ProgressEventPayloads['updateRoundStage']['streamId'],
+  activeProcessesGuard: ActiveProcessesEchoGuard,
+  processOutputGuard: ProcessOutputEchoGuard,
+): boolean {
+  const projected = projectRunFactToProgressEvent(fallbackStreamId, event);
+  if (!projected) return false;
+
+  switch (projected.event) {
+    case 'updateRoundStage':
+      applyRoundStage(projected.payload);
+      return true;
+    case 'updateActiveSubagents':
+      applyActiveSubagents(projected.payload);
+      return true;
+    case 'updateActiveProcesses':
+      activeProcessesGuard.applyDirect(projected.payload);
+      return true;
+    case 'setParentStream':
+      applyParentStream(projected.payload);
+      return true;
+    case 'updateProcessOutput':
+      processOutputGuard.applyDirect(projected.payload);
+      return true;
+    default:
+      return false;
+  }
 }
 
 function refreshQueuedFollowUps(
@@ -251,12 +407,33 @@ export function attachTuiRunFactSubscription(
     goalPausedEchoKey,
     appendGoalPausedTranscriptNotice,
   );
+  const activeProcessesGuard = new EchoGuard(
+    activeProcessesEchoKey,
+    applyActiveProcesses,
+  );
+  const processOutputGuard = new EchoGuard(
+    processOutputEchoKey,
+    applyProcessOutput,
+  );
   activeUsageEchoGuard = usageEchoGuard;
   activeGoalPausedNoticeEchoGuard = goalPausedNoticeEchoGuard;
+  activeProcessesEchoGuard = activeProcessesGuard;
+  activeProcessOutputEchoGuard = processOutputGuard;
   const detach = events.subscribe(
     (sessionEvent) => {
       if (sessionEvent.scope !== 'run') return;
       const { event } = sessionEvent;
+      if (
+        applyDirectTuiRunEvent(
+          event,
+          sessionEvent.streamId,
+          activeProcessesGuard,
+          processOutputGuard,
+        )
+      ) {
+        return;
+      }
+
       if (event.type === 'usage') {
         const payload = toUpdateStreamUsagePayload(
           event.data,
@@ -304,17 +481,34 @@ export function attachTuiRunFactSubscription(
           return;
       }
     },
-    { scope: 'run', types: ['domain', 'usage'] },
+    {
+      scope: 'run',
+      types: [
+        'domain',
+        'usage',
+        'stage.start',
+        'child.activity',
+        'process.output',
+      ],
+    },
   );
   return () => {
     detach();
     usageEchoGuard.clear();
     goalPausedNoticeEchoGuard.clear();
+    activeProcessesGuard.clear();
+    processOutputGuard.clear();
     if (activeUsageEchoGuard === usageEchoGuard) {
       activeUsageEchoGuard = undefined;
     }
     if (activeGoalPausedNoticeEchoGuard === goalPausedNoticeEchoGuard) {
       activeGoalPausedNoticeEchoGuard = undefined;
+    }
+    if (activeProcessesEchoGuard === activeProcessesGuard) {
+      activeProcessesEchoGuard = undefined;
+    }
+    if (activeProcessOutputEchoGuard === processOutputGuard) {
+      activeProcessOutputEchoGuard = undefined;
     }
   };
 }
@@ -364,7 +558,7 @@ function applyToState<K extends ProgressEvent>(
     }
     case 'setParentStream': {
       const p = payload as ProgressEventPayloads['setParentStream'];
-      setParentStream(p.childStreamId, p.parentStreamId);
+      applyParentStream(p);
       return;
     }
     case 'removeStream':
@@ -389,10 +583,7 @@ function applyToState<K extends ProgressEvent>(
     }
     case 'updateRoundStage': {
       const p = payload as ProgressEventPayloads['updateRoundStage'];
-      patchStream(p.streamId, (s) => ({
-        ...s,
-        roundStage: p.roundStage,
-      }));
+      applyRoundStage(p);
       return;
     }
     case 'updateStreamDescription': {
@@ -405,50 +596,25 @@ function applyToState<K extends ProgressEvent>(
     }
     case 'updateActiveSubagents': {
       const p = payload as ProgressEventPayloads['updateActiveSubagents'];
-      registerChildStreams(p.parentStreamId, p.children);
-      patchStream(p.parentStreamId, (s) => ({
-        ...s,
-        activeSubagents: p.children,
-        childStreams: mergeChildStreams(s.childStreams, p.children),
-      }));
+      applyActiveSubagents(p);
       return;
     }
     case 'updateActiveProcesses': {
       const p = payload as ProgressEventPayloads['updateActiveProcesses'];
-      // The shared reducer drops tails for executions that left the active
-      // list; the CLI also persists a bounded transcript for each finished
-      // process before its tail is pruned (a CLI-only side effect).
-      patchStream(p.parentStreamId, (s) => {
-        const vanishedIds = diffActiveChildren(s.activeProcesses, p.processes);
-        const entries = appendCompletedProcessEntries(
-          p.parentStreamId,
-          s,
-          vanishedIds,
-        );
-        const meta = applyStreamMeta(s, {
-          kind: 'activeProcesses',
-          processes: p.processes,
-        });
-        return {
-          ...s,
-          activeProcesses: meta.activeProcesses,
-          entries,
-          processOutput: meta.processOutput,
-        };
-      });
+      if (activeProcessesEchoGuard) {
+        activeProcessesEchoGuard.applyLegacy(p);
+      } else {
+        applyActiveProcesses(p);
+      }
       return;
     }
     case 'updateProcessOutput': {
       const p = payload as ProgressEventPayloads['updateProcessOutput'];
-      patchStream(p.parentStreamId, (s) => ({
-        ...s,
-        processOutput: applyStreamMeta(s, {
-          kind: 'processOutput',
-          executionId: p.executionId,
-          stdout: p.stdout,
-          stderr: p.stderr,
-        }).processOutput,
-      }));
+      if (activeProcessOutputEchoGuard) {
+        activeProcessOutputEchoGuard.applyLegacy(p);
+      } else {
+        applyProcessOutput(p);
+      }
       return;
     }
     case 'updateTodos': {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -15,6 +15,7 @@ import { clearAllStreamStatusesForTest } from '@test/helpers/streamStatusTestUti
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import { attachSessionRunFactProjector } from '@agent/runtime/SessionRunFactProjector';
+import { attachLegacyProgressEventProjection } from '@agent/runtime/LegacyProgressEventProjection';
 import { toRunFactDomainKey } from '@agent/runtime/runFactEvents';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import {
@@ -111,6 +112,7 @@ import {
   STREAM_PHASE,
   STREAM_STATUS,
   TODO_STATUS,
+  type ActiveChildInfo,
   type Plan,
   type StorageKey,
   type StreamTabId,
@@ -2615,6 +2617,20 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
     } as unknown as CliRuntimeHost;
   }
 
+  const runningProcessA: ActiveChildInfo = {
+    kind: 'process',
+    executionId: 'exec-a',
+    agentName: 'latexmk',
+    toolName: 'bash',
+    status: 'running',
+  };
+  const runningProcessB: ActiveChildInfo = {
+    kind: 'process',
+    executionId: 'exec-b',
+    agentName: 'bash',
+    status: 'running',
+  };
+
   it('applies direct runFact.updateTodos events without host emission', () => {
     const hub = new SessionEventHub();
     const hostEmit = vi.fn();
@@ -2712,6 +2728,232 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
           .get(root)
           ?.entries.map((entry) => entry.text),
       ).toEqual([GOAL_PAUSED_TRANSCRIPT_NOTICE]);
+      expect(wrappedEmit).not.toHaveBeenCalled();
+      expect(hostEmit).not.toHaveBeenCalled();
+    } finally {
+      detach();
+      wrappedEmit.mockRestore();
+    }
+  });
+
+  it('applies direct stage.start(kind: round) events without host emission', () => {
+    const hub = new SessionEventHub();
+    const hostEmit = vi.fn();
+    const wrapped = wrapRuntimeHost({
+      emit: hostEmit,
+      close: async () => {},
+    } as unknown as CliRuntimeHost);
+    const wrappedEmit = vi.spyOn(wrapped, 'emit');
+    const detach = attachTuiRunFactSubscription(hub);
+
+    try {
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'stage.start',
+          id: 'round-2',
+          label: 'Round 2',
+          kind: 'round',
+          index: 1,
+          total: 3,
+        },
+      });
+
+      expect(streams.get().get(root)?.roundStage).toEqual({
+        index: 1,
+        total: 3,
+      });
+      expect(wrappedEmit).not.toHaveBeenCalled();
+      expect(hostEmit).not.toHaveBeenCalled();
+    } finally {
+      detach();
+      wrappedEmit.mockRestore();
+    }
+  });
+
+  it('ignores direct non-round stage.start events without host emission', () => {
+    const hub = new SessionEventHub();
+    const hostEmit = vi.fn();
+    const wrapped = wrapRuntimeHost({
+      emit: hostEmit,
+      close: async () => {},
+    } as unknown as CliRuntimeHost);
+    const wrappedEmit = vi.spyOn(wrapped, 'emit');
+    const detach = attachTuiRunFactSubscription(hub);
+
+    try {
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'stage.start',
+          id: 'phase-1',
+          label: 'Compile phase',
+          kind: 'phase',
+          index: 0,
+        },
+      });
+
+      expect(streams.get().get(root)?.roundStage).toBeUndefined();
+      expect(wrappedEmit).not.toHaveBeenCalled();
+      expect(hostEmit).not.toHaveBeenCalled();
+    } finally {
+      detach();
+      wrappedEmit.mockRestore();
+    }
+  });
+
+  it('applies direct child.activity(subagents) and parent events without host emission', () => {
+    const hub = new SessionEventHub();
+    const hostEmit = vi.fn();
+    const wrapped = wrapRuntimeHost({
+      emit: hostEmit,
+      close: async () => {},
+    } as unknown as CliRuntimeHost);
+    const wrappedEmit = vi.spyOn(wrapped, 'emit');
+    const detach = attachTuiRunFactSubscription(hub);
+    const child: ActiveChildInfo = {
+      kind: 'subagent',
+      executionId: 'agent-1',
+      agentName: 'critic',
+      childStreamId: child1,
+      status: STREAM_STATUS.RUNNING,
+    };
+
+    try {
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'child.activity',
+          kind: 'subagents',
+          parentStreamId: root,
+          children: [child],
+        },
+      });
+      hub.emit({
+        scope: 'run',
+        streamId: child2,
+        event: {
+          type: 'child.activity',
+          kind: 'parent',
+          childStreamId: child2,
+          parentStreamId: root,
+        },
+      });
+
+      expect(streams.get().get(root)?.activeSubagents).toEqual([child]);
+      expect(streams.get().get(root)?.childStreams).toEqual([child]);
+      expect(parentStream.get().get(child1)).toBe(root);
+      expect(parentStream.get().get(child2)).toBe(root);
+      expect(wrappedEmit).not.toHaveBeenCalled();
+      expect(hostEmit).not.toHaveBeenCalled();
+    } finally {
+      detach();
+      wrappedEmit.mockRestore();
+    }
+  });
+
+  it('applies direct process.output events without host emission', () => {
+    const hub = new SessionEventHub();
+    const hostEmit = vi.fn();
+    const wrapped = wrapRuntimeHost({
+      emit: hostEmit,
+      close: async () => {},
+    } as unknown as CliRuntimeHost);
+    const wrappedEmit = vi.spyOn(wrapped, 'emit');
+    const detach = attachTuiRunFactSubscription(hub);
+
+    try {
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'process.output',
+          parentStreamId: root,
+          executionId: 'exec-a',
+          stdout: 'stdout chunk',
+          stderr: 'stderr chunk',
+        },
+      });
+
+      expect(streams.get().get(root)?.processOutput.get('exec-a')).toEqual({
+        stdout: 'stdout chunk',
+        stderr: 'stderr chunk',
+      });
+      expect(wrappedEmit).not.toHaveBeenCalled();
+      expect(hostEmit).not.toHaveBeenCalled();
+    } finally {
+      detach();
+      wrappedEmit.mockRestore();
+    }
+  });
+
+  it('applies direct child.activity(processes) completion and prunes output once', () => {
+    const hub = new SessionEventHub();
+    const hostEmit = vi.fn();
+    const wrapped = wrapRuntimeHost({
+      emit: hostEmit,
+      close: async () => {},
+    } as unknown as CliRuntimeHost);
+    const wrappedEmit = vi.spyOn(wrapped, 'emit');
+    const detach = attachTuiRunFactSubscription(hub);
+
+    try {
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'child.activity',
+          kind: 'processes',
+          parentStreamId: root,
+          processes: [runningProcessA, runningProcessB],
+        },
+      });
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'process.output',
+          parentStreamId: root,
+          executionId: 'exec-a',
+          stdout: 'done line',
+          stderr: '',
+        },
+      });
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'process.output',
+          parentStreamId: root,
+          executionId: 'exec-b',
+          stdout: 'still running',
+          stderr: '',
+        },
+      });
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'child.activity',
+          kind: 'processes',
+          parentStreamId: root,
+          processes: [runningProcessB],
+        },
+      });
+
+      const slice = streams.get().get(root);
+      expect(slice?.activeProcesses).toEqual([runningProcessB]);
+      expect(slice?.processOutput.has('exec-a')).toBe(false);
+      expect(slice?.processOutput.get('exec-b')).toEqual({
+        stdout: 'still running',
+        stderr: '',
+      });
+      expect(
+        slice?.entries.filter((entry) => entry.role === 'process'),
+      ).toHaveLength(1);
       expect(wrappedEmit).not.toHaveBeenCalled();
       expect(hostEmit).not.toHaveBeenCalled();
     } finally {
@@ -2879,6 +3121,150 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
       detachProjector();
     }
   });
+
+  it.each([
+    {
+      name: 'TUI subscriber is first',
+      attach: (hub: SessionEventHub, host: CliRuntimeHost) => {
+        const detachTui = attachTuiRunFactSubscription(hub);
+        const detachProjector = attachLegacyProgressEventProjection(hub, host);
+        return () => {
+          detachProjector();
+          detachTui();
+        };
+      },
+    },
+    {
+      name: 'projector is first',
+      attach: (hub: SessionEventHub, host: CliRuntimeHost) => {
+        const detachProjector = attachLegacyProgressEventProjection(hub, host);
+        const detachTui = attachTuiRunFactSubscription(hub);
+        return () => {
+          detachTui();
+          detachProjector();
+        };
+      },
+    },
+  ])('does not duplicate process output when the $name', ({ attach }) => {
+    const hub = new SessionEventHub();
+    const hostEmit = vi.fn();
+    const wrapped = wrapRuntimeHost({
+      emit: hostEmit,
+      close: async () => {},
+    } as unknown as CliRuntimeHost);
+    const detach = attach(hub, wrapped);
+    const payload = {
+      parentStreamId: root,
+      executionId: 'exec-output',
+      stdout: 'alpha',
+      stderr: 'beta',
+    };
+
+    try {
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'process.output',
+          ...payload,
+        },
+      });
+
+      expect(streams.get().get(root)?.processOutput.get('exec-output')).toEqual(
+        {
+          stdout: 'alpha',
+          stderr: 'beta',
+        },
+      );
+      expect(hostEmit).toHaveBeenCalledWith('updateProcessOutput', payload);
+    } finally {
+      detach();
+    }
+  });
+
+  it.each([
+    {
+      name: 'TUI subscriber is first',
+      attach: (hub: SessionEventHub, host: CliRuntimeHost) => {
+        const detachTui = attachTuiRunFactSubscription(hub);
+        const detachProjector = attachLegacyProgressEventProjection(hub, host);
+        return () => {
+          detachProjector();
+          detachTui();
+        };
+      },
+    },
+    {
+      name: 'projector is first',
+      attach: (hub: SessionEventHub, host: CliRuntimeHost) => {
+        const detachProjector = attachLegacyProgressEventProjection(hub, host);
+        const detachTui = attachTuiRunFactSubscription(hub);
+        return () => {
+          detachTui();
+          detachProjector();
+        };
+      },
+    },
+  ])(
+    'does not duplicate completed-process transcript entries when the $name',
+    ({ attach }) => {
+      const hub = new SessionEventHub();
+      const hostEmit = vi.fn();
+      const wrapped = wrapRuntimeHost({
+        emit: hostEmit,
+        close: async () => {},
+      } as unknown as CliRuntimeHost);
+      const detach = attach(hub, wrapped);
+
+      try {
+        hub.emit({
+          scope: 'run',
+          streamId: root,
+          event: {
+            type: 'child.activity',
+            kind: 'processes',
+            parentStreamId: root,
+            processes: [runningProcessA, runningProcessB],
+          },
+        });
+        hub.emit({
+          scope: 'run',
+          streamId: root,
+          event: {
+            type: 'process.output',
+            parentStreamId: root,
+            executionId: 'exec-a',
+            stdout: 'finished output',
+            stderr: '',
+          },
+        });
+        hub.emit({
+          scope: 'run',
+          streamId: root,
+          event: {
+            type: 'child.activity',
+            kind: 'processes',
+            parentStreamId: root,
+            processes: [runningProcessB],
+          },
+        });
+
+        const slice = streams.get().get(root);
+        const processEntries =
+          slice?.entries.filter((entry) => entry.role === 'process') ?? [];
+        expect(processEntries).toHaveLength(1);
+        expect(processEntries[0]?.process?.executionId).toBe('exec-a');
+        expect(slice?.processOutput.has('exec-a')).toBe(false);
+        expect(slice?.activeProcesses).toEqual([runningProcessB]);
+        expect(hostEmit).toHaveBeenCalledWith('updateActiveProcesses', {
+          parentStreamId: root,
+          processes: [runningProcessB],
+        });
+      } finally {
+        detach();
+      }
+    },
+  );
 
   it('does not duplicate the goalPaused notice when the TUI subscriber is first', () => {
     const hub = new SessionEventHub();


### PR DESCRIPTION
## Summary

- route chat TUI `stage.start`, `child.activity`, and `process.output` session events directly through `attachTuiRunFactSubscription`
- share state helpers between direct session delivery and legacy host-event handling for round stage, parent links, active subagents, active processes, and process output
- guard additive process paths so direct plus projected legacy delivery does not duplicate process tails or completed-process transcript entries in either subscription order

## Non-goals

- no deletion of `SessionRunFactProjector`, `LegacyProgressEventProjection`, or progress-bus keys
- public CLI/NDJSON and non-migrated compatibility remain on projected legacy events

## Validation

- `corepack pnpm exec prettier --check packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm exec eslint packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/TuiStateAndFocus.vitest.mts` (125 tests)
- `corepack pnpm run typecheck`
- `git diff --check`

Part of #6968 / #6951.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live TUI state for processes, subagents, and round progress with dedup logic across two delivery paths; behavior is well covered by tests but mistakes could show wrong or duplicated process output in the terminal UI.
> 
> **Overview**
> The chat TUI **subscribes to run session facts** for round stages, child activity (subagents, processes, parent links), and process output—**patching `cliState` directly** via `projectRunFactToProgressEvent` instead of waiting only on legacy progress-bus emissions.
> 
> Shared **apply** helpers now back both that direct path and `wrapRuntimeHost`’s legacy progress events, with **no-op skips** when round stage or active children are unchanged. **Echo guards** on active processes and process output prevent double application when the same facts also arrive through `LegacyProgressEventProjection`, including completed-process transcript entries, regardless of subscriber order.
> 
> Tests cover direct hub delivery without host `emit`, non-round `stage.start` ignored, and paired TUI/projector ordering for deduplication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0afd8a7ead61d4b164de69424c1464ec4f35b9d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->