### PR TITLE
fix(tools): distinguish bash-approval timeout from explicit rejection

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -161,7 +161,11 @@ export function createTuiHostInteractions(
       return withInteractionTimeout(
         () => requestBashInteraction(request, context, host, requestId),
         options,
-        { accepted: false, userMessage: 'Approval request timed out.' },
+        {
+          accepted: false,
+          userMessage: 'Approval request timed out.',
+          timedOut: true,
+        },
         () =>
           clearApprovalsWhere(
             (payload) =>

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -39,6 +39,15 @@ export interface HostBashApprovalRequest {
 export interface HostBashApprovalResult {
   readonly accepted: boolean;
   readonly userMessage?: string;
+  /**
+   * Set when `accepted: false` came from the host-side interaction timeout
+   * rather than an explicit user rejection — mirrors the distinct
+   * `{ action: 'timeout' }` shape `PlanApprovalResult`/`ProposalResult`/
+   * `RetryResult` already use (see #7327), kept as a flag here since
+   * restructuring this result to a discriminated union isn't worth it for a
+   * single boolean. Consumers must not report a timeout as a user rejection.
+   */
+  readonly timedOut?: boolean;
 }
 
 export type HostAgentProposalRequest = AgentProposal & {

--- a/src/test-kernel/cli/TuiHostInteractionsCancelForStream.vitest.mts
+++ b/src/test-kernel/cli/TuiHostInteractionsCancelForStream.vitest.mts
@@ -224,9 +224,12 @@ describe('HostInteractionOptions.timeoutMs threading', () => {
         { timeoutMs: 15 },
       );
 
+      // #7444: the timeout carries a distinct `timedOut: true` flag so it
+      // doesn't collapse into the same shape as an explicit user rejection.
       await expect(result).resolves.toEqual({
         accepted: false,
         userMessage: 'Approval request timed out.',
+        timedOut: true,
       });
       expect(currentApproval.get()).toBeUndefined();
     } finally {

--- a/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
+++ b/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
@@ -13,10 +13,23 @@ import { BASH_APPROVAL_CONFIG_KEY } from '@shared/schemas/agentCliSettings';
 
 // Local imports - tools
 import { BashTool } from '@tools/bash';
+import { requestBashApproval } from '@tools/approval/bashApproval';
 import * as agentConfig from '@utils/config/configUtils';
 
 // Local imports - system utilities
 import * as execUtils from '@utils/system/execUtils';
+
+vi.mock('@tools/approval/bashApproval', async (importActual) => {
+  const actual =
+    await importActual<typeof import('@tools/approval/bashApproval')>();
+  return {
+    ...actual,
+    // Default to auto-accept so tests unrelated to approval behavior (which
+    // stub bash approval off via config) keep working; individual tests
+    // override with mockResolvedValueOnce for the approval outcome they need.
+    requestBashApproval: vi.fn(actual.requestBashApproval),
+  };
+});
 
 class TestOpenAIResponseHandler extends ModelHandlerOpenAIResponse {
   async getClient(): Promise<never> {
@@ -139,5 +152,28 @@ describe('BashTool error feedback', () => {
 
     expect(result.status).toBe('executed');
     expect(executeSpy).toHaveBeenCalledOnce();
+  });
+
+  it('reports a real rejection distinctly from an approval timeout', async () => {
+    // Regression coverage for #7444: a host-side approval timeout must not
+    // collapse into the same "User rejected bash command" shape as an
+    // explicit reject once it reaches the agent.
+    vi.mocked(requestBashApproval).mockResolvedValueOnce({
+      accepted: false,
+      userMessage: 'No thanks.',
+    });
+    const rejected = await new BashTool().call({ command: 'echo rejected' });
+    expect(rejected.status).toBe('error');
+    expect(rejected.error).toContain('User rejected bash command');
+
+    vi.mocked(requestBashApproval).mockResolvedValueOnce({
+      accepted: false,
+      userMessage: 'Approval request timed out.',
+      timedOut: true,
+    });
+    const timedOut = await new BashTool().call({ command: 'echo timeout' });
+    expect(timedOut.status).toBe('error');
+    expect(timedOut.error).not.toContain('User rejected bash command');
+    expect(timedOut.error).toContain('timed out');
   });
 });

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -291,7 +291,11 @@ export async function withAgentCliApproval(
 ): Promise<ToolResult> {
   const approval = await requestBashApproval({ command: approvalLabel });
   if (!approval.accepted) {
-    return buildBashApprovalRejectedResult(approvalLabel, approval.userMessage);
+    return buildBashApprovalRejectedResult(
+      approvalLabel,
+      approval.userMessage,
+      approval.timedOut,
+    );
   }
 
   const contexts = getCurrentToolContexts();

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -21,12 +21,19 @@ export type BashApprovalRequest = z.infer<typeof BashApprovalRequestSchema>;
 const BashApprovalResultSchema = z.object({
   accepted: z.boolean(),
   userMessage: z.string().optional(),
+  /** Distinguishes a host-side interaction timeout from an explicit reject. */
+  timedOut: z.boolean().optional(),
 });
 export type BashApprovalResult = z.infer<typeof BashApprovalResultSchema>;
 
 const DEFAULT_BASH_REJECTION_INSTRUCTION =
   'Do not retry this rejected command or another approval-gated shell command for the same check. ' +
   'Continue without running it, use a non-shell method, or explain what approval would be needed.';
+
+const DEFAULT_BASH_TIMEOUT_INSTRUCTION =
+  'The approval request was not answered in time — this is not an explicit ' +
+  'rejection. You may retry the command later if it is still needed, use a ' +
+  'non-shell method, or continue without it.';
 
 export const bashApprovalController =
   createStreamApprovalController<BashApprovalResult>({
@@ -106,14 +113,21 @@ async function showApprovalPrompt(
 export function buildBashApprovalRejectedResult(
   command: string,
   userMessage?: string,
+  timedOut?: boolean,
 ): ToolResult {
   const preview = truncateWithEllipsis(command, 60);
-  const message = `User rejected bash command: ${preview}`;
+  const message = timedOut
+    ? `Bash command approval timed out: ${preview}`
+    : `User rejected bash command: ${preview}`;
   const feedback = userMessage?.trim();
   return {
     status: 'error',
     summary: message,
     error: message,
-    userInstruction: feedback || DEFAULT_BASH_REJECTION_INSTRUCTION,
+    userInstruction:
+      feedback ||
+      (timedOut
+        ? DEFAULT_BASH_TIMEOUT_INSTRUCTION
+        : DEFAULT_BASH_REJECTION_INSTRUCTION),
   };
 }

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -154,6 +154,7 @@ export class BashTool extends defineTool({
       return buildBashApprovalRejectedResult(
         input.command,
         approval.userMessage,
+        approval.timedOut,
       );
     }
 

--- a/src/tools/setup/SendToTerminalTool.ts
+++ b/src/tools/setup/SendToTerminalTool.ts
@@ -58,7 +58,11 @@ export class SendToTerminalTool extends defineTool({
 
     const approval = await requestBashApproval({ command });
     if (!approval.accepted) {
-      return buildBashApprovalRejectedResult(command, approval.userMessage);
+      return buildBashApprovalRejectedResult(
+        command,
+        approval.userMessage,
+        approval.timedOut,
+      );
     }
 
     const name = TERMINAL_NAME_PREFIX + input.label.trim();

--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -63,7 +63,11 @@ export class WolframTool extends defineTool({
     const command = wolframApprovalCommand(input.code);
     const approval = await requestBashApproval({ command });
     if (!approval.accepted) {
-      return buildBashApprovalRejectedResult(command, approval.userMessage);
+      return buildBashApprovalRejectedResult(
+        command,
+        approval.userMessage,
+        approval.timedOut,
+      );
     }
 
     getCurrentToolContexts()?.callContext?.onExecutionReady?.();


### PR DESCRIPTION
## Summary

- `HostBashApprovalResult` (`src/agent/runtime/HostInteractions.ts`) only had `accepted`/`userMessage`, unlike `PlanApprovalResult`/`ProposalResult`/`RetryResult`, which #7327 gave a distinct `{ action: 'timeout' }` shape specifically so a timeout isn't conflated with an explicit user rejection.
- Downstream, `bash.ts` fed `accepted: false` straight into `buildBashApprovalRejectedResult`, which reports `status: 'error'` / "User rejected bash command" to the agent — indistinguishable from a real reject.
- Adds an optional `timedOut` flag to `HostBashApprovalResult` (mirrored in `BashApprovalResult`), sets it in the CLI TUI's `subscribeApprovals.ts` timeout path, and threads it through `buildBashApprovalRejectedResult` and all its callers (`bash.ts`, `agentCliShared.ts`, `SendToTerminalTool.ts`, `WolframTool.ts`) so a timeout gets its own message/instruction ("approval request was not answered in time... you may retry") instead of being reported as "User rejected bash command."
- Not exploitable today — `requestBashApproval` never passes `options`/`timeoutMs`, so this path was dead code — this is forward-looking correctness ahead of any caller wiring a timeout through.

## Test plan

- [x] `npm run typecheck` passes.
- [x] Added a new regression test in `src/test-kernel/tools/BashToolErrorFeedback.vitest.ts` asserting a real rejection and a timeout produce distinct error messages; confirmed it fails against the pre-fix code (reverted the fix, reran, restored).
- [x] Updated the existing bash-timeout assertion in `src/test-kernel/cli/TuiHostInteractionsCancelForStream.vitest.mts` to expect the new `timedOut: true` field.
- [x] Ran the full bash/wolfram/approval-adjacent vitest suites (127+16 tests) — all green.
- [x] `npx eslint` on all changed files — clean.
- [x] `npx prettier --check` on all changed files — clean.

Closes #7444

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral change is limited to error messaging and agent instructions when approval times out; no auth or execution path changes, and the timeout path is forward-looking until callers pass `timeoutMs`.
> 
> **Overview**
> Bash approval timeouts were indistinguishable from explicit user rejections: `accepted: false` always surfaced as **"User rejected bash command"** to the agent, unlike plan/proposal/retry flows that already use a distinct timeout shape (#7327).
> 
> This PR adds an optional **`timedOut`** flag on `HostBashApprovalResult` and `BashApprovalResult`, sets it on the CLI TUI bash approval timeout path in `subscribeApprovals.ts`, and threads it through **`buildBashApprovalRejectedResult`** and callers (`bash`, agent-CLI shared prelude, `send_to_terminal`, `wolfram`). Timeouts now use separate error text and default **`userInstruction`** (retry allowed) instead of the hard "do not retry" rejection guidance.
> 
> Regression tests cover the TUI timeout payload and distinct `BashTool` error messages for reject vs timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7176d20b155f9ce04bbd67abeaf0635c6a5e6478. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->