### PR TITLE
refactor(runtime): publish child process updates as session facts

### DIFF
--- a/src/agent/runtime/ProcessOutputPoller.ts
+++ b/src/agent/runtime/ProcessOutputPoller.ts
@@ -8,12 +8,10 @@ import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { delay } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
-import type { AgentRuntimeHost } from './AgentRuntimeHost';
 import type { ProcessExecutionHandle } from './ExecutionHandle';
 
 interface ProcessOutputSource {
   handle: ProcessExecutionHandle;
-  runtimeHost: AgentRuntimeHost;
 }
 
 export interface ProcessOutputPayload {
@@ -23,7 +21,7 @@ export interface ProcessOutputPayload {
   readonly stderr: string;
 }
 
-type ProcessOutputEmitter = (payload: ProcessOutputPayload) => void;
+export type ProcessOutputEmitter = (payload: ProcessOutputPayload) => void;
 
 /** Interval at which temp files are read and pushed to the progress UI. */
 const OUTPUT_POLL_INTERVAL_MS = 500;
@@ -61,13 +59,9 @@ export class ProcessOutputPoller {
     this.emitOutput = emitOutput;
   }
 
-  register(
-    handle: ProcessExecutionHandle,
-    runtimeHost: AgentRuntimeHost,
-  ): void {
+  register(handle: ProcessExecutionHandle): void {
     this.processOutputs.set(handle.executionId, {
       handle,
-      runtimeHost,
     });
     this.reconcile();
   }
@@ -78,10 +72,7 @@ export class ProcessOutputPoller {
     this.reconcile();
   }
 
-  async flush(
-    handle: ProcessExecutionHandle,
-    runtimeHost: AgentRuntimeHost,
-  ): Promise<void> {
+  async flush(handle: ProcessExecutionHandle): Promise<void> {
     if (!handle.outputPaths) return;
 
     await this.readIncremental(
@@ -89,7 +80,6 @@ export class ProcessOutputPoller {
       handle.parentStreamId,
       handle.outputPaths.stdout,
       handle.outputPaths.stderr,
-      runtimeHost,
     );
 
     // Flush any incomplete UTF-8 sequences that StringDecoder buffered
@@ -103,7 +93,7 @@ export class ProcessOutputPoller {
       state.stdout.decoder = new StringDecoder('utf8');
       state.stderr.decoder = new StringDecoder('utf8');
       if (outTail || errTail) {
-        this.emitProcessOutput(runtimeHost, {
+        this.emitProcessOutput({
           parentStreamId: handle.parentStreamId,
           executionId: handle.executionId,
           stdout: outTail,
@@ -192,7 +182,6 @@ export class ProcessOutputPoller {
           source.handle.parentStreamId,
           outputPaths.stdout,
           outputPaths.stderr,
-          source.runtimeHost,
           true,
         );
       },
@@ -205,7 +194,6 @@ export class ProcessOutputPoller {
     parentStreamId: StreamTabId,
     stdoutPath: string,
     stderrPath: string,
-    runtimeHost: AgentRuntimeHost,
     requireRegistered = false,
   ): Promise<void> {
     const inflight = this.readingInProgress.get(executionId);
@@ -231,7 +219,7 @@ export class ProcessOutputPoller {
         ]);
         if (!outText && !errText) return;
 
-        this.emitProcessOutput(runtimeHost, {
+        this.emitProcessOutput({
           parentStreamId,
           executionId,
           stdout: outText,
@@ -259,15 +247,12 @@ export class ProcessOutputPoller {
     }
   }
 
-  private emitProcessOutput(
-    runtimeHost: AgentRuntimeHost,
-    payload: ProcessOutputPayload,
-  ): void {
+  private emitProcessOutput(payload: ProcessOutputPayload): void {
     if (this.emitOutput) {
       this.emitOutput(payload);
       return;
     }
-    runtimeHost.emit('updateProcessOutput', payload);
+    throw new Error('ProcessOutputPoller requires a process output emitter');
   }
 }
 

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -41,7 +41,7 @@ import {
   isChildExecution,
 } from './ExecutionHandle';
 import { ProcessOutputPoller } from './ProcessOutputPoller';
-import type { SessionEventHub } from './SessionEventHub';
+import { SessionEventHub } from './SessionEventHub';
 
 export type { ExecutionHandle } from './ExecutionHandle';
 export {
@@ -161,7 +161,7 @@ export class ExecutionRegistry {
     interrupts = SharedInterruptRegistry,
     processOutput = new ProcessOutputPoller(),
     streamStatus = StreamStatusService,
-    events,
+    events = new SessionEventHub(),
     publishResult,
   }: {
     readonly interrupts?: InterruptRegistry;
@@ -176,7 +176,7 @@ export class ExecutionRegistry {
     this.interrupts = interrupts;
     this.processOutput = processOutput;
     this.streamStatus = streamStatus;
-    if (events) this.attachSessionEvents(events, publishResult);
+    this.attachSessionEvents(events, publishResult);
     // Notify waiters and refresh UI badges when stream status changes
     // (e.g. RUNNING → WAITING). Without this, waitForChange only resolves
     // on progress/kill/untrack, and the background-tasks panel shows stale badges.
@@ -189,10 +189,7 @@ export class ExecutionRegistry {
           ) {
             this.notifyWaiters(executionId);
             if (handle.isChildExecution) {
-              this.emitActiveSubagentsUpdate(
-                handle.parentStreamId,
-                handle.runtimeHost,
-              );
+              this.emitActiveSubagentsUpdate(handle.parentStreamId);
             }
             break;
           }
@@ -237,19 +234,17 @@ export class ExecutionRegistry {
   /** Register an execution handle. */
   track(handle: ExecutionHandle): void {
     this.handles.set(handle.executionId, handle);
-    const { runtimeHost } = handle;
-
     if (handle instanceof AgentExecutionHandle) {
       if (handle.isChildExecution) {
-        this.emitActiveSubagentsUpdate(handle.parentStreamId, runtimeHost);
-        this.emitParentStreamUpdate(runtimeHost, {
+        this.emitActiveSubagentsUpdate(handle.parentStreamId);
+        this.emitParentStreamUpdate({
           childStreamId: handle.childStreamId,
           parentStreamId: handle.parentStreamId,
         });
       }
     } else if (handle instanceof ProcessExecutionHandle) {
-      this.processOutput.register(handle, runtimeHost);
-      this.emitActiveProcessesUpdate(handle.parentStreamId, runtimeHost);
+      this.processOutput.register(handle);
+      this.emitActiveProcessesUpdate(handle.parentStreamId);
     }
   }
 
@@ -311,10 +306,8 @@ export class ExecutionRegistry {
   private untrackHandle(handle: ExecutionHandle): void {
     this.handles.delete(handle.executionId);
     this.notifyWaiters(handle.executionId);
-    const { runtimeHost } = handle;
-
     if (handle instanceof AgentExecutionHandle && handle.isChildExecution) {
-      this.emitActiveSubagentsUpdate(handle.parentStreamId, runtimeHost);
+      this.emitActiveSubagentsUpdate(handle.parentStreamId);
       return;
     }
 
@@ -323,10 +316,10 @@ export class ExecutionRegistry {
       // badge handler prunes output entries for processes no longer active.
       const finalize = (): void => {
         this.processOutput.unregister(handle.executionId);
-        this.emitActiveProcessesUpdate(handle.parentStreamId, runtimeHost);
+        this.emitActiveProcessesUpdate(handle.parentStreamId);
       };
       if (handle.outputPaths) {
-        void this.processOutput.flush(handle, runtimeHost).finally(finalize);
+        void this.processOutput.flush(handle).finally(finalize);
       } else {
         finalize();
       }
@@ -561,14 +554,14 @@ export class ExecutionRegistry {
    */
   detachActiveChildren(
     parentStreamId: StreamTabId,
-    runtimeHost: AgentRuntimeHost,
+    _runtimeHost: AgentRuntimeHost,
     visited: Set<string> = new Set(),
   ): void {
     for (const handle of this.handles.values()) {
       if (!isChildExecution(handle, parentStreamId)) continue;
       if (handle instanceof AgentExecutionHandle) {
         handle.detach();
-        this.emitParentStreamUpdate(runtimeHost, {
+        this.emitParentStreamUpdate({
           childStreamId: handle.childStreamId,
           parentStreamId: null,
         });
@@ -576,7 +569,7 @@ export class ExecutionRegistry {
         this.terminate(handle, visited, { cascadeChildren: false });
       }
     }
-    this.emitActiveSubagentsUpdate(parentStreamId, runtimeHost);
+    this.emitActiveSubagentsUpdate(parentStreamId);
   }
 
   /**
@@ -673,84 +666,63 @@ export class ExecutionRegistry {
     };
   }
 
-  private emitActiveSubagentsUpdate(
-    parentStreamId: StreamTabId,
-    runtimeHost: AgentRuntimeHost,
-  ): void {
+  private emitActiveSubagentsUpdate(parentStreamId: StreamTabId): void {
     const children = this.collectChildSummary(
       parentStreamId,
       AgentExecutionHandle,
     );
-    if (this.events) {
-      this.events.emit({
-        scope: 'run',
-        streamId: parentStreamId,
-        event: {
-          type: 'child.activity',
-          kind: 'subagents',
-          parentStreamId,
-          children,
-        },
-      });
-      return;
-    }
-    runtimeHost.emit('updateActiveSubagents', {
-      parentStreamId,
-      children,
+    this.requireSessionEvents().emit({
+      scope: 'run',
+      streamId: parentStreamId,
+      event: {
+        type: 'child.activity',
+        kind: 'subagents',
+        parentStreamId,
+        children,
+      },
     });
   }
 
-  private emitActiveProcessesUpdate(
-    parentStreamId: StreamTabId,
-    runtimeHost: AgentRuntimeHost,
-  ): void {
+  private emitActiveProcessesUpdate(parentStreamId: StreamTabId): void {
     const processes = this.collectChildSummary(
       parentStreamId,
       ProcessExecutionHandle,
     );
-    if (this.events) {
-      this.events.emit({
-        scope: 'run',
-        streamId: parentStreamId,
-        event: {
-          type: 'child.activity',
-          kind: 'processes',
-          parentStreamId,
-          processes,
-        },
-      });
-      return;
-    }
-    runtimeHost.emit('updateActiveProcesses', {
-      parentStreamId,
-      processes,
+    this.requireSessionEvents().emit({
+      scope: 'run',
+      streamId: parentStreamId,
+      event: {
+        type: 'child.activity',
+        kind: 'processes',
+        parentStreamId,
+        processes,
+      },
     });
   }
 
-  private emitParentStreamUpdate(
-    runtimeHost: AgentRuntimeHost,
-    payload: {
-      readonly childStreamId: StreamTabId;
-      readonly parentStreamId: StreamTabId | null;
-    },
-  ): void {
-    if (this.events) {
-      this.events.emit({
-        scope: 'session',
-        event: {
-          type: 'setParentStream',
-          payload: {
-            childStreamId: payload.childStreamId,
-            parentStreamId: payload.parentStreamId,
-          },
+  private emitParentStreamUpdate(payload: {
+    readonly childStreamId: StreamTabId;
+    readonly parentStreamId: StreamTabId | null;
+  }): void {
+    this.requireSessionEvents().emit({
+      scope: 'session',
+      event: {
+        type: 'setParentStream',
+        payload: {
+          childStreamId: payload.childStreamId,
+          parentStreamId: payload.parentStreamId,
         },
-      });
-      return;
-    }
-    runtimeHost.emit('setParentStream', {
-      childStreamId: payload.childStreamId,
-      parentStreamId: payload.parentStreamId,
+      },
     });
+  }
+
+  private requireSessionEvents(): SessionEventHub {
+    if (!this.events) {
+      throw new Error(
+        'ExecutionRegistry child/process updates require SessionEventHub',
+      );
+    }
+    return this.events;
   }
 
   private collectChildSummary(

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -53,7 +53,10 @@ describe('executionRegistry', () => {
     const explicit = createRecordingHost();
     const interrupts = new InterruptRegistry();
     const streamStatus = new StreamStatusMachine();
-    const registry = new ExecutionRegistry({ interrupts, streamStatus });
+    const registry = new ExecutionRegistry({
+      interrupts,
+      streamStatus,
+    });
     const executionId = 'exec-injected-interrupt-test';
     const parentStreamId = 'parent-injected-interrupt-test' as StreamTabId;
     const childStreamId = 'child-injected-interrupt-test' as StreamTabId;
@@ -443,7 +446,16 @@ describe('executionRegistry', () => {
     const explicit = createRecordingHost();
     const interrupts = new InterruptRegistry();
     const streamStatus = new StreamStatusMachine();
-    const registry = new ExecutionRegistry({ interrupts, streamStatus });
+    const events = new SessionEventHub();
+    const detachProjection = attachSessionProgressEventProjection(
+      events,
+      explicit.host,
+    );
+    const registry = new ExecutionRegistry({
+      interrupts,
+      streamStatus,
+      events,
+    });
     const rootStreamId = 'root-detach-kill-test' as StreamTabId;
     const childStreamId = 'child-detach-kill-test' as StreamTabId;
     const grandchildStreamId = 'grandchild-detach-kill-test' as StreamTabId;
@@ -498,6 +510,7 @@ describe('executionRegistry', () => {
       });
     } finally {
       registry.dispose();
+      detachProjection();
       interrupts.unregister(childStreamId);
       interrupts.unregister(grandchildStreamId);
     }
@@ -507,7 +520,16 @@ describe('executionRegistry', () => {
     const explicit = createRecordingHost();
     const interrupts = new InterruptRegistry();
     const streamStatus = new StreamStatusMachine();
-    const registry = new ExecutionRegistry({ interrupts, streamStatus });
+    const events = new SessionEventHub();
+    const detachProjection = attachSessionProgressEventProjection(
+      events,
+      explicit.host,
+    );
+    const registry = new ExecutionRegistry({
+      interrupts,
+      streamStatus,
+      events,
+    });
     const rootStreamId = 'root-detach-stop-policy-test' as StreamTabId;
     const childStreamId = 'child-detach-stop-policy-test' as StreamTabId;
     const grandchildStreamId =
@@ -591,6 +613,7 @@ describe('executionRegistry', () => {
       });
     } finally {
       registry.dispose();
+      detachProjection();
     }
   });
 
@@ -818,9 +841,14 @@ describe('executionRegistry', () => {
     }
   });
 
-  it('publishes handle updates through the handle runtime host', () => {
+  it('projects handle updates from session events', () => {
     const explicit = createRecordingHost();
-    const registry = new ExecutionRegistry();
+    const events = new SessionEventHub();
+    const detachProjection = attachSessionProgressEventProjection(
+      events,
+      explicit.host,
+    );
+    const registry = new ExecutionRegistry({ events });
     const executionId = 'exec-handle-runtime-host-test';
     const parentStreamId = 'parent-handle-runtime-host-test' as StreamTabId;
     const childStreamId = 'child-handle-runtime-host-test' as StreamTabId;
@@ -859,6 +887,7 @@ describe('executionRegistry', () => {
       });
     } finally {
       registry.dispose();
+      detachProjection();
     }
   });
 
@@ -1119,9 +1148,14 @@ describe('executionRegistry', () => {
     }
   });
 
-  it('publishes detach updates through the caller runtime host', () => {
+  it('projects detach updates from session events', () => {
     const explicit = createRecordingHost();
-    const registry = new ExecutionRegistry();
+    const events = new SessionEventHub();
+    const detachProjection = attachSessionProgressEventProjection(
+      events,
+      explicit.host,
+    );
+    const registry = new ExecutionRegistry({ events });
     const executionId = 'exec-detach-runtime-host-test';
     const parentStreamId = 'parent-detach-runtime-host-test' as StreamTabId;
     const childStreamId = 'child-detach-runtime-host-test' as StreamTabId;
@@ -1157,6 +1191,7 @@ describe('executionRegistry', () => {
       });
     } finally {
       registry.dispose();
+      detachProjection();
     }
   });
 

--- a/src/test-kernel/agent/runtime/ProcessOutputPoller.vitest.ts
+++ b/src/test-kernel/agent/runtime/ProcessOutputPoller.vitest.ts
@@ -11,7 +11,10 @@ import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { setupPlatform } from '@test/support/setupPlatform';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { ProcessExecutionHandle } from '@agent/runtime/ExecutionHandle';
-import { ProcessOutputPoller } from '@agent/runtime/ProcessOutputPoller';
+import {
+  ProcessOutputPoller,
+  type ProcessOutputEmitter,
+} from '@agent/runtime/ProcessOutputPoller';
 
 // Local imports - shared
 import type { StreamTabId } from '@shared/schemas';
@@ -23,10 +26,14 @@ let poller: ProcessOutputPoller;
 function createRuntimeHost(): {
   host: AgentRuntimeHost;
   events: Array<{ event: string; payload: unknown }>;
+  emitOutput: (emitOutput: ProcessOutputEmitter) => void;
 } {
   const events: Array<{ event: string; payload: unknown }> = [];
   return {
     events,
+    emitOutput: (emitOutput) => {
+      poller.setOutputEmitter(emitOutput);
+    },
     host: {
       emit: vi.fn((event: string, payload: unknown) => {
         events.push({ event, payload });
@@ -37,7 +44,7 @@ function createRuntimeHost(): {
 
 function outputEvent(stdout: string, stderr: string) {
   return {
-    event: 'updateProcessOutput',
+    event: 'process.output',
     payload: {
       parentStreamId: 'parent-stream',
       executionId: 'exec-1',
@@ -95,13 +102,14 @@ describe('ProcessOutputPoller', () => {
   });
 
   it('flushes only new process output bytes', async () => {
-    const { host, events } = createRuntimeHost();
+    const { host, events, emitOutput } = createRuntimeHost();
+    emitOutput((payload) => events.push({ event: 'process.output', payload }));
     const { handle, stdoutPath, stderrPath } = await makeProcessHandle(host);
 
-    await poller.flush(handle, host);
+    await poller.flush(handle);
     await fs.appendFile(stdoutPath, 'out-2');
     await fs.appendFile(stderrPath, 'err-2');
-    await poller.flush(handle, host);
+    await poller.flush(handle);
 
     expect(events).toEqual([
       outputEvent('out-1', 'err-1'),
@@ -110,12 +118,13 @@ describe('ProcessOutputPoller', () => {
   });
 
   it('polls handles whose output paths are assigned after registration', async () => {
-    const { host, events } = createRuntimeHost();
+    const { host, events, emitOutput } = createRuntimeHost();
+    emitOutput((payload) => events.push({ event: 'process.output', payload }));
     const { handle, stdoutPath, stderrPath } = await makeProcessHandle(host, {
       assignOutputPaths: false,
     });
 
-    poller.register(handle, host);
+    poller.register(handle);
     handle.outputPaths = { stdout: stdoutPath, stderr: stderrPath };
 
     await delay(550);
@@ -130,13 +139,17 @@ describe('ProcessOutputPoller', () => {
   });
 
   it('keeps output offsets per instance', async () => {
-    const { host, events } = createRuntimeHost();
+    const { host, events, emitOutput } = createRuntimeHost();
+    emitOutput((payload) => events.push({ event: 'process.output', payload }));
     const { handle } = await makeProcessHandle(host);
     const otherPoller = new ProcessOutputPoller();
+    otherPoller.setOutputEmitter((payload) =>
+      events.push({ event: 'process.output', payload }),
+    );
 
     try {
-      await poller.flush(handle, host);
-      await otherPoller.flush(handle, host);
+      await poller.flush(handle);
+      await otherPoller.flush(handle);
     } finally {
       otherPoller.dispose();
     }
@@ -148,14 +161,15 @@ describe('ProcessOutputPoller', () => {
   });
 
   it('flushes buffered incomplete UTF-8 when process output ends', async () => {
-    const { host, events } = createRuntimeHost();
+    const { host, events, emitOutput } = createRuntimeHost();
+    emitOutput((payload) => events.push({ event: 'process.output', payload }));
     const incompleteEmoji = Buffer.from('🙂').subarray(0, 2);
     const { handle } = await makeProcessHandle(host, {
       stdout: incompleteEmoji,
       stderr: '',
     });
 
-    await poller.flush(handle, host);
+    await poller.flush(handle);
 
     expect(events).toEqual([outputEvent('\uFFFD', '')]);
   });


### PR DESCRIPTION
## Summary

Stage 5 child/process projection slice for #6968.

- remove the `ExecutionRegistry` direct host-progress fallback emits for `updateActiveSubagents`, `updateActiveProcesses`, and `setParentStream`
- remove the `ProcessOutputPoller` direct `updateProcessOutput` fallback and require an explicit process-output emitter
- keep the retained public host-progress projection in `sessionProgressEventProjection.ts`, so CLI/desktop/progress consumers still observe the same frozen events through the projector
- update runtime tests to assert the session-fact/projector route for child/process updates

This preserves the ordering invariant for process completion: final process-output flush happens before the empty active-process update.

## Validation

- `CI=true corepack pnpm exec vitest run src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/agent/runtime/ProcessOutputPoller.vitest.ts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `corepack pnpm exec eslint src/agent/runtime/ProcessOutputPoller.ts src/agent/runtime/executionRegistry.ts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/agent/runtime/ProcessOutputPoller.vitest.ts`
- `corepack pnpm exec prettier --check src/agent/runtime/ProcessOutputPoller.ts src/agent/runtime/executionRegistry.ts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/agent/runtime/ProcessOutputPoller.vitest.ts`
- `git diff --check`
- Full local kernel suite before rebase: `CI=true corepack pnpm run test` (600 files passed, 1 skipped; 5183 tests passed, 4 skipped)

Refs #6968

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior depends on SessionEventHub and the progress projector being attached everywhere consumers relied on direct host emits; mis-wiring would break badges/output without changing core kill/track logic.
> 
> **Overview**
> **ExecutionRegistry** no longer calls `AgentRuntimeHost.emit` for active subagents, active processes, or parent-stream links. Those updates always go through **SessionEventHub** as `child.activity`, `setParentStream`, and (for stdout/stderr) `process.output` wired in `attachSessionEvents`. A default hub is created in the constructor; missing hub now throws via `requireSessionEvents()`.
> 
> **ProcessOutputPoller** drops `runtimeHost` from `register`/`flush`/poll paths and no longer falls back to `updateProcessOutput` on the host. Output is delivered only through an injected **`ProcessOutputEmitter`**; without one it throws.
> 
> CLI/desktop/progress consumers should still see the same host progress events because **`sessionProgressEventProjection`** maps the new session facts to the frozen `updateActiveSubagents`, `updateActiveProcesses`, `setParentStream`, and process-output shapes. Process untrack still **flushes output before** the empty active-process update.
> 
> Tests now assert the hub → projector path instead of direct host emits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44e06ce064e4fb0a27b7fbd7bfa0259d91665d61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->