### PR TITLE
fix(storage): version-gate manifest reads; fail non-array stream logs instead of overwriting

### DIFF
--- a/src/test-kernel/tools/InquiryStorage.vitest.ts
+++ b/src/test-kernel/tools/InquiryStorage.vitest.ts
@@ -3,9 +3,10 @@
  * dropped path, follow-up turn semantics, legacy manifest migration,
  * and listing filters.
  */
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { setupPlatform } from '@test/support/setupPlatform';
+import * as logUtils from '@logger/logUtils';
 import {
   ExternalInquiryPermissionSchema,
   type ExternalInquiryThreadId,
@@ -28,11 +29,31 @@ import {
 const STREAM_A = 'stream:a' as StreamTabId;
 const STREAM_B = 'stream:b' as StreamTabId;
 
+/**
+ * Capture per-channel log lines. The storage module logs through a channel
+ * trace that binds `logUtils.warn` at module init, so a `vi.spyOn` installed
+ * inside a test can't intercept it — observe the output sink instead (same
+ * pattern as ChannelTrace.vitest.ts).
+ */
+function captureLogLines(): string[] {
+  const lines: string[] = [];
+  logUtils.setOutputChannelFactory(() => ({
+    appendLine(message: string) {
+      lines.push(message);
+    },
+  }));
+  return lines;
+}
+
 describe('InquiryStorage', () => {
   // Each test seeds threads against a fresh platform: state must not leak
   // between tests in this file, so this installs (and resets) per test
   // rather than once for the whole file.
   setupPlatform();
+
+  afterEach(() => {
+    logUtils.setOutputChannelFactory(null);
+  });
 
   it('opens, answers, and resolves a thread end-to-end', async () => {
     const opened = await recordOpenQuestion({
@@ -305,10 +326,14 @@ describe('InquiryStorage', () => {
       manifestPath,
       Buffer.from('{ not valid json', 'utf8'),
     );
+    const logLines = captureLogLines();
 
     await expect(
       readExternalInquiryThread('ei_aabbccdd0033'),
     ).resolves.toBeNull();
+    expect(logLines.join('\n')).toContain(
+      'Unreadable external-inquiry manifest for ei_aabbccdd0033',
+    );
 
     // A follow-up dispatch addressed at the corrupt thread reports
     // not-found instead of silently overwriting the on-disk file.
@@ -333,10 +358,87 @@ describe('InquiryStorage', () => {
       `${threadDir}/manifest.json`,
       Buffer.from(JSON.stringify({ threadId: 42, turns: 'nope' }), 'utf8'),
     );
+    const logLines = captureLogLines();
 
     await expect(
       readExternalInquiryThread('ei_aabbccdd0044'),
     ).resolves.toBeNull();
+    expect(logLines.join('\n')).toContain(
+      'Failed to parse external-inquiry manifest for ei_aabbccdd0044',
+    );
+  });
+
+  it('treats an unknown schemaVersion as unreadable, never as legacy data', async () => {
+    const platform = (await import('@platform/platform')).platform();
+    const threadDir = `${platform.storage.getGlobalStoragePath()}/ei_threads/ei_aabbccdd0055`;
+    const manifestPath = `${threadDir}/manifest.json`;
+    // Legacy-shaped body stamped with a future version: without the version
+    // gate this would fail the canonical arm and silently parse as a legacy
+    // thread (status rewritten to 'answered', parentStreamId to null).
+    const futureManifest = JSON.stringify({
+      schemaVersion: 2,
+      threadId: 'ei_aabbccdd0055',
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-02T00:00:00.000Z',
+      turns: [
+        {
+          turnIndex: 1,
+          timestamp: '2025-01-01T00:00:00.000Z',
+          question: 'Future Q',
+          questionRelativePath: 't1/question.txt',
+          answerRelativePath: 't1/answer.txt',
+        },
+      ],
+    });
+    await platform.fs.createDirectory(threadDir);
+    await platform.fs.writeFile(
+      manifestPath,
+      Buffer.from(futureManifest, 'utf8'),
+    );
+    const logLines = captureLogLines();
+
+    await expect(
+      readExternalInquiryThread('ei_aabbccdd0055'),
+    ).resolves.toBeNull();
+    expect(logLines.join('\n')).toContain(
+      'Unsupported external-inquiry manifest schemaVersion 2 for ei_aabbccdd0055',
+    );
+
+    // The on-disk file is preserved byte-for-byte for the newer writer.
+    const stillOnDisk = Buffer.from(
+      await platform.fs.readFile(manifestPath),
+    ).toString('utf8');
+    expect(stillOnDisk).toBe(futureManifest);
+  });
+
+  it('never legacy-parses a version-stamped manifest whose canonical shape is invalid', async () => {
+    const platform = (await import('@platform/platform')).platform();
+    const threadDir = `${platform.storage.getGlobalStoragePath()}/ei_threads/ei_aabbccdd0077`;
+    // schemaVersion present (current) but `status`/`parentStreamId` missing:
+    // the canonical arm rejects it, and the legacy arm must too — legacy is
+    // reserved for version-ABSENT manifests.
+    await platform.fs.createDirectory(threadDir);
+    await platform.fs.writeFile(
+      `${threadDir}/manifest.json`,
+      Buffer.from(
+        JSON.stringify({
+          schemaVersion: 1,
+          threadId: 'ei_aabbccdd0077',
+          createdAt: '2025-01-01T00:00:00.000Z',
+          updatedAt: '2025-01-02T00:00:00.000Z',
+          turns: [],
+        }),
+        'utf8',
+      ),
+    );
+    const logLines = captureLogLines();
+
+    await expect(
+      readExternalInquiryThread('ei_aabbccdd0077'),
+    ).resolves.toBeNull();
+    expect(logLines.join('\n')).toContain(
+      'Failed to parse external-inquiry manifest for ei_aabbccdd0077',
+    );
   });
 
   it('returns a hydrated legacy manifest when write-back fails', async () => {

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -24,7 +24,8 @@ import { StorageFS } from '@utils/files';
 import { delay } from '@utils/core';
 
 interface MockStorageOptions {
-  logs: Record<string, unknown[]>;
+  /** Values are usually arrays; non-array values simulate corrupt logs. */
+  logs: Record<string, unknown>;
   summaries: Record<string, unknown>;
   logMtimes?: Record<string, number>;
   summaryMtimes?: Record<string, number>;
@@ -853,5 +854,64 @@ describe('StreamLogStore load', () => {
       unknownEntry,
       expect.objectContaining({ id: 'beta-new', seqNo: 1 }),
     ]);
+  });
+
+  it('fails the load for a non-array persisted log and refuses to overwrite it', async () => {
+    const storage = mockStorage({
+      logs: { gamma: { corrupted: 'not an array' } },
+      summaries: {
+        gamma: {
+          firstTimestamp: 100,
+          lastTimestamp: 200,
+          hasRunningGroup: false,
+        },
+      },
+    });
+    const warnSpy = vi.spyOn(logUtils, 'warn').mockImplementation(() => {});
+    const store = new StreamLogStore();
+    await store.load();
+    await store.ensureLoaded('gamma');
+
+    // Parses-but-not-an-array is corrupt, not an empty log: the load fails
+    // loudly, exactly like unparseable JSON.
+    expect(store.get('gamma')).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      'StreamLogStore',
+      expect.stringContaining('Failed to reload stream gamma from disk'),
+    );
+
+    // New appends stay in memory, but save() refuses to destructively
+    // rewrite the corrupt on-disk file with a fresh array (#7464).
+    store.append('gamma', {
+      id: 'gamma-new',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 400,
+      messageType: MESSAGE_TYPES.DEFAULT,
+      text: 'new entry',
+    });
+    await store.flush();
+
+    expect(
+      storage.writes.get(storageFile(STREAM_LOGS_DIR, 'gamma')),
+    ).toBeUndefined();
+    expect(storage.writes.size).toBe(0);
+  });
+
+  it('skips a non-array persisted log at startup with a warning', async () => {
+    const storage = mockStorage({
+      logs: { delta: 'not an array at all' },
+      summaries: {},
+    });
+    const warnSpy = vi.spyOn(logUtils, 'warn').mockImplementation(() => {});
+    const store = new StreamLogStore();
+    await store.load();
+
+    expect(store.keys()).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'StreamLogStore',
+      expect.stringContaining('Skipping corrupt stream log: delta'),
+    );
+    expect(storage.writes.size).toBe(0);
   });
 });

--- a/src/tools/inquiry/externalInquiryStorage.ts
+++ b/src/tools/inquiry/externalInquiryStorage.ts
@@ -20,7 +20,7 @@ import {
 } from '@shared/schemas';
 import { normalizeFilePath } from '@shared/utils/path';
 import { ToolError } from '@shared/schemas/toolResult';
-import { toNewestFirstByTimestamp, hexId12 } from '@utils/core';
+import { isObject, toNewestFirstByTimestamp, hexId12 } from '@utils/core';
 import { GlobalStorageFS, StorageFS } from '@utils/files';
 import { isDirectory, isFile } from '@utils/files/fsEntryType';
 
@@ -187,9 +187,14 @@ const CanonicalManifestSchema = z.looseObject(ManifestBaseShape);
  * Legacy form: pre-async manifest with no `status` or `parentStreamId`.
  * Every turn was atomic Q+A (both `question` and `answer` recorded), so we
  * treat the whole thread as `answered` with no parent (continuation off).
+ *
+ * Legacy predates versioning, so this arm only accepts version-ABSENT data:
+ * a manifest that carries any `schemaVersion` (even the current one, on a
+ * shape the canonical arm rejected) is corrupt/unsupported, never legacy.
  */
 const LegacyManifestSchema = z
   .looseObject({
+    schemaVersion: z.undefined().optional(),
     threadId: ExternalInquiryThreadIdSchema,
     createdAt: z.string().min(1),
     updatedAt: z.string().min(1),
@@ -359,6 +364,24 @@ async function readThreadManifest(
         { data: err },
       );
     }
+    return null;
+  }
+  // Version discrimination happens BEFORE shape validation: a manifest that
+  // carries a schemaVersion we don't know (e.g. written by a newer TeXRA) is
+  // unsupported data, not a shape to reinterpret — without this gate it would
+  // fail the canonical union arm and fall through to a bogus legacy parse.
+  // Warn and treat as unreadable; the on-disk file is left untouched.
+  if (
+    isObject(raw) &&
+    'schemaVersion' in raw &&
+    raw.schemaVersion !== EXTERNAL_INQUIRY_MANIFEST_SCHEMA_VERSION
+  ) {
+    logger.warn(
+      `Unsupported external-inquiry manifest schemaVersion ` +
+        `${JSON.stringify(raw.schemaVersion)} for ${threadId}; ` +
+        `treating as unreadable.`,
+      { data: raw.schemaVersion },
+    );
     return null;
   }
   const result = ExternalInquiryThreadManifestSchema.safeParse(raw);

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -771,9 +771,10 @@ export class StreamLogStore {
     // let a later save() destructively rewrite the corrupt source (#7464).
     if (rawEntries === undefined) return parsed;
     if (!Array.isArray(rawEntries)) {
+      // `typeof null` is 'object', which would misreport a persisted null.
+      const got = rawEntries === null ? 'null' : typeof rawEntries;
       throw new Error(
-        `Stream ${streamId}: persisted log is not an array ` +
-          `(got ${typeof rawEntries}).`,
+        `Stream ${streamId}: persisted log is not an array (got ${got}).`,
       );
     }
 

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -12,6 +12,7 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 import { debounce, filterNotNull, isObject } from '@utils/core';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import {
   isRunningGroupEntry,
@@ -246,13 +247,17 @@ export class StreamLogStore {
         // append to unblock it.
         this.loadFailed.delete(streamId);
         if (this.dirtyStreamIds.has(streamId)) void this.save();
-      } catch {
+      } catch (err) {
         // Rehydrate failed. Mark so `executeWrite` skips this stream and
         // doesn't overwrite the on-disk history with whatever empty/partial
         // log the agent may now be appending to. `append` retries the load
         // in the background; once it succeeds the merge path runs.
         this.loadFailed.add(streamId);
-        log.warn(LOG_TAG, `Failed to reload stream ${streamId} from disk`);
+        log.warn(
+          LOG_TAG,
+          `Failed to reload stream ${streamId} from disk: ` +
+            toErrorMessage(err),
+        );
       }
     })();
     this.pendingLoads.set(streamId, work);
@@ -606,8 +611,11 @@ export class StreamLogStore {
         log.warn(LOG_TAG, `Failed to write stream summary: ${streamId}`);
       });
       return { streamId, summary };
-    } catch {
-      log.warn(LOG_TAG, `Skipping corrupt stream log: ${streamId}`);
+    } catch (err) {
+      log.warn(
+        LOG_TAG,
+        `Skipping corrupt stream log: ${streamId} (${toErrorMessage(err)})`,
+      );
       return null;
     }
   }
@@ -754,7 +762,20 @@ export class StreamLogStore {
       entries: [],
       preservedRawEntries: [],
     };
-    if (!Array.isArray(rawEntries)) return parsed;
+    // A missing file reads as `undefined` (KVStore's quiet-missing contract):
+    // an empty log, nothing to warn about. Anything else that isn't an array
+    // is corrupt persisted data — throw so both callers route through the
+    // same failure path as unparseable JSON (`ensureLoaded` marks the load
+    // failed, which blocks saves from overwriting the on-disk file; startup
+    // summary loading skips the stream). Returning an empty log here would
+    // let a later save() destructively rewrite the corrupt source (#7464).
+    if (rawEntries === undefined) return parsed;
+    if (!Array.isArray(rawEntries)) {
+      throw new Error(
+        `Stream ${streamId}: persisted log is not an array ` +
+          `(got ${typeof rawEntries}).`,
+      );
+    }
 
     for (const raw of rawEntries) {
       const result = PersistedStreamLogEntrySchema.safeParse(raw);


### PR DESCRIPTION
Fast-follow for #7510 (Stage 3c loud reads, #6966): the PR merged with two substantive unresolved review findings plus a repeated test nit. Each fix applies the protocol rule, not a spot patch.

## Summary

**External inquiry manifests — version discrimination before shape validation** (`src/tools/inquiry/externalInquiryStorage.ts`). #7510 added `schemaVersion` to the canonical manifest arm, so a manifest with a *present but unknown* version failed the canonical union arm and fell through to the legacy arm — corrupt/newer data was silently rewritten as an `answered` legacy thread with `parentStreamId: null` (Bugbot, high severity). Now `readThreadManifest` gates on the version first: a present-but-unknown `schemaVersion` is an unsupported read — warn and treat as unreadable, on-disk bytes preserved. The legacy arm additionally requires `schemaVersion` to be absent (`z.undefined().optional()`), so a version-stamped manifest whose canonical shape is invalid can also never legacy-parse. Legacy is reserved for version-ABSENT data, full stop.

**Stream logs — non-array parse fails the load instead of arming a destructive rewrite** (`src/transcript/StreamLogStore.ts`). Persisted JSON that parsed but was not an array was treated as an empty log, and a later `save()` overwrote the corrupt file with a fresh array — the #7464 destructive-rewrite class (Copilot). `parsePersistedEntries` now throws on a defined non-array value, routing both callers through the exact machinery unparseable JSON already uses: `ensureLoaded`'s catch marks `loadFailed` (which blocks `executeWrite` from touching the stream), and startup summary loading skips the stream with a warning. A missing file still reads quietly as an empty log (`undefined` is `KVStore`'s quiet-missing contract). The two catch warns now include the failure reason.

**Tests** (`src/test-kernel/tools/InquiryStorage.vitest.ts`, `src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts`). The corrupt/schema-invalid manifest tests now assert the warning is emitted (flagged by three reviewers). The inquiry storage module logs through a channel trace that binds `logUtils.warn` at module init, so a `vi.spyOn` installed inside a test cannot intercept it — these assert via the output-channel sink instead (the established `ChannelTrace.vitest.ts` capture pattern); the StreamLogStore suite keeps the direct `warnSpy` pattern. Four new pinning tests: unknown-version manifest → warned, not legacy-parsed, file preserved byte-for-byte; version-stamped shape-invalid manifest → never legacy-parsed; non-array stream log → load failed, `save()` refuses to write, in both the `ensureLoaded` and startup paths. All four fail against pre-fix production code.

## §14 notes (fewer-elements)

- No new files, exports, classes, or ports — every change lands inside existing functions/schemas. One test helper (`captureLogLines`) added with two callers in-suite.
- R7 test budget: no new test files; both suites extended in place.
- Net LoC +214/−8, of which ~185 is the four pinning tests plus warn assertions; this is a correctness fix, not a reduction PR.

## §15 notes (error-handling and fallback discipline)

- The version gate is the loud-read rule (#6966 bullet 5) applied at the single read entry point (`readThreadManifest`): warn + degrade to `null`, never a default that gets persisted; on-disk bytes preserved for the (presumably newer) writer.
- The `parsePersistedEntries` throw removes a defaulted read that fed a later whole-file write (the `cliSecrets.json` precedent class). No new catch sites: the throw lands in two existing classified handlers — `ensureLoaded`'s catch (the `loadFailed` owner that blocks destructive saves) and `loadStreamSummary`'s skip-with-warn.
- Quiet-missing vs corrupt-present is distinguished structurally: `undefined` (KVStore's FNF contract) stays quiet; any defined non-array is corrupt.
- No downgrade below `warn` anywhere; both enriched log lines stay at `warn`.

## Validation

- `npx tsc --noEmit` on all five projects (root, test-kernel, extension, cli, trace-viewer) — clean.
- `CI=true npx vitest run src/test-kernel/transcript/ src/test-kernel/tools/ src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts` — 93 files, 544 tests passed (re-run green after rebasing onto the post-#7518 main).
- A/B: the four new pinning tests fail with the production fixes stashed, pass with them applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes loud-read and persistence behavior for inquiry manifests and stream logs; incorrect handling could still lose or misread on-disk history, but the PR tightens guards and adds regression tests.
> 
> **Overview**
> **External inquiry manifests** now check `schemaVersion` before Zod shape parsing. Unknown versions are warned and treated as unreadable (`null`), with on-disk bytes left intact instead of falling through to legacy parsing. The legacy schema arm only accepts manifests with **no** `schemaVersion`, so version-stamped but invalid canonical data cannot be reinterpreted as legacy.
> 
> **Stream logs** treat persisted JSON that parses but is not an array as corrupt: `parsePersistedEntries` throws (while `undefined` still means an empty log). That reuses existing paths—`ensureLoaded` sets `loadFailed` so `save()` will not overwrite the bad file, and startup summary loading skips the stream with a warning. Reload/skip warnings now include the error message via `toErrorMessage`.
> 
> **Tests** assert warnings on corrupt inquiry manifests (via output-channel capture because channel trace binds `logUtils.warn` at init), plus pinning cases for unknown version, invalid version-stamped manifests, and non-array stream logs on rehydrate and at startup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01fd1084f984165087eb11ad01e614c0a7c83390. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->