### PR TITLE
refactor(platform): make four single-implementer Platform ports optional

### DIFF
--- a/src/platform/defaults/nodeHost.ts
+++ b/src/platform/defaults/nodeHost.ts
@@ -92,13 +92,10 @@ export function createNodePlatform(services: NodePlatformServices): Platform {
       ...services.toolAvailability,
     },
     // Neither Node host has a UI surface for these yet (linter diagnostics,
-    // inline criticism, tool-missing/unavailable toasts) — explicit no-ops
-    // here, in the one place both hosts share, rather than an invisible
-    // per-module default.
-    linter: async () => [],
-    addCriticismSink: () => ({ accepted: false, resolvedPath: '' }),
-    toolMissingHandler: () => {},
-    toolNotificationHandler: () => {},
+    // inline criticism, tool-missing/unavailable toasts). These four Platform
+    // ports are optional and single-implementer (VS Code only); core call
+    // sites already treat an absent port as a no-op, so omitting them here is
+    // enough — no per-host stub needed.
     // Default handler throws — a host must override this to support tool-edit
     // approvals.  CLI and desktop override via a session-scoped indirection
     // (see the host's own initPlatform code); the extension wires its native

--- a/src/platform/platform.ts
+++ b/src/platform/platform.ts
@@ -47,14 +47,30 @@ export interface Platform {
   readonly agentResume: AgentResumePort;
   readonly agentDirectories: AgentDirectoriesPort;
   readonly toolAvailability: ToolAvailabilityHost;
-  /** Linter diagnostics provider for the diagnostics tool's `list`/`count` commands. */
-  readonly linter: LinterProvider;
-  /** Sink for the diagnostics tool's `add` (manual criticism) command. */
-  readonly addCriticismSink: AddCriticismSink;
-  /** Surfaces a tool-missing error to the user. */
-  readonly toolMissingHandler: ToolMissingHandler;
-  /** Surfaces a tool-group-unavailable notification to the user. */
-  readonly toolNotificationHandler: ToolNotificationHandler;
+  /**
+   * Linter diagnostics provider for the diagnostics tool's `list`/`count`
+   * commands. Single-implementer (VS Code) — hosts without a linter
+   * integration omit it; callers treat an absent port as "no diagnostics".
+   */
+  readonly linter?: LinterProvider;
+  /**
+   * Sink for the diagnostics tool's `add` (manual criticism) command.
+   * Single-implementer (VS Code) — hosts without an inline-criticism surface
+   * omit it; callers treat an absent port as "not accepted".
+   */
+  readonly addCriticismSink?: AddCriticismSink;
+  /**
+   * Surfaces a tool-missing error to the user. Single-implementer (VS Code) —
+   * hosts without a UI for this omit it; callers treat an absent port as a
+   * no-op.
+   */
+  readonly toolMissingHandler?: ToolMissingHandler;
+  /**
+   * Surfaces a tool-group-unavailable notification to the user.
+   * Single-implementer (VS Code) — hosts without a UI for this omit it;
+   * callers treat an absent port as a no-op.
+   */
+  readonly toolNotificationHandler?: ToolNotificationHandler;
   /** Host-provided tool-edit approval UI (diff viewer + accept/reject). */
   readonly toolEditApproval: ToolEditApprovalPort;
 }

--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -128,7 +128,7 @@ export class DiagnosticsTool extends defineTool({
     const diagnosticsPath = this.resolveAbsolutePath(path);
 
     try {
-      const messages = await platform().linter(diagnosticsPath);
+      const messages = (await platform().linter?.(diagnosticsPath)) ?? [];
       const counts = countBySeverity(messages);
       const header = `${diagnosticsPath}: ${formatCounts(counts)}`;
       const summary = `Diagnostics ${command} for ${diagnosticsPath}`;
@@ -173,13 +173,13 @@ export class DiagnosticsTool extends defineTool({
 
     try {
       const absolutePath = this.resolveAbsolutePath(path);
-      const result = platform().addCriticismSink({
+      const result = platform().addCriticismSink?.({
         absolutePath,
         line,
         message,
         severity,
         confidence,
-      });
+      }) ?? { accepted: false, resolvedPath: '' };
       if (!result.accepted) {
         return {
           status: 'executed',

--- a/src/tools/toolUnavailableNotification.ts
+++ b/src/tools/toolUnavailableNotification.ts
@@ -44,7 +44,7 @@ export function notifyUnavailableTools(excludedToolNames: string[]): void {
   const hiddenGroups = fresh.filter((g) => g.hideFromDashboard);
   if (hiddenGroups.length > 0) {
     const label = formatGroupLabel(hiddenGroups.map((g) => g.name));
-    tryPlatform()?.toolNotificationHandler(
+    tryPlatform()?.toolNotificationHandler?.(
       `${label} excluded — external dependencies not installed.`,
     );
   }
@@ -65,7 +65,7 @@ export function notifyUnavailableTools(excludedToolNames: string[]): void {
   for (const [bucketKey, bucket] of byAction) {
     const [cmd, label] = bucketKey.split('\0');
     const names = formatGroupLabel(bucket.map((g) => g.name));
-    tryPlatform()?.toolNotificationHandler(
+    tryPlatform()?.toolNotificationHandler?.(
       `${names} excluded — external dependencies not installed.`,
       cmd,
       label,

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -46,7 +46,7 @@ async function reportMissingTool(
   openDocsCommand?: string,
 ): Promise<void> {
   try {
-    await platform().toolMissingHandler(message, openDocsCommand);
+    await platform().toolMissingHandler?.(message, openDocsCommand);
   } catch (err) {
     logger.error(
       CHANNEL,


### PR DESCRIPTION
## Root cause

`Platform` (`src/platform/platform.ts:51-57`) declared four required ports
that only the VS Code host implements a real behavior for:
`linter`, `addCriticismSink`, `toolMissingHandler`, `toolNotificationHandler`.
Both Node hosts (CLI, desktop) share `createNodePlatform()`
(`src/platform/defaults/nodeHost.ts`), which had to fabricate no-op stubs
for all four just to satisfy the required-field type, even though neither
host has a UI surface for them.

## Fix

- Made the four ports `readonly ... ?:` optional on `Platform`
  (`src/platform/platform.ts`).
- Deleted the now-unnecessary no-op stubs from `createNodePlatform`
  (`src/platform/defaults/nodeHost.ts`) — CLI and desktop simply omit these
  ports now.
- Updated the three core call sites to treat an absent port as its existing
  no-op behavior, via optional chaining + the same fallback value the Node
  stub used to return:
  - `src/tools/DiagnosticsTool.ts` — `linter` → `[]`, `addCriticismSink` →
    `{ accepted: false, resolvedPath: '' }`.
  - `src/utils/system/toolUtils.ts` (`reportMissingTool`) — `toolMissingHandler`
    optional-chained.
  - `src/tools/toolUnavailableNotification.ts` — `toolNotificationHandler`
    optional-chained (it was already reached through `tryPlatform()?.`, just
    needed the second `?.` on the port itself).
- The VS Code extension (`packages/extension/src/extension.ts`) is untouched:
  it still supplies concrete implementations for all four, which remains
  valid since the fields are optional, not removed.

### On collapsing `toolMissingHandler`/`toolNotificationHandler`

The issue suggested "considering" collapsing these two into one
host-notification port. I left them separate: they differ in message
severity (error vs. info) and action shape (`openDocsCommand` vs.
`actionCommand`/`actionLabel`), and only two core call sites exist in total
(`reportMissingTool`, `notifyUnavailableTools`). Unifying them would mean
adding a discriminant field to route severity/action shape rather than
removing anything — the repo's own tech-debt audits have repeatedly found
that "extract shared abstraction" across fewer than ~3 genuinely-shared call
sites nets more lines than it saves, so I kept the minimal, non-refactoring
fix per the issue's primary ask.

## Hosts audited

- **VS Code** (`packages/extension/src/extension.ts`): unaffected — still
  wires concrete implementations for all four ports.
- **CLI** (`packages/cli/src/runtime/initPlatform.ts`): uses
  `createNodePlatform`, now omits the four ports (no-op by omission).
- **Desktop** (`packages/desktop/src/main/platform/index.ts`): same —
  uses `createNodePlatform`, now omits the four ports.

## Verification

- `npx tsc --noEmit` — no new errors (diffed against the same command on
  `main`; the pre-existing `@openrouter/sdk`/`vscode-jsonrpc` module-resolution
  errors are present identically before and after this change, confirmed via
  `git stash`).
- `cd packages/extension && npx tsc --noEmit` — no new errors (same
  pre-existing unrelated errors).
- `npx eslint src/platform/defaults/nodeHost.ts src/platform/platform.ts src/tools/DiagnosticsTool.ts src/tools/toolUnavailableNotification.ts src/utils/system/toolUtils.ts` — clean.
- `npx vitest run src/test-kernel/tools/DiagnosticsTool.vitest.ts src/test-kernel/platform/FakePlatform.vitest.ts src/test-kernel/cli/CliInitPlatform.vitest.mts src/test-kernel/desktop/ElectronPlatformAdapters.vitest.mts src/test-kernel/desktop/DesktopRendererPlatform.vitest.mts src/test-kernel/tools/wolframScriptUtils.vitest.ts src/test-kernel/controllers/LatexToolingController.vitest.ts` — 7 files, 42 tests, all pass.
- `npx vitest run src/test-kernel/tools src/test-kernel/platform` — 441 tests pass (3 test files fail to *load* due to a pre-existing `vscode-jsonrpc/node` module-resolution issue in this worktree, confirmed present identically on `main` via `git stash`; unrelated to this change).
- `npx prettier --check <changed files>` — clean.

Fixes #7421.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type and wiring cleanup with explicit no-op fallbacks at existing call sites; VS Code still supplies real implementations and behavior for Node hosts is unchanged from the prior stubs.
> 
> **Overview**
> **Four VS Code–only `Platform` ports** (`linter`, `addCriticismSink`, `toolMissingHandler`, `toolNotificationHandler`) are now **optional** on `Platform`, with docs noting hosts may omit them and callers should treat absence as no-op / empty diagnostics.
> 
> **Node hosts (CLI/desktop)** no longer register **no-op stubs** in `createNodePlatform` for those ports—they simply leave them off the composed platform.
> 
> **Core call sites** use optional chaining and the same fallbacks the stubs used: diagnostics reads get `[]` / “not accepted”; missing-tool and unavailable-tool notifications skip UI when no handler is wired.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5a0ac6ad1caa527e2cb776083ef3f7af30f4378. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->