### PR TITLE
refactor(runtime): delete dead HostInteractions width (unread pending())

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -230,7 +230,6 @@ export function createTuiHostInteractions(
       return openExternalInquiryInteraction(request, context, host);
     },
     handleProgressEvent: () => false,
-    pending: () => [],
     resolve: () => false,
     cancelForStream(streamId) {
       cancelRetryRoute(retryRoutes, streamId);

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -289,7 +289,6 @@ export function createHeadlessCliHostInteractions(
       return { threadId: request.threadId };
     },
     handleProgressEvent: () => false,
-    pending: () => [],
     resolve: () => false,
     cancelForStream: () => {},
   };

--- a/packages/desktop/src/main/desktopHostInteractions.ts
+++ b/packages/desktop/src/main/desktopHostInteractions.ts
@@ -8,7 +8,6 @@ import type {
   HostPlanApprovalRequest,
   HostRetryRequest,
   HostUserQuestionResult,
-  PendingHostInteraction,
 } from '@agent/runtime/HostInteractions';
 import type { PlanApprovalResult } from '@agent/runtime/PlanApprovalCoordinator';
 import type { ProposalResult } from '@agent/runtime/AgentProposalCoordinator';
@@ -149,14 +148,6 @@ class DesktopHostInteractions implements HostInteractions {
 
   handleProgressEvent(): boolean {
     return false;
-  }
-
-  pending(): readonly PendingHostInteraction[] {
-    return [...this.pendingRequests.entries()].map(([id, request]) => ({
-      id,
-      kind: request.kind,
-      ...(request.streamId ? { streamId: request.streamId } : {}),
-    }));
   }
 
   resolve(requestId: string, result: HostInteractionResolution): boolean {

--- a/packages/extension/src/progressView/extensionHostInteractions.ts
+++ b/packages/extension/src/progressView/extensionHostInteractions.ts
@@ -9,7 +9,6 @@ import type {
   HostPlanApprovalRequest,
   HostRetryRequest,
   HostUserQuestionResult,
-  PendingHostInteraction,
 } from '@agent/runtime/HostInteractions';
 import type { PlanApprovalResult } from '@agent/runtime/PlanApprovalCoordinator';
 import type { ProposalResult } from '@agent/runtime/AgentProposalCoordinator';
@@ -35,8 +34,10 @@ export interface ExtensionHostInteractionsOptions {
 
 type PendingKind = 'bash' | 'plan' | 'proposal' | 'retry' | 'userQuestion';
 
-interface PendingExtensionInteraction<T> extends PendingHostInteraction {
+interface PendingExtensionInteraction<T> {
+  readonly id: string;
   readonly kind: PendingKind;
+  readonly streamId?: StreamTabId;
   readonly settle: (value: T) => void;
 }
 
@@ -210,14 +211,6 @@ export function createExtensionHostInteractions(
       const data = payload as ProgressEventPayloads['removeStream'];
       options.removeStream(data.streamId);
       return true;
-    },
-
-    pending(): readonly PendingHostInteraction[] {
-      return [...pendingRequests.values()].map(({ id, kind, streamId }) => ({
-        id,
-        kind,
-        streamId,
-      }));
     },
 
     resolve(requestId: string, result: HostInteractionResolution): boolean {

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -68,12 +68,6 @@ export interface HostExternalInquiryHandle {
   readonly threadId: string;
 }
 
-export interface PendingHostInteraction {
-  readonly id: string;
-  readonly kind: string;
-  readonly streamId?: StreamTabId;
-}
-
 export interface HostInteractionResolution {
   readonly kind: string;
   readonly action: string;
@@ -84,10 +78,8 @@ export interface HostInteractionResolution {
 /**
  * Session-owned host interaction surface.
  *
- * During the Stage 4 migration, hosts may still implement this port by handling
- * the legacy progress-event request names internally. The important boundary is
- * ownership: runtime code asks the session for an interaction, while host code
- * owns display, replay, and first-wins resolution.
+ * Runtime code asks the session for an interaction; host code owns display,
+ * replay (via `ApprovalRequestHandler`), and first-wins resolution.
  */
 export interface HostInteractions {
   requestToolEditApproval?(
@@ -121,7 +113,6 @@ export interface HostInteractions {
     event: K,
     payload: ProgressEventPayloads[K],
   ): boolean;
-  pending(): readonly PendingHostInteraction[];
   resolve(requestId: string, result: HostInteractionResolution): boolean;
   cancelForStream(streamId: StreamTabId, cause?: string): void;
   cancelUnscoped?(cause?: string): void;
@@ -131,7 +122,6 @@ export interface HostInteractions {
 
 const noopHostInteractions: HostInteractions = {
   handleProgressEvent: () => false,
-  pending: () => [],
   resolve: () => false,
   cancelForStream: () => {},
   cancelUnscoped: () => {},
@@ -212,10 +202,6 @@ export class SessionHostInteractions implements HostInteractions {
     request: HostExternalInquiryRequest,
   ): Promise<HostExternalInquiryHandle> | undefined {
     return this.active.openExternalInquiry?.(request);
-  }
-
-  pending(): readonly PendingHostInteraction[] {
-    return this.active.pending();
   }
 
   resolve(requestId: string, result: HostInteractionResolution): boolean {

--- a/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
@@ -241,7 +241,6 @@ describe('child stream progress events', () => {
           removedStreams.push(data.streamId);
           return true;
         },
-        pending: () => [],
         resolve: () => false,
         cancelForStream: () => {},
       },

--- a/src/test-kernel/agent/progressTestUtils.ts
+++ b/src/test-kernel/agent/progressTestUtils.ts
@@ -125,33 +125,6 @@ export function createRecordingHost(): {
       });
     },
     handleProgressEvent: () => false,
-    pending: () => [
-      ...[...pendingBashes].map(([id, entry]) => ({
-        id,
-        kind: 'bash',
-        streamId: entry.streamId,
-      })),
-      ...[...pendingPlans].map(([id, entry]) => ({
-        id,
-        kind: 'plan',
-        streamId: entry.streamId,
-      })),
-      ...[...pendingProposals].map(([id, entry]) => ({
-        id,
-        kind: 'proposal',
-        streamId: entry.streamId,
-      })),
-      ...[...pendingRetries].map(([id, entry]) => ({
-        id,
-        kind: 'retry',
-        streamId: entry.streamId,
-      })),
-      ...[...pendingUserQuestions].map(([id, entry]) => ({
-        id,
-        kind: 'userQuestion',
-        streamId: entry.streamId,
-      })),
-    ],
     resolve: (requestId, result) => {
       if (result.kind === 'bash') {
         const pending = pendingBashes.get(requestId);

--- a/src/test-kernel/agent/runtime/PromiseCoordinators.vitest.ts
+++ b/src/test-kernel/agent/runtime/PromiseCoordinators.vitest.ts
@@ -118,7 +118,6 @@ describe('promise coordinators', () => {
           return { action: 'approve' };
         },
         handleProgressEvent: () => false,
-        pending: () => [],
         resolve: () => false,
         cancelForStream: () => {},
       },

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
@@ -96,10 +96,6 @@ describe('createExtensionHostInteractions', () => {
       goalEnabled: true,
       plan: { objective: 'Prove the compactness lemma.' },
     });
-    expect(interactions.pending()).toEqual([
-      { id: 'plan-a', kind: 'plan', streamId: 'stream-a' },
-    ]);
-
     expect(
       interactions.resolve('plan-a', {
         kind: 'plan',
@@ -111,7 +107,10 @@ describe('createExtensionHostInteractions', () => {
       action: 'approve_and_goal',
     });
     expect(handlers.planApproval.resolve).toHaveBeenCalledWith('plan-a');
-    expect(interactions.pending()).toEqual([]);
+    // The request was settled first-wins: a second resolution finds nothing.
+    expect(
+      interactions.resolve('plan-a', { kind: 'plan', action: 'approve' }),
+    ).toBe(false);
   });
 
   it('cancels pending retry requests for a removed stream', async () => {
@@ -160,7 +159,6 @@ describe('createExtensionHostInteractions', () => {
       streamId: 'stream-a',
       mode: 'new',
     });
-    expect(interactions.pending()).toEqual([]);
   });
 
   it('cancels streamless user questions during unscoped cleanup', async () => {
@@ -185,7 +183,13 @@ describe('createExtensionHostInteractions', () => {
 
     await expect(resultPromise).resolves.toEqual({ submitted: false });
     expect(handlers.userQuestion.resolve).toHaveBeenCalledWith('question-a');
-    expect(interactions.pending()).toEqual([]);
+    // The cancelled question was released: a later resolution finds nothing.
+    expect(
+      interactions.resolve('question-a', {
+        kind: 'userQuestion',
+        action: 'submit',
+      }),
+    ).toBe(false);
   });
 
   it('delegates tool edit approval to the native VS Code port', async () => {

--- a/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
+++ b/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
@@ -63,7 +63,6 @@ function createHostInteractions(
 ): HostInteractions {
   return {
     handleProgressEvent: vi.fn(() => false),
-    pending: vi.fn(() => []),
     resolve: vi.fn(() => false),
     cancelForStream: vi.fn(),
     ...overrides,

--- a/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
+++ b/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
@@ -54,7 +54,6 @@ describe('approval cleanup scope (SDK Step 7d residue #5)', () => {
     const cancelUnscoped = vi.fn();
     const detach = session.useHostInteractions({
       handleProgressEvent: () => false,
-      pending: () => [],
       resolve: () => false,
       cancelForStream: () => {},
       cancelUnscoped,

--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -74,7 +74,6 @@ function runtimeHost(): AgentRuntimeHost {
     emit: vi.fn(),
     interactions: {
       handleProgressEvent: vi.fn(() => false),
-      pending: vi.fn(() => []),
       resolve: vi.fn(() => false),
       cancelForStream: vi.fn(),
     } satisfies HostInteractions,

--- a/src/test-kernel/tools/ExternalInquiryAction.vitest.ts
+++ b/src/test-kernel/tools/ExternalInquiryAction.vitest.ts
@@ -47,7 +47,6 @@ describe('handleExternalInquiryAction', () => {
     >(() => true);
     const interactions: HostInteractions = {
       handleProgressEvent: () => false,
-      pending: () => [],
       resolve,
       cancelForStream: () => {},
     };

--- a/src/test-kernel/tools/ExternalInquiryHostInteractionRejection.vitest.ts
+++ b/src/test-kernel/tools/ExternalInquiryHostInteractionRejection.vitest.ts
@@ -15,7 +15,6 @@ function createRuntimeHostWithRejectingInteraction(
     emit: () => {},
     interactions: {
       handleProgressEvent: () => false,
-      pending: () => [],
       resolve: () => false,
       cancelForStream: () => {},
       openExternalInquiry: () => Promise.reject(reason),


### PR DESCRIPTION
Deletes the never-read `pending()` accessor surface from the `HostInteractions` port and rewrites the port's stale Stage 4 migration doc comment. Scope was re-verified against today's `origin/main` (21adbc312, post-#7327): two of the four audited members turned out to be live and are kept (see below).

## Deleted: `pending()` (zero production readers, ever)

Evidence on current main:

- `grep -rn '\.pending()'` across `src/` and `packages/` (excluding tests): **1 hit** — the `SessionHostInteractions` self-forwarder in `src/agent/runtime/HostInteractions.ts`. Zero external production callers.
- `git log --all -S 'interactions.pending()'`: only the test file that asserted on it and migration docs. No production caller has ever existed.

Removed:

- the `pending(): readonly PendingHostInteraction[]` interface member and the now-unreferenced `PendingHostInteraction` value type (extension's internal `PendingExtensionInteraction` inlines the three fields it actually uses),
- the noop default and the `SessionHostInteractions` forwarder,
- both real host implementations (extension, desktop) — the per-host `pendingRequests` maps stay untouched, since they serve promise settlement and `cancelForStream`,
- the `pending: () => []` stubs in the two CLI adapters (`subscribeApprovals`, `approvalAdapter`) and in seven test fakes, including a 27-line dead fake in `progressTestUtils.ts`,
- the `ExtensionHostInteractions` suite's `pending()` bookkeeping assertions, replaced with behavioral equivalents (a second `resolve()` of a settled request returns `false`).

**#6967 gate renouncement:** this formally renounces #6967's unimplemented "replay reads `pending()`" gate. `ApprovalRequestHandler` is the display-replay owner today; a future `PendingInteractionTable` fold (issue #7447 context) can reintroduce a read surface when something actually reads it.

## Kept: live members the audit had flagged

- **`handleProgressEvent`** — live since 2ec1ecfcf (merged today): `src/tools/childStream.ts` routes child-stream auto-close through `interactions.handleProgressEvent('removeStream', ...)`, and the extension host implements it meaningfully. Not touched.
- **`HostInteractionOptions.timeoutMs`** — live since #7327: `packages/cli/src/chat/tui/state/subscribeApprovals.ts` reads `options?.timeoutMs` to time out TUI interactions, with a dedicated test suite. Not touched.

## Doc comment

The port's "During the Stage 4 migration, hosts may still implement this port by handling the legacy progress-event request names internally" comment has been false since #7316; rewritten to the current contract: runtime asks the session for an interaction; host code owns display, replay (via `ApprovalRequestHandler`), and first-wins resolution.

## Delta

- Net LoC: **-62** (+16 / -78 across 14 files).
- Elements: -1 port member, -1 exported type, -1 forwarder method, -1 noop entry, -2 real host implementations, -9 stub/fake implementations; 0 added.

Scheduled refactoring: None — this PR is itself a deletion; no shims introduced.

## Verification

- `npx tsc --noEmit` (root), `npx tsc --noEmit -p tsconfig.test-kernel.json`, `npx tsc --noEmit` in `packages/cli`: all clean.
- `npx vitest run` on all touched suites plus `src/test-kernel/agent/runtime/`: 34 files, 233 tests, all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead API removal with no production callers; approval flow still uses resolve/cancel and ApprovalRequestHandler. Risk is limited to any undiscovered external implementers of HostInteractions.
> 
> **Overview**
> Removes the **`HostInteractions.pending()`** read surface and the exported **`PendingHostInteraction`** type from the session host interaction port. **`SessionHostInteractions`**, noop defaults, CLI TUI/headless adapters, desktop and extension hosts, and test fakes no longer implement or stub **`pending()`**; internal **`pendingRequests`** maps in desktop/extension are unchanged and still drive promise settlement and **`cancelForStream`**.
> 
> The extension host’s local pending type now inlines **`id` / `kind` / `streamId`** instead of extending the removed shared type. The **`HostInteractions`** doc comment is updated to drop the obsolete Stage 4 migration wording and state that replay goes through **`ApprovalRequestHandler`**.
> 
> Tests that asserted on **`pending()`** now check first-wins behavior (a second **`resolve()`** returns **`false`** after settle or cancel).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e4cef543c13117c6d8280b0b58f973fe60d9579. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->