### PR TITLE
fix(test-kernel): drop deleted pending() from HostInteractions test mock

### DIFF
--- a/src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts
+++ b/src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts
@@ -34,7 +34,6 @@ describe('extensionAgentRuntimeHost', () => {
         interactionEvents.push({ event, payload });
         return true;
       },
-      pending: () => [],
       resolve: () => false,
       cancelForStream: () => {},
     });


### PR DESCRIPTION
## Root cause

Currently-broken-main bug blocking CI for every open PR right now (confirmed by reproducing on a clean `origin/main` checkout).

- PR #7457 (merged 2026-07-07T14:55:39+02:00) added `src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts` with a `HostInteractions` mock literal that includes `pending: () => []`.
- PR #7451 (merged 2026-07-07T15:26:55+02:00, based on an older main that predates #7457) deleted the unread `pending()` method from the `HostInteractions` interface (`src/agent/runtime/HostInteractions.ts`) as dead code.
- Neither PR's own CI ever saw the combination: `tsc --noEmit -p tsconfig.test-kernel.json` now fails unconditionally on main with `error TS2353: Object literal may only specify known properties, and 'pending' does not exist in type 'HostInteractions'` — TypeScript's excess-property check on the object literal.

Confirmed via `grep -rn "pending: () =>"` that this was the only remaining reference to the deleted property anywhere in the tree.

## Fix

Remove `pending: () => []` from the mock object literal — the property was never read by production code (that's exactly why #7451 deleted it from the interface), so the test's behavior is unchanged.

## Verification

- `npx tsc --noEmit` — clean
- `npx tsc --noEmit -p tsconfig.test-kernel.json` — clean (was failing before the fix)
- `npx eslint src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts` — clean
- `npx prettier --check src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts` — clean
- `npx vitest run src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts` — 2/2 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only type fix with no production code or runtime behavior changes.
> 
> **Overview**
> Removes **`pending: () => []`** from the `useHostInteractions` mock in `ExtensionAgentRuntimeHost.vitest.ts` so the object literal matches the current **`HostInteractions`** type after **`pending`** was removed from that interface.
> 
> No test behavior change—the mock property was unused and only caused **`tsc --noEmit -p tsconfig.test-kernel.json`** to fail on excess properties.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b99799022d237129412e53f13c615fb0c8b993d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->