### PR TITLE
fix(runtime): preserve parent stream on tool-use resume

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -150,6 +150,7 @@ export interface DesktopAgentExecution {
 type ResumeState = {
   runState: AgentConfig;
   executionId?: ExecutionId;
+  parentStreamId?: StreamTabId;
 };
 
 interface DesktopRunExecutionOptions {
@@ -1272,7 +1273,14 @@ export class DesktopProgressBridge {
   ): Promise<ResumeState | undefined> {
     let runState = this.state.snapshots.getRunConfig(streamId);
     let executionId = this.getStreamExecutionId(streamId);
-    if (runState && executionId) return { runState, executionId };
+    if (runState && executionId) {
+      const parentStreamId = this.state.snapshots.getParentStreamId(streamId);
+      return {
+        runState,
+        executionId,
+        ...(parentStreamId !== undefined && { parentStreamId }),
+      };
+    }
 
     try {
       await this.state.snapshots.preload([streamId]);
@@ -1291,9 +1299,11 @@ export class DesktopProgressBridge {
       agentCategory: runState.agentCategory,
     });
 
+    const parentStreamId = this.state.snapshots.getParentStreamId(streamId);
     return {
       runState,
       ...(executionId && { executionId }),
+      ...(parentStreamId !== undefined && { parentStreamId }),
     };
   }
 

--- a/packages/extension/src/commands/agent/resumeFromSnapshot.ts
+++ b/packages/extension/src/commands/agent/resumeFromSnapshot.ts
@@ -45,7 +45,12 @@ export function tryResumeFromSnapshot(streamId: StreamTabId): Promise<boolean> {
         logger.warn(`No task state found for stream: ${id}`);
         return undefined;
       }
-      return { runState: taskState, executionId };
+      const parentStreamId = progressState.snapshots.getParentStreamId(id);
+      return {
+        runState: taskState,
+        executionId,
+        ...(parentStreamId !== undefined && { parentStreamId }),
+      };
     },
     resumeToolUseSnapshot: resumeExtensionToolUseSnapshot,
     executeWorkflow: (config, executionId, modelHandlerCompatibilityKey) =>

--- a/src/agent/implementations/flows/tooluse/ToolUseSessionTypes.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseSessionTypes.ts
@@ -14,6 +14,7 @@ export const ToolUseSessionSnapshotSchema = z.strictObject({
   version: z.literal(TOOL_USE_SNAPSHOT_VERSION),
   executionId: ExecutionIdSchema,
   streamId: StreamTabIdSchema,
+  parentStreamId: StreamTabIdSchema.nullish(),
   agentConfig: AgentConfigSchema,
   modelHandlerCompatibilityKey: ModelHandlerCompatibilityKeySchema.nullish(),
   messages: z.array(ProviderMessageSchema),

--- a/src/agent/runtime/SessionResumeRetrieval.ts
+++ b/src/agent/runtime/SessionResumeRetrieval.ts
@@ -62,6 +62,10 @@ type WorkflowResumeData = z.infer<typeof WorkflowResumeDataSchema>;
 
 export type SessionResumeData = ToolUseResumeData | WorkflowResumeData;
 
+export interface SessionResumeRetrievalOptions {
+  readonly parentStreamId?: StreamTabId;
+}
+
 const CurrentToolUseFlowRecordStateSchema = z.looseObject({
   messages: z.array(ProviderMessageSchema),
   modelHandlerCompatibilityKey: ModelHandlerCompatibilityKeySchema.nullish(),
@@ -116,11 +120,17 @@ export async function retrieveSessionResumeData(
   streamId: StreamTabId,
   executionId: ExecutionId,
   state: AgentConfig | TaskState,
+  options: SessionResumeRetrievalOptions = {},
 ): Promise<SessionResumeData | null> {
   const agentConfig = 'agentConfig' in state ? state.agentConfig : state;
 
   if (agentConfig.agentCategory === AgentCategory.ToolUse) {
-    return retrieveToolUseResumeData(streamId, executionId, agentConfig);
+    return retrieveToolUseResumeData(
+      streamId,
+      executionId,
+      agentConfig,
+      options,
+    );
   }
 
   if (agentConfig.agentCategory === AgentCategory.Workflow) {
@@ -138,6 +148,7 @@ async function retrieveToolUseResumeData(
   streamId: StreamTabId,
   executionId: ExecutionId,
   agentConfig: AgentConfig,
+  options: SessionResumeRetrievalOptions,
 ): Promise<ToolUseResumeData | null> {
   try {
     const resumability = await deriveResumability(executionId);
@@ -190,6 +201,9 @@ async function retrieveToolUseResumeData(
       version: TOOL_USE_SNAPSHOT_VERSION,
       executionId,
       streamId,
+      ...(options.parentStreamId !== undefined && {
+        parentStreamId: options.parentStreamId,
+      }),
       agentConfig: currentConfig,
       modelHandlerCompatibilityKey,
       messages,

--- a/src/agent/runtime/resolveAndResumeStream.ts
+++ b/src/agent/runtime/resolveAndResumeStream.ts
@@ -18,6 +18,12 @@ import { StreamStatusService } from './StreamStatusService';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 import type { ModelHandlerCompatibilityKey } from './modelHandlerCompatibilityKey';
 
+export interface ResolvedResumeState {
+  readonly runState: AgentConfig | TaskState;
+  readonly executionId: ExecutionId;
+  readonly parentStreamId?: StreamTabId;
+}
+
 export interface ResumeStreamPorts {
   /** Runtime host receiving the RESUMING/WAITING status updates. */
   readonly runtimeHost: AgentRuntimeHost;
@@ -28,9 +34,7 @@ export interface ResumeStreamPorts {
    */
   resolveResumeState(
     streamId: StreamTabId,
-  ): Promise<
-    { runState: AgentConfig | TaskState; executionId: ExecutionId } | undefined
-  >;
+  ): Promise<ResolvedResumeState | undefined>;
   /** Resume a tool-use snapshot (host injects its failure surface). */
   resumeToolUseSnapshot(snapshot: ToolUseSessionSnapshot): Promise<boolean>;
   /**
@@ -87,11 +91,19 @@ export async function resolveAndResumeStream(
     // The host's resolveResumeState owns its own "no persisted state" messaging.
     if (!resolved) return false;
 
-    const resume = await retrieveSessionResumeData(
-      streamId,
-      resolved.executionId,
-      resolved.runState,
-    );
+    const resume =
+      resolved.parentStreamId !== undefined
+        ? await retrieveSessionResumeData(
+            streamId,
+            resolved.executionId,
+            resolved.runState,
+            { parentStreamId: resolved.parentStreamId },
+          )
+        : await retrieveSessionResumeData(
+            streamId,
+            resolved.executionId,
+            resolved.runState,
+          );
     if (!resume) {
       await ports.reportNoResumableSession?.(streamId);
       return false;

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -103,7 +103,8 @@ export async function resumeQueuedToolUseSnapshot(
       approvalPromptsUnavailable: options.approvalPromptsUnavailable,
       runtimeUnavailableTools: options.runtimeUnavailableTools,
       toolEditApprovalHandler: options.toolEditApprovalHandler,
-      parentStreamId: options.parentStreamId,
+      parentStreamId:
+        options.parentStreamId ?? snapshot.parentStreamId ?? undefined,
       allowWaitingResult: options.allowWaitingResult,
       onFollowUpConsumed: options.onFollowUpConsumed,
       onProgress: options.onProgress,

--- a/src/agent/runtime/resumeToolUseSnapshot.ts
+++ b/src/agent/runtime/resumeToolUseSnapshot.ts
@@ -65,6 +65,7 @@ export async function resumeToolUseSnapshot(
           ? [{ text: options.explicitFollowUp, origin: 'user' as const }]
           : [],
       onError: (error) => options.reportFailure?.(error),
+      parentStreamId: snapshot.parentStreamId ?? undefined,
     },
   );
 }

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -72,6 +72,41 @@ describe('retrieveSessionResumeData', () => {
     expect(resume.snapshot.agentConfig.model).toBe('gpt55');
   });
 
+  it('preserves a recovered parent stream id in tool-use snapshots', async () => {
+    const executionId = 'abc131' as ExecutionId;
+    const streamId = 'chat@gpt54#abc131-child' as StreamTabId;
+    const parentStreamId = 'chat@gpt54#abc131-parent' as StreamTabId;
+    await getExecutionStore(executionId).write(flowKey(executionId), {
+      flowName: 'texra',
+      params: {},
+      shared: {
+        messages: [],
+        shouldSkipCycle: false,
+        stateSlices: {
+          runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
+          workspaceSnapshot: AgentWorkspaceState.create().toSnapshot(),
+          userChannels: {
+            input: Object.freeze({ MODEL: 'gpt54' }),
+            transient: {},
+          },
+        },
+      },
+      createdAt: new Date().toISOString(),
+      nodes: [],
+    });
+
+    const resume = await retrieveSessionResumeData(
+      streamId,
+      executionId,
+      agentConfigToTaskState(CONFIG),
+      { parentStreamId },
+    );
+
+    expect(resume?.type).toBe('toolUse');
+    if (resume?.type !== 'toolUse') return;
+    expect(resume.snapshot.parentStreamId).toBe(parentStreamId);
+  });
+
   it('infers the legacy Google GenAI handler for old Google Content transcripts', async () => {
     const executionId = 'abc124' as ExecutionId;
     const streamId = 'chat@gemini35f#abc124' as StreamTabId;

--- a/src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts
+++ b/src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts
@@ -61,6 +61,32 @@ describe('resolveAndResumeStream', () => {
     expect(ports.executeWorkflow).not.toHaveBeenCalled();
   });
 
+  it('passes recovered parent stream identity to resume retrieval', async () => {
+    const parentStreamId = 'stream:parent' as StreamTabId;
+    const snapshot = { streamId: STREAM, executionId: 'exec-1' };
+    retrieveSessionResumeDataMock.mockResolvedValue({
+      type: 'toolUse',
+      snapshot,
+    });
+    const ports = basePorts({
+      resolveResumeState: vi.fn(async () => ({
+        runState: { agent: 'a', model: 'm' } as never,
+        executionId: 'exec-1' as never,
+        parentStreamId,
+      })),
+    });
+
+    await expect(resolveAndResumeStream(STREAM, ports)).resolves.toBe(true);
+
+    expect(retrieveSessionResumeDataMock).toHaveBeenCalledWith(
+      STREAM,
+      'exec-1',
+      expect.anything(),
+      { parentStreamId },
+    );
+    expect(ports.resumeToolUseSnapshot).toHaveBeenCalledWith(snapshot);
+  });
+
   it('launches workflow resumes without pre-acquiring the stream', async () => {
     const agentConfig = { agent: 'a', model: 'm' } as never;
     retrieveSessionResumeDataMock.mockResolvedValue({

--- a/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
+++ b/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
@@ -11,6 +11,7 @@ import {
   seedStreamStatusForTest,
 } from '@test/helpers/streamStatusTestUtils';
 import { resumeToolUseSnapshot } from '@agent/runtime/resumeToolUseSnapshot';
+import { resumeQueuedToolUseSnapshot } from '@agent/runtime/resumeQueuedToolUse';
 import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
@@ -22,19 +23,27 @@ const STREAM = 'stream:tooluse-resume' as StreamTabId;
 const runtimeHost = { emit: vi.fn() };
 let detachSessionProgressProjection: (() => void) | undefined;
 
-function snapshot(): ToolUseSessionSnapshot {
-  return { streamId: STREAM } as ToolUseSessionSnapshot;
+function snapshot(parentStreamId?: StreamTabId): ToolUseSessionSnapshot {
+  return { streamId: STREAM, parentStreamId } as ToolUseSessionSnapshot;
+}
+
+function capturedResumeOptions(): {
+  parentStreamId?: StreamTabId;
+  setupSession: (session: { appendFollowUp(item: unknown): void }) => void;
+} {
+  const calls = resumeToolUseFromSnapshotMock.mock
+    .calls as unknown as unknown[][];
+  return calls.at(-1)?.[2] as {
+    parentStreamId?: StreamTabId;
+    setupSession: (session: { appendFollowUp(item: unknown): void }) => void;
+  };
 }
 
 /** Capture the `setupSession` replay callback handed to the leaf resume. */
 function capturedSetupSession(): (session: {
   appendFollowUp(item: unknown): void;
 }) => void {
-  const calls = resumeToolUseFromSnapshotMock.mock
-    .calls as unknown as unknown[][];
-  const options = calls.at(-1)?.[2] as {
-    setupSession: (session: { appendFollowUp(item: unknown): void }) => void;
-  };
+  const options = capturedResumeOptions();
   return options.setupSession;
 }
 
@@ -101,6 +110,31 @@ describe('resumeToolUseSnapshot', () => {
       text: 'queued one',
       origin: 'user',
     });
+  });
+
+  it('passes snapshot parent stream identity to the leaf resume', async () => {
+    const parentStreamId = 'stream:parent' as StreamTabId;
+
+    await resumeToolUseSnapshot(snapshot(parentStreamId), { runtimeHost });
+
+    expect(capturedResumeOptions().parentStreamId).toBe(parentStreamId);
+  });
+
+  it('keeps an explicit queue parent stream ahead of the snapshot parent', async () => {
+    const explicitParent = 'stream:explicit-parent' as StreamTabId;
+    const snapshotParent = 'stream:snapshot-parent' as StreamTabId;
+
+    await resumeQueuedToolUseSnapshot(
+      STREAM,
+      snapshot(snapshotParent),
+      runtimeHost,
+      {
+        parentStreamId: explicitParent,
+        onError: vi.fn(),
+      },
+    );
+
+    expect(capturedResumeOptions().parentStreamId).toBe(explicitParent);
   });
 
   it('re-enqueues follow-ups, settles to WAITING, and reports on failure', async () => {


### PR DESCRIPTION
Closes #7543.

## Summary

- Carry an optional `parentStreamId` on persisted tool-use resume snapshots.
- Recover the parent stream edge from extension and desktop progress snapshot metadata before generic resume.
- Pass the recovered parent edge through `resumeToolUseSnapshot` / `resumeQueuedToolUseSnapshot` into `resumeToolUseFromSnapshot`, while preserving the explicit native-subagent parent override.

This keeps a delegated native subagent resumed through the generic host path attached to its orchestrator instead of falling back to its own stream as parent.

## Validation

- `CI=true corepack pnpm exec vitest run src/test-kernel/agent/SessionResumeRetrieval.vitest.ts src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts`
- `npm run typecheck`
- `CI=true corepack pnpm exec eslint src/agent/implementations/flows/tooluse/ToolUseSessionTypes.ts src/agent/runtime/SessionResumeRetrieval.ts src/agent/runtime/resolveAndResumeStream.ts src/agent/runtime/resumeToolUseSnapshot.ts src/agent/runtime/resumeQueuedToolUse.ts packages/extension/src/commands/agent/resumeFromSnapshot.ts packages/desktop/src/main/desktopAgentExecution.ts src/test-kernel/agent/SessionResumeRetrieval.vitest.ts src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts` (passes with the existing `desktopAgentExecution.ts` import-order warning)
- `corepack pnpm exec prettier --check ...touched files...`
- `git diff --check HEAD~1..HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes subagent/orchestrator stream linkage during resume—a coordination-sensitive runtime path—but scope is narrow and guarded by tests; verify desktop resume wiring forwards `parentStreamId` if that host path matters for subagents.
> 
> **Overview**
> Fixes delegated **native subagent** streams losing their orchestrator link when resumed through the shared host resume path (closes #7543).
> 
> Tool-use resume snapshots now optionally carry **`parentStreamId`**. Extension and desktop **`resolveResumeState`** paths read it from progress snapshot metadata via `getParentStreamId` and expose it on resolved resume state. **`resolveAndResumeStream`** threads that into **`retrieveSessionResumeData`**, which embeds it on the assembled snapshot. **`resumeToolUseSnapshot`** / **`resumeQueuedToolUseSnapshot`** forward snapshot (or explicit) parent identity into **`resumeToolUseFromSnapshot`**, with explicit queue options still overriding snapshot values.
> 
> Vitest coverage was added for retrieval, orchestration, and leaf resume parent propagation.
> 
> **Note for reviewers:** desktop `tryResumeStream` still returns only `runState` and `executionId` to the orchestrator in the current tree—the new `parentStreamId` from `resolveResumeState` is not spread into that return; extension does forward it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8c3823884fdc71b647d29cacc8b31f18a81b88b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->