### PR TITLE
refactor(agents): collapse apply agent to a single round

### DIFF
--- a/reference-agents/apply.yaml
+++ b/reference-agents/apply.yaml
@@ -4,6 +4,7 @@ description: Implements suggestions from review agents (criticize, enhance, logi
 settings:
   agentCategory: workflow
   outputExt: tex
+  rounds: 1
 
 prompts:
   systemPrompt: |
@@ -82,18 +83,7 @@ prompts:
     - |
       Apply all changes suggested in the inline annotations and remove the original annotations. Watch for cross-document dependencies (shared results/definitions, consistent notation).
 
-      <documents>
-      {% for output in INPUT_FILES %}
-      <document name="{{ output }}">
-      % UPDATED_CONTENT_FOR_{{ output }}
-      </document>
-      {% endfor %}
-      </documents>
-
-    - |
-      SECOND PHASE: Revise, condense, and finalize.
-
-      If extensive derivations were added in the first phase, revise them to match the document's maturity level or +1 (unless the instruction requests more detail).
+      Match the document's maturity level (or +1) when implementing fixes, unless the instruction requests more detail:
 
       Document Maturity Levels:
       \begin{itemize}


### PR DESCRIPTION
## Summary

The `apply` reference agent ran two rounds: round 1 implemented fixes, round 2 re-read the result to match maturity level, verify correctness, and enforce output ordering. Collapses it to a single round.

## Change

- `settings.rounds: 1`.
- The single `userRequest` entry now carries round 2's guidance directly (maturity-level matching, pre-output verification checklist, cross-document consistency, explicit output ordering) instead of deferring it to a second pass.

No guidance was dropped, just merged into the one prompt the model now has to satisfy before emitting output.

## Verification

- `node scripts/sync-remote-agents.mjs --check` — up to date (rounds count matches the single-entry `userRequest` array, same rule `agentYamlScanner.ts`'s `userRequestTemplateCount` enforces).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt and round-count configuration only for the `apply` reference agent; no runtime application logic changes.
> 
> **Overview**
> The **`apply`** workflow agent no longer uses a two-round pattern (implement fixes, then revise/finalize). **`settings.rounds`** is set to **1**, and the extra **`userRequest`** entry for “SECOND PHASE” is removed.
> 
> The remaining prompt still asks the model to apply annotation fixes and strip originals, but it now also includes what used to be round 2: **document maturity** matching (+1 at most), a **pre-output verification** checklist (correctness, logical flow, cross-document consistency, comment style), and **explicit output ordering** via the `INPUT_FILES` document template—without relying on a second pass over intermediate output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b258b46616bf5695614cda9f6842c0e1e5565d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->