### PR TITLE
refactor(progressView): route frontend outbound dispatch through shared createDispatcher

### DIFF
--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -257,8 +257,17 @@ export class ProgressApp extends ProgressAppBase {
     `;
   }
 
-  protected handleMessage(message: ProgressViewOutboundMessage): void {
-    dispatchMessage(message, this.createMessageHandlerContext());
+  protected override handleMessage(raw: unknown): void {
+    dispatchMessage(raw, this.createMessageHandlerContext(), (error) => {
+      const command =
+        raw && typeof raw === 'object' && 'command' in raw
+          ? String((raw as { command: unknown }).command)
+          : 'unknown';
+      this.logSchemaError(
+        `[ProgressApp] Message validation failed for command "${command}".`,
+        error,
+      );
+    });
   }
 
   /**

--- a/packages/extension/src/progressView/frontend/messageDispatcher.ts
+++ b/packages/extension/src/progressView/frontend/messageDispatcher.ts
@@ -1,16 +1,33 @@
 /**
  * Schema-driven message dispatcher for ProgressView.
  *
- * Routes typed backend messages to handlers via command lookup.
+ * Validates and routes typed backend messages to handlers via
+ * `dispatchProgressViewOutbound` — the shared `createDispatcher` mechanism
+ * from `@shared/schemas`/`@shared/utils/dispatcher` that `settingsView`/
+ * `webview` frontends already use, rather than a bespoke unvalidated lookup.
  * Handlers are organized into domain-specific slices under ./slices/.
+ *
+ * Slices keep their existing two-arg `(data, ctx) => void` shape instead of
+ * the single-arg `(data) => void` shape `createDispatcher`'s `HandlerRegistry`
+ * expects: most of `MessageHandlerContext`'s getters/setters close over
+ * module-level state, but `savePrefs` closes over the live `ProgressApp`
+ * instance's own `PersistedState`, so `ctx` is rebuilt per message rather
+ * than fixed at module scope. `bindHandlers` below binds every slice handler
+ * to the current `ctx` right before handing the registry to
+ * `dispatchProgressViewOutbound`, so the slices/`HandlerRegistry` composition
+ * itself is unchanged.
  *
  * @example
  * // In ProgressApp.handleMessage:
- * dispatchMessage(raw, ctx);
+ * dispatchMessage(raw, this.createMessageHandlerContext(), onError);
  */
 
 // Slice imports
-import type { ProgressViewOutboundMessage } from '@shared/schemas';
+import {
+  dispatchProgressViewOutbound,
+  type ProgressViewOutboundHandlerRegistry,
+} from '@shared/schemas';
+import { isUnsupported, type Unsupported } from '@shared/utils/dispatcher';
 import { streamLifecycleHandlers } from './slices/streamLifecycleSlice';
 import { logHandlers } from './slices/logSlice';
 import { streamMetaHandlers } from './slices/streamMetaSlice';
@@ -46,22 +63,54 @@ const handlers: HandlerRegistry = {
 };
 
 // ============================================================
+// ctx binding (adapts the two-arg slice registry to createDispatcher's
+// single-arg HandlerRegistry<TMessage>)
+// ============================================================
+
+/**
+ * Binds every two-arg slice handler in `handlers` to `ctx`, producing the
+ * single-arg registry `dispatchProgressViewOutbound` expects. `Unsupported`
+ * markers pass through unchanged so the shared dispatcher's `isUnsupported`
+ * check still recognizes them.
+ *
+ * Rebuilt on every dispatch rather than memoized: `ctx` is freshly
+ * constructed per message by `ProgressApp` anyway (see
+ * `createMessageHandlerContext`), and binding ~30 entries is negligible next
+ * to the postMessage/structured-clone cost already on this path.
+ */
+function bindHandlers(
+  ctx: MessageHandlerContext,
+): ProgressViewOutboundHandlerRegistry {
+  const bound: Record<string, unknown> = {};
+  for (const [command, entry] of Object.entries(handlers) as Array<
+    [string, TypedHandler<never> | Unsupported]
+  >) {
+    bound[command] = isUnsupported(entry)
+      ? entry
+      : (data: never) => entry(data, ctx);
+  }
+  return bound as ProgressViewOutboundHandlerRegistry;
+}
+
+// ============================================================
 // Main dispatcher
 // ============================================================
 
 /**
- * Dispatch a typed backend message to its handler.
+ * Dispatch a raw backend message to its handler.
  *
- * The backend sends ProgressViewOutboundMessage objects via postMessage.
- * TypeScript enforces the shape at compile time, and postMessage uses structured
- * clone (lossless) — no Zod validation needed on the hot path.
+ * The backend sends messages via postMessage; `raw` is validated against
+ * `ProgressViewOutboundMessageSchema` before a handler runs — previously
+ * this trusted TypeScript's compile-time cast alone, so a schema/handler
+ * mismatch could throw deep inside a handler body instead of surfacing as a
+ * parse error. A command whose registry entry is `unsupported(...)` (or,
+ * defensively, genuinely missing) also routes through `onError` instead of
+ * silently no-oping. Returns `true` if a real handler ran.
  */
 export function dispatchMessage(
-  message: ProgressViewOutboundMessage,
+  raw: unknown,
   ctx: MessageHandlerContext,
-): void {
-  const handler = handlers[message.command] as
-    TypedHandler<typeof message> | undefined;
-
-  handler?.(message, ctx);
+  onError?: (error: unknown) => void,
+): boolean {
+  return dispatchProgressViewOutbound(raw, bindHandlers(ctx), onError);
 }

--- a/packages/extension/src/progressView/frontend/messageHandlerTypes.ts
+++ b/packages/extension/src/progressView/frontend/messageHandlerTypes.ts
@@ -11,6 +11,7 @@ import type {
   ProgressViewPlacement,
   StreamTabId,
 } from '@shared/schemas';
+import type { Unsupported } from '@shared/utils/dispatcher';
 
 import type {
   ProgressState,
@@ -61,11 +62,17 @@ export type TypedHandler<T extends ProgressViewOutboundMessage> = (
 ) => void;
 
 /**
- * Handler registry mapping command to typed handler.
- * TypeScript ensures handlers receive the correct message type.
+ * Handler registry mapping command to typed handler. Exhaustive — every
+ * ProgressView outbound command needs a real handler or `unsupported(...)`
+ * (see `@shared/utils/dispatcher`), same contract `settingsView`/`webview`
+ * use for their outbound registries. Omitting a command is a compile error
+ * here, not a silent runtime no-op; `messageDispatcher.ts` spreads all
+ * slices together and is the actual exhaustiveness checkpoint TypeScript
+ * enforces (individual slices are typed as `satisfies Partial<HandlerRegistry>`
+ * subsets).
  */
 export type HandlerRegistry = {
-  [K in ProgressViewOutboundMessage['command']]?: TypedHandler<
-    Extract<ProgressViewOutboundMessage, { command: K }>
-  >;
+  [K in ProgressViewOutboundMessage['command']]:
+    | TypedHandler<Extract<ProgressViewOutboundMessage, { command: K }>>
+    | Unsupported;
 };

--- a/packages/extension/src/progressView/frontend/slices/followUpSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/followUpSlice.ts
@@ -36,7 +36,13 @@ function setActiveStreamRecording(
 // Handlers
 // ============================================================
 
-export const followUpHandlers: HandlerRegistry = {
+// `HandlerRegistry` is now exhaustive (every ProgressView outbound command
+// needs a real handler or `unsupported(...)` — see `@shared/utils/dispatcher`).
+// This slice only owns a subset, so it's typed as a `satisfies Partial<...>`
+// subset rather than the full registry; `messageDispatcher.ts` spreads all
+// slices together and is the actual exhaustiveness checkpoint TypeScript
+// enforces.
+export const followUpHandlers = {
   [PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT]: (data, ctx) => {
     const streamId =
       data.stream ??
@@ -92,4 +98,4 @@ export const followUpHandlers: HandlerRegistry = {
       }),
     );
   },
-};
+} satisfies Partial<HandlerRegistry>;

--- a/packages/extension/src/progressView/frontend/slices/inquirySlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/inquirySlice.ts
@@ -4,7 +4,13 @@ import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 
 import type { HandlerRegistry } from '../messageHandlerTypes';
 
-export const inquiryHandlers: HandlerRegistry = {
+// `HandlerRegistry` is now exhaustive (every ProgressView outbound command
+// needs a real handler or `unsupported(...)` — see `@shared/utils/dispatcher`).
+// This slice only owns a subset, so it's typed as a `satisfies Partial<...>`
+// subset rather than the full registry; `messageDispatcher.ts` spreads all
+// slices together and is the actual exhaustiveness checkpoint TypeScript
+// enforces.
+export const inquiryHandlers = {
   [PROGRESS_VIEW_COMMANDS.SYNC_INQUIRY_THREADS]: (data, ctx) => {
     ctx.setState((prev) =>
       create(prev, (draft) => {
@@ -26,4 +32,4 @@ export const inquiryHandlers: HandlerRegistry = {
       }),
     );
   },
-};
+} satisfies Partial<HandlerRegistry>;

--- a/packages/extension/src/progressView/frontend/slices/logSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/logSlice.ts
@@ -189,7 +189,13 @@ function applyTextDelta(
   return existingIndex;
 }
 
-export const logHandlers: HandlerRegistry = {
+// `HandlerRegistry` is now exhaustive (every ProgressView outbound command
+// needs a real handler or `unsupported(...)` — see `@shared/utils/dispatcher`).
+// This slice only owns a subset, so it's typed as a `satisfies Partial<...>`
+// subset rather than the full registry; `messageDispatcher.ts` spreads all
+// slices together and is the actual exhaustiveness checkpoint TypeScript
+// enforces.
+export const logHandlers = {
   [PROGRESS_VIEW_COMMANDS.LOG_DELTA]: (data, ctx) => {
     const { streamId, entries, updates } = data;
     const textDeltas = data.textDeltas ?? [];
@@ -254,4 +260,4 @@ export const logHandlers: HandlerRegistry = {
       }),
     );
   },
-};
+} satisfies Partial<HandlerRegistry>;

--- a/packages/extension/src/progressView/frontend/slices/permissionSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/permissionSlice.ts
@@ -87,7 +87,13 @@ export function removePrompt(
 // Handlers
 // ============================================================
 
-export const permissionHandlers: HandlerRegistry = {
+// `HandlerRegistry` is now exhaustive (every ProgressView outbound command
+// needs a real handler or `unsupported(...)` — see `@shared/utils/dispatcher`).
+// This slice only owns a subset, so it's typed as a `satisfies Partial<...>`
+// subset rather than the full registry; `messageDispatcher.ts` spreads all
+// slices together and is the actual exhaustiveness checkpoint TypeScript
+// enforces.
+export const permissionHandlers = {
   [PROGRESS_VIEW_COMMANDS.UPDATE_BYPASS]: (data, ctx) => {
     updateToolUseState(ctx, data.stream, (prev) =>
       create(prev, (draft) => {
@@ -179,4 +185,4 @@ export const permissionHandlers: HandlerRegistry = {
       }
     }
   },
-};
+} satisfies Partial<HandlerRegistry>;

--- a/packages/extension/src/progressView/frontend/slices/runTrackingSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/runTrackingSlice.ts
@@ -16,7 +16,13 @@ import { isToolUseState, isWorkflowState } from '../store';
 import { updateWorkflowState, updateRounds } from '../stateUtils';
 import type { HandlerRegistry } from '../messageHandlerTypes';
 
-export const runTrackingHandlers: HandlerRegistry = {
+// `HandlerRegistry` is now exhaustive (every ProgressView outbound command
+// needs a real handler or `unsupported(...)` — see `@shared/utils/dispatcher`).
+// This slice only owns a subset, so it's typed as a `satisfies Partial<...>`
+// subset rather than the full registry; `messageDispatcher.ts` spreads all
+// slices together and is the actual exhaustiveness checkpoint TypeScript
+// enforces.
+export const runTrackingHandlers = {
   [PROGRESS_VIEW_COMMANDS.UPDATE_FILES]: (data, ctx) => {
     const { stream, rounds, reset } = data;
     updateWorkflowState(ctx, stream, (prev) =>
@@ -62,4 +68,4 @@ export const runTrackingHandlers: HandlerRegistry = {
       return prev;
     });
   },
-};
+} satisfies Partial<HandlerRegistry>;

--- a/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
@@ -102,7 +102,13 @@ function updateStreamInfo(
 // Handlers
 // ============================================================
 
-export const streamLifecycleHandlers: HandlerRegistry = {
+// `HandlerRegistry` is now exhaustive (every ProgressView outbound command
+// needs a real handler or `unsupported(...)` — see `@shared/utils/dispatcher`).
+// This slice only owns a subset, so it's typed as a `satisfies Partial<...>`
+// subset rather than the full registry; `messageDispatcher.ts` spreads all
+// slices together and is the actual exhaustiveness checkpoint TypeScript
+// enforces.
+export const streamLifecycleHandlers = {
   [PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS]: (data, ctx) => {
     if (data.unsupportedCommands) {
       unsupportedProgressCommands$.set(new Set(data.unsupportedCommands));
@@ -200,4 +206,4 @@ export const streamLifecycleHandlers: HandlerRegistry = {
   [PROGRESS_VIEW_COMMANDS.UPDATE_PARENT_STREAM]: (data, ctx) => {
     updateParentStreamId(ctx, data.stream, data.parentStreamId);
   },
-};
+} satisfies Partial<HandlerRegistry>;

--- a/packages/extension/src/progressView/frontend/slices/streamMetaSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamMetaSlice.ts
@@ -74,7 +74,13 @@ function upsertSortedStreamInfo(
   return new Map(ordered.map((stream) => [stream.name, stream]));
 }
 
-export const streamMetaHandlers: HandlerRegistry = {
+// `HandlerRegistry` is now exhaustive (every ProgressView outbound command
+// needs a real handler or `unsupported(...)` — see `@shared/utils/dispatcher`).
+// This slice only owns a subset, so it's typed as a `satisfies Partial<...>`
+// subset rather than the full registry; `messageDispatcher.ts` spreads all
+// slices together and is the actual exhaustiveness checkpoint TypeScript
+// enforces.
+export const streamMetaHandlers = {
   [PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA]: (data, ctx) => {
     const name = data.streamInfo.name;
     const pending = takePendingDescription(name);
@@ -236,4 +242,4 @@ export const streamMetaHandlers: HandlerRegistry = {
       });
     });
   },
-};
+} satisfies Partial<HandlerRegistry>;

--- a/packages/extension/src/progressView/frontend/slices/syncSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/syncSlice.ts
@@ -12,7 +12,13 @@ import {
 import { updateParentStreamId } from '../stateUtils';
 import type { HandlerRegistry } from '../messageHandlerTypes';
 
-export const syncHandlers: HandlerRegistry = {
+// `HandlerRegistry` is now exhaustive (every ProgressView outbound command
+// needs a real handler or `unsupported(...)` — see `@shared/utils/dispatcher`).
+// This slice only owns a subset, so it's typed as a `satisfies Partial<...>`
+// subset rather than the full registry; `messageDispatcher.ts` spreads all
+// slices together and is the actual exhaustiveness checkpoint TypeScript
+// enforces.
+export const syncHandlers = {
   [PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT]: (data, ctx) => {
     if (!data.stream || data.action === 'clear') return;
 
@@ -119,4 +125,4 @@ export const syncHandlers: HandlerRegistry = {
       updateParentStreamId(ctx, data.stream as string, data.parentStreamId);
     }
   },
-};
+} satisfies Partial<HandlerRegistry>;

--- a/packages/extension/src/progressView/frontend/slices/taskSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/taskSlice.ts
@@ -9,7 +9,13 @@ import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import { updateToolUseState } from '../stateUtils';
 import type { HandlerRegistry } from '../messageHandlerTypes';
 
-export const taskHandlers: HandlerRegistry = {
+// `HandlerRegistry` is now exhaustive (every ProgressView outbound command
+// needs a real handler or `unsupported(...)` — see `@shared/utils/dispatcher`).
+// This slice only owns a subset, so it's typed as a `satisfies Partial<...>`
+// subset rather than the full registry; `messageDispatcher.ts` spreads all
+// slices together and is the actual exhaustiveness checkpoint TypeScript
+// enforces.
+export const taskHandlers = {
   [PROGRESS_VIEW_COMMANDS.UPDATE_TODOS]: (data, ctx) => {
     updateToolUseState(ctx, data.stream, (prev) =>
       create(prev, (draft) => {
@@ -24,4 +30,4 @@ export const taskHandlers: HandlerRegistry = {
       }),
     );
   },
-};
+} satisfies Partial<HandlerRegistry>;

--- a/packages/extension/src/progressView/frontend/slices/uiSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/uiSlice.ts
@@ -2,8 +2,21 @@ import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 
 import type { HandlerRegistry } from '../messageHandlerTypes';
 
-export const uiHandlers: HandlerRegistry = {
+// `HandlerRegistry` is now exhaustive (every ProgressView outbound command
+// needs a real handler or `unsupported(...)` — see `@shared/utils/dispatcher`).
+// This slice only owns the two view-wide commands below, so it's typed as a
+// `satisfies Partial<...>` subset rather than the full registry;
+// `messageDispatcher.ts` spreads all slices together and is the actual
+// exhaustiveness checkpoint TypeScript enforces.
+export const uiHandlers = {
   [PROGRESS_VIEW_COMMANDS.SET_PLACEMENT]: (data, ctx) => {
     ctx.setPlacement(data.placement);
   },
-};
+  // THEME_SET shares its command string with COMMON_COMMANDS.THEME_SET
+  // ('setTheme'): BaseWebviewApp's `messageListener` routes it through
+  // `handleCommonMessage` (which calls `onThemeChange`) *before* falling
+  // through to `handleMessage`/`dispatchMessage`, so this entry only exists
+  // to keep the outbound command union exhaustive here — it never actually
+  // runs in production. See `BaseWebviewApp.ts`'s `messageListener`.
+  [PROGRESS_VIEW_COMMANDS.THEME_SET]: () => {},
+} satisfies Partial<HandlerRegistry>;

--- a/scripts/smoke-webviews-electron.mjs
+++ b/scripts/smoke-webviews-electron.mjs
@@ -87,6 +87,7 @@ const views = [
         command: 'updateStreams',
         streams: [
           {
+            kind: 'agent',
             name: 'builtInToolUse:chat',
             label: 'chat',
             model: 'deepseekT',
@@ -160,6 +161,7 @@ const views = [
         command: 'updateStreams',
         streams: [
           {
+            kind: 'agent',
             name: 'builtInToolUse:orchestrator',
             label: 'orchestrator',
             model: 'deepseekT',

--- a/src/shared/schemas/progressView/outbound.ts
+++ b/src/shared/schemas/progressView/outbound.ts
@@ -1,10 +1,15 @@
 /**
  * ProgressView outbound message schemas (backend -> frontend): UPDATE_*, SYNC_*,
- * permission/bypass updates, and the discriminated union they compose into.
+ * permission/bypass updates, and the discriminated union + dispatcher they
+ * compose into.
  */
 import { z } from 'zod';
 
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import {
+  createDispatcher,
+  type HandlerRegistry,
+} from '@shared/utils/dispatcher';
 import { GoalStatusSchema } from '../goal';
 
 import { StreamTabIdSchema } from '../identifiers';
@@ -391,3 +396,10 @@ export const ProgressViewOutboundMessageSchema = z.discriminatedUnion(
 export type ProgressViewOutboundMessage = z.infer<
   typeof ProgressViewOutboundMessageSchema
 >;
+
+export type ProgressViewOutboundHandlerRegistry =
+  HandlerRegistry<ProgressViewOutboundMessage>;
+
+export const dispatchProgressViewOutbound = createDispatcher(
+  ProgressViewOutboundMessageSchema,
+);

--- a/src/test-kernel/progressView/InquiryPanelState.vitest.ts
+++ b/src/test-kernel/progressView/InquiryPanelState.vitest.ts
@@ -11,16 +11,20 @@ import {
   type ProgressState,
   type StreamLogs,
 } from '@progressView/frontend/store';
-import type { MessageHandlerContext } from '@progressView/frontend/messageHandlerTypes';
+import type {
+  HandlerRegistry,
+  MessageHandlerContext,
+} from '@progressView/frontend/messageHandlerTypes';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
-
-// Local imports - shared schemas
 import type {
   ExternalInquiryThreadId,
   InquiryThreadUpdatedEvent,
   ProgressViewOutboundMessage,
   StreamTabId,
 } from '@shared/schemas';
+import { assertSupported } from '@shared/utils/dispatcher';
+
+// Local imports - shared schemas
 
 function createContext(initialState: ProgressState): {
   ctx: MessageHandlerContext;
@@ -72,9 +76,11 @@ function dispatch(
   message: ProgressViewOutboundMessage,
   ctx: MessageHandlerContext,
 ) {
-  const handler = inquiryHandlers[message.command];
+  const handler = (inquiryHandlers as Partial<HandlerRegistry>)[
+    message.command
+  ];
   expect(handler).toBeDefined();
-  handler?.(message as never, ctx);
+  assertSupported(handler!)(message as never, ctx);
 }
 
 describe('inquiry panel frontend state', () => {

--- a/src/test-kernel/progressView/LogDeltaTextDeltas.vitest.ts
+++ b/src/test-kernel/progressView/LogDeltaTextDeltas.vitest.ts
@@ -23,6 +23,7 @@ import {
   type StreamLogEntry,
   type StreamTabId,
 } from '@shared/schemas';
+import { assertSupported } from '@shared/utils/dispatcher';
 
 function createContext(initialState: ProgressState): {
   ctx: MessageHandlerContext;
@@ -56,13 +57,13 @@ function createContext(initialState: ProgressState): {
 }
 
 function dispatch(
-  handlers: HandlerRegistry,
+  handlers: Partial<HandlerRegistry>,
   message: ProgressViewOutboundMessage,
   ctx: MessageHandlerContext,
 ) {
   const handler = handlers[message.command];
   expect(handler).toBeDefined();
-  handler?.(message as never, ctx);
+  assertSupported(handler!)(message as never, ctx);
 }
 
 function modelResponseEntry(

--- a/src/test-kernel/progressView/ProcessOutputState.vitest.ts
+++ b/src/test-kernel/progressView/ProcessOutputState.vitest.ts
@@ -30,6 +30,7 @@ import {
   type ProgressViewOutboundMessage,
   type StreamTabId,
 } from '@shared/schemas';
+import { assertSupported } from '@shared/utils/dispatcher';
 
 function createContext(initialState: ProgressState): {
   ctx: MessageHandlerContext;
@@ -89,13 +90,13 @@ function createProcessState(streamId: StreamTabId): ProgressState {
 }
 
 function dispatch(
-  handlers: HandlerRegistry,
+  handlers: Partial<HandlerRegistry>,
   message: ProgressViewOutboundMessage,
   ctx: MessageHandlerContext,
 ) {
   const handler = handlers[message.command];
   expect(handler).toBeDefined();
-  handler?.(message as never, ctx);
+  assertSupported(handler!)(message as never, ctx);
 }
 
 function registerWorkflowStream(

--- a/src/test-kernel/progressView/ProgressViewMessageDispatcher.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewMessageDispatcher.vitest.ts
@@ -1,0 +1,213 @@
+/**
+ * Characterization + migration tests for progressView's frontend
+ * `dispatchMessage` (packages/extension/src/progressView/frontend/messageDispatcher.ts).
+ *
+ * Covers the two acceptance criteria from TeXRA#7442:
+ *  - Dispatch parity: real outbound commands still reach the correct slice
+ *    handler with `ctx` threaded through, and malformed/unrecognized
+ *    messages route to `onError` instead of throwing inside a handler body.
+ *  - Unsupported-command capability gating: a registry entry declared
+ *    `unsupported(...)` (the mechanism `messageHandlerTypes.ts`'s
+ *    `HandlerRegistry` now requires every command to resolve to) surfaces a
+ *    clear `UnsupportedCommandError` via `onError` instead of silently
+ *    no-oping — exercised directly against the exported
+ *    `dispatchProgressViewOutbound`, since the production registry (like
+ *    settingsView's/webview's) has no live `unsupported()` entries today.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { ZodError } from 'zod';
+
+import { dispatchMessage } from '@progressView/frontend/messageDispatcher';
+import type { MessageHandlerContext } from '@progressView/frontend/messageHandlerTypes';
+import {
+  createInitialState,
+  type ProgressState,
+} from '@progressView/frontend/store';
+import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import {
+  dispatchProgressViewOutbound,
+  ProgressViewOutboundMessageSchema,
+  type ProgressViewOutboundHandlerRegistry,
+} from '@shared/schemas';
+import { UnsupportedCommandError, unsupported } from '@shared/utils/dispatcher';
+
+/** Every command in the real outbound schema, including nested unions (UPDATE_PERMISSION). */
+function outboundCommands(): string[] {
+  const commands = new Set<string>();
+  for (const opt of ProgressViewOutboundMessageSchema.options as Array<{
+    shape?: { command: { value: string } };
+    options?: Array<{ shape: { command: { value: string } } }>;
+  }>) {
+    if (opt.shape) {
+      commands.add(opt.shape.command.value);
+    } else if (opt.options) {
+      for (const sub of opt.options) commands.add(sub.shape.command.value);
+    }
+  }
+  return [...commands];
+}
+
+function createSpyContext(initialState: ProgressState = createInitialState()): {
+  ctx: MessageHandlerContext;
+  getState: () => ProgressState;
+  setState: ReturnType<typeof vi.fn>;
+  setPermissions: ReturnType<typeof vi.fn>;
+  setPlacement: ReturnType<typeof vi.fn>;
+} {
+  let state = initialState;
+  const setState = vi.fn();
+  const setPermissions = vi.fn();
+  const setPlacement = vi.fn();
+  const ctx: MessageHandlerContext = {
+    getState: () => state,
+    setState: (updater) => {
+      state = updater(state);
+      setState(updater);
+    },
+    setStreamState: () => {},
+    setStreamLogs: () => {},
+    savePrefs: () => {},
+    getPermissions: () => [],
+    setPermissions,
+    setPlacement,
+  };
+  return { ctx, getState: () => state, setState, setPermissions, setPlacement };
+}
+
+describe('progressView dispatchMessage (createDispatcher migration)', () => {
+  it('routes SET_PLACEMENT to uiHandlers with ctx threaded through — dispatch parity', () => {
+    const { ctx, setPlacement } = createSpyContext();
+    const onError = vi.fn();
+
+    const handled = dispatchMessage(
+      { command: PROGRESS_VIEW_COMMANDS.SET_PLACEMENT, placement: 'editor' },
+      ctx,
+      onError,
+    );
+
+    expect(handled).toBe(true);
+    expect(setPlacement).toHaveBeenCalledWith('editor');
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('routes DELETE_ALL to streamLifecycleHandlers with ctx threaded through — dispatch parity', () => {
+    const { ctx, setPermissions, setState } = createSpyContext();
+    const onError = vi.fn();
+
+    const handled = dispatchMessage(
+      { command: PROGRESS_VIEW_COMMANDS.DELETE_ALL },
+      ctx,
+      onError,
+    );
+
+    expect(handled).toBe(true);
+    expect(setPermissions).toHaveBeenCalledWith([]);
+    expect(setState).toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('routes a malformed message to onError instead of throwing inside a handler body', () => {
+    const { ctx, setState } = createSpyContext();
+    const onError = vi.fn();
+
+    // SET_ACTIVE_STREAM requires `activeStream`; omitting it fails schema
+    // validation before any handler runs.
+    const handled = dispatchMessage(
+      { command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM },
+      ctx,
+      onError,
+    );
+
+    expect(handled).toBe(false);
+    expect(setState).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]?.[0]).toBeInstanceOf(ZodError);
+  });
+
+  it('routes an unrecognized command through the same schema-validation path', () => {
+    const { ctx } = createSpyContext();
+    const onError = vi.fn();
+
+    const handled = dispatchMessage(
+      { command: 'notARealProgressViewCommand' },
+      ctx,
+      onError,
+    );
+
+    expect(handled).toBe(false);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]?.[0]).toBeInstanceOf(ZodError);
+  });
+
+  it('does not throw for THEME_SET, though BaseWebviewApp intercepts it before dispatchMessage() in production', () => {
+    // THEME_SET shares its command string with COMMON_COMMANDS.THEME_SET;
+    // BaseWebviewApp's messageListener routes it through handleCommonMessage
+    // before handleMessage/dispatchMessage ever sees it. uiHandlers still
+    // carries a documented no-op entry to keep the outbound union exhaustive.
+    const { ctx } = createSpyContext();
+    const onError = vi.fn();
+
+    const handled = dispatchMessage(
+      { command: PROGRESS_VIEW_COMMANDS.THEME_SET, theme: 'dark' },
+      ctx,
+      onError,
+    );
+
+    expect(handled).toBe(true);
+    expect(onError).not.toHaveBeenCalled();
+  });
+});
+
+describe('dispatchProgressViewOutbound Unsupported-command gating (@shared/utils/dispatcher wiring)', () => {
+  function stubRegistry(): ProgressViewOutboundHandlerRegistry {
+    return Object.fromEntries(
+      outboundCommands().map((command) => [command, vi.fn()]),
+    ) as unknown as ProgressViewOutboundHandlerRegistry;
+  }
+
+  it('turns an unsupported registry entry into a clear UnsupportedCommandError instead of a silent no-op', () => {
+    const registry = stubRegistry();
+    const reason = 'Not available on this host.';
+    (registry as Record<string, unknown>)[
+      PROGRESS_VIEW_COMMANDS.SET_PLACEMENT
+    ] = unsupported(reason);
+    const noOp = registry[PROGRESS_VIEW_COMMANDS.DELETE_ALL];
+    const onError = vi.fn();
+
+    const handled = dispatchProgressViewOutbound(
+      { command: PROGRESS_VIEW_COMMANDS.SET_PLACEMENT, placement: 'editor' },
+      registry,
+      onError,
+    );
+
+    expect(handled).toBe(false);
+    expect(noOp).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledTimes(1);
+    const error = onError.mock.calls[0]?.[0];
+    expect(error).toBeInstanceOf(UnsupportedCommandError);
+    expect((error as UnsupportedCommandError).command).toBe(
+      PROGRESS_VIEW_COMMANDS.SET_PLACEMENT,
+    );
+    expect((error as UnsupportedCommandError).reason).toBe(reason);
+  });
+
+  it('still dispatches every other real command normally when one entry is unsupported', () => {
+    const registry = stubRegistry();
+    (registry as Record<string, unknown>)[
+      PROGRESS_VIEW_COMMANDS.SET_PLACEMENT
+    ] = unsupported('Not available on this host.');
+    const onError = vi.fn();
+
+    const handled = dispatchProgressViewOutbound(
+      { command: PROGRESS_VIEW_COMMANDS.DELETE_ALL },
+      registry,
+      onError,
+    );
+
+    expect(handled).toBe(true);
+    expect(registry[PROGRESS_VIEW_COMMANDS.DELETE_ALL]).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(onError).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Root cause

`packages/extension/src/progressView/frontend/messageDispatcher.ts` hand-rolled its own outbound (backend → frontend) dispatch — `handlers[message.command]?.(message, ctx)` — instead of the shared `createDispatcher` mechanism from `@shared/utils/dispatcher` that `settingsView`/`webview` frontends already use (PR #7400's "Scheduled refactoring" flagged this as explicitly out of scope). Two consequences:

- **No schema validation.** The dispatcher trusted TypeScript's compile-time cast alone (`event.data as TMessage`), so a schema/handler mismatch could throw deep inside a handler body instead of surfacing as a clear parse error.
- **No Unsupported-command gating.** `HandlerRegistry`'s command keys were all optional (`?:`), so a command with no registered handler silently no-oped via `handler?.()` instead of producing a signal.

## Fix

- Export `dispatchProgressViewOutbound = createDispatcher(ProgressViewOutboundMessageSchema)` from `src/shared/schemas/progressView/outbound.ts`, mirroring the existing `dispatchProgressViewInbound` in `inbound.ts` and settingsView's `dispatchSettingsViewOutbound`.
- `messageHandlerTypes.ts`'s `HandlerRegistry` is now exhaustive: every outbound command must resolve to a real handler or `unsupported(reason)` (same contract the other two frontends use), instead of being silently omittable.
- Slices keep their existing two-arg `(data, ctx) => void` handler shape (most of `MessageHandlerContext` closes over module-level state, but `savePrefs` closes over the live `ProgressApp` instance). `messageDispatcher.ts`'s new `bindHandlers()` binds each slice handler to the current `ctx` right before handing the registry to `dispatchProgressViewOutbound`, so the slice/`HandlerRegistry` composition itself is unchanged — each slice is now typed `satisfies Partial<HandlerRegistry>` (same pattern as `settingsView`'s slices), and the composed registry in `messageDispatcher.ts` is still the exhaustiveness checkpoint.
- `THEME_SET` shares its command string with `COMMON_COMMANDS.THEME_SET` and is already fully intercepted by `BaseWebviewApp`'s `handleCommonMessage` before `handleMessage`/`dispatchMessage` ever runs — it never actually reaches this dispatcher in production. Rather than mark it `unsupported(...)` (misleading — it's not a capability gap), it gets a documented no-op entry in `uiSlice.ts` to keep the outbound union exhaustive.
- `ProgressApp.handleMessage` now takes `raw: unknown` and passes an `onError` callback (mirroring `SettingsApp`), surfacing schema-validation failures via `logSchemaError` instead of trusting the cast.

## Tests

Added `src/test-kernel/progressView/ProgressViewMessageDispatcher.vitest.ts`:
- **Dispatch parity** (characterization): real commands (`SET_PLACEMENT`, `DELETE_ALL`) still reach the correct slice handler with `ctx` threaded through.
- Malformed and unrecognized messages route to `onError` (a `ZodError`) instead of throwing inside a handler.
- `THEME_SET`'s documented no-op doesn't throw if ever reached directly.
- **Unsupported-command gating**: exercises `dispatchProgressViewOutbound` directly with a synthetic registry (derived from the real schema's command set) that marks one entry `unsupported(...)`, asserting `onError` receives an `UnsupportedCommandError` with the right `command`/`reason`, the real handler doesn't run, and every other command still dispatches normally.

Also fixed three pre-existing progressView vitest suites (`InquiryPanelState`, `LogDeltaTextDeltas`, `ProcessOutputState`) whose local `dispatch()` test helpers indexed slice handler tables directly with `handler?.()` — the now-exhaustive `HandlerRegistry` type changed handler values from `T | undefined` to `T | Unsupported`, so these now use `assertSupported()` (the same escape hatch `SettingsApp` uses for direct-entry test/call-site access).

## Verification

- `npx tsc --noEmit` — clean (pre-existing unrelated `@openrouter/sdk`/`vscode-jsonrpc` module-resolution errors present identically on `origin/main`, confirmed via `git stash`).
- `npx tsc --noEmit -p tsconfig.test-kernel.json` — no new errors (grepped for progressView/dispatcher-related output: zero hits, before and after).
- `npx eslint <all changed files>` — 0 errors, 0 warnings.
- `npx prettier --check <all changed files>` — clean.
- `npx vitest run src/test-kernel/progressView/` — 33 files, 166 tests passed.
- `npx vitest run src/test-kernel/settingsView src/test-kernel/webview` — 17 tests passed (sibling frontends unaffected).
- `npx vitest run src/test-kernel/architecture/dependencyDirection.vitest.ts` — 13 tests passed (progressView frontend stays a VS Code-free zone).

Fixes #7442.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the progress view postMessage hot path and error behavior, but dispatch parity is tested and failures become explicit instead of silent; slice handler logic is largely unchanged.
> 
> **Overview**
> **Progress view outbound dispatch** no longer uses a direct `handlers[command]?.()` lookup on compile-time-typed messages. It goes through **`dispatchProgressViewOutbound`** (`createDispatcher` + `ProgressViewOutboundMessageSchema`), with slice handlers bound to per-message **`ctx`** via **`bindHandlers`**.
> 
> **`HandlerRegistry`** is now **exhaustive**: every outbound command must have a handler or **`unsupported(...)`**; slices use **`satisfies Partial<HandlerRegistry>`**, with the merged registry in **`messageDispatcher.ts`** as the compile-time checkpoint. **`THEME_SET`** gets a documented no-op entry for exhaustiveness (intercepted earlier by **`BaseWebviewApp`** in production).
> 
> **`ProgressApp.handleMessage`** accepts **`raw: unknown`** and reports validation failures through **`onError`** → **`logSchemaError`** instead of trusting casts. Malformed or missing-handler cases surface as **`ZodError`** / **`UnsupportedCommandError`** rather than silent no-ops or throws deep in handlers.
> 
> Adds **`ProgressViewMessageDispatcher.vitest.ts`** and updates slice test helpers to use **`assertSupported`**. Electron smoke seeds add **`kind: 'agent'`** on stream fixtures for schema compliance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dab26f382829489b70990516864291d43b62374c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->