### PR TITLE
refactor(agent): dedup follow-up-consumed and waiting-result guards in executeAgent

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -111,6 +111,33 @@ function createUsageRecordingCallback(
   };
 }
 
+/** Notify the progress view of a consumed follow-up, then run the caller's own callback. */
+function wrapOnFollowUpConsumed(
+  ctx: AgentLaunchContext,
+  onFollowUpConsumed?: () => void,
+): () => void {
+  return () => {
+    emitRuntimeEvent('updateQueuedFollowUps', { streamId: ctx.streamId });
+    onFollowUpConsumed?.();
+  };
+}
+
+/**
+ * Guard against a non-terminal WAITING result escaping to a caller that
+ * didn't opt into it via `allowWaitingResult`.
+ */
+function assertAllowedWaitingResult(
+  result: AgentRuntimeFlowResult,
+  allowWaitingResult: boolean | undefined,
+  callerName: string,
+): void {
+  if (isWaitingFlowResult(result) && allowWaitingResult !== true) {
+    throw new Error(
+      `${callerName} received a non-terminal WAITING result without allowWaitingResult.`,
+    );
+  }
+}
+
 /**
  * Run the tool-use flow for a single agent execution.
  *
@@ -147,12 +174,10 @@ async function runToolUseAgent(
           }
           options.onProgress?.(update);
         },
-        onFollowUpConsumed: () => {
-          emitRuntimeEvent('updateQueuedFollowUps', {
-            streamId: ctx.streamId,
-          });
-          options.onFollowUpConsumed?.();
-        },
+        onFollowUpConsumed: wrapOnFollowUpConsumed(
+          ctx,
+          options.onFollowUpConsumed,
+        ),
         onModelChanged: (modelHandler) => {
           // The tool-use flow already wrote services.config.model
           // (=== ctx.config.model, same object), so the live model is updated
@@ -393,11 +418,11 @@ export async function executeAgent(
         onRun: options.onRun,
       },
     );
-    if (isWaitingFlowResult(result) && options.allowWaitingResult !== true) {
-      throw new Error(
-        'executeAgent received a non-terminal WAITING result without allowWaitingResult.',
-      );
-    }
+    assertAllowedWaitingResult(
+      result,
+      options.allowWaitingResult,
+      'executeAgent',
+    );
     return result;
   });
 }
@@ -485,12 +510,10 @@ export async function resumeToolUseFromSnapshot(
             isSubagent,
             onBeforeWaiting: options.onBeforeWaiting,
             onProgress: options.onProgress,
-            onFollowUpConsumed: () => {
-              emitRuntimeEvent('updateQueuedFollowUps', {
-                streamId: ctx.streamId,
-              });
-              options.onFollowUpConsumed?.();
-            },
+            onFollowUpConsumed: wrapOnFollowUpConsumed(
+              ctx,
+              options.onFollowUpConsumed,
+            ),
           },
           undefined,
           (flowContext) => {
@@ -514,11 +537,11 @@ export async function resumeToolUseFromSnapshot(
         onRun: options.onRun,
       },
     );
-    if (isWaitingFlowResult(result) && options.allowWaitingResult !== true) {
-      throw new Error(
-        'resumeToolUseFromSnapshot received a non-terminal WAITING result without allowWaitingResult.',
-      );
-    }
+    assertAllowedWaitingResult(
+      result,
+      options.allowWaitingResult,
+      'resumeToolUseFromSnapshot',
+    );
     return result;
   });
 }

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -111,7 +111,6 @@ function createUsageRecordingCallback(
   };
 }
 
-/** Notify the progress view of a consumed follow-up, then run the caller's own callback. */
 function wrapOnFollowUpConsumed(
   ctx: AgentLaunchContext,
   onFollowUpConsumed?: () => void,
@@ -122,10 +121,6 @@ function wrapOnFollowUpConsumed(
   };
 }
 
-/**
- * Guard against a non-terminal WAITING result escaping to a caller that
- * didn't opt into it via `allowWaitingResult`.
- */
 function assertAllowedWaitingResult(
   result: AgentRuntimeFlowResult,
   allowWaitingResult: boolean | undefined,


### PR DESCRIPTION
## Summary

`executeAgent` and `resumeToolUseFromSnapshot` (`src/agent/runtime/executeAgent.ts`) each hand-rolled the same `onFollowUpConsumed` closure and the same non-terminal-WAITING-result guard, differing only in the caller name interpolated into the guard's error message. Extracted both into named helpers so the two call sites can't drift.

## Issue acceptance gates

Found via a code-quality scan across the repo (asked to identify and fix the largest ad-hoc/messy areas). This scopes down the scan's "executeAgent vs resumeToolUseFromSnapshot are near-duplicate orchestrators" finding to what's safely extractable.

**Note on scope:** the scan also flagged the larger session/interrupt/persistence harness shared between `runToolUseFlow` and `runReflectionFlow` as duplicated (~90-130 LOC). I read both in full and decided not to touch it: they use different `PersistedFlow` subclasses (`PersistedFlow` vs `RoundPersistedFlow`), different interrupt-context shapes (`ToolUseFlowContext` has model-switching methods; reflection's `IInterruptible` is a bare `interrupt()`), and their terminal-record-preservation rules differ deliberately (tool-use can end in `WAITING` for subagent delegation; reflection always drives to a terminal round outcome — not accidental drift). Forcing a shared harness there would risk destabilizing the two most critical execution loops in the product for a save that's smaller than it first looks once the genuine domain differences are accounted for. This PR only touches the two closures that were byte-for-byte duplicates within the same file.

## Single source of truth

`wrapOnFollowUpConsumed` and `assertAllowedWaitingResult` in `executeAgent.ts` now own the "notify progress view of consumed follow-up" and "guard against an un-opted-in WAITING result" rules respectively, instead of each of the two call sites re-deriving them by hand (with the error message's caller name as the only intentional variance).

## Duplication and abstraction budget

Both helpers have exactly 2 real callers (`runToolUseAgent` / `resumeToolUseFromSnapshot` for the follow-up wrapper; `executeAgent` / `resumeToolUseFromSnapshot` for the guard) and compose existing primitives (`emitRuntimeEvent`, `isWaitingFlowResult`) with real logic, not a single-caller extraction or identity wrapper. Net LOC is roughly flat (+45/-22, mostly JSDoc) — the value here is removing a place where the error message text could silently drift between the two callers, not raw line count.

## Host impact

Extension: no behavior change.
Desktop: no behavior change.
CLI: no behavior change.

## Scheduled refactoring

None. See the scope note above for why the larger flow-runner harness was left untouched.

## Validation

- `npx tsc --noEmit` — passes.
- `npx eslint` / `npx prettier --check` on the changed file — clean.
- `npx vitest run` on `DesktopAgentExecution`, `resumeToolUseSnapshot`, `DelegationHeadless`, `SetupAssistantRouting` (the suites exercising `executeAgent`/`resumeToolUseFromSnapshot`) — 4 files, 82 tests, all pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_015z2DT8qDHGnayEmNaUb1Nb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only within executeAgent orchestration; behavior and error messages are preserved with no auth, persistence, or flow-loop changes.
> 
> **Overview**
> Pulls two duplicated patterns out of `executeAgent.ts` into shared helpers so `executeAgent`, `runToolUseAgent`, and `resumeToolUseFromSnapshot` stay aligned.
> 
> **`wrapOnFollowUpConsumed`** centralizes the follow-up callback: emit `updateQueuedFollowUps` for the stream, then invoke the caller’s optional hook. Both tool-use entry paths now pass this helper instead of inline closures.
> 
> **`assertAllowedWaitingResult`** centralizes the rule that a non-terminal `WAITING` flow result must only be returned when `allowWaitingResult` is true; the caller name is passed in for the error message (`executeAgent` vs `resumeToolUseFromSnapshot`).
> 
> No runtime behavior change—same events, same throws, same option wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc4c49406d0a3c556c7d7c63829e7f20d105966b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->