### PR TITLE
fix(cli): fail loudly on malformed relay usage billing fields

### DIFF
--- a/packages/cli/src/runtime/relayUsage.ts
+++ b/packages/cli/src/runtime/relayUsage.ts
@@ -9,7 +9,10 @@ const USAGE_PAGE_SIZE = 1000;
 // input_tokens/output_tokens/cached_input_tokens/reasoning_tokens/cost value
 // must fail parsing loudly rather than silently summing as 0, which would
 // under-report spend against the relay cap (see #7468, and the May-2026
-// abuse incident that motivated the cap).
+// abuse incident that motivated the cap). `cost` is restricted to
+// number|string before coercion — bare `z.coerce.number()` would otherwise
+// coerce `null`/`undefined`/booleans to `0` via `Number()`, reintroducing the
+// same silent-zero bug through coercion instead of `.catch()`.
 const RelayUsageRowSchema = z.object({
   id: z.uuid(),
   logged_at: z.iso.datetime({ offset: true }),
@@ -19,7 +22,10 @@ const RelayUsageRowSchema = z.object({
   output_tokens: z.int().nonnegative(),
   cached_input_tokens: z.int().nonnegative().nullable(),
   reasoning_tokens: z.int().nonnegative().nullable(),
-  cost: z.coerce.number().nonnegative(),
+  cost: z
+    .union([z.number(), z.string()])
+    .transform(Number)
+    .pipe(z.number().nonnegative()),
 });
 
 export type RelayUsageRow = z.infer<typeof RelayUsageRowSchema>;

--- a/packages/cli/src/runtime/relayUsage.ts
+++ b/packages/cli/src/runtime/relayUsage.ts
@@ -5,16 +5,21 @@ import { SUPABASE_CONFIG, getRelaySpendingLimit } from '@auth/sharedConfig';
 
 const USAGE_PAGE_SIZE = 1000;
 
+// Billing fields intentionally have no `.catch()` fallback: a malformed
+// input_tokens/output_tokens/cached_input_tokens/reasoning_tokens/cost value
+// must fail parsing loudly rather than silently summing as 0, which would
+// under-report spend against the relay cap (see #7468, and the May-2026
+// abuse incident that motivated the cap).
 const RelayUsageRowSchema = z.object({
   id: z.uuid(),
   logged_at: z.iso.datetime({ offset: true }),
   model: z.string(),
   provider: z.string(),
-  input_tokens: z.int().nonnegative().catch(0),
-  output_tokens: z.int().nonnegative().catch(0),
-  cached_input_tokens: z.int().nonnegative().nullable().catch(0),
-  reasoning_tokens: z.int().nonnegative().nullable().catch(0),
-  cost: z.coerce.number().nonnegative().catch(0),
+  input_tokens: z.int().nonnegative(),
+  output_tokens: z.int().nonnegative(),
+  cached_input_tokens: z.int().nonnegative().nullable(),
+  reasoning_tokens: z.int().nonnegative().nullable(),
+  cost: z.coerce.number().nonnegative(),
 });
 
 export type RelayUsageRow = z.infer<typeof RelayUsageRowSchema>;

--- a/src/test-kernel/cli/RelayUsage.vitest.mts
+++ b/src/test-kernel/cli/RelayUsage.vitest.mts
@@ -73,6 +73,45 @@ describe('CLI relay usage summary', () => {
     expect(rows[0]?.cost).toBe(1.25);
   });
 
+  it('rejects rows with a malformed cost instead of zero-defaulting spend', () => {
+    // Regression test for #7468: billing fields must never silently parse to
+    // 0 on a malformed value, since that would under-report spend against
+    // the relay cap.
+    expect(() =>
+      parseRelayUsageRows([
+        {
+          logged_at: '2026-05-17T12:00:00+00:00',
+          id: '00000000-0000-4000-8000-000000000003',
+          model: 'gpt-5.4',
+          provider: 'openai',
+          input_tokens: 10,
+          output_tokens: 4,
+          cached_input_tokens: null,
+          reasoning_tokens: null,
+          cost: 'not-a-number',
+        },
+      ]),
+    ).toThrow();
+  });
+
+  it('rejects rows with a malformed token count instead of zero-defaulting usage', () => {
+    expect(() =>
+      parseRelayUsageRows([
+        {
+          logged_at: '2026-05-17T12:00:00+00:00',
+          id: '00000000-0000-4000-8000-000000000004',
+          model: 'gpt-5.4',
+          provider: 'openai',
+          input_tokens: 'not-a-number',
+          output_tokens: 4,
+          cached_input_tokens: null,
+          reasoning_tokens: null,
+          cost: 1.25,
+        },
+      ]),
+    ).toThrow();
+  });
+
   it('builds stable keyset pagination URLs', () => {
     const first = buildRelayUsageRowsUrl({
       startIso: '2026-05-01T00:00:00.000Z',

--- a/src/test-kernel/cli/RelayUsage.vitest.mts
+++ b/src/test-kernel/cli/RelayUsage.vitest.mts
@@ -94,6 +94,27 @@ describe('CLI relay usage summary', () => {
     ).toThrow();
   });
 
+  it('rejects a null cost instead of coercing it to zero', () => {
+    // `z.coerce.number()` alone would turn `null` into `0` via `Number(null)`
+    // — the same silent-zero bug the `.catch(0)` removal fixes, reintroduced
+    // through coercion. `cost` must reject null/undefined before coercing.
+    expect(() =>
+      parseRelayUsageRows([
+        {
+          logged_at: '2026-05-17T12:00:00+00:00',
+          id: '00000000-0000-4000-8000-000000000005',
+          model: 'gpt-5.4',
+          provider: 'openai',
+          input_tokens: 10,
+          output_tokens: 4,
+          cached_input_tokens: null,
+          reasoning_tokens: null,
+          cost: null,
+        },
+      ]),
+    ).toThrow();
+  });
+
   it('rejects rows with a malformed token count instead of zero-defaulting usage', () => {
     expect(() =>
       parseRelayUsageRows([


### PR DESCRIPTION
## Root cause

`RelayUsageRowSchema` (`packages/cli/src/runtime/relayUsage.ts`) used
`.catch(0)` on `input_tokens`, `output_tokens`, `cached_input_tokens`,
`reasoning_tokens`, and `cost`. Any malformed usage row returned by the
`usage_logs` PostgREST query (e.g. a bad type from a future schema
change or corrupted row) would silently parse as a zero-cost,
zero-token row instead of failing. `summarizeRelayUsage` then sums
these fields directly (`acc.costUsd += row.cost`, etc.), so a
malformed row under-reports total spend against the monthly relay
cap surfaced by `texra auth usage` and the CLI status line — directly
weakening the free-tier abuse gate that exists because of the
May-2026 incident.

## Fix

Removed the `.catch(0)` fallbacks from all five billing fields on
`RelayUsageRowSchema`. `parseRelayUsageRows` already calls
`z.array(RelayUsageRowSchema).parse(data)`, so a malformed row now
throws instead of silently zero-defaulting. Both callers already
handle a thrown parse error gracefully:

- `packages/cli/src/runtime/apiStatus.ts` catches it and shows
  `relay usage: unavailable (<message>)` in the status line.
- `packages/cli/src/commands/auth.ts` (`texra auth usage`) catches it,
  writes the error to stderr, and exits with `ModelOrNetworkError`.

No new error-handling plumbing was needed — this is the minimal
direct fix (per repo convention, no new abstraction layer for a
single call site).

`cached_input_tokens`/`reasoning_tokens` stay `.nullable()` (unchanged):
a genuine `null` from the DB is a legitimate "not applicable" value,
not a parse failure, and downstream aggregation already treats it as
0 via `?? 0` on a *well-formed* row — that's display logic, not a
zero-default-on-malformed-input bug.

### Audit of the aggregation path (per issue's ask)

- `supabase/functions/log-usage/index.ts` (the write path) requires
  `inputTokens`, `outputTokens`, and `cost` with no default/catch —
  already correct.
- `summarizeRelayUsage` in the same file has no `.catch()`/silent
  defaulting of its own; its only `?? 0` uses are for the legitimately
  nullable `cached_input_tokens`/`reasoning_tokens` fields on rows that
  already parsed successfully.
- No other `.catch(0)` on a billing/spend field exists in the repo;
  the two other `.catch(0)` occurrences found (`history/state.ts`
  search index, CLI `inputHistory.ts` timestamp) are unrelated local
  UI state, not billing.

## Verification

- `npx tsc --noEmit` — clean
- `npx tsc --noEmit -p tsconfig.test-kernel.json` — same single
  pre-existing, unrelated failure on `main`
  (`ExtensionAgentRuntimeHost.vitest.ts` / `HostInteractions.pending`),
  confirmed via `git stash` that it's present without this change too
- `(cd packages/cli && npx tsc --noEmit -p tsconfig.json)` — clean
- `npx eslint packages/cli/src/runtime/relayUsage.ts src/test-kernel/cli/RelayUsage.vitest.mts` — clean
- `npx prettier --check packages/cli/src/runtime/relayUsage.ts src/test-kernel/cli/RelayUsage.vitest.mts` — clean
- `npx vitest run src/test-kernel/cli/RelayUsage.vitest.mts src/test-kernel/cli/ApiStatus.vitest.mts src/test-kernel/cli/ApiStatusLoad.vitest.mts src/test-kernel/cli/AuthCommand.vitest.mts` — 24 tests passed
- Added two regression tests (`RelayUsage.vitest.mts`) asserting a
  malformed `cost` / `input_tokens` value throws instead of parsing to
  0; confirmed both fail against the pre-fix schema (`git stash` the
  source change, tests fail with "expected [Function] to throw") and
  pass with the fix

Fixes #7468.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how relay spend is aggregated when usage_logs rows are bad; failures are intentional and surfaced to users, but incorrect throws could block usage display until data is fixed.
> 
> **Overview**
> **Relay usage rows** from PostgREST no longer **silently count as zero** when token or cost fields are malformed. `RelayUsageRowSchema` drops `.catch(0)` on `input_tokens`, `output_tokens`, `cached_input_tokens`, `reasoning_tokens`, and `cost`, so `parseRelayUsageRows` **throws** instead of under-reporting spend against the monthly relay cap.
> 
> For **`cost`**, parsing is tightened to **`number | string` → `Number` → nonnegative** so `null`/`undefined` are not coerced to `0` via bare `z.coerce.number()`. Legitimate **`null`** on `cached_input_tokens` / `reasoning_tokens` is unchanged.
> 
> Regression tests assert malformed `cost`, **`null` cost**, and bad token counts all **reject** rather than default to zero. Existing callers (`texra auth usage`, CLI status line) already surface parse failures as unavailable usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f6f0757447a7d74ad819ea0ece029cd832fd973. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->