### PR TITLE
fix: align extension/desktop HostInteractions resolve/cancel semantics

### DIFF
--- a/packages/desktop/src/main/desktopHostInteractions.ts
+++ b/packages/desktop/src/main/desktopHostInteractions.ts
@@ -12,11 +12,13 @@ import type {
 import type { PlanApprovalResult } from '@agent/runtime/PlanApprovalCoordinator';
 import type { ProposalResult } from '@agent/runtime/AgentProposalCoordinator';
 import type { RetryResult } from '@agent/runtime/RetryRequestCoordinator';
-import type {
-  AgentProposalPermission,
-  StreamTabId,
-  UserQuestionAnswers,
-} from '@shared/schemas';
+import {
+  toBashApprovalResult,
+  toPlanApprovalResult,
+  toProposalResult,
+  toUserQuestionResult,
+} from '@agent/runtime/hostInteractionResultMappers';
+import type { AgentProposalPermission, StreamTabId } from '@shared/schemas';
 import type { ApprovalRequestHandlerSet } from '@shared/progressView/backend/progressBackendUiConfig';
 import type {
   ToolEditApprovalRequest,
@@ -150,6 +152,13 @@ class DesktopHostInteractions implements HostInteractions {
     return false;
   }
 
+  /**
+   * `result.kind` must match the pending request's own recorded kind before
+   * it's honored — the same discriminant check the extension host performs
+   * — so a caller bug (or a stale/misrouted resolution) can't be silently
+   * reinterpreted as whatever kind happens to be pending under that
+   * requestId.
+   */
   resolve(requestId: string, result: HostInteractionResolution): boolean {
     if (result.kind === 'externalInquiry') {
       this.options.getApprovalHandlers().externalInquiry.resolve(requestId);
@@ -157,26 +166,16 @@ class DesktopHostInteractions implements HostInteractions {
     }
 
     const request = this.pendingRequests.get(requestId);
-    if (!request) return false;
+    if (!request || request.kind !== result.kind) return false;
     this.pendingRequests.delete(requestId);
 
     switch (request.kind) {
       case 'bash':
-        request.settle({
-          accepted: result.action === 'approve',
-          ...(result.feedback ? { userMessage: result.feedback } : {}),
-        });
+        request.settle(toBashApprovalResult(result));
         this.options.getApprovalHandlers().bash.resolve(requestId);
         return true;
       case 'plan':
-        request.settle(
-          result.action === 'approve' || result.action === 'approve_and_goal'
-            ? { action: result.action }
-            : {
-                action: 'reject',
-                ...(result.feedback ? { feedback: result.feedback } : {}),
-              },
-        );
+        request.settle(toPlanApprovalResult(result));
         this.options.getApprovalHandlers().planApproval.resolve(requestId);
         return true;
       case 'proposal':
@@ -184,18 +183,18 @@ class DesktopHostInteractions implements HostInteractions {
         this.options.getApprovalHandlers().agentProposal.resolve(requestId);
         return true;
       case 'userQuestion':
-        request.settle({
-          submitted: result.action === 'submit',
-          ...(result.value
-            ? { answers: result.value as UserQuestionAnswers }
-            : {}),
-          ...(result.feedback ? { feedback: result.feedback } : {}),
-        });
+        request.settle(toUserQuestionResult(result));
         this.options.getApprovalHandlers().userQuestion.resolve(requestId);
         return true;
     }
   }
 
+  /**
+   * Cancellation is a synthesized rejection routed through the same
+   * `resolve()`/mapper path a live UI action takes, forwarding `cause` as
+   * agent-visible feedback — so a cancelled request and a rejected one settle
+   * identically for a given kind.
+   */
   cancelForStream(streamId: StreamTabId, cause?: string): void {
     this.cancelMatching((request) => request.streamId === streamId, cause);
   }
@@ -223,13 +222,7 @@ class DesktopHostInteractions implements HostInteractions {
   }
 
   dispose(): void {
-    for (const requestId of [...this.pendingRequests.keys()]) {
-      this.resolve(requestId, {
-        kind: 'dispose',
-        action: 'reject',
-        feedback: 'Desktop session disposed.',
-      });
-    }
+    this.cancelAll('Desktop session disposed.');
   }
 
   private showPending<TResult, TEntry extends PendingDesktopInteraction>(
@@ -251,17 +244,4 @@ class DesktopHostInteractions implements HostInteractions {
     if (streamId)
       this.options.runtimeHost.emit('setActiveStream', { streamId });
   }
-}
-
-function toProposalResult(result: HostInteractionResolution): ProposalResult {
-  if (result.value && typeof result.value === 'object') {
-    const value = result.value as ProposalResult;
-    if ('action' in value) return value;
-  }
-  return result.action === 'approve' || result.action === 'setup'
-    ? { action: result.action }
-    : {
-        action: 'reject',
-        ...(result.feedback ? { feedback: result.feedback } : {}),
-      };
 }

--- a/packages/extension/src/progressView/extensionHostInteractions.ts
+++ b/packages/extension/src/progressView/extensionHostInteractions.ts
@@ -17,12 +17,15 @@ import type {
   ProgressEvent,
   ProgressEventPayloads,
 } from '@agent/runtime/hostProgressEvents';
+import {
+  toBashApprovalResult,
+  toPlanApprovalResult,
+  toProposalResult,
+  toRetryResult,
+  toUserQuestionResult,
+} from '@agent/runtime/hostInteractionResultMappers';
 import { nativeRequestApproval } from '@frontend/approval/nativeToolEditApproval';
-import type {
-  AgentProposalPermission,
-  StreamTabId,
-  UserQuestionAnswers,
-} from '@shared/schemas';
+import type { AgentProposalPermission, StreamTabId } from '@shared/schemas';
 import type { ApprovalRequestHandlerSet } from '@shared/progressView/backend/progressBackendUiConfig';
 import type {
   ToolEditApprovalRequest,
@@ -99,31 +102,61 @@ export function createExtensionHostInteractions(
     return true;
   };
 
+  /**
+   * Releases a pending interaction as a synthesized rejection, forwarding
+   * `cause` as agent-visible feedback through the same result mappers
+   * `resolve()` uses — so a cancellation and a live UI rejection settle
+   * identically for a given kind.
+   */
   const releasePending = (
     pending: PendingExtensionInteraction<PendingExtensionInteractionValue>,
+    cause?: string,
   ): void => {
     pendingRequests.delete(pending.id);
+    const rejection: HostInteractionResolution = {
+      kind: pending.kind,
+      action: 'reject',
+      feedback: cause,
+    };
     switch (pending.kind) {
       case 'bash':
         handlers().bash.resolve(pending.id);
-        pending.settle({ accepted: false });
+        pending.settle(toBashApprovalResult(rejection));
         break;
       case 'plan':
         handlers().planApproval.resolve(pending.id);
-        pending.settle({ action: 'reject' });
+        pending.settle(toPlanApprovalResult(rejection));
         break;
       case 'proposal':
         handlers().agentProposal.resolve(pending.id);
-        pending.settle({ action: 'reject' });
+        pending.settle(toProposalResult(rejection));
         break;
       case 'retry':
         handlers().retry.resolve(pending.id);
-        pending.settle({ action: 'cancel' });
+        pending.settle(toRetryResult(rejection));
         break;
       case 'userQuestion':
         handlers().userQuestion.resolve(pending.id);
-        pending.settle({ submitted: false });
+        pending.settle(toUserQuestionResult(rejection));
         break;
+    }
+  };
+
+  const cancelForStream = (streamId: StreamTabId, cause?: string): void => {
+    for (const pending of [...pendingRequests.values()]) {
+      if (pending.streamId === streamId) releasePending(pending, cause);
+    }
+  };
+
+  const cancelUnscoped = (cause?: string): void => {
+    for (const pending of [...pendingRequests.values()]) {
+      if (!pending.streamId) releasePending(pending, cause);
+    }
+  };
+
+  const cancelAll = (cause?: string): void => {
+    for (const pending of [...pendingRequests.values()]) {
+      releasePending(pending, cause);
     }
   };
 
@@ -230,13 +263,7 @@ export function createExtensionHostInteractions(
           return resolvePending<HostBashApprovalResult>(
             requestId,
             'bash',
-            {
-              accepted: result.action === 'approve',
-              userMessage:
-                result.action === 'reject'
-                  ? result.feedback?.trim()
-                  : undefined,
-            },
+            toBashApprovalResult(result),
             () => handlers().bash.resolve(requestId),
           );
         case 'plan':
@@ -257,24 +284,14 @@ export function createExtensionHostInteractions(
           return resolvePending<RetryResult>(
             requestId,
             'retry',
-            result.action === 'retry'
-              ? { action: 'retry', feedback: result.feedback }
-              : { action: 'cancel' },
+            toRetryResult(result),
             () => handlers().retry.resolve(requestId),
           );
         case 'userQuestion':
           return resolvePending<HostUserQuestionResult>(
             requestId,
             'userQuestion',
-            {
-              submitted: result.action === 'submit',
-              answers:
-                result.action === 'submit'
-                  ? (result.value as UserQuestionAnswers | undefined)
-                  : undefined,
-              feedback:
-                result.action === 'submit' ? undefined : result.feedback,
-            },
+            toUserQuestionResult(result),
             () => handlers().userQuestion.resolve(requestId),
           );
         case 'externalInquiry':
@@ -285,53 +302,12 @@ export function createExtensionHostInteractions(
       }
     },
 
-    cancelForStream(streamId: StreamTabId): void {
-      for (const pending of [...pendingRequests.values()]) {
-        if (pending.streamId === streamId) {
-          releasePending(pending);
-        }
-      }
-    },
-
-    cancelUnscoped(cause?: string): void {
-      void cause;
-      for (const pending of [...pendingRequests.values()]) {
-        if (!pending.streamId) {
-          releasePending(pending);
-        }
-      }
-    },
-
-    cancelAll(cause?: string): void {
-      void cause;
-      for (const pending of [...pendingRequests.values()]) {
-        releasePending(pending);
-      }
-    },
+    cancelForStream,
+    cancelUnscoped,
+    cancelAll,
 
     dispose(): void {
-      for (const pending of [...pendingRequests.values()]) {
-        releasePending(pending);
-      }
+      cancelAll('Extension session disposed.');
     },
   };
-}
-
-function toPlanApprovalResult(
-  result: HostInteractionResolution,
-): PlanApprovalResult {
-  if (result.action === 'approve') return { action: 'approve' };
-  if (result.action === 'approve_and_goal')
-    return { action: 'approve_and_goal' };
-  return { action: 'reject', feedback: result.feedback };
-}
-
-function toProposalResult(result: HostInteractionResolution): ProposalResult {
-  const value = result.value as ProposalResult | undefined;
-  if (value?.action === 'approve') return value;
-  if (value?.action === 'setup') return value;
-  if (value?.action === 'reject') return value;
-  if (result.action === 'setup') return { action: 'setup' };
-  if (result.action === 'approve') return { action: 'approve' };
-  return { action: 'reject', feedback: result.feedback };
 }

--- a/src/agent/runtime/hostInteractionResultMappers.ts
+++ b/src/agent/runtime/hostInteractionResultMappers.ts
@@ -1,0 +1,87 @@
+/**
+ * Shared mapping from the generic `HostInteractionResolution` — used both to
+ * settle a live UI action and to synthesize a cancellation/dispose rejection
+ * — into each interaction's own typed result.
+ *
+ * The extension and desktop `HostInteractions` implementations each own their
+ * pending-request bookkeeping (that stays host-specific), but they must agree
+ * on what a given `{ kind, action, value, feedback }` resolution *means* for
+ * the agent. Both hosts call these functions instead of maintaining their own
+ * copies, so the two hosts cannot silently re-diverge on that vocabulary.
+ */
+
+import type { UserQuestionAnswers } from '@shared/schemas';
+import type {
+  HostBashApprovalResult,
+  HostInteractionResolution,
+  HostUserQuestionResult,
+} from './HostInteractions';
+import type { PlanApprovalResult } from './PlanApprovalCoordinator';
+import type { ProposalResult } from './AgentProposalCoordinator';
+import type { RetryResult } from './RetryRequestCoordinator';
+
+export function toBashApprovalResult(
+  result: HostInteractionResolution,
+): HostBashApprovalResult {
+  return {
+    accepted: result.action === 'approve',
+    userMessage:
+      result.action === 'reject' ? result.feedback?.trim() : undefined,
+  };
+}
+
+export function toPlanApprovalResult(
+  result: HostInteractionResolution,
+): PlanApprovalResult {
+  if (result.action === 'approve') return { action: 'approve' };
+  if (result.action === 'approve_and_goal')
+    return { action: 'approve_and_goal' };
+  return { action: 'reject', feedback: result.feedback };
+}
+
+const PROPOSAL_RESULT_ACTIONS = new Set(['approve', 'setup', 'reject']);
+
+function isProposalResultValue(value: unknown): value is ProposalResult {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'action' in value &&
+    PROPOSAL_RESULT_ACTIONS.has((value as { action: unknown }).action as string)
+  );
+}
+
+/**
+ * `result.value` may already carry a fully-formed `ProposalResult` (e.g. from
+ * `ProgressAgentProposalController.handleAction`); only trust it when its
+ * `action` is one this union actually declares, otherwise fall back to
+ * `result.action`/`result.feedback` like every other mapper here. A bare
+ * pass-through of "any object with an `action` key" would let an unrelated
+ * caller shape masquerade as a proposal result.
+ */
+export function toProposalResult(
+  result: HostInteractionResolution,
+): ProposalResult {
+  if (isProposalResultValue(result.value)) return result.value;
+  if (result.action === 'setup') return { action: 'setup' };
+  if (result.action === 'approve') return { action: 'approve' };
+  return { action: 'reject', feedback: result.feedback };
+}
+
+export function toRetryResult(result: HostInteractionResolution): RetryResult {
+  return result.action === 'retry'
+    ? { action: 'retry', feedback: result.feedback }
+    : { action: 'cancel' };
+}
+
+export function toUserQuestionResult(
+  result: HostInteractionResolution,
+): HostUserQuestionResult {
+  return {
+    submitted: result.action === 'submit',
+    answers:
+      result.action === 'submit'
+        ? (result.value as UserQuestionAnswers | undefined)
+        : undefined,
+    feedback: result.action === 'submit' ? undefined : result.feedback,
+  };
+}

--- a/src/agent/runtime/hostInteractionResultMappers.ts
+++ b/src/agent/runtime/hostInteractionResultMappers.ts
@@ -25,6 +25,7 @@ export function toBashApprovalResult(
 ): HostBashApprovalResult {
   return {
     accepted: result.action === 'approve',
+    timedOut: result.action === 'timeout' ? true : undefined,
     userMessage:
       result.action === 'reject' ? result.feedback?.trim() : undefined,
   };
@@ -39,14 +40,21 @@ export function toPlanApprovalResult(
   return { action: 'reject', feedback: result.feedback };
 }
 
-const PROPOSAL_RESULT_ACTIONS = new Set(['approve', 'setup', 'reject']);
+const PROPOSAL_RESULT_ACTIONS: ReadonlySet<ProposalResult['action']> = new Set([
+  'approve',
+  'setup',
+  'reject',
+  'timeout',
+]);
 
 function isProposalResultValue(value: unknown): value is ProposalResult {
   return (
     typeof value === 'object' &&
     value !== null &&
     'action' in value &&
-    PROPOSAL_RESULT_ACTIONS.has((value as { action: unknown }).action as string)
+    PROPOSAL_RESULT_ACTIONS.has(
+      (value as { action: ProposalResult['action'] }).action,
+    )
   );
 }
 

--- a/src/agent/runtime/hostInteractionResultMappers.ts
+++ b/src/agent/runtime/hostInteractionResultMappers.ts
@@ -26,6 +26,12 @@ export function toBashApprovalResult(
   return {
     accepted: result.action === 'approve',
     timedOut: result.action === 'timeout' ? true : undefined,
+    // Deliberate alignment choice, not an oversight: `userMessage` exists to
+    // explain a rejection back to the agent (see buildBashApprovalRejectedResult),
+    // so it's scoped to the reject action alone. The pre-alignment desktop
+    // implementation attached it to any action with truthy feedback (e.g. an
+    // approve carrying a stray note) — that was drift, not a feature; an
+    // approved command has no rejection reason to report.
     userMessage:
       result.action === 'reject' ? result.feedback?.trim() : undefined,
   };
@@ -48,13 +54,12 @@ const PROPOSAL_RESULT_ACTIONS: ReadonlySet<ProposalResult['action']> = new Set([
 ]);
 
 function isProposalResultValue(value: unknown): value is ProposalResult {
+  if (typeof value !== 'object' || value === null) return false;
+  if (!Object.hasOwn(value, 'action')) return false;
+  const { action } = value as { action: unknown };
   return (
-    typeof value === 'object' &&
-    value !== null &&
-    'action' in value &&
-    PROPOSAL_RESULT_ACTIONS.has(
-      (value as { action: ProposalResult['action'] }).action,
-    )
+    typeof action === 'string' &&
+    PROPOSAL_RESULT_ACTIONS.has(action as ProposalResult['action'])
   );
 }
 
@@ -86,6 +91,13 @@ export function toUserQuestionResult(
 ): HostUserQuestionResult {
   return {
     submitted: result.action === 'submit',
+    // Deliberate alignment choice, not an oversight: answers only make sense
+    // once submitted, and feedback is the "why did you decline" text for a
+    // non-submit action — the two are mutually exclusive by what they mean,
+    // not just by which action produced them. The pre-alignment desktop
+    // implementation carried each field whenever its source value/feedback
+    // was truthy, independent of the action, which could report answers on
+    // a decline or feedback on a submission.
     answers:
       result.action === 'submit'
         ? (result.value as UserQuestionAnswers | undefined)

--- a/src/test-kernel/desktop/DesktopHostInteractions.vitest.mts
+++ b/src/test-kernel/desktop/DesktopHostInteractions.vitest.mts
@@ -1,0 +1,190 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports - shared
+import type { StreamTabId } from '@shared/schemas';
+
+// Local imports - desktop test paths
+import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
+
+interface HostInteractionResolution {
+  readonly kind: string;
+  readonly action: string;
+  readonly feedback?: string;
+  readonly value?: unknown;
+}
+
+interface DesktopHostInteractions {
+  requestBashApproval(request: {
+    command: string;
+    streamId?: StreamTabId;
+  }): Promise<{ accepted: boolean; userMessage?: string }>;
+  requestPlanApproval(request: {
+    approvalId: string;
+    streamId: StreamTabId;
+    goalEnabled: boolean;
+    plan: { objective: string };
+  }): Promise<unknown>;
+  requestAgentProposal(request: unknown): Promise<unknown>;
+  resolve(requestId: string, result: HostInteractionResolution): boolean;
+  cancelForStream(streamId: StreamTabId, cause?: string): void;
+  dispose?(): void;
+}
+
+interface DesktopHostInteractionsModule {
+  createDesktopHostInteractions(options: {
+    runtimeHost: { emit: (event: string, payload: unknown) => void };
+    getApprovalHandlers(): unknown;
+    getToolEditApprovals(): unknown;
+  }): DesktopHostInteractions;
+}
+
+interface RecordingApprovalHandler {
+  readonly show: ReturnType<typeof vi.fn>;
+  readonly resolve: ReturnType<typeof vi.fn>;
+}
+
+function handler(): RecordingApprovalHandler {
+  return { show: vi.fn(), resolve: vi.fn() };
+}
+
+function createHandlers() {
+  return {
+    toolEdit: handler(),
+    bash: handler(),
+    retry: handler(),
+    agentProposal: handler(),
+    planApproval: handler(),
+    externalInquiry: handler(),
+    userQuestion: handler(),
+  };
+}
+
+/** Reads the `requestId` passed to a handler's first `.show()` call. */
+function firstShowRequestId(show: ReturnType<typeof vi.fn>): string {
+  const requestId = (
+    show.mock.calls[0]?.[0] as { requestId?: string } | undefined
+  )?.requestId;
+  if (!requestId) throw new Error('Expected a captured requestId.');
+  return requestId;
+}
+
+async function createInteractions(handlers = createHandlers()) {
+  const { createDesktopHostInteractions } = (await import(
+    moduleFileUrl(desktopSourcePath('main', 'desktopHostInteractions.ts'))
+  )) as DesktopHostInteractionsModule;
+
+  return {
+    interactions: createDesktopHostInteractions({
+      runtimeHost: { emit: vi.fn() },
+      getApprovalHandlers: () => handlers,
+      getToolEditApprovals: () => ({}),
+    }),
+    handlers,
+  };
+}
+
+describe('createDesktopHostInteractions', () => {
+  it('rejects a resolution whose kind does not match the pending request', async () => {
+    const handlers = createHandlers();
+    const { interactions } = await createInteractions(handlers);
+
+    const resultPromise = interactions.requestBashApproval({
+      command: 'echo hi',
+      streamId: 'stream-a' as StreamTabId,
+    });
+    const requestId = firstShowRequestId(handlers.bash.show);
+
+    // A mismatched kind under the same requestId must not settle the
+    // pending bash approval as a plan action would — matches the extension
+    // host's discriminant check.
+    expect(
+      interactions.resolve(requestId, { kind: 'plan', action: 'approve' }),
+    ).toBe(false);
+
+    expect(
+      interactions.resolve(requestId, { kind: 'bash', action: 'approve' }),
+    ).toBe(true);
+    await expect(resultPromise).resolves.toEqual({ accepted: true });
+  });
+
+  it('forwards a cancellation cause as bash reject feedback', async () => {
+    const handlers = createHandlers();
+    const { interactions } = await createInteractions(handlers);
+
+    const resultPromise = interactions.requestBashApproval({
+      command: 'rm -rf build',
+      streamId: 'stream-a' as StreamTabId,
+    });
+
+    interactions.cancelForStream(
+      'stream-a' as StreamTabId,
+      'Stream resources released.',
+    );
+
+    await expect(resultPromise).resolves.toEqual({
+      accepted: false,
+      userMessage: 'Stream resources released.',
+    });
+    expect(handlers.bash.resolve).toHaveBeenCalled();
+  });
+
+  it('whitelists only known proposal actions from a pass-through value', async () => {
+    const handlers = createHandlers();
+    const { interactions } = await createInteractions(handlers);
+
+    const resultPromise = interactions.requestAgentProposal({
+      proposalId: 'proposal-a',
+      streamId: 'stream-a' as StreamTabId,
+      agentCategory: 'toolUse',
+      agent: 'demo-agent',
+    });
+
+    // An unrelated object shape smuggled through `value` (containing an
+    // `action` that isn't a real ProposalResult action) must not be trusted
+    // verbatim — it should fall back to the resolution's own `action`.
+    expect(
+      interactions.resolve('proposal-a', {
+        kind: 'proposal',
+        action: 'reject',
+        value: { action: 'not-a-real-action', foo: 'bar' },
+        feedback: 'Rejected via unrelated caller shape.',
+      }),
+    ).toBe(true);
+
+    await expect(resultPromise).resolves.toEqual({
+      action: 'reject',
+      feedback: 'Rejected via unrelated caller shape.',
+    });
+    expect(handlers.agentProposal.resolve).toHaveBeenCalledWith('proposal-a');
+  });
+
+  it('cancels all pending requests on dispose with a stable cause', async () => {
+    const handlers = createHandlers();
+    const { interactions } = await createInteractions(handlers);
+
+    const bashPromise = interactions.requestBashApproval({
+      command: 'echo hi',
+      streamId: 'stream-a' as StreamTabId,
+    });
+    const planPromise = interactions.requestPlanApproval({
+      approvalId: 'plan-a',
+      streamId: 'stream-b' as StreamTabId,
+      goalEnabled: false,
+      plan: { objective: 'Prove the lemma.' },
+    });
+
+    interactions.dispose?.();
+
+    await expect(bashPromise).resolves.toEqual({
+      accepted: false,
+      userMessage: 'Desktop session disposed.',
+    });
+    await expect(planPromise).resolves.toEqual({
+      action: 'reject',
+      feedback: 'Desktop session disposed.',
+    });
+    expect(handlers.bash.resolve).toHaveBeenCalled();
+    expect(handlers.planApproval.resolve).toHaveBeenCalled();
+  });
+});

--- a/src/test-kernel/desktop/DesktopHostInteractions.vitest.mts
+++ b/src/test-kernel/desktop/DesktopHostInteractions.vitest.mts
@@ -1,18 +1,14 @@
 // Third-party imports
 import { describe, expect, it, vi } from 'vitest';
 
+// Local imports - runtime
+import type { HostInteractionResolution } from '@agent/runtime/HostInteractions';
+
 // Local imports - shared
 import type { StreamTabId } from '@shared/schemas';
 
 // Local imports - desktop test paths
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
-
-interface HostInteractionResolution {
-  readonly kind: string;
-  readonly action: string;
-  readonly feedback?: string;
-  readonly value?: unknown;
-}
 
 interface DesktopHostInteractions {
   requestBashApproval(request: {
@@ -127,6 +123,27 @@ describe('createDesktopHostInteractions', () => {
       userMessage: 'Stream resources released.',
     });
     expect(handlers.bash.resolve).toHaveBeenCalled();
+  });
+
+  it('preserves a bash timeout resolution as distinct from rejection', async () => {
+    const handlers = createHandlers();
+    const { interactions } = await createInteractions(handlers);
+
+    const resultPromise = interactions.requestBashApproval({
+      command: 'sleep 10',
+      streamId: 'stream-a' as StreamTabId,
+    });
+    const requestId = firstShowRequestId(handlers.bash.show);
+
+    expect(
+      interactions.resolve(requestId, { kind: 'bash', action: 'timeout' }),
+    ).toBe(true);
+
+    await expect(resultPromise).resolves.toEqual({
+      accepted: false,
+      timedOut: true,
+    });
+    expect(handlers.bash.resolve).toHaveBeenCalledWith(requestId);
   });
 
   it('whitelists only known proposal actions from a pass-through value', async () => {

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
@@ -54,6 +54,15 @@ function createRuntimeHost() {
   return { emit: vi.fn() };
 }
 
+/** Reads the `requestId` passed to a handler's first `.show()` call. */
+function firstShowRequestId(show: ReturnType<typeof vi.fn>): string {
+  const requestId = (
+    show.mock.calls[0]?.[0] as { requestId?: string } | undefined
+  )?.requestId;
+  if (!requestId) throw new Error('Expected a captured requestId.');
+  return requestId;
+}
+
 function createInteractions(options?: {
   runtimeHost?: ReturnType<typeof createRuntimeHost>;
   handlers?: ApprovalRequestHandlerSet;
@@ -136,6 +145,53 @@ describe('createExtensionHostInteractions', () => {
     expect(handlers.retry.resolve).toHaveBeenCalledWith('stream-a');
   });
 
+  it('forwards a cancellation cause as bash reject feedback', async () => {
+    const handlers = createHandlers();
+    const interactions = createInteractions({ handlers });
+
+    const resultPromise = interactions.requestBashApproval?.({
+      command: 'rm -rf build',
+      streamId: 'stream-a' as StreamTabId,
+    });
+
+    interactions.cancelForStream(
+      'stream-a' as StreamTabId,
+      'Stream resources released.',
+    );
+
+    await expect(resultPromise).resolves.toEqual({
+      accepted: false,
+      userMessage: 'Stream resources released.',
+    });
+    expect(handlers.bash.resolve).toHaveBeenCalled();
+  });
+
+  it('rejects a resolution whose kind does not match the pending request', async () => {
+    const handlers = createHandlers();
+    const interactions = createInteractions({ handlers });
+
+    const resultPromise = interactions.requestBashApproval?.({
+      command: 'echo hi',
+      streamId: 'stream-a' as StreamTabId,
+    });
+    const requestId = firstShowRequestId(
+      handlers.bash.show as ReturnType<typeof vi.fn>,
+    );
+
+    // A mismatched kind for the same requestId must not settle the pending
+    // bash approval as a plan action would (defends against a caller bug
+    // resolving the wrong pending kind under a reused/misrouted requestId).
+    expect(
+      interactions.resolve(requestId, { kind: 'plan', action: 'approve' }),
+    ).toBe(false);
+
+    // The correctly-kinded resolution still settles it.
+    expect(
+      interactions.resolve(requestId, { kind: 'bash', action: 'approve' }),
+    ).toBe(true);
+    await expect(resultPromise).resolves.toEqual({ accepted: true });
+  });
+
   it('shows external inquiries without waiting for a user decision', async () => {
     const runtimeHost = createRuntimeHost();
     const handlers = createHandlers();
@@ -185,7 +241,12 @@ describe('createExtensionHostInteractions', () => {
 
     interactions.cancelUnscoped?.('No stream owns this question.');
 
-    await expect(resultPromise).resolves.toEqual({ submitted: false });
+    // Cancellation forwards `cause` as agent-visible feedback, matching how
+    // a live UI rejection settles (see the desktop host, which does the same).
+    await expect(resultPromise).resolves.toEqual({
+      submitted: false,
+      feedback: 'No stream owns this question.',
+    });
     expect(handlers.userQuestion.resolve).toHaveBeenCalledWith('question-a');
     // The cancelled question was released: a later resolution finds nothing.
     expect(


### PR DESCRIPTION
## Summary

Fixes the concrete drift points from the 2026-07-07 audit between `packages/extension/src/progressView/extensionHostInteractions.ts` and `packages/desktop/src/main/desktopHostInteractions.ts`:

- **Kind check on resolve**: desktop now rejects a resolution whose `result.kind` does not match the pending request kind, matching the extension host's discriminant check.
- **Shared result vocabulary**: both hosts now use `src/agent/runtime/hostInteractionResultMappers.ts` for bash, plan, proposal, retry, and user-question results instead of maintaining duplicate inline mappers.
- **Proposal pass-through is explicit**: a `result.value` proposal object is trusted only for declared `ProposalResult` actions, including `timeout`; arbitrary `{ action: ... }` objects fall back to the resolution action and feedback.
- **Cancellation cause forwarding**: extension cancellation now routes through the same mappers as live resolution, forwarding the cause for bash, plan, proposal, and user-question results. Retry cancellation still resolves to `{ action: 'cancel' }`, because `RetryResult` has no feedback field on that variant.
- **Bash timeout preservation**: after #7492, the shared bash mapper preserves `{ action: 'timeout' }` as `timedOut: true`, keeping timeout distinct from explicit rejection.

The shared mapper deliberately follows the stricter extension semantics for bash and user-question fields: bash `userMessage` is attached to rejection only, feedback is trimmed, submit questions carry answers, and non-submit questions carry feedback. That keeps both hosts on one interpretation rather than preserving the older desktop-only permissive pass-through.

Scope is deliberately bounded: this PR does not change either host's pending-request bookkeeping map.

## Verification

- `corepack pnpm exec eslint src/agent/runtime/hostInteractionResultMappers.ts packages/extension/src/progressView/extensionHostInteractions.ts packages/desktop/src/main/desktopHostInteractions.ts src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts src/test-kernel/desktop/DesktopHostInteractions.vitest.mts && git diff --check`
- `CI=true corepack pnpm exec vitest run src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts src/test-kernel/desktop/DesktopHostInteractions.vitest.mts`
- `CI=true corepack pnpm exec vitest run src/test-kernel/desktop/DesktopAgentExecution.vitest.mts -t "routes runtime events to the window-local desktop backend" --testTimeout=30000`
- `CI=true corepack pnpm exec tsc --noEmit --pretty false`
- `CI=true corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`

Addresses #7447.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent-visible approval, rejection, timeout, and cancellation outcomes for both desktop and extension hosts; behavior is intentionally tightened in a few desktop edge cases, though scope stays in host interaction mapping with dedicated tests.
> 
> **Overview**
> Unifies how the **desktop** and **extension** `HostInteractions` implementations turn generic UI resolutions and cancellations into typed agent results, closing audit drift between the two hosts.
> 
> A new **`hostInteractionResultMappers`** module is the single place that maps `HostInteractionResolution` into bash, plan, proposal, retry, and user-question outcomes. Both hosts call these mappers for live **`resolve()`** and for synthesized rejections on **cancel/dispose**, so cancellation **`cause`** text reaches the agent the same way a UI rejection would (e.g. bash **`userMessage`**, plan/proposal **`feedback`**).
> 
> **Desktop** now rejects **`resolve()`** when **`result.kind`** does not match the pending request (matching extension), routes **`dispose()`** through **`cancelAll`** with a stable message instead of a special dispose resolution, and adopts the stricter shared rules for bash (**`userMessage`** only on reject; **`timeout`** → **`timedOut`**) and user questions (answers vs feedback tied to submit vs decline). **Extension** cancellation no longer ignores **`cause`**; it uses the same mappers as **`resolve()`**.
> 
> **Proposal** **`result.value`** pass-through is guarded: only objects whose **`action`** is a known **`ProposalResult`** action (including **`timeout`**) are trusted; otherwise mapping falls back to **`result.action`** / **`feedback`**.
> 
> Vitest coverage is added/extended for kind mismatches, cancellation cause forwarding, bash timeout, proposal whitelist behavior, and dispose.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76a6c450a1e1286b5fba4ee3a96f4d6a05a43985. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->