### PR TITLE
refactor(model-handlers): unify web-search progress-view guard

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -12,7 +12,7 @@ import {
 // Local imports - agent
 import { platform } from '@platform/platform';
 import type { AgentTrace } from '@agent/trace';
-import { logWebSearch, logContextManagementEvent } from '@agent/trace';
+import { logContextManagementEvent } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import {
   AgentCategory,
@@ -98,10 +98,7 @@ import type {
   TokenCountOptions,
   TokenValidationResult,
 } from './types/ModelHandlerContracts';
-import type {
-  ServerToolExtractionResult,
-  WebSearchResult,
-} from './types/ServerToolTypes';
+import type { ServerToolExtractionResult } from './types/ServerToolTypes';
 
 // Default continuation limits
 const DEFAULT_CONTINUE_LIMIT = 10;
@@ -317,17 +314,6 @@ export abstract class ModelHandler<
       deferStart: !options?.atPhaseSignal,
       phaseOnly: !this.outputStreaming,
     });
-  }
-
-  /**
-   * Emit web search result to progress view during streaming.
-   * This allows search results to appear in correct order based on when
-   * they occurred in the response, rather than being logged after streaming.
-   */
-  protected emitWebSearchResult(result: WebSearchResult): void {
-    if (this.progressViewEnabled) {
-      logWebSearch(this.logger, result);
-    }
   }
 
   /**

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -49,6 +49,7 @@ import { getConfig } from '@utils/config/configUtils';
 import { getWebSocketEnabled } from '@utils/config/providerConfig';
 import { computeUtilizationPercent } from '../support/contextUtilization';
 import { logCompactionEvent } from '../support/compactionLogging';
+import { emitServerToolResult } from '../support/emitServerToolResult';
 import { shouldUseOpenRouter } from '../support/ProxyConfigResolver';
 import { toOpenAIReasoningEffort } from '../support/reasoningEffort';
 import {
@@ -486,7 +487,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         this.createThinkingStream({ atPhaseSignal: true }),
       createOutputStream: () => this.createOutputStream(),
       extractText: (response) => this.extractResponse(response, '').text,
-      emitWebSearchResult: (result) => this.emitWebSearchResult(result),
+      emitWebSearchResult: (result) =>
+        emitServerToolResult(this.logger, this.progressViewEnabled, result),
       logger: this.logger,
     });
   }

--- a/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
+++ b/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
@@ -3,12 +3,12 @@
  * Encapsulates the streaming event handling logic for improved testability and readability.
  */
 // Third-party imports
-import { logWebFetch, logWebSearch, type AgentTrace } from '@agent/trace';
+import { logWebFetch, type AgentTrace } from '@agent/trace';
 import {
   mapAnthropicWebSearchEntries,
   type WebFetchResult,
-  type WebSearchResult,
 } from '@agent/modelHandlers/types/ServerToolTypes';
+import { emitServerToolResult } from '@agent/modelHandlers/support/emitServerToolResult';
 import { safeParseJson } from '@common/parsing/safeParseJson';
 import type { StreamDiagnostics } from '@shared/schemas';
 import type { BetaRawMessageStreamEvent } from '@anthropic-ai/sdk/resources/beta/messages';
@@ -344,7 +344,7 @@ export class AnthropicStreamHandler {
 
     // Emit to progress view
     if (entries.length > 0 || query) {
-      this.emitWebSearchResult({
+      emitServerToolResult(this.logger, this.config.progressViewEnabled, {
         query,
         results: entries,
         provider: 'anthropic',
@@ -439,15 +439,6 @@ export class AnthropicStreamHandler {
   private finalizeOutputStream(): void {
     this.state.outputStream?.finalize();
     this.state.outputStream = null;
-  }
-
-  /**
-   * Emits a web search result to the progress view.
-   */
-  private emitWebSearchResult(result: WebSearchResult): void {
-    if (this.config.progressViewEnabled) {
-      logWebSearch(this.logger, result);
-    }
   }
 
   /**

--- a/src/agent/modelHandlers/support/emitServerToolResult.ts
+++ b/src/agent/modelHandlers/support/emitServerToolResult.ts
@@ -1,0 +1,22 @@
+import { logWebSearch, type AgentTrace } from '@agent/trace';
+
+import type { WebSearchResult } from '../types/ServerToolTypes';
+
+/**
+ * Emits a web-search result to the progress view, gated on
+ * `progressViewEnabled`.
+ *
+ * Shared by `ModelHandler`'s OpenAI-Responses streaming closure and
+ * `AnthropicStreamHandler` (a collaborator, not a `ModelHandler` subclass,
+ * so it can't reach a protected base method) — previously each re-implemented
+ * this same guard privately (#7418).
+ */
+export function emitServerToolResult(
+  logger: AgentTrace,
+  progressViewEnabled: boolean,
+  result: WebSearchResult,
+): void {
+  if (progressViewEnabled) {
+    logWebSearch(logger, result);
+  }
+}

--- a/src/test-kernel/agent/modelHandlers/support/EmitServerToolResult.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/support/EmitServerToolResult.vitest.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AgentTrace } from '@agent/trace';
+import { emitServerToolResult } from '@agent/modelHandlers/support/emitServerToolResult';
+import type { WebSearchResult } from '@agent/modelHandlers/types/ServerToolTypes';
+
+function captureTrace(): {
+  trace: AgentTrace;
+  events: Array<{ key: string; data?: unknown }>;
+} {
+  const events: Array<{ key: string; data?: unknown }> = [];
+  return {
+    events,
+    trace: {
+      domain(event: { key: string; data?: unknown }) {
+        events.push(event);
+      },
+    } as AgentTrace,
+  };
+}
+
+const searchResult: WebSearchResult = {
+  query: 'texra release notes',
+  results: [],
+  provider: 'anthropic',
+  callId: 'call_1',
+  status: 'completed',
+};
+
+describe('emitServerToolResult', () => {
+  it('logs a webSearch domain event when the progress view is enabled', () => {
+    const { trace, events } = captureTrace();
+
+    emitServerToolResult(trace, true, searchResult);
+
+    expect(events).toEqual([{ key: 'webSearch', data: searchResult }]);
+  });
+
+  it('does nothing when the progress view is disabled', () => {
+    const { trace, events } = captureTrace();
+
+    emitServerToolResult(trace, false, searchResult);
+
+    expect(events).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Root cause

Follow-up from #7408 (removed the dead `ModelHandler.emitWebFetchResult`). With
that gone, `ModelHandler.emitWebSearchResult` (`ModelHandler.ts:332`) was left
as a base method with exactly one real caller (the OpenAI-Responses streaming
closure in `modelHandlerOpenAIResponse.ts`), and its
`if (progressViewEnabled) logWebSearch(...)` guard was privately
re-implemented in `support/AnthropicStreamHandler.ts:447` — that collaborator
is not a `ModelHandler` subclass, so it can't reach the `protected` base
method, and ended up duplicating the same guard logic instead of sharing it.

## Fix

- Added `src/agent/modelHandlers/support/emitServerToolResult.ts`: a single
  free function `emitServerToolResult(logger, progressViewEnabled, result)`
  that owns the guard + `logWebSearch` call.
- Deleted `ModelHandler.emitWebSearchResult` (the now-redundant base-class
  guard) and its now-unused `logWebSearch`/`WebSearchResult` imports; the
  OpenAI-Responses closure in `modelHandlerOpenAIResponse.ts` now calls
  `emitServerToolResult(this.logger, this.progressViewEnabled, result)`
  directly.
- Deleted `AnthropicStreamHandler`'s private `emitWebSearchResult` wrapper;
  its one call site (`handleWebSearchResult`) now calls
  `emitServerToolResult(this.logger, this.config.progressViewEnabled, result)`
  directly.
- `AnthropicStreamHandler.emitWebFetchResult` (the sibling web-fetch guard) is
  untouched — it's out of scope for this issue (no base-class counterpart
  exists to duplicate against since `emitWebFetchResult` was already deleted
  from `ModelHandler` in #7408).
- Added `src/test-kernel/agent/modelHandlers/support/EmitServerToolResult.vitest.ts`,
  direct coverage for the new shared function (enabled/disabled guard), since
  this logic previously had no direct unit test.

Net production-code diff is essentially flat (+1 LOC) rather than the
issue's ≈−10 estimate, because both call sites route through the shared
function directly rather than keeping thin per-class wrapper methods around
it — avoids reintroducing a single-caller wrapper on either side.

## Verification

- `npx tsc --noEmit` (repo root) — clean; only pre-existing, unrelated
  `@openrouter/sdk` / `vscode-jsonrpc` module-resolution errors remain,
  confirmed identical with the diff stashed out.
- `npx eslint <changed files>` — clean.
- `npx prettier --check <changed files>` — clean.
- `npx vitest run src/test-kernel/agent/modelHandlers` — 391 passed, 4 skipped
  (all model-handler suites, including the new test file).

Fixes #7418.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor with no API or behavior change beyond deduplication; streaming/progress-view paths are exercised but logic is unchanged.
> 
> **Overview**
> **Unifies how native web-search hits the progress view** by extracting a shared `emitServerToolResult(logger, progressViewEnabled, result)` helper that gates on `progressViewEnabled` and calls `logWebSearch`.
> 
> The protected `ModelHandler.emitWebSearchResult` is removed; the OpenAI Responses `ResponseStreamProcessor` closure now calls the helper directly. `AnthropicStreamHandler` drops its private duplicate and uses the same helper in `handleWebSearchResult`. **Web-fetch emission is unchanged** (still local to Anthropic).
> 
> Adds **Vitest coverage** for enabled vs disabled progress view on the new helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e1390afd73e38c063e87ea21c0a8b8e9f2033f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->