### PR TITLE
refactor(storage): sidecar facade owns completed-run display/export; delete tool-use KV projections

### DIFF
--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -1,6 +1,7 @@
 import { cp, readFile, stat } from 'node:fs/promises';
 import * as path from 'node:path';
 
+import { readCompletedRunConversation } from '@transcript';
 import {
   deleteAllExecutions,
   deleteExecution,
@@ -137,7 +138,7 @@ export async function readCliHistoryDetails(
     config,
     resultMeta,
     report,
-    conversation,
+    conversationResult,
     persistedWorkspaceFilePaths,
     generatedFiles,
     resumability,
@@ -146,11 +147,14 @@ export async function readCliHistoryDetails(
     store.readConfig(),
     store.readResultMeta(),
     store.readReport(),
-    store.readConversation(),
+    // Transcript sidecar owns completed-run display (#7246 Decision 1); the
+    // facade keeps `conversation.json` as a read-only legacy fallback.
+    readCompletedRunConversation(id),
     store.readWorkspaceFiles(),
     listGeneratedFiles(id),
     deriveResumability(id),
   ]);
+  const conversation = conversationResult.conversation;
   const resumeData =
     resumability.resumable && config
       ? await readCliToolUseResumeDataForListing(id, config)

--- a/src/agent/export/loadChatExportInput.ts
+++ b/src/agent/export/loadChatExportInput.ts
@@ -2,7 +2,7 @@
  * Host-neutral loader for a stored execution's chat export input.
  *
  * Both the CLI (`texra history show <id> --export`) and the extension's
- * Settings "Export chat" action need to read the same execution-store triple
+ * Settings "Export chat" action need to read the same execution triple
  * (config, conversation, meta) and assemble the same format-agnostic
  * {@link ChatExportInput} the html/markdown/LaTeX formatters consume, so the
  * two hosts render a stored conversation identically. This module is the
@@ -12,6 +12,11 @@
  * `ChatExportController.buildExportInput` in
  * `src/controllers/settingsView/ChatExportController.ts`).
  *
+ * The conversation comes from the completed-run archive facade
+ * (`readCompletedRunConversation`): the transcript sidecar owns completed-run
+ * display/export per #7246 Decision 1, with the legacy
+ * `executions/{id}/conversation.json` projection as a read-only fallback.
+ *
  * `store.readConfig()` already validates against `AgentConfigSchema`
  * internally and falls back to `null` on a schema mismatch (see the private
  * `readValidated` helper on `StorageFSKVStore` in `ExecutionKVStore.ts`), so
@@ -19,6 +24,7 @@
  * (and no risk of it throwing on a corrupt record) is needed.
  */
 
+import { readCompletedRunConversation } from '@transcript';
 import { getExecutionStore, type ExecutionMeta } from '@agent/storage';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { ChatExportInput } from '@agent/export/schemas';
@@ -42,16 +48,16 @@ export interface ChatExportLoadResult {
 
 /**
  * A stored conversation is only "present" when it has at least one message.
- * `ExecutionKVStore.readConversation()` already normalizes an empty stored
- * array to `null` at the store layer, so this check is defensive rather than
- * the primary fix — but it keeps the "non-empty array only" contract
- * explicit for this module's callers (and for tests, which mock the store
- * directly and can return `[]` without going through that normalization).
- * Without it, a plain truthiness check (`!conversation`) would treat `[]` as
- * "present" — `![]` is `false` in JS — and every existence check downstream
- * (this module's `exportInput`, and each host's own not-found/incomplete
- * classification) would disagree with `readCliHistoryDetails`, which builds
- * no preview from an empty array either.
+ * The archive facade already normalizes an empty read to `null`, so this
+ * check is defensive rather than the primary fix — but it keeps the
+ * "non-empty array only" contract explicit for this module's callers (and
+ * for tests, which mock the facade directly and can return `[]` without
+ * going through that normalization). Without it, a plain truthiness check
+ * (`!conversation`) would treat `[]` as "present" — `![]` is `false` in JS —
+ * and every existence check downstream (this module's `exportInput`, and
+ * each host's own not-found/incomplete classification) would disagree with
+ * `readCliHistoryDetails`, which builds no preview from an empty array
+ * either.
  */
 function hasConversationMessages(
   conversation: readonly unknown[] | null,
@@ -63,13 +69,13 @@ export async function loadChatExportInput(
   id: ExecutionId,
 ): Promise<ChatExportLoadResult> {
   const store = getExecutionStore(id);
-  const [config, rawConversation, meta] = await Promise.all([
+  const [config, conversationResult, meta] = await Promise.all([
     store.readConfig(),
-    store.readConversation(),
+    readCompletedRunConversation(id),
     store.readMeta(),
   ]);
-  const conversation = hasConversationMessages(rawConversation)
-    ? rawConversation
+  const conversation = hasConversationMessages(conversationResult.conversation)
+    ? conversationResult.conversation
     : null;
 
   if (!config || !conversation) {

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -381,10 +381,11 @@ export async function runToolUseFlow<C = unknown>(
     const pf: ToolUsePersistedFlow<C> = new PersistedFlow(prepareNode, kv);
     activePersistedFlow = pf;
     pf.setServices(services);
+    // Note: the flow record is the resume SSOT and the transcript sidecar
+    // owns completed-run display/export (#7246 Decision 1) — the old
+    // per-step `conversation.json`/`todos.json` projections are gone.
+    // Live-run todos still persist event-driven via `persistTodos` above.
     pf.setProjection(async (s, store) => {
-      const todos = s.stateSlices?.workspaceSnapshot?.workPlan?.todos;
-      if (Array.isArray(todos) && todos.length) await store.writeTodos(todos);
-      if (s.messages.length) await store.writeConversation(s.messages);
       const currentTouchedFiles = extractTouchedFiles(s.stateSlices);
       if (currentTouchedFiles.length) {
         await store.writeWorkspaceFiles(currentTouchedFiles);

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -195,6 +195,8 @@ export interface ExecutionKVStore {
    */
   todosModifiedAt(): Promise<number | undefined>;
   readConversation(): Promise<unknown[] | null>;
+  /** Same freshness accessor as {@link todosModifiedAt}, for `conversation.json`. */
+  conversationModifiedAt(): Promise<number | undefined>;
   readWorkspaceFiles(): Promise<string[]>;
   readChildren(): Promise<ChildRecord[]>;
   readResultMeta(): Promise<ResultMeta | null>;
@@ -285,6 +287,10 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
   async readConversation(): Promise<unknown[] | null> {
     const raw = await this.read<unknown[]>(KEYS.CONVERSATION);
     return Array.isArray(raw) && raw.length > 0 ? raw : null;
+  }
+
+  async conversationModifiedAt(): Promise<number | undefined> {
+    return this.modifiedAt(KEYS.CONVERSATION);
   }
 
   async readWorkspaceFiles(): Promise<string[]> {

--- a/src/test-kernel/support/FakeExecutionKVStore.ts
+++ b/src/test-kernel/support/FakeExecutionKVStore.ts
@@ -21,6 +21,7 @@ export function createFakeKv(executionId = 'test-exec-0001'): ExecutionKVStore {
     readTodos: async () => [],
     todosModifiedAt: async () => undefined,
     readConversation: async () => null,
+    conversationModifiedAt: async () => undefined,
     readWorkspaceFiles: async () => [],
     readChildren: async () => [],
     readResultMeta: async () => null,

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -1,0 +1,317 @@
+/**
+ * Completed-run archive facade (#7246 Decision 1): the transcript sidecars
+ * own completed-run display/export, with `executions/{id}/conversation.json`
+ * / `todos.json` as read-only legacy fallbacks.
+ *
+ * Cross-module scenario (stated in the PR body): the fixture below builds a
+ * real completed execution on disk with ONLY sidecar data — no
+ * `conversation.json` / `todos.json` projections, matching what tool-use
+ * runs persist now that the per-step projection writes are deleted — and
+ * proves conversation display, chat export, and todos all read through the
+ * facade.
+ */
+import { mkdtemp, readdir, rm, utimes } from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { MemoryStateStore } from '@platform/defaults/memoryState';
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
+import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
+import { createFakePlatform } from '@test/support/FakePlatform';
+import { setupPlatform } from '@test/support/setupPlatform';
+import {
+  readCompletedRunConversation,
+  readCompletedRunTodos,
+  StreamLogStore,
+  StreamSnapshotStore,
+} from '@transcript';
+import { clearStoreCache, getExecutionStore } from '@agent/storage';
+import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
+import { TaskStateSchema, type TaskState } from '@agent/core/state/TaskState';
+import { loadChatExportInput } from '@agent/export/loadChatExportInput';
+import {
+  LOG_LEVELS,
+  MESSAGE_TYPES,
+  STREAM_LOG_ENTRY_TYPES,
+  type ExecutionId,
+  type StreamTabId,
+} from '@shared/schemas';
+import { AgentCategory } from '@shared/schemas/agent';
+import type { Platform } from '@platform/platform';
+
+const tempDirs: string[] = [];
+
+async function buildArchivePlatform(): Promise<Platform> {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'texra-archive-'));
+  tempDirs.push(tempDir);
+  const workspaceDir = path.join(tempDir, 'workspace');
+  const storageRoot = path.join(tempDir, 'storage');
+  return createFakePlatform(
+    { workspacePath: workspaceDir },
+    {
+      fs: nodeFilesystem,
+      workspace: createNodeWorkspace(() => workspaceDir),
+      storage: new WorkspaceStorageProvider(storageRoot, workspaceDir),
+      globalState: new MemoryStateStore(),
+      workspaceState: new MemoryStateStore(),
+    },
+  );
+}
+
+function taskState(agent: string, model = 'deepseekproT'): TaskState {
+  return TaskStateSchema.parse({
+    agentConfig: { agent, model, agentCategory: AgentCategory.ToolUse },
+  });
+}
+
+let entryCounter = 0;
+
+function logRow(
+  messageType: string,
+  fields: { text?: string; data?: unknown },
+): Parameters<StreamLogStore['append']>[1] {
+  entryCounter += 1;
+  return {
+    id: `entry-${entryCounter}`,
+    type: STREAM_LOG_ENTRY_TYPES.LOG,
+    level: LOG_LEVELS.INFO,
+    timestamp: 1000 + entryCounter,
+    messageType: messageType as never,
+    ...fields,
+  };
+}
+
+/** Write the sidecar fixture: transcript rows + snapshot meta/todos. */
+async function writeSidecarFixture(
+  executionId: ExecutionId,
+  streamId: StreamTabId,
+): Promise<void> {
+  const snapshots = new StreamSnapshotStore();
+  snapshots.setTaskState(streamId, taskState('orchestrator'), executionId);
+  snapshots.setTodos(streamId, [
+    { content: 'Fix the bug', status: 'completed', activeForm: 'Fixing' },
+  ]);
+  await snapshots.flush();
+
+  const logs = new StreamLogStore();
+  await logs.load();
+  logs.ensureStream(streamId);
+  logs.append(
+    streamId,
+    logRow(MESSAGE_TYPES.USER_MESSAGE, {
+      text: 'Fix the lemma.',
+    }),
+  );
+  logs.append(
+    streamId,
+    logRow(MESSAGE_TYPES.TOOL_USE, {
+      data: {
+        toolName: 'write_file',
+        input: { path: 'notes/lemma.tex' },
+        output: 'File written.',
+        status: 'completed',
+      },
+    }),
+  );
+  logs.append(
+    streamId,
+    logRow(MESSAGE_TYPES.MODEL_RESPONSE, {
+      text: 'Done - the lemma is fixed.',
+    }),
+  );
+  await logs.flush();
+}
+
+/** Locate a file under `dir` by name (recursive), for mtime manipulation. */
+async function findFile(dir: string, name: string): Promise<string> {
+  const entries = await readdir(dir, { withFileTypes: true, recursive: true });
+  const match = entries.find((entry) => entry.isFile() && entry.name === name);
+  if (!match) throw new Error(`Fixture file not found: ${name}`);
+  return path.join(match.parentPath, match.name);
+}
+
+async function setMtime(filePath: string, epochMs: number): Promise<void> {
+  await utimes(filePath, new Date(epochMs), new Date(epochMs));
+}
+
+describe('completedRunArchive facade', () => {
+  setupPlatform(buildArchivePlatform);
+
+  beforeEach(() => {
+    clearStoreCache();
+  });
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs
+        .splice(0)
+        .map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it('serves conversation, chat export, and todos from the sidecars alone (projections gone)', async () => {
+    const executionId = 'abc123abc123' as ExecutionId;
+    const streamId = 'orchestrator@deepseekproT#abc123abc123' as StreamTabId;
+    await writeSidecarFixture(executionId, streamId);
+
+    const store = getExecutionStore(executionId);
+    await store.writeConfig(
+      AgentConfigSchema.parse({
+        agent: 'orchestrator',
+        model: 'deepseekproT',
+        agentCategory: AgentCategory.ToolUse,
+        instruction: 'Fix the lemma.',
+      }),
+    );
+    await store.writeMeta({
+      timestamp: '2026-07-07T00:00:00.000Z',
+      terminalStatus: 'completed',
+    });
+
+    const conversationResult = await readCompletedRunConversation(executionId);
+    expect(conversationResult.source).toBe('streamLog');
+    expect(conversationResult.streamId).toBe(streamId);
+    expect(conversationResult.conversation).toEqual([
+      { role: 'user', content: 'Fix the lemma.' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            name: 'write_file',
+            input: { path: 'notes/lemma.tex' },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'tool_result', content: 'File written.' }],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Done - the lemma is fixed.' }],
+      },
+    ]);
+
+    // Chat export assembles from the same facade read — no conversation.json.
+    const exportResult = await loadChatExportInput(executionId);
+    expect(exportResult.exportInput).not.toBeNull();
+    expect(exportResult.exportInput?.messages).toEqual(
+      conversationResult.conversation,
+    );
+
+    const todosResult = await readCompletedRunTodos(executionId);
+    expect(todosResult.source).toBe('streamData');
+    expect(todosResult.todos).toEqual([
+      { content: 'Fix the bug', status: 'completed' },
+    ]);
+  });
+
+  it('falls back to the legacy KV projections when no sidecar exists', async () => {
+    const executionId = 'bbb222bbb222' as ExecutionId;
+    const store = getExecutionStore(executionId);
+    await store.writeConversation([
+      { role: 'user', content: 'Legacy question' },
+      { role: 'assistant', content: 'Legacy answer' },
+    ]);
+    await store.writeTodos([{ content: 'Legacy todo', status: 'pending' }]);
+
+    const conversationResult = await readCompletedRunConversation(executionId);
+    expect(conversationResult.source).toBe('legacyKV');
+    expect(conversationResult.conversation).toEqual([
+      { role: 'user', content: 'Legacy question' },
+      { role: 'assistant', content: 'Legacy answer' },
+    ]);
+
+    const todosResult = await readCompletedRunTodos(executionId);
+    expect(todosResult.source).toBe('legacyKV');
+    expect(todosResult.todos).toEqual([
+      { content: 'Legacy todo', status: 'pending' },
+    ]);
+  });
+
+  it('reports none when neither the sidecar nor the legacy projection has data', async () => {
+    const executionId = 'ccc333ccc333' as ExecutionId;
+
+    const conversationResult = await readCompletedRunConversation(executionId);
+    expect(conversationResult).toEqual({ conversation: null, source: 'none' });
+
+    const todosResult = await readCompletedRunTodos(executionId);
+    expect(todosResult).toEqual({ todos: [], source: 'none' });
+  });
+
+  it('prefers a demonstrably fresher legacy conversation write over the sidecar', async () => {
+    const executionId = 'ddd444ddd444' as ExecutionId;
+    const streamId = 'orchestrator@deepseekproT#ddd444ddd444' as StreamTabId;
+    await writeSidecarFixture(executionId, streamId);
+    await getExecutionStore(executionId).writeConversation([
+      { role: 'assistant', content: 'Fresher legacy write' },
+    ]);
+
+    const storageDir = tempDirs.at(-1)!;
+    const legacyPath = await findFile(storageDir, 'conversation.json');
+    const sidecarPath = await findFile(
+      path.dirname(await findFile(storageDir, 'workPlan.json')),
+      'meta.json',
+    );
+    // streamLogs/{stream}.json lives beside the streamData dir; find it by
+    // its encoded name under the streamLogs directory.
+    const streamLogsDir = path.join(
+      path.dirname(path.dirname(path.dirname(sidecarPath))),
+      'streamLogs',
+    );
+    const [streamLogFile] = await readdir(streamLogsDir);
+    const streamLogPath = path.join(streamLogsDir, streamLogFile);
+
+    // Legacy write is strictly fresher than the sidecar -> legacy wins.
+    await setMtime(streamLogPath, Date.now() - 60_000);
+    await setMtime(legacyPath, Date.now());
+
+    const fresher = await readCompletedRunConversation(executionId);
+    expect(fresher.source).toBe('legacyKV');
+    expect(fresher.conversation).toEqual([
+      { role: 'assistant', content: 'Fresher legacy write' },
+    ]);
+
+    // Sidecar strictly fresher -> sidecar wins.
+    await setMtime(legacyPath, Date.now() - 120_000);
+    await setMtime(streamLogPath, Date.now());
+    const sidecarWins = await readCompletedRunConversation(executionId);
+    expect(sidecarWins.source).toBe('streamLog');
+  });
+
+  it('falls back to legacy when the transcript holds no conversation-shaped rows', async () => {
+    const executionId = 'eee555eee555' as ExecutionId;
+    const streamId = 'orchestrator@deepseekproT#eee555eee555' as StreamTabId;
+
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setTaskState(streamId, taskState('orchestrator'), executionId);
+    await snapshots.flush();
+
+    const logs = new StreamLogStore();
+    await logs.load();
+    logs.ensureStream(streamId);
+    logs.append(
+      streamId,
+      logRow(MESSAGE_TYPES.PROGRESS_STATUS, { text: 'Working...' }),
+    );
+    await logs.flush();
+
+    await getExecutionStore(executionId).writeConversation([
+      { role: 'user', content: 'Pre-sidecar conversation' },
+    ]);
+    // The sidecar exists and is fresher, but reconstructs to zero messages —
+    // the facade must not report an empty conversation over real legacy data.
+    const legacyPath = await findFile(tempDirs.at(-1)!, 'conversation.json');
+    await setMtime(legacyPath, Date.now() - 60_000);
+
+    const result = await readCompletedRunConversation(executionId);
+    expect(result.source).toBe('legacyKV');
+    expect(result.conversation).toEqual([
+      { role: 'user', content: 'Pre-sidecar conversation' },
+    ]);
+  });
+});

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -107,6 +107,35 @@ async function writeSidecarFixture(
   );
   logs.append(
     streamId,
+    logRow(MESSAGE_TYPES.THINKING, {
+      text: 'Consider the boundary terms.',
+    }),
+  );
+  logs.append(
+    streamId,
+    logRow(MESSAGE_TYPES.WEB_SEARCH, {
+      data: {
+        query: 'sobolev constant',
+        results: [{ url: 'https://example.org/a', title: 'Sobolev notes' }],
+        provider: 'anthropic',
+        status: 'completed',
+      },
+    }),
+  );
+  logs.append(
+    streamId,
+    logRow(MESSAGE_TYPES.WEB_FETCH, {
+      data: {
+        url: 'https://example.org/a',
+        title: 'Sobolev notes',
+        provider: 'anthropic',
+        callId: 'wf-1',
+        status: 'completed',
+      },
+    }),
+  );
+  logs.append(
+    streamId,
     logRow(MESSAGE_TYPES.TOOL_USE, {
       data: {
         toolName: 'write_file',
@@ -114,6 +143,15 @@ async function writeSidecarFixture(
         output: 'File written.',
         status: 'completed',
       },
+    }),
+  );
+  // Diagnostic row: deliberately skipped by the mapper (never lived in the
+  // legacy conversation.json projection either).
+  logs.append(
+    streamId,
+    logRow(MESSAGE_TYPES.STATISTICS, {
+      text: 'Usage - input: 10, output: 5',
+      data: { inputTokens: 10, outputTokens: 5 },
     }),
   );
   logs.append(
@@ -176,6 +214,42 @@ describe('completedRunArchive facade', () => {
     expect(conversationResult.streamId).toBe(streamId);
     expect(conversationResult.conversation).toEqual([
       { role: 'user', content: 'Fix the lemma.' },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'Consider the boundary terms.' },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'server_tool_use',
+            name: 'web_search',
+            input: { query: 'sobolev constant' },
+          },
+          {
+            type: 'web_search_tool_result',
+            content: [
+              {
+                type: 'web_search_result',
+                url: 'https://example.org/a',
+                title: 'Sobolev notes',
+              },
+            ],
+          },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'web_fetch_tool_result',
+            url: 'https://example.org/a',
+            title: 'Sobolev notes',
+          },
+        ],
+      },
       {
         role: 'assistant',
         content: [

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -9,7 +9,10 @@
 import { z } from 'zod';
 
 import { platform } from '@platform/platform';
-import { readCompletedRunTodos } from '@transcript';
+import {
+  readCompletedRunConversation,
+  readCompletedRunTodos,
+} from '@transcript';
 
 // Local imports - agent
 import {
@@ -445,10 +448,7 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
       store.readMeta(),
       store.readConfig(),
       store.readChildren(),
-      readCompletedRunTodos(executionId, {
-        legacyFallback: () => store.readTodos(),
-        legacyModifiedAt: () => store.todosModifiedAt(),
-      }),
+      readCompletedRunTodos(executionId),
       store.readReport(),
     ]);
 
@@ -682,12 +682,7 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
     const store = getExecutionStore(executionId);
     const todos = handle
       ? await store.readTodos()
-      : (
-          await readCompletedRunTodos(executionId, {
-            legacyFallback: () => store.readTodos(),
-            legacyModifiedAt: () => store.todosModifiedAt(),
-          })
-        ).todos;
+      : (await readCompletedRunTodos(executionId)).todos;
 
     if (todos.length === 0) {
       return {
@@ -768,7 +763,7 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
     viewRange?: number[],
   ): Promise<ToolResult> {
     const store = getExecutionStore(executionId);
-    const conversation = await store.readConversation();
+    const { conversation } = await readCompletedRunConversation(executionId);
 
     if (!conversation) {
       // Match the top-level execution lookup: a flow-only record is found only

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -16,6 +16,8 @@ import {
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
   ToolUseLogSchema,
+  WebFetchPayloadSchema,
+  WebSearchPayloadSchema,
   type ExecutionId,
   type StreamLogEntry,
   type StreamTabId,
@@ -23,6 +25,7 @@ import {
   type ToolUseLog,
 } from '@shared/schemas';
 import { StorageFS } from '@utils/files';
+import { assertNever } from '@utils/core/typeGuards';
 
 import { resolvePersistedStreamIdForExecution } from './executionStreamResolver';
 import { STREAM_DATA_KEYS, streamDataDir } from './streamDataPaths';
@@ -154,62 +157,158 @@ function toolResultText(tool: ToolUseLog): string | undefined {
   return tool.summary;
 }
 
+function userMessageEntryToMessages(entry: StreamLogEntry): unknown[] {
+  return entry.text ? [{ role: 'user', content: entry.text }] : [];
+}
+
+function modelResponseEntryToMessages(entry: StreamLogEntry): unknown[] {
+  if (!entry.text?.trim()) return [];
+  return [{ role: 'assistant', content: [{ type: 'text', text: entry.text }] }];
+}
+
+function thinkingEntryToMessages(entry: StreamLogEntry): unknown[] {
+  if (!entry.text?.trim()) return [];
+  return [
+    {
+      role: 'assistant',
+      content: [{ type: 'thinking', thinking: entry.text }],
+    },
+  ];
+}
+
+function toolUseEntryToMessages(entry: StreamLogEntry): unknown[] {
+  const parsed = ToolUseLogSchema.safeParse(entry.data);
+  if (!parsed.success) return [];
+  const tool = parsed.data;
+  const messages: unknown[] = [
+    {
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool_use',
+          name: tool.toolName ?? 'unknown',
+          input: tool.input ?? {},
+        },
+      ],
+    },
+  ];
+  const resultText = toolResultText(tool);
+  if (resultText !== undefined) {
+    messages.push({
+      role: 'user',
+      content: [{ type: 'tool_result', content: resultText }],
+    });
+  }
+  return messages;
+}
+
+/** Anthropic-shaped `server_tool_use` + `web_search_tool_result` blocks. */
+function webSearchEntryToMessages(entry: StreamLogEntry): unknown[] {
+  const parsed = WebSearchPayloadSchema.safeParse(entry.data);
+  if (!parsed.success) return [];
+  const blocks: unknown[] = [];
+  if (parsed.data.query) {
+    blocks.push({
+      type: 'server_tool_use',
+      name: 'web_search',
+      input: { query: parsed.data.query },
+    });
+  }
+  const results = (parsed.data.results ?? [])
+    .filter((result) => result.url)
+    .map((result) => ({
+      type: 'web_search_result',
+      url: result.url,
+      title: result.title ?? result.url,
+    }));
+  if (results.length > 0) {
+    blocks.push({ type: 'web_search_tool_result', content: results });
+  }
+  return blocks.length > 0 ? [{ role: 'assistant', content: blocks }] : [];
+}
+
+function webFetchEntryToMessages(entry: StreamLogEntry): unknown[] {
+  const parsed = WebFetchPayloadSchema.safeParse(entry.data);
+  if (!parsed.success || !parsed.data.url) return [];
+  return [
+    {
+      role: 'assistant',
+      content: [
+        {
+          type: 'web_fetch_tool_result',
+          url: parsed.data.url,
+          ...(parsed.data.title !== undefined && { title: parsed.data.title }),
+        },
+      ],
+    },
+  ];
+}
+
+/**
+ * Map one transcript row to conversation messages. Exhaustive over the
+ * {@link MessageType} union — the transcript is the single completed-run
+ * record, so every entry kind must carry an explicit map-or-skip decision
+ * here; adding a new `MessageType` without deciding fails to compile
+ * (`assertNever`), instead of silently dropping conversation content.
+ */
+function conversationMessagesForEntry(entry: StreamLogEntry): unknown[] {
+  const { messageType } = entry;
+  if (messageType === undefined) return [];
+  switch (messageType) {
+    // ── Conversation content ────────────────────────────────────────────
+    case MESSAGE_TYPES.USER_MESSAGE:
+      return userMessageEntryToMessages(entry);
+    case MESSAGE_TYPES.MODEL_RESPONSE:
+      return modelResponseEntryToMessages(entry);
+    case MESSAGE_TYPES.THINKING:
+      return thinkingEntryToMessages(entry);
+    case MESSAGE_TYPES.TOOL_USE:
+      return toolUseEntryToMessages(entry);
+    case MESSAGE_TYPES.WEB_SEARCH:
+      return webSearchEntryToMessages(entry);
+    case MESSAGE_TYPES.WEB_FETCH:
+      return webFetchEntryToMessages(entry);
+    // ── Deliberately skipped: not conversation content ──────────────────
+    // scratchpad is a derived view carved from the modelResponse raw text
+    // (already mapped above); the rest are run diagnostics/status rows that
+    // the legacy conversation.json projection never contained either.
+    case MESSAGE_TYPES.SCRATCHPAD:
+    case MESSAGE_TYPES.FILE_LIST:
+    case MESSAGE_TYPES.MISSING_OUTPUTS:
+    case MESSAGE_TYPES.LATEXDIFF:
+    case MESSAGE_TYPES.STATISTICS:
+    case MESSAGE_TYPES.PROGRESS_STATUS:
+    case MESSAGE_TYPES.ERROR:
+    case MESSAGE_TYPES.INTERNAL:
+    case MESSAGE_TYPES.CONTEXT_MANAGEMENT:
+    case MESSAGE_TYPES.CONTEXT_STATE:
+    case MESSAGE_TYPES.DEFAULT:
+      return [];
+    default:
+      return assertNever(
+        messageType,
+        `Unmapped stream-log messageType: ${String(messageType)}`,
+      );
+  }
+}
+
 /**
  * Reconstruct a provider-agnostic conversation from persisted transcript
- * rows. Uses the Anthropic-style content-block vocabulary
- * (`text`/`tool_use`/`tool_result`) that every existing conversation
- * consumer (`@agent/storage/conversationFormat`, the chat-export
- * normalizer, the CLI workspace-file extractor) already recognizes, so
- * downstream rendering code needs no new shape.
+ * rows. Uses the Anthropic-style content-block vocabulary (`text`,
+ * `thinking`, `tool_use`/`tool_result`, `server_tool_use`,
+ * `web_search_tool_result`, `web_fetch_tool_result`) that every existing
+ * conversation consumer (`@agent/storage/conversationFormat`, the
+ * chat-export normalizer, the CLI workspace-file extractor) already
+ * recognizes, so downstream rendering code needs no new shape.
  */
 export function streamLogEntriesToConversation(
   entries: readonly StreamLogEntry[],
 ): unknown[] {
-  const messages: unknown[] = [];
-  for (const entry of entries) {
-    if (entry.type !== STREAM_LOG_ENTRY_TYPES.LOG) continue;
-    switch (entry.messageType) {
-      case MESSAGE_TYPES.USER_MESSAGE: {
-        if (entry.text) messages.push({ role: 'user', content: entry.text });
-        break;
-      }
-      case MESSAGE_TYPES.MODEL_RESPONSE: {
-        if (entry.text?.trim()) {
-          messages.push({
-            role: 'assistant',
-            content: [{ type: 'text', text: entry.text }],
-          });
-        }
-        break;
-      }
-      case MESSAGE_TYPES.TOOL_USE: {
-        const parsed = ToolUseLogSchema.safeParse(entry.data);
-        if (!parsed.success) break;
-        const tool = parsed.data;
-        messages.push({
-          role: 'assistant',
-          content: [
-            {
-              type: 'tool_use',
-              name: tool.toolName ?? 'unknown',
-              input: tool.input ?? {},
-            },
-          ],
-        });
-        const resultText = toolResultText(tool);
-        if (resultText !== undefined) {
-          messages.push({
-            role: 'user',
-            content: [{ type: 'tool_result', content: resultText }],
-          });
-        }
-        break;
-      }
-      default:
-        break;
-    }
-  }
-  return messages;
+  return entries.flatMap((entry) =>
+    entry.type === STREAM_LOG_ENTRY_TYPES.LOG
+      ? conversationMessagesForEntry(entry)
+      : [],
+  );
 }
 
 async function readLegacyConversation(

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -1,10 +1,32 @@
-import type { TodoEntry } from '@agent/storage';
+/**
+ * Completed-run archive reads (#7246 Decision 1): once a run finishes, its
+ * durable display/export data is owned by the transcript sidecars
+ * (`streamLogs/{stream}.json` + `streamData/{stream}/*`), keyed through the
+ * execution→stream mapping. The legacy `executions/{id}/conversation.json` /
+ * `todos.json` KV projections are READ-ONLY fallbacks for runs recorded
+ * before the sidecars existed (or written by builds that still project them)
+ * — each fact keeps exactly ONE legacy read arm, here, tracked for D3
+ * retirement in the #6981 ledger.
+ */
+import { getExecutionStore, type TodoEntry } from '@agent/storage';
+import { stringifyConversationValue } from '@agent/storage/conversationFormat';
 import { isFileNotFoundError } from '@common/errors';
-import type { ExecutionId, StreamTabId, TodoItem } from '@shared/schemas';
+import { KVStore } from '@common/storage/KVStore';
+import {
+  MESSAGE_TYPES,
+  STREAM_LOG_ENTRY_TYPES,
+  ToolUseLogSchema,
+  type ExecutionId,
+  type StreamLogEntry,
+  type StreamTabId,
+  type TodoItem,
+  type ToolUseLog,
+} from '@shared/schemas';
 import { StorageFS } from '@utils/files';
 
 import { resolvePersistedStreamIdForExecution } from './executionStreamResolver';
 import { STREAM_DATA_KEYS, streamDataDir } from './streamDataPaths';
+import { StreamLogStore, STREAM_LOGS_DIR } from './StreamLogStore';
 import { StreamSnapshotStore } from './StreamSnapshotStore';
 
 export type CompletedRunTodosSource = 'streamData' | 'legacyKV' | 'none';
@@ -15,20 +37,8 @@ export interface CompletedRunTodosReadResult {
   readonly streamId?: StreamTabId;
 }
 
-export interface CompletedRunTodosReaderOptions {
+export interface CompletedRunReaderOptions {
   readonly snapshotStore?: StreamSnapshotStore;
-  readonly legacyFallback?: () => Promise<readonly TodoEntry[]>;
-  /**
-   * Last-modified time (ms since epoch) of the legacy `todos.json`, if it
-   * exists. Used to detect a final `todo_write` that landed after the
-   * sidecar's own (asynchronous) write flushed, so the fresher source wins
-   * regardless of which one happens to exist. Millisecond-resolution mtimes
-   * (the VS Code filesystem adapter's granularity) can tie when both writes
-   * land in the same tick; ties are broken toward the legacy write, since a
-   * genuinely later legacy write is the more likely cause of a tie than a
-   * genuinely later sidecar write racing to complete in the same millisecond.
-   */
-  readonly legacyModifiedAt?: () => Promise<number | undefined>;
 }
 
 function todoItemToEntry(todo: TodoItem): TodoEntry {
@@ -55,12 +65,12 @@ async function sidecarModifiedAt(
 }
 
 async function readLegacyTodos(
-  fallback: (() => Promise<readonly TodoEntry[]>) | undefined,
+  executionId: ExecutionId,
 ): Promise<CompletedRunTodosReadResult> {
-  if (!fallback) return { todos: [], source: 'none' };
+  const todos = await getExecutionStore(executionId).readTodos();
   return {
-    todos: [...(await fallback())],
-    source: 'legacyKV',
+    todos,
+    source: todos.length > 0 ? 'legacyKV' : 'none',
   };
 }
 
@@ -71,26 +81,32 @@ async function readLegacyTodos(
  * or when the legacy write is demonstrably fresher than the sidecar (a final
  * `todo_write` can land before the snapshot store's asynchronous sidecar
  * write has flushed).
+ *
+ * Freshness detail: millisecond-resolution mtimes (the VS Code filesystem
+ * adapter's granularity) can tie when both writes land in the same tick;
+ * ties are broken toward the legacy write, since a genuinely later legacy
+ * write is the more likely cause of a tie than a genuinely later sidecar
+ * write racing to complete in the same millisecond.
  */
 export async function readCompletedRunTodos(
   executionId: ExecutionId,
-  options: CompletedRunTodosReaderOptions = {},
+  options: CompletedRunReaderOptions = {},
 ): Promise<CompletedRunTodosReadResult> {
   const snapshotStore = options.snapshotStore ?? new StreamSnapshotStore();
   const resolved = await resolvePersistedStreamIdForExecution(executionId, {
     snapshotStore,
   });
 
-  if (!resolved) return readLegacyTodos(options.legacyFallback);
+  if (!resolved) return readLegacyTodos(executionId);
 
   const sidecarMtime = await sidecarModifiedAt(resolved.streamId);
   if (sidecarMtime === undefined) {
-    return readLegacyTodos(options.legacyFallback);
+    return readLegacyTodos(executionId);
   }
 
-  const legacyMtime = await options.legacyModifiedAt?.();
+  const legacyMtime = await getExecutionStore(executionId).todosModifiedAt();
   if (legacyMtime !== undefined && legacyMtime >= sidecarMtime) {
-    return readLegacyTodos(options.legacyFallback);
+    return readLegacyTodos(executionId);
   }
 
   const snapshot = await snapshotStore.read(resolved.streamId);
@@ -99,4 +115,154 @@ export async function readCompletedRunTodos(
     source: 'streamData',
     streamId: resolved.streamId,
   };
+}
+
+// ============================================================================
+// Conversation
+// ============================================================================
+
+export type CompletedRunConversationSource = 'streamLog' | 'legacyKV' | 'none';
+
+export interface CompletedRunConversationReadResult {
+  /** Provider-agnostic `{role, content}` messages, or `null` when neither
+   *  source holds any conversation data. */
+  readonly conversation: unknown[] | null;
+  readonly source: CompletedRunConversationSource;
+  readonly streamId?: StreamTabId;
+}
+
+export interface CompletedRunConversationReaderOptions extends CompletedRunReaderOptions {
+  /**
+   * An already-`load()`ed store. When omitted a call-scoped instance is
+   * created and loaded — never pass the shared live store un-loaded, since
+   * `load()` clears a store's in-memory state (see `assembleTrace`).
+   */
+  readonly streamLogStore?: StreamLogStore;
+}
+
+/** `streamLogs/{stream}.json` mtime (ms since epoch), or `undefined` if absent. */
+function streamLogModifiedAt(
+  streamId: StreamTabId,
+): Promise<number | undefined> {
+  return new KVStore(STREAM_LOGS_DIR).modifiedAt(streamId);
+}
+
+function toolResultText(tool: ToolUseLog): string | undefined {
+  if (tool.error !== undefined) return tool.error;
+  if (typeof tool.output === 'string') return tool.output;
+  if (tool.output !== undefined) return stringifyConversationValue(tool.output);
+  return tool.summary;
+}
+
+/**
+ * Reconstruct a provider-agnostic conversation from persisted transcript
+ * rows. Uses the Anthropic-style content-block vocabulary
+ * (`text`/`tool_use`/`tool_result`) that every existing conversation
+ * consumer (`@agent/storage/conversationFormat`, the chat-export
+ * normalizer, the CLI workspace-file extractor) already recognizes, so
+ * downstream rendering code needs no new shape.
+ */
+export function streamLogEntriesToConversation(
+  entries: readonly StreamLogEntry[],
+): unknown[] {
+  const messages: unknown[] = [];
+  for (const entry of entries) {
+    if (entry.type !== STREAM_LOG_ENTRY_TYPES.LOG) continue;
+    switch (entry.messageType) {
+      case MESSAGE_TYPES.USER_MESSAGE: {
+        if (entry.text) messages.push({ role: 'user', content: entry.text });
+        break;
+      }
+      case MESSAGE_TYPES.MODEL_RESPONSE: {
+        if (entry.text?.trim()) {
+          messages.push({
+            role: 'assistant',
+            content: [{ type: 'text', text: entry.text }],
+          });
+        }
+        break;
+      }
+      case MESSAGE_TYPES.TOOL_USE: {
+        const parsed = ToolUseLogSchema.safeParse(entry.data);
+        if (!parsed.success) break;
+        const tool = parsed.data;
+        messages.push({
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              name: tool.toolName ?? 'unknown',
+              input: tool.input ?? {},
+            },
+          ],
+        });
+        const resultText = toolResultText(tool);
+        if (resultText !== undefined) {
+          messages.push({
+            role: 'user',
+            content: [{ type: 'tool_result', content: resultText }],
+          });
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+  return messages;
+}
+
+async function readLegacyConversation(
+  executionId: ExecutionId,
+): Promise<CompletedRunConversationReadResult> {
+  const conversation = await getExecutionStore(executionId).readConversation();
+  return {
+    conversation,
+    source: conversation ? 'legacyKV' : 'none',
+  };
+}
+
+/**
+ * Read the archived conversation for a completed run from the transcript
+ * sidecar (`streamLogs/{stream}.json`), reconstructed into provider-agnostic
+ * messages. Falls back to the legacy `executions/{id}/conversation.json`
+ * projection when the run predates the sidecars, when the transcript holds
+ * no conversation-shaped rows (pre-`messageType` legacy streams), or when
+ * the legacy write is fresher than the sidecar — the same mtime arbitration
+ * (ties toward legacy) as {@link readCompletedRunTodos}.
+ */
+export async function readCompletedRunConversation(
+  executionId: ExecutionId,
+  options: CompletedRunConversationReaderOptions = {},
+): Promise<CompletedRunConversationReadResult> {
+  const snapshotStore = options.snapshotStore ?? new StreamSnapshotStore();
+  let streamLogStore = options.streamLogStore;
+  if (!streamLogStore) {
+    // Call-scoped instance, same rationale as assembleTrace: load() clears a
+    // store's in-memory state, so the shared live store must never be
+    // re-loaded from a read path.
+    streamLogStore = new StreamLogStore();
+    await streamLogStore.load();
+  }
+
+  const resolved = await resolvePersistedStreamIdForExecution(executionId, {
+    snapshotStore,
+    streamLogStore,
+  });
+  if (!resolved) return readLegacyConversation(executionId);
+
+  const sidecarMtime = await streamLogModifiedAt(resolved.streamId);
+  if (sidecarMtime === undefined) return readLegacyConversation(executionId);
+
+  const legacyMtime =
+    await getExecutionStore(executionId).conversationModifiedAt();
+  if (legacyMtime !== undefined && legacyMtime >= sidecarMtime) {
+    return readLegacyConversation(executionId);
+  }
+
+  await streamLogStore.ensureLoaded(resolved.streamId);
+  const log = streamLogStore.get(resolved.streamId);
+  const conversation = log ? streamLogEntriesToConversation(log.toJSON()) : [];
+  if (conversation.length === 0) return readLegacyConversation(executionId);
+  return { conversation, source: 'streamLog', streamId: resolved.streamId };
 }

--- a/src/transcript/index.ts
+++ b/src/transcript/index.ts
@@ -32,7 +32,11 @@ export {
   type TraceDocument,
 } from './traceAssembler';
 export {
+  readCompletedRunConversation,
   readCompletedRunTodos,
+  streamLogEntriesToConversation,
+  type CompletedRunConversationReadResult,
+  type CompletedRunConversationSource,
   type CompletedRunTodosReadResult,
   type CompletedRunTodosSource,
 } from './completedRunArchive';


### PR DESCRIPTION
Part of #6966 (task bullet 2). Implements #7246 **Decision 1** (recorded): flow records stay resume-only; the transcript sidecars (`streamLogs/` + `streamData/`) own completed-run display/export; `executions/{id}/conversation.json` / `todos.json` become dated READ-ONLY legacy fallbacks.

## What changed

**Readers repointed to the archive facade** (`src/transcript/completedRunArchive.ts`):
- `readCompletedRunConversation()` (new): resolves the execution→stream mapping (`resolvePersistedStreamIdForExecution`), reconstructs provider-agnostic `{role, content}` messages from persisted transcript rows (`userMessage` / `modelResponse` / `toolUse` rows → Anthropic-style `text`/`tool_use`/`tool_result` blocks that every existing consumer — `conversationFormat`, the export normalizer, the CLI workspace-file extractor — already recognizes), and applies the same mtime arbitration as the todos reader (ties toward legacy, per the c9baa0d3a rationale).
- `packages/cli/src/runtime/history.ts` (`readCliHistoryDetails` previews / full transcript / workspace-file extraction), `src/agent/export/loadChatExportInput.ts` (markdown/LaTeX chat export, shared CLI+extension), and `src/tools/ExecutionsTool.ts` `/executions/{id}/conversation` now read through the facade. The `/executions` todos paths (already facade-routed by #7292) lose their per-call-site legacy lambdas.

**Projection dual-write deleted** (`runToolUseFlow.ts`): the per-step `writeTodos` / `writeConversation` projection writes are gone — the tool-use per-step dual-write this bullet targets. Live-run todos still persist event-driven via `persistTodos` (todo_write), and the workspace-files projection is unchanged. The reflection (workflow) flow's conversation projection is out of this lane's scope and still writes; the facade's freshness arbitration covers it.

**ONE legacy read arm per fact** (§15 L5, decide-once precedence owner): the facade internally owns the only `readConversation()` / `readTodos()` fallback reads; no caller touches the projections directly anymore. `ExecutionKVStore` gains `conversationModifiedAt()` (mirror of `todosModifiedAt`) for the freshness comparison.

## #6981 ledger expectation

- **Row:** `executions/{id}/conversation.json` + `todos.json` legacy read fallback (the `readLegacy*` arms in `completedRunArchive.ts`, plus `ExecutionKVStore.readConversation/readTodos/*ModifiedAt`). **Trigger:** age-based, the 2026-08-04 D3 window recorded on #6984 — pre-sidecar runs age out; retiring the conversation arm also requires deleting the reflection flow's remaining conversation projection (follow-up, not this lane).

## §14 net-element accounting

- `git diff --stat origin/main`: **9 files, +556 / −56** (net +500; the new regression suite is +317 of that, so production net is **+183**).
- Exported symbols: +5 (`readCompletedRunConversation`, `streamLogEntriesToConversation`, `CompletedRunConversationSource`, `CompletedRunConversationReadResult`, `CompletedRunConversationReaderOptions`); 1 renamed/shrunk (`CompletedRunTodosReaderOptions` → `CompletedRunReaderOptions`, dropping the `legacyFallback`/`legacyModifiedAt` injection fields); +1 interface method (`conversationModifiedAt`).
- Deleted in the same PR (build-implies-delete, §13): the two per-step projection writes, all three direct `readConversation()` reader call sites, and both per-call-site legacy-todos option lambdas.
- Positive net is the cost of a new owned read surface (transcript→conversation reconstruction) landing together with its write-path deletion; this is a data-ownership correctness migration, not a reduction PR.

## Tests

New suite `src/test-kernel/transcript/completedRunArchive.vitest.ts` (module had none; includes the cross-module live check): a real on-disk completed-execution fixture with ONLY sidecar data — projections absent, exactly what tool-use runs now persist — proves conversation display, chat export (`loadChatExportInput`), and todos all read correctly through the facade; plus legacy-only fallback, neither-source, fresher-legacy mtime arbitration (both directions), and no-conversation-shaped-rows fallback.

## Notes

- Stage 3c bullet 4 (shared `repairAfterRestart`) is NOT here: `desktopAgentExecution.ts`'s ~270-LoC restart-repair block (~:724-994) is deliberately untouched — bullet 4 will LIFT it to the shared owner; extraction happens there, not as a desktop file split.
- Verified: root/test-kernel/cli/extension/desktop `tsc` clean; `vitest` green on `src/test-kernel/transcript/`, `src/test-kernel/agent/storage/`, `src/test-kernel/agent/export/`, executions-tool suites, and the CLI history suites (201 tests / 21 files on the branch head).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Mapper coverage (cursor finding, addressed in `c746db77f`)

`streamLogEntriesToConversation` is now **exhaustive over the `MessageType` union** (`conversationMessagesForEntry` switches over every member with an explicit map-or-skip decision and an `assertNever` default — a new entry kind fails to compile instead of silently dropping conversation content, same guard pattern as #7505).

- **Mapped (conversation content):** `userMessage`, `modelResponse`, `thinking` (as `{type:'thinking'}` blocks), `toolUse` (`tool_use` + `tool_result`), `webSearch` (`server_tool_use` + `web_search_tool_result`), `webFetch` (`web_fetch_tool_result`). Emission verified: web search/fetch results reach the stream log via `emitServerToolResult` / `logWebFetch` (disabled only for internal helper-model calls, `helperModel.ts:40`).
- **Explicit skips (never in `conversation.json` either):** `scratchpad` (derived view of the `modelResponse` raw text), `fileList`, `missingOutputs`, `latexdiff`, `statistics`, `progressStatus`, `error`, `internal`, `contextManagement`, `contextState`, `default`.
- **Named gap (content that never reaches the stream log today):** user-message media **attachment markers**, web-fetch **page content**, and **tool-result media** exist only in provider messages; the legacy fallback still covers pre-existing runs. Follow-up scoped to emitting them into the log at the source (protocol completion, not a `conversation.json` revival): #7508.
- Fixture extended with thinking / web-search / web-fetch rows plus a skipped `statistics` row to pin the mapping.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This changes where completed-run conversation and todos come from for history, export, and the executions tool; wrong sidecar mapping or reconstruction could show stale or incomplete transcripts, though legacy KV fallback and mtime rules limit blast radius.
> 
> **Overview**
> Implements **#7246 Decision 1**: finished runs are shown and exported from **transcript sidecars** (`streamLogs/` + `streamData/`), not from per-step KV mirrors. **`readCompletedRunConversation`** (new) maps stream-log rows into the same `{role, content}` shape existing formatters expect, with **mtime arbitration** vs read-only **`conversation.json`** (ties favor legacy, matching todos).
> 
> **Readers** now go through the facade: CLI history details, **`loadChatExportInput`** (CLI + extension export), and **`ExecutionsTool`** conversation/todos. **`readCompletedRunTodos`** no longer takes per-call-site legacy fallback lambdas; legacy reads live only inside **`completedRunArchive`**. **`ExecutionKVStore`** adds **`conversationModifiedAt()`** for freshness checks.
> 
> **Writes**: tool-use **`runToolUseFlow`** stops projecting **`conversation.json`** / **`todos.json`** each persisted-flow step (workspace-files projection and event-driven **`persistTodos`** on **`todo_write`** stay). Flow records remain resume SSOT.
> 
> Regression coverage in **`completedRunArchive.vitest.ts`**: sidecar-only runs, legacy-only, empty sources, mtime precedence, and empty sidecar reconstruction falling back to legacy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c746db77f5a5fed67c1e64fe50509d9d4a708c64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
