### PR TITLE
Make four single-implementer Platform ports optional

### DIFF
--- a/src/platform/defaults/nodeHost.ts
+++ b/src/platform/defaults/nodeHost.ts
@@ -91,14 +91,12 @@ export function createNodePlatform(services: NodePlatformServices): Platform {
       ...NO_TOOL_AVAILABILITY_HOST,
       ...services.toolAvailability,
     },
-    // Neither Node host has a UI surface for these yet (linter diagnostics,
-    // inline criticism, tool-missing/unavailable toasts) — explicit no-ops
-    // here, in the one place both hosts share, rather than an invisible
-    // per-module default.
-    linter: async () => [],
-    addCriticismSink: () => ({ accepted: false, resolvedPath: '' }),
-    toolMissingHandler: () => {},
-    toolNotificationHandler: () => {},
+    // Neither Node host has a UI surface for linter diagnostics, inline
+    // criticism, or tool-missing/unavailable toasts. Those four Platform
+    // ports (`linter`, `addCriticismSink`, `toolMissingHandler`,
+    // `toolNotificationHandler`) are optional and simply omitted here; core
+    // call sites treat an absent port as a no-op rather than requiring every
+    // host to supply a stub implementation.
     // Default handler throws — a host must override this to support tool-edit
     // approvals.  CLI and desktop override via a session-scoped indirection
     // (see the host's own initPlatform code); the extension wires its native

--- a/src/platform/platform.ts
+++ b/src/platform/platform.ts
@@ -47,14 +47,32 @@ export interface Platform {
   readonly agentResume: AgentResumePort;
   readonly agentDirectories: AgentDirectoriesPort;
   readonly toolAvailability: ToolAvailabilityHost;
-  /** Linter diagnostics provider for the diagnostics tool's `list`/`count` commands. */
-  readonly linter: LinterProvider;
-  /** Sink for the diagnostics tool's `add` (manual criticism) command. */
-  readonly addCriticismSink: AddCriticismSink;
-  /** Surfaces a tool-missing error to the user. */
-  readonly toolMissingHandler: ToolMissingHandler;
-  /** Surfaces a tool-group-unavailable notification to the user. */
-  readonly toolNotificationHandler: ToolNotificationHandler;
+  /**
+   * Linter diagnostics provider for the diagnostics tool's `list`/`count`
+   * commands. Only the VS Code host implements this; hosts without a linter
+   * integration (CLI, desktop) omit it entirely — callers treat a missing
+   * port as "no diagnostics" rather than requiring a no-op stub.
+   */
+  readonly linter?: LinterProvider;
+  /**
+   * Sink for the diagnostics tool's `add` (manual criticism) command. Only
+   * the VS Code host implements this; hosts without an inline-criticism
+   * surface (CLI, desktop) omit it entirely — callers treat a missing port
+   * as "not accepted".
+   */
+  readonly addCriticismSink?: AddCriticismSink;
+  /**
+   * Surfaces a tool-missing error to the user. Only the VS Code host
+   * implements this; hosts without a UI for it (CLI, desktop) omit it
+   * entirely — callers treat a missing port as a no-op.
+   */
+  readonly toolMissingHandler?: ToolMissingHandler;
+  /**
+   * Surfaces a tool-group-unavailable notification to the user. Only the VS
+   * Code host implements this; hosts without a UI for it (CLI, desktop) omit
+   * it entirely — callers treat a missing port as a no-op.
+   */
+  readonly toolNotificationHandler?: ToolNotificationHandler;
   /** Host-provided tool-edit approval UI (diff viewer + accept/reject). */
   readonly toolEditApproval: ToolEditApprovalPort;
 }

--- a/src/test-kernel/desktop/ElectronAgentDirectories.vitest.mts
+++ b/src/test-kernel/desktop/ElectronAgentDirectories.vitest.mts
@@ -128,10 +128,9 @@ describe('desktop agent directory bootstrap', () => {
         },
       }),
       toolAvailability: NO_TOOL_AVAILABILITY_HOST,
-      linter: async () => [],
-      addCriticismSink: () => ({ accepted: false, resolvedPath: '' }),
-      toolMissingHandler: () => {},
-      toolNotificationHandler: () => {},
+      // linter / addCriticismSink / toolMissingHandler / toolNotificationHandler
+      // are optional Platform ports with no desktop implementation — omitted
+      // here rather than stubbed.
       toolEditApproval: () => {
         throw new Error('Tool edit approval not available in this test.');
       },

--- a/src/test-kernel/tools/DiagnosticsTool.vitest.ts
+++ b/src/test-kernel/tools/DiagnosticsTool.vitest.ts
@@ -47,6 +47,21 @@ describe('DiagnosticsTool', () => {
     });
   });
 
+  it('treats an absent linter port as no diagnostics (optional Platform port)', async () => {
+    await installPlatform({}, { linter: undefined });
+    const result = await withRunContext(worktreeContext(), () =>
+      new DiagnosticsTool().call({ command: 'list', path: 'paper.tex' }),
+    );
+
+    expect(result.status).toBe('executed');
+    expect(result.diagnostics).toMatchObject({
+      path: '/worktree/paper.tex',
+      command: 'list',
+      severity: { errors: 0, warnings: 0, info: 0, hints: 0 },
+      messages: [],
+    });
+  });
+
   it('rejects an add command missing required fields', async () => {
     const result = await new DiagnosticsTool().call({
       command: 'add',
@@ -68,6 +83,23 @@ describe('DiagnosticsTool', () => {
       accepted: false,
       resolvedPath: '',
     }));
+
+    const result = await withRunContext(worktreeContext(), () =>
+      new DiagnosticsTool().call({
+        command: 'add',
+        path: 'paper.tex',
+        line: 3,
+        message: 'tighten this claim',
+        severity: 4,
+        confidence: 5,
+      }),
+    );
+
+    expect(result.summary).toBe('Criticism not accepted');
+  });
+
+  it('treats an absent addCriticismSink port as not accepted (optional Platform port)', async () => {
+    await installPlatform({}, { addCriticismSink: undefined });
 
     const result = await withRunContext(worktreeContext(), () =>
       new DiagnosticsTool().call({

--- a/src/test-kernel/tools/ToolUnavailableNotification.vitest.ts
+++ b/src/test-kernel/tools/ToolUnavailableNotification.vitest.ts
@@ -1,0 +1,32 @@
+// Third-party imports
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { installPlatform } from '../support/setupPlatform';
+
+afterEach(async () => {
+  vi.doUnmock('@tools/externalToolDefs');
+  vi.resetModules();
+  await installPlatform();
+});
+
+describe('notifyUnavailableTools', () => {
+  it('no-ops when the host omits toolNotificationHandler (optional Platform port)', async () => {
+    vi.doMock('@tools/externalToolDefs', () => ({
+      EXTERNAL_TOOL_DEFS: [
+        {
+          id: 'test-tool',
+          tools: ['test_tool'],
+          name: 'Test tool',
+          category: 'ai-agents',
+          check: vi.fn(async () => true),
+        },
+      ],
+    }));
+    await installPlatform({}, { toolNotificationHandler: undefined });
+    const { notifyUnavailableTools } =
+      await import('@tools/toolUnavailableNotification');
+
+    // Must not throw even though the host has no notification surface.
+    expect(() => notifyUnavailableTools(['test_tool'])).not.toThrow();
+  });
+});

--- a/src/test-kernel/utils/system/ToolUtilsMissingHandler.vitest.ts
+++ b/src/test-kernel/utils/system/ToolUtilsMissingHandler.vitest.ts
@@ -1,0 +1,18 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { installPlatform } from '@test/support/setupPlatform';
+import { checkToolInstalled } from '@utils/system/toolUtils';
+
+afterEach(async () => {
+  await installPlatform();
+});
+
+describe('checkToolInstalled', () => {
+  it('reports an unknown tool as not installed even when toolMissingHandler is absent (optional Platform port)', async () => {
+    await installPlatform({}, { toolMissingHandler: undefined });
+
+    await expect(
+      checkToolInstalled('definitely-not-a-real-tool-xyz', true),
+    ).resolves.toBe(false);
+  });
+});

--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -128,7 +128,7 @@ export class DiagnosticsTool extends defineTool({
     const diagnosticsPath = this.resolveAbsolutePath(path);
 
     try {
-      const messages = await platform().linter(diagnosticsPath);
+      const messages = (await platform().linter?.(diagnosticsPath)) ?? [];
       const counts = countBySeverity(messages);
       const header = `${diagnosticsPath}: ${formatCounts(counts)}`;
       const summary = `Diagnostics ${command} for ${diagnosticsPath}`;
@@ -173,13 +173,13 @@ export class DiagnosticsTool extends defineTool({
 
     try {
       const absolutePath = this.resolveAbsolutePath(path);
-      const result = platform().addCriticismSink({
+      const result = platform().addCriticismSink?.({
         absolutePath,
         line,
         message,
         severity,
         confidence,
-      });
+      }) ?? { accepted: false, resolvedPath: absolutePath };
       if (!result.accepted) {
         return {
           status: 'executed',

--- a/src/tools/toolUnavailableNotification.ts
+++ b/src/tools/toolUnavailableNotification.ts
@@ -44,7 +44,7 @@ export function notifyUnavailableTools(excludedToolNames: string[]): void {
   const hiddenGroups = fresh.filter((g) => g.hideFromDashboard);
   if (hiddenGroups.length > 0) {
     const label = formatGroupLabel(hiddenGroups.map((g) => g.name));
-    tryPlatform()?.toolNotificationHandler(
+    tryPlatform()?.toolNotificationHandler?.(
       `${label} excluded — external dependencies not installed.`,
     );
   }
@@ -65,7 +65,7 @@ export function notifyUnavailableTools(excludedToolNames: string[]): void {
   for (const [bucketKey, bucket] of byAction) {
     const [cmd, label] = bucketKey.split('\0');
     const names = formatGroupLabel(bucket.map((g) => g.name));
-    tryPlatform()?.toolNotificationHandler(
+    tryPlatform()?.toolNotificationHandler?.(
       `${names} excluded — external dependencies not installed.`,
       cmd,
       label,

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -46,7 +46,7 @@ async function reportMissingTool(
   openDocsCommand?: string,
 ): Promise<void> {
   try {
-    await platform().toolMissingHandler(message, openDocsCommand);
+    await platform().toolMissingHandler?.(message, openDocsCommand);
   } catch (err) {
     logger.error(
       CHANNEL,


### PR DESCRIPTION
## Summary

- `linter`, `addCriticismSink`, `toolMissingHandler`, and `toolNotificationHandler` are now optional on the `Platform` interface (`src/platform/platform.ts`). Only the VS Code extension host (`packages/extension/src/extension.ts`) implements them; both Node hosts (CLI, desktop) go through the shared `createNodePlatform` helper and previously had to fabricate explicit no-op stubs for all four just to satisfy the interface.
- `createNodePlatform` (`src/platform/defaults/nodeHost.ts`) no longer supplies those four stubs — they're simply omitted, and core call sites treat an absent port as a no-op:
  - `DiagnosticsTool.linter?.(...)  ?? []` (no diagnostics)
  - `DiagnosticsTool.addCriticismSink?.(...) ?? { accepted: false, ... }` (not accepted)
  - `toolUtils.toolMissingHandler?.(...)` (no-op)
  - `toolUnavailableNotification.toolNotificationHandler?.(...)` (no-op)
- Considered collapsing `toolMissingHandler`/`toolNotificationHandler` into one host-notification port (per the issue's "also consider" note) but skipped it: their signatures and presentation differ (error message + docs-link action vs. info message + dashboard action), so unifying them added risk without a clear LOC or clarity win. The four-ports-optional change was the core ask and is a clean, low-risk win on its own.

## Host audit

- **VS Code** (`packages/extension/src/extension.ts`): unchanged — still wires real implementations for all four ports.
- **Desktop** and **CLI**: both compose their `Platform` via `createNodePlatform`, which now simply omits the four ports rather than stubbing them. Neither host references these ports anywhere else.
- Trimmed the same four now-unnecessary stub lines from a desktop test (`ElectronAgentDirectories.vitest.mts`) that hand-rolled a `Platform` object, and left `FakePlatform.ts`'s existing no-op defaults in place (harmless, since the fields are now optional).

## Test plan

- [x] `npm run typecheck` (full workspace: root, test-kernel, CLI, desktop, trace-viewer) — green.
- [x] `npx vitest run` targeted at every touched file's suite (`DiagnosticsTool.vitest.ts`, the new `ToolUnavailableNotification.vitest.ts` and `ToolUtilsMissingHandler.vitest.ts`, `ElectronAgentDirectories.vitest.mts`) plus the full `src/test-kernel/tools` and `src/test-kernel/utils/system` directories (455 tests) — all pass.
- [x] Added regression coverage for the actual behavior change: absent `linter`, `addCriticismSink`, and `toolMissingHandler`/`toolNotificationHandler` ports are exercised directly and asserted to no-op instead of throwing.
- [x] `npx eslint` on all changed/added files — clean.
- [x] `npm run format` — pre-commit hook passed on the first commit.

Closes #7421

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Interface and host-composition cleanup with explicit no-op semantics at call sites; VS Code wiring unchanged and behavior on Node hosts matches the previous stubs.
> 
> **Overview**
> **Four Platform ports** (`linter`, `addCriticismSink`, `toolMissingHandler`, `toolNotificationHandler`) are now **optional** on `Platform`. Only the VS Code host implements them; CLI and desktop no longer need no-op stubs in `createNodePlatform` or hand-rolled test platforms.
> 
> **Call sites** use optional chaining and safe defaults: empty diagnostics, criticism not accepted, and silent skips when notification/missing-tool UI is absent (`DiagnosticsTool`, `toolUtils`, `toolUnavailableNotification`).
> 
> **Tests** add regression coverage for omitted ports and drop redundant stub wiring in the desktop agent-directories harness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23511ec79db86f88cd68d21bf559f6539ee3d576. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->