### PR TITLE
docs(modelHandlers): document pseudo-prefill predicates as per-provider (#7101)

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -1212,12 +1212,51 @@ export abstract class ModelHandler<
     return `Organize your response with xml tags. Start your response with:\n${prefill}`;
   }
 
-  /** Whether pseudo-prefill should seed accumulated output before the model call. */
+  /**
+   * Whether pseudo-prefill should seed accumulated output before the model call.
+   * Only consulted on a fresh generation (no existing output file) when the
+   * model lacks native assistant-prefill support (`capabilities.supportsAssistantPrefill`
+   * is false) — the prefill text is only ever sent as a *user*-turn instruction
+   * (see {@link createPseudoPrefillPrompt}), never as an actual assistant-turn
+   * prefix, so this getter decides whether `workspaceState.assembly.accumulatedOutput`
+   * should be seeded with it anyway ahead of the first response.
+   *
+   * Not foldable into a single capability read (#7101 triage): overridden `true`
+   * only by the two Google handlers (`ModelHandlerGoogleGenAI`,
+   * `ModelHandlerGoogleInteractions`). Every other provider that reaches this
+   * branch — the OpenAI-wire-format family via `ModelHandlerOpenAI`,
+   * `ModelHandlerOpenRouterNative`, and Anthropic's
+   * `supportsAssistantPrefill: false` thinking variants — leaves this at the
+   * `false` default and instead either resolves the analogous resume-time need
+   * via {@link shouldPrependPrefillOnResumeWithoutAssistantPrefill} (OpenAI
+   * family, OpenRouterNative) or needs neither (Anthropic thinking variants).
+   * The two getters gate two different lifecycle points (fresh start vs.
+   * resume) and no provider needs both, so no single llm-zoo /
+   * `ProviderCapabilityProfile` flag produces the right value on both axes
+   * across all three provider shapes. Stays an overridable getter: genuinely
+   * per-provider behavior, not a foldable predicate.
+   */
   protected get shouldStorePseudoPrefillAsOutput(): boolean {
     return false;
   }
 
-  /** Whether resume should rewrite missing prefill into existing output files. */
+  /**
+   * Whether resume should rewrite missing prefill into existing output files.
+   * Only consulted when resuming a truncated generation (an existing output
+   * file with no end tag) on a model that lacks native assistant-prefill
+   * support, in case the on-disk content is missing the intended prefix.
+   *
+   * Not foldable into a single capability read (#7101 triage): overridden
+   * `true` by `ModelHandlerOpenAI` — inherited by every OpenAI-wire-format
+   * subclass (XAI, DashScope, and the `ReasoningModelHandlerOpenAI` family:
+   * DeepSeek/Kimi/GLM/MiniMax) — and independently by
+   * `ModelHandlerOpenAIResponse` (inherited by Codex) and
+   * `ModelHandlerOpenRouterNative`. The two Google handlers and Anthropic's
+   * thinking-variant models leave this at the `false` default; see
+   * {@link shouldStorePseudoPrefillAsOutput} for why the split can't collapse
+   * into one flag. Stays an overridable getter: genuinely per-provider
+   * behavior, not a foldable predicate.
+   */
   protected get shouldPrependPrefillOnResumeWithoutAssistantPrefill(): boolean {
     return false;
   }


### PR DESCRIPTION
## Context

Part of the ongoing base-predicate triage tracked in #7101. Five earlier slices (#7346, #7353, #7369, #7386, #7397) each resolved one cluster; this PR picks up the next untouched one: the pseudo-prefill pair near `ModelHandler.ts:1216-1223` — `shouldStorePseudoPrefillAsOutput` and `shouldPrependPrefillOnResumeWithoutAssistantPrefill`.

## Audit

Both getters are consulted only in `initializeOutputAndPrefill`, and only for models where `capabilities.supportsAssistantPrefill` is `false` (llm-zoo@1.12.0: OpenAI, Google, xAI, Moonshot/Kimi, DashScope, Copilot, plus 18 Anthropic "thinking" variants and 3 DeepSeek variants). They gate two different lifecycle points:

- `shouldStorePseudoPrefillAsOutput` — on a **fresh generation** (no output file yet), whether to seed `accumulatedOutput` with the prefill text even though it's only ever sent as a user-turn instruction, never an actual assistant-turn prefix.
- `shouldPrependPrefillOnResumeWithoutAssistantPrefill` — on **resume** (an existing, truncated output file), whether to rewrite the on-disk file to prepend the prefill if it's missing.

Tracing every override:

| Handler | `shouldStorePseudoPrefillAsOutput` | `shouldPrependPrefillOnResumeWithoutAssistantPrefill` |
|---|---|---|
| `ModelHandlerGoogleGenAI` / `ModelHandlerGoogleInteractions` | `true` (own override) | `false` (base default) |
| `ModelHandlerOpenAI` (→ XAI, DashScope, `ReasoningModelHandlerOpenAI` → DeepSeek/Kimi/GLM/MiniMax) | `false` (base default) | `true` (own override, inherited) |
| `ModelHandlerOpenAIResponse` (→ Codex) | `false` (base default) | `true` (own override, inherited) |
| `ModelHandlerOpenRouterNative` | `false` (base default) | `true` (own override) |
| `ModelHandlerAnthropic` (thinking variants) | `false` (base default) | `false` (base default) |

No provider needs both getters `true`, and Anthropic's thinking variants need neither. There's no existing llm-zoo capability or `ProviderCapabilityProfile` field that reproduces this split, and a single flag can't: the two getters answer different questions at different lifecycle points, and the "which provider needs which" mapping doesn't line up with any capability already in the registry (it tracks provider wire-format family — chat-completions-shaped vs. GenAI-shaped vs. Anthropic-native — not a model-level capability).

**Conclusion**: genuinely per-provider behavior (same triage bucket as `supportsManualCompaction` / `canProcessToolResultAttachments` / `requiresBatchedParallelToolResults`), not foldable into a capability-profile read.

## Change

Documentation only, no behavior change — added JSDoc to both getters explaining the audit finding, following the pattern already used by the merged slices above (e.g. `supportsManualCompaction`'s comment).

## Verification

- `npx tsc --noEmit` — same 23 pre-existing errors as a clean checkout of this branch's base commit (unrelated `@openrouter/sdk`/`vscode-jsonrpc` module-resolution issues); none touch `ModelHandler.ts`; confirmed identical count via `git stash` before/after.
- `npx eslint src/agent/modelHandlers/ModelHandler.ts` — clean, no output.
- `npx prettier --check src/agent/modelHandlers/ModelHandler.ts` — "All matched files use Prettier code style!"
- `npx vitest run` on the relevant handler suites (Continuation contract, empty-prefill, Google GenAI/legacy, OpenRouterNative, Anthropic, OpenAIResponse): **89 passed, 0 failed**.

This is one slice of the larger #7101 triage; the runtime-combinator cluster (`shouldUseServerSideKeys(+Sync)`) is left for a follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change on base-class documentation; no execution path or provider behavior is modified.
> 
> **Overview**
> **Documentation-only** slice of #7101: expands JSDoc on `shouldStorePseudoPrefillAsOutput` and `shouldPrependPrefillOnResumeWithoutAssistantPrefill` in `ModelHandler.ts`. No runtime or logic changes.
> 
> The new comments spell out **when** each getter runs inside `initializeOutputAndPrefill` (fresh pseudo-prefill vs resume without an end tag, only when `supportsAssistantPrefill` is false), **which handlers override** them (Google vs OpenAI-family / OpenRouterNative vs defaults), and why they stay separate overridable getters instead of a single llm-zoo / `ProviderCapabilityProfile` flag—matching the pattern used for other triaged base predicates like `supportsManualCompaction`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ce24507160a54f3807c9a3bd885abb766d9041d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->