### PR TITLE
fix(agent-runtime): deliver failed resume wakeups through the subagent error path

### DIFF
--- a/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
+++ b/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
@@ -313,6 +313,50 @@ describe('NativeSubagentStrategy', () => {
     ).toBeUndefined();
   });
 
+  it('settles the parent usage totals with the last known cost when a wake failure has nothing else to settle from (Bugbot: wake failure locks zero cost)', async () => {
+    const childStream = 'child-stream' as StreamTabId;
+    mocks.readConfig.mockResolvedValue({ agentCategory: 'toolUse' });
+    mocks.retrieveSessionResumeData.mockRejectedValue(
+      new Error('resume storage unreadable'),
+    );
+    mocks.persistChildRunReport.mockResolvedValue({ kind: 'persisted' });
+    mocks.deliverChildRunFollowUp.mockResolvedValue({ kind: 'delivered' });
+    const settleSubagentCost = vi.fn();
+
+    const strategy = new NativeSubagentStrategy({
+      executionId,
+      agentName: 'review',
+      orchestratorStreamId: parentStreamId,
+      parentSession: ownerSession,
+      runtimeHost: { emit: vi.fn() },
+      startedAt: 0,
+      settleSubagentCost,
+    });
+    strategy.setChildStreamId(childStream);
+    // Captures a cost snapshot on the suspended turn before the wake fails —
+    // mirrors the same real-world sequence as the #7287 abandon() test above
+    // (onBeforeWaiting always runs before a turn can suspend and later be
+    // resumed/abandoned/wake-failed).
+    await strategy.onBeforeWaiting('done for now', [], [], 0.0042);
+
+    await strategy.wakeQueuedFollowUp(
+      { status: 'queued', reason: 'waiting' },
+      {},
+    );
+
+    // deliverSubagentError's own settle call (below, second call) carries no
+    // result (the wake never reached a real turn), so without the fallback
+    // the parent would only ever see a 0-cost settle. The real
+    // `subagentExecution.ts` wrapper this strategy is constructed with in
+    // production is itself idempotent (first call wins), so it's this first
+    // call — not the second — that determines what the parent's usage totals
+    // actually record.
+    expect(settleSubagentCost).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ totalCostUsd: 0.0042 }),
+    );
+  });
+
   it('cleans up registry entries when the underlying execution is untracked while abandoned in WAITING', () => {
     let abandonListener: ((handle: unknown) => void) | undefined;
     const addListener = vi.fn((_id: string, cb: (handle: unknown) => void) => {

--- a/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
+++ b/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
@@ -264,6 +264,55 @@ describe('NativeSubagentStrategy', () => {
     );
   });
 
+  it('delivers a terminal error to the orchestrator when the wake fails before resumeStream installs its callbacks (issue #7402)', async () => {
+    const childStream = 'child-stream' as StreamTabId;
+    mocks.readConfig.mockResolvedValue({ agentCategory: 'toolUse' });
+    // Simulates `retrieveSessionResumeData` throwing for unreadable resume
+    // storage (SessionResumeRetrieval.ts:110-113) — this happens inside
+    // `resumeStream` *before* `resumeQueuedToolUseSnapshot` is ever called,
+    // so no onError/onRunError callback for this turn is installed.
+    mocks.retrieveSessionResumeData.mockRejectedValue(
+      new Error('resume storage unreadable'),
+    );
+    mocks.persistChildRunReport.mockResolvedValue({ kind: 'persisted' });
+    mocks.deliverChildRunFollowUp.mockResolvedValue({ kind: 'delivered' });
+
+    const strategy = new NativeSubagentStrategy({
+      executionId,
+      agentName: 'review',
+      orchestratorStreamId: parentStreamId,
+      parentSession: ownerSession,
+      runtimeHost: { emit: vi.fn() },
+      startedAt: 0,
+      settleSubagentCost: vi.fn(),
+    });
+    strategy.setChildStreamId(childStream);
+
+    await expect(
+      strategy.wakeQueuedFollowUp({ status: 'queued', reason: 'waiting' }, {}),
+    ).resolves.toEqual({ kind: 'queued_resume_failed' });
+
+    // The failure must reach the orchestrator through the same terminal
+    // delivery channel a resumed turn's own onError uses — not just a log
+    // line at the DelegationTools call site.
+    expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledTimes(1);
+    const [deliveredCall] = mocks.deliverChildRunFollowUp.mock.calls;
+    expect(deliveredCall[0]).toMatchObject({
+      targetStreamId: parentStreamId,
+      wake: true,
+    });
+    expect(deliveredCall[0].followUp.text).toContain(
+      'resume storage unreadable',
+    );
+
+    // Terminal delivery retires this run: a later delegate_agent resume
+    // attempt must not find stale strategy/registry state.
+    expect(getNativeSubagentStrategy(executionId)).toBeUndefined();
+    expect(
+      SharedSubagentDeliveryRegistry.getActive(executionId),
+    ).toBeUndefined();
+  });
+
   it('cleans up registry entries when the underlying execution is untracked while abandoned in WAITING', () => {
     let abandonListener: ((handle: unknown) => void) | undefined;
     const addListener = vi.fn((_id: string, cb: (handle: unknown) => void) => {

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -327,6 +327,12 @@ Git worktree support: resolved from the active workspace at runtime.`,
           undefined,
           session,
         );
+    // For a native subagent, `wakeQueuedFollowUp` already routes any wake
+    // failure through the strategy's terminal error-delivery path (see
+    // `NativeSubagentStrategy.wakeQueuedFollowUp`), so the orchestrator gets
+    // an observable result even when the wake itself fails. This `.catch` is
+    // the last-resort backstop for the non-native path (no strategy to
+    // deliver through) and for a delivery-path failure in the native case.
     wake.catch((err: unknown) => {
       logger.warn(
         LOG_CHANNEL,

--- a/src/tools/delegation/nativeSubagentStrategy.ts
+++ b/src/tools/delegation/nativeSubagentStrategy.ts
@@ -322,6 +322,21 @@ export class NativeSubagentStrategy {
       // told the follow-up "will process it automatically" and needs a real
       // delivery, not silence.
       try {
+        // deliverSubagentError has no result to settle cost from here (the
+        // wake never reached a real turn), so roll in the most recent cost
+        // snapshot captured before suspending — same fallback abandon() uses
+        // for the same reason. settleSubagentCost is idempotent (first call
+        // wins), so deliverSubagentError's own no-result settle below is a
+        // no-op once this has already recorded the real spend.
+        if (this.lastKnownCostUsd !== undefined) {
+          this.params.settleSubagentCost({
+            category: 'toolUse',
+            outcome: RUN_OUTCOME.CANCELLED,
+            executionId: this.params.executionId,
+            streamId: this.childStreamId ?? this.params.orchestratorStreamId,
+            totalCostUsd: this.lastKnownCostUsd,
+          });
+        }
         await this.deliverSubagentError(err);
       } finally {
         this.finish();

--- a/src/tools/delegation/nativeSubagentStrategy.ts
+++ b/src/tools/delegation/nativeSubagentStrategy.ts
@@ -301,14 +301,33 @@ export class NativeSubagentStrategy {
   ): Promise<FollowUpWakeResult> {
     const streamId = this.childStreamId;
     if (!streamId) return { kind: 'queued_resume_failed' };
-    return wakeQueuedFollowUpStream(
-      streamId,
-      result,
-      {
-        tryResumeStream: (id) => this.resumeStream(id, options),
-      },
-      this.params.parentSession,
-    );
+    try {
+      return await wakeQueuedFollowUpStream(
+        streamId,
+        result,
+        {
+          tryResumeStream: (id) => this.resumeStream(id, options),
+        },
+        this.params.parentSession,
+      );
+    } catch (err) {
+      // DelegationTools dispatches this wake fire-and-forget (see #7289), so a
+      // rejection here has nowhere else to surface. It can happen before
+      // `resumeStream` ever reaches `resumeQueuedToolUseSnapshot` — e.g.
+      // `retrieveSessionResumeData` throwing on unreadable resume storage —
+      // i.e. before this turn's onError/onRunError callbacks are installed.
+      // Route it through the same terminal error-delivery path a resumed
+      // turn's own onError takes, instead of leaving the caller's
+      // `logger.warn` as the only observable outcome: the orchestrator was
+      // told the follow-up "will process it automatically" and needs a real
+      // delivery, not silence.
+      try {
+        await this.deliverSubagentError(err);
+      } finally {
+        this.finish();
+      }
+      return { kind: 'queued_resume_failed' };
+    }
   }
 
   private async resumeStream(


### PR DESCRIPTION
## Summary

Follow-up from #7319, flagged by `chatgpt-codex-connector[bot]` (P2) on that PR and unaddressed at merge (https://github.com/LionSR/TeXRA/pull/7319#discussion_r3531608998).

`delegate_agent`'s resume path dispatches a native subagent's wake fire-and-forget (see #7289 — awaiting it would stall the parent's whole turn for as long as the child keeps running). But if the wake rejects before `NativeSubagentStrategy.resumeStream` ever reaches `resumeQueuedToolUseSnapshot` — e.g. `retrieveSessionResumeData` throwing for unreadable resume storage (`src/agent/runtime/SessionResumeRetrieval.ts:110-113`) — that turn's `onError`/`onRunError` callbacks are never installed. The failure previously only reached a `logger.warn` in `DelegationTools.ts`'s `wake.catch()`, even though the orchestrator had already been told the follow-up "will process it automatically" via `sendFollowUp`.

## Changes

- `NativeSubagentStrategy.wakeQueuedFollowUp` now catches a rejection from `wakeQueuedFollowUpStream` and routes it through `deliverSubagentError` — the same terminal error-delivery channel a resumed turn's own `onError`/`onRunError` use — then retires the strategy via `finish()`, matching how every other terminal path in this class tears down.
- `DelegationTools.ts`'s `wake.catch()` comment updated to reflect that it's now only a last-resort backstop (non-native path with no strategy to deliver through, or a failure in the delivery path itself), not the primary channel for native wake failures.

## Test plan

- [x] `npm run typecheck` passes.
- [x] Added a regression test in `NativeSubagentStrategy.vitest.ts` reproducing the exact failure scenario from the issue (`retrieveSessionResumeData` rejecting before `resumeQueuedToolUseSnapshot` is called); confirmed it fails against the pre-fix code and passes with the fix.
- [x] `npx vitest run src/test-kernel/tools/` — 83 files / 445 tests pass.
- [x] `npx eslint` on all changed files — clean.

Closes #7402

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subagent delegation/resume and parent cost accounting, but the change is a narrow error-handling path with regression tests and mirrors existing abandon()/onError behavior.
> 
> **Overview**
> Fixes a gap where **`delegate_agent` resume** tells the orchestrator a queued follow-up will run automatically, but a **fire-and-forget wake** could fail (e.g. unreadable resume storage in `retrieveSessionResumeData`) **before** resume installs `onError`/`onRunError`—leaving only a **`DelegationTools` log** and no parent-visible outcome.
> 
> **`NativeSubagentStrategy.wakeQueuedFollowUp`** now **catches** wake failures, **settles parent cost** from **`lastKnownCostUsd`** when the wake never reaches a real turn (same pattern as **`abandon()`**), **delivers** via **`deliverSubagentError`**, and **`finish()`** to clear strategy/registry state. **`DelegationTools`** documents that **`wake.catch`** is a **backstop** for non-native paths or delivery failures, not the primary native path.
> 
> Regression tests cover orchestrator error delivery, cleanup after wake failure, and cost settlement on wake failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d37962d2d357b967f796bcdf918043cc2f5bbe9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->