### PR TITLE
fix(transcript): rank log-backed meta matches ahead of workPlan-only

### DIFF
--- a/src/test-kernel/transcript/executionStreamResolver.vitest.ts
+++ b/src/test-kernel/transcript/executionStreamResolver.vitest.ts
@@ -166,6 +166,61 @@ describe('resolvePersistedStreamIdForExecution', () => {
   );
 
   it(
+    'prefers a log-backed meta match over an earlier-ordered workPlan-only ' +
+      'match sharing the same executionId (#7403)',
+    async () => {
+      const executionId = 'abc444' as ExecutionId;
+      // Named so the workPlan-only candidate sorts alphabetically FIRST in
+      // the persisted-stream directory listing, mirroring the reported bug:
+      // an earlier-ordered candidate has only workPlan.json (no stream log)
+      // while a later-ordered candidate has the real streamLogs entry. The
+      // resolver must still pick the log-backed one regardless of order.
+      const workPlanOnlyStream =
+        'aOrchestrator@deepseekproT#abc444' as StreamTabId;
+      const logBackedStream = 'zBashTool@tool#abc444' as StreamTabId;
+
+      const snapshotWriter = new StreamSnapshotStore();
+      snapshotWriter.setTaskState(
+        workPlanOnlyStream,
+        taskState('orchestrator'),
+        executionId,
+      );
+      snapshotWriter.setTaskState(
+        logBackedStream,
+        taskState('bash'),
+        executionId,
+      );
+      snapshotWriter.handleProgressEvent('updateTodos', {
+        streamId: workPlanOnlyStream,
+        todos: [TODO],
+      });
+      await snapshotWriter.flush();
+
+      const logStore = new StreamLogStore();
+      await logStore.load();
+      logStore.append(logBackedStream, {
+        id: 'entry-1',
+        type: STREAM_LOG_ENTRY_TYPES.LOG,
+        level: LOG_LEVELS.INFO,
+        timestamp: 100,
+        messageType: MESSAGE_TYPES.DEFAULT,
+        text: 'child stream output',
+      });
+      await logStore.flush();
+
+      const resolved = await resolvePersistedStreamIdForExecution(executionId, {
+        snapshotStore: new StreamSnapshotStore(),
+        streamLogStore: logStore,
+      });
+
+      expect(resolved).toEqual({
+        streamId: logBackedStream,
+        source: 'streamDataMeta',
+      });
+    },
+  );
+
+  it(
     'bounds the concurrent meta-file reads instead of fanning out over every ' +
       'persisted stream at once (#7299)',
     async () => {

--- a/src/transcript/executionStreamResolver.ts
+++ b/src/transcript/executionStreamResolver.ts
@@ -59,9 +59,13 @@ async function readMetaMatchDataPresence(
   streamId: StreamTabId,
   streamLogStore: Pick<StreamLogStore, 'keys' | 'has'> | undefined,
 ): Promise<MetaMatchDataPresence> {
+  const hasLog = streamLogStore?.has(streamId) ?? false;
   return {
-    hasLog: streamLogStore?.has(streamId) ?? false,
-    hasWorkPlan: await snapshotStore.hasPersistedWorkPlan(streamId),
+    hasLog,
+    // hasWorkPlan is irrelevant once hasLog is true (log rank always wins in
+    // pickBestMetaMatch) — skip the disk stat in that case, since this runs
+    // on the hot path #7299 already had to bound for fd pressure.
+    hasWorkPlan: hasLog || (await snapshotStore.hasPersistedWorkPlan(streamId)),
   };
 }
 

--- a/src/transcript/executionStreamResolver.ts
+++ b/src/transcript/executionStreamResolver.ts
@@ -41,28 +41,38 @@ function findSuffixMatch(
   return streams.find((id) => id.endsWith(suffix));
 }
 
+interface MetaMatchDataPresence {
+  readonly hasLog: boolean;
+  readonly hasWorkPlan: boolean;
+}
+
 /**
  * Whether a meta-matched candidate actually holds durable data for this
- * execution, as opposed to a bare `meta.json` record. Checked cheaply: an
- * already-loaded `StreamLogStore.has()` lookup is O(1) in-memory, and
- * `hasPersistedWorkPlan()` is a single stat, so this never re-reads the full
- * per-stream sidecar set.
+ * execution, as opposed to a bare `meta.json` record, broken out by kind so
+ * callers can rank a log-backed candidate ahead of a workPlan-only one.
+ * Checked cheaply: an already-loaded `StreamLogStore.has()` lookup is O(1)
+ * in-memory, and `hasPersistedWorkPlan()` is a single stat, so this never
+ * re-reads the full per-stream sidecar set.
  */
-async function hasRealPersistedData(
+async function readMetaMatchDataPresence(
   snapshotStore: StreamSnapshotStore,
   streamId: StreamTabId,
   streamLogStore: Pick<StreamLogStore, 'keys' | 'has'> | undefined,
-): Promise<boolean> {
-  if (streamLogStore?.has(streamId)) return true;
-  return snapshotStore.hasPersistedWorkPlan(streamId);
+): Promise<MetaMatchDataPresence> {
+  return {
+    hasLog: streamLogStore?.has(streamId) ?? false,
+    hasWorkPlan: await snapshotStore.hasPersistedWorkPlan(streamId),
+  };
 }
 
 /**
  * Disambiguate multiple persisted streams whose sidecar `meta.json` all
  * reference the same `executionId` (e.g. a parent orchestrator tab and a
- * `bash@tool#executionId` child stream). Prefers the first candidate that
- * actually has `streamLogs`/`workPlan.json` data; a bare metadata match is a
- * last resort so the resolver still returns *something* rather than nothing.
+ * `bash@tool#executionId` child stream). Ranks candidates by data kind: a
+ * real `streamLogs` entry always outranks a `workPlan.json`-only match,
+ * which in turn outranks a bare metadata match (scan order only breaks ties
+ * within the same rank), so a log-backed candidate is never shadowed by an
+ * earlier-ordered workPlan-only one.
  */
 async function pickBestMetaMatch(
   candidates: readonly MetaMatchCandidate[],
@@ -75,16 +85,17 @@ async function pickBestMetaMatch(
     candidates,
     async (candidate) => ({
       candidate,
-      hasData: await hasRealPersistedData(
+      ...(await readMetaMatchDataPresence(
         snapshotStore,
         candidate.streamId,
         streamLogStore,
-      ),
+      )),
     }),
     { concurrency: META_SCAN_CONCURRENCY },
   );
   return (
-    withData.find((entry) => entry.hasData)?.candidate.streamId ??
+    withData.find((entry) => entry.hasLog)?.candidate.streamId ??
+    withData.find((entry) => entry.hasWorkPlan)?.candidate.streamId ??
     candidates[0].streamId
   );
 }


### PR DESCRIPTION
## Summary

`pickBestMetaMatch()` in `src/transcript/executionStreamResolver.ts` disambiguates multiple persisted streams that share an `executionId` (e.g. a parent orchestrator tab and a `bash@tool#executionId` child stream). It previously returned the *first* candidate in scan order that had *any* real data — a `streamLogs` entry or a `workPlan.json` — treating the two as interchangeable "hasData" signals.

When an earlier-ordered candidate had only `workPlan.json` (no stream log) while a later-ordered candidate held the actual `streamLogs` entry, the resolver returned the workPlan-only stream. `traceAssembler.ts` would then load that stream and report `streamLogs_missing` even though a log-backed candidate was available.

## Change

- Split the per-candidate data-presence check into `hasLog` / `hasWorkPlan` (`readMetaMatchDataPresence`, replacing `hasRealPersistedData`).
- `pickBestMetaMatch()` now ranks candidates: a real `streamLogs` entry always outranks a `workPlan.json`-only match, which in turn outranks a bare metadata match. Scan order only breaks ties within the same rank, so a log-backed candidate is never shadowed by an earlier-ordered workPlan-only one.
- Added a regression test that names the workPlan-only candidate so it sorts alphabetically first in the persisted-stream listing, exercising the exact ordering bug from the issue.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx vitest run src/test-kernel/transcript/executionStreamResolver.vitest.ts` — 5/5 passing, including the new regression case
- [x] `npx vitest run src/test-kernel/transcript/` — 68/68 passing (no unrelated behavior change)
- [x] `npx eslint src/transcript/executionStreamResolver.ts src/test-kernel/transcript/executionStreamResolver.vitest.ts` — clean

Closes #7403.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized disambiguation logic in execution stream resolution with a targeted regression test; no auth, security, or broad API surface changes.
> 
> **Overview**
> When several persisted streams share the same `executionId`, **`pickBestMetaMatch`** no longer treats “has stream logs” and “has workPlan only” as one **`hasData`** bucket. It uses **`readMetaMatchDataPresence`** (`hasLog` / `hasWorkPlan`) and picks **log → workPlan → bare meta**, with scan order only as a tie-breaker within a rank.
> 
> That stops an alphabetically earlier workPlan-only tab from winning over a later stream that actually has **`streamLogs`**, which could drive **`streamLogs_missing`** in trace assembly despite logs existing. **`hasPersistedWorkPlan`** is skipped when **`hasLog`** is already true to avoid extra disk stats on the hot path.
> 
> A regression test (**#7403**) forces the workPlan-only candidate to sort first while the log lives on the later stream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cb56185f64c3f20fb9fe2d94f3b1bb0fd8c6395. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->