### PR TITLE
fix(cli): don't wipe CLI secrets on a transient read failure

### DIFF
--- a/packages/cli/src/runtime/cliSecrets.ts
+++ b/packages/cli/src/runtime/cliSecrets.ts
@@ -5,6 +5,9 @@ import path from 'node:path';
 // Local imports - platform
 import { DEFAULT_NODE_STORAGE_ROOT } from '@platform/defaults/nodeStorage';
 
+// Local imports - common
+import { isFileNotFoundError } from '@common/errors';
+
 // Local imports - CLI runtime
 import { cliEnvValue } from './cliContext';
 
@@ -66,13 +69,24 @@ export class CliSecrets implements PlatformSecrets {
     await mutation;
   }
 
+  /**
+   * Reads the secrets file. A missing file is the expected first-run state
+   * and defaults to `{}`. Any other read failure (permissions, corrupt
+   * JSON, etc.) is rethrown rather than swallowed: `updateSecrets()` does a
+   * read-mutate-write, so silently defaulting to `{}` here would make a
+   * transient read failure permanently wipe every other stored secret on
+   * the next write.
+   */
   private async readSecrets(): Promise<SecretFileData> {
+    let raw: string;
     try {
-      const data = JSON.parse(await readFile(this.filePath, 'utf8')) as unknown;
-      return isSecretFileData(data) ? data : {};
-    } catch {
-      return {};
+      raw = await readFile(this.filePath, 'utf8');
+    } catch (error) {
+      if (isFileNotFoundError(error)) return {};
+      throw error;
     }
+    const data = JSON.parse(raw) as unknown;
+    return isSecretFileData(data) ? data : {};
   }
 
   private async writeSecrets(data: SecretFileData): Promise<void> {

--- a/src/test-kernel/cli/CliSecrets.vitest.mts
+++ b/src/test-kernel/cli/CliSecrets.vitest.mts
@@ -26,6 +26,40 @@ describe('CLI secrets', () => {
     }
   });
 
+  it('aborts a write instead of wiping the file when the read fails for a reason other than a missing file', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-secrets-'));
+    const storageRoot = path.join(root, 'storage');
+    const secretsPath = cliSecretsPath(storageRoot);
+
+    try {
+      const secrets = new CliSecrets(secretsPath);
+      await secrets.set('EXISTING_KEY', 'existing-value');
+
+      // Corrupt the on-disk file to simulate a non-ENOENT read failure
+      // (e.g. corrupt JSON, or an EACCES/EMFILE on the real fs.readFile).
+      await fs.writeFile(secretsPath, '{ not valid json', 'utf8');
+
+      await expect(secrets.set('NEW_KEY', 'new-value')).rejects.toThrow();
+
+      // The mutation must have aborted rather than overwriting the file
+      // with a fresh `{}` merged with just the new key.
+      const onDisk = await fs.readFile(secretsPath, 'utf8');
+      expect(onDisk).toBe('{ not valid json');
+
+      // The queue must not be stuck: a subsequent read/write still works.
+      await fs.writeFile(
+        secretsPath,
+        '{"EXISTING_KEY":"existing-value"}\n',
+        'utf8',
+      );
+      await secrets.set('ANOTHER_KEY', 'another-value');
+      expect(await secrets.get('EXISTING_KEY')).toBe('existing-value');
+      expect(await secrets.get('ANOTHER_KEY')).toBe('another-value');
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('keeps one process-wide secrets store after the first root is selected', async () => {
     vi.resetModules();
     const { getCliSecrets } = await import('@cli/runtime/cliSecrets');


### PR DESCRIPTION
## Root cause

`CliSecrets.readSecrets()` (`packages/cli/src/runtime/cliSecrets.ts`) caught
*any* error from `readFile`/`JSON.parse` — `EACCES`, `EMFILE`, corrupt JSON,
not just a missing file — and defaulted to `{}`.

`updateSecrets()` (used by `set()`/`delete()`) does a read-mutate-write:
read the current file, apply the mutation, write the whole file back. When
`readSecrets()` swallowed a transient/non-ENOENT read failure and returned
`{}`, `updateSecrets()` would happily write that near-empty object back to
disk (containing only whatever key was just set/deleted), permanently
destroying every other previously-stored credential.

## Fix

`readSecrets()` now:
- defaults to `{}` **only** when the file is genuinely absent, via the
  existing `isFileNotFoundError` predicate (`@common/errors`) — the same
  convention already used elsewhere in the codebase (e.g.
  `packages/cli/src/runtime/cliConfig.ts`);
- rethrows any other read failure (permission errors, corrupt JSON, etc.)
  so the mutation aborts loudly instead of silently overwriting the file.

`updateSecrets()` already has `this.mutationQueue = mutation.catch(() => {})`
guarding the queue, so a thrown read error surfaces to the caller of
`set()`/`delete()` (via the un-caught `await mutation`) without leaving the
mutation queue stuck for subsequent calls — no other change was needed.

This is a minimal, surgical fix scoped to the one function the issue
identifies; no other refactor was needed or made.

## Verification

- `corepack pnpm --filter @texra-ai/cli typecheck` — clean (no errors in
  changed files; repo has pre-existing unrelated errors in `@openrouter/sdk`
  and `vscode-jsonrpc` typings, confirmed identical before/after this change
  via `git stash`).
- `npx eslint packages/cli/src/runtime/cliSecrets.ts src/test-kernel/cli/CliSecrets.vitest.mts` — clean.
- `npx prettier --check packages/cli/src/runtime/cliSecrets.ts src/test-kernel/cli/CliSecrets.vitest.mts` — clean.
- `npx vitest run src/test-kernel/cli/CliSecrets.vitest.mts` — 3/3 pass, including a new regression test
  (`aborts a write instead of wiping the file when the read fails for a
  reason other than a missing file`) that:
  - writes a secret, corrupts the on-disk JSON, then asserts a subsequent
    `set()` call rejects and leaves the corrupted file byte-for-byte
    unchanged (rather than overwriting it with a near-empty object);
  - asserts the mutation queue is not left stuck — a later `set()`/`get()`
    against a valid file still works.
  - Confirmed this new test **fails** against the pre-fix code (`promise
    resolved "undefined" instead of rejecting`), so it's a real regression
    test for this bug.

Fixes #7463.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes credential persistence behavior on error paths; fix reduces data-loss risk but callers now see failures instead of silent overwrites.
> 
> **Overview**
> **`CliSecrets.readSecrets()`** no longer treats every `readFile`/`JSON.parse` failure as “no secrets file.” It returns `{}` only when the file is missing (`isFileNotFoundError`, same pattern as `cliConfig.ts`); permission errors, corrupt JSON, and other read failures are **rethrown** so `set()`/`delete()` abort instead of read-mutate-writing a near-empty object over `secrets.json` and wiping stored credentials.
> 
> A Vitest case corrupts on-disk JSON, asserts the next `set()` rejects and leaves the file unchanged, and confirms the mutation queue still works after repair.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ffa43a39d45ef015e17ec5211b11ee8950b674c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->