### PR TITLE
fix(agents): drop retired documentTag/endTag from reference-agents YAML

### DIFF
--- a/reference-agents/apply.yaml
+++ b/reference-agents/apply.yaml
@@ -3,8 +3,6 @@ description: Implements suggestions from review agents (criticize, enhance, logi
 
 settings:
   agentCategory: workflow
-  documentTag: documents
-  endTag: </documents>
   outputExt: tex
 
 prompts:

--- a/reference-agents/criticize.yaml
+++ b/reference-agents/criticize.yaml
@@ -3,8 +3,6 @@ description: Critical reviewer for mathematical physics papers. Inserts inline c
 
 settings:
   agentCategory: workflow
-  documentTag: documents
-  endTag: </documents>
   outputExt: tex
 
 prompts:

--- a/reference-agents/devise.yaml
+++ b/reference-agents/devise.yaml
@@ -3,8 +3,6 @@ description: Mathematical paper enhancer with two-phase workflow. Rewrites docum
 
 settings:
   agentCategory: workflow
-  documentTag: documents
-  endTag: </documents>
   outputExt: tex
 
 prompts:

--- a/reference-agents/elevate.yaml
+++ b/reference-agents/elevate.yaml
@@ -3,8 +3,6 @@ description: Two-phase writing strategist that elevates academic papers for publ
 
 settings:
   agentCategory: workflow
-  documentTag: documents
-  endTag: </documents>
   outputExt: tex
 
 prompts:

--- a/reference-agents/enhance.yaml
+++ b/reference-agents/enhance.yaml
@@ -4,8 +4,6 @@ description: Mathematical substance enhancer for research papers. Identifies ele
 settings:
   agentCategory: workflow
   rounds: 2
-  documentTag: documents
-  endTag: </documents>
   outputExt: tex
 
 prompts:

--- a/reference-agents/firstread.yaml
+++ b/reference-agents/firstread.yaml
@@ -3,8 +3,6 @@ description: First-read pass --- naive linear physicist reading the paper top-to
 
 settings:
   agentCategory: workflow
-  documentTag: documents
-  endTag: </documents>
   rounds: 2
 
 prompts:

--- a/reference-agents/generic.yaml
+++ b/reference-agents/generic.yaml
@@ -3,8 +3,6 @@ description: General-purpose LaTeX document editor. Flexibly processes research 
 
 settings:
   agentCategory: workflow
-  documentTag: documents
-  endTag: </documents>
   outputExt: tex
 
 prompts:

--- a/reference-agents/humanize.yaml
+++ b/reference-agents/humanize.yaml
@@ -3,8 +3,6 @@ description: Removes LLM stylistic tells from research prose. Phase 1 annotates 
 
 settings:
   agentCategory: workflow
-  documentTag: documents
-  endTag: </documents>
   outputExt: tex
 
 prompts:

--- a/reference-agents/logic.yaml
+++ b/reference-agents/logic.yaml
@@ -3,8 +3,6 @@ description: Logical flow analyzer for research papers. Improves argument struct
 
 settings:
   agentCategory: workflow
-  documentTag: documents
-  endTag: </documents>
   outputExt: tex
 
 prompts:

--- a/reference-agents/notation.yaml
+++ b/reference-agents/notation.yaml
@@ -3,8 +3,6 @@ description: Notation consistency checker for research papers. Ensures consisten
 
 settings:
   agentCategory: workflow
-  documentTag: documents
-  endTag: </documents>
   outputExt: tex
 
 prompts:

--- a/reference-agents/verifyFix.yaml
+++ b/reference-agents/verifyFix.yaml
@@ -4,8 +4,6 @@ description: Three-phase verification and fix agent for research papers. Expands
 settings:
   agentCategory: workflow
   rounds: 3
-  documentTag: documents
-  endTag: </documents>
   outputExt: tex
 
 prompts:

--- a/src/test-kernel/agent/AgentSettingSchema.vitest.ts
+++ b/src/test-kernel/agent/AgentSettingSchema.vitest.ts
@@ -1,4 +1,9 @@
-import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it, vi } from 'vitest';
+import * as yaml from 'yaml';
 
 import {
   AgentCategory,
@@ -7,6 +12,11 @@ import {
   AgentSettingSchema,
 } from '@agent/core/definition/AgentDataclass';
 import { mergeInheritedAgentObject } from '@agent/core/definition/agentDefinitionInheritance';
+
+const REPO_ROOT = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../..',
+);
 
 describe('AgentSettingSchema', () => {
   it('strips legacy workflow outputExt without exposing it in settings', () => {
@@ -29,6 +39,31 @@ describe('AgentSettingSchema', () => {
     expect(setting.agentCategory).toBe(AgentCategory.Workflow);
     expect(Object.hasOwn(setting, 'documentTag')).toBe(false);
     expect(Object.hasOwn(setting, 'endTag')).toBe(false);
+  });
+
+  it('regression #7497: shipped reference-agents YAML no longer carries documentTag/endTag', () => {
+    // The retired keys used to be copy-pasted into every reference agent, so
+    // parsing the bundle at startup fired the deprecation console.warn 4-8x
+    // on every launch. Assert both the absence of the keys and the silent
+    // parse, so a re-added key fails loudly here instead of in users' stderr.
+    const dir = resolve(REPO_ROOT, 'reference-agents');
+    const files = readdirSync(dir).filter((name) => name.endsWith('.yaml'));
+    expect(files.length).toBeGreaterThan(0);
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    let callCountAfterParsing: number;
+    try {
+      for (const file of files) {
+        const raw = yaml.parse(readFileSync(resolve(dir, file), 'utf8'));
+        AgentDefinitionSchema.parse(raw);
+      }
+    } finally {
+      // Read the call count before mockRestore(), which clears .mock.calls
+      // (it implies mockReset()) — asserting after restore would always pass.
+      callCountAfterParsing = warnSpy.mock.calls.length;
+      warnSpy.mockRestore();
+    }
+    expect(callCountAfterParsing).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Root cause

`stripLegacySettingFields` (`src/agent/core/definition/AgentDataclass.ts:58`) drops the retired `documentTag`/`endTag` agent-setting keys during YAML parsing and `console.warn`s when it sees them — every bundled and custom agent has converged on the fixed `<documents><document name="..."></documents>` output container, so the fields are dead weight. The warning is meant to flag genuine *custom* agent YAML that still relies on a bespoke tag (#7356, ledgered D3).

The problem: all 11 `reference-agents/*.yaml` files (`generic`, `notation`, `enhance`, `verifyFix`, `apply`, `humanize`, `firstread`, `logic`, `criticize`, `elevate`, `devise`) still carried both keys — a copy-paste holdover from before the output container was unified. Since these ship as the default remote agent bundle, the deprecation warning fired 4-8x above the TUI header on every `texra chat` launch (and 8x in headless stderr), polluting scrollback on every session.

## Fix

Deleted the two dead `documentTag`/`endTag` lines from all 11 `reference-agents/*.yaml` files. Grepped `packages/extension/resources/agents` for the same pattern — already clean, no changes needed there.

Did not add the optional "warn once per source" de-dup from the issue: the root cause (shipped YAML) is now fixed, so the warning only fires for genuine custom-agent YAML going forward, which is exactly the signal it's meant to provide — adding dedup logic on top would be unrequested scope beyond the minimal fix.

## Regression test

Added a test to `src/test-kernel/agent/AgentSettingSchema.vitest.ts` that reads every shipped `reference-agents/*.yaml`, parses it through the real `AgentDefinitionSchema` (same path `agentLoad.ts` uses at runtime), and asserts `console.warn` is never called. Verified the test actually catches the regression: reverted the YAML fix locally and confirmed the test fails (`expected 11 to be +0`, one warn per file), then restored the fix and confirmed it passes.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint src/test-kernel/agent/AgentSettingSchema.vitest.ts` — clean
- `npx prettier --check src/test-kernel/agent/AgentSettingSchema.vitest.ts reference-agents/*.yaml` — clean
- `npx vitest run src/test-kernel/agent/AgentSettingSchema.vitest.ts` — 8/8 passed
- `npx vitest run src/test-kernel/agent` (broader sweep) — 1100/1104 passed, 4 pre-existing skips, 0 failures
- Manually confirmed via `git stash`/`git stash pop` that the new regression test fails against the old (unfixed) YAML and passes against the fix

Fixes #7497.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML-only cleanup of ignored legacy keys plus a test; no runtime behavior change beyond silencing false-positive deprecation warnings on default agents.
> 
> **Overview**
> Removes obsolete **`documentTag`** and **`endTag`** settings from all **11** shipped **`reference-agents/*.yaml`** workflow agents. Those keys are stripped at parse time and trigger **`console.warn`** deprecation noise even though every agent now uses the fixed **`<documents><document name="...">`** output protocol.
> 
> Adds a regression test in **`AgentSettingSchema.vitest.ts`** that loads each bundled reference agent through **`AgentDefinitionSchema`** (same path as runtime) and asserts **`console.warn`** is never called, so re-adding the keys fails in CI instead of on every **`texra chat`** launch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e06cd4045e57e1fd16dee0ba24f09f75900bd80c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->