### PR TITLE
fix(transcript): preserve unparseable stream-log entries

### DIFF
--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -23,7 +23,7 @@ import { StorageFS } from '@utils/files';
 import { delay } from '@utils/core/async';
 
 interface MockStorageOptions {
-  logs: Record<string, StreamLogEntry[]>;
+  logs: Record<string, unknown[]>;
   summaries: Record<string, unknown>;
   logMtimes?: Record<string, number>;
   summaryMtimes?: Record<string, number>;
@@ -742,5 +742,106 @@ describe('StreamLogStore load', () => {
       lastTimestamp: 500,
       hasRunningGroup: false,
     });
+  });
+
+  it('preserves unparseable persisted entries when appending after rehydrate', async () => {
+    const unknownFutureEntry = {
+      seqNo: 2,
+      id: 'alpha-future',
+      type: 'future-entry-type',
+      level: LOG_LEVELS.INFO,
+      timestamp: 150,
+      futurePayload: { ok: true },
+    };
+    const malformedEntry = {
+      seqNo: 4,
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 300,
+      text: 'missing id',
+    };
+    const storage = mockStorage({
+      logs: {
+        alpha: [
+          logEntry('alpha', 1, 100),
+          unknownFutureEntry,
+          logEntry('alpha', 3, 200),
+          malformedEntry,
+        ],
+      },
+      summaries: {
+        alpha: {
+          firstTimestamp: 100,
+          lastTimestamp: 200,
+          hasRunningGroup: false,
+        },
+      },
+    });
+    const store = new StreamLogStore();
+    await store.load();
+    await store.ensureLoaded('alpha');
+
+    expect(
+      store
+        .get('alpha')
+        ?.getRange(0)
+        .map((entry) => entry.id),
+    ).toEqual(['alpha-1', 'alpha-3']);
+
+    store.append('alpha', {
+      id: 'alpha-new',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 400,
+      messageType: MESSAGE_TYPES.DEFAULT,
+      text: 'new entry',
+    });
+    await store.flush();
+
+    expect(storage.writes.get(storageFile(STREAM_LOGS_DIR, 'alpha'))).toEqual([
+      expect.objectContaining({ id: 'alpha-1', seqNo: 1 }),
+      unknownFutureEntry,
+      expect.objectContaining({ id: 'alpha-3', seqNo: 2 }),
+      malformedEntry,
+      expect.objectContaining({ id: 'alpha-new', seqNo: 3 }),
+    ]);
+  });
+
+  it('keeps an unknown-only stream loadable so a later save preserves it', async () => {
+    const unknownEntry = {
+      seqNo: 1,
+      id: 'beta-future',
+      type: 'future-entry-type',
+      level: LOG_LEVELS.INFO,
+      timestamp: 100,
+      data: { text: 'not understood by this version' },
+    };
+    const storage = mockStorage({
+      logs: {
+        beta: [unknownEntry],
+      },
+      summaries: {},
+    });
+    const store = new StreamLogStore();
+    await store.load();
+
+    expect(store.keys()).toEqual(['beta']);
+    expect(store.get('beta')).toBeUndefined();
+
+    await store.ensureLoaded('beta');
+    store.append('beta', {
+      id: 'beta-new',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 200,
+      messageType: MESSAGE_TYPES.DEFAULT,
+      text: 'new entry',
+    });
+    await store.flush();
+
+    expect(storage.writes.get(storageFile(STREAM_LOGS_DIR, 'beta'))).toEqual([
+      unknownEntry,
+      expect.objectContaining({ id: 'beta-new', seqNo: 1 }),
+    ]);
   });
 });

--- a/src/transcript/StreamLog.ts
+++ b/src/transcript/StreamLog.ts
@@ -10,6 +10,11 @@ export type StreamLogUpdatePatch = Partial<
   Omit<StreamLogEntry, 'id' | 'seqNo'>
 >;
 
+export interface StreamLogPreservedRawEntry {
+  readonly beforeTypedIndex: number;
+  readonly raw: unknown;
+}
+
 export function isRunningGroupEntry(entry: StreamLogEntry): boolean {
   if (entry.type !== STREAM_LOG_ENTRY_TYPES.GROUP_START) return false;
   const data = isObject(entry.data) ? entry.data : {};
@@ -19,13 +24,19 @@ export function isRunningGroupEntry(entry: StreamLogEntry): boolean {
 
 export class StreamLog {
   private entries: StreamLogEntry[] = [];
+  private readonly preservedRawEntries: StreamLogPreservedRawEntry[] = [];
   private seqCounter = 0;
   private readonly indexById = new Map<string, number>();
   private readonly dirtyUpdates = new Set<string>();
   private readonly dirtyTextDeltas = new Map<string, StreamLogTextDelta>();
   private runningGroupCount = 0;
 
-  constructor(entries: StreamLogEntry[] = []) {
+  constructor(
+    entries: readonly StreamLogEntry[] = [],
+    preservedRawEntries: readonly StreamLogPreservedRawEntry[] = [],
+  ) {
+    this.preservedRawEntries = [...preservedRawEntries];
+
     if (entries.length === 0) {
       return;
     }
@@ -305,7 +316,30 @@ export class StreamLog {
    * Internal persistence view. Callers must treat the returned array as
    * immutable; avoiding a defensive copy matters on the stream-log save path.
    */
-  toPersistedEntries(): readonly StreamLogEntry[] {
-    return this.entries;
+  toPersistedEntries(): readonly unknown[] {
+    if (this.preservedRawEntries.length === 0) return this.entries;
+
+    const preservedByIndex = new Map<number, unknown[]>();
+    for (const preserved of this.preservedRawEntries) {
+      const index = Math.min(
+        Math.max(0, preserved.beforeTypedIndex),
+        this.entries.length,
+      );
+      const bucket = preservedByIndex.get(index);
+      if (bucket) {
+        bucket.push(preserved.raw);
+      } else {
+        preservedByIndex.set(index, [preserved.raw]);
+      }
+    }
+
+    const persisted: unknown[] = [];
+    for (let index = 0; index <= this.entries.length; index += 1) {
+      const preserved = preservedByIndex.get(index);
+      if (preserved) persisted.push(...preserved);
+      const entry = this.entries[index];
+      if (entry) persisted.push(entry);
+    }
+    return persisted;
   }
 }

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -17,6 +17,7 @@ import {
   isRunningGroupEntry,
   StreamLog,
   type StreamLogAppendInput,
+  type StreamLogPreservedRawEntry,
   type StreamLogUpdatePatch,
 } from './StreamLog';
 
@@ -38,6 +39,11 @@ type StreamLogSummary = z.infer<typeof StreamLogSummarySchema>;
 interface StreamLoadResult {
   streamId: StreamTabId;
   summary: StreamLogSummary;
+}
+
+interface ParsedPersistedEntries {
+  entries: StreamLogEntry[];
+  preservedRawEntries: StreamLogPreservedRawEntry[];
 }
 
 function summaryOf(logInstance: StreamLog): StreamLogSummary {
@@ -209,14 +215,20 @@ export class StreamLogStore {
           // the union instead of clobbering the authoritative disk copy
           // with just the new entries. StreamLog's constructor re-numbers
           // seqNos so the merged view stays contiguous.
-          const merged = new StreamLog([...diskEntries, ...live.toJSON()]);
+          const merged = new StreamLog(
+            [...diskEntries.entries, ...live.toJSON()],
+            diskEntries.preservedRawEntries,
+          );
           this.logs.set(streamId, merged);
           this.refreshSummary(streamId, merged);
           this.markDirty(streamId);
           void this.save();
           this.notify(streamId);
         } else {
-          const logInstance = new StreamLog(diskEntries);
+          const logInstance = new StreamLog(
+            diskEntries.entries,
+            diskEntries.preservedRawEntries,
+          );
           this.logs.set(streamId, logInstance);
           this.refreshSummary(streamId, logInstance);
           // A `releaseEntries` that arrived while the load was in flight gets
@@ -582,9 +594,14 @@ export class StreamLogStore {
     try {
       const raw = await this.kv.read<unknown[]>(streamId);
       const entries = this.parsePersistedEntries(raw);
-      if (entries.length === 0) return null;
+      if (
+        entries.entries.length === 0 &&
+        entries.preservedRawEntries.length === 0
+      ) {
+        return null;
+      }
 
-      const summary = this.summarizeEntries(entries);
+      const summary = this.summarizeEntries(entries.entries);
       await this.writeSummary(streamId, summary).catch(() => {
         log.warn(LOG_TAG, `Failed to write stream summary: ${streamId}`);
       });
@@ -729,12 +746,26 @@ export class StreamLogStore {
     for (const resolve of awaiters) resolve();
   }
 
-  private parsePersistedEntries(rawEntries: unknown): StreamLogEntry[] {
-    if (!Array.isArray(rawEntries)) return [];
-    return rawEntries.flatMap((raw) => {
+  private parsePersistedEntries(rawEntries: unknown): ParsedPersistedEntries {
+    const parsed: ParsedPersistedEntries = {
+      entries: [],
+      preservedRawEntries: [],
+    };
+    if (!Array.isArray(rawEntries)) return parsed;
+
+    for (const raw of rawEntries) {
       const result = PersistedStreamLogEntrySchema.safeParse(raw);
-      return result.success ? [result.data] : [];
-    });
+      if (result.success) {
+        parsed.entries.push(result.data);
+      } else {
+        parsed.preservedRawEntries.push({
+          beforeTypedIndex: parsed.entries.length,
+          raw,
+        });
+      }
+    }
+
+    return parsed;
   }
 
   private executeWrite(): Promise<void> {


### PR DESCRIPTION
## Root cause

`StreamLogStore` parsed persisted transcript rows with `PersistedStreamLogEntrySchema.safeParse` and silently dropped every row that current code could not understand. A later append/save then wrote only the surviving typed rows back to disk, permanently deleting future-version or malformed rows from the user's transcript history.

This is the stream-log half of #7464. Usage-stat preservation is intentionally left for a separate slice.

## Fix

- Keep the existing typed `StreamLog` view for normal readers and UI code.
- Preserve unparseable persisted rows as opaque raw entries attached to their relative positions among the typed rows.
- Make `toPersistedEntries()` reinsert preserved raw rows when saving, so load + append + save no longer erases unknown transcript data.
- Keep unknown-only stream-log files known after `load()`, so a later append preserves the raw history instead of replacing it.

## Verification

- `CI=true corepack pnpm exec vitest run src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts src/test-kernel/transcript/StreamLog.vitest.ts`
- `CI=true corepack pnpm exec tsc --noEmit --pretty false`
- `CI=true corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `corepack pnpm exec eslint src/transcript/StreamLog.ts src/transcript/StreamLogStore.ts src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transcript persistence and merge/rehydrate behavior; incorrect ordering or dropping preserved rows could still lose user history, but scope is limited to stream logs with new regression tests.
> 
> **Overview**
> Stops **permanent loss of transcript rows** when persisted stream logs contain entries the current schema cannot parse (future versions or malformed rows). Previously those rows were dropped on load and never written back on append/save.
> 
> **`StreamLogStore`** now keeps failed `PersistedStreamLogEntrySchema` parses as opaque **`preservedRawEntries`** at their position among typed rows, passes them into **`StreamLog`**, and treats streams with only preserved rows as known after **`load()`** so a later append does not replace the file.
> 
> **`StreamLog`** exposes a typed in-memory view for UI/readers while **`toPersistedEntries()`** reinserts preserved raw objects in order when persisting. Merge/rehydrate paths wire preserved entries through alongside typed entries.
> 
> Vitest coverage asserts rehydrate + append + flush keeps unknown/malformed rows on disk and handles unknown-only streams.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68889cd4f4b4c45312903516f082e678dbd0861a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->