### PR TITLE
refactor: move extension shutdown signal to app signals

### DIFF
--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -291,7 +291,7 @@ export async function activate(context: vscode.ExtensionContext) {
     SharedIssuePollingSource.disposeAll(),
   );
   lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () =>
-    ProgressEventBus.emit('extensionDeactivating', undefined),
+    appSignals.emit('extensionDeactivating', undefined),
   );
   lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => disposeDiffRefresh());
   await StorageFS.ensureDir(RUNS_STORAGE_DIR);

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -17,6 +17,7 @@ import {
   setActiveSidebarView,
 } from '@common/webview';
 import { workspaceSM } from '@common/state';
+import { appSignals } from '@eventBus/AppSignals';
 import { ProgressEventBus } from '@eventBus/ProgressEventBus';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { VscodePromptHost } from '@frontend/hosts/VscodePromptHost';
@@ -54,6 +55,7 @@ import {
 
 import { ProgressViewMessageHandler } from './ProgressViewMessageHandler';
 import { createExtensionHostInteractions } from './extensionHostInteractions';
+import { attachProgressBackendAppSignals } from './progressBackendAppSignals';
 import { attachProgressBackendProcessBus } from './progressBackendProcessBus';
 
 import type { MainViewProvider } from '../MainViewProvider';
@@ -200,6 +202,7 @@ export class ProgressViewProvider
     await this.backend.load();
     this._disposables.push(
       this.backend.setupEventListeners(),
+      attachProgressBackendAppSignals(this.backend, appSignals),
       attachProgressBackendProcessBus(this.backend, ProgressEventBus),
     );
     this.logger.debug('ProgressViewProvider initialized');

--- a/packages/extension/src/progressView/progressBackendAppSignals.ts
+++ b/packages/extension/src/progressView/progressBackendAppSignals.ts
@@ -1,0 +1,18 @@
+import type { AppSignalsLike } from '@eventBus/AppSignals';
+import type { ProgressBackend } from '@shared/progressView/backend/ProgressBackend';
+import type { ProgressEventSubscription } from '@shared/progressView/backend/events/ProgressEventHandler';
+
+/**
+ * Attach extension app-lifecycle signals to the shared progress backend.
+ * This adapter keeps app-scoped shutdown facts out of the progress event bus.
+ */
+export function attachProgressBackendAppSignals(
+  backend: Pick<ProgressBackend, 'eventHandler'>,
+  signals: AppSignalsLike,
+): ProgressEventSubscription {
+  const dispose = signals.on('extensionDeactivating', () => {
+    backend.eventHandler.markAllRunningTasksAsCancelled();
+  });
+
+  return { dispose };
+}

--- a/src/eventBus/AppSignals.ts
+++ b/src/eventBus/AppSignals.ts
@@ -1,6 +1,9 @@
 import { EventEmitter } from 'node:events';
 
 export interface AppSignalPayloads {
+  /** The VS Code extension is shutting down. */
+  extensionDeactivating: undefined;
+
   /**
    * GitHub rejected the configured token. Frontends can surface the failure
    * and direct the user to token settings.

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -215,9 +215,6 @@ export interface ProgressEventPayloads {
    *  back to the UI. */
   goalStateChanged: { streamId: StreamTabId };
 
-  // ── App/session lifecycle + integration signals ──
-  extensionDeactivating: undefined;
-
   // ── Frontend-bound events ──
   // Emitted by agent core/runtime; consumed by frontend listeners.
   // Keeps @agent/ free of @frontend/ imports.

--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -217,11 +217,6 @@ export class ProgressEventHandler {
           }
         },
       },
-      extensionDeactivating: {
-        module: 'ProgressEvents',
-        context: 'failed to handle extensionDeactivating',
-        handle: () => this.markAllRunningTasksAsCancelled(),
-      },
       // Output events — workflow tabs hold one run; ignore the storageKey dim.
       addOutputFiles: {
         module: 'ProgressEvents',
@@ -710,7 +705,7 @@ export class ProgressEventHandler {
     };
   }
 
-  private markAllRunningTasksAsCancelled(): void {
+  public markAllRunningTasksAsCancelled(): void {
     for (const [stream, status] of this.state.streamStatus.entries()) {
       if (status === STREAM_PHASE.RUNNING) {
         this.state.streamStatus.transition(

--- a/src/test-kernel/progressView/ProgressBackendAppSignals.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendAppSignals.vitest.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { STREAM_TRANSITION_CAUSE } from '@common/constants/streamStatus';
+import type {
+  AppSignal,
+  AppSignalPayloads,
+  AppSignalsLike,
+} from '@eventBus/AppSignals';
+import { attachProgressBackendAppSignals } from '@progressView/progressBackendAppSignals';
+import {
+  STREAM_PHASE,
+  type StreamPhase,
+  type StreamTabId,
+} from '@shared/schemas';
+import {
+  ProgressBackend,
+  type ProgressBackendUiConfig,
+} from '@shared/progressView/backend/ProgressBackend';
+import type { MementoStorage } from '@shared/progressView/backend/persistence/PersistentMapManager';
+
+class MemoryMementoStorage implements MementoStorage {
+  private readonly values = new Map<string, unknown>();
+
+  get<T>(key: string): T | undefined;
+  get<T>(key: string, defaultValue: T): T;
+  get<T>(key: string, defaultValue?: T): T | undefined {
+    return this.values.has(key) ? (this.values.get(key) as T) : defaultValue;
+  }
+
+  async update<T>(key: string, value: T | undefined): Promise<void> {
+    if (value === undefined) {
+      this.values.delete(key);
+      return;
+    }
+    this.values.set(key, value);
+  }
+}
+
+class MemoryAppSignals implements AppSignalsLike {
+  private readonly listeners = new Map<
+    AppSignal,
+    Set<(payload: AppSignalPayloads[AppSignal]) => void>
+  >();
+
+  on<K extends AppSignal>(
+    event: K,
+    listener: (payload: AppSignalPayloads[K]) => void,
+    options?: { signal?: AbortSignal },
+  ): () => void {
+    if (options?.signal?.aborted) return () => {};
+    let listeners = this.listeners.get(event);
+    if (!listeners) {
+      listeners = new Set();
+      this.listeners.set(event, listeners);
+    }
+    listeners.add(listener as (payload: AppSignalPayloads[AppSignal]) => void);
+    const cleanup = (): void => {
+      listeners?.delete(
+        listener as (payload: AppSignalPayloads[AppSignal]) => void,
+      );
+    };
+    options?.signal?.addEventListener('abort', cleanup, { once: true });
+    return cleanup;
+  }
+
+  emit<K extends AppSignal>(event: K, payload: AppSignalPayloads[K]): void {
+    for (const listener of this.listeners.get(event) ?? []) {
+      listener(payload);
+    }
+  }
+}
+
+function createUiConfig(): ProgressBackendUiConfig {
+  return {
+    callbacks: {
+      showRetryRequest: vi.fn(),
+      resolveRetryRequest: vi.fn(),
+      showToolEditPermission: vi.fn(),
+      resolveToolEditPermission: vi.fn(),
+      updateToolEditApprovalBypassState: vi.fn(),
+      updateSuperYoloBypassState: vi.fn(),
+      showBashPermission: vi.fn(),
+      resolveBashPermission: vi.fn(),
+      showAgentProposal: vi.fn(),
+      resolveAgentProposal: vi.fn(),
+      showPlanApproval: vi.fn(),
+      resolvePlanApproval: vi.fn(),
+      showExternalInquiry: vi.fn(),
+      resolveExternalInquiry: vi.fn(),
+      showUserQuestion: vi.fn(),
+      resolveUserQuestion: vi.fn(),
+    },
+    hasPendingPermissions: vi.fn(() => false),
+  };
+}
+
+function createBackend(): ProgressBackend {
+  return new ProgressBackend({
+    storage: new MemoryMementoStorage(),
+    sendMessage: () => true,
+    hasTarget: () => true,
+    configureUi: () => createUiConfig(),
+  });
+}
+
+function setStatus(
+  backend: ProgressBackend,
+  streamId: StreamTabId,
+  status: StreamPhase,
+): void {
+  const becameRunning = backend.state.streamStatus.transition(
+    streamId,
+    STREAM_PHASE.RUNNING,
+    STREAM_TRANSITION_CAUSE.LIFECYCLE,
+  );
+  if (!becameRunning || status === STREAM_PHASE.RUNNING) return;
+
+  backend.state.streamStatus.transition(
+    streamId,
+    status,
+    STREAM_TRANSITION_CAUSE.LIFECYCLE,
+  );
+}
+
+describe('attachProgressBackendAppSignals', () => {
+  it('marks running progress tasks cancelled on extension deactivation', () => {
+    const backend = createBackend();
+    const signals = new MemoryAppSignals();
+    const backendSubscription = backend.setupEventListeners();
+    const appSignalSubscription = attachProgressBackendAppSignals(
+      backend,
+      signals,
+    );
+    const running = 'appsignals:running' as StreamTabId;
+    const complete = 'appsignals:complete' as StreamTabId;
+
+    try {
+      setStatus(backend, running, STREAM_PHASE.RUNNING);
+      setStatus(backend, complete, STREAM_PHASE.COMPLETED);
+
+      signals.emit('extensionDeactivating', undefined);
+
+      expect(backend.state.streamStatus.get(running)).toBe(
+        STREAM_PHASE.CANCELLED,
+      );
+      expect(backend.state.streamStatus.get(complete)).toBe(
+        STREAM_PHASE.COMPLETED,
+      );
+    } finally {
+      appSignalSubscription.dispose();
+      backendSubscription.dispose();
+      backend.dispose();
+    }
+  });
+
+  it('detaches the app-signal listener cleanly', () => {
+    const backend = createBackend();
+    const signals = new MemoryAppSignals();
+    const backendSubscription = backend.setupEventListeners();
+    const appSignalSubscription = attachProgressBackendAppSignals(
+      backend,
+      signals,
+    );
+    const running = 'appsignals:disposed' as StreamTabId;
+
+    try {
+      setStatus(backend, running, STREAM_PHASE.RUNNING);
+      appSignalSubscription.dispose();
+
+      signals.emit('extensionDeactivating', undefined);
+
+      expect(backend.state.streamStatus.get(running)).toBe(
+        STREAM_PHASE.RUNNING,
+      );
+    } finally {
+      appSignalSubscription.dispose();
+      backendSubscription.dispose();
+      backend.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Move `extensionDeactivating` from `ProgressEventBus` to `AppSignals`.
- Emit extension shutdown through `appSignals`.
- Add the extension-boundary adapter `attachProgressBackendAppSignals` to connect shutdown to the progress backend.
- Expose `ProgressEventHandler.markAllRunningTasksAsCancelled()` as the explicit backend effect.
- Leave the broad `emitRuntimeEvent` fallback unchanged for the later bus-deletion slice.

Part of #6968 and #6951.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/progressView/ProgressBackendAppSignals.vitest.ts src/test-kernel/progressView/ProgressBackendProcessBus.vitest.ts src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `corepack pnpm exec eslint src/eventBus/AppSignals.ts src/eventBus/ProgressEventBus.ts packages/extension/src/extension.ts packages/extension/src/progressView/ProgressViewProvider.ts packages/extension/src/progressView/progressBackendAppSignals.ts src/shared/progressView/backend/events/ProgressEventHandler.ts src/test-kernel/progressView/ProgressBackendAppSignals.vitest.ts`
- `corepack pnpm run typecheck`
- `corepack pnpm run compile:fast`
- `corepack pnpm test` — 623 files passed, 1 skipped; 4996 tests passed, 4 skipped.
- `corepack pnpm run lint` — 0 errors, 3 pre-existing import-order warnings.

## Grep

- `extensionDeactivating` is no longer present on `ProgressEventBus`.
- Remaining references are the `AppSignals` key, extension emission point, progress-backend adapter, and adapter test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving wiring change with targeted tests; shutdown still only updates in-memory stream status, not auth or persistence.
> 
> **Overview**
> **Extension shutdown** is no longer modeled on `ProgressEventBus`. The lifecycle hook in `extension.ts` now emits **`extensionDeactivating`** on **`appSignals`**, and that key lives on **`AppSignalPayloads`** instead of progress bus payloads.
> 
> The progress backend picks up shutdown through a new extension adapter, **`attachProgressBackendAppSignals`**, registered alongside the existing process-bus wiring in **`ProgressViewProvider.initialize`**. On deactivation it calls **`ProgressEventHandler.markAllRunningTasksAsCancelled()`** (now **public**), so streams still in **`RUNNING`** transition to **`CANCELLED`** without touching the progress event bus.
> 
> **`ProgressEventHandler`** drops the **`extensionDeactivating`** bus registration; run/stream events stay on **`ProgressEventBus`**. Vitest coverage asserts cancel-on-shutdown and clean listener disposal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e6913fbc85f924a543b6232d762524eea992b9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->