### PR TITLE
test(storage): cover resumability acceptance matrix

### DIFF
--- a/src/test-kernel/agent/storage/Resumability.vitest.ts
+++ b/src/test-kernel/agent/storage/Resumability.vitest.ts
@@ -8,8 +8,15 @@ import {
   getExecutionStore,
   RESUMABILITY_CAUSE,
 } from '@agent/storage';
+import { detectWaitingStreams } from '@agent/storage/detectWaitingStreams';
 import { flowKey, type FlowRecord } from '@agent/node/persistedFlow';
-import { EXECUTION_STATUS, type ExecutionId } from '@shared/schemas';
+import {
+  EXECUTION_STATUS,
+  RUN_OUTCOME,
+  type ExecutionId,
+  type RunOutcome,
+  type StreamTabId,
+} from '@shared/schemas';
 
 const BASE_FLOW_RECORD: FlowRecord = {
   flowName: 'texra',
@@ -38,10 +45,21 @@ describe('deriveResumability', () => {
     executionId: ExecutionId,
     terminalStatus: string,
   ): Promise<void> {
+    await writeMeta(executionId, { terminalStatus });
+  }
+
+  async function writeMeta(
+    executionId: ExecutionId,
+    {
+      terminalStatus,
+      outcome,
+    }: { terminalStatus?: string; outcome?: RunOutcome },
+  ): Promise<void> {
     await getExecutionStore(executionId).writeMeta({
       schemaVersion: EXECUTION_META_SCHEMA_VERSION,
       timestamp: '2026-07-05T00:00:00.000Z',
       terminalStatus,
+      outcome,
     });
   }
 
@@ -79,6 +97,38 @@ describe('deriveResumability', () => {
       cause: RESUMABILITY_CAUSE.INTERRUPTED_WITH_FLOW,
       terminalStatus: EXECUTION_STATUS.INTERRUPTED,
       flowRecord: BASE_FLOW_RECORD,
+    });
+  });
+
+  it('marks cancelled executions with a valid flow record as resumable', async () => {
+    const executionId = 'cancelled-with-flow' as ExecutionId;
+    await writeMeta(executionId, {
+      terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+      outcome: RUN_OUTCOME.CANCELLED,
+    });
+    await writeFlow(executionId);
+
+    await expect(deriveResumability(executionId)).resolves.toMatchObject({
+      resumable: true,
+      cause: RESUMABILITY_CAUSE.INTERRUPTED_WITH_FLOW,
+      terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+      outcome: RUN_OUTCOME.CANCELLED,
+      flowRecord: BASE_FLOW_RECORD,
+    });
+  });
+
+  it('does not mark cancelled executions resumable without a flow record', async () => {
+    const executionId = 'cancelled-missing-flow' as ExecutionId;
+    await writeMeta(executionId, {
+      terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+      outcome: RUN_OUTCOME.CANCELLED,
+    });
+
+    await expect(deriveResumability(executionId)).resolves.toMatchObject({
+      resumable: false,
+      cause: RESUMABILITY_CAUSE.MISSING_FLOW,
+      terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+      outcome: RUN_OUTCOME.CANCELLED,
     });
   });
 
@@ -146,5 +196,40 @@ describe('deriveResumability', () => {
       resumable: false,
       cause: RESUMABILITY_CAUSE.UNREADABLE_FLOW,
     });
+  });
+
+  it('projects only resumable executions into WAITING streams', async () => {
+    const crashExecutionId = 'waiting-crash-with-flow' as ExecutionId;
+    const cancelledExecutionId = 'waiting-cancelled-with-flow' as ExecutionId;
+    const completedExecutionId = 'waiting-completed-with-flow' as ExecutionId;
+    const missingFlowExecutionId =
+      'waiting-interrupted-missing-flow' as ExecutionId;
+
+    await writeFlow(crashExecutionId);
+    await writeMeta(cancelledExecutionId, {
+      terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+      outcome: RUN_OUTCOME.CANCELLED,
+    });
+    await writeFlow(cancelledExecutionId);
+    await writeTerminalStatus(completedExecutionId, EXECUTION_STATUS.COMPLETED);
+    await writeFlow(completedExecutionId);
+    await writeTerminalStatus(
+      missingFlowExecutionId,
+      EXECUTION_STATUS.INTERRUPTED,
+    );
+
+    const streamIdsByExecutionId = new Map<StreamTabId, ExecutionId>([
+      ['crash-stream' as StreamTabId, crashExecutionId],
+      ['cancelled-stream' as StreamTabId, cancelledExecutionId],
+      ['completed-stream' as StreamTabId, completedExecutionId],
+      ['missing-flow-stream' as StreamTabId, missingFlowExecutionId],
+    ]);
+
+    await expect(detectWaitingStreams(streamIdsByExecutionId)).resolves.toEqual(
+      new Set<StreamTabId>([
+        'crash-stream' as StreamTabId,
+        'cancelled-stream' as StreamTabId,
+      ]),
+    );
   });
 });


### PR DESCRIPTION
## Summary

- extend `deriveResumability` coverage for cancelled/user-stopped runs with and without a persisted flow record
- add a storage-boundary WAITING projection test through `detectWaitingStreams`
- make the Stage 3c crash/completed/failed/cancelled matrix explicit without changing production behavior

## Validation

- `CI=true corepack pnpm exec vitest run src/test-kernel/agent/storage/Resumability.vitest.ts`
- `CI=true corepack pnpm exec tsc --noEmit --pretty false`
- `CI=true corepack pnpm exec eslint src/test-kernel/agent/storage/Resumability.vitest.ts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to Vitest tests; production storage/resumability behavior is unchanged.
> 
> **Overview**
> Expands **`Resumability.vitest.ts`** so the resumability acceptance matrix is explicit in tests only—no production changes.
> 
> Test helpers now support writing **`outcome`** on execution meta via a shared **`writeMeta`**, and new cases assert **cancelled** runs (`INTERRUPTED` + `RUN_OUTCOME.CANCELLED`) are resumable only when a flow record exists, mirroring interrupted/crash behavior.
> 
> Adds an integration-style case for **`detectWaitingStreams`**: among crash, cancelled-with-flow, completed, and interrupted-without-flow fixtures, only streams backed by **resumable** executions are projected into the WAITING set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49e742b89be484b5741e9e8dabd6ed6ddcf2a233. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->