### PR TITLE
refactor(progressView): derive event-registration module/context defaults

### DIFF
--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -56,8 +56,10 @@ export type GetProgressStreamControls = (
 ) => ProgressStreamControls;
 
 type ProgressEventRegistration<K extends ProgressEvent> = {
-  readonly module: string;
-  readonly context: string;
+  /** Defaults to 'ProgressEvents' when omitted. */
+  readonly module?: string;
+  /** Defaults to `failed to handle ${event}` when omitted. */
+  readonly context?: string;
   readonly handle: (payload: ProgressEventPayloads[K]) => void | Promise<void>;
 };
 
@@ -124,34 +126,22 @@ export class ProgressEventHandler {
   private createEventRegistrations(): ProgressEventRegistrationMap {
     return {
       setActiveStream: {
-        module: 'ProgressEvents',
-        context: 'failed to handle setActiveStream',
         handle: (payload) => this.handleSetActiveStream(payload),
       },
       updateStreamStatus: {
-        module: 'ProgressEvents',
-        context: 'failed to handle updateStreamStatus',
         handle: ({ streamId, status, previousStatus, substate }) =>
           this.setStreamStatus(streamId, status, previousStatus, substate),
       },
       setTaskState: {
-        module: 'ProgressEvents',
-        context: 'failed to handle setTaskState',
         handle: (data) => this.handleSetTaskState(data),
       },
       updateConversationProgress: {
-        module: 'ProgressEvents',
-        context: 'failed to handle updateConversationProgress',
         handle: (data) => this.handleUpdateConversationProgress(data),
       },
       updateRoundStage: {
-        module: 'ProgressEvents',
-        context: 'failed to handle updateRoundStage',
         handle: (data) => this.handleUpdateRoundStage(data),
       },
       updateActiveSubagents: {
-        module: 'ProgressEvents',
-        context: 'failed to handle updateActiveSubagents',
         handle: (data) =>
           this.updateActiveChildren(data.parentStreamId, {
             activeField: 'activeSubagents',
@@ -160,8 +150,6 @@ export class ProgressEventHandler {
           }),
       },
       updateActiveProcesses: {
-        module: 'ProgressEvents',
-        context: 'failed to handle updateActiveProcesses',
         handle: (data) =>
           this.updateActiveChildren(data.parentStreamId, {
             activeField: 'activeProcesses',
@@ -170,8 +158,6 @@ export class ProgressEventHandler {
           }),
       },
       updateProcessOutput: {
-        module: 'ProgressEvents',
-        context: 'failed to handle updateProcessOutput',
         handle: (data) => {
           // Always send — output accumulates in frontend state per-stream,
           // so it must not be dropped when the stream is inactive.
@@ -186,8 +172,6 @@ export class ProgressEventHandler {
         },
       },
       inquiryThreadUpdated: {
-        module: 'ProgressEvents',
-        context: 'failed to handle inquiryThreadUpdated',
         handle: (thread) => {
           if (this.webviewUpdater.isAvailable()) {
             this.webviewUpdater.updateInquiryThread(thread);
@@ -195,8 +179,6 @@ export class ProgressEventHandler {
         },
       },
       updateStreamDescription: {
-        module: 'ProgressEvents',
-        context: 'failed to handle updateStreamDescription',
         handle: ({ streamId, description }) => {
           this.state.snapshots.setDescription(streamId, description);
           if (this.webviewUpdater.isAvailable()) {
@@ -205,8 +187,6 @@ export class ProgressEventHandler {
         },
       },
       setParentStream: {
-        module: 'ProgressEvents',
-        context: 'failed to handle setParentStream',
         handle: ({ childStreamId, parentStreamId }) => {
           this.state.snapshots.setParentStream(childStreamId, parentStreamId);
           if (this.webviewUpdater.isAvailable()) {
@@ -218,19 +198,13 @@ export class ProgressEventHandler {
         },
       },
       extensionDeactivating: {
-        module: 'ProgressEvents',
-        context: 'failed to handle extensionDeactivating',
         handle: () => this.markAllRunningTasksAsCancelled(),
       },
       // Output events — workflow tabs hold one run; ignore the storageKey dim.
       addOutputFiles: {
-        module: 'ProgressEvents',
-        context: 'failed to handle addOutputFiles',
         handle: (payload) => this.handleAddOutputFiles(payload),
       },
       updateMissingOutputs: {
-        module: 'ProgressEvents',
-        context: 'failed to handle updateMissingOutputs',
         handle: ({ streamId, filesByRound }) => {
           this.state.snapshots.updateMissingOutputs(streamId, filesByRound);
           this.sendIfActive(streamId, () => {
@@ -242,8 +216,6 @@ export class ProgressEventHandler {
         },
       },
       updateCompileFailures: {
-        module: 'ProgressEvents',
-        context: 'failed to handle updateCompileFailures',
         handle: ({ streamId, filesByRound }) => {
           this.state.snapshots.updateCompileFailures(streamId, filesByRound);
           this.sendIfActive(streamId, () => {
@@ -256,8 +228,6 @@ export class ProgressEventHandler {
         },
       },
       clearMissingOutputs: {
-        module: 'ProgressEvents',
-        context: 'failed to handle clearMissingOutputs',
         handle: (payload) => {
           const targets: StreamTabId[] = payload.streamId
             ? [payload.streamId]
@@ -279,8 +249,6 @@ export class ProgressEventHandler {
       // Usage events — workflow tabs collapse to a single accumulated value;
       // tool-use tabs keep per-run accumulation (resume produces multiple runs).
       updateStreamUsage: {
-        module: 'ProgressEvents',
-        context: 'failed to handle updateStreamUsage',
         handle: ({ streamId, usage, storageKey }) => {
           void Promise.resolve(
             this.state.snapshots.addUsage(streamId, storageKey, usage),
@@ -297,8 +265,6 @@ export class ProgressEventHandler {
         },
       },
       updateTodos: {
-        module: 'ProgressEvents',
-        context: 'failed to handle updateTodos',
         handle: ({ streamId, todos }) => {
           this.state.snapshots.setTodos(streamId, todos);
           this.sendIfActive(streamId, () =>
@@ -309,8 +275,6 @@ export class ProgressEventHandler {
       // Plan events are rare and critical for the approval UX, so send them
       // whenever the webview is available rather than only for the active tab.
       updatePlan: {
-        module: 'ProgressEvents',
-        context: 'failed to handle updatePlan',
         handle: ({ streamId, plan }) => {
           this.state.snapshots.setPlan(streamId, plan);
           if (this.webviewUpdater.isAvailable()) {
@@ -319,8 +283,6 @@ export class ProgressEventHandler {
         },
       },
       updateQueuedFollowUps: {
-        module: 'ProgressEvents',
-        context: 'failed to handle updateQueuedFollowUps',
         handle: ({ streamId }) => {
           this.sendIfActive(streamId, () => {
             const messages = this.state.followUps.getAll(streamId);
@@ -468,8 +430,10 @@ export class ProgressEventHandler {
       ProgressEventRegistration<K> | undefined;
     if (!registration) return;
 
-    withEventErrorHandling(registration.module, registration.context, () =>
-      registration.handle(payload),
+    withEventErrorHandling(
+      registration.module ?? 'ProgressEvents',
+      registration.context ?? `failed to handle ${event}`,
+      () => registration.handle(payload),
     );
   }
 


### PR DESCRIPTION
## Summary

`ProgressEventHandler.createEventRegistrations()` had 20 `ProgressEvents` entries each repeating `module: 'ProgressEvents'` and a `context: 'failed to handle <eventName>'` string that just restates the map key. Both are now optional and default in `handleProgressEvent`, so those entries only declare `handle`.

## Issue acceptance gates

Found via a code-quality scan across the repo (asked to identify and fix the largest ad-hoc/messy areas). Addresses the "300-line registry dominated by derivable boilerplate" finding — scoped down from the original estimate after closer reading: only the `ProgressEvents` block was truly derivable. The `UIEvents` block (`showRetryRequest`, `resolveRetryRequest`, etc.) keeps its explicit `module`/`context`, since that phrasing ("failed to show retry request") genuinely diverges from the event key and isn't mechanically derivable — left untouched rather than forced into a lookup table.

## Single source of truth

`handleProgressEvent` now owns the `module`/`context` defaulting rule (`registration.module ?? 'ProgressEvents'`, `` registration.context ?? `failed to handle ${event}` ``) instead of each registry entry re-deriving it by hand.

## Duplication and abstraction budget

Removed 2 duplicated lines from each of 20 registry entries (40 LOC). No new abstraction — the two fields simply became optional with a default computed once at the single call site that consumes them.

## Host impact

Extension: no behavior change — same module/context strings are used, just computed instead of typed out.
Desktop: no behavior change.
CLI: not applicable (this is the shared progress-view backend).

## Scheduled refactoring

None for this file. The related `WebviewUpdater`/`SettingsViewMessageHandler` boilerplate (also flagged in the scan) was evaluated but not touched — most of that repetition is already one-line arrow functions, and a shared `refresh()` wrapper would only trim ~15 characters per call site while risking a type mismatch against the registry's exact handler signature. Not worth it.

## Validation

- `npx tsc --noEmit` — passes.
- `npx eslint` / `npx prettier --check` on the changed file — clean.
- `npx vitest run src/test-kernel/progressView` — 31 files, 156 tests, all pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only: error-logging module/context strings are unchanged; handler behavior is untouched.
> 
> **Overview**
> **`ProgressEventRegistration`** now treats **`module`** and **`context`** as optional, with JSDoc describing defaults (`ProgressEvents` and ``failed to handle ${event}``).
> 
> **`createEventRegistrations()`** drops the repeated **`module: 'ProgressEvents'`** and per-event **`context`** strings from the standard progress handlers; those entries only define **`handle`**. **`UIEvents`** registrations (retry, permissions, proposals, etc.) still set **`module`** and **`context`** explicitly where the message does not match the event name.
> 
> **`handleProgressEvent`** is the single place that applies **`registration.module ?? 'ProgressEvents'`** and **`registration.context ?? \`failed to handle ${event}\``** before **`withEventErrorHandling`** — same strings as before, less registry boilerplate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 773445458532da0b1310b2d71a7f4d929040ff1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->