### PR TITLE
refactor: move workspace file writes to app signals

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -369,7 +369,6 @@ export class DesktopProgressBridge {
         showErrorMessage: options.showErrorMessage,
       },
       {
-        runtimeHost: this.runtimeHost,
         runExecution: (request) => this.runExecution(request),
         listWorkspaceCandidateFiles: () => this.listWorkspaceCandidateFiles(),
       },
@@ -1064,11 +1063,6 @@ export class DesktopProgressBridge {
     // Releases approval state (pending approvals, bypass flags, coordinator
     // requests) and the follow-up queue for this stream.
     releaseStreamResources(streamId, this.session);
-    // releaseStreamResources only settles the legacy approval registries;
-    // DesktopHostInteractions keeps its own pendingRequests map (bash/plan/
-    // proposal/user-question) that only this cancels, so a pending approval
-    // wouldn't otherwise be settled and the awaiting tool call would hang.
-    this.session.interactions.cancelForStream(streamId, 'Stream deleted.');
 
     this.releaseApprovalsForStream(streamId);
     this.workflowFileActions.clearStreamBackups(streamId);
@@ -1094,12 +1088,6 @@ export class DesktopProgressBridge {
     for (const streamId of streamIds) {
       this.deletedStreams.add(streamId);
       releaseStreamResources(streamId, this.session);
-      // See the matching comment in deleteStream: DesktopHostInteractions'
-      // pendingRequests map is not covered by releaseStreamResources.
-      this.session.interactions.cancelForStream(
-        streamId,
-        'All streams deleted.',
-      );
     }
     // Catch pending approvals with no concrete stream context (undefined or
     // empty streamId) — the per-stream loop skips them because they do not

--- a/packages/desktop/src/main/desktopProgressFileActions.ts
+++ b/packages/desktop/src/main/desktopProgressFileActions.ts
@@ -1,8 +1,8 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { ValidatedExecutionRequest } from '@agent/core/state/executionRequests';
+import { appSignals } from '@eventBus/AppSignals';
 import type { DiffViewHost } from '@hosts/uiHosts';
 import { acceptEditedFileReplace } from '@latex/acceptedFileTarget';
 import { openFirstLabelMatch } from '@latex/labelSearch';
@@ -38,7 +38,6 @@ export interface DesktopProgressFileActionOptions {
  * full progress bridge.
  */
 export interface DesktopProgressFileActionHost {
-  runtimeHost: AgentRuntimeHost;
   runExecution(request: ValidatedExecutionRequest): Promise<void>;
   listWorkspaceCandidateFiles(): Promise<string[]>;
 }
@@ -132,7 +131,7 @@ export class DesktopProgressFileActions {
             ? this.options.confirmAcceptFile(message)
             : Promise.resolve(true),
         emitWritten: (absolutePath) =>
-          this.host.runtimeHost.emit('workspaceFilesWritten', {
+          appSignals.emit('workspaceFilesWritten', {
             absolutePaths: [absolutePath],
           }),
         showInfo: (message) => this.options.showInfoMessage?.(message),

--- a/packages/extension/src/commands/latex/compareCommands.ts
+++ b/packages/extension/src/commands/latex/compareCommands.ts
@@ -6,9 +6,9 @@ import * as vscode from 'vscode';
 
 // Local imports
 import { legacyWorkflowOutputStem } from '@agent/output/workflowOutputLayout';
-import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import { showQuickPick } from '@commands/_shared/quickInputUtils';
 import { registerCommands } from '@commands/_shared/registerCommands';
+import { appSignals } from '@eventBus/AppSignals';
 import {
   showLoggedErrorMessage,
   showLoggedMessage,
@@ -239,7 +239,7 @@ async function handleAcceptEdited(
           return answer === 'Yes';
         },
         emitWritten: (absolutePath) =>
-          emitRuntimeEvent('workspaceFilesWritten', {
+          appSignals.emit('workspaceFilesWritten', {
             absolutePaths: [absolutePath],
           }),
         showInfo: (message) => {
@@ -265,7 +265,7 @@ async function handleAcceptEdited(
     await FlexibleFS.write(targetLocation, editedContent);
 
     if (targetLocation.kind === 'workspace') {
-      emitRuntimeEvent('workspaceFilesWritten', {
+      appSignals.emit('workspaceFilesWritten', {
         absolutePaths: [targetLocation.absolutePath],
       });
     }

--- a/packages/extension/src/frontend/ui/fileDecorations.ts
+++ b/packages/extension/src/frontend/ui/fileDecorations.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 
 import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import { defaultSession } from '@agent/runtime/SessionHandle';
-import { ProgressEventBus } from '@eventBus/ProgressEventBus';
+import { appSignals } from '@eventBus/AppSignals';
 import { subscribeAddOutputFilesRunFact } from '@frontend/events/runFactSubscriptions';
 import type { OutputFileInfo } from '@shared/schemas/output';
 
@@ -81,7 +81,7 @@ export function registerFileDecorations(
     },
   );
 
-  const unsubscribeWritten = ProgressEventBus.on(
+  const unsubscribeWritten = appSignals.on(
     'workspaceFilesWritten',
     ({ absolutePaths }) => {
       provider.markTouched(absolutePaths);

--- a/src/eventBus/AppSignals.ts
+++ b/src/eventBus/AppSignals.ts
@@ -25,6 +25,12 @@ export interface AppSignalPayloads {
    * dashboards from the updated cache.
    */
   toolAvailabilityChanged: undefined;
+
+  /**
+   * One or more files were written directly to the workspace. Frontends can
+   * badge or refresh those files without routing through a run-scoped channel.
+   */
+  workspaceFilesWritten: { absolutePaths: string[] };
 }
 
 export type AppSignal = keyof AppSignalPayloads;

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -218,12 +218,6 @@ export interface ProgressEventPayloads {
   // ── App/session lifecycle + integration signals ──
   extensionDeactivating: undefined;
 
-  /**
-   * One or more files were written directly to the workspace (e.g. via
-   * accept_run_files). Listened by fileDecorations to badge the files.
-   */
-  workspaceFilesWritten: { absolutePaths: string[] };
-
   // ── Frontend-bound events ──
   // Emitted by agent core/runtime; consumed by frontend listeners.
   // Keeps @agent/ free of @frontend/ imports.

--- a/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
@@ -6,6 +6,7 @@ import { installPlatform } from '@test/support/setupPlatform';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { withToolFileInteractionContext } from '@agent/followUp/ToolFileInteractionContext';
+import { appSignals } from '@eventBus/AppSignals';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { AcceptRunFilesTool } from '@tools/AcceptRunFilesTool';
 import {
@@ -114,9 +115,16 @@ describe('accept_run_files progress events', () => {
     cleanupAllApprovals();
   });
 
-  it('publishes accepted workspace files through the tool runtime host', async () => {
+  it('publishes accepted workspace files through app signals', async () => {
     const explicit = createRecordingHost();
     const tool = new AcceptRunFilesTool();
+    const written: string[][] = [];
+    const dispose = appSignals.on(
+      'workspaceFilesWritten',
+      ({ absolutePaths }) => {
+        written.push(absolutePaths);
+      },
+    );
 
     StorageFS.exists = async (target) =>
       target === `executions/${executionId}` ||
@@ -134,28 +142,43 @@ describe('accept_run_files progress events', () => {
     ]);
 
     expect(result.status).toBe('executed');
-    expect(explicit.events).toContainEqual({
-      event: 'workspaceFilesWritten',
-      payload: { absolutePaths: [`${workspacePath}/paper.tex`] },
-    });
+    expect(explicit.events).toEqual([]);
+    expect(written).toEqual([[`${workspacePath}/paper.tex`]]);
+    dispose();
   });
 
-  it('fails before workspace writes when the tool runtime host is missing', async () => {
+  it('does not require a runtime host to publish accepted workspace files', async () => {
     const tool = new AcceptRunFilesTool();
     let writes = 0;
+    const written: string[][] = [];
+    const dispose = appSignals.on(
+      'workspaceFilesWritten',
+      ({ absolutePaths }) => {
+        written.push(absolutePaths);
+      },
+    );
 
+    StorageFS.exists = async (target) =>
+      target === `executions/${executionId}` ||
+      target === `executions/${executionId}/output.tex`;
+    WorkspaceFS.exists = async () => false;
+    WorkspaceFS.read = async () => '';
     WorkspaceFS.write = async () => {
       writes++;
     };
+    WorkspaceFS.delete = async () => undefined;
+    FlexibleFS.read = async () => 'accepted content';
+    testApprovalHandler = async () => ({ accepted: true });
 
     const result = await tool.call({
       execution_id: executionId,
       files: [{ path: 'output.tex', original: 'paper.tex' }],
     });
 
-    expect(result.status).toBe('error');
-    expect(result.error).toContain('requires a tool runtime host');
-    expect(writes).toBe(0);
+    expect(result.status).toBe('executed');
+    expect(writes).toBe(1);
+    expect(written).toEqual([[`${workspacePath}/paper.tex`]]);
+    dispose();
   });
 
   it('uses the pre-run snapshot for same-path workspace outputs', async () => {

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -2034,12 +2034,11 @@ describe('DesktopProgressBridge', () => {
 
       await bridge.deleteStream('plan-delete-stream' as StreamTabId);
 
-      // Before the fix, this promise never settled: releaseStreamResources
-      // only cleared the legacy approval registries, not
-      // DesktopHostInteractions' own pendingRequests map.
+      // This promise must settle through releaseStreamResources, which owns
+      // stream-scoped interaction cleanup.
       await expect(result).resolves.toEqual({
         action: 'reject',
-        feedback: 'Stream deleted.',
+        feedback: 'Stream resources released.',
       });
       expect(
         progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION),
@@ -2271,12 +2270,11 @@ describe('DesktopProgressBridge', () => {
 
       await bridge.deleteAllStreams();
 
-      // Before the fix, this promise never settled: releaseStreamResources
-      // only cleared the legacy approval registries, not
-      // DesktopHostInteractions' own pendingRequests map.
+      // This promise must settle through releaseStreamResources, which owns
+      // stream-scoped interaction cleanup.
       await expect(result).resolves.toEqual({
         accepted: false,
-        userMessage: 'All streams deleted.',
+        userMessage: 'Stream resources released.',
       });
     } finally {
       bridge.dispose();

--- a/src/test-kernel/desktop/DesktopProgressFileActions.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressFileActions.vitest.mts
@@ -126,7 +126,6 @@ async function loadFileActions(mocks: {
       showErrorMessage,
     },
     {
-      runtimeHost: { emit: vi.fn() },
       runExecution: vi.fn(),
       listWorkspaceCandidateFiles: vi.fn(async () => []),
     },

--- a/src/test-kernel/frontend/OutputFileRunFactSubscriptions.vitest.ts
+++ b/src/test-kernel/frontend/OutputFileRunFactSubscriptions.vitest.ts
@@ -112,6 +112,7 @@ vi.mock('vscode', () => {
 
 const { SessionEventHub } = await import('@agent/runtime/SessionEventHub');
 const { toRunFactDomainKey } = await import('@agent/runtime/runFactEvents');
+const { appSignals } = await import('@eventBus/AppSignals');
 const { ProgressEventBus } = await import('@eventBus/ProgressEventBus');
 const { registerInlineCriticism, setInlineCriticismEnabled } =
   await import('@frontend/latex/inlineCriticism');
@@ -207,7 +208,7 @@ describe('output-file run fact frontend subscriptions', () => {
     }
   });
 
-  it('badges run-fact output files and keeps workspaceFilesWritten on the bus', () => {
+  it('badges run-fact output files and app-scoped workspace writes', () => {
     const hub = new SessionEventHub();
     const context = makeContext();
     registerFileDecorations(context as unknown as VSCode.ExtensionContext, hub);
@@ -229,7 +230,7 @@ describe('output-file run fact frontend subscriptions', () => {
     ).toMatchObject({ badge: 'T', tooltip: 'Modified by TeXRA' });
 
     const writtenPath = '/tmp/texra-workspace-written.tex';
-    ProgressEventBus.emit('workspaceFilesWritten', {
+    appSignals.emit('workspaceFilesWritten', {
       absolutePaths: [writtenPath],
     });
     expect(

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -18,6 +18,9 @@ import { z } from 'zod';
 // Local imports - agent
 import { getExecutionStore } from '@agent/storage';
 
+// Local imports - event bus
+import { appSignals } from '@eventBus/AppSignals';
+
 // Local imports - shared
 import { generateDiffFileName } from '@latex/latexdiff/diffFileNameManager';
 import { stripCriticizeAnnotations } from '@replacement/advanced';
@@ -30,7 +33,6 @@ import {
 } from '@shared/schemas/toolResult';
 
 // Local imports - tools
-import { requireRuntimeHost } from '@tools/contextHelpers';
 import { assertNoParentTraversal } from '@tools/pathResolution';
 import {
   buildApprovalRejectedResult,
@@ -135,7 +137,6 @@ Optional:
 }) {
   protected async execute(input: AcceptRunFilesInput): Promise<ToolResult> {
     const { execution_id: executionId, files, strip_criticize } = input;
-    const runtimeHost = requireRuntimeHost('accept_run_files');
 
     const runDir = await findExistingRunStoragePath(executionId);
     const runDirExists = runDir !== undefined;
@@ -282,7 +283,7 @@ Optional:
 
     // Badge all accepted workspace files
     if (acceptedEntries.length > 0) {
-      runtimeHost.emit('workspaceFilesWritten', {
+      appSignals.emit('workspaceFilesWritten', {
         absolutePaths: acceptedEntries.map((e) => e.destAbsolutePath),
       });
     }


### PR DESCRIPTION
## Summary

- move `workspaceFilesWritten` from `ProgressEventBus` / runtime-host emission to `AppSignals`
- update extension file decorations, LaTeX accept paths, `accept_run_files`, and desktop file actions to emit/listen through `appSignals`
- remove the now-unneeded desktop file-action `runtimeHost` dependency
- clean up the stale desktop stream-deletion cancellation assertions from #7406: `releaseStreamResources` is the single owner of stream-scoped interaction cleanup, so the explicit duplicate desktop cancellations are removed

Part of #6968 and #6951.
Closes #7406.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/frontend/OutputFileRunFactSubscriptions.vitest.ts src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts src/test-kernel/desktop/DesktopProgressFileActions.vitest.mts src/test-kernel/tools/ToolAvailabilityAppSignals.vitest.ts`
- `corepack pnpm run typecheck`
- `corepack pnpm exec eslint src/eventBus/AppSignals.ts src/eventBus/ProgressEventBus.ts src/tools/AcceptRunFilesTool.ts packages/extension/src/frontend/ui/fileDecorations.ts packages/extension/src/commands/latex/compareCommands.ts packages/desktop/src/main/desktopProgressFileActions.ts packages/desktop/src/main/desktopAgentExecution.ts src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts src/test-kernel/frontend/OutputFileRunFactSubscriptions.vitest.ts src/test-kernel/desktop/DesktopProgressFileActions.vitest.mts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/desktop/DesktopProgressFileActions.vitest.mts src/test-kernel/frontend/OutputFileRunFactSubscriptions.vitest.ts src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts src/test-kernel/tools/ToolAvailabilityAppSignals.vitest.ts`
- `corepack pnpm test`
- `corepack pnpm run compile:fast`
- `corepack pnpm run lint` (passes with three unrelated baseline import-order warnings)

## Grep checks

- no `emitRuntimeEvent(\x27workspaceFilesWritten\x27)` / `emitRuntimeEvent("workspaceFilesWritten")`
- no `runtimeHost.emit(\x27workspaceFilesWritten\x27)`
- no `ProgressEventBus.emit/on(\x27workspaceFilesWritten\x27)`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly event routing and decoupling; desktop stream teardown behavior is consolidated into existing releaseStreamResources with updated tests.
> 
> **Overview**
> Moves **`workspaceFilesWritten`** off `ProgressEventBus` and runtime-host emission onto **`AppSignals`**, so direct workspace writes are an app-scoped signal rather than run/progress traffic.
> 
> **Emitters** now call `appSignals.emit('workspaceFilesWritten', …)` from `accept_run_files`, VS Code accept/compare flows, and desktop file actions; **file decorations** subscribe on `appSignals` instead of the progress bus. **`accept_run_files`** no longer requires a tool runtime host to publish badges after accept.
> 
> On desktop, **`DesktopProgressFileActions`** drops the **`runtimeHost`** dependency from its host interface. Stream delete paths stop calling **`session.interactions.cancelForStream`** explicitly—**`releaseStreamResources`** already cancels stream-scoped interactions (with feedback *"Stream resources released."*), so duplicate desktop cancellations are removed and tests are aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf5bb783a7d0eb9c6b684f12b3646945a4ffec9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->