### PR TITLE
fix(cli): stop masking non-ENOENT read failures on .gitignore and config reads

### DIFF
--- a/packages/cli/src/runtime/chatDefaults.ts
+++ b/packages/cli/src/runtime/chatDefaults.ts
@@ -1,11 +1,13 @@
 import { TEXRA_CONFIG_FILE_NAME } from '@platform/defaults/nodeStorage';
 import { listExecutions } from '@agent/storage';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { isFileNotFoundError } from '@common/errors';
 import {
   decideRunModel,
   type RunModelDecisionReason,
 } from '@model/runModelDecision';
 import { toNewestFirstByTimestamp } from '@utils/core';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 import { GlobalStorageFS } from '@utils/files/storageFS';
 import {
   CLI_BUILTIN_DEFAULT_MODEL,
@@ -19,6 +21,7 @@ import {
   isImplicitDefaultEligible,
   pickDefaultToolUseAgent,
 } from './defaultAgents';
+import { writeTextStderr } from './logSinks';
 
 /**
  * A configured or environment agent value, trimmed and dropped if it can't be
@@ -74,11 +77,22 @@ async function loadWorkspaceDefaults(cwd: string): Promise<PartialDefaults> {
 }
 
 async function loadUserDefaults(): Promise<PartialDefaults> {
-  // A missing or corrupt user config means no user defaults:
-  // parseCliConfigValues maps the undefined fallback to {}.
-  const raw: unknown = await GlobalStorageFS.readJson(
-    TEXRA_CONFIG_FILE_NAME,
-  ).catch(() => undefined);
+  // A missing user config means no user defaults (parseCliConfigValues maps
+  // the undefined fallback to {}). Anything else — corrupt JSON, a permission
+  // error — is surfaced as a warning instead of silently dropping the user's
+  // chat defaults, mirroring loadWorkspaceCliConfig's handling of the same
+  // class of failure for the workspace config.
+  let raw: unknown;
+  try {
+    raw = await GlobalStorageFS.readJson(TEXRA_CONFIG_FILE_NAME);
+  } catch (error: unknown) {
+    if (!isFileNotFoundError(error)) {
+      writeTextStderr(
+        `WARN Could not read user config (${TEXRA_CONFIG_FILE_NAME}): ${toErrorMessage(error)}`,
+      );
+    }
+    raw = undefined;
+  }
   return defaultsFromConfigValues(parseCliConfigValues(raw));
 }
 

--- a/packages/cli/src/runtime/initConfig.ts
+++ b/packages/cli/src/runtime/initConfig.ts
@@ -8,6 +8,7 @@ import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { TEXRA_STORAGE_DIR_NAME } from '@platform/defaults/nodeStorage';
+import { isFileNotFoundError } from '@common/errors';
 
 import type {
   CliApprovalPolicy,
@@ -87,7 +88,12 @@ export async function ensureTexraGitignored(
   let existed = true;
   try {
     existing = await readFile(gitignorePath, 'utf8');
-  } catch {
+  } catch (error: unknown) {
+    // A missing .gitignore is fine — we create one. Anything else (EACCES,
+    // a transient I/O error, ...) must not be treated as "file absent": doing
+    // so would fall through to the write below and overwrite unreadable-but-
+    // present content instead of surfacing the failure.
+    if (!isFileNotFoundError(error)) throw error;
     existed = false;
   }
   const next = gitignoreWithTexra(existing);

--- a/src/test-kernel/cli/ChatDefaults.vitest.mts
+++ b/src/test-kernel/cli/ChatDefaults.vitest.mts
@@ -12,7 +12,17 @@ import {
   BUILTIN_DEFAULT_CHAT_MODEL,
   resolveChatDefaults,
 } from '@cli/runtime/chatDefaults';
+import * as logSinks from '@cli/runtime/logSinks';
 import { GlobalStorageFS } from '@utils/files/storageFS';
+
+/** A missing user config, shaped like a genuine `fs` ENOENT rejection. */
+function enoentError(): NodeJS.ErrnoException {
+  const error = new Error(
+    'ENOENT: no such file or directory',
+  ) as NodeJS.ErrnoException;
+  error.code = 'ENOENT';
+  return error;
+}
 
 vi.mock('@agent/storage', () => ({
   listExecutions: vi.fn(async () => []),
@@ -50,7 +60,8 @@ beforeEach(() => {
   mockedListExecutions.mockReset();
   mockedListExecutions.mockResolvedValue([]);
   mockedReadJson.mockReset();
-  mockedReadJson.mockRejectedValue(new Error('no user defaults'));
+  // A missing user config (the common case) mirrors a real ENOENT rejection.
+  mockedReadJson.mockRejectedValue(enoentError());
 });
 
 async function workspaceWithConfig(config: unknown): Promise<string> {
@@ -367,5 +378,29 @@ describe('CLI chat defaults', () => {
       agentSource: 'user-config',
       modelSource: 'user-config',
     });
+  });
+
+  it('warns instead of silently dropping defaults when the user config is corrupt', async () => {
+    // Not an ENOENT — e.g. truncated/hand-edited JSON, or a permission error.
+    // The old behavior caught every readJson failure alike and silently fell
+    // through to {}, indistinguishable from "no user config".
+    const corrupt = new Error('Failed to parse JSON from config.json');
+    mockedReadJson.mockRejectedValueOnce(corrupt);
+    const warnSpy = vi
+      .spyOn(logSinks, 'writeTextStderr')
+      .mockImplementation(() => {});
+
+    await expect(
+      resolveChatDefaults({ cwd: '/tmp/no-such-texra-workspace' }),
+    ).resolves.toMatchObject({
+      agent: 'assistant',
+      model: 'deepseekproT',
+      source: 'builtin',
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('config.json'),
+    );
+    warnSpy.mockRestore();
   });
 });

--- a/src/test-kernel/cli/InitConfig.vitest.mts
+++ b/src/test-kernel/cli/InitConfig.vitest.mts
@@ -1,14 +1,28 @@
-import path from 'node:path';
+import { mkdtemp, readFile as nodeReadFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path, { join } from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { workspaceTexraConfigPath } from '@platform/defaults/nodeStorage';
 import {
   buildInitConfig,
+  ensureTexraGitignored,
   gitignoreWithTexra,
   serializeInitConfig,
   type InitAnswers,
 } from '@cli/runtime/initConfig';
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return { ...actual, readFile: vi.fn(actual.readFile) };
+});
+
+const mockedReadFile = vi.mocked(nodeReadFile);
+
+afterEach(() => {
+  mockedReadFile.mockClear();
+});
 
 const ANSWERS: InitAnswers = {
   agent: 'chat',
@@ -62,5 +76,50 @@ describe('gitignoreWithTexra', () => {
 
   it('treats a bare .texra entry as already ignored', () => {
     expect(gitignoreWithTexra('.texra\n')).toBeNull();
+  });
+});
+
+describe('ensureTexraGitignored', () => {
+  it('creates .gitignore when absent', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'texra-gitignore-'));
+
+    await expect(ensureTexraGitignored(workspace)).resolves.toBe('created');
+    await expect(
+      nodeReadFile(join(workspace, '.gitignore'), 'utf8'),
+    ).resolves.toBe('.texra/\n');
+  });
+
+  it('appends to an existing .gitignore that does not yet ignore .texra', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'texra-gitignore-'));
+    await writeFile(join(workspace, '.gitignore'), 'node_modules\n', 'utf8');
+
+    await expect(ensureTexraGitignored(workspace)).resolves.toBe('added');
+    await expect(
+      nodeReadFile(join(workspace, '.gitignore'), 'utf8'),
+    ).resolves.toBe('node_modules\n.texra/\n');
+  });
+
+  it('does not overwrite .gitignore on a non-ENOENT read failure', async () => {
+    // Reproduces #7470: a transient EACCES (or any non-missing-file error)
+    // must not be treated as "file absent" — that would fall through to the
+    // write below and clobber the user's existing .gitignore content.
+    const workspace = await mkdtemp(join(tmpdir(), 'texra-gitignore-'));
+    const gitignorePath = join(workspace, '.gitignore');
+    await writeFile(gitignorePath, 'node_modules\ndist\n', 'utf8');
+
+    const eacces = Object.assign(new Error('EACCES: permission denied'), {
+      code: 'EACCES',
+    });
+    mockedReadFile.mockImplementationOnce(async () => {
+      throw eacces;
+    });
+
+    await expect(ensureTexraGitignored(workspace)).rejects.toBe(eacces);
+
+    // Original content survives — the old bug silently overwrote it with
+    // just `.texra/\n`.
+    await expect(nodeReadFile(gitignorePath, 'utf8')).resolves.toBe(
+      'node_modules\ndist\n',
+    );
   });
 });

--- a/src/test-kernel/utils/config/ConfigUtils.vitest.ts
+++ b/src/test-kernel/utils/config/ConfigUtils.vitest.ts
@@ -1,0 +1,53 @@
+// Third-party imports
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+// Local imports
+import { installPlatform } from '@test/support/setupPlatform';
+import * as logger from '@logger/logUtils';
+import { getValidatedConfig } from '@utils/config/configUtils';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const APPROACH_SCHEMA = z.enum(['quick', 'thorough']);
+const SETTING_PATH = 'agentReview.approach';
+
+describe('getValidatedConfig', () => {
+  it('returns the stored value when it matches the schema', async () => {
+    await installPlatform({ config: { [SETTING_PATH]: 'thorough' } });
+
+    expect(getValidatedConfig(SETTING_PATH, APPROACH_SCHEMA, 'quick')).toBe(
+      'thorough',
+    );
+  });
+
+  it('falls back to the default without warning when the setting is unset', async () => {
+    await installPlatform({});
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    expect(getValidatedConfig(SETTING_PATH, APPROACH_SCHEMA, 'quick')).toBe(
+      'quick',
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('warns and falls back to the default instead of silently dropping an invalid user setting', async () => {
+    // Reproduces #7470: a stale/hand-edited settings.json value that no
+    // longer fits the schema must not vanish without a trace via
+    // `schema.catch(default)` — it's surfaced as a warning before defaulting.
+    await installPlatform({
+      config: { [SETTING_PATH]: 'not-a-real-approach' },
+    });
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    expect(getValidatedConfig(SETTING_PATH, APPROACH_SCHEMA, 'quick')).toBe(
+      'quick',
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      'configUtils',
+      expect.stringContaining(SETTING_PATH),
+    );
+  });
+});

--- a/src/utils/config/configUtils.ts
+++ b/src/utils/config/configUtils.ts
@@ -1,9 +1,13 @@
 // Local imports
 import { tryPlatform } from '@platform/platform';
+import * as logger from '@logger/logUtils';
 import { ensureArray } from '@utils/core';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 import type { ZodType } from 'zod';
 import type { ConfigTarget } from '@platform/interfaces/config';
 import type { Disposable } from '@platform/interfaces/disposable';
+
+const CHANNEL = 'configUtils';
 
 interface ConfigSubscriptionContext {
   subscriptions: Disposable[];
@@ -50,13 +54,28 @@ export function getConfig<T>(path: string, defaultValue?: T): T {
  * constant) makes that schema the single shared contract for both the type and
  * the runtime check, so drift surfaces as a clean fallback rather than an
  * invalid value flowing downstream.
+ *
+ * An unset setting parses as `undefined` and is expected to fail most
+ * schemas (enums, bounded numbers) — that's normal, not corruption, so it
+ * falls back to `defaultValue` silently. A setting the user *did* set but
+ * that fails validation (hand-edited/stale `settings.json`) instead warns
+ * before falling back, so an invalid user setting doesn't silently drop.
  */
 export function getValidatedConfig<T>(
   path: string,
   schema: ZodType<T>,
   defaultValue: T,
 ): T {
-  return schema.catch(defaultValue).parse(getConfig<unknown>(path));
+  const raw = getConfig<unknown>(path);
+  const result = schema.safeParse(raw);
+  if (result.success) return result.data;
+  if (isConfigExplicitlySet(path)) {
+    logger.warn(
+      CHANNEL,
+      `Ignoring invalid value for setting "${path}": ${toErrorMessage(result.error)}`,
+    );
+  }
+  return defaultValue;
 }
 
 /**


### PR DESCRIPTION
## Root cause

Three related read-default sites (2026-07-07 audit, CONFIRMED, checklist §15) treated *every* read failure the same as "file absent," which either destroys user data or silently drops a setting instead of surfacing the problem:

1. **`ensureTexraGitignored`** (`packages/cli/src/runtime/initConfig.ts`) caught any `readFile` error — not just `ENOENT` — and fell through to the write path. A transient `EACCES` (or any other non-missing-file error) on an *existing* `.gitignore` would silently overwrite it with just `.texra/\n`, destroying the user's content.
2. **`loadUserDefaults`** (`packages/cli/src/runtime/chatDefaults.ts`) swallowed every `GlobalStorageFS.readJson` failure alike via `.catch(() => undefined)`, so a corrupt user-level `config.json` silently dropped the user's chat defaults with zero signal. This was asymmetric with `loadWorkspaceCliConfig`, which already surfaces this class of failure via `configWarnings`.
3. **`getValidatedConfig`** (`src/utils/config/configUtils.ts`) used `schema.catch(defaultValue)`, so a stale or hand-edited VS Code setting that fails its schema silently reverts to the default with no trace — the "silent Zod default on persisted/user-authored data" masking pattern the repo's error-handling checklist explicitly flags as a blocker.

## Fix

Applied the repo's established `isFileNotFoundError` predicate (`@common/errors`) at each site, per the "loud read" pattern in the code-review checklist:

- **`ensureTexraGitignored`**: only treats a genuine `ENOENT` as "file absent"; any other read error rethrows before ever reaching the write, so the destructive-overwrite path is unreachable on a non-missing-file failure.
- **`loadUserDefaults`**: only silently defaults to `{}` on `ENOENT`; anything else writes a `WARN` line to stderr (mirroring the existing `configWarnings` stderr convention used for workspace config) and then continues with the fallback so the CLI still starts.
- **`getValidatedConfig`**: replaced `schema.catch(default)` with `schema.safeParse` + a channel-log warning (`@logger/logUtils`), gated on the existing `isConfigExplicitlySet` predicate so a *merely unset* setting (which legitimately fails most schemas as `undefined`) stays silent — only a value the user actually set that fails validation warns.

No new abstractions: each fix reuses an existing predicate/helper already established elsewhere in the codebase (`isFileNotFoundError`, `writeTextStderr`, `@logger/logUtils`, `isConfigExplicitlySet`).

## Regression coverage

- `ensureTexraGitignored`: added tests for create/append happy paths (previously untested) plus a repro that a non-ENOENT read failure (mocked `EACCES`) rejects instead of overwriting existing `.gitignore` content.
- `loadUserDefaults` / `resolveChatDefaults`: fixed the suite's default mock to reject with a realistic `ENOENT`-shaped error instead of a plain `Error` (which the old code and the new code both treat identically as "missing," but which would have made the fix's warning path fire on *every* existing test). Added a test that a non-ENOENT rejection warns via `writeTextStderr` and still falls through to the next default tier.
- `getValidatedConfig`: new test file (no prior suite existed) covering: valid value passes through, unset value falls back silently (no warning), and an explicitly-set invalid value warns and falls back.

## Verification

```
npx tsc --noEmit                                    # clean
npx tsc --noEmit -p tsconfig.test-kernel.json        # clean (1 pre-existing unrelated failure, confirmed via git stash)
cd packages/cli && npx tsc --noEmit -p tsconfig.json # clean
npx eslint <changed files>                           # clean (2 import/order warnings auto-fixed)
npx prettier --check <changed files>                 # clean
npx vitest run src/test-kernel/cli src/test-kernel/utils/config
  # 130 files / 1608 tests passed
npm run check:dead-code-ratchet                      # at baseline
```

Fixes #7470.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches init-time filesystem writes and shared config validation used across the extension; behavior changes are intentional but affect startup and settings fallback paths.
> 
> **Overview**
> Stops treating every config/read failure as “file missing” so user data is not clobbered and bad settings are not dropped silently.
> 
> **`texra init` / `.gitignore`:** `ensureTexraGitignored` only treats **ENOENT** as absent; **EACCES** and other read errors **rethrow** instead of writing a new `.gitignore` that would overwrite existing content.
> 
> **CLI chat defaults:** `loadUserDefaults` still ignores a missing user `config.json`, but **corrupt JSON or permission errors** emit a **stderr WARN** (aligned with workspace config warnings) before falling back.
> 
> **VS Code settings:** `getValidatedConfig` uses **`safeParse`** and logs a warning when a setting is **explicitly set** but invalid; unset values still default **without** a warning.
> 
> Regression tests cover gitignore create/append, EACCES non-overwrite, corrupt user config warning, and invalid explicit settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3710583a26b2c3229bb1eb7690008d6165a5ee27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->