### PR TITLE
refactor: modern-TS simplification sweep — dead fields, pass-throughs, nullish idioms (net -40)

### DIFF
--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
@@ -112,7 +112,7 @@ export function formatErrorTemplate(message: LogMessageData): FormatResult {
   // message that merely duplicates the original summary.
   const detailLines = ERROR_DETAIL_FIELDS.flatMap((key) => {
     const value = errorData[key];
-    if (value === null || value === undefined) return [];
+    if (value == null) return [];
     if (key === 'message' && value === originalSummaryText) return [];
     // Format objects (like rawErrorBody) as indented JSON
     const displayValue =

--- a/packages/extension/src/progressView/frontend/formatters/parseUtils.ts
+++ b/packages/extension/src/progressView/frontend/formatters/parseUtils.ts
@@ -26,7 +26,7 @@ export type StringifyResult = {
  * Avoids repeated parsing by tracking the serialization format used.
  */
 export function stringifyWithLanguage(value: unknown): StringifyResult {
-  if (value === undefined || value === null) {
+  if (value == null) {
     return { text: '', language: 'plaintext' };
   }
 

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -14,7 +14,6 @@ import {
   SkippableNodeResult,
 } from '@agent/core/flows/CommonCycleTypes';
 import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
-import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import type { ProviderStopReason } from '@agent/modelHandlers/types/StopReasonTypes';
 import type { ProviderUsage } from '@agent/core/usage/ResponseUsage';
 
@@ -157,14 +156,12 @@ interface ProcessPrepResult {
   shouldStop: boolean;
   responseObject: unknown;
   responseTimeMs?: number;
-  messages: ProviderMessage[];
   lastResponse: string;
   accumulatedOutput: string;
 }
 
 interface ProcessResultCommon {
   stopReason: ProviderStopReason;
-  thinkingContent?: string | null;
   useStreaming: boolean;
   responseUsage: ProviderUsage;
   normalizedUsage?: NormalizedUsage;
@@ -199,7 +196,6 @@ interface ContinuationPrepResult {
   interrupted: boolean;
   stopReason?: ProviderStopReason;
   processedResponse?: string;
-  messages: ProviderMessage[];
 }
 
 type ContinuationNodeResult = SkippableNodeResult<{
@@ -246,7 +242,6 @@ class ResponseProcessNode<C> extends BaseNode<
       shouldStop: shared.shouldStop,
       responseObject: shared.responseObject,
       responseTimeMs: shared.responseTimeMs,
-      messages: shared.messages,
       lastResponse: assembly.lastResponse,
       accumulatedOutput: assembly.accumulatedOutput,
     };
@@ -305,7 +300,6 @@ class ResponseProcessNode<C> extends BaseNode<
 
       const common = {
         stopReason,
-        thinkingContent,
         useStreaming,
         responseUsage,
         normalizedUsage,
@@ -491,7 +485,6 @@ class ResponseContinuationNode<C> extends BaseNode<
       interrupted,
       stopReason: shared.stopReason ?? undefined,
       processedResponse: shared.processedResponse,
-      messages: shared.messages,
     };
   }
 

--- a/src/agent/core/state/AgentWorkspaceState.ts
+++ b/src/agent/core/state/AgentWorkspaceState.ts
@@ -196,16 +196,12 @@ export class MediaAttachmentState {
     return { files: [...this.files] };
   }
 
-  private addFile(location: FileLocation): void {
-    if (!this.pathSet.has(location.absolutePath)) {
-      this.pathSet.add(location.absolutePath);
-      this.files.push(location);
-    }
-  }
-
   addMediaFiles(locations: FileLocation[]): void {
     for (const location of locations) {
-      this.addFile(location);
+      if (!this.pathSet.has(location.absolutePath)) {
+        this.pathSet.add(location.absolutePath);
+        this.files.push(location);
+      }
     }
   }
 

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -217,13 +217,11 @@ export async function runReflectionFlow<C = unknown>(
 
     if (validated?.success) {
       shared = validated.data as ReflectionFlowShared;
-      shared.modelHandlerCompatibilityKey =
-        shared.modelHandlerCompatibilityKey ??
+      shared.modelHandlerCompatibilityKey ??=
         inferPersistedModelHandlerCompatibilityKey(
           config.model,
           shared.conversation,
-        ) ??
-        compatibilityKey;
+        ) ?? compatibilityKey;
       // Always sync totalRounds from the current agent config so that changes
       // to the YAML (e.g. rounds: 2 → 1) take effect on resume.
       shared.totalRounds = totalRounds;

--- a/src/auth/relayToken.ts
+++ b/src/auth/relayToken.ts
@@ -83,13 +83,6 @@ export function resetRelayTokenTierCacheForTests(): void {
   statusCache.clear();
 }
 
-/** Fresh (within TTL) cached status for `token`, or undefined. */
-function getFreshCachedStatus(
-  token: string,
-): SettledRelayTokenStatus | undefined {
-  return statusCache.get(token);
-}
-
 /**
  * Last settled status of a token, without any network I/O. Lets synchronous
  * credential checks (SupabaseClient.isAuthenticated / getRelayAccessToken)
@@ -99,7 +92,7 @@ function getFreshCachedStatus(
 export function getCachedRelayTokenState(
   token: string,
 ): SettledRelayTokenStatus['state'] | undefined {
-  return getFreshCachedStatus(token)?.state;
+  return statusCache.get(token)?.state;
 }
 
 /**
@@ -117,7 +110,7 @@ export async function fetchRelayTokenStatus(
   token: string,
   fetchImpl: typeof fetch = fetch,
 ): Promise<RelayTokenStatus> {
-  const cached = getFreshCachedStatus(token);
+  const cached = statusCache.get(token);
   if (cached) return cached;
   const result = await probeRelayTokenStatus(token, fetchImpl);
   if (result.state !== 'unknown') {

--- a/src/common/errors/sdkError/errorInspection.ts
+++ b/src/common/errors/sdkError/errorInspection.ts
@@ -171,11 +171,9 @@ export function detectRequestId(err: unknown): string | undefined {
   }
 
   // Try headers (Anthropic SDK uses 'request-id'; relay may use 'x-request-id')
-  // ?? undefined converts null from headers.get() to undefined
   return (
     getHeaderValue(candidate.headers, 'request-id') ??
-    getHeaderValue(candidate.headers, 'x-request-id') ??
-    undefined
+    getHeaderValue(candidate.headers, 'x-request-id')
   );
 }
 

--- a/src/latex/latexToolchain.ts
+++ b/src/latex/latexToolchain.ts
@@ -50,14 +50,12 @@ export async function probeLatexToolchain(): Promise<LatexToolchainProbe> {
   const installed = await Promise.all(
     toolNames.map((tool) => checkToolInstalled(tool, false)),
   );
-  const tools = toolNames.map((name, index): LatexToolStatus => {
-    return {
-      name,
-      installed: installed[index] ?? false,
-      required: REQUIRED_TOOLS.has(name),
-      purpose: TOOL_PURPOSES[name],
-    };
-  });
+  const tools = toolNames.map((name, index): LatexToolStatus => ({
+    name,
+    installed: installed[index] ?? false,
+    required: REQUIRED_TOOLS.has(name),
+    purpose: TOOL_PURPOSES[name],
+  }));
   return {
     tools,
     hasCompiler: tools.some(

--- a/src/model/providerCapabilities.ts
+++ b/src/model/providerCapabilities.ts
@@ -31,10 +31,6 @@ export interface ProviderCapabilityKey {
   readonly useOpenRouter: boolean;
 }
 
-type ProviderCapabilityResolver = (
-  key: ProviderCapabilityKey,
-) => ProviderCapabilityProfile | null;
-
 /** Context window the ChatGPT-subscription (Codex) backend enforces. */
 export const CODEX_SUBSCRIPTION_CONTEXT_WINDOW = 272_000;
 
@@ -203,10 +199,11 @@ export function isCodexSubscriptionEligible(model: ModelConfig): boolean {
   );
 }
 
-const resolveChatGptSubscriptionCapabilities: ProviderCapabilityResolver = ({
+/** Resolve the active ChatGPT-subscription provider profile. */
+export function resolveProviderCapabilities({
   model,
   useOpenRouter,
-}) => {
+}: ProviderCapabilityKey): ProviderCapabilityProfile | null {
   if (useOpenRouter) return null;
   if (model.provider !== ModelProvider.OPENAI) return null;
   if (model.openRouterOnly) return null;
@@ -240,11 +237,4 @@ const resolveChatGptSubscriptionCapabilities: ProviderCapabilityResolver = ({
       failWhenFallbackOutputBudgetIsReduced: true,
     },
   };
-};
-
-/** Resolve the active ChatGPT-subscription provider profile. */
-export function resolveProviderCapabilities(
-  key: ProviderCapabilityKey,
-): ProviderCapabilityProfile | null {
-  return resolveChatGptSubscriptionCapabilities(key);
 }

--- a/src/replacement/advanced.ts
+++ b/src/replacement/advanced.ts
@@ -426,12 +426,10 @@ const BARE_COMMAND_RES = (['critique', 'comment'] as const).map(
 );
 
 export function wrapCritiqueInAlign(text: string): string {
-  // Helper to wrap both \critique and \comment
-  function wrapCommands(block: string): string {
+  return text.replaceAll(ALIGN_BLOCK_RE, (block) => {
     for (const [regex, replacement] of BARE_COMMAND_RES) {
       block = block.replace(regex, replacement);
     }
     return block;
-  }
-  return text.replaceAll(ALIGN_BLOCK_RE, wrapCommands);
+  });
 }

--- a/src/replacement/rules/equationMacros.ts
+++ b/src/replacement/rules/equationMacros.ts
@@ -17,11 +17,7 @@ const expandEquationMacro: ReplacementFunction = (
   trailing = '',
 ) => {
   const replacement = MACRO_TO_ENVIRONMENT[macro];
-  if (!replacement) {
-    return match;
-  }
-
-  return `${leading}${replacement}${trailing}`;
+  return replacement ? `${leading}${replacement}${trailing}` : match;
 };
 
 export const EQUATION_MACRO_REPLACEMENTS: ReplacementCategory = {


### PR DESCRIPTION
## What

A mechanical, behavior-preserving simplification pass over the **collision-free surface**, in the proven style of this repo's prior net-negative sweeps (`Simplify repo-wide: modern TS idioms, dead code, pass-through cleanup` #6898 −226; #7071 −52; #7485 −25). **Net −40 LOC across 11 files** (23+/63−).

Every edit was produced by a fan-out of per-area finders and then **adversarially verified** (default-to-reject) for exact-single-match, behavior preservation, net-negative LOC, and no-new-abstraction — then re-checked by eye. This deliberately avoids the *anti-pattern* the repo already rejected (#7271 "simplify data-structure designs", net **+726** — new abstractions): **no new helpers/ports/factories were added; the sweep only deletes indirection.**

## Changes

**Dead code (write-only carried fields):**
- `ResponseCycleFlow.ts` — remove `ProcessPrepResult.messages`, `ContinuationPrepResult.messages` (set in `prep()`, never read; consumers use `shared.messages`), `ProcessResultCommon.thinkingContent` (logged from the local var, never off `result`), and the now-unused `ProviderMessage` import.

**Pass-through removal (user-requested) — inline single-caller wrappers, delete dead type aliases:**
- `auth/relayToken.ts` — `getFreshCachedStatus` was `return statusCache.get(token)`; inlined at its 2 call sites (−7).
- `AgentWorkspaceState.ts` — inline the private single-caller `MediaAttachmentState.addFile` into `addMediaFiles`.
- `model/providerCapabilities.ts` — fold `resolveChatGptSubscriptionCapabilities` (single-caller resolver arrow) into the exported `resolveProviderCapabilities` and delete the unused `ProviderCapabilityResolver` alias (per the *Flattening Abstraction Layers* / *Discouraged Factory Patterns* guidance).

**Modern-TS / nullish idioms:**
- `progressView` formatters — `x == null` over `x === null || x === undefined` (×2).
- `runReflectionFlow.ts` — `??=` (preserves the `??` short-circuit so the `infer…` call is still skipped when the key is already set).
- `equationMacros.ts` — ternary over early-return guard (all map values are non-empty strings, so the branch condition is unchanged).
- `errorInspection.ts` — drop a provable no-op `?? undefined` (the operands are already `string | undefined`; tsc confirms) and its now-stale comment.
- `latexToolchain.ts` — concise arrow bodies.
- `replacement/advanced.ts` — inline an internal named helper into `replaceAll`.

## Scope / collision-safety

Branched from `origin/main` and **strictly excluded every open PR's files and hot dirs** (#7532 schemas/latexdiff/transcript/progressView-controllers, #7536 agent/runtime + tools + flows/tooluse, #7537 modelHandlers, #7538 agent/runtime). Re-verified none of the 11 touched files moved on `origin/main`.

## Verification

- `tsc --noEmit` (root) ✅
- `tsc --noEmit -p tsconfig.test-kernel.json` ✅
- extension typecheck (`pnpm --filter texra typecheck`) ✅
- eslint on changed files ✅
- full `vitest run` — **5183 passed / 4 skipped** ✅

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactors with full test/typecheck coverage; no auth, data-model, or routing logic changes beyond deleting unused fields and inlining obvious pass-throughs.
> 
> **Overview**
> Behavior-preserving cleanup across **11 files** (~**−40 LOC**): no new helpers or abstractions—only deletes indirection and tightens idioms.
> 
> **Dead / unused carry fields:** In `ResponseCycleFlow.ts`, drops `messages` from process/continuation prep results (call sites already use `shared.messages`), removes unused `thinkingContent` from the process result type, and drops the `ProviderMessage` import.
> 
> **Pass-through inlining:** `relayToken.ts` inlines `getFreshCachedStatus` into cache reads; `MediaAttachmentState` folds private `addFile` into `addMediaFiles`; `providerCapabilities.ts` merges the single-caller Codex resolver into exported `resolveProviderCapabilities` and removes `ProviderCapabilityResolver`.
> 
> **Modern TS / micro-style:** Progress view formatters and `parseUtils` use `value == null`; reflection resume uses `??=` for `modelHandlerCompatibilityKey`; `equationMacros`, `errorInspection`, `latexToolchain`, and `wrapCritiqueInAlign` get small ternary/arrow-body/inlining cleanups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55eb04ff7904e388daa78959bd37c30a7ea7ef52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->