### PR TITLE
refactor: delete progress bus listener adapter surface

### DIFF
--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -260,23 +260,7 @@ export interface ProgressEventPayloads {
 
 export type ProgressEvent = keyof ProgressEventPayloads;
 
-/**
- * Interface for the progress event bus.
- * Used by event handler modules for testability and dependency injection.
- */
-export interface ProgressEventBusLike {
-  on<K extends ProgressEvent>(
-    event: K,
-    listener: (payload: ProgressEventPayloads[K]) => void,
-    options?: { signal?: AbortSignal },
-  ): () => void;
-  emit<K extends ProgressEvent>(
-    event: K,
-    payload: ProgressEventPayloads[K],
-  ): void;
-}
-
-class ProgressEventBusImpl implements ProgressEventBusLike {
+class ProgressEventBusImpl {
   private emitter = new EventEmitter();
   private buffer: {
     event: ProgressEvent;

--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -4,7 +4,6 @@ import type { StreamPhaseState } from '@agent/runtime/StreamStatusService';
 import { isInFlightStatus } from '@common/constants/streamStatus';
 import type {
   ProgressEvent,
-  ProgressEventBusLike,
   ProgressEventPayloads,
 } from '@eventBus/ProgressEventBus';
 import { createChannelTrace } from '@logger';
@@ -381,27 +380,6 @@ export class ProgressEventHandler {
         context: 'failed to resolve user question',
         handle: (payload) =>
           this.uiCallbacks.resolveUserQuestion(payload.requestId),
-      },
-    };
-  }
-
-  setupEventListeners(bus: ProgressEventBusLike): ProgressEventSubscription {
-    const controller = new AbortController();
-    const { signal } = controller;
-    const localSubscription = this.createLocalSubscription();
-
-    for (const event of Object.keys(
-      this.eventRegistrations,
-    ) as ProgressEvent[]) {
-      bus.on(event, (payload) => this.handleProgressEvent(event, payload), {
-        signal,
-      });
-    }
-
-    return {
-      dispose: () => {
-        controller.abort();
-        localSubscription.dispose();
       },
     };
   }

--- a/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
+++ b/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
@@ -5,10 +5,7 @@ import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import type {
-  ProgressEventBusLike,
-  ProgressEventPayloads,
-} from '@eventBus/ProgressEventBus';
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import type {
   DiffOptions,
   DiffSession,
@@ -44,7 +41,12 @@ interface DesktopPlatformModule {
   createDesktopToolEditApprovalPort(): import('@platform/interfaces/toolEditApproval').ToolEditApprovalPort;
 }
 
-function createBusRuntimeHost(bus: ProgressEventBusLike): AgentRuntimeHost {
+type TestProgressEventBus = Pick<
+  typeof import('@eventBus/ProgressEventBus').ProgressEventBus,
+  'emit' | 'on'
+>;
+
+function createBusRuntimeHost(bus: TestProgressEventBus): AgentRuntimeHost {
   return {
     emit: (event, payload) => bus.emit(event, payload),
   };
@@ -66,7 +68,7 @@ async function waitForEmptyDir(dir: string): Promise<void> {
   }
 }
 
-function trackShownApprovals(bus: ProgressEventBusLike): {
+function trackShownApprovals(bus: TestProgressEventBus): {
   shown: ProgressEventPayloads['showToolEditPermission'][];
   offShow: () => void;
 } {


### PR DESCRIPTION
## Summary

- delete the production-unused `ProgressEventHandler.setupEventListeners(bus)` bridge
- remove the exported `ProgressEventBusLike` interface, which only existed for that listener adapter
- keep the remaining test-only bus usage local by defining the minimal desktop approval test bus shape in the test file

## Stage 5 evidence

This follows #7446, which removed the last extension process-bus adapter and left no production direct `ProgressEventBus.on(...)` / `.emit(...)` call sites.

Production grep after this PR:

```text
ProgressEventBus.on(...): 0 direct production call sites in src/ and packages/
ProgressEventBus.emit(...): 0 direct production call sites in src/ and packages/
ProgressEventBusLike: 0 references
ProgressEventHandler.setupEventListeners(bus): 0 references
```

Out of scope: deleting `ProgressEventPayloads`, the test-only `ProgressEventBus` singleton, approval RPC payload keys, and remaining type-only event vocabulary imports.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts` — 2 files passed, 31 tests passed
- `corepack pnpm exec eslint src/eventBus/ProgressEventBus.ts src/shared/progressView/backend/events/ProgressEventHandler.ts src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts --max-warnings=0` — passed
- `corepack pnpm exec prettier --check src/eventBus/ProgressEventBus.ts src/shared/progressView/backend/events/ProgressEventHandler.ts src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts` — passed
- `corepack pnpm run typecheck` — passed
- `corepack pnpm run compile:fast` — passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead adapter and type removal only; production progress wiring already goes through session projection, with test-only bus usage unchanged in behavior.
> 
> **Overview**
> Removes the unused **progress event bus listener bridge** after production no longer subscribes to `ProgressEventBus` directly.
> 
> **`ProgressEventBusLike`** is deleted and **`ProgressEventBusImpl`** no longer implements it. **`ProgressEventHandler.setupEventListeners(bus)`**—which registered every progress event on an injected bus—is removed; progress handling stays on **`handleProgressEvent`** and **`createLocalSubscription`**, while **`ProgressBackend.setupEventListeners()`** continues to wire session facts instead of the singleton bus.
> 
> The desktop tool-edit approval test replaces the shared interface with a local **`TestProgressEventBus`** type (`Pick` of `emit` / `on` on the real bus singleton) so tests keep a minimal mock shape without exporting a DI surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39c049bf66fc2d837c55fd14a67d721621b16636. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->