### PR TITLE
refactor(runtime): project stream status through session facts

### DIFF
--- a/packages/extension/src/commands/agent/followUpCommand.ts
+++ b/packages/extension/src/commands/agent/followUpCommand.ts
@@ -10,6 +10,7 @@ import {
 } from '@agent/followUp/ToolUseFollowUp';
 import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import { shouldProbePersistedFlowForFollowUp } from '@agent/runtime/followUpResumeDetection';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { registerCommands } from '@commands/_shared/registerCommands';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
@@ -52,7 +53,7 @@ async function lazyDetectWaitingStatus(
         streamId,
         'restart-repair',
         {
-          runtimeHost: extensionAgentRuntimeHost,
+          events: defaultSession().events,
         },
       );
       if (repaired) {

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -254,7 +254,7 @@ export abstract class RetryableInvocationNode<
     error: Error,
   ): Promise<ManualRetryPromptResult> {
     const { logger, streamStatus } = this.services;
-    const { runtimeHost, session, streamId } = useLaunchRunContext();
+    const { session, streamId } = useLaunchRunContext();
     const operationName = this.getOperationName();
     const formatted = normalizeProviderError(error);
 
@@ -265,7 +265,6 @@ export abstract class RetryableInvocationNode<
     logErrorData(logger, `${operationName} failed`, formatted);
 
     streamStatus.transition(streamId, STREAM_PHASE.WAITING, 'wait', {
-      runtimeHost,
       trace: logger,
     });
     logger.debug('Waiting for manual retry', {
@@ -286,7 +285,6 @@ export abstract class RetryableInvocationNode<
     if (result.action === 'retry') {
       logger.debug('Manual retry triggered');
       streamStatus.transition(streamId, STREAM_PHASE.RUNNING, 'resume', {
-        runtimeHost,
         trace: logger,
       });
       return { shouldRetry: true, userCancelled: false };
@@ -305,7 +303,6 @@ export abstract class RetryableInvocationNode<
         result.reason ?? 'Retry denied (no human input available)',
       );
       streamStatus.transition(streamId, STREAM_PHASE.RUNNING, 'resume', {
-        runtimeHost,
         trace: logger,
       });
       return { shouldRetry: false, userCancelled: false };
@@ -317,7 +314,6 @@ export abstract class RetryableInvocationNode<
         : 'Retry cancelled by user';
     logProgressStatus(logger, message);
     streamStatus.transition(streamId, STREAM_PHASE.CANCELLED, 'user-stop', {
-      runtimeHost,
       trace: logger,
     });
     return { shouldRetry: false, userCancelled: true };

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -1,6 +1,6 @@
-import { maybeBuildGoalContinuation } from '@agent/goal/maybeBuildGoalContinuation';
 import { Node } from '@agent/node';
 import { logUserMessage } from '@agent/trace';
+import { maybeBuildGoalContinuation } from '@agent/goal/maybeBuildGoalContinuation';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { useLaunchRunContext } from '@agent/runtime/RunContext';
 import { emitRunFact } from '@agent/runtime/runFactEvents';
@@ -123,7 +123,6 @@ export class ToolUseWaitNode<C> extends Node<
       !this.services.stopAfterCycle;
     if (shouldSuspendNativeSubagent && !session.hasQueuedFollowUp()) {
       streamStatus.transitionToWaiting(streamId, 'wait', {
-        runtimeHost,
         trace: this.services.logger,
       });
       return { kind: 'waiting' };
@@ -151,7 +150,6 @@ export class ToolUseWaitNode<C> extends Node<
 
     if (!session.hasQueuedFollowUp()) {
       streamStatus.transitionToWaiting(streamId, 'wait', {
-        runtimeHost,
         trace: this.services.logger,
       });
     }
@@ -208,7 +206,6 @@ export class ToolUseWaitNode<C> extends Node<
     }
 
     streamStatus.transition(streamId, STREAM_PHASE.RUNNING, 'resume', {
-      runtimeHost,
       trace: logger,
     });
 

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -53,8 +53,8 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 import type { AgentSource } from '@shared/schemas/agent';
-import { toErrorMessage } from '@utils/errors/errorMessage';
 import { generateExecutionId } from '@utils/core';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import {
   createRunContext,
@@ -486,12 +486,12 @@ async function assembleAgentLaunchContext(
 function acquireStreamOrThrow(
   streamId: StreamTabId,
   streamStatus: StreamStatusMachine,
-  runtimeHost: AgentRuntimeHost,
+  session: SessionHandle,
   taskType: string = 'Task',
 ): void {
   if (
     streamStatus.tryAcquire(streamId, {
-      runtimeHost,
+      events: session.events,
     })
   ) {
     return;
@@ -525,7 +525,7 @@ function compensateFailedActivation(args: {
   reservedStreamId?: StreamTabId;
   activatedStreamId?: StreamTabId;
   streamStatus: StreamStatusMachine;
-  runtimeHost: AgentRuntimeHost;
+  session: SessionHandle;
   err: unknown;
   // The run-trace from assembleAgentLaunchContext when it was created before the
   // throw. Reused for the error log so we don't allocate a second one; outer
@@ -537,7 +537,7 @@ function compensateFailedActivation(args: {
     reservedStreamId,
     activatedStreamId,
     streamStatus,
-    runtimeHost,
+    session,
     err,
     runTrace,
   } = args;
@@ -559,8 +559,8 @@ function compensateFailedActivation(args: {
         activatedStreamId,
         STREAM_PHASE.FAILED,
         {
-          runtimeHost,
           trace: runTrace?.trace,
+          ...(runTrace ? {} : { events: session.events }),
         },
       )
     ) {
@@ -576,7 +576,7 @@ function compensateFailedActivation(args: {
 
   if (reservedStreamId) {
     streamStatus.releaseIfReserved(reservedStreamId, {
-      runtimeHost,
+      events: session.events,
     });
   }
 }
@@ -610,7 +610,7 @@ export async function buildAgentLaunchContext(
     acquireStreamOrThrow(
       reservedStreamId,
       streamStatus,
-      runtimeHost,
+      launchSession,
       input.taskType,
     );
   }
@@ -641,7 +641,7 @@ export async function buildAgentLaunchContext(
       reservedStreamId,
       activatedStreamId,
       streamStatus,
-      runtimeHost,
+      session: launchSession,
       err,
       runTrace,
     });

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -174,7 +174,6 @@ export async function finalizeRunTerminal(
     params.executions.untrack(handle.executionId);
     if (
       !params.streamStatus.transitionToTerminal(handle.childStreamId, outcome, {
-        runtimeHost: handle.runtimeHost,
         trace: handle.trace,
       })
     ) {
@@ -196,7 +195,6 @@ export async function finalizeRunTerminal(
 
 function transitionRunStart(ctx: AgentLaunchContext): void {
   const options = {
-    runtimeHost: ctx.runtimeHost,
     trace: ctx.logger,
   };
   if (

--- a/src/agent/runtime/SessionEventHub.ts
+++ b/src/agent/runtime/SessionEventHub.ts
@@ -11,6 +11,7 @@ import type {
   StreamTabId,
   UpdateQueuedFollowUpsPayload,
   UpdateStreamDescriptionPayload,
+  UpdateStreamStatusPayload,
 } from '@shared/schemas';
 
 const logger = createChannelTrace('SessionEventHub');
@@ -45,6 +46,10 @@ export type SessionFact =
   | {
       readonly type: 'updateStreamDescription';
       readonly payload: UpdateStreamDescriptionPayload;
+    }
+  | {
+      readonly type: 'updateStreamStatus';
+      readonly payload: UpdateStreamStatusPayload;
     }
   | {
       readonly type: 'setParentStream';

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -1,5 +1,5 @@
 import type { AgentTrace, StatusEvent } from '@agent/trace';
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import {
   canAcquireStreamReservation,
   canTransitionStreamPhase,
@@ -25,7 +25,7 @@ export interface StreamStatusChange {
 }
 
 export interface StreamStatusEmitOptions {
-  runtimeHost?: AgentRuntimeHost;
+  events?: SessionEventHub;
   trace?: AgentTrace;
   substate?: StreamSubstate;
 }
@@ -306,7 +306,15 @@ export class StreamStatusMachine {
     options.trace?.emit(event);
 
     const change = projectStatusEvent(event);
-    options.runtimeHost?.emit('updateStreamStatus', change);
+    if (!options.trace && options.events) {
+      options.events.emit({
+        scope: 'session',
+        event: {
+          type: 'updateStreamStatus',
+          payload: change,
+        },
+      });
+    }
     for (const listener of this.statusListeners) {
       listener(change);
     }

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -10,6 +10,7 @@ import type { ResultEvent } from '@agent/trace';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
   StreamStatusService,
+  type StreamStatusEmitOptions,
   type StreamStatusMachine,
 } from '@agent/runtime/StreamStatusService';
 import {
@@ -265,10 +266,7 @@ export class ExecutionRegistry {
         handle.childStreamId,
         options.status,
         'lifecycle',
-        {
-          runtimeHost: handle.runtimeHost,
-          trace: handle.trace,
-        },
+        this.streamStatusEmitOptions(handle),
       );
     }
     this.track(handle);
@@ -291,10 +289,12 @@ export class ExecutionRegistry {
         : status === STREAM_PHASE.RUNNING && previous === STREAM_PHASE.WAITING
           ? 'resume'
           : 'lifecycle';
-    return this.streamStatus.transition(handle.childStreamId, status, cause, {
-      runtimeHost: handle.runtimeHost,
-      trace: handle.trace,
-    });
+    return this.streamStatus.transition(
+      handle.childStreamId,
+      status,
+      cause,
+      this.streamStatusEmitOptions(handle),
+    );
   }
 
   /** Remove an execution handle and notify waiters. */
@@ -628,7 +628,7 @@ export class ExecutionRegistry {
       STREAM_PHASE.CANCELLED,
       'user-stop',
       {
-        runtimeHost,
+        ...(this.events ? { events: this.events } : {}),
       },
     );
     return { kind: 'marked_stopped', streamId, childPolicy };
@@ -810,10 +810,7 @@ export class ExecutionRegistry {
           handle.childStreamId,
           STREAM_PHASE.CANCELLED,
           'user-stop',
-          {
-            runtimeHost: handle.runtimeHost,
-            trace: handle.trace,
-          },
+          this.streamStatusEmitOptions(handle),
         );
         return true;
       }
@@ -914,12 +911,16 @@ export class ExecutionRegistry {
       handle.childStreamId,
       STREAM_PHASE.CANCELLED,
       'user-stop',
-      {
-        runtimeHost: handle.runtimeHost,
-        trace: handle.trace,
-      },
+      this.streamStatusEmitOptions(handle),
     );
     return true;
+  }
+
+  private streamStatusEmitOptions(
+    handle: AgentExecutionHandle,
+  ): StreamStatusEmitOptions {
+    if (handle.trace) return { trace: handle.trace };
+    return this.events ? { events: this.events } : {};
   }
 
   private interruptRegisteredStream(
@@ -935,7 +936,7 @@ export class ExecutionRegistry {
         STREAM_PHASE.CANCELLED,
         'user-stop',
         {
-          runtimeHost,
+          ...(this.events ? { events: this.events } : {}),
         },
       );
     }

--- a/src/agent/runtime/hostProgressEvents.ts
+++ b/src/agent/runtime/hostProgressEvents.ts
@@ -19,8 +19,6 @@ import type {
   SetActiveStreamPayload,
   SetParentStreamPayload,
   ShowAgentConfigBannerPayload,
-  StreamPhase,
-  StreamSubstate,
   StreamTabId,
   ToolEditPermission,
   UpdateActiveProcessesPayload,
@@ -32,6 +30,7 @@ import type {
   UpdateQueuedFollowUpsPayload,
   UpdateRoundStagePayload,
   UpdateStreamDescriptionPayload,
+  UpdateStreamStatusPayload,
   UpdateStreamUsagePayload,
   UpdateTodosPayload,
   UserQuestionPermission,
@@ -59,14 +58,7 @@ import type {
 export interface ProgressEventPayloads {
   // ── Run/stream progress ──
   setActiveStream: SetActiveStreamPayload;
-  updateStreamStatus: {
-    streamId: StreamTabId;
-    status: StreamPhase;
-    /** Previous phase before this update, for detecting transitions. */
-    previousStatus?: StreamPhase;
-    /** Narrower in-flight display state for launch/resume overlays. */
-    substate?: StreamSubstate;
-  };
+  updateStreamStatus: UpdateStreamStatusPayload;
   addOutputFiles: AddOutputFilesPayload;
   updateMissingOutputs: UpdateMissingOutputsPayload;
   updateCompileFailures: UpdateCompileFailuresPayload;

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -79,7 +79,7 @@ export async function resumeQueuedToolUseSnapshot(
 
   followUpsQueue.acquire(streamId);
   streamStatus.transition(streamId, STREAM_PHASE.RUNNING, 'resume', {
-    runtimeHost,
+    events: session.events,
     substate: STREAM_SUBSTATE.RESUMING,
   });
 
@@ -125,7 +125,7 @@ export async function resumeQueuedToolUseSnapshot(
     // error so a blocking host dialog cannot hold the stream in RESUMING.
     if (streamStatus.getSubstate(streamId) === STREAM_SUBSTATE.RESUMING) {
       streamStatus.transition(streamId, STREAM_PHASE.WAITING, 'wait', {
-        runtimeHost,
+        events: session.events,
       });
     }
   }

--- a/src/agent/runtime/sessionProgressEventProjection.ts
+++ b/src/agent/runtime/sessionProgressEventProjection.ts
@@ -106,6 +106,8 @@ export function projectSessionFactToProgressEvent(
       return { event: 'setActiveStream', payload: fact.payload };
     case 'updateStreamDescription':
       return { event: 'updateStreamDescription', payload: fact.payload };
+    case 'updateStreamStatus':
+      return { event: 'updateStreamStatus', payload: fact.payload };
     case 'setParentStream':
       return { event: 'setParentStream', payload: fact.payload };
   }
@@ -127,6 +129,19 @@ export function projectRunFactToProgressEvent(
         streamId: event.streamId,
         executionId: event.executionId,
         taskState: agentConfigToTaskState(event.config),
+      },
+    };
+  }
+
+  if (event.type === 'status') {
+    return {
+      event: 'updateStreamStatus',
+      payload: {
+        streamId: event.streamId,
+        status: event.phase,
+        cause: event.cause,
+        ...(event.previousPhase ? { previousStatus: event.previousPhase } : {}),
+        ...(event.substate ? { substate: event.substate } : {}),
       },
     };
   }
@@ -196,6 +211,7 @@ const RUN_FACT_PROGRESS_EVENT_TYPES: readonly AgentEvent['type'][] = [
   'domain',
   'run.config',
   'usage',
+  'status',
   'stage.start',
   'child.activity',
   'process.output',

--- a/src/shared/schemas/progressEvents.ts
+++ b/src/shared/schemas/progressEvents.ts
@@ -7,6 +7,7 @@ import type {
   RoundIndexed,
 } from './output';
 import type { ActiveChildInfo, RoundStage } from './streamState';
+import type { StreamPhase, StreamSubstate } from './stream';
 import type { TokenUsageStats } from './usage';
 
 /**
@@ -46,6 +47,17 @@ export interface UpdateStreamDescriptionPayload {
 export interface SetParentStreamPayload {
   childStreamId: StreamTabId;
   parentStreamId: StreamTabId | null;
+}
+
+export interface UpdateStreamStatusPayload {
+  streamId: StreamTabId;
+  status: StreamPhase;
+  /** Diagnostic transition cause retained for legacy host/public output. */
+  cause?: string;
+  /** Previous phase before this update, for detecting transitions. */
+  previousStatus?: StreamPhase;
+  /** Narrower in-flight display state for launch/resume overlays. */
+  substate?: StreamSubstate;
 }
 
 export interface AddOutputFilesPayload extends StreamScopedPayload {

--- a/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
@@ -290,12 +290,18 @@ describe('child stream progress events', () => {
     expect(handle).toBeDefined();
     active.events.splice(0);
 
-    childStream.waitForInput();
-    childStream.beginTurn();
-    childStream.failTurn();
-    await withSessionProgressProjection(active.host, () =>
-      childStream.finalize({ failed: true }),
+    const detach = attachSessionProgressEventProjectionForTest(
+      defaultSession().events,
+      active.host,
     );
+    try {
+      childStream.waitForInput();
+      childStream.beginTurn();
+      childStream.failTurn();
+      await childStream.finalize({ failed: true });
+    } finally {
+      detach();
+    }
 
     const statusEvents = active.events.filter(
       (entry) => entry.event === 'updateStreamStatus',

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -814,11 +814,23 @@ describe('ToolUseWaitNode', () => {
     const streamId = 'wait-node-retry-cancelled-wait' as StreamTabId;
     const streamStatus = new StreamStatusMachine();
     const runtimeHost = { emit: vi.fn() };
+    const logger = Object.assign(new TraceEmitter(), {
+      error: vi.fn(),
+      info: vi.fn(),
+    });
+    const events = new SessionEventHub();
+    const detachProjection = attachSessionProgressEventProjectionForTest(
+      events,
+      runtimeHost,
+    );
+    const detachTrace = logger.subscribe((event) => {
+      events.emit({ scope: 'run', streamId, event });
+    });
     const waitForFollowUp = vi.fn(async () => null);
     const services = {
       checkInterruption: () => false,
       isSubagent: false,
-      logger: { emit: vi.fn(), error: vi.fn(), info: vi.fn() },
+      logger,
       modelHandler: { extractAssistantText: () => undefined },
       runtimeHost,
       session: {
@@ -862,6 +874,8 @@ describe('ToolUseWaitNode', () => {
         }),
       );
     } finally {
+      detachTrace();
+      detachProjection();
       clearStreamStatusForTest(streamStatus, streamId);
     }
   });
@@ -880,10 +894,23 @@ describe('ToolUseWaitNode', () => {
     );
     const info = vi.fn();
     const runtimeHost = { emit: vi.fn() };
+    const streamId = 'test-stream' as StreamTabId;
+    const logger = Object.assign(new TraceEmitter(), {
+      error: vi.fn(),
+      info,
+    });
+    const events = new SessionEventHub();
+    const detachProjection = attachSessionProgressEventProjectionForTest(
+      events,
+      runtimeHost,
+    );
+    const detachTrace = logger.subscribe((event) => {
+      events.emit({ scope: 'run', streamId, event });
+    });
     const streamStatus = new StreamStatusMachine();
     const services = {
       checkInterruption: () => false,
-      logger: { emit: vi.fn(), error: vi.fn(), info },
+      logger,
       modelHandler: {
         capabilities: { supportsVision: true },
         createUserFollowUpMessages,
@@ -907,33 +934,34 @@ describe('ToolUseWaitNode', () => {
         }),
       },
       streamStatus,
-      streamId: 'test-stream',
+      streamId,
     } as unknown as ToolUseServices;
     const node = new ToolUseWaitNode().setServices(services);
-    seedStreamStatusForTest(
-      streamStatus,
-      'test-stream' as StreamTabId,
-      STREAM_PHASE.WAITING,
-    );
+    seedStreamStatusForTest(streamStatus, streamId, STREAM_PHASE.WAITING);
 
     const prep = await node.prep(shared);
-    const transition = await withTestRunContext(
-      runtimeHost,
-      'test-stream',
-      async () => {
-        const exec = await node.exec(prep);
-        return node.post(shared, prep, exec);
-      },
-    );
+    try {
+      const transition = await withTestRunContext(
+        runtimeHost,
+        streamId,
+        async () => {
+          const exec = await node.exec(prep);
+          return node.post(shared, prep, exec);
+        },
+      );
 
-    expect(transition).toBe(FlowTransition.CONTINUE);
-    expect(runtimeHost.emit).toHaveBeenCalledWith(
-      'updateStreamStatus',
-      expect.objectContaining({ status: STREAM_STATUS.RUNNING }),
-    );
-    expect(runtimeHost.emit.mock.invocationCallOrder[0]).toBeLessThan(
-      info.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
-    );
+      expect(transition).toBe(FlowTransition.CONTINUE);
+      expect(runtimeHost.emit).toHaveBeenCalledWith(
+        'updateStreamStatus',
+        expect.objectContaining({ status: STREAM_STATUS.RUNNING }),
+      );
+      expect(runtimeHost.emit.mock.invocationCallOrder[0]).toBeLessThan(
+        info.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+      );
+    } finally {
+      detachTrace();
+      detachProjection();
+    }
     expect(createUserFollowUpMessages).toHaveBeenNthCalledWith(
       1,
       [],

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -12,6 +12,7 @@ import {
 } from '@agent/runtime/executionRegistry';
 import { InterruptRegistry } from '@agent/runtime/InterruptRegistry';
 import { ProcessOutputPoller } from '@agent/runtime/ProcessOutputPoller';
+import { attachSessionProgressEventProjection } from '@agent/runtime/sessionProgressEventProjection';
 import {
   SessionEventHub,
   type SessionEvent,
@@ -322,7 +323,13 @@ describe('executionRegistry', () => {
     const explicit = createRecordingHost();
     const interrupts = new InterruptRegistry();
     const streamStatus = new StreamStatusMachine();
-    const registry = new ExecutionRegistry({ interrupts, streamStatus });
+    const events = new SessionEventHub();
+    attachSessionProgressEventProjection(events, explicit.host);
+    const registry = new ExecutionRegistry({
+      interrupts,
+      streamStatus,
+      events,
+    });
     const rootStreamId = 'root-stop-policy-test' as StreamTabId;
     const childStreamId = 'child-stop-policy-test' as StreamTabId;
     const rootInterrupt = vi.fn();
@@ -591,7 +598,13 @@ describe('executionRegistry', () => {
     const explicit = createRecordingHost();
     const interrupts = new InterruptRegistry();
     const streamStatus = new StreamStatusMachine();
-    const registry = new ExecutionRegistry({ interrupts, streamStatus });
+    const events = new SessionEventHub();
+    attachSessionProgressEventProjection(events, explicit.host);
+    const registry = new ExecutionRegistry({
+      interrupts,
+      streamStatus,
+      events,
+    });
     const streamId = 'untracked-stop-policy-test' as StreamTabId;
     const interrupt = vi.fn();
 
@@ -621,7 +634,9 @@ describe('executionRegistry', () => {
   it('marks an ownerless stream stopped when a host can publish status', () => {
     const explicit = createRecordingHost();
     const streamStatus = new StreamStatusMachine();
-    const registry = new ExecutionRegistry({ streamStatus });
+    const events = new SessionEventHub();
+    attachSessionProgressEventProjection(events, explicit.host);
+    const registry = new ExecutionRegistry({ streamStatus, events });
     const streamId = 'ownerless-stop-policy-test' as StreamTabId;
 
     try {
@@ -1212,9 +1227,6 @@ describe('executionRegistry', () => {
       childStreamId,
       STREAM_PHASE.WAITING,
       'restart-repair',
-      {
-        runtimeHost: explicit.host,
-      },
     );
 
     expect(

--- a/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
+++ b/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
@@ -4,6 +4,8 @@ import { describe, expect, it } from 'vitest';
 // Local imports
 import { seedStreamStatusForTest } from '@test/helpers/streamStatusTestUtils';
 import { TraceEmitter, type StatusEvent } from '@agent/trace';
+import { attachSessionProgressEventProjection } from '@agent/runtime/sessionProgressEventProjection';
+import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import {
   StreamStatusMachine,
   type StreamStatusChange,
@@ -27,11 +29,16 @@ import { createRecordingHost } from '../progressTestUtils';
 function setupMachine(streamId: string): {
   machine: StreamStatusMachine;
   explicit: ReturnType<typeof createRecordingHost>;
+  events: SessionEventHub;
   streamId: StreamTabId;
 } {
+  const events = new SessionEventHub();
+  const explicit = createRecordingHost();
+  attachSessionProgressEventProjection(events, explicit.host);
   return {
     machine: new StreamStatusMachine(),
-    explicit: createRecordingHost(),
+    explicit,
+    events,
     streamId: streamId as StreamTabId,
   };
 }
@@ -56,13 +63,15 @@ describe('StreamStatusMachine', () => {
   it('keeps listeners per instance', () => {
     const first = new StreamStatusMachine();
     const second = new StreamStatusMachine();
+    const events = new SessionEventHub();
     const explicit = createRecordingHost();
+    attachSessionProgressEventProjection(events, explicit.host);
     const streamId = 'stream-status-listener-test' as StreamTabId;
     const changes: string[] = [];
 
     first.onDidChange((change) => changes.push(change.streamId));
     second.transition(streamId, STREAM_PHASE.WAITING, 'restart-repair', {
-      runtimeHost: explicit.host,
+      events,
     });
 
     expect(changes).toEqual([]);
@@ -115,7 +124,7 @@ describe('StreamStatusMachine', () => {
   });
 
   it('repairs terminal streams to waiting through resume then wait', () => {
-    const { machine, explicit, streamId } = setupMachine(
+    const { machine, explicit, events, streamId } = setupMachine(
       'stream-status-terminal-waiting-repair',
     );
 
@@ -123,7 +132,7 @@ describe('StreamStatusMachine', () => {
 
     expect(
       machine.transitionToWaiting(streamId, 'restart-repair', {
-        runtimeHost: explicit.host,
+        events,
       }),
     ).toBe(true);
 
@@ -151,7 +160,7 @@ describe('StreamStatusMachine', () => {
   });
 
   it('terminalizes waiting streams through resume then lifecycle', () => {
-    const { machine, explicit, streamId } = setupMachine(
+    const { machine, explicit, events, streamId } = setupMachine(
       'stream-status-waiting-terminal-repair',
     );
 
@@ -159,7 +168,7 @@ describe('StreamStatusMachine', () => {
 
     expect(
       machine.transitionToTerminal(streamId, STREAM_PHASE.FAILED, {
-        runtimeHost: explicit.host,
+        events,
       }),
     ).toBe(true);
 
@@ -187,13 +196,13 @@ describe('StreamStatusMachine', () => {
   });
 
   it('terminalizes visible streams that were not started yet', () => {
-    const { machine, explicit, streamId } = setupMachine(
+    const { machine, explicit, events, streamId } = setupMachine(
       'stream-status-undefined-terminal-repair',
     );
 
     expect(
       machine.transitionToTerminal(streamId, STREAM_PHASE.FAILED, {
-        runtimeHost: explicit.host,
+        events,
       }),
     ).toBe(true);
 
@@ -220,7 +229,7 @@ describe('StreamStatusMachine', () => {
   });
 
   it('accepts already-matching terminal outcomes without warning callers', () => {
-    const { machine, explicit, streamId } = setupMachine(
+    const { machine, explicit, events, streamId } = setupMachine(
       'stream-status-matching-terminal',
     );
 
@@ -228,7 +237,7 @@ describe('StreamStatusMachine', () => {
 
     expect(
       machine.transitionToTerminal(streamId, STREAM_PHASE.CANCELLED, {
-        runtimeHost: explicit.host,
+        events,
       }),
     ).toBe(true);
 
@@ -237,7 +246,7 @@ describe('StreamStatusMachine', () => {
   });
 
   it('clears a transient running substate through the table-checked resume transition', () => {
-    const { machine, explicit, streamId } = setupMachine(
+    const { machine, explicit, events, streamId } = setupMachine(
       'stream-status-clear-running-substate',
     );
 
@@ -245,7 +254,7 @@ describe('StreamStatusMachine', () => {
 
     expect(
       machine.transition(streamId, STREAM_PHASE.RUNNING, 'resume', {
-        runtimeHost: explicit.host,
+        events,
       }),
     ).toBe(true);
 
@@ -265,7 +274,7 @@ describe('StreamStatusMachine', () => {
   });
 
   it('skips the write and publish for a no-op RUNNING resume with no substate to clear', () => {
-    const { machine, explicit, streamId } = setupMachine(
+    const { machine, explicit, events, streamId } = setupMachine(
       'stream-status-noop-running-resume',
     );
 
@@ -273,7 +282,7 @@ describe('StreamStatusMachine', () => {
 
     expect(
       machine.transition(streamId, STREAM_PHASE.RUNNING, 'resume', {
-        runtimeHost: explicit.host,
+        events,
       }),
     ).toBe(true);
 
@@ -306,14 +315,12 @@ describe('StreamStatusMachine', () => {
   });
 
   it('publishes rollback when a visible reservation is released', () => {
-    const { machine, explicit, streamId } = setupMachine(
+    const { machine, explicit, events, streamId } = setupMachine(
       'stream-status-reservation-rollback',
     );
 
-    expect(machine.tryAcquire(streamId, { runtimeHost: explicit.host })).toBe(
-      true,
-    );
-    machine.releaseIfReserved(streamId, { runtimeHost: explicit.host });
+    expect(machine.tryAcquire(streamId, { events })).toBe(true);
+    machine.releaseIfReserved(streamId, { events });
 
     expect(machine.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
     expect(explicit.events).toEqual([
@@ -339,25 +346,21 @@ describe('StreamStatusMachine', () => {
   });
 
   it('overlays reservations on stale terminal phases and restores them on rollback', () => {
-    const { machine, explicit, streamId } = setupMachine(
+    const { machine, explicit, events, streamId } = setupMachine(
       'stream-status-reservation-overlay',
     );
 
     seedStreamStatusForTest(machine, streamId, STREAM_PHASE.COMPLETED);
 
-    expect(machine.tryAcquire(streamId, { runtimeHost: explicit.host })).toBe(
-      true,
-    );
+    expect(machine.tryAcquire(streamId, { events })).toBe(true);
     expect(machine.get(streamId)).toBe(STREAM_PHASE.RUNNING);
     expect(
       machine.transition(streamId, STREAM_PHASE.RUNNING, 'lifecycle'),
     ).toBe(true);
 
     seedStreamStatusForTest(machine, streamId, STREAM_PHASE.COMPLETED);
-    expect(machine.tryAcquire(streamId, { runtimeHost: explicit.host })).toBe(
-      true,
-    );
-    machine.releaseIfReserved(streamId, { runtimeHost: explicit.host });
+    expect(machine.tryAcquire(streamId, { events })).toBe(true);
+    machine.releaseIfReserved(streamId, { events });
 
     expect(machine.get(streamId)).toBe(STREAM_PHASE.COMPLETED);
     expect(explicit.events.at(-1)).toEqual({
@@ -373,20 +376,23 @@ describe('StreamStatusMachine', () => {
 
   it('projects status trace events to updateStreamStatus payloads', () => {
     const machine = new StreamStatusMachine();
+    const events = new SessionEventHub();
     const explicit = createRecordingHost();
+    attachSessionProgressEventProjection(events, explicit.host);
     const trace = new TraceEmitter();
     const streamId = 'stream-status-projection-test' as StreamTabId;
     const statusEvents: StatusEvent[] = [];
     const changes: StreamStatusChange[] = [];
 
     trace.subscribe((event) => {
-      if (event.type === 'status') statusEvents.push(event);
+      if (event.type !== 'status') return;
+      statusEvents.push(event);
+      events.emit({ scope: 'run', streamId, event });
     });
     machine.onDidChange((change) => changes.push(change));
 
     expect(
       machine.transition(streamId, STREAM_PHASE.RUNNING, 'lifecycle', {
-        runtimeHost: explicit.host,
         trace,
       }),
     ).toBe(true);

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -195,9 +195,6 @@ describe('CLI conversation transcript splitting', () => {
         STREAM_ID,
         STREAM_PHASE.COMPLETED,
         'restart-repair',
-        {
-          runtimeHost: { emit: () => undefined },
-        },
       );
 
       expect(
@@ -227,14 +224,7 @@ describe('CLI conversation transcript splitting', () => {
     const dispose = subscribeStreamStatus();
 
     try {
-      StreamStatusService.transition(
-        STREAM_ID,
-        STREAM_PHASE.RUNNING,
-        'resume',
-        {
-          runtimeHost: { emit: () => undefined },
-        },
-      );
+      StreamStatusService.transition(STREAM_ID, STREAM_PHASE.RUNNING, 'resume');
 
       expect(streams.get().get(STREAM_ID)?.status).toBe(STREAM_STATUS.RUNNING);
     } finally {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -255,9 +255,6 @@ describe('cliState Phase 4 fields', () => {
         child1,
         STREAM_PHASE.FAILED,
         'restart-repair',
-        {
-          runtimeHost: wrapped,
-        },
       );
 
       const parent = streams.get().get(root);
@@ -1617,9 +1614,6 @@ describe('CLI TUI row allocation', () => {
         child1,
         STREAM_PHASE.RUNNING,
         'restart-repair',
-        {
-          runtimeHost: wrapped,
-        },
       );
 
       activeStreamId.set(child1);
@@ -1663,9 +1657,6 @@ describe('CLI TUI row allocation', () => {
         child1,
         STREAM_PHASE.CANCELLED,
         'restart-repair',
-        {
-          runtimeHost: wrapped,
-        },
       );
 
       activeStreamId.set(child1);


### PR DESCRIPTION
Part of #6968.

## Summary

- Moves `updateStreamStatus` publication off direct `runtimeHost.emit` in `StreamStatusMachine`.
- Adds a typed `UpdateStreamStatusPayload` and a session-fact arm for status changes.
- Projects run `status` trace events and session status facts back to the retained legacy `updateStreamStatus` host event for CLI/public-output and host compatibility.
- Updates run lifecycle, retry, resume, registry, and extension restart-repair paths to use either the run trace or the owning session event hub.

## Stage 5 invariant

- Production grep shows no direct `emit("updateStreamStatus")` / `runtimeHost.emit("updateStreamStatus")` call sites in `src/` or `packages/`.
- The retained host key remains in the frozen compatibility map and is projected from the session/run fact plane.
- Tests still synthesize `updateStreamStatus` where they are explicitly exercising legacy host consumers.

## Verification

- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `CI=true corepack pnpm exec vitest run src/test-kernel/agent/runtime/StreamStatusService.vitest.ts src/test-kernel/agent/runtime/SessionEventHub.vitest.ts src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts src/test-kernel/cli/RunProgressRenderer.vitest.mts src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts`
- `corepack pnpm exec eslint <changed files>`
- `corepack pnpm exec prettier --check <changed files>`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core stream lifecycle, resume, retry, and stop/kill paths; incorrect projection or missing `events`/`trace` could leave UIs with stale phase badges, though the dual-path design and broad test updates mitigate this.
> 
> **Overview**
> **Stage 5 runtime migration:** `updateStreamStatus` is no longer published by calling `runtimeHost.emit` from `StreamStatusMachine`. Status changes now go through the **session fact plane** (`SessionEventHub` `updateStreamStatus` arm) or the **run trace** (`status` events when a trace is present).
> 
> Adds a shared **`UpdateStreamStatusPayload`** type and wires **`sessionProgressEventProjection`** to re-emit the frozen legacy `updateStreamStatus` host event for CLI, extension, and public output consumers.
> 
> **Call-site updates:** launch/reservation/rollback (`AgentLaunchContext`), resume queue dance (`resumeQueuedToolUse`), extension restart-repair (`followUpCommand`), and execution-registry stop paths pass **`session.events`** instead of **`runtimeHost`**. In-flight runs with a trace rely on trace-only emission (projection handles host parity). **`ExecutionRegistry`** centralizes emit options via **`streamStatusEmitOptions`**.
> 
> Tests attach session progress projection where they assert legacy `updateStreamStatus` on a recording host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eaeb3869ee6c1f783b82325992f2c1e1c7c062af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->