### PR TITLE
fix(transcript): loud, non-destructive read for persisted usage stats

### DIFF
--- a/src/shared/schemas/streamData.ts
+++ b/src/shared/schemas/streamData.ts
@@ -310,23 +310,68 @@ void (null as unknown as z.infer<
   typeof TokenUsageStatsParsingSchema
 > satisfies TokenUsageStats);
 
+export interface ParsedUsageData {
+  /** Successfully parsed, non-empty per-run usage. */
+  usage: Map<string, TokenUsageStats>;
+  /**
+   * Raw per-run values that failed to parse (e.g. a value that isn't an
+   * object at all — a corrupted or unrecognized future shape), keyed by
+   * runId and preserved byte-for-byte. `StreamSnapshotStore.writeUsage`
+   * round-trips these back into `usageStats.json` unchanged instead of
+   * dropping them, so a save can never permanently delete cost data current
+   * code doesn't understand. See #7464.
+   */
+  unparsedRuns: Map<string, unknown>;
+}
+
 /**
- * Per-run usage map: { runId: TokenUsageStats } → Map<runId, stats>.
- * Used by both workflow and tool-use streams. Workflow has one entry per
- * run (= one entry per tab); tool-use can accumulate multiple via resume.
+ * Parses the persisted per-run usage-stats record (`usageStats.json`) into
+ * `{ runId: TokenUsageStats }` → `Map<runId, stats>`. Used by both workflow
+ * and tool-use streams. Workflow has one entry per run (= one entry per
+ * tab); tool-use can accumulate multiple via resume.
+ *
+ * Failures are isolated PER RUN — via `safeParse` rather than the previous
+ * `.catch(emptyUsageStats())` — so one malformed entry can't silently zero
+ * every other run's cost data. A run whose value isn't a well-formed usage
+ * object is logged loudly (not swallowed) and its raw value is returned in
+ * `unparsedRuns` for the caller to preserve, rather than defaulted to zero
+ * and dropped. Individual numeric fields inside an otherwise object-shaped
+ * entry still coerce/zero via `TokenUsageStatsParsingBaseSchema`'s own
+ * per-field handling — that salvage behavior is unrelated to this fix and
+ * intentionally unchanged.
+ *
+ * A top-level value that isn't a record at all (e.g. corrupted to an array
+ * or a scalar) has no runId to key a preserved raw entry against, so it is
+ * only logged loudly; recovering it would require guessing intent. This is
+ * an extreme, likely-tampered edge case — the realistic failure mode this
+ * fixes is a single corrupted run entry within an otherwise valid record.
  */
-export const UsageDataSchema = z
-  .record(z.string(), TokenUsageStatsParsingSchema)
-  .transform((record): Map<string, TokenUsageStats> => {
-    const map = new Map<string, TokenUsageStats>();
-    for (const [runId, stats] of Object.entries(record)) {
-      if (!isEmptyUsage(stats)) map.set(runId, stats);
+export function parseUsageData(raw: unknown): ParsedUsageData {
+  const usage = new Map<string, TokenUsageStats>();
+  const unparsedRuns = new Map<string, unknown>();
+  if (raw === undefined) return { usage, unparsedRuns };
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    console.warn(
+      `[streamData] usageStats.json is not a per-run object (got ` +
+        `${raw === null ? 'null' : Array.isArray(raw) ? 'array' : typeof raw}); ` +
+        'ignoring for this read instead of silently zeroing usage.',
+    );
+    return { usage, unparsedRuns };
+  }
+
+  for (const [runId, value] of Object.entries(raw as Record<string, unknown>)) {
+    const parsed = TokenUsageStatsParsingBaseSchema.safeParse(value);
+    if (!parsed.success) {
+      console.warn(
+        `[streamData] Preserving unparseable usage entry for run "${runId}" ` +
+          `unchanged (not dropped): ${parsed.error.issues
+            .map((i) => `${i.path.join('.') || '<root>'}: ${i.message}`)
+            .join('; ')}`,
+      );
+      unparsedRuns.set(runId, value);
+      continue;
     }
-    return map;
-  })
-  // `() => new Map()` (not a literal) for the same reason as `roundMapSchema`:
-  // a fresh fallback per failed parse. The current consumer copies this map
-  // (StreamSnapshotStore.applyStreamData) so a shared instance is safe today,
-  // but the factory keeps the file consistent and guards a future by-reference
-  // reader from leaking usage across streams with malformed sidecar JSON.
-  .catch(() => new Map()) as z.ZodType<Map<string, TokenUsageStats>>;
+    if (!isEmptyUsage(parsed.data)) usage.set(runId, parsed.data);
+  }
+  return { usage, unparsedRuns };
+}

--- a/src/test-kernel/schemas/StreamDataUsage.vitest.ts
+++ b/src/test-kernel/schemas/StreamDataUsage.vitest.ts
@@ -1,14 +1,14 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   emptyUsageStats,
+  parseUsageData,
   sumUsageStats,
-  UsageDataSchema,
 } from '@shared/schemas';
 
 describe('stream data usage parsing', () => {
   it('coerces persisted usage fields and defaults missing cache counters', () => {
-    const usage = UsageDataSchema.parse({
+    const { usage } = parseUsageData({
       run: {
         inputTokens: '10',
         outputTokens: '2',
@@ -26,8 +26,24 @@ describe('stream data usage parsing', () => {
     });
   });
 
-  it('drops usage entries that parse to empty defaults', () => {
-    const usage = UsageDataSchema.parse({
+  it('drops a usage entry that legitimately parses to all-zero activity', () => {
+    const { usage, unparsedRuns } = parseUsageData({
+      run: { inputTokens: 0, outputTokens: 0, cost: 0 },
+    });
+
+    expect(usage.size).toBe(0);
+    expect(unparsedRuns.size).toBe(0);
+  });
+
+  it('preserves (does not zero-and-drop) a run entry with non-finite numeric fields', () => {
+    // Regression test for #7464: `inputTokens`/`outputTokens`/`cost` reject
+    // non-finite values (NaN/Infinity), which previously threw inside the
+    // per-entry schema and was silently caught to `emptyUsageStats()` — an
+    // all-zero value that then vanished from the map entirely, permanently
+    // erasing this run's real cost data on the next `writeUsage()`. It must
+    // now be logged and handed back raw instead.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { usage, unparsedRuns } = parseUsageData({
       run: {
         inputTokens: 'not-a-number',
         outputTokens: Number.POSITIVE_INFINITY,
@@ -35,11 +51,18 @@ describe('stream data usage parsing', () => {
       },
     });
 
-    expect(usage.size).toBe(0);
+    expect(usage.has('run')).toBe(false);
+    expect(unparsedRuns.get('run')).toEqual({
+      inputTokens: 'not-a-number',
+      outputTokens: Number.POSITIVE_INFINITY,
+      cost: Number.NaN,
+    });
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 
   it('parses numeric usage fields from the canonical usage schema shape', () => {
-    const usage = UsageDataSchema.parse({
+    const { usage } = parseUsageData({
       run: {
         inputTokens: '10',
         outputTokens: '2',
@@ -60,7 +83,7 @@ describe('stream data usage parsing', () => {
   });
 
   it('normalizes persisted legacy subscription markers to usageRoute', () => {
-    const usage = UsageDataSchema.parse({
+    const { usage } = parseUsageData({
       run: {
         inputTokens: 10,
         outputTokens: 2,
@@ -76,6 +99,34 @@ describe('stream data usage parsing', () => {
       usageRoute: 'chatgpt-subscription',
     });
     expect(usage.get('run')).not.toHaveProperty('viaChatGptSubscription');
+  });
+
+  it('preserves an unparseable run entry instead of silently zeroing it', () => {
+    // Regression test for #7464: a run entry that isn't an object at all
+    // (e.g. corrupted to a bare string) must not be replaced by zeroed
+    // usage and dropped — it must be logged and handed back raw so a save
+    // never permanently deletes it.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { usage, unparsedRuns } = parseUsageData({
+      good: { inputTokens: 10, outputTokens: 2, cost: 0.1 },
+      corrupted: 'not-a-usage-object',
+    });
+
+    expect(usage.has('corrupted')).toBe(false);
+    expect(usage.get('good')).toMatchObject({ inputTokens: 10 });
+    expect(unparsedRuns.get('corrupted')).toBe('not-a-usage-object');
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('logs and yields no data for a top-level usage payload that is not an object', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { usage, unparsedRuns } = parseUsageData(['not', 'a', 'record']);
+
+    expect(usage.size).toBe(0);
+    expect(unparsedRuns.size).toBe(0);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 
   it('keeps route badges only for unambiguous accumulated usage', () => {

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -332,6 +332,44 @@ describe('StreamSnapshotStore', () => {
     });
   });
 
+  it('preserves an unparseable persisted usage entry across a save instead of deleting it', async () => {
+    // Regression test for #7464: a run entry that fails to parse (e.g. a
+    // corrupted or future-shaped value) must be logged loudly and carried
+    // through unchanged, rather than silently zeroed and then permanently
+    // deleted from disk by the next writeUsage().
+    const dir = streamDataDir(STREAM);
+    await StorageFS.ensureDir(dir);
+    await StorageFS.write(
+      path.join(dir, 'usageStats.json'),
+      JSON.stringify({
+        [RUN]: usage(100, 20, 0.5),
+        'run-corrupt': 'this-is-not-a-usage-object',
+      }),
+    );
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const store = new StreamSnapshotStore();
+    // Force a seed + a write for an unrelated run so writeUsage() actually
+    // rewrites usageStats.json from the in-memory accumulators.
+    const pending = store.addUsage(STREAM, RUN_2, usage(50, 10, 0.25));
+    await Promise.resolve(pending);
+    await store.flush();
+
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+
+    const raw = await StorageFS.readJson(path.join(dir, 'usageStats.json'));
+    expect(raw).toMatchObject({
+      [RUN]: { inputTokens: 100, outputTokens: 20, cost: 0.5 },
+      [RUN_2]: { inputTokens: 50, outputTokens: 10, cost: 0.25 },
+      'run-corrupt': 'this-is-not-a-usage-object',
+    });
+
+    // The corrupted entry is preserved on disk for round-tripping but is
+    // never surfaced through the typed in-memory usage view.
+    expect(store.getRunUsage(STREAM).has('run-corrupt')).toBe(false);
+  });
+
   it('resolves pre-seed usage after merging existing disk usage', async () => {
     const dir = streamDataDir(STREAM);
     await StorageFS.ensureDir(dir);

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -179,6 +179,12 @@ export class StreamSnapshotStore {
     Map<number, CompileFailure[]>
   >();
   private readonly usage = new Map<StreamTabId, Map<string, TokenUsageStats>>();
+  /**
+   * Per-run usage values read from disk that failed to parse, preserved
+   * verbatim so `writeUsage` can round-trip them back unchanged instead of a
+   * lossy read permanently deleting them on the next save (#7464).
+   */
+  private readonly usageUnparsed = new Map<StreamTabId, Map<string, unknown>>();
   private readonly workPlan = new Map<StreamTabId, WorkPlanSnapshot>();
   private readonly meta = new Map<StreamTabId, StreamTabMeta>();
   /** Immutable run descriptors parsed/emitted once per execution stream. */
@@ -575,11 +581,16 @@ export class StreamSnapshotStore {
   }
 
   private writeUsage(stream: StreamTabId): void {
-    this.write(
-      stream,
-      STREAM_DATA_KEYS.USAGE_STATS,
-      mapToRecord(this.usage.get(stream) ?? new Map()),
-    );
+    const parsed = mapToRecord(this.usage.get(stream) ?? new Map());
+    const unparsed = this.usageUnparsed.get(stream);
+    // Reinsert raw entries this store couldn't interpret so the write never
+    // deletes them; a run that has since parsed successfully (`parsed`) wins
+    // over its own stale raw fallback via spread order (#7464).
+    const record =
+      unparsed && unparsed.size > 0
+        ? { ...Object.fromEntries(unparsed), ...parsed }
+        : parsed;
+    this.write(stream, STREAM_DATA_KEYS.USAGE_STATS, record);
   }
 
   addOutputFiles(
@@ -725,6 +736,7 @@ export class StreamSnapshotStore {
       ...this.missingOutputs.keys(),
       ...this.compileFailures.keys(),
       ...this.usage.keys(),
+      ...this.usageUnparsed.keys(),
       ...this.workPlan.keys(),
       ...this.meta.keys(),
       ...this.runDescriptors.keys(),
@@ -744,6 +756,7 @@ export class StreamSnapshotStore {
     this.missingOutputs.delete(stream);
     this.compileFailures.delete(stream);
     this.usage.delete(stream);
+    this.usageUnparsed.delete(stream);
     this.workPlan.delete(stream);
     this.meta.delete(stream);
     this.runDescriptors.delete(stream);
@@ -765,6 +778,7 @@ export class StreamSnapshotStore {
     this.missingOutputs.clear();
     this.compileFailures.clear();
     this.usage.clear();
+    this.usageUnparsed.clear();
     this.workPlan.clear();
     this.meta.clear();
     this.runDescriptors.clear();
@@ -1117,6 +1131,7 @@ export class StreamSnapshotStore {
       missingOutputs: this.missingOutputs.get(streamId) ?? new Map(),
       compileFailures: this.compileFailures.get(streamId) ?? new Map(),
       usage: this.usage.get(streamId) ?? new Map(),
+      usageUnparsed: this.usageUnparsed.get(streamId) ?? new Map(),
       workPlan: this.getWorkPlan(streamId),
       legacyKeys: [],
     });
@@ -1288,6 +1303,7 @@ export class StreamSnapshotStore {
       stream,
       new Map([...data.usage].filter(([, v]) => !isEmptyUsage(v))),
     );
+    this.usageUnparsed.set(stream, new Map(data.usageUnparsed));
     this.workPlan.set(stream, data.workPlan);
     this.runDescriptors.delete(stream);
     this.runConfigs.delete(stream);

--- a/src/transcript/streamSnapshotRead.ts
+++ b/src/transcript/streamSnapshotRead.ts
@@ -18,11 +18,11 @@ import {
   LegacyInstructionsDataSchema,
   MissingOutputsDataSchema,
   OutputFilesDataSchema,
+  parseUsageData,
   PersistedWorkPlanSchema,
   STREAM_SNAPSHOT_SCHEMA_VERSION,
   StreamSnapshotSchema,
   StreamTabMetaSchema,
-  UsageDataSchema,
   flattenLegacyRuns,
   isLegacyNested,
   selectPreferredLegacyInstruction,
@@ -59,6 +59,13 @@ export interface StreamData {
   missingOutputs: Map<number, string[]>;
   compileFailures: Map<number, CompileFailure[]>;
   usage: Map<string, TokenUsageStats>;
+  /**
+   * Raw per-run usage values that failed to parse, keyed by runId and
+   * preserved verbatim (see {@link parseUsageData}). `StreamSnapshotStore`
+   * round-trips these back into `usageStats.json` on the next write instead
+   * of a lossy read silently deleting them (#7464).
+   */
+  usageUnparsed: Map<string, unknown>;
   workPlan: WorkPlanSnapshot;
   /** Category keys whose on-disk file was legacy-nested (need a one-time flat rewrite). */
   legacyKeys: string[];
@@ -193,7 +200,7 @@ export async function readStreamData(kv: KVStore): Promise<StreamData> {
   ]);
 
   const usageRaw = await tryRead(kv, STREAM_DATA_KEYS.USAGE_STATS);
-  const usage = UsageDataSchema.catch(new Map()).parse(usageRaw);
+  const { usage, unparsedRuns: usageUnparsed } = parseUsageData(usageRaw);
 
   const workPlan = readPersistedWorkPlan(
     await tryRead(kv, STREAM_DATA_KEYS.WORK_PLAN),
@@ -205,6 +212,7 @@ export async function readStreamData(kv: KVStore): Promise<StreamData> {
     missingOutputs,
     compileFailures,
     usage,
+    usageUnparsed,
     workPlan,
     legacyKeys,
   };


### PR DESCRIPTION
## Root cause

`usageStats.json` parsing chained three silent `.catch()` fallbacks:
`TokenUsageStatsParsingBaseSchema.catch(emptyUsageStats())` per run entry,
`UsageDataSchema`'s own top-level `.catch(() => new Map())`, and a redundant
third `.catch(new Map())` at the `streamSnapshotRead.ts` call site. Any run
whose value failed to parse — not just a wrong type, but also plain corrupted
numeric fields such as a `NaN`/`Infinity` cost, since those reject at the
schema level too — was silently replaced with all-zero usage and dropped from
the map, with zero diagnostic. `StreamSnapshotStore.writeUsage()` then
persisted that diminished map back over the real on-disk value on the very
next save, permanently erasing the run's cost data.

This is the usage-stats half of #7464 (the stream-log half already landed in
#7486).

## Fix

- Replace the schema chain with `parseUsageData()`, which isolates parse
  failures **per run**: an entry that fails to parse is logged loudly via
  `console.warn` (with the run id and the concrete issues) instead of being
  silently defaulted to zero, and its raw value is returned verbatim in an
  `unparsedRuns` map instead of being dropped.
- `StreamSnapshotStore` now carries this raw map per stream (seeded, evicted,
  and cleared alongside the existing `usage` accumulator) and `writeUsage()`
  reinserts it into `usageStats.json` ahead of the freshly-parsed entries, so
  a save round-trips unparseable data unchanged instead of deleting it. A run
  that later parses successfully overrides its own stale raw fallback.
- Individual numeric-field coercion inside an otherwise well-formed usage
  object (e.g. a stringified `"10"` token count) is unrelated to this fix and
  intentionally unchanged.

## Verification

- `npm run typecheck` (both `tsconfig.json` and `tsconfig.test-kernel.json`)
- `vitest run src/test-kernel/schemas/StreamDataUsage.vitest.ts src/test-kernel/transcript/StreamSnapshotStore.vitest.ts`, plus the broader
  transcript/schemas/desktop/cli/progressView/latex/tools suites that touch
  `StreamData` or `StreamSnapshotStore` (386 tests total across all of the
  above)
- `eslint` on all changed files; `prettier --check` clean
- Confirmed the new `StreamSnapshotStore` regression test ("preserves an
  unparseable persisted usage entry across a save instead of deleting it")
  fails against the pre-fix code (no warning is ever emitted, and the run
  silently vanishes) before restoring the fix

Closes #7464

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persisted usage/cost sidecar read-write paths; behavior change is intentional (warn + preserve) but incorrect merge logic could still affect billing display or disk shape.
> 
> **Overview**
> Fixes **#7464** by stopping silent loss of per-run cost data when `usageStats.json` has malformed entries.
> 
> **`parseUsageData()`** replaces the old `UsageDataSchema` chain with per-run `safeParse`: bad runs are **`console.warn`**’d, kept in **`unparsedRuns`**, and no longer zeroed or dropped while other runs still load. Top-level non-objects are warned and ignored (no run keys to preserve).
> 
> **`StreamSnapshotStore`** tracks **`usageUnparsed`** per stream and **`writeUsage()`** merges raw entries back into disk (parsed values win on the same run id). **`streamSnapshotRead`** seeds that map from disk reads.
> 
> Tests cover NaN/Infinity fields, non-object run values, top-level corruption, and a store regression that corrupt entries survive the next save.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fd23f5bf9fde715df73690edcd0762ee126e2e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->