### PR TITLE
refactor: split extension presentation events from progress bus

### DIFF
--- a/packages/extension/src/frontend/agentRuntime/extensionAgentRuntimeHost.ts
+++ b/packages/extension/src/frontend/agentRuntime/extensionAgentRuntimeHost.ts
@@ -1,8 +1,23 @@
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { ProgressEventBus } from '@eventBus/ProgressEventBus';
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import {
+  extensionPresentationEvents,
+  type ExtensionPresentationEvent,
+  isExtensionPresentationEvent,
+} from '@frontend/events/extensionPresentationEvents';
 
 export const extensionAgentRuntimeHost: AgentRuntimeHost = {
   interactions: defaultSession().interactions,
-  emit: (event, payload) => ProgressEventBus.emit(event, payload),
+  emit: (event, payload) => {
+    if (isExtensionPresentationEvent(event)) {
+      extensionPresentationEvents.emit(
+        event,
+        payload as ProgressEventPayloads[ExtensionPresentationEvent],
+      );
+      return;
+    }
+    ProgressEventBus.emit(event, payload);
+  },
 };

--- a/packages/extension/src/frontend/events/agentEventListeners.ts
+++ b/packages/extension/src/frontend/events/agentEventListeners.ts
@@ -2,19 +2,16 @@
  * Frontend listeners for events emitted by agent core/runtime.
  *
  * These listeners bridge the gap between the agent layer (which must not
- * import from @frontend/) and the VS Code UI. The agent emits typed events
- * on the ProgressEventBus; this module subscribes and performs the actual
- * UI operations.
+ * import from @frontend/) and the VS Code UI. The extension runtime host
+ * routes presentation requests to the extension presentation channel; this
+ * module subscribes and performs the actual UI operations.
  */
 import * as vscode from 'vscode';
 
 import { getProgressViewBridge } from '@agent/runtime/ProgressViewBridge';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
-import {
-  ProgressEventBus,
-  INSTRUCTION_ACTION,
-} from '@eventBus/ProgressEventBus';
+import { INSTRUCTION_ACTION } from '@eventBus/ProgressEventBus';
 import type {
   InstructionAction,
   ProgressEventPayloads,
@@ -23,6 +20,7 @@ import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import { getMainWebview } from '@frontend/system/commandUtils';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
+import { extensionPresentationEvents } from '@frontend/events/extensionPresentationEvents';
 import * as logger from '@logger/logUtils';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -142,17 +140,23 @@ export function registerAgentEventListeners(): vscode.Disposable {
   const controller = new AbortController();
   const { signal } = controller;
 
-  ProgressEventBus.on('requestOpenFile', handleRequestOpenFile, { signal });
-  ProgressEventBus.on('requestShowInstruction', handleRequestShowInstruction, {
+  extensionPresentationEvents.on('requestOpenFile', handleRequestOpenFile, {
     signal,
   });
-  ProgressEventBus.on(
+  extensionPresentationEvents.on(
+    'requestShowInstruction',
+    handleRequestShowInstruction,
+    { signal },
+  );
+  extensionPresentationEvents.on(
     'showAgentConfigBanner',
     (payload) => void handleShowAgentConfigBanner(payload),
     { signal },
   );
-  ProgressEventBus.on('requestShowError', handleRequestShowError, { signal });
-  ProgressEventBus.on(
+  extensionPresentationEvents.on('requestShowError', handleRequestShowError, {
+    signal,
+  });
+  extensionPresentationEvents.on(
     'requestEnsureProgressView',
     (payload) => void handleRequestEnsureProgressView(payload),
     { signal },
@@ -160,9 +164,8 @@ export function registerAgentEventListeners(): vscode.Disposable {
 
   // Terminal-error toasts now come from the run's `result` event (the lifecycle
   // no longer emits them directly). The same shared helper every host uses
-  // re-emits `requestShow*` through `extensionAgentRuntimeHost` (=
-  // `ProgressEventBus.emit`), reaching the `ProgressEventBus.on` handlers
-  // registered above exactly once.
+  // re-emits `requestShow*` through `extensionAgentRuntimeHost`, reaching the
+  // extension presentation handlers registered above exactly once.
   const detachResult = attachTerminalResultToast(
     defaultSession(),
     extensionAgentRuntimeHost,

--- a/packages/extension/src/frontend/events/extensionPresentationEvents.ts
+++ b/packages/extension/src/frontend/events/extensionPresentationEvents.ts
@@ -1,0 +1,76 @@
+import { EventEmitter } from 'node:events';
+
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+
+export const EXTENSION_PRESENTATION_EVENTS = [
+  'requestOpenFile',
+  'requestShowInstruction',
+  'showAgentConfigBanner',
+  'requestShowError',
+  'requestEnsureProgressView',
+] as const satisfies readonly (keyof ProgressEventPayloads)[];
+
+export type ExtensionPresentationEvent =
+  (typeof EXTENSION_PRESENTATION_EVENTS)[number];
+
+const EVENT_SET = new Set<keyof ProgressEventPayloads>(
+  EXTENSION_PRESENTATION_EVENTS,
+);
+
+const MAX_BUFFER_SIZE = 1000;
+
+export function isExtensionPresentationEvent(
+  event: keyof ProgressEventPayloads,
+): event is ExtensionPresentationEvent {
+  return EVENT_SET.has(event);
+}
+
+class ExtensionPresentationEventBus {
+  private readonly emitter = new EventEmitter();
+  private buffer: {
+    event: ExtensionPresentationEvent;
+    payload: ProgressEventPayloads[ExtensionPresentationEvent];
+  }[] = [];
+
+  emit(
+    event: ExtensionPresentationEvent,
+    payload: ProgressEventPayloads[ExtensionPresentationEvent],
+  ): void {
+    if (this.emitter.listenerCount(event) === 0) {
+      this.buffer.push({ event, payload });
+      if (this.buffer.length > MAX_BUFFER_SIZE) {
+        this.buffer.shift();
+      }
+      return;
+    }
+    this.emitter.emit(event, payload);
+  }
+
+  on<K extends ExtensionPresentationEvent>(
+    event: K,
+    listener: (payload: ProgressEventPayloads[K]) => void,
+    options?: { signal?: AbortSignal },
+  ): () => void {
+    if (options?.signal?.aborted) return () => {};
+
+    this.emitter.on(event, listener);
+    const cleanup = (): void => {
+      this.emitter.off(event, listener);
+    };
+    options?.signal?.addEventListener('abort', cleanup, { once: true });
+
+    const remaining: typeof this.buffer = [];
+    for (const item of this.buffer) {
+      if (item.event === event) {
+        listener(item.payload as ProgressEventPayloads[K]);
+      } else {
+        remaining.push(item);
+      }
+    }
+    this.buffer = remaining;
+
+    return cleanup;
+  }
+}
+
+export const extensionPresentationEvents = new ExtensionPresentationEventBus();

--- a/src/agent/runtime/terminalResultToast.ts
+++ b/src/agent/runtime/terminalResultToast.ts
@@ -8,10 +8,9 @@
  * The `session` is load-bearing: desktop passes its per-window session, while
  * CLI/extension pass the process {@link defaultSession}. A helper that
  * hard-coded the default would route desktop to the wrong session and never see
- * its results. Every host presents through its `runtimeHost` — including the
- * extension, whose `extensionAgentRuntimeHost.emit` is `ProgressEventBus.emit`,
- * so the `requestShow*` events reach the same `ProgressEventBus.on` handlers
- * exactly once.
+ * its results. Every host presents through its `runtimeHost`; in the extension,
+ * `extensionAgentRuntimeHost.emit` routes these presentation requests to the
+ * extension presentation handlers exactly once.
  */
 import { terminalResultToast } from '@shared/agent/terminalResultPresentation';
 

--- a/src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts
+++ b/src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { ProgressEventBus } from '@eventBus/ProgressEventBus';
+import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
+import { extensionPresentationEvents } from '@frontend/events/extensionPresentationEvents';
+import type { StreamTabId } from '@shared/schemas';
+
+describe('extensionAgentRuntimeHost', () => {
+  it('routes extension presentation events away from ProgressEventBus', () => {
+    const busPayloads: unknown[] = [];
+    const presentationPayloads: unknown[] = [];
+    const disposeBus = ProgressEventBus.on('requestShowError', (payload) =>
+      busPayloads.push(payload),
+    );
+    const disposePresentation = extensionPresentationEvents.on(
+      'requestShowError',
+      (payload) => presentationPayloads.push(payload),
+    );
+    busPayloads.length = 0;
+    presentationPayloads.length = 0;
+
+    try {
+      extensionAgentRuntimeHost.emit('requestShowError', {
+        message: 'The model invocation failed.',
+      });
+
+      expect(busPayloads).toEqual([]);
+      expect(presentationPayloads).toEqual([
+        { message: 'The model invocation failed.' },
+      ]);
+    } finally {
+      disposePresentation();
+      disposeBus();
+    }
+  });
+
+  it('keeps run progress events on ProgressEventBus', () => {
+    const busPayloads: unknown[] = [];
+    const disposeBus = ProgressEventBus.on('setActiveStream', (payload) =>
+      busPayloads.push(payload),
+    );
+    busPayloads.length = 0;
+
+    try {
+      extensionAgentRuntimeHost.emit('setActiveStream', {
+        streamId: 'extension:progress' as StreamTabId,
+      });
+
+      expect(busPayloads).toEqual([
+        { streamId: 'extension:progress' as StreamTabId },
+      ]);
+    } finally {
+      disposeBus();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Split the VS Code extension presentation events away from `ProgressEventBus`: `requestOpenFile`, `requestShowInstruction`, `showAgentConfigBanner`, `requestShowError`, and `requestEnsureProgressView`.
- Add `extensionPresentationEvents`, a small buffered extension-boundary channel that preserves the old pre-listener delivery behavior.
- Route `extensionAgentRuntimeHost.emit(...)` for those five presentation events to the new channel.
- Update `registerAgentEventListeners()` to consume presentation events from the extension channel.
- Leave run/session progress, approval RPC, status-bar status/usage, desktop root presentation, and `removeStream` on their current paths for separate ownership slices.

Part of #6968 and #6951.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts src/test-kernel/progressView/ProgressBackendProcessBus.vitest.ts` — 9 tests passed.
- `corepack pnpm exec eslint packages/extension/src/frontend/agentRuntime/extensionAgentRuntimeHost.ts packages/extension/src/frontend/events/agentEventListeners.ts packages/extension/src/frontend/events/extensionPresentationEvents.ts src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts`
- `corepack pnpm run typecheck`
- `corepack pnpm run compile:fast`
- `corepack pnpm test` — 625 files passed, 1 skipped; 5004 tests passed, 4 skipped.
- `corepack pnpm run lint` — 0 errors, 3 pre-existing import-order warnings.

## Remaining Bus Surface

- Run/session progress remains on the extension runtime host / progress bus path.
- Approval and permission RPC events remain on their existing interactions/progress-view paths.
- `removeStream` remains a progress-view lifecycle action and is not changed here.
- Desktop still intentionally listens to `ProgressEventBus` for root `requestShowError` / `requestEnsureProgressView`; this PR changes only the VS Code extension presentation path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how agent UI notifications are delivered at extension activation boundaries; mis-routing could drop or duplicate toasts/instructions, though behavior is covered by new routing tests.
> 
> **Overview**
> **Splits extension UI presentation off `ProgressEventBus`** so five agent→VS Code events (`requestOpenFile`, `requestShowInstruction`, `showAgentConfigBanner`, `requestShowError`, `requestEnsureProgressView`) flow through a new **`extensionPresentationEvents`** channel instead of the shared progress bus.
> 
> `extensionAgentRuntimeHost.emit` **routes** those events to the presentation bus and **continues** to forward everything else (e.g. `setActiveStream`) to `ProgressEventBus`. `registerAgentEventListeners` **subscribes** on the presentation channel, so terminal-result toasts still go through the runtime host and hit the UI handlers once.
> 
> The new bus **buffers** emissions when no listener is registered yet (capped at 1000) and **replays** buffered items when a listener attaches, preserving startup ordering. Tests assert presentation events do not hit `ProgressEventBus` while progress events still do.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e63d45de5d12baf5b388e736cfe24eb5b0d04db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->