### PR TITLE
refactor: keep desktop presentation events window-local

### DIFF
--- a/packages/desktop/src/main/desktopProgressEventBridge.ts
+++ b/packages/desktop/src/main/desktopProgressEventBridge.ts
@@ -12,10 +12,7 @@
 
 import type { AgentTrace } from '@agent/trace';
 import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
-import {
-  ProgressEventBus,
-  type ProgressEventPayloads,
-} from '@eventBus/ProgressEventBus';
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import {
   STREAM_PHASE,
   type ProgressViewOutboundMessage,
@@ -111,7 +108,7 @@ export interface DesktopProgressEventBridge {
    */
   onAllStreamsDeleted(): Promise<void>;
 
-  /** Tear down event-bus subscriptions. */
+  /** Tear down local state and ignore any late runtime-host events. */
   dispose(): void;
 }
 
@@ -130,8 +127,6 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
   /** True once `dispose()` has torn down this bridge. */
   private disposed = false;
 
-  private readonly unsubscribe: () => void;
-
   constructor(private readonly opts: DesktopProgressEventBridgeOptions) {
     // Hydrate previously-persisted "ghost" streams so the rail shows
     // the user's prior runs at launch (audit item D / trajectory #19).
@@ -143,26 +138,11 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
     // available, otherwise falls back to "start fresh".
     this.hydrateRestoredStreams();
 
-    // These events can be emitted on the process bus without an active desktop
-    // runtime host. Keep them subscribed here so all desktop windows see
-    // progress-routing and root-error updates. Goal state is session-scoped and
-    // reaches this bridge through `onProgressEvent`.
-    const unsubscribeEnsureProgress = ProgressEventBus.on(
-      'requestEnsureProgressView',
-      () => {
-        opts.routeToProgress();
-      },
-    );
-    const unsubscribeShowError = ProgressEventBus.on(
-      'requestShowError',
-      ({ message }) => {
-        opts.onShowError(message);
-      },
-    );
-    this.unsubscribe = () => {
-      unsubscribeEnsureProgress();
-      unsubscribeShowError();
-    };
+    // Desktop presentation requests are window-owned: root/runtime-host events
+    // reach this bridge through `DesktopProgressBridge.handleProgressEvent` and
+    // then `onProgressEvent`. Do not subscribe this collaborator to the
+    // process-wide bus; doing so would make root UI actions cross window
+    // boundaries and outlive the owning renderer.
   }
 
   // ── Query ───────────────────────────────────────────────────────────────
@@ -402,7 +382,6 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
 
   dispose(): void {
     this.disposed = true;
-    this.unsubscribe();
     this.restoredStreams.clear();
     this.restoredDisplaySent.clear();
     this.restoredDisplayInFlight.clear();

--- a/src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts
@@ -4,9 +4,9 @@
  * Covers ghost-stream hydration, snapshot persistence, restored-display
  * sending, progress-event handling, and stream-lifecycle callbacks.
  *
- * Event-bus wiring (requestEnsureProgressView, requestShowError) and
- * session-progress handling are tested indirectly through the bridge's
- * public API and the callbacks it invokes.
+ * Desktop presentation routing (requestEnsureProgressView, requestShowError)
+ * and session-progress handling are tested through the bridge's public API and
+ * the callbacks it invokes.
  */
 
 // Third-party imports
@@ -44,9 +44,8 @@ type BridgeOptions = Parameters<
   typeof import('@desktop/main/desktopProgressEventBridge').createDesktopProgressEventBridge
 >[0];
 type SnapshotStore = NonNullable<BridgeOptions['streamSnapshotStore']>;
-type MockBusHandler = (payload: any) => void;
 
-const mockBusHandlers = new Map<string, MockBusHandler>();
+const mockProgressBusOn = vi.fn();
 
 function createSnapshotStore(
   overrides: Partial<SnapshotStore> = {},
@@ -120,7 +119,7 @@ async function loadBridgeModule(): Promise<
   typeof import('@desktop/main/desktopProgressEventBridge')
 > {
   vi.resetModules();
-  mockBusHandlers.clear();
+  mockProgressBusOn.mockClear();
   vi.doMock('@logger', () => ({
     createChannelTrace: () => makeLogger(),
     setDefaultStreamLogStore: () => {},
@@ -134,14 +133,7 @@ async function loadBridgeModule(): Promise<
   }));
   vi.doMock('@eventBus/ProgressEventBus', () => ({
     ProgressEventBus: {
-      on: vi.fn((event: string, handler: MockBusHandler) => {
-        mockBusHandlers.set(event, handler);
-        return () => {
-          if (mockBusHandlers.get(event) === handler) {
-            mockBusHandlers.delete(event);
-          }
-        };
-      }),
+      on: mockProgressBusOn,
       emit: vi.fn(),
     },
   }));
@@ -547,33 +539,30 @@ describe('DesktopProgressEventBridge', () => {
     });
   });
 
-  // ── Process-bus events ──────────────────────────────────────────────────
+  // ── Desktop presentation events ─────────────────────────────────────────
 
-  describe('process-bus events', () => {
-    it('subscribes to desktop-wide routing and root-error events only', () => {
+  describe('desktop presentation events', () => {
+    it('keeps routing and root-error events on the explicit runtime-host path', () => {
       const routeToProgress = vi.fn();
-      const onGoalStateChanged = vi.fn();
       const onShowError = vi.fn();
       const bridge = createBridge({
         routeToProgress,
-        onGoalStateChanged,
         onShowError,
       });
 
       try {
-        mockBusHandlers.get('requestEnsureProgressView')?.({});
-        mockBusHandlers.get('requestShowError')?.({
+        expect(mockProgressBusOn).not.toHaveBeenCalled();
+
+        bridge.onProgressEvent('requestEnsureProgressView', {});
+        bridge.onProgressEvent('requestShowError', {
           message: 'Root run failed',
         });
 
-        expect(mockBusHandlers.has('goalStateChanged')).toBe(false);
-        expect(onGoalStateChanged).not.toHaveBeenCalled();
         expect(routeToProgress).toHaveBeenCalledTimes(1);
         expect(onShowError).toHaveBeenCalledWith('Root run failed');
 
         bridge.dispose();
-        expect(mockBusHandlers.has('requestEnsureProgressView')).toBe(false);
-        expect(mockBusHandlers.has('requestShowError')).toBe(false);
+        expect(mockProgressBusOn).not.toHaveBeenCalled();
       } finally {
         bridge.dispose();
       }


### PR DESCRIPTION
## Summary

- remove the desktop bridge's direct `ProgressEventBus.on('requestEnsureProgressView')` and `ProgressEventBus.on('requestShowError')` subscriptions
- keep desktop presentation requests on the existing window-local runtime-host path: `DesktopProgressBridge.handleProgressEvent` -> `DesktopProgressEventBridge.onProgressEvent`
- update the focused bridge test to assert route/error handling through the direct path and no process-bus subscription

## Stage 5 evidence

This is the desktop root-presentation slice tracked in #6968 / #6951 after #7443.

Production grep after this PR:

```text
ProgressEventBus.on(...): 0 direct production call sites in src/ and packages/
ProgressEventBus.emit(...): 1 direct production call site, packages/extension/src/frontend/agentRuntime/extensionAgentRuntimeHost.ts
```

I did not add a replacement app signal because current production grep shows no concrete `ProgressEventBus.emit('requestEnsureProgressView' | 'requestShowError')` producer for desktop root presentation. The real desktop route already comes through the window-local runtime host, and adding a producer-less signal would widen the surface rather than delete it.

Out of scope: extension progress-backend compatibility adapter, approval RPC keys, `ProgressEventPayloads` deletion, and the remaining extension runtime-host compatibility emit.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts src/test-kernel/desktop/desktopProgressEventBridge.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts` — 3 files passed, 83 tests passed
- `corepack pnpm run typecheck` — passed
- `corepack pnpm exec eslint packages/desktop/src/main/desktopProgressEventBridge.ts src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts --max-warnings=0` — passed
- `corepack pnpm exec prettier --check packages/desktop/src/main/desktopProgressEventBridge.ts src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts` — passed
- `corepack pnpm run compile:fast` — passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactors event wiring without changing the primary runtime-host delivery path; risk is limited to missing edge cases that previously relied on the global bus.
> 
> **Overview**
> **Desktop progress presentation no longer listens on the process-wide `ProgressEventBus`.** `DesktopProgressEventBridge` drops constructor subscriptions to `requestEnsureProgressView` and `requestShowError`, along with the unsubscribe logic in `dispose()`. Those actions still run when the same events arrive on the **window-local** path (`DesktopProgressBridge.handleProgressEvent` → `onProgressEvent`), so routing and root errors stay tied to the owning renderer instead of fanning out across windows.
> 
> Tests now assert **`ProgressEventBus.on` is never called** and that ensure-progress and show-error behavior is exercised only through `onProgressEvent`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8abc15ab4e55d0a2f8447e1e32d0fd4c16ff533. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->