### PR TITLE
refactor: delete progress event bus singleton

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -307,7 +307,7 @@ For good separation of concerns and platform independence, core business logic s
 
 - Route logging through `@logger/logUtils`. Agent flows should use `AgentTrace` (`@agent/trace`) to get grouped output and tool-use aware channels.
 - Always pass structured payloads via the `data` argument (file lists, missing outputs, latexdiff results, usage statistics) so the progress view can render rich entries without custom parsing.
-- Publish progress updates with the event bus (`bus.emit`/`bus.on` from `src/eventBus/ProgressEventBus.ts`) and keep non-agent logs on the shared `TeXRA` output channel.
+- Publish runtime progress through session events and `AgentRuntimeHost.emit`; keep non-agent logs on the shared `TeXRA` output channel.
 
 **Agent execution and tool-use**
 

--- a/src/agent/runtime/emitRuntimeEvent.ts
+++ b/src/agent/runtime/emitRuntimeEvent.ts
@@ -1,9 +1,8 @@
 /**
  * Single emit path for session-scoped runtime facts.
  *
- * Replaces scattered `ProgressEventBus.emit(...)` in `src/tools` so one
- * session fact has one emit path and one name, resolving the target in priority
- * order:
+ * Keeps migrated runtime facts on one emit path and one name, resolving the
+ * target in priority order:
  *
  * 1. a host-path caller's explicit `session`;
  * 2. the active run's `RunContext.session`;

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -1,5 +1,3 @@
-import { EventEmitter } from 'node:events';
-
 import type { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { TaskState } from '@agent/core/state/TaskState';
 import type {
@@ -60,8 +58,6 @@ interface SetTaskStatePayload {
   taskState: TaskState;
 }
 
-const MAX_BUFFER_SIZE = 1000;
-
 /**
  * Host-agnostic action tokens for {@link ProgressEventPayloads.requestShowInstruction}.
  * The agent core emits a token; each host maps it to its own UI affordance
@@ -79,16 +75,14 @@ export type InstructionAction =
   (typeof INSTRUCTION_ACTION)[keyof typeof INSTRUCTION_ACTION];
 
 /**
- * Every payload this bus carries, grouped below by what it actually reports —
- * not one channel with one owner. It mixes run/stream progress facts, approval
+ * Shared progress-event payload vocabulary, grouped below by what each event
+ * actually reports. It still mixes run/stream progress facts, approval
  * request/resolve RPC pairs, app-lifecycle and integration signals, and
- * host-presentation requests, with delivery depending on which host
- * re-published a given event rather than on what kind of event it is. This is
- * a known, tracked shape, not an oversight: see `docs/proposals/
- * error-pipeline-and-ownership.md` (Map 3) for the audit and the planned
- * run-scoped/app-scoped split gated on SDK Step 7d. Until that split lands,
- * treat the section comments below as the de facto ownership boundaries when
- * deciding where a new event belongs.
+ * host-presentation requests. This is a known, tracked shape, not an oversight:
+ * see `docs/proposals/error-pipeline-and-ownership.md` (Map 3) for the audit
+ * and the planned run-scoped/app-scoped split gated on SDK Step 7d. Until that
+ * split lands, treat the section comments below as the de facto ownership
+ * boundaries when deciding where a new event belongs.
  */
 export interface ProgressEventPayloads {
   // ── Run/stream progress (part 1) ──
@@ -211,7 +205,7 @@ export interface ProgressEventPayloads {
   /** Emitted whenever a Goal record mutates (start/pause/resume/
    *  complete/abandon/edit-objective/cap-reached) so UI surfaces (header
    *  chip, settings tab, progress board) can refresh. The agent owns state
-   *  transitions through the plan tool; the bus event is how those flow
+   *  transitions through the plan tool; the session fact is how those flow
    *  back to the UI. */
   goalStateChanged: { streamId: StreamTabId };
 
@@ -258,54 +252,11 @@ export interface ProgressEventPayloads {
   };
 }
 
+/**
+ * Contract-only progress event vocabulary.
+ *
+ * This module no longer exports a process-wide event bus. Runtime facts are
+ * emitted through session handles; host interactions are emitted through the
+ * owning runtime host.
+ */
 export type ProgressEvent = keyof ProgressEventPayloads;
-
-class ProgressEventBusImpl {
-  private emitter = new EventEmitter();
-  private buffer: {
-    event: ProgressEvent;
-    payload: ProgressEventPayloads[ProgressEvent];
-  }[] = [];
-
-  emit<K extends ProgressEvent>(
-    event: K,
-    payload: ProgressEventPayloads[K],
-  ): void {
-    if (this.emitter.listenerCount(event) === 0) {
-      this.buffer.push({ event, payload });
-      if (this.buffer.length > MAX_BUFFER_SIZE) {
-        this.buffer.shift();
-      }
-    } else {
-      this.emitter.emit(event, payload);
-    }
-  }
-
-  on<K extends ProgressEvent>(
-    event: K,
-    listener: (payload: ProgressEventPayloads[K]) => void,
-    options?: { signal?: AbortSignal },
-  ): () => void {
-    if (options?.signal?.aborted) return () => {};
-
-    this.emitter.on(event, listener);
-    const cleanup = (): void => {
-      this.emitter.off(event, listener);
-    };
-    options?.signal?.addEventListener('abort', cleanup, { once: true });
-
-    const remaining: typeof this.buffer = [];
-    for (const item of this.buffer) {
-      if (item.event === event) {
-        listener(item.payload as ProgressEventPayloads[K]);
-      } else {
-        remaining.push(item);
-      }
-    }
-    this.buffer = remaining;
-
-    return cleanup;
-  }
-}
-
-export const ProgressEventBus = new ProgressEventBusImpl();

--- a/src/test-kernel/agent/runtime/EmitRuntimeEvent.vitest.ts
+++ b/src/test-kernel/agent/runtime/EmitRuntimeEvent.vitest.ts
@@ -5,7 +5,6 @@ import { describe, expect, it } from 'vitest';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
 import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
-import { ProgressEventBus } from '@eventBus/ProgressEventBus';
 import type { StreamTabId } from '@shared/schemas';
 
 import { attachSessionProgressEventProjectionForTest } from '../sessionProgressTestUtils';
@@ -16,12 +15,10 @@ const streamId = (s: string): StreamTabId => s as StreamTabId;
 describe('emitRuntimeEvent (SDK Step 7d F-1 — one emit path)', () => {
   it('routes migrated facts to the default session instead of the process bus', () => {
     const sessionSeen: unknown[] = [];
-    const seen: unknown[] = [];
     const detachSession = defaultSession().events.subscribe(
       (event) => sessionSeen.push(event),
       { scope: 'session' },
     );
-    const off = ProgressEventBus.on('goalStateChanged', (p) => seen.push(p));
     try {
       emitRuntimeEvent('goalStateChanged', { streamId: streamId('s:bus') });
       expect(sessionSeen).toEqual([
@@ -33,10 +30,8 @@ describe('emitRuntimeEvent (SDK Step 7d F-1 — one emit path)', () => {
           },
         },
       ]);
-      expect(seen).toEqual([]);
     } finally {
       detachSession();
-      off();
     }
   });
 
@@ -46,10 +41,6 @@ describe('emitRuntimeEvent (SDK Step 7d F-1 — one emit path)', () => {
     const detachProjection = attachSessionProgressEventProjectionForTest(
       session.events,
       run.host,
-    );
-    const busSeen: unknown[] = [];
-    const off = ProgressEventBus.on('updateQueuedFollowUps', (p) =>
-      busSeen.push(p),
     );
     try {
       withRunContext(
@@ -69,28 +60,19 @@ describe('emitRuntimeEvent (SDK Step 7d F-1 — one emit path)', () => {
           payload: { streamId: 's:run' },
         },
       ]);
-      expect(busSeen).toEqual([]);
     } finally {
-      off();
       detachProjection();
       session.dispose();
     }
   });
 
   it('rejects non-session events instead of falling back to the process bus', () => {
-    const busSeen: unknown[] = [];
-    const off = ProgressEventBus.on('requestShowError', (p) => busSeen.push(p));
-    try {
-      expect(() => {
-        // @ts-expect-error requestShowError is host interaction, not a session fact.
-        emitRuntimeEvent('requestShowError', { message: 'run error' });
-      }).toThrow(
-        'emitRuntimeEvent only supports session facts; use the owning runtime host for requestShowError',
-      );
-      expect(busSeen).toEqual([]);
-    } finally {
-      off();
-    }
+    expect(() => {
+      // @ts-expect-error requestShowError is host interaction, not a session fact.
+      emitRuntimeEvent('requestShowError', { message: 'run error' });
+    }).toThrow(
+      'emitRuntimeEvent only supports session facts; use the owning runtime host for requestShowError',
+    );
   });
 
   it('rejects non-session events instead of using the active run host', () => {
@@ -115,8 +97,6 @@ describe('emitRuntimeEvent (SDK Step 7d F-1 — one emit path)', () => {
       (event) => sessionSeen.push(event),
       { scope: 'session' },
     );
-    const busSeen: unknown[] = [];
-    const off = ProgressEventBus.on('goalStateChanged', (p) => busSeen.push(p));
     try {
       withRunContext(createRunContext({ runtimeHost: run.host }), () => {
         emitRuntimeEvent(
@@ -136,10 +116,8 @@ describe('emitRuntimeEvent (SDK Step 7d F-1 — one emit path)', () => {
       ]);
       expect(channel.events).toEqual([]);
       expect(run.events).toEqual([]);
-      expect(busSeen).toEqual([]);
     } finally {
       detachSession();
-      off();
       session.dispose();
     }
   });

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -579,14 +579,9 @@ describe('DesktopProgressBridge', () => {
     vi.restoreAllMocks();
   });
 
-  it('routes runtime events to the desktop backend without the shared progress bus', async () => {
+  it('routes runtime events to the desktop backend through the bridge', async () => {
     const messages: unknown[] = [];
     const bridge = await createBridge(messages);
-    const { ProgressEventBus } = await import('@eventBus/ProgressEventBus');
-    const seen: unknown[] = [];
-    const off = ProgressEventBus.on('setActiveStream', (payload) => {
-      seen.push(payload);
-    });
 
     try {
       bridge.handleProgressEvent('setActiveStream', {
@@ -596,7 +591,6 @@ describe('DesktopProgressBridge', () => {
       await settleProgressEvents();
       bridge.syncFullView();
 
-      expect(seen).toEqual([]);
       expect(
         progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS).at(
           -1,
@@ -606,7 +600,6 @@ describe('DesktopProgressBridge', () => {
         streams: [expect.objectContaining({ name: 'parent' })],
       });
     } finally {
-      off();
       bridge.dispose();
     }
   });

--- a/src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts
@@ -45,8 +45,6 @@ type BridgeOptions = Parameters<
 >[0];
 type SnapshotStore = NonNullable<BridgeOptions['streamSnapshotStore']>;
 
-const mockProgressBusOn = vi.fn();
-
 function createSnapshotStore(
   overrides: Partial<SnapshotStore> = {},
 ): SnapshotStore {
@@ -119,7 +117,6 @@ async function loadBridgeModule(): Promise<
   typeof import('@desktop/main/desktopProgressEventBridge')
 > {
   vi.resetModules();
-  mockProgressBusOn.mockClear();
   vi.doMock('@logger', () => ({
     createChannelTrace: () => makeLogger(),
     setDefaultStreamLogStore: () => {},
@@ -129,12 +126,6 @@ async function loadBridgeModule(): Promise<
       transition: vi.fn(),
       get: vi.fn(() => STREAM_PHASE.CANCELLED),
       isActiveOrResuming: vi.fn(() => false),
-    },
-  }));
-  vi.doMock('@eventBus/ProgressEventBus', () => ({
-    ProgressEventBus: {
-      on: mockProgressBusOn,
-      emit: vi.fn(),
     },
   }));
   vi.doMock('@tools/goal', () => ({
@@ -551,8 +542,6 @@ describe('DesktopProgressEventBridge', () => {
       });
 
       try {
-        expect(mockProgressBusOn).not.toHaveBeenCalled();
-
         bridge.onProgressEvent('requestEnsureProgressView', {});
         bridge.onProgressEvent('requestShowError', {
           message: 'Root run failed',
@@ -562,7 +551,6 @@ describe('DesktopProgressEventBridge', () => {
         expect(onShowError).toHaveBeenCalledWith('Root run failed');
 
         bridge.dispose();
-        expect(mockProgressBusOn).not.toHaveBeenCalled();
       } finally {
         bridge.dispose();
       }

--- a/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
+++ b/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
@@ -41,14 +41,34 @@ interface DesktopPlatformModule {
   createDesktopToolEditApprovalPort(): import('@platform/interfaces/toolEditApproval').ToolEditApprovalPort;
 }
 
-type TestProgressEventBus = Pick<
-  typeof import('@eventBus/ProgressEventBus').ProgressEventBus,
-  'emit' | 'on'
->;
+interface RecordingRuntimeHost extends AgentRuntimeHost {
+  shownToolEditPermissions: ProgressEventPayloads['showToolEditPermission'][];
+  resolvedToolEditPermissions: ProgressEventPayloads['resolveToolEditPermission'][];
+}
 
-function createBusRuntimeHost(bus: TestProgressEventBus): AgentRuntimeHost {
+function createRecordingRuntimeHost(): RecordingRuntimeHost {
+  const shownToolEditPermissions: ProgressEventPayloads['showToolEditPermission'][] =
+    [];
+  const resolvedToolEditPermissions: ProgressEventPayloads['resolveToolEditPermission'][] =
+    [];
+  const eventHandlers: Partial<{
+    [K in keyof ProgressEventPayloads]: (
+      payload: ProgressEventPayloads[K],
+    ) => void;
+  }> = {
+    showToolEditPermission: (payload) => {
+      shownToolEditPermissions.push(payload);
+    },
+    resolveToolEditPermission: (payload) => {
+      resolvedToolEditPermissions.push(payload);
+    },
+  };
   return {
-    emit: (event, payload) => bus.emit(event, payload),
+    shownToolEditPermissions,
+    resolvedToolEditPermissions,
+    emit: (event, payload) => {
+      eventHandlers[event]?.(payload);
+    },
   };
 }
 
@@ -66,17 +86,6 @@ async function waitForEmptyDir(dir: string): Promise<void> {
     if ((await readdir(dir)).length === 0) return;
     await delay(10);
   }
-}
-
-function trackShownApprovals(bus: TestProgressEventBus): {
-  shown: ProgressEventPayloads['showToolEditPermission'][];
-  offShow: () => void;
-} {
-  const shown: ProgressEventPayloads['showToolEditPermission'][] = [];
-  const offShow = bus.on('showToolEditPermission', (payload) =>
-    shown.push(payload),
-  );
-  return { shown, offShow };
 }
 
 async function loadApprovalModules(workspacePath = '/workspace') {
@@ -165,12 +174,10 @@ async function loadApprovalModules(workspacePath = '/workspace') {
   );
 
   const [
-    { ProgressEventBus: bus },
     { requestToolEditApproval },
     { cleanupApprovalsForStream },
     desktopModule,
   ] = await Promise.all([
-    import('@eventBus/ProgressEventBus'),
     import('@tools/approval/toolEditApproval'),
     import('@tools/approval'),
     import(
@@ -178,7 +185,6 @@ async function loadApprovalModules(workspacePath = '/workspace') {
     ) as Promise<DesktopToolEditApprovalModule>,
   ]);
   return {
-    bus,
     requestToolEditApproval,
     cleanupApprovalsForStream,
     desktopModule,
@@ -195,20 +201,15 @@ describe('desktop tool edit approval', () => {
 
   it('registers the desktop approval handler and resolves approved edits', async () => {
     const tempRoot = await mkdtemp(path.join(tmpdir(), 'texra-approval-'));
-    const { bus, requestToolEditApproval, desktopModule } =
+    const { requestToolEditApproval, desktopModule } =
       await loadApprovalModules();
+    const runtimeHost = createRecordingRuntimeHost();
     const controller = desktopModule.createDesktopToolEditApprovalController({
-      runtimeHost: createBusRuntimeHost(bus),
+      runtimeHost,
       tempRoot,
     });
-    const shown: ProgressEventPayloads['showToolEditPermission'][] = [];
-    const resolved: ProgressEventPayloads['resolveToolEditPermission'][] = [];
-    const offShow = bus.on('showToolEditPermission', (payload) =>
-      shown.push(payload),
-    );
-    const offResolve = bus.on('resolveToolEditPermission', (payload) =>
-      resolved.push(payload),
-    );
+    const { shownToolEditPermissions: shown } = runtimeHost;
+    const { resolvedToolEditPermissions: resolved } = runtimeHost;
 
     try {
       const resultPromise = requestToolEditApproval({
@@ -242,8 +243,6 @@ describe('desktop tool edit approval', () => {
       });
       expect(resolved).toEqual([{ requestId: shown[0].requestId }]);
     } finally {
-      offShow();
-      offResolve();
       controller.dispose();
       await rm(tempRoot, { recursive: true, force: true });
     }
@@ -251,17 +250,18 @@ describe('desktop tool edit approval', () => {
 
   it('routes preview and diff actions through desktop temp files before rejection', async () => {
     const tempRoot = await mkdtemp(path.join(tmpdir(), 'texra-approval-'));
-    const { bus, requestToolEditApproval, desktopModule } =
+    const { requestToolEditApproval, desktopModule } =
       await loadApprovalModules();
+    const runtimeHost = createRecordingRuntimeHost();
     const opened: string[] = [];
     const controller = desktopModule.createDesktopToolEditApprovalController({
-      runtimeHost: createBusRuntimeHost(bus),
+      runtimeHost,
       tempRoot,
       openPath: async (filePath) => {
         opened.push(filePath);
       },
     });
-    const { shown, offShow } = trackShownApprovals(bus);
+    const { shownToolEditPermissions: shown } = runtimeHost;
 
     try {
       const resultPromise = requestToolEditApproval({
@@ -303,7 +303,6 @@ describe('desktop tool edit approval', () => {
         await expect(pathExists(opened[1])).resolves.toBe(false);
       });
     } finally {
-      offShow();
       controller.dispose();
       await rm(tempRoot, { recursive: true, force: true });
     }
@@ -311,8 +310,9 @@ describe('desktop tool edit approval', () => {
 
   it('routes diff actions through the injected desktop diff host when available', async () => {
     const tempRoot = await mkdtemp(path.join(tmpdir(), 'texra-approval-'));
-    const { bus, requestToolEditApproval, desktopModule } =
+    const { requestToolEditApproval, desktopModule } =
       await loadApprovalModules();
+    const runtimeHost = createRecordingRuntimeHost();
     const openPath = vi.fn(async (_filePath: string) => {});
     const openDiff = vi.fn(
       async (
@@ -323,12 +323,12 @@ describe('desktop tool edit approval', () => {
       ): Promise<DiffSession> => ({ original, proposed, title }),
     );
     const controller = desktopModule.createDesktopToolEditApprovalController({
-      runtimeHost: createBusRuntimeHost(bus),
+      runtimeHost,
       tempRoot,
       openPath,
       openDiff,
     });
-    const { shown, offShow } = trackShownApprovals(bus);
+    const { shownToolEditPermissions: shown } = runtimeHost;
 
     try {
       const resultPromise = requestToolEditApproval({
@@ -358,7 +358,6 @@ describe('desktop tool edit approval', () => {
       });
       await expect(resultPromise).resolves.toMatchObject({ accepted: false });
     } finally {
-      offShow();
       controller.dispose();
       await rm(tempRoot, { recursive: true, force: true });
     }
@@ -366,17 +365,18 @@ describe('desktop tool edit approval', () => {
 
   it('applies user edits made in the proposed preview file', async () => {
     const tempRoot = await mkdtemp(path.join(tmpdir(), 'texra-approval-'));
-    const { bus, requestToolEditApproval, desktopModule } =
+    const { requestToolEditApproval, desktopModule } =
       await loadApprovalModules();
+    const runtimeHost = createRecordingRuntimeHost();
     const opened: string[] = [];
     const controller = desktopModule.createDesktopToolEditApprovalController({
-      runtimeHost: createBusRuntimeHost(bus),
+      runtimeHost,
       tempRoot,
       openPath: async (filePath) => {
         opened.push(filePath);
       },
     });
-    const { shown, offShow } = trackShownApprovals(bus);
+    const { shownToolEditPermissions: shown } = runtimeHost;
 
     try {
       const resultPromise = requestToolEditApproval({
@@ -411,7 +411,6 @@ describe('desktop tool edit approval', () => {
         await expect(pathExists(opened[0])).resolves.toBe(false);
       });
     } finally {
-      offShow();
       controller.dispose();
       await rm(tempRoot, { recursive: true, force: true });
     }
@@ -422,15 +421,16 @@ describe('desktop tool edit approval', () => {
       path.join(tmpdir(), 'texra-workspace-'),
     );
     const tempRoot = await mkdtemp(path.join(tmpdir(), 'texra-approval-'));
-    const { bus, requestToolEditApproval, desktopModule } =
+    const { requestToolEditApproval, desktopModule } =
       await loadApprovalModules(workspaceRoot);
+    const runtimeHost = createRecordingRuntimeHost();
     const displayed: Array<{
       absolutePath: string;
       options?: { preserveFocus?: boolean };
     }> = [];
     const messages: string[] = [];
     const controller = desktopModule.createDesktopToolEditApprovalController({
-      runtimeHost: createBusRuntimeHost(bus),
+      runtimeHost,
       tempRoot,
       openBuildDisplay: async (location, options) => {
         displayed.push({ absolutePath: location.absolutePath, options });
@@ -439,7 +439,7 @@ describe('desktop tool edit approval', () => {
         messages.push(message);
       },
     });
-    const { shown, offShow } = trackShownApprovals(bus);
+    const { shownToolEditPermissions: shown } = runtimeHost;
 
     try {
       const resultPromise = requestToolEditApproval({
@@ -475,7 +475,6 @@ describe('desktop tool edit approval', () => {
         );
       });
     } finally {
-      offShow();
       controller.dispose();
       await rm(tempRoot, { recursive: true, force: true });
       await rm(workspaceRoot, { recursive: true, force: true });
@@ -485,23 +484,17 @@ describe('desktop tool edit approval', () => {
   it('cleans pending entries and temp files when stream cleanup rejects a request', async () => {
     const tempRoot = await mkdtemp(path.join(tmpdir(), 'texra-approval-'));
     const {
-      bus,
       requestToolEditApproval,
       cleanupApprovalsForStream,
       desktopModule,
     } = await loadApprovalModules();
+    const runtimeHost = createRecordingRuntimeHost();
     const controller = desktopModule.createDesktopToolEditApprovalController({
-      runtimeHost: createBusRuntimeHost(bus),
+      runtimeHost,
       tempRoot,
     });
-    const shown: ProgressEventPayloads['showToolEditPermission'][] = [];
-    const resolved: ProgressEventPayloads['resolveToolEditPermission'][] = [];
-    const offShow = bus.on('showToolEditPermission', (payload) =>
-      shown.push(payload),
-    );
-    const offResolve = bus.on('resolveToolEditPermission', (payload) =>
-      resolved.push(payload),
-    );
+    const { shownToolEditPermissions: shown } = runtimeHost;
+    const { resolvedToolEditPermissions: resolved } = runtimeHost;
 
     try {
       const resultPromise = requestToolEditApproval({
@@ -520,8 +513,6 @@ describe('desktop tool edit approval', () => {
       await waitForEmptyDir(tempRoot);
       expect(await readdir(tempRoot)).toEqual([]);
     } finally {
-      offShow();
-      offResolve();
       controller.dispose();
       await rm(tempRoot, { recursive: true, force: true });
     }
@@ -529,13 +520,14 @@ describe('desktop tool edit approval', () => {
 
   it('returns false for unknown approval actions', async () => {
     const tempRoot = await mkdtemp(path.join(tmpdir(), 'texra-approval-'));
-    const { bus, requestToolEditApproval, desktopModule } =
+    const { requestToolEditApproval, desktopModule } =
       await loadApprovalModules();
+    const runtimeHost = createRecordingRuntimeHost();
     const controller = desktopModule.createDesktopToolEditApprovalController({
-      runtimeHost: createBusRuntimeHost(bus),
+      runtimeHost,
       tempRoot,
     });
-    const { shown, offShow } = trackShownApprovals(bus);
+    const { shownToolEditPermissions: shown } = runtimeHost;
 
     try {
       const resultPromise = requestToolEditApproval({
@@ -556,7 +548,6 @@ describe('desktop tool edit approval', () => {
       controller.dispose();
       await expect(resultPromise).resolves.toMatchObject({ accepted: false });
     } finally {
-      offShow();
       controller.dispose();
       await rm(tempRoot, { recursive: true, force: true });
     }

--- a/src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts
+++ b/src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts
@@ -1,23 +1,17 @@
 import { describe, expect, it } from 'vitest';
 
 import { defaultSession } from '@agent/runtime/SessionHandle';
-import { ProgressEventBus } from '@eventBus/ProgressEventBus';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { extensionPresentationEvents } from '@frontend/events/extensionPresentationEvents';
 import type { StreamTabId } from '@shared/schemas';
 
 describe('extensionAgentRuntimeHost', () => {
-  it('routes extension presentation events away from ProgressEventBus', () => {
-    const busPayloads: unknown[] = [];
+  it('routes extension presentation events through the presentation channel', () => {
     const presentationPayloads: unknown[] = [];
-    const disposeBus = ProgressEventBus.on('requestShowError', (payload) =>
-      busPayloads.push(payload),
-    );
     const disposePresentation = extensionPresentationEvents.on(
       'requestShowError',
       (payload) => presentationPayloads.push(payload),
     );
-    busPayloads.length = 0;
     presentationPayloads.length = 0;
 
     try {
@@ -25,22 +19,16 @@ describe('extensionAgentRuntimeHost', () => {
         message: 'The model invocation failed.',
       });
 
-      expect(busPayloads).toEqual([]);
       expect(presentationPayloads).toEqual([
         { message: 'The model invocation failed.' },
       ]);
     } finally {
       disposePresentation();
-      disposeBus();
     }
   });
 
   it('routes run progress events through extension host interactions', () => {
-    const busPayloads: unknown[] = [];
     const interactionEvents: unknown[] = [];
-    const disposeBus = ProgressEventBus.on('setActiveStream', (payload) =>
-      busPayloads.push(payload),
-    );
     const disposeInteractions = defaultSession().useHostInteractions({
       handleProgressEvent: (event, payload) => {
         interactionEvents.push({ event, payload });
@@ -50,7 +38,6 @@ describe('extensionAgentRuntimeHost', () => {
       resolve: () => false,
       cancelForStream: () => {},
     });
-    busPayloads.length = 0;
 
     try {
       extensionAgentRuntimeHost.emit('setActiveStream', {
@@ -63,7 +50,6 @@ describe('extensionAgentRuntimeHost', () => {
           payload: { streamId: 'extension:progress' as StreamTabId },
         },
       ]);
-      expect(busPayloads).toEqual([]);
 
       disposeInteractions();
       extensionAgentRuntimeHost.emit('setActiveStream', {
@@ -76,10 +62,8 @@ describe('extensionAgentRuntimeHost', () => {
           payload: { streamId: 'extension:progress' as StreamTabId },
         },
       ]);
-      expect(busPayloads).toEqual([]);
     } finally {
       disposeInteractions();
-      disposeBus();
     }
   });
 });

--- a/src/test-kernel/frontend/OutputFileRunFactSubscriptions.vitest.ts
+++ b/src/test-kernel/frontend/OutputFileRunFactSubscriptions.vitest.ts
@@ -113,7 +113,6 @@ vi.mock('vscode', () => {
 const { SessionEventHub } = await import('@agent/runtime/SessionEventHub');
 const { toRunFactDomainKey } = await import('@agent/runtime/runFactEvents');
 const { appSignals } = await import('@eventBus/AppSignals');
-const { ProgressEventBus } = await import('@eventBus/ProgressEventBus');
 const { registerInlineCriticism, setInlineCriticismEnabled } =
   await import('@frontend/latex/inlineCriticism');
 const { registerFileDecorations } =
@@ -175,11 +174,6 @@ function disposeContext(context: {
   }
 }
 
-function drainBufferedAddOutputFilesBusEvents(): void {
-  const unsubscribe = ProgressEventBus.on('addOutputFiles', () => undefined);
-  unsubscribe();
-}
-
 async function waitFor(
   predicate: () => boolean,
   message: string,
@@ -201,7 +195,6 @@ describe('output-file run fact frontend subscriptions', () => {
   });
 
   afterEach(async () => {
-    drainBufferedAddOutputFilesBusEvents();
     if (tempDir) {
       await AbsoluteFS.delete(tempDir, { recursive: true });
       tempDir = undefined;
@@ -215,13 +208,6 @@ describe('output-file run fact frontend subscriptions', () => {
     const provider = mocks.registeredProviders.at(-1) as {
       provideFileDecoration(uri: { scheme: string; fsPath: string }): unknown;
     };
-
-    const legacyPath = '/tmp/texra-legacy-output.tex';
-    ProgressEventBus.emit('addOutputFiles', addOutputFilesPayload(legacyPath));
-    expect(provider.provideFileDecoration(vscode.Uri.file(legacyPath))).toBe(
-      undefined,
-    );
-    drainBufferedAddOutputFilesBusEvents();
 
     const runFactPath = '/tmp/texra-run-fact-output.tex';
     emitAddOutputFilesRunFact(hub, addOutputFilesPayload(runFactPath));
@@ -258,13 +244,6 @@ describe('output-file run fact frontend subscriptions', () => {
     expect(mocks.diagnosticCollections.at(-1)?.items.get(outputPath)).toBe(
       undefined,
     );
-
-    ProgressEventBus.emit('addOutputFiles', addOutputFilesPayload(outputPath));
-    await sleep(20);
-    expect(mocks.diagnosticCollections.at(-1)?.items.get(outputPath)).toBe(
-      undefined,
-    );
-    drainBufferedAddOutputFilesBusEvents();
 
     emitAddOutputFilesRunFact(hub, addOutputFilesPayload(outputPath));
     await waitFor(

--- a/src/test-kernel/tools/InquiryContinuationSession.vitest.ts
+++ b/src/test-kernel/tools/InquiryContinuationSession.vitest.ts
@@ -19,10 +19,6 @@ vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
   wakeQueuedFollowUpStream: wakeQueuedFollowUpStreamMock,
 }));
 
-vi.mock('@eventBus/ProgressEventBus', () => ({
-  ProgressEventBus: { emit: vi.fn() },
-}));
-
 vi.mock('@platform/platform', () => ({
   platform: () => ({
     agentResume: { tryResumeStream: vi.fn(async () => false) },


### PR DESCRIPTION
## Summary

This Stage 5 slice deletes the now-unused `ProgressEventBus` singleton implementation. The shared `ProgressEventPayloads`, `ProgressEvent`, `INSTRUCTION_ACTION`, and `InstructionAction` contract remains in place; moving or renaming that event vocabulary is left to a later, broader import-boundary slice.\n\nThe test suite no longer imports, mocks, or subscribes to the singleton as a negative witness. Tests now observe the actual owning surfaces instead: session events, runtime-host emissions, extension presentation events, and direct recording hosts.\n\nPart of #6968 and #6951.\n\n## Single Source Of Truth\n\n- Runtime/session facts remain owned by `SessionEventHub` and the existing session projection helpers.\n- Host/RPC events remain owned by `AgentRuntimeHost` / `HostInteractions`.\n- App-scoped buffered presentation remains separate in `extensionPresentationEvents`; this PR does not alter that channel.\n- `ProgressEventBus.ts` is now a contract module only, not a process-level emitter.\n\n## Verification\n\n- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts src/test-kernel/frontend/OutputFileRunFactSubscriptions.vitest.ts src/test-kernel/agent/runtime/EmitRuntimeEvent.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts src/test-kernel/tools/InquiryContinuationSession.vitest.ts` — 7 files, 101 tests passed.\n- `corepack pnpm run typecheck` — passed.\n- `corepack pnpm run compile:fast` — passed.\n- `corepack pnpm exec eslint ...` on touched files — passed.\n- `corepack pnpm exec prettier --check ...` on touched files — passed.\n- `rg -n "ProgressEventBus\\.(on|emit)|export const ProgressEventBus|class ProgressEventBusImpl|ProgressEventBusLike" src packages --glob '!**/node_modules/**'` — zero matches.\n


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the central progress-event contract and how every host routes UI/runtime signals; behavior should be unchanged if migration is complete, but any missed `ProgressEventBus` caller would fail at compile time rather than silently buffering events.
> 
> **Overview**
> Removes the process-wide **`ProgressEventBus`** emitter (`emit` / `on` / buffered replay). **`ProgressEventBus.ts`** is now **contract-only**: `ProgressEventPayloads`, `ProgressEvent`, and `INSTRUCTION_ACTION` stay; runtime facts go through **session handles** and **`emitRuntimeEvent`**, and host/UI signals go through **`AgentRuntimeHost.emit`** (and extension presentation channels where applicable).
> 
> **`AGENTS.md`** and related comments are updated to document that split instead of the old bus.
> 
> Tests no longer subscribe to the singleton to prove “nothing leaked.” They assert the real surfaces: **session event hubs**, **recording runtime hosts**, **desktop bridge `handleProgressEvent`**, and **`extensionPresentationEvents`**. Legacy **`ProgressEventBus.emit('addOutputFiles', …)`** coverage is dropped in favor of **run-fact** `SessionEventHub` emissions only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0444f32fdddfee721783361acbb6e9ff80cb340. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->