### PR TITLE
refactor: bound runtime event emission to session facts

### DIFF
--- a/src/agent/runtime/SessionEventHub.ts
+++ b/src/agent/runtime/SessionEventHub.ts
@@ -5,12 +5,6 @@ import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import { createChannelTrace } from '@logger';
 import type { StreamTabId } from '@shared/schemas';
 
-import {
-  emitProjectedProgressEvent,
-  projectSessionFactToProgressEvent,
-} from './sessionProgressEventProjection';
-import type { AgentRuntimeHost } from './AgentRuntimeHost';
-
 const logger = createChannelTrace('SessionEventHub');
 
 export type SessionFact =
@@ -38,18 +32,6 @@ export type SessionFact =
 export type SessionEvent =
   | { scope: 'run'; streamId: StreamTabId; event: AgentEvent }
   | { scope: 'session'; event: SessionFact };
-
-/**
- * Re-emit a {@link SessionFact} on the legacy per-host progress-event
- * surface. This keeps host-channel callers on the same neutral projection as
- * any host-owned hub subscription.
- */
-export function emitLegacySessionFactOnHost(
-  host: AgentRuntimeHost,
-  fact: SessionFact,
-): void {
-  emitProjectedProgressEvent(host, projectSessionFactToProgressEvent(fact));
-}
 
 export interface SessionEventSubscriptionFilter {
   readonly scope?: SessionEvent['scope'];

--- a/src/agent/runtime/emitRuntimeEvent.ts
+++ b/src/agent/runtime/emitRuntimeEvent.ts
@@ -1,35 +1,32 @@
 /**
- * Single emit path for run/host progress events (SDK Step 7d follow-on F-1).
+ * Single emit path for session-scoped runtime facts.
  *
- * Replaces scattered `ProgressEventBus.emit(...)` in `src/tools` so one fact
- * has one emit path and one name, resolving the target in priority order:
+ * Replaces scattered `ProgressEventBus.emit(...)` in `src/tools` so one
+ * session fact has one emit path and one name, resolving the target in priority
+ * order:
  *
- * 1. migrated Stage 3a facts go to the owning `SessionEventHub`, where
- *    host-owned subscribers can project them with `sessionProgressEventProjection`;
- * 2. a host-path caller's `session.hostChannel` (set only by hosts that own a
- *    non-default session, e.g. a desktop window) — when present;
- * 3. otherwise the active run's `runtimeHost`, resolved from the ambient
- *    {@link RunContext} (the in-run case — tools firing inside a run's ALS);
- * 4. otherwise the process {@link ProgressEventBus} — the single-session
- *    fallback that keeps the extension byte-identical (its run
- *    `runtimeHost.emit` is `ProgressEventBus.emit` anyway) and host-path
- *    callers that pass no session unchanged.
+ * 1. a host-path caller's explicit `session`;
+ * 2. the active run's `RunContext.session`;
+ * 3. the process default session used by the VS Code extension and CLI.
  *
- * In-run callers pass no `session` (the ALS supplies the run host). Host-path
- * callers — reachable outside any run ALS — MUST pass their owning `session`,
- * or the event resolves to the bus and a non-default session never sees it.
+ * Host/RPC events should use the owning `AgentRuntimeHost.emit` directly. This
+ * helper deliberately has no broad process-bus fallback.
  */
-import {
-  ProgressEventBus,
-  type ProgressEventPayloads,
-} from '@eventBus/ProgressEventBus';
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
 import { tryUseRunContext } from './RunContext';
 import { defaultSession, type SessionHandle } from './SessionHandle';
-import {
-  emitLegacySessionFactOnHost,
-  type SessionFact,
-} from './SessionEventHub';
+import type { SessionFact } from './SessionEventHub';
+
+type RuntimeSessionEventPayloads = {
+  goalStateChanged: ProgressEventPayloads['goalStateChanged'];
+  inquiryThreadUpdated: ProgressEventPayloads['inquiryThreadUpdated'];
+  clearMissingOutputs: ProgressEventPayloads['clearMissingOutputs'];
+  updateQueuedFollowUps: ProgressEventPayloads['updateQueuedFollowUps'];
+  setActiveStream: ProgressEventPayloads['setActiveStream'];
+};
+
+type RuntimeSessionEvent = keyof RuntimeSessionEventPayloads;
 
 function emitSessionFact(fact: SessionFact, session?: SessionHandle): void {
   const owner = session ?? tryUseRunContext()?.session;
@@ -37,16 +34,12 @@ function emitSessionFact(fact: SessionFact, session?: SessionHandle): void {
     owner.events.emit({ scope: 'session', event: fact });
     return;
   }
-  if (owner?.hostChannel) {
-    emitLegacySessionFactOnHost(owner.hostChannel, fact);
-    return;
-  }
   defaultSession().events.emit({ scope: 'session', event: fact });
 }
 
-export function emitRuntimeEvent<K extends keyof ProgressEventPayloads>(
+export function emitRuntimeEvent<K extends RuntimeSessionEvent>(
   event: K,
-  payload: ProgressEventPayloads[K],
+  payload: RuntimeSessionEventPayloads[K],
   session?: SessionHandle,
 ): void {
   switch (event) {
@@ -96,8 +89,7 @@ export function emitRuntimeEvent<K extends keyof ProgressEventPayloads>(
       );
       return;
   }
-
-  const host = session?.hostChannel ?? tryUseRunContext()?.runtimeHost;
-  if (host) host.emit(event, payload);
-  else ProgressEventBus.emit(event, payload);
+  throw new Error(
+    `emitRuntimeEvent only supports session facts; use the owning runtime host for ${String(event)}`,
+  );
 }

--- a/src/test-kernel/agent/runtime/EmitRuntimeEvent.vitest.ts
+++ b/src/test-kernel/agent/runtime/EmitRuntimeEvent.vitest.ts
@@ -8,6 +8,7 @@ import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import { ProgressEventBus } from '@eventBus/ProgressEventBus';
 import type { StreamTabId } from '@shared/schemas';
 
+import { attachSessionProgressEventProjectionForTest } from '../sessionProgressTestUtils';
 import { createRecordingHost } from '../progressTestUtils';
 
 const streamId = (s: string): StreamTabId => s as StreamTabId;
@@ -39,22 +40,70 @@ describe('emitRuntimeEvent (SDK Step 7d F-1 — one emit path)', () => {
     }
   });
 
-  it("keeps non-migrated events on the active run's runtimeHost", () => {
+  it("routes in-run facts through the active run's session", () => {
     const run = createRecordingHost();
+    const session = new SessionHandle();
+    const detachProjection = attachSessionProgressEventProjectionForTest(
+      session.events,
+      run.host,
+    );
+    const busSeen: unknown[] = [];
+    const off = ProgressEventBus.on('updateQueuedFollowUps', (p) =>
+      busSeen.push(p),
+    );
+    try {
+      withRunContext(
+        createRunContext({
+          runtimeHost: run.host,
+          session,
+        }),
+        () => {
+          emitRuntimeEvent('updateQueuedFollowUps', {
+            streamId: streamId('s:run'),
+          });
+        },
+      );
+      expect(run.events).toEqual([
+        {
+          event: 'updateQueuedFollowUps',
+          payload: { streamId: 's:run' },
+        },
+      ]);
+      expect(busSeen).toEqual([]);
+    } finally {
+      off();
+      detachProjection();
+      session.dispose();
+    }
+  });
+
+  it('rejects non-session events instead of falling back to the process bus', () => {
     const busSeen: unknown[] = [];
     const off = ProgressEventBus.on('requestShowError', (p) => busSeen.push(p));
     try {
-      withRunContext(createRunContext({ runtimeHost: run.host }), () => {
+      expect(() => {
+        // @ts-expect-error requestShowError is host interaction, not a session fact.
         emitRuntimeEvent('requestShowError', { message: 'run error' });
-      });
-      expect(run.events).toEqual([
-        { event: 'requestShowError', payload: { message: 'run error' } },
-      ]);
-      // Not double-emitted onto the bus.
+      }).toThrow(
+        'emitRuntimeEvent only supports session facts; use the owning runtime host for requestShowError',
+      );
       expect(busSeen).toEqual([]);
     } finally {
       off();
     }
+  });
+
+  it('rejects non-session events instead of using the active run host', () => {
+    const run = createRecordingHost();
+    withRunContext(createRunContext({ runtimeHost: run.host }), () => {
+      expect(() => {
+        // @ts-expect-error requestShowError is host interaction, not a session fact.
+        emitRuntimeEvent('requestShowError', { message: 'run error' });
+      }).toThrow(
+        'emitRuntimeEvent only supports session facts; use the owning runtime host for requestShowError',
+      );
+    });
+    expect(run.events).toEqual([]);
   });
 
   it('prefers an explicit session event hub over the run context and bus for migrated facts', () => {

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -676,22 +676,15 @@ describe('DesktopProgressBridge', () => {
     const bridge = (await createBridge(messages, {
       streamSnapshotStore,
     })) as BridgeWithSession;
-    const { emitRuntimeEvent } =
-      await import('@agent/runtime/emitRuntimeEvent');
-    const session = bridge.session as unknown as Parameters<
-      typeof emitRuntimeEvent
-    >[2];
+    const { hostChannel } = bridge.session;
+    expect(hostChannel).toBeDefined();
 
     try {
-      emitRuntimeEvent(
-        'setTaskState',
-        {
-          streamId: 'desktop-host-stream',
-          executionId: 'de57e0',
-          taskState: TaskStateSchema.parse(workflowTaskState()),
-        },
-        session,
-      );
+      hostChannel?.emit('setTaskState', {
+        streamId: 'desktop-host-stream',
+        executionId: 'de57e0',
+        taskState: TaskStateSchema.parse(workflowTaskState()),
+      });
 
       await vi.waitFor(() => {
         expect(streamSnapshotStore.upsert).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

- Narrow `emitRuntimeEvent` to the explicit session-fact API only: `goalStateChanged`, `inquiryThreadUpdated`, `clearMissingOutputs`, `updateQueuedFollowUps`, and `setActiveStream`.
- Remove the broad fallback from `emitRuntimeEvent` to `ProgressEventBus.emit`.
- Delete the now-unused `emitLegacySessionFactOnHost` helper.
- Update runtime-event tests with type-level and runtime rejection coverage for host/RPC events.
- Update the desktop host-channel test to emit `setTaskState` through the owning desktop session host channel instead of the session-fact helper.

Part of #6968 and #6951.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/agent/runtime/EmitRuntimeEvent.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts` — 62 tests passed.
- `corepack pnpm exec eslint src/agent/runtime/emitRuntimeEvent.ts src/agent/runtime/SessionEventHub.ts src/test-kernel/agent/runtime/EmitRuntimeEvent.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `corepack pnpm run typecheck`
- `corepack pnpm run compile:fast`
- `corepack pnpm test` — 623 files passed, 1 skipped; 4998 tests passed, 4 skipped.
- `corepack pnpm run lint` — 0 errors, 3 pre-existing import-order warnings.

## Boundary Check

Production `emitRuntimeEvent(...)` callers are now limited to the five session facts. Host interaction/RPC and frontend-presentation events must use their owning `AgentRuntimeHost.emit` path rather than a process-bus fallback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes central runtime event routing boundaries; misrouted host events now throw instead of silently hitting the process bus, which is intentional but affects any uncaught misuse.
> 
> **Overview**
> **`emitRuntimeEvent` is now a session-fact-only API** for the five migrated facts (`goalStateChanged`, `inquiryThreadUpdated`, `clearMissingOutputs`, `updateQueuedFollowUps`, `setActiveStream`). It always publishes through `SessionEventHub` (explicit session → run context session → default session) and no longer falls back to `ProgressEventBus` or `session.hostChannel` legacy projection.
> 
> **Host/RPC and UI events must use `AgentRuntimeHost.emit` directly.** Unknown event names throw at runtime instead of being routed to the process bus or active run host.
> 
> **Cleanup:** `emitLegacySessionFactOnHost` and its imports from `SessionEventHub` are removed. Tests add rejection coverage for `requestShowError`; the desktop host-channel test emits `setTaskState` via `hostChannel.emit` instead of `emitRuntimeEvent`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c6393cc0a4182bf93320cf5cf3942620acf9f26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->