### PR TITLE
docs(model-handlers): triage getEffectiveContextWindow and isAutoRetryManagedByProvider

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -674,7 +674,7 @@ export abstract class ModelHandler<
    * `capabilities`/`config`. `ModelHandlerOpenRouterNative`'s override is
    * qualitatively different, not just a different boolean: it inspects the
    * concrete `_error` instance (`OpenRouterConnectionError`/
-   * `RequestTimeoutError`, or an HTTP status code ≥500) rather than
+   * `OpenRouterRequestTimeoutError`, or an HTTP status code ≥500) rather than
    * returning a constant, since the OpenRouter SDK's own retry coverage
    * depends on the failure kind. Each override encodes what that provider's
    * SDK actually does internally; nothing here is provider-identity data

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -301,7 +301,14 @@ export abstract class ModelHandler<
 
   /**
    * Returns the effective context window size, accounting for beta overrides.
-   * Subclasses may override (e.g. Anthropic 1M beta).
+   *
+   * Runtime combinator (#7101 triage): the only override is
+   * `ModelHandlerOpenAIResponse`, which reads
+   * `getActiveProviderCapabilities()?.contextWindow` with a fallback to this
+   * base value — same "profile read with fallback" shape as
+   * `supportsToolResultFileUpload`'s OpenAIResponse override. Not reducible
+   * into the base directly since only one subclass implements it, but not
+   * genuine per-provider behavior either.
    */
   public getEffectiveContextWindow(): number {
     return this.config.contextWindow;
@@ -660,6 +667,18 @@ export abstract class ModelHandler<
    * Whether the provider SDK already retries this error internally, so the
    * flow-level auto-retry loop should stand down. Override in subclasses that
    * delegate retries to the provider; the default is no provider-managed retry.
+   *
+   * Not foldable into a single predicate (#7101 triage): Anthropic, OpenAI,
+   * and OpenAIResponse each override to an unconditional `true` — a
+   * provider-wide fact about that SDK's own retry wrapper, not data on
+   * `capabilities`/`config`. `ModelHandlerOpenRouterNative`'s override is
+   * qualitatively different, not just a different boolean: it inspects the
+   * concrete `_error` instance (`OpenRouterConnectionError`/
+   * `RequestTimeoutError`, or an HTTP status code ≥500) rather than
+   * returning a constant, since the OpenRouter SDK's own retry coverage
+   * depends on the failure kind. Each override encodes what that provider's
+   * SDK actually does internally; nothing here is provider-identity data
+   * that a `config` read could reproduce.
    */
   isAutoRetryManagedByProvider(_error: Error): boolean {
     return false;


### PR DESCRIPTION
Part of #7101 (does not close it). Doc-only, zero behavior change — triages two remaining predicates that had no `#7101 triage` comment.

## `getEffectiveContextWindow`

Only `ModelHandlerOpenAIResponse` overrides it (`getActiveProviderCapabilities()?.contextWindow ?? super.getEffectiveContextWindow()`) — the same "profile read with fallback" shape as the already-triaged `supportsToolResultFileUpload`. The prior doc comment's "(e.g. Anthropic 1M beta)" example was stale: Anthropic never overrides this getter (grepped `modelHandlerAnthropic.ts` — no hit); its context window comes straight from `config.contextWindow` (llm-zoo data). Replaced with the actual OpenAIResponse example.

## `isAutoRetryManagedByProvider`

Bucket 3, not foldable. Anthropic, OpenAI, and OpenAIResponse each override to an unconditional `true` — a provider-wide fact about that SDK's own retry wrapper, not `capabilities`/`config` data. `ModelHandlerOpenRouterNative`'s override is qualitatively different: it inspects the concrete `error` instance (`OpenRouterConnectionError`/`RequestTimeoutError`, or HTTP status ≥500) rather than returning a constant, since OpenRouter's own retry coverage depends on the failure kind. None of this reduces to a config-identity read.

## Verification

- `tsc --noEmit` (root) — clean.
- `eslint` on the changed file — clean.
- No functional change: doc comments only, verified via `git diff` (20 insertions, all comment lines).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes in `ModelHandler.ts`; no runtime or API behavior changes.
> 
> **Overview**
> Documentation-only follow-up for **#7101**: adds `#7101 triage` notes on two base `ModelHandler` APIs so reviewers know why they stay as overridable methods instead of folding into `config`/`capabilities`.
> 
> For **`getEffectiveContextWindow`**, the stale Anthropic 1M-beta override example is removed and replaced with the real picture — only `ModelHandlerOpenAIResponse` overrides via `getActiveProviderCapabilities()?.contextWindow` with a fallback, same pattern as the already-documented `supportsToolResultFileUpload`.
> 
> For **`isAutoRetryManagedByProvider`**, the new comment records that Anthropic/OpenAI/OpenAIResponse always return `true` (SDK-owned retries), while OpenRouter Native inspects the concrete error type/status, so none of this collapses to a single config read.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92f1eb207c57f0b100cae7e6f402c4aaeb3572d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->