### PR TITLE
refactor(settings): share settings command registry

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -16,6 +16,10 @@ import {
   createModelSelectionController,
 } from '@controllers/settingsView/SettingsModelSelectionControllerFactory';
 import { createSettingsAgentControllers } from '@controllers/settingsView/SettingsAgentControllerFactory';
+import {
+  createSettingsViewCommandHandlers,
+  type SettingsViewCommandActions,
+} from '@controllers/settingsView/SettingsViewCommandHandlers';
 import { deleteAllExecutions, deleteExecution } from '@agent/storage';
 import {
   computeAgentOptionsData,
@@ -63,7 +67,6 @@ import {
   type LatexSettingsStatus,
   type ProviderKeyStatus,
   type ReasoningLevel,
-  type SettingsViewInboundHandlerRegistry,
   type ToolDashboardItem,
 } from '@shared/schemas/settingsViewMessages';
 import { unsupported, unsupportedCommands } from '@shared/utils/dispatcher';
@@ -1098,78 +1101,32 @@ export function createDesktopSettingsIpc(
   const setAgent = (key: WorkspaceStateKey, value: string) =>
     updateAgentSetting(key, value);
 
-  const settingsHandlers: SettingsViewInboundHandlerRegistry = {
+  const settingsActions: SettingsViewCommandActions = {
     // WEBVIEW_READY is intercepted in handleMessage below, before reaching
     // the dispatcher, so this entry is never actually invoked — it exists
     // only to satisfy the exhaustive registry type.
-    webviewReady: () => {},
-    // VS Code-only surfaces with no desktop equivalent.
-    openVscodeSettings: unsupported('No VS Code settings in the desktop app.'),
-    setProviderVscodeSetting: unsupported(
-      'VS Code provider settings are not applicable in the desktop app.',
-    ),
-    // Not yet wired on desktop.
-    selectAgent: unsupported(
-      'Selecting an agent from Settings is not available in the desktop app yet.',
-    ),
-    createAgent: unsupported(
-      'Creating custom agents is not available in the desktop app yet.',
-    ),
-    customizeAgent: unsupported(
-      'Customizing agents is not available in the desktop app yet.',
-    ),
-    deleteCustomAgent: unsupported(
-      'Deleting custom agents is not available in the desktop app yet.',
-    ),
-    viewRemoteAgentPrompt: unsupported(
-      'Viewing a remote agent prompt is not available in the desktop app yet.',
-    ),
-    getGitHubTokenStatus: unsupported(
-      'GitHub PR subscriptions are not available in the desktop app yet.',
-    ),
-    setGitHubToken: unsupported(
-      'GitHub PR subscriptions are not available in the desktop app yet.',
-    ),
-    removeGitHubToken: unsupported(
-      'GitHub PR subscriptions are not available in the desktop app yet.',
-    ),
-    openGitHubTokenUrl: unsupported(
-      'GitHub PR subscriptions are not available in the desktop app yet.',
-    ),
-    getPRSubscriptions: unsupported(
-      'GitHub PR subscriptions are not available in the desktop app yet.',
-    ),
-    unsubscribePR: unsupported(
-      'GitHub PR subscriptions are not available in the desktop app yet.',
-    ),
-    openPRSubscriptionStream: unsupported(
-      'GitHub PR subscriptions are not available in the desktop app yet.',
-    ),
-    getInlineCriticismEnabled: unsupported(
-      'Inline criticism is not available in the desktop app yet.',
-    ),
-    setInlineCriticismEnabled: unsupported(
-      'Inline criticism is not available in the desktop app yet.',
-    ),
-    getGoalList: unsupported('Goals are not available in the desktop app yet.'),
-    revealGoalStream: unsupported(
-      'Goals are not available in the desktop app yet.',
-    ),
-    ...{
-      getMemoryData: () => postMemoryData(),
-      getMemoryPreview: (data) => postMemoryPreview(data.storagePath),
-      getMemoryEnabled: () => postMemoryEnabled(),
-      openMemoryFile: (data) => openMemoryFile(data),
-      openMemoryFolder: () => openMemoryFolder(),
-      deleteMemory: (data) => deleteMemory(data),
-      setMemoryEnabled: (data) => setMemoryEnabled(data.enabled),
-      pinMemory: (data) => setMemoryPinned(data.storagePath, true),
-      unpinMemory: (data) => setMemoryPinned(data.storagePath, false),
+    lifecycle: {
+      webviewReady: () => {},
+      // VS Code-only surfaces with no desktop equivalent.
+      openVscodeSettings: unsupported(
+        'No VS Code settings in the desktop app.',
+      ),
     },
-    ...{
-      getHistoryData: () => postHistoryData(),
-      deleteAgent: (data) => deleteHistoryItem(data.historyId),
-      clearHistory: () => clearHistory(),
+    memory: {
+      getData: () => postMemoryData(),
+      getPreview: (storagePath) => postMemoryPreview(storagePath),
+      getEnabled: () => postMemoryEnabled(),
+      openFile: (data) => openMemoryFile(data),
+      openFolder: () => openMemoryFolder(),
+      delete: (data) => deleteMemory(data),
+      setEnabled: (enabled) => setMemoryEnabled(enabled),
+      pin: (storagePath) => setMemoryPinned(storagePath, true),
+      unpin: (storagePath) => setMemoryPinned(storagePath, false),
+    },
+    history: {
+      getData: () => postHistoryData(),
+      deleteAgent: (historyId) => deleteHistoryItem(historyId),
+      clear: () => clearHistory(),
       rerunAgent: unsupported(
         'Rerun from history is not available in the desktop app yet.',
       ),
@@ -1186,163 +1143,188 @@ export function createDesktopSettingsIpc(
         'HTML export from history is not available in the desktop app yet.',
       ),
     },
-    ...{
-      getProfileData: () => postProfileData(),
+    profile: {
+      getData: () => postProfileData(),
+      selectAgent: unsupported(
+        'Selecting an agent from Settings is not available in the desktop app yet.',
+      ),
       signIn: () => signIn(),
       signOut: () => signOut(),
-      setApiAccessMode: (data) => setApiAccessMode(data.mode),
-      setProviderKey: (data) => setProviderKey(data.provider, data.apiKey),
-      removeProviderKey: (data) => removeProviderKey(data.provider),
-      openProviderKeyUrl: (data) => openProviderKeyUrl(data.provider),
-      setProviderStreaming: (data) =>
-        updateProviderStreaming({
-          provider: data.provider,
-          enabled: data.enabled,
-        }),
-      setProviderEndpoint: (data) =>
-        updateProviderEndpoint({
-          provider: data.provider,
-          endpoint: data.endpoint,
-        }),
-      setGlobalStreaming: (data) => updateGlobalStreaming(data.enabled),
-      openExternalUrl: (data) =>
-        options.openExternalUrl?.(data.url) ?? Promise.resolve(),
+      setApiAccessMode: (mode) => setApiAccessMode(mode),
+      setProviderKey: (provider, apiKey) => setProviderKey(provider, apiKey),
+      removeProviderKey: (provider) => removeProviderKey(provider),
+      openProviderKeyUrl: (provider) => openProviderKeyUrl(provider),
+      setProviderStreaming: (provider, enabled) =>
+        updateProviderStreaming({ provider, enabled }),
+      setProviderEndpoint: (provider, endpoint) =>
+        updateProviderEndpoint({ provider, endpoint }),
+      setGlobalStreaming: (enabled) => updateGlobalStreaming(enabled),
+      setProviderVscodeSetting: unsupported(
+        'VS Code provider settings are not applicable in the desktop app.',
+      ),
+      openExternalUrl: (url) =>
+        options.openExternalUrl?.(url) ?? Promise.resolve(),
     },
-    ...{
-      getModelSelection: () => postModelSelectionData(),
-      setModelEnabled: (data) =>
-        updateModelEnabled({
-          modelName: data.modelName,
-          enabled: data.enabled,
-        }),
-      setPolishModel: (data) => updateHelperModel(data.modelName),
-      setModelReasoningLevel: (data) =>
-        updateModelReasoningLevel({
-          modelName: data.modelName,
-          level: data.level,
-        }),
-      setPreferShortModelNames: (data) =>
-        updatePreferShortModelNames(data.enabled),
+    modelSelection: {
+      getData: () => postModelSelectionData(),
+      setEnabled: (modelName, enabled) =>
+        updateModelEnabled({ modelName, enabled }),
+      setHelperModel: (modelName) => updateHelperModel(modelName),
+      setReasoningLevel: (modelName, level) =>
+        updateModelReasoningLevel({ modelName, level }),
+      setPreferShortModelNames: (enabled) =>
+        updatePreferShortModelNames(enabled),
     },
-    ...{
+    orchestration: {
       getSuperYoloEnabled: () => postSuperYoloEnabled(),
       setSuperYoloEnabled: () => postSuperYoloEnabled(),
-      setAllowOrchestratorKill: (data) =>
+      setAllowOrchestratorKill: (enabled) =>
         updateBooleanWorkspaceSetting(
           StateKeys.ALLOW_ORCHESTRATOR_KILL,
-          data.enabled,
+          enabled,
         ),
-      setDetachSubagentsOnStop: (data) =>
+      setDetachSubagentsOnStop: (enabled) =>
         updateBooleanWorkspaceSetting(
           StateKeys.DETACH_SUBAGENTS_ON_STOP,
-          data.enabled,
+          enabled,
         ),
     },
-    ...{
-      getAgentSelection: () => postAgentSelectionData(),
-      setAgentEnabled: (data) =>
-        updateAgentEnabled({
-          category: data.category,
-          source: data.agentSource,
-          name: data.agentName,
-          enabled: data.enabled,
-        }),
-      setAllAgentsEnabled: (data) =>
-        updateAllAgentsEnabled({
-          category: data.category,
-          source: data.source,
-          enabled: data.enabled,
-        }),
-      openAgentYaml: (data) =>
-        openAgentYaml({ source: data.agentSource, name: data.agentName }),
-      openAgentFolder: () => openAgentFolder(),
-      revealAgentFile: (data) =>
-        revealAgentFile({ source: data.agentSource, name: data.agentName }),
-      getCustomAgentDir: () => postCustomAgentDir(),
-      setCustomAgentDir: () => setCustomAgentDir(),
-      resetCustomAgentDir: () => resetCustomAgentDir(),
-      getAgentModePresets: () => postAgentModePresets(),
-      applyAgentModePreset: (data) => applyAgentModePreset(data.presetId),
-      saveAgentModePreset: () => saveAgentModePreset(),
-      deleteAgentModePreset: (data) => deleteAgentModePreset(data.presetId),
+    agentSelection: {
+      getData: () => postAgentSelectionData(),
+      setEnabled: ({ category, source, name, enabled }) =>
+        updateAgentEnabled({ category, source, name, enabled }),
+      setAllEnabled: ({ category, source, enabled }) =>
+        updateAllAgentsEnabled({ category, source, enabled }),
+      openYaml: ({ source, name }) => openAgentYaml({ source, name }),
+      openFolder: () => openAgentFolder(),
+      create: unsupported(
+        'Creating custom agents is not available in the desktop app yet.',
+      ),
+      customize: unsupported(
+        'Customizing agents is not available in the desktop app yet.',
+      ),
+      deleteCustom: unsupported(
+        'Deleting custom agents is not available in the desktop app yet.',
+      ),
+      revealFile: ({ source, name }) => revealAgentFile({ source, name }),
+      viewRemotePrompt: unsupported(
+        'Viewing a remote agent prompt is not available in the desktop app yet.',
+      ),
+      getCustomDir: () => postCustomAgentDir(),
+      setCustomDir: () => setCustomAgentDir(),
+      resetCustomDir: () => resetCustomAgentDir(),
+      getModePresets: () => postAgentModePresets(),
+      applyModePreset: (presetId) => applyAgentModePreset(presetId),
+      saveModePreset: () => saveAgentModePreset(),
+      deleteModePreset: (presetId) => deleteAgentModePreset(presetId),
     },
-    ...{
-      getGitAuthorSettings: () => postGitAuthorSettings(),
-      setGitMarkCommits: (data) =>
-        setGitAuthor(StateKeys.GIT_MARK_COMMITS, data.enabled),
-      setGitAuthorName: (data) =>
-        setGitAuthor(StateKeys.GIT_AUTHOR_NAME, data.name),
-      setGitAuthorEmail: (data) =>
-        setGitAuthor(StateKeys.GIT_AUTHOR_EMAIL, data.email),
-      setGitWorktreeSupport: (data) =>
-        setGitAuthor(StateKeys.GIT_WORKTREE_SUPPORT, data.enabled),
+    gitAuthor: {
+      getSettings: () => postGitAuthorSettings(),
+      setMarkCommits: (enabled) =>
+        setGitAuthor(StateKeys.GIT_MARK_COMMITS, enabled),
+      setName: (name) => setGitAuthor(StateKeys.GIT_AUTHOR_NAME, name),
+      setEmail: (email) => setGitAuthor(StateKeys.GIT_AUTHOR_EMAIL, email),
+      setWorktreeSupport: (enabled) =>
+        setGitAuthor(StateKeys.GIT_WORKTREE_SUPPORT, enabled),
     },
-    ...{
-      getChatGptAuthStatus: () => postChatGptAuthStatus(),
-      signInChatGpt: () => signInChatGpt(),
-      signOutChatGpt: () => signOutChatGpt(),
-      setChatGptPreferSubscription: (data) =>
-        setChatGptPreferSubscription(data.enabled),
-      setChatGptSubscriptionToolUseOnly: (data) =>
-        setChatGptSubscriptionToolUseOnly(data.enabled),
+    githubSubscriptions: {
+      getTokenStatus: unsupported(
+        'GitHub PR subscriptions are not available in the desktop app yet.',
+      ),
+      setToken: unsupported(
+        'GitHub PR subscriptions are not available in the desktop app yet.',
+      ),
+      removeToken: unsupported(
+        'GitHub PR subscriptions are not available in the desktop app yet.',
+      ),
+      openTokenUrl: unsupported(
+        'GitHub PR subscriptions are not available in the desktop app yet.',
+      ),
+      getSubscriptions: unsupported(
+        'GitHub PR subscriptions are not available in the desktop app yet.',
+      ),
+      unsubscribe: unsupported(
+        'GitHub PR subscriptions are not available in the desktop app yet.',
+      ),
+      openSubscriptionStream: unsupported(
+        'GitHub PR subscriptions are not available in the desktop app yet.',
+      ),
     },
-    ...{
-      getApprovalSettings: () => postApprovalSettings(),
-      setBashApprovalEnabled: (data) => updateBashApprovalEnabled(data.enabled),
-      setCodexSandboxMode: (data) =>
-        setAgent(StateKeys.CODEX_SANDBOX_MODE, data.mode),
-      setCodexReasoningEffort: (data) =>
-        setAgent(StateKeys.CODEX_REASONING_EFFORT, data.effort),
-      setCodexApprovalPolicy: (data) =>
-        setAgent(StateKeys.CODEX_APPROVAL_POLICY, data.policy),
-      setClaudeAgentModel: (data) =>
-        setAgent(StateKeys.CLAUDE_AGENT_MODEL, data.model),
-      setClaudeAgentPermissionMode: (data) =>
-        setAgent(StateKeys.CLAUDE_AGENT_PERMISSION_MODE, data.mode),
-      setClaudeAgentEffort: (data) =>
-        setAgent(StateKeys.CLAUDE_AGENT_EFFORT, data.effort),
+    chatGpt: {
+      getAuthStatus: () => postChatGptAuthStatus(),
+      signIn: () => signInChatGpt(),
+      signOut: () => signOutChatGpt(),
+      setPreferSubscription: (enabled) => setChatGptPreferSubscription(enabled),
+      setSubscriptionToolUseOnly: (enabled) =>
+        setChatGptSubscriptionToolUseOnly(enabled),
     },
-    ...{
-      getToolDashboardData: () => postToolDashboardData(),
-      openToolInstallUrl: (data) =>
-        options.openExternalUrl?.(data.url) ?? Promise.resolve(),
-      installToolExtension: (data) =>
-        options.installToolExtension?.(data.extensionId) ?? Promise.resolve(),
-      recheckToolStatus: () => recheckToolStatus(),
-      toggleTool: (data) => setToolEnabled(data.toolId, data.enabled),
-      runToolCommand: (data) =>
-        runToolCommand({ toolId: data.toolId, kind: data.kind }),
+    approval: {
+      getSettings: () => postApprovalSettings(),
+      setBashApprovalEnabled: (enabled) => updateBashApprovalEnabled(enabled),
+      setCodexSandboxMode: (mode) =>
+        setAgent(StateKeys.CODEX_SANDBOX_MODE, mode),
+      setCodexReasoningEffort: (effort) =>
+        setAgent(StateKeys.CODEX_REASONING_EFFORT, effort),
+      setCodexApprovalPolicy: (policy) =>
+        setAgent(StateKeys.CODEX_APPROVAL_POLICY, policy),
+      setClaudeAgentModel: (model) =>
+        setAgent(StateKeys.CLAUDE_AGENT_MODEL, model),
+      setClaudeAgentPermissionMode: (mode) =>
+        setAgent(StateKeys.CLAUDE_AGENT_PERMISSION_MODE, mode),
+      setClaudeAgentEffort: (effort) =>
+        setAgent(StateKeys.CLAUDE_AGENT_EFFORT, effort),
     },
-    ...{
-      getLatexSettingsStatus: () => postLatexSettingsStatus(),
-      applyLatexSettings: () => postLatexSettingsStatus(),
+    tools: {
+      getDashboardData: () => postToolDashboardData(),
+      openInstallUrl: (url) =>
+        options.openExternalUrl?.(url) ?? Promise.resolve(),
+      installExtension: (extensionId) =>
+        options.installToolExtension?.(extensionId) ?? Promise.resolve(),
+      recheckStatus: () => recheckToolStatus(),
+      toggle: (toolId, enabled) => setToolEnabled(toolId, enabled),
+      runCommand: ({ toolId, kind }) => runToolCommand({ toolId, kind }),
+    },
+    latex: {
+      getSettingsStatus: () => postLatexSettingsStatus(),
+      applySettings: () => postLatexSettingsStatus(),
       installLatexWorkshop: () =>
         options.installToolExtension?.(LATEX_WORKSHOP_EXT_ID) ??
         Promise.resolve(),
-      runInstallCommand: (data) => {
-        if (!isAllowedLatexInstallCommand(data.installCommand)) {
+      runInstallCommand: (installCommand) => {
+        if (!isAllowedLatexInstallCommand(installCommand)) {
           onError(
-            new Error(
-              `Rejected unknown install command: ${data.installCommand}`,
-            ),
+            new Error(`Rejected unknown install command: ${installCommand}`),
           );
           return;
         }
-        return (
-          options.runInstallCommand?.(data.installCommand) ?? Promise.resolve()
-        );
+        return options.runInstallCommand?.(installCommand) ?? Promise.resolve();
       },
-      getLatexConfigValues: () => postLatexConfigValues(),
-      setLatexConfigValue: (data) =>
-        updateLatexConfigValue({ field: data.field, value: data.value }),
+      getConfigValues: () => postLatexConfigValues(),
+      setConfigValue: ({ field, value }) =>
+        updateLatexConfigValue({ field, value }),
     },
-    ...{
-      getDesktopCrashReporting: () => postDesktopCrashReportingStatus(),
-      setDesktopCrashReportingEnabled: (data) =>
-        updateDesktopCrashReportingEnabled(data.enabled),
-      setDesktopCrashReportingDsn: () => updateDesktopCrashReportingDsn(),
+    inlineCriticism: {
+      getEnabled: unsupported(
+        'Inline criticism is not available in the desktop app yet.',
+      ),
+      setEnabled: unsupported(
+        'Inline criticism is not available in the desktop app yet.',
+      ),
+    },
+    goals: {
+      getList: unsupported('Goals are not available in the desktop app yet.'),
+      revealStream: unsupported(
+        'Goals are not available in the desktop app yet.',
+      ),
+    },
+    desktopCrashReporting: {
+      get: () => postDesktopCrashReportingStatus(),
+      setEnabled: (enabled) => updateDesktopCrashReportingEnabled(enabled),
+      setDsn: () => updateDesktopCrashReportingDsn(),
     },
   };
+
+  const settingsHandlers = createSettingsViewCommandHandlers(settingsActions);
 
   return {
     refreshAuthDependentData,

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -18,6 +18,10 @@ import {
   buildToolDashboardItems,
   buildToolDashboardTerminalAction,
 } from '@controllers/settingsView/ToolDashboardData';
+import {
+  createSettingsViewCommandHandlers,
+  type SettingsViewCommandActions,
+} from '@controllers/settingsView/SettingsViewCommandHandlers';
 import { platform } from '@platform/platform';
 import { resolveMemoryStoragePath } from '@platform/defaults/workspaceStorage';
 import { createSettingsMemoryController } from '@controllers/settingsView/SettingsMemoryControllerFactory';
@@ -234,33 +238,44 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     const setAgent = (key: WorkspaceStateKey, value: string) =>
       this.updateAgentSetting(key, value);
 
-    return {
-      ...{
+    const actions: SettingsViewCommandActions = {
+      lifecycle: {
         webviewReady: () => this.withActiveWebview((w) => this.sendAllData(w)),
         openVscodeSettings: () => this.openVscodeSettings(),
       },
-      ...{
-        getMemoryData: () =>
-          this.withActiveWebview((w) => this.sendMemoryData(w)),
-        getMemoryPreview: (data) => this.handleGetMemoryPreview(data),
-        openMemoryFile: (data) => this.handleOpenMemoryFile(data),
-        openMemoryFolder: () => this.handleOpenMemoryFolder(),
-        deleteMemory: (data) => this.handleDeleteMemory(data),
-        getMemoryEnabled: () =>
+      memory: {
+        getData: () => this.withActiveWebview((w) => this.sendMemoryData(w)),
+        getPreview: (storagePath) =>
+          this.handleGetMemoryPreview({
+            command: SETTINGS_VIEW_COMMANDS.GET_MEMORY_PREVIEW,
+            storagePath,
+          }),
+        openFile: (data) => this.handleOpenMemoryFile(data),
+        openFolder: () => this.handleOpenMemoryFolder(),
+        delete: (data) => this.handleDeleteMemory(data),
+        getEnabled: () =>
           this.withActiveWebview((w) => this.sendMemoryEnabled(w)),
-        setMemoryEnabled: (data) => this.handleSetMemoryEnabled(data),
-        pinMemory: (data) => this.setMemoryPinned(data.storagePath, true),
-        unpinMemory: (data) => this.setMemoryPinned(data.storagePath, false),
+        setEnabled: (enabled) =>
+          this.handleSetMemoryEnabled({
+            command: SETTINGS_VIEW_COMMANDS.SET_MEMORY_ENABLED,
+            enabled,
+          }),
+        pin: (storagePath) => this.setMemoryPinned(storagePath, true),
+        unpin: (storagePath) => this.setMemoryPinned(storagePath, false),
       },
-      ...{
-        getHistoryData: () =>
+      history: {
+        getData: () =>
           this.withActiveWebview((w) =>
             this.historyHandlers.sendHistoryData(w),
           ),
         rerunAgent: (data) => this.historyHandlers.handleRerunAgent(data),
         restoreAgent: (data) => this.historyHandlers.handleRestoreAgent(data),
-        deleteAgent: (data) => this.historyHandlers.handleDeleteAgent(data),
-        clearHistory: () => this.historyHandlers.handleClearHistory(),
+        deleteAgent: (historyId) =>
+          this.historyHandlers.handleDeleteAgent({
+            command: SETTINGS_VIEW_COMMANDS.DELETE_AGENT,
+            historyId,
+          }),
+        clear: () => this.historyHandlers.handleClearHistory(),
         exportChatMd: (data) =>
           this.historyHandlers.handleExportChat(data, 'md'),
         exportChatTex: (data) =>
@@ -268,11 +283,10 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         exportChatHtml: (data) =>
           this.historyHandlers.handleExportChat(data, 'html'),
       },
-      ...{
-        getProfileData: () =>
-          this.withActiveWebview((w) => this.sendProfileData(w)),
-        selectAgent: async (data) => {
-          await selectAgentInMainView(data.agentName, {
+      profile: {
+        getData: () => this.withActiveWebview((w) => this.sendProfileData(w)),
+        selectAgent: async (agentName) => {
+          await selectAgentInMainView(agentName, {
             showSuccessMessage: true,
             copyToClipboardOnFailure: false,
           });
@@ -281,230 +295,263 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
           safeExecuteCommand(AUTH_COMMANDS.SIGN_IN, [], this.viewName),
         signOut: () =>
           safeExecuteCommand(AUTH_COMMANDS.SIGN_OUT, [], this.viewName),
-        setApiAccessMode: (data) => this.handleSetApiAccessMode(data),
-        setProviderKey: (data) =>
-          this.runProviderKeyAction(data.provider, 'set', (targetProvider) =>
+        setApiAccessMode: (mode) =>
+          this.handleSetApiAccessMode({
+            command: SETTINGS_VIEW_COMMANDS.SET_API_ACCESS_MODE,
+            mode,
+          }),
+        setProviderKey: (provider) =>
+          this.runProviderKeyAction(provider, 'set', (targetProvider) =>
             this.profileKeyController.setProviderKey(targetProvider),
           ),
-        removeProviderKey: (data) =>
-          this.runProviderKeyAction(data.provider, 'remove', (targetProvider) =>
+        removeProviderKey: (provider) =>
+          this.runProviderKeyAction(provider, 'remove', (targetProvider) =>
             this.profileKeyController.removeProviderKey(targetProvider),
           ),
-        openProviderKeyUrl: (data) =>
-          this.profileKeyController.openProviderKeyUrl(data.provider),
-        setProviderStreaming: (data) =>
+        openProviderKeyUrl: (provider) =>
+          this.profileKeyController.openProviderKeyUrl(provider),
+        setProviderStreaming: (provider, enabled) =>
           this.updateProfileSetting(() =>
-            setProviderStreaming(data.provider, data.enabled),
+            setProviderStreaming(provider, enabled),
           ),
-        setProviderEndpoint: (data) =>
+        setProviderEndpoint: (provider, endpoint) =>
           this.updateProfileSetting(() =>
-            setProviderEndpoint(data.provider, data.endpoint),
+            setProviderEndpoint(provider, endpoint),
           ),
-        setGlobalStreaming: (data) =>
-          this.updateProfileSetting(() => setGlobalStreaming(data.enabled)),
+        setGlobalStreaming: (enabled) =>
+          this.updateProfileSetting(() => setGlobalStreaming(enabled)),
         setProviderVscodeSetting: (data) =>
           this.handleSetProviderVscodeSetting(data),
-        openExternalUrl: (data) => this.openExternalUrl(data.url),
+        openExternalUrl: (url) => this.openExternalUrl(url),
       },
-      ...{
-        getModelSelection: () =>
+      modelSelection: {
+        getData: () =>
           this.withActiveWebview((w) => this.sendModelSelectionData(w)),
-        setModelEnabled: (data) =>
+        setEnabled: (modelName, enabled) =>
           this.updateModelSelection(
             () =>
               this.modelSelectionController.setModelEnabled({
-                modelName: data.modelName,
-                enabled: data.enabled,
+                modelName,
+                enabled,
               }),
             { invalidateCache: true, refreshMainOptions: true },
           ),
-        setPolishModel: (data) =>
+        setHelperModel: (modelName) =>
           this.updateModelSelection(() =>
-            this.modelSelectionController.setHelperModel(data.modelName),
+            this.modelSelectionController.setHelperModel(modelName),
           ),
-        setModelReasoningLevel: (data) =>
+        setReasoningLevel: (modelName, level) =>
           this.updateModelSelection(() =>
             this.modelSelectionController.setReasoningLevel({
-              modelName: data.modelName,
-              level: data.level,
+              modelName,
+              level,
             }),
           ),
-        setPreferShortModelNames: (data) =>
+        setPreferShortModelNames: (enabled) =>
           this.updateModelSelection(() =>
-            this.modelSelectionController.setPreferShortModelNames(
-              data.enabled,
-            ),
+            this.modelSelectionController.setPreferShortModelNames(enabled),
           ),
       },
-      ...{
+      orchestration: {
         getSuperYoloEnabled: () =>
           this.withActiveWebview((w) => this.sendSuperYoloEnabled(w)),
         setSuperYoloEnabled: () =>
           this.withActiveWebview((w) => this.sendSuperYoloEnabled(w)),
-        setAllowOrchestratorKill: (data) =>
+        setAllowOrchestratorKill: (enabled) =>
           this.updateBooleanAndSendSuperYolo(
             StateKeys.ALLOW_ORCHESTRATOR_KILL,
-            data,
+            { enabled },
           ),
-        setDetachSubagentsOnStop: (data) =>
+        setDetachSubagentsOnStop: (enabled) =>
           this.updateBooleanAndSendSuperYolo(
             StateKeys.DETACH_SUBAGENTS_ON_STOP,
-            data,
+            { enabled },
           ),
       },
-      ...{
-        getAgentSelection: () =>
+      agentSelection: {
+        getData: () =>
           this.withActiveWebview((w) =>
             this.agentHandlers.sendAgentSelectionData(w),
           ),
-        openAgentYaml: (data) => this.agentHandlers.handleOpenAgentYaml(data),
-        setAgentEnabled: (data) =>
-          this.agentHandlers.handleSetAgentEnabled(data),
-        setAllAgentsEnabled: (data) =>
-          this.agentHandlers.handleSetAllAgentsEnabled(data),
-        openAgentFolder: (data) =>
-          this.agentHandlers.handleOpenAgentFolder(data),
-        createAgent: (data) => this.agentHandlers.handleCreateAgent(data),
-        customizeAgent: (data) => this.agentHandlers.handleCustomizeAgent(data),
-        deleteCustomAgent: (data) =>
+        openYaml: ({ source, name }) =>
+          this.agentHandlers.handleOpenAgentYaml({
+            command: SETTINGS_VIEW_COMMANDS.OPEN_AGENT_YAML,
+            agentSource: source,
+            agentName: name,
+          }),
+        setEnabled: ({ category, source, name, enabled }) =>
+          this.agentHandlers.handleSetAgentEnabled({
+            command: SETTINGS_VIEW_COMMANDS.SET_AGENT_ENABLED,
+            category,
+            agentSource: source,
+            agentName: name,
+            enabled,
+          }),
+        setAllEnabled: ({ category, source, enabled }) =>
+          this.agentHandlers.handleSetAllAgentsEnabled({
+            command: SETTINGS_VIEW_COMMANDS.SET_ALL_AGENTS_ENABLED,
+            category,
+            source,
+            enabled,
+          }),
+        openFolder: (data) => this.agentHandlers.handleOpenAgentFolder(data),
+        create: (data) => this.agentHandlers.handleCreateAgent(data),
+        customize: (data) => this.agentHandlers.handleCustomizeAgent(data),
+        deleteCustom: (data) =>
           this.agentHandlers.handleDeleteCustomAgent(data),
-        revealAgentFile: (data) =>
-          this.agentHandlers.handleRevealAgentFile(data),
-        viewRemoteAgentPrompt: (data) =>
+        revealFile: ({ source, name }) =>
+          this.agentHandlers.handleRevealAgentFile({
+            command: SETTINGS_VIEW_COMMANDS.REVEAL_AGENT_FILE,
+            agentSource: source,
+            agentName: name,
+          }),
+        viewRemotePrompt: (data) =>
           this.agentHandlers.handleViewRemoteAgentPrompt(data),
-        getCustomAgentDir: () =>
+        getCustomDir: () =>
           this.withActiveWebview((w) =>
             this.agentHandlers.sendCustomAgentDir(w),
           ),
-        setCustomAgentDir: () => this.agentHandlers.handleSetCustomAgentDir(),
-        resetCustomAgentDir: () =>
-          this.agentHandlers.handleResetCustomAgentDir(),
-        getAgentModePresets: () =>
+        setCustomDir: () => this.agentHandlers.handleSetCustomAgentDir(),
+        resetCustomDir: () => this.agentHandlers.handleResetCustomAgentDir(),
+        getModePresets: () =>
           this.withActiveWebview((w) =>
             this.agentHandlers.sendAgentModePresets(w),
           ),
-        applyAgentModePreset: (data) =>
-          this.agentHandlers.handleApplyAgentModePreset(data),
-        saveAgentModePreset: () =>
+        applyModePreset: (presetId) =>
+          this.agentHandlers.handleApplyAgentModePreset({
+            command: SETTINGS_VIEW_COMMANDS.APPLY_AGENT_MODE_PRESET,
+            presetId,
+          }),
+        saveModePreset: () =>
           this.agentHandlers.handleSaveAgentModePreset({
             command: SETTINGS_VIEW_COMMANDS.SAVE_AGENT_MODE_PRESET,
           }),
-        deleteAgentModePreset: (data) =>
-          this.agentHandlers.handleDeleteAgentModePreset(data),
+        deleteModePreset: (presetId) =>
+          this.agentHandlers.handleDeleteAgentModePreset({
+            command: SETTINGS_VIEW_COMMANDS.DELETE_AGENT_MODE_PRESET,
+            presetId,
+          }),
       },
-      ...{
-        getGitAuthorSettings: () =>
+      gitAuthor: {
+        getSettings: () =>
           this.withActiveWebview((w) => this.sendGitAuthorSettings(w)),
-        setGitMarkCommits: (data) =>
-          setGitAuthor(StateKeys.GIT_MARK_COMMITS, data.enabled),
-        setGitAuthorName: (data) =>
-          setGitAuthor(StateKeys.GIT_AUTHOR_NAME, data.name),
-        setGitAuthorEmail: (data) =>
-          setGitAuthor(StateKeys.GIT_AUTHOR_EMAIL, data.email),
-        setGitWorktreeSupport: (data) =>
-          setGitAuthor(StateKeys.GIT_WORKTREE_SUPPORT, data.enabled),
+        setMarkCommits: (enabled) =>
+          setGitAuthor(StateKeys.GIT_MARK_COMMITS, enabled),
+        setName: (name) => setGitAuthor(StateKeys.GIT_AUTHOR_NAME, name),
+        setEmail: (email) => setGitAuthor(StateKeys.GIT_AUTHOR_EMAIL, email),
+        setWorktreeSupport: (enabled) =>
+          setGitAuthor(StateKeys.GIT_WORKTREE_SUPPORT, enabled),
       },
-      ...{
-        getGitHubTokenStatus: () =>
+      githubSubscriptions: {
+        getTokenStatus: () =>
           this.withActiveWebview((w) =>
             this.githubHandlers.sendGitHubTokenStatus(w),
           ),
-        setGitHubToken: () => this.githubHandlers.handleSetGitHubToken(),
-        removeGitHubToken: () => this.githubHandlers.handleRemoveGitHubToken(),
-        openGitHubTokenUrl: () => this.githubHandlers.openGitHubTokenUrl(),
-        getPRSubscriptions: () =>
+        setToken: () => this.githubHandlers.handleSetGitHubToken(),
+        removeToken: () => this.githubHandlers.handleRemoveGitHubToken(),
+        openTokenUrl: () => this.githubHandlers.openGitHubTokenUrl(),
+        getSubscriptions: () =>
           this.withActiveWebview((w) =>
             this.githubHandlers.sendPRSubscriptions(w),
           ),
-        unsubscribePR: (data) => this.githubHandlers.handleUnsubscribePR(data),
-        openPRSubscriptionStream: (data) =>
+        unsubscribe: (data) => this.githubHandlers.handleUnsubscribePR(data),
+        openSubscriptionStream: (data) =>
           this.githubHandlers.handleOpenPRSubscriptionStream(data),
       },
-      ...{
-        getChatGptAuthStatus: () =>
+      chatGpt: {
+        getAuthStatus: () =>
           this.withActiveWebview((w) =>
             this.chatgptHandlers.sendChatGptAuthStatus(w),
           ),
-        signInChatGpt: () => this.chatgptHandlers.handleSignInChatGpt(),
-        signOutChatGpt: () => this.chatgptHandlers.handleSignOutChatGpt(),
-        setChatGptPreferSubscription: (data) =>
-          this.chatgptHandlers.handleSetPreferSubscription(data.enabled),
-        setChatGptSubscriptionToolUseOnly: (data) =>
-          this.chatgptHandlers.handleSetSubscriptionToolUseOnly(data.enabled),
+        signIn: () => this.chatgptHandlers.handleSignInChatGpt(),
+        signOut: () => this.chatgptHandlers.handleSignOutChatGpt(),
+        setPreferSubscription: (enabled) =>
+          this.chatgptHandlers.handleSetPreferSubscription(enabled),
+        setSubscriptionToolUseOnly: (enabled) =>
+          this.chatgptHandlers.handleSetSubscriptionToolUseOnly(enabled),
       },
-      ...{
-        getApprovalSettings: () =>
+      approval: {
+        getSettings: () =>
           this.withActiveWebview((w) => this.sendApprovalSettings(w)),
-        setBashApprovalEnabled: (data) =>
-          this.handleSetApprovalEnabled(data.enabled),
-        setCodexSandboxMode: (data) =>
-          setAgent(StateKeys.CODEX_SANDBOX_MODE, data.mode),
-        setCodexReasoningEffort: (data) =>
-          setAgent(StateKeys.CODEX_REASONING_EFFORT, data.effort),
-        setCodexApprovalPolicy: (data) =>
-          setAgent(StateKeys.CODEX_APPROVAL_POLICY, data.policy),
-        setClaudeAgentModel: (data) =>
-          setAgent(StateKeys.CLAUDE_AGENT_MODEL, data.model),
-        setClaudeAgentPermissionMode: (data) =>
-          setAgent(StateKeys.CLAUDE_AGENT_PERMISSION_MODE, data.mode),
-        setClaudeAgentEffort: (data) =>
-          setAgent(StateKeys.CLAUDE_AGENT_EFFORT, data.effort),
+        setBashApprovalEnabled: (enabled) =>
+          this.handleSetApprovalEnabled(enabled),
+        setCodexSandboxMode: (mode) =>
+          setAgent(StateKeys.CODEX_SANDBOX_MODE, mode),
+        setCodexReasoningEffort: (effort) =>
+          setAgent(StateKeys.CODEX_REASONING_EFFORT, effort),
+        setCodexApprovalPolicy: (policy) =>
+          setAgent(StateKeys.CODEX_APPROVAL_POLICY, policy),
+        setClaudeAgentModel: (model) =>
+          setAgent(StateKeys.CLAUDE_AGENT_MODEL, model),
+        setClaudeAgentPermissionMode: (mode) =>
+          setAgent(StateKeys.CLAUDE_AGENT_PERMISSION_MODE, mode),
+        setClaudeAgentEffort: (effort) =>
+          setAgent(StateKeys.CLAUDE_AGENT_EFFORT, effort),
       },
-      ...{
-        getToolDashboardData: () =>
+      tools: {
+        getDashboardData: () =>
           this.withActiveWebview((w) => this.sendToolDashboardData(w)),
-        openToolInstallUrl: (data) => this.openExternalUrl(data.url),
-        installToolExtension: (data) =>
-          this.latexHandlers.installExtension(data.extensionId),
-        recheckToolStatus: () => refreshToolAvailability(),
-        toggleTool: async (data) => {
-          await setToolEnabled(data.toolId, data.enabled);
+        openInstallUrl: (url) => this.openExternalUrl(url),
+        installExtension: (extensionId) =>
+          this.latexHandlers.installExtension(extensionId),
+        recheckStatus: () => refreshToolAvailability(),
+        toggle: async (toolId, enabled) => {
+          await setToolEnabled(toolId, enabled);
           refreshDisabledToolCache();
           await this.withActiveWebview((w) =>
             this.sendToolDashboardData(w, { skipChecks: true }),
           );
         },
-        runToolCommand: (data) => this.handleRunToolCommand(data),
+        runCommand: (data) =>
+          this.handleRunToolCommand({
+            command: SETTINGS_VIEW_COMMANDS.RUN_TOOL_COMMAND,
+            ...data,
+          }),
       },
-      ...{
-        getLatexSettingsStatus: () =>
+      latex: {
+        getSettingsStatus: () =>
           this.withActiveWebview((w) =>
             this.latexHandlers.sendLatexSettingsStatus(w),
           ),
-        applyLatexSettings: (data) =>
+        applySettings: (data) =>
           this.latexHandlers.handleApplyLatexSettings(data),
         installLatexWorkshop: () =>
           this.latexHandlers.handleInstallLatexWorkshop(),
-        runInstallCommand: (data) =>
-          this.latexHandlers.handleRunInstallCommand(data),
-        getLatexConfigValues: () =>
+        runInstallCommand: (installCommand) =>
+          this.latexHandlers.handleRunInstallCommand({
+            command: SETTINGS_VIEW_COMMANDS.RUN_INSTALL_COMMAND,
+            installCommand,
+          }),
+        getConfigValues: () =>
           this.withActiveWebview((w) =>
             this.latexHandlers.sendLatexConfigValues(w),
           ),
-        setLatexConfigValue: (data) =>
-          this.latexHandlers.handleSetLatexConfigValue(data),
-        getInlineCriticismEnabled: () =>
-          this.withActiveWebview((w) => this.sendInlineCriticismEnabled(w)),
-        setInlineCriticismEnabled: (data) =>
-          this.handleSetInlineCriticismEnabled(data.enabled),
+        setConfigValue: ({ field, value }) =>
+          this.latexHandlers.handleSetLatexConfigValue({
+            command: SETTINGS_VIEW_COMMANDS.SET_LATEX_CONFIG_VALUE,
+            field,
+            value,
+          }),
       },
-      ...{
-        getGoalList: () => this.withActiveWebview((w) => this.sendGoalList(w)),
-        revealGoalStream: async (data) => {
-          await revealProgressStream(data.streamId);
+      inlineCriticism: {
+        getEnabled: () =>
+          this.withActiveWebview((w) => this.sendInlineCriticismEnabled(w)),
+        setEnabled: (enabled) => this.handleSetInlineCriticismEnabled(enabled),
+      },
+      goals: {
+        getList: () => this.withActiveWebview((w) => this.sendGoalList(w)),
+        revealStream: async (streamId) => {
+          await revealProgressStream(streamId);
         },
       },
-      // Electron crash-reporter settings have no VS Code equivalent.
-      getDesktopCrashReporting: unsupported(
-        'Crash reporting is a desktop-app setting.',
-      ),
-      setDesktopCrashReportingEnabled: unsupported(
-        'Crash reporting is a desktop-app setting.',
-      ),
-      setDesktopCrashReportingDsn: unsupported(
-        'Crash reporting is a desktop-app setting.',
-      ),
+      desktopCrashReporting: {
+        get: unsupported('Crash reporting is a desktop-app setting.'),
+        setEnabled: unsupported('Crash reporting is a desktop-app setting.'),
+        setDsn: unsupported('Crash reporting is a desktop-app setting.'),
+      },
     };
+
+    return createSettingsViewCommandHandlers(actions);
   }
 
   public async sendGoalList(webview: vscode.Webview): Promise<void> {

--- a/src/controllers/settingsView/SettingsViewCommandHandlers.ts
+++ b/src/controllers/settingsView/SettingsViewCommandHandlers.ts
@@ -1,0 +1,533 @@
+// Shared schemas and dispatchers
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import type {
+  SettingsMessageFor,
+  SettingsViewInboundHandlerRegistry,
+  SettingsViewInboundMessage,
+} from '@shared/schemas/settingsViewMessages';
+import { isUnsupported, type Unsupported } from '@shared/utils/dispatcher';
+
+const CMD = SETTINGS_VIEW_COMMANDS;
+
+type Command = SettingsViewInboundMessage['command'];
+type Message<C extends Command> = SettingsMessageFor<C>;
+type Work = Promise<void> | void;
+type HandlerOrUnsupported<TArgs extends readonly unknown[] = []> =
+  ((...args: TArgs) => Work) | Unsupported;
+
+type DataAction<C extends Command> = HandlerOrUnsupported<[Message<C>]>;
+type EnabledAction = HandlerOrUnsupported<[boolean]>;
+type StringAction = HandlerOrUnsupported<[string]>;
+type StoragePathAction = HandlerOrUnsupported<[string]>;
+type ProviderAction = HandlerOrUnsupported<[string]>;
+
+export interface SettingsViewCommandActions {
+  readonly lifecycle: {
+    readonly webviewReady: HandlerOrUnsupported;
+    readonly openVscodeSettings: HandlerOrUnsupported;
+  };
+  readonly memory: {
+    readonly getData: HandlerOrUnsupported;
+    readonly getPreview: StoragePathAction;
+    readonly openFile: DataAction<typeof CMD.OPEN_MEMORY_FILE>;
+    readonly openFolder: DataAction<typeof CMD.OPEN_MEMORY_FOLDER>;
+    readonly delete: DataAction<typeof CMD.DELETE_MEMORY>;
+    readonly getEnabled: HandlerOrUnsupported;
+    readonly setEnabled: EnabledAction;
+    readonly pin: StoragePathAction;
+    readonly unpin: StoragePathAction;
+  };
+  readonly history: {
+    readonly getData: HandlerOrUnsupported;
+    readonly rerunAgent: DataAction<typeof CMD.RERUN_AGENT>;
+    readonly restoreAgent: DataAction<typeof CMD.RESTORE_AGENT>;
+    readonly deleteAgent: HandlerOrUnsupported<[string]>;
+    readonly clear: HandlerOrUnsupported;
+    readonly exportChatMd: DataAction<typeof CMD.EXPORT_CHAT_MD>;
+    readonly exportChatTex: DataAction<typeof CMD.EXPORT_CHAT_TEX>;
+    readonly exportChatHtml: DataAction<typeof CMD.EXPORT_CHAT_HTML>;
+  };
+  readonly profile: {
+    readonly getData: HandlerOrUnsupported;
+    readonly selectAgent: StringAction;
+    readonly signIn: HandlerOrUnsupported;
+    readonly signOut: HandlerOrUnsupported;
+    readonly setApiAccessMode: HandlerOrUnsupported<
+      [Message<typeof CMD.SET_API_ACCESS_MODE>['mode']]
+    >;
+    readonly setProviderKey: HandlerOrUnsupported<
+      [
+        Message<typeof CMD.SET_PROVIDER_KEY>['provider'],
+        Message<typeof CMD.SET_PROVIDER_KEY>['apiKey'],
+      ]
+    >;
+    readonly removeProviderKey: ProviderAction;
+    readonly openProviderKeyUrl: ProviderAction;
+    readonly setProviderStreaming: HandlerOrUnsupported<
+      [Message<typeof CMD.SET_PROVIDER_STREAMING>['provider'], boolean]
+    >;
+    readonly setProviderEndpoint: HandlerOrUnsupported<
+      [
+        Message<typeof CMD.SET_PROVIDER_ENDPOINT>['provider'],
+        Message<typeof CMD.SET_PROVIDER_ENDPOINT>['endpoint'],
+      ]
+    >;
+    readonly setGlobalStreaming: EnabledAction;
+    readonly setProviderVscodeSetting: DataAction<
+      typeof CMD.SET_PROVIDER_VSCODE_SETTING
+    >;
+    readonly openExternalUrl: StringAction;
+  };
+  readonly modelSelection: {
+    readonly getData: HandlerOrUnsupported;
+    readonly setEnabled: HandlerOrUnsupported<
+      [Message<typeof CMD.SET_MODEL_ENABLED>['modelName'], boolean]
+    >;
+    readonly setHelperModel: StringAction;
+    readonly setReasoningLevel: HandlerOrUnsupported<
+      [
+        Message<typeof CMD.SET_MODEL_REASONING_LEVEL>['modelName'],
+        Message<typeof CMD.SET_MODEL_REASONING_LEVEL>['level'],
+      ]
+    >;
+    readonly setPreferShortModelNames: EnabledAction;
+  };
+  readonly orchestration: {
+    readonly getSuperYoloEnabled: HandlerOrUnsupported;
+    readonly setSuperYoloEnabled: HandlerOrUnsupported;
+    readonly setAllowOrchestratorKill: EnabledAction;
+    readonly setDetachSubagentsOnStop: EnabledAction;
+  };
+  readonly agentSelection: {
+    readonly getData: HandlerOrUnsupported;
+    readonly setEnabled: HandlerOrUnsupported<
+      [
+        {
+          category: Message<typeof CMD.SET_AGENT_ENABLED>['category'];
+          source: Message<typeof CMD.SET_AGENT_ENABLED>['agentSource'];
+          name: Message<typeof CMD.SET_AGENT_ENABLED>['agentName'];
+          enabled: boolean;
+        },
+      ]
+    >;
+    readonly setAllEnabled: HandlerOrUnsupported<
+      [
+        {
+          category: Message<typeof CMD.SET_ALL_AGENTS_ENABLED>['category'];
+          source: Message<typeof CMD.SET_ALL_AGENTS_ENABLED>['source'];
+          enabled: boolean;
+        },
+      ]
+    >;
+    readonly openYaml: HandlerOrUnsupported<
+      [
+        {
+          source: Message<typeof CMD.OPEN_AGENT_YAML>['agentSource'];
+          name: Message<typeof CMD.OPEN_AGENT_YAML>['agentName'];
+        },
+      ]
+    >;
+    readonly openFolder: DataAction<typeof CMD.OPEN_AGENT_FOLDER>;
+    readonly create: DataAction<typeof CMD.CREATE_AGENT>;
+    readonly customize: DataAction<typeof CMD.CUSTOMIZE_AGENT>;
+    readonly deleteCustom: DataAction<typeof CMD.DELETE_CUSTOM_AGENT>;
+    readonly revealFile: HandlerOrUnsupported<
+      [
+        {
+          source: Message<typeof CMD.REVEAL_AGENT_FILE>['agentSource'];
+          name: Message<typeof CMD.REVEAL_AGENT_FILE>['agentName'];
+        },
+      ]
+    >;
+    readonly viewRemotePrompt: DataAction<typeof CMD.VIEW_REMOTE_AGENT_PROMPT>;
+    readonly getCustomDir: HandlerOrUnsupported;
+    readonly setCustomDir: HandlerOrUnsupported;
+    readonly resetCustomDir: HandlerOrUnsupported;
+    readonly getModePresets: HandlerOrUnsupported;
+    readonly applyModePreset: StringAction;
+    readonly saveModePreset: HandlerOrUnsupported;
+    readonly deleteModePreset: StringAction;
+  };
+  readonly gitAuthor: {
+    readonly getSettings: HandlerOrUnsupported;
+    readonly setMarkCommits: EnabledAction;
+    readonly setName: StringAction;
+    readonly setEmail: StringAction;
+    readonly setWorktreeSupport: EnabledAction;
+  };
+  readonly githubSubscriptions: {
+    readonly getTokenStatus: HandlerOrUnsupported;
+    readonly setToken: HandlerOrUnsupported;
+    readonly removeToken: HandlerOrUnsupported;
+    readonly openTokenUrl: HandlerOrUnsupported;
+    readonly getSubscriptions: HandlerOrUnsupported;
+    readonly unsubscribe: DataAction<typeof CMD.UNSUBSCRIBE_PR>;
+    readonly openSubscriptionStream: DataAction<
+      typeof CMD.OPEN_PR_SUBSCRIPTION_STREAM
+    >;
+  };
+  readonly chatGpt: {
+    readonly getAuthStatus: HandlerOrUnsupported;
+    readonly signIn: HandlerOrUnsupported;
+    readonly signOut: HandlerOrUnsupported;
+    readonly setPreferSubscription: EnabledAction;
+    readonly setSubscriptionToolUseOnly: EnabledAction;
+  };
+  readonly approval: {
+    readonly getSettings: HandlerOrUnsupported;
+    readonly setBashApprovalEnabled: EnabledAction;
+    readonly setCodexSandboxMode: StringAction;
+    readonly setCodexReasoningEffort: StringAction;
+    readonly setCodexApprovalPolicy: StringAction;
+    readonly setClaudeAgentModel: StringAction;
+    readonly setClaudeAgentPermissionMode: StringAction;
+    readonly setClaudeAgentEffort: StringAction;
+  };
+  readonly tools: {
+    readonly getDashboardData: HandlerOrUnsupported;
+    readonly openInstallUrl: StringAction;
+    readonly installExtension: StringAction;
+    readonly recheckStatus: HandlerOrUnsupported;
+    readonly toggle: HandlerOrUnsupported<
+      [Message<typeof CMD.TOGGLE_TOOL>['toolId'], boolean]
+    >;
+    readonly runCommand: HandlerOrUnsupported<
+      [
+        {
+          toolId: Message<typeof CMD.RUN_TOOL_COMMAND>['toolId'];
+          kind: Message<typeof CMD.RUN_TOOL_COMMAND>['kind'];
+        },
+      ]
+    >;
+  };
+  readonly latex: {
+    readonly getSettingsStatus: HandlerOrUnsupported;
+    readonly applySettings: DataAction<typeof CMD.APPLY_LATEX_SETTINGS>;
+    readonly installLatexWorkshop: HandlerOrUnsupported;
+    readonly runInstallCommand: StringAction;
+    readonly getConfigValues: HandlerOrUnsupported;
+    readonly setConfigValue: HandlerOrUnsupported<
+      [
+        {
+          field: Message<typeof CMD.SET_LATEX_CONFIG_VALUE>['field'];
+          value: Message<typeof CMD.SET_LATEX_CONFIG_VALUE>['value'];
+        },
+      ]
+    >;
+  };
+  readonly inlineCriticism: {
+    readonly getEnabled: HandlerOrUnsupported;
+    readonly setEnabled: EnabledAction;
+  };
+  readonly goals: {
+    readonly getList: HandlerOrUnsupported;
+    readonly revealStream: StringAction;
+  };
+  readonly desktopCrashReporting: {
+    readonly get: HandlerOrUnsupported;
+    readonly setEnabled: EnabledAction;
+    readonly setDsn: HandlerOrUnsupported;
+  };
+}
+
+function mapAction(
+  action: unknown,
+  project: (data: any) => readonly unknown[],
+) {
+  if (isUnsupported(action)) return action;
+  const handler = action as (...args: readonly unknown[]) => Work;
+  return (data: SettingsViewInboundMessage) => handler(...project(data));
+}
+
+function noDataAction(action: unknown) {
+  return mapAction(action, () => [] as const);
+}
+
+/**
+ * Builds the exhaustive settings command table once. Hosts still own the
+ * effects behind each action: posting data, prompts, IPC, VS Code commands,
+ * Electron-only settings, and unsupported host capabilities stay in the host
+ * adapter that supplies this action object.
+ */
+export function createSettingsViewCommandHandlers(
+  actions: SettingsViewCommandActions,
+): SettingsViewInboundHandlerRegistry {
+  return {
+    webviewReady: noDataAction(actions.lifecycle.webviewReady),
+    openVscodeSettings: noDataAction(actions.lifecycle.openVscodeSettings),
+    getMemoryData: noDataAction(actions.memory.getData),
+    getMemoryPreview: mapAction(actions.memory.getPreview, (data) => [
+      data.storagePath,
+    ]),
+    openMemoryFile: mapAction(actions.memory.openFile, (data) => [data]),
+    openMemoryFolder: noDataAction(actions.memory.openFolder),
+    deleteMemory: mapAction(actions.memory.delete, (data) => [data]),
+    getMemoryEnabled: noDataAction(actions.memory.getEnabled),
+    setMemoryEnabled: mapAction(actions.memory.setEnabled, (data) => [
+      data.enabled,
+    ]),
+    pinMemory: mapAction(actions.memory.pin, (data) => [data.storagePath]),
+    unpinMemory: mapAction(actions.memory.unpin, (data) => [data.storagePath]),
+
+    getHistoryData: noDataAction(actions.history.getData),
+    rerunAgent: mapAction(actions.history.rerunAgent, (data) => [data]),
+    restoreAgent: mapAction(actions.history.restoreAgent, (data) => [data]),
+    deleteAgent: mapAction(actions.history.deleteAgent, (data) => [
+      data.historyId,
+    ]),
+    clearHistory: noDataAction(actions.history.clear),
+    exportChatMd: mapAction(actions.history.exportChatMd, (data) => [data]),
+    exportChatTex: mapAction(actions.history.exportChatTex, (data) => [data]),
+    exportChatHtml: mapAction(actions.history.exportChatHtml, (data) => [data]),
+
+    getProfileData: noDataAction(actions.profile.getData),
+    selectAgent: mapAction(actions.profile.selectAgent, (data) => [
+      data.agentName,
+    ]),
+    signIn: noDataAction(actions.profile.signIn),
+    signOut: noDataAction(actions.profile.signOut),
+    setApiAccessMode: mapAction(actions.profile.setApiAccessMode, (data) => [
+      data.mode,
+    ]),
+    setProviderKey: mapAction(actions.profile.setProviderKey, (data) => [
+      data.provider,
+      data.apiKey,
+    ]),
+    removeProviderKey: mapAction(actions.profile.removeProviderKey, (data) => [
+      data.provider,
+    ]),
+    openProviderKeyUrl: mapAction(
+      actions.profile.openProviderKeyUrl,
+      (data) => [data.provider],
+    ),
+    setProviderStreaming: mapAction(
+      actions.profile.setProviderStreaming,
+      (data) => [data.provider, data.enabled],
+    ),
+    setProviderEndpoint: mapAction(
+      actions.profile.setProviderEndpoint,
+      (data) => [data.provider, data.endpoint],
+    ),
+    setGlobalStreaming: mapAction(
+      actions.profile.setGlobalStreaming,
+      (data) => [data.enabled],
+    ),
+    setProviderVscodeSetting: mapAction(
+      actions.profile.setProviderVscodeSetting,
+      (data) => [data],
+    ),
+    openExternalUrl: mapAction(actions.profile.openExternalUrl, (data) => [
+      data.url,
+    ]),
+
+    getModelSelection: noDataAction(actions.modelSelection.getData),
+    setModelEnabled: mapAction(actions.modelSelection.setEnabled, (data) => [
+      data.modelName,
+      data.enabled,
+    ]),
+    setPolishModel: mapAction(actions.modelSelection.setHelperModel, (data) => [
+      data.modelName,
+    ]),
+    setModelReasoningLevel: mapAction(
+      actions.modelSelection.setReasoningLevel,
+      (data) => [data.modelName, data.level],
+    ),
+    setPreferShortModelNames: mapAction(
+      actions.modelSelection.setPreferShortModelNames,
+      (data) => [data.enabled],
+    ),
+
+    getSuperYoloEnabled: noDataAction(
+      actions.orchestration.getSuperYoloEnabled,
+    ),
+    setSuperYoloEnabled: noDataAction(
+      actions.orchestration.setSuperYoloEnabled,
+    ),
+    setAllowOrchestratorKill: mapAction(
+      actions.orchestration.setAllowOrchestratorKill,
+      (data) => [data.enabled],
+    ),
+    setDetachSubagentsOnStop: mapAction(
+      actions.orchestration.setDetachSubagentsOnStop,
+      (data) => [data.enabled],
+    ),
+
+    getAgentSelection: noDataAction(actions.agentSelection.getData),
+    setAgentEnabled: mapAction(actions.agentSelection.setEnabled, (data) => [
+      {
+        category: data.category,
+        source: data.agentSource,
+        name: data.agentName,
+        enabled: data.enabled,
+      },
+    ]),
+    setAllAgentsEnabled: mapAction(
+      actions.agentSelection.setAllEnabled,
+      (data) => [
+        {
+          category: data.category,
+          source: data.source,
+          enabled: data.enabled,
+        },
+      ],
+    ),
+    openAgentYaml: mapAction(actions.agentSelection.openYaml, (data) => [
+      { source: data.agentSource, name: data.agentName },
+    ]),
+    openAgentFolder: mapAction(actions.agentSelection.openFolder, (data) => [
+      data,
+    ]),
+    createAgent: mapAction(actions.agentSelection.create, (data) => [data]),
+    customizeAgent: mapAction(actions.agentSelection.customize, (data) => [
+      data,
+    ]),
+    deleteCustomAgent: mapAction(
+      actions.agentSelection.deleteCustom,
+      (data) => [data],
+    ),
+    revealAgentFile: mapAction(actions.agentSelection.revealFile, (data) => [
+      { source: data.agentSource, name: data.agentName },
+    ]),
+    viewRemoteAgentPrompt: mapAction(
+      actions.agentSelection.viewRemotePrompt,
+      (data) => [data],
+    ),
+    getCustomAgentDir: noDataAction(actions.agentSelection.getCustomDir),
+    setCustomAgentDir: noDataAction(actions.agentSelection.setCustomDir),
+    resetCustomAgentDir: noDataAction(actions.agentSelection.resetCustomDir),
+    getAgentModePresets: noDataAction(actions.agentSelection.getModePresets),
+    applyAgentModePreset: mapAction(
+      actions.agentSelection.applyModePreset,
+      (data) => [data.presetId],
+    ),
+    saveAgentModePreset: noDataAction(actions.agentSelection.saveModePreset),
+    deleteAgentModePreset: mapAction(
+      actions.agentSelection.deleteModePreset,
+      (data) => [data.presetId],
+    ),
+
+    getGitAuthorSettings: noDataAction(actions.gitAuthor.getSettings),
+    setGitMarkCommits: mapAction(actions.gitAuthor.setMarkCommits, (data) => [
+      data.enabled,
+    ]),
+    setGitAuthorName: mapAction(actions.gitAuthor.setName, (data) => [
+      data.name,
+    ]),
+    setGitAuthorEmail: mapAction(actions.gitAuthor.setEmail, (data) => [
+      data.email,
+    ]),
+    setGitWorktreeSupport: mapAction(
+      actions.gitAuthor.setWorktreeSupport,
+      (data) => [data.enabled],
+    ),
+
+    getGitHubTokenStatus: noDataAction(
+      actions.githubSubscriptions.getTokenStatus,
+    ),
+    setGitHubToken: noDataAction(actions.githubSubscriptions.setToken),
+    removeGitHubToken: noDataAction(actions.githubSubscriptions.removeToken),
+    openGitHubTokenUrl: noDataAction(actions.githubSubscriptions.openTokenUrl),
+    getPRSubscriptions: noDataAction(
+      actions.githubSubscriptions.getSubscriptions,
+    ),
+    unsubscribePR: mapAction(
+      actions.githubSubscriptions.unsubscribe,
+      (data) => [data],
+    ),
+    openPRSubscriptionStream: mapAction(
+      actions.githubSubscriptions.openSubscriptionStream,
+      (data) => [data],
+    ),
+
+    getChatGptAuthStatus: noDataAction(actions.chatGpt.getAuthStatus),
+    signInChatGpt: noDataAction(actions.chatGpt.signIn),
+    signOutChatGpt: noDataAction(actions.chatGpt.signOut),
+    setChatGptPreferSubscription: mapAction(
+      actions.chatGpt.setPreferSubscription,
+      (data) => [data.enabled],
+    ),
+    setChatGptSubscriptionToolUseOnly: mapAction(
+      actions.chatGpt.setSubscriptionToolUseOnly,
+      (data) => [data.enabled],
+    ),
+
+    getApprovalSettings: noDataAction(actions.approval.getSettings),
+    setBashApprovalEnabled: mapAction(
+      actions.approval.setBashApprovalEnabled,
+      (data) => [data.enabled],
+    ),
+    setCodexSandboxMode: mapAction(
+      actions.approval.setCodexSandboxMode,
+      (data) => [data.mode],
+    ),
+    setCodexReasoningEffort: mapAction(
+      actions.approval.setCodexReasoningEffort,
+      (data) => [data.effort],
+    ),
+    setCodexApprovalPolicy: mapAction(
+      actions.approval.setCodexApprovalPolicy,
+      (data) => [data.policy],
+    ),
+    setClaudeAgentModel: mapAction(
+      actions.approval.setClaudeAgentModel,
+      (data) => [data.model],
+    ),
+    setClaudeAgentPermissionMode: mapAction(
+      actions.approval.setClaudeAgentPermissionMode,
+      (data) => [data.mode],
+    ),
+    setClaudeAgentEffort: mapAction(
+      actions.approval.setClaudeAgentEffort,
+      (data) => [data.effort],
+    ),
+
+    getToolDashboardData: noDataAction(actions.tools.getDashboardData),
+    openToolInstallUrl: mapAction(actions.tools.openInstallUrl, (data) => [
+      data.url,
+    ]),
+    installToolExtension: mapAction(actions.tools.installExtension, (data) => [
+      data.extensionId,
+    ]),
+    recheckToolStatus: noDataAction(actions.tools.recheckStatus),
+    toggleTool: mapAction(actions.tools.toggle, (data) => [
+      data.toolId,
+      data.enabled,
+    ]),
+    runToolCommand: mapAction(actions.tools.runCommand, (data) => [
+      { toolId: data.toolId, kind: data.kind },
+    ]),
+
+    getLatexSettingsStatus: noDataAction(actions.latex.getSettingsStatus),
+    applyLatexSettings: mapAction(actions.latex.applySettings, (data) => [
+      data,
+    ]),
+    installLatexWorkshop: noDataAction(actions.latex.installLatexWorkshop),
+    runInstallCommand: mapAction(actions.latex.runInstallCommand, (data) => [
+      data.installCommand,
+    ]),
+    getLatexConfigValues: noDataAction(actions.latex.getConfigValues),
+    setLatexConfigValue: mapAction(actions.latex.setConfigValue, (data) => [
+      { field: data.field, value: data.value },
+    ]),
+
+    getInlineCriticismEnabled: noDataAction(actions.inlineCriticism.getEnabled),
+    setInlineCriticismEnabled: mapAction(
+      actions.inlineCriticism.setEnabled,
+      (data) => [data.enabled],
+    ),
+
+    getGoalList: noDataAction(actions.goals.getList),
+    revealGoalStream: mapAction(actions.goals.revealStream, (data) => [
+      data.streamId,
+    ]),
+
+    getDesktopCrashReporting: noDataAction(actions.desktopCrashReporting.get),
+    setDesktopCrashReportingEnabled: mapAction(
+      actions.desktopCrashReporting.setEnabled,
+      (data) => [data.enabled],
+    ),
+    setDesktopCrashReportingDsn: noDataAction(
+      actions.desktopCrashReporting.setDsn,
+    ),
+  };
+}

--- a/src/test-kernel/controllers/SettingsViewCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/SettingsViewCommandHandlers.vitest.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createSettingsViewCommandHandlers,
+  type SettingsViewCommandActions,
+} from '@controllers/settingsView/SettingsViewCommandHandlers';
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import { SETTINGS_VIEW_CMD } from '@shared/schemas/settingsViewMessages';
+import { assertSupported, unsupportedCommands } from '@shared/utils/dispatcher';
+
+const unsupportedReason = 'not available in this host';
+const NON_INBOUND_SETTINGS_COMMANDS = new Set<string>([
+  SETTINGS_VIEW_CMD.SET_TAB,
+  SETTINGS_VIEW_CMD.UPDATE_CHATGPT_AUTH_STATUS,
+  SETTINGS_VIEW_CMD.UPDATE_DESKTOP_CRASH_REPORTING,
+  SETTINGS_VIEW_CMD.UPDATE_GITHUB_TOKEN_STATUS,
+  SETTINGS_VIEW_CMD.UPDATE_PR_SUBSCRIPTIONS,
+]);
+
+function action() {
+  return vi.fn();
+}
+
+function createActions(): SettingsViewCommandActions {
+  return {
+    lifecycle: {
+      webviewReady: action(),
+      openVscodeSettings: { unsupported: unsupportedReason },
+    },
+    memory: {
+      getData: action(),
+      getPreview: action(),
+      openFile: action(),
+      openFolder: action(),
+      delete: action(),
+      getEnabled: action(),
+      setEnabled: action(),
+      pin: action(),
+      unpin: action(),
+    },
+    history: {
+      getData: action(),
+      rerunAgent: action(),
+      restoreAgent: action(),
+      deleteAgent: action(),
+      clear: action(),
+      exportChatMd: action(),
+      exportChatTex: action(),
+      exportChatHtml: action(),
+    },
+    profile: {
+      getData: action(),
+      selectAgent: action(),
+      signIn: action(),
+      signOut: action(),
+      setApiAccessMode: action(),
+      setProviderKey: action(),
+      removeProviderKey: action(),
+      openProviderKeyUrl: action(),
+      setProviderStreaming: action(),
+      setProviderEndpoint: action(),
+      setGlobalStreaming: action(),
+      setProviderVscodeSetting: action(),
+      openExternalUrl: action(),
+    },
+    modelSelection: {
+      getData: action(),
+      setEnabled: action(),
+      setHelperModel: action(),
+      setReasoningLevel: action(),
+      setPreferShortModelNames: action(),
+    },
+    orchestration: {
+      getSuperYoloEnabled: action(),
+      setSuperYoloEnabled: action(),
+      setAllowOrchestratorKill: action(),
+      setDetachSubagentsOnStop: action(),
+    },
+    agentSelection: {
+      getData: action(),
+      setEnabled: action(),
+      setAllEnabled: action(),
+      openYaml: action(),
+      openFolder: action(),
+      create: action(),
+      customize: action(),
+      deleteCustom: action(),
+      revealFile: action(),
+      viewRemotePrompt: action(),
+      getCustomDir: action(),
+      setCustomDir: action(),
+      resetCustomDir: action(),
+      getModePresets: action(),
+      applyModePreset: action(),
+      saveModePreset: action(),
+      deleteModePreset: action(),
+    },
+    gitAuthor: {
+      getSettings: action(),
+      setMarkCommits: action(),
+      setName: action(),
+      setEmail: action(),
+      setWorktreeSupport: action(),
+    },
+    githubSubscriptions: {
+      getTokenStatus: action(),
+      setToken: action(),
+      removeToken: action(),
+      openTokenUrl: action(),
+      getSubscriptions: action(),
+      unsubscribe: action(),
+      openSubscriptionStream: action(),
+    },
+    chatGpt: {
+      getAuthStatus: action(),
+      signIn: action(),
+      signOut: action(),
+      setPreferSubscription: action(),
+      setSubscriptionToolUseOnly: action(),
+    },
+    approval: {
+      getSettings: action(),
+      setBashApprovalEnabled: action(),
+      setCodexSandboxMode: action(),
+      setCodexReasoningEffort: action(),
+      setCodexApprovalPolicy: action(),
+      setClaudeAgentModel: action(),
+      setClaudeAgentPermissionMode: action(),
+      setClaudeAgentEffort: action(),
+    },
+    tools: {
+      getDashboardData: action(),
+      openInstallUrl: action(),
+      installExtension: action(),
+      recheckStatus: action(),
+      toggle: action(),
+      runCommand: action(),
+    },
+    latex: {
+      getSettingsStatus: action(),
+      applySettings: action(),
+      installLatexWorkshop: action(),
+      runInstallCommand: action(),
+      getConfigValues: action(),
+      setConfigValue: action(),
+    },
+    inlineCriticism: {
+      getEnabled: action(),
+      setEnabled: action(),
+    },
+    goals: {
+      getList: action(),
+      revealStream: action(),
+    },
+    desktopCrashReporting: {
+      get: { unsupported: unsupportedReason },
+      setEnabled: action(),
+      setDsn: action(),
+    },
+  };
+}
+
+describe('createSettingsViewCommandHandlers', () => {
+  it('authors every settings inbound command exactly once', () => {
+    const registry = createSettingsViewCommandHandlers(createActions());
+    const expectedInboundCommands = [
+      SETTINGS_VIEW_COMMANDS.WEBVIEW_READY,
+      ...Object.values(SETTINGS_VIEW_CMD).filter(
+        (command) => !NON_INBOUND_SETTINGS_COMMANDS.has(command),
+      ),
+    ];
+
+    expect(Object.keys(registry).toSorted()).toEqual(
+      expectedInboundCommands.toSorted(),
+    );
+  });
+
+  it('preserves unsupported host decisions in the derived capability set', () => {
+    const registry = createSettingsViewCommandHandlers(createActions());
+
+    expect(unsupportedCommands(registry).toSorted()).toEqual(
+      [
+        SETTINGS_VIEW_COMMANDS.OPEN_VSCODE_SETTINGS,
+        SETTINGS_VIEW_COMMANDS.GET_DESKTOP_CRASH_REPORTING,
+      ].toSorted(),
+    );
+  });
+
+  it('projects representative command payloads to semantic host actions', () => {
+    const actions = createActions();
+    const registry = createSettingsViewCommandHandlers(actions);
+
+    assertSupported(registry.setProviderKey)({
+      command: SETTINGS_VIEW_COMMANDS.SET_PROVIDER_KEY,
+      provider: 'openai',
+      apiKey: 'sk-test',
+    });
+    expect(actions.profile.setProviderKey).toHaveBeenCalledWith(
+      'openai',
+      'sk-test',
+    );
+
+    assertSupported(registry.exportChatTex)({
+      command: SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_TEX,
+      historyId: 'hist-1',
+    });
+    expect(actions.history.exportChatTex).toHaveBeenCalledWith({
+      command: SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_TEX,
+      historyId: 'hist-1',
+    });
+
+    assertSupported(registry.setAgentEnabled)({
+      command: SETTINGS_VIEW_COMMANDS.SET_AGENT_ENABLED,
+      agentName: 'proofreader',
+      agentSource: 'custom',
+      category: 'toolUse',
+      enabled: true,
+    });
+    expect(actions.agentSelection.setEnabled).toHaveBeenCalledWith({
+      category: 'toolUse',
+      source: 'custom',
+      name: 'proofreader',
+      enabled: true,
+    });
+
+    assertSupported(registry.runToolCommand)({
+      command: SETTINGS_VIEW_COMMANDS.RUN_TOOL_COMMAND,
+      toolId: 'latex',
+      kind: 'install',
+    });
+    expect(actions.tools.runCommand).toHaveBeenCalledWith({
+      toolId: 'latex',
+      kind: 'install',
+    });
+  });
+});


### PR DESCRIPTION
## Scope

This is the settings-only first slice of F2 (#6972). It deliberately does not build the full `createSettingsViewHost(...)` or touch execution/progress wiring.

## Change

- Add `createSettingsViewCommandHandlers(...)` in `src/controllers/settingsView/SettingsViewCommandHandlers.ts`.
- Move the exhaustive inbound settings command-to-handler table into that shared factory.
- Keep host-specific effects host-owned: controller construction, webview/renderer posting, prompts, Electron-only crash reporting, VS Code commands, provider-key flows, GitHub subscriptions, goals, and unsupported host decisions remain in the extension/desktop adapters.
- Rewire the extension and desktop settings hosts to provide semantic action groups to the shared factory.
- Add a controller-level test that checks command coverage, unsupported capability derivation, and representative payload projections.

## Accounting

Full diff stat: 4 files changed, 1151 insertions, 353 deletions, net +798 lines.

Constructs added:

- 2 new files: shared settings command factory and its test.
- 2 exported symbols: `SettingsViewCommandActions` and `createSettingsViewCommandHandlers`.
- No new classes.

Host files only:

- `packages/extension/src/settingsView/SettingsViewMessageHandler.ts`: 1031 -> 1078 (+47)
- `packages/desktop/src/main/desktopSettingsIpc.ts`: 1380 -> 1362 (-18)

The net host-file change is +29 lines for this first slice; the duplicated authored command table now lives in one shared controller module. The larger LoC reduction should come from the follow-up factory work that moves repeated controller/posting setup, not from this conservative registry-only PR.

## Verification

- `CI=true corepack pnpm exec vitest run src/test-kernel/controllers/SettingsViewCommandHandlers.vitest.ts src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts src/test-kernel/desktop/desktopSettingsIpc.vitest.ts`
- `CI=true corepack pnpm exec vitest run src/test-kernel/controllers/SettingsViewCommandHandlers.vitest.ts`
- `CI=true corepack pnpm exec tsc --noEmit --pretty false`
- `CI=true corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `corepack pnpm exec eslint src/controllers/settingsView/SettingsViewCommandHandlers.ts packages/extension/src/settingsView/SettingsViewMessageHandler.ts packages/desktop/src/main/desktopSettingsIpc.ts src/test-kernel/controllers/SettingsViewCommandHandlers.vitest.ts`
- `corepack pnpm exec eslint src/controllers/settingsView/SettingsViewCommandHandlers.ts src/test-kernel/controllers/SettingsViewCommandHandlers.vitest.ts && git diff --check`
- `git diff --check`

Addresses the settings seam of #6972.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the full settings IPC surface for both hosts (auth, keys, approval, agents); behavior should be equivalent but wiring mistakes could break many settings commands at once.
> 
> **Overview**
> Introduces **`createSettingsViewCommandHandlers`** and a typed **`SettingsViewCommandActions`** surface so the exhaustive settings inbound command table lives in one shared controller module instead of being duplicated in each host.
> 
> The **VS Code extension** and **desktop** settings IPC layers now supply grouped semantic actions (memory, profile, agents, latex, etc.) with narrower arguments; the factory maps IPC payloads to those actions and still returns the existing **`SettingsViewInboundHandlerRegistry`**. Host-specific behavior—real implementations vs **`unsupported(...)`**, prompts, webview posting, and platform-only features—is unchanged but reorganized behind the action groups.
> 
> Adds **`SettingsViewCommandHandlers.vitest.ts`** to assert full inbound command coverage, that unsupported capabilities propagate to **`unsupportedCommands`**, and that representative messages project to the expected action calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a856ac9258b04407f046a0bfcdc4a7c0bce0a4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->