### PR TITLE
refactor: move status bar updates to session events

### DIFF
--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -21,6 +21,7 @@ import { loadAgents } from '@agent/index';
 import { clearStoreCache, listExecutions } from '@agent/storage';
 import { registerAgentFeatures } from '@agent/features';
 import { initializeGoalPrompts } from '@agent/goal';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import { registerAgentShutdownHandlers } from '@agent/runtime/agentShutdown';
 import { initializePolishModel } from '@agent/runtime/polishModel';
 import {
@@ -46,7 +47,6 @@ import { openGettingStarted } from '@commands/system/walkthroughCommands';
 import { SIDEBAR_VIEWS, setActiveSidebarView } from '@common/webview';
 import { globalSM, initializeStateManagers, workspaceSM } from '@common/state';
 import { appSignals } from '@eventBus/AppSignals';
-import { ProgressEventBus } from '@eventBus/ProgressEventBus';
 import { SecretManager } from '@frontend/secretManager';
 import {
   copyDefaultAgents,
@@ -59,6 +59,7 @@ import { runTerminalCommand } from '@frontend/setupTerminalRunner';
 import { agentDirectories } from '@frontend/agents';
 import { FileLister } from '@frontend/files';
 import { StatusBarUsageTracker } from '@frontend/statusBar/StatusBarUsageTracker';
+import { subscribeStatusBarSessionEvents } from '@frontend/statusBar/statusBarSessionEvents';
 import { killActiveRecording } from '@frontend/media/audio';
 import { disposeDiffRefresh } from '@frontend/ui/diffView';
 import { registerFileDecorations } from '@frontend/ui/fileDecorations';
@@ -98,10 +99,6 @@ import {
   hasUsableApiKey,
 } from '@model/apiProviders';
 import { refreshModelListStateIfNeeded } from '@model/modelListRefresh';
-import {
-  type StreamLifecycleStatus,
-  type TokenUsageStats,
-} from '@shared/schemas';
 import { migrateLegacyGlobalBashApprovalOverride } from '@shared/settingsView/handlers/approvalHandlers';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { setOpenPdfOpener } from '@tools/OpenPdfTool';
@@ -730,33 +727,16 @@ export async function activate(context: vscode.ExtensionContext) {
     }
   };
 
-  const disposeStreamStatusListener = ProgressEventBus.on(
-    'updateStreamStatus',
-    ({
-      streamId,
-      status,
-    }: {
-      streamId: string;
-      status: StreamLifecycleStatus;
-    }) => {
-      statusBarUsageTracker.updateStreamStatus(streamId, status);
+  disposeStatusListener = subscribeStatusBarSessionEvents({
+    session: defaultSession(),
+    tracker: statusBarUsageTracker,
+    onStatusChanged: () => {
       updateStatusBarTooltip();
       updateStatusBarText();
     },
-  );
-  const disposeUsageListener = ProgressEventBus.on(
-    'updateStreamUsage',
-    ({ streamId, usage }: { streamId: string; usage: TokenUsageStats }) => {
-      // UsageMonitor emits per-round deltas; the tracker accumulates them.
-      if (statusBarUsageTracker.recordUsage(streamId, usage)) {
-        updateStatusBarTooltip();
-      }
-    },
-  );
-  disposeStatusListener = () => {
-    disposeStreamStatusListener();
-    disposeUsageListener();
-  };
+    // UsageMonitor emits per-round deltas; the tracker accumulates them.
+    onUsageChanged: updateStatusBarTooltip,
+  });
 
   const showMainView = async () => {
     const mvp = getMainViewProvider();

--- a/packages/extension/src/frontend/statusBar/statusBarSessionEvents.ts
+++ b/packages/extension/src/frontend/statusBar/statusBarSessionEvents.ts
@@ -1,0 +1,50 @@
+// Local imports - runtime events
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import { toUpdateStreamUsagePayload } from '@agent/runtime/sessionProgressEventProjection';
+
+// Local imports - status bar state
+import type { StatusBarUsageTracker } from './StatusBarUsageTracker';
+
+export interface StatusBarSessionEventOptions {
+  session: Pick<SessionHandle, 'events' | 'status'>;
+  tracker: StatusBarUsageTracker;
+  onStatusChanged: () => void;
+  onUsageChanged: () => void;
+}
+
+/**
+ * Mirrors the canonical session status and usage facts into the extension
+ * status-bar usage tracker.
+ */
+export function subscribeStatusBarSessionEvents({
+  session,
+  tracker,
+  onStatusChanged,
+  onUsageChanged,
+}: StatusBarSessionEventOptions): () => void {
+  const disposeStatus = session.status.onDidChange(({ streamId, status }) => {
+    tracker.updateStreamStatus(streamId, status);
+    onStatusChanged();
+  });
+
+  const disposeUsage = session.events.subscribe(
+    (sessionEvent) => {
+      if (sessionEvent.scope !== 'run') return;
+      if (sessionEvent.event.type !== 'usage') return;
+      const payload = toUpdateStreamUsagePayload(
+        sessionEvent.event.data,
+        sessionEvent.streamId,
+      );
+      if (!payload) return;
+      if (tracker.recordUsage(payload.streamId, payload.usage)) {
+        onUsageChanged();
+      }
+    },
+    { scope: 'run', types: ['usage'] },
+  );
+
+  return () => {
+    disposeStatus();
+    disposeUsage();
+  };
+}

--- a/src/test-kernel/frontend/StatusBarSessionEvents.vitest.ts
+++ b/src/test-kernel/frontend/StatusBarSessionEvents.vitest.ts
@@ -1,0 +1,121 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports - runtime events
+import { SessionHandle } from '@agent/runtime/SessionHandle';
+
+// Local imports - status bar state
+import { StatusBarUsageTracker } from '@frontend/statusBar/StatusBarUsageTracker';
+import { subscribeStatusBarSessionEvents } from '@frontend/statusBar/statusBarSessionEvents';
+import { STREAM_PHASE } from '@shared/schemas';
+
+describe('subscribeStatusBarSessionEvents', () => {
+  it('tracks stream status changes from the session status plane', () => {
+    const session = new SessionHandle();
+    const tracker = new StatusBarUsageTracker();
+    const onStatusChanged = vi.fn();
+    const onUsageChanged = vi.fn();
+    const dispose = subscribeStatusBarSessionEvents({
+      session,
+      tracker,
+      onStatusChanged,
+      onUsageChanged,
+    });
+
+    session.status.transition('stream-a', STREAM_PHASE.RUNNING, 'lifecycle');
+
+    expect(tracker.activeStreamCount).toBe(1);
+    expect(onStatusChanged).toHaveBeenCalledTimes(1);
+    expect(onUsageChanged).not.toHaveBeenCalled();
+
+    dispose();
+    session.status.transition('stream-a', STREAM_PHASE.COMPLETED, 'lifecycle');
+    expect(tracker.activeStreamCount).toBe(1);
+    expect(onStatusChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it('records valid run usage events after an in-flight status', () => {
+    const session = new SessionHandle();
+    const tracker = new StatusBarUsageTracker();
+    const onStatusChanged = vi.fn();
+    const onUsageChanged = vi.fn();
+    const dispose = subscribeStatusBarSessionEvents({
+      session,
+      tracker,
+      onStatusChanged,
+      onUsageChanged,
+    });
+
+    session.status.transition('stream-a', STREAM_PHASE.RUNNING, 'lifecycle');
+    session.events.emit({
+      scope: 'run',
+      streamId: 'stream-a',
+      event: {
+        type: 'usage',
+        stats: {},
+        data: {
+          streamId: 'stream-a',
+          storageKey: 'run-a',
+          usage: { inputTokens: 10, outputTokens: 20, cost: 0.01 },
+        },
+      },
+    });
+
+    expect(tracker.totalUsage).toEqual({
+      inputTokens: 10,
+      outputTokens: 20,
+      cost: 0.01,
+    });
+    expect(onUsageChanged).toHaveBeenCalledTimes(1);
+
+    dispose();
+  });
+
+  it('ignores malformed usage payloads and usage for unknown streams', () => {
+    const session = new SessionHandle();
+    const tracker = new StatusBarUsageTracker();
+    const onStatusChanged = vi.fn();
+    const onUsageChanged = vi.fn();
+    const dispose = subscribeStatusBarSessionEvents({
+      session,
+      tracker,
+      onStatusChanged,
+      onUsageChanged,
+    });
+
+    session.events.emit({
+      scope: 'run',
+      streamId: 'stream-a',
+      event: {
+        type: 'usage',
+        stats: {},
+        data: {
+          streamId: 'stream-a',
+          storageKey: 'run-a',
+          usage: { inputTokens: 10, outputTokens: 20, cost: 0.01 },
+        },
+      },
+    });
+    session.events.emit({
+      scope: 'run',
+      streamId: 'stream-a',
+      event: {
+        type: 'usage',
+        stats: {},
+        data: {
+          streamId: 'stream-a',
+          usage: { inputTokens: 10, outputTokens: 20, cost: 0.01 },
+        },
+      },
+    });
+
+    expect(tracker.totalUsage).toEqual({
+      inputTokens: 0,
+      outputTokens: 0,
+      cost: 0,
+    });
+    expect(onUsageChanged).not.toHaveBeenCalled();
+
+    dispose();
+  });
+});


### PR DESCRIPTION
## Summary

- Move the VS Code extension status-bar status updates from `ProgressEventBus.on('updateStreamStatus')` to `defaultSession().status.onDidChange`.
- Move status-bar usage updates from `ProgressEventBus.on('updateStreamUsage')` to direct run-scoped `usage` session events.
- Reuse `toUpdateStreamUsagePayload` so status-bar usage parsing matches the shared session-progress projection path.
- Preserve the existing UI behavior: status changes update text and tooltip; usage deltas update tooltip only.

Part of #6968 and #6951.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/frontend/StatusBarUsageTracker.vitest.ts src/test-kernel/frontend/StatusBarSessionEvents.vitest.ts` — 7 tests passed.
- `corepack pnpm exec eslint packages/extension/src/extension.ts packages/extension/src/frontend/statusBar/statusBarSessionEvents.ts src/test-kernel/frontend/StatusBarSessionEvents.vitest.ts`
- `corepack pnpm exec prettier --check packages/extension/src/extension.ts packages/extension/src/frontend/statusBar/statusBarSessionEvents.ts src/test-kernel/frontend/StatusBarSessionEvents.vitest.ts`
- `corepack pnpm run typecheck`
- `corepack pnpm run compile:fast`
- `corepack pnpm test` — 626 files passed, 1 skipped; 5010 tests passed, 4 skipped.
- `corepack pnpm run lint` — 0 errors, 3 pre-existing import-order warnings.

## Boundary Check

This is intentionally extension-only and subscribes to `defaultSession()`, matching current extension production wiring. Desktop and fresh test sessions remain separate owners.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Extension-only UI wiring with preserved callbacks and tests; no auth or data-path changes.
> 
> **Overview**
> The VS Code extension **stops listening to** `ProgressEventBus` for `updateStreamStatus` / `updateStreamUsage` and instead drives the TeXRA status bar from **`defaultSession()`** via a new `subscribeStatusBarSessionEvents` helper.
> 
> Stream lifecycle updates come from **`session.status.onDidChange`**; token usage comes from **run-scoped `usage` session events**, parsed with **`toUpdateStreamUsagePayload`** so usage shape matches the shared session-progress projection (same path as the CLI TUI). **UI behavior is unchanged**: status changes refresh label and tooltip; usage deltas still refresh the tooltip only.
> 
> Vitest coverage was added for status transitions, valid usage after an in-flight stream, disposal, and ignored malformed or unknown-stream usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fd40a0b8400c27f5e1e4fd6927b323256c6815e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->