### PR TITLE
refactor: share settings memory model host wiring

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -6,20 +6,16 @@ import {
   isAllowedLatexInstallCommand,
   LatexToolingController,
 } from '@controllers/settingsView/LatexToolingController';
-import { createSettingsMemoryController } from '@controllers/settingsView/SettingsMemoryControllerFactory';
 import { SettingsProfileKeyController } from '@controllers/settingsView/SettingsProfileKeyController';
 import { buildProfileMessage } from '@controllers/settingsView/ProfileMessageBuilder';
 import { buildProviderKeyStatuses } from '@controllers/settingsView/SettingsProfileController';
 import { buildHistoryMessage } from '@controllers/settingsView/HistoryMessageBuilder';
-import {
-  buildModelSelectionMessage,
-  createModelSelectionController,
-} from '@controllers/settingsView/SettingsModelSelectionControllerFactory';
 import { createSettingsAgentControllers } from '@controllers/settingsView/SettingsAgentControllerFactory';
 import {
   createSettingsViewCommandHandlers,
   type SettingsViewCommandActions,
 } from '@controllers/settingsView/SettingsViewCommandHandlers';
+import { createSettingsViewHost } from '@controllers/settingsView/SettingsViewHost';
 import { deleteAllExecutions, deleteExecution } from '@agent/storage';
 import {
   computeAgentOptionsData,
@@ -48,8 +44,8 @@ import {
   invalidateModelOptionsCache,
 } from '@model/computeModelOptions';
 import type { ExecutionId } from '@shared/schemas';
-import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 import { SETTINGS_VIEW_COMMANDS, MAIN_VIEW_COMMANDS } from '@shared/ipc';
+import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 import {
   PROVIDER_DISPLAY_NAMES,
   PROVIDER_URLS,
@@ -245,19 +241,17 @@ export function createDesktopSettingsIpc(
     getAgents: getAgentEntries,
     getVisibleAgents: getVisibleAgentEntries,
   });
-  const modelSelectionController = createModelSelectionController({
-    workspaceState,
-    globalState,
-  });
   const modelListRefresh =
     options.modelListRefresh ??
     refreshDesktopModelListStateIfNeeded({
       globalState,
       onError,
     });
-  const memoryController = createSettingsMemoryController({
-    globalState,
-    prompt: {
+  const settingsHost = createSettingsViewHost({
+    state: { workspaceState, globalState },
+    respond: options.postToRenderer,
+    beforeModelSelectionMessage: () => modelListRefresh,
+    memoryPrompt: {
       confirm: (message, promptOptions) =>
         options.confirmAction?.(message, promptOptions?.confirmLabel) ??
         Promise.resolve(true),
@@ -354,14 +348,11 @@ export function createDesktopSettingsIpc(
   }
 
   async function postModelSelectionData(): Promise<void> {
-    await modelListRefresh;
-    options.postToRenderer(
-      await buildModelSelectionMessage(modelSelectionController),
-    );
+    await settingsHost.sendModelSelectionData();
   }
 
   async function postMainModelOptionsData(): Promise<void> {
-    const visibleModels = modelSelectionController.getVisibleModels();
+    const visibleModels = settingsHost.getVisibleModels();
     const [workflowModelOptions, toolUseModelOptions] = await Promise.all([
       computeModelOptionsData(visibleModels, undefined, {
         agentCategory: AgentCategory.Workflow,
@@ -434,47 +425,33 @@ export function createDesktopSettingsIpc(
   }
 
   async function postMemoryData(): Promise<void> {
-    options.postToRenderer(await memoryController.getMemoryDataMessage());
+    await settingsHost.sendMemoryData();
   }
 
   async function postMemoryPreview(storagePath: string): Promise<void> {
-    try {
-      options.postToRenderer(
-        await memoryController.getMemoryPreviewMessage(storagePath),
-      );
-    } catch (error) {
-      onError(error);
-      options.postToRenderer(
-        memoryController.getMemoryPreviewErrorMessage(storagePath),
-      );
-    }
+    await settingsHost.sendMemoryPreview({ storagePath }, { onError });
   }
 
   async function postMemoryEnabled(): Promise<void> {
-    options.postToRenderer(memoryController.getMemoryEnabledMessage());
+    await settingsHost.sendMemoryEnabled();
   }
 
   async function deleteMemory(input: {
     storagePath: string;
     displayPath: string;
   }): Promise<void> {
-    const message = await memoryController.deleteMemory(input);
-    if (message) options.postToRenderer(message);
+    await settingsHost.deleteMemory(input);
   }
 
   async function setMemoryEnabled(enabled: boolean): Promise<void> {
-    const message = await memoryController.setMemoryEnabled(enabled);
-    if (message) options.postToRenderer(message);
+    await settingsHost.setMemoryEnabled(enabled);
   }
 
   async function setMemoryPinned(
     storagePath: string,
     pinned: boolean,
   ): Promise<void> {
-    const message = pinned
-      ? await memoryController.pinMemory(storagePath)
-      : await memoryController.unpinMemory(storagePath);
-    if (message) options.postToRenderer(message);
+    await settingsHost.setMemoryPinned(storagePath, pinned);
   }
 
   async function openMemoryFile(input: { storagePath: string }): Promise<void> {
@@ -641,28 +618,25 @@ export function createDesktopSettingsIpc(
     modelName: string;
     enabled: boolean;
   }): Promise<void> {
-    await modelSelectionController.setModelEnabled(input);
-    invalidateModelOptionsCache();
-    await postModelSelectionData();
-    await postMainModelOptionsData();
+    await settingsHost.setModelEnabled(input, {
+      afterUpdate: () => invalidateModelOptionsCache(),
+      afterPost: () => postMainModelOptionsData(),
+    });
   }
 
   async function updateModelReasoningLevel(input: {
     modelName: string;
     level: ReasoningLevel | null;
   }): Promise<void> {
-    await modelSelectionController.setReasoningLevel(input);
-    await postModelSelectionData();
+    await settingsHost.setReasoningLevel(input);
   }
 
   async function updateHelperModel(modelName: string): Promise<void> {
-    await modelSelectionController.setHelperModel(modelName);
-    await postModelSelectionData();
+    await settingsHost.setHelperModel(modelName);
   }
 
   async function updatePreferShortModelNames(enabled: boolean): Promise<void> {
-    await modelSelectionController.setPreferShortModelNames(enabled);
-    await postModelSelectionData();
+    await settingsHost.setPreferShortModelNames(enabled);
   }
 
   async function refreshAfterCredentialChange(): Promise<void> {

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -22,13 +22,9 @@ import {
   createSettingsViewCommandHandlers,
   type SettingsViewCommandActions,
 } from '@controllers/settingsView/SettingsViewCommandHandlers';
+import { createSettingsViewHost } from '@controllers/settingsView/SettingsViewHost';
 import { platform } from '@platform/platform';
 import { resolveMemoryStoragePath } from '@platform/defaults/workspaceStorage';
-import { createSettingsMemoryController } from '@controllers/settingsView/SettingsMemoryControllerFactory';
-import {
-  buildModelSelectionMessage,
-  createModelSelectionController,
-} from '@controllers/settingsView/SettingsModelSelectionControllerFactory';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { AUTH_COMMANDS } from '@auth/constants';
 import { getServerSideKeyService } from '@auth/serverKeys';
@@ -109,8 +105,7 @@ import { LatexSettingsHandlers } from './handlers/latexSettingsHandlers';
 import { HistoryHandlers } from './handlers/historyHandlers';
 import { GitHubSubscriptionHandlers } from './handlers/githubSubscriptionHandlers';
 import { ChatGptSubscriptionHandlers } from './handlers/chatgptSubscriptionHandlers';
-import type { SettingsMemoryController } from '@controllers/settingsView/SettingsMemoryController';
-import type { SettingsModelSelectionController } from '@controllers/settingsView/SettingsModelSelectionController';
+import type { SettingsViewHost } from '@controllers/settingsView/SettingsViewHost';
 import type { SettingsHandlerContext } from './handlers/SettingsHandlerContext';
 
 // Re-use the shared type helper for extracting specific message types.
@@ -128,8 +123,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private readonly historyHandlers: HistoryHandlers;
   private readonly githubHandlers: GitHubSubscriptionHandlers;
   private readonly chatgptHandlers: ChatGptSubscriptionHandlers;
-  private readonly memoryController: SettingsMemoryController;
-  private readonly modelSelectionController: SettingsModelSelectionController;
+  private readonly settingsHost: SettingsViewHost;
   private readonly profileController: SettingsProfileController;
   private readonly profileKeyController: SettingsProfileKeyController;
   private readonly goalController: SettingsGoalController;
@@ -144,23 +138,20 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       withActiveWebview: (fn) => this.withActiveWebview(fn),
     };
 
-    this.memoryController = createSettingsMemoryController({
-      globalState: globalSM,
-      prompt: new VscodePromptHost(),
-      setMemoryEnabled: setToolUseMemoryEnabled,
-    });
     // Must build inside the constructor: globalSM/workspaceSM are populated
     // by extension.ts → initializeStateManagers and are still undefined at
     // module load, so destructuring them at top level captures `undefined`
     // and every later globalState.get(...) throws.
-    this.modelSelectionController = createModelSelectionController(
-      { workspaceState: workspaceSM, globalState: globalSM },
-      {
+    this.settingsHost = createSettingsViewHost({
+      state: { workspaceState: workspaceSM, globalState: globalSM },
+      memoryPrompt: new VscodePromptHost(),
+      setMemoryEnabled: setToolUseMemoryEnabled,
+      modelSelectionExtras: {
         useIncludedAccess: () =>
           getServerSideKeyService().getUseIncludedModelAccess(),
         getUserTier: () => getServerSideKeyService().getUserTier() ?? undefined,
       },
-    );
+    });
     this.profileController = new SettingsProfileController({
       globalState: globalSM,
       providerIds: SecretManager.API_PROVIDERS,
@@ -328,29 +319,25 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         getData: () =>
           this.withActiveWebview((w) => this.sendModelSelectionData(w)),
         setEnabled: (modelName, enabled) =>
-          this.updateModelSelection(
-            () =>
-              this.modelSelectionController.setModelEnabled({
-                modelName,
-                enabled,
-              }),
-            { invalidateCache: true, refreshMainOptions: true },
-          ),
+          this.setModelEnabled(modelName, enabled),
         setHelperModel: (modelName) =>
-          this.updateModelSelection(() =>
-            this.modelSelectionController.setHelperModel(modelName),
-          ),
+          this.settingsHost.setHelperModel(modelName, {
+            respond: (message) => this.postMessageToActiveWebview(message),
+          }),
         setReasoningLevel: (modelName, level) =>
-          this.updateModelSelection(() =>
-            this.modelSelectionController.setReasoningLevel({
+          this.settingsHost.setReasoningLevel(
+            {
               modelName,
               level,
-            }),
+            },
+            {
+              respond: (message) => this.postMessageToActiveWebview(message),
+            },
           ),
         setPreferShortModelNames: (enabled) =>
-          this.updateModelSelection(() =>
-            this.modelSelectionController.setPreferShortModelNames(enabled),
-          ),
+          this.settingsHost.setPreferShortModelNames(enabled, {
+            respond: (message) => this.postMessageToActiveWebview(message),
+          }),
       },
       orchestration: {
         getSuperYoloEnabled: () =>
@@ -631,8 +618,8 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   }
 
   public async sendMemoryData(webview: vscode.Webview): Promise<void> {
-    await webview.postMessage(
-      await this.memoryController.getMemoryDataMessage(),
+    await this.settingsHost.sendMemoryData((message) =>
+      webview.postMessage(message),
     );
   }
 
@@ -640,25 +627,23 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     data: MessageFor<typeof SETTINGS_VIEW_CMD.GET_MEMORY_PREVIEW>,
   ): Promise<void> {
     await this.withActiveWebview(async (webview) => {
-      try {
-        await webview.postMessage(
-          await this.memoryController.getMemoryPreviewMessage(data.storagePath),
-        );
-      } catch (error) {
-        void showLoggedErrorMessage(
-          this.channel,
-          'Failed to load memory preview',
-          error,
-        );
-        await webview.postMessage(
-          this.memoryController.getMemoryPreviewErrorMessage(data.storagePath),
-        );
-      }
+      await this.settingsHost.sendMemoryPreview(data, {
+        respond: (message) => webview.postMessage(message),
+        onError: async (error) => {
+          await showLoggedErrorMessage(
+            this.channel,
+            'Failed to load memory preview',
+            error,
+          );
+        },
+      });
     });
   }
 
   public async sendMemoryEnabled(webview: vscode.Webview): Promise<void> {
-    await webview.postMessage(this.memoryController.getMemoryEnabledMessage());
+    await this.settingsHost.sendMemoryEnabled((message) =>
+      webview.postMessage(message),
+    );
   }
 
   public async sendInlineCriticismEnabled(
@@ -684,8 +669,8 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   }
 
   public async sendModelSelectionData(webview: vscode.Webview): Promise<void> {
-    await webview.postMessage(
-      await buildModelSelectionMessage(this.modelSelectionController),
+    await this.settingsHost.sendModelSelectionData((message) =>
+      webview.postMessage(message),
     );
   }
 
@@ -866,8 +851,9 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     data: MessageFor<typeof SETTINGS_VIEW_CMD.DELETE_MEMORY>,
   ): Promise<void> {
     try {
-      const message = await this.memoryController.deleteMemory(data);
-      await this.postMessageToActiveWebview(message);
+      await this.settingsHost.deleteMemory(data, (message) =>
+        this.postMessageToActiveWebview(message),
+      );
     } catch (error) {
       await showLoggedErrorMessage(
         this.channel,
@@ -881,8 +867,9 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private async handleSetMemoryEnabled(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_MEMORY_ENABLED>,
   ): Promise<void> {
-    const message = await this.memoryController.setMemoryEnabled(data.enabled);
-    await this.postMessageToActiveWebview(message);
+    await this.settingsHost.setMemoryEnabled(data.enabled, (message) =>
+      this.postMessageToActiveWebview(message),
+    );
   }
 
   private async setMemoryPinned(
@@ -890,10 +877,9 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     pinned: boolean,
   ): Promise<void> {
     try {
-      const message = pinned
-        ? await this.memoryController.pinMemory(storagePath)
-        : await this.memoryController.unpinMemory(storagePath);
-      await this.postMessageToActiveWebview(message);
+      await this.settingsHost.setMemoryPinned(storagePath, pinned, (message) =>
+        this.postMessageToActiveWebview(message),
+      );
     } catch (error) {
       const action = pinned ? 'pin' : 'unpin';
       await showLoggedErrorMessage(
@@ -1053,26 +1039,18 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     await this.withActiveWebview((w) => this.sendProfileData(w));
   }
 
-  private async updateModelSelection(
-    update: () => Promise<void>,
-    options: { invalidateCache?: boolean; refreshMainOptions?: boolean } = {},
+  private async setModelEnabled(
+    modelName: string,
+    enabled: boolean,
   ): Promise<void> {
-    await update();
-    if (options.invalidateCache) {
-      invalidateModelOptionsCache();
-    }
-
-    const refreshSettings = this.withActiveWebview((w) =>
-      this.sendModelSelectionData(w),
+    await this.settingsHost.setModelEnabled(
+      { modelName, enabled },
+      {
+        afterUpdate: () => invalidateModelOptionsCache(),
+        respond: (message) => this.postMessageToActiveWebview(message),
+        afterPost: () =>
+          safeExecuteCommand('texra.refreshAllOptions', [], this.viewName),
+      },
     );
-    if (!options.refreshMainOptions) {
-      await refreshSettings;
-      return;
-    }
-
-    await Promise.all([
-      safeExecuteCommand('texra.refreshAllOptions', [], this.viewName),
-      refreshSettings,
-    ]);
   }
 }

--- a/src/controllers/settingsView/SettingsViewHost.ts
+++ b/src/controllers/settingsView/SettingsViewHost.ts
@@ -1,0 +1,215 @@
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import type {
+  SettingsMessageFor,
+  SETTINGS_VIEW_CMD,
+} from '@shared/schemas/settingsViewMessages';
+import type {
+  SettingsRespond,
+  SettingsStatePorts,
+} from '@shared/settingsView/types';
+
+import {
+  createSettingsMemoryController,
+  type SettingsMemoryControllerFactoryOptions,
+} from './SettingsMemoryControllerFactory';
+import {
+  buildModelSelectionMessage,
+  createModelSelectionController,
+  type ModelSelectionExtras,
+} from './SettingsModelSelectionControllerFactory';
+import type { SettingsMemoryController } from './SettingsMemoryController';
+import type { SettingsModelSelectionController } from './SettingsModelSelectionController';
+
+type Awaitable<T> = T | PromiseLike<T>;
+type MemoryPreviewMessage = SettingsMessageFor<
+  typeof SETTINGS_VIEW_CMD.GET_MEMORY_PREVIEW
+>;
+type MemoryDeleteMessage = SettingsMessageFor<
+  typeof SETTINGS_VIEW_CMD.DELETE_MEMORY
+>;
+type SetModelEnabledInput = Omit<
+  SettingsMessageFor<typeof SETTINGS_VIEW_COMMANDS.SET_MODEL_ENABLED>,
+  'command'
+>;
+type SetReasoningLevelInput = Omit<
+  SettingsMessageFor<typeof SETTINGS_VIEW_COMMANDS.SET_MODEL_REASONING_LEVEL>,
+  'command'
+>;
+
+export interface SettingsViewHostOptions {
+  readonly state: SettingsStatePorts;
+  readonly memoryPrompt: SettingsMemoryControllerFactoryOptions['prompt'];
+  readonly respond?: SettingsRespond;
+  readonly setMemoryEnabled?: SettingsMemoryControllerFactoryOptions['setMemoryEnabled'];
+  readonly modelSelectionExtras?: ModelSelectionExtras;
+  readonly beforeModelSelectionMessage?: () => Awaitable<void>;
+  readonly controllers?: {
+    readonly memory?: SettingsMemoryController;
+    readonly modelSelection?: SettingsModelSelectionController;
+  };
+}
+
+export interface SettingsViewHostMutationOptions {
+  readonly afterUpdate?: () => Awaitable<void>;
+  readonly afterPost?: () => Awaitable<void>;
+}
+
+export class SettingsViewHost {
+  readonly memoryController: SettingsMemoryController;
+  readonly modelSelectionController: SettingsModelSelectionController;
+
+  constructor(private readonly options: SettingsViewHostOptions) {
+    this.memoryController =
+      options.controllers?.memory ??
+      createSettingsMemoryController({
+        globalState: options.state.globalState,
+        prompt: options.memoryPrompt,
+        setMemoryEnabled: options.setMemoryEnabled,
+      });
+    this.modelSelectionController =
+      options.controllers?.modelSelection ??
+      createModelSelectionController(
+        options.state,
+        options.modelSelectionExtras,
+      );
+  }
+
+  async sendMemoryData(respond?: SettingsRespond): Promise<void> {
+    await this.post(
+      await this.memoryController.getMemoryDataMessage(),
+      respond,
+    );
+  }
+
+  async sendMemoryPreview(
+    data: Pick<MemoryPreviewMessage, 'storagePath'>,
+    options: {
+      readonly respond?: SettingsRespond;
+      readonly onError?: (error: unknown) => Awaitable<void>;
+    } = {},
+  ): Promise<void> {
+    try {
+      await this.post(
+        await this.memoryController.getMemoryPreviewMessage(data.storagePath),
+        options.respond,
+      );
+    } catch (error) {
+      await options.onError?.(error);
+      await this.post(
+        this.memoryController.getMemoryPreviewErrorMessage(data.storagePath),
+        options.respond,
+      );
+    }
+  }
+
+  async sendMemoryEnabled(respond?: SettingsRespond): Promise<void> {
+    await this.post(this.memoryController.getMemoryEnabledMessage(), respond);
+  }
+
+  async deleteMemory(
+    data: Pick<MemoryDeleteMessage, 'displayPath' | 'storagePath'>,
+    respond?: SettingsRespond,
+  ): Promise<void> {
+    await this.postMaybe(
+      await this.memoryController.deleteMemory(data),
+      respond,
+    );
+  }
+
+  async setMemoryEnabled(
+    enabled: boolean,
+    respond?: SettingsRespond,
+  ): Promise<void> {
+    await this.post(
+      await this.memoryController.setMemoryEnabled(enabled),
+      respond,
+    );
+  }
+
+  async setMemoryPinned(
+    storagePath: string,
+    pinned: boolean,
+    respond?: SettingsRespond,
+  ): Promise<void> {
+    const message = pinned
+      ? await this.memoryController.pinMemory(storagePath)
+      : await this.memoryController.unpinMemory(storagePath);
+    await this.postMaybe(message, respond);
+  }
+
+  async sendModelSelectionData(respond?: SettingsRespond): Promise<void> {
+    await this.options.beforeModelSelectionMessage?.();
+    await this.post(
+      await buildModelSelectionMessage(this.modelSelectionController),
+      respond,
+    );
+  }
+
+  async setModelEnabled(
+    input: SetModelEnabledInput,
+    options?: SettingsViewHostMutationOptions & { respond?: SettingsRespond },
+  ): Promise<void> {
+    await this.modelSelectionController.setModelEnabled(input);
+    await this.postModelSelectionMutation(options);
+  }
+
+  async setHelperModel(
+    modelName: string,
+    options?: SettingsViewHostMutationOptions & { respond?: SettingsRespond },
+  ): Promise<void> {
+    await this.modelSelectionController.setHelperModel(modelName);
+    await this.postModelSelectionMutation(options);
+  }
+
+  async setReasoningLevel(
+    input: SetReasoningLevelInput,
+    options?: SettingsViewHostMutationOptions & { respond?: SettingsRespond },
+  ): Promise<void> {
+    await this.modelSelectionController.setReasoningLevel(input);
+    await this.postModelSelectionMutation(options);
+  }
+
+  async setPreferShortModelNames(
+    enabled: boolean,
+    options?: SettingsViewHostMutationOptions & { respond?: SettingsRespond },
+  ): Promise<void> {
+    await this.modelSelectionController.setPreferShortModelNames(enabled);
+    await this.postModelSelectionMutation(options);
+  }
+
+  getVisibleModels(): string[] {
+    return this.modelSelectionController.getVisibleModels();
+  }
+
+  private async postModelSelectionMutation(
+    options?: SettingsViewHostMutationOptions & { respond?: SettingsRespond },
+  ): Promise<void> {
+    await options?.afterUpdate?.();
+    await this.sendModelSelectionData(options?.respond);
+    await options?.afterPost?.();
+  }
+
+  private async post(
+    message: unknown,
+    respond = this.options.respond,
+  ): Promise<void> {
+    if (!respond) {
+      throw new Error('SettingsViewHost has no response target.');
+    }
+    await respond(message);
+  }
+
+  private async postMaybe(
+    message: unknown | null | undefined,
+    respond?: SettingsRespond,
+  ): Promise<void> {
+    if (message == null) return;
+    await this.post(message, respond);
+  }
+}
+
+export function createSettingsViewHost(
+  options: SettingsViewHostOptions,
+): SettingsViewHost {
+  return new SettingsViewHost(options);
+}

--- a/src/test-kernel/controllers/SettingsViewHost.vitest.ts
+++ b/src/test-kernel/controllers/SettingsViewHost.vitest.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+
+import { SettingsMemoryController } from '@controllers/settingsView/SettingsMemoryController';
+import { SettingsModelSelectionController } from '@controllers/settingsView/SettingsModelSelectionController';
+import { createSettingsViewHost } from '@controllers/settingsView/SettingsViewHost';
+import { buildBasicModelOptionsData } from '@model/modelOptionsBasic';
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import type { ModelOptionData } from '@shared/schemas';
+import type { StateStore } from '@platform/interfaces';
+
+function createStateStore(): StateStore {
+  const values = new Map<string, unknown>();
+  return {
+    get: (key, defaultValue) =>
+      (values.has(key) ? values.get(key) : defaultValue) as never,
+    update: async (key, value) => {
+      values.set(key, value);
+    },
+  };
+}
+
+function createMemoryController() {
+  let enabled = true;
+  return {
+    controller: new SettingsMemoryController({
+      prompt: {
+        confirm: async () => true,
+        warning: async () => undefined,
+      },
+      loadMemoryItems: async () => [],
+      loadMemoryPreview: async (storagePath) => ({
+        storagePath,
+        lineCount: 1,
+        preview: 'remember',
+      }),
+      isMemoryEnabled: () => enabled,
+      setMemoryEnabled: async (next) => {
+        enabled = next;
+      },
+      memoryStoragePath: (storagePath) => `mem/${storagePath}`,
+      storage: {
+        delete: async () => undefined,
+        read: async () => '',
+        write: async () => undefined,
+      },
+      maxPinnedMemories: 3,
+      parseMemoryFile: (raw) => ({ meta: null, content: raw }),
+      buildMemoryFile: (content) => content,
+      setPinnedMeta: (meta, pinned) => ({
+        modifiedBy: meta?.modifiedBy ?? 'codex',
+        modifiedAt: meta?.modifiedAt ?? '2026-07-07T00:00:00.000Z',
+        pinned,
+      }),
+      countPinnedMemories: async () => 0,
+    }),
+    isEnabled: () => enabled,
+  };
+}
+
+function createModelSelectionController() {
+  const state = {
+    enabledModels: ['gpt55', 'sonnet46T'],
+    helperModel: 'gpt55',
+    reasoningLevelOverrides: {},
+    preferShortModelNames: false,
+  };
+  const resolveModelOptions = async (
+    models: readonly string[],
+  ): Promise<ModelOptionData[]> =>
+    buildBasicModelOptionsData(models).map((option) => ({
+      ...option,
+      availability: 'provider-key',
+      availabilityLabel: 'API key set',
+      requiresKey: false,
+      disabled: false,
+    }));
+
+  return {
+    controller: new SettingsModelSelectionController({
+      state: {
+        getEnabledModels: () => state.enabledModels,
+        setEnabledModels: async (models) => {
+          state.enabledModels = models;
+        },
+        getHelperModel: () => state.helperModel,
+        setHelperModel: async (model) => {
+          state.helperModel = model;
+        },
+        getReasoningLevelOverrides: () => state.reasoningLevelOverrides,
+        setReasoningLevelOverrides: async (overrides) => {
+          state.reasoningLevelOverrides = overrides;
+        },
+        getPreferShortModelNames: () => state.preferShortModelNames,
+        setPreferShortModelNames: async (enabled) => {
+          state.preferShortModelNames = enabled;
+        },
+      },
+      resolveModelOptions,
+    }),
+    state,
+  };
+}
+
+describe('SettingsViewHost', () => {
+  it('posts memory and model-selection messages through shared host wiring', async () => {
+    const memory = createMemoryController();
+    const modelSelection = createModelSelectionController();
+    const messages: unknown[] = [];
+    let modelRefreshes = 0;
+    const host = createSettingsViewHost({
+      state: {
+        workspaceState: createStateStore(),
+        globalState: createStateStore(),
+      },
+      memoryPrompt: {
+        confirm: async () => true,
+        warning: async () => undefined,
+      },
+      respond: (message) => {
+        messages.push(message);
+      },
+      beforeModelSelectionMessage: () => {
+        modelRefreshes += 1;
+      },
+      controllers: {
+        memory: memory.controller,
+        modelSelection: modelSelection.controller,
+      },
+    });
+
+    await host.sendMemoryEnabled();
+    await host.setMemoryEnabled(false);
+    await host.sendModelSelectionData();
+    await host.setModelEnabled({ modelName: 'gpt55', enabled: false });
+
+    expect(messages.at(0)).toEqual({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY_ENABLED,
+      enabled: true,
+    });
+    expect(messages.at(1)).toEqual({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY_ENABLED,
+      enabled: false,
+    });
+    expect(memory.isEnabled()).toBe(false);
+
+    expect(messages.at(2)).toMatchObject({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_MODEL_SELECTION,
+      helperModel: 'gpt55',
+      preferShortModelNames: false,
+    });
+    expect(messages.at(3)).toMatchObject({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_MODEL_SELECTION,
+      helperModel: 'sonnet46T',
+    });
+    expect(modelSelection.state.enabledModels).toEqual(['sonnet46T']);
+    expect(modelRefreshes).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Part of #6972 under tracker #6953.

This introduces a shared settings-view host core for the two settings domains whose host wiring had become visibly duplicated: memory messages and model-selection messages. The new host-neutral controller owns construction/posting of memory and model-selection messages, while the extension and desktop hosts retain their host-specific effects such as opening memory files, showing VS Code messages, and refreshing main-view model options.

## Design

The shared object is intentionally narrow. It accepts state ports, a memory prompt port, an outbound message sink, and optional model-selection pre/post hooks. This hides the repeated controller construction and message-posting details without pulling VS Code or Electron concerns into the controller layer.

The desktop path still refreshes the main model options after enabled-model changes. The extension path still invalidates model caches and calls `texra.refreshAllOptions` for the same case.

## Validation

- `CI=true corepack pnpm exec vitest run src/test-kernel/controllers/SettingsViewHost.vitest.ts src/test-kernel/controllers/SettingsMemoryController.vitest.ts src/test-kernel/controllers/SettingsModelSelectionController.vitest.ts src/test-kernel/desktop/desktopSettingsIpc.vitest.ts`
- `CI=true corepack pnpm exec eslint src/controllers/settingsView/SettingsViewHost.ts packages/extension/src/settingsView/SettingsViewMessageHandler.ts packages/desktop/src/main/desktopSettingsIpc.ts src/test-kernel/controllers/SettingsViewHost.vitest.ts`
- `CI=true corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec prettier --check src/controllers/settingsView/SettingsViewHost.ts packages/extension/src/settingsView/SettingsViewMessageHandler.ts packages/desktop/src/main/desktopSettingsIpc.ts src/test-kernel/controllers/SettingsViewHost.vitest.ts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with behavior preserved via the same controllers and explicit after-hooks; covered by new unit tests and existing controller/desktop IPC tests.
> 
> **Overview**
> Introduces **`SettingsViewHost`** in `src/controllers/settingsView/SettingsViewHost.ts` as shared wiring for **memory** and **model-selection** settings: it builds the memory/model controllers, posts IPC messages through an optional `respond` sink, runs `beforeModelSelectionMessage` before model payloads, and centralizes mutation flows (update → optional `afterUpdate` → refresh model selection → optional `afterPost`).
> 
> **Desktop** (`desktopSettingsIpc.ts`) and the **VS Code extension** (`SettingsViewMessageHandler.ts`) replace direct `createSettingsMemoryController` / `createModelSelectionController` usage and duplicated `postMessage` glue with a single `createSettingsViewHost` instance. Host-specific behavior stays in each shell: desktop uses `postToRenderer` and refreshes main-view model options after enable/disable changes; the extension passes per-webview `respond` callbacks and still invalidates caches / runs `texra.refreshAllOptions` when models change.
> 
> Adds **`SettingsViewHost.vitest.ts`** to assert memory enabled toggles, model-selection posts, and `beforeModelSelectionMessage` hooks fire on mutations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 524585fb75f201971fa0730c34276ba2d12690cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->