### PR TITLE
fix(desktop): remove redundant cancelForStream call, fix stale test expectations

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1062,13 +1062,10 @@ export class DesktopProgressBridge {
     this.progressEvents.onStreamDeleted(streamId);
 
     // Releases approval state (pending approvals, bypass flags, coordinator
-    // requests) and the follow-up queue for this stream.
+    // requests) and the follow-up queue for this stream. cleanupApprovalsForStream
+    // already cancels DesktopHostInteractions' own pendingRequests map (#7333),
+    // so a pending bash/plan/proposal/user-question approval is settled here too.
     releaseStreamResources(streamId, this.session);
-    // releaseStreamResources only settles the legacy approval registries;
-    // DesktopHostInteractions keeps its own pendingRequests map (bash/plan/
-    // proposal/user-question) that only this cancels, so a pending approval
-    // wouldn't otherwise be settled and the awaiting tool call would hang.
-    this.session.interactions.cancelForStream(streamId, 'Stream deleted.');
 
     this.releaseApprovalsForStream(streamId);
     this.workflowFileActions.clearStreamBackups(streamId);
@@ -1094,12 +1091,6 @@ export class DesktopProgressBridge {
     for (const streamId of streamIds) {
       this.deletedStreams.add(streamId);
       releaseStreamResources(streamId, this.session);
-      // See the matching comment in deleteStream: DesktopHostInteractions'
-      // pendingRequests map is not covered by releaseStreamResources.
-      this.session.interactions.cancelForStream(
-        streamId,
-        'All streams deleted.',
-      );
     }
     // Catch pending approvals with no concrete stream context (undefined or
     // empty streamId) — the per-stream loop skips them because they do not

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -2036,10 +2036,12 @@ describe('DesktopProgressBridge', () => {
 
       // Before the fix, this promise never settled: releaseStreamResources
       // only cleared the legacy approval registries, not
-      // DesktopHostInteractions' own pendingRequests map.
+      // DesktopHostInteractions' own pendingRequests map. #7333 closed that
+      // gap generically (cleanupApprovalsForStream cancels every pending
+      // interaction kind for the stream), hence the shared message.
       await expect(result).resolves.toEqual({
         action: 'reject',
-        feedback: 'Stream deleted.',
+        feedback: 'Stream resources released.',
       });
       expect(
         progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION),
@@ -2273,10 +2275,12 @@ describe('DesktopProgressBridge', () => {
 
       // Before the fix, this promise never settled: releaseStreamResources
       // only cleared the legacy approval registries, not
-      // DesktopHostInteractions' own pendingRequests map.
+      // DesktopHostInteractions' own pendingRequests map. #7333 closed that
+      // gap generically (cleanupApprovalsForStream cancels every pending
+      // interaction kind for the stream), hence the shared message.
       await expect(result).resolves.toEqual({
         accepted: false,
-        userMessage: 'All streams deleted.',
+        userMessage: 'Stream resources released.',
       });
     } finally {
       bridge.dispose();


### PR DESCRIPTION
## Summary

Currently broken on main: 2 tests in `DesktopAgentExecution.vitest.mts` fail.

## Root cause

#7318 added its own explicit `session.interactions.cancelForStream(streamId, 'Stream deleted.')` / `'All streams deleted.'` calls in `deleteStream`/`deleteAllStreams`, unaware that #7333 (merged earlier, on a different base commit) had already closed the exact same gap generically: `cleanupApprovalsForStream` (called via `releaseStreamResources`, which runs *before* #7318's own call) already cancels `DesktopHostInteractions`' own `pendingRequests` map for every interaction kind, with the message `'Stream resources released.'`.

Since `releaseStreamResources` runs first, its generic `cancelForStream` call always wins — #7318's own calls became dead code producing a message that can never actually reach the caller. Two independently-correct-at-merge-time PRs, but the combination shipped dead code plus 2 tests asserting an unreachable message.

## Fix

- Deleted the redundant `cancelForStream` calls in `deleteStream`/`deleteAllStreams` (and their now-inaccurate comments).
- Updated the 2 test assertions to expect the message that's actually produced (`'Stream resources released.'`).
- No behavior change — the underlying bug both PRs were independently fixing (a pending approval hanging after stream deletion) was already fixed by #7333; #7318's contribution was fully subsumed.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean
- `npx prettier --check` — clean
- `npx vitest run src/test-kernel/desktop/DesktopAgentExecution.vitest.mts` — 57/57 passing (was 55/57 before this fix)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime behavior change—only removes unreachable code and fixes test expectations.
> 
> **Overview**
> Removes duplicate `session.interactions.cancelForStream` calls from **`deleteStream`** and **`deleteAllStreams`**. **`releaseStreamResources`** (via #7333’s `cleanupApprovalsForStream`) already cancels pending `DesktopHostInteractions` approvals with **`'Stream resources released.'`**, so the extra calls were dead code and made two kernel tests fail on unreachable rejection messages.
> 
> Comments now document that generic cleanup covers bash/plan/proposal/user-question pending requests. Two **`DesktopAgentExecution`** tests were updated to expect the message that callers actually receive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ded3639723dea6174b70e02ca2807527eb42454. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->