### PR TITLE
fix(transcript): break mtime ties toward the legacy todos write

### DIFF
--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -1,0 +1,128 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { MemoryStateStore } from '@platform/defaults/memoryState';
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
+import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
+import { createFakePlatform } from '@test/support/FakePlatform';
+import { setupPlatform } from '@test/support/setupPlatform';
+import { readCompletedRunTodos, StreamSnapshotStore } from '@transcript';
+import { TaskStateSchema, type TaskState } from '@agent/core/state/TaskState';
+import type { ExecutionId, StreamTabId, TodoItem } from '@shared/schemas';
+import { AgentCategory } from '@shared/schemas/agent';
+import { StorageFS } from '@utils/files';
+import type { Platform } from '@platform/platform';
+
+const tempDirs: string[] = [];
+
+async function buildArchivePlatform(): Promise<Platform> {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'texra-archive-'));
+  tempDirs.push(tempDir);
+  const workspaceDir = path.join(tempDir, 'workspace');
+  const storageRoot = path.join(tempDir, 'storage');
+  return createFakePlatform(
+    { workspacePath: workspaceDir },
+    {
+      fs: nodeFilesystem,
+      workspace: createNodeWorkspace(() => workspaceDir),
+      storage: new WorkspaceStorageProvider(storageRoot, workspaceDir),
+      globalState: new MemoryStateStore(),
+      workspaceState: new MemoryStateStore(),
+    },
+  );
+}
+
+function taskState(agent: string, model = 'deepseekproT'): TaskState {
+  return TaskStateSchema.parse({
+    agentConfig: { agent, model, agentCategory: AgentCategory.ToolUse },
+  });
+}
+
+const SIDECAR_TODO: TodoItem = {
+  content: 'Sidecar task',
+  status: 'pending',
+  activeForm: 'Doing sidecar task',
+};
+
+const LEGACY_TODOS = [{ content: 'Legacy task', status: 'completed' as const }];
+
+describe('readCompletedRunTodos', () => {
+  setupPlatform(buildArchivePlatform);
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await Promise.all(
+      tempDirs
+        .splice(0)
+        .map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it('breaks a millisecond-resolution mtime tie toward the legacy write (#7404)', async () => {
+    const executionId = 'abc7404' as ExecutionId;
+    const streamId = 'orchestrator@deepseekproT#abc7404' as StreamTabId;
+
+    const store = new StreamSnapshotStore();
+    store.setTaskState(streamId, taskState('orchestrator'), executionId);
+    store.handleProgressEvent('updateTodos', {
+      streamId,
+      todos: [SIDECAR_TODO],
+    });
+    await store.flush();
+
+    // Real workPlan.json now exists on disk with some real mtime. Pin the
+    // sidecar's observed mtime and report the legacy write as landing at
+    // the exact same millisecond tick — the scenario where a final
+    // `todo_write` truly lands after the sidecar flush but rounds to an
+    // identical mtime.
+    const tieMtime = 1_700_000_000_000;
+    vi.spyOn(StorageFS, 'stat').mockResolvedValue({
+      type: 1,
+      ctime: tieMtime,
+      mtime: tieMtime,
+      size: 0,
+    });
+
+    const result = await readCompletedRunTodos(executionId, {
+      snapshotStore: new StreamSnapshotStore(),
+      legacyModifiedAt: async () => tieMtime,
+      legacyFallback: async () => LEGACY_TODOS,
+    });
+
+    expect(result.source).toBe('legacyKV');
+    expect(result.todos).toEqual(LEGACY_TODOS);
+  });
+
+  it('prefers the sidecar when it is strictly fresher than the legacy write', async () => {
+    const executionId = 'abd7404' as ExecutionId;
+    const streamId = 'orchestrator@deepseekproT#abd7404' as StreamTabId;
+
+    const store = new StreamSnapshotStore();
+    store.setTaskState(streamId, taskState('orchestrator'), executionId);
+    store.handleProgressEvent('updateTodos', {
+      streamId,
+      todos: [SIDECAR_TODO],
+    });
+    await store.flush();
+
+    const sidecarMtime = 1_700_000_000_000;
+    vi.spyOn(StorageFS, 'stat').mockResolvedValue({
+      type: 1,
+      ctime: sidecarMtime,
+      mtime: sidecarMtime,
+      size: 0,
+    });
+
+    const result = await readCompletedRunTodos(executionId, {
+      snapshotStore: new StreamSnapshotStore(),
+      legacyModifiedAt: async () => sidecarMtime - 1,
+      legacyFallback: async () => LEGACY_TODOS,
+    });
+
+    expect(result.source).toBe('streamData');
+  });
+});

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -76,9 +76,11 @@ async function readSidecarTodos(
  * Read the archived task list for a completed run, preferring the durable
  * stream sidecar (`streamData/{stream}/workPlan.json`) but falling back to
  * `executions/{id}/todos.json` for runs recorded before sidecars existed —
- * or when the legacy write is demonstrably fresher than the sidecar (a final
+ * or when the legacy write is at least as fresh as the sidecar (a final
  * `todo_write` can land before the snapshot store's asynchronous sidecar
- * write has flushed).
+ * write has flushed). Millisecond-resolution mtimes mean a legacy write that
+ * actually landed after the sidecar write can round to the same tick, so ties
+ * break toward the legacy write rather than the sidecar.
  */
 export async function readCompletedRunTodos(
   executionId: ExecutionId,
@@ -97,7 +99,10 @@ export async function readCompletedRunTodos(
   }
 
   const legacyMtime = await options.legacyModifiedAt?.();
-  if (legacyMtime !== undefined && legacyMtime > sidecarMtime) {
+  // `>=`, not `>`: filesystem mtimes are millisecond-resolution, so a legacy
+  // write that lands after the sidecar write but rounds to the same tick must
+  // still win the tie — otherwise the sidecar wins and stale todos display.
+  if (legacyMtime !== undefined && legacyMtime >= sidecarMtime) {
     return readLegacyTodos(options.legacyFallback);
   }
 


### PR DESCRIPTION
## Summary

`readCompletedRunTodos()` in `src/transcript/completedRunArchive.ts` compared sidecar `workPlan.json` mtime against legacy `todos.json` mtime using strict `legacyMtime > sidecarMtime` to decide which source is fresher. Filesystem mtimes have millisecond resolution, so a legacy write that lands after the sidecar write but rounds to the same millisecond tick lost the tie, leaving the (now stale) sidecar data displayed for `/executions/{id}` and `/executions/{id}/todos` even though the legacy write is actually the fresher one.

This is a follow-up to #7315, flagged by `chatgpt-codex-connector[bot]` in review (P2): https://github.com/LionSR/TeXRA/pull/7315#discussion_r3531573887

## Change

- Switch the comparison to `legacyMtime >= sidecarMtime` so ties resolve deterministically toward the legacy write.
- Updated the surrounding doc comments to describe the tie-breaking behavior.
- Added regression coverage in `src/test-kernel/transcript/completedRunArchive.vitest.ts`:
  - a tie-mtime case that fails against the old strict `>` and passes with `>=`
  - a strictly-fresher-sidecar case to confirm the sidecar still wins when it should

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx vitest run src/test-kernel/transcript/ src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts src/test-kernel/tools/ExecutionsToolResumability.vitest.ts` — 11 files / 85 tests passed
- [x] Confirmed the new tie-case test fails against the pre-fix `>` comparison and passes after the `>=` fix
- [x] `npx eslint` on changed files — clean (one auto-fixed import-order warning)

Closes #7404

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small comparison and documentation change in archive read logic, with targeted regression tests and no auth or persistence schema changes.
> 
> **Overview**
> Fixes stale todo lists on completed execution views when legacy `todos.json` and the stream sidecar `workPlan.json` share the same millisecond mtime but the legacy write is actually newer.
> 
> `readCompletedRunTodos()` now treats legacy as fresher when `legacyMtime >= sidecarMtime` instead of strict `>`, so ties favor the legacy KV write over the sidecar. Comments describe the millisecond tie-break. New Vitest coverage locks in equal-mtime → legacy and strictly newer sidecar → sidecar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f31fad3494dd6f64ff64028ec3d3e2213b5de62a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->