### PR TITLE
refactor(modelHandlers): dedupe the shouldUseServerSideKeys runtime combinator

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -74,6 +74,7 @@ import { emitServerToolResult } from './support/serverToolResultEmission';
 import {
   resolveBaseUrl,
   shouldUseOpenRouter,
+  usesServerSideKeysRoute,
 } from './support/ProxyConfigResolver';
 import {
   type SdkErrorTagger,
@@ -354,20 +355,21 @@ export abstract class ModelHandler<
    * - Client validates SHORT NAMES (this.config.name) against tier config
    * - Server validates API NAMES (from request body) against API patterns
    * - Both are defined in RELAY_MODELS, ensuring UI filtering matches API validation
+   *
+   * Runtime combinator over profile data, not a foldable predicate (#7101
+   * triage): no handler overrides this getter — grepped across every
+   * `ModelHandler*` subclass, none redefine it — so it stays a single base
+   * implementation whose inputs (`this.config.provider`, `this.config.name`,
+   * `this.config.openRouterOnly`, `this.config.requiresResponsesAPI`) are
+   * already plain profile reads, no handler-level or stringly model-family
+   * logic feeding it. The combinator formula itself lives in
+   * {@link usesServerSideKeysRoute} so `UsageMonitor` — which deliberately
+   * holds only a `ModelConfig`-shaped value, not a full handler instance —
+   * shares it instead of re-deriving the same `!openRouter && relaySync`
+   * check independently.
    */
   protected shouldUseServerSideKeys(): boolean {
-    // Models routing through OpenRouter (openRouterOnly or global toggle) always use the
-    // OpenRouter API — the server-side relay is a direct-provider path, not an OpenRouter
-    // path, so it must never take precedence here.
-    if (shouldUseOpenRouter(this.config)) {
-      return false;
-    }
-    // Pass short name (this.config.name) for client-side tier validation.
-    // The server will separately validate the actual API model name from the request.
-    return getServerSideKeyService().shouldUseServerSideKeysSync(
-      this.config.provider,
-      this.config.name,
-    );
+    return usesServerSideKeysRoute(this.config);
   }
 
   /** Fetch an API key for the given provider, throwing `errorMessage` on failure. */

--- a/src/agent/modelHandlers/support/ProxyConfigResolver.ts
+++ b/src/agent/modelHandlers/support/ProxyConfigResolver.ts
@@ -1,6 +1,9 @@
 import { ModelProvider } from 'llm-zoo';
 import { getServerSideKeyService } from '@auth/serverKeys';
-import { shouldRouteModelThroughOpenRouter } from '@model/openRouterRouting';
+import {
+  shouldRouteModelThroughOpenRouter,
+  type OpenRouterRoutingConfig,
+} from '@model/openRouterRouting';
 import { tryParseUrl } from '@utils/core';
 import { getConfig } from '@utils/config/configUtils';
 import {
@@ -63,10 +66,7 @@ interface ProxyConfig {
  * Determines whether OpenRouter should be used for API routing.
  * Models with requiresResponsesAPI bypass OpenRouter even if globally enabled.
  */
-export function shouldUseOpenRouter(config: {
-  requiresResponsesAPI?: boolean;
-  openRouterOnly: boolean;
-}): boolean {
+export function shouldUseOpenRouter(config: OpenRouterRoutingConfig): boolean {
   return shouldRouteModelThroughOpenRouter(config, getUseOpenRouter());
 }
 
@@ -84,12 +84,12 @@ export function shouldUseOpenRouter(config: {
  * delegates to, instead of re-deriving the `!openRouter && relaySync` formula
  * independently and risking drift.
  */
-export function usesServerSideKeysRoute(config: {
-  provider: ModelProvider;
-  name: string;
-  requiresResponsesAPI?: boolean;
-  openRouterOnly: boolean;
-}): boolean {
+export function usesServerSideKeysRoute(
+  config: OpenRouterRoutingConfig & {
+    provider: ModelProvider;
+    name: string;
+  },
+): boolean {
   if (shouldUseOpenRouter(config)) {
     return false;
   }

--- a/src/agent/modelHandlers/support/ProxyConfigResolver.ts
+++ b/src/agent/modelHandlers/support/ProxyConfigResolver.ts
@@ -71,6 +71,35 @@ export function shouldUseOpenRouter(config: {
 }
 
 /**
+ * Determines whether server-side (relay) API keys should be used for a model:
+ * the OpenRouter-routing gate (relay is a direct-provider path, never an
+ * OpenRouter path) combined with the server-side key service's synchronous
+ * tier/access check.
+ *
+ * Centralized here (#7101 triage — "runtime combinator over profile data")
+ * so callers that only have a plain `ModelConfig`-shaped value, not a full
+ * `ModelHandler` instance — e.g. `UsageMonitor`, which deliberately avoids
+ * holding an `IModelHandler` reference (see `UsageMonitorModelInfo`'s doc
+ * comment) — read the same combinator `ModelHandler.shouldUseServerSideKeys()`
+ * delegates to, instead of re-deriving the `!openRouter && relaySync` formula
+ * independently and risking drift.
+ */
+export function usesServerSideKeysRoute(config: {
+  provider: ModelProvider;
+  name: string;
+  requiresResponsesAPI?: boolean;
+  openRouterOnly: boolean;
+}): boolean {
+  if (shouldUseOpenRouter(config)) {
+    return false;
+  }
+  return getServerSideKeyService().shouldUseServerSideKeysSync(
+    config.provider,
+    config.name,
+  );
+}
+
+/**
  * Resolves the base URL for API requests.
  *
  * Priority order (mutually exclusive):

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -5,8 +5,7 @@ import type { AgentRunStateSnapshot } from '@agent/core/state/AgentState';
 import type { RunUsageTotals } from '@agent/core/usage/RunUsageAccumulator';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { UsageProviderSchema } from '@agent/types/NormalizedUsage';
-import { shouldUseOpenRouter } from '@agent/modelHandlers/support/ProxyConfigResolver';
-import { getServerSideKeyService } from '@auth/serverKeys';
+import { usesServerSideKeysRoute } from '@agent/modelHandlers/support/ProxyConfigResolver';
 import type {
   ExtendedTokenUsageStats,
   StorageKey,
@@ -228,14 +227,12 @@ export class UsageMonitor {
   }
 
   private usesRelayRoute(): boolean {
-    const { config } = this.modelInfo;
-    return (
-      !shouldUseOpenRouter(config) &&
-      getServerSideKeyService().shouldUseServerSideKeysSync(
-        config.provider,
-        config.name,
-      )
-    );
+    // Shares ModelHandler's runtime combinator (#7101 triage) rather than
+    // re-deriving the same `!openRouter && relaySync` formula independently
+    // — this class deliberately holds only `modelInfo.config`
+    // (`ModelConfig`-shaped), not a full `IModelHandler` reference, so it
+    // can't call `ModelHandler.shouldUseServerSideKeys()` directly.
+    return usesServerSideKeysRoute(this.modelInfo.config);
   }
 
   /**

--- a/src/model/openRouterRouting.ts
+++ b/src/model/openRouterRouting.ts
@@ -1,4 +1,4 @@
-interface OpenRouterRoutingConfig {
+export interface OpenRouterRoutingConfig {
   requiresResponsesAPI?: boolean;
   openRouterOnly: boolean;
   forceDirectProvider?: boolean;


### PR DESCRIPTION
## Context

Part of the ongoing base-predicate triage tracked in #7101. Six earlier slices (#7346, #7353, #7369, #7386, #7397, #7450) each resolved one cluster; this PR picks up the next untouched cluster flagged in #7450's own body: the "runtime combinator" pair `shouldUseServerSideKeys()` / `shouldUseServerSideKeysSync()` (`ModelHandler.ts:358+`, already commented as "runtime combinators over profile data").

**Note:** avoiding any `close/fix(es) #7101`-shaped substring in this body and the commit message — the issue's own comment thread documents four prior false-positive auto-closes from GitHub's keyword matcher, which doesn't parse negation, triggered by exactly this kind of phrase in earlier slices' PR bodies. Using "Part of #7101" only.

## Audit

- `protected shouldUseServerSideKeys()` on `ModelHandler` — grepped every `ModelHandler*` subclass: **no handler overrides it.**
- Its inputs are already plain profile reads: `this.config.provider`, `this.config.name`, `this.config.openRouterOnly`, `this.config.requiresResponsesAPI` (fed through `shouldUseOpenRouter(this.config)` and `getServerSideKeyService().shouldUseServerSideKeysSync(...)`). No handler-level or stringly model-family logic feeds it.
- Per the issue's own triage rule for this bucket ("keep the method, no handler overrides, inputs are profile reads"), the cluster was already compliant — nothing to fold or delete.

Auditing every *call site* of `shouldUseServerSideKeysSync()` (not just `ModelHandler`'s own call) surfaced one real gap: `UsageMonitor.usesRelayRoute()` independently re-implemented the identical `!openRouter && relaySync` formula:

```ts
// UsageMonitor.ts, before
private usesRelayRoute(): boolean {
  const { config } = this.modelInfo;
  return (
    !shouldUseOpenRouter(config) &&
    getServerSideKeyService().shouldUseServerSideKeysSync(config.provider, config.name)
  );
}
```

`UsageMonitor` deliberately holds only a `ModelConfig`-shaped value (`UsageMonitorModelInfo`), not a full `IModelHandler` reference (see that interface's own doc comment), so it couldn't call `ModelHandler.shouldUseServerSideKeys()` directly — it had to re-derive the combinator. Two independent copies of the same formula is exactly the kind of drift risk this triage is meant to close off.

## Fix

Extracted the formula into `usesServerSideKeysRoute(config)` in `ProxyConfigResolver.ts`, right next to the sibling `shouldUseOpenRouter()` combinator it composes with (same file already houses this class of routing-decision combinator). `ModelHandler.shouldUseServerSideKeys()` and `UsageMonitor.usesRelayRoute()` now both delegate to it — one canonical implementation, two real call sites (not a speculative abstraction), no new class/DI/port.

Added a JSDoc audit note on `ModelHandler.shouldUseServerSideKeys()` documenting the "no overrides / already profile reads" finding, following the doc-comment pattern used by prior slices (#7369, #7397, #7450) when an audited predicate turns out to already satisfy its triage bucket.

## Verification

- `npx tsc --noEmit` — clean
- `npx tsc --noEmit -p tsconfig.test-kernel.json` — clean
- `npx eslint src/agent/modelHandlers/ModelHandler.ts src/agent/modelHandlers/support/ProxyConfigResolver.ts src/agent/utils/UsageMonitor.ts` — clean
- `npx prettier --check` on the three changed files — "All matched files use Prettier code style!"
- `npx vitest run src/test-kernel/agent/modelHandlers/ src/test-kernel/auth/ src/test-kernel/agent/runtime/` — **717 passed, 4 skipped, 0 failed**

Part of #7101 (does not close it — remaining clusters are left for follow-up PRs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor that deduplicates routing logic; relay/OpenRouter gating and tier checks are unchanged, only consolidated.
> 
> **Overview**
> Centralizes the **“use TeXRA relay vs not”** decision in `usesServerSideKeysRoute()` in `ProxyConfigResolver.ts`, next to `shouldUseOpenRouter()`. The helper is: skip relay when OpenRouter routing applies, otherwise use `shouldUseServerSideKeysSync(provider, name)`.
> 
> `ModelHandler.shouldUseServerSideKeys()` now delegates to that helper instead of inlining the formula. **`UsageMonitor.usesRelayRoute()`** had duplicated the same `!openRouter && relaySync` logic for usage-route labeling (`relay` vs `api-key`); it now calls the shared helper because it only holds `ModelConfig`-shaped data, not a handler instance.
> 
> Also exports `OpenRouterRoutingConfig` from `openRouterRouting.ts` and types `shouldUseOpenRouter()` with it. Doc comments document the #7101 “runtime combinator” audit (no handler overrides; profile reads only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a5cc8594029c1dcd0a8ef9f3bf1743d0fb83733. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->