### PR TITLE
refactor: route child stream removal through host interactions

### DIFF
--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -27,7 +27,6 @@ import { getServerSideKeyService } from '@auth/serverKeys';
 import { setPreferCodexSubscription } from '@auth/codex';
 import { apiKeyCommands } from '@commands/api/apiKeyCommands';
 import { BaseViewMessageHandler } from '@common/webview';
-import { ProgressEventBus } from '@eventBus/ProgressEventBus';
 import { SecretManager } from '@frontend/secretManager';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { loadOptions } from '@frontend/agents/optionsLoader';
@@ -125,15 +124,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     this.followUpPolishController = new ProgressFollowUpPolishController();
     this.handlerRegistry = this.createHandlerRegistry();
 
-    const unsubscribeRemoveStream = ProgressEventBus.on(
-      'removeStream',
-      ({ streamId }) => {
-        void this.streamLifecycleController.deleteStream(streamId);
-        void GoalStore.forget(streamId);
-      },
-    );
-    context.subscriptions.push({ dispose: unsubscribeRemoveStream });
-
     const unsubscribeGoal = subscribeGoalStateChanges(
       defaultSession(),
       ({ streamId }) => {
@@ -146,6 +136,11 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       },
     );
     context.subscriptions.push({ dispose: unsubscribeGoal });
+  }
+
+  public removeStreamFromHost(streamId: StreamTabId): void {
+    void this.streamLifecycleController.deleteStream(streamId);
+    void GoalStore.forget(streamId);
   }
 
   /**

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -178,6 +178,8 @@ export class ProgressViewProvider
       createExtensionHostInteractions({
         runtimeHost: extensionAgentRuntimeHost,
         getApprovalHandlers: () => this.approvalHandlers,
+        removeStream: (streamId) =>
+          this.messageHandler.removeStreamFromHost(streamId),
       }),
     );
     this._disposables.push({ dispose: this.detachHostInteractions });

--- a/packages/extension/src/progressView/extensionHostInteractions.ts
+++ b/packages/extension/src/progressView/extensionHostInteractions.ts
@@ -14,6 +14,7 @@ import type {
 import type { PlanApprovalResult } from '@agent/runtime/PlanApprovalCoordinator';
 import type { ProposalResult } from '@agent/runtime/AgentProposalCoordinator';
 import type { RetryResult } from '@agent/runtime/RetryRequestCoordinator';
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import { nativeRequestApproval } from '@frontend/approval/nativeToolEditApproval';
 import type {
   AgentProposalPermission,
@@ -29,6 +30,7 @@ import type {
 export interface ExtensionHostInteractionsOptions {
   runtimeHost: AgentRuntimeHost;
   getApprovalHandlers(): ApprovalRequestHandlerSet;
+  removeStream(streamId: StreamTabId): void;
 }
 
 type PendingKind = 'bash' | 'plan' | 'proposal' | 'retry' | 'userQuestion';
@@ -203,7 +205,12 @@ export function createExtensionHostInteractions(
       return { threadId: request.threadId };
     },
 
-    handleProgressEvent: () => false,
+    handleProgressEvent(event, payload): boolean {
+      if (event !== 'removeStream') return false;
+      const data = payload as ProgressEventPayloads['removeStream'];
+      options.removeStream(data.streamId);
+      return true;
+    },
 
     pending(): readonly PendingHostInteraction[] {
       return [...pendingRequests.values()].map(({ id, kind, streamId }) => ({

--- a/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
@@ -11,6 +11,7 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import {
   STREAM_PHASE,
   STREAM_STATUS,
@@ -226,6 +227,46 @@ describe('child stream progress events', () => {
       event: 'removeStream',
       payload: { streamId: childStreamId },
     });
+  });
+
+  it('uses host interactions for child stream auto-close when available', () => {
+    const active = createRecordingHost();
+    const removedStreams: StreamTabId[] = [];
+    const host: AgentRuntimeHost = {
+      ...active.host,
+      interactions: {
+        handleProgressEvent: (event, payload) => {
+          if (event !== 'removeStream') return false;
+          const data = payload as ProgressEventPayloads['removeStream'];
+          removedStreams.push(data.streamId);
+          return true;
+        },
+        pending: () => [],
+        resolve: () => false,
+        cancelForStream: () => {},
+      },
+    };
+
+    const childStream = withSessionProgressProjection(host, () =>
+      createChildStream(executionId, parentStreamId, {
+        runtimeHost: host,
+        streamPrefix: 'bash',
+        streamCategory: AgentCategory.ToolUse,
+        agentName: 'test-agent',
+        description: 'Run a background bash command',
+        config,
+        toolName: 'bash',
+      }),
+    );
+
+    withSessionProgressProjection(host, () =>
+      childStream.finalize({ autoClose: true }),
+    );
+
+    expect(removedStreams).toEqual([childStreamId]);
+    expect(active.events.map((entry) => entry.event)).not.toContain(
+      'removeStream',
+    );
   });
 
   it('publishes child loop status changes through the child stream owner', async () => {

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
@@ -54,13 +54,25 @@ function createRuntimeHost() {
   return { emit: vi.fn() };
 }
 
+function createInteractions(options?: {
+  runtimeHost?: ReturnType<typeof createRuntimeHost>;
+  handlers?: ApprovalRequestHandlerSet;
+  removeStream?: (streamId: StreamTabId) => void;
+}) {
+  return createExtensionHostInteractions({
+    runtimeHost: options?.runtimeHost ?? createRuntimeHost(),
+    getApprovalHandlers: () => options?.handlers ?? createHandlers(),
+    removeStream: options?.removeStream ?? (() => {}),
+  });
+}
+
 describe('createExtensionHostInteractions', () => {
   it('shows and resolves plan approvals through existing handlers', async () => {
     const runtimeHost = createRuntimeHost();
     const handlers = createHandlers();
-    const interactions = createExtensionHostInteractions({
+    const interactions = createInteractions({
       runtimeHost,
-      getApprovalHandlers: () => handlers,
+      handlers,
     });
 
     const resultPromise = interactions.requestPlanApproval?.({
@@ -105,9 +117,9 @@ describe('createExtensionHostInteractions', () => {
   it('cancels pending retry requests for a removed stream', async () => {
     const runtimeHost = createRuntimeHost();
     const handlers = createHandlers();
-    const interactions = createExtensionHostInteractions({
+    const interactions = createInteractions({
       runtimeHost,
-      getApprovalHandlers: () => handlers,
+      handlers,
     });
 
     const resultPromise = interactions.requestRetry?.({
@@ -124,9 +136,9 @@ describe('createExtensionHostInteractions', () => {
   it('shows external inquiries without waiting for a user decision', async () => {
     const runtimeHost = createRuntimeHost();
     const handlers = createHandlers();
-    const interactions = createExtensionHostInteractions({
+    const interactions = createInteractions({
       runtimeHost,
-      getApprovalHandlers: () => handlers,
+      handlers,
     });
 
     await expect(
@@ -153,9 +165,8 @@ describe('createExtensionHostInteractions', () => {
 
   it('cancels streamless user questions during unscoped cleanup', async () => {
     const handlers = createHandlers();
-    const interactions = createExtensionHostInteractions({
-      runtimeHost: createRuntimeHost(),
-      getApprovalHandlers: () => handlers,
+    const interactions = createInteractions({
+      handlers,
     });
 
     const resultPromise = interactions.askUserQuestion?.({
@@ -180,10 +191,7 @@ describe('createExtensionHostInteractions', () => {
   it('delegates tool edit approval to the native VS Code port', async () => {
     const nativeResult = { accepted: true };
     mocks.nativeRequestApproval.mockResolvedValue(nativeResult);
-    const interactions = createExtensionHostInteractions({
-      runtimeHost: createRuntimeHost(),
-      getApprovalHandlers: createHandlers,
-    });
+    const interactions = createInteractions();
     const request = {
       path: 'paper.tex',
       originalContent: 'A',
@@ -196,5 +204,19 @@ describe('createExtensionHostInteractions', () => {
       nativeResult,
     );
     expect(mocks.nativeRequestApproval).toHaveBeenCalledWith(request);
+  });
+
+  it('handles extension removeStream requests through the progress lifecycle callback', () => {
+    const removed: StreamTabId[] = [];
+    const interactions = createInteractions({
+      removeStream: (streamId) => removed.push(streamId),
+    });
+
+    expect(
+      interactions.handleProgressEvent('removeStream', {
+        streamId: 'child-a' as StreamTabId,
+      }),
+    ).toBe(true);
+    expect(removed).toEqual(['child-a']);
   });
 });

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -263,6 +263,14 @@ function finalizeChildStream(args: FinalizeChildStreamArgs): void {
   disposeTrace();
 
   if (options?.autoClose) {
-    handle.runtimeHost.emit('removeStream', { streamId: handle.childStreamId });
+    const handled = handle.runtimeHost.interactions?.handleProgressEvent(
+      'removeStream',
+      { streamId: handle.childStreamId },
+    );
+    if (!handled) {
+      handle.runtimeHost.emit('removeStream', {
+        streamId: handle.childStreamId,
+      });
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Remove the extension `ProgressEventBus.on('removeStream')` listener from `ProgressViewMessageHandler`.
- Route child-stream auto-close through `runtimeHost.interactions.handleProgressEvent('removeStream', ...)` when the host claims it.
- Keep the existing `runtimeHost.emit('removeStream', ...)` fallback for hosts that still consume the legacy event, preserving CLI TUI behavior.
- Wire the VS Code extension host interactions to delete the stream through `ProgressStreamLifecycleController` and still call `GoalStore.forget(streamId)`.

Part of #6968 and #6951.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts` — 16 tests passed.
- `corepack pnpm exec eslint src/tools/childStream.ts packages/extension/src/progressView/extensionHostInteractions.ts packages/extension/src/progressView/ProgressViewProvider.ts packages/extension/src/progressView/ProgressViewMessageHandler.ts src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts`
- `corepack pnpm exec prettier --check src/tools/childStream.ts packages/extension/src/progressView/extensionHostInteractions.ts packages/extension/src/progressView/ProgressViewProvider.ts packages/extension/src/progressView/ProgressViewMessageHandler.ts src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts`
- `corepack pnpm run typecheck`
- `corepack pnpm run compile:fast`
- `corepack pnpm test` — 629 files passed, 1 skipped; 5033 tests passed, 4 skipped.
- `corepack pnpm run lint` — 0 errors, 3 pre-existing import-order warnings.

## Boundary Check

Production `ProgressEventBus.on` no longer includes the extension `removeStream` listener. The remaining production bus listeners are desktop root presentation (`requestEnsureProgressView`, `requestShowError`), and the extension runtime host still emits non-presentation run/progress/RPC events to the bus for later slices.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches progress-view stream lifecycle and child-stream teardown; wrong routing could leave orphan tabs or skip cleanup, though the legacy emit fallback limits blast radius for non-extension hosts.
> 
> **Overview**
> **Child-stream auto-close** no longer relies on the extension subscribing to `ProgressEventBus` for `removeStream`. When `finalize({ autoClose: true })` runs, `childStream` first asks `runtimeHost.interactions.handleProgressEvent('removeStream', …)`; only if the host does not handle it does it still `emit('removeStream', …)` (preserving CLI TUI behavior).
> 
> On the **VS Code extension**, `createExtensionHostInteractions` now implements that handler and calls an injected `removeStream` callback. `ProgressViewProvider` wires that to new `ProgressViewMessageHandler.removeStreamFromHost`, which deletes the stream through `ProgressStreamLifecycleController` and clears `GoalStore.forget(streamId)`—the same work the removed bus listener did.
> 
> Tests cover the host-interactions path and assert auto-close does not emit `removeStream` when the host claims the event.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ec1ecfcfa22baac603227f5222de5efcf56218b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->