### PR TITLE
fix(transcript): preserve malformed usage stats

### DIFF
--- a/src/shared/schemas/streamData.ts
+++ b/src/shared/schemas/streamData.ts
@@ -310,23 +310,70 @@ void (null as unknown as z.infer<
   typeof TokenUsageStatsParsingSchema
 > satisfies TokenUsageStats);
 
+const PersistedUsageNumber = z.preprocess((value) => {
+  if (typeof value !== 'string') return value;
+  const trimmed = value.trim();
+  return trimmed === '' ? value : Number(trimmed);
+}, z.number().finite().nonnegative());
+
+const PersistedTokenCount = PersistedUsageNumber.pipe(z.int());
+
+const PersistedTokenUsageStatsSchema = z
+  .looseObject({
+    inputTokens: PersistedTokenCount,
+    outputTokens: PersistedTokenCount,
+    cost: PersistedUsageNumber,
+    cacheReadInputTokens: PersistedTokenCount.optional().prefault(0),
+    cacheMissInputTokens: PersistedTokenCount.optional().prefault(0),
+    cacheCreationInputTokens: PersistedTokenCount.optional().prefault(0),
+    viaChatGptSubscription: z.boolean().optional().prefault(false),
+    usageRoute: UsageRouteSchema.optional(),
+  })
+  .transform(({ viaChatGptSubscription, ...usage }): TokenUsageStats => {
+    const usageRoute =
+      usage.usageRoute ??
+      (viaChatGptSubscription === true ? 'chatgpt-subscription' : undefined);
+    return usageRoute == null ? usage : { ...usage, usageRoute };
+  }) as z.ZodType<TokenUsageStats>;
+
+export interface ParsedUsageData {
+  usage: Map<string, TokenUsageStats>;
+  preservedRawEntries: Map<string, unknown>;
+}
+
+export function parseUsageData(raw: unknown): ParsedUsageData {
+  const result = z.record(z.string(), z.unknown()).safeParse(raw);
+  if (!result.success) {
+    warnDroppedItem('TokenUsageStatsMap', result.error);
+    return {
+      usage: new Map(),
+      preservedRawEntries: new Map(),
+    };
+  }
+
+  const usage = new Map<string, TokenUsageStats>();
+  const preservedRawEntries = new Map<string, unknown>();
+  for (const [runId, rawStats] of Object.entries(result.data)) {
+    const parsed = PersistedTokenUsageStatsSchema.safeParse(rawStats);
+    if (!parsed.success) {
+      warnDroppedItem(`TokenUsageStats(${runId})`, parsed.error);
+      preservedRawEntries.set(runId, rawStats);
+      continue;
+    }
+    const stats = parsed.data;
+    if (!isEmptyUsage(stats)) usage.set(runId, stats);
+  }
+
+  return { usage, preservedRawEntries };
+}
+
 /**
  * Per-run usage map: { runId: TokenUsageStats } → Map<runId, stats>.
  * Used by both workflow and tool-use streams. Workflow has one entry per
  * run (= one entry per tab); tool-use can accumulate multiple via resume.
  */
 export const UsageDataSchema = z
-  .record(z.string(), TokenUsageStatsParsingSchema)
-  .transform((record): Map<string, TokenUsageStats> => {
-    const map = new Map<string, TokenUsageStats>();
-    for (const [runId, stats] of Object.entries(record)) {
-      if (!isEmptyUsage(stats)) map.set(runId, stats);
-    }
-    return map;
-  })
-  // `() => new Map()` (not a literal) for the same reason as `roundMapSchema`:
-  // a fresh fallback per failed parse. The current consumer copies this map
-  // (StreamSnapshotStore.applyStreamData) so a shared instance is safe today,
-  // but the factory keeps the file consistent and guards a future by-reference
-  // reader from leaking usage across streams with malformed sidecar JSON.
-  .catch(() => new Map()) as z.ZodType<Map<string, TokenUsageStats>>;
+  .unknown()
+  .transform(
+    (raw): Map<string, TokenUsageStats> => parseUsageData(raw).usage,
+  ) as z.ZodType<Map<string, TokenUsageStats>>;

--- a/src/test-kernel/schemas/StreamDataUsage.vitest.ts
+++ b/src/test-kernel/schemas/StreamDataUsage.vitest.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   emptyUsageStats,
@@ -26,16 +26,45 @@ describe('stream data usage parsing', () => {
     });
   });
 
-  it('drops usage entries that parse to empty defaults', () => {
+  it('drops malformed persisted usage entries instead of zeroing them', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
     const usage = UsageDataSchema.parse({
-      run: {
+      nonFinite: {
         inputTokens: 'not-a-number',
         outputTokens: Number.POSITIVE_INFINITY,
         cost: Number.NaN,
       },
+      negative: {
+        inputTokens: -1,
+        outputTokens: 2,
+        cost: 0,
+      },
+      missingRequired: {
+        inputTokens: 1,
+        cost: 0,
+      },
+      unknownRoute: {
+        inputTokens: 1,
+        outputTokens: 2,
+        cost: 0,
+        usageRoute: 'future-route',
+      },
     });
 
     expect(usage.size).toBe(0);
+    expect(warn).toHaveBeenCalledTimes(4);
+    warn.mockRestore();
+  });
+
+  it('warns and drops a malformed usage map', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const usage = UsageDataSchema.parse(['not', 'a', 'record']);
+
+    expect(usage.size).toBe(0);
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
   });
 
   it('parses numeric usage fields from the canonical usage schema shape', () => {

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -332,6 +332,42 @@ describe('StreamSnapshotStore', () => {
     });
   });
 
+  it('preserves malformed persisted usage when writing new usage', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const dir = streamDataDir(STREAM);
+    await StorageFS.ensureDir(dir);
+    const malformedUsage = {
+      inputTokens: 'not-a-number',
+      outputTokens: 10,
+      cost: 0.25,
+    };
+    await StorageFS.write(
+      path.join(dir, 'usageStats.json'),
+      JSON.stringify({
+        'run-valid': usage(100, 20, 0.5),
+        'run-malformed': malformedUsage,
+      }),
+    );
+
+    const store = new StreamSnapshotStore();
+    store.handleProgressEvent('updateStreamUsage', {
+      streamId: STREAM,
+      storageKey: 'run-new' as StorageKey,
+      usage: usage(50, 10, 0.25),
+    });
+    await store.flush();
+
+    const raw = await StorageFS.readJson(path.join(dir, 'usageStats.json'));
+    expect(raw).toMatchObject({
+      'run-valid': { inputTokens: 100, outputTokens: 20, cost: 0.5 },
+      'run-malformed': malformedUsage,
+      'run-new': { inputTokens: 50, outputTokens: 10, cost: 0.25 },
+    });
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Dropping malformed TokenUsageStats'),
+    );
+  });
+
   it('resolves pre-seed usage after merging existing disk usage', async () => {
     const dir = streamDataDir(STREAM);
     await StorageFS.ensureDir(dir);

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -179,6 +179,10 @@ export class StreamSnapshotStore {
     Map<number, CompileFailure[]>
   >();
   private readonly usage = new Map<StreamTabId, Map<string, TokenUsageStats>>();
+  private readonly usageRawEntries = new Map<
+    StreamTabId,
+    Map<string, unknown>
+  >();
   private readonly workPlan = new Map<StreamTabId, WorkPlanSnapshot>();
   private readonly meta = new Map<StreamTabId, StreamTabMeta>();
   /** Immutable run descriptors parsed/emitted once per execution stream. */
@@ -556,6 +560,7 @@ export class StreamSnapshotStore {
     const accumulated = sumUsageStats([existing, delta]);
     current.set(storageKey, accumulated);
     this.usage.set(stream, current);
+    this.usageRawEntries.get(stream)?.delete(storageKey);
     return accumulated;
   }
 
@@ -575,11 +580,13 @@ export class StreamSnapshotStore {
   }
 
   private writeUsage(stream: StreamTabId): void {
-    this.write(
-      stream,
-      STREAM_DATA_KEYS.USAGE_STATS,
-      mapToRecord(this.usage.get(stream) ?? new Map()),
-    );
+    const usage = this.usage.get(stream) ?? new Map();
+    const record: Record<string, unknown> = {};
+    for (const [storageKey, raw] of this.usageRawEntries.get(stream) ?? []) {
+      if (!usage.has(storageKey)) record[storageKey] = raw;
+    }
+    Object.assign(record, mapToRecord(usage));
+    this.write(stream, STREAM_DATA_KEYS.USAGE_STATS, record);
   }
 
   addOutputFiles(
@@ -725,6 +732,7 @@ export class StreamSnapshotStore {
       ...this.missingOutputs.keys(),
       ...this.compileFailures.keys(),
       ...this.usage.keys(),
+      ...this.usageRawEntries.keys(),
       ...this.workPlan.keys(),
       ...this.meta.keys(),
       ...this.runDescriptors.keys(),
@@ -744,6 +752,7 @@ export class StreamSnapshotStore {
     this.missingOutputs.delete(stream);
     this.compileFailures.delete(stream);
     this.usage.delete(stream);
+    this.usageRawEntries.delete(stream);
     this.workPlan.delete(stream);
     this.meta.delete(stream);
     this.runDescriptors.delete(stream);
@@ -765,6 +774,7 @@ export class StreamSnapshotStore {
     this.missingOutputs.clear();
     this.compileFailures.clear();
     this.usage.clear();
+    this.usageRawEntries.clear();
     this.workPlan.clear();
     this.meta.clear();
     this.runDescriptors.clear();
@@ -1117,6 +1127,7 @@ export class StreamSnapshotStore {
       missingOutputs: this.missingOutputs.get(streamId) ?? new Map(),
       compileFailures: this.compileFailures.get(streamId) ?? new Map(),
       usage: this.usage.get(streamId) ?? new Map(),
+      usageRawEntries: new Map(),
       workPlan: this.getWorkPlan(streamId),
       legacyKeys: [],
     });
@@ -1288,6 +1299,7 @@ export class StreamSnapshotStore {
       stream,
       new Map([...data.usage].filter(([, v]) => !isEmptyUsage(v))),
     );
+    this.usageRawEntries.set(stream, new Map(data.usageRawEntries));
     this.workPlan.set(stream, data.workPlan);
     this.runDescriptors.delete(stream);
     this.runConfigs.delete(stream);

--- a/src/transcript/streamSnapshotRead.ts
+++ b/src/transcript/streamSnapshotRead.ts
@@ -22,9 +22,9 @@ import {
   STREAM_SNAPSHOT_SCHEMA_VERSION,
   StreamSnapshotSchema,
   StreamTabMetaSchema,
-  UsageDataSchema,
   flattenLegacyRuns,
   isLegacyNested,
+  parseUsageData,
   selectPreferredLegacyInstruction,
   type CompileFailure,
   type LegacyInstructionEntry,
@@ -59,6 +59,7 @@ export interface StreamData {
   missingOutputs: Map<number, string[]>;
   compileFailures: Map<number, CompileFailure[]>;
   usage: Map<string, TokenUsageStats>;
+  usageRawEntries: Map<string, unknown>;
   workPlan: WorkPlanSnapshot;
   /** Category keys whose on-disk file was legacy-nested (need a one-time flat rewrite). */
   legacyKeys: string[];
@@ -193,7 +194,7 @@ export async function readStreamData(kv: KVStore): Promise<StreamData> {
   ]);
 
   const usageRaw = await tryRead(kv, STREAM_DATA_KEYS.USAGE_STATS);
-  const usage = UsageDataSchema.catch(new Map()).parse(usageRaw);
+  const usageData = parseUsageData(usageRaw);
 
   const workPlan = readPersistedWorkPlan(
     await tryRead(kv, STREAM_DATA_KEYS.WORK_PLAN),
@@ -204,7 +205,8 @@ export async function readStreamData(kv: KVStore): Promise<StreamData> {
     outputFiles,
     missingOutputs,
     compileFailures,
-    usage,
+    usage: usageData.usage,
+    usageRawEntries: usageData.preservedRawEntries,
     workPlan,
     legacyKeys,
   };


### PR DESCRIPTION
## Root cause

`usageStats.json` used the same permissive usage parser as live runtime deltas. Malformed persisted numeric fields such as `NaN`, `Infinity`, negative counts, or missing required fields could be normalized into empty/zero usage and then dropped from the typed map. The next usage write would rewrite the sidecar without preserving the malformed raw entry, creating the usage-stat half of #7464's destructive read + rewrite failure.

This PR is deliberately separate from #7486, which handles stream-log transcript rows.

## Fix

- Add a persisted usage parser that keeps numeric-string compatibility but rejects non-finite, negative, missing, and otherwise malformed persisted fields.
- Warn on malformed top-level usage maps and malformed per-run usage entries.
- Return both the typed usage map and preserved raw malformed rows from the disk reader.
- Carry preserved raw usage rows in `StreamSnapshotStore` and merge them back into `usageStats.json` on write, unless a valid usage delta for the same run key replaces that raw row.
- Keep the runtime `TokenUsageStatsParsingSchema` behavior unchanged for live usage deltas.

## Verification

- `CI=true corepack pnpm exec vitest run src/test-kernel/schemas/StreamDataUsage.vitest.ts src/test-kernel/transcript/StreamSnapshotStore.vitest.ts`
- `CI=true corepack pnpm exec tsc --noEmit --pretty false`
- `CI=true corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `corepack pnpm exec eslint src/shared/schemas/streamData.ts src/transcript/streamSnapshotRead.ts src/transcript/StreamSnapshotStore.ts src/test-kernel/schemas/StreamDataUsage.vitest.ts src/test-kernel/transcript/StreamSnapshotStore.vitest.ts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how persisted usage sidecars are parsed and rewritten; incorrect merge logic could still corrupt `usageStats.json`, but behavior is more conservative (preserve unknown bad rows) and is covered by new schema and store tests.
> 
> **Overview**
> Fixes **destructive read/rewrite** of `usageStats.json` when persisted rows were malformed: the old path coerced bad numbers into empty usage and dropped them, so the next write could erase the original JSON.
> 
> **Persisted parsing** now uses a dedicated `PersistedTokenUsageStatsSchema` (numeric strings still OK; non-finite, negative, missing required fields, and invalid `usageRoute` are rejected with `console.warn`). `parseUsageData` returns both a typed `usage` map and `preservedRawEntries` for keys that failed validation.
> 
> **`StreamSnapshotStore`** keeps those raw rows in memory, merges them back into `usageStats.json` on write (unless a valid usage update replaces the same run key), and clears preserved raw when a good delta lands on that key. Live runtime deltas still go through unchanged `TokenUsageStatsParsingSchema`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c2ef56965c8ad0d330214522922fcee80114846. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->