### PR TITLE
refactor(cli): persist snapshot metadata from session events

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -47,8 +47,8 @@ import {
   type ExecutionId,
   sumUsageStats,
 } from '@shared/schemas';
-import { toErrorMessage } from '@utils/errors/errorMessage';
 import { generateExecutionId } from '@utils/core';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { chatAgentSupportsDelegation } from './tui/commands/handlers/agentModelCommands';
 import { clearApprovals } from './tui/state/approvalQueue';
@@ -231,7 +231,7 @@ export function createChatSessionController(
     readonly finalize: () => void;
   } => {
     const runtimeHost = createCliRuntimeHost(sessionContext);
-    const wrapped = wrapRuntimeHost(runtimeHost, snapshotStore);
+    const wrapped = wrapRuntimeHost(runtimeHost);
     const detachHostInteractions = defaultSession().useHostInteractions(
       createTuiHostInteractions(wrapped, sessionContext),
     );

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -44,7 +44,6 @@ import { mergeChildStreams } from './childExecutions';
 import { appendCompletedProcessEntries } from './completedProcessTranscript';
 import { sumResumeUsageStats } from './resumeHint';
 import { appendLocalAssistantTranscript } from './transcript';
-import type { StreamSnapshotStore } from '@transcript';
 
 type Emit = <K extends ProgressEvent>(
   event: K,
@@ -385,22 +384,10 @@ function applyStreamMeta(
   );
 }
 
-export function wrapRuntimeHost(
-  host: CliRuntimeHost,
-  snapshotStore?: StreamSnapshotStore,
-): CliRuntimeHost {
+export function wrapRuntimeHost(host: CliRuntimeHost): CliRuntimeHost {
   const original = host.emit;
   const emit: Emit = (event, payload) => {
     applyToState(event, payload);
-    switch (event) {
-      case 'setTaskState':
-      case 'updateStreamDescription':
-      case 'setParentStream':
-        snapshotStore?.handleProgressEvent(event, payload);
-        break;
-      default:
-        break;
-    }
     return original(event, payload);
   };
   return { ...host, emit };

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -15,10 +15,6 @@ import {
 import { runAgent } from '@agent/runtime/runAgent';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
-import type {
-  ProgressEvent,
-  ProgressEventPayloads,
-} from '@agent/runtime/hostProgressEvents';
 import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core';
 
@@ -65,30 +61,6 @@ type ExecuteAgentResultForCategory<C extends AgentCategory | undefined> =
   C extends AgentCategory
     ? Extract<ExecuteAgentResult, { category: C }>
     : ExecuteAgentResult;
-
-function persistCliMetadataProgressEvents(
-  host: CliRuntimeHost,
-  snapshotStore: StreamSnapshotStore,
-): CliRuntimeHost {
-  const emit = <K extends ProgressEvent>(
-    event: K,
-    payload: ProgressEventPayloads[K],
-  ): void => {
-    // Durable run facts enter StreamSnapshotStore from SessionEventHub. Keep
-    // only the legacy metadata events here until they move to typed run facts.
-    switch (event) {
-      case 'setTaskState':
-      case 'updateStreamDescription':
-      case 'setParentStream':
-        snapshotStore.handleProgressEvent(event, payload);
-        break;
-      default:
-        break;
-    }
-    host.emit(event, payload);
-  };
-  return { ...host, emit };
-}
 
 export interface CliConfigExecuteOptions<
   C extends AgentCategory | undefined = undefined,
@@ -194,10 +166,7 @@ export async function executeCliRequest(
   const detachSnapshotEvents = snapshotStore.attachSessionEvents(
     defaultSession().events,
   );
-  const runtimeHost = persistCliMetadataProgressEvents(
-    baseRuntimeHost,
-    snapshotStore,
-  );
+  const runtimeHost = baseRuntimeHost;
   const detachHostInteractions = defaultSession().useHostInteractions(
     createHeadlessCliHostInteractions(runContext, {
       beforePrompt: () => runtimeHost.prepareInteractivePrompt?.(),

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -14,6 +14,7 @@ import type { CliContext } from '@cli/runtime/cliContext';
 import type { executeCliRequest } from '@cli/runtime/runExecution';
 import {
   EXECUTION_STATUS,
+  type ExecutionId,
   type StorageKey,
   type StreamTabId,
   type TodoItem,
@@ -58,7 +59,8 @@ vi.mock('@agent/runtime/runAgent', () => ({
   runAgent: mocks.runAgent,
 }));
 
-vi.mock('@agent/storage', () => ({
+vi.mock('@agent/storage', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@agent/storage')>()),
   writeTerminalStatus: mocks.writeTerminalStatus,
 }));
 
@@ -277,6 +279,8 @@ describe('executeCliRequest', () => {
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
     const request = baseRequest();
     const streamId = 'stream-1' as StreamTabId;
+    const parentStreamId = 'parent-stream' as StreamTabId;
+    const executionId = 'b1c2d3e4' as ExecutionId;
     const todo: TodoItem = {
       content: 'Write the introduction',
       status: 'in_progress',
@@ -284,9 +288,25 @@ describe('executeCliRequest', () => {
     };
 
     mocks.runAgent.mockImplementationOnce(async (_request, options) => {
+      const { getExecutionStore } = await import('@agent/storage');
+      const { AgentConfigSchema } =
+        await import('@agent/core/definition/AgentConfig');
       const { defaultSession } = await import('@agent/runtime/SessionHandle');
       const { toRunFactDomainKey } =
         await import('@agent/runtime/runFactEvents');
+      const config = AgentConfigSchema.parse(toolUseConfig());
+
+      await getExecutionStore(executionId).writeConfig(config);
+      defaultSession().events.emit({
+        scope: 'run',
+        streamId,
+        event: {
+          type: 'run.config',
+          streamId,
+          executionId,
+          config,
+        },
+      });
       defaultSession().events.emit({
         scope: 'run',
         streamId,
@@ -312,6 +332,26 @@ describe('executeCliRequest', () => {
           },
         },
       });
+      defaultSession().events.emit({
+        scope: 'session',
+        event: {
+          type: 'updateStreamDescription',
+          payload: {
+            streamId,
+            description: 'chat / gpt54',
+          },
+        },
+      });
+      defaultSession().events.emit({
+        scope: 'session',
+        event: {
+          type: 'setParentStream',
+          payload: {
+            childStreamId: streamId,
+            parentStreamId,
+          },
+        },
+      });
       // This is the legacy projected event still visible on the public host
       // channel. It must not be persisted a second time by the CLI bridge.
       options.runtimeHost.emit('updateStreamUsage', {
@@ -334,12 +374,22 @@ describe('executeCliRequest', () => {
     await executeCliRequest(request, cliContext());
 
     const { StreamSnapshotStore } = await import('@transcript');
-    const snapshot = await new StreamSnapshotStore().read(streamId);
+    const reader = new StreamSnapshotStore();
+    await reader.load([streamId]);
+    const snapshot = await reader.read(streamId);
     expect(snapshot.todos).toEqual([todo]);
     expect(snapshot.runUsage['run-1']).toMatchObject({
       inputTokens: 100,
       outputTokens: 20,
       cost: 0.5,
+    });
+    expect(snapshot.executionId).toBe(executionId);
+    expect(snapshot.description).toBe('chat / gpt54');
+    expect(snapshot.parentStreamId).toBe(parentStreamId);
+    expect(reader.getTaskState(streamId)?.agentConfig).toMatchObject({
+      agent: 'chat',
+      model: 'gpt54',
+      agentCategory: 'toolUse',
     });
   });
 

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -9,7 +9,6 @@ import {
   getDefaultStreamLogStore,
   setDefaultStreamLogStore,
   StreamLogStore,
-  type StreamSnapshotStore,
 } from '@transcript';
 import { clearAllStreamStatusesForTest } from '@test/helpers/streamStatusTestUtils';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
@@ -3403,33 +3402,6 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
       detachTui();
       detachProjection();
     }
-  });
-
-  it('bridges only transitional metadata events to the snapshot store', () => {
-    const snapshotStore = {
-      handleProgressEvent: vi.fn(),
-    } as unknown as StreamSnapshotStore;
-    const wrapped = wrapRuntimeHost(makeHost(), snapshotStore);
-
-    const todos: TodoItem[] = [
-      {
-        content: 'Write the introduction',
-        status: TODO_STATUS.IN_PROGRESS,
-        activeForm: 'Writing the introduction',
-      },
-    ];
-    wrapped.emit('updateTodos', { streamId: root, todos });
-    expect(streams.get().get(root)?.todos).toEqual(todos);
-    expect(snapshotStore.handleProgressEvent).not.toHaveBeenCalled();
-
-    wrapped.emit('updateStreamDescription', {
-      streamId: root,
-      description: 'search / kimi26T',
-    });
-    expect(snapshotStore.handleProgressEvent).toHaveBeenCalledWith(
-      'updateStreamDescription',
-      { streamId: root, description: 'search / kimi26T' },
-    );
   });
 
   it('registers suppressed child streams without switching away from the parent page', () => {

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -184,7 +184,21 @@ describe('StreamSnapshotStore', () => {
     const detach = writer.attachSessionEvents(events);
     const output = outputFile('paper.tex', 1);
     const failure = compileFailure('paper.tex', 1);
+    const executionId = 'a1b2c3d4' as ExecutionId;
+    const taskState = toolUseTaskState('session-search', 'kimi26T');
 
+    await getExecutionStore(executionId).writeConfig(taskState.agentConfig);
+
+    events.emit({
+      scope: 'run',
+      streamId: STREAM,
+      event: {
+        type: 'run.config',
+        streamId: STREAM,
+        executionId,
+        config: taskState.agentConfig,
+      },
+    });
     events.emit({
       scope: 'run',
       streamId: STREAM,
@@ -252,11 +266,33 @@ describe('StreamSnapshotStore', () => {
         data: { streamId: OTHER_STREAM },
       },
     });
+    events.emit({
+      scope: 'session',
+      event: {
+        type: 'updateStreamDescription',
+        payload: {
+          streamId: STREAM,
+          description: 'session-search / kimi26T',
+        },
+      },
+    });
+    events.emit({
+      scope: 'session',
+      event: {
+        type: 'setParentStream',
+        payload: {
+          childStreamId: STREAM,
+          parentStreamId: OTHER_STREAM,
+        },
+      },
+    });
 
     detach();
     await writer.flush();
 
-    const snap = await new StreamSnapshotStore().read(STREAM);
+    const reader = new StreamSnapshotStore();
+    await reader.load([STREAM]);
+    const snap = await reader.read(STREAM);
     expect(snap.todos).toEqual([TODO]);
     expect(snap.plan).toEqual(PLAN);
     expect(snap.outputFilesByRound).toEqual({ '1': [output] });
@@ -266,6 +302,16 @@ describe('StreamSnapshotStore', () => {
       inputTokens: 100,
       outputTokens: 20,
       cost: 0.5,
+    });
+    expect(snap.executionId).toBe(executionId);
+    expect(snap.description).toBe('session-search / kimi26T');
+    expect(snap.parentStreamId).toBe(OTHER_STREAM);
+    expect(reader.getTaskState(STREAM)).toEqual(taskState);
+    expect(reader.getRunDescriptor(STREAM)).toMatchObject({
+      streamId: STREAM,
+      executionId,
+      agent: 'session-search',
+      category: AgentCategory.ToolUse,
     });
 
     const goalPausedOnly = await new StreamSnapshotStore().read(OTHER_STREAM);

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -317,15 +317,24 @@ export class StreamSnapshotStore {
   }
 
   /**
-   * Persist already-migrated durable run facts directly from the session event
+   * Persist already-migrated durable facts directly from the session event
    * plane. The legacy progress-event entry point remains for extension/desktop
-   * consumers and for CLI metadata that has not moved to run-scoped facts.
+   * consumers.
    */
   attachSessionEvents(events: SessionEventHub): () => void {
-    return events.subscribe(
+    const detachRunEvents = events.subscribe(
       (sessionEvent) => {
         if (sessionEvent.scope !== 'run') return;
         const { event } = sessionEvent;
+
+        if (event.type === 'run.config') {
+          this.setTaskState(
+            event.streamId,
+            agentConfigToTaskState(event.config),
+            event.executionId,
+          );
+          return;
+        }
 
         if (event.type === 'usage') {
           this.handleSessionUsageEvent(event.data);
@@ -389,8 +398,35 @@ export class StreamSnapshotStore {
             return;
         }
       },
-      { scope: 'run', types: ['domain', 'usage'] },
+      { scope: 'run', types: ['domain', 'run.config', 'usage'] },
     );
+    const detachSessionEvents = events.subscribe(
+      (sessionEvent) => {
+        if (sessionEvent.scope !== 'session') return;
+        switch (sessionEvent.event.type) {
+          case 'updateStreamDescription':
+            this.setDescription(
+              sessionEvent.event.payload.streamId,
+              sessionEvent.event.payload.description,
+            );
+            return;
+          case 'setParentStream':
+            this.setParentStream(
+              sessionEvent.event.payload.childStreamId,
+              sessionEvent.event.payload.parentStreamId,
+            );
+            return;
+          default:
+            return;
+        }
+      },
+      { scope: 'session' },
+    );
+
+    return () => {
+      detachSessionEvents();
+      detachRunEvents();
+    };
   }
 
   private handleSessionUsageEvent(data: unknown): void {


### PR DESCRIPTION
Part of #6968.

## Summary

- Moves CLI snapshot metadata persistence for `run.config`, `updateStreamDescription`, and `setParentStream` into `StreamSnapshotStore.attachSessionEvents()`.
- Deletes the headless CLI and TUI runtime-host wrappers that forwarded retained host-progress metadata events back into the snapshot store.
- Keeps the frozen host-progress keys and public CLI projection intact; this only removes the CLI snapshot consumer from the retained host rail.

## Stage 5 invariant

- No CLI snapshot wrapper remains for `setTaskState`, `updateStreamDescription`, or `setParentStream`.
- `StreamSnapshotStore` now persists task state, stream descriptions, and parent links directly from the session/run fact plane.
- The retained host-progress compatibility map is unchanged.

## Verification

- `CI=true corepack pnpm exec vitest run src/test-kernel/transcript/StreamSnapshotStore.vitest.ts src/test-kernel/cli/RunExecution.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/chatSessionController.vitest.mts src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `corepack pnpm exec eslint <changed files>`
- `corepack pnpm exec prettier --check <changed files>`
- `git diff --check`
- grep for removed CLI wrapper patterns returned no hits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches durable resume/snapshot metadata for CLI runs; incorrect event wiring could drop or mis-store stream sidecars, though behavior is covered by expanded kernel tests.
> 
> **Overview**
> **Stream snapshot sidecars** now pick up task state, descriptions, and parent stream links from the **session/run event hub** instead of intercepting legacy `runtimeHost.emit` progress events in the CLI.
> 
> `StreamSnapshotStore.attachSessionEvents()` subscribes to `run.config` plus session-scoped `updateStreamDescription` and `setParentStream`, alongside the existing durable run facts. Headless execution drops `persistCliMetadataProgressEvents`; TUI `wrapRuntimeHost` only patches live CLI state and no longer forwards those metadata events into a snapshot store.
> 
> Legacy host-progress projection stays in place for other consumers; this change only removes the duplicate CLI bridge that could double-persist usage and metadata. Tests assert headless runs still flush execution id, description, parent link, and agent config from session events alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2c75978fd87b99aa3ed03b42b7b4aeef5204ca8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->