### PR TITLE
refactor: project run config to task state progress

### DIFF
--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -19,7 +19,6 @@ import {
   type FlowRecord,
 } from '@agent/node/persistedFlow';
 import type { AgentToolUseSetting } from '@agent/core/definition/AgentDataclass';
-import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 import type { IToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { BaseFlowContextInit } from '@agent/core/flows/BaseFlowServices';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
@@ -266,11 +265,6 @@ export async function runToolUseFlow<C = unknown>(
       streamId,
       executionId,
       config: services.config,
-    });
-    runtimeHost.emit('setTaskState', {
-      streamId,
-      executionId,
-      taskState: agentConfigToTaskState(services.config),
     });
     input.onModelChanged?.(nextHandler, model);
   };

--- a/src/agent/runtime/sessionProgressEventProjection.ts
+++ b/src/agent/runtime/sessionProgressEventProjection.ts
@@ -1,5 +1,6 @@
 import type { AgentEvent } from '@agent/trace';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 import type {
   ProgressEvent,
   ProgressEventPayloads,
@@ -115,6 +116,17 @@ export function projectRunFactToProgressEvent(
     return payload ? { event: 'updateStreamUsage', payload } : undefined;
   }
 
+  if (event.type === 'run.config') {
+    return {
+      event: 'setTaskState',
+      payload: {
+        streamId: event.streamId,
+        executionId: event.executionId,
+        taskState: agentConfigToTaskState(event.config),
+      },
+    };
+  }
+
   if (event.type === 'domain') {
     const factName = fromRunFactDomainKey(event.key);
     if (!factName || !isObject(event.data)) return undefined;
@@ -185,6 +197,7 @@ export function projectRunFactToProgressEvent(
 
 const RUN_FACT_PROGRESS_EVENT_TYPES: readonly AgentEvent['type'][] = [
   'domain',
+  'run.config',
   'usage',
   'stage.start',
   'child.activity',

--- a/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
+++ b/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
@@ -1,6 +1,10 @@
 // Third-party imports
 import { describe, expect, it } from 'vitest';
 
+// Local imports - agent
+import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+
 // Local imports - runtime
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import { toRunFactDomainKey } from '@agent/runtime/runFactEvents';
@@ -11,6 +15,7 @@ import type {
   StorageKey,
   StreamTabId,
 } from '@shared/schemas';
+import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
 
 import { createRecordingHost } from '../agent/progressTestUtils';
 
@@ -111,6 +116,47 @@ describe('attachCliSessionProgressProjection', () => {
         {
           event: 'updateProcessOutput',
           payload: { parentStreamId, executionId, stdout: 'hello', stderr: '' },
+        },
+      ]);
+    } finally {
+      detach();
+    }
+  });
+
+  it('projects run config updates onto retained CLI task-state events', () => {
+    const hub = new SessionEventHub();
+    const host = createRecordingHost();
+    const streamId = 'stream:config' as StreamTabId;
+    const executionId = 'exec:config' as ExecutionId;
+    const config = AgentConfigSchema.parse({
+      agentCategory: AgentCategory.ToolUse,
+      agent: 'assistant',
+      model: 'sonnet46T',
+      instruction: 'Check the proof.',
+      toolConfig: DEFAULT_TOOL_CONFIG,
+    });
+
+    const detach = attachCliSessionProgressProjection(hub, host.host);
+    try {
+      hub.emit({
+        scope: 'run',
+        streamId,
+        event: {
+          type: 'run.config',
+          streamId,
+          executionId,
+          config,
+        },
+      });
+
+      expect(host.events).toEqual([
+        {
+          event: 'setTaskState',
+          payload: {
+            streamId,
+            executionId,
+            taskState: { agentConfig: config },
+          },
         },
       ]);
     } finally {


### PR DESCRIPTION
## Summary

- projects trace `run.config` events to the retained legacy `setTaskState` progress event
- removes the duplicate direct mid-run model-switch `runtimeHost.emit('setTaskState', ...)` from `runToolUseFlow`
- adds CLI projection coverage proving `run.config` still reaches the public `setTaskState` event with stream id, execution id, and task state

## Stage 5 notes

This is a bounded #6968 residue-family slice. It does not delete `setTaskState` from `ProgressEventPayloads` and does not change the frozen CLI vocabulary. Instead, it moves one producer behind `sessionProgressEventProjection`, which is the retained D3 compatibility boundary until the CLI frozen projection gate is retired.

Out of scope: launch-time `setTaskState`, `updateStreamDescription`, and `setParentStream` fallback cleanup.

## Validation

- `CI=true corepack pnpm exec vitest run src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `CI=true corepack pnpm exec eslint src/agent/runtime/sessionProgressEventProjection.ts src/agent/implementations/flows/tooluse/runToolUseFlow.ts src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts`
- `corepack pnpm exec prettier --check src/agent/runtime/sessionProgressEventProjection.ts src/agent/implementations/flows/tooluse/runToolUseFlow.ts src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts`
- `CI=true corepack pnpm exec tsc --noEmit --pretty false`
- `git diff --check`

Refs #6968

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bounded producer move behind an existing compatibility layer; external `setTaskState` shape is preserved and covered by a new CLI projection test.
> 
> **Overview**
> **Mid-run task state updates** now flow through the shared run-fact → progress projection instead of a second direct host emit in the tool-use flow.
> 
> On model switch, `runToolUseFlow` still logs a trace `run.config` event with the updated config but no longer calls `runtimeHost.emit('setTaskState', ...)`. `sessionProgressEventProjection` maps `run.config` to the legacy `setTaskState` payload (stream id, execution id, `agentConfigToTaskState(config)`), and `run.config` is included in the run-fact types that `subscribeRunFactsAsProgressEvents` forwards.
> 
> A CLI subscription test asserts that path still surfaces the same public `setTaskState` event. Launch-time `setTaskState` in `AgentRunLifecycle` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b3079c46b9e4c8dfdf648a5593f789a62051018. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->