### PR TITLE
fix(transcript): break mtime ties toward the legacy todos write

### DIFF
--- a/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
@@ -383,6 +383,45 @@ describe('ExecutionsTool', () => {
     });
   });
 
+  // Regression for #7404: a legacy write landing after the sidecar write but
+  // rounding to the same millisecond tick (the VS Code filesystem adapter's
+  // mtime resolution) used to lose to the strict `>` comparison, reproducing
+  // the #7301 staleness regression on every tie.
+  it('prefers the legacy KV write when its mtime ties the sidecar mtime', async () => {
+    await withTempStorage(async () => {
+      const executionId = 'abc123' as ExecutionId;
+      const streamId = `codex#${executionId}` as StreamTabId;
+      await writeSidecarTodos(streamId, executionId, [
+        {
+          content: 'Stale sidecar todo',
+          status: 'pending',
+          activeForm: 'Doing the stale sidecar todo',
+        },
+      ]);
+      const sidecarMtime = (
+        await StorageFS.stat(`${streamDataDir(streamId)}/workPlan.json`)
+      ).mtime;
+      mocks.readMeta.mockResolvedValue({
+        timestamp: '2026-06-15T09:36:02.345Z',
+        category: 'toolUse',
+      });
+      mocks.readConfig.mockResolvedValue(config);
+      mocks.readTodos.mockResolvedValue([
+        { content: 'Fresher legacy todo', status: 'completed' },
+      ]);
+      // Simulate a final todo_write that lands after the sidecar write but
+      // rounds to the exact same millisecond tick.
+      mocks.todosModifiedAt.mockResolvedValue(sidecarMtime);
+
+      const result = await new ExecutionsTool().call({
+        path: `/executions/${executionId}`,
+      });
+
+      expect(result.output).toContain('Fresher legacy todo');
+      expect(result.output).not.toContain('Stale sidecar todo');
+    });
+  });
+
   it('lists and reads persisted workspace files for tool-use executions', async () => {
     await withTempWorkspace(async (workspace) => {
       await writeFile(path.join(workspace, 'review.md'), '# report\n');

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -22,7 +22,11 @@ export interface CompletedRunTodosReaderOptions {
    * Last-modified time (ms since epoch) of the legacy `todos.json`, if it
    * exists. Used to detect a final `todo_write` that landed after the
    * sidecar's own (asynchronous) write flushed, so the fresher source wins
-   * regardless of which one happens to exist.
+   * regardless of which one happens to exist. Millisecond-resolution mtimes
+   * (the VS Code filesystem adapter's granularity) can tie when both writes
+   * land in the same tick; ties are broken toward the legacy write, since a
+   * genuinely later legacy write is the more likely cause of a tie than a
+   * genuinely later sidecar write racing to complete in the same millisecond.
    */
   readonly legacyModifiedAt?: () => Promise<number | undefined>;
 }
@@ -97,7 +101,7 @@ export async function readCompletedRunTodos(
   }
 
   const legacyMtime = await options.legacyModifiedAt?.();
-  if (legacyMtime !== undefined && legacyMtime > sidecarMtime) {
+  if (legacyMtime !== undefined && legacyMtime >= sidecarMtime) {
     return readLegacyTodos(options.legacyFallback);
   }
 


### PR DESCRIPTION
## Root cause

`readCompletedRunTodos()` in `src/transcript/completedRunArchive.ts` compares the sidecar `workPlan.json` mtime against the legacy `todos.json` mtime, preferring whichever is newer (added in #7315 to fix #7301). The comparison used strict `>`:

```ts
if (legacyMtime !== undefined && legacyMtime > sidecarMtime) {
  return readLegacyTodos(options.legacyFallback);
}
```

`chatgpt-codex-connector[bot]` flagged (P2) during #7315's review that this loses on a tie: when a final legacy `todo_write` lands after the sidecar write but both round to the same millisecond tick (the VS Code filesystem adapter only exposes millisecond-resolution mtimes), the sidecar still wins even though the legacy write is actually fresher — reproducing the exact stale-todos regression #7315 fixed (`/executions/{id}` and `/executions/{id}/todos` showing pending tasks after the run had completed).

## Fix

Changed the comparison to `>=` so a tie resolves toward the legacy write — the more likely explanation for two writes landing in the same tick is a later legacy write racing a completed sidecar flush, not the reverse. Updated the doc comment on `legacyModifiedAt` to explain the tie-break rationale. No new abstraction — this is the one-line minimal fix the issue asks for.

## Test

Added a regression test (`prefers the legacy KV write when its mtime ties the sidecar mtime`) in `src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts` that seeds a sidecar write, reads back its actual on-disk mtime, and mocks the legacy KV mtime to the identical value (a true tie), then asserts the legacy content wins. Verified this test fails against the pre-fix `>` comparison and passes with `>=`.

## Verification

- `npx tsc --noEmit` — clean (pre-existing unrelated errors in `@openrouter/sdk`/`vscode-jsonrpc` module resolution, confirmed identical with/without this diff via `git stash`)
- `npx eslint src/transcript/completedRunArchive.ts src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts` — clean
- `npx vitest run src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts` — 14/14 pass (13 existing + 1 new)
- `npx vitest run src/test-kernel/tools src/test-kernel/agent/storage src/test-kernel/transcript` — 506/506 tests pass (3 unrelated pre-existing file-level failures from the same `vscode-jsonrpc`/lean module-resolution issue, confirmed pre-existing via `git stash`)
- `npx prettier --check src/transcript/completedRunArchive.ts src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts` — clean

Fixes #7404.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single comparison change in completed-run todo source selection, covered by a new regression test; no auth, persistence schema, or broad API surface changes.
> 
> **Overview**
> Fixes a regression where completed-run todo lists could stay **stale** when legacy `todos.json` and sidecar `workPlan.json` share the same millisecond mtime (common under VS Code’s filesystem adapter).
> 
> `readCompletedRunTodos()` now treats legacy KV as fresher-or-equal (`legacyMtime >= sidecarMtime`) instead of strictly newer, so ties prefer the legacy write. The `legacyModifiedAt` option comment documents that tie-break. A regression test in `ExecutionsToolWorkspaceFiles.vitest.ts` asserts `/executions/{id}` shows legacy todos when mocked legacy mtime equals the on-disk sidecar mtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0b7852158ae568d1b8caf00fb4dfaf0c8d05159. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->