### PR TITLE
refactor(logger): make createChannelTrace a thin closure over logUtils

### DIFF
--- a/src/logger/channelTrace.ts
+++ b/src/logger/channelTrace.ts
@@ -6,18 +6,39 @@
  * `@transcript` so this package stays free of any product/transcript
  * dependency and can be reused by SDK consumers that only want channel
  * logging.
+ *
+ * A thin closure over the functional `@logger/logUtils` logger, not a
+ * `TraceEmitter` — these module-level singletons only ever call
+ * debug/info/warn/error, so there is no subscriber set or ALS stage scope
+ * to allocate. Everything else on `AgentTrace` no-ops, borrowed from
+ * `noopTrace` (leaf imports, not the `@agent/trace` barrel, which pulls in
+ * `TraceEmitter` and would cycle back into this logger).
+ *
+ * Note: unlike the trace-subscriber path (`attachChannelSubscriber`, used
+ * by the real per-run trace), this does not suppress `messageType:
+ * INTERNAL` lines — `LogUtilsOptions` has no `messageType` field for it to
+ * read. None of these channel-only callers set it.
  */
-import { TraceEmitter, type AgentTrace } from '@agent/trace';
+import { noopTrace } from '@agent/trace/noopTrace';
+import type { AgentTrace } from '@agent/trace/AgentTrace';
 
-import { attachChannelSubscriber } from './logUtils';
+import * as logUtils from './logUtils';
 
 /**
  * Produce a trace that writes log events to a per-channel output sink and
- * ignores everything else. Used by module-level singletons that exist
+ * no-ops everything else. Used by module-level singletons that exist
  * outside any agent run.
  */
 export function createChannelTrace(name: string): AgentTrace {
-  const trace = new TraceEmitter();
-  attachChannelSubscriber(trace, { channel: name, isAgent: false });
-  return trace;
+  return {
+    ...noopTrace,
+    debug: (message, options) =>
+      logUtils.debug(name, message, { data: options?.data }),
+    info: (message, options) =>
+      logUtils.info(name, message, { data: options?.data }),
+    warn: (message, options) =>
+      logUtils.warn(name, message, { data: options?.data }),
+    error: (message, options) =>
+      logUtils.error(name, message, { data: options?.data }),
+  };
 }

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -9,9 +9,10 @@
  *
  *   2. `attachChannelSubscriber(trace, { channel, isAgent })` — subscribes
  *      the same sink machinery to an {@link AgentTrace}. Used by
- *      `createChannelTrace` / `createRunTrace` so the trace channel
- *      converges on the same output sinks. Replaces the former
- *      `consoleSubscriber.ts` pass-through.
+ *      `createRunTrace` so the real per-run trace channel converges on the
+ *      same output sinks. Replaces the former `consoleSubscriber.ts`
+ *      pass-through. (`createChannelTrace`'s module-level singletons close
+ *      over surface 1 directly — no `AgentTrace` subscriber involved.)
  *
  * Output-channel creation is host-injected via {@link setOutputChannelFactory};
  * the VS Code extension provides a factory that returns VS Code

--- a/src/test-kernel/logger/ChannelTrace.vitest.ts
+++ b/src/test-kernel/logger/ChannelTrace.vitest.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createChannelTrace } from '@logger';
+import * as logUtils from '@logger/logUtils';
+import { MESSAGE_TYPES } from '@shared/schemas';
+import * as config from '@utils/config';
+
+describe('createChannelTrace', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    logUtils.setOutputChannelFactory(null);
+  });
+
+  function captureLines(): string[] {
+    const lines: string[] = [];
+    logUtils.setOutputChannelFactory(() => ({
+      appendLine(message: string) {
+        lines.push(message);
+      },
+    }));
+    return lines;
+  }
+
+  it('routes debug/info/warn/error straight to the channel sink', () => {
+    const lines = captureLines();
+    const trace = createChannelTrace('ChannelTraceTest');
+
+    trace.debug('debug line');
+    trace.info('info line');
+    trace.warn('warn line');
+    trace.error('error line');
+
+    const output = lines.join('\n');
+    expect(output).toContain('debug line');
+    expect(output).toContain('info line');
+    expect(output).toContain('warn line');
+    expect(output).toContain('error line');
+  });
+
+  it('forwards the data payload through to the sink in debug mode', () => {
+    vi.spyOn(config, 'getConfig').mockReturnValue(true);
+    const lines = captureLines();
+    const trace = createChannelTrace('ChannelTraceTest');
+
+    trace.warn('payload line', { data: { foo: 'bar' } });
+
+    const output = lines.join('\n');
+    expect(output).toContain('payload line');
+    expect(output).toContain('"foo"');
+    expect(output).toContain('"bar"');
+  });
+
+  it('does not suppress messageType: INTERNAL lines (no callers rely on that)', () => {
+    // Unlike the real per-run trace (attachChannelSubscriber), the channel
+    // trace's plain log methods forward straight to the functional logger,
+    // which has no `messageType` concept to filter on. This is the
+    // documented, confirmed-safe behavior change from issue #7420: none of
+    // the 25 module-singleton callers of `createChannelTrace` ever set
+    // `messageType`, so there is nothing here to regress.
+    const lines = captureLines();
+    const trace = createChannelTrace('ChannelTraceTest');
+
+    trace.info('internal-tagged line', { messageType: MESSAGE_TYPES.INTERNAL });
+
+    expect(lines.join('\n')).toContain('internal-tagged line');
+  });
+
+  it('no-ops the rest of the AgentTrace surface instead of allocating a TraceEmitter', () => {
+    const trace = createChannelTrace('ChannelTraceTest');
+
+    // subscribe/emit never reach a real subscriber set — there isn't one.
+    const unsubscribe = trace.subscribe(() => {
+      throw new Error('should never be called');
+    });
+    expect(() =>
+      trace.emit({ type: 'log', level: 'info', message: 'x' }),
+    ).not.toThrow();
+    expect(() => unsubscribe()).not.toThrow();
+
+    // Stage/stream handles are safe no-ops, matching `noopTrace`.
+    const stage = trace.openStage('stage');
+    expect(() => stage.end()).not.toThrow();
+    const stream = trace.openStream(MESSAGE_TYPES.THINKING);
+    stream.append('chunk');
+    expect(stream.finalize()).toBe('');
+  });
+});


### PR DESCRIPTION
## Root cause

25 non-test module-level singletons (`UserQuestionTool.ts`, `PlanTool.ts`,
`TodoTool.ts`, `SessionEventHub.ts`, `ModelHandler.ts`, etc.) call
`createChannelTrace(name)` at module scope just to reach
`.debug/.info/.warn/.error`. Each call allocated a full `TraceEmitter` — a
`Set`-of-subscribers plus an `AsyncLocalStorage` stage scope — and wired
`attachChannelSubscriber` onto it, when the functional `@logger/logUtils`
logger (already used by ~144 other non-trace callers) reaches the exact
same `writeLine` sink directly.

## Fix

`createChannelTrace` now returns `noopTrace` (the existing no-op
`AgentTrace` used elsewhere for SDK consumers that don't need the full
trace surface) with `debug`/`info`/`warn`/`error` overridden to forward
straight to `logUtils.debug/info/warn/error`. No `TraceEmitter`
allocation, no subscriber wiring. The function's signature
(`createChannelTrace(name: string): AgentTrace`) is unchanged, so none of
the 25 call sites need touching.

Also swapped the `@agent/trace` barrel import for leaf imports
(`@agent/trace/noopTrace`, `@agent/trace/AgentTrace`) — the barrel
re-exports `TraceEmitter`, which imports `@logger/logUtils`, so importing
it from `@logger/channelTrace.ts` was a `logger → agent/trace → logger`
cycle. `logUtils.ts` already documents/avoids this same cycle for its own
type-only imports; this file now follows the same precedent.

## Behavior nuance (confirmed before merging, per the issue)

`attachChannelSubscriber` (the old path) suppresses `messageType: INTERNAL`
log lines from reaching the console. `LogUtilsOptions` has no
`messageType` field, so the new closure has nothing to filter on.

I grepped every `.debug/.info/.warn/.error` call at all 25
`createChannelTrace` call sites for a `messageType` option — none set one
(that option is only used by the `@agent/trace/helpers.ts` sugar functions
operating on **real per-run traces**, never on these module-level
channel-only singletons). Two extra sites looked risky on first read but
turned out not to touch this trace at all:

- `ModelHandler`'s constructor sets `this.logger = createChannelTrace('Agent')`
  as a placeholder, and later calls `this.logger.openStream(...)`. But
  `setLogger()` always replaces it with the real per-run trace before any
  message is sent (`AgentLaunchContext.ts`, `runToolUseFlow.ts`), so the
  placeholder's `openStream` is never exercised in practice — and even if
  it were, `noopTrace`'s no-op stream handle is a safe default (same
  pattern already used elsewhere for SDK consumers).
- Several sites pass their channel-trace singleton as
  `{ trace: this.logger }` into `StreamStatusMachine.transition(...)`,
  which calls `trace?.emit(statusEvent)`. But the old
  `attachChannelSubscriber` subscriber only ever handled `event.type ===
  'log'` — it silently dropped `status` events already, so this `emit()`
  call was already inert before this change. Making `emit` a true no-op
  is behaviorally identical.

## Verification

```
npx tsc --noEmit                                                  # clean (pre-existing unrelated @openrouter/sdk / vscode-jsonrpc errors only, confirmed identical on origin/main)
npx eslint src/logger/channelTrace.ts src/logger/logUtils.ts src/test-kernel/logger/ChannelTrace.vitest.ts   # clean
npx prettier --check <same files>                                 # clean
npx vitest run src/test-kernel/logger/ChannelTrace.vitest.ts src/test-kernel/logger/LogUtils.vitest.ts src/test-kernel/logger/RunTraceDispose.vitest.ts src/test-kernel/logger/errorData.vitest.ts   # 9 passed
npx vitest run src/test-kernel/tools/PollingSourceBase.vitest.ts src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts src/test-kernel/agent/runtime/SessionHandle.vitest.ts src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts   # 60 passed
npx vitest run   # full suite: 550 files / 3864 tests passed (was 549/3860 on origin/main — this PR adds a new ChannelTrace.vitest.ts with 4 tests, zero regressions). The 75 failing files on both branches are pre-existing worktree node_modules issues (missing `citty`, `vscode-jsonrpc/node`, `@openrouter/sdk` packages), unrelated to this change — confirmed identical failure count via `git stash` before/after.
```

Added `src/test-kernel/logger/ChannelTrace.vitest.ts` covering: plain
log-forwarding, `data` payload passthrough in debug mode, the confirmed-safe
`messageType: INTERNAL` non-suppression, and no-op behavior for the rest of
the `AgentTrace` surface (`subscribe`/`emit`/`openStage`/`openStream`).

Fixes #7420.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with preserved public API and documented, caller-verified logging nuance; no auth or data-path changes.
> 
> **Overview**
> **`createChannelTrace`** no longer builds a **`TraceEmitter`** or wires **`attachChannelSubscriber`**. It returns **`noopTrace`** with **`debug`/`info`/`warn`/`error`** overridden to call **`logUtils`** directly, so module-level channel singletons avoid subscriber sets and ALS while keeping the same **`AgentTrace`** API.
> 
> Imports switch from the **`@agent/trace`** barrel to **`noopTrace`** and type-only **`AgentTrace`** to break a **`logger → agent/trace → logger`** cycle. **`logUtils`** docs now note that **`createChannelTrace`** uses the functional logger path, not the trace subscriber.
> 
> **Behavior:** logs no longer drop **`messageType: INTERNAL`** on this path ( **`LogUtilsOptions`** has no **`messageType`** ); callers of **`createChannelTrace`** were confirmed not to rely on that. Non-log **`AgentTrace`** methods stay no-ops via **`noopTrace`**.
> 
> New **`ChannelTrace.vitest.ts`** covers sink routing, debug **`data`** payloads, INTERNAL non-suppression, and no-op trace surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 572ed578d2d7eda482950d308be54639423689d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->