### PR TITLE
refactor(tools): share child-run delivery formatter

### DIFF
--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -29,7 +29,10 @@ import { ensureRunDir } from '@utils/files/taskRunStorage';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
 import { createChildStream, type ChildStream } from './childStream';
-import { formatDeliveryEnvelope } from './deliveryEnvelope';
+import {
+  formatChildRunDelivery,
+  formatChildRunError,
+} from './deliveryEnvelope';
 
 /** Maximum prompt length echoed back in a delivery/error XML element. */
 const DELIVERY_PROMPT_MAX = 200;
@@ -71,10 +74,10 @@ export function formatAgentCliDelivery(params: AgentCliDeliveryParams): string {
     lines.push(`<usage input="${usage.input}" output="${usage.output}" />`);
   }
   if (extraLines) lines.push(...extraLines);
-  return formatDeliveryEnvelope({
+  return formatChildRunDelivery({
     tag,
+    executionId,
     attributes: [
-      { name: 'id', value: executionId },
       { name: 'prompt', value: prompt.slice(0, DELIVERY_PROMPT_MAX) },
       {
         name: params.idAttr?.name ?? '',
@@ -95,13 +98,13 @@ export function formatAgentCliError(
   prompt: string,
   err: unknown,
 ): string {
-  return formatDeliveryEnvelope({
+  return formatChildRunError({
     tag,
+    executionId,
     attributes: [
-      { name: 'id', value: executionId },
       { name: 'prompt', value: prompt.slice(0, DELIVERY_PROMPT_MAX) },
     ],
-    bodyLines: [`<message>${escapeText(toErrorMessage(err))}</message>`],
+    message: toErrorMessage(err),
   });
 }
 

--- a/src/tools/deliveryEnvelope.ts
+++ b/src/tools/deliveryEnvelope.ts
@@ -7,24 +7,62 @@
  */
 
 // Local imports
-import { escapeAttr } from '@shared/utils/xmlEscape';
+import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
 
-export interface DeliveryEnvelopeAttribute {
+interface DeliveryEnvelopeAttribute {
   readonly name: string;
   readonly value: string | number | boolean | null | undefined;
 }
 
-export interface DeliveryEnvelopeParams {
+interface DeliveryEnvelopeParams {
   readonly tag: string;
   readonly attributes: readonly DeliveryEnvelopeAttribute[];
   readonly bodyLines: readonly string[];
 }
 
-export function formatDeliveryEnvelope(params: DeliveryEnvelopeParams): string {
+function formatDeliveryEnvelope(params: DeliveryEnvelopeParams): string {
   const attrs = params.attributes
     .filter((attr) => attr.value !== null && attr.value !== undefined)
     .map((attr) => `${attr.name}="${escapeAttr(String(attr.value))}"`)
     .join(' ');
   const open = attrs ? `<${params.tag} ${attrs}>` : `<${params.tag}>`;
   return [open, ...params.bodyLines, `</${params.tag}>`].join('\n');
+}
+
+interface ChildRunDeliveryParams {
+  readonly tag: string;
+  readonly executionId: string;
+  readonly attributes?: readonly DeliveryEnvelopeAttribute[];
+  readonly bodyLines: readonly string[];
+}
+
+export function formatChildRunDelivery(params: ChildRunDeliveryParams): string {
+  return formatDeliveryEnvelope({
+    tag: params.tag,
+    attributes: [
+      { name: 'id', value: params.executionId },
+      ...(params.attributes ?? []),
+    ],
+    bodyLines: params.bodyLines,
+  });
+}
+
+interface ChildRunErrorParams {
+  readonly tag: string;
+  readonly executionId: string;
+  readonly attributes?: readonly DeliveryEnvelopeAttribute[];
+  readonly preambleLines?: readonly string[];
+  readonly message: string;
+}
+
+export function formatChildRunError(params: ChildRunErrorParams): string {
+  return formatChildRunDelivery({
+    tag: params.tag,
+    executionId: params.executionId,
+    attributes: params.attributes,
+    bodyLines: [
+      ...(params.preambleLines ?? []),
+      `<message>${escapeText(params.message)}</message>`,
+    ],
+  });
 }

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -26,7 +26,10 @@ import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
 import { formatDuration } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { splitContentLines } from '@utils/text/stringUtils';
-import { formatDeliveryEnvelope } from './deliveryEnvelope';
+import {
+  formatChildRunDelivery,
+  formatChildRunError,
+} from './deliveryEnvelope';
 import type { DiffFileInfo } from './subagentDiffs';
 
 // ============================================================================
@@ -194,10 +197,10 @@ export function formatSubagentDelivery(
     }
   }
 
-  return formatDeliveryEnvelope({
+  return formatChildRunDelivery({
     tag: 'subagent-result',
+    executionId: result.executionId,
     attributes: [
-      { name: 'id', value: result.executionId },
       { name: 'agent', value: agentName },
       { name: 'category', value: result.category },
       { name: 'status', value: result.outcome },
@@ -220,22 +223,22 @@ export function formatSubagentError(
   },
 ): string {
   const formatted = normalizeProviderError(err);
-  const lines = [
+  const preambleLines = [
     ...formatDeliveryPreamble({
       wallTimeMs: options?.wallTimeMs,
       workingDirectory: options?.workingDirectory,
       memoryMisses: options?.memoryMisses,
     }),
   ];
-  lines.push(`<message>${escapeText(formatted.message)}</message>`);
-  return formatDeliveryEnvelope({
+  return formatChildRunError({
     tag: 'subagent-error',
+    executionId,
     attributes: [
-      { name: 'id', value: executionId },
       { name: 'agent', value: agentName },
       { name: 'retryable', value: formatted.userRetryable },
     ],
-    bodyLines: lines,
+    preambleLines,
+    message: formatted.message,
   });
 }
 


### PR DESCRIPTION
Part of #6976, first slice of the recorded PR-A plan.

## Summary

This makes the existing child-run XML envelope helper own the shared result/error envelope shape for both external CLI children and native subagents, without changing any emitted XML bytes.

- adds `formatChildRunDelivery(...)` and `formatChildRunError(...)` on top of `formatDeliveryEnvelope(...)`
- routes `formatAgentCliDelivery` / `formatAgentCliError` through that child-run protocol helper
- routes `formatSubagentDelivery` / `formatSubagentError` through the same helper

This deliberately does not move terminal finalization or the run loop yet. That remains the next F6 slice, so this PR stays behavior-preserving and easy to review.

## Validation

- `CI=true corepack pnpm exec vitest run src/test-kernel/tools/AgentCliShared.vitest.ts src/test-kernel/tools/SubagentResults.vitest.ts src/test-kernel/tools/NativeSubagentStrategy.vitest.ts src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts`
- `CI=true corepack pnpm exec tsc --noEmit --pretty false`
- `CI=true corepack pnpm exec eslint src/tools/agentCliShared.ts src/tools/deliveryEnvelope.ts src/tools/subagentResults.ts`
- `git diff --cached --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only formatting layer with tests cited in the PR; no auth, persistence, or runtime control-flow changes.
> 
> **Overview**
> Introduces **`formatChildRunDelivery`** and **`formatChildRunError`** in `deliveryEnvelope.ts` so child-run XML shares one path for the root `id` attribute, optional extra attributes, body lines, and escaped `<message>` on errors. The low-level **`formatDeliveryEnvelope`** helper is no longer exported.
> 
> **Agent-CLI** (`formatAgentCliDelivery` / `formatAgentCliError`) and **native subagent** (`formatSubagentDelivery` / `formatSubagentError`) now call those helpers instead of building envelopes directly and repeating `id` on every caller.
> 
> Intended as a behavior-preserving refactor: same XML shape and bytes, less duplication ahead of later run-loop work (#6976).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1488b34521c8b75a19cbe4e236b13393857fa47e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->