### PR TITLE
docs(modelHandlers): triage requiresBatchedParallelToolResults as per-provider behavior

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -531,6 +531,24 @@ export abstract class ModelHandler<
    * Whether parallel tool calls in a single turn must be batched into one
    * follow-up message to preserve provider-side reasoning / thought signatures.
    * Override in handlers whose APIs require it (Google, DeepSeek, Kimi, MiniMax).
+   *
+   * Not foldable into a single llm-zoo capability read (#7101 triage):
+   * `capabilities.supportsReasoning`/`supportsInterleavedThinking` look like
+   * the natural backing flags, but neither lines up. `ReasoningModelHandlerOpenAI`
+   * (the shared base for DeepSeek/Kimi/MiniMax) overrides this to an
+   * unconditional `true` for every model in those families, including
+   * non-reasoning variants — llm-zoo reports `supportsReasoning: false` for
+   * `dsv3`, `kimi`, and `kimi2`, yet they still batch, because the requirement
+   * is a provider-wire-format fact (there's a reasoning channel to preserve
+   * across the whole family's API), not a per-model reasoning toggle.
+   * `ModelHandlerGLM` overrides it back to `false` even for its
+   * reasoning-capable variants (`glm45`, `glm52`). And Grok reasoning models
+   * (`grok43`, `grok3-`; see {@link isGrokReasoningModel}) never override this
+   * at all, staying at this `false` default, via `ModelHandlerXAI`. Folding
+   * this into `supportsReasoning` would wrongly force batching on
+   * non-reasoning DeepSeek/Kimi/MiniMax variants and wrongly skip it for
+   * reasoning Grok models. Stays an overridable getter: genuinely per-provider
+   * behavior, not a foldable predicate.
    */
   get requiresBatchedParallelToolResults(): boolean {
     return false;

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -187,6 +187,8 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
   /**
    * Gemini carries thought signatures across parallel function calls, which must
    * be preserved by batching the results into a single follow-up message.
+   * Unconditional (not gated on `capabilities.supportsReasoning`) — see the
+   * base getter's doc comment (#7101 triage).
    */
   override get requiresBatchedParallelToolResults(): boolean {
     return true;

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -577,7 +577,9 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
    * `call_id` would reference a call absent from the local transcript and the
    * thought signature would be lost (spec §6.1). These steps are appended to the
    * transcript in both modes; stateless resends them, chained mode leaves them
-   * server-side once sent.
+   * server-side once sent. Unconditional (not gated on
+   * `capabilities.supportsReasoning`) — see the base getter's doc comment
+   * (#7101 triage).
    */
   override get requiresBatchedParallelToolResults(): boolean {
     return true;

--- a/src/agent/modelHandlers/openai/modelHandlerGLM.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerGLM.ts
@@ -20,7 +20,9 @@ import { ReasoningModelHandlerOpenAI } from './reasoningModelHandlerOpenAI';
 export class ModelHandlerGLM extends ReasoningModelHandlerOpenAI {
   /**
    * GLM keeps reasoning continuity without batching parallel tool results into
-   * one follow-up message.
+   * one follow-up message. See the base getter's doc comment (#7101 triage)
+   * for why this can't fold into a single `supportsReasoning` read: GLM's
+   * reasoning-capable variants (`glm45`, `glm52`) still don't batch.
    */
   override get requiresBatchedParallelToolResults(): boolean {
     return false;

--- a/src/agent/modelHandlers/openai/reasoningModelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/reasoningModelHandlerOpenAI.ts
@@ -18,7 +18,10 @@ import type { DeepSeekToolCall, OpenAIToolCall } from '../types/IModelHandler';
  *   reasoning must be replayed into tool-use follow-up messages.
  * - `requiresBatchedParallelToolResults` — most providers with separate
  *   reasoning channels need one batched follow-up message to preserve that
- *   reasoning across parallel tool calls.
+ *   reasoning across parallel tool calls. Unconditional here (not gated on
+ *   `capabilities.supportsReasoning`) because it's a family-wide wire-format
+ *   fact, not a per-model reasoning toggle — see the base getter's doc
+ *   comment (#7101 triage).
  *
  * Overrides that vary between these providers stay on the concrete handlers:
  * the GLM batching exception, content-stringification flags (DeepSeek

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -103,6 +103,9 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
    * class (config.provider is preserved through routing), so batching must be
    * decided by the routed-through provider rather than the handler class —
    * mirroring the Google/DeepSeek/Kimi/MiniMax direct-handler overrides.
+   * Keyed on provider identity rather than `capabilities.supportsReasoning`
+   * for the same reason those direct-handler overrides are — see the base
+   * getter's doc comment (#7101 triage).
    */
   override get requiresBatchedParallelToolResults(): boolean {
     const { provider } = this.config;


### PR DESCRIPTION
## Context

Part of #7101 (F4 follow-up: fold the remaining ~28 `ModelHandler` base predicates into capability-profile reads). Four clusters already merged (provider-identity getters via #7346, `supportsTokenCounting` via #7353, `supportsManualCompaction` docs via #7369, file-upload predicates via #7386). This slice picks up the next untouched cluster: `requiresBatchedParallelToolResults`.

**Note:** avoiding any `close #7101`/`fix #7101`-shaped substring in this body and the commit message, since GitHub's auto-close keyword matcher has already false-positive-closed this issue multiple times from sentences that merely mention `#7101` near "close" (even negated). Using "Part of #7101" only.

## Predicate audited

`get requiresBatchedParallelToolResults()` (`ModelHandler.ts`, base `false`), overridden by:
- `ModelHandlerGoogleGenAI` → unconditional `true`
- `ModelHandlerGoogleInteractions` → unconditional `true`
- `ReasoningModelHandlerOpenAI` (shared base for DeepSeek/Kimi/MiniMax) → unconditional `true`
- `ModelHandlerGLM` (extends `ReasoningModelHandlerOpenAI`) → overrides back to `false`
- `ModelHandlerOpenRouterNative` → computed from the routed-through `config.provider`
- `ModelHandlerXAI` (Grok) → no override, stays at the base `false`

## Root cause / findings

`capabilities.supportsReasoning` / `supportsInterleavedThinking` look like natural backing flags, but neither lines up once checked against the actual llm-zoo data:

- `ReasoningModelHandlerOpenAI` batches **unconditionally** for every DeepSeek/Kimi/MiniMax model, including non-reasoning variants — llm-zoo reports `supportsReasoning: false` for `dsv3`, `kimi`, and `kimi2`, yet they still need batching, because the requirement is a provider-wire-format fact (there's a reasoning channel in that family's API to preserve across parallel tool calls), not a per-model reasoning toggle.
- `ModelHandlerGLM` opts back out to `false` even for its own reasoning-capable variants (`glm45`, `glm52` both report `supportsReasoning: true` in llm-zoo).
- Grok reasoning models (`grok43`, `grok3-`; `supportsReasoning: true` in llm-zoo, and `isGrokReasoningModel` true for them) never need batching at all — `ModelHandlerXAI` never overrides this getter.

Folding this into `supportsReasoning` would wrongly force batching on non-reasoning DeepSeek/Kimi/MiniMax variants and wrongly skip it for reasoning Grok models. Genuinely per-provider (per-family) behavior, not a foldable predicate.

## Fix

Doc-comment only — no runtime behavior change. Expanded the base getter's JSDoc in `ModelHandler.ts` with the audit finding, following the exact rubric used for `supportsManualCompaction` (#7369) and the file-upload predicates (#7386). Cross-referenced the same reasoning from every override site: `ModelHandlerGoogleGenAI`, `ModelHandlerGoogleInteractions`, `ModelHandlerGLM`, `ReasoningModelHandlerOpenAI`, `ModelHandlerOpenRouterNative`.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint src/agent/modelHandlers/ModelHandler.ts src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts src/agent/modelHandlers/openai/modelHandlerGLM.ts src/agent/modelHandlers/openai/reasoningModelHandlerOpenAI.ts src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts` — clean
- `npx vitest run src/test-kernel/agent/modelHandlers/` — 386 passed, 4 skipped (48 files)
- `npx prettier --check` on the six changed files — all match

Part of #7101 (does not close it — remaining clusters (`shouldUseServerSideKeys` runtime combinator, pseudo-prefill predicates `shouldStorePseudoPrefillAsOutput`/`shouldPrependPrefillOnResumeWithoutAssistantPrefill`) are left for follow-up PRs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes with no logic, API, or test modifications.
> 
> **Overview**
> **Documentation only** — no runtime behavior changes. Part of **#7101** (folding `ModelHandler` predicates into capability profiles); this slice audits **`requiresBatchedParallelToolResults`**.
> 
> The base **`ModelHandler`** getter JSDoc now records why **`capabilities.supportsReasoning`** / **`supportsInterleavedThinking`** are **not** valid backing flags: DeepSeek/Kimi/MiniMax batch unconditionally via **`ReasoningModelHandlerOpenAI`** (including non-reasoning models), **GLM** overrides back to **`false`** even for reasoning variants, and **Grok** reasoning models keep the default **`false`**. Folding into **`supportsReasoning`** would mis-batch those families.
> 
> **Override sites** (**Google GenAI**, **Google Interactions**, **GLM**, **ReasoningModelHandlerOpenAI**, **OpenRouter Native**) add short cross-references to that base comment (unconditional batching vs provider-identity routing on OpenRouter).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a379b093cc8db50323f43ded3d8c524c47715858. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->