### PR TITLE
refactor(tools): centralize terminal child-run delivery

### DIFF
--- a/src/test-kernel/tools/ChildRunDelivery.vitest.ts
+++ b/src/test-kernel/tools/ChildRunDelivery.vitest.ts
@@ -5,13 +5,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
 const mocks = vi.hoisted(() => ({
+  writeResultMeta: vi.fn(),
   writeReport: vi.fn(),
   sendFollowUp: vi.fn(),
   wakeOrReleaseQueuedStream: vi.fn(),
 }));
 
 vi.mock('@agent/storage', () => ({
-  getExecutionStore: vi.fn(() => ({ writeReport: mocks.writeReport })),
+  getExecutionStore: vi.fn(() => ({
+    writeReport: mocks.writeReport,
+    writeResultMeta: mocks.writeResultMeta,
+  })),
 }));
 
 vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
@@ -22,7 +26,9 @@ vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
 // Local imports - tools
 import {
   deliverChildRunFollowUp,
+  deliverTerminalChildRun,
   persistChildRunReport,
+  persistChildRunResultMeta,
 } from '@tools/childRunDelivery';
 
 describe('child run delivery', () => {
@@ -47,6 +53,22 @@ describe('child run delivery', () => {
     await expect(
       persistChildRunReport('exec-1' as ExecutionId, 'payload'),
     ).resolves.toEqual({ kind: 'failed', err });
+  });
+
+  it('persists result manifests through the execution store', async () => {
+    const resultMeta = {
+      agentName: 'review',
+      outcome: 'completed',
+      success: true,
+      wallTimeMs: 1,
+    } as const;
+    mocks.writeResultMeta.mockResolvedValue(undefined);
+
+    await expect(
+      persistChildRunResultMeta('exec-1' as ExecutionId, resultMeta),
+    ).resolves.toEqual({ kind: 'persisted' });
+
+    expect(mocks.writeResultMeta).toHaveBeenCalledWith(resultMeta);
   });
 
   it('delivers a follow-up with the explicit owner session', async () => {
@@ -126,5 +148,120 @@ describe('child run delivery', () => {
         wake: true,
       }),
     ).resolves.toEqual({ kind: 'dropped' });
+  });
+
+  it('writes the result manifest before waking the parent for terminal delivery', async () => {
+    const session = { tag: 'owner-session' };
+    const order: string[] = [];
+    const gate = {
+      beginDelivery: vi.fn(() => {
+        order.push('begin');
+        return true;
+      }),
+      completeDelivery: vi.fn(() => {
+        order.push('complete');
+      }),
+      failDelivery: vi.fn(() => {
+        order.push('fail');
+      }),
+    };
+    mocks.writeResultMeta.mockImplementation(async () => {
+      order.push('manifest');
+    });
+    mocks.writeReport.mockImplementation(async () => {
+      order.push('report');
+    });
+    mocks.sendFollowUp.mockImplementation(async () => {
+      order.push('send');
+      return { status: 'queued', reason: 'children_running' };
+    });
+    mocks.wakeOrReleaseQueuedStream.mockImplementation(async () => {
+      order.push('wake');
+      return true;
+    });
+
+    await expect(
+      deliverTerminalChildRun({
+        executionId: 'exec-1' as ExecutionId,
+        message: 'payload',
+        resultMeta: {
+          agentName: 'review',
+          outcome: 'completed',
+          success: true,
+          wallTimeMs: 1,
+        },
+        targetStreamId: 'parent' as StreamTabId,
+        session: session as never,
+        gate,
+      }),
+    ).resolves.toMatchObject({
+      kind: 'delivered',
+      report: { kind: 'persisted' },
+      resultMeta: { kind: 'persisted' },
+    });
+
+    expect(order.indexOf('manifest')).toBeLessThan(order.indexOf('send'));
+    expect(order.indexOf('send')).toBeLessThan(order.indexOf('wake'));
+    expect(gate.completeDelivery).toHaveBeenCalledOnce();
+    expect(gate.failDelivery).not.toHaveBeenCalled();
+  });
+
+  it('persists terminal reports even when duplicate delivery is suppressed', async () => {
+    const session = { tag: 'owner-session' };
+    const gate = {
+      beginDelivery: vi.fn(() => false),
+      completeDelivery: vi.fn(),
+      failDelivery: vi.fn(),
+    };
+    mocks.writeReport.mockResolvedValue(undefined);
+
+    await expect(
+      deliverTerminalChildRun({
+        executionId: 'exec-1' as ExecutionId,
+        message: 'payload',
+        targetStreamId: 'parent' as StreamTabId,
+        session: session as never,
+        gate,
+      }),
+    ).resolves.toMatchObject({
+      kind: 'duplicate',
+      report: { kind: 'persisted' },
+    });
+
+    expect(mocks.writeReport).toHaveBeenCalledWith('payload');
+    expect(mocks.sendFollowUp).not.toHaveBeenCalled();
+    expect(gate.completeDelivery).not.toHaveBeenCalled();
+    expect(gate.failDelivery).not.toHaveBeenCalled();
+  });
+
+  it('fails the terminal gate when delivery drops so a later attempt can retry', async () => {
+    const session = { tag: 'owner-session' };
+    const gate = {
+      beginDelivery: vi.fn(() => true),
+      completeDelivery: vi.fn(),
+      failDelivery: vi.fn(),
+    };
+    mocks.writeReport.mockResolvedValue(undefined);
+    mocks.sendFollowUp.mockResolvedValue({
+      status: 'queued',
+      reason: 'children_running',
+    });
+    mocks.wakeOrReleaseQueuedStream.mockResolvedValue(false);
+
+    await expect(
+      deliverTerminalChildRun({
+        executionId: 'exec-1' as ExecutionId,
+        message: 'payload',
+        targetStreamId: 'parent' as StreamTabId,
+        session: session as never,
+        gate,
+      }),
+    ).resolves.toMatchObject({
+      kind: 'dropped',
+      report: { kind: 'persisted' },
+    });
+
+    expect(gate.failDelivery).toHaveBeenCalledOnce();
+    expect(gate.completeDelivery).not.toHaveBeenCalled();
   });
 });

--- a/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
+++ b/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
@@ -13,7 +13,9 @@ import {
 
 const mocks = vi.hoisted(() => ({
   deliverChildRunFollowUp: vi.fn(),
+  deliverTerminalChildRun: vi.fn(),
   persistChildRunReport: vi.fn(),
+  persistChildRunResultMeta: vi.fn(),
   readConfig: vi.fn(),
   resumeQueuedToolUseSnapshot: vi.fn(),
   retrieveSessionResumeData: vi.fn(),
@@ -37,7 +39,9 @@ vi.mock('@agent/runtime/resumeQueuedToolUse', () => ({
 
 vi.mock('@tools/childRunDelivery', () => ({
   deliverChildRunFollowUp: mocks.deliverChildRunFollowUp,
+  deliverTerminalChildRun: mocks.deliverTerminalChildRun,
   persistChildRunReport: mocks.persistChildRunReport,
+  persistChildRunResultMeta: mocks.persistChildRunResultMeta,
 }));
 
 import { SharedSubagentDeliveryRegistry } from '@tools/subagentDeliveryState';
@@ -56,25 +60,20 @@ describe('NativeSubagentStrategy', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.deliverTerminalChildRun.mockResolvedValue({
+      kind: 'delivered',
+      report: { kind: 'persisted' },
+      resultMeta: { kind: 'skipped' },
+    });
+    mocks.persistChildRunReport.mockResolvedValue({ kind: 'persisted' });
+    mocks.persistChildRunResultMeta.mockResolvedValue({ kind: 'persisted' });
   });
 
   afterEach(() => {
     SharedSubagentDeliveryRegistry.finish(executionId);
   });
 
-  it('persists the result manifest before waking the parent', async () => {
-    const order: string[] = [];
-    mocks.writeResultMeta.mockImplementation(async () => {
-      order.push('manifest');
-    });
-    mocks.deliverChildRunFollowUp.mockImplementation(async () => {
-      order.push('wake');
-      return { kind: 'delivered' };
-    });
-    mocks.persistChildRunReport.mockImplementation(async () => {
-      order.push('report');
-      return { kind: 'persisted' };
-    });
+  it('delegates terminal delivery to the child-run delivery owner', async () => {
     const strategy = new NativeSubagentStrategy({
       executionId,
       agentName: 'review',
@@ -94,22 +93,24 @@ describe('NativeSubagentStrategy', () => {
       }),
     ).resolves.toBe(true);
 
-    expect(order[0]).toBe('manifest');
-    expect(order).toContain('wake');
-    expect(order).toContain('report');
-    expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledWith({
+    expect(mocks.deliverTerminalChildRun).toHaveBeenCalledWith({
+      executionId,
+      message: 'payload',
+      resultMeta: {
+        agentName: 'review',
+        outcome: 'completed',
+        success: true,
+        wallTimeMs: 1,
+      },
       targetStreamId: parentStreamId,
-      followUp: { text: 'payload', origin: 'subagent_result' },
       session: ownerSession,
-      wake: true,
+      gate: expect.any(Object),
     });
   });
 
   it('uses the captured run handle delivery target', async () => {
     const handleParent = 'handle-parent' as StreamTabId;
     const childStream = 'child-stream' as StreamTabId;
-    mocks.persistChildRunReport.mockResolvedValue({ kind: 'persisted' });
-    mocks.deliverChildRunFollowUp.mockResolvedValue({ kind: 'delivered' });
     const strategy = new NativeSubagentStrategy({
       executionId,
       agentName: 'review',
@@ -134,18 +135,24 @@ describe('NativeSubagentStrategy', () => {
       true,
     );
 
-    expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledWith({
-      targetStreamId: handleParent,
-      followUp: { text: 'payload', origin: 'subagent_result' },
-      session: ownerSession,
-      wake: true,
-    });
+    expect(mocks.deliverTerminalChildRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        executionId,
+        message: 'payload',
+        targetStreamId: handleParent,
+        session: ownerSession,
+      }),
+    );
   });
 
-  it('suppresses delivery after the captured run handle is detached', async () => {
+  it('suppresses parent delivery after the captured run handle is detached', async () => {
     const handleParent = 'handle-parent' as StreamTabId;
     const childStream = 'child-stream' as StreamTabId;
-    mocks.persistChildRunReport.mockResolvedValue({ kind: 'persisted' });
+    mocks.deliverTerminalChildRun.mockResolvedValue({
+      kind: 'no_target',
+      report: { kind: 'persisted' },
+      resultMeta: { kind: 'skipped' },
+    });
     const strategy = new NativeSubagentStrategy({
       executionId,
       agentName: 'review',
@@ -170,19 +177,28 @@ describe('NativeSubagentStrategy', () => {
       false,
     );
 
-    expect(mocks.deliverChildRunFollowUp).not.toHaveBeenCalled();
-    expect(mocks.persistChildRunReport).toHaveBeenCalledWith(
-      executionId,
-      'payload',
+    expect(mocks.deliverTerminalChildRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        executionId,
+        message: 'payload',
+        targetStreamId: undefined,
+        session: ownerSession,
+      }),
     );
   });
 
-  it('resets the in-flight delivery gate when terminal delivery drops', async () => {
-    mocks.writeResultMeta.mockResolvedValue(undefined);
-    mocks.persistChildRunReport.mockResolvedValue({ kind: 'persisted' });
-    mocks.deliverChildRunFollowUp
-      .mockResolvedValueOnce({ kind: 'dropped' })
-      .mockResolvedValueOnce({ kind: 'delivered' });
+  it('returns false when terminal delivery is not completed', async () => {
+    mocks.deliverTerminalChildRun
+      .mockResolvedValueOnce({
+        kind: 'dropped',
+        report: { kind: 'persisted' },
+        resultMeta: { kind: 'skipped' },
+      })
+      .mockResolvedValueOnce({
+        kind: 'delivered',
+        report: { kind: 'persisted' },
+        resultMeta: { kind: 'skipped' },
+      });
     const strategy = new NativeSubagentStrategy({
       executionId,
       agentName: 'review',
@@ -199,6 +215,45 @@ describe('NativeSubagentStrategy', () => {
     await expect(strategy.persistAndDeliverTerminal('second')).resolves.toBe(
       true,
     );
+
+    expect(mocks.deliverTerminalChildRun).toHaveBeenCalledTimes(2);
+  });
+
+  it('delivers progress follow-ups to the captured run handle delivery target', async () => {
+    const handleParent = 'handle-parent' as StreamTabId;
+    const childStream = 'child-stream' as StreamTabId;
+    mocks.deliverChildRunFollowUp.mockResolvedValue({ kind: 'delivered' });
+    const strategy = new NativeSubagentStrategy({
+      executionId,
+      agentName: 'review',
+      orchestratorStreamId: parentStreamId,
+      parentSession: ownerSession,
+      runtimeHost: { emit: vi.fn() },
+      startedAt: 0,
+      settleSubagentCost: vi.fn(),
+    });
+    strategy.setRunHandle(
+      new AgentExecutionHandle(
+        executionId,
+        handleParent,
+        childStream,
+        'review',
+        'toolUse',
+        {} as never,
+      ),
+    );
+
+    strategy.onProgress({
+      kind: 'stage',
+      message: 'running',
+    } as never);
+
+    expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledWith({
+      targetStreamId: handleParent,
+      followUp: expect.objectContaining({ origin: 'subagent_result' }),
+      session: ownerSession,
+      wake: undefined,
+    });
   });
 
   it('resumes queued follow-ups with native delivery callbacks', async () => {
@@ -274,8 +329,6 @@ describe('NativeSubagentStrategy', () => {
     mocks.retrieveSessionResumeData.mockRejectedValue(
       new Error('resume storage unreadable'),
     );
-    mocks.persistChildRunReport.mockResolvedValue({ kind: 'persisted' });
-    mocks.deliverChildRunFollowUp.mockResolvedValue({ kind: 'delivered' });
 
     const strategy = new NativeSubagentStrategy({
       executionId,
@@ -295,15 +348,13 @@ describe('NativeSubagentStrategy', () => {
     // The failure must reach the orchestrator through the same terminal
     // delivery channel a resumed turn's own onError uses — not just a log
     // line at the DelegationTools call site.
-    expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledTimes(1);
-    const [deliveredCall] = mocks.deliverChildRunFollowUp.mock.calls;
+    expect(mocks.deliverTerminalChildRun).toHaveBeenCalledTimes(1);
+    const [deliveredCall] = mocks.deliverTerminalChildRun.mock.calls;
     expect(deliveredCall[0]).toMatchObject({
+      executionId,
+      message: expect.stringContaining('resume storage unreadable'),
       targetStreamId: parentStreamId,
-      wake: true,
     });
-    expect(deliveredCall[0].followUp.text).toContain(
-      'resume storage unreadable',
-    );
 
     // Terminal delivery retires this run: a later delegate_agent resume
     // attempt must not find stale strategy/registry state.

--- a/src/tools/childRunDelivery.ts
+++ b/src/tools/childRunDelivery.ts
@@ -7,7 +7,7 @@
  */
 
 // Local imports - agent
-import { getExecutionStore } from '@agent/storage';
+import { getExecutionStore, type ResultMeta } from '@agent/storage';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import {
   sendFollowUp,
@@ -26,12 +26,52 @@ export type ChildRunDeliveryResult =
 export type ChildRunReportResult =
   { kind: 'persisted' } | { kind: 'failed'; err: unknown };
 
+export type ChildRunResultMetaResult =
+  | { kind: 'persisted' }
+  | { kind: 'skipped' }
+  | { kind: 'failed'; err: unknown };
+
+export interface ChildRunTerminalDeliveryGate {
+  beginDelivery(): boolean;
+  completeDelivery(): void;
+  failDelivery(): void;
+}
+
+type ChildRunTerminalPersistence = {
+  readonly report: ChildRunReportResult;
+  readonly resultMeta: ChildRunResultMetaResult;
+};
+
+export type ChildRunTerminalDeliveryResult = ChildRunTerminalPersistence &
+  (
+    | { readonly kind: 'delivered' }
+    | { readonly kind: 'duplicate' }
+    | { readonly kind: 'no_target' }
+    | { readonly kind: 'no_session'; readonly streamStatus: string | undefined }
+    | { readonly kind: 'dropped' }
+  );
+
 export async function persistChildRunReport(
   executionId: ExecutionId,
   message: string,
 ): Promise<ChildRunReportResult> {
   try {
     await getExecutionStore(executionId).writeReport(message);
+    return { kind: 'persisted' };
+  } catch (err) {
+    return { kind: 'failed', err };
+  }
+}
+
+export async function persistChildRunResultMeta(
+  executionId: ExecutionId,
+  resultMeta: ResultMeta | undefined,
+): Promise<ChildRunResultMetaResult> {
+  if (!resultMeta) {
+    return { kind: 'skipped' };
+  }
+  try {
+    await getExecutionStore(executionId).writeResultMeta(resultMeta);
     return { kind: 'persisted' };
   } catch (err) {
     return { kind: 'failed', err };
@@ -64,4 +104,73 @@ export async function deliverChildRunFollowUp(params: {
   ))
     ? { kind: 'delivered' }
     : { kind: 'dropped' };
+}
+
+/**
+ * Persist and deliver a terminal child-run result.
+ *
+ * The result manifest is written before the parent wake so a resumed parent
+ * can immediately read `/executions/{id}/result`. The report write is
+ * best-effort and runs for every attempted terminal delivery, including
+ * duplicates and missing parent targets, preserving the durable transcript.
+ */
+export async function deliverTerminalChildRun(params: {
+  readonly executionId: ExecutionId;
+  readonly message: string;
+  readonly resultMeta?: ResultMeta;
+  readonly targetStreamId: StreamTabId | undefined;
+  readonly session: SessionHandle;
+  readonly gate?: ChildRunTerminalDeliveryGate;
+}): Promise<ChildRunTerminalDeliveryResult> {
+  const resultMeta = await persistChildRunResultMeta(
+    params.executionId,
+    params.resultMeta,
+  );
+  const reportPromise = persistChildRunReport(
+    params.executionId,
+    params.message,
+  );
+
+  const persistence = async (): Promise<ChildRunTerminalPersistence> => ({
+    report: await reportPromise,
+    resultMeta,
+  });
+
+  if (params.gate && !params.gate.beginDelivery()) {
+    return { kind: 'duplicate', ...(await persistence()) };
+  }
+
+  if (!params.targetStreamId) {
+    params.gate?.failDelivery();
+    return { kind: 'no_target', ...(await persistence()) };
+  }
+
+  let delivery: ChildRunDeliveryResult;
+  try {
+    delivery = await deliverChildRunFollowUp({
+      targetStreamId: params.targetStreamId,
+      followUp: { text: params.message, origin: 'subagent_result' },
+      session: params.session,
+      wake: true,
+    });
+  } catch (err) {
+    params.gate?.failDelivery();
+    await reportPromise;
+    throw err;
+  }
+
+  if (delivery.kind === 'delivered') {
+    params.gate?.completeDelivery();
+    return { kind: 'delivered', ...(await persistence()) };
+  }
+
+  params.gate?.failDelivery();
+  if (delivery.kind === 'no_session') {
+    return {
+      kind: 'no_session',
+      streamStatus: delivery.streamStatus,
+      ...(await persistence()),
+    };
+  }
+  return { kind: 'dropped', ...(await persistence()) };
 }

--- a/src/tools/delegation/nativeSubagentStrategy.ts
+++ b/src/tools/delegation/nativeSubagentStrategy.ts
@@ -39,7 +39,10 @@ import {
 } from '@shared/schemas';
 import {
   deliverChildRunFollowUp,
+  deliverTerminalChildRun,
   persistChildRunReport,
+  persistChildRunResultMeta,
+  type ChildRunTerminalDeliveryResult,
 } from '@tools/childRunDelivery';
 import {
   buildSubagentFailureResultMeta,
@@ -157,12 +160,11 @@ export async function writeSubagentResultMeta(
   executionId: ExecutionId,
   resultMeta: ResultMeta,
 ): Promise<void> {
-  try {
-    await getExecutionStore(executionId).writeResultMeta(resultMeta);
-  } catch (err) {
+  const result = await persistChildRunResultMeta(executionId, resultMeta);
+  if (result.kind === 'failed') {
     logger.warn(
       'subagentDelivery',
-      `Failed to persist subagent result manifest for ${executionId}: ${toErrorMessage(err)}`,
+      `Failed to persist subagent result manifest for ${executionId}: ${toErrorMessage(result.err)}`,
     );
   }
 }
@@ -243,24 +245,6 @@ export class NativeSubagentStrategy {
     return true;
   }
 
-  async deliverTerminalFollowUp(
-    followUp: FollowUpQueueInput,
-  ): Promise<boolean> {
-    if (!this.deliveryState.beginDelivery()) return false;
-    try {
-      const delivered = await this.deliverFollowUp(followUp, { wake: true });
-      if (delivered) {
-        this.deliveryState.completeDelivery();
-      } else {
-        this.deliveryState.failDelivery();
-      }
-      return delivered;
-    } catch (err) {
-      this.deliveryState.failDelivery();
-      throw err;
-    }
-  }
-
   /**
    * Deliver a terminal result and persist its report and manifest. The manifest
    * lands before wake because the parent can immediately read
@@ -270,15 +254,54 @@ export class NativeSubagentStrategy {
     msg: string,
     resultMeta?: ResultMeta,
   ): Promise<boolean> {
+    const { executionId, parentSession } = this.params;
+    const targetStreamId = this.runHandle
+      ? this.runHandle.deliveryTargetStreamId
+      : this.params.orchestratorStreamId;
+    const result = await deliverTerminalChildRun({
+      executionId,
+      message: msg,
+      resultMeta,
+      targetStreamId,
+      session: parentSession,
+      gate: this.deliveryState,
+    });
+    this.warnTerminalDeliveryResult(result, targetStreamId);
+    return result.kind === 'delivered';
+  }
+
+  private warnTerminalDeliveryResult(
+    result: ChildRunTerminalDeliveryResult,
+    targetStreamId: StreamTabId | undefined,
+  ): void {
     const { executionId } = this.params;
-    if (resultMeta) {
-      await writeSubagentResultMeta(executionId, resultMeta);
+    if (result.resultMeta.kind === 'failed') {
+      logger.warn(
+        'subagentDelivery',
+        `Failed to persist subagent result manifest for ${executionId}: ${toErrorMessage(result.resultMeta.err)}`,
+      );
     }
-    const [delivered] = await Promise.all([
-      this.deliverTerminalFollowUp({ text: msg, origin: 'subagent_result' }),
-      writeSubagentReport(executionId, msg),
-    ]);
-    return delivered;
+    if (result.report.kind === 'failed') {
+      // Non-fatal, but the report is the only durable copy of the result when
+      // delivery later fails.
+      logger.warn(
+        'subagentDelivery',
+        `Failed to persist subagent report for ${executionId}: ${toErrorMessage(result.report.err)}`,
+      );
+    }
+    if (result.kind === 'no_session') {
+      logger.warn(
+        'subagentDelivery',
+        `Unable to deliver subagent result for ${executionId}: parent stream ${targetStreamId ?? 'unknown'} has no active session (status: ${result.streamStatus ?? 'unknown'}).`,
+      );
+      return;
+    }
+    if (result.kind === 'dropped') {
+      logger.warn(
+        'subagentDelivery',
+        `Dropped subagent result for ${executionId}: parent stream ${targetStreamId ?? 'unknown'} is gone and could not be resumed. The result remains in the execution report.`,
+      );
+    }
   }
 
   onProgress(update: SubagentProgressUpdate): void {


### PR DESCRIPTION
## Summary

- make `childRunDelivery` own terminal child-run delivery: result manifest persistence before parent wake, duplicate-delivery gate handling, follow-up wake, and best-effort report persistence
- keep native strategy responsible for native-specific target selection, progress delivery, lifecycle state, and warning text
- move the order-sensitive terminal delivery tests to `ChildRunDelivery.vitest` and retarget native tests to the new owner boundary

## Validation

- `CI=true corepack pnpm exec vitest run src/test-kernel/tools/ChildRunDelivery.vitest.ts src/test-kernel/tools/NativeSubagentStrategy.vitest.ts`
- `CI=true corepack pnpm exec vitest run src/test-kernel/tools/DelegationHeadless.vitest.mts src/test-kernel/tools/SubagentResults.vitest.ts src/test-kernel/tools/AgentCliShared.vitest.ts`
- `CI=true corepack pnpm exec tsc --noEmit --pretty false`
- `CI=true corepack pnpm exec eslint src/tools/childRunDelivery.ts src/tools/delegation/nativeSubagentStrategy.ts src/test-kernel/tools/ChildRunDelivery.vitest.ts src/test-kernel/tools/NativeSubagentStrategy.vitest.ts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subagent-to-parent delivery ordering and duplicate/retry gating on a critical orchestration path; behavior is intended to be preserved but regressions could affect result visibility or follow-up retries.
> 
> **Overview**
> **Terminal subagent completion** is now orchestrated in `childRunDelivery` via `deliverTerminalChildRun` and `persistChildRunResultMeta`, instead of `NativeSubagentStrategy` wiring manifest writes, report persistence, duplicate gating, follow-up enqueue, and parent wake itself.
> 
> The shared path **writes the result manifest before** enqueue/wake so a resumed parent can read `/executions/{id}/result` immediately, still **persists the report on every terminal attempt** (including duplicate suppression and missing targets), and drives an optional **delivery gate** (`begin` / `complete` / `fail`) so dropped wakes can retry.
> 
> `NativeSubagentStrategy.persistAndDeliverTerminal` now only picks the parent stream (orchestrator vs run-handle target), calls `deliverTerminalChildRun` with `deliveryState` as the gate, and maps structured outcomes to warnings; `deliverTerminalFollowUp` is removed. `writeSubagentResultMeta` delegates to `persistChildRunResultMeta`.
> 
> Order-sensitive and gate behavior tests move to `ChildRunDelivery.vitest.ts`; native strategy tests mock the new boundary and assert delegation, targets, and resume-failure terminal delivery (#7402).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a67efbb00074f4fedcef4d66310f1f828c467f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->