### PR TITLE
fix(storage): make persistence reads warn on corrupt data

### DIFF
--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -94,8 +94,8 @@ const TodoEntrySchema = z.object({
 });
 export type TodoEntry = z.infer<typeof TodoEntrySchema>;
 
-const TodoArraySchema = z.array(TodoEntrySchema).catch([]);
-const WorkspaceFilePathArraySchema = z.array(z.string()).catch([]);
+const TodoArraySchema = z.array(TodoEntrySchema);
+const WorkspaceFilePathArraySchema = z.array(z.string());
 
 /** Stored data for a child execution record (without the derived `id` field). */
 const ChildRecordDataSchema = z.object({
@@ -237,35 +237,33 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
   // -- Typed readers --------------------------------------------------------
 
   /**
-   * Read a key and validate it against a schema, returning the parsed value or
-   * `null` when the key is absent or fails validation. Single source of truth
-   * for the read-validate-or-null policy shared by the typed readers below.
+   * Read a key and validate it against a schema, returning the parsed value
+   * or `null` when the key is absent or fails validation. Single source of
+   * truth for the read-validate-or-null policy shared by the typed readers
+   * below. A missing file is the expected case and stays quiet; a present
+   * value that fails validation is a loud read (#6966 bullet 5) — corrupt is
+   * never silently conflated with missing (#7210 pattern).
    */
   private async readValidated<T>(
     key: string,
     schema: z.ZodType<T>,
-    options: { warnOnFailure?: boolean } = {},
   ): Promise<T | null> {
     const raw = await this.read(key);
     if (raw == null) return null;
     const result = schema.nullable().safeParse(raw);
     if (result.success) return result.data;
-    if (options.warnOnFailure) {
-      logger.warn(
-        CHANNEL,
-        `Failed to parse execution ${this.executionId} ${key}.json: ${toErrorMessage(
-          result.error,
-        )}`,
-        { data: result.error },
-      );
-    }
+    logger.warn(
+      CHANNEL,
+      `Failed to parse execution ${this.executionId} ${key}.json: ${toErrorMessage(
+        result.error,
+      )}`,
+      { data: result.error },
+    );
     return null;
   }
 
   async readMeta(): Promise<ExecutionMeta | null> {
-    return this.readValidated(KEYS.META, ExecutionMetaSchema, {
-      warnOnFailure: true,
-    });
+    return this.readValidated(KEYS.META, ExecutionMetaSchema);
   }
 
   async readConfig(): Promise<AgentConfig | null> {
@@ -277,7 +275,7 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
   }
 
   async readTodos(): Promise<TodoEntry[]> {
-    return TodoArraySchema.parse(await this.read<unknown[]>(KEYS.TODOS));
+    return (await this.readValidated(KEYS.TODOS, TodoArraySchema)) ?? [];
   }
 
   async todosModifiedAt(): Promise<number | undefined> {
@@ -294,8 +292,12 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
   }
 
   async readWorkspaceFiles(): Promise<string[]> {
-    const raw = await this.read(KEYS.WORKSPACE_FILES);
-    return normalizeWorkspaceFilePaths(WorkspaceFilePathArraySchema.parse(raw));
+    const paths =
+      (await this.readValidated(
+        KEYS.WORKSPACE_FILES,
+        WorkspaceFilePathArraySchema,
+      )) ?? [];
+    return normalizeWorkspaceFilePaths(paths);
   }
 
   /** Read children: per-child KV keys with schema validation. */

--- a/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
@@ -89,3 +89,59 @@ describe('ExecutionKVStore meta read shims', () => {
     );
   });
 });
+
+describe('ExecutionKVStore loud typed reads (#6966 bullet 5)', () => {
+  it('warns when config is malformed instead of silently returning null', async () => {
+    const id = 'bad-config' as ExecutionId;
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    await getExecutionStore(id).write('config', { outputFiles: 'not-a-list' });
+
+    await expect(getExecutionStore(id).readConfig()).resolves.toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      'ExecutionKVStore',
+      expect.stringContaining(`Failed to parse execution ${id} config.json`),
+      { data: expect.any(Error) },
+    );
+  });
+
+  it('warns when todos are malformed instead of silently defaulting to []', async () => {
+    const id = 'bad-todos' as ExecutionId;
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    await getExecutionStore(id).write('todos', { not: 'an array' });
+
+    await expect(getExecutionStore(id).readTodos()).resolves.toEqual([]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'ExecutionKVStore',
+      expect.stringContaining(`Failed to parse execution ${id} todos.json`),
+      { data: expect.any(Error) },
+    );
+  });
+
+  it('stays quiet for genuinely missing todos (missing != corrupt)', async () => {
+    const id = 'no-todos' as ExecutionId;
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    await expect(getExecutionStore(id).readTodos()).resolves.toEqual([]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('warns when workspace files are malformed instead of silently defaulting to []', async () => {
+    const id = 'bad-wsfiles' as ExecutionId;
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    await getExecutionStore(id).write('workspace-files', [42]);
+
+    await expect(getExecutionStore(id).readWorkspaceFiles()).resolves.toEqual(
+      [],
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      'ExecutionKVStore',
+      expect.stringContaining(
+        `Failed to parse execution ${id} workspace-files.json`,
+      ),
+      { data: expect.any(Error) },
+    );
+  });
+});

--- a/src/test-kernel/tools/ExternalInquiryResultFormatter.vitest.ts
+++ b/src/test-kernel/tools/ExternalInquiryResultFormatter.vitest.ts
@@ -7,6 +7,7 @@ function manifestWithSessionLinks(
   turns: Array<{ turnIndex: number; sessionLinks?: string[] | null }>,
 ): ExternalInquiryThreadManifest {
   return {
+    schemaVersion: 1,
     threadId: 'thread-1',
     parentStreamId: null,
     status: 'answered',

--- a/src/test-kernel/tools/InquiryContinuationSession.vitest.ts
+++ b/src/test-kernel/tools/InquiryContinuationSession.vitest.ts
@@ -44,6 +44,7 @@ const STREAM = 'stream:desktop-parent' as StreamTabId;
 
 function answeredManifest(): ExternalInquiryThreadManifest {
   return {
+    schemaVersion: 1,
     threadId: THREAD,
     parentStreamId: STREAM,
     status: 'answered',

--- a/src/test-kernel/tools/InquiryStorage.vitest.ts
+++ b/src/test-kernel/tools/InquiryStorage.vitest.ts
@@ -8,6 +8,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { setupPlatform } from '@test/support/setupPlatform';
 import {
   ExternalInquiryPermissionSchema,
+  type ExternalInquiryThreadId,
   type StreamTabId,
 } from '@shared/schemas';
 import { ToolError } from '@shared/schemas/toolResult';
@@ -279,6 +280,63 @@ describe('InquiryStorage', () => {
       ).toString('utf8'),
     ) as { turns: Array<{ answer?: string }> };
     expect(persisted.turns[0]?.answer).toBe('Legacy A');
+  });
+
+  it('stamps schemaVersion on newly written manifests', async () => {
+    const t = await recordOpenQuestion({
+      parentStreamId: STREAM_A,
+      question: 'Q1',
+    });
+
+    const platform = (await import('@platform/platform')).platform();
+    const manifestPath = `${platform.storage.getGlobalStoragePath()}/ei_threads/${t.threadId}/manifest.json`;
+    const persisted = JSON.parse(
+      Buffer.from(await platform.fs.readFile(manifestPath)).toString('utf8'),
+    ) as { schemaVersion?: number };
+    expect(persisted.schemaVersion).toBe(1);
+  });
+
+  it('treats a corrupt manifest as missing (loud read) without clobbering it', async () => {
+    const platform = (await import('@platform/platform')).platform();
+    const threadDir = `${platform.storage.getGlobalStoragePath()}/ei_threads/ei_aabbccdd0033`;
+    const manifestPath = `${threadDir}/manifest.json`;
+    await platform.fs.createDirectory(threadDir);
+    await platform.fs.writeFile(
+      manifestPath,
+      Buffer.from('{ not valid json', 'utf8'),
+    );
+
+    await expect(
+      readExternalInquiryThread('ei_aabbccdd0033'),
+    ).resolves.toBeNull();
+
+    // A follow-up dispatch addressed at the corrupt thread reports
+    // not-found instead of silently overwriting the on-disk file.
+    await expect(
+      recordOpenQuestion({
+        threadId: 'ei_aabbccdd0033' as ExternalInquiryThreadId,
+        parentStreamId: STREAM_A,
+        question: 'Q?',
+      }),
+    ).rejects.toBeInstanceOf(ToolError);
+    const stillOnDisk = Buffer.from(
+      await platform.fs.readFile(manifestPath),
+    ).toString('utf8');
+    expect(stillOnDisk).toBe('{ not valid json');
+  });
+
+  it('treats a schema-invalid manifest as missing (loud read)', async () => {
+    const platform = (await import('@platform/platform')).platform();
+    const threadDir = `${platform.storage.getGlobalStoragePath()}/ei_threads/ei_aabbccdd0044`;
+    await platform.fs.createDirectory(threadDir);
+    await platform.fs.writeFile(
+      `${threadDir}/manifest.json`,
+      Buffer.from(JSON.stringify({ threadId: 42, turns: 'nope' }), 'utf8'),
+    );
+
+    await expect(
+      readExternalInquiryThread('ei_aabbccdd0044'),
+    ).resolves.toBeNull();
   });
 
   it('returns a hydrated legacy manifest when write-back fails', async () => {

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -12,6 +12,7 @@ import {
   STREAM_LOGS_DIR,
   STREAM_LOG_SUMMARIES_DIR,
 } from '@transcript';
+import * as logUtils from '@logger/logUtils';
 import {
   END_GROUP_STATUS,
   LOG_LEVELS,
@@ -777,6 +778,7 @@ describe('StreamLogStore load', () => {
         },
       },
     });
+    const warnSpy = vi.spyOn(logUtils, 'warn').mockImplementation(() => {});
     const store = new StreamLogStore();
     await store.load();
     await store.ensureLoaded('alpha');
@@ -787,6 +789,14 @@ describe('StreamLogStore load', () => {
         ?.getRange(0)
         .map((entry) => entry.id),
     ).toEqual(['alpha-1', 'alpha-3']);
+    // Loud read (#7464): the preserved rows are invisible to the typed view,
+    // so the load says they exist rather than silently hiding them.
+    expect(warnSpy).toHaveBeenCalledWith(
+      'StreamLogStore',
+      expect.stringContaining(
+        'Stream alpha: 2 persisted transcript entries did not parse',
+      ),
+    );
 
     store.append('alpha', {
       id: 'alpha-new',

--- a/src/tools/inquiry/externalInquiryStorage.ts
+++ b/src/tools/inquiry/externalInquiryStorage.ts
@@ -4,6 +4,7 @@ import { Mutex } from 'async-mutex';
 import { z } from 'zod';
 
 import { RUNS_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
+import { isFileNotFoundError } from '@common/errors';
 import { createChannelTrace } from '@logger';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import {
@@ -163,7 +164,13 @@ const RawTurnRecordSchema = z.looseObject(RawTurnShape);
 const ExternalInquiryTurnRecordSchema =
   RawTurnRecordSchema.transform(toCanonicalTurn);
 
+const EXTERNAL_INQUIRY_MANIFEST_SCHEMA_VERSION = 1;
+
 const ManifestBaseShape = {
+  /** Stamped on every write; absent on manifests written before it existed. */
+  schemaVersion: z
+    .literal(EXTERNAL_INQUIRY_MANIFEST_SCHEMA_VERSION)
+    .prefault(EXTERNAL_INQUIRY_MANIFEST_SCHEMA_VERSION),
   threadId: ExternalInquiryThreadIdSchema,
   parentStreamId: StreamTabIdSchema.nullable(),
   status: z.enum(['open', 'answered', 'dropped']),
@@ -190,6 +197,7 @@ const LegacyManifestSchema = z
     turns: z.array(ExternalInquiryTurnRecordSchema),
   })
   .transform((raw): ExternalInquiryThreadManifest => ({
+    schemaVersion: EXTERNAL_INQUIRY_MANIFEST_SCHEMA_VERSION,
     threadId: raw.threadId,
     parentStreamId: null,
     status: 'answered' as const,
@@ -330,14 +338,39 @@ async function hydrateAnswersFromDisk(
   return { manifest: { ...manifest, turns }, didHydrate };
 }
 
+/**
+ * Loud read (#6966 bullet 5): a missing manifest is the expected "no such
+ * thread" case, but a corrupt/unparseable one is a real failure that must
+ * not be silently conflated with it — every consumer here treats `null` as
+ * "not found" and none of them writes the manifest back on that path, so a
+ * warning (rather than a default that later gets persisted) is the correct
+ * ceiling. Distinguishes `isFileNotFoundError` from read/parse failures per
+ * the #7210 pattern.
+ */
 async function readThreadManifest(
   threadId: ExternalInquiryThreadId,
 ): Promise<ExternalInquiryThreadManifest | null> {
-  // An unreadable manifest fails schema validation below, yielding null.
-  const raw = await GlobalStorageFS.readJson<unknown>(
-    threadManifestPath(threadId),
-  ).catch(() => undefined);
-  return ExternalInquiryThreadManifestSchema.nullable().catch(null).parse(raw);
+  let raw: unknown;
+  try {
+    raw = await GlobalStorageFS.readJson<unknown>(threadManifestPath(threadId));
+  } catch (err) {
+    if (!isFileNotFoundError(err)) {
+      logger.warn(
+        `Unreadable external-inquiry manifest for ${threadId}; treating as missing.`,
+        { data: err },
+      );
+    }
+    return null;
+  }
+  const result = ExternalInquiryThreadManifestSchema.safeParse(raw);
+  if (!result.success) {
+    logger.warn(
+      `Failed to parse external-inquiry manifest for ${threadId}; treating as missing.`,
+      { data: result.error },
+    );
+    return null;
+  }
+  return result.data;
 }
 
 async function writeThreadManifest(
@@ -481,6 +514,7 @@ export async function recordOpenQuestion(params: {
 
     const timestamp = new Date().toISOString();
     const baseManifest: ExternalInquiryThreadManifest = existing ?? {
+      schemaVersion: EXTERNAL_INQUIRY_MANIFEST_SCHEMA_VERSION,
       threadId,
       parentStreamId: params.parentStreamId,
       status: 'open',

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -207,7 +207,7 @@ export class StreamLogStore {
         ) {
           return;
         }
-        const diskEntries = this.parsePersistedEntries(raw);
+        const diskEntries = this.parsePersistedEntries(streamId, raw);
         const live = this.logs.get(streamId);
         if (live && live.size > 0) {
           // A concurrent `append` populated `logs` during the disk read.
@@ -593,7 +593,7 @@ export class StreamLogStore {
 
     try {
       const raw = await this.kv.read<unknown[]>(streamId);
-      const entries = this.parsePersistedEntries(raw);
+      const entries = this.parsePersistedEntries(streamId, raw);
       if (
         entries.entries.length === 0 &&
         entries.preservedRawEntries.length === 0
@@ -746,7 +746,10 @@ export class StreamLogStore {
     for (const resolve of awaiters) resolve();
   }
 
-  private parsePersistedEntries(rawEntries: unknown): ParsedPersistedEntries {
+  private parsePersistedEntries(
+    streamId: StreamTabId,
+    rawEntries: unknown,
+  ): ParsedPersistedEntries {
     const parsed: ParsedPersistedEntries = {
       entries: [],
       preservedRawEntries: [],
@@ -763,6 +766,19 @@ export class StreamLogStore {
           raw,
         });
       }
+    }
+
+    // Loud read (#7464): unparseable rows are invisible to the typed view,
+    // so say they exist — but they are preserved verbatim and reinserted on
+    // save, never silently deleted from disk.
+    if (parsed.preservedRawEntries.length > 0) {
+      const count = parsed.preservedRawEntries.length;
+      log.warn(
+        LOG_TAG,
+        `Stream ${streamId}: ${count} persisted transcript ` +
+          `entr${count === 1 ? 'y' : 'ies'} did not parse; ` +
+          `preserving raw for round-trip on save.`,
+      );
     }
 
     return parsed;


### PR DESCRIPTION
Part of #6966, and a replacement for the closed stacked PR #7501 after #7500 merged into `main`.

## Summary

This applies the Stage 3c loud-read rule to three persistence paths: missing files remain quiet, while present-but-invalid persisted data emits a warning and degrades without overwriting the corrupt source.

- `ExecutionKVStore.readValidated` now warns unconditionally on validation failure, so config, result metadata, todos, and workspace files no longer conflate corrupt content with absent content.
- `StreamLogStore.parsePersistedEntries` now warns when persisted transcript rows fail schema parsing while preserving the raw rows for save round-trip.
- `externalInquiryStorage.readThreadManifest` distinguishes file-not-found from corrupt or unreadable manifests, adds `schemaVersion: 1` on new writes, and keeps legacy manifests readable with `.prefault`.

## Notes

This does not introduce a new migration or dual-write path. It also deliberately leaves Stage 3c's shared `repairAfterRestart` lift for a later slice.

## Validation

- `CI=true corepack pnpm exec vitest run src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts src/test-kernel/tools/ExternalInquiryResultFormatter.vitest.ts src/test-kernel/tools/InquiryContinuationSession.vitest.ts src/test-kernel/tools/InquiryStorage.vitest.ts src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts`
- `CI=true corepack pnpm exec tsc --noEmit --pretty false`
- `CI=true corepack pnpm exec eslint src/agent/storage/ExecutionKVStore.ts src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts src/test-kernel/tools/ExternalInquiryResultFormatter.vitest.ts src/test-kernel/tools/InquiryContinuationSession.vitest.ts src/test-kernel/tools/InquiryStorage.vitest.ts src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts src/tools/inquiry/externalInquiryStorage.ts src/transcript/StreamLogStore.ts`
- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches execution storage, stream transcripts, and inquiry thread manifests on read paths; behavior change is mostly observability plus safer degradation, but callers still see null/empty for corrupt data and must not assume silence means “never existed.”
> 
> **Overview**
> Implements **Stage 3c loud reads** (#6966): absent data stays silent; present-but-invalid persisted JSON logs a warning and degrades safely instead of looking like “missing.”
> 
> **`ExecutionKVStore`** — `readValidated` always warns on schema failure. `readTodos` and `readWorkspaceFiles` route through it (no more `.catch([])`), so corrupt todos/workspace-files are not treated like empty arrays without a trace.
> 
> **`StreamLogStore`** — When transcript rows fail `PersistedStreamLogEntrySchema`, the store warns per stream, keeps raw rows for save round-trip, and still exposes only parsed entries in the typed view.
> 
> **External inquiry manifests** — `readThreadManifest` uses `isFileNotFoundError` for quiet “no thread” vs warn on unreadable or invalid JSON; corrupt manifests return `null` without overwriting on-disk bytes. New writes stamp **`schemaVersion: 1`**; legacy manifests read via `.prefault`.
> 
> Vitests cover warn vs quiet-missing, corrupt manifest non-clobber, and stream log preserve-on-save behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc53d83b984be2b3ff11dc54f3f735242d3ac4dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->