### PR TITLE
fix(cli): widen the Esc-chord defer window to cover WAITING children

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -101,7 +101,14 @@ const APPROVAL_FOREGROUND_MAX_ROWS = 18;
 // conversation or push the input bar off-screen.
 const BOTTOM_PANEL_MAX_ROWS = 10;
 const COMPACT_STATIC_TRANSCRIPT_MAX_ROWS = 14;
-const ESC_META_CHORD_INTERRUPT_DELAY_MS = 125;
+// A bare Esc and the second key of an `Esc s` / `Esc p` chord are two
+// separate keystrokes on terminals without true Meta-key detection (macOS
+// Terminal.app). 125ms was too tight for a deliberate but unhurried chord
+// (issue #7496: a ~400ms pause between Esc and `s` fired the bare-Esc
+// interrupt and stopped a suspended WAITING subagent); widen to a
+// tmux-style chord window so a human-paced chord still resolves before we
+// commit to interrupting.
+const ESC_META_CHORD_INTERRUPT_DELAY_MS = 500;
 const COMPACT_LIVE_TRANSCRIPT_RESERVE_ROWS = 2;
 
 const PINNED_CHROME_ROWS = {
@@ -367,19 +374,25 @@ export function appEscapeInterruptActive({
   );
 }
 
+// The footer advertises `[Esc s]subagents` / `[Esc p]tasks` any time these
+// controls are available, regardless of which stream is currently focused
+// or whether it's still in-flight (e.g. WAITING). Bare Esc must therefore
+// give a chord a chance to resolve any time that binding is on screen —
+// gating on the focused child's own input-disabled state (as this used to)
+// left the WAITING-child case with no defer window at all, so a slow
+// `Esc s` fired an immediate interrupt instead. `Alt`-chord platforms are
+// unaffected: their Esc+key sequences arrive as one burst, resolved
+// synchronously by `metaChordInput`.
 export function shouldDeferEscapeInterruptForMetaChord({
-  childInputDisabled,
   shortcutModifierLabel,
   subagentControlsAvailable,
   taskControlsAvailable,
 }: {
-  readonly childInputDisabled: boolean;
   readonly shortcutModifierLabel: string;
   readonly subagentControlsAvailable: boolean;
   readonly taskControlsAvailable: boolean;
 }): boolean {
   return (
-    childInputDisabled &&
     shortcutModifierLabel === 'Esc' &&
     (subagentControlsAvailable || taskControlsAvailable)
   );
@@ -967,7 +980,6 @@ export function App(props: AppProps): React.JSX.Element {
     ) {
       if (
         shouldDeferEscapeInterruptForMetaChord({
-          childInputDisabled: childInputDisabledMessage !== undefined,
           shortcutModifierLabel: defaultShortcutModifierLabel(),
           subagentControlsAvailable,
           taskControlsAvailable,

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -853,10 +853,15 @@ describe('CLI TUI row allocation', () => {
     ).toBe(false);
   });
 
-  it('defers Escape interrupt only when stopped child Esc chords are visible', () => {
+  it('defers Escape interrupt whenever an Esc chord binding is visible', () => {
+    // #7496 regression: the footer advertises `[Esc s]`/`[Esc p]` whenever
+    // these controls are available, independent of the focused stream's own
+    // status — including a focused child that is still WAITING (in-flight,
+    // so its own input is NOT disabled). Deferring only for a disabled-input
+    // child left WAITING children with no chord grace window at all, so a
+    // slow `Esc s` fired an immediate interrupt and stopped the subagent.
     expect(
       shouldDeferEscapeInterruptForMetaChord({
-        childInputDisabled: true,
         shortcutModifierLabel: 'Esc',
         subagentControlsAvailable: true,
         taskControlsAvailable: false,
@@ -864,7 +869,6 @@ describe('CLI TUI row allocation', () => {
     ).toBe(true);
     expect(
       shouldDeferEscapeInterruptForMetaChord({
-        childInputDisabled: true,
         shortcutModifierLabel: 'Esc',
         subagentControlsAvailable: false,
         taskControlsAvailable: true,
@@ -872,15 +876,6 @@ describe('CLI TUI row allocation', () => {
     ).toBe(true);
     expect(
       shouldDeferEscapeInterruptForMetaChord({
-        childInputDisabled: false,
-        shortcutModifierLabel: 'Esc',
-        subagentControlsAvailable: true,
-        taskControlsAvailable: false,
-      }),
-    ).toBe(false);
-    expect(
-      shouldDeferEscapeInterruptForMetaChord({
-        childInputDisabled: true,
         shortcutModifierLabel: 'Alt',
         subagentControlsAvailable: true,
         taskControlsAvailable: false,
@@ -888,12 +883,29 @@ describe('CLI TUI row allocation', () => {
     ).toBe(false);
     expect(
       shouldDeferEscapeInterruptForMetaChord({
-        childInputDisabled: true,
         shortcutModifierLabel: 'Esc',
         subagentControlsAvailable: false,
         taskControlsAvailable: false,
       }),
     ).toBe(false);
+
+    // The exact reported repro: a focused child is WAITING (in-flight), so
+    // its own input is not disabled, yet the chord still must be deferred.
+    setParentStream(child1, root);
+    expect(
+      focusedChildInputDisabledMessage({
+        activeStreamId: child1,
+        parentStream: parentStream.get(),
+        status: STREAM_STATUS.WAITING,
+      }),
+    ).toBeUndefined();
+    expect(
+      shouldDeferEscapeInterruptForMetaChord({
+        shortcutModifierLabel: 'Esc',
+        subagentControlsAvailable: true,
+        taskControlsAvailable: false,
+      }),
+    ).toBe(true);
   });
 
   it('parses stripped meta shortcut digits', () => {


### PR DESCRIPTION
## Root cause

The CLI TUI footer advertises `[Esc s]subagents` / `[Esc p]tasks` whenever
those controls are available (`subagentControlsAvailable || taskControlsAvailable`),
independent of which stream is focused or its status. On macOS (where the
chord modifier defaults to `Esc` rather than `Alt`), a bare Esc and the
second key of that chord arrive as **two separate keystrokes** — there's
no true Meta-key detection in most terminals — so the TUI needs a short
grace window before committing bare Esc to an interrupt.

That grace window (`shouldDeferEscapeInterruptForMetaChord` +
`scheduleEscapeInterrupt`, added in #5854) only activated when the
*focused child's own input was disabled* (i.e. the child had already gone
terminal). A focused child that is `WAITING` is still in-flight, so its
input is **not** disabled — `focusedChildInputDisabledMessage` returns
`undefined` for it — and the defer condition never fired. Bare Esc on a
WAITING child therefore committed to `triggerEscapeInterrupt` **immediately**,
with zero grace period for the second key of a deliberate `Esc s` chord to
arrive.

Sending `Esc` then a ~400ms-delayed `s` (a perfectly normal human chord
pace) fired the bare-Esc interrupt, stopping the suspended WAITING
subagent and closing its group, instead of opening the subagents panel.
125ms (the window's old value, which *did* apply in the terminal-child
case) was also too tight for that pace.

## Fix

`packages/cli/src/chat/tui/App.tsx`:

- `shouldDeferEscapeInterruptForMetaChord` now defers whenever the chord
  binding is actually on screen (`shortcutModifierLabel === 'Esc' &&
  (subagentControlsAvailable || taskControlsAvailable)`), matching exactly
  what the footer advertises, instead of gating on the focused child's own
  disabled-input state. `Alt`-chord platforms are unaffected — those
  sequences arrive as one burst and resolve synchronously via
  `metaChordInput`, never touching this timer path.
- Widened `ESC_META_CHORD_INTERRUPT_DELAY_MS` from 125ms to 500ms (a
  tmux-style chord window) so a human-paced two-key chord reliably
  resolves before Esc commits to an interrupt.

No new abstractions — this reuses the existing defer/timer machinery from
#5854, just corrects and generalizes its gating condition and widens the
window.

## Verification

- `npx tsc --noEmit` — clean
- `npx tsc --noEmit -p tsconfig.test-kernel.json` — clean
- `(cd packages/cli && npx tsc --noEmit -p tsconfig.json)` — clean
- `npx eslint packages/cli/src/chat/tui/App.tsx src/test-kernel/cli/TuiStateAndFocus.vitest.mts` — clean
- `npx vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts` — 125 passed, including an updated/expanded test that directly reproduces the reported scenario: `focusedChildInputDisabledMessage` returns `undefined` for a WAITING focused child, yet `shouldDeferEscapeInterruptForMetaChord` now correctly returns `true` for it
- `npx vitest run src/test-kernel/cli` — 128 files / 1605 tests passed
- `npx prettier --check packages/cli/src/chat/tui/App.tsx src/test-kernel/cli/TuiStateAndFocus.vitest.mts` — clean

I did not additionally drive the `node-pty` `validate-tui.mjs` harness for
this change: the CI job only runs 3 unrelated scenarios on `ubuntu-latest`,
where `defaultShortcutModifierLabel()` resolves to `Alt` (this whole defer
path is `Esc`-platform-only), so it's a no-op there either way. I traced
every `darwin`-gated PTY scenario that exercises the delayed-Esc chord
path (`focused-stopped-subagent-esc-s-picker`, `-esc-tab-focus`) and
confirmed their `delayMs: 40` stays well under both the old and new
window, so they're unaffected by the widened timeout.

Fixes #7496.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized TUI keyboard handling in App.tsx with updated unit tests; behavior change is limited to Esc-platform chord vs interrupt timing.
> 
> **Overview**
> Fixes **#7496**: on macOS-style terminals, a slow **`Esc s`** / **`Esc p`** could **interrupt a WAITING subagent** instead of opening subagents/tasks.
> 
> **`shouldDeferEscapeInterruptForMetaChord`** now defers bare Esc whenever the footer shows those chords (`Esc` modifier and subagent/task controls available), not only when the focused child’s input is disabled. WAITING children stay in-flight with input enabled, so the old gate skipped the grace window entirely.
> 
> **`ESC_META_CHORD_INTERRUPT_DELAY_MS`** increases from **125ms → 500ms** so a human-paced two-key chord can arrive before Esc commits to interrupt. Alt-chord platforms are unchanged.
> 
> Tests in **`TuiStateAndFocus.vitest.mts`** cover the WAITING-child repro.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55c8808c48b4d7a5338c953118e6f7fffac2ddfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->