### PR TITLE
fix(transcript): log the initial user message even if media insertion throws

### DIFF
--- a/src/agent/implementations/flows/reflection/nodes/MediaExtractionNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/MediaExtractionNode.ts
@@ -95,22 +95,32 @@ export class MediaExtractionNode<C = unknown> extends Node<
   ): Promise<string | undefined> {
     shared.workspaceSnapshot = prepRes.workspaceState.toSnapshot();
 
+    // The transcript's opening row must be logged whether addMediaToUserMessage
+    // succeeds or throws (e.g. a corrupt/oversized media file) -- otherwise a
+    // failed first turn leaves no record of what the user asked for. `finally`
+    // preserves the throw so the run still fails as before; a throw before any
+    // attachment was inserted just yields an empty attachments list, which is
+    // accurate (nothing was actually inserted).
     let attachmentKinds: MediaAttachmentKind[] = [];
-    if (mediaFiles?.length && shared.context) {
-      attachmentKinds = await this.services.modelHandler.addMediaToUserMessage(
-        shared.context.messages,
-        mediaFiles,
-      );
-    }
-    if (
-      prepRes.currentRound === 0 &&
-      this.services.initialUserMessageForTranscript
-    ) {
-      logUserMessage(
-        this.services.logger,
-        this.services.initialUserMessageForTranscript,
-        attachmentKinds,
-      );
+    try {
+      if (mediaFiles?.length && shared.context) {
+        attachmentKinds =
+          await this.services.modelHandler.addMediaToUserMessage(
+            shared.context.messages,
+            mediaFiles,
+          );
+      }
+    } finally {
+      if (
+        prepRes.currentRound === 0 &&
+        this.services.initialUserMessageForTranscript
+      ) {
+        logUserMessage(
+          this.services.logger,
+          this.services.initialUserMessageForTranscript,
+          attachmentKinds,
+        );
+      }
     }
 
     return FlowTransition.DEFAULT;

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -99,18 +99,28 @@ export class ToolUsePrepareNode<C> extends Node<
     const mediaFiles = config.mediaFiles.length
       ? config.mediaFiles.map((p) => fileService.createLocation(p))
       : undefined;
-    const messages = await this.services.modelHandler.initializeMessages(
-      userPrefix,
-      userRequest,
-      mediaFiles,
-      systemMessage,
-    );
-    if (this.services.initialUserMessageForTranscript) {
-      logUserMessage(
-        logger,
-        this.services.initialUserMessageForTranscript,
-        this.services.modelHandler.consumeInsertedAttachmentKinds('initial'),
+    // The transcript's opening row must be logged whether initializeMessages
+    // succeeds or throws (e.g. a corrupt/oversized media file) -- otherwise a
+    // failed first turn leaves no record of what the user asked for. `finally`
+    // preserves the throw so the run still fails as before; a throw before any
+    // attachment was inserted just yields an empty attachments list, which is
+    // accurate (nothing was actually inserted).
+    let messages: ProviderMessage[];
+    try {
+      messages = await this.services.modelHandler.initializeMessages(
+        userPrefix,
+        userRequest,
+        mediaFiles,
+        systemMessage,
       );
+    } finally {
+      if (this.services.initialUserMessageForTranscript) {
+        logUserMessage(
+          logger,
+          this.services.initialUserMessageForTranscript,
+          this.services.modelHandler.consumeInsertedAttachmentKinds('initial'),
+        );
+      }
     }
 
     return {

--- a/src/test-kernel/agent/followUp/MediaExtractionNodeTranscriptLog.vitest.ts
+++ b/src/test-kernel/agent/followUp/MediaExtractionNodeTranscriptLog.vitest.ts
@@ -1,0 +1,114 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports
+import { ConversationRoundStateSnapshotSchema } from '@agent/core/state/AgentState';
+import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
+import { MediaExtractionNode } from '@agent/implementations/flows/reflection/nodes/MediaExtractionNode';
+import type { ReflectionFlowShared } from '@agent/implementations/flows/reflection/ReflectionFlowState';
+import type { ReflectionServices } from '@agent/implementations/flows/reflection/ReflectionServices';
+import type { FileLocation } from '@shared/schemas';
+
+function buildShared(
+  overrides: Partial<ReflectionFlowShared> = {},
+): ReflectionFlowShared {
+  return {
+    currentRound: 0,
+    totalRounds: 1,
+    workspaceSnapshot: AgentWorkspaceState.create().toSnapshot(),
+    context: {
+      messages: [],
+      stateRoundSnapshot: ConversationRoundStateSnapshotSchema.parse({
+        roundIndex: 0,
+      }),
+    },
+    outputLocation: null,
+    ...overrides,
+  } as ReflectionFlowShared;
+}
+
+function buildServices(
+  overrides: Partial<ReflectionServices<unknown>> = {},
+): ReflectionServices<unknown> {
+  return {
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    modelHandler: {
+      addMediaToUserMessage: vi.fn(async () => []),
+    } as never,
+    onRoundFinalized: vi.fn(),
+    checkInterruption: () => false,
+    setAbortController: () => {},
+    ...overrides,
+  } as ReflectionServices<unknown>;
+}
+
+const MEDIA_FILES: FileLocation[] = [
+  {
+    kind: 'external',
+    absolutePath: '/tmp/img.png',
+  },
+];
+
+function buildPrepRes(currentRound: number) {
+  return {
+    currentRound,
+    files: [],
+    extraMediaFiles: [],
+    workspaceState: AgentWorkspaceState.create(),
+  };
+}
+
+describe('MediaExtractionNode transcript logging (regression #7508)', () => {
+  it('logs the initial transcript row when addMediaToUserMessage throws', async () => {
+    // A failed round-0 media insertion (corrupt/oversized file, provider
+    // validation error, ...) must still leave a record of what the user
+    // asked for — otherwise the transcript's opening row silently vanishes
+    // for exactly the runs most likely to need debugging.
+    const services = buildServices({
+      initialUserMessageForTranscript: 'Do the thing.',
+    });
+    (
+      services.modelHandler.addMediaToUserMessage as ReturnType<typeof vi.fn>
+    ).mockRejectedValue(new Error('media insertion failed'));
+    const node = new MediaExtractionNode().setServices(services);
+    const shared = buildShared();
+
+    await expect(
+      node.post(shared, buildPrepRes(0), MEDIA_FILES),
+    ).rejects.toThrow('media insertion failed');
+
+    expect(services.logger.info).toHaveBeenCalledWith(
+      'Do the thing.',
+      expect.objectContaining({ messageType: expect.any(String) }),
+    );
+  });
+
+  it('still logs exactly once on the success path', async () => {
+    const services = buildServices({
+      initialUserMessageForTranscript: 'Do the thing.',
+    });
+    const node = new MediaExtractionNode().setServices(services);
+    const shared = buildShared();
+
+    await node.post(shared, buildPrepRes(0), MEDIA_FILES);
+
+    expect(services.logger.info).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not log on rounds after the first', async () => {
+    const services = buildServices({
+      initialUserMessageForTranscript: 'Do the thing.',
+    });
+    (
+      services.modelHandler.addMediaToUserMessage as ReturnType<typeof vi.fn>
+    ).mockRejectedValue(new Error('boom'));
+    const node = new MediaExtractionNode().setServices(services);
+    const shared = buildShared({ currentRound: 1 });
+
+    await expect(
+      node.post(shared, buildPrepRes(1), MEDIA_FILES),
+    ).rejects.toThrow('boom');
+
+    expect(services.logger.info).not.toHaveBeenCalled();
+  });
+});

--- a/src/test-kernel/agent/followUp/ToolUsePrepareNodeTranscriptLog.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUsePrepareNodeTranscriptLog.vitest.ts
@@ -1,0 +1,91 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports
+import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
+import { AgentPromptSchema } from '@agent/core/definition/AgentDataclass';
+import { ToolUsePrepareNode } from '@agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode';
+import type { ToolUseServices } from '@agent/implementations/flows/tooluse/ToolUseServices';
+
+function buildServices(
+  overrides: Partial<ToolUseServices<unknown>> = {},
+): ToolUseServices<unknown> {
+  return {
+    config: AgentConfigSchema.parse({ agent: 'chat', model: 'deepseekT' }),
+    fileService: {} as never,
+    isSubagent: false,
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    modelHandler: {
+      consumeInsertedAttachmentKinds: vi.fn(() => []),
+      initializeMessages: vi.fn(async () => []),
+    } as never,
+    onRoundFinalized: vi.fn(),
+    prompt: AgentPromptSchema.parse({
+      systemPrompt: 'You are careful.',
+      userRequest: 'Do the thing.',
+    }),
+    resolvedTools: [],
+    session: {} as never,
+    setting: { agentCategory: 'toolUse' } as never,
+    snapshot: null,
+    streamStatus: {} as never,
+    toolRegistry: {} as never,
+    userVarChannels: { input: {}, transient: {} },
+    checkInterruption: () => false,
+    setAbortController: () => {},
+    ...overrides,
+  } as ToolUseServices<unknown>;
+}
+
+describe('ToolUsePrepareNode transcript logging (regression #7508)', () => {
+  it('logs the initial transcript row when initializeMessages throws', async () => {
+    // A failed first turn (corrupt/oversized media, provider validation
+    // error, ...) must still leave a record of what the user asked for —
+    // otherwise the transcript's opening row silently vanishes for exactly
+    // the runs most likely to need debugging.
+    const services = buildServices({
+      initialUserMessageForTranscript: 'Do the thing.',
+    });
+    (
+      services.modelHandler.initializeMessages as ReturnType<typeof vi.fn>
+    ).mockRejectedValue(new Error('media processing failed'));
+    const node = new ToolUsePrepareNode().setServices(services);
+
+    await expect(node.exec(undefined)).rejects.toThrow(
+      'media processing failed',
+    );
+
+    expect(services.logger.info).toHaveBeenCalledWith(
+      'Do the thing.',
+      expect.objectContaining({ messageType: expect.any(String) }),
+    );
+    expect(
+      services.modelHandler.consumeInsertedAttachmentKinds,
+    ).toHaveBeenCalledWith('initial');
+  });
+
+  it('still logs exactly once on the success path', async () => {
+    const services = buildServices({
+      initialUserMessageForTranscript: 'Do the thing.',
+    });
+    const node = new ToolUsePrepareNode().setServices(services);
+
+    await node.exec(undefined);
+
+    expect(services.logger.info).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not log when there is no initial transcript row to write', async () => {
+    const services = buildServices({
+      initialUserMessageForTranscript: undefined,
+    });
+    services.modelHandler.initializeMessages = vi
+      .fn()
+      .mockRejectedValue(new Error('boom')) as never;
+    const node = new ToolUsePrepareNode().setServices(services);
+
+    await expect(node.exec(undefined)).rejects.toThrow('boom');
+
+    expect(services.logger.info).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Context

Follow-up to #7508 (merged as #7517). That PR moved the initial-instruction
transcript log to fire only *after* `initializeMessages()` /
`addMediaToUserMessage()` succeeds, since the log call needs
`consumeInsertedAttachmentKinds()` data that's only known once media
processing has actually run.

Cursor Bugbot flagged a real gap on #7517 during review: deferring the log
this way means a throw from that media call skips the transcript's opening
row entirely, for exactly the runs most likely to need debugging (a failed
first turn). The implementer agent explicitly left this open in the PR body
rather than resolve it unilaterally, since the branch was under active
concurrent edit from another session at the time. #7517 has since merged and
main is stable again, so this PR resolves it.

## Root cause

Confirmed independently by reading the current (merged) code:

- `ToolUsePrepareNode.exec()` (`src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts`)
  calls `logUserMessage(...)` only after `this.services.modelHandler.initializeMessages(...)`
  returns, with no surrounding try/catch.
- `MediaExtractionNode.post()` (`src/agent/implementations/flows/reflection/nodes/MediaExtractionNode.ts`)
  has the same exposure via `addMediaToUserMessage(...)`.

A thrown error from either (corrupt/oversized media file, provider
validation error) means the run fails with zero record of what the user
originally asked for in the transcript.

## Fix

Wrap each media call in `try/finally` so `logUserMessage()` always fires,
on both the success and throw paths. `consumeInsertedAttachmentKinds()` is
safe to call even if nothing was inserted yet (it just returns `[]`), so the
degraded case correctly logs zero attachments instead of lying about what
got inserted. The `finally` block doesn't swallow the throw — the run still
fails exactly as before, only the transcript row is now guaranteed to exist.

## Verification

- `npx tsc --noEmit` — clean
- `npx tsc --noEmit -p tsconfig.test-kernel.json` — clean
- `npx eslint` on all 4 changed files — clean
- `npx prettier --check` on all 4 changed files — clean
- New regression tests (`ToolUsePrepareNodeTranscriptLog.vitest.ts`,
  `MediaExtractionNodeTranscriptLog.vitest.ts`) confirm the log fires on
  both success and throw paths, and does NOT fire when there's no initial
  message to log. Confirmed both new throw-path tests actually fail against
  the pre-fix code (via `git stash` on just the two source files).
- `npx vitest run src/test-kernel/agent/` — 1124 passed, 4 pre-existing
  skips, 0 failures (full sweep, not just the touched files)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change around transcript logging; run failure behavior is unchanged and errors are not swallowed.
> 
> **Overview**
> **Ensures the transcript always records the user's opening message on round 0**, even when first-turn media handling fails (corrupt/oversized files, provider validation, etc.). Previously, deferring `logUserMessage` until after `initializeMessages` / `addMediaToUserMessage` succeeded meant those failures left no transcript row for what the user asked—exactly when you'd want that context for debugging.
> 
> In **`ToolUsePrepareNode`** and **`MediaExtractionNode`**, the media call is wrapped in `try/finally` so `logUserMessage` runs on both success and throw paths. Errors still propagate unchanged; if nothing was inserted, attachment metadata is logged as empty via `consumeInsertedAttachmentKinds` / an empty `attachmentKinds` list. Reflection flow still only logs on round 0.
> 
> New **Vitest regression tests** (#7508) cover throw vs success paths and cases where logging should be skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c31165cfbbb51b54b59a710431c7efd44e93046. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->