### PR TITLE
fix(openai): fail loudly on malformed tool_calls instead of mis-completing

### DIFF
--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -1216,14 +1216,13 @@ export class ModelHandlerOpenAI<
       return [];
     }
 
-    try {
-      assertToolCallsAreChatCompletionFunctionToolCalls(toolCalls);
-    } catch {
-      this.logger.warn(
-        'Skipping malformed OpenAI tool_calls payload while extracting tool use.',
-      );
-      return [];
-    }
+    // Let a malformed payload throw: swallowing it here would return an
+    // empty tool-call list, which the caller reads as "the model made no
+    // tool calls" and finalizes the run as a successful completion instead
+    // of surfacing the corrupted provider response. The thrown error
+    // propagates to the existing classifyAgentError boundary
+    // (AgentRunLifecycle.ts), which fails the run loudly and retryably.
+    assertToolCallsAreChatCompletionFunctionToolCalls(toolCalls);
 
     return toolCalls.map((call) => ({
       provider: this.toolCallProvider,

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIToolUse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIToolUse.vitest.ts
@@ -1,0 +1,126 @@
+// Third-party imports
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'vitest';
+import {
+  DEFAULT_MODEL_CAPABILITIES,
+  type ModelCapabilities,
+  type ModelConfig,
+  ModelProvider,
+} from 'llm-zoo';
+
+// Local imports - agent
+import type { AgentTrace } from '@agent/trace';
+import { ModelHandlerOpenAI } from '@agent/modelHandlers/openai/modelHandlerOpenAI';
+
+function createLoggerStub(): AgentTrace {
+  const noop = () => {
+    /* no-op for tests */
+  };
+  return {
+    streamId: 'test-channel',
+    debug: noop,
+    info: noop,
+    warn: noop,
+    error: noop,
+  } as unknown as AgentTrace;
+}
+
+function buildConfig(
+  provider: ModelProvider,
+  overrides: Partial<Omit<ModelConfig, 'capabilities'>> & {
+    capabilities?: Partial<ModelCapabilities>;
+  } = {},
+): ModelConfig {
+  const { capabilities: capabilityOverrides, label, ...rest } = overrides;
+  return {
+    name: 'test-model',
+    fullName: 'test-model',
+    shortName: 'test-model',
+    provider,
+    maxOutputTokens: 1024,
+    inputPrice: 0,
+    outputPrice: 0,
+    contextWindow: 200000,
+    openRouterOnly: false,
+    ...rest,
+    capabilities: {
+      ...DEFAULT_MODEL_CAPABILITIES,
+      supportsVision: false,
+      ...(capabilityOverrides ?? {}),
+    },
+    label: label ?? 'Test Model',
+  };
+}
+
+/** A well-formed completion with a single `function` tool call. */
+function completionWithValidToolCall() {
+  return {
+    id: 'test-completion',
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: 'assistant',
+          content: null,
+          tool_calls: [
+            {
+              id: 'call_1',
+              type: 'function',
+              function: { name: 'do_thing', arguments: '{}' },
+            },
+          ],
+        },
+        finish_reason: 'tool_calls',
+      },
+    ],
+    usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+  } as any;
+}
+
+/**
+ * A malformed completion whose `tool_calls` entry has an unsupported
+ * `type` — the shape a corrupted/unexpected provider payload produces.
+ */
+function completionWithMalformedToolCall() {
+  return {
+    id: 'test-completion',
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: 'assistant',
+          content: null,
+          tool_calls: [{ id: 'call_1', type: 'not_a_real_type' }],
+        },
+        finish_reason: 'tool_calls',
+      },
+    ],
+    usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+  } as any;
+}
+
+describe('ModelHandlerOpenAI.extractToolUse', () => {
+  it('extracts a well-formed function tool call', () => {
+    const handler = new ModelHandlerOpenAI(buildConfig(ModelProvider.OPENAI));
+    handler.setLogger(createLoggerStub());
+
+    const result = handler.extractToolUse(completionWithValidToolCall());
+
+    assert.equal(result.length, 1);
+    assert.equal(result[0]?.name, 'do_thing');
+  });
+
+  it('throws instead of silently returning no tool calls for a malformed payload', () => {
+    // Regression test for #7467: previously this caught the parser's
+    // assertion error and returned [], which the tool-use cycle read as
+    // "the model made no tool calls" and finalized the run as a successful
+    // completion despite the corrupted provider payload. It must now throw
+    // so the run fails loudly via the classifyAgentError boundary instead.
+    const handler = new ModelHandlerOpenAI(buildConfig(ModelProvider.OPENAI));
+    handler.setLogger(createLoggerStub());
+
+    assert.throws(() =>
+      handler.extractToolUse(completionWithMalformedToolCall()),
+    );
+  });
+});


### PR DESCRIPTION
## Root cause

`ModelHandlerOpenAI.extractToolUse` (`src/agent/modelHandlers/openai/modelHandlerOpenAI.ts`)
called `assertToolCallsAreChatCompletionFunctionToolCalls(toolCalls)` inside a
`try { … } catch { this.logger.warn(...); return []; }`. When the OpenAI SDK's
own parser assertion throws — because a `tool_calls` entry has an unexpected
`type` (a malformed/corrupted provider payload) — the catch swallowed the
error and returned an empty tool-call array instead.

`ToolUseProcessNode.exec()` (`src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts`)
treats an empty/falsy tool-call list the same as a genuine end-of-turn
(`!toolCalls?.length` feeds directly into `endTurn`), so the run finalized as
a normal successful "completed" result — the user got a confidently wrong
answer instead of any indication the provider response was corrupted.

## Fix

Per checklist §15 (delete-the-guard, already applied repo-wide in #7472,
#7477, #7478), removed the try/catch. The assertion error now propagates
out of `extractToolUse`, up through `ToolUseProcessNode.exec()`, to the
existing top-level catch in `AgentRunLifecycle.ts` (`classifyAgentError`),
which classifies it as `unexpected` → `RUN_OUTCOME.FAILED` — the run fails
loudly and is retryable, instead of silently mis-completing.

Scope is intentionally narrow: only this one function/file, matching the
issue's ask. A structurally similar `try`/catch around the same SDK
assertion in `src/agent/export/normalizeConversation.ts` is a different,
legitimately distinct concern (best-effort filtering of malformed entries
while preserving valid ones for *chat export/display*, not live run
completion logic) and is out of scope here.

## Verification

- `npx tsc --noEmit` — clean for the changed file; only pre-existing,
  unrelated `@openrouter/sdk` / `vscode-jsonrpc` module-resolution errors
  remain (confirmed present identically via `git stash` against `main`)
- `npx eslint src/agent/modelHandlers/openai/modelHandlerOpenAI.ts src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIToolUse.vitest.ts` — clean
- `npx prettier --check src/agent/modelHandlers/openai/modelHandlerOpenAI.ts src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIToolUse.vitest.ts` — clean
- Added a new regression suite `src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIToolUse.vitest.ts`:
  - asserts a well-formed `function` tool call still extracts correctly
  - asserts a malformed tool-call entry (`type` other than `function`)
    now **throws** instead of returning `[]`
  - confirmed the new throw-test fails against the pre-fix source
    (`git stash` the source change → `AssertionError: Missing expected
    exception`) and passes with the fix
- `npx vitest run` across the new suite plus the other existing OpenAI /
  tool-use-round suites that exercise `extractToolUse` and its callers
  (`ModelHandlerOpenAIEndTag`, `ModelHandlerContinuationContract`,
  `ModelFactoryRouting`, `EmptyPrefill`, `ModelHandlerOpenAINormalize`,
  `ToolUseRoundFollowUpMedia`, `ToolUseDispatchInterruption`) — 8 files,
  64 tests passed

Fixes #7467.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live agent completion behavior when provider tool-call payloads are malformed—runs fail instead of silently succeeding, which is intended but affects the tool-use round error path.
> 
> **Overview**
> **OpenAI tool-call extraction** no longer swallows validation failures on corrupted `tool_calls` payloads. `ModelHandlerOpenAI.extractToolUse` calls `assertToolCallsAreChatCompletionFunctionToolCalls` directly instead of catching errors and returning `[]`.
> 
> That empty list was treated like a normal end-of-turn with no tools, so agent runs could **complete successfully** even when the provider response was invalid. Errors now bubble to the existing `classifyAgentError` path so the run **fails** and can be retried.
> 
> Adds **`ModelHandlerOpenAIToolUse.vitest.ts`** with a happy-path extraction test and a regression test that malformed `tool_calls` **throw** (issue #7467).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21d0b329940e611c3d5d53bd1fccbc7816133211. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->