### PR TITLE
fix(tests): drop stale pending() stub that broke main's typecheck

### DIFF
--- a/src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts
+++ b/src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts
@@ -34,7 +34,6 @@ describe('extensionAgentRuntimeHost', () => {
         interactionEvents.push({ event, payload });
         return true;
       },
-      pending: () => [],
       resolve: () => false,
       cancelForStream: () => {},
     });


### PR DESCRIPTION
Main has been typecheck-red (test-kernel project) since #7446 merged: its new test stubs `pending: () => []` on a `HostInteractions` fake, but #7451 — merged between #7446's CI run and its merge — deleted `pending` from the port. Semantic merge race, the same class as the three typecheck-red incidents the process audit counted this morning.

One line removed. `tsc -p tsconfig.test-kernel.json` green; the test file passes (2/2). The identical fix already exists inside #7474's branch; main should not stay red while that PR awaits sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line test stub removal with no production code or behavioral test changes.
> 
> **Overview**
> **Test-only alignment with `HostInteractions`.** The extension agent runtime host vitest fake passed `pending: () => []` into `defaultSession().useHostInteractions(...)`, but `pending` was removed from the `HostInteractions` interface elsewhere on main. Dropping that property restores `tsc -p tsconfig.test-kernel.json` for this file without changing runtime behavior under test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59d544a15964e48c4725e424857c983ec9994303. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->