### PR TITLE
refactor: project initial task state from run config

### DIFF
--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -12,7 +12,6 @@ import {
 } from '@agent/trace';
 import { flowKey } from '@agent/node/persistedFlow';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 import {
   AGENT_ERROR_OUTCOME,
   AgentError,
@@ -240,13 +239,11 @@ function emitRunStart(ctx: AgentLaunchContext): void {
     category: ctx.setting.agentCategory,
   });
   ctx.logger.emit({ type: 'run.start', descriptor });
-
-  // Legacy compatibility for hosts still ingressing run identity through the
-  // host progress-event rail. The snapshot store no longer persists `taskState`.
-  ctx.runtimeHost.emit('setTaskState', {
+  ctx.logger.emit({
+    type: 'run.config',
     streamId: ctx.streamId,
     executionId: ctx.executionId,
-    taskState: agentConfigToTaskState(ctx.config),
+    config: ctx.config,
   });
 }
 

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -9,7 +9,7 @@ import {
 } from '@test/helpers/streamStatusTestUtils';
 import { platform } from '@platform/platform';
 import { installPlatform } from '@test/support/setupPlatform';
-import { noopTrace } from '@agent/trace';
+import { noopTrace, TraceEmitter } from '@agent/trace';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import {
   AgentCategory,
@@ -48,6 +48,7 @@ import { agentKey } from '@shared/schemas/agent';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 
 import { createRecordingHost } from '../progressTestUtils';
+import { attachSessionProgressEventProjectionForTest } from '../sessionProgressTestUtils';
 
 const storageMocks = vi.hoisted(() => ({
   writeTerminalStatus: vi.fn().mockResolvedValue(undefined),
@@ -247,9 +248,17 @@ describe('runFlowWithLifecycle', () => {
     }
   });
 
-  it('emits run config before the RUNNING status projection', async () => {
+  it('projects run config before the RUNNING status projection', async () => {
     const { executionId, streamId, streamStatus, ctx, explicit } =
       lifecycleFixture('lifecycle-run-config-before-running');
+    const trace = new TraceEmitter();
+    const detachTrace = ctx.session.attachRunTrace(trace, streamId);
+    const detachProjection = attachSessionProgressEventProjectionForTest(
+      ctx.session.events,
+      explicit.host,
+    );
+    ctx.logger = trace;
+    ctx.disposeTrace = detachTrace;
 
     try {
       await runFlowWithLifecycle(ctx, async () => ({
@@ -278,6 +287,8 @@ describe('runFlowWithLifecycle', () => {
       expect(runningIndex).toBeGreaterThanOrEqual(0);
       expect(setTaskStateIndex).toBeLessThan(runningIndex);
     } finally {
+      detachProjection();
+      detachTrace();
       clearStreamStatusForTest(streamStatus, streamId);
     }
   });

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -11,7 +11,6 @@ import {
   currentSession,
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
-import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 
 // Local imports - errors
 import { classifyAgentError } from '@common/errors';
@@ -123,10 +122,11 @@ export function createChildStream(
       category: options.config.agentCategory,
     }),
   });
-  runtimeHost.emit('setTaskState', {
+  runTrace.trace.emit({
+    type: 'run.config',
     streamId: childStreamId,
     executionId,
-    taskState: agentConfigToTaskState(options.config),
+    config: options.config,
   });
   emitRuntimeEvent(
     'updateStreamDescription',


### PR DESCRIPTION
Part of #6968 and #6951.

## Summary

This Stage 5 slice removes the remaining production direct `setTaskState` producers. The frozen host `setTaskState` event remains for CLI/progress/desktop/snapshot compatibility, but it is now produced from `run.config` projection.

- root run start emits `run.config` immediately after `run.start`, before the RUNNING transition
- child stream registration emits `run.config` through the child run trace instead of direct `runtimeHost.emit("setTaskState", ...)`
- the lifecycle ordering test now uses the real session projection path to assert projected `setTaskState` still precedes RUNNING

The retained `setTaskState` consumers are intentionally not deleted in this PR. CLI public output, TUI state, snapshots, desktop bridge, and progress backend still consume the frozen event via the compatibility projection.

## Validation

- `CI=true corepack pnpm exec vitest run src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts`
- `CI=true corepack pnpm exec vitest run src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts src/test-kernel/agent/runtime/SessionEventHub.vitest.ts src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/transcript/StreamSnapshotStore.vitest.ts src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts src/test-kernel/cli/RunProgressRenderer.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts`
- `CI=true corepack pnpm exec tsc --noEmit --pretty false`
- `CI=true corepack pnpm exec eslint src/agent/runtime/AgentRunLifecycle.ts src/tools/childStream.ts src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts`
- `corepack pnpm exec prettier --check src/agent/runtime/AgentRunLifecycle.ts src/tools/childStream.ts src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts`
- `git diff --check`
- `CI=true corepack pnpm run test` passed locally with 600 files passed, 1 skipped; 5173 tests passed, 4 skipped

A read-only verifier also checked the worktree and found no blocking issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Ordering of initial task state vs RUNNING is contract-sensitive for progress backends; behavior is preserved via projection but the producer path moved from host emit to trace facts.
> 
> **Overview**
> **Removes the last production paths that called `runtimeHost.emit('setTaskState', …)`** and routes initial run configuration through the trace fact plane instead.
> 
> Root run start (`emitRunStart` in `AgentRunLifecycle`) and child stream registration (`createChildStream`) now emit **`run.config`** on the run trace immediately after **`run.start`**, carrying the full **`AgentConfig`** rather than a converted **`taskState`**. The **`agentConfigToTaskState`** import is dropped from both sites. Legacy **`setTaskState`** on the host rail is unchanged for CLI/TUI/snapshots/desktop; consumers still receive it via **`run.config` → compatibility projection** (not deleted in this slice).
> 
> The lifecycle ordering test wires **`TraceEmitter`**, session run-trace attachment, and **`attachSessionProgressEventProjectionForTest`** so it asserts projected **`setTaskState`** still precedes the **RUNNING** **`updateStreamStatus`** event.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57fdfa74af59cc73a08d884662c30361129d0eec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->