### PR TITLE
Unify server-tool-result emission guard; inline continuation prompt hook

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -12,7 +12,7 @@ import {
 // Local imports - agent
 import { platform } from '@platform/platform';
 import type { AgentTrace } from '@agent/trace';
-import { logWebSearch, logContextManagementEvent } from '@agent/trace';
+import { logContextManagementEvent } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import {
   AgentCategory,
@@ -70,6 +70,7 @@ import {
 import { computeUtilizationPercent } from './support/contextUtilization';
 import { logCompactionEvent } from './support/compactionLogging';
 import { MediaAttachmentProcessor } from './support/MediaAttachmentProcessor';
+import { emitServerToolResult } from './support/serverToolResultEmission';
 import {
   resolveBaseUrl,
   shouldUseOpenRouter,
@@ -325,9 +326,7 @@ export abstract class ModelHandler<
    * they occurred in the response, rather than being logged after streaming.
    */
   protected emitWebSearchResult(result: WebSearchResult): void {
-    if (this.progressViewEnabled) {
-      logWebSearch(this.logger, result);
-    }
+    emitServerToolResult(this.logger, this.progressViewEnabled, result);
   }
 
   /**
@@ -769,19 +768,6 @@ export abstract class ModelHandler<
     return content.some((c) => c.text?.includes(marker));
   }
 
-  /**
-   * Creates a continuation message for truncated responses.
-   * Shared implementation used by all model handlers that don't support assistant prefill.
-   * @returns The formatted continuation message string
-   */
-  protected createContinuationPrompt(
-    workspaceState: AgentWorkspaceState,
-    _agentSetting: AgentSetting,
-  ): string {
-    const prefillTokens = workspaceState.assembly.lastResponse.slice(-K_SLICE);
-    return `Your response got cut off, because you only have limited response space. Continue responding exactly from where you left off until the very end, marked by ${OUTPUT_END_TAG}. Avoid repeating yourself and avoid starting over. Start your response at the next token after: "${prefillTokens}"`;
-  }
-
   /** Creates and configures a client instance for the specific model provider. */
   abstract getClient(): Promise<C>;
 
@@ -915,7 +901,7 @@ export abstract class ModelHandler<
   addContinueMessage(
     messages: M[],
     workspaceState: AgentWorkspaceState,
-    agentSetting: AgentSetting,
+    _agentSetting: AgentSetting,
   ): void {
     if (this.capabilities.supportsAssistantPrefill) {
       this.logger.debug(
@@ -924,10 +910,8 @@ export abstract class ModelHandler<
       return;
     }
 
-    const continuationPrompt = this.createContinuationPrompt(
-      workspaceState,
-      agentSetting,
-    );
+    const prefillTokens = workspaceState.assembly.lastResponse.slice(-K_SLICE);
+    const continuationPrompt = `Your response got cut off, because you only have limited response space. Continue responding exactly from where you left off until the very end, marked by ${OUTPUT_END_TAG}. Avoid repeating yourself and avoid starting over. Start your response at the next token after: "${prefillTokens}"`;
 
     this.logger.debug('Adding continuation message to conversation', {
       data: { continuationMessage: continuationPrompt },

--- a/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
+++ b/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
@@ -3,7 +3,7 @@
  * Encapsulates the streaming event handling logic for improved testability and readability.
  */
 // Third-party imports
-import { logWebFetch, logWebSearch, type AgentTrace } from '@agent/trace';
+import { logWebFetch, type AgentTrace } from '@agent/trace';
 import {
   mapAnthropicWebSearchEntries,
   type WebFetchResult,
@@ -11,6 +11,7 @@ import {
 } from '@agent/modelHandlers/types/ServerToolTypes';
 import { safeParseJson } from '@common/parsing/safeParseJson';
 import type { StreamDiagnostics } from '@shared/schemas';
+import { emitServerToolResult } from './serverToolResultEmission';
 import type { BetaRawMessageStreamEvent } from '@anthropic-ai/sdk/resources/beta/messages';
 // BetaMessageStream is only exported from lib/ — not re-exported from the SDK's
 // public resources/ entry point. The BetaMessageStream class is what
@@ -445,9 +446,7 @@ export class AnthropicStreamHandler {
    * Emits a web search result to the progress view.
    */
   private emitWebSearchResult(result: WebSearchResult): void {
-    if (this.config.progressViewEnabled) {
-      logWebSearch(this.logger, result);
-    }
+    emitServerToolResult(this.logger, this.config.progressViewEnabled, result);
   }
 
   /**

--- a/src/agent/modelHandlers/support/serverToolResultEmission.ts
+++ b/src/agent/modelHandlers/support/serverToolResultEmission.ts
@@ -1,0 +1,21 @@
+import { logWebSearch, type AgentTrace } from '@agent/trace';
+import type { WebSearchResult } from '@agent/modelHandlers/types/ServerToolTypes';
+
+/**
+ * Emits a web search result to the progress view during streaming, gated on
+ * whether the progress view is enabled.
+ *
+ * Shared by `ModelHandler.emitWebSearchResult` (base method used by the
+ * OpenAI-Responses handler) and `AnthropicStreamHandler`'s private method —
+ * the latter can't reach the protected base method, so both route through
+ * this free function instead of re-implementing the guard.
+ */
+export function emitServerToolResult(
+  logger: AgentTrace,
+  progressViewEnabled: boolean,
+  result: WebSearchResult,
+): void {
+  if (progressViewEnabled) {
+    logWebSearch(logger, result);
+  }
+}

--- a/src/test-kernel/agent/modelHandlers/AnthropicStreamHandlerEmission.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/AnthropicStreamHandlerEmission.vitest.ts
@@ -1,0 +1,108 @@
+// Third-party imports
+import { describe, it, expect, vi } from 'vitest';
+
+// Local imports - class under test
+import type { AgentTrace } from '@agent/trace';
+import { AnthropicStreamHandler } from '@agent/modelHandlers/support/AnthropicStreamHandler';
+
+// Type imports
+import type { BetaRawMessageStreamEvent } from '@anthropic-ai/sdk/resources/beta/messages';
+
+function createLoggerStub() {
+  return {
+    streamId: 'test',
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    domain: vi.fn(),
+    openStream: vi.fn(),
+  };
+}
+
+/**
+ * Builds a handler wired to a captured event callback, so tests can push
+ * synthetic stream events without a real Anthropic SDK stream.
+ */
+function createHandlerHarness(progressViewEnabled: boolean) {
+  const logger = createLoggerStub();
+  const handler = new AnthropicStreamHandler(
+    logger as unknown as AgentTrace,
+    { progressViewEnabled },
+    {
+      createThinkingStream: () =>
+        ({ append: vi.fn(), finalize: vi.fn() }) as never,
+      createOutputStream: () =>
+        ({ append: vi.fn(), finalize: vi.fn() }) as never,
+    },
+  );
+
+  let onStreamEvent: ((event: BetaRawMessageStreamEvent) => void) | undefined;
+  handler.attachToStream({
+    on: (eventName: string, cb: (event: BetaRawMessageStreamEvent) => void) => {
+      if (eventName === 'streamEvent') onStreamEvent = cb;
+    },
+  } as never);
+
+  const emit = (event: unknown) =>
+    onStreamEvent?.(event as BetaRawMessageStreamEvent);
+
+  return { logger, handler, emit };
+}
+
+/** Emits the server_tool_use + web_search_tool_result pair that triggers emission. */
+function emitWebSearchSequence(emit: (event: unknown) => void) {
+  emit({
+    type: 'content_block_start',
+    index: 0,
+    content_block: {
+      type: 'server_tool_use',
+      id: 'call_1',
+      name: 'web_search',
+      input: {},
+    },
+  });
+  emit({
+    type: 'content_block_start',
+    index: 1,
+    content_block: {
+      type: 'web_search_tool_result',
+      tool_use_id: 'call_1',
+      content: [
+        {
+          type: 'web_search_result',
+          url: 'https://example.com',
+          title: 'Example',
+          encrypted_content: 'enc',
+          page_age: null,
+        },
+      ],
+    },
+  });
+}
+
+describe('AnthropicStreamHandler server-tool-result emission guard', () => {
+  it('emits a webSearch domain event when the progress view is enabled', () => {
+    const { logger, emit } = createHandlerHarness(true);
+
+    emitWebSearchSequence(emit);
+
+    expect(logger.domain).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: 'webSearch',
+        data: expect.objectContaining({
+          callId: 'call_1',
+          status: 'completed',
+        }),
+      }),
+    );
+  });
+
+  it('withholds the webSearch domain event when the progress view is disabled', () => {
+    const { logger, emit } = createHandlerHarness(false);
+
+    emitWebSearchSequence(emit);
+
+    expect(logger.domain).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Two small ModelHandler.ts cleanups from the SDK-readiness audit follow-ups, combined since both touch the same file.

**#7418 — unify the progress-view guard.** `ModelHandler.emitWebSearchResult` has exactly one caller (the OpenAI-Responses closure in `modelHandlerOpenAIResponse.ts`). `support/AnthropicStreamHandler.ts` privately re-implements the identical `if (progressViewEnabled) logWebSearch(...)` guard because it can't reach the protected base method. Extracted a shared free function, `emitServerToolResult(logger, progressViewEnabled, result)`, in a new `support/serverToolResultEmission.ts`; both `ModelHandler.emitWebSearchResult` and `AnthropicStreamHandler`'s private method now route through it, and the duplicated guard logic is gone.

**#7419 — inline the single-caller hook.** `ModelHandler.createContinuationPrompt` had zero provider overrides and exactly one internal caller (`addContinueMessage`). Inlined it into `addContinueMessage` and removed the now-unused method.

## Verification

- `npm run typecheck` — clean.
- Full `src/test-kernel/agent/modelHandlers/` + `src/test-kernel/modelHandlers/` vitest suites (50 files, 414 tests) — all pass, zero unrelated behavior change.
- Added `src/test-kernel/agent/modelHandlers/AnthropicStreamHandlerEmission.vitest.ts`: direct coverage of `AnthropicStreamHandler`'s web-search-result emission for both `progressViewEnabled: true` (domain event fires) and `false` (withheld) — the existing suite didn't exercise this guard directly.
- `npx eslint` on all changed files — clean (0 errors, 0 warnings after auto-fixing two import-order nits).

Closes #7418
Closes #7419

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor and test-only coverage with no auth or data-path changes; continuation and web-search logging behavior stay the same.
> 
> **Overview**
> **Unifies** the duplicated `progressViewEnabled` → `logWebSearch` guard into `emitServerToolResult` in `support/serverToolResultEmission.ts`. `ModelHandler.emitWebSearchResult` and `AnthropicStreamHandler` now both call that helper instead of repeating the same `if` block.
> 
> **Inlines** the unused `createContinuationPrompt` hook into `addContinueMessage` on `ModelHandler` (no provider overrides); continuation behavior is unchanged.
> 
> **Adds** `AnthropicStreamHandlerEmission.vitest.ts` to assert web-search domain events fire when the progress view is on and are withheld when it is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21529d357ef2ac91aafa427ca1195d4616b92e8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->