### PR TITLE
fix(transcript): emit attachment markers and web-fetch page content into the stream log

### DIFF
--- a/src/agent/core/flows/BaseFlowServices.ts
+++ b/src/agent/core/flows/BaseFlowServices.ts
@@ -46,6 +46,8 @@ export interface AgentCore<C = unknown> {
   delegation?: DelegationPolicy;
   /** Tools unavailable because the current host/runtime cannot support them. */
   runtimeUnavailableTools?: readonly string[];
+  /** Initial user row to log after the flow has inserted launch media. */
+  initialUserMessageForTranscript?: string;
 }
 
 export interface AgentRunIdentity {

--- a/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
@@ -203,7 +203,7 @@ export class ToolUseProcessNode<C> extends BaseNode<
         blankAfterToolResult &&
         shared.blankToolResultContinuationMessageIndex !== lastMessageIndex
       ) {
-        shared.messages = await appendFollowUpAsUserMessage(
+        const result = await appendFollowUpAsUserMessage(
           shared.messages,
           {
             text: BLANK_TOOL_RESULT_CONTINUATION,
@@ -211,6 +211,7 @@ export class ToolUseProcessNode<C> extends BaseNode<
           },
           this.services,
         );
+        shared.messages = result.messages;
         shared.blankToolResultContinuationMessageIndex = lastMessageIndex;
         workspace.resetServerToolContent();
         workspace.resetReasoning();

--- a/src/agent/core/flows/toolUseRound/ToolUseRoundPrepNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseRoundPrepNode.ts
@@ -11,7 +11,6 @@ import {
   followUpDisplayText,
 } from '@agent/followUp/followUpMessages';
 import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
-import { mediaAttachmentKinds } from '@agent/runtime/mediaVisionWarning';
 
 // Local file imports
 import { FlowTransition } from '../FlowTransitions';
@@ -77,21 +76,20 @@ export class ToolUseRoundPrepNode<C> extends BaseNode<
     // This ensures user's message typed during tool execution is seen
     // before the model starts thinking/responding
     if (prepRes.queuedFollowUps?.length) {
-      if (!prepRes.synthetic) {
-        for (const followUp of prepRes.queuedFollowUps) {
-          logUserMessage(
-            this.services.logger,
-            followUpDisplayText(followUp),
-            mediaAttachmentKinds(followUp.mediaFiles),
-          );
-        }
-      }
       for (const followUp of prepRes.queuedFollowUps) {
-        shared.messages = await appendFollowUpAsUserMessage(
+        const result = await appendFollowUpAsUserMessage(
           shared.messages,
           followUp,
           this.services,
         );
+        shared.messages = result.messages;
+        if (!prepRes.synthetic) {
+          logUserMessage(
+            this.services.logger,
+            followUpDisplayText(followUp),
+            result.attachmentKinds,
+          );
+        }
       }
       if (!prepRes.synthetic) {
         this.services.onFollowUpConsumed?.();

--- a/src/agent/core/flows/toolUseRound/ToolUseRoundPrepNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseRoundPrepNode.ts
@@ -11,6 +11,7 @@ import {
   followUpDisplayText,
 } from '@agent/followUp/followUpMessages';
 import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
+import { mediaAttachmentKinds } from '@agent/runtime/mediaVisionWarning';
 
 // Local file imports
 import { FlowTransition } from '../FlowTransitions';
@@ -78,7 +79,11 @@ export class ToolUseRoundPrepNode<C> extends BaseNode<
     if (prepRes.queuedFollowUps?.length) {
       if (!prepRes.synthetic) {
         for (const followUp of prepRes.queuedFollowUps) {
-          logUserMessage(this.services.logger, followUpDisplayText(followUp));
+          logUserMessage(
+            this.services.logger,
+            followUpDisplayText(followUp),
+            mediaAttachmentKinds(followUp.mediaFiles),
+          );
         }
       }
       for (const followUp of prepRes.queuedFollowUps) {

--- a/src/agent/followUp/followUpMessages.ts
+++ b/src/agent/followUp/followUpMessages.ts
@@ -9,6 +9,7 @@ import {
   formatMediaNeedsVisionWarning,
   shouldWarnMediaNeedsVision,
 } from '@agent/runtime/mediaVisionWarning';
+import type { MediaAttachmentKind } from '@shared/schemas';
 import { summarizeFollowupMessage } from '@shared/subagentFollowup';
 import type { TaskRunFileService } from '@utils/files';
 import type { FollowUpQueueBatchItem } from './FollowUpQueue';
@@ -29,17 +30,24 @@ export function followUpDisplayText(followUp: FollowUpQueueBatchItem): string {
     : followUp.text;
 }
 
+export interface AppendFollowUpResult {
+  readonly messages: ProviderMessage[];
+  readonly attachmentKinds: MediaAttachmentKind[];
+}
+
 export async function appendFollowUpAsUserMessage<C>(
   messages: ProviderMessage[],
   followUp: FollowUpQueueBatchItem,
   services: FollowUpMessageServices<C>,
-): Promise<ProviderMessage[]> {
+): Promise<AppendFollowUpResult> {
   const nextMessages = await services.modelHandler.createUserFollowUpMessages(
     messages,
     followUp.text,
   );
 
-  if (!followUp.mediaFiles?.length) return nextMessages;
+  if (!followUp.mediaFiles?.length) {
+    return { messages: nextMessages, attachmentKinds: [] };
+  }
 
   if (
     shouldWarnMediaNeedsVision(
@@ -53,9 +61,9 @@ export async function appendFollowUpAsUserMessage<C>(
     );
   }
 
-  await services.modelHandler.addMediaToUserMessage(
+  const attachmentKinds = await services.modelHandler.addMediaToUserMessage(
     nextMessages,
     followUp.mediaFiles.map((p) => services.fileService.createLocation(p)),
   );
-  return nextMessages;
+  return { messages: nextMessages, attachmentKinds };
 }

--- a/src/agent/implementations/flows/reflection/nodes/MediaExtractionNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/MediaExtractionNode.ts
@@ -1,8 +1,9 @@
 import { Node } from '@agent/node';
+import { logUserMessage } from '@agent/trace';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
-import type { FileLocation } from '@shared/schemas';
+import type { FileLocation, MediaAttachmentKind } from '@shared/schemas';
 
 import { getFilesForRound } from '../helpers';
 import type { ReflectionFlowShared } from '../ReflectionFlowState';
@@ -94,10 +95,21 @@ export class MediaExtractionNode<C = unknown> extends Node<
   ): Promise<string | undefined> {
     shared.workspaceSnapshot = prepRes.workspaceState.toSnapshot();
 
+    let attachmentKinds: MediaAttachmentKind[] = [];
     if (mediaFiles?.length && shared.context) {
-      await this.services.modelHandler.addMediaToUserMessage(
+      attachmentKinds = await this.services.modelHandler.addMediaToUserMessage(
         shared.context.messages,
         mediaFiles,
+      );
+    }
+    if (
+      prepRes.currentRound === 0 &&
+      this.services.initialUserMessageForTranscript
+    ) {
+      logUserMessage(
+        this.services.logger,
+        this.services.initialUserMessageForTranscript,
+        attachmentKinds,
       );
     }
 

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -1,4 +1,5 @@
 import { Node } from '@agent/node';
+import { logUserMessage } from '@agent/trace';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
@@ -104,6 +105,13 @@ export class ToolUsePrepareNode<C> extends Node<
       mediaFiles,
       systemMessage,
     );
+    if (this.services.initialUserMessageForTranscript) {
+      logUserMessage(
+        logger,
+        this.services.initialUserMessageForTranscript,
+        this.services.modelHandler.consumeInsertedAttachmentKinds('initial'),
+      );
+    }
 
     return {
       kind: 'success',

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -2,6 +2,7 @@ import { maybeBuildGoalContinuation } from '@agent/goal';
 import { Node } from '@agent/node';
 import { logUserMessage } from '@agent/trace';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
+import { mediaAttachmentKinds } from '@agent/runtime/mediaVisionWarning';
 import { useLaunchRunContext } from '@agent/runtime/RunContext';
 import { emitRunFact } from '@agent/runtime/runFactEvents';
 import {
@@ -221,7 +222,11 @@ export class ToolUseWaitNode<C> extends Node<
       shared.deliveredToOrchestrator = undefined;
       onFollowUpConsumed?.();
       for (const followUp of execRes.followUps) {
-        logUserMessage(logger, followUpDisplayText(followUp));
+        logUserMessage(
+          logger,
+          followUpDisplayText(followUp),
+          mediaAttachmentKinds(followUp.mediaFiles),
+        );
       }
     }
 

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -2,7 +2,6 @@ import { maybeBuildGoalContinuation } from '@agent/goal';
 import { Node } from '@agent/node';
 import { logUserMessage } from '@agent/trace';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
-import { mediaAttachmentKinds } from '@agent/runtime/mediaVisionWarning';
 import { useLaunchRunContext } from '@agent/runtime/RunContext';
 import { emitRunFact } from '@agent/runtime/runFactEvents';
 import {
@@ -221,21 +220,22 @@ export class ToolUseWaitNode<C> extends Node<
     if (!execRes.synthetic) {
       shared.deliveredToOrchestrator = undefined;
       onFollowUpConsumed?.();
-      for (const followUp of execRes.followUps) {
-        logUserMessage(
-          logger,
-          followUpDisplayText(followUp),
-          mediaAttachmentKinds(followUp.mediaFiles),
-        );
-      }
     }
 
     for (const followUp of execRes.followUps) {
-      shared.messages = await appendFollowUpAsUserMessage(
+      const result = await appendFollowUpAsUserMessage(
         shared.messages,
         followUp,
         this.services,
       );
+      shared.messages = result.messages;
+      if (!execRes.synthetic) {
+        logUserMessage(
+          logger,
+          followUpDisplayText(followUp),
+          result.attachmentKinds,
+        );
+      }
     }
 
     return FlowTransition.CONTINUE;

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -45,7 +45,7 @@ import { isGpt5ModelName } from '@model/modelNames';
 
 // Local imports - logger
 import { MESSAGE_TYPES } from '@shared/schemas';
-import type { FileLocation } from '@shared/schemas';
+import type { FileLocation, MediaAttachmentKind } from '@shared/schemas';
 import { OUTPUT_END_TAG } from '@shared/constants/outputProtocol';
 
 // Local imports - tools
@@ -137,6 +137,16 @@ const END_TURN_REASONS: ProviderStopReason[] = [
   GOOGLE_FINISH.STOP,
 ];
 
+function mediaAttachmentKindsFromEntries(
+  entries: readonly MediaEntry[],
+): MediaAttachmentKind[] {
+  return entries.map((entry) =>
+    entry.media_category === 'image' && entry.media_type.startsWith('image/')
+      ? 'image'
+      : 'document',
+  );
+}
+
 /**
  * Abstract base class for model-specific handlers that manage API interactions, message processing, and response handling.
  * @template M Provider-specific message type
@@ -165,6 +175,11 @@ export abstract class ModelHandler<
   protected progressViewEnabled = true;
   protected agentCategory?: AgentCategory;
   protected mediaProcessor: MediaAttachmentProcessor;
+  private readonly insertedAttachmentKinds = new Map<
+    MediaAttachmentContext,
+    MediaAttachmentKind[]
+  >();
+  private createdMediaEntriesForAttachmentLog: MediaEntry[] = [];
 
   /**
    * Whether the handler supports processing attachments in tool results.
@@ -698,7 +713,22 @@ export abstract class ModelHandler<
     const { entries, results } =
       await this.mediaProcessor.loadEntries(mediaFiles);
     this.mediaProcessor.logResults(results);
+    this.setCreatedMediaEntriesForAttachmentLog(entries);
     return this.createMediaContent(entries);
+  }
+
+  protected setCreatedMediaEntriesForAttachmentLog(
+    entries: readonly MediaEntry[],
+  ): void {
+    this.createdMediaEntriesForAttachmentLog = [...entries];
+  }
+
+  public consumeInsertedAttachmentKinds(
+    context: MediaAttachmentContext,
+  ): MediaAttachmentKind[] {
+    const kinds = this.insertedAttachmentKinds.get(context) ?? [];
+    this.insertedAttachmentKinds.set(context, []);
+    return [...kinds];
   }
 
   /**
@@ -715,8 +745,19 @@ export abstract class ModelHandler<
     mediaFiles: FileLocation[],
     context: MediaAttachmentContext,
   ): Promise<Media[]> {
+    this.insertedAttachmentKinds.set(context, []);
+    this.setCreatedMediaEntriesForAttachmentLog([]);
     try {
-      return await this.createMediaMessage(mediaFiles);
+      const media = await this.createMediaMessage(mediaFiles);
+      if (media.length > 0) {
+        this.insertedAttachmentKinds.set(
+          context,
+          mediaAttachmentKindsFromEntries(
+            this.createdMediaEntriesForAttachmentLog,
+          ),
+        );
+      }
+      return media;
     } catch (err) {
       reportMediaAttachmentFailure(this.logger, context, err);
       return [];
@@ -1442,7 +1483,7 @@ export abstract class ModelHandler<
   abstract addMediaToUserMessage(
     messages: M[],
     mediaFiles: FileLocation[],
-  ): Promise<void>;
+  ): Promise<MediaAttachmentKind[]>;
 
   // =========================================================================
   // Token counting methods

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -32,7 +32,7 @@ import {
 import replacementEngine from '@replacement/engine';
 
 // Local imports - tools
-import type { FileLocation } from '@shared/schemas';
+import type { FileLocation, MediaAttachmentKind } from '@shared/schemas';
 import type {
   ToolFileAttachment,
   ToolResult,
@@ -1556,14 +1556,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
   async addMediaToUserMessage(
     messages: MessageParam[],
     mediaFiles: FileLocation[],
-  ): Promise<void> {
-    if (!mediaFiles.length || !this.capabilities.supportsVision) return;
+  ): Promise<MediaAttachmentKind[]> {
+    if (!mediaFiles.length || !this.capabilities.supportsVision) return [];
 
     const lastUserMsg = messages.findLast((m) => m.role === 'user');
-    if (!lastUserMsg) return;
+    if (!lastUserMsg) return [];
 
     const formattedMedia = await this.createMediaForRound(mediaFiles, 'insert');
-    if (formattedMedia.length === 0) return;
+    if (formattedMedia.length === 0) return [];
 
     if (typeof lastUserMsg.content === 'string') {
       lastUserMsg.content = [
@@ -1573,5 +1573,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
     } else if (Array.isArray(lastUserMsg.content)) {
       lastUserMsg.content.unshift(...formattedMedia);
     }
+    return this.consumeInsertedAttachmentKinds('insert');
   }
 }

--- a/src/agent/modelHandlers/google/googleHandlerShared.ts
+++ b/src/agent/modelHandlers/google/googleHandlerShared.ts
@@ -153,6 +153,7 @@ interface UploadGoogleMediaEntriesOptions<T> {
   logger: AgentTrace;
   buildInline: (data: string, mimeType: string) => T;
   buildUploaded: (uri: string, mimeType: string) => T;
+  onInsertedEntry?: (entry: MediaEntry) => void;
 }
 
 /**
@@ -167,8 +168,14 @@ export async function uploadGoogleMediaEntries<T>(
     return [];
   }
 
-  const { getClient, inlineLimit, logger, buildInline, buildUploaded } =
-    options;
+  const {
+    getClient,
+    inlineLimit,
+    logger,
+    buildInline,
+    buildUploaded,
+    onInsertedEntry,
+  } = options;
   const client = await getClient();
   const parts: T[] = [];
   const summaries: MediaFileResult[] = [];
@@ -186,6 +193,7 @@ export async function uploadGoogleMediaEntries<T>(
           `Attaching media entry ${fileName} inline (${payloadBytes} bytes).`,
         );
         parts.push(buildInline(inlinePayload, mimeType));
+        onInsertedEntry?.(entry);
         summaries.push({ path: fileName, ok: true });
         continue;
       }
@@ -229,6 +237,7 @@ export async function uploadGoogleMediaEntries<T>(
       const resolvedMimeType =
         uploaded.mimeType || entry.media_type || DEFAULT_ATTACHMENT_MIME_TYPE;
       parts.push(buildUploaded(fileUri, resolvedMimeType));
+      onInsertedEntry?.(entry);
       summaries.push({ path: fileName, ok: true });
     } catch (error) {
       summaries.push({ path: fileName, ok: false });

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -32,7 +32,7 @@ import {
 import replacementEngine from '@replacement/engine';
 
 // Local imports - tools
-import type { FileLocation } from '@shared/schemas';
+import type { FileLocation, MediaAttachmentKind } from '@shared/schemas';
 import type {
   ToolFileAttachment,
   ToolResult,
@@ -159,7 +159,8 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
   }
 
   protected async uploadMediaEntries(entries: MediaEntry[]): Promise<Part[]> {
-    return uploadGoogleMediaEntries<Part>(entries, {
+    const insertedEntries: MediaEntry[] = [];
+    const parts = await uploadGoogleMediaEntries<Part>(entries, {
       getClient: () => this.getClient(),
       inlineLimit: this.getInlineUploadLimitBytes(),
       logger: this.logger,
@@ -167,7 +168,10 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         createPartFromBase64(data, mimeType, this.getMediaResolution(mimeType)),
       buildUploaded: (uri, mimeType) =>
         createPartFromUri(uri, mimeType, this.getMediaResolution(mimeType)),
+      onInsertedEntry: (entry) => insertedEntries.push(entry),
     });
+    this.setCreatedMediaEntriesForAttachmentLog(insertedEntries);
+    return parts;
   }
 
   async getClient(): Promise<GoogleGenAI> {
@@ -183,7 +187,6 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       },
     });
   }
-
   /**
    * Gemini carries thought signatures across parallel function calls, which must
    * be preserved by batching the results into a single follow-up message.
@@ -1121,14 +1124,15 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
   async addMediaToUserMessage(
     messages: Content[],
     mediaFiles: FileLocation[],
-  ): Promise<void> {
-    if (!mediaFiles.length || !this.capabilities.supportsVision) return;
+  ): Promise<MediaAttachmentKind[]> {
+    if (!mediaFiles.length || !this.capabilities.supportsVision) return [];
 
     const lastUserMsg = messages.findLast((m) => m.role === 'user' && m.parts);
-    if (!lastUserMsg?.parts) return;
+    if (!lastUserMsg?.parts) return [];
 
     const formattedMedia = await this.createMediaForRound(mediaFiles, 'insert');
-    if (formattedMedia.length === 0) return;
+    if (formattedMedia.length === 0) return [];
     lastUserMsg.parts.unshift(...formattedMedia);
+    return this.consumeInsertedAttachmentKinds('insert');
   }
 }

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -32,7 +32,7 @@ import type { ToolDefinition } from '@model';
 import replacementEngine from '@replacement/engine';
 
 // Local imports - tools
-import type { FileLocation } from '@shared/schemas';
+import type { FileLocation, MediaAttachmentKind } from '@shared/schemas';
 import type {
   ToolFileAttachment,
   ToolResult,
@@ -882,7 +882,8 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
 
   /** Build typed Content for media entries (inline ≤20 MB; uploaded uri otherwise). */
   private async uploadMediaEntries(entries: MediaEntry[]): Promise<Content[]> {
-    return uploadGoogleMediaEntries<Content>(entries, {
+    const insertedEntries: MediaEntry[] = [];
+    const content = await uploadGoogleMediaEntries<Content>(entries, {
       getClient: () => this.getClient(),
       inlineLimit: this.getInlineUploadLimitBytes(),
       logger: this.logger,
@@ -890,7 +891,10 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
         this.buildMediaContent({ data }, mimeType),
       buildUploaded: (uri, mimeType) =>
         this.buildMediaContent({ uri }, mimeType),
+      onInsertedEntry: (entry) => insertedEntries.push(entry),
     });
+    this.setCreatedMediaEntriesForAttachmentLog(insertedEntries);
+    return content;
   }
 
   private textContent(text: string): TextContent {
@@ -1350,15 +1354,16 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
   async addMediaToUserMessage(
     messages: Step[],
     mediaFiles: FileLocation[],
-  ): Promise<void> {
-    if (!mediaFiles.length || !this.supportsFileUploads()) return;
+  ): Promise<MediaAttachmentKind[]> {
+    if (!mediaFiles.length || !this.supportsFileUploads()) return [];
     const lastUser = messages.findLast(
       (s): s is UserInputStep => s.type === 'user_input',
     );
-    if (!lastUser) return;
+    if (!lastUser) return [];
     const media = await this.createMediaForRound(mediaFiles, 'insert');
-    if (media.length === 0) return;
+    if (media.length === 0) return [];
     (lastUser.content ??= []).unshift(...media);
+    return this.consumeInsertedAttachmentKinds('insert');
   }
 
   // ===========================================================================

--- a/src/agent/modelHandlers/modelHandlerValidation.ts
+++ b/src/agent/modelHandlers/modelHandlerValidation.ts
@@ -9,7 +9,7 @@ import type { MediaEntry } from '@agent/utils/mediaTypes';
 
 // Local imports - tools and utils
 import replacementEngine from '@replacement/engine';
-import type { FileLocation } from '@shared/schemas';
+import type { FileLocation, MediaAttachmentKind } from '@shared/schemas';
 import type {
   ToolFileAttachment,
   ToolResult,
@@ -238,7 +238,8 @@ export class ModelHandlerValidation extends ModelHandler<
   async addMediaToUserMessage(
     _messages: ChatCompletionMessageParam[],
     _mediaFiles: FileLocation[],
-  ): Promise<void> {
+  ): Promise<MediaAttachmentKind[]> {
     // The validation model is text-only.
+    return [];
   }
 }

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -25,7 +25,7 @@ import type { ToolDefinition } from '@model';
 
 // Local imports - tools and utils
 import replacementEngine from '@replacement/engine';
-import type { FileLocation } from '@shared/schemas';
+import type { FileLocation, MediaAttachmentKind } from '@shared/schemas';
 import type {
   ToolFileAttachment,
   ToolResult,
@@ -1396,14 +1396,15 @@ export class ModelHandlerOpenAI<
   async addMediaToUserMessage(
     messages: ChatCompletionMessageParam[],
     mediaFiles: FileLocation[],
-  ): Promise<void> {
-    if (!mediaFiles.length || !this.capabilities.supportsVision) return;
+  ): Promise<MediaAttachmentKind[]> {
+    if (!mediaFiles.length || !this.capabilities.supportsVision) return [];
 
     const lastUserMsg = messages.findLast((m) => m.role === 'user');
-    if (!lastUserMsg || !('content' in lastUserMsg)) return;
+    if (!lastUserMsg || !('content' in lastUserMsg)) return [];
 
     const formattedMedia = await this.createMediaForRound(mediaFiles, 'insert');
-    if (formattedMedia.length === 0) return;
+    if (formattedMedia.length === 0) return [];
     insertMediaIntoChatUserMessage(lastUserMsg, formattedMedia);
+    return this.consumeInsertedAttachmentKinds('insert');
   }
 }

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -30,7 +30,7 @@ import type {
 import replacementEngine from '@replacement/engine';
 
 // Type imports
-import type { FileLocation } from '@shared/schemas';
+import type { FileLocation, MediaAttachmentKind } from '@shared/schemas';
 import type {
   ToolFileAttachment,
   ToolResult,
@@ -2719,14 +2719,15 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   async addMediaToUserMessage(
     messages: ResponseInputItem[],
     mediaFiles: FileLocation[],
-  ): Promise<void> {
-    if (!mediaFiles.length || !this.capabilities.supportsVision) return;
+  ): Promise<MediaAttachmentKind[]> {
+    if (!mediaFiles.length || !this.capabilities.supportsVision) return [];
 
     const lastUserMsg = this.findLastUserMessage(messages);
-    if (!lastUserMsg || !Array.isArray(lastUserMsg.content)) return;
+    if (!lastUserMsg || !Array.isArray(lastUserMsg.content)) return [];
 
     const formattedMedia = await this.createMediaForRound(mediaFiles, 'insert');
-    if (formattedMedia.length === 0) return;
+    if (formattedMedia.length === 0) return [];
     lastUserMsg.content.unshift(...formattedMedia);
+    return this.consumeInsertedAttachmentKinds('insert');
   }
 }

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -22,7 +22,7 @@ import {
 import replacementEngine from '@replacement/engine';
 
 // Local imports - tools and utils
-import type { FileLocation } from '@shared/schemas';
+import type { FileLocation, MediaAttachmentKind } from '@shared/schemas';
 import type {
   ToolFileAttachment,
   ToolResult,
@@ -828,13 +828,14 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
   async addMediaToUserMessage(
     messages: ChatMessages[],
     mediaFiles: FileLocation[],
-  ): Promise<void> {
-    if (!mediaFiles.length || !this.capabilities.supportsVision) return;
+  ): Promise<MediaAttachmentKind[]> {
+    if (!mediaFiles.length || !this.capabilities.supportsVision) return [];
     const lastUserMsg = messages.findLast((m) => m.role === 'user');
-    if (!lastUserMsg || !('content' in lastUserMsg)) return;
+    if (!lastUserMsg || !('content' in lastUserMsg)) return [];
 
     const formattedMedia = await this.createMediaForRound(mediaFiles, 'insert');
-    if (formattedMedia.length === 0) return;
+    if (formattedMedia.length === 0) return [];
     insertMediaIntoChatUserMessage(lastUserMsg, formattedMedia);
+    return this.consumeInsertedAttachmentKinds('insert');
   }
 }

--- a/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
+++ b/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
@@ -5,6 +5,8 @@
 // Third-party imports
 import { logWebFetch, type AgentTrace } from '@agent/trace';
 import {
+  capWebFetchContent,
+  extractWebFetchPageText,
   mapAnthropicWebSearchEntries,
   type WebFetchResult,
   type WebSearchResult,
@@ -378,6 +380,9 @@ export class AnthropicStreamHandler {
             provider: 'anthropic',
             callId: block.tool_use_id,
             status: 'completed',
+            content: capWebFetchContent(
+              extractWebFetchPageText(block.content.content),
+            ),
           }
         : {
             url: fetchUrl,

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -96,6 +96,7 @@ export type IModelHandler<
   | 'extractAssistantText'
   | 'prependTextToUserMessage'
   | 'addMediaToUserMessage'
+  | 'consumeInsertedAttachmentKinds'
   | 'dispose'
 > & {
   /**

--- a/src/agent/modelHandlers/types/ServerToolTypes.ts
+++ b/src/agent/modelHandlers/types/ServerToolTypes.ts
@@ -93,6 +93,8 @@ export const WebFetchResultSchema = z.object({
   status: z.enum(['completed', 'failed']),
   /** Error code if fetch failed */
   errorCode: z.string().optional(),
+  /** Fetched document text, size-capped via {@link capWebFetchContent} (#7508). */
+  content: z.string().optional(),
 });
 
 /** Unified web fetch result - derived from schema. */
@@ -307,6 +309,38 @@ function isWebFetchBlock(
 }
 
 /**
+ * Cap on the fetched page text stored on a `WebFetchResult` row (#7508): the
+ * transcript sidecar is a completed-run archive fact, not working model
+ * context, so this stays far below a typical context window while still
+ * giving the archived conversation / chat export meaningful content instead
+ * of none.
+ */
+export const MAX_WEB_FETCH_CONTENT_CHARS = 20_000;
+
+/** Truncate fetched page text to {@link MAX_WEB_FETCH_CONTENT_CHARS}. */
+export function capWebFetchContent(
+  text: string | undefined,
+): string | undefined {
+  if (!text) return undefined;
+  return text.length > MAX_WEB_FETCH_CONTENT_CHARS
+    ? `${text.slice(0, MAX_WEB_FETCH_CONTENT_CHARS)}...`
+    : text;
+}
+
+/**
+ * Extract the fetched document's plain text, when the provider returned one
+ * (`PlainTextSource`) rather than binary content (e.g. a fetched PDF's
+ * `Base64PDFSource`, which this deliberately does not surface as text).
+ * Shared by the batch ({@link extractAnthropicWebFetchResults}) and streaming
+ * (`AnthropicStreamHandler`) extraction paths.
+ */
+export function extractWebFetchPageText(
+  content: WebFetchBlock['content'] | undefined,
+): string | undefined {
+  return content?.source?.type === 'text' ? content.source.data : undefined;
+}
+
+/**
  * Extract web fetch results from Anthropic response content.
  * Uses SDK's WebFetchToolResultBlock type.
  * Correlates server_tool_use blocks (which contain the URL) with
@@ -344,6 +378,9 @@ export function extractAnthropicWebFetchResults(
         provider: 'anthropic',
         callId: block.tool_use_id,
         status: 'completed',
+        content: capWebFetchContent(
+          extractWebFetchPageText(block.content.content),
+        ),
       });
     } else {
       // Error result — block.content is narrowed to WebFetchToolResultErrorBlock

--- a/src/agent/modelHandlers/types/ServerToolTypes.ts
+++ b/src/agent/modelHandlers/types/ServerToolTypes.ts
@@ -322,8 +322,9 @@ export function capWebFetchContent(
   text: string | undefined,
 ): string | undefined {
   if (!text) return undefined;
+  const marker = '...';
   return text.length > MAX_WEB_FETCH_CONTENT_CHARS
-    ? `${text.slice(0, MAX_WEB_FETCH_CONTENT_CHARS)}...`
+    ? `${text.slice(0, MAX_WEB_FETCH_CONTENT_CHARS - marker.length)}${marker}`
     : text;
 }
 

--- a/src/agent/modelHandlers/types/ServerToolTypes.ts
+++ b/src/agent/modelHandlers/types/ServerToolTypes.ts
@@ -315,7 +315,7 @@ function isWebFetchBlock(
  * giving the archived conversation / chat export meaningful content instead
  * of none.
  */
-export const MAX_WEB_FETCH_CONTENT_CHARS = 20_000;
+const MAX_WEB_FETCH_CONTENT_CHARS = 20_000;
 
 /** Truncate fetched page text to {@link MAX_WEB_FETCH_CONTENT_CHARS}. */
 export function capWebFetchContent(

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -63,7 +63,6 @@ import {
 import {
   countMediaFilesNeedingVision,
   formatMediaNeedsVisionWarning,
-  mediaAttachmentKinds,
   shouldWarnMediaNeedsVision,
 } from './mediaVisionWarning';
 import { getStreamTabId } from './streamTab';
@@ -247,10 +246,9 @@ async function beginRunStage(
   agentLogger: AgentTrace,
   label: string,
   instruction: string | undefined,
-  mediaFiles: readonly string[] | undefined,
 ): Promise<StageHandle> {
   if (instruction) {
-    logUserMessage(agentLogger, instruction, mediaAttachmentKinds(mediaFiles));
+    logUserMessage(agentLogger, instruction);
   }
   return agentLogger.openStage(label, { kind: 'run' });
 }
@@ -380,12 +378,17 @@ async function assembleAgentLaunchContext(
     displayInstruction && !input.streamTabIdOverride
       ? displayInstruction
       : undefined;
+  const initialMediaMayBeInserted =
+    config.mediaFiles.length > 0 &&
+    (setting.agentCategory === AgentCategory.ToolUse
+      ? modelHandler.capabilities.supportsVision ||
+        modelHandler.capabilities.supportsNativeAudio
+      : modelHandler.capabilities.supportsVision);
 
   const parentStage = await beginRunStage(
     agentLogger,
     `Run: ${config.agent}`,
-    initialInstruction,
-    config.mediaFiles,
+    initialMediaMayBeInserted ? undefined : initialInstruction,
   );
   const storageKey: StorageKey = parentStage.id
     ? normalizeRunId(parentStage.id)
@@ -460,6 +463,9 @@ async function assembleAgentLaunchContext(
     runtimeHost,
     streamStatus,
     workingDirectory: configPayload.workingDirectory?.trim() || undefined,
+    initialUserMessageForTranscript: initialMediaMayBeInserted
+      ? initialInstruction
+      : undefined,
     session,
     disposeTrace: runTrace.dispose,
   };

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -63,6 +63,7 @@ import {
 import {
   countMediaFilesNeedingVision,
   formatMediaNeedsVisionWarning,
+  mediaAttachmentKinds,
   shouldWarnMediaNeedsVision,
 } from './mediaVisionWarning';
 import { getStreamTabId } from './streamTab';
@@ -246,8 +247,11 @@ async function beginRunStage(
   agentLogger: AgentTrace,
   label: string,
   instruction: string | undefined,
+  mediaFiles: readonly string[] | undefined,
 ): Promise<StageHandle> {
-  if (instruction) logUserMessage(agentLogger, instruction);
+  if (instruction) {
+    logUserMessage(agentLogger, instruction, mediaAttachmentKinds(mediaFiles));
+  }
   return agentLogger.openStage(label, { kind: 'run' });
 }
 
@@ -381,6 +385,7 @@ async function assembleAgentLaunchContext(
     agentLogger,
     `Run: ${config.agent}`,
     initialInstruction,
+    config.mediaFiles,
   );
   const storageKey: StorageKey = parentStage.id
     ? normalizeRunId(parentStage.id)

--- a/src/agent/runtime/mediaVisionWarning.ts
+++ b/src/agent/runtime/mediaVisionWarning.ts
@@ -1,3 +1,4 @@
+import type { MediaAttachmentKind } from '@shared/schemas';
 import { getMimeType } from '@utils/files';
 import type { ModelCapabilities } from 'llm-zoo';
 
@@ -5,6 +6,21 @@ type MediaVisionWarningKind = 'attached' | 'pasted';
 
 function needsVision(filePath: string): boolean {
   return !getMimeType(filePath)?.startsWith('audio/');
+}
+
+/**
+ * Classify each attached media file as `image` or `document` (everything
+ * non-image) by its MIME type — the same coarse split
+ * `normalizeConversationForExport` renders attachment markers for. Feeds the
+ * `userMessage` transcript row's attachment markers (#7508): kind + count
+ * only, never bytes.
+ */
+export function mediaAttachmentKinds(
+  mediaFiles: readonly string[] | undefined,
+): MediaAttachmentKind[] {
+  return (mediaFiles ?? []).map((filePath) =>
+    getMimeType(filePath)?.startsWith('image/') ? 'image' : 'document',
+  );
 }
 
 export function countMediaFilesNeedingVision(

--- a/src/agent/storage/conversationFormat.ts
+++ b/src/agent/storage/conversationFormat.ts
@@ -46,6 +46,10 @@ export function asText(value: unknown): string {
   return typeof value === 'string' ? value : '';
 }
 
+function objectStringField(value: unknown, key: string): string {
+  return isObject(value) ? asText(value[key]) : '';
+}
+
 /** `JSON.stringify` returns `undefined` for undefined/symbol/function values; fall back to `''` so truncation never sees a non-string. */
 export function stringifyConversationValue(value: unknown): string {
   try {
@@ -146,6 +150,26 @@ export function formatConversationBlock(
   // `text` field is the only signal, so check it before the `type` switch.
   if (typeof block.text === 'string') return block.text;
 
+  if (
+    isObject(block.inlineData) ||
+    isObject(block.fileData) ||
+    isObject(block.image_url) ||
+    isObject(block.source)
+  ) {
+    const mimeType =
+      asText(block.mimeType) ||
+      asText(block.media_type) ||
+      objectStringField(block.inlineData, 'mimeType') ||
+      objectStringField(block.inlineData, 'mime_type') ||
+      objectStringField(block.fileData, 'mimeType') ||
+      objectStringField(block.fileData, 'mime_type') ||
+      objectStringField(block.image_url, 'mime_type') ||
+      objectStringField(block.source, 'media_type');
+    return mimeType.startsWith('image/')
+      ? '[image attachment]'
+      : '[document attachment]';
+  }
+
   if (isObject(block.functionCall)) {
     return formatToolUseMarker(
       asText(block.functionCall.name) || 'unknown',
@@ -165,6 +189,14 @@ export function formatConversationBlock(
       // A recognized text block whose `text` failed the duck-type check
       // above (missing/non-string) — render empty, not its JSON form.
       return asText(block.text);
+    case 'image':
+    case 'image_url':
+    case 'input_image':
+      return '[image attachment]';
+    case 'document':
+    case 'file':
+    case 'input_file':
+      return '[document attachment]';
     case 'thinking':
     case 'redacted_thinking':
       return options.hideProviderReasoning

--- a/src/agent/trace/helpers.ts
+++ b/src/agent/trace/helpers.ts
@@ -19,6 +19,7 @@ import {
   type ConversationProgress,
   type ErrorContext,
   type FileListEntry,
+  type MediaAttachmentKind,
 } from '@shared/schemas';
 import { formatResultCount } from '@utils/text/stringUtils';
 
@@ -65,9 +66,22 @@ export function logProgressStatus(
   });
 }
 
-/** Echo a user instruction back into the transcript at the run boundary. */
-export function logUserMessage(trace: AgentTrace, message: string): void {
-  trace.info(message, { messageType: MESSAGE_TYPES.USER_MESSAGE });
+/**
+ * Echo a user instruction back into the transcript at the run boundary.
+ * `attachments` records each attached media file's kind (not bytes) so the
+ * archived conversation can render `[image attachment]` / `[document
+ * attachment]` markers for media that only ever reached the provider
+ * message (#7508).
+ */
+export function logUserMessage(
+  trace: AgentTrace,
+  message: string,
+  attachments?: readonly MediaAttachmentKind[],
+): void {
+  trace.info(message, {
+    messageType: MESSAGE_TYPES.USER_MESSAGE,
+    ...(attachments?.length ? { data: { attachments } } : {}),
+  });
 }
 
 /** Internal-only info line; subscribers suppress it from non-debug views. */

--- a/src/shared/schemas/progressView/data.ts
+++ b/src/shared/schemas/progressView/data.ts
@@ -39,6 +39,25 @@ export const MissingOutputsPayloadSchema = z.object({
   xmlFile: z.string().nullable().prefault(null),
 });
 
+/**
+ * Coarse media-attachment classification: `image` vs everything else. Matches
+ * the split `normalizeConversationForExport` already renders attachment
+ * markers for (`[image attachment]` / `[document attachment]`).
+ */
+export const MediaAttachmentKindSchema = z.enum(['image', 'document']);
+export type MediaAttachmentKind = z.infer<typeof MediaAttachmentKindSchema>;
+
+/**
+ * `userMessage` row payload (#7508): attachment kind + count only — never
+ * bytes — so the archived conversation can render `[image attachment]` /
+ * `[document attachment]` markers for media that was sent to the model but
+ * only ever lived in the provider message, not the transcript row.
+ */
+export const UserMessagePayloadSchema = z.object({
+  attachments: z.array(MediaAttachmentKindSchema).optional(),
+});
+export type UserMessagePayload = z.infer<typeof UserMessagePayloadSchema>;
+
 export const TOOL_USE_STATUS = {
   IN_PROGRESS: 'in_progress',
   COMPLETED: 'completed',
@@ -109,5 +128,7 @@ export const WebFetchPayloadSchema = z.object({
   provider: z.string().optional(),
   status: z.string().optional(),
   errorCode: z.string().optional(),
+  /** Fetched document text, size-capped at the source (#7508). */
+  content: z.string().optional(),
 });
 export type WebFetchPayload = z.infer<typeof WebFetchPayloadSchema>;

--- a/src/shared/schemas/progressView/data.ts
+++ b/src/shared/schemas/progressView/data.ts
@@ -44,7 +44,7 @@ export const MissingOutputsPayloadSchema = z.object({
  * the split `normalizeConversationForExport` already renders attachment
  * markers for (`[image attachment]` / `[document attachment]`).
  */
-export const MediaAttachmentKindSchema = z.enum(['image', 'document']);
+const MediaAttachmentKindSchema = z.enum(['image', 'document']);
 export type MediaAttachmentKind = z.infer<typeof MediaAttachmentKindSchema>;
 
 /**
@@ -56,7 +56,6 @@ export type MediaAttachmentKind = z.infer<typeof MediaAttachmentKindSchema>;
 export const UserMessagePayloadSchema = z.object({
   attachments: z.array(MediaAttachmentKindSchema).optional(),
 });
-export type UserMessagePayload = z.infer<typeof UserMessagePayloadSchema>;
 
 export const TOOL_USE_STATUS = {
   IN_PROGRESS: 'in_progress',

--- a/src/test-kernel/agent/followUp/ToolUseDispatchInterruption.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseDispatchInterruption.vitest.ts
@@ -86,7 +86,7 @@ describe('ToolUseDispatchNode interruption', () => {
       },
       logger: createRunTrace('ToolUseDispatchInterruption').trace,
       modelHandler: {
-        addMediaToUserMessage: vi.fn(async () => {}),
+        addMediaToUserMessage: vi.fn(async () => []),
         capabilities: { supportsVision: true },
         createAssistantMessageFromResponse: vi.fn(
           (_response: unknown, text: string) =>
@@ -256,7 +256,7 @@ describe('ToolUseDispatchNode interruption', () => {
       },
       logger: createRunTrace('ToolUseDispatchInterruption').trace,
       modelHandler: {
-        addMediaToUserMessage: vi.fn(async () => {}),
+        addMediaToUserMessage: vi.fn(async () => []),
         capabilities: { supportsVision: true },
         createAssistantMessageFromResponse: vi.fn(
           (_response: unknown, text: string) =>

--- a/src/test-kernel/agent/followUp/ToolUseRoundFollowUpMedia.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseRoundFollowUpMedia.vitest.ts
@@ -25,7 +25,7 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
           { role: 'user', content: userMessage },
         ] as ProviderMessage[],
     );
-    const addMediaToUserMessage = vi.fn(async () => {});
+    const addMediaToUserMessage = vi.fn(async () => []);
 
     const services = {
       checkInterruption: () => false,
@@ -163,7 +163,7 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
       },
       logger: createRunTrace('ToolUseRoundBlankToolResult').trace,
       modelHandler: {
-        addMediaToUserMessage: vi.fn(async () => {}),
+        addMediaToUserMessage: vi.fn(async () => []),
         capabilities: { supportsVision: true },
         createAssistantMessageFromResponse: vi.fn(
           (_response: unknown, text: string) =>
@@ -349,7 +349,7 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
       },
       logger: createRunTrace('ToolUseRoundSystemPrompt').trace,
       modelHandler: {
-        addMediaToUserMessage: vi.fn(async () => {}),
+        addMediaToUserMessage: vi.fn(async () => []),
         capabilities: { supportsVision: true },
         createAssistantMessageFromResponse: vi.fn(
           (_response: unknown, text: string) =>

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -308,8 +308,9 @@ describe('ToolUseWaitNode', () => {
       shouldSkipCycle: false,
       stateSlices: null,
     };
+    const info = vi.fn();
     const warn = vi.fn();
-    const addMediaToUserMessage = vi.fn(async () => {});
+    const addMediaToUserMessage = vi.fn(async () => []);
     const runtimeHost = { emit: vi.fn() };
 
     const services = {
@@ -317,7 +318,7 @@ describe('ToolUseWaitNode', () => {
       fileService: {
         createLocation: (filePath: string) => ({ absolutePath: filePath }),
       },
-      logger: { emit: vi.fn(), info: vi.fn(), warn },
+      logger: { emit: vi.fn(), info, warn },
       modelHandler: {
         addMediaToUserMessage,
         capabilities: {
@@ -362,6 +363,69 @@ describe('ToolUseWaitNode', () => {
       expect.stringContaining('Model has no vision support'),
     );
     expect(addMediaToUserMessage).toHaveBeenCalledOnce();
+    expect(info).toHaveBeenCalledWith(
+      'please inspect this figure',
+      expect.not.objectContaining({
+        data: expect.objectContaining({ attachments: expect.anything() }),
+      }),
+    );
+  });
+
+  it('logs follow-up markers reported by provider insertion', async () => {
+    const shared: ToolUseRunShared = {
+      messages: [],
+      shouldSkipCycle: false,
+      stateSlices: null,
+    };
+    const info = vi.fn();
+    const runtimeHost = { emit: vi.fn() };
+
+    const services = {
+      checkInterruption: () => false,
+      fileService: {
+        createLocation: (filePath: string) => ({ absolutePath: filePath }),
+      },
+      logger: { emit: vi.fn(), info, warn: vi.fn() },
+      modelHandler: {
+        addMediaToUserMessage: vi.fn(async () => ['image']),
+        capabilities: {
+          supportsNativeAudio: false,
+          supportsVision: true,
+        },
+        createUserFollowUpMessages: vi.fn(async () => []),
+      },
+      runtimeHost,
+      streamStatus: new StreamStatusMachine(),
+      streamId: 'test-stream',
+    } as unknown as ToolUseServices;
+
+    const node = new ToolUseWaitNode().setServices(services);
+    await withTestRunContext(runtimeHost, 'test-stream', () =>
+      node.post(
+        shared,
+        {
+          afterError: false,
+          lastResponse: undefined,
+          previouslyDeliveredToOrchestrator: false,
+          touchedFiles: [],
+        },
+        {
+          followUps: [
+            {
+              text: 'please inspect this figure',
+              mediaFiles: ['/tmp/figure.png', '/tmp/missing.pdf'],
+              origin: 'user',
+            },
+          ],
+          kind: 'continue',
+        },
+      ),
+    );
+
+    expect(info).toHaveBeenCalledWith('please inspect this figure', {
+      messageType: MESSAGE_TYPES.USER_MESSAGE,
+      data: { attachments: ['image'] },
+    });
   });
 
   it('pauses the goal after a failed parent cycle', async () => {

--- a/src/test-kernel/agent/modelHandlers/ServerToolTypes.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ServerToolTypes.vitest.ts
@@ -1,0 +1,14 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'vitest';
+
+import { capWebFetchContent } from '@agent/modelHandlers/types/ServerToolTypes';
+
+describe('capWebFetchContent', () => {
+  it('includes the ellipsis in the advertised maximum length', () => {
+    const capped = capWebFetchContent('x'.repeat(20_001));
+
+    assert.equal(capped?.length, 20_000);
+    assert.equal(capped?.endsWith('...'), true);
+    assert.equal(capped, `${'x'.repeat(19_997)}...`);
+  });
+});

--- a/src/test-kernel/agent/runtime/mediaVisionWarning.vitest.ts
+++ b/src/test-kernel/agent/runtime/mediaVisionWarning.vitest.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 import {
   countMediaFilesNeedingVision,
   formatMediaNeedsVisionWarning,
+  mediaAttachmentKinds,
   shouldWarnMediaNeedsVision,
 } from '@agent/runtime/mediaVisionWarning';
 
@@ -51,5 +52,20 @@ describe('media vision warnings', () => {
     expect(formatMediaNeedsVisionWarning(2, 'pasted')).toBe(
       'Model has no vision support — 2 pasted media files are not sent to the model. Switch to a vision-capable model to use them.',
     );
+  });
+
+  // #7508: classifies each attached file as image/document (kind only, no
+  // bytes) so the userMessage transcript row can carry attachment markers.
+  describe('mediaAttachmentKinds', () => {
+    it('classifies image files as image and everything else as document', () => {
+      expect(
+        mediaAttachmentKinds(['figure.png', 'notes.pdf', 'voice.mp3']),
+      ).toEqual(['image', 'document', 'document']);
+    });
+
+    it('returns an empty array for no media files', () => {
+      expect(mediaAttachmentKinds(undefined)).toEqual([]);
+      expect(mediaAttachmentKinds([])).toEqual([]);
+    });
   });
 });

--- a/src/test-kernel/agent/trace/logUserMessage.vitest.ts
+++ b/src/test-kernel/agent/trace/logUserMessage.vitest.ts
@@ -1,0 +1,68 @@
+// Third-party imports
+import { strict as assert } from 'node:assert';
+import { describe, it, beforeEach, afterEach } from 'vitest';
+
+// Local imports
+import {
+  createRunTrace,
+  getDefaultStreamLogStore,
+  setDefaultStreamLogStore,
+  StreamLogStore,
+} from '@transcript';
+import { logUserMessage, type AgentTrace } from '@agent/trace';
+import { MESSAGE_TYPES } from '@shared/schemas';
+
+// #7508: the `userMessage` row's attachment-kind/count payload — verifies
+// `logUserMessage` stamps `data.attachments` when attachments are present,
+// and stays byte-for-byte the same (no `data` at all) for the common no-media
+// case so every other consumer of this row is unaffected.
+describe('logUserMessage', () => {
+  let logger: AgentTrace;
+  let disposeTrace: () => void;
+
+  beforeEach(async () => {
+    const store = new StreamLogStore();
+    setDefaultStreamLogStore(store);
+    await store.clear();
+    const runTrace = createRunTrace('TestUserMessageLogger');
+    logger = runTrace.trace;
+    disposeTrace = runTrace.dispose;
+  });
+
+  afterEach(() => {
+    disposeTrace();
+  });
+
+  const capturedEntries = () => {
+    const log = getDefaultStreamLogStore().get('TestUserMessageLogger');
+    return log?.getRange(0, log.head) ?? [];
+  };
+
+  it('logs a plain userMessage row with no data when there are no attachments', () => {
+    logUserMessage(logger, 'Fix the lemma.');
+
+    const entries = capturedEntries();
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].messageType, MESSAGE_TYPES.USER_MESSAGE);
+    assert.equal(entries[0].text, 'Fix the lemma.');
+    assert.equal(entries[0].data, undefined);
+  });
+
+  it('omits data when the attachments array is empty', () => {
+    logUserMessage(logger, 'Fix the lemma.', []);
+
+    const entries = capturedEntries();
+    assert.equal(entries[0].data, undefined);
+  });
+
+  it('records attachment kinds (not bytes) on the row data', () => {
+    logUserMessage(logger, 'See the attached figure.', ['image', 'document']);
+
+    const entries = capturedEntries();
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].messageType, MESSAGE_TYPES.USER_MESSAGE);
+    assert.deepEqual(entries[0].data, {
+      attachments: ['image', 'document'],
+    });
+  });
+});

--- a/src/test-kernel/tools/ExecutionsConversationFormat.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsConversationFormat.vitest.ts
@@ -29,6 +29,26 @@ describe('formatConversation', () => {
     expect(output).toContain('[tool_result: done]');
   });
 
+  it('formats media blocks as readable attachment markers', () => {
+    const output = formatConversation([
+      {
+        role: 'user',
+        content: [
+          { type: 'input_image', image_url: 'data:image/png;base64,abc' },
+          {
+            type: 'document',
+            source: { type: 'base64', media_type: 'application/pdf' },
+          },
+          { inlineData: { mimeType: 'image/png', data: 'abc' } },
+        ],
+      },
+    ]);
+
+    expect(output).toContain('[image attachment]');
+    expect(output).toContain('[document attachment]');
+    expect(output).not.toContain('base64');
+  });
+
   it('renders known blocks with missing fields and JSON-stringifies unknown shapes', () => {
     const output = formatConversation([
       {

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -103,6 +103,7 @@ async function writeSidecarFixture(
     streamId,
     logRow(MESSAGE_TYPES.USER_MESSAGE, {
       text: 'Fix the lemma.',
+      data: { attachments: ['image'] },
     }),
   );
   logs.append(
@@ -131,6 +132,7 @@ async function writeSidecarFixture(
         provider: 'anthropic',
         callId: 'wf-1',
         status: 'completed',
+        content: 'The Sobolev constant satisfies...',
       },
     }),
   );
@@ -213,7 +215,10 @@ describe('completedRunArchive facade', () => {
     expect(conversationResult.source).toBe('streamLog');
     expect(conversationResult.streamId).toBe(streamId);
     expect(conversationResult.conversation).toEqual([
-      { role: 'user', content: 'Fix the lemma.' },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Fix the lemma.' }, { type: 'image' }],
+      },
       {
         role: 'assistant',
         content: [
@@ -247,6 +252,7 @@ describe('completedRunArchive facade', () => {
             type: 'web_fetch_tool_result',
             url: 'https://example.org/a',
             title: 'Sobolev notes',
+            page_content: 'The Sobolev constant satisfies...',
           },
         ],
       },

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -18,6 +18,7 @@ import {
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
   ToolUseLogSchema,
+  UserMessagePayloadSchema,
   WebFetchPayloadSchema,
   WebSearchPayloadSchema,
   type ExecutionId,
@@ -152,6 +153,18 @@ function streamLogModifiedAt(
   return new KVStore(STREAM_LOGS_DIR).modifiedAt(streamId);
 }
 
+/**
+ * Deliberate non-goal (#7508): image blocks inside a tool result are not
+ * reconstructed here. `ToolUseLog.output` only ever carries display text —
+ * a local `ToolResult.output` is a plain string, and any image content a
+ * tool_result block sends to the provider is built at message-construction
+ * time from `ToolResult.files` (base64 attachment bytes), which never
+ * reaches the transcript row. Unlike the web-fetch page-content case,
+ * there's no existing size-capped/marker-only slot for this in the export
+ * pipeline (`ExportNode`'s `tool-result` kind is `{text}` only), and
+ * reconstructing one would mean threading attachment bytes through
+ * `tool.end` just to summarize them — out of scope here.
+ */
 function toolResultText(tool: ToolUseLog): string | undefined {
   if (tool.error !== undefined) return tool.error;
   if (typeof tool.output === 'string') return tool.output;
@@ -159,8 +172,32 @@ function toolResultText(tool: ToolUseLog): string | undefined {
   return tool.summary;
 }
 
+/**
+ * `userMessage` rows may carry an attachment-kind/count payload (#7508) —
+ * media that was sent to the model but only ever lived in the provider
+ * message. When present, render `content` as Anthropic-shaped blocks
+ * (`{type:'image'}` / `{type:'document'}`, no bytes) so
+ * `normalizeConversationForExport`'s existing attachment-marker rendering
+ * (`[image attachment]` / `[document attachment]`) picks them up; otherwise
+ * keep the plain-string `content` shape every other conversation consumer
+ * already expects.
+ */
 function userMessageEntryToMessages(entry: StreamLogEntry): unknown[] {
-  return entry.text ? [{ role: 'user', content: entry.text }] : [];
+  if (!entry.text) return [];
+  const parsed = UserMessagePayloadSchema.safeParse(entry.data);
+  const attachments = parsed.success ? (parsed.data.attachments ?? []) : [];
+  if (attachments.length === 0) {
+    return [{ role: 'user', content: entry.text }];
+  }
+  return [
+    {
+      role: 'user',
+      content: [
+        { type: 'text', text: entry.text },
+        ...attachments.map((kind) => ({ type: kind })),
+      ],
+    },
+  ];
 }
 
 function modelResponseEntryToMessages(entry: StreamLogEntry): unknown[] {
@@ -240,6 +277,11 @@ function webFetchEntryToMessages(entry: StreamLogEntry): unknown[] {
           type: 'web_fetch_tool_result',
           url: parsed.data.url,
           ...(parsed.data.title !== undefined && { title: parsed.data.title }),
+          // `page_content` is the field name normalizeConversationForExport's
+          // ContentBlockSchema already recognizes for this block type (#7508).
+          ...(parsed.data.content !== undefined && {
+            page_content: parsed.data.content,
+          }),
         },
       ],
     },


### PR DESCRIPTION
## Root cause

Stage 3c (#7246 Decision 1) made the transcript sidecar (`streamLogs/{stream}.json`) the single completed-run record — `conversation.json` is now a read-only legacy fallback. `streamLogEntriesToConversation` (`src/transcript/completedRunArchive.ts`) is exhaustive over `MessageType`, but three content classes that existed only in provider messages never reached the stream log in the first place, so the mapper had nothing to reconstruct them from (#7500's cursor finding, formalized as this follow-up issue):

1. User-message media-attachment markers (`addMediaToUserMessage` attaches image/document blocks to the provider message only; the `userMessage` row carries display text).
2. Web-fetch page content (`WebFetchResult` carried `url`/`title`/`status` only; the Anthropic `web_fetch_tool_result` block also carries the fetched document text).
3. Tool-result media (`ToolUseLog.output` is display text; image blocks inside tool results are dropped).

Notably, (1) and (2) already had unused downstream plumbing waiting for them: `normalizeConversationForExport`'s `ContentBlockSchema` already has a `page_content` field and a `case 'web_fetch_tool_result'` arm that reads it (`src/agent/export/normalizeConversation.ts`), and `blocksToUserParts` already renders `[image attachment]` / `[document attachment]` markers for `{type:'image'}` / `{type:'document'}` content blocks. Only the row-shape hop into the transcript was missing.

## Fix

**Class 1 — user-message attachments** (emitted, mapper extended):
- `logUserMessage` (`src/agent/trace/helpers.ts`) now accepts an optional `attachments: readonly MediaAttachmentKind[]` and stamps `data.attachments` on the row when non-empty.
- A new `mediaAttachmentKinds()` helper (`src/agent/runtime/mediaVisionWarning.ts`) classifies each attached file path as `image`/`document` by MIME type (kind only, never bytes) — reused at all three call sites.
- Wired at the launch-context initial-instruction echo (`AgentLaunchContext.ts`, using `config.mediaFiles`) and both follow-up-injection sites (`ToolUseRoundPrepNode.ts`, `ToolUseWaitNode.ts`, using `followUp.mediaFiles`).
- `userMessageEntryToMessages` (`completedRunArchive.ts`) renders `content` as an Anthropic-shaped block array (`{type:'text',...}` + `{type:'image'|'document'}`) when attachments are present, falling back to the existing plain-string shape otherwise (no behavior change for the common no-media case).
- New schema: `UserMessagePayloadSchema` / `MediaAttachmentKindSchema` (`src/shared/schemas/progressView/data.ts`).

**Class 2 — web-fetch page content** (emitted, mapper extended):
- `WebFetchResultSchema` (`ServerToolTypes.ts`) gains an optional `content` field: the fetched document's plain text, size-capped at 20k chars (`MAX_WEB_FETCH_CONTENT_CHARS`/`capWebFetchContent`), extracted only when the provider returned `PlainTextSource` (`extractWebFetchPageText`) — binary fetches (e.g. a fetched PDF's `Base64PDFSource`) are deliberately not surfaced as text.
- Wired in both the streaming path (`AnthropicStreamHandler.handleWebFetchResult`) and the non-streaming path (`extractAnthropicWebFetchResults`, used by `ToolUseProcessNode`'s non-streaming `logWebFetch` call).
- `WebFetchPayloadSchema` gains a matching optional `content` field.
- `webFetchEntryToMessages` maps it to `page_content` — the exact field name `normalizeConversationForExport`'s `ContentBlockSchema` already expects for this block type.

**Class 3 — tool-result media** (documented as a deliberate non-goal, per the issue's decide-or-document acceptance criteria):
- Unlike (2), there's no existing downstream slot: `ToolResult.output` is always a plain string locally, and any image content a `tool_result` block sends to the provider is built at message-construction time from `ToolResult.files` (base64 bytes) — never through `tool.end`/`ToolUseLog`. `ExportNode`'s `tool-result` kind is `{text}`-only, with no attachment-marker precedent. Reconstructing this would mean threading attachment bytes through the tool-result emission path just to summarize them — out of scope here. Documented with the reason directly above `toolResultText` in `completedRunArchive.ts`.

## Verification

- `npx tsc --noEmit && npx tsc --noEmit -p tsconfig.test-kernel.json` — clean
- `npx eslint <changed files>` — clean (one auto-fixed import-order warning)
- `npx prettier --check <changed files>` — clean (one auto-formatted test fixture)
- `npx vitest run` on the directly relevant suites — all pass:
  - `src/test-kernel/transcript/completedRunArchive.vitest.ts` (extended the #7500 fixture to pin both new classes)
  - `src/test-kernel/agent/runtime/mediaVisionWarning.vitest.ts` (new `mediaAttachmentKinds` coverage)
  - `src/test-kernel/agent/trace/logUserMessage.vitest.ts` (new — pins `logUserMessage`'s attachment-data contract, including the "no attachments → no `data`" no-op case)
  - `src/test-kernel/agent/modelHandlers/` (53 files, 419 tests)
  - `src/test-kernel/agent/followUp/`, `src/test-kernel/agent/trace/`, `src/test-kernel/transcript/`, `src/test-kernel/agent/export/`, `src/test-kernel/commands/history/`

## Verified

Opened and read in full before editing: `src/transcript/completedRunArchive.ts`, `src/agent/followUp/followUpMessages.ts`, `src/agent/runtime/AgentLaunchContext.ts`, `src/agent/trace/helpers.ts`, `src/agent/trace/AgentTrace.ts`, `src/agent/modelHandlers/types/ServerToolTypes.ts`, `src/agent/modelHandlers/support/AnthropicStreamHandler.ts`, `src/agent/modelHandlers/support/serverToolResultEmission.ts`, `src/agent/modelHandlers/anthropic/anthropicServerTools.ts`, `src/agent/modelHandlers/anthropic/anthropicTools.ts`, `src/agent/core/flows/toolUseRound/ToolUseRoundPrepNode.ts`, `src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts`, `src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts`, `src/agent/export/normalizeConversation.ts`, `src/agent/export/schemas.ts`, `src/agent/export/chatExport/{markdownSpec,latexSpec}.ts`, `src/agent/storage/conversationFormat.ts`, `src/shared/schemas/progressView/data.ts`, `src/shared/schemas/toolResult.ts`, `src/agent/runtime/mediaVisionWarning.ts`, `src/test-kernel/transcript/completedRunArchive.vitest.ts`, plus the Anthropic SDK's `WebFetchBlock`/`DocumentBlock`/`PlainTextSource` type definitions.

Fixes #7508.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and how user rows are written across launch, follow-up, and reflection flows, plus provider media plumbing; impact is mostly transcript/archive fidelity rather than model I/O, but regressions could affect chat history and completed-run exports.
> 
> **Overview**
> **Fills gaps in the completed-run transcript** so `streamLogEntriesToConversation` can reconstruct content that previously lived only in provider messages (#7508).
> 
> **User-message media:** `logUserMessage` can stamp `data.attachments` (`image` / `document`, no bytes). Model handlers track what was actually inserted via `createMediaForRound` / `consumeInsertedAttachmentKinds`, and `addMediaToUserMessage` returns those kinds. Launch runs with attachable media defer the initial user row until after media is wired (`initialUserMessageForTranscript` on tool-use prepare, reflection `MediaExtractionNode`, etc.); follow-up injection logs attachment kinds **after** `appendFollowUpAsUserMessage` attaches media. The archive mapper turns those rows into text + `{type:'image'|'document'}` blocks, and export formatting renders `[image attachment]` / `[document attachment]` markers.
> 
> **Web fetch:** Anthropic web-fetch results now carry optional plain-text `content` (20k cap) in both streaming and batch extraction; transcript `WEB_FETCH` payloads and archive export use `page_content` for the same field export already understood.
> 
> **Out of scope:** Tool-result image bytes remain undocumented in the archive path (comment only). Tests cover `logUserMessage`, attachment classification, web-fetch capping, conversation formatting, and extended `completedRunArchive` fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc5a3d484270c44e425932a0ee00b59bed269dda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->