### PR TITLE
fix(tools): delete dead writeTerminalStatus .catch guards

### DIFF
--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -139,9 +139,11 @@ export async function registerExecution(
  * Persist supplementary metadata fields on an existing execution.
  * Serialized with other meta updates for the same execution to prevent
  * read-modify-write races (e.g. between terminal status and description).
- * Never throws — these are non-critical bookkeeping writes, so storage
- * failures are swallowed and callers' lifecycle logic (registry untrack,
- * follow-up delivery) always runs.
+ * Never throws: storage failures are swallowed and logged so callers'
+ * lifecycle logic (registry untrack, follow-up delivery) always runs — even
+ * for fields like terminal status that are the resumability/status source of
+ * truth, not incidental bookkeeping. Callers must not add their own
+ * `.catch()` around this; it can never reject.
  */
 async function persistMetaField(
   executionId: ExecutionId,
@@ -151,7 +153,7 @@ async function persistMetaField(
   try {
     await enqueueMetaUpdate(executionId, () => fields);
   } catch (err) {
-    // Non-critical bookkeeping — don't let I/O errors disrupt execution lifecycle.
+    // Swallow and log — don't let storage I/O errors disrupt execution lifecycle.
     logger.debug(
       'ExecutionLifecycle',
       `Failed to persist ${what} for ${executionId}: ${toErrorMessage(err)}`,

--- a/src/tools/agentCliSessionLoop.ts
+++ b/src/tools/agentCliSessionLoop.ts
@@ -326,9 +326,7 @@ export function runAgentCliSession<TTurn>(
       strategy.onSessionCleanup?.();
       // Persist terminal status before childStream.finalize() untracks and
       // notifies waiters.
-      await writeTerminalStatus(executionId, projection.executionStatus).catch(
-        () => {},
-      );
+      await writeTerminalStatus(executionId, projection.executionStatus);
 
       const finalStatus = sawTurnFailure
         ? STREAM_STATUS.ERROR

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -438,7 +438,7 @@ export class BashTool extends defineTool({
           await writeTerminalStatus(
             executionId,
             backgroundBashTerminalStatus(result.success),
-          ).catch(() => {});
+          );
           await store.writeReport(msg);
         } catch (err: unknown) {
           logBackgroundFailure('persist', err);
@@ -454,7 +454,7 @@ export class BashTool extends defineTool({
         await writeTerminalStatus(
           executionId,
           backgroundBashTerminalStatus(false),
-        ).catch(() => {});
+        );
         await getExecutionStore(executionId).writeReport(msg);
       } catch (err: unknown) {
         logBackgroundFailure('persist', err);


### PR DESCRIPTION
## Root cause

`writeTerminalStatus` (in `src/agent/storage/executionLifecycle.ts`) is built on
`persistMetaField`, which already wraps its write in a `try/catch` and swallows +
logs any storage error internally — it is documented and implemented to never
reject. Three call sites nonetheless wrapped the call in a redundant
`.catch(() => {})`:

- `src/tools/bash.ts:438-441`
- `src/tools/bash.ts:454-457`
- `src/tools/agentCliSessionLoop.ts:329-331`

Per this repo's code-review checklist §15 ("delete-the-guard" rule), a
`.catch` on a promise that can never reject is dead code — it can't run, and it
misleads readers into thinking `writeTerminalStatus` is fallible at the call
site.

Separately, `persistMetaField`'s doc comment (and its inline catch comment)
called these writes "non-critical bookkeeping." That's misleading for the
terminal-status field specifically — it's the resumability/status source of
truth used for restart repair (`shared/progressView/backend/restartRepair.ts`),
not incidental bookkeeping.

## Fix

- Removed the three redundant `.catch(() => {})` wrappers around
  `writeTerminalStatus(...)` — behavior is unchanged since the promise never
  rejected in the first place.
- Reworded `persistMetaField`'s JSDoc and inline catch comment to describe the
  actual swallow-and-log contract without mischaracterizing the write as
  "non-critical." The swallow-and-log implementation itself is untouched.

Scope note: the issue enumerated exactly these three sites (and verified them
against `origin/main` HEAD). I found the same dead-guard pattern at three more
call sites (`src/agent/runtime/AgentRunLifecycle.ts:287-290`, `:365-368`, and
`src/agent/runtime/executionRegistry.ts:948-951`) but left them out of scope
per "minimal fix, don't refactor beyond what the issue asks for" — flagging
here for a possible follow-up issue.

## Verification

- `npx tsc --noEmit` — pre-existing failures only (`@openrouter/sdk` moduleResolution,
  `vscode-jsonrpc/node`, `jsonRpc.ts` implicit-any), confirmed identical on
  unmodified `origin/main` via `git stash`; no errors in changed files.
- `npx eslint src/tools/bash.ts src/tools/agentCliSessionLoop.ts src/agent/storage/executionLifecycle.ts` — clean.
- `npx prettier --check` on the same three files — clean.
- `npx vitest run` on the most relevant suites (BashTool, BashToolErrorFeedback,
  Resumability, AgentRunLifecycle, SessionResultEvent, SessionIsolation,
  RegisterExecutionWorkspaceDirectory, ExecutionWriterCategory) — 56/56 passed.
  No new regression test added since this is a pure dead-code deletion with no
  behavior change.

Fixes #7471.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No behavior change—only dead-code removal and documentation; `persistMetaField`'s swallow-and-log logic is unchanged.
> 
> **Overview**
> Removes redundant `.catch(() => {})` wrappers around **`writeTerminalStatus`** in background bash and agent-CLI session cleanup. **`persistMetaField`** already swallows and logs storage failures, so those guards never ran and implied the call could reject.
> 
> Updates **`persistMetaField`** JSDoc and inline comments to state the real contract: errors are logged but not propagated so lifecycle teardown continues, including for **terminal status** (resumability/restart-repair source of truth—not incidental bookkeeping). Callers are told not to add their own `.catch()` around this path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3672ba51cd165627c55e392812944e11a86d35b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->