### PR TITLE
fix(scripts): harden knip JSON parsing in dead-code ratchet

### DIFF
--- a/scripts/check-dead-code-ratchet.d.mts
+++ b/scripts/check-dead-code-ratchet.d.mts
@@ -25,3 +25,5 @@ export function findRatchetViolations(
   current: KnipCounts,
   baseline: KnipCounts,
 ): RatchetViolation[];
+
+export function parseKnipIssues(stdout: string, stderr: string): KnipIssue[];

--- a/scripts/check-dead-code-ratchet.mjs
+++ b/scripts/check-dead-code-ratchet.mjs
@@ -62,7 +62,7 @@ export function parseKnipIssues(stdout, stderr) {
     console.error(stderr);
     throw new Error('knip did not produce parseable JSON output', { cause });
   }
-  if (!Array.isArray(parsed.issues)) {
+  if (!Array.isArray(parsed?.issues)) {
     console.error(stdout);
     console.error(stderr);
     throw new Error(

--- a/scripts/check-dead-code-ratchet.mjs
+++ b/scripts/check-dead-code-ratchet.mjs
@@ -50,6 +50,28 @@ export function findRatchetViolations(current, baseline) {
   return violations;
 }
 
+// Parses and validates the `--reporter json` stdout produced by `knip`.
+// Split out from runKnip() so the parsing/validation logic is unit-testable
+// without spawning the real knip binary.
+export function parseKnipIssues(stdout, stderr) {
+  let parsed;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch (cause) {
+    console.error(stdout);
+    console.error(stderr);
+    throw new Error('knip did not produce parseable JSON output', { cause });
+  }
+  if (!Array.isArray(parsed.issues)) {
+    console.error(stdout);
+    console.error(stderr);
+    throw new Error(
+      'knip JSON output has no `issues` array; the --reporter json shape may have changed (see scripts/check-dead-code-ratchet.mjs)',
+    );
+  }
+  return parsed.issues;
+}
+
 function runKnip() {
   const knipBin = path.join(rootDir, 'node_modules', '.bin', 'knip');
   const result = spawnSync(
@@ -69,15 +91,7 @@ function runKnip() {
   // knip exits 1 whenever it finds any issue at all, which is expected here
   // (the whole point is to count existing issues), so a non-zero status is
   // only a real failure if it didn't produce parseable JSON.
-  let parsed;
-  try {
-    parsed = JSON.parse(result.stdout);
-  } catch (cause) {
-    console.error(result.stdout);
-    console.error(result.stderr);
-    throw new Error('knip did not produce parseable JSON output', { cause });
-  }
-  return parsed.issues ?? [];
+  return parseKnipIssues(result.stdout, result.stderr);
 }
 
 function main() {

--- a/src/test-kernel/scripts/CheckDeadCodeRatchet.vitest.mts
+++ b/src/test-kernel/scripts/CheckDeadCodeRatchet.vitest.mts
@@ -158,6 +158,12 @@ describe('check-dead-code-ratchet parseKnipIssues', () => {
       parseKnipIssues(JSON.stringify({ issues: { oops: true } }), ''),
     ).toThrow(/knip JSON output has no `issues` array/);
   });
+
+  it('throws the contextual error, not a raw TypeError, when stdout parses to null', () => {
+    expect(() => parseKnipIssues('null', '')).toThrow(
+      /knip JSON output has no `issues` array/,
+    );
+  });
 });
 
 describe('check-dead-code-ratchet findRatchetViolations', () => {

--- a/src/test-kernel/scripts/CheckDeadCodeRatchet.vitest.mts
+++ b/src/test-kernel/scripts/CheckDeadCodeRatchet.vitest.mts
@@ -2,8 +2,68 @@ import { describe, expect, it } from 'vitest';
 
 import {
   findRatchetViolations,
+  parseKnipIssues,
   summarizeKnipIssues,
 } from '../../../scripts/check-dead-code-ratchet.mjs';
+
+// Captured verbatim from a real `knip --reporter json` run against this repo
+// (knip 6.24.0, `--include files,exports,types,duplicates`) and trimmed to a
+// representative subset of entries. This confirms the real reporter shape:
+// the top-level object has exactly one key, `issues`, and each issue entry
+// nests its own `files`/`exports`/`types`/`duplicates` arrays — there is no
+// separate top-level `files` array for wholly-unused files.
+const REAL_KNIP_STDOUT = JSON.stringify({
+  issues: [
+    {
+      file: 'src/test-kernel/support/setupFakePlatform.ts',
+      duplicates: [],
+      exports: [],
+      files: [{ name: 'src/test-kernel/support/setupFakePlatform.ts' }],
+      types: [],
+    },
+    {
+      file: 'packages/trace-viewer/vite.standalone.config.ts',
+      duplicates: [],
+      exports: [],
+      files: [{ name: 'packages/trace-viewer/vite.standalone.config.ts' }],
+      types: [],
+    },
+    {
+      file: 'src/auth/serverKeys/ServerSideKeyService.ts',
+      duplicates: [],
+      exports: [
+        { name: 'USE_INCLUDED_ACCESS_KEY', line: 47, col: 14, pos: 1491 },
+      ],
+      files: [],
+      types: [],
+    },
+    {
+      file: 'src/test-kernel/support/FakePlatform.ts',
+      duplicates: [],
+      exports: [
+        { name: 'FakeWorkspaceProvider', line: 429, col: 14, pos: 12849 },
+        { name: 'FakeStorageProvider', line: 450, col: 14, pos: 13498 },
+      ],
+      files: [],
+      types: [
+        { name: 'RecordingLogLevel', line: 28, col: 13, pos: 1023 },
+        { name: 'RecordingLogEntry', line: 30, col: 18, pos: 1098 },
+      ],
+    },
+    {
+      file: 'src/shared/schemas/goal.ts',
+      duplicates: [
+        [
+          { name: 'goalElapsedMs', line: 53, col: 17, pos: 1751 },
+          { name: 'goalDurationMs', line: 62, col: 14, pos: 2079 },
+        ],
+      ],
+      exports: [],
+      files: [],
+      types: [],
+    },
+  ],
+});
 
 describe('check-dead-code-ratchet summarizeKnipIssues', () => {
   it('sums files/exports/types/duplicates across all knip issue entries', () => {
@@ -57,6 +117,46 @@ describe('check-dead-code-ratchet summarizeKnipIssues', () => {
       unusedTypes: 0,
       duplicateExports: 0,
     });
+  });
+
+  it('sums counts correctly against real captured knip --reporter json output', () => {
+    const { issues } = JSON.parse(REAL_KNIP_STDOUT);
+
+    expect(summarizeKnipIssues(issues)).toEqual({
+      unusedFiles: 2,
+      unusedExports: 3,
+      unusedTypes: 2,
+      duplicateExports: 1,
+    });
+  });
+});
+
+describe('check-dead-code-ratchet parseKnipIssues', () => {
+  it('extracts issues from real captured knip --reporter json output', () => {
+    const issues = parseKnipIssues(REAL_KNIP_STDOUT, '');
+
+    expect(issues).toHaveLength(5);
+    expect(issues[0]).toMatchObject({
+      file: 'src/test-kernel/support/setupFakePlatform.ts',
+    });
+  });
+
+  it('throws with stdout/stderr context when stdout is not parseable JSON', () => {
+    expect(() => parseKnipIssues('not json', 'some stderr')).toThrow(
+      'knip did not produce parseable JSON output',
+    );
+  });
+
+  it('throws instead of silently defaulting to zero issues when `issues` is missing', () => {
+    expect(() => parseKnipIssues(JSON.stringify({}), '')).toThrow(
+      /knip JSON output has no `issues` array/,
+    );
+  });
+
+  it('throws when `issues` is present but not an array', () => {
+    expect(() =>
+      parseKnipIssues(JSON.stringify({ issues: { oops: true } }), ''),
+    ).toThrow(/knip JSON output has no `issues` array/);
   });
 });
 


### PR DESCRIPTION
## Root cause

Two review threads on #7458 (merged) flagged unverified assumptions about knip's `--reporter json` output shape in `scripts/check-dead-code-ratchet.mjs`:

1. `runKnip()` returned `parsed.issues ?? []`. If knip's JSON output ever lacked an `issues` key (schema drift on a knip upgrade, or an error path that still emits parseable JSON), this silently computed to zero issues — a false-green ratchet.
2. `summarizeKnipIssues()`'s `unusedFiles` count (`(issue.files ?? []).length` on each issue entry) was never verified against real `knip --reporter json` output, so it was unclear whether `files` is nested per-issue-entry (as assumed) or reported as a separate top-level array.

## Verification against real knip output

Installed deps (`CI=true corepack pnpm install`) and ran the exact command the script runs:

```
node_modules/.bin/knip --no-progress --include files,exports,types,duplicates --reporter json
```

against this repo's current tree (knip 6.24.0). Result:

- Top-level parsed object has exactly **one key, `issues`** — no separate top-level `files` array.
- Each issue entry nests its own `files`/`exports`/`types`/`duplicates` arrays, e.g.:
  ```json
  {"file":"src/test-kernel/support/setupFakePlatform.ts","duplicates":[],"exports":[],"files":[{"name":"src/test-kernel/support/setupFakePlatform.ts"}],"types":[]}
  ```
- Summing `files.length` across all issue entries gives `unusedFiles=2`, `unusedExports=385`, `unusedTypes=299`, `duplicateExports=3` — an exact match with the checked-in `knip-baseline.json`.

**Conclusion: `summarizeKnipIssues()`'s existing assumption was already correct** — it's unchanged in this PR. Only `runKnip()`'s silent-default needed hardening.

## Fix

- Extracted the JSON-parse + shape-validation logic out of `runKnip()` into a new exported `parseKnipIssues(stdout, stderr)`, so it's unit-testable without mocking `spawnSync` (mirrors the existing split of `summarizeKnipIssues`/`findRatchetViolations` out of `main()` for the same reason).
- `parseKnipIssues` now throws — dumping `stdout`/`stderr` for debugging, matching the existing parse-failure branch's style — when `parsed.issues` is missing or not an array, instead of silently defaulting to `[]`.
- Added the `parseKnipIssues` type declaration to `scripts/check-dead-code-ratchet.d.mts`.
- Extended `src/test-kernel/scripts/CheckDeadCodeRatchet.vitest.mts` with a fixture captured verbatim from the real knip run above (trimmed to a representative subset of entries covering all four metrics), plus new tests for `parseKnipIssues`' throw-loud paths (unparseable stdout, missing `issues`, non-array `issues`).

## Verification commands run

- `npx tsc --noEmit` — clean.
- `npx tsc --noEmit -p tsconfig.test-kernel.json` — one pre-existing unrelated error in `ExtensionAgentRuntimeHost.vitest.ts` (confirmed present on clean HEAD via `git stash`, untouched by this PR).
- `npx eslint src/test-kernel/scripts/CheckDeadCodeRatchet.vitest.mts` — clean. (`scripts/*.mjs` files aren't part of `npm run lint`'s target globs — same as on main — so no `console`-global false positives from linting them standalone apply to CI.)
- `npx vitest run src/test-kernel/scripts/CheckDeadCodeRatchet.vitest.mts` — 11/11 passed.
- `npx prettier --write` on the three changed files (was previously unformatted; now clean per `--check`).
- `npm run check:dead-code-ratchet` (the real script, against this repo) — `unusedFiles=2 (baseline 2), unusedExports=385 (baseline 385), unusedTypes=299 (baseline 299), duplicateExports=3 (baseline 3)` — `Dead-code ratchet OK`, i.e. the real end-to-end path still works unchanged.

Fixes #7473.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI tooling only; behavior change is stricter validation on knip output with no production runtime impact.
> 
> **Overview**
> Hardens the **dead-code ratchet** CI script so bad or drifted `knip --reporter json` output cannot silently pass as zero issues.
> 
> **`parseKnipIssues`** is extracted from `runKnip()` and exported (with a `.d.mts` declaration). It parses stdout, logs stdout/stderr on failure, and **throws** if JSON is invalid or if `issues` is missing or not an array—replacing the previous `parsed.issues ?? []` behavior that could false-green the ratchet.
> 
> Tests add a **real knip JSON fixture** to lock in reporter shape and counts for `summarizeKnipIssues`, plus coverage for `parseKnipIssues` success and error paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbc46a3df2422a471452a5ad58e37c85a56e030d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->