### PR TITLE
fix(agent): warn loudly on resume-time flow-record read failures

### DIFF
--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -38,6 +38,7 @@ import type { SubagentProgressUpdate } from '@shared/schemas';
 // Local imports - tools and flow
 import { getDefaultToolRegistry } from '@tools/registry';
 import { TaskRunFileService } from '@utils/files';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 import { ToolUsePrepareNode } from './nodes/ToolUsePrepareNode';
 import { ToolUseCycleNode } from './nodes/ToolUseCycleNode';
 import { ToolUseWaitNode } from './nodes/ToolUseWaitNode';
@@ -322,8 +323,13 @@ export async function runToolUseFlow<C = unknown>(
     let flowRecord: FlowRecord | null = null;
     try {
       flowRecord = (await kv.read<FlowRecord>(flowKey(executionId))) ?? null;
-    } catch {
-      logger.debug('Resume parse failed, starting fresh');
+    } catch (error) {
+      // A failed read here silently converts a resume into an empty-history
+      // fresh run -- as loud as the adjacent migration-failure warning below,
+      // so it is visible instead of vanishing into debug output.
+      logger.warn('Resume parse failed, starting fresh', {
+        data: { executionId, error: toErrorMessage(error) },
+      });
     }
     if (flowRecord?.shared) {
       logger.debug('Resuming tool-use flow from persistence');

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -43,6 +43,7 @@ import { buildUserVars } from '@agent/utils/userVars';
 import { UsageMonitor } from '@agent/utils/UsageMonitor';
 import { AgentError, getSdkErrorMessage } from '@common/errors';
 import { normalizeRunId } from '@common/constants/runIds';
+import { createChannelTrace } from '@logger';
 import { INSTRUCTION_ACTION } from '@shared/schemas';
 import {
   STREAM_PHASE,
@@ -71,6 +72,8 @@ import { attachConversationProgressHub } from './conversationProgressHub';
 import type { StreamStatusMachine } from './StreamStatusService';
 import type { ToolEditApprovalPort } from '@platform/interfaces/toolEditApproval';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
+
+const logger = createChannelTrace('AgentLaunchContext');
 
 export interface AgentLaunchContext extends AgentCore, AgentRunIdentity {
   usageMonitor: UsageMonitor;
@@ -222,7 +225,16 @@ async function inferLaunchModelHandlerCompatibilityKey(
       model,
       flowRecord?.shared,
     );
-  } catch {
+  } catch (error) {
+    // A failed read here silently falls through to the default model-handler
+    // route, which can resume with the wrong provider message format. Warn
+    // loudly instead of swallowing it so a bad resume is diagnosable.
+    logger.warn(
+      'Failed to read flow record for launch, using default model-handler route',
+      {
+        data: { executionId, error: toErrorMessage(error) },
+      },
+    );
     return undefined;
   }
 }


### PR DESCRIPTION
## Root cause

Issue #7466 (2026-07-07 error-handling audit) reports three findings; this PR fixes the two concrete, verified bugs and documents why the third is deliberately deferred.

**1. `runToolUseFlow.ts:323-327`** — the `kv.read<FlowRecord>()` that loads a tool-use flow record for resume was wrapped in a bare `catch { logger.debug(...) }`. Any read failure (IO error, corrupt JSON) silently degraded a resume into an empty-history fresh run, invisible unless debug logging happened to be on — while the very next branch in the same function (`migrationResult === null`) already `logger.warn`s for the equivalent "resume degraded to fresh start" outcome.

**2. `AgentLaunchContext.ts:225-227`** — `inferLaunchModelHandlerCompatibilityKey()`'s flow-record read had the same bare-catch-to-`undefined` shape. A failed read here makes launch fall through to `createModelHandler(modelConfig)` (today's default route) instead of `createModelHandlerForCompatibilityKey()`, which can resume a session using the wrong provider message format (e.g. Google Interactions vs GenAI) with no diagnostic trail.

**3. The 6-site `inferPersistedModelHandlerCompatibilityKey` "re-derivation"** — investigated but intentionally **not** changed in this PR (see "Deferred" below).

## Fix

Both catches keep their existing fallback behavior (start fresh / use the default handler route) — only the log level and message change, matching the sibling fixes already shipped for the same audit wave (#7463, #7464, #7467, #7468, #7470, #7471):

- `runToolUseFlow.ts`: `logger.debug('Resume parse failed, starting fresh')` → `logger.warn('Resume parse failed, starting fresh', { data: { executionId, error } })`.
- `AgentLaunchContext.ts`: added a module-level `createChannelTrace('AgentLaunchContext')` logger (this catch runs before the run trace exists, so no `AgentTrace` is available yet) and warn with `{ executionId, error }`.

## Deferred: the compatibility-key "6 call sites" finding

I traced all 6 callers of `inferPersistedModelHandlerCompatibilityKey`/`inferPersistedFlowModelHandlerCompatibilityKey` (`SessionResumeRetrieval.ts` ×2, `executeAgent.ts`, `runToolUseFlow.ts`, `runReflectionFlow.ts`, `AgentLaunchContext.ts`). Every one already follows the decide-once shape: prefer a persisted `modelHandlerCompatibilityKey` field, and only sniff message shape when that field is absent (i.e. legacy flow records written before this field existed).

Critically, in `runToolUseFlow.ts`'s backfill branch, the sniff result is given priority *over* the already-decided key read off the live model handler:

```ts
const backfillCompatibilityKey =
  inferPersistedModelHandlerCompatibilityKey(sharedModel, migratedData.messages) ??
  compatibilityKey; // the launch-decided value
```

That ordering is not an accident — it's defense-in-depth against exactly the failure this PR's finding #2 fixes: if `AgentLaunchContext`'s own inference silently failed (pre-this-PR) or legitimately found nothing, `compatibilityKey` reflects *current default* routing, not necessarily the historical message format. Sniffing the actual persisted messages first is more likely to be correct in that case. Reordering it to prefer the "decided" value, as the issue's literal ask ("decide once at launch and carry as data instead") implies, would make wrong-handler-resume (finding #2's own bug) *more* likely, not less.

A literal "eliminate the sniffing fallback" change would also break resume for any flow record written before this field existed, unless it's treated as a formally-tracked temporary exception per the active #6951 migration program ("Temporary exceptions ... are legal only with a #6981 ledger row and a removal trigger. No row, no merge."). That's a governance/design decision for the #6951/#6981 program, not something to bundle unilaterally into this bugfix. Leaving this for a maintainer decision rather than forcing a change that could regress resume resilience.

## Verification

- `npx tsc --noEmit` — clean for both changed files (repo has pre-existing unrelated errors in `@openrouter/sdk`/`vscode-jsonrpc` typings, confirmed identical before/after).
- `npx eslint src/agent/implementations/flows/tooluse/runToolUseFlow.ts src/agent/runtime/AgentLaunchContext.ts` — clean (0 errors, 0 warnings after `--fix` for import order).
- `npx prettier --check` on both files — clean.
- `npx vitest run src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts src/test-kernel/agent/modelHandlers/ModelHandlerCompatibilityInference.vitest.ts` — 6/6 pass.
- `npx vitest run src/test-kernel/agent/runtime src/test-kernel/agent/modelHandlers src/test-kernel/agent/implementations` (broader regression sweep for touched areas) — 614 passed, 4 skipped, 0 failed.
- No new automated test added: neither catch block is reachable from any existing test harness (no test-kernel suite calls `runToolUseFlow` or `buildAgentLaunchContext` directly — both require heavy scaffolding to reach), and the change is a pure log-level/message bump with no behavior change to verify.

Fixes findings 1 and 2 of #7466; finding 3 (compatibility-key consolidation) is left open pending a maintainer decision on the #6951/#6981 migration ledger.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change; resume fallbacks (fresh start / default model handler) are unchanged.
> 
> **Overview**
> Resume paths that read persisted flow records no longer swallow KV/read failures in bare `catch` blocks or **debug** logs. **Fallback behavior is unchanged** (fresh tool-use run vs default model-handler route), but failures are now **`logger.warn`** with `executionId` and `toErrorMessage(error)`.
> 
> In **`runToolUseFlow`**, a failed `kv.read` on resume is logged at warn level to match the adjacent migration-failure warning when shared state cannot be parsed. In **`AgentLaunchContext`**, `inferLaunchModelHandlerCompatibilityKey` gets a module-level `createChannelTrace('AgentLaunchContext')` logger (before a run trace exists) and warns when the flow-record read fails before falling back to `createModelHandler` instead of a compatibility-key-specific handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4271ca998b2cc0f71452ad69a486105f5661f46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->