### PR TITLE
refactor(tools): dedup edit-tool approval write/record/diff-note scaffold

### DIFF
--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -3,10 +3,7 @@ import { z } from 'zod';
 
 // Local imports - tools
 import { ToolError, ToolResult } from '@shared/schemas/toolResult';
-import {
-  recordToolFileRead,
-  requireFileReadForEdit,
-} from '@tools/fileInteractions';
+import { requireFileReadForEdit } from '@tools/fileInteractions';
 import {
   assertWritable,
   resolveAndFormat,
@@ -14,9 +11,9 @@ import {
 } from '@tools/pathResolution';
 import { countOccurrences } from '@tools/utils';
 import {
-  formatUnifiedApprovalUserDiff,
+  appendApprovalDiffNote,
   requestApprovedEditContent,
-  writeApprovedContent,
+  writeAndRecordApprovedEdit,
 } from '@tools/approval/toolEditApproval';
 import { WorkspaceFS } from '@utils/files';
 import { pluralize } from '@utils/text/stringUtils';
@@ -113,27 +110,23 @@ export class EditFileTool extends defineTool({
     }
     const { approval, finalContent } = outcome;
 
-    const { appliedContent } = await writeApprovedContent(
+    const { appliedContent } = await writeAndRecordApprovedEdit(
       targetPath,
       currentContent,
       finalContent,
     );
-
-    recordToolFileRead(targetPath);
 
     const count = replace_all ? occurrences : 1;
     const occurrenceWord = pluralize(count, 'occurrence');
     const replacementSummary = `Replaced ${count} ${occurrenceWord}.`;
     const summary = `Edited ${displayPath}: replaced ${count} ${occurrenceWord}`;
 
-    const userDiffNote = formatUnifiedApprovalUserDiff(
+    const output = appendApprovalDiffNote(
+      replacementSummary,
       displayPath,
       updatedContent,
       appliedContent,
     );
-    const output = userDiffNote
-      ? `${replacementSummary}\n\n${userDiffNote}`
-      : replacementSummary;
 
     return {
       status: 'executed',

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -15,9 +15,9 @@ import {
   requireFileReadForEdit,
 } from '@tools/fileInteractions';
 import {
-  formatUnifiedApprovalUserDiff,
+  appendApprovalDiffNote,
   requestApprovedEditContent,
-  writeApprovedContent,
+  writeAndRecordApprovedEdit,
   type ToolEditApprovalResult,
 } from '@tools/approval/toolEditApproval';
 import { assertNever } from '@utils/core';
@@ -317,24 +317,20 @@ export class TextEditorTool extends defineTool({
         await WorkspaceFS.ensureDir(dirPath);
       }
 
-      const { appliedContent } = await writeApprovedContent(
+      // writeAndRecordApprovedEdit marks the file "read" after creation so
+      // subsequent edits don't require an explicit read first.
+      const { appliedContent } = await writeAndRecordApprovedEdit(
         filePath,
         '',
         finalContent,
       );
 
-      // Record file as "read" after creation so subsequent edits don't require
-      // an explicit read - this is essential for newly created files.
-      recordToolFileRead(filePath);
-
-      const userDiffNote = formatUnifiedApprovalUserDiff(
+      const output = appendApprovalDiffNote(
+        `File created successfully at: ${displayPath}`,
         displayPath,
         proposedContent,
         appliedContent,
       );
-      const output = userDiffNote
-        ? `File created successfully at: ${displayPath}\n\n${userDiffNote}`
-        : `File created successfully at: ${displayPath}`;
 
       return {
         status: 'executed',
@@ -398,7 +394,7 @@ export class TextEditorTool extends defineTool({
       return { rejected: outcome.rejected };
     }
 
-    const { appliedContent, baseContent } = await writeApprovedContent(
+    const { appliedContent, baseContent } = await writeAndRecordApprovedEdit(
       filePath,
       fileContent,
       outcome.finalContent,
@@ -406,8 +402,6 @@ export class TextEditorTool extends defineTool({
     if (appliedContent !== baseContent) {
       this.addToHistory(filePath, baseContent);
     }
-
-    recordToolFileRead(filePath);
 
     return { approval: outcome.approval, appliedContent };
   }
@@ -614,28 +608,25 @@ export class TextEditorTool extends defineTool({
       }
       const { approval, finalContent } = outcome;
 
-      const { appliedContent } = await writeApprovedContent(
+      const { appliedContent } = await writeAndRecordApprovedEdit(
         filePath,
         currentContent,
         finalContent,
       );
       history.pop();
 
-      recordToolFileRead(filePath);
-
       if (history.length === 0) {
         this.fileHistory.delete(key);
       }
 
-      const userDiffNote = formatUnifiedApprovalUserDiff(
+      const baseOutput = `Last edit to ${displayPath} undone successfully. ${this.makeOutput(appliedContent)}`;
+      const output = appendApprovalDiffNote(
+        baseOutput,
         displayPath,
         previousContent,
         appliedContent,
+        '\n',
       );
-      const baseOutput = `Last edit to ${displayPath} undone successfully. ${this.makeOutput(appliedContent)}`;
-      const output = userDiffNote
-        ? `${baseOutput}\n${userDiffNote}`
-        : baseOutput;
 
       return {
         status: 'executed',
@@ -660,13 +651,13 @@ export class TextEditorTool extends defineTool({
   ): string {
     const successIntro = `The file ${filePath} has been edited.`;
     const snippetOutput = this.makeOutput(snippetText, startLine);
-    const userDiffNote = formatUnifiedApprovalUserDiff(
+    const baseMsg = `${successIntro} ${snippetOutput}${reviewNote}`;
+    return appendApprovalDiffNote(
+      baseMsg,
       filePath,
       proposedContent,
       appliedContent,
     );
-    const baseMsg = `${successIntro} ${snippetOutput}${reviewNote}`;
-    return userDiffNote ? `${baseMsg}\n\n${userDiffNote}` : baseMsg;
   }
 
   /**

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -317,8 +317,6 @@ export class TextEditorTool extends defineTool({
         await WorkspaceFS.ensureDir(dirPath);
       }
 
-      // writeAndRecordApprovedEdit marks the file "read" after creation so
-      // subsequent edits don't require an explicit read first.
       const { appliedContent } = await writeAndRecordApprovedEdit(
         filePath,
         '',

--- a/src/tools/WriteTool.ts
+++ b/src/tools/WriteTool.ts
@@ -5,19 +5,16 @@ import { z } from 'zod';
 import { isTexFile } from '@common/files/fileTypeUtils';
 import replacementEngine from '@replacement/engine';
 import { ToolResult } from '@shared/schemas/toolResult';
-import {
-  recordToolFileRead,
-  requireFileReadForEdit,
-} from '@tools/fileInteractions';
+import { requireFileReadForEdit } from '@tools/fileInteractions';
 import {
   assertWritable,
   resolveAndFormat,
   currentToolRoot,
 } from '@tools/pathResolution';
 import {
-  formatUnifiedApprovalUserDiff,
+  appendApprovalDiffNote,
   requestApprovedEditContent,
-  writeApprovedContent,
+  writeAndRecordApprovedEdit,
 } from '@tools/approval/toolEditApproval';
 import { WorkspaceFS } from '@utils/files';
 import { countLines } from '@utils/text/stringUtils';
@@ -73,20 +70,18 @@ export class WriteFileTool extends defineTool({
     }
     const { approval, finalContent } = outcome;
 
-    const { appliedContent } = await writeApprovedContent(
+    const { appliedContent } = await writeAndRecordApprovedEdit(
       filePath,
       originalContent,
       finalContent,
     );
 
-    recordToolFileRead(filePath);
-
-    const userDiffNote = formatUnifiedApprovalUserDiff(
+    const output = appendApprovalDiffNote(
+      'written',
       displayPath,
       proposedContent,
       appliedContent,
     );
-    const output = userDiffNote ? `written\n\n${userDiffNote}` : 'written';
 
     const originalLineCount = countLines(originalContent);
     const newLineCount = countLines(appliedContent);

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -283,7 +283,7 @@ export function getApprovedContent(
   return approval.appliedContent ?? fallback;
 }
 
-export function formatUnifiedApprovalUserDiff(
+function formatUnifiedApprovalUserDiff(
   path: string,
   suggestedContent: string,
   appliedContent: string,

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -6,6 +6,7 @@ import type { StreamTabId } from '@shared/schemas';
 import type { ToolEditApprovalAction } from '@shared/schemas/prompts';
 import type { LineChanges } from '@shared/schemas/lineChanges';
 import { type ToolResult } from '@shared/schemas/toolResult';
+import { recordToolFileRead } from '@tools/fileInteractions';
 import { WorkspaceFS } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
 import {
@@ -338,6 +339,47 @@ export async function writeApprovedContent(
 
   await WorkspaceFS.write(path, finalContent);
   return { appliedContent: finalContent, baseContent: currentContent };
+}
+
+/**
+ * `writeApprovedContent` plus the `recordToolFileRead` that must always
+ * follow it — every edit tool marks the file "read" immediately after a
+ * successful approved write so a later edit in the same run doesn't hit the
+ * read-before-edit gate. Centralized because every call site paired these two
+ * calls by hand and it's an easy one to forget.
+ */
+export async function writeAndRecordApprovedEdit(
+  path: string,
+  originalContent: string,
+  finalContent: string,
+): Promise<WriteApprovedContentResult> {
+  const result = await writeApprovedContent(
+    path,
+    originalContent,
+    finalContent,
+  );
+  recordToolFileRead(path);
+  return result;
+}
+
+/**
+ * Append the unified user-adjustment diff note to a base output message, or
+ * return the base message unchanged when the user made no adjustments.
+ * `separator` defaults to a blank line between the base message and the note.
+ */
+export function appendApprovalDiffNote(
+  baseOutput: string,
+  path: string,
+  proposedContent: string,
+  appliedContent: string,
+  separator: string = '\n\n',
+): string {
+  const diffNote = formatUnifiedApprovalUserDiff(
+    path,
+    proposedContent,
+    appliedContent,
+  );
+  return diffNote ? `${baseOutput}${separator}${diffNote}` : baseOutput;
 }
 
 export function buildApprovalRejectedResult(


### PR DESCRIPTION
## Summary

`EditTool`, `WriteTool`, and `TextEditorTool` each hand-paired `writeApprovedContent` + `recordToolFileRead` and separately re-built the same "append unified diff note if present" output string at every write site (5-6 call sites total). The duplication had already drifted slightly between tools (e.g. inconsistent newline separators). This centralizes both patterns into two small helpers in `toolEditApproval.ts` and adopts them at every call site.

## Issue acceptance gates

Found via a code-quality scan across the repo (asked to identify and fix the largest ad-hoc/messy areas). This addresses the "file-editing approval scaffold duplicated across 3 tools" finding.

## Single source of truth

`toolEditApproval.ts` now owns two invariants that were previously re-derived by hand at each call site:
- `writeAndRecordApprovedEdit`: every approved write is immediately followed by `recordToolFileRead` (so a later edit in the same run doesn't hit the read-before-edit gate).
- `appendApprovalDiffNote`: the "append the user-adjustment diff note, or return the base message unchanged" formatting rule.

## Duplication and abstraction budget

Removed ~6 duplicated write+record pairs and ~6 duplicated diff-note ternaries across `EditTool.ts`, `WriteTool.ts`, and `TextEditorTool.ts` (`create`, `approveAndWriteEdit`, `undoEdit`, `formatEditOutput`). No new abstraction layers beyond the two functions above; both are pure compositions of existing exported primitives (`writeApprovedContent`, `recordToolFileRead`, `formatUnifiedApprovalUserDiff`) with 5-6 real callers each. `TextEditorTool.undoEdit`'s single-newline separator (vs. the `\n\n` used elsewhere) was preserved via an explicit `separator` parameter rather than silently normalized.

## Host impact

Extension: no behavior change — same approval/write/diff-note flow, now shared.
Desktop: no behavior change.
CLI: no behavior change.

## Scheduled refactoring

None — this is one PR in a small series from the same scan. Two more scoped, independent refactors (webview backend boilerplate; flow-runner scaffolding dedup) are planned as separate PRs.

## Validation

- `npm run typecheck` — passes.
- `npx eslint` on all four changed files — clean.
- `npx prettier --check` on all four changed files — clean.
- Targeted vitest suites covering the edit-approval path (`ToolEditApprovalGate`, `ConcurrentToolEditApprovalHandlers`, `DesktopToolEditApproval`, `ToolUseDispatchParallel`, `ToolUseToolResolution`) — all pass.
- Full `src/test-kernel` suite — 4988 passed, 3 pre-existing failures (verified identical on clean `main` before this change, unrelated to these files: a desktop stream-teardown message-text mismatch and a flaky process-group-abort timing test).


---
_Generated by [Claude Code](https://claude.ai/code/session_015z2DT8qDHGnayEmNaUb1Nb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with preserved behavior; targeted tests cover the approval path. Risk is low aside from accidentally skipping `recordToolFileRead` at a new call site—now enforced in one helper.
> 
> **Overview**
> **Edit**, **Write**, and **TextEditor** tools no longer hand-pair `writeApprovedContent` with `recordToolFileRead` or duplicate the “append user-adjustment diff note” ternary at every write site.
> 
> `toolEditApproval.ts` now exposes **`writeAndRecordApprovedEdit`** (approved write + read gate bookkeeping) and **`appendApprovalDiffNote`** (base message plus optional unified diff; default `\n\n` separator). **`formatUnifiedApprovalUserDiff`** is module-private. Call sites in create/str_replace/insert/undo and **EditTool**/**WriteTool** use the helpers; **TextEditor** `undo_edit` keeps a single newline via an explicit `separator` argument.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60e78eefd327ec65ce65531a702c1e6e748e3f20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->