### PR TITLE
docs(cli): document and strengthen UsageEchoGuard's order-independence

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -83,6 +83,29 @@ function consumeEchoCount(counts: Map<string, number>, key: string): boolean {
   return true;
 }
 
+/**
+ * Dedupe a fact that reaches this module through two paths that both fire
+ * off the *same* underlying `SessionEventHub` event: `attachTuiRunFactSubscription`
+ * applying it directly, and `attachSessionRunFactProjector` re-emitting it as a
+ * legacy `runtimeHost.emit(...)` that `applyToState` also applies.
+ *
+ * This guard is deliberately **order-independent**: `applyDirect` and
+ * `applyLegacy` are symmetric, each first checking whether the *other* side
+ * already recorded this key before applying anything itself. Whichever path's
+ * subscriber the hub happens to invoke first for a given event "wins" the
+ * apply; the second one only consumes the marker and skips. Correctness does
+ * NOT depend on `attachTuiRunFactSubscription` being registered on the hub
+ * before `attachSessionRunFactProjector` (today it always is, via
+ * `chatSessionController.ts` attaching before `AgentLaunchContext.ts`/
+ * `childStream.ts`, but nothing requires that and it isn't guaranteed to stay
+ * true) — see #7388. Regression coverage for both attach orders lives in
+ * `TuiStateAndFocus.vitest.mts` ("does not double-count projected usage when
+ * the TUI subscriber is first" / "... when the projector is first").
+ *
+ * Do not replace this with a one-directional variant (remember-on-direct,
+ * consume-on-legacy-only) — that reintroduces exactly the order dependency
+ * this comment rules out.
+ */
 class EchoGuard<T> {
   private readonly directAppliedCounts = new Map<string, number>();
   private readonly legacyAppliedCounts = new Map<string, number>();

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -2781,6 +2781,11 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
       emit: hostEmit,
       close: async () => {},
     } as unknown as CliRuntimeHost);
+    // Regression coverage for #7388: `attachTuiRunFactSubscription` is
+    // registered on the hub before `attachSessionRunFactProjector` here (the
+    // order `chatSessionController.ts` uses today), and two distinct usage
+    // events are emitted so the guard's dedupe is proven across a sequence,
+    // not just a single isolated pairing.
     const detachTui = attachTuiRunFactSubscription(hub);
     const detachProjector = attachSessionRunFactProjector(hub, wrapped, root);
     const storageKey = 'root-echo-run' as StorageKey;
@@ -2798,6 +2803,20 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
         reasoningTokens: 7,
       },
     };
+    const secondPayload = {
+      streamId: root,
+      storageKey,
+      executionId: 'exec-echo',
+      usage: {
+        inputTokens: 50,
+        outputTokens: 10,
+        cost: 0.5,
+        cacheReadInputTokens: 5,
+        elapsedTime: 0.8,
+        percentageCached: 10,
+        reasoningTokens: 3,
+      },
+    };
 
     try {
       hub.emit({
@@ -2809,18 +2828,32 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
           data: payload,
         },
       });
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'usage',
+          stats: secondPayload.usage,
+          data: secondPayload,
+        },
+      });
 
-      expect(streams.get().get(root)?.usage).toEqual(payload.usage);
+      expect(streams.get().get(root)?.usage).toEqual(secondPayload.usage);
       expect(streams.get().get(root)?.cumulativeUsage).toEqual({
-        inputTokens: 100,
-        outputTokens: 20,
-        cost: 1,
-        cacheReadInputTokens: 30,
+        inputTokens: 150,
+        outputTokens: 30,
+        cost: 1.5,
+        cacheReadInputTokens: 35,
         cacheMissInputTokens: 0,
         cacheCreationInputTokens: 0,
-        reasoningTokens: 7,
+        reasoningTokens: 10,
       });
-      expect(hostEmit).toHaveBeenCalledWith('updateStreamUsage', payload);
+      expect(hostEmit).toHaveBeenNthCalledWith(1, 'updateStreamUsage', payload);
+      expect(hostEmit).toHaveBeenNthCalledWith(
+        2,
+        'updateStreamUsage',
+        secondPayload,
+      );
     } finally {
       detachProjector();
       detachTui();
@@ -2834,6 +2867,12 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
       emit: hostEmit,
       close: async () => {},
     } as unknown as CliRuntimeHost);
+    // Regression coverage for #7388: the projector is registered on the hub
+    // before the TUI subscription here — the reverse of what
+    // `chatSessionController.ts` does today — to prove the echo guard's
+    // dedupe does not depend on that registration order. Two distinct usage
+    // events are emitted so the guard is proven across a sequence, not just a
+    // single isolated pairing.
     const detachProjector = attachSessionRunFactProjector(hub, wrapped, root);
     const detachTui = attachTuiRunFactSubscription(hub);
     const storageKey = 'root-projector-first-run' as StorageKey;
@@ -2851,6 +2890,20 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
         reasoningTokens: 7,
       },
     };
+    const secondPayload = {
+      streamId: root,
+      storageKey,
+      executionId: 'exec-projector-first',
+      usage: {
+        inputTokens: 50,
+        outputTokens: 10,
+        cost: 0.5,
+        cacheReadInputTokens: 5,
+        elapsedTime: 0.8,
+        percentageCached: 10,
+        reasoningTokens: 3,
+      },
+    };
 
     try {
       hub.emit({
@@ -2862,18 +2915,32 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
           data: payload,
         },
       });
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'usage',
+          stats: secondPayload.usage,
+          data: secondPayload,
+        },
+      });
 
-      expect(streams.get().get(root)?.usage).toEqual(payload.usage);
+      expect(streams.get().get(root)?.usage).toEqual(secondPayload.usage);
       expect(streams.get().get(root)?.cumulativeUsage).toEqual({
-        inputTokens: 100,
-        outputTokens: 20,
-        cost: 1,
-        cacheReadInputTokens: 30,
+        inputTokens: 150,
+        outputTokens: 30,
+        cost: 1.5,
+        cacheReadInputTokens: 35,
         cacheMissInputTokens: 0,
         cacheCreationInputTokens: 0,
-        reasoningTokens: 7,
+        reasoningTokens: 10,
       });
-      expect(hostEmit).toHaveBeenCalledWith('updateStreamUsage', payload);
+      expect(hostEmit).toHaveBeenNthCalledWith(1, 'updateStreamUsage', payload);
+      expect(hostEmit).toHaveBeenNthCalledWith(
+        2,
+        'updateStreamUsage',
+        secondPayload,
+      );
     } finally {
       detachTui();
       detachProjector();


### PR DESCRIPTION
Fixes #7388.

## Root cause investigation

Issue #7388 (a follow-up from #7385's review thread) worried that `UsageEchoGuard`'s no-double-count guarantee in `packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts` silently depends on `SessionEventHub.emit` invoking `attachTuiRunFactSubscription`'s subscriber *before* `attachSessionRunFactProjector`'s subscriber for the same `usage` event, with nothing enforcing or documenting that order.

Tracing the merged `EchoGuard` class carefully (and empirically verifying), the guard is **already order-independent**: `applyDirect`/`applyLegacy` are symmetric — each checks whether the *other* side already recorded the key before applying, so whichever subscriber the hub happens to invoke first for a given event "wins" the apply and the other just consumes the marker. `TuiStateAndFocus.vitest.mts` already had a regression test attaching the projector before the TUI subscription ("does not double-count projected usage when the projector is first") that passes today, proving the reversed order the issue worried about is safe.

To make sure this wasn't a false negative, I locally reverted `applyLegacy` to a one-directional variant (remember-on-direct, consume-only-on-legacy) that matches the *fragile* shape the original PR #7385 review comment was describing. That reproduced the exact double-count the issue describes (cumulative usage came out as 300/60 instead of 150/30) and was caught immediately by the existing reversed-order test. So the underlying correctness guarantee needed no design change — it was already fixed as part of #7385 — but nothing recorded *why* it's safe, so a future "simplification" could silently reintroduce the one-directional bug, and the existing tests only exercised a single isolated event pairing rather than a realistic multi-event sequence.

## Fix

- Added a doc comment on `EchoGuard` in `subscribeRuntimeHost.ts` spelling out the order-independence invariant, why it holds (symmetric cross-consumption), and an explicit "do not replace with a one-directional variant" warning, citing #7388.
- Strengthened the two existing reversed/forward-order regression tests in `TuiStateAndFocus.vitest.mts` to emit **two** distinct usage events (not just one) and assert the running `cumulativeUsage` reflects each exactly once, in both attach orders — a strictly stronger check than the single-pairing tests that existed before, matching what a real multi-turn run actually produces.

No behavior change; this is documentation + strengthened regression coverage over already-correct code.

## Verification

- `npx tsc --noEmit` — clean
- `npx tsc --noEmit -p tsconfig.test-kernel.json` — clean
- `cd packages/cli && npx tsc --noEmit -p tsconfig.json` — clean
- `npx eslint packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts src/test-kernel/cli/TuiStateAndFocus.vitest.mts` — clean
- `npx prettier --check packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts src/test-kernel/cli/TuiStateAndFocus.vitest.mts` — clean (after `--write`)
- `npx vitest run --config vitest.config.mjs src/test-kernel/cli/TuiStateAndFocus.vitest.mts` — 116/116 passed
- Sanity check: locally reverted `EchoGuard.applyLegacy` to a one-directional variant and confirmed the strengthened "projector is first" test fails with the exact double-count symptom (300/60 vs expected 150/30), then restored the real fix and reran green — this validates the regression test actually catches the class of bug the issue describes.

Claude-Session: https://claude.ai/code/session_01WPQvBwoRRof78oSE8VKTHD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test-only changes; no production logic modifications.
> 
> **Overview**
> Documents why **`EchoGuard`** in `subscribeRuntimeHost.ts` dedupes TUI direct vs legacy `updateStreamUsage` paths without depending on **`SessionEventHub`** subscriber order (#7388), and warns against replacing it with a one-directional variant that would reintroduce double-counting.
> 
> Strengthens the two **`TuiStateAndFocus`** regression tests so each emits **two** usage events and asserts **`cumulativeUsage`** and **`hostEmit`** reflect each event once, for both TUI-first and projector-first attach orders.
> 
> **No runtime behavior change** — documentation and test coverage only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2dcb0fab41da924b3afe1a04db98fe728aa38a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->