### PR TITLE
fix(cli): distinguish a WAITING child from a plain idle root in TUI labels

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1877,7 +1877,7 @@ const SCENARIOS = [
     bootExpect: '[Tab]streams',
     expect: [
       'strategy running',
-      'leanSolver idle',
+      'leanSolver waiting for you',
       'reviewer error',
       '2 sub',
       '[Tab]streams',
@@ -2746,7 +2746,7 @@ const SCENARIOS = [
     bootExpect: '[Tab]streams',
     keys: [ESC + 'p', 'k', ESC + 's', 'f', { input: ESC, delayMs: 40 }, '\t'],
     frame: 'tail',
-    expect: ['[2:leanSolver]', '◆ idle', 'root active'],
+    expect: ['[2:leanSolver]', '◆ waiting for you', 'root active'],
     unexpect: [
       'Harness interrupt requested.',
       STOPPED_SUBAGENT_INPUT_MESSAGE_START,

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -123,6 +123,9 @@ export interface StatusBarDisplayInput {
    *  colliding with durable left-side status segments. */
   readonly width?: number;
   readonly ctrlCAction?: CtrlCAction;
+  /** True when `status` belongs to a focused child/subagent stream rather
+   *  than the root session — see `statusBarStreamTarget`. */
+  readonly isChildStream?: boolean;
   /** False while a foreground surface (approval, picker, form, transcript,
    *  slash palette, or reverse search) owns input and global chat shortcuts are
    *  intentionally inactive. */
@@ -628,6 +631,11 @@ interface StatusBarVisibleStream {
 interface StatusBarStreamTarget {
   readonly ctrlCAction: CtrlCAction;
   readonly displaySlice: StreamSlice | undefined;
+  /** True when `displaySlice` belongs to a child/subagent stream rather than
+   *  the root session (the live-ancestor fallback can surface an ancestor
+   *  other than the nominally "active" id, so this is derived from whichever
+   *  stream is actually displayed, not from `activeStreamId` alone). */
+  readonly isChildStream: boolean;
 }
 
 export function statusBarStreamTarget({
@@ -654,6 +662,7 @@ export function statusBarStreamTarget({
   const canStopVisibleRun =
     canStopActiveRun &&
     (canStopPendingRunWithoutStream || hasPendingOrLiveStream(streams));
+  const displayStreamId = activeSlice ? activeStreamId : liveAncestor?.streamId;
   return {
     ctrlCAction: ctrlCActionForFocus({
       activeStreamId,
@@ -661,6 +670,9 @@ export function statusBarStreamTarget({
       parentStream,
     }),
     displaySlice: activeSlice ?? liveAncestor?.value,
+    isChildStream:
+      displayStreamId !== undefined &&
+      parentStream.get(displayStreamId) !== undefined,
   };
 }
 
@@ -697,7 +709,11 @@ export function buildStatusBarDisplay(
     }
   } else {
     left.push({
-      text: formatCliStatusLabel(input.status, input.substate),
+      text: formatCliStatusLabel(
+        input.status,
+        input.substate,
+        input.isChildStream,
+      ),
       color: 'dim',
     });
     if (
@@ -921,6 +937,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     transcriptAvailable: props.transcriptAvailable,
     width: columns,
     ctrlCAction: target.ctrlCAction,
+    isChildStream: target.isChildStream,
     foregroundEscapeAction: props.foregroundEscapeAction,
     shortcutsActive: props.shortcutsActive,
   });

--- a/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
+++ b/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
@@ -193,6 +193,10 @@ export function streamTabsDisplayItems(init: {
     const slice = view.slice;
     const status = formatStreamStatusLabel(slice?.status, {
       style: 'cliCompact',
+      // A tab with a parent is a child/subagent stream; the root tab has no
+      // parentId. WAITING reads differently for each (see
+      // CLI_CHILD_WAITING_LABEL), so the two must not share one label here.
+      isChildStream: view.parentId !== undefined,
       ...(slice?.substate ? { substate: slice.substate } : {}),
     });
     return {

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -38,7 +38,9 @@ export interface ChildRow {
 const TAIL_LINES = 4;
 
 function childStatusLabel(status: string | undefined): string | undefined {
-  return formatStreamStatusLabel(status, { style: 'cli' });
+  // Every row in this panel is a child/subagent stream, never the root
+  // session, so WAITING always gets the distinct child-waiting wording.
+  return formatStreamStatusLabel(status, { style: 'cli', isChildStream: true });
 }
 
 export function compactChildRowText({

--- a/packages/cli/src/chat/tui/sessionStatus.ts
+++ b/packages/cli/src/chat/tui/sessionStatus.ts
@@ -41,11 +41,13 @@ export interface CliSessionStatusInput {
 export function formatCliStatusLabel(
   status: string | undefined,
   substate?: StreamSubstate,
+  isChildStream?: boolean,
 ): string {
   return formatStreamStatusLabel(status, {
     style: 'cli',
     missingLabel: '—',
     ...(substate ? { substate } : {}),
+    ...(isChildStream ? { isChildStream } : {}),
   });
 }
 

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -109,7 +109,12 @@ function compactParts(parts: readonly (string | null | undefined)[]): string {
 function childStatusDescription(
   status: string | undefined,
 ): string | undefined {
-  return formatStreamStatusLabel(status, { style: 'cliCompact' });
+  // Every picker/detail row here is a child/subagent stream, never the root
+  // session, so WAITING always gets the distinct child-waiting wording.
+  return formatStreamStatusLabel(status, {
+    style: 'cliCompact',
+    isChildStream: true,
+  });
 }
 
 function hasLiveChildElapsed(

--- a/src/shared/streams/streamStatusDisplay.ts
+++ b/src/shared/streams/streamStatusDisplay.ts
@@ -110,49 +110,56 @@ function legacyStatusLabel(
   return style === 'progressHeader' ? 'Stopped' : 'stopped';
 }
 
+// A child/subagent stream suspended at WAITING is stalled awaiting a
+// reply-or-stop decision from whoever is looking at it — a different
+// situation from the root session's ordinary idle-between-turns WAITING, so
+// the CLI styles ('cli'/'cliCompact', which otherwise fold WAITING into the
+// root's "idle" wording) use this distinct label instead. `progressHeader`
+// already says "Waiting for follow-up" for both root and child, so it needs
+// no such split.
+const CLI_CHILD_WAITING_LABEL = 'waiting for you';
+
+interface FormatStreamStatusLabelOptions {
+  readonly style?: StreamStatusLabelStyle;
+  readonly missingLabel?: string;
+  readonly substate?: StreamSubstate;
+  /** True when `status` belongs to a child/subagent stream rather than the
+   *  root session — see `CLI_CHILD_WAITING_LABEL`. */
+  readonly isChildStream?: boolean;
+}
+
 export function formatStreamStatusLabel(
   status: string | undefined,
-  options: {
-    readonly style?: StreamStatusLabelStyle;
-    readonly missingLabel: string;
-    readonly substate?: StreamSubstate;
-  },
+  options: FormatStreamStatusLabelOptions & { readonly missingLabel: string },
 ): string;
 
 export function formatStreamStatusLabel(
   status: string,
-  options?: {
-    readonly style?: StreamStatusLabelStyle;
-    readonly missingLabel?: string;
-    readonly substate?: StreamSubstate;
-  },
+  options?: FormatStreamStatusLabelOptions,
 ): string;
 
 export function formatStreamStatusLabel(
   status: string | undefined,
-  options?: {
-    readonly style?: StreamStatusLabelStyle;
-    readonly missingLabel?: string;
-    readonly substate?: StreamSubstate;
-  },
+  options?: FormatStreamStatusLabelOptions,
 ): string | undefined;
 
 export function formatStreamStatusLabel(
   status: string | undefined,
-  options: {
-    readonly style?: StreamStatusLabelStyle;
-    readonly missingLabel?: string;
-    readonly substate?: StreamSubstate;
-  } = {},
+  options: FormatStreamStatusLabelOptions = {},
 ): string | undefined {
   if (status == null) return options.missingLabel;
   const state = streamStatusDisplayState(status, options.substate);
-  const legacyLabel = legacyStatusLabel(
-    state.legacyStatus,
-    options.style ?? 'progressHeader',
-  );
+  const style = options.style ?? 'progressHeader';
+  const legacyLabel = legacyStatusLabel(state.legacyStatus, style);
   if (legacyLabel) return legacyLabel;
   const key = state.key;
   if (!key) return status;
-  return STREAM_STATUS_LABELS[options.style ?? 'progressHeader'][key] ?? status;
+  if (
+    options.isChildStream &&
+    key === STREAM_PHASE.WAITING &&
+    (style === 'cli' || style === 'cliCompact')
+  ) {
+    return CLI_CHILD_WAITING_LABEL;
+  }
+  return STREAM_STATUS_LABELS[style][key] ?? status;
 }

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -378,20 +378,20 @@ describe('CLI child execution controls', () => {
     expect(buildChildControlItems(state, 'subagents')).toMatchObject([
       {
         executionId: 'agent-1',
-        description: 'idle · 20s',
-        statusLabel: 'idle',
+        description: 'waiting for you · 20s',
+        statusLabel: 'waiting for you',
       },
     ]);
     expect(buildChildControlItems(state, 'tasks')).toMatchObject([
       {
         executionId: 'agent-1',
-        description: 'idle · 20s',
-        statusLabel: 'idle',
+        description: 'waiting for you · 20s',
+        statusLabel: 'waiting for you',
       },
       {
         executionId: 'proc-1',
-        description: 'idle · 3s · last line',
-        statusLabel: 'idle',
+        description: 'waiting for you · 3s · last line',
+        statusLabel: 'waiting for you',
       },
     ]);
   });

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -620,6 +620,63 @@ describe('CLI StatusBar display model', () => {
     );
   });
 
+  it('labels a focused WAITING child distinctly from the root idle wording', () => {
+    const rootDisplay = buildStatusBarDisplay(
+      statusInput({ status: STREAM_STATUS.WAITING, isChildStream: false }),
+    );
+    expect(rootDisplay.left.map(statusBarSegmentText)).toContain('idle');
+
+    const childDisplay = buildStatusBarDisplay(
+      statusInput({
+        status: STREAM_STATUS.WAITING,
+        isChildStream: true,
+        subagentControlsAvailable: true,
+        hasMultipleStreams: true,
+        ctrlCAction: 'stop root',
+      }),
+    );
+    expect(childDisplay.left.map(statusBarSegmentText)).toContain(
+      'waiting for you',
+    );
+    expect(childDisplay.left.map(statusBarSegmentText)).not.toContain('idle');
+  });
+
+  it('derives isChildStream for statusBarStreamTarget from whichever stream is actually displayed', () => {
+    const root = 'root';
+    const child = 'child';
+    const waitingChildSlice = {
+      streamId: child,
+      status: STREAM_STATUS.WAITING,
+    } as StreamSlice;
+    const streams = new Map<StreamSlice['streamId'], StreamSlice>([
+      [child, waitingChildSlice],
+    ]);
+
+    expect(
+      statusBarStreamTarget({
+        activeStreamId: child,
+        canStopActiveRun: true,
+        parentStream: new Map([[child, root]]),
+        streams,
+      }),
+    ).toMatchObject({
+      displaySlice: waitingChildSlice,
+      isChildStream: true,
+    });
+
+    expect(
+      statusBarStreamTarget({
+        activeStreamId: root,
+        canStopActiveRun: true,
+        parentStream: new Map([[child, root]]),
+        streams,
+      }),
+    ).toMatchObject({
+      displaySlice: undefined,
+      isChildStream: false,
+    });
+  });
+
   it('projects focused status while keeping stop capability host-owned', () => {
     const root = 'root';
     const child = 'child';

--- a/src/test-kernel/cli/StreamTabsStrip.vitest.mts
+++ b/src/test-kernel/cli/StreamTabsStrip.vitest.mts
@@ -227,7 +227,7 @@ describe('CLI stream tabs strip', () => {
 
     expect(items.map(streamTabSegmentText)).toEqual([
       'main*',
-      '1:setup(idle)',
+      '1:setup(waiting for you)',
       '[2:bash]*',
     ]);
   });
@@ -296,7 +296,7 @@ describe('CLI stream tabs strip', () => {
     });
 
     expect(items.map(streamTabSegmentText)).toEqual([
-      '1:child-1(idle)',
+      '1:child-1(waiting for you)',
       '[2:child-2]',
     ]);
   });
@@ -330,7 +330,7 @@ describe('CLI stream tabs strip', () => {
 
     expect(items.map(streamTabSegmentText)).toEqual([
       '[main]',
-      '1:polish(idle)',
+      '1:polish(waiting for you)',
     ]);
   });
 

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -165,6 +165,6 @@ describe('CLI SubagentList display model', () => {
         },
         nowMs: Date.now(),
       }),
-    ).toBe('review idle');
+    ).toBe('review waiting for you');
   });
 });

--- a/src/test-kernel/shared/StreamStatusDisplay.vitest.ts
+++ b/src/test-kernel/shared/StreamStatusDisplay.vitest.ts
@@ -28,6 +28,46 @@ describe('stream status display labels', () => {
     },
   );
 
+  it.each(['cli', 'cliCompact'] as const)(
+    'labels a child stream WAITING distinctly from the root idle wording (%s)',
+    (style) => {
+      expect(
+        formatStreamStatusLabel(STREAM_STATUS.WAITING, {
+          style,
+          isChildStream: true,
+        }),
+      ).toBe('waiting for you');
+      // Unset (or false) isChildStream keeps the root's plain "idle" wording.
+      expect(formatStreamStatusLabel(STREAM_STATUS.WAITING, { style })).toBe(
+        'idle',
+      );
+      expect(
+        formatStreamStatusLabel(STREAM_STATUS.WAITING, {
+          style,
+          isChildStream: false,
+        }),
+      ).toBe('idle');
+    },
+  );
+
+  it('ignores isChildStream for the progressHeader style, which already says "Waiting for follow-up"', () => {
+    expect(
+      formatStreamStatusLabel(STREAM_STATUS.WAITING, {
+        style: 'progressHeader',
+        isChildStream: true,
+      }),
+    ).toBe('Waiting for follow-up');
+  });
+
+  it('ignores isChildStream for statuses other than WAITING', () => {
+    expect(
+      formatStreamStatusLabel(STREAM_PHASE.COMPLETED, {
+        style: 'cli',
+        isChildStream: true,
+      }),
+    ).toBe('completed');
+  });
+
   it('passes through unknown statuses and supports an explicit missing label', () => {
     expect(formatStreamStatusLabel('custom')).toBe('custom');
     expect(formatStreamStatusLabel('')).toBe('');


### PR DESCRIPTION
## Root cause

A native subagent suspended at `WAITING` (delivered its result/question to the orchestrator and is now stalled pending a reply-or-stop decision) rendered with the same **"idle"** text as the root session's ordinary between-turns idle state.

Both go through the shared `'cli'`/`'cliCompact'` status-label tables in `src/shared/streams/streamStatusDisplay.ts`, which fold `STREAM_PHASE.WAITING` into `"idle"` for every stream alike. That wording is accurate for the root (nothing pending, it's just your turn to type) but misleading for a child row in the subagent panel, a picker entry, a background tab, or the status bar when a child is focused — there, WAITING means *someone needs to actively decide to continue or stop that subagent*, which is a materially different situation from "idle."

`progressHeader` (the VS Code / desktop progress view) was **not** affected — it already renders WAITING as `"Waiting for follow-up"` for both root and child, so there was nothing to conflate there.

## Fix (display-projection only, per the issue)

Added an `isChildStream` option to `formatStreamStatusLabel`. When set and the resolved key is `STREAM_PHASE.WAITING` under the `'cli'`/`'cliCompact'` styles, it returns a distinct `"waiting for you"` label instead of `"idle"`. The root keeps `"idle"` (default `isChildStream` is falsy).

Threaded through every CLI surface that displays a *child's own* status, so none of them regress back to the old conflation:
- `packages/cli/src/chat/tui/panes/SubagentList.tsx` — subagent/process panel rows (always children)
- `packages/cli/src/chat/tui/state/childControls.ts` — subagent/task picker descriptions (always children)
- `packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx` — stream-tabs strip, gated on `view.parentId !== undefined` (child tabs only; the root tab keeps `"idle"`)
- `packages/cli/src/chat/tui/panes/StatusBar.tsx` — the `◆ <status>` segment when the *focused* stream is a child, derived precisely from whichever stream is actually displayed (`statusBarStreamTarget`'s new `isChildStream`, correct even through the live-ancestor fallback)

No status-machine changes — this is purely which string gets displayed for an already-correct status value.

## The issue's second report

I investigated but could not find a reproducible instance of "stopping only a child marks `main(stopped)` in resume hints, reading as if the orchestrator was killed":

- The status bar's `"root active"` segment (#5327, merged well before this issue was filed) already keeps the root's own displayed status from being conflated with a stopped child's while a child is focused — confirmed via `focused-stopped-subagent-esc-tab-focus` and related PTY-harness scenarios.
- `SharedExecutionRegistry.kill(executionId, …)` only targets the specified execution id; nothing cascades a child stop up to root's own status.
- The only literal `"main(stopped)"` occurrence anywhere in the codebase is a `StreamTabsStrip` unit test that deliberately sets the **root's own** status to `CANCELLED` — correct, intended behavior (root really is stopped in that fixture), not a bug.

Given the issue's own framing ("technically coherent… fix in the label maps, not the status machine"), I did not want to guess at an unconfirmed target and risk an incorrect or scope-creeping change (e.g. reworking `/status`'s handling of a focused child's resume id, which would cross from a label tweak into new resolution logic). Left this part undone rather than force a patch; happy to pick it up in a follow-up once there's a concrete repro.

## Verification

- `npm run typecheck` — clean (root `tsc --noEmit`, `tsconfig.test-kernel.json`, and the `texra`/`@texra-ai/cli`/`@texra/trace-viewer` package typechecks all pass)
- `npm run lint` — clean (0 errors; 2 pre-existing warnings unrelated to this change)
- `npx prettier --check <changed files>` — all pass
- `npx vitest run src/test-kernel/shared/StreamStatusDisplay.vitest.ts src/test-kernel/cli/SubagentListDisplay.vitest.mts src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/StreamTabsStrip.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/SessionStatus.vitest.mts --config vitest.config.mjs` — 157/157 pass
- `npx vitest run src/test-kernel/cli src/test-kernel/shared --config vitest.config.mjs` (full CLI + shared suites) — 1734/1734 pass
- Updated the `failed-subagent-status` and `focused-stopped-subagent-esc-tab-focus` PTY-harness scenarios in `packages/cli/scripts/validate-tui.mjs` (`leanSolver idle` → `leanSolver waiting for you`, `◆ idle` → `◆ waiting for you`) to match; did not have a working node-pty/@xterm harness environment available in this sandbox to execute `validate-tui.mjs` itself, so these are updated-but-not-executed — worth a manual PTY-harness spot check before merge per the issue's own suggestion.
- Added new regression coverage: `StreamStatusDisplay.vitest.ts` (isChildStream on/off for `cli`/`cliCompact`/`progressHeader`), `StatusBar.vitest.mts` (`buildStatusBarDisplay` shows `"waiting for you"` only when `isChildStream: true`; `statusBarStreamTarget` derives `isChildStream` from the actually-displayed stream)

Fixes #7498.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only label mapping with no status-machine or execution changes; risk is limited to incorrect `isChildStream` wiring on a UI surface.
> 
> **Overview**
> Child/subagent streams in **WAITING** no longer show **"idle"** like the root session. Under `cli` / `cliCompact` they now read **"waiting for you"**, while the root keeps **"idle"**.
> 
> `formatStreamStatusLabel` gains an `isChildStream` option (WAITING + child only; `progressHeader` unchanged). That flag is passed from the status bar (`statusBarStreamTarget` derives it from the displayed stream), stream tabs (child tabs via `parentId`), subagent list, and child pickers. `formatCliStatusLabel` forwards the same flag.
> 
> Tests and PTY harness expectations are updated for the new wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4958a16572f6dc49af62d3a1ce420ce26f1841bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->