### PR TITLE
refactor: derive RunAgentOptions from ExecuteAgentOptions via Pick

### DIFF
--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -4,27 +4,28 @@ import type { ValidatedExecutionRequest } from '@agent/core/state/executionReque
 import type { ExecutionId } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core/executionId';
 import { applyHelperModelPreference } from './helperModelPreference';
-import { executeAgent } from './executeAgent';
-import type { ToolEditApprovalPort } from '@platform/interfaces/toolEditApproval';
-import type { AgentRuntimeHost } from './AgentRuntimeHost';
+import { executeAgent, type ExecuteAgentOptions } from './executeAgent';
 import type { AgentFlowResult, WorkflowFlowResult } from './AgentFlowResult';
-import type { AgentRunHandle } from './executionRegistry';
-import type { ModelHandlerCompatibilityKey } from './modelHandlerCompatibilityKey';
-import type { SessionHandle } from './SessionHandle';
 
-export interface RunAgentOptions {
-  runtimeHost: AgentRuntimeHost;
+/**
+ * Options for `runAgent`. Fields shared with the lower-level `executeAgent`
+ * are picked from `ExecuteAgentOptions` (and forwarded as-is) so the two
+ * option types can't drift apart silently; see that interface for their docs.
+ */
+export interface RunAgentOptions extends Pick<
+  ExecuteAgentOptions,
+  | 'runtimeHost'
+  | 'enforceCategory'
+  | 'stopAfterCycle'
+  | 'approvalPromptsUnavailable'
+  | 'runtimeUnavailableTools'
+  | 'toolEditApprovalHandler'
+  | 'session'
+  | 'modelHandlerCompatibilityKey'
+  | 'onRun'
+> {
   openWorkflowOutput?: (result: WorkflowFlowResult) => Promise<void>;
-  enforceCategory?: boolean;
   registerExecution?: boolean;
-  stopAfterCycle?: boolean;
-  approvalPromptsUnavailable?: boolean;
-  runtimeUnavailableTools?: readonly string[];
-  /**
-   * Per-run override for the host's tool-edit approval UI — see
-   * `ExecuteAgentOptions.toolEditApprovalHandler`.
-   */
-  toolEditApprovalHandler?: ToolEditApprovalPort;
   /**
    * Opt-in set by the "fix LaTeX" VS Code actions (Fix-Compilation command, the
    * progress-view compile fixer): run the launched agent on the configured
@@ -32,17 +33,6 @@ export interface RunAgentOptions {
    * the CLI, and orchestrator delegations, which all keep the chosen model.
    */
   preferHelperModel?: boolean;
-  /** Session owning this run's coordination state. Defaults to the process session. */
-  session?: SessionHandle;
-  /** Resume using this persisted provider-message format instead of today's default route. */
-  modelHandlerCompatibilityKey?: ModelHandlerCompatibilityKey | null;
-  /**
-   * Fires once with the live per-run handle right after it is tracked (F-2):
-   * `handle.result` settles with the terminal outcome, `handle.trace` is the
-   * run's event channel, and the handle can interrupt via the session. The
-   * returned promise is unchanged — this is additive, post-launch exposure.
-   */
-  onRun?: (handle: AgentRunHandle) => void | Promise<void>;
 }
 
 /**


### PR DESCRIPTION
## Summary

`RunAgentOptions` (`runAgent.ts`) hand-mirrored nine fields from
`ExecuteAgentOptions` purely to forward them to the underlying
`executeAgent` call, with no independent purpose. If `ExecuteAgentOptions`
changed one of those field's types, `RunAgentOptions` would silently drift
out of sync.

- `RunAgentOptions` now `extends Pick<ExecuteAgentOptions, ...>` for the
  nine shared/forwarded fields (`runtimeHost`, `enforceCategory`,
  `stopAfterCycle`, `approvalPromptsUnavailable`, `runtimeUnavailableTools`,
  `toolEditApprovalHandler`, `session`, `modelHandlerCompatibilityKey`,
  `onRun`), so the compiler catches drift on both sides going forward.
- The three fields unique to `RunAgentOptions` (`openWorkflowOutput`,
  `registerExecution`, `preferHelperModel`) stay declared directly.
- Scoped to the type declaration only, per the issue: the `runAgent` /
  `executeAgent` function layering (already reviewed as justified) is
  untouched — the body still forwards each field explicitly to
  `executeAgent`.

## Test plan

- [x] `npm run typecheck` (full workspace: root, test-kernel,
      `packages/cli`, `packages/extension` (`texra`), trace-viewer) — clean
- [x] `npx eslint src/agent/runtime/runAgent.ts` — clean
- [x] Existing suites covering `runAgent` all green (115 tests):
      `src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`,
      `src/test-kernel/agent/WorkflowScriptEngine.vitest.ts`,
      `src/test-kernel/cli/RunExecution.vitest.mts`
- No behavior change (pure type-level refactor of a `.ts` interface), so no
  new regression test was needed beyond the type-check itself, which is
  exactly the mechanism this issue asks for to prevent silent drift.

Closes #7422

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only interface refactor with no runtime or API behavior change.
> 
> **Overview**
> **`RunAgentOptions` is now tied to `ExecuteAgentOptions`** so the nine fields that `runAgent` only forwards to `executeAgent` (`runtimeHost`, `enforceCategory`, `stopAfterCycle`, `approvalPromptsUnavailable`, `runtimeUnavailableTools`, `toolEditApprovalHandler`, `session`, `modelHandlerCompatibilityKey`, `onRun`) come from `Pick<ExecuteAgentOptions, …>` instead of being duplicated on the interface.
> 
> The three **`runAgent`-only** options (`openWorkflowOutput`, `registerExecution`, `preferHelperModel`) stay declared on `RunAgentOptions`. JSDoc on the shared fields now points readers to `ExecuteAgentOptions`; redundant type-only imports were dropped. **`runAgent`’s body and forwarding are unchanged** — this is compile-time alignment only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f61b7900b6b1641a9ecbfb2d3a3359be8d23b14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->