### PR TITLE
refactor(runtime): fact-native event vocabulary — SessionFact owns the payload types

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -20,6 +20,10 @@ import {
   UpdatePlanPayloadSchema,
   UpdateTodosPayloadSchema,
   type ActiveChildInfo,
+  type GoalPausedPayload,
+  type UpdateActiveProcessesPayload,
+  type UpdateProcessOutputPayload,
+  type UpdateStreamUsagePayload,
 } from '@shared/schemas';
 import { diffActiveChildren } from '@shared/streams/childActivityReducer';
 import {
@@ -46,12 +50,6 @@ type Emit = <K extends ProgressEvent>(
   event: K,
   payload: ProgressEventPayloads[K],
 ) => void;
-
-type UpdateStreamUsagePayload = ProgressEventPayloads['updateStreamUsage'];
-type GoalPausedPayload = ProgressEventPayloads['goalPaused'];
-type UpdateActiveProcessesPayload =
-  ProgressEventPayloads['updateActiveProcesses'];
-type UpdateProcessOutputPayload = ProgressEventPayloads['updateProcessOutput'];
 
 const GOAL_PAUSED_TRANSCRIPT_NOTICE =
   'Goal paused after a failed cycle. Review the error before starting a new goal.';

--- a/src/agent/runtime/SessionEventHub.ts
+++ b/src/agent/runtime/SessionEventHub.ts
@@ -13,6 +13,12 @@ import type {
 
 const logger = createChannelTrace('SessionEventHub');
 
+/**
+ * Session-scoped fact vocabulary. Each arm's payload is a fact-native named
+ * type from `@shared/schemas`; the frozen legacy progress-event map
+ * (`hostProgressEvents.ts`) derives its key payloads from those names, never
+ * the reverse. Run-scoped facts live on `AgentEvent` (trace), not here.
+ */
 export type SessionFact =
   | {
       readonly type: 'goalStateChanged';

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -26,10 +26,10 @@ import {
   type AgentWorkflowSetting,
 } from '@agent/core/definition/AgentDataclass';
 import { computeDelegationDepthFromStorage } from '@agent/runtime/delegationPolicy';
-import type { ProgressEventPayloads } from '@agent/runtime/hostProgressEvents';
 import { AgentError, getSdkErrorMessage } from '@common/errors';
 import { createChannelTrace } from '@logger';
 import {
+  type RequestEnsureProgressViewPayload,
   type StreamTabId,
   type ExecutionId,
   type SubagentProgressUpdate,
@@ -237,7 +237,7 @@ async function runReflectionAgent(
 
 /** Toast payload shown when the progress view cannot be opened. */
 type FallbackNotification = NonNullable<
-  ProgressEventPayloads['requestEnsureProgressView']['fallbackNotification']
+  RequestEnsureProgressViewPayload['fallbackNotification']
 >;
 
 function buildFallbackNotification(config: AgentConfig): FallbackNotification {

--- a/src/agent/runtime/hostProgressEvents.ts
+++ b/src/agent/runtime/hostProgressEvents.ts
@@ -1,6 +1,5 @@
 import type { TaskState } from '@agent/core/state/TaskState';
 import type {
-  ActiveChildInfo,
   AddOutputFilesPayload,
   AgentProposalPermission,
   BashPermission,
@@ -17,17 +16,20 @@ import type {
   RequestShowErrorPayload,
   RequestShowInstructionPayload,
   RetryPermission,
-  RoundStage,
   SetActiveStreamPayload,
   ShowAgentConfigBannerPayload,
   StreamPhase,
   StreamSubstate,
   StreamTabId,
   ToolEditPermission,
+  UpdateActiveProcessesPayload,
+  UpdateActiveSubagentsPayload,
   UpdateCompileFailuresPayload,
   UpdateMissingOutputsPayload,
   UpdatePlanPayload,
+  UpdateProcessOutputPayload,
   UpdateQueuedFollowUpsPayload,
+  UpdateRoundStagePayload,
   UpdateStreamUsagePayload,
   UpdateTodosPayload,
   UserQuestionPermission,
@@ -47,6 +49,10 @@ import type {
  * carried these keys is deleted; this map survives only so the retained host
  * rails keep one shared key/payload table while they are migrated to typed
  * session/host surfaces.
+ * Every fact-plane key below references its named vocabulary type — this map
+ * projects the vocabulary, it does not define it. Keys still typed inline are
+ * not facts: host-rail status/RPC keys plus the Stage-5 residue trio
+ * (`setTaskState`, `updateStreamDescription`, `setParentStream`).
  */
 export interface ProgressEventPayloads {
   // ── Run/stream progress ──
@@ -102,26 +108,12 @@ export interface ProgressEventPayloads {
     streamId: StreamTabId;
     progress: ConversationProgress;
   };
-  updateRoundStage: {
-    streamId: StreamTabId;
-    roundStage: RoundStage;
-  };
+  updateRoundStage: UpdateRoundStagePayload;
   updateQueuedFollowUps: UpdateQueuedFollowUpsPayload;
   goalPaused: GoalPausedPayload;
-  updateActiveSubagents: {
-    parentStreamId: StreamTabId;
-    children: ActiveChildInfo[];
-  };
-  updateActiveProcesses: {
-    parentStreamId: StreamTabId;
-    processes: ActiveChildInfo[];
-  };
-  updateProcessOutput: {
-    parentStreamId: StreamTabId;
-    executionId: ExecutionId;
-    stdout: string;
-    stderr: string;
-  };
+  updateActiveSubagents: UpdateActiveSubagentsPayload;
+  updateActiveProcesses: UpdateActiveProcessesPayload;
+  updateProcessOutput: UpdateProcessOutputPayload;
   updateStreamDescription: {
     streamId: StreamTabId;
     description: string;

--- a/src/agent/runtime/runFactEvents.ts
+++ b/src/agent/runtime/runFactEvents.ts
@@ -10,10 +10,11 @@ import type {
 
 /**
  * Run facts ride the run trace as `domain` events keyed `'runFact.' + name`.
- * The prefix survives this stage because every key below still has live
- * direct consumers (extension run-fact subscriptions, CLI TUI, snapshot
- * store) plus the retained CLI projection; retiring it means typed
- * `AgentEvent` arms per fact, tracked for a later slice.
+ * The prefix survives until v0.41: every key still has live consumers of the
+ * prefixed key (R8 census 2026-07-07 — the CLI projection decodes all six,
+ * `StreamSnapshotStore` persists all but `goalPaused`, the CLI TUI applies
+ * `updateTodos`/`updatePlan`/`goalPaused`, the extension filters on
+ * `addOutputFiles`). Retiring it means typed `AgentEvent` arms per fact.
  */
 export const RUN_FACT_DOMAIN_PREFIX = 'runFact.';
 
@@ -28,14 +29,18 @@ export type RunFactPayloads = {
 
 export type RunFactEventName = keyof RunFactPayloads;
 
-const RUN_FACT_EVENT_SET = new Set<string>([
-  'updateTodos',
-  'updatePlan',
-  'addOutputFiles',
-  'updateMissingOutputs',
-  'updateCompileFailures',
-  'goalPaused',
-] satisfies RunFactEventName[]);
+// `satisfies Record<...>` (not a name array) so a new `RunFactPayloads` key
+// fails compile here until it is decodable, instead of silently dropping.
+const RUN_FACT_EVENT_NAMES = {
+  updateTodos: true,
+  updatePlan: true,
+  addOutputFiles: true,
+  updateMissingOutputs: true,
+  updateCompileFailures: true,
+  goalPaused: true,
+} as const satisfies Record<RunFactEventName, true>;
+
+const RUN_FACT_EVENT_SET = new Set<string>(Object.keys(RUN_FACT_EVENT_NAMES));
 
 export function toRunFactDomainKey(event: RunFactEventName): string {
   return `${RUN_FACT_DOMAIN_PREFIX}${event}`;

--- a/src/agent/runtime/sessionProgressEventProjection.ts
+++ b/src/agent/runtime/sessionProgressEventProjection.ts
@@ -8,6 +8,7 @@ import {
   ExtendedTokenUsageStatsSchema,
   type StorageKey,
   type StreamTabId,
+  type UpdateStreamUsagePayload,
 } from '@shared/schemas';
 import { isObject } from '@utils/core';
 
@@ -57,8 +58,6 @@ export function attachSessionProgressEventProjection(
     detachSessionFacts();
   };
 }
-
-type UpdateStreamUsagePayload = ProgressEventPayloads['updateStreamUsage'];
 
 function asString(value: unknown): string | undefined {
   return typeof value === 'string' ? value : undefined;

--- a/src/shared/schemas/progressEvents.ts
+++ b/src/shared/schemas/progressEvents.ts
@@ -6,6 +6,7 @@ import type {
   OutputFileInfo,
   RoundIndexed,
 } from './output';
+import type { ActiveChildInfo, RoundStage } from './streamState';
 import type { TokenUsageStats } from './usage';
 
 /**
@@ -73,6 +74,32 @@ export interface UpdateStreamUsagePayload {
   storageKey: StorageKey;
   executionId?: ExecutionId;
   usage: TokenUsageStats;
+}
+
+/** Round advance within a run, projected from `stage.start` (kind 'round'). */
+export interface UpdateRoundStagePayload {
+  streamId: StreamTabId;
+  roundStage: RoundStage;
+}
+
+/** Active subagent roster, projected from `child.activity` (kind 'subagents'). */
+export interface UpdateActiveSubagentsPayload {
+  parentStreamId: StreamTabId;
+  children: ActiveChildInfo[];
+}
+
+/** Active process roster, projected from `child.activity` (kind 'processes'). */
+export interface UpdateActiveProcessesPayload {
+  parentStreamId: StreamTabId;
+  processes: ActiveChildInfo[];
+}
+
+/** Incremental child-process output, projected from `process.output`. */
+export interface UpdateProcessOutputPayload {
+  parentStreamId: StreamTabId;
+  executionId: ExecutionId;
+  stdout: string;
+  stderr: string;
 }
 
 /**


### PR DESCRIPTION
Implements the types-only-zombie rule pinned on #6968 (2026-07-07 standing rule 2) and the fewer-elements doc §5 facts-plane item: the fact plane owns the payload vocabulary, and the frozen legacy map derives from it.

## The dependency inversion

The four fact-plane keys whose payload shapes were still defined inline on the frozen `ProgressEventPayloads` map — `updateRoundStage`, `updateActiveSubagents`, `updateActiveProcesses`, `updateProcessOutput` (the `stage.start`/`child.activity`/`process.output` trace-fact projections) — now have fact-native named types in `src/shared/schemas/progressEvents.ts`, and the frozen map references those names. The CLI's frozen v0.41 view is therefore a projection of the vocabulary rather than its definition, matching the D3 ruling on #6984 ("the type survives only as the CLI's frozen view, not as the vocabulary").

Plain types, not Zod: nothing runtime-validates these payloads today, so no runtime validation is invented. Duplicate local aliases that re-derived vocabulary names through the map are deleted (`UpdateStreamUsagePayload` in `sessionProgressEventProjection.ts` and `subscribeRuntimeHost.ts`; `GoalPausedPayload`, `UpdateActiveProcessesPayload`, `UpdateProcessOutputPayload` in `subscribeRuntimeHost.ts`), and `executeAgent.ts` moves off `ProgressEventPayloads['requestEnsureProgressView']` to `RequestEnsureProgressViewPayload`.

## R8 consumer census — `'runFact.'` prefix keys

**Prefix keys retired: 0. Kept until v0.41: all 6.** Every key has live consumers of the prefixed domain key, and all six are consumed by the frozen CLI projection (`sessionProgressEventProjection.ts` decodes any valid `runFact.*` key and forwards it), which alone mandates keep-until-v0.41:

| Key | Prefixed-key consumers | Count |
|---|---|---|
| `updateTodos` | CLI projection, `StreamSnapshotStore`, CLI TUI (`subscribeRuntimeHost.ts`) | 3 |
| `updatePlan` | CLI projection, `StreamSnapshotStore`, CLI TUI | 3 |
| `addOutputFiles` | CLI projection, `StreamSnapshotStore`, extension (`runFactSubscriptions.ts`) | 3 |
| `updateMissingOutputs` | CLI projection, `StreamSnapshotStore` | 2 |
| `updateCompileFailures` | CLI projection, `StreamSnapshotStore` | 2 |
| `goalPaused` | CLI projection, CLI TUI | 2 |

(`TexraTranscriptRecorder.ts` additionally consumes the prefix as a filter via a local constant copy; it is in another lane's file boundary and untouched.) Their payload TYPES were already fact-native (`RunFactPayloads` references `@shared/schemas` names); this PR adds a compile-time exhaustiveness guard so the decode table can no longer silently drop a new run fact: `RUN_FACT_EVENT_NAMES satisfies Record<RunFactEventName, true>` — probe-verified (a 7th `RunFactPayloads` key fails compile with TS1360 until listed).

## Exhaustiveness over `SessionFact`

Of the 3 hand-enumerated switches flagged by the 2026-07-06 readiness checkpoint, two (`emitLegacyHostFact`, the `emitRuntimeEvent` outer routing switch) and `LegacyProgressEventProjection.ts` no longer exist on main. The sole surviving switch, `projectSessionFactToProgressEvent`, is compile-time exhaustive — probe-verified: adding a 6th `SessionFact` arm fails `tsc` with TS2366 at that switch. The run-fact key table gets the new `satisfies Record<...>` guard above. No `assertNever` boilerplate was added where the compiler already enforces exhaustiveness.

## §14 element accounting

- New exported names: 4 type-only (`UpdateRoundStagePayload`, `UpdateActiveSubagentsPayload`, `UpdateActiveProcessesPayload`, `UpdateProcessOutputPayload`) — these NAME shapes that already existed anonymously inline; no new runtime elements, functions, ports, or files.
- Deleted: 5 duplicate local type aliases + 1 indexed-access re-derivation, so each vocabulary name now has exactly one definition (`UpdateStreamUsagePayload` went 3→1, `GoalPausedPayload` 2→1, `UpdateActiveProcessesPayload`/`UpdateProcessOutputPayload` alias+anonymous→1) — strictly fewer name-duplications.
- LoC: +69/−42 (net +27), all of it the 4 named payload types plus the vocabulary-contract doc comments on `SessionFact`, the frozen map, and the run-fact key table.

## What stays frozen until v0.41

Per the D3 decision on #6984: `sessionProgressEventProjection.ts`, `sessionProgressSubscription.ts`, `terminalStatus.ts`, the `ProgressEventPayloads` key map itself, and the `'runFact.'` prefix for all six keys. Scoped OUT (Stage-5 residue, per the sweep-1 scoping): the `setTaskState`-family (`setTaskState`, `updateStreamDescription`, `setParentStream`) stays inline on the frozen map — they are not session facts yet, and `setTaskState` is structurally gated on `TaskState` from `@agent/core`, which `@shared/schemas` must not import. Host-rail status/RPC keys that are not facts (`updateStreamStatus`, `updateConversationProgress`, `followUpSent`, `removeStream`, the approval bypass/resolve keys) also keep their inline types; they leave with the map.

## Verification

- `tsc --noEmit` green on all five projects: root, `tsconfig.test-kernel.json`, `packages/cli`, `packages/extension`, `packages/desktop`.
- `vitest run` on `src/test-kernel/agent/runtime/`, `src/test-kernel/shared/`, `src/test-kernel/schemas/`, `OutputFileRunFactSubscriptions.vitest.ts`, `CliSessionProgressSubscription.vitest.mts`: 56 files, 414 tests, all passed.
- Exhaustiveness probes: 6th `SessionFact` arm → TS2366 at `projectSessionFactToProgressEvent`; 7th run-fact key → TS1360 at `RUN_FACT_EVENT_NAMES` (both reverted).
- No behavior change: type/schema restructuring and comments only; no emit path, key string, or payload shape changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only refactor and documentation; no changes to event keys, emission, or payload values at runtime.
> 
> **Overview**
> Moves **fact-plane payload shapes** out of the frozen `ProgressEventPayloads` map into `@shared/schemas/progressEvents.ts` as named types (`UpdateRoundStagePayload`, `UpdateActiveSubagentsPayload`, `UpdateActiveProcessesPayload`, `UpdateProcessOutputPayload`). The legacy map and CLI projection now **reference** that vocabulary instead of defining it inline.
> 
> Call sites stop re-deriving types through the frozen map: the CLI TUI and `sessionProgressEventProjection` import `UpdateStreamUsagePayload` (and related payloads) from `@shared/schemas`; `executeAgent` uses `RequestEnsureProgressViewPayload` for fallback toasts. **`runFactEvents`** gains a `RUN_FACT_EVENT_NAMES satisfies Record<RunFactEventName, true>` guard so new run facts cannot be omitted from the decode set without a compile error.
> 
> Doc comments on `SessionFact`, `hostProgressEvents`, and run-fact prefix retention clarify that schemas own the vocabulary and the frozen host view is a projection until v0.41. **No runtime behavior, emit paths, or payload shapes change.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c395b762c8521110cba46fc24ad086fd03bbd290. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->