### PR TITLE
refactor: project stream descriptions from session facts

### DIFF
--- a/src/agent/runtime/SessionEventHub.ts
+++ b/src/agent/runtime/SessionEventHub.ts
@@ -9,6 +9,7 @@ import type {
   SetActiveStreamPayload,
   StreamTabId,
   UpdateQueuedFollowUpsPayload,
+  UpdateStreamDescriptionPayload,
 } from '@shared/schemas';
 
 const logger = createChannelTrace('SessionEventHub');
@@ -39,6 +40,10 @@ export type SessionFact =
   | {
       readonly type: 'setActiveStream';
       readonly payload: SetActiveStreamPayload;
+    }
+  | {
+      readonly type: 'updateStreamDescription';
+      readonly payload: UpdateStreamDescriptionPayload;
     };
 
 export type SessionEvent =

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -376,7 +376,7 @@ export async function executeAgent(
       ctx.executionId,
       streamId,
       config,
-      ctx.runtimeHost,
+      ctx.session,
     ).catch(() => {});
     const result = await runFlowWithLifecycle(
       ctx,

--- a/src/agent/runtime/sessionDescription.ts
+++ b/src/agent/runtime/sessionDescription.ts
@@ -11,7 +11,8 @@ import { getAgent } from '@agent/index';
 import { writeSessionDescription } from '@agent/storage';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import {
   createHelperModelKit,
   runHelperModelCompletion,
@@ -82,7 +83,7 @@ export async function generateSessionDescription(
   executionId: ExecutionId,
   streamId: StreamTabId,
   config: AgentConfig,
-  runtimeHost: AgentRuntimeHost,
+  session: SessionHandle,
 ): Promise<void> {
   try {
     if (config.agentCategory !== AgentCategory.ToolUse) return;
@@ -113,10 +114,11 @@ export async function generateSessionDescription(
       const description = cleanSessionDescription(text);
       if (!description) return;
       await writeSessionDescription(executionId, description);
-      runtimeHost.emit('updateStreamDescription', {
-        streamId,
-        description,
-      });
+      emitRuntimeEvent(
+        'updateStreamDescription',
+        { streamId, description },
+        session,
+      );
       logger.info(CHANNEL, `Generated session description for ${executionId}`);
     }
   } catch (err) {

--- a/src/agent/runtime/sessionProgressEventProjection.ts
+++ b/src/agent/runtime/sessionProgressEventProjection.ts
@@ -104,6 +104,8 @@ export function projectSessionFactToProgressEvent(
       return { event: 'updateQueuedFollowUps', payload: fact.payload };
     case 'setActiveStream':
       return { event: 'setActiveStream', payload: fact.payload };
+    case 'updateStreamDescription':
+      return { event: 'updateStreamDescription', payload: fact.payload };
   }
 }
 

--- a/src/shared/schemas/progressEvents.ts
+++ b/src/shared/schemas/progressEvents.ts
@@ -38,6 +38,11 @@ export interface SetActiveStreamPayload {
   suppressViewSwitch?: boolean;
 }
 
+export interface UpdateStreamDescriptionPayload {
+  streamId: StreamTabId;
+  description: string;
+}
+
 export interface AddOutputFilesPayload extends StreamScopedPayload {
   filesByRound: RoundIndexed<OutputFileInfo>;
 }

--- a/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
@@ -190,6 +190,13 @@ describe('child stream progress events', () => {
         },
       },
     });
+    expect(events[2]).toEqual({
+      event: 'updateStreamDescription',
+      payload: {
+        streamId: childStreamId,
+        description: 'Run a background bash command',
+      },
+    });
     expect(events[3]).toEqual({
       event: 'updateStreamStatus',
       payload: {

--- a/src/test-kernel/agent/runtime/SessionDescription.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionDescription.vitest.ts
@@ -6,12 +6,12 @@ import {
   generateSessionDescription,
   getSessionDescriptionInstruction,
 } from '@agent/runtime/sessionDescription';
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { SessionHandle } from '@agent/runtime/SessionHandle';
+import type { SessionEvent } from '@agent/runtime/SessionEventHub';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
 const mocks = vi.hoisted(() => ({
   createHelperModelKit: vi.fn(),
-  emit: vi.fn(),
   getAgent: vi.fn(),
   writeSessionDescription: vi.fn(),
 }));
@@ -63,19 +63,31 @@ describe('session description helpers', () => {
   });
 
   it('does not generate helper-model descriptions for workflow runs', async () => {
+    const session = new SessionHandle();
+    const events: SessionEvent[] = [];
+    const detach = session.events.subscribe((event) => events.push(event), {
+      scope: 'session',
+    });
+
     await generateSessionDescription(
       'exec-workflow' as ExecutionId,
       'stream-workflow' as StreamTabId,
       configFor(AgentCategory.Workflow),
-      { emit: mocks.emit } as unknown as AgentRuntimeHost,
+      session,
     );
+    detach();
 
     expect(mocks.createHelperModelKit).not.toHaveBeenCalled();
     expect(mocks.writeSessionDescription).not.toHaveBeenCalled();
-    expect(mocks.emit).not.toHaveBeenCalled();
+    expect(events).toEqual([]);
   });
 
   it('keeps generating compact descriptions for tool-use runs', async () => {
+    const session = new SessionHandle();
+    const events: SessionEvent[] = [];
+    const detach = session.events.subscribe((event) => events.push(event), {
+      scope: 'session',
+    });
     const handler = {
       createResponse: vi.fn().mockResolvedValue({ response: {} }),
       extractResponse: vi.fn().mockReturnValue({ text: 'Fixing proof typos' }),
@@ -90,16 +102,25 @@ describe('session description helpers', () => {
       'exec-tool' as ExecutionId,
       'stream-tool' as StreamTabId,
       configFor(AgentCategory.ToolUse),
-      { emit: mocks.emit } as unknown as AgentRuntimeHost,
+      session,
     );
+    detach();
 
     expect(mocks.writeSessionDescription).toHaveBeenCalledWith(
       'exec-tool',
       'Fixing proof typos',
     );
-    expect(mocks.emit).toHaveBeenCalledWith('updateStreamDescription', {
-      streamId: 'stream-tool',
-      description: 'Fixing proof typos',
-    });
+    expect(events).toEqual([
+      {
+        scope: 'session',
+        event: {
+          type: 'updateStreamDescription',
+          payload: {
+            streamId: 'stream-tool',
+            description: 'Fixing proof typos',
+          },
+        },
+      },
+    ]);
   });
 });

--- a/src/test-kernel/agent/runtime/SessionEventHub.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionEventHub.vitest.ts
@@ -181,6 +181,37 @@ describe('SessionEventHub', () => {
     detachTrace();
   });
 
+  it('projects stream descriptions from session facts to the runtime host', () => {
+    const hub = new SessionEventHub();
+    const host = createRecordingHost();
+    const detachProjection = attachSessionProgressEventProjectionForTest(
+      hub,
+      host.host,
+    );
+
+    hub.emit({
+      scope: 'session',
+      event: {
+        type: 'updateStreamDescription',
+        payload: {
+          streamId,
+          description: 'Checking proof outline',
+        },
+      },
+    });
+
+    expect(host.events).toEqual([
+      {
+        event: 'updateStreamDescription',
+        payload: {
+          streamId,
+          description: 'Checking proof outline',
+        },
+      },
+    ]);
+    detachProjection();
+  });
+
   it('detaches test projection subscriptions cleanly', () => {
     const trace = new TraceEmitter();
     const hub = new SessionEventHub();

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -4,6 +4,7 @@ import type { AgentTrace } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
 import {
   currentSession,
@@ -122,10 +123,14 @@ export function createChildStream(
     executionId,
     taskState: agentConfigToTaskState(options.config),
   });
-  runtimeHost.emit('updateStreamDescription', {
-    streamId: childStreamId,
-    description: truncateWithEllipsis(options.description, 80),
-  });
+  emitRuntimeEvent(
+    'updateStreamDescription',
+    {
+      streamId: childStreamId,
+      description: truncateWithEllipsis(options.description, 80),
+    },
+    session,
+  );
 
   const handle = new AgentExecutionHandle(
     executionId,


### PR DESCRIPTION
## Summary

Part of #6968 under tracker #6951.

This moves `updateStreamDescription` producers onto the session fact plane while preserving the retained legacy progress-event projection for existing hosts and UI consumers. Session descriptions and child-stream labels now emit a typed `updateStreamDescription` session fact; `sessionProgressEventProjection` projects that fact back to the existing progress event.

## Design

The slice intentionally keeps the fact name aligned with the retained progress event. This avoids widening the migration surface while still removing direct producer use of the host progress bus. The observable host event sequence for child streams remains unchanged.

The session-description generator now receives the owning `SessionHandle` from `executeAgent`, writes the description metadata as before, and emits the session fact through `emitRuntimeEvent`. Child streams reuse the session already captured at stream creation.

## Validation

- `CI=true corepack pnpm exec vitest run src/test-kernel/agent/runtime/SessionDescription.vitest.ts src/test-kernel/agent/runtime/SessionEventHub.vitest.ts src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts`
- `CI=true corepack pnpm exec eslint src/shared/schemas/progressEvents.ts src/agent/runtime/SessionEventHub.ts src/agent/runtime/sessionProgressEventProjection.ts src/agent/runtime/sessionDescription.ts src/agent/runtime/executeAgent.ts src/tools/childStream.ts src/test-kernel/agent/runtime/SessionDescription.vitest.ts src/test-kernel/agent/runtime/SessionEventHub.vitest.ts src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts`
- `CI=true corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec prettier --check src/shared/schemas/progressEvents.ts src/agent/runtime/SessionEventHub.ts src/agent/runtime/sessionProgressEventProjection.ts src/agent/runtime/sessionDescription.ts src/agent/runtime/executeAgent.ts src/tools/childStream.ts src/test-kernel/agent/runtime/SessionDescription.vitest.ts src/test-kernel/agent/runtime/SessionEventHub.vitest.ts src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow refactor of progress signaling with backward-compatible projection; no auth, data, or execution-lifecycle logic changes beyond the emission path.
> 
> **Overview**
> **Stream descriptions** now flow through the session fact plane instead of calling `AgentRuntimeHost.emit` directly. Producers (`generateSessionDescription`, child stream creation) use `emitRuntimeEvent('updateStreamDescription', …)` with the owning `SessionHandle`; `executeAgent` passes `ctx.session` into the description generator.
> 
> A new **`updateStreamDescription` session fact** is wired end-to-end: `UpdateStreamDescriptionPayload` in shared schemas, a `SessionFact` arm on `SessionEventHub`, and a branch in `sessionProgressEventProjection` that re-emits the existing **`updateStreamDescription` progress event** so hosts and UI keep the same observable sequence.
> 
> Tests assert session-hub emission for AI-generated labels, projection to the recording host, and unchanged child-stream progress event ordering (including the description event after `setTaskState`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 666e038238db4282a5002944d449d3fc794336cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->