### PR TITLE
refactor(data-structures): eliminate three complexity-prone glued shapes

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -1170,7 +1170,7 @@ if (SHOW_EDIT_APPROVAL) {
     void enqueueApproval(
       {
         kind: 'toolEdit',
-        request: makeEditApprovalRequest(),
+        payload: makeEditApprovalRequest(),
       },
       { onPresent: () => notify({ kind: 'approvalNeeded' }) },
     ).then(applyHarnessApprovalDecision);

--- a/packages/cli/src/chat/tui/modals/ApprovalModal.tsx
+++ b/packages/cli/src/chat/tui/modals/ApprovalModal.tsx
@@ -37,7 +37,7 @@ export function ApprovalModal(
       return (
         <EditApproval
           availableRows={props.availableRows}
-          request={payload.request}
+          request={payload.payload}
           onDecide={decide}
         />
       );

--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -31,7 +31,7 @@ export type ApprovalQueueStatusKind = 'approval' | 'question' | 'request';
 
 export type ApprovalPayload =
   | { kind: 'bash'; payload: BashPermission }
-  | { kind: 'toolEdit'; request: ToolEditApprovalRequest }
+  | { kind: 'toolEdit'; payload: ToolEditApprovalRequest }
   | { kind: 'plan'; payload: PlanApprovalPermission }
   | { kind: 'proposal'; payload: AgentProposalPermission }
   | { kind: 'retry'; payload: RetryPermission }
@@ -148,9 +148,8 @@ export function approvalPayloadStreamId(
     case 'retry':
     case 'externalInquiry':
     case 'userQuestion':
-      return payload.payload.streamId || undefined;
     case 'toolEdit':
-      return payload.request.streamId || undefined;
+      return payload.payload.streamId || undefined;
     default:
       return assertNever(payload, 'Unhandled approval payload kind');
   }

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -139,7 +139,7 @@ export function createTuiHostInteractions(
       let decision: ApprovalDecision | undefined = immediateDecision(context);
       if (!decision) {
         decision = await enqueueTuiApproval(
-          { kind: 'toolEdit', request },
+          { kind: 'toolEdit', payload: request },
           host,
         );
         markIfRejected(context, decision);

--- a/src/agent/core/usage/ResponseUsage.ts
+++ b/src/agent/core/usage/ResponseUsage.ts
@@ -1,9 +1,5 @@
 // Third-party imports
-import type {
-  Usage as AnthropicUsage,
-  CacheCreation,
-  ServerToolUsage,
-} from '@anthropic-ai/sdk/resources/messages';
+import type { Usage as AnthropicUsage } from '@anthropic-ai/sdk/resources/messages';
 import type {
   GenerateContentResponseUsageMetadata,
   Interactions,
@@ -54,49 +50,3 @@ export type NativeUsagePayload =
  * the provider doesn't return usage data.
  */
 export type ProviderUsage = NativeUsagePayload | null | undefined;
-
-/** Base interface for common response usage metrics. Internal only. */
-interface ResponseUsageBase {
-  totalInputTokens: number;
-  totalOutputTokens: number;
-  percentageCached: number;
-  cost: number;
-  responseTime: number;
-}
-
-/** OpenAI-specific response usage metrics with detailed token breakdowns. */
-export interface OpenAIAPIResponseUsage extends ResponseUsageBase {
-  prompt_tokens: number;
-  completion_tokens: number;
-  cached_tokens: number;
-  cache_miss_tokens?: number;
-  reasoning_tokens: number;
-  accepted_prediction_tokens: number | null;
-  rejected_prediction_tokens: number | null;
-  // Some providers expose tool-use tokens via the OpenAI-compatible interface.
-  tool_use_tokens?: number;
-  prompt_tokens_details?: {
-    cached_tokens?: number;
-  };
-  completion_tokens_details?: {
-    reasoning_tokens?: number;
-    accepted_prediction_tokens?: number | null;
-    rejected_prediction_tokens?: number | null;
-  };
-}
-
-/** Anthropic-specific response usage metrics with cache statistics. */
-export interface AnthropicAPIResponseUsage extends ResponseUsageBase {
-  input_tokens: number;
-  output_tokens: number;
-  cache_read_input_tokens: number | null;
-  cache_creation_input_tokens: number | null;
-  /** Breakdown of cache creation tokens by TTL (5m vs 1h) */
-  cache_creation: CacheCreation | null;
-  /** Server tool usage statistics (e.g., web search requests) */
-  server_tool_use: ServerToolUsage | null;
-  /** Service tier used for the request (standard, priority, or batch) */
-  service_tier: 'standard' | 'priority' | 'batch' | null;
-  // Optional field surfaced by compatibility layers that expose tool-use costs.
-  tool_use_tokens?: number;
-}

--- a/src/test-kernel/cli/ApprovalQueue.vitest.mts
+++ b/src/test-kernel/cli/ApprovalQueue.vitest.mts
@@ -205,7 +205,7 @@ describe('CLI approval queue', () => {
     expect(
       approvalPayloadStreamId({
         kind: 'toolEdit',
-        request: { streamId: 'child-edit' },
+        payload: { streamId: 'child-edit' },
       } as ApprovalPayload),
     ).toBe('child-edit');
     expect(

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -492,7 +492,7 @@ describe('CLI TUI row allocation', () => {
       approvalForegroundMaxRows({
         payload: {
           kind: 'toolEdit',
-          request: {
+          payload: {
             path: 'draft.tex',
             originalContent: 'old',
             proposedContent: 'new',
@@ -998,7 +998,7 @@ describe('CLI TUI row allocation', () => {
     const globalApproval = {
       payload: {
         kind: 'toolEdit',
-        request: {
+        payload: {
           path: 'paper.tex',
           originalContent: '',
           proposedContent: '',

--- a/src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts
+++ b/src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts
@@ -19,8 +19,7 @@ interface CurrentShaState {
   ciComplete: boolean;
   ciPassed: boolean;
   checkRunsCache?: {
-    etagsByPage: Map<number, string>;
-    pagesByPage: Map<number, GhCheckRun[]>;
+    pages: Map<number, { etag?: string; runs: GhCheckRun[] }>;
     lastTotalCount: number;
   };
   pendingAnnotationRuns: GhCheckRun[];

--- a/src/tools/github/checkRunsClient.ts
+++ b/src/tools/github/checkRunsClient.ts
@@ -44,9 +44,13 @@ const MAX_ANNOTATION_PAGES_PER_RUN = 50;
  * Exported as a standalone type so `SubscriptionState` can reference it
  * without `checkRunsClient` importing back from `PRPollingSource` (cycle).
  */
+export interface CheckRunsCachePage {
+  etag?: string;
+  runs: GhCheckRun[];
+}
+
 export interface CheckRunsCache {
-  etagsByPage: Map<number, string>;
-  pagesByPage: Map<number, GhCheckRun[]>;
+  pages: Map<number, CheckRunsCachePage>;
   lastTotalCount: number;
 }
 
@@ -129,12 +133,11 @@ export async function fetchAllCheckRuns(
 ): Promise<FetchAllCheckRunsResult> {
   const basePath = `/repos/${owner}/${repo}/commits/${sha}/check-runs?per_page=${CHECK_RUNS_PAGE_SIZE}`;
 
-  // Seed scratch caches we'll stage on the return value. We rebuild from
+  // Seed a scratch cache we'll stage on the return value. We rebuild from
   // scratch each tick (rather than mutating in-place) so any pages dropped
   // on this tick — e.g. new push reduced page count from 5 to 3 — don't
   // leave stale entries behind.
-  const nextEtags = new Map<number, string>();
-  const nextPages = new Map<number, GhCheckRun[]>();
+  const nextPages = new Map<number, CheckRunsCachePage>();
 
   // We need a place to record whether *every* page returned 304 so we can
   // surface a true 304 to the caller (and skip the seeding/diff work).
@@ -154,16 +157,15 @@ export async function fetchAllCheckRuns(
     total: number | undefined;
     was304: boolean;
   }> => {
-    const pageEtag = cache?.etagsByPage.get(page);
+    const pageEtag = cache?.pages.get(page)?.etag;
     const res = await ghGet<{
       total_count: number;
       check_runs: GhCheckRun[];
     }>(`${basePath}&page=${page}`, pageEtag);
     if (res.status === 304) {
       // Reuse cached page. Carry forward the ETag we sent.
-      const cachedRuns = cache?.pagesByPage.get(page) ?? [];
-      if (pageEtag) nextEtags.set(page, pageEtag);
-      nextPages.set(page, cachedRuns);
+      const cachedRuns = cache?.pages.get(page)?.runs ?? [];
+      nextPages.set(page, { etag: pageEtag, runs: cachedRuns });
       return {
         runs: cachedRuns,
         // total_count isn't returned on 304. We deliberately return
@@ -177,8 +179,7 @@ export async function fetchAllCheckRuns(
         was304: true,
       };
     }
-    if (res.etag) nextEtags.set(page, res.etag);
-    nextPages.set(page, res.data.check_runs);
+    nextPages.set(page, { etag: res.etag, runs: res.data.check_runs });
     return {
       runs: res.data.check_runs,
       total: res.data.total_count,
@@ -201,7 +202,7 @@ export async function fetchAllCheckRuns(
     first.was304 &&
     cache &&
     cache.lastTotalCount <= CHECK_RUNS_PAGE_SIZE &&
-    cache.etagsByPage.size === 1
+    cache.pages.size === 1
   ) {
     return { response: { status: 304 } };
   }
@@ -293,8 +294,7 @@ export async function fetchAllCheckRuns(
   // We always overwrite on commit: any pages from a previous tick that we
   // didn't touch this tick (e.g. page count shrank) are intentionally evicted.
   const stagedCache: CheckRunsCache = {
-    etagsByPage: nextEtags,
-    pagesByPage: nextPages,
+    pages: nextPages,
     lastTotalCount: reportedTotal,
   };
 


### PR DESCRIPTION
## Summary

A codebase-wide review flagged several data structures that glue unrelated variants together, forcing type assertions or repeated null-checks at call sites (full report shared separately). This PR fixes the three findings that are safe, contained, and independently verifiable — pure type-level cleanup, no wire/storage format changes:

- **Dead usage types deleted.** `OpenAIAPIResponseUsage`, `AnthropicAPIResponseUsage`, and their shared `ResponseUsageBase` in `src/agent/core/usage/ResponseUsage.ts` were never referenced anywhere outside their own declarations — `NormalizedUsage` is the only usage shape actually consumed downstream. Confirmed via repo-wide grep before deleting; also dropped the now-unused `CacheCreation`/`ServerToolUsage` imports.
- **`CheckRunsCache`'s two parallel Maps merged into one.** `src/tools/github/checkRunsClient.ts` kept `etagsByPage: Map<number, string>` and `pagesByPage: Map<number, GhCheckRun[]>` as separate maps that had to be mutated in lockstep at every call site, with nothing enforcing they stayed in sync. Replaced with a single `Map<number, {etag?, runs}>` so one cache entry = one page, structurally.
- **CLI `ApprovalPayload`'s `toolEdit` variant field renamed `request` → `payload`.** Six of the seven discriminated-union variants already used `payload`; `toolEdit` alone used `request`, forcing the one consumer that reads a field generically across all variants (`approvalPayloadStreamId`) to special-case it. Now uniform.

**Explicitly out of scope for this PR:** several higher-severity findings from the review (round-indexed data modeled in 3+ incompatible shapes across `src/shared/schemas` and the extension frontend, the untagged 45-key `ProgressEventPayloads` grab-bag, `ResultMeta`'s glued producer variants, and provider-message/conversation-storage normalization) touch persisted formats and cross many files. Per this repo's abstraction-cost guardrails (`CLAUDE.md` §13 — build implies delete in the same PR, no leapfrogging migrations), those deserve dedicated, narrowly-scoped follow-up PRs with their own test coverage rather than being bundled into one large, harder-to-verify change. One finding (`ToolDashboardItem`'s install-related optional fields) turned out on inspection to be legitimate — the fields are independently composable, not mutually-exclusive variants — so no change was made there.

## Issue acceptance gates

Ad hoc review request ("refactor and make PRs" following a data-structure complexity audit) — no tracked issue. Gate: the three findings above are fixed with no behavior change, verified by full typecheck and the existing test suite.

## Single source of truth

- `NormalizedUsage` (`src/agent/types/NormalizedUsage.ts`) remains the sole usage-metrics shape after API extraction.
- `CheckRunsCache.pages: Map<number, CheckRunsCachePage>` is now the single source for a page's cached etag + runs.
- `ApprovalPayload`'s `payload` field is now the uniform accessor across all seven variants.

## Duplication and abstraction budget

Removed duplication (two dead type declarations, two Maps kept in sync by convention, one asymmetric field name requiring a special-cased switch branch). No new abstractions added. Net -52 LoC (`git diff --stat`: 24 insertions, 76 deletions across 9 files).

## Host impact

Extension: none (files touched are host-agnostic `src/agent/core` and `src/tools/github`, not extension-specific).

Desktop: none.

CLI: `ApprovalPayload`'s `toolEdit` variant field renamed; all construction/read sites (approval queue, subscribe handler, modal, harness script, tests) updated in the same commit.

## Scheduled refactoring

None filed. The larger deferred findings (round-indexed data unification, `ProgressEventPayloads` split, `ResultMeta`/provider-message normalization) were called out to the requester as follow-up candidates but no issue was opened for them yet.

## Validation

- `npm run typecheck` — full workspace (extension, CLI, trace-viewer) passes clean.
- `npx eslint` on all changed files — clean (one pre-existing "no matching configuration" warning on a script outside lint scope, unrelated to this change).
- `npx vitest run` on `src/test-kernel/cli/ApprovalQueue.vitest.mts`, `TuiStateAndFocus.vitest.mts`, `src/test-kernel/tools/PRPollingSourceCiStarted.vitest.ts` — 135/135 pass.
- `npx vitest run src/test-kernel/tools/ src/test-kernel/agent/` (broader regression sweep covering the touched GitHub-tools and usage code) — 1494/1494 pass, 4 pre-existing skips.


---
_Generated by [Claude Code](https://claude.ai/code/session_017s82yo52jwyx5S2caM7khv)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical renames and cache struct consolidation with existing tests; no auth, persistence, or API contract changes.
> 
> **Overview**
> This PR is **type-level cleanup** with no intended runtime or wire-format changes.
> 
> **CLI approvals:** The `toolEdit` variant of `ApprovalPayload` now uses **`payload`** like the other six variants, so `approvalPayloadStreamId` no longer special-cases `request`. Harness, modal, queue, subscribe handler, and tests are updated together.
> 
> **GitHub check-runs cache:** `CheckRunsCache` replaces parallel **`etagsByPage`** and **`pagesByPage`** maps with a single **`pages: Map<number, { etag?, runs }>`**, so etag and runs for a page stay one struct. `fetchAllCheckRuns` staging/commit logic is adjusted accordingly.
> 
> **Usage types:** Removes dead **`OpenAIAPIResponseUsage`**, **`AnthropicAPIResponseUsage`**, and **`ResponseUsageBase`** from `ResponseUsage.ts` (unused outside their declarations); **`NormalizedUsage`** remains the consumed shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04fa17687450f0e0ebe09b685b1f10d1fd1fc8d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->