### PR TITLE
fix(transcript): an empty source never wins conversation arbitration

### DIFF
--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -357,6 +357,66 @@ describe('completedRunArchive facade', () => {
     expect(sidecarWins.source).toBe('streamLog');
   });
 
+  it('never lets an empty-but-present legacy file beat a full sidecar (non-empty rule)', async () => {
+    const executionId = 'fff666fff666' as ExecutionId;
+    const streamId = 'orchestrator@deepseekproT#fff666fff666' as StreamTabId;
+    await writeSidecarFixture(executionId, streamId);
+    // Present but EMPTY legacy projection with an mtime after the stream
+    // log — under pure mtime arbitration this would win and hide the full
+    // transcript. The non-empty rule orders legacy first but falls through.
+    await getExecutionStore(executionId).writeConversation([]);
+    const legacyPath = await findFile(tempDirs.at(-1)!, 'conversation.json');
+    await setMtime(legacyPath, Date.now() + 60_000);
+
+    const result = await readCompletedRunConversation(executionId);
+    expect(result.source).toBe('streamLog');
+    expect(result.streamId).toBe(streamId);
+    expect(result.conversation).not.toBeNull();
+    expect(result.conversation!.length).toBeGreaterThan(0);
+  });
+
+  it('falls through to the content-bearing sibling when the resolver picks an empty log (non-empty rule)', async () => {
+    const executionId = '0777aa0777aa' as ExecutionId;
+    // Both streams are meta-matched and log-backed; the alphabetically
+    // first-scanned one holds only non-conversation rows, so the resolver's
+    // log-rank pick (#7433 criteria) reconstructs empty. No legacy file
+    // exists — the facade must fall through to the sibling that actually
+    // holds the transcript.
+    const emptyStream = 'aChild@tool#0777aa0777aa' as StreamTabId;
+    const fullStream = 'zOrchestrator@deepseekproT#0777aa0777aa' as StreamTabId;
+
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setTaskState(emptyStream, taskState('bash'), executionId);
+    snapshots.setTaskState(fullStream, taskState('orchestrator'), executionId);
+    await snapshots.flush();
+
+    const logs = new StreamLogStore();
+    await logs.load();
+    logs.ensureStream(emptyStream);
+    logs.append(
+      emptyStream,
+      logRow(MESSAGE_TYPES.PROGRESS_STATUS, { text: 'Working...' }),
+    );
+    logs.ensureStream(fullStream);
+    logs.append(
+      fullStream,
+      logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'Real question' }),
+    );
+    logs.append(
+      fullStream,
+      logRow(MESSAGE_TYPES.MODEL_RESPONSE, { text: 'Real answer' }),
+    );
+    await logs.flush();
+
+    const result = await readCompletedRunConversation(executionId);
+    expect(result.source).toBe('streamLog');
+    expect(result.streamId).toBe(fullStream);
+    expect(result.conversation).toEqual([
+      { role: 'user', content: 'Real question' },
+      { role: 'assistant', content: [{ type: 'text', text: 'Real answer' }] },
+    ]);
+  });
+
   it('falls back to legacy when the transcript holds no conversation-shaped rows', async () => {
     const executionId = 'eee555eee555' as ExecutionId;
     const streamId = 'orchestrator@deepseekproT#eee555eee555' as StreamTabId;

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -8,6 +8,8 @@
  * — each fact keeps exactly ONE legacy read arm, here, tracked for D3
  * retirement in the #6981 ledger.
  */
+import pMap from 'p-map';
+
 import { getExecutionStore, type TodoEntry } from '@agent/storage';
 import { stringifyConversationValue } from '@agent/storage/conversationFormat';
 import { isFileNotFoundError } from '@common/errors';
@@ -311,24 +313,120 @@ export function streamLogEntriesToConversation(
   );
 }
 
-async function readLegacyConversation(
+/** Legacy `conversation.json` read; `null` when missing or empty. */
+async function readLegacyConversationMessages(
   executionId: ExecutionId,
-): Promise<CompletedRunConversationReadResult> {
-  const conversation = await getExecutionStore(executionId).readConversation();
-  return {
-    conversation,
-    source: conversation ? 'legacyKV' : 'none',
-  };
+): Promise<unknown[] | null> {
+  return getExecutionStore(executionId).readConversation();
+}
+
+/** Reconstruct one stream's conversation; `[]` when the log is absent/empty. */
+async function conversationFromStream(
+  streamLogStore: StreamLogStore,
+  streamId: StreamTabId,
+): Promise<unknown[]> {
+  await streamLogStore.ensureLoaded(streamId);
+  const log = streamLogStore.get(streamId);
+  return log ? streamLogEntriesToConversation(log.toJSON()) : [];
+}
+
+/** Bounded fan-out for the sibling meta scan (mirrors the resolver's). */
+const CONVERSATION_CANDIDATE_SCAN_CONCURRENCY = 8;
+
+/**
+ * Sibling sidecar streams for the same execution, tried only when the
+ * resolver's pick reconstructs empty (cold path). #7433's resolver ranking
+ * (log-backed > workPlan-only > bare, scan order within a rank) stays the
+ * primary criteria — this layers the has-content preference on top without
+ * teaching the generic resolver (also used by the todos reader and the
+ * trace assembler) what "conversation content" means. Only log-backed
+ * siblings can yield content, so the rest are skipped.
+ */
+async function siblingConversationStreams(
+  executionId: ExecutionId,
+  primary: StreamTabId,
+  snapshotStore: StreamSnapshotStore,
+  streamLogStore: StreamLogStore,
+): Promise<StreamTabId[]> {
+  const persisted = await snapshotStore.listPersistedStreams();
+  const metaMatched = (
+    await pMap(
+      persisted,
+      async (streamId) => ({
+        streamId,
+        executionId: await snapshotStore.readPersistedExecutionId(streamId),
+      }),
+      { concurrency: CONVERSATION_CANDIDATE_SCAN_CONCURRENCY },
+    )
+  )
+    .filter((candidate) => candidate.executionId === executionId)
+    .map((candidate) => candidate.streamId);
+
+  const suffix = `#${executionId}`;
+  const suffixMatched = [...persisted, ...streamLogStore.keys()].filter((id) =>
+    id.endsWith(suffix),
+  );
+
+  const seen = new Set<StreamTabId>([primary]);
+  const siblings: StreamTabId[] = [];
+  for (const streamId of [...metaMatched, ...suffixMatched]) {
+    if (seen.has(streamId) || !streamLogStore.has(streamId)) continue;
+    seen.add(streamId);
+    siblings.push(streamId);
+  }
+  return siblings;
+}
+
+/**
+ * Sidecar arm of the non-empty rule: the resolver's pick first, then —
+ * only if it reconstructs empty — every other log-backed sibling stream
+ * sharing this executionId, in the same deterministic enumeration order the
+ * resolver scans. Returns `null` when no candidate yields content.
+ */
+async function readSidecarConversation(
+  executionId: ExecutionId,
+  primary: StreamTabId,
+  snapshotStore: StreamSnapshotStore,
+  streamLogStore: StreamLogStore,
+): Promise<CompletedRunConversationReadResult | null> {
+  const primaryConversation = await conversationFromStream(
+    streamLogStore,
+    primary,
+  );
+  if (primaryConversation.length > 0) {
+    return {
+      conversation: primaryConversation,
+      source: 'streamLog',
+      streamId: primary,
+    };
+  }
+  for (const streamId of await siblingConversationStreams(
+    executionId,
+    primary,
+    snapshotStore,
+    streamLogStore,
+  )) {
+    const conversation = await conversationFromStream(streamLogStore, streamId);
+    if (conversation.length > 0) {
+      return { conversation, source: 'streamLog', streamId };
+    }
+  }
+  return null;
 }
 
 /**
  * Read the archived conversation for a completed run from the transcript
  * sidecar (`streamLogs/{stream}.json`), reconstructed into provider-agnostic
- * messages. Falls back to the legacy `executions/{id}/conversation.json`
- * projection when the run predates the sidecars, when the transcript holds
- * no conversation-shaped rows (pre-`messageType` legacy streams), or when
- * the legacy write is fresher than the sidecar — the same mtime arbitration
- * (ties toward legacy) as {@link readCompletedRunTodos}.
+ * messages, with the legacy `executions/{id}/conversation.json` projection
+ * as the fallback arm.
+ *
+ * Arbitration protocol: the mtime comparison (ties toward legacy, same as
+ * {@link readCompletedRunTodos}) decides the ORDER the two sources are
+ * tried in — but **an empty result never wins**. A source that reads or
+ * reconstructs empty (a present-but-empty legacy file, a resolver pick
+ * whose log holds no conversation-shaped rows) falls through to the next
+ * source, symmetrically in both directions, until one yields content or
+ * all are empty.
  */
 export async function readCompletedRunConversation(
   executionId: ExecutionId,
@@ -343,25 +441,47 @@ export async function readCompletedRunConversation(
     streamLogStore = new StreamLogStore();
     await streamLogStore.load();
   }
+  const loadedStreamLogStore = streamLogStore;
 
   const resolved = await resolvePersistedStreamIdForExecution(executionId, {
     snapshotStore,
     streamLogStore,
   });
-  if (!resolved) return readLegacyConversation(executionId);
 
-  const sidecarMtime = await streamLogModifiedAt(resolved.streamId);
-  if (sidecarMtime === undefined) return readLegacyConversation(executionId);
+  const tryLegacy =
+    async (): Promise<CompletedRunConversationReadResult | null> => {
+      const conversation = await readLegacyConversationMessages(executionId);
+      return conversation ? { conversation, source: 'legacyKV' } : null;
+    };
+  const trySidecar =
+    async (): Promise<CompletedRunConversationReadResult | null> =>
+      resolved
+        ? readSidecarConversation(
+            executionId,
+            resolved.streamId,
+            snapshotStore,
+            loadedStreamLogStore,
+          )
+        : null;
 
-  const legacyMtime =
-    await getExecutionStore(executionId).conversationModifiedAt();
-  if (legacyMtime !== undefined && legacyMtime >= sidecarMtime) {
-    return readLegacyConversation(executionId);
+  // Freshness decides order only. The resolver pick's streamLogs mtime
+  // stands in for "the sidecar's" — an absent log file orders legacy first
+  // (without even statting the legacy file), and the sidecar arm still gets
+  // its turn if legacy is empty.
+  const sidecarMtime = resolved
+    ? await streamLogModifiedAt(resolved.streamId)
+    : undefined;
+  let legacyFirst = true;
+  if (sidecarMtime !== undefined) {
+    const legacyMtime =
+      await getExecutionStore(executionId).conversationModifiedAt();
+    legacyFirst = legacyMtime !== undefined && legacyMtime >= sidecarMtime;
   }
 
-  await streamLogStore.ensureLoaded(resolved.streamId);
-  const log = streamLogStore.get(resolved.streamId);
-  const conversation = log ? streamLogEntriesToConversation(log.toJSON()) : [];
-  if (conversation.length === 0) return readLegacyConversation(executionId);
-  return { conversation, source: 'streamLog', streamId: resolved.streamId };
+  const arms = legacyFirst ? [tryLegacy, trySidecar] : [trySidecar, tryLegacy];
+  for (const arm of arms) {
+    const result = await arm();
+    if (result) return result;
+  }
+  return { conversation: null, source: 'none' };
 }


### PR DESCRIPTION
Fast-follow to #7500 (merged before its last two cursor findings could land there). Part of #6966 bullet 2.

## The two findings (same root)

1. A present-but-**empty** `conversation.json` whose mtime is at/after the stream log won the freshness arbitration and hid a full sidecar transcript (`readConversation()` maps an empty array to `null` only AFTER arbitration had already committed to legacy).
2. With multiple log-backed sidecars sharing an `executionId`, the resolver's first pick in scan order won even when its log reconstructs empty while a sibling stream holds the real transcript.

## One protocol rule, not two patches

**An empty result never wins.** The mtime comparison (ties toward legacy, unchanged) now decides only the ORDER the two sources are tried in; a source that reads or reconstructs empty falls through to the next — symmetric in both directions (`legacy→sidecar` and `sidecar→legacy`) — until a source yields content or all are empty (`source: 'none'`).

Within the sidecar arm: the resolver's pick keeps #7433's ranking (merged; log-backed > workPlan-only > bare, scan order within a rank) as the primary criteria. Only when that pick reconstructs empty does the facade try the remaining **log-backed sibling streams** for the same execution, in the resolver's deterministic enumeration order — i.e. selection is "has-content first, then the existing criteria" as a stable sort. The has-content preference lives in `completedRunArchive`, not the generic resolver, because "reconstructs conversation content" is conversation-domain knowledge the resolver's other callers (todos reader, trace assembler) must not absorb. The sibling scan is a cold path: it runs only after an empty primary reconstruction.

§15 classification: L5 decide-once precedence owner (the facade remains the single arbitration point; no new fallback chains at call sites).

## Fixture evidence (both exact scenarios pinned)

- `never lets an empty-but-present legacy file beat a full sidecar`: empty `conversation.json` with mtime 60s AFTER the stream log, beside a full sidecar → `source: 'streamLog'`, full conversation.
- `falls through to the content-bearing sibling when the resolver picks an empty log`: two meta-matched, log-backed sidecars (`aChild@tool#id` with only `progressStatus` rows scans first; `zOrchestrator@…#id` holds the transcript), no legacy file → `source: 'streamLog'` with the sibling's streamId and messages.
- Existing cases (fresher-legacy-with-content wins, no-conversation-rows falls back to legacy, neither-source → `none`) still pass — content-bearing legacy behavior is unchanged.

## §14 accounting

`git diff --stat origin/main`: 2 files, **+205 / −25** (test +117). Exported symbols: 0 added / 0 deleted; 4 private helpers added inside the facade (`readLegacyConversationMessages`, `conversationFromStream`, `siblingConversationStreams`, `readSidecarConversation`), all ≥2-call-path or protocol-carrying. The legacy-mtime stat is now lazy (only taken when a sidecar exists to compare against).

## Verification

- root / test-kernel / cli / extension / desktop `tsc` clean.
- `vitest` green: `src/test-kernel/transcript/` (incl. the 9-case facade suite), `src/test-kernel/agent/storage/`, `src/test-kernel/agent/export/`, executions-tool suites, CLI history suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes precedence for completed-run conversation display/export (chat export and history) in edge cases with empty legacy projections or multi-stream sidecars; behavior is intentional but affects what users see for archived runs.
> 
> **Overview**
> **`readCompletedRunConversation`** no longer lets an empty legacy file or an empty resolver-chosen stream log “win” just because mtime or scan order favored them. **Mtime still only sets try order** (legacy first when legacy mtime ≥ sidecar, ties toward legacy); each arm must return **non-empty** content or the facade tries the other.
> 
> On the **sidecar** path, after the resolver’s primary stream, the facade can scan **other log-backed sibling streams** for the same `executionId` when the primary reconstructs no conversation-shaped messages—without changing the shared `resolvePersistedStreamIdForExecution` ranking used by todos/trace.
> 
> Two vitest cases pin the regressions: empty `conversation.json` with newer mtime vs full sidecar, and resolver picking an empty sibling log while another stream holds the transcript.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 695d232dbeb0886d2b21d8afacd34311de298999. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->