### PR TITLE
refactor: make parent stream links session facts

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -426,7 +426,16 @@ export function attachTuiRunFactSubscription(
   activeGoalPausedNoticeEchoGuard = goalPausedNoticeEchoGuard;
   activeProcessesEchoGuard = activeProcessesGuard;
   activeProcessOutputEchoGuard = processOutputGuard;
-  const detach = events.subscribe(
+  const detachSessionFacts = events.subscribe(
+    (sessionEvent) => {
+      if (sessionEvent.scope !== 'session') return;
+      if (sessionEvent.event.type === 'setParentStream') {
+        applyParentStream(sessionEvent.event.payload);
+      }
+    },
+    { scope: 'session' },
+  );
+  const detachRunFacts = events.subscribe(
     (sessionEvent) => {
       if (sessionEvent.scope !== 'run') return;
       const { event } = sessionEvent;
@@ -500,7 +509,8 @@ export function attachTuiRunFactSubscription(
     },
   );
   return () => {
-    detach();
+    detachRunFacts();
+    detachSessionFacts();
     usageEchoGuard.clear();
     goalPausedNoticeEchoGuard.clear();
     activeProcessesGuard.clear();

--- a/src/agent/runtime/SessionEventHub.ts
+++ b/src/agent/runtime/SessionEventHub.ts
@@ -7,6 +7,7 @@ import type {
   GoalStateChangedPayload,
   InquiryThreadUpdatedEvent,
   SetActiveStreamPayload,
+  SetParentStreamPayload,
   StreamTabId,
   UpdateQueuedFollowUpsPayload,
   UpdateStreamDescriptionPayload,
@@ -44,6 +45,10 @@ export type SessionFact =
   | {
       readonly type: 'updateStreamDescription';
       readonly payload: UpdateStreamDescriptionPayload;
+    }
+  | {
+      readonly type: 'setParentStream';
+      readonly payload: SetParentStreamPayload;
     };
 
 export type SessionEvent =

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -246,7 +246,6 @@ export class ExecutionRegistry {
       if (handle.isChildExecution) {
         this.emitActiveSubagentsUpdate(handle.parentStreamId, runtimeHost);
         this.emitParentStreamUpdate(runtimeHost, {
-          parentScopeStreamId: handle.parentStreamId,
           childStreamId: handle.childStreamId,
           parentStreamId: handle.parentStreamId,
         });
@@ -607,7 +606,6 @@ export class ExecutionRegistry {
       if (handle instanceof AgentExecutionHandle) {
         handle.detach();
         this.emitParentStreamUpdate(runtimeHost, {
-          parentScopeStreamId: parentStreamId,
           childStreamId: handle.childStreamId,
           parentStreamId: null,
         });
@@ -769,20 +767,19 @@ export class ExecutionRegistry {
   private emitParentStreamUpdate(
     runtimeHost: AgentRuntimeHost,
     payload: {
-      readonly parentScopeStreamId: StreamTabId;
       readonly childStreamId: StreamTabId;
       readonly parentStreamId: StreamTabId | null;
     },
   ): void {
     if (this.events) {
       this.events.emit({
-        scope: 'run',
-        streamId: payload.parentScopeStreamId,
+        scope: 'session',
         event: {
-          type: 'child.activity',
-          kind: 'parent',
-          childStreamId: payload.childStreamId,
-          parentStreamId: payload.parentStreamId,
+          type: 'setParentStream',
+          payload: {
+            childStreamId: payload.childStreamId,
+            parentStreamId: payload.parentStreamId,
+          },
         },
       });
       return;

--- a/src/agent/runtime/hostProgressEvents.ts
+++ b/src/agent/runtime/hostProgressEvents.ts
@@ -17,6 +17,7 @@ import type {
   RequestShowInstructionPayload,
   RetryPermission,
   SetActiveStreamPayload,
+  SetParentStreamPayload,
   ShowAgentConfigBannerPayload,
   StreamPhase,
   StreamSubstate,
@@ -30,6 +31,7 @@ import type {
   UpdateProcessOutputPayload,
   UpdateQueuedFollowUpsPayload,
   UpdateRoundStagePayload,
+  UpdateStreamDescriptionPayload,
   UpdateStreamUsagePayload,
   UpdateTodosPayload,
   UserQuestionPermission,
@@ -51,8 +53,8 @@ import type {
  * session/host surfaces.
  * Every fact-plane key below references its named vocabulary type — this map
  * projects the vocabulary, it does not define it. Keys still typed inline are
- * not facts: host-rail status/RPC keys plus the Stage-5 residue trio
- * (`setTaskState`, `updateStreamDescription`, `setParentStream`).
+ * not facts: host-rail status/RPC keys plus the remaining Stage-5 residue
+ * (`setTaskState`).
  */
 export interface ProgressEventPayloads {
   // ── Run/stream progress ──
@@ -114,14 +116,8 @@ export interface ProgressEventPayloads {
   updateActiveSubagents: UpdateActiveSubagentsPayload;
   updateActiveProcesses: UpdateActiveProcessesPayload;
   updateProcessOutput: UpdateProcessOutputPayload;
-  updateStreamDescription: {
-    streamId: StreamTabId;
-    description: string;
-  };
-  setParentStream: {
-    childStreamId: StreamTabId;
-    parentStreamId: StreamTabId | null;
-  };
+  updateStreamDescription: UpdateStreamDescriptionPayload;
+  setParentStream: SetParentStreamPayload;
   /** A follow-up message was sent to an active tool-use session.
    *  Listened by blocking tools (e.g. ExecutionsTool wait) to abort early. */
   followUpSent: { streamId: StreamTabId };

--- a/src/agent/runtime/sessionProgressEventProjection.ts
+++ b/src/agent/runtime/sessionProgressEventProjection.ts
@@ -106,6 +106,8 @@ export function projectSessionFactToProgressEvent(
       return { event: 'setActiveStream', payload: fact.payload };
     case 'updateStreamDescription':
       return { event: 'updateStreamDescription', payload: fact.payload };
+    case 'setParentStream':
+      return { event: 'setParentStream', payload: fact.payload };
   }
 }
 
@@ -173,13 +175,6 @@ export function projectRunFactToProgressEvent(
         },
       };
     }
-    return {
-      event: 'setParentStream',
-      payload: {
-        childStreamId: event.childStreamId,
-        parentStreamId: event.parentStreamId,
-      },
-    };
   }
 
   if (event.type === 'process.output') {

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -167,12 +167,6 @@ export type ChildActivityEvent =
       readonly kind: 'processes';
       readonly parentStreamId: StreamTabId;
       readonly processes: readonly ActiveChildInfo[];
-    })
-  | (StageStamp & {
-      readonly type: 'child.activity';
-      readonly kind: 'parent';
-      readonly childStreamId: StreamTabId;
-      readonly parentStreamId: StreamTabId | null;
     });
 
 /** Incremental output from a child process owned by a parent run stream. */

--- a/src/shared/schemas/progressEvents.ts
+++ b/src/shared/schemas/progressEvents.ts
@@ -43,6 +43,11 @@ export interface UpdateStreamDescriptionPayload {
   description: string;
 }
 
+export interface SetParentStreamPayload {
+  childStreamId: StreamTabId;
+  parentStreamId: StreamTabId | null;
+}
+
 export interface AddOutputFilesPayload extends StreamScopedPayload {
   filesByRound: RoundIndexed<OutputFileInfo>;
 }

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -12,7 +12,10 @@ import {
 } from '@agent/runtime/executionRegistry';
 import { InterruptRegistry } from '@agent/runtime/InterruptRegistry';
 import { ProcessOutputPoller } from '@agent/runtime/ProcessOutputPoller';
-import { SessionEventHub } from '@agent/runtime/SessionEventHub';
+import {
+  SessionEventHub,
+  type SessionEvent,
+} from '@agent/runtime/SessionEventHub';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import {
   RUN_OUTCOME,
@@ -964,6 +967,45 @@ describe('executionRegistry', () => {
     }
   });
 
+  it('publishes parent links through the attached session event hub', () => {
+    const explicit = createRecordingHost();
+    const events = new SessionEventHub();
+    const seen: SessionEvent[] = [];
+    const detach = events.subscribe((event) => seen.push(event));
+    const registry = new ExecutionRegistry({ events });
+    const executionId = 'exec-session-parent-link-test';
+    const parentStreamId = 'parent-session-parent-link-test' as StreamTabId;
+    const childStreamId = 'child-session-parent-link-test' as StreamTabId;
+
+    try {
+      const handle = new AgentExecutionHandle(
+        executionId,
+        parentStreamId,
+        childStreamId,
+        'test-subagent',
+        'toolUse',
+        explicit.host,
+      );
+
+      registry.track(handle);
+
+      expect(explicit.events).toEqual([]);
+      expect(seen).toContainEqual({
+        scope: 'session',
+        event: {
+          type: 'setParentStream',
+          payload: {
+            childStreamId,
+            parentStreamId,
+          },
+        },
+      });
+    } finally {
+      detach();
+      registry.dispose();
+    }
+  });
+
   it('clears live tool-use context while the handle remains tracked', () => {
     const explicit = createRecordingHost();
     const registry = new ExecutionRegistry();
@@ -1219,6 +1261,48 @@ describe('executionRegistry', () => {
         children: [],
       });
     } finally {
+      registry.dispose();
+    }
+  });
+
+  it('publishes detach parent links through the attached session event hub', () => {
+    const explicit = createRecordingHost();
+    const events = new SessionEventHub();
+    const seen: SessionEvent[] = [];
+    const detach = events.subscribe((event) => seen.push(event));
+    const registry = new ExecutionRegistry({ events });
+    const executionId = 'exec-detach-session-parent-link-test';
+    const parentStreamId =
+      'parent-detach-session-parent-link-test' as StreamTabId;
+    const childStreamId =
+      'child-detach-session-parent-link-test' as StreamTabId;
+
+    try {
+      const handle = new AgentExecutionHandle(
+        executionId,
+        parentStreamId,
+        childStreamId,
+        'test-subagent',
+        'toolUse',
+        explicit.host,
+      );
+
+      registry.track(handle);
+      registry.detachActiveChildren(parentStreamId, explicit.host);
+
+      expect(explicit.events).toEqual([]);
+      expect(seen).toContainEqual({
+        scope: 'session',
+        event: {
+          type: 'setParentStream',
+          payload: {
+            childStreamId,
+            parentStreamId: null,
+          },
+        },
+      });
+    } finally {
+      detach();
       registry.dispose();
     }
   });

--- a/src/test-kernel/agent/runtime/SessionEventHub.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionEventHub.vitest.ts
@@ -212,6 +212,37 @@ describe('SessionEventHub', () => {
     detachProjection();
   });
 
+  it('projects parent-stream links from session facts to the runtime host', () => {
+    const hub = new SessionEventHub();
+    const host = createRecordingHost();
+    const detachProjection = attachSessionProgressEventProjectionForTest(
+      hub,
+      host.host,
+    );
+
+    hub.emit({
+      scope: 'session',
+      event: {
+        type: 'setParentStream',
+        payload: {
+          childStreamId: otherStreamId,
+          parentStreamId: streamId,
+        },
+      },
+    });
+
+    expect(host.events).toEqual([
+      {
+        event: 'setParentStream',
+        payload: {
+          childStreamId: otherStreamId,
+          parentStreamId: streamId,
+        },
+      },
+    ]);
+    detachProjection();
+  });
+
   it('detaches test projection subscriptions cleanly', () => {
     const trace = new TraceEmitter();
     const hub = new SessionEventHub();

--- a/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
+++ b/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
@@ -75,13 +75,10 @@ describe('attachCliSessionProgressProjection', () => {
         },
       });
       hub.emit({
-        scope: 'run',
-        streamId: parentStreamId,
+        scope: 'session',
         event: {
-          type: 'child.activity',
-          kind: 'parent',
-          childStreamId,
-          parentStreamId,
+          type: 'setParentStream',
+          payload: { childStreamId, parentStreamId },
         },
       });
       hub.emit({

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -2811,7 +2811,7 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
     }
   });
 
-  it('applies direct child.activity(subagents) and parent events without host emission', () => {
+  it('applies direct child activity and parent-link facts without host emission', () => {
     const hub = new SessionEventHub();
     const hostEmit = vi.fn();
     const wrapped = wrapRuntimeHost({
@@ -2840,13 +2840,13 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
         },
       });
       hub.emit({
-        scope: 'run',
-        streamId: child2,
+        scope: 'session',
         event: {
-          type: 'child.activity',
-          kind: 'parent',
-          childStreamId: child2,
-          parentStreamId: root,
+          type: 'setParentStream',
+          payload: {
+            childStreamId: child2,
+            parentStreamId: root,
+          },
         },
       });
 

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -1217,13 +1217,13 @@ describe('ProgressBackend', () => {
       });
 
       direct.session.events.emit({
-        scope: 'run',
-        streamId: parentStreamId,
+        scope: 'session',
         event: {
-          type: 'child.activity',
-          kind: 'parent',
-          childStreamId,
-          parentStreamId,
+          type: 'setParentStream',
+          payload: {
+            childStreamId,
+            parentStreamId,
+          },
         },
       });
       legacyEquivalent.backend.handleProgressEvent('setParentStream', {


### PR DESCRIPTION
Part of #6968 and #6951.

## Summary

This Stage 5 slice moves parent-stream linkage onto the session fact plane while preserving the frozen legacy host event as a projection target.

- adds `SetParentStreamPayload` to the fact-native progress payload vocabulary
- adds `setParentStream` to `SessionFact` and projects it back to the retained `setParentStream` host event
- changes `ExecutionRegistry` to emit parent-link attach/detach updates through `SessionEventHub` when attached
- removes the old `child.activity` parent arm from the trace event union and projection path
- keeps CLI/TUI direct state in sync by applying session parent-link facts without host emission
- updates the stale host-progress comment now that `updateStreamDescription` and `setParentStream` are fact-native

The frozen `setParentStream` host event is intentionally not deleted; CLI, desktop, snapshots, and progress backend still consume it through the compatibility projection.

## Validation

- `CI=true corepack pnpm exec vitest run src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/agent/runtime/SessionEventHub.vitest.ts src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts`
- `CI=true corepack pnpm exec tsc --noEmit --pretty false`
- `CI=true corepack pnpm exec eslint src/shared/schemas/progressEvents.ts src/agent/runtime/SessionEventHub.ts src/agent/runtime/sessionProgressEventProjection.ts src/agent/runtime/executionRegistry.ts src/agent/trace/events.ts src/agent/runtime/hostProgressEvents.ts packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts src/test-kernel/agent/runtime/SessionEventHub.vitest.ts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm exec prettier --check ...`
- `git diff --check`
- `CI=true corepack pnpm run test` passed locally with 601 files passed, 1 skipped; 5173 tests passed, 4 skipped

A read-only verifier also checked the worktree and found no blocking issues before the final detach hardening test was added.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how parent–child stream relationships are broadcast across execution registry, TUI, and progress surfaces; legacy `setParentStream` host events are preserved via projection and tests cover the new path.
> 
> **Overview**
> Stage 5 migration: **parent–child stream linkage** is no longer a run-scoped `child.activity` event with `kind: 'parent'`; it is a **session-scoped** `setParentStream` fact with typed `SetParentStreamPayload`.
> 
> `ExecutionRegistry` publishes attach/detach parent links through `SessionEventHub` (`scope: 'session'`) when a hub is attached, instead of emitting on the parent run stream. The frozen legacy `setParentStream` host progress event remains for CLI, desktop, and progress backend via `sessionProgressEventProjection`.
> 
> The CLI TUI applies parent links from a dedicated **session-fact** subscription in `subscribeRuntimeHost` (without going through host `emit`). The `child.activity` **parent** variant is removed from the trace union and from run-fact → progress projection; subagent/process rosters stay on run-scoped `child.activity`.
> 
> Tests cover hub emission, projection, CLI subscription, TUI state, and progress backend parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 391409d62b63c1cee1d309fd320faaa82a6aca3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->