### PR TITLE
fix(tests): update DelegationTools.vitest.ts for renamed subagentDeliveryRegistry

### DIFF
--- a/src/test-kernel/tools/DelegationTools.vitest.ts
+++ b/src/test-kernel/tools/DelegationTools.vitest.ts
@@ -61,7 +61,7 @@ import {
   rejectOversizedBibAttachments,
   type WorkflowAgentInput,
 } from '@tools/DelegationTools';
-import { subagentDeliveryRegistry } from '@tools/subagentDeliveryState';
+import { SharedSubagentDeliveryRegistry } from '@tools/subagentDeliveryState';
 import { WorkspaceFS } from '@utils/files';
 
 const BASE_INPUT: WorkflowAgentInput = {
@@ -206,11 +206,11 @@ describe('DelegateAgentTool resume (issue #7289)', () => {
       status: 'queued',
       reason: 'waiting',
     });
-    subagentDeliveryRegistry.start(executionId);
+    SharedSubagentDeliveryRegistry.start(executionId);
   });
 
   afterEach(() => {
-    subagentDeliveryRegistry.finish(executionId);
+    SharedSubagentDeliveryRegistry.finish(executionId);
   });
 
   it('returns once the follow-up is queued, without waiting for a resumed native subagent to reach its next boundary', async () => {


### PR DESCRIPTION
## Summary

Currently broken on main. #7319 (merged) and #7376/#7347 (singleton PascalCase naming rename, merged after) each correctly reflected their own base commit at merge time, but the combination broke this test file: neither PR's diff touched `DelegationTools.vitest.ts`, so it kept importing the now-nonexistent `subagentDeliveryRegistry` export from `@tools/subagentDeliveryState` — the rename PR replaced it with `SharedSubagentDeliveryRegistry`. Two tests currently fail on `main` with `TypeError: Cannot read properties of undefined`.

## Fix

Renamed the import and both call sites (`.start()`/`.finish()`) to `SharedSubagentDeliveryRegistry`. No logic change.

## Verification

- `npx tsc --noEmit -p tsconfig.test-kernel.json` — clean
- `npx vitest run src/test-kernel/tools/DelegationTools.vitest.ts` — 6/6 passing (was 4/6 before this fix)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only import rename with no production code changes.
> 
> **Overview**
> Updates **`DelegationTools.vitest.ts`** so it imports and uses **`SharedSubagentDeliveryRegistry`** from `@tools/subagentDeliveryState` instead of the removed **`subagentDeliveryRegistry`** export.
> 
> The **`DelegateAgentTool` resume** suite still calls **`.start()`** / **`.finish()`** in `beforeEach` / `afterEach`; only the symbol name changes. No production or test behavior changes beyond fixing the broken reference that caused `undefined` at runtime on `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ea8922bba4abaddc25c3a6a6cb10785aa941dbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->