### PR TITLE
fix(runtime): align host interaction results

### DIFF
--- a/packages/desktop/src/main/desktopHostInteractions.ts
+++ b/packages/desktop/src/main/desktopHostInteractions.ts
@@ -12,11 +12,13 @@ import type {
 import type { PlanApprovalResult } from '@agent/runtime/PlanApprovalCoordinator';
 import type { ProposalResult } from '@agent/runtime/AgentProposalCoordinator';
 import type { RetryResult } from '@agent/runtime/RetryRequestCoordinator';
-import type {
-  AgentProposalPermission,
-  StreamTabId,
-  UserQuestionAnswers,
-} from '@shared/schemas';
+import {
+  toBashApprovalResult,
+  toPlanApprovalResult,
+  toProposalResult,
+  toUserQuestionResult,
+} from '@agent/runtime/hostInteractionResults';
+import type { AgentProposalPermission, StreamTabId } from '@shared/schemas';
 import type { ApprovalRequestHandlerSet } from '@shared/progressView/backend/progressBackendUiConfig';
 import type {
   ToolEditApprovalRequest,
@@ -157,26 +159,16 @@ class DesktopHostInteractions implements HostInteractions {
     }
 
     const request = this.pendingRequests.get(requestId);
-    if (!request) return false;
+    if (!request || request.kind !== result.kind) return false;
     this.pendingRequests.delete(requestId);
 
     switch (request.kind) {
       case 'bash':
-        request.settle({
-          accepted: result.action === 'approve',
-          ...(result.feedback ? { userMessage: result.feedback } : {}),
-        });
+        request.settle(toBashApprovalResult(result));
         this.options.getApprovalHandlers().bash.resolve(requestId);
         return true;
       case 'plan':
-        request.settle(
-          result.action === 'approve' || result.action === 'approve_and_goal'
-            ? { action: result.action }
-            : {
-                action: 'reject',
-                ...(result.feedback ? { feedback: result.feedback } : {}),
-              },
-        );
+        request.settle(toPlanApprovalResult(result));
         this.options.getApprovalHandlers().planApproval.resolve(requestId);
         return true;
       case 'proposal':
@@ -184,13 +176,7 @@ class DesktopHostInteractions implements HostInteractions {
         this.options.getApprovalHandlers().agentProposal.resolve(requestId);
         return true;
       case 'userQuestion':
-        request.settle({
-          submitted: result.action === 'submit',
-          ...(result.value
-            ? { answers: result.value as UserQuestionAnswers }
-            : {}),
-          ...(result.feedback ? { feedback: result.feedback } : {}),
-        });
+        request.settle(toUserQuestionResult(result));
         this.options.getApprovalHandlers().userQuestion.resolve(requestId);
         return true;
     }
@@ -223,13 +209,7 @@ class DesktopHostInteractions implements HostInteractions {
   }
 
   dispose(): void {
-    for (const requestId of [...this.pendingRequests.keys()]) {
-      this.resolve(requestId, {
-        kind: 'dispose',
-        action: 'reject',
-        feedback: 'Desktop session disposed.',
-      });
-    }
+    this.cancelAll('Desktop session disposed.');
   }
 
   private showPending<TResult, TEntry extends PendingDesktopInteraction>(
@@ -238,7 +218,8 @@ class DesktopHostInteractions implements HostInteractions {
     show: (settle: TEntry['settle']) => TEntry['settle'],
   ): Promise<TResult> {
     return new Promise<TResult>((resolve) => {
-      const settle = show((result) => resolve(result as TResult));
+      const settle = show(((result: unknown) =>
+        resolve(result as TResult)) as TEntry['settle']);
       this.pendingRequests.set(requestId, {
         ...entry,
         settle,
@@ -251,17 +232,4 @@ class DesktopHostInteractions implements HostInteractions {
     if (streamId)
       this.options.runtimeHost.emit('setActiveStream', { streamId });
   }
-}
-
-function toProposalResult(result: HostInteractionResolution): ProposalResult {
-  if (result.value && typeof result.value === 'object') {
-    const value = result.value as ProposalResult;
-    if ('action' in value) return value;
-  }
-  return result.action === 'approve' || result.action === 'setup'
-    ? { action: result.action }
-    : {
-        action: 'reject',
-        ...(result.feedback ? { feedback: result.feedback } : {}),
-      };
 }

--- a/packages/extension/src/progressView/extensionHostInteractions.ts
+++ b/packages/extension/src/progressView/extensionHostInteractions.ts
@@ -17,12 +17,15 @@ import type {
   ProgressEvent,
   ProgressEventPayloads,
 } from '@agent/runtime/hostProgressEvents';
+import {
+  toBashApprovalResult,
+  toPlanApprovalResult,
+  toProposalResult,
+  toRetryResult,
+  toUserQuestionResult,
+} from '@agent/runtime/hostInteractionResults';
 import { nativeRequestApproval } from '@frontend/approval/nativeToolEditApproval';
-import type {
-  AgentProposalPermission,
-  StreamTabId,
-  UserQuestionAnswers,
-} from '@shared/schemas';
+import type { AgentProposalPermission, StreamTabId } from '@shared/schemas';
 import type { ApprovalRequestHandlerSet } from '@shared/progressView/backend/progressBackendUiConfig';
 import type {
   ToolEditApprovalRequest,
@@ -101,28 +104,34 @@ export function createExtensionHostInteractions(
 
   const releasePending = (
     pending: PendingExtensionInteraction<PendingExtensionInteractionValue>,
+    cause?: string,
   ): void => {
+    const rejection = {
+      kind: pending.kind,
+      action: 'reject',
+      feedback: cause,
+    };
     pendingRequests.delete(pending.id);
     switch (pending.kind) {
       case 'bash':
         handlers().bash.resolve(pending.id);
-        pending.settle({ accepted: false });
+        pending.settle(toBashApprovalResult(rejection));
         break;
       case 'plan':
         handlers().planApproval.resolve(pending.id);
-        pending.settle({ action: 'reject' });
+        pending.settle(toPlanApprovalResult(rejection));
         break;
       case 'proposal':
         handlers().agentProposal.resolve(pending.id);
-        pending.settle({ action: 'reject' });
+        pending.settle(toProposalResult(rejection));
         break;
       case 'retry':
         handlers().retry.resolve(pending.id);
-        pending.settle({ action: 'cancel' });
+        pending.settle(toRetryResult({ ...rejection, action: 'cancel' }));
         break;
       case 'userQuestion':
         handlers().userQuestion.resolve(pending.id);
-        pending.settle({ submitted: false });
+        pending.settle(toUserQuestionResult(rejection));
         break;
     }
   };
@@ -230,13 +239,7 @@ export function createExtensionHostInteractions(
           return resolvePending<HostBashApprovalResult>(
             requestId,
             'bash',
-            {
-              accepted: result.action === 'approve',
-              userMessage:
-                result.action === 'reject'
-                  ? result.feedback?.trim()
-                  : undefined,
-            },
+            toBashApprovalResult(result),
             () => handlers().bash.resolve(requestId),
           );
         case 'plan':
@@ -257,24 +260,14 @@ export function createExtensionHostInteractions(
           return resolvePending<RetryResult>(
             requestId,
             'retry',
-            result.action === 'retry'
-              ? { action: 'retry', feedback: result.feedback }
-              : { action: 'cancel' },
+            toRetryResult(result),
             () => handlers().retry.resolve(requestId),
           );
         case 'userQuestion':
           return resolvePending<HostUserQuestionResult>(
             requestId,
             'userQuestion',
-            {
-              submitted: result.action === 'submit',
-              answers:
-                result.action === 'submit'
-                  ? (result.value as UserQuestionAnswers | undefined)
-                  : undefined,
-              feedback:
-                result.action === 'submit' ? undefined : result.feedback,
-            },
+            toUserQuestionResult(result),
             () => handlers().userQuestion.resolve(requestId),
           );
         case 'externalInquiry':
@@ -285,53 +278,32 @@ export function createExtensionHostInteractions(
       }
     },
 
-    cancelForStream(streamId: StreamTabId): void {
+    cancelForStream(streamId: StreamTabId, cause?: string): void {
       for (const pending of [...pendingRequests.values()]) {
         if (pending.streamId === streamId) {
-          releasePending(pending);
+          releasePending(pending, cause);
         }
       }
     },
 
     cancelUnscoped(cause?: string): void {
-      void cause;
       for (const pending of [...pendingRequests.values()]) {
         if (!pending.streamId) {
-          releasePending(pending);
+          releasePending(pending, cause);
         }
       }
     },
 
     cancelAll(cause?: string): void {
-      void cause;
       for (const pending of [...pendingRequests.values()]) {
-        releasePending(pending);
+        releasePending(pending, cause);
       }
     },
 
     dispose(): void {
       for (const pending of [...pendingRequests.values()]) {
-        releasePending(pending);
+        releasePending(pending, 'Extension session disposed.');
       }
     },
   };
-}
-
-function toPlanApprovalResult(
-  result: HostInteractionResolution,
-): PlanApprovalResult {
-  if (result.action === 'approve') return { action: 'approve' };
-  if (result.action === 'approve_and_goal')
-    return { action: 'approve_and_goal' };
-  return { action: 'reject', feedback: result.feedback };
-}
-
-function toProposalResult(result: HostInteractionResolution): ProposalResult {
-  const value = result.value as ProposalResult | undefined;
-  if (value?.action === 'approve') return value;
-  if (value?.action === 'setup') return value;
-  if (value?.action === 'reject') return value;
-  if (result.action === 'setup') return { action: 'setup' };
-  if (result.action === 'approve') return { action: 'approve' };
-  return { action: 'reject', feedback: result.feedback };
 }

--- a/src/agent/runtime/hostInteractionResults.ts
+++ b/src/agent/runtime/hostInteractionResults.ts
@@ -1,0 +1,74 @@
+import type { UserQuestionAnswers } from '@shared/schemas';
+
+import type {
+  HostBashApprovalResult,
+  HostInteractionResolution,
+  HostUserQuestionResult,
+} from './HostInteractions';
+import type { ProposalResult } from './AgentProposalCoordinator';
+import type { PlanApprovalResult } from './PlanApprovalCoordinator';
+import type { RetryResult } from './RetryRequestCoordinator';
+
+export function toBashApprovalResult(
+  result: HostInteractionResolution,
+): HostBashApprovalResult {
+  return {
+    accepted: result.action === 'approve',
+    ...(result.action === 'reject' && result.feedback
+      ? { userMessage: result.feedback }
+      : {}),
+  };
+}
+
+export function toPlanApprovalResult(
+  result: HostInteractionResolution,
+): PlanApprovalResult {
+  if (result.action === 'approve') return { action: 'approve' };
+  if (result.action === 'approve_and_goal') {
+    return { action: 'approve_and_goal' };
+  }
+  return {
+    action: 'reject',
+    ...(result.feedback ? { feedback: result.feedback } : {}),
+  };
+}
+
+export function toProposalResult(
+  result: HostInteractionResolution,
+): ProposalResult {
+  const value = result.value as ProposalResult | undefined;
+  if (value?.action === 'approve') return value;
+  if (value?.action === 'setup') return value;
+  if (value?.action === 'reject') return value;
+  if (result.action === 'setup') return { action: 'setup' };
+  if (result.action === 'approve') return { action: 'approve' };
+  return {
+    action: 'reject',
+    ...(result.feedback ? { feedback: result.feedback } : {}),
+  };
+}
+
+export function toRetryResult(result: HostInteractionResolution): RetryResult {
+  if (result.action === 'retry') {
+    return {
+      action: 'retry',
+      ...(result.feedback ? { feedback: result.feedback } : {}),
+    };
+  }
+  return { action: 'cancel' };
+}
+
+export function toUserQuestionResult(
+  result: HostInteractionResolution,
+): HostUserQuestionResult {
+  if (result.action === 'submit') {
+    return {
+      submitted: true,
+      ...(result.value ? { answers: result.value as UserQuestionAnswers } : {}),
+    };
+  }
+  return {
+    submitted: false,
+    ...(result.feedback ? { feedback: result.feedback } : {}),
+  };
+}

--- a/src/test-kernel/desktop/DesktopHostInteractions.vitest.mts
+++ b/src/test-kernel/desktop/DesktopHostInteractions.vitest.mts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { ProgressEventPayloads } from '@agent/runtime/hostProgressEvents';
+import { createDesktopHostInteractions } from '@desktop/main/desktopHostInteractions';
+import type { DesktopToolEditApprovalController } from '@desktop/main/desktopToolEditApproval';
+import { AgentCategory, type StreamTabId } from '@shared/schemas';
+import type { ApprovalRequestHandlerSet } from '@shared/progressView/backend/progressBackendUiConfig';
+
+interface RecordingApprovalHandler {
+  readonly show: ReturnType<typeof vi.fn>;
+  readonly resolve: ReturnType<typeof vi.fn>;
+  readonly replay: ReturnType<typeof vi.fn>;
+  readonly get: ReturnType<typeof vi.fn>;
+  readonly hasPendingForStream: ReturnType<typeof vi.fn>;
+  readonly releaseForStream: ReturnType<typeof vi.fn>;
+  readonly clear: ReturnType<typeof vi.fn>;
+  readonly pendingSize: number;
+}
+
+function handler(): RecordingApprovalHandler {
+  return {
+    show: vi.fn(),
+    resolve: vi.fn(),
+    replay: vi.fn(),
+    get: vi.fn(),
+    hasPendingForStream: vi.fn(() => false),
+    releaseForStream: vi.fn(),
+    clear: vi.fn(),
+    pendingSize: 0,
+  };
+}
+
+function createHandlers(): ApprovalRequestHandlerSet {
+  return {
+    toolEdit: handler(),
+    bash: handler(),
+    retry: handler(),
+    agentProposal: handler(),
+    planApproval: handler(),
+    externalInquiry: handler(),
+    userQuestion: handler(),
+  } as unknown as ApprovalRequestHandlerSet;
+}
+
+function createRuntimeHost(): AgentRuntimeHost {
+  return {
+    emit: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+    showErrorMessage: vi.fn(),
+    emitStatus: vi.fn(),
+    emitProgressEvent: vi.fn(),
+  } as unknown as AgentRuntimeHost;
+}
+
+function createToolEditApprovals(): DesktopToolEditApprovalController {
+  return {
+    requestApproval: vi.fn(),
+    handleAction: vi.fn(),
+    dispose: vi.fn(),
+  } as unknown as DesktopToolEditApprovalController;
+}
+
+describe('createDesktopHostInteractions', () => {
+  it('keeps pending requests unresolved when the resolution kind is wrong', async () => {
+    const handlers = createHandlers();
+    const interactions = createDesktopHostInteractions({
+      runtimeHost: createRuntimeHost(),
+      getApprovalHandlers: () => handlers,
+      getToolEditApprovals: () => createToolEditApprovals(),
+    });
+
+    const resultPromise = interactions.requestPlanApproval?.({
+      approvalId: 'plan-desktop',
+      streamId: 'stream-desktop' as StreamTabId,
+      goalEnabled: false,
+      plan: { objective: 'Align host interaction semantics.' },
+    });
+
+    expect(resultPromise).toBeDefined();
+    expect(
+      interactions.resolve('plan-desktop', {
+        kind: 'bash',
+        action: 'approve',
+      }),
+    ).toBe(false);
+    expect(handlers.planApproval.resolve).not.toHaveBeenCalled();
+
+    expect(
+      interactions.resolve('plan-desktop', {
+        kind: 'plan',
+        action: 'approve',
+      }),
+    ).toBe(true);
+    await expect(resultPromise).resolves.toEqual({ action: 'approve' });
+    expect(handlers.planApproval.resolve).toHaveBeenCalledWith('plan-desktop');
+  });
+
+  it('uses the shared proposal mapper instead of passing unknown actions through', async () => {
+    const handlers = createHandlers();
+    const interactions = createDesktopHostInteractions({
+      runtimeHost: createRuntimeHost(),
+      getApprovalHandlers: () => handlers,
+      getToolEditApprovals: () => createToolEditApprovals(),
+    });
+
+    const resultPromise = interactions.requestAgentProposal?.({
+      proposalId: 'proposal-desktop',
+      streamId: 'stream-desktop' as StreamTabId,
+      agent: 'assistant',
+      model: 'test-model',
+      instruction: 'Use an agent.',
+      memories: [],
+      agentCategory: AgentCategory.ToolUse,
+    });
+
+    expect(
+      interactions.resolve('proposal-desktop', {
+        kind: 'proposal',
+        action: 'reject',
+        feedback: 'Not now.',
+        value: { action: 'future-action' },
+      }),
+    ).toBe(true);
+
+    await expect(resultPromise).resolves.toEqual({
+      action: 'reject',
+      feedback: 'Not now.',
+    });
+  });
+});

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { createExtensionHostInteractions } from '@progressView/extensionHostInteractions';
-import type { OutputFileInfo, StreamTabId } from '@shared/schemas';
+import {
+  AgentCategory,
+  type OutputFileInfo,
+  type StreamTabId,
+} from '@shared/schemas';
 import type { ApprovalRequestHandlerSet } from '@shared/progressView/backend/progressBackendUiConfig';
 
 const mocks = vi.hoisted(() => ({
@@ -136,6 +140,57 @@ describe('createExtensionHostInteractions', () => {
     expect(handlers.retry.resolve).toHaveBeenCalledWith('stream-a');
   });
 
+  it('passes cancellation causes into stream-scoped approval results', async () => {
+    const handlers = createHandlers();
+    const interactions = createInteractions({ handlers });
+    const streamId = 'stream-cause' as StreamTabId;
+
+    const bash = interactions.requestBashApproval?.({
+      command: 'echo hi',
+      streamId,
+    });
+    const plan = interactions.requestPlanApproval?.({
+      approvalId: 'plan-cause',
+      streamId,
+      goalEnabled: false,
+      plan: { objective: 'Check cancellation feedback.' },
+    });
+    const proposal = interactions.requestAgentProposal?.({
+      proposalId: 'proposal-cause',
+      streamId,
+      agent: 'assistant',
+      model: 'test-model',
+      instruction: 'Use a helper agent.',
+      memories: [],
+      agentCategory: AgentCategory.ToolUse,
+    });
+    const question = interactions.askUserQuestion?.({
+      requestId: 'question-cause',
+      questions: [{ question: 'Continue?', options: [] }],
+      allowBypass: false,
+      streamId,
+    });
+
+    interactions.cancelForStream(streamId, 'Stream resources released.');
+
+    await expect(bash).resolves.toEqual({
+      accepted: false,
+      userMessage: 'Stream resources released.',
+    });
+    await expect(plan).resolves.toEqual({
+      action: 'reject',
+      feedback: 'Stream resources released.',
+    });
+    await expect(proposal).resolves.toEqual({
+      action: 'reject',
+      feedback: 'Stream resources released.',
+    });
+    await expect(question).resolves.toEqual({
+      submitted: false,
+      feedback: 'Stream resources released.',
+    });
+  });
+
   it('shows external inquiries without waiting for a user decision', async () => {
     const runtimeHost = createRuntimeHost();
     const handlers = createHandlers();
@@ -185,7 +240,10 @@ describe('createExtensionHostInteractions', () => {
 
     interactions.cancelUnscoped?.('No stream owns this question.');
 
-    await expect(resultPromise).resolves.toEqual({ submitted: false });
+    await expect(resultPromise).resolves.toEqual({
+      submitted: false,
+      feedback: 'No stream owns this question.',
+    });
     expect(handlers.userQuestion.resolve).toHaveBeenCalledWith('question-a');
     // The cancelled question was released: a later resolution finds nothing.
     expect(


### PR DESCRIPTION
## Root cause

The extension and desktop `HostInteractions` implementations had begun to diverge in how they converted UI replies into runtime results. Cancellation also lost its cause in the extension host, and desktop replies could settle a pending request even when the reply kind did not match the pending interaction kind.

## Fix

- Add a shared `hostInteractionResults` mapper for bash approvals, plan approvals, proposals, retry decisions, and user questions.
- Route both extension and desktop hosts through the shared mapper so invalid proposal actions and cancellation results are handled consistently.
- Preserve cancellation cause text in extension-host releases: bash receives `userMessage`, plan/proposal/user-question receive `feedback`, and retry stays a plain cancel result.
- Make the desktop host reject wrong-kind `resolve()` calls without deleting or settling the pending request.

## Verification

- `corepack pnpm exec eslint src/agent/runtime/hostInteractionResults.ts packages/extension/src/progressView/extensionHostInteractions.ts packages/desktop/src/main/desktopHostInteractions.ts src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts src/test-kernel/desktop/DesktopHostInteractions.vitest.mts && git diff --check`
- `CI=true corepack pnpm exec vitest run src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts src/test-kernel/desktop/DesktopHostInteractions.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `CI=true corepack pnpm exec tsc --noEmit --pretty false`
- `CI=true corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`

Addresses #7447.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches approval/cancellation paths in both hosts; behavior changes (kind-mismatch resolve, cancellation feedback) could affect agent runtime UX if callers assumed old semantics.
> 
> **Overview**
> Introduces shared **`hostInteractionResults`** mappers so desktop and extension hosts translate UI **`HostInteractionResolution`** values into runtime results the same way for bash, plan, proposal, retry, and user-question flows.
> 
> **Desktop** now refuses **`resolve()`** when the resolution **kind** does not match the pending request (leaves the promise open), routes all settles through the shared mappers, and **`dispose()`** uses **`cancelAll`** with a fixed message instead of a special-case reject kind.
> 
> **Extension** uses the same mappers for normal **`resolve()`** and for **`releasePending`** on cancel/dispose; **`cancelForStream`**, **`cancelUnscoped`**, and **`cancelAll`** forward optional **cause** text into results (e.g. bash **`userMessage`**, plan/proposal/question **`feedback`**, retry still **`cancel`**). Local duplicate mapper helpers are removed.
> 
> Vitest coverage adds desktop wrong-kind **`resolve`** and proposal mapping behavior, plus extension tests for cancellation causes on stream-scoped approvals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48b4cd10f33a9fd21da96c26668fa50e9c39dafa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->