### PR TITLE
fix(extension): exclude the CLI-only shared-assets trace-viewer build from the VSIX

### DIFF
--- a/packages/extension/.vscodeignore
+++ b/packages/extension/.vscodeignore
@@ -33,8 +33,23 @@ test-loader.mjs
 AGENTS.md
 CLAUDE.md
 
+# Multi-file, external-assets trace-viewer build (shared-assets/site-hosting
+# export mode) — CLI-only (packages/cli/src/runtime/history.ts), never
+# referenced by the extension host. resources/traceViewerStandalone (the
+# single-file build historyHandlers.ts actually loads) is unaffected.
+#
+# No `!resources/**` line exists in this file (deliberately — see below), so
+# this plain ignore line works: vsce applies every `!`-negated line *after*
+# all plain ignore lines regardless of position in this file, so a blanket
+# `!resources/**` anywhere would silently re-include this directory no
+# matter where a plain `resources/traceViewer/**` ignore line was placed.
+# A prior `!resources/**` line here was dead weight anyway — verified no
+# earlier rule in this file matches any resources/ path, so every other
+# resources/* entry (agents, docs, examples, templates, ...) is already
+# included by default with no unignore needed at all.
+resources/traceViewer/**
+
 # Webview HTML entry points (loaded by BaseViewContentProvider)
-!resources/**
 !src/webview/*.html
 !src/progressView/*.html
 !src/settingsView/*.html

--- a/packages/extension/.vscodeignore
+++ b/packages/extension/.vscodeignore
@@ -44,8 +44,9 @@ CLAUDE.md
 # `!resources/**` anywhere would silently re-include this directory no
 # matter where a plain `resources/traceViewer/**` ignore line was placed.
 # A prior `!resources/**` line here was dead weight anyway — verified no
-# earlier rule in this file matches any resources/ path, so every other
-# resources/* entry (agents, docs, examples, templates, ...) is already
+# earlier rule in this file broadly excludes resources/ content (the only
+# earlier match is the specific `resources/.DS_Store` line above), so every
+# other resources/* entry (agents, docs, examples, templates, ...) is already
 # included by default with no unignore needed at all.
 resources/traceViewer/**
 

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -788,7 +788,7 @@
   ],
   "requiredVscodeIgnoreLines": [
     "src/**",
-    "!resources/**",
+    "resources/traceViewer/**",
     "!src/common/styles/*.css",
     "!src/progressView/*.html",
     "!src/settingsView/*.html",

--- a/scripts/verify-extension-package-invariants.mjs
+++ b/scripts/verify-extension-package-invariants.mjs
@@ -63,7 +63,13 @@ const BUILD_TIME_PACKAGED_PATHS = new Set(['readme.md', 'changelog.md']);
 
 const REQUIRED_VSCODEIGNORE_LINES = [
   'src/**',
-  '!resources/**',
+  // No blanket `!resources/**` line: it was dead weight (nothing earlier in
+  // .vscodeignore matches any resources/ path, so every resources/* entry
+  // is already included by default) and, if present, would silently
+  // override the plain resources/traceViewer/** exclusion below — vsce
+  // applies every `!`-negated line after all plain ignore lines regardless
+  // of position, so a later plain ignore line can never win against it.
+  'resources/traceViewer/**',
   '!src/common/styles/*.css',
   '!src/progressView/*.html',
   '!src/settingsView/*.html',

--- a/scripts/verify-extension-package-invariants.mjs
+++ b/scripts/verify-extension-package-invariants.mjs
@@ -63,9 +63,11 @@ const BUILD_TIME_PACKAGED_PATHS = new Set(['readme.md', 'changelog.md']);
 
 const REQUIRED_VSCODEIGNORE_LINES = [
   'src/**',
-  // No blanket `!resources/**` line: it was dead weight (nothing earlier in
-  // .vscodeignore matches any resources/ path, so every resources/* entry
-  // is already included by default) and, if present, would silently
+  // No blanket `!resources/**` line: it was dead weight (no earlier rule in
+  // .vscodeignore broadly excludes resources/ content — the only earlier
+  // match is the specific `resources/.DS_Store` line — so every
+  // resources/* entry is already included by default) and, if present,
+  // would silently
   // override the plain resources/traceViewer/** exclusion below — vsce
   // applies every `!`-negated line after all plain ignore lines regardless
   // of position, so a later plain ignore line can never win against it.

--- a/scripts/verify-vsix-contents.mjs
+++ b/scripts/verify-vsix-contents.mjs
@@ -129,9 +129,22 @@ function verifyRequiredPaths(entries, snapshot, failures) {
   }
 }
 
+// resources/traceViewer is the multi-file, external-assets trace-viewer
+// build (shared-assets/site-hosting export mode) — CLI-only
+// (packages/cli/src/runtime/history.ts), never referenced by the extension
+// host. It's built straight into the extension's resources/ as a staging
+// spot for packages/cli/scripts/copy-resources.mjs to copy from, and
+// .vscodeignore deliberately excludes it from the packaged VSIX (see
+// resources/traceViewer/** there) to avoid ~3.4MB of dead weight. Only
+// resources/traceViewerStandalone (the single-file build historyHandlers.ts
+// actually loads) ships.
+const RESOURCE_HASH_EXCLUDED_PREFIX = 'traceViewer/';
+
 function verifyResourceHashes(vsixPath, entries, failures) {
   const resourcesDir = path.join(extensionDir, 'resources');
-  const sourceFiles = walkFiles(resourcesDir);
+  const sourceFiles = walkFiles(resourcesDir).filter(
+    (file) => !file.startsWith(RESOURCE_HASH_EXCLUDED_PREFIX),
+  );
   const sourceFileSet = new Set(sourceFiles);
 
   for (const sourceFile of sourceFiles) {


### PR DESCRIPTION
## Context

`packages/trace-viewer` builds two outputs into `packages/extension/resources/` as a staging spot for the CLI's own `copy-resources.mjs`:

- `traceViewerStandalone/` (1 file, ~5.1MB) — the single-file, self-contained build (`vite-plugin-singlefile`, needed because `file://` blocks module-script fetches via CORS). **Actually used by the extension**: `packages/extension/src/settingsView/handlers/historyHandlers.ts` loads it as `traceViewerStandaloneTemplate` for the "Export as HTML" feature.
- `traceViewer/` (62 files, ~3.4MB) — the multi-file, external-`assets/` build for the shared-assets/site-hosting export mode (served over http(s), never `file://`). Grepped all of `packages/extension/src/` — referenced nowhere. Only consumed by `packages/cli/src/runtime/history.ts` and `packages/cli/scripts/copy-resources.mjs`; it's a CLI-only export mode.

Both were shipping in the VSIX, confirmed via a real `npm run build:fast` build:
```
resources/
├─ ...
├─ traceViewer/ (62 files) [3.39 MB]
├─ traceViewerStandalone/ (1 file) [5.09 MB]
└─ ...
```

## Root cause

`.vscodeignore`'s blanket `!resources/**` line was doing the (unintentional) job of shipping both. Investigated why a plain `resources/traceViewer/**` exclusion line didn't work when added: `vsce` collects every `!`-negated `.vscodeignore` line into one "not ignored" list applied *after* all plain ignore lines (`[...defaultIgnore, ...ignore, ...notIgnored]` in `@vscode/vsce`'s `package.js`), regardless of where each line physically sits in the file — so a blanket `!resources/**` anywhere always wins against a later plain ignore line for the same path, no matter the ordering.

Also discovered `!resources/**` was already dead weight for everything *other* than this exclusion attempt: verified via the `ignore` npm package directly that no earlier line in `.vscodeignore` matches any `resources/` path, so every `resources/*` entry (agents, docs, examples, templates, etc.) was already included by default with no unignore needed at all.

## Fix

- Removed the dead `!resources/**` line.
- Added a plain `resources/traceViewer/**` ignore line (now effective, since nothing un-ignores it).
- Updated `scripts/verify-extension-package-invariants.mjs`'s `REQUIRED_VSCODEIGNORE_LINES` (which required the old line verbatim) and regenerated the snapshot.
- Updated `scripts/verify-vsix-contents.mjs`'s `verifyResourceHashes()`, which walks the entire `resources/` tree on disk and asserts a 1:1 match with the VSIX — added a documented exclusion for the `traceViewer/` prefix so it doesn't flag the now-intentional exclusion as drift.

## Verification

- `node -e "require('ignore').add(...)"` tested against both the old and new `.vscodeignore` content directly, confirming the exact pattern-matching semantics before touching the real build.
- `vsce ls --no-dependencies`, diffed against a captured baseline: exactly the 62 `resources/traceViewer/*` entries disappear; all 54 other `resources/*` entries (including `traceViewerStandalone/index.html`) are byte-for-byte unchanged.
- Full `npm run build:fast` production VSIX build — `vsce`'s own file-tree output confirms `traceViewerStandalone/` (1 file, 5.09MB) ships and `traceViewer/` is absent; everything else in the tree matches exactly.
- `npm run check:vsix-contents` and `npm run check:extension-package-invariants` both pass against the built VSIX.
- `node scripts/check-dead-code-ratchet.mjs` — at/below baseline.
- `npx tsc --noEmit` — clean.
- `npx eslint` on both changed `.mjs` files shows only the pre-existing `no-undef` on `console` (confirmed identical count on unmodified `main` via `git stash`; `scripts/**` isn't covered by the repo's lint script or any `eslint.config.mjs` override).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and verification-only changes; extension runtime still uses `traceViewerStandalone`, with no auth or data-path changes.
> 
> **Overview**
> Stops shipping the **CLI-only** multi-file `resources/traceViewer/` tree (~3.4MB) in the extension VSIX while keeping **`traceViewerStandalone/`** for Settings “Export as HTML”.
> 
> **`.vscodeignore`:** Drops the blanket `!resources/**` (it re-included everything under `resources/` after plain ignores, so a `resources/traceViewer/**` rule could never win). Adds an explicit `resources/traceViewer/**` ignore plus comments on `vsce` ignore ordering.
> 
> **CI/scripts:** `REQUIRED_VSCODEIGNORE_LINES` and the extension-package snapshot now expect `resources/traceViewer/**` instead of `!resources/**`. `verify-vsix-contents.mjs` skips `traceViewer/` when comparing on-disk `resources/` to VSIX hashes so the intentional omission is not reported as drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26ce063df3b5b31f119cc5c63543820601f4b967. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->