### PR TITLE
fix: drop stale pending field from HostInteractions test literal

### DIFF
--- a/src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts
+++ b/src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts
@@ -34,7 +34,6 @@ describe('extensionAgentRuntimeHost', () => {
         interactionEvents.push({ event, payload });
         return true;
       },
-      pending: () => [],
       resolve: () => false,
       cancelForStream: () => {},
     });


### PR DESCRIPTION
## Summary

Main is currently broken for typecheck (blocking CI on every open PR): a prior refactor removed \`pending()\` from the \`HostInteractions\` interface, but \`ExtensionAgentRuntimeHost.vitest.ts\` still passed a \`pending: () => []\` field in its test object literal, tripping \`TS2353\` (excess property check on an object literal).

## Verification

- Confirmed by diffing directly against \`origin/main\` (not a PR branch) that this is a pre-existing break, not something introduced by any in-flight PR.
- \`npm run typecheck\`: clean after the fix (confirmed this was the only breakage).
- \`eslint\` clean.
- \`vitest run src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts\`: 2/2 passing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime or production behavior impact.
> 
> **Overview**
> Fixes a **typecheck failure** on main by aligning a vitest stub with the current `HostInteractions` shape.
> 
> The test for extension host progress routing still passed `pending: () => []` into `defaultSession().useHostInteractions({ ... })` after `pending()` was removed from the interface. That excess property triggers **TS2353** on object literals. The change drops that field; the stub keeps `handleProgressEvent`, `resolve`, and `cancelForStream` only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdf6fcb7c396339303f7a926d420df7f2f914d66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->