### PR TITLE
docs(model-handlers): triage isBackgroundModeActive as bucket-3

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -332,6 +332,21 @@ export abstract class ModelHandler<
    * Indicates whether background mode is active for this handler.
    * Background mode runs requests asynchronously and polls for completion.
    * Override in handlers that support background execution.
+   *
+   * Not foldable into a single predicate (#7101 triage): the two overriding
+   * handlers compute this with materially different formulas, not just
+   * different booleans. `ModelHandlerGoogleInteractions` gates on server
+   * state plus a workflow-mode eligibility check and a config toggle
+   * (`useBackgroundMode(this.serverStateEnabled())`).
+   * `ModelHandlerOpenAIResponse` gates on `backgroundModeSupported`, its own
+   * toggle/eligibility checks, *and* a `ProviderCapabilityProfile` override
+   * (`getOpenAIResponseCapabilities()?.backgroundMode === 'disabled'`) that
+   * can force it off regardless of the other checks. `ModelHandlerOpenRouterNative`
+   * doesn't override this at all — it correctly inherits the base `false`,
+   * and since the base is a plain constant rather than a `config.provider`
+   * read, there's no OpenRouterNative-shares-config.provider risk here (see
+   * `requiresPerCallSystemPrompt`'s note on that failure mode). Stays an
+   * overridable method.
    */
   public isBackgroundModeActive(): boolean {
     return false;


### PR DESCRIPTION
Part of #7101. Doc-only, zero behavior change — triages the last remaining `ModelHandler.ts` predicate without a `#7101 triage` comment.

## `isBackgroundModeActive`

Bucket 3, not foldable. `ModelHandlerGoogleInteractions` and `ModelHandlerOpenAIResponse` each override this with a materially different formula, not just a different boolean:

- GoogleInteractions: `useBackgroundMode(serverStateEnabled())`, itself gated on a workflow-mode eligibility check and a config toggle.
- OpenAIResponse: gated on `backgroundModeSupported`, its own toggle/eligibility checks, *and* a `ProviderCapabilityProfile` override (`getOpenAIResponseCapabilities()?.backgroundMode === 'disabled'`) that can force it off regardless of the other checks.

`ModelHandlerOpenRouterNative` doesn't override this at all — it correctly inherits the base `false` constant. Since the base isn't a `config.provider` read, this predicate carries none of `requiresPerCallSystemPrompt`'s (#7531) fold risk; it's simply genuine per-provider behavior with two different implementations.

## Where this leaves #7101 on `ModelHandler.ts`

Every remaining predicate/getter has now either been folded (when verified safe against `ModelHandlerOpenRouterNative`) or documented as bucket-3. The handful of methods left untouched (`isToolUseMode`, `isWorkflowMode`, `shouldCompactByInputTokens`, `isEndTurnStop`, `shouldContinue`) are out of scope for this triage: they're either agent-category checks with no provider/capability data feeding them, already a correctly-shared combinator with no redundant override to delete, or pure string-matching logic. The mechanical triage on this file is effectively complete after this PR — remaining #7101 scope (per the issue's own body) is elsewhere in the codebase, not more `ModelHandler.ts` predicates.

## Verification

- `tsc --noEmit` (root) — clean.
- `eslint` on the changed file — clean.
- Doc comment only; no functional change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change on `ModelHandler.ts`; no logic, APIs, or runtime paths are modified.
> 
> **Overview**
> Documentation-only change for **#7101**: expands the JSDoc on `ModelHandler.isBackgroundModeActive()` to record a **bucket-3** triage — the predicate is **not foldable** into one shared implementation.
> 
> The comment explains why **Google Interactions** and **OpenAI Response** each override with different gating (server state + workflow eligibility + config vs. `backgroundModeSupported`, toggles, and `ProviderCapabilityProfile` forcing background off), and why **OpenRouter Native** correctly inherits the base `false` without the `requiresPerCallSystemPrompt`-style `config.provider` fold risk. **Runtime behavior is unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebb5d1a9cb2a5f51e32e83e9daaa04c87e99b3d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->