### PR TITLE
docs(cli): document migration lifetime of activeUsageEchoGuard

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -118,6 +118,14 @@ class EchoGuard<T> {
   }
 }
 
+// Migration lifetime: this module-level handle is the only way `applyToState`
+// (the legacy `updateStreamUsage` projection path, driven by
+// `SessionRunFactProjector`) can reach the guard owned by the direct
+// subscription path in `attachTuiRunFactSubscription`. It exists solely to
+// dedupe the two paths' overlapping usage updates during the migration and
+// must be deleted together with the legacy `updateStreamUsage` projection
+// once `SessionRunFactProjector` reaches its Stage 5 deletion gate (#6968) —
+// do not treat it as permanent architecture.
 type UsageEchoGuard = EchoGuard<UpdateStreamUsagePayload>;
 let activeUsageEchoGuard: UsageEchoGuard | undefined;
 


### PR DESCRIPTION
## Root cause

`attachTuiRunFactSubscription` (`packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts`) sets a module-level `activeUsageEchoGuard` variable so that `applyToState` — invoked from the wrapped runtime host's legacy `emit` path for `updateStreamUsage` (driven by `SessionRunFactProjector`) — can reach the same `EchoGuard` instance the direct-subscription path uses, and dedupe the two paths' overlapping usage updates.

This hidden module-level channel is correct today (one active chat session per process; `detach()` clears it with an identity check before nulling), but it's a migration-lifetime artifact tied to `SessionRunFactProjector`'s eventual Stage 5 deletion (#6968), not permanent architecture. A reviewer flagged this on #7385 (https://github.com/LionSR/TeXRA/pull/7385#discussion_r3533507920) — without a comment, a future reader could mistake it for a long-term design choice instead of scaffolding to delete.

## Fix

Minimal, comment-only change: added a comment directly above `type UsageEchoGuard` / `let activeUsageEchoGuard` explaining what the variable bridges, why it exists (migration-era dedupe between the direct-subscription and legacy projection paths), and that it must be deleted together with the legacy `updateStreamUsage` projection path once `SessionRunFactProjector` reaches its Stage 5 deletion gate (#6968). No behavior change — no new abstraction, no refactor of the guard itself, per the issue's ask and this repo's minimal-fix convention.

## Verification

- `npx tsc --noEmit -p packages/cli/tsconfig.json` — clean
- `npm run typecheck` (full workspace, including `tsconfig.test-kernel.json`, cli, and trace-viewer) — clean
- `npx eslint packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts` — clean
- `npx vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts` (covers `attachTuiRunFactSubscription` / `subscribeRuntimeHost.updateActiveProcesses` and friends) — 116 passed
- `npx prettier --check packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts` — matches style

Fixes #7390.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only documentation with no logic, API, or runtime changes.
> 
> **Overview**
> Adds a comment above **`activeUsageEchoGuard`** in `subscribeRuntimeHost.ts` so reviewers know the module-level handle is temporary migration scaffolding, not a long-term design.
> 
> The comment explains that it bridges the legacy **`updateStreamUsage`** path in **`applyToState`** (via **`SessionRunFactProjector`**) with the **`EchoGuard`** owned by **`attachTuiRunFactSubscription`**, and that both should be removed at the Stage 5 deletion gate (#6968). **No runtime behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 111e4142474fc354ddb08ccf0a17e46de2468897. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->