### PR TITLE
refactor(schemas): one canonical round-indexed representation

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -61,6 +61,7 @@ import {
   type ExecutionId,
   type StreamTabId,
 } from '@shared/schemas';
+import { PROGRESS_VIEW_COMMANDS, COMMON_COMMANDS } from '@shared/ipc';
 import type { ProgressViewInboundHandlerRegistry } from '@shared/schemas/progressView';
 import { ProgressBackend } from '@shared/progressView/backend/ProgressBackend';
 import {
@@ -73,7 +74,6 @@ import {
   RESTART_REPAIR_PHASES,
 } from '@shared/progressView/backend/restartRepair';
 import type { MementoStorage } from '@shared/progressView/backend/persistence/PersistentMapManager';
-import { PROGRESS_VIEW_COMMANDS, COMMON_COMMANDS } from '@shared/ipc';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import { unsupported, unsupportedCommands } from '@shared/utils/dispatcher';
 import {
@@ -372,8 +372,7 @@ export class DesktopProgressBridge {
       state: {
         getTaskState: (stream) => this.state.snapshots.getTaskState(stream),
         getExecutionId: (stream) => this.getStreamExecutionId(stream),
-        getOutputFiles: (stream) =>
-          new Map(this.state.snapshots.getOutputFiles(stream)),
+        getOutputFiles: (stream) => this.state.snapshots.getOutputFiles(stream),
         getKnownWorkspaceOutputPaths: () => new Set(),
       },
       executeAgent: async (request) => {
@@ -400,8 +399,7 @@ export class DesktopProgressBridge {
       state: {
         getActiveStream: () => this.state.activeStream,
         getExecutionId: (stream) => this.getStreamExecutionId(stream),
-        getOutputFiles: (stream) =>
-          new Map(this.state.snapshots.getOutputFiles(stream)),
+        getOutputFiles: (stream) => this.state.snapshots.getOutputFiles(stream),
         // The desktop bridge has no quick-pick UI, so Accept always replaces
         // the workspace file. Returning undefined keeps the controller from
         // building copy metadata that the desktop host would silently drop.
@@ -1225,15 +1223,15 @@ export class DesktopProgressBridge {
     const stream = this.state.activeStream;
     if (!stream) return undefined;
 
-    // Sort rounds ascending so round and between-round diffs are produced (and
-    // opened) in order, matching the VS Code command.
-    const outputsByRound = new Map(
-      [...this.state.snapshots.getOutputFiles(stream)].sort(
-        (a, b) => a[0] - b[0],
-      ),
-    );
+    // Round keys are non-negative integers, so the canonical round-indexed
+    // record already iterates ascending (integer object keys are spec-ordered
+    // numerically) — round and between-round diffs are produced (and opened)
+    // in order, matching the VS Code command, with no separate sort needed.
+    const outputsByRound = this.state.snapshots.getOutputFiles(stream);
     const workspaceScan = this.getLatexdiffWorkspaceScan(stream, editedFile);
-    if (outputsByRound.size === 0 && !workspaceScan) return undefined;
+    if (Object.keys(outputsByRound).length === 0 && !workspaceScan) {
+      return undefined;
+    }
 
     const executionId = this.getStreamExecutionId(stream);
     return {

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1223,10 +1223,17 @@ export class DesktopProgressBridge {
     const stream = this.state.activeStream;
     if (!stream) return undefined;
 
-    // Round keys are non-negative integers, so the canonical round-indexed
-    // record already iterates ascending (integer object keys are spec-ordered
-    // numerically) — round and between-round diffs are produced (and opened)
-    // in order, matching the VS Code command, with no separate sort needed.
+    // Round keys are non-negative integers BY CONSTRUCTION: every write path
+    // into StreamSnapshotStore's outputFiles accumulator (both the live
+    // addOutputFiles patch path and the persisted-sidecar read path) coerces
+    // and rejects round keys through the shared RoundKeySchema
+    // (`@shared/schemas/roundIndexed.ts`), so a malformed key can never reach
+    // this accumulator. That structural guarantee is what makes the ES2015+
+    // spec's ascending-numeric-enumeration-order rule for non-negative
+    // integer keys apply here — round and between-round diffs are produced
+    // (and opened) in order, matching the VS Code command, with no separate
+    // sort needed. A defensive re-sort would only mask a schema regression,
+    // not add safety.
     const outputsByRound = this.state.snapshots.getOutputFiles(stream);
     const workspaceScan = this.getLatexdiffWorkspaceScan(stream, editedFile);
     if (Object.keys(outputsByRound).length === 0 && !workspaceScan) {

--- a/packages/desktop/src/main/desktopProgressFileActions.ts
+++ b/packages/desktop/src/main/desktopProgressFileActions.ts
@@ -14,7 +14,11 @@ import type {
   DiffRunOutcome,
   DiffRunResult,
 } from '@latex/latexdiff/types';
-import type { FileLocation, OutputFileInfo } from '@shared/schemas';
+import type {
+  FileLocation,
+  OutputFileInfo,
+  RoundIndexed,
+} from '@shared/schemas';
 import type { BuildDisplayFn } from '@tools/approval/latexPreview';
 import {
   AbsoluteFS,
@@ -51,7 +55,7 @@ export interface DesktopLatexdiffWorkspaceScan {
 }
 
 export interface DesktopLatexdiffRunContext {
-  outputsByRound: Map<number, OutputFileInfo[]>;
+  outputsByRound: RoundIndexed<OutputFileInfo>;
   executionId?: string;
   workspaceScan?: DesktopLatexdiffWorkspaceScan;
 }
@@ -193,8 +197,9 @@ export class DesktopProgressFileActions {
     runContext: DesktopLatexdiffRunContext,
   ): Promise<DiffRunOutcome | undefined> {
     const scan = runContext.workspaceScan;
+    const hasOutputs = Object.keys(runContext.outputsByRound).length > 0;
     // Nothing to diff without either pre-resolved rounds or a scan identity.
-    if (runContext.outputsByRound.size === 0 && !scan) return undefined;
+    if (!hasOutputs && !scan) return undefined;
 
     // Delegate the resolve + dispatch policy (caller metadata → run-id scan →
     // auto-discovery → workspace scan) to the single host-neutral core shared
@@ -208,8 +213,7 @@ export class DesktopProgressFileActions {
         inputFile: scan?.inputFile ?? '',
         outputFiles: scan?.outputFiles,
         runId: runContext.executionId ?? null,
-        outputsByRound:
-          runContext.outputsByRound.size > 0 ? runContext.outputsByRound : null,
+        outputsByRound: hasOutputs ? runContext.outputsByRound : null,
         mathMarkup: DEFAULT_MATH_MARKUP,
         generateBetweenRoundDiffs: true,
         progress,

--- a/src/controllers/progressView/ProgressFollowUpController.ts
+++ b/src/controllers/progressView/ProgressFollowUpController.ts
@@ -23,6 +23,7 @@ import type {
   CompileFailure,
   FileLocation,
   OutputFileInfo,
+  RoundIndexed,
   StreamTabId,
 } from '@shared/schemas';
 import { pluralize } from '@utils/text/stringUtils';
@@ -50,8 +51,8 @@ export interface ProgressFollowUpControllerDeps {
 
 export interface ProgressFollowUpState {
   getTaskState(stream: StreamTabId): TaskState | undefined;
-  getOutputFiles(stream: StreamTabId): Map<number, OutputFileInfo[]>;
-  getCompileFailures(stream: StreamTabId): Map<number, CompileFailure[]>;
+  getOutputFiles(stream: StreamTabId): RoundIndexed<OutputFileInfo>;
+  getCompileFailures(stream: StreamTabId): RoundIndexed<CompileFailure>;
   getExecutionId(stream: StreamTabId): string | undefined;
 }
 
@@ -93,7 +94,7 @@ export interface CompileFixerInput {
   streamId: StreamTabId;
   taskState: TaskState | undefined;
   compileFailures: CompileFailure[];
-  runOutputs: Map<number, OutputFileInfo[]>;
+  runOutputs: RoundIndexed<OutputFileInfo>;
   modelOptions: readonly ProgressFollowUpModelOption[];
   executionId?: string;
 }
@@ -110,9 +111,9 @@ export class ProgressFollowUpController {
     input: StreamToolUseFollowUpInput,
   ): Promise<ProgressFollowUpPlan> {
     const modelOptions = await this.deps.loadModelOptions();
-    const outputFiles = [
-      ...this.deps.state.getOutputFiles(input.streamId).values(),
-    ].flat();
+    const outputFiles = Object.values(
+      this.deps.state.getOutputFiles(input.streamId),
+    ).flat();
 
     return this.planToolUseFollowUp({
       ...input,
@@ -127,9 +128,9 @@ export class ProgressFollowUpController {
     streamId: StreamTabId,
   ): Promise<ProgressFollowUpPlan> {
     const modelOptions = await this.deps.loadModelOptions();
-    const compileFailures = [
-      ...this.deps.state.getCompileFailures(streamId).values(),
-    ].flat();
+    const compileFailures = Object.values(
+      this.deps.state.getCompileFailures(streamId),
+    ).flat();
 
     return this.planCompileFixer({
       streamId,
@@ -381,7 +382,7 @@ export class ProgressFollowUpController {
   private async compileFixerTargets(
     originalConfig: AgentConfig,
     compileFailures: CompileFailure[],
-    runOutputs: Map<number, OutputFileInfo[]>,
+    runOutputs: RoundIndexed<OutputFileInfo>,
   ): Promise<CompileFixerTarget[]> {
     const preferred = this.compileFixerInputCandidates(
       originalConfig,
@@ -455,10 +456,10 @@ export class ProgressFollowUpController {
   private compileFixerInputCandidates(
     originalConfig: AgentConfig,
     compileFailures: CompileFailure[],
-    runOutputs: Map<number, OutputFileInfo[]>,
+    runOutputs: RoundIndexed<OutputFileInfo>,
   ): string[] {
     const outputByPath = new Map<string, OutputFileInfo>();
-    for (const output of [...runOutputs.values()].flat()) {
+    for (const output of Object.values(runOutputs).flat()) {
       outputByPath.set(output.location.absolutePath, output);
     }
 

--- a/src/controllers/progressView/ProgressWorkflowActionsController.ts
+++ b/src/controllers/progressView/ProgressWorkflowActionsController.ts
@@ -8,7 +8,11 @@ import {
 } from '@agent/core/state/TaskState';
 
 // Local imports - shared
-import type { OutputFileInfo, StreamTabId } from '@shared/schemas';
+import type {
+  OutputFileInfo,
+  RoundIndexed,
+  StreamTabId,
+} from '@shared/schemas';
 
 export interface WorkflowDiffRequest {
   agent: string;
@@ -18,7 +22,7 @@ export interface WorkflowDiffRequest {
   outputFilesActive: boolean;
   streamId: StreamTabId;
   runId?: string;
-  outputsByRound?: [round: number, files: OutputFileInfo[]][];
+  outputsByRound?: RoundIndexed<OutputFileInfo>;
 }
 
 export type WorkflowFileOperation = 'pack' | 'clean';
@@ -36,7 +40,7 @@ export interface WorkflowFileOperationRequest {
 export interface ProgressWorkflowActionsState {
   getTaskState(stream: StreamTabId): TaskState | undefined;
   getExecutionId(stream: StreamTabId): string | undefined;
-  getOutputFiles(stream: StreamTabId): Map<number, OutputFileInfo[]>;
+  getOutputFiles(stream: StreamTabId): RoundIndexed<OutputFileInfo>;
   getKnownWorkspaceOutputPaths(stream: StreamTabId): Set<string>;
 }
 
@@ -77,8 +81,8 @@ export class ProgressWorkflowActionsController {
   async diffStream(stream: StreamTabId): Promise<void> {
     await this.withWorkflowTaskState(stream, async (taskState) => {
       const runOutputs = this.deps.state.getOutputFiles(stream);
-      const outputsByRound = runOutputs.size
-        ? [...runOutputs.entries()].sort((a, b) => a[0] - b[0])
+      const outputsByRound = Object.keys(runOutputs).length
+        ? runOutputs
         : undefined;
 
       await this.deps.runDiff({

--- a/src/controllers/progressView/ProgressWorkflowActionsController.ts
+++ b/src/controllers/progressView/ProgressWorkflowActionsController.ts
@@ -80,6 +80,12 @@ export class ProgressWorkflowActionsController {
 
   async diffStream(stream: StreamTabId): Promise<void> {
     await this.withWorkflowTaskState(stream, async (taskState) => {
+      // Round keys are non-negative integers by construction (enforced by
+      // the shared RoundKeySchema at every write into the snapshot store's
+      // accumulator — see `@shared/schemas/roundIndexed.ts`), so this record
+      // already enumerates ascending per the ES2015+ integer-key spec rule;
+      // runLatexdiffForExecution consumes `outputsByRound` in that order
+      // without needing an explicit sort here.
       const runOutputs = this.deps.state.getOutputFiles(stream);
       const outputsByRound = Object.keys(runOutputs).length
         ? runOutputs

--- a/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
+++ b/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
@@ -4,7 +4,11 @@ import path from 'node:path';
 import * as logger from '@logger/logUtils';
 
 // Local imports - shared
-import type { OutputFileInfo, StreamTabId } from '@shared/schemas';
+import type {
+  OutputFileInfo,
+  RoundIndexed,
+  StreamTabId,
+} from '@shared/schemas';
 
 // Local imports - utilities
 import { ensureRunDir, findRunDir, getRunDir } from '@utils/files';
@@ -21,7 +25,7 @@ export interface AcceptCopyMeta {
 export interface ProgressWorkflowFileActionsState {
   getActiveStream(): StreamTabId | '';
   getExecutionId(stream: StreamTabId): string | undefined;
-  getOutputFiles(stream: StreamTabId): Map<number, OutputFileInfo[]>;
+  getOutputFiles(stream: StreamTabId): RoundIndexed<OutputFileInfo>;
   getAgentModel(
     stream: StreamTabId,
   ): { agent: string; model: string } | undefined;
@@ -76,7 +80,7 @@ export class ProgressWorkflowFileActionsController {
           await ensureRunDir(executionId);
           directoryToReveal = getRunDir(executionId);
         }
-      } else if (runOutputs.size > 0) {
+      } else if (Object.keys(runOutputs).length > 0) {
         directoryToReveal = this.findOutputDirectory(runOutputs);
       }
 
@@ -255,7 +259,7 @@ export class ProgressWorkflowFileActionsController {
     // in-place workflows reuse the same workspace path across rounds, so the
     // Map key (and the first match) would mislabel the `r<round>` postfix.
     let round: number | undefined;
-    for (const infos of this.deps.state.getOutputFiles(stream).values()) {
+    for (const infos of Object.values(this.deps.state.getOutputFiles(stream))) {
       for (const info of infos) {
         if (
           info.location.absolutePath === file &&
@@ -271,9 +275,9 @@ export class ProgressWorkflowFileActionsController {
   }
 
   private findOutputDirectory(
-    runOutputs: Map<number, OutputFileInfo[]>,
+    runOutputs: RoundIndexed<OutputFileInfo>,
   ): string | undefined {
-    for (const infos of runOutputs.values()) {
+    for (const infos of Object.values(runOutputs)) {
       for (const info of infos) {
         const kind = info.location.kind;
         if (kind === 'runStorage' || kind === 'workspace') {

--- a/src/latex/latexdiff/diffOperations.ts
+++ b/src/latex/latexdiff/diffOperations.ts
@@ -15,8 +15,12 @@ import {
 } from '@agent/output/workflowOutputLayout';
 import type { MathMarkupOption } from '@latex/latexdiff/mathMarkup';
 import * as logger from '@logger/logUtils';
-import { getEffectiveDiffBase, RoundKeySchema } from '@shared/schemas';
-import type { OutputFileInfo } from '@shared/schemas';
+import {
+  getEffectiveDiffBase,
+  roundIndexedEntries,
+  RoundKeySchema,
+} from '@shared/schemas';
+import type { OutputFileInfo, RoundIndexed } from '@shared/schemas';
 import {
   WorkspaceFS,
   FlexibleFS,
@@ -99,7 +103,7 @@ export async function executeDiffOperations(
 }
 
 export async function runLatexdiffFromMetadata(params: {
-  rounds: Map<number, OutputFileInfo[]>;
+  rounds: RoundIndexed<OutputFileInfo>;
   mathMarkup?: MathMarkupOption;
   generateBetweenRoundDiffs: boolean;
   progress: DiffProgressReporter;
@@ -114,7 +118,7 @@ export async function runLatexdiffFromMetadata(params: {
     Array<{ round: number; info: OutputFileInfo }>
   >();
 
-  for (const [round, infos] of rounds.entries()) {
+  for (const [round, infos] of roundIndexedEntries(rounds)) {
     for (const info of infos) {
       const base = getEffectiveDiffBase(info.lineage);
       const description = `${getFileLabel(info)} (r${round})`;

--- a/src/latex/latexdiff/outputDiscovery.ts
+++ b/src/latex/latexdiff/outputDiscovery.ts
@@ -22,6 +22,7 @@ import type {
   ExecutionId,
   FileLocation,
   OutputFileInfo,
+  RoundIndexed,
 } from '@shared/schemas';
 import {
   WorkspaceFS,
@@ -84,7 +85,7 @@ export async function scanRunDirForOutputs(
   executionId: ExecutionId,
   inputFile: string,
   extraBaseFiles?: string[],
-): Promise<Map<number, OutputFileInfo[]> | null> {
+): Promise<RoundIndexed<OutputFileInfo> | null> {
   try {
     const runDirAbsolute = await findRunDir(executionId);
     if (!runDirAbsolute) return null;
@@ -112,7 +113,7 @@ export async function scanRunDirForOutputs(
     }
     const defaultBaseLocation = pathToLocation(toAbs(inputFile));
 
-    const rounds = new Map<number, OutputFileInfo[]>();
+    const rounds: RoundIndexed<OutputFileInfo> = {};
 
     for (const [entryName, fileType] of dirEntries) {
       if (!isDirectory(fileType)) continue;
@@ -180,12 +181,10 @@ export async function scanRunDirForOutputs(
         });
       }
 
-      if (outputs.length > 0) rounds.set(round, outputs);
+      if (outputs.length > 0) rounds[round] = outputs;
     }
 
-    return rounds.size > 0
-      ? new Map([...rounds.entries()].sort((a, b) => a[0] - b[0]))
-      : null;
+    return Object.keys(rounds).length > 0 ? rounds : null;
   } catch (error) {
     logger.debug(
       CHANNEL,
@@ -207,7 +206,7 @@ export async function discoverLatestExecutionOutputs(query: {
   inputFile: string;
 }): Promise<{
   executionId: ExecutionId;
-  rounds: Map<number, OutputFileInfo[]>;
+  rounds: RoundIndexed<OutputFileInfo>;
 } | null> {
   try {
     const executions = await listExecutions();
@@ -235,7 +234,7 @@ export async function discoverLatestExecutionOutputs(query: {
         executionId: candidate.id,
       });
       const rounds = await snapshots.readOutputFiles(streamId);
-      if (rounds && rounds.size > 0) {
+      if (rounds && Object.keys(rounds).length > 0) {
         return { executionId: candidate.id, rounds };
       }
       // Stream-tab snapshots are a progress-view artifact that headless
@@ -253,7 +252,7 @@ export async function discoverLatestExecutionOutputs(query: {
         query.inputFile,
         candidate.agentConfig?.inputFiles?.slice(1),
       );
-      if (scanned && scanned.size > 0) {
+      if (scanned && Object.keys(scanned).length > 0) {
         return { executionId: candidate.id, rounds: scanned };
       }
     }

--- a/src/latex/latexdiff/runLatexdiff.ts
+++ b/src/latex/latexdiff/runLatexdiff.ts
@@ -10,8 +10,16 @@
  */
 
 import * as logger from '@logger/logUtils';
-import { ExecutionIdSchema } from '@shared/schemas';
-import type { ExecutionId, OutputFileInfo } from '@shared/schemas';
+import {
+  ExecutionIdSchema,
+  OutputFileInfoSchema,
+  parsePersistedRoundIndexed,
+} from '@shared/schemas';
+import type {
+  ExecutionId,
+  OutputFileInfo,
+  RoundIndexed,
+} from '@shared/schemas';
 
 import {
   runLatexdiffFromMetadata,
@@ -26,28 +34,21 @@ import type { MathMarkupOption } from './mathMarkup';
 import type { DiffProgressReporter, DiffRunOutcome } from './types';
 
 /**
- * Normalize arbitrary command payload metadata into the internal round map.
- * VS Code commands can be invoked with any argument shape, so only the current
- * tuple-array form is trusted; malformed or legacy map-shaped values fall back
- * to discovery instead of crashing the command handler.
+ * Normalize arbitrary command payload metadata into the canonical round
+ * record. VS Code commands can be invoked with any argument shape, so this
+ * routes through the same canonical parse entry used for persisted
+ * round-indexed data — malformed rounds/items are dropped rather than
+ * crashing the command handler.
  */
 export function normalizeRunLatexdiffOutputsByRound(
   value: unknown,
-): Map<number, OutputFileInfo[]> | null {
-  if (!Array.isArray(value)) return null;
-
-  const validRounds = value
-    .filter(
-      (entry): entry is [number, OutputFileInfo[]] =>
-        Array.isArray(entry) &&
-        typeof entry[0] === 'number' &&
-        Number.isInteger(entry[0]) &&
-        Array.isArray(entry[1]) &&
-        entry[1].length > 0,
-    )
-    .sort((a, b) => a[0] - b[0]);
-
-  return validRounds.length > 0 ? new Map(validRounds) : null;
+): RoundIndexed<OutputFileInfo> | null {
+  const { rounds } = parsePersistedRoundIndexed(
+    'latexdiffOutputsByRound',
+    value,
+    OutputFileInfoSchema,
+  );
+  return Object.keys(rounds).length > 0 ? rounds : null;
 }
 
 /** How the round outputs fed to the diff engine were resolved. */
@@ -65,7 +66,7 @@ export interface RunLatexdiffForExecutionParams {
    * Pre-resolved round outputs (e.g. from a progress-toolbar payload). When
    * present, discovery is skipped and the metadata engine runs directly.
    */
-  readonly outputsByRound?: Map<number, OutputFileInfo[]> | null;
+  readonly outputsByRound?: RoundIndexed<OutputFileInfo> | null;
   readonly mathMarkup?: MathMarkupOption;
   readonly generateBetweenRoundDiffs: boolean;
   readonly progress: DiffProgressReporter;

--- a/src/latex/latexdiff/types.ts
+++ b/src/latex/latexdiff/types.ts
@@ -1,6 +1,10 @@
 /** Shared types for latexdiff output discovery and operation building. */
 
-import type { FileLocation, OutputFileInfo } from '@shared/schemas';
+import type {
+  FileLocation,
+  OutputFileInfo,
+  RoundIndexed,
+} from '@shared/schemas';
 
 /**
  * Minimal progress sink for long-running diff runs. Host-neutral so the core
@@ -19,7 +23,7 @@ export interface RunLatexdiffCommandConfig {
   outputFilesActive?: string[];
   streamId?: string;
   runId?: string | null;
-  outputsByRound?: [round: number, files: OutputFileInfo[]][];
+  outputsByRound?: RoundIndexed<OutputFileInfo>;
 }
 
 export interface DiffRunResult {

--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -221,7 +221,7 @@ export class ProgressEventHandler {
           this.sendIfActive(streamId, () => {
             const rounds = this.state.snapshots.getMissingOutputs(streamId);
             this.webviewUpdater.updateMissingOutputs(streamId, {
-              rounds: rounds.size ? mapToRecord(rounds) : undefined,
+              rounds: Object.keys(rounds).length ? rounds : undefined,
             });
           });
         },
@@ -232,7 +232,7 @@ export class ProgressEventHandler {
           this.sendIfActive(streamId, () => {
             const rounds = this.state.snapshots.getCompileFailures(streamId);
             this.webviewUpdater.updateCompileFailures(streamId, {
-              rounds: rounds.size ? mapToRecord(rounds) : undefined,
+              rounds: Object.keys(rounds).length ? rounds : undefined,
               reset: true,
             });
           });
@@ -369,7 +369,7 @@ export class ProgressEventHandler {
     this.sendIfActive(streamId, () => {
       const rounds = this.state.snapshots.getOutputFiles(streamId);
       this.webviewUpdater.updateFiles(streamId, {
-        rounds: rounds.size ? mapToRecord(rounds) : undefined,
+        rounds: Object.keys(rounds).length ? rounds : undefined,
       });
     });
   }
@@ -676,29 +676,16 @@ export class ProgressEventHandler {
   }
 
   private buildStreamSyncExtras(stream: StreamTabId): LogContentExtras {
-    // Workflow files/missing outputs are flat (one run per tab).
-    const workflowFiles = mapToRecord(
-      this.state.snapshots.getOutputFiles(stream),
-    );
-    const workflowMissingOutputs = mapToRecord(
-      this.state.snapshots.getMissingOutputs(stream),
-    );
-    const workflowCompileFailures = mapToRecord(
-      this.state.snapshots.getCompileFailures(stream),
-    );
-
-    // Per-run usage map — shared by workflow and tool-use. Frontend derives
-    // sessionUsage as the sum so cumulative totals survive resume.
-    const runUsage = mapToRecord(this.state.snapshots.getRunUsage(stream));
-
-    const contextState = this.state.getContextState(stream);
-
     return {
-      workflowFiles,
-      workflowMissingOutputs,
-      workflowCompileFailures,
-      runUsage,
-      contextState,
+      // Workflow files/missing outputs are flat (one run per tab), already in
+      // the canonical round-indexed record shape the webview consumes.
+      workflowFiles: this.state.snapshots.getOutputFiles(stream),
+      workflowMissingOutputs: this.state.snapshots.getMissingOutputs(stream),
+      workflowCompileFailures: this.state.snapshots.getCompileFailures(stream),
+      // Per-run usage map — shared by workflow and tool-use. Frontend derives
+      // sessionUsage as the sum so cumulative totals survive resume.
+      runUsage: mapToRecord(this.state.snapshots.getRunUsage(stream)),
+      contextState: this.state.getContextState(stream),
     };
   }
 

--- a/src/shared/schemas/diffResult.ts
+++ b/src/shared/schemas/diffResult.ts
@@ -6,6 +6,7 @@ import {
   type OutputFileInfo,
   OutputFileInfoSchema,
 } from './output';
+import { RoundNumberSchema } from './roundIndexed';
 import { getBasename } from '../utils/path';
 
 export const DiffStatusSchema = z.enum(['success', 'error']);
@@ -18,10 +19,18 @@ const DiffMetadataSchema = z.object({
   runId: z.string().optional(),
 });
 
-/** Canonical DiffResult format from backend */
+/**
+ * Canonical DiffResult format from backend. `baseRound` is a round POINTER
+ * (which round the base file came from — null when the base isn't
+ * round-scoped, e.g. an original pre-round source), not a round-indexed
+ * collection: it shares {@link RoundNumberSchema} with the round-indexed
+ * item fields but deliberately does not join the {@link RoundIndexed}
+ * container shape. `revisedRound` (see {@link DiffResultDisplaySchema}) is
+ * derived from `revised.round` rather than duplicated here.
+ */
 export const DiffResultSchema = DiffMetadataSchema.extend({
   baseLocation: FileLocationSchema.nullable(),
-  baseRound: z.number().nullable(),
+  baseRound: RoundNumberSchema.nullable(),
   revised: OutputFileInfoSchema,
   diffLocation: FileLocationSchema.nullable(),
 });
@@ -33,8 +42,8 @@ const DiffResultDisplayShapeSchema = DiffMetadataSchema.extend({
   revisedFile: z.string(),
   diffFile: z.string(),
   displayName: z.string(),
-  baseRound: z.number().nullable(),
-  revisedRound: z.number(),
+  baseRound: RoundNumberSchema.nullable(),
+  revisedRound: RoundNumberSchema,
 });
 
 export type DiffResultDisplay = z.infer<typeof DiffResultDisplayShapeSchema>;
@@ -103,6 +112,14 @@ const LegacyLocationsSchema = z
   })
   .optional();
 
+/**
+ * Legacy round-label parse arm: pre-#3061 persisted latexdiff log entries
+ * (see `LegacyDiffResultInputBaseSchema` below) predate the explicit
+ * `baseRound`/`revisedRound` fields and only carry the round baked into a
+ * display label (e.g. `"main.tex [r2]"`). Kept as the one read arm for that
+ * shape; tracked for D3 retirement 2026-08-04 alongside the other #3061-era
+ * shims in the #6981 ledger.
+ */
 function parseRoundFromLabel(label: string | undefined): number | null {
   if (typeof label !== 'string') return null;
   const match = label.match(/\[r(\d+)\]/);
@@ -116,8 +133,8 @@ const LegacyDiffResultInputBaseSchema = z.looseObject({
   diffPath: z.string().optional(),
   baseLabel: z.string().optional(),
   revisedLabel: z.string().optional(),
-  baseRound: z.number().optional(),
-  revisedRound: z.number().optional(),
+  baseRound: RoundNumberSchema.optional(),
+  revisedRound: RoundNumberSchema.optional(),
   originalFileName: z.string().optional(),
   status: z.string().optional(),
   message: z.string().optional(),

--- a/src/shared/schemas/index.ts
+++ b/src/shared/schemas/index.ts
@@ -28,6 +28,7 @@ export * from './onboarding';
 
 // Layer 2: Depends on layer 1 only
 export * from './stream';
+export * from './roundIndexed';
 export * from './output';
 export * from './progressEvents';
 

--- a/src/shared/schemas/output.ts
+++ b/src/shared/schemas/output.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { DiffStatsSchema } from './lineChanges';
 import { ExecutionIdSchema } from './identifiers';
+import { RoundNumberSchema } from './roundIndexed';
 
 export const WorkspaceFileLocationSchema = z.strictObject({
   kind: z.literal('workspace'),
@@ -66,7 +67,7 @@ export function getEffectiveDiffBase(
 }
 
 export const OutputFileInfoSchema = OutputFileSchema.extend({
-  round: z.number().prefault(() => 0),
+  round: RoundNumberSchema.prefault(() => 0),
   lineage: FileLineageSchema.nullable(),
   diff: DiffStatsSchema.nullable(),
 });
@@ -116,11 +117,11 @@ export type CompileFailureSummary = z.infer<typeof CompileFailureSummarySchema>;
 export const CompileResultSchema = z.discriminatedUnion('status', [
   z.strictObject({
     status: z.literal('ok'),
-    round: z.number(),
+    round: RoundNumberSchema,
   }),
   z.strictObject({
     status: z.literal('failed'),
-    round: z.number(),
+    round: RoundNumberSchema,
     failures: z.array(CompileFailureSchema),
     logExcerpt: z.string(),
   }),
@@ -142,24 +143,8 @@ export const OutputXmlSummarySchema = z.strictObject({
 });
 export type OutputXmlSummary = z.infer<typeof OutputXmlSummarySchema>;
 
-/**
- * Schema factory for round-indexed records: `{ "1": T[], "2": T[], … }`.
- * Used by both the live stream state and the persisted snapshot so the
- * shape is defined once and shared.
- */
-export function roundIndexedRecord<T extends z.ZodType>(valueSchema: T) {
-  return z.record(z.string(), z.array(valueSchema)).prefault({});
-}
-
-/**
- * Map keyed by round number to arrays of `T`, e.g. `{ 1: T[], 2: T[], … }`.
- * Used to batch round-scoped data (output files, missing-output paths,
- * compile failures) for a subset of rounds without touching the others.
- */
-export type RoundIndexed<T> = { [round: number]: T[] };
-
 export const RoundOutputSchema = z.strictObject({
-  round: z.number(),
+  round: RoundNumberSchema,
   rawOutput: FileLocationSchema.nullable(),
   outputs: OutputFileInfoSchema.array(),
   compileFailures: CompileFailureSchema.array().prefault(() => []),

--- a/src/shared/schemas/progressEvents.ts
+++ b/src/shared/schemas/progressEvents.ts
@@ -1,11 +1,7 @@
 import type { AgentCategory } from './agent';
 import type { ExecutionId, StorageKey, StreamTabId } from './identifiers';
-import type {
-  CompileFailure,
-  FileLocation,
-  OutputFileInfo,
-  RoundIndexed,
-} from './output';
+import type { CompileFailure, FileLocation, OutputFileInfo } from './output';
+import type { RoundIndexed } from './roundIndexed';
 import type { ActiveChildInfo, RoundStage } from './streamState';
 import type { StreamPhase, StreamSubstate } from './stream';
 import type { TokenUsageStats } from './usage';

--- a/src/shared/schemas/progressView/outbound.ts
+++ b/src/shared/schemas/progressView/outbound.ts
@@ -16,6 +16,7 @@ import { StreamTabIdSchema } from '../identifiers';
 import { StreamLogEntrySchema, StreamLogTextDeltaSchema } from '../log';
 import { AgentOptionDataSchema, ModelOptionDataSchema } from '../mainView';
 import { CompileFailureSchema, OutputFileInfoSchema } from '../output';
+import { roundIndexedRecord } from '../roundIndexed';
 import { InquiryThreadUpdatedEventSchema } from '../inquiry';
 import {
   AgentProposalPermissionSchema,
@@ -138,7 +139,7 @@ function RoundUpdateMessageSchema<C extends string, T extends z.ZodType>(
 ) {
   return StreamScopedBaseSchema.extend({
     command: z.literal(command),
-    rounds: z.record(z.string(), z.array(elementSchema)).optional(),
+    rounds: roundIndexedRecord(elementSchema).optional(),
     reset: z.boolean().optional(),
   });
 }
@@ -293,11 +294,9 @@ export const SyncStreamContentMessageSchema = z.object({
   stream: z.union([StreamTabIdSchema, z.literal('')]),
   action: z.enum(['render', 'clear']).optional(),
   // Workflow flat files (one run per tab)
-  workflowFiles: z.record(z.string(), z.array(OutputFileInfoSchema)).optional(),
-  workflowMissingOutputs: z.record(z.string(), z.array(z.string())).optional(),
-  workflowCompileFailures: z
-    .record(z.string(), z.array(CompileFailureSchema))
-    .optional(),
+  workflowFiles: roundIndexedRecord(OutputFileInfoSchema).optional(),
+  workflowMissingOutputs: roundIndexedRecord(z.string()).optional(),
+  workflowCompileFailures: roundIndexedRecord(CompileFailureSchema).optional(),
   // Per-run usage map — used by both workflow and tool-use so resume
   // correctly accumulates. Frontend derives sessionUsage as the sum.
   runUsage: RunUsageMapSchema.optional(),

--- a/src/shared/schemas/roundIndexed.ts
+++ b/src/shared/schemas/roundIndexed.ts
@@ -1,0 +1,184 @@
+/**
+ * THE canonical round-indexed representation: `{ [round: number]: T[] }`.
+ *
+ * One shape for every round-scoped collection (output files, missing-output
+ * paths, compile failures) across the live stream state, progress events,
+ * webview messages, snapshots, and the persisted `streamData/{id}/*.json`
+ * sidecars — the record is the JSON wire/disk format itself, so no encode
+ * step exists anywhere. Legacy persisted shapes are absorbed ONCE, here, at
+ * {@link parsePersistedRoundIndexed}; downstream code only ever sees the
+ * canonical record.
+ *
+ * Deliberately NOT unified into this shape (different requirements, not
+ * history): `RoundOutput[]` (a per-round aggregate carrying `rawOutput` and
+ * `xmlSummary`, owned by the reflection flow) and `DiffResult.baseRound` /
+ * `revisedRound` (scalar round references, already legacy-normalized at their
+ * own parse entry in `diffResult.ts`).
+ */
+
+import { z } from 'zod';
+
+/**
+ * Round number → items for that round. Runtime keys are strings (JSON), so a
+ * `Record<string, T[]>` (e.g. a parsed {@link roundIndexedRecord}) is
+ * assignable to this type; index it with a number.
+ */
+export type RoundIndexed<T> = { [round: number]: T[] };
+
+/** Coerces and validates integer round keys from string record keys. */
+export const RoundKeySchema = z.coerce.number().int();
+
+/**
+ * Scalar round-number schema: the single definition shared by round-indexed
+ * collections' own item fields (`OutputFileInfo.round`, `RoundOutput.round`,
+ * `CompileResult.round`) and by round-POINTER fields that reference a round
+ * without holding a per-round collection (`DiffResult.baseRound` /
+ * `revisedRound` in `diffResult.ts`). Those pointer fields are a genuinely
+ * different concept from {@link RoundIndexed} — "which round does this diff
+ * compare" rather than "items grouped by round" — so they are not folded into
+ * the record container, but they still mean the same "this integer is a
+ * round number" and now share one schema instead of a repeated `z.number()`.
+ */
+export const RoundNumberSchema = z.number();
+
+/**
+ * Schema factory for the canonical record: `{ "0": T[], "1": T[], … }`.
+ * Trusted-input role (IPC messages, live state, snapshots): callers attach
+ * their own field policy (`.prefault({})`, `.optional()`). Untrusted persisted
+ * files go through {@link parsePersistedRoundIndexed} instead.
+ */
+export function roundIndexedRecord<T extends z.ZodType>(valueSchema: T) {
+  return z.record(z.string(), z.array(valueSchema));
+}
+
+/** Entries with numeric round keys, ascending by round. */
+export function roundIndexedEntries<T>(
+  rounds: RoundIndexed<T>,
+): [number, T[]][] {
+  return Object.entries(rounds)
+    .map(([round, items]): [number, T[]] => [Number(round), items])
+    .sort((a, b) => a[0] - b[0]);
+}
+
+// ============================================================================
+// Persisted-file parse entry (single legacy-absorbing entry point)
+// ============================================================================
+
+const INTEGER_KEY = /^-?\d+$/;
+
+function warnDroppedItem(
+  kind: string,
+  error: { issues: readonly { path: PropertyKey[]; message: string }[] },
+): void {
+  console.warn(
+    `[roundIndexed] Dropping malformed ${kind} entry: ${error.issues
+      .map((i) => `${i.path.join('.') || '<root>'}: ${i.message}`)
+      .join('; ')}`,
+  );
+}
+
+/**
+ * Pick one run's round-keyed record out of the legacy nested shape. Prefers
+ * `preferredRunId` when that entry exists (legacy tabs persisted `activeRunId`
+ * in meta.json to mark the selected run); otherwise falls back to JS insertion
+ * order and picks the last-written run.
+ */
+function pickLegacyRun(
+  raw: Record<string, unknown>,
+  preferredRunId?: string | null,
+): Record<string, unknown> {
+  if (preferredRunId) {
+    const picked = raw[preferredRunId];
+    if (picked && typeof picked === 'object' && !Array.isArray(picked)) {
+      return picked as Record<string, unknown>;
+    }
+  }
+  const latest = Object.values(raw).findLast(
+    (value) =>
+      value != null && typeof value === 'object' && !Array.isArray(value),
+  );
+  return (latest as Record<string, unknown> | undefined) ?? {};
+}
+
+export interface PersistedRoundIndexed<T> {
+  rounds: RoundIndexed<T>;
+  /** True when the on-disk file held the legacy nested shape (the caller
+   *  rewrites it flat once so the conversion never re-runs). */
+  wasLegacy: boolean;
+}
+
+/**
+ * Parse a persisted round-indexed sidecar file (`outputFiles.json`,
+ * `missingOutputs.json`, `compileFailures.json`) into the canonical record.
+ *
+ * Canonical flat shape first; the legacy nested `{ runId: { round: items[] } }`
+ * shape (from before the one-run-per-tab refactor, #3061) transforms into it
+ * via the union's legacy arm — handled here ONCE, never at call sites.
+ * Ledger: the legacy arm retires with the other #3061-era read shims after
+ * 2026-08-04 (D3), tracked in #6981.
+ *
+ * Salvage semantics: round keys are coerced integers (anything else is
+ * skipped), malformed items are dropped LOUDLY (warned, never silently
+ * swallowed), empty rounds are omitted, and a genuinely corrupt top-level
+ * value degrades to an empty record with a warning. A missing file
+ * (`undefined`) is silently empty. Every failure path returns a FRESH object:
+ * consumers (e.g. `StreamSnapshotStore`) hold the result by reference and
+ * mutate it, so a shared fallback instance would leak rounds across streams.
+ */
+export function parsePersistedRoundIndexed<T>(
+  kind: string,
+  raw: unknown,
+  itemSchema: z.ZodType<T>,
+  preferredRunId?: string | null,
+): PersistedRoundIndexed<T> {
+  if (raw === undefined) return { rounds: {}, wasLegacy: false };
+
+  const toRounds = (record: Record<string, unknown>): RoundIndexed<T> => {
+    const rounds: RoundIndexed<T> = {};
+    for (const [key, value] of Object.entries(record)) {
+      const round = RoundKeySchema.safeParse(key);
+      if (!round.success) continue;
+      if (!Array.isArray(value)) {
+        console.warn(
+          `[roundIndexed] Dropping non-array round "${key}" in ${kind}.`,
+        );
+        continue;
+      }
+      const items = value.flatMap((item) => {
+        const parsed = itemSchema.safeParse(item);
+        if (parsed.success) return [parsed.data];
+        warnDroppedItem(kind, parsed.error);
+        return [];
+      });
+      if (items.length > 0) rounds[round.data] = items;
+    }
+    return rounds;
+  };
+
+  // Canonical flat shape: every key an integer round, every value an array.
+  // The key/value constraints make this arm REJECT legacy input (a runId key,
+  // or a numeric-only runId whose value is a nested object), routing it to
+  // the legacy arm — mirroring the old `isLegacyNested` predicate.
+  const FlatArmSchema = z
+    .record(z.string().regex(INTEGER_KEY), z.array(z.unknown()))
+    .transform((record): PersistedRoundIndexed<T> => ({
+      rounds: toRounds(record),
+      wasLegacy: false,
+    }));
+
+  const LegacyNestedArmSchema = z
+    .record(z.string(), z.unknown())
+    .transform((record): PersistedRoundIndexed<T> => ({
+      rounds: toRounds(pickLegacyRun(record, preferredRunId)),
+      wasLegacy: true,
+    }));
+
+  const result = z.union([FlatArmSchema, LegacyNestedArmSchema]).safeParse(raw);
+  if (!result.success) {
+    console.warn(
+      `[roundIndexed] Ignoring malformed ${kind} (not a round-keyed record); treating as empty.`,
+    );
+    return { rounds: {}, wasLegacy: false };
+  }
+  return result.data;
+}

--- a/src/shared/schemas/roundIndexed.ts
+++ b/src/shared/schemas/roundIndexed.ts
@@ -25,8 +25,20 @@ import { z } from 'zod';
  */
 export type RoundIndexed<T> = { [round: number]: T[] };
 
-/** Coerces and validates integer round keys from string record keys. */
-export const RoundKeySchema = z.coerce.number().int();
+/**
+ * Coerces and validates round keys from string record keys: non-negative
+ * safe integers only. Rounds never go negative (round 0 is the first), and
+ * every consumer that reads a `RoundIndexed<T>` record via plain
+ * `Object.keys()`/`for...in` enumeration (rather than {@link
+ * roundIndexedEntries}) relies on the ES2015+ spec guarantee that
+ * non-negative-integer-string keys enumerate in ascending numeric order —
+ * that guarantee does NOT hold for negative or non-integer keys, so this is
+ * a structural invariant, not just a naming convention. Enforced once, here,
+ * at parse time (see {@link RoundKeyStringSchema}, used by both
+ * {@link roundIndexedRecord} and {@link parsePersistedRoundIndexed}'s flat
+ * arm), so downstream code never re-checks it.
+ */
+export const RoundKeySchema = z.coerce.number().int().nonnegative();
 
 /**
  * Scalar round-number schema: the single definition shared by round-indexed
@@ -37,21 +49,47 @@ export const RoundKeySchema = z.coerce.number().int();
  * different concept from {@link RoundIndexed} — "which round does this diff
  * compare" rather than "items grouped by round" — so they are not folded into
  * the record container, but they still mean the same "this integer is a
- * round number" and now share one schema instead of a repeated `z.number()`.
+ * round number" (non-negative integer, matching {@link RoundKeySchema}) and
+ * now share one schema instead of a repeated `z.number()`.
  */
-export const RoundNumberSchema = z.number();
+export const RoundNumberSchema = z.int().nonnegative();
+
+/**
+ * A JSON object key that {@link RoundKeySchema} can coerce to a valid round
+ * number. The SAME predicate — not a parallel regex — backs both
+ * {@link roundIndexedRecord}'s key schema and {@link
+ * parsePersistedRoundIndexed}'s flat-arm key schema, so a key like `"1e5"`
+ * (scientific notation, which `RoundKeySchema` coerces to round `100000`) is
+ * accepted or rejected identically by every round-indexed record schema in
+ * the codebase instead of drifting between a strict `/^\d+$/`-style regex in
+ * one place and the looser numeric coercion in another.
+ */
+export const RoundKeyStringSchema = z
+  .string()
+  .refine((key) => RoundKeySchema.safeParse(key).success, {
+    message: 'Round key must be a non-negative integer',
+  });
 
 /**
  * Schema factory for the canonical record: `{ "0": T[], "1": T[], … }`.
  * Trusted-input role (IPC messages, live state, snapshots): callers attach
  * their own field policy (`.prefault({})`, `.optional()`). Untrusted persisted
- * files go through {@link parsePersistedRoundIndexed} instead.
+ * files go through {@link parsePersistedRoundIndexed} instead. Keys are
+ * validated against {@link RoundKeyStringSchema} so every consumer of a
+ * parsed record can rely on the ascending-iteration-order invariant.
  */
 export function roundIndexedRecord<T extends z.ZodType>(valueSchema: T) {
-  return z.record(z.string(), z.array(valueSchema));
+  return z.record(RoundKeyStringSchema, z.array(valueSchema));
 }
 
-/** Entries with numeric round keys, ascending by round. */
+/**
+ * Entries with numeric round keys, ascending by round. Prefer plain
+ * `Object.entries()`/`Object.values()` when the record is already known to
+ * come from a schema-validated {@link RoundIndexed} (its keys already
+ * enumerate in ascending order per spec); reach for this when a caller wants
+ * `[round, items]` pairs rather than the enumeration order itself, or is
+ * handling a record that was not necessarily schema-validated.
+ */
 export function roundIndexedEntries<T>(
   rounds: RoundIndexed<T>,
 ): [number, T[]][] {
@@ -60,11 +98,28 @@ export function roundIndexedEntries<T>(
     .sort((a, b) => a[0] - b[0]);
 }
 
+/**
+ * Deep-enough copy: a fresh record with a fresh array per round, so a caller
+ * that mutates the returned value — including pushing into one of its
+ * per-round arrays — can never corrupt an internal accumulator that still
+ * holds the original arrays by reference. Item objects themselves are not
+ * cloned; they are treated as immutable value objects, same as every other
+ * schema-derived type in this codebase.
+ */
+export function cloneRoundIndexed<T>(
+  rounds: RoundIndexed<T> | undefined,
+): RoundIndexed<T> {
+  const clone: RoundIndexed<T> = {};
+  if (!rounds) return clone;
+  for (const [round, items] of Object.entries(rounds)) {
+    clone[Number(round)] = [...items];
+  }
+  return clone;
+}
+
 // ============================================================================
 // Persisted-file parse entry (single legacy-absorbing entry point)
 // ============================================================================
-
-const INTEGER_KEY = /^-?\d+$/;
 
 function warnDroppedItem(
   kind: string,
@@ -155,12 +210,15 @@ export function parsePersistedRoundIndexed<T>(
     return rounds;
   };
 
-  // Canonical flat shape: every key an integer round, every value an array.
-  // The key/value constraints make this arm REJECT legacy input (a runId key,
-  // or a numeric-only runId whose value is a nested object), routing it to
-  // the legacy arm — mirroring the old `isLegacyNested` predicate.
+  // Canonical flat shape: every key a valid round (per RoundKeyStringSchema —
+  // the SAME predicate RoundKeySchema itself uses, so e.g. "1e5" is accepted
+  // or rejected identically here and in `toRounds` below), every value an
+  // array. The key/value constraints make this arm REJECT legacy input (a
+  // runId key, or a numeric-only runId whose value is a nested object),
+  // routing it to the legacy arm — mirroring the old `isLegacyNested`
+  // predicate.
   const FlatArmSchema = z
-    .record(z.string().regex(INTEGER_KEY), z.array(z.unknown()))
+    .record(RoundKeyStringSchema, z.array(z.unknown()))
     .transform((record): PersistedRoundIndexed<T> => ({
       rounds: toRounds(record),
       wasLegacy: false,

--- a/src/shared/schemas/streamData.ts
+++ b/src/shared/schemas/streamData.ts
@@ -10,15 +10,13 @@
  *
  * Legacy data (from before the one-run-per-tab refactor) was keyed by runId:
  *   - outputFiles.json / missingOutputs.json used `{ runId: { round: … } }`
+ *     (absorbed at the canonical parse entry — see
+ *     `parsePersistedRoundIndexed` in `./roundIndexed`)
  *   - usageStats.json used `{ runId: TokenUsageStats }` (still the stored shape)
- *
- * The preprocess helpers below detect the legacy nested shape and flatten it to
- * the new format by picking the most recent run (last-inserted key).
  */
 
 import { z } from 'zod';
 
-import { CompileFailureSchema, OutputFileInfoSchema } from './output';
 import {
   RUN_DESCRIPTOR_SCHEMA_VERSION,
   RunDescriptorSchema,
@@ -30,13 +28,6 @@ import {
   isEmptyUsage,
   type TokenUsageStats,
 } from './usage';
-
-// ============================================================================
-// Shared: round key coercion
-// ============================================================================
-
-/** Coerces and validates integer round keys from string record keys. */
-export const RoundKeySchema = z.coerce.number().int();
 
 // ============================================================================
 // Per-stream meta file (streamData/{id}/meta.json) — single source of truth
@@ -120,144 +111,6 @@ export function selectPreferredLegacyInstruction(
 
   return selected;
 }
-
-// ============================================================================
-// Legacy detection + flattening
-// ============================================================================
-
-/**
- * Detects whether a record is the legacy nested shape
- * (`{ runId: { round: items[] } }`) rather than the flat shape
- * (`{ round: items[] }`).
- *
- * Flat records satisfy BOTH properties:
- *   - every top-level key parses as an integer (round number)
- *   - every top-level value is an array (the items list for that round)
- *
- * If either property fails on any entry, the record is treated as legacy.
- * This guards against a numeric-only runId sneaking through the key check
- * and against a legacy record whose inner maps happen to be arrays.
- */
-export function isLegacyNested(raw: unknown): raw is Record<string, unknown> {
-  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return false;
-  const entries = Object.entries(raw as Record<string, unknown>);
-  if (entries.length === 0) return false;
-  return entries.some(
-    ([key, value]) => !/^-?\d+$/.test(key) || !Array.isArray(value),
-  );
-}
-
-/**
- * Flatten a legacy nested record to a single run's round-keyed map.
- * Prefers the `preferredRunId` when that entry exists (legacy tabs persisted
- * `activeRunId` in meta.json to mark the selected run); otherwise falls back
- * to JS insertion order and picks the last-written run.
- */
-export function flattenLegacyRuns(
-  raw: Record<string, unknown>,
-  preferredRunId?: string | null,
-): Record<string, unknown> {
-  if (preferredRunId) {
-    const picked = raw[preferredRunId];
-    if (picked && typeof picked === 'object' && !Array.isArray(picked)) {
-      return picked as Record<string, unknown>;
-    }
-  }
-  const latest = Object.values(raw).findLast(
-    (value) =>
-      value != null && typeof value === 'object' && !Array.isArray(value),
-  );
-  return (latest as Record<string, unknown> | undefined) ?? {};
-}
-
-// ============================================================================
-// Shared transform helpers
-// ============================================================================
-
-/** Convert { stringKey: items[] } record to Map<number, items[]>, coercing keys. */
-function recordToRoundMap<T>(record: Record<string, T[]>): Map<number, T[]> {
-  const map = new Map<number, T[]>();
-  for (const [key, items] of Object.entries(record)) {
-    const round = RoundKeySchema.safeParse(key);
-    if (round.success && items.length > 0) {
-      map.set(round.data, items);
-    }
-  }
-  return map;
-}
-
-/**
- * Builds a schema that parses a flat round-keyed record
- * (`{ "1": items[], … }`) into `Map<number, items[]>`: keys are coerced to
- * integers, empty/malformed rounds are dropped, and a malformed top-level
- * value falls back to an empty map. Callers pre-flatten legacy nested records
- * (`{ runId: { round: items[] } }`, see `flattenLegacyRuns`) before parsing —
- * the schema itself does not fall back to insertion order.
- *
- * The single cast here replaces the per-schema casts that the
- * `.transform(recordToRoundMap)` → `.catch(…)` pipeline would otherwise
- * require at each call site.
- *
- * The fallback uses a `() => new Map()` factory rather than a literal
- * `new Map()`: Zod stores a literal catch value once and returns that same
- * instance on every failure, and consumers (e.g. `StreamSnapshotStore`) hold
- * the parsed map by reference and mutate it via `.set()`, so a shared instance
- * would leak rounds across streams whose sidecar JSON is malformed.
- */
-function roundMapSchema<T>(
-  itemList: z.ZodType<T[]>,
-): z.ZodType<Map<number, T[]>> {
-  return z
-    .record(z.string(), itemList)
-    .transform(recordToRoundMap)
-    .catch(() => new Map()) as z.ZodType<Map<number, T[]>>;
-}
-
-function warnDroppedItem(
-  kind: string,
-  error: { issues: readonly { path: PropertyKey[]; message: string }[] },
-): void {
-  console.warn(
-    `[streamData] Dropping malformed ${kind} entry: ${error.issues
-      .map((i) => `${i.path.join('.') || '<root>'}: ${i.message}`)
-      .join('; ')}`,
-  );
-}
-
-// ============================================================================
-// Output files: { round: OutputFileInfo[] } (caller pre-flattens legacy input,
-// threading the activeRunId hint in via flattenLegacyRuns).
-// ============================================================================
-
-const OutputFileListSchema = z
-  .array(z.unknown())
-  .transform((items) =>
-    items.flatMap((item) => {
-      const parsed = OutputFileInfoSchema.safeParse(item);
-      if (parsed.success) return [parsed.data];
-      warnDroppedItem('OutputFileInfo', parsed.error);
-      return [];
-    }),
-  )
-  .catch([]);
-
-export const OutputFilesDataSchema = roundMapSchema(OutputFileListSchema);
-
-// ============================================================================
-// Missing outputs: { round: string[] } (caller pre-flattens legacy input).
-// ============================================================================
-
-export const MissingOutputsDataSchema = roundMapSchema(
-  z.array(z.string()).catch([]),
-);
-
-// ============================================================================
-// Compile failures: { round: CompileFailure[] } (caller pre-flattens legacy input).
-// ============================================================================
-
-export const CompileFailuresDataSchema = roundMapSchema(
-  z.array(CompileFailureSchema).catch([]),
-);
 
 // ============================================================================
 // Usage stats — per-run map kept (tool-use can resume → multiple runs).

--- a/src/shared/schemas/streamSnapshot.ts
+++ b/src/shared/schemas/streamSnapshot.ts
@@ -25,11 +25,8 @@
 import { z } from 'zod';
 
 import { ExecutionIdSchema, StreamTabIdSchema } from './identifiers';
-import {
-  OutputFileInfoSchema,
-  CompileFailureSchema,
-  roundIndexedRecord,
-} from './output';
+import { OutputFileInfoSchema, CompileFailureSchema } from './output';
+import { roundIndexedRecord } from './roundIndexed';
 import { StreamStatusSchema } from './stream';
 import {
   ActiveChildInfoSchema,
@@ -50,9 +47,13 @@ export const STREAM_SNAPSHOT_SCHEMA_VERSION = 1 as const;
 // Round / run keyed records (match the on-disk JSON: string keys → arrays)
 // ============================================================================
 
-const OutputFilesByRoundSchema = roundIndexedRecord(OutputFileInfoSchema);
-const MissingOutputsByRoundSchema = roundIndexedRecord(z.string());
-const CompileFailuresByRoundSchema = roundIndexedRecord(CompileFailureSchema);
+const OutputFilesByRoundSchema = roundIndexedRecord(
+  OutputFileInfoSchema,
+).prefault({});
+const MissingOutputsByRoundSchema = roundIndexedRecord(z.string()).prefault({});
+const CompileFailuresByRoundSchema = roundIndexedRecord(
+  CompileFailureSchema,
+).prefault({});
 const RunUsageSchema = RunUsageMapSchema.prefault({});
 
 // ============================================================================

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -2,11 +2,8 @@ import { z } from 'zod';
 
 import { GoalStatusSchema } from './goal';
 import { AgentCategory, AgentCategorySchema } from './agent';
-import {
-  CompileFailureSchema,
-  OutputFileInfoSchema,
-  roundIndexedRecord,
-} from './output';
+import { CompileFailureSchema, OutputFileInfoSchema } from './output';
+import { roundIndexedRecord } from './roundIndexed';
 import {
   STREAM_STATUS,
   StreamLifecycleStatusSchema,
@@ -188,9 +185,9 @@ export const WorkflowStreamStateSchema = BaseStreamStateSchema.extend({
   // the original and resumed runs; sessionUsage is derived as their sum.
   runUsage: RunUsageMapSchema.prefault({}),
   sessionUsage: TokenUsageStatsSchema.nullable().prefault(null),
-  files: roundIndexedRecord(OutputFileInfoSchema),
-  missingOutputs: roundIndexedRecord(z.string()),
-  compileFailures: roundIndexedRecord(CompileFailureSchema),
+  files: roundIndexedRecord(OutputFileInfoSchema).prefault({}),
+  missingOutputs: roundIndexedRecord(z.string()).prefault({}),
+  compileFailures: roundIndexedRecord(CompileFailureSchema).prefault({}),
 });
 
 export type WorkflowStreamState = z.infer<typeof WorkflowStreamStateSchema>;

--- a/src/test-kernel/controllers/ProgressFollowUpController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressFollowUpController.vitest.ts
@@ -76,8 +76,8 @@ function createCompileFailure(): CompileFailure {
 
 const emptyFollowUpState: ProgressFollowUpState = {
   getTaskState: () => undefined,
-  getOutputFiles: () => new Map(),
-  getCompileFailures: () => new Map(),
+  getOutputFiles: () => ({}),
+  getCompileFailures: () => ({}),
   getExecutionId: () => undefined,
 };
 
@@ -108,9 +108,7 @@ describe('ProgressFollowUpController', () => {
         inputFiles: ['main-diffea268c1.tex'],
       }),
       compileFailures: [createCompileFailure()],
-      runOutputs: new Map([
-        [2, [createRunStorageOutputFile('main-diffea268c1.tex')]],
-      ]),
+      runOutputs: { 2: [createRunStorageOutputFile('main-diffea268c1.tex')] },
       modelOptions: [{ value: 'gemini31p' }],
       executionId: 'exec-123',
     });
@@ -141,9 +139,7 @@ describe('ProgressFollowUpController', () => {
         inputFiles: ['main-diffea268c1.tex'],
       }),
       compileFailures: [createCompileFailure()],
-      runOutputs: new Map([
-        [2, [createRunStorageOutputFile('main-diffea268c1.tex')]],
-      ]),
+      runOutputs: { 2: [createRunStorageOutputFile('main-diffea268c1.tex')] },
       modelOptions: [{ value: 'gemini31p' }],
       executionId: 'exec-123',
     });
@@ -164,9 +160,7 @@ describe('ProgressFollowUpController', () => {
           inputFiles: ['main-diffea268c1.tex'],
         }),
         compileFailures: [createCompileFailure()],
-        runOutputs: new Map([
-          [2, [createRunStorageOutputFile('main-diffea268c1.tex')]],
-        ]),
+        runOutputs: { 2: [createRunStorageOutputFile('main-diffea268c1.tex')] },
         modelOptions: [{ value: 'gemini31p' }],
         executionId: 'exec-123',
       },
@@ -188,7 +182,7 @@ describe('ProgressFollowUpController', () => {
           inputFiles: ['main.tex', 'main-diffea268c1.tex'],
         }),
         compileFailures: [createCompileFailure()],
-        runOutputs: new Map(),
+        runOutputs: {},
         modelOptions: [{ value: 'gemini31p' }],
         executionId: 'exec-123',
       },

--- a/src/test-kernel/controllers/ProgressFollowUpPlanning.vitest.ts
+++ b/src/test-kernel/controllers/ProgressFollowUpPlanning.vitest.ts
@@ -88,8 +88,8 @@ function createCompileFailure(
 
 const emptyFollowUpState: ProgressFollowUpState = {
   getTaskState: () => undefined,
-  getOutputFiles: () => new Map(),
-  getCompileFailures: () => new Map(),
+  getOutputFiles: () => ({}),
+  getCompileFailures: () => ({}),
   getExecutionId: () => undefined,
 };
 
@@ -166,8 +166,8 @@ describe('ProgressFollowUpController', () => {
       modelOptions: [{ value: 'gemini31p' }],
       state: {
         getTaskState: () => taskState,
-        getOutputFiles: () => new Map([[2, [outputFile]]]),
-        getCompileFailures: () => new Map(),
+        getOutputFiles: () => ({ 2: [outputFile] }),
+        getCompileFailures: () => ({}),
         getExecutionId: () => 'exec-123',
       },
     });
@@ -222,7 +222,7 @@ describe('ProgressFollowUpController', () => {
         inputFiles: ['main.tex', 'source.tex'],
       }),
       compileFailures: [createCompileFailure()],
-      runOutputs: new Map([[2, [output]]]),
+      runOutputs: { 2: [output] },
       modelOptions: [{ value: 'other-model' }],
       executionId: 'exec-123',
     });
@@ -253,7 +253,7 @@ describe('ProgressFollowUpController', () => {
         inputFiles: ['main.tex', 'chapter.tex'],
       }),
       compileFailures: [createCompileFailure()],
-      runOutputs: new Map(),
+      runOutputs: {},
       modelOptions: [{ value: 'gemini31p' }],
       executionId: 'exec-123',
     });
@@ -277,9 +277,9 @@ describe('ProgressFollowUpController', () => {
         inputFiles: ['/external/main.tex'],
       }),
       compileFailures: [createCompileFailure()],
-      runOutputs: new Map([
-        [2, [createRunStorageOutputFile({ source: '/external/main.tex' })]],
-      ]),
+      runOutputs: {
+        2: [createRunStorageOutputFile({ source: '/external/main.tex' })],
+      },
       modelOptions: [{ value: 'gemini31p' }],
       executionId: 'exec-123',
     });

--- a/src/test-kernel/controllers/ProgressWorkflowActionsController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressWorkflowActionsController.vitest.ts
@@ -73,7 +73,7 @@ describe('ProgressWorkflowActionsController', () => {
     const { controller, diffs } = createProgressWorkflowActionsHarness({
       taskStates: new Map([['stream-a', taskState]]),
       executionIds: new Map([['stream-a', 'exec-123']]),
-      outputs: new Map([['stream-a', new Map([[1, [output]]])]]),
+      outputs: new Map([['stream-a', { 1: [output] }]]),
     });
 
     await controller.diffStream('stream-a');
@@ -87,7 +87,7 @@ describe('ProgressWorkflowActionsController', () => {
         outputFilesActive: false,
         streamId: 'stream-a',
         runId: 'exec-123',
-        outputsByRound: [[1, [output]]],
+        outputsByRound: { 1: [output] },
       },
     ]);
   });

--- a/src/test-kernel/controllers/ProgressWorkflowFileActionsController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressWorkflowFileActionsController.vitest.ts
@@ -14,7 +14,7 @@ function createDeps(
     state: {
       getActiveStream: () => '',
       getExecutionId: () => undefined,
-      getOutputFiles: () => new Map(),
+      getOutputFiles: () => ({}),
       getAgentModel: () => undefined,
     },
     host: {

--- a/src/test-kernel/controllers/ProgressWorkflowFileActionsHostFlows.vitest.ts
+++ b/src/test-kernel/controllers/ProgressWorkflowFileActionsHostFlows.vitest.ts
@@ -55,7 +55,7 @@ function createDeps(
     state: {
       getActiveStream: () => '',
       getExecutionId: () => undefined,
-      getOutputFiles: () => new Map(),
+      getOutputFiles: () => ({}),
       getAgentModel: () => undefined,
     },
     host,

--- a/src/test-kernel/desktop/DesktopProgressFileActions.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressFileActions.vitest.mts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import type { OutputFileInfo } from '@shared/schemas';
+import type { OutputFileInfo, RoundIndexed } from '@shared/schemas';
 
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
 
@@ -15,7 +15,7 @@ type DiffOutcome = {
 };
 
 type RunContext = {
-  outputsByRound: Map<number, OutputFileInfo[]>;
+  outputsByRound: RoundIndexed<OutputFileInfo>;
   executionId?: string;
   workspaceScan?: {
     agent: string;
@@ -161,7 +161,7 @@ describe('DesktopProgressFileActions latexdiff', () => {
     };
     const { actions, openPath, runLatexdiffForExecution, runDiff } =
       await loadFileActions({ outcome });
-    const outputsByRound = new Map([[1, [outputInfo('/run/r1/main.tex')]]]);
+    const outputsByRound = { 1: [outputInfo('/run/r1/main.tex')] };
 
     await actions.runLatexdiffForRun(
       '/workspace/main.tex',
@@ -202,7 +202,7 @@ describe('DesktopProgressFileActions latexdiff', () => {
       '/workspace/main.tex',
       '/workspace/main_orchestrator_r1_gpt.tex',
       {
-        outputsByRound: new Map(),
+        outputsByRound: {},
         workspaceScan: {
           agent: 'orchestrator',
           model: 'gpt-5',
@@ -236,7 +236,7 @@ describe('DesktopProgressFileActions latexdiff', () => {
       '/workspace/base.tex',
       '/run/r1/main.tex',
       {
-        outputsByRound: new Map([[1, [outputInfo('/run/r1/main.tex')]]]),
+        outputsByRound: { 1: [outputInfo('/run/r1/main.tex')] },
       },
     );
 
@@ -268,7 +268,7 @@ describe('DesktopProgressFileActions latexdiff', () => {
       '/workspace/main.tex',
       '/run/r2/main.tex',
       {
-        outputsByRound: new Map([[1, [outputInfo('/run/r1/main.tex')]]]),
+        outputsByRound: { 1: [outputInfo('/run/r1/main.tex')] },
       },
     );
 
@@ -288,7 +288,7 @@ describe('DesktopProgressFileActions latexdiff', () => {
       '/workspace/base.tex',
       '/run/r1/main.tex',
       {
-        outputsByRound: new Map(),
+        outputsByRound: {},
         workspaceScan: { agent: 'a', model: 'm', inputFile: 'main.tex' },
       },
     );
@@ -310,7 +310,7 @@ describe('DesktopProgressFileActions latexdiff', () => {
       '/workspace/base.tex',
       '/run/r1/main.tex',
       {
-        outputsByRound: new Map([[1, [outputInfo('/run/r1/main.tex')]]]),
+        outputsByRound: { 1: [outputInfo('/run/r1/main.tex')] },
       },
     );
 
@@ -336,7 +336,7 @@ describe('DesktopProgressFileActions latexdiff', () => {
       '/workspace/a.tex',
       '/workspace/a_r1.tex',
       {
-        outputsByRound: new Map(),
+        outputsByRound: {},
         workspaceScan: {
           agent: 'orchestrator',
           model: 'gpt-5',

--- a/src/test-kernel/latex/OutputDiscovery.vitest.mts
+++ b/src/test-kernel/latex/OutputDiscovery.vitest.mts
@@ -104,9 +104,11 @@ describe('discoverLatestExecutionOutputs', () => {
     });
 
     expect(result?.executionId).toBe('exec-headless');
-    expect([...(result?.rounds.keys() ?? [])].sort((a, b) => a - b)).toEqual([
-      0, 1,
-    ]);
+    expect(
+      Object.keys(result?.rounds ?? {})
+        .map(Number)
+        .sort((a, b) => a - b),
+    ).toEqual([0, 1]);
     expect(mocks.findRunDir).toHaveBeenCalledWith('exec-headless');
   });
 

--- a/src/test-kernel/latex/RunLatexdiff.vitest.mts
+++ b/src/test-kernel/latex/RunLatexdiff.vitest.mts
@@ -2,8 +2,8 @@
 // normalization).
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { OutputFileInfo } from '@shared/schemas';
 import { normalizeRunLatexdiffOutputsByRound } from '@latex/latexdiff/runLatexdiff';
+import type { OutputFileInfo, RoundIndexed } from '@shared/schemas';
 import { createOutputFile } from '../support/ProgressControllerHarnesses';
 
 // ---------------------------------------------------------------------------
@@ -35,8 +35,8 @@ const { runLatexdiffForExecution } =
 const METADATA_OUTCOME = { results: [], totalOperations: 1 };
 const SCAN_OUTCOME = { results: [], totalOperations: 2 };
 
-function roundMap(): Map<number, OutputFileInfo[]> {
-  return new Map([[1, [] as OutputFileInfo[]]]);
+function roundMap(): RoundIndexed<OutputFileInfo> {
+  return { 1: [] as OutputFileInfo[] };
 }
 
 const baseRequest = {
@@ -152,39 +152,44 @@ describe('runLatexdiffForExecution', () => {
 // ---------------------------------------------------------------------------
 
 describe('normalizeRunLatexdiffOutputsByRound', () => {
-  it('keeps non-empty tuple-array rounds in numeric order', () => {
+  it('keeps non-empty round-record entries, dropping empty rounds', () => {
     const first = createOutputFile({ round: 1 });
     const second = createOutputFile({ round: 2 });
 
     expect(
-      normalizeRunLatexdiffOutputsByRound([
-        [2, [second]],
-        [1, [first]],
-        [3, []],
-      ]),
-    ).toEqual(
-      new Map([
-        [1, [first]],
-        [2, [second]],
-      ]),
-    );
+      normalizeRunLatexdiffOutputsByRound({
+        2: [second],
+        1: [first],
+        3: [],
+      }),
+    ).toEqual({ 1: [first], 2: [second] });
   });
 
-  it('falls back for malformed or legacy map-shaped command payloads', () => {
-    expect(
-      normalizeRunLatexdiffOutputsByRound({ 1: [createOutputFile()] }),
-    ).toBeNull();
+  it('falls back to null for malformed command payloads', () => {
     expect(normalizeRunLatexdiffOutputsByRound('not-rounds')).toBeNull();
+    expect(normalizeRunLatexdiffOutputsByRound(null)).toBeNull();
+    expect(normalizeRunLatexdiffOutputsByRound([1, 2, 3])).toBeNull();
   });
 
-  it('drops non-integer round entries', () => {
+  it('drops malformed items within an otherwise-valid round record', () => {
     const valid = createOutputFile({ round: 1 });
 
     expect(
-      normalizeRunLatexdiffOutputsByRound([
-        [1.5, [createOutputFile({ round: 1.5 })]],
-        [1, [valid]],
-      ]),
-    ).toEqual(new Map([[1, [valid]]]));
+      normalizeRunLatexdiffOutputsByRound({
+        1: [valid, { not: 'an output file' }],
+      }),
+    ).toEqual({ 1: [valid] });
+  });
+
+  it('treats a record with any non-integer round key as legacy-shaped, salvaging nothing when it is not run-nested either', () => {
+    // Mirrors parsePersistedRoundIndexed's whole-file legacy fallback: a
+    // non-integer key routes the record to the run-nested arm, and since
+    // this payload isn't actually nested per-run data, nothing salvages.
+    expect(
+      normalizeRunLatexdiffOutputsByRound({
+        '1.5': [createOutputFile({ round: 1.5 })],
+        1: [createOutputFile({ round: 1 })],
+      }),
+    ).toBeNull();
   });
 });

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -480,14 +480,14 @@ describe('ProgressBackend', () => {
       expect(first.backend.state.snapshots.getWorkPlan(streamId).todos).toEqual(
         [firstTodo],
       );
-      expect(first.backend.state.snapshots.getOutputFiles(streamId)).toEqual(
-        new Map([[1, [firstOutput]]]),
-      );
+      expect(first.backend.state.snapshots.getOutputFiles(streamId)).toEqual({
+        1: [firstOutput],
+      });
       expect(
         second.backend.state.snapshots.getWorkPlan(streamId).todos,
       ).toEqual([]);
       expect(second.backend.state.snapshots.getOutputFiles(streamId)).toEqual(
-        new Map(),
+        {},
       );
       expect(JSON.stringify(second.messages)).not.toContain(
         'from first window',
@@ -938,15 +938,15 @@ describe('ProgressBackend', () => {
           cacheCreationInputTokens: 0,
         }),
       );
-      expect(backend.state.snapshots.getOutputFiles(streamId)).toEqual(
-        new Map([[1, [outputFile]]]),
-      );
-      expect(backend.state.snapshots.getMissingOutputs(streamId)).toEqual(
-        new Map([[1, ['paper.pdf']]]),
-      );
-      expect(backend.state.snapshots.getCompileFailures(streamId)).toEqual(
-        new Map([[1, [compileFailure]]]),
-      );
+      expect(backend.state.snapshots.getOutputFiles(streamId)).toEqual({
+        1: [outputFile],
+      });
+      expect(backend.state.snapshots.getMissingOutputs(streamId)).toEqual({
+        1: ['paper.pdf'],
+      });
+      expect(backend.state.snapshots.getCompileFailures(streamId)).toEqual({
+        1: [compileFailure],
+      });
       expect(backend.state.snapshots.getWorkPlan(streamId)).toMatchObject({
         todos,
         plan,
@@ -1021,9 +1021,7 @@ describe('ProgressBackend', () => {
 
       expect(handleProgressEvent).not.toHaveBeenCalled();
       expect(updateFiles).not.toHaveBeenCalled();
-      expect(backend.state.snapshots.getOutputFiles(streamId)).toEqual(
-        new Map(),
-      );
+      expect(backend.state.snapshots.getOutputFiles(streamId)).toEqual({});
     } finally {
       subscription.dispose();
       await backend.state.clearAll();

--- a/src/test-kernel/schemas/StreamDataRoundMaps.vitest.ts
+++ b/src/test-kernel/schemas/StreamDataRoundMaps.vitest.ts
@@ -1,9 +1,73 @@
 import { describe, expect, it } from 'vitest';
 
 import { z } from 'zod';
-import { parsePersistedRoundIndexed } from '@shared/schemas';
+import {
+  parsePersistedRoundIndexed,
+  roundIndexedRecord,
+  RoundKeySchema,
+  RoundKeyStringSchema,
+  RoundNumberSchema,
+} from '@shared/schemas';
 
 const StringItemSchema = z.string();
+
+describe('round-key/round-number invariant: non-negative safe integers only', () => {
+  it('RoundNumberSchema rejects negative and fractional round numbers', () => {
+    expect(RoundNumberSchema.safeParse(0).success).toBe(true);
+    expect(RoundNumberSchema.safeParse(5).success).toBe(true);
+    expect(RoundNumberSchema.safeParse(-1).success).toBe(false);
+    expect(RoundNumberSchema.safeParse(1.5).success).toBe(false);
+  });
+
+  it('RoundKeySchema coerces and rejects negative/fractional string keys', () => {
+    expect(RoundKeySchema.safeParse('0')).toMatchObject({
+      success: true,
+      data: 0,
+    });
+    expect(RoundKeySchema.safeParse('5')).toMatchObject({
+      success: true,
+      data: 5,
+    });
+    expect(RoundKeySchema.safeParse('-1').success).toBe(false);
+    expect(RoundKeySchema.safeParse('1.5').success).toBe(false);
+  });
+
+  it('RoundKeySchema and RoundKeyStringSchema agree on scientific notation', () => {
+    // "1e5" is a plain numeric string Number() coerces to 100000; both the
+    // scalar coercion and the record-key predicate must agree it is valid,
+    // rather than one accepting it via numeric coercion and the other
+    // rejecting it via a stricter digits-only regex.
+    expect(RoundKeySchema.safeParse('1e5')).toMatchObject({
+      success: true,
+      data: 100000,
+    });
+    expect(RoundKeyStringSchema.safeParse('1e5').success).toBe(true);
+  });
+
+  it('RoundKeyStringSchema rejects non-numeric and legacy runId-shaped keys', () => {
+    expect(RoundKeyStringSchema.safeParse('run-1').success).toBe(false);
+    expect(RoundKeyStringSchema.safeParse('abc').success).toBe(false);
+    expect(RoundKeyStringSchema.safeParse('-1').success).toBe(false);
+    expect(RoundKeyStringSchema.safeParse('1.5').success).toBe(false);
+  });
+
+  it('roundIndexedRecord() rejects negative, fractional, and non-numeric keys', () => {
+    const schema = roundIndexedRecord(StringItemSchema);
+
+    expect(schema.safeParse({ '0': ['a'], '5': ['b'] }).success).toBe(true);
+    expect(schema.safeParse({ '-1': ['a'] }).success).toBe(false);
+    expect(schema.safeParse({ '1.5': ['a'] }).success).toBe(false);
+    expect(schema.safeParse({ 'run-1': ['a'] }).success).toBe(false);
+  });
+
+  it('roundIndexedRecord() accepts scientific-notation keys, matching RoundKeySchema', () => {
+    const schema = roundIndexedRecord(StringItemSchema);
+    expect(schema.safeParse({ '1e5': ['a'] })).toMatchObject({
+      success: true,
+      data: { '1e5': ['a'] },
+    });
+  });
+});
 
 describe('parsePersistedRoundIndexed (canonical round-indexed parse entry)', () => {
   it('coerces string round keys and drops empty rounds', () => {
@@ -115,5 +179,30 @@ describe('parsePersistedRoundIndexed (canonical round-indexed parse entry)', () 
 
     expect(wasLegacy).toBe(true);
     expect(rounds).toEqual({});
+  });
+
+  it('treats a negative round key the same as any other non-integer key: legacy-shaped, salvaging nothing when not run-nested', () => {
+    // A negative key fails RoundKeyStringSchema, so the flat arm rejects the
+    // whole record (mirroring the non-integer-key case above) and the
+    // legacy-nested arm finds no nested run object to salvage from.
+    const { rounds, wasLegacy } = parsePersistedRoundIndexed(
+      'missingOutputs',
+      { '-1': ['a.tex'], '0': ['b.tex'] },
+      StringItemSchema,
+    );
+
+    expect(wasLegacy).toBe(true);
+    expect(rounds).toEqual({});
+  });
+
+  it('accepts a scientific-notation round key in the flat arm, agreeing with RoundKeySchema', () => {
+    const { rounds, wasLegacy } = parsePersistedRoundIndexed(
+      'missingOutputs',
+      { '1e2': ['a.tex'] },
+      StringItemSchema,
+    );
+
+    expect(wasLegacy).toBe(false);
+    expect(rounds).toEqual({ 100: ['a.tex'] });
   });
 });

--- a/src/test-kernel/schemas/StreamDataRoundMaps.vitest.ts
+++ b/src/test-kernel/schemas/StreamDataRoundMaps.vitest.ts
@@ -1,41 +1,119 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-  CompileFailuresDataSchema,
-  MissingOutputsDataSchema,
-  OutputFilesDataSchema,
-} from '@shared/schemas';
+import { z } from 'zod';
+import { parsePersistedRoundIndexed } from '@shared/schemas';
 
-describe('round-keyed stream data parsing', () => {
+const StringItemSchema = z.string();
+
+describe('parsePersistedRoundIndexed (canonical round-indexed parse entry)', () => {
   it('coerces string round keys and drops empty rounds', () => {
-    const missing = MissingOutputsDataSchema.parse({
-      '1': ['a.tex', 'b.tex'],
-      '2': [],
-    });
+    const { rounds, wasLegacy } = parsePersistedRoundIndexed(
+      'missingOutputs',
+      { '1': ['a.tex', 'b.tex'], '2': [] },
+      StringItemSchema,
+    );
 
-    expect(missing).toBeInstanceOf(Map);
-    expect(missing.get(1)).toEqual(['a.tex', 'b.tex']);
+    expect(wasLegacy).toBe(false);
+    expect(rounds).toEqual({ 1: ['a.tex', 'b.tex'] });
     // Round 2 is empty and must be dropped, not stored as an empty array.
-    expect(missing.has(2)).toBe(false);
+    expect(rounds).not.toHaveProperty('2');
   });
 
-  it('falls back to an empty map on malformed top-level input', () => {
-    const result = OutputFilesDataSchema.parse('not-a-record');
+  it('falls back to an empty record on malformed top-level input', () => {
+    const { rounds, wasLegacy } = parsePersistedRoundIndexed(
+      'outputFiles',
+      'not-a-record',
+      StringItemSchema,
+    );
 
-    expect(result).toBeInstanceOf(Map);
-    expect(result.size).toBe(0);
+    expect(rounds).toEqual({});
+    expect(wasLegacy).toBe(false);
   });
 
-  it('returns a fresh map per failed parse so consumers cannot leak across streams', () => {
-    // Both parses fail and hit the `.catch(() => new Map())` fallback. Each
-    // must yield a distinct instance, because consumers (StreamSnapshotStore)
-    // hold the parsed map by reference and mutate it via `.set()`.
-    const first = CompileFailuresDataSchema.parse(42);
-    const second = CompileFailuresDataSchema.parse(42);
+  it('returns a fresh record per failed parse so consumers cannot leak across streams', () => {
+    // Both parses fail and hit the "malformed top-level" fallback. Each must
+    // yield a distinct object, because consumers (StreamSnapshotStore) hold
+    // the parsed record by reference and mutate it in place.
+    const first = parsePersistedRoundIndexed(
+      'compileFailures',
+      42,
+      StringItemSchema,
+    );
+    const second = parsePersistedRoundIndexed(
+      'compileFailures',
+      42,
+      StringItemSchema,
+    );
 
-    expect(first).not.toBe(second);
+    expect(first.rounds).not.toBe(second.rounds);
 
-    first.set(1, []);
-    expect(second.size).toBe(0);
+    first.rounds[1] = ['x'];
+    expect(second.rounds).toEqual({});
+  });
+
+  it('treats a missing file (undefined) as empty, not legacy', () => {
+    const { rounds, wasLegacy } = parsePersistedRoundIndexed(
+      'outputFiles',
+      undefined,
+      StringItemSchema,
+    );
+
+    expect(rounds).toEqual({});
+    expect(wasLegacy).toBe(false);
+  });
+
+  it('absorbs the legacy nested { runId: { round: items[] } } shape, picking the last-inserted run', () => {
+    const { rounds, wasLegacy } = parsePersistedRoundIndexed(
+      'missingOutputs',
+      {
+        'run-1': { '0': ['a.tex'] },
+        'run-2': { '0': ['b.tex'], '1': ['c.tex'] },
+      },
+      StringItemSchema,
+    );
+
+    expect(wasLegacy).toBe(true);
+    expect(rounds).toEqual({ 0: ['b.tex'], 1: ['c.tex'] });
+  });
+
+  it('prefers the preferredRunId when it exists in the legacy nested shape', () => {
+    const { rounds, wasLegacy } = parsePersistedRoundIndexed(
+      'missingOutputs',
+      {
+        'run-1': { '0': ['a.tex'] },
+        'run-2': { '0': ['b.tex'] },
+      },
+      StringItemSchema,
+      'run-1',
+    );
+
+    expect(wasLegacy).toBe(true);
+    expect(rounds).toEqual({ 0: ['a.tex'] });
+  });
+
+  it('drops malformed items within an otherwise valid round, keeping the rest', () => {
+    const { rounds } = parsePersistedRoundIndexed(
+      'missingOutputs',
+      { '1': ['a.tex', 42, 'b.tex'] },
+      StringItemSchema,
+    );
+
+    expect(rounds).toEqual({ 1: ['a.tex', 'b.tex'] });
+  });
+
+  it('treats a record with any non-array round value as legacy-shaped and salvages nothing when it is not run-nested either', () => {
+    // Mirrors the pre-refactor `isLegacyNested` predicate: a flat round
+    // record must have EVERY value be an array, or the whole file is routed
+    // to the legacy-run-nested arm instead of a per-round salvage. Here
+    // neither arm finds anything usable, so the result is empty rather than
+    // throwing.
+    const { rounds, wasLegacy } = parsePersistedRoundIndexed(
+      'missingOutputs',
+      { '1': ['a.tex'], '2': 'not-an-array' },
+      StringItemSchema,
+    );
+
+    expect(wasLegacy).toBe(true);
+    expect(rounds).toEqual({});
   });
 });

--- a/src/test-kernel/support/ProgressControllerHarnesses.ts
+++ b/src/test-kernel/support/ProgressControllerHarnesses.ts
@@ -21,7 +21,11 @@ import type { ExecutionRequest } from '@agent/core/state/executionRequests';
 import type { TaskState, WorkflowTaskState } from '@agent/core/state/TaskState';
 
 // Local imports - shared
-import type { OutputFileInfo, StreamTabId } from '@shared/schemas';
+import type {
+  OutputFileInfo,
+  RoundIndexed,
+  StreamTabId,
+} from '@shared/schemas';
 
 export class ControllerCallRecorder<T = unknown> {
   readonly calls = new Map<string, T[]>();
@@ -226,7 +230,7 @@ export function createOutputFile(
 export interface ProgressWorkflowActionsHarnessOptions {
   taskStates?: Map<StreamTabId, TaskState>;
   executionIds?: Map<StreamTabId, string>;
-  outputs?: Map<StreamTabId, Map<number, OutputFileInfo[]>>;
+  outputs?: Map<StreamTabId, RoundIndexed<OutputFileInfo>>;
   knownWorkspaceOutputs?: Map<StreamTabId, Set<string>>;
 }
 
@@ -255,7 +259,7 @@ export function createProgressWorkflowActionsHarness(
       state: {
         getTaskState: (stream) => options.taskStates?.get(stream),
         getExecutionId: (stream) => options.executionIds?.get(stream),
-        getOutputFiles: (stream) => new Map(options.outputs?.get(stream) ?? []),
+        getOutputFiles: (stream) => options.outputs?.get(stream) ?? {},
         getKnownWorkspaceOutputPaths: (stream) =>
           new Set(options.knownWorkspaceOutputs?.get(stream) ?? []),
       },

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -530,6 +530,20 @@ describe('StreamSnapshotStore', () => {
     });
   });
 
+  it('returns a deep-enough copy from getOutputFiles so mutating the returned array cannot corrupt internal state', async () => {
+    const first = outputFile('first.tex', 0);
+    const store = new StreamSnapshotStore();
+    store.addOutputFiles(STREAM, { 0: [first] });
+
+    const returned = store.getOutputFiles(STREAM);
+    // Mutate the returned round's array directly (not just reassign the
+    // top-level record) — a shallow `{ ...map }` copy would still share this
+    // array by reference with the store's internal accumulator.
+    returned[0]?.push(outputFile('injected.tex', 0));
+
+    expect(store.getOutputFiles(STREAM)[0]).toEqual([first]);
+  });
+
   it('keeps output overlays when flattening legacy output files after preload', async () => {
     const dir = streamDataDir(OTHER_STREAM);
     await StorageFS.ensureDir(dir);

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -520,7 +520,7 @@ describe('StreamSnapshotStore', () => {
     await store.preload([STREAM]);
 
     store.addOutputFiles(OTHER_STREAM, { 1: [next] });
-    expect(store.getOutputFiles(OTHER_STREAM).get(1)).toEqual([next]);
+    expect(store.getOutputFiles(OTHER_STREAM)[1]).toEqual([next]);
     await store.flush();
 
     const raw = await StorageFS.readJson(path.join(dir, 'outputFiles.json'));
@@ -544,7 +544,7 @@ describe('StreamSnapshotStore', () => {
     await store.preload([STREAM]);
 
     store.addOutputFiles(OTHER_STREAM, { 1: [next] });
-    expect(store.getOutputFiles(OTHER_STREAM).get(1)).toEqual([next]);
+    expect(store.getOutputFiles(OTHER_STREAM)[1]).toEqual([next]);
     await store.flush();
 
     const raw = await StorageFS.readJson(path.join(dir, 'outputFiles.json'));

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -35,6 +35,7 @@ import { KVStore } from '@common/storage/KVStore';
 import * as logger from '@logger/logUtils';
 import {
   CompileFailureSchema,
+  cloneRoundIndexed,
   emptyUsageStats,
   isEmptyUsage,
   OutputFileInfoListSchema,
@@ -719,16 +720,20 @@ export class StreamSnapshotStore {
   // Read accessors over in-memory accumulated state (replace manager getters)
   // ==========================================================================
 
+  // Deep-enough copies (fresh record, fresh per-round array): a caller that
+  // mutates the returned value — including pushing into a returned round's
+  // array — can never corrupt these in-memory accumulators. A shallow
+  // `{ ...map }` spread would share the per-round arrays by reference.
   getOutputFiles(stream: StreamTabId): RoundIndexed<OutputFileInfo> {
-    return { ...this.outputFiles.get(stream) };
+    return cloneRoundIndexed(this.outputFiles.get(stream));
   }
 
   getMissingOutputs(stream: StreamTabId): RoundIndexed<string> {
-    return { ...this.missingOutputs.get(stream) };
+    return cloneRoundIndexed(this.missingOutputs.get(stream));
   }
 
   getCompileFailures(stream: StreamTabId): RoundIndexed<CompileFailure> {
-    return { ...this.compileFailures.get(stream) };
+    return cloneRoundIndexed(this.compileFailures.get(stream));
   }
 
   getRunUsage(stream: StreamTabId): Map<string, TokenUsageStats> {

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -38,10 +38,12 @@ import {
   emptyUsageStats,
   isEmptyUsage,
   OutputFileInfoListSchema,
+  OutputFileInfoSchema,
   PersistedWorkPlanSchema,
   RUN_DESCRIPTOR_SCHEMA_VERSION,
   planSummaryLine,
   RoundKeySchema,
+  roundIndexedRecord,
   StreamTabIdSchema,
   sumUsageStats,
   TokenUsageStatsParsingSchema,
@@ -91,15 +93,15 @@ const SEED_IO_CONCURRENCY = 8;
 
 const AddOutputFilesRunFactSchema = z.looseObject({
   streamId: StreamTabIdSchema,
-  filesByRound: z.record(z.string(), OutputFileInfoListSchema),
+  filesByRound: roundIndexedRecord(OutputFileInfoSchema),
 });
 const UpdateMissingOutputsRunFactSchema = z.looseObject({
   streamId: StreamTabIdSchema,
-  filesByRound: z.record(z.string(), z.array(z.string())),
+  filesByRound: roundIndexedRecord(z.string()),
 });
 const UpdateCompileFailuresRunFactSchema = z.looseObject({
   streamId: StreamTabIdSchema,
-  filesByRound: z.record(z.string(), z.array(CompileFailureSchema)),
+  filesByRound: roundIndexedRecord(CompileFailureSchema),
 });
 const UsageRunEventDataSchema = z.looseObject({
   streamId: StreamTabIdSchema,
@@ -166,17 +168,20 @@ function executionIdFromMeta(
 
 export class StreamSnapshotStore {
   // -- In-memory accumulators (one entry per stream that has emitted) --------
+  // Round-scoped accumulators hold the canonical RoundIndexed record — the
+  // same shape that is persisted and sent over IPC, so no conversion exists
+  // between memory, disk, and the wire.
   private readonly outputFiles = new Map<
     StreamTabId,
-    Map<number, OutputFileInfo[]>
+    RoundIndexed<OutputFileInfo>
   >();
   private readonly missingOutputs = new Map<
     StreamTabId,
-    Map<number, string[]>
+    RoundIndexed<string>
   >();
   private readonly compileFailures = new Map<
     StreamTabId,
-    Map<number, CompileFailure[]>
+    RoundIndexed<CompileFailure>
   >();
   private readonly usage = new Map<StreamTabId, Map<string, TokenUsageStats>>();
   /**
@@ -504,13 +509,13 @@ export class StreamSnapshotStore {
   // Mutators (mirror the consolidated managers)
   // ==========================================================================
 
-  private getOrCreate<V>(
-    map: Map<StreamTabId, Map<number, V>>,
+  private getOrCreate<T>(
+    map: Map<StreamTabId, RoundIndexed<T>>,
     key: StreamTabId,
-  ): Map<number, V> {
+  ): RoundIndexed<T> {
     let inner = map.get(key);
     if (!inner) {
-      inner = new Map();
+      inner = {};
       map.set(key, inner);
     }
     return inner;
@@ -522,19 +527,19 @@ export class StreamSnapshotStore {
    * a round's entry (e.g. once its failure list empties out) or the value to
    * store otherwise.
    */
-  private applyRoundKeyedPatch<V>(
-    map: Map<StreamTabId, Map<number, V>>,
+  private applyRoundKeyedPatch<T>(
+    map: Map<StreamTabId, RoundIndexed<T>>,
     stream: StreamTabId,
     filesByRound: Record<string, unknown>,
-    normalize: (raw: unknown) => V | null,
-  ): Map<number, V> {
+    normalize: (raw: unknown) => T[] | null,
+  ): RoundIndexed<T> {
     const rounds = this.getOrCreate(map, stream);
     for (const [round, raw] of Object.entries(filesByRound)) {
       const key = RoundKeySchema.safeParse(round);
       if (!key.success) continue;
       const value = normalize(raw);
-      if (value === null) rounds.delete(key.data);
-      else rounds.set(key.data, value);
+      if (value === null) delete rounds[key.data];
+      else rounds[key.data] = value;
     }
     return rounds;
   }
@@ -557,11 +562,11 @@ export class StreamSnapshotStore {
   private applyOutputFilesPatch(
     stream: StreamTabId,
     patch: OutputFilesPatch,
-  ): Map<number, OutputFileInfo[]> {
+  ): RoundIndexed<OutputFileInfo> {
     const rounds = this.getOrCreate(this.outputFiles, stream);
     for (const [round, files] of patch) {
-      if (files === null) rounds.delete(round);
-      else rounds.set(round, files);
+      if (files === null) delete rounds[round];
+      else rounds[round] = files;
     }
     return rounds;
   }
@@ -579,11 +584,11 @@ export class StreamSnapshotStore {
   }
 
   private writeOutputFiles(stream: StreamTabId): void {
-    this.write(
-      stream,
-      STREAM_DATA_KEYS.OUTPUT_FILES,
-      mapToRecord(this.outputFiles.get(stream) ?? new Map()),
-    );
+    // Shallow copy: the write is queued, so snapshot the record at call time
+    // rather than letting later round mutations leak into a pending write.
+    this.write(stream, STREAM_DATA_KEYS.OUTPUT_FILES, {
+      ...this.outputFiles.get(stream),
+    });
   }
 
   private applyUsageDeltaMemory(
@@ -653,13 +658,13 @@ export class StreamSnapshotStore {
     filesByRound: RoundIndexed<string>,
   ): void {
     this.mutate(stream, () => {
-      const rounds = this.applyRoundKeyedPatch<string[]>(
+      const rounds = this.applyRoundKeyedPatch<string>(
         this.missingOutputs,
         stream,
         filesByRound,
         (raw) => raw as string[],
       );
-      this.write(stream, STREAM_DATA_KEYS.MISSING_OUTPUTS, mapToRecord(rounds));
+      this.write(stream, STREAM_DATA_KEYS.MISSING_OUTPUTS, { ...rounds });
     });
   }
 
@@ -668,7 +673,7 @@ export class StreamSnapshotStore {
     filesByRound: RoundIndexed<CompileFailure>,
   ): void {
     this.mutate(stream, () => {
-      const rounds = this.applyRoundKeyedPatch<CompileFailure[]>(
+      const rounds = this.applyRoundKeyedPatch<CompileFailure>(
         this.compileFailures,
         stream,
         filesByRound,
@@ -679,11 +684,7 @@ export class StreamSnapshotStore {
           return normalized.length === 0 ? null : normalized;
         },
       );
-      this.write(
-        stream,
-        STREAM_DATA_KEYS.COMPILE_FAILURES,
-        mapToRecord(rounds),
-      );
+      this.write(stream, STREAM_DATA_KEYS.COMPILE_FAILURES, { ...rounds });
     });
   }
 
@@ -718,16 +719,16 @@ export class StreamSnapshotStore {
   // Read accessors over in-memory accumulated state (replace manager getters)
   // ==========================================================================
 
-  getOutputFiles(stream: StreamTabId): Map<number, OutputFileInfo[]> {
-    return new Map(this.outputFiles.get(stream) ?? []);
+  getOutputFiles(stream: StreamTabId): RoundIndexed<OutputFileInfo> {
+    return { ...this.outputFiles.get(stream) };
   }
 
-  getMissingOutputs(stream: StreamTabId): Map<number, string[]> {
-    return new Map(this.missingOutputs.get(stream) ?? []);
+  getMissingOutputs(stream: StreamTabId): RoundIndexed<string> {
+    return { ...this.missingOutputs.get(stream) };
   }
 
-  getCompileFailures(stream: StreamTabId): Map<number, CompileFailure[]> {
-    return new Map(this.compileFailures.get(stream) ?? []);
+  getCompileFailures(stream: StreamTabId): RoundIndexed<CompileFailure> {
+    return { ...this.compileFailures.get(stream) };
   }
 
   getRunUsage(stream: StreamTabId): Map<string, TokenUsageStats> {
@@ -743,7 +744,7 @@ export class StreamSnapshotStore {
     const rounds = this.outputFiles.get(stream);
     if (!rounds) return paths;
     const workspaceOnly = options.workspaceOnly ?? false;
-    for (const infos of rounds.values()) {
+    for (const infos of Object.values(rounds)) {
       for (const info of infos) {
         if (!workspaceOnly || info.location.kind === 'workspace') {
           paths.add(info.location.absolutePath);
@@ -1163,9 +1164,9 @@ export class StreamSnapshotStore {
   private snapshotFromMemory(streamId: StreamTabId): StreamSnapshot {
     return assembleSnapshot(streamId, {
       meta: this.meta.get(streamId),
-      outputFiles: this.outputFiles.get(streamId) ?? new Map(),
-      missingOutputs: this.missingOutputs.get(streamId) ?? new Map(),
-      compileFailures: this.compileFailures.get(streamId) ?? new Map(),
+      outputFiles: this.outputFiles.get(streamId) ?? {},
+      missingOutputs: this.missingOutputs.get(streamId) ?? {},
+      compileFailures: this.compileFailures.get(streamId) ?? {},
       usage: this.usage.get(streamId) ?? new Map(),
       usageUnparsed: this.usageUnparsed.get(streamId) ?? new Map(),
       workPlan: this.getWorkPlan(streamId),
@@ -1181,7 +1182,7 @@ export class StreamSnapshotStore {
    */
   async readOutputFiles(
     streamId: StreamTabId,
-  ): Promise<Map<number, OutputFileInfo[]>> {
+  ): Promise<RoundIndexed<OutputFileInfo>> {
     const seedChain = this.seedChains.get(streamId);
     if (seedChain) {
       await seedChain;
@@ -1411,13 +1412,13 @@ export class StreamSnapshotStore {
           if (this.usage.has(stream)) this.writeUsage(stream);
           break;
         case STREAM_DATA_KEYS.MISSING_OUTPUTS: {
-          const map = this.missingOutputs.get(stream);
-          if (map) this.write(stream, key, mapToRecord(map));
+          const rounds = this.missingOutputs.get(stream);
+          if (rounds) this.write(stream, key, { ...rounds });
           break;
         }
         case STREAM_DATA_KEYS.COMPILE_FAILURES: {
-          const map = this.compileFailures.get(stream);
-          if (map) this.write(stream, key, mapToRecord(map));
+          const rounds = this.compileFailures.get(stream);
+          if (rounds) this.write(stream, key, { ...rounds });
           break;
         }
       }

--- a/src/transcript/streamSnapshotRead.ts
+++ b/src/transcript/streamSnapshotRead.ts
@@ -3,9 +3,10 @@
  *
  * Split out of `StreamSnapshotStore` so the (stateless) read/assembly is
  * separate from the (stateful) accumulate/write side. Reads every sidecar file
- * ONCE into canonical (flat) Maps; `StreamSnapshotStore.load()` seeds its
- * in-memory accumulators from this directly, and persists any legacy-flattened
- * files once (see `legacyKeys`) so the conversion never re-runs.
+ * ONCE into canonical round-indexed records; `StreamSnapshotStore.load()`
+ * seeds its in-memory accumulators from this directly, and persists any
+ * legacy-flattened files once (see `legacyKeys`) so the conversion never
+ * re-runs.
  */
 
 import { z } from 'zod';
@@ -13,22 +14,21 @@ import { z } from 'zod';
 import { KVStore } from '@common/storage/KVStore';
 import * as logger from '@logger/logUtils';
 import {
-  CompileFailuresDataSchema,
+  CompileFailureSchema,
   ExecutionIdSchema,
   LegacyInstructionsDataSchema,
-  MissingOutputsDataSchema,
-  OutputFilesDataSchema,
+  OutputFileInfoSchema,
+  parsePersistedRoundIndexed,
   parseUsageData,
   PersistedWorkPlanSchema,
   STREAM_SNAPSHOT_SCHEMA_VERSION,
   StreamSnapshotSchema,
   StreamTabMetaSchema,
-  flattenLegacyRuns,
-  isLegacyNested,
   selectPreferredLegacyInstruction,
   type CompileFailure,
   type LegacyInstructionEntry,
   type OutputFileInfo,
+  type RoundIndexed,
   type StreamSnapshot,
   type StreamTabId,
   type StreamTabMeta,
@@ -55,9 +55,9 @@ export const EMPTY_WORK_PLAN = Object.freeze({
 /** Per-stream sidecar data read from disk, flattened to canonical (flat) form. */
 export interface StreamData {
   meta: StreamTabMeta | undefined;
-  outputFiles: Map<number, OutputFileInfo[]>;
-  missingOutputs: Map<number, string[]>;
-  compileFailures: Map<number, CompileFailure[]>;
+  outputFiles: RoundIndexed<OutputFileInfo>;
+  missingOutputs: RoundIndexed<string>;
+  compileFailures: RoundIndexed<CompileFailure>;
   usage: Map<string, TokenUsageStats>;
   /**
    * Raw per-run usage values that failed to parse, keyed by runId and
@@ -163,40 +163,26 @@ export async function readStreamData(kv: KVStore): Promise<StreamData> {
   const activeRunId = meta?.activeRunId ?? undefined;
   const legacyKeys: string[] = [];
 
-  const flatten = async <T extends Map<number, unknown[]>>(
+  // Legacy nested `{ runId: { round } }` files are absorbed inside the single
+  // canonical parse entry; only the "rewrite it flat once" signal surfaces.
+  const readRoundIndexed = async <T>(
     key: string,
-    schema: z.ZodType<T>,
-    fallback: () => T,
-  ): Promise<T> => {
-    const raw = await tryRead(kv, key);
-    if (raw === undefined) return fallback();
-    const wasLegacy = isLegacyNested(raw);
-    if (wasLegacy) legacyKeys.push(key);
-    return (
-      schema
-        .nullable()
-        .catch(null)
-        .parse(wasLegacy ? flattenLegacyRuns(raw, activeRunId) : raw) ??
-      fallback()
+    itemSchema: z.ZodType<T>,
+  ): Promise<RoundIndexed<T>> => {
+    const { rounds, wasLegacy } = parsePersistedRoundIndexed(
+      key,
+      await tryRead(kv, key),
+      itemSchema,
+      activeRunId,
     );
+    if (wasLegacy) legacyKeys.push(key);
+    return rounds;
   };
 
   const [outputFiles, missingOutputs, compileFailures] = await Promise.all([
-    flatten(
-      STREAM_DATA_KEYS.OUTPUT_FILES,
-      OutputFilesDataSchema,
-      () => new Map<number, OutputFileInfo[]>(),
-    ),
-    flatten(
-      STREAM_DATA_KEYS.MISSING_OUTPUTS,
-      MissingOutputsDataSchema,
-      () => new Map<number, string[]>(),
-    ),
-    flatten(
-      STREAM_DATA_KEYS.COMPILE_FAILURES,
-      CompileFailuresDataSchema,
-      () => new Map<number, CompileFailure[]>(),
-    ),
+    readRoundIndexed(STREAM_DATA_KEYS.OUTPUT_FILES, OutputFileInfoSchema),
+    readRoundIndexed(STREAM_DATA_KEYS.MISSING_OUTPUTS, z.string()),
+    readRoundIndexed(STREAM_DATA_KEYS.COMPILE_FAILURES, CompileFailureSchema),
   ]);
 
   const usageRaw = await tryRead(kv, STREAM_DATA_KEYS.USAGE_STATS);
@@ -232,9 +218,9 @@ export function assembleSnapshot(
       todos: data.workPlan.todos,
       plan: data.workPlan.plan,
       planSummary: data.workPlan.planSummary,
-      outputFilesByRound: mapToRecord(data.outputFiles),
-      missingOutputsByRound: mapToRecord(data.missingOutputs),
-      compileFailuresByRound: mapToRecord(data.compileFailures),
+      outputFilesByRound: data.outputFiles,
+      missingOutputsByRound: data.missingOutputs,
+      compileFailuresByRound: data.compileFailures,
       runUsage: mapToRecord(data.usage),
       executionId: data.meta?.executionId,
       parentStreamId: data.meta?.parentStreamId,


### PR DESCRIPTION
## Summary

Converges round-indexed workflow data onto one canonical representation owned by `src/shared/schemas/roundIndexed.ts`.

The PR removes the former mix of record, `Map<number, T[]>`, legacy run-nested sidecars, and tuple-array command payloads for output files, missing outputs, and compile failures. Persisted legacy shapes now enter through a single parser and live state stays in the canonical record shape through transcript storage, progress controllers, latexdiff, and desktop file actions.

## Issue acceptance gates

Addresses #7425.

- Identifies the incompatible round-indexed shapes and keeps only the genuinely distinct `RoundOutput[]` aggregate separate.
- Adds the canonical `RoundIndexed<T>` owner, schema factory, persisted parser, entries helper, clone helper, and shared round-number/key schemas.
- Deletes the ad hoc `Map` conversion pipeline, per-domain sidecar schemas, legacy nested flatten helpers, tuple-array latexdiff validator, and several record/map round trips.
- Keeps persisted-data compatibility through explicit legacy read arms with regression coverage.
- Adds regression coverage for non-negative integer round-key validation, scientific-notation key handling, legacy persisted reads, and clone isolation.

## Single source of truth

`src/shared/schemas/roundIndexed.ts` now owns the round-indexed container type, round-key/round-number validation, canonical record schema, persisted legacy parser, ordered entries helper, and clone helper.

## Duplication and abstraction budget

Removed duplicated round-indexed representations instead of adding a pass-through layer. The new owner module is a deep schema boundary: it centralizes the persistence compatibility arms and the round-key invariant that downstream ordering relies on.

Net size is positive because the new module carries the canonical schema, parser, invariant helpers, and focused tests; the old scattered conversion paths and per-domain schema constants were deleted.

## Host impact

Extension: progress-view controllers and backend events now consume canonical round-indexed records directly; UI behavior and display ordering remain equivalent.

Desktop: desktop progress/file actions now receive canonical records instead of tuple arrays or map-derived records; behavior is equivalent.

CLI: no public `texra run`, `--print`, or `--output-format json` output change. The latexdiff command payload shape changed only on the internal producer/consumer boundary updated in this PR.

## Scheduled refactoring

#6981 ledger row added for the two retained legacy read arms: `parsePersistedRoundIndexed()`'s run-nested arm and `parseRoundFromLabel()` in `diffResult.ts`, with D3 retirement on 2026-08-04.

## Validation

Latest local validation on `origin/main` `1917867e`:

- `git diff --name-only origin/main...HEAD | xargs corepack pnpm exec prettier --write`
- `npm run typecheck`
- `npm test` (601 files passed, 1 skipped; 5198 tests passed, 4 skipped)
- `git diff --check`

Closes #7425
