### PR TITLE
ci: wire knip dead-code check into CI as a ratchet, not a cliff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,9 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
+      - name: Check dead-code ratchet
+        run: pnpm run check:dead-code-ratchet
+
       - name: Check extension package invariants
         run: pnpm run check:extension-package-invariants
 

--- a/knip-baseline.json
+++ b/knip-baseline.json
@@ -1,0 +1,6 @@
+{
+  "unusedFiles": 2,
+  "unusedExports": 385,
+  "unusedTypes": 299,
+  "duplicateExports": 3
+}

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "check:cli-architecture": "corepack pnpm --filter @texra-ai/cli check:architecture",
     "check:cli-orchestration-manifest": "node scripts/check-cli-orchestration-manifest.mjs",
     "check:dead-code": "knip --no-progress --include files,exports,types,duplicates",
+    "check:dead-code-ratchet": "node scripts/check-dead-code-ratchet.mjs",
     "texra-local:build": "corepack pnpm --filter @texra-ai/cli run prepare:trace-viewer-assets && corepack pnpm --filter @texra-ai/cli run bundle && corepack pnpm --filter @texra-ai/cli run copy:resources && corepack pnpm --filter @texra-ai/cli run copy:docs",
     "texra-local:link": "node scripts/link-texra-local.mjs",
     "check:desktop-installers": "node scripts/verify-desktop-installer-artifacts.mjs",

--- a/scripts/check-dead-code-ratchet.d.mts
+++ b/scripts/check-dead-code-ratchet.d.mts
@@ -1,0 +1,27 @@
+export interface KnipCounts {
+  unusedFiles: number;
+  unusedExports: number;
+  unusedTypes: number;
+  duplicateExports: number;
+}
+
+export interface RatchetViolation {
+  metric: keyof KnipCounts;
+  currentCount: number;
+  baselineCount: number;
+}
+
+export interface KnipIssue {
+  file: string;
+  files?: readonly unknown[];
+  exports?: readonly unknown[];
+  types?: readonly unknown[];
+  duplicates?: readonly unknown[];
+}
+
+export function summarizeKnipIssues(issues: readonly KnipIssue[]): KnipCounts;
+
+export function findRatchetViolations(
+  current: KnipCounts,
+  baseline: KnipCounts,
+): RatchetViolation[];

--- a/scripts/check-dead-code-ratchet.mjs
+++ b/scripts/check-dead-code-ratchet.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+// Ratchets knip's dead-code counts: fails CI only when a PR *increases* the
+// number of unused files/exports/types or duplicate exports past the
+// checked-in baseline (knip-baseline.json), rather than blocking on the
+// existing debt. Burning the baseline down is a separate, scheduled sweep.
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+);
+const baselinePath = path.join(rootDir, 'knip-baseline.json');
+
+const METRICS = /** @type {const} */ ([
+  ['unusedFiles', 'files'],
+  ['unusedExports', 'exports'],
+  ['unusedTypes', 'types'],
+  ['duplicateExports', 'duplicates'],
+]);
+
+export function summarizeKnipIssues(issues) {
+  const counts = {
+    unusedFiles: 0,
+    unusedExports: 0,
+    unusedTypes: 0,
+    duplicateExports: 0,
+  };
+  for (const issue of issues) {
+    for (const [countKey, issueKey] of METRICS) {
+      counts[countKey] += (issue[issueKey] ?? []).length;
+    }
+  }
+  return counts;
+}
+
+export function findRatchetViolations(current, baseline) {
+  const violations = [];
+  for (const [countKey] of METRICS) {
+    const currentCount = current[countKey];
+    const baselineCount = baseline[countKey];
+    if (currentCount > baselineCount) {
+      violations.push({ metric: countKey, currentCount, baselineCount });
+    }
+  }
+  return violations;
+}
+
+function runKnip() {
+  const knipBin = path.join(rootDir, 'node_modules', '.bin', 'knip');
+  const result = spawnSync(
+    knipBin,
+    [
+      '--no-progress',
+      '--include',
+      'files,exports,types,duplicates',
+      '--reporter',
+      'json',
+    ],
+    { cwd: rootDir, encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 },
+  );
+  if (result.error) {
+    throw result.error;
+  }
+  // knip exits 1 whenever it finds any issue at all, which is expected here
+  // (the whole point is to count existing issues), so a non-zero status is
+  // only a real failure if it didn't produce parseable JSON.
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch (cause) {
+    console.error(result.stdout);
+    console.error(result.stderr);
+    throw new Error('knip did not produce parseable JSON output', { cause });
+  }
+  return parsed.issues ?? [];
+}
+
+function main() {
+  const baseline = JSON.parse(readFileSync(baselinePath, 'utf8'));
+  const current = summarizeKnipIssues(runKnip());
+  const violations = findRatchetViolations(current, baseline);
+
+  console.log(
+    `knip dead-code counts: unusedFiles=${current.unusedFiles} (baseline ${baseline.unusedFiles}), ` +
+      `unusedExports=${current.unusedExports} (baseline ${baseline.unusedExports}), ` +
+      `unusedTypes=${current.unusedTypes} (baseline ${baseline.unusedTypes}), ` +
+      `duplicateExports=${current.duplicateExports} (baseline ${baseline.duplicateExports})`,
+  );
+
+  if (violations.length > 0) {
+    console.error(
+      '\nDead-code ratchet failed: this PR increases knip counts above the baseline.',
+    );
+    for (const { metric, currentCount, baselineCount } of violations) {
+      console.error(
+        `  - ${metric}: ${currentCount} > baseline ${baselineCount}`,
+      );
+    }
+    console.error(
+      '\nRun `npm run check:dead-code` to see the newly introduced dead code, then either ' +
+        'remove it or, if the increase is intentional, update knip-baseline.json in this PR.',
+    );
+    process.exit(1);
+  }
+
+  console.log('Dead-code ratchet OK: counts are at or below the baseline.');
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/src/test-kernel/scripts/CheckDeadCodeRatchet.vitest.mts
+++ b/src/test-kernel/scripts/CheckDeadCodeRatchet.vitest.mts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  findRatchetViolations,
+  summarizeKnipIssues,
+} from '../../../scripts/check-dead-code-ratchet.mjs';
+
+describe('check-dead-code-ratchet summarizeKnipIssues', () => {
+  it('sums files/exports/types/duplicates across all knip issue entries', () => {
+    const issues = [
+      {
+        file: 'a.ts',
+        files: [{ name: 'a.ts' }],
+        exports: [],
+        types: [],
+        duplicates: [],
+      },
+      {
+        file: 'b.ts',
+        files: [],
+        exports: [{ name: 'foo' }, { name: 'bar' }],
+        types: [{ name: 'Baz' }],
+        duplicates: [],
+      },
+      {
+        file: 'c.ts',
+        files: [],
+        exports: [],
+        types: [],
+        duplicates: [[{ name: 'x' }, { name: 'y' }]],
+      },
+    ];
+
+    expect(summarizeKnipIssues(issues)).toEqual({
+      unusedFiles: 1,
+      unusedExports: 2,
+      unusedTypes: 1,
+      duplicateExports: 1,
+    });
+  });
+
+  it('treats missing per-metric arrays as zero, matching knip omitting empty keys', () => {
+    const issues = [{ file: 'a.ts' }];
+
+    expect(summarizeKnipIssues(issues)).toEqual({
+      unusedFiles: 0,
+      unusedExports: 0,
+      unusedTypes: 0,
+      duplicateExports: 0,
+    });
+  });
+
+  it('returns all-zero counts for an empty issue list', () => {
+    expect(summarizeKnipIssues([])).toEqual({
+      unusedFiles: 0,
+      unusedExports: 0,
+      unusedTypes: 0,
+      duplicateExports: 0,
+    });
+  });
+});
+
+describe('check-dead-code-ratchet findRatchetViolations', () => {
+  const baseline = {
+    unusedFiles: 2,
+    unusedExports: 385,
+    unusedTypes: 299,
+    duplicateExports: 3,
+  };
+
+  it('reports no violations when counts stay at or below the baseline', () => {
+    expect(findRatchetViolations(baseline, baseline)).toEqual([]);
+    expect(
+      findRatchetViolations(
+        {
+          unusedFiles: 0,
+          unusedExports: 0,
+          unusedTypes: 0,
+          duplicateExports: 0,
+        },
+        baseline,
+      ),
+    ).toEqual([]);
+  });
+
+  it('flags only the metrics that increase past the baseline', () => {
+    const current = { ...baseline, unusedExports: 386, unusedTypes: 300 };
+
+    expect(findRatchetViolations(current, baseline)).toEqual([
+      { metric: 'unusedExports', currentCount: 386, baselineCount: 385 },
+      { metric: 'unusedTypes', currentCount: 300, baselineCount: 299 },
+    ]);
+  });
+
+  it('does not flag a decrease below the baseline', () => {
+    const current = { ...baseline, unusedFiles: 1 };
+
+    expect(findRatchetViolations(current, baseline)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Root cause

`check:dead-code` (knip) reports 385 unused exports, 299 unused types, 2
unused files, and 3 duplicate exports on main (#6951's own pattern note
flags width — spare exports, unused enum values, consumer-less registry
slots — as the campaign's current failure mode), but the check was never
wired into CI, so it's advisory-only and the count can grow silently.

## Fix

- **`knip-baseline.json`** (new, repo root) — checked-in snapshot of the
  current knip counts (`unusedFiles: 2, unusedExports: 385, unusedTypes: 299,
  duplicateExports: 3`), taken from a fresh `origin/main` build. (The issue
  narrative quoted 386 unused exports; the live count on current `main` is
  385 — some unrelated PR shaved one off since the issue was filed. Baselining
  off the live count is the correct ratchet starting point.)
- **`scripts/check-dead-code-ratchet.mjs`** (new) — runs knip with the JSON
  reporter (`--include files,exports,types,duplicates`), sums each issue
  category, and fails (exit 1) only for metrics that exceed the baseline —
  a metric that *drops* below baseline is not flagged, since knip's own exit
  code is unconditionally 1 whenever any issue exists at all and can't
  express a ratchet by itself. Exports two pure functions
  (`summarizeKnipIssues`, `findRatchetViolations`) for direct unit testing,
  following the existing `desktop-package-metafile-paths.mjs` /
  `.d.mts` companion pattern used elsewhere in `scripts/` for typechecking
  `.mjs` imports from `.mts` test files.
- **`package.json`** — new `check:dead-code-ratchet` script (kept separate
  from the existing human-facing `check:dead-code`, which uses the
  unparsable `symbols` reporter).
- **`.github/workflows/ci.yml`** — new "Check dead-code ratchet" step inside
  the existing `validate` job's node matrix, right after Lint.
- Docs-only PRs: no extra skip logic needed — the `changes` job already
  skips the whole `validate` job (which now includes this step) for
  docs-only PRs, per the existing CI-spend policy.

Burning the baseline down is explicitly out of scope here (left to later
scheduled sweeps per the issue).

## Verification

- `npx tsc --noEmit` — clean
- `npx tsc --noEmit -p tsconfig.test-kernel.json` — clean
- `npx eslint scripts/check-dead-code-ratchet.mjs src/test-kernel/scripts/CheckDeadCodeRatchet.vitest.mts` —
  `scripts/**` isn't covered by the repo's `lint` script or any
  `eslint.config.mjs` override (confirmed pre-existing: running eslint
  directly against any existing `scripts/*.mjs` file, e.g.
  `check-cli-orchestration-manifest.mjs`, hits the same `no-undef` errors on
  `console`/`process`), so this is unaffected by the change and out of scope
  to fix here.
- `npx prettier --check <changed files>` — clean (after one `--write` pass)
- `npx vitest run --config vitest.config.mjs src/test-kernel/scripts/CheckDeadCodeRatchet.vitest.mts` —
  6 passed
- `node scripts/check-dead-code-ratchet.mjs` locally — passes at baseline;
  manually verified it fails with a clear diff when the baseline is
  temporarily lowered

Fixes #7448.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI tooling and a non-runtime baseline file; no application or security-sensitive paths are modified.
> 
> **Overview**
> Adds **CI enforcement** so knip dead-code debt cannot grow silently, without blocking merges on the existing backlog.
> 
> A new **`knip-baseline.json`** records current counts (unused files/exports/types and duplicate exports). **`scripts/check-dead-code-ratchet.mjs`** runs knip with JSON output, aggregates those metrics, and **fails only when any count exceeds the baseline** (improvements below baseline are allowed). **`check:dead-code-ratchet`** is wired into the Linux **`validate`** job after lint, alongside unit tests for the summarization and violation logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c03fcc78ffb1239ea2fbfd5a637cd77958b2c39a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->