### PR TITLE
refactor(runtime): share one usage-payload parser across TUI and projector

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -5,6 +5,7 @@
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { fromRunFactDomainKey } from '@agent/runtime/runFactEvents';
 import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
+import { toUpdateStreamUsagePayload } from '@agent/runtime/SessionRunFactProjector';
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 import type {
   ProgressEvent,
@@ -135,27 +136,6 @@ function appendGoalPausedTranscriptNotice(payload: GoalPausedPayload): void {
     GOAL_PAUSED_TRANSCRIPT_NOTICE,
     payload.streamId,
   );
-}
-
-function toUpdateStreamUsagePayload(
-  data: unknown,
-  fallbackStreamId: string,
-): UpdateStreamUsagePayload | undefined {
-  if (!isObject(data)) return undefined;
-  const storageKey = typeof data.storageKey === 'string' ? data.storageKey : '';
-  if (!storageKey) return undefined;
-  const usage = ExtendedTokenUsageStatsSchema.safeParse(data.usage);
-  if (!usage.success) return undefined;
-  const streamId =
-    typeof data.streamId === 'string' ? data.streamId : fallbackStreamId;
-  const executionId =
-    typeof data.executionId === 'string' ? data.executionId : undefined;
-  return {
-    streamId: streamId as UpdateStreamUsagePayload['streamId'],
-    storageKey: storageKey as UpdateStreamUsagePayload['storageKey'],
-    ...(executionId ? { executionId } : {}),
-    usage: usage.data,
-  };
 }
 
 function applyUsageUpdate(payload: UpdateStreamUsagePayload): void {

--- a/src/agent/runtime/SessionRunFactProjector.ts
+++ b/src/agent/runtime/SessionRunFactProjector.ts
@@ -1,6 +1,10 @@
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
-import { type StorageKey, type StreamTabId } from '@shared/schemas';
+import {
+  ExtendedTokenUsageStatsSchema,
+  type StorageKey,
+  type StreamTabId,
+} from '@shared/schemas';
 import { isObject } from '@utils/core';
 
 import { fromRunFactDomainKey } from './runFactEvents';
@@ -12,14 +16,22 @@ function asString(value: unknown): string | undefined {
   return typeof value === 'string' ? value : undefined;
 }
 
-function toUpdateStreamUsagePayload(
+/**
+ * Parse a raw `usage` session-event `data` payload into the typed
+ * `updateStreamUsage` progress payload. Shared by this projector and the CLI
+ * TUI's direct subscriber (`subscribeRuntimeHost.ts`) so the two consumers of
+ * the same `usage` session event can't silently diverge on which usage
+ * shapes they accept.
+ */
+export function toUpdateStreamUsagePayload(
   data: unknown,
   fallbackStreamId: StreamTabId,
 ): UpdateStreamUsagePayload | undefined {
   if (!isObject(data)) return undefined;
   const storageKey = asString(data.storageKey);
-  const usage = isObject(data.usage) ? data.usage : undefined;
-  if (!storageKey || !usage) return undefined;
+  if (!storageKey) return undefined;
+  const usage = ExtendedTokenUsageStatsSchema.safeParse(data.usage);
+  if (!usage.success) return undefined;
 
   const streamId = asString(data.streamId) ?? fallbackStreamId;
   const executionId = asString(data.executionId);
@@ -27,7 +39,7 @@ function toUpdateStreamUsagePayload(
     streamId: streamId as StreamTabId,
     storageKey: storageKey as StorageKey,
     ...(executionId ? { executionId } : {}),
-    usage: usage as UpdateStreamUsagePayload['usage'],
+    usage: usage.data,
   };
 }
 


### PR DESCRIPTION
## Root cause

`toUpdateStreamUsagePayload` was implemented twice, both reading the same
`event.data` shape from the same `usage` session event:

- `packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts` validated
  `data.usage` with `ExtendedTokenUsageStatsSchema.safeParse` (strict).
- `src/agent/runtime/SessionRunFactProjector.ts` did a loose `isObject` check
  and cast (no field validation).

Because both consumers hand-rolled their own parser, they could silently
diverge on which usage payload shapes they accept.

## Fix

Exported `toUpdateStreamUsagePayload` from `SessionRunFactProjector.ts` as
the single shared parser (now using the stricter `ExtendedTokenUsageStatsSchema`
validation that the TUI copy already had), and had
`subscribeRuntimeHost.ts` import it instead of maintaining its own copy.
`subscribeRuntimeHost.ts` already imports other `@agent/runtime/*` helpers
(`fromRunFactDomainKey`, `SessionEventHub`), so this doesn't introduce a new
dependency direction. Net -8 lines; no new abstraction layer — this was a
straight de-duplication of an already 2-call-site helper.

## Verification

- `npx tsc --noEmit` — clean (0 errors; confirmed pre-existing unrelated
  errors from a stale worktree `node_modules` were resolved by `pnpm install`,
  not caused by this change).
- `cd packages/cli && npx tsc --noEmit -p tsconfig.json` — clean.
- `npx eslint packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts src/agent/runtime/SessionRunFactProjector.ts` — clean.
- `npx prettier --check <changed files>` — clean.
- `npx vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/progressView/SessionRunFactProjectorEquivalence.vitest.ts` — 117/117 passing (these cover the usage-echo dedup logic and projector/direct-event equivalence).
- Broader sanity pass: `npx vitest run src/test-kernel/cli src/test-kernel/agent/runtime src/test-kernel/progressView` — 1919/1919 passing.

Fixes #7389.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor with two call sites; tightens validation on the projector path and reduces duplicate logic without changing auth or data persistence.
> 
> **Overview**
> **Deduplicates** parsing of `usage` session-event `data` into `updateStreamUsage` progress payloads so the CLI TUI subscriber and `SessionRunFactProjector` cannot drift.
> 
> The local copy in `subscribeRuntimeHost.ts` is removed; both call sites now use **`toUpdateStreamUsagePayload`** exported from `SessionRunFactProjector.ts`. The shared helper validates **`data.usage`** with **`ExtendedTokenUsageStatsSchema.safeParse`** (replacing the projector’s previous loose object check and cast), aligning acceptance rules with what the TUI already enforced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b630f9943ace0453121fbce684e1cec23e992457. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->