### PR TITLE
refactor(model-handlers): fold supportsReasoningLevelOverride into a combinator

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -595,12 +595,14 @@ export abstract class ModelHandler<
    *
    * Runtime combinator (#7101 triage): `ModelHandlerDeepSeek` is only ever
    * constructed for `ModelProvider.DEEPSEEK` (see `ModelFactory.ts`'s
-   * `PROVIDER_HANDLER_ROUTES`), so `config.provider === DEEPSEEK` there is
-   * always true and this reduces to its former override exactly. For every
-   * other native handler, `config.provider` is never `DEEPSEEK`, so this
-   * reduces to the former plain `supportsReasoningEffort` default. And this
-   * is verified identical to `ModelHandlerOpenRouterNative`'s pre-existing
-   * override (which already gated on `config.provider === DEEPSEEK` since
+   * `PROVIDER_HANDLER_ROUTES`), so `config.provider === ModelProvider.DEEPSEEK`
+   * there is always true and this reduces to its former override exactly.
+   * For every other handler besides `ModelHandlerOpenRouterNative` — which
+   * gets its own paragraph below — `config.provider` is never
+   * `ModelProvider.DEEPSEEK`, so this reduces to the former plain
+   * `supportsReasoningEffort` default. And this is verified identical to
+   * `ModelHandlerOpenRouterNative`'s pre-existing override (which already
+   * gated on `config.provider === ModelProvider.DEEPSEEK` since
    * OpenRouterNative shares `config.provider` with the underlying model —
    * see that predicate's own #7101 note on `requiresPerCallSystemPrompt`).
    */

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -589,11 +589,27 @@ export abstract class ModelHandler<
 
   /**
    * Whether a user-set reasoning-level override applies to this handler.
-   * Defaults to the model's configurable-effort capability; handlers that honor
-   * a reasoning level without a granular effort flag override this getter.
+   * True for the model's configurable-effort capability, or for DeepSeek
+   * models (native or proxied via OpenRouter) that support reasoning without
+   * a granular effort flag.
+   *
+   * Runtime combinator (#7101 triage): `ModelHandlerDeepSeek` is only ever
+   * constructed for `ModelProvider.DEEPSEEK` (see `ModelFactory.ts`'s
+   * `PROVIDER_HANDLER_ROUTES`), so `config.provider === DEEPSEEK` there is
+   * always true and this reduces to its former override exactly. For every
+   * other native handler, `config.provider` is never `DEEPSEEK`, so this
+   * reduces to the former plain `supportsReasoningEffort` default. And this
+   * is verified identical to `ModelHandlerOpenRouterNative`'s pre-existing
+   * override (which already gated on `config.provider === DEEPSEEK` since
+   * OpenRouterNative shares `config.provider` with the underlying model —
+   * see that predicate's own #7101 note on `requiresPerCallSystemPrompt`).
    */
   get supportsReasoningLevelOverride(): boolean {
-    return this.capabilities.supportsReasoningEffort;
+    return (
+      this.capabilities.supportsReasoningEffort ||
+      (this.config.provider === ModelProvider.DEEPSEEK &&
+        this.capabilities.supportsReasoning)
+    );
   }
 
   /**

--- a/src/agent/modelHandlers/openai/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerDeepSeek.ts
@@ -46,17 +46,6 @@ export class ModelHandlerDeepSeek extends ReasoningModelHandlerOpenAI<DeepSeekTo
   }
 
   /**
-   * DeepSeek accepts a reasoning-level override whenever it supports reasoning,
-   * even though it doesn't expose a granular configurable-effort capability.
-   */
-  override get supportsReasoningLevelOverride(): boolean {
-    return (
-      this.capabilities.supportsReasoningEffort ||
-      this.capabilities.supportsReasoning
-    );
-  }
-
-  /**
    * DeepSeek expects string content format instead of array format.
    */
   protected override formatAssistantContent(text: string): string {

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -117,18 +117,6 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     );
   }
 
-  /**
-   * DeepSeek (proxied via OpenRouter) honors a reasoning-level override whenever
-   * it supports reasoning, even without a granular configurable-effort capability.
-   */
-  override get supportsReasoningLevelOverride(): boolean {
-    return (
-      this.capabilities.supportsReasoningEffort ||
-      (this.config.provider === ModelProvider.DEEPSEEK &&
-        this.capabilities.supportsReasoning)
-    );
-  }
-
   protected get usageProvider(): NormalizedUsage['provider'] {
     return 'openrouter';
   }

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenRouterNative.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenRouterNative.vitest.ts
@@ -110,6 +110,48 @@ describe('ModelHandlerOpenRouterNative system prompt placement', () => {
   );
 });
 
+describe('ModelHandlerOpenRouterNative reasoning-level override', () => {
+  it.each([
+    {
+      name: 'DeepSeek (via OpenRouter) with reasoning but no granular effort control',
+      provider: ModelProvider.DEEPSEEK,
+      supportsReasoning: true,
+      supportsReasoningEffort: false,
+      expected: true,
+    },
+    {
+      name: 'non-DeepSeek provider without granular effort control',
+      provider: ModelProvider.ANTHROPIC,
+      supportsReasoning: true,
+      supportsReasoningEffort: false,
+      expected: false,
+    },
+    {
+      name: 'any provider with granular effort control',
+      provider: ModelProvider.OPENAI,
+      supportsReasoning: false,
+      supportsReasoningEffort: true,
+      expected: true,
+    },
+  ])(
+    '$name',
+    ({ provider, supportsReasoning, supportsReasoningEffort, expected }) => {
+      const handler = new ModelHandlerOpenRouterNative(
+        buildConfig({
+          provider,
+          capabilities: {
+            ...DEFAULT_MODEL_CAPABILITIES,
+            supportsReasoning,
+            supportsReasoningEffort,
+          },
+        }),
+      );
+
+      assert.equal(handler.supportsReasoningLevelOverride, expected);
+    },
+  );
+});
+
 describe('ModelHandlerOpenRouterNative retry ownership', () => {
   it('matches the OpenRouter SDK retry boundary', () => {
     const handler = new ModelHandlerOpenRouterNative(buildConfig());


### PR DESCRIPTION
Part of #7101 (does not close it — remaining predicates are left for follow-up PRs). Next cluster: `supportsReasoningLevelOverride`.

## Why this predicate is safe to fold (unlike #7531's near-miss)

`supportsReasoningLevelOverride` had identical overrides in `ModelHandlerDeepSeek` and `ModelHandlerOpenRouterNative`:

```ts
capabilities.supportsReasoningEffort || (config.provider === DEEPSEEK && capabilities.supportsReasoning)
```

PR #7531 folded a predicate into a `config.provider` check and shipped a regression that Bugbot caught: `ModelHandlerOpenRouterNative` extends the base class directly, so a naive `config.provider` comparison can't reproduce a *class-identity* dispatch. This predicate doesn't have that problem, verified two ways:

- `ModelHandlerDeepSeek` is only ever constructed for `ModelProvider.DEEPSEEK` (`ModelFactory.ts`'s `PROVIDER_HANDLER_ROUTES`) — so within that class, `config.provider === DEEPSEEK` is always true, and the combined base formula reduces to exactly its former override.
- `ModelHandlerOpenRouterNative`'s own override was **already** gated on `config.provider === DEEPSEEK` — the fold reproduces its existing behavior verbatim, not a new inference about what OpenRouterNative "should" do.
- Every other native handler (Anthropic, Google, OpenAI, XAI, GLM, Kimi, MiniMax) never has `config.provider === DEEPSEEK`, so the fold reduces to the unchanged plain `capabilities.supportsReasoningEffort` default for all of them.

## Fix

- Moved the combined formula into the base getter (`ModelHandler.ts`), with a doc comment explaining the reduction argument above.
- Deleted both now-redundant subclass overrides (`modelHandlerDeepSeek.ts`, `modelHandlerOpenRouterNative.ts`).
- Added a parameterized regression test on `ModelHandlerOpenRouterNative` (`ModelHandlerOpenRouterNative.vitest.ts`) covering: DeepSeek-via-OpenRouter with reasoning but no granular effort control, a non-DeepSeek provider in the same shape, and a provider with granular effort control — closing the same class of coverage gap #7531 exposed, this time proactively.

## Verification

- `tsc --noEmit` (root) and `tsc --noEmit -p tsconfig.test-kernel.json` — clean.
- `vitest run src/test-kernel/agent/modelHandlers/` — 426/430 passing (4 pre-existing skips), including the existing `ModelFactoryRouting.vitest.ts` assertions on this predicate and the 3 new parameterized cases.
- `eslint` on all changed files — clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor of a capability predicate with explicit reduction arguments and new regression tests; no auth, data, or API surface changes.
> 
> **Overview**
> Part of **#7101**: consolidates duplicate `supportsReasoningLevelOverride` logic into the base **`ModelHandler`** getter instead of separate overrides on **`ModelHandlerDeepSeek`** and **`ModelHandlerOpenRouterNative`**.
> 
> The base implementation now returns **`supportsReasoningEffort`** or, for **`ModelProvider.DEEPSEEK`** with **`supportsReasoning`**, true—matching what both subclasses had before. Subclass getters are removed; the base doc comment records why this **`config.provider`** combinator is safe here (unlike the **#7531** class-identity pitfall).
> 
> Adds a parameterized **`ModelHandlerOpenRouterNative`** test suite for DeepSeek-via-OpenRouter, non-DeepSeek reasoning-without-effort, and granular-effort cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 292e0432d0a38677018a37956b92a9e2acbd35c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->